### PR TITLE
doc(MPS/RFP): mark Beigi chain-length scope

### DIFF
--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -525,6 +525,11 @@ of length greater than two, the dimension is the sum over ordered cyclic
 sector sequences of the products of the adjacent edge-ground-space
 dimensions.
 
+**Scope restriction (chain length):** Beigi's equations (3)--(4) apply to all
+periodic lengths, whereas this theorem treats the range `N > 2` used by the
+NNCPH clause of arXiv:1606.00608, Theorem 3.10(iii). Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
 Source: Beigi, arXiv:1105.1019v2, Section III, equations (3)--(4), page 4. -/
 theorem parentHamiltonianGroundSpaceES_finrank_eq
     (F : BeigiSectorGraphData A) {N : ℕ} (hN : 2 < N) :

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2397,7 +2397,7 @@ specialization of that Appendix~D definition.
         \dim\operatorname{ran}P_{a_n,a_{n+1}},
     \]
     where the sum is over ordered cycles and the indices are read modulo $N$.
-    This is equations~(3)--(4) of
+    This is the specialization to $N>2$ of equations~(3)--(4) of
     \cite[Section~III]{Beigi2012Classification}.
 \end{theorem}
 

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -270,10 +270,13 @@ right tensor factors on which the two adjacent interactions act separately.
 The subsequent sector datum is now formalized in
 \leanid{MPSTensor.BeigiSectorGraphData}.  From its source equation~(2) alone,
 \leanid{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq}
-constructs the finite directed graph and proves Beigi's ordered-cycle
-ground-space dimension formula for every $N>2$.  No chain-level ground-space
-equation, eventual degeneracy, or canonical-form datum is assumed in this
-sector-graph theorem.
+constructs the finite directed graph and proves the $N>2$ specialization of
+Beigi's ordered-cycle ground-space dimension formula.  Beigi states this
+formula for every periodic length, while the present restriction matches the
+NNCPH range in Theorem~3.10(iii).  No chain-level ground-space equation,
+eventual degeneracy, or canonical-form datum is assumed in this sector-graph
+theorem.  The remaining lengths $N=1,2$ require separate periodic-window
+conventions and are tracked by \ghissue{4400}.
 
 \section{Elimination plan}
 


### PR DESCRIPTION
### Motivation

- PR #4389 proved the `N > 2` ordered-cycle dimension formula required by the NNCPH clause of CPSV16 Theorem 3.10(iii), but its source attribution read as though it covered Beigi’s all-length equations (3)–(4).
- Beigi, arXiv:1105.1019v2, Section III, source lines 497–508 states the decomposition and formula for every periodic length; lines 509–512 explicitly discuss ordered cycles at length two.
- The local CPSV16 source restricts the relevant NNCPH clause to `N > 2` at `Papers/1606.00608/MPDO-22-12-17-2.tex:534–540`.

### Description

- add the required `**Scope restriction (chain length):**` marker to the Lean theorem docstring, citing the existing paper-gap note;
- describe the checked blueprint result as the `N > 2` specialization, not as complete coverage of Beigi equations (3)–(4);
- record the all-length/source boundary and the remaining `N = 1,2` work in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`;
- track the short-chain source coverage separately in #4400.

No theorem statement or proof changes.

### Testing

- exact-head PR CI: Lean build, file-length guard, and blueprint/checkdecls gate pass
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/tactic_pattern_scan.py`

Follow-up to #4375 and #4389.
Advances #2380 and #2633.
Tracks complete Beigi coverage in #4400.