### PR TITLE
feat(MPS/MPDO): normalize diagonal finite-chain coefficients

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -417,7 +417,6 @@ import TNLean.PiAlgebra.Construction
 import TNLean.PiAlgebra.FundamentalTheoremComplete
 import TNLean.PiAlgebra.TIReduction
 import TNLean.PiAlgebra.GlobalSymmetry
-
 -- Layer 3b: MPO / MPDO / LPDO foundations
 import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.AreaLaw
@@ -427,6 +426,7 @@ import TNLean.MPS.MPDO.MutualInfoBridge
 import TNLean.MPS.MPDO.PureAreaLaw
 import TNLean.MPS.MPDO.LocalPurificationAreaLaw
 import TNLean.MPS.MPDO.DiagonalCutRank
+import TNLean.MPS.MPDO.DiagonalFiniteChain
 import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.VerticalCoisometry

--- a/TNLean/MPS/MPDO/DiagonalCutRank.lean
+++ b/TNLean/MPS/MPDO/DiagonalCutRank.lean
@@ -119,12 +119,10 @@ This is the formal assembly of Riazanov--Vyalyi, Theorem 4.1
 arXiv:1606.00608, Proposition 4.5. This statement does not concern unrestricted
 quantum mutual information.
 
-**Scope restriction (coefficient matrix and probability distribution):** The
-real coefficient matrix `W`, the joint distribution `P`, their normalization
-relation, and the identification of the scalar extension of `W` with the
-complex cut matrix are explicit hypotheses rather than consequences of the
-current MPDO definitions. This remaining construction is documented in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+This conditional form keeps the real coefficient matrix, its normalization,
+and its scalar-extension identity as explicit hypotheses.  For a positive
+diagonal finite-chain operator they are derived in
+`TNLean.MPS.MPDO.DiagonalFiniteChain`. -/
 theorem diagonalCut_classicalMutualInformation_le_two_log [NeZero D]
     (M : MPOTensor d D) (L R : ℕ)
     (W P : Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ) (Z : ℝ)

--- a/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
+++ b/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.DiagonalCutRank
+import Mathlib.Analysis.Matrix.Hermitian
+import Mathlib.LinearAlgebra.Matrix.IsDiag
+
+/-!
+# Diagonal finite-chain matrix product operators
+
+This file associates a real coefficient matrix and a joint probability
+distribution to a positive diagonal finite-chain matrix product operator.
+The resulting classical mutual information is at most twice the logarithm of
+the bond dimension.
+
+Only positivity and diagonality at the chain length under consideration are
+assumed.  No local purification or positivity at other lengths is required.
+
+## Main definitions
+
+* `MPOTensor.IsDiagonalAt`: diagonality of the operator at one chain length.
+* `MPOTensor.diagonalCutRealMatrix`: the real diagonal coefficients across a cut.
+* `MPOTensor.diagonalCutMass`: the total mass of these coefficients.
+* `MPOTensor.normalizedDiagonalCutDistribution`: their normalization.
+
+## Main statements
+
+* `MPOTensor.normalizedDiagonalCutDistribution_isJointDistribution`: positivity
+  and positive total mass give a joint probability distribution.
+* `MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log`: the
+  classical mutual information of a positive diagonal finite-chain operator is
+  at most $2\log D$.
+
+## References
+
+* arXiv:1606.00608, Proposition 4.5, lines 795--806.
+* `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`, section
+  "Diagonal matrix product operators".
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+open Matrix
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- An MPO tensor is diagonal at length `N` when the generated finite-chain
+operator has no off-diagonal matrix entries.
+
+This is the diagonal finite-chain specialization considered in the analysis of
+arXiv:1606.00608, Proposition 4.5, lines 795--806; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+def IsDiagonalAt (M : MPOTensor d D) (N : ℕ) : Prop :=
+  (mpo M N).IsDiag
+
+/-- The real parts of the diagonal coefficients across a periodic cut.
+
+For a positive finite-chain operator these coefficients are real and
+nonnegative.  They are the coefficients denoted by $P_{x,y}$ in the diagonal
+analysis of arXiv:1606.00608, Proposition 4.5, lines 795--806. -/
+noncomputable def diagonalCutRealMatrix (M : MPOTensor d D) (L R : ℕ) :
+    Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ :=
+  (diagonalCutMatrix M L R).map Complex.re
+
+/-- The total mass of the real diagonal coefficients across a periodic cut.
+
+This is the normalization constant $Z$ in the diagonal analysis of
+arXiv:1606.00608, Proposition 4.5, lines 795--806. -/
+noncomputable def diagonalCutMass (M : MPOTensor d D) (L R : ℕ) : ℝ :=
+  ∑ x, ∑ y, diagonalCutRealMatrix M L R x y
+
+/-- The real diagonal coefficient matrix divided by its total mass.
+
+This is the joint distribution $\widehat P=Z^{-1}P$ in the diagonal analysis of
+arXiv:1606.00608, Proposition 4.5, lines 795--806. -/
+noncomputable def normalizedDiagonalCutDistribution (M : MPOTensor d D) (L R : ℕ) :
+    Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ :=
+  (diagonalCutMass M L R)⁻¹ • diagonalCutRealMatrix M L R
+
+/-- A diagonal cut coefficient is the corresponding diagonal matrix entry of
+the finite-chain MPO operator.
+
+This is the coefficient identity used in the diagonal finite-chain analysis of
+arXiv:1606.00608, Proposition 4.5, lines 795--806; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalCutMatrix_apply_eq_mpo (M : MPOTensor d D) (L R : ℕ)
+    (x : Fin L → Fin d) (y : Fin R → Fin d) :
+    diagonalCutMatrix M L R x y =
+      mpo M (L + R) (Fin.append x y) (Fin.append x y) := by
+  simp [diagonalCutMatrix, mpo_apply, mpoMatrixEntry, List.ofFn_fin_append]
+
+/-- Positivity makes every diagonal cut coefficient equal to the scalar
+extension of its real part.
+
+This is the real-coefficient step in the diagonal finite-chain analysis of
+arXiv:1606.00608, Proposition 4.5, lines 795--806; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalCutRealMatrix_map_ofReal_of_posSemidef (M : MPOTensor d D) (L R : ℕ)
+    (hpos : (mpo M (L + R)).PosSemidef) :
+    (diagonalCutRealMatrix M L R).map Complex.ofReal = diagonalCutMatrix M L R := by
+  ext x y
+  rw [Matrix.map_apply, diagonalCutRealMatrix, Matrix.map_apply,
+    diagonalCutMatrix_apply_eq_mpo]
+  exact hpos.isHermitian.coe_re_apply_self _
+
+/-- The real diagonal cut coefficients of a positive finite-chain operator are
+nonnegative.
+
+This is the positivity step in the diagonal finite-chain analysis of
+arXiv:1606.00608, Proposition 4.5, lines 795--806; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalCutRealMatrix_nonneg_of_posSemidef (M : MPOTensor d D) (L R : ℕ)
+    (hpos : (mpo M (L + R)).PosSemidef) (x : Fin L → Fin d) (y : Fin R → Fin d) :
+    0 ≤ diagonalCutRealMatrix M L R x y := by
+  rw [diagonalCutRealMatrix, Matrix.map_apply, diagonalCutMatrix_apply_eq_mpo]
+  exact (RCLike.nonneg_iff.mp hpos.diag_nonneg).1
+
+/-- Positive semidefiniteness and positive total mass make the normalized
+diagonal cut coefficients a joint probability distribution.
+
+This is the normalization step in the diagonal case of arXiv:1606.00608,
+Proposition 4.5, lines 795--806. -/
+theorem normalizedDiagonalCutDistribution_isJointDistribution (M : MPOTensor d D)
+    (L R : ℕ) (hpos : (mpo M (L + R)).PosSemidef)
+    (hmass : 0 < diagonalCutMass M L R) :
+    (normalizedDiagonalCutDistribution M L R).IsJointDistribution := by
+  constructor
+  case right =>
+    simp only [normalizedDiagonalCutDistribution, Matrix.smul_apply, smul_eq_mul]
+    simp_rw [← Finset.mul_sum]
+    change (diagonalCutMass M L R)⁻¹ * diagonalCutMass M L R = 1
+    exact inv_mul_cancel₀ hmass.ne'
+  case left =>
+    intro x y
+    simp only [normalizedDiagonalCutDistribution, Matrix.smul_apply, smul_eq_mul]
+    exact mul_nonneg (inv_nonneg.mpr hmass.le)
+      (diagonalCutRealMatrix_nonneg_of_posSemidef M L R hpos x y)
+
+/-- **Classical estimate for a positive diagonal finite-chain MPO.** If the
+operator generated on `L + R` sites is diagonal and positive semidefinite, and
+its total diagonal mass is positive, then the classical mutual information of
+its normalized diagonal coefficients is at most `2 * log D`.
+
+Positivity produces the joint distribution from the diagonal entries, while
+diagonality says that these entries constitute the whole finite-chain state.
+Thus the normalized coefficients are the classical finite-chain distribution.
+
+This is the diagonal finite-chain consequence of arXiv:1606.00608,
+Proposition 4.5, lines 795--806, using Riazanov--Vyalyi, Theorem 4.1
+(arXiv:1704.06507).  It does not assert a bound for unrestricted quantum mutual
+information.
+
+**Scope restriction (diagonal finite-chain operator):** Proposition 4.5 concerns
+arbitrary MPDOs, whereas this theorem treats the classical diagonal subcase at
+one chain length.  The distinction and the unrestricted quantum question are
+documented in `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalFiniteChain_classicalMutualInformation_le_two_log [NeZero D]
+    (M : MPOTensor d D) (L R : ℕ) (_hdiag : M.IsDiagonalAt (L + R))
+    (hpos : (mpo M (L + R)).PosSemidef) (hmass : 0 < diagonalCutMass M L R) :
+    Entropy.classicalMutualInformation (normalizedDiagonalCutDistribution M L R) ≤
+      2 * Real.log D := by
+  apply diagonalCut_classicalMutualInformation_le_two_log M L R
+      (diagonalCutRealMatrix M L R) (normalizedDiagonalCutDistribution M L R)
+      (diagonalCutMass M L R)
+  · exact normalizedDiagonalCutDistribution_isJointDistribution M L R hpos hmass
+  · exact hmass
+  · rfl
+  · exact diagonalCutRealMatrix_map_ofReal_of_posSemidef M L R hpos
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -1169,6 +1169,58 @@
     logarithm gives the result.
 \end{proof}
 
+\begin{definition}[Normalized diagonal distribution at fixed length]
+    \label{def:mpo_normalized_diagonal_cut_distribution}
+    \lean{MPOTensor.IsDiagonalAt,
+      MPOTensor.diagonalCutRealMatrix,
+      MPOTensor.diagonalCutMass,
+      MPOTensor.normalizedDiagonalCutDistribution}
+    \leanok
+    \uses{def:mpo_tensor}
+    For a chain of length $N=L+R$, call $\rho^{(N)}(M)$ diagonal if
+    $\rho^{(N)}(M)_{u,v}=0$ whenever $u\ne v$.  For configurations $x$ and $y$
+    on the two consecutive blocks, define
+    \[
+      W_{x,y}=\operatorname{Re}\rho^{(L+R)}(M)_{(x,y),(x,y)},\qquad
+      Z=\sum_{x,y}W_{x,y},\qquad
+      \widehat P=Z^{-1}W.
+    \]
+\end{definition}
+
+\begin{theorem}[Classical estimate for a positive diagonal finite-chain operator]
+    \label{thm:mpo_diagonal_finite_chain_classical_mutual_information}
+    \lean{MPOTensor.diagonalCutMatrix_apply_eq_mpo,
+      MPOTensor.diagonalCutRealMatrix_map_ofReal_of_posSemidef,
+      MPOTensor.diagonalCutRealMatrix_nonneg_of_posSemidef,
+      MPOTensor.normalizedDiagonalCutDistribution_isJointDistribution,
+      MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log}
+    \leanok
+    \uses{def:mpo_normalized_diagonal_cut_distribution,
+      thm:mpo_diagonal_cut_rank}
+    Let $D\geq1$.  Suppose that $\rho^{(L+R)}(M)$ is diagonal and positive
+    semidefinite, and that $Z>0$.  Then $W_{x,y}\geq0$, the scalar extension of
+    $W$ to $\C$ is the diagonal cut matrix of
+    Theorem~\ref{thm:mpo_diagonal_cut_rank}, and $\widehat P$ is a joint
+    probability distribution.  Its classical mutual information satisfies
+    \[
+      I(X:Y)_{\widehat P}\leq2\log D.
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpo_diagonal_cut_classical_mutual_information}
+    Positive semidefiniteness makes every diagonal entry real and nonnegative,
+    so $W_{x,y}\geq0$ and its scalar extension recovers the complex diagonal
+    cut matrix.  Since $Z$ is the sum of the entries of $W$,
+    \[
+      \sum_{x,y}\widehat P_{x,y}
+      =Z^{-1}\sum_{x,y}W_{x,y}=1.
+    \]
+    Thus $\widehat P$ is a joint probability distribution.  Diagonality says
+    that these coefficients constitute the full classical finite-chain state,
+    and Theorem~\ref{thm:mpo_diagonal_cut_classical_mutual_information} gives
+    the bound.
+\end{proof}
+
 \begin{remark}[Boundedness of the mutual information]
     Proposition~4.5 of \cite{Cirac2016MPDO_arXiv} asserts the uniform estimate
     $I_L \le 4\log D$ for every MPDO. Its cited proof, however, treats mixed
@@ -1193,22 +1245,11 @@
     unrestricted estimate therefore requires a direct operator-Schmidt
     argument not supplied by the cited proof.
 
-    Diagonal operators cannot violate the estimate.  Suppose that the
-    finite-chain operator is diagonal and positive semidefinite, with positive
-    trace $Z$.  If $P$ is the diagonal coefficient matrix in
-    Theorem~\ref{thm:mpo_diagonal_cut_rank}, then
-    \[
-        \widehat P=Z^{-1}P
-    \]
-    is a joint probability distribution.  Multiplication by the nonzero real
-    scalar $Z^{-1}$ does not change rank, and the real matrix $\widehat P$ has
-    the same rank over $\R$ and $\C$.
-    Theorem~\ref{thm:classical_mutual_information_le_log_rank} gives
-    $I(X:Y)\leq\log\operatorname{rank}_{\R}\widehat P$.  Therefore
-    Theorem~\ref{thm:mpo_diagonal_cut_rank} yields
-    \[
-      I_L^{(L+R)}\leq 2\log D.
-    \]
+    Diagonal operators cannot violate the finite-chain estimate.  Indeed,
+    Theorem~\ref{thm:mpo_diagonal_finite_chain_classical_mutual_information}
+    bounds by $2\log D$ the classical mutual information of the normalized
+    diagonal coefficients whenever the finite-chain operator is diagonal and
+    positive semidefinite and has positive total mass.
     Thus any counterexample must have genuine quantum coherences.  The
     unrestricted quantum estimate remains open. The
     same example as Theorem~\ref{thm:parity_mpdo_no_thermodynamic_limit} also

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -211,10 +211,25 @@ finite-chain estimate
 \leanid{MPOTensor.diagonalCut_classicalMutualInformation_le_two_log} is in
 \doclink{TNLean/MPS/MPDO/DiagonalCutRank}.  The estimate assumes a real
 coefficient matrix, its normalized joint distribution, and an identification
-of its complex scalar extension with the diagonal cut matrix.  The remaining
-step at the MPDO level is to construct that coefficient matrix and probability
-distribution, together with the two identifications, from positivity and
-diagonality of the finite-chain operator.
+of its complex scalar extension with the diagonal cut matrix.  The fixed-length
+construction is formalized in
+\doclink{TNLean/MPS/MPDO/DiagonalFiniteChain}.
+\footnote{Formal declarations:
+\leanid{MPOTensor.IsDiagonalAt},
+\leanid{MPOTensor.diagonalCutRealMatrix},
+\leanid{MPOTensor.diagonalCutMass},
+\leanid{MPOTensor.normalizedDiagonalCutDistribution},
+\leanid{MPOTensor.diagonalCutRealMatrix_map_ofReal_of_posSemidef},
+\leanid{MPOTensor.diagonalCutRealMatrix_nonneg_of_posSemidef},
+\leanid{MPOTensor.normalizedDiagonalCutDistribution_isJointDistribution},
+and
+\leanid{MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log}.}
+For a positive diagonal operator at the chosen length, the real diagonal
+coefficients are nonnegative, their scalar extension is the cut matrix, and
+division by their positive total mass gives a joint distribution.  Diagonality
+identifies these normalized coefficients with the full classical finite-chain
+distribution.  The conclusion is classical; it does not settle the
+unrestricted quantum mutual-information question.
 
 \section{What the rank-three separation establishes}
 


### PR DESCRIPTION
### Motivation

- The conditional diagonal-cut theorem from #4361 still required callers to provide a real coefficient matrix, a normalization, a joint-distribution proof, and the scalar-extension identity. The scalar-rank prerequisite was discharged by #4374; this PR constructs the remaining objects directly from a positive finite-chain MPO.
- Mathematical source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 792–806, Proposition `PropILILp1` (Proposition 4.5). The normalization convention says: “whenever we consider one such entropic quantity for an MPDO ..., we will be referring to its normalized version”. The proposition itself begins “For any MPDO”; the present result formalizes only the fixed-length diagonal classical subcase, as recorded in `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`.
- Blueprint source: `blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex`, lines 1142–1222, labels `thm:mpo_diagonal_cut_classical_mutual_information` and `thm:mpo_diagonal_finite_chain_classical_mutual_information`. The resulting statement is `I(X:Y) ≤ 2 log D` for the normalized diagonal coefficients.

### Description

- Add `TNLean.MPS.MPDO.DiagonalFiniteChain`, defining diagonality at a chosen chain length, the real diagonal cut matrix, its total mass, and its normalized coefficient distribution.
- Identify each cut coefficient with the corresponding diagonal entry of the finite-chain MPO. Positive semidefiniteness then proves reality and entrywise nonnegativity; positive total mass proves that normalization is a joint probability distribution.
- Prove `MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log` without caller-supplied coefficient, normalization, distribution, or rank hypotheses, using the rank theorem completed in #4374.
- Add source-cited docstrings and blueprint declarations, and update the paper-gap note. Diagonality identifies the normalized diagonal coefficients with the whole classical finite-chain state.
- This does not prove the unrestricted quantum mutual-information estimate. The distinct quantum problem #4295 remains open.

### Testing

- `lake build TNLean` on exact current main: 9608 jobs completed successfully.
- `lake env lean TNLean/MPS/MPDO/DiagonalFiniteChain.lean`
- `lake exe lint_style --github TNLean/MPS/MPDO/DiagonalFiniteChain.lean TNLean/MPS/MPDO/DiagonalCutRank.lean`
- Kernel axiom audit for all five new theorems: only `propext`, `Classical.choice`, and `Quot.sound`.
- Proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the changed Lean files.
- Blueprint/Lean synchronization, reverse coverage, `lake exe checkdecls blueprint/lean_decls`, `chktex`, and `leanblueprint web`.
- Reader-facing prose check; `TNLean.lean` verified at exactly 1000 lines; and `git diff --check`.

---

Closes #4367.
Closes #4348.
Advances #2380.
Related to #4169 and #4295; #4295 remains open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved Lean lemmas on top of existing diagonal-cut rank machinery; no runtime, auth, or data-path changes—only formalization and documentation sync.
> 
> **Overview**
> **Derives** the real diagonal cut matrix, total mass \(Z\), and normalized joint distribution \(\widehat P\) from a positive semidefinite finite-chain MPO at length \(L+R\), instead of requiring callers to supply those objects to the conditional theorem in `DiagonalCutRank`.
> 
> The new module `TNLean.MPS.MPDO.DiagonalFiniteChain` introduces `IsDiagonalAt`, `diagonalCutRealMatrix`, `diagonalCutMass`, and `normalizedDiagonalCutDistribution`, with lemmas tying cut coefficients to `mpo` diagonal entries, positivity to reality/nonnegativity, and positive mass to `IsJointDistribution`. **`diagonalFiniteChain_classicalMutualInformation_le_two_log`** instantiates `diagonalCut_classicalMutualInformation_le_two_log` from those facts.
> 
> `DiagonalCutRank` docstrings now point here for the unconditional diagonal case. The blueprint chapter and `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` record the fixed-length construction and theorem; the remark replaces an informal diagonal argument with a reference to the new result. **`TNLean.lean`** imports the new file.
> 
> This remains the **classical diagonal subcase** at one chain length; unrestricted quantum mutual information is unchanged and still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d83971ae1ee3cc412cc9a551f2fa74a94b45c6d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

