### PR TITLE
docs(tenkz): migrate algebraic FT diagrams

### DIFF
--- a/blueprint/src/chapter/ch23_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft.tex
@@ -74,11 +74,19 @@ first.
     $n$ so that $Z_n = Z_0$. Locally, this gauge relation is
     represented by
     \begin{center}
-        \TNGaugeConjugation{Z_k}{i}{Z_{k+1}^{-1}}
+        % B_k^i = Z_k A_k^i Z_{k+1}^{-1}: the black nodes are the
+        % site tensors, the red capsules are the two neighboring bond
+        % gauges, and the upper leg carries the free physical index i.
+        % Both sides have boundary signature (1,1,1,0), ordered as
+        % (virtual-west, virtual-east, physical-up, physical-down).
+        \begin{tenkz}[physical=up]
+            \tn[up=$i$]{B_k}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[physical=up]
+            \tnX{Z_k} & \tn[up=$i$]{A_k} & \tnX{Z_{k+1}^{-1}}
+        \end{tenkz}
     \end{center}
-    where the black node denotes the site tensor named in the surrounding
-    formula and the two red side nodes denote the bond gauges on the
-    neighboring virtual legs.
 \end{definition}
 
 \begin{lemma}[Cyclic gauge equivalence is an equivalence relation]
@@ -185,7 +193,19 @@ used in the virtual bond gauge.
     Diagrammatically, the inserted virtual matrix is re-expressed as a
     physical operation on the same local tensor:
     \begin{center}
-        \TNPhysicalRealization{X}{O_A(X)}
+        % A^i X = sum_j O_A(X)_{ij} A^j: on the left, X is inserted on
+        % A's east virtual leg.  On the right, the lower leg of O_A(X)
+        % contracts with A's physical leg over j, while O_A(X)'s upper
+        % leg is the free index i.  The operator row has no virtual
+        % boundary.  Both sides have signature (1,1,1,0).
+        \begin{tenkz}[physical=up]
+            \tn[up=$i$]{A} & \tnX{X}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[rows={op:none, ket}]
+            \tn[mpo, up=$i$, down=$j$]{O_A(X)} \\
+            \tn{A}
+        \end{tenkz}
     \end{center}
     The map $X \mapsto O_A(X)$ is $\C$-linear.
 \end{definition}
@@ -369,12 +389,33 @@ shows that this agreement forces the local tensors to be proportional.
     Diagrammatically, inserting $X$ on the bond between the two sites
     (Eq.~\ref{eq:internal_bond}):
     \begin{center}
-        \TNInternalTraceInsertion{i}{j}{X}
+        % tr(A_1^i X A_2^j) = tr(B_1^i X B_2^j): X lies on the
+        % internal bond between the two site tensors, and the periodic
+        % return closes the remaining virtual ends.  The two upper legs
+        % are the free indices i,j.  Both sides have signature (0,0,2,0).
+        \begin{tenkz}[periodic, physical=up]
+            \tn[up=$i$]{A_1} & \tnX{X} & \tn[up=$j$]{A_2}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[periodic, physical=up]
+            \tn[up=$i$]{B_1} & \tnX{X} & \tn[up=$j$]{B_2}
+        \end{tenkz}
     \end{center}
     while the insertion $Y$ on the outer trace bond
     (Eq.~\ref{eq:external_bond}) is:
     \begin{center}
-        \TNExternalTraceInsertion{i}{j}{Y}
+        % tr(A_2^j Y A_1^i) = tr(B_2^j Y B_1^i): reading each periodic
+        % word from its second site encounters A_2/B_2, then Y on the
+        % outer return bond, then A_1/B_1.  Thus this is not the internal
+        % cyclic order above.  The upper legs are the free indices i,j,
+        % and both sides have signature (0,0,2,0).
+        \begin{tenkz}[periodic, physical=up]
+            \tn[up=$i$]{A_1} & \tn[up=$j$]{A_2} & \tnX{Y}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[periodic, physical=up]
+            \tn[up=$i$]{B_1} & \tn[up=$j$]{B_2} & \tnX{Y}
+        \end{tenkz}
     \end{center}
     so the two hypotheses distinguish the internal and external virtual
     loops of the two-site periodic chain.
@@ -404,9 +445,35 @@ shows that this agreement forces the local tensors to be proportional.
     This is the point where the two-site comparison collapses to a single
     boundary matrix:
     \begin{center}
-        \TNBoundaryRegrow{Z}{i}{j}{2}
-        \qquad
-        \TNLocalEqualityStep{Z}{\lambda \Id}{i}
+        % A_1^i = Z B_1^i = B_1^i Z: the upper leg is the free physical
+        % index i, the red capsule Z acts on the west or east virtual
+        % index, and the untouched outer virtual indices remain open.
+        % All three terms have boundary signature (1,1,1,0).
+        \begin{tenkz}[physical=up]
+            \tn[up=$i$]{A_1}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[physical=up]
+            \tnX{Z} & \tn[up=$i$]{B_1}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[physical=up]
+            \tn[up=$i$]{B_1} & \tnX{Z}
+        \end{tenkz}
+
+        \medskip
+
+        % Z B_1^i = (lambda Id_D) B_1^i: after centrality identifies Z
+        % with lambda Id_D, the two red capsules act on the same west
+        % virtual index of B_1^i.  Both terms keep the east virtual index
+        % and physical index i open, hence have signature (1,1,1,0).
+        \begin{tenkz}[physical=up]
+            \tnX{Z} & \tn[up=$i$]{B_1}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[physical=up]
+            \tnX{\lambda \Id_D} & \tn[up=$i$]{B_1}
+        \end{tenkz}
     \end{center}
     The first product identity~(\ref{eq:aft_product_identities_a}) gives
     $A_1^i = Z B_1^i$, and the second~(\ref{eq:aft_product_identities_b})
@@ -1592,9 +1659,29 @@ scalar factor.
     \uses{def:gauge_equiv}
     Diagrammatically, the hypothesis is that the two local gauges
     \begin{center}
-        \TNGaugeConjugation{X}{i}{X^{-1}}
-        \qquad and\qquad
-        \TNGaugeConjugation{Y}{i}{Y^{-1}}
+        % B^i = X A^i X^{-1}: the red capsules act on the west and east
+        % virtual indices of A^i; the upper leg is the free index i.
+        % Both sides have boundary signature (1,1,1,0).
+        \begin{tenkz}[physical=up]
+            \tn[up=$i$]{B}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[physical=up]
+            \tnX{X} & \tn[up=$i$]{A} & \tnX{X^{-1}}
+        \end{tenkz}
+
+        \qquad\text{and}\qquad
+
+        % B^i = Y A^i Y^{-1}: this second gauge has the same source,
+        % target, and free physical index as the X-gauge above.  Both
+        % sides again have boundary signature (1,1,1,0).
+        \begin{tenkz}[physical=up]
+            \tn[up=$i$]{B}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[physical=up]
+            \tnX{Y} & \tn[up=$i$]{A} & \tnX{Y^{-1}}
+        \end{tenkz}
     \end{center}
     produce the same target tensor $B^i$ from the same source tensor
     $A^i$.
@@ -1646,7 +1733,18 @@ scalar factor.
     $c(g,h) \in \C^{\times}$. Diagrammatically, the two candidate gauges
     are competing local replacements for the same twisted tensor:
     \begin{center}
-        \TNLocalEqualityStep{X(h)\,X(g)}{X(gh)}{i}
+        % (X(h)X(g)) A^i (X(h)X(g))^{-1}
+        %   = X(gh) A^i X(gh)^{-1}: the two candidate gauges act on
+        % the same virtual indices of A^i and produce the same twisted
+        % tensor.  The upper leg is i; both terms have signature (1,1,1,0).
+        \begin{tenkz}[physical=up]
+            \tnX{X(h)X(g)} & \tn[up=$i$]{A} &
+                \tnX{(X(h)X(g))^{-1}}
+        \end{tenkz}
+        $\;=\;$
+        \begin{tenkz}[physical=up]
+            \tnX{X(gh)} & \tn[up=$i$]{A} & \tnX{X(gh)^{-1}}
+        \end{tenkz}
     \end{center}
     and both sides conjugate $A^i$ to the same twisted tensor
     $\widetilde{A}_{gh}^i$.

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -633,39 +633,10 @@
     {chapter/ch02_mps.tex,
      chapter/ch03_single.tex,
      chapter/ch12_symmetry.tex,
-     chapter/ch23_algebraic_ft.tex,
      chapter/ch24_peps_ft_edge_kernel_gauges.tex}{%
     \begin{TNDiagram}[normal]
         \TNGaugeConjugatedMPSSite{tnGauge}{at=origin}{#2}{#1}{#3}
     \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
-    {TNPhysicalRealization}
-    {virtual,physical}
-    {display}
-    {normal}
-    {\TNPhysicalRealization{X}{i}}
-    {chapter/ch23_algebraic_ft.tex}{%
-    \begin{TNEquationRow}[normal]
-        \TNTerm[normal]{%
-            \TNMPSSite{tnA1}{at=origin}{}
-            \TNInsertion{tnX}{right=of tnA1}{#1}
-            \TNOpenVirtualWest{tnA1West}
-            \TNOpenPhysicalNorth{tnA1Ket}
-            \TNVirtualPort{tnXTotnA1}{tnX}{west}
-            \TNConnectVirtual{tnA1East}{tnXTotnA1}
-            \TNVirtualPort{tnXOpenEastPort}{tnX}{east}
-            \TNOpenVirtualEast{tnXOpenEastPort}}
-        \TNRelation{=}
-        \TNTerm[normal]{%
-            \TNMPSSite{tnA2}{at=origin}{}
-            \TNOpenVirtualWest{tnA2West}
-            \TNOpenVirtualEast{tnA2East}
-            \TNInsertion{tnO}{above=of tnA2}{#2}
-            \TNPhysicalPort{tnOTotnA2}{tnO}{south}
-            \TNConnectPhysical{tnA2Ket}{tnOTotnA2}}
-    \end{TNEquationRow}%
 }
 
 % Fix (#401): use a dedicated physical-leg operator insertion for
@@ -820,58 +791,12 @@
 }
 
 \TNDeclareDiagram
-    {TNInternalTraceInsertion}
-    {left,right,virtual}
-    {display}
-    {normal}
-    {\TNInternalTraceInsertion{i}{k}{X}}
-    {chapter/ch23_algebraic_ft.tex}{%
-    \begin{TNDiagram}[normal]
-        \TNMPSSite{tnL}{at=origin}{}
-        \TNInsertion{tnX}{right=of tnL}{#3}
-        \TNMPSSite{tnR}{right=of tnX}{}
-        \TNOpenPhysicalNorth{tnLKet}
-        \TNOpenPhysicalNorth{tnRKet}
-        \TNLabelAbove{tnL}{#1}
-        \TNLabelAbove{tnR}{#2}
-        \TNVirtualPort{tnXTotnL}{tnX}{west}
-        \TNConnectVirtual{tnLEast}{tnXTotnL}
-        \TNVirtualPort{tnXTotnR}{tnX}{east}
-        \TNConnectVirtual{tnXTotnR}{tnRWest}
-        \TNTraceVirtualBelow{tnLWest}{tnREast}
-        \TNLabelBelow{tnX}{\tr}
-    \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
-    {TNExternalTraceInsertion}
-    {left,right,virtual}
-    {display}
-    {normal}
-    {\TNExternalTraceInsertion{i}{k}{X}}
-    {chapter/ch23_algebraic_ft.tex}{%
-    \begin{TNDiagram}[normal]
-        \TNMPSSite{tnL}{at=origin}{}
-        \TNMPSSite{tnR}{right=of tnL}{}
-        \TNInsertion{tnY}{below=of tnL}{#3}
-        \TNOpenPhysicalNorth{tnLKet}
-        \TNOpenPhysicalNorth{tnRKet}
-        \TNLabelAbove{tnL}{#1}
-        \TNLabelAbove{tnR}{#2}
-        \TNConnectVirtual{tnLEast}{tnRWest}
-        \TNMPSExternalTraceInsertionMotif
-            {tnExternalTrace}{tnLWest}{tnREast}{tnY}{\tr}
-    \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
     {TNBoundaryRegrow}
     {virtual,left,right,length}
     {display}
     {normal}
     {\TNBoundaryRegrow{X}{i}{k}{L}}
-    {chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex,
-     chapter/ch23_algebraic_ft.tex}{%
+    {chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex}{%
     \begin{TNDiagram}[normal]
         \TNMPSSite{rA}{at=origin}{}
         \TNMPSSite{rB}{right=of rA}{}
@@ -888,44 +813,6 @@
         \TNVirtualPort{rXOpenEastPort}{rX}{east}\TNOpenVirtualEast{rXOpenEastPort}
         \TNLabelBelow{rB}{#4}
     \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
-    {TNLocalEqualityStep}
-    {left_virtual,right_virtual,physical}
-    {display}
-    {normal}
-    {\TNLocalEqualityStep{X}{Y}{i}}
-    {chapter/ch23_algebraic_ft.tex}{%
-    \begin{TNEquationRow}[normal]
-        \TNTerm[normal]{%
-        \TNTensor{lA}{at=origin}
-        \TNInsertion{lX}{right=of lA}{#1}
-        \TNMPSSite{lB}{right=of lX}{}
-        \TNOpenPhysicalNorth{lBKet}
-        \TNLabelAbove{lB}{#3}
-        \TNVirtualPort{lAOpenWestPort}{lA}{west}\TNOpenVirtualWest{lAOpenWestPort}
-        \TNVirtualPort{lATolX}{lA}{east}
-        \TNVirtualPort{lXTolA}{lX}{west}
-        \TNConnectVirtual{lATolX}{lXTolA}
-        \TNVirtualPort{lXTolB}{lX}{east}
-        \TNConnectVirtual{lXTolB}{lBWest}
-        \TNOpenVirtualEast{lBEast}}
-        \TNRelation{=}
-        \TNTerm[normal]{%
-        \TNTensor{rA}{at=origin}
-        \TNInsertion{rX}{right=of rA}{#2}
-        \TNMPSSite{rB}{right=of rX}{}
-        \TNOpenPhysicalNorth{rBKet}
-        \TNLabelAbove{rB}{#3}
-        \TNVirtualPort{rAOpenWestPort}{rA}{west}\TNOpenVirtualWest{rAOpenWestPort}
-        \TNVirtualPort{rATorX}{rA}{east}
-        \TNVirtualPort{rXTorA}{rX}{west}
-        \TNConnectVirtual{rATorX}{rXTorA}
-        \TNVirtualPort{rXTorB}{rX}{east}
-        \TNConnectVirtual{rXTorB}{rBWest}
-        \TNOpenVirtualEast{rBEast}}
-    \end{TNEquationRow}%
 }
 
 \TNDeclareDiagram


### PR DESCRIPTION
Closes LionSR/tenkz#38.

## What changed

- replace all nine Chapter 23 legacy catalogue calls with native inline tenkz;
- draw the six algebraic identities with their exact open-index signatures;
- keep the internal insertion \(A_1-X-A_2\) distinct from the outer-return insertion \(A_1-A_2-Y\);
- remove the four catalogue declarations whose final call sites disappeared, while retaining the still-shared gauge and boundary declarations;
- keep every formula and ink-to-index correspondence in adjacent \`%\` comments.

## Validation

- focused 19-picture fixture: compile + \`tenkz_audit.py\`;
- temporary Chapter 23 volume: two XeLaTeX passes + audit; inspected PDF pages 4, 5, 7, 18, and 19;
- all 19 tenkz examples: compile + audit;
- \`manual2.tex\`: two passes + audit;
- full \`tn_diagrams.py --check --check-peps-usage --check-slides --audit --audit-strict --smoke-render\`;
- \`test_tenkz_face_ports.py\`, \`test_tenkz_index_routing.py\`, \`test_tenkz_pic.py\`, and \`test_tenkz_tree.py\`;
- 114-file tenkz lint and \`git diff --check\`;
- prohibited-slogan and deleted-prototype scans are empty.

The repository's full default blueprint router does not include Chapter 23. Its separate regression build reached page 457 but exceeded a 15-minute local bound during a latexmk rerun; the dedicated Chapter 23 build above is the relevant render gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-source only; no runtime or auth logic, with catalogue cleanup limited to macros no longer referenced.
> 
> **Overview**
> **Chapter 23** now draws gauge, physical realisation, trace-insertion, and boundary-step identities with **inline `tenkz`** instead of `\TN…` catalogue macros, with `%` comments documenting boundary signatures and index routing (including **internal** vs **outer-return** periodic insertions).
> 
> **`tn_catalogue.tex`** removes the declarations for `TNPhysicalRealization`, `TNInternalTraceInsertion`, `TNExternalTraceInsertion`, and `TNLocalEqualityStep`, and drops ch23 from `TNGaugeConjugation` / `TNBoundaryRegrow` context lists where those were the only ch23 call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8dbc914beee3cc91ff3c5dc01fd01859115296d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->