### PR TITLE
fix(MPS/MPDO): add global diagonal-MPDO corollary

### DIFF
--- a/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
+++ b/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
@@ -16,8 +16,10 @@ distribution to a positive diagonal finite-chain matrix product operator.
 The resulting classical mutual information is at most twice the logarithm of
 the bond dimension.
 
-Only positivity and diagonality at the chain length under consideration are
-assumed.  No local purification or positivity at other lengths is required.
+The fixed-length theorem assumes positivity and diagonality only at the chain
+length under consideration; no local purification or positivity at other
+lengths is required there.  The global corollary instead assumes diagonality
+and positive semidefiniteness at every positive chain length.
 
 ## Main definitions
 

--- a/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
+++ b/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.DiagonalCutRank
+import TNLean.MPS.MPDO.AreaLaw
 import Mathlib.Analysis.Matrix.Hermitian
 import Mathlib.LinearAlgebra.Matrix.IsDiag
 
@@ -21,6 +22,7 @@ assumed.  No local purification or positivity at other lengths is required.
 ## Main definitions
 
 * `MPOTensor.IsDiagonalAt`: diagonality of the operator at one chain length.
+* `MPOTensor.IsDiagonal`: diagonality at every positive chain length.
 * `MPOTensor.diagonalCutRealMatrix`: the real diagonal coefficients across a cut.
 * `MPOTensor.diagonalCutMass`: the total mass of these coefficients.
 * `MPOTensor.normalizedDiagonalCutDistribution`: their normalization.
@@ -32,10 +34,14 @@ assumed.  No local purification or positivity at other lengths is required.
 * `MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log`: the
   classical mutual information of a positive diagonal finite-chain operator is
   at most $2\log D$.
+* `MPOTensor.diagonalMPDO_classicalMutualInformation_le_two_log`: the same
+  estimate from global diagonality, MPDO positivity, and positive trace.
 
 ## References
 
-* arXiv:1606.00608, Proposition 4.5, lines 795--806.
+* arXiv:1606.00608, Proposition 4.5, lines 792--806, and its proof at
+  lines 1316--1320.
+* Riazanov--Vyalyi, arXiv:1704.06507, Theorem 4.1.
 * `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`, section
   "Diagonal matrix product operators".
 -/
@@ -50,32 +56,46 @@ variable {d D : ℕ}
 /-- An MPO tensor is diagonal at length `N` when the generated finite-chain
 operator has no off-diagonal matrix entries.
 
-This is the diagonal finite-chain specialization considered in the analysis of
-arXiv:1606.00608, Proposition 4.5, lines 795--806; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+This is the fixed-length diagonal restriction used here to study the bound
+invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines 1316--1320;
+see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 def IsDiagonalAt (M : MPOTensor d D) (N : ℕ) : Prop :=
   (mpo M N).IsDiag
+
+/-- An MPO tensor is diagonal when it generates a diagonal operator at every
+positive chain length.
+
+This is the global diagonal restriction used here to study the bound invoked
+in the proof of arXiv:1606.00608, Proposition 4.5, lines 1316--1320; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+def IsDiagonal (M : MPOTensor d D) : Prop :=
+  ∀ N : ℕ, 0 < N → M.IsDiagonalAt N
 
 /-- The real parts of the diagonal coefficients across a periodic cut.
 
 For a positive finite-chain operator these coefficients are real and
-nonnegative.  They are the coefficients denoted by $P_{x,y}$ in the diagonal
-analysis of arXiv:1606.00608, Proposition 4.5, lines 795--806. -/
+nonnegative.  This matrix belongs to the fixed-length diagonal restriction of
+the bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
+1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 noncomputable def diagonalCutRealMatrix (M : MPOTensor d D) (L R : ℕ) :
     Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ :=
   (diagonalCutMatrix M L R).map Complex.re
 
 /-- The total mass of the real diagonal coefficients across a periodic cut.
 
-This is the normalization constant $Z$ in the diagonal analysis of
-arXiv:1606.00608, Proposition 4.5, lines 795--806. -/
+This is the normalization constant for the fixed-length diagonal restriction
+of arXiv:1606.00608, Proposition 4.5.  The source normalization convention is
+at lines 792--793; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 noncomputable def diagonalCutMass (M : MPOTensor d D) (L R : ℕ) : ℝ :=
   ∑ x, ∑ y, diagonalCutRealMatrix M L R x y
 
 /-- The real diagonal coefficient matrix divided by its total mass.
 
-This is the joint distribution $\widehat P=Z^{-1}P$ in the diagonal analysis of
-arXiv:1606.00608, Proposition 4.5, lines 795--806. -/
+This is the joint distribution $\widehat P=Z^{-1}P$ for the fixed-length
+diagonal restriction of arXiv:1606.00608, Proposition 4.5.  The source
+normalization convention is at lines 792--793; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 noncomputable def normalizedDiagonalCutDistribution (M : MPOTensor d D) (L R : ℕ) :
     Matrix (Fin L → Fin d) (Fin R → Fin d) ℝ :=
   (diagonalCutMass M L R)⁻¹ • diagonalCutRealMatrix M L R
@@ -83,9 +103,9 @@ noncomputable def normalizedDiagonalCutDistribution (M : MPOTensor d D) (L R : �
 /-- A diagonal cut coefficient is the corresponding diagonal matrix entry of
 the finite-chain MPO operator.
 
-This is the coefficient identity used in the diagonal finite-chain analysis of
-arXiv:1606.00608, Proposition 4.5, lines 795--806; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+This is the coefficient identity used for the fixed-length diagonal restriction
+of the bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
+1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem diagonalCutMatrix_apply_eq_mpo (M : MPOTensor d D) (L R : ℕ)
     (x : Fin L → Fin d) (y : Fin R → Fin d) :
     diagonalCutMatrix M L R x y =
@@ -95,9 +115,9 @@ theorem diagonalCutMatrix_apply_eq_mpo (M : MPOTensor d D) (L R : ℕ)
 /-- Positivity makes every diagonal cut coefficient equal to the scalar
 extension of its real part.
 
-This is the real-coefficient step in the diagonal finite-chain analysis of
-arXiv:1606.00608, Proposition 4.5, lines 795--806; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+This is the real-coefficient step for the fixed-length diagonal restriction of
+the bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
+1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem diagonalCutRealMatrix_map_ofReal_of_posSemidef (M : MPOTensor d D) (L R : ℕ)
     (hpos : (mpo M (L + R)).PosSemidef) :
     (diagonalCutRealMatrix M L R).map Complex.ofReal = diagonalCutMatrix M L R := by
@@ -109,20 +129,60 @@ theorem diagonalCutRealMatrix_map_ofReal_of_posSemidef (M : MPOTensor d D) (L R 
 /-- The real diagonal cut coefficients of a positive finite-chain operator are
 nonnegative.
 
-This is the positivity step in the diagonal finite-chain analysis of
-arXiv:1606.00608, Proposition 4.5, lines 795--806; see
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+This is the positivity step for the fixed-length diagonal restriction of the
+bound invoked in the proof of arXiv:1606.00608, Proposition 4.5, lines
+1316--1320; see `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem diagonalCutRealMatrix_nonneg_of_posSemidef (M : MPOTensor d D) (L R : ℕ)
     (hpos : (mpo M (L + R)).PosSemidef) (x : Fin L → Fin d) (y : Fin R → Fin d) :
     0 ≤ diagonalCutRealMatrix M L R x y := by
   rw [diagonalCutRealMatrix, Matrix.map_apply, diagonalCutMatrix_apply_eq_mpo]
   exact (RCLike.nonneg_iff.mp hpos.diag_nonneg).1
 
+/-- The mass of the diagonal cut coefficients is the real part of the
+finite-chain trace.
+
+This identifies the local normalization constant with the trace in the
+normalization convention of arXiv:1606.00608, lines 792--793; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalCutMass_eq_trace_re (M : MPOTensor d D) (L R : ℕ) :
+    diagonalCutMass M L R = (mpo M (L + R)).trace.re := by
+  classical
+  have hsum :
+      (∑ x : Fin L → Fin d, ∑ y : Fin R → Fin d,
+        mpo M (L + R) (Fin.append x y) (Fin.append x y)) =
+        (mpo M (L + R)).trace := by
+    calc
+      (∑ x : Fin L → Fin d, ∑ y : Fin R → Fin d,
+          mpo M (L + R) (Fin.append x y) (Fin.append x y)) =
+        ∑ p : (Fin L → Fin d) × (Fin R → Fin d),
+          mpo M (L + R) (Fin.append p.1 p.2) (Fin.append p.1 p.2) :=
+        (Fintype.sum_prod_type' _).symm
+      _ = ∑ σ, mpo M (L + R) σ σ := by
+        apply Fintype.sum_equiv (blockSplitEquiv d L R).symm
+        rintro ⟨x, y⟩
+        simp only [blockSplitEquiv_symm_apply]
+      _ = (mpo M (L + R)).trace := rfl
+  rw [diagonalCutMass]
+  simp only [diagonalCutRealMatrix, Matrix.map_apply, diagonalCutMatrix_apply_eq_mpo]
+  calc
+    (∑ x : Fin L → Fin d, ∑ y : Fin R → Fin d,
+        (mpo M (L + R) (Fin.append x y) (Fin.append x y)).re) =
+      ∑ x : Fin L → Fin d,
+        (∑ y : Fin R → Fin d, mpo M (L + R) (Fin.append x y) (Fin.append x y)).re := by
+      refine Finset.sum_congr rfl (fun x _ ↦ ?_)
+      exact (Complex.re_sum Finset.univ _).symm
+    _ = (∑ x : Fin L → Fin d, ∑ y : Fin R → Fin d,
+        mpo M (L + R) (Fin.append x y) (Fin.append x y)).re :=
+      (Complex.re_sum Finset.univ _).symm
+    _ = (mpo M (L + R)).trace.re := congrArg Complex.re hsum
+
 /-- Positive semidefiniteness and positive total mass make the normalized
 diagonal cut coefficients a joint probability distribution.
 
-This is the normalization step in the diagonal case of arXiv:1606.00608,
-Proposition 4.5, lines 795--806. -/
+This is the normalization step for the fixed-length diagonal restriction of
+arXiv:1606.00608, Proposition 4.5.  The source normalization convention is at
+lines 792--793; see
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem normalizedDiagonalCutDistribution_isJointDistribution (M : MPOTensor d D)
     (L R : ℕ) (hpos : (mpo M (L + R)).PosSemidef)
     (hmass : 0 < diagonalCutMass M L R) :
@@ -148,10 +208,10 @@ Positivity produces the joint distribution from the diagonal entries, while
 diagonality says that these entries constitute the whole finite-chain state.
 Thus the normalized coefficients are the classical finite-chain distribution.
 
-This is the diagonal finite-chain consequence of arXiv:1606.00608,
-Proposition 4.5, lines 795--806, using Riazanov--Vyalyi, Theorem 4.1
-(arXiv:1704.06507).  It does not assert a bound for unrestricted quantum mutual
-information.
+This is a fixed-length classical restriction of the bound invoked in the proof
+of arXiv:1606.00608, Proposition 4.5, lines 1316--1320, using
+Riazanov--Vyalyi, Theorem 4.1 (arXiv:1704.06507).  It does not assert a bound
+for unrestricted quantum mutual information.
 
 **Scope restriction (diagonal finite-chain operator):** Proposition 4.5 concerns
 arbitrary MPDOs, whereas this theorem treats the classical diagonal subcase at
@@ -169,5 +229,31 @@ theorem diagonalFiniteChain_classicalMutualInformation_le_two_log [NeZero D]
   · exact hmass
   · rfl
   · exact diagonalCutRealMatrix_map_ofReal_of_posSemidef M L R hpos
+
+/-- **Classical estimate for a diagonal MPDO.** A globally diagonal MPDO with
+positive trace at length `L + R` has classical mutual information of its
+normalized diagonal coefficients at most `2 * log D`.
+
+Global MPDO positivity supplies the fixed-length positive-semidefinite
+hypothesis, while `diagonalCutMass_eq_trace_re` identifies the positive trace
+with the normalization mass.
+
+This is a diagonal classical restriction of the bound invoked in the proof of
+arXiv:1606.00608, Proposition 4.5, lines 1316--1320, using Riazanov--Vyalyi,
+Theorem 4.1 (arXiv:1704.06507).
+
+**Scope restriction (globally diagonal MPDO):** Proposition 4.5 concerns
+arbitrary MPDOs, whereas this theorem treats globally diagonal tensors.  The
+unrestricted quantum question is documented in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem diagonalMPDO_classicalMutualInformation_le_two_log [NeZero D]
+    (M : MPOTensor d D) (hdiag : M.IsDiagonal) (hmpdo : M.IsMPDO)
+    (L R : ℕ) (hN : 0 < L + R) (htrace : 0 < (mpo M (L + R)).trace.re) :
+    Entropy.classicalMutualInformation (normalizedDiagonalCutDistribution M L R) ≤
+      2 * Real.log D := by
+  apply diagonalFiniteChain_classicalMutualInformation_le_two_log M L R
+  · exact hdiag (L + R) hN
+  · exact hmpdo (L + R) hN
+  · rwa [diagonalCutMass_eq_trace_re]
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
+++ b/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
@@ -231,8 +231,8 @@ theorem diagonalFiniteChain_classicalMutualInformation_le_two_log [NeZero D]
   · exact diagonalCutRealMatrix_map_ofReal_of_posSemidef M L R hpos
 
 /-- **Classical estimate for a diagonal MPDO.** A globally diagonal MPDO with
-positive trace at length `L + R` has classical mutual information of its
-normalized diagonal coefficients at most `2 * log D`.
+positive trace at length $L+R$ has classical mutual information of its
+normalized diagonal coefficients at most $2\log D$.
 
 Global MPDO positivity supplies the fixed-length positive-semidefinite
 hypothesis.  The total mass $Z$ equals the real part of the finite-chain trace,

--- a/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
+++ b/TNLean/MPS/MPDO/DiagonalFiniteChain.lean
@@ -235,8 +235,8 @@ positive trace at length `L + R` has classical mutual information of its
 normalized diagonal coefficients at most `2 * log D`.
 
 Global MPDO positivity supplies the fixed-length positive-semidefinite
-hypothesis, while `diagonalCutMass_eq_trace_re` identifies the positive trace
-with the normalization mass.
+hypothesis.  The total mass $Z$ equals the real part of the finite-chain trace,
+so trace positivity gives $Z>0$.
 
 This is a diagonal classical restriction of the bound invoked in the proof of
 arXiv:1606.00608, Proposition 4.5, lines 1316--1320, using Riazanov--Vyalyi,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -1172,6 +1172,7 @@
 \begin{definition}[Normalized diagonal distribution at fixed length]
     \label{def:mpo_normalized_diagonal_cut_distribution}
     \lean{MPOTensor.IsDiagonalAt,
+      MPOTensor.IsDiagonal,
       MPOTensor.diagonalCutRealMatrix,
       MPOTensor.diagonalCutMass,
       MPOTensor.normalizedDiagonalCutDistribution}
@@ -1192,6 +1193,7 @@
     \lean{MPOTensor.diagonalCutMatrix_apply_eq_mpo,
       MPOTensor.diagonalCutRealMatrix_map_ofReal_of_posSemidef,
       MPOTensor.diagonalCutRealMatrix_nonneg_of_posSemidef,
+      MPOTensor.diagonalCutMass_eq_trace_re,
       MPOTensor.normalizedDiagonalCutDistribution_isJointDistribution,
       MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log}
     \leanok
@@ -1221,9 +1223,29 @@
     the bound.
 \end{proof}
 
+\begin{corollary}[Classical estimate for a diagonal matrix product density operator]
+    \label{cor:mpo_diagonal_classical_mutual_information}
+    \lean{MPOTensor.diagonalMPDO_classicalMutualInformation_le_two_log}
+    \leanok
+    \uses{thm:mpo_diagonal_finite_chain_classical_mutual_information}
+    Let $M$ generate diagonal positive semidefinite operators at every positive
+    chain length.  If the trace at length $L+R$ is positive, then the classical
+    mutual information of its normalized diagonal coefficients satisfies
+    \[
+      I(X:Y)\leq2\log D.
+    \]
+\end{corollary}
+\begin{proof}\leanok
+    Global diagonality and positivity give the fixed-length hypotheses of
+    Theorem~\ref{thm:mpo_diagonal_finite_chain_classical_mutual_information}.
+    The total mass of the diagonal coefficients is the real part of the trace,
+    so the assumed trace positivity supplies the required normalization.
+\end{proof}
+
 \begin{remark}[Boundedness of the mutual information]
-    Proposition~4.5 of \cite{Cirac2016MPDO_arXiv} asserts the uniform estimate
-    $I_L \le 4\log D$ for every MPDO. Its cited proof, however, treats mixed
+    The proof of Proposition~4.5 of \cite{Cirac2016MPDO_arXiv} invokes the
+    uniform estimate $I_L \le 4\log D$ for every MPDO. Its cited argument,
+    however, treats mixed
     tensor-network states obtained from local completely positive maps
     \cite{Wolf2008AreaLaws}. After purifying those maps, data processing and
     the pure-state boundary estimate give

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -1189,12 +1189,28 @@
     \]
 \end{definition}
 
+\begin{lemma}[Diagonal coefficient mass and trace]
+    \label{lem:mpo_diagonal_cut_mass_trace}
+    \lean{MPOTensor.diagonalCutMass_eq_trace_re}
+    \leanok
+    \uses{def:mpo_normalized_diagonal_cut_distribution}
+    For every MPO tensor $M$ and cut lengths $L,R$, the total diagonal
+    coefficient mass satisfies
+    \[
+      Z=\operatorname{Re}\operatorname{tr}\rho^{(L+R)}(M).
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    Splitting a configuration on $L+R$ sites into its first $L$ and last $R$
+    components rewrites $Z$ as the sum of all diagonal entries of
+    $\rho^{(L+R)}(M)$, which is its trace.
+\end{proof}
+
 \begin{theorem}[Classical estimate for a positive diagonal finite-chain operator]
     \label{thm:mpo_diagonal_finite_chain_classical_mutual_information}
     \lean{MPOTensor.diagonalCutMatrix_apply_eq_mpo,
       MPOTensor.diagonalCutRealMatrix_map_ofReal_of_posSemidef,
       MPOTensor.diagonalCutRealMatrix_nonneg_of_posSemidef,
-      MPOTensor.diagonalCutMass_eq_trace_re,
       MPOTensor.normalizedDiagonalCutDistribution_isJointDistribution,
       MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log}
     \leanok
@@ -1228,7 +1244,6 @@
     \label{cor:mpo_diagonal_classical_mutual_information}
     \lean{MPOTensor.diagonalMPDO_classicalMutualInformation_le_two_log}
     \leanok
-    \uses{thm:mpo_diagonal_finite_chain_classical_mutual_information}
     Let $D\geq1$, and let $M$ generate diagonal positive semidefinite operators
     at every positive chain length.  If $L+R>0$ and the trace at length $L+R$
     is positive, then the classical mutual information of its normalized
@@ -1238,6 +1253,8 @@
     \]
 \end{corollary}
 \begin{proof}\leanok
+    \uses{thm:mpo_diagonal_finite_chain_classical_mutual_information,
+      lem:mpo_diagonal_cut_mass_trace}
     Global diagonality and positivity give the fixed-length hypotheses of
     Theorem~\ref{thm:mpo_diagonal_finite_chain_classical_mutual_information}.
     Since the chain operator is diagonal,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -1179,8 +1179,9 @@
     \leanok
     \uses{def:mpo_tensor}
     For a chain of length $N=L+R$, call $\rho^{(N)}(M)$ diagonal if
-    $\rho^{(N)}(M)_{u,v}=0$ whenever $u\ne v$.  For configurations $x$ and $y$
-    on the two consecutive blocks, define
+    $\rho^{(N)}(M)_{u,v}=0$ whenever $u\ne v$.  Call $M$ globally diagonal if
+    $\rho^{(N)}(M)$ is diagonal for every $N>0$.  For configurations $x$ and
+    $y$ on the two consecutive blocks, define
     \[
       W_{x,y}=\operatorname{Re}\rho^{(L+R)}(M)_{(x,y),(x,y)},\qquad
       Z=\sum_{x,y}W_{x,y},\qquad
@@ -1228,9 +1229,10 @@
     \lean{MPOTensor.diagonalMPDO_classicalMutualInformation_le_two_log}
     \leanok
     \uses{thm:mpo_diagonal_finite_chain_classical_mutual_information}
-    Let $M$ generate diagonal positive semidefinite operators at every positive
-    chain length.  If $L+R>0$ and the trace at length $L+R$ is positive, then
-    the classical mutual information of its normalized diagonal coefficients satisfies
+    Let $D\geq1$, and let $M$ generate diagonal positive semidefinite operators
+    at every positive chain length.  If $L+R>0$ and the trace at length $L+R$
+    is positive, then the classical mutual information of its normalized
+    diagonal coefficients satisfies
     \[
       I(X:Y)\leq2\log D.
     \]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -1201,9 +1201,13 @@
     \]
 \end{lemma}
 \begin{proof}\leanok
-    Splitting a configuration on $L+R$ sites into its first $L$ and last $R$
-    components rewrites $Z$ as the sum of all diagonal entries of
-    $\rho^{(L+R)}(M)$, which is its trace.
+    Pairing each configuration $\sigma$ on $L+R$ sites with its unique block
+    split $(x,y)$ on $L$ and $R$ sites gives
+    \[
+      Z=\sum_{x,y}W_{x,y}
+      =\sum_\sigma\operatorname{Re}\rho^{(L+R)}(M)_{\sigma,\sigma}
+      =\operatorname{Re}\operatorname{tr}\rho^{(L+R)}(M).
+    \]
 \end{proof}
 
 \begin{theorem}[Classical estimate for a positive diagonal finite-chain operator]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -1229,8 +1229,8 @@
     \leanok
     \uses{thm:mpo_diagonal_finite_chain_classical_mutual_information}
     Let $M$ generate diagonal positive semidefinite operators at every positive
-    chain length.  If the trace at length $L+R$ is positive, then the classical
-    mutual information of its normalized diagonal coefficients satisfies
+    chain length.  If $L+R>0$ and the trace at length $L+R$ is positive, then
+    the classical mutual information of its normalized diagonal coefficients satisfies
     \[
       I(X:Y)\leq2\log D.
     \]
@@ -1238,8 +1238,12 @@
 \begin{proof}\leanok
     Global diagonality and positivity give the fixed-length hypotheses of
     Theorem~\ref{thm:mpo_diagonal_finite_chain_classical_mutual_information}.
-    The total mass of the diagonal coefficients is the real part of the trace,
-    so the assumed trace positivity supplies the required normalization.
+    Since the chain operator is diagonal,
+    \[
+      Z=\sum_{x,y}W_{x,y}
+      =\operatorname{Re}\operatorname{tr}\rho^{(L+R)}(M),
+    \]
+    so the trace positivity hypothesis supplies the required normalization.
 \end{proof}
 
 \begin{remark}[Boundedness of the mutual information]

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -216,14 +216,18 @@ construction is formalized in
 \doclink{TNLean/MPS/MPDO/DiagonalFiniteChain}.
 \footnote{Formal declarations:
 \leanid{MPOTensor.IsDiagonalAt},
+\leanid{MPOTensor.IsDiagonal},
 \leanid{MPOTensor.diagonalCutRealMatrix},
 \leanid{MPOTensor.diagonalCutMass},
 \leanid{MPOTensor.normalizedDiagonalCutDistribution},
 \leanid{MPOTensor.diagonalCutRealMatrix_map_ofReal_of_posSemidef},
 \leanid{MPOTensor.diagonalCutRealMatrix_nonneg_of_posSemidef},
+\leanid{MPOTensor.diagonalCutMass_eq_trace_re},
 \leanid{MPOTensor.normalizedDiagonalCutDistribution_isJointDistribution},
 and
-\leanid{MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log}.}
+\leanid{MPOTensor.diagonalFiniteChain_classicalMutualInformation_le_two_log}.
+The global diagonal-MPDO corollary is
+\leanid{MPOTensor.diagonalMPDO_classicalMutualInformation_le_two_log}.}
 For a positive diagonal operator at the chosen length, the real diagonal
 coefficients are nonnegative, their scalar extension is the cut matrix, and
 division by their positive total mass gives a joint distribution.  Diagonality


### PR DESCRIPTION
### Motivation

PR #4402 constructed the fixed-length real diagonal coefficient matrix and its normalized joint distribution, but its final theorem retains fixed-length positivity and positive mass as explicit hypotheses, and its diagonality hypothesis is only interpretive. That does not by itself supply the global diagonal-MPDO route requested by #4367 and #4348.

The post-merge source audit also found that CPSV16 does not introduce the diagonal coefficient matrix or the `2 log D` classical estimate. CPSV16 gives the normalization convention at lines 792–793 and invokes the unrestricted `4 log D` claim in the proof of Proposition 4.5 at lines 1316–1320. The diagonal `2 log D` theorem is a local classical restriction obtained with Riazanov–Vyalyi, Theorem 4.1.

### Description

- Define `MPOTensor.IsDiagonal` as diagonality of the generated operator at every positive chain length.
- Prove `diagonalCutMass_eq_trace_re`, using the established contiguous-block equivalence to identify the sum of diagonal cut coefficients with the finite-chain trace.
- Add `diagonalMPDO_classicalMutualInformation_le_two_log`, deriving the fixed-length hypotheses from global diagonality, `IsMPDO`, and positive trace.
- Add the matching blueprint corollary and paper-gap links.
- Correct the new source-facing docstrings and blueprint remark so the locally derived diagonal construction is not attributed to CPSV16.

This remains a classical diagonal result. The unrestricted quantum operator-Schmidt-rank question #4295 remains open.

### Testing

- `lake env lean TNLean/MPS/MPDO/DiagonalFiniteChain.lean`
- `git diff --check origin/main...HEAD`
- proof-integrity scan of the changed Lean file
- `python3 scripts/tactic_pattern_scan.py` (no new repeated pattern attributable to this change)
- `TNLean.lean` remains exactly 1000 lines and is unchanged by this follow-up

The full build, blueprint checks, prose/style checks, CI, and superseding exact-head reviews remain guarded while this PR is draft.

---

Closes #4367.
Closes #4348.
Advances #2380 and #4169.
Related to #4295; #4295 remains open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in MPS/MPDO diagonal theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Extends the diagonal finite-chain formalization so **globally diagonal MPDOs** get the same **$2\log D$** classical mutual-information bound without re-stating fixed-length positivity and positive mass at each cut.
> 
> **Lean:** Defines `MPOTensor.IsDiagonal` (diagonal at every positive length), proves `diagonalCutMass_eq_trace_re` (normalization mass $Z$ equals $\mathrm{Re}\,\mathrm{tr}\,\rho^{(L+R)}$), and adds `diagonalMPDO_classicalMutualInformation_le_two_log` by deriving `IsDiagonalAt`, `PosSemidef`, and $Z>0$ from `IsDiagonal`, `IsMPDO`, and positive trace. Imports `AreaLaw` for the MPDO layer. Docstrings are retargeted to CPSV16 normalization (792–793) and the proof invocation (1316–1320), not the diagonal $2\log D$ construction itself.
> 
> **Docs:** Blueprint adds global diagonality, lemma `lem:mpo_diagonal_cut_mass_trace`, and corollary `cor:mpo_diagonal_classical_mutual_information`; paper-gap and remark text align with the same source attribution. Still **classical diagonal only**; unrestricted quantum MI is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f797e5b97b43e8ac6e332a4442623ca8d9cc2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->