### PR TITLE
fix(Channel/Schwarz): correct Weyl resolvent citations

### DIFF
--- a/TNLean/Analysis/SuperoperatorResolvent.lean
+++ b/TNLean/Analysis/SuperoperatorResolvent.lean
@@ -93,7 +93,7 @@ Under the vectorization `X ↦ Matrix.vec Xᵀ`, the displayed matrix acts as th
 left-right multiplication operator.  This is the fixed-resolvent positivity
 input in Jenčová--Ruskai, arXiv:0903.2895, §4 and Appendix. -/
 theorem superop_leftRight_posDef
-    {n : Type*} [Fintype n] [DecidableEq n]
+    {n : Type*} [Finite n] [DecidableEq n]
     {t : ℝ} (ht : 0 < t) {A B : Matrix n n ℂ}
     (hA : A.PosDef) (hB : B.PosDef) :
     (A ⊗ₖ (1 : Matrix n n ℂ) +

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -392,6 +392,7 @@ private theorem resolvent_residual_identity
   rw [hleft, hright, hlast, hx]
   ring
 
+omit [DecidableEq n] in
 private lemma sum_norm_sq_eq_re_dotProduct (y : n → ℂ) :
     ∑ p, ‖y p‖ ^ 2 = (dotProduct (star y) y).re := by
   simp [dotProduct, Complex.sq_norm, ← Complex.normSq_eq_conj_mul_self]
@@ -412,7 +413,7 @@ private lemma sqrt_inv_mulVec_normSq (S : Matrix n n ℂ) (hS : S.PosDef)
   letI : Invertible Q := hQunit.invertible
   letI : Invertible S := hS.isUnit.invertible
   have hQherm : Q.IsHermitian := by
-    show Qᴴ = Q
+    change Qᴴ = Q
     simpa only [Q, star_eq_conjTranspose] using
       (CFC.sqrt_nonneg (a := S)).isSelfAdjoint.star_eq
   let y : n → ℂ := Q⁻¹ *ᵥ r
@@ -558,7 +559,7 @@ summand quadratic forms and the quadratic form of their average.
 The vectorization is `X ↦ Matrix.vec Xᵀ`; hence
 `A ⊗ₖ 1 + t • (1 ⊗ₖ Bᵀ)` represents `X ↦ A * X + t • (X * B)`.
 This is the finite-Weyl specialization of Jenčová--Ruskai,
-arXiv:0903.2895, §4 and Appendix. It is a
+arXiv:0903.2895v4, Appendix, lines 1313--1343. It is a
 fixed-`t`, positive-definite statement and does not derive vanishing of the
 defect from relative-entropy equality.
 
@@ -738,7 +739,8 @@ Taking `g = (0, 0)` gives the identity-Weyl summand required in the
 partial-trace equality argument.
 
 This is the zero-defect conclusion of Jenčová--Ruskai,
-arXiv:0903.2895, §4 and Appendix. It does not assert that equality of
+arXiv:0903.2895v4, §4, lines 652--674, using the squared-defect expansion
+from Appendix, lines 1313--1343. It does not assert that equality of
 relative entropies makes the
 displayed defect vanish.
 

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2570,9 +2570,9 @@ Theorem~\ref{thm:trace_norm_abs}.
           \langle B,T^{-1}(B)\rangle_{\mathrm{HS}}.
     \]
     This is the positive-definite, fixed-$t$ identity in
-    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895, \S4 and Appendix.  It does not infer zero defect from
-    equality of relative entropies and makes no assertion about singular
-    supports.
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, Appendix,
+    lines 1313--1343.  It does not infer zero defect from equality of relative
+    entropies and makes no assertion about singular supports.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2693,6 +2693,9 @@ Theorem~\ref{thm:trace_norm_abs}.
         T_g^{-1}(B_g)=T^{-1}(B).
     \]
     In particular this holds for the identity Weyl element $g=(0,0)$.
+    This is the common-resolvent conclusion in Jen\v{c}ov\'a--Ruskai,
+    arXiv:0903.2895v4, \S4, lines 652--674; its squared-defect input is in
+    Appendix, lines 1313--1343.
     This fixed-$t$, positive-definite conclusion does not assert that equality
     of relative entropies implies the displayed scalar hypothesis.
 \end{theorem}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -298,8 +298,9 @@ the residuals $R_g=B_g-T_g(\Lambda_t)$ gives the exact identity
 \end{align}
 Consequently, if the right-hand side vanishes, then
 $T_g^{-1}(B_g)=\Lambda_t$ for every $g$, in particular for the identity Weyl
-element.  This is the fixed-$t$ calculation of Jen\v{c}ov\'a--Ruskai,
-arXiv:0903.2895v4, \S4 and Appendix.
+element.  The squared-defect identity is the Appendix calculation of
+Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 1313--1343; the resulting
+common-resolvent equality is in \S4, lines 652--674.
 \footnote{Formal declarations:
 \leanid{Matrix.weyl_resolvent_defect_identity} and
 \leanid{Matrix.weyl_resolvent_eq_of_defect_eq_zero} in


### PR DESCRIPTION
## Summary

- distinguish the Appendix squared-defect identity (arXiv:0903.2895v4, lines 1313--1343) from the §4 common-resolvent conclusion (lines 652--674)
- synchronize the Lean docstrings, entropy blueprint, and existing paper-gap note
- remove the three linter warnings identified in the post-merge audit without weakening any theorem statement

## Validation

- `lake build TNLean.Analysis.SuperoperatorResolvent TNLean.Channel.Schwarz.PetzEqualityPrerequisites`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity scan of both changed Lean files
- `git diff --check origin/main...HEAD`
- full `lake build` is still running locally; draft status will be retained until it finishes and exact-head CI/reviews are green

Closes #4379
Closes #4380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and minor type-class/proof-style fixes only; theorem statements and mathematical claims are unchanged.
> 
> **Overview**
> **Citation alignment** for the finite Weyl fixed-resolvent material: docstrings in `PetzEqualityPrerequisites.lean`, the entropy blueprint (`ch19_entropy.tex`), and the paper-gap note now **split** Jenčová–Ruskai **arXiv:0903.2895v4** into the **Appendix squared-defect identity** (lines 1313–1343) versus the **§4 common-resolvent conclusion** (lines 652–674), instead of lumping both under “§4 and Appendix.”
> 
> **Lean-only tweaks** (no statement changes): `superop_leftRight_posDef` uses `[Finite n]` instead of `[Fintype n]`; `sum_norm_sq_eq_re_dotProduct` is wrapped in `omit [DecidableEq n]`; Hermitian proof for `CFC.sqrt` uses `change` instead of `show`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a53e24e3fe7c616db27a73e6a15523d66ef404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->