### PR TITLE
docs: migrate Chapter 20 local purification to tenkz

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch20_mpdo_foundations.tex
@@ -326,10 +326,29 @@ Diagrammatically,
     denotes entrywise complex conjugation, and $(\cdot)_{e,e}$ denotes
     reindexing along $e$ back to $\{0, \ldots, D - 1\}$.
     See \cite[Section~4.3]{Cirac2016MPDO_arXiv}.
+    % Coefficient identity:
+    % M^{ij}_{\alpha\beta}
+    %   = \sum_{k,a,a',b,b'} e^{aa'}_{\alpha}
+    %       A^{(i,k)}_{ab}\overline{A^{(j,k)}_{a'b'}}
+    %       (e^{-1})^{\beta}_{bb'}.
+    % Both sides have boundary signature (1,1,1,1): alpha and beta are the
+    % west and east virtual indices, while i and j are the upper and lower
+    % physical indices.  The west e wedge splits alpha into a,a'; the east
+    % e^{-1} wedge combines b,b' into beta.  The unique inter-row pairleg is
+    % the ancillary contraction k; a,a',b,b' are the remaining contracted
+    % virtual indices.  No east cup is present, since beta remains free.
     The local contraction is
-    \TNMPOLocalPurification
-    where the straight internal line is the ancillary index $k$, while the
-    ket and bra physical legs remain external.
+    \[
+        \begin{tenkz}[physical=updown, tensor style=box]
+            \tn[mpo, up=$i$, down=$j$]{M}
+        \end{tenkz}
+        \;=\;
+        \begin{tenkz}[rows={op,op}, tensor style=box]
+            \tnfuse{e} & \tn[up=$i$]{A} &
+                \tnfuse[combined=east]{e^{-1}}\\
+                       & \tn*[down=$j$]{A} &
+        \end{tenkz}
+    \]
 \end{definition}
 
 \begin{theorem}[LPDOs are MPDOs]\label{thm:lpdo_is_mpdo}

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -133,36 +133,6 @@
     \end{TNDiagram}%
 }
 
-% Local purification of an MPO tensor: the ket and bra tensors share the
-% ancillary index (straight contraction on the right) and retain their physical
-% and virtual legs.
-\TNDeclareDiagram
-    {TNMPOLocalPurification}
-    {}
-    {display}
-    {compact}
-    {\TNMPOLocalPurification}
-    {chapter/ch20_mpdo_foundations.tex}{%
-    \begin{TNEquationRow}[compact]
-        \TNTerm{%
-            \TNMPOSite{purM}{at=origin}{M}
-            \TNOpenVirtualWest{purMWest}
-            \TNOpenVirtualEast{purMEast}
-            \TNOpenPhysicalNorth{purMKet}
-            \TNOpenPhysicalSouth{purMBra}}
-        \TNRelation{=}
-        \TNTerm{%
-            \TNMPDOPurificationMotif{pur}{at=origin}
-            \TNOpenVirtualWest{purKetWest}
-            \TNOpenVirtualEast{purKetEast}
-            \TNOpenVirtualWest{purBraWest}
-            \TNOpenVirtualEast{purBraEast}
-            \TNOpenPhysicalNorth{purKet}
-            \TNOpenPhysicalSouth{purBra}
-            \TNLabelRight{purAncillaMid}{k}}
-    \end{TNEquationRow}%
-}
-
 % The physical renormalization maps of the mixed-state RFP definition.
 \TNDeclareDiagram
     {TNMPORenormalizationTS}


### PR DESCRIPTION
Closes LionSR/tenkz#46.

## What changed

- replace the single `\TNMPOLocalPurification` catalogue call with an inline native tenkz identity;
- state the coefficient formula and complete ink-to-index correspondence in source comments;
- delete only the now-unused catalogue declaration, retaining the legacy primitive and straight-purification reference fixture.

The right-hand side uses the bond identification (e), its inverse, and one inter-row pairleg for the ancillary index (k). Both sides have boundary signature `(1,1,1,1)`; in particular, there is no east cup because the east virtual index remains free.

## Validation

- focused standalone compile, event audit, and 600 dpi visual comparison with the paper and legacy topology reference;
- focused Chapter 20 print compile, event audit, and rendered-page inspection;
- all 19 `tex/tenkz/examples/*.tex` compile and audit without hard errors;
- `docs/tenkz/manual2.tex` compiles twice and audits without hard errors;
- `scripts/check_tn_references.py --margins-only`;
- `scripts/test_tenkz_face_ports.py`;
- `scripts/test_tenkz_index_routing.py`;
- `scripts/test_tenkz_pic.py`;
- `scripts/test_tenkz_tree.py`;
- `blueprint/src/Packages/tn_diagrams.py --check --check-peps-usage --check-slides --audit --audit-strict --smoke-render`;
- 114-file tenkz lint and `git diff --check`.

The local `dvisvgm` build lacks the PostScript special handler and drops TikZ paths for every legacy SVG reference, so the pixel-comparison mode of `check_tn_references.py` is not meaningful on this host. The unchanged references pass the margin gate; the PDF renders retain all ink. CI remains the authoritative pixel-reference check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-source only; no runtime or proof logic changes.
> 
> **Overview**
> Chapter 20’s **LPDO local purification** identity is no longer pulled from the tensor-network catalogue: the `\TNMPOLocalPurification` call is replaced by an **inline `tenkz` equation** in the LPDO definition, matching the rest of the chapter’s migrated MPO figures.
> 
> The new diagram spells out **bond identification** (`e`, `e^{-1}`) and a **two-row Kraus pair** with the ancillary index carried on the inter-row pairleg; source comments document the **coefficient formula** and **(1,1,1,1) boundary signature** (no east cup because β stays free). The **`\TNMPOLocalPurification` catalogue entry** is removed from `tn_catalogue.tex` as unused; legacy primitives/fixtures called out in the PR description are left in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f7566d710936ccfa44d4f8fae45486f544c8434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->