### PR TITLE
docs: migrate MPDO renormalization map to tenkz

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -718,8 +718,49 @@ the remaining sites unchanged.
     transfer map for general mixed states. Its source zero-correlation-length
     consequence concerns the physical-trace transfer and is proved below.
     This is \cite[Definition~4.1, line~657]{Cirac2016MPDO_arXiv}.
-    The two maps act as follows on every virtual closure $X$:
-    \TNMPORenormalizationTS
+    On the open coefficient tensors the two maps have types:
+    % Formula: for every pair of virtual indices \alpha,\beta, set
+    % (M_{\alpha\beta})_{ij}=M^{ij}_{\alpha\beta} and
+    % ((MM)_{\alpha\beta})_{(i_1,i_2),(j_1,j_2)}
+    % =\sum_\gamma M^{i_1j_1}_{\alpha\gamma}
+    % M^{i_2j_2}_{\gamma\beta}.  The pictured identities are
+    % \mathcal T(M_{\alpha\beta})=(MM)_{\alpha\beta} and
+    % \mathcal S((MM)_{\alpha\beta})=M_{\alpha\beta} for every \alpha,\beta.
+    % Here i,j,\alpha,\beta are free on M_{\alpha\beta}, giving signature
+    % (1,1,1,1).  On (MM)_{\alpha\beta}, i_1,i_2,j_1,j_2,\alpha,\beta are
+    % free and \gamma is contracted between the two copies of M, giving
+    % signature (1,1,2,2).
+    % Contracting \alpha,\beta against X gives
+    % M_1(X)_{ij}=\tr(M^{ij}X) and
+    % M_2(X)_{(i_1,i_2),(j_1,j_2)}
+    % =\tr(M^{i_1j_1}M^{i_2j_2}X), hence
+    % \mathcal T[M_1(X)]=M_2(X) and \mathcal S[M_2(X)]=M_1(X) for every X.
+    % Their X-closed signatures are (0,0,1,1) and (0,0,2,2), respectively.
+    % Conversely, nondegeneracy of the trace pairing recovers the pictured
+    % open coefficient identities from the X-closed identities.
+    % Ink: each square M carries one west and one east virtual index and one
+    % north and one south physical index; the bond in each two-site object is
+    % the contracted virtual index \gamma.  Each blue stroke is a typed map
+    % between the complete objects at its endpoints, never a tensor contraction.
+    \par\noindent\hfil
+    \begin{tenkzcd}[maps, species={channel},
+        column sep=10mm, row sep=8mm]
+      \tnpic[inline, physical=updown]{
+        \tn[mpo]{M}
+      } &
+      \tnpic[inline, physical=updown]{
+        \tn[mpo]{M} & \tn[mpo]{M}
+      } \\
+      \tnpic[inline, physical=updown]{
+        \tn[mpo]{M} & \tn[mpo]{M}
+      } &
+      \tnpic[inline, physical=updown]{
+        \tn[mpo]{M}
+      }
+      \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\mathcal T}
+      \tnarrow[from={(2,1)}, to={(2,2)}, species=channel]{\mathcal S}
+    \end{tenkzcd}
+    \hfil\par
 \end{definition}
 
 \begin{definition}[Initial-coordinate regroupings]

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -133,37 +133,6 @@
     \end{TNDiagram}%
 }
 
-% The physical renormalization maps of the mixed-state RFP definition.
-\TNDeclareDiagram
-    {TNMPORenormalizationTS}
-    {}
-    {display}
-    {compact}
-    {\TNMPORenormalizationTS}
-    {chapter/ch21_mpdo_rfp_renormalization.tex}{%
-    \begin{TNEquationRow}[compact]
-        \ensuremath{M_1(X)=}
-        \TNTerm{%
-            \TNMPOSite{rtsOne}{at=origin}{M}
-            \TNOpenVirtualWest{rtsOneWest}
-            \TNOpenVirtualEast{rtsOneEast}
-            \TNOpenPhysicalNorth{rtsOneKet}
-            \TNOpenPhysicalSouth{rtsOneBra}}
-        \TNRelation{\xrightleftharpoons[\mathcal S]{\mathcal T}}
-        \TNTerm{%
-            \TNMPOSite{rtsLeft}{at=origin}{M}
-            \TNMPOSite{rtsRight}{right=of rtsLeft}{M}
-            \TNOpenVirtualWest{rtsLeftWest}
-            \TNConnectVirtual{rtsLeftEast}{rtsRightWest}
-            \TNOpenVirtualEast{rtsRightEast}
-            \TNOpenPhysicalNorth{rtsLeftKet}
-            \TNOpenPhysicalSouth{rtsLeftBra}
-            \TNOpenPhysicalNorth{rtsRightKet}
-            \TNOpenPhysicalSouth{rtsRightBra}}
-        \ensuremath{=M_2(X)}
-    \end{TNEquationRow}%
-}
-
 % The overlapping applications of T and S used after two-site blocking in
 % Theorem 4.9.  The endpoint frames identify one and two blocked sites; the
 % intermediate rows retain the original physical-site decomposition.


### PR DESCRIPTION
Closes LionSR/tenkz#47

Summary:
- replace the single-use legacy diagram call with two inline typed-map rows
- state the open coefficient identities and their trace-pairing relation to the X-closed operators in source comments
- remove the now-unused catalogue declaration

Validation:
- focused standalone compile and tenkz audit: four object signatures and two channel-map events verified
- Chapter 21 renormalization fragment compiled twice and audited with no hard errors or advisories
- 114-file tenkz lint passed
- git diff check and repository forbidden scans passed
- rendered figure inspected against the three cited paper images

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram tooling only; no Lean or runtime logic changes.
> 
> **Overview**
> **Definition 4.1** (`def:is_rfp_via_ts`) no longer pulls in the legacy catalogue macro `\TNMPORenormalizationTS`. It now uses an inline **`tenkzcd`** figure with **`species=channel`**: one-site vs two-site MPO objects on the top and bottom rows, with **`\mathcal T`** and **`\mathcal S`** as typed horizontal maps (not contractions).
> 
> Source comments document the **open coefficient** identities on \(M_{\alpha\beta}\) and \((MM)_{\alpha\beta}\), their **index signatures**, and how contracting virtual indices with \(X\) recovers the **\(M_1(X)\)/\(M_2(X)\)** operator form (and the converse via trace nondegeneracy).
> 
> **`tex/tn/tn_catalogue.tex`** drops the unused **`TNMPORenormalizationTS`** `\TNDeclareDiagram` block (~31 lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce5fe431053805ac23993feeae789b8f3aba5d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->