### PR TITLE
docs: migrate Hayashi sector tensor to tenkz

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex
@@ -1422,13 +1422,39 @@ This is the single-block identity in
     hypothesis is used in this comparison.
 \end{theorem}
 
-The same comparison may be read directly as the following compact identity:
-\begin{center}
-    \TNMPDOHayashiSectorComparison
-\end{center}
-Here the closing entry $R_{\beta_3,\alpha_1}$ multiplies the physical slice
-in the basis adapted to sector $k$; compare
-\cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.
+For fixed $k,\alpha_1,\beta_3$, the identity reads coefficientwise as follows.
+% Formula:
+% R_{\beta_3,\alpha_1}
+% \widetilde\kappa^{(k)}_{\beta_1,\alpha_3}((l,r),(l',r'))
+% = p_k A^{(k)}_{\alpha_1,\beta_1}(l,l')
+% B^{(k)}_{\alpha_3,\beta_3}(r,r').
+% The displayed tensor has free indices beta_1 west, alpha_3 east, (l,r)
+% north, and (l',r') south.  None is contracted, so its boundary signature is
+% (1,1,1,1).  Its square is the coefficient tensor
+% \widetilde\kappa^{(k)}; the four incident strokes carry precisely those four
+% free indices.  The fixed k, alpha_1, and beta_3 select the sector and scalar
+% coefficients.  R, A, and B remain scalar factors under ordinary
+% multiplication; they are not tensor nodes.
+% Source comparison: Papers/1606.00608/MPDO_kappaab.png, from lines 1415--1438
+% of MPDO-22-12-17-2.tex, fixes the one-tensor four-leg topology.  The
+% normalized formula is Theorem thm:mpdo_inverse_map_hayashi_sector_comparison.
+\[
+R_{\beta_3,\alpha_1}\,
+\tnpic[
+    physical=updown,
+    west label=$\beta_1$,
+    east label=$\alpha_3$
+]{
+    \tn[
+        mpo,
+        up={$(l,r)$},
+        down={$(l',r')$}
+    ]{\widetilde\kappa^{(k)}}
+}
+=
+p_k\,A^{(k)}_{\alpha_1,\beta_1}(l,l')\,
+B^{(k)}_{\alpha_3,\beta_3}(r,r').
+\]
 
 \begin{proof}
     \leanok

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -173,39 +173,6 @@
     \end{TNEquationRow}%
 }
 
-% Sectorwise comparison between the inverse-map contraction and the Hayashi
-% product in the basis adapted to the middle-site direct sum.
-\TNDeclareDiagram
-    {TNMPDOHayashiSectorComparison}
-    {}
-    {display}
-    {compact}
-    {\TNMPDOHayashiSectorComparison}
-    {chapter/ch21_mpdo_rfp_simple_local_markov_factorization.tex}{%
-    \begin{TNEquationRow}[compact]
-        \ensuremath{R_{\beta_3,\alpha_1}\,\cdot\,}
-        \TNTerm{%
-            \TNMPOSite{hscK}{at=origin}{\widetilde\kappa^{(k)}}
-            \TNOpenVirtualWest{hscKWest}
-            \TNOpenVirtualEast{hscKEast}
-            \TNOpenPhysicalNorth{hscKKet}
-            \TNOpenPhysicalSouth{hscKBra}
-            \TNLabelLeft{hscKWestOpen}{\beta_1}
-            \TNLabelRight{hscKEastOpen}{\alpha_3}
-            \TNLabelAbove{hscKKetOpen}{k;l,r}
-            \TNLabelBelow{hscKBraOpen}{k;l',r'}}
-        \TNRelation{=}
-        \ensuremath{p_k}
-        \TNTerm{%
-            \TNFactor{hscA}{at=origin}{A^{(k)}_{\alpha_1,\beta_1}}
-            \TNLabelAbove{hscA}{l,l'}}
-        \TNRelation{\otimes}
-        \TNTerm{%
-            \TNFactor{hscB}{at=origin}{B^{(k)}_{\alpha_3,\beta_3}}
-            \TNLabelAbove{hscB}{r,r'}}
-    \end{TNEquationRow}%
-}
-
 % Coefficient form of a basis of normal tensors: the gauge X, one basis
 % tensor with its physical leg, and X^{-1} on the virtual chain, threaded by
 % the block-index lines j and q; the coefficient tensor mu hangs on the two


### PR DESCRIPTION
Closes LionSR/tenkz#48.

## What changed

- replace the sole `\TNMPDOHayashiSectorComparison` call with one inline native tenkz tensor;
- keep the normalized coefficient identity and complete ink-to-index correspondence in adjacent source comments;
- render (R), (A), and (B) as scalar coefficient factors under ordinary multiplication;
- delete only the now-unused catalogue declaration.

The diagram has one four-legged `\widetilde\kappa^{(k)}` tensor, boundary signature `(1,1,1,1)`, and no contractions or fabricated coefficient nodes.

## Validation

- focused compile, event audit, and 600 dpi comparison with `MPDO_kappaab.png`;
- actual Chapter 21 context compile, audit, and rendered-page inspection;
- all 19 tenkz examples compile and audit without hard errors;
- manual compiles twice and audits without hard errors;
- all four tenkz Python test scripts;
- strict `tn_diagrams.py` check/audit/slide/smoke-render gate (62 diagrams);
- 114-file tenkz lint;
- reference margin/topology check;
- `git diff --check` and required repository scans.

The local `dvisvgm` build lacks the PostScript special handler and drops TikZ paths for all unchanged legacy SVG references, so the pixel-comparison mode is not meaningful on this host. The PDF renders retain all ink, no reference files changed, and CI remains the authoritative pixel-reference check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only tensor diagram migration with no logic, API, or data-path changes; risk is limited to LaTeX/tenkz rendering consistency.
> 
> **Overview**
> **Hayashi sector comparison** is now drawn with **native tenkz** in `ch21_mpdo_rfp_simple_local_markov_factorization.tex` instead of the shared `\TNMPDOHayashiSectorComparison` catalogue diagram.
> 
> The displayed identity is unchanged: \(R_{\beta_3,\alpha_1}\) times a four-legged \(\widetilde\kappa^{(k)}\) MPO tensor equals \(p_k A^{(k)}_{\alpha_1,\beta_1}(l,l')\,B^{(k)}_{\alpha_3,\beta_3}(r,r')\). The new `\tnpic` block labels virtual west/east and physical up/down legs; **\(R\), \(A\), and \(B\)** stay ordinary scalar factors in the math, not extra tensor nodes. Adjacent comments document boundary signature `(1,1,1,1)` and the `MPDO_kappaab.png` reference topology.
> 
> The **`TNMPDOHayashiSectorComparison` declaration** is removed from `tex/tn/tn_catalogue.tex` because nothing calls it after the migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b8f95dc04309ded9a0055dd0f22568dac7984b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->