### PR TITLE
feat(Channel/Schwarz): prove positive-definite Weyl recovery

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -156,6 +156,7 @@ import TNLean.Analysis.OperatorConvexity
 -- Layer 2b: Operator (Loewner) convexity of `a ↦ a^p` for `p ∈ [1,2]` (proved)
 import TNLean.Analysis.RpowConvexity
 import TNLean.Analysis.RelativeEntropyResolventIntegral
+import TNLean.Analysis.ResolventFunctionalCalculus
 -- Layer 2b: Quantum channels (general theory)
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -9,11 +9,9 @@ Authors: TNLean contributors
 
 Stable import surface for the maintained TNLean library.
 
-This file imports the modules intended for downstream users. Most
-specialized helper modules are still omitted from the root import list, but the
-public chapter-index modules and the chapter-facing semigroup modules are
-included so that blueprint links and the generated documentation can see
-them.
+This file imports the modules intended for downstream users. Most specialized helper modules
+are omitted from the root import list, but public chapter-index and chapter-facing semigroup
+modules are included so that blueprint links and the generated documentation can see them.
 
 The following archival modules are intentionally excluded
 (they live in `TNLean/Archive/`):

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.TraceCFC
+import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.SpecialFunctions.Sqrt
 
@@ -20,13 +21,32 @@ operator theory development.
   root of a positive-semidefinite matrix is Hermitian.
 * `Matrix.PosSemidef.cfc_sqrt_mul_self`: the square of that square root is the
   original matrix.
+* `Matrix.PosSemidef.sqrt_smul`: the positive square root commutes with
+  nonnegative real scaling.
 * `Matrix.PosSemidef.blockDiagonal'`: a finite dependent block diagonal of
   positive-semidefinite matrices is positive semidefinite.
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix ComplexOrder MatrixOrder
 
 namespace Matrix
+
+open scoped Classical in
+/-- The positive square root commutes with multiplication by a nonnegative
+real scalar. -/
+theorem PosSemidef.sqrt_smul
+    {n : Type*} [Fintype n]
+    {A : Matrix n n ℂ} (hA : A.PosSemidef) {c : ℝ} (hc : 0 ≤ c) :
+    CFC.sqrt (c • A) = Real.sqrt c • CFC.sqrt A := by
+  have hscaled : (c • A).PosSemidef := hA.smul hc
+  have hsqrt : (CFC.sqrt A).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)
+  have hcand : (Real.sqrt c • CFC.sqrt A).PosSemidef :=
+    hsqrt.smul (Real.sqrt_nonneg c)
+  apply (CFC.sqrt_eq_iff (c • A) (Real.sqrt c • CFC.sqrt A)
+    hscaled.nonneg hcand.nonneg).2
+  rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+    CFC.sqrt_mul_sqrt_self A hA.nonneg, Real.mul_self_sqrt hc]
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -11,9 +11,9 @@ import Mathlib.Analysis.SpecialFunctions.Sqrt
 /-!
 # Positive-semidefinite matrix square roots
 
-This file records the two elementary Hermitian functional-calculus facts about
-the positive-semidefinite square root used throughout the finite-dimensional
-operator theory development.
+This file records elementary facts about positive-semidefinite square roots
+and block-diagonal matrices used throughout the finite-dimensional operator
+theory development.
 
 ## Main results
 

--- a/TNLean/Analysis/ResolventFunctionalCalculus.lean
+++ b/TNLean/Analysis/ResolventFunctionalCalculus.lean
@@ -13,11 +13,15 @@ import Mathlib.LinearAlgebra.Matrix.Vec
 This file records the finite-dimensional passage from equality of resolvents on
 a fixed vector to equality of the positive square roots on that vector.
 
-## Main result
+## Main results
 
 * `Matrix.sqrt_mulVec_eq_of_resolvent_mulVec_eq` shows that if two positive
   semidefinite matrices have the same shifted inverse on a vector for every
   positive shift, then their positive square roots agree on that vector.
+* `Matrix.sourceB_resolvent_eq_relativeModular` factors the source-`B`
+  left--right resolvent through the relative modular Kronecker matrix.
+* `Matrix.relativeModular_sqrt_mulVec_vec_one` evaluates its positive square
+  root on the vectorized identity.
 
 ## References
 

--- a/TNLean/Analysis/ResolventFunctionalCalculus.lean
+++ b/TNLean/Analysis/ResolventFunctionalCalculus.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Analysis.Matrix.Order
+import TNLean.Analysis.MatrixSqrt
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
 import Mathlib.LinearAlgebra.Matrix.Vec
 
@@ -34,23 +34,6 @@ namespace Matrix
 attribute [local instance] Matrix.instL2OpNormedAddCommGroup
 attribute [local instance] Matrix.instL2OpNormedRing
 attribute [local instance] Matrix.instL2OpNormedAlgebra
-
-open scoped Classical in
-/-- The positive square root commutes with multiplication by a nonnegative
-real scalar. -/
-theorem PosSemidef.sqrt_smul
-    {n : Type*} [Fintype n]
-    {A : Matrix n n ℂ} (hA : A.PosSemidef) {c : ℝ} (hc : 0 ≤ c) :
-    CFC.sqrt (c • A) = Real.sqrt c • CFC.sqrt A := by
-  have hscaled : (c • A).PosSemidef := hA.smul hc
-  have hsqrt : (CFC.sqrt A).PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)
-  have hcand : (Real.sqrt c • CFC.sqrt A).PosSemidef :=
-    hsqrt.smul (Real.sqrt_nonneg c)
-  apply (CFC.sqrt_eq_iff (c • A) (Real.sqrt c • CFC.sqrt A)
-    hscaled.nonneg hcand.nonneg).2
-  rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
-    CFC.sqrt_mul_sqrt_self A hA.nonneg, Real.mul_self_sqrt hc]
 
 /-- Resolvent form of the Löwner real-power integrand. -/
 private lemma cfc_rpowIntegrand₀₁_eq_resolvent

--- a/TNLean/Analysis/ResolventFunctionalCalculus.lean
+++ b/TNLean/Analysis/ResolventFunctionalCalculus.lean
@@ -52,8 +52,6 @@ private lemma cfc_rpowIntegrand₀₁_eq_resolvent
     rw [Real.rpowIntegrand₀₁_eq_sub (by grind) ht]
     have hg : ContinuousOn (fun z : ℝ ↦ (t + z)⁻¹) (spectrum ℝ X) := by
       fun_prop (disch := grind -abstractProof)
-    have hf : ContinuousOn (fun z : ℝ ↦ 1 + z) (spectrum ℝ X) := by
-      fun_prop
     have hspectrum : ∀ r ∈ spectrum ℝ X, t + r ≠ 0 := by
       grind
     have hcfc := cfc_sub (fun _ : ℝ ↦ t ^ (p - 1))
@@ -115,12 +113,6 @@ theorem sqrt_mulVec_eq_of_resolvent_mulVec_eq
       { toFun := fun M ↦ M *ᵥ x
         map_add' := fun M N ↦ add_mulVec M N x
         map_smul' := fun c M ↦ smul_mulVec c M x }
-  have hSmulInt : IntegrableOn
-      (fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x) (Ioi 0) μ := by
-    exact L.integrable_comp hSint
-  have hTmulInt : IntegrableOn
-      (fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x) (Ioi 0) μ := by
-    exact L.integrable_comp hTint
   rw [CFC.sqrt_eq_nnrpow, CFC.sqrt_eq_nnrpow,
     show (1 / 2 : NNReal) = p by rfl,
     (hμ S hS.nonneg).2, (hμ T hT.nonneg).2]

--- a/TNLean/Analysis/ResolventFunctionalCalculus.lean
+++ b/TNLean/Analysis/ResolventFunctionalCalculus.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
+import Mathlib.LinearAlgebra.Matrix.Vec
+
+/-!
+# Functional calculus from common resolvent vectors
+
+This file records the finite-dimensional passage from equality of resolvents on
+a fixed vector to equality of the positive square roots on that vector.
+
+## Main result
+
+* `Matrix.sqrt_mulVec_eq_of_resolvent_mulVec_eq` shows that if two positive
+  semidefinite matrices have the same shifted inverse on a vector for every
+  positive shift, then their positive square roots agree on that vector.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
+  Entropy and Related Trace Functions, with Conditions for Equality*,
+  arXiv:0903.2895v4, lines 658–680.
+-/
+
+open Filter MeasureTheory Set
+open scoped Matrix ComplexOrder Kronecker MatrixOrder Matrix.Norms.L2Operator
+
+namespace Matrix
+
+attribute [local instance] Matrix.instL2OpNormedAddCommGroup
+attribute [local instance] Matrix.instL2OpNormedRing
+attribute [local instance] Matrix.instL2OpNormedAlgebra
+
+open scoped Classical in
+/-- The positive square root commutes with multiplication by a nonnegative
+real scalar. -/
+theorem PosSemidef.sqrt_smul
+    {n : Type*} [Fintype n]
+    {A : Matrix n n ℂ} (hA : A.PosSemidef) {c : ℝ} (hc : 0 ≤ c) :
+    CFC.sqrt (c • A) = Real.sqrt c • CFC.sqrt A := by
+  have hscaled : (c • A).PosSemidef := hA.smul hc
+  have hsqrt : (CFC.sqrt A).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)
+  have hcand : (Real.sqrt c • CFC.sqrt A).PosSemidef :=
+    hsqrt.smul (Real.sqrt_nonneg c)
+  apply (CFC.sqrt_eq_iff (c • A) (Real.sqrt c • CFC.sqrt A)
+    hscaled.nonneg hcand.nonneg).2
+  rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+    CFC.sqrt_mul_sqrt_self A hA.nonneg, Real.mul_self_sqrt hc]
+
+/-- Resolvent form of the Löwner real-power integrand. -/
+private lemma cfc_rpowIntegrand₀₁_eq_resolvent
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A : Matrix n n ℂ} (hA : A.PosSemidef) {p t : ℝ}
+    (hp : p ∈ Ioo (0 : ℝ) 1) (ht : 0 < t) :
+    cfc (Real.rpowIntegrand₀₁ p t) A =
+      t ^ (p - 1) • (1 : Matrix n n ℂ) -
+        t ^ p • (t • (1 : Matrix n n ℂ) + A)⁻¹ := by
+  have hEq : ({A | (0 : Matrix n n ℂ) ≤ A}.EqOn
+      (cfc (Real.rpowIntegrand₀₁ p t))
+      (fun X : Matrix n n ℂ ↦
+        algebraMap ℝ (Matrix n n ℂ) (t ^ (p - 1)) -
+          t ^ p • Ring.inverse (algebraMap ℝ (Matrix n n ℂ) t + X))) := by
+    intro X hX
+    rw [Real.rpowIntegrand₀₁_eq_sub (by grind) ht]
+    have hg : ContinuousOn (fun z : ℝ ↦ (t + z)⁻¹) (spectrum ℝ X) := by
+      fun_prop (disch := grind -abstractProof)
+    have hf : ContinuousOn (fun z : ℝ ↦ 1 + z) (spectrum ℝ X) := by
+      fun_prop
+    have hspectrum : ∀ r ∈ spectrum ℝ X, t + r ≠ 0 := by
+      grind
+    have hcfc := cfc_sub (fun _ : ℝ ↦ t ^ (p - 1))
+      (fun z : ℝ ↦ t ^ p * (t + z)⁻¹) X
+    rw [hcfc, cfc_const .., cfc_const_mul .., cfc_inv _ _ hspectrum ..,
+      cfc_const_add .., cfc_id' ..]
+  have hA_nonneg : (0 : Matrix n n ℂ) ≤ A :=
+    Matrix.nonneg_iff_posSemidef.mpr hA
+  have hcalc := hEq hA_nonneg
+  simpa [Algebra.algebraMap_eq_smul_one, ← Matrix.nonsing_inv_eq_ringInverse] using hcalc
+
+/-- Equality of all positive shifted resolvents on a fixed vector implies
+equality of the positive square roots on that vector.
+
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 658–680, obtains the corresponding
+functional-calculus conclusion from analytic continuation and the Cauchy
+integral formula. Here the same positive-square-root specialization is proved
+with the Löwner integral representation of the real power `p = 1 / 2`. -/
+theorem sqrt_mulVec_eq_of_resolvent_mulVec_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {S T : Matrix n n ℂ} (hS : S.PosSemidef) (hT : T.PosSemidef)
+    {x : n → ℂ}
+    (hres : ∀ {t : ℝ}, 0 < t →
+      (t • (1 : Matrix n n ℂ) + S)⁻¹ *ᵥ x =
+        (t • (1 : Matrix n n ℂ) + T)⁻¹ *ᵥ x) :
+    CFC.sqrt S *ᵥ x = CFC.sqrt T *ᵥ x := by
+  let p : NNReal := 1 / 2
+  have hp : (p : ℝ) ∈ Ioo 0 1 := by
+    norm_num [p]
+  obtain ⟨μ, hμ⟩ :=
+    CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁
+      (Matrix n n ℂ) hp
+  have hSint := (hμ S hS.nonneg).1
+  have hTint := (hμ T hT.nonneg).1
+  have hintegrand : ∀ {t : ℝ}, 0 < t →
+      cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x =
+        cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x := by
+    intro t ht
+    have hSnonneg : (0 : Matrix n n ℂ) ≤ S := hS.nonneg
+    have hTnonneg : (0 : Matrix n n ℂ) ≤ T := hT.nonneg
+    have hcontS : ContinuousOn (Real.rpowIntegrand₀₁ (p : ℝ) t)
+        (quasispectrum ℝ S) :=
+      (Real.continuousOn_rpowIntegrand₀₁_Ici hp ht).mono (by grind)
+    have hcontT : ContinuousOn (Real.rpowIntegrand₀₁ (p : ℝ) t)
+        (quasispectrum ℝ T) :=
+      (Real.continuousOn_rpowIntegrand₀₁_Ici hp ht).mono (by grind)
+    rw [cfcₙ_eq_cfc hcontS, cfcₙ_eq_cfc hcontT,
+      cfc_rpowIntegrand₀₁_eq_resolvent hS hp ht,
+      cfc_rpowIntegrand₀₁_eq_resolvent hT hp ht]
+    simp only [sub_mulVec, smul_mulVec, one_mulVec]
+    rw [hres ht]
+  have hAE :
+      (fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x) =ᵐ[μ.restrict (Ioi 0)]
+        fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x := by
+    filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+    exact hintegrand ht
+  let L : Matrix n n ℂ →L[ℂ] (n → ℂ) :=
+    LinearMap.toContinuousLinearMap
+      { toFun := fun M ↦ M *ᵥ x
+        map_add' := fun M N ↦ add_mulVec M N x
+        map_smul' := fun c M ↦ smul_mulVec c M x }
+  have hSmulInt : IntegrableOn
+      (fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x) (Ioi 0) μ := by
+    exact L.integrable_comp hSint
+  have hTmulInt : IntegrableOn
+      (fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x) (Ioi 0) μ := by
+    exact L.integrable_comp hTint
+  rw [CFC.sqrt_eq_nnrpow, CFC.sqrt_eq_nnrpow,
+    show (1 / 2 : NNReal) = p by rfl,
+    (hμ S hS.nonneg).2, (hμ T hT.nonneg).2]
+  change L (∫ t in Ioi 0, cfcₙ (Real.rpowIntegrand₀₁ p t) S ∂μ) =
+    L (∫ t in Ioi 0, cfcₙ (Real.rpowIntegrand₀₁ p t) T ∂μ)
+  rw [← L.integral_comp_comm hSint, ← L.integral_comp_comm hTint]
+  exact integral_congr_ae hAE
+
+/-- The source-`B` left-right resolvent is the shifted resolvent of the
+relative modular Kronecker matrix on the vectorized identity.
+
+This is the finite-dimensional factorization in Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 661–670. -/
+theorem sourceB_resolvent_eq_relativeModular
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef)
+    {t : ℝ} (ht : 0 < t) :
+    (A ⊗ₖ (1 : Matrix n n ℂ) +
+        t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ))⁻¹ *ᵥ Matrix.vec Bᵀ =
+      (t • (1 : Matrix (n × n) (n × n) ℂ) +
+        A ⊗ₖ (B⁻¹)ᵀ)⁻¹ *ᵥ
+          Matrix.vec (1 : Matrix n n ℂ)ᵀ := by
+  let cMat : Matrix (n × n) (n × n) ℂ :=
+    (1 : Matrix n n ℂ) ⊗ₖ Bᵀ
+  let delta : Matrix (n × n) (n × n) ℂ := A ⊗ₖ (B⁻¹)ᵀ
+  let res : Matrix (n × n) (n × n) ℂ := t • 1 + delta
+  have hC : cMat.PosDef := by
+    exact Matrix.PosDef.one.kronecker hB.transpose
+  have hΔ : delta.PosDef := by
+    exact hA.kronecker hB.inv.transpose
+  have hR : res.PosDef := by
+    exact (Matrix.PosDef.one.smul ht).add hΔ
+  letI : Invertible B := hB.isUnit.invertible
+  letI : Invertible cMat := hC.isUnit.invertible
+  letI : Invertible res := hR.isUnit.invertible
+  have hBT : Bᵀ * (B⁻¹)ᵀ = (1 : Matrix n n ℂ) := by
+    rw [← Matrix.transpose_mul, inv_mul_of_invertible, Matrix.transpose_one]
+  have hCΔ : cMat * delta = A ⊗ₖ (1 : Matrix n n ℂ) := by
+    dsimp only [cMat, delta]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, hBT]
+  have hfactor : cMat * res =
+      A ⊗ₖ (1 : Matrix n n ℂ) +
+        t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ) := by
+    dsimp only [res]
+    rw [Matrix.mul_add, Matrix.mul_smul, Matrix.mul_one, hCΔ]
+    dsimp only [cMat]
+    abel
+  have hb : cMat *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ = Matrix.vec Bᵀ := by
+    dsimp only [cMat]
+    rw [Matrix.kronecker_mulVec_vec]
+    simp
+  rw [← hfactor, ← hb, Matrix.mul_inv_rev, mulVec_mulVec,
+    Matrix.mul_assoc, inv_mul_of_invertible, Matrix.mul_one]
+
+/-- The positive square root of the relative modular Kronecker matrix, applied
+to the vectorized identity, is the vectorization of the square-root ratio.
+
+This is the positive-definite square-root specialization of the functional
+calculus conclusion in Jenčová--Ruskai, arXiv:0903.2895v4, lines 675–680. -/
+theorem relativeModular_sqrt_mulVec_vec_one
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef) :
+    CFC.sqrt (A ⊗ₖ (B⁻¹)ᵀ) *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ =
+      Matrix.vec (CFC.sqrt A * (CFC.sqrt B)⁻¹)ᵀ := by
+  let qA : Matrix n n ℂ := CFC.sqrt A
+  let qB : Matrix n n ℂ := CFC.sqrt B
+  let delta : Matrix (n × n) (n × n) ℂ := A ⊗ₖ (B⁻¹)ᵀ
+  let qDelta : Matrix (n × n) (n × n) ℂ := qA ⊗ₖ (qB⁻¹)ᵀ
+  have hqA : qA.PosSemidef := by
+    exact Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)
+  have hqB : qB.PosSemidef := by
+    exact Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg B)
+  have hdelta : delta.PosDef := hA.kronecker hB.inv.transpose
+  have hqDelta : qDelta.PosSemidef :=
+    hqA.kronecker hqB.inv.transpose
+  have hqA_sq : qA * qA = A := by
+    simpa only [qA] using CFC.sqrt_mul_sqrt_self A hA.posSemidef.nonneg
+  have hqB_sq : qB * qB = B := by
+    simpa only [qB] using CFC.sqrt_mul_sqrt_self B hB.posSemidef.nonneg
+  have hqBunit : IsUnit qB := by
+    apply (CFC.isUnit_sqrt_iff B hB.posSemidef.nonneg).2
+    exact hB.isUnit
+  letI : Invertible qB := hqBunit.invertible
+  have hqB_inv_sq : qB⁻¹ * qB⁻¹ = B⁻¹ := by
+    rw [← Matrix.mul_inv_rev, hqB_sq]
+  have hqDelta_sq : qDelta * qDelta = delta := by
+    dsimp only [qDelta, delta]
+    rw [← Matrix.mul_kronecker_mul, hqA_sq, ← Matrix.transpose_mul,
+      hqB_inv_sq]
+  have hsqrt : CFC.sqrt delta = qDelta := by
+    apply (CFC.sqrt_eq_iff delta qDelta hdelta.posSemidef.nonneg
+      hqDelta.nonneg).2
+    exact hqDelta_sq
+  change CFC.sqrt delta *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ =
+    Matrix.vec (qA * qB⁻¹)ᵀ
+  rw [hsqrt]
+  dsimp only [qDelta]
+  rw [Matrix.kronecker_mulVec_vec]
+  simp only [Matrix.transpose_one, Matrix.mul_one, Matrix.transpose_mul]
+
+end Matrix

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -21,6 +21,8 @@ reference matrix.
 ## Main declarations
 
 * `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
+* `Matrix.PosDef.supportInvSqrt_eq_inv_sqrt`: the support inverse square root
+  of a positive-definite matrix is its ordinary inverse square root.
 * `Matrix.PosSemidef.supportInvSqrt_smul`: scaling by a positive real scalar.
 * `Matrix.PosSemidef.supportInvSqrt_kronecker_one`: compatibility with the
   unital left tensor embedding.

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -52,7 +52,7 @@ reference matrix.
   relative-entropy monotonicity equation.
 -/
 
-open scoped Matrix BigOperators ComplexOrder Kronecker
+open scoped Matrix BigOperators ComplexOrder MatrixOrder Kronecker
 
 namespace Matrix
 
@@ -75,6 +75,33 @@ theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
   rw [PosSemidef.supportInvSqrt, ← hρ.isHermitian.cfc_eq]
   exact Matrix.isHermitian_iff_isSelfAdjoint.mpr
     (cfc_predicate (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ)
+
+/-- On a positive-definite matrix, the support inverse square root is the
+ordinary inverse of the positive square root.
+
+This is the invertible specialization of the support inverse in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8). -/
+theorem PosDef.supportInvSqrt_eq_inv_sqrt {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosDef) :
+    hρ.posSemidef.supportInvSqrt = (CFC.sqrt ρ)⁻¹ := by
+  unfold PosSemidef.supportInvSqrt
+  rw [← hρ.isHermitian.cfc_eq]
+  have hspectrum : ∀ x ∈ spectrum ℝ ρ, Real.sqrt x ≠ 0 := by
+    intro x hx
+    rw [hρ.isHermitian.spectrum_real_eq_range_eigenvalues] at hx
+    obtain ⟨i, rfl⟩ := hx
+    exact Real.sqrt_ne_zero'.mpr (hρ.eigenvalues_pos i)
+  rw [CFC.sqrt_eq_real_sqrt ρ hρ.posSemidef.nonneg, cfcₙ_eq_cfc,
+    Matrix.nonsing_inv_eq_ringInverse,
+    ← cfc_inv _ _ hspectrum]
+  apply cfc_congr
+  intro x hx
+  dsimp only
+  rw [if_pos]
+  intro hxzero
+  subst x
+  simpa using hspectrum 0 hx
 
 /-- The support inverse square root of a positive real multiple scales by the
 inverse square root of that multiple. This is the scalar normalization in the

--- a/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
+++ b/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.RelativeEntropyResolventIntegral
+import TNLean.Analysis.ResolventFunctionalCalculus
 import TNLean.Channel.Schwarz.PetzEqualityPrerequisites
 import Mathlib.MeasureTheory.Measure.OpenPos
 
@@ -23,12 +24,17 @@ data-processing argument.
   every `t > 0`.
 * `Matrix.weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero` combines this with
   the fixed-resolvent result to obtain the common source-`B` solution.
+* `Matrix.weyl_identity_sandwich_of_partialTraceRight_eq` passes from the
+  common resolvent through the relative modular square root to the
+  positive-definite identity-Weyl sandwich.
+* `Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq_posDef` concludes
+  positive-definite recovery by the raw partial-trace Petz map.
 
 ## References
 
 * A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
   Entropy and Related Trace Functions, with Conditions for Equality*,
-  arXiv:0903.2895v4, §4 and Appendix.
+  arXiv:0903.2895v4, §4 and Appendix, especially lines 658–680.
 -/
 
 open Filter MeasureTheory Set Topology
@@ -124,6 +130,35 @@ private lemma trace_sum_re_eq
       Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
     ∑ g, (Matrix.trace (B g)).re = (Matrix.trace (∑ g, B g)).re := by
   rw [← Complex.re_sum, ← Matrix.trace_sum]
+
+/-- The weighted finite Weyl average is the right partial trace tensored with
+the maximally mixed right factor. -/
+theorem weightedWeylAverage_eq_partialTraceRight_kronecker
+    {dS dC : ℕ} [NeZero dC] {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+    weightedWeylAverage ζ M =
+      partialTraceRight M ⊗ₖ
+        ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)) := by
+  calc
+    weightedWeylAverage ζ M =
+        ((dC : ℂ) ^ 2)⁻¹ • ∑ c : ZMod dC, ∑ e : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e) * M *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ c e)ᴴ := by
+      rw [weightedWeylAverage, Fintype.sum_prod_type]
+      simp only [weightedWeylConjugate]
+      rw [sum_sum_smul]
+      ext i j
+      norm_num
+    _ = partialTraceRight M ⊗ₖ
+        ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)) :=
+      sum_kronecker_one_weyl_conj hζ M
+
+/-- The zero-index Weyl summand is the uniformly scaled original matrix. -/
+private lemma weightedWeylConjugate_zero_zero
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+    weightedWeylConjugate ζ M (0, 0) = ((dC : ℝ) ^ 2)⁻¹ • M := by
+  simp [weightedWeylConjugate, weyl, weylShift, weylClock]
 
 /-- Saturation under the right partial trace makes the coefficient-correct
 positive-definite finite-Weyl relative-entropy gap vanish.
@@ -616,5 +651,234 @@ theorem weyl_resolvent_eq_of_partialTraceRight_eq
     ∀ g, (S g)⁻¹ *ᵥ b g = Sbar⁻¹ *ᵥ bbar := by
   exact weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero hρ hσ hζ
     (weylRelativeEntropyGap_eq_zero_of_partialTraceRight_eq hρ hσ heq hζ) ht
+
+/-- Saturation under the right partial trace identifies the positive square-root
+ratio of the original pair with that of its uniform Weyl average.
+
+The common resolvent is first rewritten as a relative-modular resolvent and
+then passed through the positive square-root functional calculus, following
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 658–680.
+
+**Scope restriction (positive definite):** The singular-support extension is
+not asserted here. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_sqrt_ratio_eq_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    let barρ := partialTraceRight ρ ⊗ₖ
+      ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+    CFC.sqrt ρ * hσ.posSemidef.supportInvSqrt =
+      CFC.sqrt barρ *
+        ((partialTraceRight_posDef hσ).kronecker
+          maximallyMixed_posDef).posSemidef.supportInvSqrt := by
+  classical
+  let aZero := weightedWeylConjugate ζ ρ (0, 0)
+  let bZero := weightedWeylConjugate ζ σ (0, 0)
+  let aBar := weightedWeylAverage ζ ρ
+  let bBar := weightedWeylAverage ζ σ
+  have haZero : aZero.PosDef := weightedWeylConjugate_posDef hρ hζ (0, 0)
+  have hbZero : bZero.PosDef := weightedWeylConjugate_posDef hσ hζ (0, 0)
+  have haBar : aBar.PosDef := weightedWeylAverage_posDef hρ hζ
+  have hbBar : bBar.PosDef := weightedWeylAverage_posDef hσ hζ
+  have hmodularResolvent : ∀ {t : ℝ}, 0 < t →
+      (t • (1 : Matrix ((Fin dS × ZMod dC) × (Fin dS × ZMod dC))
+          ((Fin dS × ZMod dC) × (Fin dS × ZMod dC)) ℂ) +
+        aZero ⊗ₖ (bZero⁻¹)ᵀ)⁻¹ *ᵥ
+          Matrix.vec (1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)ᵀ =
+      (t • (1 : Matrix ((Fin dS × ZMod dC) × (Fin dS × ZMod dC))
+          ((Fin dS × ZMod dC) × (Fin dS × ZMod dC)) ℂ) +
+        aBar ⊗ₖ (bBar⁻¹)ᵀ)⁻¹ *ᵥ
+          Matrix.vec (1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)ᵀ := by
+    intro t ht
+    calc
+      _ = (aZero ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+              (Fin dS × ZMod dC) ℂ) +
+            t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ
+              bZeroᵀ))⁻¹ *ᵥ Matrix.vec bZeroᵀ :=
+        (sourceB_resolvent_eq_relativeModular haZero hbZero ht).symm
+      _ = (aBar ⊗ₖ (1 : Matrix (Fin dS × ZMod dC)
+              (Fin dS × ZMod dC) ℂ) +
+            t • ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ
+              bBarᵀ))⁻¹ *ᵥ Matrix.vec bBarᵀ := by
+        simpa only [aZero, bZero, aBar, bBar, weightedWeylConjugate,
+          weightedWeylAverage] using
+          (weyl_resolvent_eq_of_partialTraceRight_eq hρ hσ heq hζ ht (0, 0))
+      _ = _ := sourceB_resolvent_eq_relativeModular haBar hbBar ht
+  have hsqrt := sqrt_mulVec_eq_of_resolvent_mulVec_eq
+    (haZero.kronecker hbZero.inv.transpose).posSemidef
+    (haBar.kronecker hbBar.inv.transpose).posSemidef hmodularResolvent
+  rw [relativeModular_sqrt_mulVec_vec_one haZero hbZero,
+    relativeModular_sqrt_mulVec_vec_one haBar hbBar] at hsqrt
+  have hratio : CFC.sqrt aZero * (CFC.sqrt bZero)⁻¹ =
+      CFC.sqrt aBar * (CFC.sqrt bBar)⁻¹ :=
+    Matrix.transpose_injective (Matrix.vec_inj.mp hsqrt)
+  have hqpos : 0 < ((dC : ℝ) ^ 2)⁻¹ := by
+    have hdC : (0 : ℝ) < dC := by
+      exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+    positivity
+  have haZeroEq : aZero = ((dC : ℝ) ^ 2)⁻¹ • ρ :=
+    weightedWeylConjugate_zero_zero ζ ρ
+  have hbZeroEq : bZero = ((dC : ℝ) ^ 2)⁻¹ • σ :=
+    weightedWeylConjugate_zero_zero ζ σ
+  have haBarEq : aBar = partialTraceRight ρ ⊗ₖ
+      ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)) :=
+    weightedWeylAverage_eq_partialTraceRight_kronecker hζ ρ
+  have hbBarEq : bBar = partialTraceRight σ ⊗ₖ
+      ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)) :=
+    weightedWeylAverage_eq_partialTraceRight_kronecker hζ σ
+  rw [haZeroEq, hbZeroEq, haBarEq, hbBarEq,
+    hρ.posSemidef.sqrt_smul hqpos.le,
+    hσ.posSemidef.sqrt_smul hqpos.le] at hratio
+  have hsqrtq : Real.sqrt (((dC : ℝ) ^ 2)⁻¹) ≠ 0 :=
+    Real.sqrt_ne_zero'.mpr hqpos
+  letI : Invertible (Real.sqrt (((dC : ℝ) ^ 2)⁻¹) : ℂ) :=
+    invertibleOfNonzero (by exact_mod_cast hsqrtq)
+  have hsqrtσunit : IsUnit (CFC.sqrt σ) := by
+    exact (CFC.isUnit_sqrt_iff σ hσ.posSemidef.nonneg).2 hσ.isUnit
+  have hsqrtσdet : IsUnit (CFC.sqrt σ).det :=
+    (Matrix.isUnit_iff_isUnit_det (CFC.sqrt σ)).mp hsqrtσunit
+  have hinvScale :
+      (Real.sqrt (((dC : ℝ) ^ 2)⁻¹) • CFC.sqrt σ)⁻¹ =
+        (Real.sqrt (((dC : ℝ) ^ 2)⁻¹))⁻¹ • (CFC.sqrt σ)⁻¹ := by
+    change (((Real.sqrt (((dC : ℝ) ^ 2)⁻¹) : ℂ) • CFC.sqrt σ)⁻¹ =
+      (((Real.sqrt (((dC : ℝ) ^ 2)⁻¹))⁻¹ : ℝ) : ℂ) • (CFC.sqrt σ)⁻¹)
+    rw [Complex.ofReal_inv]
+    simpa only [invOf_eq_inv] using
+      Matrix.inv_smul (A := CFC.sqrt σ)
+        (Real.sqrt (((dC : ℝ) ^ 2)⁻¹) : ℂ) hsqrtσdet
+  rw [hinvScale] at hratio
+  simp only [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+    inv_mul_cancel₀ hsqrtq, one_smul] at hratio
+  rw [PosDef.supportInvSqrt_eq_inv_sqrt hσ,
+    PosDef.supportInvSqrt_eq_inv_sqrt
+      ((partialTraceRight_posDef hσ).kronecker maximallyMixed_posDef)]
+  exact hratio
+
+/-- Saturation under the right partial trace gives the identity-Weyl Petz
+sandwich in the positive-definite case.
+
+The square-root ratio equality is converted to the sandwich by taking its
+Gram matrix and cancelling the invertible square root of `σ`. This is the
+positive-definite recovery step corresponding to Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 658–680, and Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8).
+
+**Scope restriction (positive definite):** The singular-support extension is
+not asserted here. Documented in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+theorem weyl_identity_sandwich_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    let hbarσ := (PosSemidef.partialTraceRight hσ.posSemidef).kronecker
+      maximallyMixed_posDef.posSemidef
+    hσ.isHermitian.cfc Real.sqrt *
+        (hbarσ.supportInvSqrt *
+          (partialTraceRight ρ ⊗ₖ
+            ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) *
+          hbarσ.supportInvSqrt) *
+        hσ.isHermitian.cfc Real.sqrt = ρ := by
+  classical
+  let barρ := partialTraceRight ρ ⊗ₖ
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+  let barσ := partialTraceRight σ ⊗ₖ
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+  have hbarρ : barρ.PosDef :=
+    (partialTraceRight_posDef hρ).kronecker maximallyMixed_posDef
+  have hbarσ : barσ.PosDef :=
+    (partialTraceRight_posDef hσ).kronecker maximallyMixed_posDef
+  have hratio := weyl_sqrt_ratio_eq_of_partialTraceRight_eq hρ hσ heq hζ
+  dsimp only at hratio
+  rw [PosDef.supportInvSqrt_eq_inv_sqrt hσ,
+    PosDef.supportInvSqrt_eq_inv_sqrt hbarσ] at hratio
+  change CFC.sqrt ρ * (CFC.sqrt σ)⁻¹ =
+    CFC.sqrt barρ * (CFC.sqrt barσ)⁻¹ at hratio
+  have hsqrtρ : (CFC.sqrt ρ)ᴴ = CFC.sqrt ρ := by
+    exact (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)).isHermitian.eq
+  have hsqrtσ : (CFC.sqrt σ)ᴴ = CFC.sqrt σ := by
+    exact (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg σ)).isHermitian.eq
+  have hsqrtBarρ : (CFC.sqrt barρ)ᴴ = CFC.sqrt barρ := by
+    exact (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg barρ)).isHermitian.eq
+  have hsqrtBarσ : (CFC.sqrt barσ)ᴴ = CFC.sqrt barσ := by
+    exact (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg barσ)).isHermitian.eq
+  have hgram := congrArg (fun X => Xᴴ * X) hratio
+  have hleftGram :
+      (CFC.sqrt ρ * (CFC.sqrt σ)⁻¹)ᴴ *
+          (CFC.sqrt ρ * (CFC.sqrt σ)⁻¹) =
+        (CFC.sqrt σ)⁻¹ * ρ * (CFC.sqrt σ)⁻¹ := by
+    simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
+      hsqrtρ, hsqrtσ]
+    calc
+      ((CFC.sqrt σ)⁻¹ * CFC.sqrt ρ) *
+            (CFC.sqrt ρ * (CFC.sqrt σ)⁻¹) =
+          (CFC.sqrt σ)⁻¹ * (CFC.sqrt ρ * CFC.sqrt ρ) *
+            (CFC.sqrt σ)⁻¹ := by noncomm_ring
+      _ = (CFC.sqrt σ)⁻¹ * ρ * (CFC.sqrt σ)⁻¹ := by
+        rw [CFC.sqrt_mul_sqrt_self ρ hρ.posSemidef.nonneg]
+  have hrightGram :
+      (CFC.sqrt barρ * (CFC.sqrt barσ)⁻¹)ᴴ *
+          (CFC.sqrt barρ * (CFC.sqrt barσ)⁻¹) =
+        (CFC.sqrt barσ)⁻¹ * barρ * (CFC.sqrt barσ)⁻¹ := by
+    simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
+      hsqrtBarρ, hsqrtBarσ]
+    calc
+      ((CFC.sqrt barσ)⁻¹ * CFC.sqrt barρ) *
+            (CFC.sqrt barρ * (CFC.sqrt barσ)⁻¹) =
+          (CFC.sqrt barσ)⁻¹ * (CFC.sqrt barρ * CFC.sqrt barρ) *
+            (CFC.sqrt barσ)⁻¹ := by noncomm_ring
+      _ = (CFC.sqrt barσ)⁻¹ * barρ * (CFC.sqrt barσ)⁻¹ := by
+        rw [CFC.sqrt_mul_sqrt_self barρ hbarρ.posSemidef.nonneg]
+  have hgram' :
+      (CFC.sqrt σ)⁻¹ * ρ * (CFC.sqrt σ)⁻¹ =
+        (CFC.sqrt barσ)⁻¹ * barρ * (CFC.sqrt barσ)⁻¹ := by
+    exact hleftGram.symm.trans (hgram.trans hrightGram)
+  have hsqrtσunit : IsUnit (CFC.sqrt σ) :=
+    (CFC.isUnit_sqrt_iff σ hσ.posSemidef.nonneg).2 hσ.isUnit
+  letI : Invertible (CFC.sqrt σ) := hsqrtσunit.invertible
+  have hsandwich : CFC.sqrt σ *
+      ((CFC.sqrt barσ)⁻¹ * barρ * (CFC.sqrt barσ)⁻¹) *
+      CFC.sqrt σ = ρ := by
+    rw [← hgram']
+    calc
+      CFC.sqrt σ * ((CFC.sqrt σ)⁻¹ * ρ * (CFC.sqrt σ)⁻¹) * CFC.sqrt σ =
+          (CFC.sqrt σ * (CFC.sqrt σ)⁻¹) * ρ *
+            ((CFC.sqrt σ)⁻¹ * CFC.sqrt σ) := by noncomm_ring
+      _ = ρ := by
+        rw [mul_inv_of_invertible, inv_mul_of_invertible,
+          Matrix.one_mul, Matrix.mul_one]
+  have hsqrtCfc : hσ.isHermitian.cfc Real.sqrt = CFC.sqrt σ := by
+    rw [← hσ.isHermitian.cfc_eq, ← cfcₙ_eq_cfc]
+    exact (CFC.sqrt_eq_real_sqrt σ hσ.posSemidef.nonneg).symm
+  have hbarSupport :
+      ((PosSemidef.partialTraceRight hσ.posSemidef).kronecker
+        maximallyMixed_posDef.posSemidef).supportInvSqrt =
+          (CFC.sqrt barσ)⁻¹ := by
+    convert PosDef.supportInvSqrt_eq_inv_sqrt hbarσ using 1
+  dsimp only
+  rw [hsqrtCfc, hbarSupport]
+  exact hsandwich
+
+/-- Positive-definite equality in right-partial-trace data processing implies
+recovery by the native raw Petz map.
+
+This is the positive-definite specialization of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/
+theorem partialTraceRightPetzMap_eq_of_relativeEntropy_eq_posDef
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+    partialTraceRightPetzMap σ hσ.posSemidef (partialTraceRight ρ) = ρ := by
+  apply partialTraceRightPetzMap_eq_of_weyl_identity_sandwich hσ.posSemidef
+  exact weyl_identity_sandwich_of_partialTraceRight_eq hρ hσ heq hζ
 
 end Matrix

--- a/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
+++ b/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
@@ -667,8 +667,7 @@ theorem weyl_sqrt_ratio_eq_of_partialTraceRight_eq
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
     (hρ : ρ.PosDef) (hσ : σ.PosDef)
     (heq : quantumRelativeEntropy ρ σ =
-      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
-    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
     let barρ := partialTraceRight ρ ⊗ₖ
       ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
     CFC.sqrt ρ * hσ.posSemidef.supportInvSqrt =
@@ -676,6 +675,8 @@ theorem weyl_sqrt_ratio_eq_of_partialTraceRight_eq
         ((partialTraceRight_posDef hσ).kronecker
           maximallyMixed_posDef).posSemidef.supportInvSqrt := by
   classical
+  obtain ⟨ζ, hζ⟩ : ∃ ζ : ℂ, IsPrimitiveRoot ζ dC :=
+    ⟨_, Complex.isPrimitiveRoot_exp dC (NeZero.ne dC)⟩
   let aZero := weightedWeylConjugate ζ ρ (0, 0)
   let bZero := weightedWeylConjugate ζ σ (0, 0)
   let aBar := weightedWeylAverage ζ ρ
@@ -775,8 +776,7 @@ theorem weyl_identity_sandwich_of_partialTraceRight_eq
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
     (hρ : ρ.PosDef) (hσ : σ.PosDef)
     (heq : quantumRelativeEntropy ρ σ =
-      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
-    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
     let hbarσ := (PosSemidef.partialTraceRight hσ.posSemidef).kronecker
       maximallyMixed_posDef.posSemidef
     hσ.isHermitian.cfc Real.sqrt *
@@ -794,7 +794,7 @@ theorem weyl_identity_sandwich_of_partialTraceRight_eq
     (partialTraceRight_posDef hρ).kronecker maximallyMixed_posDef
   have hbarσ : barσ.PosDef :=
     (partialTraceRight_posDef hσ).kronecker maximallyMixed_posDef
-  have hratio := weyl_sqrt_ratio_eq_of_partialTraceRight_eq hρ hσ heq hζ
+  have hratio := weyl_sqrt_ratio_eq_of_partialTraceRight_eq hρ hσ heq
   dsimp only at hratio
   rw [PosDef.supportInvSqrt_eq_inv_sqrt hσ,
     PosDef.supportInvSqrt_eq_inv_sqrt hbarσ] at hratio
@@ -875,10 +875,9 @@ theorem partialTraceRightPetzMap_eq_of_relativeEntropy_eq_posDef
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
     (hρ : ρ.PosDef) (hσ : σ.PosDef)
     (heq : quantumRelativeEntropy ρ σ =
-      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
-    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC) :
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
     partialTraceRightPetzMap σ hσ.posSemidef (partialTraceRight ρ) = ρ := by
   apply partialTraceRightPetzMap_eq_of_weyl_identity_sandwich hσ.posSemidef
-  exact weyl_identity_sandwich_of_partialTraceRight_eq hρ hσ heq hζ
+  exact weyl_identity_sandwich_of_partialTraceRight_eq hρ hσ heq
 
 end Matrix

--- a/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
+++ b/TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean
@@ -24,6 +24,10 @@ data-processing argument.
   every `t > 0`.
 * `Matrix.weyl_resolvent_eq_of_relativeEntropy_gap_eq_zero` combines this with
   the fixed-resolvent result to obtain the common source-`B` solution.
+* `Matrix.weightedWeylAverage_eq_partialTraceRight_kronecker` identifies the
+  Weyl average with the maximally mixed extension of the right partial trace.
+* `Matrix.weyl_sqrt_ratio_eq_of_partialTraceRight_eq` converts common
+  resolvents into equality of the positive square-root ratios.
 * `Matrix.weyl_identity_sandwich_of_partialTraceRight_eq` passes from the
   common resolvent through the relative modular square root to the
   positive-definite identity-Weyl sandwich.
@@ -763,7 +767,7 @@ theorem weyl_sqrt_ratio_eq_of_partialTraceRight_eq
 sandwich in the positive-definite case.
 
 The square-root ratio equality is converted to the sandwich by taking its
-Gram matrix and cancelling the invertible square root of `σ`. This is the
+Gram matrix and cancelling the invertible square root of σ. This is the
 positive-definite recovery step corresponding to Jenčová--Ruskai,
 arXiv:0903.2895v4, lines 658–680, and Hayden--Jozsa--Petz--Winter,
 arXiv:quant-ph/0304007v2, Theorem 3, equation (8).
@@ -866,7 +870,7 @@ theorem weyl_identity_sandwich_of_partialTraceRight_eq
   exact hsandwich
 
 /-- Positive-definite equality in right-partial-trace data processing implies
-recovery by the native raw Petz map.
+recovery by the raw partial-trace Petz map.
 
 This is the positive-definite specialization of Hayden--Jozsa--Petz--Winter,
 arXiv:quant-ph/0304007v2, Theorem 3, equation (8). -/

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1345,6 +1345,18 @@ Theorem~\ref{thm:trace_norm_abs}.
     Hermitian.
 \end{lemma}
 
+\begin{lemma}[Support inverse square root of a positive-definite matrix]
+    \label{lem:support_inverse_square_root_positive_definite}
+    \lean{Matrix.PosDef.supportInvSqrt_eq_inv_sqrt}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    If $\tau$ is positive definite, then its inverse square root on the support
+    is its ordinary inverse square root:
+    \[
+        \tau^{-1/2}_{\mathrm{supp}}=(\sqrt\tau)^{-1}.
+    \]
+\end{lemma}
+
 \begin{lemma}[Support inverse-square-root identity]
     \label{lem:support_inverse_square_root_sandwich}
     \lean{Matrix.PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt}
@@ -2750,10 +2762,10 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{Matrix.sourceB_resolvent_eq_relativeModular}
     \lean{Matrix.relativeModular_sqrt_mulVec_vec_one}
     \leanok
-    Let $S,T$ be positive semidefinite matrices and let $x$ be a vector.  If
+    Let $S,T$ be positive semidefinite matrices and let $x$ be a vector.  If,
+    for every $t>0$,
     \[
-        (t\mathbf 1+S)^{-1}x=(t\mathbf 1+T)^{-1}x
-        \qquad(t>0),
+        (t\mathbf 1+S)^{-1}x=(t\mathbf 1+T)^{-1}x,
     \]
     then $\sqrt S\,x=\sqrt T\,x$.
 
@@ -2771,11 +2783,15 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
-    Use the L\"owner integral representation of the power $p=1/2$.  Each
-    integrand is a scalar multiple of the identity minus a scalar multiple of
-    the shifted resolvent, so the hypothesis makes the two vector-valued
-    integrands equal.  Integration gives equality of the positive square
-    roots on $x$.
+    Use the L\"owner integral representation of the power $p=1/2$.  Its
+    integrand at $t>0$ is
+    \[
+      f_t(S)=t^{-1/2}\mathbf 1-t^{1/2}(t\mathbf 1+S)^{-1}.
+    \]
+    Applied to $x$, this is
+    $t^{-1/2}x-t^{1/2}(t\mathbf 1+S)^{-1}x$.  The hypothesis therefore makes
+    the two vector-valued integrands equal, and integration gives equality of
+    the positive square roots on $x$.
 
     For the second assertion, factor
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1357,6 +1357,12 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
 \end{lemma}
 
+\begin{proof}\leanok
+    Every eigenvalue of $\tau$ is strictly positive.  Hence the function
+    defining the support inverse square root agrees on the spectrum with the
+    reciprocal of the positive square-root function.
+\end{proof}
+
 \begin{lemma}[Support inverse-square-root identity]
     \label{lem:support_inverse_square_root_sandwich}
     \lean{Matrix.PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt}
@@ -2789,9 +2795,11 @@ Theorem~\ref{thm:trace_norm_abs}.
       f_t(S)=t^{-1/2}\mathbf 1-t^{1/2}(t\mathbf 1+S)^{-1}.
     \]
     Applied to $x$, this is
-    $t^{-1/2}x-t^{1/2}(t\mathbf 1+S)^{-1}x$.  The hypothesis therefore makes
-    the two vector-valued integrands equal, and integration gives equality of
-    the positive square roots on $x$.
+    \[
+      f_t(S)x=t^{-1/2}x-t^{1/2}(t\mathbf 1+S)^{-1}x.
+    \]
+    The hypothesis therefore gives $f_t(S)x=f_t(T)x$ for every $t>0$.
+    Integration gives equality of the positive square roots on $x$.
 
     For the second assertion, factor
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2775,9 +2775,16 @@ Theorem~\ref{thm:trace_norm_abs}.
     \]
     then $\sqrt S\,x=\sqrt T\,x$.
 
-    In particular, for positive definite $A,B$, the source-$B$ left--right
-    resolvent factors through the relative modular matrix
-    $\Delta_{A,B}=A\otimes(B^{-1})^{\mathsf T}$, and
+    In particular, for positive definite $A,B$ and every $t>0$, put
+    $\Delta_{A,B}=A\otimes(B^{-1})^{\mathsf T}$.  The source-$B$ left--right
+    resolvent satisfies
+    \[
+      \left(A\otimes\mathbf 1+t\,\mathbf 1\otimes B^{\mathsf T}\right)^{-1}
+        \operatorname{vec}(B^{\mathsf T})
+      =\left(t\mathbf 1+\Delta_{A,B}\right)^{-1}
+        \operatorname{vec}(\mathbf 1^{\mathsf T}),
+    \]
+    and
     \[
       \sqrt{\Delta_{A,B}}\,\operatorname{vec}(\mathbf 1^{\mathsf T})
         =\operatorname{vec}\!\left(
@@ -2841,7 +2848,10 @@ Theorem~\ref{thm:trace_norm_abs}.
       \sqrt\sigma\,\overline\sigma^{-1/2}\,
       \overline\rho\,\overline\sigma^{-1/2}\,\sqrt\sigma=\rho.
     \]
-    Hence the raw partial-trace Petz map recovers $\rho$ from $\tr_C\rho$.
+    Hence the raw partial-trace Petz map satisfies
+    \[
+      \mathcal R_\sigma(\tr_C\rho)=\rho.
+    \]
     This is the positive-definite case only; no singular-support conclusion is
     asserted.
 \end{theorem}
@@ -2852,9 +2862,16 @@ Theorem~\ref{thm:trace_norm_abs}.
         thm:weyl_identity_sandwich_petz_recovery}
     Apply the common-resolvent theorem to the identity Weyl summand and the
     Weyl average.  The preceding lemma converts the result to equality of the
-    two square-root ratios; the uniform scalar in the identity summand cancels,
-    and the Weyl twirl identifies the average with the displayed maximally
-    mixed extensions.
+    two square-root ratios.  For $c=d_C^{-2}$, the uniform scalar in the
+    identity summand cancels through
+    \[
+      \sqrt{c\rho}\,(\sqrt{c\sigma})^{-1}
+      =(\sqrt c\,\sqrt\rho)
+        \bigl((\sqrt c)^{-1}(\sqrt\sigma)^{-1}\bigr)
+      =\sqrt\rho\,(\sqrt\sigma)^{-1}.
+    \]
+    The Weyl twirl identifies the average with the displayed maximally mixed
+    extensions.
 
     Taking the adjoint product of the ratio equality yields
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2744,6 +2744,106 @@ Theorem~\ref{thm:trace_norm_abs}.
     \ref{thm:weyl_resolvent_zero_defect} now gives the common solution.
 \end{proof}
 
+\begin{lemma}[Positive square root from common resolvents]
+    \label{lem:positive_sqrt_from_common_resolvents}
+    \lean{Matrix.sqrt_mulVec_eq_of_resolvent_mulVec_eq}
+    \lean{Matrix.sourceB_resolvent_eq_relativeModular}
+    \lean{Matrix.relativeModular_sqrt_mulVec_vec_one}
+    \leanok
+    Let $S,T$ be positive semidefinite matrices and let $x$ be a vector.  If
+    \[
+        (t\mathbf 1+S)^{-1}x=(t\mathbf 1+T)^{-1}x
+        \qquad(t>0),
+    \]
+    then $\sqrt S\,x=\sqrt T\,x$.
+
+    In particular, for positive definite $A,B$, the source-$B$ left--right
+    resolvent factors through the relative modular matrix
+    $\Delta_{A,B}=A\otimes(B^{-1})^{\mathsf T}$, and
+    \[
+      \sqrt{\Delta_{A,B}}\,\operatorname{vec}(\mathbf 1^{\mathsf T})
+        =\operatorname{vec}\!\left(
+          (\sqrt A\,(\sqrt B)^{-1})^{\mathsf T}\right).
+    \]
+    These are the positive-square-root specializations of the passage from
+    relative modular resolvents to analytic functions of the relative modular
+    operator in Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 658--680.
+\end{lemma}
+
+\begin{proof}\leanok
+    Use the L\"owner integral representation of the power $p=1/2$.  Each
+    integrand is a scalar multiple of the identity minus a scalar multiple of
+    the shifted resolvent, so the hypothesis makes the two vector-valued
+    integrands equal.  Integration gives equality of the positive square
+    roots on $x$.
+
+    For the second assertion, factor
+    \[
+      L_A+tR_B=(\Delta_{A,B}+t\mathbf 1)R_B.
+    \]
+    Applying the inverse to $B=R_B(\mathbf 1)$ gives the shifted relative
+    modular resolvent on $\mathbf 1$.  Finally,
+    \[
+      \sqrt{\Delta_{A,B}}
+        =\sqrt A\otimes\bigl((\sqrt B)^{-1}\bigr)^{\mathsf T},
+    \]
+    as follows from uniqueness of the positive square root.
+\end{proof}
+
+\begin{theorem}[Positive-definite saturation gives the identity Weyl sandwich]
+    \label{thm:partial_trace_saturation_identity_weyl_sandwich}
+    \lean{Matrix.weightedWeylAverage_eq_partialTraceRight_kronecker}
+    \lean{Matrix.weyl_sqrt_ratio_eq_of_partialTraceRight_eq}
+    \lean{Matrix.weyl_identity_sandwich_of_partialTraceRight_eq}
+    \lean{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq_posDef}
+    \leanok
+    \uses{thm:weyl_relative_entropy_zero_gap_resolvent,
+        lem:positive_sqrt_from_common_resolvents,
+        thm:weyl_identity_sandwich_petz_recovery}
+    Let $\rho$ and $\sigma$ be positive definite and suppose that
+    \[
+      D(\rho\Vert\sigma)
+        =D(\tr_C\rho\Vert\tr_C\sigma).
+    \]
+    Put
+    \[
+      \overline\rho=(\tr_C\rho)\otimes d_C^{-1}\mathbf 1_C,
+      \qquad
+      \overline\sigma=(\tr_C\sigma)\otimes d_C^{-1}\mathbf 1_C.
+    \]
+    Then
+    \[
+      \sqrt\rho\,\sigma^{-1/2}
+        =\sqrt{\overline\rho}\,\overline\sigma^{-1/2},
+    \]
+    and consequently
+    \[
+      \sqrt\sigma\,\overline\sigma^{-1/2}\,
+      \overline\rho\,\overline\sigma^{-1/2}\,\sqrt\sigma=\rho.
+    \]
+    Hence the raw partial-trace Petz map recovers $\rho$ from $\tr_C\rho$.
+    This is the positive-definite case only; no singular-support conclusion is
+    asserted.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the common-resolvent theorem to the identity Weyl summand and the
+    Weyl average.  The preceding lemma converts the result to equality of the
+    two square-root ratios; the uniform scalar in the identity summand cancels,
+    and the Weyl twirl identifies the average with the displayed maximally
+    mixed extensions.
+
+    Taking the adjoint product of the ratio equality yields
+    \[
+      \sigma^{-1/2}\rho\sigma^{-1/2}
+        =\overline\sigma^{-1/2}\overline\rho
+          \overline\sigma^{-1/2}.
+    \]
+    Multiplication by $\sqrt\sigma$ on both sides gives the sandwich.  The raw
+    Petz recovery identity follows from
+    Theorem~\ref{thm:weyl_identity_sandwich_petz_recovery}.
+\end{proof}
+
 \begin{lemma}[Maximally mixed support-sandwich normalization]
     \label{lem:maximally_mixed_support_sandwich}
     \lean{Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2792,14 +2792,10 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{theorem}[Positive-definite saturation gives the identity Weyl sandwich]
     \label{thm:partial_trace_saturation_identity_weyl_sandwich}
-    \lean{Matrix.weightedWeylAverage_eq_partialTraceRight_kronecker}
     \lean{Matrix.weyl_sqrt_ratio_eq_of_partialTraceRight_eq}
     \lean{Matrix.weyl_identity_sandwich_of_partialTraceRight_eq}
     \lean{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq_posDef}
     \leanok
-    \uses{thm:weyl_relative_entropy_zero_gap_resolvent,
-        lem:positive_sqrt_from_common_resolvents,
-        thm:weyl_identity_sandwich_petz_recovery}
     Let $\rho$ and $\sigma$ be positive definite and suppose that
     \[
       D(\rho\Vert\sigma)
@@ -2827,6 +2823,9 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:weyl_relative_entropy_zero_gap_resolvent,
+        lem:positive_sqrt_from_common_resolvents,
+        thm:weyl_identity_sandwich_petz_recovery}
     Apply the common-resolvent theorem to the identity Weyl summand and the
     Weyl average.  The preceding lemma converts the result to equality of the
     two square-root ratios; the uniform scalar in the identity summand cancels,

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -45,8 +45,9 @@ quantum-Markov-chain structure of the tripartite state
 
 In the present development the biconditional
 \eqref{eq:ssa-eq} $\Leftrightarrow$~\eqref{eq:qmc} is recovered by combining a
-forward-only axiom with a proved reverse direction.\footnote{The forward-only
-axiom is \leanid{hayashi_ssa_equality_characterization_forward} in
+forward-only external assumption with a proved reverse direction.\footnote{The
+forward-only external assumption is
+\leanid{hayashi_ssa_equality_characterization_forward} in
 \doclink{TNLean/Axioms/Entropy} (\path{TNLean/Axioms/Entropy.lean}); the proved
 reverse direction is
 \leanid{hayashi_ssa_equality_characterization_reverse} in
@@ -105,11 +106,11 @@ downstream result.
 
 \section{The one-directional hygiene split}
 
-Because only the forward direction is both deep and used, the axiom boundary is
-kept minimal: the axiom states the single forward
+Because only the forward direction is both deep and used, the assumption
+boundary is kept minimal: the external assumption states the single forward
 implication \eqref{eq:ssa-eq} $\Rightarrow$~\eqref{eq:qmc}, and the reverse
 implication \eqref{eq:qmc} $\Rightarrow$~\eqref{eq:ssa-eq} is a theorem. The full
-biconditional is recovered by combining the two, and the axiomatic content
+biconditional is recovered by combining the two, and the postulated content
 is reduced to exactly the part that genuinely needs the missing theory.
 
 The reverse half uses the following entropy-additivity sub-lemmas, all proved in
@@ -425,12 +426,12 @@ After this analytic implication, the proof of the block decomposition still
 requires the invariant-state decomposition used in
 \cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the
 Koashi--Imoto structural step.  Both steps remain necessary before the forward
-axiom can be removed.
+external assumption can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
-reverse direction and an axiomatic forward direction. Only the forward
+reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
 singular-support recovery theorem and the structural analysis of recovered
 states; positive-definite recovery and the trace-preserving Petz channel are
@@ -439,7 +440,7 @@ direction, a block-diagonal product state attains equality, is proved from
 entropy additivity over weighted direct sums and tensor factors together with
 unitary and reindexing invariance.
 Until those remaining steps are formalized, the forward direction remains the
-irreducible axiomatic content of this characterization.
+irreducible unproved content of this characterization.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -80,7 +80,8 @@ when the data-processing inequality for relative entropy is saturated and the
 reconstruction of the discarded subsystem from a recovery map. This recovery-map
 argument still lacks the singular-support extension of saturation-to-recovery
 and the subsequent structural analysis, which is why the forward direction is
-axiomatized rather than proved.  The positive-definite recovery implication and
+treated as an external assumption rather than proved.  The positive-definite
+recovery implication and
 the complementary trace-preserving extension of the support Petz map have now
 been supplied and are no longer part of this gap.
 
@@ -151,8 +152,8 @@ The reverse half uses the following entropy-additivity sub-lemmas, all proved in
 
 With these five facts the reverse implication is a finite computation, now
 carried out in \path{TNLean/Analysis/EntropyMarkovReverse.lean}; the
-forward implication remains an axiom until the singular-support recovery
-extension and the structural analysis are available.
+forward implication remains an external assumption until the singular-support
+recovery extension and the structural analysis are available.
 
 \section{Trace-preserving Petz channel now available}
 
@@ -433,9 +434,10 @@ reverse direction and an axiomatic forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
 singular-support recovery theorem and the structural analysis of recovered
 states; positive-definite recovery and the trace-preserving Petz channel are
-now available.  The forward direction alone is axiomatized. The reverse direction, a block-diagonal
-product state attains equality, is proved from entropy additivity over weighted
-direct sums and tensor factors together with unitary and reindexing invariance.
+now available.  The forward direction alone is postulated. The reverse
+direction, a block-diagonal product state attains equality, is proved from
+entropy additivity over weighted direct sums and tensor factors together with
+unitary and reindexing invariance.
 Until those remaining steps are formalized, the forward direction remains the
 irreducible axiomatic content of this characterization.
 

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -59,11 +59,12 @@ and the right-hand structure is recorded by
 finite decomposition, the unitary basis change, the weights $p_j$, the component
 density operators, and the block-diagonal equality.} The forward direction is an
 external stand-in: that implication is a theorem of Ruskai, of
-Hayden--Jozsa--Petz--Winter, and of Hayashi, but its proof rests on
-the full saturation-to-recovery theorem and the structural analysis of
-recovered states.  The trace-preserving extension of the support Petz map is
-now available, but those two later steps are not.  The reverse direction is
-proved from the entropy-additivity sub-lemmas listed below.
+Hayden--Jozsa--Petz--Winter, and of Hayashi, but its proof rests on the full
+singular-support saturation-to-recovery theorem and the structural analysis of
+recovered states.  Positive-definite saturation-to-recovery and the
+trace-preserving extension of the support Petz map are now available; the
+singular-support extension and structural step are not.  The reverse direction
+is proved from the entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
 
@@ -77,10 +78,11 @@ downstream. Its proof is the deep part of the characterization: it requires
 recovery-map theory and the Petz transpose channel, that is, the analysis of
 when the data-processing inequality for relative entropy is saturated and the
 reconstruction of the discarded subsystem from a recovery map. This recovery-map
-argument still lacks the saturation-to-recovery theorem and the subsequent
-structural analysis, which is why the forward direction is axiomatized rather
-than proved.  The complementary trace-preserving extension of the support
-Petz map has now been supplied and is no longer part of this gap.
+argument still lacks the singular-support extension of saturation-to-recovery
+and the subsequent structural analysis, which is why the forward direction is
+axiomatized rather than proved.  The positive-definite recovery implication and
+the complementary trace-preserving extension of the support Petz map have now
+been supplied and are no longer part of this gap.
 
 \paragraph{Reverse direction (tractable, currently unused).}
 The implication \eqref{eq:qmc} $\Rightarrow$~\eqref{eq:ssa-eq} --- a state of the
@@ -149,8 +151,8 @@ The reverse half uses the following entropy-additivity sub-lemmas, all proved in
 
 With these five facts the reverse implication is a finite computation, now
 carried out in \path{TNLean/Analysis/EntropyMarkovReverse.lean}; the
-forward implication remains an axiom until the full saturation-to-recovery
-theorem and the structural analysis are available.
+forward implication remains an axiom until the singular-support recovery
+extension and the structural analysis are available.
 
 \section{Trace-preserving Petz channel now available}
 
@@ -335,11 +337,36 @@ fixed-resolvent theorem gives $T_g^{-1}(B_g)=T^{-1}(B)$ for every Weyl index.
 \leanid{Matrix.weyl_resolvent_eq_of_partialTraceRight_eq} in
 \path{TNLean/Analysis/RelativeEntropyResolventIntegral.lean} and
 \path{TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean}.}
-This completes the positive-definite finite-Weyl integral step of
-Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S4 and Appendix.  The remaining
-analytic
-work is the inverse-square-root passage from the common resolvent solution to
-the identity-Weyl sandwich, followed by extension to singular supports.
+The positive-definite inverse-square-root passage is now also complete.  The
+source-$B$ resolvent factors through the relative modular matrix
+$\Delta_{A,B}=A\otimes(B^{-1})^{\mathsf T}$.  Equality of its shifted
+resolvents on the vectorized identity passes through the positive square-root
+functional calculus, giving
+\begin{align}
+  \sqrt\rho\,\sigma^{-1/2}
+    =\sqrt{\overline\rho}\,\overline\sigma^{-1/2}.
+\end{align}
+Taking adjoint products and cancelling $\sqrt\sigma$ gives
+\begin{align}
+  \sqrt\sigma\,\overline\sigma^{-1/2}\,\overline\rho\,
+    \overline\sigma^{-1/2}\,\sqrt\sigma=\rho.
+\end{align}
+This is the positive-square-root specialization of the relative-modular
+analytic-continuation argument in Jen\v{c}ov\'a--Ruskai,
+arXiv:0903.2895v4, lines 658--680.  The formal proof uses the equivalent
+L\"owner integral representation of the power $p=1/2$.
+\footnote{Formal declarations:
+\leanid{Matrix.sqrt_mulVec_eq_of_resolvent_mulVec_eq},
+\leanid{Matrix.sourceB_resolvent_eq_relativeModular}, and
+\leanid{Matrix.relativeModular_sqrt_mulVec_vec_one} in
+\path{TNLean/Analysis/ResolventFunctionalCalculus.lean}; and
+\leanid{Matrix.weyl_sqrt_ratio_eq_of_partialTraceRight_eq},
+\leanid{Matrix.weyl_identity_sandwich_of_partialTraceRight_eq}, and
+\leanid{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq_posDef} in
+\path{TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean}.}
+Thus equality under the partial trace implies raw Petz recovery for positive
+definite inputs.  The remaining analytic work is the extension of this passage
+to singular supports.
 
 There is nevertheless a useful algebraic reduction for the identity summand.
 Write
@@ -373,12 +400,13 @@ of \cite[Theorem~3, equation~(8)]{HaydenJozsaPetzWinter2004}.
 \leanid{Matrix.PosSemidef.supportInvSqrt_kronecker_maximallyMixed_mul_mul}, and
 \leanid{Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich} in
 \path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
-This implication is conditional on the displayed operator identity.  It does
-not infer that identity from the scalar equality in the finite Weyl Jensen
-step, and it makes no assertion for an arbitrary convex ensemble.
+The algebraic implication itself is conditional on the displayed operator
+identity.  The positive-definite finite-Weyl argument above now supplies that
+identity from equality of relative entropy under the partial trace.  No claim
+is made here for an arbitrary convex ensemble or for singular inputs.
 
-The exact remaining analytic implication is the equality case of data
-processing on this support domain:
+The exact remaining analytic implication is the singular-support equality case
+of data processing:
 \begin{align}
   D(\rho\Vert\sigma)
     =D(\operatorname{tr}_R\rho\Vert\operatorname{tr}_R\sigma)
@@ -389,8 +417,9 @@ This is the forward implication of
 \cite[Theorem~3]{HaydenJozsaPetzWinter2004}.  The present proof of data
 processing establishes the inequality by regularization, unitary averaging,
 and joint convexity.  In the positive-definite case its equality analysis now
-reaches the common Weyl resolvent solution, but not yet the limiting
-inverse-square-root sandwich required for recovery.
+reaches the common Weyl resolvent solution, the inverse-square-root sandwich,
+and raw Petz recovery.  What remains is to control the same passage on the
+supports of singular inputs.
 After this analytic implication, the proof of the block decomposition still
 requires the invariant-state decomposition used in
 \cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the
@@ -402,9 +431,9 @@ axiom can be removed.
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and an axiomatic forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-full saturation-to-recovery theorem and the structural analysis of recovered
-states; the trace-preserving Petz channel is now available.  The forward
-direction alone is axiomatized. The reverse direction, a block-diagonal
+singular-support recovery theorem and the structural analysis of recovered
+states; positive-definite recovery and the trace-preserving Petz channel are
+now available.  The forward direction alone is axiomatized. The reverse direction, a block-diagonal
 product state attains equality, is proved from entropy additivity over weighted
 direct sums and tensor factors together with unitary and reindexing invariance.
 Until those remaining steps are formalized, the forward direction remains the


### PR DESCRIPTION
Closes LionSR/QICLean#242.

Advances LionSR/QICLean#233. Tracking: LionSR/TNLean#239.

## Summary

- prove that equality of all positive shifted resolvents on a vector implies equality of the positive square roots on that vector
- factor the source-`B` left-right resolvent through the relative modular matrix and compute its square root on the vectorized identity
- derive the positive-definite Weyl square-root ratio, identity-summand sandwich, and raw partial-trace Petz recovery endpoint
- record the exact positive-definite scope in the entropy blueprint and narrow the paper-gap note to the singular-support extension
- register the new functional-calculus module in the root import surface

## Source audit

Jenčová--Ruskai, arXiv:0903.2895v4, lines 658--680, rewrites the common left-right resolvent as a relative-modular resolvent and then invokes analytic continuation and the Cauchy formula. The Lean proof uses the equivalent Löwner integral representation at power `p = 1 / 2`. The primitive root needed for the finite Weyl calculation is chosen inside the proof and is not exposed as a hypothesis of the source-facing recovery statements.

This PR is restricted to positive-definite inputs. It does not address the singular-support extension tracked separately in LionSR/QICLean#243.

## Validation

Validated on base `7a7aa819` and head `2ab72cfff3`:

- `lake build` (9,617 jobs)
- focused builds of `MatrixSqrt`, `ResolventFunctionalCalculus`, `PetzRecovery`, and `WeylRelativeEntropyIntegral`
- root-import build after registering `ResolventFunctionalCalculus`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web` and `leanblueprint checkdecls`
- proof-integrity, reader-facing prose, file-size, repeated-tactic, and whitespace checks
- `#print axioms` on the five new public results: only `propext`, `Classical.choice`, and `Quot.sound`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new proofs on the relative-entropy saturation and Petz-recovery path; scope is explicitly positive-definite only, but errors would affect downstream entropy characterization work.
> 
> **Overview**
> **Positive-definite saturation under right partial trace** now yields raw Petz recovery: equality of quantum relative entropy with its partial-trace marginal implies `partialTraceRightPetzMap` returns the original state (Hayden–Jozsa–Petz–Winter, pos-def case only).
> 
> The missing analytic step is a new **`ResolventFunctionalCalculus`** layer: matching shifted resolvents on a vector imply equal positive square roots (via Löwner \(p=1/2\) integrals), plus source-\(B\) resolvent factorization through the relative modular Kronecker matrix and evaluation of \(\sqrt{\Delta}\) on the vectorized identity. Supporting lemmas add **`PosSemidef.sqrt_smul`** and **`PosDef.supportInvSqrt_eq_inv_sqrt`**.
> 
> **`WeylRelativeEntropyIntegral`** chains the existing common-resolvent Weyl argument through square-root ratio equality, the identity-Weyl support sandwich, and the existing `partialTraceRightPetzMap_eq_of_weyl_identity_sandwich` reduction. Weyl averaging is identified with partial trace tensored by the maximally mixed right factor.
> 
> Blueprint chapter 19 and **`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`** are updated to record the completed pos-def inverse-square-root passage; the forward SSA characterization gap is narrowed to **singular-support** recovery and structural (Koashi–Imoto) steps. **`TNLean.lean`** exports the new analysis module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6cf565a2c15bed76886f2e5f4da1e45d9bc12d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->