### PR TITLE
feat(MPS/RFP): classify eventually constant sector graphs

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -40,6 +40,7 @@ import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.ConstantPowerSums
+import TNLean.Algebra.EventuallyConstantCycleWeights
 import TNLean.Algebra.UnitModulusPowerSum
 import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.PiTensorProductPhase
@@ -608,7 +609,6 @@ import TNLean.MPS.Examples.MajumdarGhosh
 import TNLean.MPS.Examples.WState
 import TNLean.MPS.Examples.ZMod2
 import TNLean.MPS.Examples.ZeroCorrelationExamples
-
 -- Layer 5b: Renormalization fixed points (RFP) — pure-state scaffolding
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.RFP.ZeroCorrelationLength
@@ -631,6 +631,7 @@ import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.BeigiGroundSpaceDimension
 import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BeigiSectorGraph
+import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 -- Layer 6a: Quantum Wielandt span-growth infrastructure
@@ -641,7 +642,6 @@ import TNLean.Wielandt.SpanGrowth.EigenvectorSpreading
 import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 import TNLean.Wielandt.RankOne.Construction
 import TNLean.Wielandt.RankOne.Products
-
 -- Layer 6b: Proposition 3 and the quantum Wielandt inequality.
 -- `Inequality/` records the bounds of arXiv:0909.5347 / Wolf §6.9 in their
 -- standard notation. These declarations are independent of the MPS fundamental

--- a/TNLean/Algebra/EventuallyConstantCycleWeights.lean
+++ b/TNLean/Algebra/EventuallyConstantCycleWeights.lean
@@ -1,0 +1,401 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Order.BigOperators.Group.Finset
+import Mathlib.Algebra.Order.GroupWithZero.Basic
+import Mathlib.Data.Fin.Tuple.Basic
+import Mathlib.Data.Fintype.EquivFin
+
+/-!
+# Eventually constant weighted cycle sums
+
+This file contains the finite combinatorial argument used in Beigi's
+classification of one-dimensional commuting Hamiltonians.  An ordered cycle
+is a finite word with its last vertex joined back to its first vertex.  Its
+weight is the product of the weights of its directed edges.
+
+If the sum of these weights is eventually constant, comparison of cycles of
+two sufficiently large consecutive lengths with their repetitions at the
+common length `N(N+1)` forces every cyclic edge to have weight one.  The same
+comparison makes both repetition maps exhaustive.  Their common values have
+periods `N` and `N+1`, hence period one, so every cycle is constant.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Section IV, equations (7)--(13), source
+  lines 561--606.
+-/
+
+open scoped BigOperators
+
+namespace FiniteWeightedDigraph
+
+variable {V : Type*} [Fintype V]
+
+/-- The successor of an index on a nonempty finite cycle.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--606. -/
+def next {N : ℕ} (hN : 0 < N) (i : Fin N) : Fin N :=
+  ⟨(i.val + 1) % N, Nat.mod_lt _ hN⟩
+
+/-- The product of the directed-edge weights around an ordered cycle.
+
+Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
+561--606. -/
+def cycleWeight (w : V → V → ℕ) {N : ℕ} (hN : 0 < N)
+    (x : Fin N → V) : ℕ :=
+  ∏ i, w (x i) (x (next hN i))
+
+/-- The ordered-cycle weighted sum at a positive length.
+
+Cycles are ordered: cyclic rotations are counted separately, exactly as in
+Beigi's dimension formula.
+
+Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
+561--606. -/
+def cycleWeightSum (w : V → V → ℕ) {N : ℕ} (hN : 0 < N) : ℕ :=
+  ∑ x : Fin N → V, cycleWeight w hN x
+
+/-- The numerical cycle sum is constant at all sufficiently large positive
+lengths.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--568. -/
+def HasEventuallyConstantCycleWeightSum (w : V → V → ℕ) : Prop :=
+  ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N → ∀ hN : 0 < N, cycleWeightSum w hN = c
+
+omit [Fintype V] in
+/-- Repeating a finite word a positive number of times is injective as a
+function of the original word.
+
+Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+theorem repeat_injective {N m : ℕ} (hm : 0 < m) :
+    Function.Injective (Fin.repeat m : (Fin N → V) → Fin (m * N) → V) := by
+  intro x y hxy
+  funext i
+  have h := congrFun hxy ⟨i.val, lt_of_lt_of_le i.isLt (Nat.le_mul_of_pos_left N hm)⟩
+  simpa [Fin.repeat, Fin.modNat, Nat.mod_eq_of_lt i.isLt] using h
+
+omit [Fintype V] in
+@[simp]
+private theorem repeat_finProdFinEquiv {N m : ℕ} (x : Fin N → V)
+    (i : Fin m) (j : Fin N) :
+    Fin.repeat m x (finProdFinEquiv (i, j)) = x j := by
+  simp [Fin.repeat, finProdFinEquiv, Fin.modNat, Nat.mod_eq_of_lt]
+
+omit [Fintype V] in
+@[simp]
+private theorem repeat_next_finProdFinEquiv {N m : ℕ} (hN : 0 < N)
+    (hm : 0 < m) (x : Fin N → V) (i : Fin m) (j : Fin N) :
+    Fin.repeat m x
+        (next (Nat.mul_pos hm hN) (finProdFinEquiv (i, j))) =
+      x (next hN j) := by
+  simp [Fin.repeat, finProdFinEquiv, Fin.modNat, next, Nat.add_mod,
+    Nat.mod_eq_of_lt]
+
+omit [Fintype V] in
+/-- Repetition raises the weight of a cycle to the repetition power.
+
+This is the product identity underlying Beigi's comparisons at lengths `N`,
+`N+1`, and `N(N+1)`.
+
+Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+theorem cycleWeight_repeat (w : V → V → ℕ) {N m : ℕ}
+    (hN : 0 < N) (hm : 0 < m) (x : Fin N → V) :
+    cycleWeight w (Nat.mul_pos hm hN) (Fin.repeat m x) = cycleWeight w hN x ^ m := by
+  unfold cycleWeight
+  rw [← finProdFinEquiv.prod_comp]
+  rw [Fintype.prod_prod_type]
+  simp_rw [repeat_next_finProdFinEquiv hN hm x]
+  simp_rw [repeat_finProdFinEquiv x]
+  simp
+
+/-- The total weight of repeated cycles is bounded by the total weight of all
+cycles at the repeated length.
+
+Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+theorem sum_cycleWeight_pow_le (w : V → V → ℕ) {N m : ℕ}
+    (hN : 0 < N) (hm : 0 < m) :
+    (∑ x : Fin N → V, cycleWeight w hN x ^ m) ≤
+      cycleWeightSum w (Nat.mul_pos hm hN) := by
+  classical
+  simp_rw [← cycleWeight_repeat w hN hm]
+  unfold cycleWeightSum
+  calc
+    (∑ x : Fin N → V, cycleWeight w (Nat.mul_pos hm hN) (Fin.repeat m x)) =
+        (Finset.univ.image (Fin.repeat m)).sum
+          (cycleWeight w (Nat.mul_pos hm hN)) := by
+      rw [Finset.sum_image]
+      exact (repeat_injective (V := V) hm).injOn
+    _ ≤ ∑ y : Fin (m * N) → V, cycleWeight w (Nat.mul_pos hm hN) y :=
+      Finset.sum_le_sum_of_subset (Finset.image_subset_iff.mpr fun _ _ ↦ Finset.mem_univ _)
+
+private theorem eq_zero_or_one_of_sum_pow_le {I : Type*} [Fintype I]
+    (f : I → ℕ) {m : ℕ} (hm : 1 < m)
+    (h : (∑ i, f i ^ m) ≤ ∑ i, f i) (i : I) :
+    f i = 0 ∨ f i = 1 := by
+  by_contra hi
+  have hfi : 1 < f i := by omega
+  have hpoint : ∀ j : I, f j ≤ f j ^ m := by
+    intro j
+    by_cases hj : f j = 0
+    · simp [hj]
+    · exact Nat.le_pow (Nat.zero_lt_of_lt hm)
+  have hstrict : (∑ j, f j) < ∑ j, f j ^ m := by
+    apply Finset.sum_lt_sum
+    · intro j _
+      exact hpoint j
+    · refine ⟨i, Finset.mem_univ _, ?_⟩
+      simpa only [pow_one] using Nat.pow_lt_pow_right hfi hm
+  exact (Nat.not_lt_of_ge h) hstrict
+
+/-- Every positive-weight ordered cycle has weight one when the ordered-cycle
+weight sum is eventually constant.
+
+In particular, every edge that occurs in a directed cycle has weight one.
+
+Source: Beigi, arXiv:1105.1019v2, equations (7)--(11), source lines 570--593. -/
+theorem cycleWeight_eq_one {w : V → V → ℕ}
+    (hconst : HasEventuallyConstantCycleWeightSum w) {K : ℕ}
+    (hK : 0 < K) (x : Fin K → V) (hx : cycleWeight w hK x ≠ 0) :
+    cycleWeight w hK x = 1 := by
+  rcases hconst with ⟨c, N₀, hconst⟩
+  let t := N₀ + 1
+  let N := t * K
+  have ht : 0 < t := by simp [t]
+  have hN : 0 < N := Nat.mul_pos ht hK
+  have hN₀ : N₀ < N := by
+    exact (Nat.lt_succ_self N₀).trans_le (Nat.le_mul_of_pos_right t hK)
+  have hm : 1 < N + 1 := by omega
+  have hL : 0 < (N + 1) * N := Nat.mul_pos (Nat.succ_pos N) hN
+  have hN₀L : N₀ < (N + 1) * N :=
+    hN₀.trans_le (Nat.le_mul_of_pos_left N (Nat.succ_pos N))
+  have hsumle :
+      (∑ y : Fin N → V, cycleWeight w hN y ^ (N + 1)) ≤
+        ∑ y : Fin N → V, cycleWeight w hN y := by
+    calc
+      (∑ y : Fin N → V, cycleWeight w hN y ^ (N + 1)) ≤
+          cycleWeightSum w hL := sum_cycleWeight_pow_le w hN (Nat.succ_pos N)
+      _ = c := hconst _ hN₀L hL
+      _ = cycleWeightSum w hN := (hconst N hN₀ hN).symm
+  have hy01 := eq_zero_or_one_of_sum_pow_le
+    (fun y : Fin N → V ↦ cycleWeight w hN y) hm hsumle (Fin.repeat t x)
+  have hyne : cycleWeight w hN (Fin.repeat t x) ≠ 0 := by
+    rw [cycleWeight_repeat w hK ht]
+    exact pow_ne_zero _ hx
+  have hyone := hy01.resolve_left hyne
+  rw [cycleWeight_repeat w hK ht] at hyone
+  exact (Nat.pow_eq_one.mp hyone).resolve_right (Nat.ne_of_gt ht)
+
+/-- Every edge belonging to a positive-weight directed cycle has weight one.
+
+Source: Beigi, arXiv:1105.1019v2, equation (11), source lines 587--593. -/
+theorem cyclicEdgeWeight_eq_one {w : V → V → ℕ}
+    (hconst : HasEventuallyConstantCycleWeightSum w) {N : ℕ}
+    (hN : 0 < N) (x : Fin N → V) (hx : cycleWeight w hN x ≠ 0)
+    (i : Fin N) :
+    w (x i) (x (next hN i)) = 1 := by
+  have hprod := cycleWeight_eq_one hconst hN x hx
+  unfold cycleWeight at hprod
+  exact (Finset.prod_eq_one_iff.mp hprod) i (Finset.mem_univ i)
+
+/-- Positive-weight ordered cycles at a fixed positive length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--606. -/
+private def PositiveCycle (w : V → V → ℕ) {N : ℕ} (hN : 0 < N) :=
+  {x : Fin N → V // cycleWeight w hN x ≠ 0}
+
+private noncomputable instance (w : V → V → ℕ) {N : ℕ} (hN : 0 < N) :
+    Fintype (PositiveCycle w hN) := by
+  classical
+  unfold PositiveCycle
+  infer_instance
+
+private theorem positiveCycle_card_eq_cycleWeightSum {w : V → V → ℕ}
+    (hconst : HasEventuallyConstantCycleWeightSum w) {N : ℕ} (hN : 0 < N) :
+    Fintype.card (PositiveCycle w hN) = cycleWeightSum w hN := by
+  classical
+  unfold PositiveCycle
+  rw [Fintype.card_subtype]
+  unfold cycleWeightSum
+  rw [← Finset.sum_filter_ne_zero]
+  rw [Finset.card_eq_sum_ones]
+  apply Finset.sum_congr rfl
+  intro x hx
+  exact (cycleWeight_eq_one hconst hN x (Finset.mem_filter.mp hx).2).symm
+
+/-- Repetition sends a positive-weight ordered cycle to a positive-weight
+ordered cycle.
+
+Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+private noncomputable def repeatPositiveCycle (w : V → V → ℕ) {N m : ℕ}
+    (hN : 0 < N) (hm : 0 < m) :
+    PositiveCycle w hN → PositiveCycle w (Nat.mul_pos hm hN) :=
+  fun x ↦ ⟨Fin.repeat m x.1, by
+    rw [cycleWeight_repeat w hN hm]
+    exact pow_ne_zero _ x.2⟩
+
+omit [Fintype V] in
+private theorem repeatPositiveCycle_injective (w : V → V → ℕ)
+    {N m : ℕ} (hN : 0 < N) (hm : 0 < m) :
+    Function.Injective (repeatPositiveCycle w hN hm) := by
+  intro x y hxy
+  apply Subtype.ext
+  exact (repeat_injective (V := V) hm) (congrArg Subtype.val hxy)
+
+private theorem repeatPositiveCycle_surjective {w : V → V → ℕ}
+    (hconst : HasEventuallyConstantCycleWeightSum w) {N m : ℕ}
+    (hN : 0 < N) (hm : 0 < m)
+    (hsum : cycleWeightSum w hN = cycleWeightSum w (Nat.mul_pos hm hN)) :
+    Function.Surjective (repeatPositiveCycle w hN hm) := by
+  apply ((Fintype.bijective_iff_injective_and_card _).mpr ⟨
+    repeatPositiveCycle_injective w hN hm, ?_⟩).2
+  rw [positiveCycle_card_eq_cycleWeightSum hconst hN,
+    positiveCycle_card_eq_cycleWeightSum hconst (Nat.mul_pos hm hN)]
+  exact hsum
+
+omit [Fintype V] in
+private theorem constant_of_repeat_succ_eq_repeat {N : ℕ} (hN : 0 < N)
+    (y : Fin N → V) (e : Fin (N + 1) → V)
+    (h : Fin.repeat (N + 1) y =
+      Fin.repeat N e ∘ Fin.cast (Nat.mul_comm (N + 1) N)) :
+    ∀ i : Fin N, y i = y ⟨0, hN⟩ := by
+  cases N with
+  | zero => simp at hN
+  | succ n =>
+      intro i
+      induction i using Fin.induction with
+      | zero => rfl
+      | succ i ih =>
+          let p₀ : Fin ((n + 1 + 1) * (n + 1)) :=
+            ⟨i.val, by
+              exact i.isLt.trans_le ((Nat.le_succ n).trans
+                (Nat.le_mul_of_pos_left (n + 1) (by omega)))⟩
+          let p₁ : Fin ((n + 1 + 1) * (n + 1)) :=
+            ⟨i.val + (n + 1) + 1, by
+              have hmul : 2 * (n + 1) ≤ (n + 1 + 1) * (n + 1) :=
+                Nat.mul_le_mul_right (n + 1) (by omega)
+              omega⟩
+          have h₀ := congrFun h p₀
+          have h₁ := congrFun h p₁
+          have hmod₀N : i.val % (n + 1) = i.val := Nat.mod_eq_of_lt (by omega)
+          have hmod₀S : i.val % (n + 1 + 1) = i.val := Nat.mod_eq_of_lt (by omega)
+          have hmod₁N : (i.val + (n + 1) + 1) % (n + 1) = i.val + 1 := by
+            rw [show i.val + (n + 1) + 1 = (i.val + 1) + (n + 1) by omega,
+              Nat.add_mod_right, Nat.mod_eq_of_lt (by omega)]
+          have hmod₁S : (i.val + (n + 1) + 1) % (n + 1 + 1) = i.val := by
+            rw [show i.val + (n + 1) + 1 = i.val + (n + 1 + 1) by omega,
+              Nat.add_mod_right, Nat.mod_eq_of_lt (by omega)]
+          have h₀' : y i.castSucc = e i.castSucc.castSucc := by
+            simp only [Fin.repeat_apply, Function.comp_apply, p₀, Fin.modNat,
+              Fin.cast, hmod₀N, hmod₀S] at h₀
+            convert h₀ using 1 <;> congr 1
+          have h₁' : y i.succ = e i.castSucc.castSucc := by
+            simp only [Fin.repeat_apply, Function.comp_apply, p₁, Fin.modNat,
+              Fin.cast, hmod₁N, hmod₁S] at h₁
+            convert h₁ using 1 <;> congr 1
+          exact h₁'.trans (h₀'.symm.trans ih)
+
+omit [Fintype V] in
+private theorem cycleWeight_cast (w : V → V → ℕ) {N M : ℕ}
+    (hNM : N = M) (hN : 0 < N) (hM : 0 < M) (x : Fin N → V) :
+    cycleWeight w hM (x ∘ Fin.cast hNM.symm) = cycleWeight w hN x := by
+  subst M
+  rfl
+
+/-- Every positive-weight ordered cycle is the repetition of a single loop.
+
+Equivalently, its vertex word is constant.  The proof repeats an arbitrary
+cycle to a sufficiently large length `N`, compares the exhaustive repetition
+maps from lengths `N` and `N+1` into their common multiple, and uses the two
+consecutive periods.
+
+Source: Beigi, arXiv:1105.1019v2, equations (12)--(13), source lines 594--606. -/
+theorem cycle_eq_constant {w : V → V → ℕ}
+    (hconst : HasEventuallyConstantCycleWeightSum w) {K : ℕ}
+    (hK : 0 < K) (x : Fin K → V) (hx : cycleWeight w hK x ≠ 0) :
+    ∀ i : Fin K, x i = x ⟨0, hK⟩ := by
+  rcases hconst with ⟨c, N₀, hlarge⟩
+  let t := N₀ + 1
+  let N := t * K
+  have ht : 0 < t := by simp [t]
+  have hN : 0 < N := Nat.mul_pos ht hK
+  have hN₀ : N₀ < N :=
+    (Nat.lt_succ_self N₀).trans_le (Nat.le_mul_of_pos_right t hK)
+  have hNp : 0 < N + 1 := Nat.succ_pos N
+  have hN₀p : N₀ < N + 1 := hN₀.trans (Nat.lt_succ_self N)
+  have hL₁ : 0 < (N + 1) * N := Nat.mul_pos hNp hN
+  have hL₂ : 0 < N * (N + 1) := Nat.mul_pos hN hNp
+  have hN₀L₁ : N₀ < (N + 1) * N :=
+    hN₀.trans_le (Nat.le_mul_of_pos_left N hNp)
+  have hN₀L₂ : N₀ < N * (N + 1) :=
+    hN₀p.trans_le (Nat.le_mul_of_pos_left (N + 1) hN)
+  let y : PositiveCycle w hN := repeatPositiveCycle w hK ht ⟨x, hx⟩
+  let z : PositiveCycle w hL₁ := repeatPositiveCycle w hN hNp y
+  let z' : PositiveCycle w hL₂ := ⟨
+    z.1 ∘ Fin.cast (Nat.mul_comm N (N + 1)), by
+      rw [cycleWeight_cast w (Nat.mul_comm (N + 1) N) hL₁ hL₂]
+      exact z.2⟩
+  have hsum₂ : cycleWeightSum w hNp = cycleWeightSum w hL₂ := by
+    rw [hlarge (N + 1) hN₀p hNp, hlarge _ hN₀L₂ hL₂]
+  obtain ⟨e, he⟩ := repeatPositiveCycle_surjective
+    ⟨c, N₀, hlarge⟩ hNp hN hsum₂ z'
+  have hrepetition : Fin.repeat (N + 1) y.1 =
+      Fin.repeat N e.1 ∘ Fin.cast (Nat.mul_comm (N + 1) N) := by
+    funext i
+    have hei := congrFun (congrArg Subtype.val he)
+      (Fin.cast (Nat.mul_comm (N + 1) N) i)
+    have hcast : Fin.cast (Nat.mul_comm N (N + 1))
+        (Fin.cast (Nat.mul_comm (N + 1) N) i) = i := by
+      apply Fin.ext
+      rfl
+    simpa only [z', z, repeatPositiveCycle, Function.comp_apply, hcast] using hei.symm
+  have hyconst := constant_of_repeat_succ_eq_repeat hN y.1 e.1 hrepetition
+  intro i
+  let j : Fin N := ⟨i.val, i.isLt.trans_le (by
+    simpa [N, Nat.mul_comm] using Nat.le_mul_of_pos_right K ht)⟩
+  have hj := hyconst j
+  simpa [y, repeatPositiveCycle, j, Fin.repeat, Fin.modNat,
+    Nat.mod_eq_of_lt i.isLt] using hj
+
+/-- Vertices carrying a positive-weight loop.
+
+Source: Beigi, arXiv:1105.1019v2, equation (13), source lines 600--606. -/
+def Loop (w : V → V → ℕ) := {v : V // w v v ≠ 0}
+
+noncomputable instance (w : V → V → ℕ) : Fintype (Loop w) := by
+  classical
+  unfold Loop
+  infer_instance
+
+private noncomputable def positiveCycleEquivLoop {w : V → V → ℕ}
+    (hconst : HasEventuallyConstantCycleWeightSum w) {N : ℕ} (hN : 0 < N) :
+    PositiveCycle w hN ≃ Loop w where
+  toFun x := ⟨x.1 ⟨0, hN⟩, by
+    have hedge := cyclicEdgeWeight_eq_one hconst hN x.1 x.2 ⟨0, hN⟩
+    rw [cycle_eq_constant hconst hN x.1 x.2 (next hN ⟨0, hN⟩)] at hedge
+    omega⟩
+  invFun v := ⟨fun _ ↦ v.1, by
+    unfold cycleWeight
+    simp only
+    exact Finset.prod_ne_zero_iff.mpr fun _ _ ↦ v.2⟩
+  left_inv x := by
+    apply Subtype.ext
+    funext i
+    exact (cycle_eq_constant hconst hN x.1 x.2 i).symm
+  right_inv v := rfl
+
+/-- At every positive length, the ordered-cycle weight sum is the number of
+positive-weight loops.
+
+Source: Beigi, arXiv:1105.1019v2, equation (13), source lines 600--606. -/
+theorem cycleWeightSum_eq_card_loop {w : V → V → ℕ}
+    (hconst : HasEventuallyConstantCycleWeightSum w) {N : ℕ} (hN : 0 < N) :
+    cycleWeightSum w hN = Fintype.card (Loop w) := by
+  rw [← positiveCycle_card_eq_cycleWeightSum hconst hN]
+  exact Fintype.card_congr (positiveCycleEquivLoop hconst hN)
+
+end FiniteWeightedDigraph

--- a/TNLean/MPS/RFP/BeigiEventuallyConstantSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiEventuallyConstantSectorGraph.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.EventuallyConstantCycleWeights
+import TNLean.MPS.RFP.BeigiGroundSpaceDimension
+import TNLean.MPS.RFP.BeigiSectorGraph
+
+/-!
+# Eventually constant Beigi sector graphs
+
+Beigi's finite-chain formula expresses the parent-ground-space dimension as
+the weighted sum of ordered cycles in the sector graph.  If these dimensions
+are eventually constant, the finite graph theorem shows that every cyclic
+edge ground space is one-dimensional and every directed cycle is a repeated
+loop.  Consequently the ground-space dimension at every length covered by
+the parent formula equals the number of loops.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Section IV, equations (7)--(13), source
+  lines 561--606.
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor.BeigiSectorGraphData
+
+open FiniteWeightedDigraph
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+/-- The dimension of the ground space carried by a directed sector edge.
+
+Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
+561--606. -/
+noncomputable def edgeWeight (F : BeigiSectorGraphData A)
+    (a b : Fin F.sectorCount) : ℕ :=
+  Module.finrank ℂ (F.edgeGroundSpace a b)
+
+/-- A sector edge is present exactly when its edge-ground-space dimension is
+nonzero.
+
+Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
+561--606. -/
+theorem isEdge_iff_edgeWeight_ne_zero (F : BeigiSectorGraphData A)
+    (a b : Fin F.sectorCount) :
+    F.IsEdge a b ↔ F.edgeWeight a b ≠ 0 := by
+  constructor
+  · intro hedge hzero
+    exact hedge (Submodule.finrank_eq_zero.mp hzero)
+  · intro hweight hbot
+    exact hweight (Submodule.finrank_eq_zero.mpr hbot)
+
+private theorem next_eq_add_one {N : ℕ} [NeZero N] (hN : 0 < N) (i : Fin N) :
+    FiniteWeightedDigraph.next hN i = i + 1 := by
+  apply Fin.ext
+  simp [FiniteWeightedDigraph.next, Fin.add_def]
+
+/-- The abstract weighted-cycle sum agrees with Beigi's sum over ordered
+sector cycles.
+
+Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
+561--606. -/
+theorem cycleWeightSum_edgeWeight_eq (F : BeigiSectorGraphData A)
+    {N : ℕ} (hN : 0 < N) :
+    letI : NeZero N := ⟨Nat.ne_of_gt hN⟩
+    cycleWeightSum F.edgeWeight hN =
+      ∑ c : F.OrderedCycle N,
+        ∏ n : Fin N, F.edgeWeight (c.1 n) (c.1 (n + 1)) := by
+  classical
+  letI : NeZero N := ⟨Nat.ne_of_gt hN⟩
+  let weight : (Fin N → Fin F.sectorCount) → ℕ := fun k ↦
+    ∏ n : Fin N, F.edgeWeight (k n) (k (n + 1))
+  let cycle : (Fin N → Fin F.sectorCount) → Prop := fun k ↦
+    ∀ n : Fin N, F.IsEdge (k n) (k (n + 1))
+  unfold cycleWeightSum FiniteWeightedDigraph.cycleWeight
+  simp_rw [next_eq_add_one hN]
+  change ∑ k : Fin N → Fin F.sectorCount, weight k =
+    ∑ c : {k // cycle k}, weight c.1
+  calc
+    ∑ k : Fin N → Fin F.sectorCount, weight k =
+        ∑ k ∈ Finset.univ.filter cycle, weight k := by
+      symm
+      apply Finset.sum_subset (Finset.filter_subset cycle Finset.univ)
+      intro k _ hk
+      have hncycle : ¬cycle k := by simpa using hk
+      simp only [cycle, not_forall] at hncycle
+      obtain ⟨n, hn⟩ := hncycle
+      change (∏ m : Fin N, F.edgeWeight (k m) (k (m + 1))) = 0
+      rw [Finset.prod_eq_zero (Finset.mem_univ n)]
+      exact not_ne_iff.mp ((F.isEdge_iff_edgeWeight_ne_zero _ _).not.mp hn)
+    _ = ∑ c : {k // cycle k}, weight c.1 := by
+      exact Finset.sum_subtype (Finset.univ.filter cycle) (by simp) weight
+
+/-- Eventual constancy of the actual parent-ground-space dimension implies
+eventual constancy of the numerical weighted-cycle sum.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--568. -/
+theorem hasEventuallyConstantCycleWeightSum_of_parentGroundSpace
+    (F : BeigiSectorGraphData A)
+    (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
+      Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) = c) :
+    HasEventuallyConstantCycleWeightSum F.edgeWeight := by
+  rcases hparent with ⟨c, N₀, hparent⟩
+  refine ⟨c, max N₀ 2, ?_⟩
+  intro N hN hNpos
+  have hN₀ : N₀ < N := (Nat.le_max_left N₀ 2).trans_lt hN
+  have htwo : 2 < N := (Nat.le_max_right N₀ 2).trans_lt hN
+  rw [F.cycleWeightSum_edgeWeight_eq hNpos]
+  simpa only [edgeWeight] using
+    (F.parentHamiltonianGroundSpaceES_finrank_eq htwo).symm.trans (hparent N hN₀)
+
+/-- If the parent-ground-space dimension is eventually constant, then at
+every length greater than two it equals the number of positive sector loops.
+
+Source: Beigi, arXiv:1105.1019v2, equation (13), source lines 600--606. -/
+theorem parentHamiltonianGroundSpaceES_finrank_eq_card_loop
+    (F : BeigiSectorGraphData A)
+    (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
+      Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) = c)
+    {N : ℕ} (hN : 2 < N) :
+    Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) =
+      Fintype.card (Loop F.edgeWeight) := by
+  have hNpos : 0 < N := by omega
+  letI : NeZero N := ⟨Nat.ne_of_gt hNpos⟩
+  have hconst := F.hasEventuallyConstantCycleWeightSum_of_parentGroundSpace hparent
+  calc
+    Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) =
+        ∑ c : F.OrderedCycle N,
+          ∏ n : Fin N,
+            Module.finrank ℂ (F.edgeGroundSpace (c.1 n) (c.1 (n + 1))) :=
+      F.parentHamiltonianGroundSpaceES_finrank_eq hN
+    _ = cycleWeightSum F.edgeWeight hNpos := by
+      simpa only [edgeWeight] using (F.cycleWeightSum_edgeWeight_eq hNpos).symm
+    _ = Fintype.card (Loop F.edgeWeight) := cycleWeightSum_eq_card_loop hconst hNpos
+
+/-- Transport to Euclidean-space coordinates preserves the dimension of the
+parent ground space. -/
+theorem parentHamiltonianGroundSpaceES_finrank_eq_ker
+    (A : MPSTensor d D) (L N : ℕ) :
+    Module.finrank ℂ (parentHamiltonianGroundSpaceES A L N) =
+      Module.finrank ℂ (LinearMap.ker (parentHamiltonian A L N)) := by
+  unfold parentHamiltonianGroundSpaceES
+  exact LinearEquiv.finrank_map_eq
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm
+    (LinearMap.ker (parentHamiltonian A L N))
+
+/-- In the BNT nearest-neighbor parent-Hamiltonian setting, every finite-chain
+dimension covered by Beigi's cycle formula equals the number of positive
+sector loops.
+
+Source: CPSV16, Definition 3.9 and Theorem 3.10, lines 517--540; Beigi,
+arXiv:1105.1019v2, Section IV, source lines 561--606. -/
+theorem parentHamiltonianGroundSpaceES_finrank_eq_card_loop_of_hasBNTSectorData
+    {P : SectorDecomposition d} (F : BeigiSectorGraphData P.toTensor)
+    (hBNT : HasBNTSectorData P)
+    (hNNCPH : HasNNCPHGroundSpaces P.toTensor P.basis)
+    {N : ℕ} (hN : 2 < N) :
+    Module.finrank ℂ (parentHamiltonianGroundSpaceES P.toTensor 2 N) =
+      Fintype.card (Loop F.edgeWeight) := by
+  rcases hBNT.eventually_parentHamiltonian_groundSpace_finrank_eq hNNCPH with
+    ⟨N₀, hraw⟩
+  have hparent : ∃ c N₁ : ℕ, ∀ M : ℕ, N₁ < M →
+      Module.finrank ℂ (parentHamiltonianGroundSpaceES P.toTensor 2 M) = c := by
+    refine ⟨P.basisCount, N₀, ?_⟩
+    intro M hM
+    rw [parentHamiltonianGroundSpaceES_finrank_eq_ker]
+    exact hraw M hM
+  exact F.parentHamiltonianGroundSpaceES_finrank_eq_card_loop hparent hN
+
+end MPSTensor.BeigiSectorGraphData

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2411,6 +2411,68 @@ specialization of that Appendix~D definition.
     edge contributes zero, leaving exactly the displayed ordered-cycle sum.
 \end{proof}
 
+\begin{theorem}[Classification of eventually constant weighted sector graphs]
+    \label{thm:beigi_eventually_constant_sector_graph}
+    \lean{FiniteWeightedDigraph.cyclicEdgeWeight_eq_one}
+    \lean{FiniteWeightedDigraph.cycle_eq_constant}
+    \lean{FiniteWeightedDigraph.cycleWeightSum_eq_card_loop}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    Let $G$ be a finite directed graph whose edge weights are nonnegative
+    integers, and let
+    \[
+        s_N=\sum_{(a_0,\ldots,a_{N-1})}
+        \prod_{n=0}^{N-1}w(a_n,a_{n+1})
+    \]
+    be the weighted sum over ordered cyclic vertex sequences.  Suppose that
+    $s_N$ is constant for all sufficiently large $N$.  Then every edge that
+    belongs to a directed cycle has weight one, every directed cycle is a
+    repetition of a single loop, and, for every $N>0$,
+    \[
+        s_N=\#\{a:w(a,a)>0\}.
+    \]
+    This is the comparison in
+    \cite[Section~IV]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose a sufficiently large $N$ such that the sums at lengths $N$,
+    $N+1$, and $N(N+1)$ have their common eventual value.  Repeating each
+    ordered $N$-cycle $N+1$ times gives an injection into the cycles of length
+    $N(N+1)$, while repeating each ordered $(N+1)$-cycle $N$ times gives a
+    second injection.  Comparison of the three weighted sums shows first that
+    every positive cyclic weight is one.  Both injections must then be
+    exhaustive.  Hence a cycle at the common length has periods $N$ and
+    $N+1$; comparison of adjacent entries gives period one.  Repeating an
+    arbitrary shorter cycle to a sufficiently large length proves that it is
+    constant.  The only surviving ordered cycles at any positive length are
+    therefore the constant words supported on positive loops, each of weight
+    one.
+\end{proof}
+
+\begin{corollary}[Parent-ground-space dimension is the loop number]
+    \label{cor:beigi_parent_ground_space_loop_number}
+    \lean{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq_card_loop}
+    \lean{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq_card_loop_of_hasBNTSectorData}
+    \leanok
+    \uses{thm:beigi_ordered_cycle_ground_space_dimension,
+        thm:beigi_eventually_constant_sector_graph,
+        thm:nncph_eventual_ground_space_dimension}
+    If the parent-ground-space dimension is eventually constant, then for
+    every $N>2$ it equals the number of positive loops in the sector graph.
+    In particular, this conclusion holds under the BNT and all-chain
+    nearest-neighbor parent-ground-space hypotheses of
+    Theorem~\ref{thm:nncph_eventual_ground_space_dimension}.
+\end{corollary}
+
+\begin{proof}\leanok
+    The ordered-cycle dimension formula identifies the eventual
+    parent-ground-space dimension with the eventual weighted-cycle sum.
+    The preceding theorem identifies that sum, at every positive length, with
+    the loop number.  Transport between coefficient and Euclidean coordinates
+    preserves the dimension of the ground space.
+\end{proof}
+
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -278,6 +278,27 @@ eventual degeneracy, or canonical-form datum is assumed in this sector-graph
 theorem.  The remaining lengths $N=1,2$ require separate periodic-window
 conventions and are tracked by \ghissue{4400}.
 
+The remaining finite graph comparison in Beigi's Section~IV is now proved
+without an axiom.  For a finite directed graph with nonnegative integral edge weights,
+the declarations
+\leanid{FiniteWeightedDigraph.cyclicEdgeWeight_eq_one},
+\leanid{FiniteWeightedDigraph.cycle_eq_constant}, and
+\leanid{FiniteWeightedDigraph.cycleWeightSum_eq_card_loop}
+show that eventual constancy of the ordered-cycle sum forces every cyclic edge
+weight to be one, every directed cycle to be a repeated loop, and every
+positive-length cycle sum to equal the number of positive loops.  The proof
+uses the two repetition maps from consecutive sufficiently large lengths into
+their common product, exactly as in the source.  Applied to the sector datum,
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{parentHamiltonianGroundSpaceES_finrank_eq_card_loop}
+identifies every parent-ground-space dimension with $N>2$ with the loop number
+whenever those dimensions are eventually constant.  Combining this with the
+BNT eventual-dimension theorem gives
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{parentHamiltonianGroundSpaceES_finrank_eq_card_loop_of_hasBNTSectorData}.
+This conclusion does not identify the loop states with the original BNT
+representatives.
+
 \section{Elimination plan}
 
 A source-faithful formalization should replace the remaining axiom-backed
@@ -295,12 +316,12 @@ including the spanning condition in the parent-Hamiltonian ground-space clause:
 The forward commutation implication uses the basic-vector form in
 Theorem~3.11 and the corresponding local projectors.  The reverse implication
 must internalize the remaining part of Beigi's one-dimensional
-nearest-neighbor commuting-Hamiltonian ground-space classification: use
-eventual degeneracy constancy together with the proved finite-sector-graph
-dimension formula to reduce its cycles to loops with one-dimensional cyclic
-edge kernels, and identify the resulting
-locally orthogonal product-of-pairs states with the basis of normal tensors of
-$A$.\footnote{Tracked by \ghissue{2633}.}
+nearest-neighbor commuting-Hamiltonian ground-space classification: identify
+the locally orthogonal product-of-pairs states associated with the proved
+sector loops with the basis of normal tensors of $A$.  Eventual degeneracy
+constancy, one-dimensional cyclic edge kernels, and the reduction of all
+directed cycles to loops are now proved and require no axiom.\footnote{Tracked
+by \ghissue{2633}.}
 
 The current proof boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
@@ -321,9 +342,10 @@ canonical form is subject to the source obstruction recorded in
 ground-space spanning clause and the multiplicity-one distinct-sector
 extension are proved. The repeated-copy and arbitrary-raw-weight extension
 remains open.  In the reverse direction, eventual ground-space dimension
-stability, the local spatial decomposition, and the ordered-cycle sector-graph
-dimension formula are proved.  The reduction of this graph under eventual
-constancy and its identification with the basis of normal tensors remain open.
+stability, the local spatial decomposition, the ordered-cycle dimension
+formula, and the reduction of the sector graph to one-dimensional loops are
+proved.  The identification of the resulting loop states with the basis of
+normal tensors remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- This PR formalizes the finite weighted-graph argument in Beigi, arXiv:1105.1019v2, Section IV, source TeX lines 561–606, especially equations `eq:comparing1`–`eq:comparing4`, `eq:dim-ker-q`, and `eq:deg-loops`.
- The source compares the cycle sums at sufficiently large consecutive lengths `N` and `N+1` with their repetitions at `N(N+1)`. Eventual constancy forces cyclic edge weights to be one and every directed cycle to be a repeated loop.
- This closes the graph-classification part of #2633 while retaining the later identification of loop product states with the original BNT basis as an explicit open boundary. It also advances #232.

### Description

- Add a finite weighted-digraph theorem independent of MPS and BNT hypotheses. The proof uses the two source repetition maps at lengths `N`, `N+1`, and `N(N+1)`, proves that positive cyclic weights equal one, proves exhaustivity by finite cardinality, and derives period one from the two consecutive periods.
- Specialize the theorem to `BeigiSectorGraphData`: derive eventual constancy from the actual parent-ground-space dimension and prove that every ground-space dimension with `N > 2` equals the number of positive sector loops.
- Add the BNT and all-chain nearest-neighbor parent-ground-space consequence without placing BNT assumptions in the purely graph-theoretic statement.
- Add a blueprint theorem and proof, and update `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` so that only the loop-state/BNT identification remains open.
- Keep `TNLean.lean` at exactly 1000 lines.

### Testing

- `lake env lean TNLean/Algebra/EventuallyConstantCycleWeights.lean`
- `lake env lean TNLean/MPS/RFP/BeigiEventuallyConstantSectorGraph.lean`
- `lake build TNLean`
- `lake build`
- `lake exe lint_style`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base HEAD^`
- Proof-integrity scan covering all blockers and warnings in `docs/PROOF_INTEGRITY.md`
- `git diff HEAD^ --check`

Closes #4391
Advances #2633 and #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive formalization and documentation with no runtime, auth, or data-path changes; main residual risk is proof correctness in new combinatorial lemmas.
> 
> **Overview**
> Formalizes **Beigi Section IV**’s finite weighted-graph argument: if ordered cyclic edge-weight sums are eventually constant, then cyclic edges have weight one, every directed cycle is a repeated loop, and each length’s sum equals the number of positive loops.
> 
> New module `EventuallyConstantCycleWeights.lean` proves this in `FiniteWeightedDigraph` via repetition injections at lengths `N`, `N+1`, and `N(N+1)`. `BeigiEventuallyConstantSectorGraph.lean` maps sector **edge ground-space dimensions** to those weights, derives eventual constancy from stable parent ground-space dimension, and shows **`N > 2` dimensions equal `Fintype.card (Loop …)`**, including under BNT + all-chain NNCPH hypotheses.
> 
> Blueprint chapter 13 and `cpsv16_nncph_ground_state_scope.tex` are updated so graph reduction is proved; **identifying loop product states with the BNT basis** stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e58add9b3344f1746d6392b0e8498adfada7f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->