### PR TITLE
docs(tenkz): migrate BNT fusion identity

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -306,17 +306,50 @@ them.
     Definition~\ref{def:mpdo_bnt_label_idempotent_coefficient_form}.
 \end{definition}
 
-The following compact display depicts the sitewise identity
-$U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^{\dagger}
- =\bigoplus_\gamma\chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}$ from
+For fixed labels $\alpha,\beta$, put
+$G_{\alpha,\beta}^{ij}=\bigoplus_\gamma
+\chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}$.  Then
 \cite[Theorem~4.14(iii), equation~(89), lines~986--991]
-{Cirac2016MPDO_arXiv}.  Its arrangement follows the physical isometry and
-weighted direct-sum decomposition in
-\cite[Proposition~4.13, lines~943--959]{Cirac2016MPDO_arXiv}.
-\begin{center}
-    \centering
-    \TNMPDOBNTFusionIdentity
-\end{center}
+{Cirac2016MPDO_arXiv} gives
+% For fixed \alpha,\beta,
+%   U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}U_{\alpha,\beta}^{\dagger}
+%     = G_{\alpha,\beta}^{ij},
+%   G_{\alpha,\beta}^{ij}
+%     = \bigoplus_\gamma \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}.
+% Coefficientwise, with x,y,i,j free,
+%   (G_{\alpha,\beta}^{ij})_{x,y}
+%     = \sum_{q,a_1,a_2,b_1,b_2}
+%       (U_{\alpha,\beta})_{x,(a_1,b_1)}
+%       (M_\alpha^{iq})_{a_1,a_2}(M_\beta^{qj})_{b_1,b_2}
+%       (U_{\alpha,\beta}^{\dagger})_{(a_2,b_2),y}.
+% Thus q,a_1,a_2,b_1,b_2 are contracted.  For
+% x=(\gamma,r,a) and y=(\gamma',r',a'),
+%   (G_{\alpha,\beta}^{ij})_{(\gamma,r,a),(\gamma',r',a')}
+%     = \delta_{\gamma,\gamma'}(\chi_{\alpha,\beta,\gamma})_{r,r'}
+%       (M_\gamma^{ij})_{a,a'},
+% or, since chi is diagonal,
+%   \delta_{\gamma,\gamma'}\delta_{r,r'}\chi_{\alpha,\beta,\gamma;r}
+%       (M_\gamma^{ij})_{a,a'}.
+% The sector \gamma is a direct-sum block label, not a contraction index.
+% Ink-to-index map: the combined west and east fuser legs are x and y;
+% the north and south physical legs are i and j; the unique inter-row
+% pairleg is q; and the four fuser-to-tensor strands carry a_1,b_1,a_2,b_2.
+% The left and right objects each have boundary signature (1,1,1,1).
+% The single G_{\alpha,\beta} atom has no internal contraction.  The cited
+% source states the algebraic identity and direct-sum decomposition, but
+% contains no dedicated diagram for U_{\alpha,\beta}.
+\par\noindent\hfil
+\tnpic[rows={op,op}]{
+    \tnfuse[combined=west]{U_{\alpha,\beta}} &
+    \tn[mpo, up=$i$]{M_\alpha} &
+    \tnfuse[combined=east]{U_{\alpha,\beta}^{\dagger}} \\
+    & \tn[mpo, down=$j$]{M_\beta} &
+}
+\qquad$=$\qquad
+\tnpic[physical=updown]{
+    \tn[mpo, up=$i$, down=$j$]{G_{\alpha,\beta}}
+}
+\hfil\par
 
 \begin{theorem}[Weighted zipper identities]%
     \label{thm:mpdo_bnt_weighted_zipper}

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -189,47 +189,6 @@
     \end{TNDiagram}%
 }
 
-% Local BNT fusion identity from CPSV16, eq. (Ualphabeta).  The left-hand
-% isometry combines the two incoming bond factors, while its adjoint separates
-% the outgoing factors.  The right-hand side records the weighted final-sector
-% direct sum without introducing an F-move.
-\TNDeclareDiagram
-    {TNMPDOBNTFusionIdentity}
-    {}
-    {display}
-    {compact}
-    {\TNMPDOBNTFusionIdentity}
-    {chapter/ch21_mpdo_rfp_fusion_isometries.tex}{%
-    \begin{TNEquationRow}[compact]
-        \TNTerm{%
-            \TNSplitMap{bfiU}{at=origin}{U_{\alpha,\beta}}
-            \TNStackedMPOProduct{bfiProduct}{right=of bfiU}
-                {M_\alpha}{M_\beta}{}
-            \TNMergeMap{bfiUd}{right=of bfiProductUpper}
-                {U_{\alpha,\beta}^{\dagger}}
-            \TNConnectVirtual{bfiUFactorOne}{bfiProductUpperWest}
-            \TNConnectVirtual{bfiUFactorTwo}{bfiProductLowerWest}
-            \TNConnectVirtual{bfiProductUpperEast}{bfiUdFactorOne}
-            \TNConnectVirtual{bfiProductLowerEast}{bfiUdFactorTwo}
-            \TNOpenVirtualWest{bfiUCombined}
-            \TNOpenVirtualEast{bfiUdCombined}
-            \TNOpenPhysicalNorth{bfiProductUpperKet}
-            \TNOpenPhysicalSouth{bfiProductLowerBra}
-            \TNLabelAbove{bfiProductUpperKetOpen}{i}
-            \TNLabelBelow{bfiProductLowerBraOpen}{j}}
-        \TNRelation{=\displaystyle\bigoplus_\gamma}
-        \TNTerm{%
-            \TNWeightedMPOBlock{bfiBlock}{at=origin}
-                {M_\gamma}{M_\gamma}{}{\chi_{\alpha,\beta,\gamma}}
-            \TNOpenVirtualWest{bfiBlockWeightW}
-            \TNOpenVirtualEast{bfiBlockWeightedEast}
-            \TNOpenVirtualWest{bfiBlockLowerWest}
-            \TNOpenVirtualEast{bfiBlockLowerEast}
-            \TNOpenPhysicalNorth{bfiBlockUpperKet}
-            \TNOpenPhysicalSouth{bfiBlockLowerBra}}
-    \end{TNEquationRow}%
-}
-
 % The two unweighted zipper directions and the resulting reconstruction of a
 % product letter.  This follows the graphical arrangement of the zipper
 % figures in Bultinck et al., arXiv:1511.08090, while using the notation of


### PR DESCRIPTION
## Summary

- replace the sole Chapter 21 `\TNMPDOBNTFusionIdentity` call with the native two-row fuser spelling
- represent the right-hand side by the single aggregate tensor `G_{\alpha,\beta}`
- delete only the now-unused catalogue declaration

The adjacent comments record the exact fusion identity, its coefficient expansion, the free and contracted indices, both boundary signatures, the ink-to-index map, and the fact that the cited source gives an algebraic identity rather than a dedicated diagram.

Closes LionSR/tenkz#49

## Mathematical check

The displayed identity is

```text
U_{alpha,beta} (M_alpha M_beta)^{ij} U_{alpha,beta}^dagger
  = G_{alpha,beta}^{ij},
G_{alpha,beta}^{ij}
  = direct-sum_gamma chi_{alpha,beta,gamma} tensor M_gamma^{ij}.
```

The left object keeps `x,y,i,j` free and contracts the physical index `q` together with the four bond indices `a_1,a_2,b_1,b_2`. The right object is one aggregate `G` atom; the sector label `gamma` is not drawn as a contraction.

## Verification

- focused XeLaTeX compile and `tenkz_audit.py`: no hard errors
  - left: four horizontal bonds, one inter-row pairleg, boundary `(1,1,1,1)`
  - right: one MPO atom, no internal contraction, boundary `(1,1,1,1)`
- focused and actual Chapter 21 pages inspected at 600 dpi
- all 19 `tex/tenkz/examples/*.tex` compile and audit
- `docs/tenkz/manual2.tex` compiles twice and audits without hard errors
- four tenkz Python regression scripts pass
- strict `tn_diagrams.py` check/audit/smoke-render gate passes (61 SVGs)
- 114-file tenkz lint passes
- `git diff --check` passes
- required repository phrase scans are empty

The local macOS reference rasterizer cannot reproduce the approved reference images: the ordinary comparison reports `1.0000` for all seven unchanged fixtures, and the all-registered margin check eventually reports no visible ink for `TNPEPSLatticeState`. No package or reference file changes are present; the strict 61-diagram PDF-fallback smoke render passes, so CI is the authoritative reference check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-source migration only; no Lean or runtime logic changes, with mathematical content preserved via `G_{\alpha,\beta}` and audit-oriented comments.
> 
> **Overview**
> **Chapter 21** replaces the catalogue macro `\TNMPDOBNTFusionIdentity` with an inline **tenkz** display: west/east `\tnfuse` around a two-row stacked product `M_\alpha M_\beta`, equated to a single aggregate MPO atom `G_{\alpha,\beta}` (the weighted direct sum folded into one tensor).
> 
> The prose now defines `G_{\alpha,\beta}^{ij}` explicitly and adds commented notes on the coefficient expansion, which indices contract vs stay free, boundary signature `(1,1,1,1)`, and the ink-to-index map.
> 
> **`tex/tn/tn_catalogue.tex`** drops the unused `\TNDeclareDiagram{TNMPDOBNTFusionIdentity}{...}` block (~40 lines); other chapter diagrams are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0925379392ccc3231623a65ecc37e901f1f074e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->