### PR TITLE
feat(Channel/FixedPoint): export faithful fixed point

### DIFF
--- a/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
@@ -25,6 +25,8 @@ adjoint projection is a positive unital retraction.
 
 open scoped Matrix Matrix.Norms.Frobenius
 
+universe u
+
 variable {D : ℕ}
 
 /-- A matrix endomorphism is trace-preserving if and only if its trace-pairing
@@ -35,7 +37,8 @@ sources `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines
 723--737, and `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
 226--256. -/
 theorem isTracePreservingMap_iff_traceAdjointMap_one
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} :
+    {n : Type u} [Fintype n] [DecidableEq n]
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
     IsTracePreservingMap T ↔ Matrix.traceAdjointMap T 1 = 1 := by
   constructor
   · intro hTP

--- a/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
@@ -25,8 +25,6 @@ adjoint projection is a positive unital retraction.
 
 open scoped Matrix Matrix.Norms.Frobenius
 
-universe u
-
 variable {D : ℕ}
 
 /-- A matrix endomorphism is trace-preserving if and only if its trace-pairing
@@ -37,7 +35,7 @@ sources `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines
 723--737, and `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines
 226--256. -/
 theorem isTracePreservingMap_iff_traceAdjointMap_one
-    {n : Type u} [Fintype n] [DecidableEq n]
+    {n : Type*} [Fintype n] [DecidableEq n]
     {T : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
     IsTracePreservingMap T ↔ Matrix.traceAdjointMap T 1 = 1 := by
   constructor

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
@@ -284,9 +284,4 @@ theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_spa
   change 1 - Matrix.traceAdjointMap T 1 = 0 at hGapZero
   have hAdjointOneEq : Matrix.traceAdjointMap T 1 = 1 :=
     (sub_eq_zero.mp hGapZero).symm
-  intro X
-  calc
-    Matrix.trace (T X) = Matrix.trace (1 * T X) := by simp
-    _ = Matrix.trace (Matrix.traceAdjointMap T 1 * X) :=
-      (Matrix.trace_traceAdjointMap_mul T 1 X).symm
-    _ = Matrix.trace X := by rw [hAdjointOneEq]; simp
+  exact isTracePreservingMap_iff_traceAdjointMap_one.mpr hAdjointOneEq

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean
@@ -24,6 +24,7 @@ place them in the spanning argument.
 
 ## Main results
 
+* `IsPositiveMap.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span`
 * `IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span`
 
 ## References
@@ -41,18 +42,19 @@ variable {D : ℕ}
 
 open Kraus
 
-/-- A positive trace-nonincreasing endomorphism is trace preserving when the
-identity lies in the span of positive-length products of a fixed family.
+/-- A positive trace-nonincreasing endomorphism has a positive-definite fixed
+point when the identity lies in the span of positive-length products of a
+fixed family.
 
 No product is assumed to be fixed.  The fixed factors lie on the support of
 the mean-ergodic image of the identity, so their products do as well.  The
-product-span hypothesis forces this support to be the identity.  Faithfulness
-then makes the positive trace-loss functional vanish.
+product-span hypothesis forces this support to be the identity.
 
 This is the channel-hypothesis step used at arXiv:1606.00608, Appendix C.4.
 Lines 1974--1980 supply the fixed contraction factors; lines 1980--1995
 supply their spanning context. -/
-private theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span_fin
+private theorem
+    IsPositiveMap.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span_fin
     {J : Type*}
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T)
@@ -61,7 +63,7 @@ private theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_pro
     (hOne : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
       Submodule.span ℂ (Set.range fun x : Fin L → J =>
         (List.ofFn fun t => V (x t)).prod)) :
-    IsTracePreservingMap T := by
+    ∃ ρ : Matrix (Fin D) (Fin D) ℂ, ρ.PosDef ∧ T ρ = ρ := by
   classical
   let hbounded := hT.hasBoundedOrbits_of_traceNonincreasing hTNI
   let ρ := LinearMap.meanErgodicProjection (𝕜 := ℂ)
@@ -132,41 +134,20 @@ private theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_pro
   have hQone : Q = 1 := by
     simpa [hQidem] using hOneSupport
   have hρposDef : ρ.PosDef := hρ.posDef_of_supportProj_eq_one hQone
-  let gap : Matrix (Fin D) (Fin D) ℂ :=
-    1 - Matrix.traceAdjointMap T 1
-  have hAdjointOne : (Matrix.traceAdjointMap T 1).PosSemidef :=
-    IsPositiveMap.traceAdjointMap hT 1 Matrix.PosSemidef.one
-  have hGapHermitian : gap.IsHermitian := by
-    exact Matrix.IsHermitian.sub Matrix.isHermitian_one hAdjointOne.isHermitian
-  have hGap : gap.PosSemidef := by
-    apply Matrix.PosSemidef.of_forall_trace_mul_nonneg hGapHermitian
-    intro X hX
-    have hloss : 0 ≤ Matrix.trace X - Matrix.trace (T X) :=
-      sub_nonneg.mpr (hTNI X hX)
-    simpa only [gap, Matrix.sub_mul, Matrix.trace_sub, Matrix.one_mul,
-      Matrix.trace_traceAdjointMap_mul] using hloss
-  have hGapTrace : Matrix.trace (ρ * gap) = 0 := by
-    calc
-      Matrix.trace (ρ * gap) = Matrix.trace (gap * ρ) := Matrix.trace_mul_comm _ _
-      _ = Matrix.trace ρ - Matrix.trace (T ρ) := by
-        simp only [gap, Matrix.sub_mul, Matrix.trace_sub, Matrix.one_mul,
-          Matrix.trace_traceAdjointMap_mul]
-      _ = 0 := by rw [hρfixed, sub_self]
-  have hGapZero : gap = 0 :=
-    Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hGap hρposDef hGapTrace
-  apply isTracePreservingMap_iff_traceAdjointMap_one.mpr
-  change 1 - Matrix.traceAdjointMap T 1 = 0 at hGapZero
-  exact (sub_eq_zero.mp hGapZero).symm
+  exact ⟨ρ, hρposDef, hρfixed⟩
 
-/-- A positive trace-nonincreasing endomorphism of a finite matrix algebra is
-trace preserving when the identity lies in the span of positive-length
-products of a fixed family.
+/-- A positive trace-nonincreasing endomorphism of a finite matrix algebra has
+a positive-definite fixed point when the identity lies in the span of
+positive-length products of a fixed family.
 
-This coordinate-free finite-index form is obtained from the preceding
-`Fin`-indexed argument by simultaneous matrix reindexing.  In
-arXiv:1606.00608, Appendix C.4, lines 1974--1980 supply the fixed factors to
-which this criterion is applied. -/
-theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span
+No product is assumed to be fixed. The maximal-support fixed point contains
+every fixed factor, hence every positive-length product of those factors. The
+spanning hypothesis makes its support the whole matrix algebra.
+
+This is the faithful fixed-point step used in arXiv:1606.00608, Appendix C.4,
+lines 1980--1995, before applying the density-block classification of the
+fixed-point space. -/
+theorem IsPositiveMap.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span
     {n J : Type*} [Fintype n] [DecidableEq n]
     {T : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T)
@@ -175,7 +156,7 @@ theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_spa
     (hOne : (1 : Matrix n n ℂ) ∈
       Submodule.span ℂ (Set.range fun x : Fin L → J =>
         (List.ofFn fun t => V (x t)).prod)) :
-    IsTracePreservingMap T := by
+    ∃ ρ : Matrix n n ℂ, ρ.PosDef ∧ T ρ = ρ := by
   classical
   let e : n ≃ Fin (Fintype.card n) := Fintype.equivFin n
   let Φ := Matrix.reindexLinearEquiv ℂ ℂ e e
@@ -241,14 +222,71 @@ theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_spa
         rw [_root_.map_smul]
         exact Submodule.smul_mem productSpanFin c hX)
       hOne
-  have hTPFin : IsTracePreservingMap TFin :=
-    hTFin.tracePreserving_of_traceNonincreasing_of_fixed_product_span_fin
+  obtain ⟨ρFin, hρFin, hρFinFixed⟩ :=
+    hTFin.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span_fin
       hTNIFin VFin L hL hFixedFin hOneFin
-  intro A
-  have h := hTPFin (Matrix.reindex e e A)
-  change Matrix.trace
-      (Matrix.reindex e e
-        (T (Matrix.reindex e.symm e.symm (Matrix.reindex e e A)))) =
-      Matrix.trace (Matrix.reindex e e A) at h
-  rw [hreindex_symm] at h
-  simpa only [Matrix.trace_reindex] using h
+  let ρ := Φ.symm ρFin
+  have hρ : ρ.PosDef := by
+    exact hρFin.reindex e.symm
+  have hρFixed : T ρ = ρ := by
+    have hΦρ : Φ ρ = ρFin := Φ.apply_symm_apply ρFin
+    apply Φ.injective
+    calc
+      Φ (T ρ) = TFin (Φ ρ) := by
+        change Matrix.reindex e e (T ρ) = Matrix.reindex e e
+          (T (Matrix.reindex e.symm e.symm (Matrix.reindex e e ρ)))
+        rw [hreindex_symm]
+      _ = Φ ρ := by rw [hΦρ, hρFinFixed]
+  exact ⟨ρ, hρ, hρFixed⟩
+
+/-- A positive trace-nonincreasing endomorphism of a finite matrix algebra is
+trace preserving when the identity lies in the span of positive-length
+products of a fixed family.
+
+This coordinate-free finite-index form is obtained from the preceding
+`Fin`-indexed argument by simultaneous matrix reindexing.  In
+arXiv:1606.00608, Appendix C.4, lines 1974--1980 supply the fixed factors to
+which this criterion is applied. -/
+theorem IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span
+    {n J : Type*} [Fintype n] [DecidableEq n]
+    {T : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (hT : IsPositiveMap T) (hTNI : IsTraceNonincreasingMap T)
+    (V : J → Matrix n n ℂ) (L : ℕ) (hL : 0 < L)
+    (hFixed : ∀ j, T (V j) = V j)
+    (hOne : (1 : Matrix n n ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J =>
+        (List.ofFn fun t => V (x t)).prod)) :
+    IsTracePreservingMap T := by
+  obtain ⟨ρ, hρposDef, hρfixed⟩ :=
+    hT.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span
+      hTNI V L hL hFixed hOne
+  let gap : Matrix n n ℂ := 1 - Matrix.traceAdjointMap T 1
+  have hAdjointOne : (Matrix.traceAdjointMap T 1).PosSemidef :=
+    IsPositiveMap.traceAdjointMap hT 1 Matrix.PosSemidef.one
+  have hGapHermitian : gap.IsHermitian := by
+    exact Matrix.IsHermitian.sub Matrix.isHermitian_one hAdjointOne.isHermitian
+  have hGap : gap.PosSemidef := by
+    apply Matrix.PosSemidef.of_forall_trace_mul_nonneg hGapHermitian
+    intro X hX
+    have hloss : 0 ≤ Matrix.trace X - Matrix.trace (T X) :=
+      sub_nonneg.mpr (hTNI X hX)
+    simpa only [gap, Matrix.sub_mul, Matrix.trace_sub, Matrix.one_mul,
+      Matrix.trace_traceAdjointMap_mul] using hloss
+  have hGapTrace : Matrix.trace (ρ * gap) = 0 := by
+    calc
+      Matrix.trace (ρ * gap) = Matrix.trace (gap * ρ) := Matrix.trace_mul_comm _ _
+      _ = Matrix.trace ρ - Matrix.trace (T ρ) := by
+        simp only [gap, Matrix.sub_mul, Matrix.trace_sub, Matrix.one_mul,
+          Matrix.trace_traceAdjointMap_mul]
+      _ = 0 := by rw [hρfixed, sub_self]
+  have hGapZero : gap = 0 :=
+    Matrix.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero hGap hρposDef hGapTrace
+  change 1 - Matrix.traceAdjointMap T 1 = 0 at hGapZero
+  have hAdjointOneEq : Matrix.traceAdjointMap T 1 = 1 :=
+    (sub_eq_zero.mp hGapZero).symm
+  intro X
+  calc
+    Matrix.trace (T X) = Matrix.trace (1 * T X) := by simp
+    _ = Matrix.trace (Matrix.traceAdjointMap T 1 * X) :=
+      (Matrix.trace_traceAdjointMap_mul T 1 X).symm
+    _ = Matrix.trace X := by rw [hAdjointOneEq]; simp

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -22,7 +22,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \label{def:positive_map_is_positive_linear_map}
     \lean{IsPositiveMap.toPositiveLinearMap}
     \leanok
-    \uses{def:positive_map}
+    \uses{def:positive_map, def:has_bounded_orbits}
     A positive matrix map $E : \MN{n} \to \MN{m}$ determines the same
     linear map regarded as a positive linear map: if
     $A,B\in\MN{n}$ and $A \le B$, then $E(A) \le E(B)$ in $\MN{m}$.

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1041,6 +1041,25 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     of the mean-ergodic projection gives the conclusion.
 \end{proof}
 
+\begin{theorem}[Bounded orbits from trace nonincrease]
+    \label{thm:positive_trace_nonincreasing_bounded_orbits}
+    \lean{IsPositiveMap.hasBoundedOrbits_of_traceNonincreasing}
+    \leanok
+    \uses{def:positive_map}
+    Let $T:\MN{D}\to\MN{D}$ be positive and trace nonincreasing.  Then the
+    forward orbit $\{T^n(X):n\geq 0\}$ is bounded for every $X\in\MN{D}$.
+    This is the trace-nonincreasing form of
+    \cite[Proposition~6.3]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    For $X\succeq 0$, positivity and trace nonincrease place every iterate
+    $T^n(X)$ in a bounded trace section of the positive cone.  Apply this to
+    the positive and negative parts of a Hermitian matrix, and then write an
+    arbitrary matrix as a complex linear combination of two Hermitian
+    matrices.
+\end{proof}
+
 \begin{theorem}[Positive trace-preserving mean-ergodic projection]
     \label{thm:positive_trace_preserving_mean_ergodic_projection}
     \lean{IsPositiveMap.hasBoundedOrbits_of_tracePreserving,
@@ -1067,6 +1086,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 
 \begin{proof}\leanok
     \uses{thm:mean_ergodic_bounded_orbits,
+        thm:positive_trace_nonincreasing_bounded_orbits,
         thm:positive_mean_ergodic_projection,
         thm:trace_preserving_mean_ergodic_projection,
         thm:unital_mean_ergodic_projection}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1095,16 +1095,10 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
         thm:positive_mean_ergodic_projection,
         thm:trace_preserving_mean_ergodic_projection,
         thm:unital_mean_ergodic_projection}
-    If $X\ge 0$, then $T^n(X)\ge 0$ and
-    $\tr(T^n(X))=\tr(X)$. Hence the orbit of $X$ lies in a bounded trace
-    section of the positive cone. For Hermitian $X$, write
-    $X=X_+-X_-$, and for arbitrary $X$ use the two Hermitian matrices
-    \[
-        H_1=X+X^*,\qquad H_2=i(X-X^*),\qquad
-        X=\frac12(H_1-iH_2).
-    \]
-    Thus every orbit is bounded. Theorem~\ref{thm:mean_ergodic_bounded_orbits}
-    gives the projection and its fixed-point characterization. Its positivity,
+    Trace preservation implies trace nonincrease, so
+    Theorem~\ref{thm:positive_trace_nonincreasing_bounded_orbits} gives
+    bounded orbits.  Theorem~\ref{thm:mean_ergodic_bounded_orbits} then gives
+    the projection and its fixed-point characterization.  Its positivity,
     trace preservation, and behavior on the identity follow from the three
     preceding theorems.
 \end{proof}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -22,7 +22,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \label{def:positive_map_is_positive_linear_map}
     \lean{IsPositiveMap.toPositiveLinearMap}
     \leanok
-    \uses{def:positive_map, def:has_bounded_orbits}
+    \uses{def:positive_map}
     A positive matrix map $E : \MN{n} \to \MN{m}$ determines the same
     linear map regarded as a positive linear map: if
     $A,B\in\MN{n}$ and $A \le B$, then $E(A) \le E(B)$ in $\MN{m}$.
@@ -1045,7 +1045,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \label{thm:positive_trace_nonincreasing_bounded_orbits}
     \lean{IsPositiveMap.hasBoundedOrbits_of_traceNonincreasing}
     \leanok
-    \uses{def:positive_map}
+    \uses{def:positive_map, def:has_bounded_orbits}
     Let $T:\MN{D}\to\MN{D}$ be positive and trace nonincreasing.  Then the
     forward orbit $\{T^n(X):n\geq 0\}$ is bounded for every $X\in\MN{D}$.
     This is the trace-nonincreasing form of
@@ -1053,11 +1053,16 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    For $X\succeq 0$, positivity and trace nonincrease place every iterate
-    $T^n(X)$ in a bounded trace section of the positive cone.  Apply this to
-    the positive and negative parts of a Hermitian matrix, and then write an
-    arbitrary matrix as a complex linear combination of two Hermitian
-    matrices.
+    For $X\succeq 0$, positivity and induction on $n$ give
+    \[
+        T^n(X)\succeq 0,
+        \qquad
+        \tr(T^n(X))\leq\tr(X).
+    \]
+    Thus the orbit lies in a bounded trace section of the positive cone.
+    Apply this to the positive and negative parts of a Hermitian matrix, and
+    then write an arbitrary matrix as a complex linear combination of two
+    Hermitian matrices.
 \end{proof}
 
 \begin{theorem}[Positive trace-preserving mean-ergodic projection]

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1089,8 +1089,9 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \lean{isTracePreservingMap_iff_traceAdjointMap_one}
     \leanok
     \uses{def:trace_preserving, def:trace_pairing_adjoint}
-    A linear map $S:\MN{D}\to\MN{D}$ is trace-preserving if and only if its
-    trace-pairing adjoint fixes the identity:
+    On any finite full matrix algebra, a linear endomorphism $S$ is
+    trace-preserving if and only if its trace-pairing adjoint fixes the
+    identity:
     \[
         (\forall X,\; \tr(S(X))=\tr(X))
         \quad\Longleftrightarrow\quad

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3020,7 +3020,8 @@ transfers the support.
     \label{thm:maximalSupport_fixedPoint_of_bounded_orbits}
     \lean{IsPositiveMap.exists_maximalSupport_fixedPoint_of_hasBoundedOrbits}
     \leanok
-    \uses{def:positive_map, def:mean_ergodic_projection, def:support_proj}
+    \uses{def:positive_map, def:has_bounded_orbits,
+        def:mean_ergodic_projection, def:support_proj}
     Let $T:\MN{D}\to\MN{D}$ be positive and have bounded orbits, and let
     $T_\infty$ be its mean-ergodic projection.  Then
     $\rho_0=T_\infty(\Id)$ is positive semidefinite and fixed by $T$.  If

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3016,6 +3016,36 @@ transfers the support.
     Hermitian.
 \end{proof}
 
+\begin{theorem}[A fixed point of maximal support from bounded orbits]%
+    \label{thm:maximalSupport_fixedPoint_of_bounded_orbits}
+    \lean{IsPositiveMap.exists_maximalSupport_fixedPoint_of_hasBoundedOrbits}
+    \leanok
+    \uses{def:positive_map, def:mean_ergodic_projection, def:support_proj}
+    Let $T:\MN{D}\to\MN{D}$ be positive and have bounded orbits, and let
+    $T_\infty$ be its mean-ergodic projection.  Then
+    $\rho_0=T_\infty(\Id)$ is positive semidefinite and fixed by $T$.  If
+    $Q_0$ is the support projection of $\rho_0$, then every fixed point $X$
+    of $T$ satisfies
+    \[
+        Q_0\,X\,Q_0=X.
+    \]
+    This is the bounded-orbit form of the maximal-support argument underlying
+    \cite[Proposition~6.9]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:positive_mean_ergodic_projection,
+        thm:mean_ergodic_bounded_orbits,
+        thm:positive_map_conjTranspose, thm:hermitian_fixedpoint_parts,
+        thm:psd_le_trace_smul_one, lem:stationaryProj_absorb_of_le}
+    Positivity of the mean-ergodic projection gives $\rho_0\succeq 0$, while
+    its range and idempotence give $T(\rho_0)=\rho_0$.  Decompose a fixed
+    point into fixed Hermitian parts and dominate their positive and negative
+    parts by scalar multiples of $\rho_0$.  The support-absorption lemma then
+    gives $Q_0XQ_0=X$.
+\end{proof}
+
 \begin{theorem}[A fixed point of maximal support]%
     \label{thm:maximalSupport_fixedPoint}
     \lean{IsPositiveMap.exists_maximalSupport_fixedPoint}
@@ -3036,46 +3066,10 @@ transfers the support.
 \begin{proof}
     \leanok
     \uses{thm:positive_trace_preserving_mean_ergodic_projection,
-        thm:positive_map_conjTranspose, thm:hermitian_fixedpoint_parts,
-        thm:psd_le_trace_smul_one, lem:stationaryProj_absorb_of_le}
-    Positivity of the mean-ergodic projection gives $\rho_0\succeq 0$, while its range
-    and idempotence give $T(\rho_0)=\rho_0$.  Each fixed point $X$ splits into fixed
-    Hermitian components:
-    \[
-        H_1 = X + X^{\dagger},
-        \qquad
-        H_2 = i\,\bigl(X - X^{\dagger}\bigr),
-    \]
-    Both are Hermitian fixed points (the conjugate transpose of a fixed point is fixed),
-    and
-    \[
-        X \;=\; \tfrac{1}{2}\,H_1 - \tfrac{i}{2}\,H_2.
-    \]
-    By the decomposition of Hermitian fixed points into positive parts
-    (Theorem~\ref{thm:hermitian_fixedpoint_parts}) there are positive semidefinite fixed
-    points with
-    \[
-        H_1 = P^{+}_1 - P^{-}_1,
-        \qquad
-        H_2 = P^{+}_2 - P^{-}_2.
-    \]
-    If $P\succeq0$ is any of these positive fixed points, then
-    $\tr(P)\Id-P\succeq0$. Positivity of $T_\infty$ and
-    $T_\infty(P)=P$ give
-    \[
-        \tr(P)\rho_0-P
-        =T_\infty\!\left(\tr(P)\Id-P\right)\succeq0.
-    \]
-    Thus $P\preceq\tr(P)\rho_0$, and scalar domination transfers the support, so
-    $Q_0P Q_0=P$. Substituting this identity into the two positive-part decompositions
-    gives
-    \[
-        Q_0\, H_k\, Q_0 = H_k,
-        \qquad
-        Q_0\, X\, Q_0
-        = \tfrac{1}{2}\,Q_0 H_1 Q_0 - \tfrac{i}{2}\,Q_0 H_2 Q_0
-        = X.
-    \]
+        thm:maximalSupport_fixedPoint_of_bounded_orbits}
+    Theorem~\ref{thm:positive_trace_preserving_mean_ergodic_projection} gives
+    bounded orbits.  Apply
+    Theorem~\ref{thm:maximalSupport_fixedPoint_of_bounded_orbits}.
 \end{proof}
 
 \begin{theorem}[Restriction to the support of a stationary positive matrix]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3037,13 +3037,23 @@ transfers the support.
     \leanok
     \uses{thm:positive_mean_ergodic_projection,
         thm:mean_ergodic_bounded_orbits,
-        thm:positive_map_conjTranspose, thm:hermitian_fixedpoint_parts,
-        thm:psd_le_trace_smul_one, lem:stationaryProj_absorb_of_le}
+        thm:positive_map_conjTranspose, thm:psd_le_trace_smul_one,
+        lem:stationaryProj_absorb_of_le}
     Positivity of the mean-ergodic projection gives $\rho_0\succeq 0$, while
-    its range and idempotence give $T(\rho_0)=\rho_0$.  Decompose a fixed
-    point into fixed Hermitian parts and dominate their positive and negative
-    parts by scalar multiples of $\rho_0$.  The support-absorption lemma then
-    gives $Q_0XQ_0=X$.
+    its range and idempotence give $T(\rho_0)=\rho_0$.  If $A\succeq0$, then
+    $A\preceq\tr(A)\Id$; applying the positive map $T_\infty$ gives
+    \[
+        T_\infty(A)\preceq\tr(A)\rho_0.
+    \]
+    Hence the support projection $Q_0$ absorbs $T_\infty(A)$.  For a fixed
+    Hermitian matrix $H$, write $H=H^+-H^-$.  Since
+    $T_\infty(H)=H$, linearity gives
+    \[
+        H=T_\infty(H^+)-T_\infty(H^-),
+    \]
+    so $Q_0HQ_0=H$.  Finally decompose an arbitrary fixed point into two
+    Hermitian fixed matrices, using preservation of conjugate transpose, and
+    conclude that $Q_0XQ_0=X$.
 \end{proof}
 
 \begin{theorem}[A fixed point of maximal support]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3049,8 +3049,11 @@ transfers the support.
         \qquad
         T_\infty(A)\preceq\tr(A)\rho_0.
     \]
-    Hence the support projection $Q_0$ absorbs $T_\infty(A)$.  For a fixed
-    Hermitian matrix $H$, write $H=H^+-H^-$.  Since
+    Scalar domination therefore gives
+    \[
+        Q_0\,T_\infty(A)\,Q_0=T_\infty(A).
+    \]
+    For a fixed Hermitian matrix $H$, write $H=H^+-H^-$.  Since
     $T_\infty(H)=H$, linearity gives
     \[
         H=T_\infty(H^+)-T_\infty(H^-),

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -3043,6 +3043,9 @@ transfers the support.
     its range and idempotence give $T(\rho_0)=\rho_0$.  If $A\succeq0$, then
     $A\preceq\tr(A)\Id$; applying the positive map $T_\infty$ gives
     \[
+        \tr(A)\rho_0-T_\infty(A)
+        =T_\infty\!\left(\tr(A)\Id-A\right)\succeq0,
+        \qquad
         T_\infty(A)\preceq\tr(A)\rho_0.
     \]
     Hence the support projection $Q_0$ absorbs $T_\infty(A)$.  For a fixed

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1570,9 +1570,13 @@ physical indices, as in
     \[
       QV_jQ=V_j.
     \]
-    Since $Q$ is a projection, this implies
-    $QV_j=V_j=V_jQ$, and therefore every positive-length product of the
-    $V_j$ is supported on $Q$.  The product-span hypothesis then gives
+    Since $Q$ is a projection, this implies $QV_j=V_j=V_jQ$.  By induction,
+    \[
+      Q\cdot V_{j_1}\cdots V_{j_k}\cdot Q
+        =V_{j_1}\cdots V_{j_k}
+      \qquad (k\geq1).
+    \]
+    The product-span hypothesis then gives
     $Q\mathbf 1Q=\mathbf 1$, so $Q=\mathbf 1$.  Thus $\rho$ is positive
     definite, and the construction of $P$ gives $F(\rho)=\rho$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1550,11 +1550,12 @@ physical indices, as in
     \leanok
     Let $F:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace
     nonincreasing.  Suppose that a family $(V_j)_{j\in J}$ consists of fixed
-    points of $F$ and that, for some $L>0$, the products
+    points of $F$ and that, for some $L>0$, the identity belongs to the
+    linear span of the products
     \[
       V_{j_1}\cdots V_{j_L}
     \]
-    span $M_D(\mathbb C)$.  Then $F$ has a positive-definite fixed point.
+    in $M_D(\mathbb C)$.  Then $F$ has a positive-definite fixed point.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -1566,7 +1567,7 @@ physical indices, as in
     \]
     for every $j$.  Since $Q$ is a projection, this implies
     $QV_j=V_j=V_jQ$, and therefore every positive-length product of the
-    $V_j$ is supported on $Q$.  The spanning hypothesis then gives
+    $V_j$ is supported on $Q$.  The product-span hypothesis then gives
     $Q\mathbf 1Q=\mathbf 1$, so $Q=\mathbf 1$.  Thus $\rho$ is positive
     definite, and the construction of $P$ gives $F(\rho)=\rho$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1556,9 +1556,14 @@ physical indices, as in
       V_{j_1}\cdots V_{j_L}
     \]
     in $\mathcal M$.  Then $F$ has a positive-definite fixed point.
+    This is the local full-matrix intermediate implication used in
+    \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}; it is not
+    stated there as a separate theorem.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:positive_trace_nonincreasing_bounded_orbits,
+      thm:maximalSupport_fixedPoint_of_bounded_orbits}
     Boundedness of the forward orbits gives the mean-ergodic projection $P$.
     Set $\rho=P(\mathbf 1)$ and let $Q$ be the support projection of $\rho$.
     For every $j$, the maximal-support property of $\rho$ gives
@@ -1574,9 +1579,7 @@ physical indices, as in
 
 \begin{theorem}[Trace preservation of the transported vertical-sector maps]
     \label{thm:mpdo_transported_vertical_sector_composites_trace_preserving}
-    \lean{IsPositiveMap.hasBoundedOrbits_of_traceNonincreasing,
-      IsPositiveMap.exists_maximalSupport_fixedPoint_of_hasBoundedOrbits,
-      IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span,
+    \lean{IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span,
       Matrix.IsPositiveDirectSumMap.%
         tracePreserving_of_traceNonincreasing_of_fixed_product_span,
       Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1543,8 +1543,8 @@ physical indices, as in
     \]
 \end{proof}
 
-\begin{lemma}[Faithful fixed point from fixed product generators]
-    \label{lem:positive_map_faithful_fixed_point_from_product_span}
+\begin{theorem}[Faithful fixed point from fixed product generators]
+    \label{thm:positive_map_faithful_fixed_point_from_product_span}
     \lean{IsPositiveMap.%
       exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span}
     \leanok
@@ -1556,7 +1556,7 @@ physical indices, as in
       V_{j_1}\cdots V_{j_L}
     \]
     in $M_D(\mathbb C)$.  Then $F$ has a positive-definite fixed point.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Boundedness of the forward orbits gives the mean-ergodic projection $P$.
@@ -1582,7 +1582,7 @@ physical indices, as in
       Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing,
       MPOTensor.transportedVerticalSector_composites_tracePreserving}
     \leanok
-    \uses{lem:positive_map_faithful_fixed_point_from_product_span,
+    \uses{thm:positive_map_faithful_fixed_point_from_product_span,
       lem:mpdo_transported_vertical_sector_fixed_generators,
       thm:mpdo_vertical_bond_contractions_generate_sector_algebra,
       thm:mpdo_transported_vertical_sector_trace_loss}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1548,24 +1548,24 @@ physical indices, as in
     \lean{IsPositiveMap.%
       exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span}
     \leanok
-    Let $F:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace
-    nonincreasing.  Suppose that a family $(V_j)_{j\in J}$ consists of fixed
-    points of $F$ and that, for some $L>0$, the identity belongs to the
-    linear span of the products
+    Let $\mathcal M$ be a finite full matrix algebra over $\mathbb C$, and let
+    $F:\mathcal M\to\mathcal M$ be positive and trace nonincreasing.  Suppose
+    that a family $(V_j)_{j\in J}$ consists of fixed points of $F$ and that,
+    for some $L>0$, the identity belongs to the linear span of the products
     \[
       V_{j_1}\cdots V_{j_L}
     \]
-    in $M_D(\mathbb C)$.  Then $F$ has a positive-definite fixed point.
+    in $\mathcal M$.  Then $F$ has a positive-definite fixed point.
 \end{theorem}
 
 \begin{proof}\leanok
     Boundedness of the forward orbits gives the mean-ergodic projection $P$.
     Set $\rho=P(\mathbf 1)$ and let $Q$ be the support projection of $\rho$.
-    The maximal-support property of $\rho$ gives
+    For every $j$, the maximal-support property of $\rho$ gives
     \[
-      QV_jQ=V_j
+      QV_jQ=V_j.
     \]
-    for every $j$.  Since $Q$ is a projection, this implies
+    Since $Q$ is a projection, this implies
     $QV_j=V_j=V_jQ$, and therefore every positive-length product of the
     $V_j$ is supported on $Q$.  The product-span hypothesis then gives
     $Q\mathbf 1Q=\mathbf 1$, so $Q=\mathbf 1$.  Thus $\rho$ is positive

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1543,6 +1543,34 @@ physical indices, as in
     \]
 \end{proof}
 
+\begin{lemma}[Faithful fixed point from fixed product generators]
+    \label{lem:positive_map_faithful_fixed_point_from_product_span}
+    \lean{IsPositiveMap.%
+      exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span}
+    \leanok
+    Let $F:M_D(\mathbb C)\to M_D(\mathbb C)$ be positive and trace
+    nonincreasing.  Suppose that a family $(V_j)_{j\in J}$ consists of fixed
+    points of $F$ and that, for some $L>0$, the products
+    \[
+      V_{j_1}\cdots V_{j_L}
+    \]
+    span $M_D(\mathbb C)$.  Then $F$ has a positive-definite fixed point.
+\end{lemma}
+
+\begin{proof}\leanok
+    Boundedness of the forward orbits gives the mean-ergodic projection $P$.
+    Set $\rho=P(\mathbf 1)$ and let $Q$ be the support projection of $\rho$.
+    The maximal-support property of $\rho$ gives
+    \[
+      QV_jQ=V_j
+    \]
+    for every $j$.  Since $Q$ is a projection, this implies
+    $QV_j=V_j=V_jQ$, and therefore every positive-length product of the
+    $V_j$ is supported on $Q$.  The spanning hypothesis then gives
+    $Q\mathbf 1Q=\mathbf 1$, so $Q=\mathbf 1$.  Thus $\rho$ is positive
+    definite, and the construction of $P$ gives $F(\rho)=\rho$.
+\end{proof}
+
 \begin{theorem}[Trace preservation of the transported vertical-sector maps]
     \label{thm:mpdo_transported_vertical_sector_composites_trace_preserving}
     \lean{IsPositiveMap.hasBoundedOrbits_of_traceNonincreasing,
@@ -1553,7 +1581,8 @@ physical indices, as in
       Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing,
       MPOTensor.transportedVerticalSector_composites_tracePreserving}
     \leanok
-    \uses{lem:mpdo_transported_vertical_sector_fixed_generators,
+    \uses{lem:positive_map_faithful_fixed_point_from_product_span,
+      lem:mpdo_transported_vertical_sector_fixed_generators,
       thm:mpdo_vertical_bond_contractions_generate_sector_algebra,
       thm:mpdo_transported_vertical_sector_trace_loss}
     Suppose that every one-site and two-site multiplicity space is nonzero

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1646,33 +1646,16 @@ physical indices, as in
 \end{theorem}
 
 \begin{proof}\leanok
-    Each transported map is positive and trace nonincreasing.  Hence the same
-    is true of either square composite $F$.  For $X\geq0$ and $n\geq0$,
+    Each transported map is positive and trace nonincreasing, and hence so is
+    either square composite $F$.  The preceding fixed-generator lemma and
+    product-spanning theorem give the hypotheses of
+    Theorem~\ref{thm:positive_map_faithful_fixed_point_from_product_span},
+    applied to the canonical full-matrix extension of the sector algebra.
+    Thus there is a positive-definite fixed point $\rho$:
     \[
-      0\leq\operatorname{tr}(F^n(X))
-        \leq\operatorname{tr}(X).
+      \rho\succ0,
+      \qquad F(\rho)=\rho.
     \]
-    Thus positive orbits remain in a bounded trace section; decomposition
-    into Hermitian parts gives bounded orbits for every input.  Let $P$ be the
-    mean-ergodic projection of $F$, set $\rho=P(\mathbf 1)$, and let $Q$ be
-    the support projection of $\rho$.  Positivity of $P$ implies that every
-    fixed operator is supported on $Q$.
-
-    The preceding fixed-generator lemma places every weighted vertical bond
-    contraction $V_j$ in the fixed-point space.  The support absorption
-    identities give
-    \[
-      QV_jQ=V_j,
-      \qquad QV_j=V_j=V_jQ,
-    \]
-    and hence, for every positive-length product,
-    \[
-      Q(V_{j_1}\cdots V_{j_L})
-        =V_{j_1}\cdots V_{j_L}
-        =(V_{j_1}\cdots V_{j_L})Q.
-    \]
-    These products span the sector algebra, so their common support contains
-    the identity.  Therefore $Q=\mathbf 1$ and $\rho$ is positive definite.
 
     Let $F^*$ be the trace adjoint and set
     \[
@@ -1684,8 +1667,8 @@ physical indices, as in
     $F$ implies that $\Delta$ is Hermitian.  Hence $\Delta\geq0$.  Since
     $F(\rho)=\rho$, one has $\operatorname{tr}(\rho\Delta)=0$.
     Positive definiteness of $\rho$ therefore forces $\Delta=0$, which is
-    equivalent to trace preservation.  This argument uses fixedness only of
-    the contraction factors, not of their products.
+    equivalent to trace preservation.  The faithful-fixed-point theorem uses
+    fixedness only of the contraction factors, not of their products.
 
     Finally, for positive $X$ the two trace-nonincreasing inequalities give
     \[

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -170,6 +170,15 @@ distinguished vertical bond contraction.  Since positive-length products of
 these contractions span the whole sector algebra, their common support must
 contain the identity.  Hence $\rho$ is positive definite.
 
+The full-matrix statement of this intermediate conclusion is now
+formalized: a positive trace-nonincreasing endomorphism with fixed factors
+whose products of one positive length span the matrix algebra has a
+positive-definite fixed point.  No product is required to be fixed.  The
+remaining fixed-point argument for the transported composites must still
+pass this statement through the finite direct sums and combine it with the
+density-block dimension bound; the present result alone does not prove that
+either composite is the identity.
+
 Let $F^*$ be the trace adjoint and define the trace-loss operator
 \[
   \Delta=\mathbf 1-F^*(\mathbf 1).

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -171,13 +171,17 @@ these contractions span the whole sector algebra, their common support must
 contain the identity.  Hence $\rho$ is positive definite.
 
 The full-matrix statement of this intermediate conclusion is now
-formalized: a positive trace-nonincreasing endomorphism with fixed factors
-for which the identity lies in the span of the products of one positive
-length has a positive-definite fixed point.  No product is required to be
-fixed.  The remaining fixed-point argument for the transported composites
-must still pass this statement through the finite direct sums and combine it
-with the density-block dimension bound; the present result alone does not
-prove that either composite is the identity.
+formalized.\footnote{Formal declaration:
+\leanid{IsPositiveMap.%
+exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span}
+in \doclink{TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan}.}
+A positive trace-nonincreasing endomorphism with fixed factors for which the
+identity lies in the span of the products of one positive length has a
+positive-definite fixed point.  No product is required to be fixed.  The
+remaining fixed-point argument for the transported composites must still pass
+this statement through the finite direct sums and combine it with the
+density-block dimension bound; the present result alone does not prove that
+either composite is the identity.
 
 Let $F^*$ be the trace adjoint and define the trace-loss operator
 \[

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -172,12 +172,12 @@ contain the identity.  Hence $\rho$ is positive definite.
 
 The full-matrix statement of this intermediate conclusion is now
 formalized: a positive trace-nonincreasing endomorphism with fixed factors
-whose products of one positive length span the matrix algebra has a
-positive-definite fixed point.  No product is required to be fixed.  The
-remaining fixed-point argument for the transported composites must still
-pass this statement through the finite direct sums and combine it with the
-density-block dimension bound; the present result alone does not prove that
-either composite is the identity.
+for which the identity lies in the span of the products of one positive
+length has a positive-definite fixed point.  No product is required to be
+fixed.  The remaining fixed-point argument for the transported composites
+must still pass this statement through the finite direct sums and combine it
+with the density-block dimension bound; the present result alone does not
+prove that either composite is the identity.
 
 Let $F^*$ be the trace adjoint and define the trace-loss operator
 \[


### PR DESCRIPTION
## Summary

- exports the positive-definite fixed point constructed by the product-span trace-preservation argument
- refactors trace preservation to use the exported theorem
- records the faithful fixed-point stage in the blueprint and the vertical-sector paper-gap note

## Mathematical scope

The new theorem isolates the faithful fixed-point step used in CPSV16, Appendix C.4, lines 1980–1995: a positive trace-nonincreasing endomorphism with fixed factors has a positive-definite fixed point when, at one positive length, the identity lies in the linear span of products of those factors. It assumes neither fixedness of products, multiplicativity, active-image range inclusions, nor invertibility.

This PR advances only the faithful fixed-point stage. It does not yet prove the canonical direct-sum complete-positivity and adjoint-Schwarz lift, the Wolf fixed-space finrank bound, or the two identity composites. The remaining route is documented in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`.

## Validation

- `lake env lean TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan.lean`
- `lake build TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan`
- `lake build TNLean`
- declaration check for `IsPositiveMap.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span`
- proof-integrity and whitespace scans

Advances #4418.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and documentation of existing fixed-point/channel math in Lean; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Splits the CPSV16 Appendix C.4 “faithful fixed point” step into its own Lean theorem**, then derives trace preservation from it.
> 
> Under positivity, trace nonincrease, fixed generators `V_j`, and a hypothesis that **1 lies in the span of length-`L` products** of those generators, the PR adds `IsPositiveMap.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span`, proving a **positive-definite** `ρ` with `T ρ = ρ`. The proof is unchanged in spirit: mean-ergodic `ρ = P_T(1)`, maximal-support projection `Q`, product-span forcing `Q = 1`, hence full support. **`tracePreserving_of_traceNonincreasing_of_fixed_product_span`** now obtains this `ρ` first and reuses the existing trace-loss / trace-adjoint gap argument.
> 
> **`isTracePreservingMap_iff_traceAdjointMap_one`** is generalized from `Fin D` to arbitrary finite index types `n`.
> 
> Blueprint and the vertical-sector paper-gap note are updated: bounded orbits from trace nonincrease, maximal-support fixed points from bounded orbits, the new faithful fixed-point theorem, and shorter proofs that cite these instead of inlining the argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824d7a8918caffb57d6dec115c6154860d65156d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->