### PR TITLE
feat(MPS/RFP): construct Beigi loop tensors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -631,6 +631,7 @@ import TNLean.MPS.RFP.BeigiGroundSpaceDimension
 import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BeigiSectorGraph
 import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
+import TNLean.MPS.RFP.BeigiLoopTensor
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 -- Layer 6a: Quantum Wielandt span-growth infrastructure
@@ -654,7 +655,6 @@ import TNLean.Wielandt.Inequality.EigenvectorSpreading
 import TNLean.Wielandt.Inequality.MatrixSpanExistence
 import TNLean.Wielandt.Inequality.MatrixSpanSharpBound
 import TNLean.Wielandt.Inequality.Bounds
-
 -- Layer 6c: Conditional Wielandt arguments
 -- These modules support specialized span-growth and aperiodicity routes. They
 -- are not on the active canonical / FT / BNT path, but they remain root-visible

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -655,6 +655,7 @@ import TNLean.Wielandt.Inequality.EigenvectorSpreading
 import TNLean.Wielandt.Inequality.MatrixSpanExistence
 import TNLean.Wielandt.Inequality.MatrixSpanSharpBound
 import TNLean.Wielandt.Inequality.Bounds
+
 -- Layer 6c: Conditional Wielandt arguments
 -- These modules support specialized span-growth and aperiodicity routes. They
 -- are not on the active canonical / FT / BNT path, but they remain root-visible

--- a/TNLean/MPS/Periodic/Applications.lean
+++ b/TNLean/MPS/Periodic/Applications.lean
@@ -53,6 +53,64 @@ def rotatePhysical (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) : MPSTen
     (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) (i : Fin d) :
     rotatePhysical M A i = ∑ j : Fin d, M i j • A j := rfl
 
+/-- Expanding a word of a physically rotated tensor gives the sitewise matrix
+coefficients multiplying the corresponding unrotated words. -/
+theorem evalWord_rotatePhysical_ofFn
+    (M : Matrix (Fin d) (Fin d) ℂ) (A : MPSTensor d D) :
+    ∀ (N : ℕ) (s : Fin N → Fin d),
+      evalWord (rotatePhysical M A) (List.ofFn s) =
+        ∑ t : Fin N → Fin d,
+          (∏ n : Fin N, M (s n) (t n)) • evalWord A (List.ofFn t) := by
+  intro N
+  induction N with
+  | zero =>
+      intro s
+      classical
+      simp
+  | succ N ih =>
+      intro s
+      classical
+      rw [List.ofFn_succ, evalWord_cons, rotatePhysical_apply]
+      rw [ih (fun n : Fin N => s n.succ)]
+      rw [Finset.sum_mul_sum]
+      let e : (Fin d × (Fin N → Fin d)) ≃ (Fin (N + 1) → Fin d) :=
+        Fin.consEquiv (fun _ => Fin d)
+      have hreindex :
+          (∑ t : Fin (N + 1) → Fin d,
+              (∏ n : Fin (N + 1), M (s n) (t n)) •
+                evalWord A (List.ofFn t)) =
+            ∑ p : Fin d × (Fin N → Fin d),
+              (∏ n : Fin (N + 1), M (s n) (e p n)) •
+                evalWord A (List.ofFn (e p)) :=
+        (Fintype.sum_equiv e
+          (f := fun p : Fin d × (Fin N → Fin d) =>
+            (∏ n : Fin (N + 1), M (s n) (e p n)) •
+              evalWord A (List.ofFn (e p)))
+          (g := fun t : Fin (N + 1) → Fin d =>
+            (∏ n : Fin (N + 1), M (s n) (t n)) •
+              evalWord A (List.ofFn t))
+          (by intro p; rfl)).symm
+      rw [hreindex, ← Fintype.sum_prod_type']
+      refine Finset.sum_congr rfl ?_
+      rintro ⟨i, t⟩ _
+      have hprod :
+          (∏ n : Fin (N + 1), M (s n) (e (i, t) n)) =
+            M (s 0) i * ∏ n : Fin N, M (s n.succ) (t n) := by
+        rw [Fin.prod_univ_succ]
+        simp [e, Fin.consEquiv]
+      have hlist : List.ofFn (e (i, t)) = i :: List.ofFn t := by
+        simp [e, Fin.consEquiv]
+      rw [hprod, hlist, evalWord_cons, smul_mul_smul_comm]
+
+/-- The matrix product vector of a physical-index rotation is the sitewise
+matrix action on the original matrix product vector. -/
+theorem mpv_rotatePhysical (M : Matrix (Fin d) (Fin d) ℂ)
+    (A : MPSTensor d D) {N : ℕ} (s : Fin N → Fin d) :
+    mpv (rotatePhysical M A) s =
+      ∑ t : Fin N → Fin d, (∏ n : Fin N, M (s n) (t n)) * mpv A t := by
+  rw [mpv, coeff, evalWord_rotatePhysical_ofFn, Matrix.trace_sum]
+  simp only [Matrix.trace_smul, smul_eq_mul, mpv, coeff]
+
 /-- Symmetry-to-virtual-gauge theorem.
 
 If `A` is injective and has the same MPV family as its physical-leg rotation

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -1,0 +1,230 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
+
+/-!
+# Matrix product tensors associated with Beigi loops
+
+For a positive loop in Beigi's sector graph, choose a nonzero vector in the
+corresponding edge ground space.  Its components couple the right factor at
+one site to the left factor at the next site.  This cyclic product is a
+translation-invariant matrix product vector: the virtual index is the left
+factor of the loop sector, and the local matrix has entries
+\[
+  A^{(r,l)}_{a,b}=\delta_{a,l}\,\varphi(r,b).
+\]
+The one-site unitary in the spatial decomposition then transports this tensor
+back to the original physical coordinates.
+
+This is the product-of-pairs state in Beigi's construction.  It is distinct
+from a product over disjoint pairs of physical sites.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Section IV, source lines 602--606.
+-/
+
+open scoped BigOperators Matrix
+
+namespace MPSTensor.BeigiSectorGraphData
+
+open FiniteWeightedDigraph
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+private theorem evalWord_physicalMix_ofFn
+    {m E : ℕ} (B : MPSTensor d E) (W : Matrix (Fin m) (Fin d) ℂ) :
+    ∀ (N : ℕ) (s : Fin N → Fin m),
+      evalWord (fun i : Fin m => ∑ j : Fin d, W i j • B j) (List.ofFn s) =
+        ∑ t : Fin N → Fin d,
+          (∏ n : Fin N, W (s n) (t n)) • evalWord B (List.ofFn t) := by
+  intro N
+  induction N with
+  | zero =>
+      intro s
+      classical
+      simp
+  | succ N ih =>
+      intro s
+      classical
+      rw [List.ofFn_succ, evalWord_cons]
+      rw [ih (fun n : Fin N => s n.succ)]
+      rw [Finset.sum_mul_sum]
+      let e : (Fin d × (Fin N → Fin d)) ≃ (Fin (N + 1) → Fin d) :=
+        Fin.consEquiv (fun _ => Fin d)
+      have hreindex :
+          (∑ t : Fin (N + 1) → Fin d,
+              (∏ n : Fin (N + 1), W (s n) (t n)) •
+                evalWord B (List.ofFn t)) =
+            ∑ p : Fin d × (Fin N → Fin d),
+              (∏ n : Fin (N + 1), W (s n) (e p n)) •
+                evalWord B (List.ofFn (e p)) :=
+        (Fintype.sum_equiv e
+          (f := fun p : Fin d × (Fin N → Fin d) =>
+            (∏ n : Fin (N + 1), W (s n) (e p n)) •
+              evalWord B (List.ofFn (e p)))
+          (g := fun t : Fin (N + 1) → Fin d =>
+            (∏ n : Fin (N + 1), W (s n) (t n)) •
+              evalWord B (List.ofFn t))
+          (by intro p; rfl)).symm
+      rw [hreindex, ← Fintype.sum_prod_type']
+      refine Finset.sum_congr rfl ?_
+      rintro ⟨i, t⟩ _
+      have hprod :
+          (∏ n : Fin (N + 1), W (s n) (e (i, t) n)) =
+            W (s 0) i * ∏ n : Fin N, W (s n.succ) (t n) := by
+        rw [Fin.prod_univ_succ]
+        simp [e, Fin.consEquiv]
+      have hlist : List.ofFn (e (i, t)) = i :: List.ofFn t := by
+        simp [e, Fin.consEquiv]
+      rw [hprod, hlist, evalWord_cons, smul_mul_smul_comm]
+
+/-- A nonzero vector in the edge ground space carried by a positive loop.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+noncomputable def loopBondVector (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) :
+    Matrix.EtaEdgeIndex F.leftDim F.rightDim l.1 l.1 → ℂ :=
+  Classical.choose <| Submodule.exists_mem_ne_zero_of_ne_bot <|
+    (F.isEdge_iff_edgeWeight_ne_zero l.1 l.1).2 l.2
+
+/-- The chosen loop vector belongs to its edge ground space. -/
+theorem loopBondVector_mem (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) :
+    F.loopBondVector l ∈ F.edgeGroundSpace l.1 l.1 :=
+  (Classical.choose_spec <| Submodule.exists_mem_ne_zero_of_ne_bot <|
+    (F.isEdge_iff_edgeWeight_ne_zero l.1 l.1).2 l.2).1
+
+/-- The chosen loop vector is nonzero. -/
+theorem loopBondVector_ne_zero (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) :
+    F.loopBondVector l ≠ 0 :=
+  (Classical.choose_spec <| Submodule.exists_mem_ne_zero_of_ne_bot <|
+    (F.isEdge_iff_edgeWeight_ne_zero l.1 l.1).2 l.2).2
+
+/-- The sector-coordinate tensor associated with a positive loop.
+
+For a physical coordinate in the loop sector, the row index records the local
+left factor and the column index is contracted with the next site's left
+factor.  The matrix entry is the corresponding component of the loop bond
+vector.  Coordinates in every other sector give the zero matrix.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+noncomputable def loopCoordinateTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : MPSTensor d (F.leftDim l.1) :=
+  fun i a b ↦
+    if hq : (F.sectorEquiv.symm i).1 = l.1 then
+      if a = Fin.cast (congrArg F.leftDim hq) (F.sectorEquiv.symm i).2.2 then
+        F.loopBondVector l
+          (Fin.cast (congrArg F.rightDim hq) (F.sectorEquiv.symm i).2.1, b)
+      else 0
+    else 0
+
+/-- The physical loop tensor obtained by applying the spatial-decomposition
+unitary to the sector-coordinate tensor.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+noncomputable def loopTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : MPSTensor d (F.leftDim l.1) :=
+  fun i ↦ ∑ j : Fin d, F.unitary i j • F.loopCoordinateTensor l j
+
+private def loopLeftIndex (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} (s : Fin N → Fin d)
+    (hsector : ∀ n, (F.sectorEquiv.symm (s n)).1 = l.1) (n : Fin N) :
+    Fin (F.leftDim l.1) :=
+  Fin.cast (congrArg F.leftDim (hsector n))
+    (F.sectorEquiv.symm (s n)).2.2
+
+private def loopRightIndex (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} (s : Fin N → Fin d)
+    (hsector : ∀ n, (F.sectorEquiv.symm (s n)).1 = l.1) (n : Fin N) :
+    Fin (F.rightDim l.1) :=
+  Fin.cast (congrArg F.rightDim (hsector n))
+    (F.sectorEquiv.symm (s n)).2.1
+
+/-- The cyclic product of copies of the loop bond vector in sector coordinates.
+
+The right factor at site `n` is paired with the left factor at site `n + 1`.
+The value is zero unless every site belongs to the chosen loop sector.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+noncomputable def loopCyclicProduct (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N]
+    (s : Fin N → Fin d) : ℂ :=
+  if hsector : ∀ n, (F.sectorEquiv.symm (s n)).1 = l.1 then
+    ∏ n : Fin N, F.loopBondVector l
+      (F.loopRightIndex l s hsector n, F.loopLeftIndex l s hsector (n + 1))
+  else 0
+
+/-- The physical product-of-pairs state associated with a positive loop.
+
+It is the sitewise unitary image of the cyclic product whose bonds join the
+right factor at site `n` to the left factor at site `n + 1`.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+noncomputable def loopProductState (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] : NSiteSpace d N :=
+  fun s ↦ ∑ t : Fin N → Fin d,
+    (∏ n : Fin N, F.unitary (s n) (t n)) * F.loopCyclicProduct l t
+
+/-- The sector-coordinate loop tensor closes to the cyclic product of loop
+bond vectors at every positive length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem mpv_loopCoordinateTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
+    mpv (F.loopCoordinateTensor l) s = F.loopCyclicProduct l s := by
+  classical
+  rw [mpv, coeff, trace_evalWord_eq_sum_cyclic]
+  unfold loopCyclicProduct
+  by_cases hsector : ∀ n, (F.sectorEquiv.symm (s n)).1 = l.1
+  · rw [dif_pos hsector]
+    let g : Fin N → Fin (F.leftDim l.1) := F.loopLeftIndex l s hsector
+    rw [Finset.sum_eq_single g]
+    · apply Finset.prod_congr rfl
+      intro n _
+      simp only [loopCoordinateTensor, hsector n, ↓reduceDIte, g]
+      rw [if_pos (by rfl)]
+      simp only [loopRightIndex]
+    · intro b _ hb
+      have hdiff : ∃ n, b n ≠ g n := by
+        by_contra h
+        apply hb
+        funext n
+        exact not_ne_iff.mp (not_exists.mp h n)
+      obtain ⟨n, hn⟩ := hdiff
+      rw [Finset.prod_eq_zero (Finset.mem_univ n)]
+      simp only [loopCoordinateTensor, hsector n, ↓reduceDIte]
+      rw [if_neg (by simpa only [g, loopLeftIndex] using hn)]
+    · simp
+  · rw [dif_neg hsector]
+    apply Finset.sum_eq_zero
+    intro g _
+    simp only [not_forall] at hsector
+    obtain ⟨n, hn⟩ := hsector
+    rw [Finset.prod_eq_zero (Finset.mem_univ n)]
+    simp only [loopCoordinateTensor, hn, ↓reduceDIte]
+
+/-- The periodic matrix product vector of `loopTensor` is exactly Beigi's
+physical product-of-pairs state at every positive chain length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem mpv_loopTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
+    mpv (F.loopTensor l) s = F.loopProductState l s := by
+  change Matrix.trace
+      (evalWord (fun i : Fin d => ∑ j : Fin d,
+        F.unitary i j • F.loopCoordinateTensor l j) (List.ofFn s)) = _
+  rw [evalWord_physicalMix_ofFn, Matrix.trace_sum]
+  simp only [Matrix.trace_smul, smul_eq_mul, loopProductState]
+  apply Finset.sum_congr rfl
+  intro t _
+  congr 1
+  exact F.mpv_loopCoordinateTensor l t
+
+end MPSTensor.BeigiSectorGraphData

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Core.CyclicTrace
+import TNLean.MPS.Periodic.Applications
 import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
 
 /-!
@@ -36,53 +37,6 @@ namespace MPSTensor.BeigiSectorGraphData
 open FiniteWeightedDigraph
 
 variable {d D : ℕ} {A : MPSTensor d D}
-
-private theorem evalWord_physicalMix_ofFn
-    {m E : ℕ} (B : MPSTensor d E) (W : Matrix (Fin m) (Fin d) ℂ) :
-    ∀ (N : ℕ) (s : Fin N → Fin m),
-      evalWord (fun i : Fin m => ∑ j : Fin d, W i j • B j) (List.ofFn s) =
-        ∑ t : Fin N → Fin d,
-          (∏ n : Fin N, W (s n) (t n)) • evalWord B (List.ofFn t) := by
-  intro N
-  induction N with
-  | zero =>
-      intro s
-      classical
-      simp
-  | succ N ih =>
-      intro s
-      classical
-      rw [List.ofFn_succ, evalWord_cons]
-      rw [ih (fun n : Fin N => s n.succ)]
-      rw [Finset.sum_mul_sum]
-      let e : (Fin d × (Fin N → Fin d)) ≃ (Fin (N + 1) → Fin d) :=
-        Fin.consEquiv (fun _ => Fin d)
-      have hreindex :
-          (∑ t : Fin (N + 1) → Fin d,
-              (∏ n : Fin (N + 1), W (s n) (t n)) •
-                evalWord B (List.ofFn t)) =
-            ∑ p : Fin d × (Fin N → Fin d),
-              (∏ n : Fin (N + 1), W (s n) (e p n)) •
-                evalWord B (List.ofFn (e p)) :=
-        (Fintype.sum_equiv e
-          (f := fun p : Fin d × (Fin N → Fin d) =>
-            (∏ n : Fin (N + 1), W (s n) (e p n)) •
-              evalWord B (List.ofFn (e p)))
-          (g := fun t : Fin (N + 1) → Fin d =>
-            (∏ n : Fin (N + 1), W (s n) (t n)) •
-              evalWord B (List.ofFn t))
-          (by intro p; rfl)).symm
-      rw [hreindex, ← Fintype.sum_prod_type']
-      refine Finset.sum_congr rfl ?_
-      rintro ⟨i, t⟩ _
-      have hprod :
-          (∏ n : Fin (N + 1), W (s n) (e (i, t) n)) =
-            W (s 0) i * ∏ n : Fin N, W (s n.succ) (t n) := by
-        rw [Fin.prod_univ_succ]
-        simp [e, Fin.consEquiv]
-      have hlist : List.ofFn (e (i, t)) = i :: List.ofFn t := by
-        simp [e, Fin.consEquiv]
-      rw [hprod, hlist, evalWord_cons, smul_mul_smul_comm]
 
 /-- A nonzero vector in the edge ground space carried by a positive loop.
 
@@ -131,8 +85,10 @@ unitary to the sector-coordinate tensor.
 Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
 noncomputable def loopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : MPSTensor d (F.leftDim l.1) :=
-  fun i ↦ ∑ j : Fin d, F.unitary i j • F.loopCoordinateTensor l j
+  rotatePhysical F.unitary (F.loopCoordinateTensor l)
 
+/-- The left sector factor at site `n`, transported to the loop sector using
+the hypothesis that the physical index at that site belongs to the loop. -/
 private def loopLeftIndex (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} (s : Fin N → Fin d)
     (hsector : ∀ n, (F.sectorEquiv.symm (s n)).1 = l.1) (n : Fin N) :
@@ -140,6 +96,8 @@ private def loopLeftIndex (F : BeigiSectorGraphData A)
   Fin.cast (congrArg F.leftDim (hsector n))
     (F.sectorEquiv.symm (s n)).2.2
 
+/-- The right sector factor at site `n`, transported to the loop sector using
+the hypothesis that the physical index at that site belongs to the loop. -/
 private def loopRightIndex (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} (s : Fin N → Fin d)
     (hsector : ∀ n, (F.sectorEquiv.symm (s n)).1 = l.1) (n : Fin N) :
@@ -217,11 +175,8 @@ Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
 theorem mpv_loopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
     mpv (F.loopTensor l) s = F.loopProductState l s := by
-  change Matrix.trace
-      (evalWord (fun i : Fin d => ∑ j : Fin d,
-        F.unitary i j • F.loopCoordinateTensor l j) (List.ofFn s)) = _
-  rw [evalWord_physicalMix_ofFn, Matrix.trace_sum]
-  simp only [Matrix.trace_smul, smul_eq_mul, loopProductState]
+  rw [loopTensor, MPSTensor.mpv_rotatePhysical]
+  simp only [loopProductState]
   apply Finset.sum_congr rfl
   intro t _
   congr 1

--- a/blueprint/src/chapter/ch12_symmetry.tex
+++ b/blueprint/src/chapter/ch12_symmetry.tex
@@ -27,6 +27,27 @@ enter the string-order criteria.
     When the matrix is a unitary $u$, the rotation is written $A_u$.
 \end{definition}
 
+\begin{lemma}[Matrix product vector under physical rotation]
+    \label{lem:mpv_rotate_physical}
+    \lean{MPSTensor.mpv_rotatePhysical}
+    \leanok
+    \uses{def:rotate_physical, def:mpv}
+    For a length-$N$ physical configuration
+    $s=(s_0,\ldots,s_{N-1})$, physical rotation satisfies
+    \[
+        \operatorname{tr}((A_M)^{s_0}\cdots(A_M)^{s_{N-1}})
+        =\sum_{t\in\{0,\ldots,d-1\}^N}
+          \left(\prod_{n=0}^{N-1}M_{s_n,t_n}\right)
+          \operatorname{tr}(A^{t_0}\cdots A^{t_{N-1}}).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute $(A_M)^{s_n}=\sum_{t_n}M_{s_n,t_n}A^{t_n}$ at each
+    site, distribute the finite sums through the ordered matrix product, and
+    use linearity of the trace.
+\end{proof}
+
 \begin{corollary}[Periodic symmetry yields gauge equivalence up to a root of unity]%
     \label{cor:symmetry_periodic_assembly}
     \lean{MPSTensor.zGaugeEquiv_of_isIrreducibleForm_sameMPV_rotatePhysical}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2473,6 +2473,53 @@ specialization of that Appendix~D definition.
     preserves the dimension of the ground space.
 \end{proof}
 
+\begin{definition}[Tensor associated with a positive Beigi loop]
+    \label{def:beigi_loop_product_state}
+    \lean{MPSTensor.BeigiSectorGraphData.loopBondVector}
+    \lean{MPSTensor.BeigiSectorGraphData.loopBondVector_mem}
+    \lean{MPSTensor.BeigiSectorGraphData.loopBondVector_ne_zero}
+    \lean{MPSTensor.BeigiSectorGraphData.loopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.loopTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.loopCyclicProduct}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductState}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    Let $a\to a$ be a positive loop and choose a nonzero vector
+    $\varphi_a\in\operatorname{ran}P_{a,a}$.  In sector coordinates define
+    the matrix product tensor
+    \[
+        (C_a^{(r,l)})_{x,y}=\delta_{x,l}\,\varphi_a(r,y),
+    \]
+    and set it to zero outside sector $a$.  The physical loop tensor is the
+    image of $C_a$ under the one-site unitary of the spatial decomposition.
+    Its associated cyclic product pairs the right factor at site $n$ with the
+    left factor at site $n+1$.
+\end{definition}
+
+\begin{theorem}[Periodic vector of a positive Beigi loop]
+    \label{thm:beigi_loop_tensor_periodic_vector}
+    \lean{MPSTensor.BeigiSectorGraphData.mpv_loopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.mpv_loopTensor}
+    \leanok
+    \uses{def:beigi_loop_product_state}
+    For every $N>0$, the periodic matrix product vector of $C_a$ has
+    coefficient
+    \[
+        \prod_{n=0}^{N-1}\varphi_a(r_n,l_{n+1})
+    \]
+    on a cyclic configuration in sector $a$, and coefficient zero on every
+    other sector configuration.  Consequently the periodic vector of the
+    physical loop tensor is exactly the sitewise-unitary image of this cyclic
+    product-of-pairs state.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the trace of the closed matrix product as a sum over cyclic virtual
+    indices.  Each local Kronecker delta forces the virtual index at site $n$
+    to equal $l_n$, leaving precisely the displayed product.  Expanding the
+    one-site unitary at every physical leg gives its sitewise tensor power.
+\end{proof}
+
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2501,7 +2501,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.mpv_loopCoordinateTensor}
     \lean{MPSTensor.BeigiSectorGraphData.mpv_loopTensor}
     \leanok
-    \uses{def:beigi_loop_product_state}
+    \uses{def:beigi_loop_product_state, lem:mpv_rotate_physical}
     For every $N>0$, the periodic matrix product vector of $C_a$ has
     coefficient
     \[
@@ -2514,10 +2514,28 @@ specialization of that Appendix~D definition.
 \end{theorem}
 
 \begin{proof}\leanok
-    Expand the trace of the closed matrix product as a sum over cyclic virtual
-    indices.  Each local Kronecker delta forces the virtual index at site $n$
-    to equal $l_n$, leaving precisely the displayed product.  Expanding the
-    one-site unitary at every physical leg gives its sitewise tensor power.
+    Write $D_a^{\mathrm L}$ for the left-factor dimension of sector~$a$.
+    Expanding the closed matrix product on a sector configuration
+    $((r_n,l_n))_{n=0}^{N-1}$ gives
+    \[
+        \sum_{g\in\{0,\ldots,D_a^{\mathrm L}-1\}^N}
+          \prod_{n=0}^{N-1}
+            \delta_{g_n,l_n}\,
+            \varphi_a\!\left(r_n,g_{n+1}\right)
+        =\prod_{n=0}^{N-1}\varphi_a(r_n,l_{n+1}),
+    \]
+    where all site labels are read cyclically.  Indeed, the Kronecker deltas
+    leave only the assignment $g_n=l_n$.  If $A_a$ denotes the physical loop
+    tensor and $U$ the one-site unitary, then for a physical configuration
+    $s=(s_0,\ldots,s_{N-1})$ one has
+    \[
+        \operatorname{tr}(A_a^{s_0}\cdots A_a^{s_{N-1}})
+        =\sum_{t\in\{0,\ldots,d-1\}^N}
+          \left(\prod_{n=0}^{N-1}U_{s_n,t_n}\right)
+          \operatorname{tr}(C_a^{t_0}\cdots C_a^{t_{N-1}}).
+    \]
+    Substitution of the preceding cyclic coefficient formula gives the stated
+    sitewise-unitary image.
 \end{proof}
 
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -299,6 +299,21 @@ BNT eventual-dimension theorem gives
 This conclusion does not identify the loop states with the original BNT
 representatives.
 
+The product-of-pairs vector carried by each positive loop is now also
+constructed explicitly.  The declaration
+\leanid{MPSTensor.BeigiSectorGraphData.loopTensor} uses the left factor of the
+loop sector as its virtual space and the chosen nonzero loop-edge vector as
+the cyclic right--left bond.  For every positive length,
+\leanid{MPSTensor.BeigiSectorGraphData.mpv_loopTensor} identifies its periodic
+matrix product vector with the sitewise-unitary image of Beigi's cyclic
+product
+\[
+  \prod_n \varphi_a(r_n,l_{n+1}).
+\]
+This is the construction in Beigi, arXiv:1105.1019v2, source lines 602--606.
+It does not yet prove that these vectors belong to, or span, the parent ground
+space, nor does it identify them with the original BNT representatives.
+
 \section{Elimination plan}
 
 A source-faithful formalization should replace the remaining axiom-backed
@@ -343,9 +358,10 @@ ground-space spanning clause and the multiplicity-one distinct-sector
 extension are proved. The repeated-copy and arbitrary-raw-weight extension
 remains open.  In the reverse direction, eventual ground-space dimension
 stability, the local spatial decomposition, the ordered-cycle dimension
-formula, and the reduction of the sector graph to one-dimensional loops are
-proved.  The identification of the resulting loop states with the basis of
-normal tensors remains open.
+formula, the reduction of the sector graph to one-dimensional loops, and the
+exact matrix product realization of every positive loop state are proved.
+Parent-ground-space membership and spanning for these loop vectors, followed
+by their identification with the basis of normal tensors, remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -302,8 +302,10 @@ representatives.
 The product-of-pairs vector carried by each positive loop is now also
 constructed explicitly.  The declaration
 \leanid{MPSTensor.BeigiSectorGraphData.loopTensor} uses the left factor of the
-loop sector as its virtual space and the chosen nonzero loop-edge vector as
-the cyclic right--left bond.  For every positive length,
+loop sector as its virtual space and denotes the chosen nonzero loop-edge
+vector by $\varphi_a$.  At site $n$, write $r_n$ and $l_n$ for the right and
+left sector factors, respectively; the cyclic bond pairs $r_n$ with
+$l_{n+1}$.  For every positive length,
 \leanid{MPSTensor.BeigiSectorGraphData.mpv_loopTensor} identifies its periodic
 matrix product vector with the sitewise-unitary image of Beigi's cyclic
 product


### PR DESCRIPTION
## Summary

- construct, for every positive loop in `BeigiSectorGraphData`, a nonzero loop bond vector and the corresponding translation-invariant matrix product tensor;
- prove at every positive chain length that its periodic vector is exactly the cyclic right-to-left product of the loop bond vector, and prove the same equality after the one-site spatial-decomposition unitary;
- record the construction in the blueprint and refine the existing NNCPH paper-gap boundary.

The local matrix is
\[
  (C_a^{(r,l)})_{x,y}=\delta_{x,l}\,\varphi_a(r,y),
\]
so closing the virtual indices gives
\[
  \prod_n \varphi_a(r_n,l_{n+1}).
\]
This is the cyclic product in Beigi's argument, not a product over disjoint pairs of physical sites.

## Sources

- Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606: a positive loop carries a vector spanning the edge kernel; its cyclic tensor powers are ground states, and these loop states span the ground space.
- CPSV16, arXiv:1606.00608, Section 3.3, local source line 1307: the NNCPH implication invokes Beigi's classification.

This pull request formalizes only the explicit loop tensor and its exact periodic-vector formula from the first source passage.

## Deliberate exclusions

- no proof that the loop vectors belong to or span the parent-Hamiltonian ground space;
- no construction of `BeigiSectorGraphData` from the NNCPH hypotheses;
- no identification of the loop tensors with the basis of normal tensors;
- no treatment of repeated copies or arbitrary raw BNT weights.

Accordingly, `Axioms.beigi_nncph_to_rfp` and the statement using it are unchanged. This is a strictly scoped first stage of #4423 and does not close that issue.

## Verification

- `lake env lean TNLean/MPS/RFP/BeigiLoopTensor.lean`
- `lake build TNLean.MPS.RFP.BeigiLoopTensor`
- `lake build TNLean`
- `lake build`
- `lake exe lint_style`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- `leanblueprint checkdecls`
- reader-facing prose, proof-integrity, diff, and root-file size checks

Part of #4423.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style additions and documentation; no runtime, auth, or data paths. Remaining NNCPH reverse implication stays axiom-backed as before.
> 
> **Overview**
> Formalizes **Beigi’s positive-loop “product-of-pairs” state** as explicit MPS data on `BeigiSectorGraphData`: a chosen nonzero edge ground vector, sector tensor `loopCoordinateTensor`, physical tensor `loopTensor` via `rotatePhysical` with the spatial unitary, and `loopProductState` as the sitewise-unitary image of the cyclic bond product \(\prod_n \varphi(r_n,l_{n+1})\).
> 
> **Proved:** `mpv_loopCoordinateTensor` and `mpv_loopTensor` identify periodic matrix product vectors with that cyclic product and product state at every positive length. Supporting lemma **`MPSTensor.mpv_rotatePhysical`** (and `evalWord_rotatePhysical_ofFn`) in `Periodic/Applications.lean` links physical rotation to summed sitewise matrix weights on MPVs—used when passing from sector coordinates to physical coordinates.
> 
> **Wiring:** new module `TNLean/MPS/RFP/BeigiLoopTensor.lean` imported from `TNLean.lean`; blueprint ch12 (rotation MPV lemma) and ch13 (loop tensor definition/theorem); `cpsv16_nncph_ground_state_scope.tex` notes the explicit construction while **still open**: parent ground-space membership/spanning and identification with BNT representatives; `Axioms.beigi_nncph_to_rfp` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f828f307ca339569b467f7d13adf6edfd5ae5c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->