### PR TITLE
feat(Channel/Schwarz): pass support resolvents to square roots

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -172,6 +172,7 @@ import TNLean.Channel.Schwarz.PetzRecoverySupport
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import TNLean.Channel.Schwarz.SSAEqualityDPI
 import TNLean.Channel.Schwarz.PetzEqualityPrerequisites
+import TNLean.Channel.Schwarz.SupportRelativeModular
 import TNLean.Channel.Schwarz.WeylRelativeEntropyIntegral
 import TNLean.Channel.Schwarz.WeylTwirl
 import TNLean.Channel.Schwarz.PositiveOnAbelian

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -99,7 +99,6 @@ import TNLean.Channel.PositiveExamples
 import TNLean.Channel.BreuerHallMap
 import TNLean.Channel.ChoiTypeMap
 import TNLean.Channel.DensityRetract
-
 -- Layer 2 (Ch. 2 infrastructure): Choi–Jamiolkowski, Kraus, Stinespring
 import TNLean.Channel.PartialTrace
 import TNLean.Channel.MaximallyEntangled

--- a/TNLean/Analysis/ResolventFunctionalCalculus.lean
+++ b/TNLean/Analysis/ResolventFunctionalCalculus.lean
@@ -70,64 +70,6 @@ private lemma cfc_rpowIntegrand₀₁_eq_resolvent
   have hcalc := hEq hA_nonneg
   simpa [Algebra.algebraMap_eq_smul_one, ← Matrix.nonsing_inv_eq_ringInverse] using hcalc
 
-/-- Equality of all positive shifted resolvents on a fixed vector implies
-equality of the positive square roots on that vector.
-
-Jenčová--Ruskai, arXiv:0903.2895v4, lines 658–680, obtains the corresponding
-functional-calculus conclusion from analytic continuation and the Cauchy
-integral formula. Here the same positive-square-root specialization is proved
-with the Löwner integral representation of the real power `p = 1 / 2`. -/
-theorem sqrt_mulVec_eq_of_resolvent_mulVec_eq
-    {n : Type*} [Fintype n] [DecidableEq n]
-    {S T : Matrix n n ℂ} (hS : S.PosSemidef) (hT : T.PosSemidef)
-    {x : n → ℂ}
-    (hres : ∀ {t : ℝ}, 0 < t →
-      (t • (1 : Matrix n n ℂ) + S)⁻¹ *ᵥ x =
-        (t • (1 : Matrix n n ℂ) + T)⁻¹ *ᵥ x) :
-    CFC.sqrt S *ᵥ x = CFC.sqrt T *ᵥ x := by
-  let p : NNReal := 1 / 2
-  have hp : (p : ℝ) ∈ Ioo 0 1 := by
-    norm_num [p]
-  obtain ⟨μ, hμ⟩ :=
-    CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁
-      (Matrix n n ℂ) hp
-  have hSint := (hμ S hS.nonneg).1
-  have hTint := (hμ T hT.nonneg).1
-  have hintegrand : ∀ {t : ℝ}, 0 < t →
-      cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x =
-        cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x := by
-    intro t ht
-    have hSnonneg : (0 : Matrix n n ℂ) ≤ S := hS.nonneg
-    have hTnonneg : (0 : Matrix n n ℂ) ≤ T := hT.nonneg
-    have hcontS : ContinuousOn (Real.rpowIntegrand₀₁ (p : ℝ) t)
-        (quasispectrum ℝ S) :=
-      (Real.continuousOn_rpowIntegrand₀₁_Ici hp ht).mono (by grind)
-    have hcontT : ContinuousOn (Real.rpowIntegrand₀₁ (p : ℝ) t)
-        (quasispectrum ℝ T) :=
-      (Real.continuousOn_rpowIntegrand₀₁_Ici hp ht).mono (by grind)
-    rw [cfcₙ_eq_cfc hcontS, cfcₙ_eq_cfc hcontT,
-      cfc_rpowIntegrand₀₁_eq_resolvent hS hp ht,
-      cfc_rpowIntegrand₀₁_eq_resolvent hT hp ht]
-    simp only [sub_mulVec, smul_mulVec, one_mulVec]
-    rw [hres ht]
-  have hAE :
-      (fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x) =ᵐ[μ.restrict (Ioi 0)]
-        fun t : ℝ ↦ cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x := by
-    filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
-    exact hintegrand ht
-  let L : Matrix n n ℂ →L[ℂ] (n → ℂ) :=
-    LinearMap.toContinuousLinearMap
-      { toFun := fun M ↦ M *ᵥ x
-        map_add' := fun M N ↦ add_mulVec M N x
-        map_smul' := fun c M ↦ smul_mulVec c M x }
-  rw [CFC.sqrt_eq_nnrpow, CFC.sqrt_eq_nnrpow,
-    show (1 / 2 : NNReal) = p by rfl,
-    (hμ S hS.nonneg).2, (hμ T hT.nonneg).2]
-  change L (∫ t in Ioi 0, cfcₙ (Real.rpowIntegrand₀₁ p t) S ∂μ) =
-    L (∫ t in Ioi 0, cfcₙ (Real.rpowIntegrand₀₁ p t) T ∂μ)
-  rw [← L.integral_comp_comm hSint, ← L.integral_comp_comm hTint]
-  exact integral_congr_ae hAE
-
 /-- Equality of all positive shifted resolvents after a fixed matrix is applied
 to their values on a vector implies the corresponding equality for positive
 square roots.
@@ -190,6 +132,29 @@ theorem mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq
     L (∫ t in Ioi 0, cfcₙ (Real.rpowIntegrand₀₁ p t) T ∂μ)
   rw [← L.integral_comp_comm hSint, ← L.integral_comp_comm hTint]
   exact integral_congr_ae hAE
+
+/-- Equality of all positive shifted resolvents on a fixed vector implies
+equality of the positive square roots on that vector.
+
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 658–680, obtains the corresponding
+functional-calculus conclusion from analytic continuation and the Cauchy
+integral formula. Here the same positive-square-root specialization is proved
+with the Löwner integral representation of the real power `p = 1 / 2`. -/
+theorem sqrt_mulVec_eq_of_resolvent_mulVec_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {S T : Matrix n n ℂ} (hS : S.PosSemidef) (hT : T.PosSemidef)
+    {x : n → ℂ}
+    (hres : ∀ {t : ℝ}, 0 < t →
+      (t • (1 : Matrix n n ℂ) + S)⁻¹ *ᵥ x =
+        (t • (1 : Matrix n n ℂ) + T)⁻¹ *ᵥ x) :
+    CFC.sqrt S *ᵥ x = CFC.sqrt T *ᵥ x := by
+  have hresOne : ∀ {t : ℝ}, 0 < t →
+      (1 : Matrix n n ℂ) *ᵥ ((t • 1 + S)⁻¹ *ᵥ x) =
+        (1 : Matrix n n ℂ) *ᵥ ((t • 1 + T)⁻¹ *ᵥ x) := by
+    intro t ht
+    simpa only [one_mulVec] using hres ht
+  simpa only [one_mulVec] using
+    mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq hS hT hresOne
 
 /-- The source-`B` left-right resolvent is the shifted resolvent of the
 relative modular Kronecker matrix on the vectorized identity.

--- a/TNLean/Analysis/ResolventFunctionalCalculus.lean
+++ b/TNLean/Analysis/ResolventFunctionalCalculus.lean
@@ -18,6 +18,9 @@ a fixed vector to equality of the positive square roots on that vector.
 * `Matrix.sqrt_mulVec_eq_of_resolvent_mulVec_eq` shows that if two positive
   semidefinite matrices have the same shifted inverse on a vector for every
   positive shift, then their positive square roots agree on that vector.
+* `Matrix.mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq` gives the same
+  conclusion after applying a fixed matrix to the resolvent and square-root
+  vectors.
 * `Matrix.sourceB_resolvent_eq_relativeModular` factors the source-`B`
   left--right resolvent through the relative modular Kronecker matrix.
 * `Matrix.relativeModular_sqrt_mulVec_vec_one` evaluates its positive square
@@ -117,6 +120,69 @@ theorem sqrt_mulVec_eq_of_resolvent_mulVec_eq
       { toFun := fun M ↦ M *ᵥ x
         map_add' := fun M N ↦ add_mulVec M N x
         map_smul' := fun c M ↦ smul_mulVec c M x }
+  rw [CFC.sqrt_eq_nnrpow, CFC.sqrt_eq_nnrpow,
+    show (1 / 2 : NNReal) = p by rfl,
+    (hμ S hS.nonneg).2, (hμ T hT.nonneg).2]
+  change L (∫ t in Ioi 0, cfcₙ (Real.rpowIntegrand₀₁ p t) S ∂μ) =
+    L (∫ t in Ioi 0, cfcₙ (Real.rpowIntegrand₀₁ p t) T ∂μ)
+  rw [← L.integral_comp_comm hSint, ← L.integral_comp_comm hTint]
+  exact integral_congr_ae hAE
+
+/-- Equality of all positive shifted resolvents after a fixed matrix is applied
+to their values on a vector implies the corresponding equality for positive
+square roots.
+
+This is the support-restricted form of the functional-calculus passage in
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 788--793. -/
+theorem mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {S T : Matrix n n ℂ} (hS : S.PosSemidef) (hT : T.PosSemidef)
+    {Q : Matrix n n ℂ} {x : n → ℂ}
+    (hres : ∀ {t : ℝ}, 0 < t →
+      Q *ᵥ ((t • (1 : Matrix n n ℂ) + S)⁻¹ *ᵥ x) =
+        Q *ᵥ ((t • (1 : Matrix n n ℂ) + T)⁻¹ *ᵥ x)) :
+    Q *ᵥ (CFC.sqrt S *ᵥ x) = Q *ᵥ (CFC.sqrt T *ᵥ x) := by
+  let p : NNReal := 1 / 2
+  have hp : (p : ℝ) ∈ Ioo 0 1 := by
+    norm_num [p]
+  obtain ⟨μ, hμ⟩ :=
+    CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁
+      (Matrix n n ℂ) hp
+  have hSint := (hμ S hS.nonneg).1
+  have hTint := (hμ T hT.nonneg).1
+  have hintegrand : ∀ {t : ℝ}, 0 < t →
+      Q *ᵥ (cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x) =
+        Q *ᵥ (cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x) := by
+    intro t ht
+    have hSnonneg : (0 : Matrix n n ℂ) ≤ S := hS.nonneg
+    have hTnonneg : (0 : Matrix n n ℂ) ≤ T := hT.nonneg
+    have hcontS : ContinuousOn (Real.rpowIntegrand₀₁ (p : ℝ) t)
+        (quasispectrum ℝ S) :=
+      (Real.continuousOn_rpowIntegrand₀₁_Ici hp ht).mono (by grind)
+    have hcontT : ContinuousOn (Real.rpowIntegrand₀₁ (p : ℝ) t)
+        (quasispectrum ℝ T) :=
+      (Real.continuousOn_rpowIntegrand₀₁_Ici hp ht).mono (by grind)
+    rw [cfcₙ_eq_cfc hcontS, cfcₙ_eq_cfc hcontT,
+      cfc_rpowIntegrand₀₁_eq_resolvent hS hp ht,
+      cfc_rpowIntegrand₀₁_eq_resolvent hT hp ht]
+    simp only [sub_mulVec, smul_mulVec, one_mulVec, mulVec_sub, mulVec_smul]
+    rw [hres ht]
+  have hAE :
+      (fun t : ℝ ↦ Q *ᵥ (cfcₙ (Real.rpowIntegrand₀₁ p t) S *ᵥ x))
+          =ᵐ[μ.restrict (Ioi 0)]
+        fun t : ℝ ↦ Q *ᵥ (cfcₙ (Real.rpowIntegrand₀₁ p t) T *ᵥ x) := by
+    filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+    exact hintegrand ht
+  let L : Matrix n n ℂ →L[ℂ] (n → ℂ) :=
+    LinearMap.toContinuousLinearMap
+      { toFun := fun M ↦ Q *ᵥ (M *ᵥ x)
+        map_add' := by
+          intro M N
+          rw [add_mulVec, mulVec_add]
+        map_smul' := by
+          intro c M
+          rw [smul_mulVec, mulVec_smul]
+          rfl }
   rw [CFC.sqrt_eq_nnrpow, CFC.sqrt_eq_nnrpow,
     show (1 / 2 : NNReal) = p by rfl,
     (hμ S hS.nonneg).2, (hμ T hT.nonneg).2]

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -23,6 +23,8 @@ reference matrix.
 * `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
 * `Matrix.PosDef.supportInvSqrt_eq_inv_sqrt`: the support inverse square root
   of a positive-definite matrix is its ordinary inverse square root.
+* `Matrix.PosSemidef.supportInvSqrt_posSemidef`: the support inverse square
+  root is positive semidefinite.
 * `Matrix.PosSemidef.supportInvSqrt_smul`: scaling by a positive real scalar.
 * `Matrix.PosSemidef.supportInvSqrt_kronecker_one`: compatibility with the
   unital left tensor embedding.
@@ -77,6 +79,22 @@ theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
   rw [PosSemidef.supportInvSqrt, ← hρ.isHermitian.cfc_eq]
   exact Matrix.isHermitian_iff_isSelfAdjoint.mpr
     (cfc_predicate (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ)
+
+/-- The support inverse square root is positive semidefinite.
+
+This is the positivity of the generalized inverse square root used in
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 255--261. -/
+theorem PosSemidef.supportInvSqrt_posSemidef {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) : hρ.supportInvSqrt.PosSemidef := by
+  unfold PosSemidef.supportInvSqrt
+  have hnonneg : 0 ≤ cfc (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ := by
+    apply cfc_nonneg
+    intro x _
+    split_ifs
+    · positivity
+    · exact le_rfl
+  rw [hρ.isHermitian.cfc_eq] at hnonneg
+  exact Matrix.nonneg_iff_posSemidef.mp hnonneg
 
 /-- On a positive-definite matrix, the support inverse square root is the
 ordinary inverse of the positive square root.

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -15,6 +15,9 @@ reference matrix is represented as the square of its support inverse square root
 
 ## Main results
 
+* `Matrix.one_kronecker_transpose_mulVec_vec_transpose` identifies the
+  Kronecker matrix that represents right multiplication on a transposed
+  vectorization.
 * `Matrix.supportRelativeModular_sqrt_mulVec_vec_one` evaluates the positive
   square root of the support relative-modular matrix on the vectorized identity.
 * `Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq` turns a
@@ -34,6 +37,17 @@ formalized here; see `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.
 open scoped Matrix ComplexOrder Kronecker MatrixOrder
 
 namespace Matrix
+
+/-- Under column-stacking vectorization, `1 ⊗ Pᵀ` represents right
+multiplication by `P` when the matrix itself is transposed before
+vectorization. -/
+theorem one_kronecker_transpose_mulVec_vec_transpose
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (M P : Matrix n n ℂ) :
+    ((1 : Matrix n n ℂ) ⊗ₖ Pᵀ) *ᵥ Matrix.vec Mᵀ =
+      Matrix.vec (M * P)ᵀ := by
+  rw [Matrix.kronecker_mulVec_vec]
+  simp only [Matrix.transpose_mul, Matrix.transpose_one, Matrix.mul_one]
 
 /-- The positive square root of the support relative-modular matrix, applied to
 the vectorized identity, is the vectorization of the support square-root ratio.
@@ -112,14 +126,8 @@ theorem supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq
     (hC.kronecker hDInvSq.transpose) hres
   rw [supportRelativeModular_sqrt_mulVec_vec_one hA hB,
     supportRelativeModular_sqrt_mulVec_vec_one hC hD] at hsqrt
-  rw [Matrix.kronecker_mulVec_vec, Matrix.kronecker_mulVec_vec] at hsqrt
-  have hratioTranspose :
-      Matrix.vec ((CFC.sqrt A * hB.supportInvSqrt) *
-        hB.isHermitian.supportProj)ᵀ =
-        Matrix.vec ((CFC.sqrt C * hD.supportInvSqrt) *
-          hB.isHermitian.supportProj)ᵀ := by
-    simpa only [Matrix.transpose_mul, Matrix.transpose_one,
-      Matrix.mul_one, Matrix.mul_assoc] using hsqrt
-  exact Matrix.transpose_injective (Matrix.vec_inj.mp hratioTranspose)
+  rw [one_kronecker_transpose_mulVec_vec_transpose,
+    one_kronecker_transpose_mulVec_vec_transpose] at hsqrt
+  exact Matrix.transpose_injective (Matrix.vec_inj.mp hsqrt)
 
 end Matrix

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -76,18 +76,15 @@ ratios.
 
 This is the positive-square-root specialization of the singular-support
 functional-calculus step in Jenčová--Ruskai, arXiv:0903.2895v4, §4.2,
-lines 766--793, stated on its domain
-\(\ker B\subseteq\ker A\) and \(\ker D\subseteq\ker C\). Their preceding
-continuity argument, lines 717--720, is what supplies such resolvent equalities
-from equality of relative entropy; this theorem does not assert that equality
-for regularized pairs follows from equality of the original pair. -/
+lines 766--793. Their preceding equality argument is stated for supported pairs,
+but the functional-calculus implication here needs only positive semidefiniteness
+and the common resolvents. This theorem does not assert that equality for
+regularized pairs follows from equality of the original pair. -/
 theorem supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq
     {n : Type*} [Fintype n] [DecidableEq n]
     {A B C D : Matrix n n ℂ}
     (hA : A.PosSemidef) (hB : B.PosSemidef)
     (hC : C.PosSemidef) (hD : D.PosSemidef)
-    (_hAB : ∀ v : n → ℂ, B.mulVec v = 0 → A.mulVec v = 0)
-    (_hCD : ∀ v : n → ℂ, D.mulVec v = 0 → C.mulVec v = 0)
     (hres : ∀ {t : ℝ}, 0 < t →
       (t • (1 : Matrix (n × n) (n × n) ℂ) +
           A ⊗ₖ (hB.supportInvSqrt * hB.supportInvSqrt)ᵀ)⁻¹ *ᵥ

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -24,7 +24,10 @@ reference matrix is represented as the square of its support inverse square root
 
 * A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
   Entropy and Related Trace Functions, with Conditions for Equality*,
-  arXiv:0903.2895v4, §4.2, lines 717--720 and 766--793.
+  arXiv:0903.2895v4, §4.2, lines 766--793.
+
+The preceding singular equality-to-resolvent step at lines 717--720 is not
+formalized here; see `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.
 -/
 
 open scoped Matrix ComplexOrder Kronecker MatrixOrder
@@ -70,41 +73,52 @@ theorem supportRelativeModular_sqrt_mulVec_vec_one
   rw [Matrix.kronecker_mulVec_vec]
   simp only [Matrix.transpose_one, Matrix.mul_one, Matrix.transpose_mul]
 
-/-- Equality of all positive shifted support relative-modular resolvents on the
-vectorized identity implies equality of the corresponding support square-root
-ratios.
+/-- Equality of all positive shifted relative-modular resolvents on the
+vectorized identity, after restriction to the support of the first reference
+matrix, implies equality of the square-root ratios on that support.
 
 This is the positive-square-root specialization of the singular-support
 functional-calculus step in Jenčová--Ruskai, arXiv:0903.2895v4, §4.2,
-lines 766--793. Their preceding equality argument is stated for supported pairs,
-but the functional-calculus implication here needs only positive semidefiniteness
-and the common resolvents. This theorem does not assert that equality for
-regularized pairs follows from equality of the original pair. -/
+lines 788--793. The restriction by the support projection is essential: the
+source asserts equality only on the complement of the kernel of the smaller
+reference matrix. This theorem does not supply that resolvent equality from
+equality in data processing; the missing preceding step is recorded in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
 theorem supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq
     {n : Type*} [Fintype n] [DecidableEq n]
     {A B C D : Matrix n n ℂ}
     (hA : A.PosSemidef) (hB : B.PosSemidef)
     (hC : C.PosSemidef) (hD : D.PosSemidef)
     (hres : ∀ {t : ℝ}, 0 < t →
-      (t • (1 : Matrix (n × n) (n × n) ℂ) +
-          A ⊗ₖ (hB.supportInvSqrt * hB.supportInvSqrt)ᵀ)⁻¹ *ᵥ
-          Matrix.vec (1 : Matrix n n ℂ)ᵀ =
-        (t • (1 : Matrix (n × n) (n × n) ℂ) +
-          C ⊗ₖ (hD.supportInvSqrt * hD.supportInvSqrt)ᵀ)⁻¹ *ᵥ
-          Matrix.vec (1 : Matrix n n ℂ)ᵀ) :
-    CFC.sqrt A * hB.supportInvSqrt =
-      CFC.sqrt C * hD.supportInvSqrt := by
+      ((1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ) *ᵥ
+          ((t • (1 : Matrix (n × n) (n × n) ℂ) +
+            A ⊗ₖ (hB.supportInvSqrt * hB.supportInvSqrt)ᵀ)⁻¹ *ᵥ
+            Matrix.vec (1 : Matrix n n ℂ)ᵀ) =
+        ((1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ) *ᵥ
+          ((t • (1 : Matrix (n × n) (n × n) ℂ) +
+            C ⊗ₖ (hD.supportInvSqrt * hD.supportInvSqrt)ᵀ)⁻¹ *ᵥ
+            Matrix.vec (1 : Matrix n n ℂ)ᵀ)) :
+    (CFC.sqrt A * hB.supportInvSqrt) * hB.isHermitian.supportProj =
+      (CFC.sqrt C * hD.supportInvSqrt) * hB.isHermitian.supportProj := by
   have hBInvSq : (hB.supportInvSqrt * hB.supportInvSqrt).PosSemidef := by
     simpa [hB.supportInvSqrt_isHermitian.eq] using
       posSemidef_conjTranspose_mul_self hB.supportInvSqrt
   have hDInvSq : (hD.supportInvSqrt * hD.supportInvSqrt).PosSemidef := by
     simpa [hD.supportInvSqrt_isHermitian.eq] using
       posSemidef_conjTranspose_mul_self hD.supportInvSqrt
-  have hsqrt := sqrt_mulVec_eq_of_resolvent_mulVec_eq
+  have hsqrt := mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq
     (hA.kronecker hBInvSq.transpose)
     (hC.kronecker hDInvSq.transpose) hres
   rw [supportRelativeModular_sqrt_mulVec_vec_one hA hB,
     supportRelativeModular_sqrt_mulVec_vec_one hC hD] at hsqrt
-  exact Matrix.transpose_injective (Matrix.vec_inj.mp hsqrt)
+  rw [Matrix.kronecker_mulVec_vec, Matrix.kronecker_mulVec_vec] at hsqrt
+  have hratioTranspose :
+      Matrix.vec ((CFC.sqrt A * hB.supportInvSqrt) *
+        hB.isHermitian.supportProj)ᵀ =
+        Matrix.vec ((CFC.sqrt C * hD.supportInvSqrt) *
+          hB.isHermitian.supportProj)ᵀ := by
+    simpa only [Matrix.transpose_mul, Matrix.transpose_one,
+      Matrix.mul_one, Matrix.mul_assoc] using hsqrt
+  exact Matrix.transpose_injective (Matrix.vec_inj.mp hratioTranspose)
 
 end Matrix

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -18,7 +18,8 @@ reference matrix is represented as the square of its support inverse square root
 * `Matrix.supportRelativeModular_sqrt_mulVec_vec_one` evaluates the positive
   square root of the support relative-modular matrix on the vectorized identity.
 * `Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq` turns a
-  common family of shifted resolvents into equality of support square-root ratios.
+  support-restricted common family of shifted resolvents into equality of
+  support-restricted square-root ratios.
 
 ## References
 

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.ResolventFunctionalCalculus
+import TNLean.Channel.PetzRecovery
+
+/-!
+# Relative modular square roots on singular supports
+
+This file proves the support-domain passage from equality of relative-modular
+resolvents to equality of square-root ratios. The generalized inverse of the
+reference matrix is represented as the square of its support inverse square root.
+
+## Main results
+
+* `Matrix.supportRelativeModular_sqrt_mulVec_vec_one` evaluates the positive
+  square root of the support relative-modular matrix on the vectorized identity.
+* `Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq` turns a
+  common family of shifted resolvents into equality of support square-root ratios.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
+  Entropy and Related Trace Functions, with Conditions for Equality*,
+  arXiv:0903.2895v4, §4.2, lines 717--720 and 766--793.
+-/
+
+open scoped Matrix ComplexOrder Kronecker MatrixOrder
+
+namespace Matrix
+
+/-- The positive square root of the support relative-modular matrix, applied to
+the vectorized identity, is the vectorization of the support square-root ratio.
+
+The generalized inverse convention is that of Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 255--261. The singular equality argument uses this
+convention on the reference support in §4.2, lines 766--793. -/
+theorem supportRelativeModular_sqrt_mulVec_vec_one
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    CFC.sqrt (A ⊗ₖ
+        (hB.supportInvSqrt * hB.supportInvSqrt)ᵀ) *ᵥ
+        Matrix.vec (1 : Matrix n n ℂ)ᵀ =
+      Matrix.vec (CFC.sqrt A * hB.supportInvSqrt)ᵀ := by
+  let qA : Matrix n n ℂ := CFC.sqrt A
+  let qBInv : Matrix n n ℂ := hB.supportInvSqrt
+  let delta : Matrix (n × n) (n × n) ℂ := A ⊗ₖ (qBInv * qBInv)ᵀ
+  let qDelta : Matrix (n × n) (n × n) ℂ := qA ⊗ₖ qBInvᵀ
+  have hqA : qA.PosSemidef := by
+    exact Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)
+  have hqBInv : qBInv.PosSemidef := hB.supportInvSqrt_posSemidef
+  have hqBInv_sq : (qBInv * qBInv).PosSemidef := by
+    simpa [hqBInv.isHermitian.eq] using posSemidef_conjTranspose_mul_self qBInv
+  have hdelta : delta.PosSemidef := hA.kronecker hqBInv_sq.transpose
+  have hqDelta : qDelta.PosSemidef := hqA.kronecker hqBInv.transpose
+  have hqA_sq : qA * qA = A := by
+    simpa only [qA] using CFC.sqrt_mul_sqrt_self A hA.nonneg
+  have hqDelta_sq : qDelta * qDelta = delta := by
+    dsimp only [qDelta, delta]
+    rw [← Matrix.mul_kronecker_mul, hqA_sq, ← Matrix.transpose_mul]
+  have hsqrt : CFC.sqrt delta = qDelta := by
+    apply (CFC.sqrt_eq_iff delta qDelta hdelta.nonneg hqDelta.nonneg).2
+    exact hqDelta_sq
+  change CFC.sqrt delta *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ =
+    Matrix.vec (qA * qBInv)ᵀ
+  rw [hsqrt]
+  dsimp only [qDelta]
+  rw [Matrix.kronecker_mulVec_vec]
+  simp only [Matrix.transpose_one, Matrix.mul_one, Matrix.transpose_mul]
+
+/-- Equality of all positive shifted support relative-modular resolvents on the
+vectorized identity implies equality of the corresponding support square-root
+ratios.
+
+This is the positive-square-root specialization of the singular-support
+functional-calculus step in Jenčová--Ruskai, arXiv:0903.2895v4, §4.2,
+lines 766--793, stated on its domain
+\(\ker B\subseteq\ker A\) and \(\ker D\subseteq\ker C\). Their preceding
+continuity argument, lines 717--720, is what supplies such resolvent equalities
+from equality of relative entropy; this theorem does not assert that equality
+for regularized pairs follows from equality of the original pair. -/
+theorem supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B C D : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hC : C.PosSemidef) (hD : D.PosSemidef)
+    (_hAB : ∀ v : n → ℂ, B.mulVec v = 0 → A.mulVec v = 0)
+    (_hCD : ∀ v : n → ℂ, D.mulVec v = 0 → C.mulVec v = 0)
+    (hres : ∀ {t : ℝ}, 0 < t →
+      (t • (1 : Matrix (n × n) (n × n) ℂ) +
+          A ⊗ₖ (hB.supportInvSqrt * hB.supportInvSqrt)ᵀ)⁻¹ *ᵥ
+          Matrix.vec (1 : Matrix n n ℂ)ᵀ =
+        (t • (1 : Matrix (n × n) (n × n) ℂ) +
+          C ⊗ₖ (hD.supportInvSqrt * hD.supportInvSqrt)ᵀ)⁻¹ *ᵥ
+          Matrix.vec (1 : Matrix n n ℂ)ᵀ) :
+    CFC.sqrt A * hB.supportInvSqrt =
+      CFC.sqrt C * hD.supportInvSqrt := by
+  have hBInvSq : (hB.supportInvSqrt * hB.supportInvSqrt).PosSemidef := by
+    simpa [hB.supportInvSqrt_isHermitian.eq] using
+      posSemidef_conjTranspose_mul_self hB.supportInvSqrt
+  have hDInvSq : (hD.supportInvSqrt * hD.supportInvSqrt).PosSemidef := by
+    simpa [hD.supportInvSqrt_isHermitian.eq] using
+      posSemidef_conjTranspose_mul_self hD.supportInvSqrt
+  have hsqrt := sqrt_mulVec_eq_of_resolvent_mulVec_eq
+    (hA.kronecker hBInvSq.transpose)
+    (hC.kronecker hDInvSq.transpose) hres
+  rw [supportRelativeModular_sqrt_mulVec_vec_one hA hB,
+    supportRelativeModular_sqrt_mulVec_vec_one hC hD] at hsqrt
+  exact Matrix.transpose_injective (Matrix.vec_inj.mp hsqrt)
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2821,6 +2821,47 @@ Theorem~\ref{thm:trace_norm_abs}.
     as follows from uniqueness of the positive square root.
 \end{proof}
 
+\begin{lemma}[Relative modular square-root ratio on the support]
+    \label{lem:support_relative_modular_sqrt_ratio}
+    \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}
+    \lean{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq}
+    \leanok
+    \uses{def:support_inverse_square_root,
+        lem:positive_sqrt_from_common_resolvents}
+    Let $A,B,C,D$ be positive semidefinite matrices such that
+    $\ker B\subseteq\ker A$ and $\ker D\subseteq\ker C$.  Write
+    $B^+=(B^{-1/2}_{\mathrm{supp}})^2$ and
+    $D^+=(D^{-1/2}_{\mathrm{supp}})^2$.  If, for every $t>0$,
+    \[
+      \left(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\right)^{-1}
+        \operatorname{vec}(\mathbf 1^{\mathsf T})
+      =
+      \left(t\mathbf 1+C\otimes(D^+)^{\mathsf T}\right)^{-1}
+        \operatorname{vec}(\mathbf 1^{\mathsf T}),
+    \]
+    then
+    \[
+      \sqrt A\,B^{-1/2}_{\mathrm{supp}}
+        =\sqrt C\,D^{-1/2}_{\mathrm{supp}}.
+    \]
+    This is the square-root specialization of the support functional-calculus
+    passage in Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 717--720 and
+    766--793.  It does not derive the common resolvent equality from equality
+    of relative entropies.
+\end{lemma}
+
+\begin{proof}\leanok
+    The support inverse square roots are positive semidefinite.  Hence
+    \[
+      \sqrt{A\otimes(B^+)^{\mathsf T}}
+        =\sqrt A\otimes(B^{-1/2}_{\mathrm{supp}})^{\mathsf T},
+    \]
+    with the analogous identity for $C,D$.  Applying these square roots to the
+    vectorized identity gives the two support square-root ratios.  The preceding
+    common-resolvent lemma identifies the two square-root vectors, and injectivity
+    of vectorization gives the displayed matrix equality.
+\end{proof}
+
 \begin{theorem}[Positive-definite saturation gives the identity Weyl sandwich]
     \label{thm:partial_trace_saturation_identity_weyl_sandwich}
     \lean{Matrix.weyl_sqrt_ratio_eq_of_partialTraceRight_eq}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2833,7 +2833,8 @@ Theorem~\ref{thm:trace_norm_abs}.
     \[
       f_t(S)x=t^{-1/2}x-t^{1/2}(t\mathbf 1+S)^{-1}x.
     \]
-    The hypothesis therefore gives $f_t(S)x=f_t(T)x$ for every $t>0$.
+    The hypothesis therefore gives
+    $Q\bigl(f_t(S)x\bigr)=Q\bigl(f_t(T)x\bigr)$ for every $t>0$.
     Since $M\mapsto Q(Mx)$ is a bounded linear map from
     $\mathbb{M}_n(\mathbb{C})$ to $\mathbb{C}^n$,
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2779,6 +2779,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{lemma}[Positive square root from common resolvents]
     \label{lem:positive_sqrt_from_common_resolvents}
     \lean{Matrix.sqrt_mulVec_eq_of_resolvent_mulVec_eq}
+    \lean{Matrix.mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq}
     \lean{Matrix.sourceB_resolvent_eq_relativeModular}
     \lean{Matrix.relativeModular_sqrt_mulVec_vec_one}
     \leanok
@@ -2788,6 +2789,11 @@ Theorem~\ref{thm:trace_norm_abs}.
         (t\mathbf 1+S)^{-1}x=(t\mathbf 1+T)^{-1}x,
     \]
     then $\sqrt S\,x=\sqrt T\,x$.
+    More generally, for any fixed matrix $Q$, if
+    \[
+        Q(t\mathbf 1+S)^{-1}x=Q(t\mathbf 1+T)^{-1}x
+    \]
+    for every $t>0$, then $Q\sqrt S\,x=Q\sqrt T\,x$.
 
     In particular, for positive definite $A,B$ and every $t>0$, put
     $\Delta_{A,B}=A\otimes(B^{-1})^{\mathsf T}$.  The source-$B$ left--right
@@ -2820,7 +2826,9 @@ Theorem~\ref{thm:trace_norm_abs}.
       f_t(S)x=t^{-1/2}x-t^{1/2}(t\mathbf 1+S)^{-1}x.
     \]
     The hypothesis therefore gives $f_t(S)x=f_t(T)x$ for every $t>0$.
-    Integration gives equality of the positive square roots on $x$.
+    Applying a fixed matrix $Q$, when present, commutes with this finite-
+    dimensional integral.  Integration gives the asserted equality of the
+    positive square roots on $x$.
 
     For the second assertion, factor
     \[
@@ -2840,41 +2848,47 @@ Theorem~\ref{thm:trace_norm_abs}.
     \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}
     \lean{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq}
     \leanok
-    \uses{def:support_inverse_square_root,
-        lem:positive_sqrt_from_common_resolvents}
+    \uses{def:support_inverse_square_root}
     Let $A,B,C,D$ be positive semidefinite matrices.  Write
     $B^+=(B^{-1/2}_{\mathrm{supp}})^2$ and
-    $D^+=(D^{-1/2}_{\mathrm{supp}})^2$.  If, for every $t>0$,
+    $D^+=(D^{-1/2}_{\mathrm{supp}})^2$, and let $P_B$ be the orthogonal
+    projection onto $(\ker B)^\perp$.  If, for every $t>0$,
     \[
-      \left(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\right)^{-1}
-        \operatorname{vec}(\mathbf 1^{\mathsf T})
+      \left[
+        \left(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\right)^{-1}
+          (\mathbf 1)
+      \right]P_B
       =
-      \left(t\mathbf 1+C\otimes(D^+)^{\mathsf T}\right)^{-1}
-        \operatorname{vec}(\mathbf 1^{\mathsf T}),
+      \left[
+        \left(t\mathbf 1+C\otimes(D^+)^{\mathsf T}\right)^{-1}
+          (\mathbf 1)
+      \right]P_B,
     \]
-    then
+    where the inverses act as relative-modular superoperators on matrices, then
     \[
-      \sqrt A\,B^{-1/2}_{\mathrm{supp}}
-        =\sqrt C\,D^{-1/2}_{\mathrm{supp}}.
+      \left(\sqrt A\,B^{-1/2}_{\mathrm{supp}}\right)P_B
+        =\left(\sqrt C\,D^{-1/2}_{\mathrm{supp}}\right)P_B.
     \]
     This is the square-root specialization of the support functional-calculus
-    passage in Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 766--793.  No
-    kernel hypothesis is needed for this final implication once the common
-    generalized resolvents are given.  In the source application, the preceding
-    equality-to-resolvent argument is stated for pairs satisfying
-    $\ker B\subseteq\ker A$; this lemma does not formalize that preceding step.
+    passage in Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 788--793.  The
+    projection $P_B$ is essential: the source gives the common generalized
+    resolvents only after restriction to $(\ker B)^\perp$.  The preceding
+    equality-to-resolvent argument, including its kernel hypotheses, is not
+    formalized here.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:positive_sqrt_from_common_resolvents,
+        lem:support_inverse_square_root_positive_semidefinite}
     The support inverse square roots are positive semidefinite.  Hence
     \[
       \sqrt{A\otimes(B^+)^{\mathsf T}}
         =\sqrt A\otimes(B^{-1/2}_{\mathrm{supp}})^{\mathsf T},
     \]
-    with the analogous identity for $C,D$.  Applying these square roots to the
-    vectorized identity gives the two support square-root ratios.  The preceding
-    common-resolvent lemma identifies the two square-root vectors, and injectivity
-    of vectorization gives the displayed matrix equality.
+    with the analogous identity for $C,D$.  Right multiplication by $P_B$ is a
+    fixed linear map on the vectorized matrix space.  Apply the projected
+    common-resolvent lemma, evaluate both relative-modular square roots on the
+    vectorized identity, and use injectivity of vectorization.
 \end{proof}
 
 \begin{theorem}[Positive-definite saturation gives the identity Weyl sandwich]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2828,8 +2828,7 @@ Theorem~\ref{thm:trace_norm_abs}.
     \leanok
     \uses{def:support_inverse_square_root,
         lem:positive_sqrt_from_common_resolvents}
-    Let $A,B,C,D$ be positive semidefinite matrices such that
-    $\ker B\subseteq\ker A$ and $\ker D\subseteq\ker C$.  Write
+    Let $A,B,C,D$ be positive semidefinite matrices.  Write
     $B^+=(B^{-1/2}_{\mathrm{supp}})^2$ and
     $D^+=(D^{-1/2}_{\mathrm{supp}})^2$.  If, for every $t>0$,
     \[
@@ -2845,9 +2844,11 @@ Theorem~\ref{thm:trace_norm_abs}.
         =\sqrt C\,D^{-1/2}_{\mathrm{supp}}.
     \]
     This is the square-root specialization of the support functional-calculus
-    passage in Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 717--720 and
-    766--793.  It does not derive the common resolvent equality from equality
-    of relative entropies.
+    passage in Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 766--793.  No
+    kernel hypothesis is needed for this final implication once the common
+    generalized resolvents are given.  In the source application, the preceding
+    equality-to-resolvent argument is stated for pairs satisfying
+    $\ker B\subseteq\ker A$; this lemma does not formalize that preceding step.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2843,6 +2843,24 @@ Theorem~\ref{thm:trace_norm_abs}.
     as follows from uniqueness of the positive square root.
 \end{proof}
 
+\begin{lemma}[Right multiplication under transposed vectorization]
+    \label{lem:right_multiplication_transposed_vectorization}
+    \lean{Matrix.one_kronecker_transpose_mulVec_vec_transpose}
+    \leanok
+    For matrices $M$ and $P$, column-stacking vectorization satisfies
+    \[
+      \left(\mathbf 1\otimes P^{\mathsf T}\right)
+        \operatorname{vec}(M^{\mathsf T})
+      =\operatorname{vec}\!\left((MP)^{\mathsf T}\right).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    This is the Kronecker vectorization identity
+    $(B\otimes A)\operatorname{vec}(X)=\operatorname{vec}(AXB^{\mathsf T})$
+    with $A=P^{\mathsf T}$, $B=\mathbf 1$, and $X=M^{\mathsf T}$.
+\end{proof}
+
 \begin{lemma}[Relative modular square-root ratio on the support]
     \label{lem:support_relative_modular_sqrt_ratio}
     \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}
@@ -2880,7 +2898,8 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     \uses{lem:positive_sqrt_from_common_resolvents,
-        lem:support_inverse_square_root_positive_semidefinite}
+        lem:support_inverse_square_root_positive_semidefinite,
+        lem:right_multiplication_transposed_vectorization}
     The support inverse square roots are positive semidefinite.  Hence
     \[
       \sqrt{A\otimes(B^+)^{\mathsf T}}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1355,8 +1355,16 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
-    This follows from the spectral definition, since the reciprocal of every
-    positive square root is nonnegative and the zero eigenspace is sent to zero.
+    On the nonnegative spectrum of $\rho$, the defining function satisfies
+    \[
+      f(x)=
+      \begin{cases}
+        x^{-1/2}, & x>0,\\
+        0, & x=0
+      \end{cases}
+      \geq 0 \qquad (x\geq 0).
+    \]
+    The spectral functional calculus therefore gives $f(\rho)\geq 0$.
 \end{proof}
 
 \begin{lemma}[Support inverse square root of a positive-definite matrix]
@@ -2866,9 +2874,36 @@ Theorem~\ref{thm:trace_norm_abs}.
     with $A=P^{\mathsf T}$, $B=\mathbf 1$, and $X=M^{\mathsf T}$.
 \end{proof}
 
+\begin{lemma}[Support relative-modular square-root evaluation]
+    \label{lem:support_relative_modular_sqrt_evaluation}
+    \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    Let $A$ and $B$ be positive semidefinite, and write
+    $B^+=(B^{-1/2}_{\mathrm{supp}})^2$.  Then
+    \[
+      \sqrt{A\otimes(B^+)^{\mathsf T}}\,
+        \operatorname{vec}(\mathbf 1^{\mathsf T})
+      =\operatorname{vec}\!\left(
+        (\sqrt A\,B^{-1/2}_{\mathrm{supp}})^{\mathsf T}\right).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:support_inverse_square_root_positive_semidefinite}
+    The support inverse square root is positive semidefinite, and
+    \[
+      \left(\sqrt A\otimes
+        (B^{-1/2}_{\mathrm{supp}})^{\mathsf T}\right)^2
+      =A\otimes(B^+)^{\mathsf T}.
+    \]
+    Uniqueness of the positive square root gives the corresponding Kronecker
+    factorization.  Applying the Kronecker vectorization identity to
+    $\operatorname{vec}(\mathbf 1^{\mathsf T})$ gives the stated equation.
+\end{proof}
+
 \begin{lemma}[Relative modular square-root ratio on the support]
     \label{lem:support_relative_modular_sqrt_ratio}
-    \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}
     \lean{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq}
     \leanok
     \uses{def:support_inverse_square_root}
@@ -2903,14 +2938,9 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     \uses{lem:positive_sqrt_from_common_resolvents,
-        lem:support_inverse_square_root_positive_semidefinite,
+        lem:support_relative_modular_sqrt_evaluation,
         lem:right_multiplication_transposed_vectorization}
-    The support inverse square roots are positive semidefinite.  Hence
-    \[
-      \sqrt{A\otimes(B^+)^{\mathsf T}}
-        =\sqrt A\otimes(B^{-1/2}_{\mathrm{supp}})^{\mathsf T},
-    \]
-    with the analogous identity for $C,D$.  Consequently,
+    By Lemma~\ref{lem:support_relative_modular_sqrt_evaluation},
     \[
       \sqrt{A\otimes(B^+)^{\mathsf T}}\,
         \operatorname{vec}(\mathbf 1^{\mathsf T})

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2872,9 +2872,10 @@ Theorem~\ref{thm:trace_norm_abs}.
     This is the square-root specialization of the support functional-calculus
     passage in Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines 788--793.  The
     projection $P_B$ is essential: the source gives the common generalized
-    resolvents only after restriction to $(\ker B)^\perp$.  The preceding
-    equality-to-resolvent argument, including its kernel hypotheses, is not
-    formalized here.
+    resolvents only after restriction to $(\ker B)^\perp$.  Deriving this
+    restricted equality requires the preceding singular equality argument and
+    its kernel hypotheses.
+    % Formalization status: the preceding equality-to-resolvent step remains open.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -2885,10 +2886,16 @@ Theorem~\ref{thm:trace_norm_abs}.
       \sqrt{A\otimes(B^+)^{\mathsf T}}
         =\sqrt A\otimes(B^{-1/2}_{\mathrm{supp}})^{\mathsf T},
     \]
-    with the analogous identity for $C,D$.  Right multiplication by $P_B$ is a
-    fixed linear map on the vectorized matrix space.  Apply the projected
-    common-resolvent lemma, evaluate both relative-modular square roots on the
-    vectorized identity, and use injectivity of vectorization.
+    with the analogous identity for $C,D$.  Consequently,
+    \[
+      \sqrt{A\otimes(B^+)^{\mathsf T}}\,
+        \operatorname{vec}(\mathbf 1^{\mathsf T})
+      =\operatorname{vec}\!\left(
+        (\sqrt A\,B^{-1/2}_{\mathrm{supp}})^{\mathsf T}\right).
+    \]
+    Right multiplication by $P_B$ is a fixed linear transformation on the
+    vectorized matrix space.  Apply the projected common-resolvent lemma to this
+    identity and its analogue for $C,D$, then use injectivity of vectorization.
 \end{proof}
 
 \begin{theorem}[Positive-definite saturation gives the identity Weyl sandwich]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2826,9 +2826,14 @@ Theorem~\ref{thm:trace_norm_abs}.
       f_t(S)x=t^{-1/2}x-t^{1/2}(t\mathbf 1+S)^{-1}x.
     \]
     The hypothesis therefore gives $f_t(S)x=f_t(T)x$ for every $t>0$.
-    Applying a fixed matrix $Q$, when present, commutes with this finite-
-    dimensional integral.  Integration gives the asserted equality of the
-    positive square roots on $x$.
+    Since left multiplication by $Q$ is a bounded linear map on
+    $\mathbb{M}_n(\mathbb{C})$,
+    \[
+      Q\int_0^\infty f_t(S)\,d\mu(t)
+        =\int_0^\infty Qf_t(S)\,d\mu(t),
+    \]
+    and similarly for $T$.  Integration therefore gives
+    $Q\sqrt S\,x=Q\sqrt T\,x$.
 
     For the second assertion, factor
     \[
@@ -2912,9 +2917,20 @@ Theorem~\ref{thm:trace_norm_abs}.
       =\operatorname{vec}\!\left(
         (\sqrt A\,B^{-1/2}_{\mathrm{supp}})^{\mathsf T}\right).
     \]
-    Right multiplication by $P_B$ is a fixed linear transformation on the
-    vectorized matrix space.  Apply the projected common-resolvent lemma to this
-    identity and its analogue for $C,D$, then use injectivity of vectorization.
+    Setting $Q=\mathbf 1\otimes P_B^{\mathsf T}$ and applying the common-
+    resolvent lemma (Lemma~\ref{lem:positive_sqrt_from_common_resolvents}) gives
+    \[
+      \operatorname{vec}\!\left(
+        (\sqrt A\,B^{-1/2}_{\mathrm{supp}}P_B)^{\mathsf T}\right)
+      =\operatorname{vec}\!\left(
+        (\sqrt C\,D^{-1/2}_{\mathrm{supp}}P_B)^{\mathsf T}\right).
+    \]
+    Since
+    \[
+      \operatorname{vec}(X^{\mathsf T})
+        =\operatorname{vec}(Y^{\mathsf T})\quad\Longrightarrow\quad X=Y,
+    \]
+    injectivity of vectorization gives the conclusion.
 \end{proof}
 
 \begin{theorem}[Positive-definite saturation gives the identity Weyl sandwich]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1345,6 +1345,20 @@ Theorem~\ref{thm:trace_norm_abs}.
     Hermitian.
 \end{lemma}
 
+\begin{lemma}[Positivity of the support inverse square root]
+    \label{lem:support_inverse_square_root_positive_semidefinite}
+    \lean{Matrix.PosSemidef.supportInvSqrt_posSemidef}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    The inverse square root of a positive semidefinite matrix on its support is
+    positive semidefinite.
+\end{lemma}
+
+\begin{proof}\leanok
+    This follows from the spectral definition, since the reciprocal of every
+    positive square root is nonnegative and the zero eigenspace is sent to zero.
+\end{proof}
+
 \begin{lemma}[Support inverse square root of a positive-definite matrix]
     \label{lem:support_inverse_square_root_positive_definite}
     \lean{Matrix.PosDef.supportInvSqrt_eq_inv_sqrt}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2826,11 +2826,11 @@ Theorem~\ref{thm:trace_norm_abs}.
       f_t(S)x=t^{-1/2}x-t^{1/2}(t\mathbf 1+S)^{-1}x.
     \]
     The hypothesis therefore gives $f_t(S)x=f_t(T)x$ for every $t>0$.
-    Since left multiplication by $Q$ is a bounded linear map on
-    $\mathbb{M}_n(\mathbb{C})$,
+    Since $M\mapsto Q(Mx)$ is a bounded linear map from
+    $\mathbb{M}_n(\mathbb{C})$ to $\mathbb{C}^n$,
     \[
-      Q\int_0^\infty f_t(S)\,d\mu(t)
-        =\int_0^\infty Qf_t(S)\,d\mu(t),
+      Q\left(\left(\int_0^\infty f_t(S)\,d\mu(t)\right)x\right)
+        =\int_0^\infty Q\bigl(f_t(S)x\bigr)\,d\mu(t),
     \]
     and similarly for $T$.  Integration therefore gives
     $Q\sqrt S\,x=Q\sqrt T\,x$.

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -359,6 +359,7 @@ arXiv:0903.2895v4, lines 658--680.  The formal proof uses the equivalent
 L\"owner integral representation of the power $p=1/2$.
 \footnote{Formal declarations:
 \leanid{Matrix.sqrt_mulVec_eq_of_resolvent_mulVec_eq},
+\leanid{Matrix.mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq},
 \leanid{Matrix.sourceB_resolvent_eq_relativeModular}, and
 \leanid{Matrix.relativeModular_sqrt_mulVec_vec_one} in
 \path{TNLean/Analysis/ResolventFunctionalCalculus.lean}; and
@@ -376,22 +377,31 @@ $\ker B\subseteq\ker A$; see arXiv:0903.2895v4, lines 717--720.  Their singular
 equality argument then obtains the common relative-modular resolvent on the
 reference support and passes through functional calculus; see lines 766--793.
 Following the latter step, if two positive semidefinite pairs already have the
-same shifted generalized relative-modular resolvents on the vectorized identity,
-then
+same shifted generalized relative-modular resolvents on the identity after
+right restriction to the support projection $P_B$ of the smaller reference,
+then their square-root ratios agree on that same support:
 \begin{align}
-  \sqrt A\,B^{-1/2}_{\mathrm{supp}}
-    =\sqrt C\,D^{-1/2}_{\mathrm{supp}}.
+  \bigl(\sqrt A\,B^{-1/2}_{\mathrm{supp}}\bigr)P_B
+    =\bigl(\sqrt C\,D^{-1/2}_{\mathrm{supp}}\bigr)P_B.
 \end{align}
 Here the generalized inverse is the square of the support inverse square root.
 \footnote{Formal declarations:
 \leanid{Matrix.supportRelativeModular_sqrt_mulVec_vec_one} and
 \leanid{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq} in
 \path{TNLean/Channel/Schwarz/SupportRelativeModular.lean}.}
-No kernel hypothesis is needed for this final functional-calculus implication.
+The restriction is essential.  Equality on the ambient vectorized identity
+would force equality of the two reference support projections, since each
+resolvent contributes $t^{-1}$ on the complement of its reference support.
+This is false in the intended data-processing application: if
+$\rho=\sigma$ is a rank-one maximally entangled state, equality under partial
+trace is automatic, whereas the comparison pair formed from its marginal is
+full rank.  Thus the ambient resolvent equality is not a consequence of the
+singular equality theorem.
+
 The kernel inclusion belongs to the preceding source theorem that must derive
-the common support resolvents from equality in data processing.  That theorem
-is not yet formalized, and therefore neither is the singular Petz recovery
-identity.
+the support-restricted common resolvents from equality in data processing.  That
+theorem is not yet formalized, and therefore neither is the singular Petz
+recovery identity.
 
 In particular, the affine regularizations used to prove the inequality cannot
 by themselves prove its equality case.  Equality at the limiting pair implies

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -375,9 +375,9 @@ definition and convexity argument directly to positive semidefinite pairs with
 $\ker B\subseteq\ker A$; see arXiv:0903.2895v4, lines 717--720.  Their singular
 equality argument then obtains the common relative-modular resolvent on the
 reference support and passes through functional calculus; see lines 766--793.
-Following the latter step, if two positive semidefinite supported pairs already
-have the same shifted generalized relative-modular resolvents on the vectorized
-identity, then
+Following the latter step, if two positive semidefinite pairs already have the
+same shifted generalized relative-modular resolvents on the vectorized identity,
+then
 \begin{align}
   \sqrt A\,B^{-1/2}_{\mathrm{supp}}
     =\sqrt C\,D^{-1/2}_{\mathrm{supp}}.
@@ -387,9 +387,11 @@ Here the generalized inverse is the square of the support inverse square root.
 \leanid{Matrix.supportRelativeModular_sqrt_mulVec_vec_one} and
 \leanid{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq} in
 \path{TNLean/Channel/Schwarz/SupportRelativeModular.lean}.}
-This proves only the resolvent-to-square-root passage.  It does not yet derive
-the common support resolvents from equality in data processing, and therefore
-does not yet prove the singular Petz recovery identity.
+No kernel hypothesis is needed for this final functional-calculus implication.
+The kernel inclusion belongs to the preceding source theorem that must derive
+the common support resolvents from equality in data processing.  That theorem
+is not yet formalized, and therefore neither is the singular Petz recovery
+identity.
 
 In particular, the affine regularizations used to prove the inequality cannot
 by themselves prove its equality case.  Equality at the limiting pair implies

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -370,6 +370,34 @@ Thus equality under the partial trace implies raw Petz recovery for positive
 definite inputs.  The remaining analytic work is the extension of this passage
 to singular supports.
 
+One part of that extension is now available.  Jen\v{c}ov\'a--Ruskai extend the
+definition and convexity argument directly to positive semidefinite pairs with
+$\ker B\subseteq\ker A$; see arXiv:0903.2895v4, lines 717--720.  Their singular
+equality argument then obtains the common relative-modular resolvent on the
+reference support and passes through functional calculus; see lines 766--793.
+Following the latter step, if two positive semidefinite supported pairs already
+have the same shifted generalized relative-modular resolvents on the vectorized
+identity, then
+\begin{align}
+  \sqrt A\,B^{-1/2}_{\mathrm{supp}}
+    =\sqrt C\,D^{-1/2}_{\mathrm{supp}}.
+\end{align}
+Here the generalized inverse is the square of the support inverse square root.
+\footnote{Formal declarations:
+\leanid{Matrix.supportRelativeModular_sqrt_mulVec_vec_one} and
+\leanid{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq} in
+\path{TNLean/Channel/Schwarz/SupportRelativeModular.lean}.}
+This proves only the resolvent-to-square-root passage.  It does not yet derive
+the common support resolvents from equality in data processing, and therefore
+does not yet prove the singular Petz recovery identity.
+
+In particular, the affine regularizations used to prove the inequality cannot
+by themselves prove its equality case.  Equality at the limiting pair implies
+only that the nonnegative regularized gaps tend to zero; it does not imply that
+any gap at positive regularization parameter is zero.  Thus the
+positive-definite equality theorem cannot be applied pointwise to those
+regularized pairs without an additional equality-preservation theorem.
+
 There is nevertheless a useful algebraic reduction for the identity summand.
 Write
 \[

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -384,8 +384,15 @@ then their square-root ratios agree on that same support:
   \bigl(\sqrt A\,B^{-1/2}_{\mathrm{supp}}\bigr)P_B
     =\bigl(\sqrt C\,D^{-1/2}_{\mathrm{supp}}\bigr)P_B.
 \end{align}
+The orientation of the vectorized restriction is fixed by
+\begin{align}
+  (\mathbf 1\otimes P_B^{\mathsf T})
+    \operatorname{vec}(M^{\mathsf T})
+    =\operatorname{vec}\bigl((MP_B)^{\mathsf T}\bigr).
+\end{align}
 Here the generalized inverse is the square of the support inverse square root.
 \footnote{Formal declarations:
+\leanid{Matrix.one_kronecker_transpose_mulVec_vec_transpose},
 \leanid{Matrix.supportRelativeModular_sqrt_mulVec_vec_one} and
 \leanid{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq} in
 \path{TNLean/Channel/Schwarz/SupportRelativeModular.lean}.}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -376,10 +376,21 @@ definition and convexity argument directly to positive semidefinite pairs with
 $\ker B\subseteq\ker A$; see arXiv:0903.2895v4, lines 717--720.  Their singular
 equality argument then obtains the common relative-modular resolvent on the
 reference support and passes through functional calculus; see lines 766--793.
-Following the latter step, if two positive semidefinite pairs already have the
-same shifted generalized relative-modular resolvents on the identity after
-right restriction to the support projection $P_B$ of the smaller reference,
-then their square-root ratios agree on that same support:
+Following the latter step, consider two positive semidefinite pairs $(A,B)$ and
+$(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
+$B$, and write
+$B^+=(B^{-1/2}_{\mathrm{supp}})^2$ and
+$D^+=(D^{-1/2}_{\mathrm{supp}})^2$.  Suppose that, for every $t>0$, their
+shifted generalized relative-modular resolvents satisfy
+\begin{align}
+  &(\mathbf 1\otimes P_B^{\mathsf T})
+    \bigl(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\bigr)^{-1}
+    \operatorname{vec}(\mathbf 1^{\mathsf T}) \notag\\
+  &\qquad=(\mathbf 1\otimes P_B^{\mathsf T})
+    \bigl(t\mathbf 1+C\otimes(D^+)^{\mathsf T}\bigr)^{-1}
+    \operatorname{vec}(\mathbf 1^{\mathsf T}).
+\end{align}
+Then their square-root ratios agree on the same support:
 \begin{align}
   \bigl(\sqrt A\,B^{-1/2}_{\mathrm{supp}}\bigr)P_B
     =\bigl(\sqrt C\,D^{-1/2}_{\mathrm{supp}}\bigr)P_B.


### PR DESCRIPTION
### Motivation

- Issue LionSR/QICLean#243 asks for the singular-support extension of the positive-definite recovery argument, without invertibility or trace-one assumptions.
- The proposed affine perturbation does not transport equality: convergence of the nonnegative regularized gaps to zero does not make any positive-parameter gap vanish.
- Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720, extend the convexity analysis directly to positive semidefinite pairs with `ker B ⊆ ker A`; lines 766--793 pass from the resulting common resolvent on the reference support to functional calculus. Their conclusion at this stage is the support-domain modular identity, not equality for perturbed pairs.

### Description

- Prove that the support inverse square root of a positive semidefinite matrix is positive semidefinite.
- Extend the common-resolvent functional-calculus lemma to permit a fixed matrix
  to be applied to every resolvent value and to the resulting square-root value.
- Add `SupportRelativeModular.lean`, proving that
  `sqrt (A ⊗ (B⁺)ᵀ)` applied to the vectorized identity is the vectorization of `sqrt A * B⁻¹ᐟ²_support`.
- Prove the independently reviewable support functional-calculus milestone in
  the form actually supplied by Jenčová--Ruskai: after both generalized
  relative-modular resolvent values are right-restricted by the smaller
  reference support projection `P_B`, equality for every positive shift implies
  equality of the two support square-root ratios after right restriction by
  that same `P_B`.
- Make the vectorization orientation explicit in a checked theorem:
  `(1 ⊗ Pᵀ) vec(Mᵀ) = vec((M P)ᵀ)`. This is the direct specialization of
  `Matrix.kronecker_mulVec_vec` appropriate to the transposed-vector convention
  used by the relative-modular lemmas.
- Explicitly rule out the stronger ambient-vectorized-identity premise: it
  would force the reference support projections to agree and therefore fails,
  for example, for a rank-one maximally entangled state compared with the
  full-rank pair formed from its marginal.
- The kernel inclusions belong to the upstream equality-to-common-resolvent
  theorem and are not redundant arguments of this final functional-calculus
  implication.
- Record in the blueprint and paper-gap note that this PR proves only the resolvent-to-square-root passage. Deriving the common support resolvents from data-processing equality, the identity sandwich, and final Petz recovery remain open.

### Testing

- `lake env lean TNLean/Channel/Schwarz/SupportRelativeModular.lean`
- `lake build`
- `lake exe checkdecls /tmp/tnlean_4405_new_lean_decls` for the five new declarations
- `lake env lean /tmp/TNLeanIssue4405Orientation.lean` for a `Fin 2`
  nonsymmetric orientation check
- `leanblueprint pdf`
- integrity scan of `TNLean/Analysis/ResolventFunctionalCalculus.lean`,
  `TNLean/Channel/PetzRecovery.lean`, and
  `TNLean/Channel/Schwarz/SupportRelativeModular.lean`
- `git diff --check`

The full `leanblueprint checkdecls` wrapper could not regenerate `blueprint/lean_decls` locally because the installed web generator loads an incompatible `pygraphviz` extension. The underlying declaration checker succeeded on every declaration added by this PR.

---
Addresses LionSR/QICLean#243

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive formalization in analysis/channel Schwarz layer with no runtime or auth impact; main risk is mathematical/API surface growth and explicit scoping so callers do not assume DPI→resolvent is proved.
> 
> **Overview**
> Formalizes the **support-restricted** step from matching generalized relative-modular resolvents to equality of support square-root ratios (Jenčová–Ruskai §4.2), not full singular Petz recovery from data-processing equality.
> 
> **`PetzRecovery`:** proves the support inverse square root `supportInvSqrt` is positive semidefinite.
> 
> **`ResolventFunctionalCalculus`:** adds `mulVec_sqrt_mulVec_eq_of_mulVec_resolvent_mulVec_eq` (fixed `Q` may act on every shifted resolvent and on the square-root vectors); reimplements `sqrt_mulVec_eq_of_resolvent_mulVec_eq` as the `Q = 1` case.
> 
> **New `SupportRelativeModular.lean`:** Kronecker/vectorization identity for `(1 ⊗ Pᵀ)` on transposed `vec`; evaluation of `sqrt(A ⊗ (B⁺)ᵀ)` on `vec(1ᵀ)`; main implication—if support-projected resolvents agree for all `t > 0`, then `(√A B⁻¹ᐟ²_support) P_B = (√C D⁻¹ᐟ²_support) P_B`. Documents that deriving those resolvents from DPI/kernel hypotheses remains open.
> 
> **Docs:** blueprint entropy chapter and `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex` updated; root import for `SupportRelativeModular`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9893bd0a13aae8c250a31869d4f2c0ee838734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->