### PR TITLE
docs(tenkz): migrate BNT vertical product

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -218,7 +218,22 @@
 
 The physical supports are locally orthogonal:
 \begin{center}
-    \TNMPDOBNTVerticalProduct
+    % Formula: (\mathcal K_y^*\mathcal K_x)^{ij}_{a_y a_x;b_y b_x}
+    % = \sum_q (\mathcal K_y^*)^{iq}_{a_y b_y}
+    % (\mathcal K_x)^{qj}_{a_x b_x}=0 for x\ne y.
+    % Source: Papers/1606.00608/MPDO_KxKy.png and source TeX lines 863--868.
+    % Source verdict: the upper source glyph is plain \mathcal K_y, without a
+    % conjugate skin; here it is the source's adjoint-oriented upper occurrence.
+    % Ink-to-index: q is the sole contracted physical index; the free indices
+    % are west (a_y,a_x), east (b_y,b_x), up i, and down j.
+    % LHS paired signature: boundary|virtual-west=2|virtual-east=2|
+    % physical-up=1|physical-down=1. The typed-zero RHS has that same boundary
+    % type, although the plain 0 carries no tensor-network ink.
+    \begin{tenkz}[rows={op,op}]
+        \tn[mpo]{\mathcal K_y} \\
+        \tn[mpo]{\mathcal K_x}
+    \end{tenkz}
+    $\;=\;0\qquad(x\ne y)$
 \end{center}
 In contraction notation, local orthogonality is
 $\mathcal K_y^*\mathcal K_x=0$ whenever $x\ne y$.

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -332,29 +332,6 @@
     \end{TNEquationRow}%
 }
 
-% Vertical product of two distinct basis tensors, contracted through the
-% shared physical index.
-\TNDeclareDiagram
-    {TNMPDOBNTVerticalProduct}
-    {}
-    {display}
-    {compact}
-    {\TNMPDOBNTVerticalProduct}
-    {chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex}{%
-    \begin{TNEquationRow}[compact]
-        \TNTerm{%
-            \TNStackedMPOProduct{vp}{at=origin}{\mathcal K_y}{\mathcal K_x}{}
-            \TNOpenVirtualWest{vpUpperWest}
-            \TNOpenVirtualEast{vpUpperEast}
-            \TNOpenVirtualWest{vpLowerWest}
-            \TNOpenVirtualEast{vpLowerEast}
-            \TNOpenPhysicalNorth{vpUpperKet}
-            \TNOpenPhysicalSouth{vpLowerBra}}
-        \TNRelation{=}
-        \ensuremath{0\qquad(x\ne y)}
-    \end{TNEquationRow}%
-}
-
 % The two block closure maps: a boundary insertion on the virtual bond of a
 % block tensor, with the virtual loop closed by the trace, gives an operator
 % on the open physical legs.


### PR DESCRIPTION
Closes #4428.

## Summary

- inline the BNT local-orthogonality picture as a two-row `tenkz` diagram
- keep the source's plain `K_y` over plain `K_x`, with exactly one physical contraction and free boundary `(2,2,1,1)`
- retain the typed zero as plain mathematics and document its tensor-space type in source comments
- remove the obsolete whole-figure catalogue declaration

## Source fidelity

The migration follows `Papers/1606.00608/MPDO_KxKy.png` and source TeX lines 863--868. The source image has no conjugate skin on the upper box; the adjoint is represented only by this source formula's upper occurrence. The emitted trace records two MPO atoms, one adjacent physical pairing, and

`boundary|virtual-west=2|virtual-east=2|physical-up=1|physical-down=1`.

## Validation

- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex`
- `python3 scripts/check_tn_references.py --margins-only`
- `git diff --check`
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- visually inspected PDF page 633 and `web/tenkz_svg/tenkz-b5e868b70784bcf1.svg`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-rendering only; no Lean or runtime logic changes.
> 
> **Overview**
> Replaces the catalogue macro **`\TNMPDOBNTVerticalProduct`** with an inline **`tenkz`** block in the local simple-MPDO structure capstone, showing BNT local orthogonality as two stacked MPO tensors **`\mathcal K_y`** / **`\mathcal K_x`** equated to **0** for **x ≠ y**.
> 
> The inline diagram documents source alignment (Cirac2016 MPDO figure and TeX), index wiring (single physical contraction, boundary signature 2|2|1|1), and how the adjoint appears in the accompanying formula. The **`TNMPDOBNTVerticalProduct`** **`TNDeclareDiagram`** entry is removed from **`tn_catalogue.tex`** as obsolete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6c16956757b18f13512539ca4f9bf28362092f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->