### PR TITLE
feat(MPS/RFP): prove Beigi loop ground-state membership

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -100,9 +100,10 @@ theorem trace_blockDiagonal'_mul
 /-- A dependent product of matrices fixes a pure tensor whenever every factor
 fixes the corresponding vector. -/
 theorem piProduct_mulVec_pureTensor
+    {R : Type*} [CommSemiring R]
     {N : ℕ} {α : Fin N → Type*} [∀ n, Fintype (α n)]
-    (P : (n : Fin N) → Matrix (α n) (α n) ℂ)
-    (v : (n : Fin N) → α n → ℂ)
+    (P : (n : Fin N) → Matrix (α n) (α n) R)
+    (v : (n : Fin N) → α n → R)
     (hv : ∀ n, (P n).mulVec (v n) = v n)
     (x : (n : Fin N) → α n) :
     Matrix.mulVec
@@ -123,7 +124,8 @@ theorem piProduct_mulVec_pureTensor
 /-- Reindexing a square matrix along an equivalence intertwines its action on
 vectors with precomposition by the inverse equivalence. -/
 theorem reindex_mulVec {α β : Type*} [Fintype α] [Fintype β]
-    (e : α ≃ β) (M : Matrix α α ℂ) (v : α → ℂ) :
+    {R : Type*} [NonUnitalNonAssocSemiring R]
+    (e : α ≃ β) (M : Matrix α α R) (v : α → R) :
     (Matrix.reindex e e M).mulVec (v ∘ e.symm) =
       (M.mulVec v) ∘ e.symm := by
   funext x

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -97,9 +97,28 @@ theorem trace_blockDiagonal'_mul
 
 /-! ## Matrix action on product vectors -/
 
+/-- A dependent product of matrices acts componentwise on a pure tensor. -/
+theorem piProduct_mulVec_pureTensor
+    {R : Type*} [CommSemiring R]
+    {N : ℕ} {α : Fin N → Type*} [∀ n, Fintype (α n)]
+    (P : (n : Fin N) → Matrix (α n) (α n) R)
+    (v : (n : Fin N) → α n → R)
+    (x : (n : Fin N) → α n) :
+    Matrix.mulVec
+        (fun (x y : (n : Fin N) → α n) ↦ ∏ n, P n (x n) (y n))
+        (fun y : (n : Fin N) → α n ↦ ∏ n, v n (y n)) x =
+      ∏ n, (P n).mulVec (v n) (x n) := by
+  classical
+  simp only [Matrix.mulVec, dotProduct]
+  rw [← Fintype.piFinset_univ]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Finset.prod_univ_sum
+    (fun n : Fin N ↦ (Finset.univ : Finset (α n)))
+    (fun n y ↦ P n (x n) y * v n y)]
+
 /-- A dependent product of matrices fixes a pure tensor whenever every factor
 fixes the corresponding vector. -/
-theorem piProduct_mulVec_pureTensor
+theorem piProduct_mulVec_pureTensor_of_mulVec_eq_self
     {R : Type*} [CommSemiring R]
     {N : ℕ} {α : Fin N → Type*} [∀ n, Fintype (α n)]
     (P : (n : Fin N) → Matrix (α n) (α n) R)
@@ -110,16 +129,10 @@ theorem piProduct_mulVec_pureTensor
         (fun (x y : (n : Fin N) → α n) ↦ ∏ n, P n (x n) (y n))
         (fun y : (n : Fin N) → α n ↦ ∏ n, v n (y n)) x =
       ∏ n, v n (x n) := by
-  classical
-  simp only [Matrix.mulVec, dotProduct]
-  rw [← Fintype.piFinset_univ]
-  simp_rw [← Finset.prod_mul_distrib]
-  rw [← Finset.prod_univ_sum
-    (fun n : Fin N ↦ (Finset.univ : Finset (α n)))
-    (fun n y ↦ P n (x n) y * v n y)]
+  rw [piProduct_mulVec_pureTensor]
   apply Finset.prod_congr rfl
   intro n _
-  simpa only [Matrix.mulVec, dotProduct] using congrFun (hv n) (x n)
+  exact congrFun (hv n) (x n)
 
 /-- Reindexing a square matrix along an equivalence intertwines its action on
 vectors with precomposition by the inverse equivalence. -/

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -31,6 +31,9 @@ Extracted from various files for reusability.
   multiplicativity for Kronecker products
 - `Matrix.trace_blockDiagonal'_mul`: the trace pairing with a dependent
   block-diagonal matrix is the sum over diagonal block compressions
+- `Matrix.piProduct_mulVec_pureTensor`: a dependent product of matrices acts
+  componentwise on a pure tensor
+- `Matrix.reindex_mulVec`: matrix reindexing intertwines matrix--vector action
 - `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one`: determinant
   AM--GM lower bound for the Hilbert--Schmidt trace form
 - `Matrix.PosSemidef.trace_mul_nonneg`: the trace product of two positive
@@ -91,6 +94,43 @@ theorem trace_blockDiagonal'_mul
     simp
   · intro hi
     exact (hi (Finset.mem_univ _)).elim
+
+/-! ## Matrix action on product vectors -/
+
+/-- A dependent product of matrices fixes a pure tensor whenever every factor
+fixes the corresponding vector. -/
+theorem piProduct_mulVec_pureTensor
+    {N : ℕ} {α : Fin N → Type*} [∀ n, Fintype (α n)]
+    (P : (n : Fin N) → Matrix (α n) (α n) ℂ)
+    (v : (n : Fin N) → α n → ℂ)
+    (hv : ∀ n, (P n).mulVec (v n) = v n)
+    (x : (n : Fin N) → α n) :
+    Matrix.mulVec
+        (fun (x y : (n : Fin N) → α n) ↦ ∏ n, P n (x n) (y n))
+        (fun y : (n : Fin N) → α n ↦ ∏ n, v n (y n)) x =
+      ∏ n, v n (x n) := by
+  classical
+  simp only [Matrix.mulVec, dotProduct]
+  rw [← Fintype.piFinset_univ]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Finset.prod_univ_sum
+    (fun n : Fin N ↦ (Finset.univ : Finset (α n)))
+    (fun n y ↦ P n (x n) y * v n y)]
+  apply Finset.prod_congr rfl
+  intro n _
+  simpa only [Matrix.mulVec, dotProduct] using congrFun (hv n) (x n)
+
+/-- Reindexing a square matrix along an equivalence intertwines its action on
+vectors with precomposition by the inverse equivalence. -/
+theorem reindex_mulVec {α β : Type*} [Fintype α] [Fintype β]
+    (e : α ≃ β) (M : Matrix α α ℂ) (v : α → ℂ) :
+    (Matrix.reindex e e M).mulVec (v ∘ e.symm) =
+      (M.mulVec v) ∘ e.symm := by
+  funext x
+  simp only [Matrix.mulVec, dotProduct, Matrix.reindex_apply,
+    Function.comp_apply]
+  exact Equiv.sum_comp e.symm
+    (fun y : α ↦ M (e.symm x) y * v y)
 
 /-! ## Uniform density matrices -/
 

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -134,15 +134,8 @@ private theorem edgeProjector_mulVec_loopBondVector
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
     (F.edgeProjector l.1 l.1).mulVec (F.loopBondVector l) =
       F.loopBondVector l := by
-  have hproj : LinearMap.IsProj (F.edgeGroundSpace l.1 l.1)
-      (Matrix.toLin' (F.edgeProjector l.1 l.1)) := by
-    rw [edgeGroundSpace, LinearMap.isProj_range_iff_isIdempotentElem]
-    change Matrix.toLin' (F.edgeProjector l.1 l.1) *
-      Matrix.toLin' (F.edgeProjector l.1 l.1) =
-        Matrix.toLin' (F.edgeProjector l.1 l.1)
-    rw [Module.End.mul_eq_comp, ← Matrix.toLin'_mul,
-      (F.edgeProjector_isOrthogonal l.1 l.1).2.eq]
-  exact hproj.mem_iff_map_id.mp (F.loopBondVector_mem l)
+  exact (F.edgeProjector_isProj l.1 l.1).mem_iff_map_id.mp
+    (F.loopBondVector_mem l)
 
 private theorem loopCyclicProduct_etaCyclicEdgeEquiv_symm_constant
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -323,9 +323,6 @@ private theorem groundBondProduct_mulVec_loopProductState
         (star (F.unitary ⊗ₖ F.unitary) *
           twoSiteParentGroundProjectorMatrix A *
             (F.unitary ⊗ₖ F.unitary)))).prod
-  have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
-    simpa only [Matrix.star_eq_conjTranspose] using
-      Unitary.star_mul_self_of_mem F.unitary_mem
   have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
     simpa only [Matrix.star_eq_conjTranspose] using
       Unitary.mul_star_self_of_mem F.unitary_mem
@@ -334,20 +331,7 @@ private theorem groundBondProduct_mulVec_loopProductState
     rw [MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose, hUUstar,
       MPOTensor.sitewisePhysicalMatrix_one]
   have hconj : singleKrausMap (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N) Q = T := by
-    have hprod := MPOTensor.singleKrausMap_bondProduct_of_unitary F.unitaryᴴ
-      (by simpa using hUUstar) (by simpa using hUstarU) hN
-      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
-        (finTwoArrowEquiv (Fin d)).symm (twoSiteParentGroundProjectorMatrix A))
-    simp_rw [MPOTensor.singleKrausMap_sitewise_conjTranspose_two_eq] at hprod
-    have hpair : MPOTensor.pairBondMatrix
-        (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
-          (finTwoArrowEquiv (Fin d)).symm
-          (twoSiteParentGroundProjectorMatrix A)) =
-        twoSiteParentGroundProjectorMatrix A := by
-      ext x y
-      simp [MPOTensor.pairBondMatrix, Matrix.reindex_apply]
-    rw [hpair] at hprod
-    simpa only [Q, T] using hprod
+    simpa only [Q, T] using F.singleKrausMap_groundBondProduct hN
   have hmatrix : Q * W = W * T := by
     have hconj' : Wᴴ * Q * W = T := by
       simpa only [singleKrausMap_apply,

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -144,37 +144,6 @@ private theorem edgeProjector_mulVec_loopBondVector
       (F.edgeProjector_isOrthogonal l.1 l.1).2.eq]
   exact hproj.mem_iff_map_id.mp (F.loopBondVector_mem l)
 
-private theorem piProduct_mulVec_pureTensor
-    {N : ℕ} {α : Fin N → Type*} [∀ n, Fintype (α n)]
-    (P : (n : Fin N) → Matrix (α n) (α n) ℂ)
-    (v : (n : Fin N) → α n → ℂ)
-    (hv : ∀ n, (P n).mulVec (v n) = v n)
-    (x : (n : Fin N) → α n) :
-    Matrix.mulVec
-        (fun (x y : (n : Fin N) → α n) ↦ ∏ n, P n (x n) (y n))
-        (fun y : (n : Fin N) → α n ↦ ∏ n, v n (y n)) x =
-      ∏ n, v n (x n) := by
-  classical
-  simp only [Matrix.mulVec, dotProduct]
-  rw [← Fintype.piFinset_univ]
-  simp_rw [← Finset.prod_mul_distrib]
-  rw [← Finset.prod_univ_sum
-    (fun n : Fin N ↦ (Finset.univ : Finset (α n)))
-    (fun n y ↦ P n (x n) y * v n y)]
-  apply Finset.prod_congr rfl
-  intro n _
-  simpa only [Matrix.mulVec, dotProduct] using congrFun (hv n) (x n)
-
-private theorem reindex_mulVec {α β : Type*} [Fintype α] [Fintype β]
-    (e : α ≃ β) (M : Matrix α α ℂ) (v : α → ℂ) :
-    (Matrix.reindex e e M).mulVec (v ∘ e.symm) =
-      (M.mulVec v) ∘ e.symm := by
-  funext x
-  simp only [Matrix.mulVec, dotProduct, Matrix.reindex_apply,
-    Function.comp_apply]
-  exact Equiv.sum_comp e.symm
-    (fun y : α ↦ M (e.symm x) y * v y)
-
 private theorem loopCyclicProduct_etaCyclicEdgeEquiv_symm_constant
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
     {N : ℕ} [NeZero N]
@@ -276,7 +245,7 @@ private theorem blockGroundProduct_mulVec_loopCyclicProduct
     by_cases hk : k = fun _ ↦ l.1
     · subst k
       simp_rw [F.loopCyclicProduct_etaCyclicEdgeEquiv_symm_constant l]
-      exact piProduct_mulVec_pureTensor
+      exact Matrix.piProduct_mulVec_pureTensor
         (fun _ : Fin N ↦ F.edgeProjector l.1 l.1)
         (fun _ : Fin N ↦ F.loopBondVector l)
         (fun _ ↦ F.edgeProjector_mulVec_loopBondVector l) x
@@ -325,7 +294,7 @@ private theorem transformedGroundBondProduct_mulVec_loopCyclicProduct
       (F.loopCyclicProduct l ∘ e.symm) = F.loopCyclicProduct l ∘ e.symm := by
     rw [hblocks]
     exact F.blockGroundProduct_mulVec_loopCyclicProduct l
-  rw [reindex_mulVec] at hfix
+  rw [Matrix.reindex_mulVec] at hfix
   funext s
   have hs := congrFun hfix (e s)
   simpa only [Function.comp_apply, Equiv.symm_apply_apply] using hs

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -30,7 +30,7 @@ from a product over disjoint pairs of physical sites.
   Hamiltonians*, arXiv:1105.1019v2, Section IV, source lines 602--606.
 -/
 
-open scoped BigOperators Matrix
+open scoped BigOperators Kronecker Matrix
 
 namespace MPSTensor.BeigiSectorGraphData
 
@@ -129,6 +129,323 @@ noncomputable def loopProductState (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] : NSiteSpace d N :=
   fun s ↦ ∑ t : Fin N → Fin d,
     (∏ n : Fin N, F.unitary (s n) (t n)) * F.loopCyclicProduct l t
+
+private theorem edgeProjector_mulVec_loopBondVector
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    (F.edgeProjector l.1 l.1).mulVec (F.loopBondVector l) =
+      F.loopBondVector l := by
+  have hproj : LinearMap.IsProj (F.edgeGroundSpace l.1 l.1)
+      (Matrix.toLin' (F.edgeProjector l.1 l.1)) := by
+    rw [edgeGroundSpace, LinearMap.isProj_range_iff_isIdempotentElem]
+    change Matrix.toLin' (F.edgeProjector l.1 l.1) *
+      Matrix.toLin' (F.edgeProjector l.1 l.1) =
+        Matrix.toLin' (F.edgeProjector l.1 l.1)
+    rw [Module.End.mul_eq_comp, ← Matrix.toLin'_mul,
+      (F.edgeProjector_isOrthogonal l.1 l.1).2.eq]
+  exact hproj.mem_iff_map_id.mp (F.loopBondVector_mem l)
+
+private theorem piProduct_mulVec_pureTensor
+    {N : ℕ} {α : Fin N → Type*} [∀ n, Fintype (α n)]
+    (P : (n : Fin N) → Matrix (α n) (α n) ℂ)
+    (v : (n : Fin N) → α n → ℂ)
+    (hv : ∀ n, (P n).mulVec (v n) = v n)
+    (x : (n : Fin N) → α n) :
+    Matrix.mulVec
+        (fun (x y : (n : Fin N) → α n) ↦ ∏ n, P n (x n) (y n))
+        (fun y : (n : Fin N) → α n ↦ ∏ n, v n (y n)) x =
+      ∏ n, v n (x n) := by
+  classical
+  simp only [Matrix.mulVec, dotProduct]
+  rw [← Fintype.piFinset_univ]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Finset.prod_univ_sum
+    (fun n : Fin N ↦ (Finset.univ : Finset (α n)))
+    (fun n y ↦ P n (x n) y * v n y)]
+  apply Finset.prod_congr rfl
+  intro n _
+  simpa only [Matrix.mulVec, dotProduct] using congrFun (hv n) (x n)
+
+private theorem reindex_mulVec {α β : Type*} [Fintype α] [Fintype β]
+    (e : α ≃ β) (M : Matrix α α ℂ) (v : α → ℂ) :
+    (Matrix.reindex e e M).mulVec (v ∘ e.symm) =
+      (M.mulVec v) ∘ e.symm := by
+  funext x
+  simp only [Matrix.mulVec, dotProduct, Matrix.reindex_apply,
+    Function.comp_apply]
+  exact Equiv.sum_comp e.symm
+    (fun y : α ↦ M (e.symm x) y * v y)
+
+private theorem loopCyclicProduct_etaCyclicEdgeEquiv_symm_constant
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} [NeZero N]
+    (x : (n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim l.1 l.1) :
+    F.loopCyclicProduct l
+        ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm
+          ⟨fun _ ↦ l.1, x⟩) =
+      ∏ n : Fin N, F.loopBondVector l (x n) := by
+  classical
+  unfold loopCyclicProduct
+  have hsector : ∀ n : Fin N,
+      (F.sectorEquiv.symm
+        ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm
+          ⟨fun _ ↦ l.1, x⟩ n)).1 = l.1 := by
+    intro n
+    rw [Matrix.etaCyclicEdgeEquiv_symm_apply]
+    simp
+  rw [dif_pos hsector]
+  have hsite (m : Fin N) :
+      F.sectorEquiv.symm
+          ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm
+            ⟨fun _ ↦ l.1, x⟩ m) =
+        ⟨l.1,
+          (Matrix.etaFixedSectorCyclicEdgeEquiv F.leftDim F.rightDim
+            (fun _ : Fin N ↦ l.1)).symm x m⟩ := by
+    rw [Matrix.etaCyclicEdgeEquiv_symm_apply]
+    exact Equiv.symm_apply_apply F.sectorEquiv _
+  apply Finset.prod_congr rfl
+  intro n _
+  congr 1
+  apply Prod.ext
+  · apply Fin.ext
+    simp only [loopRightIndex, Fin.val_cast]
+    have h := congrArg (fun z ↦ z.2.1.val) (hsite n)
+    exact h
+  · apply Fin.ext
+    simp only [loopLeftIndex, Fin.val_cast]
+    have h := congrArg (fun z ↦ z.2.2.val) (hsite (n + 1))
+    have hedge := Matrix.etaFixedSectorCyclicEdgeEquiv_symm_edge
+      F.leftDim F.rightDim (fun _ : Fin N ↦ l.1) x n
+    exact h.trans (congrArg (fun z ↦ z.2.val) hedge)
+
+private theorem loopCyclicProduct_etaCyclicEdgeEquiv_symm_of_ne
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} [NeZero N] (k : Fin N → Fin F.sectorCount)
+    (hk : k ≠ fun _ ↦ l.1)
+    (x : (n : Fin N) →
+      Matrix.EtaEdgeIndex F.leftDim F.rightDim (k n) (k (n + 1))) :
+    F.loopCyclicProduct l
+        ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm
+          ⟨k, x⟩) = 0 := by
+  unfold loopCyclicProduct
+  rw [dif_neg]
+  intro hsector
+  apply hk
+  funext n
+  have hsite :
+      F.sectorEquiv.symm
+          ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm
+            ⟨k, x⟩ n) =
+        ⟨k n,
+          (Matrix.etaFixedSectorCyclicEdgeEquiv F.leftDim F.rightDim k).symm x n⟩ := by
+    rw [Matrix.etaCyclicEdgeEquiv_symm_apply]
+    exact Equiv.symm_apply_apply F.sectorEquiv _
+  exact (congrArg Sigma.fst hsite).symm.trans (hsector n)
+
+private theorem blockGroundProduct_mulVec_loopCyclicProduct
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} [NeZero N] :
+    (Matrix.blockDiagonal' fun k : Fin N → Fin F.sectorCount ↦
+        fun (x y : (n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim
+          (k n) (k (n + 1))) ↦ ∏ n : Fin N,
+          F.edgeProjector (k n) (k (n + 1)) (x n) (y n)).mulVec
+        (fun z ↦ F.loopCyclicProduct l
+          ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm z)) =
+      fun z ↦ F.loopCyclicProduct l
+        ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm z) := by
+  classical
+  let B : (k : Fin N → Fin F.sectorCount) →
+      Matrix ((n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim
+        (k n) (k (n + 1)))
+        ((n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim
+          (k n) (k (n + 1))) ℂ :=
+    fun k x y ↦ ∏ n : Fin N,
+      F.edgeProjector (k n) (k (n + 1)) (x n) (y n)
+  change (Matrix.blockDiagonal' B).mulVec
+      (fun z ↦ F.loopCyclicProduct l
+        ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm z)) = _
+  funext z
+  obtain ⟨k, x⟩ := z
+  simp only [Matrix.mulVec, dotProduct, Fintype.sum_sigma]
+  rw [Finset.sum_eq_single k]
+  · have hdiag (y : (n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim
+        (k n) (k (n + 1))) :
+        Matrix.blockDiagonal' B ⟨k, x⟩ ⟨k, y⟩ = B k x y := by
+      exact Matrix.blockDiagonal'_apply_eq B k x y
+    simp_rw [hdiag]
+    simp only [B]
+    by_cases hk : k = fun _ ↦ l.1
+    · subst k
+      simp_rw [F.loopCyclicProduct_etaCyclicEdgeEquiv_symm_constant l]
+      exact piProduct_mulVec_pureTensor
+        (fun _ : Fin N ↦ F.edgeProjector l.1 l.1)
+        (fun _ : Fin N ↦ F.loopBondVector l)
+        (fun _ ↦ F.edgeProjector_mulVec_loopBondVector l) x
+    · simp_rw [F.loopCyclicProduct_etaCyclicEdgeEquiv_symm_of_ne l k hk]
+      simp
+  · intro h _ hne
+    apply Finset.sum_eq_zero
+    intro y _
+    have hoff : Matrix.blockDiagonal' B ⟨k, x⟩ ⟨h, y⟩ = 0 := by
+      exact Matrix.blockDiagonal'_apply_ne B x y (Ne.symm hne)
+    rw [hoff, zero_mul]
+  · exact fun h ↦ absurd (Finset.mem_univ k) h
+
+private theorem transformedGroundBondProduct_mulVec_loopCyclicProduct
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    ((List.ofFn fun i : Fin N ↦
+      MPOTensor.embedLocalOperator (d := d) 2 N hN i
+        (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+          (finTwoArrowEquiv (Fin d)).symm
+          (star (F.unitary ⊗ₖ F.unitary) *
+            twoSiteParentGroundProjectorMatrix A *
+              (F.unitary ⊗ₖ F.unitary)))).prod).mulVec
+        (F.loopCyclicProduct l) = F.loopCyclicProduct l := by
+  classical
+  let e := Matrix.etaCyclicEdgeEquiv (N := N)
+    F.leftDim F.rightDim F.sectorEquiv
+  let T := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i
+      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm
+        (star (F.unitary ⊗ₖ F.unitary) *
+          twoSiteParentGroundProjectorMatrix A *
+            (F.unitary ⊗ₖ F.unitary)))).prod
+  have hblocks : Matrix.reindex e e T =
+      Matrix.blockDiagonal' fun k : Fin N → Fin F.sectorCount ↦
+        fun (x y : (n : Fin N) → Matrix.EtaEdgeIndex F.leftDim F.rightDim
+          (k n) (k (n + 1))) ↦ ∏ n : Fin N,
+            F.edgeProjector (k n) (k (n + 1)) (x n) (y n) := by
+    exact MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition
+      hN F.leftDim F.rightDim F.sectorEquiv F.edgeProjector
+      (star (F.unitary ⊗ₖ F.unitary) *
+        twoSiteParentGroundProjectorMatrix A * (F.unitary ⊗ₖ F.unitary))
+      F.groundProjector_block
+  have hfix : (Matrix.reindex e e T).mulVec
+      (F.loopCyclicProduct l ∘ e.symm) = F.loopCyclicProduct l ∘ e.symm := by
+    rw [hblocks]
+    exact F.blockGroundProduct_mulVec_loopCyclicProduct l
+  rw [reindex_mulVec] at hfix
+  funext s
+  have hs := congrFun hfix (e s)
+  simpa only [Function.comp_apply, Equiv.symm_apply_apply] using hs
+
+private theorem loopProductState_eq_sitewisePhysicalMatrix_mulVec
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} [NeZero N] :
+    F.loopProductState l =
+      (MPOTensor.sitewisePhysicalMatrix F.unitary N).mulVec
+        (F.loopCyclicProduct l) := by
+  rfl
+
+private theorem groundBondProduct_mulVec_loopProductState
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    ((List.ofFn fun i : Fin N ↦
+      MPOTensor.embedLocalOperator (d := d) 2 N hN i
+        (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+          (finTwoArrowEquiv (Fin d)).symm
+          (twoSiteParentGroundProjectorMatrix A))).prod).mulVec
+        (F.loopProductState l) = F.loopProductState l := by
+  classical
+  let W := MPOTensor.sitewisePhysicalMatrix F.unitary N
+  let Q := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i
+      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm
+        (twoSiteParentGroundProjectorMatrix A))).prod
+  let T := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i
+      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm
+        (star (F.unitary ⊗ₖ F.unitary) *
+          twoSiteParentGroundProjectorMatrix A *
+            (F.unitary ⊗ₖ F.unitary)))).prod
+  have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.star_mul_self_of_mem F.unitary_mem
+  have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.mul_star_self_of_mem F.unitary_mem
+  have hWWstar : W * Wᴴ = 1 := by
+    simp only [W]
+    rw [MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose, hUUstar,
+      MPOTensor.sitewisePhysicalMatrix_one]
+  have hconj : singleKrausMap (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N) Q = T := by
+    have hprod := MPOTensor.singleKrausMap_bondProduct_of_unitary F.unitaryᴴ
+      (by simpa using hUUstar) (by simpa using hUstarU) hN
+      (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+        (finTwoArrowEquiv (Fin d)).symm (twoSiteParentGroundProjectorMatrix A))
+    simp_rw [MPOTensor.singleKrausMap_sitewise_conjTranspose_two_eq] at hprod
+    have hpair : MPOTensor.pairBondMatrix
+        (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+          (finTwoArrowEquiv (Fin d)).symm
+          (twoSiteParentGroundProjectorMatrix A)) =
+        twoSiteParentGroundProjectorMatrix A := by
+      ext x y
+      simp [MPOTensor.pairBondMatrix, Matrix.reindex_apply]
+    rw [hpair] at hprod
+    simpa only [Q, T] using hprod
+  have hmatrix : Q * W = W * T := by
+    have hconj' : Wᴴ * Q * W = T := by
+      simpa only [singleKrausMap_apply,
+        MPOTensor.sitewisePhysicalMatrix_conjTranspose,
+        Matrix.conjTranspose_conjTranspose, W] using hconj
+    calc
+      Q * W = 1 * (Q * W) := by rw [Matrix.one_mul]
+      _ = (W * Wᴴ) * (Q * W) := by rw [hWWstar]
+      _ = W * (Wᴴ * Q * W) := by simp only [Matrix.mul_assoc]
+      _ = W * T := by rw [hconj']
+  rw [F.loopProductState_eq_sitewisePhysicalMatrix_mulVec l]
+  change Q.mulVec (W.mulVec (F.loopCyclicProduct l)) =
+    W.mulVec (F.loopCyclicProduct l)
+  rw [Matrix.mulVec_mulVec, hmatrix, ← Matrix.mulVec_mulVec,
+    F.transformedGroundBondProduct_mulVec_loopCyclicProduct l hN]
+
+/-- The product-of-pairs state associated with a positive Beigi loop has zero
+energy for the finite two-site parent Hamiltonian.
+
+This is the membership part of Beigi's ground-space description: it does not
+assert that the loop states span the ground space.
+
+**Scope restriction (chain length):** The theorem treats `N ≥ 2`, the
+nondegenerate range of the two-site periodic parent Hamiltonian used here.
+The length-one convention is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and
+Section IV, source lines 602--606. -/
+theorem loopProductState_mem_ker_parentHamiltonian
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} (hN : 2 ≤ N) :
+    letI : NeZero N := ⟨by omega⟩
+    F.loopProductState l ∈ LinearMap.ker (parentHamiltonian A 2 N) := by
+  letI : NeZero N := ⟨by omega⟩
+  exact F.mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self hN
+    (F.loopProductState l) (F.groundBondProduct_mulVec_loopProductState l hN)
+
+/-- In the Euclidean-space realization, every positive-loop product state
+belongs to the finite parent-Hamiltonian ground space.
+
+This theorem proves membership only; the assertion that these states span the
+ground space is a separate part of Beigi's argument.
+
+**Scope restriction (chain length):** The theorem treats `N ≥ 2`, the
+nondegenerate range of the two-site periodic parent Hamiltonian used here.
+The length-one convention is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and
+Section IV, source lines 602--606. -/
+theorem loopProductState_mem_parentHamiltonianGroundSpaceES
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    {N : ℕ} (hN : 2 ≤ N) :
+    letI : NeZero N := ⟨by omega⟩
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm (F.loopProductState l) ∈
+      parentHamiltonianGroundSpaceES A 2 N := by
+  letI : NeZero N := ⟨by omega⟩
+  rw [parentHamiltonianGroundSpaceES, Submodule.mem_map]
+  exact ⟨F.loopProductState l, F.loopProductState_mem_ker_parentHamiltonian l hN, rfl⟩
 
 /-- The sector-coordinate loop tensor closes to the cyclic product of loop
 bond vectors at every positive length.

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -238,7 +238,7 @@ private theorem blockGroundProduct_mulVec_loopCyclicProduct
     by_cases hk : k = fun _ ↦ l.1
     · subst k
       simp_rw [F.loopCyclicProduct_etaCyclicEdgeEquiv_symm_constant l]
-      exact Matrix.piProduct_mulVec_pureTensor
+      exact Matrix.piProduct_mulVec_pureTensor_of_mulVec_eq_self
         (fun _ : Fin N ↦ F.edgeProjector l.1 l.1)
         (fun _ : Fin N ↦ F.loopBondVector l)
         (fun _ ↦ F.edgeProjector_mulVec_loopBondVector l) x

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -29,6 +29,10 @@ Hamiltonian, its trace gives Beigi's ordered-cycle formula.
   coordinate identity;
 * `BeigiSectorGraphData.OrderedCycle`: ordered cyclic sector sequences whose
   adjacent edge ground spaces are nonzero;
+* `BeigiSectorGraphData.singleKrausMap_groundBondProduct`: spatial conjugation
+  of the complete complementary-interaction product;
+* `BeigiSectorGraphData.mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self`:
+  its fixed vectors have zero parent-Hamiltonian energy;
 * `BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq`: Beigi's
   finite-chain dimension formula.
 
@@ -264,6 +268,37 @@ private theorem singleKrausMap_groundBond_eq_transformedGroundBond
   rw [MPOTensor.singleKrausMap_sitewise_conjTranspose_two_eq]
   congr 1
 
+/-- Conjugating the product of complementary two-site parent interactions by
+the sitewise spatial unitary gives the corresponding product in sector
+coordinates.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+theorem singleKrausMap_groundBondProduct (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    singleKrausMap (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N)
+        ((List.ofFn fun i : Fin N ↦
+          MPOTensor.embedLocalOperator (d := d) 2 N hN i
+            (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+              (finTwoArrowEquiv (Fin d)).symm
+              (twoSiteParentGroundProjectorMatrix A))).prod) =
+      (List.ofFn fun i : Fin N ↦
+        MPOTensor.embedLocalOperator (d := d) 2 N hN i
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm
+            (star (F.unitary ⊗ₖ F.unitary) *
+              twoSiteParentGroundProjectorMatrix A *
+                (F.unitary ⊗ₖ F.unitary)))).prod := by
+  have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.star_mul_self_of_mem F.unitary_mem
+  have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.mul_star_self_of_mem F.unitary_mem
+  have hprod := MPOTensor.singleKrausMap_bondProduct_of_unitary F.unitaryᴴ
+    (by simpa using hUUstar) (by simpa using hUstarU) hN (groundBond A)
+  simp_rw [singleKrausMap_groundBond_eq_transformedGroundBond] at hprod
+  simpa only [groundBond, transformedGroundBond] using hprod
+
 private theorem groundBondEmbeddings_commute (F : BeigiSectorGraphData A)
     {N : ℕ} [NeZero N] (hN : 2 ≤ N) (i j : Fin N) :
     Commute
@@ -430,9 +465,6 @@ private theorem groundBondProduct_trace (F : BeigiSectorGraphData A)
   let W := MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N
   let Q := (List.ofFn fun i : Fin N ↦
     MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
-  have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
-    simpa only [Matrix.star_eq_conjTranspose] using
-      Unitary.star_mul_self_of_mem F.unitary_mem
   have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
     simpa only [Matrix.star_eq_conjTranspose] using
       Unitary.mul_star_self_of_mem F.unitary_mem
@@ -442,18 +474,21 @@ private theorem groundBondProduct_trace (F : BeigiSectorGraphData A)
     rw [← MPOTensor.sitewisePhysicalMatrix_conjTranspose,
       MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose, hUUstar,
       MPOTensor.sitewisePhysicalMatrix_one]
-  have hprod := MPOTensor.singleKrausMap_bondProduct_of_unitary F.unitaryᴴ
-    (by simpa using hUUstar) (by simpa using hUstarU) hN (groundBond A)
-  simp_rw [singleKrausMap_groundBond_eq_transformedGroundBond] at hprod
+  have hprod := F.singleKrausMap_groundBondProduct hN
   have htrace := F.transformedGroundBondProduct_trace hN
-  rw [← hprod] at htrace
+  have hconj : singleKrausMap W Q =
+      (List.ofFn fun i : Fin N ↦
+        MPOTensor.embedLocalOperator (d := d) 2 N hN i
+          (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+            (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond)).prod := by
+    simpa only [W, Q, groundBond, transformedGroundBond] using hprod
   calc
     Matrix.trace Q = Matrix.trace (singleKrausMap W Q) := by
       simp only [singleKrausMap_apply]
       symm
       rw [Matrix.trace_mul_comm (W * Q) Wᴴ, ← Matrix.mul_assoc, hWstarW,
         Matrix.one_mul]
-    _ = _ := by simpa only [Q, W] using htrace
+    _ = _ := by rw [hconj]; exact htrace
 
 private theorem toLin'_groundBondProduct {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
     Matrix.toLin' ((List.ofFn fun i : Fin N ↦
@@ -545,6 +580,12 @@ interactions belongs to the kernel of the finite parent Hamiltonian.
 
 For sector data of Beigi type, the translated parent interactions commute, so
 the product of their complements is the projector onto the common kernel.
+
+**Scope restriction (sector data):** This criterion is stated under
+`BeigiSectorGraphData A`, which supplies the commutativity of the translated
+parent interactions.  This restricted auxiliary form, and its possible
+generalization to an explicit commutativity hypothesis, are recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500. -/
 theorem mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -130,6 +130,19 @@ noncomputable def edgeGroundSpace (F : BeigiSectorGraphData A)
     Submodule ℂ (Matrix.EtaEdgeIndex F.leftDim F.rightDim a b → ℂ) :=
   LinearMap.range (Matrix.toLin' (F.edgeProjector a b))
 
+/-- The edge projector is a projection onto its edge ground space.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+theorem edgeProjector_isProj (F : BeigiSectorGraphData A)
+    (a b : Fin F.sectorCount) :
+    LinearMap.IsProj (F.edgeGroundSpace a b)
+      (Matrix.toLin' (F.edgeProjector a b)) := by
+  rw [edgeGroundSpace, LinearMap.isProj_range_iff_isIdempotentElem]
+  change Matrix.toLin' (F.edgeProjector a b) *
+    Matrix.toLin' (F.edgeProjector a b) = Matrix.toLin' (F.edgeProjector a b)
+  rw [Module.End.mul_eq_comp, ← Matrix.toLin'_mul,
+    (F.edgeProjector_isOrthogonal a b).2.eq]
+
 /-- A directed edge is present exactly when its edge ground space is nonzero.
 
 Source: Beigi, arXiv:1105.1019v2, Section III, graph definition immediately
@@ -353,15 +366,8 @@ private theorem edgeProjector_trace (F : BeigiSectorGraphData A)
     Matrix.trace (F.edgeProjector a b) =
       (Module.finrank ℂ (F.edgeGroundSpace a b) : ℂ) := by
   classical
-  have hproj : LinearMap.IsProj (F.edgeGroundSpace a b)
-      (Matrix.toLin' (F.edgeProjector a b)) := by
-    rw [edgeGroundSpace, LinearMap.isProj_range_iff_isIdempotentElem]
-    change Matrix.toLin' (F.edgeProjector a b) *
-      Matrix.toLin' (F.edgeProjector a b) = Matrix.toLin' (F.edgeProjector a b)
-    rw [Module.End.mul_eq_comp, ← Matrix.toLin'_mul,
-      (F.edgeProjector_isOrthogonal a b).2.eq]
   rw [← Matrix.trace_toLin'_eq]
-  exact hproj.trace
+  exact (F.edgeProjector_isProj a b).trace
 
 private theorem transformedGroundBondProduct_trace (F : BeigiSectorGraphData A)
     {N : ℕ} [NeZero N] (hN : 2 ≤ N) :

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -449,19 +449,11 @@ private theorem groundBondProduct_trace (F : BeigiSectorGraphData A)
         Matrix.one_mul]
     _ = _ := by simpa only [Q, W] using htrace
 
-private theorem localComplementProductES_trace (F : BeigiSectorGraphData A)
-    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
-    LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N))
-        (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod =
-      ∑ k : Fin N → Fin F.sectorCount,
-        (↑(∏ n : Fin N,
-          Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1)))) : ℂ) := by
+private theorem toLin'_groundBondProduct {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    Matrix.toLin' ((List.ofFn fun i : Fin N ↦
+      MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod) =
+      (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod := by
   classical
-  let qMatrix := (List.ofFn fun i : Fin N ↦
-    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
-  let qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
-  let qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
-  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
   have hfactor (i : Fin N) : Matrix.toLin'
       (MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)) =
       1 - localTerm A 2 N i := by
@@ -476,24 +468,46 @@ private theorem localComplementProductES_trace (F : BeigiSectorGraphData A)
       (MPOTensor.embedLocalOperator (d := d) 2 N hN i
         (LinearMap.toMatrix' (parentInteraction A 2))) = _
     rw [localTerm_eq_toLin'_embedLocalOperator (A := A) hN i]
+  change (Matrix.toLinAlgEquiv' :
+    Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
+      Module.End ℂ (NSiteSpace d N)) _ = _
+  rw [map_list_prod, List.map_ofFn]
+  apply congrArg List.prod
+  apply congrArg List.ofFn
+  funext i
+  exact hfactor i
+
+private theorem conj_localComplementProduct {N : ℕ} :
+    (LinearEquiv.conjAlgEquiv ℂ
+      (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm)
+        (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod =
+      (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod := by
+  rw [map_list_prod, List.map_ofFn]
+  apply congrArg List.prod
+  apply congrArg List.ofFn
+  funext i
+  simp only [Function.comp_apply, map_sub, map_one, localTermES,
+    LinearEquiv.conjAlgEquiv_apply, LinearEquiv.symm_symm]
+
+private theorem localComplementProductES_trace (F : BeigiSectorGraphData A)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N))
+        (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod =
+      ∑ k : Fin N → Fin F.sectorCount,
+        (↑(∏ n : Fin N,
+          Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1)))) : ℂ) := by
+  classical
+  let qMatrix := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
+  let qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
+  let qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
   have hMatrix : Matrix.toLin' qMatrix = qRaw := by
-    change (Matrix.toLinAlgEquiv' :
-      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
-        Module.End ℂ (NSiteSpace d N)) qMatrix = qRaw
-    simp only [qMatrix, qRaw]
-    rw [map_list_prod, List.map_ofFn]
-    apply congrArg List.prod
-    apply congrArg List.ofFn
-    funext i
-    exact hfactor i
+    simpa only [qMatrix, qRaw] using
+      (toLin'_groundBondProduct (A := A) hN)
   have hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES := by
-    simp only [qRaw, qES]
-    rw [map_list_prod, List.map_ofFn]
-    apply congrArg List.prod
-    apply congrArg List.ofFn
-    funext i
-    simp only [Function.comp_apply, map_sub, map_one, localTermES, e,
-      LinearEquiv.conjAlgEquiv_apply, LinearEquiv.symm_symm]
+    simpa only [e, qRaw, qES] using
+      (conj_localComplementProduct (A := A) (N := N))
   calc
     LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N)) qES =
         LinearMap.trace ℂ (NSiteSpace d N) qRaw := by
@@ -542,38 +556,12 @@ theorem mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self
   let qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
   let qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
   let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
-  have hfactor (i : Fin N) : Matrix.toLin'
-      (MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)) =
-      1 - localTerm A 2 N i := by
-    rw [embedLocalOperator_groundBond_eq_one_sub]
-    change (Matrix.toLinAlgEquiv' :
-      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
-        Module.End ℂ (NSiteSpace d N))
-        (1 - MPOTensor.embedLocalOperator (d := d) 2 N hN i
-          (LinearMap.toMatrix' (parentInteraction A 2))) = _
-    rw [map_sub, map_one]
-    change 1 - Matrix.toLin'
-      (MPOTensor.embedLocalOperator (d := d) 2 N hN i
-        (LinearMap.toMatrix' (parentInteraction A 2))) = _
-    rw [localTerm_eq_toLin'_embedLocalOperator (A := A) hN i]
   have hMatrix : Matrix.toLin' qMatrix = qRaw := by
-    change (Matrix.toLinAlgEquiv' :
-      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
-        Module.End ℂ (NSiteSpace d N)) qMatrix = qRaw
-    simp only [qMatrix, qRaw]
-    rw [map_list_prod, List.map_ofFn]
-    apply congrArg List.prod
-    apply congrArg List.ofFn
-    funext i
-    exact hfactor i
+    simpa only [qMatrix, qRaw] using
+      (toLin'_groundBondProduct (A := A) hN)
   have hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES := by
-    simp only [qRaw, qES]
-    rw [map_list_prod, List.map_ofFn]
-    apply congrArg List.prod
-    apply congrArg List.ofFn
-    funext i
-    simp only [Function.comp_apply, map_sub, map_one, localTermES, e,
-      LinearEquiv.conjAlgEquiv_apply, LinearEquiv.symm_symm]
+    simpa only [e, qRaw, qES] using
+      (conj_localComplementProduct (A := A) (N := N))
   have hraw : qRaw v = v := by
     rw [← hMatrix, Matrix.toLin'_apply]
     exact hv

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -520,6 +520,79 @@ private theorem parentHamiltonianGroundSpaceES_finrank_eq_all_sequences
   rw [parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES]
   exact htrace.symm
 
+/-- A vector fixed by the complete product of complementary two-site parent
+interactions belongs to the kernel of the finite parent Hamiltonian.
+
+For sector data of Beigi type, the translated parent interactions commute, so
+the product of their complements is the projector onto the common kernel.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500. -/
+theorem mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self
+    (F : BeigiSectorGraphData A) {N : ℕ} [NeZero N] (hN : 2 ≤ N)
+    (v : NSiteSpace d N)
+    (hv : ((List.ofFn fun i : Fin N ↦
+      MPOTensor.embedLocalOperator (d := d) 2 N hN i
+        (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
+          (finTwoArrowEquiv (Fin d)).symm
+          (twoSiteParentGroundProjectorMatrix A))).prod).mulVec v = v) :
+    v ∈ LinearMap.ker (parentHamiltonian A 2 N) := by
+  classical
+  let qMatrix := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
+  let qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
+  let qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  have hfactor (i : Fin N) : Matrix.toLin'
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)) =
+      1 - localTerm A 2 N i := by
+    rw [embedLocalOperator_groundBond_eq_one_sub]
+    change (Matrix.toLinAlgEquiv' :
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
+        Module.End ℂ (NSiteSpace d N))
+        (1 - MPOTensor.embedLocalOperator (d := d) 2 N hN i
+          (LinearMap.toMatrix' (parentInteraction A 2))) = _
+    rw [map_sub, map_one]
+    change 1 - Matrix.toLin'
+      (MPOTensor.embedLocalOperator (d := d) 2 N hN i
+        (LinearMap.toMatrix' (parentInteraction A 2))) = _
+    rw [localTerm_eq_toLin'_embedLocalOperator (A := A) hN i]
+  have hMatrix : Matrix.toLin' qMatrix = qRaw := by
+    change (Matrix.toLinAlgEquiv' :
+      Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ ≃ₐ[ℂ]
+        Module.End ℂ (NSiteSpace d N)) qMatrix = qRaw
+    simp only [qMatrix, qRaw]
+    rw [map_list_prod, List.map_ofFn]
+    apply congrArg List.prod
+    apply congrArg List.ofFn
+    funext i
+    exact hfactor i
+  have hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES := by
+    simp only [qRaw, qES]
+    rw [map_list_prod, List.map_ofFn]
+    apply congrArg List.prod
+    apply congrArg List.ofFn
+    funext i
+    simp only [Function.comp_apply, map_sub, map_one, localTermES, e,
+      LinearEquiv.conjAlgEquiv_apply, LinearEquiv.symm_symm]
+  have hraw : qRaw v = v := by
+    rw [← hMatrix, Matrix.toLin'_apply]
+    exact hv
+  have hfixES : qES (e.symm v) = e.symm v := by
+    rw [← hES]
+    simp only [LinearEquiv.conjAlgEquiv_apply]
+    change e.symm (qRaw (e (e.symm v))) = e.symm v
+    rw [e.apply_symm_apply, hraw]
+  have hproj := LinearMap.isProj_ker_sum_listProd_one_sub
+    (fun i : Fin N ↦ localTermES A 2 i)
+    (fun i ↦ localTermES_isSymmetricProjection A 2 i)
+    (fun i j ↦ F.localTermES_commute hN i j)
+  rw [← parentHamiltonianES_eq_sum_localTermES] at hproj
+  have hkerES : e.symm v ∈ LinearMap.ker (parentHamiltonianES A 2 N) :=
+    hproj.mem_iff_map_id.mpr hfixES
+  rw [LinearMap.mem_ker] at hkerES ⊢
+  have h := congrArg e hkerES
+  simpa [parentHamiltonianES, e] using h
+
 /-- Beigi's finite-chain ground-space dimension formula: for a periodic chain
 of length greater than two, the dimension is the sum over ordered cyclic
 sector sequences of the products of the adjacent edge-ground-space

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2538,13 +2538,36 @@ specialization of that Appendix~D definition.
     sitewise-unitary image.
 \end{proof}
 
+\begin{theorem}[Spatial conjugation of complementary interaction products]
+    \label{thm:beigi_complement_product_conjugation}
+    \lean{MPSTensor.BeigiSectorGraphData.singleKrausMap_groundBondProduct}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    Suppose that $A$ is equipped with Beigi sector data, with one-site spatial
+    unitary $U$.  For $N\geq2$, let $Q_N$ be the product of the translated
+    complementary parent interactions and let $\widetilde Q_N$ be the
+    corresponding product in sector coordinates.  Then
+    \[
+        (U^*)^{\otimes N}Q_NU^{\otimes N}=\widetilde Q_N.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The two-site coordinate identity gives
+    $(U^*\otimes U^*)(\mathbf 1-h)(U\otimes U)=\widetilde Q$ for one bond.
+    Conjugation by $(U^*)^{\otimes N}$ carries every translated copy of this
+    bond identity to the corresponding translated sector interaction and
+    preserves their ordered product, which gives the displayed equality.
+\end{proof}
+
 \begin{theorem}[Fixed complementary-product vectors have zero parent energy]
     \label{thm:beigi_complement_product_fixed_vector}
     \lean{MPSTensor.BeigiSectorGraphData.mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self}
     \leanok
     \uses{def:beigi_sector_graph}
-    For $N\geq2$, let $h_0,\ldots,h_{N-1}$ be the translated length-two
-    parent interactions and set
+    Suppose that $A$ is equipped with Beigi sector data.  For $N\geq2$, let
+    $h_0,\ldots,h_{N-1}$ be its translated length-two parent interactions and
+    set
     \[
         Q_N=\prod_{n=0}^{N-1}(\mathbf 1-h_n).
     \]
@@ -2576,6 +2599,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.loopProductState_mem_parentHamiltonianGroundSpaceES}
     \leanok
     \uses{def:beigi_sector_graph, def:beigi_loop_product_state,
+        thm:beigi_complement_product_conjugation,
         thm:beigi_complement_product_fixed_vector}
     Let $a\to a$ be a positive loop.  For every $N\geq 2$, its physical
     cyclic product-of-pairs state belongs to the kernel of the length-two

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2538,6 +2538,34 @@ specialization of that Appendix~D definition.
     sitewise-unitary image.
 \end{proof}
 
+\begin{theorem}[A positive Beigi loop gives a parent ground state]
+    \label{thm:beigi_loop_product_state_ground_state}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductState_mem_ker_parentHamiltonian}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductState_mem_parentHamiltonianGroundSpaceES}
+    \leanok
+    \uses{def:beigi_sector_graph, def:beigi_loop_product_state,
+        thm:beigi_loop_tensor_periodic_vector}
+    Let $a\to a$ be a positive loop.  For every $N\geq 2$, its physical
+    cyclic product-of-pairs state belongs to the kernel of the length-two
+    periodic parent Hamiltonian.  Equivalently, its Euclidean representative
+    belongs to the parent ground space.  This is only a membership assertion;
+    it does not assert that the loop states span the ground space.
+\end{theorem}
+
+\begin{proof}\leanok
+    In sector coordinates, the complete product of the complementary
+    two-site interactions is block diagonal over cyclic sector sequences.
+    In the constant sector sequence $a$, its action is the tensor product of
+    the edge projectors $P_{a,a}$.  Each factor fixes the chosen vector
+    $\varphi_a\in\operatorname{ran}P_{a,a}$, hence their tensor product fixes
+    the cyclic product of copies of $\varphi_a$.  Every other sector block
+    acts on a zero coefficient.  Conjugating by the sitewise tensor power of
+    the spatial unitary shows that the complete product of complementary
+    physical interactions fixes the physical loop state.  Since the parent
+    interactions commute, this product is the projector onto their common
+    kernel, which is the kernel of the parent Hamiltonian.
+\end{proof}
+
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2556,8 +2556,17 @@ specialization of that Appendix~D definition.
     The two-site coordinate identity gives
     $(U^*\otimes U^*)(\mathbf 1-h)(U\otimes U)=\widetilde Q$ for one bond.
     Conjugation by $(U^*)^{\otimes N}$ carries every translated copy of this
-    bond identity to the corresponding translated sector interaction and
-    preserves their ordered product, which gives the displayed equality.
+    bond identity to the corresponding translated sector interaction.  Since
+    unitary conjugation distributes over an ordered product,
+    \[
+        (U^*)^{\otimes N}\!\left(\prod_{n=0}^{N-1}Q_n\right)U^{\otimes N}
+        =\prod_{n=0}^{N-1}
+          \left((U^*)^{\otimes N}Q_nU^{\otimes N}\right)
+        =\prod_{n=0}^{N-1}\widetilde Q_n
+        =\widetilde Q_N,
+    \]
+    where $Q_n$ and $\widetilde Q_n$ are the translated physical and sector
+    complementary interactions, respectively.
 \end{proof}
 
 \begin{theorem}[Fixed complementary-product vectors have zero parent energy]
@@ -2583,8 +2592,16 @@ specialization of that Appendix~D definition.
         =\prod_{n=0}^{N-1}(\mathbf 1-h_n^{\mathrm{E}}).
     \]
     The operators $h_n^{\mathrm{E}}$ are commuting orthogonal projections.
-    Consequently $Q_N^{\mathrm{E}}$ is the orthogonal projector onto
+    For any commuting orthogonal projections $P_0,\ldots,P_{N-1}$,
     \[
+        \prod_{n=0}^{N-1}(\mathbf 1-P_n)
+        =\operatorname{proj}_{\bigcap_{n=0}^{N-1}\ker P_n}.
+    \]
+    Applying this identity to the $h_n^{\mathrm{E}}$ gives
+    \[
+        Q_N^{\mathrm{E}}
+        =\operatorname{proj}_{\bigcap_{n=0}^{N-1}\ker h_n^{\mathrm{E}}},
+        \qquad
         \bigcap_{n=0}^{N-1}\ker h_n^{\mathrm{E}}
         =\ker\!\left(\sum_{n=0}^{N-1}h_n^{\mathrm{E}}\right)
         =\ker H_N^{\mathrm{E}}.
@@ -2611,9 +2628,16 @@ specialization of that Appendix~D definition.
 \begin{proof}\leanok
     In sector coordinates, the complete product $\widetilde Q_N$ of the
     complementary two-site interactions is block diagonal over cyclic sector
-    sequences.  On the constant sequence $a$, it acts as the tensor product
-    of the edge projectors.  Since
-    $\varphi_a\in\operatorname{ran}P_{a,a}$, one has
+    sequences.  Write $\Phi_a(k;x)$ for the coefficient of the loop cyclic
+    product in the block indexed by $k$.  Its support lies in sector $a$, so
+    for every
+    $k\ne(a,\ldots,a)$ and every edge-index tuple $x$,
+    \[
+        \Phi_a(k;x)=0.
+    \]
+    Thus only the constant cyclic sector sequence contributes.  On this block,
+    $\widetilde Q_N$ is the tensor product of the edge projectors.  Since
+    $\varphi_a\in\operatorname{ran}P_{a,a}$,
     \[
         \widetilde Q_N\Phi_a
         =P_{a,a}^{\otimes N}\Phi_a
@@ -2622,9 +2646,9 @@ specialization of that Appendix~D definition.
         \Phi_a(t_0,\ldots,t_{N-1})
         =\prod_{n=0}^{N-1}\varphi_a(r_n,l_{n+1}).
     \]
-    Every other sector block acts on a zero coefficient.  If $U$ is the
-    one-site spatial unitary and $\Psi_a=U^{\otimes N}\Phi_a$ is the physical
-    loop state, unitary conjugation gives
+    If $U$ is the one-site spatial unitary and
+    $\Psi_a=U^{\otimes N}\Phi_a$ is the physical loop state, unitary
+    conjugation gives
     \[
         Q_N\Psi_a
         =U^{\otimes N}\widetilde Q_N\Phi_a

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2538,13 +2538,45 @@ specialization of that Appendix~D definition.
     sitewise-unitary image.
 \end{proof}
 
+\begin{theorem}[Fixed complementary-product vectors have zero parent energy]
+    \label{thm:beigi_complement_product_fixed_vector}
+    \lean{MPSTensor.BeigiSectorGraphData.mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    For $N\geq2$, let $h_0,\ldots,h_{N-1}$ be the translated length-two
+    parent interactions and set
+    \[
+        Q_N=\prod_{n=0}^{N-1}(\mathbf 1-h_n).
+    \]
+    Every vector fixed by $Q_N$ belongs to the kernel of the periodic parent
+    Hamiltonian $H_N=\sum_n h_n$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Under the Euclidean identification $E$, the matrix product of the
+    complementary interactions is carried to
+    \[
+        Q_N^{\mathrm{E}}=E^{-1}Q_NE
+        =\prod_{n=0}^{N-1}(\mathbf 1-h_n^{\mathrm{E}}).
+    \]
+    The operators $h_n^{\mathrm{E}}$ are commuting orthogonal projections.
+    Consequently $Q_N^{\mathrm{E}}$ is the orthogonal projector onto
+    \[
+        \bigcap_{n=0}^{N-1}\ker h_n^{\mathrm{E}}
+        =\ker\!\left(\sum_{n=0}^{N-1}h_n^{\mathrm{E}}\right)
+        =\ker H_N^{\mathrm{E}}.
+    \]
+    Thus $Q_Nv=v$ implies $E^{-1}v\in\ker H_N^{\mathrm{E}}$, and conjugating
+    back by $E$ gives $v\in\ker H_N$.
+\end{proof}
+
 \begin{theorem}[A positive Beigi loop gives a parent ground state]
     \label{thm:beigi_loop_product_state_ground_state}
     \lean{MPSTensor.BeigiSectorGraphData.loopProductState_mem_ker_parentHamiltonian}
     \lean{MPSTensor.BeigiSectorGraphData.loopProductState_mem_parentHamiltonianGroundSpaceES}
     \leanok
     \uses{def:beigi_sector_graph, def:beigi_loop_product_state,
-        thm:beigi_loop_tensor_periodic_vector}
+        thm:beigi_complement_product_fixed_vector}
     Let $a\to a$ be a positive loop.  For every $N\geq 2$, its physical
     cyclic product-of-pairs state belongs to the kernel of the length-two
     periodic parent Hamiltonian.  Equivalently, its Euclidean representative
@@ -2553,17 +2585,30 @@ specialization of that Appendix~D definition.
 \end{theorem}
 
 \begin{proof}\leanok
-    In sector coordinates, the complete product of the complementary
-    two-site interactions is block diagonal over cyclic sector sequences.
-    In the constant sector sequence $a$, its action is the tensor product of
-    the edge projectors $P_{a,a}$.  Each factor fixes the chosen vector
-    $\varphi_a\in\operatorname{ran}P_{a,a}$, hence their tensor product fixes
-    the cyclic product of copies of $\varphi_a$.  Every other sector block
-    acts on a zero coefficient.  Conjugating by the sitewise tensor power of
-    the spatial unitary shows that the complete product of complementary
-    physical interactions fixes the physical loop state.  Since the parent
-    interactions commute, this product is the projector onto their common
-    kernel, which is the kernel of the parent Hamiltonian.
+    In sector coordinates, the complete product $\widetilde Q_N$ of the
+    complementary two-site interactions is block diagonal over cyclic sector
+    sequences.  On the constant sequence $a$, it acts as the tensor product
+    of the edge projectors.  Since
+    $\varphi_a\in\operatorname{ran}P_{a,a}$, one has
+    \[
+        \widetilde Q_N\Phi_a
+        =P_{a,a}^{\otimes N}\Phi_a
+        =\Phi_a,
+        \qquad
+        \Phi_a(t_0,\ldots,t_{N-1})
+        =\prod_{n=0}^{N-1}\varphi_a(r_n,l_{n+1}).
+    \]
+    Every other sector block acts on a zero coefficient.  If $U$ is the
+    one-site spatial unitary and $\Psi_a=U^{\otimes N}\Phi_a$ is the physical
+    loop state, unitary conjugation gives
+    \[
+        Q_N\Psi_a
+        =U^{\otimes N}\widetilde Q_N\Phi_a
+        =U^{\otimes N}\Phi_a
+        =\Psi_a.
+    \]
+    Theorem~\ref{thm:beigi_complement_product_fixed_vector} now yields
+    $\Psi_a\in\ker H_N$.
 \end{proof}
 
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -165,9 +165,10 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 - `cpsv16_nncph_ground_state_scope.tex` records the separation between the
   zero-energy ground-vector predicate and the source ground-space spanning
   predicates for CPSV16 Theorem 3.10(iii). The finite Beigi sector graph and
-  its ordered-cycle ground-space dimension formula are formalized; reducing
-  the graph by eventual constancy and identifying its states with the chosen
-  normal-tensor basis remain open.
+  its ordered-cycle ground-space dimension formula are formalized; each
+  positive-loop product state is proved to belong to the finite parent ground
+  space for lengths at least two. Identifying these states with the chosen
+  normal-tensor basis and proving that they span remain open.
 - `cpsv16_parent_commuting_hamiltonian_scope.tex` records that the current
   parent commuting Hamiltonian predicate keeps only the idempotent-product
   consequence of CPSV16 Definition D.2, while the source definition also has

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -328,6 +328,16 @@ parent Hamiltonian used here; the length-one convention remains part of
 that the loop states span the parent ground space or identify them with the
 original BNT representatives.
 
+The auxiliary declaration
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self}
+is stated under the sector-data hypothesis, which supplies commutativity of
+all translated two-site parent interactions.  Thus it is a restricted
+fixed-vector criterion rather than an unrestricted assertion for arbitrary
+parent interactions.  If the criterion is needed independently of Beigi's
+decomposition, its hypothesis should be replaced by explicit pairwise
+commutativity of the translated interactions.
+
 \section{Elimination plan}
 
 A source-faithful formalization should replace the remaining axiom-backed
@@ -373,9 +383,10 @@ extension are proved. The repeated-copy and arbitrary-raw-weight extension
 remains open.  In the reverse direction, eventual ground-space dimension
 stability, the local spatial decomposition, the ordered-cycle dimension
 formula, the reduction of the sector graph to one-dimensional loops, and the
-exact matrix product realization of every positive loop state are proved.
-Parent-ground-space membership and spanning for these loop vectors, followed
-by their identification with the basis of normal tensors, remain open.
+exact matrix product realization and parent-ground-space membership of every
+positive loop state are proved.  Spanning of the parent ground space by these
+loop vectors, followed by their identification with the basis of normal
+tensors, remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -313,8 +313,20 @@ product
   \prod_n \varphi_a(r_n,l_{n+1}).
 \]
 This is the construction in Beigi, arXiv:1105.1019v2, source lines 602--606.
-It does not yet prove that these vectors belong to, or span, the parent ground
-space, nor does it identify them with the original BNT representatives.
+For every $N\geq2$,
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{loopProductState_mem_ker_parentHamiltonian}
+now proves that this vector belongs to the kernel of the length-two periodic
+parent Hamiltonian.  Its Euclidean-space form is recorded by
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{loopProductState_mem_parentHamiltonianGroundSpaceES}.
+The proof uses Beigi's local edge-ground-space condition from source
+lines 487--500 and the positive-loop specialization at lines 602--606.  The
+restriction $N\geq2$ is the nondegenerate range of the two-site periodic
+parent Hamiltonian used here; the length-one convention remains part of
+\ghissue{4400}.  This result proves membership only.  It does not yet prove
+that the loop states span the parent ground space or identify them with the
+original BNT representatives.
 
 \section{Elimination plan}
 


### PR DESCRIPTION
## Summary

- prove that every positive Beigi loop product state belongs to the kernel of the finite length-two parent Hamiltonian for every chain length `N ≥ 2`
- provide the equivalent Euclidean-space ground-space membership theorem
- derive membership from the existing local edge-ground-space data, without adding a finite-chain hypothesis to `BeigiSectorGraphData`
- update the blueprint and the NNCPH ground-state scope note, while leaving spanning and BNT identification explicitly open

## Mathematical argument

The chosen loop vector lies in the range of the corresponding orthogonal edge projector, hence is fixed by that projector. In cyclic edge coordinates, the complete product of complementary parent interactions is block diagonal. Its constant loop-sector block is the tensor product of the edge projectors, so it fixes the cyclic product of loop vectors; every other sector block acts on a zero coefficient. Sitewise unitary conjugation carries this statement back to the physical loop state. Finally, the commuting-product projection identifies fixed vectors with the common kernel of the translated interactions, hence with the kernel of the parent Hamiltonian.

The source passages are Beigi, arXiv:1105.1019v2, Section III, source lines 487–500, and Section IV, source lines 602–606. The theorem is stated for `N ≥ 2`, the nondegenerate range of the two-site periodic parent Hamiltonian used in this development. This PR proves membership only; it does not prove that loop states span the ground space or identify them with the chosen normal-tensor basis.

## Validation

- `lake env lean TNLean/MPS/RFP/BeigiLoopTensor.lean`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` added in the changed Lean files

Advances #4423 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in MPS/parent-Hamiltonian theory with no runtime impact; correctness risk is mathematical proof maintenance rather than production behavior.
> 
> **Overview**
> **Proves** that every positive Beigi loop **product-of-pairs** state has zero energy for the finite length-two periodic parent Hamiltonian when **N ≥ 2**, including the Euclidean-space ground-space form. Spanning and BNT identification stay explicitly open.
> 
> Adds reusable **matrix** lemmas (`piProduct_mulVec_pureTensor`, `reindex_mulVec`) and factors **`edgeProjector_isProj`** out of trace arguments. On the sector-graph side: **`singleKrausMap_groundBondProduct`**, **`mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self`**, and a long **`BeigiLoopTensor`** proof chain (block-diagonal complementary product fixes the cyclic loop vector, then sitewise unitary conjugation lifts to **`loopProductState`**).
> 
> **Blueprint** chapter 13 and **`cpsv16_nncph_ground_state_scope`** are updated to record proved membership versus still-open spanning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a9f98b72c91b8a35573a5c770402e66fa77abd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->