### PR TITLE
feat(MPS/MPDO): bound fixed-point product spans

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -479,6 +479,7 @@ import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorGeneration
+import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
 import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -478,7 +478,6 @@ import TNLean.MPS.MPDO.VerticalSectorCoordinates
 import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
-import TNLean.MPS.MPDO.VerticalSectorGeneration
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
 import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.PRFP

--- a/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockRetraction.lean
@@ -204,6 +204,47 @@ namespace Matrix
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
 variable {n : ι → Type*} [∀ k, Fintype (n k)] [∀ k, DecidableEq (n k)]
 
+omit [∀ k, DecidableEq (n k)] in
+/-- The canonical full-matrix extension, after a simultaneous reindexing,
+inherits positivity, trace preservation, the Schwarz inequality for its trace
+adjoint, and a positive-definite fixed point from a faithful fixed family.
+
+This is the change-of-coordinates step used before applying the fixed-point
+classification of Wolf, Theorem 6.14, in arXiv:1606.00608, Appendix C.4,
+lines 1980--1995. -/
+theorem IsPositiveDirectSumMap.reindexedExtension_properties
+    {T : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hT : IsPositiveDirectSumMap T)
+    (hTP : IsTracePreservingDirectSumMap T)
+    (hSchwarz : IsSchwarzDirectSumMap (Matrix.directSumTraceAdjointMap T))
+    {ρ : ∀ k, Matrix (n k) (n k) ℂ} (hρ : ∀ k, (ρ k).PosDef)
+    (hρfix : T ρ = ρ)
+    {β : Type*} [Fintype β]
+    (e : ((k : ι) × n k) ≃ β) :
+    IsPositiveMap (reindexEndomorphism e (directSumExtension T)) ∧
+      IsTracePreservingMap (reindexEndomorphism e (directSumExtension T)) ∧
+      IsSchwarzMap
+          (traceAdjointMap (reindexEndomorphism e (directSumExtension T))) ∧
+        (Matrix.reindex e e (directSumDiagonalEmbedding ρ)).PosDef ∧
+        reindexEndomorphism e (directSumExtension T)
+            (Matrix.reindex e e (directSumDiagonalEmbedding ρ)) =
+          Matrix.reindex e e (directSumDiagonalEmbedding ρ) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · exact IsPositiveMap.reindexEndomorphism
+      hT.directSumExtension_isPositiveMap e
+  · exact IsTracePreservingMap.reindexEndomorphism
+      hTP.directSumExtension_isTracePreservingMap e
+  · rw [traceAdjointMap_reindexEndomorphism]
+    exact IsSchwarzMap.reindexEndomorphism
+      (hSchwarz.traceAdjointMap_directSumExtension_isSchwarzMap hT) e
+  · exact (directSumDiagonalEmbedding_posDef hρ).reindex e
+  · let Φ := Matrix.reindexLinearEquiv ℂ ℂ e e
+    change Φ (directSumExtension T (Φ.symm (Φ
+      (directSumDiagonalEmbedding ρ)))) = Φ (directSumDiagonalEmbedding ρ)
+    rw [Φ.symm_apply_apply]
+    exact congrArg Φ ((directSumExtension_embedding_eq_self_iff T ρ).2 hρfix)
+
 /-- **Density-block form for fixed points on a finite direct sum.**
 
 Let `T` be a positive map of a finite sum of full matrix algebras that
@@ -247,25 +288,12 @@ theorem IsPositiveDirectSumMap.exists_block_densities_of_fixedPoints
   let TFin := reindexEndomorphism efin TExt
   let ρExt := directSumDiagonalEmbedding ρ
   let ρFin := Matrix.reindex efin efin ρExt
-  have hTFin : IsPositiveMap TFin := by
-    exact IsPositiveMap.reindexEndomorphism
-      hT.directSumExtension_isPositiveMap efin
-  have hTPFin : IsTracePreservingMap TFin := by
-    exact IsTracePreservingMap.reindexEndomorphism
-      hTP.directSumExtension_isTracePreservingMap efin
-  have hSchwarzExt : IsSchwarzMap (Matrix.traceAdjointMap TExt) := by
-    exact hSchwarz.traceAdjointMap_directSumExtension_isSchwarzMap hT
-  have hSchwarzFin : IsSchwarzMap (Matrix.traceAdjointMap TFin) := by
-    rw [traceAdjointMap_reindexEndomorphism]
-    exact IsSchwarzMap.reindexEndomorphism hSchwarzExt efin
-  have hρExt : ρExt.PosDef := directSumDiagonalEmbedding_posDef hρ
-  have hρFin : ρFin.PosDef := hρExt.reindex efin
-  have hρExtFix : TExt ρExt = ρExt := by
-    exact (directSumExtension_embedding_eq_self_iff T ρ).2 hρfix
-  have hρFinFix : TFin ρFin = ρFin := by
-    let Φ := Matrix.reindexLinearEquiv ℂ ℂ efin efin
-    change Φ (TExt (Φ.symm (Φ ρExt))) = Φ ρExt
-    rw [Φ.symm_apply_apply, hρExtFix]
+  obtain ⟨hTFin, hTPFin, hSchwarzFin, hρFin, hρFinFix⟩ :
+      IsPositiveMap TFin ∧ IsTracePreservingMap TFin ∧
+        IsSchwarzMap (Matrix.traceAdjointMap TFin) ∧
+        ρFin.PosDef ∧ TFin ρFin = ρFin := by
+    simpa only [ρFin, ρExt, TFin, TExt] using
+      hT.reindexedExtension_properties hTP hSchwarz hρ hρfix efin
   obtain ⟨K, d, m, eClass, UFin, σ, hUFin, hd, hm, hσpos, hσtrace,
       _, hfixed⟩ :=
     hTFin.exists_block_densities_of_meanErgodicProjection

--- a/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
@@ -306,7 +306,16 @@ Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
 Equation (6.63); local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1469--1494.
 This is the dimension implication used in arXiv:1606.00608, Appendix C.4,
-lines 1980--1995. -/
+lines 1980--1995.
+
+**Scope restriction (faithful fixed family):** Wolf's Theorem 6.14 does not
+assume a positive-definite fixed point and allows a complementary zero
+summand.  The present theorem is its full-support corollary for a direct-sum
+map with a positive-definite fixed family.  In the CPSV16 argument this family
+is supplied separately by the fixed contraction factors and their
+positive-length product span.  This restriction and its elimination in the
+tensor-attached argument are documented in
+`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`. -/
 theorem fixedPointProductSpan_finrank_le_of_densityBlocks
     {g : ℕ} {dim : Fin g → ℕ}
     {F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim}

--- a/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
@@ -25,7 +25,7 @@ renormalization fixed-point theorem.
   Appendix C.4, lines 1980--1995.
 -/
 
-open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
+open scoped Matrix MatrixOrder ComplexOrder Kronecker
 
 noncomputable section
 
@@ -189,6 +189,9 @@ private theorem pi_list_prod_apply
   | cons A l ih =>
       rw [List.prod_cons, List.map_cons, List.prod_cons, Pi.mul_apply, ih]
 
+/-- Full-matrix density-block argument underlying the public direct-sum
+theorem below.  This is the dimension implication of Wolf, Theorem 6.14 and
+Equation (6.63); see the public wrapper for the source and scope discussion. -/
 private theorem matrixFixedPointProductSpan_finrank_le_of_densityBlocks
     {N : ℕ} {F : Matrix (Fin N) (Fin N) ℂ →ₗ[ℂ]
       Matrix (Fin N) (Fin N) ℂ}
@@ -315,7 +318,10 @@ map with a positive-definite fixed family.  In the CPSV16 argument this family
 is supplied separately by the fixed contraction factors and their
 positive-length product span.  This restriction and its elimination in the
 tensor-attached argument are documented in
-`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`. -/
+`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`.
+
+The condition $L>0$ is retained to match the quantifier in the cited
+formulation; the proof also gives the bound for $L=0$. -/
 theorem fixedPointProductSpan_finrank_le_of_densityBlocks
     {g : ℕ} {dim : Fin g → ℕ}
     {F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim}
@@ -333,25 +339,12 @@ theorem fixedPointProductSpan_finrank_le_of_densityBlocks
   let EFin := Matrix.reindexEndomorphism efin E
   let ρExt := Matrix.directSumDiagonalEmbedding ρ
   let ρFin := Matrix.reindex efin efin ρExt
-  have hEFin : IsPositiveMap EFin :=
-    Matrix.IsPositiveMap.reindexEndomorphism
-      hF.directSumExtension_isPositiveMap efin
-  have hTPFin : IsTracePreservingMap EFin :=
-    Matrix.IsTracePreservingMap.reindexEndomorphism
-      hTP.directSumExtension_isTracePreservingMap efin
-  have hSchwarzExt : IsSchwarzMap (Matrix.traceAdjointMap E) :=
-    hSchwarz.traceAdjointMap_directSumExtension_isSchwarzMap hF
-  have hSchwarzFin : IsSchwarzMap (Matrix.traceAdjointMap EFin) := by
-    rw [Matrix.traceAdjointMap_reindexEndomorphism]
-    exact Matrix.IsSchwarzMap.reindexEndomorphism hSchwarzExt efin
-  have hρFin : ρFin.PosDef :=
-    (Matrix.directSumDiagonalEmbedding_posDef hρ).reindex efin
-  have hρExtFix : E ρExt = ρExt :=
-    (Matrix.directSumExtension_embedding_eq_self_iff F ρ).2 hρfix
-  have hρFinFix : EFin ρFin = ρFin := by
-    let Ψ := Matrix.reindexLinearEquiv ℂ ℂ efin efin
-    change Ψ (E (Ψ.symm (Ψ ρExt))) = Ψ ρExt
-    rw [Ψ.symm_apply_apply, hρExtFix]
+  obtain ⟨hEFin, hTPFin, hSchwarzFin, hρFin, hρFinFix⟩ :
+      IsPositiveMap EFin ∧ IsTracePreservingMap EFin ∧
+        IsSchwarzMap (Matrix.traceAdjointMap EFin) ∧
+        ρFin.PosDef ∧ EFin ρFin = ρFin := by
+    simpa only [ρFin, ρExt, EFin, E] using
+      hF.reindexedExtension_properties hTP hSchwarz hρ hρfix efin
   have hFull := matrixFixedPointProductSpan_finrank_le_of_densityBlocks
     hEFin hTPFin hSchwarzFin hρFin hρFinFix L
   let ιmap : VerticalSectorAlgebra dim →ₗ[ℂ]

--- a/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
@@ -1,0 +1,469 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
+import TNLean.MPS.MPDO.VerticalSectorGeneration
+
+/-!
+# Product spans of density-weighted fixed points
+
+Wolf's density-block description identifies the fixed points of a positive
+trace-preserving map with blocks of the form $\sigma_k\otimes X_k$.  Products
+of $L$ fixed points therefore have blocks
+$\sigma_k^L\otimes(X_{1,k}\cdots X_{L,k})$.  This file turns that observation
+into the dimension bound used in the proof of the general MPDO
+renormalization fixed-point theorem.
+
+## References
+
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
+  Equation (6.63); local source
+  `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1469--1494.
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1980--1995.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+private def matrixFixedPointProductSpan
+    {n : Type*} [Fintype n] [DecidableEq n] (L : ℕ)
+    (F : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    Submodule ℂ (Matrix n n ℂ) :=
+  Submodule.span ℂ (Set.range fun X : Fin L → F.fixedSubmodule ↦
+    (List.ofFn fun t ↦ (X t : Matrix n n ℂ)).prod)
+
+private def densityBlockLinearMap
+    {K : ℕ} {m d : Fin K → ℕ}
+    (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ) :
+    (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) →ₗ[ℂ]
+      Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
+        ((k : Fin K) × (Fin (m k) × Fin (d k))) ℂ where
+  toFun X := Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k
+  map_add' X Y := by
+    rw [← Matrix.blockDiagonal'_add]
+    congr 1
+    funext k
+    exact Matrix.kronecker_add (σ k) (X k) (Y k)
+  map_smul' c X := by
+    rw [← Matrix.blockDiagonal'_smul]
+    congr 1
+    funext k
+    exact Matrix.kronecker_smul c (σ k) (X k)
+
+private theorem densityBlockLinearMap_injective
+    {K : ℕ} {m d : Fin K → ℕ}
+    (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (hσtrace : ∀ k, (σ k).trace = 1) :
+    Function.Injective (densityBlockLinearMap (d := d) σ) := by
+  intro X Y hXY
+  apply funext
+  intro k
+  change Matrix.blockDiagonal' (fun k ↦ σ k ⊗ₖ X k) =
+    Matrix.blockDiagonal' (fun k ↦ σ k ⊗ₖ Y k) at hXY
+  have hblocks := Matrix.blockDiagonal'_injective hXY
+  have hk := congrFun hblocks k
+  have hpartial := congrArg Matrix.partialTraceLeft hk
+  simpa only [Matrix.partialTraceLeft_kronecker, hσtrace, one_smul] using hpartial
+
+private theorem unitaryReindexLinearEquiv_one
+    {n H : Type*} [Fintype n] [DecidableEq n]
+    [Fintype H] [DecidableEq H] (e : H ≃ n)
+    (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    Matrix.unitaryReindexLinearEquiv e U hU 1 = 1 := by
+  rw [Matrix.unitaryReindexLinearEquiv_apply]
+  rw [Matrix.mul_one, Matrix.mem_unitaryGroup_iff'.mp hU]
+  exact Matrix.reindexLinearEquiv_one ℂ ℂ e.symm
+
+private theorem unitaryReindexLinearEquiv_mul
+    {n H : Type*} [Fintype n] [DecidableEq n]
+    [Fintype H] [DecidableEq H] (e : H ≃ n)
+    (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (A B : Matrix n n ℂ) :
+    Matrix.unitaryReindexLinearEquiv e U hU (A * B) =
+      Matrix.unitaryReindexLinearEquiv e U hU A *
+        Matrix.unitaryReindexLinearEquiv e U hU B := by
+  rw [Matrix.unitaryReindexLinearEquiv_apply,
+    Matrix.unitaryReindexLinearEquiv_apply,
+    Matrix.unitaryReindexLinearEquiv_apply]
+  have hUright : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hU
+  have hconj : star U * (A * B) * U =
+      (star U * A * U) * (star U * B * U) := by
+    calc
+      star U * (A * B) * U = star U * A * (U * star U) * B * U := by
+        rw [hUright]
+        simp only [Matrix.mul_one, Matrix.mul_assoc]
+      _ = (star U * A * U) * (star U * B * U) := by
+        simp only [Matrix.mul_assoc]
+  calc
+    Matrix.reindex e.symm e.symm (star U * (A * B) * U) =
+        Matrix.reindex e.symm e.symm
+          ((star U * A * U) * (star U * B * U)) := congrArg _ hconj
+    _ = Matrix.reindex e.symm e.symm (star U * A * U) *
+        Matrix.reindex e.symm e.symm (star U * B * U) :=
+      (Matrix.reindexLinearEquiv_mul ℂ ℂ e.symm e.symm e.symm _ _).symm
+
+private theorem unitaryReindexLinearEquiv_list_prod
+    {n H : Type*} [Fintype n] [DecidableEq n]
+    [Fintype H] [DecidableEq H] (e : H ≃ n)
+    (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (A : List (Matrix n n ℂ)) :
+    Matrix.unitaryReindexLinearEquiv e U hU A.prod =
+      (A.map (Matrix.unitaryReindexLinearEquiv e U hU)).prod := by
+  induction A with
+  | nil =>
+      simpa only [List.prod_nil, List.map_nil] using
+        unitaryReindexLinearEquiv_one e U hU
+  | cons A l ih =>
+      rw [List.prod_cons, List.map_cons, List.prod_cons,
+        unitaryReindexLinearEquiv_mul, ih]
+
+private theorem densityBlockLinearMap_list_prod
+    {K L : ℕ} {m d : Fin K → ℕ}
+    (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ)
+    (X : Fin L → ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :
+    (List.ofFn fun t ↦ densityBlockLinearMap σ (X t)).prod =
+      densityBlockLinearMap (fun k ↦ (σ k) ^ L)
+        (fun k ↦ (List.ofFn fun t ↦ X t k).prod) := by
+  induction L with
+  | zero =>
+      simp only [List.ofFn_zero, List.prod_nil, pow_zero]
+      change 1 = Matrix.blockDiagonal' fun k ↦
+        (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ
+          (1 : Matrix (Fin (d k)) (Fin (d k)) ℂ)
+      simp only [Matrix.one_kronecker_one]
+      rw [show (fun k ↦ (1 : Matrix (Fin (m k) × Fin (d k))
+        (Fin (m k) × Fin (d k)) ℂ)) = 1 by rfl]
+      exact Matrix.blockDiagonal'_one.symm
+  | succ L ih =>
+      rw [List.ofFn_succ, List.prod_cons]
+      have ih' := ih (fun t ↦ X t.succ)
+      rw [ih']
+      change Matrix.blockDiagonal' (fun k ↦ σ k ⊗ₖ X 0 k) *
+          Matrix.blockDiagonal' (fun k ↦
+            ((σ k) ^ L) ⊗ₖ (List.ofFn fun t ↦ X t.succ k).prod) =
+        Matrix.blockDiagonal' (fun k ↦
+          ((σ k) ^ (L + 1)) ⊗ₖ (List.ofFn fun t ↦ X t k).prod)
+      rw [← Matrix.blockDiagonal'_mul]
+      congr 1
+      funext k
+      rw [← Matrix.mul_kronecker_mul, pow_succ']
+      rw [List.ofFn_succ, List.prod_cons]
+
+private theorem reindex_directSumDiagonalEmbedding_list_prod
+    {ι β : Type*} [Fintype ι] [DecidableEq ι]
+    {n : ι → Type*} [∀ k, Fintype (n k)] [∀ k, DecidableEq (n k)]
+    [Fintype β] [DecidableEq β] (e : ((k : ι) × n k) ≃ β)
+    (A : List (∀ k, Matrix (n k) (n k) ℂ)) :
+    Matrix.reindex e e (Matrix.directSumDiagonalEmbedding A.prod) =
+      (A.map fun X ↦
+        Matrix.reindex e e (Matrix.directSumDiagonalEmbedding X)).prod := by
+  induction A with
+  | nil =>
+      simp only [List.prod_nil, List.map_nil]
+      change Matrix.reindex e e (Matrix.blockDiagonal' 1) = 1
+      rw [Matrix.blockDiagonal'_one]
+      exact Matrix.reindexLinearEquiv_one ℂ ℂ e
+  | cons A l ih =>
+      rw [List.prod_cons, List.map_cons, List.prod_cons,
+        Matrix.directSumDiagonalEmbedding_mul]
+      rw [show Matrix.reindex e e
+          (Matrix.directSumDiagonalEmbedding A *
+            Matrix.directSumDiagonalEmbedding l.prod) =
+          Matrix.reindex e e (Matrix.directSumDiagonalEmbedding A) *
+            Matrix.reindex e e (Matrix.directSumDiagonalEmbedding l.prod) by
+        exact (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e _ _).symm]
+      rw [ih]
+
+private theorem pi_list_prod_apply
+    {ι : Type*} {M : ι → Type*} [∀ k, Monoid (M k)]
+    (A : List (∀ k, M k)) (k : ι) :
+    A.prod k = (A.map fun X ↦ X k).prod := by
+  induction A with
+  | nil => rfl
+  | cons A l ih =>
+      rw [List.prod_cons, List.map_cons, List.prod_cons, Pi.mul_apply, ih]
+
+private theorem matrixFixedPointProductSpan_finrank_le_of_densityBlocks
+    {N : ℕ} {F : Matrix (Fin N) (Fin N) ℂ →ₗ[ℂ]
+      Matrix (Fin N) (Fin N) ℂ}
+    (hF : IsPositiveMap F) (hTP : IsTracePreservingMap F)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap F))
+    {ρ : Matrix (Fin N) (Fin N) ℂ} (hρ : ρ.PosDef) (hρfix : F ρ = ρ)
+    (L : ℕ) :
+    Module.finrank ℂ (matrixFixedPointProductSpan L F) ≤
+      Module.finrank ℂ F.fixedSubmodule := by
+  obtain ⟨K, d, m, e, U, σ, hU, _, _, _, hσtrace, _, hfixed⟩ :=
+    hF.exists_block_densities_of_meanErgodicProjection
+      hTP hSchwarz hρ hρfix
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  let D := densityBlockLinearMap (d := d) σ
+  let DL := densityBlockLinearMap (d := d) (fun k ↦ (σ k) ^ L)
+  have hDinj : Function.Injective D :=
+    densityBlockLinearMap_injective (d := d) σ hσtrace
+  have hFixedRange : F.fixedSubmodule.map Φ.toLinearMap =
+      LinearMap.range D := by
+    ext B
+    constructor
+    · rintro ⟨A, hA, rfl⟩
+      obtain ⟨X, hX⟩ :=
+        (hfixed A).mp (LinearMap.mem_fixedSubmodule_iff.mp hA)
+      refine ⟨X, ?_⟩
+      apply Eq.symm
+      dsimp only [D, Φ]
+      change Matrix.reindex e.symm e.symm (star U * A * U) =
+        densityBlockLinearMap (d := d) σ X
+      change star U * A * U =
+        Matrix.reindex e e (densityBlockLinearMap (d := d) σ X) at hX
+      rw [hX]
+      simpa only [Matrix.coe_reindexLinearEquiv,
+        Matrix.symm_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv ℂ ℂ e e).symm_apply_apply
+          (densityBlockLinearMap (d := d) σ X)
+    · rintro ⟨X, rfl⟩
+      let A := Φ.symm (D X)
+      have hAcoord : star U * A * U = Matrix.reindex e e (D X) := by
+        rw [show A = U * Matrix.reindex e e (D X) * star U by
+          exact Matrix.unitaryReindexLinearEquiv_symm_apply e U hU (D X)]
+        have hUleft : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hU
+        calc
+          star U * (U * Matrix.reindex e e (D X) * star U) * U =
+              (star U * U) * Matrix.reindex e e (D X) * (star U * U) := by
+            simp only [Matrix.mul_assoc]
+          _ = Matrix.reindex e e (D X) := by rw [hUleft]; simp
+      have hAfix : F A = A := (hfixed A).mpr ⟨X, hAcoord⟩
+      refine ⟨A, LinearMap.mem_fixedSubmodule_iff.mpr hAfix, ?_⟩
+      exact Φ.apply_symm_apply (D X)
+  have hProductMap :
+      (matrixFixedPointProductSpan L F).map Φ.toLinearMap ≤
+        LinearMap.range DL := by
+    rw [Submodule.map_le_iff_le_comap]
+    apply Submodule.span_le.mpr
+    rintro _ ⟨X, rfl⟩
+    change Φ ((List.ofFn fun t ↦ (X t : Matrix (Fin N) (Fin N) ℂ)).prod) ∈
+      LinearMap.range DL
+    choose Y hY using fun t ↦ (hfixed (X t)).mp (X t).property
+    have hΦ (t : Fin L) : Φ (X t) = D (Y t) := by
+      dsimp only [Φ, D]
+      change Matrix.reindex e.symm e.symm
+          (star U * (X t : Matrix (Fin N) (Fin N) ℂ) * U) =
+        densityBlockLinearMap (d := d) σ (Y t)
+      have hYt := hY t
+      change star U * (X t : Matrix (Fin N) (Fin N) ℂ) * U =
+        Matrix.reindex e e (densityBlockLinearMap (d := d) σ (Y t)) at hYt
+      rw [hYt]
+      simpa only [Matrix.coe_reindexLinearEquiv,
+        Matrix.symm_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv ℂ ℂ e e).symm_apply_apply
+          (densityBlockLinearMap (d := d) σ (Y t))
+    refine ⟨fun k ↦ (List.ofFn fun t ↦ Y t k).prod, ?_⟩
+    calc
+      DL (fun k ↦ (List.ofFn fun t ↦ Y t k).prod) =
+          (List.ofFn fun t ↦ D (Y t)).prod := by
+        exact (densityBlockLinearMap_list_prod σ Y).symm
+      _ = (List.ofFn fun t ↦ Φ (X t)).prod := by
+        congr 2
+        funext t
+        exact (hΦ t).symm
+      _ = Φ ((List.ofFn fun t ↦
+          (X t : Matrix (Fin N) (Fin N) ℂ)).prod) := by
+        rw [unitaryReindexLinearEquiv_list_prod]
+        rw [List.map_ofFn]
+        rfl
+  calc
+    Module.finrank ℂ (matrixFixedPointProductSpan L F) =
+        Module.finrank ℂ
+          ((matrixFixedPointProductSpan L F).map Φ.toLinearMap) :=
+      (LinearEquiv.finrank_map_eq Φ (matrixFixedPointProductSpan L F)).symm
+    _ ≤ Module.finrank ℂ (LinearMap.range DL) :=
+      Submodule.finrank_mono hProductMap
+    _ ≤ Module.finrank ℂ (∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ) :=
+      LinearMap.finrank_range_le DL
+    _ = Module.finrank ℂ (LinearMap.range D) :=
+      (LinearMap.finrank_range_of_inj hDinj).symm
+    _ = Module.finrank ℂ (F.fixedSubmodule.map Φ.toLinearMap) := by
+      rw [hFixedRange]
+    _ = Module.finrank ℂ F.fixedSubmodule :=
+      LinearEquiv.finrank_map_eq Φ F.fixedSubmodule
+
+/-- Products of $L$ fixed points of a positive trace-preserving map on a
+finite direct sum have dimension at most that of the fixed-point space,
+provided that the trace adjoint satisfies the Schwarz inequality and the map
+has a positive-definite fixed family.
+
+The proof applies Wolf's density-block classification to the canonical
+full-matrix extension.  In density-block coordinates the fixed points are
+$\bigoplus_k \sigma_k\otimes X_k$, whereas their $L$-fold products lie in the
+range of $X\mapsto\bigoplus_k\sigma_k^L\otimes X_k$.  Both parameter spaces
+therefore have the same dimension bound.
+
+Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
+Equation (6.63); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1469--1494.
+This is the dimension implication used in arXiv:1606.00608, Appendix C.4,
+lines 1980--1995. -/
+theorem fixedPointProductSpan_finrank_le_of_densityBlocks
+    {g : ℕ} {dim : Fin g → ℕ}
+    {F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim}
+    (hF : Matrix.IsPositiveDirectSumMap F)
+    (hTP : Matrix.IsTracePreservingDirectSumMap F)
+    (hSchwarz : Matrix.IsSchwarzDirectSumMap
+      (Matrix.directSumTraceAdjointMap F))
+    {ρ : VerticalSectorAlgebra dim} (hρ : ∀ k, (ρ k).PosDef)
+    (hρfix : F ρ = ρ) (L : ℕ) (_hL : 0 < L) :
+    Module.finrank ℂ (fixedPointProductSpan L F) ≤
+      Module.finrank ℂ F.fixedSubmodule := by
+  let s := (k : Fin g) × Fin (dim k)
+  let efin : s ≃ Fin (Fintype.card s) := Fintype.equivFin s
+  let E := Matrix.directSumExtension F
+  let EFin := Matrix.reindexEndomorphism efin E
+  let ρExt := Matrix.directSumDiagonalEmbedding ρ
+  let ρFin := Matrix.reindex efin efin ρExt
+  have hEFin : IsPositiveMap EFin :=
+    Matrix.IsPositiveMap.reindexEndomorphism
+      hF.directSumExtension_isPositiveMap efin
+  have hTPFin : IsTracePreservingMap EFin :=
+    Matrix.IsTracePreservingMap.reindexEndomorphism
+      hTP.directSumExtension_isTracePreservingMap efin
+  have hSchwarzExt : IsSchwarzMap (Matrix.traceAdjointMap E) :=
+    hSchwarz.traceAdjointMap_directSumExtension_isSchwarzMap hF
+  have hSchwarzFin : IsSchwarzMap (Matrix.traceAdjointMap EFin) := by
+    rw [Matrix.traceAdjointMap_reindexEndomorphism]
+    exact Matrix.IsSchwarzMap.reindexEndomorphism hSchwarzExt efin
+  have hρFin : ρFin.PosDef :=
+    (Matrix.directSumDiagonalEmbedding_posDef hρ).reindex efin
+  have hρExtFix : E ρExt = ρExt :=
+    (Matrix.directSumExtension_embedding_eq_self_iff F ρ).2 hρfix
+  have hρFinFix : EFin ρFin = ρFin := by
+    let Ψ := Matrix.reindexLinearEquiv ℂ ℂ efin efin
+    change Ψ (E (Ψ.symm (Ψ ρExt))) = Ψ ρExt
+    rw [Ψ.symm_apply_apply, hρExtFix]
+  have hFull := matrixFixedPointProductSpan_finrank_le_of_densityBlocks
+    hEFin hTPFin hSchwarzFin hρFin hρFinFix L
+  let ιmap : VerticalSectorAlgebra dim →ₗ[ℂ]
+      Matrix (Fin (Fintype.card s)) (Fin (Fintype.card s)) ℂ :=
+    (Matrix.reindexLinearEquiv ℂ ℂ efin efin).toLinearMap.comp
+      Matrix.directSumDiagonalEmbedding
+  have hιinj : Function.Injective ιmap := by
+    intro A B hAB
+    apply Matrix.blockDiagonal'_injective
+    apply (Matrix.reindexLinearEquiv ℂ ℂ efin efin).injective
+    exact hAB
+  have hιfixed (A : VerticalSectorAlgebra dim) (hA : F A = A) :
+      EFin (ιmap A) = ιmap A := by
+    change Matrix.reindex efin efin
+        (E (Matrix.reindex efin.symm efin.symm
+          (Matrix.reindex efin efin
+            (Matrix.directSumDiagonalEmbedding A)))) =
+      Matrix.reindex efin efin (Matrix.directSumDiagonalEmbedding A)
+    have hback : Matrix.reindex efin.symm efin.symm
+        (Matrix.reindex efin efin (Matrix.directSumDiagonalEmbedding A)) =
+        Matrix.directSumDiagonalEmbedding A := by
+      simpa only [Matrix.coe_reindexLinearEquiv,
+        Matrix.symm_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv ℂ ℂ efin efin).symm_apply_apply
+          (Matrix.directSumDiagonalEmbedding A)
+    rw [hback]
+    rw [(Matrix.directSumExtension_embedding_eq_self_iff F A).2 hA]
+  have hProductMap : (fixedPointProductSpan L F).map ιmap ≤
+      matrixFixedPointProductSpan L EFin := by
+    rw [Submodule.map_le_iff_le_comap]
+    apply Submodule.span_le.mpr
+    rintro _ ⟨X, rfl⟩
+    change ιmap (fun α ↦
+        (List.ofFn fun t ↦ (X t : VerticalSectorAlgebra dim) α).prod) ∈
+      matrixFixedPointProductSpan L EFin
+    have hsector : (fun α ↦
+        (List.ofFn fun t ↦ (X t : VerticalSectorAlgebra dim) α).prod) =
+        (List.ofFn fun t ↦ (X t : VerticalSectorAlgebra dim)).prod := by
+      funext α
+      rw [pi_list_prod_apply, List.map_ofFn]
+      rfl
+    rw [hsector]
+    apply Submodule.subset_span
+    let XFin : Fin L → EFin.fixedSubmodule := fun t ↦
+      ⟨ιmap (X t), hιfixed (X t) (X t).property⟩
+    refine ⟨XFin, ?_⟩
+    change (List.ofFn fun t ↦ (XFin t : Matrix (Fin (Fintype.card s))
+        (Fin (Fintype.card s)) ℂ)).prod =
+      ιmap (List.ofFn fun t ↦ (X t : VerticalSectorAlgebra dim)).prod
+    symm
+    change Matrix.reindex efin efin
+        (Matrix.directSumDiagonalEmbedding
+          (List.ofFn fun t ↦ (X t : VerticalSectorAlgebra dim)).prod) = _
+    rw [reindex_directSumDiagonalEmbedding_list_prod]
+    rw [List.map_ofFn]
+    rfl
+  let back : Matrix (Fin (Fintype.card s)) (Fin (Fintype.card s)) ℂ →ₗ[ℂ]
+      Matrix s s ℂ :=
+    (Matrix.reindexLinearEquiv ℂ ℂ efin.symm efin.symm).toLinearMap
+  let compress : EFin.fixedSubmodule →ₗ[ℂ] VerticalSectorAlgebra dim :=
+    Matrix.directSumDiagonalCompression.comp
+      (back.comp EFin.fixedSubmodule.subtype)
+  have hBackFixed (B : EFin.fixedSubmodule) : E (back B) = back B := by
+    have hB := B.property
+    change Matrix.reindex efin efin
+        (E (Matrix.reindex efin.symm efin.symm
+          (B : Matrix (Fin (Fintype.card s)) (Fin (Fintype.card s)) ℂ))) =
+      (B : Matrix (Fin (Fintype.card s)) (Fin (Fintype.card s)) ℂ) at hB
+    apply (Matrix.reindexLinearEquiv ℂ ℂ efin efin).injective
+    change Matrix.reindex efin efin (E (back B)) =
+      Matrix.reindex efin efin (back B)
+    calc
+      Matrix.reindex efin efin (E (back B)) = B := hB
+      _ = Matrix.reindex efin efin (back B) := by
+        dsimp only [back, LinearMap.coe_comp, LinearEquiv.coe_coe,
+          Function.comp_apply, Submodule.coe_subtype]
+        simpa only [Matrix.coe_reindexLinearEquiv,
+          Matrix.symm_reindexLinearEquiv] using
+          ((Matrix.reindexLinearEquiv ℂ ℂ efin efin).apply_symm_apply
+            (B : Matrix (Fin (Fintype.card s))
+              (Fin (Fintype.card s)) ℂ)).symm
+  have hCompressFixed (B : EFin.fixedSubmodule) : F (compress B) = compress B := by
+    have hB := congrArg Matrix.directSumDiagonalCompression (hBackFixed B)
+    change F (Matrix.directSumDiagonalCompression (back B)) =
+      Matrix.directSumDiagonalCompression (back B)
+    simpa only [E, Matrix.directSumExtension_apply,
+      Matrix.directSumDiagonalCompression_embedding] using hB
+  let κ : EFin.fixedSubmodule →ₗ[ℂ] F.fixedSubmodule :=
+    LinearMap.codRestrict F.fixedSubmodule compress
+      (fun B ↦ LinearMap.mem_fixedSubmodule_iff.mpr (hCompressFixed B))
+  have hκinj : Function.Injective κ := by
+    intro B C hBC
+    apply Subtype.ext
+    apply (Matrix.reindexLinearEquiv ℂ ℂ efin.symm efin.symm).injective
+    change back B = back C
+    have hEmbed (X : EFin.fixedSubmodule) :
+        back X = Matrix.directSumDiagonalEmbedding (compress X) := by
+      calc
+        back X = E (back X) := (hBackFixed X).symm
+        _ = Matrix.directSumDiagonalEmbedding
+            (F (Matrix.directSumDiagonalCompression (back X))) := rfl
+        _ = Matrix.directSumDiagonalEmbedding (compress X) := by
+          change Matrix.directSumDiagonalEmbedding (F (compress X)) =
+            Matrix.directSumDiagonalEmbedding (compress X)
+          rw [hCompressFixed X]
+    rw [hEmbed B, hEmbed C]
+    congr 1
+    change compress B = compress C
+    exact congrArg Subtype.val hBC
+  let ιProduct : fixedPointProductSpan L F →ₗ[ℂ]
+      matrixFixedPointProductSpan L EFin :=
+    LinearMap.codRestrict (matrixFixedPointProductSpan L EFin)
+      (ιmap.comp (fixedPointProductSpan L F).subtype) (fun X ↦ by
+        apply hProductMap
+        exact ⟨X, X.property, rfl⟩)
+  have hιProductInj : Function.Injective ιProduct := by
+    intro A B hAB
+    apply Subtype.ext
+    apply hιinj
+    exact congrArg Subtype.val hAB
+  exact (LinearMap.finrank_le_finrank_of_injective hιProductInj).trans
+    (hFull.trans (LinearMap.finrank_le_finrank_of_injective hκinj))
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
@@ -12,9 +12,9 @@ import TNLean.MPS.MPDO.VerticalSectorGeneration
 Wolf's density-block description identifies the fixed points of a positive
 trace-preserving map with blocks of the form $\sigma_k\otimes X_k$.  Products
 of $L$ fixed points therefore have blocks
-$\sigma_k^L\otimes(X_{1,k}\cdots X_{L,k})$.  This file turns that observation
-into the dimension bound used in the proof of the general MPDO
-renormalization fixed-point theorem.
+$\sigma_k^L\otimes(X_{1,k}\cdots X_{L,k})$.  The main result bounds the
+dimension of their span by the dimension of the fixed-point space, through
+the density-block parametrization of Wolf's Theorem 6.14.
 
 ## References
 

--- a/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
@@ -156,13 +156,14 @@ private theorem densityBlockLinearMap_list_prod
       rw [List.ofFn_succ, List.prod_cons]
 
 private theorem reindex_directSumDiagonalEmbedding_list_prod
-    {ι β : Type*} [Fintype ι] [DecidableEq ι]
+    {ι β : Type*} [Finite ι] [DecidableEq ι]
     {n : ι → Type*} [∀ k, Fintype (n k)] [∀ k, DecidableEq (n k)]
     [Fintype β] [DecidableEq β] (e : ((k : ι) × n k) ≃ β)
     (A : List (∀ k, Matrix (n k) (n k) ℂ)) :
     Matrix.reindex e e (Matrix.directSumDiagonalEmbedding A.prod) =
       (A.map fun X ↦
         Matrix.reindex e e (Matrix.directSumDiagonalEmbedding X)).prod := by
+  letI := Fintype.ofFinite ι
   induction A with
   | nil =>
       simp only [List.prod_nil, List.map_nil]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -485,7 +485,7 @@ physical indices, as in
     \uses{def:mpdo_vertical_fixed_point_products}
     Let
     \[
-        \mathcal A=\bigoplus_{\alpha}M_{d_\alpha}(\mathbb C),
+        \mathcal A=\prod_\alpha M_{d_\alpha},
     \]
     and let $F:\mathcal A\to\mathcal A$ be positive and trace preserving.
     Suppose that the trace adjoint $F^*$ satisfies the Schwarz inequality and
@@ -525,10 +525,15 @@ physical indices, as in
     \]
     Thus the span of these products has dimension at most
     $\sum_k h_k^2$, which is the dimension of the fixed-point space of the
-    extension.  The block-diagonal embedding sends products for $F$
-    injectively to products for the extension, while diagonal compression
-    sends fixed points of the extension injectively to fixed points of $F$.
-    The asserted inequality follows.
+    extension.  Writing $\mathcal E$ for the fixed-point space of the
+    full-matrix extension, the injective block-diagonal embedding and
+    diagonal compression give the dimension chain
+    \[
+        \dim C_L(\mathcal F)
+        \leq \dim C_L(\mathcal E)
+        \leq \dim\mathcal E
+        \leq \dim\mathcal F.
+    \]
 \end{proof}
 
 \begin{theorem}[Fixed contractions and the dimension of their fixed-point space]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -495,12 +495,13 @@ physical indices, as in
     \[
         \dim C_L(\mathcal F)\leq\dim\mathcal F.
     \]
-    This is the full-support corollary of
-    \cite[Theorem~6.14 and Equation~(6.63)]{Wolf2012Quantum} used after a
-    faithful fixed family has been obtained in the argument of
-    \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}.  The general
-    theorem of Wolf allows a complementary zero summand and does not assume
-    such a family; that stronger statement is not asserted here.
+    % Full-support corollary of
+    % \cite[Theorem~6.14 and Equation~(6.63)]{Wolf2012Quantum}; the general
+    % theorem allows a complementary zero summand and does not require a
+    % positive-definite fixed family.  Used in
+    % \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv} after such a
+    % family is obtained.  See
+    % docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -478,6 +478,56 @@ physical indices, as in
     \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Density blocks bound products of fixed points]
+    \label{thm:mpdo_density_blocks_fixed_point_product_dimension}
+    \lean{MPOTensor.fixedPointProductSpan_finrank_le_of_densityBlocks}
+    \leanok
+    \uses{def:mpdo_vertical_fixed_point_products}
+    Let
+    \[
+        \mathcal A=\bigoplus_{\alpha}M_{d_\alpha}(\mathbb C),
+    \]
+    and let $F:\mathcal A\to\mathcal A$ be positive and trace preserving.
+    Suppose that the trace adjoint $F^*$ satisfies the Schwarz inequality and
+    that $F$ fixes a family $\rho=(\rho_\alpha)_\alpha$ for which every
+    $\rho_\alpha$ is positive definite.  If $\mathcal F=\operatorname{Fix}(F)$,
+    then, for every $L>0$,
+    \[
+        \dim C_L(\mathcal F)\leq\dim\mathcal F.
+    \]
+    This is the density-block dimension estimate from
+    \cite[Theorem~6.14 and Equation~(6.63)]{Wolf2012Quantum} used in
+    \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:direct_sum_full_matrix_extension_compatibility,
+        thm:mean_ergodic_projection_density_block_form}
+    Extend $F$ to the full matrix algebra by diagonal compression followed by
+    block-diagonal embedding, and choose a numbered basis of the ambient
+    space.  The extension is positive and trace preserving, its trace adjoint
+    satisfies the Schwarz inequality, and the embedded family $\rho$ is a
+    positive definite fixed point.  The fixed points therefore have the form
+    \[
+        U\left(\bigoplus_k\sigma_k\otimes X_k\right)U^*,
+        \qquad X_k\in M_{h_k}(\mathbb C),
+    \]
+    where $\operatorname{tr}(\sigma_k)=1$.  The parametrization
+    $(X_k)_k\mapsto\bigoplus_k\sigma_k\otimes X_k$ is injective, since its
+    left partial trace is $(X_k)_k$.  Every product of $L$ fixed points lies
+    in the range of
+    \[
+        (Y_k)_k\longmapsto
+        U\left(\bigoplus_k\sigma_k^L\otimes Y_k\right)U^*.
+    \]
+    Thus the span of these products has dimension at most
+    $\sum_k h_k^2$, which is the dimension of the fixed-point space of the
+    extension.  The block-diagonal embedding sends products for $F$
+    injectively to products for the extension, while diagonal compression
+    sends fixed points of the extension injectively to fixed points of $F$.
+    The asserted inequality follows.
+\end{proof}
+
 \begin{theorem}[Fixed contractions and the dimension of their fixed-point space]
     \label{thm:mpdo_fixed_contractions_product_dimension}
     \lean{MPOTensor.%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -478,7 +478,7 @@ physical indices, as in
     \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Density blocks bound products of fixed points]
+\begin{theorem}[Density blocks of a faithful fixed family bound products]
     \label{thm:mpdo_density_blocks_fixed_point_product_dimension}
     \lean{MPOTensor.fixedPointProductSpan_finrank_le_of_densityBlocks}
     \leanok
@@ -495,9 +495,12 @@ physical indices, as in
     \[
         \dim C_L(\mathcal F)\leq\dim\mathcal F.
     \]
-    This is the density-block dimension estimate from
-    \cite[Theorem~6.14 and Equation~(6.63)]{Wolf2012Quantum} used in
-    \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}.
+    This is the full-support corollary of
+    \cite[Theorem~6.14 and Equation~(6.63)]{Wolf2012Quantum} used after a
+    faithful fixed family has been obtained in the argument of
+    \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}.  The general
+    theorem of Wolf allows a complementary zero summand and does not assume
+    such a family; that stronger statement is not asserted here.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -9,7 +9,7 @@
 
 \title{CPSV16 Vertical-Sector Invertibility and Sector Relabelling}
 \author{}
-\date{2026-07-18}
+\date{2026-07-19}
 
 \begin{document}
 \maketitle
@@ -107,8 +107,14 @@ then the endomorphism is the identity.\footnote{Formal declarations:
 in \doclink{TNLean/MPS/MPDO/VerticalSectorGeneration}.}
 This second implication does not assume that products of distinguished
 contractions are fixed.  It isolates the source's dimension argument.  The
-formalized fixed-point theorem supplies the displayed inequality from the
-density-weighted form of $\mathcal F$ once its channel hypotheses are known.
+displayed inequality is now formalized for a positive trace-preserving map on
+a finite direct sum whenever its trace adjoint satisfies the Schwarz
+inequality and it has a positive-definite fixed family.\footnote{Formal
+declaration:
+\leanid{MPOTensor.fixedPointProductSpan_finrank_le_of_densityBlocks}
+in \doclink{TNLean/MPS/MPDO/VerticalSectorDensityBlocks}.}
+No tensor hypothesis, multiplicativity assumption, or fixedness of products
+enters this result.
 
 The positive trace-preserving mean-ergodic retraction on a full matrix algebra
 and its positive unital trace-adjoint retraction onto the adjoint fixed-point
@@ -126,20 +132,18 @@ trace preserving precisely when the precompression output lies in its active
 image.  The established image identity is restricted to the source-generated
 contractions.
 
-There is also a difference between the domains of the two results.  The
-present full-support theorem concerns an endomorphism of one full matrix
-algebra, whereas the transported composites act on dependent direct sums of
-matrix algebras.  The canonical full-matrix extension is now formalized: one
-first compresses to the diagonal blocks, applies the direct-sum map, and then
-embeds the output block diagonally.  Positivity, total-trace preservation, and
-the Schwarz inequality pass to this extension, its trace adjoint is the
-extension of the direct-sum trace adjoint, and its fixed points are exactly the
-block-diagonal images of the direct-sum fixed points.  Reindexing the extension
-by a finite equivalence and applying the full-support theorem now gives the
-density-block form of the fixed families on the original direct sum.  The
+The passage from one full matrix algebra to the dependent direct sums is also
+complete for this dimension estimate.  One compresses to the diagonal blocks,
+applies the direct-sum map, and embeds the result block diagonally.  Positivity,
+total-trace preservation, and the Schwarz inequality pass to this extension;
+its fixed points compress injectively to the fixed points of the direct-sum
+map, while products of direct-sum fixed points embed injectively among the
+products of fixed points of the extension.  The density-block calculation on
+the extension therefore gives
+$\dim C_L(\mathcal F)\leq\dim\mathcal F$ on the original direct sum.  The
 trace-preservation part of the required channel hypotheses for the two square
 composites is resolved below.  Complete positivity and the adjoint Schwarz
-inequality still have to be transferred to the full direct sums.
+inequality still have to be obtained from the source tensor hypotheses.
 Alternatively, the maximal-support witness
 $T_\infty(\mathbf 1)$ is now available for an arbitrary positive
 trace-preserving map.  The construction of the supported endomorphism and its
@@ -257,12 +261,12 @@ order:
           two transported square composites on the full sector algebras;
           trace preservation of the individual maps and composites is now
           established without an all-input active-image statement;
-    \item complete the density-weighted fixed-point theorem and transfer it to
-          the sector direct sums, either through a block-diagonal full-matrix
-          extension or through a direct-sum theorem, to prove
-          $\dim C_L(\mathcal F)\leq\dim\mathcal F$ for the fixed-point spaces
-          of $\widetilde S\widetilde T$ and $\widetilde T\widetilde S$;
-    \item combine this dimension bound with the fixed contraction families,
+    \item apply the maximal-support fixed-point construction to the canonical
+          full-matrix extensions and compress the resulting positive-definite
+          fixed points to positive-definite fixed families on the sector
+          direct sums;
+    \item apply the proved density-block dimension bound and combine it with
+          the fixed contraction families,
           the already proved product-generation theorem, and the
           finite-dimensional implication above to obtain both identity
           compositions;
@@ -273,12 +277,15 @@ order:
 
 \section{Classification}
 
-\textbf{Verdict: trace subproblem closed; invertibility gap open.}  The two
-transported maps and their square composites are trace preserving under the
-source tensor hypotheses.  The stronger active-image inclusions remain
-unproved.  Until the remaining channel-structure and fixed-point steps are
-proved, neither transported-map invertibility nor sector relabelling should
-carry a completion marker in the blueprint.
+\textbf{Verdict: trace and density-dimension subproblems closed; invertibility
+gap open.}  The two transported maps and their square composites are trace
+preserving under the source tensor hypotheses.  The fixed-point
+density-block form now yields the required product-span dimension inequality
+on finite direct sums under its channel hypotheses.  The stronger
+active-image inclusions remain unproved and are not needed for this route.
+Until the adjoint Schwarz inequalities and the tensor-attached fixed-family
+application are proved, neither transported-map invertibility nor sector
+relabelling should carry a completion marker in the blueprint.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -114,7 +114,11 @@ declaration:
 \leanid{MPOTensor.fixedPointProductSpan_finrank_le_of_densityBlocks}
 in \doclink{TNLean/MPS/MPDO/VerticalSectorDensityBlocks}.}
 No tensor hypothesis, multiplicativity assumption, or fixedness of products
-enters this result.
+enters this result.  It is nevertheless a full-support corollary: unlike
+Wolf's unrestricted Theorem~6.14, its statement assumes the positive-definite
+fixed family.  The tensor-attached argument must first obtain that family from
+the fixed contractions and their positive-length product span, as recorded in
+the elimination plan below.
 
 The positive trace-preserving mean-ergodic retraction on a full matrix algebra
 and its positive unital trace-adjoint retraction onto the adjoint fixed-point
@@ -277,15 +281,16 @@ order:
 
 \section{Classification}
 
-\textbf{Verdict: trace and density-dimension subproblems closed; invertibility
-gap open.}  The two transported maps and their square composites are trace
-preserving under the source tensor hypotheses.  The fixed-point
-density-block form now yields the required product-span dimension inequality
-on finite direct sums under its channel hypotheses.  The stronger
+\textbf{Verdict: trace subproblem closed; full-support density-dimension lemma
+proved; invertibility gap open.}  The two transported maps and their square
+composites are trace preserving under the source tensor hypotheses.  For a
+finite direct sum with a positive-definite fixed family, the density-block
+form now yields the required product-span dimension inequality.  The stronger
 active-image inclusions remain unproved and are not needed for this route.
-Until the adjoint Schwarz inequalities and the tensor-attached fixed-family
-application are proved, neither transported-map invertibility nor sector
-relabelling should carry a completion marker in the blueprint.
+Until the adjoint Schwarz inequalities and the tensor-attached construction
+of the faithful fixed families are proved, neither transported-map
+invertibility nor sector relabelling should carry a completion marker in the
+blueprint.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- prove `MPOTensor.fixedPointProductSpan_finrank_le_of_densityBlocks` for positive trace-preserving endomorphisms of finite direct sums whose trace adjoints satisfy Schwarz and which admit a positive-definite fixed family;
- pass to the canonical full-matrix extension, apply the density-block form from Wolf Theorem 6.14, and compare the product parameter map with the fixed-point parameter map;
- record the result in the MPDO blueprint and update the vertical-sector invertibility gap document.

## Mathematical content

For `F : ⨁ₖ M_{dₖ}(ℂ) → ⨁ₖ M_{dₖ}(ℂ)`, the theorem proves

```text
dim C_L(Fix(F)) ≤ dim Fix(F)
```

under positivity, total-trace preservation, the Schwarz inequality for the trace adjoint, and a positive-definite fixed family. There is no tensor-specific hypothesis, no multiplicativity assumption, and no assumption that products of fixed points are fixed.

The canonical extension has fixed points of the form

```text
U (⨁ₖ σₖ ⊗ Xₖ) U*
```

with `tr(σₖ) = 1`. Hence the fixed-point parameter map is injective by left partial trace, while every length-`L` product lies in the range of the map with density factors `σₖ^L`. The direct-sum product span embeds injectively into that of the extension, and fixed points of the extension compress injectively to fixed points of `F`.

Scope: this is the full-support corollary needed after a faithful fixed family has been supplied. The unrestricted Wolf theorem permits a complementary zero summand and does not assume such a family; that unrestricted statement is not claimed here. The tensor-attached construction of the faithful family remains part of the open invertibility argument.

Source: Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and Equation (6.63), local source lines 1469–1494; CPSV16, arXiv:1606.00608, Appendix C.4, lines 1980–1995.

This completes Stage 3 of #4418 and advances #232. It does not close #4418: the tensor-attached adjoint Schwarz argument and the two identity compositions remain.

## Validation

- `lake env lean TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean`
- `lake build` (9,620 jobs)
- `leanblueprint pdf`
- `leanblueprint web`
- `leanblueprint checkdecls`
- proof-integrity search for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` in the new file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal mathematics and documentation only; no runtime, auth, or data paths. Large new Lean file increases proof-maintenance surface but follows established fixed-point infrastructure.
> 
> **Overview**
> Adds **`MPOTensor.fixedPointProductSpan_finrank_le_of_densityBlocks`**: for a positive trace-preserving map on a finite direct sum, with Schwarz on the trace adjoint and a **positive-definite fixed family** ρ, the span of length-`L` products of fixed points has dimension at most **dim Fix(F)**. The proof passes to the canonical full-matrix extension, uses Wolf density blocks (σ_k ⊗ X_k vs σ_k^L on products), and compares dimensions via injective block-diagonal embedding and diagonal compression.
> 
> **`IsPositiveDirectSumMap.reindexedExtension_properties`** in `DirectSumBlockRetraction.lean` packages positivity, trace preservation, Schwarz, and fixed ρ after reindexing; the existing density-block classification proof now calls it instead of duplicating that setup.
> 
> New module **`VerticalSectorDensityBlocks.lean`** (root import switched from `VerticalSectorGeneration` only for this surface). Blueprint **ch21** records the theorem and proof sketch; **`cpsv16_vertical_sector_invertibility.tex`** marks the full-support density-dimension step as proved and revises the elimination plan (faithful ρ from maximal support, then this bound).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d7ed15b07121ce1b3155768e2891423f7a91a76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->