### PR TITLE
docs(tenkz): migrate MPDO block closures

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -60,7 +60,35 @@
 
 The two closure maps have the same local form:
 \begin{center}
-    \TNMPDOBlockClosureMap
+    % Formula: M_\alpha(X)_{ij}
+    % = \sum_{a,b}(M_\alpha^{ij})_{ab}X_{ba}
+    % = \operatorname{tr}(M_\alpha^{ij}X).
+    % Source verdict: Papers/1606.00608/DAVID_Fig10.png, cited at source TeX
+    % lines 1974--1980, places X immediately left of the boxed M_\alpha.
+    % Ink-to-index and contraction audit: the direct adjacent virtual bond and
+    % the single-row periodic return below together contract a and b;
+    % the unlabeled upper and lower physical stubs carry the free i and j.
+    % Paired signature (formula and network):
+    % boundary|virtual-west=0|virtual-east=0|physical-up=1|physical-down=1.
+    $M_\alpha(X)=$
+    \begin{tenkz}[periodic, physical=updown, tensor style=box]
+        \tn[box, no legs]{X} & \tn[mpo]{M_\alpha}
+    \end{tenkz}
+    \qquad
+    % Formula: A_\alpha(X)_{ij}
+    % = \sum_{a,b}(A_\alpha^{ij})_{ab}X_{ba}
+    % = \operatorname{tr}(A_\alpha^{ij}X).
+    % Source verdict: the second panel of DAVID_Fig10.png has the same geometry,
+    % with X immediately left of the boxed A_\alpha.
+    % Ink-to-index and contraction audit: the direct adjacent virtual bond and
+    % the single-row periodic return below together contract a and b;
+    % the unlabeled upper and lower physical stubs carry the free i and j.
+    % Paired signature (formula and network):
+    % boundary|virtual-west=0|virtual-east=0|physical-up=1|physical-down=1.
+    $A_\alpha(X)=$
+    \begin{tenkz}[periodic, physical=updown, tensor style=box]
+        \tn[box, no legs]{X} & \tn[mpo]{A_\alpha}
+    \end{tenkz}
 \end{center}
 In each cell, $X$ is inserted on the virtual bond and the virtual indices are
 closed by $\tr$; the physical legs remain open.  Their spans are the

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -332,25 +332,6 @@
     \end{TNEquationRow}%
 }
 
-% The two block closure maps: a boundary insertion on the virtual bond of a
-% block tensor, with the virtual loop closed by the trace, gives an operator
-% on the open physical legs.
-\TNDeclareDiagram
-    {TNMPDOBlockClosureMap}
-    {}
-    {display}
-    {compact}
-    {\TNMPDOBlockClosureMap}
-    {chapter/ch21_mpdo_rfp_algebra_tower.tex}{%
-    \begin{TNEquationRow}[compact]
-        \ensuremath{M_\alpha(X)=}
-        \TNTerm{\TNSymmetryTraceCell{bcm}{M_\alpha}{X}{}}
-        \qquad
-        \ensuremath{A_\alpha(X)=}
-        \TNTerm{\TNSymmetryTraceCell{bca}{A_\alpha}{X}{}}
-    \end{TNEquationRow}%
-}
-
 % The BNT-label operator O_L(M_alpha): L vertically read copies of M_alpha
 % are multiplied along the vertical index and closed by the trace, while the
 % horizontal legs remain open.  This follows source figure MPDO_O_L_A_.png.

--- a/tex/tn/tn_motifs_symmetry.tex
+++ b/tex/tn/tn_motifs_symmetry.tex
@@ -38,13 +38,6 @@
         {(#1PhiOne)}{P_{12}}%
 }
 
-% The existing trace-cell and vertical-word constructions use a centre point.
-% These wrappers give catalogue terms a coordinate-free origin convention.
-\newcommand{\TNSymmetryTraceCell}[4]{%
-    \TNEventInternal{motif|picture=\the\TN@pictureid|name=#1|kind=trace-cell}%
-    \TNCompactTraceCell{#1}{(0,0)}{#2}{#3}{#4}%
-}
-
 % A periodic MPS closure may carry a virtual insertion on the return bond.
 % The insertion is placed by the surrounding diagram; this motif supplies its
 % two typed ports and the canonical rounded routing from the outer site ports.


### PR DESCRIPTION
Closes #4434.

## Summary

- inline the two MPDO block-closure maps as independent `tenkz` panels
- place a square, legless `X` immediately left of each boxed `M_\alpha` or `A_\alpha`
- contract the adjacent virtual bond and close the remaining virtual ports by one periodic return below
- remove the obsolete whole-figure declaration and its now-unused trace-cell wrapper
- retain `TNCompactTraceCell`, its live users, checker fixture, and reference image

## Source fidelity

The panels follow `Papers/1606.00608/DAVID_Fig10.png`, cited from Appendix C.4, source TeX lines 1974--1980. In each panel, the virtual indices `a,b` are contracted while the physical indices `i,j` remain free. The print trace records one box atom, one MPO atom, one direct bond, one lower periodic trace, and

`boundary|virtual-west=0|virtual-east=0|physical-up=1|physical-down=1`.

## Validation

- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex`
- `python3 scripts/check_tn_references.py --margins-only`
- `git diff --check`
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- visually inspected PDF page 646 and both emitted web SVG panels against `DAVID_Fig10.png`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram infrastructure only; no runtime or proof logic changes.
> 
> **Overview**
> **MPDO block-closure figures** in `ch21_mpdo_rfp_algebra_tower.tex` no longer use the catalogue macro `\TNMPDOBlockClosureMap`. Each of `M_\alpha(X)` and `A_\alpha(X)` is drawn as its own inline `tenkz` panel: legless boxed `X` immediately left of `M_\alpha` / `A_\alpha`, periodic virtual trace below, and up/down physical legs—aligned with `DAVID_Fig10.png` and Appendix C.4. Extensive TeX comments document the index contraction and port signature.
> 
> **Cleanup:** The `TNMPDOBlockClosureMap` catalogue entry is removed from `tn_catalogue.tex`, and the unused `\TNSymmetryTraceCell` wrapper is dropped from `tn_motifs_symmetry.tex`. `TNCompactTraceCell` and other trace-cell users are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b0fc59908d71d12d93365abe30783e8793ef18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->