### PR TITLE
feat(Channel/FixedPoint): extend direct-sum Kraus maps

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -202,7 +202,7 @@ import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
-import TNLean.Channel.FixedPoint.DirectSumExtension
+import TNLean.Channel.FixedPoint.DirectSumKraus
 import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
 import TNLean.Channel.FixedPoint.DirectSumBlockRetraction

--- a/TNLean/Channel/FixedPoint/DirectSumKraus.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumKraus.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumExtension
+import TNLean.Channel.KrausCPTP
+
+/-!
+# Kraus maps between finite sums of matrix algebras
+
+A linear map between two finite sums of full matrix algebras has a canonical
+extension between the full matrix algebras on the corresponding direct sums:
+retain the diagonal input blocks, apply the original map, and embed the output
+as a block-diagonal matrix. This extension commutes with composition.
+
+Complete positivity of a map between the finite sums is expressed by a Kraus
+representation of this canonical extension. Consequently, complete positivity
+is preserved by composition. For a trace-preserving endomorphism, complete
+positivity also gives the Schwarz inequality for its trace adjoint.
+
+These facts supply the finite-direct-sum part of the argument in
+arXiv:1606.00608, Appendix C.4, lines 1974--1995. The Kraus representations of
+the particular transported vertical-sector maps are separate.
+
+## Main definitions
+
+* `Matrix.directSumMapExtension`: the canonical full-matrix extension of a map
+  between two finite sums of matrix algebras.
+* `Matrix.IsKrausDirectSumMap`: complete positivity through this extension.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators
+
+noncomputable section
+
+namespace Matrix
+
+variable {ι κ τ : Type*}
+variable [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+variable [Fintype τ] [DecidableEq τ]
+variable {n : ι → Type*} {m : κ → Type*} {p : τ → Type*}
+variable [∀ i, Fintype (n i)] [∀ i, DecidableEq (n i)]
+variable [∀ j, Fintype (m j)] [∀ j, DecidableEq (m j)]
+variable [∀ l, Fintype (p l)] [∀ l, DecidableEq (p l)]
+
+/-- Extend a linear map between finite sums of matrix algebras to the full
+matrix algebras on the two direct sums. The extension first retains the
+diagonal input blocks and then embeds the output as a block-diagonal matrix.
+
+This is the full-matrix form of the maps between \(\mathcal A_1\) and
+\(\mathcal A_2\) in arXiv:1606.00608, Appendix C.4, lines 1974--1995. -/
+noncomputable def directSumMapExtension
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)) :
+    Matrix ((i : ι) × n i) ((i : ι) × n i) ℂ →ₗ[ℂ]
+      Matrix ((j : κ) × m j) ((j : κ) × m j) ℂ :=
+  directSumDiagonalEmbedding.comp (T.comp directSumDiagonalCompression)
+
+omit [Fintype ι] [DecidableEq ι] [Fintype κ]
+    [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    [(j : κ) → Fintype (m j)] [(j : κ) → DecidableEq (m j)] in
+@[simp]
+theorem directSumMapExtension_apply
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (A : Matrix ((i : ι) × n i) ((i : ι) × n i) ℂ) :
+    directSumMapExtension T A =
+      directSumDiagonalEmbedding (T (directSumDiagonalCompression A)) :=
+  rfl
+
+omit [Fintype ι] [DecidableEq ι] [Fintype κ] [Fintype τ]
+    [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    [(j : κ) → Fintype (m j)] [(j : κ) → DecidableEq (m j)]
+    [(l : τ) → Fintype (p l)] [(l : τ) → DecidableEq (p l)] in
+/-- Canonical full-matrix extension commutes with composition of maps between
+finite sums of matrix algebras. -/
+theorem directSumMapExtension_comp
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ l, Matrix (p l) (p l) ℂ)) :
+    directSumMapExtension (S.comp T) =
+      (directSumMapExtension S).comp (directSumMapExtension T) := by
+  apply LinearMap.ext
+  intro A
+  simp [directSumMapExtension]
+  change S (T (directSumDiagonalCompression A)) =
+    S (directSumDiagonalCompression
+      (directSumDiagonalEmbedding (T (directSumDiagonalCompression A))))
+  rw [directSumDiagonalCompression_embedding]
+
+/-- A map between finite sums of full matrix algebras is completely positive
+when its canonical full-matrix extension admits a Kraus representation. -/
+def IsKrausDirectSumMap
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)) : Prop :=
+  IsKrausCP (directSumMapExtension T)
+
+/-- Composition preserves complete positivity for maps between finite sums of
+full matrix algebras. -/
+theorem IsKrausDirectSumMap.comp
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    {S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ l, Matrix (p l) (p l) ℂ)}
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S) :
+    IsKrausDirectSumMap (S.comp T) := by
+  rw [IsKrausDirectSumMap, directSumMapExtension_comp]
+  exact isKrausCP_comp hT hS
+
+omit [Fintype ι] [(i : ι) → Fintype (n i)]
+    [(i : ι) → DecidableEq (n i)] in
+/-- For an endomorphism of one finite direct sum, the extension between two
+finite sums agrees with the canonical endomorphism extension. -/
+theorem directSumMapExtension_self
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)) :
+    directSumMapExtension T = directSumExtension T :=
+  rfl
+
+omit [(i : ι) → DecidableEq (n i)] in
+/-- If the canonical full-matrix extension satisfies the Schwarz inequality,
+then the original map satisfies the inequality in every direct summand. -/
+theorem isSchwarzDirectSumMap_of_directSumExtension_isSchwarzMap
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)}
+    (hT : IsSchwarzMap (directSumExtension T)) :
+    IsSchwarzDirectSumMap T := by
+  intro A i
+  have h := hT (directSumDiagonalEmbedding A)
+  have hstar : (directSumDiagonalEmbedding A)ᴴ =
+      directSumDiagonalEmbedding (fun l ↦ (A l)ᴴ) :=
+    (directSumDiagonalEmbedding_conjTranspose A).symm
+  have hprod : (directSumDiagonalEmbedding A)ᴴ *
+      directSumDiagonalEmbedding A =
+        directSumDiagonalEmbedding (fun l ↦ (A l)ᴴ * A l) := by
+    rw [hstar, ← directSumDiagonalEmbedding_mul]
+    rfl
+  rw [hprod, hstar] at h
+  simp only [directSumExtension_apply,
+    directSumDiagonalCompression_embedding] at h
+  rw [← directSumDiagonalEmbedding_mul, ← map_sub] at h
+  have hi := directSumDiagonalCompression_posSemidef h i
+  simpa only [directSumDiagonalCompression_embedding, Pi.sub_apply,
+    Pi.mul_apply] using hi
+
+/-- The trace adjoint of a trace-preserving completely positive endomorphism
+of a finite sum of matrix algebras satisfies the Schwarz inequality in every
+summand.
+
+This is the direct-sum Kadison--Schwarz implication used for the transported
+composites in arXiv:1606.00608, Appendix C.4, lines 1980--1995. -/
+theorem IsKrausDirectSumMap.directSumTraceAdjointMap_isSchwarz
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)}
+    (hT : IsKrausDirectSumMap T)
+    (hTP : IsTracePreservingDirectSumMap T) :
+    IsSchwarzDirectSumMap (directSumTraceAdjointMap T) := by
+  have hCP : IsCPMap (directSumExtension T) := by
+    change IsKrausCP (directSumExtension T)
+    rw [← directSumMapExtension_self]
+    exact hT
+  have h2 : Is2PositiveMap
+      (Matrix.traceAdjointMap (directSumExtension T)) :=
+    (hCP.isNPositiveMap 2).traceAdjointMap
+  have hUnital : KadisonSchwarz.IsUnitalMap
+      (Matrix.traceAdjointMap (directSumExtension T)) := by
+    change Matrix.traceAdjointMap (directSumExtension T) 1 = 1
+    refine sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff
+      (M := Matrix.traceAdjointMap (directSumExtension T) 1 - 1)).1 ?_)
+    intro X
+    simp only [Matrix.sub_mul, Matrix.trace_sub,
+      Matrix.trace_traceAdjointMap_mul, Matrix.one_mul]
+    exact sub_eq_zero.mpr
+      (hTP.directSumExtension_isTracePreservingMap X)
+  have hSchwarz : IsSchwarzMap
+      (Matrix.traceAdjointMap (directSumExtension T)) := by
+    intro X
+    have hPos := h2.isPositiveMap
+    simpa only [hPos.map_conjTranspose X] using
+      kadison_schwarz_2positive
+        (Matrix.traceAdjointMap (directSumExtension T)) h2 hUnital X
+  rw [traceAdjointMap_directSumExtension] at hSchwarz
+  exact isSchwarzDirectSumMap_of_directSumExtension_isSchwarzMap hSchwarz
+
+end Matrix

--- a/TNLean/Channel/FixedPoint/DirectSumKraus.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumKraus.lean
@@ -30,7 +30,7 @@ the particular transported vertical-sector maps are separate.
 * `Matrix.IsKrausDirectSumMap`: complete positivity through this extension.
 -/
 
-open scoped Matrix MatrixOrder ComplexOrder BigOperators
+open scoped Matrix MatrixOrder ComplexOrder
 
 noncomputable section
 
@@ -84,14 +84,14 @@ theorem directSumMapExtension_comp
       (directSumMapExtension S).comp (directSumMapExtension T) := by
   apply LinearMap.ext
   intro A
-  simp [directSumMapExtension]
-  change S (T (directSumDiagonalCompression A)) =
-    S (directSumDiagonalCompression
-      (directSumDiagonalEmbedding (T (directSumDiagonalCompression A))))
+  change directSumDiagonalEmbedding (S (T (directSumDiagonalCompression A))) =
+    directSumDiagonalEmbedding
+      (S (directSumDiagonalCompression
+        (directSumDiagonalEmbedding (T (directSumDiagonalCompression A)))))
   rw [directSumDiagonalCompression_embedding]
 
-/-- A map between finite sums of full matrix algebras is completely positive
-when its canonical full-matrix extension admits a Kraus representation. -/
+/-- A map between finite sums of full matrix algebras is completely positive when its
+canonical full-matrix extension admits a Kraus representation. -/
 def IsKrausDirectSumMap
     (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
       (∀ j, Matrix (m j) (m j) ℂ)) : Prop :=

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2634,9 +2634,14 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \[
         \widehat{S\circ T}=\widehat S\circ\widehat T,
     \]
-    and $S\circ T$ is again a direct-sum Kraus map.  If
-    $F:\mathcal A\to\mathcal A$ is a trace-preserving direct-sum Kraus map,
-    then its trace adjoint satisfies, for every $X\in\mathcal A$,
+    and $S\circ T$ is again a direct-sum Kraus map.  If an endomorphism
+    $T:\mathcal A\to\mathcal A$ has an extension satisfying
+    \[
+        \widehat T(Y^*Y)-\widehat T(Y^*)\widehat T(Y)\succeq0,
+    \]
+    then $T$ satisfies the corresponding inequality in every summand.
+    Finally, if $F:\mathcal A\to\mathcal A$ is a trace-preserving direct-sum
+    Kraus map, then its trace adjoint satisfies, for every $X\in\mathcal A$,
     \[
         F^*(X^*X)-F^*(X^*)F^*(X)\succeq0
     \]
@@ -2653,16 +2658,35 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
         =\iota_{\mathcal C}ST\pi_{\mathcal A}
         =\widehat{S\circ T}.
     \]
-    Products of Kraus operators therefore give a Kraus representation of the
-    composite.  If $F$ preserves the total trace, then $\widehat F$ preserves
-    the ordinary trace, so $(\widehat F)^*$ is unital.  Complete positivity
-    implies two-positivity for $(\widehat F)^*$, and Kadison--Schwarz gives
+    If $\widehat T(X)=\sum_i K_iXK_i^*$ and
+    $\widehat S(Y)=\sum_j L_jYL_j^*$, then
+    \[
+        \widehat{S\circ T}(X)
+          =\sum_{i,j}(L_jK_i)X(L_jK_i)^*,
+    \]
+    which gives the asserted Kraus representation.  For
+    $Y=\iota_{\mathcal A}(X)$, the $i$-th diagonal block of the extension
+    Schwarz inequality is
+    \[
+        \left[\widehat T(Y^*Y)-\widehat T(Y^*)\widehat T(Y)\right]_i
+          =T(X^*X)_i-T(X^*)_iT(X)_i\succeq0,
+    \]
+    which proves the descent assertion.  If $F$ preserves the total trace,
+    then $\widehat F$ preserves the ordinary trace, so $(\widehat F)^*$ is
+    unital.  Complete positivity implies two-positivity for
+    $(\widehat F)^*$, and Kadison--Schwarz gives
     \[
         (\widehat F)^*(Y^*Y)
           -(\widehat F)^*(Y^*)(\widehat F)^*(Y)\succeq0.
     \]
-    Using $(\widehat F)^*=\widehat{F^*}$ and compressing to each diagonal
-    summand gives the stated inequality.
+    For $Y=\iota_{\mathcal A}(X)$, use
+    $(\widehat F)^*=\widehat{F^*}$ and project this inequality onto the
+    $i$-th diagonal summand.  The resulting block identity is
+    \[
+        \left[\widehat{F^*}(Y^*Y)
+          -\widehat{F^*}(Y^*)\widehat{F^*}(Y)\right]_i
+        =F^*(X_i^*X_i)-F^*(X_i^*)F^*(X_i)\succeq0.
+    \]
 \end{proof}
 
 % Scope restriction documented in

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2669,7 +2669,7 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     Schwarz inequality is
     \[
         \left[\widehat T(Y^*Y)-\widehat T(Y^*)\widehat T(Y)\right]_i
-          =T(X^*X)_i-T(X^*)_iT(X)_i\succeq0,
+          =(T(X^*X))_i-(T(X^*))_i(T(X))_i\succeq0,
     \]
     which proves the descent assertion.  If $F$ preserves the total trace,
     then $\widehat F$ preserves the ordinary trace, so $(\widehat F)^*$ is
@@ -2685,7 +2685,7 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \[
         \left[\widehat{F^*}(Y^*Y)
           -\widehat{F^*}(Y^*)\widehat{F^*}(Y)\right]_i
-        =F^*(X_i^*X_i)-F^*(X_i^*)F^*(X_i)\succeq0.
+        =(F^*(X^*X))_i-(F^*(X^*))_i(F^*(X))_i\succeq0.
     \]
 \end{proof}
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2596,6 +2596,75 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \]
 \end{proof}
 
+\begin{definition}[Kraus maps between finite sums of matrix algebras]
+    \label{def:kraus_map_between_direct_sums}
+    \lean{Matrix.directSumMapExtension, Matrix.IsKrausDirectSumMap}
+    \leanok
+    Let
+    \[
+        \mathcal A=\bigoplus_{i\in I}M_{n_i}(\mathbb C),
+        \qquad
+        \mathcal B=\bigoplus_{j\in J}M_{m_j}(\mathbb C),
+    \]
+    and write $\iota_{\mathcal A},\pi_{\mathcal A}$ and
+    $\iota_{\mathcal B},\pi_{\mathcal B}$ for the corresponding
+    block-diagonal embeddings and diagonal-block compressions.  The canonical
+    full-matrix extension of $T:\mathcal A\to\mathcal B$ is
+    \[
+        \widehat T=\iota_{\mathcal B}\circ T\circ\pi_{\mathcal A}.
+    \]
+    The map $T$ is a direct-sum Kraus map when $\widehat T$ has a Kraus
+    representation.
+\end{definition}
+
+% This is the finite-sum complete-positivity implication used for the
+% transported composites in CPSV16, Appendix C.4, lines 1974--1995.  It does
+% not establish Kraus representations for those transported maps; that is the
+% tensor-specific preparation and partial-trace step tracked in issue #4438.
+\begin{lemma}[Composition and trace-adjoint Schwarz for direct-sum Kraus maps]
+    \label{lem:direct_sum_kraus_composition_schwarz}
+    \lean{Matrix.directSumMapExtension_comp,
+        Matrix.IsKrausDirectSumMap.comp,
+        Matrix.isSchwarzDirectSumMap_of_directSumExtension_isSchwarzMap,
+        Matrix.IsKrausDirectSumMap.directSumTraceAdjointMap_isSchwarz}
+    \leanok
+    \uses{def:kraus_map_between_direct_sums}
+    For direct-sum Kraus maps
+    $T:\mathcal A\to\mathcal B$ and $S:\mathcal B\to\mathcal C$, one has
+    \[
+        \widehat{S\circ T}=\widehat S\circ\widehat T,
+    \]
+    and $S\circ T$ is again a direct-sum Kraus map.  If
+    $F:\mathcal A\to\mathcal A$ is a trace-preserving direct-sum Kraus map,
+    then its trace adjoint satisfies, for every $X\in\mathcal A$,
+    \[
+        F^*(X^*X)-F^*(X^*)F^*(X)\succeq0
+    \]
+    in every summand.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:kadison_schwarz_2positive}
+    Since $\pi_{\mathcal B}\iota_{\mathcal B}=\operatorname{id}_{\mathcal B}$,
+    \[
+        \widehat S\,\widehat T
+        =\iota_{\mathcal C}S\pi_{\mathcal B}
+          \iota_{\mathcal B}T\pi_{\mathcal A}
+        =\iota_{\mathcal C}ST\pi_{\mathcal A}
+        =\widehat{S\circ T}.
+    \]
+    Products of Kraus operators therefore give a Kraus representation of the
+    composite.  If $F$ preserves the total trace, then $\widehat F$ preserves
+    the ordinary trace, so $(\widehat F)^*$ is unital.  Complete positivity
+    implies two-positivity for $(\widehat F)^*$, and Kadison--Schwarz gives
+    \[
+        (\widehat F)^*(Y^*Y)
+          -(\widehat F)^*(Y^*)(\widehat F)^*(Y)\succeq0.
+    \]
+    Using $(\widehat F)^*=\widehat{F^*}$ and compressing to each diagonal
+    summand gives the stated inequality.
+\end{proof}
+
 % Scope restriction documented in
 % docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
 \begin{theorem}[Weighted block form of the adjoint Ces\`aro projection on full support]%


### PR DESCRIPTION
## Summary

This change introduces the canonical full-matrix extension of a linear map
\[
  \prod_\alpha M_{d_\alpha}(\mathbb C)
    \longrightarrow
  \prod_\beta M_{e_\beta}(\mathbb C).
\]
The extension retains the diagonal input blocks, applies the original map, and embeds the output as a block-diagonal matrix.

It proves:

- canonical extension commutes with composition;
- maps whose canonical extensions admit Kraus representations are closed under composition;
- Schwarz on the canonical extension descends to the finite product;
- the direct-sum trace adjoint of a trace-preserving Kraus endomorphism satisfies the Schwarz inequality.

The last implication passes through complete positivity, two-positivity of the trace adjoint, and Kadison--Schwarz. It does not assume multiplicativity or fixedness of products.

The new module is exported through `TNLean.lean`. A blueprint definition and lemma record the finite-product construction and its mathematical proof separately from the tensor-specific theorem.

## Source and role

The results supply the finite-product part of CPSV16, arXiv:1606.00608, Appendix C.4, lines 1974--1995. The physical RFP maps are tp-CP by Definition 4.1. A subsequent theorem will identify the normalized sector embeddings and retractions with controlled preparation and controlled partial trace, proving that the transported maps are Kraus maps from the original tensor hypotheses.

This is the first stage of #4438, a native subissue of #4418. It does not close either issue. The Wolf product-span dimension estimate is separate in #4432.

The blueprint entry states only the finite-sum result proved here. Its source-role qualification is retained as a LaTeX comment rather than printed mathematical prose. The paper theorem remains unmarked until #4418 proves both identity compositions from the exact tensor hypotheses.

## Validation

- `lake build`
- `lake build TNLean.Channel.FixedPoint.DirectSumKraus`
- `lake env lean TNLean.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- `leanblueprint pdf`
- `git diff --check`
- root import length: exactly 1000 lines
- line-length check: no line in the new Lean module exceeds 100 characters
- proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or kernel bypass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean module and blueprint sync on fixed-point/channel theory; no changes to auth, runtime behavior, or existing theorem statements beyond the new public import path.
> 
> **Overview**
> Adds **`TNLean.Channel.FixedPoint.DirectSumKraus`**, formalizing the canonical full-matrix extension \(\widehat T = \iota \circ T \circ \pi\) for maps between finite products of matrix algebras, **`IsKrausDirectSumMap`** (CP via Kraus on \(\widehat T\)), and lemmas: extension commutes with composition, Kraus/CP closed under composition, Schwarz on \(\widehat T\) descends to every summand, and trace adjoint of a trace-preserving Kraus endomorphism is Schwarz summandwise (via Kadison–Schwarz).
> 
> **`TNLean.lean`** now imports **`DirectSumKraus`** instead of **`DirectSumExtension`** (extension machinery remains via the new module’s import). **Blueprint** `ch07_spectral.tex` gains the matching definition and composition/trace-adjoint Schwarz lemma for CPSV16 Appendix C.4 (lines 1974–1995); tensor-specific Kraus for transported maps is explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0662f6b326bf520cfe3ebba2a95cb5f823df0501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->