### PR TITLE
feat(MPS/RFP): construct Beigi sector graph data

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -13,8 +13,7 @@ This file imports the modules intended for downstream users. Most specialized he
 are omitted from the root import list, but public chapter-index and chapter-facing semigroup
 modules are included so that blueprint links and the generated documentation can see them.
 
-The following archival modules are intentionally excluded
-(they live in `TNLean/Archive/`):
+The following modules in `TNLean/Archive/` are intentionally excluded:
 
 * the archival alternate proof `TNLean.Archive.BlockingPeriodicityCFII2`;
 * the documentary counterexample `TNLean.Archive.BlockSepCounterexample`.
@@ -630,6 +629,7 @@ import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.BeigiGroundSpaceDimension
 import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BeigiSectorGraph
+import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
 import TNLean.MPS.RFP.BeigiLoopTensor
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample

--- a/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
@@ -60,12 +60,6 @@ def etaPairSpatialBlockEquiv {K : ℕ} {dl dr : Fin K → ℕ}
     simp only
     rw [e.apply_symm_apply, e.apply_symm_apply]
 
-end Matrix
-
-namespace MPOTensor.TranslationInvariantBondData
-
-variable {d : ℕ}
-
 /-- A positive two-site operator whose overlapping translates commute has one spatial
 decomposition and a positive neighboring operator \(\eta_{q,h}\) for each ordered pair of
 sectors such that
@@ -84,7 +78,7 @@ does not assert the rank-one trace factorization invoked later in Proposition 4t
 Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
 lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III,
 equation (2). -/
-theorem _root_.Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute
+theorem exists_positive_etaPair_decomposition_of_overlappingLifts_commute
     (B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (hB : B.PosSemidef)
     (hComm : Matrix.leftOverlappingLift B * Matrix.rightOverlappingLift B =
       Matrix.rightOverlappingLift B * Matrix.leftOverlappingLift B) :
@@ -284,6 +278,12 @@ theorem _root_.Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_
         exact hB'_right_sector_ne q q h h' hh lq lq' rq rq' lh lh' rh rh'
     · rw [Matrix.blockDiagonal'_apply_ne _ _ _ (fun hp ↦ hq (Prod.mk.inj hp).1)]
       exact hB'_left_sector_ne q q' h h' hq lq lq' rq rq' lh lh' rh rh'
+
+end Matrix
+
+namespace MPOTensor.TranslationInvariantBondData
+
+variable {d : ℕ}
 
 /-- A positive translation-invariant commuting bond has one chain-independent symmetric
 eta-pair decomposition.

--- a/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
@@ -16,6 +16,7 @@ finite chain.
 ## Main declarations
 
 * `Matrix.etaPairSpatialBlockEquiv`
+* `Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute`
 * `MPOTensor.TranslationInvariantBondData.exists_positive_eta_pairBond_decomposition`
 * `MPOTensor.EtaLocalStructureData.exists_positive_eta_pairBond_decomposition`
 
@@ -65,24 +66,28 @@ namespace MPOTensor.TranslationInvariantBondData
 
 variable {d : ℕ}
 
-/-- A positive translation-invariant commuting bond has one spatial decomposition and a
-positive neighboring operator \(\eta_{q,h}\) for each ordered pair of sectors such that
+/-- A positive two-site operator whose overlapping translates commute has one spatial
+decomposition and a positive neighboring operator \(\eta_{q,h}\) for each ordered pair of
+sectors such that
 \[
   (U^*\otimes U^*)B(U\otimes U)
     =\bigoplus_{q,h}\mathbf 1_{q,l}\otimes\eta_{q,h}\otimes\mathbf 1_{h,r}.
 \]
 
-The unitary and the family \(\eta\) depend only on the fixed two-site bond, not on a chain
-length or a bond position.  Thus this is the local transport from Beigi's block actions to
-the neighboring operators in equation sigmaNK2.
+This is the local matrix argument transporting Beigi's one-sided block actions to the
+symmetric two-sided coordinates used in equation sigmaNK2.  It assumes only positivity of
+the two-site operator and commutation of its two overlapping lifts.
 
 No zero-correlation-length or area-law hypothesis is used.  In particular, this theorem
 does not assert the rank-one trace factorization invoked later in Proposition 4to2.
 
 Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
-lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
-theorem exists_positive_eta_pairBond_decomposition
-    (data : TranslationInvariantBondData d) :
+lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III,
+equation (2). -/
+theorem _root_.Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute
+    (B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (hB : B.PosSemidef)
+    (hComm : Matrix.leftOverlappingLift B * Matrix.rightOverlappingLift B =
+      Matrix.rightOverlappingLift B * Matrix.leftOverlappingLift B) :
     ∃ (K : ℕ) (dl dr : Fin K → ℕ)
       (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
       (U : Matrix (Fin d) (Fin d) ℂ)
@@ -93,18 +98,19 @@ theorem exists_positive_eta_pairBond_decomposition
         (∀ q h, (η q h).PosSemidef) ∧
         Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
             (Matrix.etaPairSpatialBlockEquiv e).symm
-            (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)) =
+            (star (U ⊗ₖ U) * B * (U ⊗ₖ U)) =
           Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
             ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
               η qh.1 qh.2) ⊗ₖ
                 (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ) := by
   classical
   obtain ⟨K, dl, dr, e, U, R, S, hU, hdl, hdr, _, _, hR, hS⟩ :=
-    data.exists_unitary_blockActions_of_pairBond
-  let B' := star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)
-  let BR := star ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) * data.pairBond *
+    Matrix.exists_unitary_blockActions_of_overlappingLifts_commute B B
+      hB.isHermitian hB.isHermitian hComm
+  let B' := star (U ⊗ₖ U) * B * (U ⊗ₖ U)
+  let BR := star ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U) * B *
     ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ U)
-  let BS := star (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * data.pairBond *
+  let BS := star (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ)) * B *
     (U ⊗ₖ (1 : Matrix (Fin d) (Fin d) ℂ))
   let η : (q h : Fin K) →
       Matrix (Fin (dr q) × Fin (dl h)) (Fin (dr q) × Fin (dl h)) ℂ :=
@@ -253,13 +259,8 @@ theorem exists_positive_eta_pairBond_decomposition
       simp [Matrix.one_apply, hl]
   refine ⟨K, dl, dr, e, U, η, hU, hdl, hdr, ?_, ?_⟩
   · intro q h
-    have hpair : data.pairBond.PosSemidef := by
-      have hsub := data.bond_pos.submatrix
-        (finTwoArrowEquiv (Fin d)).symm
-      simpa [TranslationInvariantBondData.pairBond, pairBondMatrix,
-        Matrix.reindex_apply] using hsub
     have hBpos : B'.PosSemidef := by
-      have hconj := hpair.mul_mul_conjTranspose_same (B := star (U ⊗ₖ U))
+      have hconj := hB.mul_mul_conjTranspose_same (B := star (U ⊗ₖ U))
       simpa [B', Matrix.star_eq_conjTranspose] using hconj
     let f : Fin (dr q) × Fin (dl h) → Fin d × Fin d := fun x ↦
       (e ⟨q, (x.1, ⟨0, hdl q⟩)⟩, e ⟨h, (⟨0, hdr h⟩, x.2)⟩)
@@ -283,6 +284,35 @@ theorem exists_positive_eta_pairBond_decomposition
         exact hB'_right_sector_ne q q h h' hh lq lq' rq rq' lh lh' rh rh'
     · rw [Matrix.blockDiagonal'_apply_ne _ _ _ (fun hp ↦ hq (Prod.mk.inj hp).1)]
       exact hB'_left_sector_ne q q' h h' hq lq lq' rq rq' lh lh' rh rh'
+
+/-- A positive translation-invariant commuting bond has one chain-independent symmetric
+eta-pair decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
+lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+theorem exists_positive_eta_pairBond_decomposition
+    (data : TranslationInvariantBondData d) :
+    ∃ (K : ℕ) (dl dr : Fin K → ℕ)
+      (e : ((q : Fin K) × (Fin (dr q) × Fin (dl q))) ≃ Fin d)
+      (U : Matrix (Fin d) (Fin d) ℂ)
+      (η : (q h : Fin K) →
+        Matrix (Fin (dr q) × Fin (dl h)) (Fin (dr q) × Fin (dl h)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin d) ℂ ∧
+        (∀ q, 0 < dl q) ∧ (∀ q, 0 < dr q) ∧
+        (∀ q h, (η q h).PosSemidef) ∧
+        Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+            (Matrix.etaPairSpatialBlockEquiv e).symm
+            (star (U ⊗ₖ U) * data.pairBond * (U ⊗ₖ U)) =
+          Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+            ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+              η qh.1 qh.2) ⊗ₖ
+                (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ) := by
+  have hpair : data.pairBond.PosSemidef := by
+    have hsub := data.bond_pos.submatrix (finTwoArrowEquiv (Fin d)).symm
+    simpa [TranslationInvariantBondData.pairBond, pairBondMatrix,
+      Matrix.reindex_apply] using hsub
+  exact Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute
+    data.pairBond hpair data.overlappingLifts_pairBond_comm
 
 end MPOTensor.TranslationInvariantBondData
 

--- a/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
@@ -105,6 +105,9 @@ theorem IsNNCPH.twoSiteParentGroundProjectorMatrix_overlappingLifts_commute
     _ = (1 - Matrix.rightOverlappingLift H) * (1 - Matrix.leftOverlappingLift H) := by
       noncomm_ring
 
+/-- Idempotence of a block-diagonal eta-pair operator forces idempotence of each
+neighboring eta operator.  Positivity of the outer dimensions supplies fixed basis
+indices at which the identity factors evaluate to one, exposing the eta block. -/
 private theorem eta_isIdempotent_of_blockDiagonal_isIdempotent
     {K : ℕ} {dl dr : Fin K → ℕ}
     (hdl : ∀ q, 0 < dl q) (hdr : ∀ q, 0 < dr q)

--- a/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.OrthogonalProjection
+import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
+import TNLean.MPS.RFP.BeigiSectorGraph
+
+/-!
+# Constructing Beigi sector data from a commuting parent interaction
+
+This file derives the symmetric two-sided sector coordinates of a nearest-neighbor
+commuting parent interaction and packages them as `BeigiSectorGraphData`.
+
+## Main declarations
+
+* `IsNNCPH.nonempty_beigiSectorGraphData`: existence of Beigi's finite sector graph data;
+* `IsNNCPH.beigiSectorGraphData`: a chosen source-faithful sector graph datum.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2).
+-/
+
+open scoped ComplexOrder Kronecker Matrix MatrixOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The canonical two-site parent interaction is an orthogonal projection.
+
+Source: Beigi, arXiv:1105.1019v2, Section II, paragraph before Lemma 2.1, and
+Section III, equation (2). -/
+theorem twoSiteParentInteractionMatrix_isStarProjection (A : MPSTensor d D) :
+    IsStarProjection (twoSiteParentInteractionMatrix A) := by
+  rw [isStarProjection_iff']
+  constructor
+  · have h := congrArg LinearMap.toMatrix' (parentInteraction_idempotent A 2)
+    simp only [LinearMap.toMatrix'_mul] at h
+    rw [twoSiteParentInteractionMatrix]
+    change (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))) (LinearMap.toMatrix' (parentInteraction A 2)) *
+        (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))) (LinearMap.toMatrix' (parentInteraction A 2)) =
+      (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d))) (LinearMap.toMatrix' (parentInteraction A 2))
+    rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))]
+    exact congrArg (Matrix.reindex (finTwoArrowEquiv (Fin d))
+      (finTwoArrowEquiv (Fin d))) h
+  · simpa [Matrix.star_eq_conjTranspose] using
+      (twoSiteParentInteractionMatrix_isHermitian A).eq
+
+/-- The complementary two-site parent interaction is an orthogonal projection.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equation (2). -/
+theorem twoSiteParentGroundProjectorMatrix_isStarProjection (A : MPSTensor d D) :
+    IsStarProjection (twoSiteParentGroundProjectorMatrix A) := by
+  exact (twoSiteParentInteractionMatrix_isStarProjection A).one_sub
+
+/-- The complementary two-site parent interaction is positive semidefinite.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equation (2). -/
+theorem twoSiteParentGroundProjectorMatrix_posSemidef (A : MPSTensor d D) :
+    (twoSiteParentGroundProjectorMatrix A).PosSemidef := by
+  rw [← Matrix.nonneg_iff_posSemidef]
+  exact (twoSiteParentGroundProjectorMatrix_isStarProjection A).nonneg
+
+/-- The two overlapping lifts of the complementary parent interaction commute.
+
+This is the complement form of the local commutator used in Beigi's spatial
+decomposition.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2). -/
+theorem IsNNCPH.twoSiteParentGroundProjectorMatrix_overlappingLifts_commute
+    {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
+    Matrix.leftOverlappingLift (twoSiteParentGroundProjectorMatrix A) *
+        Matrix.rightOverlappingLift (twoSiteParentGroundProjectorMatrix A) =
+      Matrix.rightOverlappingLift (twoSiteParentGroundProjectorMatrix A) *
+        Matrix.leftOverlappingLift (twoSiteParentGroundProjectorMatrix A) := by
+  let H := twoSiteParentInteractionMatrix A
+  have hLeft : Matrix.leftOverlappingLift (c := Fin d) (1 - H) =
+      1 - Matrix.leftOverlappingLift (c := Fin d) H := by
+    ext x y
+    simp [Matrix.leftOverlappingLift, Matrix.one_apply, Prod.ext_iff]
+    split_ifs <;> simp_all
+  have hRight : Matrix.rightOverlappingLift (a := Fin d) (1 - H) =
+      1 - Matrix.rightOverlappingLift (a := Fin d) H := by
+    ext x y
+    simp [Matrix.rightOverlappingLift, Matrix.one_apply, Prod.ext_iff]
+    split_ifs <;> simp_all
+  rw [twoSiteParentGroundProjectorMatrix, hLeft, hRight]
+  have hComm := hNNCPH.twoSiteParentInteractionMatrix_overlappingLifts_commute
+  calc
+    (1 - Matrix.leftOverlappingLift H) * (1 - Matrix.rightOverlappingLift H) =
+        1 - Matrix.leftOverlappingLift H - Matrix.rightOverlappingLift H +
+          Matrix.leftOverlappingLift H * Matrix.rightOverlappingLift H := by
+      noncomm_ring
+    _ = 1 - Matrix.leftOverlappingLift H - Matrix.rightOverlappingLift H +
+          Matrix.rightOverlappingLift H * Matrix.leftOverlappingLift H := by
+      rw [hComm]
+    _ = (1 - Matrix.rightOverlappingLift H) * (1 - Matrix.leftOverlappingLift H) := by
+      noncomm_ring
+
+private theorem eta_isIdempotent_of_blockDiagonal_isIdempotent
+    {K : ℕ} {dl dr : Fin K → ℕ}
+    (hdl : ∀ q, 0 < dl q) (hdr : ∀ q, 0 < dr q)
+    (η : (q h : Fin K) →
+      Matrix (Fin (dr q) × Fin (dl h)) (Fin (dr q) × Fin (dl h)) ℂ)
+    (hBlock : IsIdempotentElem
+      (Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          η qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ))) :
+    ∀ q h, IsIdempotentElem (η q h) := by
+  classical
+  intro q h
+  rw [IsIdempotentElem] at hBlock ⊢
+  have hBlocks :
+      (fun qh : Fin K × Fin K ↦
+        (((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+            η qh.1 qh.2) ⊗ₖ
+              (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ)) *
+          (((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+            η qh.1 qh.2) ⊗ₖ
+              (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ))) =
+        fun qh : Fin K × Fin K ↦
+          ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+            η qh.1 qh.2) ⊗ₖ
+              (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ) := by
+    apply Matrix.blockDiagonal'_injective
+    rw [Matrix.blockDiagonal'_mul]
+    exact hBlock
+  have hSector := congrFun hBlocks (q, h)
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+    Matrix.one_mul, Matrix.one_mul] at hSector
+  let l0 : Fin (dl q) := ⟨0, hdl q⟩
+  let r0 : Fin (dr h) := ⟨0, hdr h⟩
+  ext x y
+  have hEntry := congrFun (congrFun hSector ((l0, x), r0)) ((l0, y), r0)
+  simpa [Matrix.kroneckerMap_apply, Matrix.one_apply, l0, r0] using hEntry
+
+/-- A nearest-neighbor commuting parent interaction determines Beigi's finite sector graph
+data in the symmetric two-sided coordinates.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2). -/
+theorem IsNNCPH.nonempty_beigiSectorGraphData
+    {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
+    Nonempty (BeigiSectorGraphData A) := by
+  classical
+  obtain ⟨K, dl, dr, e, U, η, hU, hdl, hdr, hηpos, hηblock⟩ :=
+    Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute
+      (twoSiteParentGroundProjectorMatrix A)
+      (twoSiteParentGroundProjectorMatrix_posSemidef A)
+      hNNCPH.twoSiteParentGroundProjectorMatrix_overlappingLifts_commute
+  have hUU : (U ⊗ₖ U) ∈ Matrix.unitaryGroup (Fin d × Fin d) ℂ :=
+    Matrix.kronecker_mem_unitary hU hU
+  have hConj : IsStarProjection
+      (star (U ⊗ₖ U) * twoSiteParentGroundProjectorMatrix A * (U ⊗ₖ U)) := by
+    have h := IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+      (twoSiteParentGroundProjectorMatrix_isStarProjection A) (U ⊗ₖ U)
+      (Matrix.mem_unitaryGroup_iff.mp hUU)
+    simpa [Matrix.star_eq_conjTranspose] using h
+  have hReindexed : IsIdempotentElem
+      (Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm
+        (star (U ⊗ₖ U) * twoSiteParentGroundProjectorMatrix A * (U ⊗ₖ U))) := by
+    rw [IsIdempotentElem]
+    rw [Matrix.reindex_apply, Matrix.submatrix_mul_equiv]
+    exact congrArg
+      (Matrix.reindex (Matrix.etaPairSpatialBlockEquiv e).symm
+        (Matrix.etaPairSpatialBlockEquiv e).symm)
+      hConj.isIdempotentElem.eq
+  have hBlockIdem : IsIdempotentElem
+      (Matrix.blockDiagonal' fun qh : Fin K × Fin K ↦
+        ((1 : Matrix (Fin (dl qh.1)) (Fin (dl qh.1)) ℂ) ⊗ₖ
+          η qh.1 qh.2) ⊗ₖ
+            (1 : Matrix (Fin (dr qh.2)) (Fin (dr qh.2)) ℂ)) := by
+    rw [← hηblock]
+    exact hReindexed
+  have hηidem := eta_isIdempotent_of_blockDiagonal_isIdempotent hdl hdr η hBlockIdem
+  exact ⟨{
+    sectorCount := K
+    leftDim := dl
+    rightDim := dr
+    sectorEquiv := e
+    unitary := U
+    unitary_mem := hU
+    edgeProjector := η
+    edgeProjector_isOrthogonal := fun q h ↦ ⟨(hηpos q h).isHermitian, hηidem q h⟩
+    groundProjector_block := hηblock }⟩
+
+/-- A chosen Beigi sector graph datum for a nearest-neighbor commuting parent interaction.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2). -/
+noncomputable def IsNNCPH.beigiSectorGraphData
+    {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) : BeigiSectorGraphData A :=
+  Classical.choice hNNCPH.nonempty_beigiSectorGraphData
+
+end MPSTensor

--- a/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
@@ -106,8 +106,9 @@ theorem IsNNCPH.twoSiteParentGroundProjectorMatrix_overlappingLifts_commute
       noncomm_ring
 
 /-- Idempotence of a block-diagonal eta-pair operator forces idempotence of each
-neighboring eta operator.  Positivity of the outer dimensions supplies fixed basis
-indices at which the identity factors evaluate to one, exposing the eta block. -/
+neighboring eta operator. Positivity of the outer dimensions supplies fixed basis
+indices. Evaluating `((1 ⊗ₖ η q h) ⊗ₖ 1) ^ 2 = (1 ⊗ₖ η q h) ⊗ₖ 1` at those
+indices reduces the block identity to `(η q h) ^ 2 = η q h`. -/
 private theorem eta_isIdempotent_of_blockDiagonal_isIdempotent
     {K : ℕ} {dl dr : Fin K → ℕ}
     (hdl : ∀ q, 0 < dl q) (hdr : ∀ q, 0 < dr q)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2383,6 +2383,84 @@ specialization of that Appendix~D definition.
     of \cite[Section~III]{Beigi2012Classification}.
 \end{definition}
 
+\begin{theorem}[Symmetric spatial form of a commuting positive interaction]
+    \label{thm:commuting_positive_interaction_symmetric_spatial_form}
+    \lean{Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute}
+    \lean{Matrix.etaPairSpatialBlockEquiv}
+    \leanok
+    Let $B\geq0$ be a two-site operator whose overlapping placements commute:
+    \[
+        (B\otimes\mathbf 1)(\mathbf 1\otimes B)
+        =
+        (\mathbf 1\otimes B)(B\otimes\mathbf 1).
+    \]
+    There are positive integers $d_{q,l},d_{q,r}$, a one-site unitary $U$,
+    and positive semidefinite operators $\eta_{q,h}$ on
+    $\mathcal H_{q,r}\otimes\mathcal H_{h,l}$ such that
+    \[
+        (U\otimes U)^*B(U\otimes U)
+        =\bigoplus_{q,h}
+          \mathbf 1_{q,l}\otimes\eta_{q,h}\otimes\mathbf 1_{h,r}.
+    \]
+    This is the symmetric two-sided form obtained from
+    \cite[Lemma~2.1 and Section~III, equation~(2)]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the spatial decomposition to the two overlapping placements of $B$.
+    In the resulting coordinates, matrix entries vanish unless both the left
+    and right sector labels agree.  For fixed sectors $q,h$, choose unit
+    vectors $l_0\in\mathcal H_{q,l}$ and
+    $r_0\in\mathcal H_{h,r}$ and define
+    \[
+      \langle r,l|\eta_{q,h}|r',l'\rangle
+      =\langle l_0,r;l,r_0|\widetilde B|l_0,r';l',r_0\rangle,
+      \qquad
+      \widetilde B=(U\otimes U)^*B(U\otimes U).
+    \]
+    The left block action makes the right outer factor an identity, while the
+    right block action makes the left outer factor an identity.  Hence the
+    displayed matrix element is independent of the chosen outer coordinates
+    and gives the stated direct sum.  Each $\eta_{q,h}$ is a compression of
+    the positive semidefinite matrix $\widetilde B$, so it is positive
+    semidefinite.
+\end{proof}
+
+\begin{theorem}[Sector graph of a commuting parent interaction]
+    \label{thm:nncph_beigi_sector_graph}
+    \lean{MPSTensor.IsNNCPH.nonempty_beigiSectorGraphData}
+    \lean{MPSTensor.IsNNCPH.beigiSectorGraphData}
+    \lean{MPSTensor.twoSiteParentInteractionMatrix_isStarProjection}
+    \lean{MPSTensor.twoSiteParentGroundProjectorMatrix_isStarProjection}
+    \lean{MPSTensor.twoSiteParentGroundProjectorMatrix_posSemidef}
+    \lean{MPSTensor.IsNNCPH.twoSiteParentGroundProjectorMatrix_overlappingLifts_commute}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    Suppose that the canonical length-two parent terms of $A$ commute on a
+    three-site chain.  Then the complementary two-site interaction admits a
+    finite sector graph as in Definition~\ref{def:beigi_sector_graph}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:commuting_positive_interaction_symmetric_spatial_form}
+    The canonical two-site parent interaction $Q_A$ is an orthogonal
+    projector.  Thus $\mathbf 1-Q_A$ is a positive semidefinite orthogonal
+    projector.  The overlapping placements of $\mathbf 1-Q_A$ commute because
+    those of $Q_A$ commute.  Apply
+    Theorem~\ref{thm:commuting_positive_interaction_symmetric_spatial_form} to
+    obtain
+    \[
+      (U\otimes U)^*(\mathbf 1-Q_A)(U\otimes U)
+      =\bigoplus_{q,h}
+        \mathbf 1_{q,l}\otimes\eta_{q,h}\otimes\mathbf 1_{h,r}.
+    \]
+    The left-hand side is idempotent, so every block on the right is
+    idempotent.  Evaluating the two outer identity factors at fixed unit
+    vectors gives $\eta_{q,h}^2=\eta_{q,h}$.  Since $\eta_{q,h}\geq0$, each
+    $\eta_{q,h}$ is an orthogonal projector and therefore defines the required
+    edge projection.
+\end{proof}
+
 \begin{theorem}[Ordered-cycle ground-space dimension formula]
     \label{thm:beigi_ordered_cycle_ground_space_dimension}
     \lean{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -267,8 +267,25 @@ canonical-form or ground-space-spanning assumption.  Its direct consequence
 \hspace{0pt}\leanid{exists_unitary_blockActions_of_twoSiteParentInteractionMatrix}
 decomposes the middle physical space into a finite direct sum of left and
 right tensor factors on which the two adjacent interactions act separately.
-The subsequent sector datum is now formalized in
-\leanid{MPSTensor.BeigiSectorGraphData}.  From its source equation~(2) alone,
+The symmetric two-sided form is also internal.  The complementary two-site
+interaction is a positive semidefinite orthogonal projector, and its two
+overlapping lifts commute under the same three-site hypothesis.  The theorem
+\leanid{Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute}
+combines the two one-sided block actions into
+\[
+  (U\otimes U)^*(\mathbf 1-Q_A)(U\otimes U)
+  =\bigoplus_{q,h}
+    \mathbf 1_{q,l}\otimes\eta_{q,h}\otimes\mathbf 1_{h,r}.
+\]
+Idempotence of the left-hand side forces every $\eta_{q,h}$ to be idempotent;
+its positivity then makes it an orthogonal projector.  Consequently
+\leanid{MPSTensor.IsNNCPH.nonempty_beigiSectorGraphData} constructs a finite
+sector graph directly from the three-site commuting-parent hypothesis, and
+\leanid{MPSTensor.IsNNCPH.beigiSectorGraphData} chooses such a graph.  No
+canonical-form, all-chain ground-space, or eventual-dimension hypothesis is
+used in this construction.
+
+For a finite sector graph,
 \leanid{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq}
 constructs the finite directed graph and proves the $N>2$ specialization of
 Beigi's ordered-cycle ground-space dimension formula.  Beigi states this
@@ -381,12 +398,12 @@ canonical form is subject to the source obstruction recorded in
 ground-space spanning clause and the multiplicity-one distinct-sector
 extension are proved. The repeated-copy and arbitrary-raw-weight extension
 remains open.  In the reverse direction, eventual ground-space dimension
-stability, the local spatial decomposition, the ordered-cycle dimension
-formula, the reduction of the sector graph to one-dimensional loops, and the
-exact matrix product realization and parent-ground-space membership of every
-positive loop state are proved.  Spanning of the parent ground space by these
-loop vectors, followed by their identification with the basis of normal
-tensors, remains open.
+stability, the symmetric sector-graph construction from three-site commuting
+parent terms, the ordered-cycle dimension formula, the reduction of the
+sector graph to one-dimensional loops, and the exact matrix product realization
+and parent-ground-space membership of every positive loop state are proved.
+Spanning of the parent ground space by these loop vectors, followed by their
+identification with the basis of normal tensors, remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- extract the existing one-sided-to-symmetric eta-pair argument as a matrix-level theorem requiring only positivity and the local overlapping-lift commutator
- prove that the complementary two-site parent interaction is a star projection whose overlapping lifts commute under `IsNNCPH A 3`
- transport block idempotence to every eta-pair block and package the result as `IsNNCPH.beigiSectorGraphData`
- expose the construction through the root import

## Mathematical argument

Beigi's Lemma 2.1 gives one site decomposition for two commuting overlapping Hermitian operators. The repository already contained the coefficient argument combining its two one-sided block actions into the symmetric `U ⊗ U` eta-pair form, but that argument was only exposed through `TranslationInvariantBondData`, whose all-chain commutation field is stronger than the local input used by the proof.

This PR exposes the argument at its actual hypothesis boundary: a positive two-site matrix and commutation of its two overlapping lifts. For the MPS parent interaction, `1 - h` is a star projection, and the commutator for its overlapping lifts follows algebraically from the `IsNNCPH A 3` commutator for `h`. Unitary conjugation and reindexing preserve idempotence; injectivity of the dependent block-diagonal embedding then shows each eta block is idempotent. Positivity supplies Hermiticity, so these blocks satisfy the orthogonal-projector field of `BeigiSectorGraphData`.

The source is Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2).

## Coordination blocker

This PR is intentionally draft. PR #4431 currently owns the overlapping chapter 13 blueprint and `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` edits. After #4431 merges, this branch must be rebased and receive the mandatory blueprint entry and gap-note update for the new source-faithful construction before it is marked ready.

## Validation

- `lake env lean TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean`
- `lake env lean TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean`
- `lake build TNLean.MPS.RFP.BeigiSectorGraphConstruction`
- `lake build TNLean` (9620 jobs; only pre-existing warnings)
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 07334d78c39d575d8f308540a4b011249cad5f58 --ci`
- `git diff --check`
- no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in the changed Lean files

Advances #4398.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean formalization with no runtime, auth, or data paths; refactors existing proof structure and adds a new construction module behind the same mathematical hypotheses.
> 
> **Overview**
> **Refactors** the symmetric eta-pair spatial decomposition in `CommutingBondEtaDecomposition.lean` into `Matrix.exists_positive_etaPair_decomposition_of_overlappingLifts_commute`, which only needs a positive semidefinite two-site matrix and commuting overlapping lifts; bond-specific wrappers now call this lemma instead of inlining the proof.
> 
> **Adds** `BeigiSectorGraphConstruction.lean`: shows the complementary two-site parent projector `1 - h` is a star projection, derives overlapping-lift commutation from `IsNNCPH A 3`, applies the matrix eta decomposition, and proves each η block is idempotent so the result packages as `BeigiSectorGraphData` via `IsNNCPH.nonempty_beigiSectorGraphData` and `IsNNCPH.beigiSectorGraphData`.
> 
> **Registers** the new module on the root `TNLean` import surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d6c22d8500278871aba040f93f8cdf2a1f73f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->