### PR TITLE
feat(MPS/MPDO): restrict the Beigi trace matrix to cyclic sectors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -539,7 +539,7 @@ import TNLean.MPS.MPDO.PhysicalSectorProductTransport
 import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
-import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
+import TNLean.MPS.MPDO.CyclicActiveSectorRestriction
 import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample
 import TNLean.MPS.MPDO.ActiveSectorInverseMapProvenance
 import TNLean.MPS.MPDO.ActiveSectorSpanningAreaLaw

--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -97,28 +97,53 @@ theorem rank_eq_one_of_pos_of_mul_self_eq_self [Nonempty n]
     Matrix.toLin_eq_toLin']
   simpa only [f] using hrange
 
+/-- Multiplication by a positive scalar preserves primitivity. -/
+theorem IsPrimitive.smul_of_pos [DecidableEq n]
+    {T : Matrix n n ℝ} (hT : T.IsPrimitive)
+    {c : ℝ} (hc : 0 < c) : (c • T).IsPrimitive := by
+  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
+  refine ⟨fun i j ↦ mul_nonneg hc.le (hT.nonneg i j), m, hm, ?_⟩
+  intro i j
+  rw [smul_pow, Matrix.smul_apply]
+  exact mul_pos (pow_pos hc m) (hpos i j)
+
 /-- If a primitive nonnegative real matrix has equal second and third powers,
 then its square has rank one.
 
 This is the finite-dimensional Perron-projection lemma supporting the proposed
 argument at arXiv:1606.00608, Appendix C.2, line 1613; it is not itself a
-claim of that source. The assumption N ≥ 1 is necessary: for N = 0,
-primitivity is vacuous and the square has rank zero. -/
+claim of that source. Nonemptiness of the finite index type is necessary:
+primitivity is vacuous for the empty matrix, whose square has rank zero. -/
 theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
-    {N : ℕ} [NeZero N] {T : Matrix (Fin N) (Fin N) ℝ}
+    [DecidableEq n] [Nonempty n] {T : Matrix n n ℝ}
     (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :
     (T ^ 2).rank = 1 := by
   obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
-  have htwom_pos (i j : Fin N) : 0 < (T ^ (m + m)) i j := by
+  have htwom_pos (i j : n) : 0 < (T ^ (m + m)) i j := by
     rw [pow_add, Matrix.mul_apply]
     exact Finset.sum_pos (fun k _ ↦ mul_pos (hpos i k) (hpos k j))
       Finset.univ_nonempty
-  have hsq_pos (i j : Fin N) : 0 < (T ^ 2) i j := by
-    rw [← pow_eq_pow_two_of_pow_two_eq_pow_three h (m + m) (by omega)]
+  have hstable : ∀ N, 2 ≤ N → T ^ N = T ^ 2 := by
+    have hmul : T * T = T * T * T := by
+      have htwo : T ^ 2 = T * T := by rw [pow_succ, pow_one]
+      have hthree : T ^ 3 = T * T * T := by rw [pow_succ, pow_succ, pow_one]
+      rw [htwo, hthree] at h
+      exact h
+    intro N hN
+    induction N, hN using Nat.le_induction with
+    | base => rfl
+    | succ k _ ih =>
+      rw [pow_succ, ih]
+      calc
+        T ^ 2 * T = T * T * T := by rw [pow_two]
+        _ = T * T := hmul.symm
+        _ = T ^ 2 := (pow_two T).symm
+  have hsq_pos (i j : n) : 0 < (T ^ 2) i j := by
+    rw [← hstable (m + m) (by omega)]
     exact htwom_pos i j
   have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
     rw [← pow_add]
-    exact pow_eq_pow_two_of_pow_two_eq_pow_three h 4 (by omega)
+    exact hstable 4 (by omega)
   exact rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
 
 /-- If a primitive nonnegative real matrix has equal second and third powers,

--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -123,27 +123,12 @@ theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
     rw [pow_add, Matrix.mul_apply]
     exact Finset.sum_pos (fun k _ ↦ mul_pos (hpos i k) (hpos k j))
       Finset.univ_nonempty
-  have hstable : ∀ N, 2 ≤ N → T ^ N = T ^ 2 := by
-    have hmul : T * T = T * T * T := by
-      have htwo : T ^ 2 = T * T := by rw [pow_succ, pow_one]
-      have hthree : T ^ 3 = T * T * T := by rw [pow_succ, pow_succ, pow_one]
-      rw [htwo, hthree] at h
-      exact h
-    intro N hN
-    induction N, hN using Nat.le_induction with
-    | base => rfl
-    | succ k _ ih =>
-      rw [pow_succ, ih]
-      calc
-        T ^ 2 * T = T * T * T := by rw [pow_two]
-        _ = T * T := hmul.symm
-        _ = T ^ 2 := (pow_two T).symm
   have hsq_pos (i j : n) : 0 < (T ^ 2) i j := by
-    rw [← hstable (m + m) (by omega)]
+    rw [← pow_eq_pow_two_of_pow_two_eq_pow_three h (m + m) (by omega)]
     exact htwom_pos i j
   have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
     rw [← pow_add]
-    exact hstable 4 (by omega)
+    exact pow_eq_pow_two_of_pow_two_eq_pow_three h 4 (by omega)
   exact rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
 
 /-- If a primitive nonnegative real matrix has equal second and third powers,

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -476,7 +476,8 @@ theorem trace_eq_trace_sq_of_pairing_idempotent
 
 /-- If `T^2 = T^3`, then every power `T^N` for `N ≥ 2` agrees with `T^2`. -/
 theorem pow_eq_pow_two_of_pow_two_eq_pow_three
-    {T : Matrix (Fin n) (Fin n) ℝ} (h : T ^ 2 = T ^ 3) :
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {T : Matrix ι ι ℝ} (h : T ^ 2 = T ^ 3) :
     ∀ N, 2 ≤ N → T ^ N = T ^ 2 := by
   have hmul : T * T = T * T * T := by
     have e2 : T ^ 2 = T * T := by rw [pow_succ, pow_one]

--- a/TNLean/Algebra/TraceReindex.lean
+++ b/TNLean/Algebra/TraceReindex.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Matrix.Reindex
 import Mathlib.LinearAlgebra.Matrix.Trace
-import Mathlib.Data.Complex.Basic
 
 /-!
 # Trace under matrix reindexing
@@ -17,8 +16,8 @@ the row and column index sets.
 namespace Matrix
 
 /-- Trace is invariant under simultaneous reindexing of the rows and columns. -/
-theorem trace_reindex {m n : Type*} [Fintype m] [Fintype n]
-    (e : m ≃ n) (M : Matrix m m ℂ) :
+theorem trace_reindex {R m n : Type*} [AddCommMonoid R] [Fintype m] [Fintype n]
+    (e : m ≃ n) (M : Matrix m m R) :
     Matrix.trace (Matrix.reindex e e M) = Matrix.trace M := by
   classical
   simpa [trace, reindex_apply] using

--- a/TNLean/MPS/MPDO/ActiveSectorTraceMatrixZCL.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorTraceMatrixZCL.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
+import TNLean.MPS.MPDO.SectorPairingTransfer
+
+/-!
+# Zero correlation length on an active-sector trace matrix
+
+This file gives the source-zero-correlation-length relations for an arbitrary
+active restriction of a positive physical-sector trace matrix.  It has no
+area-law or inverse-map hypothesis.
+
+## Main result
+
+* `PhysicalSectorFactorization.activeSectorTraceMatrix_normalized_relations_of_isSourceZCL`:
+  one positive normalization of the active trace matrix satisfies the
+  square--cube and positive-power trace relations.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`, lines
+  1473--1497.
+-/
+
+open scoped Matrix ComplexOrder BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Suppose that the left tensor vanishes in every sector of zero weight and
+that all neighboring operators are positive semidefinite.  If the original
+tensor has source zero correlation length, then one positive normalization of
+the active trace matrix satisfies
+\[
+  \widehat T^2=\widehat T^3,
+  \qquad
+  \operatorname{tr}(\widehat T^N)=\operatorname{tr}(\widehat T)
+  \quad (N\geq1).
+\]
+
+The proof restricts the rectangular decomposition of the physical-trace
+transfer to the nonzero-weight sectors.  Positivity identifies the opposite
+rectangular product with the complexification of the real active trace matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`, lines
+1473--1497.  The conclusion does not assert idempotence, rank one, or
+semisimplicity of the trace matrix. -/
+theorem activeSectorTraceMatrix_normalized_relations_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
+    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hZCL : K.IsSourceZCL) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let T := F.activeSectorTraceMatrix p
+      ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+        ∀ N : ℕ, 0 < N →
+          Matrix.trace ((lam⁻¹ • T) ^ N) = Matrix.trace (lam⁻¹ • T) := by
+  classical
+  obtain ⟨lam, hlam, hidem⟩ := hZCL.normalized_idempotent
+  let L : Matrix (Fin D) (F.ActiveSector p) ℂ :=
+    fun beta h ↦ (F.leftTensor h beta).trace
+  let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
+    fun k alpha ↦ (F.rightTensor k alpha).trace
+  have hphys : MPOTensor.physTraceTransfer K = L * Q := by
+    let U : Matrix.unitaryGroup (Fin d) ℂ := ⟨F.physicalIsometry, by
+      rw [Matrix.mem_unitaryGroup_iff', Matrix.star_eq_conjTranspose]
+      exact F.physicalIsometry_isometry⟩
+    have hfactor : ∀ beta alpha,
+        Matrix.reindex F.sectorEquiv F.sectorEquiv
+            ((U : Matrix (Fin d) (Fin d) ℂ) * MPOTensor.physicalSlice K beta alpha *
+              (U : Matrix (Fin d) (Fin d) ℂ)ᴴ) =
+          Matrix.blockDiagonal' fun q ↦
+            Matrix.kroneckerMap (· * ·) (F.leftTensor q beta) (F.rightTensor q alpha) := by
+      simpa [U] using F.factorization
+    rw [MPOTensor.physTraceTransfer_eq_sum_closedSector K F.sectorEquiv U
+      F.leftTensor F.rightTensor hfactor]
+    ext beta alpha
+    simp only [MPOTensor.closedSectorPairingOperator, Matrix.sum_apply,
+      Matrix.vecMulVec_apply, Matrix.mul_apply, L, Q]
+    rw [← Finset.sum_subtype (Finset.univ.filter (fun k ↦ p k ≠ 0)) (by simp)
+      (fun k ↦ (F.leftTensor k beta).trace * (F.rightTensor k alpha).trace)]
+    rw [Finset.sum_filter]
+    apply Finset.sum_congr rfl
+    intro k _
+    by_cases hk : p k ≠ 0
+    · simp [hk]
+    · rw [if_neg hk, hinactive k (not_ne_iff.mp hk) beta, Matrix.trace_zero, zero_mul]
+  have hrect : IsIdempotentElem (((lam : ℂ)⁻¹ • L) * Q) := by
+    simpa only [Matrix.smul_mul, ← hphys] using hidem
+  let TC : Matrix (F.ActiveSector p) (F.ActiveSector p) ℂ := Q * L
+  have hTC : TC = Matrix.map (F.activeSectorTraceMatrix p) Complex.ofReal := by
+    ext k h
+    simp only [TC, Matrix.mul_apply, Q, L, Matrix.map_apply]
+    change (∑ j, (F.rightTensor (k : Fin F.sectorCount) j).trace *
+      (F.leftTensor (h : Fin F.sectorCount) j).trace) =
+        ((F.neighboringOperator k h).trace.re : ℂ)
+    rw [← (hpos k h).isHermitian.trace_eq_ofReal_re]
+    simp only [neighboringOperator, Matrix.trace, Matrix.diag, Matrix.of_apply]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [Finset.mul_sum]
+    rw [Fintype.sum_prod_type]
+    simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+  refine ⟨lam, hlam, ?_⟩
+  dsimp only
+  have hmap : Matrix.map (lam⁻¹ • F.activeSectorTraceMatrix p) Complex.ofReal =
+      (lam : ℂ)⁻¹ • TC := by
+    rw [hTC]
+    ext k h
+    simp [Matrix.smul_apply, Matrix.map_apply]
+  have hmapHom :
+      Matrix.map (lam⁻¹ • F.activeSectorTraceMatrix p) (⇑Complex.ofRealHom) =
+        (lam : ℂ)⁻¹ • TC := hmap
+  constructor
+  · apply Matrix.map_injective Complex.ofReal_injective
+    change Matrix.map ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ 2) (⇑Complex.ofRealHom) =
+      Matrix.map ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ 3) (⇑Complex.ofRealHom)
+    rw [Matrix.map_pow, Matrix.map_pow, hmapHom]
+    simpa only [Matrix.mul_smul, TC] using
+      (Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
+        ((lam : ℂ)⁻¹ • L) Q hrect)
+  · intro N hN
+    apply Complex.ofReal_injective
+    change Complex.ofRealHom (Matrix.trace ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ N)) =
+      Complex.ofRealHom (Matrix.trace (lam⁻¹ • F.activeSectorTraceMatrix p))
+    rw [AddMonoidHom.map_trace Complex.ofRealHom,
+      AddMonoidHom.map_trace Complex.ofRealHom, Matrix.map_pow, hmapHom]
+    simpa only [Matrix.mul_smul, TC] using
+      (Matrix.trace_pow_eq_trace_of_rectangular_idempotent
+        ((lam : ℂ)⁻¹ • L) Q hrect N hN)
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -7,6 +7,7 @@ import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
 import TNLean.MPS.MPDO.ActiveSectorTraceMatrixZCL
 import TNLean.Algebra.PerronFrobenius.Idempotent
 import TNLean.Algebra.TraceReindex
+
 /-!
 # Cyclic-active physical sectors
 
@@ -70,7 +71,11 @@ def IsCyclicActiveSector (F : PhysicalSectorFactorization K)
 directed walk.
 
 Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
-449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
+
+**Local fix (cyclic-active restriction):** This indicator vanishes outside
+the positive-length cyclic support, rather than ranging over every source
+sector.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveWeight (F : PhysicalSectorFactorization K)
     (k : Fin F.sectorCount) : ℝ :=
   by
@@ -91,7 +96,11 @@ Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 /-- The subtype of sectors lying on a positive-length closed directed walk.
 
 Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
-449--514. -/
+449--514.
+
+**Local fix (cyclic-active restriction):** This subtype contains only the
+positive-length cyclic support, rather than every source sector.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
   F.ActiveSector F.cyclicActiveWeight
 
@@ -722,9 +731,10 @@ cyclic-active sectors rank one.
 Writing `T k h = Re (tr (eta k h))`, the entry of `T ^ 2` is the sum of the
 two-step products `T k q * T q h` over cyclic-active `q`.  Identifying this
 algebraic coefficient with a three-boundary physical trace still requires the
-additional marginal-replacement argument tracked in issue #4445.  This
-theorem applies only after deleting sectors absent from every nonzero cyclic
-product and makes no assertion about the unreduced Beigi trace matrix.
+additional marginal-replacement argument documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.  This theorem applies only
+after deleting sectors absent from every nonzero cyclic product and makes no
+assertion about the unreduced Beigi trace matrix.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497,
 and Proposition `4to2`, lines 1606--1616.

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -53,7 +53,12 @@ can return through a possibly empty directed path.  The explicit outgoing
 edge excludes the empty reflexive walk.
 
 Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
-449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
+
+**Local fix (cyclic-active restriction):** This definition isolates the
+nonzero cyclic support missing from the SAL-dependent primitive-matrix step
+of CPSV16 Lemma `propSN`.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def IsCyclicActiveSector (F : PhysicalSectorFactorization K)
     (k : Fin F.sectorCount) : Prop :=
   ∃ h : Fin F.sectorCount,
@@ -92,7 +97,7 @@ abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
 
 /-- The real trace matrix restricted to cyclic-active sectors.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1461--1470. -/
+Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1480--1482. -/
 noncomputable abbrev cyclicActiveSectorTraceMatrix
     (F : PhysicalSectorFactorization K) :
     Matrix F.CyclicActiveSector F.CyclicActiveSector ℝ :=
@@ -164,7 +169,11 @@ theorem exists_sectorVirtualMatrix_ne_zero_of_isCyclicActiveSector
 /-- If the sector virtual matrices span the full matrix algebra, every sector
 containing a nonzero virtual matrix lies on a directed two-cycle.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** This is a restricted trace-pairing
+consequence used in place of the SAL-dependent primitive-matrix step of
+`propSN`.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
     (F : PhysicalSectorFactorization K)
     (hspan : Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤)
@@ -217,7 +226,11 @@ theorem isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
 /-- For an injective tensor, every virtual matrix outside cyclic-active
 support vanishes.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** This removes only sectors outside
+nonzero cyclic support; it does not assert primitivity of the unreduced trace
+matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem sectorVirtualMatrix_eq_zero_of_not_isCyclicActiveSector
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (k : Fin F.sectorCount) (hk : ¬F.IsCyclicActiveSector k)
@@ -235,7 +248,11 @@ It is an auxiliary representative used to apply source ZCL to the restricted
 trace matrix; it does not identify that matrix with the unreduced one.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `formK`, `etarl`, and
-`Tkn`, lines 1434--1493. -/
+`Tkn`, lines 1434--1493.
+
+**Local fix (cyclic-active restriction):** This auxiliary representative
+implements the restricted repair; it is not the SAL decomposition in
+`propSN`.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveLeftRestriction
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
     PhysicalSectorFactorization K where
@@ -290,7 +307,7 @@ Source: arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines
 cyclic-active and kills every other target column.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `etarl` and `Tkn`, lines
-1441--1470. -/
+1441--1482. -/
 theorem cyclicActiveLeftRestriction_neighboringOperator
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (k h : Fin F.sectorCount) :
@@ -321,7 +338,7 @@ private noncomputable def cyclicActiveLeftRestriction_activeSectorEquiv
 /-- On cyclic-active indices, reindexing the restricted representative gives
 the original restricted trace matrix.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1461--1470. -/
+Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1480--1482. -/
 theorem reindex_cyclicActiveLeftRestriction_activeSectorTraceMatrix
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
     Matrix.reindex (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
@@ -371,7 +388,12 @@ the physical-sector factorization and every retained entry.  Thus this result
 concerns the restricted trace matrix only, not the unreduced Beigi matrix.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`, lines
-1473--1497, used at Proposition `4to2`, lines 1606--1616. -/
+1473--1497, used at Proposition `4to2`, lines 1606--1616.
+
+**Local fix (cyclic-active restriction):** The conclusion is transported to
+the restricted matrix.  It neither invokes SAL nor identifies this matrix
+with the full matrix of `propSN`.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -433,7 +455,11 @@ theorem cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
 
 /-- Injectivity reduces full virtual spanning to the cyclic-active sectors.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** This restricted spanning statement
+replaces the SAL-dependent sector selection in `propSN`.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorOneSiteMatrixFamily_span_eq_top
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
     Submodule.span ℂ
@@ -448,7 +474,11 @@ theorem cyclicActiveSectorOneSiteMatrixFamily_span_eq_top
 /-- An injective tensor with nonzero virtual dimension has a cyclic-active
 sector.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** Nonemptiness is proved for the
+restricted support, without the SAL hypothesis of `propSN`.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem nonempty_cyclicActiveSector
     (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective) :
     Nonempty F.CyclicActiveSector := by
@@ -475,7 +505,11 @@ theorem nonempty_cyclicActiveSector
 /-- Every cyclic-active sector contains a nonzero virtual matrix, in the
 indicator-weight indexing used by the restricted trace matrix.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** This is an indexed form of the
+restricted support statement, not the SAL-dependent sector selection in
+`propSN`.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
     (F : PhysicalSectorFactorization K) (k : F.CyclicActiveSector) :
     ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0 :=
@@ -485,7 +519,11 @@ theorem cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
 /-- Every edge between cyclic-active sectors closes through a third
 cyclic-active sector when the tensor is injective.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** The length-three return is proved
+on the restricted support and replaces the paper's blocking assertion.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem exists_cyclicActive_two_edge_return
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     {k h : F.CyclicActiveSector}
@@ -572,7 +610,11 @@ theorem exists_cyclicActive_two_edge_return
 /-- The cyclic-active support is one strongly connected component when the
 tensor is injective and the neighboring operators are positive semidefinite.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** Irreducibility is asserted only
+for the restricted trace matrix, without the SAL hypothesis of `propSN`.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_isIrreducible
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
@@ -583,7 +625,11 @@ theorem cyclicActiveSectorTraceMatrix_isIrreducible
 
 /-- Every cyclic-active sector has a positive length-two return weight.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** This return weight belongs to the
+restricted trace matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_pow_two_diag_pos
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -595,7 +641,11 @@ theorem cyclicActiveSectorTraceMatrix_pow_two_diag_pos
 
 /-- Every cyclic-active sector has a positive length-three return weight.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
+
+**Local fix (cyclic-active restriction):** This return weight belongs to the
+restricted trace matrix and replaces the paper's blocking assertion.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_pow_three_diag_pos
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -615,7 +665,12 @@ trace pairing supplies closed walks of lengths two and three, hence
 aperiodicity.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471;
-Beigi, arXiv:1105.1019v2, lines 449--514. -/
+Beigi, arXiv:1105.1019v2, lines 449--514.
+
+**Local fix (cyclic-active restriction):** This proves primitivity only after
+deleting sectors absent from nonzero cyclic products.  It is not the
+SAL-dependent full-matrix assertion of `propSN`.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_isPrimitive
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
@@ -685,7 +740,11 @@ private theorem rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
 square--cube relation, then its square has rank one.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `SALZCL`, lines
-1490--1497. -/
+1490--1497.
+
+**Local fix (cyclic-active restriction):** The rank-one conclusion concerns
+the square of the restricted trace matrix, not the one-step full matrix in
+the printed proof.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -701,7 +760,11 @@ theorem cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
 rank-one square whenever it satisfies the source-ZCL square--cube relation.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `SALZCL`, lines
-1490--1497. -/
+1490--1497.
+
+**Local fix (cyclic-active restriction):** The rank-one conclusion concerns
+the square of the restricted trace matrix, not the one-step full matrix in
+the printed proof.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -729,7 +792,12 @@ applies only after deleting sectors absent from every nonzero cyclic product
 and makes no assertion about the unreduced Beigi trace matrix.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497,
-and Proposition `4to2`, lines 1606--1616. -/
+and Proposition `4to2`, lines 1606--1616.
+
+**Local fix (cyclic-active restriction):** CPSV16 line 1613 uses the one-step
+coefficient, whereas this theorem proves rank one for the square of the
+restricted coefficient.  The additional marginal replacement remains open.
+See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem exists_normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one_of_isSourceZCL
     (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -825,7 +893,11 @@ Thus deleting all non-cyclic-active sector blocks leaves every finite cyclic
 bond product unchanged: precisely the deleted blocks vanish.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450; Beigi,
-arXiv:1105.1019v2, directed-cycle discussion at lines 449--514. -/
+arXiv:1105.1019v2, directed-cycle discussion at lines 449--514.
+
+**Local fix (cyclic-active restriction):** This deletion concerns the
+restricted cyclic support and makes no primitivity claim about the full trace
+matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector
     (F : PhysicalSectorFactorization K) [NeZero N]
     (k : Fin N → Fin F.sectorCount) (n : Fin N)

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -18,8 +18,17 @@ nonzero edge followed by a return path.
 Every nonzero finite cyclic neighboring product is supported entirely on
 cyclic-active sectors.  Consequently, deleting all other sector blocks leaves
 the finite cyclic bond products unchanged: every deleted block was already
-zero.  This conclusion is purely combinatorial and uses neither saturation of
-the area law, zero correlation length, nor injectivity.
+zero.  For an injective tensor with positive semidefinite neighboring
+operators, the restricted trace matrix is nonempty and primitive.  Source
+zero correlation length then makes the square of a positive normalization of
+this restricted matrix rank one.
+
+The last conclusion supplies the coefficient needed after tracing three
+boundary sites: the two fully traced middle edges contribute the square of
+the restricted trace matrix.  The fourth-region formula presently available
+in this development traces only two boundary sites and contains the original
+trace matrix.  Thus a further marginal-replacement argument is still needed;
+the two matrices are not identified here.
 
 ## References
 
@@ -53,13 +62,21 @@ def IsCyclicActiveSector (F : PhysicalSectorFactorization K)
         (fun a b ↦ F.neighboringOperator a b ≠ 0) h k
 
 /-- The indicator weight of the sectors lying on a positive-length closed
-directed walk. -/
+directed walk.
+
+Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
+449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
 noncomputable def cyclicActiveWeight (F : PhysicalSectorFactorization K)
     (k : Fin F.sectorCount) : ℝ :=
   by
     classical
     exact if F.IsCyclicActiveSector k then 1 else 0
 
+/-- The cyclic-active indicator is nonzero precisely on sectors which lie on
+a positive-length closed walk.
+
+Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
+449--514. -/
 @[simp] theorem cyclicActiveWeight_ne_zero_iff
     (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :
     F.cyclicActiveWeight k ≠ 0 ↔ F.IsCyclicActiveSector k := by
@@ -73,7 +90,9 @@ Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
   F.ActiveSector F.cyclicActiveWeight
 
-/-- The real trace matrix restricted to cyclic-active sectors. -/
+/-- The real trace matrix restricted to cyclic-active sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1461--1470. -/
 noncomputable abbrev cyclicActiveSectorTraceMatrix
     (F : PhysicalSectorFactorization K) :
     Matrix F.CyclicActiveSector F.CyclicActiveSector ℝ :=
@@ -123,7 +142,9 @@ private theorem exists_leftTensor_entry_ne_zero_of_neighboringOperator_ne_zero
   obtain ⟨beta, _, hbeta⟩ := Finset.exists_ne_zero_of_sum_ne_zero hxy
   exact ⟨beta, x.2, y.2, right_ne_zero_of_mul hbeta⟩
 
-/-- Every cyclic-active sector contains a nonzero virtual matrix. -/
+/-- Every cyclic-active sector contains a nonzero virtual matrix.
+
+Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and lines 449--514. -/
 theorem exists_sectorVirtualMatrix_ne_zero_of_isCyclicActiveSector
     (F : PhysicalSectorFactorization K) {k : Fin F.sectorCount}
     (hk : F.IsCyclicActiveSector k) :
@@ -141,7 +162,9 @@ theorem exists_sectorVirtualMatrix_ne_zero_of_isCyclicActiveSector
   exact mul_ne_zero hleft hright hentry
 
 /-- If the sector virtual matrices span the full matrix algebra, every sector
-containing a nonzero virtual matrix lies on a directed two-cycle. -/
+containing a nonzero virtual matrix lies on a directed two-cycle.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
     (F : PhysicalSectorFactorization K)
     (hspan : Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤)
@@ -192,7 +215,9 @@ theorem isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
   exact ⟨q.1, hkq, Relation.ReflTransGen.single hqk⟩
 
 /-- For an injective tensor, every virtual matrix outside cyclic-active
-support vanishes. -/
+support vanishes.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem sectorVirtualMatrix_eq_zero_of_not_isCyclicActiveSector
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (k : Fin F.sectorCount) (hk : ¬F.IsCyclicActiveSector k)
@@ -240,12 +265,21 @@ noncomputable def cyclicActiveLeftRestriction
         hK k hk (x.1, x.2) (y.1, y.2)
       exact congrFun (congrFun hzero beta) alpha
 
+/-- The auxiliary restriction sets precisely the inactive left tensors to
+zero.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines
+1434--1450. -/
 @[simp] theorem cyclicActiveLeftRestriction_leftTensor
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (k : Fin F.sectorCount) (beta : Fin D) :
     (F.cyclicActiveLeftRestriction hK).leftTensor k beta =
       if F.IsCyclicActiveSector k then F.leftTensor k beta else 0 := rfl
 
+/-- The auxiliary restriction leaves every right tensor unchanged.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines
+1434--1450. -/
 @[simp] theorem cyclicActiveLeftRestriction_rightTensor
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (k : Fin F.sectorCount) (alpha : Fin D) :
@@ -253,7 +287,10 @@ noncomputable def cyclicActiveLeftRestriction
       F.rightTensor k alpha := rfl
 
 /-- The left restriction preserves neighboring operators whose target is
-cyclic-active and kills every other target column. -/
+cyclic-active and kills every other target column.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `etarl` and `Tkn`, lines
+1441--1470. -/
 theorem cyclicActiveLeftRestriction_neighboringOperator
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (k h : Fin F.sectorCount) :
@@ -282,7 +319,9 @@ private noncomputable def cyclicActiveLeftRestriction_activeSectorEquiv
   right_inv _ := Subtype.ext rfl
 
 /-- On cyclic-active indices, reindexing the restricted representative gives
-the original restricted trace matrix. -/
+the original restricted trace matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1461--1470. -/
 theorem reindex_cyclicActiveLeftRestriction_activeSectorTraceMatrix
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
     Matrix.reindex (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
@@ -384,7 +423,9 @@ theorem cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
               F.cyclicActiveWeight)).symm
       _ = Matrix.trace (lam⁻¹ • T) := by rw [hreindex]
 
-/-- Injectivity reduces full virtual spanning to the cyclic-active sectors. -/
+/-- Injectivity reduces full virtual spanning to the cyclic-active sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem cyclicActiveSectorOneSiteMatrixFamily_span_eq_top
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
     Submodule.span ℂ
@@ -397,7 +438,9 @@ theorem cyclicActiveSectorOneSiteMatrixFamily_span_eq_top
   exact (F.cyclicActiveWeight_ne_zero_iff k).2 hactive hk
 
 /-- An injective tensor with nonzero virtual dimension has a cyclic-active
-sector. -/
+sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem nonempty_cyclicActiveSector
     (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective) :
     Nonempty F.CyclicActiveSector := by
@@ -422,7 +465,9 @@ theorem nonempty_cyclicActiveSector
   exact ⟨⟨q.1, (F.cyclicActiveWeight_ne_zero_iff q.1).2 hactive⟩⟩
 
 /-- Every cyclic-active sector contains a nonzero virtual matrix, in the
-indicator-weight indexing used by the restricted trace matrix. -/
+indicator-weight indexing used by the restricted trace matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
     (F : PhysicalSectorFactorization K) (k : F.CyclicActiveSector) :
     ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0 :=
@@ -430,7 +475,9 @@ theorem cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
     ((F.cyclicActiveWeight_ne_zero_iff k).1 k.2)
 
 /-- Every edge between cyclic-active sectors closes through a third
-cyclic-active sector when the tensor is injective. -/
+cyclic-active sector when the tensor is injective.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem exists_cyclicActive_two_edge_return
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     {k h : F.CyclicActiveSector}
@@ -515,7 +562,9 @@ theorem exists_cyclicActive_two_edge_return
         q.1 k hzero q.2.1 q.2.2 x y
 
 /-- The cyclic-active support is one strongly connected component when the
-tensor is injective and the neighboring operators are positive semidefinite. -/
+tensor is injective and the neighboring operators are positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem cyclicActiveSectorTraceMatrix_isIrreducible
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
@@ -524,7 +573,9 @@ theorem cyclicActiveSectorTraceMatrix_isIrreducible
     (F.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top hK)
     F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
 
-/-- Every cyclic-active sector has a positive length-two return weight. -/
+/-- Every cyclic-active sector has a positive length-two return weight.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem cyclicActiveSectorTraceMatrix_pow_two_diag_pos
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -534,7 +585,9 @@ theorem cyclicActiveSectorTraceMatrix_pow_two_diag_pos
     (F.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top hK)
     F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero k
 
-/-- Every cyclic-active sector has a positive length-three return weight. -/
+/-- Every cyclic-active sector has a positive length-three return weight.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471. -/
 theorem cyclicActiveSectorTraceMatrix_pow_three_diag_pos
     (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -564,25 +617,6 @@ theorem cyclicActiveSectorTraceMatrix_isPrimitive
       (F.cyclicActiveSectorTraceMatrix_pow_two_diag_pos hK hpos)
       (F.cyclicActiveSectorTraceMatrix_pow_three_diag_pos hK hpos)
 
-private theorem matrix_pow_eq_pow_two_of_pow_two_eq_pow_three
-    {I : Type*} [Fintype I] [DecidableEq I] (T : Matrix I I ℝ)
-    (h : T ^ 2 = T ^ 3) :
-    ∀ m, 2 ≤ m → T ^ m = T ^ 2 := by
-  classical
-  have hmul : T * T = T * T * T := by
-    have e3 : T ^ 3 = T * T * T := by rw [pow_succ, pow_two]
-    rw [pow_two, e3] at h
-    exact h
-  intro m hm
-  induction m, hm using Nat.le_induction with
-  | base => rfl
-  | succ m _ ih =>
-      rw [pow_succ, ih]
-      calc
-        T ^ 2 * T = T * T * T := by rw [pow_two]
-        _ = T * T := hmul.symm
-        _ = T ^ 2 := (pow_two T).symm
-
 private theorem isPrimitive_smul_of_pos
     {I : Type*} [Fintype I] [DecidableEq I]
     {T : Matrix I I ℝ} (hT : Matrix.IsPrimitive T)
@@ -594,28 +628,51 @@ private theorem isPrimitive_smul_of_pos
   rw [smul_pow, Matrix.smul_apply]
   exact mul_pos (pow_pos hc m) (hpos i j)
 
+private theorem isPrimitive_reindex
+    {I J : Type*} [Fintype I] [Fintype J] [DecidableEq I] [DecidableEq J]
+    (e : I ≃ J) {T : Matrix I I ℝ} (hT : Matrix.IsPrimitive T) :
+    Matrix.IsPrimitive (Matrix.reindex e e T) := by
+  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
+  refine ⟨fun i j ↦ hT.nonneg (e.symm i) (e.symm j), m, hm, ?_⟩
+  intro i j
+  have hreindex_pow : Matrix.reindex e e (T ^ m) =
+      (Matrix.reindex e e T) ^ m := by
+    change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ m) = _
+    rw [map_pow]
+  rw [← hreindex_pow]
+  exact hpos (e.symm i) (e.symm j)
+
 private theorem rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
     {I : Type*} [Fintype I] [DecidableEq I] [Nonempty I]
     {T : Matrix I I ℝ} (hprimitive : Matrix.IsPrimitive T)
     (hpow : T ^ 2 = T ^ 3) :
     (T ^ 2).rank = 1 := by
-  obtain ⟨m, hm, hmpos⟩ := hprimitive.exists_pos_pow
-  have htwom_pos (i j : I) : 0 < (T ^ (m + m)) i j := by
-    rw [pow_add, Matrix.mul_apply]
-    exact Finset.sum_pos (fun k _ ↦ mul_pos (hmpos i k) (hmpos k j))
-      Finset.univ_nonempty
-  have hsq_pos (i j : I) : 0 < (T ^ 2) i j := by
-    have heq := matrix_pow_eq_pow_two_of_pow_two_eq_pow_three
-      T hpow (m + m) (by omega)
-    have hentry := congrFun (congrFun heq i) j
-    exact hentry ▸ htwom_pos i j
-  have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
-    rw [← pow_add]
-    exact matrix_pow_eq_pow_two_of_pow_two_eq_pow_three T hpow 4 (by omega)
-  exact Matrix.rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
+  classical
+  let e : I ≃ Fin (Fintype.card I) := Fintype.equivFin I
+  let TF : Matrix (Fin (Fintype.card I)) (Fin (Fintype.card I)) ℝ :=
+    Matrix.reindex e e T
+  letI : NeZero (Fintype.card I) := ⟨Fintype.card_ne_zero⟩
+  have hprimitiveFin : Matrix.IsPrimitive TF := isPrimitive_reindex e hprimitive
+  have hpowFin : TF ^ 2 = TF ^ 3 := by
+    have hreindex_pow (m : ℕ) : Matrix.reindex e e (T ^ m) = TF ^ m := by
+      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ m) = TF ^ m
+      rw [map_pow]
+    rw [← hreindex_pow, ← hreindex_pow, hpow]
+  have hrank := hprimitiveFin.rank_pow_two_eq_one_of_pow_two_eq_pow_three hpowFin
+  calc
+    (T ^ 2).rank = (Matrix.reindex e e (T ^ 2)).rank :=
+      (Matrix.rank_reindex e e (T ^ 2)).symm
+    _ = (TF ^ 2).rank := by
+      congr 1
+      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ 2) = TF ^ 2
+      rw [map_pow]
+    _ = 1 := hrank
 
 /-- If the normalized cyclic-active trace matrix satisfies the source-ZCL
-square--cube relation, then its square has rank one. -/
+square--cube relation, then its square has rank one.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `SALZCL`, lines
+1490--1497. -/
 theorem cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -628,7 +685,10 @@ theorem cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos) hpow
 
 /-- A positive source normalization of the cyclic-active trace matrix has
-rank-one square whenever it satisfies the source-ZCL square--cube relation. -/
+rank-one square whenever it satisfies the source-ZCL square--cube relation.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `SALZCL`, lines
+1490--1497. -/
 theorem normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
@@ -642,6 +702,37 @@ theorem normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     (isPrimitive_smul_of_pos
       (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos) (inv_pos.mpr hlam))
   exact hpow
+
+/-- Source ZCL makes the normalized two-step trace coefficient on the
+cyclic-active sectors rank one.
+
+Writing `T k h = tr(eta k h)`, the entry of `T ^ 2` is the sum over two
+successive fully traced neighboring operators.  It is therefore the boundary
+coefficient obtained by applying the source-ZCL marginal replacement once
+more than at line 1613 and tracing three boundary sites.  The existing
+two-boundary formula contains `T`, not `T ^ 2`; identifying these expressions
+still requires that additional marginal-replacement argument.  This theorem
+applies only after deleting sectors absent from every nonzero cyclic product
+and makes no assertion about the unreduced Beigi trace matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497,
+and Proposition `4to2`, lines 1606--1616. -/
+theorem exists_normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hZCL : K.IsSourceZCL) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let T := F.cyclicActiveSectorTraceMatrix
+      ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+        ((lam⁻¹ • T) ^ 2).rank = 1 ∧
+          ∀ m : ℕ, 0 < m →
+            Matrix.trace ((lam⁻¹ • T) ^ m) = Matrix.trace (lam⁻¹ • T) := by
+  obtain ⟨lam, hlam, hpow, htrace⟩ :=
+    F.cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
+      hK hpos hZCL
+  refine ⟨lam, hlam, hpow, ?_, htrace⟩
+  exact F.normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
+    hK hpos hlam hpow
 
 private theorem reflTransGen_iterate_map
     {V W : Type*} (r : W → W → Prop) (step : V → V) (f : V → W)

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -533,82 +533,15 @@ theorem exists_cyclicActive_two_edge_return
     (hkh : F.neighboringOperator k h ≠ 0) :
     ∃ j : F.CyclicActiveSector,
       F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0 := by
-  classical
-  obtain ⟨kx, ky, hkxy⟩ :=
-    F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero k
-  obtain ⟨hx, hy, hhxy⟩ :=
-    F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero h
-  obtain ⟨ex, ey, heta⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hkh
-  obtain ⟨beta, alpha, hkentry⟩ :=
-    Matrix.exists_entry_ne_zero_of_ne_zero _ hkxy
-  have hkleft : F.leftTensor k beta kx.1 ky.1 ≠ 0 :=
-    left_ne_zero_of_mul hkentry
-  obtain ⟨delta, gamma, hhentry⟩ :=
-    Matrix.exists_entry_ne_zero_of_ne_zero _ hhxy
-  have hhright : F.rightTensor h gamma hx.2 hy.2 ≠ 0 :=
-    right_ne_zero_of_mul hhentry
-  let x : F.SectorIndex k := (kx.1, ex.1)
-  let y : F.SectorIndex k := (ky.1, ey.1)
-  let u : F.SectorIndex h := (ex.2, hx.2)
-  let v : F.SectorIndex h := (ey.2, hy.2)
-  let A := F.sectorVirtualMatrix k x y
-  let B := F.sectorVirtualMatrix h u v
-  have hAB : A * B ≠ 0 := by
-    intro hzero
-    have hentry := congrFun (congrFun hzero beta) gamma
-    rw [Matrix.zero_apply,
-      F.sectorVirtualMatrix_mul_apply k h x y u v beta gamma] at hentry
-    exact mul_ne_zero (mul_ne_zero hkleft heta) hhright hentry
-  obtain ⟨Y, htraceY⟩ : ∃ Y : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace (A * B * Y) ≠ 0 := by
-    by_contra hall
-    push Not at hall
-    exact hAB ((Matrix.trace_mul_right_eq_zero_iff (A * B)).mp hall)
-  have hYmem : Y ∈ Submodule.span ℂ
-      (Set.range (F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight)) := by
-    rw [F.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top hK]
-    exact Submodule.mem_top
-  obtain ⟨c, hc⟩ :=
-    (Submodule.mem_span_range_iff_exists_fun ℂ).mp hYmem
-  have hsum : Matrix.trace
-      (A * B * ∑ q, c q •
-        F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) ≠ 0 := by
-    rw [hc]
-    exact htraceY
-  simp only [Matrix.mul_sum, Matrix.mul_smul, Matrix.trace_sum,
-    Matrix.trace_smul] at hsum
-  obtain ⟨q, hq⟩ : ∃ q : F.ActiveSectorEntryIndex F.cyclicActiveWeight,
-      c q * Matrix.trace
-        (A * B * F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) ≠ 0 := by
-    by_contra hall
-    push Not at hall
-    exact hsum (Finset.sum_eq_zero fun q _ ↦ hall q)
-  have htraceC : Matrix.trace
-      (A * B * F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) ≠ 0 :=
-    right_ne_zero_of_mul hq
-  have hBC : B * F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q ≠ 0 := by
-    intro hzero
-    apply htraceC
-    rw [← Matrix.trace_mul_cycle B
-      (F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) A,
-      hzero, Matrix.zero_mul, Matrix.trace_zero]
-  have hCA : F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q * A ≠ 0 := by
-    intro hzero
-    apply htraceC
-    rw [Matrix.trace_mul_cycle A B
-      (F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q),
-      hzero, Matrix.zero_mul, Matrix.trace_zero]
-  refine ⟨q.1, ?_, ?_⟩
-  · intro hzero
-    apply hBC
-    simpa [B, activeSectorOneSiteMatrixFamily] using
-      F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
-        h q.1 hzero u v q.2.1 q.2.2
-  · intro hzero
-    apply hCA
-    simpa [A, activeSectorOneSiteMatrixFamily] using
-      F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
-        q.1 k hzero q.2.1 q.2.2 x y
+  obtain ⟨j, hhj, hjk⟩ :=
+    F.exists_two_edge_return_of_neighboringOperator_ne_zero_of_endpoints
+      (F.sectorVirtualMatrixFamily_span_eq_top hK)
+      (F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero k)
+      (F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero h) hkh
+  have hjactive : F.IsCyclicActiveSector j :=
+    ⟨k, hjk, Relation.ReflTransGen.head hkh
+      (Relation.ReflTransGen.single hhj)⟩
+  exact ⟨⟨j, (F.cyclicActiveWeight_ne_zero_iff j).2 hjactive⟩, hhj, hjk⟩
 
 /-- The cyclic-active support is one strongly connected component when the
 tensor is injective and the neighboring operators are positive semidefinite.

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -4,9 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
-import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
+import TNLean.MPS.MPDO.ActiveSectorTraceMatrixZCL
 import TNLean.Algebra.PerronFrobenius.Idempotent
-
+import TNLean.Algebra.TraceReindex
 /-!
 # Cyclic-active physical sectors
 
@@ -97,7 +97,11 @@ abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
 
 /-- The real trace matrix restricted to cyclic-active sectors.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1480--1482. -/
+Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1480--1482.
+
+**Local fix (cyclic-active restriction):** Unlike the source matrix, this
+matrix is indexed only by sectors on positive-length directed cycles.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable abbrev cyclicActiveSectorTraceMatrix
     (F : PhysicalSectorFactorization K) :
     Matrix F.CyclicActiveSector F.CyclicActiveSector ℝ :=
@@ -372,21 +376,11 @@ private theorem cyclicActiveLeftRestriction_neighboringOperator_posSemidef
   · exact hpos k h
   · exact Matrix.PosSemidef.zero
 
-private theorem trace_reindex_real
-    {I J : Type*} [Fintype I] [Fintype J]
-    (e : I ≃ J) (T : Matrix I I ℝ) :
-    Matrix.trace (Matrix.reindex e e T) = Matrix.trace T := by
-  classical
-  simpa [Matrix.trace, Matrix.reindex_apply] using
-    Fintype.sum_equiv e.symm _ _ (by intro; simp)
-
 /-- Source ZCL gives the square--cube and constant-trace-power relations for
 one positive normalization of the cyclic-active trace matrix.
-
 The auxiliary left restriction kills inactive target columns while preserving
 the physical-sector factorization and every retained entry.  Thus this result
 concerns the restricted trace matrix only, not the unreduced Beigi matrix.
-
 Source: arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`, lines
 1473--1497, used at Proposition `4to2`, lines 1606--1616.
 
@@ -440,14 +434,14 @@ theorem cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
         rw [hreindex_pow]
       _ = Matrix.trace ((lam⁻¹ • TG) ^ m) := by
         simpa only [e, TG, G] using
-          (trace_reindex_real
+          (Matrix.trace_reindex
             (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
             ((lam⁻¹ • (F.cyclicActiveLeftRestriction hK).activeSectorTraceMatrix
               F.cyclicActiveWeight) ^ m))
       _ = Matrix.trace (lam⁻¹ • TG) := htrace m hm
       _ = Matrix.trace (Matrix.reindex e e (lam⁻¹ • TG)) := by
         simpa only [e, TG, G] using
-          (trace_reindex_real
+          (Matrix.trace_reindex
             (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
             (lam⁻¹ • (F.cyclicActiveLeftRestriction hK).activeSectorTraceMatrix
               F.cyclicActiveWeight)).symm
@@ -680,62 +674,6 @@ theorem cyclicActiveSectorTraceMatrix_isPrimitive
       (F.cyclicActiveSectorTraceMatrix_pow_two_diag_pos hK hpos)
       (F.cyclicActiveSectorTraceMatrix_pow_three_diag_pos hK hpos)
 
-private theorem isPrimitive_smul_of_pos
-    {I : Type*} [Fintype I] [DecidableEq I]
-    {T : Matrix I I ℝ} (hT : Matrix.IsPrimitive T)
-    {c : ℝ} (hc : 0 < c) :
-    Matrix.IsPrimitive (c • T) := by
-  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
-  refine ⟨fun i j ↦ mul_nonneg hc.le (hT.nonneg i j), m, hm, ?_⟩
-  intro i j
-  rw [smul_pow, Matrix.smul_apply]
-  exact mul_pos (pow_pos hc m) (hpos i j)
-
-private theorem isPrimitive_reindex
-    {I J : Type*} [Fintype I] [Fintype J] [DecidableEq I] [DecidableEq J]
-    (e : I ≃ J) {T : Matrix I I ℝ} (hT : Matrix.IsPrimitive T) :
-    Matrix.IsPrimitive (Matrix.reindex e e T) := by
-  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
-  refine ⟨fun i j ↦ hT.nonneg (e.symm i) (e.symm j), m, hm, ?_⟩
-  intro i j
-  have hreindex_pow : Matrix.reindex e e (T ^ m) =
-      (Matrix.reindex e e T) ^ m := by
-    change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ m) = _
-    rw [map_pow]
-    rfl
-  rw [← hreindex_pow]
-  exact hpos (e.symm i) (e.symm j)
-
-private theorem rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
-    {I : Type*} [Fintype I] [DecidableEq I] [Nonempty I]
-    {T : Matrix I I ℝ} (hprimitive : Matrix.IsPrimitive T)
-    (hpow : T ^ 2 = T ^ 3) :
-    (T ^ 2).rank = 1 := by
-  classical
-  let e : I ≃ Fin (Fintype.card I) := Fintype.equivFin I
-  let TF : Matrix (Fin (Fintype.card I)) (Fin (Fintype.card I)) ℝ :=
-    Matrix.reindex e e T
-  letI : NeZero (Fintype.card I) := ⟨Fintype.card_ne_zero⟩
-  have hprimitiveFin : Matrix.IsPrimitive TF := isPrimitive_reindex e hprimitive
-  have hpowFin : TF ^ 2 = TF ^ 3 := by
-    have hreindex_pow (m : ℕ) : Matrix.reindex e e (T ^ m) = TF ^ m := by
-      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ m) =
-        (Matrix.reindex e e T) ^ m
-      rw [map_pow]
-      rfl
-    rw [← hreindex_pow, ← hreindex_pow, hpow]
-  have hrank := hprimitiveFin.rank_pow_two_eq_one_of_pow_two_eq_pow_three hpowFin
-  calc
-    (T ^ 2).rank = (Matrix.reindex e e (T ^ 2)).rank :=
-      (Matrix.rank_reindex e e (T ^ 2)).symm
-    _ = (TF ^ 2).rank := by
-      congr 1
-      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ 2) =
-        (Matrix.reindex e e T) ^ 2
-      rw [map_pow]
-      rfl
-    _ = 1 := hrank
-
 /-- If the normalized cyclic-active trace matrix satisfies the source-ZCL
 square--cube relation, then its square has rank one.
 
@@ -753,8 +691,8 @@ theorem cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     (F.cyclicActiveSectorTraceMatrix ^ 2).rank = 1 := by
   classical
   letI : Nonempty F.CyclicActiveSector := F.nonempty_cyclicActiveSector hK
-  exact rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
-    (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos) hpow
+  exact (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos)
+    |>.rank_pow_two_eq_one_of_pow_two_eq_pow_three hpow
 
 /-- A positive source normalization of the cyclic-active trace matrix has
 rank-one square whenever it satisfies the source-ZCL square--cube relation.
@@ -774,22 +712,19 @@ theorem normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     ((lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2).rank = 1 := by
   classical
   letI : Nonempty F.CyclicActiveSector := F.nonempty_cyclicActiveSector hK
-  apply rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
-    (isPrimitive_smul_of_pos
-      (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos) (inv_pos.mpr hlam))
-  exact hpow
+  exact (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos)
+    |>.smul_of_pos (inv_pos.mpr hlam)
+    |>.rank_pow_two_eq_one_of_pow_two_eq_pow_three hpow
 
 /-- Source ZCL makes the normalized two-step trace coefficient on the
 cyclic-active sectors rank one.
 
-Writing `T k h = tr(eta k h)`, the entry of `T ^ 2` is the sum over two
-successive fully traced neighboring operators.  It is therefore the boundary
-coefficient obtained by applying the source-ZCL marginal replacement once
-more than at line 1613 and tracing three boundary sites.  The existing
-two-boundary formula contains `T`, not `T ^ 2`; identifying these expressions
-still requires that additional marginal-replacement argument.  This theorem
-applies only after deleting sectors absent from every nonzero cyclic product
-and makes no assertion about the unreduced Beigi trace matrix.
+Writing `T k h = Re (tr (eta k h))`, the entry of `T ^ 2` is the sum of the
+two-step products `T k q * T q h` over cyclic-active `q`.  Identifying this
+algebraic coefficient with a three-boundary physical trace still requires the
+additional marginal-replacement argument tracked in issue #4445.  This
+theorem applies only after deleting sectors absent from every nonzero cyclic
+product and makes no assertion about the unreduced Beigi trace matrix.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497,
 and Proposition `4to2`, lines 1606--1616.

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
+
+/-!
+# Cyclic-active physical sectors
+
+For a physical-sector factorization, a sector is cyclic-active when it lies
+on a nonempty closed directed walk of nonzero neighboring operators.  This is
+stronger than reflexive reachability: the sector must have an outgoing
+nonzero edge followed by a return path.
+
+Every nonzero finite cyclic neighboring product is supported entirely on
+cyclic-active sectors.  Consequently, deleting all other sector blocks leaves
+the finite cyclic bond products unchanged: every deleted block was already
+zero.  This conclusion is purely combinatorial and uses neither saturation of
+the area law, zero correlation length, nor injectivity.
+
+## References
+
+* Beigi, arXiv:1105.1019v2, Lemma 2.1 and lines 449--514.
+* arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines
+  1434--1450.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D N : ℕ} {K : MPOTensor d D}
+
+/-- A sector lies on a positive-length closed walk in the directed support of
+the neighboring operators.
+
+Equivalently, it has an outgoing nonzero neighboring operator whose target
+can return through a possibly empty directed path.  The explicit outgoing
+edge excludes the empty reflexive walk.
+
+Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
+449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+def IsCyclicActiveSector (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) : Prop :=
+  ∃ h : Fin F.sectorCount,
+    F.neighboringOperator k h ≠ 0 ∧
+      Relation.ReflTransGen
+        (fun a b ↦ F.neighboringOperator a b ≠ 0) h k
+
+/-- The subtype of sectors lying on a positive-length closed directed walk.
+
+Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
+449--514. -/
+abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
+  {k : Fin F.sectorCount // F.IsCyclicActiveSector k}
+
+private theorem reflTransGen_iterate_map
+    {V W : Type*} (r : W → W → Prop) (step : V → V) (f : V → W)
+    (hstep : ∀ x, r (f x) (f (step x))) (m : ℕ) (x : V) :
+    Relation.ReflTransGen r (f x) (f ((step^[m]) x)) := by
+  induction m with
+  | zero => exact .refl
+  | succ m ih =>
+    rw [Function.iterate_succ_apply']
+    exact ih.tail (hstep _)
+
+private theorem finRotate_pow_card [NeZero N] (n : Fin N) :
+    ((finRotate N : Fin N → Fin N)^[N]) n = n := by
+  apply Fin.ext
+  rw [coe_finRotate_pow]
+  simp [Nat.mod_eq_of_lt n.isLt]
+
+/-- If every consecutive edge of a finite cyclic sector word is nonzero,
+then every sector in that word is cyclic-active.
+
+Source: arXiv:1606.00608, Appendix C.2, equation following `etarl`, lines
+1446--1450. -/
+theorem isCyclicActiveSector_of_cyclic_edges
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (hedge : ∀ n, F.neighboringOperator (k n) (k (n + 1)) ≠ 0)
+    (n : Fin N) :
+    F.IsCyclicActiveSector (k n) := by
+  refine ⟨k (n + 1), hedge n, ?_⟩
+  have hNpos : 1 ≤ N := Nat.one_le_iff_ne_zero.mpr (NeZero.ne N)
+  have hreturn :
+      ((finRotate N : Fin N → Fin N)^[N - 1]) (finRotate N n) = n := by
+    rw [← Function.iterate_succ_apply]
+    simpa [Nat.succ_eq_add_one, Nat.sub_add_cancel hNpos] using finRotate_pow_card n
+  have hwalk := reflTransGen_iterate_map
+    (fun a b ↦ F.neighboringOperator a b ≠ 0) (finRotate N) k
+    (fun i ↦ by
+      rw [finRotate_apply]
+      exact hedge i) (N - 1) (finRotate N n)
+  rw [hreturn] at hwalk
+  simpa only [finRotate_apply] using hwalk
+
+/-- A nonzero cyclic neighboring product has a nonzero neighboring operator
+at every edge of its sector word.
+
+Source: arXiv:1606.00608, Appendix C.2, equation following `etarl`, lines
+1446--1450. -/
+theorem neighboringOperator_ne_zero_of_cyclicNeighboringProduct_ne_zero
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (hprod : F.cyclicNeighboringProduct k ≠ 0) (n : Fin N) :
+    F.neighboringOperator (k n) (k (n + 1)) ≠ 0 := by
+  intro hn
+  apply hprod
+  ext x y
+  rw [cyclicNeighboringProduct]
+  apply Finset.prod_eq_zero (Finset.mem_univ n)
+  rw [hn]
+  rfl
+
+/-- Every sector occurring in a nonzero cyclic neighboring product is
+cyclic-active.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+theorem isCyclicActiveSector_of_cyclicNeighboringProduct_ne_zero
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (hprod : F.cyclicNeighboringProduct k ≠ 0) (n : Fin N) :
+    F.IsCyclicActiveSector (k n) := by
+  apply F.isCyclicActiveSector_of_cyclic_edges k
+  exact F.neighboringOperator_ne_zero_of_cyclicNeighboringProduct_ne_zero k hprod
+
+/-- If a finite cyclic sector word contains a sector outside the
+cyclic-active support, then its neighboring product is zero.
+
+Thus deleting all non-cyclic-active sector blocks leaves every finite cyclic
+bond product unchanged: precisely the deleted blocks vanish.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450; Beigi,
+arXiv:1105.1019v2, directed-cycle discussion at lines 449--514. -/
+theorem cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount) (n : Fin N)
+    (hn : ¬ F.IsCyclicActiveSector (k n)) :
+    F.cyclicNeighboringProduct k = 0 := by
+  by_contra hprod
+  exact hn (F.isCyclicActiveSector_of_cyclicNeighboringProduct_ne_zero k hprod n)
+
+/-- The finite cyclic neighboring-product family is supported on sector words
+whose every value is cyclic-active.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450. -/
+theorem cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (hk : ¬ ∀ n, F.IsCyclicActiveSector (k n)) :
+    F.cyclicNeighboringProduct k = 0 := by
+  classical
+  push Not at hk
+  obtain ⟨n, hn⟩ := hk
+  exact F.cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector k n hn
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -355,6 +355,14 @@ private theorem cyclicActiveLeftRestriction_neighboringOperator_posSemidef
   · exact hpos k h
   · exact Matrix.PosSemidef.zero
 
+private theorem trace_reindex_real
+    {I J : Type*} [Fintype I] [Fintype J]
+    (e : I ≃ J) (T : Matrix I I ℝ) :
+    Matrix.trace (Matrix.reindex e e T) = Matrix.trace T := by
+  classical
+  simpa [Matrix.trace, Matrix.reindex_apply] using
+    Fintype.sum_equiv e.symm _ _ (by intro; simp)
+
 /-- Source ZCL gives the square--cube and constant-trace-power relations for
 one positive normalization of the cyclic-active trace matrix.
 
@@ -410,14 +418,14 @@ theorem cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
         rw [hreindex_pow]
       _ = Matrix.trace ((lam⁻¹ • TG) ^ m) := by
         simpa only [e, TG, G] using
-          (Matrix.trace_reindex (R := ℝ)
+          (trace_reindex_real
             (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
             ((lam⁻¹ • (F.cyclicActiveLeftRestriction hK).activeSectorTraceMatrix
               F.cyclicActiveWeight) ^ m))
       _ = Matrix.trace (lam⁻¹ • TG) := htrace m hm
       _ = Matrix.trace (Matrix.reindex e e (lam⁻¹ • TG)) := by
         simpa only [e, TG, G] using
-          (Matrix.trace_reindex (R := ℝ)
+          (trace_reindex_real
             (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
             (lam⁻¹ • (F.cyclicActiveLeftRestriction hK).activeSectorTraceMatrix
               F.cyclicActiveWeight)).symm
@@ -639,6 +647,7 @@ private theorem isPrimitive_reindex
       (Matrix.reindex e e T) ^ m := by
     change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ m) = _
     rw [map_pow]
+    rfl
   rw [← hreindex_pow]
   exact hpos (e.symm i) (e.symm j)
 
@@ -655,8 +664,10 @@ private theorem rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
   have hprimitiveFin : Matrix.IsPrimitive TF := isPrimitive_reindex e hprimitive
   have hpowFin : TF ^ 2 = TF ^ 3 := by
     have hreindex_pow (m : ℕ) : Matrix.reindex e e (T ^ m) = TF ^ m := by
-      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ m) = TF ^ m
+      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ m) =
+        (Matrix.reindex e e T) ^ m
       rw [map_pow]
+      rfl
     rw [← hreindex_pow, ← hreindex_pow, hpow]
   have hrank := hprimitiveFin.rank_pow_two_eq_one_of_pow_two_eq_pow_three hpowFin
   calc
@@ -664,8 +675,10 @@ private theorem rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
       (Matrix.rank_reindex e e (T ^ 2)).symm
     _ = (TF ^ 2).rank := by
       congr 1
-      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ 2) = TF ^ 2
+      change (Matrix.reindexAlgEquiv ℝ ℝ e) (T ^ 2) =
+        (Matrix.reindex e e T) ^ 2
       rw [map_pow]
+      rfl
     _ = 1 := hrank
 
 /-- If the normalized cyclic-active trace matrix satisfies the source-ZCL

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
+import TNLean.MPS.MPDO.InverseMapActiveSectorZCL
+import TNLean.Algebra.PerronFrobenius.Idempotent
 
 /-!
 # Cyclic-active physical sectors
@@ -26,11 +28,13 @@ the area law, zero correlation length, nor injectivity.
   1434--1450.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 
 namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D N : ℕ} {K : MPOTensor d D}
+
+attribute [local instance] Classical.decEq Classical.propDecidable
 
 /-- A sector lies on a positive-length closed walk in the directed support of
 the neighboring operators.
@@ -48,12 +52,596 @@ def IsCyclicActiveSector (F : PhysicalSectorFactorization K)
       Relation.ReflTransGen
         (fun a b ↦ F.neighboringOperator a b ≠ 0) h k
 
+/-- The indicator weight of the sectors lying on a positive-length closed
+directed walk. -/
+noncomputable def cyclicActiveWeight (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) : ℝ :=
+  by
+    classical
+    exact if F.IsCyclicActiveSector k then 1 else 0
+
+@[simp] theorem cyclicActiveWeight_ne_zero_iff
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :
+    F.cyclicActiveWeight k ≠ 0 ↔ F.IsCyclicActiveSector k := by
+  classical
+  simp [cyclicActiveWeight]
+
 /-- The subtype of sectors lying on a positive-length closed directed walk.
 
 Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 449--514. -/
 abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
-  {k : Fin F.sectorCount // F.IsCyclicActiveSector k}
+  F.ActiveSector F.cyclicActiveWeight
+
+/-- The real trace matrix restricted to cyclic-active sectors. -/
+noncomputable abbrev cyclicActiveSectorTraceMatrix
+    (F : PhysicalSectorFactorization K) :
+    Matrix F.CyclicActiveSector F.CyclicActiveSector ℝ :=
+  F.activeSectorTraceMatrix F.cyclicActiveWeight
+
+/-- For a positive semidefinite neighboring family, operator support agrees
+with positive real trace support.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1446--1450. -/
+theorem neighboringOperator_trace_re_pos_iff
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (k h : Fin F.sectorCount) :
+    0 < (F.neighboringOperator k h).trace.re ↔
+      F.neighboringOperator k h ≠ 0 := by
+  constructor
+  · intro htrace hzero
+    simp [hzero] at htrace
+  · intro hne
+    exact (Complex.lt_def.mp ((hpos k h).trace_pos_of_ne_zero hne)).1
+
+private theorem exists_incoming_of_edge_reaches
+    {V : Type*} {r : V → V → Prop} {k h : V}
+    (hkh : r k h) (hreturn : Relation.ReflTransGen r h k) :
+    ∃ j, r j k := by
+  induction hreturn with
+  | refl => exact ⟨h, hkh⟩
+  | tail hab hbc ih => exact ⟨_, hbc⟩
+
+private theorem exists_rightTensor_entry_ne_zero_of_neighboringOperator_ne_zero
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (hkh : F.neighboringOperator k h ≠ 0) :
+    ∃ alpha x y, F.rightTensor k alpha x y ≠ 0 := by
+  classical
+  obtain ⟨x, y, hxy⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hkh
+  rw [F.neighboringOperator_apply] at hxy
+  obtain ⟨alpha, _, halpha⟩ := Finset.exists_ne_zero_of_sum_ne_zero hxy
+  exact ⟨alpha, x.1, y.1, left_ne_zero_of_mul halpha⟩
+
+private theorem exists_leftTensor_entry_ne_zero_of_neighboringOperator_ne_zero
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (hkh : F.neighboringOperator k h ≠ 0) :
+    ∃ beta x y, F.leftTensor h beta x y ≠ 0 := by
+  classical
+  obtain ⟨x, y, hxy⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hkh
+  rw [F.neighboringOperator_apply] at hxy
+  obtain ⟨beta, _, hbeta⟩ := Finset.exists_ne_zero_of_sum_ne_zero hxy
+  exact ⟨beta, x.2, y.2, right_ne_zero_of_mul hbeta⟩
+
+/-- Every cyclic-active sector contains a nonzero virtual matrix. -/
+theorem exists_sectorVirtualMatrix_ne_zero_of_isCyclicActiveSector
+    (F : PhysicalSectorFactorization K) {k : Fin F.sectorCount}
+    (hk : F.IsCyclicActiveSector k) :
+    ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0 := by
+  obtain ⟨h, hkh, hreturn⟩ := hk
+  obtain ⟨j, hjk⟩ := exists_incoming_of_edge_reaches
+    (r := fun a b ↦ F.neighboringOperator a b ≠ 0) hkh hreturn
+  obtain ⟨beta, xL, yL, hleft⟩ :=
+    F.exists_leftTensor_entry_ne_zero_of_neighboringOperator_ne_zero hjk
+  obtain ⟨alpha, xR, yR, hright⟩ :=
+    F.exists_rightTensor_entry_ne_zero_of_neighboringOperator_ne_zero hkh
+  refine ⟨(xL, xR), (yL, yR), ?_⟩
+  intro hzero
+  have hentry := congrFun (congrFun hzero beta) alpha
+  exact mul_ne_zero hleft hright hentry
+
+/-- If the sector virtual matrices span the full matrix algebra, every sector
+containing a nonzero virtual matrix lies on a directed two-cycle. -/
+theorem isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
+    (F : PhysicalSectorFactorization K)
+    (hspan : Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤)
+    {k : Fin F.sectorCount} {x y : F.SectorIndex k}
+    (hA : F.sectorVirtualMatrix k x y ≠ 0) :
+    F.IsCyclicActiveSector k := by
+  classical
+  let A := F.sectorVirtualMatrix k x y
+  obtain ⟨Y, htraceY⟩ : ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace (A * Y) ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    exact hA ((Matrix.trace_mul_right_eq_zero_iff A).mp hall)
+  have hYmem : Y ∈ Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) := by
+    rw [hspan]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hYmem
+  have hsum : Matrix.trace
+      (A * ∑ q, c q • F.sectorVirtualMatrixFamily q) ≠ 0 := by
+    rw [hc]
+    exact htraceY
+  simp only [Matrix.mul_sum, Matrix.mul_smul, Matrix.trace_sum,
+    Matrix.trace_smul] at hsum
+  obtain ⟨q, hq⟩ : ∃ q : F.SectorEntryIndex,
+      c q * Matrix.trace (A * F.sectorVirtualMatrixFamily q) ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    exact hsum (Finset.sum_eq_zero fun q _ ↦ hall q)
+  have htrace : Matrix.trace (A * F.sectorVirtualMatrixFamily q) ≠ 0 :=
+    right_ne_zero_of_mul hq
+  have hAB : A * F.sectorVirtualMatrixFamily q ≠ 0 := by
+    intro hzero
+    exact htrace (by rw [hzero, Matrix.trace_zero])
+  have hBA : F.sectorVirtualMatrixFamily q * A ≠ 0 := by
+    intro hzero
+    apply htrace
+    rw [Matrix.trace_mul_comm, hzero, Matrix.trace_zero]
+  have hkq : F.neighboringOperator k q.1 ≠ 0 := by
+    intro hzero
+    apply hAB
+    exact F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+      k q.1 hzero x y q.2.1 q.2.2
+  have hqk : F.neighboringOperator q.1 k ≠ 0 := by
+    intro hzero
+    apply hBA
+    exact F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+      q.1 k hzero q.2.1 q.2.2 x y
+  exact ⟨q.1, hkq, Relation.ReflTransGen.single hqk⟩
+
+/-- For an injective tensor, every virtual matrix outside cyclic-active
+support vanishes. -/
+theorem sectorVirtualMatrix_eq_zero_of_not_isCyclicActiveSector
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (k : Fin F.sectorCount) (hk : ¬F.IsCyclicActiveSector k)
+    (x y : F.SectorIndex k) :
+    F.sectorVirtualMatrix k x y = 0 := by
+  by_contra hxy
+  exact hk (F.isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
+    (F.sectorVirtualMatrixFamily_span_eq_top hK) hxy)
+
+/-- Replace the left tensor outside cyclic-active support by zero.
+
+For an injective tensor this leaves the physical-sector factorization
+unchanged, because every virtual matrix in a deleted sector already vanishes.
+It is an auxiliary representative used to apply source ZCL to the restricted
+trace matrix; it does not identify that matrix with the unreduced one.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `formK`, `etarl`, and
+`Tkn`, lines 1434--1493. -/
+noncomputable def cyclicActiveLeftRestriction
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
+    PhysicalSectorFactorization K where
+  sectorCount := F.sectorCount
+  leftDim := F.leftDim
+  rightDim := F.rightDim
+  leftDim_pos := F.leftDim_pos
+  rightDim_pos := F.rightDim_pos
+  sectorEquiv := F.sectorEquiv
+  physicalIsometry := F.physicalIsometry
+  physicalIsometry_isometry := F.physicalIsometry_isometry
+  leftTensor := fun k beta ↦
+    if F.IsCyclicActiveSector k then F.leftTensor k beta else 0
+  rightTensor := F.rightTensor
+  factorization := by
+    classical
+    intro beta alpha
+    rw [F.factorization]
+    congr 1
+    funext k
+    by_cases hk : F.IsCyclicActiveSector k
+    · simp [hk]
+    · ext x y
+      simp only [hk, if_false, Matrix.kroneckerMap_apply, Matrix.zero_apply,
+        zero_mul]
+      have hzero := F.sectorVirtualMatrix_eq_zero_of_not_isCyclicActiveSector
+        hK k hk (x.1, x.2) (y.1, y.2)
+      exact congrFun (congrFun hzero beta) alpha
+
+@[simp] theorem cyclicActiveLeftRestriction_leftTensor
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (k : Fin F.sectorCount) (beta : Fin D) :
+    (F.cyclicActiveLeftRestriction hK).leftTensor k beta =
+      if F.IsCyclicActiveSector k then F.leftTensor k beta else 0 := rfl
+
+@[simp] theorem cyclicActiveLeftRestriction_rightTensor
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (k : Fin F.sectorCount) (alpha : Fin D) :
+    (F.cyclicActiveLeftRestriction hK).rightTensor k alpha =
+      F.rightTensor k alpha := rfl
+
+/-- The left restriction preserves neighboring operators whose target is
+cyclic-active and kills every other target column. -/
+theorem cyclicActiveLeftRestriction_neighboringOperator
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (k h : Fin F.sectorCount) :
+    (F.cyclicActiveLeftRestriction hK).neighboringOperator k h =
+      if F.IsCyclicActiveSector h then F.neighboringOperator k h else 0 := by
+  classical
+  by_cases hh : F.IsCyclicActiveSector h
+  · rw [if_pos hh]
+    ext x y
+    simp [neighboringOperator_apply, hh]
+  · rw [if_neg hh]
+    ext x y
+    simp only [neighboringOperator_apply,
+      cyclicActiveLeftRestriction_leftTensor,
+      cyclicActiveLeftRestriction_rightTensor, hh, if_false]
+    change (∑ _ : Fin D, _ * 0) = 0
+    simp
+
+private noncomputable def cyclicActiveLeftRestriction_activeSectorEquiv
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
+    (F.cyclicActiveLeftRestriction hK).ActiveSector F.cyclicActiveWeight ≃
+      F.CyclicActiveSector where
+  toFun k := ⟨k.1, k.2⟩
+  invFun k := ⟨k.1, k.2⟩
+  left_inv _ := Subtype.ext rfl
+  right_inv _ := Subtype.ext rfl
+
+/-- On cyclic-active indices, reindexing the restricted representative gives
+the original restricted trace matrix. -/
+theorem reindex_cyclicActiveLeftRestriction_activeSectorTraceMatrix
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
+    Matrix.reindex (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
+      (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
+      ((F.cyclicActiveLeftRestriction hK).activeSectorTraceMatrix
+        F.cyclicActiveWeight) = F.cyclicActiveSectorTraceMatrix := by
+  ext k h
+  change ((F.cyclicActiveLeftRestriction hK).neighboringOperator
+      k.1 h.1).trace.re = (F.neighboringOperator k.1 h.1).trace.re
+  rw [F.cyclicActiveLeftRestriction_neighboringOperator hK]
+  rw [if_pos ((F.cyclicActiveWeight_ne_zero_iff h.1).1 h.2)]
+  rfl
+
+private theorem cyclicActiveLeftRestriction_leftTensor_eq_zero_of_weight_eq_zero
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (k : Fin F.sectorCount) (hk : F.cyclicActiveWeight k = 0)
+    (beta : Fin D) :
+    (F.cyclicActiveLeftRestriction hK).leftTensor k beta = 0 := by
+  rw [F.cyclicActiveLeftRestriction_leftTensor hK]
+  apply if_neg
+  intro hactive
+  exact (F.cyclicActiveWeight_ne_zero_iff k).2 hactive hk
+
+private theorem cyclicActiveLeftRestriction_neighboringOperator_posSemidef
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (k h : Fin F.sectorCount) :
+    ((F.cyclicActiveLeftRestriction hK).neighboringOperator k h).PosSemidef := by
+  rw [F.cyclicActiveLeftRestriction_neighboringOperator hK]
+  split
+  · exact hpos k h
+  · exact Matrix.PosSemidef.zero
+
+/-- Source ZCL gives the square--cube and constant-trace-power relations for
+one positive normalization of the cyclic-active trace matrix.
+
+The auxiliary left restriction kills inactive target columns while preserving
+the physical-sector factorization and every retained entry.  Thus this result
+concerns the restricted trace matrix only, not the unreduced Beigi matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`, lines
+1473--1497, used at Proposition `4to2`, lines 1606--1616. -/
+theorem cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hZCL : K.IsSourceZCL) :
+    ∃ lam : ℝ, 0 < lam ∧
+      let T := F.cyclicActiveSectorTraceMatrix
+      ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
+        ∀ m : ℕ, 0 < m →
+          Matrix.trace ((lam⁻¹ • T) ^ m) = Matrix.trace (lam⁻¹ • T) := by
+  let G := F.cyclicActiveLeftRestriction hK
+  obtain ⟨lam, hlam, hpow, htrace⟩ :=
+    G.activeSectorTraceMatrix_normalized_relations_of_isSourceZCL
+      F.cyclicActiveWeight
+      (F.cyclicActiveLeftRestriction_leftTensor_eq_zero_of_weight_eq_zero hK)
+      (F.cyclicActiveLeftRestriction_neighboringOperator_posSemidef hK hpos)
+      hZCL
+  let e := F.cyclicActiveLeftRestriction_activeSectorEquiv hK
+  let TG := G.activeSectorTraceMatrix F.cyclicActiveWeight
+  let T := F.cyclicActiveSectorTraceMatrix
+  have hmatrix : Matrix.reindex e e TG = T := by
+    simpa only [e, TG, T, G] using
+      F.reindex_cyclicActiveLeftRestriction_activeSectorTraceMatrix hK
+  have hreindex : Matrix.reindex e e (lam⁻¹ • TG) = lam⁻¹ • T := by
+    change (Matrix.reindexAlgEquiv ℝ ℝ e) (lam⁻¹ • TG) = lam⁻¹ • T
+    rw [map_smul]
+    change lam⁻¹ • Matrix.reindex e e TG = lam⁻¹ • T
+    rw [hmatrix]
+  have hreindex_pow (m : ℕ) :
+      Matrix.reindex e e ((lam⁻¹ • TG) ^ m) = (lam⁻¹ • T) ^ m := by
+    change (Matrix.reindexAlgEquiv ℝ ℝ e) ((lam⁻¹ • TG) ^ m) = _
+    rw [map_pow]
+    change (Matrix.reindex e e (lam⁻¹ • TG)) ^ m = _
+    rw [hreindex]
+  refine ⟨lam, hlam, ?_, ?_⟩
+  · calc
+      (lam⁻¹ • T) ^ 2 = Matrix.reindex e e ((lam⁻¹ • TG) ^ 2) :=
+        (hreindex_pow 2).symm
+      _ = Matrix.reindex e e ((lam⁻¹ • TG) ^ 3) := congrArg _ hpow
+      _ = (lam⁻¹ • T) ^ 3 := hreindex_pow 3
+  · intro m hm
+    calc
+      Matrix.trace ((lam⁻¹ • T) ^ m) =
+          Matrix.trace (Matrix.reindex e e ((lam⁻¹ • TG) ^ m)) := by
+        rw [hreindex_pow]
+      _ = Matrix.trace ((lam⁻¹ • TG) ^ m) := by
+        simpa only [e, TG, G] using
+          (Matrix.trace_reindex (R := ℝ)
+            (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
+            ((lam⁻¹ • (F.cyclicActiveLeftRestriction hK).activeSectorTraceMatrix
+              F.cyclicActiveWeight) ^ m))
+      _ = Matrix.trace (lam⁻¹ • TG) := htrace m hm
+      _ = Matrix.trace (Matrix.reindex e e (lam⁻¹ • TG)) := by
+        simpa only [e, TG, G] using
+          (Matrix.trace_reindex (R := ℝ)
+            (F.cyclicActiveLeftRestriction_activeSectorEquiv hK)
+            (lam⁻¹ • (F.cyclicActiveLeftRestriction hK).activeSectorTraceMatrix
+              F.cyclicActiveWeight)).symm
+      _ = Matrix.trace (lam⁻¹ • T) := by rw [hreindex]
+
+/-- Injectivity reduces full virtual spanning to the cyclic-active sectors. -/
+theorem cyclicActiveSectorOneSiteMatrixFamily_span_eq_top
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective) :
+    Submodule.span ℂ
+      (Set.range (F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight)) = ⊤ := by
+  apply F.activeSectorOneSiteMatrixFamily_span_eq_top F.cyclicActiveWeight
+    (F.sectorVirtualMatrixFamily_span_eq_top hK)
+  intro k hk x y
+  apply F.sectorVirtualMatrix_eq_zero_of_not_isCyclicActiveSector hK
+  intro hactive
+  exact (F.cyclicActiveWeight_ne_zero_iff k).2 hactive hk
+
+/-- An injective tensor with nonzero virtual dimension has a cyclic-active
+sector. -/
+theorem nonempty_cyclicActiveSector
+    (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective) :
+    Nonempty F.CyclicActiveSector := by
+  classical
+  have hspan := F.sectorVirtualMatrixFamily_span_eq_top hK
+  have hone_mem : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+      Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) := by
+    rw [hspan]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ :=
+    (Submodule.mem_span_range_iff_exists_fun ℂ).mp hone_mem
+  have hsum : (∑ q, c q • F.sectorVirtualMatrixFamily q) ≠ 0 := by
+    rw [hc]
+    exact one_ne_zero
+  obtain ⟨q, _, hq⟩ := Finset.exists_ne_zero_of_sum_ne_zero hsum
+  have hmatrix : F.sectorVirtualMatrixFamily q ≠ 0 := by
+    intro hzero
+    rw [hzero, smul_zero] at hq
+    exact hq rfl
+  have hactive := F.isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
+    hspan hmatrix
+  exact ⟨⟨q.1, (F.cyclicActiveWeight_ne_zero_iff q.1).2 hactive⟩⟩
+
+/-- Every cyclic-active sector contains a nonzero virtual matrix, in the
+indicator-weight indexing used by the restricted trace matrix. -/
+theorem cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
+    (F : PhysicalSectorFactorization K) (k : F.CyclicActiveSector) :
+    ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0 :=
+  F.exists_sectorVirtualMatrix_ne_zero_of_isCyclicActiveSector
+    ((F.cyclicActiveWeight_ne_zero_iff k).1 k.2)
+
+/-- Every edge between cyclic-active sectors closes through a third
+cyclic-active sector when the tensor is injective. -/
+theorem exists_cyclicActive_two_edge_return
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    {k h : F.CyclicActiveSector}
+    (hkh : F.neighboringOperator k h ≠ 0) :
+    ∃ j : F.CyclicActiveSector,
+      F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0 := by
+  classical
+  obtain ⟨kx, ky, hkxy⟩ :=
+    F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero k
+  obtain ⟨hx, hy, hhxy⟩ :=
+    F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero h
+  obtain ⟨ex, ey, heta⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hkh
+  obtain ⟨beta, alpha, hkentry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ hkxy
+  have hkleft : F.leftTensor k beta kx.1 ky.1 ≠ 0 :=
+    left_ne_zero_of_mul hkentry
+  obtain ⟨delta, gamma, hhentry⟩ :=
+    Matrix.exists_entry_ne_zero_of_ne_zero _ hhxy
+  have hhright : F.rightTensor h gamma hx.2 hy.2 ≠ 0 :=
+    right_ne_zero_of_mul hhentry
+  let x : F.SectorIndex k := (kx.1, ex.1)
+  let y : F.SectorIndex k := (ky.1, ey.1)
+  let u : F.SectorIndex h := (ex.2, hx.2)
+  let v : F.SectorIndex h := (ey.2, hy.2)
+  let A := F.sectorVirtualMatrix k x y
+  let B := F.sectorVirtualMatrix h u v
+  have hAB : A * B ≠ 0 := by
+    intro hzero
+    have hentry := congrFun (congrFun hzero beta) gamma
+    rw [Matrix.zero_apply,
+      F.sectorVirtualMatrix_mul_apply k h x y u v beta gamma] at hentry
+    exact mul_ne_zero (mul_ne_zero hkleft heta) hhright hentry
+  obtain ⟨Y, htraceY⟩ : ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace (A * B * Y) ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    exact hAB ((Matrix.trace_mul_right_eq_zero_iff (A * B)).mp hall)
+  have hYmem : Y ∈ Submodule.span ℂ
+      (Set.range (F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight)) := by
+    rw [F.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top hK]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ :=
+    (Submodule.mem_span_range_iff_exists_fun ℂ).mp hYmem
+  have hsum : Matrix.trace
+      (A * B * ∑ q, c q •
+        F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) ≠ 0 := by
+    rw [hc]
+    exact htraceY
+  simp only [Matrix.mul_sum, Matrix.mul_smul, Matrix.trace_sum,
+    Matrix.trace_smul] at hsum
+  obtain ⟨q, hq⟩ : ∃ q : F.ActiveSectorEntryIndex F.cyclicActiveWeight,
+      c q * Matrix.trace
+        (A * B * F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) ≠ 0 := by
+    by_contra hall
+    push Not at hall
+    exact hsum (Finset.sum_eq_zero fun q _ ↦ hall q)
+  have htraceC : Matrix.trace
+      (A * B * F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) ≠ 0 :=
+    right_ne_zero_of_mul hq
+  have hBC : B * F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q ≠ 0 := by
+    intro hzero
+    apply htraceC
+    rw [← Matrix.trace_mul_cycle B
+      (F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q) A,
+      hzero, Matrix.zero_mul, Matrix.trace_zero]
+  have hCA : F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q * A ≠ 0 := by
+    intro hzero
+    apply htraceC
+    rw [Matrix.trace_mul_cycle A B
+      (F.activeSectorOneSiteMatrixFamily F.cyclicActiveWeight q),
+      hzero, Matrix.zero_mul, Matrix.trace_zero]
+  refine ⟨q.1, ?_, ?_⟩
+  · intro hzero
+    apply hBC
+    simpa [B, activeSectorOneSiteMatrixFamily] using
+      F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+        h q.1 hzero u v q.2.1 q.2.2
+  · intro hzero
+    apply hCA
+    simpa [A, activeSectorOneSiteMatrixFamily] using
+      F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
+        q.1 k hzero q.2.1 q.2.2 x y
+
+/-- The cyclic-active support is one strongly connected component when the
+tensor is injective and the neighboring operators are positive semidefinite. -/
+theorem cyclicActiveSectorTraceMatrix_isIrreducible
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    Matrix.IsIrreducible F.cyclicActiveSectorTraceMatrix :=
+  F.activeSectorTraceMatrix_isIrreducible F.cyclicActiveWeight hpos
+    (F.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top hK)
+    F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
+
+/-- Every cyclic-active sector has a positive length-two return weight. -/
+theorem cyclicActiveSectorTraceMatrix_pow_two_diag_pos
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (k : F.CyclicActiveSector) :
+    0 < (F.cyclicActiveSectorTraceMatrix ^ 2) k k :=
+  F.activeSectorTraceMatrix_pow_two_diag_pos F.cyclicActiveWeight hpos
+    (F.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top hK)
+    F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero k
+
+/-- Every cyclic-active sector has a positive length-three return weight. -/
+theorem cyclicActiveSectorTraceMatrix_pow_three_diag_pos
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (k : F.CyclicActiveSector) :
+    0 < (F.cyclicActiveSectorTraceMatrix ^ 3) k k :=
+  F.activeSectorTraceMatrix_pow_three_diag_pos F.cyclicActiveWeight hpos
+    (F.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top hK)
+    F.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
+    (fun hkh ↦ F.exists_cyclicActive_two_edge_return hK hkh) k
+
+/-- The trace matrix on cyclic-active sectors is primitive for an injective
+tensor with positive semidefinite neighboring operators.
+
+The proof first removes sectors whose virtual matrices vanish, then applies
+the directed-cut argument to obtain one strongly connected component.  The
+trace pairing supplies closed walks of lengths two and three, hence
+aperiodicity.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471;
+Beigi, arXiv:1105.1019v2, lines 449--514. -/
+theorem cyclicActiveSectorTraceMatrix_isPrimitive
+    (F : PhysicalSectorFactorization K) (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    Matrix.IsPrimitive F.cyclicActiveSectorTraceMatrix :=
+  (F.cyclicActiveSectorTraceMatrix_isIrreducible hK hpos)
+    |>.isPrimitive_of_pow_two_diagonal_pos_of_pow_three_diagonal_pos
+      (F.cyclicActiveSectorTraceMatrix_pow_two_diag_pos hK hpos)
+      (F.cyclicActiveSectorTraceMatrix_pow_three_diag_pos hK hpos)
+
+private theorem matrix_pow_eq_pow_two_of_pow_two_eq_pow_three
+    {I : Type*} [Fintype I] [DecidableEq I] (T : Matrix I I ℝ)
+    (h : T ^ 2 = T ^ 3) :
+    ∀ m, 2 ≤ m → T ^ m = T ^ 2 := by
+  classical
+  have hmul : T * T = T * T * T := by
+    have e3 : T ^ 3 = T * T * T := by rw [pow_succ, pow_two]
+    rw [pow_two, e3] at h
+    exact h
+  intro m hm
+  induction m, hm using Nat.le_induction with
+  | base => rfl
+  | succ m _ ih =>
+      rw [pow_succ, ih]
+      calc
+        T ^ 2 * T = T * T * T := by rw [pow_two]
+        _ = T * T := hmul.symm
+        _ = T ^ 2 := (pow_two T).symm
+
+private theorem isPrimitive_smul_of_pos
+    {I : Type*} [Fintype I] [DecidableEq I]
+    {T : Matrix I I ℝ} (hT : Matrix.IsPrimitive T)
+    {c : ℝ} (hc : 0 < c) :
+    Matrix.IsPrimitive (c • T) := by
+  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
+  refine ⟨fun i j ↦ mul_nonneg hc.le (hT.nonneg i j), m, hm, ?_⟩
+  intro i j
+  rw [smul_pow, Matrix.smul_apply]
+  exact mul_pos (pow_pos hc m) (hpos i j)
+
+private theorem rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
+    {I : Type*} [Fintype I] [DecidableEq I] [Nonempty I]
+    {T : Matrix I I ℝ} (hprimitive : Matrix.IsPrimitive T)
+    (hpow : T ^ 2 = T ^ 3) :
+    (T ^ 2).rank = 1 := by
+  obtain ⟨m, hm, hmpos⟩ := hprimitive.exists_pos_pow
+  have htwom_pos (i j : I) : 0 < (T ^ (m + m)) i j := by
+    rw [pow_add, Matrix.mul_apply]
+    exact Finset.sum_pos (fun k _ ↦ mul_pos (hmpos i k) (hmpos k j))
+      Finset.univ_nonempty
+  have hsq_pos (i j : I) : 0 < (T ^ 2) i j := by
+    have heq := matrix_pow_eq_pow_two_of_pow_two_eq_pow_three
+      T hpow (m + m) (by omega)
+    have hentry := congrFun (congrFun heq i) j
+    exact hentry ▸ htwom_pos i j
+  have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
+    rw [← pow_add]
+    exact matrix_pow_eq_pow_two_of_pow_two_eq_pow_three T hpow 4 (by omega)
+  exact Matrix.rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
+
+/-- If the normalized cyclic-active trace matrix satisfies the source-ZCL
+square--cube relation, then its square has rank one. -/
+theorem cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
+    (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hpow : F.cyclicActiveSectorTraceMatrix ^ 2 =
+      F.cyclicActiveSectorTraceMatrix ^ 3) :
+    (F.cyclicActiveSectorTraceMatrix ^ 2).rank = 1 := by
+  classical
+  letI : Nonempty F.CyclicActiveSector := F.nonempty_cyclicActiveSector hK
+  exact rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
+    (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos) hpow
+
+/-- A positive source normalization of the cyclic-active trace matrix has
+rank-one square whenever it satisfies the source-ZCL square--cube relation. -/
+theorem normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
+    (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    {lam : ℝ} (hlam : 0 < lam)
+    (hpow : (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2 =
+      (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 3) :
+    ((lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2).rank = 1 := by
+  classical
+  letI : Nonempty F.CyclicActiveSector := F.nonempty_cyclicActiveSector hK
+  apply rank_pow_two_eq_one_of_isPrimitive_of_pow_two_eq_pow_three
+    (isPrimitive_smul_of_pos
+      (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos) (inv_pos.mpr hlam))
+  exact hpow
 
 private theorem reflTransGen_iterate_map
     {V W : Type*} (r : W → W → Prop) (step : V → V) (f : V → W)

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.InverseMapActiveSectorPrimitivity
-import TNLean.MPS.MPDO.SectorPairingTransfer
+import TNLean.MPS.MPDO.ActiveSectorTraceMatrixZCL
 
 /-!
 # Zero correlation length on the active inverse-map trace matrix
@@ -37,117 +37,6 @@ neighboring operators are positive semidefinite.
 -/
 
 open scoped Matrix ComplexOrder BigOperators
-
-namespace MPOTensor.PhysicalSectorFactorization
-
-variable {d D : ℕ} {K : MPOTensor d D}
-
-/-- Suppose that the left tensor vanishes in every sector of zero weight and
-that all neighboring operators are positive semidefinite.  If the original
-tensor has source zero correlation length, then one positive normalization of
-the active trace matrix satisfies
-\[
-  \widehat T^2=\widehat T^3,
-  \qquad
-  \operatorname{tr}(\widehat T^N)=\operatorname{tr}(\widehat T)
-  \quad (N\geq 1).
-\]
-
-The proof restricts the rectangular decomposition of the physical-trace
-transfer to the nonzero-weight sectors.  Positivity identifies the opposite
-rectangular product with the complexification of the real active trace
-matrix.
-
-Source: arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`,
-lines 1473--1497.  The conclusion does not assert idempotence, rank one, or
-semisimplicity of the trace matrix. -/
-theorem activeSectorTraceMatrix_normalized_relations_of_isSourceZCL
-    (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
-    (hinactive : ∀ k, p k = 0 → ∀ beta, F.leftTensor k beta = 0)
-    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
-    (hZCL : K.IsSourceZCL) :
-    ∃ lam : ℝ, 0 < lam ∧
-      let T := F.activeSectorTraceMatrix p
-      ((lam⁻¹ • T) ^ 2 = (lam⁻¹ • T) ^ 3) ∧
-        ∀ N : ℕ, 0 < N →
-          Matrix.trace ((lam⁻¹ • T) ^ N) = Matrix.trace (lam⁻¹ • T) := by
-  classical
-  obtain ⟨lam, hlam, hidem⟩ := hZCL.normalized_idempotent
-  let L : Matrix (Fin D) (F.ActiveSector p) ℂ :=
-    fun beta h ↦ (F.leftTensor h beta).trace
-  let Q : Matrix (F.ActiveSector p) (Fin D) ℂ :=
-    fun k alpha ↦ (F.rightTensor k alpha).trace
-  have hphys : MPOTensor.physTraceTransfer K = L * Q := by
-    let U : Matrix.unitaryGroup (Fin d) ℂ := ⟨F.physicalIsometry, by
-      rw [Matrix.mem_unitaryGroup_iff', Matrix.star_eq_conjTranspose]
-      exact F.physicalIsometry_isometry⟩
-    have hfactor : ∀ beta alpha,
-        Matrix.reindex F.sectorEquiv F.sectorEquiv
-            ((U : Matrix (Fin d) (Fin d) ℂ) * MPOTensor.physicalSlice K beta alpha *
-              (U : Matrix (Fin d) (Fin d) ℂ)ᴴ) =
-          Matrix.blockDiagonal' fun q ↦
-            Matrix.kroneckerMap (· * ·) (F.leftTensor q beta) (F.rightTensor q alpha) := by
-      simpa [U] using F.factorization
-    rw [MPOTensor.physTraceTransfer_eq_sum_closedSector K F.sectorEquiv U
-      F.leftTensor F.rightTensor hfactor]
-    ext beta alpha
-    simp only [MPOTensor.closedSectorPairingOperator, Matrix.sum_apply,
-      Matrix.vecMulVec_apply, Matrix.mul_apply, L, Q]
-    rw [← Finset.sum_subtype (Finset.univ.filter (fun k ↦ p k ≠ 0)) (by simp)
-      (fun k ↦ (F.leftTensor k beta).trace * (F.rightTensor k alpha).trace)]
-    rw [Finset.sum_filter]
-    apply Finset.sum_congr rfl
-    intro k _
-    by_cases hk : p k ≠ 0
-    · simp [hk]
-    · rw [if_neg hk, hinactive k (not_ne_iff.mp hk) beta, Matrix.trace_zero, zero_mul]
-  have hrect : IsIdempotentElem (((lam : ℂ)⁻¹ • L) * Q) := by
-    simpa only [Matrix.smul_mul, ← hphys] using hidem
-  let TC : Matrix (F.ActiveSector p) (F.ActiveSector p) ℂ := Q * L
-  have hTC : TC = Matrix.map (F.activeSectorTraceMatrix p) Complex.ofReal := by
-    ext k h
-    simp only [TC, Matrix.mul_apply, Q, L, Matrix.map_apply]
-    change (∑ j, (F.rightTensor (k : Fin F.sectorCount) j).trace *
-      (F.leftTensor (h : Fin F.sectorCount) j).trace) =
-        ((F.neighboringOperator k h).trace.re : ℂ)
-    rw [← (hpos k h).isHermitian.trace_eq_ofReal_re]
-    simp only [neighboringOperator, Matrix.trace, Matrix.diag, Matrix.of_apply]
-    rw [Finset.sum_comm]
-    apply Finset.sum_congr rfl
-    intro j _
-    rw [Finset.mul_sum]
-    rw [Fintype.sum_prod_type]
-    simp_rw [Finset.sum_mul]
-    rw [Finset.sum_comm]
-  refine ⟨lam, hlam, ?_⟩
-  dsimp only
-  have hmap : Matrix.map (lam⁻¹ • F.activeSectorTraceMatrix p) Complex.ofReal =
-      (lam : ℂ)⁻¹ • TC := by
-    rw [hTC]
-    ext k h
-    simp [Matrix.smul_apply, Matrix.map_apply]
-  have hmapHom :
-      Matrix.map (lam⁻¹ • F.activeSectorTraceMatrix p) (⇑Complex.ofRealHom) =
-        (lam : ℂ)⁻¹ • TC := hmap
-  constructor
-  · apply Matrix.map_injective Complex.ofReal_injective
-    change Matrix.map ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ 2) (⇑Complex.ofRealHom) =
-      Matrix.map ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ 3) (⇑Complex.ofRealHom)
-    rw [Matrix.map_pow, Matrix.map_pow, hmapHom]
-    simpa only [Matrix.mul_smul, TC] using
-      (Matrix.pow_two_eq_pow_three_of_rectangular_idempotent
-        ((lam : ℂ)⁻¹ • L) Q hrect)
-  · intro N hN
-    apply Complex.ofReal_injective
-    change Complex.ofRealHom (Matrix.trace ((lam⁻¹ • F.activeSectorTraceMatrix p) ^ N)) =
-      Complex.ofRealHom (Matrix.trace (lam⁻¹ • F.activeSectorTraceMatrix p))
-    rw [AddMonoidHom.map_trace Complex.ofRealHom,
-      AddMonoidHom.map_trace Complex.ofRealHom, Matrix.map_pow, hmapHom]
-    simpa only [Matrix.mul_smul, TC] using
-      (Matrix.trace_pow_eq_trace_of_rectangular_idempotent
-        ((lam : ℂ)⁻¹ • L) Q hrect N hN)
-
-end MPOTensor.PhysicalSectorFactorization
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
+++ b/TNLean/MPS/MPDO/InverseMapActiveSectorZCL.lean
@@ -20,9 +20,6 @@ neighboring operators are positive semidefinite.
 
 ## Main results
 
-* `PhysicalSectorFactorization.activeSectorTraceMatrix_normalized_relations_of_isSourceZCL`:
-  source zero correlation length gives normalized square--cube and trace-power
-  relations on the active trace matrix of a positive sector factorization.
 * `exists_rephased_inverseMap_activeSectorTraceMatrix_normalized_relations`:
   the inverse-map construction has one rephasing for which positivity,
   primitivity, and both normalized relations hold.

--- a/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorSupportRecurrence.lean
@@ -84,26 +84,34 @@ def sectorVirtualMatrixFamily (F : PhysicalSectorFactorization K)
   F.sectorVirtualMatrix q.1 q.2.1 q.2.2
 
 /-- Suppose the sector virtual matrices span the full virtual matrix algebra
-and both endpoint sectors of every nonzero neighboring edge contain a nonzero
-virtual matrix. Then every nonzero edge `k → h` has a two-edge return
+and the endpoint sectors of a nonzero neighboring edge contain nonzero
+virtual matrices. Then that edge `k → h` has a two-edge return
 `h → j → k`.
 
 Indeed, a nonzero neighboring entry gives sector matrices `A` and `B` with
 `A * B ≠ 0`. Nondegeneracy of the trace pairing and the spanning hypothesis
 give a sector matrix `C` with `trace (A * B * C) ≠ 0`. Cyclicity of the trace
-then forces both `B * C` and `C * A` to be nonzero. -/
-theorem exists_two_edge_return_of_neighboringOperator_ne_zero
+then forces both `B * C` and `C * A` to be nonzero.
+
+Source: arXiv:1606.00608, Appendix C.2, proof of Lemma `propSN`,
+lines 1451--1471.
+
+**Local fix (triangle closure):** The explicit two-edge return replaces the
+blocking assertion in the source. See
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem exists_two_edge_return_of_neighboringOperator_ne_zero_of_endpoints
     (F : PhysicalSectorFactorization K)
     (hspan : Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤)
-    (hnonzero : ∀ {k h}, F.neighboringOperator k h ≠ 0 →
-      (∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0) ∧
-        ∃ x y : F.SectorIndex h, F.sectorVirtualMatrix h x y ≠ 0)
-    {k h : Fin F.sectorCount} (hkh : F.neighboringOperator k h ≠ 0) :
+    {k h : Fin F.sectorCount}
+    (hk : ∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0)
+    (hh : ∃ x y : F.SectorIndex h, F.sectorVirtualMatrix h x y ≠ 0)
+    (hkh : F.neighboringOperator k h ≠ 0) :
     ∃ j : Fin F.sectorCount,
       F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0 := by
   classical
   obtain ⟨ex, ey, heta⟩ := Matrix.exists_entry_ne_zero_of_ne_zero _ hkh
-  obtain ⟨⟨kx, ky, hkxy⟩, ⟨hx, hy, hhxy⟩⟩ := hnonzero hkh
+  obtain ⟨kx, ky, hkxy⟩ := hk
+  obtain ⟨hx, hy, hhxy⟩ := hh
   obtain ⟨beta, alpha, hkentry⟩ :=
     Matrix.exists_entry_ne_zero_of_ne_zero _ hkxy
   have hkleft : F.leftTensor k beta kx.1 ky.1 ≠ 0 :=
@@ -166,6 +174,30 @@ theorem exists_two_edge_return_of_neighboringOperator_ne_zero
   · intro hz
     exact hCA (F.sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero
       q.1 k hz q.2.1 q.2.2 x y)
+
+/-- Suppose the sector virtual matrices span the full virtual matrix algebra
+and both endpoint sectors of every nonzero neighboring edge contain a nonzero
+virtual matrix. Then every nonzero edge `k → h` has a two-edge return
+`h → j → k`.
+
+Source: arXiv:1606.00608, Appendix C.2, proof of Lemma `propSN`,
+lines 1451--1471.
+
+**Local fix (triangle closure):** The explicit two-edge return replaces the
+blocking assertion in the source. See
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
+theorem exists_two_edge_return_of_neighboringOperator_ne_zero
+    (F : PhysicalSectorFactorization K)
+    (hspan : Submodule.span ℂ (Set.range F.sectorVirtualMatrixFamily) = ⊤)
+    (hnonzero : ∀ {k h}, F.neighboringOperator k h ≠ 0 →
+      (∃ x y : F.SectorIndex k, F.sectorVirtualMatrix k x y ≠ 0) ∧
+        ∃ x y : F.SectorIndex h, F.sectorVirtualMatrix h x y ≠ 0)
+    {k h : Fin F.sectorCount} (hkh : F.neighboringOperator k h ≠ 0) :
+    ∃ j : Fin F.sectorCount,
+      F.neighboringOperator h j ≠ 0 ∧ F.neighboringOperator j k ≠ 0 := by
+  obtain ⟨hk, hh⟩ := hnonzero hkh
+  exact F.exists_two_edge_return_of_neighboringOperator_ne_zero_of_endpoints
+    hspan hk hh hkh
 
 /-- Under the spanning and endpoint-nonvanishing hypotheses, the terminal
 sector of every nonzero neighboring edge reaches its initial sector through

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -870,10 +870,11 @@
     positive-length directed cycles, in the sense of
     \cite[Section~III]{Beigi2012Classification}.  Define
     \[
-        T_{k,h}=\tr(\eta_{k,h})\qquad(k,h\in C).
+        T_{k,h}=\operatorname{Re}\tr(\eta_{k,h})\qquad(k,h\in C).
     \]
-    For positive semidefinite neighboring operators,
-    $T_{k,h}>0$ is equivalent to $\eta_{k,h}\ne0$.
+    For positive semidefinite neighboring operators the trace is real, so
+    $T_{k,h}=\tr(\eta_{k,h})$, and $T_{k,h}>0$ is equivalent to
+    $\eta_{k,h}\ne0$.
 \end{definition}
 
 % **Local fix (cyclic-active restriction):** this theorem concerns the restricted
@@ -986,16 +987,9 @@
         (\widehat T^2)_{k,h}
         =\sum_{q\in C}\widehat T_{k,q}\widehat T_{q,h}
     \]
-    obtained from two successive fully traced neighboring operators.  In the
-    argument of
-    \cite[Appendix~C.2, lines~1606--1616]{Cirac2016MPDO_arXiv}, it enters after
-    applying the zero-correlation-length marginal replacement once more than
-    at line~1613 and tracing three boundary sites.  The conditional
-    two-boundary formula in
-    Theorem~\ref{thm:mpdo_eta_fourth_region_trace_formula} instead contains
-    $\widehat T$ itself.  The assertion therefore neither identifies these
-    two coefficients nor implies that the unreduced Beigi trace matrix is
-    primitive or rank one.
+    by matrix multiplication.  The assertion neither identifies
+    $\widehat T$ with $\widehat T^2$ nor implies that the unreduced Beigi trace
+    matrix is primitive or rank one.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1006,11 +1000,20 @@
     $\widehat T^2=\widehat T^3$ on the restricted indices.  By
     Theorem~\ref{thm:mpdo_cyclic_active_trace_matrix_primitive},
     $\widehat T$ is primitive.  Its square is therefore a strictly positive
-    idempotent matrix and has rank one.  To use this factorization in the
-    fourth-region argument, apply the marginal replacement one further time,
-    so that the fully traced middle segment contributes $\widehat T^2$ rather
-    than $\widehat T$.
+    idempotent matrix and has rank one.
 \end{proof}
+
+% Tracked in https://github.com/LionSR/TNLean/issues/4445.
+\begin{remark}[Open three-boundary identification]
+    \notready
+    The remaining physical step is to apply the zero-correlation-length
+    marginal replacement one further time than at line~1613 of
+    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}, express the trace of three
+    boundary sites in the cyclic-active sector coordinates, and prove that
+    the fully traced middle segment contributes $\widehat T^2$.  This must be
+    done without identifying $\widehat T$ with $\widehat T^2$ or the
+    cyclic-active matrix with the unreduced Beigi matrix.
+\end{remark}
 
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -843,12 +843,17 @@
     trace matrix is primitive.
 \end{proof}
 
+% **Local fix (cyclic-active restriction):** CPSV16 Lemma `propSN` assumes SAL.
+% The following restricted construction repairs the arbitrary-factorization obstruction.
+% See docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{definition}[Cyclic-active sectors]
     \label{def:mpdo_cyclic_active_sector}
-    \lean{MPOTensor.PhysicalSectorFactorization.IsCyclicActiveSector,
-      MPOTensor.PhysicalSectorFactorization.cyclicActiveWeight,
-      MPOTensor.PhysicalSectorFactorization.CyclicActiveSector,
-      MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.IsCyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveWeight}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveWeight_ne_zero_iff}
+    \lean{MPOTensor.PhysicalSectorFactorization.CyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperator_trace_re_pos_iff}
     \leanok
     \uses{def:mpdo_physical_sector_factorization,
       def:mpdo_minimal_neighboring_operator}
@@ -860,8 +865,10 @@
     \]
     where $\leadsto$ denotes reachability by nonzero neighboring operators.
     The first edge $k\to h$ is explicit, so the resulting closed walk has
-    positive length even when the return path is empty.  Let $C$ be the set
-    of retained sectors and define
+    positive length even when the return path is empty.  The set $C$ of
+    retained sectors is therefore exactly the set of vertices occurring in
+    positive-length directed cycles, in the sense of
+    \cite[Section~III]{Beigi2012Classification}.  Define
     \[
         T_{k,h}=\tr(\eta_{k,h})\qquad(k,h\in C).
     \]
@@ -869,16 +876,16 @@
     $T_{k,h}>0$ is equivalent to $\eta_{k,h}\ne0$.
 \end{definition}
 
+% **Local fix (cyclic-active restriction):** this theorem concerns the restricted
+% cyclic support, not the full trace matrix in CPSV16 Lemma `propSN`. See
+% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{theorem}[Deletion of sectors absent from cyclic products]
     \label{thm:mpdo_cyclic_active_deletion}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      neighboringOperator_ne_zero_of_cyclicNeighboringProduct_ne_zero}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      isCyclicActiveSector_of_cyclicNeighboringProduct_ne_zero}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.isCyclicActiveSector_of_cyclic_edges}
+    \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperator_ne_zero_of_cyclicNeighboringProduct_ne_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.isCyclicActiveSector_of_cyclicNeighboringProduct_ne_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector}
     \leanok
     \uses{def:mpdo_cyclic_active_sector,
       def:mpdo_physical_sector_chain_coordinates}
@@ -898,19 +905,22 @@
     path to $k_n$.  Hence every $k_n$ belongs to $C$.
 \end{proof}
 
+% **Local fix (cyclic-active restriction):** this is a restricted replacement for
+% the primitive-matrix step of the SAL-dependent CPSV16 Lemma `propSN`. See
+% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{theorem}[Primitivity on cyclic-active sectors]
     \label{thm:mpdo_cyclic_active_trace_matrix_primitive}
+    \lean{MPOTensor.PhysicalSectorFactorization.exists_sectorVirtualMatrix_ne_zero_of_isCyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix_eq_zero_of_not_isCyclicActiveSector}
     \lean{MPOTensor.PhysicalSectorFactorization.nonempty_cyclicActiveSector}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicActiveSectorOneSiteMatrixFamily_span_eq_top}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicActiveSectorTraceMatrix_isIrreducible}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicActiveSectorTraceMatrix_pow_two_diag_pos}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicActiveSectorTraceMatrix_pow_three_diag_pos}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicActiveSectorTraceMatrix_isPrimitive}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorOneSiteMatrixFamily_span_eq_top}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.exists_cyclicActive_two_edge_return}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix_isIrreducible}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix_pow_two_diag_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix_pow_three_diag_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix_isPrimitive}
     \leanok
     \uses{def:injective, def:mpdo_cyclic_active_sector}
     Suppose that the virtual dimension is positive, the MPO tensor is
@@ -940,15 +950,24 @@
     the coprime return lengths imply primitivity.
 \end{proof}
 
+% **Local fix (cyclic-active restriction):** CPSV16 line 1613 uses the one-step
+% coefficient, whereas this restricted theorem proves rank one for its square.
+% See docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{theorem}[Rank-one cyclic-active two-step coefficient]
     \label{thm:mpdo_cyclic_active_zcl_rank_one}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL}
-    \lean{MPOTensor.PhysicalSectorFactorization.%
-      exists_normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one_of_isSourceZCL}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveLeftRestriction}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveLeftRestriction_leftTensor}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveLeftRestriction_rightTensor}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveLeftRestriction_neighboringOperator}
+    \lean{MPOTensor.PhysicalSectorFactorization.reindex_cyclicActiveLeftRestriction_activeSectorTraceMatrix}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL}
+    \lean{MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one}
+    \lean{MPOTensor.PhysicalSectorFactorization.normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one}
+    \lean{MPOTensor.PhysicalSectorFactorization.exists_normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one_of_isSourceZCL}
     \leanok
     \uses{def:mpo_source_zcl,
-      thm:mpdo_cyclic_active_trace_matrix_primitive}
+      thm:mpdo_cyclic_active_trace_matrix_primitive,
+      thm:matrix_primitive_pow_two_rank_one}
     Under the hypotheses of
     Theorem~\ref{thm:mpdo_cyclic_active_trace_matrix_primitive}, suppose that
     the physical-trace transfer has source zero correlation length.  There is

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -937,18 +937,36 @@
 
 \begin{proof}\leanok
     The virtual matrices of all physical sectors span the full matrix
-    algebra.  Nondegeneracy and cyclicity of the trace pairing show that a
-    sector containing a nonzero virtual matrix lies on a directed two-cycle.
-    Hence every virtual matrix outside $C$ vanishes, and the virtual matrices
-    belonging to $C$ still span the full algebra.
+    algebra.  If $A=A_k^{xy}$ is nonzero, nondegeneracy of the trace pairing
+    gives a virtual matrix $B=A_q^{uv}$ such that
+    \[
+        \tr(AB)\ne0.
+    \]
+    Cyclicity gives $\tr(BA)=\tr(AB)\ne0$, and therefore
+    \[
+        \eta_{k,q}\ne0,
+        \qquad
+        \eta_{q,k}\ne0.
+    \]
+    Thus a sector containing a nonzero virtual matrix lies on a directed
+    two-cycle.  Hence every virtual matrix outside $C$ vanishes, and the
+    virtual matrices belonging to $C$ still span the full algebra.
 
-    If a proper directed cut separated two nonempty subsets of $C$, the
-    corresponding nonzero virtual matrix spaces would multiply to zero while
-    their sum was the full matrix algebra, a contradiction.  Thus $T$ is
-    irreducible.  The same trace pairing gives a two-edge return through each
-    sector and closes every retained edge through a third retained sector.
-    These yield the displayed positive diagonal entries of $T^2$ and $T^3$;
-    the coprime return lengths imply primitivity.
+    If a proper directed cut separated two nonempty subsets $C_1,C_2$ of
+    $C$, let $V_{C_i}$ denote the span of the virtual matrices in $C_i$.
+    Absence of an edge across the cut gives
+    \[
+        V_{C_1}V_{C_2}=\{0\},
+        \qquad
+        V_{C_1}+V_{C_2}=M_D(\mathbb C).
+    \]
+    Both spaces contain a nonzero matrix.  This contradicts the one-sided
+    product obstruction for two nonzero subspaces whose sum is the full
+    matrix algebra.  Thus $T$ is irreducible.  The same trace pairing gives a
+    two-edge return through each sector and closes every retained edge
+    through a third retained sector.  These yield the displayed positive
+    diagonal entries of $T^2$ and $T^3$; the coprime return lengths imply
+    primitivity.
 \end{proof}
 
 % **Local fix (cyclic-active restriction):** CPSV16 line 1613 uses the one-step
@@ -996,8 +1014,9 @@
     Set the left sector tensor equal to zero outside $C$.  The preceding span
     argument shows that this does not change the physical tensor, and the
     neighboring operators with both indices in $C$ are unchanged.  The
-    normalized physical-trace identity gives
-    $\widehat T^2=\widehat T^3$ on the restricted indices.  By
+    source zero-correlation-length relation, transported through this
+    restricted factorization, gives
+    $\widehat T^2=\widehat T^3$ on the cyclic-active indices.  By
     Theorem~\ref{thm:mpdo_cyclic_active_trace_matrix_primitive},
     $\widehat T$ is primitive.  Its square is therefore a strictly positive
     idempotent matrix and has rank one.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -843,6 +843,156 @@
     trace matrix is primitive.
 \end{proof}
 
+\begin{definition}[Cyclic-active sectors]
+    \label{def:mpdo_cyclic_active_sector}
+    \lean{MPOTensor.PhysicalSectorFactorization.IsCyclicActiveSector,
+      MPOTensor.PhysicalSectorFactorization.cyclicActiveWeight,
+      MPOTensor.PhysicalSectorFactorization.CyclicActiveSector,
+      MPOTensor.PhysicalSectorFactorization.cyclicActiveSectorTraceMatrix}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator}
+    For a physical-sector factorization with neighboring operators
+    $\eta_{k,h}$, retain a sector $k$ when there is a sector $h$ such that
+    \[
+        \eta_{k,h}\ne0,
+        \qquad h\leadsto k,
+    \]
+    where $\leadsto$ denotes reachability by nonzero neighboring operators.
+    The first edge $k\to h$ is explicit, so the resulting closed walk has
+    positive length even when the return path is empty.  Let $C$ be the set
+    of retained sectors and define
+    \[
+        T_{k,h}=\tr(\eta_{k,h})\qquad(k,h\in C).
+    \]
+    For positive semidefinite neighboring operators,
+    $T_{k,h}>0$ is equivalent to $\eta_{k,h}\ne0$.
+\end{definition}
+
+\begin{theorem}[Deletion of sectors absent from cyclic products]
+    \label{thm:mpdo_cyclic_active_deletion}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      neighboringOperator_ne_zero_of_cyclicNeighboringProduct_ne_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      isCyclicActiveSector_of_cyclicNeighboringProduct_ne_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector}
+    \leanok
+    \uses{def:mpdo_cyclic_active_sector,
+      def:mpdo_physical_sector_chain_coordinates}
+    Let $N\geq1$ and let $k=(k_0,\ldots,k_{N-1})$ be a cyclic sector
+    configuration.  If $k_n\notin C$ for some $n$, then
+    \[
+        \Omega_k=0.
+    \]
+    Thus deleting the sectors outside $C$ leaves every finite cyclic
+    neighboring product unchanged.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $\Omega_k\ne0$, each factor $\eta_{k_n,k_{n+1}}$ is nonzero; otherwise
+    every matrix entry of the product vanishes.  Starting with the edge
+    $k_n\to k_{n+1}$ and following the remaining cyclic edges gives a return
+    path to $k_n$.  Hence every $k_n$ belongs to $C$.
+\end{proof}
+
+\begin{theorem}[Primitivity on cyclic-active sectors]
+    \label{thm:mpdo_cyclic_active_trace_matrix_primitive}
+    \lean{MPOTensor.PhysicalSectorFactorization.nonempty_cyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicActiveSectorOneSiteMatrixFamily_span_eq_top}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicActiveSectorTraceMatrix_isIrreducible}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicActiveSectorTraceMatrix_pow_two_diag_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicActiveSectorTraceMatrix_pow_three_diag_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicActiveSectorTraceMatrix_isPrimitive}
+    \leanok
+    \uses{def:injective, def:mpdo_cyclic_active_sector}
+    Suppose that the virtual dimension is positive, the MPO tensor is
+    injective, and every $\eta_{k,h}$ is positive semidefinite.  Then $C$ is
+    nonempty and the matrix $T$ is primitive.  More precisely, $T$ is
+    irreducible and every $k\in C$ satisfies
+    \[
+        (T^2)_{k,k}>0,
+        \qquad
+        (T^3)_{k,k}>0.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The virtual matrices of all physical sectors span the full matrix
+    algebra.  Nondegeneracy and cyclicity of the trace pairing show that a
+    sector containing a nonzero virtual matrix lies on a directed two-cycle.
+    Hence every virtual matrix outside $C$ vanishes, and the virtual matrices
+    belonging to $C$ still span the full algebra.
+
+    If a proper directed cut separated two nonempty subsets of $C$, the
+    corresponding nonzero virtual matrix spaces would multiply to zero while
+    their sum was the full matrix algebra, a contradiction.  Thus $T$ is
+    irreducible.  The same trace pairing gives a two-edge return through each
+    sector and closes every retained edge through a third retained sector.
+    These yield the displayed positive diagonal entries of $T^2$ and $T^3$;
+    the coprime return lengths imply primitivity.
+\end{proof}
+
+\begin{theorem}[Rank-one cyclic-active two-step coefficient]
+    \label{thm:mpdo_cyclic_active_zcl_rank_one}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      exists_normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one_of_isSourceZCL}
+    \leanok
+    \uses{def:mpo_source_zcl,
+      thm:mpdo_cyclic_active_trace_matrix_primitive}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_cyclic_active_trace_matrix_primitive}, suppose that
+    the physical-trace transfer has source zero correlation length.  There is
+    a number $\lambda>0$ such that, with $\widehat T=\lambda^{-1}T$,
+    \[
+        \widehat T^2=\widehat T^3,
+        \qquad
+        \rank(\widehat T^2)=1,
+    \]
+    and for every $m\geq1$,
+    \[
+        \tr(\widehat T^m)=\tr(\widehat T).
+    \]
+    The matrix $\widehat T^2$ is the two-step coefficient
+    \[
+        (\widehat T^2)_{k,h}
+        =\sum_{q\in C}\widehat T_{k,q}\widehat T_{q,h}
+    \]
+    obtained from two successive fully traced neighboring operators.  In the
+    argument of
+    \cite[Appendix~C.2, lines~1606--1616]{Cirac2016MPDO_arXiv}, it enters after
+    applying the zero-correlation-length marginal replacement once more than
+    at line~1613 and tracing three boundary sites.  The conditional
+    two-boundary formula in
+    Theorem~\ref{thm:mpdo_eta_fourth_region_trace_formula} instead contains
+    $\widehat T$ itself.  The assertion therefore neither identifies these
+    two coefficients nor implies that the unreduced Beigi trace matrix is
+    primitive or rank one.
+\end{theorem}
+
+\begin{proof}\leanok
+    Set the left sector tensor equal to zero outside $C$.  The preceding span
+    argument shows that this does not change the physical tensor, and the
+    neighboring operators with both indices in $C$ are unchanged.  The
+    normalized physical-trace identity gives
+    $\widehat T^2=\widehat T^3$ on the restricted indices.  By
+    Theorem~\ref{thm:mpdo_cyclic_active_trace_matrix_primitive},
+    $\widehat T$ is primitive.  Its square is therefore a strictly positive
+    idempotent matrix and has rank one.  To use this factorization in the
+    fourth-region argument, apply the marginal replacement one further time,
+    so that the fully traced middle segment contributes $\widehat T^2$ rather
+    than $\widehat T$.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_rephasing.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_closed_sector_rephasing.tex
@@ -749,6 +749,8 @@ This is the contraction in
     \lean{MPOTensor.PhysicalSectorFactorization.sectorVirtualMatrix_mul_apply}
     \lean{MPOTensor.PhysicalSectorFactorization.%
       sectorVirtualMatrix_mul_eq_zero_of_neighboringOperator_eq_zero}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      exists_two_edge_return_of_neighboringOperator_ne_zero_of_endpoints}
     \lean{MPOTensor.PhysicalSectorFactorization.exists_two_edge_return_of_neighboringOperator_ne_zero}
     \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperator_reaches_of_ne_zero}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -747,11 +747,12 @@
 
 \begin{theorem}[Rank and factorization of a stationary primitive square]
     \label{thm:matrix_primitive_pow_two_rank_one}
+    \lean{Matrix.IsPrimitive.smul_of_pos}
     \lean{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}
     \lean{Matrix.IsPrimitive.exists_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three}
     \leanok
     Let $T$ be a primitive real $N\times N$ matrix, where
-    $N\geq 1$. If
+    $N\geq 1$.  Multiplication by a positive scalar preserves primitivity.  If
     \[
         T^2=T^3,
     \]

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -379,6 +379,64 @@ Lemma~2.1, which supplies only the direct-sum tensor-factor decomposition,
 must be supplemented by a source-faithful minimal or visible-sector selection
 before primitivity can be used.
 
+Such a visible-sector selection is now available without SAL.  A sector is
+called cyclic-active when it has an outgoing nonzero neighboring operator
+followed by a possibly empty return path.  The explicit first edge excludes
+the empty reflexive walk.  This is
+\leanid{MPOTensor.PhysicalSectorFactorization.IsCyclicActiveSector}.  Every
+nonzero finite cyclic neighboring product uses only cyclic-active sectors, and
+therefore deleting all other sectors leaves every finite cyclic bond product
+unchanged; see
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector}.
+
+For an injective tensor with positive semidefinite neighboring operators, the
+cyclic-active sectors are nonempty and their trace matrix is primitive.  The
+proof uses the nondegeneracy of the matrix trace pairing twice.  First, every
+nonzero virtual sector lies on a directed two-cycle, so all virtual matrices
+outside the cyclic-active set vanish and the retained virtual matrices still
+span the full matrix algebra.  The directed-cut argument then gives one
+strongly connected component.  Second, every retained sector has a return of
+length two, and every retained edge closes through a third retained sector;
+the resulting coprime return lengths give aperiodicity.  This is
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+cyclicActiveSectorTraceMatrix_isPrimitive}.  No inverse-map sector weights,
+SAL, or Hayashi decomposition occur in this argument.
+
+Source ZCL gives a positive normalization
+$\widehat T=\lambda^{-1}T$ of this restricted matrix satisfying
+\[
+  \widehat T^2=\widehat T^3,
+  \qquad \operatorname{rank}(\widehat T^2)=1,
+  \qquad
+  \tr(\widehat T^m)=\tr(\widehat T)\quad(m\geq1).
+\]
+The combined result is
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+exists_normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one_of_isSourceZCL}.
+It concerns the restricted matrix only.  In particular, it neither makes the
+unreduced trace matrix primitive nor asserts that $\widehat T$ itself has rank
+one.
+
+This last distinction determines how the new result can enter Proposition
+\emph{4to2}.  The two-boundary expression at source lines~1613--1616 contains
+the one-step coefficient $T_{q,h}=\tr(\eta_{q,h})$.  It does not contain
+$T^2$.  Applying the ZCL marginal replacement once further, and hence tracing
+three boundary sites of a chain longer by two sites, produces two successive
+fully traced middle edges.  Their coefficient is
+\[
+  (T^2)_{q,h}=\sum_{r\in C}
+    \tr(\eta_{q,r})\tr(\eta_{r,h}).
+\]
+Thus the proved rank-one statement supplies the separating boundary
+coefficient only in this three-boundary form.  What remains is to express the
+iterated marginal replacement in the physical-sector coordinates, carry the
+cyclic deletion through the two surviving partial traces, extract an explicit
+outer-product factorization of the restricted $\widehat T^2$, and construct
+the direct-sum Markov decomposition.  The present conditional theorem
+\leanid{Matrix.eta_fourth_region_trace_formula} still assumes a factorization
+of the one-step matrix and cannot be discharged directly by the new theorem.
+
 Consequently the source implication
 \[
   \text{one translation-invariant commuting bond}
@@ -442,28 +500,16 @@ implies SAL.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Replace the full Beigi sector set by a source-faithfully defined active
-restriction, formed without using SAL, and prove that normality leaves one
-aperiodic recurrent component.  The inactive-sector example above shows that
-an arbitrary nonminimal factorization is insufficient; it does not rule out an
-appropriate existential selection.  The active-sector construction presently
-used for the inverse-map factorization depends on SAL-derived sector weights
-and therefore cannot be invoked at this call site.
-
-For such an active restriction, one possible corrected route is to use the
-square of its trace matrix.  If a primitive nonnegative matrix $T$ satisfies
-$T^2=T^3$, then $T^2$ is an idempotent Perron projection of rank one.  This is
-formalized by
-\leanid{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}; the
-nonempty matrix convention is explicit, since primitivity is vacuous for the
-zero-dimensional matrix under the library definition.  The construction and
-primitivity of the required SAL-independent active restriction remain absent.
-Alternatively, replace the printed line-1613 argument by a direct Markov
-decomposition which does not require any rank-one trace matrix.
-\item Trace the fourth region, construct the quantum Markov decomposition at
-each admissible cut, and apply the all-cut Markov theorem.  Only then may the
-source proposition receive a formal declaration and a
-\texttt{\string\leanok} marker.
+\item Formalize the second iteration of the ZCL marginal replacement: replace
+the one-site boundary trace by a three-site trace of a chain longer by two
+sites, and identify its fully traced middle coefficient with the restricted
+matrix $\widehat T^2$.  The cyclic-active deletion theorem must also be carried
+through the two adjacent partial traces.
+\item Extract an explicit outer-product factorization of
+$\widehat T^2$, separate the two remaining boundary sector sums, and construct
+the quantum Markov decomposition at each admissible cut.
+\item Apply the all-cut Markov theorem.  Only then may the source proposition
+receive a formal declaration and a \texttt{\string\leanok} marker.
 \end{enumerate}
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
Closes #4364.

### Motivation

Issue #4315 shows that an arbitrary nonminimal Beigi factorization may retain an inactive sector, so its full trace matrix need not be primitive. The cyclic-active restriction removes precisely the sectors absent from every nonzero finite cyclic neighboring product, without assuming saturation of the area law, inverse-map weights, or a Hayashi decomposition.

### Description

For an injective physical-sector factorization with positive semidefinite neighboring operators, this pull request proves that:

- a cyclic neighboring product vanishes whenever its sector word contains an inactive sector;
- the virtual matrices outside cyclic-active support vanish, while the retained virtual matrices span the full matrix algebra;
- the restricted real trace matrix is irreducible and has positive returns at lengths two and three, hence is primitive;
- source zero correlation length gives a positive normalization satisfying
  \(\widehat T^2=\widehat T^3\) and constant positive-power traces;
- consequently \(\operatorname{rank}(\widehat T^2)=1\).

The general trace-reindexing, positive-scaling, stationary-power, and square-rank lemmas are placed in `TNLean/Algebra/`. The source-ZCL trace-matrix theorem is placed in the SAL-neutral module `TNLean/MPS/MPDO/ActiveSectorTraceMatrixZCL.lean`. The root import and the corresponding Chapter 21 entries are updated.

### Faithfulness and remaining gap

This is a marked local fix, not the SAL-dependent full-matrix assertion of CPSV16 Lemma `propSN`. The Lean docstrings, blueprint comments, and `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` state this restriction explicitly.

CPSV16 Proposition `4to2`, line 1613, uses the one-step coefficient \(T\), whereas the theorem proved here gives rank one for \(\widehat T^2\). The checked blueprint theorem is therefore algebraic only. The physical identification of \(\widehat T^2\) with the coefficient arising from a second marginal replacement is separated into a `\notready` remark and tracked by #4445. No identification of the restricted and unreduced Beigi matrices is asserted.

### Testing

Validated at exact head `71aa0e37a41843cfde0cb6d10f62a42dd3a678a0`:

- `lake build TNLean.MPS.MPDO.PhysicalSectorSupportRecurrence TNLean.MPS.MPDO.CyclicActiveSectorRestriction -q --log-level=info` — passed;
- `lake build TNLean -q --log-level=info` — passed;
- `leanblueprint checkdecls` — passed after refreshing the root import target;
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — passed;
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — passed;
- `python3 scripts/check_oversized_lean_files.py --root .` — passed;
- `python3 scripts/tactic_pattern_scan.py --top 20 --show-locations 5` — no repeated pattern involving the changed proofs;
- proof-integrity scan of every changed Lean file — no blocker or warning token in code;
- `git diff --check origin/main...HEAD` — passed.

GitHub CI is green at this exact head. The merge diff was also audited against current main `d884ba7921f8caae3072ab9025f8822081d5832b`; the worktree is clean and the pull request is mergeable.