### PR TITLE
feat(Channel/Schwarz): solve singular source resolvent

### DIFF
--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -25,6 +25,8 @@ reference matrix.
   of a positive-definite matrix is its ordinary inverse square root.
 * `Matrix.PosSemidef.supportInvSqrt_posSemidef`: the support inverse square
   root is positive semidefinite.
+* `Matrix.PosSemidef.supportInvSqrt_sq_mul_self`: the squared support inverse
+  square root is a generalized inverse on the support.
 * `Matrix.PosSemidef.supportInvSqrt_smul`: scaling by a positive real scalar.
 * `Matrix.PosSemidef.supportInvSqrt_kronecker_one`: compatibility with the
   unital left tensor embedding.
@@ -209,6 +211,41 @@ theorem PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt
           simpa [f, hi] using congrArg Complex.ofReal hreal
       unfold Matrix.IsHermitian.supportProj
       rw [Matrix.IsHermitian.cfc, Unitary.conjStarAlgAut_apply, hdiag]
+
+/-- The square of the support inverse square root is a generalized inverse:
+multiplying it by the original matrix gives the support projection.
+
+This is the generalized-inverse convention of Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 255--261. -/
+theorem PosSemidef.supportInvSqrt_sq_mul_self
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInvSqrt * hρ.supportInvSqrt * ρ =
+      hρ.isHermitian.supportProj := by
+  have hcomm : hρ.supportInvSqrt * ρ = ρ * hρ.supportInvSqrt := by
+    let f : ℝ → ℝ := fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
+    change hρ.isHermitian.cfc f * ρ = ρ * hρ.isHermitian.cfc f
+    have hid := hρ.isHermitian.cfc_id
+    calc
+      hρ.isHermitian.cfc f * ρ =
+          hρ.isHermitian.cfc f * hρ.isHermitian.cfc id :=
+        congrArg (hρ.isHermitian.cfc f * ·) hid.symm
+      _ = hρ.isHermitian.cfc (fun x ↦ f x * id x) :=
+        (hρ.isHermitian.cfc_mul f id).symm
+      _ = hρ.isHermitian.cfc (fun x ↦ id x * f x) := by
+        congr 1
+        funext x
+        ring
+      _ = hρ.isHermitian.cfc id * hρ.isHermitian.cfc f :=
+        hρ.isHermitian.cfc_mul id f
+      _ = ρ * hρ.isHermitian.cfc f :=
+        congrArg (· * hρ.isHermitian.cfc f) hid
+  calc
+    hρ.supportInvSqrt * hρ.supportInvSqrt * ρ =
+        hρ.supportInvSqrt * (hρ.supportInvSqrt * ρ) := Matrix.mul_assoc ..
+    _ = hρ.supportInvSqrt * (ρ * hρ.supportInvSqrt) := by rw [hcomm]
+    _ = hρ.supportInvSqrt * ρ * hρ.supportInvSqrt := (Matrix.mul_assoc ..).symm
+    _ = hρ.isHermitian.supportProj :=
+      hρ.supportInvSqrt_mul_self_mul_supportInvSqrt
 
 section PartialTrace
 

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -20,6 +20,8 @@ reference matrix is represented as the square of its support inverse square root
   vectorization.
 * `Matrix.supportRelativeModular_sqrt_mulVec_vec_one` evaluates the positive
   square root of the support relative-modular matrix on the vectorized identity.
+* `Matrix.supportRelativeModular_sourceB_solution` gives the canonical
+  support-domain solution of the singular source resolvent equation.
 * `Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq` turns a
   support-restricted common family of shifted resolvents into equality of
   support-restricted square-root ratios.
@@ -48,6 +50,75 @@ theorem one_kronecker_transpose_mulVec_vec_transpose
       Matrix.vec (M * P)ᵀ := by
   rw [Matrix.kronecker_mulVec_vec]
   simp only [Matrix.transpose_mul, Matrix.transpose_one, Matrix.mul_one]
+
+/-- The canonical support-domain vector built from the generalized relative
+modular resolvent solves the singular source equation.
+
+This is the algebraic source-side resolvent identity used in the equality
+argument of Jenčová--Ruskai, arXiv:0903.2895v4, lines 783--790, with the
+generalized inverse convention from lines 255--261. It does not derive a
+common resolvent from equality in data processing. -/
+theorem supportRelativeModular_sourceB_solution
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    let Bplus := hB.supportInvSqrt * hB.supportInvSqrt
+    let delta := A ⊗ₖ Bplusᵀ
+    let res := t • (1 : Matrix (n × n) (n × n) ℂ) + delta
+    let P := (1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ
+    let S := A ⊗ₖ (1 : Matrix n n ℂ) +
+      t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
+    S *ᵥ (P *ᵥ (res⁻¹ *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ)) =
+      Matrix.vec Bᵀ := by
+  dsimp only
+  let Bplus := hB.supportInvSqrt * hB.supportInvSqrt
+  let delta := A ⊗ₖ Bplusᵀ
+  let res := t • (1 : Matrix (n × n) (n × n) ℂ) + delta
+  let P := (1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ
+  let S := A ⊗ₖ (1 : Matrix n n ℂ) +
+    t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
+  let C := (1 : Matrix n n ℂ) ⊗ₖ Bᵀ
+  have hBplus : Bplus * B = hB.isHermitian.supportProj := by
+    simpa only [Bplus] using hB.supportInvSqrt_sq_mul_self
+  have hBplusPSD : Bplus.PosSemidef := by
+    simpa only [Bplus, hB.supportInvSqrt_isHermitian.eq] using
+      posSemidef_conjTranspose_mul_self hB.supportInvSqrt
+  have hdelta : delta.PosSemidef := hA.kronecker hBplusPSD.transpose
+  have hres : res.PosDef :=
+    (Matrix.PosDef.one.smul ht).add_posSemidef hdelta
+  letI : Invertible res := hres.isUnit.invertible
+  have hCdelta : C * delta =
+      A ⊗ₖ hB.isHermitian.supportProjᵀ := by
+    dsimp only [C, delta]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, hBplus]
+  have hBTP : Bᵀ * hB.isHermitian.supportProjᵀ = Bᵀ := by
+    rw [← Matrix.transpose_mul, hB.isHermitian.supportProj_mul_self]
+  have hSP : S * P = C * res := by
+    dsimp only [S, P, C, res]
+    rw [Matrix.add_mul, Matrix.smul_mul,
+      ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+      Matrix.mul_one, Matrix.one_mul, hBTP,
+      Matrix.mul_add, Matrix.mul_smul, Matrix.mul_one, hCdelta]
+    simp only [Matrix.mul_one]
+    abel
+  have hCe : C *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ = Matrix.vec Bᵀ := by
+    dsimp only [C]
+    rw [Matrix.kronecker_mulVec_vec]
+    simp
+  calc
+    S *ᵥ (P *ᵥ (res⁻¹ *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ)) =
+        (S * P) *ᵥ (res⁻¹ *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ) :=
+      Matrix.mulVec_mulVec
+        (res⁻¹ *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ) S P
+    _ = (C * res) *ᵥ (res⁻¹ *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ) := by
+      rw [hSP]
+    _ = C *ᵥ ((res * res⁻¹) *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ) := by
+      rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec, Matrix.mul_assoc]
+    _ = C *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ := by
+      rw [Matrix.mul_inv_of_invertible]
+      simp
+    _ = Matrix.vec Bᵀ := hCe
 
 /-- The positive square root of the support relative-modular matrix, applied to
 the vectorized identity, is the vectorization of the support square-root ratio.

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -103,9 +103,8 @@ theorem supportRelativeModular_sourceB_solution
     simp only [Matrix.mul_one]
     abel
   have hCe : C *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ = Matrix.vec Bᵀ := by
-    dsimp only [C]
-    rw [Matrix.kronecker_mulVec_vec]
-    simp
+    simpa only [C, Matrix.one_mul] using
+      one_kronecker_transpose_mulVec_vec_transpose (1 : Matrix n n ℂ) B
   calc
     S *ᵥ (P *ᵥ (res⁻¹ *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ)) =
         (S * P) *ᵥ (res⁻¹ *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ) :=

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2919,7 +2919,8 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:support_inverse_square_root_generalized_inverse}
+    \uses{lem:support_inverse_square_root_generalized_inverse,
+      lem:right_multiplication_transposed_vectorization}
     Put $C=\mathbf 1\otimes B^{\mathsf T}$.  The support generalized-inverse
     identity gives
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1419,7 +1419,14 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{proof}\leanok
     \uses{lem:support_inverse_square_root_sandwich}
     The support inverse square root commutes with $\tau$ by spectral functional
-    calculus.  The claim therefore follows from
+    calculus, so
+    \[
+      \left(\tau^{-1/2}_{\mathrm{supp}}\right)^2\tau
+      =\tau^{-1/2}_{\mathrm{supp}}\,\tau\,
+        \tau^{-1/2}_{\mathrm{supp}}
+      =P_\tau,
+    \]
+    where the last step is
     Lemma~\ref{lem:support_inverse_square_root_sandwich}.
 \end{proof}
 
@@ -2926,8 +2933,20 @@ Theorem~\ref{thm:trace_norm_abs}.
         (\mathbf 1\otimes P_B^{\mathsf T})
       =C\left(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\right).
     \]
-    The shifted relative-modular matrix is positive definite.  Cancelling it
-    and applying the Kronecker vectorization identity proves the claim.
+    The shifted relative-modular matrix is positive definite and hence
+    invertible, so
+    \[
+      \left(A\otimes\mathbf 1+tC\right)
+        (\mathbf 1\otimes P_B^{\mathsf T})
+        \left(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\right)^{-1}
+      =C.
+    \]
+    The Kronecker vectorization identity gives
+    \[
+      C\operatorname{vec}(\mathbf 1^{\mathsf T})
+        =\operatorname{vec}(B^{\mathsf T}),
+    \]
+    which is the claim.
 \end{proof}
 
 \begin{lemma}[Support relative-modular square-root evaluation]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1417,6 +1417,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:support_inverse_square_root_sandwich}
     The support inverse square root commutes with $\tau$ by spectral functional
     calculus.  The claim therefore follows from
     Lemma~\ref{lem:support_inverse_square_root_sandwich}.
@@ -2897,7 +2898,7 @@ Theorem~\ref{thm:trace_norm_abs}.
     \label{lem:support_relative_modular_source_solution}
     \lean{Matrix.supportRelativeModular_sourceB_solution}
     \leanok
-    \uses{lem:support_inverse_square_root_generalized_inverse}
+    \uses{def:support_inverse_square_root}
     Let $A,B$ be positive semidefinite, let $t>0$, set
     $B^+=(B^{-1/2}_{\mathrm{supp}})^2$, and let $P_B$ be the support
     projection of $B$.  Then
@@ -2911,6 +2912,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:support_inverse_square_root_generalized_inverse}
     Put $C=\mathbf 1\otimes B^{\mathsf T}$.  The support generalized-inverse
     identity gives
     \[

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -1404,6 +1404,24 @@ Theorem~\ref{thm:trace_norm_abs}.
     $\lambda_i^{-1/2}\lambda_i\lambda_i^{-1/2}=1$ otherwise.
 \end{proof}
 
+\begin{lemma}[Support generalized-inverse identity]
+    \label{lem:support_inverse_square_root_generalized_inverse}
+    \lean{Matrix.PosSemidef.supportInvSqrt_sq_mul_self}
+    \leanok
+    \uses{def:support_inverse_square_root}
+    If $P_\tau$ is the orthogonal projector onto the support of a positive
+    semidefinite matrix $\tau$, then
+    \[
+        \left(\tau^{-1/2}_{\mathrm{supp}}\right)^2\tau=P_\tau.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The support inverse square root commutes with $\tau$ by spectral functional
+    calculus.  The claim therefore follows from
+    Lemma~\ref{lem:support_inverse_square_root_sandwich}.
+\end{proof}
+
 \begin{lemma}[Support inverse square root under scaling and a maximally mixed factor]
     \label{lem:support_inverse_square_root_maximally_mixed}
     \lean{Matrix.PosSemidef.supportInvSqrt_smul}
@@ -2873,6 +2891,41 @@ Theorem~\ref{thm:trace_norm_abs}.
     This is the Kronecker vectorization identity
     $(B\otimes A)\operatorname{vec}(X)=\operatorname{vec}(AXB^{\mathsf T})$
     with $A=P^{\mathsf T}$, $B=\mathbf 1$, and $X=M^{\mathsf T}$.
+\end{proof}
+
+\begin{lemma}[Canonical support-domain source resolvent solution]
+    \label{lem:support_relative_modular_source_solution}
+    \lean{Matrix.supportRelativeModular_sourceB_solution}
+    \leanok
+    \uses{lem:support_inverse_square_root_generalized_inverse}
+    Let $A,B$ be positive semidefinite, let $t>0$, set
+    $B^+=(B^{-1/2}_{\mathrm{supp}})^2$, and let $P_B$ be the support
+    projection of $B$.  Then
+    \[
+      \left(A\otimes\mathbf 1+t(\mathbf 1\otimes B^{\mathsf T})\right)
+      (\mathbf 1\otimes P_B^{\mathsf T})
+      \left(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\right)^{-1}
+      \operatorname{vec}(\mathbf 1^{\mathsf T})
+      =\operatorname{vec}(B^{\mathsf T}).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Put $C=\mathbf 1\otimes B^{\mathsf T}$.  The support generalized-inverse
+    identity gives
+    \[
+      C\left(A\otimes(B^+)^{\mathsf T}\right)
+        =A\otimes P_B^{\mathsf T}.
+    \]
+    Together with $B^{\mathsf T}P_B^{\mathsf T}=B^{\mathsf T}$, this factors
+    the left two operators as
+    \[
+      \left(A\otimes\mathbf 1+tC\right)
+        (\mathbf 1\otimes P_B^{\mathsf T})
+      =C\left(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\right).
+    \]
+    The shifted relative-modular matrix is positive definite.  Cancelling it
+    and applying the Kronecker vectorization identity proves the claim.
 \end{proof}
 
 \begin{lemma}[Support relative-modular square-root evaluation]

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -404,6 +404,7 @@ The orientation of the vectorized restriction is fixed by
 Here the generalized inverse is the square of the support inverse square root.
 \footnote{Formal declarations:
 \leanid{Matrix.one_kronecker_transpose_mulVec_vec_transpose},
+\leanid{Matrix.supportRelativeModular_sourceB_solution},
 \leanid{Matrix.supportRelativeModular_sqrt_mulVec_vec_one} and
 \leanid{Matrix.supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq} in
 \path{TNLean/Channel/Schwarz/SupportRelativeModular.lean}.}
@@ -415,6 +416,16 @@ $\rho=\sigma$ is a rank-one maximally entangled state, equality under partial
 trace is automatic, whereas the comparison pair formed from its marginal is
 full rank.  Thus the ambient resolvent equality is not a consequence of the
 singular equality theorem.
+
+The canonical source-side projected resolver is now known to solve its
+singular left--right equation: after projection by
+$\mathbf 1\otimes P_B^{\mathsf T}$, multiplication by
+$A\otimes\mathbf 1+t(\mathbf 1\otimes B^{\mathsf T})$ gives
+$\operatorname{vec}(B^{\mathsf T})$.  This uses only the generalized-inverse
+identity $(B^{-1/2}_{\mathrm{supp}})^2B=P_B$ and does not supply equality
+with the comparison resolver.  The remaining step is the support-domain
+relative-entropy defect identity and its zero-defect consequence, tracked in
+issue~\#4435.
 
 The kernel inclusion belongs to the preceding source theorem that must derive
 the support-restricted common resolvents from equality in data processing.  That


### PR DESCRIPTION
## Summary

- prove that the square of the support inverse square root is a generalized inverse on the support
- prove the canonical support-domain source-`B` resolver solves its singular left-right equation
- document the result in the entropy blueprint and the CPSV16/SSA paper-gap note

## Scope

This is a deliberately narrow algebraic milestone for LionSR/QICLean#245, the prerequisite split from LionSR/QICLean#244. It does **not** derive a common support resolvent from equality in data processing. The remaining support-domain relative-entropy defect/integral identity and zero-defect implication stay tracked in LionSR/QICLean#245.

The statements cite Jenčová–Ruskai, arXiv:0903.2895v4, lines 255–261 and 783–790.

## Validation

- `lake build`
- `lake exe checkdecls /private/tmp/issue4435-lean-decls` for the two new blueprint tags
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity scan of both changed Lean files
- `git diff --check`

A full `leanblueprint web && leanblueprint checkdecls` attempt is currently blocked by the local renderer environment: plasTeX cannot import the `leanblueprint` Python module, so it never emits `blueprint/lean_decls`. The two new declaration tags were checked directly with `checkdecls`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds self-contained matrix lemmas and documentation only; no changes to runtime code, auth, or existing proof interfaces beyond new theorems.
> 
> **Overview**
> Adds two linked Lean lemmas for the **singular support** relative-modular route (Jenčová–Ruskai), plus matching blueprint and paper-gap notes. This is an algebraic milestone toward LionSR/QICLean#245; it does **not** derive a common support resolvent from equality in data processing.
> 
> **Support generalized inverse.** `Matrix.PosSemidef.supportInvSqrt_sq_mul_self` shows \((\tau^{-1/2}_{\mathrm{supp}})^2\tau = P_\tau\), using commutation of the support inverse square root with \(\tau\) and the existing sandwich identity.
> 
> **Canonical source resolvent.** `Matrix.supportRelativeModular_sourceB_solution` proves that the projected support-domain vector from the shifted resolvent \((t\mathbf 1 + A\otimes(B^+)^\top)^{-1}\) is mapped to \(\operatorname{vec}(B^\top)\) by \(A\otimes\mathbf 1 + t(\mathbf 1\otimes B^\top)\), with \(B^+\) built from squared support inverse square roots.
> 
> Documentation in `ch19_entropy.tex` and `cpsv16_ssa_equality_hayashi_markov.tex` records scope: the support-domain relative-entropy defect step remains open in LionSR/QICLean#245.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9835e12ddf2c5f157f1ad14bc0c76d09b25cda78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->