### PR TITLE
doc(MPS/MPDO): separate vertical trace blueprint lemmas

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1839,10 +1839,11 @@ physical indices, as in
         =\spn_{\C}\{v_1\cdots v_L:v_1,\ldots,v_L\in\mathcal V\}.
     \]
     If $\mathbf 1\in C_L(\mathcal V)$ for some $L>0$, then $F$ is trace
-    preserving.  The product-span hypothesis is the fixed-generator structure
-    appearing in \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv};
-    the trace-preservation conclusion here is derived from trace nonincrease
-    and the resulting faithful fixed point.
+    preserving.
+    % The product-span hypothesis is the fixed-generator structure appearing in
+    % \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv}.  Trace
+    % preservation is derived here from trace nonincrease and the resulting
+    % faithful fixed point, not from the cited passage.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1933,10 +1934,11 @@ physical indices, as in
         =\spn_{\C}\{v_1\cdots v_L:v_1,\ldots,v_L\in\mathcal V\}.
     \]
     If $\mathbf 1_{\mathcal A}\in C_L(\mathcal V)$ for some $L>0$, then $F$
-    preserves the total trace on $\mathcal A$.  This is the finite-sector form
-    of the preceding trace argument.  The source passage
-    \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv} supplies the
-    product-span structure to which that argument is applied.
+    preserves the total trace on $\mathcal A$.
+    % This is the finite-sector form of the preceding full-matrix trace argument.
+    % The source passage
+    % \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv} supplies the
+    % product-span structure to which that argument is applied.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1839,9 +1839,10 @@ physical indices, as in
         =\spn_{\C}\{v_1\cdots v_L:v_1,\ldots,v_L\in\mathcal V\}.
     \]
     If $\mathbf 1\in C_L(\mathcal V)$ for some $L>0$, then $F$ is trace
-    preserving.
-    This is the full-matrix trace step used in
-    \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv}.
+    preserving.  The product-span hypothesis is the fixed-generator structure
+    appearing in \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv};
+    the trace-preservation conclusion here is derived from trace nonincrease
+    and the resulting faithful fixed point.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1933,8 +1934,9 @@ physical indices, as in
     \]
     If $\mathbf 1_{\mathcal A}\in C_L(\mathcal V)$ for some $L>0$, then $F$
     preserves the total trace on $\mathcal A$.  This is the finite-sector form
-    of the same step in
-    \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv}.
+    of the preceding trace argument.  The source passage
+    \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv} supplies the
+    product-span structure to which that argument is applied.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1840,10 +1840,10 @@ physical indices, as in
     Let $\mathcal M$ be a finite full matrix algebra over $\mathbb C$, and let
     $F:\mathcal M\to\mathcal M$ be positive and trace nonincreasing.  Suppose
     that $F(V_j)=V_j$ for every $j\in J$.  Put
-    $\mathcal V=\operatorname{span}\{V_j:j\in J\}$ and, in the notation of
+    $\mathcal V=\spn_{\C}\{V_j:j\in J\}$ and, in the notation of
     \cite[Appendix~C.4]{Cirac2016MPDO_arXiv}, define
     \[
-      C_L(\mathcal V)=\operatorname{span}
+      C_L(\mathcal V)=\spn_{\C}
         \{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
     \]
     If $\mathbf 1\in C_L(\mathcal V)$ for some $L>0$, then $F$ is trace
@@ -1889,9 +1889,9 @@ physical indices, as in
     \]
     Let $F:\mathcal A\to\mathcal A$ be positive and trace nonincreasing.
     Suppose that $F(V_j)=V_j$ for every $j\in J$.  With
-    $\mathcal V=\operatorname{span}\{V_j:j\in J\}$, put
+    $\mathcal V=\spn_{\C}\{V_j:j\in J\}$, put
     \[
-      C_L(\mathcal V)=\operatorname{span}
+      C_L(\mathcal V)=\spn_{\C}
         \{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
     \]
     If $\mathbf 1_{\mathcal A}\in C_L(\mathcal V)$ for some $L>0$, then $F$

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1843,8 +1843,8 @@ physical indices, as in
     $\mathcal V=\spn_{\C}\{V_j:j\in J\}$ and, in the notation of
     \cite[Appendix~C.4]{Cirac2016MPDO_arXiv}, define
     \[
-      C_L(\mathcal V)=\spn_{\C}
-        \{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+      C_L(\mathcal V)
+        =\spn_{\C}\{v_1\cdots v_L:v_1,\ldots,v_L\in\mathcal V\}.
     \]
     If $\mathbf 1\in C_L(\mathcal V)$ for some $L>0$, then $F$ is trace
     preserving.
@@ -1858,6 +1858,11 @@ physical indices, as in
       thm:psd_trace_pairing_self_dual,
       lem:posDef_weighted_trace_faithful,
       thm:trace_preserving_iff_trace_adjoint_unital}
+    Multilinearity gives
+    \[
+      C_L(\mathcal V)
+        =\spn_{\C}\{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+    \]
     By Theorem~\ref{thm:positive_map_faithful_fixed_point_from_product_span},
     there is a positive-definite matrix $\rho$ such that $F(\rho)=\rho$.
     Let $F^*$ be the trace-pairing adjoint and set
@@ -1931,8 +1936,8 @@ physical indices, as in
     Suppose that $F(V_j)=V_j$ for every $j\in J$.  With
     $\mathcal V=\spn_{\C}\{V_j:j\in J\}$, put
     \[
-      C_L(\mathcal V)=\spn_{\C}
-        \{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+      C_L(\mathcal V)
+        =\spn_{\C}\{v_1\cdots v_L:v_1,\ldots,v_L\in\mathcal V\}.
     \]
     If $\mathbf 1_{\mathcal A}\in C_L(\mathcal V)$ for some $L>0$, then $F$
     preserves the total trace on $\mathcal A$.  This is the finite-sector form
@@ -1944,6 +1949,11 @@ physical indices, as in
     \uses{thm:positive_map_trace_preserving_from_fixed_product_span,
       thm:direct_sum_full_matrix_extension_compatibility,
       lem:direct_sum_extension_trace_transfer}
+    Multilinearity first gives
+    \[
+      C_L(\mathcal V)
+        =\spn_{\C}\{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+    \]
     Let $\iota:\mathcal A\to\operatorname{End}(\bigoplus_\alpha
     \mathbb C^{d_\alpha})$ be the block-diagonal embedding and let
     $\widehat F$ be the canonical full-matrix extension.  These maps satisfy

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1876,6 +1876,46 @@ physical indices, as in
     to trace preservation.
 \end{proof}
 
+\begin{lemma}[Trace transfer through the canonical full-matrix extension]
+    \label{lem:direct_sum_extension_trace_transfer}
+    \lean{Matrix.IsTraceNonincreasingBetweenDirectSums.directSumExtension}
+    \lean{Matrix.IsTracePreservingMap.isTracePreservingDirectSumMap_of_extension}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    Let
+    $\mathcal A=\bigoplus_{\alpha\in I}\mathcal M_{d_\alpha\times d_\alpha}$,
+    let $\iota:\mathcal A\to\operatorname{End}(\bigoplus_\alpha
+    \mathbb C^{d_\alpha})$ be the block-diagonal embedding, and let $\pi$ be
+    diagonal compression.  For a linear map $F:\mathcal A\to\mathcal A$, set
+    $\widehat F=\iota\circ F\circ\pi$.  Then:
+    \begin{enumerate}
+      \item if $F$ is trace nonincreasing on positive elements of $\mathcal A$,
+        then $\widehat F$ is trace nonincreasing;
+      \item if $\widehat F$ is trace preserving, then $F$ preserves the total
+        trace on $\mathcal A$.
+    \end{enumerate}
+\end{lemma}
+
+\begin{proof}\leanok
+    If $Y\geq0$, then $\pi(Y)\geq0$, and the trace identities for diagonal
+    compression and block-diagonal embedding give
+    \[
+      \operatorname{tr}(\widehat F(Y))
+        =\operatorname{tr}_{\mathcal A}(F(\pi(Y)))
+        \leq\operatorname{tr}_{\mathcal A}(\pi(Y))
+        =\operatorname{tr}(Y).
+    \]
+    This proves the first assertion.  For $X\in\mathcal A$, the identity
+    $\pi\circ\iota=\operatorname{id}_{\mathcal A}$ gives
+    \[
+      \operatorname{tr}_{\mathcal A}(F(X))
+        =\operatorname{tr}(\widehat F(\iota(X)))
+        =\operatorname{tr}(\iota(X))
+        =\operatorname{tr}_{\mathcal A}(X),
+    \]
+    whenever $\widehat F$ is trace preserving.
+\end{proof}
+
 \begin{theorem}[Trace preservation on a finite sum from fixed products]
     \label{thm:positive_direct_sum_map_trace_preserving_from_fixed_product_span}
     \lean{Matrix.IsPositiveDirectSumMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span}
@@ -1902,7 +1942,8 @@ physical indices, as in
 
 \begin{proof}\leanok
     \uses{thm:positive_map_trace_preserving_from_fixed_product_span,
-      thm:direct_sum_full_matrix_extension_compatibility}
+      thm:direct_sum_full_matrix_extension_compatibility,
+      lem:direct_sum_extension_trace_transfer}
     Let $\iota:\mathcal A\to\operatorname{End}(\bigoplus_\alpha
     \mathbb C^{d_\alpha})$ be the block-diagonal embedding and let
     $\widehat F$ be the canonical full-matrix extension.  These maps satisfy

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1786,8 +1786,7 @@ physical indices, as in
 
 \begin{theorem}[Faithful fixed point from fixed product generators]
     \label{thm:positive_map_faithful_fixed_point_from_product_span}
-    \lean{IsPositiveMap.%
-      exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span}
+    \lean{IsPositiveMap.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span}
     \leanok
     Let $\mathcal M$ be a finite full matrix algebra over $\mathbb C$, and let
     $F:\mathcal M\to\mathcal M$ be positive and trace nonincreasing.  Suppose
@@ -1806,6 +1805,14 @@ physical indices, as in
     \uses{thm:positive_trace_nonincreasing_bounded_orbits,
       thm:maximalSupport_fixedPoint_of_bounded_orbits}
     Boundedness of the forward orbits gives the mean-ergodic projection $P$.
+    After decomposing a Hermitian input into its positive and negative parts,
+    the passage to an arbitrary $X$ uses
+    \[
+      H_1=X+X^\dagger,
+      \qquad H_2=\mathrm{i}(X-X^\dagger),
+      \qquad X=\frac12(H_1-\mathrm{i}H_2),
+    \]
+    where $H_1$ and $H_2$ are Hermitian.
     Set $\rho=P(\mathbf 1)$ and let $Q$ be the support projection of $\rho$.
     For every $j$, the maximal-support property of $\rho$ gives
     \[
@@ -1817,23 +1824,137 @@ physical indices, as in
         =V_{j_1}\cdots V_{j_k}
       \qquad (k\geq1).
     \]
-    The product-span hypothesis then gives
-    $Q\mathbf 1Q=\mathbf 1$, so $Q=\mathbf 1$.  Thus $\rho$ is positive
-    definite, and the construction of $P$ gives $F(\rho)=\rho$.
+    The product-span hypothesis and linearity then give
+    $Q\mathbf 1Q=\mathbf 1$.  Since $Q^2=Q$, one has
+    \[
+      Q=Q^2=Q\mathbf 1Q=\mathbf 1.
+    \]
+    Thus $\rho$ is positive definite, and the construction of $P$ gives
+    $F(\rho)=\rho$.
+\end{proof}
+
+\begin{theorem}[Trace preservation from fixed product generators]
+    \label{thm:positive_map_trace_preserving_from_fixed_product_span}
+    \lean{IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span}
+    \leanok
+    Let $\mathcal M$ be a finite full matrix algebra over $\mathbb C$, and let
+    $F:\mathcal M\to\mathcal M$ be positive and trace nonincreasing.  Suppose
+    that $F(V_j)=V_j$ for every $j\in J$.  Put
+    $\mathcal V=\operatorname{span}\{V_j:j\in J\}$ and, in the notation of
+    \cite[Appendix~C.4]{Cirac2016MPDO_arXiv}, define
+    \[
+      C_L(\mathcal V)=\operatorname{span}
+        \{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+    \]
+    If $\mathbf 1\in C_L(\mathcal V)$ for some $L>0$, then $F$ is trace
+    preserving.
+    This is the full-matrix trace step used in
+    \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:positive_map_faithful_fixed_point_from_product_span,
+      thm:trace_pairing_adjoint_positive,
+      thm:psd_trace_pairing_self_dual,
+      lem:posDef_weighted_trace_faithful,
+      thm:trace_preserving_iff_trace_adjoint_unital}
+    By Theorem~\ref{thm:positive_map_faithful_fixed_point_from_product_span},
+    there is a positive-definite matrix $\rho$ such that $F(\rho)=\rho$.
+    Let $F^*$ be the trace-pairing adjoint and set
+    \[
+      \Delta=\mathbf 1-F^*(\mathbf 1).
+    \]
+    For every positive semidefinite $X$, trace nonincrease gives
+    \[
+      \operatorname{tr}(\Delta X)
+        =\operatorname{tr}(X)-\operatorname{tr}(F(X))\geq0.
+    \]
+    Positivity of $F^*$ and self-duality of the positive semidefinite cone
+    therefore give $\Delta\geq0$.  The fixed-point equation gives
+    $\operatorname{tr}(\rho\Delta)=0$, so positive definiteness of $\rho$
+    forces $\Delta=0$.  Thus $F^*(\mathbf 1)=\mathbf 1$, which is equivalent
+    to trace preservation.
+\end{proof}
+
+\begin{theorem}[Trace preservation on a finite sum from fixed products]
+    \label{thm:positive_direct_sum_map_trace_preserving_from_fixed_product_span}
+    \lean{Matrix.IsPositiveDirectSumMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span}
+    \leanok
+    Let
+    $\mathcal A=\bigoplus_{\alpha\in I}\mathcal M_{d_\alpha\times d_\alpha}$
+    be a finite sum of full matrix algebras, with total trace
+    \[
+      \operatorname{tr}_{\mathcal A}(X)
+        =\sum_{\alpha\in I}\operatorname{tr}(X_\alpha).
+    \]
+    Let $F:\mathcal A\to\mathcal A$ be positive and trace nonincreasing.
+    Suppose that $F(V_j)=V_j$ for every $j\in J$.  With
+    $\mathcal V=\operatorname{span}\{V_j:j\in J\}$, put
+    \[
+      C_L(\mathcal V)=\operatorname{span}
+        \{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+    \]
+    If $\mathbf 1_{\mathcal A}\in C_L(\mathcal V)$ for some $L>0$, then $F$
+    preserves the total trace on $\mathcal A$.  This is the finite-sector form
+    of the same step in
+    \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:positive_map_trace_preserving_from_fixed_product_span,
+      thm:direct_sum_full_matrix_extension_compatibility}
+    Let $\iota:\mathcal A\to\operatorname{End}(\bigoplus_\alpha
+    \mathbb C^{d_\alpha})$ be the block-diagonal embedding and let
+    $\widehat F$ be the canonical full-matrix extension.  These maps satisfy
+    \[
+      \iota(XY)=\iota(X)\iota(Y),
+      \qquad \iota(\mathbf 1_{\mathcal A})=\mathbf 1,
+      \qquad \widehat F(\iota(X))=\iota(F(X)).
+    \]
+    The extension is positive and trace nonincreasing.  The matrices
+    $\iota(V_j)$ are fixed by $\widehat F$, and the displayed identities
+    carry the product-span hypothesis to the full matrix algebra.
+    Theorem~\ref{thm:positive_map_trace_preserving_from_fixed_product_span}
+    makes $\widehat F$ trace preserving.  Restricting to block-diagonal
+    matrices proves preservation of $\operatorname{tr}_{\mathcal A}$ by $F$.
+\end{proof}
+
+\begin{theorem}[Trace sandwich on finite sums of matrix algebras]
+    \label{thm:direct_sum_trace_preservation_sandwich}
+    \lean{Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing}
+    \leanok
+    Let $\mathcal A$ and $\mathcal B$ be finite sums of full matrix algebras,
+    and let $T:\mathcal A\to\mathcal B$ and $S:\mathcal B\to\mathcal A$ be
+    linear maps.  Suppose that $T$ is positive, both maps are trace
+    nonincreasing, and $S\circ T$ is trace preserving.  Then $T$ is trace
+    preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    For every positive $X\in\mathcal A$, positivity of $T$ and the two
+    trace-nonincreasing inequalities give
+    \[
+      \operatorname{tr}_{\mathcal A}(X)
+        =\operatorname{tr}_{\mathcal A}(S(T(X)))
+        \leq\operatorname{tr}_{\mathcal B}(T(X))
+        \leq\operatorname{tr}_{\mathcal A}(X).
+    \]
+    Hence the middle term equals the endpoints.  Equality extends from the
+    positive cone to Hermitian matrices by positive and negative parts.  For
+    arbitrary $X$, put
+    \[
+      H_1=X+X^\dagger,
+      \qquad H_2=\mathrm{i}(X-X^\dagger),
+      \qquad X=\frac12(H_1-\mathrm{i}H_2).
+    \]
+    Both $H_1$ and $H_2$ are Hermitian, so linearity proves trace preservation
+    for every $X$.
 \end{proof}
 
 \begin{theorem}[Trace preservation of the transported vertical-sector maps]
     \label{thm:mpdo_transported_vertical_sector_composites_trace_preserving}
-    \lean{IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span,
-      Matrix.IsPositiveDirectSumMap.%
-        tracePreserving_of_traceNonincreasing_of_fixed_product_span,
-      Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing,
-      MPOTensor.transportedVerticalSector_composites_tracePreserving}
+    \lean{MPOTensor.transportedVerticalSector_composites_tracePreserving}
     \leanok
-    \uses{thm:positive_map_faithful_fixed_point_from_product_span,
-      lem:mpdo_transported_vertical_sector_fixed_generators,
-      thm:mpdo_vertical_bond_contractions_generate_sector_algebra,
-      thm:mpdo_transported_vertical_sector_trace_loss}
     Suppose that every one-site and two-site multiplicity space is nonzero
     and every corresponding diagonal weight is positive.  Let
     $\widetilde M^{(1)}$ and $\widetilde M^{(2)}$ be the vertical tensors of
@@ -1887,39 +2008,29 @@ physical indices, as in
 \end{theorem}
 
 \begin{proof}\leanok
-    Each transported map is positive and trace nonincreasing, and hence so is
-    either square composite $F$.  The preceding fixed-generator lemma and
+    \uses{thm:positive_direct_sum_map_trace_preserving_from_fixed_product_span,
+      thm:direct_sum_trace_preservation_sandwich,
+      lem:mpdo_transported_vertical_sector_fixed_generators,
+      thm:mpdo_vertical_bond_contractions_generate_sector_algebra,
+      thm:mpdo_transported_vertical_sector_trace_loss}
+    Each transported map is positive and trace nonincreasing, and hence so are
+    the square composites $\widetilde S\widetilde T$ and
+    $\widetilde T\widetilde S$.  The fixed-generator lemma and the
     product-spanning theorem give the hypotheses of
-    Theorem~\ref{thm:positive_map_faithful_fixed_point_from_product_span},
-    applied to the canonical full-matrix extension of the sector algebra.
-    Thus there is a positive-definite fixed point $\rho$:
-    \[
-      \rho\succ0,
-      \qquad F(\rho)=\rho.
-    \]
+    Theorem~\ref{thm:positive_direct_sum_map_trace_preserving_from_fixed_product_span}
+    for both composites.  Thus both preserve the corresponding total trace.
 
-    Let $F^*$ be the trace adjoint and set
+    For positive $X\in\mathcal A_1$, one has
     \[
-      \Delta=\mathbf 1-F^*(\mathbf 1).
+      \operatorname{tr}_{\mathcal A_1}(X)
+        =\operatorname{tr}_{\mathcal A_1}
+          ((\widetilde S\widetilde T)(X))
+        \leq\operatorname{tr}_{\mathcal A_2}(\widetilde T(X))
+        \leq\operatorname{tr}_{\mathcal A_1}(X).
     \]
-    Trace nonincrease gives
-    $\operatorname{tr}(\Delta X)=\operatorname{tr}(X)-
-    \operatorname{tr}(F(X))\geq0$ for every positive $X$, and positivity of
-    $F$ implies that $\Delta$ is Hermitian.  Hence $\Delta\geq0$.  Since
-    $F(\rho)=\rho$, one has $\operatorname{tr}(\rho\Delta)=0$.
-    Positive definiteness of $\rho$ therefore forces $\Delta=0$, which is
-    equivalent to trace preservation.  The faithful-fixed-point theorem uses
-    fixedness only of the contraction factors, not of their products.
-
-    Finally, for positive $X$ the two trace-nonincreasing inequalities give
-    \[
-      \operatorname{tr}((\widetilde S\widetilde T)(X))
-        \leq\operatorname{tr}(\widetilde T(X))
-        \leq\operatorname{tr}(X).
-    \]
-    The equality of the endpoints forces trace preservation by
-    $\widetilde T$ on the positive cone and hence on the whole algebra.
-    Interchanging the two maps proves the corresponding assertion for
+    Theorem~\ref{thm:direct_sum_trace_preservation_sandwich} therefore makes
+    $\widetilde T$ trace preserving.  Applying the same theorem to
+    $\widetilde S$ and $\widetilde T\widetilde S$ proves the assertion for
     $\widetilde S$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1805,14 +1805,6 @@ physical indices, as in
     \uses{thm:positive_trace_nonincreasing_bounded_orbits,
       thm:maximalSupport_fixedPoint_of_bounded_orbits}
     Boundedness of the forward orbits gives the mean-ergodic projection $P$.
-    After decomposing a Hermitian input into its positive and negative parts,
-    the passage to an arbitrary $X$ uses
-    \[
-      H_1=X+X^\dagger,
-      \qquad H_2=\mathrm{i}(X-X^\dagger),
-      \qquad X=\frac12(H_1-\mathrm{i}H_2),
-    \]
-    where $H_1$ and $H_2$ are Hermitian.
     Set $\rho=P(\mathbf 1)$ and let $Q$ be the support projection of $\rho$.
     For every $j$, the maximal-support property of $\rho$ gives
     \[

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1873,8 +1873,8 @@ physical indices, as in
     to trace preservation.
 \end{proof}
 
-\begin{lemma}[Trace transfer through the canonical full-matrix extension]
-    \label{lem:direct_sum_extension_trace_transfer}
+\begin{theorem}[Trace transfer through the canonical full-matrix extension]
+    \label{thm:direct_sum_extension_trace_transfer}
     \lean{Matrix.IsTraceNonincreasingBetweenDirectSums.directSumExtension}
     \lean{Matrix.IsTracePreservingMap.isTracePreservingDirectSumMap_of_extension}
     \leanok
@@ -1891,7 +1891,7 @@ physical indices, as in
       \item if $\widehat F$ is trace preserving, then $F$ preserves the total
         trace on $\mathcal A$.
     \end{enumerate}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     If $Y\geq0$, then $\pi(Y)\geq0$, and the trace identities for diagonal
@@ -1940,7 +1940,7 @@ physical indices, as in
 \begin{proof}\leanok
     \uses{thm:positive_map_trace_preserving_from_fixed_product_span,
       thm:direct_sum_full_matrix_extension_compatibility,
-      lem:direct_sum_extension_trace_transfer}
+      thm:direct_sum_extension_trace_transfer}
     Multilinearity first gives
     \[
       C_L(\mathcal V)


### PR DESCRIPTION
### Motivation

- PR #4390 was merged before four late exact-head review threads arrived. Those comments identify a blueprint declaration-mapping error and two proof steps whose formulas were not displayed.
- The relevant source is Papers/1606.00608/MPDO-22-12-17-2.tex, lines 1974–1995: the fixed transported contractions, the spaces C_L(V), and the conclusion for the two transported composites.
- This follow-up repairs the mathematical blueprint record without changing any Lean declaration or proof.

### Description

- Give the full-matrix fixed-product trace-preservation theorem, its finite-direct-sum form, and the trace-sandwich theorem independent blueprint entries with their exact Lean declarations.
- Leave only MPOTensor.transportedVerticalSector_composites_tracePreserving on the transported vertical-sector theorem and record the three general results through the proof dependency graph.
- Replace the reviewed identifier continuation by complete declaration names.
- Display the Hermitian decomposition
  H₁ = X + X†, H₂ = i(X − X†), X = 1/2(H₁ − iH₂)
  and the support-projection implication Q = Q² = Q1Q = 1.
- Retain the paper notation C_L(V), A₁, A₂, T̃, and S̃.
- Keep the comparison with CPSV16 Appendix C.4 as LaTeX comments, so the displayed theorem statements contain only their mathematical assertions.

### Testing

- lake build — 9636 jobs
- lake exe checkdecls blueprint/lean_decls
- leanblueprint pdf — 685 pages; affected pages visually inspected
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/check_reader_facing_prose.py --root . --diff-base 07334d78c39d575d8f308540a4b011249cad5f58 --ci
- git diff --check

Follow-up to #4390.
Addresses #4370.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint–Lean sync only; no executable Lean or runtime code changes.
> 
> **Overview**
> **Blueprint-only** follow-up to #4390: repairs the MPDO vertical-sector trace narrative in `ch21_mpdo_rfp_blocked_rfp.tex` without changing Lean proofs.
> 
> **New standalone theorems** each carry a single `\lean{...}` name: full-matrix trace preservation from fixed product generators (`IsPositiveMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span`), the finite direct-sum version (`Matrix.IsPositiveDirectSumMap.tracePreserving_of_traceNonincreasing_of_fixed_product_span`), trace transfer through the canonical full-matrix extension, and the trace-sandwich on finite sums (`Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing`). The transported vertical-sector theorem now lists only **`MPOTensor.transportedVerticalSector_composites_tracePreserving`**; the general results are wired in via `\uses{...}` on the shorter composite proof.
> 
> **Proof text** spells out steps that were implicit: support projection **Q = Q² = Q1Q = 1** in the faithful fixed-point argument, and Hermitian decomposition **H₁ = X + X†**, **H₂ = i(X − X†)** in the sandwich theorem. The faithful fixed-point `\lean` line drops a spurious line break inside the declaration name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1318b5ab6084436ea70110e9475bb582484bdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
