### PR TITLE
feat(Algebra/PerronFrobenius): factor the stationary primitive square

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -14,10 +14,12 @@ nonnegative real matrix whose second and third powers agree. Its square is a
 strictly positive idempotent, and the fixed space of such an idempotent is
 one-dimensional. Consequently the square has rank one.
 
-The result supports the rank-one trace factorization sought at
-arXiv:1606.00608, Appendix C.2, line 1613. It is a source-independent matrix
-lemma, not a statement asserted in that paper: applying it to the sector trace
-matrix still requires a separate, non-circular proof of primitivity.
+The results support the rank-one trace factorization sought at
+arXiv:1606.00608, Appendix C.2, line 1613.  In addition to the rank statement,
+the square is factored as an outer product with diagonal pairing one.  These
+are source-independent matrix lemmas, not statements asserted in that paper:
+applying them to the sector trace matrix still requires a separate,
+non-circular proof of primitivity.
 -/
 
 open scoped BigOperators Matrix
@@ -118,5 +120,39 @@ theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
     rw [← pow_add]
     exact pow_eq_pow_two_of_pow_two_eq_pow_three h 4 (by omega)
   exact rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
+
+/-- If a primitive nonnegative real matrix has equal second and third powers,
+then its square is an outer product whose diagonal pairing is one.
+
+This is the normalized factorization needed for the corrected two-step
+coefficient in arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1616.  It factors `T ^ 2`, not the one-step matrix `T` printed at
+line 1613. -/
+theorem IsPrimitive.exists_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three
+    {N : ℕ} [NeZero N] {T : Matrix (Fin N) (Fin N) ℝ}
+    (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :
+    ∃ a b : Fin N → ℝ, T ^ 2 = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
+  have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
+    rw [← pow_add]
+    exact pow_eq_pow_two_of_pow_two_eq_pow_three h 4 (by omega)
+  have hrank := hT.rank_pow_two_eq_one_of_pow_two_eq_pow_three h
+  let f : (Fin N → ℝ) →ₗ[ℝ] (Fin N → ℝ) := Matrix.toLin' (T ^ 2)
+  have hf : IsIdempotentElem f := by
+    change Matrix.toLin' (T ^ 2) ∘ₗ Matrix.toLin' (T ^ 2) = Matrix.toLin' (T ^ 2)
+    rw [← Matrix.toLin'_mul, hsq_idem]
+  have hrange : Module.finrank ℝ (LinearMap.range f) = 1 := by
+    rw [Matrix.rank_eq_finrank_range_toLin (T ^ 2)
+      (Pi.basisFun ℝ (Fin N)) (Pi.basisFun ℝ (Fin N)), Matrix.toLin_eq_toLin'] at hrank
+    exact hrank
+  have htrace : Matrix.trace (T ^ 2) = 1 := by
+    have hproj := (LinearMap.isProj_range_iff_isIdempotentElem f).2 hf |>.trace
+    rw [Matrix.trace_toLin'_eq] at hproj
+    rw [hrange] at hproj
+    exact_mod_cast hproj
+  obtain ⟨a, b, hab⟩ :=
+    Matrix.hasRankOneFactorization_of_mul_self_eq_self hsq_idem htrace
+  refine ⟨a, b, hab, ?_⟩
+  rw [← Matrix.trace_vecMulVec, ← hab]
+  exact htrace
 
 end Matrix

--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -125,7 +125,7 @@ theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
 then its square is an outer product whose diagonal pairing is one.
 
 This is the normalized factorization needed for the corrected two-step
-coefficient in arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+coefficient in arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines
 1606--1616.  It factors `T ^ 2`, not the one-step matrix `T` printed at
 line 1613. -/
 theorem IsPrimitive.exists_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three

--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -16,10 +16,10 @@ one-dimensional. Consequently the square has rank one.
 
 The results support the rank-one trace factorization sought at
 arXiv:1606.00608, Appendix C.2, line 1613.  In addition to the rank statement,
-the square is factored as an outer product with diagonal pairing one.  These
-are source-independent matrix lemmas, not statements asserted in that paper:
-applying them to the sector trace matrix still requires a separate,
-non-circular proof of primitivity.
+the square is factored as $a b^{\mathsf T}$ for real vectors satisfying
+$a \mathbin{\cdot} b=1$.  These are source-independent matrix lemmas, not
+statements asserted in that paper: applying them to the sector trace matrix
+still requires a separate, non-circular proof of primitivity.
 -/
 
 open scoped BigOperators Matrix
@@ -122,7 +122,8 @@ theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
   exact rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
 
 /-- If a primitive nonnegative real matrix has equal second and third powers,
-then its square is an outer product whose diagonal pairing is one.
+then its square has the form $a b^{\mathsf T}$ for real vectors satisfying
+$a \mathbin{\cdot} b=1$.
 
 This is the normalized factorization needed for the corrected two-step
 coefficient in arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -745,9 +745,10 @@
     is its fixed space, so it is one-dimensional.
 \end{proof}
 
-\begin{theorem}[Rank of a stationary primitive square]
+\begin{theorem}[Rank and factorization of a stationary primitive square]
     \label{thm:matrix_primitive_pow_two_rank_one}
     \lean{Matrix.IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three}
+    \lean{Matrix.IsPrimitive.exists_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three}
     \leanok
     Let $T$ be a primitive real $N\times N$ matrix, where
     $N\geq 1$. If
@@ -757,6 +758,12 @@
     then
     \[
         \operatorname{rank}(T^2)=1.
+    \]
+    There are vectors $a,b\in\mathbb R^N$ such that
+    \[
+        T^2=ab^{\mathsf T},
+        \qquad
+        \sum_i a_i b_i=1.
     \]
     This finite-dimensional matrix lemma supports the argument sought at
     \cite[Appendix~C.2, line~1613]{Cirac2016MPDO_arXiv}; it is not a theorem
@@ -775,6 +782,10 @@
     \]
     The same stabilization identity gives $(T^2)^2=T^2$.
     The preceding theorem applied to $P=T^2$ now gives the conclusion.
+    Since an idempotent has trace equal to its rank,
+    $\tr(T^2)=1$.  Factoring its one-dimensional range gives
+    $T^2=ab^{\mathsf T}$, and taking the trace yields
+    $\sum_i a_i b_i=1$.
 \end{proof}
 
 \begin{theorem}[Idempotence of the sector trace matrix]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_primitivity.tex
@@ -773,7 +773,8 @@
 \begin{proof}
     \leanok
     \uses{thm:matrix_positive_idempotent_rank_one,
-        thm:matrix_pairing_sq_eq_cube}
+        thm:matrix_pairing_sq_eq_cube,
+        thm:matrix_idempotent_trace_one_rank_one}
     Primitivity gives $m\geq 1$ such that $(T^m)_{i,j}>0$ for every $i,j$.
     Stabilization gives $T^{2m}=T^2$. Thus, for every $i,j$,
     \[


### PR DESCRIPTION
### Motivation

- Proposition `4to2` of arXiv:1606.00608 uses a rank-one coefficient to separate the two boundary sector sums. The repository source is `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1598–1617; line 1613 states `T_{kh}=tr(η_{kh})=a_kb_h`. That one-step inference is false in general.
- The corrected route tracked by #4175 and #4445 proposes applying source ZCL once more, so its coefficient is the two-step matrix `T^2`. The existing Perron theorem proves only `rank(T^2)=1`; this PR supplies the explicit normalized outer product required by the fourth-region calculation.

### Description

- Prove that for a primitive real matrix on a nonempty finite index set, `T^2=T^3` implies
  `T^2 = Matrix.vecMulVec a b` and `a ⬝ᵥ b = 1` for some real vectors `a,b`.
- Derive the normalization without an additional hypothesis: `T^2` is idempotent, its rank is one by the existing Perron theorem, and the trace of an idempotent equals the dimension of its range.
- Extend the corresponding blueprint theorem with the factorization and its proof. The conclusion concerns `T^2` only; it neither factors `T` nor asserts anything about the unreduced Beigi trace matrix.
- The paper-gap note is intentionally unchanged because PR #4442 is currently revising that file. The new theorem is disjoint and supplies the algebraic part of #4445 after the cyclic-active result is available.

### Testing

- `lake build TNLean.Algebra.PerronFrobenius.Idempotent`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base ecba3a25558eab581903973d75a6c52bfd4c6c15 --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref ecba3a25558eab581903973d75a6c52bfd4c6c15`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check ecba3a25558eab581903973d75a6c52bfd4c6c15..HEAD`

Closes #4446

Parent: #4175.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure linear algebra in an existing Perron–Frobenius module plus blueprint text; no auth, IO, or runtime behavior changes.
> 
> **Overview**
> Adds the **normalized rank-one factorization** for a primitive real matrix with `T^2 = T^3`: besides `rank(T^2) = 1`, the PR proves `T^2 = ab^T` with real vectors and **`a · b = 1`**, targeting the two-step coefficient in the Cirac MPDO appendix (not the incorrect one-step `T` factorization).
> 
> The new Lean proof reuses idempotence of `T^2`, the existing rank-one Perron lemma, **trace = rank** for an idempotent, and `hasRankOneFactorization_of_mul_self_eq_self`, then ties normalization via `trace_vecMulVec`. The blueprint theorem is renamed/extended to state the outer product and trace normalization, with an updated proof sketch and lean sync for the new declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7c308ad995dd3cde0adec32d6fa95948853f135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->