### PR TITLE
feat(MPS/RFP): construct residual-family two-site support

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -314,7 +314,6 @@ import TNLean.MPS.ParentHamiltonian.TripartiteDecorrelation
 import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 -- Downstream users needing periodic-chain definitions may import the uniqueness capstone.
-
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension
 import TNLean.MPS.FundamentalTheorem.Basic

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -626,6 +626,7 @@ import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.ResidualWordSpan
+import TNLean.MPS.RFP.ResidualFamilySupport
 import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.BeigiGroundSpaceDimension
 import TNLean.MPS.RFP.BeigiSpatialDecomposition

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
-import TNLean.MPS.RFP.ResidualWordSpan
+import TNLean.MPS.RFP.ResidualFamilySupport
 
 /-!
 # Nearest-neighbor ground spaces for multiplicity-one RFP sectors

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
-import TNLean.MPS.RFP.ResidualFamilySupport
+import TNLean.MPS.RFP.ResidualWordSpan
 
 /-!
 # Nearest-neighbor ground spaces for multiplicity-one RFP sectors

--- a/TNLean/MPS/RFP/ResidualFamilySupport.lean
+++ b/TNLean/MPS/RFP/ResidualFamilySupport.lean
@@ -1,0 +1,271 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
+import TNLean.MPS.RFP.AppendixBCommutation
+import TNLean.MPS.RFP.ResidualWordSpan
+
+/-!
+# Two-site support of a residual-isometry family
+
+This file constructs the common physical isometry carried by the valid
+Sigma-indexed virtual pairs of a family of distinct normal sectors.  The index
+space is
+`BlockEntryIndex dim = Σ j, Fin (dim j) × Fin (dim j)`, not the full square
+of the direct-sum bond space: cross-sector virtual pairs are absent from the
+source isometry equation.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
+543--555, and equations (3.16)--(3.18), lines 549--578.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+/-- The common one-site physical matrix of a residual-isometry family, indexed
+only by valid within-sector virtual pairs.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+noncomputable def residualFamilyPhysicalIsometryMatrix
+    (U : (j : Fin r) → MPSTensor d (dim j)) :
+    Matrix (Fin d) (BlockEntryIndex dim) ℂ :=
+  fun i x ↦ U x.1 i x.2.1 x.2.2
+
+/-- The cross-sector residual-isometry equations say that the common physical
+matrix is an isometry on `BlockEntryIndex dim`.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+theorem IsResidualIsometryFamily.residualFamilyPhysicalIsometryMatrix_isometry
+    {U : (j : Fin r) → MPSTensor d (dim j)}
+    (hU : IsResidualIsometryFamily U) :
+    (residualFamilyPhysicalIsometryMatrix U)ᴴ *
+        residualFamilyPhysicalIsometryMatrix U = 1 := by
+  classical
+  ext x y
+  rcases x with ⟨j, a, b⟩
+  rcases y with ⟨k, c, e⟩
+  by_cases hjk : j = k
+  · subst k
+    simp only [residualFamilyPhysicalIsometryMatrix, Matrix.mul_apply,
+      Matrix.conjTranspose_apply, Matrix.one_apply]
+    rw [show (∑ i : Fin d, star (U j i a b) * U j i c e) =
+        ∑ i : Fin d, U j i c e * star (U j i a b) by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact mul_comm _ _]
+    rw [hU.1 j c e a b]
+    simp [eq_comm]
+  · have hCross := hU.2 k j (Ne.symm hjk) c e a b
+    simpa [residualFamilyPhysicalIsometryMatrix, Matrix.mul_apply,
+      Matrix.conjTranspose_apply, Matrix.one_apply, hjk, mul_comm] using hCross
+
+/-- Simultaneous Appendix B data for a finite family of sectors.  The fields
+are precisely the sectorwise product-pair form and the common cross-sector
+isometry equation; no cross-sector virtual matrix entries are introduced.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
+543--555. -/
+structure ResidualFamilyAppendixBData
+    (B : (j : Fin r) → MPSTensor d (dim j)) where
+  /-- Appendix B structural data for each normal sector. -/
+  sector : (j : Fin r) → AppendixBStructuralData (B j)
+  /-- The residual tensors of all sectors form the one common physical
+  isometry in equation `eq:III_isometry`. -/
+  residual : IsResidualIsometryFamily (fun j ↦ (sector j).U)
+
+namespace ResidualFamilyAppendixBData
+
+variable {B : (j : Fin r) → MPSTensor d (dim j)}
+
+/-- The boundary-coordinate space for the equal-sector two-site basic
+vectors.  It is the curried form of functions on `BlockEntryIndex dim`.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+abbrev TwoSiteBoundary (dim : Fin r → ℕ) :=
+  (j : Fin r) → Fin (dim j) × Fin (dim j) → ℂ
+
+/-- Insert the rank-one virtual bond separately in every sector and sum the
+resulting two-site physical vectors.  Unequal-sector bonds are absent by
+construction.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def twoSiteBondEmbedding
+    (h : ResidualFamilyAppendixBData B) :
+    TwoSiteBoundary dim →ₗ[ℂ] NSiteSpace d 2 where
+  toFun v := ∑ j : Fin r, (h.sector j).twoSiteBasicEmbedding (v j)
+  map_add' v w := by
+    simp only [Pi.add_apply, map_add, Finset.sum_add_distrib]
+  map_smul' c v := by
+    simp only [Pi.smul_apply, RingHom.id_apply, map_smul]
+    exact Finset.smul_sum.symm
+
+/-- The combined equal-sector bond insertion has range equal to the linear sum
+of the sector two-site ground spaces.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and (3.17)--(3.18), lines
+543--578. -/
+theorem twoSiteBondEmbedding_range
+    (h : ResidualFamilyAppendixBData B) :
+    LinearMap.range h.twoSiteBondEmbedding =
+      ⨆ j : Fin r, groundSpace (B j) 2 := by
+  classical
+  apply le_antisymm
+  · rintro ψ ⟨v, rfl⟩
+    change (∑ j : Fin r, (h.sector j).twoSiteBasicEmbedding (v j)) ∈
+      ⨆ j : Fin r, groundSpace (B j) 2
+    apply Submodule.sum_mem
+    intro j _
+    apply Submodule.mem_iSup_of_mem j
+    rw [(h.sector j).groundSpace_eq_coreTensor]
+    change (h.sector j).twoSiteBasicEmbedding (v j) ∈
+      (h.sector j).twoSiteBasicSpace
+    rw [← (h.sector j).twoSiteBasicEmbedding_range]
+    exact ⟨v j, rfl⟩
+  · refine iSup_le fun j ↦ ?_
+    rintro ψ hψ
+    rw [(h.sector j).groundSpace_eq_coreTensor] at hψ
+    have hψ' : ψ ∈ (h.sector j).twoSiteBasicSpace := hψ
+    rw [← (h.sector j).twoSiteBasicEmbedding_range] at hψ'
+    obtain ⟨v, rfl⟩ := hψ'
+    refine ⟨Pi.single j v, ?_⟩
+    let f : Fin r → NSiteSpace d 2 := fun k ↦
+      (h.sector k).twoSiteBasicEmbedding
+        ((Pi.single j v : TwoSiteBoundary dim) k)
+    change (∑ k : Fin r, f k) = (h.sector j).twoSiteBasicEmbedding v
+    calc
+      _ = f j := Finset.sum_eq_single j (fun k _ hkj ↦ by
+        simp [f, Pi.single_eq_of_ne hkj]) (by simp)
+      _ = _ := by simp [f]
+
+/-- The equal-sector bond-insertion range is exactly the two-site local ground
+space of the unit-weight direct sum.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and (3.17)--(3.18), lines
+543--578. -/
+theorem twoSiteBondEmbedding_range_eq_directSum_groundSpace
+    (h : ResidualFamilyAppendixBData B) :
+    LinearMap.range h.twoSiteBondEmbedding =
+      groundSpace (directSumTensor B) 2 := by
+  rw [h.twoSiteBondEmbedding_range]
+  have hTensor :
+      toTensorFromBlocks (d := d) (fun _ : Fin r ↦ 1) B = directSumTensor B := by
+    funext i
+    simp [toTensorFromBlocks, directSumTensor]
+  rw [← hTensor]
+  exact (groundSpace_toTensorFromBlocks_eq_iSup
+    (fun _ : Fin r ↦ 1) B (by simp) 2).symm
+
+/-- The orthogonal projector onto the physical image of the equal-sector bond
+insertion.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578, and the
+parent-space construction, lines 511--524. -/
+noncomputable def twoSiteBondSupportProjection
+    (_h : ResidualFamilyAppendixBData B) :
+    NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)
+  e.toLinearMap.comp
+    (((groundSpaceES (directSumTensor B) 2).starProjection.toLinearMap).comp
+      e.symm.toLinearMap)
+
+/-- The physical equal-sector bond projector has exactly the combined
+bond-insertion range.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and (3.17)--(3.18), lines
+543--578. -/
+theorem twoSiteBondSupportProjection_range
+    (h : ResidualFamilyAppendixBData B) :
+    LinearMap.range h.twoSiteBondSupportProjection =
+      LinearMap.range h.twoSiteBondEmbedding := by
+  rw [h.twoSiteBondEmbedding_range_eq_directSum_groundSpace]
+  ext ψ
+  constructor
+  · rintro ⟨v, rfl⟩
+    change (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES (directSumTensor B) 2).starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v)) ∈
+          groundSpace (directSumTensor B) 2
+    apply (mem_groundSpaceES_iff (directSumTensor B) 2 _).1
+    exact Submodule.starProjection_apply_mem _ _
+  · intro hψ
+    refine ⟨ψ, ?_⟩
+    change (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES (directSumTensor B) 2).starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm ψ)) = ψ
+    have hψES : (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm ψ ∈
+        groundSpaceES (directSumTensor B) 2 := by
+      apply (mem_groundSpaceES_iff (directSumTensor B) 2 _).2
+      simpa using hψ
+    rw [Submodule.starProjection_eq_self_iff.mpr hψES,
+      LinearEquiv.apply_symm_apply]
+
+/-- The physical transport target of the residual-family bond projector is
+the canonical two-site support projector of the direct-sum tensor.
+
+Source: arXiv:1606.00608, parent construction, lines 511--524, and equations
+(3.16)--(3.18), lines 549--578. -/
+theorem twoSiteBondSupportProjection_eq_complement
+    (h : ResidualFamilyAppendixBData B) :
+    h.twoSiteBondSupportProjection =
+      1 - parentInteraction (directSumTensor B) 2 := by
+  apply LinearMap.ext
+  intro v
+  change (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES (directSumTensor B) 2).starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v)) =
+    v - (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES (directSumTensor B) 2)ᗮ.starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v))
+  rw [Submodule.starProjection_orthogonal_val]
+  simp
+
+end ResidualFamilyAppendixBData
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- Whole-direct-sum transfer idempotence supplies simultaneous Appendix B
+data on the faithful Sigma-indexed residual-pair space.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
+543--555, and Corollary `III.cor3`, lines 583--589. -/
+theorem exists_residualFamilyAppendixBData
+    (hCF : IsBNTCanonicalForm P)
+    (hRFP : IsTransferIdempotent (directSumTensor P.basis)) :
+    Nonempty (ResidualFamilyAppendixBData P.basis) := by
+  obtain ⟨X, Λ, U, hX, hΛ, _hTrace, hBasis, hU⟩ :=
+    hCF.exists_residualIsometryFamily_of_isTransferIdempotent_basisDirectSum hRFP
+  let sector : (j : Fin P.basisCount) →
+      AppendixBStructuralData (P.basis j) := fun j ↦
+    { X := X j
+      Λ := fun k ↦ Real.sqrt (Λ j k)
+      U := U j
+      hX_det := hX j
+      hΛ_pos := fun k ↦ Real.sqrt_pos.2 (hΛ j k)
+      hU_pair := by
+        intro p q
+        rw [show (∑ i : Fin d, star (U j i p.1 p.2) * U j i q.1 q.2) =
+            ∑ i : Fin d, U j i q.1 q.2 * star (U j i p.1 p.2) by
+          apply Finset.sum_congr rfl
+          intro i _
+          exact mul_comm _ _]
+        rw [hU.1 j q.1 q.2 p.1 p.2]
+        by_cases hpq : p = q
+        · subst q
+          simp
+        · have hne : ¬ (q.1 = p.1 ∧ q.2 = p.2) := by
+            intro h
+            exact hpq (Prod.ext h.1.symm h.2.symm)
+          simp [hpq, hne]
+      hA_eq := hBasis j }
+  exact ⟨{ sector := sector, residual := hU }⟩
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/RFP/ResidualFamilySupport.lean
+++ b/TNLean/MPS/RFP/ResidualFamilySupport.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
-import TNLean.MPS.RFP.AppendixBCommutation
+import TNLean.MPS.RFP.AppendixBSupport
 import TNLean.MPS.RFP.ResidualWordSpan
 
 /-!
@@ -253,6 +253,11 @@ variable {P : SectorDecomposition d}
 
 /-- Whole-direct-sum transfer idempotence supplies simultaneous Appendix B
 data on the disjoint union of the within-sector residual-pair spaces.
+
+**Scope restriction (multiplicity-one canonical form):** this theorem treats
+one copy of each distinct normal tensor.  The repeated-copy physical-space
+construction in CPSV16, Corollary `III.cor3`, remains separate; see
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
 
 Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
 543--555, and Corollary `III.cor3`, lines 583--589. -/

--- a/TNLean/MPS/RFP/ResidualFamilySupport.lean
+++ b/TNLean/MPS/RFP/ResidualFamilySupport.lean
@@ -10,9 +10,9 @@ import TNLean.MPS.RFP.ResidualWordSpan
 /-!
 # Two-site support of a residual-isometry family
 
-This file constructs the common physical isometry carried by the valid
-Sigma-indexed virtual pairs of a family of distinct normal sectors.  The index
-space is
+This file constructs the common physical isometry carried by the disjoint
+union of the within-sector virtual pairs of a family of distinct normal
+sectors.  The index space is
 `BlockEntryIndex dim = Σ j, Fin (dim j) × Fin (dim j)`, not the full square
 of the direct-sum bond space: cross-sector virtual pairs are absent from the
 source isometry equation.
@@ -36,6 +36,37 @@ noncomputable def residualFamilyPhysicalIsometryMatrix
     Matrix (Fin d) (BlockEntryIndex dim) ℂ :=
   fun i x ↦ U x.1 i x.2.1 x.2.2
 
+/-- The one-letter Gram identity, written in the orientation used by the
+matrix of the common physical isometry. -/
+private theorem IsResidualIsometryFamily.residual_entry_gram
+    {U : (j : Fin r) → MPSTensor d (dim j)}
+    (hU : IsResidualIsometryFamily U)
+    (j k : Fin r) (a b : Fin (dim j)) (c e : Fin (dim k)) :
+    ∑ i : Fin d, star (U j i a b) * U k i c e =
+      if (⟨j, (a, b)⟩ : BlockEntryIndex dim) = ⟨k, (c, e)⟩ then 1 else 0 := by
+  have hGram := hU.wordEntryFamily_one_gram
+    (⟨k, (c, e)⟩ : BlockEntryIndex dim) ⟨j, (a, b)⟩
+  rw [← Equiv.sum_comp (Equiv.funUnique (Fin 1) (Fin d)).symm
+    (fun w : Fin 1 → Fin d ↦
+      wordEntryFamily U 1 ⟨k, (c, e)⟩ w *
+        star (wordEntryFamily U 1 ⟨j, (a, b)⟩ w))] at hGram
+  simp only [wordEntryFamily, blockEntryValue, wordTuple,
+    Equiv.funUnique_symm_apply, List.ofFn_succ, List.ofFn_zero,
+    evalWord_cons, evalWord_nil, mul_one, uniqueElim_const] at hGram
+  calc
+    ∑ i : Fin d, star (U j i a b) * U k i c e =
+        ∑ i : Fin d, U k i c e * star (U j i a b) := by
+          apply Finset.sum_congr rfl
+          intro i _
+          rw [mul_comm]
+    _ = if (⟨k, (c, e)⟩ : BlockEntryIndex dim) = ⟨j, (a, b)⟩ then 1 else 0 := hGram
+    _ = if (⟨j, (a, b)⟩ : BlockEntryIndex dim) = ⟨k, (c, e)⟩ then 1 else 0 := by
+      by_cases h : (⟨j, (a, b)⟩ : BlockEntryIndex dim) = ⟨k, (c, e)⟩
+      · rw [if_pos h, if_pos h.symm]
+      · have hk : (⟨k, (c, e)⟩ : BlockEntryIndex dim) ≠ ⟨j, (a, b)⟩ :=
+          fun hk ↦ h hk.symm
+        rw [if_neg h, if_neg hk]
+
 /-- The cross-sector residual-isometry equations say that the common physical
 matrix is an isometry on `BlockEntryIndex dim`.
 
@@ -49,20 +80,9 @@ theorem IsResidualIsometryFamily.residualFamilyPhysicalIsometryMatrix_isometry
   ext x y
   rcases x with ⟨j, a, b⟩
   rcases y with ⟨k, c, e⟩
-  by_cases hjk : j = k
-  · subst k
-    simp only [residualFamilyPhysicalIsometryMatrix, Matrix.mul_apply,
-      Matrix.conjTranspose_apply, Matrix.one_apply]
-    rw [show (∑ i : Fin d, star (U j i a b) * U j i c e) =
-        ∑ i : Fin d, U j i c e * star (U j i a b) by
-      apply Finset.sum_congr rfl
-      intro i _
-      exact mul_comm _ _]
-    rw [hU.1 j c e a b]
-    simp [eq_comm]
-  · have hCross := hU.2 k j (Ne.symm hjk) c e a b
-    simpa [residualFamilyPhysicalIsometryMatrix, Matrix.mul_apply,
-      Matrix.conjTranspose_apply, Matrix.one_apply, hjk, mul_comm] using hCross
+  simpa [residualFamilyPhysicalIsometryMatrix, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, Matrix.one_apply] using
+      hU.residual_entry_gram j k a b c e
 
 /-- Simultaneous Appendix B data for a finite family of sectors.  The fields
 are precisely the sectorwise product-pair form and the common cross-sector
@@ -83,7 +103,8 @@ namespace ResidualFamilyAppendixBData
 variable {B : (j : Fin r) → MPSTensor d (dim j)}
 
 /-- The boundary-coordinate space for the equal-sector two-site basic
-vectors.  It is the curried form of functions on `BlockEntryIndex dim`.
+vectors: for each sector, a coefficient function on its two outer
+virtual indices.
 
 Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
 abbrev TwoSiteBoundary (dim : Fin r → ℕ) :=
@@ -166,7 +187,7 @@ insertion.
 Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578, and the
 parent-space construction, lines 511--524. -/
 noncomputable def twoSiteBondSupportProjection
-    (_h : ResidualFamilyAppendixBData B) :
+    (B : (j : Fin r) → MPSTensor d (dim j)) :
     NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
   let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)
   e.toLinearMap.comp
@@ -180,7 +201,7 @@ Source: arXiv:1606.00608, equations `III_CFI_RFP` and (3.17)--(3.18), lines
 543--578. -/
 theorem twoSiteBondSupportProjection_range
     (h : ResidualFamilyAppendixBData B) :
-    LinearMap.range h.twoSiteBondSupportProjection =
+    LinearMap.range (twoSiteBondSupportProjection B) =
       LinearMap.range h.twoSiteBondEmbedding := by
   rw [h.twoSiteBondEmbedding_range_eq_directSum_groundSpace]
   ext ψ
@@ -210,8 +231,8 @@ the canonical two-site support projector of the direct-sum tensor.
 Source: arXiv:1606.00608, parent construction, lines 511--524, and equations
 (3.16)--(3.18), lines 549--578. -/
 theorem twoSiteBondSupportProjection_eq_complement
-    (h : ResidualFamilyAppendixBData B) :
-    h.twoSiteBondSupportProjection =
+    (B : (j : Fin r) → MPSTensor d (dim j)) :
+    twoSiteBondSupportProjection B =
       1 - parentInteraction (directSumTensor B) 2 := by
   apply LinearMap.ext
   intro v
@@ -231,7 +252,7 @@ namespace IsBNTCanonicalForm
 variable {P : SectorDecomposition d}
 
 /-- Whole-direct-sum transfer idempotence supplies simultaneous Appendix B
-data on the faithful Sigma-indexed residual-pair space.
+data on the disjoint union of the within-sector residual-pair spaces.
 
 Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
 543--555, and Corollary `III.cor3`, lines 583--589. -/
@@ -248,21 +269,8 @@ theorem exists_residualFamilyAppendixBData
       U := U j
       hX_det := hX j
       hΛ_pos := fun k ↦ Real.sqrt_pos.2 (hΛ j k)
-      hU_pair := by
-        intro p q
-        rw [show (∑ i : Fin d, star (U j i p.1 p.2) * U j i q.1 q.2) =
-            ∑ i : Fin d, U j i q.1 q.2 * star (U j i p.1 p.2) by
-          apply Finset.sum_congr rfl
-          intro i _
-          exact mul_comm _ _]
-        rw [hU.1 j q.1 q.2 p.1 p.2]
-        by_cases hpq : p = q
-        · subst q
-          simp
-        · have hne : ¬ (q.1 = p.1 ∧ q.2 = p.2) := by
-            intro h
-            exact hpq (Prod.ext h.1.symm h.2.symm)
-          simp [hpq, hne]
+      hU_pair := fun p q ↦ by
+        simpa using hU.residual_entry_gram j j p.1 p.2 q.1 q.2
       hA_eq := hBasis j }
   exact ⟨{ sector := sector, residual := hU }⟩
 

--- a/TNLean/MPS/RFP/ResidualWordSpan.lean
+++ b/TNLean/MPS/RFP/ResidualWordSpan.lean
@@ -24,7 +24,11 @@ namespace MPSTensor
 
 variable {d r : ℕ} {dim : Fin r → ℕ}
 
-private theorem IsResidualIsometryFamily.wordEntryFamily_one_gram
+/-- The one-letter entry vectors of a residual-isometry family have identity
+Gram matrix on the Sigma-indexed space of valid sector entries.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+theorem IsResidualIsometryFamily.wordEntryFamily_one_gram
     {U : (j : Fin r) → MPSTensor d (dim j)}
     (hU : IsResidualIsometryFamily U) (x y : BlockEntryIndex dim) :
     ∑ w : Fin 1 → Fin d,

--- a/TNLean/MPS/RFP/ResidualWordSpan.lean
+++ b/TNLean/MPS/RFP/ResidualWordSpan.lean
@@ -25,7 +25,7 @@ namespace MPSTensor
 variable {d r : ℕ} {dim : Fin r → ℕ}
 
 /-- The one-letter entry vectors of a residual-isometry family have identity
-Gram matrix on the Sigma-indexed space of valid sector entries.
+Gram matrix on the disjoint union of the within-sector virtual pairs.
 
 Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
 theorem IsResidualIsometryFamily.wordEntryFamily_one_gram

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1548,7 +1548,8 @@ specialization of that Appendix~D definition.
     \leanok
     \uses{lem:residual_isometry_family_one_gram,
         def:residual_family_two_site_support,
-        thm:appendixB_two_site_basic_embedding_range}
+        thm:appendixB_two_site_basic_embedding_range,
+        def:parent_interaction}
     The common physical map is an isometry,
     \[
         V^*V=1.
@@ -1571,6 +1572,8 @@ specialization of that Appendix~D definition.
     If the $B_j$ form a basis of normal tensors and their direct sum is a
     renormalization fixed point, the sectorwise Appendix~B decompositions and
     the common residual isometry required above exist.
+% Scope restriction (multiplicity-one canonical form): repeated copies remain
+% outside this statement; see docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1503,6 +1503,88 @@ specialization of that Appendix~D definition.
     \]
 \end{proof}
 
+\begin{definition}[Two-site support of a residual isometry family]
+    \label{def:residual_family_two_site_support}
+    \lean{MPSTensor.residualFamilyPhysicalIsometryMatrix}
+    \lean{MPSTensor.ResidualFamilyAppendixBData}
+    \lean{MPSTensor.ResidualFamilyAppendixBData.TwoSiteBoundary}
+    \lean{MPSTensor.ResidualFamilyAppendixBData.twoSiteBondEmbedding}
+    \lean{MPSTensor.ResidualFamilyAppendixBData.twoSiteBondSupportProjection}
+    \leanok
+    \uses{def:is_residual_isometry_family,
+        def:appendixB_two_site_bond_embedding,
+        def:appendixB_two_site_basic_support_projector}
+    Let
+    \[
+        \mathcal V=\bigsqcup_j\{j\}\times[D_j]\times[D_j]
+    \]
+    be the disjoint union of the within-sector virtual pairs, and let
+    $V:\mathcal V\to\mathbb C^d$ be the common physical map whose matrix
+    elements are
+    \[
+        V_{i,(j,\alpha,\beta)}=(U_j^i)_{\alpha,\beta}.
+    \]
+    For each sector insert the vector
+    $\ket{\varphi_j}=\sum_b\lambda_{j,b}\ket{b,b}$ on the middle virtual
+    bond, apply $V$ on both sites, and sum the resulting physical vectors.
+    This defines the equal-sector two-site embedding
+    \[
+        I_{\mathrm{res}}:\prod_j\mathbb C^{D_j\times D_j}
+            \longrightarrow (\mathbb C^d)^{\otimes2}.
+    \]
+    Unequal-sector virtual bonds do not occur.  The corresponding physical
+    support operator $P_{2,\mathrm{res}}$ is the orthogonal projector onto
+    $G_2(\bigoplus_j B_j)$.
+\end{definition}
+
+\begin{theorem}[Range of the residual-family bond embedding]
+    \label{thm:residual_family_two_site_support}
+    \lean{MPSTensor.IsResidualIsometryFamily.residualFamilyPhysicalIsometryMatrix_isometry}
+    \lean{MPSTensor.ResidualFamilyAppendixBData.twoSiteBondEmbedding_range}
+    \lean{MPSTensor.ResidualFamilyAppendixBData.twoSiteBondEmbedding_range_eq_directSum_groundSpace}
+    \lean{MPSTensor.ResidualFamilyAppendixBData.twoSiteBondSupportProjection_range}
+    \lean{MPSTensor.ResidualFamilyAppendixBData.twoSiteBondSupportProjection_eq_complement}
+    \lean{MPSTensor.IsBNTCanonicalForm.exists_residualFamilyAppendixBData}
+    \leanok
+    \uses{lem:residual_isometry_family_one_gram,
+        def:residual_family_two_site_support,
+        thm:appendixB_two_site_basic_embedding_range}
+    The common physical map is an isometry,
+    \[
+        V^*V=1.
+    \]
+    Moreover, the equal-sector bond embedding and the physical support
+    projector satisfy
+    \[
+        \operatorname{ran}(I_{\mathrm{res}})
+        =\sum_j G_2(B_j)
+        =G_2\!\left(\bigoplus_j B_j\right),
+        \qquad
+        \operatorname{ran}(P_{2,\mathrm{res}})
+        =\operatorname{ran}(I_{\mathrm{res}}),
+    \]
+    and
+    \[
+        P_{2,\mathrm{res}}
+        =1-q_2\!\left(\bigoplus_j B_j\right).
+    \]
+    If the $B_j$ form a basis of normal tensors and their direct sum is a
+    renormalization fixed point, the sectorwise Appendix~B decompositions and
+    the common residual isometry required above exist.
+\end{theorem}
+
+\begin{proof}\leanok
+    The first identity is the one-letter Gram identity on the disjoint union
+    of the within-sector virtual pairs.  In each sector, the bond insertion
+    has range $G_2(B_j)$; allowing independent outer-boundary coefficients
+    and summing over sectors therefore gives $\sum_jG_2(B_j)$.  The local
+    ground space of a direct sum is this sum, which proves the two range
+    identities.  Orthogonal projection onto that space is complementary to
+    its parent interaction.  Finally, the residual-isometry form of the
+    cross-block fixed-point structure supplies the simultaneous sector
+    decompositions.
+\end{proof}
+
 \begin{theorem}[Commutation of adjacent two-site basic support projectors]
     \label{thm:appendixB_two_site_basic_support_projectors_commute}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicSupportProjection_commute_lifts}

--- a/blueprint/src/chapter/ch26_mps_rfp_core.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_core.tex
@@ -1121,6 +1121,29 @@ of the per-block theorem above.
     and $j\ne j'$ cases.
 \end{definition}
 
+\begin{lemma}[One-letter Gram matrix of a residual isometry family]%
+    \label{lem:residual_isometry_family_one_gram}
+    \lean{MPSTensor.IsResidualIsometryFamily.wordEntryFamily_one_gram}
+    \leanok
+    \uses{def:is_residual_isometry_family}
+    Let
+    \[
+        \mathcal V=\bigsqcup_j\{j\}\times [D_j]\times[D_j]
+    \]
+    be the disjoint union of the within-sector virtual pairs.  For
+    $x=(j,\alpha,\beta)$ in $\mathcal V$, set
+    $u_x(i)=(U_j^i)_{\alpha,\beta}$.  Then
+    \[
+        \sum_i u_x(i)\overline{u_y(i)}=\delta_{x,y}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    If $x$ and $y$ belong to the same sector, the assertion is the
+    within-sector part of the residual isometry condition.  If they belong to
+    distinct sectors, it is the cross-sector vanishing condition.
+\end{proof}
+
 \begin{lemma}[Covariance of the mixed transfer operator]%
     \label{lem:mixed_transfer_conj_apply}
     \lean{MPSTensor.mixedTransferMap₂_conj_apply}


### PR DESCRIPTION
### Motivation

- CPSV16, arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, express the common physical isometry of a basis of normal tensors.
- Equations (3.16)--(3.18), source lines 549--578, identify the sectorwise two-site bond supports used in the commuting-parent argument.
- Issue #4441 requires these supports on the disjoint union of within-sector virtual pairs, before the remaining adjacent-commutation calculation can be stated faithfully.

### Description

- Add the one-letter residual-family Gram identity and prove that the common physical matrix is an isometry.
- Introduce simultaneous sectorwise Appendix B hypotheses, the equal-sector two-site bond embedding, and its orthogonal support projector.
- Prove that the embedding range is the two-site ground space of the direct-sum tensor and that the support projector is the complement of the parent interaction.
- Construct these hypotheses from BNT canonical form plus whole-direct-sum transfer idempotence, without adding a hypothesis to the eventual consumer.
- Add complete chapter 13 and chapter 26 blueprint entries, use mathematical prose throughout, and keep `NNCPHMultiSector` on its direct import.

The contribution does not yet close #4441. The remaining source step is to construct the equal-sector virtual bond matrix (Q), prove commutation of its two adjacent placements, and identify its transport through the common physical isometry with the two-site support projector. This requires no new hypothesis, but is a separate dependent-sum matrix argument.

### Testing

- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- blueprint--Lean synchronization check
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity search on all changed Lean files
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

Addresses #4441
Related: #4436, #4342, #2633.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-style proofs and blueprint sync on the RFP path; no auth, runtime, or API surface changes beyond library imports.
> 
> **Overview**
> **Adds** formal infrastructure for the **two-site support** of a **residual-isometry family** over distinct normal sectors (within-sector virtual pairs only), ahead of adjacent-commutation work on issue #4441.
> 
> A new module defines the **common physical isometry matrix** `residualFamilyPhysicalIsometryMatrix`, proves **\(V^*V = 1\)** from the residual Gram identity, and packages **simultaneous Appendix B data** in `ResidualFamilyAppendixBData`. It defines the **equal-sector two-site bond embedding** `twoSiteBondEmbedding`, shows its range is \(\bigvee_j G_2(B_j) = G_2(\bigoplus_j B_j)\), and identifies the **support projector** with **\(1 - q_2(\bigoplus_j B_j)\)**. **BNT canonical form** plus **whole-direct-sum transfer idempotence** yields `exists_residualFamilyAppendixBData` (multiplicity-one scope; repeated copies still documented separately).
> 
> **`IsResidualIsometryFamily.wordEntryFamily_one_gram`** is promoted from `private` to a public theorem in `ResidualWordSpan.lean` for reuse. **`TNLean.lean`** imports the new module. **Blueprint** chapter 13 gains definition `def:residual_family_two_site_support` and theorem `thm:residual_family_two_site_support`; chapter 26 adds lemma `lem:residual_isometry_family_one_gram`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0a50009d70b46175a6b77bc9237aa8f10c8547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->