### PR TITLE
fix(ci): isolate agent mention checkout credentials

### DIFF
--- a/.github/workflows/agent-mention.yml
+++ b/.github/workflows/agent-mention.yml
@@ -21,9 +21,6 @@ concurrency:
   group: agent-mention-${{ github.event.issue.number || github.event.pull_request.number || github.event.comment.id }}
   cancel-in-progress: false
 
-env:
-  GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
-
 jobs:
   respond:
     # Skip when:
@@ -108,7 +105,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-          token: ${{ env.GH_TOKEN }}
 
       - name: Set up Lean toolchain and cache
         uses: texra-ai/lean-env-action@v1
@@ -166,4 +162,4 @@ jobs:
           comment-body: ${{ github.event.comment.body || '' }}
           issue-body: ${{ github.event.issue.body || '' }}
           issue-title: ${{ github.event.issue.title || '' }}
-          gh-token: ${{ env.GH_TOKEN }}
+          gh-token: ${{ secrets.BOT_PAT || github.token }}


### PR DESCRIPTION
### Motivation

Agent Mention could not start the exact-head Claude review requested on #4444 because repository checkout failed before the agent step.

- [Run 29708454141, attempt 1](https://github.com/LionSR/TNLean/actions/runs/29708454141/attempts/1): `actions/checkout` installed a nonempty masked HTTP credential, but all three fetch attempts ended with `fatal: could not read Username for 'https://github.com': terminal prompts disabled`.
- [Run 29708454141, attempt 2](https://github.com/LionSR/TNLean/actions/runs/29708454141/attempts/2): the single rerun failed at the same checkout stage with the same three authentication failures.

In both attempts, `Run mentioned agent` was skipped.

### Root cause

The workflow supplied checkout with `${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}` through a job-global `GH_TOKEN`. Because the `BOT_PAT` secret exists, GitHub Actions selected it and never used the repository-scoped fallback. The checkout logs show that this token was nonempty and configured as the HTTP authorization header, but GitHub rejected it. The stored PAT is therefore stale, revoked, or otherwise invalid.

### Change

- Let `actions/checkout@v6` use its default per-job `${{ github.token }}`.
- Remove the long-lived PAT from the job-global environment.
- Preserve `${{ secrets.BOT_PAT || github.token }}` only on the issue-origin PR-creation input, where a non-`GITHUB_TOKEN` credential may be needed to trigger subsequent workflows.

The review agent itself does not require the PAT: `anthropics/claude-code-action@v1` exchanges the workflow OIDC identity for a scoped GitHub App token and installs that token for its own GitHub operations.

### Security

Checkout now uses an ephemeral, repository-scoped token bounded by the existing job permissions and lifetime. No permission is added. The long-lived PAT is no longer exposed to checkout, setup actions, or ordinary review-agent execution.

The stale `BOT_PAT` should still be rotated or removed administratively for issue-origin automatic PR creation. That separate action does not justify keeping PR-review checkout dependent on the stale credential.

### Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/agent-mention.yml`
- `git diff --check`
- Exact scope check: only `.github/workflows/agent-mention.yml` changes.

Closes #4451