### PR TITLE
refactor(MPS/RFP): share Beigi transport witnesses

### DIFF
--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -323,9 +323,7 @@ private theorem groundBondProduct_mulVec_loopProductState
         (star (F.unitary ⊗ₖ F.unitary) *
           twoSiteParentGroundProjectorMatrix A *
             (F.unitary ⊗ₖ F.unitary)))).prod
-  have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
-    simpa only [Matrix.star_eq_conjTranspose] using
-      Unitary.mul_star_self_of_mem F.unitary_mem
+  have hUUstar := F.unitary_mul_conjTranspose
   have hWWstar : W * Wᴴ = 1 := by
     simp only [W]
     rw [MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose, hUUstar,

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -147,6 +147,14 @@ theorem edgeProjector_isProj (F : BeigiSectorGraphData A)
   rw [Module.End.mul_eq_comp, ← Matrix.toLin'_mul,
     (F.edgeProjector_isOrthogonal a b).2.eq]
 
+/-- The spatial coordinate matrix is right-unitary.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+theorem unitary_mul_conjTranspose (F : BeigiSectorGraphData A) :
+    F.unitary * F.unitaryᴴ = 1 := by
+  simpa only [Matrix.star_eq_conjTranspose] using
+    Unitary.mul_star_self_of_mem F.unitary_mem
+
 /-- A directed edge is present exactly when its edge ground space is nonzero.
 
 Source: Beigi, arXiv:1105.1019v2, Section III, graph definition immediately
@@ -291,9 +299,7 @@ theorem singleKrausMap_groundBondProduct (F : BeigiSectorGraphData A)
   have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
     simpa only [Matrix.star_eq_conjTranspose] using
       Unitary.star_mul_self_of_mem F.unitary_mem
-  have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
-    simpa only [Matrix.star_eq_conjTranspose] using
-      Unitary.mul_star_self_of_mem F.unitary_mem
+  have hUUstar := F.unitary_mul_conjTranspose
   have hprod := MPOTensor.singleKrausMap_bondProduct_of_unitary F.unitaryᴴ
     (by simpa using hUUstar) (by simpa using hUstarU) hN (groundBond A)
   simp_rw [singleKrausMap_groundBond_eq_transformedGroundBond] at hprod
@@ -314,12 +320,9 @@ private theorem groundBondEmbeddings_commute (F : BeigiSectorGraphData A)
         (finTwoArrowEquiv (Fin d)).symm F.transformedGroundBond)
   have hUstarU : star F.unitary * F.unitary = 1 :=
     Unitary.star_mul_self_of_mem F.unitary_mem
-  have hUUstar : F.unitary * star F.unitary = 1 :=
-    Unitary.mul_star_self_of_mem F.unitary_mem
   have hUstarU' : F.unitaryᴴ * F.unitary = 1 := by
     simpa only [Matrix.star_eq_conjTranspose] using hUstarU
-  have hUUstar' : F.unitary * F.unitaryᴴ = 1 := by
-    simpa only [Matrix.star_eq_conjTranspose] using hUUstar
+  have hUUstar' := F.unitary_mul_conjTranspose
   have hWstarW : Wᴴ * W = 1 := by
     simp only [W, MPOTensor.sitewisePhysicalMatrix_conjTranspose,
       Matrix.conjTranspose_conjTranspose]
@@ -465,9 +468,7 @@ private theorem groundBondProduct_trace (F : BeigiSectorGraphData A)
   let W := MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N
   let Q := (List.ofFn fun i : Fin N ↦
     MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
-  have hUUstar : F.unitary * F.unitaryᴴ = 1 := by
-    simpa only [Matrix.star_eq_conjTranspose] using
-      Unitary.mul_star_self_of_mem F.unitary_mem
+  have hUUstar := F.unitary_mul_conjTranspose
   have hWstarW : Wᴴ * W = 1 := by
     simp only [W, MPOTensor.sitewisePhysicalMatrix_conjTranspose,
       Matrix.conjTranspose_conjTranspose]
@@ -530,6 +531,28 @@ private theorem conj_localComplementProduct {N : ℕ} :
   simp only [Function.comp_apply, map_sub, map_one, localTermES,
     LinearEquiv.conjAlgEquiv_apply, LinearEquiv.symm_symm]
 
+/-- The three realizations of the complete complementary-interaction product,
+together with the canonical identifications between them. -/
+private structure ComplementProductTransport (A : MPSTensor d D)
+    (N : ℕ) [NeZero N] (hN : 2 ≤ N) where
+  qMatrix : Matrix (Cfg d N) (Cfg d N) ℂ
+  qRaw : Module.End ℂ (NSiteSpace d N)
+  qES : Module.End ℂ (EuclideanSpace ℂ (Cfg d N))
+  e : EuclideanSpace ℂ (Cfg d N) ≃ₗ[ℂ] NSiteSpace d N
+  hMatrix : Matrix.toLin' qMatrix = qRaw
+  hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES
+
+private noncomputable def complementProductTransport (A : MPSTensor d D)
+    {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
+    ComplementProductTransport A N hN where
+  qMatrix := (List.ofFn fun i : Fin N ↦
+    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
+  qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
+  qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
+  e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  hMatrix := toLin'_groundBondProduct (A := A) hN
+  hES := conj_localComplementProduct (A := A) (N := N)
+
 private theorem localComplementProductES_trace (F : BeigiSectorGraphData A)
     {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
     LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N))
@@ -538,25 +561,18 @@ private theorem localComplementProductES_trace (F : BeigiSectorGraphData A)
         (↑(∏ n : Fin N,
           Module.finrank ℂ (F.edgeGroundSpace (k n) (k (n + 1)))) : ℂ) := by
   classical
-  let qMatrix := (List.ofFn fun i : Fin N ↦
-    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
-  let qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
-  let qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
-  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
-  have hMatrix : Matrix.toLin' qMatrix = qRaw := by
-    simpa only [qMatrix, qRaw] using
-      (toLin'_groundBondProduct (A := A) hN)
-  have hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES := by
-    simpa only [e, qRaw, qES] using
-      (conj_localComplementProduct (A := A) (N := N))
+  let transport := complementProductTransport A hN
+  change LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N)) transport.qES = _
   calc
-    LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N)) qES =
-        LinearMap.trace ℂ (NSiteSpace d N) qRaw := by
-          rw [← hES]
-          exact LinearMap.trace_conj' qRaw e.symm
-    _ = Matrix.trace qMatrix := by
-      rw [← hMatrix, Matrix.trace_toLin'_eq]
-    _ = _ := F.groundBondProduct_trace hN
+    LinearMap.trace ℂ (EuclideanSpace ℂ (Cfg d N)) transport.qES =
+        LinearMap.trace ℂ (NSiteSpace d N) transport.qRaw := by
+          rw [← transport.hES]
+          exact LinearMap.trace_conj' transport.qRaw transport.e.symm
+    _ = Matrix.trace transport.qMatrix := by
+      rw [← transport.hMatrix, Matrix.trace_toLin'_eq]
+    _ = _ := by
+      simpa only [transport, complementProductTransport] using
+        F.groundBondProduct_trace hN
 
 private theorem parentHamiltonianGroundSpaceES_finrank_eq_all_sequences
     (F : BeigiSectorGraphData A) {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
@@ -598,35 +614,27 @@ theorem mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self
           (twoSiteParentGroundProjectorMatrix A))).prod).mulVec v = v) :
     v ∈ LinearMap.ker (parentHamiltonian A 2 N) := by
   classical
-  let qMatrix := (List.ofFn fun i : Fin N ↦
-    MPOTensor.embedLocalOperator (d := d) 2 N hN i (groundBond A)).prod
-  let qRaw := (List.ofFn fun i : Fin N ↦ 1 - localTerm A 2 N i).prod
-  let qES := (List.ofFn fun i : Fin N ↦ 1 - localTermES A 2 i).prod
-  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
-  have hMatrix : Matrix.toLin' qMatrix = qRaw := by
-    simpa only [qMatrix, qRaw] using
-      (toLin'_groundBondProduct (A := A) hN)
-  have hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES := by
-    simpa only [e, qRaw, qES] using
-      (conj_localComplementProduct (A := A) (N := N))
-  have hraw : qRaw v = v := by
-    rw [← hMatrix, Matrix.toLin'_apply]
+  let transport := complementProductTransport A hN
+  have hraw : transport.qRaw v = v := by
+    rw [← transport.hMatrix, Matrix.toLin'_apply]
     exact hv
-  have hfixES : qES (e.symm v) = e.symm v := by
-    rw [← hES]
+  have hfixES : transport.qES (transport.e.symm v) = transport.e.symm v := by
+    rw [← transport.hES]
     simp only [LinearEquiv.conjAlgEquiv_apply]
-    change e.symm (qRaw (e (e.symm v))) = e.symm v
-    rw [e.apply_symm_apply, hraw]
+    change transport.e.symm
+      (transport.qRaw (transport.e (transport.e.symm v))) = transport.e.symm v
+    rw [transport.e.apply_symm_apply, hraw]
   have hproj := LinearMap.isProj_ker_sum_listProd_one_sub
     (fun i : Fin N ↦ localTermES A 2 i)
     (fun i ↦ localTermES_isSymmetricProjection A 2 i)
     (fun i j ↦ F.localTermES_commute hN i j)
   rw [← parentHamiltonianES_eq_sum_localTermES] at hproj
-  have hkerES : e.symm v ∈ LinearMap.ker (parentHamiltonianES A 2 N) :=
+  have hkerES : transport.e.symm v ∈
+      LinearMap.ker (parentHamiltonianES A 2 N) :=
     hproj.mem_iff_map_id.mpr hfixES
   rw [LinearMap.mem_ker] at hkerES ⊢
-  have h := congrArg e hkerES
-  simpa [parentHamiltonianES, e] using h
+  have h := congrArg transport.e hkerES
+  simpa [parentHamiltonianES, transport, complementProductTransport] using h
 
 /-- Beigi's finite-chain ground-space dimension formula: for a periodic chain
 of length greater than two, the dimension is the sum over ordered cyclic

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -542,6 +542,8 @@ private structure ComplementProductTransport (A : MPSTensor d D)
   hMatrix : Matrix.toLin' qMatrix = qRaw
   hES : (LinearEquiv.conjAlgEquiv ℂ e.symm) qRaw = qES
 
+/-- The canonical matrix, raw-linear, and Euclidean transport witness for the
+complete complementary-interaction product. -/
 private noncomputable def complementProductTransport (A : MPSTensor d D)
     {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
     ComplementProductTransport A N hN where

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2629,7 +2629,8 @@ specialization of that Appendix~D definition.
 \end{lemma}
 
 \begin{proof}\leanok
-    This is the right-unitarity identity for the spatial coordinate matrix.
+    Since the spatial coordinate matrix is unitary, multiplying it by its
+    adjoint gives the identity.
 \end{proof}
 
 \begin{theorem}[Spatial conjugation of complementary interaction products]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2360,6 +2360,7 @@ specialization of that Appendix~D definition.
 
 \begin{definition}[Finite sector graph]\label{def:beigi_sector_graph}
     \lean{MPSTensor.BeigiSectorGraphData}
+    \lean{MPSTensor.BeigiSectorGraphData.unitary_mul_conjTranspose}
     \lean{MPSTensor.BeigiSectorGraphData.edgeGroundSpace}
     \lean{MPSTensor.BeigiSectorGraphData.IsEdge}
     \lean{MPSTensor.BeigiSectorGraphData.OrderedCycle}
@@ -2614,23 +2615,6 @@ specialization of that Appendix~D definition.
     \]
     Substitution of the preceding cyclic coefficient formula gives the stated
     sitewise-unitary image.
-\end{proof}
-
-\begin{lemma}[Right-unitarity of the Beigi spatial coordinate matrix]
-    \label{lem:beigi_spatial_coordinate_right_unitary}
-    \lean{MPSTensor.BeigiSectorGraphData.unitary_mul_conjTranspose}
-    \leanok
-    \uses{def:beigi_sector_graph}
-    Suppose that $A$ is equipped with Beigi sector data, with one-site spatial
-    unitary $U$.  Then
-    \[
-        UU^*=\mathbf 1.
-    \]
-\end{lemma}
-
-\begin{proof}\leanok
-    Since the spatial coordinate matrix is unitary, multiplying it by its
-    adjoint gives the identity.
 \end{proof}
 
 \begin{theorem}[Spatial conjugation of complementary interaction products]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2616,9 +2616,24 @@ specialization of that Appendix~D definition.
     sitewise-unitary image.
 \end{proof}
 
+\begin{lemma}[Right-unitarity of the Beigi spatial coordinate matrix]
+    \label{lem:beigi_spatial_coordinate_right_unitary}
+    \lean{MPSTensor.BeigiSectorGraphData.unitary_mul_conjTranspose}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    Suppose that $A$ is equipped with Beigi sector data, with one-site spatial
+    unitary $U$.  Then
+    \[
+        UU^*=\mathbf 1.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    This is the right-unitarity identity for the spatial coordinate matrix.
+\end{proof}
+
 \begin{theorem}[Spatial conjugation of complementary interaction products]
     \label{thm:beigi_complement_product_conjugation}
-    \lean{MPSTensor.BeigiSectorGraphData.unitary_mul_conjTranspose}
     \lean{MPSTensor.BeigiSectorGraphData.singleKrausMap_groundBondProduct}
     \leanok
     \uses{def:beigi_sector_graph}
@@ -2671,11 +2686,11 @@ specialization of that Appendix~D definition.
         =\prod_{n=0}^{N-1}(\mathbf 1-h_n^{\mathrm{E}}).
     \]
     The operators $h_n^{\mathrm{E}}$ are orthogonal projections.  Beigi sector
-    data supply pairwise commutativity, which Euclidean transport preserves:
+    data supply pairwise commutativity, which Euclidean transport preserves.
+    For all $0\leq m,n<N$,
     \[
         h_m^{\mathrm{E}}h_n^{\mathrm{E}}
-        =h_n^{\mathrm{E}}h_m^{\mathrm{E}}
-        \qquad (0\leq m,n<N).
+        =h_n^{\mathrm{E}}h_m^{\mathrm{E}}.
     \]
     For any commuting orthogonal projections $P_0,\ldots,P_{N-1}$,
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2618,6 +2618,7 @@ specialization of that Appendix~D definition.
 
 \begin{theorem}[Spatial conjugation of complementary interaction products]
     \label{thm:beigi_complement_product_conjugation}
+    \lean{MPSTensor.BeigiSectorGraphData.unitary_mul_conjTranspose}
     \lean{MPSTensor.BeigiSectorGraphData.singleKrausMap_groundBondProduct}
     \leanok
     \uses{def:beigi_sector_graph}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2669,7 +2669,13 @@ specialization of that Appendix~D definition.
         Q_N^{\mathrm{E}}=E^{-1}Q_NE
         =\prod_{n=0}^{N-1}(\mathbf 1-h_n^{\mathrm{E}}).
     \]
-    The operators $h_n^{\mathrm{E}}$ are commuting orthogonal projections.
+    The operators $h_n^{\mathrm{E}}$ are orthogonal projections.  Beigi sector
+    data supply pairwise commutativity, which Euclidean transport preserves:
+    \[
+        h_m^{\mathrm{E}}h_n^{\mathrm{E}}
+        =h_n^{\mathrm{E}}h_m^{\mathrm{E}}
+        \qquad (0\leq m,n<N).
+    \]
     For any commuting orthogonal projections $P_0,\ldots,P_{N-1}$,
     \[
         \prod_{n=0}^{N-1}(\mathbf 1-P_n)


### PR DESCRIPTION
## Summary

This corrective follow-up addresses the three exact post-merge review findings on #4431.

- The chapter 13 proof now displays the Euclidean commutativity relation h_m^E h_n^E = h_n^E h_m^E before applying the commuting-projector product identity.
- A private ComplementProductTransport bundle now supplies the matrix, coefficient-space, and Euclidean realizations of the complete complementary-interaction product and both canonical transport equalities. The trace proof and the fixed-vector proof reuse this single bundle.
- BeigiSectorGraphData.unitary_mul_conjTranspose records the mathematically useful right-unitarity consequence of the spatial coordinate data, replacing the three repeated derivations in BeigiSectorGraph.lean and BeigiLoopTensor.lean. The public helper is tagged in the existing spatial-conjugation blueprint theorem.

No theorem statement changes. No spanning, BNT-identification, or #4440 mathematics is included.

## Source

Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3 and source lines 487–500.

## Validation

- lake build TNLean.MPS.RFP.BeigiSectorGraph
- lake env lean TNLean/MPS/RFP/BeigiLoopTensor.lean
- lake build — 9620 jobs
- leanblueprint checkdecls
- leanblueprint web
- leanblueprint pdf — 686 pages
- blueprint_lean_sync.py --update-lean-decls and --ci
- git diff --check
- proof-integrity search over both changed Lean files
- changed Lean files remain below 1000 lines

The final rebase from 6b47095f onto current main d04ea23c has an unchanged two-entry range-diff.

## Review provenance

Follow-up to #4431 and the post-merge discussions:

- https://github.com/LionSR/TNLean/pull/4431#discussion_r3611604341
- https://github.com/LionSR/TNLean/pull/4431#discussion_r3611606744
- https://github.com/LionSR/TNLean/pull/4431#discussion_r3611606877

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure and documentation-only refactor with no statement changes; risk is limited to accidental proof regressions in MPS/RFP Beigi files.
> 
> **Overview**
> Refactors Beigi sector-graph proofs without changing any theorem statements.
> 
> **Shared right-unitarity:** Adds `BeigiSectorGraphData.unitary_mul_conjTranspose` and uses it in `BeigiSectorGraph.lean` and `BeigiLoopTensor.lean` instead of repeating the same `Unitary.mul_star_self_of_mem` argument.
> 
> **Complementary-product transport:** Introduces private `ComplementProductTransport` and `complementProductTransport`, bundling the matrix, raw linear, and Euclidean realizations of the full complementary-interaction product plus the `toLin'` and conjugation links. `localComplementProductES_trace` and `mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self` both pull from this bundle.
> 
> **Blueprint:** Tags `unitary_mul_conjTranspose` on the finite sector graph definition and spells out Euclidean commutativity \(h_m^{\mathrm{E}} h_n^{\mathrm{E}} = h_n^{\mathrm{E}} h_m^{\mathrm{E}}\) before the commuting-projector product identity in the fixed-vector proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 007cdc1a57c44ba29629d881d679b8456121b98a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->