### PR TITLE
feat(MPS/MPDO): realize normalized vertical-sector maps as Kraus maps

### DIFF
--- a/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRetractions.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.FixedPoint.DirectSumKraus
 import TNLean.Channel.PartialTrace
 import TNLean.MPS.MPDO.Defs
 
@@ -123,6 +124,162 @@ theorem verticalSectorPartialTrace_apply {g : ℕ} (dim mult : Fin g → ℕ)
     (Y : VerticalWeightedSectorSpace dim mult) (α : Fin g) :
     verticalSectorPartialTrace dim mult Y α = Matrix.traceLeft (Y α) :=
   rfl
+
+/-- Exchange the multiplicity and simple-matrix coordinates within every
+vertical sector.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1961--1970. -/
+def verticalSectorSwapEquiv {g : ℕ} (dim mult : Fin g → ℕ) :
+    (Σ α, Fin (mult α) × Fin (dim α)) ≃
+      (Σ α, Fin (dim α) × Fin (mult α)) where
+  toFun x := ⟨x.1, x.2.swap⟩
+  invFun x := ⟨x.1, x.2.swap⟩
+  left_inv x := by
+    obtain ⟨α, i, j⟩ := x
+    rfl
+  right_inv x := by
+    obtain ⟨α, i, j⟩ := x
+    rfl
+
+/-- The normalized embedding of the simple vertical-sector algebras is
+completely positive as a map between finite sums of matrix algebras.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1957--1968. -/
+theorem normalizedVerticalSectorEmbedding_isKrausDirectSumMap
+    {g : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q) :
+    Matrix.IsKrausDirectSumMap
+      (normalizedVerticalSectorEmbedding dim mult weight) := by
+  let ρ : (α : Fin g) → Matrix (Fin (mult α)) (Fin (mult α)) ℂ :=
+    fun α ↦ (verticalMultiplicityTrace weight α)⁻¹ •
+      Matrix.diagonal (weight α)
+  have hTrace (α : Fin g) : 0 < verticalMultiplicityTrace weight α := by
+    apply Finset.sum_pos'
+    · intro q _
+      exact (hWeight α q).le
+    · let q : Fin (mult α) := ⟨0, hMult α⟩
+      exact ⟨q, Finset.mem_univ q, hWeight α q⟩
+  have hρ (α : Fin g) : (ρ α).PosSemidef := by
+    dsimp only [ρ]
+    exact (Matrix.PosSemidef.diagonal (fun q ↦ (hWeight α q).le)).smul
+      (inv_nonneg.mpr (hTrace α).le)
+  have hρTrace (α : Fin g) : Matrix.trace (ρ α) = 1 := by
+    simp only [ρ, Matrix.trace_smul, Matrix.trace_diagonal]
+    change (verticalMultiplicityTrace weight α)⁻¹ *
+      verticalMultiplicityTrace weight α = 1
+    field_simp [ne_of_gt (hTrace α)]
+  let P :
+      Matrix (Σ α, Fin (dim α)) (Σ α, Fin (dim α)) ℂ →ₗ[ℂ]
+        Matrix (Σ α, Fin (dim α) × Fin (mult α))
+          (Σ α, Fin (dim α) × Fin (mult α)) ℂ :=
+    Matrix.controlledKrausMap
+      (fun α ↦ Fintype.card (Fin (mult α)))
+      (fun α j ↦ Matrix.preparationKraus (ρ α) (hρ α)
+        ((Fintype.equivFin (Fin (mult α))).symm j))
+  have hP : IsKrausCPTP P := by
+    dsimp only [P]
+    apply Matrix.controlledKrausMap_isKrausCPTP
+    intro α
+    exact Matrix.preparationKraus_resolution (ρ α) (hρ α) (hρTrace α)
+  change IsKrausCP
+    (Matrix.directSumMapExtension
+      (normalizedVerticalSectorEmbedding dim mult weight))
+  rw [show Matrix.directSumMapExtension
+      (normalizedVerticalSectorEmbedding dim mult weight) =
+        Matrix.equivReindexMap (verticalSectorSwapEquiv dim mult).symm ∘ₗ P by
+    apply LinearMap.ext
+    intro Z
+    ext ⟨α, ⟨q, i⟩⟩ ⟨β, ⟨s, j⟩⟩
+    by_cases hαβ : α = β
+    · subst β
+      simp only [Matrix.directSumMapExtension_apply,
+        Matrix.directSumDiagonalEmbedding_apply,
+        Matrix.blockDiagonal'_apply_eq,
+        normalizedVerticalSectorEmbedding_apply,
+        Matrix.directSumDiagonalCompression_apply,
+        Matrix.smul_apply,
+        Matrix.kroneckerMap_apply,
+        LinearMap.comp_apply,
+        Matrix.equivReindexMap,
+        LinearEquiv.coe_toLinearMap,
+        Matrix.coe_reindexLinearEquiv,
+        Matrix.reindex_apply,
+        Matrix.submatrix_apply,
+        verticalSectorSwapEquiv]
+      change _ = P Z ⟨α, (i, q)⟩ ⟨α, (j, s)⟩
+      dsimp only [P]
+      rw [Matrix.controlledKrausMap_sameBlock_apply,
+        Matrix.rectangularKrausMap_equiv
+          (Fintype.equivFin (Fin (mult α))),
+        Matrix.rectangularKrausMap_preparationKraus_eq]
+      change _ = Matrix.kroneckerMap (fun x y : ℂ ↦ x * y)
+        (Z.submatrix (Sigma.mk α) (Sigma.mk α)) (ρ α) (i, q) (j, s)
+      simp only [Matrix.kroneckerMap_apply, Matrix.submatrix_apply, ρ,
+        Matrix.smul_apply, smul_eq_mul]
+      ring
+    · rw [Matrix.directSumMapExtension_apply,
+        Matrix.directSumDiagonalEmbedding_apply,
+        Matrix.blockDiagonal'_apply_ne _ _ _ hαβ]
+      simp only [LinearMap.comp_apply, Matrix.equivReindexMap,
+        LinearEquiv.coe_toLinearMap, Matrix.coe_reindexLinearEquiv,
+        Matrix.reindex_apply, verticalSectorSwapEquiv]
+      change 0 = P Z ⟨α, (i, q)⟩ ⟨β, (j, s)⟩
+      dsimp only [P]
+      rw [Matrix.controlledKrausMap_apply_of_ne _ _ _ hαβ]]
+  exact isKrausCP_comp hP.isKrausCP
+    (Matrix.equivReindexMap_isKrausCPTP
+      (verticalSectorSwapEquiv dim mult).symm).isKrausCP
+
+/-- Partial trace over the multiplicity coordinate is completely positive as
+a map between the finite sums of vertical-sector matrix algebras.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1961--1970. -/
+theorem verticalSectorPartialTrace_isKrausDirectSumMap
+    {g : ℕ} (dim mult : Fin g → ℕ) :
+    Matrix.IsKrausDirectSumMap
+      (verticalSectorPartialTrace dim mult) := by
+  change IsKrausCP
+    (Matrix.directSumMapExtension (verticalSectorPartialTrace dim mult))
+  rw [show Matrix.directSumMapExtension (verticalSectorPartialTrace dim mult) =
+      Matrix.controlledPartialTraceRightLM
+          (α := fun α : Fin g ↦ Fin (dim α))
+          (β := fun α : Fin g ↦ Fin (mult α)) ∘ₗ
+        Matrix.equivReindexMap (verticalSectorSwapEquiv dim mult) by
+    apply LinearMap.ext
+    intro Y
+    ext ⟨α, i⟩ ⟨β, j⟩
+    by_cases hαβ : α = β
+    · subst β
+      simp only [Matrix.directSumMapExtension_apply,
+        Matrix.directSumDiagonalEmbedding_apply,
+        Matrix.blockDiagonal'_apply_eq,
+        verticalSectorPartialTrace_apply,
+        Matrix.directSumDiagonalCompression_apply,
+        Matrix.traceLeft_apply,
+        LinearMap.comp_apply,
+        Matrix.controlledPartialTraceRightLM_sameBlock_apply,
+        Matrix.partialTraceRight_apply,
+        Matrix.submatrix_apply,
+        Matrix.equivReindexMap,
+        LinearEquiv.coe_toLinearMap,
+        Matrix.coe_reindexLinearEquiv,
+        Matrix.reindex_apply,
+        verticalSectorSwapEquiv]
+      rfl
+    · rw [Matrix.directSumMapExtension_apply,
+        Matrix.directSumDiagonalEmbedding_apply,
+        Matrix.blockDiagonal'_apply_ne _ _ _ hαβ,
+        LinearMap.comp_apply,
+        Matrix.controlledPartialTraceRightLM,
+        Matrix.controlledKrausMap_apply_of_ne _ _ _ hαβ]]
+  exact isKrausCP_comp
+    (Matrix.equivReindexMap_isKrausCPTP
+      (verticalSectorSwapEquiv dim mult)).isKrausCP
+    (Matrix.controlledPartialTraceRightLM_isKrausCPTP
+      (α := fun α : Fin g ↦ Fin (dim α))
+      (β := fun α : Fin g ↦ Fin (mult α))).isKrausCP
 
 /-- Partial trace is a left inverse of the normalized vertical-sector
 embedding.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -263,6 +263,114 @@ physical indices, as in
     \cite[Appendix~C.4, lines~1957--1971]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Complete positivity of the normalized vertical-sector maps]
+    \label{thm:mpdo_vertical_sector_partial_trace_kraus}
+    \lean{MPOTensor.verticalSectorSwapEquiv}
+    \lean{MPOTensor.normalizedVerticalSectorEmbedding_isKrausDirectSumMap}
+    \lean{MPOTensor.verticalSectorPartialTrace_isKrausDirectSumMap}
+    \leanok
+    \uses{def:mpdo_normalized_vertical_sector_maps,
+        def:kraus_map_between_direct_sums}
+    Let $(d_\alpha)_\alpha$ and $(r_\alpha)_\alpha$ be finite families of
+    dimensions with $r_\alpha>0$, and suppose that every diagonal entry of
+    $\mu_\alpha$ is positive.  Then the normalized embedding
+    \[
+        R_\mu:\bigoplus_\alpha M_{d_\alpha}(\mathbb C)
+          \longrightarrow \bigoplus_\alpha M_{r_\alpha d_\alpha}(\mathbb C),
+        \qquad
+        R_\mu((X_\alpha)_\alpha)
+          =\left(\frac{\mu_\alpha}{m_\alpha}\otimes X_\alpha\right)_\alpha
+    \]
+    is a direct-sum Kraus map.  Without any condition on the multiplicities,
+    the map
+    \[
+        \widetilde R:\bigoplus_\alpha M_{r_\alpha d_\alpha}(\mathbb C)
+          \longrightarrow \bigoplus_\alpha M_{d_\alpha}(\mathbb C),
+        \qquad
+        \widetilde R((Y_\alpha)_\alpha)
+          =\bigl(\operatorname{tr}_{\mathrm{mult}}(Y_\alpha)\bigr)_\alpha
+    \]
+    is a direct-sum Kraus map.  Its restriction to the weighted sectors is
+    the retraction in
+    \cite[Appendix~C.4, lines~1961--1970]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_equiv_reindex_cptp,
+        thm:mpdo_state_preparation_kraus_resolution,
+        thm:mpdo_controlled_kraus_map_cptp,
+        thm:mpdo_controlled_kraus_map_same_block,
+        thm:mpdo_controlled_dependent_partial_trace_same_block,
+        thm:mpdo_controlled_kraus_map_off_block,
+        thm:mpdo_controlled_dependent_partial_trace_cptp,
+        lem:is_kraus_cp_comp}
+    Exchange the two coordinates within each sector by
+    \[
+        w(\alpha,q,i)=(\alpha,i,q).
+    \]
+    Let $R_w$ be the corresponding matrix reindexing.  For the normalized
+    embedding, set
+    \[
+        \rho_\alpha=m_\alpha^{-1}\mu_\alpha.
+    \]
+    The hypotheses give $\rho_\alpha\succeq0$ and
+    $\operatorname{tr}(\rho_\alpha)=1$.  Let $\mathcal P$ be the
+    orthogonally controlled preparation of these density matrices.  Thus
+    \[
+      [\mathcal P(Z)]_{\langle\alpha,(i,q)\rangle,
+          \langle\beta,(j,s)\rangle}
+      =\begin{cases}
+        Z_{\langle\alpha,i\rangle,\langle\alpha,j\rangle}
+          \rho_\alpha(q,s), & \alpha=\beta,\\
+        0, & \alpha\ne\beta.
+      \end{cases}
+    \]
+    The preparation Kraus operators resolve the identity in each sector, so
+    $\mathcal P$ is trace-preserving and completely positive.  Reindexing by
+    $w^{-1}$ changes $X_\alpha\otimes\rho_\alpha$ into
+    $\rho_\alpha\otimes X_\alpha$.  Consequently, the full-matrix extension
+    satisfies
+    \[
+      [\widehat R_\mu(Z)]_{\langle\alpha,(q,i)\rangle,
+          \langle\beta,(s,j)\rangle}
+      =\begin{cases}
+        \rho_\alpha(q,s)
+          Z_{\langle\alpha,i\rangle,\langle\alpha,j\rangle},
+          & \alpha=\beta,\\
+        0, & \alpha\ne\beta,
+      \end{cases}
+    \]
+    and
+    \[
+        \widehat R_\mu=R_{w^{-1}}\circ\mathcal P.
+    \]
+    This proves complete positivity of the normalized embedding.
+
+    Now let $\mathcal C_{\mathrm{tr}}$ be the controlled partial trace over
+    the $\mathbb C^{r_\alpha}$ factors.  For a matrix $Y$ on
+    $\bigoplus_\alpha(\mathbb C^{r_\alpha}\otimes\mathbb C^{d_\alpha})$,
+    the full-matrix extension satisfies
+    \[
+      [\widehat{\widetilde R}(Y)]_{\langle\alpha,i\rangle,
+          \langle\beta,j\rangle}
+      =\begin{cases}
+        \displaystyle\sum_{q=0}^{r_\alpha-1}
+          Y_{\langle\alpha,(q,i)\rangle,\langle\alpha,(q,j)\rangle},
+          & \alpha=\beta,\\
+        0, & \alpha\ne\beta.
+      \end{cases}
+    \]
+    The diagonal case is the ordinary right partial trace after applying
+    $R_w$, and the off-diagonal case vanishes under the orthogonal sector
+    control.  Hence
+    \[
+        \widehat{\widetilde R}=\mathcal C_{\mathrm{tr}}\circ R_w.
+    \]
+    Equivalence reindexing and the controlled dependent partial trace are
+    trace-preserving completely positive maps, so their composition has a
+    Kraus representation.
+\end{proof}
+
 \begin{lemma}[Retraction of the normalized vertical-sector embedding]
     \label{lem:mpdo_vertical_sector_retraction}
     \lean{MPOTensor.verticalMultiplicityTrace_ne_zero}


### PR DESCRIPTION
## Summary

This change proves that the normalized vertical-sector embedding and the multiplicity partial-trace retraction in CPSV16 Appendix C.4 admit Kraus realizations as maps between finite direct sums of matrix algebras.

For each sector α, the normalized embedding prepares the density matrix ρₐ = tr(μₐ)⁻¹μₐ under orthogonal sector control and then exchanges the simple and multiplicity coordinates. The retraction exchanges those coordinates in the opposite direction and applies the controlled partial trace. These factorizations establish complete positivity of both direct-sum maps.

The corresponding blueprint entry records the Kraus constructions and their matrix-entry formulas.

## Source and scope

Source: Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix C.4, lines 1957–1971.

This result supplies the Kraus realizations for the normalized sector embeddings and retractions used in Appendix C.4. It does not yet prove that the transported maps, or their square composites, satisfy the adjoint Schwarz inequalities, and it does not prove the full transported-map identity theorem. Those tensor-attached steps remain separate.

## Verification

- `lake build TNLean.MPS.MPDO.VerticalSectorRetractions TNLean`
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- proof-integrity and range-diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Mathlib proofs and blueprint text only; no runtime, auth, or API surface changes. Risk is limited to proof maintenance if direct-sum Kraus API evolves.
> 
> **Overview**
> Adds **formal proofs** that the normalized vertical-sector embedding \(R_\mu\) and the multiplicity partial trace \(\widetilde R\) are **direct-sum Kraus maps** (complete positivity on the canonical full-matrix extension), matching CPSV16 Appendix C.4.
> 
> Lean introduces `verticalSectorSwapEquiv` and shows each map factors through existing infrastructure: **\(R_{w^{-1}} \circ \mathcal P\)** (per-sector state preparation from normalized \(\rho_\alpha\)) for the embedding, and **\(\mathcal C_{\mathrm{tr}} \circ R_w\)** (controlled right partial trace after reindexing) for the retraction. Matrix-entry equalities are checked on- and off-diagonal blocks before composing with `isKrausCP_comp`.
> 
> The blueprint gains **Theorem** `thm:mpdo_vertical_sector_partial_trace_kraus` with the Kraus constructions, entry formulas, and `\leanok` links to the new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23610472ef32c235d8e8e584ac2f563cc68e9fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->