### PR TITLE
feat(MPS/RFP): span Beigi ground spaces by positive loops

### DIFF
--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -549,7 +549,7 @@ private theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_fin
 length greater than two the positive-loop product states span the whole parent
 ground space.
 
-**Scope restriction (chain length):** The theorem treats `N > 2`, the range
+**Scope restriction (chain length):** The theorem treats $N > 2$, the range
 covered by the ordered-cycle ground-space dimension formula used here.  The
 short-chain conventions are recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
@@ -571,7 +571,7 @@ theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES
 /-- In the BNT nearest-neighbor setting, positive-loop product states span the
 whole parent ground space at every length greater than two.
 
-**Scope restriction (chain length):** The theorem treats `N > 2`, the range
+**Scope restriction (chain length):** The theorem treats $N > 2$, the range
 covered by the ordered-cycle ground-space dimension formula used here.  The
 short-chain conventions are recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -130,6 +130,14 @@ noncomputable def loopProductState (F : BeigiSectorGraphData A)
   fun s ↦ ∑ t : Fin N → Fin d,
     (∏ n : Fin N, F.unitary (s n) (t n)) * F.loopCyclicProduct l t
 
+/-- The Euclidean-space realization of a positive-loop product state.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+noncomputable def loopProductStateES (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
+    EuclideanSpace ℂ (Fin N → Fin d) :=
+  (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm (F.loopProductState l)
+
 private theorem edgeProjector_mulVec_loopBondVector
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
     (F.edgeProjector l.1 l.1).mulVec (F.loopBondVector l) =
@@ -202,6 +210,60 @@ private theorem loopCyclicProduct_etaCyclicEdgeEquiv_symm_of_ne
     rw [Matrix.etaCyclicEdgeEquiv_symm_apply]
     exact Equiv.symm_apply_apply F.sectorEquiv _
   exact (congrArg Sigma.fst hsite).symm.trans (hsector n)
+
+/-- The cyclic product belonging to a positive loop is nonzero at every
+positive chain length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem loopCyclicProduct_ne_zero (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
+    F.loopCyclicProduct l ≠ (0 : NSiteSpace d N) := by
+  classical
+  have hexists : ∃ q, F.loopBondVector l q ≠ 0 := by
+    by_contra h
+    push Not at h
+    apply F.loopBondVector_ne_zero l
+    funext q
+    exact h q
+  obtain ⟨q, hq⟩ := hexists
+  let x : (n : Fin N) →
+      Matrix.EtaEdgeIndex F.leftDim F.rightDim l.1 l.1 := fun _ ↦ q
+  intro hzero
+  have hvalue := congrFun hzero
+    ((Matrix.etaCyclicEdgeEquiv F.leftDim F.rightDim F.sectorEquiv).symm
+      ⟨fun _ ↦ l.1, x⟩)
+  rw [F.loopCyclicProduct_etaCyclicEdgeEquiv_symm_constant l x] at hvalue
+  have hprod : ∏ n : Fin N, F.loopBondVector l (x n) ≠ 0 := by
+    exact Finset.prod_ne_zero_iff.mpr fun n _ ↦ by simpa only [x] using hq
+  exact hprod hvalue
+
+/-- Cyclic products belonging to distinct positive loops have disjoint sector
+support and hence zero inner product.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem loopCyclicProduct_inner_eq_zero_of_ne
+    (F : BeigiSectorGraphData A) {l m : Loop F.edgeWeight}
+    {N : ℕ} [NeZero N] (hlm : l ≠ m) :
+    inner ℂ (WithLp.toLp 2 (F.loopCyclicProduct (N := N) l))
+      (WithLp.toLp 2 (F.loopCyclicProduct (N := N) m)) = 0 := by
+  classical
+  rw [EuclideanSpace.inner_toLp_toLp, dotProduct]
+  apply Finset.sum_eq_zero
+  intro s _
+  by_cases hl : ∀ n, (F.sectorEquiv.symm (s n)).1 = l.1
+  · have hm : ¬ ∀ n, (F.sectorEquiv.symm (s n)).1 = m.1 := by
+      intro hm
+      apply hlm
+      apply Subtype.ext
+      exact (hl 0).symm.trans (hm 0)
+    have hmzero : F.loopCyclicProduct m s = 0 := by
+      unfold loopCyclicProduct
+      rw [dif_neg hm]
+    rw [hmzero, zero_mul]
+  · have hlzero : F.loopCyclicProduct l s = 0 := by
+      unfold loopCyclicProduct
+      rw [dif_neg hl]
+    rw [Pi.star_apply, hlzero, star_zero, mul_zero]
 
 private theorem blockGroundProduct_mulVec_loopCyclicProduct
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
@@ -300,6 +362,91 @@ private theorem loopProductState_eq_sitewisePhysicalMatrix_mulVec
         (F.loopCyclicProduct l) := by
   rfl
 
+private theorem sitewisePhysicalMatrix_conjTranspose_mul_self
+    (F : BeigiSectorGraphData A) (N : ℕ) :
+    (MPOTensor.sitewisePhysicalMatrix F.unitary N)ᴴ *
+        MPOTensor.sitewisePhysicalMatrix F.unitary N = 1 := by
+  have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.star_mul_self_of_mem F.unitary_mem
+  calc
+    (MPOTensor.sitewisePhysicalMatrix F.unitary N)ᴴ *
+        MPOTensor.sitewisePhysicalMatrix F.unitary N =
+        MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N *
+          (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N)ᴴ := by
+      simp only [MPOTensor.sitewisePhysicalMatrix_conjTranspose,
+        Matrix.conjTranspose_conjTranspose]
+    _ = MPOTensor.sitewisePhysicalMatrix (F.unitaryᴴ * F.unitary) N := by
+      rw [MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose]
+      simp only [Matrix.conjTranspose_conjTranspose]
+    _ = 1 := by rw [hUstarU, MPOTensor.sitewisePhysicalMatrix_one]
+
+/-- A positive-loop product state is nonzero at every positive chain length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem loopProductState_ne_zero (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
+    F.loopProductState (N := N) l ≠ 0 := by
+  classical
+  let W := MPOTensor.sitewisePhysicalMatrix F.unitary N
+  have hWstarW : Wᴴ * W = 1 := F.sitewisePhysicalMatrix_conjTranspose_mul_self N
+  rw [F.loopProductState_eq_sitewisePhysicalMatrix_mulVec l]
+  intro hzero
+  apply F.loopCyclicProduct_ne_zero (N := N) l
+  have hzero' := congrArg (fun v ↦ Wᴴ *ᵥ v) hzero
+  simp only [Matrix.mulVec_zero] at hzero'
+  change Wᴴ *ᵥ W *ᵥ F.loopCyclicProduct (N := N) l = 0 at hzero'
+  rw [Matrix.mulVec_mulVec, hWstarW, Matrix.one_mulVec] at hzero'
+  exact hzero'
+
+/-- The Euclidean realization of a positive-loop product state is nonzero at
+every positive chain length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem loopProductStateES_ne_zero (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
+    F.loopProductStateES (N := N) l ≠ 0 := by
+  exact (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm.injective.ne
+    (F.loopProductState_ne_zero l)
+
+/-- Euclidean positive-loop product states belonging to distinct loops are
+orthogonal at every positive chain length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem loopProductStateES_inner_eq_zero_of_ne
+    (F : BeigiSectorGraphData A) {l m : Loop F.edgeWeight}
+    {N : ℕ} [NeZero N] (hlm : l ≠ m) :
+    inner ℂ (F.loopProductStateES (N := N) l)
+      (F.loopProductStateES (N := N) m) = 0 := by
+  classical
+  let W := MPOTensor.sitewisePhysicalMatrix F.unitary N
+  have hWstarW : Wᴴ * W = 1 := F.sitewisePhysicalMatrix_conjTranspose_mul_self N
+  rw [loopProductStateES, loopProductStateES]
+  change inner ℂ (WithLp.toLp 2 (F.loopProductState l))
+    (WithLp.toLp 2 (F.loopProductState m)) = 0
+  rw [F.loopProductState_eq_sitewisePhysicalMatrix_mulVec l,
+    F.loopProductState_eq_sitewisePhysicalMatrix_mulVec m]
+  change inner ℂ (WithLp.toLp 2 (W *ᵥ F.loopCyclicProduct l))
+    (WithLp.toLp 2 (W *ᵥ F.loopCyclicProduct m)) = 0
+  rw [EuclideanSpace.inner_toLp_toLp, dotProduct_comm, Matrix.star_mulVec,
+    ← Matrix.dotProduct_mulVec, Matrix.mulVec_mulVec, hWstarW,
+    Matrix.one_mulVec, dotProduct_comm]
+  exact F.loopCyclicProduct_inner_eq_zero_of_ne hlm
+
+/-- The Euclidean positive-loop product states are linearly independent at
+every positive chain length.
+
+Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+theorem loopProductStateES_linearIndependent
+    (F : BeigiSectorGraphData A) {N : ℕ} [NeZero N] :
+    LinearIndependent ℂ
+      (fun l : Loop F.edgeWeight ↦ F.loopProductStateES (N := N) l) := by
+  apply linearIndependent_of_ne_zero_of_inner_eq_zero
+  · intro l
+    exact F.loopProductStateES_ne_zero l
+  · intro l m hlm
+    exact F.loopProductStateES_inner_eq_zero_of_ne hlm
+
 private theorem groundBondProduct_mulVec_loopProductState
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
     {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
@@ -385,11 +532,76 @@ theorem loopProductState_mem_parentHamiltonianGroundSpaceES
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
     {N : ℕ} (hN : 2 ≤ N) :
     letI : NeZero N := ⟨by omega⟩
-    (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm (F.loopProductState l) ∈
+    F.loopProductStateES l ∈ parentHamiltonianGroundSpaceES A 2 N := by
+  letI : NeZero N := ⟨by omega⟩
+  rw [loopProductStateES, parentHamiltonianGroundSpaceES, Submodule.mem_map]
+  exact ⟨F.loopProductState l, F.loopProductState_mem_ker_parentHamiltonian l hN, rfl⟩
+
+/-- If the parent-ground-space dimension is eventually constant, then at every
+length greater than two the positive-loop product states span the whole parent
+ground space.
+
+**Scope restriction (chain length):** The theorem treats `N > 2`, the range
+covered by the ordered-cycle ground-space dimension formula used here.  The
+short-chain conventions are recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and
+Section IV, source lines 602--606. -/
+theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES
+    (F : BeigiSectorGraphData A)
+    (hparent : ∃ c N₀ : ℕ, ∀ M : ℕ, N₀ < M →
+      Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 M) = c)
+    {N : ℕ} (hN : 2 < N) :
+    letI : NeZero N := ⟨by omega⟩
+    Submodule.span ℂ
+      (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l)) =
       parentHamiltonianGroundSpaceES A 2 N := by
   letI : NeZero N := ⟨by omega⟩
-  rw [parentHamiltonianGroundSpaceES, Submodule.mem_map]
-  exact ⟨F.loopProductState l, F.loopProductState_mem_ker_parentHamiltonian l hN, rfl⟩
+  apply Submodule.eq_of_le_of_finrank_eq
+  · rw [Submodule.span_le]
+    rintro _ ⟨l, rfl⟩
+    change F.loopProductStateES l ∈ parentHamiltonianGroundSpaceES A 2 N
+    exact F.loopProductState_mem_parentHamiltonianGroundSpaceES l (by omega)
+  · calc
+      Module.finrank ℂ (Submodule.span ℂ
+          (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l))) =
+          Fintype.card (Loop F.edgeWeight) :=
+        finrank_span_eq_card F.loopProductStateES_linearIndependent
+      _ = Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) :=
+        (F.parentHamiltonianGroundSpaceES_finrank_eq_card_loop hparent hN).symm
+
+/-- In the BNT nearest-neighbor setting, positive-loop product states span the
+whole parent ground space at every length greater than two.
+
+**Scope restriction (chain length):** The theorem treats `N > 2`, the range
+covered by the ordered-cycle ground-space dimension formula used here.  The
+short-chain conventions are recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: CPSV16, Definition 3.9 and Theorem 3.10, source lines 517--540;
+Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and Section IV,
+source lines 602--606. -/
+theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_hasBNTSectorData
+    {P : SectorDecomposition d} (F : BeigiSectorGraphData P.toTensor)
+    (hBNT : HasBNTSectorData P)
+    (hNNCPH : HasNNCPHGroundSpaces P.toTensor P.basis)
+    {N : ℕ} (hN : 2 < N) :
+    letI : NeZero N := ⟨by omega⟩
+    Submodule.span ℂ
+      (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l)) =
+      parentHamiltonianGroundSpaceES P.toTensor 2 N := by
+  letI : NeZero N := ⟨by omega⟩
+  rcases hBNT.eventually_parentHamiltonian_groundSpace_finrank_eq hNNCPH with
+    ⟨N₀, hraw⟩
+  have hparent : ∃ c N₁ : ℕ, ∀ M : ℕ, N₁ < M →
+      Module.finrank ℂ
+        (parentHamiltonianGroundSpaceES P.toTensor 2 M) = c := by
+    refine ⟨P.basisCount, N₀, ?_⟩
+    intro M hM
+    rw [parentHamiltonianGroundSpaceES_finrank_eq_ker]
+    exact hraw M hM
+  exact F.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES hparent hN
 
 /-- The sector-coordinate loop tensor closes to the cyclic product of loop
 bond vectors at every positive length.

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -524,6 +524,27 @@ theorem loopProductState_mem_parentHamiltonianGroundSpaceES
   rw [loopProductStateES, parentHamiltonianGroundSpaceES, Submodule.mem_map]
   exact ⟨F.loopProductState l, F.loopProductState_mem_ker_parentHamiltonian l hN, rfl⟩
 
+private theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_finrank_eq
+    (F : BeigiSectorGraphData A) {N : ℕ} (hN : 2 < N)
+    (hfinrank : Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) =
+      Fintype.card (Loop F.edgeWeight)) :
+    letI : NeZero N := ⟨by omega⟩
+    Submodule.span ℂ
+      (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l)) =
+      parentHamiltonianGroundSpaceES A 2 N := by
+  letI : NeZero N := ⟨by omega⟩
+  apply Submodule.eq_of_le_of_finrank_eq
+  · rw [Submodule.span_le]
+    rintro _ ⟨l, rfl⟩
+    change F.loopProductStateES l ∈ parentHamiltonianGroundSpaceES A 2 N
+    exact F.loopProductState_mem_parentHamiltonianGroundSpaceES l (by omega)
+  · calc
+      Module.finrank ℂ (Submodule.span ℂ
+          (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l))) =
+          Fintype.card (Loop F.edgeWeight) :=
+        finrank_span_eq_card F.loopProductStateES_linearIndependent
+      _ = Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) := hfinrank.symm
+
 /-- If the parent-ground-space dimension is eventually constant, then at every
 length greater than two the positive-loop product states span the whole parent
 ground space.
@@ -544,19 +565,8 @@ theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES
     Submodule.span ℂ
       (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l)) =
       parentHamiltonianGroundSpaceES A 2 N := by
-  letI : NeZero N := ⟨by omega⟩
-  apply Submodule.eq_of_le_of_finrank_eq
-  · rw [Submodule.span_le]
-    rintro _ ⟨l, rfl⟩
-    change F.loopProductStateES l ∈ parentHamiltonianGroundSpaceES A 2 N
-    exact F.loopProductState_mem_parentHamiltonianGroundSpaceES l (by omega)
-  · calc
-      Module.finrank ℂ (Submodule.span ℂ
-          (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l))) =
-          Fintype.card (Loop F.edgeWeight) :=
-        finrank_span_eq_card F.loopProductStateES_linearIndependent
-      _ = Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) :=
-        (F.parentHamiltonianGroundSpaceES_finrank_eq_card_loop hparent hN).symm
+  exact F.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_finrank_eq hN
+    (F.parentHamiltonianGroundSpaceES_finrank_eq_card_loop hparent hN)
 
 /-- In the BNT nearest-neighbor setting, positive-loop product states span the
 whole parent ground space at every length greater than two.
@@ -578,17 +588,9 @@ theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_hasBNTSecto
     Submodule.span ℂ
       (Set.range (fun l : Loop F.edgeWeight ↦ F.loopProductStateES l)) =
       parentHamiltonianGroundSpaceES P.toTensor 2 N := by
-  letI : NeZero N := ⟨by omega⟩
-  rcases hBNT.eventually_parentHamiltonian_groundSpace_finrank_eq hNNCPH with
-    ⟨N₀, hraw⟩
-  have hparent : ∃ c N₁ : ℕ, ∀ M : ℕ, N₁ < M →
-      Module.finrank ℂ
-        (parentHamiltonianGroundSpaceES P.toTensor 2 M) = c := by
-    refine ⟨P.basisCount, N₀, ?_⟩
-    intro M hM
-    rw [parentHamiltonianGroundSpaceES_finrank_eq_ker]
-    exact hraw M hM
-  exact F.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES hparent hN
+  exact F.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_finrank_eq hN
+    (F.parentHamiltonianGroundSpaceES_finrank_eq_card_loop_of_hasBNTSectorData
+      hBNT hNNCPH hN)
 
 /-- The sector-coordinate loop tensor closes to the cyclic product of loop
 bond vectors at every positive length.

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -362,25 +362,6 @@ private theorem loopProductState_eq_sitewisePhysicalMatrix_mulVec
         (F.loopCyclicProduct l) := by
   rfl
 
-private theorem sitewisePhysicalMatrix_conjTranspose_mul_self
-    (F : BeigiSectorGraphData A) (N : ℕ) :
-    (MPOTensor.sitewisePhysicalMatrix F.unitary N)ᴴ *
-        MPOTensor.sitewisePhysicalMatrix F.unitary N = 1 := by
-  have hUstarU : F.unitaryᴴ * F.unitary = 1 := by
-    simpa only [Matrix.star_eq_conjTranspose] using
-      Unitary.star_mul_self_of_mem F.unitary_mem
-  calc
-    (MPOTensor.sitewisePhysicalMatrix F.unitary N)ᴴ *
-        MPOTensor.sitewisePhysicalMatrix F.unitary N =
-        MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N *
-          (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N)ᴴ := by
-      simp only [MPOTensor.sitewisePhysicalMatrix_conjTranspose,
-        Matrix.conjTranspose_conjTranspose]
-    _ = MPOTensor.sitewisePhysicalMatrix (F.unitaryᴴ * F.unitary) N := by
-      rw [MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose]
-      simp only [Matrix.conjTranspose_conjTranspose]
-    _ = 1 := by rw [hUstarU, MPOTensor.sitewisePhysicalMatrix_one]
-
 /-- A positive-loop product state is nonzero at every positive chain length.
 
 Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
@@ -389,7 +370,10 @@ theorem loopProductState_ne_zero (F : BeigiSectorGraphData A)
     F.loopProductState (N := N) l ≠ 0 := by
   classical
   let W := MPOTensor.sitewisePhysicalMatrix F.unitary N
-  have hWstarW : Wᴴ * W = 1 := F.sitewisePhysicalMatrix_conjTranspose_mul_self N
+  have hWstarW : Wᴴ * W = 1 := by
+    apply MPOTensor.sitewisePhysicalMatrix_isometry
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.star_mul_self_of_mem F.unitary_mem
   rw [F.loopProductState_eq_sitewisePhysicalMatrix_mulVec l]
   intro hzero
   apply F.loopCyclicProduct_ne_zero (N := N) l
@@ -420,7 +404,10 @@ theorem loopProductStateES_inner_eq_zero_of_ne
       (F.loopProductStateES (N := N) m) = 0 := by
   classical
   let W := MPOTensor.sitewisePhysicalMatrix F.unitary N
-  have hWstarW : Wᴴ * W = 1 := F.sitewisePhysicalMatrix_conjTranspose_mul_self N
+  have hWstarW : Wᴴ * W = 1 := by
+    apply MPOTensor.sitewisePhysicalMatrix_isometry
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.star_mul_self_of_mem F.unitary_mem
   rw [loopProductStateES, loopProductStateES]
   change inner ℂ (WithLp.toLp 2 (F.loopProductState l))
     (WithLp.toLp 2 (F.loopProductState m)) = 0

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2561,6 +2561,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.loopTensor}
     \lean{MPSTensor.BeigiSectorGraphData.loopCyclicProduct}
     \lean{MPSTensor.BeigiSectorGraphData.loopProductState}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductStateES}
     \leanok
     \uses{def:beigi_sector_graph}
     Let $a\to a$ be a positive loop and choose a nonzero vector
@@ -2742,6 +2743,45 @@ specialization of that Appendix~D definition.
     \]
     Theorem~\ref{thm:beigi_complement_product_fixed_vector} now yields
     $\Psi_a\in\ker H_N$.
+\end{proof}
+
+\begin{theorem}[Positive Beigi loops span the parent ground space]
+    \label{thm:beigi_loop_product_states_span_ground_space}
+    \lean{MPSTensor.BeigiSectorGraphData.loopCyclicProduct_ne_zero}
+    \lean{MPSTensor.BeigiSectorGraphData.loopCyclicProduct_inner_eq_zero_of_ne}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductState_ne_zero}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductStateES_ne_zero}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductStateES_inner_eq_zero_of_ne}
+    \lean{MPSTensor.BeigiSectorGraphData.loopProductStateES_linearIndependent}
+    \lean{MPSTensor.BeigiSectorGraphData.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES}
+    \lean{MPSTensor.BeigiSectorGraphData.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_hasBNTSectorData}
+    \leanok
+    \uses{thm:beigi_loop_product_state_ground_state,
+        cor:beigi_parent_ground_space_loop_number}
+    Suppose that the parent-ground-space dimension is eventually constant.
+    For every $N>2$, the Euclidean representatives of the positive-loop
+    product states form a nonzero pairwise orthogonal family and
+    \[
+        \operatorname{span}\{\Psi_a:a\to a\text{ is a positive loop}\}
+        =\ker H_N.
+    \]
+    In particular, the same conclusion holds under the BNT and all-chain
+    nearest-neighbor parent-ground-space hypotheses.
+\end{theorem}
+
+\begin{proof}\leanok
+    Choose a nonzero coefficient of the loop-edge vector $\varphi_a$.
+    The constant edge-index configuration formed from this coefficient has
+    cyclic amplitude equal to a product of $N$ nonzero factors.  Hence every
+    loop product state is nonzero.  States belonging to distinct loops have
+    disjoint constant-sector support, so their inner product vanishes.  The
+    sitewise unitary preserves both conclusions, and the Euclidean loop states
+    are therefore linearly independent.  Their span is contained in
+    $\ker H_N$ by
+    Theorem~\ref{thm:beigi_loop_product_state_ground_state}.  Its dimension is
+    the number of positive loops, which equals $\dim\ker H_N$ by
+    Corollary~\ref{cor:beigi_parent_ground_space_loop_number}.  The inclusion
+    is consequently an equality.
 \end{proof}
 
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2771,17 +2771,25 @@ specialization of that Appendix~D definition.
 \end{theorem}
 
 \begin{proof}\leanok
-    Choose a nonzero coefficient of the loop-edge vector $\varphi_a$.
-    The constant edge-index configuration formed from this coefficient has
-    cyclic amplitude equal to a product of $N$ nonzero factors.  Hence every
-    loop product state is nonzero.  Write $\Phi_a^{(N)}$ for the cyclic product
-    in sector coordinates.  If $a\ne b$, then every sector configuration $s$
+    Write $\Phi_a^{(N)}$ for the cyclic product in sector coordinates and
+    $\Psi_a^{(N)}=U^{\otimes N}\Phi_a^{(N)}$ for the physical state, where
+    $U$ is the one-site spatial unitary.  Choose $q$ with
+    $\varphi_a(q)\ne0$.  On the constant edge-index configuration,
+    \[
+        \Phi_a^{(N)}(q,\ldots,q)
+        =\prod_{n=0}^{N-1}\varphi_a(q)\ne0.
+    \]
+    Thus $\Phi_a^{(N)}\ne0$, and unitarity gives
+    \[
+        \Psi_a^{(N)}=U^{\otimes N}\Phi_a^{(N)}\ne0.
+    \]
+    If $a\ne b$, then every sector configuration $s$
     satisfies $\Phi_a^{(N)}(s)=0$ or $\Phi_b^{(N)}(s)=0$, and hence
     \[
         \langle\Phi_a^{(N)},\Phi_b^{(N)}\rangle
         =\sum_s\overline{\Phi_a^{(N)}(s)}\,\Phi_b^{(N)}(s)=0.
     \]
-    If $U$ is the one-site spatial unitary, then
+    Moreover,
     \[
         \langle\Psi_a^{(N)},\Psi_b^{(N)}\rangle
         =\langle U^{\otimes N}\Phi_a^{(N)},

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2573,7 +2573,8 @@ specialization of that Appendix~D definition.
     and set it to zero outside sector $a$.  The physical loop tensor is the
     image of $C_a$ under the one-site unitary of the spatial decomposition.
     Its associated cyclic product pairs the right factor at site $n$ with the
-    left factor at site $n+1$.
+    left factor at site $n+1$.  The corresponding $N$-site product state is
+    denoted by $\Psi_a^{(N)}\in(\mathbb C^d)^{\otimes N}$.
 \end{definition}
 
 \begin{theorem}[Periodic vector of a positive Beigi loop]
@@ -2759,10 +2760,10 @@ specialization of that Appendix~D definition.
     \uses{thm:beigi_loop_product_state_ground_state,
         cor:beigi_parent_ground_space_loop_number}
     Suppose that the parent-ground-space dimension is eventually constant.
-    For every $N>2$, the Euclidean representatives of the positive-loop
-    product states form a nonzero pairwise orthogonal family and
+    For every $N>2$, the positive-loop product states form a nonzero pairwise
+    orthogonal family and
     \[
-        \operatorname{span}\{\Psi_a:a\to a\text{ is a positive loop}\}
+        \operatorname{span}\{\Psi_a^{(N)}:a\to a\text{ is a positive loop}\}
         =\ker H_N.
     \]
     In particular, the same conclusion holds under the BNT and all-chain
@@ -2773,10 +2774,21 @@ specialization of that Appendix~D definition.
     Choose a nonzero coefficient of the loop-edge vector $\varphi_a$.
     The constant edge-index configuration formed from this coefficient has
     cyclic amplitude equal to a product of $N$ nonzero factors.  Hence every
-    loop product state is nonzero.  States belonging to distinct loops have
-    disjoint constant-sector support, so their inner product vanishes.  The
-    sitewise unitary preserves both conclusions, and the Euclidean loop states
-    are therefore linearly independent.  Their span is contained in
+    loop product state is nonzero.  Write $\Phi_a^{(N)}$ for the cyclic product
+    in sector coordinates.  If $a\ne b$, then every sector configuration $s$
+    satisfies $\Phi_a^{(N)}(s)=0$ or $\Phi_b^{(N)}(s)=0$, and hence
+    \[
+        \langle\Phi_a^{(N)},\Phi_b^{(N)}\rangle
+        =\sum_s\overline{\Phi_a^{(N)}(s)}\,\Phi_b^{(N)}(s)=0.
+    \]
+    If $U$ is the one-site spatial unitary, then
+    \[
+        \langle\Psi_a^{(N)},\Psi_b^{(N)}\rangle
+        =\langle U^{\otimes N}\Phi_a^{(N)},
+            U^{\otimes N}\Phi_b^{(N)}\rangle
+        =\langle\Phi_a^{(N)},\Phi_b^{(N)}\rangle=0.
+    \]
+    Thus the loop states are linearly independent.  Their span is contained in
     $\ker H_N$ by
     Theorem~\ref{thm:beigi_loop_product_state_ground_state}.  Its dimension is
     the number of positive loops, which equals $\dim\ker H_N$ by

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -114,8 +114,8 @@ now implies this reverse containment.  The resulting spanning theorem is
 These reductions alone do not prove the full source theorem.  The
 ground-space spanning condition for repeated copies and arbitrary raw sector
 weights, the three-way equivalence with ZCL, the complete canonical-form
-hypotheses from the source statement, and the Beigi ground-space
-characterization as an internal theorem remain open.
+hypotheses from the source statement, and the identification of Beigi's loop
+states with the basis of normal tensors remain open.
 For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 Appendix~B supplies the basic-vector form.  The local projectors in
@@ -341,9 +341,24 @@ The proof uses Beigi's local edge-ground-space condition from source
 lines 487--500 and the positive-loop specialization at lines 602--606.  The
 restriction $N\geq2$ is the nondegenerate range of the two-site periodic
 parent Hamiltonian used here; the length-one convention remains part of
-\ghissue{4400}.  This result proves membership only.  It does not yet prove
-that the loop states span the parent ground space or identify them with the
-original BNT representatives.
+\ghissue{4400}.  At every positive length the loop vectors are nonzero and
+pairwise orthogonal, as recorded by
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{loopProductStateES_linearIndependent}.  If the parent
+ground-space dimension is eventually constant, membership and the loop-count
+dimension formula therefore give
+\begin{align}
+  \operatorname{span}\{\Psi_a:a\to a\text{ is a positive loop}\}
+  =\ker H_2^{(N)}(A),\qquad N>2.
+\end{align}
+This is
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{span_loopProductStateES_eq_parentHamiltonianGroundSpaceES}.
+Its BNT and all-chain specialization is
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_hasBNTSectorData}.
+These results do not yet identify the loop states with the original BNT
+representatives.
 
 The auxiliary declaration
 \leanid{MPSTensor.BeigiSectorGraphData.}
@@ -402,8 +417,10 @@ stability, the symmetric sector-graph construction from three-site commuting
 parent terms, the ordered-cycle dimension formula, the reduction of the
 sector graph to one-dimensional loops, and the exact matrix product realization
 and parent-ground-space membership of every positive loop state are proved.
-Spanning of the parent ground space by these loop vectors, followed by their
-identification with the basis of normal tensors, remains open.
+The loop vectors are also proved to span the parent ground space for every
+$N>2$ under the eventual-dimension hypothesis supplied by BNT eventual linear
+independence together with the source all-chain ground-space condition.  Their
+identification with the basis of normal tensors remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -353,10 +353,10 @@ are linearly independent, as recorded by
 \leanid{MPSTensor.BeigiSectorGraphData.}
 \hspace{0pt}\leanid{loopProductStateES_linearIndependent}.  If the parent
 ground-space dimension is eventually constant, membership and the loop-count
-dimension formula therefore give
+dimension formula therefore give, for every $N>2$,
 \begin{align}
   \operatorname{span}\{\Psi_a^{(N)}:a\to a\text{ is a positive loop}\}
-  =\ker H_2^{(N)}(A),\qquad N>2.
+  =\ker H_2^{(N)}(A).
 \end{align}
 This is
 \leanid{MPSTensor.BeigiSectorGraphData.}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -329,6 +329,8 @@ product
 \[
   \prod_n \varphi_a(r_n,l_{n+1}).
 \]
+For a positive loop $a\to a$, denote the resulting physical state on a chain
+of length $N$ by $\Psi_a^{(N)}$.
 This is the construction in Beigi, arXiv:1105.1019v2, source lines 602--606.
 For every $N\geq2$,
 \leanid{MPSTensor.BeigiSectorGraphData.}
@@ -341,14 +343,19 @@ The proof uses Beigi's local edge-ground-space condition from source
 lines 487--500 and the positive-loop specialization at lines 602--606.  The
 restriction $N\geq2$ is the nondegenerate range of the two-site periodic
 parent Hamiltonian used here; the length-one convention remains part of
-\ghissue{4400}.  At every positive length the loop vectors are nonzero and
-pairwise orthogonal, as recorded by
+\ghissue{4400}.  At every positive length the loop vectors are nonzero by
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{loopProductStateES_ne_zero}, and distinct loop vectors are
+orthogonal by
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{loopProductStateES_inner_eq_zero_of_ne}.  Consequently they
+are linearly independent, as recorded by
 \leanid{MPSTensor.BeigiSectorGraphData.}
 \hspace{0pt}\leanid{loopProductStateES_linearIndependent}.  If the parent
 ground-space dimension is eventually constant, membership and the loop-count
 dimension formula therefore give
 \begin{align}
-  \operatorname{span}\{\Psi_a:a\to a\text{ is a positive loop}\}
+  \operatorname{span}\{\Psi_a^{(N)}:a\to a\text{ is a positive loop}\}
   =\ker H_2^{(N)}(A),\qquad N>2.
 \end{align}
 This is


### PR DESCRIPTION
This PR proves that the positive-loop product states arising from Beigi sector data are nonzero and pairwise orthogonal at every positive chain length. If the dimension of the two-site parent-Hamiltonian ground space is eventually constant, then for every N > 2,
\[
\operatorname{span}\{\Psi_a^{(N)} : a\to a \text{ is a positive loop}\}
= \ker H_2^{(N)}.
\]
The BNT specialization obtains the dimension hypothesis from BNT sector data and the all-chain nearest-neighbor parent-ground-space hypothesis.

The proof first establishes disjoint support for the cyclic products in sector coordinates and then transports orthogonality through the sitewise physical unitary. Ground-space membership and the positive-loop dimension formula then identify their span with the whole ground space.

The restriction N > 2 is retained because the ordered-cycle ground-space dimension formula used here is proved in that range. The general theorem retains the explicit eventual-dimension hypothesis. The source comparison and short-chain conventions are recorded in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.

This result does not identify the positive-loop states with the original basis-of-normal-tensors representatives. It does not eliminate the remaining Beigi renormalization-fixed-point axiom and does not complete the full nearest-neighbor commuting-parent-Hamiltonian implication.

Advances #4450 and #4423.

Validated by a focused Lean check, a full TNLean build on the rebased mathematical patch, the style linter, blueprint declaration and synchronization checks, blueprint web generation, reader-facing prose and LaTeX checks, and proof-integrity, line-length, file-length, and diff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new Lean proofs in parent-Hamiltonian ground-space theory; errors would mis-state a key Beigi/CPSV bridge, but changes are formal math only with no runtime or security surface.
> 
> **Overview**
> **Positive-loop product states** are now shown to be a **nonzero, pairwise orthogonal** family at every positive chain length, with orthogonality proved first on sector cyclic products (disjoint loop support) and then transported through the sitewise physical unitary to Euclidean states via `loopProductStateES`.
> 
> When the two-site parent ground-space dimension is **eventually constant**, the PR proves that for **N > 2** the span of these loop states equals the full parent Hamiltonian ground space; a **BNT + all-chain NNCPH** specialization supplies the dimension hypothesis from existing finrank–loop-count results. Blueprint and `cpsv16_nncph_ground_state_scope.tex` are updated to record spanning and to narrow the remaining gap to identifying loop states with BNT representatives (not full reverse RFP).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9764ca35c56753b0419a7348f2e52b9f4a302c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->