### PR TITLE
feat(MPS/MPDO): prove vertical-sector identity criterion

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -479,6 +479,7 @@ import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
 import TNLean.MPS.MPDO.VerticalSectorTracePreservation
+import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -478,6 +478,7 @@ import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
+import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
@@ -681,7 +682,6 @@ import TNLean.Channel.Peripheral.Cycles
 import TNLean.Channel.Peripheral.MultiCycleDecomposition
 -- Chapter 2 §2.3 normal-form existence (SVD + Lorentz)
 import TNLean.Channel.NormalForm
-
 -- Public documentation index modules
 import TNLean.Channel.WolfChapter2Index
 import TNLean.Channel.WolfChapter6Index

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -478,7 +478,6 @@ import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
-import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
+++ b/TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum.lean
@@ -12,7 +12,8 @@ import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
 The canonical block-diagonal extension transfers trace nonincrease and fixed
 product generators from a finite direct sum to a full matrix algebra.  The
 full-matrix product-span theorem then gives trace preservation on the original
-direct sum.
+direct sum.  For a trace-preserving endomorphism, the same extension also
+produces a componentwise positive-definite fixed family.
 
 This is the finite-direct-sum form needed for arXiv:1606.00608, Appendix C.4.
 Lines 1974--1980 identify the fixed contraction families, and lines
@@ -171,6 +172,60 @@ theorem IsTracePreservingMap.isTracePreservingDirectSumMap_of_extension
   simpa only [directSumExtension_apply, directSumDiagonalCompression_embedding,
     trace_directSumDiagonalEmbedding] using h
 
+/-- The block-diagonal embedding carries identity membership in a span of
+pointwise products to identity membership in the corresponding full-matrix
+product span. -/
+private theorem directSumDiagonalEmbedding_one_mem_product_span
+    {J : Type*}
+    (V : J → (∀ k, Matrix (n k) (n k) ℂ))
+    (L : ℕ)
+    (hOne : (1 : ∀ k, Matrix (n k) (n k) ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J ↦
+        (List.ofFn fun t ↦ V (x t)).prod)) :
+    (1 : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J ↦
+        (List.ofFn fun t ↦ directSumDiagonalEmbedding (V (x t))).prod) := by
+  classical
+  let productSpan := Submodule.span ℂ
+    (Set.range fun x : Fin L → J ↦
+      (List.ofFn fun t ↦ directSumDiagonalEmbedding (V (x t))).prod)
+  have hEmbeddingProd (l : List J) :
+      directSumDiagonalEmbedding (l.map V).prod =
+        (l.map (fun j ↦ directSumDiagonalEmbedding (V j))).prod := by
+    induction l with
+    | nil =>
+        simp only [List.map_nil, List.prod_nil]
+        exact Matrix.blockDiagonal'_one
+    | cons a l ih =>
+        simp only [List.map_cons, List.prod_cons]
+        rw [directSumDiagonalEmbedding_mul, ih]
+  have hOneEmbedded :
+      directSumDiagonalEmbedding (1 : ∀ k, Matrix (n k) (n k) ℂ) = 1 :=
+    Matrix.blockDiagonal'_one
+  rw [← hOneEmbedded]
+  exact Submodule.span_induction (p := fun X _ ↦
+      directSumDiagonalEmbedding X ∈ productSpan)
+    (fun X hX ↦ by
+      obtain ⟨x, rfl⟩ := hX
+      apply Submodule.subset_span
+      refine ⟨x, ?_⟩
+      have hprod := hEmbeddingProd (List.ofFn x)
+      rw [List.map_ofFn, List.map_ofFn] at hprod
+      have hfun : V ∘ x = fun t ↦ V (x t) := rfl
+      have hfunW : (fun j ↦ directSumDiagonalEmbedding (V j)) ∘ x =
+          fun t ↦ directSumDiagonalEmbedding (V (x t)) := rfl
+      simpa only [hfun, hfunW] using hprod.symm)
+    (by
+      rw [map_zero]
+      exact Submodule.zero_mem productSpan)
+    (fun X Y _ _ hX hY ↦ by
+      rw [map_add]
+      exact Submodule.add_mem productSpan hX hY)
+    (fun c X _ hX ↦ by
+      rw [_root_.map_smul]
+      exact Submodule.smul_mem productSpan c hX)
+    hOne
+
 omit [DecidableEq ι] in
 /-- A positive trace-nonincreasing endomorphism of a finite sum of matrix
 algebras preserves the total trace when the identity family lies in the span
@@ -202,48 +257,73 @@ theorem IsPositiveDirectSumMap.tracePreserving_of_traceNonincreasing_of_fixed_pr
   have hETNI : IsTraceNonincreasingMap E := hTNI.directSumExtension
   have hWFixed (j : J) : E (W j) = W j := by
     exact (directSumExtension_embedding_eq_self_iff T (V j)).2 (hFixed j)
-  have hEmbeddingProd (l : List J) :
-      directSumDiagonalEmbedding (l.map V).prod = (l.map W).prod := by
-    induction l with
-    | nil =>
-        simp only [List.map_nil, List.prod_nil]
-        change Matrix.blockDiagonal' (1 : ∀ k, Matrix (n k) (n k) ℂ) = 1
-        exact Matrix.blockDiagonal'_one
-    | cons a l ih =>
-        simp only [List.map_cons, List.prod_cons]
-        rw [directSumDiagonalEmbedding_mul, ih]
-  let productSpan := Submodule.span ℂ
-    (Set.range fun x : Fin L → J ↦ (List.ofFn fun t ↦ W (x t)).prod)
-  have hOneEmbedded :
-      directSumDiagonalEmbedding (1 : ∀ k, Matrix (n k) (n k) ℂ) = 1 := by
-    exact Matrix.blockDiagonal'_one
   have hOneFull :
-      (1 : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) ∈ productSpan := by
-    rw [← hOneEmbedded]
-    exact Submodule.span_induction (p := fun X _ ↦
-        directSumDiagonalEmbedding X ∈ productSpan)
-      (fun X hX ↦ by
-        obtain ⟨x, rfl⟩ := hX
-        apply Submodule.subset_span
-        refine ⟨x, ?_⟩
-        have hprod := hEmbeddingProd (List.ofFn x)
-        rw [List.map_ofFn, List.map_ofFn] at hprod
-        have hfun : V ∘ x = fun t ↦ V (x t) := rfl
-        have hfunW : W ∘ x = fun t ↦ W (x t) := rfl
-        simpa only [hfun, hfunW] using hprod.symm)
-      (by
-        rw [map_zero]
-        exact Submodule.zero_mem productSpan)
-      (fun X Y _ _ hX hY ↦ by
-        rw [map_add]
-        exact Submodule.add_mem productSpan hX hY)
-      (fun c X _ hX ↦ by
-        rw [_root_.map_smul]
-        exact Submodule.smul_mem productSpan c hX)
-      hOne
+      (1 : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) ∈
+        Submodule.span ℂ (Set.range fun x : Fin L → J ↦
+          (List.ofFn fun t ↦ W (x t)).prod) := by
+    simpa only [W] using directSumDiagonalEmbedding_one_mem_product_span V L hOne
   have hETrace : IsTracePreservingMap E :=
     hEpos.tracePreserving_of_traceNonincreasing_of_fixed_product_span
       hETNI W L hL hWFixed hOneFull
   exact Matrix.IsTracePreservingMap.isTracePreservingDirectSumMap_of_extension hETrace
+
+omit [DecidableEq ι] in
+/-- A positive trace-preserving endomorphism of a finite product of matrix
+algebras has a positive-definite fixed family when the identity belongs to
+the span of positive-length products of a fixed family.
+
+No product of the fixed factors is assumed to be fixed.  The proof applies
+the full-matrix maximal-support theorem to the canonical block-diagonal
+extension and then takes its diagonal blocks.
+
+Local finite-product consequence used to formalize arXiv:1606.00608,
+Appendix C.4, lines 1980--1993.  CPSV16 instead applies Wolf's density-block
+description directly, including its possible zero summand. -/
+theorem IsPositiveDirectSumMap.exists_posDef_fixedFamily_of_fixed_product_span
+    {J : Type*}
+    {F : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hF : IsPositiveDirectSumMap F)
+    (hTP : IsTracePreservingDirectSumMap F)
+    (V : J → (∀ k, Matrix (n k) (n k) ℂ))
+    (L : ℕ) (hL : 0 < L)
+    (hFixed : ∀ j, F (V j) = V j)
+    (hOne : (1 : ∀ k, Matrix (n k) (n k) ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J ↦
+        (List.ofFn fun t ↦ V (x t)).prod)) :
+    ∃ ρ : ∀ k, Matrix (n k) (n k) ℂ,
+      (∀ k, (ρ k).PosDef) ∧ F ρ = ρ := by
+  classical
+  let E := directSumExtension F
+  let W : J → Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ :=
+    fun j ↦ directSumDiagonalEmbedding (V j)
+  have hEpos : IsPositiveMap E :=
+    hF.directSumExtension_isPositiveMap
+  have hETP : IsTracePreservingMap E :=
+    hTP.directSumExtension_isTracePreservingMap
+  have hETNI : IsTraceNonincreasingMap E := by
+    intro X _
+    exact (hETP X).le
+  have hWFixed (j : J) : E (W j) = W j := by
+    exact (directSumExtension_embedding_eq_self_iff F (V j)).2 (hFixed j)
+  have hOneFull :
+      (1 : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) ∈
+        Submodule.span ℂ (Set.range fun x : Fin L → J ↦
+          (List.ofFn fun t ↦ W (x t)).prod) := by
+    simpa only [W] using directSumDiagonalEmbedding_one_mem_product_span V L hOne
+  obtain ⟨ρFull, hρFull, hρFullFixed⟩ :=
+    hEpos.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span
+      hETNI W L hL hWFixed hOneFull
+  obtain ⟨ρ, hρFixed, hρFullEq⟩ :=
+    (directSumExtension_apply_eq_self_iff F ρFull).mp hρFullFixed
+  refine ⟨ρ, ?_, hρFixed⟩
+  intro k
+  have hρBlock : (directSumDiagonalCompression ρFull k).PosDef := by
+    rw [directSumDiagonalCompression_apply]
+    apply hρFull.submatrix
+    intro a b hab
+    simpa using hab
+  rw [hρFullEq, directSumDiagonalCompression_embedding] at hρBlock
+  exact hρBlock
 
 end Matrix

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -103,6 +103,49 @@ def WeightedVerticalBondContractionProductSpanTop
   Submodule.span ℂ
     (Set.range (weightedVerticalBondContractionProduct (L := L) m A)) = ⊤
 
+/-- If the weighted vertical bond contractions span by products of length
+`L`, then the identity belongs to the corresponding pointwise product span.
+
+Local pointwise-product reformulation of arXiv:1606.00608, Appendix C.4,
+lines 1980--1990. -/
+theorem one_mem_product_span_of_weightedVerticalBondContractions
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (hSpan : WeightedVerticalBondContractionProductSpanTop m A L) :
+    (1 : VerticalSectorAlgebra dim) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → Matrix (Fin D) (Fin D) ℂ ↦
+        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) := by
+  have hOneRaw : (1 : VerticalSectorAlgebra dim) ∈
+      Submodule.span ℂ (Set.range
+        (weightedVerticalBondContractionProduct (L := L) m A)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hRange : Set.range (weightedVerticalBondContractionProduct
+      (L := L) m A) =
+      Set.range (fun x : Fin L → Matrix (Fin D) (Fin D) ℂ ↦
+        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) := by
+    ext Y
+    constructor
+    · rintro ⟨x, rfl⟩
+      refine ⟨x, ?_⟩
+      funext α
+      change ((List.ofFn fun t ↦
+          weightedVerticalBondContraction m A (x t)).prod) α =
+        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t) α).prod
+      rw [Pi.list_prod_apply, List.map_ofFn]
+      rfl
+    · rintro ⟨x, rfl⟩
+      refine ⟨x, ?_⟩
+      funext α
+      change (List.ofFn fun t ↦
+          weightedVerticalBondContraction m A (x t) α).prod =
+        ((List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) α
+      rw [Pi.list_prod_apply, List.map_ofFn]
+      rfl
+  rw [← hRange]
+  exact hOneRaw
+
 /-- The span of all $L$-fold products of fixed points of a linear
 endomorphism of the vertical-sector algebra.
 

--- a/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
-import TNLean.MPS.MPDO.VerticalSectorTracePreservation
+import TNLean.MPS.MPDO.VerticalSectorGeneration
 
 /-!
 # Identity criterion for vertical-sector maps

--- a/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
@@ -19,7 +19,7 @@ then shows that the endomorphism is the identity.
 ## References
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
-  Appendix C.4, lines 1980--1993.
+  Appendix C.4, lines 1980--1995.
 * M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
   Equation (6.63).
 -/
@@ -41,7 +41,9 @@ No product of the fixed factors is assumed to be fixed.  The proof applies
 the full-matrix maximal-support theorem to the canonical block-diagonal
 extension and then takes its diagonal blocks.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+Local finite-product consequence used to formalize arXiv:1606.00608,
+Appendix C.4, lines 1980--1993.  CPSV16 instead applies Wolf's density-block
+description directly, including its possible zero summand. -/
 theorem IsPositiveDirectSumMap.exists_posDef_fixedFamily_of_fixed_product_span
     {F : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
       (∀ k, Matrix (n k) (n k) ℂ)}
@@ -134,7 +136,7 @@ contractions first give a positive-definite fixed family.  Wolf's
 density-block description then bounds the dimension of the products of fixed
 points, which forces every sector matrix to be fixed.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+Source application: arXiv:1606.00608, Appendix C.4, lines 1980--1995. -/
 theorem eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
     {g D L : ℕ} {dim : Fin g → ℕ}
     (m : Fin g → ℂ)

--- a/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
+import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
 import TNLean.MPS.MPDO.VerticalSectorGeneration
 
@@ -27,103 +27,6 @@ then shows that the endomorphism is the identity.
 open scoped Matrix MatrixOrder ComplexOrder
 
 noncomputable section
-
-namespace Matrix
-
-variable {ι J : Type*} [Fintype ι]
-variable {n : ι → Type*} [∀ k, Fintype (n k)] [∀ k, DecidableEq (n k)]
-
-/-- A positive trace-preserving endomorphism of a finite product of matrix
-algebras has a positive-definite fixed family when the identity belongs to
-the span of positive-length products of a fixed family.
-
-No product of the fixed factors is assumed to be fixed.  The proof applies
-the full-matrix maximal-support theorem to the canonical block-diagonal
-extension and then takes its diagonal blocks.
-
-Local finite-product consequence used to formalize arXiv:1606.00608,
-Appendix C.4, lines 1980--1993.  CPSV16 instead applies Wolf's density-block
-description directly, including its possible zero summand. -/
-theorem IsPositiveDirectSumMap.exists_posDef_fixedFamily_of_fixed_product_span
-    {F : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
-      (∀ k, Matrix (n k) (n k) ℂ)}
-    (hF : IsPositiveDirectSumMap F)
-    (hTP : IsTracePreservingDirectSumMap F)
-    (V : J → (∀ k, Matrix (n k) (n k) ℂ))
-    (L : ℕ) (hL : 0 < L)
-    (hFixed : ∀ j, F (V j) = V j)
-    (hOne : (1 : ∀ k, Matrix (n k) (n k) ℂ) ∈
-      Submodule.span ℂ (Set.range fun x : Fin L → J ↦
-        (List.ofFn fun t ↦ V (x t)).prod)) :
-    ∃ ρ : ∀ k, Matrix (n k) (n k) ℂ,
-      (∀ k, (ρ k).PosDef) ∧ F ρ = ρ := by
-  classical
-  let E := directSumExtension F
-  let W : J → Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ :=
-    fun j ↦ directSumDiagonalEmbedding (V j)
-  have hEpos : IsPositiveMap E :=
-    hF.directSumExtension_isPositiveMap
-  have hETP : IsTracePreservingMap E :=
-    hTP.directSumExtension_isTracePreservingMap
-  have hETNI : IsTraceNonincreasingMap E := by
-    intro X _
-    exact (hETP X).le
-  have hWFixed (j : J) : E (W j) = W j := by
-    exact (directSumExtension_embedding_eq_self_iff F (V j)).2 (hFixed j)
-  have hEmbeddingProd (l : List J) :
-      directSumDiagonalEmbedding (l.map V).prod = (l.map W).prod := by
-    induction l with
-    | nil =>
-        simp only [List.map_nil, List.prod_nil]
-        exact Matrix.blockDiagonal'_one
-    | cons a l ih =>
-        simp only [List.map_cons, List.prod_cons]
-        rw [directSumDiagonalEmbedding_mul, ih]
-  let productSpan := Submodule.span ℂ
-    (Set.range fun x : Fin L → J ↦ (List.ofFn fun t ↦ W (x t)).prod)
-  have hOneEmbedded :
-      directSumDiagonalEmbedding (1 : ∀ k, Matrix (n k) (n k) ℂ) = 1 :=
-    Matrix.blockDiagonal'_one
-  have hOneFull :
-      (1 : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) ∈ productSpan := by
-    rw [← hOneEmbedded]
-    exact Submodule.span_induction (p := fun X _ ↦
-        directSumDiagonalEmbedding X ∈ productSpan)
-      (fun X hX ↦ by
-        obtain ⟨x, rfl⟩ := hX
-        apply Submodule.subset_span
-        refine ⟨x, ?_⟩
-        have hprod := hEmbeddingProd (List.ofFn x)
-        rw [List.map_ofFn, List.map_ofFn] at hprod
-        have hfun : V ∘ x = fun t ↦ V (x t) := rfl
-        have hfunW : W ∘ x = fun t ↦ W (x t) := rfl
-        simpa only [hfun, hfunW] using hprod.symm)
-      (by
-        rw [map_zero]
-        exact Submodule.zero_mem productSpan)
-      (fun X Y _ _ hX hY ↦ by
-        rw [map_add]
-        exact Submodule.add_mem productSpan hX hY)
-      (fun c X _ hX ↦ by
-        rw [_root_.map_smul]
-        exact Submodule.smul_mem productSpan c hX)
-      hOne
-  obtain ⟨ρFull, hρFull, hρFullFixed⟩ :=
-    hEpos.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span
-      hETNI W L hL hWFixed hOneFull
-  obtain ⟨ρ, hρFixed, hρFullEq⟩ :=
-    (directSumExtension_apply_eq_self_iff F ρFull).mp hρFullFixed
-  refine ⟨ρ, ?_, hρFixed⟩
-  intro k
-  have hρBlock : (directSumDiagonalCompression ρFull k).PosDef := by
-    rw [directSumDiagonalCompression_apply]
-    apply hρFull.submatrix
-    intro a b hab
-    simpa using hab
-  rw [hρFullEq, directSumDiagonalCompression_embedding] at hρBlock
-  exact hρBlock
-
-end Matrix
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorInvertibility.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
+import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
+import TNLean.MPS.MPDO.VerticalSectorTracePreservation
+
+/-!
+# Identity criterion for vertical-sector maps
+
+A positive trace-preserving endomorphism of a finite product of matrix
+algebras has a positive-definite fixed family when fixed factors generate the
+identity by products of one positive length.  If its trace adjoint satisfies
+the Schwarz inequality, the density-block description of its fixed points
+then shows that the endomorphism is the identity.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1980--1993.
+* M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14 and
+  Equation (6.63).
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder
+
+noncomputable section
+
+namespace Matrix
+
+variable {ι J : Type*} [Fintype ι]
+variable {n : ι → Type*} [∀ k, Fintype (n k)] [∀ k, DecidableEq (n k)]
+
+/-- A positive trace-preserving endomorphism of a finite product of matrix
+algebras has a positive-definite fixed family when the identity belongs to
+the span of positive-length products of a fixed family.
+
+No product of the fixed factors is assumed to be fixed.  The proof applies
+the full-matrix maximal-support theorem to the canonical block-diagonal
+extension and then takes its diagonal blocks.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+theorem IsPositiveDirectSumMap.exists_posDef_fixedFamily_of_fixed_product_span
+    {F : (∀ k, Matrix (n k) (n k) ℂ) →ₗ[ℂ]
+      (∀ k, Matrix (n k) (n k) ℂ)}
+    (hF : IsPositiveDirectSumMap F)
+    (hTP : IsTracePreservingDirectSumMap F)
+    (V : J → (∀ k, Matrix (n k) (n k) ℂ))
+    (L : ℕ) (hL : 0 < L)
+    (hFixed : ∀ j, F (V j) = V j)
+    (hOne : (1 : ∀ k, Matrix (n k) (n k) ℂ) ∈
+      Submodule.span ℂ (Set.range fun x : Fin L → J ↦
+        (List.ofFn fun t ↦ V (x t)).prod)) :
+    ∃ ρ : ∀ k, Matrix (n k) (n k) ℂ,
+      (∀ k, (ρ k).PosDef) ∧ F ρ = ρ := by
+  classical
+  let E := directSumExtension F
+  let W : J → Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ :=
+    fun j ↦ directSumDiagonalEmbedding (V j)
+  have hEpos : IsPositiveMap E :=
+    hF.directSumExtension_isPositiveMap
+  have hETP : IsTracePreservingMap E :=
+    hTP.directSumExtension_isTracePreservingMap
+  have hETNI : IsTraceNonincreasingMap E := by
+    intro X _
+    exact (hETP X).le
+  have hWFixed (j : J) : E (W j) = W j := by
+    exact (directSumExtension_embedding_eq_self_iff F (V j)).2 (hFixed j)
+  have hEmbeddingProd (l : List J) :
+      directSumDiagonalEmbedding (l.map V).prod = (l.map W).prod := by
+    induction l with
+    | nil =>
+        simp only [List.map_nil, List.prod_nil]
+        exact Matrix.blockDiagonal'_one
+    | cons a l ih =>
+        simp only [List.map_cons, List.prod_cons]
+        rw [directSumDiagonalEmbedding_mul, ih]
+  let productSpan := Submodule.span ℂ
+    (Set.range fun x : Fin L → J ↦ (List.ofFn fun t ↦ W (x t)).prod)
+  have hOneEmbedded :
+      directSumDiagonalEmbedding (1 : ∀ k, Matrix (n k) (n k) ℂ) = 1 :=
+    Matrix.blockDiagonal'_one
+  have hOneFull :
+      (1 : Matrix ((k : ι) × n k) ((k : ι) × n k) ℂ) ∈ productSpan := by
+    rw [← hOneEmbedded]
+    exact Submodule.span_induction (p := fun X _ ↦
+        directSumDiagonalEmbedding X ∈ productSpan)
+      (fun X hX ↦ by
+        obtain ⟨x, rfl⟩ := hX
+        apply Submodule.subset_span
+        refine ⟨x, ?_⟩
+        have hprod := hEmbeddingProd (List.ofFn x)
+        rw [List.map_ofFn, List.map_ofFn] at hprod
+        have hfun : V ∘ x = fun t ↦ V (x t) := rfl
+        have hfunW : W ∘ x = fun t ↦ W (x t) := rfl
+        simpa only [hfun, hfunW] using hprod.symm)
+      (by
+        rw [map_zero]
+        exact Submodule.zero_mem productSpan)
+      (fun X Y _ _ hX hY ↦ by
+        rw [map_add]
+        exact Submodule.add_mem productSpan hX hY)
+      (fun c X _ hX ↦ by
+        rw [_root_.map_smul]
+        exact Submodule.smul_mem productSpan c hX)
+      hOne
+  obtain ⟨ρFull, hρFull, hρFullFixed⟩ :=
+    hEpos.exists_posDef_fixedPoint_of_traceNonincreasing_of_fixed_product_span
+      hETNI W L hL hWFixed hOneFull
+  obtain ⟨ρ, hρFixed, hρFullEq⟩ :=
+    (directSumExtension_apply_eq_self_iff F ρFull).mp hρFullFixed
+  refine ⟨ρ, ?_, hρFixed⟩
+  intro k
+  have hρBlock : (directSumDiagonalCompression ρFull k).PosDef := by
+    rw [directSumDiagonalCompression_apply]
+    apply hρFull.submatrix
+    intro a b hab
+    simpa using hab
+  rw [hρFullEq, directSumDiagonalCompression_embedding] at hρBlock
+  exact hρBlock
+
+end Matrix
+
+namespace MPOTensor
+
+/-- A positive trace-preserving endomorphism of a vertical-sector algebra is
+the identity if its trace adjoint satisfies the Schwarz inequality and it
+fixes weighted bond contractions whose products span the sector algebra.
+
+No product of fixed contractions is assumed to be fixed.  The fixed
+contractions first give a positive-definite fixed family.  Wolf's
+density-block description then bounds the dimension of the products of fixed
+points, which forces every sector matrix to be fixed.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+theorem eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
+    {g D L : ℕ} {dim : Fin g → ℕ}
+    (m : Fin g → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim)
+    (hL : 0 < L)
+    (hF : Matrix.IsPositiveDirectSumMap F)
+    (hTP : Matrix.IsTracePreservingDirectSumMap F)
+    (hSchwarz : Matrix.IsSchwarzDirectSumMap
+      (Matrix.directSumTraceAdjointMap F))
+    (hSpan : WeightedVerticalBondContractionProductSpanTop m A L)
+    (hFixed : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      F (weightedVerticalBondContraction m A X) =
+        weightedVerticalBondContraction m A X) :
+    F = LinearMap.id := by
+  have hOne :=
+    one_mem_product_span_of_weightedVerticalBondContractions m A hSpan
+  obtain ⟨ρ, hρ, hρFixed⟩ :=
+    hF.exists_posDef_fixedFamily_of_fixed_product_span
+      hTP (weightedVerticalBondContraction m A) L hL hFixed hOne
+  apply eq_id_of_weightedVerticalBondContractions_fixed_of_productSpan_finrank_le
+    m A F hSpan hFixed
+  exact fixedPointProductSpan_finrank_le_of_densityBlocks
+    hF hTP hSchwarz hρ hρFixed L hL
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -40,7 +40,8 @@ namespace MPOTensor
 /-- If the weighted vertical bond contractions span by products of length
 `L`, then the identity belongs to the corresponding pointwise product span.
 
-Source: arXiv:1606.00608, Appendix C.4, lines 1980--1990. -/
+Local pointwise-product reformulation of arXiv:1606.00608, Appendix C.4,
+lines 1980--1990. -/
 theorem one_mem_product_span_of_weightedVerticalBondContractions
     {g D L : ℕ} {dim : Fin g → ℕ}
     (m : Fin g → ℂ)

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -37,9 +37,11 @@ noncomputable section
 
 namespace MPOTensor
 
-/-- The BNT product-span formulation agrees with the pointwise product family
-used by the direct-sum trace criterion. -/
-private theorem one_mem_product_span_of_weightedVerticalBondContractions
+/-- If the weighted vertical bond contractions span by products of length
+`L`, then the identity belongs to the corresponding pointwise product span.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1990. -/
+theorem one_mem_product_span_of_weightedVerticalBondContractions
     {g D L : ℕ} {dim : Fin g → ℕ}
     (m : Fin g → ℂ)
     (A : (α : Fin g) → MPSTensor (D * D) (dim α))

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -37,49 +37,6 @@ noncomputable section
 
 namespace MPOTensor
 
-/-- If the weighted vertical bond contractions span by products of length
-`L`, then the identity belongs to the corresponding pointwise product span.
-
-Local pointwise-product reformulation of arXiv:1606.00608, Appendix C.4,
-lines 1980--1990. -/
-theorem one_mem_product_span_of_weightedVerticalBondContractions
-    {g D L : ℕ} {dim : Fin g → ℕ}
-    (m : Fin g → ℂ)
-    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
-    (hSpan : WeightedVerticalBondContractionProductSpanTop m A L) :
-    (1 : VerticalSectorAlgebra dim) ∈
-      Submodule.span ℂ (Set.range fun x : Fin L → Matrix (Fin D) (Fin D) ℂ ↦
-        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) := by
-  have hOneRaw : (1 : VerticalSectorAlgebra dim) ∈
-      Submodule.span ℂ (Set.range
-        (weightedVerticalBondContractionProduct (L := L) m A)) := by
-    rw [hSpan]
-    exact Submodule.mem_top
-  have hRange : Set.range (weightedVerticalBondContractionProduct
-      (L := L) m A) =
-      Set.range (fun x : Fin L → Matrix (Fin D) (Fin D) ℂ ↦
-        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) := by
-    ext Y
-    constructor
-    · rintro ⟨x, rfl⟩
-      refine ⟨x, ?_⟩
-      funext α
-      change ((List.ofFn fun t ↦
-          weightedVerticalBondContraction m A (x t)).prod) α =
-        (List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t) α).prod
-      rw [Pi.list_prod_apply, List.map_ofFn]
-      rfl
-    · rintro ⟨x, rfl⟩
-      refine ⟨x, ?_⟩
-      funext α
-      change (List.ofFn fun t ↦
-          weightedVerticalBondContraction m A (x t) α).prod =
-        ((List.ofFn fun t ↦ weightedVerticalBondContraction m A (x t)).prod) α
-      rw [Pi.list_prod_apply, List.map_ofFn]
-      rfl
-  rw [← hRange]
-  exact hOneRaw
-
 /-- The transported coarse-graining and refinement maps, as well as their two
 square composites, preserve the appropriate total sector traces.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -686,6 +686,41 @@ physical indices, as in
     Thus $\mathcal F=\mathcal A$, and $F$ is the identity.
 \end{proof}
 
+\begin{theorem}[Identity criterion from fixed contractions]
+    \label{thm:mpdo_fixed_contractions_trace_adjoint_schwarz_identity}
+    \lean{MPOTensor.%
+        eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz}
+    \leanok
+    \uses{thm:mpdo_direct_sum_faithful_fixed_family,
+        thm:mpdo_density_blocks_fixed_point_product_dimension,
+        thm:mpdo_fixed_contractions_product_dimension}
+    Let $F$ be a positive trace-preserving endomorphism of
+    $\mathcal A=\prod_\alpha M_{d_\alpha}$ whose trace adjoint satisfies the
+    Schwarz inequality.  Suppose that, for some $L>0$,
+    \[
+        C_L(V_c)=\mathcal A,
+        \qquad F(V_c(X))=V_c(X)
+    \]
+    for every bond matrix $X$.  Then $F=\operatorname{id}_{\mathcal A}$.
+    No product $V_c(X_1)\cdots V_c(X_L)$ is assumed to be fixed.
+
+    This is the implication used for each transported square composite in
+    \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The fixed contractions and their positive-length product span give a
+    positive-definite fixed family $\rho=(\rho_\alpha)_\alpha$.  Hence
+    Theorem~\ref{thm:mpdo_density_blocks_fixed_point_product_dimension}
+    gives
+    \[
+        \dim C_L(\mathcal F)\leq\dim\mathcal F,
+        \qquad \mathcal F=\operatorname{Fix}(F).
+    \]
+    Since $C_L(V_c)=\mathcal A$ and $V_c(X)\in\mathcal F$, the preceding
+    theorem gives $F=\operatorname{id}_{\mathcal A}$.
+\end{proof}
+
 \begin{definition}[Retained coordinates for the vertical-sector algebra]
     \label{def:mpdo_retained_vertical_sector_coordinates}
     \lean{MPOTensor.verticalSectorFinEquiv}
@@ -1746,6 +1781,42 @@ physical indices, as in
     The product-span hypothesis then gives
     $Q\mathbf 1Q=\mathbf 1$, so $Q=\mathbf 1$.  Thus $\rho$ is positive
     definite, and the construction of $P$ gives $F(\rho)=\rho$.
+\end{proof}
+
+\begin{theorem}[Faithful fixed family in a finite product]
+    \label{thm:mpdo_direct_sum_faithful_fixed_family}
+    \lean{Matrix.IsPositiveDirectSumMap.%
+        exists_posDef_fixedFamily_of_fixed_product_span}
+    \leanok
+    \uses{thm:positive_map_faithful_fixed_point_from_product_span,
+        thm:direct_sum_full_matrix_extension_compatibility}
+    Let $F$ be a positive trace-preserving endomorphism of
+    $\mathcal A=\prod_\alpha M_{d_\alpha}$.  Suppose that each $V_j$ is
+    fixed by $F$ and, for some $L>0$, the identity belongs to
+    \[
+        \spn_{\C}\{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+    \]
+    Then there is a fixed family $\rho=(\rho_\alpha)_\alpha$ such that every
+    $\rho_\alpha$ is positive definite.
+
+    This is the finite-product form of the faithful fixed-point argument in
+    \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Extend $F$ to the full matrix algebra by diagonal compression followed
+    by block-diagonal embedding.  This extension is positive and trace
+    preserving.  Block-diagonal embedding preserves the identity and every
+    product $V_{j_1}\cdots V_{j_L}$, so
+    Theorem~\ref{thm:positive_map_faithful_fixed_point_from_product_span}
+    gives a positive-definite fixed point $\widehat\rho$ of the extension.
+    Fixed points of the extension are block diagonal.  Thus
+    \[
+        \widehat\rho=\bigoplus_\alpha\rho_\alpha,
+        \qquad F(\rho)=\rho.
+    \]
+    Every diagonal block $\rho_\alpha$ of the positive-definite matrix
+    $\widehat\rho$ is positive definite.
 \end{proof}
 
 \begin{theorem}[Trace preservation of the transported vertical-sector maps]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -686,6 +686,45 @@ physical indices, as in
     Thus $\mathcal F=\mathcal A$, and $F$ is the identity.
 \end{proof}
 
+\begin{theorem}[Faithful fixed family in a finite product]
+    \label{thm:mpdo_direct_sum_faithful_fixed_family}
+    \lean{Matrix.IsPositiveDirectSumMap.%
+        exists_posDef_fixedFamily_of_fixed_product_span}
+    \leanok
+    \uses{thm:positive_map_faithful_fixed_point_from_product_span,
+        thm:direct_sum_full_matrix_extension_compatibility}
+    Let $F$ be a positive trace-preserving endomorphism of
+    $\mathcal A=\prod_\alpha M_{d_\alpha}$.  Suppose that each $V_j$ is
+    fixed by $F$ and, for some $L>0$, the identity belongs to
+    \[
+        \spn_{\C}\{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
+    \]
+    Then there is a fixed family $\rho=(\rho_\alpha)_\alpha$ such that every
+    $\rho_\alpha$ is positive definite.
+
+    This is a local finite-product consequence used to formalize the
+    fixed-point argument in
+    \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}; CPSV16 applies
+    Wolf's density-block description directly rather than stating this
+    intermediate result.
+\end{theorem}
+
+\begin{proof}\leanok
+    Extend $F$ to the full matrix algebra by diagonal compression followed
+    by block-diagonal embedding.  This extension is positive and trace
+    preserving.  Block-diagonal embedding preserves the identity and every
+    product $V_{j_1}\cdots V_{j_L}$, so
+    Theorem~\ref{thm:positive_map_faithful_fixed_point_from_product_span}
+    gives a positive-definite fixed point $\widehat\rho$ of the extension.
+    Fixed points of the extension are block diagonal.  Thus
+    \[
+        \widehat\rho=\bigoplus_\alpha\rho_\alpha,
+        \qquad F(\rho)=\rho.
+    \]
+    Every diagonal block $\rho_\alpha$ of the positive-definite matrix
+    $\widehat\rho$ is positive definite.
+\end{proof}
+
 \begin{theorem}[Identity criterion from fixed contractions]
     \label{thm:mpdo_fixed_contractions_trace_adjoint_schwarz_identity}
     \lean{MPOTensor.%
@@ -705,7 +744,7 @@ physical indices, as in
     No product $V_c(X_1)\cdots V_c(X_L)$ is assumed to be fixed.
 
     This is the implication used for each transported square composite in
-    \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.
+    \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1781,42 +1820,6 @@ physical indices, as in
     The product-span hypothesis then gives
     $Q\mathbf 1Q=\mathbf 1$, so $Q=\mathbf 1$.  Thus $\rho$ is positive
     definite, and the construction of $P$ gives $F(\rho)=\rho$.
-\end{proof}
-
-\begin{theorem}[Faithful fixed family in a finite product]
-    \label{thm:mpdo_direct_sum_faithful_fixed_family}
-    \lean{Matrix.IsPositiveDirectSumMap.%
-        exists_posDef_fixedFamily_of_fixed_product_span}
-    \leanok
-    \uses{thm:positive_map_faithful_fixed_point_from_product_span,
-        thm:direct_sum_full_matrix_extension_compatibility}
-    Let $F$ be a positive trace-preserving endomorphism of
-    $\mathcal A=\prod_\alpha M_{d_\alpha}$.  Suppose that each $V_j$ is
-    fixed by $F$ and, for some $L>0$, the identity belongs to
-    \[
-        \spn_{\C}\{V_{j_1}\cdots V_{j_L}:j_1,\ldots,j_L\in J\}.
-    \]
-    Then there is a fixed family $\rho=(\rho_\alpha)_\alpha$ such that every
-    $\rho_\alpha$ is positive definite.
-
-    This is the finite-product form of the faithful fixed-point argument in
-    \cite[Appendix~C.4, lines~1980--1993]{Cirac2016MPDO_arXiv}.
-\end{theorem}
-
-\begin{proof}\leanok
-    Extend $F$ to the full matrix algebra by diagonal compression followed
-    by block-diagonal embedding.  This extension is positive and trace
-    preserving.  Block-diagonal embedding preserves the identity and every
-    product $V_{j_1}\cdots V_{j_L}$, so
-    Theorem~\ref{thm:positive_map_faithful_fixed_point_from_product_span}
-    gives a positive-definite fixed point $\widehat\rho$ of the extension.
-    Fixed points of the extension are block diagonal.  Thus
-    \[
-        \widehat\rho=\bigoplus_\alpha\rho_\alpha,
-        \qquad F(\rho)=\rho.
-    \]
-    Every diagonal block $\rho_\alpha$ of the positive-definite matrix
-    $\widehat\rho$ is positive definite.
 \end{proof}
 
 \begin{theorem}[Trace preservation of the transported vertical-sector maps]

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -195,7 +195,8 @@ positive-definite fixed point.  No product is required to be fixed.  The
 finite-product passage and its combination with the density-block dimension
 bound are now also formalized.\footnote{Formal declarations:
 \leanid{Matrix.IsPositiveDirectSumMap.%
-exists_posDef_fixedFamily_of_fixed_product_span} and
+exists_posDef_fixedFamily_of_fixed_product_span}
+in \doclink{TNLean/Channel/FixedPoint/TraceNonincreasingDirectSum}, and
 \leanid{MPOTensor.%
 eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz}
 in \doclink{TNLean/MPS/MPDO/VerticalSectorInvertibility}.}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -186,10 +186,20 @@ in \doclink{TNLean/Channel/FixedPoint/TraceNonincreasingProductSpan}.}
 A positive trace-nonincreasing endomorphism with fixed factors for which the
 identity lies in the span of the products of one positive length has a
 positive-definite fixed point.  No product is required to be fixed.  The
-remaining fixed-point argument for the transported composites must still pass
-this statement through the finite direct sums and combine it with the
-density-block dimension bound; the present result alone does not prove that
-either composite is the identity.
+finite-product passage and its combination with the density-block dimension
+bound are now also formalized.\footnote{Formal declarations:
+\leanid{Matrix.IsPositiveDirectSumMap.%
+exists_posDef_fixedFamily_of_fixed_product_span} and
+\leanid{MPOTensor.%
+eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz}
+in \doclink{TNLean/MPS/MPDO/VerticalSectorInvertibility}.}
+A positive trace-preserving endomorphism of
+a finite product therefore has a positive-definite fixed family under the
+same product-span hypothesis; if its trace adjoint satisfies the Schwarz
+inequality, the fixed contractions and the density-block bound force the
+endomorphism to be the identity.  The remaining application to the transported
+composites is to derive the required positivity and adjoint Schwarz properties
+from the source tensor hypotheses.
 
 Let $F^*$ be the trace adjoint and define the trace-loss operator
 \[
@@ -265,15 +275,9 @@ order:
           two transported square composites on the full sector algebras;
           trace preservation of the individual maps and composites is now
           established without an all-input active-image statement;
-    \item apply the maximal-support fixed-point construction to the canonical
-          full-matrix extensions and compress the resulting positive-definite
-          fixed points to positive-definite fixed families on the sector
-          direct sums;
-    \item apply the proved density-block dimension bound and combine it with
-          the fixed contraction families,
-          the already proved product-generation theorem, and the
-          finite-dimensional implication above to obtain both identity
-          compositions;
+    \item apply the finite-product identity criterion to each square
+          composite, using the fixed contraction families and the proved
+          product-generation theorem, to obtain both identity compositions;
     \item derive the permutation and matching dimensions from the resulting
           positive, trace-preserving inverse pair, retaining the Schwarz
           hypothesis for the unitary-conjugation conclusion.
@@ -281,16 +285,16 @@ order:
 
 \section{Classification}
 
-\textbf{Verdict: trace subproblem closed; full-support density-dimension lemma
-proved; invertibility gap open.}  The two transported maps and their square
-composites are trace preserving under the source tensor hypotheses.  For a
-finite direct sum with a positive-definite fixed family, the density-block
-form now yields the required product-span dimension inequality.  The stronger
-active-image inclusions remain unproved and are not needed for this route.
-Until the adjoint Schwarz inequalities and the tensor-attached construction
-of the faithful fixed families are proved, neither transported-map
-invertibility nor sector relabelling should carry a completion marker in the
-blueprint.
+\textbf{Verdict: trace and abstract fixed-point subproblems closed;
+invertibility gap open.}  The two transported maps and their square composites
+are trace preserving under the source tensor hypotheses.  The
+positive-definite fixed-family construction on finite products, the
+density-block product-span bound, and the resulting abstract identity
+criterion are proved.  The stronger active-image inclusions remain unproved
+and are not needed for this route.  Until the adjoint Schwarz inequalities are
+derived for the tensor-attached square composites and the identity criterion
+is instantiated for them, neither transported-map invertibility nor sector
+relabelling should carry a completion marker in the blueprint.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -71,7 +71,8 @@ composition is treated symmetrically
 
 \section{The present formal boundary}
 
-Three ingredients preceding the fixed-point classification are proved:
+Three source-specific ingredients preceding the fixed-point classification are
+proved:
 \begin{enumerate}
     \item the two transported composites fix their respective weighted bond
           contraction families;
@@ -81,11 +82,14 @@ Three ingredients preceding the fixed-point classification are proved:
     \item on the source-generated contraction families, the final compression
           preserves the active image and hence preserves total trace.
 \end{enumerate}
-The third item does not establish trace preservation on the whole sector
+The third item alone does not establish trace preservation on the whole sector
 algebra.  The contraction family itself need not span the algebra linearly;
 only its length-$L$ products are known to span.  Since a linear map fixing
 $V(X)$ need not fix products $V(X_1)\cdots V(X_L)$, neither trace preservation
-nor the identity conclusion extends from the generators by linearity.
+nor the identity conclusion extends from the generators by linearity.  Whole-
+sector trace preservation is nevertheless proved by the independent
+maximal-support argument in the next section.  The identity conclusion still
+requires the fixed-point classification.
 
 Two finite-dimensional final implications are formalized.  First, if a linear
 endomorphism fixes every length-$L$ contraction product and these products
@@ -144,10 +148,12 @@ its fixed points compress injectively to the fixed points of the direct-sum
 map, while products of direct-sum fixed points embed injectively among the
 products of fixed points of the extension.  The density-block calculation on
 the extension therefore gives
-$\dim C_L(\mathcal F)\leq\dim\mathcal F$ on the original direct sum.  The
-trace-preservation part of the required channel hypotheses for the two square
-composites is resolved below.  Complete positivity and the adjoint Schwarz
-inequality still have to be obtained from the source tensor hypotheses.
+$\dim C_L(\mathcal F)\leq\dim\mathcal F$ on the original direct sum.  Positivity
+and trace preservation for the two square composites are resolved below.  The
+remaining hypothesis of the abstract identity criterion is the Schwarz
+inequality for the trace adjoint.  The route proposed in \ghissue{4418} is to
+prove complete positivity of the canonical lifts of the transported maps and
+then derive this Schwarz inequality.
 Alternatively, the maximal-support witness
 $T_\infty(\mathbf 1)$ is now available for an arbitrary positive
 trace-preserving map.  The construction of the supported endomorphism and its
@@ -198,8 +204,10 @@ a finite product therefore has a positive-definite fixed family under the
 same product-span hypothesis; if its trace adjoint satisfies the Schwarz
 inequality, the fixed contractions and the density-block bound force the
 endomorphism to be the identity.  The remaining application to the transported
-composites is to derive the required positivity and adjoint Schwarz properties
-from the source tensor hypotheses.
+composites is to derive the trace-adjoint Schwarz inequalities from the source
+tensor hypotheses---with complete positivity of the canonical lifts as the
+proposed route---and instantiate the criterion using the already established
+positivity and trace preservation.
 
 Let $F^*$ be the trace adjoint and define the trace-loss operator
 \[
@@ -271,8 +279,9 @@ one of the following source-faithful routes:
 The unrestricted CPSV16 conclusion should be completed in the following
 order:
 \begin{enumerate}
-    \item prove complete positivity and the adjoint Schwarz inequality for the
-          two transported square composites on the full sector algebras;
+    \item prove complete positivity of the canonical lifts of the transported
+          maps and use it to derive the adjoint Schwarz inequality for the two
+          square composites on the full sector algebras;
           trace preservation of the individual maps and composites is now
           established without an all-input active-image statement;
     \item apply the finite-product identity criterion to each square


### PR DESCRIPTION
## Summary

This change proves two abstract finite-dimensional consequences used in the Appendix C.4 invertibility argument.

First, a positive trace-preserving endomorphism of a finite product of matrix algebras has a componentwise positive-definite fixed family when it fixes a family of contractions whose products of some positive length span the identity. This is a local finite-product faithful fixed-family consequence of the maximal-support mean-ergodic argument.

Second, the change proves an abstract identity criterion: a positive trace-preserving endomorphism is the identity when its trace adjoint satisfies the Schwarz inequality, it fixes the distinguished weighted vertical contractions, and products of those contractions of some positive length generate the full direct-sum algebra. No product of fixed contractions is assumed to be fixed.

The corresponding Chapter 21 blueprint entries and the Appendix C.4 paper-gap note are updated, and the new module is included in the root import graph.

## Mathematical source and boundary

The argument isolates the fixed-point step used in Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix C.4, lines 1980–1995, together with the density-block description underlying Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.14.

The precise remaining gap is recorded in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`.

This change does not prove the tensor-attached transported composite identities. In particular, it does not derive the trace-adjoint Schwarz inequalities for those composites or instantiate the abstract criterion to prove that both square composites are identities. It therefore does not close #4418; it only supplies intermediate abstract results needed there. The tensor-derived Schwarz step and the final two identity applications remain separate.

Partially addresses #4418.

## Verification

- `lake build TNLean.MPS.MPDO.VerticalSectorInvertibility TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base f9d241698a42cefba65b65f69b29f04ea23107e4 --ci`
- proof-integrity, whitespace, stable-patch, and range-diff checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean additions and documentation on an already-isolated MPDO invertibility path; no auth, runtime, or broad API surface changes.
> 
> **Overview**
> Proves two **abstract finite-dimensional steps** used in CPSV16 Appendix C.4 (lines 1980–1995): a **componentwise positive-definite fixed family** when fixed contractions generate the identity by products, and an **identity criterion** when the map is positive trace-preserving and its trace adjoint satisfies Schwarz.
> 
> On the channel side, **`Matrix.IsPositiveDirectSumMap.exists_posDef_fixedFamily_of_fixed_product_span`** lifts the full-matrix maximal-support argument through the block-diagonal extension; **`directSumDiagonalEmbedding_one_mem_product_span`** is factored out and reused for trace-preservation and the new result. **`one_mem_product_span_of_weightedVerticalBondContractions`** moves to **`VerticalSectorGeneration`** for shared use.
> 
> New module **`VerticalSectorInvertibility`** wires **`MPOTensor.eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz`** (fixed contractions + product span → pos-def fixed family → density-block dimension bound → identity). Chapter 21 blueprint entries and **`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`** are updated; **`TNLean.lean`** imports the new module.
> 
> This does **not** prove invertibility of the tensor-attached transported composites—only derives trace-adjoint Schwarz (e.g. via CP lifts) and instantiates the criterion there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595067613776e9581f6010e5c58bb04443665b93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->