### PR TITLE
feat(MPS/MPDO): prove transported vertical-sector Schwarz

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -314,8 +314,7 @@ import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.TripartiteDecorrelation
 import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
--- The finite-chain uniqueness capstone is not part of this foundational layer.
--- Downstream files may import it when they need the periodic-chain definitions.
+-- Downstream users needing periodic-chain definitions may import the uniqueness capstone.
 
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension
@@ -478,6 +477,7 @@ import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
+import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.PRFP

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -316,6 +316,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 -- The finite-chain uniqueness capstone is not part of this foundational layer.
 -- Downstream files may import it when they need the periodic-chain definitions.
+
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension
 import TNLean.MPS.FundamentalTheorem.Basic
@@ -477,7 +478,6 @@ import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
 import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
-import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.PRFP

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -316,7 +316,6 @@ import TNLean.MPS.ParentHamiltonian.Martingale
 import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 -- The finite-chain uniqueness capstone is not part of this foundational layer.
 -- Downstream files may import it when they need the periodic-chain definitions.
-
 -- Layer 4: Fundamental theorem (single block)
 import TNLean.MPS.Structure.LinearExtension
 import TNLean.MPS.FundamentalTheorem.Basic
@@ -479,6 +478,7 @@ import TNLean.MPS.MPDO.VerticalSectorTraceLoss
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
 import TNLean.MPS.MPDO.VerticalSectorTracePreservation
+import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean
@@ -1,0 +1,324 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorTracePreservation
+
+/-!
+# Complete positivity of the transported vertical-sector maps
+
+The normalized vertical-sector embedding is a controlled state preparation,
+and the vertical-sector retraction is a controlled partial trace.  After
+identifying the retained physical coordinates with the corresponding direct
+sums, these maps can be composed with the completely positive physical
+refinement and coarse-graining maps.  Thus both transported vertical-sector
+maps are completely positive between finite sums of matrix algebras.
+
+The two square composites are trace preserving by the independent
+maximal-support argument in `VerticalSectorTracePreservation`.  Complete
+positivity therefore gives the Schwarz inequalities for their trace adjoints.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Definition 4.1 and Appendix C.4, lines 1955--1995.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- Transporting a completely positive refinement map through the retained
+vertical coordinates preserves complete positivity.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1979. -/
+theorem transportTToVerticalCoordinates_isKrausCP
+    {d R₁ R₂ : ℕ}
+    (U₁ : Matrix (Fin R₁) (Fin d) ℂ)
+    (U₂ : Matrix (Fin R₂) (Fin (d * d)) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hT : IsKrausCP T) :
+    IsKrausCP (transportTToVerticalCoordinates U₁ U₂ T) := by
+  unfold transportTToVerticalCoordinates
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · apply isKrausCP_comp
+      · exact singleKrausMap_isKrausCP U₁ᴴ
+      · exact hT
+    · exact (Matrix.equivReindexMap_isKrausCPTP
+        (blockedIndexEquiv d).symm).isKrausCP
+  · exact singleKrausMap_isKrausCP U₂
+
+/-- Transporting a completely positive coarse-graining map through the
+retained vertical coordinates preserves complete positivity.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1979. -/
+theorem transportSToVerticalCoordinates_isKrausCP
+    {d R₁ R₂ : ℕ}
+    (U₁ : Matrix (Fin R₁) (Fin d) ℂ)
+    (U₂ : Matrix (Fin R₂) (Fin (d * d)) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hS : IsKrausCP S) :
+    IsKrausCP (transportSToVerticalCoordinates U₁ U₂ S) := by
+  unfold transportSToVerticalCoordinates
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · exact isKrausCP_comp (singleKrausMap_isKrausCP U₂ᴴ)
+        (Matrix.equivReindexMap_isKrausCPTP
+          (blockedIndexEquiv d)).isKrausCP
+    · exact hS
+  · exact singleKrausMap_isKrausCP U₁
+
+/-- In retained coordinates, putting a vertical-sector family on the block
+diagonal is block-diagonal embedding followed by the canonical reindexing.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+theorem verticalSectorBlockDiagonal_eq_equivReindexMap_comp_embedding
+    {g : ℕ} (dim mult : Fin g → ℕ) :
+    verticalSectorBlockDiagonal dim mult =
+      (Matrix.equivReindexMap (verticalSectorFinEquiv dim mult)).comp
+        Matrix.directSumDiagonalEmbedding :=
+  rfl
+
+/-- In retained coordinates, extracting the vertical-sector blocks is the
+canonical inverse reindexing followed by diagonal-block compression.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+theorem verticalSectorBlocks_eq_compression_comp_equivReindexMap
+    {g : ℕ} (dim mult : Fin g → ℕ) :
+    verticalSectorBlocks dim mult =
+      Matrix.directSumDiagonalCompression.comp
+        (Matrix.equivReindexMap (verticalSectorFinEquiv dim mult).symm) :=
+  rfl
+
+/-- The canonical full-matrix extension of the transported refinement map is
+the composition of the normalized preparation, retained-coordinate changes,
+physical refinement map, and partial trace.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1979. -/
+theorem directSumMapExtension_transportedVerticalSectorT
+    {g₁ g₂ d : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
+    Matrix.directSumMapExtension
+        (transportedVerticalSectorT
+          dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T) =
+      (Matrix.directSumMapExtension
+        (verticalSectorPartialTrace dim₂ mult₂)).comp
+        ((Matrix.equivReindexMap
+          (verticalSectorFinEquiv dim₂ mult₂).symm).comp
+          ((transportTToVerticalCoordinates U₁ U₂ T).comp
+            ((Matrix.equivReindexMap
+              (verticalSectorFinEquiv dim₁ mult₁)).comp
+              (Matrix.directSumMapExtension
+                (normalizedVerticalSectorEmbedding
+                  dim₁ mult₁ weight₁))))) := by
+  apply LinearMap.ext
+  intro X
+  rfl
+
+/-- The canonical full-matrix extension of the transported coarse-graining
+map is the composition of the normalized preparation, retained-coordinate
+changes, physical coarse-graining map, and partial trace.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1979. -/
+theorem directSumMapExtension_transportedVerticalSectorS
+    {g₁ g₂ d : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ) :
+    Matrix.directSumMapExtension
+        (transportedVerticalSectorS
+          dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S) =
+      (Matrix.directSumMapExtension
+        (verticalSectorPartialTrace dim₁ mult₁)).comp
+        ((Matrix.equivReindexMap
+          (verticalSectorFinEquiv dim₁ mult₁).symm).comp
+          ((transportSToVerticalCoordinates U₁ U₂ S).comp
+            ((Matrix.equivReindexMap
+              (verticalSectorFinEquiv dim₂ mult₂)).comp
+              (Matrix.directSumMapExtension
+                (normalizedVerticalSectorEmbedding
+                  dim₂ mult₂ weight₂))))) := by
+  apply LinearMap.ext
+  intro X
+  rfl
+
+/-- The transported refinement map is completely positive between the finite
+sums of vertical simple-sector matrix algebras.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1979. -/
+theorem transportedVerticalSectorT_isKrausDirectSumMap
+    {g₁ g₂ d : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hT : IsKrausCP T) :
+    Matrix.IsKrausDirectSumMap
+      (transportedVerticalSectorT
+        dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T) := by
+  rw [Matrix.IsKrausDirectSumMap,
+    directSumMapExtension_transportedVerticalSectorT]
+  have hPrep := normalizedVerticalSectorEmbedding_isKrausDirectSumMap
+    dim₁ mult₁ weight₁ hMult₁ hWeight₁
+  have hReindex₁ := (Matrix.equivReindexMap_isKrausCPTP
+    (verticalSectorFinEquiv dim₁ mult₁)).isKrausCP
+  have hTransport := transportTToVerticalCoordinates_isKrausCP U₁ U₂ T hT
+  have hReindex₂ := (Matrix.equivReindexMap_isKrausCPTP
+    (verticalSectorFinEquiv dim₂ mult₂).symm).isKrausCP
+  have hTrace := verticalSectorPartialTrace_isKrausDirectSumMap dim₂ mult₂
+  exact isKrausCP_comp
+    (isKrausCP_comp
+      (isKrausCP_comp (isKrausCP_comp hPrep hReindex₁) hTransport)
+      hReindex₂)
+    hTrace
+
+/-- The transported coarse-graining map is completely positive between the
+finite sums of vertical simple-sector matrix algebras.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1979. -/
+theorem transportedVerticalSectorS_isKrausDirectSumMap
+    {g₁ g₂ d : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hS : IsKrausCP S) :
+    Matrix.IsKrausDirectSumMap
+      (transportedVerticalSectorS
+        dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S) := by
+  rw [Matrix.IsKrausDirectSumMap,
+    directSumMapExtension_transportedVerticalSectorS]
+  have hPrep := normalizedVerticalSectorEmbedding_isKrausDirectSumMap
+    dim₂ mult₂ weight₂ hMult₂ hWeight₂
+  have hReindex₂ := (Matrix.equivReindexMap_isKrausCPTP
+    (verticalSectorFinEquiv dim₂ mult₂)).isKrausCP
+  have hTransport := transportSToVerticalCoordinates_isKrausCP U₁ U₂ S hS
+  have hReindex₁ := (Matrix.equivReindexMap_isKrausCPTP
+    (verticalSectorFinEquiv dim₁ mult₁).symm).isKrausCP
+  have hTrace := verticalSectorPartialTrace_isKrausDirectSumMap dim₁ mult₁
+  exact isKrausCP_comp
+    (isKrausCP_comp
+      (isKrausCP_comp (isKrausCP_comp hPrep hReindex₂) hTransport)
+      hReindex₁)
+    hTrace
+
+/-- The trace adjoints of the two transported square composites satisfy the
+Schwarz inequality under the tensor hypotheses of Appendix C.4.
+
+Complete positivity follows from the Kraus forms of the normalized sector
+preparations, physical maps, coordinate changes, and partial traces.  The
+independent maximal-support argument gives trace preservation of the square
+composites, so their trace adjoints are unital completely positive maps.
+
+Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1995. -/
+theorem transportedVerticalSector_composites_traceAdjointSchwarz
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hTCPTP : IsKrausCPTP T)
+    (hSCPTP : IsKrausCPTP S)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
+    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
+    Matrix.IsSchwarzDirectSumMap
+        (Matrix.directSumTraceAdjointMap
+          ((transportedVerticalSectorS
+            dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
+            (transportedVerticalSectorT
+              dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T))) ∧
+      Matrix.IsSchwarzDirectSumMap
+        (Matrix.directSumTraceAdjointMap
+          ((transportedVerticalSectorT
+            dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
+            (transportedVerticalSectorS
+              dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S))) := by
+  obtain ⟨hSTTrace, hTSTrace, _, _⟩ :=
+    transportedVerticalSector_composites_tracePreserving
+      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
+      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
+      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+  have hT := transportedVerticalSectorT_isKrausDirectSumMap
+    dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁
+    U₁ U₂ T hTCPTP.isKrausCP
+  have hS := transportedVerticalSectorS_isKrausDirectSumMap
+    dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂
+    U₁ U₂ S hSCPTP.isKrausCP
+  exact ⟨(hT.comp hS).directSumTraceAdjointMap_isSchwarz hSTTrace,
+    (hS.comp hT).directSumTraceAdjointMap_isSchwarz hTSTrace⟩
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean
@@ -16,8 +16,8 @@ refinement and coarse-graining maps.  Thus both transported vertical-sector
 maps are completely positive between finite sums of matrix algebras.
 
 The two square composites are trace preserving by the independent
-maximal-support argument in `VerticalSectorTracePreservation`.  Complete
-positivity therefore gives the Schwarz inequalities for their trace adjoints.
+maximal-support argument established earlier.  Complete positivity therefore
+gives the Schwarz inequalities for their trace adjoints.
 
 ## References
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1923,19 +1923,139 @@ physical indices, as in
     $\widetilde S$.
 \end{proof}
 
+\begin{lemma}[Complete positivity of refinement in vertical coordinates]
+    \label{lem:mpdo_transport_t_vertical_coordinates_cp}
+    \lean{MPOTensor.transportTToVerticalCoordinates_isKrausCP}
+    \leanok
+    \uses{def:mpdo_vertical_coordinate_map_transport}
+    If the physical refinement map $T$ is completely positive, then the
+    transported map $T_{\mathrm v}$ in vertical canonical coordinates is
+    completely positive.
+\end{lemma}
+
+\begin{proof}\leanok
+    By Definition~\ref{def:mpdo_vertical_coordinate_map_transport},
+    \[
+      T_{\mathrm v}(Z)
+        =U_2J\!\left(T(U_1^\dagger ZU_1)\right)U_2^\dagger.
+    \]
+    The two single-operator conjugations and the reindexing $J$ are completely
+    positive, so the assertion follows by composition.
+\end{proof}
+
+\begin{lemma}[Complete positivity of coarse-graining in vertical coordinates]
+    \label{lem:mpdo_transport_s_vertical_coordinates_cp}
+    \lean{MPOTensor.transportSToVerticalCoordinates_isKrausCP}
+    \leanok
+    \uses{def:mpdo_vertical_coordinate_map_transport}
+    If the physical coarse-graining map $S$ is completely positive, then the
+    transported map $S_{\mathrm v}$ in vertical canonical coordinates is
+    completely positive.
+\end{lemma}
+
+\begin{proof}\leanok
+    By Definition~\ref{def:mpdo_vertical_coordinate_map_transport},
+    \[
+      S_{\mathrm v}(W)
+        =U_1S\!\left(J^{-1}(U_2^\dagger WU_2)\right)U_1^\dagger.
+    \]
+    Again, single-operator conjugation, reindexing, and composition preserve
+    complete positivity.
+\end{proof}
+
+\begin{lemma}[Retained-coordinate block-diagonal inclusion]
+    \label{lem:mpdo_vertical_sector_block_diagonal_reindex}
+    \lean{MPOTensor.verticalSectorBlockDiagonal_eq_equivReindexMap_comp_embedding}
+    \leanok
+    \uses{def:mpdo_retained_vertical_sector_coordinates}
+    Let $\iota$ be block-diagonal inclusion of the simple-sector algebra and
+    let $W$ be the canonical reindexing to retained physical coordinates.
+    Then the retained-coordinate inclusion is
+    \[
+      \iota_{\mathrm v}=W\circ\iota.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    This is the defining relation between the direct-sum and retained
+    coordinates.
+\end{proof}
+
+\begin{lemma}[Retained-coordinate diagonal-block extraction]
+    \label{lem:mpdo_vertical_sector_blocks_reindex}
+    \lean{MPOTensor.verticalSectorBlocks_eq_compression_comp_equivReindexMap}
+    \leanok
+    \uses{def:mpdo_retained_vertical_sector_coordinates}
+    Let $\pi$ be diagonal-block extraction from the direct sum and let $W$ be
+    the canonical reindexing to retained physical coordinates.  Then the
+    retained-coordinate extraction is
+    \[
+      \pi_{\mathrm v}=\pi\circ W^{-1}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    This is the inverse defining relation between the retained and direct-sum
+    coordinates.
+\end{proof}
+
+\begin{lemma}[Full-matrix factorization of transported refinement]
+    \label{lem:mpdo_transported_vertical_sector_t_extension}
+    \lean{MPOTensor.directSumMapExtension_transportedVerticalSectorT}
+    \leanok
+    \uses{def:mpdo_transported_vertical_sector_maps,
+      lem:mpdo_vertical_sector_block_diagonal_reindex,
+      lem:mpdo_vertical_sector_blocks_reindex}
+    Write $\widehat R_1$ for normalized state preparation,
+    $\widehat{\widetilde R}_2$ for controlled partial trace, and $W_i$ for
+    retained-coordinate reindexing.  The full-matrix extension of the
+    transported refinement map is
+    \[
+      \widehat{\widetilde T}
+        =\widehat{\widetilde R}_2\circ W_2^{-1}\circ
+          T_{\mathrm v}\circ W_1\circ\widehat R_1.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute the preceding inclusion and extraction identities into
+    $\widetilde T=\widetilde R_2T_{\mathrm v}R_1$.
+\end{proof}
+
+\begin{lemma}[Full-matrix factorization of transported coarse-graining]
+    \label{lem:mpdo_transported_vertical_sector_s_extension}
+    \lean{MPOTensor.directSumMapExtension_transportedVerticalSectorS}
+    \leanok
+    \uses{def:mpdo_transported_vertical_sector_maps,
+      lem:mpdo_vertical_sector_block_diagonal_reindex,
+      lem:mpdo_vertical_sector_blocks_reindex}
+    Write $\widehat R_2$ for normalized state preparation,
+    $\widehat{\widetilde R}_1$ for controlled partial trace, and $W_i$ for
+    retained-coordinate reindexing.  The full-matrix extension of the
+    transported coarse-graining map is
+    \[
+      \widehat{\widetilde S}
+        =\widehat{\widetilde R}_1\circ W_1^{-1}\circ
+          S_{\mathrm v}\circ W_2\circ\widehat R_2.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute the preceding inclusion and extraction identities into
+    $\widetilde S=\widetilde R_1S_{\mathrm v}R_2$.
+\end{proof}
+
 \begin{theorem}[Complete positivity and adjoint Schwarz for the transported maps]
     \label{thm:mpdo_transported_vertical_sector_composites_schwarz}
-    \lean{MPOTensor.transportTToVerticalCoordinates_isKrausCP,
-      MPOTensor.transportSToVerticalCoordinates_isKrausCP,
-      MPOTensor.verticalSectorBlockDiagonal_eq_equivReindexMap_comp_embedding,
-      MPOTensor.verticalSectorBlocks_eq_compression_comp_equivReindexMap,
-      MPOTensor.directSumMapExtension_transportedVerticalSectorT,
-      MPOTensor.directSumMapExtension_transportedVerticalSectorS,
-      MPOTensor.transportedVerticalSectorT_isKrausDirectSumMap,
+    \lean{MPOTensor.transportedVerticalSectorT_isKrausDirectSumMap,
       MPOTensor.transportedVerticalSectorS_isKrausDirectSumMap,
       MPOTensor.transportedVerticalSector_composites_traceAdjointSchwarz}
     \leanok
     \uses{def:mpdo_transported_vertical_sector_maps,
+      lem:mpdo_transport_t_vertical_coordinates_cp,
+      lem:mpdo_transport_s_vertical_coordinates_cp,
+      lem:mpdo_transported_vertical_sector_t_extension,
+      lem:mpdo_transported_vertical_sector_s_extension,
       thm:mpdo_vertical_sector_partial_trace_kraus,
       lem:direct_sum_kraus_composition_schwarz,
       thm:mpdo_transported_vertical_sector_composites_trace_preserving}
@@ -1964,15 +2084,20 @@ physical indices, as in
     \]
     Here $\widehat R_1$ is normalized state preparation,
     $\widehat{\widetilde R}_2$ is controlled partial trace, and
-    $T_{\mathrm v}$ is the physical refinement map composed with
-    single-operator conjugations and a physical-index reindexing.  Every
-    factor is completely positive.  The analogous identity
     \[
+      T_{\mathrm v}(Z)
+        =U_2J\!\left(T(U_1^\dagger ZU_1)\right)U_2^\dagger.
+    \]
+    Every factor is completely positive.  The analogous identities
+    \[
+      S_{\mathrm v}(W)
+        =U_1S\!\left(J^{-1}(U_2^\dagger WU_2)\right)U_1^\dagger,
+      \qquad
       \widehat{\widetilde S}
         =\widehat{\widetilde R}_1\circ W_1^{-1}\circ
           S_{\mathrm v}\circ W_2\circ\widehat R_2
     \]
-    proves complete positivity of $\widetilde S$.  These factorizations are
+    prove complete positivity of $\widetilde S$.  These factorizations are
     exact on the full matrix algebras: $\pi_iW_i^{-1}$ is precisely extraction
     of the retained diagonal sector blocks.  Thus no range inclusion is used.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1947,9 +1947,8 @@ physical indices, as in
       \qquad
       \widetilde S:\mathcal A_2\longrightarrow\mathcal A_1
     \]
-    are completely positive.  Consequently, both square composites are
-    completely positive, and their trace adjoints satisfy the Schwarz
-    inequality in every simple summand.
+    are completely positive.  The trace adjoints of the two square composites
+    satisfy the Schwarz inequality in every simple summand.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1923,6 +1923,67 @@ physical indices, as in
     $\widetilde S$.
 \end{proof}
 
+\begin{theorem}[Complete positivity and adjoint Schwarz for the transported maps]
+    \label{thm:mpdo_transported_vertical_sector_composites_schwarz}
+    \lean{MPOTensor.transportTToVerticalCoordinates_isKrausCP,
+      MPOTensor.transportSToVerticalCoordinates_isKrausCP,
+      MPOTensor.verticalSectorBlockDiagonal_eq_equivReindexMap_comp_embedding,
+      MPOTensor.verticalSectorBlocks_eq_compression_comp_equivReindexMap,
+      MPOTensor.directSumMapExtension_transportedVerticalSectorT,
+      MPOTensor.directSumMapExtension_transportedVerticalSectorS,
+      MPOTensor.transportedVerticalSectorT_isKrausDirectSumMap,
+      MPOTensor.transportedVerticalSectorS_isKrausDirectSumMap,
+      MPOTensor.transportedVerticalSector_composites_traceAdjointSchwarz}
+    \leanok
+    \uses{def:mpdo_transported_vertical_sector_maps,
+      thm:mpdo_vertical_sector_partial_trace_kraus,
+      lem:direct_sum_kraus_composition_schwarz,
+      thm:mpdo_transported_vertical_sector_composites_trace_preserving}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_transported_vertical_sector_composites_trace_preserving},
+    the maps
+    \[
+      \widetilde T:\mathcal A_1\longrightarrow\mathcal A_2,
+      \qquad
+      \widetilde S:\mathcal A_2\longrightarrow\mathcal A_1
+    \]
+    are completely positive.  Consequently, both square composites are
+    completely positive, and their trace adjoints satisfy the Schwarz
+    inequality in every simple summand.
+\end{theorem}
+
+\begin{proof}\leanok
+    Let $\iota_i$ and $\pi_i$ be block-diagonal inclusion and diagonal-block
+    extraction, respectively, and let $W_i$ denote the canonical reindexing
+    from the weighted vertical-sector coordinates to the retained physical
+    coordinates.  The full-matrix extension of the transported refinement
+    map has the factorization
+    \[
+      \widehat{\widetilde T}
+        =\widehat{\widetilde R}_2\circ W_2^{-1}\circ
+          T_{\mathrm v}\circ W_1\circ\widehat R_1.
+    \]
+    Here $\widehat R_1$ is normalized state preparation,
+    $\widehat{\widetilde R}_2$ is controlled partial trace, and
+    $T_{\mathrm v}$ is the physical refinement map composed with
+    single-operator conjugations and a physical-index reindexing.  Every
+    factor is completely positive.  The analogous identity
+    \[
+      \widehat{\widetilde S}
+        =\widehat{\widetilde R}_1\circ W_1^{-1}\circ
+          S_{\mathrm v}\circ W_2\circ\widehat R_2
+    \]
+    proves complete positivity of $\widetilde S$.  These factorizations are
+    exact on the full matrix algebras: $\pi_iW_i^{-1}$ is precisely extraction
+    of the retained diagonal sector blocks.  Thus no range inclusion is used.
+
+    Composition gives complete positivity of
+    $\widetilde S\widetilde T$ and $\widetilde T\widetilde S$.
+    The preceding theorem gives trace preservation of these two composites.
+    Their trace adjoints are therefore unital completely positive maps, and
+    the Kadison--Schwarz inequality applies in each simple summand.
+\end{proof}
+
 \begin{theorem}[Two-site closure of the two-site blocking]
     \label{thm:mpdo_two_site_closure_two_site_blocking}
     \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -1968,9 +1968,10 @@ physical indices, as in
     \lean{MPOTensor.verticalSectorBlockDiagonal_eq_equivReindexMap_comp_embedding}
     \leanok
     \uses{def:mpdo_retained_vertical_sector_coordinates}
-    Let $\iota$ be block-diagonal inclusion of the simple-sector algebra and
-    let $W$ be the canonical reindexing to retained physical coordinates.
-    Then the retained-coordinate inclusion is
+    Let $\iota$ be block-diagonal inclusion of the weighted vertical-sector
+    block family into its full matrix algebra, and let $W$ be the canonical
+    reindexing to retained physical coordinates.  Then the retained-coordinate
+    inclusion is
     \[
       \iota_{\mathrm v}=W\circ\iota.
     \]
@@ -1986,9 +1987,9 @@ physical indices, as in
     \lean{MPOTensor.verticalSectorBlocks_eq_compression_comp_equivReindexMap}
     \leanok
     \uses{def:mpdo_retained_vertical_sector_coordinates}
-    Let $\pi$ be diagonal-block extraction from the direct sum and let $W$ be
-    the canonical reindexing to retained physical coordinates.  Then the
-    retained-coordinate extraction is
+    Let $\pi$ be diagonal-block extraction to the weighted vertical-sector
+    block family, and let $W$ be the canonical reindexing to retained physical
+    coordinates.  Then the retained-coordinate extraction is
     \[
       \pi_{\mathrm v}=\pi\circ W^{-1}.
     \]

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -150,10 +150,19 @@ products of fixed points of the extension.  The density-block calculation on
 the extension therefore gives
 $\dim C_L(\mathcal F)\leq\dim\mathcal F$ on the original direct sum.  Positivity
 and trace preservation for the two square composites are resolved below.  The
-remaining hypothesis of the abstract identity criterion is the Schwarz
-inequality for the trace adjoint.  The route proposed in \ghissue{4418} is to
-prove complete positivity of the canonical lifts of the transported maps and
-then derive this Schwarz inequality.
+Schwarz hypothesis of the abstract identity criterion is also resolved.  The
+canonical full-matrix lifts of the two transported maps factor into normalized
+state preparation, retained-coordinate reindexings, the physical completely
+positive maps, single-operator conjugations, and controlled partial trace.
+Consequently the two transported maps and their square composites are
+completely positive.  Since the square composites preserve trace, their trace
+adjoints are unital completely positive maps and satisfy the Schwarz
+inequality in every simple summand.\footnote{Formal declarations:
+\leanid{MPOTensor.transportedVerticalSectorT_isKrausDirectSumMap},
+\leanid{MPOTensor.transportedVerticalSectorS_isKrausDirectSumMap}, and
+\leanid{MPOTensor.%
+transportedVerticalSector_composites_traceAdjointSchwarz}
+in \doclink{TNLean/MPS/MPDO/VerticalSectorCompletePositivity}.}
 Alternatively, the maximal-support witness
 $T_\infty(\mathbf 1)$ is now available for an arbitrary positive
 trace-preserving map.  The construction of the supported endomorphism and its
@@ -204,11 +213,11 @@ A positive trace-preserving endomorphism of
 a finite product therefore has a positive-definite fixed family under the
 same product-span hypothesis; if its trace adjoint satisfies the Schwarz
 inequality, the fixed contractions and the density-block bound force the
-endomorphism to be the identity.  The remaining application to the transported
-composites is to derive the trace-adjoint Schwarz inequalities from the source
-tensor hypotheses---with complete positivity of the canonical lifts as the
-proposed route---and instantiate the criterion using the already established
-positivity and trace preservation.
+endomorphism to be the identity.  For the transported composites, complete
+positivity of the canonical lifts and the established trace preservation now
+give the required trace-adjoint Schwarz inequalities from the source tensor
+hypotheses.  The remaining application is to instantiate the criterion twice,
+using the fixed contraction families and their positive-length product spans.
 
 Let $F^*$ be the trace adjoint and define the trace-loss operator
 \[
@@ -280,11 +289,10 @@ one of the following source-faithful routes:
 The unrestricted CPSV16 conclusion should be completed in the following
 order:
 \begin{enumerate}
-    \item prove complete positivity of the canonical lifts of the transported
-          maps and use it to derive the adjoint Schwarz inequality for the two
-          square composites on the full sector algebras;
-          trace preservation of the individual maps and composites is now
-          established without an all-input active-image statement;
+    \item complete positivity of the canonical lifts of the transported maps,
+          and hence the adjoint Schwarz inequality for the two trace-preserving
+          square composites, is established without an all-input active-image
+          statement;
     \item apply the finite-product identity criterion to each square
           composite, using the fixed contraction families and the proved
           product-generation theorem, to obtain both identity compositions;
@@ -295,16 +303,18 @@ order:
 
 \section{Classification}
 
-\textbf{Verdict: trace and abstract fixed-point subproblems closed;
-invertibility gap open.}  The two transported maps and their square composites
-are trace preserving under the source tensor hypotheses.  The
+\textbf{Verdict: trace, complete-positivity, and abstract fixed-point
+subproblems closed; invertibility gap open.}  The two transported maps and
+their square composites are trace preserving under the source tensor
+hypotheses, and the trace adjoints of the square composites satisfy the
+Schwarz inequality.  The
 positive-definite fixed-family construction on finite products, the
 density-block product-span bound, and the resulting abstract identity
 criterion are proved.  The stronger active-image inclusions remain unproved
-and are not needed for this route.  Until the adjoint Schwarz inequalities are
-derived for the tensor-attached square composites and the identity criterion
-is instantiated for them, neither transported-map invertibility nor sector
-relabelling should carry a completion marker in the blueprint.
+and are not needed for this route.  Until the identity criterion is
+instantiated for the two tensor-attached square composites, neither
+transported-map invertibility nor sector relabelling should carry a completion
+marker in the blueprint.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation
- CPSV16 defines the transported maps between the one-site and two-site vertical-sector algebras and uses their square composites in the Appendix C.4 fixed-point argument.
- Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1957--1995, especially lines 1974--1976: “Let us call T tilde and S tilde, where T,S are the tpCPM in the definition of RFP.”
- This completes the complete-positivity and trace-adjoint Schwarz child #4438 of the identity theorem #4418.

### Description
- Add `VerticalSectorCompletePositivity.lean`, proving Kraus complete positivity of the physical coordinate transports and exact full-matrix factorizations of both transported sector maps.
- Deduce complete positivity of the transported maps from normalized state preparation, retained-coordinate reindexing, the physical Kraus maps, and controlled partial trace.
- Combine closure under composition with the independently proved trace preservation to obtain the direct-sum Kadison--Schwarz inequalities for both trace adjoints, under exactly the hypotheses of `transportedVerticalSector_composites_tracePreserving`.
- Add the corresponding mathematical blueprint theorem and update the vertical-sector paper-gap note.
- This PR does not prove either square composite to be the identity, does not prove transported-map invertibility or sector relabelling, and does not assume active-image containment, multiplicativity, fixedness of products, or any transported complete-positivity or Schwarz hypothesis.

### Testing
- `lake env lean TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean`
- `lake build TNLean.MPS.MPDO.VerticalSectorCompletePositivity -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `lake exe lint_style TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean TNLean.lean`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- proof-integrity and whitespace checks on the changed files

Closes #4438
Partially addresses #4418
Partially addresses #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes extend a long formal proof chain on the CPSV16 vertical-sector route; errors would block downstream invertibility work but do not touch runtime or security-sensitive code.
> 
> **Overview**
> Adds **`VerticalSectorCompletePositivity.lean`** and registers it in **`TNLean.lean`**, closing the CPSV16 Appendix C.4 step that was still open after trace preservation: the transported refinement/coarse-graining maps and their square composites are **Kraus completely positive**, and the **trace adjoints of both composites satisfy the direct-sum Kadison–Schwarz inequality** under the same hypotheses as `transportedVerticalSector_composites_tracePreserving`.
> 
> The Lean proofs show coordinate transports preserve CP, give exact **full-matrix factorizations** of the transported sector maps (normalized preparation, reindexing, physical CPTP maps, partial trace), then combine **composition closure** with the existing trace-preservation theorem to derive Schwarz for the adjoints. The blueprint chapter gains matching lemmas/theorem (`thm:mpdo_transported_vertical_sector_composites_schwarz`), and the vertical-sector invertibility gap note is updated to treat **complete positivity and adjoint Schwarz as resolved** while **square-composite identity / invertibility** remain future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa24c1e94be83e22e81f7701c842bf89bedb0a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->