### PR TITLE
feat(MPS/MPDO): prove transported vertical-sector identities

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -480,6 +480,7 @@ import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
 import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
+import TNLean.MPS.MPDO.VerticalSectorIdentity
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
@@ -934,8 +935,7 @@ import TNLean.PEPS.NormalSquareInteriorAbsorbedFamily
 import TNLean.PEPS.NormalSquareComparisonRegion
 -- The unconditional interior-window Fundamental Theorem on the open square lattice.
 import TNLean.PEPS.NormalSquareFundamentalTheorem2
--- Shared blocking data for two normal PEPS tensors: the conjunction
--- region-injectivity predicate and its one-edge projections.
+-- Shared two-tensor normal PEPS blocking data and its one-edge projections.
 import TNLean.PEPS.NormalPairBlocking
 -- The absorbed gauge family of a general normal PEPS blocking: the bare-edge
 -- absorbed equality at every edge of an arbitrary finite simple graph.

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -246,7 +246,6 @@ import TNLean.Channel.Peripheral.PeriodicityRemoval
 import TNLean.Channel.Peripheral.GroupStructure
 import TNLean.Channel.Peripheral.CyclicGroup
 import TNLean.Channel.Semigroup.RelaxationConditions
-
 -- Layer 2c: Spectral theory (QPF + transfer-operator gaps)
 import TNLean.QPF.PosDef
 import TNLean.QPF.Uniqueness
@@ -935,7 +934,8 @@ import TNLean.PEPS.NormalSquareInteriorAbsorbedFamily
 import TNLean.PEPS.NormalSquareComparisonRegion
 -- The unconditional interior-window Fundamental Theorem on the open square lattice.
 import TNLean.PEPS.NormalSquareFundamentalTheorem2
--- Shared two-tensor normal PEPS blocking data and its one-edge projections.
+-- Shared blocking data for two normal PEPS tensors: the conjunction
+-- region-injectivity predicate and its one-edge projections.
 import TNLean.PEPS.NormalPairBlocking
 -- The absorbed gauge family of a general normal PEPS blocking: the bare-edge
 -- absorbed equality at every edge of an arbitrary finite simple graph.

--- a/TNLean/MPS/MPDO/VerticalSectorIdentity.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorIdentity.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
+import TNLean.MPS.MPDO.VerticalSectorInvertibility
+
+/-!
+# Identity compositions of the transported vertical-sector maps
+
+The transported coarse-graining and refinement maps are mutually inverse on
+their vertical-sector algebras.  Each square composite is positive and trace
+preserving, and its trace adjoint satisfies the Schwarz inequality.  The
+composite fixes the corresponding weighted vertical bond contractions, whose
+positive-length products span the sector algebra.  The fixed-point
+density-block criterion therefore makes each composite the identity.
+
+No product of fixed contractions is assumed to be fixed.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1974--1995.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The transported coarse-graining--refinement and
+refinement--coarse-graining composites are the identities on their respective
+vertical-sector algebras.
+
+The hypotheses are precisely those of the tensor-derived trace-preservation
+and trace-adjoint Schwarz theorems.  The proof uses only positivity, trace
+preservation, the two Schwarz inequalities, fixedness of the distinguished
+contraction families, and their positive-length product spans.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1995. -/
+theorem transportedVerticalSector_composites_eq_id
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hTCPTP : IsKrausCPTP T)
+    (hSCPTP : IsKrausCPTP S)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
+    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
+    (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
+        (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T) =
+      LinearMap.id ∧
+    (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
+        (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S) =
+      LinearMap.id := by
+  classical
+  let Tbar := transportedVerticalSectorT
+    dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
+  let Sbar := transportedVerticalSectorS
+    dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
+  let F₁ := Sbar.comp Tbar
+  let F₂ := Tbar.comp Sbar
+  have hTbarpos (X : VerticalSectorAlgebra dim₁)
+      (hX : IsVerticalSectorPosSemidef X) :
+      IsVerticalSectorPosSemidef (Tbar X) := by
+    exact transportedVerticalSectorT_posSemidef
+      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁ U₁ U₂ T hTCPTP X hX
+  have hSbarpos (X : VerticalSectorAlgebra dim₂)
+      (hX : IsVerticalSectorPosSemidef X) :
+      IsVerticalSectorPosSemidef (Sbar X) := by
+    exact transportedVerticalSectorS_posSemidef
+      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ U₁ U₂ S hSCPTP X hX
+  have hF₁pos : Matrix.IsPositiveDirectSumMap F₁ := by
+    intro X hX
+    exact hSbarpos (Tbar X) (hTbarpos X hX)
+  have hF₂pos : Matrix.IsPositiveDirectSumMap F₂ := by
+    intro X hX
+    exact hTbarpos (Sbar X) (hSbarpos X hX)
+  obtain ⟨hF₁TP, hF₂TP, _, _⟩ :=
+    transportedVerticalSector_composites_tracePreserving
+      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
+      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
+      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+  obtain ⟨hF₁Schwarz, hF₂Schwarz⟩ :=
+    transportedVerticalSector_composites_traceAdjointSchwarz
+      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
+      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
+      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+  obtain ⟨L₁, hL₁, hSpan₁⟩ :=
+    exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
+      hBNT₁ weight₁ hMult₁ hWeight₁
+  obtain ⟨L₂, hL₂, hSpan₂⟩ :=
+    exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
+      hBNT₂ weight₂ hMult₂ hWeight₂
+  have hFixed₁ (X : Matrix (Fin D) (Fin D) ℂ) :
+      F₁ (weightedVerticalBondContraction
+        (verticalMultiplicityTrace weight₁) A₁ X) =
+        weightedVerticalBondContraction
+          (verticalMultiplicityTrace weight₁) A₁ X := by
+    change F₁ (fun α ↦ verticalMultiplicityTrace weight₁ α •
+      MPSTensor.contractBondMatrix (A₁ α) X) =
+        fun α ↦ verticalMultiplicityTrace weight₁ α •
+          MPSTensor.contractBondMatrix (A₁ α) X
+    simpa only [F₁, Tbar, Sbar] using
+      transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
+        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
+        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
+        (hTphys X) (hSphys X)
+  have hFixed₂ (X : Matrix (Fin D) (Fin D) ℂ) :
+      F₂ (weightedVerticalBondContraction
+        (verticalMultiplicityTrace weight₂) A₂ X) =
+        weightedVerticalBondContraction
+          (verticalMultiplicityTrace weight₂) A₂ X := by
+    change F₂ (fun β ↦ verticalMultiplicityTrace weight₂ β •
+      MPSTensor.contractBondMatrix (A₂ β) X) =
+        fun β ↦ verticalMultiplicityTrace weight₂ β •
+          MPSTensor.contractBondMatrix (A₂ β) X
+    simpa only [F₂, Tbar, Sbar] using
+      transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
+        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
+        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
+        (hTphys X) (hSphys X)
+  constructor
+  · change F₁ = LinearMap.id
+    exact eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
+      (verticalMultiplicityTrace weight₁) A₁ F₁ hL₁ hF₁pos hF₁TP hF₁Schwarz
+      hSpan₁ hFixed₁
+  · change F₂ = LinearMap.id
+    exact eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
+      (verticalMultiplicityTrace weight₂) A₂ F₂ hL₂ hF₂pos hF₂TP hF₂Schwarz
+      hSpan₂ hFixed₂
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -2109,6 +2109,52 @@ physical indices, as in
     the Kadison--Schwarz inequality applies in each simple summand.
 \end{proof}
 
+\begin{theorem}[Transported vertical-sector composites are identities]
+    \label{thm:mpdo_transported_vertical_sector_composites_identity}
+    \lean{MPOTensor.transportedVerticalSector_composites_eq_id}
+    \leanok
+    \uses{thm:mpdo_transported_vertical_sector_composites_trace_preserving,
+      thm:mpdo_transported_vertical_sector_composites_schwarz,
+      lem:mpdo_transported_vertical_sector_fixed_generators,
+      thm:mpdo_vertical_bond_contractions_generate_sector_algebra,
+      thm:mpdo_fixed_contractions_trace_adjoint_schwarz_identity}
+    Under precisely the hypotheses of
+    Theorem~\ref{thm:mpdo_transported_vertical_sector_composites_trace_preserving},
+    the transported maps satisfy
+    \[
+      \widetilde S\circ\widetilde T
+        =\operatorname{id}_{\mathcal A_1},
+      \qquad
+      \widetilde T\circ\widetilde S
+        =\operatorname{id}_{\mathcal A_2}.
+    \]
+    Thus $\widetilde T$ and $\widetilde S$ are mutually inverse.  This is the
+    identity-composition conclusion of
+    \cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    For each square composite $F$, positivity follows from positivity of the
+    two transported maps.  Theorems~
+    \ref{thm:mpdo_transported_vertical_sector_composites_trace_preserving}
+    and~\ref{thm:mpdo_transported_vertical_sector_composites_schwarz} give
+    trace preservation and the Schwarz inequality for $F^*$, respectively.
+    Lemma~\ref{lem:mpdo_transported_vertical_sector_fixed_generators} gives
+    \[
+      F(V_i(X))=V_i(X)
+    \]
+    for every bond matrix $X$.  Theorem~
+    \ref{thm:mpdo_vertical_bond_contractions_generate_sector_algebra} gives a
+    positive integer $L_i$ such that
+    \[
+      C_{L_i}(V_i)=\mathcal A_i.
+    \]
+    Applying Theorem~
+    \ref{thm:mpdo_fixed_contractions_trace_adjoint_schwarz_identity} first to
+    $F=\widetilde S\circ\widetilde T$ and then to
+    $F=\widetilde T\circ\widetilde S$ proves the two identities.
+\end{proof}
+
 \begin{theorem}[Two-site closure of the two-site blocking]
     \label{thm:mpdo_two_site_closure_two_site_blocking}
     \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -216,8 +216,18 @@ inequality, the fixed contractions and the density-block bound force the
 endomorphism to be the identity.  For the transported composites, complete
 positivity of the canonical lifts and the established trace preservation now
 give the required trace-adjoint Schwarz inequalities from the source tensor
-hypotheses.  The remaining application is to instantiate the criterion twice,
-using the fixed contraction families and their positive-length product spans.
+hypotheses.  Instantiating the criterion twice with the fixed contraction
+families and their positive-length product spans gives
+\[
+  \widetilde S\widetilde T=\operatorname{id}_{\mathcal A_1},
+  \qquad
+  \widetilde T\widetilde S=\operatorname{id}_{\mathcal A_2}.
+\]
+These are precisely the two identity compositions in
+\cite[Appendix~C.4, lines~1974--1995]{Cirac2016MPDO_arXiv}.\footnote{Formal
+declaration:
+\leanid{MPOTensor.transportedVerticalSector_composites_eq_id}
+in \doclink{TNLean/MPS/MPDO/VerticalSectorIdentity}.}
 
 Let $F^*$ be the trace adjoint and define the trace-loss operator
 \[
@@ -286,35 +296,31 @@ one of the following source-faithful routes:
 
 \section{Elimination plan}
 
-The unrestricted CPSV16 conclusion should be completed in the following
-order:
+The first two steps of the Appendix~C.4 argument are complete:
 \begin{enumerate}
     \item complete positivity of the canonical lifts of the transported maps,
           and hence the adjoint Schwarz inequality for the two trace-preserving
           square composites, is established without an all-input active-image
           statement;
-    \item apply the finite-product identity criterion to each square
+    \item the finite-product identity criterion is applied to each square
           composite, using the fixed contraction families and the proved
-          product-generation theorem, to obtain both identity compositions;
-    \item derive the permutation and matching dimensions from the resulting
-          positive, trace-preserving inverse pair, retaining the Schwarz
-          hypothesis for the unitary-conjugation conclusion.
+          product-generation theorem, and gives both identity compositions;
 \end{enumerate}
+The remaining step is to derive the sector permutation and matching dimensions
+from the resulting positive, trace-preserving inverse pair, retaining the
+Schwarz hypothesis for the unitary-conjugation conclusion.
 
 \section{Classification}
 
-\textbf{Verdict: trace, complete-positivity, and abstract fixed-point
-subproblems closed; invertibility gap open.}  The two transported maps and
-their square composites are trace preserving under the source tensor
-hypotheses, and the trace adjoints of the square composites satisfy the
-Schwarz inequality.  The
-positive-definite fixed-family construction on finite products, the
-density-block product-span bound, and the resulting abstract identity
-criterion are proved.  The stronger active-image inclusions remain unproved
-and are not needed for this route.  Until the identity criterion is
-instantiated for the two tensor-attached square composites, neither
-transported-map invertibility nor sector relabelling should carry a completion
-marker in the blueprint.
+\textbf{Verdict: transported-map invertibility closed; sector relabelling
+open.}  The two transported maps and their square composites are trace
+preserving under the source tensor hypotheses, and the trace adjoints of the
+square composites satisfy the Schwarz inequality.  The positive-definite
+fixed-family construction, density-block product-span bound, and abstract
+identity criterion prove that both composites are identities.  The stronger
+active-image inclusions remain unproved and are not needed for this route.
+The sector permutation, matching dimensions, and unitary-conjugation
+classification from Appendix~C.4, lines~1995--2003 remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This proves that the transported vertical-sector refinement and coarse-graining maps are mutually inverse under exactly the tensor, canonical-form, coisometry, and physical-channel hypotheses used for their trace-preservation theorem.

For each square composite, the proof combines:

- positivity derived from the transported tensor maps;
- the established trace-preservation and trace-adjoint Schwarz theorems;
- fixedness of the corresponding weighted vertical bond contractions;
- the positive-length product span supplied by the basis-of-normal-tensors hypotheses; and
- the finite-product fixed-point identity criterion.

The resulting declaration is `MPOTensor.transportedVerticalSector_composites_eq_id`.

The proof assumes neither multiplicativity nor fixedness of products, active-image containment, invertibility, a product-span dimension inequality, or an additional Schwarz hypothesis. The sector permutation, matching block dimensions, and unitary-conjugation classification from Appendix C.4, lines 1995–2003 remain outside this change.

The blueprint and `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex` now record that transported-map invertibility is complete, while sector relabelling remains open.

Source: CPSV16, arXiv:1606.00608, Appendix C.4, lines 1974–1995.

Closes #4418.

## Validation

- `lake env lean TNLean/MPS/MPDO/VerticalSectorIdentity.lean`
- `lake build TNLean.MPS.MPDO.VerticalSectorIdentity`
- `lake build`
- `lake env lean TNLean.lean`
- `lake exe lint_style`
- blueprint synchronization and changed-declaration coverage
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- reader-facing prose, proof-integrity, line-length, and oversized-file checks
- `chktex` on the changed LaTeX sources
- all 91 paper-gap PDFs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a formal proof and documentation on an established MPDO vertical-sector route; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Proves** that the transported vertical-sector refinement and coarse-graining maps are **mutually inverse** on their respective sector algebras by showing both square composites equal the identity.
> 
> Adds `MPOTensor.transportedVerticalSector_composites_eq_id` in `VerticalSectorIdentity.lean`, wired into the root import graph. Each composite is assembled from positivity of the transported maps, existing trace-preservation and trace-adjoint Schwarz results, fixedness of weighted vertical bond contractions, BNT product-spanning, and `eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz`.
> 
> The blueprint gains **Theorem** “Transported vertical-sector composites are identities” (`thm:mpdo_transported_vertical_sector_composites_identity`). `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex` now records that **transported-map invertibility is complete** while **sector permutation, matching dimensions, and unitary conjugation** (Appendix C.4, lines 1995–2003) remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00e8a1bb1054e69f840d1cc7775136313ca939f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->