### PR TITLE
feat(MPS/RFP): restrict Beigi loops to Schmidt support

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -632,7 +632,7 @@ import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BeigiSectorGraph
 import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
-import TNLean.MPS.RFP.BeigiLoopTensor
+import TNLean.MPS.RFP.BeigiLoopSchmidtSupport
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 -- Layer 6a: Quantum Wielandt span-growth infrastructure

--- a/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
+++ b/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
@@ -1,0 +1,290 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.SchmidtRank
+import TNLean.MPS.RFP.BeigiLoopTensor
+
+/-!
+# Schmidt-support realization of a positive Beigi loop
+
+A positive loop in Beigi's sector graph carries a nonzero vector in a tensor
+product of right and left sector factors.  Its coefficient matrix need not
+have full rank in either ambient factor.  Factoring this matrix through its
+Schmidt rank gives a matrix product tensor whose virtual dimension is that
+rank.  The resulting tensor has the same periodic vectors as the ambient
+realization at every positive length.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Section IV, equation (10) and the paragraph following it.
+-/
+
+open scoped BigOperators Kronecker Matrix
+
+namespace MPSTensor.BeigiSectorGraphData
+
+open FiniteWeightedDigraph
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+/-- The Schmidt rank of the bond vector carried by a positive loop.
+
+**Local fix (Schmidt support):** Beigi chooses a nonzero vector in the loop
+edge ground space, but does not assume that it has full Schmidt rank in the
+ambient left and right factors.  The minimal virtual space is therefore its
+Schmidt support.  This point is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+noncomputable def loopSchmidtRank (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : ℕ :=
+  Matrix.schmidtRank (F.loopBondVector l)
+
+/-- A rank factorization of the coefficient matrix of the loop bond vector
+through its Schmidt support.
+
+**Local fix (Schmidt support):** The intermediate dimension is the Schmidt
+rank rather than either ambient tensor-factor dimension.  This removes
+unused virtual directions when the chosen loop vector has deficient Schmidt
+rank; see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+structure LoopSchmidtFactorization (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) where
+  /-- The right/Schmidt-indexed factor of the loop bond coefficient matrix.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Section IV, equation (10) and the paragraph following it. -/
+  rightFactor :
+    Matrix (Fin (F.rightDim l.1)) (Fin (F.loopSchmidtRank l)) ℂ
+  /-- The Schmidt/left-indexed factor of the loop bond coefficient matrix.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Section IV, equation (10) and the paragraph following it. -/
+  leftFactor :
+    Matrix (Fin (F.loopSchmidtRank l)) (Fin (F.leftDim l.1)) ℂ
+  /-- The two factors multiply to the loop bond coefficient matrix.
+
+  Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Section IV, equation (10) and the paragraph following it. -/
+  mul_eq : rightFactor * leftFactor =
+    Matrix.schmidtCoeffMatrix (F.loopBondVector l)
+
+/-- The chosen rank factorization of the loop bond vector through its
+Schmidt support.
+
+**Local fix (Schmidt support):** The factorization passes through the Schmidt
+rank rather than an ambient tensor-factor dimension; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+noncomputable def loopSchmidtFactorization (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : LoopSchmidtFactorization F l := by
+  let h := Matrix.exists_mul_eq_of_rank_le
+    (Matrix.schmidtCoeffMatrix (F.loopBondVector l))
+    (show (Matrix.schmidtCoeffMatrix (F.loopBondVector l)).rank ≤
+      F.loopSchmidtRank l from le_rfl)
+  exact {
+    rightFactor := Classical.choose h
+    leftFactor := Classical.choose (Classical.choose_spec h)
+    mul_eq := Classical.choose_spec (Classical.choose_spec h)
+  }
+
+/-- The Schmidt support of a nonzero loop bond vector has positive
+dimension.
+
+**Local fix (Schmidt support):** Positivity follows from Beigi's nonzero loop
+bond vector after restricting to its Schmidt support; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+theorem loopSchmidtRank_pos (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : 0 < F.loopSchmidtRank l := by
+  rw [Nat.pos_iff_ne_zero]
+  intro hrank
+  have hmul :
+      (F.loopSchmidtFactorization l).rightFactor *
+          (F.loopSchmidtFactorization l).leftFactor = 0 := by
+    ext q a
+    simp only [Matrix.mul_apply, Matrix.zero_apply]
+    apply Finset.sum_eq_zero
+    intro j _
+    exact Fin.elim0 (Fin.cast hrank j)
+  apply F.loopBondVector_ne_zero l
+  funext qa
+  have hcoeff := congrArg (fun M ↦ M qa.1 qa.2)
+    (hmul.symm.trans (F.loopSchmidtFactorization l).mul_eq)
+  simpa using hcoeff.symm
+
+/-- The rectangular letter whose product with the left Schmidt factor gives
+the ambient loop tensor letter.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it, with the
+Schmidt-support refinement recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+private noncomputable def loopSchmidtBridge (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) (i : Fin d) :
+    Matrix (Fin (F.leftDim l.1)) (Fin (F.loopSchmidtRank l)) ℂ :=
+  fun a α ↦
+    if hq : (F.sectorEquiv.symm i).1 = l.1 then
+      if a = Fin.cast (congrArg F.leftDim hq)
+          (F.sectorEquiv.symm i).2.2 then
+        (F.loopSchmidtFactorization l).rightFactor
+          (Fin.cast (congrArg F.rightDim hq)
+            (F.sectorEquiv.symm i).2.1) α
+      else 0
+    else 0
+
+/-- The loop tensor in sector coordinates on the minimal Schmidt support.
+
+Its letter at a loop-sector coordinate is the outer product of the
+corresponding row of the left factor with the corresponding column of the
+right factor.  Coordinates in other sectors give zero.
+
+**Local fix (Schmidt support):** The virtual dimension is the Schmidt rank of
+the chosen bond vector, not the full left-factor dimension.  This is the
+minimal realization compatible with Beigi's product-of-pairs state; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+noncomputable def minimalLoopCoordinateTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : MPSTensor d (F.loopSchmidtRank l) :=
+  fun i ↦ (F.loopSchmidtFactorization l).leftFactor *
+    F.loopSchmidtBridge l i
+
+/-- Applying the spatial-decomposition unitary gives the physical loop
+tensor on the minimal Schmidt support.
+
+**Local fix (Schmidt support):** The virtual space is restricted to the
+Schmidt support as documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+noncomputable def minimalLoopTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : MPSTensor d (F.loopSchmidtRank l) :=
+  rotatePhysical F.unitary (F.minimalLoopCoordinateTensor l)
+
+/-- Each ambient loop letter is the rectangular Schmidt-support letter
+followed by the left factor of the bond coefficient matrix.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it, with the
+Schmidt-support refinement recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+private theorem loopCoordinateTensor_eq_bridge_mul_leftFactor
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    F.loopCoordinateTensor l = fun i ↦
+      F.loopSchmidtBridge l i *
+        (F.loopSchmidtFactorization l).leftFactor := by
+  classical
+  ext i a b
+  by_cases hq : (F.sectorEquiv.symm i).1 = l.1
+  · by_cases ha : a = Fin.cast (congrArg F.leftDim hq)
+        (F.sectorEquiv.symm i).2.2
+    · have hentry := congrArg
+          (fun M ↦ M
+            (Fin.cast (congrArg F.rightDim hq)
+              (F.sectorEquiv.symm i).2.1) b)
+          (F.loopSchmidtFactorization l).mul_eq
+      simpa [loopCoordinateTensor, loopSchmidtBridge, Matrix.mul_apply,
+        hq, ha] using hentry.symm
+    · simp [loopCoordinateTensor, loopSchmidtBridge, Matrix.mul_apply,
+        hq, ha]
+  · simp [loopCoordinateTensor, loopSchmidtBridge, Matrix.mul_apply, hq]
+
+/-- A nonempty word in the products \(S_iY\) and \(YS_i\) factors as
+\(RY\) and \(YR\), respectively, for a common rectangular matrix \(R\). -/
+private theorem exists_schmidtWordCore {r L : ℕ}
+    (Y : Matrix (Fin r) (Fin L) ℂ)
+    (S : Fin d → Matrix (Fin L) (Fin r) ℂ)
+    (w : List (Fin d)) (hw : w ≠ []) :
+    ∃ R : Matrix (Fin L) (Fin r) ℂ,
+      evalWord (fun i ↦ S i * Y) w = R * Y ∧
+        evalWord (fun i ↦ Y * S i) w = Y * R := by
+  induction w with
+  | nil => exact (hw rfl).elim
+  | cons i w ih =>
+      by_cases htail : w = []
+      · subst w
+        exact ⟨S i, by simp, by simp⟩
+      · obtain ⟨R, hraw, hminimal⟩ := ih htail
+        refine ⟨S i * Y * R, ?_, ?_⟩
+        · simp only [evalWord_cons, hraw, Matrix.mul_assoc]
+        · simp only [evalWord_cons, hminimal, Matrix.mul_assoc]
+
+/-- The ambient and Schmidt-support loop tensors have equal traces on every
+nonempty word.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it, with the
+Schmidt-support refinement recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+private theorem trace_evalWord_loopCoordinateTensor_eq_minimal
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    (w : List (Fin d)) (hw : w ≠ []) :
+    Matrix.trace (evalWord (F.loopCoordinateTensor l) w) =
+      Matrix.trace (evalWord (F.minimalLoopCoordinateTensor l) w) := by
+  rw [F.loopCoordinateTensor_eq_bridge_mul_leftFactor l]
+  obtain ⟨R, hraw, hminimal⟩ := exists_schmidtWordCore
+    (F.loopSchmidtFactorization l).leftFactor
+    (F.loopSchmidtBridge l) w hw
+  rw [hraw]
+  change Matrix.trace (R * (F.loopSchmidtFactorization l).leftFactor) =
+    Matrix.trace (evalWord
+      (fun i ↦ (F.loopSchmidtFactorization l).leftFactor *
+        F.loopSchmidtBridge l i) w)
+  rw [hminimal]
+  exact Matrix.trace_mul_comm _ _
+
+/-- The periodic matrix product vector of the minimal Schmidt-support tensor
+is the cyclic product of loop bond vectors at every positive length.
+
+**Local fix (Schmidt support):** Restricting the virtual space to the Schmidt
+support leaves every positive-length periodic vector unchanged.  The role of
+this restriction is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+theorem mpv_minimalLoopCoordinateTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
+    mpv (F.minimalLoopCoordinateTensor l) s = F.loopCyclicProduct l s := by
+  rw [← F.mpv_loopCoordinateTensor l s]
+  unfold mpv coeff
+  have hw : List.ofFn s ≠ [] :=
+    List.length_pos_iff_ne_nil.mp
+      (by simpa only [List.length_ofFn] using NeZero.pos N)
+  exact (F.trace_evalWord_loopCoordinateTensor_eq_minimal l
+    (List.ofFn s) hw).symm
+
+/-- The physical tensor on the minimal Schmidt support has exactly Beigi's
+product-of-pairs state as its periodic vector at every positive chain length.
+
+**Local fix (Schmidt support):** The equality shows that removing the unused
+virtual directions does not alter the physical loop state; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Section IV, equation (10) and the paragraph following it. -/
+theorem mpv_minimalLoopTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
+    mpv (F.minimalLoopTensor l) s = F.loopProductState l s := by
+  rw [minimalLoopTensor, MPSTensor.mpv_rotatePhysical]
+  simp only [loopProductState]
+  apply Finset.sum_congr rfl
+  intro t _
+  congr 1
+  exact F.mpv_minimalLoopCoordinateTensor l t
+
+end MPSTensor.BeigiSectorGraphData

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2577,12 +2577,55 @@ specialization of that Appendix~D definition.
     denoted by $\Psi_a^{(N)}\in(\mathbb C^d)^{\otimes N}$.
 \end{definition}
 
+\begin{definition}[Schmidt-support tensor associated with a positive Beigi loop]
+    \label{def:beigi_loop_schmidt_support}
+    \lean{MPSTensor.BeigiSectorGraphData.loopSchmidtRank}
+    \lean{MPSTensor.BeigiSectorGraphData.LoopSchmidtFactorization}
+    \lean{MPSTensor.BeigiSectorGraphData.loopSchmidtFactorization}
+    \lean{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.minimalLoopTensor}
+    \leanok
+    \uses{def:beigi_loop_product_state}
+    Let $\Phi_a=(\varphi_a(r,l))_{r,l}$ and write
+    $r_a=\rank\Phi_a$.  Choose a rank factorization
+    \[
+        \Phi_a=X_aY_a,
+        \qquad
+        X_a\in M_{D_a^{\mathrm R},r_a}(\C),\quad
+        Y_a\in M_{r_a,D_a^{\mathrm L}}(\C).
+    \]
+    The tensor on the minimal Schmidt support is
+    \[
+        (\widetilde C_a^{(r,l)})_{\alpha,\beta}
+          =(Y_a)_{\alpha,l}(X_a)_{r,\beta},
+    \]
+    again extended by zero outside sector~$a$.  Its physical tensor is its
+    image under the same one-site unitary.
+\end{definition}
+
+\begin{lemma}[Positive Schmidt dimension of a Beigi loop]
+    \label{lem:beigi_loop_schmidt_rank_pos}
+    \lean{MPSTensor.BeigiSectorGraphData.loopSchmidtRank_pos}
+    \leanok
+    \uses{def:beigi_loop_schmidt_support}
+    The Schmidt rank $r_a$ of the nonzero loop bond vector is positive.
+\end{lemma}
+
+\begin{proof}\leanok
+    If $r_a=0$, then the intermediate index set in the factorization
+    $\Phi_a=X_aY_a$ is empty.  Every entry of $X_aY_a$ is therefore zero,
+    contrary to $\varphi_a\ne0$.
+\end{proof}
+
 \begin{theorem}[Periodic vector of a positive Beigi loop]
     \label{thm:beigi_loop_tensor_periodic_vector}
     \lean{MPSTensor.BeigiSectorGraphData.mpv_loopCoordinateTensor}
     \lean{MPSTensor.BeigiSectorGraphData.mpv_loopTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.mpv_minimalLoopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.mpv_minimalLoopTensor}
     \leanok
-    \uses{def:beigi_loop_product_state, lem:mpv_rotate_physical}
+    \uses{def:beigi_loop_product_state, def:beigi_loop_schmidt_support,
+        lem:mpv_rotate_physical}
     For every $N>0$, the periodic matrix product vector of $C_a$ has
     coefficient
     \[
@@ -2591,7 +2634,8 @@ specialization of that Appendix~D definition.
     on a cyclic configuration in sector $a$, and coefficient zero on every
     other sector configuration.  Consequently the periodic vector of the
     physical loop tensor is exactly the sitewise-unitary image of this cyclic
-    product-of-pairs state.
+    product-of-pairs state.  The same identities hold for the tensor on the
+    minimal Schmidt support.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2606,8 +2650,22 @@ specialization of that Appendix~D definition.
         =\prod_{n=0}^{N-1}\varphi_a(r_n,l_{n+1}),
     \]
     where all site labels are read cyclically.  Indeed, the Kronecker deltas
-    leave only the assignment $g_n=l_n$.  If $A_a$ denotes the physical loop
-    tensor and $U$ the one-site unitary, then for a physical configuration
+    leave only the assignment $g_n=l_n$.
+
+    For the minimal tensor, let $S^{(r,l)}$ be the rectangular matrix whose
+    only nonzero row is row $l$, equal there to row $r$ of $X_a$.  Then
+    \[
+        C_a^{(r,l)}=S^{(r,l)}Y_a,
+        \qquad
+        \widetilde C_a^{(r,l)}=Y_aS^{(r,l)}.
+    \]
+    For every nonempty word there is therefore a rectangular matrix $R$ such
+    that its two products are $RY_a$ and $Y_aR$, respectively.  Cyclicity of
+    the trace gives $\tr(RY_a)=\tr(Y_aR)$, proving equality of all
+    positive-length periodic vectors.
+
+    If $A_a$ denotes the physical loop tensor and $U$ the one-site unitary,
+    then for a physical configuration
     $s=(s_0,\ldots,s_{N-1})$ one has
     \[
         \operatorname{tr}(A_a^{s_0}\cdots A_a^{s_{N-1}})

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -332,6 +332,21 @@ product
 For a positive loop $a\to a$, denote the resulting physical state on a chain
 of length $N$ by $\Psi_a^{(N)}$.
 This is the construction in Beigi, arXiv:1105.1019v2, source lines 602--606.
+The ambient left factor need not be the minimal virtual space: Beigi assumes
+only that the selected bond vector is nonzero, not that its coefficient matrix
+has full rank.  Writing that matrix as
+$\Phi_a=X_aY_a$ through its positive Schmidt rank $r_a$, the declarations
+\leanid{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor} and
+\leanid{MPSTensor.BeigiSectorGraphData.minimalLoopTensor} restrict the virtual
+space to $\C^{r_a}$.  Their letters are
+$(Y_a)_{\alpha,l}(X_a)_{r,\beta}$, and
+\leanid{MPSTensor.BeigiSectorGraphData.mpv_minimalLoopTensor} proves that this
+restriction leaves every positive-length periodic vector equal to Beigi's
+product-of-pairs vector.  No injectivity, normality, or normalization condition
+is imposed on these tensors at this stage.  Consequently, the spanning
+statement below may equivalently be formulated using the periodic vectors of
+the minimal Schmidt-support tensors.
+
 For every $N\geq2$,
 \leanid{MPSTensor.BeigiSectorGraphData.}
 \hspace{0pt}\leanid{loopProductState_mem_ker_parentHamiltonian}


### PR DESCRIPTION
## Mathematical contribution

For each positive Beigi loop, this pull request factors the loop bond coefficient matrix through its Schmidt rank and defines the resulting minimal-bond coordinate and physical MPS tensors. It proves that the Schmidt rank is positive and that both minimal tensors generate exactly the original loop periodic vector at every positive chain length.

The trace argument uses the rectangular factorization in both cyclic orders. This is the formal finite-dimensional version of the product-of-pairs MPS observation in Beigi, arXiv:1105.1019v2, Section III, p. 4, together with the one-dimensional loop form in Section IV, equation (10) and the paragraph following it.

The declarations are placed in `BeigiLoopSchmidtSupport.lean`, which transitively imports the preceding loop-tensor construction while keeping every Lean source file within the 1000-line limit. The blueprint and the existing CPSV16 paper-gap note now distinguish the ambient left factor from the positive Schmidt support.

## Scope

This advances #4423 and the paper-level program #232. It does not identify the minimal loop tensors with the BNT representatives. It introduces no injectivity, normality, or normalization assertion, does not prove transfer idempotence, and does not remove `Axioms.beigi_nncph_to_rfp`. Consequently it does not close #4423, #2633, or #232.

## Validation

- `lake env lean TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean`
- `lake build TNLean.MPS.RFP.BeigiLoopSchmidtSupport -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `lake env lean TNLean.lean`
- `lake exe lint_style`
- blueprint synchronization with reverse coverage for all changed declarations
- `lake exe checkdecls blueprint/lean_decls`
- reader-facing prose, proof-integrity, line-length, and oversized-file checks
- repository ChkTeX and standalone compilation of the updated paper-gap note

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 90624380c2a28203bc6a0ba54d1d4ba641ee5ce7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->