### PR TITLE
feat(Channel/FixedPoint): add rectangular trace adjoints

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -208,6 +208,7 @@ import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
 import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
 import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
 import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
+import TNLean.Channel.FixedPoint.DirectSumTraceAdjoint
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.StationaryProjection
@@ -259,7 +260,6 @@ import TNLean.Spectral.TransferOperatorGapRect
 import TNLean.Spectral.PrimitiveOverlap
 import TNLean.Spectral.CrossCorrelation
 import TNLean.Spectral.QuantitativeGap
-
 -- Layer 3: MPS core
 import TNLean.MPS.Defs
 import TNLean.MPS.OpenBoundary

--- a/TNLean/Channel/FixedPoint/DirectSumKraus.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumKraus.lean
@@ -28,6 +28,8 @@ the particular transported vertical-sector maps are separate.
 * `Matrix.directSumMapExtension`: the canonical full-matrix extension of a map
   between two finite sums of matrix algebras.
 * `Matrix.IsKrausDirectSumMap`: complete positivity through this extension.
+* `Matrix.IsKrausDirectSumMap.map_posSemidef`: complete positivity preserves
+  positive-semidefinite families.
 -/
 
 open scoped Matrix MatrixOrder ComplexOrder
@@ -96,6 +98,22 @@ def IsKrausDirectSumMap
     (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
       (∀ j, Matrix (m j) (m j) ℂ)) : Prop :=
   IsKrausCP (directSumMapExtension T)
+
+/-- A completely positive map between finite sums of full matrix algebras
+sends every positive-semidefinite family to a positive-semidefinite family. -/
+theorem IsKrausDirectSumMap.map_posSemidef
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hT : IsKrausDirectSumMap T)
+    {A : ∀ i, Matrix (n i) (n i) ℂ}
+    (hA : ∀ i, (A i).PosSemidef) (j : κ) :
+    (T A j).PosSemidef := by
+  have hExt :
+      (directSumMapExtension T (directSumDiagonalEmbedding A)).PosSemidef :=
+    IsKrausCP.map_posSemidef hT (directSumDiagonalEmbedding_posSemidef hA)
+  have hj := directSumDiagonalCompression_posSemidef hExt j
+  simpa only [directSumMapExtension_apply,
+    directSumDiagonalCompression_embedding] using hj
 
 /-- Composition preserves complete positivity for maps between finite sums of
 full matrix algebras. -/

--- a/TNLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
@@ -1,0 +1,301 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumKraus
+import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
+
+/-!
+# Trace adjoints between finite sums of matrix algebras
+
+The trace pairing on a finite sum of full matrix algebras is the sum of the
+ordinary matrix trace pairings. This file defines the adjoint of a linear map
+between two such sums, proves the defining trace identity, and establishes its
+identity, composition, unitality, positivity, and complete-positivity properties.
+
+These statements provide the rectangular direct-sum trace-adjoint argument for
+the classification step in arXiv:1606.00608, Appendix C.4, lines 1995--2003,
+where trace-preserving completely positive maps run in opposite directions
+between two products of simple matrix algebras.
+
+These are supporting trace-adjoint facts, not a formalization of the
+classification conclusion in that passage. The remaining argument is recorded
+in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`; it still requires
+Schwarz equality, multiplicativity, the relabeling and dimension matching of
+simple summands, and their implementation by unitary conjugations.
+
+## Main definitions
+
+* `Matrix.directSumTraceAdjointMapBetween`: the trace adjoint of a map between
+  two finite sums of full matrix algebras.
+
+## Main results
+
+* `Matrix.sum_trace_directSumTraceAdjointMapBetween_mul`: the defining trace
+  identity.
+* `Matrix.directSumTraceAdjointMapBetween_comp`: adjoints reverse composition.
+* `Matrix.IsTracePreservingBetweenDirectSums.directSumTraceAdjointMapBetween_one`:
+  the adjoint of a trace-preserving map is unital.
+* `Matrix.IsKrausDirectSumMap.directSumTraceAdjointMapBetween`: the adjoint of a
+  completely positive direct-sum map is completely positive.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators
+
+noncomputable section
+
+namespace Matrix
+
+variable {ι κ τ : Type*}
+variable [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+variable [Fintype τ] [DecidableEq τ]
+variable {n : ι → Type*} {m : κ → Type*} {p : τ → Type*}
+variable [∀ i, Fintype (n i)] [∀ i, DecidableEq (n i)]
+variable [∀ j, Fintype (m j)] [∀ j, DecidableEq (m j)]
+variable [∀ l, Fintype (p l)] [∀ l, DecidableEq (p l)]
+
+/-- The adjoint of a linear map between two finite sums of full matrix
+algebras, for the pairing given by the sum of the block trace pairings.
+
+It is obtained by embedding the codomain family block-diagonally, taking the
+full-matrix trace adjoint, and retaining the diagonal blocks in the domain.
+This is the preparatory adjoint construction for arXiv:1606.00608,
+Appendix C.4, lines 1995--2003. -/
+noncomputable def directSumTraceAdjointMapBetween
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)) :
+    (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ) :=
+  directSumDiagonalCompression.comp
+    ((Matrix.traceAdjointMap (directSumMapExtension T)).comp
+      directSumDiagonalEmbedding)
+
+omit [Fintype ι] [DecidableEq ι] [(i : ι) → Fintype (n i)]
+    [(i : ι) → DecidableEq (n i)] [(j : κ) → DecidableEq (m j)] in
+/-- The rectangular direct-sum trace adjoint is diagonal compression after
+the full-matrix trace adjoint. -/
+@[simp]
+theorem directSumTraceAdjointMapBetween_apply
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (A : ∀ j, Matrix (m j) (m j) ℂ) :
+    directSumTraceAdjointMapBetween T A =
+      directSumDiagonalCompression
+        (Matrix.traceAdjointMap (directSumMapExtension T)
+          (directSumDiagonalEmbedding A)) :=
+  rfl
+
+omit [DecidableEq ι] [(i : ι) → DecidableEq (n i)]
+    [(j : κ) → DecidableEq (m j)] in
+/-- The rectangular direct-sum trace adjoint satisfies its defining pairing:
+
+\[
+  \sum_i \operatorname{tr}(T^*(A)_i B_i)
+  = \sum_j \operatorname{tr}(A_j T(B)_j).
+\]
+
+This is the trace-pairing identity needed for the classification argument in
+arXiv:1606.00608, Appendix C.4, lines 1995--2003. -/
+theorem sum_trace_directSumTraceAdjointMapBetween_mul
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (A : ∀ j, Matrix (m j) (m j) ℂ)
+    (B : ∀ i, Matrix (n i) (n i) ℂ) :
+    ∑ i, (directSumTraceAdjointMapBetween T A i * B i).trace =
+      ∑ j, (A j * T B j).trace := by
+  classical
+  calc
+    ∑ i, (directSumTraceAdjointMapBetween T A i * B i).trace =
+        (directSumDiagonalEmbedding (directSumTraceAdjointMapBetween T A) *
+          directSumDiagonalEmbedding B).trace :=
+      (trace_directSumDiagonalEmbedding_mul _ _).symm
+    _ = (Matrix.traceAdjointMap (directSumMapExtension T)
+          (directSumDiagonalEmbedding A) * directSumDiagonalEmbedding B).trace := by
+      rw [directSumTraceAdjointMapBetween_apply]
+      exact trace_embedding_compression_mul_embedding _ _
+    _ = (directSumDiagonalEmbedding A *
+          directSumMapExtension T (directSumDiagonalEmbedding B)).trace :=
+      Matrix.trace_traceAdjointMap_mul _ _ _
+    _ = (directSumDiagonalEmbedding A *
+          directSumDiagonalEmbedding (T B)).trace := by
+      rw [directSumMapExtension_apply, directSumDiagonalCompression_embedding]
+    _ = ∑ j, (A j * T B j).trace :=
+      trace_directSumDiagonalEmbedding_mul _ _
+
+omit [DecidableEq ι] [(i : ι) → DecidableEq (n i)] in
+private theorem eq_of_sum_trace_mul_eq
+    {A B : ∀ i, Matrix (n i) (n i) ℂ}
+    (h : ∀ X : ∀ i, Matrix (n i) (n i) ℂ,
+      ∑ i, (A i * X i).trace = ∑ i, (B i * X i).trace) :
+    A = B := by
+  classical
+  funext i
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro X
+  let Y : ∀ i, Matrix (n i) (n i) ℂ := Function.update 0 i X
+  calc
+    (A i * X).trace = ∑ k, (A k * Y k).trace := by
+      rw [Finset.sum_eq_single i]
+      · simp [Y]
+      · intro k _ hki
+        simp [Y, hki]
+      · simp
+    _ = ∑ k, (B k * Y k).trace := h Y
+    _ = (B i * X).trace := by
+      rw [Finset.sum_eq_single i]
+      · simp [Y]
+      · intro k _ hki
+        simp [Y, hki]
+      · simp
+
+omit [(i : ι) → DecidableEq (n i)] in
+/-- The trace adjoint of the identity on a finite sum of matrix algebras is
+the identity. -/
+theorem directSumTraceAdjointMapBetween_id :
+    directSumTraceAdjointMapBetween
+        (LinearMap.id : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+          (∀ i, Matrix (n i) (n i) ℂ)) =
+      LinearMap.id := by
+  apply LinearMap.ext
+  intro A
+  apply eq_of_sum_trace_mul_eq
+  intro B
+  simpa using sum_trace_directSumTraceAdjointMapBetween_mul
+    (LinearMap.id : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)) A B
+
+omit [Fintype ι] [DecidableEq ι] [(i : ι) → Fintype (n i)]
+    [(i : ι) → DecidableEq (n i)]
+    [(j : κ) → DecidableEq (m j)] [(l : τ) → DecidableEq (p l)] in
+/-- Taking trace adjoints reverses the composition of maps between finite
+sums of matrix algebras. -/
+theorem directSumTraceAdjointMapBetween_comp
+    [Finite ι] [∀ i, Finite (n i)]
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ l, Matrix (p l) (p l) ℂ)) :
+    directSumTraceAdjointMapBetween (S.comp T) =
+      (directSumTraceAdjointMapBetween T).comp
+        (directSumTraceAdjointMapBetween S) := by
+  classical
+  letI := Fintype.ofFinite ι
+  letI (i : ι) := Fintype.ofFinite (n i)
+  apply LinearMap.ext
+  intro A
+  apply eq_of_sum_trace_mul_eq
+  intro B
+  calc
+    ∑ i, (directSumTraceAdjointMapBetween (S.comp T) A i * B i).trace =
+        ∑ l, (A l * S (T B) l).trace :=
+      sum_trace_directSumTraceAdjointMapBetween_mul (S.comp T) A B
+    _ = ∑ j, (directSumTraceAdjointMapBetween S A j * T B j).trace :=
+      (sum_trace_directSumTraceAdjointMapBetween_mul S A (T B)).symm
+    _ = ∑ i, (directSumTraceAdjointMapBetween T
+          (directSumTraceAdjointMapBetween S A) i * B i).trace :=
+      (sum_trace_directSumTraceAdjointMapBetween_mul T _ B).symm
+    _ = ∑ i, (((directSumTraceAdjointMapBetween T).comp
+          (directSumTraceAdjointMapBetween S)) A i * B i).trace := rfl
+
+omit [(i : ι) → DecidableEq (n i)] in
+/-- For an endomorphism of one finite sum, the rectangular trace adjoint
+agrees with the previously defined endomorphism trace adjoint. -/
+theorem directSumTraceAdjointMapBetween_self
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)) :
+    directSumTraceAdjointMapBetween T = directSumTraceAdjointMap T :=
+  rfl
+
+omit [DecidableEq ι] in
+/-- The trace adjoint of a total-trace-preserving map between finite sums of
+matrix algebras is unital.
+
+This is the Schrödinger--Heisenberg duality needed for the classification
+argument in arXiv:1606.00608, Appendix C.4, lines 1995--2003. -/
+theorem IsTracePreservingBetweenDirectSums.directSumTraceAdjointMapBetween_one
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hT : IsTracePreservingBetweenDirectSums T) :
+    directSumTraceAdjointMapBetween T 1 = 1 := by
+  apply eq_of_sum_trace_mul_eq
+  intro B
+  calc
+    ∑ i, (directSumTraceAdjointMapBetween T 1 i * B i).trace =
+        ∑ j, ((1 : ∀ j, Matrix (m j) (m j) ℂ) j * T B j).trace :=
+      sum_trace_directSumTraceAdjointMapBetween_mul T 1 B
+    _ = ∑ j, (T B j).trace := by simp
+    _ = ∑ i, (B i).trace := hT B
+    _ = ∑ i, ((1 : ∀ i, Matrix (n i) (n i) ℂ) i * B i).trace := by simp
+
+omit [Fintype ι] [(i : ι) → Fintype (n i)]
+    [(i : ι) → DecidableEq (n i)] [(j : κ) → DecidableEq (m j)] in
+/-- Taking the full-matrix trace adjoint commutes with the rectangular
+canonical extension of a map between finite sums of matrix algebras. -/
+theorem traceAdjointMap_directSumMapExtension
+    [Finite ι] [∀ i, Finite (n i)]
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)) :
+    Matrix.traceAdjointMap (directSumMapExtension T) =
+      directSumMapExtension (directSumTraceAdjointMapBetween T) := by
+  classical
+  letI := Fintype.ofFinite ι
+  letI (i : ι) := Fintype.ofFinite (n i)
+  apply LinearMap.ext
+  intro A
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro B
+  calc
+    (Matrix.traceAdjointMap (directSumMapExtension T) A * B).trace =
+        (A * directSumMapExtension T B).trace :=
+      Matrix.trace_traceAdjointMap_mul _ _ _
+    _ = (A * directSumDiagonalEmbedding
+          (T (directSumDiagonalCompression B))).trace := rfl
+    _ = (directSumDiagonalEmbedding (directSumDiagonalCompression A) *
+          directSumDiagonalEmbedding
+            (T (directSumDiagonalCompression B))).trace :=
+      (trace_embedding_compression_mul_embedding _ _).symm
+    _ = ∑ j, (directSumDiagonalCompression A j *
+          T (directSumDiagonalCompression B) j).trace :=
+      trace_directSumDiagonalEmbedding_mul _ _
+    _ = ∑ i, (directSumTraceAdjointMapBetween T
+          (directSumDiagonalCompression A) i *
+            directSumDiagonalCompression B i).trace :=
+      (sum_trace_directSumTraceAdjointMapBetween_mul T _ _).symm
+    _ = ∑ i, (directSumDiagonalCompression B i *
+          directSumTraceAdjointMapBetween T
+            (directSumDiagonalCompression A) i).trace := by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact Matrix.trace_mul_comm _ _
+    _ = (directSumDiagonalEmbedding (directSumDiagonalCompression B) *
+          directSumDiagonalEmbedding
+            (directSumTraceAdjointMapBetween T
+              (directSumDiagonalCompression A))).trace :=
+      (trace_directSumDiagonalEmbedding_mul _ _).symm
+    _ = (B * directSumDiagonalEmbedding
+          (directSumTraceAdjointMapBetween T
+            (directSumDiagonalCompression A))).trace :=
+      trace_embedding_compression_mul_embedding _ _
+    _ = (directSumDiagonalEmbedding
+          (directSumTraceAdjointMapBetween T
+            (directSumDiagonalCompression A)) * B).trace :=
+      Matrix.trace_mul_comm _ _
+    _ = (directSumMapExtension (directSumTraceAdjointMapBetween T) A * B).trace := rfl
+
+/-- The trace adjoint of a completely positive map between finite sums of
+full matrix algebras is completely positive.
+
+At the full-matrix level, a Kraus family \(K_a\) for the original map gives
+the Kraus family \(K_a^*\) for its trace adjoint. This is the complete-
+positivity passage needed for the classification argument in arXiv:1606.00608,
+Appendix C.4, lines 1995--2003. -/
+theorem IsKrausDirectSumMap.directSumTraceAdjointMapBetween
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hT : IsKrausDirectSumMap T) :
+    IsKrausDirectSumMap (directSumTraceAdjointMapBetween T) := by
+  rw [IsKrausDirectSumMap, ← traceAdjointMap_directSumMapExtension]
+  exact IsKrausCP.traceAdjointMap (S := directSumMapExtension T) hT
+
+end Matrix

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -28,6 +28,7 @@ dimensions.
 * `IsKrausCPTP.isKrausCP`: a trace-preserving Kraus map is a Kraus CP map.
 * `IsKrausCP.map_posSemidef`: a Kraus CP map preserves positive
   semidefiniteness.
+* `IsKrausCP.traceAdjointMap`: the trace adjoint of a Kraus CP map is Kraus CP.
 * `IsKrausCPTP.trace_map`: a map satisfying `IsKrausCPTP` preserves trace.
 * `isKrausCPTP_of_isKrausCP_trace_preserving`: a Kraus CP map that preserves
   trace is Kraus CPTP.
@@ -122,6 +123,26 @@ theorem IsKrausCP.map_posSemidef
   obtain ⟨r, A, hA⟩ := hS
   rw [hA]
   exact Matrix.posSemidef_sum _ fun i _ => hX.mul_mul_conjTranspose_same (A i)
+
+/-- The trace adjoint of a completely positive map in rectangular Kraus form
+is completely positive. A Kraus family `A i` for the original map gives the
+conjugate-transposed Kraus family `(A i)ᴴ` for its trace adjoint. -/
+theorem IsKrausCP.traceAdjointMap
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCP S) :
+    IsKrausCP (Matrix.traceAdjointMap S) := by
+  obtain ⟨r, A, hA⟩ := hS
+  refine ⟨r, fun i ↦ (A i)ᴴ, ?_⟩
+  intro X
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro Y
+  rw [Matrix.trace_traceAdjointMap_mul, hA]
+  rw [Matrix.mul_sum, Matrix.trace_sum, Matrix.sum_mul, Matrix.trace_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Matrix.conjTranspose_conjTranspose]
+  simpa only [Matrix.mul_assoc] using
+    Matrix.trace_mul_cycle (X * A i) Y (A i)ᴴ
 
 /-- A completely positive map in rectangular Kraus form sends positive
 semidefinite matrices to positive semidefinite matrices. -/

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2499,31 +2499,95 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \lean{Matrix.directSumDiagonalEmbedding}
     \lean{Matrix.directSumDiagonalCompression}
     \lean{Matrix.directSumExtension}
+    \lean{Matrix.directSumMapExtension}
     \lean{Matrix.directSumTraceAdjointMap}
+    \lean{Matrix.directSumTraceAdjointMapBetween}
     \leanok
     Let
     \[
         \mathcal A=\bigoplus_{k\in I}M_{n_k}(\mathbb C),
         \qquad
-        \mathcal H=\bigoplus_{k\in I}\mathbb C^{n_k}.
+        \mathcal B=\bigoplus_{l\in J}M_{m_l}(\mathbb C),
     \]
-    Write $\iota:\mathcal A\to\operatorname{End}(\mathcal H)$ for the
-    block-diagonal embedding and $\pi:\operatorname{End}(\mathcal H)\to
-    \mathcal A$ for diagonal-block compression.  For a linear map
-    $T:\mathcal A\to\mathcal A$, its canonical full-matrix extension is
+    and let $\mathcal H_A=\bigoplus_{k\in I}\mathbb C^{n_k}$ and
+    $\mathcal H_B=\bigoplus_{l\in J}\mathbb C^{m_l}$.  Write $\iota_A,\iota_B$
+    for the block-diagonal embeddings and $\pi_A,\pi_B$ for diagonal-block
+    compression.  For a linear map $T:\mathcal A\to\mathcal B$, its canonical
+    full-matrix extension is
     \[
-        \widehat T=\iota\circ T\circ\pi.
+        \widehat T=\iota_B\circ T\circ\pi_A:
+        \operatorname{End}(\mathcal H_A)\longrightarrow
+        \operatorname{End}(\mathcal H_B).
     \]
-    The trace adjoint $T^*:\mathcal A\to\mathcal A$ is defined by
+    For $X\in\mathcal A$ and $Y\in\mathcal B$, the trace adjoint
+    $T^*:\mathcal B\to\mathcal A$ is defined by
     \[
-      \sum_k\operatorname{tr}(T^*(A)_kB_k)
-      =\sum_k\operatorname{tr}(A_kT(B)_k)
-      \qquad(A,B\in\mathcal A).
+      \sum_{k\in I}\operatorname{tr}(T^*(Y)_kX_k)
+      =\sum_{l\in J}\operatorname{tr}(Y_lT(X)_l).
     \]
-    This is the block-diagonal realization needed when the fixed-point
-    argument in \cite[Appendix~C.4, lines~1980--1995]{Cirac2016MPDO_arXiv}
-    is applied to finite direct sums of matrix algebras.
+    This is the block-diagonal realization needed for the fixed-point and
+    classification arguments in
+    \cite[Appendix~C.4, lines~1980--2003]{Cirac2016MPDO_arXiv}.
+    It is only an auxiliary construction: it does not assert the
+    classification conclusion of that passage.
 \end{definition}
+
+The preceding definition and the elementary laws below provide supporting
+facts for the classification argument.  They do not prove Schwarz equality
+for the transported maps, multiplicativity, a relabeling or dimension matching
+of the simple summands, or implementation on each summand by unitary
+conjugation.
+
+\begin{lemma}[Trace-adjoint laws for two finite sums of matrix algebras]%
+    \label{lem:direct_sum_rectangular_trace_adjoint}
+    \lean{Matrix.sum_trace_directSumTraceAdjointMapBetween_mul}
+    \lean{Matrix.directSumTraceAdjointMapBetween_id}
+    \lean{Matrix.directSumTraceAdjointMapBetween_comp}
+    \lean{Matrix.directSumTraceAdjointMapBetween_self}
+    \lean{Matrix.IsTracePreservingBetweenDirectSums.directSumTraceAdjointMapBetween_one}
+    \lean{Matrix.traceAdjointMap_directSumMapExtension}
+    \lean{IsKrausCP.traceAdjointMap}
+    \lean{Matrix.IsKrausDirectSumMap.map_posSemidef}
+    \lean{Matrix.IsKrausDirectSumMap.directSumTraceAdjointMapBetween}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    For maps $T:\mathcal A\to\mathcal B$ and
+    $S:\mathcal B\to\mathcal C$, trace adjoints satisfy
+    \[
+        \operatorname{id}_{\mathcal A}^*=\operatorname{id}_{\mathcal A},
+        \qquad
+        (S\circ T)^*=T^*\circ S^*,
+        \qquad
+        (\widehat T)^*=\widehat{T^*}.
+    \]
+    If $T$ preserves the total trace, then $T^*(\Id_{\mathcal B})=
+    \Id_{\mathcal A}$.  If $\widehat T$ admits a Kraus representation, then
+    so does $\widehat{T^*}$; in particular, both $T$ and $T^*$ send families
+    of positive-semidefinite matrices to positive-semidefinite families.
+    These statements are only the adjoint and positivity part of the
+    classification argument; none of its multiplicative or blockwise
+    conclusions is asserted here.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:direct_sum_full_matrix_extension}
+    The defining trace identity and nondegeneracy of the trace pairing give
+    the identity and composition formulas.  Total-trace preservation gives,
+    for every $X\in\mathcal A$,
+    \[
+        \sum_{k\in I}\operatorname{tr}(T^*(\Id_{\mathcal B})_kX_k)
+        =\sum_{l\in J}\operatorname{tr}(T(X)_l)
+        =\sum_{k\in I}\operatorname{tr}(X_k),
+    \]
+    so $T^*(\Id_{\mathcal B})=\Id_{\mathcal A}$.  Finally, if
+    $\widehat T(X)=\sum_a K_aXK_a^*$, cyclicity of the trace shows that
+    \[
+        (\widehat T)^*(Y)=\sum_a K_a^*YK_a.
+    \]
+    Thus the adjoint again has a Kraus representation, and compression of
+    positive block-diagonal matrices gives the stated positivity.
+\end{proof}
 
 \begin{theorem}[Channel and fixed-point compatibility of the canonical extension]%
     \label{thm:direct_sum_full_matrix_extension_compatibility}
@@ -2535,6 +2599,9 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     \lean{Matrix.directSumExtension_apply_eq_self_iff}
     \leanok
     \uses{def:direct_sum_full_matrix_extension}
+    In the endomorphic case $\mathcal B=\mathcal A$, write
+    $\mathcal H=\mathcal H_A=\mathcal H_B$ and
+    $\iota=\iota_A=\iota_B$.
     If $T$ is positive and satisfies the Schwarz inequality on
     $\mathcal A$, then $\widehat T$ is positive and satisfies the Schwarz
     inequality on $\operatorname{End}(\mathcal H)$.  If $T$ preserves the


### PR DESCRIPTION
### Motivation

Issue LionSR/QICLean#247 requires the trace adjoint for maps between two possibly different finite
products of full complex matrix algebras before the mutual-inverse classification can
begin.

The mathematical source is `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1995–2003.
There, the two transported maps are shown to be mutually inverse and the argument of
Wolf–Pérez-García, Theorem 8, is then invoked to obtain a relabeling of the blocks and
unitary conjugation within each block. This pull request supplies the rectangular
trace-adjoint part of that argument.

### Description

- Define the rectangular direct-sum trace adjoint and prove its trace-pairing identity.
- Prove the identity and reversed-composition laws, agreement with the existing
  endomorphic adjoint, trace-preserving-to-unitality, and compatibility with the
  full-matrix extension.
- Record the general full-matrix fact that conjugate-transposing a rectangular Kraus
  family represents the trace adjoint in `Channel/KrausCPTP.lean`, use it for the
  direct-sum adjoint, and record pointwise positivity beside the direct-sum Kraus
  predicate.
- Generalize the corresponding blueprint definition and document these laws.

This pull request deliberately does not prove the rectangular Schwarz equality step,
multiplicativity, the permutation of simple summands, equality of the block dimensions,
blockwise unitary implementation, or the transported MPDO classification. Thus it does
not close issue LionSR/QICLean#247.

### Testing

- `lake exe cache get`
- `lake env lean TNLean/Channel/KrausCPTP.lean`
- `lake env lean TNLean/Channel/FixedPoint/DirectSumKraus.lean`
- `lake env lean TNLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean`
- `lake build TNLean.Channel.FixedPoint.DirectSumKraus TNLean.Channel.FixedPoint.DirectSumTraceAdjoint TNLean.MPS.MPDO.VerticalSectorCompletePositivity TNLean.MPS.MPDO.VerticalSectorIdentity`
- `lake build`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `leanblueprint checkdecls`
- `git diff --check`
- proof-integrity scan of the changed Lean files

Addresses LionSR/QICLean#247

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalization and library lemmas in channel/fixed-point theory with no runtime or security surface; scope is additive proof infrastructure ahead of MPDO classification.
> 
> **Overview**
> Adds the **rectangular** trace adjoint for linear maps between two finite direct sums of matrix algebras (`directSumTraceAdjointMapBetween`), with the defining block-trace pairing identity and functorial laws (identity, reversed composition, agreement with the existing endomorphic adjoint, unitality under trace preservation).
> 
> At the Kraus level, proves **`IsKrausCP.traceAdjointMap`** (adjoint Kraus operators are conjugate-transposes) and lifts this to direct sums via compatibility with `directSumMapExtension`, yielding **CP of the adjoint** and a new **pointwise PosSemidef** lemma for `IsKrausDirectSumMap`. Wires the module into `TNLean.lean` and extends the blueprint definition/lemma for Appendix C.4 (1995–2003), explicitly **not** claiming the full classification (Schwarz, multiplicativity, block relabeling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 941824509d28a1e2260107497a150d02ab54cbbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->