### PR TITLE
feat(MPS/RFP): prove minimal Beigi loop injectivity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -632,7 +632,7 @@ import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BeigiSectorGraph
 import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
-import TNLean.MPS.RFP.BeigiLoopSchmidtSupport
+import TNLean.MPS.RFP.BeigiLoopInjectivity
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 -- Layer 6a: Quantum Wielandt span-growth infrastructure

--- a/TNLean/MPS/RFP/BeigiLoopInjectivity.lean
+++ b/TNLean/MPS/RFP/BeigiLoopInjectivity.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixAux
+import TNLean.MPS.RFP.BeigiLoopSchmidtSupport
+
+/-!
+# Injectivity of the minimal Beigi loop tensor
+
+The rank factors of a loop bond coefficient matrix span its Schmidt support.
+Their pairwise outer products are the letters of the minimal loop tensor, so
+these letters span the full matrix algebra.  Thus the coordinate tensor and
+its physical unitary rotation are injective, and the latter is normal.
+
+This module makes no normalization or transfer-idempotence assertion and does
+not identify the loop tensors with the basis of normal tensors of the original
+tensor.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Section IV, equation (10) and the paragraph following it.
+-/
+
+open scoped BigOperators Kronecker Matrix
+
+namespace Matrix
+
+/-- Pairwise outer products of two spanning vector families span the full
+matrix space. -/
+private theorem span_range_vecMulVec_eq_top
+    {ι κ n : Type*} [Finite n]
+    (u : ι → n → ℂ) (v : κ → n → ℂ)
+    (hu : Submodule.span ℂ (Set.range u) = ⊤)
+    (hv : Submodule.span ℂ (Set.range v) = ⊤) :
+    Submodule.span ℂ
+      (Set.range fun p : ι × κ ↦ Matrix.vecMulVec (u p.1) (v p.2)) = ⊤ := by
+  classical
+  letI := Fintype.ofFinite n
+  let S := Submodule.span ℂ
+    (Set.range fun p : ι × κ ↦ Matrix.vecMulVec (u p.1) (v p.2))
+  have hright (i : ι) : ∀ y ∈ Submodule.span ℂ (Set.range v),
+      Matrix.vecMulVec (u i) y ∈ S := by
+    intro y hy
+    induction hy using Submodule.span_induction with
+    | mem y hy =>
+        obtain ⟨j, rfl⟩ := hy
+        exact Submodule.subset_span ⟨(i, j), rfl⟩
+    | zero => simp
+    | add x y _ _ hx hy =>
+        simpa only [Matrix.vecMulVec_add] using S.add_mem hx hy
+    | smul c x _ hx =>
+        simpa only [Matrix.vecMulVec_smul] using S.smul_mem c hx
+  have houter : ∀ x ∈ Submodule.span ℂ (Set.range u),
+      ∀ y ∈ Submodule.span ℂ (Set.range v),
+        Matrix.vecMulVec x y ∈ S := by
+    intro x hx
+    induction hx using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨i, rfl⟩ := hx
+        exact hright i
+    | zero =>
+        intro y _
+        simp
+    | add x y _ _ hx hy =>
+        intro z hz
+        simpa only [Matrix.add_vecMulVec] using S.add_mem (hx z hz) (hy z hz)
+    | smul c x _ hx =>
+        intro y hy
+        simpa only [Matrix.smul_vecMulVec] using S.smul_mem c (hx y hy)
+  refine (Submodule.eq_top_iff_forall_basis_mem (Matrix.stdBasis ℂ n n)).2 ?_
+  rintro ⟨i, j⟩
+  have hi : Pi.single i (1 : ℂ) ∈ Submodule.span ℂ (Set.range u) := by
+    rw [hu]
+    exact Submodule.mem_top
+  have hj : Pi.single j (1 : ℂ) ∈ Submodule.span ℂ (Set.range v) := by
+    rw [hv]
+    exact Submodule.mem_top
+  rw [Matrix.stdBasis_eq_single, Matrix.single_eq_single_vecMulVec_single]
+  exact houter _ hi _ hj
+
+end Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A unitary change of physical coordinates preserves one-site
+injectivity. -/
+private theorem isInjective_rotatePhysical (A : MPSTensor d D)
+    (u : Matrix (Fin d) (Fin d) ℂ) (hu : u * uᴴ = 1)
+    (hA : IsInjective A) :
+    IsInjective (rotatePhysical u A) := by
+  classical
+  have hstar : uᴴ * u = 1 := mul_eq_one_comm.mp hu
+  have hletter (j : Fin d) :
+      A j = ∑ i : Fin d, (uᴴ) j i • rotatePhysical u A i := by
+    have hentry (k : Fin d) :
+        ∑ i : Fin d, (uᴴ) j i * u i k = if j = k then 1 else 0 := by
+      have h := congrArg (fun M : Matrix (Fin d) (Fin d) ℂ ↦ M j k) hstar
+      simpa [Matrix.mul_apply, Matrix.one_apply] using h
+    simp only [rotatePhysical_apply]
+    simp_rw [Finset.smul_sum, smul_smul]
+    rw [Finset.sum_comm]
+    simp_rw [← Finset.sum_smul, hentry]
+    simp
+  rw [IsInjective, eq_top_iff]
+  intro M _
+  have hM : M ∈ Submodule.span ℂ (Set.range A) := hA ▸ Submodule.mem_top
+  apply (Submodule.span_le.mpr ?_) hM
+  rintro _ ⟨j, rfl⟩
+  rw [hletter]
+  exact Submodule.sum_mem _ fun i _ ↦
+    Submodule.smul_mem _ _ (Submodule.subset_span ⟨i, rfl⟩)
+
+namespace BeigiSectorGraphData
+
+open FiniteWeightedDigraph
+
+variable {A : MPSTensor d D}
+
+private theorem loopSchmidtFactorization_rightFactor_rank
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    (F.loopSchmidtFactorization l).rightFactor.rank =
+      F.loopSchmidtRank l := by
+  apply le_antisymm
+  · exact Matrix.rank_le_width _
+  · have h := Matrix.rank_mul_le_left
+      (F.loopSchmidtFactorization l).rightFactor
+      (F.loopSchmidtFactorization l).leftFactor
+    rw [(F.loopSchmidtFactorization l).mul_eq] at h
+    simpa [loopSchmidtRank, Matrix.schmidtRank] using h
+
+private theorem loopSchmidtFactorization_leftFactor_rank
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    (F.loopSchmidtFactorization l).leftFactor.rank =
+      F.loopSchmidtRank l := by
+  apply le_antisymm
+  · exact Matrix.rank_le_height _
+  · have h := Matrix.rank_mul_le_right
+      (F.loopSchmidtFactorization l).rightFactor
+      (F.loopSchmidtFactorization l).leftFactor
+    rw [(F.loopSchmidtFactorization l).mul_eq] at h
+    simpa [loopSchmidtRank, Matrix.schmidtRank] using h
+
+/-- The sector-coordinate loop tensor is injective on its Schmidt support.
+
+The rank factors have maximal possible rank on their common Schmidt index.
+Their columns and rows therefore span that index space, so their outer
+products span the full matrix algebra.
+
+Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+and Section IV, equation (10) and the paragraph following it.  The
+Schmidt-support consequence is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem minimalLoopCoordinateTensor_isInjective
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    IsInjective (F.minimalLoopCoordinateTensor l) := by
+  classical
+  have hleft : Submodule.span ℂ
+      (Set.range (F.loopSchmidtFactorization l).leftFactor.col) = ⊤ := by
+    apply Submodule.eq_top_of_finrank_eq
+    rw [← Matrix.rank_eq_finrank_span_cols,
+      F.loopSchmidtFactorization_leftFactor_rank l]
+    simp
+  have hright : Submodule.span ℂ
+      (Set.range (F.loopSchmidtFactorization l).rightFactor.row) = ⊤ := by
+    apply Submodule.eq_top_of_finrank_eq
+    rw [← Matrix.rank_eq_finrank_span_row,
+      F.loopSchmidtFactorization_rightFactor_rank l]
+    simp
+  have houter := Matrix.span_range_vecMulVec_eq_top
+    (F.loopSchmidtFactorization l).leftFactor.col
+    (F.loopSchmidtFactorization l).rightFactor.row hleft hright
+  rw [IsInjective, eq_top_iff]
+  intro M _
+  have hM : M ∈ Submodule.span ℂ
+      (Set.range fun p : Fin (F.leftDim l.1) × Fin (F.rightDim l.1) ↦
+        Matrix.vecMulVec
+          ((F.loopSchmidtFactorization l).leftFactor.col p.1)
+          ((F.loopSchmidtFactorization l).rightFactor.row p.2)) := by
+    rw [houter]
+    exact Submodule.mem_top
+  apply (Submodule.span_le.mpr ?_) hM
+  rintro _ ⟨⟨a, q⟩, rfl⟩
+  have hletter := F.minimalLoopCoordinateTensor_sector_apply l q a
+  have hmem : F.minimalLoopCoordinateTensor l
+        (F.sectorEquiv ⟨l.1, (q, a)⟩) ∈
+      Submodule.span ℂ (Set.range (F.minimalLoopCoordinateTensor l)) :=
+    Submodule.subset_span ⟨F.sectorEquiv ⟨l.1, (q, a)⟩, rfl⟩
+  rw [hletter] at hmem
+  exact hmem
+
+/-- The physical loop tensor is injective on its Schmidt support.
+
+Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+and Section IV, equation (10) and the paragraph following it.  The physical
+unitary preserves the one-site spanning property. -/
+theorem minimalLoopTensor_isInjective
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    IsInjective (F.minimalLoopTensor l) := by
+  rw [minimalLoopTensor]
+  apply isInjective_rotatePhysical _ F.unitary
+  · simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.mul_star_self_of_mem F.unitary_mem
+  · exact F.minimalLoopCoordinateTensor_isInjective l
+
+/-- The physical loop tensor is normal on its Schmidt support.
+
+Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+and Section IV, equation (10) and the paragraph following it.  This is the
+one-site-injective consequence only; no normalization or transfer identity is
+asserted. -/
+theorem minimalLoopTensor_isNormal
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    IsNormal (F.minimalLoopTensor l) :=
+  (F.minimalLoopTensor_isInjective l).isNormal
+
+end BeigiSectorGraphData
+
+end MPSTensor

--- a/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
+++ b/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
@@ -175,6 +175,44 @@ noncomputable def minimalLoopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : MPSTensor d (F.loopSchmidtRank l) :=
   rotatePhysical F.unitary (F.minimalLoopCoordinateTensor l)
 
+/-- At a coordinate in the loop sector, the minimal tensor letter is the
+outer product of a column of the left rank factor and a row of the right rank
+factor.
+
+Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+and Section IV, equation (10) and the paragraph following it.  The
+Schmidt-support refinement is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem minimalLoopCoordinateTensor_sector_apply
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    (q : Fin (F.rightDim l.1)) (a : Fin (F.leftDim l.1)) :
+    F.minimalLoopCoordinateTensor l
+        (F.sectorEquiv ⟨l.1, (q, a)⟩) =
+      Matrix.vecMulVec
+        ((F.loopSchmidtFactorization l).leftFactor.col a)
+        ((F.loopSchmidtFactorization l).rightFactor.row q) := by
+  classical
+  have hsite :
+      F.sectorEquiv.symm (F.sectorEquiv ⟨l.1, (q, a)⟩) =
+        ⟨l.1, (q, a)⟩ :=
+    Equiv.symm_apply_apply F.sectorEquiv _
+  have hq :
+      (F.sectorEquiv.symm (F.sectorEquiv ⟨l.1, (q, a)⟩)).1 = l.1 :=
+    congrArg Sigma.fst hsite
+  have hright :
+      Fin.cast (congrArg F.rightDim hq)
+          (F.sectorEquiv.symm (F.sectorEquiv ⟨l.1, (q, a)⟩)).2.1 = q := by
+    apply Fin.ext
+    simpa only [Fin.val_cast] using congrArg (fun z ↦ z.2.1.val) hsite
+  have hleft :
+      Fin.cast (congrArg F.leftDim hq)
+          (F.sectorEquiv.symm (F.sectorEquiv ⟨l.1, (q, a)⟩)).2.2 = a := by
+    apply Fin.ext
+    simpa only [Fin.val_cast] using congrArg (fun z ↦ z.2.2.val) hsite
+  ext α β
+  simp [minimalLoopCoordinateTensor, Matrix.mul_apply, loopSchmidtBridge,
+    hright, hleft, Matrix.vecMulVec_apply]
+
 /-- Each ambient loop letter is the rectangular Schmidt-support letter
 followed by the left factor of the bond coefficient matrix.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2584,6 +2584,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.loopSchmidtFactorization}
     \lean{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor}
     \lean{MPSTensor.BeigiSectorGraphData.minimalLoopTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor_sector_apply}
     \leanok
     \uses{def:beigi_loop_product_state}
     Let $\Phi_a=(\varphi_a(r,l))_{r,l}$ and write
@@ -2615,6 +2616,27 @@ specialization of that Appendix~D definition.
     If $r_a=0$, then the intermediate index set in the factorization
     $\Phi_a=X_aY_a$ is empty.  Every entry of $X_aY_a$ is therefore zero,
     contrary to $\varphi_a\ne0$.
+\end{proof}
+
+\begin{theorem}[Injectivity of the minimal Beigi loop tensor]
+    \label{thm:beigi_minimal_loop_tensor_injective}
+    \lean{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor_isInjective}
+    \lean{MPSTensor.BeigiSectorGraphData.minimalLoopTensor_isInjective}
+    \lean{MPSTensor.BeigiSectorGraphData.minimalLoopTensor_isNormal}
+    \leanok
+    \uses{def:beigi_loop_schmidt_support, def:injective, def:normal}
+    The tensor $\widetilde C_a$ on the Schmidt support is injective, as is its
+    image under the one-site unitary.  In particular, the physical tensor is
+    normal.
+\end{theorem}
+
+\begin{proof}\leanok
+    In a rank factorization $\Phi_a=X_aY_a$ through
+    $r_a=\rank\Phi_a$, the columns of $Y_a$ and the rows of $X_a$ each span
+    $\C^{r_a}$.  Their pairwise outer products therefore span
+    $M_{r_a}(\C)$, and these outer products are precisely the loop-sector
+    letters of $\widetilde C_a$.  A unitary change of physical coordinates preserves
+    this span.  One-site injectivity implies normality.
 \end{proof}
 
 \begin{theorem}[Periodic vector of a positive Beigi loop]

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -342,10 +342,19 @@ space to $\C^{r_a}$.  Their letters are
 $(Y_a)_{\alpha,l}(X_a)_{r,\beta}$, and
 \leanid{MPSTensor.BeigiSectorGraphData.mpv_minimalLoopTensor} proves that this
 restriction leaves every positive-length periodic vector equal to Beigi's
-product-of-pairs vector.  No injectivity, normality, or normalization condition
-is imposed on these tensors at this stage.  Consequently, the spanning
-statement below may equivalently be formulated using the periodic vectors of
-the minimal Schmidt-support tensors.
+product-of-pairs vector.  Exactness of the rank factorization shows that the
+columns of $Y_a$ and the rows of $X_a$ span $\C^{r_a}$.  Their outer products
+are the letters of the minimal tensor, and hence
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{minimalLoopCoordinateTensor_isInjective} proves one-site
+injectivity.  The one-site unitary preserves this spanning property, giving
+\leanid{MPSTensor.BeigiSectorGraphData.minimalLoopTensor_isInjective} and the
+normality conclusion
+\leanid{MPSTensor.BeigiSectorGraphData.minimalLoopTensor_isNormal}.
+No normalization, transfer-idempotence, or identification with the original
+basis of normal tensors is asserted at this stage.  Consequently, the
+spanning statement below may equivalently be formulated using the periodic
+vectors of the minimal Schmidt-support tensors.
 
 For every $N\geq2$,
 \leanid{MPSTensor.BeigiSectorGraphData.}


### PR DESCRIPTION
## Summary

This PR proves that Beigi's loop tensor becomes one-site injective after restricting its virtual space to the exact Schmidt support of the loop bond vector.

- expose the loop-sector coordinate formula for the minimal Schmidt-support tensor;
- prove that its letters span the full matrix algebra;
- prove that the physical unitary rotation remains injective;
- deduce normality from one-site injectivity;
- record the result in the blueprint and the existing CPSV16/Beigi scope note.

This is a focused contribution toward #4423.

## Mathematical argument

For a loop bond coefficient matrix `Phi_a`, choose the existing exact rank factorization
`Phi_a = X_a Y_a`, with `r_a = rank(Phi_a)`. Since the intermediate dimension is
`r_a`, the rows of `X_a` and the columns of `Y_a` both span the
`r_a`-dimensional complex vector space. Their pairwise outer products are the
loop-sector letters and span the full `r_a × r_a` matrix algebra. The physical
unitary preserves this letter span. Hence the minimal coordinate tensor and
physical tensor are injective, and the physical tensor is normal.

## Source boundary

Beigi, arXiv:1105.1019v2, Section III, p. 4 gives the MPS observation; Section IV, equation (10) and the following paragraph give the one-dimensional cyclic edge kernels and loop product vectors. Beigi does **not** state this injectivity theorem. The theorem proved here is a Schmidt-support consequence of that construction, as recorded in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.

An independent mathematical and source-faithfulness audit found no blocking issue. It confirmed the rank-factor argument and the distinction between Beigi's source statement and the formal Schmidt-support consequence.

## Explicit exclusions

This PR does not assert or prove:

- normalization of the loop tensor;
- transfer-map idempotence;
- identification with the original basis of normal tensors;
- removal of any axiom.

## Validation

- `lake env lean TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean`
- `lake env lean TNLean/MPS/RFP/BeigiLoopInjectivity.lean`
- `lake build TNLean.MPS.RFP.BeigiLoopInjectivity -q --log-level=info`
- `lake env lean TNLean.lean`
- `lake build TNLean -q --log-level=info`
- `lake exe lint_style`
- blueprint synchronization and changed-declaration coverage
- `lake exe checkdecls blueprint/lean_decls`
- reader-facing prose, oversized-file, proof-integrity, line-length, and `git diff --check` checks
- `chktex` on the changed blueprint chapter
- standalone compilation of the updated paper-gap note

The root import remains exactly 1000 lines and retains the newly merged `TNLean.Channel.FixedPoint.DirectSumTraceAdjoint` import.