### PR TITLE
docs(tenkz): migrate two-point correlator

### DIFF
--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -47,7 +47,27 @@ their spectral decomposition, and quantitative bounds on decay rates.
     Equivalently: insert $X$ at site $0$, propagate by $\E_A^n$, then insert
     $Y$ and take the trace.
     \begin{center}
-        \TNTwoPointCorrelator
+        % Formula: \langle X_0Y_n\rangle
+        %   = \tr\!\left(Y\,\E_A^n(X\rho^R)\right).
+        % Source verdict: Cirac2021Matrix, Section II.B.3, supports the
+        % correlator discussion but supplies no dedicated picture of this
+        % contraction; the displayed definition is authoritative here.
+        % For composite indices a=(k,l) and b=(i,j), the doubled map carries
+        % (\E_A^n)_{ij,kl}; the east cup supplies (X\rho^R)_{kl}, and the
+        % west cup contracts Y_{ji} with the output.  Thus the ink denotes
+        % \sum_{i,j,k,l}Y_{ji}(\E_A^n)_{ij,kl}(X\rho^R)_{kl}.
+        % The east cup is the applied-channel input; reading from the west
+        % instead feeds the adjoint and gives the same trace pairing with Y.
+        % Boundary signature: (virtual-west=0 | virtual-east=0 |
+        % physical-up=0 | physical-down=0).
+        \begin{tenkz}[
+            sandwich,
+            west={cup=$Y$},
+            east={cup=$X\rho^R$}
+        ]
+            \tnghost{} & \tnX[wires=2]{\E_A^n} & \tnghost{} \\
+            \tnghost{} & & \tnghost{}
+        \end{tenkz}
     \end{center}
 \end{definition}
 

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -157,7 +157,7 @@ Note: the 7 hand-digitized region polygons inside `tn_motifs_peps.tex` all becom
 | TNStinespring | ch16_channel_representations:697 | `[sandwich, west label=$\rho$, east label=$\tr_E[V\rho V^\dagger]$]: \tn{V} \\ \tn*{V}` | trivial (K5 `pair label=$E$` optional) |
 | TNChoiMatrix | ch16_channel_representations:108 | `[sandwich, close west={$\Omega$}]: \tn{T} \\ \tn{\mathrm{id}}` | trivial (0.6 bare identity-wire atom would let `id` be a plain wire) |
 | TNTransferMapTracePairing | ch16_channel_representations:1478 | demote: `T(\rho)=\sum_{ij}t_{ij}\tr(\sigma_j\rho)\,\sigma_i` (+ optional `\tnpic[inline, periodic]{\tnX{\sigma_j}&\tnX{\rho}}` for the trace loop) | needs-judgment (candidate demotion to plain math) |
-| TNTwoPointCorrelator | ch14_correlations:50 | `[periodic]: \tn{\rho^R} & \tnX{X} & \tn{\mathcal E_A^n} & \tnX{Y}` (trace loop = periodic) | trivial |
+| TNTwoPointCorrelator | ch14_correlations:50 | `[sandwich, west={cup=$Y$}, east={cup=$X\rho^R$}]` with `\tnX[wires=2]{\mathcal E_A^n}` between ghost anchors | trivial (a doubled-index map between input and trace-pairing cups; not a periodic word) |
 
 ### 5b. Free tier (irregular graphs, stars, projector chains)
 

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -1018,19 +1018,4 @@
     \end{TNDiagram}%
 }
 
-% Two-point correlator <X_0 Y_n> = tr(Y E_A^n(X rho^R)): on the transfer-map
-% (M_D) line, start from the fixed point rho^R, insert X, propagate by n copies
-% of the transfer map E_A, insert Y, and close the line by the trace.
-\TNDeclareDiagram
-    {TNTwoPointCorrelator}
-    {}
-    {display}
-    {normal}
-    {\TNTwoPointCorrelator}
-    {chapter/ch14_correlations.tex}{%
-    \begin{TNDiagram}[normal]
-        \TNTwoPointCorrelatorMotif
-    \end{TNDiagram}%
-}
-
 \makeatother

--- a/tex/tn/tn_motifs_peps.tex
+++ b/tex/tn/tn_motifs_peps.tex
@@ -765,23 +765,5 @@
         \TN@motiflabelright{tnClientLabel2176}{(4.15,0)}{=T(\rho)}
 }
 
-% TNTwoPointCorrelator
-\newcommand{\TNTwoPointCorrelatorMotif}{%
-        \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNTwoPointCorrelator|kind=correlator}%
-        \TNComponent{coR}{(0,0)}{\rho^R}
-        \TNInsertion{coX}{(1.05,0)}{}
-        \TNMap{coE}{(2.3,0)}{\E_A^n}
-        \TNInsertion{coY}{(3.55,0)}{}
-        \TNVirtualPort{coRTocoX}{coR}{east}\TNVirtualPort{coXTocoR}{coX}{west}\TNConnectVirtual{coRTocoX}{coXTocoR}
-        \TNVirtualPort{coXTocoE}{coX}{east}\TNVirtualPort{coETocoX}{coE}{west}\TNConnectVirtual{coXTocoE}{coETocoX}
-        \TNVirtualPort{coETocoY}{coE}{east}\TNVirtualPort{coYTocoE}{coY}{west}\TNConnectVirtual{coETocoY}{coYTocoE}
-        \TN@motiflabel{tnClientLabel2192}{(1.05,0.28)}{X}
-        \TN@motiflabel{tnClientLabel2193}{(3.55,0.28)}{Y}
-        \TNVirtualPort{coRTrace}{coR}{west}
-        \TNVirtualPort{coYTrace}{coY}{east}
-        \TNTraceVirtualBelow{coRTrace}{coYTrace}
-        \TN@motiflabel{tnClientLabel2197}{(1.8,-1.08)}{\tr}
-}
-
 \makeatother
 \endinput


### PR DESCRIPTION
## Summary

- replace the legacy one-line correlator sketch with the faithful doubled-index contraction
- show the east input cup as $X\rho^R$, the central two-rail map as $\mathcal E_A^n$, and the west trace pairing as $Y$
- keep the result scalar, with boundary signature `(0, 0, 0, 0)`
- remove the sole-use catalogue declaration and dead motif helper, and correct the migration-map entry

The inline source records the exact index contraction
\[
\sum_{i,j,k,l}Y_{ji}(\mathcal E_A^n)_{ij,kl}(X\rho^R)_{kl}
=\operatorname{tr}\!\left(Y\mathcal E_A^n(X\rho^R)\right).
\]
The cited source supports the correlator discussion but does not supply a dedicated diagram, so the displayed definition is authoritative. In particular, this is not a periodic word or an ellipsis-based surrogate.

## Validation

- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch14_correlations.tex tex/tn/tn_catalogue.tex tex/tn/tn_motifs_peps.tex` — 0 findings
- `python3 scripts/test_tenkz_face_ports.py` — pass
- `python3 scripts/check_tn_references.py --margins-only` — pass
- `leanblueprint pdf` — pass, 695 pages; affected PDF page 351 / printed page 350 visually inspected
- `leanblueprint web` — completed; `tenkz-dce878849c1a6d03.svg` visually inspected after rasterization
- target event audit — two west/east rail bonds and scalar boundary `(0, 0, 0, 0)`
- `git diff --check` — clean

Repository-wide reference modes retain their existing baseline failures: seven approved-reference raster drifts in default comparison mode, and `TNPEPSLatticeState` contains no visible ink in `--all-registered --margins-only`. The full blueprint audit likewise reports inherited legacy-dialect advisories, while the changed picture has no local advisory. The web build exits successfully despite the known environment-level `leanblueprint` module-loader diagnostics.

Closes LionSR/TNLean#4469.

Parent tracking issue LionSR/tenkz#20 remains open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-shim cleanup only; no Lean, runtime, or security-sensitive code paths change.
> 
> **Overview**
> **Migrates the two-point expectation figure** in `ch14_correlations` from the legacy `\TNTwoPointCorrelator` catalogue macro to an inline **tenkz** `sandwich` layout that matches the doubled-index formula \(\mathrm{tr}(Y\,\mathcal E_A^n(X\rho^R))\).
> 
> The new ink uses west cup \(Y\), east cup \(X\rho^R\), and a central two-rail \(\mathcal E_A^n\) glyph between ghost anchors, with comments documenting the index contraction and scalar boundary signature. **Removes** the sole-use `\TNDeclareDiagram` entry and the unused `\TNTwoPointCorrelatorMotif` helper, and **updates** `MIGRATION-MAP.md` so the channel-spelling row reflects the sandwich spelling (not a periodic MPS word).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef76ef9110e048bc76bfd68589b68105a91f4e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->