### PR TITLE
docs(tenkz): migrate physical linear twist

### DIFF
--- a/blueprint/src/chapter/ch12_symmetry.tex
+++ b/blueprint/src/chapter/ch12_symmetry.tex
@@ -167,11 +167,18 @@ on the bond space.
 \begin{proof}\leanok\uses{lem:gauge_equiv_twisted}
     The physical action is transferred to the virtual level by the same
     local move that replaces the twisted tensor by a gauge-conjugated one:
-    % Use a physical-leg operator insertion for the
-    % linear twist \widetilde{A}_g^{\,i} = \sum_j U(g)_{ij}\, A^j rather
-    % than the relabelling-only permutation-twist glyph.
+    % Formula: (\widetilde A_g^i)_{ab}=\sum_j U(g)_{ij}(A^j)_{ab}.
+    % Source verdict: U(g) acts only on the physical index of A and has
+    % no virtual indices.
+    % Index map: i is the free upper physical index, j is the unique
+    % contracted index, and a,b are the free west/east virtual indices.
+    % Boundary: virtual-west=1 | virtual-east=1 | physical-up=1 |
+    % physical-down=0.
     \begin{center}
-        \TNLinearTwist{U(g)}{i}
+        \begin{tenkz}[rows={op:none,ket}]
+            \tn[role=operator,up=$i$]{U(g)} \\
+            \tn{A}
+        \end{tenkz}
         \qquad $\leadsto$ \qquad
         \TNGaugeConjugation{X(g)}{i}{X(g)^{-1}}
     \end{center}

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -213,7 +213,7 @@ Note: the 7 hand-digitized region polygons inside `tn_motifs_peps.tex` all becom
 | entry | call site | tenkz spelling sketch | risk |
 |---|---|---|---|
 | TNPhysicalRealization | ch23_algebraic_ft:188 | `\tnpic[physical=up]{\tn{A}&\tnX{X}} = \tnpic[rows={op,ket}]{\tn{O_A(X)}\\ \tn{A}}` | trivial |
-| TNLinearTwist | ch12_symmetry:153 | `[rows={op,ket}]: \tn[up=$i$]{u} \\ \tn{A}` | trivial |
+| TNLinearTwist | ch12_symmetry:153 | `[rows={op:none,ket}]: \tn[role=operator,up=$i$]{U(g)} \\ \tn{A}` | trivial (`op:none` is required because $U(g)$ has no virtual legs) |
 | TNPermutationTwist | ch12_symmetry:549 | fold into the `\tndefine`d PermutationTwistLabeled with $\sigma_g$ | trivial |
 | TNTwistedTransfer | ch12_symmetry:616 | `[rows={ket,op,bra}, west label=$X$, east label=$\mathcal E_u(X)$]: \tn{A^{(n)}} \\ \tn{u} \\ \tn*{A^{(n')}}` | trivial |
 | TNStringOrderParameter | ch12_symmetry:634 | `[rows={ket,op,bra}]` word with `\tnghost` end cells in the op row, `\tndots`, length brace $L$ | trivial |

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -343,26 +343,6 @@
     \end{TNDiagram}%
 }
 
-% Fix (#401): use a dedicated physical-leg operator insertion for
-% general linear twists, and keep permutation twists for index relabellings.
-\TNDeclareDiagram
-    {TNLinearTwist}
-    {twist,label}
-    {display}
-    {normal}
-    {\TNLinearTwist{u}{i}}
-    {chapter/ch12_symmetry.tex}{%
-    \begin{TNDiagram}[normal]
-        \TNMPSSite{tnA}{at=origin}{}
-        \TNOpenVirtualWest{tnAWest}
-        \TNOpenVirtualEast{tnAEast}
-        \TNInsertion{tnu}{above=of tnA}{#1}
-        \TNPhysicalPort{tnuTotnA}{tnu}{south}
-        \TNConnectPhysical{tnAKet}{tnuTotnA}
-        \TNLabelAbove{tnu.north}{#2}
-    \end{TNDiagram}%
-}
-
 % Fix (#401): make the relabelling arrow explicit so multi-step
 % permutation diagrams can distinguish \sigma_h from \sigma_g.
 \TNDeclareDiagram


### PR DESCRIPTION
Closes #4470.

## Summary

- inline the physical linear action as a two-row `tenkz` diagram
- seal the operator row with `op:none`, so `U(g)` carries no virtual legs
- retain the adjacent gauge-conjugation diagram unchanged
- remove the obsolete `TNLinearTwist` catalogue declaration
- correct the migration inventory so it no longer recommends the ill-typed `rows={op,ket}` spelling

## Mathematical contract

The diagram represents

\[
(\widetilde A_g^i)_{ab}=\sum_j U(g)_{ij}(A^j)_{ab}.
\]

The upper physical index \(i\) and the west/east virtual indices \(a,b\) remain free. The unique vertical pairleg contracts \(j\). The emitted trace records exactly two atoms, one pairleg, and

`boundary|virtual-west=1|virtual-east=1|physical-up=1|physical-down=0`.

This agrees with the external type of the unchanged gauge-conjugation diagram.

## Source fidelity

The construction follows the twisted-tensor definition in Chapter 12 and `TNLean/MPS/Symmetry/Defs.lean`. It preserves the correction from #401 / PR #644: a general physical linear action is an operator insertion, not a permutation relabelling. Pérez-García et al., `Papers/0802.0447/StringOrder-v10.tex`, Figure 1 and equation `EU`, place \(U(g)\) on the physical index and the gauge operators on the virtual indices.

## Validation

- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch12_symmetry.tex`
- `python3 scripts/tenkz_audit.py blueprint/print/print.tnlog` — no hard errors
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/check_tn_references.py --margins-only`
- `git diff --check`
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- verified the prohibited handoff phrase has zero occurrences
- visually inspected PDF page 190 and `web/tenkz_svg/tenkz-12478551100a2ed4.svg`: one physical contraction, no virtual legs on \(U(g)\), no clipping, and clean alignment with the gauge diagram

The full mixed legacy/tenkz event stream reports existing advisory-only dialect noise; the new picture itself has the exact trace stated above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-catalog migration only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Migrates the Chapter 12 physical linear-twist figure** from `\TNLinearTwist` to an inline `tenkz` grid: `U(g)` on an operator row sealed with `op:none` (no virtual legs) above the MPS tensor `A`, matching \((\widetilde A_g^i)_{ab}=\sum_j U(g)_{ij}(A^j)_{ab}\). The proof still hands off to the unchanged `\TNGaugeConjugation` diagram.
> 
> **Housekeeping:** deletes the `\TNDeclareDiagram{TNLinearTwist}` block from `tn_catalogue.tex` and updates `MIGRATION-MAP.md` so the recommended spelling uses `rows={op:none,ket}` instead of the ill-typed `rows={op,ket}` variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ca4cee2ddaa6c505e1c496a7904dc4bb6b4d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->