### PR TITLE
docs(tenkz): migrate Kraus channel contraction

### DIFF
--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -464,7 +464,28 @@ A Kraus representation writes the channel as
 $T(\rho)=\sum_i K_i\rho K_i^\dagger$. In tensor-network form the Kraus index $i$
 is summed between the $K_i$ layer and the $K_i^\dagger$ layer:
 \begin{center}
-    \TNKrausMap
+    % Formula: T(\rho)=\sum_i K_i\rho K_i^\dagger.
+    % Source verdict: Wolf, Theorem 2.1 and Equation (2.8), gives the Kraus
+    %   formula but no dedicated figure; that formula is authoritative here.
+    % In indices, T(\rho)_{ab}
+    %   =\sum_{i,c,d}(K_i)_{ac}\rho_{cd}\overline{(K_i)_{bd}}.
+    % The sandwich pairleg contracts the unique Kraus index i.  Its upper
+    %   node is K_i and its lower node is the conjugate \overline{K_i}; reading
+    %   the lower wire from the east input toward the west output supplies the
+    %   transpose, hence K_i^\dagger in the matrix product.
+    % The east cup contracts the input indices c,d against \rho.  The west
+    %   pair carries the free output indices a,b, so reversing the picture
+    %   would instead feed the adjoint channel.
+    % Boundary signature: (virtual-west=2 | virtual-east=0 |
+    % physical-up=0 | physical-down=0).
+    \begin{tenkz}[
+        sandwich,
+        east={cup=$\rho$},
+        west label=$T(\rho)$
+    ]
+        \tn{K_i} \\
+        \tn*{K_i}
+    \end{tenkz}
 \end{center}
 
 \begin{theorem}[Trace preservation implies Kraus normalization]\label{thm:kraus_sum_conjTranspose_mul_of_tp}

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -153,7 +153,7 @@ Note: the 7 hand-digitized region polygons inside `tn_motifs_peps.tex` all becom
 
 | entry | call site | tenkz spelling sketch | risk |
 |---|---|---|---|
-| TNKrausMap | ch16_channel_representations:417 | `[sandwich, west label=$\rho$, east label=$T(\rho)$]: \tn{K_i} \\ \tn*{K_i}` | trivial (K5 `pair label=$i$` optional) |
+| TNKrausMap | ch16_channel_representations:467 | `[sandwich, east={cup=$\rho$}, west label=$T(\rho)$]: \tn{K_i} \\ \tn*{K_i}` | source-faithful applied channel; exact boundary `(2,0,0,0)`, no package change |
 | TNStinespring | ch16_channel_representations:697 | `[sandwich, west label=$\rho$, east label=$\tr_E[V\rho V^\dagger]$]: \tn{V} \\ \tn*{V}` | trivial (K5 `pair label=$E$` optional) |
 | TNChoiMatrix | ch16_channel_representations:108 | `[sandwich, close west={$\Omega$}]: \tn{T} \\ \tn{\mathrm{id}}` | trivial (0.6 bare identity-wire atom would let `id` be a plain wire) |
 | TNTransferMapTracePairing | ch16_channel_representations:1478 | demote: `T(\rho)=\sum_{ij}t_{ij}\tr(\sigma_j\rho)\,\sigma_i` (+ optional `\tnpic[inline, periodic]{\tnX{\sigma_j}&\tnX{\rho}}` for the trace loop) | needs-judgment (candidate demotion to plain math) |

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -937,21 +937,6 @@
 
 % ---------- Quantum-channel representation diagrams ----------
 
-% Kraus representation T(rho) = sum_i K_i rho K_i^dagger as a double-layer
-% contraction: the Kraus index i is summed between the K_i (ket) and
-% K_i^dagger (bra) layers; rho enters on the left, T(rho) leaves on the right.
-\TNDeclareDiagram
-    {TNKrausMap}
-    {}
-    {display}
-    {compact}
-    {\TNKrausMap}
-    {chapter/ch16_channel_representations.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNKrausMapMotif
-    \end{TNDiagram}%
-}
-
 % Stinespring dilation T(rho) = tr_E[V rho V^dagger]: the isometry V and its
 % adjoint map the system into a larger space; the environment E is traced out
 % (the loop on the right), leaving the channel output T(rho) on the system legs.

--- a/tex/tn/tn_motifs_peps.tex
+++ b/tex/tn/tn_motifs_peps.tex
@@ -718,18 +718,6 @@
         \TN@motiflabel{tnClientLabel2114}{(2.35,0)}{\displaystyle\prod_{e \ni v} c_{v,e} = 1}
 }
 
-% TNKrausMap
-\newcommand{\TNKrausMapMotif}{%
-        \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNKrausMap|kind=quantum-channel}%
-        \TNStackedMPOProduct{kr}{(0,0)}{K_i}{K_i^\dagger}{i}
-        \TNOpenVirtualWest{krUpperWest}
-        \TNOpenVirtualWest{krLowerWest}
-        \TNOpenVirtualEast{krUpperEast}
-        \TNOpenVirtualEast{krLowerEast}
-        \TN@motiflabelleft{tnClientLabel2130}{(-0.70,0)}{\rho}
-        \TN@motiflabelright{tnClientLabel2131}{(0.70,0)}{T(\rho)}
-}
-
 % TNStinespring
 \newcommand{\TNStinespringMotif}{%
         \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNStinespring|kind=quantum-channel}%


### PR DESCRIPTION
Closes #4480.

Exact head: `6a8e7411c96c4a971b2a87affce75daf62f2a909`.

## Summary

- replace the legacy `\TNKrausMap` catalogue diagram with an inline `tenkz` applied-channel contraction
- orient the network as `T(\rho)=\sum_i K_i\rho K_i^\dagger`: input `\rho` on the east cup, output `T(\rho)` on the west pair, and a single shared Kraus-index pairleg
- remove the now-unused catalogue declaration and motif helper, and update the migration map

## Source fidelity

Wolf, Theorem 2.1 and Equation (2.8), supplies the authoritative formula but no dedicated figure. The inline source records the index contraction and explains why the lower conjugate layer, read from east to west, contributes the transpose required for `K_i^\dagger`.

The compiled event trace for the migrated diagram is:

```text
cup|picture=4|side=east|top=1|bottom=2|matrix=1
pairleg|picture=4|upper=1-1|lower=2-1|upper-port=center|column=1
boundary|picture=4|virtual-west=2|virtual-east=0|physical-up=0|physical-down=0
```

## Validation

- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch16_channel_representations.tex tex/tn/tn_catalogue.tex tex/tn/tn_motifs_peps.tex`
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/check_tn_references.py --margins-only`
- `python3 scripts/tenkz_audit.py blueprint/print/print.tnlog` (no hard errors; inherited advisories only)
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- `git diff --check`

Visually inspected PDF page 370 and generated SVG `tenkz-fb87fa7072a875eb.svg`; both show the same unclipped east-input/west-output Kraus sandwich.
