### PR TITLE
feat(MPS/RFP): normalize minimal Beigi loop tensors

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -630,7 +630,7 @@ import TNLean.MPS.RFP.BeigiSpatialDecomposition
 import TNLean.MPS.RFP.BeigiSectorGraph
 import TNLean.MPS.RFP.BeigiSectorGraphConstruction
 import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph
-import TNLean.MPS.RFP.BeigiLoopInjectivity
+import TNLean.MPS.RFP.BeigiLoopFixedPoint
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.BNTWeightCounterexample
 -- Layer 6a: Quantum Wielandt span-growth infrastructure

--- a/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
+++ b/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
@@ -25,8 +25,10 @@ length `N`, it multiplies Beigi's product-of-pairs vector by `‖φ‖₂⁻ᴺ`
   Hamiltonians*, arXiv:1105.1019v2, Section IV, source lines 602--606.
 * J. I. Cirac, D. Pérez-García, N. Schuch, and F. Verstraete, *Matrix product
   density operators: Renormalization fixed points and boundary theories*,
-  arXiv:1606.00608, equations `eq:basic-vectors-RFP-pure` and `eq:III_varphi`,
-  source lines 570--578.
+  arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, source
+  lines 543--555; equations `eq:basic-vectors-RFP-pure` and `eq:III_varphi`,
+  source lines 570--578; and the fixed-point normal-form derivation, source
+  lines 1293--1300.
 -/
 
 open scoped BigOperators ComplexOrder Kronecker Matrix Matrix.Norms.Frobenius
@@ -94,7 +96,8 @@ vector.  The normalized RFP representative divides by its Euclidean norm; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
+the fixed-point normal-form derivation, source lines 1293--1300. -/
 noncomputable def loopBondNorm (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : ℝ :=
   ‖(WithLp.toLp 2 (F.loopBondVector l) :
@@ -102,8 +105,9 @@ noncomputable def loopBondNorm (F : BeigiSectorGraphData A)
 
 /-- The Euclidean norm of a positive-loop bond vector is positive.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606.  The normalization
-correction is recorded in
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16, fixed-point
+normal-form derivation, source lines 1293--1300.  The normalization correction
+is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem loopBondNorm_pos (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : 0 < F.loopBondNorm l := by
@@ -112,8 +116,9 @@ theorem loopBondNorm_pos (F : BeigiSectorGraphData A)
 
 /-- The Euclidean norm of a positive-loop bond vector is nonzero.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606.  The normalization
-correction is recorded in
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16, fixed-point
+normal-form derivation, source lines 1293--1300.  The normalization correction
+is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem loopBondNorm_ne_zero (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : F.loopBondNorm l ≠ 0 :=
@@ -122,8 +127,9 @@ theorem loopBondNorm_ne_zero (F : BeigiSectorGraphData A)
 /-- The Euclidean norm of the loop bond vector is the Frobenius norm of its
 coefficient matrix.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606.  The normalization
-correction is recorded in
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16, fixed-point
+normal-form derivation, source lines 1293--1300.  The normalization correction
+is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem loopBondNorm_eq_frobeniusNorm (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) :
@@ -141,7 +147,9 @@ norm gives the normalized fixed-point representative; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
+the fixed-point normal-form derivation, source lines 1293--1300. -/
 noncomputable def normalizedMinimalLoopCoordinateTensor
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
     MPSTensor d (F.loopSchmidtRank l) :=
@@ -155,7 +163,9 @@ representative of Beigi's product-of-pairs tensor on its Schmidt support; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
+the fixed-point normal-form derivation, source lines 1293--1300. -/
 noncomputable def normalizedMinimalLoopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : MPSTensor d (F.loopSchmidtRank l) :=
   fun i ↦ ((F.loopBondNorm l : ℂ)⁻¹) • F.minimalLoopTensor l i
@@ -177,8 +187,11 @@ rank-one map on the virtual matrix algebra.
 rank factorization through the Schmidt support; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+Source context: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
+fixed-point normal-form derivation, source lines 1293--1300.  The rank-one
+formula itself is the local rank-factorization calculation recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem transferMap_minimalLoopCoordinateTensor
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
     (Z : Matrix (Fin (F.loopSchmidtRank l))
@@ -247,6 +260,45 @@ private theorem loopSchmidtGram_trace
       rw [(F.loopSchmidtFactorization l).mul_eq]
       rw [← F.loopBondNorm_eq_frobeniusNorm l]
 
+/-- Squaring the transfer map of the unnormalized minimal loop tensor gives
+the same map multiplied by the squared Euclidean bond norm.
+
+**Local fix (Schmidt support and normalization):** Beigi's chosen bond vector
+is nonzero but need not have unit norm.  Thus the raw transfer map is a scalar
+multiple of an idempotent rather than necessarily idempotent itself; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source context: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
+fixed-point normal-form derivation, source lines 1293--1300.  The scalar
+identity itself is the local rank-factorization calculation recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem transferMap_minimalLoopCoordinateTensor_comp_self
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    transferMap (F.minimalLoopCoordinateTensor l) ∘ₗ
+        transferMap (F.minimalLoopCoordinateTensor l) =
+      (((F.loopBondNorm l) ^ 2 : ℝ) : ℂ) •
+        transferMap (F.minimalLoopCoordinateTensor l) := by
+  apply LinearMap.ext
+  intro Z
+  simp only [LinearMap.comp_apply, LinearMap.smul_apply]
+  let Q := (F.loopSchmidtFactorization l).rightFactorᴴ *
+    (F.loopSchmidtFactorization l).rightFactor
+  let P := (F.loopSchmidtFactorization l).leftFactor *
+    (F.loopSchmidtFactorization l).leftFactorᴴ
+  have hformula (W : Matrix (Fin (F.loopSchmidtRank l))
+      (Fin (F.loopSchmidtRank l)) ℂ) :
+      transferMap (F.minimalLoopCoordinateTensor l) W =
+        Matrix.trace (Q * W) • P := by
+    simpa only [Q, P, Matrix.mul_assoc] using
+      F.transferMap_minimalLoopCoordinateTensor l W
+  have htrace : Matrix.trace (Q * P) =
+      (((F.loopBondNorm l) ^ 2 : ℝ) : ℂ) := by
+    simpa only [Q, P, Matrix.mul_assoc] using F.loopSchmidtGram_trace l
+  rw [hformula, hformula]
+  simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul, htrace,
+    smul_smul, mul_comm]
+
 /-- Euclidean normalization multiplies the rank-one transfer formula by the
 inverse squared bond norm.
 
@@ -255,7 +307,8 @@ norm of the bond vector, equivalently the Frobenius norm of its coefficient
 matrix; see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
+fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem transferMap_normalizedMinimalLoopCoordinateTensor
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
     (Z : Matrix (Fin (F.loopSchmidtRank l))
@@ -284,7 +337,8 @@ removes the factor `‖φ‖₂²` from the square of the raw rank-one transfer 
 see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
+fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopCoordinateTensor_isTransferIdempotent
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
     IsTransferIdempotent (F.normalizedMinimalLoopCoordinateTensor l) := by
@@ -323,7 +377,8 @@ physical coordinates; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
+fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopTensor_isTransferIdempotent
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
     IsTransferIdempotent (F.normalizedMinimalLoopTensor l) := by
@@ -345,7 +400,8 @@ nonzero inverse bond norm preserves one-site injectivity; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
+fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopTensor_isInjective
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
     IsInjective (F.normalizedMinimalLoopTensor l) := by
@@ -359,7 +415,8 @@ one-site injectivity of the normalized representative; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
+fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopTensor_isNormal
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
     IsNormal (F.normalizedMinimalLoopTensor l) :=
@@ -373,7 +430,9 @@ Euclidean bond norm at each site; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
-`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+`III_CFI_RFP` and `eq:III_isometry`, source lines 543--555,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
+the fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem mpv_normalizedMinimalLoopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
     mpv (F.normalizedMinimalLoopTensor l) s =

--- a/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
+++ b/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
@@ -1,0 +1,384 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.RFP.BeigiLoopInjectivity
+import TNLean.MPS.RFP.Defs
+import TNLean.MPS.SharedInfra.Scaling
+import TNLean.Spectral.FrobeniusNorm
+
+/-!
+# Transfer fixed point of a normalized Beigi loop tensor
+
+The minimal tensor associated with a nonzero Beigi loop need not itself have
+an idempotent transfer map.  If the loop bond vector is `φ`, its transfer map
+satisfies `E² = ‖φ‖₂² E`.  Dividing every tensor letter by the Euclidean norm
+of `φ` gives an injective normal tensor whose transfer map is idempotent.
+
+The normalization does not alter the associated ray of periodic vectors: at
+length `N`, it multiplies Beigi's product-of-pairs vector by `‖φ‖₂⁻ᴺ`.
+
+## References
+
+* S. Beigi, *Classification of the phases of 1D spin chains with commuting
+  Hamiltonians*, arXiv:1105.1019v2, Section IV, source lines 602--606.
+* J. I. Cirac, D. Pérez-García, N. Schuch, and F. Verstraete, *Matrix product
+  density operators: Renormalization fixed points and boundary theories*,
+  arXiv:1606.00608, equations `eq:basic-vectors-RFP-pure` and `eq:III_varphi`,
+  source lines 570--578.
+-/
+
+open scoped BigOperators ComplexOrder Kronecker Matrix Matrix.Norms.Frobenius
+
+namespace Matrix
+
+/-- Summing the completely positive terms associated with all pairwise outer
+products gives a rank-one map on the matrix algebra. -/
+private theorem sum_vecMulVec_mul_mul_conjTranspose
+    {l r n : Type*} [Fintype l] [Fintype r] [Fintype n]
+    (Y : Matrix n l ℂ) (X : Matrix r n ℂ) (Z : Matrix n n ℂ) :
+    ∑ q : r, ∑ a : l,
+      Matrix.vecMulVec (Y.col a) (X.row q) * Z *
+          (Matrix.vecMulVec (Y.col a) (X.row q))ᴴ =
+      Matrix.trace (Xᴴ * X * Z) • (Y * Yᴴ) := by
+  classical
+  have hletter (q : r) (a : l) :
+      Matrix.vecMulVec (Y.col a) (X.row q) * Z *
+          (Matrix.vecMulVec (Y.col a) (X.row q))ᴴ =
+        (((X.row q ᵥ* Z) ⬝ᵥ star (X.row q)) : ℂ) •
+          Matrix.vecMulVec (Y.col a) (star (Y.col a)) := by
+    rw [Matrix.vecMulVec_mul, Matrix.conjTranspose_vecMulVec,
+      Matrix.vecMulVec_mul_vecMulVec, Matrix.vecMulVec_smul]
+  have hleft :
+      ∑ a : l, Matrix.vecMulVec (Y.col a) (star (Y.col a)) = Y * Yᴴ := by
+    ext i j
+    simp only [Matrix.sum_apply, Matrix.vecMulVec_apply, Matrix.mul_apply,
+      Matrix.conjTranspose_apply, Matrix.col_apply, Pi.star_apply, RCLike.star_def]
+  have hright :
+      ∑ q : r, (((X.row q ᵥ* Z) ⬝ᵥ star (X.row q)) : ℂ) =
+        Matrix.trace (Xᴴ * X * Z) := by
+    rw [← Matrix.trace_mul_cycle X Z Xᴴ]
+    simp [Matrix.trace, Matrix.diag, Matrix.mul_apply, dotProduct, Matrix.vecMul]
+  simp_rw [hletter, ← Finset.smul_sum]
+  rw [← Finset.sum_smul, hright, hleft]
+
+/-- The Hilbert--Schmidt trace is the squared Frobenius norm, regarded as a
+complex number. -/
+private theorem trace_conjTranspose_mul_self_eq_frobenius_norm_sq
+    {m n : Type*} [Fintype m] [Fintype n] (A : Matrix m n ℂ) :
+    trace (Aᴴ * A) = ((‖A‖ ^ 2 : ℝ) : ℂ) := by
+  apply Complex.ext
+  · simpa only [Complex.ofReal_re] using
+      trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq A
+  · have him : (trace (Aᴴ * A)).im = 0 :=
+      (RCLike.nonneg_iff.mp
+        (posSemidef_conjTranspose_mul_self A).trace_nonneg).2
+    simpa only [Complex.ofReal_im] using him
+
+end Matrix
+
+namespace MPSTensor.BeigiSectorGraphData
+
+open FiniteWeightedDigraph
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+/-- The Euclidean norm of the loop bond vector.
+
+The coordinate-function space has the supremum norm, so the passage to
+Euclidean space is essential here.
+
+**Local fix (normalization):** Beigi chooses an arbitrary nonzero loop bond
+vector.  The normalized RFP representative divides by its Euclidean norm; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+noncomputable def loopBondNorm (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : ℝ :=
+  ‖(WithLp.toLp 2 (F.loopBondVector l) :
+    EuclideanSpace ℂ (Matrix.EtaEdgeIndex F.leftDim F.rightDim l.1 l.1))‖
+
+/-- The Euclidean norm of a positive-loop bond vector is positive.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606.  The normalization
+correction is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem loopBondNorm_pos (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : 0 < F.loopBondNorm l := by
+  rw [loopBondNorm, norm_pos_iff]
+  simpa [WithLp.toLp_eq_zero] using F.loopBondVector_ne_zero l
+
+/-- The Euclidean norm of a positive-loop bond vector is nonzero.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606.  The normalization
+correction is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem loopBondNorm_ne_zero (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : F.loopBondNorm l ≠ 0 :=
+  ne_of_gt (F.loopBondNorm_pos l)
+
+/-- The Euclidean norm of the loop bond vector is the Frobenius norm of its
+coefficient matrix.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606.  The normalization
+correction is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem loopBondNorm_eq_frobeniusNorm (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) :
+    F.loopBondNorm l =
+      ‖Matrix.schmidtCoeffMatrix (F.loopBondVector l)‖ := by
+  rw [loopBondNorm, ← MPSTensor.norm_matToES_eq_frobenius_norm]
+  rfl
+
+/-- The minimal sector-coordinate loop tensor divided by the Euclidean norm
+of its bond vector.
+
+**Local fix (Schmidt support and normalization):** Restriction to the Schmidt
+support removes unused virtual directions, while division by the Euclidean
+norm gives the normalized fixed-point representative; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+noncomputable def normalizedMinimalLoopCoordinateTensor
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    MPSTensor d (F.loopSchmidtRank l) :=
+  fun i ↦ ((F.loopBondNorm l : ℂ)⁻¹) • F.minimalLoopCoordinateTensor l i
+
+/-- The physical minimal loop tensor divided by the Euclidean norm of its
+bond vector.
+
+**Local fix (Schmidt support and normalization):** This is the normalized
+representative of Beigi's product-of-pairs tensor on its Schmidt support; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+noncomputable def normalizedMinimalLoopTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) : MPSTensor d (F.loopSchmidtRank l) :=
+  fun i ↦ ((F.loopBondNorm l : ℂ)⁻¹) • F.minimalLoopTensor l i
+
+private theorem normalizedMinimalLoopTensor_eq_rotatePhysical
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    F.normalizedMinimalLoopTensor l =
+      rotatePhysical F.unitary (F.normalizedMinimalLoopCoordinateTensor l) := by
+  classical
+  ext i
+  simp only [normalizedMinimalLoopTensor, normalizedMinimalLoopCoordinateTensor,
+    minimalLoopTensor, rotatePhysical_apply, Finset.smul_sum, smul_smul]
+  simp [mul_comm]
+
+/-- The transfer map of the minimal loop tensor in sector coordinates is a
+rank-one map on the virtual matrix algebra.
+
+**Local fix (Schmidt support):** The two Gram matrices are formed from the
+rank factorization through the Schmidt support; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+theorem transferMap_minimalLoopCoordinateTensor
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    (Z : Matrix (Fin (F.loopSchmidtRank l))
+      (Fin (F.loopSchmidtRank l)) ℂ) :
+    transferMap (F.minimalLoopCoordinateTensor l) Z =
+      Matrix.trace
+          ((F.loopSchmidtFactorization l).rightFactorᴴ *
+            (F.loopSchmidtFactorization l).rightFactor * Z) •
+        ((F.loopSchmidtFactorization l).leftFactor *
+          (F.loopSchmidtFactorization l).leftFactorᴴ) := by
+  classical
+  rw [transferMap_apply]
+  calc
+    (∑ i : Fin d, F.minimalLoopCoordinateTensor l i * Z *
+        (F.minimalLoopCoordinateTensor l i)ᴴ) =
+        ∑ z : Σ k, Fin (F.rightDim k) × Fin (F.leftDim k),
+          F.minimalLoopCoordinateTensor l (F.sectorEquiv z) * Z *
+            (F.minimalLoopCoordinateTensor l (F.sectorEquiv z))ᴴ := by
+      exact Fintype.sum_equiv F.sectorEquiv.symm
+        (fun i : Fin d ↦ F.minimalLoopCoordinateTensor l i * Z *
+          (F.minimalLoopCoordinateTensor l i)ᴴ)
+        (fun z ↦ F.minimalLoopCoordinateTensor l (F.sectorEquiv z) * Z *
+          (F.minimalLoopCoordinateTensor l (F.sectorEquiv z))ᴴ)
+        (fun i ↦ by rw [Equiv.apply_symm_apply])
+    _ = ∑ k : Fin F.sectorCount,
+        ∑ qa : Fin (F.rightDim k) × Fin (F.leftDim k),
+          F.minimalLoopCoordinateTensor l (F.sectorEquiv ⟨k, qa⟩) * Z *
+            (F.minimalLoopCoordinateTensor l (F.sectorEquiv ⟨k, qa⟩))ᴴ := by
+      rw [Fintype.sum_sigma]
+    _ = ∑ qa : Fin (F.rightDim l.1) × Fin (F.leftDim l.1),
+        F.minimalLoopCoordinateTensor l (F.sectorEquiv ⟨l.1, qa⟩) * Z *
+          (F.minimalLoopCoordinateTensor l (F.sectorEquiv ⟨l.1, qa⟩))ᴴ := by
+      rw [Finset.sum_eq_single l.1]
+      · intro k _ hk
+        apply Finset.sum_eq_zero
+        rintro ⟨q, a⟩ _
+        rw [F.minimalLoopCoordinateTensor_sector_ne l k hk q a]
+        simp
+      · simp
+    _ = _ := by
+      rw [Fintype.sum_prod_type]
+      simp_rw [F.minimalLoopCoordinateTensor_sector_apply l]
+      exact Matrix.sum_vecMulVec_mul_mul_conjTranspose
+        (F.loopSchmidtFactorization l).leftFactor
+        (F.loopSchmidtFactorization l).rightFactor Z
+
+private theorem loopSchmidtGram_trace
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    Matrix.trace
+        ((F.loopSchmidtFactorization l).rightFactorᴴ *
+          (F.loopSchmidtFactorization l).rightFactor *
+            ((F.loopSchmidtFactorization l).leftFactor *
+              (F.loopSchmidtFactorization l).leftFactorᴴ)) =
+      (((F.loopBondNorm l) ^ 2 : ℝ) : ℂ) := by
+  let X := (F.loopSchmidtFactorization l).rightFactor
+  let Y := (F.loopSchmidtFactorization l).leftFactor
+  calc
+    Matrix.trace (Xᴴ * X * (Y * Yᴴ)) =
+        Matrix.trace ((X * Y)ᴴ * (X * Y)) := by
+      rw [Matrix.conjTranspose_mul]
+      simpa only [Matrix.mul_assoc] using
+        Matrix.trace_mul_cycle' Xᴴ (X * Y) Yᴴ
+    _ = ((‖X * Y‖ ^ 2 : ℝ) : ℂ) :=
+      Matrix.trace_conjTranspose_mul_self_eq_frobenius_norm_sq (X * Y)
+    _ = (((F.loopBondNorm l) ^ 2 : ℝ) : ℂ) := by
+      rw [(F.loopSchmidtFactorization l).mul_eq]
+      rw [← F.loopBondNorm_eq_frobeniusNorm l]
+
+/-- Euclidean normalization multiplies the rank-one transfer formula by the
+inverse squared bond norm.
+
+**Local fix (Schmidt support and normalization):** The norm is the Euclidean
+norm of the bond vector, equivalently the Frobenius norm of its coefficient
+matrix; see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+theorem transferMap_normalizedMinimalLoopCoordinateTensor
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    (Z : Matrix (Fin (F.loopSchmidtRank l))
+      (Fin (F.loopSchmidtRank l)) ℂ) :
+    transferMap (F.normalizedMinimalLoopCoordinateTensor l) Z =
+      (((F.loopBondNorm l : ℂ) ^ 2)⁻¹ *
+        Matrix.trace
+          ((F.loopSchmidtFactorization l).rightFactorᴴ *
+            (F.loopSchmidtFactorization l).rightFactor * Z)) •
+        ((F.loopSchmidtFactorization l).leftFactor *
+          (F.loopSchmidtFactorization l).leftFactorᴴ) := by
+  unfold normalizedMinimalLoopCoordinateTensor
+  rw [transferMap_smul, F.transferMap_minimalLoopCoordinateTensor l]
+  simp only [smul_smul]
+  have hscalar :
+      (F.loopBondNorm l : ℂ)⁻¹ * starRingEnd ℂ (F.loopBondNorm l : ℂ)⁻¹ =
+        ((F.loopBondNorm l : ℂ) ^ 2)⁻¹ := by
+    simp [pow_two]
+  rw [hscalar]
+
+/-- The Euclidean-normalized minimal loop tensor in sector coordinates has an
+idempotent transfer map.
+
+**Local fix (Schmidt support and normalization):** Euclidean normalization
+removes the factor `‖φ‖₂²` from the square of the raw rank-one transfer map;
+see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+theorem normalizedMinimalLoopCoordinateTensor_isTransferIdempotent
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    IsTransferIdempotent (F.normalizedMinimalLoopCoordinateTensor l) := by
+  rw [IsTransferIdempotent]
+  apply LinearMap.ext
+  intro Z
+  simp only [LinearMap.comp_apply]
+  let Q := (F.loopSchmidtFactorization l).rightFactorᴴ *
+    (F.loopSchmidtFactorization l).rightFactor
+  let P := (F.loopSchmidtFactorization l).leftFactor *
+    (F.loopSchmidtFactorization l).leftFactorᴴ
+  let c : ℂ := ((F.loopBondNorm l : ℂ) ^ 2)⁻¹
+  have hformula (W : Matrix (Fin (F.loopSchmidtRank l))
+      (Fin (F.loopSchmidtRank l)) ℂ) :
+      transferMap (F.normalizedMinimalLoopCoordinateTensor l) W =
+        (c * Matrix.trace (Q * W)) • P := by
+    simpa only [Q, P, c, Matrix.mul_assoc] using
+      F.transferMap_normalizedMinimalLoopCoordinateTensor l W
+  have htrace : Matrix.trace (Q * P) =
+      (((F.loopBondNorm l) ^ 2 : ℝ) : ℂ) := by
+    simpa only [Q, P, Matrix.mul_assoc] using F.loopSchmidtGram_trace l
+  rw [hformula, hformula]
+  simp only [Matrix.mul_smul, Matrix.trace_smul, smul_eq_mul, htrace]
+  congr 1
+  dsimp only [c]
+  field_simp [Complex.ofReal_ne_zero.mpr (F.loopBondNorm_ne_zero l)]
+  push_cast
+  exact mul_comm _ _
+
+/-- The Euclidean-normalized physical minimal loop tensor has an idempotent
+transfer map.
+
+**Local fix (Schmidt support and normalization):** The physical unitary leaves
+the transfer map invariant, so the coordinate result passes to Beigi's
+physical coordinates; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+theorem normalizedMinimalLoopTensor_isTransferIdempotent
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    IsTransferIdempotent (F.normalizedMinimalLoopTensor l) := by
+  have hunitary : F.unitary * F.unitaryᴴ = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      Unitary.mul_star_self_of_mem F.unitary_mem
+  have htransfer :
+      transferMap (F.normalizedMinimalLoopTensor l) =
+        transferMap (F.normalizedMinimalLoopCoordinateTensor l) := by
+    rw [F.normalizedMinimalLoopTensor_eq_rotatePhysical l,
+      transferMap_rotatePhysical _ F.unitary hunitary]
+  rw [IsTransferIdempotent, htransfer]
+  exact F.normalizedMinimalLoopCoordinateTensor_isTransferIdempotent l
+
+/-- The normalized physical loop tensor is injective on its Schmidt support.
+
+**Local fix (Schmidt support and normalization):** Multiplication by the
+nonzero inverse bond norm preserves one-site injectivity; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+theorem normalizedMinimalLoopTensor_isInjective
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    IsInjective (F.normalizedMinimalLoopTensor l) := by
+  apply (F.minimalLoopTensor_isInjective l).smul
+  exact inv_ne_zero (Complex.ofReal_ne_zero.mpr (F.loopBondNorm_ne_zero l))
+
+/-- The normalized physical loop tensor is normal on its Schmidt support.
+
+**Local fix (Schmidt support and normalization):** This follows from the
+one-site injectivity of the normalized representative; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+theorem normalizedMinimalLoopTensor_isNormal
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight) :
+    IsNormal (F.normalizedMinimalLoopTensor l) :=
+  (F.normalizedMinimalLoopTensor_isInjective l).isNormal
+
+/-- At length `N`, the periodic vector of the normalized minimal loop tensor
+is Beigi's product-of-pairs vector multiplied by `‖φ‖₂⁻ᴺ`.
+
+**Local fix (Schmidt support and normalization):** The scalar is the inverse
+Euclidean bond norm at each site; see
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+
+Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+`eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578. -/
+theorem mpv_normalizedMinimalLoopTensor (F : BeigiSectorGraphData A)
+    (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
+    mpv (F.normalizedMinimalLoopTensor l) s =
+      ((F.loopBondNorm l : ℂ)⁻¹) ^ N * F.loopProductState l s := by
+  unfold normalizedMinimalLoopTensor
+  rw [mpv_smul, F.mpv_minimalLoopTensor l]
+
+end MPSTensor.BeigiSectorGraphData

--- a/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
+++ b/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
@@ -203,7 +203,7 @@ theorem transferMap_minimalLoopCoordinateTensor
         ((F.loopSchmidtFactorization l).leftFactor *
           (F.loopSchmidtFactorization l).leftFactorᴴ) := by
   classical
-  rw [transferMap_apply]
+  transfer_simp
   calc
     (∑ i : Fin d, F.minimalLoopCoordinateTensor l i * Z *
         (F.minimalLoopCoordinateTensor l i)ᴴ) =

--- a/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
+++ b/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
@@ -213,6 +213,21 @@ theorem minimalLoopCoordinateTensor_sector_apply
   simp [minimalLoopCoordinateTensor, Matrix.mul_apply, loopSchmidtBridge,
     hright, hleft, Matrix.vecMulVec_apply]
 
+/-- Outside the chosen loop sector, every letter of the minimal coordinate
+tensor vanishes.
+
+Source context: Beigi, arXiv:1105.1019v2, Section IV, equation (10) and the
+paragraph following it.  The Schmidt-support refinement is recorded in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem minimalLoopCoordinateTensor_sector_ne
+    (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
+    (k : Fin F.sectorCount) (hk : k ≠ l.1)
+    (q : Fin (F.rightDim k)) (a : Fin (F.leftDim k)) :
+    F.minimalLoopCoordinateTensor l (F.sectorEquiv ⟨k, (q, a)⟩) = 0 := by
+  classical
+  ext α β
+  simp [minimalLoopCoordinateTensor, Matrix.mul_apply, loopSchmidtBridge, hk]
+
 /-- Each ambient loop letter is the rectangular Schmidt-support letter
 followed by the left factor of the bond coefficient matrix.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2699,18 +2699,11 @@ specialization of that Appendix~D definition.
     \uses{def:beigi_loop_schmidt_support}
     Let $\nu_a=\lVert\varphi_a\rVert_2>0$, where the norm is the
     Hilbert-space norm of the bond vector, or equivalently the Frobenius norm
-    of $\Phi_a$.  The normalized minimal tensors are
+    of $\Phi_a$.  In either coordinate system, the normalized representative is
     \[
-        \widehat C_a=\nu_a^{-1}\widetilde C_a
+        \widehat C_a=\nu_a^{-1}\widetilde C_a.
     \]
-    in sector and physical coordinates, respectively.  The raw coordinate
-    and physical tensors remain separately unchanged.  For every $N>0$,
-    Theorem~\ref{thm:beigi_loop_tensor_periodic_vector} gives
-    \[
-        \ket{V^{(N)}(\widehat C_a)}=\nu_a^{-N}\Psi_a^{(N)},
-    \]
-    Thus the normalized periodic vector determines the same ray as the periodic
-    vector of the raw physical tensor.
+    The raw coordinate and physical tensors are retained separately.
 \end{definition}
 
 \begin{lemma}[Positive Schmidt dimension of a Beigi loop]
@@ -2797,7 +2790,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.mpv_normalizedMinimalLoopTensor}
     \leanok
     \uses{def:beigi_loop_product_state, def:beigi_loop_schmidt_support,
-        lem:mpv_rotate_physical}
+        def:beigi_normalized_minimal_loop_tensor, lem:mpv_rotate_physical}
     For every $N>0$, the periodic matrix product vector of $C_a$ has
     coefficient
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2670,6 +2670,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor}
     \lean{MPSTensor.BeigiSectorGraphData.minimalLoopTensor}
     \lean{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor_sector_apply}
+    \lean{MPSTensor.BeigiSectorGraphData.minimalLoopCoordinateTensor_sector_ne}
     \leanok
     \uses{def:beigi_loop_product_state}
     Let $\Phi_a=(\varphi_a(r,l))_{r,l}$ and write
@@ -2687,6 +2688,23 @@ specialization of that Appendix~D definition.
     \]
     again extended by zero outside sector~$a$.  Its physical tensor is its
     image under the same one-site unitary.
+\end{definition}
+
+\begin{definition}[Normalized minimal tensor associated with a positive Beigi loop]
+    \label{def:beigi_normalized_minimal_loop_tensor}
+    \lean{MPSTensor.BeigiSectorGraphData.loopBondNorm}
+    \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor}
+    \leanok
+    \uses{def:beigi_loop_schmidt_support}
+    Let $\nu_a=\lVert\varphi_a\rVert_2>0$, where the norm is the
+    Hilbert-space norm of the bond vector, or equivalently the Frobenius norm
+    of $\Phi_a$.  The normalized minimal tensors are
+    \[
+        \widehat C_a=\nu_a^{-1}\widetilde C_a
+    \]
+    in sector and physical coordinates, respectively.  The original tensor
+    and its exact periodic-vector identities remain unchanged.
 \end{definition}
 
 \begin{lemma}[Positive Schmidt dimension of a Beigi loop]
@@ -2724,12 +2742,52 @@ specialization of that Appendix~D definition.
     this span.  One-site injectivity implies normality.
 \end{proof}
 
+\begin{theorem}[Transfer fixed point of a normalized Beigi loop tensor]
+    \label{thm:beigi_normalized_minimal_loop_tensor_rfp}
+    \lean{MPSTensor.BeigiSectorGraphData.loopBondNorm_pos}
+    \lean{MPSTensor.BeigiSectorGraphData.loopBondNorm_ne_zero}
+    \lean{MPSTensor.BeigiSectorGraphData.loopBondNorm_eq_frobeniusNorm}
+    \lean{MPSTensor.BeigiSectorGraphData.transferMap_minimalLoopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.transferMap_normalizedMinimalLoopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopCoordinateTensor_isTransferIdempotent}
+    \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_isTransferIdempotent}
+    \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_isInjective}
+    \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_isNormal}
+    \leanok
+    \uses{def:beigi_normalized_minimal_loop_tensor,
+        thm:beigi_minimal_loop_tensor_injective,
+        def:mps_transfer_idempotence}
+    The transfer map of the unnormalized coordinate tensor is
+    \[
+        \mathcal E_a(Z)=\operatorname{tr}(X_a^*X_aZ)Y_aY_a^*,
+        \qquad
+        \mathcal E_a^2=\nu_a^2\mathcal E_a.
+    \]
+    Hence the transfer map of $\widehat C_a$ is idempotent.  This remains
+    true after the physical unitary rotation.  The normalized physical tensor
+    is injective and therefore normal.
+\end{theorem}
+
+\begin{proof}\leanok
+    Summing the Kraus terms over the loop-sector coordinates gives the stated
+    rank-one formula.  Cyclicity of the trace and $\Phi_a=X_aY_a$ give
+    \[
+        \operatorname{tr}(X_a^*X_aY_aY_a^*)
+          =\operatorname{tr}(\Phi_a^*\Phi_a)=\nu_a^2.
+    \]
+    Scaling every letter by $\nu_a^{-1}$ scales the transfer map by
+    $\nu_a^{-2}$, which makes it idempotent.  A unitary change of physical
+    coordinates leaves the transfer map invariant, and the nonzero scalar
+    preserves injectivity.
+\end{proof}
+
 \begin{theorem}[Periodic vector of a positive Beigi loop]
     \label{thm:beigi_loop_tensor_periodic_vector}
     \lean{MPSTensor.BeigiSectorGraphData.mpv_loopCoordinateTensor}
     \lean{MPSTensor.BeigiSectorGraphData.mpv_loopTensor}
     \lean{MPSTensor.BeigiSectorGraphData.mpv_minimalLoopCoordinateTensor}
     \lean{MPSTensor.BeigiSectorGraphData.mpv_minimalLoopTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.mpv_normalizedMinimalLoopTensor}
     \leanok
     \uses{def:beigi_loop_product_state, def:beigi_loop_schmidt_support,
         lem:mpv_rotate_physical}
@@ -2742,7 +2800,8 @@ specialization of that Appendix~D definition.
     other sector configuration.  Consequently the periodic vector of the
     physical loop tensor is exactly the sitewise-unitary image of this cyclic
     product-of-pairs state.  The same identities hold for the tensor on the
-    minimal Schmidt support.
+    minimal Schmidt support.  For the normalized minimal tensor it is
+    $\nu_a^{-N}\Psi_a^{(N)}$.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2703,8 +2703,14 @@ specialization of that Appendix~D definition.
     \[
         \widehat C_a=\nu_a^{-1}\widetilde C_a
     \]
-    in sector and physical coordinates, respectively.  The original tensor
-    and its exact periodic-vector identities remain unchanged.
+    in sector and physical coordinates, respectively.  The raw coordinate
+    and physical tensors remain separately unchanged.  For every $N>0$,
+    Theorem~\ref{thm:beigi_loop_tensor_periodic_vector} gives
+    \[
+        \ket{V^{(N)}(\widehat C_a)}=\nu_a^{-N}\Psi_a^{(N)},
+    \]
+    Thus the normalized periodic vector determines the same ray as the periodic
+    vector of the raw physical tensor.
 \end{definition}
 
 \begin{lemma}[Positive Schmidt dimension of a Beigi loop]
@@ -2748,6 +2754,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.loopBondNorm_ne_zero}
     \lean{MPSTensor.BeigiSectorGraphData.loopBondNorm_eq_frobeniusNorm}
     \lean{MPSTensor.BeigiSectorGraphData.transferMap_minimalLoopCoordinateTensor}
+    \lean{MPSTensor.BeigiSectorGraphData.transferMap_minimalLoopCoordinateTensor_comp_self}
     \lean{MPSTensor.BeigiSectorGraphData.transferMap_normalizedMinimalLoopCoordinateTensor}
     \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopCoordinateTensor_isTransferIdempotent}
     \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_isTransferIdempotent}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -351,10 +351,31 @@ injectivity.  The one-site unitary preserves this spanning property, giving
 \leanid{MPSTensor.BeigiSectorGraphData.minimalLoopTensor_isInjective} and the
 normality conclusion
 \leanid{MPSTensor.BeigiSectorGraphData.minimalLoopTensor_isNormal}.
-No normalization, transfer-idempotence, or identification with the original
-basis of normal tensors is asserted at this stage.  Consequently, the
-spanning statement below may equivalently be formulated using the periodic
-vectors of the minimal Schmidt-support tensors.
+Here $\lVert\varphi_a\rVert_2$ denotes the Euclidean norm of the bond vector,
+equivalently the Frobenius norm of its coefficient matrix; it is not the
+supremum norm on the ordinary coordinate-function space.  With
+$P=Y_aY_a^*$ and $Q=X_a^*X_a$, the transfer map of the minimal coordinate
+tensor has the rank-one form
+\[
+  \mathcal E_a(Z)=\operatorname{tr}(QZ)P,
+  \qquad
+  \mathcal E_a^2=\lVert\varphi_a\rVert_2^2\mathcal E_a.
+\]
+The declaration \leanid{MPSTensor.BeigiSectorGraphData.loopBondVector}
+chooses a nonzero vector but does not normalize it.  Thus transfer
+idempotence is not asserted for the raw tensor unless
+$\lVert\varphi_a\rVert_2=1$.  The separate declaration
+\leanid{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor} defines
+$\lVert\varphi_a\rVert_2^{-1}\widetilde C_a$ without changing the raw tensor
+or any of its exact state formulas.  Its transfer map is idempotent by
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{normalizedMinimalLoopTensor_isTransferIdempotent}, and its
+length-$N$ matrix product vector is
+$\lVert\varphi_a\rVert_2^{-N}$ times the original loop state by
+\leanid{MPSTensor.BeigiSectorGraphData.mpv_normalizedMinimalLoopTensor}.
+No identification with the original basis of normal tensors is asserted at
+this stage.  Consequently, the spanning statement below may equivalently be
+formulated using the periodic vectors of the minimal Schmidt-support tensors.
 
 For every $N\geq2$,
 \leanid{MPSTensor.BeigiSectorGraphData.}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -361,6 +361,9 @@ tensor has the rank-one form
   \qquad
   \mathcal E_a^2=\lVert\varphi_a\rVert_2^2\mathcal E_a.
 \]
+The second identity is formalized by
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{transferMap_minimalLoopCoordinateTensor_comp_self}.
 The declaration \leanid{MPSTensor.BeigiSectorGraphData.loopBondVector}
 chooses a nonzero vector but does not normalize it.  Thus transfer
 idempotence is not asserted for the raw tensor unless


### PR DESCRIPTION
### Motivation

For a nonzero loop vector \(\varphi\), the minimal coordinate tensor has raw transfer map
\[
  \mathcal E(Z)=\operatorname{tr}(X^*XZ)YY^*,
\]
and therefore \(\mathcal E^2=\|\varphi\|_2^2\mathcal E\). Transfer idempotence belongs to the normalized representative, not to the raw tensor unless the loop vector already has unit norm. This is the normalization correction recorded in #4477.

### Description

- Define the positive loop bond norm and the normalized minimal coordinate and physical tensors.
- Prove the raw rank-one transfer formula and the scalar identity \(\mathcal E^2=\nu^2\mathcal E\).
- Prove idempotence for the normalized coordinate tensor and its physical-unitary transport.
- Preserve injectivity and normality under normalization.
- Prove that the normalized periodic vector is \(\nu^{-N}\) times the raw periodic vector, hence lies on the same ray.
- Expose the off-Schmidt-sector vanishing statement needed by the construction.
- Update the root import, chapter 13 blueprint, and the existing paper-gap record.

The contribution does not attempt the later BNT-basis identification, permutation rigidity, or removal of the remaining parent-Hamiltonian assumption.

### Sources

- Beigi, arXiv:1105.1019v2, lines 602–606.
- CPSV16, arXiv:1606.00608, equations `III_CFI_RFP`, `eq:III_isometry`, `eq:basic-vectors-RFP-pure`, and `eq:III_varphi`, including the Appendix calculation at lines 1293–1300.
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.

### Testing

- `lake env lean TNLean/MPS/RFP/BeigiLoopFixedPoint.lean`
- `lake env lean TNLean.lean`
- `lake exe lint_style`
- proof-integrity scan on changed Lean files
- changed-line length audit
- tactic-pattern scan
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`

Closes #4477
Related: #4423, #3375, #2633, #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean proofs and blueprint/docs only—no runtime services or auth. Scope is localized to Beigi RFP loop normalization with a straightforward root import swap.
> 
> **Overview**
> Adds **`BeigiLoopFixedPoint.lean`** and wires it through **`TNLean.lean`** instead of importing **`BeigiLoopInjectivity`** alone at the root. The new layer defines the loop bond Euclidean norm **`loopBondNorm`**, normalized minimal coordinate/physical tensors, and proves the raw minimal transfer map is rank-one with **\(\mathcal E^2 = \nu^2\mathcal E\)**; dividing by \(\nu\) yields an **idempotent** transfer map while keeping injectivity, normality, and the same periodic-vector ray (**\(\nu^{-N}\)** scaling).
> 
> **`minimalLoopCoordinateTensor_sector_ne`** is added in **`BeigiLoopSchmidtSupport.lean`** so off-loop-sector letters vanish (used in the transfer sum). Chapter 13 blueprint and **`cpsv16_nncph_ground_state_scope.tex`** document normalized tensors and the normalization correction; the periodic-vector theorem gains the normalized **`mpv`** identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31cbacef4a8d923108e7046a7339363854151c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->