### PR TITLE
fix(ci): restore root import line limit

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -654,7 +654,6 @@ import TNLean.Wielandt.Inequality.EigenvectorSpreading
 import TNLean.Wielandt.Inequality.MatrixSpanExistence
 import TNLean.Wielandt.Inequality.MatrixSpanSharpBound
 import TNLean.Wielandt.Inequality.Bounds
-
 -- Layer 6c: Conditional Wielandt arguments
 -- These modules support specialized span-growth and aperiodicity routes. They
 -- are not on the active canonical / FT / BNT path, but they remain root-visible


### PR DESCRIPTION
### Motivation

After PR #4448 merged on top of PR #4479, the combined root import file contained 1001 lines even though each topic branch had passed the line-count check independently.

### Description

Remove one blank separator before the Layer 6c heading. No import, declaration, or mathematical content changes.

### Testing

- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

Follow-up to #4448 and #4479.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only change with no functional or import-surface impact.
> 
> **Overview**
> Brings **`TNLean.lean`** back under the **1000-line** oversized-file CI gate by deleting **one blank line** before the Layer 6c comment block (after the `TNLean.Wielandt.Inequality.Bounds` import).
> 
> **No** import lines, declarations, or mathematical content change—only whitespace so the combined root import surface stays at or below the limit after stacked merges left it at 1001 lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a055f7e1bcae0bf555f69a20fbaef7558eac66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->