### PR TITLE
docs(blueprint): migrate Stinespring channel diagram

### DIFF
--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -765,7 +765,24 @@ channel through an isometry $V$ into a larger space,
 $T(\rho)=\tr_E[V\rho V^\dagger]$; tracing out the environment $E$ returns the
 channel:
 \begin{center}
-    \TNStinespring
+    % Formula/source: Wolf, Sec. 2.2, proof of Thm. 2.5, gives the
+    % Schrödinger-picture identity
+    % T(\rho)=\operatorname{tr}_{\mathbb C^r}(V\rho V^\dagger).
+    % Indices: \rho contracts the east system-index pair; the west system
+    % pair consists of the free indices of T(\rho), while the unique vertical
+    % pairleg contracts the repeated dilation-space index e.
+    % Orientation: the starred lower V is the conjugate bra layer; together
+    % with the return path it represents V^\dagger in the operator formula.
+    % Boundary signature: (virtual-west=2 | virtual-east=0 |
+    % physical-up=0 | physical-down=0).
+    \begin{tenkz}[
+        sandwich,
+        east={cup=$\rho$},
+        west label=$T(\rho)$
+    ]
+        \tn{V} \\
+        \tn*{V}
+    \end{tenkz}
 \end{center}
 
 \begin{definition}[Stinespring matrix]\label{def:stinespring_v}

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -53,7 +53,7 @@ The WHATS-NEW-0.5 §Gaps (0.6 backlog) is: *per-side boundary control, bare iden
 | K2 `periodic=physical` — vertical trace closure of a stacked op-row column (multi-row analogue of per-glyph `trace=physical`) | TNMPDOBNTOperatorTraceClosure (`O_L(M_α)` vertical word) | **no** | none faithful; demote to `O_L(M_α)=\tr_v(M_α^{⊗v L})`-style plain math |
 | K3 lattice `physical stubs` — per-site physical leg (diagonal stub) on tenkzlattice vertices | TNPEPSLatticeState, TNPEPSTorusGeometry | **no** | draw the patch in tenkzfree with `ports={north east:physical}` per site (verbose) |
 | K4 lattice `torus`/identification marks (opposite-boundary gluing) | TNPEPSTorusGeometry | **no** (but anticipated by the final spec's manual plan, ch5 "torus/cylinder marks") | annotation arrows outside the picture |
-| K5 `pair label=` / plain (dot-free) label on a cup apex or paired internal leg | TNKrausMap ($i$), TNStinespring ($E$), TNMPOLocalPurification ($k$ on the ancilla cup) | **no** | drop the label (index already in $K_i$), or accept the `close east={…}` fixed-point-dot styling |
+| K5 `pair label=` / plain (dot-free) label on a cup apex or paired internal leg | TNMPOLocalPurification ($k$ on the ancilla cup) | **no** | drop the $k$ label (the sole closed ancilla pair makes the contraction unambiguous), or accept the `close east={…}` fixed-point-dot styling |
 | K6 `\tnedge[insert=$X$]` — on-edge insertion glyph in the lattice tier | TNPEPSEdgeInsertedCoeff, TNPEPSThreeSiteInsertionComparison, TNPEPSPhysicalToVirtualInsertion (lattice-strip route) | **no** | tenkzfree: the insertion is its own `\tnput` node with two `\tnjoin`s — expressible today |
 | K7 free-tier region highlight — hull/slot fill over a set of `\tnput` nodes | TNPEPSEdgeBlockingReduction + TNPEPSEdgeInsertionEquality (pentagon patch with region overlays), TNAppendixB* grouping regions | **no** | hand-drawn dashed box in tenkzfree (violates "no raw styling at call sites") |
 
@@ -154,7 +154,7 @@ Note: the 7 hand-digitized region polygons inside `tn_motifs_peps.tex` all becom
 | entry | call site | tenkz spelling sketch | risk |
 |---|---|---|---|
 | TNKrausMap | ch16_channel_representations:467 | `[sandwich, east={cup=$\rho$}, west label=$T(\rho)$]: \tn{K_i} \\ \tn*{K_i}` | source-faithful applied channel; exact boundary `(2,0,0,0)`, no package change |
-| TNStinespring | ch16_channel_representations:697 | `[sandwich, west label=$\rho$, east label=$\tr_E[V\rho V^\dagger]$]: \tn{V} \\ \tn*{V}` | trivial (K5 `pair label=$E$` optional) |
+| TNStinespring | ch16_channel_representations:768 | `[sandwich, east={cup=$\rho$}, west label=$T(\rho)$]: \tn{V} \\ \tn*{V}` | migrated inline (applied channel; the house input is the east cup; the unique unlabelled pairleg traces $E$) |
 | TNChoiMatrix | ch16_channel_representations:108 | `[sandwich, close west={$\Omega$}]: \tn{T} \\ \tn{\mathrm{id}}` | trivial (0.6 bare identity-wire atom would let `id` be a plain wire) |
 | TNTransferMapTracePairing | ch16_channel_representations:1478 | demote: `T(\rho)=\sum_{ij}t_{ij}\tr(\sigma_j\rho)\,\sigma_i` (+ optional `\tnpic[inline, periodic]{\tnX{\sigma_j}&\tnX{\rho}}` for the trace loop) | needs-judgment (candidate demotion to plain math) |
 | TNTwoPointCorrelator | ch14_correlations:50 | `[sandwich, west={cup=$Y$}, east={cup=$X\rho^R$}]` with `\tnX[wires=2]{\mathcal E_A^n}` between ghost anchors | trivial (a doubled-index map between input and trace-pairing cups; not a periodic word) |

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -920,21 +920,6 @@
 
 % ---------- Quantum-channel representation diagrams ----------
 
-% Stinespring dilation T(rho) = tr_E[V rho V^dagger]: the isometry V and its
-% adjoint map the system into a larger space; the environment E is traced out
-% (the loop on the right), leaving the channel output T(rho) on the system legs.
-\TNDeclareDiagram
-    {TNStinespring}
-    {}
-    {display}
-    {compact}
-    {\TNStinespring}
-    {chapter/ch16_channel_representations.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNStinespringMotif
-    \end{TNDiagram}%
-}
-
 % Choi--Jamiolkowski isomorphism tau = (T tensor id)(|Omega><Omega|): the channel
 % T (double layer) has its input legs bent around the maximally entangled pair
 % |Omega|, presenting the map as a matrix on the doubled space.

--- a/tex/tn/tn_motifs_peps.tex
+++ b/tex/tn/tn_motifs_peps.tex
@@ -718,18 +718,6 @@
         \TN@motiflabel{tnClientLabel2114}{(2.35,0)}{\displaystyle\prod_{e \ni v} c_{v,e} = 1}
 }
 
-% TNStinespring
-\newcommand{\TNStinespringMotif}{%
-        \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNStinespring|kind=quantum-channel}%
-        \TNStackedMPOProduct{s}{(0,0)}{V}{V^\dagger}{E}
-        \TNOpenVirtualWest{sUpperWest}
-        \TNOpenVirtualWest{sLowerWest}
-        \TNOpenVirtualEast{sUpperEast}
-        \TNOpenVirtualEast{sLowerEast}
-        \TN@motiflabelleft{tnClientLabel2145}{(-0.70,0)}{\rho}
-        \TN@motiflabelright{tnClientLabel2146}{(0.70,0)}{\tr_E[V\rho V^\dagger]}
-}
-
 % TNChoiMatrix
 \newcommand{\TNChoiMatrixMotif}{%
         \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNChoiMatrix|kind=quantum-channel}%


### PR DESCRIPTION
## Summary

- replace the legacy four-boundary `\TNStinespring` map with the applied
  Stinespring channel
- put `ρ` on the east input cup, leave the two west output indices of
  `T(ρ)` open, and contract the unique environment index between `V` and
  its conjugate layer
- retire the sole catalogue declaration and motif helper, and correct the
  migration map, including K5's remaining-consumer list

Wolf's proof of Theorem 2.5 gives the Schrödinger-picture identity
`T(ρ) = tr_{C^r}(VρV†)`, which fixes the contraction. The exact emitted
boundary is `(virtual-west=2 | virtual-east=0 | physical-up=0 |
physical-down=0)`.

## Validation

Validated head: `c8e382bc781d7a20cdf39cc593fd1daaaf0ebc15`

- `python3 scripts/tenkz_lint.py ...` — 114 files, zero findings
- targeted standalone compile + `scripts/tenkz_audit.py` — zero advisories
- strict `Packages/tn_diagrams.py` checker/smoke render — 51 declarations
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/test_tenkz_index_routing.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `leanblueprint pdf` — 696 pages; inspected physical PDF page 374 (printed page 373)
- `leanblueprint web` — clean run; inspected
  `tenkz-14bffe62f6357398.svg`

`scripts/check_tn_references.py` reports the same six unrelated 1.0000 raster
mismatches on this branch and on an untouched `origin/main` checkout:
`straight_purification`, `compact_trace_cell`, `rotated_vertical_word`,
`dense_fusion_tree`, `parallel_sector_buses`, and `peps_three_site`.

Closes #4483

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram-shim only; no runtime, auth, or data paths. Risk is limited to PDF/visual regression for one pedagogical figure.
> 
> **Overview**
> **Migrates the Stinespring dilation figure** off the legacy catalogue macro `\TNStinespring` and onto an **inline `tenkz` sandwich** in ch16, aligned with the already-migrated Kraus spelling.
> 
> The new diagram encodes the **applied channel** \(T(\rho)=\mathrm{tr}_E(V\rho V^\dagger)\): **\(\rho\)** on the **east input cup**, **\(T(\rho)\)** on the west, and **\(V\)** / **\(\tn*{V}\)** with the environment traced via the sole vertical pairleg (no explicit \(E\) label). Inline comments document Wolf Thm. 2.5 and boundary signature `(virtual-west=2 | virtual-east=0 | …)`.
> 
> **Removes** the `\TNDeclareDiagram{TNStinespring}` entry and `\TNStinespringMotif` helper. **`docs/tenkz/MIGRATION-MAP.md`** records the inline migration and narrows proposed key **K5** so Stinespring/Kraus no longer depend on optional cup labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e382bc781d7a20cdf39cc593fd1daaaf0ebc15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->