### PR TITLE
feat(Channel/FixedPoint): derive inverse CPTP star equivalence

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -153,7 +153,6 @@ import TNLean.Analysis.OperatorConvexity
 import TNLean.Analysis.RpowConvexity
 import TNLean.Analysis.RelativeEntropyResolventIntegral
 import TNLean.Analysis.ResolventFunctionalCalculus
--- Layer 2b: Quantum channels (general theory)
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import TNLean.Channel.Schwarz.Douglas
@@ -209,6 +208,7 @@ import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
 import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
 import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
 import TNLean.Channel.FixedPoint.DirectSumTraceAdjoint
+import TNLean.Channel.FixedPoint.DirectSumInverseKraus
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.StationaryProjection

--- a/TNLean/Channel/FixedPoint/DirectSumInverseKraus.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumInverseKraus.lean
@@ -28,62 +28,6 @@ noncomputable section
 
 namespace Matrix
 
-variable {α β : Type*}
-variable [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
-
-/-- A unital rectangular Kraus map satisfies the Kadison--Schwarz inequality.
-
-This is the rectangular Kraus form of the usual Kadison--Schwarz inequality.
-It is the inequality appearing in the definition of a Schwarz map in
-Wolf--Perez-Garcia, arXiv:1005.4545, source line 306. -/
-theorem IsKrausCP.kadison_schwarz_of_map_one_eq_one
-    {E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
-    (hE : IsKrausCP E) (hOne : E 1 = 1) (X : Matrix α α ℂ) :
-    (E (Xᴴ * X) - (E X)ᴴ * E X).PosSemidef := by
-  obtain ⟨r, K, hK⟩ := hE
-  have hUnital : ∑ i, K i * (K i)ᴴ = (1 : Matrix β β ℂ) := by
-    simpa [hK, Matrix.mul_one] using hOne
-  have hGap :
-      E (Xᴴ * X) - (E X)ᴴ * E X =
-        ∑ i, (X * (K i)ᴴ - (K i)ᴴ * E X)ᴴ *
-          (X * (K i)ᴴ - (K i)ᴴ * E X) := by
-    have hExpand (i : Fin r) :
-        (X * (K i)ᴴ - (K i)ᴴ * E X)ᴴ *
-            (X * (K i)ᴴ - (K i)ᴴ * E X) =
-          K i * (Xᴴ * X) * (K i)ᴴ - K i * Xᴴ * ((K i)ᴴ * E X) -
-            (E X)ᴴ * (K i * X * (K i)ᴴ) +
-              (E X)ᴴ * (K i * (K i)ᴴ) * E X := by
-      simp only [conjTranspose_sub, conjTranspose_mul,
-        conjTranspose_conjTranspose, Matrix.sub_mul, Matrix.mul_sub,
-        Matrix.mul_assoc]
-      abel
-    have hReassocTwo (i : Fin r) :
-        K i * Xᴴ * ((K i)ᴴ * E X) =
-          K i * Xᴴ * (K i)ᴴ * E X := by
-      simp only [Matrix.mul_assoc]
-    have hReassocFour (i : Fin r) :
-        (E X)ᴴ * (K i * (K i)ᴴ) * E X =
-          (E X)ᴴ * K i * (K i)ᴴ * E X := by
-      simp only [Matrix.mul_assoc]
-    simp_rw [hExpand]
-    simp_rw [hReassocTwo, hReassocFour]
-    simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
-    rw [← Finset.sum_mul (f := fun i ↦ K i * Xᴴ * (K i)ᴴ)]
-    rw [← Finset.mul_sum (a := (E X)ᴴ) (f := fun i ↦ K i * X * (K i)ᴴ)]
-    rw [← Finset.sum_mul (f := fun i ↦ (E X)ᴴ * K i * (K i)ᴴ)]
-    have hStar : E Xᴴ = (E X)ᴴ := by
-      rw [hK, hK]
-      simp only [conjTranspose_sum, conjTranspose_mul,
-        conjTranspose_conjTranspose, Matrix.mul_assoc]
-    have hUnit : ∑ i, (E X)ᴴ * K i * (K i)ᴴ = (E X)ᴴ := by
-      simp_rw [Matrix.mul_assoc]
-      rw [← Finset.mul_sum, hUnital, Matrix.mul_one]
-    rw [← hK, ← hK, ← hK, hStar, hUnit]
-    noncomm_ring
-  rw [hGap]
-  exact Matrix.posSemidef_sum _ fun i _ ↦
-    Matrix.posSemidef_conjTranspose_mul_self _
-
 variable {ι κ : Type*}
 variable [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
 variable {n : ι → Type*} {m : κ → Type*}
@@ -100,7 +44,27 @@ def IsSchwarzBetweenDirectSums
       (∀ j, Matrix (m j) (m j) ℂ)) : Prop :=
   ∀ A j,
     (T (fun i ↦ (A i)ᴴ * A i) j -
-      (T A j)ᴴ * T A j).PosSemidef
+      T (fun i ↦ (A i)ᴴ) j * T A j).PosSemidef
+
+/-- A completely positive map between finite matrix direct sums preserves
+the adjoint operation.
+
+This is the adjoint-preservation input for the algebraic argument preceding
+arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem IsKrausDirectSumMap.map_conjTranspose_between
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hT : IsKrausDirectSumMap T) (A : ∀ i, Matrix (n i) (n i) ℂ) :
+    T (fun i ↦ (A i)ᴴ) = fun j ↦ (T A j)ᴴ := by
+  have hPositive : IsPositiveMap (directSumMapExtension T) :=
+    fun X hX ↦ IsKrausCP.map_posSemidef hT hX
+  have hStar := hPositive.map_conjTranspose (directSumDiagonalEmbedding A)
+  rw [← directSumDiagonalEmbedding_conjTranspose] at hStar
+  simp only [directSumMapExtension_apply,
+    directSumDiagonalCompression_embedding] at hStar
+  rw [← directSumDiagonalEmbedding_conjTranspose] at hStar
+  apply_fun directSumDiagonalCompression at hStar
+  simpa only [directSumDiagonalCompression_embedding] using hStar
 
 /-- A unital completely positive map between finite matrix direct sums
 satisfies the Schwarz inequality in each output summand.
@@ -132,29 +96,10 @@ theorem IsKrausDirectSumMap.is_schwarz_between_direct_sums
   have hj := directSumDiagonalCompression_posSemidef h j
   simp only [directSumDiagonalCompression_embedding, Pi.sub_apply,
     Pi.mul_apply] at hj
+  rw [← congrFun (hT.map_conjTranspose_between A) j] at hj
   change (T (fun i ↦ (A i)ᴴ * A i) j -
-    (T A j)ᴴ * T A j).PosSemidef at hj
+    T (fun i ↦ (A i)ᴴ) j * T A j).PosSemidef at hj
   exact hj
-
-/-- A completely positive map between finite matrix direct sums preserves
-the adjoint operation.
-
-This is the adjoint-preservation input for the algebraic argument preceding
-arXiv:1606.00608, Appendix C.4, line 1997. -/
-theorem IsKrausDirectSumMap.map_conjTranspose_between
-    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
-      (∀ j, Matrix (m j) (m j) ℂ)}
-    (hT : IsKrausDirectSumMap T) (A : ∀ i, Matrix (n i) (n i) ℂ) :
-    T (fun i ↦ (A i)ᴴ) = fun j ↦ (T A j)ᴴ := by
-  have hPositive : IsPositiveMap (directSumMapExtension T) :=
-    fun X hX ↦ IsKrausCP.map_posSemidef hT hX
-  have hStar := hPositive.map_conjTranspose (directSumDiagonalEmbedding A)
-  rw [← directSumDiagonalEmbedding_conjTranspose] at hStar
-  simp only [directSumMapExtension_apply,
-    directSumDiagonalCompression_embedding] at hStar
-  rw [← directSumDiagonalEmbedding_conjTranspose] at hStar
-  apply_fun directSumDiagonalCompression at hStar
-  simpa only [directSumDiagonalCompression_embedding] using hStar
 
 /-- Mutually inverse unital completely positive maps attain equality in the
 Schwarz inequality at every element. This gives an algebraic alternative to
@@ -174,7 +119,9 @@ theorem schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps
   let Δ : ∀ i, Matrix (n i) (n i) ℂ :=
     F (fun j ↦ (A j)ᴴ * A j) - fun i ↦ (F A i)ᴴ * F A i
   have hΔ (i : ι) : (Δ i).PosSemidef := by
-    exact hF.is_schwarz_between_direct_sums hFOne A i
+    simpa only [Δ, Pi.sub_apply,
+      congrFun (hF.map_conjTranspose_between A) i] using
+        hF.is_schwarz_between_direct_sums hFOne A i
   have hGΔ (j : κ) : (G Δ j).PosSemidef :=
     hG.map_posSemidef hΔ j
   have hGFA : G (F A) = A := by
@@ -192,7 +139,7 @@ theorem schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps
       rw [hGFProduct, hGFA]
       abel
     rw [hIdentity]
-    exact hSchwarz
+    simpa only [congrFun (hG.map_conjTranspose_between (F A)) j] using hSchwarz
   have hGΔZero : G Δ = 0 := by
     funext j
     exact Matrix.PosSemidef.eq_zero_of_neg_posSemidef (hGΔ j) (hNegGΔ j)

--- a/TNLean/Channel/FixedPoint/DirectSumInverseKraus.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumInverseKraus.lean
@@ -1,0 +1,457 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumTraceAdjoint
+
+/-!
+# Inverse completely positive maps between matrix direct sums
+
+This file establishes the multiplicative-domain step for mutually inverse
+completely positive trace-preserving maps between finite direct sums of full
+matrix algebras. Their trace adjoints are mutually inverse unital completely
+positive maps, hence preserve multiplication and the adjoint operation. They
+therefore determine a star-algebra equivalence.
+
+This is the algebraic step preceding the classification of the individual
+simple summands in arXiv:1606.00608, Appendix C.4, line 1997. It provides an
+algebraic route to the classification for which that paper cites
+Wolf--Perez-Garcia, *The inverse eigenvalue problem for quantum channels*,
+arXiv:1005.4545, Theorem 8, source lines 306--324. No permutation or dimension
+matching of summands is asserted here.
+-/
+
+open scoped Matrix MatrixOrder ComplexOrder BigOperators
+
+noncomputable section
+
+namespace Matrix
+
+variable {α β : Type*}
+variable [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+
+/-- A unital rectangular Kraus map satisfies the Kadison--Schwarz inequality.
+
+This is the rectangular Kraus form of the usual Kadison--Schwarz inequality.
+It is the inequality appearing in the definition of a Schwarz map in
+Wolf--Perez-Garcia, arXiv:1005.4545, source line 306. -/
+theorem IsKrausCP.kadison_schwarz_of_map_one_eq_one
+    {E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    (hE : IsKrausCP E) (hOne : E 1 = 1) (X : Matrix α α ℂ) :
+    (E (Xᴴ * X) - (E X)ᴴ * E X).PosSemidef := by
+  obtain ⟨r, K, hK⟩ := hE
+  have hUnital : ∑ i, K i * (K i)ᴴ = (1 : Matrix β β ℂ) := by
+    simpa [hK, Matrix.mul_one] using hOne
+  have hGap :
+      E (Xᴴ * X) - (E X)ᴴ * E X =
+        ∑ i, (X * (K i)ᴴ - (K i)ᴴ * E X)ᴴ *
+          (X * (K i)ᴴ - (K i)ᴴ * E X) := by
+    have hExpand (i : Fin r) :
+        (X * (K i)ᴴ - (K i)ᴴ * E X)ᴴ *
+            (X * (K i)ᴴ - (K i)ᴴ * E X) =
+          K i * (Xᴴ * X) * (K i)ᴴ - K i * Xᴴ * ((K i)ᴴ * E X) -
+            (E X)ᴴ * (K i * X * (K i)ᴴ) +
+              (E X)ᴴ * (K i * (K i)ᴴ) * E X := by
+      simp only [conjTranspose_sub, conjTranspose_mul,
+        conjTranspose_conjTranspose, Matrix.sub_mul, Matrix.mul_sub,
+        Matrix.mul_assoc]
+      abel
+    have hReassocTwo (i : Fin r) :
+        K i * Xᴴ * ((K i)ᴴ * E X) =
+          K i * Xᴴ * (K i)ᴴ * E X := by
+      simp only [Matrix.mul_assoc]
+    have hReassocFour (i : Fin r) :
+        (E X)ᴴ * (K i * (K i)ᴴ) * E X =
+          (E X)ᴴ * K i * (K i)ᴴ * E X := by
+      simp only [Matrix.mul_assoc]
+    simp_rw [hExpand]
+    simp_rw [hReassocTwo, hReassocFour]
+    simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+    rw [← Finset.sum_mul (f := fun i ↦ K i * Xᴴ * (K i)ᴴ)]
+    rw [← Finset.mul_sum (a := (E X)ᴴ) (f := fun i ↦ K i * X * (K i)ᴴ)]
+    rw [← Finset.sum_mul (f := fun i ↦ (E X)ᴴ * K i * (K i)ᴴ)]
+    have hStar : E Xᴴ = (E X)ᴴ := by
+      rw [hK, hK]
+      simp only [conjTranspose_sum, conjTranspose_mul,
+        conjTranspose_conjTranspose, Matrix.mul_assoc]
+    have hUnit : ∑ i, (E X)ᴴ * K i * (K i)ᴴ = (E X)ᴴ := by
+      simp_rw [Matrix.mul_assoc]
+      rw [← Finset.mul_sum, hUnital, Matrix.mul_one]
+    rw [← hK, ← hK, ← hK, hStar, hUnit]
+    noncomm_ring
+  rw [hGap]
+  exact Matrix.posSemidef_sum _ fun i _ ↦
+    Matrix.posSemidef_conjTranspose_mul_self _
+
+variable {ι κ : Type*}
+variable [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+variable {n : ι → Type*} {m : κ → Type*}
+variable [∀ i, Fintype (n i)] [∀ i, DecidableEq (n i)]
+variable [∀ j, Fintype (m j)] [∀ j, DecidableEq (m j)]
+
+/-- A map between two finite direct sums satisfies the Schwarz inequality
+when the inequality holds in every output summand.
+
+This is the heterogeneous direct-sum form of the Schwarz condition in
+Wolf--Perez-Garcia, arXiv:1005.4545, source line 306. -/
+def IsSchwarzBetweenDirectSums
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)) : Prop :=
+  ∀ A j,
+    (T (fun i ↦ (A i)ᴴ * A i) j -
+      (T A j)ᴴ * T A j).PosSemidef
+
+/-- A unital completely positive map between finite matrix direct sums
+satisfies the Schwarz inequality in each output summand.
+
+This is the Schwarz input for the algebraic argument preceding
+arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem IsKrausDirectSumMap.is_schwarz_between_direct_sums
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hT : IsKrausDirectSumMap T) (hOne : T 1 = 1) :
+    IsSchwarzBetweenDirectSums T := by
+  have hCompressionOne :
+      directSumDiagonalCompression
+          (1 : Matrix ((i : ι) × n i) ((i : ι) × n i) ℂ) = 1 := by
+    funext i a b
+    simp [directSumDiagonalCompression, Matrix.one_apply]
+  have hExtensionOne : directSumMapExtension T 1 = 1 := by
+    rw [directSumMapExtension_apply, hCompressionOne, hOne]
+    exact Matrix.blockDiagonal'_one
+  intro A j
+  have h := IsKrausCP.kadison_schwarz_of_map_one_eq_one
+    hT hExtensionOne (directSumDiagonalEmbedding A)
+  rw [← directSumDiagonalEmbedding_conjTranspose,
+    ← directSumDiagonalEmbedding_mul] at h
+  simp only [directSumMapExtension_apply,
+    directSumDiagonalCompression_embedding] at h
+  rw [← directSumDiagonalEmbedding_conjTranspose] at h
+  rw [← directSumDiagonalEmbedding_mul, ← map_sub] at h
+  have hj := directSumDiagonalCompression_posSemidef h j
+  simp only [directSumDiagonalCompression_embedding, Pi.sub_apply,
+    Pi.mul_apply] at hj
+  change (T (fun i ↦ (A i)ᴴ * A i) j -
+    (T A j)ᴴ * T A j).PosSemidef at hj
+  exact hj
+
+/-- A completely positive map between finite matrix direct sums preserves
+the adjoint operation.
+
+This is the adjoint-preservation input for the algebraic argument preceding
+arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem IsKrausDirectSumMap.map_conjTranspose_between
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hT : IsKrausDirectSumMap T) (A : ∀ i, Matrix (n i) (n i) ℂ) :
+    T (fun i ↦ (A i)ᴴ) = fun j ↦ (T A j)ᴴ := by
+  have hPositive : IsPositiveMap (directSumMapExtension T) :=
+    fun X hX ↦ IsKrausCP.map_posSemidef hT hX
+  have hStar := hPositive.map_conjTranspose (directSumDiagonalEmbedding A)
+  rw [← directSumDiagonalEmbedding_conjTranspose] at hStar
+  simp only [directSumMapExtension_apply,
+    directSumDiagonalCompression_embedding] at hStar
+  rw [← directSumDiagonalEmbedding_conjTranspose] at hStar
+  apply_fun directSumDiagonalCompression at hStar
+  simpa only [directSumDiagonalCompression_embedding] using hStar
+
+/-- Mutually inverse unital completely positive maps attain equality in the
+Schwarz inequality at every element. This gives an algebraic alternative to
+the extreme-state argument in Wolf--Perez-Garcia, *The inverse eigenvalue
+problem for quantum channels*, arXiv:1005.4545, Theorem 8, source lines
+318--324. -/
+theorem schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps
+    {F : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)}
+    {G : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hF : IsKrausDirectSumMap F) (hG : IsKrausDirectSumMap G)
+    (hFOne : F 1 = 1) (hGOne : G 1 = 1)
+    (hFG : F.comp G = LinearMap.id) (hGF : G.comp F = LinearMap.id)
+    (A : ∀ j, Matrix (m j) (m j) ℂ) :
+    F (fun j ↦ (A j)ᴴ * A j) = fun i ↦ (F A i)ᴴ * F A i := by
+  let Δ : ∀ i, Matrix (n i) (n i) ℂ :=
+    F (fun j ↦ (A j)ᴴ * A j) - fun i ↦ (F A i)ᴴ * F A i
+  have hΔ (i : ι) : (Δ i).PosSemidef := by
+    exact hF.is_schwarz_between_direct_sums hFOne A i
+  have hGΔ (j : κ) : (G Δ j).PosSemidef :=
+    hG.map_posSemidef hΔ j
+  have hGFA : G (F A) = A := by
+    exact LinearMap.congr_fun hGF A
+  have hGFProduct :
+      G (F (fun j ↦ (A j)ᴴ * A j)) = fun j ↦ (A j)ᴴ * A j := by
+    exact LinearMap.congr_fun hGF _
+  have hNegGΔ (j : κ) : (-G Δ j).PosSemidef := by
+    have hSchwarz := hG.is_schwarz_between_direct_sums hGOne (F A) j
+    have hIdentity :
+        -G Δ j =
+          G (fun i ↦ (F A i)ᴴ * F A i) j -
+            (G (F A) j)ᴴ * G (F A) j := by
+      simp only [Δ, map_sub, Pi.sub_apply]
+      rw [hGFProduct, hGFA]
+      abel
+    rw [hIdentity]
+    exact hSchwarz
+  have hGΔZero : G Δ = 0 := by
+    funext j
+    exact Matrix.PosSemidef.eq_zero_of_neg_posSemidef (hGΔ j) (hNegGΔ j)
+  have hLeftInverse : Function.LeftInverse F G := fun X ↦
+    LinearMap.congr_fun hFG X
+  have hGInjective : Function.Injective G := hLeftInverse.injective
+  have hΔZero : Δ = 0 := hGInjective (by simpa using hGΔZero)
+  exact sub_eq_zero.mp hΔZero
+
+omit [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+    [(i : ι) → DecidableEq (n i)] [(j : κ) → DecidableEq (m j)] in
+private theorem map_mul_of_schwarz_equality
+    {F : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)}
+    (hStar : ∀ A, F (star A) = star (F A))
+    (hEq : ∀ A, F (star A * A) = star (F A) * F A)
+    (A B : ∀ j, Matrix (m j) (m j) ℂ) :
+    F (A * B) = F A * F B := by
+  have hAdd := hEq (star A + B)
+  have hImag := hEq (star A + Complex.I • B)
+  have hA := hEq (star A)
+  have hB := hEq B
+  simp only [star_add, star_star, add_mul, mul_add, map_add, hStar,
+    star_smul, map_smul, smul_add, smul_mul_assoc, mul_smul_comm,
+    smul_smul] at hAdd hImag hA hB ⊢
+  rw [hA, hB] at hAdd hImag
+  have hStarI : star (Complex.I : ℂ) = -Complex.I := by simp
+  rw [hStarI] at hImag
+  norm_num [smul_smul] at hImag
+  funext i
+  have hAddI := congrFun hAdd i
+  have hImagI := congrFun hImag i
+  simp only [Pi.add_apply, Pi.mul_apply, Pi.smul_apply, Pi.neg_apply] at hAddI hImagI
+  have hImagScaled := congrArg
+    (fun X : Matrix (n i) (n i) ℂ ↦ Complex.I • X) hImagI
+  simp only [smul_add, smul_neg, smul_smul, Complex.I_mul_I] at hImagScaled
+  have hTwice :
+      (2 : ℂ) • F (A * B) i = (2 : ℂ) • (F A * F B) i := by
+    linear_combination (norm := module) hAddI - hImagScaled
+  exact (show IsUnit (2 : ℂ) by norm_num).smul_left_cancel.mp hTwice
+
+/-- A member of a mutually inverse pair of unital completely positive maps
+between finite matrix direct sums preserves multiplication.
+
+This is the multiplicative-domain conclusion preceding the block relabeling in
+arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem map_mul_of_mutual_inverse_kraus_direct_sum_maps
+    {F : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)}
+    {G : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    (hF : IsKrausDirectSumMap F) (hG : IsKrausDirectSumMap G)
+    (hFOne : F 1 = 1) (hGOne : G 1 = 1)
+    (hFG : F.comp G = LinearMap.id) (hGF : G.comp F = LinearMap.id)
+    (A B : ∀ j, Matrix (m j) (m j) ℂ) :
+    F (A * B) = F A * F B := by
+  have hStar (X : ∀ j, Matrix (m j) (m j) ℂ) :
+      F (star X) = star (F X) := by
+    change F (fun j ↦ (X j)ᴴ) = fun i ↦ (F X i)ᴴ
+    exact hF.map_conjTranspose_between X
+  have hEquality (X : ∀ j, Matrix (m j) (m j) ℂ) :
+      F (star X * X) = star (F X) * F X := by
+    change F (fun j ↦ (X j)ᴴ * X j) = fun i ↦ (F X i)ᴴ * F X i
+    exact schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps
+      hF hG hFOne hGOne hFG hGF X
+  exact map_mul_of_schwarz_equality hStar hEquality A B
+
+/-- Mutually inverse unital completely positive maps between finite direct
+sums of full matrix algebras determine a star-algebra equivalence.
+
+This packages the algebraic conclusion preceding the block classification in
+arXiv:1606.00608, Appendix C.4, line 1997. It does not classify the simple
+summands. -/
+noncomputable def starAlgEquivOfMutualInverseKrausDirectSumMaps
+    (F : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ))
+    (G : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (hF : IsKrausDirectSumMap F) (hG : IsKrausDirectSumMap G)
+    (hFOne : F 1 = 1) (hGOne : G 1 = 1)
+    (hFG : F.comp G = LinearMap.id) (hGF : G.comp F = LinearMap.id) :
+    (∀ j, Matrix (m j) (m j) ℂ) ≃⋆ₐ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ) := by
+  let f : (∀ j, Matrix (m j) (m j) ℂ) →⋆ₐ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ) :=
+    { AlgHom.ofLinearMap F hFOne
+        (map_mul_of_mutual_inverse_kraus_direct_sum_maps
+          hF hG hFOne hGOne hFG hGF) with
+      map_star' := fun X ↦ by
+        change F (fun j ↦ (X j)ᴴ) = fun i ↦ (F X i)ᴴ
+        exact hF.map_conjTranspose_between X }
+  let g : (∀ i, Matrix (n i) (n i) ℂ) →⋆ₐ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ) :=
+    { AlgHom.ofLinearMap G hGOne
+        (map_mul_of_mutual_inverse_kraus_direct_sum_maps
+          hG hF hGOne hFOne hGF hFG) with
+      map_star' := fun X ↦ by
+        change G (fun i ↦ (X i)ᴴ) = fun j ↦ (G X j)ᴴ
+        exact hG.map_conjTranspose_between X }
+  apply StarAlgEquiv.ofStarAlgHom f g
+  · apply StarAlgHom.ext
+    intro X
+    exact LinearMap.congr_fun hGF X
+  · apply StarAlgHom.ext
+    intro X
+    exact LinearMap.congr_fun hFG X
+
+/-- The forward map of the star-algebra equivalence obtained from a mutually
+inverse unital completely positive pair is the first map.
+
+This identifies the algebraic conclusion preceding arXiv:1606.00608,
+Appendix C.4, line 1997. -/
+@[simp]
+theorem starAlgEquivOfMutualInverseKrausDirectSumMaps_apply
+    (F : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ))
+    (G : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (hF : IsKrausDirectSumMap F) (hG : IsKrausDirectSumMap G)
+    (hFOne : F 1 = 1) (hGOne : G 1 = 1)
+    (hFG : F.comp G = LinearMap.id) (hGF : G.comp F = LinearMap.id)
+    (A : ∀ j, Matrix (m j) (m j) ℂ) :
+    starAlgEquivOfMutualInverseKrausDirectSumMaps
+      F G hF hG hFOne hGOne hFG hGF A = F A :=
+  rfl
+
+/-- The inverse map of the star-algebra equivalence obtained from a mutually
+inverse unital completely positive pair is the second map.
+
+This identifies the algebraic conclusion preceding arXiv:1606.00608,
+Appendix C.4, line 1997. -/
+@[simp]
+theorem starAlgEquivOfMutualInverseKrausDirectSumMaps_symm_apply
+    (F : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ))
+    (G : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (hF : IsKrausDirectSumMap F) (hG : IsKrausDirectSumMap G)
+    (hFOne : F 1 = 1) (hGOne : G 1 = 1)
+    (hFG : F.comp G = LinearMap.id) (hGF : G.comp F = LinearMap.id)
+    (A : ∀ i, Matrix (n i) (n i) ℂ) :
+    (starAlgEquivOfMutualInverseKrausDirectSumMaps
+      F G hF hG hFOne hGOne hFG hGF).symm A = G A :=
+  rfl
+
+omit [(i : ι) → DecidableEq (n i)] [(j : κ) → DecidableEq (m j)] in
+/-- Taking rectangular trace adjoints turns an inverse law into the reversed
+inverse law.
+
+This reversed adjoint law is auxiliary to the alternative algebraic route to
+the classification in arXiv:1606.00608, Appendix C.4, lines 1995--2003; it is
+not asserted explicitly in that passage. -/
+theorem directSumTraceAdjointMapBetween_comp_eq_id_of_comp_eq_id
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ))
+    (hST : S.comp T = LinearMap.id) :
+    (directSumTraceAdjointMapBetween T).comp
+        (directSumTraceAdjointMapBetween S) = LinearMap.id := by
+  rw [← directSumTraceAdjointMapBetween_comp, hST,
+    directSumTraceAdjointMapBetween_id]
+
+/-- The rectangular trace adjoint of either member of a mutually inverse
+CPTP pair preserves multiplication.
+
+This gives the multiplicativity used immediately before the block
+relabeling in arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem directSumTraceAdjointMapBetween_map_mul_of_mutual_inverse
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)}
+    {S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ)}
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id)
+    (A B : ∀ j, Matrix (m j) (m j) ℂ) :
+    directSumTraceAdjointMapBetween T (A * B) =
+      directSumTraceAdjointMapBetween T A *
+        directSumTraceAdjointMapBetween T B := by
+  exact map_mul_of_mutual_inverse_kraus_direct_sum_maps
+    hT.directSumTraceAdjointMapBetween
+    hS.directSumTraceAdjointMapBetween
+    hTTP.directSumTraceAdjointMapBetween_one
+    hSTP.directSumTraceAdjointMapBetween_one
+    (directSumTraceAdjointMapBetween_comp_eq_id_of_comp_eq_id T S hST)
+    (directSumTraceAdjointMapBetween_comp_eq_id_of_comp_eq_id S T hTS) A B
+
+/-- The rectangular trace adjoints of mutually inverse CPTP maps between
+finite matrix direct sums form a star-algebra equivalence.
+
+This star-algebra equivalence is used immediately before the block
+relabeling in arXiv:1606.00608, Appendix C.4, line 1997. -/
+noncomputable def directSumTraceAdjointStarAlgEquiv
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ))
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id) :
+    (∀ j, Matrix (m j) (m j) ℂ) ≃⋆ₐ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ) := by
+  let F := directSumTraceAdjointMapBetween T
+  let G := directSumTraceAdjointMapBetween S
+  have hFG : F.comp G = LinearMap.id := by
+    dsimp only [F, G]
+    exact directSumTraceAdjointMapBetween_comp_eq_id_of_comp_eq_id T S hST
+  have hGF : G.comp F = LinearMap.id := by
+    dsimp only [F, G]
+    exact directSumTraceAdjointMapBetween_comp_eq_id_of_comp_eq_id S T hTS
+  exact starAlgEquivOfMutualInverseKrausDirectSumMaps F G
+    hT.directSumTraceAdjointMapBetween
+    hS.directSumTraceAdjointMapBetween
+    hTTP.directSumTraceAdjointMapBetween_one
+    hSTP.directSumTraceAdjointMapBetween_one hFG hGF
+
+/-- The forward map of the trace-adjoint star-algebra equivalence is the
+rectangular trace adjoint of the first CPTP map.
+
+This identifies the algebraic conclusion preceding arXiv:1606.00608,
+Appendix C.4, line 1997. -/
+@[simp]
+theorem directSumTraceAdjointStarAlgEquiv_apply
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ))
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id)
+    (A : ∀ j, Matrix (m j) (m j) ℂ) :
+    directSumTraceAdjointStarAlgEquiv
+      T S hT hS hTTP hSTP hST hTS A =
+        directSumTraceAdjointMapBetween T A :=
+  rfl
+
+/-- The inverse map of the trace-adjoint star-algebra equivalence is the
+rectangular trace adjoint of the second CPTP map.
+
+This identifies the algebraic conclusion preceding arXiv:1606.00608,
+Appendix C.4, line 1997. -/
+@[simp]
+theorem directSumTraceAdjointStarAlgEquiv_symm_apply
+    (T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (S : (∀ j, Matrix (m j) (m j) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (n i) (n i) ℂ))
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id)
+    (A : ∀ i, Matrix (n i) (n i) ℂ) :
+    (directSumTraceAdjointStarAlgEquiv
+      T S hT hS hTTP hSTP hST hTS).symm A =
+        directSumTraceAdjointMapBetween S A :=
+  rfl
+
+end Matrix

--- a/TNLean/Channel/FixedPoint/DirectSumInverseKraus.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumInverseKraus.lean
@@ -71,7 +71,7 @@ satisfies the Schwarz inequality in each output summand.
 
 This is the Schwarz input for the algebraic argument preceding
 arXiv:1606.00608, Appendix C.4, line 1997. -/
-theorem IsKrausDirectSumMap.is_schwarz_between_direct_sums
+theorem IsKrausDirectSumMap.isSchwarzBetweenDirectSums
     {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
       (∀ j, Matrix (m j) (m j) ℂ)}
     (hT : IsKrausDirectSumMap T) (hOne : T 1 = 1) :
@@ -121,7 +121,7 @@ theorem schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps
   have hΔ (i : ι) : (Δ i).PosSemidef := by
     simpa only [Δ, Pi.sub_apply,
       congrFun (hF.map_conjTranspose_between A) i] using
-        hF.is_schwarz_between_direct_sums hFOne A i
+        hF.isSchwarzBetweenDirectSums hFOne A i
   have hGΔ (j : κ) : (G Δ j).PosSemidef :=
     hG.map_posSemidef hΔ j
   have hGFA : G (F A) = A := by
@@ -130,7 +130,7 @@ theorem schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps
       G (F (fun j ↦ (A j)ᴴ * A j)) = fun j ↦ (A j)ᴴ * A j := by
     exact LinearMap.congr_fun hGF _
   have hNegGΔ (j : κ) : (-G Δ j).PosSemidef := by
-    have hSchwarz := hG.is_schwarz_between_direct_sums hGOne (F A) j
+    have hSchwarz := hG.isSchwarzBetweenDirectSums hGOne (F A) j
     have hIdentity :
         -G Δ j =
           G (fun i ↦ (F A i)ᴴ * F A i) j -

--- a/TNLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
@@ -20,10 +20,12 @@ where trace-preserving completely positive maps run in opposite directions
 between two products of simple matrix algebras.
 
 These are supporting trace-adjoint facts, not a formalization of the
-classification conclusion in that passage. The remaining argument is recorded
-in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`; it still requires
-Schwarz equality, multiplicativity, the relabeling and dimension matching of
-simple summands, and their implementation by unitary conjugations.
+classification conclusion in that passage. Schwarz equality, multiplicativity,
+and the resulting star-algebra equivalence are established in
+`TNLean.Channel.FixedPoint.DirectSumInverseKraus`. The remaining argument,
+recorded in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`, is the
+relabeling and dimension matching of simple summands and their implementation
+by unitary conjugations.
 
 ## Main definitions
 

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -28,6 +28,8 @@ dimensions.
 * `IsKrausCPTP.isKrausCP`: a trace-preserving Kraus map is a Kraus CP map.
 * `IsKrausCP.map_posSemidef`: a Kraus CP map preserves positive
   semidefiniteness.
+* `IsKrausCP.kadison_schwarz_of_map_one_eq_one`: a unital rectangular Kraus
+  map satisfies the Kadison--Schwarz inequality.
 * `IsKrausCP.traceAdjointMap`: the trace adjoint of a Kraus CP map is Kraus CP.
 * `IsKrausCPTP.trace_map`: a map satisfying `IsKrausCPTP` preserves trace.
 * `isKrausCPTP_of_isKrausCP_trace_preserving`: a Kraus CP map that preserves
@@ -123,6 +125,61 @@ theorem IsKrausCP.map_posSemidef
   obtain ⟨r, A, hA⟩ := hS
   rw [hA]
   exact Matrix.posSemidef_sum _ fun i _ => hX.mul_mul_conjTranspose_same (A i)
+
+/-- A unital completely positive map in rectangular Kraus form satisfies the
+Kadison--Schwarz inequality.
+
+This is the dimension-changing counterpart of the usual Kraus
+Kadison--Schwarz inequality. It supplies the Schwarz condition used in
+Wolf--Perez-Garcia, arXiv:1005.4545, source line 306. -/
+theorem IsKrausCP.kadison_schwarz_of_map_one_eq_one
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    (hE : IsKrausCP E) (hOne : E 1 = 1) (X : Matrix α α ℂ) :
+    (E (Xᴴ * X) - (E X)ᴴ * E X).PosSemidef := by
+  obtain ⟨r, K, hK⟩ := hE
+  have hUnital : ∑ i, K i * (K i)ᴴ = (1 : Matrix β β ℂ) := by
+    simpa [hK, Matrix.mul_one] using hOne
+  have hGap :
+      E (Xᴴ * X) - (E X)ᴴ * E X =
+        ∑ i, (X * (K i)ᴴ - (K i)ᴴ * E X)ᴴ *
+          (X * (K i)ᴴ - (K i)ᴴ * E X) := by
+    have hExpand (i : Fin r) :
+        (X * (K i)ᴴ - (K i)ᴴ * E X)ᴴ *
+            (X * (K i)ᴴ - (K i)ᴴ * E X) =
+          K i * (Xᴴ * X) * (K i)ᴴ - K i * Xᴴ * ((K i)ᴴ * E X) -
+            (E X)ᴴ * (K i * X * (K i)ᴴ) +
+              (E X)ᴴ * (K i * (K i)ᴴ) * E X := by
+      simp only [Matrix.conjTranspose_sub, Matrix.conjTranspose_mul,
+        Matrix.conjTranspose_conjTranspose, Matrix.sub_mul, Matrix.mul_sub,
+        Matrix.mul_assoc]
+      abel
+    have hReassocTwo (i : Fin r) :
+        K i * Xᴴ * ((K i)ᴴ * E X) =
+          K i * Xᴴ * (K i)ᴴ * E X := by
+      simp only [Matrix.mul_assoc]
+    have hReassocFour (i : Fin r) :
+        (E X)ᴴ * (K i * (K i)ᴴ) * E X =
+          (E X)ᴴ * K i * (K i)ᴴ * E X := by
+      simp only [Matrix.mul_assoc]
+    simp_rw [hExpand]
+    simp_rw [hReassocTwo, hReassocFour]
+    simp only [Finset.sum_add_distrib, Finset.sum_sub_distrib]
+    rw [← Finset.sum_mul (f := fun i ↦ K i * Xᴴ * (K i)ᴴ)]
+    rw [← Finset.mul_sum (a := (E X)ᴴ) (f := fun i ↦ K i * X * (K i)ᴴ)]
+    rw [← Finset.sum_mul (f := fun i ↦ (E X)ᴴ * K i * (K i)ᴴ)]
+    have hStar : E Xᴴ = (E X)ᴴ := by
+      rw [hK, hK]
+      simp only [Matrix.conjTranspose_sum, Matrix.conjTranspose_mul,
+        Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+    have hUnit : ∑ i, (E X)ᴴ * K i * (K i)ᴴ = (E X)ᴴ := by
+      simp_rw [Matrix.mul_assoc]
+      rw [← Finset.mul_sum, hUnital, Matrix.mul_one]
+    rw [← hK, ← hK, ← hK, hStar, hUnit]
+    noncomm_ring
+  rw [hGap]
+  exact Matrix.posSemidef_sum _ fun i _ ↦
+    Matrix.posSemidef_conjTranspose_mul_self _
 
 /-- The trace adjoint of a completely positive map in rectangular Kraus form
 is completely positive. A Kraus family `A i` for the original map gives the

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2532,11 +2532,12 @@ $\bigoplus_k \Id_{m_k} \otimes \MN{d_k}$.
     classification conclusion of that passage.
 \end{definition}
 
-The preceding definition and the elementary laws below provide supporting
-facts for the classification argument.  They do not prove Schwarz equality
-for the transported maps, multiplicativity, a relabeling or dimension matching
-of the simple summands, or implementation on each summand by unitary
-conjugation.
+The preceding definition and the trace-adjoint laws in the next lemma provide
+supporting facts for the classification argument.  By themselves, they do not
+prove Schwarz equality or multiplicativity.  The inverse-CPTP theorem below
+supplies those two conclusions; relabeling and dimension matching of the simple
+summands, and implementation on each summand by unitary conjugation, remain
+outside the present result.
 
 \begin{lemma}[Trace-adjoint laws for two finite sums of matrix algebras]%
     \label{lem:direct_sum_rectangular_trace_adjoint}
@@ -2754,6 +2755,58 @@ conjugation.
           -\widehat{F^*}(Y^*)\widehat{F^*}(Y)\right]_i
         =(F^*(X^*X))_i-(F^*(X^*))_i(F^*(X))_i\succeq0.
     \]
+\end{proof}
+
+\begin{theorem}[Mutually inverse CPTP maps give a star equivalence]%
+    \label{thm:direct_sum_inverse_cptp_star_equiv}
+    \lean{Matrix.IsKrausCP.kadison_schwarz_of_map_one_eq_one}
+    \lean{Matrix.IsSchwarzBetweenDirectSums}
+    \lean{Matrix.IsKrausDirectSumMap.is_schwarz_between_direct_sums}
+    \lean{Matrix.IsKrausDirectSumMap.map_conjTranspose_between}
+    \lean{Matrix.schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps}
+    \lean{Matrix.map_mul_of_mutual_inverse_kraus_direct_sum_maps}
+    \lean{Matrix.starAlgEquivOfMutualInverseKrausDirectSumMaps}
+    \lean{Matrix.starAlgEquivOfMutualInverseKrausDirectSumMaps_apply}
+    \lean{Matrix.starAlgEquivOfMutualInverseKrausDirectSumMaps_symm_apply}
+    \lean{Matrix.directSumTraceAdjointMapBetween_comp_eq_id_of_comp_eq_id}
+    \lean{Matrix.directSumTraceAdjointMapBetween_map_mul_of_mutual_inverse}
+    \lean{Matrix.directSumTraceAdjointStarAlgEquiv}
+    \lean{Matrix.directSumTraceAdjointStarAlgEquiv_apply}
+    \lean{Matrix.directSumTraceAdjointStarAlgEquiv_symm_apply}
+    \leanok
+    \uses{def:kraus_map_between_direct_sums,
+        lem:direct_sum_rectangular_trace_adjoint}
+    Let $T:\mathcal A\to\mathcal B$ and $S:\mathcal B\to\mathcal A$ be
+    mutually inverse completely positive trace-preserving maps between finite
+    direct sums of full matrix algebras.  Their trace adjoints are mutually
+    inverse unital completely positive maps.  Moreover, for all
+    $X,Y\in\mathcal B$,
+    \[
+        T^*(XY)=T^*(X)T^*(Y),
+        \qquad T^*(X^*)=T^*(X)^*,
+    \]
+    and likewise for $S^*$.  Thus $T^*$ and $S^*$ determine mutually inverse
+    star-algebra equivalences.  This theorem does not yet identify the simple
+    summands or their dimensions.
+\end{theorem}
+
+\begin{proof}\leanok
+    Complete positivity and trace preservation make both trace adjoints
+    unital Schwarz maps.  For $F=T^*$ and $G=S^*$, let
+    \[
+        \Delta_F(X)=F(X^*X)-F(X)^*F(X)\succeq0.
+    \]
+    Positivity of $G$ gives $G(\Delta_F(X))\succeq0$.  The Schwarz inequality
+    for $G$, together with $GF=\operatorname{id}$, gives
+    $-G(\Delta_F(X))\succeq0$.  Hence $G(\Delta_F(X))=0$, and injectivity of
+    $G$ implies $\Delta_F(X)=0$.  Polarization of this equality gives
+    multiplicativity.  Positivity gives preservation of the adjoint, so the
+    mutually inverse maps are star-algebra equivalences.  This supplies an
+    algebraic route to the block-classification step for which
+    \cite[Appendix~C.4, line~1997]{Cirac2016MPDO_arXiv} cites
+    \cite[Theorem~8]{WolfPerezGarcia2010Inverse}.  The latter instead uses
+    extreme states and the positive inverse to identify the blocks, then the
+    Schwarz condition to exclude transposition.
 \end{proof}
 
 % Scope restriction documented in

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2761,7 +2761,7 @@ outside the present result.
     \label{thm:direct_sum_inverse_cptp_star_equiv}
     \lean{IsKrausCP.kadison_schwarz_of_map_one_eq_one}
     \lean{Matrix.IsSchwarzBetweenDirectSums}
-    \lean{Matrix.IsKrausDirectSumMap.is_schwarz_between_direct_sums}
+    \lean{Matrix.IsKrausDirectSumMap.isSchwarzBetweenDirectSums}
     \lean{Matrix.IsKrausDirectSumMap.map_conjTranspose_between}
     \lean{Matrix.schwarz_equality_of_mutual_inverse_kraus_direct_sum_maps}
     \lean{Matrix.map_mul_of_mutual_inverse_kraus_direct_sum_maps}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2759,7 +2759,7 @@ outside the present result.
 
 \begin{theorem}[Mutually inverse CPTP maps give a star equivalence]%
     \label{thm:direct_sum_inverse_cptp_star_equiv}
-    \lean{Matrix.IsKrausCP.kadison_schwarz_of_map_one_eq_one}
+    \lean{IsKrausCP.kadison_schwarz_of_map_one_eq_one}
     \lean{Matrix.IsSchwarzBetweenDirectSums}
     \lean{Matrix.IsKrausDirectSumMap.is_schwarz_between_direct_sums}
     \lean{Matrix.IsKrausDirectSumMap.map_conjTranspose_between}

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -39,6 +39,15 @@
   doi          = {10.1007/BF02099178},
 }
 
+@unpublished{WolfPerezGarcia2010Inverse,
+  author       = {Wolf, Michael M. and P{\'e}rez-Garc{\'i}a, David},
+  title        = {The Inverse Eigenvalue Problem for Quantum Channels},
+  year         = {2010},
+  eprint       = {1005.4545},
+  eprinttype   = {arxiv},
+  note         = {Preprint},
+}
+
 @misc{Wolf2012Quantum,
   author       = {Wolf, Michael M.},
   title        = {Quantum Channels \& Operations: Guided Tour},

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -261,7 +261,7 @@ basis-of-normal-tensors conclusion that products of the fixed contraction
 subproblem is closed for the individual maps and their square composites even
 though the active-image inclusions remain unproved.
 
-\section{Sector relabelling uses positivity, not linear isomorphism}
+\section{Sector relabelling from the star-algebra equivalence}
 
 After proving mutual invertibility, CPSV16 cites the argument of
 Wolf--P\'erez-Garc\'ia, Theorem~8
@@ -281,17 +281,16 @@ the transpose alternative
 \cite[Theorem~8 and its proof]{WolfPerezGarcia2010Inverse}.
 
 A linear equivalence between two finite products of matrix spaces does not
-determine their simple summands.  Likewise, the existing theorem that ring
-automorphisms permute simple block ideals cannot be applied until
-multiplicativity has been derived.  The sector relabelling therefore requires
-one of the following source-faithful routes:
+determine their simple summands.  The trace adjoints of a mutually inverse
+CPTP pair have now been proved to be mutually inverse $*$-algebra
+homomorphisms, by the Schwarz-defect argument above.  The sector relabelling
+therefore reduces to the following source-faithful algebraic step:
 \begin{enumerate}
-    \item formalize the positive order-isomorphism argument on the normalized
-          density-operator sections and then exclude transposition by the
-          Schwarz inequality; or
-    \item prove that mutually inverse completely positive maps between the
-          direct sums are $*$-isomorphisms, and apply uniqueness of the simple
-          summands.
+    \item apply uniqueness of the simple summands to this $*$-algebra
+          equivalence, obtaining the sector permutation and equality of the
+          corresponding matrix dimensions;
+    \item identify each matched simple-summand isomorphism with unitary
+          conjugation.
 \end{enumerate}
 
 \section{Elimination plan}
@@ -306,21 +305,22 @@ The first two steps of the Appendix~C.4 argument are complete:
           composite, using the fixed contraction families and the proved
           product-generation theorem, and gives both identity compositions;
 \end{enumerate}
-The remaining step is to derive the sector permutation and matching dimensions
-from the resulting positive, trace-preserving inverse pair, retaining the
-Schwarz hypothesis for the unitary-conjugation conclusion.
+The inverse-UCP multiplicative-domain step is also complete: the rectangular
+trace adjoints form mutually inverse $*$-algebra equivalences.  The remaining
+step is the simple-summand classification of this equivalence, giving the
+sector permutation, matching dimensions, and unitary conjugations.
 
 \section{Classification}
 
-\textbf{Verdict: transported-map invertibility closed; sector relabelling
-open.}  The two transported maps and their square composites are trace
-preserving under the source tensor hypotheses, and the trace adjoints of the
-square composites satisfy the Schwarz inequality.  The positive-definite
-fixed-family construction, density-block product-span bound, and abstract
-identity criterion prove that both composites are identities.  The stronger
-active-image inclusions remain unproved and are not needed for this route.
-The sector permutation, matching dimensions, and unitary-conjugation
-classification from Appendix~C.4, lines~1995--2003 remain open.
+\textbf{Verdict: transported-map invertibility and the inverse-UCP
+multiplicative-domain step are closed; sector relabelling remains open.}  The
+two transported maps and their square composites are trace preserving under
+the source tensor hypotheses.  Their two compositions are identities, and
+the rectangular trace adjoints form mutually inverse $*$-algebra
+equivalences.  The stronger active-image inclusions remain unproved and are
+not needed for this route.  The sector permutation, matching dimensions, and
+unitary-conjugation classification from Appendix~C.4, lines~1995--2003 remain
+open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

CPSV16 Appendix C.4 reaches a pair of mutually inverse transported completely positive trace-preserving maps between heterogeneous finite direct sums of matrix algebras. Before classifying the simple summands, one needs the algebraic fact that the corresponding trace adjoints form a star-algebra equivalence.

### Description

- Prove a rectangular Kraus form of the Kadison–Schwarz inequality.
- Establish Schwarz and adjoint preservation for heterogeneous direct-sum trace adjoints.
- Show that mutual inverse laws force both Schwarz defects to vanish.
- Derive multiplicativity by polarization and package the mutually inverse maps as a `StarAlgEquiv`.
- Reverse the inverse laws under the total trace pairing and expose the resulting trace-adjoint `StarAlgEquiv`.
- Add stable `[simp]` lemmas for the forward and inverse applications.
- Update the root import, chapter 7 blueprint, bibliography, predecessor documentation, and the CPSV16 paper-gap status.

The contribution does not assert a permutation of summands, equality of block dimensions, unitary implementation, multiplicity data, or coefficient relations. Those classification steps remain in LionSR/QICLean#247.

### Sources

- CPSV16, arXiv:1606.00608, Appendix C.4, source lines 1974–1997.
- Wolf–Pérez-García, arXiv:1005.4545, Theorem 8, source lines 306–324.

The Schwarz-defect argument used here is an alternative consequence of mutual complete positivity; it is not attributed as a lemma stated in Theorem 8.

### Testing

- focused Lean check and module build
- `lake env lean TNLean.lean`
- `lake build TNLean`
- focused `leanblueprint checkdecls` for all 14 declarations
- proof-integrity, terminology, line-length, tactic-pattern, and diff checks
- `python3 scripts/check_oversized_lean_files.py --root .`

Closes LionSR/QICLean#248
Related: LionSR/QICLean#247, LionSR/TNLean#232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean additions and documentation; no runtime, auth, or data-path changes. Risk is mainly proof-maintenance surface in channel fixed-point theory.
> 
> **Overview**
> Adds **`TNLean.Channel.FixedPoint.DirectSumInverseKraus`** and wires it into the root import. For mutually inverse Kraus direct-sum CPTP maps, the PR proves rectangular **Kadison–Schwarz** (`IsKrausCP.kadison_schwarz_of_map_one_eq_one` in `KrausCPTP.lean`), per-summand Schwarz and adjoint preservation, **Schwarz equality** from mutual inverses, **multiplicativity** by polarization, and packages the maps as **`starAlgEquivOfMutualInverseKrausDirectSumMaps`** / **`directSumTraceAdjointStarAlgEquiv`** with `[simp]` lemmas.
> 
> **Blueprint** chapter 7 gains Theorem “Mutually inverse CPTP maps give a star equivalence”; **`DirectSumTraceAdjoint`** and **`docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`** now record Schwarz/multiplicativity/star-equivalence as done and leave **summand relabeling, dimension matching, and unitary implementation** open. Adds **`WolfPerezGarcia2010Inverse`** to the bibliography.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48cf5dc3ad41c11532cbf4bea7ad7fa583b8a183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->