### PR TITLE
docs(tenkz): migrate Choi matrix diagram

### DIFF
--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -106,7 +106,25 @@ The Choi--Jamio\l{}kowski isomorphism bends the input legs of the channel $T$
 around the maximally entangled pair $\ket{\Omega}$, presenting the map as the
 matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
 \begin{center}
-    \TNChoiMatrix
+    % Formula: \tau=(T\otimes\id)(\ketbra{\Omega}{\Omega}).
+    % Source verdict: Wolf, Proposition 2.1 and Equation (2.1), applies the
+    %   two-wire map T\otimes\id to the maximally entangled projector.
+    % In indices, \tau_{(i_1,i_2),(j_1,j_2)}
+    %   =D^{-1}(T(E_{i_2j_2}))_{i_1j_1}; there is no summed Kraus index and
+    %   therefore no pairleg between the two rails.
+    % The east matrix cup is the input projector \ketbra{\Omega}{\Omega}.
+    % The opaque two-wire atom acts by T on one tensor factor and by \id on
+    %   the other; the two west rails are the output indices of \tau.
+    % Boundary signature: (virtual-west=2 | virtual-east=0 |
+    % physical-up=0 | physical-down=0).
+    \begin{tenkz}[
+        rows={wire,wire},
+        east={cup=$\ketbra{\Omega}{\Omega}$},
+        west label=$\tau$
+    ]
+        \tnghost{} & \tnX[wires=2]{T\otimes\id} & \tnghost{} \\
+        \tnghost{} & & \tnghost{}
+    \end{tenkz}
 \end{center}
 
 \begin{definition}[Choi matrix]\label{def:choi_matrix}

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -155,7 +155,7 @@ Note: the 7 hand-digitized region polygons inside `tn_motifs_peps.tex` all becom
 |---|---|---|---|
 | TNKrausMap | ch16_channel_representations:467 | `[sandwich, east={cup=$\rho$}, west label=$T(\rho)$]: \tn{K_i} \\ \tn*{K_i}` | source-faithful applied channel; exact boundary `(2,0,0,0)`, no package change |
 | TNStinespring | ch16_channel_representations:768 | `[sandwich, east={cup=$\rho$}, west label=$T(\rho)$]: \tn{V} \\ \tn*{V}` | migrated inline (applied channel; the house input is the east cup; the unique unlabelled pairleg traces $E$) |
-| TNChoiMatrix | ch16_channel_representations:108 | `[sandwich, close west={$\Omega$}]: \tn{T} \\ \tn{\mathrm{id}}` | trivial (0.6 bare identity-wire atom would let `id` be a plain wire) |
+| TNChoiMatrix | ch16_channel_representations:108 | `[rows={wire,wire}, east={cup=$\ketbra{\Omega}{\Omega}$}, west label=$\tau$]: \tnghost{} & \tnX[wires=2]{T\otimes\id} & \tnghost{} \\ \tnghost{} & & \tnghost{}` | applied two-wire Choi map; zero pairlegs, exact boundary `(2,0,0,0)`, no package change |
 | TNTransferMapTracePairing | ch16_channel_representations:1478 | demote: `T(\rho)=\sum_{ij}t_{ij}\tr(\sigma_j\rho)\,\sigma_i` (+ optional `\tnpic[inline, periodic]{\tnX{\sigma_j}&\tnX{\rho}}` for the trace loop) | needs-judgment (candidate demotion to plain math) |
 | TNTwoPointCorrelator | ch14_correlations:50 | `[sandwich, west={cup=$Y$}, east={cup=$X\rho^R$}]` with `\tnX[wires=2]{\mathcal E_A^n}` between ghost anchors | trivial (a doubled-index map between input and trace-pairing cups; not a periodic word) |
 

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -920,21 +920,6 @@
 
 % ---------- Quantum-channel representation diagrams ----------
 
-% Choi--Jamiolkowski isomorphism tau = (T tensor id)(|Omega><Omega|): the channel
-% T (double layer) has its input legs bent around the maximally entangled pair
-% |Omega|, presenting the map as a matrix on the doubled space.
-\TNDeclareDiagram
-    {TNChoiMatrix}
-    {}
-    {display}
-    {compact}
-    {\TNChoiMatrix}
-    {chapter/ch16_channel_representations.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNChoiMatrixMotif
-    \end{TNDiagram}%
-}
-
 % Trace-pairing transfer form
 % T(rho)=sum_{i,j} t_ij tr(sigma_j rho) sigma_i.  The trace loop passes through
 % rho and sigma_j; the scalar coefficient t_ij joins the two basis labels, and

--- a/tex/tn/tn_motifs_peps.tex
+++ b/tex/tn/tn_motifs_peps.tex
@@ -8,10 +8,6 @@
     \TN@annotationterminal{#1}{#2}%
     \TN@label{#1}{(0,0)}{#3}%
 }
-\newcommand{\TN@motiflabelleft}[3]{%
-    \TN@annotationterminal{#1}{#2}%
-    \TN@label[anchor=east]{#1}{(0,0)}{#3}%
-}
 \newcommand{\TN@motiflabelright}[3]{%
     \TN@annotationterminal{#1}{#2}%
     \TN@label[anchor=west]{#1}{(0,0)}{#3}%
@@ -716,18 +712,6 @@
         \TN@motiflabel{tnClientLabel2112}{(-0.42,0.60)}{c_{v,e_3}}
         \TN@motiflabel{tnClientLabel2113}{(0.42,-0.60)}{c_{v,e_4}}
         \TN@motiflabel{tnClientLabel2114}{(2.35,0)}{\displaystyle\prod_{e \ni v} c_{v,e} = 1}
-}
-
-% TNChoiMatrix
-\newcommand{\TNChoiMatrixMotif}{%
-        \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNChoiMatrix|kind=quantum-channel}%
-        \TNStackedMPOProduct{cm}{(0,0)}{T}{\mathrm{id}}{}
-        \TNOpenVirtualWest{cmUpperWest}
-        \TNOpenVirtualWest{cmLowerWest}
-        \TNOpenVirtualEast{cmUpperEast}
-        \TNOpenVirtualEast{cmLowerEast}
-        \TN@motiflabelleft{tnClientLabel2160}{(-0.70,0)}{\ket{\Omega}\!\bra{\Omega}}
-        \TN@motiflabelright{tnClientLabel2161}{(0.70,0)}{\tau}
 }
 
 % TNTransferMapTracePairing


### PR DESCRIPTION
Closes LionSR/tenkz#51.

Exact head: `72d168a75513b1679eae8c71af9673c777439a81`.

## Summary

- replace the legacy `\TNChoiMatrix` catalogue diagram with an inline `tenkz` Choi contraction
- draw two neutral wire rows through one opaque `T\otimes\mathrm{id}` map, fed by the east projector cup and leaving two west output rails labelled `\tau`
- remove the now-unused catalogue declaration, motif, and private label helper, and correct the migration map's former sandwich sketch

## Source fidelity

Wolf, Proposition 2.1 and Equation (2.1), defines

```tex
\tau=(T\otimes\mathrm{id})(|\Omega\rangle\langle\Omega|).
```

The old stacked-product motif introduced a false inter-row contraction. The new opaque two-wire map has no Kraus index and therefore no pairleg. Its compiled event block is:

```text
atom|picture=11|cell=1-2|kind=onwire|role=none|species=none
faceports|picture=11|cell=1-2|face=west|arity=2|at=rows
faceports|picture=11|cell=1-2|face=east|arity=2|at=rows
cup|picture=11|side=east|top=1|bottom=2|matrix=1
boundary|picture=11|virtual-west=2|virtual-east=0|physical-up=0|physical-down=0
```

## Validation

- `python3 scripts/tenkz_lint.py blueprint/src/chapter/ch16_channel_representations.tex tex/tn/tn_catalogue.tex tex/tn/tn_motifs_peps.tex`
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/check_tn_references.py --margins-only`
- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --check-slides --audit --audit-strict --smoke-render`
- `python3 scripts/tenkz_audit.py blueprint/print/print.tnlog` (no hard errors; inherited advisories only)
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- `git diff --check`

Visually inspected fresh PDF page 369 and generated SVG `tenkz-90ba18562bdb1bfa.svg`; both show the same unclipped east-input/west-output two-wire Choi map.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pedagogical LaTeX/diagram migration only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Replaces the legacy **Choi–Jamiołkowski** figure in ch16 with an inline **`tenkz`** contraction and drops the old catalogue/motif plumbing.
> 
> The new drawing matches Wolf’s \(\tau=(T\otimes\mathrm{id})(\ketbra{\Omega}{\Omega})\): an east **matrix cup** for the maximally entangled projector, a **two-wire** opaque **`T\otimes\mathrm{id}`** atom (no Kraus **pairleg**), and two west rails labelled **\(\tau\)**. The prior stacked-product motif incorrectly suggested an inter-row contraction; **MIGRATION-MAP** is updated to the new spelling.
> 
> Removes **`TNChoiMatrix`** from **`tn_catalogue.tex`**, **`TNChoiMatrixMotif`** from **`tn_motifs_peps.tex`**, and the unused **`TN@motiflabelleft`** helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d168a75513b1679eae8c71af9673c777439a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->