### PR TITLE
docs(blueprint): migrate boundary-regrow trace diagram

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
@@ -635,7 +635,24 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     restrictions on their common $(L-1)$-site overlap and then reconstructs the
     full $(L+1)$-site word from a single boundary matrix:
     \begin{center}
-        \TNBoundaryRegrow{X'}{\sigma_1}{\sigma_{L+1}}{L+1}
+        % Formula/source: Perez-Garcia et al., Eq. (eq:injectivity), define
+        % Gamma_{L+1}(X') by the coefficients
+        % tr(X' A^{sigma_1} ... A^{sigma_{L+1}}).
+        % In indices, this is the sum of
+        % X'_{a_0 a_1}(A^{sigma_1})_{a_1 a_2} ...
+        % (A^{sigma_{L+1}})_{a_{L+1} a_0} over every virtual index a_r.
+        % The physical indices sigma_1,...,sigma_{L+1} remain free.
+        % Orientation: placing X' first matches the source's cyclic order;
+        % the periodic return closes the final A factor back into X'.
+        % Semantic boundary signature: (virtual-west=0 | virtual-east=0 |
+        % physical-up=L+1 | physical-down=0).  This finite schematic emits
+        % (virtual-west=0 | virtual-east=0 | physical-up=3 | physical-down=0).
+        \begin{tenkz}[periodic, physical=up]
+            \tnX{X'} &
+            \tn[up=$\sigma_1$]{A}%
+            \tnspan[brace below]{4}{$L+1\text{ sites}$} &
+            \tn{A} & \tndots & \tn[up=$\sigma_{L+1}$]{A}
+        \end{tenkz}
     \end{center}
     \begin{enumerate}
         \item From the right ground condition, for each physical index~$i$ there

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -118,7 +118,7 @@ The wrapper (`TNEquationRow` around a single `\ensuremath`) draws nothing; Phase
 | TNPEPSNormalRegionT | 2 | ch24_peps_ft_normal_square:95,1217 | `tenkzlattice` + `\tnregion[slot=selected, label=$T$]{…}` | trivial |
 | TNPEPSGaugeVertexAction | 2 | ch24_peps_ft_balanced_edge_scalars:206; ch24_peps_ft_foundations:106 | tenkzfree star with $Z_{e_i}^{\pm1}$ nodes on each leg (FourBondGaugeStar shape) | needs-judgment (free-tier star) |
 | TNLocalEqualityStep | 2 | ch23_algebraic_ft:409,1646 | `\tnpic[physical=up]{\tn{}&\tnX{#1}&\tn[up=$#3$]{}} = \tnpic[physical=up]{\tn{}&\tnX{#2}&\tn[up=$#3$]{}}` | trivial |
-| TNBoundaryRegrow | 2 | ch23_algebraic_ft:407; ch13_parent_hamiltonian_injective_ground_spaces:638 | `\tnpic[physical=up]{\tn[up=$#2$]{}&\tn{}&\tn[up=$#3$]{}&\tnX{#1}}` + length label below | trivial |
+| TNBoundaryRegrow | 2 at census; 1 before this migration | ch23_algebraic_ft:407 (migrated inline in #4403); ch13_parent_hamiltonian_injective_ground_spaces:638 (migrated here) | `[periodic, physical=up]: \tnX{X'} & \tn[up=$\sigma_1$]{A} & \tn{A} & \tndots & \tn[up=$\sigma_{L+1}$]{A}` + an `$L+1$ sites` brace | migrated inline here as the traced word defining $\Gamma_{L+1}(X')$ |
 
 ## 3. cd genre → tenkzcd / `\tntree` (5 entries)
 

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -445,31 +445,6 @@
 }
 
 \TNDeclareDiagram
-    {TNBoundaryRegrow}
-    {virtual,left,right,length}
-    {display}
-    {normal}
-    {\TNBoundaryRegrow{X}{i}{k}{L}}
-    {chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex}{%
-    \begin{TNDiagram}[normal]
-        \TNMPSSite{rA}{at=origin}{}
-        \TNMPSSite{rB}{right=of rA}{}
-        \TNMPSSite{rC}{right=of rB}{}
-        \TNInsertion{rX}{right=of rC}{#1}
-        \foreach \n in {rA,rB,rC} {\TNOpenPhysicalNorth{\n Ket}}
-        \TNLabelAbove{rA}{#2}
-        \TNLabelAbove{rC}{#3}
-        \TNOpenVirtualWest{rAWest}
-        \TNConnectVirtual{rAEast}{rBWest}
-        \TNConnectVirtual{rBEast}{rCWest}
-        \TNVirtualPort{rXTorC}{rX}{west}
-        \TNConnectVirtual{rCEast}{rXTorC}
-        \TNVirtualPort{rXOpenEastPort}{rX}{east}\TNOpenVirtualEast{rXOpenEastPort}
-        \TNLabelBelow{rB}{#4}
-    \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
     {TNGroundSpaceMap}
     {tensor,left,right,length,virtual}
     {display}


### PR DESCRIPTION
Closes #4493

## Summary

- replace the legacy `\TNBoundaryRegrow` call with a local tenkz spelling of the traced word defining `\Gamma_{L+1}(X')`
- make the virtual contraction periodic, so the diagram has no open virtual boundary
- retire the now-unused catalogue declaration and record the migration against the map's historical census

## Mathematical contract

Pérez-García et al. define the coefficients of `\Gamma_{L+1}(X')` by
`\operatorname{tr}(X' A^{\sigma_1}\cdots A^{\sigma_{L+1}})`.
Thus every virtual index is contracted, while the physical indices
`\sigma_1,\ldots,\sigma_{L+1}` remain free.

- semantic boundary: `(virtual-west=0 | virtual-east=0 | physical-up=L+1 | physical-down=0)`
- finite schematic emitted by the source: `(virtual-west=0 | virtual-east=0 | physical-up=3 | physical-down=0)`

The old catalogue macro instead opened both horizontal ends, so it depicted an
open word rather than the trace used in the proof.

## Validation

Validated at head `6323d91ea23fd9fef3bee335a58a30aedbb72d86`, rebased directly onto
`832b01d7008d7cddd1e5ed16af3e9a0245f553db`.

- `python3 scripts/tenkz_lint.py 'blueprint/src/chapter/*.tex' 'docs/tenkz/manual2.tex' 'docs/tenkz/chapters2/*.tex' 'tex/tenkz/examples/*.tex'`
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --check-slides --audit --audit-strict --smoke-render`
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/test_tenkz_index_routing.py`
- changed-lines reader-facing prose check
- `chktex` over blueprint, catalogue, and tenkz examples
- standalone target render plus `scripts/tenkz_audit.py`: zero advisories
- `leanblueprint pdf`: 699-page PDF built; current-main target page inspected
- `leanblueprint web`: current-main target SVG inspected

The repository-wide latexindent check remains advisory and still reports the
pre-existing indentation at chapter 13 line 325; the newly added diagram
matches latexindent's output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reader-facing diagram and catalogue cleanup only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Completes the **TNBoundaryRegrow** tenkz migration for the intersection-property proof in chapter 13.
> 
> The proof figure no longer calls `\TNBoundaryRegrow`. It uses a local **`tenkz`** environment with **`periodic`** and **`physical=up`**: boundary matrix **`X'`**, an **`L+1`**-site **`A`** chain with free labels \(\sigma_1,\ldots,\sigma_{L+1}\), and a brace for the site count. Comments tie the picture to Pérez-García et al. and note that virtual indices are fully contracted (no open horizontal ends), unlike the old catalogue drawing.
> 
> **`tex/tn/tn_catalogue.tex`** drops the **`TNBoundaryRegrow`** `\TNDeclareDiagram` block. **`docs/tenkz/MIGRATION-MAP.md`** records that ch13 is migrated here and ch23 was done in #4403.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6323d91ea23fd9fef3bee335a58a30aedbb72d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->