### PR TITLE
feat(Channel/FixedPoint): match inverse CPTP simple summands

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -208,7 +208,7 @@ import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
 import TNLean.Channel.FixedPoint.TraceNonincreasingProductSpan
 import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
 import TNLean.Channel.FixedPoint.DirectSumTraceAdjoint
-import TNLean.Channel.FixedPoint.DirectSumInverseKraus
+import TNLean.Channel.FixedPoint.DirectSumBlockPermutation
 import TNLean.Channel.FixedPoint.CornerAlgebra
 import TNLean.Channel.FixedPoint.CornerBlockForm
 import TNLean.Channel.FixedPoint.StationaryProjection

--- a/TNLean/Algebra/BlockPermutation.lean
+++ b/TNLean/Algebra/BlockPermutation.lean
@@ -92,6 +92,36 @@ noncomputable def blockIdeal (R : ι → Type*) [∀ i, Ring (R i)] [∀ i, IsSi
   (twoSidedIdealPiOrderIso (R := R)).symm
     (Function.update (⊥ : ∀ j, TwoSidedIdeal (R j)) i ⊤)
 
+/-- An element belongs to the block ideal at `i` precisely when every other
+component vanishes. -/
+theorem mem_blockIdeal_iff {i : ι} {x : ∀ j, R j} :
+    x ∈ blockIdeal R i ↔ ∀ j, j ≠ i → x j = 0 := by
+  classical
+  have hEq : blockIdeal R i =
+      (Ideal.pi fun j ↦
+        ((Function.update (⊥ : ∀ k, TwoSidedIdeal (R k)) i ⊤) j).asIdeal).toTwoSided := by
+    simp [blockIdeal, twoSidedIdealPiOrderIso]
+  rw [hEq, Ideal.mem_toTwoSided, Ideal.mem_pi]
+  constructor
+  · intro h j hj
+    have hjMem := h j
+    rw [Function.update_of_ne hj] at hjMem
+    exact TwoSidedIdeal.mem_asIdeal.mp hjMem
+  · intro h j
+    by_cases hj : j = i
+    · subst hj
+      rw [Function.update_self]
+      exact TwoSidedIdeal.mem_asIdeal.mpr trivial
+    · rw [Function.update_of_ne hj]
+      exact TwoSidedIdeal.mem_asIdeal.mpr
+        (h j hj ▸ (⊥ : TwoSidedIdeal (R j)).asIdeal.zero_mem)
+
+/-- A tuple supported in one component belongs to the corresponding block
+ideal. -/
+theorem pi_single_mem_blockIdeal {i : ι} (x : R i) :
+    Pi.single i x ∈ blockIdeal R i :=
+  mem_blockIdeal_iff.mpr (fun _ hj ↦ Pi.single_eq_of_ne hj x)
+
 /-- Under `twoSidedIdealPiOrderIso`, the block ideal becomes the function which is `⊤` at `i` and
 `⊥` elsewhere. -/
 @[simp] lemma twoSidedIdealPiOrderIso_blockIdeal (i : ι) :
@@ -103,7 +133,9 @@ noncomputable def blockIdeal (R : ι → Type*) [∀ i, Ring (R i)] [∀ i, IsSi
 theorem isAtom_blockIdeal (i : ι) : IsAtom (blockIdeal R i) := by
   classical
   rw [← (twoSidedIdealPiOrderIso (R := R)).isAtom_iff]
-  simpa using Pi.isAtom_single (isAtom_top (α := TwoSidedIdeal (R i)))
+  simpa only [twoSidedIdealPiOrderIso_blockIdeal] using
+    (@Pi.isAtom_single ι (fun j ↦ TwoSidedIdeal (R j)) i _ _ _ _
+      (isAtom_top (α := TwoSidedIdeal (R i))))
 
 /-- Atoms in `TwoSidedIdeal (∀ i, R i)` are exactly the block ideals. -/
 theorem isAtom_iff_exists_eq_blockIdeal (I : TwoSidedIdeal (∀ i, R i)) :
@@ -172,6 +204,145 @@ theorem ringEquiv_pi_simple_permutes_blockIdeals
     ⟨Equiv.ofBijective σfun ⟨hσfun_inj, hσfun_surj⟩, fun i => ?_⟩
   simpa using hσfun i
 
+/-- A ring isomorphism between two finite products of simple rings matches
+their block ideals through an equivalence of the two index types.
+
+This is the simple-summand correspondence used in arXiv:1606.00608,
+Appendix C.4, line 1997, and in the proof of Wolf--Perez-Garcia,
+arXiv:1005.4545, Theorem 8, source lines 322--324. -/
+theorem exists_blockEquiv_of_ringEquiv_pi_simple
+    {κ : Type*} [Finite κ] [DecidableEq κ]
+    {S : κ → Type*} [∀ j, Ring (S j)] [∀ j, IsSimpleRing (S j)]
+    (T : (∀ i, R i) ≃+* (∀ j, S j)) :
+    ∃ σ : ι ≃ κ,
+      ∀ i : ι, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S (σ i) := by
+  classical
+  have huniq :
+      ∀ i, ∃! j, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S j :=
+    fun i ↦
+      existsUnique_eq_blockIdeal _
+        ((T.mapTwoSidedIdeal.isAtom_iff _).2 (isAtom_blockIdeal (R := R) i))
+  let σfun : ι → κ := fun i ↦ (huniq i).choose
+  have hσfun :
+      ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S (σfun i) :=
+    fun i ↦ (huniq i).choose_spec.1
+  have hσfun_inj : Function.Injective σfun := by
+    intro i j hij
+    refine blockIdeal_injective (R := R) ?_
+    refine T.mapTwoSidedIdeal.injective ?_
+    rw [hσfun i, hσfun j, hij]
+  have hσfun_surj : Function.Surjective σfun := by
+    intro k
+    have hAtom : IsAtom (T.mapTwoSidedIdeal.symm (blockIdeal S k)) := by
+      rw [← T.mapTwoSidedIdeal.isAtom_iff]
+      simp [isAtom_blockIdeal]
+    rcases (isAtom_iff_exists_eq_blockIdeal (R := R) _).1 hAtom with ⟨i, hi⟩
+    refine ⟨i, blockIdeal_injective (R := S) ?_⟩
+    rw [← hσfun i, ← hi]
+    simp
+  refine ⟨Equiv.ofBijective σfun ⟨hσfun_inj, hσfun_surj⟩, ?_⟩
+  intro i
+  simpa using hσfun i
+
 end BlockPermutation
+
+section BlockComponentMap
+
+variable {ι κ : Type*} [Finite ι] [DecidableEq ι] [Finite κ] [DecidableEq κ]
+variable {R : ι → Type*} [∀ i, Ring (R i)] [∀ i, IsSimpleRing (R i)]
+variable {S : κ → Type*} [∀ j, Ring (S j)] [∀ j, IsSimpleRing (S j)]
+
+/-- The component map from one simple factor to its paired factor under a
+ring isomorphism of finite products.
+
+This is the restriction to a paired summand used in the proof of
+Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8, source lines 322--324. -/
+noncomputable def blockComponentMap
+    (T : (∀ i, R i) ≃+* (∀ j, S j)) (σ : ι ≃ κ) (i : ι) : R i → S (σ i) :=
+  fun x ↦ T (Pi.single i x) (σ i)
+
+/-- A tuple supported in one source factor is mapped into its paired target
+factor.
+
+This is the block-support consequence underlying arXiv:1005.4545,
+Theorem 8, source lines 322--324. -/
+theorem ringEquiv_maps_single_support_between
+    (T : (∀ i, R i) ≃+* (∀ j, S j)) (σ : ι ≃ κ)
+    (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S (σ i))
+    {i : ι} (x : R i) (j : κ) (hj : j ≠ σ i) :
+    T (Pi.single i x) j = 0 := by
+  have hMem : T (Pi.single i x) ∈ blockIdeal S (σ i) := by
+    rw [← hσ i, RingEquiv.mapTwoSidedIdeal_apply, TwoSidedIdeal.mem_comap]
+    simp [pi_single_mem_blockIdeal x]
+  exact (mem_blockIdeal_iff.mp hMem) j hj
+
+/-- The inverse isomorphism carries a paired target block ideal back to its
+source block ideal.
+
+This is the inverse block-support consequence underlying arXiv:1005.4545,
+Theorem 8, source lines 322--324. -/
+theorem ringEquiv_symm_maps_blockIdeal_between
+    (T : (∀ i, R i) ≃+* (∀ j, S j)) (σ : ι ≃ κ)
+    (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S (σ i))
+    (i : ι) :
+    T.symm.mapTwoSidedIdeal (blockIdeal S (σ i)) = blockIdeal R i := by
+  rw [← hσ i]
+  ext x
+  simp [RingEquiv.mapTwoSidedIdeal_apply, TwoSidedIdeal.mem_comap]
+
+/-- The component map between paired simple factors is injective.
+
+This is the injectivity used in the paired-summand argument of
+arXiv:1005.4545, Theorem 8, source lines 322--324. -/
+theorem blockComponentMap_injective
+    (T : (∀ i, R i) ≃+* (∀ j, S j)) (σ : ι ≃ κ)
+    (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S (σ i))
+    (i : ι) : Function.Injective (blockComponentMap T σ i) := by
+  intro x y hxy
+  have hFull : T (Pi.single i x) = T (Pi.single i y) := by
+    ext j
+    by_cases hj : j = σ i
+    · subst hj
+      simpa only [blockComponentMap] using hxy
+    · rw [ringEquiv_maps_single_support_between T σ hσ x j hj,
+        ringEquiv_maps_single_support_between T σ hσ y j hj]
+  have hSingle := T.injective hFull
+  simpa using congrFun hSingle i
+
+/-- The component map between paired simple factors is surjective.
+
+This is the surjectivity used in the paired-summand argument of
+arXiv:1005.4545, Theorem 8, source lines 322--324. -/
+theorem blockComponentMap_surjective
+    (T : (∀ i, R i) ≃+* (∀ j, S j)) (σ : ι ≃ κ)
+    (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S (σ i))
+    (i : ι) : Function.Surjective (blockComponentMap T σ i) := by
+  intro y
+  have hMem : T.symm (Pi.single (σ i) y) ∈ blockIdeal R i := by
+    rw [← ringEquiv_symm_maps_blockIdeal_between T σ hσ i,
+      RingEquiv.mapTwoSidedIdeal_apply, TwoSidedIdeal.mem_comap]
+    simp [pi_single_mem_blockIdeal]
+  have hEq : T.symm (Pi.single (σ i) y) =
+      Pi.single i (T.symm (Pi.single (σ i) y) i) := by
+    ext j
+    by_cases hj : j = i
+    · subst hj
+      simp
+    · rw [mem_blockIdeal_iff.mp hMem j hj, Pi.single_eq_of_ne hj]
+  refine ⟨T.symm (Pi.single (σ i) y) i, ?_⟩
+  simp only [blockComponentMap, ← hEq, T.apply_symm_apply, Pi.single_eq_same]
+
+/-- The component map between paired simple factors is bijective.
+
+This is the bijectivity used to match summand dimensions in
+arXiv:1005.4545, Theorem 8, source lines 322--324. -/
+theorem blockComponentMap_bijective
+    (T : (∀ i, R i) ≃+* (∀ j, S j)) (σ : ι ≃ κ)
+    (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal S (σ i))
+    (i : ι) : Function.Bijective (blockComponentMap T σ i) :=
+  ⟨blockComponentMap_injective T σ hσ i,
+    blockComponentMap_surjective T σ hσ i⟩
+
+end BlockComponentMap
 
 end MPSTensor

--- a/TNLean/Algebra/BlockPermutation.lean
+++ b/TNLean/Algebra/BlockPermutation.lean
@@ -171,39 +171,6 @@ theorem existsUnique_eq_blockIdeal (I : TwoSidedIdeal (∀ i, R i)) (hI : IsAtom
   rcases (isAtom_iff_exists_eq_blockIdeal I).1 hI with ⟨i, hi⟩
   exact ⟨i, hi, fun j hj => (blockIdeal_injective (hi.symm.trans hj)).symm⟩
 
-/-- A ring automorphism of `∀ i, R i` (product of simple rings) permutes the block ideals,
-yielding a permutation `σ : ι ≃ ι`. -/
-theorem ringEquiv_pi_simple_permutes_blockIdeals
-    (T : (∀ i, R i) ≃+* (∀ i, R i)) :
-    ∃ σ : ι ≃ ι, ∀ i : ι, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal R (σ i) := by
-  classical
-  have huniq :
-      ∀ i, ∃! j, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal R j :=
-    fun i =>
-      existsUnique_eq_blockIdeal _
-        ((T.mapTwoSidedIdeal.isAtom_iff _).2 (isAtom_blockIdeal (R := R) i))
-  let σfun : ι → ι := fun i => (huniq i).choose
-  have hσfun :
-      ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal R (σfun i) :=
-    fun i => (huniq i).choose_spec.1
-  have hσfun_inj : Function.Injective σfun := by
-    intro i j hij
-    refine blockIdeal_injective (R := R) ?_
-    refine T.mapTwoSidedIdeal.injective ?_
-    simp [hσfun, hij]
-  have hσfun_surj : Function.Surjective σfun := by
-    intro k
-    have hAtom : IsAtom (T.mapTwoSidedIdeal.symm (blockIdeal R k)) := by
-      rw [← T.mapTwoSidedIdeal.isAtom_iff]
-      simp [isAtom_blockIdeal]
-    rcases (isAtom_iff_exists_eq_blockIdeal (R := R) _).1 hAtom with ⟨i, hi⟩
-    refine ⟨i, blockIdeal_injective (R := R) ?_⟩
-    rw [← hσfun i, ← hi]
-    simp
-  refine
-    ⟨Equiv.ofBijective σfun ⟨hσfun_inj, hσfun_surj⟩, fun i => ?_⟩
-  simpa using hσfun i
-
 /-- A ring isomorphism between two finite products of simple rings matches
 their block ideals through an equivalence of the two index types.
 
@@ -243,6 +210,13 @@ theorem exists_blockEquiv_of_ringEquiv_pi_simple
   refine ⟨Equiv.ofBijective σfun ⟨hσfun_inj, hσfun_surj⟩, ?_⟩
   intro i
   simpa using hσfun i
+
+/-- A ring automorphism of `∀ i, R i` (product of simple rings) permutes the block ideals,
+yielding a permutation `σ : ι ≃ ι`. -/
+theorem ringEquiv_pi_simple_permutes_blockIdeals
+    (T : (∀ i, R i) ≃+* (∀ i, R i)) :
+    ∃ σ : ι ≃ ι, ∀ i : ι, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal R (σ i) :=
+  exists_blockEquiv_of_ringEquiv_pi_simple T
 
 end BlockPermutation
 

--- a/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.BlockPermutation
+import TNLean.Channel.FixedPoint.DirectSumInverseKraus
+
+import Mathlib.RingTheory.SimpleRing.Matrix
+
+/-!
+# Simple summands of inverse completely positive maps
+
+This file identifies the simple matrix summands carried into one another by a
+star-algebra equivalence between two finite products. It then applies this
+classification to the star-algebra equivalence associated with mutually
+inverse completely positive trace-preserving maps.
+
+This is the sector-relabeling and dimension-matching part of
+arXiv:1606.00608, Appendix C.4, line 1997. The cited proof in
+Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8, source lines 322--324, first
+permutes summands of equal matrix dimension and only then identifies the map
+inside each summand. Unitary implementation is not proved here.
+-/
+
+open scoped Matrix
+
+noncomputable section
+
+namespace Matrix
+
+variable {ι κ : Type*}
+variable [Finite ι] [Finite κ]
+variable {d : ι → ℕ} {e : κ → ℕ}
+variable [∀ i, NeZero (d i)] [∀ j, NeZero (e j)]
+
+noncomputable local instance sourceMatrix_isSimpleRing (i : ι) :
+    IsSimpleRing (Matrix (Fin (d i)) (Fin (d i)) ℂ) := by
+  have : Nonempty (Fin (d i)) := Fin.pos_iff_nonempty.mp (NeZero.pos (d i))
+  exact IsSimpleRing.matrix (Fin (d i)) ℂ
+
+noncomputable local instance targetMatrix_isSimpleRing (j : κ) :
+    IsSimpleRing (Matrix (Fin (e j)) (Fin (e j)) ℂ) := by
+  have : Nonempty (Fin (e j)) := Fin.pos_iff_nonempty.mp (NeZero.pos (e j))
+  exact IsSimpleRing.matrix (Fin (e j)) ℂ
+
+/-- The linear map from one source summand to its paired target summand.
+
+This is the linear restriction used to compare summand dimensions in
+arXiv:1005.4545, Theorem 8, source lines 322--324. -/
+private noncomputable def blockComponentLinearMap
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) ≃⋆ₐ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (σ : ι ≃ κ) (i : ι) :
+    Matrix (Fin (d i)) (Fin (d i)) ℂ →ₗ[ℂ]
+      Matrix (Fin (e (σ i))) (Fin (e (σ i))) ℂ := by
+  classical
+  exact
+    { toFun := fun M ↦ T (Pi.single i M) (σ i)
+      map_add' := fun M N ↦ by
+        simp only [Pi.single_add, map_add, Pi.add_apply]
+      map_smul' := fun c M ↦ by
+        simp only [Pi.single_smul, map_smul, Pi.smul_apply, RingHom.id_apply] }
+
+/-- A star-algebra equivalence between two finite products of nonzero full
+matrix algebras matches their simple summands and their matrix dimensions.
+
+This is the first conclusion of the relabeling argument in arXiv:1606.00608,
+Appendix C.4, line 1997, following Wolf--Perez-Garcia,
+arXiv:1005.4545, Theorem 8, source lines 322--324. -/
+theorem exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) ≃⋆ₐ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)) :
+    ∃ σ : ι ≃ κ, ∀ i, d i = e (σ i) := by
+  classical
+  obtain ⟨σ, hσ⟩ :=
+    MPSTensor.exists_blockEquiv_of_ringEquiv_pi_simple T.toRingEquiv
+  refine ⟨σ, ?_⟩
+  intro i
+  let φ := blockComponentLinearMap T σ i
+  have hφBij : Function.Bijective φ := by
+    exact MPSTensor.blockComponentMap_bijective T.toRingEquiv σ hσ i
+  have hfinrank := (LinearEquiv.ofBijective φ hφBij).finrank_eq
+  rw [Module.finrank_matrix, Module.finrank_matrix] at hfinrank
+  simp only [Module.finrank_self, Fintype.card_fin, mul_one] at hfinrank
+  exact Nat.mul_self_inj.mp hfinrank
+
+/-- Mutually inverse completely positive trace-preserving maps between two
+finite products of nonzero full matrix algebras match their simple summands
+and the corresponding matrix dimensions.
+
+This is the simple-summand matching conclusion in arXiv:1606.00608,
+Appendix C.4, line 1997, following Wolf--Perez-Garcia,
+arXiv:1005.4545, Theorem 8, source lines 322--324.
+
+**Scope restriction (simple summands):** This theorem does not construct the
+unitary action within each paired summand. That remaining conclusion is
+documented in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`. -/
+theorem exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps
+    [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ))
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id) :
+    ∃ σ : ι ≃ κ, ∀ i, d i = e (σ i) := by
+  exact exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix
+    (directSumTraceAdjointStarAlgEquiv T S hT hS hTTP hSTP hST hTS).symm
+
+end Matrix

--- a/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
@@ -30,7 +30,7 @@ noncomputable section
 namespace Matrix
 
 variable {ι κ : Type*}
-variable [Finite ι] [Finite κ]
+variable [Finite ι] [DecidableEq ι] [Finite κ] [DecidableEq κ]
 variable {d : ι → ℕ} {e : κ → ℕ}
 variable [∀ i, NeZero (d i)] [∀ j, NeZero (e j)]
 
@@ -71,11 +71,15 @@ arXiv:1005.4545, Theorem 8, source lines 322--324. -/
 theorem exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix
     (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) ≃⋆ₐ[ℂ]
       (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)) :
-    ∃ σ : ι ≃ κ, ∀ i, d i = e (σ i) := by
+    ∃ σ : ι ≃ κ,
+      (∀ i, T.toRingEquiv.mapTwoSidedIdeal
+        (MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (d k)) (Fin (d k)) ℂ) i) =
+          MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (σ i)) ∧
+      ∀ i, d i = e (σ i) := by
   classical
   obtain ⟨σ, hσ⟩ :=
     MPSTensor.exists_blockEquiv_of_ringEquiv_pi_simple T.toRingEquiv
-  refine ⟨σ, ?_⟩
+  refine ⟨σ, hσ, ?_⟩
   intro i
   let φ := blockComponentLinearMap T σ i
   have hφBij : Function.Bijective φ := by
@@ -97,7 +101,7 @@ arXiv:1005.4545, Theorem 8, source lines 322--324.
 unitary action within each paired summand. That remaining conclusion is
 documented in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`. -/
 theorem exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps
-    [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+    [Fintype ι] [Fintype κ]
     (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
       (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
     (S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
@@ -106,7 +110,12 @@ theorem exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps
     (hTTP : IsTracePreservingBetweenDirectSums T)
     (hSTP : IsTracePreservingBetweenDirectSums S)
     (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id) :
-    ∃ σ : ι ≃ κ, ∀ i, d i = e (σ i) := by
+    let E := (directSumTraceAdjointStarAlgEquiv T S hT hS hTTP hSTP hST hTS).symm
+    ∃ σ : ι ≃ κ,
+      (∀ i, E.toRingEquiv.mapTwoSidedIdeal
+        (MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (d k)) (Fin (d k)) ℂ) i) =
+          MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (σ i)) ∧
+      ∀ i, d i = e (σ i) := by
   exact exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix
     (directSumTraceAdjointStarAlgEquiv T S hT hS hTTP hSTP hST hTS).symm
 

--- a/TNLean/MPS/Structure/BlockPermutation.lean
+++ b/TNLean/MPS/Structure/BlockPermutation.lean
@@ -57,12 +57,6 @@ theorem ringEquiv_maps_single_support
     T (Pi.single i M) j = 0 :=
   ringEquiv_maps_single_support_between T σ hσ M j hj
 
-theorem ringEquiv_symm_maps_blockIdeal
-    (T : (∀ j, R j) ≃+* (∀ j, R j)) (σ : ι ≃ ι)
-    (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal R (σ i)) (i : ι) :
-    T.symm.mapTwoSidedIdeal (blockIdeal R (σ i)) = blockIdeal R i :=
-  ringEquiv_symm_maps_blockIdeal_between T σ hσ i
-
 end BlockIdealMembership
 
 /-! ### T maps Pi.single i 1 to Pi.single (σ i) 1 -/

--- a/TNLean/MPS/Structure/BlockPermutation.lean
+++ b/TNLean/MPS/Structure/BlockPermutation.lean
@@ -101,31 +101,32 @@ noncomputable instance instSimple (i : ι) :
   have : Nonempty (Fin (D i)) := Fin.pos_iff_nonempty.mp (NeZero.pos (D i))
   exact IsSimpleRing.matrix (Fin (D i)) ℂ
 
-/-- The per-block map: `M ↦ T(Pi.single i M)(σ i)`. -/
+/-- The homogeneous matrix-algebra specialization of `blockComponentMap`:
+`M ↦ T(Pi.single i M)(σ i)`. -/
 noncomputable def componentMap
     (T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+*
          (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ))
     (σ : ι ≃ ι) (i : ι)
     (M : Matrix (Fin (D i)) (Fin (D i)) ℂ) :
     Matrix (Fin (D (σ i))) (Fin (D (σ i))) ℂ :=
-  T (Pi.single i M) (σ i)
+  blockComponentMap T σ i M
 
 private theorem componentMap_map_zero
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι} {i : ι} :
     componentMap T σ i 0 = 0 := by
-  simp [componentMap, Pi.single_zero, map_zero]
+  simp [componentMap, blockComponentMap, Pi.single_zero, map_zero]
 
 private theorem componentMap_map_add
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι} {i : ι}
     (M N : Matrix (Fin (D i)) (Fin (D i)) ℂ) :
     componentMap T σ i (M + N) = componentMap T σ i M + componentMap T σ i N := by
-  simp [componentMap, Pi.single_add, map_add, Pi.add_apply]
+  simp [componentMap, blockComponentMap, Pi.single_add, map_add, Pi.add_apply]
 
 theorem componentMap_map_mul
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι} {i : ι}
     (M N : Matrix (Fin (D i)) (Fin (D i)) ℂ) :
     componentMap T σ i (M * N) = componentMap T σ i M * componentMap T σ i N := by
-  simp only [componentMap, Pi.single_mul, map_mul, Pi.mul_apply]
+  simp only [componentMap, blockComponentMap, Pi.single_mul, map_mul, Pi.mul_apply]
 
 theorem componentMap_map_one
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι}
@@ -134,7 +135,8 @@ theorem componentMap_map_one
       blockIdeal (fun j => Matrix (Fin (D j)) (Fin (D j)) ℂ) (σ i))
     (i : ι) :
     componentMap T σ i 1 = 1 := by
-  simp only [componentMap, ringEquiv_single_one_eq T σ hσ i, Pi.single_eq_same]
+  simp only [componentMap, blockComponentMap, ringEquiv_single_one_eq T σ hσ i,
+    Pi.single_eq_same]
 
 /-- The component map commutes with ℂ-scalar multiplication when T is a ℂ-algebra map. -/
 theorem componentMap_map_smul_of_algEquiv

--- a/TNLean/MPS/Structure/BlockPermutation.lean
+++ b/TNLean/MPS/Structure/BlockPermutation.lean
@@ -50,46 +50,18 @@ section BlockIdealMembership
 variable {ι : Type*} [Finite ι] [DecidableEq ι]
 variable {R : ι → Type*} [∀ i, Ring (R i)] [∀ i, IsSimpleRing (R i)]
 
-/-- An element belongs to the block ideal at `i` iff all other components vanish. -/
-theorem mem_blockIdeal_iff {i : ι} {x : ∀ j, R j} :
-    x ∈ blockIdeal R i ↔ ∀ j, j ≠ i → x j = 0 := by
-  classical
-  have h_eq : blockIdeal R i =
-      (Ideal.pi fun j =>
-        ((Function.update (⊥ : ∀ k, TwoSidedIdeal (R k)) i ⊤) j).asIdeal).toTwoSided := by
-    simp [blockIdeal, twoSidedIdealPiOrderIso]
-  rw [h_eq, Ideal.mem_toTwoSided, Ideal.mem_pi]
-  constructor
-  · intro h j hj
-    have := h j; rw [Function.update_of_ne hj] at this
-    exact TwoSidedIdeal.mem_asIdeal.mp this
-  · intro h j
-    by_cases hj : j = i
-    · subst hj; rw [Function.update_self]; exact TwoSidedIdeal.mem_asIdeal.mpr trivial
-    · rw [Function.update_of_ne hj]
-      exact TwoSidedIdeal.mem_asIdeal.mpr (h j hj ▸ (⊥ : TwoSidedIdeal (R j)).asIdeal.zero_mem)
-
-/-- `Pi.single i M` belongs to the block ideal at `i`. -/
-theorem pi_single_mem_blockIdeal {i : ι} (M : R i) :
-    Pi.single i M ∈ blockIdeal R i :=
-  mem_blockIdeal_iff.mpr (fun _ hj => Pi.single_eq_of_ne hj M)
-
 theorem ringEquiv_maps_single_support
     (T : (∀ j, R j) ≃+* (∀ j, R j)) (σ : ι ≃ ι)
     (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal R (σ i))
     {i : ι} (M : R i) (j : ι) (hj : j ≠ σ i) :
-    T (Pi.single i M) j = 0 := by
-  have : T (Pi.single i M) ∈ blockIdeal R (σ i) := by
-    rw [← hσ i, RingEquiv.mapTwoSidedIdeal_apply, TwoSidedIdeal.mem_comap]
-    simp [pi_single_mem_blockIdeal M]
-  exact (mem_blockIdeal_iff.mp this) j hj
+    T (Pi.single i M) j = 0 :=
+  ringEquiv_maps_single_support_between T σ hσ M j hj
 
 theorem ringEquiv_symm_maps_blockIdeal
     (T : (∀ j, R j) ≃+* (∀ j, R j)) (σ : ι ≃ ι)
     (hσ : ∀ i, T.mapTwoSidedIdeal (blockIdeal R i) = blockIdeal R (σ i)) (i : ι) :
-    T.symm.mapTwoSidedIdeal (blockIdeal R (σ i)) = blockIdeal R i := by
-  rw [← hσ i]; ext x
-  simp [RingEquiv.mapTwoSidedIdeal_apply, TwoSidedIdeal.mem_comap]
+    T.symm.mapTwoSidedIdeal (blockIdeal R (σ i)) = blockIdeal R i :=
+  ringEquiv_symm_maps_blockIdeal_between T σ hσ i
 
 end BlockIdealMembership
 
@@ -203,20 +175,8 @@ theorem componentMap_surjective
     (hσ : ∀ i, T.mapTwoSidedIdeal
         (blockIdeal (fun j => Matrix (Fin (D j)) (Fin (D j)) ℂ) i) =
       blockIdeal (fun j => Matrix (Fin (D j)) (Fin (D j)) ℂ) (σ i))
-    (i : ι) : Function.Surjective (componentMap T σ i) := by
-  intro N
-  have h_mem : T.symm (Pi.single (σ i) N) ∈
-      blockIdeal (fun k => Matrix (Fin (D k)) (Fin (D k)) ℂ) i := by
-    rw [← ringEquiv_symm_maps_blockIdeal T σ hσ i,
-        RingEquiv.mapTwoSidedIdeal_apply, TwoSidedIdeal.mem_comap]
-    simp [pi_single_mem_blockIdeal]
-  have h_eq : T.symm (Pi.single (σ i) N) =
-      Pi.single i (T.symm (Pi.single (σ i) N) i) := by
-    ext j; by_cases hj : j = i
-    · subst hj; simp
-    · rw [mem_blockIdeal_iff.mp h_mem j hj, Pi.single_eq_of_ne hj]
-  exact ⟨T.symm (Pi.single (σ i) N) i, by
-    simp only [componentMap, ← h_eq, T.apply_symm_apply, Pi.single_eq_same]⟩
+    (i : ι) : Function.Surjective (componentMap T σ i) :=
+  blockComponentMap_surjective T σ hσ i
 
 theorem componentMap_bijective
     {T : (∀ j, Matrix (Fin (D j)) (Fin (D j)) ℂ) ≃+* _} {σ : ι ≃ ι}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2809,6 +2809,42 @@ outside the present result.
     Schwarz condition to exclude transposition.
 \end{proof}
 
+\begin{theorem}[Simple-summand matching for inverse CPTP maps]%
+    \label{thm:direct_sum_inverse_cptp_block_matching}
+    \lean{Matrix.exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps}
+    \leanok
+    \uses{thm:direct_sum_inverse_cptp_star_equiv,
+        thm:dim_preserved}
+    Let $\{D_i\}_{i\in I}$ and $\{E_j\}_{j\in J}$ be positive integers, and
+    set
+    \[
+        \mathcal A=\prod_{i\in I}M_{D_i}(\C),
+        \qquad
+        \mathcal B=\prod_{j\in J}M_{E_j}(\C).
+    \]
+    If $T:\mathcal A\to\mathcal B$ and
+    $S:\mathcal B\to\mathcal A$ are mutually inverse completely positive
+    trace-preserving maps, then there is an equivalence $\sigma:I\simeq J$
+    such that
+    \[
+        D_i=E_{\sigma(i)}
+    \]
+    for every $i\in I$. This is the simple-summand matching conclusion used
+    in \cite[Appendix~C.4, line~1997]{Cirac2016MPDO_arXiv}; the unitary action
+    within the paired summands is a separate conclusion.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:direct_sum_inverse_cptp_star_equiv,
+        thm:dim_preserved}
+    By Theorem~\ref{thm:direct_sum_inverse_cptp_star_equiv}, the rectangular
+    trace adjoints determine a star-algebra isomorphism between
+    $\mathcal A$ and $\mathcal B$. Theorem~\ref{thm:dim_preserved} applied to
+    this isomorphism gives the equivalence~$\sigma$ and the equalities
+    $D_i=E_{\sigma(i)}$.
+\end{proof}
+
 % Scope restriction documented in
 % docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
 \begin{theorem}[Weighted block form of the adjoint Ces\`aro projection on full support]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2824,9 +2824,13 @@ outside the present result.
     \]
     If $T:\mathcal A\to\mathcal B$ and
     $S:\mathcal B\to\mathcal A$ are mutually inverse completely positive
-    trace-preserving maps, then there is an equivalence $\sigma:I\simeq J$
-    such that
+    trace-preserving maps, let $\Phi:\mathcal A\simeq\mathcal B$ be the
+    star-algebra isomorphism obtained from their trace adjoints.  Write $I_i$
+    and $J_j$ for the block ideals of $\mathcal A$ and $\mathcal B$,
+    respectively.  Then there is an equivalence $\sigma:I\simeq J$ such that
     \[
+        \Phi(I_i)=J_{\sigma(i)},
+        \qquad
         D_i=E_{\sigma(i)}
     \]
     for every $i\in I$. This is the simple-summand matching conclusion used
@@ -2841,7 +2845,8 @@ outside the present result.
     By Theorem~\ref{thm:direct_sum_inverse_cptp_star_equiv}, the rectangular
     trace adjoints determine a star-algebra isomorphism between
     $\mathcal A$ and $\mathcal B$. Theorem~\ref{thm:dim_preserved} applied to
-    this isomorphism gives the equivalence~$\sigma$ and the equalities
+    this isomorphism gives the equivalence~$\sigma$, proves that it carries
+    $I_i$ onto $J_{\sigma(i)}$, and gives the equalities
     $D_i=E_{\sigma(i)}$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch23_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft.tex
@@ -980,7 +980,7 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
     gives~$\sigma$.
 \end{proof}
 
-\begin{theorem}[Dimension preservation]\label{thm:dim_preserved}
+\begin{theorem}[Summand matching and dimension preservation]\label{thm:dim_preserved}
     \lean{MPSTensor.dim_preserved}
     \lean{Matrix.exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix}
     \leanok
@@ -990,9 +990,10 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
         \prod_{i\in I}M_{D_i}(\C)
         \simeq \prod_{j\in J}M_{E_j}(\C)
     \]
-    determines an equivalence $\sigma:I\simeq J$ satisfying
-    $D_i=E_{\sigma(i)}$ for every $i\in I$. For an automorphism of one
-    product, the induced permutation preserves every block dimension.
+    determines an equivalence $\sigma:I\simeq J$ such that the isomorphism
+    carries the $i$-th block ideal onto the $\sigma(i)$-th block ideal and
+    $D_i=E_{\sigma(i)}$ for every $i\in I$. For an automorphism of one product,
+    the induced permutation preserves every block ideal and its dimension.
 \end{theorem}
 
 \begin{proof}\leanok\uses{thm:ring_perm, thm:component_map_bijective}
@@ -1013,6 +1014,7 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
     \lean{MPSTensor.blockComponentMap_injective}
     \lean{MPSTensor.blockComponentMap_surjective}
     \lean{MPSTensor.blockComponentMap_bijective}
+    \lean{MPSTensor.componentMap_surjective}
     \lean{MPSTensor.componentMap_bijective}
     \leanok
     \uses{thm:ring_perm}

--- a/blueprint/src/chapter/ch23_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft.tex
@@ -957,66 +957,80 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
     hence so is $I_k$.
 \end{proof}
 
-\begin{theorem}[Ring isomorphisms permute block ideals]\label{thm:ring_perm}
+\begin{theorem}[Ring isomorphisms match block ideals]\label{thm:ring_perm}
     \lean{MPSTensor.ringEquiv_pi_simple_permutes_blockIdeals}
+    \lean{MPSTensor.exists_blockEquiv_of_ringEquiv_pi_simple}
     \leanok
     \uses{def:block_ideal}
-    Let $\{R_k\}_{k=0}^{r-1}$ be simple rings.
-    Every ring isomorphism $T : \prod_k R_k \to \prod_k R_k$
-    permutes the block ideals:
-    there exists a permutation $\pi$ such that
-    $T$ maps the $k$-th block ideal to the $\pi(k)$-th block ideal.
+    Let $\{R_i\}_{i\in I}$ and $\{S_j\}_{j\in J}$ be two finite families of
+    simple rings. Every ring isomorphism
+    $T : \prod_{i\in I}R_i \to \prod_{j\in J}S_j$ determines an equivalence
+    $\sigma:I\simeq J$ such that $T$ maps the $i$-th block ideal onto the
+    $\sigma(i)$-th block ideal. In particular, an automorphism of one product
+    permutes its block ideals.
 \end{theorem}
 
 \begin{proof}
     \leanok
     \uses{thm:block_ideal_atom}
-    By Theorem~\ref{thm:block_ideal_atom}, each block ideal is an atom in the
-    lattice of two-sided ideals of $\prod_k R_k$.
-    A ring isomorphism induces an order automorphism of this lattice,
-    so it permutes the atoms. Since the atoms are exactly the block ideals,
-    this gives the required permutation~$\pi$.
+    By Theorem~\ref{thm:block_ideal_atom}, the atoms in each two-sided ideal
+    lattice are exactly its block ideals. The induced order isomorphism
+    therefore assigns a unique target block ideal to every source block
+    ideal. Applying its inverse shows that this assignment is bijective and
+    gives~$\sigma$.
 \end{proof}
 
 \begin{theorem}[Dimension preservation]\label{thm:dim_preserved}
     \lean{MPSTensor.dim_preserved}
+    \lean{Matrix.exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix}
     \leanok
-    Assume $D_k \ge 1$ for all~$k$.
-    If $T$ is an algebra automorphism of
-    $\prod_{k=0}^{r-1} \MN{D_k}$,
-    and $\pi$ is the induced permutation, then
-    $D_{\pi(k)} = D_k$ for all~$k$.
+    Let $\{D_i\}_{i\in I}$ and $\{E_j\}_{j\in J}$ be positive integers.
+    A star-algebra isomorphism
+    \[
+        \prod_{i\in I}M_{D_i}(\C)
+        \simeq \prod_{j\in J}M_{E_j}(\C)
+    \]
+    determines an equivalence $\sigma:I\simeq J$ satisfying
+    $D_i=E_{\sigma(i)}$ for every $i\in I$. For an automorphism of one
+    product, the induced permutation preserves every block dimension.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:ring_perm}
-    The restriction of $T$ to the $k$-th block ideal
-    induces a $\C$-algebra isomorphism
-    $\MN{D_k} \cong \MN{D_{\pi(k)}}$,
-    which forces $D_k = D_{\pi(k)}$
-    by comparing dimensions as $\C$-vector spaces.
+\begin{proof}\leanok\uses{thm:ring_perm, thm:component_map_bijective}
+    The isomorphism carries the $i$-th block ideal onto the
+    $\sigma(i)$-th block ideal. Its restriction gives a bijective complex
+    linear map from $M_{D_i}(\C)$ to $M_{E_{\sigma(i)}}(\C)$. Comparing
+    dimensions gives $D_i^2=E_{\sigma(i)}^2$, hence
+    $D_i=E_{\sigma(i)}$.
 \end{proof}
 
-\begin{theorem}[Per-block component maps are bijections]\label{thm:component_map_bijective}
+\begin{theorem}[Paired component maps are bijections]\label{thm:component_map_bijective}
+    \lean{MPSTensor.mem_blockIdeal_iff}
+    \lean{MPSTensor.pi_single_mem_blockIdeal}
+    \lean{MPSTensor.blockComponentMap}
+    \lean{MPSTensor.ringEquiv_maps_single_support_between}
+    \lean{MPSTensor.ringEquiv_symm_maps_blockIdeal_between}
+    \lean{MPSTensor.blockComponentMap_injective}
+    \lean{MPSTensor.blockComponentMap_surjective}
+    \lean{MPSTensor.blockComponentMap_bijective}
     \lean{MPSTensor.componentMap_bijective}
     \leanok
     \uses{thm:ring_perm}
-    Assume $D_k \ge 1$ for all~$k$.
-    Let $T$ be a ring automorphism of $\prod_{k=0}^{r-1} \MN{D_k}$, and let $\pi$
-    be the induced permutation from Theorem~\ref{thm:ring_perm}.
-    For each block index $k$, the map
+    Under the hypotheses of Theorem~\ref{thm:ring_perm}, for each $i\in I$
+    the map
     \[
-        M \mapsto (T(0, \ldots, 0, M, 0, \ldots, 0))_{\pi(k)}
+        x\longmapsto \bigl(T(0,\ldots,0,x,0,\ldots,0)\bigr)_{\sigma(i)}
     \]
-    from $\MN{D_k}$ to $\MN{D_{\pi(k)}}$ is bijective.
+    from $R_i$ to $S_{\sigma(i)}$ is bijective.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Theorem~\ref{thm:ring_perm} forces a single-support element in the $k$-th
-    block ideal to remain supported on the $\pi(k)$-th block after applying~$T$.
+    Theorem~\ref{thm:ring_perm} forces an element supported in the $i$-th
+    block ideal to remain supported in the $\sigma(i)$-th block after
+    applying~$T$.
     Injectivity follows from injectivity of~$T$.
     For surjectivity, apply the same argument to $T^{-1}$ and the inverse
-    permutation.
+    equivalence.
 \end{proof}
 
 \begin{theorem}[Decomposition of automorphisms of $\prod \MN{D_k}$]\label{thm:pi_auto_decomp}

--- a/blueprint/src/chapter/ch23_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft.tex
@@ -958,8 +958,8 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
 \end{proof}
 
 \begin{theorem}[Ring isomorphisms match block ideals]\label{thm:ring_perm}
-    \lean{MPSTensor.ringEquiv_pi_simple_permutes_blockIdeals}
     \lean{MPSTensor.exists_blockEquiv_of_ringEquiv_pi_simple}
+    \lean{MPSTensor.ringEquiv_pi_simple_permutes_blockIdeals}
     \leanok
     \uses{def:block_ideal}
     Let $\{R_i\}_{i\in I}$ and $\{S_j\}_{j\in J}$ be two finite families of
@@ -981,8 +981,8 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
 \end{proof}
 
 \begin{theorem}[Summand matching and dimension preservation]\label{thm:dim_preserved}
-    \lean{MPSTensor.dim_preserved}
     \lean{Matrix.exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix}
+    \lean{MPSTensor.dim_preserved}
     \leanok
     Let $\{D_i\}_{i\in I}$ and $\{E_j\}_{j\in J}$ be positive integers.
     A star-algebra isomorphism

--- a/blueprint/src/chapter/ch23_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft.tex
@@ -1008,6 +1008,7 @@ Throughout this section, assume $D_k \ge 1$ for every block~$k$.
     \lean{MPSTensor.pi_single_mem_blockIdeal}
     \lean{MPSTensor.blockComponentMap}
     \lean{MPSTensor.ringEquiv_maps_single_support_between}
+    \lean{MPSTensor.ringEquiv_maps_single_support}
     \lean{MPSTensor.ringEquiv_symm_maps_blockIdeal_between}
     \lean{MPSTensor.blockComponentMap_injective}
     \lean{MPSTensor.blockComponentMap_surjective}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -296,13 +296,20 @@ The first conclusion is now proved for an arbitrary $*$-algebra isomorphism
 between two finite products of nonzero full matrix algebras.  The block ideals
 are precisely the atoms in the two-sided ideal lattices, so the induced order
 isomorphism gives an equivalence $\sigma$ of the block index sets.  Its
+defining matching relation is
+\[
+    E(I_i)=J_{\sigma(i)},
+\]
+where $E$ is the given $*$-algebra isomorphism and $I_i,J_j$ are the source
+and target block ideals.  Its
 restriction to each paired block is a bijective complex-linear map
 \[
     M_{d_i}(\mathbb C)\longrightarrow M_{e_{\sigma(i)}}(\mathbb C),
 \]
 and comparison of dimensions gives $d_i=e_{\sigma(i)}$.
-Applying this result to the trace-adjoint $*$-algebra isomorphism proves the
-same conclusion for every mutually inverse CPTP pair.\footnote{Formal
+Applying this result to the trace-adjoint $*$-algebra isomorphism proves both
+this block-ideal matching relation and the dimension equality for every
+mutually inverse CPTP pair.\footnote{Formal
 declarations:
 \leanid{MPSTensor.exists_blockEquiv_of_ringEquiv_pi_simple} in
 \doclink{TNLean/Algebra/BlockPermutation};
@@ -326,10 +333,11 @@ The first two steps of the Appendix~C.4 argument are complete:
 The inverse-UCP multiplicative-domain step is also complete: the rectangular
 trace adjoints form mutually inverse $*$-algebra equivalences.  The remaining
 generic simple-summand correspondence is now complete as well: it gives an
-equivalence of the sector index sets and equality of the paired matrix
-dimensions.  It remains to identify each paired component map with unitary
-conjugation and then specialize the resulting formula to the transported
-vertical-sector maps.
+equivalence of the sector index sets, identifies the actual block ideals
+carried into one another by the star-algebra isomorphism, and proves equality
+of the paired matrix dimensions.  It remains to identify each paired
+component map with unitary conjugation and then specialize the resulting
+formula to the transported vertical-sector maps.
 
 \section{Classification}
 
@@ -339,11 +347,13 @@ unitary implementation remains open.}  The two transported maps and their
 square composites are trace preserving under the source tensor hypotheses.
 Their two compositions are identities, and the rectangular trace adjoints
 form mutually inverse $*$-algebra equivalences.  For any such pair, the simple
-summands are matched by an equivalence of the index sets and the paired matrix
-dimensions are equal.  The stronger active-image inclusions remain unproved
-and are not needed for this route.  The blockwise unitary-conjugation formula
-and its specialization to the transported vertical-sector maps remain to be
-proved before the conclusion of Appendix~C.4, line~1997 is complete.
+summands are matched by an equivalence of the index sets, the corresponding
+block ideals are carried into one another by the star-algebra isomorphism,
+and the paired matrix dimensions are equal.  The stronger active-image
+inclusions remain unproved and are not needed for this route.  The blockwise
+unitary-conjugation formula and its specialization to the transported
+vertical-sector maps remain to be proved before the conclusion of
+Appendix~C.4, line~1997 is complete.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -284,7 +284,7 @@ A linear equivalence between two finite products of matrix spaces does not
 determine their simple summands.  The trace adjoints of a mutually inverse
 CPTP pair have now been proved to be mutually inverse $*$-algebra
 homomorphisms, by the Schwarz-defect argument above.  The sector relabelling
-therefore reduces to the following source-faithful algebraic step:
+therefore reduces to the following two algebraic conclusions:
 \begin{enumerate}
     \item apply uniqueness of the simple summands to this $*$-algebra
           equivalence, obtaining the sector permutation and equality of the
@@ -292,6 +292,24 @@ therefore reduces to the following source-faithful algebraic step:
     \item identify each matched simple-summand isomorphism with unitary
           conjugation.
 \end{enumerate}
+The first conclusion is now proved for an arbitrary $*$-algebra isomorphism
+between two finite products of nonzero full matrix algebras.  The block ideals
+are precisely the atoms in the two-sided ideal lattices, so the induced order
+isomorphism gives an equivalence $\sigma$ of the block index sets.  Its
+restriction to each paired block is a bijective complex-linear map
+\[
+    M_{d_i}(\mathbb C)\longrightarrow M_{e_{\sigma(i)}}(\mathbb C),
+\]
+and comparison of dimensions gives $d_i=e_{\sigma(i)}$.
+Applying this result to the trace-adjoint $*$-algebra isomorphism proves the
+same conclusion for every mutually inverse CPTP pair.\footnote{Formal
+declarations:
+\leanid{MPSTensor.exists_blockEquiv_of_ringEquiv_pi_simple} in
+\doclink{TNLean/Algebra/BlockPermutation};
+\leanid{Matrix.exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix} and
+\leanid{Matrix.%
+exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps} in
+\doclink{TNLean/Channel/FixedPoint/DirectSumBlockPermutation}.}
 
 \section{Elimination plan}
 
@@ -307,20 +325,25 @@ The first two steps of the Appendix~C.4 argument are complete:
 \end{enumerate}
 The inverse-UCP multiplicative-domain step is also complete: the rectangular
 trace adjoints form mutually inverse $*$-algebra equivalences.  The remaining
-step is the simple-summand classification of this equivalence, giving the
-sector permutation, matching dimensions, and unitary conjugations.
+generic simple-summand correspondence is now complete as well: it gives an
+equivalence of the sector index sets and equality of the paired matrix
+dimensions.  It remains to identify each paired component map with unitary
+conjugation and then specialize the resulting formula to the transported
+vertical-sector maps.
 
 \section{Classification}
 
-\textbf{Verdict: transported-map invertibility and the inverse-UCP
-multiplicative-domain step are closed; sector relabelling remains open.}  The
-two transported maps and their square composites are trace preserving under
-the source tensor hypotheses.  Their two compositions are identities, and
-the rectangular trace adjoints form mutually inverse $*$-algebra
-equivalences.  The stronger active-image inclusions remain unproved and are
-not needed for this route.  The sector permutation, matching dimensions, and
-unitary-conjugation classification from Appendix~C.4, lines~1995--2003 remain
-open.
+\textbf{Verdict: transported-map invertibility, the inverse-UCP
+multiplicative-domain step, and generic simple-summand matching are closed;
+unitary implementation remains open.}  The two transported maps and their
+square composites are trace preserving under the source tensor hypotheses.
+Their two compositions are identities, and the rectangular trace adjoints
+form mutually inverse $*$-algebra equivalences.  For any such pair, the simple
+summands are matched by an equivalence of the index sets and the paired matrix
+dimensions are equal.  The stronger active-image inclusions remain unproved
+and are not needed for this route.  The blockwise unitary-conjugation formula
+and its specialization to the transported vertical-sector maps remain to be
+proved before the conclusion of Appendix~C.4, line~1997 is complete.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- CPSV16, arXiv:1606.00608, Appendix C.4, lines 1995–1997, relabels the simple summands after obtaining mutually inverse transported maps.
- Wolf–Pérez-García, arXiv:1005.4545, Theorem 8, lines 308–324, first matches simple summands of equal matrix dimension before identifying their internal action.
- This pull request isolates that summand-matching step without assuming a permutation or matching dimensions. It closes issue LionSR/QICLean#251.

### Description

- Prove that a ring equivalence between finite products of simple rings induces an equivalence of their index types by matching the corresponding block ideals.
- Specialize the result to finite products of nonzero full complex matrix algebras, exposing the induced block-ideal pairing and proving equality of the paired matrix dimensions.
- Apply both conclusions to the star-algebra equivalence induced by mutually inverse completely positive trace-preserving direct-sum maps.
- Add source-aligned blueprint statements and update the paper-gap discussion. The construction of blockwise unitaries and the transported MPDO theorem remain outside this pull request.

### Testing

- `lake build TNLean.Channel.FixedPoint.DirectSumBlockPermutation TNLean.MPS.Structure.BlockPermutation`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --changed-files TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean TNLean/MPS/Structure/BlockPermutation.lean --diff-base origin/main --diff-head HEAD`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`

---
Closes LionSR/QICLean#251

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation; no runtime or security-sensitive paths. Risk is mainly proof maintenance and import-surface changes in TNLean.
> 
> **Overview**
> Proves the **simple-summand relabeling** step for mutually inverse CPTP maps on finite matrix direct sums: a sector equivalence \(\sigma\) pairs block ideals and forces **\(d_i = e_{\sigma(i)}\)**, without yet constructing blockwise unitaries.
> 
> **Algebra (`BlockPermutation.lean`):** Block-ideal membership lemmas move here; `exists_blockEquiv_of_ringEquiv_pi_simple` generalizes block matching to **isomorphisms between two** finite products of simple rings (automorphism permutation is a corollary). New `blockComponentMap` and injectivity/surjectivity lemmas support dimension comparison.
> 
> **Channels:** New `DirectSumBlockPermutation.lean` specializes to star-algebra equivalences of matrix products and applies the result to the trace-adjoint equivalence from `directSumTraceAdjointStarAlgEquiv` for mutual-inverse Kraus direct-sum maps.
> 
> **MPS structure:** `componentMap` and related proofs delegate to the shared algebra layer instead of duplicating block-ideal logic.
> 
> Blueprint (ch. 7 spectral, ch. 23 algebraic FT) and the CPSV16 vertical-sector gap note are updated to record this matching as proved and unitary implementation as still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d24ac5da2adeef5b10f8936bd34ac9fe4a38a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->