### PR TITLE
fix(blueprint): include Chapter 12 in FT-MPS PDF

### DIFF
--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -12,9 +12,8 @@ corresponding Lean declarations with `\lean{...}` and `\leanok` tags.
 - `src/content.tex` is the chapter router for the full Tensor Network Theory
   blueprint.
 - `src/content_ft_mps.tex` contains the separate Fundamental Theorem of Matrix
-  Product States volume, comprising exactly Chapters 1--11 through the proof of
-  the Fundamental Theorem. The symmetry chapter follows the theorem only in the
-  full blueprint.
+  Product States volume, comprising exactly Chapters 1--12 through Symmetries
+  and String Order.
 - `src/print_ft_mps.tex` is the PDF entry point for that FT--MPS volume.
 - `src/macros/` contains blueprint-specific macros and diagram commands.
 - `src/references.bib` is the blueprint bibliography.
@@ -42,9 +41,8 @@ Build the separate FT--MPS volume from the repository root:
 ./scripts/build_blueprint_ch01_12.sh
 ```
 
-This writes the historically named `blueprint/print/print12.pdf`, which now
-contains the focused Chapters 1--11 FT--MPS volume. The full build, including
-the downstream symmetry chapter, remains at `blueprint/print/print.pdf`.
+This writes `blueprint/print/print12.pdf`, containing the Chapters 1--12
+FT--MPS volume. The full build remains at `blueprint/print/print.pdf`.
 
 ## Writing Conventions
 

--- a/blueprint/comments/20260719/ft_conciseness_relocation_audit.md
+++ b/blueprint/comments/20260719/ft_conciseness_relocation_audit.md
@@ -2,6 +2,11 @@
 
 Date: 2026-07-19
 
+> **Superseded 2026-07-20:** The standalone FT--MPS artifact again includes
+> Chapter 12, *Symmetries and String Order*. The historical audit below records
+> the temporary Chapters 1--11 routing decision; it is not the current router
+> contract.
+
 ## Scope and method
 
 This began as a read-only audit of `blueprint/src/content_ft_mps.tex`, which

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -77,20 +77,19 @@ power-sum comparison.
 % explicit hypotheses until the corresponding source steps are supplied. Paper-gap
 % note: docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex.
 
-This completes the focused Fundamental-Theorem volume.  In the full
-blueprint, the immediately following symmetry chapter is a downstream
-application: it uses the Fundamental Theorem to obtain virtual symmetry gauges,
-projective bond representations, and string-order criteria.  Its Kraus-mixing
-step appeals only to the later channel-representation chapter, not to any
-additional input for the Fundamental Theorem.
+Chapter~\ref{ch:symmetry} uses the Fundamental Theorem to obtain virtual
+symmetry gauges, projective bond representations, and string-order criteria;
+its Kraus-mixing step appeals only to the later channel-representation chapter,
+not to any additional input for the Fundamental Theorem.
 
-The remaining full-blueprint chapters develop parent-Hamiltonian consequences,
-correlation estimates, examples, channel representations, normal forms, quantum
-dynamical semigroups, operator convexity, entropy, and standard examples of
-positive maps that fail to be completely positive.  The final three chapters
-introduce matrix product operators and density operators, develop the
-renormalization fixed points of pure matrix product states, and then treat the
-zero-correlation-length and fixed-point conditions for mixed states.
+Beyond Chapter~12, the later chapters develop parent-Hamiltonian
+consequences, correlation estimates, examples, channel representations,
+normal forms, quantum dynamical semigroups, operator convexity, and entropy.
+They also include the standard examples of positive maps that fail to be
+completely positive. The final three chapters introduce matrix product
+operators and density operators, develop the renormalization fixed points of
+pure matrix product states, and then treat the zero-correlation-length and
+fixed-point conditions for mixed states.
 % Draft chapters also treat the direct Fundamental Theorem for periodically
 % repeated tensors in irreducible form, together with compatibility theorems
 % for physical-index rotation (Definition~\ref{def:rotate_physical} in

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -82,7 +82,7 @@ symmetry gauges, projective bond representations, and string-order criteria;
 its Kraus-mixing step appeals only to the later channel-representation chapter,
 not to any additional input for the Fundamental Theorem.
 
-Beyond Chapter~12, the later chapters develop parent-Hamiltonian
+Beyond Chapter~\ref{ch:symmetry}, the later chapters develop parent-Hamiltonian
 consequences, correlation estimates, examples, channel representations,
 normal forms, quantum dynamical semigroups, operator convexity, and entropy.
 They also include the standard examples of positive maps that fail to be

--- a/blueprint/src/content_ft_mps.tex
+++ b/blueprint/src/content_ft_mps.tex
@@ -11,3 +11,4 @@
 \input{chapter/ch09_canonical}
 \input{chapter/ch10_bnt}
 \input{chapter/ch11_fundamental_theorem_proof}
+\input{chapter/ch12_symmetry}

--- a/scripts/build_blueprint_ch01_12.sh
+++ b/scripts/build_blueprint_ch01_12.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Build the focused FT--MPS blueprint volume (ch01_intro through
-# ch11_fundamental_theorem_proof) as blueprint/print/print12.pdf.
-# The script and artifact retain their historical names for compatibility.
+# Build the FT--MPS blueprint volume (ch01_intro through ch12_symmetry) as
+# blueprint/print/print12.pdf.
 #
 # Run after scripts/blueprint_bibtex.py (which refreshes src/references.bib).
 # The blueprint sources are copied to a temporary directory and the dedicated
@@ -9,9 +8,8 @@
 # never modified; only the gitignored
 # blueprint/print/print12.pdf artifact is written back.
 #
-# The focused route ends at the proof itself.  Its retained prose must not
-# depend on the downstream symmetry chapter; inspect any unresolved references.
-# The full PDF remains the authoritative complete-blueprint version.
+# Cross-references from the kept chapters into dropped ones render as "??";
+# these are expected (the full PDF remains the authoritative version).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -25,15 +23,15 @@ rsync -a --exclude='.tn_svg_cache/' \
 cp -R "$REPO_ROOT/tex/tn" "$WORK_DIR/tex/tn"
 cp -R "$REPO_ROOT/tex/tenkz" "$WORK_DIR/tex/tenkz"
 
-# Verify that the dedicated router contains exactly the focused ch01_* through
-# ch11_* sequence, in order and without duplicates.
+# Verify that the dedicated router contains exactly the ch01_* through ch12_*
+# sequence, in order and without duplicates.
 echo "==> Checking the FT--MPS chapter router..."
-expected="$(printf 'ch%02d\n' $(seq 1 11))"
+expected="$(printf 'ch%02d\n' $(seq 1 12))"
 kept="$(grep '^[[:space:]]*\\input{chapter/' \
   "$WORK_DIR/blueprint/src/content_ft_mps.tex" \
   | sed -E 's|.*chapter/(ch[0-9]{2})_.*|\1|')"
 if [ "$kept" != "$expected" ]; then
-  echo "::error::Active chapters are not exactly the focused ch01..ch11 sequence; got:"
+  echo "::error::Active chapters are not exactly the ch01..ch12 sequence; got:"
   echo "$kept"
   exit 1
 fi
@@ -49,4 +47,4 @@ echo "==> Building with latexmk (XeLaTeX)..."
 mkdir -p "$REPO_ROOT/blueprint/print"
 cp "$WORK_DIR/blueprint/src/print_ft_mps.pdf" \
   "$REPO_ROOT/blueprint/print/print12.pdf"
-echo "==> Wrote blueprint/print/print12.pdf (focused Chapters 1--11 volume)"
+echo "==> Wrote blueprint/print/print12.pdf (Chapters 1--12 volume)"


### PR DESCRIPTION
## Summary

- restore Chapter 12, *Symmetries and String Order*, to the dedicated FT--MPS router
- make the standalone build guard enforce the ordered Chapters 1--12 sequence
- update the README, Chapter 1 route prose, and the earlier conciseness audit to reflect the restored contract

## Root cause

PR #4411 intentionally shortened the standalone volume to Chapters 1--11 while retaining the public `blueprint-ch01-12.pdf` name. The public artifact should include the chapter named by that contract.

## Validation

- `./scripts/build_blueprint_ch01_12.sh`
- generated a 198-page `print12.pdf`; Chapter 12 begins on printed page 183
- rendered and visually inspected the Chapter 12 opening page
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

The standalone build retains the expected unresolved cross-references into chapters outside the 1--12 volume; no citation remains unresolved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX routing only; no Lean or proof logic changes. Standalone PDF may still show expected `??` refs to chapters outside 1--12.
> 
> **Overview**
> Reverses the temporary **Chapters 1--11** standalone FT--MPS volume so **`content_ft_mps.tex`** again includes **`ch12_symmetry`**, matching the **`print12.pdf`** / `build_blueprint_ch01_12.sh` naming.
> 
> **`scripts/build_blueprint_ch01_12.sh`** now enforces an ordered **`ch01`–`ch12`** router (was `ch11`). **`blueprint/README.md`**, **`ch01_intro.tex`**, and the conciseness audit note the restored contract: Chapter 12 is part of the FT--MPS volume again, and the intro treats symmetry as the next chapter rather than ending the volume at the Fundamental Theorem proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60bb5f9828f8846b630923cb74b494d220d2f272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->