### PR TITLE
fix(tenkz): measure typed-map label bands

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -32,6 +32,7 @@ on:
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_lint.py'
       - 'scripts/test_tenkz_pic.py'
+      - 'scripts/test_tenkz_cd_map_labels.py'
       - 'scripts/test_tenkz_face_ports.py'
       - 'scripts/test_tenkz_index_routing.py'
   pull_request:
@@ -59,6 +60,7 @@ on:
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_lint.py'
       - 'scripts/test_tenkz_pic.py'
+      - 'scripts/test_tenkz_cd_map_labels.py'
       - 'scripts/test_tenkz_face_ports.py'
       - 'scripts/test_tenkz_index_routing.py'
   workflow_dispatch:
@@ -118,6 +120,7 @@ jobs:
               - 'scripts/tenkz_audit.py'
               - 'scripts/tenkz_lint.py'
               - 'scripts/test_tenkz_pic.py'
+              - 'scripts/test_tenkz_cd_map_labels.py'
               - 'scripts/test_tenkz_face_ports.py'
               - 'scripts/test_tenkz_index_routing.py'
             workflow:
@@ -311,6 +314,10 @@ jobs:
       - name: Smoke-test tenkz picture pipeline
         if: env.TEX_CHANGED == 'true'
         run: python3 scripts/test_tenkz_pic.py
+
+      - name: Test measured tenkz typed-map label bands
+        if: env.TEX_CHANGED == 'true'
+        run: python3 scripts/test_tenkz_cd_map_labels.py
 
       - name: Test asymmetric tenkz face ports
         if: env.TEX_CHANGED == 'true'

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -159,6 +159,16 @@ Cell commands (expandable; legal only inside `tenkz`/`\tnpic`):
   `\tnarrow[from={(r,c)}, to={(r,c+1)}, species=⟨species⟩]{⟨name⟩}`;
   `fused` selects the fused line type, and `\tnarrow*` places the name on the opposite side. Every map must have either a role or a declared species. The line style records the map's type; the label records only the map itself. There are no arrowheads: the order of the objects determines the order of composition. Vertical maps, reverse maps, and maps that skip an object column lie outside this grammar.
 
+Map declarations are literal top-level commands after the matrix objects.
+Grouping or nesting a declaration is an error: the layout pass does not enter
+an opaque object merely to discover geometry that the outer matrix would own.
+
+The object-column gap is uniform across the small multiples and is measured
+from their widest opaque map-name band: its width plus two daylights, with
+`0.34·pitch` as the floor. Thus a long or superscripted name cannot erase the
+adjacent objects. An explicit `column sep=` remains an authoritative opt-in
+override and may deliberately undercut this automatic clearance.
+
 Typed-map rows belong to the categorical diagram language, not to the tensor-network language. Their vertices are mathematical objects and their joining strokes are maps, not contracted indices. A `\tnpic` occurring in an object cell remains an opaque mathematical object; the adjacent typed-map stroke does not acquire tensor ports or enter its contraction graph. The modes `maps` and `polygon` are disjoint, while ordinary grid mode retains the complete tikz-cd arrow grammar.
 
 A family is written as small multiples: one complete domain--codomain row for each member, with the same number of object columns in every row. A finite family is displayed in full, rather than by selected representatives. Parameters may remain symbolic when the displayed row asserts a formula uniformly over all their values. The matrix is a math object and requires no separate sizing mode. In an ordinary TeX document it may occur in displayed or running mathematics. In blueprint chapter source, until the whole-equation web reroute (G20) lands, a `tenkzcd` must instead be a top-level block outside `$...$` and `\[...\]`; use `\par\noindent\hfil ... \hfil\par` for a centered nonfloating diagram, or a `figure` when a genuine float is intended.
@@ -463,7 +473,7 @@ One base: `pitch = 11mm` (display). Derived constants (name, value, motivation):
 | `junction diameter` | 3.2 × wire width (≥ 0.9mm) | below 3×, a junction is indistinguishable from a wire crossing at 600 dpi |
 | `region margin` | 0.36·pitch | strictly < pitch/2 so single-site notches read; > glyph radius so hulls never clip glyphs |
 | `compact` / `inline` | 0.8 scale / em-based scale on pitch | profiles are one scale factor, not parallel constant lists — literals cannot bypass them |
-| `map column gap` | 0.34·pitch | a short composition remains a mathematical atom rather than expanding to display width; wider labels override it with `column sep=` |
+| `map column gap` | max(0.34·pitch, widest map-name band + 2·daylight) | the floor keeps a short composition compact; measured opaque label ink clears both adjacent objects without budgeting glyphs; explicit `column sep=` remains an opt-in override |
 | `map row gap` | 0.50·pitch | adjacent small multiples remain distinct without figure-scale leading; `row sep=` overrides it |
 
 ---
@@ -976,6 +986,10 @@ drop, and the braces' unnamed 0.20 offset.
   only, so a brace over unlabeled cells is not pushed out by labels
   elsewhere in the row, and a box-mode brace clears the *actual*
   (strut-grown) box edge instead of a nominal minimum.
+- **Typed-map label bands** (`tenkzcd[maps]`): the uniform object-column
+  gap is the widest opaque map-name band plus two daylights, with the
+  historical map gap as its floor.  The actual label node is measured; no
+  glyph budget or superscript allowance is predicted.
 
 The former per-consumer scan functions `\tenkz_span_leg_labels:nnnnN`
 and `\tenkz_span_dot_labels:nnnnN` are deleted; their logic lives

--- a/scripts/test_tenkz_cd_map_labels.py
+++ b/scripts/test_tenkz_cd_map_labels.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Regression checks for measured typed-map label bands."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = r"""
+\documentclass{article}
+\usepackage{tenkz}
+\pagestyle{empty}
+\makeatletter
+\newdimen\tenkzTestFloor
+\newdimen\tenkzTestDaylight
+\newdimen\tenkzTestOverride
+\begin{document}
+\tenkzTestFloor=\tenkz@r@mapgap\tenkz@pitch
+\tenkzTestDaylight=\tenkz@r@daylight\tenkz@pitch
+\tenkzTestOverride=2mm
+\typeout{TENKZ-FLOOR-SP=\number\tenkzTestFloor}
+\typeout{TENKZ-DAYLIGHT-SP=\number\tenkzTestDaylight}
+\typeout{TENKZ-OVERRIDE-SP=\number\tenkzTestOverride}
+\makeatother
+
+% Name the production label node and observe its live anchors immediately
+% after the production path is drawn.  The wrapper changes no geometry.
+\makeatletter
+\ExplSyntaxOn
+\int_new:N \g__tenkztest_map_int
+\cs_set_protected:Npn \tenkz_cd_map_path:nnn #1#2#3
+  {
+    \int_gincr:N \g__tenkztest_map_int
+    \draw[#1]
+      (tenkzmap-\int_use:N\l__tenkzcd_fromrow_int-
+        \int_use:N\l__tenkzcd_fromcol_int.base~east) --
+      node[tn~label, fill=tenkzPaper, outer~sep=0pt, #2]
+        (tenkz-test-map-label-\int_use:N\g__tenkztest_map_int)
+        {$\tenkz@labelsize #3$}
+      (tenkzmap-\int_use:N\l__tenkzcd_torow_int-
+        \int_use:N\l__tenkzcd_tocol_int.base~west);
+    \path let
+      \p1=(tenkzmap-\int_use:N\l__tenkzcd_fromrow_int-
+        \int_use:N\l__tenkzcd_fromcol_int.base~east),
+      \p2=(tenkz-test-map-label-\int_use:N\g__tenkztest_map_int.west),
+      \p3=(tenkz-test-map-label-\int_use:N\g__tenkztest_map_int.east),
+      \p4=(tenkzmap-\int_use:N\l__tenkzcd_torow_int-
+        \int_use:N\l__tenkzcd_tocol_int.base~west)
+    in \pgfextra
+      {
+        \typeout{TENKZ-MAP-\int_use:N\g__tenkztest_map_int-
+          LEFT-SP=\number\dimexpr\x2-\x1\relax}
+        \typeout{TENKZ-MAP-\int_use:N\g__tenkztest_map_int-
+          BAND-SP=\number\dimexpr\x3-\x2\relax}
+        \typeout{TENKZ-MAP-\int_use:N\g__tenkztest_map_int-
+          RIGHT-SP=\number\dimexpr\x4-\x3\relax}
+        \typeout{TENKZ-MAP-\int_use:N\g__tenkztest_map_int-
+          GAP-SP=\number\dimexpr\x4-\x1\relax}
+      };
+  }
+\ExplSyntaxOff
+\makeatother
+
+% An explicit, deliberately unsafe column separation remains authoritative.
+\begin{tenkzcd}[maps, species={channel}, column sep=2mm]
+  A & B
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{f}
+\end{tenkzcd}
+
+% A negative thin space leaves a nonempty, sub-floor label band and thus
+% exercises the historical mapgap floor without changing visible geometry.
+\begin{tenkzcd}[maps, species={channel}]
+  A & B
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{\!}
+\end{tenkzcd}
+
+% The rule makes this regression independent of font metrics; the genuine
+% mathematical name following it still exercises superscripted label ink.
+\begin{tenkzcd}[maps, species={channel}]
+  A & B
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]
+    {\rule{24mm}{0pt}\mathcal T_{\mathrm{seed}}^{(k,l,h)}}
+\end{tenkzcd}
+
+% Matrix passthrough keys cannot mutate the explicit tn-label skin used by
+% the deferred map-name node.
+\begin{tenkzcd}[
+  maps,
+  species={channel},
+  tn label/.append style={inner sep=10pt}
+]
+  A & B
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{f}
+\end{tenkzcd}
+\end{document}
+"""
+GROUPED_SOURCE = r"""
+\documentclass{article}
+\usepackage{tenkz}
+\begin{document}
+\begin{tenkzcd}[maps, species={channel}]
+  A & B
+  {\tnarrow[from={(1,1)}, to={(1,2)}, species=channel]
+    {\rule{24mm}{0pt}\mathcal T_{\mathrm{seed}}^{(k,l,h)}}}
+\end{tenkzcd}
+\end{document}
+"""
+SCALAR = re.compile(r"TENKZ-(FLOOR|DAYLIGHT|OVERRIDE)-SP=(-?[0-9]+)")
+MAP_VALUE = re.compile(
+    r"TENKZ-MAP-([1-4])-(LEFT|BAND|RIGHT|GAP)-SP=(-?[0-9]+)"
+)
+
+
+def close(actual: int, expected: int, tolerance: int = 2) -> bool:
+    return abs(actual - expected) <= tolerance
+
+
+def main() -> int:
+    engine = shutil.which("xelatex")
+    if engine is None:
+        print("FAIL: xelatex is required")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="tenkz-cd-map-labels-") as tmp:
+        work = Path(tmp)
+        tex = work / "typed-map-label-bands.tex"
+        tex.write_text(SOURCE, encoding="utf-8")
+        env = os.environ.copy()
+        env["TEXINPUTS"] = f"{ROOT / 'tex/tenkz'}//:" + env.get("TEXINPUTS", "")
+        run = subprocess.run(
+            [engine, "-interaction=nonstopmode", "-halt-on-error", tex.name],
+            cwd=work,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=120,
+        )
+        if run.returncode:
+            print(run.stdout)
+            print("FAIL: typed-map label-band fixture did not compile")
+            return 1
+
+        grouped_tex = work / "grouped-typed-map-label.tex"
+        grouped_tex.write_text(GROUPED_SOURCE, encoding="utf-8")
+        grouped_run = subprocess.run(
+            [engine, "-interaction=nonstopmode", "-halt-on-error", grouped_tex.name],
+            cwd=work,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=120,
+        )
+        if grouped_run.returncode == 0:
+            raise AssertionError("grouped typed-map declaration compiled silently")
+        if "Typed-map declarations must be literal" not in grouped_run.stdout:
+            print(grouped_run.stdout)
+            raise AssertionError("grouped declaration failed without the grammar error")
+
+    scalars = {name: int(value) for name, value in SCALAR.findall(run.stdout)}
+    maps = {index: {} for index in range(1, 5)}
+    for index, name, value in MAP_VALUE.findall(run.stdout):
+        maps[int(index)][name] = int(value)
+    if scalars.keys() != {"FLOOR", "DAYLIGHT", "OVERRIDE"}:
+        raise AssertionError(f"missing typed-map scalar measurements: {scalars}")
+    if any(row.keys() != {"LEFT", "BAND", "RIGHT", "GAP"}
+           for row in maps.values()):
+        raise AssertionError(f"missing live typed-map anchor measurements: {maps}")
+
+    # Map 1 deliberately exercises an unsafe explicit override; every
+    # automatically resolved map must retain daylight on both sides.
+    for index in (3, 2, 4):
+        row = maps[index]
+        for side in ("LEFT", "RIGHT"):
+            if row[side] + 2 < scalars["DAYLIGHT"]:
+                raise AssertionError(
+                    f"map {index} {side.lower()} clearance {row[side]}sp "
+                    f"is below daylight {scalars['DAYLIGHT']}sp"
+                )
+    if not close(maps[1]["GAP"], scalars["OVERRIDE"]):
+        raise AssertionError(
+            "explicit column sep did not remain authoritative: "
+            f"actual={maps[1]['GAP']}sp expected={scalars['OVERRIDE']}sp"
+        )
+    if not close(maps[2]["GAP"], scalars["FLOOR"]):
+        raise AssertionError(
+            "sub-floor label changed the historical mapgap geometry: "
+            f"actual={maps[2]['GAP']}sp expected={scalars['FLOOR']}sp"
+        )
+    expected_wide = maps[3]["BAND"] + 2 * scalars["DAYLIGHT"]
+    if not close(maps[3]["GAP"], expected_wide):
+        raise AssertionError(
+            "wide map gap is not its live label band plus two daylights: "
+            f"actual={maps[3]['GAP']}sp expected={expected_wide}sp"
+        )
+    expected_styled = max(
+        scalars["FLOOR"], maps[4]["BAND"] + 2 * scalars["DAYLIGHT"]
+    )
+    if not close(maps[4]["GAP"], expected_styled):
+        raise AssertionError(
+            "matrix passthrough style leaked into the deferred map label: "
+            f"actual={maps[4]['GAP']}sp expected={expected_styled}sp"
+        )
+    print(
+        "PASS: typed-map labels enforce top-level grammar, retain explicit/"
+        "floor geometry, and clear both adjacent objects by daylight"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -46,9 +46,9 @@
   \coordinate (#1) at ($(#2)!#4!#5:(#3)$);}
 \ExplSyntaxOn
 % Typed-map rows are mathematical objects joined by named maps.  One
-% third-pitch column air keeps adjacent object names distinct without
-% turning a short composition into a display-width commutative diagram;
-% half a pitch separates family members as small multiples.
+% third-pitch column air is the floor for an unlabelled or sub-floor band;
+% measured names grow it before placement.  Half a pitch separates family
+% members as small multiples.
 \def\tenkz@r@mapgap{0.34}
 \def\tenkz@r@maprowsep{0.50}
 
@@ -124,7 +124,10 @@
 \int_new:N \l__tenkzcd_fromcol_int
 \int_new:N \l__tenkzcd_torow_int
 \int_new:N \l__tenkzcd_tocol_int
+\int_new:N \l__tenkzcd_mapdecls_int
 \seq_new:N \l__tenkzcd_addr_seq
+\dim_new:N \l__tenkzcd_mapgap_dim
+\quark_new:N \q__tenkzcd_map_scan_stop
 
 % ---------- keys ----------
 \pgfkeys{
@@ -754,6 +757,38 @@
 % the existing wire styles, never an arrow tip.  Requiring (r,c)->(r,c+1)
 % makes composition left-to-right by grammar, not by a decorative head.
 
+% Map declarations conventionally follow the matrix objects, but their
+% opaque label bands determine the matrix spacing.  Delimited scanning finds
+% literal top-level declarations without expanding objects or entering their
+% balanced groups; the post-matrix count check rejects any hidden declaration.
+\cs_new_protected:Npn \tenkz_cd_measure_map_labels:n #1
+  { \tenkz_cd_measure_map_labels:w #1 \tnarrow \q__tenkzcd_map_scan_stop }
+
+\cs_new_protected:Npn \tenkz_cd_measure_map_labels:w #1 \tnarrow
+  {
+    \peek_meaning_remove:NTF \q__tenkzcd_map_scan_stop
+      { }
+      { \tenkz_cd_measure_map_label_aux }
+  }
+
+\NewDocumentCommand \tenkz_cd_measure_map_label_aux { s O{} m }
+  {
+    \int_incr:N \l__tenkzcd_mapdecls_int
+    \hbox_set:Nn \l_tmpa_box
+      {
+        \begin{tikzpicture}[baseline]
+          \node[tn~label, fill=tenkzPaper, outer~sep=0pt]
+            {$\tenkz@labelsize #3$};
+        \end{tikzpicture}
+      }
+    \dim_set:Nn \l_tmpa_dim
+      { \box_wd:N \l_tmpa_box
+        + \tenkz@r@daylight\tenkz@pitch * 2 }
+    \dim_compare:nNnT { \l_tmpa_dim } > { \l__tenkzcd_mapgap_dim }
+      { \dim_set_eq:NN \l__tenkzcd_mapgap_dim \l_tmpa_dim }
+    \tenkz_cd_measure_map_labels:w
+  }
+
 \cs_new_protected:Npn \tenkz_cd_map_address:nnNN #1#2#3#4
   {
     \tl_set:Ne \l_tmpa_tl { \tl_to_str:n {#2} }
@@ -806,7 +841,7 @@
     \draw[#1]
       (tenkzmap-\int_use:N\l__tenkzcd_fromrow_int-
         \int_use:N\l__tenkzcd_fromcol_int.base~east) --
-      node[tn~label, fill=tenkzPaper, #2]
+      node[tn~label, fill=tenkzPaper, outer~sep=0pt, #2]
         {$\tenkz@labelsize #3$}
       (tenkzmap-\int_use:N\l__tenkzcd_torow_int-
         \int_use:N\l__tenkzcd_tocol_int.base~west);
@@ -910,6 +945,10 @@
   {
     \tenkz_cd_measure_map:n {#2}
     \seq_gclear:N \g__tenkzcd_maps_seq
+    \int_zero:N \l__tenkzcd_mapdecls_int
+    \dim_set:Nn \l__tenkzcd_mapgap_dim
+      { \tenkz@dim{\tenkz@r@mapgap} }
+    \tenkz_cd_measure_map_labels:n {#2}
     \bool_if:NT \l__tenkzcd_mapmatrixvalid_bool
       {
         \tl_set:Nn \l__tenkzcd_body_tl {#2}
@@ -917,14 +956,29 @@
         \tl_put_right:Nn \l__tenkzcd_body_tl { \\ }
         \bool_gset_true:N \g__tenkzcd_inmaps_bool
         \begin{tikzpicture}[tenkz~every~picture, tenkz~cd~baseline]
-          \matrix (tenkzmap)
-            [matrix~of~math~nodes,
-             column~sep=\tenkz@dim{\tenkz@r@mapgap},
-             row~sep=\tenkz@dim{\tenkz@r@maprowsep},
-             nodes={inner~sep=1pt}, #1]
-            { \tl_use:N \l__tenkzcd_body_tl };
-          \seq_map_inline:Nn \g__tenkzcd_maps_seq
-            { \tenkz_cd_draw_map:nnnnnnn ##1 }
+          % Passthrough keys belong to the matrix and its cells.  Their scope
+          % ends before deferred house-label nodes are drawn.
+          \begin{scope}
+            \matrix (tenkzmap)
+              [matrix~of~math~nodes,
+               column~sep=\dim_use:N \l__tenkzcd_mapgap_dim,
+               row~sep=\tenkz@dim{\tenkz@r@maprowsep},
+               nodes={inner~sep=1pt, outer~sep=0pt}, #1]
+              { \tl_use:N \l__tenkzcd_body_tl };
+          \end{scope}
+          \int_compare:nNnTF
+            { \seq_count:N \g__tenkzcd_maps_seq }
+            = { \l__tenkzcd_mapdecls_int }
+            {
+              \seq_map_inline:Nn \g__tenkzcd_maps_seq
+                { \tenkz_cd_draw_map:nnnnnnn ##1 }
+            }
+            {
+              \PackageError{tenkz}{Typed-map~declarations~must~be~literal~
+                top-level~commands~after~the~objects}{A~grouped~or~nested~
+                declaration~cannot~be~measured~without~entering~an~opaque~
+                object.~Move~each~\string\tnarrow\space to~top~level.}
+            }
         \end{tikzpicture}
         \bool_gset_false:N \g__tenkzcd_inmaps_bool
       }


### PR DESCRIPTION
## Summary

Fix typed-map layout so opaque map-name bands are measured before the object matrix is placed.

The root cause was that `tenkzcd[maps]` always resolved the historical fixed map gap before deferred `\tnarrow` labels were drawn. A wide or superscripted paper-filled label could therefore overlap and erase the adjacent mathematical objects.

The automatic uniform column gap is now

```text
max(0.34 * pitch, widest live map-name band + 2 * daylight)
```

An explicit `column sep=` remains an authoritative opt-in override and may deliberately undercut the automatic clearance.

## Ownership boundary

- Map declarations must be literal top-level commands after the matrix objects. Grouped or nested declarations fail deterministically instead of forcing the outer layout pass to inspect opaque object contents.
- Matrix passthrough keys are scoped to the matrix and its cells, so they cannot mutate deferred house label styling.
- The production label node itself is measured with the house label skin; there is no glyph or superscript budget.

## Regression evidence

On the old base, a seeded wide-label fixture showed:

- measured gap growth: `0sp`, expected `1706249sp`;
- live left clearance: `-2832586sp`, below the required daylight `307659sp`.

With this change, the font-independent 24 mm seed has:

- live label band: `6336340sp`;
- left clearance: `307659sp`;
- right clearance: `307659sp`;
- total gap: `6951658sp = 6336340sp + 2 * 307659sp`.

The historical floor fixture remains exactly `697382sp`. The explicit `column sep=2mm` fixture remains exactly `372935sp`.

## Validation

- `python3 scripts/test_tenkz_cd_map_labels.py`
- 114-file tenkz lint scan: 0 findings
- face-port, index-routing, and tree regressions
- Python byte-compilation of the new regression
- all 19 acceptance examples compile and audit with 0 hard errors
- `typed-maps`: 8 pictures, 0 advisories
- manual compiled twice: 43 pages; 77 audited pictures, 0 hard errors
- `python3 scripts/test_tenkz_pic.py`: all cold, warm-cache, and edit-invalidation checks pass
- complete print blueprint: 703 pages

The Chapter 21 target is PDF page 632 (printed page 631). Local validation renders, named for reproducibility but not attached as public links, are:

- `/private/tmp/tnlean-4393-typed-maps-fiberwise-rebased-200dpi.png`
- `/private/tmp/tnlean-4393-ch21-fiberwise-rebased-page-632-200dpi.png`
- `/private/tmp/tnlean-4393-ch21-fiberwise-rebased-page-632-crop-200dpi.png`

All were rendered at 200 dpi and inspected at original detail. All four source/target superscripts are fully visible; the `T_0`, `S_2`, `S_0`, and `T_2` labels remain distinct with clearance on both sides; no paper-fill erasure or collision remains.

Closes LionSR/tenkz#39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes layout math in `tenkzcd[maps]` used by blueprint diagrams; risk is mitigated by a dedicated xelatex regression and explicit grammar errors for invalid declarations.
> 
> **Overview**
> **Fixes `tenkzcd[maps]` column spacing** so wide or superscripted map names no longer overlap adjacent object cells. The uniform object-column gap is now `max(0.34·pitch, widest measured opaque label band + 2·daylight)` instead of a fixed historical map gap applied before labels exist.
> 
> **Implementation in `tenkz-cd.code.tex`:** a pre-matrix pass scans literal top-level `\tnarrow` declarations (without entering grouped object content), measures each name with the production `tn~label` skin, and sets `column sep` from that width. Grouped or nested `\tnarrow` fails with a deterministic grammar error when declaration count does not match recorded maps. Matrix passthrough keys are scoped so they cannot restyle deferred map labels; drawn labels use `outer sep=0pt`.
> 
> **Docs and CI:** `docs/tenkz/DESIGN.md` records the grammar rule and updated `map column gap` metric. New `scripts/test_tenkz_cd_map_labels.py` (xelatex) asserts override, floor, wide-label, daylight clearance, and matrix-style isolation; PR CI runs it when TeX changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de13cc33b6b178860c8759da6cb4108339a0ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->