### PR TITLE
docs(blueprint): demote transfer trace pairing diagram

### DIFF
--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1596,17 +1596,17 @@ a common dilation space.
 \label{sec:trace_pairing_expansion}
 %% =========================================================
 
-The trace-pairing expansion separates a linear map into the scalar input
-pairing, the transfer coefficients, and the output basis element:
-\[
-    T(\rho)=\sum_i\sum_j t_{ij}\,\tr(\sigma_j\rho)\,\sigma_i.
-\]
-The diagram records the same factorization by closing the input matrix with
-$\sigma_j$, weighting the resulting scalar by $t_{ij}$, and producing the output
-matrix through $\sigma_i$:
-\begin{center}
-    \TNTransferMapTracePairing
-\end{center}
+% Formula/source: Wolf, Eq. (2.20), defines the transfer coefficients by
+% \widehat T_{\alpha\beta}=\tr(F_\alpha^\dagger T(G_\beta)).
+% In the chapter's same-D trace-self-dual specialization, the input and output
+% bases are identified with {\sigma_i}, and this becomes
+% t_{ij}=\tr(\sigma_i T(\sigma_j)) together with
+% T(\rho)=\sum_{i,j}t_{ij}\tr(\sigma_j\rho)\sigma_i.
+% Index verdict: j is summed in the input coordinate \tr(\sigma_j\rho), while
+% i is summed in the coefficient and output basis element \sigma_i.  This is an
+% algebraic basis expansion, not one tensor-network contraction.  In the
+% retired figure only \sigma_j and \rho were contracted; t_{ij}, \sigma_i, and
+% the equality to T(\rho) were unattached labels.
 
 \begin{definition}[Trace-self-dual basis]\label{def:trace_pairing_self_dual_basis}
     \lean{TracePairingSelfDualBasis}

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1596,11 +1596,13 @@ a common dilation space.
 \label{sec:trace_pairing_expansion}
 %% =========================================================
 
-% Formula/source: Wolf, Eq. (2.20), defines the transfer coefficients by
-% \widehat T_{\alpha\beta}=\tr(F_\alpha^\dagger T(G_\beta)).
-% In the chapter's same-D trace-self-dual specialization, the input and output
-% bases are identified with {\sigma_i}, and this becomes
-% t_{ij}=\tr(\sigma_i T(\sigma_j)) together with
+% Formula/source: Wolf, Eq. (2.20), writes the transfer coefficients for
+% Hilbert--Schmidt orthonormal bases as
+% \widehat T_{\alpha\beta}=\tr(F_\alpha^\dagger T(G_\beta)).  Identifying the
+% two bases with a Hermitian Hilbert--Schmidt orthonormal basis {\sigma_i}
+% gives t_{ij}=\tr(\sigma_i T(\sigma_j)).  The chapter proves the analogous
+% coordinate expansion more generally for a basis self-dual under the
+% bilinear pairing (A,B)\mapsto\tr(AB):
 % T(\rho)=\sum_{i,j}t_{ij}\tr(\sigma_j\rho)\sigma_i.
 % Index verdict: j is summed in the input coordinate \tr(\sigma_j\rho), while
 % i is summed in the coefficient and output basis element \sigma_i.  This is an

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -156,7 +156,7 @@ Note: the 7 hand-digitized region polygons inside `tn_motifs_peps.tex` all becom
 | TNKrausMap | ch16_channel_representations:467 | `[sandwich, east={cup=$\rho$}, west label=$T(\rho)$]: \tn{K_i} \\ \tn*{K_i}` | source-faithful applied channel; exact boundary `(2,0,0,0)`, no package change |
 | TNStinespring | ch16_channel_representations:768 | `[sandwich, east={cup=$\rho$}, west label=$T(\rho)$]: \tn{V} \\ \tn*{V}` | migrated inline (applied channel; the house input is the east cup; the unique unlabelled pairleg traces $E$) |
 | TNChoiMatrix | ch16_channel_representations:108 | `[rows={wire,wire}, east={cup=$\ketbra{\Omega}{\Omega}$}, west label=$\tau$]: \tnghost{} & \tnX[wires=2]{T\otimes\id} & \tnghost{} \\ \tnghost{} & & \tnghost{}` | applied two-wire Choi map; zero pairlegs, exact boundary `(2,0,0,0)`, no package change |
-| TNTransferMapTracePairing | ch16_channel_representations:1478 | demote: `T(\rho)=\sum_{ij}t_{ij}\tr(\sigma_j\rho)\,\sigma_i` (+ optional `\tnpic[inline, periodic]{\tnX{\sigma_j}&\tnX{\rho}}` for the trace loop) | needs-judgment (candidate demotion to plain math) |
+| TNTransferMapTracePairing | ch16_channel_representations:1478 | demote to the adjacent coefficient definition and expansion theorem; no replacement picture | demoted here: the legacy figure contracted only $\sigma_j$ with $\rho$, while $t_{ij}$, $\sigma_i$, and $T(\rho)$ were unattached labels; the separate public `TNCompactTraceCell` remains |
 | TNTwoPointCorrelator | ch14_correlations:50 | `[sandwich, west={cup=$Y$}, east={cup=$X\rho^R$}]` with `\tnX[wires=2]{\mathcal E_A^n}` between ghost anchors | trivial (a doubled-index map between input and trace-pairing cups; not a periodic word) |
 
 ### 5b. Free tier (irregular graphs, stars, projector chains)

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -829,22 +829,4 @@
     \end{TNDiagram}%
 }
 
-% ---------- Quantum-channel representation diagrams ----------
-
-% Trace-pairing transfer form
-% T(rho)=sum_{i,j} t_ij tr(sigma_j rho) sigma_i.  The trace loop passes through
-% rho and sigma_j; the scalar coefficient t_ij joins the two basis labels, and
-% sigma_i supplies the output matrix legs.
-\TNDeclareDiagram
-    {TNTransferMapTracePairing}
-    {}
-    {display}
-    {compact}
-    {\TNTransferMapTracePairing}
-    {chapter/ch16_channel_representations.tex}{%
-    \begin{TNDiagram}[compact]
-        \TNTransferMapTracePairingMotif
-    \end{TNDiagram}%
-}
-
 \makeatother

--- a/tex/tn/tn_motifs_peps.tex
+++ b/tex/tn/tn_motifs_peps.tex
@@ -8,11 +8,6 @@
     \TN@annotationterminal{#1}{#2}%
     \TN@label{#1}{(0,0)}{#3}%
 }
-\newcommand{\TN@motiflabelright}[3]{%
-    \TN@annotationterminal{#1}{#2}%
-    \TN@label[anchor=west]{#1}{(0,0)}{#3}%
-}
-
 % TNPEPSEdgeBlockingReduction
 \newcommand{\TNPEPSEdgeBlockingReductionMotif}{%
         \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNPEPSEdgeBlockingReduction|kind=peps-edge-reduction}%
@@ -668,17 +663,6 @@
         \TN@motiflabel{tnClientLabel2112}{(-0.42,0.60)}{c_{v,e_3}}
         \TN@motiflabel{tnClientLabel2113}{(0.42,-0.60)}{c_{v,e_4}}
         \TN@motiflabel{tnClientLabel2114}{(2.35,0)}{\displaystyle\prod_{e \ni v} c_{v,e} = 1}
-}
-
-% TNTransferMapTracePairing
-\newcommand{\TNTransferMapTracePairingMotif}{%
-        \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNTransferMapTracePairing|kind=transfer-pairing}%
-        \TNCompactTraceCell{tp}{(0,0)}{\sigma_j}{\rho}{}
-        \TNExpression{tpCoeff}{(2.10,0)}{t_{ij}}
-        \TNExpression{tpOut}{(3.45,0)}{\sigma_i}
-        \TN@motiflabel{tnClientLabel2174}{(1.35,0)}{\cdot}
-        \TN@motiflabel{tnClientLabel2175}{(2.78,0)}{\cdot}
-        \TN@motiflabelright{tnClientLabel2176}{(4.15,0)}{=T(\rho)}
 }
 
 \makeatother


### PR DESCRIPTION
## Summary

- remove the redundant transfer-map trace-pairing preamble and legacy figure
- retain the trace-self-dual basis, coefficient definition, and expansion theorem as the mathematical account
- record Wolf's Hilbert--Schmidt formula, the Hermitian-basis specialization, the chapter's more general bilinear-pairing analogue, and the index-contraction verdict in adjacent TeX comments
- remove only the retired catalogue declaration, its private motif, and the resulting orphaned private label helper
- preserve `TNCompactTraceCell` and the lower-level public tensor-network surface

## Validation

- strict tensor-network catalogue, semantic, and smoke-render audit: 44 declarations, 64 calls, zero private/raw/local-geometry debt
- `scripts/tenkz_lint.py`: 114 files, zero findings
- reader-facing prose diff check and targeted ChkTeX
- tenkz picture-pipeline, asymmetric-face-port, and coefficient-index-routing tests
- approved-reference margin checks; the full pixel comparison gives the same all-reference `1.0000` renderer mismatch on untouched `origin/main`
- full blueprint PDF: 703 pages
- full blueprint web build with the leanblueprint environment's bundled plasTeX
- visual review of PDF physical page 378 (printed 377) and the web section confirms that the heading now leads directly into the definitions without an empty block or orphaned prose

Closes #4498.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and legacy TN catalogue removal only; no Lean, auth, or runtime behavior changes.
> 
> **Overview**
> Removes the **TNTransferMapTracePairing** tensor-network figure from the trace-pairing expansion section in ch16 and treats the content as **plain math** only: the trace-self-dual basis, coefficient definition, and expansion theorem stay as the authoritative account.
> 
> The old preamble and `\TNTransferMapTracePairing` call are replaced by TeX comments that tie the expansion to Wolf Eq. (2.20), the Hermitian-basis specialization, and an explicit **index verdict**—the retired picture only contracted `\sigma_j` with `\rho`, while `t_{ij}`, `\sigma_i`, and `T(\rho)` were unattached labels, so it was not a faithful single contraction.
> 
> **Catalogue cleanup:** drops the `\TNDeclareDiagram` entry in `tn_catalogue.tex`, the `TNTransferMapTracePairingMotif` in `tn_motifs_peps.tex`, and the unused private `\TN@motiflabelright` helper. **`TNCompactTraceCell`** and other public TN surface are unchanged. **`docs/tenkz/MIGRATION-MAP.md`** records the demotion (no replacement tenkz picture).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3dfa9dc25fd88e5d5a252b0e08f3a61f86326e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->