### PR TITLE
feat(MPS/MPDO): identify cyclic-active three-boundary coefficient

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -539,7 +539,7 @@ import TNLean.MPS.MPDO.PhysicalSectorProductTransport
 import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalTransport
 import TNLean.MPS.MPDO.SectorPairingTransfer
-import TNLean.MPS.MPDO.CyclicActiveSectorRestriction
+import TNLean.MPS.MPDO.CyclicActiveThreeBoundaryTrace
 import TNLean.MPS.MPDO.ActiveSectorSpanningCounterexample
 import TNLean.MPS.MPDO.ActiveSectorInverseMapProvenance
 import TNLean.MPS.MPDO.ActiveSectorSpanningAreaLaw

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -798,4 +798,28 @@ theorem cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector
   obtain ⟨n, hn⟩ := hk
   exact F.cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector k n hn
 
+/-- Deleting a cyclic sector word outside the cyclic-active support remains
+valid after any linear coordinate contraction.
+
+In particular, reindexing a cyclic block and then taking either of the two
+surviving boundary partial traces cannot turn a deleted zero block into a
+nonzero contribution.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617, together with the cyclic sector decomposition at lines 1441--1450.
+
+**Local fix (cyclic-active restriction):** This assertion concerns deletion
+outside the positive-length cyclic support; it does not identify the
+restricted trace matrix with the unreduced Beigi matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem map_cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector
+    (F : PhysicalSectorFactorization K) [NeZero N]
+    (k : Fin N → Fin F.sectorCount)
+    (hk : ¬ ∀ n, F.IsCyclicActiveSector (k n))
+    {V : Type*} [AddCommMonoid V] [Module ℂ V]
+    (f : Matrix (SectorChainFiber F k) (SectorChainFiber F k) ℂ →ₗ[ℂ] V) :
+    f (F.cyclicNeighboringProduct k) = 0 := by
+  rw [F.cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector k hk,
+    map_zero]
+
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
@@ -111,7 +111,7 @@ theorem sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two
       ((F.neighboringOperator a b).trace.re : ℂ)
     exact (hpos a b).isHermitian.trace_eq_ofReal_re
   simp_rw [htrace, Matrix.smul_apply]
-  push_cast
+  norm_cast
 
 /-- Summing the partial traces of the three-site closures over the
 intermediate cyclic-active sector leaves the outer boundary operator with

--- a/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
@@ -44,7 +44,12 @@ variable {d D : ℕ} {K : MPOTensor d D}
 /-- The trace of a positive neighboring operator is the complexification of
 the corresponding cyclic-active trace-matrix entry.
 
-Source: arXiv:1606.00608, Appendix C.2, lines 1441--1455. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1455.
+
+**Local fix (cyclic-active restriction):** This equality is recorded on the
+positive-length cyclic support used in the three-boundary coefficient.  It
+does not identify the restricted trace matrix with the unreduced Beigi
+matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem neighboringOperator_trace_eq_cyclicActiveSectorTraceMatrix
     (F : PhysicalSectorFactorization K)
     (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)

--- a/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
@@ -41,6 +41,20 @@ namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D : ℕ} {K : MPOTensor d D}
 
+/-- The trace of a positive neighboring operator is the complexification of
+the corresponding cyclic-active trace-matrix entry.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1441--1455. -/
+theorem neighboringOperator_trace_eq_cyclicActiveSectorTraceMatrix
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (a b : F.CyclicActiveSector) :
+    (F.neighboringOperator a b).trace =
+      (F.cyclicActiveSectorTraceMatrix a b : ℂ) := by
+  change (F.neighboringOperator a b).trace =
+    ((F.neighboringOperator a b).trace.re : ℂ)
+  exact (hpos a b).isHermitian.trace_eq_ofReal_re
+
 /-- The two fully traced middle neighboring operators give the square of the
 cyclic-active trace matrix:
 \[
@@ -69,13 +83,7 @@ theorem sum_cyclicActive_trace_mul_trace_eq_pow_two
       ((F.cyclicActiveSectorTraceMatrix ^ 2) q h : ℂ) := by
   classical
   rw [pow_two, Matrix.mul_apply]
-  have htrace (a b : F.CyclicActiveSector) :
-      (F.neighboringOperator a b).trace =
-        (F.cyclicActiveSectorTraceMatrix a b : ℂ) := by
-    change (F.neighboringOperator a b).trace =
-      ((F.neighboringOperator a b).trace.re : ℂ)
-    exact (hpos a b).isHermitian.trace_eq_ofReal_re
-  simp_rw [htrace]
+  simp_rw [F.neighboringOperator_trace_eq_cyclicActiveSectorTraceMatrix hpos]
   norm_cast
 
 /-- After rescaling each traced neighboring edge by \(\lambda^{-1}\), the two
@@ -104,13 +112,8 @@ theorem sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two
       ((((lam⁻¹ : ℝ) • F.cyclicActiveSectorTraceMatrix) ^ 2) q h : ℂ) := by
   classical
   rw [pow_two, Matrix.mul_apply]
-  have htrace (a b : F.CyclicActiveSector) :
-      (F.neighboringOperator a b).trace =
-        (F.cyclicActiveSectorTraceMatrix a b : ℂ) := by
-    change (F.neighboringOperator a b).trace =
-      ((F.neighboringOperator a b).trace.re : ℂ)
-    exact (hpos a b).isHermitian.trace_eq_ofReal_re
-  simp_rw [htrace, Matrix.smul_apply]
+  simp_rw [F.neighboringOperator_trace_eq_cyclicActiveSectorTraceMatrix hpos,
+    Matrix.smul_apply]
   norm_cast
 
 /-- Summing the partial traces of the three-site closures over the

--- a/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
@@ -27,6 +27,7 @@ decomposition.
 ## Main results
 
 * `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_trace_mul_trace_eq_pow_two`.
+* `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two`.
 * `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_partialTraceRight_threeSiteSectorClosure`.
 
 ## Reference
@@ -76,6 +77,41 @@ theorem sum_cyclicActive_trace_mul_trace_eq_pow_two
     exact (hpos a b).isHermitian.trace_eq_ofReal_re
   simp_rw [htrace]
   norm_cast
+
+/-- After rescaling each traced neighboring edge by \(\lambda^{-1}\), the two
+fully traced middle edges give the square of the normalized cyclic-active
+trace matrix:
+\[
+  \sum_{r\in C}\lambda^{-1}\operatorname{tr}(\eta_{q,r})
+    \lambda^{-1}\operatorname{tr}(\eta_{r,h})
+  =\bigl((\lambda^{-1}T_C)^2\bigr)_{q,h}.
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This is the normalized two-step
+coefficient on the positive-length cyclic support.  It does not identify the
+one-step matrix with its square or with the unreduced Beigi matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (lam : ℝ) (q h : F.CyclicActiveSector) :
+    ∑ r : F.CyclicActiveSector,
+        ((lam⁻¹ : ℝ) : ℂ) * (F.neighboringOperator q r).trace *
+          (((lam⁻¹ : ℝ) : ℂ) * (F.neighboringOperator r h).trace) =
+      ((((lam⁻¹ : ℝ) • F.cyclicActiveSectorTraceMatrix) ^ 2) q h : ℂ) := by
+  classical
+  rw [pow_two, Matrix.mul_apply]
+  have htrace (a b : F.CyclicActiveSector) :
+      (F.neighboringOperator a b).trace =
+        (F.cyclicActiveSectorTraceMatrix a b : ℂ) := by
+    change (F.neighboringOperator a b).trace =
+      ((F.neighboringOperator a b).trace.re : ℂ)
+    exact (hpos a b).isHermitian.trace_eq_ofReal_re
+  simp_rw [htrace, Matrix.smul_apply]
+  push_cast
 
 /-- Summing the partial traces of the three-site closures over the
 intermediate cyclic-active sector leaves the outer boundary operator with

--- a/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveSectorRestriction
+import TNLean.MPS.MPDO.PhysicalSectorTraceActions
+
+/-!
+# Three-boundary trace on cyclic-active sectors
+
+This file identifies the coefficient obtained by summing the three-site
+partial trace over the intermediate cyclic-active sector.  If
+$T_{q,h}=\operatorname{Re}\operatorname{tr}(\eta_{q,h})$, then positivity of
+the neighboring operators gives
+\[
+  \sum_r \operatorname{tr}(\eta_{q,r})
+    \operatorname{tr}(\eta_{r,h})=(T^2)_{q,h}.
+\]
+Consequently, the corresponding sum of three-site partial traces is
+$(T^2)_{q,h}$ times the outer boundary operator.
+
+These are coordinate identities.  They do not identify $T$ with $T^2$, do
+not assert that $T$ has rank one, and do not construct a quantum Markov
+decomposition.
+
+## Main results
+
+* `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_trace_mul_trace_eq_pow_two`.
+* `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_partialTraceRight_threeSiteSectorClosure`.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The two fully traced middle neighboring operators give the square of the
+cyclic-active trace matrix:
+\[
+  \sum_{r\in C}\operatorname{tr}(\eta_{q,r})
+    \operatorname{tr}(\eta_{r,h})=(T_C^2)_{q,h}.
+\]
+
+Positive semidefiniteness is used only to replace each complex trace by the
+complexification of its real part.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The sum is restricted to sectors
+on positive-length directed cycles and yields the square of the restricted
+trace matrix.  It does not replace this square by the one-step trace matrix
+printed at source line 1613.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem sum_cyclicActive_trace_mul_trace_eq_pow_two
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (q h : F.CyclicActiveSector) :
+    ∑ r : F.CyclicActiveSector,
+        (F.neighboringOperator q r).trace *
+          (F.neighboringOperator r h).trace =
+      ((F.cyclicActiveSectorTraceMatrix ^ 2) q h : ℂ) := by
+  classical
+  rw [pow_two, Matrix.mul_apply]
+  have htrace (a b : F.CyclicActiveSector) :
+      (F.neighboringOperator a b).trace =
+        (F.cyclicActiveSectorTraceMatrix a b : ℂ) := by
+    change (F.neighboringOperator a b).trace =
+      ((F.neighboringOperator a b).trace.re : ℂ)
+    exact (hpos a b).isHermitian.trace_eq_ofReal_re
+  simp_rw [htrace]
+  norm_cast
+
+/-- Summing the partial traces of the three-site closures over the
+intermediate cyclic-active sector leaves the outer boundary operator with
+coefficient $(T_C^2)_{q,h}$.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This is the three-boundary
+coordinate identity for the positive-length cyclic support.  It proves only
+the appearance of the two-step coefficient; the identification with the
+source-ZCL reduced state and the Markov decomposition remain separate.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem sum_cyclicActive_partialTraceRight_threeSiteSectorClosure
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (q h : F.CyclicActiveSector) (X : Matrix (Fin D) (Fin D) ℂ) :
+    ∑ r : F.CyclicActiveSector,
+        Matrix.partialTraceRight (F.threeSiteSectorClosure q r h X) =
+      ((F.cyclicActiveSectorTraceMatrix ^ 2) q h : ℂ) •
+        F.boundaryOperator q h X := by
+  classical
+  simp_rw [F.partialTraceRight_threeSiteSectorClosure]
+  rw [← Finset.sum_smul, F.sum_cyclicActive_trace_mul_trace_eq_pow_two hpos q h]
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/SourceZCLMarginal.lean
+++ b/TNLean/MPS/MPDO/SourceZCLMarginal.lean
@@ -120,7 +120,13 @@ first apply the ZCL replacement while retaining `L + 1` sites, trace the last
 retained site, and then apply the ZCL replacement while retaining `L` sites.
 It makes no assertion that the neighboring trace matrix equals its square.
 
-Source: arXiv:1606.00608, Appendix C.2, lines 1606–1617. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1606–1617.
+
+**Local fix (additional marginal replacement):** The printed argument makes
+only the first replacement before returning to the one-step trace
+coefficient.  This theorem records the further replacement needed for the
+two-step coefficient.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reducedBlockState_add_three_eq_succ_of_isSourceZCL
     (M : MPOTensor d D) (hZCL : IsSourceZCL M) (L : ℕ) :
     M.reducedBlockState (L + 3) L (by omega) =

--- a/TNLean/MPS/MPDO/SourceZCLMarginal.lean
+++ b/TNLean/MPS/MPDO/SourceZCLMarginal.lean
@@ -23,6 +23,7 @@ at source line 1613 and does not construct a quantum Markov decomposition.
 
 * `MPOTensor.reducedBlockState_apply_eq_trace_evalWord_mul_verticalLoop_pow`
 * `MPOTensor.reducedBlockState_succ_succ_eq_succ_of_isSourceZCL`
+* `MPOTensor.reducedBlockState_add_three_eq_succ_of_isSourceZCL`
 
 ## Reference
 
@@ -109,5 +110,38 @@ theorem reducedBlockState_succ_succ_eq_succ_of_isSourceZCL
     exact_mod_cast ne_of_gt hlam
   rw [htrace, hnum]
   field_simp
+
+/-- Under source zero correlation length, tracing three sites from length
+`L + 3` gives the same normalized `L`-site marginal as tracing one site from
+length `L + 1`.
+
+This is the iterated marginal replacement needed for the four-region argument:
+first apply the ZCL replacement while retaining `L + 1` sites, trace the last
+retained site, and then apply the ZCL replacement while retaining `L` sites.
+It makes no assertion that the neighboring trace matrix equals its square.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1606–1617. -/
+theorem reducedBlockState_add_three_eq_succ_of_isSourceZCL
+    (M : MPOTensor d D) (hZCL : IsSourceZCL M) (L : ℕ) :
+    M.reducedBlockState (L + 3) L (by omega) =
+      M.reducedBlockState (L + 1) L (by omega) := by
+  have hstep :
+      M.reducedBlockState (L + 3) (L + 1) (by omega) =
+        M.reducedBlockState (L + 2) (L + 1) (by omega) := by
+    simpa [Nat.add_assoc] using
+      reducedBlockState_succ_succ_eq_succ_of_isSourceZCL M hZCL (L + 1)
+  have htrace :
+      M.reducedBlockState (L + 3) L (by omega) =
+        M.reducedBlockState (L + 2) L (by omega) := by
+    ext u v
+    have hcollapse3 :=
+      collapse_last M (N := L + 3) (a := L) (b := 0) (c := 1) (by omega) u v
+    have hcollapse2 :=
+      collapse_last M (N := L + 2) (a := L) (b := 0) (c := 1) (by omega) u v
+    simp only [Nat.add_zero] at hcollapse3 hcollapse2
+    rw [← hcollapse3, ← hcollapse2]
+    exact Finset.sum_congr rfl fun y _ ↦ congr_fun (congr_fun hstep (Fin.append u y))
+      (Fin.append v y)
+  exact htrace.trans (reducedBlockState_succ_succ_eq_succ_of_isSourceZCL M hZCL L)
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -654,6 +654,9 @@
     denominator on the right nonzero.
 \end{proof}
 
+% **Local fix (additional marginal replacement):** the printed proof returns
+% to a one-step coefficient after its first replacement.  See
+% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \begin{lemma}[Iterated marginal stability under zero correlation length]
     \label{lem:mpdo_source_zcl_iterated_marginal_stability}
     \lean{MPOTensor.reducedBlockState_add_three_eq_succ_of_isSourceZCL}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -654,6 +654,24 @@
     denominator on the right nonzero.
 \end{proof}
 
+\begin{lemma}[Iterated marginal stability under zero correlation length]
+    \label{lem:mpdo_source_zcl_iterated_marginal_stability}
+    \lean{MPOTensor.reducedBlockState_add_three_eq_succ_of_isSourceZCL}
+    \leanok
+    \uses{lem:mpdo_source_zcl_marginal_stability}
+    Let $M$ have source zero correlation length.  For every $L\geq0$, the
+    normalized $L$-site marginal obtained by tracing three sites from
+    $\sigma^{(L+3)}(M)$ equals the normalized $L$-site marginal obtained by
+    tracing one site from $\sigma^{(L+1)}(M)$.
+\end{lemma}
+
+\begin{proof}\leanok
+    First retain $L+1$ sites and apply
+    Lemma~\ref{lem:mpdo_source_zcl_marginal_stability}.  Trace the last of
+    these retained sites, and then apply the same lemma while retaining $L$
+    sites.
+\end{proof}
+
 \begin{definition}[Rank-one trace factorization for neighboring operators]
     \label{def:mpdo_generic_eta_rank_one_trace_factorization}
     \lean{Matrix.EtaRankOneTraceFactorization}
@@ -887,6 +905,8 @@
     \lean{MPOTensor.PhysicalSectorFactorization.isCyclicActiveSector_of_cyclicNeighboringProduct_ne_zero}
     \lean{MPOTensor.PhysicalSectorFactorization.cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector}
     \lean{MPOTensor.PhysicalSectorFactorization.cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      map_cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector}
     \leanok
     \uses{def:mpdo_cyclic_active_sector,
       def:mpdo_physical_sector_chain_coordinates}
@@ -896,14 +916,19 @@
         \Omega_k=0.
     \]
     Thus deleting the sectors outside $C$ leaves every finite cyclic
-    neighboring product unchanged.
+    neighboring product unchanged.  For every linear contraction $\Phi$,
+    including a composition of reindexings and partial traces,
+    \[
+        \Omega_k=0 \quad\Longrightarrow\quad \Phi(\Omega_k)=0.
+    \]
 \end{theorem}
 
 \begin{proof}\leanok
     If $\Omega_k\ne0$, each factor $\eta_{k_n,k_{n+1}}$ is nonzero; otherwise
     every matrix entry of the product vanishes.  Starting with the edge
     $k_n\to k_{n+1}$ and following the remaining cyclic edges gives a return
-    path to $k_n$.  Hence every $k_n$ belongs to $C$.
+    path to $k_n$.  Hence every $k_n$ belongs to $C$.  The last assertion is
+    the linear identity $\Phi(0)=0$.
 \end{proof}
 
 % **Local fix (cyclic-active restriction):** this is a restricted replacement for
@@ -1023,15 +1048,74 @@
 \end{proof}
 
 % Tracked in https://github.com/LionSR/TNLean/issues/4445.
-\begin{remark}[Open three-boundary identification]
+% **Local fix (cyclic-active restriction):** the intermediate sum is over the
+% positive-length cyclic support.  See
+% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\begin{lemma}[Cyclic-active three-boundary trace coefficient]
+    \label{lem:mpdo_cyclic_active_three_boundary_trace}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      sum_cyclicActive_trace_mul_trace_eq_pow_two}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      sum_cyclicActive_partialTraceRight_threeSiteSectorClosure}
+    \leanok
+    \uses{def:mpdo_cyclic_active_sector,
+      thm:mpdo_sector_closure_partial_traces}
+    Let $C$ be the set of cyclic-active sectors and suppose that every
+    neighboring operator is positive semidefinite.  For $q,h\in C$,
+    \[
+        \sum_{r\in C}\tr(\eta_{q,r})\tr(\eta_{r,h})
+        =(T_C^2)_{q,h}.
+    \]
+    More generally, if $B_{q,h}(X)$ denotes the outer boundary operator in
+    the three-site closure, then
+    \[
+      \sum_{r\in C}\tr_{\mathrm{mid}}
+        \bigl(B_{q,h}(X)\otimes\eta_{q,r}\otimes\eta_{r,h}\bigr)
+      =(T_C^2)_{q,h}B_{q,h}(X).
+    \]
+    Here $\tr_{\mathrm{mid}}$ traces both neighboring factors.  No equality
+    between $T_C$ and $T_C^2$ is asserted.
+
+    For every $\lambda\in\R$, set
+    $\widehat T_C=\lambda^{-1}T_C$.  The same calculation with each fully
+    traced edge multiplied by $\lambda^{-1}$ gives
+    \[
+      \sum_{r\in C}
+        \lambda^{-1}\tr(\eta_{q,r})\,
+        \lambda^{-1}\tr(\eta_{r,h})
+      =(\widehat T_C^2)_{q,h}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Positivity makes each $\tr(\eta_{a,b})$ real.  Expanding matrix
+    multiplication gives
+    \[
+      (T_C^2)_{q,h}=\sum_{r\in C}(T_C)_{q,r}(T_C)_{r,h}
+      =\sum_{r\in C}\tr(\eta_{q,r})\tr(\eta_{r,h}).
+    \]
+    The partial trace of the fixed-sector three-site closure is
+    \[
+      \tr(\eta_{q,r})\tr(\eta_{r,h})B_{q,h}(X).
+    \]
+    Summing over $r\in C$ proves the second identity.  Multiplying each of the
+    two trace factors by $\lambda^{-1}$ gives the normalized identity.
+\end{proof}
+
+% Tracked in https://github.com/LionSR/TNLean/issues/4445.
+\begin{remark}[Open fourth-region coordinate identification]
     \notready
-    The remaining physical step is to apply the zero-correlation-length
-    marginal replacement one further time than at line~1613 of
-    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}, express the trace of three
-    boundary sites in the cyclic-active sector coordinates, and prove that
-    the fully traced middle segment contributes $\widehat T^2$.  This must be
-    done without identifying $\widehat T$ with $\widehat T^2$ or the
-    cyclic-active matrix with the unreduced Beigi matrix.
+    Lemma~\ref{lem:mpdo_source_zcl_iterated_marginal_stability} gives the
+    required equality of normalized marginals, while
+    Lemma~\ref{lem:mpdo_cyclic_active_three_boundary_trace} and
+    Theorem~\ref{thm:mpdo_cyclic_active_deletion} give the local coefficient
+    and the deletion of vanishing cyclic summands.  It remains to
+    transport the marginal equality through the complete physical-sector
+    direct sum, retaining the two outer partial traces.  This must be done
+    without identifying $T_C$ with $T_C^2$ or $T_C$ with the unreduced Beigi
+    matrix.
 \end{remark}
 
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -657,8 +657,8 @@
 % **Local fix (additional marginal replacement):** the printed proof returns
 % to a one-step coefficient after its first replacement.  See
 % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
-\begin{lemma}[Iterated marginal stability under zero correlation length]
-    \label{lem:mpdo_source_zcl_iterated_marginal_stability}
+\begin{theorem}[Iterated marginal stability under zero correlation length]
+    \label{thm:mpdo_source_zcl_iterated_marginal_stability}
     \lean{MPOTensor.reducedBlockState_add_three_eq_succ_of_isSourceZCL}
     \leanok
     \uses{lem:mpdo_source_zcl_marginal_stability}
@@ -666,7 +666,7 @@
     normalized $L$-site marginal obtained by tracing three sites from
     $\sigma^{(L+3)}(M)$ equals the normalized $L$-site marginal obtained by
     tracing one site from $\sigma^{(L+1)}(M)$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     First retain $L+1$ sites and apply
@@ -1054,10 +1054,12 @@
 % **Local fix (cyclic-active restriction):** the intermediate sum is over the
 % positive-length cyclic support.  See
 % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
-\begin{lemma}[Cyclic-active three-boundary trace coefficient]
-    \label{lem:mpdo_cyclic_active_three_boundary_trace}
+\begin{theorem}[Cyclic-active three-boundary trace coefficient]
+    \label{thm:mpdo_cyclic_active_three_boundary_trace}
     \lean{MPOTensor.PhysicalSectorFactorization.%
       sum_cyclicActive_trace_mul_trace_eq_pow_two}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      neighboringOperator_trace_eq_cyclicActiveSectorTraceMatrix}
     \lean{MPOTensor.PhysicalSectorFactorization.%
       sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two}
     \lean{MPOTensor.PhysicalSectorFactorization.%
@@ -1090,7 +1092,7 @@
         \lambda^{-1}\tr(\eta_{r,h})
       =(\widehat T_C^2)_{q,h}.
     \]
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Positivity makes each $\tr(\eta_{a,b})$ real.  Expanding matrix
@@ -1110,9 +1112,9 @@
 % Tracked in https://github.com/LionSR/TNLean/issues/4445.
 \begin{remark}[Open fourth-region coordinate identification]
     \notready
-    Lemma~\ref{lem:mpdo_source_zcl_iterated_marginal_stability} gives the
+    Theorem~\ref{thm:mpdo_source_zcl_iterated_marginal_stability} gives the
     required equality of normalized marginals, while
-    Lemma~\ref{lem:mpdo_cyclic_active_three_boundary_trace} and
+    Theorem~\ref{thm:mpdo_cyclic_active_three_boundary_trace} and
     Theorem~\ref{thm:mpdo_cyclic_active_deletion} give the local coefficient
     and the deletion of vanishing cyclic summands.  It remains to
     transport the marginal equality through the complete physical-sector

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -428,12 +428,26 @@ fully traced middle edges.  Their coefficient is
   (T^2)_{q,h}=\sum_{r\in C}
     \tr(\eta_{q,r})\tr(\eta_{r,h}).
 \]
-Thus the proved rank-one statement supplies the separating boundary
-coefficient only in this three-boundary form.  What remains is to express the
-iterated marginal replacement in the physical-sector coordinates, carry the
-cyclic deletion through the two surviving partial traces, extract an explicit
-outer-product factorization of the restricted $\widehat T^2$, and construct
-the direct-sum Markov decomposition.  The present conditional theorem
+The second iteration of the normalized marginal identity is now
+\leanid{MPOTensor.reducedBlockState_add_three_eq_succ_of_isSourceZCL}.
+The coefficient calculation in cyclic-active physical-sector coordinates is
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+sum_cyclicActive_partialTraceRight_threeSiteSectorClosure}.  Its normalized
+form, with each traced edge scaled by $\lambda^{-1}$, is
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two} and yields precisely
+the coefficient $(\widehat T^2)_{q,h}$.  Also,
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+map_cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector}
+shows that an arbitrary linear coordinate contraction preserves the deletion
+of every vanishing cyclic summand.  Thus the proved rank-one statement
+supplies the separating boundary coefficient in this three-boundary form.
+
+What remains is to transport the normalized marginal equality through the
+complete physical-sector direct sum while retaining the two outer partial
+traces, extract an explicit outer-product factorization of the restricted
+$\widehat T^2$, and construct the direct-sum Markov decomposition.  The
+present conditional theorem
 \leanid{Matrix.eta_fourth_region_trace_formula} still assumes a factorization
 of the one-step matrix and cannot be discharged directly by the new theorem.
 
@@ -500,11 +514,11 @@ implies SAL.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Formalize the second iteration of the ZCL marginal replacement: replace
-the one-site boundary trace by a three-site trace of a chain longer by two
-sites, and identify its fully traced middle coefficient with the restricted
-matrix $\widehat T^2$.  The cyclic-active deletion theorem must also be carried
-through the two adjacent partial traces.
+\item Transport the proved second ZCL marginal replacement through the
+complete physical-sector direct sum.  Retain the two outer partial traces and
+insert the proved middle coefficient $\widehat T^2$.  The general linear
+deletion theorem already shows that discarded cyclic summands remain zero;
+the missing step is the dependent direct-sum reindexing of the full marginal.
 \item Extract an explicit outer-product factorization of
 $\widehat T^2$, separate the two remaining boundary sector sums, and construct
 the quantum Markov decomposition at each admissible cut.


### PR DESCRIPTION
## Summary

This change identifies the coefficient obtained by summing the three-site
partial trace over the intermediate cyclic-active sector.  For the restricted
trace matrix \(T_C\), the coefficient is
\[
  \sum_{r\in C}\operatorname{tr}(\eta_{q,r})
    \operatorname{tr}(\eta_{r,h})=(T_C^2)_{q,h}.
\]
It also proves the corresponding normalized identity and the resulting
three-boundary partial-trace formula.

The source zero-correlation-length marginal identity is iterated once more,
from an \((L+3)\)-site state to the same normalized \(L\)-site marginal as the
\((L+1)\)-site state.  Linear coordinate contractions are shown to preserve
the deletion of cyclic sector words outside the cyclic-active support.

The blueprint and the paper-gap account are updated to separate this completed
coefficient calculation from the remaining fourth-region coordinate
transport.  In particular, no equality \(T_C=T_C^2\), no identification with
the unreduced Beigi matrix, and no quantum Markov decomposition is asserted.

Source: CPSV16, arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
1606--1617.  The local clarification is recorded in
`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.

This is a child step of the fourth-region argument tracked by #4445.

## Validation

- `lake build TNLean.MPS.MPDO.CyclicActiveThreeBoundaryTrace -q --log-level=info`
- `lake build TNLean.MPS.MPDO.SourceZCLMarginal -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- whitespace, prohibited-token, line-length, oversized-file, and tactic-pattern checks

Closes #4500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean additions and documentation in specialized MPDO theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes **local coordinate identities** for the CPSV16 fourth-region step (#4445): summing over intermediate cyclic-active sectors yields the **two-step trace matrix** \(T_C^2\), not a claim that \(T_C = T_C^2\) or a Markov decomposition.
> 
> Adds **`CyclicActiveThreeBoundaryTrace`**: under PSD neighboring operators, \(\sum_{r\in C}\mathrm{tr}(\eta_{q,r})\mathrm{tr}(\eta_{r,h}) = (T_C^2)_{q,h}\), the \(\lambda^{-1}\)-normalized variant, and the matching **three-site partial-trace** formula on sector closures.
> 
> Adds **`reducedBlockState_add_three_eq_succ_of_isSourceZCL`**: a **second** source-ZCL marginal replacement (trace three sites from \(L+3\) vs one from \(L+1\)). Extends cyclic deletion with **`map_cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector`** so linear contractions preserve zero off-support cyclic words.
> 
> Blueprint and **`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`** record completed coefficient/marginal work and narrow the open item to **transporting the marginal through the full physical-sector direct sum** with outer partial traces retained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 506c12d72191cabe01750bfa5d52819cab025e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->