### PR TITLE
docs(tenkz): migrate one-site separation figure

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_square.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square.tex
@@ -1185,7 +1185,7 @@ rectangles, so a rectangular injectivity hypothesis yields their injectivity.
             \tnsite[role=marked, label=$v$]{(4,4)}
         \end{tenkzlattice}
         \qquad
-        \(R\subset S=R\cup\{v\}\).
+        $R\subset S=R\cup\{v\}$.
     \end{center}
 \end{definition}
 

--- a/blueprint/src/chapter/ch24_peps_ft_normal_square.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_square.tex
@@ -1166,7 +1166,26 @@ rectangles, so a rectangular injectivity hypothesis yields their injectivity.
     Diagrammatically, in the square-lattice proof this is the comparison
     between the source regions $R$ and $S=R\cup\{v\}$:
     \begin{center}
-        \TNPEPSNormalOneSiteSeparation
+        % Source verdict: paper_normal.tex:1519--1544 compares the injective
+        % regions R and S=R\cup\{v\}; their complements are injective as well.
+        % Type verdict: this is a lattice/set schematic, not a tensor
+        % contraction. The marked site v remains present with all its bonds.
+        % Cell-set audit: R=(2-4,2-4)-(4,4) has eight selected cells, while
+        % S=(2-4,2-4) has nine; v=(4,4) is marked in both pictures.
+        % Contraction/boundary audit: there are no tensor contractions and no
+        % tensor boundary signature; the boundary legs are cut lattice edges.
+        \begin{tenkzlattice}[rows=5, cols=5, boundary legs]
+            \tnregion[slot=selected, label=$R$]
+                {(2-4,2-4) - (4,4)}
+            \tnsite[role=marked, label=$v$]{(4,4)}
+        \end{tenkzlattice}
+        \qquad
+        \begin{tenkzlattice}[rows=5, cols=5, boundary legs]
+            \tnregion[slot=selected, label=$S$]{(2-4,2-4)}
+            \tnsite[role=marked, label=$v$]{(4,4)}
+        \end{tenkzlattice}
+        \qquad
+        \(R\subset S=R\cup\{v\}\).
     \end{center}
 \end{definition}
 

--- a/docs/tenkz/MIGRATION-MAP.md
+++ b/docs/tenkz/MIGRATION-MAP.md
@@ -138,7 +138,7 @@ The wrapper (`TNEquationRow` around a single `\ensuremath`) draws nothing; Phase
 | TNPEPSInjectiveRegionUnionProof | ch24_peps_ft_normal_union:211 | 5 `tenkzlattice` panels joined by `=`/`⊆` math, regions via `\tnregion` slots | trivial |
 | TNPEPSNormalRectangleCover | ch24_peps_ft_normal_square:242 | `tenkzlattice[rows=4, cols=4]` + overlapping `\tnregion[outline]` rectangles | trivial |
 | TNPEPSNormalEdgeComplementTopCollar | ch24_peps_ft_normal_square:517 | two lattice panels with `=`; complement + `slot=collar` regions | trivial |
-| TNPEPSNormalOneSiteSeparation | ch24_peps_ft_normal_square:1169 | two lattice panels; `\tnsite[removed]` + region slots | trivial |
+| TNPEPSNormalOneSiteSeparation | ch24_peps_ft_normal_square:1173 | two inline 5-by-5 `tenkzlattice` panels; $R=(2\mathbin{-}4,2\mathbin{-}4)\setminus\{(4,4)\}$ and $S=(2\mathbin{-}4,2\mathbin{-}4)$ via region slots, with the present site $v=(4,4)$ marked in both and $R\subset S=R\cup\{v\}$ shown explicitly | migrated inline; no package change |
 | TNPEPSNormalEdgeBlockingReduction | ch24_peps_ft_normal_square:1236 | lattice panel `\rightsquigarrow` blocked grid row | needs-judgment (mixed lattice+grid display), K1 for the blocked box |
 | TNPEPSNormalEdgeBlockingHypotheses | ch24_peps_ft_normal_square:1123 | single lattice panel with hypothesis regions | trivial |
 | TNPEPSNormalBlockingHypotheses | ch24_peps_ft_normal_capstone:33 | nested lattice panels (outer + two inner) with regions | trivial |

--- a/tex/tn/tn_catalogue.tex
+++ b/tex/tn/tn_catalogue.tex
@@ -604,18 +604,6 @@
 }
 
 \TNDeclareDiagram
-    {TNPEPSNormalOneSiteSeparation}
-    {}
-    {display}
-    {normal}
-    {\TNPEPSNormalOneSiteSeparation}
-    {chapter/ch24_peps_ft_normal_square.tex}{%
-    \begin{TNDiagram}[normal]
-        \TNPEPSNormalOneSiteSeparationMotif
-    \end{TNDiagram}%
-}
-
-\TNDeclareDiagram
     {TNPEPSNormalEdgeBlockingReduction}
     {}
     {display}

--- a/tex/tn/tn_motifs_peps.tex
+++ b/tex/tn/tn_motifs_peps.tex
@@ -357,25 +357,6 @@
         \end{TNPanel}
 }
 
-% TNPEPSNormalOneSiteSeparation
-\newcommand{\TNPEPSNormalOneSiteSeparationMotif}{%
-        \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNPEPSNormalOneSiteSeparation|kind=peps-region}%
-        \begin{TNPanel}{tnClientPanel1772}{(0,0)}
-            \TNPEPSNormalTallWindow
-            \TNPEPSNormalSquareLattice
-            \TNPEPSNormalRegionR
-            \TNPEPSNormalSingleSiteDifference
-        \end{TNPanel}
-        \TN@motiflabel{tnClientLabel1778}{(2.85,2.00)}{\subset}
-        \begin{TNPanel}{tnClientPanel1779}{(3.55cm,0)}
-            \TNPEPSNormalTallWindow
-            \TNPEPSNormalSquareLattice
-            \TNPEPSNormalRegionS
-            \TNPEPSNormalSingleSiteDifference
-        \end{TNPanel}
-        \TN@motiflabel{tnClientLabel1785}{(4.55,0.52)}{S=R\cup\{v\}}
-}
-
 % TNPEPSNormalEdgeBlockingReduction
 \newcommand{\TNPEPSNormalEdgeBlockingReductionMotif}{%
         \TNEventInternal{motif|picture=\the\TN@pictureid|name=TNPEPSNormalEdgeBlockingReduction|kind=peps-edge-reduction}%


### PR DESCRIPTION
## Summary

- replace the legacy one-site-separation wrapper with two inline 5-by-5 `tenkzlattice` panels
- draw R as the eight-site region and S as the corresponding nine-site region
- keep v present and marked in both panels, with all incident lattice bonds intact
- state the ordinary relation R subset S = R union {v}
- remove only the retired catalogue declaration and private motif

## Mathematical contract

The source comparison is a lattice-region schematic, not a tensor contraction. The first selected cell set is the 3-by-3 block with the lower-right site omitted; the second is the full 3-by-3 block. The distinguished site v is still part of the ambient lattice in both pictures.

## Validation

- independent source audit against `Papers/1804.04964/paper_normal.tex:1519-1544` and source PDF page 16
- exact event-log audit: region sizes 8 and 9, no removed-site events
- strict tenkz catalogue, semantic, lint, index, smoke, and pipeline checks
- full blueprint PDF and web builds
- visual review of the affected PDF page
- targeted SVG fallback for the excluded PEPS web chapter, with both generated SVG panels inspected
- forbidden visible phrase and `issue4152_proto` both absent

Closes #4499.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Figure and documentation-only tenkz migration with no runtime, auth, or data-path changes; remaining risk is visual/mathematical fidelity of the schematic.
> 
> **Overview**
> **Migrates** the normal one-site separation schematic from the legacy `\TNPEPSNormalOneSiteSeparation` catalogue wrapper to **two inline 5×5 `tenkzlattice` panels** in the one-site separation definition.
> 
> The new figure spells out **$R$** as the eight-site region `(2–4,2–4) \ {(4,4)}`, **$S$** as the full nine-site block, **$v=(4,4)$** marked (not removed) in both panels with bonds intact, and **$R \subset S = R \cup \{v\}$** in text. Maintainer comments document the lattice/set (non-contraction) contract and cell-count audit.
> 
> **Removes** the `\TNDeclareDiagram{TNPEPSNormalOneSiteSeparation}` entry and `\TNPEPSNormalOneSiteSeparationMotif` from the TN catalogue and PEPS motifs. **`docs/tenkz/MIGRATION-MAP.md`** records the entry as migrated inline at line 1173.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb2007c6fd250a1b494c38328f44e7f39cdadf6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->