### PR TITLE
fix(blueprint): restore block-injective inverse routing

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -329,31 +329,175 @@ gauges on the virtual legs of $K$ and identifies the block index of
 $\mathcal K_j$ with the label $j$:
 \[
     % K^{-1}K in block-injective canonical form (arXiv:1606.00608,
-    % eq. biCFK, Appendix C.2 lines 1666--1670; paper figure
-    % MPDO_biCF.png).  Panel 1 contracts K^{-1} with K through their
-    % doubled physical index.  Panel 2 substitutes
-    % K=X(bigoplus_j K_j)X^{-1}: K^{-1} remains on the upper rail, while
-    % X and X^{-1} flank K_j on the lower rail and extend to the internal
-    % block-index rail beneath it.
-    % Panel 3 removes the resolved K^{-1}-K pair and leaves the gauge legs
-    % and block-index wires.  Every panel has boundary signature
-    % (virtual-west=2 | virtual-east=2 | physical-up=0 |
-    % physical-down=0).
-    \begin{tenkz}[rows={ket, bra}, compact]
-        \tn{K^{-1}} \\
-        \tn{K}
-    \end{tenkz}
+    % eq. biCFK, Appendix C.2 lines 1666--1670; MPDO_biCF.png is the
+    % ink specification).  In panel 1 the vertical contraction joins the
+    % physical input of K to the corresponding input of K^{-1}; the other
+    % physical/output index of K^{-1} remains open above.  Its primitive
+    % boundary signature is (virtual-west=2 | virtual-east=2 |
+    % physical-up=1 | physical-down=0).
+    \begin{tenkzfree}[tensor style=box, compact]
+        \tnput[box, ports={west:virtual,east:virtual,
+                north:physical,south:physical}]
+            {biInvOne}{(0,8mm)}{K^{-1}}
+        \tnput[box, ports={west:virtual,east:virtual,north:physical}]
+            {biKOne}{(0,-5mm)}{K}
+        \tnput[boundary, ports={east:virtual}]
+            {biInvOneWest}{(-8mm,8mm)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biInvOneEast}{(8mm,8mm)}{}
+        \tnput[boundary, ports={east:virtual}]
+            {biKOneWest}{(-8mm,-5mm)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biKOneEast}{(8mm,-5mm)}{}
+        \tnput[boundary, ports={south:physical}]
+            {biOutOne}{(0,18mm)}{}
+        \tnjoin{biInvOneWest.east}{biInvOne.west}
+        \tnjoin{biInvOne.east}{biInvOneEast.west}
+        \tnjoin{biKOneWest.east}{biKOne.west}
+        \tnjoin{biKOne.east}{biKOneEast.west}
+        \tnjoin{biOutOne.south}{biInvOne.north}
+        \begin{scope}[bond/.append style={dashed}]
+            \tnjoin{biInvOne.south}{biKOne.north}
+        \end{scope}
+    \end{tenkzfree}
     \;=\;
-    \begin{tenkz}[rows={ket, bra, wire:none}, compact]
-        & \tn{K^{-1}} & \\
-        \tnX[wires=2]{X} & \tn{\mathcal K} & \tnX[wires=2]{X^{-1}} \\
-        & \tnghost{} &
-    \end{tenkz}
+    % Panel 2 resolves each virtual boundary index into the tensor leg and
+    % the j- and q-rails used by the block decomposition.  X and X^{-1}
+    % tap both rails, while K_j taps only the j-rail.  Thus the composite
+    % virtual boundaries of panel 1 appear here as four primitive virtual
+    % wires on each side (tensor, gauge, j, q); the open physical signature
+    % remains (physical-up=1 | physical-down=0).
+    \begin{tenkzfree}[tensor style=box, compact]
+        \tnput[box, ports={west:virtual,east:virtual,
+                north:physical,south:physical}]
+            {biInvTwo}{(18mm,15mm)}{K^{-1}}
+        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+            {biXTwo}{(0,0)}{X}
+        \tnput[box, ports={west:virtual,east:virtual,
+                north:physical,south:virtual}]
+            {biKTwo}{(18mm,0)}{\mathcal K_j}
+        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+            {biXinvTwo}{(36mm,0)}{X^{-1}}
+        \tnput[boundary, ports={east:virtual}]
+            {biInvTwoWest}{(10mm,15mm)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biInvTwoEast}{(26mm,15mm)}{}
+        \tnput[boundary, ports={east:virtual}]
+            {biGaugeTwoWest}{(-7mm,0)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biGaugeTwoEast}{(43mm,0)}{}
+        \tnput[boundary, ports={south:physical}]
+            {biOutTwo}{(18mm,27mm)}{}
+        \tnput[boundary, label pos=west, ports={east:virtual}]
+            {biJTwoWest}{(-7mm,-10mm)}{j}
+        \tnput[dot, ports={west:virtual,east:virtual,
+                north:virtual,south:virtual}]
+            {biXjTwo}{(0,-10mm)}{}
+        \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+            {biKjTwo}{(18mm,-10mm)}{}
+        \tnput[dot, ports={west:virtual,east:virtual,
+                north:virtual,south:virtual}]
+            {biXinvjTwo}{(36mm,-10mm)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biJTwoEast}{(43mm,-10mm)}{}
+        \tnput[boundary, label pos=west, ports={east:virtual}]
+            {biQTwoWest}{(-7mm,-18mm)}{q}
+        \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+            {biXqTwo}{(0,-18mm)}{}
+        \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+            {biXinvqTwo}{(36mm,-18mm)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biQTwoEast}{(43mm,-18mm)}{}
+        \tnjoin{biInvTwoWest.east}{biInvTwo.west}
+        \tnjoin{biInvTwo.east}{biInvTwoEast.west}
+        \tnjoin{biOutTwo.south}{biInvTwo.north}
+        \begin{scope}[bond/.append style={dashed}]
+            \tnjoin{biInvTwo.south}{biKTwo.north}
+        \end{scope}
+        \tnjoin{biGaugeTwoWest.east}{biXTwo.west}
+        \tnjoin{biXTwo.east}{biKTwo.west}
+        \tnjoin{biKTwo.east}{biXinvTwo.west}
+        \tnjoin{biXinvTwo.east}{biGaugeTwoEast.west}
+        \tnjoin{biXTwo.south}{biXjTwo.north}
+        \tnjoin{biXjTwo.south}{biXqTwo.north}
+        \tnjoin{biKTwo.south}{biKjTwo.north}
+        \tnjoin{biXinvTwo.south}{biXinvjTwo.north}
+        \tnjoin{biXinvjTwo.south}{biXinvqTwo.north}
+        \tnjoin{biJTwoWest.east}{biXjTwo.west}
+        \tnjoin{biXjTwo.east}{biKjTwo.west}
+        \tnjoin{biKjTwo.east}{biXinvjTwo.west}
+        \tnjoin{biXinvjTwo.east}{biJTwoEast.west}
+        \tnjoin{biQTwoWest.east}{biXqTwo.west}
+        \tnjoin{biXqTwo.east}{biXinvqTwo.west}
+        \tnjoin{biXinvqTwo.east}{biQTwoEast.west}
+    \end{tenkzfree}
     \;=\;
-    \begin{tenkz}[rows={wire, wire}, compact]
-        \tnX[wires=2]{X} & \tnghost{} & \tnX[wires=2]{X^{-1}} \\
-        & \tnghost{} &
-    \end{tenkz}
+    % Panel 3 is the componentwise identity.  The inward virtual legs of X
+    % and X^{-1} form the two matrix-unit elbows: the left open tip points
+    % west and the right open tip points east, exactly as in MPDO_biCF.png.
+    % The vertical line is physical, not virtual: it is normal to the tensor
+    % rail, continues the north/output port of K^{-1}, and ends at the
+    % j-rail dot which records delta_{j,j'}.  The q-rail passes independently
+    % below.  The primitive boundary signature is (virtual-west=4 |
+    % virtual-east=4 | physical-up=1 | physical-down=0).
+    \begin{tenkzfree}[tensor style=box, compact]
+        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+            {biXThree}{(0,0)}{X}
+        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+            {biXinvThree}{(36mm,0)}{X^{-1}}
+        \tnput[boundary, ports={east:virtual}]
+            {biGaugeThreeWest}{(-7mm,0)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biGaugeThreeEast}{(43mm,0)}{}
+        \tnput[boundary, ports={west:virtual,north:virtual}]
+            {biLeftElbow}{(12mm,0)}{}
+        \tnput[boundary, ports={east:virtual}]
+            {biLeftUnit}{(9mm,10mm)}{}
+        \tnput[boundary, ports={east:virtual,north:virtual}]
+            {biRightElbow}{(24mm,0)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biRightUnit}{(27mm,10mm)}{}
+        \tnput[boundary, ports={south:physical}]
+            {biOutThree}{(18mm,14mm)}{}
+        \tnput[boundary, label pos=west, ports={east:virtual}]
+            {biJThreeWest}{(-7mm,-10mm)}{j}
+        \tnput[dot, ports={west:virtual,east:virtual,
+                north:virtual,south:virtual}]
+            {biXjThree}{(0,-10mm)}{}
+        \tnput[dot, ports={west:virtual,east:virtual,north:physical}]
+            {biDeltaThree}{(18mm,-10mm)}{}
+        \tnput[dot, ports={west:virtual,east:virtual,
+                north:virtual,south:virtual}]
+            {biXinvjThree}{(36mm,-10mm)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biJThreeEast}{(43mm,-10mm)}{}
+        \tnput[boundary, label pos=west, ports={east:virtual}]
+            {biQThreeWest}{(-7mm,-18mm)}{q}
+        \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+            {biXqThree}{(0,-18mm)}{}
+        \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
+            {biXinvqThree}{(36mm,-18mm)}{}
+        \tnput[boundary, ports={west:virtual}]
+            {biQThreeEast}{(43mm,-18mm)}{}
+        \tnjoin{biGaugeThreeWest.east}{biXThree.west}
+        \tnjoin{biXThree.east}{biLeftElbow.west}
+        \tnjoin[route=vh]{biLeftElbow.north}{biLeftUnit.east}
+        \tnjoin[route=hv]{biRightUnit.west}{biRightElbow.north}
+        \tnjoin[route=vh]{biRightElbow.east}{biXinvThree.west}
+        \tnjoin{biXinvThree.east}{biGaugeThreeEast.west}
+        \tnjoin{biOutThree.south}{biDeltaThree.north}
+        \tnjoin{biXThree.south}{biXjThree.north}
+        \tnjoin{biXjThree.south}{biXqThree.north}
+        \tnjoin{biXinvThree.south}{biXinvjThree.north}
+        \tnjoin{biXinvjThree.south}{biXinvqThree.north}
+        \tnjoin{biJThreeWest.east}{biXjThree.west}
+        \tnjoin{biXjThree.east}{biDeltaThree.west}
+        \tnjoin{biDeltaThree.east}{biXinvjThree.west}
+        \tnjoin{biXinvjThree.east}{biJThreeEast.west}
+        \tnjoin{biQThreeWest.east}{biXqThree.west}
+        \tnjoin{biXqThree.east}{biXinvqThree.west}
+        \tnjoin{biXinvqThree.east}{biQThreeEast.west}
+    \end{tenkzfree}
 \]
 Consequently,
 \[

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -334,7 +334,11 @@ $\mathcal K_j$ with the label $j$:
     % physical input of K to the corresponding input of K^{-1}; the other
     % physical/output index of K^{-1} remains open above.  Its primitive
     % boundary signature is (virtual-west=2 | virtual-east=2 |
-    % physical-up=1 | physical-down=0).
+    % physical-up=1 | physical-down=0).  The paper distinguishes both
+    % physical contractions by a dashed stroke.  The public tenkzfree
+    % grammar has no semantic dash key, so the typed physical--physical
+    % joins below use the ordinary solid bond; issue #4536 tracks the
+    % missing public spelling.
     \begin{tenkzfree}[tensor style=box, compact]
         \tnput[box, ports={west:virtual,east:virtual,
                 north:physical,south:physical}]
@@ -356,9 +360,7 @@ $\mathcal K_j$ with the label $j$:
         \tnjoin{biKOneWest.east}{biKOne.west}
         \tnjoin{biKOne.east}{biKOneEast.west}
         \tnjoin{biOutOne.south}{biInvOne.north}
-        \begin{scope}[bond/.append style={dashed}]
-            \tnjoin{biInvOne.south}{biKOne.north}
-        \end{scope}
+        \tnjoin{biInvOne.south}{biKOne.north}
     \end{tenkzfree}
     \;=\;
     % Panel 2 resolves each virtual boundary index into the tensor leg and
@@ -411,9 +413,7 @@ $\mathcal K_j$ with the label $j$:
         \tnjoin{biInvTwoWest.east}{biInvTwo.west}
         \tnjoin{biInvTwo.east}{biInvTwoEast.west}
         \tnjoin{biOutTwo.south}{biInvTwo.north}
-        \begin{scope}[bond/.append style={dashed}]
-            \tnjoin{biInvTwo.south}{biKTwo.north}
-        \end{scope}
+        \tnjoin{biInvTwo.south}{biKTwo.north}
         \tnjoin{biGaugeTwoWest.east}{biXTwo.west}
         \tnjoin{biXTwo.east}{biKTwo.west}
         \tnjoin{biKTwo.east}{biXinvTwo.west}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -365,7 +365,9 @@ $\mathcal K_j$ with the label $j$:
     \;=\;
     % Panel 2 resolves each virtual boundary index into the tensor leg and
     % the j- and q-rails used by the block decomposition.  X and X^{-1}
-    % tap both rails, while K_j taps only the j-rail.  Thus the composite
+    % have two distinct downward legs: one terminates at the j-dot and the
+    % other crosses the j-rail without a junction before terminating at the
+    % q-dot.  K_j taps only the j-rail.  Thus the composite
     % virtual boundaries of panel 1 appear here as four primitive virtual
     % wires on each side (tensor, gauge, j, q); the open physical signature
     % remains (physical-up=1 | physical-down=0).
@@ -373,12 +375,14 @@ $\mathcal K_j$ with the label $j$:
         \tnput[box, ports={west:virtual,east:virtual,
                 north:physical,south:physical}]
             {biInvTwo}{(18mm,15mm)}{K^{-1}}
-        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+        \tnput[box, ports={west:virtual,east:virtual,
+                south west:virtual,south east:virtual}]
             {biXTwo}{(0,0)}{X}
         \tnput[box, ports={west:virtual,east:virtual,
                 north:physical,south:virtual}]
             {biKTwo}{(18mm,0)}{\mathcal K_j}
-        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+        \tnput[box, ports={west:virtual,east:virtual,
+                south west:virtual,south east:virtual}]
             {biXinvTwo}{(36mm,0)}{X^{-1}}
         \tnput[boundary, ports={east:virtual}]
             {biInvTwoWest}{(10mm,15mm)}{}
@@ -394,20 +398,20 @@ $\mathcal K_j$ with the label $j$:
             {biJTwoWest}{(-7mm,-10mm)}{j}
         \tnput[dot, ports={west:virtual,east:virtual,
                 north:virtual,south:virtual}]
-            {biXjTwo}{(0,-10mm)}{}
+            {biXjTwo}{(biXTwo.south west |- 0,-10mm)}{}
         \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
             {biKjTwo}{(18mm,-10mm)}{}
         \tnput[dot, ports={west:virtual,east:virtual,
                 north:virtual,south:virtual}]
-            {biXinvjTwo}{(36mm,-10mm)}{}
+            {biXinvjTwo}{(biXinvTwo.south west |- 0,-10mm)}{}
         \tnput[boundary, ports={west:virtual}]
             {biJTwoEast}{(43mm,-10mm)}{}
         \tnput[boundary, label pos=west, ports={east:virtual}]
             {biQTwoWest}{(-7mm,-18mm)}{q}
         \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
-            {biXqTwo}{(0,-18mm)}{}
+            {biXqTwo}{(biXTwo.south east |- 0,-18mm)}{}
         \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
-            {biXinvqTwo}{(36mm,-18mm)}{}
+            {biXinvqTwo}{(biXinvTwo.south east |- 0,-18mm)}{}
         \tnput[boundary, ports={west:virtual}]
             {biQTwoEast}{(43mm,-18mm)}{}
         \tnjoin{biInvTwoWest.east}{biInvTwo.west}
@@ -418,11 +422,11 @@ $\mathcal K_j$ with the label $j$:
         \tnjoin{biXTwo.east}{biKTwo.west}
         \tnjoin{biKTwo.east}{biXinvTwo.west}
         \tnjoin{biXinvTwo.east}{biGaugeTwoEast.west}
-        \tnjoin{biXTwo.south}{biXjTwo.north}
-        \tnjoin{biXjTwo.south}{biXqTwo.north}
+        \tnjoin{biXTwo.south west}{biXjTwo.north}
+        \tnjoin{biXTwo.south east}{biXqTwo.north}
         \tnjoin{biKTwo.south}{biKjTwo.north}
-        \tnjoin{biXinvTwo.south}{biXinvjTwo.north}
-        \tnjoin{biXinvjTwo.south}{biXinvqTwo.north}
+        \tnjoin{biXinvTwo.south west}{biXinvjTwo.north}
+        \tnjoin{biXinvTwo.south east}{biXinvqTwo.north}
         \tnjoin{biJTwoWest.east}{biXjTwo.west}
         \tnjoin{biXjTwo.east}{biKjTwo.west}
         \tnjoin{biKjTwo.east}{biXinvjTwo.west}
@@ -433,28 +437,27 @@ $\mathcal K_j$ with the label $j$:
     \end{tenkzfree}
     \;=\;
     % Panel 3 is the componentwise identity.  The inward virtual legs of X
-    % and X^{-1} form the two matrix-unit elbows: the left open tip points
-    % west and the right open tip points east, exactly as in MPDO_biCF.png.
+    % and X^{-1} form the two matrix-unit hooks: each hook is one continuous
+    % virtual edge, the left open tip points west, and the right open tip
+    % points east, exactly as in MPDO_biCF.png.
     % The vertical line is physical, not virtual: it is normal to the tensor
     % rail, continues the north/output port of K^{-1}, and ends at the
     % j-rail dot which records delta_{j,j'}.  The q-rail passes independently
     % below.  The primitive boundary signature is (virtual-west=4 |
     % virtual-east=4 | physical-up=1 | physical-down=0).
     \begin{tenkzfree}[tensor style=box, compact]
-        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+        \tnput[box, ports={west:virtual,east:virtual,
+                south west:virtual,south east:virtual}]
             {biXThree}{(0,0)}{X}
-        \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
+        \tnput[box, ports={west:virtual,east:virtual,
+                south west:virtual,south east:virtual}]
             {biXinvThree}{(36mm,0)}{X^{-1}}
         \tnput[boundary, ports={east:virtual}]
             {biGaugeThreeWest}{(-7mm,0)}{}
         \tnput[boundary, ports={west:virtual}]
             {biGaugeThreeEast}{(43mm,0)}{}
-        \tnput[boundary, ports={west:virtual,north:virtual}]
-            {biLeftElbow}{(12mm,0)}{}
         \tnput[boundary, ports={east:virtual}]
             {biLeftUnit}{(9mm,10mm)}{}
-        \tnput[boundary, ports={east:virtual,north:virtual}]
-            {biRightElbow}{(24mm,0)}{}
         \tnput[boundary, ports={west:virtual}]
             {biRightUnit}{(27mm,10mm)}{}
         \tnput[boundary, ports={south:physical}]
@@ -463,33 +466,33 @@ $\mathcal K_j$ with the label $j$:
             {biJThreeWest}{(-7mm,-10mm)}{j}
         \tnput[dot, ports={west:virtual,east:virtual,
                 north:virtual,south:virtual}]
-            {biXjThree}{(0,-10mm)}{}
+            {biXjThree}{(biXThree.south west |- 0,-10mm)}{}
         \tnput[dot, ports={west:virtual,east:virtual,north:physical}]
             {biDeltaThree}{(18mm,-10mm)}{}
         \tnput[dot, ports={west:virtual,east:virtual,
                 north:virtual,south:virtual}]
-            {biXinvjThree}{(36mm,-10mm)}{}
+            {biXinvjThree}{(biXinvThree.south west |- 0,-10mm)}{}
         \tnput[boundary, ports={west:virtual}]
             {biJThreeEast}{(43mm,-10mm)}{}
         \tnput[boundary, label pos=west, ports={east:virtual}]
             {biQThreeWest}{(-7mm,-18mm)}{q}
         \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
-            {biXqThree}{(0,-18mm)}{}
+            {biXqThree}{(biXThree.south east |- 0,-18mm)}{}
         \tnput[dot, ports={west:virtual,east:virtual,north:virtual}]
-            {biXinvqThree}{(36mm,-18mm)}{}
+            {biXinvqThree}{(biXinvThree.south east |- 0,-18mm)}{}
         \tnput[boundary, ports={west:virtual}]
             {biQThreeEast}{(43mm,-18mm)}{}
         \tnjoin{biGaugeThreeWest.east}{biXThree.west}
-        \tnjoin{biXThree.east}{biLeftElbow.west}
-        \tnjoin[route=vh]{biLeftElbow.north}{biLeftUnit.east}
-        \tnjoin[route=hv]{biRightUnit.west}{biRightElbow.north}
-        \tnjoin[route=vh]{biRightElbow.east}{biXinvThree.west}
+        \tnjoin[route=arc,out=0,in=0]
+            {biXThree.east}{biLeftUnit.east}
+        \tnjoin[route=arc,out=180,in=180]
+            {biXinvThree.west}{biRightUnit.west}
         \tnjoin{biXinvThree.east}{biGaugeThreeEast.west}
         \tnjoin{biOutThree.south}{biDeltaThree.north}
-        \tnjoin{biXThree.south}{biXjThree.north}
-        \tnjoin{biXjThree.south}{biXqThree.north}
-        \tnjoin{biXinvThree.south}{biXinvjThree.north}
-        \tnjoin{biXinvjThree.south}{biXinvqThree.north}
+        \tnjoin{biXThree.south west}{biXjThree.north}
+        \tnjoin{biXThree.south east}{biXqThree.north}
+        \tnjoin{biXinvThree.south west}{biXinvjThree.north}
+        \tnjoin{biXinvThree.south east}{biXinvqThree.north}
         \tnjoin{biJThreeWest.east}{biXjThree.west}
         \tnjoin{biXjThree.east}{biDeltaThree.west}
         \tnjoin{biDeltaThree.east}{biXinvjThree.west}


### PR DESCRIPTION
Closes LionSR/tenkz#40.

The block-injective inverse display now follows `MPDO_biCF.png` panel by panel. It retains the open physical/output leg of `K^{-1}`, resolves the `j` and `q` rails as distinct typed edges, attaches the middle tensor only to the `j` rail, and draws the two matrix-unit hooks together with the physical identity thread at the `delta_{j,j-prime}` rail dot. Each `q` leg crosses the `j` rail without a junction, and each matrix-unit hook is one continuous virtual edge.

The paper uses a dashed stroke for the two physical contractions. The public `tenkzfree` grammar has no semantic dashed typed join, so this chapter uses ordinary typed solid joins rather than bypassing the public calculus; LionSR/tenkz#53 tracks the missing semantic stroke.

All formula, ink-to-index, and boundary-signature discussion remains in TeX comments. Visible prose is unchanged. This is a chapter-only repair: no `tenkz` package code, catalogue declaration, or figure macro is added.

Validation:
- focused standalone SVG compile of all three panels
- focused `tenkz` audit: 3 pictures, 0 hard errors, 0 advisories
- strict legacy tensor-network audit passes
- `tenkz` source lint: 0 findings
- full `leanblueprint pdf`: 704 pages
- full `tenkz` audit: 0 hard errors
- 200 dpi exact-page render and side-by-side comparison with `Papers/1606.00608/MPDO_biCF.png`

Exact-head artifacts (head `96629d776` on base `02b9b11c7`):
- page: `/private/tmp/tnlean-4394-base-02b9-page-474-200dpi.png`
- figure crop: `/private/tmp/tnlean-4394-base-02b9-figure-200dpi.png`
- source comparison: `/private/tmp/tnlean-4394-base-02b9-side-by-side.png`
- focused panel 1: `/private/tmp/tnlean-4394-base-02b9-focused-svg/tenkz-336e31f01dff4f7d.svg`
- focused panel 2: `/private/tmp/tnlean-4394-base-02b9-focused-svg/tenkz-536fc3e9ffd089e0.svg`
- focused panel 3: `/private/tmp/tnlean-4394-base-02b9-focused-svg/tenkz-1db8859d07e663f1.svg`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint LaTeX figure repair only; no runtime, auth, or library API changes.
>
> **Overview**
> Replaces the three compact **`tenkz`** row layouts for the **block-injective** identity **\(K^{-1}K\)** in `ch20_mpdo_canonical_forms.tex` with explicit **`tenkzfree`** diagrams that follow **MPDO_biCF.png** panel by panel (closes LionSR/tenkz#40).
>
> The new ink keeps **\(K^{-1}\)**’s open physical/output leg, expands **\(j\)** and **\(q\)** rails in the middle panel, attaches the middle tensor to the **\(j\)** rail, and draws matrix-unit elbows plus the physical thread at **\(\delta_{j,j'}\)** in the final panel. **Visible prose is unchanged**; panel-by-panel boundary signatures, ink-to-index notes, and the dashed-contraction caveat (solid bonds until LionSR/tenkz#53) live in TeX comments only. **No `tenkz` package or macro changes**—chapter TeX only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17bd196c8b06628691c62bbdd2be7e0670078eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
