### PR TITLE
doc: correct the repository module map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ The source lives in `TNLean/` and is organized into **layers 0-6 with sublayers*
 | **5b** | `MPS/RFP/` | Renormalization fixed-point scaffolding |
 | **6** | `Wielandt/` | Span-growth, rank-one extraction, rectangular span, Wielandt bound, primitivity equivalences |
 
-**Other modules**: `PiAlgebra/` (pi-algebra FT variants), `PEPS/` (exploratory), `MPS/MPDO/` (density operator foundations), `Archive/` (legacy, excluded from root imports), `Scratch/` (experimental).
+**Other modules**: `PiAlgebra/` (pi-algebra FT variants), `PEPS/` (two-dimensional fundamental-theorem development for torus, cycle, and normal-tensor routes), `MPS/MPDO/` (density operator foundations), and `Archive/` (legacy, excluded from root imports).
 
 ### Key Types and Definitions
 


### PR DESCRIPTION
### Motivation
- `CLAUDE.md` described the 187-file PEPS development as exploratory and listed a nonexistent `TNLean/Scratch/` module.
- The injected repository map should reflect the current source tree.

### Description
- Describe PEPS as the two-dimensional fundamental-theorem development covering torus, cycle, and normal-tensor routes.
- Remove the nonexistent Scratch module from the architecture summary.
- Preserve the remaining module descriptions after checking them against the tree.

### Testing
- Confirmed `TNLean/PEPS/` contains 187 Lean files, including 49 Torus, 16 Cycle, and 23 Normal files.
- Confirmed `TNLean/Scratch/` does not exist.
- `git diff --check`

---
Closes #4527

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to `CLAUDE.md` with no code or build impact.
> 
> **Overview**
> Updates the **Other modules** blurb in `CLAUDE.md` so the architecture summary matches the current tree.
> 
> **`PEPS/`** is no longer labeled exploratory; it is described as the two-dimensional fundamental-theorem work (torus, cycle, and normal-tensor routes). The nonexistent **`Scratch/`** module is removed from that list. Wording for **`PiAlgebra/`**, **`MPS/MPDO/`**, and **`Archive/`** is unchanged aside from light punctuation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d4c716775f0aab9c9b68675a88b46363261db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->