### PR TITLE
fix(tenkz): materialize typed-map labels once

### DIFF
--- a/scripts/test_tenkz_cd_map_labels.py
+++ b/scripts/test_tenkz_cd_map_labels.py
@@ -20,6 +20,15 @@ SOURCE = r"""
 \newdimen\tenkzTestFloor
 \newdimen\tenkzTestDaylight
 \newdimen\tenkzTestOverride
+\newcount\tenkzStatefulCalls
+\tenkzStatefulCalls=0
+\newcommand\tenkzStatefulLabel{%
+  \global\advance\tenkzStatefulCalls by 1
+  \ifnum\tenkzStatefulCalls=1
+    \rule{24mm}{0pt}f%
+  \else
+    \rule{48mm}{0pt}f%
+  \fi}
 \begin{document}
 \tenkzTestFloor=\tenkz@r@mapgap\tenkz@pitch
 \tenkzTestDaylight=\tenkz@r@daylight\tenkz@pitch
@@ -40,9 +49,12 @@ SOURCE = r"""
     \draw[#1]
       (tenkzmap-\int_use:N\l__tenkzcd_fromrow_int-
         \int_use:N\l__tenkzcd_fromcol_int.base~east) --
-      node[tn~label, fill=tenkzPaper, outer~sep=0pt, #2]
+      node[inner~sep=0pt, outer~sep=0pt, #2]
         (tenkz-test-map-label-\int_use:N\g__tenkztest_map_int)
-        {$\tenkz@labelsize #3$}
+        {
+          \exp_args:Nc \box_use:N
+            { l__tenkzcd_map_label_#3_box }
+        }
       (tenkzmap-\int_use:N\l__tenkzcd_torow_int-
         \int_use:N\l__tenkzcd_tocol_int.base~west);
     \path let
@@ -98,6 +110,33 @@ SOURCE = r"""
   A & B
   \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{f}
 \end{tenkzcd}
+
+% Stateful label material must execute exactly once and the same boxed
+% material must determine both measured spacing and production geometry.
+\begin{tenkzcd}[maps, species={channel}]
+  A & B
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]
+    {\tenkzStatefulLabel}
+\end{tenkzcd}
+\typeout{TENKZ-STATEFUL-FINAL-CALLS=\the\tenkzStatefulCalls}
+
+% A globally appended label font must govern both materialization and the
+% deferred node.  Compare its live band with an independently styled node.
+\makeatletter
+\begingroup
+\tikzset{tn label/.append style={font=\tiny}}
+\setbox0=\hbox{%
+  \begin{tikzpicture}[baseline]
+    \node[tn label, fill=tenkzPaper, outer sep=0pt]
+      {$\tenkz@labelsize WWWW$};
+  \end{tikzpicture}}
+\typeout{TENKZ-FONT-BAND-SP=\number\wd0}
+\begin{tenkzcd}[maps, species={channel}]
+  A & B
+  \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{WWWW}
+\end{tenkzcd}
+\endgroup
+\makeatother
 \end{document}
 """
 GROUPED_SOURCE = r"""
@@ -111,10 +150,25 @@ GROUPED_SOURCE = r"""
 \end{tenkzcd}
 \end{document}
 """
+MISASSOCIATED_SOURCE = r"""
+\documentclass{article}
+\usepackage{tenkz}
+\begin{document}
+\begin{tenkzcd}[maps, species={channel}]
+  A & B
+  \iffalse
+    \tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{skipped}
+  \fi
+  {\tnarrow[from={(1,1)}, to={(1,2)}, species=channel]{hidden}}
+\end{tenkzcd}
+\end{document}
+"""
 SCALAR = re.compile(r"TENKZ-(FLOOR|DAYLIGHT|OVERRIDE)-SP=(-?[0-9]+)")
 MAP_VALUE = re.compile(
-    r"TENKZ-MAP-([1-4])-(LEFT|BAND|RIGHT|GAP)-SP=(-?[0-9]+)"
+    r"TENKZ-MAP-([1-6])-(LEFT|BAND|RIGHT|GAP)-SP=(-?[0-9]+)"
 )
+STATEFUL_CALLS = re.compile(r"TENKZ-STATEFUL-FINAL-CALLS=([0-9]+)")
+FONT_BAND = re.compile(r"TENKZ-FONT-BAND-SP=([0-9]+)")
 
 
 def close(actual: int, expected: int, tolerance: int = 2) -> bool:
@@ -164,8 +218,27 @@ def main() -> int:
             print(grouped_run.stdout)
             raise AssertionError("grouped declaration failed without the grammar error")
 
+        misassociated_tex = work / "misassociated-typed-map-label.tex"
+        misassociated_tex.write_text(MISASSOCIATED_SOURCE, encoding="utf-8")
+        misassociated_run = subprocess.run(
+            [engine, "-interaction=nonstopmode", "-halt-on-error", misassociated_tex.name],
+            cwd=work,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=120,
+        )
+        if misassociated_run.returncode == 0:
+            raise AssertionError("misassociated typed-map declaration compiled silently")
+        if "Typed-map declarations must be literal" not in misassociated_run.stdout:
+            print(misassociated_run.stdout)
+            raise AssertionError(
+                "misassociated declaration failed without the grammar error"
+            )
+
     scalars = {name: int(value) for name, value in SCALAR.findall(run.stdout)}
-    maps = {index: {} for index in range(1, 5)}
+    maps = {index: {} for index in range(1, 7)}
     for index, name, value in MAP_VALUE.findall(run.stdout):
         maps[int(index)][name] = int(value)
     if scalars.keys() != {"FLOOR", "DAYLIGHT", "OVERRIDE"}:
@@ -173,10 +246,18 @@ def main() -> int:
     if any(row.keys() != {"LEFT", "BAND", "RIGHT", "GAP"}
            for row in maps.values()):
         raise AssertionError(f"missing live typed-map anchor measurements: {maps}")
+    stateful_calls = STATEFUL_CALLS.findall(run.stdout)
+    if stateful_calls != ["1"]:
+        raise AssertionError(
+            f"stateful typed-map label executed {stateful_calls!r}, expected once"
+        )
+    font_bands = FONT_BAND.findall(run.stdout)
+    if len(font_bands) != 1:
+        raise AssertionError(f"missing styled label-band reference: {font_bands}")
 
     # Map 1 deliberately exercises an unsafe explicit override; every
     # automatically resolved map must retain daylight on both sides.
-    for index in (3, 2, 4):
+    for index in (3, 4, 5, 6):
         row = maps[index]
         for side in ("LEFT", "RIGHT"):
             if row[side] + 2 < scalars["DAYLIGHT"]:
@@ -208,9 +289,21 @@ def main() -> int:
             "matrix passthrough style leaked into the deferred map label: "
             f"actual={maps[4]['GAP']}sp expected={expected_styled}sp"
         )
+    expected_stateful = maps[5]["BAND"] + 2 * scalars["DAYLIGHT"]
+    if not close(maps[5]["GAP"], expected_stateful):
+        raise AssertionError(
+            "stateful map measured band differs from its production band: "
+            f"actual={maps[5]['GAP']}sp expected={expected_stateful}sp"
+        )
+    if not close(maps[6]["BAND"], int(font_bands[0])):
+        raise AssertionError(
+            "appended tn-label font did not govern the materialized band: "
+            f"actual={maps[6]['BAND']}sp expected={font_bands[0]}sp"
+        )
     print(
-        "PASS: typed-map labels enforce top-level grammar, retain explicit/"
-        "floor geometry, and clear both adjacent objects by daylight"
+        "PASS: typed-map labels materialize once with the effective font, bind "
+        "to literal declarations, retain explicit/floor geometry, and clear "
+        "adjacent objects by daylight"
     )
     return 0
 

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -103,7 +103,7 @@
 \fp_new:N  \l__tenkzcd_angle_fp
 \seq_new:N \l__tenkzcd_cells_seq
 \seq_new:N \g__tenkzcd_arrows_seq    % {from}{to}{side keys}{label}
-\seq_new:N \g__tenkzcd_maps_seq      % {from}{to}{side}{fused}{role}{species}{label}
+\seq_new:N \g__tenkzcd_maps_seq      % {from}{to}{side}{fused}{role}{species}{label box ordinal}
 \bool_new:N \g__tenkzcd_inpoly_bool  % a polygon body is being typeset
 \bool_new:N \g__tenkzcd_inmaps_bool  % a typed-map matrix is being typeset
 \tl_new:N  \l__tenkzcd_afrom_tl
@@ -116,6 +116,7 @@
 \bool_new:N \l__tenkzcd_maps_bool
 \bool_new:N \l__tenkzcd_mapvalid_bool
 \bool_new:N \l__tenkzcd_mapmatrixvalid_bool
+\bool_new:N \l__tenkzcd_mapdeclsvalid_bool
 \seq_new:N \l__tenkzcd_maprows_seq
 \seq_new:N \l__tenkzcd_mapcells_seq
 \int_new:N \l__tenkzcd_maprows_int
@@ -125,6 +126,7 @@
 \int_new:N \l__tenkzcd_torow_int
 \int_new:N \l__tenkzcd_tocol_int
 \int_new:N \l__tenkzcd_mapdecls_int
+\int_new:N \g__tenkzcd_mapordinal_int
 \seq_new:N \l__tenkzcd_addr_seq
 \dim_new:N \l__tenkzcd_mapgap_dim
 \quark_new:N \q__tenkzcd_map_scan_stop
@@ -703,7 +705,8 @@
                 { \bool_if:NTF \l__tenkzcd_afused_bool {1}{0} }
                 { \tl_use:N \l__tenkzcd_arole_tl }
                 { \tl_use:N \l__tenkzcd_aspecies_tl }
-                { \exp_not:n {#3} } }
+                { \int_use:N \g__tenkzcd_mapordinal_int } }
+            \int_gzero:N \g__tenkzcd_mapordinal_int
             \group_end:
           }
           {
@@ -760,34 +763,66 @@
 % Map declarations conventionally follow the matrix objects, but their
 % opaque label bands determine the matrix spacing.  Delimited scanning finds
 % literal top-level declarations without expanding objects or entering their
-% balanced groups; the post-matrix count check rejects any hidden declaration.
+% balanced groups; the copied-body tags let the post-matrix check reject any
+% skipped, hidden, or otherwise misassociated declaration.
 \cs_new_protected:Npn \tenkz_cd_measure_map_labels:n #1
-  { \tenkz_cd_measure_map_labels:w #1 \tnarrow \q__tenkzcd_map_scan_stop }
+  {
+    \tl_clear:N \l__tenkzcd_body_tl
+    \tenkz_cd_measure_map_labels:w #1 \tnarrow \q__tenkzcd_map_scan_stop
+  }
 
 \cs_new_protected:Npn \tenkz_cd_measure_map_labels:w #1 \tnarrow
   {
+    \tl_put_right:Nn \l__tenkzcd_body_tl {#1}
     \peek_meaning_remove:NTF \q__tenkzcd_map_scan_stop
       { }
       { \tenkz_cd_measure_map_label_aux }
   }
 
+% Tag each scanned declaration in the copied matrix body.  The tag and its
+% \tnarrow execute adjacently, so the recording pass can associate a map with
+% its measured label even when TeX conditionals skip declarations.  A hidden
+% declaration inside an opaque group has no tag and records ordinal zero.
+\cs_new_protected:Npn \tenkz_cd_mark_map:n #1
+  { \int_gset:Nn \g__tenkzcd_mapordinal_int {#1} }
+
 \NewDocumentCommand \tenkz_cd_measure_map_label_aux { s O{} m }
   {
     \int_incr:N \l__tenkzcd_mapdecls_int
-    \hbox_set:Nn \l_tmpa_box
+    % Box registers are allocated once per declaration ordinal, but their
+    % contents remain local to this tenkzcd group.  A document therefore uses
+    % only as many registers as its largest typed-map family, and no material
+    % can leak from one environment to the next.
+    \cs_if_exist:cF
+      { l__tenkzcd_map_label_\int_use:N \l__tenkzcd_mapdecls_int _box }
+      {
+        \exp_args:Nc \box_new:N
+          { l__tenkzcd_map_label_\int_use:N \l__tenkzcd_mapdecls_int _box }
+      }
+    \exp_args:Nc \hbox_set:Nn
+      { l__tenkzcd_map_label_\int_use:N \l__tenkzcd_mapdecls_int _box }
       {
         \begin{tikzpicture}[baseline]
           \node[tn~label, fill=tenkzPaper, outer~sep=0pt]
-            {$\tenkz@labelsize #3$};
+            { $\tenkz@labelsize #3$ };
         \end{tikzpicture}
       }
     \dim_set:Nn \l_tmpa_dim
-      { \box_wd:N \l_tmpa_box
+      { \exp_args:Nc \box_wd:N
+          { l__tenkzcd_map_label_\int_use:N \l__tenkzcd_mapdecls_int _box }
         + \tenkz@r@daylight\tenkz@pitch * 2 }
     \dim_compare:nNnT { \l_tmpa_dim } > { \l__tenkzcd_mapgap_dim }
       { \dim_set_eq:NN \l__tenkzcd_mapgap_dim \l_tmpa_dim }
+    \tl_put_right:Nn \l__tenkzcd_body_tl { \tenkz_cd_mark_map:n }
+    \tl_put_right:Ne \l__tenkzcd_body_tl
+      { { \int_use:N \l__tenkzcd_mapdecls_int } \exp_not:N \tnarrow }
+    \IfBooleanT {#1} { \tl_put_right:Nn \l__tenkzcd_body_tl { * } }
+    \tl_put_right:Ne \l__tenkzcd_body_tl
+      { [ \exp_not:n {#2} ] { \exp_not:n {#3} } }
     \tenkz_cd_measure_map_labels:w
   }
+
+\cs_new:Npn \tenkz_cd_map_ordinal:nnnnnnn #1#2#3#4#5#6#7 {#7}
 
 \cs_new_protected:Npn \tenkz_cd_map_address:nnNN #1#2#3#4
   {
@@ -841,8 +876,11 @@
     \draw[#1]
       (tenkzmap-\int_use:N\l__tenkzcd_fromrow_int-
         \int_use:N\l__tenkzcd_fromcol_int.base~east) --
-      node[tn~label, fill=tenkzPaper, outer~sep=0pt, #2]
-        {$\tenkz@labelsize #3$}
+      node[inner~sep=0pt, outer~sep=0pt, #2]
+        {
+          \exp_args:Nc \box_use:N
+            { l__tenkzcd_map_label_#3_box }
+        }
       (tenkzmap-\int_use:N\l__tenkzcd_torow_int-
         \int_use:N\l__tenkzcd_tocol_int.base~west);
   }
@@ -951,9 +989,9 @@
     \tenkz_cd_measure_map_labels:n {#2}
     \bool_if:NT \l__tenkzcd_mapmatrixvalid_bool
       {
-        \tl_set:Nn \l__tenkzcd_body_tl {#2}
         \tl_replace_all:Nnn \l__tenkzcd_body_tl { & } { \pgfmatrixnextcell }
         \tl_put_right:Nn \l__tenkzcd_body_tl { \\ }
+        \int_gzero:N \g__tenkzcd_mapordinal_int
         \bool_gset_true:N \g__tenkzcd_inmaps_bool
         \begin{tikzpicture}[tenkz~every~picture, tenkz~cd~baseline]
           % Passthrough keys belong to the matrix and its cells.  Their scope
@@ -966,9 +1004,18 @@
                nodes={inner~sep=1pt, outer~sep=0pt}, #1]
               { \tl_use:N \l__tenkzcd_body_tl };
           \end{scope}
-          \int_compare:nNnTF
+          \bool_set_true:N \l__tenkzcd_mapdeclsvalid_bool
+          \int_compare:nNnF
             { \seq_count:N \g__tenkzcd_maps_seq }
             = { \l__tenkzcd_mapdecls_int }
+            { \bool_set_false:N \l__tenkzcd_mapdeclsvalid_bool }
+          \seq_map_indexed_inline:Nn \g__tenkzcd_maps_seq
+            {
+              \int_compare:nNnF {##1}
+                = { \tenkz_cd_map_ordinal:nnnnnnn ##2 }
+                { \bool_set_false:N \l__tenkzcd_mapdeclsvalid_bool }
+            }
+          \bool_if:NTF \l__tenkzcd_mapdeclsvalid_bool
             {
               \seq_map_inline:Nn \g__tenkzcd_maps_seq
                 { \tenkz_cd_draw_map:nnnnnnn ##1 }
@@ -981,6 +1028,7 @@
             }
         \end{tikzpicture}
         \bool_gset_false:N \g__tenkzcd_inmaps_bool
+        \int_gzero:N \g__tenkzcd_mapordinal_int
       }
   }
 


### PR DESCRIPTION
## Summary

Materialize every literal top-level typed-map label exactly once, then reuse that same styled band for both layout measurement and production drawing.

The label scan lazily allocates reusable box registers by declaration ordinal. Each box contains the complete `tn label` mini-picture, so the effective default or appended label font/style is applied during the label's sole execution. Contents remain local to one `tenkzcd` environment, while register allocation grows only with the maximum simultaneous label count. Deferred map records store the ordinal, never the raw label tokens.

The copied matrix body also tags each scanned declaration with its ordinal. The executing `\tnarrow` consumes that exact tag, so indexed validation rejects skipped or hidden declarations even when their counts happen to match.

## Root cause

The pre-matrix measurement pass and deferred production path each typeset the raw label token list. Stateful TeX commands therefore executed twice and could produce a wider production label than the band used for matrix spacing.

## Regression coverage

The deterministic regression asserts:

- a stateful label executes exactly once;
- the production band plus two daylights equals the measured gap;
- an appended `tn label` font governs the cached production band;
- a skipped literal declaration cannot be substituted by an executed hidden declaration with the same total count;
- explicit `column sep=`, the historical mapgap floor, wide-label geometry, matrix-style isolation, and grouped-declaration rejection remain unchanged.

## Validation

Exact head `1e4bc41e93690af6abe026414edc0a2e87ad5512` rebased on `e3163845032aeb4395d5da59cc4ad8c16d80cb41`:

- `python3 scripts/test_tenkz_cd_map_labels.py`
- `python3 scripts/test_tenkz_pic.py`
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/test_tenkz_index_routing.py`
- `python3 scripts/test_tenkz_tree.py`
- `PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --check-peps-usage --check-slides --audit --audit-strict --smoke-render`
- exact 114-file tenkz lint scan: 0 findings, 0 unescaped
- relevant Python byte-compilation and `git diff --check`
- all 19 acceptance examples compile and audit with 0 hard errors; `typed-maps` has 8 pictures and 0 advisories
- manual compiled twice: 43 pages; 77 audited pictures, 0 hard errors
- complete print blueprint: 704 pages; only the existing three unresolved `thm:dim_preserved` references
- current typed-map acceptance output and Chapter 23 fiberwise typed maps inspected at original detail after 200-dpi rendering
- forbidden text searches: zero matches for `The source-faithful periodic network` (exact and case-insensitive variant) and `issue4152_proto`

After the final base-only rebase, `git range-diff` confirms the implementation commit is unchanged. The focused label regression, exact 114-file lint, `git diff --check`, and all forbidden-text searches were rerun on the exact head above.

Local validation artifacts:

- `/private/tmp/tnlean-4530-final-typed-maps-200dpi.png`
- `/private/tmp/tnlean-4530-final-ch23-fiberwise-page-632-200dpi.png`

Follow-up to the late review finding on LionSR/TNLean#4512: https://github.com/LionSR/TNLean/pull/4512#discussion_r3614601841

Closes LionSR/tenkz#52
