### PR TITLE
refactor(MPS/Structure): consolidate invariant decomposition

### DIFF
--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -105,7 +105,10 @@ private lemma mpv_twoBlockTensor_eq {n m N : ℕ}
         simp only [h0, h1]
 
 
-/-! ## Main theorem: invariant projection ⇒ two-block block diagonal tensor -/
+/-! ## Invariant projection ⇒ two-block block diagonal tensor
+
+### Shared construction
+-/
 
 /-- Spectral decomposition auxiliary lemma for a Hermitian matrix (matrix form). -/
 private lemma orthProj_spectral_eq'
@@ -470,6 +473,8 @@ private theorem exists_twoBlock_decomp_of_lowerZero_aux
     _ = mpv A₁ σ + mpv A₂ σ := hTrace_diagPart
     _ = mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ :=
       hmpv_twoBlockTensor.symm
+
+/-! ### General decomposition theorem -/
 
 /-- Canonical-form reduction step (Wolf/Cirac/Verstraete):
 

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -122,7 +122,7 @@ private lemma orthProj_spectral_eq'
 
 /-- Common spectral and block construction underlying the general and strict
 invariant-subspace decompositions. The final two implications record exactly the
-additional dimension information needed by the strict public theorem. -/
+additional dimension information needed by the strict variant. -/
 private theorem exists_twoBlock_decomp_of_lowerZero_aux
     (A : MPSTensor d D)
     (P : Matrix (Fin D) (Fin D) ℂ)
@@ -513,10 +513,6 @@ References:
   invariant-subspace step in the "canonical forms" reduction.
 -/
 
-section StrictDimDecrease
-
-variable {d D : ℕ}
-
 /-- **Strict dimension decrease** for the invariant-projection splitting step.
 
 If `A` admits an invariant orthogonal projection `P` with `P ≠ 0` and `P ≠ 1`, then
@@ -543,7 +539,5 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
   have hn_lt : n < D := by omega
   have hm_lt : m < D := by omega
   exact ⟨n, m, hnm, hn_lt, hm_lt, A₁, A₂, hSame⟩
-
-end StrictDimDecrease
 
 end MPSTensor

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -107,7 +107,7 @@ private lemma mpv_twoBlockTensor_eq {n m N : ℕ}
 
 /-! ## Invariant projection ⇒ two-block block diagonal tensor
 
-### Shared construction
+### Spectral splitting and block extraction
 -/
 
 /-- Spectral decomposition auxiliary lemma for a Hermitian matrix (matrix form). -/
@@ -499,7 +499,7 @@ theorem exists_twoBlock_decomp_of_lowerZero
   exact ⟨n, m, hnm, A₁, A₂, hSame⟩
 
 
-/-! ## Strict dimension decrease variant
+/-! ### Strict dimension decrease variant
 
 The following theorem strengthens `exists_twoBlock_decomp_of_lowerZero` by showing that
 both returned block dimensions are *strictly smaller* than `D`. This is the key

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -107,24 +107,28 @@ private lemma mpv_twoBlockTensor_eq {n m N : ℕ}
 
 /-! ## Main theorem: invariant projection ⇒ two-block block diagonal tensor -/
 
-/-- Canonical-form reduction step (Wolf/Cirac/Verstraete):
+/-- Spectral decomposition auxiliary lemma for a Hermitian matrix (matrix form). -/
+private lemma orthProj_spectral_eq'
+    (P : Matrix (Fin D) (Fin D) ℂ) (hHerm : P.IsHermitian) :
+    P = (↑hHerm.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
+      Matrix.diagonal (fun j => (↑(hHerm.eigenvalues j) : ℂ)) *
+      (↑hHerm.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
+  have h := hHerm.spectral_theorem
+  rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
+  simpa [Matrix.mul_assoc, Function.comp_def] using h
 
-If `A` admits an invariant orthogonal projection `P` (i.e. `(1-P) * A i * P = 0` for all `i`),
-then `A` is MPV-equivalent to an explicit `2`-block block-diagonal tensor.
-
-We return the two smaller tensors `A₁ : MPSTensor d n` and `A₂ : MPSTensor d m` together with the
-dimension split `n + m = D`.
-
-The MPV equivalence is stated using `SameMPV₂` to avoid type-cast overhead.
--/
-theorem exists_twoBlock_decomp_of_lowerZero
+/-- Common spectral and block construction underlying the general and strict
+invariant-subspace decompositions. The final two implications record exactly the
+additional dimension information needed by the strict public theorem. -/
+private theorem exists_twoBlock_decomp_of_lowerZero_aux
     (A : MPSTensor d D)
     (P : Matrix (Fin D) (Fin D) ℂ)
     (hP : IsOrthogonalProjection P)
     (hLower : ∀ i : Fin d, (1 - P) * A i * P = 0) :
     ∃ (n m : ℕ) (_ : n + m = D)
       (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
-      SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) := by
+      SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) ∧
+        (P ≠ 0 → 0 < n) ∧ (P ≠ 1 → 0 < m) := by
   classical
   -- Diagonalize the projection `P`.
   let hHerm : P.IsHermitian := hP.1
@@ -256,7 +260,41 @@ theorem exists_twoBlock_decomp_of_lowerZero
   let eT : T ≃ Fin m := Fintype.equivFin T
   let A₁ : MPSTensor d n := fun i => Matrix.reindex eS eS (A11raw i)
   let A₂ : MPSTensor d m := fun i => Matrix.reindex eT eT (A22raw i)
-  refine ⟨n, m, hnm, A₁, A₂, ?_⟩
+  have hn_pos : P ≠ 0 → 0 < n := by
+    intro hP0
+    apply Fintype.card_pos_iff.mpr
+    by_contra hempty
+    rw [not_nonempty_iff] at hempty
+    apply hP0
+    have hf_zero : ∀ j, f j = 0 := fun j =>
+      (hf01 j).resolve_right (fun h1 => (IsEmpty.false (α := S) ⟨j, h1⟩).elim)
+    rw [orthProj_spectral_eq' P hHerm]
+    have hdiag0 : Matrix.diagonal f = 0 := by
+      ext i k
+      simp [Matrix.diagonal_apply, hf_zero]
+    rw [hdiag0, Matrix.mul_zero, Matrix.zero_mul]
+  have hm_pos : P ≠ 1 → 0 < m := by
+    intro hP1
+    apply Fintype.card_pos_iff.mpr
+    by_contra hempty
+    rw [not_nonempty_iff] at hempty
+    apply hP1
+    have hf_one : ∀ j, f j = 1 := fun j =>
+      (hf01 j).resolve_left
+        (fun h0 =>
+          (IsEmpty.false (α := T)
+            ⟨j, fun (h1 : f j = 1) => absurd (h0.symm.trans h1) zero_ne_one⟩).elim)
+    rw [orthProj_spectral_eq' P hHerm]
+    have hdiag1 : Matrix.diagonal f = 1 := by
+      ext i k
+      simp only [Matrix.diagonal_apply, Matrix.one_apply]
+      split_ifs with heq
+      · subst heq
+        exact hf_one i
+      · rfl
+    rw [hdiag1, Matrix.mul_one, ← Matrix.star_eq_conjTranspose]
+    simp
+  refine ⟨n, m, hnm, A₁, A₂, ?_, hn_pos, hm_pos⟩
   -- Final MPV equality.
   intro N σ
   -- Chain: A ~ Aconj ~ diagPart Aconj Pdiag ~ blockDiag(A₁,A₂).
@@ -430,7 +468,30 @@ theorem exists_twoBlock_decomp_of_lowerZero
     mpv A σ = mpv Aconj σ := hA_Aconj
     _ = mpv (diagPart (d := d) (D := D) Aconj Pdiag) σ := hAconj_diag
     _ = mpv A₁ σ + mpv A₂ σ := hTrace_diagPart
-    _ = mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ := hmpv_twoBlockTensor.symm
+    _ = mpv (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) σ :=
+      hmpv_twoBlockTensor.symm
+
+/-- Canonical-form reduction step (Wolf/Cirac/Verstraete):
+
+If `A` admits an invariant orthogonal projection `P` (i.e. `(1-P) * A i * P = 0` for all `i`),
+then `A` is MPV-equivalent to an explicit `2`-block block-diagonal tensor.
+
+We return the two smaller tensors `A₁ : MPSTensor d n` and `A₂ : MPSTensor d m` together with the
+dimension split `n + m = D`.
+
+The MPV equivalence is stated using `SameMPV₂` to avoid type-cast overhead.
+-/
+theorem exists_twoBlock_decomp_of_lowerZero
+    (A : MPSTensor d D)
+    (P : Matrix (Fin D) (Fin D) ℂ)
+    (hP : IsOrthogonalProjection P)
+    (hLower : ∀ i : Fin d, (1 - P) * A i * P = 0) :
+    ∃ (n m : ℕ) (_ : n + m = D)
+      (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
+      SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) := by
+  rcases exists_twoBlock_decomp_of_lowerZero_aux A P hP hLower with
+    ⟨n, m, hnm, A₁, A₂, hSame, -, -⟩
+  exact ⟨n, m, hnm, A₁, A₂, hSame⟩
 
 
 /-! ## Strict dimension decrease variant
@@ -451,16 +512,6 @@ section StrictDimDecrease
 
 variable {d D : ℕ}
 
-/-- Spectral decomposition auxiliary lemma for a Hermitian matrix (matrix form). -/
-private lemma orthProj_spectral_eq'
-    (P : Matrix (Fin D) (Fin D) ℂ) (hHerm : P.IsHermitian) :
-    P = (↑hHerm.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
-      Matrix.diagonal (fun j => (↑(hHerm.eigenvalues j) : ℂ)) *
-      (↑hHerm.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-  have h := hHerm.spectral_theorem
-  rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
-  simpa [Matrix.mul_assoc, Function.comp_def] using h
-
 /-- **Strict dimension decrease** for the invariant-projection splitting step.
 
 If `A` admits an invariant orthogonal projection `P` with `P ≠ 0` and `P ≠ 1`, then
@@ -480,248 +531,13 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
     ∃ n m : ℕ, ∃ _ : n + m = D, n < D ∧ m < D ∧
       ∃ (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
         SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) := by
-  classical
-  -- ═══ Spectral setup (same as `exists_twoBlock_decomp_of_lowerZero`) ═══
-  let hHerm : P.IsHermitian := hP.1
-  let U : ↥(Matrix.unitaryGroup (Fin D) ℂ) := hHerm.eigenvectorUnitary
-  let Umat : Matrix (Fin D) (Fin D) ℂ := (U : Matrix (Fin D) (Fin D) ℂ)
-  let Pdiag : Matrix (Fin D) (Fin D) ℂ := star Umat * P * Umat
-  let f : Fin D → ℂ := fun j => (↑(hHerm.eigenvalues j) : ℂ)
-  have hPdiag_eq : Pdiag = Matrix.diagonal f := by
-    have h := hHerm.conjStarAlgAut_star_eigenvectorUnitary
-    simpa [Pdiag, f, Unitary.conjStarAlgAut_star_apply, Function.comp_def] using h
-  have hU_mul_star : Umat * star Umat = 1 :=
-    Unitary.mul_star_self_of_mem U.2
-  have hPdiag_idem : Pdiag * Pdiag = Pdiag := by
-    calc Pdiag * Pdiag
-        = star Umat * P * (Umat * star Umat) * P * Umat := by
-            simp [Pdiag, Matrix.mul_assoc]
-      _ = star Umat * P * P * Umat := by simp [hU_mul_star, Matrix.mul_assoc]
-      _ = star Umat * P * Umat := by simp [hP.2, Matrix.mul_assoc]
-      _ = Pdiag := by simp [Pdiag, Matrix.mul_assoc]
-  have hDiag_idem : Matrix.diagonal f * Matrix.diagonal f = Matrix.diagonal f := by
-    simpa [hPdiag_eq] using hPdiag_idem
-  have hf01 : ∀ j : Fin D, f j = 0 ∨ f j = 1 := by
-    intro j
-    have hfun : (fun k => f k * f k) = f := by
-      apply Matrix.diagonal_injective
-      simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
-    exact IsIdempotentElem.iff_eq_zero_or_one.mp (congrFun hfun j)
-  -- ═══ Index splitting ═══
-  let p : Fin D → Prop := fun j => f j = 1
-  haveI : DecidablePred p := fun _ => inferInstance
-  let S : Type := { j : Fin D // p j }
-  let T : Type := { j : Fin D // ¬ p j }
-  let n : ℕ := Fintype.card S
-  let m : ℕ := Fintype.card T
-  have hnm : n + m = D := by
-    have hST : Fintype.card (S ⊕ T) = D :=
-      (Fintype.card_congr (Equiv.sumCompl p)).trans (by simp [Fintype.card_fin])
-    have hsum : Fintype.card (S ⊕ T) = Fintype.card S + Fintype.card T :=
-      Fintype.card_sum (α := S) (β := T)
-    simpa [n, m] using hsum.symm.trans hST
-  -- ═══ Strict bounds ═══
-  -- `S` is nonempty from `P ≠ 0`.
-  have hS_nonempty : Nonempty S := by
-    by_contra hempty
-    rw [not_nonempty_iff] at hempty
-    apply hP0
-    have hf_zero : ∀ j, f j = 0 := fun j =>
-      (hf01 j).resolve_right (fun h1 => (IsEmpty.false (α := S) ⟨j, h1⟩).elim)
-    rw [orthProj_spectral_eq' P hHerm]
-    have hdiag0 : Matrix.diagonal f = 0 := by
-      ext i k
-      simp [Matrix.diagonal_apply, hf_zero]
-    rw [hdiag0, Matrix.mul_zero, Matrix.zero_mul]
-  have hn_pos : 0 < n := by
-    simpa [n] using Fintype.card_pos_iff.mpr hS_nonempty
-  -- `T` is nonempty from `P ≠ 1`.
-  have hT_nonempty : Nonempty T := by
-    by_contra hempty
-    rw [not_nonempty_iff] at hempty
-    apply hP1
-    have hf_one : ∀ j, f j = 1 := fun j =>
-      (hf01 j).resolve_left
-        (fun h0 =>
-          (IsEmpty.false (α := T)
-            ⟨j, fun (h1 : f j = 1) => absurd (h0.symm.trans h1) zero_ne_one⟩).elim)
-    rw [orthProj_spectral_eq' P hHerm]
-    have hdiag1 : Matrix.diagonal f = 1 := by
-      ext i k
-      simp only [Matrix.diagonal_apply, Matrix.one_apply]
-      split_ifs with heq
-      · subst heq
-        exact hf_one i
-      · rfl
-    rw [hdiag1, Matrix.mul_one, ← Matrix.star_eq_conjTranspose]
-    simp
-  have hm_pos : 0 < m := by
-    simpa [m] using Fintype.card_pos_iff.mpr hT_nonempty
+  rcases exists_twoBlock_decomp_of_lowerZero_aux A P hP hLower with
+    ⟨n, m, hnm, A₁, A₂, hSame, hn_pos, hm_pos⟩
+  have hn_pos' : 0 < n := hn_pos hP0
+  have hm_pos' : 0 < m := hm_pos hP1
   have hn_lt : n < D := by omega
   have hm_lt : m < D := by omega
-  -- ═══ Block decomposition ═══
-  have hfT : ∀ t : T, f t.1 = 0 := fun t => (hf01 t.1).resolve_right t.2
-  let eST : Fin D ≃ (S ⊕ T) := (Equiv.sumCompl p).symm
-  let Aconj : MPSTensor d D := fun i => star Umat * A i * Umat
-  have hSame_conj : SameMPV A Aconj := sameMPV_conj_unitary A U
-  have hPdiag_proj : IsOrthogonalProjection Pdiag := by
-    refine ⟨?_, hPdiag_idem⟩
-    have : ∀ j : Fin D, IsSelfAdjoint (f j) := fun j =>
-      (hf01 j).elim (fun h => by simp [IsSelfAdjoint, h]) (fun h => by simp [IsSelfAdjoint, h])
-    simpa [hPdiag_eq] using (Matrix.isHermitian_diagonal_iff (d := f)).2 this
-  have hLower_conj : ∀ i : Fin d, (1 - Pdiag) * Aconj i * Pdiag = 0 := by
-    intro i
-    have hStar_mul : star Umat * Umat = 1 := by
-      simp [Umat]
-    have hOneSub : (1 - Pdiag) = star Umat * (1 - P) * Umat := by
-      have : star Umat * (1 - P) * Umat = (1 - Pdiag) := by
-        simp [Pdiag, mul_sub, sub_mul, Matrix.mul_assoc, hStar_mul]
-      exact this.symm
-    calc (1 - Pdiag) * Aconj i * Pdiag
-        = (star Umat * (1 - P) * Umat) * (star Umat * A i * Umat) *
-            (star Umat * P * Umat) := by simp [hOneSub, Aconj, Pdiag]
-      _ = star Umat * ((1 - P) * A i * P) * Umat := by
-            calc (star Umat * (1 - P) * Umat) * (star Umat * A i * Umat) *
-                    (star Umat * P * Umat)
-                = star Umat * (1 - P) * (Umat * star Umat) * A i *
-                    (Umat * star Umat) * P * Umat := by noncomm_ring
-              _ = star Umat * (1 - P) * A i * P * Umat := by
-                    simp [hU_mul_star, Matrix.mul_assoc]
-              _ = star Umat * ((1 - P) * A i * P) * Umat := by noncomm_ring
-      _ = 0 := by simp [hLower i]
-  have hSame_diagPart : SameMPV Aconj (diagPart Aconj Pdiag) :=
-    sameMPV_diagPart_of_lowerZero Aconj Pdiag hPdiag_proj hLower_conj
-  -- Extract block tensors.
-  let X : Fin d → Matrix (S ⊕ T) (S ⊕ T) ℂ := fun i => Matrix.reindex eST eST (Aconj i)
-  let A11raw : Fin d → Matrix S S ℂ := fun i => (X i).toBlocks₁₁
-  let A22raw : Fin d → Matrix T T ℂ := fun i => (X i).toBlocks₂₂
-  let eS : S ≃ Fin n := Fintype.equivFin S
-  let eT : T ≃ Fin m := Fintype.equivFin T
-  let A₁ : MPSTensor d n := fun i => Matrix.reindex eS eS (A11raw i)
-  let A₂ : MPSTensor d m := fun i => Matrix.reindex eT eT (A22raw i)
-  refine ⟨n, m, hnm, hn_lt, hm_lt, A₁, A₂, ?_⟩
-  -- ═══ MPV equivalence ═══
-  intro N σ
-  set w : List (Fin d) := List.ofFn σ
-  have hA_Aconj : mpv A σ = mpv Aconj σ := hSame_conj N σ
-  have hAconj_diag : mpv Aconj σ = mpv (diagPart Aconj Pdiag) σ := hSame_diagPart N σ
-  have hTrace_reindex :
-      Matrix.trace (MPSTensor.evalWord (diagPart Aconj Pdiag) w) =
-        Matrix.trace (_root_.evalWord (fun i => Matrix.reindex eST eST
-          ((diagPart Aconj Pdiag) i)) w) := by
-    calc Matrix.trace (MPSTensor.evalWord (diagPart Aconj Pdiag) w)
-        = Matrix.trace (Matrix.reindex eST eST
-            (MPSTensor.evalWord (diagPart Aconj Pdiag) w)) := by
-              simpa using (Matrix.trace_reindex eST
-                (MPSTensor.evalWord (diagPart Aconj Pdiag) w)).symm
-      _ = _ := by
-              have := evalWord_reindex_fin (e := eST) (A := diagPart Aconj Pdiag) w
-              simpa using congrArg Matrix.trace this.symm
-  have hPdiag_std :
-      Matrix.reindex eST eST Pdiag =
-        Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ) := by
-    rw [hPdiag_eq]
-    have : Matrix.reindex eST eST (Matrix.diagonal f) =
-        Matrix.diagonal (f ∘ eST.symm) := by
-      simp [Matrix.reindex_apply]
-    rw [this]
-    ext x y
-    cases x with
-    | inl s =>
-        cases y with
-        | inl s' =>
-            by_cases h : s = s'
-            · subst h
-              rw [Matrix.diagonal_apply_eq, Matrix.fromBlocks_apply₁₁]
-              change f ((Equiv.sumCompl p) (Sum.inl s)) = (1 : Matrix S S ℂ) s s
-              rw [Equiv.sumCompl_apply_inl]
-              simpa using s.2
-            · simp [Matrix.fromBlocks_apply₁₁, h]
-        | inr t =>
-            simp [Matrix.fromBlocks_apply₁₂]
-    | inr t =>
-        cases y with
-        | inl s =>
-            simp [Matrix.fromBlocks_apply₂₁]
-        | inr t' =>
-            by_cases h : t = t'
-            · subst h
-              rw [Matrix.diagonal_apply_eq, Matrix.fromBlocks_apply₂₂]
-              change f ((Equiv.sumCompl p) (Sum.inr t)) = (0 : Matrix T T ℂ) t t
-              rw [Equiv.sumCompl_apply_inr]
-              simpa using hfT t
-            · simp [Matrix.fromBlocks_apply₂₂, h]
-  have hLetter_block : ∀ i : Fin d,
-      Matrix.reindex eST eST ((diagPart Aconj Pdiag) i) =
-        Matrix.fromBlocks (A11raw i) 0 0 (A22raw i) := by
-    intro i
-    let φ : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.reindexAlgEquiv ℂ ℂ eST
-    let P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
-    let Q0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.fromBlocks (0 : Matrix S S ℂ) 0 0 (1 : Matrix T T ℂ)
-    have hφP : φ Pdiag = P0 := by simpa [φ, P0] using hPdiag_std
-    have hφA : φ (Aconj i) = X i := by simp [φ, X]
-    have hXfull : X i = Matrix.fromBlocks (A11raw i) (X i).toBlocks₁₂
-        (X i).toBlocks₂₁ (A22raw i) := by
-      simpa [A11raw, A22raw] using (Matrix.fromBlocks_toBlocks (X i)).symm
-    have hQ : (1 - P0) = Q0 := by
-      ext x y; cases x <;> cases y <;>
-        simp [P0, Q0, Matrix.fromBlocks_apply₁₁, Matrix.fromBlocks_apply₁₂,
-          Matrix.fromBlocks_apply₂₁, Matrix.fromBlocks_apply₂₂, Matrix.one_apply]
-    have hφ_diag : φ ((diagPart Aconj Pdiag) i) =
-        Matrix.fromBlocks (A11raw i) 0 0 (A22raw i) := by
-      simp only [MPSTensor.diagPart, map_add, map_mul, map_sub, map_one, hφP, hφA]
-      rw [hQ, hXfull]
-      simp [P0, Q0, Matrix.fromBlocks_multiply, Matrix.fromBlocks_add]
-    simpa [φ] using hφ_diag
-  have hEval_block :
-      _root_.evalWord (fun i => Matrix.reindex eST eST
-        ((diagPart Aconj Pdiag) i)) w =
-        Matrix.fromBlocks (_root_.evalWord A11raw w) 0 0 (_root_.evalWord A22raw w) := by
-    have hfun :
-        (fun i => Matrix.reindex eST eST ((diagPart Aconj Pdiag) i)) =
-          fun i => Matrix.fromBlocks (A11raw i) 0 0 (A22raw i) :=
-      funext hLetter_block
-    rw [hfun]
-    simpa using evalWord_fromBlocks_diag A11raw A22raw w
-  have hTrace_diagPart :
-      mpv (diagPart Aconj Pdiag) σ = mpv A₁ σ + mpv A₂ σ := by
-    simp only [MPSTensor.mpv, MPSTensor.coeff]
-    have htr_blocks :
-        Matrix.trace (_root_.evalWord (fun i => Matrix.reindex eST eST
-            ((diagPart Aconj Pdiag) i)) w)
-          = Matrix.trace (_root_.evalWord A11raw w) +
-              Matrix.trace (_root_.evalWord A22raw w) := by
-      rw [hEval_block]
-      simpa using trace_fromBlocks_diag (_root_.evalWord A11raw w) (_root_.evalWord A22raw w)
-    have hmpv₁ : mpv A₁ σ = Matrix.trace (_root_.evalWord A11raw w) := by
-      have : MPSTensor.evalWord A₁ w = Matrix.reindex eS eS (_root_.evalWord A11raw w) := by
-        simpa [A₁] using MPSTensor.evalWord_reindex (e := eS) (A := A11raw) w
-      calc mpv A₁ σ = Matrix.trace (MPSTensor.evalWord A₁ w) := rfl
-        _ = Matrix.trace (Matrix.reindex eS eS (_root_.evalWord A11raw w)) := by rw [this]
-        _ = _ := by simpa using Matrix.trace_reindex eS (_root_.evalWord A11raw w)
-    have hmpv₂ : mpv A₂ σ = Matrix.trace (_root_.evalWord A22raw w) := by
-      have : MPSTensor.evalWord A₂ w = Matrix.reindex eT eT (_root_.evalWord A22raw w) := by
-        simpa [A₂] using MPSTensor.evalWord_reindex (e := eT) (A := A22raw) w
-      calc mpv A₂ σ = Matrix.trace (MPSTensor.evalWord A₂ w) := rfl
-        _ = Matrix.trace (Matrix.reindex eT eT (_root_.evalWord A22raw w)) := by rw [this]
-        _ = _ := by simpa using Matrix.trace_reindex eT (_root_.evalWord A22raw w)
-    calc Matrix.trace (MPSTensor.evalWord (diagPart Aconj Pdiag) w)
-        = Matrix.trace (_root_.evalWord (fun i => Matrix.reindex eST eST
-            ((diagPart Aconj Pdiag) i)) w) := hTrace_reindex
-      _ = Matrix.trace (_root_.evalWord A11raw w) +
-            Matrix.trace (_root_.evalWord A22raw w) := htr_blocks
-      _ = mpv A₁ σ + mpv A₂ σ := by rw [← hmpv₁, ← hmpv₂]
-  have hmpv_twoBlockTensor :
-      mpv (twoBlockTensor A₁ A₂) σ = mpv A₁ σ + mpv A₂ σ :=
-    mpv_twoBlockTensor_eq A₁ A₂ σ
-  -- Chain all steps.
-  calc mpv A σ = mpv Aconj σ := hA_Aconj
-    _ = mpv (diagPart Aconj Pdiag) σ := hAconj_diag
-    _ = mpv A₁ σ + mpv A₂ σ := hTrace_diagPart
-    _ = mpv (twoBlockTensor A₁ A₂) σ := hmpv_twoBlockTensor.symm
+  exact ⟨n, m, hnm, hn_lt, hm_lt, A₁, A₂, hSame⟩
 
 end StrictDimDecrease
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -44,6 +44,19 @@ abstracted — record why, so it is not re-proposed).
 - **Abstraction:** `@[mps_transfer]` simp set + `transfer_simp` macro
   (`TNLean/MPS/Tactic/Basic.lean`).
 
+### invariant-subspace two-block fork — promoted
+- **Pattern:** the general and strict invariant-subspace decompositions repeated the
+  spectral split, block construction, and MPV calculation.
+- **Seen:** 2 full proof paths in
+  `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`.
+- **Abstraction:** the private semantic construction
+  `exists_twoBlock_decomp_of_lowerZero_aux`; the strict public theorem adds only
+  positivity and arithmetic for the strict dimension bounds.
+- **Notes:** Counting proof lines inclusively from `:= by` through the final proof line,
+  the two public implementations had 307 + 243 = 550 lines. The shared construction
+  and two projections have 342 + 4 + 8 = 354 lines, a net reduction of 196 lines
+  (35.6%). Both public theorem statements are unchanged.
+
 ---
 
 ## Candidates
@@ -199,15 +212,4 @@ current counts and full location lists).
 
 ## Retired
 
-### invariant-subspace two-block fork — retired
-- **Pattern:** the general and strict invariant-subspace decompositions repeated the
-  spectral split, block construction, and MPV calculation.
-- **Seen:** 2 full proof paths in
-  `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`.
-- **Abstraction:** the private semantic construction
-  `exists_twoBlock_decomp_of_lowerZero_aux`; the strict public theorem adds only
-  positivity and arithmetic for the strict dimension bounds.
-- **Notes:** Counting proof lines inclusively from `:= by` through the final proof line,
-  the two public implementations had 307 + 243 = 550 lines. The shared construction
-  and two projections have 342 + 4 + 8 = 354 lines, a net reduction of 196 lines
-  (35.6%). Both public theorem statements are unchanged.
+(none yet)

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -47,6 +47,10 @@ abstracted — record why, so it is not re-proposed).
 ### invariant-subspace two-block fork — promoted
 - **Pattern:** the general and strict invariant-subspace decompositions repeated the
   spectral split, block construction, and MPV calculation.
+```
+spectral split → block extraction → MPV calculation
+spectral split → block extraction → MPV calculation → strict bounds
+```
 - **Seen:** 2 full proof paths in
   `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`.
 - **Abstraction:** the private semantic construction

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -199,4 +199,15 @@ current counts and full location lists).
 
 ## Retired
 
-(none yet)
+### invariant-subspace two-block fork — retired
+- **Pattern:** the general and strict invariant-subspace decompositions repeated the
+  spectral split, block construction, and MPV calculation.
+- **Seen:** 2 full proof paths in
+  `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`.
+- **Abstraction:** the private semantic construction
+  `exists_twoBlock_decomp_of_lowerZero_aux`; the strict public theorem adds only
+  positivity and arithmetic for the strict dimension bounds.
+- **Notes:** Counting proof lines inclusively from `:= by` through the final proof line,
+  the two public implementations had 307 + 243 = 550 lines. The shared construction
+  and two projections have 342 + 4 + 8 = 354 lines, a net reduction of 196 lines
+  (35.6%). Both public theorem statements are unchanged.


### PR DESCRIPTION
### Motivation
- The general and strict invariant-subspace decomposition theorems repeated the same spectral split, block construction, and MPV calculation.
- Issue #4507 requires preserving both public, blueprint-linked statements while removing the parallel proof paths.

### Description
- Introduce one private construction returning the two block tensors, their dimension sum, the MPV equivalence, and the two conditional positivity facts used for strictness.
- Derive the general theorem by projecting the decomposition and derive the strict theorem by adding only positivity and natural-number arithmetic.
- Record the proof-size change in `docs/tactic_patterns.md`: 550 proof lines became 354, a reduction of 196 lines (35.6%).
- Preserve both public theorem names and statements.

### Testing
- `lake env lean /private/tmp/tnlean-4507-structural/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean` (using an existing TNLean dependency cache)
- `python3 scripts/tactic_pattern_scan.py`
- `rg -n -P "\\b(sorry|admit|native_decide|unsafeCast|axiom|maxHeartbeats)\\b" TNLean/MPS/Structure/InvariantSubspaceDecomp.lean docs/tactic_patterns.md || true`
- `git diff --check`
- A clean `lake build` began rebuilding Mathlib from source and was stopped without a failure; the complete repository build is deferred to CI.

Closes #4507

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with identical public theorem statements; behavior for callers such as canonical-form reduction should be unchanged.
> 
> **Overview**
> **Refactors** `InvariantSubspaceDecomp.lean` so the general and strict invariant-subspace two-block theorems no longer each carry a full spectral split, block build, and MPV chain.
> 
> A new private lemma `exists_twoBlock_decomp_of_lowerZero_aux` holds that shared construction and also proves `(P ≠ 0 → 0 < n)` and `(P ≠ 1 → 0 < m)` (using `orthProj_spectral_eq'`, moved up with the aux). `exists_twoBlock_decomp_of_lowerZero` and `exists_twoBlock_decomp_of_lowerZero_strict` are short projections from the aux; the strict theorem only adds positivity and `omega` for `n < D` and `m < D`. The duplicate `StrictDimDecrease` section and its long proof are removed.
> 
> `docs/tactic_patterns.md` records the pattern as promoted and notes ~196 fewer proof lines (~35.6%) with unchanged public names and statements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fadb9f519eaa659d1d36d39d103f17c21391601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->