### PR TITLE
fix(tenkz): make RMP PEPS marginal type-correct

### DIFF
--- a/tex/tenkz/examples/marginals-rmp-fig2.tex
+++ b/tex/tenkz/examples/marginals-rmp-fig2.tex
@@ -29,13 +29,17 @@
 \begin{tenkzlattice}[rows=4, cols=4, frame=oblique, physical=up]
 \end{tenkzlattice}
 \par\medskip
-% rho_kept = Tr_{col 4} |psi><psi|: the double layer with the rightmost
-% column's inter-sheet pairings closed by wrap loops
-\begin{tenkzplanes}[rows=4, cols=4, sheets={ket, bra}, trace={(1-4,4)}]
-\end{tenkzplanes}
-\par\medskip
-% (b') the same marginal with the KEPT columns' physical indices open
-% (the paper draws rho's row/column indices as stubs); trace beats open
+% rho_{1:3} = Tr_{col 4} |psi><psi| acts on the 12 kept sites.  Columns 1--3
+% retain one ket and one bra physical
+% index at each site, while the four physical pairs in column 4 are traced.
+% Ink-to-index correspondence: black vertices on the upper and lower sheets
+% are the ket tensors A and conjugate bra tensors; horizontal and diagonal lines
+% contract virtual indices within each sheet.  The twelve rising stubs in
+% columns 1--3 are the free bra physical indices and the twelve falling stubs
+% are the free ket physical indices.  Each wrap loop in column 4 joins the
+% ket and bra physical indices at one site, and no other ket--bra segment is
+% present.  The lattice frame seals the exterior virtual boundary: suppressed
+% outer virtual stubs are fixed boundary contractions, not physical traces.
 \begin{tenkzplanes}[rows=4, cols=4, sheets={ket, bra},
                     open={(1-4,1-3)}, trace={(1-4,4)}]
 \end{tenkzplanes}


### PR DESCRIPTION
Closes LionSR/tenkz#43.

## Summary

- remove the duplicate scalar lower PEPS panel
- retain the single source-faithful marginal with twelve open physical ket-bra pairs and four column-4 traces
- state the operator formula, ink-to-index correspondence, and sealed exterior virtual-boundary convention in the source comments

No tenkz package code changes.

## Validation

- exact base `d935da91647666c3e0584643cc04fd1bf513ee10`; exact head `5451bc52f0652546dd3870674fe41acee65877eb`
- standalone XeLaTeX compile and strict audit: zero hard errors
- event signature: `pair-closed-0=0`, `pair-open-0=12`, `pair-traced-0=4`
- exactly four trace events, at column 4 only
- exactly one PEPS state panel and one PEPS marginal panel
- source lint: 114 files, zero findings
- all five tenkz Python tests pass
- ChkTeX and `git diff --check` pass
- `marginals-rmp-fig2.png` inspected at 200 dpi against bundled RMP Fig. 2(b): no clipping/overlap; columns 1-3 retain the ket/bra stubs and column 4 alone carries wrap loops

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example LaTeX and comments only; no `tenkz` package or renderer changes.
> 
> **Overview**
> Fixes the PEPS marginal panel in the RMP Fig. 2(b) example so it matches the intended **ρ₁:₃ = Tr_col₄ |ψ⟩⟨ψ|** operator instead of showing a duplicate, effectively scalar double layer.
> 
> The extra `tenkzplanes` block (rightmost column traced with **no** `open=` on columns 1–3) is removed. The figure now has one state lattice and one marginal with `open={(1-4,1-3)}` and `trace={(1-4,4)}` — twelve free ket/bra physical pairs and four column-4 traces.
> 
> Inline comments document the formula, how ink maps to ket/bra tensors and physical stubs, wrap loops, and that the oblique frame seals exterior virtual boundaries rather than tracing physics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 537234180fc116cc052556b20ca9fed111fe0819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->