### PR TITLE
fix(tenkz): close PEPO stack outer boundary

### DIFF
--- a/tex/tenkz/examples/pepo-stack.tex
+++ b/tex/tenkz/examples/pepo-stack.tex
@@ -3,6 +3,8 @@
 % e.g. two Trotter layers of imaginary-time evolution:
 %
 %   <psi| O_2 O_1 |psi>,   O_k = e^{-delta H}  (one Trotter step)
+%   sum_{s_0,s_1,s_2} \overline{\psi}_{s_2} (O_2)_{s_2,s_1}
+%       (O_1)_{s_1,s_0} \psi_{s_0}                    (at each site)
 %
 % Sheets top-to-bottom: ket, op, op, bra — O_1 is the op sheet under
 % the ket (applied first), O_2 the sheet above the bra.  The three
@@ -10,12 +12,16 @@
 %   interface 2 (ket-O_1):  ket physical index into O_1's input;
 %   interface 1 (O_1-O_2):  the operator product O_2 O_1;
 %   interface 0 (O_2-bra):  O_2's output into the bra.
-% Both op sheets box their sites over the pairing ink; the outer faces
-% keep the role-list default (open window of the boundary doctrine).
+% Thus every site contracts s_0 at ket-O_1, s_1 at O_1-O_2, and s_2 at
+% O_2-bra.  Both op sheets box their sites over this pairing ink.  The
+% lattice frame seals the exterior virtual boundary: suppressed outer
+% virtual stubs are fixed boundary contractions, not physical indices.
+% outer legs=none removes the ket and bra outer physical stubs, so the
+% diagram has no free physical boundary and denotes the displayed scalar.
 \documentclass[border=6pt]{standalone}
 \usepackage{tenkz}
 \begin{document}
 \begin{tenkzlattice}[rows=3, cols=3, sheets={ket, op, op, bra},
-                     frame=oblique]
+                     outer legs=none, frame=oblique]
 \end{tenkzlattice}
 \end{document}


### PR DESCRIPTION
Closes LionSR/tenkz#44.

## Summary

- set `outer legs=none` so the PEPO stack has no free ket/bra physical boundary and matches its scalar formula
- state the complete sitewise contraction and identify all three sheet interfaces with the indices they contract
- document that the exterior virtual boundary is sealed rather than traced

No tenkz package code changes.

## Validation

- exact base `d935da91647666c3e0584643cc04fd1bf513ee10`; exact head `10d884ee47d0ac33de71463cc9f9c8830d118cce`
- standalone XeLaTeX compile and strict audit: zero hard errors
- event signature: `physical-up=0`, `physical-down=0`; `pair-closed-0/1/2=9`; all pair-open and pair-traced counts are zero
- source lint: 114 files, zero findings
- all five tenkz Python tests pass
- ChkTeX and `git diff --check` pass
- `pepo-stack.png` inspected at 200 dpi against bundled RMP Fig. 3(b): no outer ket/bra physical stubs; all three internal interfaces remain visible

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single LaTeX example; no library or runtime behavior is modified.
> 
> **Overview**
> Updates the **PEPO evolution stack** standalone example so the diagram matches the scalar \(\langle\psi|O_2 O_1|\psi\rangle\) contraction instead of an open ket/bra window.
> 
> The `tenkzlattice` call now sets **`outer legs=none`**, removing free ket/bra physical stubs so the figure denotes a fully contracted scalar. Comments add the per-site index sum, map each of the three pairing interfaces to \(s_0\)–\(s_2\), and clarify that the lattice frame seals exterior virtual boundaries rather than leaving traced physical legs.
> 
> No changes to the tenkz package itself—documentation and example options only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d884ee47d0ac33de71463cc9f9c8830d118cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->