### PR TITLE
ci: enforce Lean module split policy

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -103,6 +103,7 @@ jobs:
       pull-requests: read
     outputs:
       lean: ${{ steps.filter.outputs.lean }}
+      module-policy: ${{ steps.filter.outputs.module-policy }}
       blueprint: ${{ steps.filter.outputs.blueprint }}
       workflow: ${{ steps.filter.outputs.workflow }}
     steps:
@@ -117,6 +118,7 @@ jobs:
               - 'lake-manifest.json'
               - 'scripts/LintStyle.lean'
               - 'scripts/nolints-style.txt'
+            module-policy:
               - 'scripts/check_numbered_lean_files.py'
               - 'scripts/check_oversized_lean_files.py'
               - 'scripts/test_lean_file_policies.py'
@@ -185,6 +187,7 @@ jobs:
       !cancelled() && (
         github.event_name != 'pull_request' ||
         needs.changes.outputs.lean == 'true' ||
+        needs.changes.outputs.module-policy == 'true' ||
         needs.changes.outputs.workflow == 'true'
       )
     runs-on: ubuntu-latest
@@ -208,7 +211,7 @@ jobs:
         run: >
           python3 scripts/check_oversized_lean_files.py
           --root .
-          --generated-aggregator TNLean.lean
+          --import-only-aggregator TNLean.lean
 
       - name: Reject new numbered-sequel modules
         run: python3 scripts/check_numbered_lean_files.py --root .

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,7 +1,7 @@
 name: PR CI
 
 # The pull-request pipeline: Lean build + style lint, blueprint lint and
-# Lean-blueprint sync, and the oversized-file guard, formerly
+# Lean-blueprint sync, and the Lean module-policy guards, formerly
 # lean_action_ci.yml, lint-blueprint.yml, and oversized-lean-files.yml.
 # One workflow means one completion event for the auto-fix dispatcher and
 # per-job change gating: Lean-only changes skip the TeX pipeline, and
@@ -18,6 +18,11 @@ on:
       - 'lake-manifest.json'
       - 'scripts/LintStyle.lean'
       - 'scripts/nolints-style.txt'
+      - 'scripts/check_numbered_lean_files.py'
+      - 'scripts/check_oversized_lean_files.py'
+      - 'scripts/test_lean_file_policies.py'
+      - 'docs/ci-automation.md'
+      - 'docs/CONTRIBUTING.md'
       - '.github/workflows/pr-ci.yml'
       - 'blueprint/src/**'
       - 'tex/tn/**'
@@ -46,6 +51,11 @@ on:
       - 'lake-manifest.json'
       - 'scripts/LintStyle.lean'
       - 'scripts/nolints-style.txt'
+      - 'scripts/check_numbered_lean_files.py'
+      - 'scripts/check_oversized_lean_files.py'
+      - 'scripts/test_lean_file_policies.py'
+      - 'docs/ci-automation.md'
+      - 'docs/CONTRIBUTING.md'
       - '.github/workflows/pr-ci.yml'
       - 'blueprint/src/**'
       - 'tex/tn/**'
@@ -107,6 +117,11 @@ jobs:
               - 'lake-manifest.json'
               - 'scripts/LintStyle.lean'
               - 'scripts/nolints-style.txt'
+              - 'scripts/check_numbered_lean_files.py'
+              - 'scripts/check_oversized_lean_files.py'
+              - 'scripts/test_lean_file_policies.py'
+              - 'docs/ci-automation.md'
+              - 'docs/CONTRIBUTING.md'
             blueprint:
               - 'blueprint/src/**'
               - 'tex/tn/**'
@@ -164,11 +179,14 @@ jobs:
           key: tnlean-build-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ github.sha }}
 
   file-length:
-    name: Check Lean file lengths
+    name: Check Lean module policies
     needs: changes
     if: |
-      !cancelled() && github.event_name == 'pull_request' &&
-      (needs.changes.outputs.lean == 'true' || needs.changes.outputs.workflow == 'true')
+      !cancelled() && (
+        github.event_name != 'pull_request' ||
+        needs.changes.outputs.lean == 'true' ||
+        needs.changes.outputs.workflow == 'true'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -181,11 +199,19 @@ jobs:
         with:
           python-version: '3.12'
 
-      # New oversized files (any Lean file over 1000 lines) fail the check.
+      - name: Test Lean module-policy checkers
+        run: PYTHONPATH=scripts python3 scripts/test_lean_file_policies.py -v
+
+      # Ordinary Lean modules over 1000 lines fail. The exact root aggregator
+      # exemption is accepted only while its uncommented content is import-only.
       - name: Run oversized-file guard
         run: >
           python3 scripts/check_oversized_lean_files.py
           --root .
+          --generated-aggregator TNLean.lean
+
+      - name: Reject new numbered-sequel modules
+        run: python3 scripts/check_numbered_lean_files.py --root .
 
   blueprint:
     name: Check blueprint compiles without errors

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -196,6 +196,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -213,7 +215,21 @@ jobs:
           --root .
           --import-only-aggregator TNLean.lean
 
-      - name: Reject new numbered-sequel modules
+      - name: Fetch pull-request base for the debt ratchet
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
+
+      - name: Reject new numbered-sequel modules (pull request)
+        if: github.event_name == 'pull_request'
+        run: >
+          python3 scripts/check_numbered_lean_files.py
+          --root .
+          --base-ref "origin/${{ github.event.pull_request.base.ref }}"
+
+      - name: Reject new numbered-sequel modules (main)
+        if: github.event_name != 'pull_request'
         run: python3 scripts/check_numbered_lean_files.py --root .
 
   blueprint:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -228,9 +228,12 @@ jobs:
           --root .
           --base-ref "origin/${{ github.event.pull_request.base.ref }}"
 
-      - name: Reject new numbered-sequel modules (main)
+      - name: Reject new numbered-sequel modules (push or dispatch)
         if: github.event_name != 'pull_request'
-        run: python3 scripts/check_numbered_lean_files.py --root .
+        run: >
+          python3 scripts/check_numbered_lean_files.py
+          --root .
+          --base-ref HEAD^
 
   blueprint:
     name: Check blueprint compiles without errors

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -228,8 +228,15 @@ jobs:
           --root .
           --base-ref "origin/${{ github.event.pull_request.base.ref }}"
 
-      - name: Reject new numbered-sequel modules (push or dispatch)
-        if: github.event_name != 'pull_request'
+      - name: Reject new numbered-sequel modules (push)
+        if: github.event_name == 'push'
+        run: >
+          python3 scripts/check_numbered_lean_files.py
+          --root .
+          --base-ref "${{ github.event.before }}"
+
+      - name: Reject new numbered-sequel modules (manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
         run: >
           python3 scripts/check_numbered_lean_files.py
           --root .

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -103,7 +103,7 @@ jobs:
       pull-requests: read
     outputs:
       lean: ${{ steps.filter.outputs.lean }}
-      module-policy: ${{ steps.filter.outputs.module-policy }}
+      module_policy: ${{ steps.filter.outputs.module_policy }}
       blueprint: ${{ steps.filter.outputs.blueprint }}
       workflow: ${{ steps.filter.outputs.workflow }}
     steps:
@@ -118,7 +118,7 @@ jobs:
               - 'lake-manifest.json'
               - 'scripts/LintStyle.lean'
               - 'scripts/nolints-style.txt'
-            module-policy:
+            module_policy:
               - 'scripts/check_numbered_lean_files.py'
               - 'scripts/check_oversized_lean_files.py'
               - 'scripts/test_lean_file_policies.py'
@@ -187,7 +187,7 @@ jobs:
       !cancelled() && (
         github.event_name != 'pull_request' ||
         needs.changes.outputs.lean == 'true' ||
-        needs.changes.outputs.module-policy == 'true' ||
+        needs.changes.outputs.module_policy == 'true' ||
         needs.changes.outputs.workflow == 'true'
       )
     runs-on: ubuntu-latest

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -9,6 +9,9 @@ Authors: TNLean contributors
 
 Stable import surface for the maintained TNLean library.
 
+This import-only root aggregator is the exact path exempted from the ordinary
+1000-line module cap; CI validates that it contains no Lean declarations.
+
 This file imports the modules intended for downstream users. Most specialized helper modules
 are omitted from the root import list, but public chapter-index and chapter-facing semigroup
 modules are included so that blueprint links and the generated documentation can see them.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -420,9 +420,10 @@ role and is rejected for new tracked production files. Instead:
 4. if callers need one import, provide a concept-named import-only aggregator.
 
 The numbered-file allowlist in `scripts/check_numbered_lean_files.py` records
-legacy debt and may only shrink. Numerals intrinsic to a mathematical object
+legacy debt and may only shrink; pull-request CI compares it with the merge-base
+allowlist and rejects additions. Numerals intrinsic to a mathematical object
 (such as `ZMod2`) or to an explicitly cited source result require an exact,
-documented semantic exception. Generated import aggregators can exceed the
+documented semantic exception. Import-only aggregators can exceed the
 line cap only when their exact path is passed to the size checker; the checker
 validates that uncommented content contains imports and nothing else.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -402,10 +402,29 @@ The following workflows run automatically:
 | **PR Review** (`pr-review.yml`) | After a successful PR CI run | Automated review for sorrys, Mathlib style, type safety, performance, modularity, documentation, plus blueprint/prose review |
 | **Issue Automation** (`issue-automation.yml`) | Issue opened/labeled/closed/reopened; PR opened/merged | Classifies new issues, posts Mathlib scouting reports, keeps tracking issues current (progress comments, sub-issue counts, `all-resolved` label — deterministic, no model), and scans merged PRs for follow-ups (deferred review feedback, new `sorry` markers, missing blueprint tags), filing them with the `follow-up` label |
 | **Blueprint Lint** (`pr-ci.yml`, `blueprint` job) | PRs touching blueprint or Lean files | Validates LaTeX blueprint for broken labels and references |
-| **Oversized Lean File Guard** (`pr-ci.yml`, `file-length` job) | PRs touching Lean files | Reports `.lean` files above the 1000-line style limit; advisory while main still has existing oversized files |
+| **Lean Module Policy** (`pr-ci.yml`, `file-length` job) | PRs and main pushes touching Lean policy paths | Blocks ordinary files above 1000 lines and new numbered-sequel production modules; validates exact import-only aggregator exemptions |
 | **Lean Linter-Warning Sweep** (`housekeeping.yml`, `linter-sweep` job) | Weekly + manual dispatch | Captures Lean compiler/linter warnings and uploads a report for maintainer triage |
 | **Lean Linter-Warning Auto-Fix** (`lean-linter-warning-autofix.yml`) | Manual dispatch | Runs the warning sweep and can open a guarded Lean-only PR when explicitly requested |
 | **Docs & Blueprint Sync** (`docs-blueprint-sync.lock.yml`) | Daily (weekdays) + manual dispatch | Detects stale documentation and opens a sync PR if needed |
+
+### Splitting large Lean modules
+
+Do not split a proof according to where editing happened to stop. A filename
+such as `Recovery2.lean` or `Recovery3b.lean` hides the module's mathematical
+role and is rejected for new tracked production files. Instead:
+
+1. identify the mathematical responsibilities in the large module;
+2. move repeated definitions, notation, and setup into a family `Basic.lean`;
+3. give each proof module a concept name, for example
+   `BoundaryRecovery.lean` or `OverlapInjectivity.lean`; and
+4. if callers need one import, provide a concept-named import-only aggregator.
+
+The numbered-file allowlist in `scripts/check_numbered_lean_files.py` records
+legacy debt and may only shrink. Numerals intrinsic to a mathematical object
+(such as `ZMod2`) or to an explicitly cited source result require an exact,
+documented semantic exception. Generated import aggregators can exceed the
+line cap only when their exact path is passed to the size checker; the checker
+validates that uncommented content contains imports and nothing else.
 
 ### What CI checks before merge
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -255,7 +255,7 @@ diagrams render to SVG.
 **What it does**: Enforces two blocking structural checks:
 
 - Ordinary `.lean` files may not exceed 1000 lines. The exact path passed with
-  `--generated-aggregator` is exempt only after the checker removes nested Lean
+  `--import-only-aggregator` is exempt only after the checker removes nested Lean
   comments and verifies that every remaining command is an `import`. Missing,
   excluded, empty, malformed, or declaration-bearing exemptions fail even when
   the file is below the limit. CI currently registers only `TNLean.lean`.

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -262,8 +262,10 @@ diagrams render to SVG.
 - New Git-tracked production modules below `TNLean/` may not end in a numeral
   (optionally followed by one letter). `TNLean/Archive/` and untracked scratch
   files are outside this production policy. Existing continuation files form a
-  shrinking allowlist: a new name fails, and a removed or renamed file leaves a
-  stale entry that must be deleted in the same change. Exact names whose numeral
+  shrinking allowlist: pull-request CI compares the proposed set with its
+  merge-base value and rejects additions; a new name fails, and a removed or
+  renamed file leaves a stale entry that must be deleted in the same change.
+  Exact names whose numeral
   denotes a mathematical object or source label have path-specific documented
   exceptions in `scripts/check_numbered_lean_files.py`.
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -279,7 +279,9 @@ citation; it is not an escape hatch for continuation files.
 
 **When it runs**: On pull requests and pushes to `main` whenever Lean sources,
 either checker, their tests, this documentation, or the workflow changes. CI
-runs the policy unit tests before both repository checks.
+runs the policy unit tests before both repository checks. The numbered-module
+ratchet compares a pull request with its merge base and a push with the commit
+recorded by the push event before any commit in that push was applied.
 
 ---
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -13,7 +13,7 @@ This repository uses [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
   - [Issue Automation](#issue-automation-issue-automationyml)
   - [CI Failure Auto-Fix](#ci-failure-auto-fix-auto-fixyml)
   - [Blueprint Auto-Fix](#blueprint-auto-fix-auto-fixyml)
-  - [Oversized Lean File Guard](#oversized-lean-file-guard-pr-ciyml-file-length-job)
+  - [Lean Module Policy](#lean-module-policy-pr-ciyml-file-length-job)
   - [Lean Linter-Warning Sweep](#lean-linter-warning-sweep-housekeepingyml-linter-sweep-job)
   - [Lean Linter-Warning Auto-Fix](#lean-linter-warning-auto-fix-lean-linter-warning-autofixyml)
   - [Review Comment Auto-Fix](#review-comment-auto-fix-auto-fixyml)
@@ -250,13 +250,34 @@ diagrams render to SVG.
 
 ---
 
-### Oversized Lean File Guard (`pr-ci.yml`, `file-length` job)
+### Lean Module Policy (`pr-ci.yml`, `file-length` job)
 
-**What it does**: Reports `.lean` files above the 1000-line style limit.
+**What it does**: Enforces two blocking structural checks:
 
-**When it runs**: On pull requests. The check is advisory while `main` still
-contains existing files above the limit; once those files are split, remove the
-`continue-on-error` line in the workflow to make it a blocking gate.
+- Ordinary `.lean` files may not exceed 1000 lines. The exact path passed with
+  `--generated-aggregator` is exempt only after the checker removes nested Lean
+  comments and verifies that every remaining command is an `import`. Missing,
+  excluded, empty, malformed, or declaration-bearing exemptions fail even when
+  the file is below the limit. CI currently registers only `TNLean.lean`.
+- New Git-tracked production modules below `TNLean/` may not end in a numeral
+  (optionally followed by one letter). `TNLean/Archive/` and untracked scratch
+  files are outside this production policy. Existing continuation files form a
+  shrinking allowlist: a new name fails, and a removed or renamed file leaves a
+  stale entry that must be deleted in the same change. Exact names whose numeral
+  denotes a mathematical object or source label have path-specific documented
+  exceptions in `scripts/check_numbered_lean_files.py`.
+
+When a proof approaches the cap, split by mathematical responsibility rather
+than chronology. Put shared definitions and setup in a family `Basic.lean`
+module, choose concept names such as `BoundaryRecovery.lean` for the proof
+modules, and use a concept-named import-only aggregator. Do not create
+`Foo2.lean`, `Foo3.lean`, or variants such as `Foo3b.lean`. A new semantic
+exception must explain why the numeral belongs to the mathematics or source
+citation; it is not an escape hatch for continuation files.
+
+**When it runs**: On pull requests and pushes to `main` whenever Lean sources,
+either checker, their tests, this documentation, or the workflow changes. CI
+runs the policy unit tests before both repository checks.
 
 ---
 

--- a/scripts/check_numbered_lean_files.py
+++ b/scripts/check_numbered_lean_files.py
@@ -10,8 +10,10 @@ allowlist in the same change.  Genuine mathematical/source numbers belong in
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 NUMBERED_STEM = re.compile(r"\d+[A-Za-z]?$")
@@ -81,6 +83,8 @@ SEMANTIC_EXCEPTIONS: dict[str, str] = {
         "Corollary 4.1 is the source result formalized by this module.",
 }
 
+# This guidance is intentionally naming-specific.  The size checker gives
+# complementary advice about decomposing a large mathematical development.
 SPLIT_GUIDANCE = (
     "Choose names for mathematical responsibilities (for example, "
     "BoundaryRecovery.lean), move shared definitions into a family Basic.lean "
@@ -110,12 +114,86 @@ def _has_numbered_suffix(path: str) -> bool:
     return NUMBERED_STEM.search(Path(path).stem) is not None
 
 
+def _debt_allowlist_from_source(source: str) -> frozenset[str]:
+    """Read ``NUMBERED_DEBT_ALLOWLIST`` from one checker source revision."""
+    tree = ast.parse(source)
+    for statement in tree.body:
+        if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+        if not any(isinstance(target, ast.Name) and target.id == "NUMBERED_DEBT_ALLOWLIST"
+                   for target in targets):
+            continue
+        value = statement.value
+        if (
+            not isinstance(value, ast.Call)
+            or not isinstance(value.func, ast.Name)
+            or value.func.id != "frozenset"
+            or len(value.args) != 1
+            or value.keywords
+        ):
+            raise ValueError("NUMBERED_DEBT_ALLOWLIST must be a literal frozenset")
+        parsed = ast.literal_eval(value.args[0])
+        if not isinstance(parsed, set) or not all(isinstance(path, str) for path in parsed):
+            raise ValueError("NUMBERED_DEBT_ALLOWLIST must contain only literal paths")
+        return frozenset(parsed)
+    raise ValueError("NUMBERED_DEBT_ALLOWLIST assignment not found")
+
+
+def _debt_allowlist_at_merge_base(root: Path, base_ref: str) -> frozenset[str] | None:
+    """Return the debt set at the merge base with *base_ref*.
+
+    ``None`` is returned only while this checker is first introduced and is
+    therefore absent from the base revision.
+    """
+    merge_base = subprocess.run(
+        ["git", "-C", str(root), "merge-base", "HEAD", base_ref],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if merge_base.returncode != 0:
+        raise ValueError(
+            f"cannot find merge base with {base_ref}: {merge_base.stderr.strip()}"
+        )
+    base_commit = merge_base.stdout.strip()
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "show",
+            f"{base_commit}:scripts/check_numbered_lean_files.py",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        missing_path = (
+            "does not exist in" in result.stderr
+            or "exists on disk, but not in" in result.stderr
+        )
+        if missing_path:
+            return None
+        raise ValueError(
+            f"cannot read checker at merge base {base_commit}: {result.stderr.strip()}"
+        )
+    return _debt_allowlist_from_source(result.stdout)
+
+
 def check_numbered_files(
     root: Path,
     debt_allowlist: frozenset[str] = NUMBERED_DEBT_ALLOWLIST,
-    semantic_exceptions: dict[str, str] = SEMANTIC_EXCEPTIONS,
+    semantic_exceptions: Mapping[str, str] | None = None,
+    base_debt_allowlist: frozenset[str] | None = None,
 ) -> int:
     """Check the numbered-name ratchet and return a process exit status."""
+    semantic_exceptions = dict(
+        SEMANTIC_EXCEPTIONS if semantic_exceptions is None else semantic_exceptions
+    )
     try:
         tracked = _tracked_production_lean_files(root)
     except (subprocess.CalledProcessError, UnicodeDecodeError) as error:
@@ -123,6 +201,12 @@ def check_numbered_files(
         return 1
 
     errors: list[str] = []
+    if base_debt_allowlist is not None:
+        for path in sorted(debt_allowlist - base_debt_allowlist):
+            errors.append(
+                f"{path}: added to the numbered debt allowlist; this set may only shrink"
+            )
+
     overlap = debt_allowlist & semantic_exceptions.keys()
     for path in sorted(overlap):
         errors.append(f"{path}: listed as both structural debt and a semantic exception")
@@ -173,8 +257,28 @@ def main() -> int:
         description="Reject new numbered-sequel names in tracked production Lean modules."
     )
     parser.add_argument("--root", type=Path, default=Path("."), help="Repository root")
+    parser.add_argument(
+        "--base-ref",
+        help=(
+            "Pull-request merge-base ref used to enforce that the debt allowlist "
+            "only shrinks"
+        ),
+    )
     args = parser.parse_args()
-    return check_numbered_files(args.root.resolve())
+    root = args.root.resolve()
+    base_debt_allowlist: frozenset[str] | None = None
+    if args.base_ref is not None:
+        try:
+            base_debt_allowlist = _debt_allowlist_at_merge_base(root, args.base_ref)
+        except (SyntaxError, ValueError) as error:
+            print(f"::error title=Numbered Lean file check failed::{error}")
+            return 1
+        if base_debt_allowlist is None:
+            print(
+                "Initializing the numbered-module debt baseline: the checker is absent "
+                f"from {args.base_ref}."
+            )
+    return check_numbered_files(root, base_debt_allowlist=base_debt_allowlist)
 
 
 if __name__ == "__main__":

--- a/scripts/check_numbered_lean_files.py
+++ b/scripts/check_numbered_lean_files.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Reject new numbered-sequel names among tracked production Lean modules.
+
+The debt allowlist is a ratchet: existing numbered sequel files may remain, but
+new entries fail, and removed or concept-renamed files must be removed from the
+allowlist in the same change.  Genuine mathematical/source numbers belong in
+``SEMANTIC_EXCEPTIONS`` with a path-specific explanation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+NUMBERED_STEM = re.compile(r"\d+[A-Za-z]?$")
+PRODUCTION_ROOT = "TNLean/"
+ARCHIVE_ROOT = "TNLean/Archive/"
+
+# Existing structural debt only.  Never add a new path: split into modules named
+# for their mathematical responsibility, then use a concept-named aggregator.
+NUMBERED_DEBT_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "TNLean/MPS/Periodic/Overlap/Case1.lean",
+        "TNLean/MPS/Periodic/Overlap/Case2.lean",
+        "TNLean/MPS/Periodic/Overlap/Case3.lean",
+        "TNLean/PEPS/CoherentFrameInstance2.lean",
+        "TNLean/PEPS/NormalSquareFundamentalTheorem2.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite2.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite4.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite6.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean",
+        "TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean",
+        "TNLean/PEPS/RegionBlock/GaugeInjectivity2.lean",
+        "TNLean/PEPS/RegionBlock/Recovery10.lean",
+        "TNLean/PEPS/RegionBlock/Recovery11.lean",
+        "TNLean/PEPS/RegionBlock/Recovery2.lean",
+        "TNLean/PEPS/RegionBlock/Recovery3.lean",
+        "TNLean/PEPS/RegionBlock/Recovery4.lean",
+        "TNLean/PEPS/RegionBlock/Recovery5.lean",
+        "TNLean/PEPS/RegionBlock/Recovery6.lean",
+        "TNLean/PEPS/RegionBlock/Recovery7.lean",
+        "TNLean/PEPS/RegionBlock/Recovery8.lean",
+        "TNLean/PEPS/RegionBlock/Recovery9.lean",
+        "TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean",
+        "TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean",
+        "TNLean/PEPS/RegionBlock/UnionInjectivityOverlap2.lean",
+        "TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3.lean",
+        "TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3b.lean",
+        "TNLean/PEPS/RegionBlock/UnionInjectivityOverlap4.lean",
+        "TNLean/PEPS/RegionBlock/UnionInjectivityOverlap5.lean",
+        "TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean",
+        "TNLean/PEPS/TorusFundamentalTheorem2.lean",
+        "TNLean/PEPS/TorusWindowChain2.lean",
+        "TNLean/PEPS/TorusWindowChain3.lean",
+        "TNLean/PEPS/TorusWindowChain4.lean",
+        "TNLean/PEPS/TorusWindowChain5.lean",
+        "TNLean/PEPS/TorusWindowChain6.lean",
+        "TNLean/PEPS/TorusWindowPeel2.lean",
+        "TNLean/PEPS/TorusWindowPeel3.lean",
+        "TNLean/PEPS/TorusWindowPeel4.lean",
+    }
+)
+
+# These suffixes identify mathematical objects or source labels, not the order
+# in which a proof was split.  Each exception is exact and reviewable.
+SEMANTIC_EXCEPTIONS: dict[str, str] = {
+    "TNLean/Channel/FixedPoint/WolfTheorem614.lean":
+        "Wolf's theorem 6.14 is the source result formalized by this module.",
+    "TNLean/MPS/Examples/ZMod2.lean":
+        "ZMod 2 is the mathematical coefficient group used by the example.",
+    "TNLean/MPS/MPDO/GroupedFigure8.lean":
+        "Figure 8 is the source-paper figure whose grouped construction is formalized.",
+    "TNLean/MPS/Periodic/Symmetry/Corollary41.lean":
+        "Corollary 4.1 is the source result formalized by this module.",
+}
+
+SPLIT_GUIDANCE = (
+    "Choose names for mathematical responsibilities (for example, "
+    "BoundaryRecovery.lean), move shared definitions into a family Basic.lean "
+    "module, and use a concept-named import aggregator. Do not continue a proof "
+    "as Foo2.lean/Foo3.lean."
+)
+
+
+def _tracked_production_lean_files(root: Path) -> set[str]:
+    """Return Git-tracked, non-archive Lean files below ``TNLean/``."""
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z", "--", "TNLean"],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    paths = result.stdout.decode("utf-8").split("\0")
+    return {
+        path
+        for path in paths
+        if path.startswith(PRODUCTION_ROOT)
+        and not path.startswith(ARCHIVE_ROOT)
+        and path.endswith(".lean")
+    }
+
+
+def _has_numbered_suffix(path: str) -> bool:
+    return NUMBERED_STEM.search(Path(path).stem) is not None
+
+
+def check_numbered_files(
+    root: Path,
+    debt_allowlist: frozenset[str] = NUMBERED_DEBT_ALLOWLIST,
+    semantic_exceptions: dict[str, str] = SEMANTIC_EXCEPTIONS,
+) -> int:
+    """Check the numbered-name ratchet and return a process exit status."""
+    try:
+        tracked = _tracked_production_lean_files(root)
+    except (subprocess.CalledProcessError, UnicodeDecodeError) as error:
+        print(f"::error title=Numbered Lean file check failed::git ls-files failed: {error}")
+        return 1
+
+    errors: list[str] = []
+    overlap = debt_allowlist & semantic_exceptions.keys()
+    for path in sorted(overlap):
+        errors.append(f"{path}: listed as both structural debt and a semantic exception")
+
+    for path in sorted(debt_allowlist):
+        if path not in tracked:
+            errors.append(
+                f"{path}: stale debt allowlist entry; remove it now that the tracked "
+                "production file is gone"
+            )
+        elif not _has_numbered_suffix(path):
+            errors.append(f"{path}: no longer has a numbered suffix; remove its debt entry")
+
+    for path, reason in sorted(semantic_exceptions.items()):
+        if not reason.strip():
+            errors.append(f"{path}: semantic exception has no explanation")
+        if path not in tracked:
+            errors.append(f"{path}: stale semantic exception; remove or update it")
+        elif not _has_numbered_suffix(path):
+            errors.append(f"{path}: semantic exception is unnecessary; remove it")
+
+    numbered = {path for path in tracked if _has_numbered_suffix(path)}
+    unexplained = numbered - debt_allowlist - semantic_exceptions.keys()
+    for path in sorted(unexplained):
+        errors.append(
+            f"{path}: new numbered-sequel filename; name the module for what it proves"
+        )
+
+    for message in errors:
+        path = message.split(":", 1)[0]
+        print(f"::error file={path},title=Numbered Lean module policy::{message}")
+
+    debt_present = len(numbered & debt_allowlist)
+    semantic_present = len(numbered & semantic_exceptions.keys())
+    print(
+        f"Checked {len(tracked)} tracked production Lean files: "
+        f"{debt_present} numbered debt, {semantic_present} semantic exceptions, "
+        f"{len(unexplained)} new violations."
+    )
+    if errors:
+        print(f"Split guidance: {SPLIT_GUIDANCE}")
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Reject new numbered-sequel names in tracked production Lean modules."
+    )
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repository root")
+    args = parser.parse_args()
+    return check_numbered_files(args.root.resolve())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_oversized_lean_files.py
+++ b/scripts/check_oversized_lean_files.py
@@ -20,6 +20,8 @@ THRESHOLD: int = 1000
 EXCLUDE_DIRS: tuple[str, ...] = (".lake", "lake-packages", "tmp")
 IMPORT_COMMAND = re.compile(r"import\s+[A-Za-z_][A-Za-z0-9_'.]*(?:\.[A-Za-z0-9_']+)*")
 
+# This guidance is intentionally size-specific.  The numbered-name checker
+# gives complementary advice about choosing mathematical module names.
 SPLIT_GUIDANCE = (
     "Split by mathematical responsibility into concept-named modules; move shared "
     "definitions and setup into a family Basic.lean module; and keep only imports "
@@ -120,21 +122,21 @@ def _normalize_paths(root: Path, paths: list[str]) -> tuple[set[str], list[str]]
 def check_files(
     root: Path,
     known_oversized: set[str],
-    generated_aggregators: set[str] | None = None,
+    import_only_aggregators: set[str] | None = None,
 ) -> int:
     """Scan Lean files under *root* and return 1 for any policy violation."""
-    generated_aggregators = generated_aggregators or set()
+    import_only_aggregators = import_only_aggregators or set()
     oversized: list[tuple[int, str]] = []
     known: list[tuple[int, str]] = []
     errors = 0
     total = 0
     valid_aggregators: set[str] = set()
 
-    for relative in sorted(generated_aggregators):
+    for relative in sorted(import_only_aggregators):
         path = root / relative
         if path.suffix != ".lean" or not path.is_file() or _is_excluded(path, root):
             print(
-                f"::error file={relative},title=Invalid generated aggregator exemption::"
+                f"::error file={relative},title=Invalid import-only aggregator exemption::"
                 f"{relative}: exemption must name an existing, scanned .lean file"
             )
             errors += 1
@@ -142,7 +144,7 @@ def check_files(
         reason = validate_import_aggregator(path)
         if reason is not None:
             print(
-                f"::error file={relative},title=Invalid generated aggregator exemption::"
+                f"::error file={relative},title=Invalid import-only aggregator exemption::"
                 f"{relative}: {reason}"
             )
             errors += 1
@@ -180,7 +182,7 @@ def check_files(
     print(
         f"Scanned {total} .lean files, {total_oversized} nonexempt files exceed "
         f"{THRESHOLD} lines ({len(known)} known, {len(oversized)} new); "
-        f"validated {len(valid_aggregators)} of {len(generated_aggregators)} "
+        f"validated {len(valid_aggregators)} of {len(import_only_aggregators)} "
         "exact aggregator exemption(s)."
     )
     if oversized:

--- a/scripts/check_oversized_lean_files.py
+++ b/scripts/check_oversized_lean_files.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Guard against oversized Lean files (>1000 lines).
 
-Every Lean file over 1000 lines must be split.
-This is a hard gate: any ``.lean`` file exceeding 1000 lines fails the check.
+Every Lean file over 1000 lines must be split.  Exact import-aggregator paths
+may be exempted explicitly, but each exemption is validated: after Lean
+comments are removed, the file must contain only ``import`` commands.
 
 Known oversized files can be listed via ``--known`` arguments; they are
 reported as warnings but do **not** cause the check to fail.  Once a known
@@ -12,137 +13,219 @@ file is split, remove it from the ``--known`` list.
 from __future__ import annotations
 
 import argparse
+import re
 from pathlib import Path
 
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-THRESHOLD: int = 1000  # lines — files exceeding this fail the check
-
-# Directories to exclude from scanning (matched against relative-to-root parts)
+THRESHOLD: int = 1000
 EXCLUDE_DIRS: tuple[str, ...] = (".lake", "lake-packages", "tmp")
+IMPORT_COMMAND = re.compile(r"import\s+[A-Za-z_][A-Za-z0-9_'.]*(?:\.[A-Za-z0-9_']+)*")
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+SPLIT_GUIDANCE = (
+    "Split by mathematical responsibility into concept-named modules; move shared "
+    "definitions and setup into a family Basic.lean module; and keep only imports "
+    "in a concept-named aggregator. Do not create numbered continuations such as "
+    "Foo2.lean or Foo3.lean."
+)
 
 
 def _is_excluded(path: Path, root: Path) -> bool:
-    """Return True if *path* lives under an excluded directory or is not a .lean file."""
+    """Return whether *path* is excluded or is not a Lean source file."""
     if path.suffix != ".lean":
         return True
     try:
         rel_parts = path.relative_to(root).parts
     except ValueError:
         return True
-    return any(d in rel_parts for d in EXCLUDE_DIRS)
+    return any(directory in rel_parts for directory in EXCLUDE_DIRS)
 
 
 def _count_lines(path: Path) -> int:
-    """Count lines in *path* efficiently."""
-    with path.open("rb") as fh:
-        return sum(1 for _ in fh)
+    with path.open("rb") as handle:
+        return sum(1 for _ in handle)
 
 
-# ---------------------------------------------------------------------------
-# Core logic
-# ---------------------------------------------------------------------------
+def _strip_lean_comments(source: str) -> tuple[str, str | None]:
+    """Remove nested block and line comments, or return a parse error."""
+    output: list[str] = []
+    index = 0
+    block_depth = 0
+    while index < len(source):
+        pair = source[index:index + 2]
+        if block_depth:
+            if pair == "/-":
+                block_depth += 1
+                index += 2
+            elif pair == "-/":
+                block_depth -= 1
+                index += 2
+            else:
+                if source[index] == "\n":
+                    output.append("\n")
+                index += 1
+        elif pair == "/-":
+            block_depth = 1
+            index += 2
+        elif pair == "--":
+            newline = source.find("\n", index + 2)
+            if newline == -1:
+                index = len(source)
+            else:
+                output.append("\n")
+                index = newline + 1
+        else:
+            output.append(source[index])
+            index += 1
+    if block_depth:
+        return "".join(output), "unterminated block comment"
+    return "".join(output), None
 
 
-def check_files(root: Path, known_oversized: set[str]) -> int:
-    """Scan all .lean files under *root*; return 1 if any exceed the threshold, else 0.
+def validate_import_aggregator(path: Path) -> str | None:
+    """Return ``None`` exactly when *path* is a nonempty import-only Lean file."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        return f"cannot read file: {error}"
+    uncommented, error = _strip_lean_comments(source)
+    if error is not None:
+        return error
+    commands = [line.strip() for line in uncommented.splitlines() if line.strip()]
+    if not commands:
+        return "file contains no import commands"
+    for line_number, command in enumerate(commands, start=1):
+        if IMPORT_COMMAND.fullmatch(command) is None:
+            return (
+                "contains non-import Lean code after comments are removed "
+                f"(command {line_number}: {command!r})"
+            )
+    return None
 
-    Files listed in *known_oversized* are reported as warnings (not errors)
-    and do not cause the check to fail.  Unknown oversized files cause failure.
-    """
+
+def _normalize_paths(root: Path, paths: list[str]) -> tuple[set[str], list[str]]:
+    normalized: set[str] = set()
+    outside: list[str] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = root / path
+        try:
+            relative = path.resolve().relative_to(root).as_posix()
+        except ValueError:
+            outside.append(raw_path)
+        else:
+            normalized.add(relative)
+    return normalized, outside
+
+
+def check_files(
+    root: Path,
+    known_oversized: set[str],
+    generated_aggregators: set[str] | None = None,
+) -> int:
+    """Scan Lean files under *root* and return 1 for any policy violation."""
+    generated_aggregators = generated_aggregators or set()
     oversized: list[tuple[int, str]] = []
     known: list[tuple[int, str]] = []
-    total: int = 0
+    errors = 0
+    total = 0
+    valid_aggregators: set[str] = set()
+
+    for relative in sorted(generated_aggregators):
+        path = root / relative
+        if path.suffix != ".lean" or not path.is_file() or _is_excluded(path, root):
+            print(
+                f"::error file={relative},title=Invalid generated aggregator exemption::"
+                f"{relative}: exemption must name an existing, scanned .lean file"
+            )
+            errors += 1
+            continue
+        reason = validate_import_aggregator(path)
+        if reason is not None:
+            print(
+                f"::error file={relative},title=Invalid generated aggregator exemption::"
+                f"{relative}: {reason}"
+            )
+            errors += 1
+        else:
+            valid_aggregators.add(relative)
 
     for path in root.rglob("*.lean"):
         if _is_excluded(path, root):
             continue
         total += 1
-
-        try:
-            rel = path.relative_to(root).as_posix()
-        except ValueError:
-            rel = str(path)
-
+        relative = path.relative_to(root).as_posix()
         lines = _count_lines(path)
-        if lines > THRESHOLD:
-            if rel in known_oversized:
-                known.append((lines, rel))
-            else:
-                oversized.append((lines, rel))
+        if lines <= THRESHOLD or relative in valid_aggregators:
+            continue
+        if relative in known_oversized:
+            known.append((lines, relative))
+        else:
+            oversized.append((lines, relative))
 
-    # Report known oversized files as warnings
-    for lines, rel in sorted(known, reverse=True):
+    for lines, relative in sorted(known, reverse=True):
         print(
-            f"::warning file={rel},line={THRESHOLD + 1},"
-            f"title=Known oversized Lean file::{rel}: {lines} lines "
+            f"::warning file={relative},line={THRESHOLD + 1},"
+            f"title=Known oversized Lean file::{relative}: {lines} lines "
             f"(limit: {THRESHOLD}) — known, tracked for future splitting"
         )
 
-    # Report unknown oversized files as errors
-    for lines, rel in sorted(oversized, reverse=True):
+    for lines, relative in sorted(oversized, reverse=True):
         print(
-            f"::error file={rel},line={THRESHOLD + 1},"
-            f"title=Oversized Lean file::{rel}: {lines} lines "
-            f"(limit: {THRESHOLD})"
+            f"::error file={relative},line={THRESHOLD + 1},"
+            f"title=Oversized Lean file::{relative}: {lines} lines "
+            f"(limit: {THRESHOLD}). {SPLIT_GUIDANCE}"
         )
 
     total_oversized = len(known) + len(oversized)
-    print(f"Scanned {total} .lean files, {total_oversized} exceed {THRESHOLD} lines"
-          f" ({len(known)} known, {len(oversized)} new).")
+    print(
+        f"Scanned {total} .lean files, {total_oversized} nonexempt files exceed "
+        f"{THRESHOLD} lines ({len(known)} known, {len(oversized)} new); "
+        f"validated {len(valid_aggregators)} of {len(generated_aggregators)} "
+        "exact aggregator exemption(s)."
+    )
     if oversized:
         print(f"::error::{len(oversized)} new oversized file(s) detected.")
+        print(f"Split guidance: {SPLIT_GUIDANCE}")
+    if errors or oversized:
         return 1
     if total_oversized == 0:
-        print("All .lean files are within the line limit.")
+        print("All nonexempt .lean files are within the line limit.")
     else:
         print(f"{len(known)} known oversized file(s) — no new oversized files.")
     return 0
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Check Lean files for oversized length violations."
     )
-    parser.add_argument(
-        "--root",
-        type=Path,
-        default=Path("."),
-        help="Repository root (default: .)",
-    )
+    parser.add_argument("--root", type=Path, default=Path("."), help="Repository root")
     parser.add_argument(
         "--known",
         action="append",
         default=[],
         metavar="PATH",
-        help="Known oversized file (can be used multiple times). "
-             "Reported as a warning, not an error.",
+        help="Known oversized file (repeatable; warning rather than error).",
+    )
+    parser.add_argument(
+        "--generated-aggregator",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Exact generated import-aggregator path to exempt (repeatable). "
+            "The file is rejected unless its uncommented content is import-only."
+        ),
     )
     args = parser.parse_args()
-    root_resolved = args.root.resolve()
-    known_set: set[str] = set()
-    for k in args.known:
-        p = Path(k)
-        if not p.is_absolute():
-            p = root_resolved / p
-        try:
-            known_set.add(p.resolve().relative_to(root_resolved).as_posix())
-        except ValueError:
-            # If the path is not under root, keep it as-is
-            known_set.add(p.as_posix())
-    return check_files(root_resolved, known_set)
+    root = args.root.resolve()
+    known, known_outside = _normalize_paths(root, args.known)
+    aggregators, aggregator_outside = _normalize_paths(root, args.generated_aggregator)
+    for path in known_outside + aggregator_outside:
+        print(f"::error title=Path outside repository::{path}")
+    if known_outside or aggregator_outside:
+        return 1
+    return check_files(root, known, aggregators)
 
 
 if __name__ == "__main__":

--- a/scripts/check_oversized_lean_files.py
+++ b/scripts/check_oversized_lean_files.py
@@ -208,19 +208,19 @@ def main() -> int:
         help="Known oversized file (repeatable; warning rather than error).",
     )
     parser.add_argument(
-        "--generated-aggregator",
+        "--import-only-aggregator",
         action="append",
         default=[],
         metavar="PATH",
         help=(
-            "Exact generated import-aggregator path to exempt (repeatable). "
+            "Exact import-only aggregator path to exempt (repeatable). "
             "The file is rejected unless its uncommented content is import-only."
         ),
     )
     args = parser.parse_args()
     root = args.root.resolve()
     known, known_outside = _normalize_paths(root, args.known)
-    aggregators, aggregator_outside = _normalize_paths(root, args.generated_aggregator)
+    aggregators, aggregator_outside = _normalize_paths(root, args.import_only_aggregator)
     for path in known_outside + aggregator_outside:
         print(f"::error title=Path outside repository::{path}")
     if known_outside or aggregator_outside:

--- a/scripts/test_lean_file_policies.py
+++ b/scripts/test_lean_file_policies.py
@@ -132,6 +132,14 @@ class NumberedLeanFilePolicyTests(CapturedCheck):
         self.assertEqual(status, 1)
         self.assertIn(f"{new_path}: added to the numbered debt allowlist", output)
 
+        push_baseline = numbered._debt_allowlist_at_merge_base(self.root, "HEAD^")
+        push_status, push_output = self.check(
+            frozenset({old_path, new_path}),
+            base_debt=push_baseline,
+        )
+        self.assertEqual(push_status, 1)
+        self.assertIn(f"{new_path}: added to the numbered debt allowlist", push_output)
+
     def test_removing_debt_allowlist_entry_is_allowed(self) -> None:
         path = "TNLean/Proof2.lean"
         self.track(path)

--- a/scripts/test_lean_file_policies.py
+++ b/scripts/test_lean_file_policies.py
@@ -8,6 +8,7 @@ import io
 import subprocess
 import tempfile
 import unittest
+from collections.abc import Callable
 from pathlib import Path
 
 import check_numbered_lean_files as numbered
@@ -15,7 +16,7 @@ import check_oversized_lean_files as oversized
 
 
 class CapturedCheck(unittest.TestCase):
-    def capture(self, function, *args):  # type: ignore[no-untyped-def]
+    def capture(self, function: Callable[..., int], *args: object) -> tuple[int, str]:
         output = io.StringIO()
         with contextlib.redirect_stdout(output):
             status = function(*args)
@@ -37,12 +38,18 @@ class NumberedLeanFilePolicyTests(CapturedCheck):
         path.write_text(source, encoding="utf-8")
         subprocess.run(["git", "-C", str(self.root), "add", relative], check=True)
 
-    def check(self, debt=frozenset(), exceptions=None):  # type: ignore[no-untyped-def]
+    def check(
+        self,
+        debt: frozenset[str] = frozenset(),
+        exceptions: dict[str, str] | None = None,
+        base_debt: frozenset[str] | None = None,
+    ) -> tuple[int, str]:
         return self.capture(
             numbered.check_numbered_files,
             self.root,
             debt,
-            exceptions or {},
+            {} if exceptions is None else exceptions,
+            base_debt,
         )
 
     def test_new_numbered_production_file_fails_with_guidance(self) -> None:
@@ -58,6 +65,81 @@ class NumberedLeanFilePolicyTests(CapturedCheck):
         status, output = self.check(frozenset({path}))
         self.assertEqual(status, 0)
         self.assertIn("1 numbered debt", output)
+
+    def test_new_debt_allowlist_entry_fails_against_base(self) -> None:
+        path = "TNLean/Proof2.lean"
+        self.track(path)
+        status, output = self.check(frozenset({path}), base_debt=frozenset())
+        self.assertEqual(status, 1)
+        self.assertIn("debt allowlist; this set may only shrink", output)
+
+    def test_merge_base_debt_allowlist_rejects_a_later_addition(self) -> None:
+        old_path = "TNLean/Old2.lean"
+        new_path = "TNLean/New3.lean"
+        self.track(old_path)
+        checker = self.root / "scripts" / "check_numbered_lean_files.py"
+        checker.parent.mkdir(parents=True)
+        checker.write_text(
+            "NUMBERED_DEBT_ALLOWLIST: frozenset[str] = "
+            f"frozenset({{{old_path!r}}})\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", checker.relative_to(self.root)],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git", "-C", str(self.root),
+                "-c", "user.name=Test",
+                "-c", "user.email=test@example.com",
+                "commit", "-qm", "baseline",
+            ],
+            check=True,
+        )
+        base_ref = subprocess.run(
+            ["git", "-C", str(self.root), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+
+        self.track(new_path)
+        checker.write_text(
+            "NUMBERED_DEBT_ALLOWLIST: frozenset[str] = "
+            f"frozenset({{{old_path!r}, {new_path!r}}})\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            ["git", "-C", str(self.root), "add", checker.relative_to(self.root)],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git", "-C", str(self.root),
+                "-c", "user.name=Test",
+                "-c", "user.email=test@example.com",
+                "commit", "-qm", "proposed addition",
+            ],
+            check=True,
+        )
+
+        baseline = numbered._debt_allowlist_at_merge_base(self.root, base_ref)
+        status, output = self.check(
+            frozenset({old_path, new_path}),
+            base_debt=baseline,
+        )
+        self.assertEqual(status, 1)
+        self.assertIn(f"{new_path}: added to the numbered debt allowlist", output)
+
+    def test_removing_debt_allowlist_entry_is_allowed(self) -> None:
+        path = "TNLean/Proof2.lean"
+        self.track(path)
+        status, output = self.check(
+            frozenset({path}),
+            base_debt=frozenset({path, "TNLean/Removed3.lean"}),
+        )
+        self.assertEqual(status, 0)
 
     def test_stale_debt_entry_fails_so_allowlist_shrinks(self) -> None:
         status, output = self.check(frozenset({"TNLean/Gone2.lean"}))

--- a/scripts/test_lean_file_policies.py
+++ b/scripts/test_lean_file_policies.py
@@ -73,7 +73,7 @@ class NumberedLeanFilePolicyTests(CapturedCheck):
         self.assertEqual(status, 1)
         self.assertIn("debt allowlist; this set may only shrink", output)
 
-    def test_merge_base_debt_allowlist_rejects_a_later_addition(self) -> None:
+    def test_base_debt_ratchet_rejects_pr_and_multicommit_push_additions(self) -> None:
         old_path = "TNLean/Old2.lean"
         new_path = "TNLean/New3.lean"
         self.track(old_path)
@@ -132,7 +132,25 @@ class NumberedLeanFilePolicyTests(CapturedCheck):
         self.assertEqual(status, 1)
         self.assertIn(f"{new_path}: added to the numbered debt allowlist", output)
 
-        push_baseline = numbered._debt_allowlist_at_merge_base(self.root, "HEAD^")
+        self.track("TNLean/Unrelated.lean")
+        subprocess.run(
+            [
+                "git", "-C", str(self.root),
+                "-c", "user.name=Test",
+                "-c", "user.email=test@example.com",
+                "commit", "-qm", "later commit in the same push",
+            ],
+            check=True,
+        )
+
+        parent_baseline = numbered._debt_allowlist_at_merge_base(self.root, "HEAD^")
+        parent_status, _ = self.check(
+            frozenset({old_path, new_path}),
+            base_debt=parent_baseline,
+        )
+        self.assertEqual(parent_status, 0)
+
+        push_baseline = numbered._debt_allowlist_at_merge_base(self.root, base_ref)
         push_status, push_output = self.check(
             frozenset({old_path, new_path}),
             base_debt=push_baseline,

--- a/scripts/test_lean_file_policies.py
+++ b/scripts/test_lean_file_policies.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Unit tests for Lean module naming and file-size policy checkers."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_numbered_lean_files as numbered
+import check_oversized_lean_files as oversized
+
+
+class CapturedCheck(unittest.TestCase):
+    def capture(self, function, *args):  # type: ignore[no-untyped-def]
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            status = function(*args)
+        return status, output.getvalue()
+
+
+class NumberedLeanFilePolicyTests(CapturedCheck):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        subprocess.run(["git", "init", "-q", str(self.root)], check=True)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def track(self, relative: str, source: str = "def x := 1\n") -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", relative], check=True)
+
+    def check(self, debt=frozenset(), exceptions=None):  # type: ignore[no-untyped-def]
+        return self.capture(
+            numbered.check_numbered_files,
+            self.root,
+            debt,
+            exceptions or {},
+        )
+
+    def test_new_numbered_production_file_fails_with_guidance(self) -> None:
+        self.track("TNLean/Proof2.lean")
+        status, output = self.check()
+        self.assertEqual(status, 1)
+        self.assertIn("new numbered-sequel filename", output)
+        self.assertIn("Basic.lean", output)
+
+    def test_existing_debt_is_allowed(self) -> None:
+        path = "TNLean/Proof2.lean"
+        self.track(path)
+        status, output = self.check(frozenset({path}))
+        self.assertEqual(status, 0)
+        self.assertIn("1 numbered debt", output)
+
+    def test_stale_debt_entry_fails_so_allowlist_shrinks(self) -> None:
+        status, output = self.check(frozenset({"TNLean/Gone2.lean"}))
+        self.assertEqual(status, 1)
+        self.assertIn("stale debt allowlist entry", output)
+
+    def test_documented_semantic_exception_is_allowed(self) -> None:
+        path = "TNLean/ZMod2.lean"
+        self.track(path)
+        status, output = self.check(
+            exceptions={path: "The numeral is part of the mathematical type name."}
+        )
+        self.assertEqual(status, 0)
+        self.assertIn("1 semantic exceptions", output)
+
+    def test_empty_semantic_explanation_fails(self) -> None:
+        path = "TNLean/ZMod2.lean"
+        self.track(path)
+        status, output = self.check(exceptions={path: "  "})
+        self.assertEqual(status, 1)
+        self.assertIn("has no explanation", output)
+
+    def test_archive_and_untracked_files_are_out_of_scope(self) -> None:
+        self.track("TNLean/Archive/Legacy2.lean")
+        untracked = self.root / "TNLean" / "Scratch2.lean"
+        untracked.write_text("def scratch := 2\n", encoding="utf-8")
+        status, output = self.check()
+        self.assertEqual(status, 0)
+        self.assertIn("0 numbered debt", output)
+
+
+class OversizedLeanFilePolicyTests(CapturedCheck):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write(self, relative: str, source: str) -> None:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(source, encoding="utf-8")
+
+    def test_oversized_module_fails_with_actionable_split_guidance(self) -> None:
+        self.write("TNLean/Huge.lean", "def x := 1\n" * (oversized.THRESHOLD + 1))
+        status, output = self.capture(oversized.check_files, self.root, set(), set())
+        self.assertEqual(status, 1)
+        self.assertIn("concept-named modules", output)
+        self.assertIn("Foo2.lean", output)
+
+    def test_exact_import_only_aggregator_is_exempt(self) -> None:
+        source = "/- generated\n  /- nested comment -/\n-/\n" + (
+            "import TNLean.Algebra.Basic -- public import\n" * (oversized.THRESHOLD + 1)
+        )
+        self.write("TNLean.lean", source)
+        status, output = self.capture(
+            oversized.check_files, self.root, set(), {"TNLean.lean"}
+        )
+        self.assertEqual(status, 0)
+        self.assertIn("validated 1 of 1 exact aggregator exemption", output)
+
+    def test_import_only_file_is_not_exempt_without_exact_registration(self) -> None:
+        self.write(
+            "TNLean/All.lean",
+            "import TNLean.Basic\n" * (oversized.THRESHOLD + 1),
+        )
+        status, output = self.capture(oversized.check_files, self.root, set(), set())
+        self.assertEqual(status, 1)
+        self.assertIn("Oversized Lean file", output)
+
+    def test_aggregator_with_declaration_is_rejected_even_below_limit(self) -> None:
+        self.write("TNLean.lean", "import TNLean.Basic\ndef notAnAggregator := 1\n")
+        status, output = self.capture(
+            oversized.check_files, self.root, set(), {"TNLean.lean"}
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("contains non-import Lean code", output)
+
+    def test_missing_aggregator_exemption_is_rejected(self) -> None:
+        status, output = self.capture(
+            oversized.check_files, self.root, set(), {"Missing.lean"}
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("must name an existing, scanned .lean file", output)
+
+    def test_unterminated_comment_rejects_aggregator(self) -> None:
+        self.write("TNLean.lean", "import TNLean.Basic\n/- never closed\n")
+        status, output = self.capture(
+            oversized.check_files, self.root, set(), {"TNLean.lean"}
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("unterminated block comment", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part of #4525.

## Summary
- reject new numbered continuation modules with a shrinking debt allowlist, compared with the pull-request merge base or the pre-push commit, and documented semantic exceptions
- validate exact pure-import aggregator exemptions instead of regex exemptions
- add actionable concept-split guidance, policy tests, CI wiring, and documentation
- retain `TorusWindowPeel3.lean`, which remains blueprint-linked and is not dead

## Verification
- 15 policy tests passed
- numbered checker: 982 production files, 43 existing debt entries, 4 semantic exceptions, no new violations
- size checker: 988 files, no nonexempt oversized files, exact aggregator validated
- full `lake build` passed (9640 jobs)
- style, reader-facing prose, blueprint sync/checkdecls, actionlint, YAML parse, and `git diff --check` passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect CI gates and Python policy scripts only, not Lean proofs or runtime behavior; risk is mainly workflow misconfiguration or false positives blocking merges.
> 
> **Overview**
> **Turns the former oversized-file advisory into blocking Lean module policy** in PR CI’s `file-length` job: unit tests run first, then the 1000-line cap with an exact **import-only** exemption for `TNLean.lean`, plus a new numbered-sequel name ratchet on tracked `TNLean/` production files.
> 
> Adds **`check_numbered_lean_files.py`** with a shrinking debt allowlist, documented semantic exceptions, and merge-base comparison so the allowlist cannot grow on PRs/pushes. Extends **`check_oversized_lean_files.py`** to validate registered aggregators (comments stripped; only `import` commands allowed) instead of broad regex exemptions.
> 
> **Workflow wiring:** new `module_policy` path filter, full git history for ratchet steps, and numbered checks for PR/push/dispatch. **`TNLean.lean`** documents the aggregator exemption; **CONTRIBUTING** and **ci-automation** describe concept-based splits instead of `Foo2.lean` continuations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61142e9bb815bdd4780614864826ec2f7580fe3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->