### PR TITLE
refactor(PEPS): transport vertical torus windows by coordinate swap

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -735,7 +735,6 @@ import TNLean.PEPS.TorusWindowRegion
 import TNLean.PEPS.TorusWindowSingleCrossingObstruction
 import TNLean.PEPS.TorusRowColumnReductionObstruction
 import TNLean.PEPS.TorusDeformedWindow
-import TNLean.PEPS.TorusCoordinateSwap
 import TNLean.PEPS.TorusWindowChain
 import TNLean.PEPS.TorusWindowFamily
 import TNLean.PEPS.TorusWindowFamilyVertical

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -735,6 +735,7 @@ import TNLean.PEPS.TorusWindowRegion
 import TNLean.PEPS.TorusWindowSingleCrossingObstruction
 import TNLean.PEPS.TorusRowColumnReductionObstruction
 import TNLean.PEPS.TorusDeformedWindow
+import TNLean.PEPS.TorusCoordinateSwap
 import TNLean.PEPS.TorusWindowChain
 import TNLean.PEPS.TorusWindowFamily
 import TNLean.PEPS.TorusWindowFamilyVertical

--- a/TNLean/PEPS/RegionTransport.lean
+++ b/TNLean/PEPS/RegionTransport.lean
@@ -68,6 +68,15 @@ theorem mem_Region_map_apply (φ : G ≃g G') (R : Finset V) (v : V) :
   rw [mem_Region_map]
   rw [show φ.symm (φ v) = v from φ.symm_apply_apply v]
 
+omit [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- Region inclusion is preserved by a graph isomorphism. -/
+theorem Region_map_mono (φ : G ≃g G') {R S : Finset V} (h : R ⊆ S) :
+    Region.map φ R ⊆ Region.map φ S := by
+  intro w hw
+  rw [mem_Region_map] at hw ⊢
+  exact h hw
+
 omit [DecidableRel G.Adj] [DecidableRel G'.Adj] in
 /-- The image of the set complement is the set complement of the image: the edge action carries
 `univ \ R` to `univ \ (Region.map φ R)`.  This is the bookkeeping that lets the complement-side

--- a/TNLean/PEPS/RegionTransportData.lean
+++ b/TNLean/PEPS/RegionTransportData.lean
@@ -74,6 +74,35 @@ theorem Region_map_univ (φ : G ≃g G') :
     Region.map φ (Finset.univ : Finset V) = (Finset.univ : Finset W) := by
   ext w; simp only [mem_Region_map, Finset.mem_univ]
 
+/-! ### Transport of abstract region injectivity -/
+
+omit [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- Pull region-injectivity data on the target graph back along a graph isomorphism.
+A source region is injective exactly when its image is injective for the target data. -/
+def RegionInjectivityData.pullback (φ : G ≃g G') (κ : RegionInjectivityData W) :
+    RegionInjectivityData V where
+  IsInjective R := κ.IsInjective (Region.map φ R)
+
+omit [Fintype V] [DecidableEq V] [LinearOrder V] [Fintype W] [DecidableEq W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+@[simp] theorem RegionInjectivityData.pullback_isInjective
+    (φ : G ≃g G') (κ : RegionInjectivityData W) (R : Finset V) :
+    (κ.pullback φ).IsInjective R ↔ κ.IsInjective (Region.map φ R) :=
+  Iff.rfl
+
+omit [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- Union closure is preserved when region-injectivity data is pulled back along a
+graph isomorphism. -/
+theorem RegionInjectivityUnionClosure.pullback (φ : G ≃g G')
+    {κ : RegionInjectivityData W} (h : RegionInjectivityUnionClosure κ) :
+    RegionInjectivityUnionClosure (κ.pullback φ) where
+  union_injective := by
+    intro A B hA hB
+    rw [RegionInjectivityData.pullback_isInjective, Region_map_union]
+    exact h.union_injective hA hB
+
 /-! ### The image block is injective for the transported tensor -/
 
 omit [DecidableEq V] [DecidableEq W] in

--- a/TNLean/PEPS/TorusCoordinateSwap.lean
+++ b/TNLean/PEPS/TorusCoordinateSwap.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.PEPS.RegionTransportData
-import TNLean.PEPS.TorusWindowChain
+import TNLean.PEPS.RegionTransport
+import TNLean.PEPS.TorusWindowComplement
 
 /-!
 # Coordinate swap on the discrete torus
@@ -157,14 +157,6 @@ theorem Region_map_torusCoordinateSwap_torusArcRectangle
       torusArcRectangle (s.2, s.1) yLen xLen := by
   change torusCoordinateSwapRegion (torusArcRectangle s xLen yLen) = _
   exact torusCoordinateSwapRegion_torusArcRectangle s xLen yLen
-
-/-- Region inclusion is preserved by a graph isomorphism. -/
-theorem Region_map_mono {V W : Type*}
-    {G : SimpleGraph V} {G' : SimpleGraph W} (φ : G ≃g G') {R S : Finset V}
-    (h : R ⊆ S) : Region.map φ R ⊆ Region.map φ S := by
-  intro w hw
-  rw [mem_Region_map] at hw ⊢
-  exact h hw
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusCoordinateSwap.lean
+++ b/TNLean/PEPS/TorusCoordinateSwap.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.RegionTransportData
+import TNLean.PEPS.TorusWindowChain
+
+/-!
+# Coordinate swap on the discrete torus
+
+Interchanging the two coordinates identifies the `width × height` torus with the
+`height × width` torus. This file records the graph isomorphism and the covariance
+of cyclic rectangles under that isomorphism. These lemmas let proofs for horizontal
+windows be reused for their vertical transposes.
+-/
+
+namespace TNLean
+namespace PEPS
+
+/-- Interchange the two coordinates of a torus vertex. -/
+def torusCoordinateSwapEquiv (width height : ℕ) :
+    TorusVertex width height ≃ TorusVertex height width :=
+  Equiv.prodComm (ZMod width) (ZMod height)
+
+@[simp] theorem torusCoordinateSwapEquiv_apply {width height : ℕ}
+    (v : TorusVertex width height) :
+    torusCoordinateSwapEquiv width height v = (v.2, v.1) :=
+  rfl
+
+@[simp] theorem torusCoordinateSwapEquiv_symm {width height : ℕ} :
+    (torusCoordinateSwapEquiv width height).symm = torusCoordinateSwapEquiv height width :=
+  rfl
+
+/-- Coordinate swap exchanges horizontal and vertical cyclic neighbours. -/
+theorem torusHorizontalNeighbor_coordinateSwap {width height : ℕ}
+    {v w : TorusVertex width height} :
+    torusVerticalNeighbor (torusCoordinateSwapEquiv width height v)
+      (torusCoordinateSwapEquiv width height w) ↔ torusHorizontalNeighbor v w :=
+  Iff.rfl
+
+/-- Coordinate swap exchanges vertical and horizontal cyclic neighbours. -/
+theorem torusVerticalNeighbor_coordinateSwap {width height : ℕ}
+    {v w : TorusVertex width height} :
+    torusHorizontalNeighbor (torusCoordinateSwapEquiv width height v)
+      (torusCoordinateSwapEquiv width height w) ↔ torusVerticalNeighbor v w :=
+  Iff.rfl
+
+/-- The image of a finite torus region under coordinate swap.  Unlike the graph
+isomorphism below, this operation does not require nontrivial side lengths. -/
+def torusCoordinateSwapRegion {width height : ℕ}
+    (R : Finset (TorusVertex width height)) : Finset (TorusVertex height width) :=
+  R.map (torusCoordinateSwapEquiv width height).toEmbedding
+
+@[simp] theorem mem_torusCoordinateSwapRegion {width height : ℕ}
+    (R : Finset (TorusVertex width height)) (v : TorusVertex height width) :
+    v ∈ torusCoordinateSwapRegion R ↔ (v.2, v.1) ∈ R := by
+  simp [torusCoordinateSwapRegion]
+
+/-- Coordinate swap preserves unions of finite regions. -/
+theorem torusCoordinateSwapRegion_union {width height : ℕ}
+    (R S : Finset (TorusVertex width height)) :
+    torusCoordinateSwapRegion (R ∪ S) =
+      torusCoordinateSwapRegion R ∪ torusCoordinateSwapRegion S := by
+  ext v
+  simp only [mem_torusCoordinateSwapRegion, Finset.mem_union]
+
+/-- Coordinate swap commutes with finite indexed unions. -/
+theorem torusCoordinateSwapRegion_biUnion {width height : ℕ} {ι : Type*}
+    (s : Finset ι) (R : ι → Finset (TorusVertex width height)) :
+    torusCoordinateSwapRegion (s.biUnion R) =
+      s.biUnion (fun i => torusCoordinateSwapRegion (R i)) := by
+  ext v
+  simp only [mem_torusCoordinateSwapRegion, Finset.mem_biUnion]
+
+/-- Coordinate swap preserves inclusion of finite regions. -/
+theorem torusCoordinateSwapRegion_mono {width height : ℕ}
+    {R S : Finset (TorusVertex width height)} (h : R ⊆ S) :
+    torusCoordinateSwapRegion R ⊆ torusCoordinateSwapRegion S := by
+  intro v hv
+  rw [mem_torusCoordinateSwapRegion] at hv ⊢
+  exact h hv
+
+/-- Swapping both coordinates of a finite region returns the original region. -/
+@[simp] theorem torusCoordinateSwapRegion_swap {width height : ℕ}
+    (R : Finset (TorusVertex width height)) :
+    torusCoordinateSwapRegion (torusCoordinateSwapRegion R) = R := by
+  ext v
+  simp only [mem_torusCoordinateSwapRegion]
+
+/-- Coordinate swap transposes a cyclic rectangle and exchanges its side lengths. -/
+theorem torusCoordinateSwapRegion_torusArcRectangle {width height : ℕ}
+    [NeZero width] [NeZero height] (s : TorusVertex width height) (xLen yLen : ℕ) :
+    torusCoordinateSwapRegion (torusArcRectangle s xLen yLen) =
+      torusArcRectangle (s.2, s.1) yLen xLen := by
+  ext v
+  simp only [mem_torusCoordinateSwapRegion, mem_torusArcRectangle]
+  exact and_comm
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- Interchanging coordinates as an isomorphism from the `width × height` torus graph
+onto the `height × width` torus graph. -/
+def torusCoordinateSwap :
+    torusGraph width height ≃g torusGraph height width where
+  toEquiv := torusCoordinateSwapEquiv width height
+  map_rel_iff' := by
+    intro v w
+    rw [torusGraph_adj, torusGraph_adj]
+    rw [torusHorizontalNeighbor_coordinateSwap, torusVerticalNeighbor_coordinateSwap,
+      or_comm]
+
+@[simp] theorem torusCoordinateSwap_apply (v : TorusVertex width height) :
+    torusCoordinateSwap v = (v.2, v.1) :=
+  rfl
+
+@[simp] theorem torusCoordinateSwap_symm :
+    (torusCoordinateSwap (width := width) (height := height)).symm =
+      torusCoordinateSwap (width := height) (height := width) :=
+  rfl
+
+/-- Coordinate swap sends horizontal edges to vertical edges. -/
+theorem torusCoordinateSwap_isVertical {e : Edge (torusGraph width height)}
+    (he : IsHorizontalTorusEdge e) :
+    IsVerticalTorusEdge (Edge.map torusCoordinateSwap e) := by
+  have h := (torusHorizontalNeighbor_coordinateSwap (v := e.1.1) (w := e.1.2)).mpr he
+  rcases Edge.map_endpoints torusCoordinateSwap e with hends | hends
+  · unfold IsVerticalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.1 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.2 from hends.2]
+    exact h
+  · unfold IsVerticalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.2 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.1 from hends.2]
+    exact torusVerticalNeighbor_symm h
+
+/-- Coordinate swap sends vertical edges to horizontal edges. -/
+theorem torusCoordinateSwap_isHorizontal {e : Edge (torusGraph width height)}
+    (he : IsVerticalTorusEdge e) :
+    IsHorizontalTorusEdge (Edge.map torusCoordinateSwap e) := by
+  have h := (torusVerticalNeighbor_coordinateSwap (v := e.1.1) (w := e.1.2)).mpr he
+  rcases Edge.map_endpoints torusCoordinateSwap e with hends | hends
+  · unfold IsHorizontalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.1 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.2 from hends.2]
+    exact h
+  · unfold IsHorizontalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.2 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.1 from hends.2]
+    exact torusHorizontalNeighbor_symm h
+
+/-- Coordinate swap transposes a cyclic rectangle and exchanges its side lengths. -/
+theorem Region_map_torusCoordinateSwap_torusArcRectangle
+    (s : TorusVertex width height) (xLen yLen : ℕ) :
+    Region.map torusCoordinateSwap (torusArcRectangle s xLen yLen) =
+      torusArcRectangle (s.2, s.1) yLen xLen := by
+  change torusCoordinateSwapRegion (torusArcRectangle s xLen yLen) = _
+  exact torusCoordinateSwapRegion_torusArcRectangle s xLen yLen
+
+/-- Region inclusion is preserved by a graph isomorphism. -/
+theorem Region_map_mono {V W : Type*}
+    {G : SimpleGraph V} {G' : SimpleGraph W} (φ : G ≃g G') {R S : Finset V}
+    (h : R ⊆ S) : Region.map φ R ⊆ Region.map φ S := by
+  intro w hw
+  rw [mem_Region_map] at hw ⊢
+  exact h hw
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -3,7 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.PEPS.TorusWindowChain
+import TNLean.PEPS.TorusCoordinateSwap
+import TNLean.PEPS.TorusWindowFamily
 
 /-!
 # The staircase window family around a vertical edge
@@ -127,6 +128,47 @@ def verticalStaircaseWindow (s : TorusVertex width height) (L K j : ℕ) :
   torusArcRectangle
     (s.1 + ((L - 1 - (j - K) : ℕ) : ZMod width), s.2 + ((K - j : ℕ) : ZMod height)) L K
 
+/-! ### Coordinate-swap covariance -/
+
+/-- The first vertical end window is the coordinate transpose of the first horizontal
+end window with exchanged side lengths. -/
+theorem torusCoordinateSwapRegion_horizontalStaircaseRightWindow
+    (s : TorusVertex width height) (L K : ℕ) :
+    torusCoordinateSwapRegion
+        (horizontalStaircaseRightWindow (s.2, s.1) K L) =
+      verticalStaircaseRightWindow s L K := by
+  rw [horizontalStaircaseRightWindow, verticalStaircaseRightWindow,
+    torusCoordinateSwapRegion_torusArcRectangle]
+
+/-- The last vertical end window is the coordinate transpose of the last horizontal
+end window with exchanged side lengths. -/
+theorem torusCoordinateSwapRegion_horizontalStaircaseLeftWindow
+    (s : TorusVertex width height) (L K : ℕ) :
+    torusCoordinateSwapRegion
+        (horizontalStaircaseLeftWindow (s.2, s.1) K L) =
+      verticalStaircaseLeftWindow s L K := by
+  rw [horizontalStaircaseLeftWindow, verticalStaircaseLeftWindow,
+    torusCoordinateSwapRegion_torusArcRectangle]
+
+/-- The vertical staircase patch is the coordinate transpose of the horizontal
+staircase patch with exchanged side lengths. -/
+theorem torusCoordinateSwapRegion_horizontalStaircasePatch
+    (s : TorusVertex width height) (L K : ℕ) :
+    torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L) =
+      verticalStaircasePatch s L K := by
+  rw [horizontalStaircasePatch, verticalStaircasePatch, torusCoordinateSwapRegion_union,
+    torusCoordinateSwapRegion_torusArcRectangle,
+    torusCoordinateSwapRegion_torusArcRectangle]
+
+/-- Each vertical staircase window is the coordinate transpose of the corresponding
+horizontal staircase window with exchanged side lengths. -/
+theorem torusCoordinateSwapRegion_staircaseWindow
+    (s : TorusVertex width height) (L K j : ℕ) :
+    torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j) =
+      verticalStaircaseWindow s L K j := by
+  rw [staircaseWindow, verticalStaircaseWindow,
+    torusCoordinateSwapRegion_torusArcRectangle]
+
 /-- The first window of the family is the right end window: at `j = 0` the column
 offset is `L - 1` and the row offset `K`, the start of `verticalStaircaseRightWindow`. -/
 theorem verticalStaircaseWindow_zero (s : TorusVertex width height) (L K : ℕ) :
@@ -178,6 +220,43 @@ def verticalStaircaseUnion (s : TorusVertex width height) (L K j : ℕ) :
     Finset (TorusVertex width height) :=
   verticalStaircaseWindow s L K j ∪ verticalStaircaseWindow s L K (j + 1)
 
+/-- Each vertical consecutive-window union is the coordinate transpose of the
+corresponding horizontal union with exchanged side lengths. -/
+theorem torusCoordinateSwapRegion_staircaseUnion
+    (s : TorusVertex width height) (L K j : ℕ) :
+    torusCoordinateSwapRegion (staircaseUnion (s.2, s.1) K L j) =
+      verticalStaircaseUnion s L K j := by
+  rw [staircaseUnion, verticalStaircaseUnion, torusCoordinateSwapRegion_union,
+    torusCoordinateSwapRegion_staircaseWindow,
+    torusCoordinateSwapRegion_staircaseWindow]
+
+section GraphCovariance
+
+variable [Fact (1 < width)] [Fact (1 < height)]
+
+/-- Graph-isomorphism form of coordinate-swap covariance for staircase windows. -/
+theorem Region_map_torusCoordinateSwap_staircaseWindow
+    (s : TorusVertex width height) (L K j : ℕ) :
+    Region.map (torusCoordinateSwap (width := height) (height := width))
+        (staircaseWindow (s.2, s.1) K L j) = verticalStaircaseWindow s L K j :=
+  torusCoordinateSwapRegion_staircaseWindow s L K j
+
+/-- Graph-isomorphism form of coordinate-swap covariance for consecutive unions. -/
+theorem Region_map_torusCoordinateSwap_staircaseUnion
+    (s : TorusVertex width height) (L K j : ℕ) :
+    Region.map (torusCoordinateSwap (width := height) (height := width))
+        (staircaseUnion (s.2, s.1) K L j) = verticalStaircaseUnion s L K j :=
+  torusCoordinateSwapRegion_staircaseUnion s L K j
+
+/-- Graph-isomorphism form of coordinate-swap covariance for staircase patches. -/
+theorem Region_map_torusCoordinateSwap_horizontalStaircasePatch
+    (s : TorusVertex width height) (L K : ℕ) :
+    Region.map (torusCoordinateSwap (width := height) (height := width))
+        (horizontalStaircasePatch (s.2, s.1) K L) = verticalStaircasePatch s L K :=
+  torusCoordinateSwapRegion_horizontalStaircasePatch s L K
+
+end GraphCovariance
+
 /-- **A descending-arm consecutive union is an `L × (K + 1)` cyclic rectangle.**
 
 For `j < K` the windows `W_j` and `W_{j+1}` share the column band
@@ -194,16 +273,11 @@ theorem verticalStaircaseUnion_eq_verticalRectangle {L K : ℕ} (hh : 1 < height
       torusArcRectangle
         (s.1 + ((L - 1 : ℕ) : ZMod width), s.2 + ((K - (j + 1) : ℕ) : ZMod height))
         L (K + 1) := by
-  rw [verticalStaircaseUnion, verticalStaircaseWindow, verticalStaircaseWindow,
-    Finset.union_comm]
-  -- The column offsets agree on the descending arm and the row offsets differ by one.
-  have hcolj : (L - 1 - (j - K) : ℕ) = (L - 1 : ℕ) := by omega
-  have hcolj1 : (L - 1 - ((j + 1) - K) : ℕ) = (L - 1 : ℕ) := by omega
-  have hrow : ((K - j : ℕ) : ZMod height) = ((K - (j + 1) : ℕ) : ZMod height) + 1 := by
-    rw [show (K - j : ℕ) = (K - (j + 1)) + 1 by omega]; push_cast; ring
-  rw [hcolj, hcolj1, hrow, ← add_assoc]
-  exact verticalAdjacentWindows_union (by omega) hh
-    (s.1 + ((L - 1 : ℕ) : ZMod width), s.2 + ((K - (j + 1) : ℕ) : ZMod height))
+  have h := congrArg torusCoordinateSwapRegion
+    (staircaseUnion_eq_horizontalRectangle (width := height) (height := width)
+      (L := K) (K := L) hh (s.2, s.1) hj)
+  simpa only [torusCoordinateSwapRegion_staircaseUnion,
+    torusCoordinateSwapRegion_torusArcRectangle] using h
 
 /-- **A right-shifting-arm consecutive union is an `(L + 1) × K` cyclic rectangle.**
 
@@ -220,17 +294,11 @@ theorem verticalStaircaseUnion_eq_horizontalRectangle {L K : ℕ} (hw : 1 < widt
     verticalStaircaseUnion s L K j =
       torusArcRectangle
         (s.1 + ((L - 1 - ((j + 1) - K) : ℕ) : ZMod width), s.2) (L + 1) K := by
-  rw [verticalStaircaseUnion, verticalStaircaseWindow, verticalStaircaseWindow,
-    Finset.union_comm]
-  -- The row offsets vanish on the right-shifting arm and the column offsets differ by one.
-  have hrowj : (K - j : ℕ) = 0 := by omega
-  have hrowj1 : (K - (j + 1) : ℕ) = 0 := by omega
-  have hcol : ((L - 1 - (j - K) : ℕ) : ZMod width) =
-      ((L - 1 - ((j + 1) - K) : ℕ) : ZMod width) + 1 := by
-    rw [show (L - 1 - (j - K) : ℕ) = (L - 1 - ((j + 1) - K)) + 1 by omega]; push_cast; ring
-  rw [hrowj, hrowj1, hcol, Nat.cast_zero, add_zero, ← add_assoc]
-  exact horizontalAdjacentWindows_union (by omega) hw
-    (s.1 + ((L - 1 - ((j + 1) - K) : ℕ) : ZMod width), s.2)
+  have h := congrArg torusCoordinateSwapRegion
+    (staircaseUnion_eq_verticalRectangle (width := height) (height := width)
+      (L := K) (K := L) hw (s.2, s.1) hj (by simpa [Nat.add_comm] using hjK))
+  simpa only [torusCoordinateSwapRegion_staircaseUnion,
+    torusCoordinateSwapRegion_torusArcRectangle] using h
 
 /-- Each consecutive union of the staircase family is injective: on the descending arm
 it is the `L × (K + 1)` cyclic rectangle, on the right-shifting arm the `(L + 1) × K`
@@ -273,26 +341,13 @@ theorem mem_verticalStaircaseWindow {L K j : ℕ} (hxw : 2 * L ≤ width) (hyh :
       ((L - 1 - (j - K) : ℕ) ≤ (v.1 - s.1).val ∧
           (v.1 - s.1).val < (L - 1 - (j - K)) + L) ∧
         ((K - j : ℕ) ≤ (v.2 - s.2).val ∧ (v.2 - s.2).val < (K - j) + K) := by
-  have hw0 : 0 < width := NeZero.pos width
-  have hh0 : 0 < height := NeZero.pos height
-  have hLj : L - 1 - (j - K) ≤ L - 1 := Nat.sub_le _ _
-  have hKj : K - j ≤ K := Nat.sub_le _ _
-  rw [verticalStaircaseWindow, mem_torusArcRectangle,
-    zmod_val_sub_shift width v.1 s.1 (L - 1 - (j - K)) (by omega),
-    zmod_val_sub_shift height v.2 s.2 (K - j) (by omega)]
-  have hdx := ZMod.val_lt (v.1 - s.1)
-  have hdy := ZMod.val_lt (v.2 - s.2)
-  constructor
-  · rintro ⟨hx, hy⟩
-    refine ⟨⟨?_, ?_⟩, ⟨?_, ?_⟩⟩ <;> (split_ifs at hx hy with hcx hcy <;> omega)
-  · rintro ⟨⟨hx0, hx1⟩, ⟨hy0, hy1⟩⟩
-    refine ⟨?_, ?_⟩
-    · rw [if_neg (by omega)]; omega
-    · rw [if_neg (by omega)]; omega
+  rw [← torusCoordinateSwapRegion_staircaseWindow s L K j,
+    mem_torusCoordinateSwapRegion, mem_staircaseWindow hyh hxw]
+  exact and_comm
 
 /-! ### The subset nesting `W_j ⊆ U_j ⊆ P`
 
-The nesting consumed by the patch chaining.  Each window sits in its consecutive union
+The nesting consumed by the patch chaining. Each window sits in its consecutive union
 (definitionally), and every window — hence every union — sits in the staircase patch
 `P`. -/
 
@@ -319,25 +374,10 @@ Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
 theorem verticalStaircaseWindow_subset_patch {L K j : ℕ} (hL : 0 < L)
     (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
     verticalStaircaseWindow s L K j ⊆ verticalStaircasePatch s L K := by
-  intro v hv
-  rw [mem_verticalStaircaseWindow hxw hyh] at hv
-  obtain ⟨⟨hx0, hx1⟩, ⟨hy0, hy1⟩⟩ := hv
-  rw [verticalStaircasePatch, Finset.mem_union, mem_torusArcRectangle, mem_torusArcRectangle]
-  dsimp only
-  have hdx := ZMod.val_lt (v.1 - s.1)
-  have hdy := ZMod.val_lt (v.2 - s.2)
-  have hw0 : 0 < width := NeZero.pos width
-  have hLj : L - 1 - (j - K) ≤ L - 1 := Nat.sub_le _ _
-  have hKj : K - j ≤ K := Nat.sub_le _ _
-  by_cases harm : K ≤ j
-  · -- Right-shifting arm: the horizontal band, with row offset `0`.
-    right
-    exact ⟨by omega, by omega⟩
-  · -- Descending arm: the vertical band, column offset `L - 1`.
-    left
-    rw [zmod_val_sub_shift width v.1 s.1 (L - 1) (by omega)]
-    rw [if_neg (by omega)]
-    exact ⟨by omega, by omega⟩
+  rw [← torusCoordinateSwapRegion_staircaseWindow,
+    ← torusCoordinateSwapRegion_horizontalStaircasePatch]
+  exact torusCoordinateSwapRegion_mono
+    (staircaseWindow_subset_patch hL hyh hxw (s.2, s.1))
 
 /-- **Each consecutive union sits in the staircase patch.**  The union of two windows of
 the family, both of which sit in the patch.
@@ -348,16 +388,15 @@ Step 2. -/
 theorem verticalStaircaseUnion_subset_patch {L K j : ℕ} (hL : 0 < L)
     (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
     verticalStaircaseUnion s L K j ⊆ verticalStaircasePatch s L K := by
-  rw [verticalStaircaseUnion, Finset.union_subset_iff]
-  exact ⟨verticalStaircaseWindow_subset_patch hL hxw hyh s,
-    verticalStaircaseWindow_subset_patch hL hxw hyh s⟩
+  rw [← torusCoordinateSwapRegion_staircaseUnion,
+    ← torusCoordinateSwapRegion_horizontalStaircasePatch]
+  exact torusCoordinateSwapRegion_mono
+    (staircaseUnion_subset_patch hL hyh hxw (s.2, s.1))
 
 /-! ### The patch is the union of the family
 
 The staircase patch `P = ⋃_j W_j` is exactly the union of the `L + K` windows of the
-family.  The forward inclusion is the per-window subset; the reverse threads a patch
-vertex through the arm it lies on — a vertical-band vertex through a descending window, a
-horizontal-band vertex through a right-shifting window. -/
+family. The result follows by transposing the corresponding horizontal family. -/
 
 /-- **The patch is the union of the staircase family.**  The staircase patch `P` equals
 the union of the `L + K` windows `W_0, …, W_{L+K-1}`: every window sits in `P`, and
@@ -372,41 +411,21 @@ theorem biUnion_verticalStaircaseWindow_eq_patch {L K : ℕ} (hL : 0 < L) (hK : 
     (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
     (Finset.range (L + K)).biUnion (verticalStaircaseWindow s L K) =
       verticalStaircasePatch s L K := by
-  apply Finset.Subset.antisymm
-  · -- Forward: every window sits in the patch.
-    rw [Finset.biUnion_subset]
-    exact fun j _ => verticalStaircaseWindow_subset_patch hL hxw hyh s
-  · -- Reverse: thread a patch vertex through its arm.
-    intro v hv
-    simp only [Finset.mem_biUnion, Finset.mem_range]
-    rw [verticalStaircasePatch, Finset.mem_union, mem_torusArcRectangle,
-      mem_torusArcRectangle] at hv
-    dsimp only at hv
-    have hw0 : 0 < width := NeZero.pos width
-    have hh0 : 0 < height := NeZero.pos height
-    have hdx := ZMod.val_lt (v.1 - s.1)
-    have hdy := ZMod.val_lt (v.2 - s.2)
-    rcases hv with ⟨hcx, hcy⟩ | ⟨hcx, hcy⟩
-    · -- Vertical band: a descending window `W_j`, `j = K - min (v.2 - s.2).val K`.
-      rw [zmod_val_sub_shift width v.1 s.1 (L - 1) (by omega)] at hcx
-      have hnw : ¬ (v.1 - s.1).val < L - 1 := by
-        intro h; rw [if_pos h] at hcx; omega
-      rw [if_neg hnw] at hcx
-      refine ⟨K - min (v.2 - s.2).val K, by omega, ?_⟩
-      rw [mem_verticalStaircaseWindow hxw hyh]
-      have hcol : L - 1 - ((K - min (v.2 - s.2).val K) - K) = L - 1 := by omega
-      have hrow : K - (K - min (v.2 - s.2).val K) = min (v.2 - s.2).val K := by omega
-      rw [hcol, hrow]
-      exact ⟨⟨by omega, by omega⟩, ⟨by omega, by omega⟩⟩
-    · -- Horizontal band: a right-shifting window `W_{K+i}`,
-      -- `i = (L - 1) - min (v.1 - s.1).val (L - 1)`.
-      refine ⟨K + ((L - 1) - min (v.1 - s.1).val (L - 1)), by omega, ?_⟩
-      rw [mem_verticalStaircaseWindow hxw hyh]
-      have hcol : L - 1 - ((K + ((L - 1) - min (v.1 - s.1).val (L - 1))) - K) =
-          min (v.1 - s.1).val (L - 1) := by omega
-      have hrow : K - (K + ((L - 1) - min (v.1 - s.1).val (L - 1))) = 0 := by omega
-      rw [hcol, hrow]
-      exact ⟨⟨by omega, by omega⟩, ⟨by omega, by omega⟩⟩
+  calc
+    (Finset.range (L + K)).biUnion (verticalStaircaseWindow s L K) =
+        (Finset.range (K + L)).biUnion
+          (fun j => torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j)) := by
+      rw [Nat.add_comm]
+      congr 1
+      funext j
+      exact (torusCoordinateSwapRegion_staircaseWindow s L K j).symm
+    _ = torusCoordinateSwapRegion
+        ((Finset.range (K + L)).biUnion (staircaseWindow (s.2, s.1) K L)) :=
+      (torusCoordinateSwapRegion_biUnion _ _).symm
+    _ = torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L) := by
+      rw [biUnion_staircaseWindow_eq_patch hK hL hyh hxw]
+    _ = verticalStaircasePatch s L K :=
+      torusCoordinateSwapRegion_horizontalStaircasePatch s L K
 
 end PEPS
 end TNLean


### PR DESCRIPTION
Part of #4526.

## Summary
- add the torus coordinate-swap graph isomorphism and orientation/rectangle covariance
- add reusable abstract region-injectivity pullback transport
- derive the substantial vertical staircase-window geometry from horizontal theorems while preserving the public API
- remove 99 lines of mirrored vertical proofs

## Review corrections
- make `TorusCoordinateSwap` depend only on `RegionTransport` and `TorusWindowComplement`, avoiding the higher staircase and transport-data layers
- place the general monotonicity theorem `Region_map_mono` beside `Region.map` in `RegionTransport`
- preserve the specialized `torusCoordinateSwapRegion_mono`, which does not require nontrivial side-length hypotheses
- expose `TorusCoordinateSwap` explicitly from the import-only root aggregator under the module policy introduced by #4548

## Verification
- the review-fix head `316dbdf8e2` passed the GitHub full Lean build, blueprint, and module-policy checks before rebase
- after rebasing onto `49dead8d69`, `lake env lean TNLean/PEPS/TorusCoordinateSwap.lean` passed at heads `7a65dbafbf` and `b6ff6464a8`
- stable patch identifiers of both rebased mathematical commits are unchanged
- the aggregator-aware oversized-file guard, numbered-module ratchet, forbidden-token guard, tactic-pattern scan, Python compilation, and `git diff --check` passed
- no new proof-integrity placeholders

Exact-head GitHub integration checks provide the final full-repository gate.