### PR TITLE
refactor(MPS/CanonicalForm): reuse compression algebra laws

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -201,6 +201,20 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
   -- `reindex eST.symm eST.symm (X i) = B i`.
   have hExST_X : ∀ i, Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i) = B i :=
     fun i => (Matrix.reindexLinearEquiv ℂ ℂ eST eST).symm_apply_apply (B i)
+  have hLetter : ∀ i : Fin d, expand (C i) = A i := by
+    intro i
+    have hBlockBack :
+        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
+            (Matrix.fromBlocks
+              (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i))
+              (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) =
+          B i := by
+      rw [hExM_C i, ← hX_block i]
+      exact hExST_X i
+    calc
+      expand (C i) = Umat * B i * Umatᴴ := by
+        rw [hexpand_def, hBlockBack]
+      _ = A i := (hA_i i).symm
   refine ⟨n, C, cornerEmbed, V, ?_, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range,
     hEmbed_eq_V⟩
   -- (1) Trace identity: n = tr P
@@ -414,71 +428,9 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     rw [map_sum]
     refine Finset.sum_congr rfl ?_
     intro i _
-    -- Per-letter: expand ((C i)ᴴ * Z * C i) = (A i)ᴴ * expand Z * A i.
-    -- Abbreviations for readability.
-    set M' : Matrix S S ℂ := Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm Z
-    set F : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-      Matrix.fromBlocks M'
-        (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) with hF_def
-    set G : MatrixAlg D := Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm F
-    -- `expand Z = Umat * G * Umatᴴ`.
-    have hexpand_Z : expand Z = Umat * G * Umatᴴ := hexpand_def Z
-    -- `(A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ`.
-    have hA_i_ct : (A i)ᴴ = Umat * (B i)ᴴ * Umatᴴ := by
-      rw [hA_i i, Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
-        Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
-    -- Reduction: reindex eS.symm eS.symm ((C i)ᴴ * Z * C i) = (B11 i)ᴴ * M' * B11 i.
-    have hExM_letter :
-        Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm ((C i)ᴴ * Z * C i) =
-          (B11 i)ᴴ * M' * B11 i := by
-      rw [← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-            eS.symm eS.symm eS.symm ((C i)ᴴ * Z) (C i),
-          ← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-            eS.symm eS.symm eS.symm ((C i)ᴴ) Z]
-      have hCt_reindex :
-          Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ := by
-        change Matrix.reindex eS.symm eS.symm ((C i)ᴴ) = (B11 i)ᴴ
-        simpa [Matrix.conjTranspose_reindex] using congrArg (fun M => Mᴴ) (hExM_C i)
-      rw [hCt_reindex, hExM_C i]
-    -- Block identity: fromBlocks ((B11 i)ᴴ * M' * B11 i) 0 0 0 = (X i)ᴴ * F * X i.
-    have hF_letter :
-        Matrix.fromBlocks ((B11 i)ᴴ * M' * B11 i) (0 : Matrix S T ℂ)
-            (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) =
-          (X i)ᴴ * F * X i := by
-      rw [hX_block i, hF_def]
-      rw [show (Matrix.fromBlocks (B11 i) (0 : Matrix S T ℂ)
-              (0 : Matrix T S ℂ) (0 : Matrix T T ℂ))ᴴ =
-            Matrix.fromBlocks (B11 i)ᴴ (0 : Matrix S T ℂ)
-              (0 : Matrix T S ℂ) (0 : Matrix T T ℂ) from by
-          simp [Matrix.fromBlocks_conjTranspose]]
-      simp [Matrix.fromBlocks_multiply]
-    -- Compute LHS = Umat * ((B i)ᴴ * G * B i) * Umatᴴ.
-    have hLHS :
-        expand ((C i)ᴴ * Z * C i) = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
-      rw [hexpand_def ((C i)ᴴ * Z * C i)]
-      congr 1
-      congr 1
-      rw [hExM_letter, hF_letter]
-      rw [← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-            eST.symm eST.symm eST.symm ((X i)ᴴ * F) (X i),
-          ← Matrix.reindexLinearEquiv_mul (R := ℂ) (A := ℂ)
-            eST.symm eST.symm eST.symm ((X i)ᴴ) F]
-      have hXct_reindex :
-          Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ := by
-        change Matrix.reindex eST.symm eST.symm ((X i)ᴴ) = (B i)ᴴ
-        simpa [Matrix.conjTranspose_reindex] using congrArg (fun M => Mᴴ) (hExST_X i)
-      rw [hXct_reindex, hExST_X i]
-    -- Compute RHS = Umat * ((B i)ᴴ * G * B i) * Umatᴴ.
-    have hRHS :
-        (A i)ᴴ * expand Z * A i = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
-      rw [hexpand_Z, hA_i_ct, hA_i i]
-      calc
-        (Umat * (B i)ᴴ * Umatᴴ) * (Umat * G * Umatᴴ) * (Umat * B i * Umatᴴ)
-            = Umat * (B i)ᴴ * (Umatᴴ * Umat) * G * (Umatᴴ * Umat) * B i * Umatᴴ := by
-              noncomm_ring
-        _ = Umat * ((B i)ᴴ * G * B i) * Umatᴴ := by
-              rw [hU'U]; noncomm_ring
-    rw [hLHS, hRHS]
+    rw [cornerCompressionExpand_mul Umat eST eS hU'U,
+      cornerCompressionExpand_mul Umat eST eS hU'U,
+      ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
   -- (5) Multiplicativity: (φ (X * Y)).1 = (φ X).1 * (φ Y).1.
   · intro X Y
     change expand (X * Y) = expand X * expand Y
@@ -490,18 +442,7 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
   -- (7) Letter expansion: φ(C_i) is the original supported ambient letter.
   · intro i
     change expand (C i) = A i
-    have hBlockBack :
-        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
-            (Matrix.fromBlocks
-              (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i))
-              (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) =
-          B i := by
-      rw [hExM_C i, ← hX_block i]
-      exact hExST_X i
-    calc
-      expand (C i) = Umat * B i * Umatᴴ := by
-        rw [hexpand_def, hBlockBack]
-      _ = A i := (hA_i i).symm
+    exact hLetter i
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -16,7 +16,6 @@ import Mathlib.Data.Matrix.Block
 import Mathlib.Data.Matrix.Diagonal
 import Mathlib.LinearAlgebra.Matrix.Reindex
 import Mathlib.Logic.Equiv.Sum
-import Mathlib.Tactic.NoncommRing
 
 /-!
 # Compression to cyclic sectors

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -46,6 +46,21 @@ abstracted — record why, so it is not re-proposed).
 
 ---
 
+## Completed refactors
+
+### Cyclic-sector compression transport
+- **Pattern:** the transfer-intertwining branch in
+  `exists_compressedTensor_of_supported_projection_with_letter_and_isometry`
+  manually reopened both reindexed block coordinate systems to prove the
+  per-letter identity.
+- **Reuse:** prove the already-returned letter-expansion identity before
+  packaging the existential, then compose `cornerCompressionExpand_mul` and
+  `cornerCompressionExpand_conjTranspose`.
+- **Result:** the theorem proof decreased from 421 to 362 lines (59 lines net),
+  with no new declaration; the file diff is 18 insertions and 77 deletions.
+
+---
+
 ## Candidates
 
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for


### PR DESCRIPTION
### Motivation
- The compression theorem manually reopened both reindexed block coordinate systems to prove transfer intertwining, even though the corner-compression API already exposes multiplication and adjoint compatibility.
- This addresses the proof-path debt identified in #4510 without adding a broad helper family or changing the public compression projections.

### Description
- Prove the existing letter-expansion identity before packaging the compression result.
- Derive the per-letter transfer identity by composing `cornerCompressionExpand_mul`, `cornerCompressionExpand_conjTranspose`, and letter expansion.
- Preserve all public theorem statements and their thin projection wrappers.
- Reduce the main proof from 421 to 362 lines, for a net deletion of 59 lines and no new declaration.
- Record the completed refactor and before/after measurement in `docs/tactic_patterns.md`.

### Testing
- `lake env lean TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean`
- `lake build TNLean.Channel.FixedPoint.CornerBlockForm TNLean.Channel.FixedPoint.CornerFixedPoints TNLean.Channel.FixedPoint.WeightedCornerFixedPoints TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition TNLean.MPS.CanonicalForm.CyclicSectors.CommutingProj TNLean.MPS.CanonicalForm.CyclicSectors.CompressionPositive`
- `python3 scripts/tactic_pattern_scan.py`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast|set_option maxHeartbeats" TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean`
- `git diff --check`

Closes #4510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No new declarations or statement changes—only internal proof structure in one MPS canonical-form file.
> 
> **Overview**
> **Proof-only refactor** of `exists_compressedTensor_of_supported_projection_with_letter_and_isometry` in `Compression.lean`: the transfer-intertwining case no longer reopens both reindexed block coordinate systems by hand.
> 
> The letter identity `expand (C i) = A i` is proved once as **`hLetter`** before packaging the existential, then reused for the intertwining sum (via `cornerCompressionExpand_mul`, `cornerCompressionExpand_conjTranspose`, and `hLetter`) and for the final letter-expansion goal. Drops the **`noncomm_ring`**-based manual per-letter calculation and the unused **`Mathlib.Tactic.NoncommRing`** import.
> 
> **Public theorem statements and thin projections are unchanged.** `docs/tactic_patterns.md` records the completed pattern under “Completed refactors.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37572f2027510e9875accfd4d9f078b1387113ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->