### PR TITLE
doc(tenkz): align manual package version

### DIFF
--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -40,7 +40,7 @@
   \vspace{2.5mm}
   {\Large second edition \quad---\quad the equation is the diagram\par}
   \vspace{4mm}
-  {documenting \pkg{} 0.5 \quad---\quad 17 July 2026 \quad---\quad
+  {documenting \pkg{} 0.6 \quad---\quad 17 July 2026 \quad---\quad
    The TNLean project\par}
   \vspace{14mm}
 


### PR DESCRIPTION
### Motivation

- The second-edition manual still says it documents tenkz 0.5, while `tex/tenkz/tenkz.sty` declares v0.6 dated 2026/07/17.
- Keep the manual title page aligned with the package version users actually load.

### Description

- Change the title-page package version from 0.5 to 0.6.
- Retain 17 July 2026 because it already matches the package declaration.

### Testing

- Ran three sequential XeLaTeX passes from `docs/tenkz/` with `TEXINPUTS="../../tex/tenkz//:"`; the settled PDF is 43 pages.
- Ran `python3 ../../scripts/tenkz_audit.py manual2.tnlog manual2.tex`: 77 pictures and no hard errors.
- Ran `python3 ../../scripts/tenkz_lint.py manual2.tex chapters2/*.tex`: 9 files, 0 findings.
- Verified the final log has no unresolved-reference or rerun warnings.
- Rendered the title page at 200 dpi and visually confirmed the 0.6 version line is aligned and legible.

Closes LionSR/tenkz#54

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation version string; no code or behavior changes.
> 
> **Overview**
> Updates the **second-edition** `manual2.tex` title page so it documents **tenkz 0.6** instead of **0.5**, matching `\ProvidesPackage{tenkz}[2026/07/17 v0.6 ...]` in `tenkz.sty`. The **17 July 2026** date line is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f89760eea2c01223a35567b628355da2a1953d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->