### PR TITLE
doc(tactic ledger): correct invariant fork status

### DIFF
--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -49,23 +49,6 @@ abstracted — record why, so it is not re-proposed).
   are 30 and 44 declaration/proof lines. Including the dependency-neutral module split,
   the refactor removes 364 source lines overall (865 additions, 1229 deletions).
 
-### invariant-subspace two-block fork — promoted
-- **Pattern:** the general and strict invariant-subspace decompositions repeated the
-  spectral split, block construction, and MPV calculation.
-```
-spectral split → block extraction → MPV calculation
-spectral split → block extraction → MPV calculation → strict bounds
-```
-- **Seen:** 2 full proof paths in
-  `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`.
-- **Abstraction:** the private semantic construction
-  `exists_twoBlock_decomp_of_lowerZero_aux`; the strict public theorem adds only
-  positivity and arithmetic for the strict dimension bounds.
-- **Notes:** Counting proof lines inclusively from `:= by` through the final proof line,
-  the two public implementations had 307 + 243 = 550 lines. The shared construction
-  and two projections have 342 + 4 + 8 = 354 lines, a net reduction of 196 lines
-  (35.6%). Both public theorem statements are unchanged.
-
 ---
 
 ## Completed refactors
@@ -87,6 +70,25 @@ spectral split → block extraction → MPV calculation → strict bounds
 
 Seeded from `scripts/tactic_pattern_scan.py` (2026-07-18 scan; re-run for
 current counts and full location lists).
+
+### invariant-subspace two-block fork — candidate
+- **Pattern:** the general and strict invariant-subspace decompositions repeated the
+  spectral split, block construction, and MPV calculation.
+```
+spectral split → block extraction → MPV calculation
+spectral split → block extraction → MPV calculation → strict bounds
+```
+- **Seen:** 2 full proof paths in
+  `TNLean/MPS/Structure/InvariantSubspaceDecomp.lean`; no further occurrence is
+  currently identified, so this remains below the promotion threshold.
+- **Abstraction:** the implemented private semantic construction
+  `exists_twoBlock_decomp_of_lowerZero_aux`; the strict public theorem adds only
+  positivity and arithmetic for the strict dimension bounds.
+- **Notes:** The local helper is retained because it removes two long proof paths without
+  adding a public interface. Counting proof lines inclusively from `:= by` through the
+  final proof line, the two public implementations had 307 + 243 = 550 lines. The shared
+  construction and two projections have 342 + 4 + 8 = 354 lines, a net reduction of 196
+  lines (35.6%). Both public theorem statements are unchanged.
 
 ### product_span_transport — candidate
 - **Pattern:** transport membership in the span of fixed-length products through


### PR DESCRIPTION
### Motivation

- The late review on #4543 correctly found that the invariant-subspace fork has
  two occurrences in one file and no identified future occurrence.
- `docs/tactic_development.md` requires three occurrences across two files, or
  two long occurrences with more clearly coming, before promotion.

### Description

- Move the invariant-subspace two-block fork entry from `Promoted` to
  `Candidates`.
- Retain the implemented private helper and the measured 196-line reduction;
  clarify that this is a useful local semantic refactor below the reusable
  promotion threshold.
- Leave all Lean source and theorem statements unchanged.

### Testing

- `git diff --check`
- 100-character line-length check for `docs/tactic_patterns.md`
- `python3 scripts/tactic_pattern_scan.py`

Closes #4569

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ledger correction with no changes to proofs, APIs, or runtime behavior.
> 
> **Overview**
> **Reclassifies** the invariant-subspace two-block fork in `docs/tactic_patterns.md` from **Promoted** to **Candidates**, aligning the ledger with `docs/tactic_development.md` promotion rules (only two occurrences in one file, no further reuse identified).
> 
> The entry still documents the private helper `exists_twoBlock_decomp_of_lowerZero_aux` and the measured ~196-line proof reduction, but now states explicitly that this is a useful local refactor **below** the reusable promotion threshold. **No Lean code or theorem statements change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52f24953abef4d51fef7f0b1a17989524244ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->