### PR TITLE
doc(MPS/SectorBNT): record exact matcher consolidation

### DIFF
--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -70,6 +70,22 @@ spectral split → block extraction → MPV calculation → strict bounds
 
 ## Completed refactors
 
+### Exact-sector matching through the proportional core
+- **Pattern:** The equal-MPV sector matcher repeated the eventually-proportional
+  matcher's fixed-length linear-independence and coefficient-comparison proof
+  instead of specializing it at scalar `1`.
+- **Reuse:** `exists_block_match_exact` now applies
+  `exists_block_match_exact_of_eventuallyProportional` through
+  `SameMPV₂Pos.toNonzeroProportionalMPV₂` and
+  `NonzeroProportionalMPV₂.eventually`. The two low-level overlap lemmas used
+  by the surviving proof live in `SectorBNT/MatchAux.lean`.
+- **Result:** Across `ExactMatch.lean`, `ProportionalMatch/Core.lean`, and
+  `MatchAux.lean`, the declaration count fell from 7 to 6. The
+  exact-match-specific proof bodies fell from 195 lines to 2 lines, counting
+  from the first tactic after `:= by` through the last tactic. Total source
+  lines fell from 666 to 481 (185 lines net). The public theorem statement and
+  blueprint link are unchanged.
+
 ### Cyclic-sector compression transport
 - **Pattern:** the transfer-intertwining branch in
   `exists_compressedTensor_of_supported_projection_with_letter_and_isometry`


### PR DESCRIPTION
### Motivation
- PR #4547 landed the source-faithful exact-to-proportional matcher consolidation tracked by #4533, but its `Part of #4521` footer left #4533 open.
- The landed change also omitted #4533's required before/after declaration and proof-line accounting in `docs/tactic_patterns.md`.
- Mathematical source: CPSV16, arXiv:1606.00608, Section II.C lines 349-352 and Appendix MPV lines 1167-1192; blueprint entry `blueprint/src/chapter/ch10_bnt.tex`, theorem `MPSTensor.exists_block_match_exact`.

### Description
- Record the already-landed exact-sector matching refactor under completed proof-path refactors.
- Document the single surviving route through `exists_block_match_exact_of_eventuallyProportional` and the dependency-neutral shared home `SectorBNT/MatchAux.lean`.
- Record 7 to 6 declarations, 195 to 2 exact-specific proof-body lines, and 666 to 481 source lines across the three matching modules.
- Make no Lean or public API changes; PR #4547 already supplied the implementation.

### Testing
- `lake build`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ExactMatch.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- Proof-integrity search on the three landed matching modules found no blocker.

Closes #4533
