### PR TITLE
refactor(MPS/MPDO): finish cyclic transport cleanup

### DIFF
--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
@@ -13,12 +13,6 @@ This file transports a two-site neighboring-operator decomposition around a peri
 finite chain.  The argument is purely algebraic: it uses neither zero correlation length,
 trace factorization, a Markov decomposition, nor saturation of the area law.
 
-## Main declarations
-
-* `Matrix.etaCyclicEdgeEquiv`
-* `MPOTensor.reindex_embedLocalOperator_etaPairBond`
-* `MPOTensor.reindex_product_embedLocalOperator_of_etaPair_decomposition`
-
 ## References
 
 * arXiv:1606.00608, Appendix C.2, equation expression, lines 1571--1576,
@@ -666,7 +660,7 @@ theorem reindex_product_embedLocalOperator_of_etaPair_decomposition
     Matrix.reindex (Matrix.etaCyclicEdgeEquiv dl dr e)
         (Matrix.etaCyclicEdgeEquiv dl dr e)
         (List.ofFn fun i : Fin N ↦
-          embedLocalOperator (d := d) 2 N (by omega) i
+          embedLocalOperator (d := d) 2 N hN i
             (Matrix.reindex (finTwoArrowEquiv (Fin d)).symm
               (finTwoArrowEquiv (Fin d)).symm B)).prod =
       Matrix.blockDiagonal' fun k : Fin N → Fin K ↦


### PR DESCRIPTION
### Motivation
- Two review threads were submitted after #4560 had already merged.
- The extracted core module retained an incomplete declaration inventory and rebuilt a proof already available as `hN`.

### Description
- Remove the incomplete `## Main declarations` section; the module summary and declaration docstrings remain the single maintained documentation surface.
- Pass `hN : 2 ≤ N` directly to `embedLocalOperator` in `reindex_product_embedLocalOperator_of_etaPair_decomposition`.
- No mathematical hypotheses or conclusions change.

### Testing
- `lake env lean TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean`
- `lake build`
- `git diff --check`
- Proof-integrity scan of the changed module
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint checkdecls` was attempted but this checkout has no generated `blueprint/lean_decls` input; this patch does not change blueprint declarations.

Closes #4570

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a proof-term refactor in one MPS/MPDO module; mathematics and API behavior are unchanged.
> 
> **Overview**
> Follow-up cleanup in `CommutingBondEtaCyclicCore.lean` after the cyclic transport extraction: no lemmas or hypotheses change.
> 
> The module doc no longer lists a **## Main declarations** section that was out of date; the file header and declaration docstrings stay the documentation surface.
> 
> In `reindex_product_embedLocalOperator_of_etaPair_decomposition`, the `List.ofFn` call now passes the existing `hN : 2 ≤ N` into `embedLocalOperator` instead of synthesizing the same bound with `(by omega)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e39be18de1912578df21840eada8b4965acda11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->