### PR TITLE
fix(Channel/Schwarz): finish support-resolvent review cleanup

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -34,6 +34,8 @@ Extracted from various files for reusability.
 - `Matrix.piProduct_mulVec_pureTensor`: a dependent product of matrices acts
   componentwise on a pure tensor
 - `Matrix.reindex_mulVec`: matrix reindexing intertwines matrix--vector action
+- `Matrix.IsHermitian.star_mulVec_dotProduct`: a Hermitian matrix may be moved
+  between the two arguments of the complex dot product
 - `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one`: determinant
   AM--GM lower bound for the Hilbert--Schmidt trace form
 - `Matrix.PosSemidef.trace_mul_nonneg`: the trace product of two positive
@@ -62,6 +64,15 @@ Extracted from various files for reusability.
 open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius MatrixOrder
 
 namespace Matrix
+
+/-! ## Hermitian matrix action -/
+
+/-- A Hermitian matrix may be moved between the two arguments of the complex
+dot product. -/
+theorem IsHermitian.star_mulVec_dotProduct {n : Type*} [Fintype n]
+    {S : Matrix n n ℂ} (hS : S.IsHermitian) (x y : n → ℂ) :
+    star (S *ᵥ x) ⬝ᵥ y = star x ⬝ᵥ (S *ᵥ y) := by
+  rw [star_mulVec, ← Matrix.dotProduct_mulVec, hS.eq]
 
 /-! ## Dependent block-diagonal matrices -/
 

--- a/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
+++ b/TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean
@@ -3,9 +3,10 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
+import TNLean.Analysis.SuperoperatorResolvent
 import TNLean.Channel.Schwarz.PetzRecoverySupport
 import TNLean.Channel.Schwarz.SSAEqualityDPI
-import TNLean.Analysis.SuperoperatorResolvent
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 import Mathlib.Data.Complex.BigOperators
 import Mathlib.LinearAlgebra.Matrix.Vec
@@ -323,11 +324,6 @@ namespace Matrix
 
 variable {n : Type*} [Fintype n]
 
-private lemma star_mulVec_dotProduct (S : Matrix n n ℂ) (hS : S.IsHermitian)
-    (x y : n → ℂ) :
-    star (S *ᵥ x) ⬝ᵥ y = star x ⬝ᵥ (S *ᵥ y) := by
-  rw [star_mulVec, ← Matrix.dotProduct_mulVec, hS.eq]
-
 variable [DecidableEq n]
 
 private lemma resolvent_residual_expand (S : Matrix n n ℂ) (hS : S.PosDef)
@@ -341,9 +337,9 @@ private lemma resolvent_residual_expand (S : Matrix n n ℂ) (hS : S.PosDef)
   have hinv' (y : n → ℂ) : S *ᵥ (S⁻¹ *ᵥ y) = y := by
     rw [mulVec_mulVec, mul_inv_of_invertible, one_mulVec]
   simp only [star_sub, sub_dotProduct, mulVec_sub, dotProduct_sub, hinv]
-  rw [star_mulVec_dotProduct S hS.isHermitian]
+  rw [hS.isHermitian.star_mulVec_dotProduct]
   rw [hinv']
-  rw [star_mulVec_dotProduct S hS.isHermitian]
+  rw [hS.isHermitian.star_mulVec_dotProduct]
   ring
 
 private theorem resolvent_residual_identity
@@ -426,7 +422,7 @@ private lemma sqrt_inv_mulVec_normSq (S : Matrix n n ℂ) (hS : S.PosDef)
       Matrix.mul_one]
   have hquad : dotProduct (star r) (S⁻¹ *ᵥ r) =
       dotProduct (star y) y := by
-    rw [← hy, hSinv, hcancel, star_mulVec_dotProduct Q hQherm]
+    rw [← hy, hSinv, hcancel, hQherm.star_mulVec_dotProduct]
     rw [mulVec_mulVec, mul_inv_of_invertible, one_mulVec]
   calc
     ∑ p, ‖((CFC.sqrt S)⁻¹ *ᵥ r) p‖ ^ 2 =

--- a/TNLean/Channel/Schwarz/SupportResolvent.lean
+++ b/TNLean/Channel/Schwarz/SupportResolvent.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.Channel.PetzRecovery
 import Mathlib.Data.Complex.BigOperators
 import Mathlib.LinearAlgebra.Matrix.Vec
@@ -25,7 +26,7 @@ gives a common generalized-inverse solution after projection to each support.
 ## References
 
 * A. Jenčová and M. B. Ruskai, arXiv:0903.2895v4, Appendix, equations `(Mj)`
-  and `(eq:Schz1)`, and §4.2, equation `(basiceq)`.
+  and `(eq:Schz1)`, and §3.1, equation `(basiceq)`.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -33,11 +34,6 @@ open scoped Matrix BigOperators ComplexOrder
 namespace Matrix
 
 variable {n : Type*} [Fintype n]
-
-private lemma star_mulVec_dotProduct (S : Matrix n n ℂ) (hS : S.IsHermitian)
-    (x y : n → ℂ) :
-    star (S *ᵥ x) ⬝ᵥ y = star x ⬝ᵥ (S *ᵥ y) := by
-  rw [star_mulVec, ← Matrix.dotProduct_mulVec, hS.eq]
 
 variable [DecidableEq n]
 
@@ -57,13 +53,13 @@ private lemma support_resolvent_residual_expand
     simpa only [G, P] using hS.self_mul_supportInvSqrt_sq
   have hPb (y : n → ℂ) :
       dotProduct (star b) (P *ᵥ y) = dotProduct (star b) y := by
-    rw [← star_mulVec_dotProduct P hS.isHermitian.supportProj_isHermitian b y]
+    rw [← hS.isHermitian.supportProj_isHermitian.star_mulVec_dotProduct b y]
     rw [hb]
   simp only [star_sub, sub_dotProduct, mulVec_sub, dotProduct_sub]
   rw [mulVec_mulVec, hGS, hPb]
-  rw [star_mulVec_dotProduct S hS.isHermitian]
+  rw [hS.isHermitian.star_mulVec_dotProduct]
   rw [mulVec_mulVec, hSG, hb]
-  rw [star_mulVec_dotProduct S hS.isHermitian]
+  rw [hS.isHermitian.star_mulVec_dotProduct]
   rw [mulVec_mulVec]
   rw [show S * P = S from hS.isHermitian.mul_supportProj_self]
   ring
@@ -155,7 +151,7 @@ solution for each summand is the restriction of the summed solution to that
 summand's support.
 
 This is the support-domain form of the common-resolvent conclusion
-`(basiceq)` in Jenčová--Ruskai, arXiv:0903.2895v4, §4.2. Its residual
+`(basiceq)` in Jenčová--Ruskai, arXiv:0903.2895v4, §3.1. Its residual
 calculation is the one in the Appendix, equations `(Mj)` and `(eq:Schz1)`. -/
 theorem support_resolvent_eq_of_defect_eq_zero
     {ι : Type*} [Fintype ι] [Nonempty ι]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2614,6 +2614,7 @@ Theorem~\ref{thm:trace_norm_abs}.
 \begin{lemma}[Residual identity on the supports]
     \label{lem:support_resolvent_residual_identity}
     \lean{Matrix.support_resolvent_residual_identity}
+    \lean{Matrix.IsHermitian.star_mulVec_dotProduct}
     \leanok
     \uses{def:support_inverse_square_root}
     Let $I$ be a finite nonempty set. For each $i\in I$, let $S_i$ be a
@@ -2663,13 +2664,14 @@ Theorem~\ref{thm:trace_norm_abs}.
       G_i b_i=P_i x.
     \]
     This is the support-domain form of the common-resolvent equation
-    $(\mathrm{basiceq})$ in Section~4.2 of Jen\v{c}ov\'a--Ruskai,
+    $(\mathrm{basiceq})$ in Section~3.1 of Jen\v{c}ov\'a--Ruskai,
     arXiv:0903.2895v4. Its residual calculation is the one in the Appendix,
     equations~$(\mathrm{Mj})$ and~$(\mathrm{eq:Schz1})$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:support_resolvent_residual_identity}
+    \uses{lem:support_resolvent_residual_identity,
+          lem:support_inverse_square_root_generalized_inverse}
     The preceding lemma writes the vanishing defect as a finite sum of
     nonnegative quadratic forms. Hence $G_i(b_i-S_ix)=0$ for every $i$.
     Multiplication by $S_i$ shows that $P_i(b_i-S_ix)=0$. Both $b_i$ and


### PR DESCRIPTION
### Motivation

PR LionSR/TNLean#4504 merged concurrently at its previous head (`39491a1b0f`) while the final exact-head review cleanup was being validated. This follow-up carries only that omitted cleanup on top of the merged result.

### Description

- Move the shared Hermitian matrix-action identity to `Matrix.IsHermitian.star_mulVec_dotProduct` in `TNLean/Algebra/MatrixAux.lean`.
- Remove the duplicate private copies from the positive-definite and support-resolvent arguments.
- Correct the location of Jenčová–Ruskai equation `(basiceq)` from §4.2 to §3.1.
- Record the helper and the direct generalized-inverse dependency in the mathematical blueprint.
- Preserve every public theorem statement from LionSR/TNLean#4504 unchanged.

### Validation

- `lake env lean TNLean/Algebra/MatrixAux.lean`
- `lake env lean TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean`
- `lake env lean TNLean/Channel/PetzRecovery.lean`
- `lake env lean TNLean/Channel/Schwarz/SupportResolvent.lean`
- blueprint declaration synchronization and changed-declaration coverage
- import-aggregator-aware file-length policy
- numbered-module, reader-facing prose, diff, and proof-integrity checks

### Related work

Follow-up to LionSR/TNLean#4504. Related to LionSR/QICLean#243 and LionSR/TNLean#232; this pull request does not close either issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor and documentation: shared lemma extraction and bibliography fixes with no changes to public theorem statements.
> 
> **Overview**
> Follow-up cleanup after LionSR/TNLean#4504: the Hermitian **swap** identity for complex dot products is now a single public lemma `Matrix.IsHermitian.star_mulVec_dotProduct` in `TNLean/Algebra/MatrixAux.lean`, and the duplicate private copies in `PetzEqualityPrerequisites` and `SupportResolvent` are removed in favor of that lemma (with `import TNLean.Algebra.MatrixAux` on those files).
> 
> Doc fixes only: Jenčová–Ruskai equation `(basiceq)` is cited as **§3.1** instead of §4.2 in Lean and blueprint; the blueprint also tags the new helper on the support-resolvent lemma and adds a `\uses` edge for the generalized-inverse lemma. **No public theorem statements change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6477689d341229a4fd7c2a18397216067aff370b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->