### PR TITLE
refactor(tenkz): align lattice reference and endpoint checks

### DIFF
--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -74,8 +74,8 @@ tenkz-cd.code.tex         L2b tenkzcd: grid mode = tikz-cd verbatim + house arro
                               TN objects; polygon=n mode = native polar placement of named
                               nodes, arrows rendered through tikz-cd's arrow-style vocabulary;
                               \tntree bracketing parser with internal charges (G5)
-tenkz-lattice.code.tex    L2c tenkzlattice: rows×cols site grid (dot/tensor/\tnpic skins),
-                              dangling boundary legs, torus/cylinder wrap marks; cell-set
+tenkz-lattice.code.tex    L2c tenkzlattice: rows×cols site grid (dot or bond-only skins),
+                              per-side openings, traces, and two-sheet cups; cell-set
                               algebra; rectilinear hull tracer WITH notches (fallback G18);
                               \tnregion / \tnedge / \tnsite on semantic slots
 tenkz-free.code.tex       L2d tenkzfree: tikzpicture preset + \tnput/\tnjoin; the only place
@@ -101,13 +101,13 @@ docs/tenkz_style_guide.md replaces the TN sections of the blueprint style guide
 
 ### 1.3 Sub-language relations and the bridge object
 
-`\tnpic{…}` is the bridge: a robust, saveboxed, overlay-free command form of the `tenkz` environment producing a self-contained math atom. It is legal (a) inline in running math (B8), (b) as a cell object in `tenkzcd` (B5), (c) as a site skin in `tenkzlattice` (`site=\tnpic{…}` for PEPS patches with drawn tensors). The cd and region languages therefore *contain* TN pictures without sharing the contraction grammar. All four languages write to one `.tnlog` with a `lang=` tag.
+`\tnpic{…}` is the bridge: a robust, saveboxed, overlay-free command form of the `tenkz` environment producing a self-contained math atom. It is legal (a) inline in running math (B8) and (b) as a cell object in `tenkzcd` (B5). The cd language therefore contains TN pictures without sharing the contraction grammar; lattice sites use their own `site=dot|none` policy. All four languages write to one `.tnlog` with a `lang=` tag.
 
 Region hulls: the tracer computes rectilinear outlines with notches from cell-set expressions in expl3. Day 1 ships with G18 fallbacks (`fill` mode as per-cell rounded squares; `outline` restricted to simply-connected sets) so B6-family figures render before the notch algorithm is final.
 
 ### 1.4 The slice contract (G1)
 
-Every environment and `\tnpic` yields a **slice**: a TeX box whose declared axis (`align=` row, default the midline of the wire rows) is pinned to the math axis (`\fontdimen22\textfont2`), with published border anchors (N/S/E/W + corners) and a picture id in the event stream. Consequences: plain `=`, `\to`, `\Rightarrow`, `\sum`, and `\left(…\right)` compose diagrams with zero glue commands; tikz-cd cells, lattice site skins, and running math all receive the same box type. Embedded slices are opaque except axis + border in v1 (port re-export across an embedding is a documented v2 extension).
+Every environment and `\tnpic` yields a **slice**: a TeX box whose declared axis (`align=` row, default the midline of the wire rows) is pinned to the math axis (`\fontdimen22\textfont2`), with published border anchors (N/S/E/W + corners) and a picture id in the event stream. Consequences: plain `=`, `\to`, `\Rightarrow`, `\sum`, and `\left(…\right)` compose diagrams with zero glue commands; tikz-cd cells, complete lattice windows, and running math all receive the same box type. Embedded slices are opaque except axis + border in v1 (port re-export across an embedding is a documented v2 extension).
 
 ### 1.5 Engine and web pipeline
 
@@ -278,16 +278,18 @@ partial trace.
 
 ### 2.3 Math / CD objects
 
-- `\tnpic[⟨keys⟩]{⟨grid body⟩}` — command form of `tenkz`; the inline math atom and the cd/lattice embedding vehicle. Identical grammar and keys; `inline` switches to text-style metrics with the axis on the inter-layer midline.
+- `\tnpic[⟨keys⟩]{⟨grid body⟩}` — command form of `tenkz`; the inline-math and cd embedding vehicle. Identical grammar and keys; `inline` switches to text-style metrics with the axis on the inter-layer midline.
 - `\tntree[⟨keys⟩]{⟨bracketing⟩}` — fusion tree from a parenthesization word **with internal-charge subscripts** (G5): `(((a\,b)_x\,c)_y\,d)_e` labels internal edges x, y and the total charge e. Module trees carry type marks for mixed wire types; `grow=down|up`. Kills the 5 frozen fusion-tree macros: the bracketing *is* the data.
 
 ### 2.4 `tenkzlattice` — lattice-region schematics
 
-`\begin{tenkzlattice}[rows=, cols=, site=dot|none|⟨pic⟩ (e.g. site=\tnpic{…}), boundary legs, physical=up|none, topology=plane|cylinder|torus, remove={(r,c),…}, pitch=] … \end{tenkzlattice}`
+`\begin{tenkzlattice}[rows=, cols=, site=dot|none, boundary=open|none, west|east|north|south=open|none|trace|cup|cup=⟨m⟩, physical=up|updown|none, pitch=, compact, inline, tensor style=, species=, frame=flat|oblique|slab, plane slant=, plane rise=, plane lean=east|west, sheets=, sheet sep=, pairing, open=, trace=, outer legs=, col|row|sheet vector={x,y}] … \end{tenkzlattice}`
 
 - `\tnregion[slot=selected|secondary|complement|collar, label=⟨math⟩, label at=⟨anchor⟩, outline, name=⟨R⟩]{⟨cell set⟩}` — cell-set algebra: `(r1-r2, c1-c2)` rectangles, `(r,c)` singletons, `+`/`-` union/difference, named sets (`R - (2,2)`). Hull traced automatically with notches (fallback per G18). Slots bind document-wide semantic colors; role stability is audited (G10).
-- `\tnedge[distinguished|slot=]{(r,c)-(r',c')}` — lattice-edge decoration, own layer (under sites, over wires).
-- `\tnsite[removed|distinguished|⟨keys⟩]{(r,c)}` — single-site decoration.
+- `\tnedge[distinguished|none|role=operator|marked|extra|passive|style=⟨TikZ⟩|label=⟨math⟩]{(r,c[,h])-(r',c'[,h'])}` — lattice-edge decoration, suppression, or label, on its own layer (under sites, over wires).
+- `\tnsite[removed|role=operator|marked|extra|passive|label=⟨math⟩]{(r,c[,h])}` — single-site removal or decoration.
+
+The environment body is a live execute-once customization layer. It records any number of `\tnregion`, `\tnedge`, and `\tnsite` commands before the lattice draw passes consume them; a stacked lattice never replays the body once per sheet.
 
 ### 2.5 `tenkzfree` — sanctioned free placement
 
@@ -635,7 +637,7 @@ Quantikz-style citable artifact; arXiv-shippable (single `tenkz.sty` + code file
 2. **Tutorial** (5–6 pages): spine is literally B1→B8, one concept per boxed example, rendered output beside verbatim source; includes the **deliberate type-error demonstration** (G24: a physical–virtual `\tnjoin` and the compile error it produces).
 3. **Reference** (~2 pages of tables + one block per command): per environment a key table; per command one signature line, key table, minimal example, and the printed **"why this is a command and not a key"** justification (G22) — the anti-sugar-creep rule is part of the citable contract.
 4. **The house style** (2–3 pages): glyph dictionary (glyph, key, mathematical meaning); semantic hue table and region slots; the metric table in geometry-appendix format (G23: constant, value, derivation from pitch, printed motivation); ellipsis and label-quadrant policies; the **canonical-spelling table** — one sanctioned drawing per semantic object (transfer map: sandwich vs opaque pill, and when each is correct); the **genre-ownership table** (G23) mapping every Tier-A/B/C use case in the brief to exactly one sub-language home.
-5. **Sub-language chapters:** tenkzcd (grid mode, polygon mode, the raw tikz-cd fallback shown side-by-side per G25, `\tntree` grammar including internal charges and module-tree marks); tenkzlattice (cell-set algebra, slots, torus/cylinder marks, `site=\tnpic{…}` skins); tenkzfree (typed anchors, `\tnjoin`, and the escape policy: when free placement is legitimate).
+5. **Sub-language chapters:** tenkzcd (grid mode, polygon mode, the raw tikz-cd fallback shown side-by-side per G25, `\tntree` grammar including internal charges and module-tree marks); tenkzlattice (cell-set algebra, semantic roles, side policies, and stacked-sheet closures); tenkzfree (typed anchors, `\tnjoin`, and the escape policy: when free placement is legitimate).
 6. **Extension:** worked `\tndeclareatom` example (adding the RMP circle-matrix-on-wire glyph) documenting the typed-port contract; restyling via `\tnset` with the complete style-name table.
 7. **Migration appendix:** the `\TN*` → tenkz mapping table auto-generated from the Phase-1 shim; idiom conversions.
 8. **Troubleshooting:** real failure modes with cell-coordinate error messages (missing `{}`, trailing `\\`, unequal column counts, `&` under plasTeX and `align`), the **&-free fallback** (`\tndefine` route, named explicitly), externalization-vs-audit interaction, stale SVG cache.
@@ -997,6 +999,29 @@ them.
 3. **The prose gate.** Manual and documentation prose follows the Elements of Style: every
    sentence asserts. Hedges, caveats, and self-commentary go in `%` comments — sanctioned
    murmuring, visible in printed source blocks — never in the running text.
+
+### 17.1 Recurring simplification gate (2026-07-20)
+
+The gate asks three questions after each migration slice.
+
+1. **What grew ad hoc?** The `tenkzlattice` public key family outgrew its
+   reference table. The table omitted `pitch`, `compact`, `inline`, `tensor
+   style`, `species`, the oblique-frame overrides, `sheet sep`, `pairing`,
+   `open`, `trace`, and the three expert basis vectors; it also omitted
+   `updown` from `physical`. The design still advertised the unimplemented
+   `topology=`, `remove=`, and `site=\tnpic{…}` forms, while the edge and site
+   signatures predated their real key families. The reference and
+   quick-reference entries now describe the implemented surface.
+2. **Which two things are secretly one thing?** Drawing, silhouette, and
+   boundary-counting passes repeated the same question: does `(r,c,h)` survive
+   both a whole-column removal and a sheet-addressed removal? They now share
+   `\tenkzl_endpoint_exists:nnn`. Cup and trace routing remain separate: a cup
+   joins the two sheets of one boundary port, whereas a trace joins opposing
+   sides within each sheet.
+3. **What would be deleted in a redesign?** `boundary legs` is exactly the
+   compatibility spelling of `boundary=open`. Keep it while migrated sources
+   use it; once an in-repository search reaches zero, delete the alias and its
+   reference row rather than maintaining two names for one policy.
 
 
 ## 18. The silhouette (recorded 2026-07-18)

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -62,7 +62,8 @@ padded with bare wire.
   trace: each row closed to itself \\
 \texttt{west label=}, \texttt{east label=} & \meta{math} & --- &
   boundary index at the stub tip \\
-\texttt{west=}, \texttt{east=} & \texttt{open|none|trace|cup|cup=\meta{m}} &
+\texttt{west=}, \texttt{east=} & \texttt{open|none|}\newline
+  \texttt{trace|cup|}\newline \texttt{cup=}\meta{m} &
   --- & the side policy; \texttt{cup} ties adjacent row pairs, the
   \texttt{cup=} value rides the bend \\
 \texttt{layer sep=} & \meta{factor} & \texttt{1} &

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -456,8 +456,10 @@ five-slot pentagon, trees and all, is Example~\ref{ex:tut-pentagon}.
 \textbackslash end\{tenkzlattice\}}
 
 A finite window of a two-dimensional lattice: sites, bonds, and the
-regions of an entanglement argument.  The body is a list of region,
-edge, and site commands drawn over the window.
+regions of an entanglement argument.  The body is a live customization
+layer, executed exactly once to record any number of \tncmd{tnregion},
+\tncmd{tnedge}, and \tncmd{tnsite} commands.  The later drawing passes
+consume those records; they do not replay the body for each sheet.
 
 \medskip
 {\footnotesize
@@ -484,54 +486,65 @@ edge, and site commands drawn over the window.
   numeric sheets or a top-to-bottom role stack \\
 \texttt{outer legs=} & \texttt{both|top|}\newline
   \texttt{bottom|none} & --- &
-  outer physical faces of a role stack \\
-\texttt{physical=} & \texttt{up|none} & \texttt{none} &
-  a physical leg on every site \\
-\texttt{frame=} & \texttt{flat|oblique|}\newline
-  \texttt{slab} & \texttt{flat} &
-  the sheared sheet: bonds shear, glyphs and labels stay upright
-  (Example~\ref{ex:rmp-peps}) \\
+  outer physical faces of a role stack; role lists default to
+  \texttt{both}, while other stacks default to \texttt{none} \\
+\texttt{physical=} & \texttt{up|updown|none} & \texttt{none} &
+  on bare sheets only, \texttt{up} draws one upward leg per site and
+  \texttt{updown} draws both; role stacks use pairing and outer legs \\
+\texttt{pitch=} & \meta{length} & \texttt{11mm} &
+  the lattice metric unit \\
+\texttt{compact}, \texttt{inline} & --- & --- &
+  use the $0.8$ and $0.62$ pitch profiles \\
+\texttt{tensor style=} & \texttt{dot|box} & \texttt{dot} &
+  site glyph policy for bare and non-operator role sheets; operator sheets
+  remain MPO boxes \\
+\texttt{species=} & \texttt{\{name,\ldots\}} & --- &
+  declare names; semantic-cycle hues are assigned in order \\
 \bottomrule
 \end{tabularx}\par}
-\medskip
-
-The plane-geometry keys tune the frame's projection past the three
-\texttt{frame=} presets --- expert overrides, guarded but not clamped:
-
-\medskip
+\smallskip
 {\footnotesize
 \noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
 \toprule
 \keyhead
-\texttt{plane slant=}, \texttt{plane rise=} & \meta{ratio} & preset &
-  explicit depth-axis ratios of the lattice pitch, overriding
-  \texttt{frame=oblique|slab} \\
+\texttt{frame=} & \texttt{flat|oblique|}\newline
+  \texttt{slab} & \texttt{flat} &
+  the sheared sheet: bonds shear, glyphs and labels stay upright
+  (Example~\ref{ex:rmp-peps}) \\
+\texttt{plane slant=}, \texttt{plane rise=} & \meta{ratio} &
+  \texttt{0.45}, \texttt{0.60} & oblique-frame basis ratios \\
 \texttt{plane lean=} & \texttt{east|west} & \texttt{east} &
-  mirrors the depth axis by negating the slant register \\
-\texttt{col vector=}, \texttt{row vector=}, \texttt{sheet vector=} &
-  \texttt{\{x,y\}} & --- &
-  expert escape hatch: set the projected basis directly, in paper
-  lengths \\
-\texttt{outer legs=} & \texttt{both|top|} \texttt{bottom|none} & auto &
-  physical legs on the sheet stack's outer faces (both for a role-list
-  sheet stack, none otherwise) \\
+  choose the oblique frame's horizontal lean \\
+\texttt{sheet sep=} & \meta{ratio} & auto &
+  override the distance between sheets \\
+\texttt{pairing} & --- & role list &
+  pair every adjacent sheet interface \\
+\texttt{open=}, \texttt{trace=} & \meta{cell set} & --- &
+  leave selected pairing interfaces open, or close them by wrap loops \\
+\texttt{col vector=}, \texttt{row vector=},
+  \texttt{sheet vector=} & \texttt{\{x,y\}} & preset &
+  expert paper-frame basis vectors \\
 \bottomrule
 \end{tabularx}\par}
 \medskip
 
 \thumbtag{\tncmd{tnregion}}%
 \cmdsig{\textbackslash tnregion[\meta{keys}]\{\meta{cell set}\}\\
-\textbackslash tnedge[distinguished]\{(r,c)-(r,c)\}\\
-\textbackslash tnsite[removed]\{(r,c)\}}
+\textbackslash tnedge[\meta{keys}]\{\meta{site}-\meta{site}\}\\
+\textbackslash tnsite[\meta{keys}]\{\meta{site}\}}
 
 \noindent A region is a set of cells, written as ranges
 \tnval{(1-3, 2-4)}; a named region composes by set algebra, as in
 \tnval{R - (2,2)}.\whynote{Regions are open-ended in number and
 compose by name, so they are drawn commands, not window keys: the
 window is configured once, while an argument may lay any number of
-overlapping subsets over it.}  \tncmd{tnedge} strokes one bond in the
-emphasis width; \tncmd{tnsite} with any option removes the site and
-its bonds from the drawing.
+overlapping subsets over it.}  \tncmd{tnedge} defaults to the
+distinguished stroke.  Its keys are \tnkey{distinguished}, \tnkey{none},
+\tnkey{role=operator|marked|extra|passive}, \tnkey{style=} (TikZ options),
+and \tnkey{label=}.  \tncmd{tnsite} removes a site and its bonds only with
+\tnkey{removed}; \tnkey{role=operator|marked|extra|passive} and
+\tnkey{label=} customize a retained site.  A site may be written
+\tnval{(r,c)} or, in a stack, \tnval{(r,c,h)}.
 
 \medskip
 {\footnotesize

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -265,8 +265,10 @@ whole language.
   \qritem{\textbackslash tnregion[slot=, label=, label at=, inset=,
     outline, name=]\{(1-3, 2-4)\}}{region; named sets compose:
     \texttt{R - (2,2)}}
-  \qritem{\textbackslash tnedge[style]\{(2,3)-(2,4)\}}{one edge}
-  \qritem{\textbackslash tnsite[style]\{(2,2)\}}{one site}
+  \qritem{\textbackslash tnedge[role=, style=, label=, none]
+    \{(2,3)-(2,4)\}}{decorate, label, or suppress one edge}
+  \qritem{\textbackslash tnsite[removed, role=, label=]\{(2,2)\}}
+    {remove or decorate one site}
 
   \qrsection{Planes (tenkzplanes)}
   \qritem{rows=, cols=, sheets=\{ket, bra\}}{the double layer,

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -38,6 +38,7 @@ SOURCE = r"""
 \newcount\tenkzlatticebodyseen
 \newcount\tenkzcuplabelseen
 \newcount\tenkzsitelabelseen
+\newcount\tenkzlatticeskinchecks
 \newcommand{\tenkzcuplabelprobe}{%
   \global\advance\tenkzcuplabelseen by 1\relax $W$}
 \newcommand{\tenkzsitelabelprobe}{%
@@ -47,6 +48,26 @@ SOURCE = r"""
 % out-and-back paths, so this wrapper fails on the collapsed geometry itself.
 \makeatletter
 \ExplSyntaxOn
+\prop_new:N \g__tenkzl_test_skin_prop
+\cs_new_protected:Npn \tenkzLatticeSkinProbe #1#2
+  { \prop_gput:Nnn \g__tenkzl_test_skin_prop {#1} {#2} }
+\cs_new_protected:Npn \tenkzLatticeSkinProbeDone
+  {
+    \prop_if_empty:NF \g__tenkzl_test_skin_prop
+      { \tex_errmessage:D { lattice~skin~probe~did~not~visit~every~sheet } }
+  }
+\cs_new_eq:NN \__tenkzl_test_select_sheet:n \tenkzl_select_sheet:n
+\cs_set_protected:Npn \tenkzl_select_sheet:n #1
+  {
+    \__tenkzl_test_select_sheet:n {#1}
+    \prop_get:NnNT \g__tenkzl_test_skin_prop {#1} \l_tmpa_tl
+      {
+        \tl_if_eq:NNF \l__tenkzl_skin_tl \l_tmpa_tl
+          { \tex_errmessage:D { lattice~tensor~style~resolved~wrong~skin } }
+        \prop_gremove:Nn \g__tenkzl_test_skin_prop {#1}
+        \global\advance\tenkzlatticeskinchecks by 1\relax
+      }
+  }
 \bool_new:N \g__tenkzl_test_one_row_label_bool
 \bool_new:N \g__tenkzl_test_routing_basis_bool
 \dim_new:N \g__tenkzl_test_routing_dx_dim
@@ -862,6 +883,34 @@ SOURCE = r"""
   \tn[dot, up at=none, label pos=north]{A}\tnspan[brace above]{1}{probe}
 \end{tenkz}
 \tenkzNoneFaceLabelAssert
+% The lattice reads the shared glyph policy for every non-operator site.
+% Defaults stay beads, picture-local box policy reaches bare and role sheets,
+% and an operator sheet remains the dedicated MPO box.
+\tenkzLatticeSkinProbe{0}{tensor}
+\begin{tenkzlattice}[rows=1, cols=2, boundary=none]
+\end{tenkzlattice}
+\tenkzLatticeSkinProbe{0}{box tensor}
+\begin{tenkzlattice}[
+    rows=1, cols=2, boundary=none, tensor style=box]
+\end{tenkzlattice}
+\tenkzLatticeSkinProbe{0}{box tensor}
+\tenkzLatticeSkinProbe{1}{mpo tensor}
+\tenkzLatticeSkinProbe{2}{box tensor}
+\begin{tenkzlattice}[
+    rows=1, cols=2, sheets={ket,op,bra}, boundary=none,
+    outer legs=none, tensor style=box]
+\end{tenkzlattice}
+\tenkzLatticeSkinProbeDone
+\ifnum\tenkzlatticeskinchecks=5\else
+  \errmessage{lattice tensor style did not exercise every skin contract}
+\fi
+% Outer-leg drawing and counting share the endpoint-survival predicate.  Each
+% sheet-local removal suppresses exactly the physical leg on its own face.
+\begin{tenkzlattice}[
+    rows=1, cols=2, sheets={ket,bra}, boundary=none]
+  \tnsite[removed]{(1,1,1)}
+  \tnsite[removed]{(1,2,0)}
+\end{tenkzlattice}
 \end{document}
 """
 
@@ -2389,6 +2438,16 @@ def main() -> int:
         "trace|picture=113|lang=lattice|axis=west-east|sheet=0|slot=2|"
         "from=2-1|to=2-2",
         "ordering fixture lost its later complete trace",
+    )
+    removed_outer_picture = max(pictures)
+    removed_outer_legs = pictures[removed_outer_picture]
+    require(
+        removed_outer_legs,
+        f"boundary|picture={removed_outer_picture}|physical-up=1|physical-down=1|"
+        "pair-closed-0=0|"
+        "pair-open-0=0|pair-traced-0=0|virtual-west=0|virtual-east=0|"
+        "virtual-north=0|virtual-south=0",
+        "outer-leg drawing and counting disagreed after sheet removals",
     )
     print("PASS: physical faces, compatibility aliases, and virtual face arity")
     return 0

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -22,10 +22,10 @@
 %                      \overline{A}, and no external auto label exists,
 %                      so brace clearances tighten accordingly.
 % The policy is a document-wide \tnset key and a per-picture key of the
-% tenkz environment, \tnpic, and tenkzfree (the environments group, so a
-% picture-local assignment scopes itself; tenkzcd cells inherit it through
-% the \tnpic objects they contain).  Explicit per-cell skins (dot, box, pill,
-% mpo) always override the policy; the event stream always records the
+% tenkz environment, \tnpic, tenkzlattice, and tenkzfree.  These environments
+% group, so a picture-local assignment scopes itself; tenkzcd cells inherit
+% it through the \tnpic objects they contain.  Explicit per-cell skins (dot,
+% box, pill, mpo) always override the policy.  The event stream records the
 % RESOLVED skin.
 
 % Triangle skins (tri=l / tri=r) borrow the isosceles-triangle node shape;
@@ -123,8 +123,11 @@
 
 % ---------- glyph policy (see the tensor-style doctrine above) ----------
 % \tenkz@tensorstyle holds the resolved mode, `dot` or `box`; grid cells
-% and \tnput read it as their default skin at option-parse time.
+% and \tnput read it as their default skin at option-parse time;
+% \tenkz@tensorskin is the corresponding resolved TikZ node style for
+% automatic-site families such as tenkzlattice.
 \def\tenkz@tensorstyle{dot}
+\def\tenkz@tensorskin{tensor}
 
 % ---------- pgfkeys front door ----------
 \def\tnset#1{\pgfqkeys{/tenkz}{#1}}
@@ -141,8 +144,10 @@
                        \let\tenkz@r@physleg\tenkz@r@inlinephysleg
                        \let\tenkz@r@labelclear\tenkz@r@inlinelabelclear},
   /tenkz/tensor style/.is choice,
-  /tenkz/tensor style/dot/.code={\def\tenkz@tensorstyle{dot}},
-  /tenkz/tensor style/box/.code={\def\tenkz@tensorstyle{box}},
+  /tenkz/tensor style/dot/.code={\def\tenkz@tensorstyle{dot}%
+                                  \def\tenkz@tensorskin{tensor}},
+  /tenkz/tensor style/box/.code={\def\tenkz@tensorstyle{box}%
+                                  \def\tenkz@tensorskin{box tensor}},
 }
 
 % Label mathematics is script-size by default: glyphs are compact marks, not

--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -678,7 +678,7 @@
     \bool_set_false:N \l__tenkzl_roles_bool
     \tl_clear:N \l__tenkzl_rolelist_tl
     \tl_clear:N \l__tenkzl_outer_tl
-    \tl_set:Nn \l__tenkzl_skin_tl {tensor}
+    \tl_set:Ne \l__tenkzl_skin_tl { \tenkz@tensorskin }
     \bool_set_false:N \l__tenkzl_opsheet_bool
     \prop_clear:N \l__tenkzl_open_prop
     \prop_clear:N \l__tenkzl_trace_prop
@@ -854,9 +854,9 @@
       { \l__tenkzl_ayx_tl \l__tenkzl_fx_dim
         + \l__tenkzl_ayy_tl \l__tenkzl_fy_dim + \l__tenkzl_shy_dim }
   }
-% select the pass's sheet: ambient index, shift h S, and site skin --
-% op sheets box their sites (the mpo skin); every other role, and the
-% bare wire-sheets, keeps the dot
+% select the pass's sheet: ambient index, shift h S, and site skin.  An op
+% sheet always uses the MPO box; every other role and every bare sheet reads
+% the core's resolved tensor-style skin.
 \cs_new_protected:Npn \tenkzl_select_sheet:n #1
   {
     \int_set:Nn \l__tenkzl_sheet_int {#1}
@@ -866,7 +866,7 @@
       { \str_if_eq_p:ee { \tenkzl_role:n {#1} } {op} }
     \bool_if:NTF \l__tenkzl_opsheet_bool
       { \tl_set:Nn \l__tenkzl_skin_tl { mpo~tensor } }
-      { \tl_set:Nn \l__tenkzl_skin_tl { tensor } }
+      { \tl_set:Ne \l__tenkzl_skin_tl { \tenkz@tensorskin } }
   }
 % paper-frame centre of site (#1,#2) on the current sheet
 % -> (\l__tenkzl_px_dim, \l__tenkzl_py_dim)
@@ -1714,14 +1714,7 @@
 
 \cs_new_protected:Npn \tenkzl_side_cup_site_silhouette:nnn #1#2#3
   {
-    \bool_set:Nn \l_tmpa_bool
-      {
-        ! \prop_if_in_p:Ne \l__tenkzl_removed_prop
-          { \tenkzl_key:nn { \int_eval:n {#1} }{ \int_eval:n {#2} } }
-        && ! \tenkzl_removed_on_p:nnn
-          { \int_eval:n {#1} }{ \int_eval:n {#2} }{ \int_eval:n {#3} }
-      }
-    \bool_if:NT \l_tmpa_bool
+    \tenkzl_endpoint_exists:nnnT {#1}{#2}{#3}
       {
         \tenkzl_xyz:nnnNN {#1}{#2}{#3}
           \l__tenkzl_cupax_dim \l__tenkzl_cupay_dim
@@ -1754,12 +1747,8 @@
   {
     \bool_set:Nn \l_tmpa_bool
       {
-        ! \prop_if_in_p:Ne \l__tenkzl_removed_prop
-            { \tenkzl_key:nn { \int_eval:n {#2} }{ \int_eval:n {#3} } }
-        && ! \tenkzl_removed_on_p:nnn
-          { \int_eval:n {#2} }{ \int_eval:n {#3} }{0}
-        && ! \tenkzl_removed_on_p:nnn
-          { \int_eval:n {#2} }{ \int_eval:n {#3} }{1}
+        \tenkzl_endpoint_exists_p:nnn {#2}{#3}{0}
+        && \tenkzl_endpoint_exists_p:nnn {#2}{#3}{1}
       }
     \bool_if:NT \l_tmpa_bool
       {
@@ -2112,24 +2101,18 @@
 
 \cs_new_protected:Npn \tenkzl_draw_side_cup_at:nnn #1#2#3
   {
-    \prop_if_in:NeF \l__tenkzl_removed_prop
-      { \tenkzl_key:nn { \int_eval:n {#2} }{ \int_eval:n {#3} } }
+    \bool_set:Nn \l__tenkzl_cupaexists_bool
+      { \tenkzl_endpoint_exists_p:nnn {#2}{#3}{0} }
+    \bool_set:Nn \l__tenkzl_cupbexists_bool
+      { \tenkzl_endpoint_exists_p:nnn {#2}{#3}{1} }
+    \bool_if:NTF \l__tenkzl_cupaexists_bool
       {
-        \bool_set:Nn \l__tenkzl_cupaexists_bool
-          { ! \tenkzl_removed_on_p:nnn
-              { \int_eval:n {#2} }{ \int_eval:n {#3} }{0} }
-        \bool_set:Nn \l__tenkzl_cupbexists_bool
-          { ! \tenkzl_removed_on_p:nnn
-              { \int_eval:n {#2} }{ \int_eval:n {#3} }{1} }
-        \bool_if:NTF \l__tenkzl_cupaexists_bool
-          {
-            \bool_if:NTF \l__tenkzl_cupbexists_bool
-              { \tenkzl_draw_complete_side_cup_at:nnn {#1}{#2}{#3} }
-              { \tenkzl_draw_incomplete_side_cup_at:nnnn {#1}{#2}{#3}{0} }
-          }
-          { \bool_if:NT \l__tenkzl_cupbexists_bool
-              { \tenkzl_draw_incomplete_side_cup_at:nnnn {#1}{#2}{#3}{1} } }
+        \bool_if:NTF \l__tenkzl_cupbexists_bool
+          { \tenkzl_draw_complete_side_cup_at:nnn {#1}{#2}{#3} }
+          { \tenkzl_draw_incomplete_side_cup_at:nnnn {#1}{#2}{#3}{0} }
       }
+      { \bool_if:NT \l__tenkzl_cupbexists_bool
+          { \tenkzl_draw_incomplete_side_cup_at:nnnn {#1}{#2}{#3}{1} } }
   }
 
 \cs_new_protected:Npn \tenkzl_draw_complete_side_cup_at:nnn #1#2#3
@@ -3864,51 +3847,48 @@
   }
 \cs_new_protected:Npn \tenkzl_outer_col:nn #1#2
   {
-    \prop_if_in:NeF \l__tenkzl_removed_prop { \tenkzl_key:nn {#1}{#2} }
+    \bool_lazy_and:nnT
+      { \tenkzl_outer_face_p:n {top} }
+      { \tenkzl_endpoint_exists_p:nnn {#1}{#2}
+          { \int_eval:n { \l__tenkzl_sheets_int - 1 } } }
       {
-        \bool_lazy_and:nnT
-          { \tenkzl_outer_face_p:n {top} }
-          { ! \tenkzl_removed_on_p:nnn {#1}{#2}
-              { \int_eval:n { \l__tenkzl_sheets_int - 1 } } }
-          {
-            \int_incr:N \l__tenkzl_bot_int
-            \tenkzl_xyz:nnnNN {#1}{#2}{ \l__tenkzl_sheets_int - 1 }
-              \l__tenkzl_px_dim \l__tenkzl_py_dim
-            \draw[physical~leg]
-              ( \dim_use:N \l__tenkzl_px_dim ,
-                \dim_use:N \l__tenkzl_py_dim ) --
-              ( \dim_use:N \l__tenkzl_px_dim ,
-                \dim_eval:n { \l__tenkzl_py_dim
-                              + \tenkz@dim{\tenkz@r@physleg} } );
-            \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
-            \dim_set:Nn \l__tenkzl_qy_dim
-              { \l__tenkzl_py_dim + \tenkz@dim{\tenkz@r@physleg} }
-            \tenkzl_record_obstacle_point:NN
-              \l__tenkzl_px_dim \l__tenkzl_py_dim
-            \tenkzl_record_obstacle_point:NN
-              \l__tenkzl_qx_dim \l__tenkzl_qy_dim
-          }
-        \bool_lazy_and:nnT
-          { \tenkzl_outer_face_p:n {bottom} }
-          { ! \tenkzl_removed_on_p:nnn {#1}{#2}{0} }
-          {
-            \int_incr:N \l__tenkzl_bob_int
-            \tenkzl_xyz:nnnNN {#1}{#2}{0}
-              \l__tenkzl_px_dim \l__tenkzl_py_dim
-            \draw[physical~leg]
-              ( \dim_use:N \l__tenkzl_px_dim ,
-                \dim_use:N \l__tenkzl_py_dim ) --
-              ( \dim_use:N \l__tenkzl_px_dim ,
-                \dim_eval:n { \l__tenkzl_py_dim
-                              - \tenkz@dim{\tenkz@r@physleg} } );
-            \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
-            \dim_set:Nn \l__tenkzl_qy_dim
-              { \l__tenkzl_py_dim - \tenkz@dim{\tenkz@r@physleg} }
-            \tenkzl_record_obstacle_point:NN
-              \l__tenkzl_px_dim \l__tenkzl_py_dim
-            \tenkzl_record_obstacle_point:NN
-              \l__tenkzl_qx_dim \l__tenkzl_qy_dim
-          }
+        \int_incr:N \l__tenkzl_bot_int
+        \tenkzl_xyz:nnnNN {#1}{#2}{ \l__tenkzl_sheets_int - 1 }
+          \l__tenkzl_px_dim \l__tenkzl_py_dim
+        \draw[physical~leg]
+          ( \dim_use:N \l__tenkzl_px_dim ,
+            \dim_use:N \l__tenkzl_py_dim ) --
+          ( \dim_use:N \l__tenkzl_px_dim ,
+            \dim_eval:n { \l__tenkzl_py_dim
+                          + \tenkz@dim{\tenkz@r@physleg} } );
+        \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
+        \dim_set:Nn \l__tenkzl_qy_dim
+          { \l__tenkzl_py_dim + \tenkz@dim{\tenkz@r@physleg} }
+        \tenkzl_record_obstacle_point:NN
+          \l__tenkzl_px_dim \l__tenkzl_py_dim
+        \tenkzl_record_obstacle_point:NN
+          \l__tenkzl_qx_dim \l__tenkzl_qy_dim
+      }
+    \bool_lazy_and:nnT
+      { \tenkzl_outer_face_p:n {bottom} }
+      { \tenkzl_endpoint_exists_p:nnn {#1}{#2}{0} }
+      {
+        \int_incr:N \l__tenkzl_bob_int
+        \tenkzl_xyz:nnnNN {#1}{#2}{0}
+          \l__tenkzl_px_dim \l__tenkzl_py_dim
+        \draw[physical~leg]
+          ( \dim_use:N \l__tenkzl_px_dim ,
+            \dim_use:N \l__tenkzl_py_dim ) --
+          ( \dim_use:N \l__tenkzl_px_dim ,
+            \dim_eval:n { \l__tenkzl_py_dim
+                          - \tenkz@dim{\tenkz@r@physleg} } );
+        \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
+        \dim_set:Nn \l__tenkzl_qy_dim
+          { \l__tenkzl_py_dim - \tenkz@dim{\tenkz@r@physleg} }
+        \tenkzl_record_obstacle_point:NN
+          \l__tenkzl_px_dim \l__tenkzl_py_dim
+        \tenkzl_record_obstacle_point:NN
+          \l__tenkzl_qx_dim \l__tenkzl_qy_dim
       }
   }
 
@@ -4129,29 +4109,21 @@
         \tenkzl_count_virtual_at:nnnN {#1}{#2}{1} #4
       }
       {
-        \prop_if_in:NeF \l__tenkzl_removed_prop
-          { \tenkzl_key:nn { \int_eval:n {#1} }{ \int_eval:n {#2} } }
+        \bool_set:Nn \l__tenkzl_cupaexists_bool
+          { \tenkzl_endpoint_exists_p:nnn {#1}{#2}{0} }
+        \bool_set:Nn \l__tenkzl_cupbexists_bool
+          { \tenkzl_endpoint_exists_p:nnn {#1}{#2}{1} }
+        \bool_if:NTF \l__tenkzl_cupaexists_bool
           {
-            \bool_set:Nn \l__tenkzl_cupaexists_bool
-              { ! \tenkzl_removed_on_p:nnn
-                  { \int_eval:n {#1} }{ \int_eval:n {#2} }{0} }
-            \bool_set:Nn \l__tenkzl_cupbexists_bool
-              { ! \tenkzl_removed_on_p:nnn
-                  { \int_eval:n {#1} }{ \int_eval:n {#2} }{1} }
-            \bool_if:NTF \l__tenkzl_cupaexists_bool
-              { \bool_if:NF \l__tenkzl_cupbexists_bool { \int_incr:N #4 } }
-              { \bool_if:NT \l__tenkzl_cupbexists_bool { \int_incr:N #4 } }
+            \bool_if:NF \l__tenkzl_cupbexists_bool { \int_incr:N #4 }
           }
+          { \bool_if:NT \l__tenkzl_cupbexists_bool { \int_incr:N #4 } }
       }
   }
 \cs_generate_variant:Nn \tenkzl_count_unresolved_cup_at:nnnN { nnVN }
 \cs_new_protected:Npn \tenkzl_count_virtual_at:nnnN #1#2#3#4
   {
-    \bool_lazy_and:nnT
-      { ! \prop_if_in_p:Ne \l__tenkzl_removed_prop
-          { \tenkzl_key:nn { \int_eval:n {#1} }{ \int_eval:n {#2} } } }
-      { ! \tenkzl_removed_on_p:nnn
-          { \int_eval:n {#1} }{ \int_eval:n {#2} }{ \int_eval:n {#3} } }
+    \tenkzl_endpoint_exists:nnnT {#1}{#2}{#3}
       { \int_incr:N #4 }
   }
 % look up interface #1's recorded count in prop #2, defaulting to 0 when


### PR DESCRIPTION
Progress on #4158.

This recurring simplification gate keeps the lattice public contract and implementation aligned after the side-cup and periodic-trace slices.

- centralize the whole-column plus sheet-local endpoint-existence predicate across cup drawing, silhouettes, and boundary counting
- document the complete implemented `tenkzlattice` key surface, including frame, stack, pairing, closure, and expert-vector keys
- correct the `tnedge` and `tnsite` signatures: decoration options do not remove a site; only `removed` does
- state and demonstrate that the `tenkzlattice` body is a live execute-once customization layer
- apply `tensor style=dot|box` to bare and non-operator lattice sheets while keeping operator sheets as MPO boxes
- record the ad-hoc, secretly-one, and eventual-deletion gate answers in `DESIGN.md`
- fix the visibly overflowing west/east policy cell in the reference table

Validation:

- focused face-port and lattice-skin regression, including default, picture-local box, and role-stack cases
- `tenkz` picture, index-routing, typed-map-label, and tree sibling suites
- `tenkz` lint: 115 files, zero findings
- strict tensor-network diagram audit: 25 declarations checked and 25 SVGs rendered
- three-pass XeLaTeX manual build: 45 pages, no undefined references or hard audit errors
- reader-facing prose check and `git diff --check`

Coordination: #4561 has landed. This head is the minimal semantic reconciliation on top of that simplification: it preserves the draw-owned outer counters and shared forwarding installer, and retains only the missing lattice-skin behavior, unified endpoint predicate, regression, and corresponding public documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and internal lattice refactor with targeted regression tests; behavior changes are limited to unified removal logic and tensor-style skin resolution on lattice sheets.
> 
> **Overview**
> **Aligns `tenkzlattice` docs and implementation** after the side-cup / periodic-trace work: one shared endpoint-survival predicate, honest public API text, and `tensor style` on lattice sites.
> 
> **Implementation**
> - **`tenkzl_endpoint_exists:nnn`** centralizes “does `(r,c,h)` survive whole-column and sheet-local removal?” Cup drawing, cup silhouettes, outer-leg drawing, and boundary counting now call this instead of duplicating removal checks.
> - **`tensor style=dot|box`** from core (`\tenkz@tensorskin`) applies to bare and non-operator lattice sheets; **operator** sheets stay **MPO** boxes. Core docs now list `tenkzlattice` alongside `tenkz` / `\tnpic` / `tenkzfree`.
> - **Regression** in `test_tenkz_face_ports.py`: lattice skin probe (default / box / role stack) and boundary agreement when sheet-local `\tnsite[removed]` suppresses outer legs.
> 
> **Documentation**
> - **`DESIGN.md`**: lattice described as dot/bond-only (not `\tnpic` site skins); §17.1 recurring simplification gate; full implemented key surface; body = execute-once customization layer.
> - **Reference / quick-ref**: expanded `tenkzlattice` keys (`physical=updown`, `tensor style`, frame/stack/pairing/closure, expert vectors); `\tnedge` / `\tnsite` keys clarified (**only `removed` deletes a site**); west/east policy cell line-breaking fix.
> - **`\tnpic` bridge** text narrowed: CD embedding + inline math, not lattice `site=\tnpic{…}` (unimplemented).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20b5e85f192c7fb00b7de68143a0f490ea998a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->