### PR TITLE
feat(Algebra): implement matched matrix blocks by unitary conjugation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -26,6 +26,7 @@ import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.TracePairing
 import TNLean.Algebra.BlockPermutation
 import TNLean.Algebra.SkolemNoether
+import TNLean.Algebra.SkolemNoetherUnitary
 import TNLean.Algebra.GramMatrixLI
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp

--- a/TNLean/Algebra/SkolemNoetherUnitary.lean
+++ b/TNLean/Algebra/SkolemNoetherUnitary.lean
@@ -165,16 +165,6 @@ variable {I J : Type*} [Finite I] [DecidableEq I] [Finite J] [DecidableEq J]
 variable {d : I → ℕ} {e : J → ℕ}
 variable [∀ i, NeZero (d i)] [∀ j, NeZero (e j)]
 
-noncomputable local instance sourceMatrix_isSimpleRing (i : I) :
-    IsSimpleRing (Matrix (Fin (d i)) (Fin (d i)) ℂ) := by
-  have : Nonempty (Fin (d i)) := Fin.pos_iff_nonempty.mp (NeZero.pos (d i))
-  exact IsSimpleRing.matrix (Fin (d i)) ℂ
-
-noncomputable local instance targetMatrix_isSimpleRing (j : J) :
-    IsSimpleRing (Matrix (Fin (e j)) (Fin (e j)) ℂ) := by
-  have : Nonempty (Fin (e j)) := Fin.pos_iff_nonempty.mp (NeZero.pos (e j))
-  exact IsSimpleRing.matrix (Fin (e j)) ℂ
-
 /-- The star-algebra equivalence obtained by restricting a product equivalence
 to a supplied pair of simple matrix summands.
 

--- a/TNLean/Algebra/SkolemNoetherUnitary.lean
+++ b/TNLean/Algebra/SkolemNoetherUnitary.lean
@@ -1,0 +1,268 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.BlockPermutation
+import TNLean.Algebra.MatrixGramUnitary
+import TNLean.Algebra.SkolemNoether
+
+import Mathlib.Algebra.Central.Matrix
+import Mathlib.LinearAlgebra.Matrix.PosDef
+
+/-!
+# Unitary Skolem--Noether theorem for complex matrices
+
+A star-algebra automorphism of a nonzero full complex matrix algebra is
+conjugation by a unitary matrix.  This is the simple-summand implementation
+step used in CPSV16, arXiv:1606.00608, Appendix C.4, line 1997, following
+Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8, source lines 322--324.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPSTensor
+
+/-- A star-algebra automorphism of a nonzero full complex matrix algebra is
+implemented by unitary conjugation.
+
+Source: CPSV16, arXiv:1606.00608, Appendix C.4, line 1997; the argument cited
+there is Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8, source lines
+322--324. -/
+theorem exists_unitary_conj_of_starAlgEquiv_matrix
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    (f : Matrix n n ℂ ≃⋆ₐ[ℂ] Matrix n n ℂ) :
+    ∃ U : Matrix.unitaryGroup n ℂ, ∀ M : Matrix n n ℂ,
+      f M = (U : Matrix n n ℂ) * M * (U : Matrix n n ℂ)ᴴ := by
+  classical
+  obtain ⟨P, hP⟩ := skolemNoether_matrix f.toAlgEquiv
+  have hPinvP :
+      (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) * (↑P : Matrix n n ℂ) = 1 :=
+    congrArg Units.val (inv_mul_cancel P)
+  have hPPinv :
+      (↑P : Matrix n n ℂ) * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) = 1 :=
+    congrArg Units.val (mul_inv_cancel P)
+  have hstar_inner : ∀ X : Matrix n n ℂ,
+      (↑P : Matrix n n ℂ) * Xᴴ * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) =
+        (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)ᴴ * Xᴴ * (↑P : Matrix n n ℂ)ᴴ := by
+    intro X
+    have h := map_star f X
+    rw [Matrix.star_eq_conjTranspose,
+      show f Xᴴ = (↑P : Matrix n n ℂ) * Xᴴ *
+        (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) from hP Xᴴ,
+      show f X = (↑P : Matrix n n ℂ) * X *
+        (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) from hP X] at h
+    simpa only [Matrix.star_eq_conjTranspose, Matrix.mul_assoc, Matrix.conjTranspose_mul] using h
+  have hPstarPinvstar :
+      (↑P : Matrix n n ℂ)ᴴ * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)ᴴ = 1 := by
+    rw [← Matrix.conjTranspose_mul, hPinvP, Matrix.conjTranspose_one]
+  have hP_star_comm : ∀ Y : Matrix n n ℂ,
+      (↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ) * Y =
+        Y * ((↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ)) := by
+    intro Y
+    specialize hstar_inner Yᴴ
+    simp only [Matrix.conjTranspose_conjTranspose] at hstar_inner
+    calc
+      (↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ) * Y
+          = (↑P : Matrix n n ℂ)ᴴ *
+              ((↑P : Matrix n n ℂ) * Y * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)) *
+              (↑P : Matrix n n ℂ) := by
+            simp only [Matrix.mul_assoc, hPinvP, Matrix.mul_one]
+      _ = (↑P : Matrix n n ℂ)ᴴ *
+            ((↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)ᴴ * Y *
+              (↑P : Matrix n n ℂ)ᴴ) *
+            (↑P : Matrix n n ℂ) := by
+            exact congrArg (fun Z : Matrix n n ℂ ↦
+              (↑P : Matrix n n ℂ)ᴴ * Z * (↑P : Matrix n n ℂ)) hstar_inner
+      _ = ((↑P : Matrix n n ℂ)ᴴ *
+              (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)ᴴ) * Y *
+            ((↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ)) := by
+            simp only [Matrix.mul_assoc]
+      _ = Y * ((↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ)) := by
+            rw [Matrix.mul_assoc, hPstarPinvstar, Matrix.one_mul]
+  have hPHP_center :
+      (↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ) ∈
+        Set.range (Matrix.scalar n : ℂ →+* Matrix n n ℂ) := by
+    rw [← Matrix.center_eq_range, Semigroup.mem_center_iff]
+    exact fun Y ↦ (hP_star_comm Y).symm
+  obtain ⟨c, hc_eq⟩ := hPHP_center
+  rw [Matrix.scalar_apply] at hc_eq
+  have hPHP_smul :
+      (↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ) = c • (1 : Matrix n n ℂ) := by
+    rw [← hc_eq, ← Matrix.smul_one_eq_diagonal]
+  have hPHP_psd :
+      ((↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ)).PosSemidef :=
+    Matrix.posSemidef_conjTranspose_mul_self _
+  let i : n := Classical.choice (inferInstance : Nonempty n)
+  have hc_nonneg : 0 ≤ c := by
+    have hdiag :
+        ((↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ)) i i = c := by
+      rw [hPHP_smul]
+      simp only [Matrix.smul_apply, Matrix.one_apply_eq, smul_eq_mul, mul_one]
+    simpa only [hdiag] using hPHP_psd.diag_nonneg (i := i)
+  have hc_ne : c ≠ 0 := by
+    intro hc0
+    have h0 : (↑P : Matrix n n ℂ)ᴴ * (↑P : Matrix n n ℂ) = 0 := by
+      rw [hPHP_smul, hc0, zero_smul]
+    have hPH_zero : (↑P : Matrix n n ℂ)ᴴ = 0 := by
+      have h := congrArg (· * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)) h0
+      simp only [Matrix.zero_mul, Matrix.mul_assoc] at h
+      rwa [hPPinv, Matrix.mul_one] at h
+    have hP_zero : (↑P : Matrix n n ℂ) = 0 := by
+      rw [← Matrix.conjTranspose_conjTranspose (↑P : Matrix n n ℂ),
+        hPH_zero, Matrix.conjTranspose_zero]
+    exact one_ne_zero (show (1 : Matrix n n ℂ) = 0 by
+      rw [← hPPinv, hP_zero, Matrix.zero_mul])
+  have hc_re_nonneg : 0 ≤ c.re := (RCLike.nonneg_iff.mp hc_nonneg).1
+  have hc_im_zero : c.im = 0 := (RCLike.nonneg_iff.mp hc_nonneg).2
+  have hc_re_pos : 0 < c.re := by
+    rcases lt_or_eq_of_le hc_re_nonneg with h | h
+    · exact h
+    · exact absurd (Complex.ext h.symm (by simpa using hc_im_zero)) hc_ne
+  have hc_eq_re : (c.re : ℂ) = c :=
+    Complex.ext (Complex.ofReal_re _) (by simpa using hc_im_zero.symm)
+  let V : Matrix n n ℂ := ((Real.sqrt c.re : ℂ))⁻¹ • (↑P : Matrix n n ℂ)
+  have hV_mem : V ∈ Matrix.unitaryGroup n ℂ := by
+    apply Matrix.smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one hc_re_pos
+    rw [hc_eq_re, hPHP_smul]
+  have hVHV : Vᴴ * V = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using
+      (Matrix.mem_unitaryGroup_iff'.mp hV_mem)
+  have hr_ne : (Real.sqrt c.re : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr hc_re_pos).ne'
+  have hPm_eq :
+      (↑P : Matrix n n ℂ) = (Real.sqrt c.re : ℂ) • V := by
+    simp only [V, smul_smul, mul_inv_cancel₀ hr_ne, one_smul]
+  have hVPinv :
+      V * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) =
+        (Real.sqrt c.re : ℂ)⁻¹ • (1 : Matrix n n ℂ) := by
+    rw [show V = (Real.sqrt c.re : ℂ)⁻¹ • (↑P : Matrix n n ℂ) from rfl,
+      smul_mul_assoc, hPPinv]
+  have hPinvm_eq :
+      (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) =
+        (Real.sqrt c.re : ℂ)⁻¹ • Vᴴ := by
+    calc
+      (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)
+          = 1 * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) :=
+              (Matrix.one_mul _).symm
+      _ = (Vᴴ * V) * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) := by rw [hVHV]
+      _ = Vᴴ * (V * (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ)) := by
+            rw [Matrix.mul_assoc]
+      _ = Vᴴ * ((Real.sqrt c.re : ℂ)⁻¹ • (1 : Matrix n n ℂ)) := by
+            rw [hVPinv]
+      _ = (Real.sqrt c.re : ℂ)⁻¹ • Vᴴ := by
+            rw [mul_smul_comm, Matrix.mul_one]
+  refine ⟨⟨V, hV_mem⟩, fun M ↦ ?_⟩
+  change f M = V * M * Vᴴ
+  rw [show f M = (↑P : Matrix n n ℂ) * M *
+      (↑(P⁻¹ : GL n ℂ) : Matrix n n ℂ) from hP M,
+    hPm_eq, hPinvm_eq, smul_mul_assoc, mul_smul_comm, smul_mul_assoc, smul_smul,
+    inv_mul_cancel₀ hr_ne, one_smul]
+
+section PairedBlocks
+
+variable {I J : Type*} [Finite I] [DecidableEq I] [Finite J] [DecidableEq J]
+variable {d : I → ℕ} {e : J → ℕ}
+variable [∀ i, NeZero (d i)] [∀ j, NeZero (e j)]
+
+noncomputable local instance sourceMatrix_isSimpleRing (i : I) :
+    IsSimpleRing (Matrix (Fin (d i)) (Fin (d i)) ℂ) := by
+  have : Nonempty (Fin (d i)) := Fin.pos_iff_nonempty.mp (NeZero.pos (d i))
+  exact IsSimpleRing.matrix (Fin (d i)) ℂ
+
+noncomputable local instance targetMatrix_isSimpleRing (j : J) :
+    IsSimpleRing (Matrix (Fin (e j)) (Fin (e j)) ℂ) := by
+  have : Nonempty (Fin (e j)) := Fin.pos_iff_nonempty.mp (NeZero.pos (e j))
+  exact IsSimpleRing.matrix (Fin (e j)) ℂ
+
+/-- The star-algebra equivalence obtained by restricting a product equivalence
+to a supplied pair of simple matrix summands.
+
+The supplied pairing is the relabeling fixed in arXiv:1606.00608,
+Appendix C.4, line 1997. -/
+noncomputable def blockComponentStarAlgEquiv
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) ≃⋆ₐ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (sigma : I ≃ J)
+    (hsigma : ∀ i, T.toRingEquiv.mapTwoSidedIdeal
+      (blockIdeal (fun k ↦ Matrix (Fin (d k)) (Fin (d k)) ℂ) i) =
+        blockIdeal (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (sigma i))
+    (i : I) :
+    Matrix (Fin (d i)) (Fin (d i)) ℂ ≃⋆ₐ[ℂ]
+      Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ := by
+  classical
+  let phi : Matrix (Fin (d i)) (Fin (d i)) ℂ →⋆ₙₐ[ℂ]
+      Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ :=
+    { toFun := fun M ↦ T (Pi.single i M) (sigma i)
+      map_zero' := by simp only [Pi.single_zero, map_zero, Pi.zero_apply]
+      map_add' := by
+        intro M N
+        simp only [Pi.single_add, map_add, Pi.add_apply]
+      map_mul' := by
+        intro M N
+        simp only [Pi.single_mul, map_mul, Pi.mul_apply]
+      map_smul' := by
+        intro c M
+        simp only [Pi.single_smul, map_smul, Pi.smul_apply, MonoidHom.id_apply]
+      map_star' := by
+        intro M
+        rw [Pi.single_star, map_star, Pi.star_apply] }
+  exact StarAlgEquiv.ofBijective phi
+    (blockComponentMap_bijective T.toRingEquiv sigma hsigma i)
+
+/-- Reindexing both matrix indices along the same equivalence is a
+star-algebra equivalence. -/
+noncomputable def matrixReindexStarAlgEquiv
+    {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+    (p : m ≃ n) : Matrix m m ℂ ≃⋆ₐ[ℂ] Matrix n n ℂ :=
+  StarAlgEquiv.ofAlgEquiv (Matrix.reindexAlgEquiv ℂ ℂ p) fun M ↦ by
+    change Matrix.reindex p p (star M) = star (Matrix.reindex p p M)
+    rw [Matrix.star_eq_conjTranspose, Matrix.star_eq_conjTranspose,
+      Matrix.conjTranspose_reindex]
+
+/-- The restriction of a product star-algebra equivalence to each supplied
+pair of equally sized simple matrix summands is implemented by a unitary.
+
+This is the unitary implementation step in arXiv:1606.00608,
+Appendix C.4, line 1997. The statement retains the supplied summand pairing
+and dimension equalities rather than selecting new witnesses. -/
+theorem exists_unitary_block_implementers_of_starAlgEquiv_pi_matrix
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) ≃⋆ₐ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (sigma : I ≃ J)
+    (hsigma : ∀ i, T.toRingEquiv.mapTwoSidedIdeal
+      (blockIdeal (fun k ↦ Matrix (Fin (d k)) (Fin (d k)) ℂ) i) =
+        blockIdeal (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (sigma i))
+    (hDim : ∀ i, d i = e (sigma i)) :
+    ∃ U : ∀ i, Matrix.unitaryGroup (Fin (e (sigma i))) ℂ,
+      ∀ (i : I) (M : Matrix (Fin (d i)) (Fin (d i)) ℂ),
+        T (Pi.single i M) (sigma i) =
+          (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M *
+              (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ := by
+  classical
+  have hImplementer (i : I) :
+      ∃ U : Matrix.unitaryGroup (Fin (e (sigma i))) ℂ,
+        ∀ M : Matrix (Fin (d i)) (Fin (d i)) ℂ,
+          T (Pi.single i M) (sigma i) =
+            (U : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M *
+                (U : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ := by
+    let reindexEquiv := matrixReindexStarAlgEquiv (finCongr (hDim i))
+    let componentEquiv := blockComponentStarAlgEquiv T sigma hsigma i
+    let automorphism := reindexEquiv.symm.trans componentEquiv
+    obtain ⟨U, hU⟩ := exists_unitary_conj_of_starAlgEquiv_matrix automorphism
+    refine ⟨U, fun M ↦ ?_⟩
+    change componentEquiv M =
+      (U : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+        reindexEquiv M *
+          (U : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ
+    have hComponent : componentEquiv M = automorphism (reindexEquiv M) := by
+      simp only [automorphism, StarAlgEquiv.trans_apply, StarAlgEquiv.symm_apply_apply]
+    rw [hComponent, hU]
+  exact ⟨fun i ↦ (hImplementer i).choose,
+    fun i ↦ (hImplementer i).choose_spec⟩
+
+end PairedBlocks
+
+end MPSTensor

--- a/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.BlockPermutation
+import TNLean.Algebra.SkolemNoetherUnitary
 import TNLean.Channel.FixedPoint.DirectSumInverseKraus
 
 import Mathlib.RingTheory.SimpleRing.Matrix
@@ -89,6 +90,34 @@ theorem exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix
   simp only [Module.finrank_self, Fintype.card_fin, mul_one] at hfinrank
   exact Nat.mul_self_inj.mp hfinrank
 
+/-- A star-algebra equivalence between finite products of nonzero full matrix
+algebras acts by unitary conjugation inside the simple summands selected by its
+block-ideal matching.
+
+This is the blockwise-unitary portion of arXiv:1606.00608, Appendix C.4,
+line 1997, following Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8,
+source lines 322--324. The companion formula for the inverse map is not
+asserted here. -/
+theorem exists_blockEquiv_dim_eq_unitary_of_starAlgEquiv_pi_matrix
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) ≃⋆ₐ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ)) :
+    ∃ sigma : ι ≃ κ, ∃ hDim : ∀ i, d i = e (sigma i),
+      (∀ i, T.toRingEquiv.mapTwoSidedIdeal
+        (MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (d k)) (Fin (d k)) ℂ) i) =
+          MPSTensor.blockIdeal
+            (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (sigma i)) ∧
+      ∃ U : ∀ i, Matrix.unitaryGroup (Fin (e (sigma i))) ℂ,
+        ∀ (i : ι) (M : Matrix (Fin (d i)) (Fin (d i)) ℂ),
+          T (Pi.single i M) (sigma i) =
+            (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M *
+                (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ := by
+  obtain ⟨sigma, hsigma, hDim⟩ :=
+    exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix T
+  exact ⟨sigma, hDim, hsigma,
+    MPSTensor.exists_unitary_block_implementers_of_starAlgEquiv_pi_matrix
+      T sigma hsigma hDim⟩
+
 /-- Mutually inverse completely positive trace-preserving maps between two
 finite products of nonzero full matrix algebras match their simple summands
 and the corresponding matrix dimensions.
@@ -117,6 +146,38 @@ theorem exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps
           MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (σ i)) ∧
       ∀ i, d i = e (σ i) := by
   exact exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix
+    (directSumTraceAdjointStarAlgEquiv T S hT hS hTTP hSTP hST hTS).symm
+
+/-- The trace-adjoint star-algebra equivalence associated with mutually inverse
+completely positive trace-preserving maps acts by unitary conjugation on its
+matched simple matrix summands.
+
+This is the algebraic blockwise-unitary step in arXiv:1606.00608,
+Appendix C.4, line 1997. It does not specialize the formula to transported
+MPDO sectors or assert the later multiplicity and coefficient relations. -/
+theorem exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps
+    [Fintype ι] [Fintype κ]
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ))
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id) :
+    let E := (directSumTraceAdjointStarAlgEquiv T S hT hS hTTP hSTP hST hTS).symm
+    ∃ sigma : ι ≃ κ, ∃ hDim : ∀ i, d i = e (sigma i),
+      (∀ i, E.toRingEquiv.mapTwoSidedIdeal
+        (MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (d k)) (Fin (d k)) ℂ) i) =
+          MPSTensor.blockIdeal
+            (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (sigma i)) ∧
+      ∃ U : ∀ i, Matrix.unitaryGroup (Fin (e (sigma i))) ℂ,
+        ∀ (i : ι) (M : Matrix (Fin (d i)) (Fin (d i)) ℂ),
+          E (Pi.single i M) (sigma i) =
+            (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M *
+                (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ := by
+  exact exists_blockEquiv_dim_eq_unitary_of_starAlgEquiv_pi_matrix
     (directSumTraceAdjointStarAlgEquiv T S hT hS hTTP hSTP hST hTS).symm
 
 end Matrix

--- a/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
@@ -21,7 +21,9 @@ This is the sector-relabeling and dimension-matching part of
 arXiv:1606.00608, Appendix C.4, line 1997. The cited proof in
 Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8, source lines 322--324, first
 permutes summands of equal matrix dimension and only then identifies the map
-inside each summand. Unitary implementation is not proved here.
+inside each summand. The present file proves the resulting blockwise-unitary
+formula for the star-algebra equivalence. The companion inverse formula and
+the transported MPDO specialization are not asserted here.
 -/
 
 open scoped Matrix

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2854,7 +2854,6 @@ outside the present result.
     \label{thm:unitary_skolem_noether_matrix}
     \lean{MPSTensor.exists_unitary_conj_of_starAlgEquiv_matrix}
     \leanok
-    \uses{thm:skolem_noether}
     Every star-algebra automorphism $\Phi$ of a nonzero full complex matrix
     algebra is implemented by a unitary: there is a unitary matrix $U$ such
     that
@@ -2865,6 +2864,7 @@ outside the present result.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:skolem_noether}
     By Skolem--Noether, there is an invertible matrix $P$ such that
     $\Phi(X)=PXP^{-1}$.  Preservation of the adjoint implies that $P^*P$
     commutes with every matrix, hence $P^*P=c\Id$ for a scalar $c$.  Positivity
@@ -2880,9 +2880,6 @@ outside the present result.
     \lean{Matrix.exists_blockEquiv_dim_eq_unitary_of_starAlgEquiv_pi_matrix}
     \lean{Matrix.exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps}
     \leanok
-    \uses{thm:unitary_skolem_noether_matrix,
-        thm:direct_sum_inverse_cptp_star_equiv,
-        thm:direct_sum_inverse_cptp_block_matching}
     Retain an equivalence $\sigma:I\simeq J$ which matches the block ideals
     of a star-algebra isomorphism
     \[
@@ -2905,6 +2902,9 @@ outside the present result.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:unitary_skolem_noether_matrix,
+        thm:direct_sum_inverse_cptp_star_equiv,
+        thm:direct_sum_inverse_cptp_block_matching}
     The restriction of $\Phi$ to a matched block is a star-algebra
     isomorphism.  After reindexing by $D_i=E_{\sigma(i)}$, it is an
     automorphism of a full complex matrix algebra.  Skolem--Noether writes

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2850,13 +2850,38 @@ outside the present result.
     $D_i=E_{\sigma(i)}$.
 \end{proof}
 
+\begin{theorem}[Unitary Skolem--Noether theorem for complex matrices]%
+    \label{thm:unitary_skolem_noether_matrix}
+    \lean{MPSTensor.exists_unitary_conj_of_starAlgEquiv_matrix}
+    \leanok
+    \uses{thm:skolem_noether}
+    Every star-algebra automorphism $\Phi$ of a nonzero full complex matrix
+    algebra is implemented by a unitary: there is a unitary matrix $U$ such
+    that
+    \[
+        \Phi(X)=UXU^*
+    \]
+    for every matrix $X$.
+\end{theorem}
+
+\begin{proof}\leanok
+    By Skolem--Noether, there is an invertible matrix $P$ such that
+    $\Phi(X)=PXP^{-1}$.  Preservation of the adjoint implies that $P^*P$
+    commutes with every matrix, hence $P^*P=c\Id$ for a scalar $c$.  Positivity
+    and invertibility give $c>0$.  Therefore $U=c^{-1/2}P$ is unitary and
+    implements the same automorphism.
+\end{proof}
+
 \begin{theorem}[Unitary action within matched simple summands]%
     \label{thm:direct_sum_star_equiv_block_unitary}
+    \lean{MPSTensor.blockComponentStarAlgEquiv}
+    \lean{MPSTensor.matrixReindexStarAlgEquiv}
     \lean{MPSTensor.exists_unitary_block_implementers_of_starAlgEquiv_pi_matrix}
     \lean{Matrix.exists_blockEquiv_dim_eq_unitary_of_starAlgEquiv_pi_matrix}
     \lean{Matrix.exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps}
     \leanok
-    \uses{thm:direct_sum_inverse_cptp_star_equiv,
+    \uses{thm:unitary_skolem_noether_matrix,
+        thm:direct_sum_inverse_cptp_star_equiv,
         thm:direct_sum_inverse_cptp_block_matching}
     Retain an equivalence $\sigma:I\simeq J$ which matches the block ideals
     of a star-algebra isomorphism

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2850,6 +2850,45 @@ outside the present result.
     $D_i=E_{\sigma(i)}$.
 \end{proof}
 
+\begin{theorem}[Unitary action within matched simple summands]%
+    \label{thm:direct_sum_star_equiv_block_unitary}
+    \lean{MPSTensor.exists_unitary_block_implementers_of_starAlgEquiv_pi_matrix}
+    \lean{Matrix.exists_blockEquiv_dim_eq_unitary_of_starAlgEquiv_pi_matrix}
+    \lean{Matrix.exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps}
+    \leanok
+    \uses{thm:direct_sum_inverse_cptp_star_equiv,
+        thm:direct_sum_inverse_cptp_block_matching}
+    Retain an equivalence $\sigma:I\simeq J$ which matches the block ideals
+    of a star-algebra isomorphism
+    \[
+        \Phi:\prod_{i\in I}M_{D_i}(\C)
+        \simeq \prod_{j\in J}M_{E_j}(\C),
+    \]
+    together with equalities $D_i=E_{\sigma(i)}$.  Then there are unitaries
+    $U_i\in M_{E_{\sigma(i)}}(\C)$ such that
+    \[
+        \Phi(0,\ldots,0,X,0,\ldots,0)_{\sigma(i)}
+        =U_i\,\iota_i(X)\,U_i^*
+    \]
+    for every $X\in M_{D_i}(\C)$, where $\iota_i$ is the reindexing induced
+    by the retained dimension equality.  In particular, this conclusion
+    applies to the trace-adjoint star-algebra isomorphism of any mutually
+    inverse completely positive trace-preserving pair.  This is the
+    blockwise-unitary statement in
+    \cite[Appendix~C.4, line~1997]{Cirac2016MPDO_arXiv}; it does not assert
+    the later MPDO multiplicity or coefficient relations.
+\end{theorem}
+
+\begin{proof}\leanok
+    The restriction of $\Phi$ to a matched block is a star-algebra
+    isomorphism.  After reindexing by $D_i=E_{\sigma(i)}$, it is an
+    automorphism of a full complex matrix algebra.  Skolem--Noether writes
+    this automorphism as conjugation by an invertible matrix $P$.  Preservation
+    of the adjoint implies that $P^*P$ commutes with every matrix and is
+    therefore a positive scalar multiple of the identity.  Dividing $P$ by
+    the positive square root of this scalar produces the required unitary.
+\end{proof}
+
 % Scope restriction documented in
 % docs/paper-gaps/wolf_theorem6_14_fixed_point_projection_gap.tex.
 \begin{theorem}[Weighted block form of the adjoint Ces\`aro projection on full support]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2904,7 +2904,7 @@ outside the present result.
 \begin{proof}\leanok
     \uses{thm:unitary_skolem_noether_matrix,
         thm:direct_sum_inverse_cptp_star_equiv,
-        thm:direct_sum_inverse_cptp_block_matching}
+        thm:dim_preserved}
     The restriction of $\Phi$ to a matched block is a star-algebra
     isomorphism.  After reindexing by $D_i=E_{\sigma(i)}$, it is an
     automorphism of a full complex matrix algebra.  Skolem--Noether writes

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -309,13 +309,22 @@ restriction to each paired block is a bijective complex-linear map
 and comparison of dimensions gives $d_i=e_{\sigma(i)}$.
 Applying this result to the trace-adjoint $*$-algebra isomorphism proves both
 this block-ideal matching relation and the dimension equality for every
-mutually inverse CPTP pair.\footnote{Formal
+mutually inverse CPTP pair.  The second conclusion is now proved while
+retaining these particular witnesses.  The restriction to a paired block is
+a $*$-algebra isomorphism; after reindexing by the retained dimension
+equality, Skolem--Noether gives an invertible implementer $P$.  Preservation
+of the adjoint forces $P^*P$ to be a positive scalar matrix, and normalization
+therefore gives a unitary implementer on the actual target block.\footnote{Formal
 declarations:
 \leanid{MPSTensor.exists_blockEquiv_of_ringEquiv_pi_simple} in
 \doclink{TNLean/Algebra/BlockPermutation};
+\leanid{MPSTensor.exists_unitary_conj_of_starAlgEquiv_matrix} and
+\leanid{MPSTensor.%
+exists_unitary_block_implementers_of_starAlgEquiv_pi_matrix} in
+\doclink{TNLean/Algebra/SkolemNoetherUnitary};
 \leanid{Matrix.exists_blockEquiv_dim_eq_of_starAlgEquiv_pi_matrix} and
 \leanid{Matrix.%
-exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps} in
+exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps} in
 \doclink{TNLean/Channel/FixedPoint/DirectSumBlockPermutation}.}
 
 \section{Elimination plan}
@@ -331,29 +340,30 @@ The first two steps of the Appendix~C.4 argument are complete:
           product-generation theorem, and gives both identity compositions;
 \end{enumerate}
 The inverse-UCP multiplicative-domain step is also complete: the rectangular
-trace adjoints form mutually inverse $*$-algebra equivalences.  The remaining
-generic simple-summand correspondence is now complete as well: it gives an
-equivalence of the sector index sets, identifies the actual block ideals
-carried into one another by the star-algebra isomorphism, and proves equality
-of the paired matrix dimensions.  It remains to identify each paired
-component map with unitary conjugation and then specialize the resulting
-formula to the transported vertical-sector maps.
+trace adjoints form mutually inverse $*$-algebra equivalences.  The generic
+simple-summand correspondence and its internal unitary action are complete as
+well: they give an equivalence of the sector index sets, identify the actual
+block ideals carried into one another, prove equality of the paired matrix
+dimensions, and implement every retained paired component by unitary
+conjugation.  It remains to specialize this formula to the transported
+vertical-sector maps.
 
 \section{Classification}
 
 \textbf{Verdict: transported-map invertibility, the inverse-UCP
-multiplicative-domain step, and generic simple-summand matching are closed;
-unitary implementation remains open.}  The two transported maps and their
+multiplicative-domain step, generic simple-summand matching, and generic
+unitary implementation are closed; the transported-sector specialization
+remains open.}  The two transported maps and their
 square composites are trace preserving under the source tensor hypotheses.
 Their two compositions are identities, and the rectangular trace adjoints
 form mutually inverse $*$-algebra equivalences.  For any such pair, the simple
 summands are matched by an equivalence of the index sets, the corresponding
 block ideals are carried into one another by the star-algebra isomorphism,
-and the paired matrix dimensions are equal.  The stronger active-image
-inclusions remain unproved and are not needed for this route.  The blockwise
-unitary-conjugation formula and its specialization to the transported
-vertical-sector maps remain to be proved before the conclusion of
-Appendix~C.4, line~1997 is complete.
+the paired matrix dimensions are equal, and the induced map on each matched
+summand is unitary conjugation.  The stronger active-image inclusions remain
+unproved and are not needed for this route.  Specializing the generic unitary
+formula to the transported vertical-sector maps remains necessary before the
+conclusion of Appendix~C.4, line~1997 is complete.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- prove the unitary form of Skolem--Noether for nonzero full complex matrix algebras;
- restrict a product star-algebra equivalence to the simple summands selected by a supplied block pairing and dimension equality;
- obtain unitary implementers on those exact target blocks, with wrappers for the existing block-matching theorem and for mutually inverse completely positive trace-preserving maps;
- synchronize the Chapter 7 blueprint and the vertical-sector paper-gap record.

## Mathematical scope

This is the blockwise-unitary step in CPSV16, arXiv:1606.00608, Appendix C.4, line 1997, following Wolf--Pérez-García, arXiv:1005.4545, Theorem 8. The supplied equivalence of block labels and the supplied dimension witnesses are retained throughout; the proof does not choose a second pairing.

The PR does not specialize the formula to the transported MPDO sectors and does not assert the later multiplicity, weight, or coefficient relations. Those parts of Appendix C.4 remain open under LionSR/QICLean#247.

Closes LionSR/TNLean#4574.

## Validation

- focused Lean checks for `TNLean.Algebra.SkolemNoetherUnitary` and `TNLean.Channel.FixedPoint.DirectSumBlockPermutation`;
- full `lake build` on the patch before the conflict-free rebase (9,643 jobs);
- stable patch identifiers verified across the rebase onto current `main`;
- blueprint synchronization and reverse-coverage checks, with no changed declaration missing a blueprint entry;
- reader-facing prose and `git diff --check`;
- independent exact-head mathematical and source-faithfulness review with no findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation; no runtime, auth, or data paths. Risk is mainly proof maintenance and API surface in the Lean library.
> 
> **Overview**
> Adds **`TNLean.Algebra.SkolemNoetherUnitary`**, proving that every star-algebra automorphism of a nonzero full complex matrix algebra is **unitary conjugation** (building on inner Skolem–Noether and rescaling the implementer), and that a product star-algebra equivalence acts by unitaries on each **supplied** matched block after reindexing.
> 
> **`DirectSumBlockPermutation`** gains unitary strengthenings of the existing block-matching theorems, including for the trace-adjoint star-algebra equivalence of mutually inverse CPTP Kraus direct-sum maps. Module docs and the older dimension-only theorem note are updated to reflect that blockwise unitary action is now proved here (MPDO transport and inverse formulas still out of scope).
> 
> **`TNLean.lean`** exports the new algebra module; **Chapter 7 blueprint** and **`cpsv16_vertical_sector_invertibility.tex`** record the closed generic unitary step and what remains (transported vertical-sector specialization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d4595652551cdda062b1b3dc96a0683d42ae2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->