### PR TITLE
fix(tenkz): address gate post-merge review

### DIFF
--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -496,7 +496,7 @@ not hand-maintained prose — the two drift out of step otherwise.
 |---|---|---|
 | `grid` | `atom`, `bond`, `faceports`, `pairleg`, `hole`, `cup`, `boundary`, `phtrace`, `pairtrace`, `trace`, `hooks` | `tenkz-grid.code.tex` |
 | `free` | `atom`, `join` | `tenkz-free.code.tex` |
-| `lattice` | `lattice`, `site`, `region`, `edge`, `pairtrace`, `boundary` | `tenkz-lattice.code.tex` |
+| `lattice` | `lattice`, `site`, `region`, `edge`, `cup`, `trace`, `pairtrace`, `boundary` | `tenkz-lattice.code.tex` |
 | `cd` | `cdcell`, `cdobject`, `cdmap`, `cdarrow`, `tree` | `tenkz-cd.code.tex` |
 
 Notes against the previous (wrong) table: grid never emits `leg`, `fuse`,

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -108,8 +108,8 @@ DIALECT_KINDS = {
     "grid": {"atom", "bond", "faceports", "pairleg", "trace", "pairtrace",
              "phtrace", "hooks", "cup", "hole", "warning", "boundary"},
     "free": {"atom", "join"},
-    "lattice": {"lattice", "site", "region", "edge", "pairtrace",
-                "boundary", "warning"},
+    "lattice": {"lattice", "site", "region", "edge", "cup", "trace",
+                "pairtrace", "boundary", "warning"},
     "cd": {"cdcell", "cdobject", "cdarrow", "cdmap", "tree"},
 }
 

--- a/scripts/test_tenkz_face_ports.py
+++ b/scripts/test_tenkz_face_ports.py
@@ -176,6 +176,21 @@ SOURCE = r"""
   }
 \cs_new_protected:Npn \tenkzPairtraceObstacleProbe
   { \bool_gset_true:N \g__tenkzl_test_pairtrace_obstacle_bool }
+\bool_new:N \g__tenkz_test_none_face_label_bool
+\cs_new_protected:Npn \tenkzNoneFaceLabelProbe
+  { \bool_gset_true:N \g__tenkz_test_none_face_label_bool }
+\cs_new_protected:Npn \tenkzNoneFaceLabelAssert
+  {
+    \bool_if:NT \g__tenkz_test_none_face_label_bool
+      { \tex_errmessage:D { none~face~dropped~external~label~clearance } }
+  }
+\cs_new_eq:NN \__tenkz_test_sil_band: \tenkz_sil_band:
+\cs_set_protected:Npn \tenkz_sil_band:
+  {
+    \bool_if:NT \g__tenkz_test_none_face_label_bool
+      { \bool_gset_false:N \g__tenkz_test_none_face_label_bool }
+    \__tenkz_test_sil_band:
+  }
 \cs_new_eq:NN \__tenkzl_test_pairtrace:nnn \tenkzl_pairtrace:nnn
 \cs_set_protected:Npn \tenkzl_pairtrace:nnn #1#2#3
   {
@@ -840,6 +855,13 @@ SOURCE = r"""
   \tenkzRoutingBasisProbe
   \tnsite[removed]{(1,2,0)}
 \end{tenkzlattice}
+% An absent upper face suppresses only the leg.  Its north external bead
+% label remains ink and must still reserve the ordinary label band.
+\tenkzNoneFaceLabelProbe
+\begin{tenkz}[physical=up]
+  \tn[dot, up at=none, label pos=north]{A}\tnspan[brace above]{1}{probe}
+\end{tenkz}
+\tenkzNoneFaceLabelAssert
 \end{document}
 """
 
@@ -934,6 +956,10 @@ def main() -> int:
         pairleg_faceport_findings = [
             finding for finding in audit.findings
             if finding.rule == "pairleg-faceport-mismatch"
+        ]
+        dialect_findings = [
+            finding for finding in audit.findings
+            if finding.rule == "dialect-mismatch"
         ]
         topology_hashes = {
             picture.ident: canonical_hash(picture) for picture in audit.pictures
@@ -1185,6 +1211,11 @@ def main() -> int:
         raise AssertionError("audit rejected a grid hooks event")
     if pairleg_faceport_findings:
         raise AssertionError("audit rejected a rendered pairleg declared by its upper face")
+    if dialect_findings:
+        raise AssertionError(
+            "audit rejected an emitted event in its declared dialect: "
+            f"{[finding.msg for finding in dialect_findings]!r}"
+        )
     inverse = pictures[1]
     require(
         inverse,

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -3609,7 +3609,7 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
     \tenkz_get:NeN \l__tenkz_opts_prop {#1-#2} \l__tenkz_silq_tl
     \exp_args:NV \tenkz_cell_opts:n \l__tenkz_silq_tl
     % cell-level physical= faces of a wires=k brick
-    \tenkz_sil_brick:nn {#1}{#3}
+    \tenkz_sil_brick:n {#3}
     % row-typed legs and wrap loops.  `#3 at=none' draws no leg (the
     % leg pass's own gate, \tenkz_leg_open:nnn); the silhouette must
     % read the same resolved face so clearance and ink cannot drift --
@@ -3654,18 +3654,14 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
               { \tenkz_auto_quadrant:nN {#1} \l__tenkz_silq_tl }
               { \tl_set:Ne \l__tenkz_silq_tl
                   { \tenkz_compass:V \l__tenkz_clpos_tl } }
-            % re-resolve: the quadrant/compass calls above may have
-            % reused the shared scratch tl.  A `none' face has no leg
-            % to widen the label past, so it takes the plain band.
-            \tenkz_face_ports:nN {#3} \l__tenkz_faceports_tl
-            \str_if_eq:VnF \l__tenkz_faceports_tl {none}
-              {
-                \str_if_eq:nnTF {#3} {up}
-                  { \str_if_in:NnT \l__tenkz_silq_tl {north}
-                      { \tenkz_sil_band: } }
-                  { \str_if_in:NnT \l__tenkz_silq_tl {south}
-                      { \tenkz_sil_band: } }
-              }
+            % The external bead label is ink even when the queried face
+            % resolves to `none'.  Only leg clearance follows face ports;
+            % the label always contributes its plain band on its own side.
+            \str_if_eq:nnTF {#3} {up}
+              { \str_if_in:NnT \l__tenkz_silq_tl {north}
+                  { \tenkz_sil_band: } }
+              { \str_if_in:NnT \l__tenkz_silq_tl {south}
+                  { \tenkz_sil_band: } }
           }
       }
   }
@@ -3681,13 +3677,13 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
 % ink-and-clearance-cannot-drift-apart contract).  A brick's implicit,
 % row-typed leg is priced by the ordinary open/paired branch below this
 % call, exactly as for a wires=1 cell.
-\cs_new_protected:Npn \tenkz_sil_brick:nn #1#2
+\cs_new_protected:Npn \tenkz_sil_brick:n #1
   {
     \int_compare:nNnT { \l__tenkz_cwires_int } > {1}
       {
         \tl_if_empty:NF \l__tenkz_cphys_tl
           {
-            \str_if_eq:nnTF {#2} {up}
+            \str_if_eq:nnTF {#1} {up}
               { \bool_lazy_or:nnT
                   { \str_if_eq_p:Vn \l__tenkz_cphys_tl {up} }
                   { \str_if_eq_p:Vn \l__tenkz_cphys_tl {updown} }
@@ -3723,7 +3719,7 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
         \tenkz_get:NeN \l__tenkz_opts_prop
           { \int_use:N \l__tenkz_silr_int - #2 } \l__tenkz_silq_tl
         \exp_args:NV \tenkz_cell_opts:n \l__tenkz_silq_tl
-        \tenkz_sil_brick:nn { \int_use:N \l__tenkz_silr_int } {#3}
+        \tenkz_sil_brick:n {#3}
       }
   }
 


### PR DESCRIPTION
Follow-up to #4561 for three exact-head review findings that arrived as the gate PR merged.

- keep external bead-label clearance independent of a `none` physical face, with a real upper-silhouette regression fixture
- remove the unused row argument from the brick silhouette helper
- admit emitted lattice `cup` and `trace` events in the audit dialect and document the contract

Validation:
- `git diff --check`
- tenkz source lint (115 files)
- `test_tenkz_pic.py`
- `test_tenkz_cd_map_labels.py`
- `test_tenkz_face_ports.py` (twice)
- `test_tenkz_index_routing.py`
- `test_tenkz_tree.py`
- exact `tn_diagrams.py` check/audit/smoke-render gate
- two-pass manual build plus `tenkz_audit.py manual2.tnlog`
- all tenkz acceptance examples compile and audit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted silhouette and audit-metadata alignment with a dedicated regression; no auth, data, or broad API surface changes.
> 
> **Overview**
> Follow-up fixes **silhouette clearance**, **audit dialect tables**, and **regression coverage** after the gate merge.
> 
> **External labels vs `none` faces:** In the grid silhouette resolver, a north/south **external bead label** now always contributes its ordinary label band when `label pos` places it on that side, even if the queried physical face is `up at=none` (no leg). Leg clearance still follows resolved face ports; only label band logic changed. A compile-time probe in `test_tenkz_face_ports.py` locks this (`up at=none` + `label pos=north` + span brace).
> 
> **Brick silhouette helper:** `\tenkz_sil_brick` drops an unused row argument (`:nn` → `:n`); call sites pass only the face (`up`/`down`).
> 
> **Lattice `.tnlog` contract:** `DESIGN.md` §5.1 and `scripts/tenkz_audit.py` `DIALECT_KINDS` now list lattice **`cup`** and **`trace`** (emitted by `tenkz-lattice.code.tex`), so audits no longer flag real lattice closures as `dialect-mismatch`. The face-ports test fails if any such advisory appears on the fixture log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8453a57da9fc9579e3e91f3959c10b8f3d8f34f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->