### PR TITLE
feat(MPS/MPDO): classify transported vertical sectors by unitaries

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -484,6 +484,7 @@ import TNLean.MPS.MPDO.VerticalSectorTracePreservation
 import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.VerticalSectorIdentity
+import TNLean.MPS.MPDO.VerticalSectorRelabeling
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumBlockPermutation.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.BlockPermutation
 import TNLean.Algebra.SkolemNoetherUnitary
+import TNLean.Algebra.TraceReindex
 import TNLean.Channel.FixedPoint.DirectSumInverseKraus
 
 import Mathlib.RingTheory.SimpleRing.Matrix
@@ -22,8 +23,9 @@ arXiv:1606.00608, Appendix C.4, line 1997. The cited proof in
 Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8, source lines 322--324, first
 permutes summands of equal matrix dimension and only then identifies the map
 inside each summand. The present file proves the resulting blockwise-unitary
-formula for the star-algebra equivalence. The companion inverse formula and
-the transported MPDO specialization are not asserted here.
+formula first for the trace-adjoint star-algebra equivalence and then for the
+original mutually inverse maps. The transported MPDO specialization is stated
+separately.
 -/
 
 open scoped Matrix
@@ -120,6 +122,66 @@ theorem exists_blockEquiv_dim_eq_unitary_of_starAlgEquiv_pi_matrix
     MPSTensor.exists_unitary_block_implementers_of_starAlgEquiv_pi_matrix
       T sigma hsigma hDim⟩
 
+/-- A star-algebra equivalence whose action on its matched simple summands is
+implemented by unitaries preserves the sum of the block traces.
+
+This is the trace-preservation calculation implicit in the unitary formula of
+CPSV16, arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem isTracePreservingBetweenDirectSums_of_unitary_block_implementers
+    [Fintype ι] [Fintype κ]
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) ≃⋆ₐ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (sigma : ι ≃ κ)
+    (hsigma : ∀ i, T.toRingEquiv.mapTwoSidedIdeal
+      (MPSTensor.blockIdeal (fun k ↦ Matrix (Fin (d k)) (Fin (d k)) ℂ) i) =
+        MPSTensor.blockIdeal
+          (fun k ↦ Matrix (Fin (e k)) (Fin (e k)) ℂ) (sigma i))
+    (hDim : ∀ i, d i = e (sigma i))
+    (U : ∀ i, Matrix.unitaryGroup (Fin (e (sigma i))) ℂ)
+    (hU : ∀ (i : ι) (M : Matrix (Fin (d i)) (Fin (d i)) ℂ),
+      T (Pi.single i M) (sigma i) =
+        (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M *
+            (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ) :
+    IsTracePreservingBetweenDirectSums T.toAlgEquiv.toLinearEquiv.toLinearMap := by
+  classical
+  have hSingle (i : ι) (M : Matrix (Fin (d i)) (Fin (d i)) ℂ) :
+      ∑ j, (T (Pi.single i M) j).trace = M.trace := by
+    rw [Finset.sum_eq_single (sigma i)]
+    · let V : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ := U i
+      let R : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ :=
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M
+      rw [show T (Pi.single i M) (sigma i) = V * R * Vᴴ from hU i M]
+      have hUnitary : Vᴴ * V = 1 := by
+        simpa only [Matrix.star_eq_conjTranspose] using
+          (Matrix.mem_unitaryGroup_iff'.mp (U i).property)
+      calc
+        (V * R * Vᴴ).trace = R.trace := by
+          rw [Matrix.trace_mul_comm, ← Matrix.mul_assoc, hUnitary, Matrix.one_mul]
+        _ = M.trace := Matrix.trace_reindex (finCongr (hDim i)) M
+    · intro j _ hj
+      have hzero : T (Pi.single i M) j = 0 := by
+        exact MPSTensor.ringEquiv_maps_single_support_between
+          T.toRingEquiv sigma hsigma M j hj
+      rw [hzero, Matrix.trace_zero]
+    · intro hnot
+      exact (hnot (Finset.mem_univ _)).elim
+  intro X
+  calc
+    ∑ j, (T X j).trace =
+        ∑ j, (T (∑ i, Pi.single i (X i)) j).trace := by
+      rw [Finset.univ_sum_single]
+    _ = ∑ j, ((∑ i, T (Pi.single i (X i))) j).trace := by
+      rw [map_sum]
+    _ = ∑ j, ∑ i, (T (Pi.single i (X i)) j).trace := by
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [Finset.sum_apply, Matrix.trace_sum]
+    _ = ∑ i, ∑ j, (T (Pi.single i (X i)) j).trace :=
+      Finset.sum_comm
+    _ = ∑ i, (X i).trace :=
+      Finset.sum_congr rfl fun i _ ↦ hSingle i (X i)
+
 /-- Mutually inverse completely positive trace-preserving maps between two
 finite products of nonzero full matrix algebras match their simple summands
 and the corresponding matrix dimensions.
@@ -129,8 +191,8 @@ Appendix C.4, line 1997, following Wolf--Perez-Garcia,
 arXiv:1005.4545, Theorem 8, source lines 322--324.
 
 **Scope restriction (simple summands):** This theorem does not construct the
-unitary action within each paired summand. That remaining conclusion is
-documented in `docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex`. -/
+unitary action within each paired summand. The unitary strengthening is stated
+separately below. -/
 theorem exists_blockEquiv_dim_eq_of_mutual_inverse_kraus_direct_sum_maps
     [Fintype ι] [Fintype κ]
     (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
@@ -181,5 +243,116 @@ theorem exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps
                 (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ := by
   exact exists_blockEquiv_dim_eq_unitary_of_starAlgEquiv_pi_matrix
     (directSumTraceAdjointStarAlgEquiv T S hT hS hTTP hSTP hST hTS).symm
+
+/-- Mutually inverse completely positive trace-preserving maps act on paired
+simple matrix summands by conjugation with the same unitaries.
+
+Unlike the trace-adjoint formulation above, this statement gives the formulas
+for both original maps. This is the form used for the transported maps in
+arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem exists_blockEquiv_dim_eq_unitary_forward_of_mutual_inverse_kraus_direct_sum_maps
+    [Fintype ι] [Fintype κ]
+    (T : (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ))
+    (S : (∀ j, Matrix (Fin (e j)) (Fin (e j)) ℂ) →ₗ[ℂ]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ))
+    (hT : IsKrausDirectSumMap T) (hS : IsKrausDirectSumMap S)
+    (hTTP : IsTracePreservingBetweenDirectSums T)
+    (hSTP : IsTracePreservingBetweenDirectSums S)
+    (hST : S.comp T = LinearMap.id) (hTS : T.comp S = LinearMap.id) :
+    ∃ sigma : ι ≃ κ, ∃ hDim : ∀ i, d i = e (sigma i),
+      ∃ U : ∀ i, Matrix.unitaryGroup (Fin (e (sigma i))) ℂ,
+        (∀ (i : ι) (M : Matrix (Fin (d i)) (Fin (d i)) ℂ),
+            T (Pi.single i M) = Pi.single (sigma i)
+              ((U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+                Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M *
+                  (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ)) ∧
+          ∀ (i : ι) (N : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ),
+            S (Pi.single (sigma i) N) = Pi.single i
+              ((Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))).symm
+                ((U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ * N *
+                  (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ))) := by
+  let E := (directSumTraceAdjointStarAlgEquiv
+    T S hT hS hTTP hSTP hST hTS).symm
+  obtain ⟨sigma, hDim, hsigma, U, hU⟩ :=
+    exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps
+      T S hT hS hTTP hSTP hST hTS
+  have hETP : IsTracePreservingBetweenDirectSums
+      E.toAlgEquiv.toLinearEquiv.toLinearMap :=
+    isTracePreservingBetweenDirectSums_of_unitary_block_implementers
+      E sigma hsigma hDim U hU
+  have hElinear : E.toAlgEquiv.toLinearEquiv.toLinearMap =
+      directSumTraceAdjointMapBetween S := by
+    apply LinearMap.ext
+    intro A
+    exact directSumTraceAdjointStarAlgEquiv_symm_apply
+      T S hT hS hTTP hSTP hST hTS A
+  have hEsymm : E.symm.toAlgEquiv.toLinearEquiv.toLinearMap = S := by
+    rw [← directSumTraceAdjointMapBetween_starAlgEquiv_eq_symm E hETP,
+      hElinear, directSumTraceAdjointMapBetween_involutive]
+  have hSinjective : Function.Injective S := by
+    have hLeft : Function.LeftInverse T S := fun X ↦
+      LinearMap.congr_fun hTS X
+    exact hLeft.injective
+  have hEeqT (X : ∀ i, Matrix (Fin (d i)) (Fin (d i)) ℂ) : E X = T X := by
+    apply hSinjective
+    calc
+      S (E X) = E.symm (E X) :=
+        (LinearMap.congr_fun hEsymm (E X)).symm
+      _ = X := E.symm_apply_apply X
+      _ = S (T X) := (LinearMap.congr_fun hST X).symm
+  have hTforward (i : ι) (M : Matrix (Fin (d i)) (Fin (d i)) ℂ) :
+      T (Pi.single i M) = Pi.single (sigma i)
+        ((U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) M *
+            (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ) := by
+    rw [← hEeqT]
+    funext j
+    by_cases hj : j = sigma i
+    · subst j
+      rw [Pi.single_eq_same, hU]
+    · have hzero : E (Pi.single i M) j = 0 := by
+        exact MPSTensor.ringEquiv_maps_single_support_between
+          E.toRingEquiv sigma hsigma M j hj
+      rw [hzero, Pi.single_eq_of_ne hj]
+  have hSinverse (i : ι)
+      (N : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ) :
+      S (Pi.single (sigma i) N) = Pi.single i
+        ((Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))).symm
+          ((U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ * N *
+            (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ))) := by
+    let V : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ := U i
+    let X : Matrix (Fin (d i)) (Fin (d i)) ℂ :=
+      (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))).symm (Vᴴ * N * V)
+    have hVright : V * Vᴴ = 1 := by
+      simpa only [V, Matrix.star_eq_conjTranspose] using
+        (Matrix.mem_unitaryGroup_iff.mp (U i).property)
+    have hEX : E (Pi.single i X) = Pi.single (sigma i) N := by
+      funext j
+      by_cases hj : j = sigma i
+      · subst j
+        rw [Pi.single_eq_same, hU]
+        change V * Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) X * Vᴴ = N
+        rw [show Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) X = Vᴴ * N * V by
+          exact (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))).apply_symm_apply _]
+        calc
+          V * (Vᴴ * N * V) * Vᴴ = (V * Vᴴ) * N * (V * Vᴴ) := by
+            simp only [mul_assoc]
+          _ = N := by rw [hVright, one_mul, mul_one]
+      · have hzero : E (Pi.single i X) j = 0 := by
+          exact MPSTensor.ringEquiv_maps_single_support_between
+            E.toRingEquiv sigma hsigma X j hj
+        rw [hzero, Pi.single_eq_of_ne hj]
+    have hEsm : E.symm (Pi.single (sigma i) N) = Pi.single i X := by
+      rw [← hEX, E.symm_apply_apply]
+    calc
+      S (Pi.single (sigma i) N) = E.symm (Pi.single (sigma i) N) :=
+        (LinearMap.congr_fun hEsymm (Pi.single (sigma i) N)).symm
+      _ = Pi.single i X := hEsm
+      _ = Pi.single i
+          ((Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))).symm
+            ((U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ)ᴴ * N *
+              (U i : Matrix (Fin (e (sigma i))) (Fin (e (sigma i))) ℂ))) := rfl
+  exact ⟨sigma, hDim, U, hTforward, hSinverse⟩
 
 end Matrix

--- a/TNLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumTraceAdjoint.lean
@@ -151,6 +151,65 @@ private theorem eq_of_sum_trace_mul_eq
         simp [Y, hki]
       · simp
 
+omit [(i : ι) → DecidableEq (n i)] [(j : κ) → DecidableEq (m j)] in
+/-- Taking the rectangular trace adjoint twice recovers the original map.
+
+This is the involutivity of the trace pairing used in the classification at
+CPSV16, arXiv:1606.00608, Appendix C.4, line 1997. -/
+theorem directSumTraceAdjointMapBetween_involutive
+    {T : (∀ i, Matrix (n i) (n i) ℂ) →ₗ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ)} :
+    directSumTraceAdjointMapBetween (directSumTraceAdjointMapBetween T) = T := by
+  apply LinearMap.ext
+  intro B
+  apply eq_of_sum_trace_mul_eq
+  intro X
+  calc
+    ∑ j, (directSumTraceAdjointMapBetween
+          (directSumTraceAdjointMapBetween T) B j * X j).trace =
+        ∑ i, (B i * directSumTraceAdjointMapBetween T X i).trace :=
+      sum_trace_directSumTraceAdjointMapBetween_mul
+        (directSumTraceAdjointMapBetween T) B X
+    _ = ∑ i, (directSumTraceAdjointMapBetween T X i * B i).trace := by
+      apply Finset.sum_congr rfl
+      intro i _
+      exact Matrix.trace_mul_comm _ _
+    _ = ∑ j, (X j * T B j).trace :=
+      sum_trace_directSumTraceAdjointMapBetween_mul T X B
+    _ = ∑ j, (T B j * X j).trace := by
+      apply Finset.sum_congr rfl
+      intro j _
+      exact Matrix.trace_mul_comm _ _
+
+omit [DecidableEq ι] in
+/-- The trace adjoint of a trace-preserving star-algebra equivalence is its
+inverse.
+
+This is the trace-pairing passage from the adjoint star-algebra isomorphism to
+the original reversible map in CPSV16, arXiv:1606.00608, Appendix C.4,
+line 1997. -/
+theorem directSumTraceAdjointMapBetween_starAlgEquiv_eq_symm
+    (E : (∀ i, Matrix (n i) (n i) ℂ) ≃⋆ₐ[ℂ]
+      (∀ j, Matrix (m j) (m j) ℂ))
+    (hE : IsTracePreservingBetweenDirectSums
+      E.toAlgEquiv.toLinearEquiv.toLinearMap) :
+    directSumTraceAdjointMapBetween E.toAlgEquiv.toLinearEquiv.toLinearMap =
+      E.symm.toAlgEquiv.toLinearEquiv.toLinearMap := by
+  apply LinearMap.ext
+  intro A
+  apply eq_of_sum_trace_mul_eq
+  intro B
+  calc
+    ∑ i, (directSumTraceAdjointMapBetween
+        E.toAlgEquiv.toLinearEquiv.toLinearMap A i * B i).trace =
+        ∑ j, (A j * E B j).trace :=
+      sum_trace_directSumTraceAdjointMapBetween_mul
+        E.toAlgEquiv.toLinearEquiv.toLinearMap A B
+    _ = ∑ j, (E (E.symm A * B) j).trace := by
+      simp only [map_mul, E.apply_symm_apply, Pi.mul_apply]
+    _ = ∑ i, ((E.symm A * B) i).trace := hE (E.symm A * B)
+    _ = ∑ i, (E.symm A i * B i).trace := rfl
+
 omit [(i : ι) → DecidableEq (n i)] in
 /-- The trace adjoint of the identity on a finite sum of matrix algebras is
 the identity. -/

--- a/TNLean/MPS/MPDO/VerticalSectorRelabeling.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRelabeling.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.DirectSumBlockPermutation
+import TNLean.MPS.MPDO.VerticalSectorIdentity
+
+/-!
+# Relabelling of transported vertical sectors
+
+The mutually inverse transported vertical-sector maps determine the same
+matching of simple matrix summands as their trace-adjoint star-algebra
+equivalence.  This file specializes the abstract classification to the
+vertical canonical forms of an MPDO.
+
+The source is CPSV16, arXiv:1606.00608, Appendix C.4, line 1997.  The
+multiplicity and coefficient calculation at lines 2001--2008 is not used.
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The two transported vertical-sector algebras have matched simple summands,
+and their mutually inverse maps act by conjugation with the same unitaries.
+
+Source: CPSV16, arXiv:1606.00608, Appendix C.4, line 1997. The multiplicity
+and coefficient comparison at lines 2001--2008 is not asserted here. -/
+theorem transportedVerticalSector_exists_unitaryBlockEquiv
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hTCPTP : IsKrausCPTP T)
+    (hSCPTP : IsKrausCPTP S)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
+    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
+    let Tbar := transportedVerticalSectorT
+      dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
+    let Sbar := transportedVerticalSectorS
+      dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
+    ∃ sigma : Fin g₁ ≃ Fin g₂, ∃ hDim : ∀ i, dim₁ i = dim₂ (sigma i),
+      ∃ V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ,
+        (∀ (i : Fin g₁) (X : Matrix (Fin (dim₁ i)) (Fin (dim₁ i)) ℂ),
+            Tbar (Pi.single i X) = Pi.single (sigma i)
+              ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+                Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) X *
+                  (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ)) ∧
+          ∀ (i : Fin g₁) (Y : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ),
+            Sbar (Pi.single (sigma i) Y) = Pi.single i
+              ((Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))).symm
+                ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ * Y *
+                  (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ))) := by
+  classical
+  let Tbar := transportedVerticalSectorT
+    dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
+  let Sbar := transportedVerticalSectorS
+    dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
+  letI : ∀ i, NeZero (dim₁ i) := fun i ↦ ⟨(hBNT₁.blocks_dim_pos i).ne'⟩
+  letI : ∀ j, NeZero (dim₂ j) := fun j ↦ ⟨(hBNT₂.blocks_dim_pos j).ne'⟩
+  have hTbar : Matrix.IsKrausDirectSumMap Tbar := by
+    exact transportedVerticalSectorT_isKrausDirectSumMap
+      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁ U₁ U₂ T hTCPTP.isKrausCP
+  have hSbar : Matrix.IsKrausDirectSumMap Sbar := by
+    exact transportedVerticalSectorS_isKrausDirectSumMap
+      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ U₁ U₂ S hSCPTP.isKrausCP
+  obtain ⟨_, _, hTbarTP, hSbarTP⟩ :=
+    transportedVerticalSector_composites_tracePreserving
+      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
+      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
+      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+  obtain ⟨hST, hTS⟩ := transportedVerticalSector_composites_eq_id
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+    hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
+    U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
+    hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+  obtain ⟨sigma, hDim, V, hVT, hVS⟩ :=
+    Matrix.exists_blockEquiv_dim_eq_unitary_forward_of_mutual_inverse_kraus_direct_sum_maps
+      Tbar Sbar hTbar hSbar hTbarTP hSbarTP hST hTS
+  exact ⟨sigma, hDim, V, hVT, hVS⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -2542,6 +2542,7 @@ outside the present result.
 \begin{lemma}[Trace-adjoint laws for two finite sums of matrix algebras]%
     \label{lem:direct_sum_rectangular_trace_adjoint}
     \lean{Matrix.sum_trace_directSumTraceAdjointMapBetween_mul}
+    \lean{Matrix.directSumTraceAdjointMapBetween_involutive}
     \lean{Matrix.directSumTraceAdjointMapBetween_id}
     \lean{Matrix.directSumTraceAdjointMapBetween_comp}
     \lean{Matrix.directSumTraceAdjointMapBetween_self}
@@ -2558,6 +2559,7 @@ outside the present result.
         \operatorname{id}_{\mathcal A}^*=\operatorname{id}_{\mathcal A},
         \qquad
         (S\circ T)^*=T^*\circ S^*,
+        \qquad (T^*)^*=T,
         \qquad
         (\widehat T)^*=\widehat{T^*}.
     \]
@@ -2588,6 +2590,31 @@ outside the present result.
     \]
     Thus the adjoint again has a Kraus representation, and compression of
     positive block-diagonal matrices gives the stated positivity.
+\end{proof}
+
+\begin{lemma}[Trace adjoint of a trace-preserving star isomorphism]
+    \label{lem:direct_sum_trace_adjoint_star_equiv_inverse}
+    \lean{Matrix.directSumTraceAdjointMapBetween_starAlgEquiv_eq_symm}
+    \leanok
+    Let $\Phi:\mathcal A\simeq\mathcal B$ be a star-algebra isomorphism
+    between finite products of full matrix algebras.  If $\Phi$ preserves the
+    total block trace, then
+    \[
+        \Phi^*=\Phi^{-1}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:direct_sum_rectangular_trace_adjoint}
+    For $A\in\mathcal B$ and $B\in\mathcal A$, multiplicativity and trace
+    preservation give
+    \[
+      \sum_j\operatorname{tr}(A_j\Phi(B)_j)
+      =\sum_j\operatorname{tr}
+        \bigl(\Phi(\Phi^{-1}(A)B)_j\bigr)
+      =\sum_i\operatorname{tr}(\Phi^{-1}(A)_iB_i).
+    \]
+    Nondegeneracy of the trace pairing gives the asserted identity.
 \end{proof}
 
 \begin{theorem}[Channel and fixed-point compatibility of the canonical extension]%
@@ -2912,6 +2939,76 @@ outside the present result.
     of the adjoint implies that $P^*P$ commutes with every matrix and is
     therefore a positive scalar multiple of the identity.  Dividing $P$ by
     the positive square root of this scalar produces the required unitary.
+\end{proof}
+
+\begin{lemma}[Total trace under unitary action on matched summands]
+    \label{lem:direct_sum_block_unitary_trace_preserving}
+    \lean{Matrix.isTracePreservingBetweenDirectSums_of_unitary_block_implementers}
+    \leanok
+    Let $\Phi:\mathcal A\simeq\mathcal B$ match the simple summands by an
+    equivalence $\sigma:I\simeq J$, with $D_i=E_{\sigma(i)}$.  Suppose that
+    there are unitaries $U_i$ satisfying
+    \[
+      \Phi(0,\ldots,0,X,0,\ldots,0)_{\sigma(i)}
+      =U_i\,\iota_i(X)\,U_i^*.
+    \]
+    Then $\Phi$ preserves the total block trace.
+\end{lemma}
+
+\begin{proof}\leanok
+    The image of a matrix supported on the $i$-th summand is supported on the
+    $\sigma(i)$-th summand.  Unitary conjugation and reindexing preserve the
+    trace, so
+    \[
+      \sum_j\operatorname{tr}
+        \bigl(\Phi(0,\ldots,0,X,0,\ldots,0)_j\bigr)
+      =\operatorname{tr}(X).
+    \]
+    Summing this identity over the source summands proves the result.
+\end{proof}
+
+\begin{theorem}[Unitary action of an invertible CPTP map]
+    \label{thm:direct_sum_inverse_cptp_forward_unitary}
+    \lean{Matrix.%
+      exists_blockEquiv_dim_eq_unitary_forward_of_mutual_inverse_kraus_direct_sum_maps}
+    \leanok
+    Let $T:\mathcal A\to\mathcal B$ and $S:\mathcal B\to\mathcal A$ be
+    mutually inverse completely positive trace-preserving maps between finite
+    products of nonzero full matrix algebras.  There are an equivalence
+    $\sigma:I\simeq J$, equalities $D_i=E_{\sigma(i)}$, and unitaries
+    $U_i\in M_{E_{\sigma(i)}}(\C)$ such that
+    \[
+      T(0,\ldots,0,X,0,\ldots,0)
+      =(0,\ldots,0,U_i\,\iota_i(X)\,U_i^*,0,\ldots,0)
+    \]
+    with the nonzero entry on the right in position $\sigma(i)$, and
+    \[
+      S(0,\ldots,0,Y,0,\ldots,0)
+      =(0,\ldots,0,\iota_i^{-1}(U_i^*YU_i),0,\ldots,0)
+    \]
+    with the entries on the left and right in positions $\sigma(i)$ and $i$,
+    respectively.  These identities hold for every $i\in I$,
+    $X\in M_{D_i}(\C)$, and $Y\in M_{E_{\sigma(i)}}(\C)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:direct_sum_inverse_cptp_star_equiv,
+      thm:direct_sum_star_equiv_block_unitary,
+      lem:direct_sum_block_unitary_trace_preserving,
+      lem:direct_sum_trace_adjoint_star_equiv_inverse,
+      lem:direct_sum_rectangular_trace_adjoint}
+    Let $\Phi=S^*:\mathcal A\simeq\mathcal B$ be the star-algebra
+    isomorphism obtained from the inverse pair.  Theorem~
+    \ref{thm:direct_sum_star_equiv_block_unitary} supplies $\sigma$, the
+    dimension equalities, and the unitaries for $\Phi$.  Lemma~
+    \ref{lem:direct_sum_block_unitary_trace_preserving} shows that $\Phi$
+    preserves the total trace, hence Lemma~
+    \ref{lem:direct_sum_trace_adjoint_star_equiv_inverse} gives
+    $\Phi^*=\Phi^{-1}$.  On the other hand, involutivity of the trace adjoint
+    gives $\Phi^*=S$.  Therefore $S=\Phi^{-1}$, and the two inverse laws imply
+    $T=\Phi$.  The unitary formula for $\Phi$ gives the asserted formula for
+    $T$, while the inverse formula for $S=\Phi^{-1}$ uses the same summand
+    matching and the same unitaries.
 \end{proof}
 
 % Scope restriction documented in

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -40,6 +40,21 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     block MPVs $\{\ket{V^{(N)}(A_j)}\}$ are eventually linearly independent.
 \end{definition}
 
+\begin{lemma}[Positive bond dimensions in a coefficient-form BNT]
+    \label{lem:cpsv_bnt_block_dimensions_positive}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.blocks_dim_pos}
+    \leanok
+    Every block in a coefficient-form basis of normal tensors has positive
+    bond dimension.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:bnt_cpsv}
+    Eventual linear independence makes the matrix product vector of each block
+    nonzero at some positive length.  A tensor with zero bond dimension has
+    zero matrix product vector at every length, which is a contradiction.
+\end{proof}
+
 \begin{lemma}[Bond dimension one implies irreducibility]
     \label{lem:bond_dimension_one_irreducible}
     \lean{MPSTensor.isIrreducibleTensor_of_bondDim_one}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -2313,6 +2313,56 @@ physical indices, as in
     $F=\widetilde T\circ\widetilde S$ proves the two identities.
 \end{proof}
 
+\begin{theorem}[Unitary relabelling of transported vertical sectors]
+    \label{thm:mpdo_transported_vertical_sector_unitary_relabeling}
+    \lean{MPOTensor.transportedVerticalSector_exists_unitaryBlockEquiv}
+    \leanok
+    Under the hypotheses of Theorem~
+    \ref{thm:mpdo_transported_vertical_sector_composites_identity}, write
+    \[
+      \mathcal A_1=\prod_{\alpha}M_{D^{(1)}_\alpha}(\C),
+      \qquad
+      \mathcal A_2=\prod_{\beta}M_{D^{(2)}_\beta}(\C).
+    \]
+    There are an equivalence $\sigma$ of the two sector index sets, equalities
+    $D^{(1)}_\alpha=D^{(2)}_{\sigma(\alpha)}$, and unitaries
+    $V_\alpha\in M_{D^{(2)}_{\sigma(\alpha)}}(\C)$ such that
+    \[
+      \widetilde T(0,\ldots,0,X,0,\ldots,0)
+      =(0,\ldots,0,V_\alpha\,\iota_\alpha(X)\,V_\alpha^*,0,\ldots,0),
+    \]
+    where the nonzero entry on the right is in position $\sigma(\alpha)$, and
+    \[
+      \widetilde S(0,\ldots,0,Y,0,\ldots,0)
+      =(0,\ldots,0,\iota_\alpha^{-1}
+        (V_\alpha^*YV_\alpha),0,\ldots,0),
+    \]
+    where the entries on the left and right are in positions $\sigma(\alpha)$
+    and $\alpha$, respectively.  These identities hold for every
+    $X\in M_{D^{(1)}_\alpha}(\C)$ and
+    $Y\in M_{D^{(2)}_{\sigma(\alpha)}}(\C)$.
+    Here $\iota_\alpha$ is the reindexing induced by the displayed dimension
+    equality.  These are the mutually inverse unitary formulas of
+    \cite[Appendix~C.4, line~1997]{Cirac2016MPDO_arXiv}.  They make no assertion
+    about the multiplicities, weights, or coefficient identity at
+    lines~2001--2008.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:direct_sum_inverse_cptp_forward_unitary,
+      lem:cpsv_bnt_block_dimensions_positive,
+      thm:mpdo_transported_vertical_sector_composites_trace_preserving,
+      thm:mpdo_transported_vertical_sector_composites_schwarz,
+      thm:mpdo_transported_vertical_sector_composites_identity}
+    The two basis-of-normal-tensors decompositions have positive matrix
+    dimensions.  The transported maps are completely positive and preserve
+    the total block trace, and the preceding theorem gives both inverse laws.
+    Apply Theorem~\ref{thm:direct_sum_inverse_cptp_forward_unitary} to this
+    pair.  Its equivalence of summands, dimension equalities, and unitary
+    matrices give the two displayed formulas without changing the chosen
+    relabelling.
+\end{proof}
+
 \begin{theorem}[Two-site closure of the two-site blocking]
     \label{thm:mpdo_two_site_closure_two_site_blocking}
     \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -326,6 +326,18 @@ exists_unitary_block_implementers_of_starAlgEquiv_pi_matrix} in
 \leanid{Matrix.%
 exists_blockEquiv_dim_eq_unitary_of_mutual_inverse_kraus_direct_sum_maps} in
 \doclink{TNLean/Channel/FixedPoint/DirectSumBlockPermutation}.}
+The trace pairing for this unitary star-algebra isomorphism identifies it with
+the original forward map, not merely with the adjoint of the inverse.  Its
+inverse uses the same retained relabelling and the adjoints of the same
+unitaries.  Applied to the two transported vertical-sector maps, this gives
+the two full single-summand formulas for $\widetilde T$ and $\widetilde S$
+stated at line~1997.
+\footnote{Formal declarations:
+\leanid{Matrix.%
+exists_blockEquiv_dim_eq_unitary_forward_of_mutual_inverse_kraus_direct_sum_maps}
+in \doclink{TNLean/Channel/FixedPoint/DirectSumBlockPermutation}, and
+\leanid{MPOTensor.transportedVerticalSector_exists_unitaryBlockEquiv} in
+\doclink{TNLean/MPS/MPDO/VerticalSectorRelabeling}.}
 
 \section{Elimination plan}
 
@@ -345,25 +357,27 @@ simple-summand correspondence and its internal unitary action are complete as
 well: they give an equivalence of the sector index sets, identify the actual
 block ideals carried into one another, prove equality of the paired matrix
 dimensions, and implement every retained paired component by unitary
-conjugation.  It remains to specialize this formula to the transported
-vertical-sector maps.
+conjugation.  The specialization to both original transported maps, with the
+same relabelling and the same unitaries, is also complete.  The remaining
+calculation begins at line~2001: it compares
+the multiplicity factors and yields the coefficient identity at line~2008.
 
 \section{Classification}
 
 \textbf{Verdict: transported-map invertibility, the inverse-UCP
 multiplicative-domain step, generic simple-summand matching, and generic
-unitary implementation are closed; the transported-sector specialization
-remains open.}  The two transported maps and their
+unitary implementation are closed; the two transported maps have the
+mutually inverse blockwise-unitary forms with the same witnesses.}  The two transported maps and their
 square composites are trace preserving under the source tensor hypotheses.
 Their two compositions are identities, and the rectangular trace adjoints
 form mutually inverse $*$-algebra equivalences.  For any such pair, the simple
 summands are matched by an equivalence of the index sets, the corresponding
 block ideals are carried into one another by the star-algebra isomorphism,
 the paired matrix dimensions are equal, and the induced map on each matched
-summand is unitary conjugation.  The stronger active-image inclusions remain
-unproved and are not needed for this route.  Specializing the generic unitary
-formula to the transported vertical-sector maps remains necessary before the
-conclusion of Appendix~C.4, line~1997 is complete.
+summand is unitary conjugation.  The corresponding formulas now hold for
+$\widetilde T$ and $\widetilde S$ themselves.  The stronger active-image inclusions remain unproved
+and are not needed for this route.  No equality of multiplicities or weights,
+and no coefficient formula from Appendix~C.4, lines~2001--2008, is asserted.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- Proves involutivity of the rectangular trace adjoint and identifies the trace adjoint of a trace-preserving star-algebra equivalence with its inverse.
- Classifies mutually inverse completely positive trace-preserving maps between finite products of matrix algebras by one block equivalence, one family of dimension identifications, and one family of unitary implementers shared by both directions.
- Specializes this classification to the transported vertical-sector maps of an MPDO.
- Adds the corresponding blueprint statements and updates the vertical-sector paper-gap record.

## Source and scope

The source is CPSV16, arXiv:1606.00608, Appendix C.4, line 1997. The public specialization gives both full single-summand formulas for the original transported maps with the same relabelling, dimension witnesses, and unitaries. By linearity these are equivalent to the direct-sum formulas in the source.

This pull request deliberately stops before the multiplicity and coefficient comparison at lines 2001–2008. It proves no equality of multiplicities or weights and no coefficient-ratio formula.

Closes LionSR/TNLean#4580.
Parent: LionSR/QICLean#247.
Tracker: LionSR/TNLean#232.

## Verification

- `lake build` — passed, 9,647 jobs
- exact Lean checks for `DirectSumTraceAdjoint`, `DirectSumBlockPermutation`, and `VerticalSectorRelabeling` — passed
- `leanblueprint checkdecls` — passed
- style lint, Lean file policy tests, file-size and numbering checks, reader-facing prose check — passed
- proof-integrity scan of changed Lean files — passed
- independent exact-head mathematical review — approved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes add formal theorems on a critical MPDO invertibility/classification path; risk is moderate proof complexity and downstream blueprint reliance, not runtime or security exposure.
> 
> **Overview**
> Extends the **inverse-CPTP direct-sum classification** so it applies to the **original** maps \(T\) and \(S\), not only the trace-adjoint star isomorphism: paired summands share one index equivalence \(\sigma\), dimension witnesses, and unitaries, with \(T\) acting by \(U_i \cdot \iota_i(X) \cdot U_i^*\) and \(S\) by the conjugate inverse on the matched block.
> 
> Supporting Lean additions include **involutivity** of the rectangular trace adjoint \((T^*)^* = T\), **\(\Phi^* = \Phi^{-1}\)** for trace-preserving star-algebra equivalences, and a lemma that **unitary block implementers imply total block-trace preservation**.
> 
> **`VerticalSectorRelabeling`** instantiates this for **`transportedVerticalSectorT` / `transportedVerticalSectorS`** under the existing vertical BNT and physical-closure hypotheses. Blueprint chapters and the vertical-sector gap document are updated to record the closed scope at Appendix C.4 line 1997; **lines 2001–2008** (multiplicities, weights, coefficients) remain explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a884118abe10325b850f1c712af6cdeccb16f667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->