### PR TITLE
feat(MPS/MPDO): compare transported sector coefficients

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -485,6 +485,7 @@ import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.VerticalSectorIdentity
 import TNLean.MPS.MPDO.VerticalSectorRelabeling
+import TNLean.MPS.MPDO.VerticalSectorCoefficientComparison
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/MPDO/VerticalSectorCoefficientComparison.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorCoefficientComparison.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorGeneration
+import TNLean.MPS.MPDO.VerticalSectorRelabeling
+
+/-!
+# Coefficients of transported vertical sectors
+
+The unitary relabelling of the transported vertical-sector maps determines the
+coefficient relating each two-site vertical BNT representative to its paired
+one-site representative.  The coefficient is the ratio of the traces of the
+two positive multiplicity matrices.
+
+The source is CPSV16, arXiv:1606.00608, Appendix C.4, lines 2001--2008.
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+private theorem component_eq_of_unitary_single
+    {g₁ g₂ : ℕ} {dim₁ : Fin g₁ → ℕ} {dim₂ : Fin g₂ → ℕ}
+    (Tbar : VerticalSectorAlgebra dim₁ →ₗ[ℂ] VerticalSectorAlgebra dim₂)
+    (sigma : Fin g₁ ≃ Fin g₂) (hDim : ∀ i, dim₁ i = dim₂ (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ)
+    (hSingle : ∀ (i : Fin g₁)
+      (X : Matrix (Fin (dim₁ i)) (Fin (dim₁ i)) ℂ),
+      Tbar (Pi.single i X) = Pi.single (sigma i)
+        ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) X *
+            (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ))
+    (Y : VerticalSectorAlgebra dim₁) (i : Fin g₁) :
+    Tbar Y (sigma i) =
+      (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (Y i) *
+          (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ := by
+  classical
+  calc
+    Tbar Y (sigma i) = Tbar (∑ j, Pi.single j (Y j)) (sigma i) := by
+      rw [Finset.univ_sum_single]
+    _ = ∑ j, Tbar (Pi.single j (Y j)) (sigma i) := by
+      rw [map_sum, Finset.sum_apply]
+    _ = (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (Y i) *
+            (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ := by
+      rw [Finset.sum_eq_single i]
+      · rw [hSingle, Pi.single_eq_same]
+      · intro j _ hji
+        rw [hSingle, Pi.single_eq_of_ne]
+        exact sigma.injective.ne hji.symm
+      · simp
+
+private theorem component_eq_trace_ratio_smul_of_unitary_single
+    {g₁ g₂ : ℕ} {dim₁ : Fin g₁ → ℕ} {dim₂ : Fin g₂ → ℕ}
+    {mult₁ : Fin g₁ → ℕ} {mult₂ : Fin g₂ → ℕ}
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (Tbar : VerticalSectorAlgebra dim₁ →ₗ[ℂ] VerticalSectorAlgebra dim₂)
+    (sigma : Fin g₁ ≃ Fin g₂) (hDim : ∀ i, dim₁ i = dim₂ (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ)
+    (hSingle : ∀ (i : Fin g₁)
+      (X : Matrix (Fin (dim₁ i)) (Fin (dim₁ i)) ℂ),
+      Tbar (Pi.single i X) = Pi.single (sigma i)
+        ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) X *
+            (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ))
+    (X₁ : VerticalSectorAlgebra dim₁) (X₂ : VerticalSectorAlgebra dim₂)
+    (hScaled : Tbar (fun α ↦ verticalMultiplicityTrace weight₁ α • X₁ α) =
+      fun β ↦ verticalMultiplicityTrace weight₂ β • X₂ β)
+    (i : Fin g₁) :
+    X₂ (sigma i) =
+      (verticalMultiplicityTrace weight₁ i /
+        verticalMultiplicityTrace weight₂ (sigma i)) •
+      ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (X₁ i) *
+          (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ) := by
+  have hComponent := congrFun hScaled (sigma i)
+  rw [component_eq_of_unitary_single Tbar sigma hDim V hSingle] at hComponent
+  simp only [map_smul, Matrix.mul_smul, Matrix.smul_mul] at hComponent
+  have hn : verticalMultiplicityTrace weight₂ (sigma i) ≠ 0 :=
+    verticalMultiplicityTrace_ne_zero (sigma i) (hMult₂ (sigma i)) (hWeight₂ (sigma i))
+  calc
+    X₂ (sigma i) = (verticalMultiplicityTrace weight₂ (sigma i))⁻¹ •
+        (verticalMultiplicityTrace weight₂ (sigma i) • X₂ (sigma i)) := by
+      rw [smul_smul, inv_mul_cancel₀ hn, one_smul]
+    _ = (verticalMultiplicityTrace weight₂ (sigma i))⁻¹ •
+        (verticalMultiplicityTrace weight₁ i •
+          ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (X₁ i) *
+              (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ)) := by
+      rw [hComponent]
+    _ = _ := by
+      rw [smul_smul, div_eq_mul_inv, mul_comm]
+
+/-- Paired one-site and two-site vertical BNT sectors differ by unitary
+conjugation and the ratio of their multiplicity-matrix traces.  The first
+conclusion is the identity for an arbitrary horizontal bond contraction; the
+second is its tensor-letter specialization.
+
+Source: CPSV16, arXiv:1606.00608, Appendix C.4, lines 2001--2008. -/
+theorem transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hTCPTP : IsKrausCPTP T)
+    (hSCPTP : IsKrausCPTP S)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
+    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
+    ∃ sigma : Fin g₁ ≃ Fin g₂, ∃ hDim : ∀ i, dim₁ i = dim₂ (sigma i),
+      ∃ V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ,
+        (∀ (i : Fin g₁) (X : Matrix (Fin D) (Fin D) ℂ),
+          MPSTensor.contractBondMatrix (A₂ (sigma i)) X =
+            (verticalMultiplicityTrace weight₁ i /
+              verticalMultiplicityTrace weight₂ (sigma i)) •
+            ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))
+                (MPSTensor.contractBondMatrix (A₁ i) X) *
+              (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ)) ∧
+        ∀ (i : Fin g₁) (ab : Fin (D * D)),
+          A₂ (sigma i) ab =
+            (verticalMultiplicityTrace weight₁ i /
+              verticalMultiplicityTrace weight₂ (sigma i)) •
+            ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (A₁ i ab) *
+              (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ) := by
+  classical
+  obtain ⟨sigma, hDim, V, hVT, _⟩ :=
+    transportedVerticalSector_exists_unitaryBlockEquiv
+      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
+      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
+      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+  have hCoefficient : ∀ (i : Fin g₁) (X : Matrix (Fin D) (Fin D) ℂ),
+      MPSTensor.contractBondMatrix (A₂ (sigma i)) X =
+        (verticalMultiplicityTrace weight₁ i /
+          verticalMultiplicityTrace weight₂ (sigma i)) •
+        ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i))
+            (MPSTensor.contractBondMatrix (A₁ i) X) *
+          (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ) := by
+    intro i X
+    let X₁ : VerticalSectorAlgebra dim₁ :=
+      fun α ↦ MPSTensor.contractBondMatrix (A₁ α) X
+    let X₂ : VerticalSectorAlgebra dim₂ :=
+      fun β ↦ MPSTensor.contractBondMatrix (A₂ β) X
+    have hScaled :
+        transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
+            (fun α ↦ verticalMultiplicityTrace weight₁ α • X₁ α) =
+          fun β ↦ verticalMultiplicityTrace weight₂ β • X₂ β := by
+      exact transportedVerticalSectorT_contractBondMatrix_trace_smul
+        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁
+        M A₁ A₂ U₁ U₂ T hReconstruct₁ hForward₂ X (hTphys X)
+    exact component_eq_trace_ratio_smul_of_unitary_single
+      weight₁ weight₂ hMult₂ hWeight₂
+      (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T)
+      sigma hDim V hVT X₁ X₂ hScaled i
+  refine ⟨sigma, hDim, V, hCoefficient, ?_⟩
+  intro i ab
+  simpa only [MPSTensor.contractBondMatrix_single_mod_div] using
+    hCoefficient i (Matrix.single ab.modNat ab.divNat 1)
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -2363,6 +2363,56 @@ physical indices, as in
     relabelling.
 \end{proof}
 
+\begin{theorem}[Coefficient comparison for transported vertical sectors]
+    \label{thm:mpdo_transported_vertical_sector_coefficient_comparison}
+    \lean{MPOTensor.transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq}
+    \leanok
+    Under the hypotheses and with the notation of Theorem~
+    \ref{thm:mpdo_transported_vertical_sector_unitary_relabeling}, let
+    $\mu_\alpha$ and $\nu_\beta$ be the positive diagonal multiplicity
+    matrices in the one-site and two-site vertical canonical forms, and set
+    \[
+      m_\alpha=\operatorname{tr}(\mu_\alpha),
+      \qquad
+      n_\beta=\operatorname{tr}(\nu_\beta).
+    \]
+    For every horizontal bond matrix $X$ and every sector $\alpha$,
+    \[
+      A^{(2)}_{\sigma(\alpha)}(X)
+      =\frac{m_\alpha}{n_{\sigma(\alpha)}}
+        V_\alpha\,
+        \iota_\alpha\bigl(A^{(1)}_\alpha(X)\bigr)V_\alpha^*.
+    \]
+    Consequently, for every tensor letter $a$,
+    \[
+      A^{(2)}_{\sigma(\alpha),a}
+      =\frac{m_\alpha}{n_{\sigma(\alpha)}}
+        V_\alpha\,\iota_\alpha
+          \bigl(A^{(1)}_{\alpha,a}\bigr)V_\alpha^*.
+    \]
+    This is the coefficient identity in
+    \cite[Appendix~C.4, lines~2001--2008]{Cirac2016MPDO_arXiv}.  It compares
+    the traces of the multiplicity matrices; it does not assert equality of
+    their dimensions or of their individual diagonal entries.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_vertical_bond_contraction_encoded_matrix_unit,
+      lem:mpdo_vertical_sector_retraction,
+      thm:mpdo_transported_vertical_sector_unitary_relabeling,
+      thm:mpdo_transported_vertical_sector_maps}
+    Decompose the weighted contraction family into its individual matrix
+    summands.  At the summand paired with $\alpha$, the unitary formula gives
+    \[
+      m_\alpha V_\alpha
+        \iota_\alpha\bigl(A^{(1)}_\alpha(X)\bigr)V_\alpha^*
+      =n_{\sigma(\alpha)}A^{(2)}_{\sigma(\alpha)}(X).
+    \]
+    Positivity of $\nu_{\sigma(\alpha)}$ makes
+    $n_{\sigma(\alpha)}$ nonzero, so division gives the first identity.
+    Taking $X$ to be a matrix unit gives the tensor-letter identity.
+\end{proof}
+
 \begin{theorem}[Two-site closure of the two-site blocking]
     \label{thm:mpdo_two_site_closure_two_site_blocking}
     \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}

--- a/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
+++ b/docs/paper-gaps/cpsv16_vertical_sector_invertibility.tex
@@ -337,7 +337,10 @@ stated at line~1997.
 exists_blockEquiv_dim_eq_unitary_forward_of_mutual_inverse_kraus_direct_sum_maps}
 in \doclink{TNLean/Channel/FixedPoint/DirectSumBlockPermutation}, and
 \leanid{MPOTensor.transportedVerticalSector_exists_unitaryBlockEquiv} in
-\doclink{TNLean/MPS/MPDO/VerticalSectorRelabeling}.}
+\doclink{TNLean/MPS/MPDO/VerticalSectorRelabeling}, and
+\leanid{MPOTensor.%
+transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq} in
+\doclink{TNLean/MPS/MPDO/VerticalSectorCoefficientComparison}.}
 
 \section{Elimination plan}
 
@@ -358,16 +361,28 @@ well: they give an equivalence of the sector index sets, identify the actual
 block ideals carried into one another, prove equality of the paired matrix
 dimensions, and implement every retained paired component by unitary
 conjugation.  The specialization to both original transported maps, with the
-same relabelling and the same unitaries, is also complete.  The remaining
-calculation begins at line~2001: it compares
-the multiplicity factors and yields the coefficient identity at line~2008.
+same relabelling and the same unitaries, is also complete.  Finally, applying
+the transported refinement map to the weighted contraction family gives
+\[
+  m_\alpha V_\alpha\iota_\alpha(M_\alpha(X))V_\alpha^*
+  =n_{\sigma(\alpha)}A_{\sigma(\alpha)}(X).
+\]
+Since the positive multiplicity matrix $\nu_{\sigma(\alpha)}$ has nonzero
+trace, cancellation proves
+\[
+  A_{\sigma(\alpha)}(X)
+  =\frac{m_\alpha}{n_{\sigma(\alpha)}}
+    V_\alpha\iota_\alpha(M_\alpha(X))V_\alpha^*,
+\]
+and evaluation on matrix units gives the tensor-letter identity at line~2008.
+This comparison concerns the traces of the multiplicity matrices.  It does
+not identify their dimensions, the matrices themselves, or their individual
+diagonal entries.
 
 \section{Classification}
 
-\textbf{Verdict: transported-map invertibility, the inverse-UCP
-multiplicative-domain step, generic simple-summand matching, and generic
-unitary implementation are closed; the two transported maps have the
-mutually inverse blockwise-unitary forms with the same witnesses.}  The two transported maps and their
+\textbf{Verdict: the Appendix~C.4 argument through the coefficient identity at
+line~2008 is closed.}  The two transported maps and their
 square composites are trace preserving under the source tensor hypotheses.
 Their two compositions are identities, and the rectangular trace adjoints
 form mutually inverse $*$-algebra equivalences.  For any such pair, the simple
@@ -375,9 +390,12 @@ summands are matched by an equivalence of the index sets, the corresponding
 block ideals are carried into one another by the star-algebra isomorphism,
 the paired matrix dimensions are equal, and the induced map on each matched
 summand is unitary conjugation.  The corresponding formulas now hold for
-$\widetilde T$ and $\widetilde S$ themselves.  The stronger active-image inclusions remain unproved
-and are not needed for this route.  No equality of multiplicities or weights,
-and no coefficient formula from Appendix~C.4, lines~2001--2008, is asserted.
+$\widetilde T$ and $\widetilde S$ themselves.  Their action on the weighted
+contraction family gives the trace-ratio coefficient formula and its
+tensor-letter specialization.  The stronger active-image inclusions remain
+unproved and are not needed for this route.  No equality of multiplicities,
+multiplicity matrices, or individual weights is asserted, and no conclusion
+after Appendix~C.4, line~2008 is included.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- Extracts the component of the transported vertical-sector map paired by the block equivalence from LionSR/TNLean#4583.
- Compares the weighted contraction families and proves the trace-ratio identity
  `A₂ = (m₁ / m₂) • V A₁ Vᴴ` on every paired sector, with the retained dimension reindexing.
- Derives the tensor-letter identity by evaluation on encoded matrix units.
- Adds the corresponding Chapter 21 statement and advances the vertical-sector paper-gap record through source line 2008.

## Source and scope

The source is CPSV16, arXiv:1606.00608, Appendix C.4, lines 2001–2008. The theorem retains the sector equivalence, dimension identifications, and unitaries produced by the line-1997 classification in PR LionSR/TNLean#4583. It proves the coefficient with orientation

`verticalMultiplicityTrace weight₁ i / verticalMultiplicityTrace weight₂ (sigma i)`.

This pull request does not assert equality of multiplicities, multiplicity-space dimensions, multiplicity matrices, or individual weights. It includes no conclusion after line 2008: in particular, no `O_L(B)` comparison, coefficient-fusion relation, or algebraic structure is claimed.

Closes LionSR/TNLean#4584.
Parent: LionSR/QICLean#247.
Tracker: LionSR/TNLean#232.

## Verification

- focused Lean check and root import check — passed
- full `lake build` / root build — passed
- generated blueprint synchronization and `lake exe checkdecls blueprint/lean_decls` — passed
- style lint, file-policy tests, file-size and numbering checks, reader-facing prose check — passed
- proof-integrity and diff checks — passed
- independent exact-head mathematical and source-faithfulness review — approved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and documentation; no runtime, security, or data-path changes. Scope is limited to MPS/MPDO vertical-sector proofs and their blueprint/gap tracking.
> 
> **Overview**
> Adds **`VerticalSectorCoefficientComparison.lean`** and wires it into the root import. On top of the existing unitary sector relabelling, it proves that paired one-site and two-site vertical BNT representatives differ by **unitary conjugation** and the **ratio of multiplicity-matrix traces** \(m_\alpha/n_{\sigma(\alpha)}\), for general bond contractions and for individual tensor letters (via matrix units).
> 
> Chapter 21 gains the matching **coefficient comparison** theorem, and the CPSV16 vertical-sector invertibility gap note is updated to treat **Appendix C.4 through line 2008** as closed, while still not claiming equality of multiplicities, weights, or anything after that line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e56726ea44b54e20625224dea5eac1e95257f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->