### PR TITLE
feat(MPS/MPDO): derive blocked vertical operator representations

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -486,6 +486,7 @@ import TNLean.MPS.MPDO.VerticalSectorInvertibility
 import TNLean.MPS.MPDO.VerticalSectorIdentity
 import TNLean.MPS.MPDO.VerticalSectorRelabeling
 import TNLean.MPS.MPDO.VerticalSectorCoefficientComparison
+import TNLean.MPS.MPDO.VerticalBlockedOperatorRepresentations
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure

--- a/TNLean/MPS/MPDO/VerticalBlockedOperatorRepresentations.lean
+++ b/TNLean/MPS/MPDO/VerticalBlockedOperatorRepresentations.lean
@@ -1,0 +1,352 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.VerticalSectorCoefficientComparison
+import TNLean.Analysis.CoisometricCompression
+import TNLean.MPS.Tactic.Basic
+
+/-!
+# Simultaneous operator representations of a blocked vertical tensor
+
+This file develops the two closed-chain representations of the two-site
+blocked tensor used in CPSV16, Appendix C.4, lines 2011--2018.  The first
+step identifies its vertical reading with the product of two copies of the
+one-site vertical tensor.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.4, lines 2011--2018
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The vertical reading of a two-site physical block is the product tensor
+of two copies of the one-site vertical reading.
+
+This is the local tensor identity underlying the second representation of
+the blocked closed-chain operator in CPSV16, Appendix C.4, lines 2011--2018.
+-/
+theorem verticalBNTMPO_verticalTensor_blockTwo (M : MPOTensor d D) :
+    verticalBNTMPO (verticalTensor (blockTwo M)) =
+      mulTensor (verticalBNTMPO (verticalTensor M))
+        (verticalBNTMPO (verticalTensor M)) := by
+  ext a b x y
+  simp [verticalBNTMPO, verticalTensor, blockTwo, mulTensor,
+    Matrix.mul_apply, Matrix.sum_apply, Matrix.submatrix_apply,
+    Matrix.kroneckerMap_apply]
+
+end MPOTensor
+
+namespace MPSTensor
+
+/-- A tensor reconstructed through a coisometry has the same positive-length
+closed-chain coefficients as the tensor on the retained space.
+
+The positive-length restriction is necessary because the two tensors may
+have different bond dimensions. This is the trace-preserving reconstruction
+used for CPSV16, Appendix C.4, lines 2011--2018; the reconstruction itself is
+the vertical canonical-form relation of Proposition 4.13, lines 1863--1870. -/
+theorem sameMPV₂Pos_of_coisometry_reconstruction
+    {s d n : ℕ} (T : MPSTensor s d) (B : MPSTensor s n)
+    (U : Matrix (Fin n) (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ v, T v = Uᴴ * B v * U) :
+    SameMPV₂Pos T B := by
+  mpv_ext
+  have hEval : ∀ (v : Fin s) (w : List (Fin s)),
+      evalWord T (v :: w) = Uᴴ * evalWord B (v :: w) * U := by
+    intro v w
+    induction w generalizing v with
+    | nil => simp [hReconstruct]
+    | cons v' w ih =>
+      change T v * evalWord T (v' :: w) =
+        Uᴴ * (B v * evalWord B (v' :: w)) * U
+      rw [hReconstruct v, ih v']
+      simp only [Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc U Uᴴ, hU, Matrix.one_mul]
+  have hword : List.ofFn σ ≠ [] := by
+    intro hzero
+    have hlength := congrArg List.length hzero
+    simp only [List.length_ofFn, List.length_nil] at hlength
+    omega
+  obtain ⟨v, w, hw⟩ := List.exists_cons_of_ne_nil hword
+  simp only [mpv, coeff, hw]
+  rw [hEval v w]
+  exact Matrix.trace_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one U hU _
+
+end MPSTensor
+
+namespace MPOTensor
+
+variable {D g : ℕ} {dim mult : Fin g → ℕ}
+
+/-- Closed chains of a vertical assembly split into its weighted sector
+closed chains.
+
+This is the block-diagonal expansion used in CPSV16, Appendix C.4, lines
+2011--2018. -/
+theorem mpo_verticalBNTMPO_verticalAssembledTensor_eq_sum
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α)) (L : ℕ) :
+    mpo (verticalBNTMPO (verticalAssembledTensor dim mult weight A)) L =
+      ∑ α, (∑ q, weight α q ^ L) • mpo (verticalBNTMPO (A α)) L := by
+  ext σ τ
+  rw [← MPSTensor.mpv_toMPSTensor_pairConfig
+    (verticalBNTMPO (verticalAssembledTensor dim mult weight A)) σ τ]
+  simp only [verticalBNTMPO_toMPSTensor]
+  rw [mpv_verticalAssembledTensor_eq_sum, Fintype.sum_sigma]
+  simp only [Matrix.sum_apply, Matrix.smul_apply,
+    ← MPSTensor.mpv_toMPSTensor_pairConfig, verticalBNTMPO_toMPSTensor,
+    smul_eq_mul, Finset.sum_mul]
+
+/-- A coisometric vertical canonical-form reconstruction gives the weighted
+sector expansion of every positive-length closed chain.
+
+Source: CPSV16, Appendix C.4, lines 2011--2018. -/
+theorem mpo_verticalBNTMPO_eq_sum_of_coisometry_reconstruction
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (T : MPSTensor (D * D) d)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ v,
+      T v = Uᴴ * verticalAssembledTensor dim mult weight A v * U)
+    {L : ℕ} (hL : 0 < L) :
+    mpo (verticalBNTMPO T) L =
+      ∑ α, (∑ q, weight α q ^ L) • mpo (verticalBNTMPO (A α)) L := by
+  calc
+    mpo (verticalBNTMPO T) L =
+        mpo (verticalBNTMPO (verticalAssembledTensor dim mult weight A)) L := by
+      ext σ τ
+      rw [← MPSTensor.mpv_toMPSTensor_pairConfig,
+        ← MPSTensor.mpv_toMPSTensor_pairConfig]
+      simp only [verticalBNTMPO_toMPSTensor]
+      exact MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction
+        T (verticalAssembledTensor dim mult weight A) U hU hReconstruct L hL _
+    _ = _ := mpo_verticalBNTMPO_verticalAssembledTensor_eq_sum weight A L
+
+/-- Unitary conjugacy after reindexing, with a common scalar on every tensor
+letter, multiplies the length-`L` closed-chain operator by the `L`-th power of
+that scalar.
+
+This is the gauge-invariance step in CPSV16, Appendix C.4, lines 2011--2018. -/
+theorem mpo_verticalBNTMPO_eq_pow_smul_of_unitary_reindex
+    {n₁ n₂ : ℕ} (A₁ : MPSTensor (D * D) n₁)
+    (A₂ : MPSTensor (D * D) n₂) (c : ℂ) (hDim : n₁ = n₂)
+    (V : Matrix.unitaryGroup (Fin n₂) ℂ)
+    (hLetter : ∀ ab,
+      A₂ ab = c • ((V : Matrix (Fin n₂) (Fin n₂) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDim) (A₁ ab) *
+          (V : Matrix (Fin n₂) (Fin n₂) ℂ)ᴴ))
+    (L : ℕ) :
+    mpo (verticalBNTMPO A₂) L = c ^ L • mpo (verticalBNTMPO A₁) L := by
+  classical
+  let A₁' : MPSTensor (D * D) n₂ := fun ab =>
+    Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDim) (A₁ ab)
+  have hReindex : MPSTensor.SameMPV₂ A₁ A₁' := by
+    mpv_ext
+    simp only [MPSTensor.mpv, MPSTensor.coeff]
+    change Matrix.trace (MPSTensor.evalWord A₁ (List.ofFn σ)) =
+      Matrix.trace (MPSTensor.evalWord
+        (fun ab => Matrix.reindex (finCongr hDim) (finCongr hDim) (A₁ ab))
+        (List.ofFn σ))
+    rw [MPSTensor.evalWord_reindex, Matrix.trace_reindex]
+    simp
+  have hScaled (N : ℕ) (σ : Fin N → Fin (D * D)) :
+      MPSTensor.mpv A₂ σ = c ^ N * MPSTensor.mpv A₁' σ := by
+    have hA₂ : A₂ = fun ab => c • ((V : Matrix (Fin n₂) (Fin n₂) ℂ) *
+        A₁' ab * (V : Matrix (Fin n₂) (Fin n₂) ℂ)ᴴ) := by
+      funext ab
+      exact hLetter ab
+    rw [hA₂, MPSTensor.mpv_smul]
+    congr 1
+    have hGauge := MPSTensor.sameMPV_conj_unitary A₁' (star V)
+    simpa only [Unitary.coe_star, star_star, Matrix.star_eq_conjTranspose,
+      Matrix.conjTranspose_conjTranspose] using (hGauge N σ).symm
+  ext σ τ
+  simp only [Matrix.smul_apply]
+  let pair : Fin L → Fin (D * D) := fun n => finProdFinEquiv (σ n, τ n)
+  calc
+    mpo (verticalBNTMPO A₂) L σ τ = MPSTensor.mpv A₂ pair := by
+      simpa [pair] using
+        (MPSTensor.mpv_toMPSTensor_pairConfig (verticalBNTMPO A₂) σ τ).symm
+    _ = c ^ L * MPSTensor.mpv A₁' pair := hScaled L pair
+    _ = c ^ L * MPSTensor.mpv A₁ pair := by rw [hReindex L pair]
+    _ = c ^ L * mpo (verticalBNTMPO A₁) L σ τ := by
+      rw [← MPSTensor.mpv_toMPSTensor_pairConfig]
+      simp [pair]
+
+/-- The two closed-chain representations, given the sector correspondence
+and its coefficient comparison.
+
+This is the algebraic assembly of CPSV16, Appendix C.4, lines 2011--2018. -/
+theorem blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (sigma : Fin g₁ ≃ Fin g₂)
+    (hDim : ∀ i, dim₁ i = dim₂ (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ)
+    (hLetter : ∀ (i : Fin g₁) (ab : Fin (D * D)),
+      A₂ (sigma i) ab =
+        (verticalMultiplicityTrace weight₁ i /
+          verticalMultiplicityTrace weight₂ (sigma i)) •
+        ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (A₁ i ab) *
+          (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ))
+    {L : ℕ} (hL : 0 < L) :
+    mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+        ∑ i,
+          (((verticalMultiplicityTrace weight₁ i /
+              verticalMultiplicityTrace weight₂ (sigma i)) ^ L) *
+            (∑ q, weight₂ (sigma i) q ^ L)) •
+            mpo (verticalBNTMPO (A₁ i)) L ∧
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+        ∑ i, ∑ j,
+          ((∑ q, weight₁ i q ^ L) * (∑ r, weight₁ j r ^ L)) •
+            (mpo (verticalBNTMPO (A₁ i)) L *
+              mpo (verticalBNTMPO (A₁ j)) L) := by
+  have hOne := mpo_verticalBNTMPO_eq_sum_of_coisometry_reconstruction
+    weight₁ A₁ (verticalTensor M) U₁ hU₁ hReconstruct₁ hL
+  have hTwo := mpo_verticalBNTMPO_eq_sum_of_coisometry_reconstruction
+    weight₂ A₂ (verticalTensor (blockTwo M)) U₂ hU₂ hReconstruct₂ hL
+  constructor
+  · rw [hTwo]
+    rw [← sigma.sum_comp]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [mpo_verticalBNTMPO_eq_pow_smul_of_unitary_reindex
+      (A₁ i) (A₂ (sigma i))
+      (verticalMultiplicityTrace weight₁ i /
+        verticalMultiplicityTrace weight₂ (sigma i))
+      (hDim i) (V i) (hLetter i) L]
+    rw [smul_smul, mul_comm]
+  · rw [verticalBNTMPO_verticalTensor_blockTwo, mpo_mulTensor, hOne]
+    rw [Finset.sum_mul]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro j _
+    rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+
+/-- The one-site and blocked vertical canonical forms give two simultaneous
+representations of the same positive-length blocked closed-chain operator.
+The sector relabelling, bond-dimension identifications, and unitary gauges are
+the witnesses obtained from the transported vertical-sector comparison.
+
+Source: CPSV16, arXiv:1606.00608, Appendix C.4, lines 2001--2018. The first
+conjunct retains the tensor-letter identity of lines 2001--2008; the two
+operator representations are lines 2011--2018.
+
+**Local fix (blocked coefficient exponent):** CPSV16 Appendix C.4, line 2013
+prints $m_γ^L/n_γ$. The line-2008 tensor scaling and line 2040 give
+$(m_γ/n_γ)^L$. Documented in
+`docs/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.tex`. -/
+theorem transportedVerticalSector_exists_blockedOperatorRepresentations
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ)
+    (hTCPTP : IsKrausCPTP T)
+    (hSCPTP : IsKrausCPTP S)
+    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
+    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X)
+    {L : ℕ} (hL : 0 < L) :
+    ∃ sigma : Fin g₁ ≃ Fin g₂,
+      ∃ hDim : ∀ i, dim₁ i = dim₂ (sigma i),
+        ∃ V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ,
+          (∀ (i : Fin g₁) (ab : Fin (D * D)),
+            A₂ (sigma i) ab =
+              (verticalMultiplicityTrace weight₁ i /
+                verticalMultiplicityTrace weight₂ (sigma i)) •
+              ((V i : Matrix (Fin (dim₂ (sigma i)))
+                  (Fin (dim₂ (sigma i))) ℂ) *
+                Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (A₁ i ab) *
+                (V i : Matrix (Fin (dim₂ (sigma i)))
+                  (Fin (dim₂ (sigma i))) ℂ)ᴴ)) ∧
+          mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+              ∑ i,
+                (((verticalMultiplicityTrace weight₁ i /
+                    verticalMultiplicityTrace weight₂ (sigma i)) ^ L) *
+                  (∑ q, weight₂ (sigma i) q ^ L)) •
+                  mpo (verticalBNTMPO (A₁ i)) L ∧
+          mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+            ∑ i, ∑ j,
+              ((∑ q, weight₁ i q ^ L) * (∑ r, weight₁ j r ^ L)) •
+                (mpo (verticalBNTMPO (A₁ i)) L *
+                  mpo (verticalBNTMPO (A₁ j)) L) := by
+  obtain ⟨sigma, hDim, V, _, hLetter⟩ :=
+    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
+      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
+      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
+      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+  obtain ⟨hFirst, hSecond⟩ :=
+    blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv
+      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ M A₁ A₂ U₁ U₂ hU₁ hU₂
+      hReconstruct₁ hReconstruct₂ sigma hDim V hLetter hL
+  exact ⟨sigma, hDim, V, hLetter, hFirst, hSecond⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -2454,6 +2454,8 @@ physical indices, as in
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:mpdo_operator_product_mpo, lem:mpv_vertical_assembled,
+      thm:mpdo_transported_vertical_sector_coefficient_comparison}
     The two-site vertical canonical form first gives
     \[
       O_L(B)=\sum_\delta

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -2416,6 +2416,12 @@ physical indices, as in
 \begin{theorem}[Simultaneous representations of the blocked vertical operator]
     \label{thm:mpdo_blocked_vertical_operator_representations}
     \lean{MPOTensor.transportedVerticalSector_exists_blockedOperatorRepresentations}
+    \lean{MPOTensor.verticalBNTMPO_verticalTensor_blockTwo}
+    \lean{MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction}
+    \lean{MPOTensor.mpo_verticalBNTMPO_verticalAssembledTensor_eq_sum}
+    \lean{MPOTensor.mpo_verticalBNTMPO_eq_sum_of_coisometry_reconstruction}
+    \lean{MPOTensor.mpo_verticalBNTMPO_eq_pow_smul_of_unitary_reindex}
+    \lean{MPOTensor.blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv}
     \leanok
     \uses{thm:mpdo_transported_vertical_sector_coefficient_comparison,
       def:vertical_cf_mpdo, def:mpdo_two_site_blocking}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -2413,6 +2413,73 @@ physical indices, as in
     Taking $X$ to be a matrix unit gives the tensor-letter identity.
 \end{proof}
 
+\begin{theorem}[Simultaneous representations of the blocked vertical operator]
+    \label{thm:mpdo_blocked_vertical_operator_representations}
+    \lean{MPOTensor.transportedVerticalSector_exists_blockedOperatorRepresentations}
+    \leanok
+    \uses{thm:mpdo_transported_vertical_sector_coefficient_comparison,
+      def:vertical_cf_mpdo, def:mpdo_two_site_blocking}
+    Under the hypotheses and with the sector correspondence of Theorem~
+    \ref{thm:mpdo_transported_vertical_sector_coefficient_comparison}, let
+    \(B\) be the vertical reading of the two-site blocking, and write
+    \[
+      O_L(A)=\operatorname{Tr}_{\mathrm{bond}}
+        \bigl(A_{i_1}\cdots A_{i_L}\bigr)
+    \]
+    for the length-$L$ closed-chain operator.  If $L>0$, then the same
+    equivalence $\sigma$, dimension identifications, and unitaries appearing
+    in the tensor-letter identity satisfy
+    \[
+    \begin{aligned}
+      O_L(B)
+      &=\sum_\alpha
+        \left(\frac{m_\alpha}{n_{\sigma(\alpha)}}\right)^L
+        \operatorname{tr}\!\left(\nu_{\sigma(\alpha)}^L\right)
+        O_L\!\left(A^{(1)}_\alpha\right), \\
+      O_L(B)
+      &=\sum_{\alpha,\beta}
+        \operatorname{tr}(\mu_\alpha^L)
+        \operatorname{tr}(\mu_\beta^L)
+        O_L\!\left(A^{(1)}_\alpha\right)
+        O_L\!\left(A^{(1)}_\beta\right).
+    \end{aligned}
+    \]
+    These are the two representations in
+    \cite[Appendix~C.4, lines~2011--2018]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Local fix (blocked coefficient exponent):} CPSV16 Appendix C.4,
+    line~2013 prints $m_\gamma^L/n_\gamma$.  The line-2008 tensor scaling and
+    line~2040 give $(m_\gamma/n_\gamma)^L$.  This is documented in
+    \path{docs/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The two-site vertical canonical form first gives
+    \[
+      O_L(B)=\sum_\delta
+        \operatorname{tr}(\nu_\delta^L)
+        O_L\!\left(A^{(2)}_\delta\right).
+    \]
+    Reindex this sum by $\delta=\sigma(\alpha)$.  The tensor-letter identity
+    from the preceding theorem multiplies every letter of
+    $A^{(1)}_\alpha$ by
+    $m_\alpha/n_{\sigma(\alpha)}$.  Along a chain of length $L$ this scalar
+    therefore occurs to the power $L$; unitary conjugation and the bond-index
+    identification leave the closing trace unchanged.  This proves the first
+    formula.
+
+    For the second formula, the vertical reading of a two-site block is the
+    product tensor of two copies of the one-site vertical reading.  Closed
+    chains turn this tensor product into multiplication of operators.  Expand
+    each copy by the one-site vertical canonical form,
+    \[
+      O_L(\widetilde M)=\sum_\alpha
+        \operatorname{tr}(\mu_\alpha^L)
+        O_L\!\left(A^{(1)}_\alpha\right),
+    \]
+    and distribute the product of the two finite sums.
+\end{proof}
+
 \begin{theorem}[Two-site closure of the two-site blocking]
     \label{thm:mpdo_two_site_closure_two_site_blocking}
     \lean{MPOTensor.physClose2_blockTwo_eq_physClose4}

--- a/docs/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.tex
+++ b/docs/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.tex
@@ -1,0 +1,92 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+
+\input{./command}
+
+\title{The Trace-Ratio Exponent in the Blocked Vertical-Operator Formula}
+\author{}
+\date{2026-07-21}
+
+\begin{document}
+\maketitle
+
+\section{The two formulas in Appendix C.4}
+
+Appendix~C.4 of \cite{Cirac2016MPDO_arXiv} compares the one-site and
+two-site vertical canonical forms.  Its lines~2001--2008 pair their sectors
+and show that the corresponding representative tensors satisfy
+\begin{equation}
+  A^{(2)}_{\sigma(\alpha)}
+  =\frac{m_\alpha}{n_{\sigma(\alpha)}}
+    V_\alpha A^{(1)}_\alpha V_\alpha^*,
+  \label{eq:letter-scaling}
+\end{equation}
+up to the harmless identification of equal bond dimensions.  Here
+$m_\alpha=\operatorname{tr}(\mu_\alpha)$ and
+$n_\beta=\operatorname{tr}(\nu_\beta)$ are the traces of the positive
+diagonal multiplicity matrices.
+
+For a closed chain of length $L$, multiplying every tensor letter by a scalar
+$c$ multiplies the resulting operator by $c^L$.  Unitary conjugation and the
+identification of the bond indices do not change the closing trace.  Thus
+\eqref{eq:letter-scaling} gives the coefficient
+\begin{equation}
+  \left(\frac{m_\alpha}{n_{\sigma(\alpha)}}\right)^L
+  \operatorname{tr}\!\left(\nu_{\sigma(\alpha)}^L\right).
+  \label{eq:correct-coefficient}
+\end{equation}
+
+Line~2013 instead prints
+\begin{equation}
+  \frac{m_\alpha^L}{n_{\sigma(\alpha)}}
+  \operatorname{tr}\!\left(\nu_{\sigma(\alpha)}^L\right).
+  \label{eq:printed-coefficient}
+\end{equation}
+The two expressions differ by the factor
+$n_{\sigma(\alpha)}^{L-1}$.  No normalization setting this factor equal to
+one appears in the source.
+
+\section{Confirmation later in the source}
+
+The same appendix resolves the exponent unambiguously at line~2040, where it
+uses
+\begin{equation}
+  \operatorname{tr}\!\left[
+    \left(\frac{m_\alpha}{n_{\sigma(\alpha)}}
+      \nu_{\sigma(\alpha)}\right)^L\right]
+  =
+  \left(\frac{m_\alpha}{n_{\sigma(\alpha)}}\right)^L
+  \operatorname{tr}\!\left(\nu_{\sigma(\alpha)}^L\right).
+  \label{eq:source-confirmation}
+\end{equation}
+This is precisely \eqref{eq:correct-coefficient}.  It also agrees directly
+with the tensor-letter scaling at line~2008.  Therefore the denominator in
+line~2013 is missing the exponent $L$; this is a local typographical error,
+not an additional hypothesis or a change in the mathematical argument.
+
+\section{Formal correction}
+
+The simultaneous blocked-operator representations use
+\eqref{eq:correct-coefficient}.  The formal statement retains the same sector
+equivalence, bond-dimension identifications, and unitary matrices that give
+\eqref{eq:letter-scaling}; it introduces no normalization of the multiplicity
+matrices.  The corresponding declaration is
+\path{MPOTensor.transportedVerticalSector_exists_blockedOperatorRepresentations}
+in
+\path{TNLean/MPS/MPDO/VerticalBlockedOperatorRepresentations.lean}.
+This correction is tracked in \ghissue{4586}.
+
+\paragraph{Verdict.}
+The coefficient consistent with both the preceding tensor identity and the
+later trace-power calculation is
+$\bigl(m_\alpha/n_{\sigma(\alpha)}\bigr)^L
+\operatorname{tr}(\nu_{\sigma(\alpha)}^L)$.  The expression printed at
+line~2013 has a missing exponent on the denominator.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

This pull request formalizes CPSV16 Appendix C.4 through lines 2011–2018. It proves two simultaneous closed-chain representations of the same two-site blocked vertical tensor, using the sector correspondence and trace-ratio comparison established in #4585.

The source-facing theorem retains one common sector equivalence, the matched bond-dimension identifications, the unitary family, and the tensor-letter relation from lines 2001–2008. For every positive chain length L, it then proves

- the two-site-sector expansion with coefficient `((m_i / n_(sigma i)) ^ L) * tr(nu_(sigma i)^L)`;
- the product expansion obtained from two copies of the one-site vertical canonical form.

## Mathematical components

- identifies the vertical reading of `blockTwo` with the MPO product tensor;
- proves positive-length closed-chain invariance under coisometric reconstruction;
- expands a vertical assembly as the weighted sum of its sector operators;
- proves scalar-power, bond-reindexing, and unitary-conjugation invariance of closed chains;
- packages both formulas for one literal common blocked tensor and the same transported-sector witnesses.

## Source correction

CPSV16 line 2013 prints `m_gamma^L / n_gamma`. Scaling each tensor letter by `m_gamma / n_gamma` gives `(m_gamma / n_gamma)^L`, and line 2040 confirms this exponent. The local typographical correction is documented in `docs/paper-gaps/cpsv16_blocked_operator_trace_ratio_exponent.tex` and marked in both the Lean theorem and blueprint entry.

No normalization of the multiplicity matrices, equality of individual weights, or equality of multiplicity matrices is assumed.

## Blueprint and integrity

Chapter 21 now records the source-facing theorem, all six supporting declarations, and the proof dependencies. No `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` is introduced.

## Validation

- focused Lean module: passed with warnings treated as errors;
- updated root import: passed;
- targeted declaration checking for the capstone and all six helpers: passed;
- blueprint web generation: passed;
- blueprint source synchronization: passed;
- policy unit tests: 15/15 passed;
- proof-integrity, 100-column, and diff checks: passed;
- independent mathematical and exact-head review: approved at `3e653caf5b7ff39ff3f728db4780b7e2698c65eb`.

Closes #4586.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization and documentation; no runtime, auth, or data-path changes. Mathematical risk is localized to MPDO vertical-sector theory already built in prior PRs.
> 
> **Overview**
> Formalizes **CPSV16 Appendix C.4, lines 2011–2018**: for positive chain length \(L\), the blocked vertical closed-chain operator admits **two equivalent expansions**—a two-site sector sum with trace-ratio and multiplicity weights, and a **product** of two one-site sector expansions.
> 
> New module `VerticalBlockedOperatorRepresentations.lean` proves helper lemmas (vertical `blockTwo` as MPO product, coisometric MPV invariance, sector assembly sums, unitary/scalar gauge on closed chains) and packages them in `transportedVerticalSector_exists_blockedOperatorRepresentations`, importing the sector correspondence from `VerticalSectorCoefficientComparison`.
> 
> **Blueprint** chapter 21 gains Theorem `mpdo_blocked_vertical_operator_representations` with Lean links and proof sketch. A **paper-gap note** records that line 2013 should use \((m_\alpha/n_{\sigma(\alpha)})^L\) on the denominator, not \(m_\alpha^L/n_{\sigma(\alpha)}\), consistent with lines 2008 and 2040. Root import `TNLean.lean` wires the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e653caf5b7ff39ff3f728db4780b7e2698c65eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->