### PR TITLE
chore(tenkz): ignore local generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,13 @@ blueprint/src/print.xdv
 
 # Local scratch / experiments
 Scratch/
+/tmp/
+
+# tenkz manual generated artifacts
+/docs/tenkz/*.exa
+/docs/tenkz/*.exm
+/docs/tenkz/*.tnlog
+/docs/tenkz/manual2.pdf
 
 # Nested Lake artifacts in vendored local packages
 External/**/.lake/


### PR DESCRIPTION
### Motivation
- Keep repository-local scratch files and reproducible tenkz manual outputs out of working-tree status.
- Avoid broad PDF ignore rules because the repository intentionally tracks source/reference PDFs elsewhere.

### Description
- Ignore the repository-root `tmp/` directory.
- Ignore generated tenkz manual `.exa`, `.exm`, and `.tnlog` files.
- Ignore only `docs/tenkz/manual2.pdf`, leaving other PDFs unaffected.

### Testing
- `git diff --check`
- Verified each existing generated file with `git check-ignore -v`.
- Confirmed proof-debt workflow, documentation, and metrics sources remain visible as untracked files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ignore-rule-only change with no runtime or CI behavior impact beyond cleaner working trees.
> 
> **Overview**
> Extends **`.gitignore`** so local scratch and tenkz manual build outputs stop showing up in `git status`.
> 
> Adds **`/tmp/`** at the repo root for scratch work. Under **`docs/tenkz/`**, ignores reproducible tenkz outputs (`.exa`, `.exm`, `.tnlog`) and the built **`manual2.pdf`**, without a blanket `*.pdf` rule so other tracked or reference PDFs stay unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be35bd6385e32e601383723af5063c59663b6dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->