### PR TITLE
refactor(QPF): derive injective results from irreducibility

### DIFF
--- a/TNLean/QPF/Assembly.lean
+++ b/TNLean/QPF/Assembly.lean
@@ -92,15 +92,14 @@ theorem quantum_perron_frobenius [DecidableEq (Fin D)]
     (hD : 0 < D) :
     ∃ ρ : Matrix (Fin D) (Fin D) ℂ,
       HasUniqueFixedPoint (transferMap (d := d) (D := D) A) ρ := by
+  have hIrr := injective_implies_irreducibleCP A hA
   obtain ⟨ρ, hρ_psd, hρ_ne, hρ_fix⟩ := exists_posSemidef_fixedPoint A (by convert hNorm) hD
-  have hρ_pd := posSemidef_fixedPoint_isPosDef A hA ρ hρ_psd hρ_ne hρ_fix
   exact ⟨ρ, {
     fixed := hρ_fix
-    pos_def := hρ_pd
-    unique := fun σ hσ_psd hσ_fix => by
-      by_cases hσ : σ = 0
-      · exact ⟨0, by simp [hσ]⟩
-      · exact posSemidef_fixedPoint_unique A hA ρ σ hρ_psd hρ_ne hσ_psd hσ hρ_fix hσ_fix
+    pos_def := posSemidef_fixedPoint_isPosDef_of_irreducible A hIrr ρ hρ_psd hρ_ne hρ_fix
+    unique := fun σ hσ_psd hσ_fix =>
+      posSemidef_fixedPoint_unique_of_irreducible A hIrr ρ σ
+        hρ_psd hρ_ne hσ_psd hρ_fix hσ_fix
   }⟩
 
 /-! ### Reduction: handle the `D = 0` edge case

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -86,68 +86,6 @@ private lemma ker_invariant_under_adjoint
   intro i
   exact (hρ_psd.dotProduct_mulVec_zero_iff _).mp (h_each_zero i)
 
-private lemma ker_contains_all_of_span
-    (A : MPSTensor d D) (hA : IsInjective A)
-    (ρ : Matrix (Fin D) (Fin D) ℂ)
-    (x : Fin D → ℂ)
-    (h : ∀ i : Fin d, ρ *ᵥ ((A i)ᴴ *ᵥ x) = 0) :
-    ∀ M : Matrix (Fin D) (Fin D) ℂ, ρ *ᵥ (M *ᵥ x) = 0 := by
-  intro M
-  suffices ∀ N : Matrix (Fin D) (Fin D) ℂ, ρ *ᵥ (Nᴴ *ᵥ x) = 0 by
-    specialize this Mᴴ; rwa [Matrix.conjTranspose_conjTranspose] at this
-  intro N
-  have hN : N ∈ Submodule.span ℂ (Set.range A) := hA ▸ Submodule.mem_top
-  induction hN using Submodule.span_induction with
-  | mem y hy =>
-    obtain ⟨i, rfl⟩ := hy
-    exact h i
-  | zero => simp
-  | add a b _ _ ha hb =>
-    simp [Matrix.add_mulVec, Matrix.mulVec_add, ha, hb]
-  | smul c a _ ha =>
-    simp [Matrix.conjTranspose_smul, Matrix.smul_mulVec, Matrix.mulVec_smul, ha]
-
-/-- **Positive definiteness from injectivity** (Wolf Theorem 6.3(2)):
-If `A` is injective and `ρ` is a nonzero PSD fixed point of the transfer map,
-then `ρ` is positive definite. -/
-theorem posSemidef_fixedPoint_isPosDef
-    (A : MPSTensor d D) (hA : IsInjective A)
-    (ρ : Matrix (Fin D) (Fin D) ℂ)
-    (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0)
-    (hρ_fix : transferMap (d := d) (D := D) A ρ = ρ) :
-    ρ.PosDef := by
-  classical
-  rw [Matrix.posDef_iff_dotProduct_mulVec]
-  refine ⟨hρ_psd.isHermitian, fun x hx => ?_⟩
-  have h_nonneg := hρ_psd.dotProduct_mulVec_nonneg x
-  suffices h_ne : star x ⬝ᵥ (ρ *ᵥ x) ≠ 0 from
-    lt_of_le_of_ne h_nonneg (Ne.symm h_ne)
-  intro h_zero
-  have h_ker := (hρ_psd.dotProduct_mulVec_zero_iff x).mp h_zero
-  have h_inv := ker_invariant_under_adjoint A ρ hρ_psd hρ_fix x h_ker
-  have h_all := ker_contains_all_of_span A hA ρ x h_inv
-  have h_surj : ∀ v : Fin D → ℂ, ρ *ᵥ v = 0 := by
-    intro v
-    have ⟨k, hk⟩ : ∃ k, x k ≠ 0 := by
-      by_contra h_all_zero; push Not at h_all_zero
-      exact hx (funext h_all_zero)
-    let M : Matrix (Fin D) (Fin D) ℂ :=
-      Matrix.of (fun i j => if j = k then v i * (x k)⁻¹ else 0)
-    have hMx : M *ᵥ x = v := by
-      ext i
-      simp only [M, Matrix.mulVec, dotProduct, Matrix.of_apply]
-      rw [Finset.sum_eq_single k]
-      · simp [hk]
-      · intro j _ hj; simp [hj]
-      · exact absurd (Finset.mem_univ k)
-    rw [← hMx]; exact h_all M
-  have h_rho_zero : ρ = 0 := by
-    ext i j
-    have h := congr_fun (h_surj (Pi.single j 1)) i
-    simp only [Matrix.mulVec, dotProduct, Pi.single_apply, Pi.zero_apply] at h
-    simpa [Finset.sum_ite_eq, Finset.mem_univ] using h
-  exact hρ_ne h_rho_zero
-
 /-- Corollary for the irreducibility-based formulation (still Wolf Theorem 6.3(2),
 but with `IsIrreducibleMap E` instead of `IsInjective A`). -/
 theorem posSemidef_fixedPoint_isPosDef_of_irreducible
@@ -301,6 +239,18 @@ theorem posSemidef_fixedPoint_isPosDef_of_irreducible
   rcases hQ_zero_or_one with h | h
   · exact hQ_ne_zero h
   · exact hQ_ne_one (by convert h)
+
+/-- **Positive definiteness from injectivity** (Wolf Theorem 6.3(2)):
+If `A` is injective and `ρ` is a nonzero PSD fixed point of the transfer map,
+then `ρ` is positive definite. -/
+theorem posSemidef_fixedPoint_isPosDef
+    (A : MPSTensor d D) (hA : IsInjective A)
+    (ρ : Matrix (Fin D) (Fin D) ℂ)
+    (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0)
+    (hρ_fix : transferMap (d := d) (D := D) A ρ = ρ) :
+    ρ.PosDef :=
+  posSemidef_fixedPoint_isPosDef_of_irreducible A
+    (injective_implies_irreducibleCP A hA) ρ hρ_psd hρ_ne hρ_fix
 
 end PosDef
 

--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -231,30 +231,6 @@ lemma exists_critical_scalar [Nonempty (Fin D)]
   · rw [h_key, hst]; intro h_pd
     exact hHc_not_pd ((Matrix.IsUnit.posDef_star_right_conjugate_iff hS_unit).mp h_pd)
 
-/-- **Uniqueness** (Wolf Theorem 6.3(2), non-degeneracy): any two nonzero PSD
-fixed points of an injective transfer map are proportional. -/
-theorem posSemidef_fixedPoint_unique
-    (A : MPSTensor d D) (hA : IsInjective A)
-    (ρ σ : Matrix (Fin D) (Fin D) ℂ)
-    (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0)
-    (hσ_psd : σ.PosSemidef) (hσ_ne : σ ≠ 0)
-    (hρ_fix : transferMap (d := d) (D := D) A ρ = ρ)
-    (hσ_fix : transferMap (d := d) (D := D) A σ = σ) :
-    ∃ c : ℂ, σ = c • ρ := by
-  classical
-  have hρ_pd := posSemidef_fixedPoint_isPosDef A hA ρ hρ_psd hρ_ne hρ_fix
-  have hσ_pd := posSemidef_fixedPoint_isPosDef A hA σ hσ_psd hσ_ne hσ_fix
-  by_cases hD : D = 0
-  · exact ⟨1, by ext i; exact (Fin.elim0 (hD ▸ i))⟩
-  · haveI : Nonempty (Fin D) := ⟨⟨0, Nat.pos_of_ne_zero hD⟩⟩
-    obtain ⟨c₀, _, hτ_psd, hτ_not_pd⟩ := exists_critical_scalar hρ_pd hσ_pd
-    set τ := σ - (↑c₀ : ℂ) • ρ
-    have hτ_fix : transferMap (d := d) (D := D) A τ = τ := by
-      simp only [τ, map_sub, LinearMap.map_smul, hρ_fix, hσ_fix]
-    by_cases hτ_ne : τ = 0
-    · exact ⟨↑c₀, sub_eq_zero.mp hτ_ne⟩
-    · exact absurd (posSemidef_fixedPoint_isPosDef A hA τ hτ_psd hτ_ne hτ_fix) hτ_not_pd
-
 /-- **Uniqueness under irreducibility** (Wolf Theorem 6.3(2)): any PSD fixed point
 of an irreducible transfer map is proportional to a fixed nonzero PSD fixed point. -/
 theorem posSemidef_fixedPoint_unique_of_irreducible
@@ -285,6 +261,20 @@ theorem posSemidef_fixedPoint_unique_of_irreducible
     · exact absurd
         (posSemidef_fixedPoint_isPosDef_of_irreducible A hIrr τ hτ_psd hτ_ne hτ_fix)
         hτ_not_pd
+
+/-- **Uniqueness** (Wolf Theorem 6.3(2), non-degeneracy): any two nonzero PSD
+fixed points of an injective transfer map are proportional. -/
+theorem posSemidef_fixedPoint_unique
+    (A : MPSTensor d D) (hA : IsInjective A)
+    (ρ σ : Matrix (Fin D) (Fin D) ℂ)
+    (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0)
+    (hσ_psd : σ.PosSemidef) (hσ_ne : σ ≠ 0)
+    (hρ_fix : transferMap (d := d) (D := D) A ρ = ρ)
+    (hσ_fix : transferMap (d := d) (D := D) A σ = σ) :
+    ∃ c : ℂ, σ = c • ρ := by
+  have _hσ_ne := hσ_ne
+  exact posSemidef_fixedPoint_unique_of_irreducible A
+    (injective_implies_irreducibleCP A hA) ρ σ hρ_psd hρ_ne hσ_psd hρ_fix hσ_fix
 
 end Uniqueness
 

--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -272,7 +272,6 @@ theorem posSemidef_fixedPoint_unique
     (hρ_fix : transferMap (d := d) (D := D) A ρ = ρ)
     (hσ_fix : transferMap (d := d) (D := D) A σ = σ) :
     ∃ c : ℂ, σ = c • ρ := by
-  have _hσ_ne := hσ_ne
   exact posSemidef_fixedPoint_unique_of_irreducible A
     (injective_implies_irreducibleCP A hA) ρ σ hρ_psd hρ_ne hσ_psd hρ_fix hσ_fix
 


### PR DESCRIPTION
## Summary

- derive `posSemidef_fixedPoint_isPosDef` from `injective_implies_irreducibleCP` and the existing irreducible-map theorem
- derive `posSemidef_fixedPoint_unique` through the same bridge
- route `quantum_perron_frobenius` through the irreducible QPF APIs
- remove the now-dead injective-only helper `ker_contains_all_of_span`
- preserve all public theorem names and signatures; leave `Primitive.lean` and shared spectral machinery unchanged

This is the QPF first slice only. The spectral-side relocation remains separate.

## Verification

```text
lake build TNLean.QPF.PosDef TNLean.QPF.Uniqueness TNLean.QPF.Assembly TNLean.QPF.Primitive
Build completed successfully (3041 jobs).
```

`git diff --check` passes. The scoped diff is 31 insertions and 92 deletions: net **-61 lines**.

Refs #4568

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor only; behavior and exported lemmas stay the same, with no auth, data, or runtime impact.
> 
> **Overview**
> **Refactors** the MPS quantum Perron–Frobenius layer so injectivity hypotheses no longer carry separate long proofs: **`posSemidef_fixedPoint_isPosDef`** and **`posSemidef_fixedPoint_unique`** are reintroduced as one-line corollaries of the existing **`_of_irreducible`** theorems, using **`injective_implies_irreducibleCP`**.
> 
> **`quantum_perron_frobenius`** in `Assembly.lean` now obtains **`hIrr`** once and calls **`posSemidef_fixedPoint_isPosDef_of_irreducible`** and **`posSemidef_fixedPoint_unique_of_irreducible`** for positive definiteness and uniqueness instead of the injective-named lemmas.
> 
> The injective-only **`ker_contains_all_of_span`** helper and the old standalone PosDef/Uniqueness proof bodies are **removed** (~92 deletions, ~31 insertions). **Public theorem names and signatures are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 192e71179c17f83c0614f63b0d7131cedfe4e639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->