### PR TITLE
refactor(PEPS/RegionBlock): extract region merge calculus

### DIFF
--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -118,14 +118,14 @@ theorem hostMerge_complement (F : CoherentCoarseBlockingFrame (G := G) (d := d) 
     {ζb ζc : VirtualConfig A} {e : Edge G}
     (he : IsRegionIncidentEdge (G := G) F.frame.complement e) :
     hostMerge F ζb ζc e = ζc e := by
-  rw [hostMerge, regionMerge, if_pos he]
+  exact regionMerge_of_incident A F.frame.complement (ζc, ζb) he
 
 /-- The host merge reads the blue configuration on an edge not incident to the complement. -/
 theorem hostMerge_not_complement (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     {ζb ζc : VirtualConfig A} {e : Edge G}
     (he : ¬ IsRegionIncidentEdge (G := G) F.frame.complement e) :
     hostMerge F ζb ζc e = ζb e := by
-  rw [hostMerge, regionMerge, if_neg he]
+  exact regionMerge_of_not_incident A F.frame.complement (ζc, ζb) he
 
 /-- The complement vertex product of a relaxed triple reads the host merge unchanged:
 complement-incident edges read the complement configuration. -/
@@ -135,13 +135,7 @@ theorem complProd_hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A
     (∏ w : {w : V // w ∈ F.frame.complement}, A.component w.1 (fun ie => ζc ie.1) (σc w)) =
       ∏ w : {w : V // w ∈ F.frame.complement},
         A.component w.1 (fun ie => hostMerge F ζb ζc ie.1) (σc w) := by
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1; funext ie
-  have hcinc : IsRegionIncidentEdge (G := G) F.frame.complement ie.1 := by
-    rcases ie.2 with hie | hie
-    · exact Or.inl (by rw [hie]; exact w.2)
-    · exact Or.inr (by rw [hie]; exact w.2)
-  rw [hostMerge_complement F hcinc]
+  exact regionProd_eq_merge (G := G) A F.frame.complement σc (ζc, ζb)
 
 /-- The blue vertex product of a relaxed triple agreeing on the blue-to-complement
 crossings reads the host merge unchanged: a blue-incident edge that is also
@@ -153,20 +147,13 @@ theorem blueProd_hostMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     (∏ w : {w : V // w ∈ F.frame.blue}, A.component w.1 (fun ie => ζb ie.1) (σb w)) =
       ∏ w : {w : V // w ∈ F.frame.blue},
         A.component w.1 (fun ie => hostMerge F ζb ζc ie.1) (σb w) := by
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1; funext ie
-  have hbinc : IsRegionIncidentEdge (G := G) F.frame.blue ie.1 := by
-    rcases ie.2 with hie | hie
-    · exact Or.inl (by rw [hie]; exact w.2)
-    · exact Or.inr (by rw [hie]; exact w.2)
-  by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement ie.1
-  · -- A blue-incident, complement-incident edge is a blue-to-complement crossing.
-    rw [hostMerge_complement F hc]
-    have hbc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement ie.1 :=
-      isCrossing_bc_of_incident F hP hbinc hc
-    have := congrFun h.2 ⟨ie.1, hbc⟩
-    simpa [crossingLabel] using this
-  · rw [hostMerge_not_complement F hc]
+  refine regionProd_p2_eq_merge_of_incident_agree (G := G) A F.frame.complement
+    F.frame.blue σb (ζc, ζb) ?_
+  intro e hc hb
+  have hbc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e :=
+    isCrossing_bc_of_incident F hP hb hc
+  have he := congrFun h.2 ⟨e, hbc⟩
+  simpa [crossingLabel] using he.symm
 
 /-- The host vertex product of the host merge, read with the fused blue/complement physical
 leg, equals the relaxed triple's complement product against its blue product. -/

--- a/TNLean/PEPS/RegionBlock/Recovery.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery.lean
@@ -227,6 +227,22 @@ noncomputable def regionMerge (A : Tensor G d) (R : Finset V)
   fun e => if IsRegionIncidentEdge (G := G) R e then p.1 e else p.2 e
 
 omit [Fintype V] in
+/-- A region merge reads its first configuration on an edge incident to the region. -/
+theorem regionMerge_of_incident (A : Tensor G d) (R : Finset V)
+    (p : VirtualConfig A × VirtualConfig A) {e : Edge G}
+    (he : IsRegionIncidentEdge (G := G) R e) :
+    regionMerge (G := G) A R p e = p.1 e := by
+  rw [regionMerge, if_pos he]
+
+omit [Fintype V] in
+/-- A region merge reads its second configuration on an edge not incident to the region. -/
+theorem regionMerge_of_not_incident (A : Tensor G d) (R : Finset V)
+    (p : VirtualConfig A × VirtualConfig A) {e : Edge G}
+    (he : ¬ IsRegionIncidentEdge (G := G) R e) :
+    regionMerge (G := G) A R p e = p.2 e := by
+  rw [regionMerge, if_neg he]
+
+omit [Fintype V] in
 /-- The region vertex product reads the first configuration only through the
 region-incident edges, so it agrees with the merged configuration. -/
 theorem regionProd_eq_merge (A : Tensor G d) (R : Finset V)
@@ -244,7 +260,30 @@ theorem regionProd_eq_merge (A : Tensor G d) (R : Finset V)
     rcases ie.2 with hie | hie
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
-  rw [regionMerge, if_pos hinc]
+  rw [regionMerge_of_incident A R p hinc]
+
+omit [Fintype V] in
+/-- A vertex product reads the second configuration through a region merge if the two
+configurations agree on every edge incident to both the merge region and the product region. -/
+theorem regionProd_p2_eq_merge_of_incident_agree (A : Tensor G d) (T B : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) B)
+    (p : VirtualConfig A × VirtualConfig A)
+    (hp : ∀ e : Edge G, IsRegionIncidentEdge (G := G) T e →
+      IsRegionIncidentEdge (G := G) B e → p.1 e = p.2 e) :
+    (∏ w : {w : V // w ∈ B}, A.component w.1 (fun ie => p.2 ie.1) (σ w)) =
+      ∏ w : {w : V // w ∈ B},
+        A.component w.1 (fun ie => regionMerge (G := G) A T p ie.1) (σ w) := by
+  classical
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  have hB : IsRegionIncidentEdge (G := G) B ie.1 := by
+    rcases ie.2 with hie | hie
+    · exact Or.inl (by rw [hie]; exact w.2)
+    · exact Or.inr (by rw [hie]; exact w.2)
+  by_cases hT : IsRegionIncidentEdge (G := G) T ie.1
+  · rw [regionMerge_of_incident A T p hT, hp ie.1 hT hB]
+  · rw [regionMerge_of_not_incident A T p hT]
 
 /-- The complement vertex product reads the second configuration only through the
 complement-incident edges, so it agrees with the merged configuration: on the
@@ -257,28 +296,15 @@ theorem complementProd_eq_merge (A : Tensor G d) (R : Finset V)
     (∏ w : {w : V // w ∈ Finset.univ \ R}, A.component w.1 (fun ie => p.2 ie.1) (τ w)) =
       ∏ w : {w : V // w ∈ Finset.univ \ R},
         A.component w.1 (fun ie => regionMerge (G := G) A R p ie.1) (τ w) := by
-  classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  have hw : w.1 ∉ R := by have := w.2; rw [Finset.mem_sdiff] at this; exact this.2
-  by_cases hinc : IsRegionIncidentEdge (G := G) R ie.1
-  · -- `ie` is region-incident but also complement-incident: it is a boundary edge,
-    -- where `p.1` and `p.2` agree.
-    have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-    have hbdry : IsRegionBoundaryEdge (G := G) R ie.1 := by
-      rcases hinc with h1 | h2
-      · -- `ie.1.1.1 ∈ R`; since one endpoint is `w ∉ R`, the edge crosses the boundary.
-        rcases hwinc with hw1 | hw2
-        · exact absurd (by rw [← hw1]; exact h1) hw
-        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hw
-      · rcases hwinc with hw1 | hw2
-        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hw
-        · exact absurd (by rw [← hw2]; exact h2) hw
-    rw [regionMerge, if_pos hinc]
-    have := congrFun hp ⟨ie.1, hbdry⟩
-    simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  apply regionProd_p2_eq_merge_of_incident_agree
+  intro e hR hcompl
+  have hbdry : IsRegionBoundaryEdge (G := G) R e := by
+    rcases hR with hR1 | hR2 <;> rcases hcompl with hc1 | hc2
+    · exact absurd hR1 (Finset.mem_sdiff.mp hc1).2
+    · exact Or.inl ⟨hR1, (Finset.mem_sdiff.mp hc2).2⟩
+    · exact Or.inr ⟨(Finset.mem_sdiff.mp hc1).2, hR2⟩
+    · exact absurd hR2 (Finset.mem_sdiff.mp hc2).2
+  exact congrFun hp ⟨e, hbdry⟩
 
 /-! ### The cardinality collapse to the closed state coefficient
 


### PR DESCRIPTION
## Summary

- add the canonical readback lemmas `regionMerge_of_incident` and `regionMerge_of_not_incident`
- add `regionProd_p2_eq_merge_of_incident_agree`, a generic product readback lemma for a product region whose shared incident edges agree
- specialize the existing complement product theorem and the `hostMerge` readback/product family to this canonical API, leaving only coarse crossing geometry local

This removes duplicated merge proofs without changing the `regionMerge` or `hostMerge` representations. The patch is 2 files, +59/-46.

## Verification

- `lake build TNLean.PEPS.RegionBlock.CoarseThreeSite11` (1966 jobs)
- `git diff --check`
- no new `sorry`, `admit`, or axioms

Refs #4522

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS region-block Lean with no API or definitional changes to merge representations; risk is limited to accidental proof regressions, mitigated by the stated build.
> 
> **Overview**
> Introduces a small **canonical API** for `regionMerge` in `Recovery.lean`: pointwise readback (`regionMerge_of_incident`, `regionMerge_of_not_incident`) and a generic lemma that a region vertex product built from the second config matches the merge when the two configs agree on edges incident to both the merge region and the product region (`regionProd_p2_eq_merge_of_incident_agree`).
> 
> **`regionProd_eq_merge`** now uses the incident readback lemma instead of unfolding `regionMerge` inline. **`complementProd_eq_merge`** is reduced to the new generic product lemma plus a short boundary-edge classification argument, replacing a longer case split.
> 
> In **`CoarseThreeSite9`**, `hostMerge_complement` / `hostMerge_not_complement`, `complProd_hostMerge`, and `blueProd_hostMerge` are thin wrappers around the shared lemmas; only the coarse crossing geometry (e.g. blue–complement agreement from `CrossTripleAgreesAwayRB`) stays local.
> 
> **`regionMerge` and `hostMerge` definitions are unchanged**—this is proof deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f46fba66067f714d23cda284a486325495e6ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->