### PR TITLE
fix(blueprint): restore unitary-group notation

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -2843,7 +2843,7 @@ exists_unitaryNormalization}
     \[
       X_j^\dagger X_j=\omega_j\Id,
       \qquad
-      \omega_j^{-1/2}X_j\in\U(D_j).
+      \omega_j^{-1/2}X_j\in\mathrm{U}(D_j).
     \]
 \end{theorem}
 


### PR DESCRIPTION
Closes #4598.

## Summary

- spell the Chapter 21 unitary group as `\mathrm{U}(D_j)`
- restore the full blueprint PDF build on current `main`

## Root cause

PR #4590 introduced `\U(D_j)`, but the blueprint defines no `\U` control
sequence. The surrounding statement is the usual unitary group, and existing
chapters consistently use `\mathrm{U}(D)`.

## Validation

- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex`
- `git diff --check`
- `leanblueprint pdf` (715 pages; exit 0)

The four remaining unresolved cross-references reported by LaTeX are
pre-existing and unrelated to this one-line correction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single notation fix in blueprint TeX with no Lean or runtime behavior changes.
> 
> **Overview**
> **Fixes a LaTeX build break** in the active-product gauge normalization theorem (`thm:mpdo_active_product_gauge_unitary_normalization`): the conclusion now writes `\omega_j^{-1/2}X_j\in\mathrm{U}(D_j)` instead of `\U(D_j)`.
> 
> PR #4590 had introduced `\U`, which is not defined in the blueprint preamble; other chapters already use `\mathrm{U}(D)` for unitary groups. This one-line change restores consistent notation and unblocks `leanblueprint pdf`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9136dd53402542494bf91965904a251e3e140edf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->