### PR TITLE
refactor(PEPS): transport vertical edge gauge by square swap

### DIFF
--- a/TNLean/PEPS/NormalEdgeGaugeFamily.lean
+++ b/TNLean/PEPS/NormalEdgeGaugeFamily.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.PEPS.NormalEdgeBlockingInterior
 import TNLean.PEPS.NormalEdgeSingleCrossing
+import TNLean.PEPS.SquareLatticeCoordinateSwap
 import TNLean.PEPS.CoherentFrameInstance2
 import TNLean.Algebra.ScalarCommutant
 
@@ -314,39 +315,36 @@ theorem exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge
   subst he
   have hew : xStart + 3 ≤ width := by omega
   have heh : yStart + 3 ≤ height := by omega
+  let φ := squareLatticeCoordinateSwap (width := width) (height := height)
   let e := normalSquareVerticalTranslatedEdge xStart yStart hew heh
-  change ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ)
-      (fwd : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ →
-        Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ),
-      ∀ M, fwd M =
-          (Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
-            Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
-            ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
-              Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)
-  let DA := normalSquareVerticalTranslatedEdge_blockingDatum_interior
-      (κ := regionInjectivityDataOf A) hA hUA hx0 hy0 hxw hyh
-  let DB := normalSquareVerticalTranslatedEdge_blockingDatum_interior
-      (κ := regionInjectivityDataOf B) hB hUB hx0 hy0 hxw hyh
-  have hDAred : DA.red = normalSquareVerticalTranslatedEdgeRed xStart yStart := rfl
-  have hDAblue : DA.blue = normalSquareVerticalTranslatedEdgeBlue xStart yStart := rfl
-  have hred : DA.red = DB.red := rfl
-  have hblue : DA.blue = DB.blue := rfl
-  have hcompl : DA.complement = DB.complement := rfl
-  have hsingle : ∀ g, IsCrossingEdge (G := squareLatticeGraph width height) A DA.red DA.blue g
-      ↔ g = e := by
-    intro g
-    rw [hDAred, hDAblue]
-    exact isCrossingEdge_normalSquareVerticalTranslatedEdge (width := width) (height := height)
-      A (xStart := xStart) (yStart := yStart) hew heh g
-  have hRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B DA.red := by
-    rw [hred]; exact regionBlockedTensorInjective_red DB
-  have hCB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
-      (Finset.univ \ DA.red) := by
-    rw [hred]; exact regionBlockedTensorInjective_host DB hUB
-  obtain ⟨_, _, _, hEdge, Z, hZ⟩ :=
-    exists_regionEdgeGauge_of_blockingData (A := A) (B := B) (e := e) DA DB
-      hred hblue hcompl hbond hAB hd hposA hposB hsingle hRB hCB
-  exact ⟨hEdge, Z, _, hZ⟩
+  let e' := Edge.map φ e
+  have hbond' : (A.transport φ).bondDim = (B.transport φ).bondDim := by
+    funext g
+    simp only [Tensor.transport_bondDim]
+    rw [hbond]
+  have hposA' : ∀ g : Edge (squareLatticeGraph height width),
+      0 < (A.transport φ).bondDim g := fun g => hposA (Edge.map φ.symm g)
+  have hposB' : ∀ g : Edge (squareLatticeGraph height width),
+      0 < (B.transport φ).bondDim g := fun g => hposB (Edge.map φ.symm g)
+  have he' : e' = normalSquareHorizontalTranslatedEdge yStart xStart heh hew := by
+    dsimp only [e', e, φ]
+    exact Edge.map_squareLatticeCoordinateSwap_verticalTranslatedEdge hew heh
+  have hGauge := exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge
+    (width := height) (height := width) (A.transport φ) (B.transport φ)
+    (hA.transportCoordinateSwap A) (hUA.transportCoordinateSwap A)
+    (hB.transportCoordinateSwap B) (hUB.transportCoordinateSwap B)
+    hy0 hx0 hyh hxw hbond' (hAB.transport φ) hd hposA' hposB' e' he'
+  have hAedge : (A.transport φ).bondDim e' = A.bondDim e := by
+    simp only [e', φ, Tensor.transport_bondDim,
+      squareLatticeCoordinateSwap_symm,
+      Edge.map_squareLatticeCoordinateSwap_map]
+  have hBedge : (B.transport φ).bondDim e' = B.bondDim e := by
+    simp only [e', φ, Tensor.transport_bondDim,
+      squareLatticeCoordinateSwap_symm,
+      Edge.map_squareLatticeCoordinateSwap_map]
+  rw [hAedge, hBedge] at hGauge
+  simpa only [e] using hGauge
+
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/SquareLatticeCoordinateSwap.lean
+++ b/TNLean/PEPS/SquareLatticeCoordinateSwap.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.RegionTransportData
+import TNLean.PEPS.SquareLatticeGraph
+import TNLean.PEPS.NormalEdgeBlockingTranslated
+
+/-!
+# Coordinate swap on finite square lattices
+
+Interchanging the two coordinates identifies the `width × height` square lattice
+with the `height × width` lattice. This exchanges horizontal and vertical edges
+and transposes contiguous rectangles.
+-/
+
+namespace TNLean
+namespace PEPS
+
+/-- Interchange the coordinates of a finite square-lattice vertex. -/
+def squareLatticeCoordinateSwapEquiv (width height : ℕ) :
+    SquareLatticeVertex width height ≃ SquareLatticeVertex height width :=
+  Equiv.prodComm (Fin width) (Fin height)
+
+@[simp] theorem squareLatticeCoordinateSwapEquiv_apply {width height : ℕ}
+    (v : SquareLatticeVertex width height) :
+    squareLatticeCoordinateSwapEquiv width height v = (v.2, v.1) :=
+  rfl
+
+/-- Coordinate swap as an isomorphism of finite square-lattice graphs. -/
+def squareLatticeCoordinateSwap {width height : ℕ} :
+    squareLatticeGraph width height ≃g squareLatticeGraph height width where
+  toEquiv := squareLatticeCoordinateSwapEquiv width height
+  map_rel_iff' := by
+    intro v w
+    rw [squareLatticeGraph_adj, squareLatticeGraph_adj]
+    change squareLatticeHorizontalNeighbor (v.2, v.1) (w.2, w.1) ∨
+        squareLatticeVerticalNeighbor (v.2, v.1) (w.2, w.1) ↔
+      squareLatticeHorizontalNeighbor v w ∨ squareLatticeVerticalNeighbor v w
+    change squareLatticeVerticalNeighbor v w ∨ squareLatticeHorizontalNeighbor v w ↔ _
+    exact or_comm
+
+@[simp] theorem squareLatticeCoordinateSwap_apply {width height : ℕ}
+    (v : SquareLatticeVertex width height) :
+    squareLatticeCoordinateSwap v = (v.2, v.1) :=
+  rfl
+
+@[simp] theorem squareLatticeCoordinateSwap_symm {width height : ℕ} :
+    (squareLatticeCoordinateSwap (width := width) (height := height)).symm =
+      squareLatticeCoordinateSwap (width := height) (height := width) :=
+  rfl
+
+@[simp] theorem Edge.map_squareLatticeCoordinateSwap_map {width height : ℕ}
+    (e : Edge (squareLatticeGraph width height)) :
+    Edge.map (squareLatticeCoordinateSwap (width := height) (height := width))
+        (Edge.map squareLatticeCoordinateSwap e) = e := by
+  rw [← squareLatticeCoordinateSwap_symm]
+  exact Edge.map_symm_map squareLatticeCoordinateSwap e
+
+/-- Coordinate swap transposes a contiguous square-lattice rectangle. -/
+theorem Region_map_squareLatticeCoordinateSwap_contiguousRectangle
+    {width height : ℕ} (xStart yStart xLength yLength : ℕ) :
+    Region.map squareLatticeCoordinateSwap
+        (squareLatticeContiguousRectangle xStart yStart xLength yLength) =
+      (squareLatticeContiguousRectangle yStart xStart yLength xLength :
+        Finset (SquareLatticeVertex height width)) := by
+  ext v
+  simp only [mem_Region_map, squareLatticeCoordinateSwap_symm,
+    squareLatticeCoordinateSwap_apply, mem_squareLatticeContiguousRectangle]
+  tauto
+
+/-- Injectivity of a region for a coordinate-swapped tensor is injectivity of its
+transposed preimage for the original tensor. -/
+theorem regionInjectivityDataOf_transport_squareLatticeCoordinateSwap_isInjective
+    {width height d : ℕ} (A : Tensor (squareLatticeGraph width height) d)
+    (R : Finset (SquareLatticeVertex height width)) :
+    (regionInjectivityDataOf (A.transport squareLatticeCoordinateSwap)).IsInjective R ↔
+      (regionInjectivityDataOf A).IsInjective
+        (Region.map (squareLatticeCoordinateSwap (width := height) (height := width)) R) := by
+  change RegionBlockedTensorInjective (A.transport squareLatticeCoordinateSwap) R ↔
+    RegionBlockedTensorInjective A (Region.map squareLatticeCoordinateSwap R)
+  let S := Region.map
+    (squareLatticeCoordinateSwap (width := height) (height := width)) R
+  have hS : Region.map
+      (squareLatticeCoordinateSwap (width := width) (height := height)) S = R := by
+    ext v
+    simp only [S, mem_Region_map, squareLatticeCoordinateSwap_symm,
+      squareLatticeCoordinateSwap_apply]
+  change RegionBlockedTensorInjective (A.transport squareLatticeCoordinateSwap) R ↔
+    RegionBlockedTensorInjective A S
+  rw [← hS]
+  exact regionBlockedTensorInjective_transport A squareLatticeCoordinateSwap S
+
+/-- Coordinate swap preserves the rectangular injectivity hypotheses of a tensor. -/
+theorem NormalSquareLatticeRectangleInjectivityHypotheses.transportCoordinateSwap
+    {width height d : ℕ} (A : Tensor (squareLatticeGraph width height) d)
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses (regionInjectivityDataOf A)) :
+    NormalSquareLatticeRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (A.transport squareLatticeCoordinateSwap)) where
+  twoByThree_injective := by
+    rintro R ⟨x, y, hx, hy, rfl⟩
+    rw [regionInjectivityDataOf_transport_squareLatticeCoordinateSwap_isInjective,
+      Region_map_squareLatticeCoordinateSwap_contiguousRectangle]
+    exact h.rect32_injective hy hx
+  threeByTwo_injective := by
+    rintro R ⟨x, y, hx, hy, rfl⟩
+    rw [regionInjectivityDataOf_transport_squareLatticeCoordinateSwap_isInjective,
+      Region_map_squareLatticeCoordinateSwap_contiguousRectangle]
+    exact h.rect23_injective hy hx
+
+/-- Coordinate swap preserves closure of tensor injectivity under unions. -/
+theorem RegionInjectivityUnionClosure.transportCoordinateSwap
+    {width height d : ℕ} (A : Tensor (squareLatticeGraph width height) d)
+    (h : RegionInjectivityUnionClosure (regionInjectivityDataOf A)) :
+    RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (A.transport squareLatticeCoordinateSwap)) where
+  union_injective := by
+    intro R S hR hS
+    rw [regionInjectivityDataOf_transport_squareLatticeCoordinateSwap_isInjective] at hR hS ⊢
+    rw [Region_map_union]
+    exact h.union_injective hR hS
+
+/-- Coordinate swap sends the distinguished translated vertical edge to the
+translated horizontal edge in the transposed frame. -/
+theorem Edge.map_squareLatticeCoordinateSwap_verticalTranslatedEdge
+    {width height xStart yStart : ℕ}
+    (hx : xStart + 3 ≤ width) (hy : yStart + 3 ≤ height) :
+    Edge.map squareLatticeCoordinateSwap
+        (normalSquareVerticalTranslatedEdge xStart yStart hx hy) =
+      normalSquareHorizontalTranslatedEdge yStart xStart hy hx := by
+  apply Edge.ofAdj_eq_of_endpoints
+  rcases Edge.map_endpoints squareLatticeCoordinateSwap
+      (normalSquareVerticalTranslatedEdge xStart yStart hx hy) with h | h
+  · exact Or.inl ⟨rfl, rfl⟩
+  · exfalso
+    have hlt := (Edge.map squareLatticeCoordinateSwap
+      (normalSquareVerticalTranslatedEdge xStart yStart hx hy)).2.1
+    rw [h.1, h.2] at hlt
+    change toLex
+      ((⟨yStart + 2, by omega⟩ : Fin height), (⟨xStart + 2, by omega⟩ : Fin width)) <
+      toLex ((⟨yStart + 1, by omega⟩ : Fin height),
+        (⟨xStart + 2, by omega⟩ : Fin width)) at hlt
+    rw [Prod.Lex.toLex_lt_toLex] at hlt
+    simp at hlt
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/SquareLatticeCoordinateSwap.lean
+++ b/TNLean/PEPS/SquareLatticeCoordinateSwap.lean
@@ -28,6 +28,22 @@ def squareLatticeCoordinateSwapEquiv (width height : ℕ) :
     squareLatticeCoordinateSwapEquiv width height v = (v.2, v.1) :=
   rfl
 
+/-- Coordinate swap exchanges horizontal and vertical square-lattice neighbours. -/
+theorem squareLatticeHorizontalNeighbor_coordinateSwap {width height : ℕ}
+    {v w : SquareLatticeVertex width height} :
+    squareLatticeVerticalNeighbor (squareLatticeCoordinateSwapEquiv width height v)
+      (squareLatticeCoordinateSwapEquiv width height w) ↔
+      squareLatticeHorizontalNeighbor v w :=
+  Iff.rfl
+
+/-- Coordinate swap exchanges vertical and horizontal square-lattice neighbours. -/
+theorem squareLatticeVerticalNeighbor_coordinateSwap {width height : ℕ}
+    {v w : SquareLatticeVertex width height} :
+    squareLatticeHorizontalNeighbor (squareLatticeCoordinateSwapEquiv width height v)
+      (squareLatticeCoordinateSwapEquiv width height w) ↔
+        squareLatticeVerticalNeighbor v w :=
+  Iff.rfl
+
 /-- Coordinate swap as an isomorphism of finite square-lattice graphs. -/
 def squareLatticeCoordinateSwap {width height : ℕ} :
     squareLatticeGraph width height ≃g squareLatticeGraph height width where
@@ -35,11 +51,8 @@ def squareLatticeCoordinateSwap {width height : ℕ} :
   map_rel_iff' := by
     intro v w
     rw [squareLatticeGraph_adj, squareLatticeGraph_adj]
-    change squareLatticeHorizontalNeighbor (v.2, v.1) (w.2, w.1) ∨
-        squareLatticeVerticalNeighbor (v.2, v.1) (w.2, w.1) ↔
-      squareLatticeHorizontalNeighbor v w ∨ squareLatticeVerticalNeighbor v w
-    change squareLatticeVerticalNeighbor v w ∨ squareLatticeHorizontalNeighbor v w ↔ _
-    exact or_comm
+    rw [squareLatticeHorizontalNeighbor_coordinateSwap,
+      squareLatticeVerticalNeighbor_coordinateSwap, or_comm]
 
 @[simp] theorem squareLatticeCoordinateSwap_apply {width height : ℕ}
     (v : SquareLatticeVertex width height) :


### PR DESCRIPTION
## Summary

- add the finite square-lattice coordinate-swap graph isomorphism in `SquareLatticeCoordinateSwap`
- record only the rectangle, region-injectivity, union-closure, and distinguished-edge covariance needed by the gauge capstone
- derive `exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge` from its horizontal twin by transporting both tensors across coordinate swap
- preserve the vertical theorem statement byte-for-byte, including its gauge witness and conjugation identity

Part of #4526.

## Verification

- `lake build TNLean.PEPS.SquareLatticeCoordinateSwap TNLean.PEPS.NormalEdgeGaugeFamily`
- public vertical theorem statement compared byte-for-byte against `origin/main`
- `git diff --check`
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in the changed files
- `NormalEdgeGaugeFamily.lean`: +30/-32 (net deletion of 2 lines)

## Scope

Only `TNLean/PEPS/SquareLatticeCoordinateSwap.lean` and `TNLean/PEPS/NormalEdgeGaugeFamily.lean` are changed. Region-block merge files, union-injectivity files, torus staircase files, docs, and `TNLean.lean` are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in formal Lean PEPS code; no runtime, auth, or data-path changes, and the public vertical theorem statement is preserved.
> 
> **Overview**
> Introduces **`squareLatticeCoordinateSwap`**, a graph isomorphism that swaps `width × height` with `height × width`, together with the lemmas needed to transport PEPS tensors and their injectivity hypotheses (rectangles, region injectivity, union closure) and to identify a translated **vertical** interior edge with the corresponding **horizontal** edge in the transposed frame.
> 
> **`exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge`** is no longer proved by repeating the horizontal blocking-datum / `exists_regionEdgeGauge_of_blockingData` argument. The proof now transports `A` and `B` across the swap, applies the existing horizontal gauge theorem on the mapped edge, and rewrites bond dimensions back to the original vertical edge. The vertical theorem’s **statement** (existence of `hEdge`, `Z`, and the conjugation identity for `fwd`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7675bda0ac99f1e441db2c46f7d36071b13ddf82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
