### PR TITLE
feat(tenkz): add corpus render baselines

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -37,7 +37,9 @@ on:
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_corpus.sh'
+      - 'scripts/tenkz_render_corpus.py'
       - 'scripts/test_tenkz_corpus_provenance.py'
+      - 'scripts/test_tenkz_corpus_render.py'
       - 'scripts/tenkz_lint.py'
       - 'scripts/test_tenkz_pic.py'
       - 'scripts/test_tenkz_cd_map_labels.py'
@@ -76,7 +78,9 @@ on:
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_corpus.sh'
+      - 'scripts/tenkz_render_corpus.py'
       - 'scripts/test_tenkz_corpus_provenance.py'
+      - 'scripts/test_tenkz_corpus_render.py'
       - 'scripts/tenkz_lint.py'
       - 'scripts/test_tenkz_pic.py'
       - 'scripts/test_tenkz_cd_map_labels.py'
@@ -161,7 +165,9 @@ jobs:
               - 'tests/tenkz/**'
               - 'scripts/tenkz_audit.py'
               - 'scripts/tenkz_corpus.sh'
+              - 'scripts/tenkz_render_corpus.py'
               - 'scripts/test_tenkz_corpus_provenance.py'
+              - 'scripts/test_tenkz_corpus_render.py'
             workflow:
               - '.github/workflows/pr-ci.yml'
 
@@ -183,6 +189,9 @@ jobs:
 
       - name: Test tenkz provenance invariant
         run: python3 scripts/test_tenkz_corpus_provenance.py
+
+      - name: Test tenkz render baseline replacement
+        run: python3 scripts/test_tenkz_corpus_render.py
 
       - name: Install TeX dependencies
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -1074,6 +1074,9 @@ them.
    between phases, under a pixel-identity regression gate: baseline renders first, byte-equal
    event streams and unchanged pages after. Two passes cleaned Phase 0; a third cleaned the
    grid, lattice, and cd modules after the Phase-0.5 growth.
+   The durable render contract is the corpus-wide 200-dpi before/after procedure in
+   `tests/tenkz/README.md`: issue #4158 requires equal fixture/page censuses and PNG checksums
+   for behavior-preserving work, while intentional changes require page-by-page visual review.
 2. **The mathematical referee.** Every figure is refereed against its formula: the formula is
    stated; the ink matches it exactly — open legs counted (no open legs = scalar), signatures
    balanced across `=`, the channel spelling canonical, conjugation on the bra layer, trace

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -28,6 +28,11 @@ Render for visual review (exit codes do not review figures — eyes do):
 pdftocairo -png -r 200 -singlefile <file>.pdf <file>
 ```
 
+For repository-wide review, `scripts/tenkz_corpus.sh --render` compiles and
+audits the adopted corpus before producing a complete 200-dpi PNG baseline.
+The before/after checksum and visual-review discipline is specified in
+`tests/tenkz/README.md`.
+
 Audit the event stream after a compile: `scripts/tenkz_audit.py` over the
 produced `.tnlog`. `scripts/tenkz_lint.py` checks source conventions.
 The asymmetric-port regression is `python3 scripts/test_tenkz_face_ports.py`;
@@ -85,7 +90,8 @@ style; never pixel-mimic, and never draw what the source does not assert.
 
 ## Test corpus
 
-The in-repo acceptance set lives in `tex/tenkz/examples/`. The extended
-regression corpus is tracked by the corpus-adoption issue; until it
-lands in-repo, treat every package change as requiring: the examples
-compile, the manual compiles, and renders of anything touched are viewed.
+The in-repo acceptance set lives in `tex/tenkz/examples/`. The adopted
+extended regression corpus lives in `tests/tenkz/`; run
+`scripts/tenkz_corpus.sh` for compile-and-audit coverage and add `--render` for
+the repository-wide visual baseline. Every package change still requires the
+examples and manual to compile and renders of anything touched to be viewed.

--- a/scripts/tenkz_corpus.sh
+++ b/scripts/tenkz_corpus.sh
@@ -60,6 +60,9 @@ if [[ "$RENDER_DIR_SET" -eq 1 && "$RENDER" -ne 1 ]]; then
   echo "FAIL: --render-dir requires --render" >&2
   exit 2
 fi
+if [[ "$RENDER" -eq 1 && "$RENDER_DIR" != /* ]]; then
+  RENDER_DIR="$REPO/$RENDER_DIR"
+fi
 if [[ "${TENKZ_CORPUS_VALIDATE_ONLY:-0}" == 1 && "$RENDER" -eq 1 ]]; then
   echo "FAIL: --render cannot be combined with TENKZ_CORPUS_VALIDATE_ONLY=1" >&2
   exit 2

--- a/scripts/tenkz_corpus.sh
+++ b/scripts/tenkz_corpus.sh
@@ -7,6 +7,63 @@ CORPUS="$REPO/tests/tenkz"
 # Test seam for the isolated manifest-mutation regression.
 PROVENANCE=${TENKZ_CORPUS_PROVENANCE:-"$CORPUS/PROVENANCE.tsv"}
 JOBS=${TENKZ_CORPUS_JOBS:-4}
+RENDER=0
+RENDER_DIR="$REPO/build/tenkz-corpus-render"
+RENDER_DIR_SET=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/tenkz_corpus.sh [--render] [--render-dir DIRECTORY]
+
+Compile and audit the standalone tenkz regression corpus.  --render also
+produces deterministic 200-dpi PNGs; its default output directory is
+build/tenkz-corpus-render.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --render)
+      if [[ "$RENDER" -eq 1 ]]; then
+        echo "FAIL: --render may be specified only once" >&2
+        exit 2
+      fi
+      RENDER=1
+      shift
+      ;;
+    --render-dir)
+      if [[ "$RENDER_DIR_SET" -eq 1 ]]; then
+        echo "FAIL: --render-dir may be specified only once" >&2
+        exit 2
+      fi
+      if [[ $# -lt 2 || -z "$2" || "$2" == -* ]]; then
+        echo "FAIL: --render-dir requires a non-empty directory" >&2
+        exit 2
+      fi
+      RENDER_DIR=$2
+      RENDER_DIR_SET=1
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "FAIL: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$RENDER_DIR_SET" -eq 1 && "$RENDER" -ne 1 ]]; then
+  echo "FAIL: --render-dir requires --render" >&2
+  exit 2
+fi
+if [[ "${TENKZ_CORPUS_VALIDATE_ONLY:-0}" == 1 && "$RENDER" -eq 1 ]]; then
+  echo "FAIL: --render cannot be combined with TENKZ_CORPUS_VALIDATE_ONLY=1" >&2
+  exit 2
+fi
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "FAIL: tenkz corpus requires python3" >&2
@@ -175,7 +232,11 @@ if [[ "${TENKZ_CORPUS_VALIDATE_ONLY:-0}" == 1 ]]; then
   exit 0
 fi
 
-for command in timeout xelatex; do
+required_commands=(timeout xelatex)
+if [[ "$RENDER" -eq 1 ]]; then
+  required_commands+=(pdfinfo pdftocairo)
+fi
+for command in "${required_commands[@]}"; do
   if ! command -v "$command" >/dev/null 2>&1; then
     echo "FAIL: tenkz corpus requires $command" >&2
     exit 1
@@ -267,6 +328,14 @@ passed=$(find "$RESULTS" -maxdepth 1 -type f -name '*.ok' | wc -l | tr -d ' ')
 if [[ "$passed" -ne "$source_count" ]]; then
   echo "FAIL: compiled and audited $passed of $source_count corpus files" >&2
   exit 1
+fi
+
+if [[ "$RENDER" -eq 1 ]]; then
+  python3 "$REPO/scripts/tenkz_render_corpus.py" \
+    --input-dir "$WORK" \
+    --output-dir "$RENDER_DIR" \
+    --protect "$REPO" \
+    --protect "$CORPUS"
 fi
 
 echo "PASS: compiled and audited $passed standalone tenkz corpus files"

--- a/scripts/tenkz_render_corpus.py
+++ b/scripts/tenkz_render_corpus.py
@@ -38,7 +38,7 @@ def has_valid_ownership_marker(output_dir: Path) -> bool:
         return False
     try:
         return marker.read_text(encoding="utf-8") == MARKER_CONTENT
-    except OSError:
+    except (OSError, UnicodeError):
         return False
 
 

--- a/scripts/tenkz_render_corpus.py
+++ b/scripts/tenkz_render_corpus.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import hashlib
 import os
 import re
@@ -12,12 +13,15 @@ import stat
 import subprocess
 import sys
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
 
 DPI = 200
 MARKER_NAME = ".tenkz-corpus-render"
 MARKER_CONTENT = "tenkz-corpus-render-v1\n"
+_UNSET = object()
 
 
 class RenderError(RuntimeError):
@@ -42,6 +46,82 @@ def has_valid_ownership_marker(output_dir: Path) -> bool:
         return False
 
 
+def destination_snapshot(output_dir: Path) -> tuple[tuple[object, ...], ...] | None:
+    """Capture enough identity metadata to detect a destination changed during rendering."""
+    try:
+        root_status = output_dir.lstat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise RenderError(f"cannot inspect render destination {output_dir}: {exc}") from exc
+
+    entries: list[tuple[object, ...]] = [
+        (".", root_status.st_mode, root_status.st_dev, root_status.st_ino,
+         root_status.st_size, root_status.st_mtime_ns, "")
+    ]
+    try:
+        for root, directories, files in os.walk(output_dir, followlinks=False):
+            directories.sort()
+            files.sort()
+            root_path = Path(root)
+            for name in [*directories, *files]:
+                path = root_path / name
+                status = path.lstat()
+                target = os.readlink(path) if stat.S_ISLNK(status.st_mode) else ""
+                entries.append(
+                    (
+                        path.relative_to(output_dir).as_posix(),
+                        status.st_mode,
+                        status.st_dev,
+                        status.st_ino,
+                        status.st_size,
+                        status.st_mtime_ns,
+                        target,
+                    )
+                )
+    except OSError as exc:
+        raise RenderError(f"cannot snapshot render destination {output_dir}: {exc}") from exc
+    return tuple(entries)
+
+
+@contextmanager
+def destination_lock(output_dir: Path) -> Iterator[None]:
+    """Serialize cooperating installers for one destination without replacing the lock inode."""
+    lock = output_dir.parent / f".{output_dir.name}.install.lock"
+    flags = os.O_RDWR | os.O_CREAT | os.O_NONBLOCK
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(lock, flags, 0o600)
+    except OSError as exc:
+        raise RenderError(f"cannot open render destination lock {lock}: {exc}") from exc
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise RenderError(f"render destination lock is not a regular file: {lock}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise RenderError(f"another render is installing at {output_dir}") from exc
+        yield
+    finally:
+        os.close(descriptor)
+
+
+def validate_output_dir(output_dir: Path) -> None:
+    if output_dir.is_symlink():
+        raise RenderError(f"output directory must not be a symlink: {output_dir}")
+    if output_dir.exists() and not output_dir.is_dir():
+        raise RenderError(f"output path exists and is not a directory: {output_dir}")
+    if (
+        output_dir.exists()
+        and any(output_dir.iterdir())
+        and not has_valid_ownership_marker(output_dir)
+    ):
+        raise RenderError(
+            f"refusing to replace nonempty directory without a valid regular "
+            f"{MARKER_NAME}: {output_dir}"
+        )
+
+
 def validate_paths(input_dir: Path, output_dir: Path, protected: list[Path]) -> None:
     if not input_dir.is_dir():
         raise RenderError(f"input directory does not exist: {input_dir}")
@@ -56,19 +136,7 @@ def validate_paths(input_dir: Path, output_dir: Path, protected: list[Path]) -> 
         raise RenderError("input and output directories must not contain one another")
     if output_dir in protected:
         raise RenderError(f"refusing to replace protected directory: {output_dir}")
-    if output_dir.is_symlink():
-        raise RenderError(f"output directory must not be a symlink: {output_dir}")
-    if output_dir.exists() and not output_dir.is_dir():
-        raise RenderError(f"output path exists and is not a directory: {output_dir}")
-    if (
-        output_dir.exists()
-        and any(output_dir.iterdir())
-        and not has_valid_ownership_marker(output_dir)
-    ):
-        raise RenderError(
-            f"refusing to replace nonempty directory without a valid regular "
-            f"{MARKER_NAME}: {output_dir}"
-        )
+    validate_output_dir(output_dir)
 
 
 def require_tool(name: str) -> str:
@@ -168,7 +236,31 @@ def write_manifests(stage: Path, census: list[tuple[str, int]], pngs: list[Path]
     (stage / "SHA256SUMS").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
 
 
-def install_stage(stage: Path, output_dir: Path) -> None:
+def install_stage(
+    stage: Path,
+    output_dir: Path,
+    expected: tuple[tuple[object, ...], ...] | None | object = _UNSET,
+) -> None:
+    with destination_lock(output_dir):
+        install_stage_locked(stage, output_dir, expected)
+
+
+def install_stage_locked(
+    stage: Path,
+    output_dir: Path,
+    expected: tuple[tuple[object, ...], ...] | None | object,
+) -> None:
+    if expected is _UNSET:
+        validate_output_dir(output_dir)
+        expected = destination_snapshot(output_dir)
+    else:
+        current = destination_snapshot(output_dir)
+        if current != expected:
+            raise RenderError(
+                f"render destination changed while rendering; refusing to replace it: {output_dir}"
+            )
+        validate_output_dir(output_dir)
+
     backup = output_dir.parent / f".{output_dir.name}.previous.{os.getpid()}"
     if backup.exists():
         raise RenderError(f"stale render backup blocks installation: {backup}")
@@ -179,6 +271,21 @@ def install_stage(stage: Path, output_dir: Path) -> None:
             output_dir.rename(backup)
         except OSError as exc:
             raise RenderError(f"cannot stage prior baseline at {backup}: {exc}") from exc
+
+        actual = destination_snapshot(backup)
+        if actual != expected:
+            try:
+                backup.rename(output_dir)
+            except OSError as restore_exc:
+                raise RenderError(
+                    f"render destination changed while rendering; concurrent data is retained "
+                    f"at {backup}, but restoring it to {output_dir} failed: {restore_exc}"
+                ) from restore_exc
+            raise RenderError(
+                f"render destination changed while rendering; refusing to replace it: {output_dir}"
+            )
+    elif expected is not None:
+        raise RenderError(f"render destination changed while rendering: {output_dir}")
 
     try:
         stage.rename(output_dir)
@@ -216,6 +323,9 @@ def render_corpus(input_dir: Path, output_dir: Path, protected: list[Path]) -> t
     pdftocairo = require_tool("pdftocairo")
     pdfs = compiled_pdfs(input_dir)
     output_dir.parent.mkdir(parents=True, exist_ok=True)
+    with destination_lock(output_dir):
+        validate_paths(input_dir, output_dir, protected)
+        expected_output = destination_snapshot(output_dir)
     stage = Path(
         tempfile.mkdtemp(prefix=f".{output_dir.name}.staging.", dir=output_dir.parent)
     )
@@ -233,7 +343,7 @@ def render_corpus(input_dir: Path, output_dir: Path, protected: list[Path]) -> t
                 render_page(pdf, page, destination, pdftocairo)
                 pngs.append(destination)
         write_manifests(stage, census, pngs)
-        install_stage(stage, output_dir)
+        install_stage(stage, output_dir, expected_output)
     except Exception:
         if stage.exists():
             shutil.rmtree(stage)

--- a/scripts/tenkz_render_corpus.py
+++ b/scripts/tenkz_render_corpus.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Render a compiled tenkz corpus into a deterministic PNG baseline tree."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+DPI = 200
+MARKER_NAME = ".tenkz-corpus-render"
+MARKER_CONTENT = "tenkz-corpus-render-v1\n"
+
+
+class RenderError(RuntimeError):
+    """A render precondition or tool invocation failed."""
+
+
+def resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def has_valid_ownership_marker(output_dir: Path) -> bool:
+    marker = output_dir / MARKER_NAME
+    try:
+        marker_status = marker.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISREG(marker_status.st_mode):
+        return False
+    try:
+        return marker.read_text(encoding="utf-8") == MARKER_CONTENT
+    except OSError:
+        return False
+
+
+def validate_paths(input_dir: Path, output_dir: Path, protected: list[Path]) -> None:
+    if not input_dir.is_dir():
+        raise RenderError(f"input directory does not exist: {input_dir}")
+    if output_dir == Path(output_dir.anchor):
+        raise RenderError(f"refusing to replace filesystem root: {output_dir}")
+    paths_overlap = (
+        output_dir == input_dir
+        or output_dir in input_dir.parents
+        or input_dir in output_dir.parents
+    )
+    if paths_overlap:
+        raise RenderError("input and output directories must not contain one another")
+    if output_dir in protected:
+        raise RenderError(f"refusing to replace protected directory: {output_dir}")
+    if output_dir.is_symlink():
+        raise RenderError(f"output directory must not be a symlink: {output_dir}")
+    if output_dir.exists() and not output_dir.is_dir():
+        raise RenderError(f"output path exists and is not a directory: {output_dir}")
+    if (
+        output_dir.exists()
+        and any(output_dir.iterdir())
+        and not has_valid_ownership_marker(output_dir)
+    ):
+        raise RenderError(
+            f"refusing to replace nonempty directory without a valid regular "
+            f"{MARKER_NAME}: {output_dir}"
+        )
+
+
+def require_tool(name: str) -> str:
+    executable = shutil.which(name)
+    if executable is None:
+        raise RenderError(f"tenkz corpus rendering requires {name}")
+    return executable
+
+
+def compiled_pdfs(input_dir: Path) -> list[Path]:
+    sources = sorted(input_dir.glob("*.tex"), key=lambda path: path.name)
+    if not sources:
+        raise RenderError(f"no corpus sources found in {input_dir}")
+
+    expected = {source.with_suffix(".pdf") for source in sources}
+    missing = sorted(path.name for path in expected if not path.is_file())
+    if missing:
+        raise RenderError("compiled corpus PDFs are missing: " + ", ".join(missing))
+
+    actual = {path for path in input_dir.glob("*.pdf") if path.is_file()}
+    extras = sorted(path.name for path in actual - expected)
+    if extras:
+        raise RenderError("unexpected PDFs in compiled corpus: " + ", ".join(extras))
+    return sorted(expected, key=lambda path: path.name)
+
+
+def pdf_page_count(pdf: Path, pdfinfo: str) -> int:
+    try:
+        result = subprocess.run(
+            [pdfinfo, str(pdf)],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RenderError(f"pdfinfo timed out for {pdf.name}") from exc
+    if result.returncode:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        raise RenderError(f"pdfinfo failed for {pdf.name}: {detail}")
+    match = re.search(r"^Pages:\s+([1-9][0-9]*)\s*$", result.stdout, re.MULTILINE)
+    if match is None:
+        raise RenderError(f"pdfinfo reported no positive page count for {pdf.name}")
+    return int(match.group(1))
+
+
+def render_page(pdf: Path, page: int, destination: Path, pdftocairo: str) -> None:
+    prefix = destination.with_suffix("")
+    try:
+        result = subprocess.run(
+            [
+                pdftocairo,
+                "-png",
+                "-r",
+                str(DPI),
+                "-f",
+                str(page),
+                "-l",
+                str(page),
+                "-singlefile",
+                str(pdf),
+                str(prefix),
+            ],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RenderError(f"pdftocairo timed out for {pdf.name} page {page}") from exc
+    if result.returncode:
+        detail = result.stderr.strip() or f"exit status {result.returncode}"
+        raise RenderError(f"pdftocairo failed for {pdf.name} page {page}: {detail}")
+    if not destination.is_file() or destination.stat().st_size == 0:
+        raise RenderError(f"pdftocairo produced no PNG for {pdf.name} page {page}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_manifests(stage: Path, census: list[tuple[str, int]], pngs: list[Path]) -> None:
+    (stage / MARKER_NAME).write_text(MARKER_CONTENT, encoding="utf-8")
+    census_lines = ["source_file\tpages", *(f"{source}\t{pages}" for source, pages in census)]
+    (stage / "CENSUS.tsv").write_text("\n".join(census_lines) + "\n", encoding="utf-8")
+
+    checksum_lines = [
+        f"{sha256(path)}  {path.relative_to(stage).as_posix()}"
+        for path in sorted(pngs, key=lambda item: item.relative_to(stage).as_posix())
+    ]
+    (stage / "SHA256SUMS").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
+
+
+def install_stage(stage: Path, output_dir: Path) -> None:
+    backup = output_dir.parent / f".{output_dir.name}.previous.{os.getpid()}"
+    if backup.exists():
+        raise RenderError(f"stale render backup blocks installation: {backup}")
+
+    moved_old = output_dir.exists()
+    if moved_old:
+        try:
+            output_dir.rename(backup)
+        except OSError as exc:
+            raise RenderError(f"cannot stage prior baseline at {backup}: {exc}") from exc
+
+    try:
+        stage.rename(output_dir)
+    except OSError as exc:
+        if moved_old:
+            try:
+                backup.rename(output_dir)
+            except OSError as restore_exc:
+                raise RenderError(
+                    f"cannot install render baseline at {output_dir}; restoring untouched "
+                    f"backup {backup} also failed: {restore_exc}"
+                ) from exc
+        raise RenderError(f"cannot install render baseline at {output_dir}: {exc}") from exc
+
+    if moved_old:
+        try:
+            shutil.rmtree(backup)
+        except OSError as exc:
+            print(
+                f"WARNING: installed complete render baseline at {output_dir}, but could not "
+                f"remove prior baseline backup {backup}: {exc}",
+                file=sys.stderr,
+            )
+
+
+def render_corpus(input_dir: Path, output_dir: Path, protected: list[Path]) -> tuple[int, int]:
+    input_dir = resolved(input_dir)
+    if output_dir.expanduser().is_symlink():
+        raise RenderError(f"output directory must not be a symlink: {output_dir}")
+    output_dir = resolved(output_dir)
+    protected = [resolved(path) for path in protected]
+    validate_paths(input_dir, output_dir, protected)
+
+    pdfinfo = require_tool("pdfinfo")
+    pdftocairo = require_tool("pdftocairo")
+    pdfs = compiled_pdfs(input_dir)
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    stage = Path(
+        tempfile.mkdtemp(prefix=f".{output_dir.name}.staging.", dir=output_dir.parent)
+    )
+
+    census: list[tuple[str, int]] = []
+    pngs: list[Path] = []
+    try:
+        for pdf in pdfs:
+            pages = pdf_page_count(pdf, pdfinfo)
+            census.append((pdf.with_suffix(".tex").name, pages))
+            fixture_dir = stage / pdf.stem
+            fixture_dir.mkdir()
+            for page in range(1, pages + 1):
+                destination = fixture_dir / f"page-{page:03d}.png"
+                render_page(pdf, page, destination, pdftocairo)
+                pngs.append(destination)
+        write_manifests(stage, census, pngs)
+        install_stage(stage, output_dir)
+    except Exception:
+        if stage.exists():
+            shutil.rmtree(stage)
+        raise
+    return len(pdfs), len(pngs)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--protect", action="append", default=[], type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        pdf_count, page_count = render_corpus(args.input_dir, args.output_dir, args.protect)
+    except (OSError, RenderError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    output_dir = resolved(args.output_dir)
+    print(
+        f"PASS: rendered {pdf_count} corpus PDFs ({page_count} pages) at {DPI} dpi "
+        f"in {output_dir}"
+    )
+    print(f"Checksums: {output_dir / 'SHA256SUMS'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_tenkz_corpus_render.py
+++ b/scripts/test_tenkz_corpus_render.py
@@ -299,6 +299,37 @@ Path(sys.argv[-1] + '.png').write_bytes(
         if (malformed_marker / "keep.txt").read_text(encoding="utf-8") != "user data\n":
             raise AssertionError("malformed-marker output directory was changed")
 
+        raced_output = work / "raced-output"
+        raced_output.mkdir()
+        original_write_manifests = render.write_manifests
+
+        def populate_destination_during_render(
+            stage: Path,
+            census: list[tuple[str, int]],
+            pngs: list[Path],
+        ) -> None:
+            original_write_manifests(stage, census, pngs)
+            (raced_output / "keep.txt").write_text("concurrent user data\n", encoding="utf-8")
+
+        with mock.patch.dict(
+            os.environ, {"FAKE_RENDER_VERSION": "race", "FAKE_RENDER_FAIL": ""}
+        ), mock.patch.object(
+            render, "require_tool", side_effect=lambda name: str(bin_dir / name)
+        ), mock.patch.object(
+            render, "write_manifests", side_effect=populate_destination_during_render
+        ):
+            try:
+                render.render_corpus(input_dir, raced_output, [])
+            except render.RenderError as exc:
+                if "changed while rendering" not in str(exc):
+                    raise AssertionError(f"race refusal was not explicit: {exc}") from exc
+            else:
+                raise AssertionError("destination populated during rendering was replaced")
+        if (raced_output / "keep.txt").read_text(encoding="utf-8") != (
+            "concurrent user data\n"
+        ):
+            raise AssertionError("concurrent user data was changed or deleted")
+
         restore_output = work / "restore-output"
         missing_stage = work / "missing-stage"
         restore_output.mkdir()

--- a/scripts/test_tenkz_corpus_render.py
+++ b/scripts/test_tenkz_corpus_render.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Regression checks for deterministic, transactional tenkz corpus rendering."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RENDERER = ROOT / "scripts" / "tenkz_render_corpus.py"
+DRIVER = ROOT / "scripts" / "tenkz_corpus.sh"
+sys.path.insert(0, str(ROOT / "scripts"))
+import tenkz_render_corpus as render  # noqa: E402
+
+
+def write_executable(path: Path, source: str) -> None:
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def run_renderer(
+    input_dir: Path,
+    output_dir: Path,
+    bin_dir: Path,
+    *,
+    version: str = "v1",
+    fail_render: str = "",
+    protect: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["FAKE_RENDER_VERSION"] = version
+    env["FAKE_RENDER_FAIL"] = fail_render
+    command = [
+        sys.executable,
+        str(RENDERER),
+        "--input-dir",
+        str(input_dir),
+        "--output-dir",
+        str(output_dir),
+    ]
+    if protect is not None:
+        command.extend(["--protect", str(protect)])
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+
+
+def tree_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def expected_checksums(output: Path, relative_pngs: list[str]) -> str:
+    return "".join(
+        f"{hashlib.sha256((output / relative).read_bytes()).hexdigest()}  {relative}\n"
+        for relative in relative_pngs
+    )
+
+
+def run_driver(*arguments: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["TENKZ_CORPUS_VALIDATE_ONLY"] = "1"
+    return subprocess.run(
+        ["bash", str(DRIVER), *arguments],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+
+
+def main() -> int:
+    bad_cli = [
+        (("--unknown",), "unknown argument"),
+        (("--render-dir", "baseline"), "requires --render"),
+        (("--render-dir", "--render"), "requires a non-empty directory"),
+        (("--render",), "cannot be combined"),
+    ]
+    for arguments, diagnostic in bad_cli:
+        result = run_driver(*arguments)
+        if result.returncode == 0 or diagnostic not in result.stderr:
+            raise AssertionError(f"bad driver CLI was accepted: {arguments!r}")
+
+    with tempfile.TemporaryDirectory(prefix="tenkz-render-test-") as tmp:
+        work = Path(tmp)
+        input_dir = work / "compiled"
+        output_dir = work / "baseline"
+        bin_dir = work / "bin"
+        input_dir.mkdir()
+        output_dir.mkdir()
+        bin_dir.mkdir()
+
+        for stem in ("alpha", "beta"):
+            (input_dir / f"{stem}.tex").write_text("fixture\n", encoding="utf-8")
+            (input_dir / f"{stem}.pdf").write_bytes(b"synthetic pdf")
+
+        write_executable(
+            bin_dir / "pdfinfo",
+            """#!/usr/bin/env python3
+import sys
+from pathlib import Path
+print(f"Pages: {2 if Path(sys.argv[-1]).stem == 'alpha' else 1}")
+""",
+        )
+        write_executable(
+            bin_dir / "pdftocairo",
+            """#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+page = sys.argv[sys.argv.index('-f') + 1]
+pdf = Path(sys.argv[-2])
+identity = f"{pdf.stem}:{page}"
+if os.environ.get('FAKE_RENDER_FAIL') == identity:
+    print('injected render failure', file=sys.stderr)
+    raise SystemExit(9)
+Path(sys.argv[-1] + '.png').write_bytes(
+    f"{os.environ['FAKE_RENDER_VERSION']}:{identity}".encode()
+)
+""",
+        )
+
+        first = run_renderer(input_dir, output_dir, bin_dir)
+        if first.returncode:
+            raise AssertionError(first.stdout + first.stderr)
+        relative_pngs = [
+            "alpha/page-001.png",
+            "alpha/page-002.png",
+            "beta/page-001.png",
+        ]
+        if (output_dir / "CENSUS.tsv").read_text(encoding="utf-8") != (
+            "source_file\tpages\nalpha.tex\t2\nbeta.tex\t1\n"
+        ):
+            raise AssertionError("render census was not deterministic")
+        if (output_dir / "SHA256SUMS").read_text(encoding="utf-8") != (
+            expected_checksums(output_dir, relative_pngs)
+        ):
+            raise AssertionError("render checksum manifest was not deterministic")
+
+        (output_dir / "stale.png").write_bytes(b"stale")
+        before_failure = tree_bytes(output_dir)
+        failed = run_renderer(
+            input_dir,
+            output_dir,
+            bin_dir,
+            version="v2",
+            fail_render="beta:1",
+        )
+        if failed.returncode == 0 or "injected render failure" not in failed.stderr:
+            raise AssertionError("injected renderer failure was not reported")
+        if tree_bytes(output_dir) != before_failure:
+            raise AssertionError("failed render changed the last complete baseline")
+
+        second = run_renderer(input_dir, output_dir, bin_dir, version="v2")
+        if second.returncode:
+            raise AssertionError(second.stdout + second.stderr)
+        if tree_bytes(output_dir) == before_failure:
+            raise AssertionError("successful rerender did not replace the baseline")
+        if (output_dir / "stale.png").exists():
+            raise AssertionError("successful rerender retained a stale file")
+
+        protected = run_renderer(
+            input_dir,
+            output_dir,
+            bin_dir,
+            protect=output_dir,
+        )
+        if protected.returncode == 0 or "protected directory" not in protected.stderr:
+            raise AssertionError("protected output directory was accepted")
+
+        unowned = work / "unowned"
+        unowned.mkdir()
+        (unowned / "keep.txt").write_text("user data\n", encoding="utf-8")
+        rejected = run_renderer(input_dir, unowned, bin_dir)
+        if rejected.returncode == 0 or "without a valid" not in rejected.stderr:
+            raise AssertionError("nonempty unowned output directory was accepted")
+        if (unowned / "keep.txt").read_text(encoding="utf-8") != "user data\n":
+            raise AssertionError("rejected output directory was changed")
+
+        symlinked_marker = work / "symlinked-marker"
+        symlinked_marker.mkdir()
+        (symlinked_marker / "keep.txt").write_text("user data\n", encoding="utf-8")
+        (symlinked_marker / render.MARKER_NAME).symlink_to(
+            output_dir / render.MARKER_NAME
+        )
+        rejected_symlink = run_renderer(input_dir, symlinked_marker, bin_dir)
+        if rejected_symlink.returncode == 0 or "valid regular" not in rejected_symlink.stderr:
+            raise AssertionError("symlinked ownership marker was accepted")
+        if (symlinked_marker / "keep.txt").read_text(encoding="utf-8") != "user data\n":
+            raise AssertionError("symlink-marker output directory was changed")
+
+        nonregular_marker = work / "nonregular-marker"
+        nonregular_marker.mkdir()
+        (nonregular_marker / "keep.txt").write_text("user data\n", encoding="utf-8")
+        (nonregular_marker / render.MARKER_NAME).mkdir()
+        rejected_nonregular = run_renderer(input_dir, nonregular_marker, bin_dir)
+        if (
+            rejected_nonregular.returncode == 0
+            or "valid regular" not in rejected_nonregular.stderr
+        ):
+            raise AssertionError("non-regular ownership marker was accepted")
+        if (nonregular_marker / "keep.txt").read_text(encoding="utf-8") != "user data\n":
+            raise AssertionError("non-regular-marker output directory was changed")
+
+        restore_output = work / "restore-output"
+        missing_stage = work / "missing-stage"
+        restore_output.mkdir()
+        (restore_output / render.MARKER_NAME).write_text(
+            render.MARKER_CONTENT, encoding="utf-8"
+        )
+        (restore_output / "old.png").write_bytes(b"old")
+        try:
+            render.install_stage(missing_stage, restore_output)
+        except render.RenderError:
+            pass
+        else:
+            raise AssertionError("missing render stage was accepted")
+        if (restore_output / "old.png").read_bytes() != b"old":
+            raise AssertionError("pre-commit install failure did not restore the prior baseline")
+
+        cleanup_output = work / "cleanup-output"
+        cleanup_stage = work / "cleanup-stage"
+        cleanup_output.mkdir()
+        cleanup_stage.mkdir()
+        (cleanup_output / render.MARKER_NAME).write_text(
+            render.MARKER_CONTENT, encoding="utf-8"
+        )
+        (cleanup_output / "old.png").write_bytes(b"old")
+        (cleanup_stage / "new.png").write_bytes(b"new")
+        cleanup_backup = cleanup_output.parent / (
+            f".{cleanup_output.name}.previous.{os.getpid()}"
+        )
+
+        def partially_delete_backup(path: Path) -> None:
+            (path / "old.png").unlink()
+            raise OSError("injected partial cleanup failure")
+
+        warning = io.StringIO()
+        with mock.patch.object(
+            render.shutil, "rmtree", side_effect=partially_delete_backup
+        ), redirect_stderr(warning):
+            render.install_stage(cleanup_stage, cleanup_output)
+        if (cleanup_output / "new.png").read_bytes() != b"new":
+            raise AssertionError("cleanup failure displaced the committed new baseline")
+        if cleanup_stage.exists():
+            raise AssertionError("committed render remained at the staging path")
+        if not cleanup_backup.is_dir():
+            raise AssertionError("remaining prior baseline backup was not retained")
+        if str(cleanup_backup) not in warning.getvalue():
+            raise AssertionError("cleanup warning omitted the exact backup path")
+        if "installed complete render baseline" not in warning.getvalue():
+            raise AssertionError(
+                "cleanup warning did not identify the new baseline as authoritative"
+            )
+        shutil.rmtree(cleanup_backup)
+
+        (input_dir / "beta.pdf").unlink()
+        before_missing = tree_bytes(output_dir)
+        missing = run_renderer(input_dir, output_dir, bin_dir)
+        if missing.returncode == 0 or "compiled corpus PDFs are missing" not in missing.stderr:
+            raise AssertionError("missing compiled PDF was accepted")
+        if tree_bytes(output_dir) != before_missing:
+            raise AssertionError("preflight failure changed the last complete baseline")
+
+    print("PASS: tenkz corpus render baseline replacement")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_tenkz_corpus_render.py
+++ b/scripts/test_tenkz_corpus_render.py
@@ -90,6 +90,70 @@ def run_driver(*arguments: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def test_repo_relative_render_dir(work: Path) -> None:
+    bin_dir = work / "driver-bin"
+    capture = work / "render-dir.txt"
+    bin_dir.mkdir()
+    write_executable(
+        bin_dir / "python3",
+        """#!/bin/sh
+if [ "$1" = "-" ]; then
+    cat >/dev/null
+    exit 0
+fi
+case "$1" in
+    */tenkz_render_corpus.py)
+        shift
+        while [ "$#" -gt 0 ]; do
+            if [ "$1" = "--output-dir" ]; then
+                printf '%s\n' "$2" > "$FAKE_RENDER_DIR_CAPTURE"
+                exit 0
+            fi
+            shift
+        done
+        exit 9
+        ;;
+esac
+exit 0
+""",
+    )
+    write_executable(
+        bin_dir / "xelatex",
+        """#!/bin/sh
+for source do :; done
+stem=${source%.tex}
+: > "$stem.pdf"
+printf 'picture|id=fake\n' > "$stem.tnlog"
+""",
+    )
+    for command in ("pdfinfo", "pdftocairo"):
+        write_executable(bin_dir / command, "#!/bin/sh\nexit 0\n")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["FAKE_RENDER_DIR_CAPTURE"] = str(capture)
+    result = subprocess.run(
+        [
+            "bash",
+            str(DRIVER),
+            "--render",
+            "--render-dir",
+            "build/tenkz-relative-probe",
+        ],
+        cwd=ROOT / "tests" / "tenkz",
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=120,
+    )
+    if result.returncode:
+        raise AssertionError(result.stdout + result.stderr)
+    expected = ROOT / "build" / "tenkz-relative-probe"
+    if capture.read_text(encoding="utf-8").strip() != str(expected):
+        raise AssertionError("relative --render-dir was not anchored to the repository root")
+
+
 def main() -> int:
     bad_cli = [
         (("--unknown",), "unknown argument"),
@@ -223,6 +287,18 @@ Path(sys.argv[-1] + '.png').write_bytes(
         if (nonregular_marker / "keep.txt").read_text(encoding="utf-8") != "user data\n":
             raise AssertionError("non-regular-marker output directory was changed")
 
+        malformed_marker = work / "malformed-marker"
+        malformed_marker.mkdir()
+        (malformed_marker / "keep.txt").write_text("user data\n", encoding="utf-8")
+        (malformed_marker / render.MARKER_NAME).write_bytes(b"\xff\xfe")
+        rejected_malformed = run_renderer(input_dir, malformed_marker, bin_dir)
+        if rejected_malformed.returncode == 0 or "valid regular" not in rejected_malformed.stderr:
+            raise AssertionError("malformed UTF-8 ownership marker was accepted")
+        if "Traceback" in rejected_malformed.stderr:
+            raise AssertionError("malformed UTF-8 ownership marker escaped as a traceback")
+        if (malformed_marker / "keep.txt").read_text(encoding="utf-8") != "user data\n":
+            raise AssertionError("malformed-marker output directory was changed")
+
         restore_output = work / "restore-output"
         missing_stage = work / "missing-stage"
         restore_output.mkdir()
@@ -282,6 +358,8 @@ Path(sys.argv[-1] + '.png').write_bytes(
             raise AssertionError("missing compiled PDF was accepted")
         if tree_bytes(output_dir) != before_missing:
             raise AssertionError("preflight failure changed the last complete baseline")
+
+        test_repo_relative_render_dir(work)
 
     print("PASS: tenkz corpus render baseline replacement")
     return 0

--- a/tests/tenkz/README.md
+++ b/tests/tenkz/README.md
@@ -31,7 +31,10 @@ earlier successful corpus render. A successful rerun therefore contains no
 stale pages. Any failure before the completed directory swap leaves the last
 baseline untouched. Once that swap succeeds, the new baseline is authoritative;
 failure to remove the prior backup emits a warning with its exact retained path
-but does not invalidate or roll back the completed render.
+but does not invalidate or roll back the completed render. Installers for the
+same destination are serialized with a sibling lock, and the destination is
+compared with its pre-render snapshot after the atomic move; if it changed while
+rendering, the captured data is restored and the new baseline is refused.
 
 Each fixture has a directory containing zero-padded `page-NNN.png` files.
 `CENSUS.tsv` records the page count for every source, and `SHA256SUMS` records

--- a/tests/tenkz/README.md
+++ b/tests/tenkz/README.md
@@ -12,6 +12,49 @@ standalone `.tex` file with the invocation from `docs/tenkz/HACKING.md`, and run
 `scripts/tenkz_audit.py` on every resulting `.tnlog`. The tracked corpus remains
 clean, and sibling inputs such as `modes_suite.inc` remain available.
 
+## Render baselines
+
+Add `--render` to compile and audit the corpus, then render every page of every
+corpus PDF at 200 dpi:
+
+```bash
+scripts/tenkz_corpus.sh --render
+```
+
+The default output is `build/tenkz-corpus-render/`. Use `--render-dir DIR` to
+name a different directory. The driver reports the absolute output path and
+replaces it only after the complete render succeeds. It refuses to replace a
+nonempty directory unless that directory carries the ownership marker from an
+earlier successful corpus render. A successful rerun therefore contains no
+stale pages. Any failure before the completed directory swap leaves the last
+baseline untouched. Once that swap succeeds, the new baseline is authoritative;
+failure to remove the prior backup emits a warning with its exact retained path
+but does not invalidate or roll back the completed render.
+
+Each fixture has a directory containing zero-padded `page-NNN.png` files.
+`CENSUS.tsv` records the page count for every source, and `SHA256SUMS` records
+the byte checksum of every PNG in stable path order. A baseline is complete
+only when the reported PDF count equals the standalone corpus census and the
+sum of `CENSUS.tsv` page counts equals the number of checksum entries.
+
+For a behavior-preserving change, generate two baselines with the same TeX and
+Poppler toolchain:
+
+```bash
+scripts/tenkz_corpus.sh --render --render-dir build/tenkz-before
+# Apply the change.
+scripts/tenkz_corpus.sh --render --render-dir build/tenkz-after
+diff -u build/tenkz-before/CENSUS.tsv build/tenkz-after/CENSUS.tsv
+diff -u build/tenkz-before/SHA256SUMS build/tenkz-after/SHA256SUMS
+```
+
+Both diffs must be empty. This is the render proof required by the recurring
+simplification gate in issue #4158. A deliberately behavior-changing PR must
+instead list every changed fixture/page from the checksum diff, compare the
+corresponding before/after PNGs visually, and explain why each change is
+expected. Preserve both generated directories until review is complete; do
+not commit generated PNGs as source fixtures.
+
 ## Provenance
 
 The source is `handoff/corpus/` on branch `tenkz/handoff-artifacts`. The branch

--- a/tests/tenkz/README.md
+++ b/tests/tenkz/README.md
@@ -22,8 +22,10 @@ scripts/tenkz_corpus.sh --render
 ```
 
 The default output is `build/tenkz-corpus-render/`. Use `--render-dir DIR` to
-name a different directory. The driver reports the absolute output path and
-replaces it only after the complete render succeeds. It refuses to replace a
+name a different directory; relative directories are resolved from the
+repository root, independent of the caller's working directory. The driver
+reports the absolute output path and replaces it only after the complete
+render succeeds. It refuses to replace a
 nonempty directory unless that directory carries the ownership marker from an
 earlier successful corpus render. A successful rerun therefore contains no
 stale pages. Any failure before the completed directory swap leaves the last


### PR DESCRIPTION
## Summary

- add an opt-in `scripts/tenkz_corpus.sh --render` mode for the adopted 257-fixture corpus
- render every PDF page at 200 dpi into deterministic per-fixture PNG paths
- write stable `CENSUS.tsv` and `SHA256SUMS` manifests for before/after review
- protect custom output directories with a non-symlink regular ownership marker and staged installation
- document the LionSR/TNLean#4158 baseline discipline and route the focused safety test through CI

## Safety contract

- arbitrary nonempty, symlinked, protected, or overlapping output paths are rejected
- all rendering and manifest construction finish before the live baseline is touched
- a pre-commit installation failure restores the untouched previous baseline
- after the complete new tree is live, backup cleanup is best effort; failure keeps the new baseline authoritative and reports the residual backup path

## Validation

- `python3 scripts/test_tenkz_corpus_render.py`
- `python3 scripts/test_tenkz_corpus_provenance.py`
- `TENKZ_CORPUS_VALIDATE_ONLY=1 scripts/tenkz_corpus.sh` (257 fixtures)
- two full real `scripts/tenkz_corpus.sh --render` runs: 257 PDFs, 259 pages, identical census and checksum manifests
- all 259 generated checksums verified; representative 16-page contact sheet inspected
- ShellCheck, `bash -n`, `py_compile`, actionlint, reader-prose check, `git diff --check`
- tenkz source lint: 116 files, 0 findings

Closes LionSR/tenkz#26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to optional corpus rendering tooling, CI path filters, and documentation; default `tenkz_corpus.sh` behavior is unchanged without `--render`.
> 
> **Overview**
> Adds an **opt-in `--render` path** on `scripts/tenkz_corpus.sh` so the adopted `tests/tenkz` corpus can produce a **repository-wide 200 dpi PNG baseline** (default `build/tenkz-corpus-render/`) after the usual compile-and-audit pass, with `--render-dir` resolved from the repo root.
> 
> New **`scripts/tenkz_render_corpus.py`** turns compiled corpus PDFs into per-fixture `page-NNN.png` trees plus **`CENSUS.tsv`** and **`SHA256SUMS`**, using staged install, destination locking, ownership markers, and protected paths so failed or concurrent runs do not clobber unrelated data or the last good baseline.
> 
> **`scripts/test_tenkz_corpus_render.py`** exercises that safety contract and driver CLI; **PR CI** runs it in the `tenkz-corpus` job and watches the new scripts in path filters. Docs in **`tests/tenkz/README.md`**, **`docs/tenkz/HACKING.md`**, and **`docs/tenkz/DESIGN.md`** describe the before/after checksum workflow for issue **#4158** behavior-preserving changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f08ffe1e44dd7d78d00ef8b96d536ab20eca926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->