### PR TITLE
refactor(tenkz): fewer-elements gate — dead code, duplicate validation, shared error dispatch

### DIFF
--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -913,6 +913,16 @@
       { \int_gset:Nn \g__tenkzcd_mapinvalid_int {#1} }
   }
 
+% the companion of \tenkz_cd_note_map_invalid:n's numbered reasons: reports
+% one typed-map validation failure with the doctrine's standard shape
+% (invalidate, then explain) so the sixteen reasons share one call instead
+% of retyping the bool-then-PackageError pair at each
+\cs_new_protected:Npn \tenkz_cd_map_error:nn #1#2
+  {
+    \bool_set_false:N \l__tenkzcd_mapvalid_bool
+    \PackageError{tenkz}{#1}{#2}
+  }
+
 \cs_new_protected:Npn \tenkz_cd_read_map_transform:N #1
   {
     \pgfgettransformentries
@@ -989,33 +999,12 @@
       { \tenkz_cd_note_map_invalid:n {3} }
   }
 
-% The emitted wire is an undecorated, unshortened horizontal rectangle between
-% the measured object anchors.  This hook runs after all public map styles, so
-% unsupported path-local state is observed without rewriting user options.
-\cs_new_protected:Npn \tenkz_cd_validate_map_declared_modes:
-  {
-    \group_begin:
-      \tikz@mode@clipfalse
-      \tikz@mode@fade@pathfalse
-      \tikz@mode@fade@scopefalse
-      \let\tikz@path@picture\pgfutil@empty
-      \tikz@mode
-      \iftikz@mode@clip
-        \tenkz_cd_note_map_invalid:n {11}
-      \fi
-      \iftikz@mode@fade@path
-        \tenkz_cd_note_map_invalid:n {12}
-      \fi
-      \iftikz@mode@fade@scope
-        \tenkz_cd_note_map_invalid:n {13}
-      \fi
-      \ifx\tikz@path@picture\pgfutil@empty\else
-        \tenkz_cd_note_map_invalid:n {14}
-      \fi
-    \group_end:
-  }
-
-\cs_new_protected:Npn \tenkz_cd_validate_map_path_state:
+% the four `tikz@mode'/`tikz@path@picture' checks both the declared-time
+% and the draw-time validator must make, byte-identical -- only the
+% RESET that precedes reading them (declared time re-derives the modes
+% from a clean \tikz@mode; draw time reads whatever the live path already
+% set) differs between the two callers below
+\cs_new_protected:Npn \tenkz_cd_note_map_mode_flags:
   {
     \iftikz@mode@clip
       \tenkz_cd_note_map_invalid:n {11}
@@ -1029,6 +1018,26 @@
     \ifx\tikz@path@picture\pgfutil@empty\else
       \tenkz_cd_note_map_invalid:n {14}
     \fi
+  }
+
+% The emitted wire is an undecorated, unshortened horizontal rectangle between
+% the measured object anchors.  This hook runs after all public map styles, so
+% unsupported path-local state is observed without rewriting user options.
+\cs_new_protected:Npn \tenkz_cd_validate_map_declared_modes:
+  {
+    \group_begin:
+      \tikz@mode@clipfalse
+      \tikz@mode@fade@pathfalse
+      \tikz@mode@fade@scopefalse
+      \let\tikz@path@picture\pgfutil@empty
+      \tikz@mode
+      \tenkz_cd_note_map_mode_flags:
+    \group_end:
+  }
+
+\cs_new_protected:Npn \tenkz_cd_validate_map_path_state:
+  {
+    \tenkz_cd_note_map_mode_flags:
     \group_begin:
       \tikz@transform
       \tenkz_cd_check_current_map_transform:
@@ -1152,8 +1161,7 @@
     \int_compare:nNnTF {\l__tenkzcd_mapdrawuses_int} = {1}
       { }
       {
-        \bool_set_false:N \l__tenkzcd_mapvalid_bool
-        \PackageError{tenkz}{Typed-map~path~has~
+        \tenkz_cd_map_error:nn {Typed-map~path~has~
           \int_use:N\l__tenkzcd_mapdrawuses_int\space live~draw~uses}
           {Use~one~ordinary~solid~or~fused~draw~path~for~a~typed~map.}
       }
@@ -1161,86 +1169,54 @@
       {
         \int_case:nnF {\l__tenkzcd_mapinvalid_int}
           {
-            {1}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~a~dashed~stroke}
-                {Use~a~solid~stroke~for~typed-map~visible~geometry.}
-            }
-            {2}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~zero~draw~opacity}
-                {Use~positive~draw~opacity~for~typed-map~visible~geometry.}
-            }
-            {3}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~a~path-local~transform}
-                {Transform~the~whole~picture,~not~one~typed-map~path.}
-            }
-            {4}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~nonzero~shortening}
-                {Use~an~unshortened~typed-map~path.}
-            }
-            {5}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~changes~the~line~cap}
-                {Use~the~inherited~line~cap~for~typed-map~paths.}
-            }
-            {6}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~a~decoration}
-                {Use~an~undecorated~typed-map~path.}
-            }
-            {7}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~a~pre/post~action}
-                {Use~one~ordinary~draw~action~for~a~typed-map~path.}
-            }
-            {8}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~is~not~one~horizontal~line}
-                {Use~exactly~one~straight~horizontal~typed-map~path.}
-            }
-            {9}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~arrow~tips}
-                {Use~an~unarrowed~typed-map~path.}
-            }
-            {10}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~nonpositive~live~width}
-                {Use~a~positive~line~width~for~typed-map~visible~geometry.}
-            }
-            {11}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~clipping}
-                {Use~an~unclipped~typed-map~path.}
-            }
-            {12}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~path~fading}
-                {Use~an~unfaded~typed-map~path.}
-            }
-            {13}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~scope~fading}
-                {Use~an~unfaded~typed-map~scope.}
-            }
-            {14}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~a~path~picture}
-                {Use~a~typed-map~path~without~path-picture~ink.}
-            }
-            {15}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~invalid~double~geometry}
-                {Require~zero~inner~width~or~a~gap~smaller~than~the~outer~width.}
-            }
-            {16}{
-              \bool_set_false:N \l__tenkzcd_mapvalid_bool
-              \PackageError{tenkz}{Typed-map~path~has~a~non-normal~blend~mode}
-                {Use~blend~mode=normal~for~exact~typed-map~geometry.}
-            }
+            {1}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~a~dashed~stroke}
+              {Use~a~solid~stroke~for~typed-map~visible~geometry.} }
+            {2}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~zero~draw~opacity}
+              {Use~positive~draw~opacity~for~typed-map~visible~geometry.} }
+            {3}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~a~path-local~transform}
+              {Transform~the~whole~picture,~not~one~typed-map~path.} }
+            {4}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~nonzero~shortening}
+              {Use~an~unshortened~typed-map~path.} }
+            {5}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~changes~the~line~cap}
+              {Use~the~inherited~line~cap~for~typed-map~paths.} }
+            {6}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~a~decoration}
+              {Use~an~undecorated~typed-map~path.} }
+            {7}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~a~pre/post~action}
+              {Use~one~ordinary~draw~action~for~a~typed-map~path.} }
+            {8}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~is~not~one~horizontal~line}
+              {Use~exactly~one~straight~horizontal~typed-map~path.} }
+            {9}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~arrow~tips}
+              {Use~an~unarrowed~typed-map~path.} }
+            {10}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~nonpositive~live~width}
+              {Use~a~positive~line~width~for~typed-map~visible~geometry.} }
+            {11}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~clipping}
+              {Use~an~unclipped~typed-map~path.} }
+            {12}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~path~fading}
+              {Use~an~unfaded~typed-map~path.} }
+            {13}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~scope~fading}
+              {Use~an~unfaded~typed-map~scope.} }
+            {14}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~a~path~picture}
+              {Use~a~typed-map~path~without~path-picture~ink.} }
+            {15}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~invalid~double~geometry}
+              {Require~zero~inner~width~or~a~gap~smaller~than~the~outer~width.} }
+            {16}{ \tenkz_cd_map_error:nn
+              {Typed-map~path~has~a~non-normal~blend~mode}
+              {Use~blend~mode=normal~for~exact~typed-map~geometry.} }
           }
           { }
       }

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -751,7 +751,7 @@
 \bool_new:N \l__tenkzcd_aok_bool
 \cs_new_protected:Npn \tenkz_cd_arrow_endpoint:nn #1#2
   {
-    \regex_match:nnTF { \A \d+ \Z } {#2}
+    \tenkz_token_if_decimal_digits:nTF {#2}
       {
         \bool_lazy_and:nnF
           { \int_compare_p:nNn {#2} > {0} }

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -401,8 +401,6 @@
 \newdimen\tenkz@bboxymax
 \newdimen\tenkz@bboxxa
 \newdimen\tenkz@bboxya
-\newdimen\tenkz@bboxxb
-\newdimen\tenkz@bboxyb
 \newif\iftenkz@bboxcapture
 \newif\iftenkz@identitylinear
 \newif\iftenkz@labelrectangle
@@ -1293,6 +1291,18 @@
 % message instead of a raw pgfkeys error; re-declaring the name
 % re-derives the styles with the same hue.
 \ExplSyntaxOn
+
+% ---------- shared syntax predicates ----------
+% This predicate recognizes a nonempty string of decimal digits.  Callers
+% retain their own range checks and diagnostics.
+\prg_new_conditional:Npnn \tenkz_token_if_decimal_digits:n #1 { T, F, TF }
+  {
+    \regex_match:nnTF { \A [0-9]+ \Z } {#1}
+      { \prg_return_true: }
+      { \prg_return_false: }
+  }
+\prg_generate_conditional_variant:Nnn \tenkz_token_if_decimal_digits:n
+  { V } { T, F, TF }
 
 % ---------- measured named enclosures ----------
 % Every enclosure consumes this ONE registry: a semantic member name maps to

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -467,13 +467,6 @@
       \tenkz@event{label-use|picture=\the\tenkz@pictureid}%
     \fi
   \fi}
-\def\tenkz@writebbox#1{%
-  \global\advance\tenkz@bboxuid by 1\relax
-  \tenkz@event{bbox|picture=\the\tenkz@pictureid|class=#1|%
-    id=\the\tenkz@bboxuid|owner=\the\tenkz@inkowner|%
-    xmin=\number\tenkz@bboxxmin|%
-    xmax=\number\tenkz@bboxxmax|ymin=\number\tenkz@bboxymin|%
-    ymax=\number\tenkz@bboxymax}}
 \def\tenkz@writelabelbbox{%
   \global\advance\tenkz@bboxuid by 1\relax
   \tenkz@event{bbox|picture=\the\tenkz@pictureid|class=label|%
@@ -614,11 +607,7 @@
 \def\tenkz@checkrequiredlastauditowner#1{%
   \tenkz@checklastauditowner{#1}%
   \iftenkz@auditownermatch\else
-    \edef\tenkz@currentauditowner{\tenkz@auditinstallowner}%
-    \edef\tenkz@intendedauditowner{#1}%
-    \ifx\tenkz@currentauditowner\tenkz@intendedauditowner
-      \tenkz@auditownermatchtrue
-    \fi
+    \tenkz@checkcurrentauditowner{#1}%
   \fi}
 \def\tenkz@incrementtokenslot#1#2{%
   \count@=\csname tenkz@#1@#2\endcsname\relax
@@ -1223,31 +1212,6 @@
     x2=\number\tenkz@glyphxtwo|y2=\number\tenkz@glyphytwo|%
     x3=\number\tenkz@glyphxthree|y3=\number\tenkz@glyphythree}%
   \endgroup}
-\def\tenkz@emitwirebbox#1#2#3#4#5{%
-  \begingroup
-  \pgfextractx{\tenkz@bboxxa}{\pgfpointanchor{#1}{#2}}%
-  \pgfextracty{\tenkz@bboxya}{\pgfpointanchor{#1}{#2}}%
-  \pgfextractx{\tenkz@bboxxb}{\pgfpointanchor{#3}{#4}}%
-  \pgfextracty{\tenkz@bboxyb}{\pgfpointanchor{#3}{#4}}%
-  \ifdim\tenkz@bboxxa<\tenkz@bboxxb
-    \tenkz@bboxxmin=\tenkz@bboxxa \tenkz@bboxxmax=\tenkz@bboxxb
-  \else
-    \tenkz@bboxxmin=\tenkz@bboxxb \tenkz@bboxxmax=\tenkz@bboxxa
-  \fi
-  \ifdim\tenkz@bboxya<\tenkz@bboxyb
-    \tenkz@bboxymin=\tenkz@bboxya \tenkz@bboxymax=\tenkz@bboxyb
-  \else
-    \tenkz@bboxymin=\tenkz@bboxyb \tenkz@bboxymax=\tenkz@bboxya
-  \fi
-  \advance\tenkz@bboxymin by -#5\relax
-  \advance\tenkz@bboxymax by  #5\relax
-  \tenkz@writebbox{wire}%
-  \endgroup}
-% This helper is intentionally tokenized outside ExplSyntax: TikZ's coordinate
-% parser requires the literal space in the `canvas cs:' delimiter.
-\def\tenkz@canvascoordinate#1#2#3{%
-  \coordinate (#1) at (canvas cs:x=#2,y=#3);}
-
 \tikzset{
   tenkz audited label/.style={
     /utils/exec=\tenkz@installlabelaudit},

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -555,14 +555,14 @@
 % its OWN further check (cell keys require > 0, \tnspan does not) and
 % its OWN error message, so this predicate owns only the shared syntax
 % test, not the callers' differing business rules
-\prg_new_conditional:Npnn \tenkz_token_if_decimal_digits:n #1 { p, T, F, TF }
+\prg_new_conditional:Npnn \tenkz_token_if_decimal_digits:n #1 { T, F, TF }
   {
     \regex_match:nnTF { \A [0-9]+ \Z } {#1}
       { \prg_return_true: }
       { \prg_return_false: }
   }
 \prg_generate_conditional_variant:Nnn \tenkz_token_if_decimal_digits:n
-  { V } { p, T, F, TF }
+  { V } { T, F, TF }
 \tl_new:N \l__tenkz_cellinteger_tl
 \msg_new:nnn { tenkz } { cell-positive-integer }
   { Cell~key~'#1'~needs~a~decimal~positive~integer,~not~'#2'. }

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -506,7 +506,7 @@
     \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/span}{#1} }
     \tl_set:Nn \l__tenkz_spanlength_tl {#2}
     \tl_trim_spaces:N \l__tenkz_spanlength_tl
-    \exp_args:NV \tenkz_decimal_digits_p:nTF \l__tenkz_spanlength_tl
+    \tenkz_token_if_decimal_digits:VTF \l__tenkz_spanlength_tl
       { \tl_set:Ne \l__tenkz_spanlength_tl
           { \int_eval:n {\l__tenkz_spanlength_tl} } }
       {
@@ -555,12 +555,14 @@
 % its OWN further check (cell keys require > 0, \tnspan does not) and
 % its OWN error message, so this predicate owns only the shared syntax
 % test, not the callers' differing business rules
-\prg_new_conditional:Npnn \tenkz_decimal_digits_p:n #1 { p, T, F, TF }
+\prg_new_conditional:Npnn \tenkz_token_if_decimal_digits:n #1 { p, T, F, TF }
   {
     \regex_match:nnTF { \A [0-9]+ \Z } {#1}
       { \prg_return_true: }
       { \prg_return_false: }
   }
+\prg_generate_conditional_variant:Nnn \tenkz_token_if_decimal_digits:n
+  { V } { p, T, F, TF }
 \tl_new:N \l__tenkz_cellinteger_tl
 \msg_new:nnn { tenkz } { cell-positive-integer }
   { Cell~key~'#1'~needs~a~decimal~positive~integer,~not~'#2'. }
@@ -568,7 +570,7 @@
   {
     \tl_set:Nn \l__tenkz_cellinteger_tl {#2}
     \tl_trim_spaces:N \l__tenkz_cellinteger_tl
-    \exp_args:NV \tenkz_decimal_digits_p:nTF \l__tenkz_cellinteger_tl
+    \tenkz_token_if_decimal_digits:VTF \l__tenkz_cellinteger_tl
       {
         \int_compare:nNnTF {\l__tenkz_cellinteger_tl} > {0}
           { \int_set:Nn #3 {\l__tenkz_cellinteger_tl} }

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -506,7 +506,7 @@
     \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz/span}{#1} }
     \tl_set:Nn \l__tenkz_spanlength_tl {#2}
     \tl_trim_spaces:N \l__tenkz_spanlength_tl
-    \regex_match:nVTF { \A [0-9]+ \Z } \l__tenkz_spanlength_tl
+    \exp_args:NV \tenkz_decimal_digits_p:nTF \l__tenkz_spanlength_tl
       { \tl_set:Ne \l__tenkz_spanlength_tl
           { \int_eval:n {\l__tenkz_spanlength_tl} } }
       {
@@ -550,6 +550,17 @@
 % \tnfuse options
 \int_new:N \l__tenkz_frows_int
 \tl_new:N \l__tenkz_fcombined_tl
+% one regex answers "is this a bare decimal-integer token", reused
+% everywhere a key/argument must parse as an integer; each caller keeps
+% its OWN further check (cell keys require > 0, \tnspan does not) and
+% its OWN error message, so this predicate owns only the shared syntax
+% test, not the callers' differing business rules
+\prg_new_conditional:Npnn \tenkz_decimal_digits_p:n #1 { p, T, F, TF }
+  {
+    \regex_match:nnTF { \A [0-9]+ \Z } {#1}
+      { \prg_return_true: }
+      { \prg_return_false: }
+  }
 \tl_new:N \l__tenkz_cellinteger_tl
 \msg_new:nnn { tenkz } { cell-positive-integer }
   { Cell~key~'#1'~needs~a~decimal~positive~integer,~not~'#2'. }
@@ -557,7 +568,7 @@
   {
     \tl_set:Nn \l__tenkz_cellinteger_tl {#2}
     \tl_trim_spaces:N \l__tenkz_cellinteger_tl
-    \regex_match:nVTF { \A [0-9]+ \Z } \l__tenkz_cellinteger_tl
+    \exp_args:NV \tenkz_decimal_digits_p:nTF \l__tenkz_cellinteger_tl
       {
         \int_compare:nNnTF {\l__tenkz_cellinteger_tl} > {0}
           { \int_set:Nn #3 {\l__tenkz_cellinteger_tl} }

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -550,19 +550,6 @@
 % \tnfuse options
 \int_new:N \l__tenkz_frows_int
 \tl_new:N \l__tenkz_fcombined_tl
-% one regex answers "is this a bare decimal-integer token", reused
-% everywhere a key/argument must parse as an integer; each caller keeps
-% its OWN further check (cell keys require > 0, \tnspan does not) and
-% its OWN error message, so this predicate owns only the shared syntax
-% test, not the callers' differing business rules
-\prg_new_conditional:Npnn \tenkz_token_if_decimal_digits:n #1 { T, F, TF }
-  {
-    \regex_match:nnTF { \A [0-9]+ \Z } {#1}
-      { \prg_return_true: }
-      { \prg_return_false: }
-  }
-\prg_generate_conditional_variant:Nnn \tenkz_token_if_decimal_digits:n
-  { V } { T, F, TF }
 \tl_new:N \l__tenkz_cellinteger_tl
 \msg_new:nnn { tenkz } { cell-positive-integer }
   { Cell~key~'#1'~needs~a~decimal~positive~integer,~not~'#2'. }


### PR DESCRIPTION
Second execution of the recurring simplification gate (#4158), scoped to the ~4500-line accumulation since the first gate (#4561) — a 5-lane census over the package + audit machinery, explicitly framed around motivated minimalism, composable primitives over proliferating special cases, and no mark/mechanism without a caller.

## Fixed (5, all mechanical, individually compile-verified before the full regression pass)

- **tenkz-core.code.tex**: deleted `\tenkz@emitwirebbox`, `\tenkz@writebbox`, `\tenkz@canvascoordinate` — a wire-geometry audit cluster with zero callers anywhere in the repo.
- **tenkz-core.code.tex**: `\tenkz@checkrequiredlastauditowner` reimplemented `\tenkz@checkcurrentauditowner`'s body verbatim instead of calling it. Now calls it.
- **tenkz-grid.code.tex**: extracted `\tenkz_decimal_digits_p:n`, a shared regex-only predicate, used by both `\tenkz_cell_positive_integer:nnN` and `\tnspan`'s length parser. Deliberately did not unify further — cell keys require strictly positive values, `\tnspan` does not, so each caller keeps its own post-check and error message.
- **tenkz-cd.code.tex**: the 16-branch typed-map-path-invalid dispatcher repeated bool-set + two-part `PackageError` at every branch. Now calls one shared `\tenkz_cd_map_error:nn`.
- **tenkz-cd.code.tex**: the four tikz-mode/path-picture validity checks were duplicated verbatim between the declared-time and draw-time typed-map validators. Extracted `\tenkz_cd_note_map_mode_flags:`, called from both.

## Declined

`scripts/tenkz_corpus.sh`'s hardcoded 4-file allowlist for zero-event probe fixtures. The obvious derivation (absence of a literal `\begin{tenkz` substring) is unsafe — a dozen other legitimate fixtures also lack that exact substring (they use `tenkzlattice`/`tenkzcd`/`tnpic[inline]` instead) and would be misclassified. Left as-is rather than risk a subtle bug in the CI gate itself for a four-line saving.

## Deferred to LionSR/tenkz#62

Unifying `/tenkz/region` (lattice) and `/tenkz/free~region` (free) into one declarative key family — the flagship "one prop surface, two render backends" consolidation, confirmed independently by two census lanes. The two families have asymmetric side effects (free's `slot` choice also computes a style-name string lattice's doesn't; lattice has `inset=`, free has `group=`) that make a safe merge nontrivial. Written up with an implementation sketch rather than rushed into this pass — a hurried shared-parsing-layer change earlier this week (the corner-label fix, post-#4589) produced a real, hard-to-spot regression in this exact codebase, and this touches the parsing layer for every `\tnregion` call in the corpus and the manual.

## Verification

- Full 257-file corpus (`scripts/tenkz_corpus.sh`): compiled and audited clean, exit 0.
- Every `tex/tenkz/examples/*.tex` individually compiled and audited: 0 failures.
- `docs/tenkz/manual2.tex`: two-pass compile clean, audit clean (0 hard errors; only pre-existing style advisories).

https://claude.ai/code/session_01NwpUjhu75KnYgwyM6hBxxi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring and dead-code removal only; validation messages and checks are preserved via shared helpers with no API or security surface changes.
> 
> **Overview**
> Mechanical simplification pass across **tenkz-core**, **tenkz-cd**, and **tenkz-grid** with no intended user-visible behavior change.
> 
> **tenkz-core** drops unused wire-bbox helpers (`\tenkz@emitwirebbox`, `\tenkz@writebbox`, `\tenkz@canvascoordinate`) and related dim registers; `\tenkz@checkrequiredlastauditowner` now delegates to `\tenkz@checkcurrentauditowner` instead of duplicating its logic. A shared expl3 conditional `\tenkz_token_if_decimal_digits:n` (with `V` variant) centralizes the “nonempty decimal digits” regex.
> 
> **tenkz-grid** and **tenkz-cd** switch span length, cell keys, and `\tnarrow` endpoint parsing to that predicate; each site still owns its own range rules and error text.
> 
> **tenkz-cd** adds `\tenkz_cd_map_error:nn` for the standard invalidate-then-`PackageError` pattern and `\tenkz_cd_note_map_mode_flags:` for the four TikZ mode/path-picture checks shared by declared-time and draw-time typed-map validators; the 16-branch invalid-map dispatcher and duplicate mode-flag blocks are collapsed onto these helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c149e844799242dea0f4966dbbafcd82113da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->