### PR TITLE
fix(tenkz): render manual degree symbol

### DIFF
--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -91,7 +91,7 @@ padded with bare wire.
 \texttt{tensor style=} & \texttt{dot|box} & \texttt{dot} &
   glyph policy (Section~\ref{sec:ref-policy}) \\
 \texttt{frame=} & \texttt{flat|vertical} & \texttt{flat} &
-  rotates the whole grammar $90°$: columns descend, legs point
+  rotates the whole grammar $90^\circ$: columns descend, legs point
   west/east, \tncmd{tndots} draws \texttt{\textbackslash vdots} \\
 \texttt{chain axis=} & \texttt{east|south} & \texttt{east} &
   alias of \texttt{frame=} naming the run direction (east = flat,


### PR DESCRIPTION
## Summary

- typeset the ninety-degree frame angle with TeX-safe `\circ` notation
- preserve the reference-table wording and layout

## Root cause

The source used a literal Unicode degree sign inside math mode. XeLaTeX selected
`cmr9`, which has no glyph for that character, emitted three missing-character
diagnostics, and rendered `grammar 90:` on manual page 26.

## Validation

- exact base: `ef01d54cfc78ac283bf153a9734aa43ce4892537`
- three XeLaTeX passes with `TEXINPUTS="../../tex/tenkz//:"`; pass-2 and
  pass-3 `manual2.aux`, `manual2.out`, and `manual2.toc` checksums are identical
- `scripts/tenkz_audit.py manual2.tnlog`: 79 pictures, zero hard errors
- zero missing-degree, changed-label, or undefined-reference diagnostics after
  the final pass
- `pdfinfo`: 46 A4 pages; title and author metadata intact
- 200-dpi before/after review of page 26: `90:` becomes `90°:`; the table
  remains aligned and unclipped
- `chktex -q -l blueprint/.chktexrc docs/tenkz/chapters2/ch-reference.tex`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tenkz_lint.py docs/tenkz/chapters2/ch-reference.tex`
- `git diff --check`

The package declaration and manual title remain synchronized at tenkz v0.6,
dated 17 July 2026.

Closes LionSR/tenkz#63

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation typography fix in `ch-reference.tex` with no runtime or package behavior changes.
> 
> **Overview**
> Fixes XeLaTeX missing-glyph diagnostics on manual page 26 by replacing a literal Unicode degree sign in the **`frame=`** reference row with **`$90^\circ$`**, so the ninety-degree rotation reads correctly in math mode without changing table wording or layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bdb0591a2b4c52540bb1cac64fdbbf90c96ec2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->