### PR TITLE
style(tenkz): align core section headings

### DIFF
--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -1273,23 +1273,6 @@
     \fi
   \fi}
 
-% ---------- species (the 0.6 hue contract, clause 2) ----------
-% Species declare NAMES, never colors: `species={right,left}' (document
-% preamble via \tnset, or picture scope) assigns each new name the next
-% hue of the theme's semantic cycle and derives one style per glyph
-% family — `species <name> bond', `species <name> tensor', `species
-% <name> outline' — through the same indirection as the role styles, so
-% a theme rebinding the core hue slots recolours every species at one
-% point.  A name keeps its index (hence its hue) across redeclarations,
-% so a document-global declaration holds one hue per species over every
-% figure of a paper.  An undeclared species at a call site is an error.
-% Scope: the index registry is global (a hue, once assigned, is never
-% reassigned), but the derived styles are ordinary tikz styles, LOCAL to
-% the declaring group -- a picture-scope declaration ends with its
-% picture.  The call-site check therefore tests the derived style, not
-% the registry, so an out-of-scope species is reported by the curated
-% message instead of a raw pgfkeys error; re-declaring the name
-% re-derives the styles with the same hue.
 \ExplSyntaxOn
 
 % ---------- shared syntax predicates ----------
@@ -1657,6 +1640,24 @@
   }
 \NewDocumentCommand \tnregion { O{} m }
   { \tenkz_region_dispatch:nn {#1}{#2} }
+
+% ---------- species (the 0.6 hue contract, clause 2) ----------
+% Species declare NAMES, never colors: `species={right,left}' (document
+% preamble via \tnset, or picture scope) assigns each new name the next
+% hue of the theme's semantic cycle and derives one style per glyph
+% family — `species <name> bond', `species <name> tensor', `species
+% <name> outline' — through the same indirection as the role styles, so
+% a theme rebinding the core hue slots recolours every species at one
+% point.  A name keeps its index (hence its hue) across redeclarations,
+% so a document-global declaration holds one hue per species over every
+% figure of a paper.  An undeclared species at a call site is an error.
+% Scope: the index registry is global (a hue, once assigned, is never
+% reassigned), but the derived styles are ordinary tikz styles, LOCAL to
+% the declaring group -- a picture-scope declaration ends with its
+% picture.  The call-site check therefore tests the derived style, not
+% the registry, so an out-of-scope species is reported by the curated
+% message instead of a raw pgfkeys error; re-declaring the name
+% re-derives the styles with the same hue.
 \prop_new:N \g__tenkz_species_prop     % name -> 1-based declaration index
 \int_new:N  \g__tenkz_species_int
 % the semantic cycle: hue slots, in assignment order


### PR DESCRIPTION
Follow-up to #4609. Moves the existing species-section heading and doctrine to the actual species registry, so the shared decimal predicate and measured-enclosure section are no longer nested under the species banner. This is a comment-only source-navigation fix with no TeX behavior change.

Verification:
- `python3 scripts/test_tenkz_corpus_provenance.py`
- `python3 scripts/test_tenkz_corpus_render.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only relocation in tenkz-core with no executable changes; risk is negligible aside from merge noise.
> 
> **Overview**
> **Repositions the species section banner** in `tenkz-core.code.tex` so source navigation matches the real layout: the `% ---------- species (the 0.6 hue contract, clause 2) ----------` heading and its doctrine comment now sit immediately above `\g__tenkz_species_prop` and the species implementation, instead of appearing before `\ExplSyntaxOn` and the shared decimal-digit predicate.
> 
> Shared syntax predicates and measured named enclosures are no longer visually grouped under the species heading. **No TeX macros, keys, or runtime behavior change**—comment placement only, as noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce75b7f149aedba63016431e9e5df142f3c3aaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->