### PR TITLE
refactor(tenkz): fewer-elements gate continued — shared capture-state error, consolidated field validation

### DIFF
--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -611,6 +611,20 @@ class Audit:
     def note(self, rule: str, where: str, msg: str) -> None:
         self.findings.append(Finding("NOTE", rule, where, msg))
 
+    def require_fields(self, event: Event, required: set[str],
+                        description: str) -> bool:
+        """True if `event` carries every field in `required`; otherwise
+        reports the standard malformed-event finding and returns False.
+        Callers still decide their own control flow (continue vs. return)
+        since that depends on whether the check runs inside a loop."""
+        missing = sorted(required - event.attrs.keys())
+        if missing:
+            self.hard("malformed-event", f"{self.log_path.name}:{event.line}",
+                      f"{description} event lacks required field(s): "
+                      + ", ".join(missing))
+            return False
+        return True
+
     def events(self, picture_id: Optional[int] = None) -> list[Event]:
         """Typed events already produced by `parse_log`, one picture or
         all of them.  The canonical accessor for consumers (tests, the
@@ -815,13 +829,7 @@ class Audit:
             for event in pic.events:
                 if event.kind != "bbox":
                     continue
-                missing = sorted(bbox_required - event.attrs.keys())
-                if missing:
-                    self.hard(
-                        "malformed-event",
-                        f"{self.log_path.name}:{event.line}",
-                        f"bbox event lacks required field(s): {', '.join(missing)}",
-                    )
+                if not self.require_fields(event, bbox_required, "bbox"):
                     continue
                 if (event.attrs["class"] not in {"label", "wire"}
                         or any(not _is_int(event.attrs[field])
@@ -843,14 +851,7 @@ class Audit:
                 shape = "rect"
                 radius = 0
                 if event.attrs["class"] == "label":
-                    missing = sorted(label_required - event.attrs.keys())
-                    if missing:
-                        self.hard(
-                            "malformed-event",
-                            f"{self.log_path.name}:{event.line}",
-                            "label bbox event lacks required field(s): "
-                            + ", ".join(missing),
-                        )
+                    if not self.require_fields(event, label_required, "label bbox"):
                         continue
                     if (event.attrs["shape"] not in {"rect", "roundrect"}
                             or not _is_nonnegative_int(event.attrs["radius"])):
@@ -886,14 +887,7 @@ class Audit:
             for event in pic.events:
                 if event.kind != "glyph-geometry":
                     continue
-                missing = sorted(glyph_required - event.attrs.keys())
-                if missing:
-                    self.hard(
-                        "malformed-event",
-                        f"{self.log_path.name}:{event.line}",
-                        "glyph-geometry event lacks required field(s): "
-                        + ", ".join(missing),
-                    )
+                if not self.require_fields(event, glyph_required, "glyph-geometry"):
                     continue
                 numeric = glyph_required - {"shape"}
                 if any(not _is_int(event.attrs[field]) for field in numeric):
@@ -941,14 +935,7 @@ class Audit:
             for event in pic.events:
                 if event.kind != "wire-geometry":
                     continue
-                missing = sorted(wire_required - event.attrs.keys())
-                if missing:
-                    self.hard(
-                        "malformed-event",
-                        f"{self.log_path.name}:{event.line}",
-                        "wire-geometry event lacks required field(s): "
-                        + ", ".join(missing),
-                    )
+                if not self.require_fields(event, wire_required, "wire-geometry"):
                     continue
                 numeric = wire_required - {"shape", "cut-shape"}
                 if any(not _is_int(event.attrs[field]) for field in numeric):
@@ -1049,14 +1036,7 @@ class Audit:
                     )
                     continue
                 required = {"label", "x", "y"}
-                missing = sorted(required - event.attrs.keys())
-                if missing:
-                    self.hard(
-                        "malformed-event",
-                        f"{self.log_path.name}:{event.line}",
-                        "label-anchor-site event lacks required field(s): "
-                        + ", ".join(missing),
-                    )
+                if not self.require_fields(event, required, "label-anchor-site"):
                     continue
                 if any(not _is_int(event.attrs[field]) for field in required):
                     continue
@@ -1259,14 +1239,7 @@ class Audit:
             for event in pic.events:
                 if event.kind != "ink-use":
                     continue
-                missing = sorted({"class", "id"} - event.attrs.keys())
-                if missing:
-                    self.hard(
-                        "malformed-event",
-                        f"{self.log_path.name}:{event.line}",
-                        "ink-use event lacks required field(s): "
-                        + ", ".join(missing),
-                    )
+                if not self.require_fields(event, {"class", "id"}, "ink-use"):
                     continue
                 if not _is_positive_int(event.attrs["id"]):
                     continue  # FIELD_VALIDATORS already reported the bad value.

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -829,13 +829,21 @@
   \else\PackageError{tenkz}{Audited #2 node '#3' has invalid visible state}%
       {Use an ordinary filled, optionally round-stroked audited node.}%
   \fi}
+% shared by the label and glyph capture entry points below: neither ran
+% its owned PGF path callback (the node's audit style was never actually
+% applied), so there is no invalid-code register to read at all.  #2 is
+% the node to DISPLAY (not necessarily \tikzlastnode -- a deferred glyph
+% capture reports a saved node reference instead), #3 the invalid-code
+% lookup key to clean up
+\def\tenkz@nocapturedpathstate#1#2#3{%
+  \tenkz@cleanupglyphsnapshot{#3}%
+  \PackageError{tenkz}{Audited #1 node '#2' has no captured path state}%
+    {The node did not run its owned PGF path callback.}}
 \def\tenkz@capturelabelbbox#1{%
   \tenkz@checkrequiredlastauditowner{#1}%
   \iftenkz@auditownermatch
     \expandafter\ifx\csname tenkz@invalid@#1\endcsname\relax
-      \tenkz@cleanupglyphsnapshot{#1}%
-      \PackageError{tenkz}{Audited label node '\tikzlastnode' has no captured path state}%
-        {The node did not run its owned PGF path callback.}%
+      \tenkz@nocapturedpathstate{label}{\tikzlastnode}{#1}%
     \else
       \tenkz@capturelabelbboxstate{#1}%
     \fi
@@ -1102,9 +1110,7 @@
   \tenkz@cleanupvisiblesnapshot{#1}}
 \def\tenkz@captureglyphgeometrynode#1#2#3#4{%
   \expandafter\ifx\csname tenkz@invalid@#4\endcsname\relax
-    \tenkz@cleanupglyphsnapshot{#4}%
-    \PackageError{tenkz}{Audited glyph node '#1' has no captured path state}%
-      {The node did not run its owned PGF path callback.}%
+    \tenkz@nocapturedpathstate{glyph}{#1}{#4}%
   \else
     \edef\tenkz@visibleinvalid{\csname tenkz@invalid@#4\endcsname}%
     \ifnum\tenkz@visibleinvalid=0\relax


### PR DESCRIPTION
Continuation of the fewer-elements gate (#4609, itself the second run of the recurring gate LionSR/TNLean#4158). Works through two more candidates from the original 5-lane census that weren't executed in LionSR/TNLean#4609.

## Fixed

- **tenkz-core.code.tex**: extracted `\tenkz@nocapturedpathstate`, shared between `\tenkz@capturelabelbbox` and `\tenkz@captureglyphgeometrynode`, which previously duplicated the identical "no captured path state" ifx-check/cleanup/PackageError shape.

  **Caught a real bug while doing this.** The first draft hardcoded `\tikzlastnode` as the displayed node name — but `\tenkz@captureglyphgeometrynode` has a *second* call site in `tenkz-cd.code.tex` (a deferred map-node context) that passes a different node reference, `\tenkz@mapnode`, not `\tikzlastnode`. The original census evidence only cited the first call site. Found by exhaustively re-grepping every caller before finalizing rather than trusting the cited evidence — fixed by making the display name an explicit parameter instead of an assumption, so both call sites keep their exact original behavior.

- **scripts/tenkz_audit.py**: added `Audit.require_fields(event, required, description) -> bool`, consolidating six copy-pasted "check required fields present, else report malformed-event" blocks (bbox, label-bbox, glyph-geometry, wire-geometry, label-anchor-site, ink-use). Deliberately left two look-alike sites untouched: the tree-event check (a different finding code, `malformed-tree`, plus a function-level `return` instead of a loop `continue`) and the faceports check (a materially different message shape). Verified against seven targeted test scripts — all pass.

## Deferred

Six further census candidates, written up in LionSR/tenkz#64 rather than rushed — each, on inspection, spans more call sites or files than its original estimate suggested (the same pattern the caught bug above demonstrates). A ninth-site "reject unknown pgfkeys key/choice" idiom was scoped and found bigger still (9 sites, 4 files); noted in LionSR/tenkz#64 without a numbered candidate.

## Verification

- Full 257-file corpus (`scripts/tenkz_corpus.sh`): compiled and audited clean, exit 0.
- Every `tex/tenkz/examples/*.tex` individually compiled and audited: 0 failures.
- `docs/tenkz/manual2.tex`: two-pass compile clean, audit clean (0 hard errors; only pre-existing style advisories).

https://claude.ai/code/session_01NwpUjhu75KnYgwyM6hBxxi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring only: audit messages and LaTeX error paths are consolidated without changing validation rules or capture logic when callers pass the same node names as before.
> 
> **Overview**
> This PR continues the fewer-elements refactor with two deduplication passes and no intended behavior change aside from clearer error reporting for deferred glyph capture.
> 
> **`scripts/tenkz_audit.py`** adds `Audit.require_fields(event, required, description)`, which emits the standard `malformed-event` hard finding when required keys are missing and returns whether the event is usable. Six inline copy-paste checks (bbox, label bbox, glyph-geometry, wire-geometry, label-anchor-site, ink-use) now call this helper; callers still choose `continue` vs other control flow.
> 
> **`tex/tenkz/tenkz-core.code.tex`** introduces `\tenkz@nocapturedpathstate{#1}{#2}{#3}` for the shared “no captured path state” cleanup and `\PackageError` path. Label capture uses `\tikzlastnode` for the displayed name; glyph capture passes the node reference explicitly (`#1` in `\tenkz@captureglyphgeometrynode`), which matters for deferred map-node capture in `tenkz-cd.code.tex` where the node is `\tenkz@mapnode`, not `\tikzlastnode`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5057c2328a10c54896462a051121c8ad2875e602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->