### PR TITLE
refactor(PEPS): transport vertical crossing by square swap

### DIFF
--- a/TNLean/PEPS/NormalEdgeSingleCrossing.lean
+++ b/TNLean/PEPS/NormalEdgeSingleCrossing.lean
@@ -113,7 +113,7 @@ theorem isCrossingEdge_normalSquareHorizontalTranslatedEdge
 /-- **The red-to-blue crossings of the translated vertical edge blocking are the
 single distinguished edge.**
 
-The rotated counterpart of
+The coordinate-swap counterpart of
 `isCrossingEdge_normalSquareHorizontalTranslatedEdge`.  The red block (the removed
 horizontal edge block) occupies the three columns `xStart + 2, …, xStart + 4` and the
 two rows `yStart, yStart + 1`; the blue block (the removed vertical edge block)

--- a/TNLean/PEPS/NormalEdgeSingleCrossing.lean
+++ b/TNLean/PEPS/NormalEdgeSingleCrossing.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.PEPS.NormalEdgeBlockingInterior
 import TNLean.PEPS.RegionBlock.CoarseThreeSite2
+import TNLean.PEPS.SquareLatticeCoordinateSwap
 
 /-!
 # The single red-to-blue crossing of the translated edge blocking
@@ -131,48 +132,32 @@ theorem isCrossingEdge_normalSquareVerticalTranslatedEdge
         (normalSquareVerticalTranslatedEdgeRed xStart yStart)
         (normalSquareVerticalTranslatedEdgeBlue xStart yStart) g ↔
       g = normalSquareVerticalTranslatedEdge xStart yStart hx hy := by
+  let φ := squareLatticeCoordinateSwap (width := width) (height := height)
+  have htransport :
+      IsCrossingEdge (G := squareLatticeGraph width height) A
+          (normalSquareVerticalTranslatedEdgeRed xStart yStart)
+          (normalSquareVerticalTranslatedEdgeBlue xStart yStart) g ↔
+        IsCrossingEdge (G := squareLatticeGraph height width) (A.transport φ)
+          (normalSquareHorizontalTranslatedEdgeRed yStart xStart)
+          (normalSquareHorizontalTranslatedEdgeBlue yStart xStart) (Edge.map φ g) := by
+    have h := isCrossingEdge_Region_map A φ
+      (normalSquareVerticalTranslatedEdgeRed xStart yStart)
+      (normalSquareVerticalTranslatedEdgeBlue xStart yStart) g
+    rw [Region_map_squareLatticeCoordinateSwap_verticalTranslatedEdgeRed,
+      Region_map_squareLatticeCoordinateSwap_verticalTranslatedEdgeBlue] at h
+    exact h.symm
+  rw [htransport,
+    isCrossingEdge_normalSquareHorizontalTranslatedEdge (A.transport φ) hy hx]
   constructor
-  · rintro ⟨hRed, hBlue⟩
-    simp only [IsRegionBoundaryEdge, normalSquareVerticalTranslatedEdgeRed,
-      normalSquareVerticalTranslatedEdgeBlue, mem_squareLatticeContiguousRectangle] at hRed hBlue
-    have hadj := g.2.2
-    rw [squareLatticeGraph_adj, squareLatticeHorizontalNeighbor,
-      squareLatticeVerticalNeighbor] at hadj
-    have hlt : g.1.1.1.1 < g.1.2.1.1 ∨
-        (g.1.1.1.1 = g.1.2.1.1 ∧ g.1.1.2.1 < g.1.2.2.1) := by
-      have hlex : toLex g.1.1 < toLex g.1.2 := g.2.1
-      rw [Prod.Lex.toLex_lt_toLex] at hlex
-      rcases hlex with hxlt | ⟨hxe, hye⟩
-      · exact Or.inl hxlt
-      · exact Or.inr ⟨congrArg Fin.val hxe, hye⟩
-    have hyeq : ∀ {p q : Fin height}, p = q → p.1 = q.1 := fun h => congrArg Fin.val h
-    have hxeq : ∀ {p q : Fin width}, p = q → p.1 = q.1 := fun h => congrArg Fin.val h
-    apply Subtype.ext
-    have hcoord : g.1.1.1.1 = xStart + 2 ∧ g.1.1.2.1 = yStart + 1 ∧
-        g.1.2.1.1 = xStart + 2 ∧ g.1.2.2.1 = yStart + 2 := by
-      rcases hadj with ⟨hrow, hcol⟩ | ⟨hcol, hrow⟩
-      · -- Horizontal step: same row, but red rows and blue rows are disjoint.
-        exfalso
-        have hrow' := hyeq hrow
-        rcases hRed with ⟨hr1, hr2⟩ | ⟨hr1, hr2⟩ <;>
-          rcases hBlue with ⟨hb1, hb2⟩ | ⟨hb1, hb2⟩ <;> omega
-      · -- Vertical step: same column, adjacent rows.
-        have hcol' := hxeq hcol
-        rcases hRed with ⟨hr1, hr2⟩ | ⟨hr1, hr2⟩ <;>
-          rcases hBlue with ⟨hb1, hb2⟩ | ⟨hb1, hb2⟩ <;> omega
-    obtain ⟨hc1, hc2, hc3, hc4⟩ := hcoord
-    refine Prod.ext (Prod.ext (Fin.ext ?_) (Fin.ext ?_)) (Prod.ext (Fin.ext ?_) (Fin.ext ?_))
-    · simpa only [normalSquareVerticalTranslatedEdge] using hc1
-    · simpa only [normalSquareVerticalTranslatedEdge] using hc2
-    · simpa only [normalSquareVerticalTranslatedEdge] using hc3
-    · simpa only [normalSquareVerticalTranslatedEdge] using hc4
+  · intro h
+    apply (Edge.equiv φ).injective
+    change Edge.map φ g = Edge.map φ
+      (normalSquareVerticalTranslatedEdge xStart yStart hx hy)
+    rw [h]
+    dsimp only [φ]
+    exact (Edge.map_squareLatticeCoordinateSwap_verticalTranslatedEdge hx hy).symm
   · rintro rfl
-    refine ⟨?_, ?_⟩ <;>
-      simp only [IsRegionBoundaryEdge, normalSquareVerticalTranslatedEdgeRed,
-        normalSquareVerticalTranslatedEdgeBlue, normalSquareVerticalTranslatedEdge,
-        mem_squareLatticeContiguousRectangle]
-    · exact Or.inl ⟨⟨by omega, by omega, by omega, by omega⟩, by omega⟩
-    · exact Or.inr ⟨by omega, ⟨by omega, by omega, by omega, by omega⟩⟩
+    exact Edge.map_squareLatticeCoordinateSwap_verticalTranslatedEdge hx hy
 
 /-! ### The single-crossing hypothesis for the interior blocking data
 

--- a/TNLean/PEPS/SquareLatticeCoordinateSwap.lean
+++ b/TNLean/PEPS/SquareLatticeCoordinateSwap.lean
@@ -134,6 +134,32 @@ theorem RegionInjectivityUnionClosure.transportCoordinateSwap
     rw [Region_map_union]
     exact h.union_injective hR hS
 
+/-- Coordinate swap sends the red block of a translated vertical edge to the red block of the
+transposed horizontal edge. -/
+theorem Region_map_squareLatticeCoordinateSwap_verticalTranslatedEdgeRed
+    {width height xStart yStart : ℕ} :
+    Region.map squareLatticeCoordinateSwap
+        (normalSquareVerticalTranslatedEdgeRed xStart yStart) =
+      (normalSquareHorizontalTranslatedEdgeRed yStart xStart :
+        Finset (SquareLatticeVertex height width)) := by
+  simpa only [normalSquareVerticalTranslatedEdgeRed,
+    normalSquareHorizontalTranslatedEdgeRed, normalSquareRegionTVerticalBlock] using
+    Region_map_squareLatticeCoordinateSwap_contiguousRectangle
+      (width := width) (height := height) (xStart + 2) yStart 3 2
+
+/-- Coordinate swap sends the blue block of a translated vertical edge to the blue block of the
+transposed horizontal edge. -/
+theorem Region_map_squareLatticeCoordinateSwap_verticalTranslatedEdgeBlue
+    {width height xStart yStart : ℕ} :
+    Region.map squareLatticeCoordinateSwap
+        (normalSquareVerticalTranslatedEdgeBlue xStart yStart) =
+      (normalSquareHorizontalTranslatedEdgeBlue yStart xStart :
+        Finset (SquareLatticeVertex height width)) := by
+  simpa only [normalSquareVerticalTranslatedEdgeBlue,
+    normalSquareHorizontalTranslatedEdgeBlue, normalSquareRegionTHorizontalBlock] using
+    Region_map_squareLatticeCoordinateSwap_contiguousRectangle
+      (width := width) (height := height) (xStart + 1) (yStart + 2) 2 3
+
 /-- Coordinate swap sends the distinguished translated vertical edge to the
 translated horizontal edge in the transposed frame. -/
 theorem Edge.map_squareLatticeCoordinateSwap_verticalTranslatedEdge

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
@@ -859,7 +859,7 @@ produces the global gauge family that relates the two tensors.
     \label{thm:peps_exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge}
     \lean{TNLean.PEPS.exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge}
     \leanok
-    \uses{lem:peps_normalSquareVerticalTranslatedEdge_blockingData}
+    \uses{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}
     The rotated counterpart of
     Theorem~\ref{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}.
     Under the same hypotheses on $A$ and $B$, for a translated vertical interior
@@ -874,16 +874,14 @@ produces the global gauge family that relates the two tensors.
 \end{theorem}
 
 \begin{proof}\leanok
-    The vertical translated frame, the horizontal frame rotated by a quarter
-    turn, likewise supplies for both $A$ and $B$ the shared one-edge interior
-    blocking datum,
-    \[
-        R_A = R_B,\qquad B_A = B_B,\qquad C_A = C_B,
-    \]
-    with the distinguished vertical edge $e$ as the unique crossing edge of the
-    red and blue blocks. Applying the per-edge gauge construction from a one-edge
-    blocking datum to the two blocking data yields the bond-dimension equality on
-    $e$ and the conjugating gauge $Z$.
+    Interchange the two lattice coordinates. This graph isomorphism sends the
+    vertical translated frame to the horizontal translated frame, transposes the
+    rectangular injectivity hypotheses, and sends the distinguished vertical edge
+    to the distinguished horizontal edge. Apply
+    Theorem~\ref{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}
+    to the transported tensors. Transporting its bond-dimension equality and
+    conjugating gauge back along the inverse coordinate swap gives the required
+    equality on $e$ and the matrix $Z$.
 \end{proof}
 
 \begin{definition}[Factorized local gauge datum]%

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
@@ -859,8 +859,7 @@ produces the global gauge family that relates the two tensors.
     \label{thm:peps_exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge}
     \lean{TNLean.PEPS.exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge}
     \leanok
-    \uses{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}
-    The rotated counterpart of
+    The coordinate-swap counterpart of
     Theorem~\ref{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}.
     Under the same hypotheses on $A$ and $B$, for a translated vertical interior
     frame with two rows and two columns of margin, that is $2\le x_0$,
@@ -873,7 +872,11 @@ produces the global gauge family that relates the two tensors.
     bond-dimension equality on $e$.
 \end{theorem}
 
-\begin{proof}\leanok
+\begin{proof}
+    \lean{TNLean.PEPS.Region_map_squareLatticeCoordinateSwap_verticalTranslatedEdgeRed}
+    \lean{TNLean.PEPS.Region_map_squareLatticeCoordinateSwap_verticalTranslatedEdgeBlue}
+    \leanok
+    \uses{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}
     Interchange the two lattice coordinates. This graph isomorphism sends the
     vertical translated frame to the horizontal translated frame, transposes the
     rectangular injectivity hypotheses, and sends the distinguished vertical edge


### PR DESCRIPTION
Continues #4526 after merged PR #4601.

Derives the vertical single-crossing statements through the square-lattice coordinate swap instead of maintaining a second proof, adds the required swap covariance lemmas, and updates the blueprint proof sketch without changing the public mathematical statements.

Verification completed in the issue worktree:
- affected Lean diagnostics/builds passed
- proof-debt marker scan found no new debt
- `git diff --check` passed

Refs #4526.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor and documentation only; public theorem statements are preserved and logic is delegated to the existing horizontal proof plus established transport lemmas.
> 
> **Overview**
> **Derives vertical translated-edge single-crossing from the horizontal theorem** by transporting `IsCrossingEdge` along `squareLatticeCoordinateSwap`, instead of a second coordinate-geometry proof in `NormalEdgeSingleCrossing.lean`.
> 
> Adds **`Region_map_squareLatticeCoordinateSwap_verticalTranslatedEdgeRed`** and **`...Blue`** in `SquareLatticeCoordinateSwap.lean` so vertical red/blue blocks map to the transposed horizontal blocks under the swap, then finishes with **`Edge.map_squareLatticeCoordinateSwap_verticalTranslatedEdge`** and edge-map injectivity.
> 
> The blueprint vertical per-edge gauge theorem proof is rewritten to cite coordinate interchange and the horizontal theorem (replacing the rotation-style sketch); **stated mathematics is unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c7328b0a7ed14668cab590a5aede8c9541148b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->