### PR TITLE
refactor(MPS/MPDO): bundle vertical-sector hypotheses

### DIFF
--- a/TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorCompletePositivity.lean
@@ -255,69 +255,20 @@ composites, so their trace adjoints are unital completely positive maps.
 Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1955--1995. -/
 theorem transportedVerticalSector_composites_traceAdjointSchwarz
     {g₁ g₂ d D : ℕ}
-    (dim₁ mult₁ : Fin g₁ → ℕ)
-    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
-    (dim₂ mult₂ : Fin g₂ → ℕ)
-    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
-    (hMult₁ : ∀ α, 0 < mult₁ α)
-    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
-    (hMult₂ : ∀ β, 0 < mult₂ β)
-    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
-    (M : MPOTensor d D)
-    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
-    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
-    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
-      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
-    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
-      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
-    (U₁ : Matrix
-      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
-      (Fin d) ℂ)
-    (U₂ : Matrix
-      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
-      (Fin (d * d)) ℂ)
-    (hU₁ : U₁ * U₁ᴴ = 1)
-    (hU₂ : U₂ * U₂ᴴ = 1)
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
-    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d) (Fin d) ℂ)
-    (hTCPTP : IsKrausCPTP T)
-    (hSCPTP : IsKrausCPTP S)
-    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
-      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
-    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
-      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
-    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
-      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
-    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
-      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
-    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
-    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
+    (h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
     Matrix.IsSchwarzDirectSumMap
-        (Matrix.directSumTraceAdjointMap
-          ((transportedVerticalSectorS
-            dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
-            (transportedVerticalSectorT
-              dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T))) ∧
+        (Matrix.directSumTraceAdjointMap h.SbarTbar) ∧
       Matrix.IsSchwarzDirectSumMap
-        (Matrix.directSumTraceAdjointMap
-          ((transportedVerticalSectorT
-            dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
-            (transportedVerticalSectorS
-              dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S))) := by
+        (Matrix.directSumTraceAdjointMap h.TbarSbar) := by
   obtain ⟨hSTTrace, hTSTrace, _, _⟩ :=
-    transportedVerticalSector_composites_tracePreserving
-      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
-      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
-      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
-      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+    transportedVerticalSector_composites_tracePreserving h
   have hT := transportedVerticalSectorT_isKrausDirectSumMap
-    dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁
-    U₁ U₂ T hTCPTP.isKrausCP
+    h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁
+    h.U₁ h.U₂ h.T h.hTCPTP.isKrausCP
   have hS := transportedVerticalSectorS_isKrausDirectSumMap
-    dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂
-    U₁ U₂ S hSCPTP.isKrausCP
+    h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂
+    h.U₁ h.U₂ h.S h.hSCPTP.isKrausCP
   exact ⟨(hT.comp hS).directSumTraceAdjointMap_isSchwarz hSTTrace,
     (hS.comp hT).directSumTraceAdjointMap_isSchwarz hTSTrace⟩
 

--- a/TNLean/MPS/MPDO/VerticalSectorCoordinates.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorCoordinates.lean
@@ -434,7 +434,7 @@ hypotheses used by the later analytic argument.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
 structure VerticalSectorFixedGeneratorHypotheses {g₁ g₂ d D : ℕ} where
-  /-- One-site simple-sector dimensions and multiplicities.
+  /-- One-site simple-sector dimensions.
 
   Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
   dim₁ : Fin g₁ → ℕ
@@ -446,7 +446,7 @@ structure VerticalSectorFixedGeneratorHypotheses {g₁ g₂ d D : ℕ} where
 
   Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
   weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ
-  /-- Two-site simple-sector dimensions and multiplicities.
+  /-- Two-site simple-sector dimensions.
 
   Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
   dim₂ : Fin g₂ → ℕ

--- a/TNLean/MPS/MPDO/VerticalSectorCoordinates.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorCoordinates.lean
@@ -425,6 +425,161 @@ def transportedVerticalSectorS
     transportSToVerticalCoordinates U₁ U₂ S ∘ₗ
       normalizedRetainedVerticalSectorEmbedding dim₂ mult₂ weight₂
 
+/-- The common vertical-sector hypotheses needed to identify the fixed
+one-site and two-site bond-contraction families.
+
+This is the source-faithful algebraic part of the Appendix C.4 context.  It
+does not include the normal-tensor spanning, coisometry, or channel
+hypotheses used by the later analytic argument.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1980. -/
+structure VerticalSectorFixedGeneratorHypotheses {g₁ g₂ d D : ℕ} where
+  /-- One-site simple-sector dimensions and multiplicities.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  dim₁ : Fin g₁ → ℕ
+  /-- One-site sector multiplicities.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  mult₁ : Fin g₁ → ℕ
+  /-- One-site multiplicity weights.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ
+  /-- Two-site simple-sector dimensions and multiplicities.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  dim₂ : Fin g₂ → ℕ
+  /-- Two-site sector multiplicities.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  mult₂ : Fin g₂ → ℕ
+  /-- Two-site multiplicity weights.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ
+  /-- Every one-site multiplicity space is nontrivial.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hMult₁ : ∀ α, 0 < mult₁ α
+  /-- The one-site multiplicity weights are strictly positive.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q
+  /-- Every two-site multiplicity space is nontrivial.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hMult₂ : ∀ β, 0 < mult₂ β
+  /-- The two-site multiplicity weights are strictly positive.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q
+  /-- The MPDO tensor whose one-site and two-site vertical forms are compared.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1958. -/
+  M : MPOTensor d D
+  /-- The one-site vertical normal tensors.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α)
+  /-- The two-site vertical normal tensors.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β)
+  /-- The retained one-site vertical coordinate map.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  U₁ : Matrix
+    (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+    (Fin d) ℂ
+  /-- The retained two-site vertical coordinate map.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  U₂ : Matrix
+    (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+    (Fin (d * d)) ℂ
+  /-- The physical refinement map.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+  T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ
+  /-- The physical coarse-graining map.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+  S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+    Matrix (Fin d) (Fin d) ℂ
+  /-- The one-site vertical form is obtained by the retained coordinate map.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
+    verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab
+  /-- The retained one-site vertical form reconstructs the original tensor.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hReconstruct₁ : ∀ ab, verticalTensor M ab =
+    U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁
+  /-- The two-site vertical form is obtained by the retained coordinate map.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
+    verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab
+  /-- The retained two-site vertical form reconstructs the blocked tensor.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+    U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂
+  /-- Refinement sends every one-site physical bond closure to its two-site
+  counterpart.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+  hTphys : ∀ X, T (physClose1 M X) = physClose2 M X
+  /-- Coarse-graining sends every two-site physical bond closure back to its
+  one-site counterpart.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+  hSphys : ∀ X, S (physClose2 M X) = physClose1 M X
+
+namespace VerticalSectorFixedGeneratorHypotheses
+
+/-- The transported vertical-sector refinement map determined by the weak
+Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+def Tbar {g₁ g₂ d D : ℕ} (h : VerticalSectorFixedGeneratorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    VerticalSectorAlgebra h.dim₁ →ₗ[ℂ] VerticalSectorAlgebra h.dim₂ :=
+  transportedVerticalSectorT h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.U₁ h.U₂ h.T
+
+/-- The transported vertical-sector coarse-graining map determined by the
+weak Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+def Sbar {g₁ g₂ d D : ℕ} (h : VerticalSectorFixedGeneratorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    VerticalSectorAlgebra h.dim₂ →ₗ[ℂ] VerticalSectorAlgebra h.dim₁ :=
+  transportedVerticalSectorS h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.U₁ h.U₂ h.S
+
+/-- The coarse-graining--refinement composite determined by the weak
+Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+def SbarTbar {g₁ g₂ d D : ℕ} (h : VerticalSectorFixedGeneratorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    VerticalSectorAlgebra h.dim₁ →ₗ[ℂ] VerticalSectorAlgebra h.dim₁ :=
+  h.Sbar.comp h.Tbar
+
+/-- The refinement--coarse-graining composite determined by the weak
+Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+def TbarSbar {g₁ g₂ d D : ℕ} (h : VerticalSectorFixedGeneratorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    VerticalSectorAlgebra h.dim₂ →ₗ[ℂ] VerticalSectorAlgebra h.dim₂ :=
+  h.Tbar.comp h.Sbar
+
+end VerticalSectorFixedGeneratorHypotheses
+
+
 /-- The transported refinement map sends multiplicity-trace-scaled one-site
 sector operators to the corresponding scaled two-site sector operators.
 

--- a/TNLean/MPS/MPDO/VerticalSectorFixedGenerators.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorFixedGenerators.lean
@@ -39,51 +39,22 @@ the later fixed-point structure argument of Appendix C.4, lines 1980--1993.
 Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
 theorem transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
     {g₁ g₂ d D : ℕ}
-    (dim₁ mult₁ : Fin g₁ → ℕ)
-    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
-    (dim₂ mult₂ : Fin g₂ → ℕ)
-    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
-    (hMult₁ : ∀ α, 0 < mult₁ α)
-    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
-    (hMult₂ : ∀ β, 0 < mult₂ β)
-    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
-    (M : MPOTensor d D)
-    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
-    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
-    (U₁ : Matrix
-      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
-      (Fin d) ℂ)
-    (U₂ : Matrix
-      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
-      (Fin (d * d)) ℂ)
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
-    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d) (Fin d) ℂ)
-    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
-      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
-    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
-      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
-    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
-      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
-    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
-      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
-    (X : Matrix (Fin D) (Fin D) ℂ)
-    (hT : T (physClose1 M X) = physClose2 M X)
-    (hS : S (physClose2 M X) = physClose1 M X) :
-    ((transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
-      (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T))
-        (fun α => verticalMultiplicityTrace weight₁ α •
-          MPSTensor.contractBondMatrix (A₁ α) X) =
-      fun α => verticalMultiplicityTrace weight₁ α •
-        MPSTensor.contractBondMatrix (A₁ α) X := by
-  simp only [LinearMap.comp_apply]
+    (h : VerticalSectorFixedGeneratorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D))
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    h.SbarTbar (fun α => verticalMultiplicityTrace h.weight₁ α •
+      MPSTensor.contractBondMatrix (h.A₁ α) X) =
+      fun α => verticalMultiplicityTrace h.weight₁ α •
+        MPSTensor.contractBondMatrix (h.A₁ α) X := by
+  simp only [VerticalSectorFixedGeneratorHypotheses.SbarTbar,
+    VerticalSectorFixedGeneratorHypotheses.Sbar,
+    VerticalSectorFixedGeneratorHypotheses.Tbar, LinearMap.comp_apply]
   rw [transportedVerticalSectorT_contractBondMatrix_trace_smul
-    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ M A₁ A₂ U₁ U₂ T
-    hReconstruct₁ hForward₂ X hT]
+    h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₁ h.hWeight₁
+    h.M h.A₁ h.A₂ h.U₁ h.U₂ h.T h.hReconstruct₁ h.hForward₂ X (h.hTphys X)]
   exact transportedVerticalSectorS_contractBondMatrix_trace_smul
-    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ M A₁ A₂ U₁ U₂ S
-    hForward₁ hReconstruct₂ X hS
+    h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂
+    h.M h.A₁ h.A₂ h.U₁ h.U₂ h.S h.hForward₁ h.hReconstruct₂ X (h.hSphys X)
 
 /-- Every multiplicity-trace-scaled two-site vertical BNT bond contraction is
 fixed by the transported refinement--coarse-graining composite.
@@ -95,50 +66,21 @@ the later fixed-point structure argument of Appendix C.4, lines 1980--1993.
 Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
 theorem transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
     {g₁ g₂ d D : ℕ}
-    (dim₁ mult₁ : Fin g₁ → ℕ)
-    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
-    (dim₂ mult₂ : Fin g₂ → ℕ)
-    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
-    (hMult₁ : ∀ α, 0 < mult₁ α)
-    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
-    (hMult₂ : ∀ β, 0 < mult₂ β)
-    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
-    (M : MPOTensor d D)
-    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
-    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
-    (U₁ : Matrix
-      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
-      (Fin d) ℂ)
-    (U₂ : Matrix
-      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
-      (Fin (d * d)) ℂ)
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
-    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d) (Fin d) ℂ)
-    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
-      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
-    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
-      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
-    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
-      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
-    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
-      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
-    (X : Matrix (Fin D) (Fin D) ℂ)
-    (hT : T (physClose1 M X) = physClose2 M X)
-    (hS : S (physClose2 M X) = physClose1 M X) :
-    ((transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
-      (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S))
-        (fun β => verticalMultiplicityTrace weight₂ β •
-          MPSTensor.contractBondMatrix (A₂ β) X) =
-      fun β => verticalMultiplicityTrace weight₂ β •
-        MPSTensor.contractBondMatrix (A₂ β) X := by
-  simp only [LinearMap.comp_apply]
+    (h : VerticalSectorFixedGeneratorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D))
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    h.TbarSbar (fun β => verticalMultiplicityTrace h.weight₂ β •
+      MPSTensor.contractBondMatrix (h.A₂ β) X) =
+      fun β => verticalMultiplicityTrace h.weight₂ β •
+        MPSTensor.contractBondMatrix (h.A₂ β) X := by
+  simp only [VerticalSectorFixedGeneratorHypotheses.TbarSbar,
+    VerticalSectorFixedGeneratorHypotheses.Tbar,
+    VerticalSectorFixedGeneratorHypotheses.Sbar, LinearMap.comp_apply]
   rw [transportedVerticalSectorS_contractBondMatrix_trace_smul
-    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ M A₁ A₂ U₁ U₂ S
-    hForward₁ hReconstruct₂ X hS]
+    h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂
+    h.M h.A₁ h.A₂ h.U₁ h.U₂ h.S h.hForward₁ h.hReconstruct₂ X (h.hSphys X)]
   exact transportedVerticalSectorT_contractBondMatrix_trace_smul
-    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ M A₁ A₂ U₁ U₂ T
-    hReconstruct₁ hForward₂ X hT
+    h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₁ h.hWeight₁
+    h.M h.A₁ h.A₂ h.U₁ h.U₂ h.T h.hReconstruct₁ h.hForward₂ X (h.hTphys X)
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -13,7 +13,15 @@ import Mathlib.LinearAlgebra.FixedSubmodule
 The proof of the general MPDO renormalization fixed-point theorem uses the
 fact that finite products of the weighted vertical bond contractions span the
 full direct product of the BNT matrix algebras.  This file derives that claim
-from simultaneous word-tuple span of the vertical BNT representatives.
+from simultaneous word-tuple span of the vertical BNT representatives.  It also
+packages the shared algebraic and analytic hypotheses for the subsequent
+positivity, identity, and trace-preservation results.
+
+## Main declarations
+
+* `MPOTensor.VerticalSectorHypotheses`: the common vertical-sector assumptions.
+* `MPOTensor.exists_vertical_weightedProduct_span_eq_top`: generation of the
+  full product algebra.
 
 ## References
 

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -65,6 +65,80 @@ end MPSTensor
 
 namespace MPOTensor
 
+/-- The full vertical-sector hypotheses used in the analytic argument of
+Appendix C.4.
+
+They extend the algebraic fixed-generator context by the normal-tensor,
+coisometry, and channel assumptions needed for positivity, trace
+preservation, and the trace-adjoint Schwarz inequalities.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1955--1995. -/
+structure VerticalSectorHypotheses {g₁ g₂ d D : ℕ} : Type
+    extends VerticalSectorFixedGeneratorHypotheses (g₁ := g₁) (g₂ := g₂) (d := d) (D := D) where
+  /-- The one-site vertical tensors form a basis of normal tensors.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1980--1995. -/
+  hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+    (fun α ↦ ⟨dim₁ α, A₁ α⟩)
+  /-- The two-site vertical tensors form a basis of normal tensors.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1980--1995. -/
+  hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+    (fun β ↦ ⟨dim₂ β, A₂ β⟩)
+  /-- The one-site retained coordinate map is a coisometry.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hU₁ : U₁ * U₁ᴴ = 1
+  /-- The two-site retained coordinate map is a coisometry.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 1955--1971. -/
+  hU₂ : U₂ * U₂ᴴ = 1
+  /-- The physical refinement map is completely positive and trace preserving.
+
+  Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1972--1979. -/
+  hTCPTP : IsKrausCPTP T
+  /-- The physical coarse-graining map is completely positive and trace preserving.
+
+  Source: arXiv:1606.00608, Definition 4.1 and Appendix C.4, lines 1972--1979. -/
+  hSCPTP : IsKrausCPTP S
+
+namespace VerticalSectorHypotheses
+
+/-- The transported vertical-sector refinement map determined by the strong
+Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+abbrev Tbar {g₁ g₂ d D : ℕ} (h : VerticalSectorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :=
+  h.toVerticalSectorFixedGeneratorHypotheses.Tbar
+
+/-- The transported vertical-sector coarse-graining map determined by the
+strong Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1972--1979. -/
+abbrev Sbar {g₁ g₂ d D : ℕ} (h : VerticalSectorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :=
+  h.toVerticalSectorFixedGeneratorHypotheses.Sbar
+
+/-- The coarse-graining--refinement composite determined by the strong
+Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+abbrev SbarTbar {g₁ g₂ d D : ℕ} (h : VerticalSectorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :=
+  h.toVerticalSectorFixedGeneratorHypotheses.SbarTbar
+
+/-- The refinement--coarse-graining composite determined by the strong
+Appendix C.4 hypotheses.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1974--1980. -/
+abbrev TbarSbar {g₁ g₂ d D : ℕ} (h : VerticalSectorHypotheses
+    (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :=
+  h.toVerticalSectorFixedGeneratorHypotheses.TbarSbar
+
+end VerticalSectorHypotheses
+
+
 /-- The direct-product sector operator whose `α`-th sector is the scalar
 multiple $m_α M_α(X)$ obtained by contracting the common horizontal bond
 matrix `X` into every vertical BNT representative.

--- a/TNLean/MPS/MPDO/VerticalSectorIdentity.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorIdentity.lean
@@ -42,128 +42,65 @@ contraction families, and their positive-length product spans.
 Source: arXiv:1606.00608, Appendix C.4, lines 1974--1995. -/
 theorem transportedVerticalSector_composites_eq_id
     {g₁ g₂ d D : ℕ}
-    (dim₁ mult₁ : Fin g₁ → ℕ)
-    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
-    (dim₂ mult₂ : Fin g₂ → ℕ)
-    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
-    (hMult₁ : ∀ α, 0 < mult₁ α)
-    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
-    (hMult₂ : ∀ β, 0 < mult₂ β)
-    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
-    (M : MPOTensor d D)
-    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
-    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
-    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
-      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
-    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
-      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
-    (U₁ : Matrix
-      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
-      (Fin d) ℂ)
-    (U₂ : Matrix
-      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
-      (Fin (d * d)) ℂ)
-    (hU₁ : U₁ * U₁ᴴ = 1)
-    (hU₂ : U₂ * U₂ᴴ = 1)
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
-    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d) (Fin d) ℂ)
-    (hTCPTP : IsKrausCPTP T)
-    (hSCPTP : IsKrausCPTP S)
-    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
-      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
-    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
-      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
-    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
-      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
-    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
-      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
-    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
-    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
-    (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
-        (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T) =
-      LinearMap.id ∧
-    (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
-        (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S) =
-      LinearMap.id := by
+    (h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    h.SbarTbar = LinearMap.id ∧
+      h.TbarSbar = LinearMap.id := by
   classical
-  let Tbar := transportedVerticalSectorT
-    dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
-  let Sbar := transportedVerticalSectorS
-    dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
-  let F₁ := Sbar.comp Tbar
-  let F₂ := Tbar.comp Sbar
-  have hTbarpos (X : VerticalSectorAlgebra dim₁)
+  have hTbarpos (X : VerticalSectorAlgebra h.dim₁)
       (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (Tbar X) := by
+      IsVerticalSectorPosSemidef (h.Tbar X) := by
     exact transportedVerticalSectorT_posSemidef
-      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁ U₁ U₂ T hTCPTP X hX
-  have hSbarpos (X : VerticalSectorAlgebra dim₂)
+      h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁ h.U₁ h.U₂ h.T h.hTCPTP X hX
+  have hSbarpos (X : VerticalSectorAlgebra h.dim₂)
       (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (Sbar X) := by
+      IsVerticalSectorPosSemidef (h.Sbar X) := by
     exact transportedVerticalSectorS_posSemidef
-      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ U₁ U₂ S hSCPTP X hX
-  have hF₁pos : Matrix.IsPositiveDirectSumMap F₁ := by
+      h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂ h.U₁ h.U₂ h.S h.hSCPTP X hX
+  have hF₁pos : Matrix.IsPositiveDirectSumMap h.SbarTbar := by
     intro X hX
-    exact hSbarpos (Tbar X) (hTbarpos X hX)
-  have hF₂pos : Matrix.IsPositiveDirectSumMap F₂ := by
+    exact hSbarpos (h.Tbar X) (hTbarpos X hX)
+  have hF₂pos : Matrix.IsPositiveDirectSumMap h.TbarSbar := by
     intro X hX
-    exact hTbarpos (Sbar X) (hSbarpos X hX)
+    exact hTbarpos (h.Sbar X) (hSbarpos X hX)
   obtain ⟨hF₁TP, hF₂TP, _, _⟩ :=
-    transportedVerticalSector_composites_tracePreserving
-      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
-      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
-      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
-      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+    transportedVerticalSector_composites_tracePreserving h
   obtain ⟨hF₁Schwarz, hF₂Schwarz⟩ :=
-    transportedVerticalSector_composites_traceAdjointSchwarz
-      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
-      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
-      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
-      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+    transportedVerticalSector_composites_traceAdjointSchwarz h
   obtain ⟨L₁, hL₁, hSpan₁⟩ :=
     exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
-      hBNT₁ weight₁ hMult₁ hWeight₁
+      h.hBNT₁ h.weight₁ h.hMult₁ h.hWeight₁
   obtain ⟨L₂, hL₂, hSpan₂⟩ :=
     exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
-      hBNT₂ weight₂ hMult₂ hWeight₂
+      h.hBNT₂ h.weight₂ h.hMult₂ h.hWeight₂
   have hFixed₁ (X : Matrix (Fin D) (Fin D) ℂ) :
-      F₁ (weightedVerticalBondContraction
-        (verticalMultiplicityTrace weight₁) A₁ X) =
+      h.SbarTbar (weightedVerticalBondContraction
+        (verticalMultiplicityTrace h.weight₁) h.A₁ X) =
         weightedVerticalBondContraction
-          (verticalMultiplicityTrace weight₁) A₁ X := by
-    change F₁ (fun α ↦ verticalMultiplicityTrace weight₁ α •
-      MPSTensor.contractBondMatrix (A₁ α) X) =
-        fun α ↦ verticalMultiplicityTrace weight₁ α •
-          MPSTensor.contractBondMatrix (A₁ α) X
-    simpa only [F₁, Tbar, Sbar] using
-      transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
-        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
-        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
-        (hTphys X) (hSphys X)
+          (verticalMultiplicityTrace h.weight₁) h.A₁ X := by
+    change h.SbarTbar (fun α ↦ verticalMultiplicityTrace h.weight₁ α •
+      MPSTensor.contractBondMatrix (h.A₁ α) X) =
+        fun α ↦ verticalMultiplicityTrace h.weight₁ α •
+          MPSTensor.contractBondMatrix (h.A₁ α) X
+    exact transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
+      h.toVerticalSectorFixedGeneratorHypotheses X
   have hFixed₂ (X : Matrix (Fin D) (Fin D) ℂ) :
-      F₂ (weightedVerticalBondContraction
-        (verticalMultiplicityTrace weight₂) A₂ X) =
+      h.TbarSbar (weightedVerticalBondContraction
+        (verticalMultiplicityTrace h.weight₂) h.A₂ X) =
         weightedVerticalBondContraction
-          (verticalMultiplicityTrace weight₂) A₂ X := by
-    change F₂ (fun β ↦ verticalMultiplicityTrace weight₂ β •
-      MPSTensor.contractBondMatrix (A₂ β) X) =
-        fun β ↦ verticalMultiplicityTrace weight₂ β •
-          MPSTensor.contractBondMatrix (A₂ β) X
-    simpa only [F₂, Tbar, Sbar] using
-      transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
-        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
-        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
-        (hTphys X) (hSphys X)
+          (verticalMultiplicityTrace h.weight₂) h.A₂ X := by
+    change h.TbarSbar (fun β ↦ verticalMultiplicityTrace h.weight₂ β •
+      MPSTensor.contractBondMatrix (h.A₂ β) X) =
+        fun β ↦ verticalMultiplicityTrace h.weight₂ β •
+          MPSTensor.contractBondMatrix (h.A₂ β) X
+    exact transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
+      h.toVerticalSectorFixedGeneratorHypotheses X
   constructor
-  · change F₁ = LinearMap.id
-    exact eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
-      (verticalMultiplicityTrace weight₁) A₁ F₁ hL₁ hF₁pos hF₁TP hF₁Schwarz
+  · exact eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
+      (verticalMultiplicityTrace h.weight₁) h.A₁ h.SbarTbar hL₁ hF₁pos hF₁TP hF₁Schwarz
       hSpan₁ hFixed₁
-  · change F₂ = LinearMap.id
-    exact eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
-      (verticalMultiplicityTrace weight₂) A₂ F₂ hL₂ hF₂pos hF₂TP hF₂Schwarz
+  · exact eq_id_of_weightedVerticalBondContractions_fixed_of_traceAdjointSchwarz
+      (verticalMultiplicityTrace h.weight₂) h.A₂ h.TbarSbar hL₂ hF₂pos hF₂TP hF₂Schwarz
       hSpan₂ hFixed₂
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorRelabeling.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRelabeling.lean
@@ -87,6 +87,37 @@ theorem transportedVerticalSector_exists_unitaryBlockEquiv
                 ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ * Y *
                   (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ))) := by
   classical
+  let h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D) :=
+    { dim₁ := dim₁
+      mult₁ := mult₁
+      weight₁ := weight₁
+      dim₂ := dim₂
+      mult₂ := mult₂
+      weight₂ := weight₂
+      hMult₁ := hMult₁
+      hWeight₁ := hWeight₁
+      hMult₂ := hMult₂
+      hWeight₂ := hWeight₂
+      M := M
+      A₁ := A₁
+      A₂ := A₂
+      U₁ := U₁
+      U₂ := U₂
+      T := T
+      S := S
+      hForward₁ := hForward₁
+      hReconstruct₁ := hReconstruct₁
+      hForward₂ := hForward₂
+      hReconstruct₂ := hReconstruct₂
+      hTphys := hTphys
+      hSphys := hSphys
+      hBNT₁ := hBNT₁
+      hBNT₂ := hBNT₂
+      hU₁ := hU₁
+      hU₂ := hU₂
+      hTCPTP := hTCPTP
+      hSCPTP := hSCPTP }
   let Tbar := transportedVerticalSectorT
     dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
   let Sbar := transportedVerticalSectorS
@@ -100,16 +131,8 @@ theorem transportedVerticalSector_exists_unitaryBlockEquiv
     exact transportedVerticalSectorS_isKrausDirectSumMap
       dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ U₁ U₂ S hSCPTP.isKrausCP
   obtain ⟨_, _, hTbarTP, hSbarTP⟩ :=
-    transportedVerticalSector_composites_tracePreserving
-      dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
-      hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
-      U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
-      hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
-  obtain ⟨hST, hTS⟩ := transportedVerticalSector_composites_eq_id
-    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
-    hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
-    U₁ U₂ hU₁ hU₂ T S hTCPTP hSCPTP
-    hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
+    transportedVerticalSector_composites_tracePreserving h
+  obtain ⟨hST, hTS⟩ := transportedVerticalSector_composites_eq_id h
   obtain ⟨sigma, hDim, V, hVT, hVS⟩ :=
     Matrix.exists_blockEquiv_dim_eq_unitary_forward_of_mutual_inverse_kraus_direct_sum_maps
       Tbar Sbar hTbar hSbar hTbarTP hSbarTP hST hTS

--- a/TNLean/MPS/MPDO/VerticalSectorRelabeling.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorRelabeling.lean
@@ -118,24 +118,22 @@ theorem transportedVerticalSector_exists_unitaryBlockEquiv
       hU₂ := hU₂
       hTCPTP := hTCPTP
       hSCPTP := hSCPTP }
-  let Tbar := transportedVerticalSectorT
-    dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
-  let Sbar := transportedVerticalSectorS
-    dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
-  letI : ∀ i, NeZero (dim₁ i) := fun i ↦ ⟨(hBNT₁.blocks_dim_pos i).ne'⟩
-  letI : ∀ j, NeZero (dim₂ j) := fun j ↦ ⟨(hBNT₂.blocks_dim_pos j).ne'⟩
-  have hTbar : Matrix.IsKrausDirectSumMap Tbar := by
+  letI : ∀ i, NeZero (h.dim₁ i) := fun i ↦ ⟨(h.hBNT₁.blocks_dim_pos i).ne'⟩
+  letI : ∀ j, NeZero (h.dim₂ j) := fun j ↦ ⟨(h.hBNT₂.blocks_dim_pos j).ne'⟩
+  have hTbar : Matrix.IsKrausDirectSumMap h.Tbar := by
     exact transportedVerticalSectorT_isKrausDirectSumMap
-      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁ U₁ U₂ T hTCPTP.isKrausCP
-  have hSbar : Matrix.IsKrausDirectSumMap Sbar := by
+      h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁
+      h.U₁ h.U₂ h.T h.hTCPTP.isKrausCP
+  have hSbar : Matrix.IsKrausDirectSumMap h.Sbar := by
     exact transportedVerticalSectorS_isKrausDirectSumMap
-      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ U₁ U₂ S hSCPTP.isKrausCP
+      h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂
+      h.U₁ h.U₂ h.S h.hSCPTP.isKrausCP
   obtain ⟨_, _, hTbarTP, hSbarTP⟩ :=
     transportedVerticalSector_composites_tracePreserving h
   obtain ⟨hST, hTS⟩ := transportedVerticalSector_composites_eq_id h
   obtain ⟨sigma, hDim, V, hVT, hVS⟩ :=
     Matrix.exists_blockEquiv_dim_eq_unitary_forward_of_mutual_inverse_kraus_direct_sum_maps
-      Tbar Sbar hTbar hSbar hTbarTP hSbarTP hST hTS
+      h.Tbar h.Sbar hTbar hSbar hTbarTP hSbarTP hST hTS
   exact ⟨sigma, hDim, V, hVT, hVS⟩
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorTracePreservation.lean
@@ -47,156 +47,101 @@ support of a positive mean-ergodic fixed point; it is not used to claim that
 products of fixed points are fixed. -/
 theorem transportedVerticalSector_composites_tracePreserving
     {g₁ g₂ d D : ℕ}
-    (dim₁ mult₁ : Fin g₁ → ℕ)
-    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
-    (dim₂ mult₂ : Fin g₂ → ℕ)
-    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
-    (hMult₁ : ∀ α, 0 < mult₁ α)
-    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
-    (hMult₂ : ∀ β, 0 < mult₂ β)
-    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
-    (M : MPOTensor d D)
-    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
-    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
-    (hBNT₁ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
-      (fun α ↦ ⟨dim₁ α, A₁ α⟩))
-    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
-      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
-    (U₁ : Matrix
-      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
-      (Fin d) ℂ)
-    (U₂ : Matrix
-      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
-      (Fin (d * d)) ℂ)
-    (hU₁ : U₁ * U₁ᴴ = 1)
-    (hU₂ : U₂ * U₂ᴴ = 1)
-    (T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
-    (S : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
-      Matrix (Fin d) (Fin d) ℂ)
-    (hTCPTP : IsKrausCPTP T)
-    (hSCPTP : IsKrausCPTP S)
-    (hForward₁ : ∀ ab, U₁ * verticalTensor M ab * U₁ᴴ =
-      verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab)
-    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
-      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
-    (hForward₂ : ∀ ab, U₂ * verticalTensor (blockTwo M) ab * U₂ᴴ =
-      verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab)
-    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
-      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
-    (hTphys : ∀ X, T (physClose1 M X) = physClose2 M X)
-    (hSphys : ∀ X, S (physClose2 M X) = physClose1 M X) :
-    Matrix.IsTracePreservingDirectSumMap
-        ((transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S).comp
-          (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T)) ∧
-      Matrix.IsTracePreservingDirectSumMap
-        ((transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T).comp
-          (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S)) ∧
-      Matrix.IsTracePreservingBetweenDirectSums
-        (transportedVerticalSectorT dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T) ∧
-      Matrix.IsTracePreservingBetweenDirectSums
-        (transportedVerticalSectorS dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S) := by
+    (h : VerticalSectorHypotheses
+      (g₁ := g₁) (g₂ := g₂) (d := d) (D := D)) :
+    Matrix.IsTracePreservingDirectSumMap h.SbarTbar ∧
+      Matrix.IsTracePreservingDirectSumMap h.TbarSbar ∧
+      Matrix.IsTracePreservingBetweenDirectSums h.Tbar ∧
+      Matrix.IsTracePreservingBetweenDirectSums h.Sbar := by
   classical
-  let Tbar := transportedVerticalSectorT
-    dim₁ mult₁ weight₁ dim₂ mult₂ U₁ U₂ T
-  let Sbar := transportedVerticalSectorS
-    dim₁ mult₁ dim₂ mult₂ weight₂ U₁ U₂ S
-  let F₁ := Sbar.comp Tbar
-  let F₂ := Tbar.comp Sbar
-  have hTbarpos (X : VerticalSectorAlgebra dim₁)
+  have hTbarpos (X : VerticalSectorAlgebra h.dim₁)
       (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (Tbar X) := by
+      IsVerticalSectorPosSemidef (h.Tbar X) := by
     exact transportedVerticalSectorT_posSemidef
-      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁ U₁ U₂ T hTCPTP X hX
-  have hSbarpos (X : VerticalSectorAlgebra dim₂)
+      h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁ h.U₁ h.U₂ h.T h.hTCPTP X hX
+  have hSbarpos (X : VerticalSectorAlgebra h.dim₂)
       (hX : IsVerticalSectorPosSemidef X) :
-      IsVerticalSectorPosSemidef (Sbar X) := by
+      IsVerticalSectorPosSemidef (h.Sbar X) := by
     exact transportedVerticalSectorS_posSemidef
-      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂ U₁ U₂ S hSCPTP X hX
-  have hF₁pos : Matrix.IsPositiveDirectSumMap F₁ := by
+      h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂ h.U₁ h.U₂ h.S h.hSCPTP X hX
+  have hF₁pos : Matrix.IsPositiveDirectSumMap h.SbarTbar := by
     intro X hX
-    exact hSbarpos (Tbar X) (hTbarpos X hX)
-  have hF₂pos : Matrix.IsPositiveDirectSumMap F₂ := by
+    exact hSbarpos (h.Tbar X) (hTbarpos X hX)
+  have hF₂pos : Matrix.IsPositiveDirectSumMap h.TbarSbar := by
     intro X hX
-    exact hTbarpos (Sbar X) (hSbarpos X hX)
-  have hTbarle (X : VerticalSectorAlgebra dim₁)
+    exact hTbarpos (h.Sbar X) (hSbarpos X hX)
+  have hTbarle (X : VerticalSectorAlgebra h.dim₁)
       (hX : IsVerticalSectorPosSemidef X) :
-      verticalSectorTrace (Tbar X) ≤ verticalSectorTrace X :=
+      verticalSectorTrace (h.Tbar X) ≤ verticalSectorTrace X :=
     transportedVerticalSectorT_trace_le
-      dim₁ mult₁ weight₁ dim₂ mult₂ hMult₁ hWeight₁
-      U₁ hU₁ U₂ hU₂ T hTCPTP X hX
-  have hSbarle (X : VerticalSectorAlgebra dim₂)
+      h.dim₁ h.mult₁ h.weight₁ h.dim₂ h.mult₂ h.hMult₁ h.hWeight₁
+      h.U₁ h.hU₁ h.U₂ h.hU₂ h.T h.hTCPTP X hX
+  have hSbarle (X : VerticalSectorAlgebra h.dim₂)
       (hX : IsVerticalSectorPosSemidef X) :
-      verticalSectorTrace (Sbar X) ≤ verticalSectorTrace X :=
+      verticalSectorTrace (h.Sbar X) ≤ verticalSectorTrace X :=
     transportedVerticalSectorS_trace_le
-      dim₁ mult₁ dim₂ mult₂ weight₂ hMult₂ hWeight₂
-      U₁ hU₁ U₂ hU₂ S hSCPTP X hX
-  have hTbarTNI : Matrix.IsTraceNonincreasingBetweenDirectSums Tbar := by
+      h.dim₁ h.mult₁ h.dim₂ h.mult₂ h.weight₂ h.hMult₂ h.hWeight₂
+      h.U₁ h.hU₁ h.U₂ h.hU₂ h.S h.hSCPTP X hX
+  have hTbarTNI : Matrix.IsTraceNonincreasingBetweenDirectSums h.Tbar := by
     intro X hX
     exact hTbarle X hX
-  have hSbarTNI : Matrix.IsTraceNonincreasingBetweenDirectSums Sbar := by
+  have hSbarTNI : Matrix.IsTraceNonincreasingBetweenDirectSums h.Sbar := by
     intro X hX
     exact hSbarle X hX
-  have hF₁TNI : Matrix.IsTraceNonincreasingBetweenDirectSums F₁ := by
+  have hF₁TNI : Matrix.IsTraceNonincreasingBetweenDirectSums h.SbarTbar := by
     intro X hX
-    exact (hSbarle (Tbar X) (hTbarpos X hX)).trans (hTbarle X hX)
-  have hF₂TNI : Matrix.IsTraceNonincreasingBetweenDirectSums F₂ := by
+    exact (hSbarle (h.Tbar X) (hTbarpos X hX)).trans (hTbarle X hX)
+  have hF₂TNI : Matrix.IsTraceNonincreasingBetweenDirectSums h.TbarSbar := by
     intro X hX
-    exact (hTbarle (Sbar X) (hSbarpos X hX)).trans (hSbarle X hX)
+    exact (hTbarle (h.Sbar X) (hSbarpos X hX)).trans (hSbarle X hX)
   obtain ⟨L₁, hL₁, hSpan₁⟩ :=
     exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
-      hBNT₁ weight₁ hMult₁ hWeight₁
+      h.hBNT₁ h.weight₁ h.hMult₁ h.hWeight₁
   obtain ⟨L₂, hL₂, hSpan₂⟩ :=
     exists_positive_verticalMultiplicityTraceBondContractionProductSpanTop_of_bnt
-      hBNT₂ weight₂ hMult₂ hWeight₂
+      h.hBNT₂ h.weight₂ h.hMult₂ h.hWeight₂
   let V₁ := weightedVerticalBondContraction
-    (verticalMultiplicityTrace weight₁) A₁
+    (verticalMultiplicityTrace h.weight₁) h.A₁
   let V₂ := weightedVerticalBondContraction
-    (verticalMultiplicityTrace weight₂) A₂
-  have hV₁fixed (X : Matrix (Fin D) (Fin D) ℂ) : F₁ (V₁ X) = V₁ X := by
-    change F₁ (fun α ↦ verticalMultiplicityTrace weight₁ α •
-      MPSTensor.contractBondMatrix (A₁ α) X) =
-        fun α ↦ verticalMultiplicityTrace weight₁ α •
-          MPSTensor.contractBondMatrix (A₁ α) X
-    simpa only [F₁, Tbar, Sbar] using
-      transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
-        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
-        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
-        (hTphys X) (hSphys X)
-  have hV₂fixed (X : Matrix (Fin D) (Fin D) ℂ) : F₂ (V₂ X) = V₂ X := by
-    change F₂ (fun β ↦ verticalMultiplicityTrace weight₂ β •
-      MPSTensor.contractBondMatrix (A₂ β) X) =
-        fun β ↦ verticalMultiplicityTrace weight₂ β •
-          MPSTensor.contractBondMatrix (A₂ β) X
-    simpa only [F₂, Tbar, Sbar] using
-      transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
-        dim₁ mult₁ weight₁ dim₂ mult₂ weight₂ hMult₁ hWeight₁ hMult₂ hWeight₂
-        M A₁ A₂ U₁ U₂ T S hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ X
-        (hTphys X) (hSphys X)
-  have hOne₁ : (1 : VerticalSectorAlgebra dim₁) ∈
+    (verticalMultiplicityTrace h.weight₂) h.A₂
+  have hV₁fixed (X : Matrix (Fin D) (Fin D) ℂ) : h.SbarTbar (V₁ X) = V₁ X := by
+    change h.SbarTbar (fun α ↦ verticalMultiplicityTrace h.weight₁ α •
+      MPSTensor.contractBondMatrix (h.A₁ α) X) =
+        fun α ↦ verticalMultiplicityTrace h.weight₁ α •
+          MPSTensor.contractBondMatrix (h.A₁ α) X
+    exact transportedVerticalSectorS_comp_T_fixed_contractBondMatrix_trace_smul
+      h.toVerticalSectorFixedGeneratorHypotheses X
+  have hV₂fixed (X : Matrix (Fin D) (Fin D) ℂ) : h.TbarSbar (V₂ X) = V₂ X := by
+    change h.TbarSbar (fun β ↦ verticalMultiplicityTrace h.weight₂ β •
+      MPSTensor.contractBondMatrix (h.A₂ β) X) =
+        fun β ↦ verticalMultiplicityTrace h.weight₂ β •
+          MPSTensor.contractBondMatrix (h.A₂ β) X
+    exact transportedVerticalSectorT_comp_S_fixed_contractBondMatrix_trace_smul
+      h.toVerticalSectorFixedGeneratorHypotheses X
+  have hOne₁ : (1 : VerticalSectorAlgebra h.dim₁) ∈
       Submodule.span ℂ (Set.range fun x : Fin L₁ → Matrix (Fin D) (Fin D) ℂ ↦
         (List.ofFn fun t ↦ V₁ (x t)).prod) := by
     simpa only [V₁] using
       one_mem_product_span_of_weightedVerticalBondContractions
-        (verticalMultiplicityTrace weight₁) A₁ hSpan₁
-  have hOne₂ : (1 : VerticalSectorAlgebra dim₂) ∈
+        (verticalMultiplicityTrace h.weight₁) h.A₁ hSpan₁
+  have hOne₂ : (1 : VerticalSectorAlgebra h.dim₂) ∈
       Submodule.span ℂ (Set.range fun x : Fin L₂ → Matrix (Fin D) (Fin D) ℂ ↦
         (List.ofFn fun t ↦ V₂ (x t)).prod) := by
     simpa only [V₂] using
       one_mem_product_span_of_weightedVerticalBondContractions
-        (verticalMultiplicityTrace weight₂) A₂ hSpan₂
+        (verticalMultiplicityTrace h.weight₂) h.A₂ hSpan₂
   have hF₁trace :=
     hF₁pos.tracePreserving_of_traceNonincreasing_of_fixed_product_span
       hF₁TNI V₁ L₁ hL₁ hV₁fixed hOne₁
   have hF₂trace :=
     hF₂pos.tracePreserving_of_traceNonincreasing_of_fixed_product_span
       hF₂TNI V₂ L₂ hL₂ hV₂fixed hOne₂
-  have hTbarTrace : Matrix.IsTracePreservingBetweenDirectSums Tbar :=
+  have hTbarTrace : Matrix.IsTracePreservingBetweenDirectSums h.Tbar :=
     Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
       hTbarpos hTbarTNI hSbarTNI
         (Matrix.isTracePreservingBetweenDirectSums_iff_isTracePreservingDirectSumMap.mpr
           hF₁trace)
-  have hSbarTrace : Matrix.IsTracePreservingBetweenDirectSums Sbar :=
+  have hSbarTrace : Matrix.IsTracePreservingBetweenDirectSums h.Sbar :=
     Matrix.isTracePreservingBetweenDirectSums_of_comp_of_traceNonincreasing
       hSbarpos hSbarTNI hTbarTNI
         (Matrix.isTracePreservingBetweenDirectSums_iff_isTracePreservingDirectSumMap.mpr


### PR DESCRIPTION
Closes #4517.

Bundles the repeated fixed-generator and vertical-sector assumptions into named structures, adds the bundled transported maps, migrates the five targeted long-signature theorems, and updates the relabeling consumer. Public mathematical conclusions are unchanged.

Verification:
- native Lean diagnostics clean on all seven changed files
- no new `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
- `git diff --check`
- no local cache/build recreation; full build delegated to CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorem statements; risk is limited to field projection mistakes in migrated proofs, not runtime or security impact.
> 
> **Overview**
> Introduces **`VerticalSectorFixedGeneratorHypotheses`** (algebraic Appendix C.4 data: sectors, coordinates, `T`/`S`, physical closure) and **`VerticalSectorHypotheses`** (extends it with BNT bases, coisometry, and CPTP channel assumptions). Each bundle exposes **`Tbar`**, **`Sbar`**, **`SbarTbar`**, and **`TbarSbar`** as the transported maps and their composites.
> 
> The long-parameter theorems for trace preservation, Schwarz inequalities, composite identity, and fixed bond contractions now take a single hypothesis record and refer to **`h.SbarTbar`** / **`h.TbarSbar`** instead of rebuilding **`transportedVerticalSectorT`** / **`S`** compositions inline. **`transportedVerticalSector_exists_unitaryBlockEquiv`** still accepts the original loose arguments but assembles a **`VerticalSectorHypotheses`** value and calls the bundled lemmas.
> 
> **No change to stated mathematical conclusions**—only hypothesis packaging and call-site wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0cbc5435fb970f214c8e84707a2750fa2c2293e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->