### PR TITLE
refactor(MPS): share invariant subspace decomposition

### DIFF
--- a/TNLean/Channel/Determinant/Bound.lean
+++ b/TNLean/Channel/Determinant/Bound.lean
@@ -36,25 +36,27 @@ quantum channel, determinant bound, positive map, trace-preserving map
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
-open ChannelDeterminant.Internal
 
 variable {d : ℕ}
 
 section WolfStatements
 
-variable {T : MatrixEnd d}
+abbrev MatAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
+abbrev MatEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
+
+variable {T : MatEnd d}
 
 private theorem trace_zero_hermitian_eq_smul_density_sub_density [NeZero d]
-    {X : MatrixAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
-    ∃ c : ℂ, 0 ≤ c ∧ ∃ ρ σ : MatrixAlg d,
+    {X : MatAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
+    ∃ c : ℂ, 0 ≤ c ∧ ∃ ρ σ : MatAlg d,
       ρ ∈ densityMatrices d ∧ σ ∈ densityMatrices d ∧ X = c • (ρ - σ) := by
   obtain ⟨ρ₀, hρ₀_mem⟩ :=
     densityMatrices_nonempty (D := d) (Nat.pos_of_ne_zero (NeZero.ne d))
   by_cases hX0 : X = 0
   · exact ⟨0, by simp only [Std.le_refl], ρ₀, ρ₀, hρ₀_mem, hρ₀_mem,
       by simp only [hX0, sub_self, smul_zero]⟩
-  · let Q₁ : MatrixAlg d := X⁺
-    let Q₂ : MatrixAlg d := X⁻
+  · let Q₁ : MatAlg d := X⁺
+    let Q₂ : MatAlg d := X⁻
     have hQ₁_psd : Q₁.PosSemidef :=
       Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg X)
     have hQ₂_psd : Q₂.PosSemidef :=
@@ -78,8 +80,8 @@ private theorem trace_zero_hermitian_eq_smul_density_sub_density [NeZero d]
         simpa only using hc0
       apply hX0
       simp only [hX_decomp, hQ₁_zero, hQ₂_zero, sub_self]
-    let ρ : MatrixAlg d := c⁻¹ • Q₁
-    let σ : MatrixAlg d := c⁻¹ • Q₂
+    let ρ : MatAlg d := c⁻¹ • Q₁
+    let σ : MatAlg d := c⁻¹ • Q₂
     have hc_inv_nonneg : 0 ≤ c⁻¹ := inv_nonneg.2 hc_nonneg
     have hρ_mem : ρ ∈ densityMatrices d := by
       refine ⟨hQ₁_psd.smul hc_inv_nonneg, ?_⟩
@@ -96,13 +98,13 @@ private theorem trace_zero_hermitian_eq_smul_density_sub_density [NeZero d]
       c, ρ, σ]
 
 private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [NeZero d]
-    {T : MatrixEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
-    {X : MatrixAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
+    {T : MatEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {X : MatAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
     ∃ C : ℝ, ∀ n : ℕ, ‖(T ^ n) X‖ ≤ C := by
   have hmap_density :
-      ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d → T ρ ∈ densityMatrices d :=
+      ∀ ρ : MatAlg d, ρ ∈ densityMatrices d → T ρ ∈ densityMatrices d :=
     fun ρ hρ => ⟨hPos ρ hρ.1, by rw [hTP ρ, hρ.2]⟩
-  have hiter_density : ∀ n : ℕ, ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d →
+  have hiter_density : ∀ n : ℕ, ∀ ρ : MatAlg d, ρ ∈ densityMatrices d →
       (T ^ n) ρ ∈ densityMatrices d := by
     intro n
     induction n with
@@ -114,9 +116,9 @@ private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [N
         rw [pow_succ']
         exact hmap_density ((T ^ n) ρ) (ih ρ hρ)
   have hbounded_density :
-      ∃ M : ℝ, ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d → ‖ρ‖ ≤ M := by
+      ∃ M : ℝ, ∀ ρ : MatAlg d, ρ ∈ densityMatrices d → ‖ρ‖ ≤ M := by
     have hbd : Bornology.IsBounded
-        {X : MatrixAlg d | X.PosSemidef ∧ ‖Matrix.trace X‖ ≤ 1} :=
+        {X : MatAlg d | X.PosSemidef ∧ ‖Matrix.trace X‖ ≤ 1} :=
       posSemidef_trace_bounded_isBounded (D := d) 1
     rw [isBounded_iff_forall_norm_le] at hbd
     obtain ⟨M, hM⟩ := hbd
@@ -141,15 +143,15 @@ private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [N
       mul_le_mul_of_nonneg_left (add_le_add hρ_orbit hσ_orbit) (norm_nonneg _)
 
 private theorem positiveTracePreserving_eigenvalue_norm_le_one [NeZero d]
-    {T : MatrixEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {T : MatEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
     (μ : ℂ) (hμ : Module.End.HasEigenvalue T μ) :
     ‖μ‖ ≤ 1 := by
   obtain ⟨z, hz⟩ := hμ.exists_hasEigenvector
   have hz_eig : T z = μ • z := Module.End.mem_eigenspace_iff.mp hz.1
   have hz_ne : z ≠ 0 := hz.2
   by_cases htrz : Matrix.trace z = 0
-  · let x : MatrixAlg d := (1 / 2 : ℝ) • (z + zᴴ)
-    let y : MatrixAlg d := (1 / 2 : ℝ) • (Complex.I • (zᴴ - z))
+  · let x : MatAlg d := (1 / 2 : ℝ) • (z + zᴴ)
+    let y : MatAlg d := (1 / 2 : ℝ) • (Complex.I • (zᴴ - z))
     have hx_herm : x.IsHermitian := by
       ext i j
       simp only [smul_add, one_div, conjTranspose_apply, Matrix.add_apply, Matrix.smul_apply,
@@ -283,7 +285,8 @@ theorem channelDet_norm_le_one_of_positive_tracePreserving
     intro μ hμ
     exact positiveTracePreserving_eigenvalue_norm_le_one (d := d) hPos hTP μ
       (Module.End.hasEigenvalue_iff_mem_spectrum.2
-        ((AlgEquiv.spectrum_eq (LinearMap.toMatrixAlgEquiv (matrixSpaceBasis d)) T) ▸
+        ((AlgEquiv.spectrum_eq (LinearMap.toMatrixAlgEquiv
+            (ChannelDeterminant.Internal.matrixSpaceBasis d)) T) ▸
           Matrix.mem_spectrum_of_isRoot_charpoly
             ((Polynomial.mem_roots (channelMatrix T).charpoly_monic.ne_zero).1 hμ)))
 

--- a/TNLean/Channel/Determinant/Bound.lean
+++ b/TNLean/Channel/Determinant/Bound.lean
@@ -41,22 +41,22 @@ variable {d : ℕ}
 
 section WolfStatements
 
-abbrev MatAlg (d : ℕ) := ChannelDeterminant.Internal.MatrixAlg d
-abbrev MatEnd (d : ℕ) := ChannelDeterminant.Internal.MatrixEnd d
+local notation "MatrixAlg" => ChannelDeterminant.Internal.MatrixAlg
+local notation "MatrixEnd" => ChannelDeterminant.Internal.MatrixEnd
 
-variable {T : MatEnd d}
+variable {T : MatrixEnd d}
 
 private theorem trace_zero_hermitian_eq_smul_density_sub_density [NeZero d]
-    {X : MatAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
-    ∃ c : ℂ, 0 ≤ c ∧ ∃ ρ σ : MatAlg d,
+    {X : MatrixAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
+    ∃ c : ℂ, 0 ≤ c ∧ ∃ ρ σ : MatrixAlg d,
       ρ ∈ densityMatrices d ∧ σ ∈ densityMatrices d ∧ X = c • (ρ - σ) := by
   obtain ⟨ρ₀, hρ₀_mem⟩ :=
     densityMatrices_nonempty (D := d) (Nat.pos_of_ne_zero (NeZero.ne d))
   by_cases hX0 : X = 0
   · exact ⟨0, by simp only [Std.le_refl], ρ₀, ρ₀, hρ₀_mem, hρ₀_mem,
       by simp only [hX0, sub_self, smul_zero]⟩
-  · let Q₁ : MatAlg d := X⁺
-    let Q₂ : MatAlg d := X⁻
+  · let Q₁ : MatrixAlg d := X⁺
+    let Q₂ : MatrixAlg d := X⁻
     have hQ₁_psd : Q₁.PosSemidef :=
       Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg X)
     have hQ₂_psd : Q₂.PosSemidef :=
@@ -80,8 +80,8 @@ private theorem trace_zero_hermitian_eq_smul_density_sub_density [NeZero d]
         simpa only using hc0
       apply hX0
       simp only [hX_decomp, hQ₁_zero, hQ₂_zero, sub_self]
-    let ρ : MatAlg d := c⁻¹ • Q₁
-    let σ : MatAlg d := c⁻¹ • Q₂
+    let ρ : MatrixAlg d := c⁻¹ • Q₁
+    let σ : MatrixAlg d := c⁻¹ • Q₂
     have hc_inv_nonneg : 0 ≤ c⁻¹ := inv_nonneg.2 hc_nonneg
     have hρ_mem : ρ ∈ densityMatrices d := by
       refine ⟨hQ₁_psd.smul hc_inv_nonneg, ?_⟩
@@ -98,13 +98,13 @@ private theorem trace_zero_hermitian_eq_smul_density_sub_density [NeZero d]
       c, ρ, σ]
 
 private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [NeZero d]
-    {T : MatEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
-    {X : MatAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
+    {T : MatrixEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {X : MatrixAlg d} (hX : X.IsHermitian) (htrX : Matrix.trace X = 0) :
     ∃ C : ℝ, ∀ n : ℕ, ‖(T ^ n) X‖ ≤ C := by
   have hmap_density :
-      ∀ ρ : MatAlg d, ρ ∈ densityMatrices d → T ρ ∈ densityMatrices d :=
+      ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d → T ρ ∈ densityMatrices d :=
     fun ρ hρ => ⟨hPos ρ hρ.1, by rw [hTP ρ, hρ.2]⟩
-  have hiter_density : ∀ n : ℕ, ∀ ρ : MatAlg d, ρ ∈ densityMatrices d →
+  have hiter_density : ∀ n : ℕ, ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d →
       (T ^ n) ρ ∈ densityMatrices d := by
     intro n
     induction n with
@@ -116,9 +116,9 @@ private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [N
         rw [pow_succ']
         exact hmap_density ((T ^ n) ρ) (ih ρ hρ)
   have hbounded_density :
-      ∃ M : ℝ, ∀ ρ : MatAlg d, ρ ∈ densityMatrices d → ‖ρ‖ ≤ M := by
+      ∃ M : ℝ, ∀ ρ : MatrixAlg d, ρ ∈ densityMatrices d → ‖ρ‖ ≤ M := by
     have hbd : Bornology.IsBounded
-        {X : MatAlg d | X.PosSemidef ∧ ‖Matrix.trace X‖ ≤ 1} :=
+        {X : MatrixAlg d | X.PosSemidef ∧ ‖Matrix.trace X‖ ≤ 1} :=
       posSemidef_trace_bounded_isBounded (D := d) 1
     rw [isBounded_iff_forall_norm_le] at hbd
     obtain ⟨M, hM⟩ := hbd
@@ -143,15 +143,15 @@ private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [N
       mul_le_mul_of_nonneg_left (add_le_add hρ_orbit hσ_orbit) (norm_nonneg _)
 
 private theorem positiveTracePreserving_eigenvalue_norm_le_one [NeZero d]
-    {T : MatEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    {T : MatrixEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
     (μ : ℂ) (hμ : Module.End.HasEigenvalue T μ) :
     ‖μ‖ ≤ 1 := by
   obtain ⟨z, hz⟩ := hμ.exists_hasEigenvector
   have hz_eig : T z = μ • z := Module.End.mem_eigenspace_iff.mp hz.1
   have hz_ne : z ≠ 0 := hz.2
   by_cases htrz : Matrix.trace z = 0
-  · let x : MatAlg d := (1 / 2 : ℝ) • (z + zᴴ)
-    let y : MatAlg d := (1 / 2 : ℝ) • (Complex.I • (zᴴ - z))
+  · let x : MatrixAlg d := (1 / 2 : ℝ) • (z + zᴴ)
+    let y : MatrixAlg d := (1 / 2 : ℝ) • (Complex.I • (zᴴ - z))
     have hx_herm : x.IsHermitian := by
       ext i j
       simp only [smul_add, one_div, conjTranspose_apply, Matrix.add_apply, Matrix.smul_apply,

--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -34,21 +34,20 @@ quantum channel, Heisenberg dual, Kadison-Schwarz, multiplicative domain
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
-open ChannelDeterminant.Internal
 
 variable {d : ℕ}
 
 section WolfStatements
 
-variable {T : MatrixEnd d}
+variable {T : MatEnd d}
 
 namespace ChannelDeterminant
 namespace Internal
 
 private theorem heisenberg_dual_det_eq_one [NeZero d]
-    {T : MatrixEnd d} (hdet : ‖channelDet T‖ = 1)
+    {T : MatEnd d} (hdet : ‖channelDet T‖ = 1)
     {r : ℕ} (K : Fin r → MatrixAlg d) (hK : ∀ X, T X = ∑ i, K i * X * (K i)ᴴ)
-    (Td : MatrixEnd d) (hTd : ∀ X, Td X = ∑ i : Fin r, (K i)ᴴ * X * K i) :
+    (Td : MatEnd d) (hTd : ∀ X, Td X = ∑ i : Fin r, (K i)ᴴ * X * K i) :
     ‖channelDet Td‖ = 1 := by
   let b : Module.Basis (Fin d × Fin d) ℂ (MatrixAlg d) :=
     Matrix.stdBasis ℂ (Fin d) (Fin d)

--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -39,15 +39,17 @@ variable {d : ℕ}
 
 section WolfStatements
 
-variable {T : MatEnd d}
+local notation "MatrixEnd" => ChannelDeterminant.Internal.MatrixEnd
+
+variable {T : MatrixEnd d}
 
 namespace ChannelDeterminant
 namespace Internal
 
 private theorem heisenberg_dual_det_eq_one [NeZero d]
-    {T : MatEnd d} (hdet : ‖channelDet T‖ = 1)
+    {T : MatrixEnd d} (hdet : ‖channelDet T‖ = 1)
     {r : ℕ} (K : Fin r → MatrixAlg d) (hK : ∀ X, T X = ∑ i, K i * X * (K i)ᴴ)
-    (Td : MatEnd d) (hTd : ∀ X, Td X = ∑ i : Fin r, (K i)ᴴ * X * K i) :
+    (Td : MatrixEnd d) (hTd : ∀ X, Td X = ∑ i : Fin r, (K i)ᴴ * X * K i) :
     ‖channelDet Td‖ = 1 := by
   let b : Module.Basis (Fin d × Fin d) ℂ (MatrixAlg d) :=
     Matrix.stdBasis ℂ (Fin d) (Fin d)

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -42,13 +42,12 @@ quantum channel, determinant, Hilbert-Schmidt norm, standard basis, AM-GM
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
-open ChannelDeterminant.Internal
 
 variable {d : ℕ}
 
 section WolfStatements
 
-variable {T : MatrixEnd d}
+variable {T : MatEnd d}
 
 /-! ### Auxiliary lemmas for the forward direction of Wolf Theorem 6.1(2) -/
 

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -47,7 +47,9 @@ variable {d : ℕ}
 
 section WolfStatements
 
-variable {T : MatEnd d}
+local notation "MatrixEnd" => ChannelDeterminant.Internal.MatrixEnd
+
+variable {T : MatrixEnd d}
 
 /-! ### Auxiliary lemmas for the forward direction of Wolf Theorem 6.1(2) -/
 

--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -43,7 +43,10 @@ variable {d : ℕ}
 
 section WolfStatements
 
-variable {T : MatEnd d}
+local notation "MatrixAlg" => ChannelDeterminant.Internal.MatrixAlg
+local notation "MatrixEnd" => ChannelDeterminant.Internal.MatrixEnd
+
+variable {T : MatrixEnd d}
 
 /-- Extract a unitary from the Skolem–Noether inner form plus star-preservation.
 
@@ -52,52 +55,52 @@ Given `T(A) = P⁻¹AP` where `P ∈ GL_d(ℂ)`, and `T` preserves `*` (i.e. `T�
 and invertible, the scalar is positive real; defining `V = (√c)⁻¹ • P` makes
 `V` unitary, and setting `U := Vᴴ` yields `T = unitaryChannel U`. -/
 private theorem extract_unitary_from_inner_form [NeZero d]
-    {T : MatEnd d} (_hT : IsChannel T)
+    {T : MatrixEnd d} (_hT : IsChannel T)
     (P : GL (Fin d) ℂ)
-    (hT_inner : ∀ A : MatAlg d,
-        T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * A * (↑P : MatAlg d))
-    (hP_star_comm : ∀ Y : MatAlg d,
-        (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) * Y =
-          Y * ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d))) :
+    (hT_inner : ∀ A : MatrixAlg d,
+        T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A * (↑P : MatrixAlg d))
+    (hP_star_comm : ∀ Y : MatrixAlg d,
+        (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) * Y =
+          Y * ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d))) :
     ∃ U : Matrix.unitaryGroup (Fin d) ℂ, T = unitaryChannel U := by
   -- GL identities
-  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * (↑P : MatAlg d) = 1 :=
+  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * (↑P : MatrixAlg d) = 1 :=
     congrArg Units.val (inv_mul_cancel P)
-  have hPPinv : (↑P : MatAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) = 1 :=
+  have hPPinv : (↑P : MatrixAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) = 1 :=
     congrArg Units.val (mul_inv_cancel P)
   -- Step 1: P†P is in the center → is a scalar matrix
   have hPHP_center :
-      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) ∈
-        Set.range (Matrix.scalar (Fin d) : ℂ →+* MatAlg d) := by
+      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) ∈
+        Set.range (Matrix.scalar (Fin d) : ℂ →+* MatrixAlg d) := by
     rw [← Matrix.center_eq_range, Semigroup.mem_center_iff]
     exact fun Y => (hP_star_comm Y).symm
   obtain ⟨c, hc_eq⟩ := hPHP_center
   rw [Matrix.scalar_apply] at hc_eq
   have hPHP_smul :
-      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) = c • (1 : MatAlg d) := by
+      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) = c • (1 : MatrixAlg d) := by
     rw [← hc_eq, ← Matrix.smul_one_eq_diagonal]
   -- Step 2: c ≥ 0 (from PSD)
-  have hPHP_psd : ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)).PosSemidef :=
+  have hPHP_psd : ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)).PosSemidef :=
     Matrix.posSemidef_conjTranspose_mul_self _
   have hc_nonneg : 0 ≤ c := by
     have hdiag :
-        ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) (0 : Fin d) (0 : Fin d) = c := by
+        ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) (0 : Fin d) (0 : Fin d) = c := by
       rw [hPHP_smul]
       simp only [Matrix.smul_apply, Matrix.one_apply_eq, smul_eq_mul, mul_one]
     simpa only [hdiag] using hPHP_psd.diag_nonneg (i := (0 : Fin d))
   -- Step 3: c ≠ 0 (from invertibility of P)
   have hc_ne : c ≠ 0 := by
     intro hc0
-    have h0 : (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) = 0 := by
+    have h0 : (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) = 0 := by
       rw [hPHP_smul, hc0, zero_smul]
-    have hPH_zero : (↑P : MatAlg d)ᴴ = 0 := by
-      have := congr_arg (· * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) h0
+    have hPH_zero : (↑P : MatrixAlg d)ᴴ = 0 := by
+      have := congr_arg (· * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) h0
       simp only [zero_mul, Matrix.mul_assoc] at this
       rwa [hPPinv, mul_one] at this
-    have hP_zero : (↑P : MatAlg d) = 0 := by
-      rw [← conjTranspose_conjTranspose (↑P : MatAlg d),
+    have hP_zero : (↑P : MatrixAlg d) = 0 := by
+      rw [← conjTranspose_conjTranspose (↑P : MatrixAlg d),
         hPH_zero, conjTranspose_zero]
-    exact one_ne_zero (show (1 : MatAlg d) = 0 by
+    exact one_ne_zero (show (1 : MatrixAlg d) = 0 by
       rw [← hPPinv, hP_zero, zero_mul])
   -- Step 4: c is a positive real number
   have hc_re_nonneg : 0 ≤ c.re := (RCLike.nonneg_iff.mp hc_nonneg).1
@@ -113,7 +116,7 @@ private theorem extract_unitary_from_inner_form [NeZero d]
   have hr_sq : (↑r : ℂ) * (↑r : ℂ) = c := by
     rw [← Complex.ofReal_mul, Real.mul_self_sqrt hc_re_nonneg]
     exact Complex.ext (Complex.ofReal_re _) (by simp only [Complex.ofReal_im, hc_im_zero])
-  set V : MatAlg d := (↑r : ℂ)⁻¹ • (↑P : MatAlg d) with hV_def
+  set V : MatrixAlg d := (↑r : ℂ)⁻¹ • (↑P : MatrixAlg d) with hV_def
   have hstar_r_inv : star ((↑r : ℂ)⁻¹) = (↑r : ℂ)⁻¹ := by
     rw [star_inv₀, show star (↑r : ℂ) = ↑r from RCLike.conj_ofReal r]
   have hVHV : Vᴴ * V = 1 := by
@@ -132,25 +135,25 @@ private theorem extract_unitary_from_inner_form [NeZero d]
   set U : Matrix.unitaryGroup (Fin d) ℂ := ⟨Vᴴ, hU_mem⟩
   -- Step 7: T = unitaryChannel U
   -- Key: Pm = ↑r • V and Pinvm = (↑r)⁻¹ • V†
-  have hPm_eq : (↑P : MatAlg d) = (↑r : ℂ) • V := by
+  have hPm_eq : (↑P : MatrixAlg d) = (↑r : ℂ) • V := by
     simp only [hV_def, smul_smul, mul_inv_cancel₀ hr_ne, one_smul]
   have hPinvm_eq :
-      (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) = (↑r : ℂ)⁻¹ • Vᴴ := by
-    have hVPinv : V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) =
-        (↑r : ℂ)⁻¹ • (1 : MatAlg d) := by
-      have h : (↑r : ℂ) • (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) = 1 := by
+      (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) = (↑r : ℂ)⁻¹ • Vᴴ := by
+    have hVPinv : V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) =
+        (↑r : ℂ)⁻¹ • (1 : MatrixAlg d) := by
+      have h : (↑r : ℂ) • (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) = 1 := by
         rw [← smul_mul_assoc, ← hPm_eq]; exact hPPinv
-      rw [show V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) =
-          (↑r : ℂ)⁻¹ • (1 : MatAlg d) from by
+      rw [show V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) =
+          (↑r : ℂ)⁻¹ • (1 : MatrixAlg d) from by
         have := congr_arg ((↑r : ℂ)⁻¹ • ·) h
         simp only [smul_smul, inv_mul_cancel₀ hr_ne, one_smul] at this
         exact this]
-    calc (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)
-        = 1 * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) := (one_mul _).symm
-      _ = (Vᴴ * V) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) := by rw [hVHV]
-      _ = Vᴴ * (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) := by
+    calc (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)
+        = 1 * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) := (one_mul _).symm
+      _ = (Vᴴ * V) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) := by rw [hVHV]
+      _ = Vᴴ * (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) := by
           rw [Matrix.mul_assoc]
-      _ = Vᴴ * ((↑r : ℂ)⁻¹ • (1 : MatAlg d)) := by rw [hVPinv]
+      _ = Vᴴ * ((↑r : ℂ)⁻¹ • (1 : MatrixAlg d)) := by rw [hVPinv]
       _ = (↑r : ℂ)⁻¹ • Vᴴ := by rw [mul_smul_comm, mul_one]
   refine ⟨U, LinearMap.ext fun A => ?_⟩
   simp only [unitaryChannel, LinearMap.coe_mk, AddHom.coe_mk]
@@ -169,7 +172,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
     kraus_sum_conjTranspose_mul_of_tp K T hK hT.tp
   -- Build the Heisenberg dual
-  let Td : MatEnd d :=
+  let Td : MatrixEnd d :=
     { toFun := fun X => ∑ i : Fin r, (K i)ᴴ * X * K i
       map_add' := fun X Y => by simp only [mul_add, add_mul, Finset.sum_add_distrib]
       map_smul' := fun c X => by
@@ -179,7 +182,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   have hTd_one : Td 1 = 1 := by
     change ∑ i : Fin r, (K i)ᴴ * 1 * K i = 1
     simp only [mul_one, hK_tp]
-  have hTd_star : ∀ X : MatAlg d, Td Xᴴ = (Td X)ᴴ := by
+  have hTd_star : ∀ X : MatrixAlg d, Td Xᴴ = (Td X)ᴴ := by
     intro X
     change ∑ i, (K i)ᴴ * Xᴴ * K i = (∑ i, (K i)ᴴ * X * K i)ᴴ
     simp only [Matrix.mul_assoc, conjTranspose_sum, conjTranspose_mul,
@@ -195,17 +198,17 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   have hTd_bij := MPSTensor.linear_mul_endomorphism_bijective Td hMul hTd_ne
   -- Skolem–Noether: Td(X) = PXP⁻¹
   let Td_alg := MPSTensor.linearMapToAlgHom Td hMul hTd_bij.2
-  let Td_equiv : MatAlg d ≃ₐ[ℂ] MatAlg d := AlgEquiv.ofBijective Td_alg hTd_bij
+  let Td_equiv : MatrixAlg d ≃ₐ[ℂ] MatrixAlg d := AlgEquiv.ofBijective Td_alg hTd_bij
   obtain ⟨P, hP⟩ := MPSTensor.skolemNoether_matrix Td_equiv
   -- Key identities for P
-  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * (↑P : MatAlg d) = 1 := by
+  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * (↑P : MatrixAlg d) = 1 := by
     have : (P⁻¹ * P : GL (Fin d) ℂ) = 1 := inv_mul_cancel _
     exact congrArg Units.val this
-  have hPPinv : (↑P : MatAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) = 1 := by
+  have hPPinv : (↑P : MatrixAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) = 1 := by
     have : (P * P⁻¹ : GL (Fin d) ℂ) = 1 := mul_inv_cancel _
     exact congrArg Units.val this
   -- Trace adjointness: tr(T(A)*B) = tr(A*Td(B))
-  have hAdj : ∀ A B : MatAlg d, trace (T A * B) = trace (A * Td B) := by
+  have hAdj : ∀ A B : MatrixAlg d, trace (T A * B) = trace (A * Td B) := by
     intro A B
     simp only [hK, hTd_def]
     rw [Finset.sum_mul, trace_sum]
@@ -215,53 +218,53 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
     simpa only [coe_units_inv, Matrix.mul_assoc] using
       (Matrix.trace_mul_cycle A ((K i)ᴴ * B) (K i)).symm
   -- Derive T(A) = P⁻¹AP from trace adjointness
-  have hT_inner : ∀ A : MatAlg d,
-      T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * A * (↑P : MatAlg d) := by
+  have hT_inner : ∀ A : MatrixAlg d,
+      T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A * (↑P : MatrixAlg d) := by
     intro A
     apply (Matrix.ext_iff_trace_mul_right).2
     intro B
     rw [hAdj A B]
     change trace (A * Td B) =
-      trace ((↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * A *
-        (↑P : MatAlg d) * B)
+      trace ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A *
+        (↑P : MatrixAlg d) * B)
     rw [show Td B = Td_equiv B from rfl, hP B]
     simpa only [Matrix.mul_assoc] using
-      (Matrix.trace_mul_cycle (A * (↑P : MatAlg d)) B
-        ((↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)))
+      (Matrix.trace_mul_cycle (A * (↑P : MatrixAlg d)) B
+        ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)))
   -- `Pᴴ * P` commutes with all matrices, from star-preservation of `Td`.
-  have hP_star_comm : ∀ Y : MatAlg d,
-      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) * Y =
-        Y * ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) := by
+  have hP_star_comm : ∀ Y : MatrixAlg d,
+      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) * Y =
+        Y * ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) := by
     intro Y
-    have hstar_inner : ∀ X : MatAlg d,
-        (↑P : MatAlg d) * Xᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) =
-          (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ * Xᴴ * (↑P : MatAlg d)ᴴ := by
+    have hstar_inner : ∀ X : MatrixAlg d,
+        (↑P : MatrixAlg d) * Xᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) =
+          (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ * Xᴴ * (↑P : MatrixAlg d)ᴴ := by
       intro X
       have h := hTd_star X
       rw [show Td Xᴴ = Td_equiv Xᴴ from rfl, hP Xᴴ] at h
       rw [show Td X = Td_equiv X from rfl, hP X] at h
       simpa only [coe_units_inv, Matrix.mul_assoc, conjTranspose_mul] using h
     have hPstarPinvstar :
-        (↑P : MatAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ = 1 := by
+        (↑P : MatrixAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ = 1 := by
       rw [← conjTranspose_mul, hPinvP, conjTranspose_one]
     specialize hstar_inner Yᴴ
     simp only [conjTranspose_conjTranspose] at hstar_inner
     calc
-      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) * Y
-          = (↑P : MatAlg d)ᴴ *
-              ((↑P : MatAlg d) * Y * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) *
-              (↑P : MatAlg d) := by
+      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) * Y
+          = (↑P : MatrixAlg d)ᴴ *
+              ((↑P : MatrixAlg d) * Y * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) *
+              (↑P : MatrixAlg d) := by
             simp only [Matrix.mul_assoc, coe_units_inv, inv_mul_of_invertible, mul_one]
-      _ = (↑P : MatAlg d)ᴴ *
-            ((↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ * Y * (↑P : MatAlg d)ᴴ) *
-            (↑P : MatAlg d) := by
+      _ = (↑P : MatrixAlg d)ᴴ *
+            ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ * Y * (↑P : MatrixAlg d)ᴴ) *
+            (↑P : MatrixAlg d) := by
             simpa only [coe_units_inv] using
-              congrArg (fun Z : MatAlg d => (↑P : MatAlg d)ᴴ * Z *
-                (↑P : MatAlg d)) hstar_inner
-      _ = ((↑P : MatAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ) * Y *
-            ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) := by
+              congrArg (fun Z : MatrixAlg d => (↑P : MatrixAlg d)ᴴ * Z *
+                (↑P : MatrixAlg d)) hstar_inner
+      _ = ((↑P : MatrixAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ) * Y *
+            ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) := by
             simp only [coe_units_inv, Matrix.mul_assoc]
-      _ = Y * ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) := by
+      _ = Y * ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) := by
             rw [Matrix.mul_assoc, hPstarPinvstar, Matrix.one_mul]
   -- Extract unitary from inner form + P†P commuting with everything
   exact extract_unitary_from_inner_form hT P hT_inner hP_star_comm
@@ -269,28 +272,28 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
 /-- The determinant of a unitary channel equals `1`. -/
 theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
     channelDet (unitaryChannel U) = 1 := by
-  let e : MatAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) :=
+  let e : MatrixAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) :=
     LinearEquiv.ofBijective
       { toFun := Matrix.vec
         map_add' := Matrix.vec_add
         map_smul' := Matrix.vec_smul }
       Matrix.vec_bijective
   let M : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
-    ((U : MatAlg d).map star) ⊗ₖ (U : MatAlg d)
-  have hvec : ∀ X : MatAlg d,
+    ((U : MatrixAlg d).map star) ⊗ₖ (U : MatrixAlg d)
+  have hvec : ∀ X : MatrixAlg d,
       e (unitaryChannel U X) = Matrix.toLin' M (e X) := by
     intro X
     -- The equivalence `e` is the column-stacking vectorization used by `Matrix.vec`.
-    change Matrix.vec (((U : MatAlg d) * X * (U : MatAlg d)ᴴ) : MatAlg d) =
+    change Matrix.vec (((U : MatrixAlg d) * X * (U : MatrixAlg d)ᴴ) : MatrixAlg d) =
       M.mulVec (Matrix.vec X)
     symm
     simpa only [M, RCLike.star_def, conjTranspose, ← Matrix.transpose_map] using
-      (Matrix.kronecker_mulVec_vec (A := (U : MatAlg d)) (X := X)
-        (B := (U : MatAlg d).map star))
+      (Matrix.kronecker_mulVec_vec (A := (U : MatrixAlg d)) (X := X)
+        (B := (U : MatrixAlg d).map star))
   have hconj :
-      ((e : MatAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
-          ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatAlg d) :
-            (Fin d × Fin d → ℂ) →ₗ[ℂ] MatAlg d)) =
+      ((e : MatrixAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
+          ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatrixAlg d) :
+            (Fin d × Fin d → ℂ) →ₗ[ℂ] MatrixAlg d)) =
         Matrix.toLin' M := by
     apply LinearMap.ext
     intro w
@@ -298,12 +301,12 @@ theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
     simpa only [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply,
       toLin'_apply, LinearEquiv.apply_symm_apply] using congrFun (hvec (e.symm w)) ij
   have hdet_map_star :
-      ((U : MatAlg d).map star).det = star (Matrix.det (U : MatAlg d)) := by
+      ((U : MatrixAlg d).map star).det = star (Matrix.det (U : MatrixAlg d)) := by
     simpa only [RCLike.star_def, RingHom.mapMatrix_apply] using
-      (RingHom.map_det (starRingEnd ℂ) (U : MatAlg d)).symm
+      (RingHom.map_det (starRingEnd ℂ) (U : MatrixAlg d)).symm
   have hdet_unitary :
-      star (Matrix.det (U : MatAlg d)) * Matrix.det (U : MatAlg d) = 1 := by
-    have hU : ((U : MatAlg d)ᴴ) * (U : MatAlg d) = 1 := by
+      star (Matrix.det (U : MatrixAlg d)) * Matrix.det (U : MatrixAlg d) = 1 := by
+    have hU : ((U : MatrixAlg d)ᴴ) * (U : MatrixAlg d) = 1 := by
       simpa only [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
     have h := congrArg Matrix.det hU
     simpa only [RCLike.star_def, det_mul, det_conjTranspose, det_one] using h
@@ -311,17 +314,17 @@ theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
     channelDet (unitaryChannel U) = LinearMap.det (unitaryChannel U) :=
       channelDet_eq_linearMap_det (T := unitaryChannel U)
     _ = LinearMap.det
-          (((e : MatAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
-            ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatAlg d) :
-              (Fin d × Fin d → ℂ) →ₗ[ℂ] MatAlg d))) :=
+          (((e : MatrixAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
+            ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatrixAlg d) :
+              (Fin d × Fin d → ℂ) →ₗ[ℂ] MatrixAlg d))) :=
         (LinearMap.det_conj (f := unitaryChannel U) (e := e)).symm
     _ = LinearMap.det (Matrix.toLin' M) := by rw [hconj]
     _ = Matrix.det M := by rw [LinearMap.det_toLin']
-    _ = ((U : MatAlg d).map star).det ^ d * Matrix.det (U : MatAlg d) ^ d := by
+    _ = ((U : MatrixAlg d).map star).det ^ d * Matrix.det (U : MatrixAlg d) ^ d := by
           simpa only [RCLike.star_def, Fintype.card_fin, M] using
-            (Matrix.det_kronecker (A := (U : MatAlg d).map star)
-              (B := (U : MatAlg d)))
-    _ = (star (Matrix.det (U : MatAlg d)) * Matrix.det (U : MatAlg d)) ^ d := by
+            (Matrix.det_kronecker (A := (U : MatrixAlg d).map star)
+              (B := (U : MatrixAlg d)))
+    _ = (star (Matrix.det (U : MatrixAlg d)) * Matrix.det (U : MatrixAlg d)) ^ d := by
           rw [hdet_map_star, mul_pow]
     _ = 1 := by rw [hdet_unitary, one_pow]
 

--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -38,13 +38,12 @@ quantum channel, determinant, unitary channel, Skolem-Noether
 -/
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker Matrix.Norms.Frobenius
 open Matrix
-open ChannelDeterminant.Internal
 
 variable {d : ℕ}
 
 section WolfStatements
 
-variable {T : MatrixEnd d}
+variable {T : MatEnd d}
 
 /-- Extract a unitary from the Skolem–Noether inner form plus star-preservation.
 
@@ -53,52 +52,52 @@ Given `T(A) = P⁻¹AP` where `P ∈ GL_d(ℂ)`, and `T` preserves `*` (i.e. `T�
 and invertible, the scalar is positive real; defining `V = (√c)⁻¹ • P` makes
 `V` unitary, and setting `U := Vᴴ` yields `T = unitaryChannel U`. -/
 private theorem extract_unitary_from_inner_form [NeZero d]
-    {T : MatrixEnd d} (_hT : IsChannel T)
+    {T : MatEnd d} (_hT : IsChannel T)
     (P : GL (Fin d) ℂ)
-    (hT_inner : ∀ A : MatrixAlg d,
-        T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A * (↑P : MatrixAlg d))
-    (hP_star_comm : ∀ Y : MatrixAlg d,
-        (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) * Y =
-          Y * ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d))) :
+    (hT_inner : ∀ A : MatAlg d,
+        T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * A * (↑P : MatAlg d))
+    (hP_star_comm : ∀ Y : MatAlg d,
+        (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) * Y =
+          Y * ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d))) :
     ∃ U : Matrix.unitaryGroup (Fin d) ℂ, T = unitaryChannel U := by
   -- GL identities
-  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * (↑P : MatrixAlg d) = 1 :=
+  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * (↑P : MatAlg d) = 1 :=
     congrArg Units.val (inv_mul_cancel P)
-  have hPPinv : (↑P : MatrixAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) = 1 :=
+  have hPPinv : (↑P : MatAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) = 1 :=
     congrArg Units.val (mul_inv_cancel P)
   -- Step 1: P†P is in the center → is a scalar matrix
   have hPHP_center :
-      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) ∈
-        Set.range (Matrix.scalar (Fin d) : ℂ →+* MatrixAlg d) := by
+      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) ∈
+        Set.range (Matrix.scalar (Fin d) : ℂ →+* MatAlg d) := by
     rw [← Matrix.center_eq_range, Semigroup.mem_center_iff]
     exact fun Y => (hP_star_comm Y).symm
   obtain ⟨c, hc_eq⟩ := hPHP_center
   rw [Matrix.scalar_apply] at hc_eq
   have hPHP_smul :
-      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) = c • (1 : MatrixAlg d) := by
+      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) = c • (1 : MatAlg d) := by
     rw [← hc_eq, ← Matrix.smul_one_eq_diagonal]
   -- Step 2: c ≥ 0 (from PSD)
-  have hPHP_psd : ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)).PosSemidef :=
+  have hPHP_psd : ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)).PosSemidef :=
     Matrix.posSemidef_conjTranspose_mul_self _
   have hc_nonneg : 0 ≤ c := by
     have hdiag :
-        ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) (0 : Fin d) (0 : Fin d) = c := by
+        ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) (0 : Fin d) (0 : Fin d) = c := by
       rw [hPHP_smul]
       simp only [Matrix.smul_apply, Matrix.one_apply_eq, smul_eq_mul, mul_one]
     simpa only [hdiag] using hPHP_psd.diag_nonneg (i := (0 : Fin d))
   -- Step 3: c ≠ 0 (from invertibility of P)
   have hc_ne : c ≠ 0 := by
     intro hc0
-    have h0 : (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) = 0 := by
+    have h0 : (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) = 0 := by
       rw [hPHP_smul, hc0, zero_smul]
-    have hPH_zero : (↑P : MatrixAlg d)ᴴ = 0 := by
-      have := congr_arg (· * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) h0
+    have hPH_zero : (↑P : MatAlg d)ᴴ = 0 := by
+      have := congr_arg (· * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) h0
       simp only [zero_mul, Matrix.mul_assoc] at this
       rwa [hPPinv, mul_one] at this
-    have hP_zero : (↑P : MatrixAlg d) = 0 := by
-      rw [← conjTranspose_conjTranspose (↑P : MatrixAlg d),
+    have hP_zero : (↑P : MatAlg d) = 0 := by
+      rw [← conjTranspose_conjTranspose (↑P : MatAlg d),
         hPH_zero, conjTranspose_zero]
-    exact one_ne_zero (show (1 : MatrixAlg d) = 0 by
+    exact one_ne_zero (show (1 : MatAlg d) = 0 by
       rw [← hPPinv, hP_zero, zero_mul])
   -- Step 4: c is a positive real number
   have hc_re_nonneg : 0 ≤ c.re := (RCLike.nonneg_iff.mp hc_nonneg).1
@@ -114,7 +113,7 @@ private theorem extract_unitary_from_inner_form [NeZero d]
   have hr_sq : (↑r : ℂ) * (↑r : ℂ) = c := by
     rw [← Complex.ofReal_mul, Real.mul_self_sqrt hc_re_nonneg]
     exact Complex.ext (Complex.ofReal_re _) (by simp only [Complex.ofReal_im, hc_im_zero])
-  set V : MatrixAlg d := (↑r : ℂ)⁻¹ • (↑P : MatrixAlg d) with hV_def
+  set V : MatAlg d := (↑r : ℂ)⁻¹ • (↑P : MatAlg d) with hV_def
   have hstar_r_inv : star ((↑r : ℂ)⁻¹) = (↑r : ℂ)⁻¹ := by
     rw [star_inv₀, show star (↑r : ℂ) = ↑r from RCLike.conj_ofReal r]
   have hVHV : Vᴴ * V = 1 := by
@@ -133,25 +132,25 @@ private theorem extract_unitary_from_inner_form [NeZero d]
   set U : Matrix.unitaryGroup (Fin d) ℂ := ⟨Vᴴ, hU_mem⟩
   -- Step 7: T = unitaryChannel U
   -- Key: Pm = ↑r • V and Pinvm = (↑r)⁻¹ • V†
-  have hPm_eq : (↑P : MatrixAlg d) = (↑r : ℂ) • V := by
+  have hPm_eq : (↑P : MatAlg d) = (↑r : ℂ) • V := by
     simp only [hV_def, smul_smul, mul_inv_cancel₀ hr_ne, one_smul]
   have hPinvm_eq :
-      (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) = (↑r : ℂ)⁻¹ • Vᴴ := by
-    have hVPinv : V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) =
-        (↑r : ℂ)⁻¹ • (1 : MatrixAlg d) := by
-      have h : (↑r : ℂ) • (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) = 1 := by
+      (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) = (↑r : ℂ)⁻¹ • Vᴴ := by
+    have hVPinv : V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) =
+        (↑r : ℂ)⁻¹ • (1 : MatAlg d) := by
+      have h : (↑r : ℂ) • (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) = 1 := by
         rw [← smul_mul_assoc, ← hPm_eq]; exact hPPinv
-      rw [show V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) =
-          (↑r : ℂ)⁻¹ • (1 : MatrixAlg d) from by
+      rw [show V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) =
+          (↑r : ℂ)⁻¹ • (1 : MatAlg d) from by
         have := congr_arg ((↑r : ℂ)⁻¹ • ·) h
         simp only [smul_smul, inv_mul_cancel₀ hr_ne, one_smul] at this
         exact this]
-    calc (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)
-        = 1 * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) := (one_mul _).symm
-      _ = (Vᴴ * V) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) := by rw [hVHV]
-      _ = Vᴴ * (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) := by
+    calc (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)
+        = 1 * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) := (one_mul _).symm
+      _ = (Vᴴ * V) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) := by rw [hVHV]
+      _ = Vᴴ * (V * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) := by
           rw [Matrix.mul_assoc]
-      _ = Vᴴ * ((↑r : ℂ)⁻¹ • (1 : MatrixAlg d)) := by rw [hVPinv]
+      _ = Vᴴ * ((↑r : ℂ)⁻¹ • (1 : MatAlg d)) := by rw [hVPinv]
       _ = (↑r : ℂ)⁻¹ • Vᴴ := by rw [mul_smul_comm, mul_one]
   refine ⟨U, LinearMap.ext fun A => ?_⟩
   simp only [unitaryChannel, LinearMap.coe_mk, AddHom.coe_mk]
@@ -170,7 +169,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
     kraus_sum_conjTranspose_mul_of_tp K T hK hT.tp
   -- Build the Heisenberg dual
-  let Td : MatrixEnd d :=
+  let Td : MatEnd d :=
     { toFun := fun X => ∑ i : Fin r, (K i)ᴴ * X * K i
       map_add' := fun X Y => by simp only [mul_add, add_mul, Finset.sum_add_distrib]
       map_smul' := fun c X => by
@@ -180,7 +179,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   have hTd_one : Td 1 = 1 := by
     change ∑ i : Fin r, (K i)ᴴ * 1 * K i = 1
     simp only [mul_one, hK_tp]
-  have hTd_star : ∀ X : MatrixAlg d, Td Xᴴ = (Td X)ᴴ := by
+  have hTd_star : ∀ X : MatAlg d, Td Xᴴ = (Td X)ᴴ := by
     intro X
     change ∑ i, (K i)ᴴ * Xᴴ * K i = (∑ i, (K i)ᴴ * X * K i)ᴴ
     simp only [Matrix.mul_assoc, conjTranspose_sum, conjTranspose_mul,
@@ -196,17 +195,17 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   have hTd_bij := MPSTensor.linear_mul_endomorphism_bijective Td hMul hTd_ne
   -- Skolem–Noether: Td(X) = PXP⁻¹
   let Td_alg := MPSTensor.linearMapToAlgHom Td hMul hTd_bij.2
-  let Td_equiv : MatrixAlg d ≃ₐ[ℂ] MatrixAlg d := AlgEquiv.ofBijective Td_alg hTd_bij
+  let Td_equiv : MatAlg d ≃ₐ[ℂ] MatAlg d := AlgEquiv.ofBijective Td_alg hTd_bij
   obtain ⟨P, hP⟩ := MPSTensor.skolemNoether_matrix Td_equiv
   -- Key identities for P
-  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * (↑P : MatrixAlg d) = 1 := by
+  have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * (↑P : MatAlg d) = 1 := by
     have : (P⁻¹ * P : GL (Fin d) ℂ) = 1 := inv_mul_cancel _
     exact congrArg Units.val this
-  have hPPinv : (↑P : MatrixAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) = 1 := by
+  have hPPinv : (↑P : MatAlg d) * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) = 1 := by
     have : (P * P⁻¹ : GL (Fin d) ℂ) = 1 := mul_inv_cancel _
     exact congrArg Units.val this
   -- Trace adjointness: tr(T(A)*B) = tr(A*Td(B))
-  have hAdj : ∀ A B : MatrixAlg d, trace (T A * B) = trace (A * Td B) := by
+  have hAdj : ∀ A B : MatAlg d, trace (T A * B) = trace (A * Td B) := by
     intro A B
     simp only [hK, hTd_def]
     rw [Finset.sum_mul, trace_sum]
@@ -216,53 +215,53 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
     simpa only [coe_units_inv, Matrix.mul_assoc] using
       (Matrix.trace_mul_cycle A ((K i)ᴴ * B) (K i)).symm
   -- Derive T(A) = P⁻¹AP from trace adjointness
-  have hT_inner : ∀ A : MatrixAlg d,
-      T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A * (↑P : MatrixAlg d) := by
+  have hT_inner : ∀ A : MatAlg d,
+      T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * A * (↑P : MatAlg d) := by
     intro A
     apply (Matrix.ext_iff_trace_mul_right).2
     intro B
     rw [hAdj A B]
     change trace (A * Td B) =
-      trace ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A *
-        (↑P : MatrixAlg d) * B)
+      trace ((↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) * A *
+        (↑P : MatAlg d) * B)
     rw [show Td B = Td_equiv B from rfl, hP B]
     simpa only [Matrix.mul_assoc] using
-      (Matrix.trace_mul_cycle (A * (↑P : MatrixAlg d)) B
-        ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)))
+      (Matrix.trace_mul_cycle (A * (↑P : MatAlg d)) B
+        ((↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)))
   -- `Pᴴ * P` commutes with all matrices, from star-preservation of `Td`.
-  have hP_star_comm : ∀ Y : MatrixAlg d,
-      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) * Y =
-        Y * ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) := by
+  have hP_star_comm : ∀ Y : MatAlg d,
+      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) * Y =
+        Y * ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) := by
     intro Y
-    have hstar_inner : ∀ X : MatrixAlg d,
-        (↑P : MatrixAlg d) * Xᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) =
-          (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ * Xᴴ * (↑P : MatrixAlg d)ᴴ := by
+    have hstar_inner : ∀ X : MatAlg d,
+        (↑P : MatAlg d) * Xᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d) =
+          (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ * Xᴴ * (↑P : MatAlg d)ᴴ := by
       intro X
       have h := hTd_star X
       rw [show Td Xᴴ = Td_equiv Xᴴ from rfl, hP Xᴴ] at h
       rw [show Td X = Td_equiv X from rfl, hP X] at h
       simpa only [coe_units_inv, Matrix.mul_assoc, conjTranspose_mul] using h
     have hPstarPinvstar :
-        (↑P : MatrixAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ = 1 := by
+        (↑P : MatAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ = 1 := by
       rw [← conjTranspose_mul, hPinvP, conjTranspose_one]
     specialize hstar_inner Yᴴ
     simp only [conjTranspose_conjTranspose] at hstar_inner
     calc
-      (↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d) * Y
-          = (↑P : MatrixAlg d)ᴴ *
-              ((↑P : MatrixAlg d) * Y * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)) *
-              (↑P : MatrixAlg d) := by
+      (↑P : MatAlg d)ᴴ * (↑P : MatAlg d) * Y
+          = (↑P : MatAlg d)ᴴ *
+              ((↑P : MatAlg d) * Y * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)) *
+              (↑P : MatAlg d) := by
             simp only [Matrix.mul_assoc, coe_units_inv, inv_mul_of_invertible, mul_one]
-      _ = (↑P : MatrixAlg d)ᴴ *
-            ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ * Y * (↑P : MatrixAlg d)ᴴ) *
-            (↑P : MatrixAlg d) := by
+      _ = (↑P : MatAlg d)ᴴ *
+            ((↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ * Y * (↑P : MatAlg d)ᴴ) *
+            (↑P : MatAlg d) := by
             simpa only [coe_units_inv] using
-              congrArg (fun Z : MatrixAlg d => (↑P : MatrixAlg d)ᴴ * Z *
-                (↑P : MatrixAlg d)) hstar_inner
-      _ = ((↑P : MatrixAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ) * Y *
-            ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) := by
+              congrArg (fun Z : MatAlg d => (↑P : MatAlg d)ᴴ * Z *
+                (↑P : MatAlg d)) hstar_inner
+      _ = ((↑P : MatAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatAlg d)ᴴ) * Y *
+            ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) := by
             simp only [coe_units_inv, Matrix.mul_assoc]
-      _ = Y * ((↑P : MatrixAlg d)ᴴ * (↑P : MatrixAlg d)) := by
+      _ = Y * ((↑P : MatAlg d)ᴴ * (↑P : MatAlg d)) := by
             rw [Matrix.mul_assoc, hPstarPinvstar, Matrix.one_mul]
   -- Extract unitary from inner form + P†P commuting with everything
   exact extract_unitary_from_inner_form hT P hT_inner hP_star_comm
@@ -270,28 +269,28 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
 /-- The determinant of a unitary channel equals `1`. -/
 theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
     channelDet (unitaryChannel U) = 1 := by
-  let e : MatrixAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) :=
+  let e : MatAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) :=
     LinearEquiv.ofBijective
       { toFun := Matrix.vec
         map_add' := Matrix.vec_add
         map_smul' := Matrix.vec_smul }
       Matrix.vec_bijective
   let M : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
-    ((U : MatrixAlg d).map star) ⊗ₖ (U : MatrixAlg d)
-  have hvec : ∀ X : MatrixAlg d,
+    ((U : MatAlg d).map star) ⊗ₖ (U : MatAlg d)
+  have hvec : ∀ X : MatAlg d,
       e (unitaryChannel U X) = Matrix.toLin' M (e X) := by
     intro X
     -- The equivalence `e` is the column-stacking vectorization used by `Matrix.vec`.
-    change Matrix.vec (((U : MatrixAlg d) * X * (U : MatrixAlg d)ᴴ) : MatrixAlg d) =
+    change Matrix.vec (((U : MatAlg d) * X * (U : MatAlg d)ᴴ) : MatAlg d) =
       M.mulVec (Matrix.vec X)
     symm
     simpa only [M, RCLike.star_def, conjTranspose, ← Matrix.transpose_map] using
-      (Matrix.kronecker_mulVec_vec (A := (U : MatrixAlg d)) (X := X)
-        (B := (U : MatrixAlg d).map star))
+      (Matrix.kronecker_mulVec_vec (A := (U : MatAlg d)) (X := X)
+        (B := (U : MatAlg d).map star))
   have hconj :
-      ((e : MatrixAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
-          ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatrixAlg d) :
-            (Fin d × Fin d → ℂ) →ₗ[ℂ] MatrixAlg d)) =
+      ((e : MatAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
+          ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatAlg d) :
+            (Fin d × Fin d → ℂ) →ₗ[ℂ] MatAlg d)) =
         Matrix.toLin' M := by
     apply LinearMap.ext
     intro w
@@ -299,12 +298,12 @@ theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
     simpa only [LinearMap.coe_comp, LinearEquiv.coe_coe, Function.comp_apply,
       toLin'_apply, LinearEquiv.apply_symm_apply] using congrFun (hvec (e.symm w)) ij
   have hdet_map_star :
-      ((U : MatrixAlg d).map star).det = star (Matrix.det (U : MatrixAlg d)) := by
+      ((U : MatAlg d).map star).det = star (Matrix.det (U : MatAlg d)) := by
     simpa only [RCLike.star_def, RingHom.mapMatrix_apply] using
-      (RingHom.map_det (starRingEnd ℂ) (U : MatrixAlg d)).symm
+      (RingHom.map_det (starRingEnd ℂ) (U : MatAlg d)).symm
   have hdet_unitary :
-      star (Matrix.det (U : MatrixAlg d)) * Matrix.det (U : MatrixAlg d) = 1 := by
-    have hU : ((U : MatrixAlg d)ᴴ) * (U : MatrixAlg d) = 1 := by
+      star (Matrix.det (U : MatAlg d)) * Matrix.det (U : MatAlg d) = 1 := by
+    have hU : ((U : MatAlg d)ᴴ) * (U : MatAlg d) = 1 := by
       simpa only [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
     have h := congrArg Matrix.det hU
     simpa only [RCLike.star_def, det_mul, det_conjTranspose, det_one] using h
@@ -312,17 +311,17 @@ theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
     channelDet (unitaryChannel U) = LinearMap.det (unitaryChannel U) :=
       channelDet_eq_linearMap_det (T := unitaryChannel U)
     _ = LinearMap.det
-          (((e : MatrixAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
-            ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatrixAlg d) :
-              (Fin d × Fin d → ℂ) →ₗ[ℂ] MatrixAlg d))) :=
+          (((e : MatAlg d →ₗ[ℂ] (Fin d × Fin d → ℂ)) ∘ₗ unitaryChannel U ∘ₗ
+            ((e.symm : (Fin d × Fin d → ℂ) ≃ₗ[ℂ] MatAlg d) :
+              (Fin d × Fin d → ℂ) →ₗ[ℂ] MatAlg d))) :=
         (LinearMap.det_conj (f := unitaryChannel U) (e := e)).symm
     _ = LinearMap.det (Matrix.toLin' M) := by rw [hconj]
     _ = Matrix.det M := by rw [LinearMap.det_toLin']
-    _ = ((U : MatrixAlg d).map star).det ^ d * Matrix.det (U : MatrixAlg d) ^ d := by
+    _ = ((U : MatAlg d).map star).det ^ d * Matrix.det (U : MatAlg d) ^ d := by
           simpa only [RCLike.star_def, Fintype.card_fin, M] using
-            (Matrix.det_kronecker (A := (U : MatrixAlg d).map star)
-              (B := (U : MatrixAlg d)))
-    _ = (star (Matrix.det (U : MatrixAlg d)) * Matrix.det (U : MatrixAlg d)) ^ d := by
+            (Matrix.det_kronecker (A := (U : MatAlg d).map star)
+              (B := (U : MatAlg d)))
+    _ = (star (Matrix.det (U : MatAlg d)) * Matrix.det (U : MatAlg d)) ^ d := by
           rw [hdet_map_star, mul_pow]
     _ = 1 := by rw [hdet_unitary, one_pow]
 

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -387,8 +387,10 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
     apply sub_eq_zero.mp
     apply (isOrthogonalProjection_posSemidef hP.one_sub).trace_eq_zero_iff.mp
     rw [Matrix.trace_sub, Matrix.trace_one, Fintype.card_fin, ← htrace]
-    norm_num [hm] at hnm ⊢
-    exact_mod_cast hnm.symm
+    have hn_eq_D : D = n := by
+      omega
+    have hn_eq_D' : (D : ℂ) = (n : ℂ) := by exact_mod_cast hn_eq_D
+    rw [hn_eq_D', sub_self]
   have hn_lt : n < D := by omega
   have hm_lt : m < D := by omega
   exact ⟨n, m, hnm, hn_lt, hm_lt, A₁, A₂, hSame⟩

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -138,16 +138,9 @@ private theorem exists_twoBlock_decomp_of_lowerZero_aux
   let Aconj : MPSTensor d D := fun i => Umatᴴ * A i * Umat
   have hSame_conj : SameMPV A Aconj := sameMPV_conj_unitary (d := d) (D := D) A U
   have hPdiag : IsOrthogonalProjection Pdiag := by
-    refine ⟨?_, ?_⟩
-    · change (Umatᴴ * P * Umat)ᴴ = Umatᴴ * P * Umat
-      simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
-      rw [hP.1.eq]
-    · change (Umatᴴ * P * Umat) * (Umatᴴ * P * Umat) = Umatᴴ * P * Umat
-      calc
-        (Umatᴴ * P * Umat) * (Umatᴴ * P * Umat) =
-            Umatᴴ * P * (Umat * Umatᴴ) * P * Umat := by noncomm_ring
-        _ = Umatᴴ * P * P * Umat := by simp [hUU, Matrix.mul_assoc]
-        _ = Umatᴴ * P * Umat := by simp [Matrix.mul_assoc, hP.2]
+    simpa [Pdiag] using
+      (IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+        hP.isStarProjection Umat hUU).isOrthogonalProjection
   -- Lower-left block condition for the conjugated tensor.
   have hLower_conj : ∀ i : Fin d, (1 - Pdiag) * Aconj i * Pdiag = 0 := by
     intro i
@@ -393,7 +386,7 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
     symm
     apply sub_eq_zero.mp
     apply (isOrthogonalProjection_posSemidef hP.one_sub).trace_eq_zero_iff.mp
-    rw [map_sub, Matrix.trace_one, Fintype.card_fin, ← htrace]
+    rw [Matrix.trace_sub, Matrix.trace_one, Fintype.card_fin, ← htrace]
     norm_num [hm] at hnm ⊢
     exact_mod_cast hnm.symm
   have hn_lt : n < D := by omega

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.Peripheral.CyclicDecomposition.Basic
 import TNLean.MPS.Structure.InvariantSubspaceDecomp.Basic
 
 /-!
@@ -110,19 +111,9 @@ private lemma mpv_twoBlockTensor_eq {n m N : ℕ}
 ### Spectral splitting and block extraction
 -/
 
-/-- Spectral decomposition auxiliary lemma for a Hermitian matrix (matrix form). -/
-private lemma orthProj_spectral_eq'
-    (P : Matrix (Fin D) (Fin D) ℂ) (hHerm : P.IsHermitian) :
-    P = (↑hHerm.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
-      Matrix.diagonal (fun j => (↑(hHerm.eigenvalues j) : ℂ)) *
-      (↑hHerm.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-  have h := hHerm.spectral_theorem
-  rw [Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose] at h
-  simpa [Matrix.mul_assoc, Function.comp_def] using h
-
 /-- Common spectral and block construction underlying the general and strict
-invariant-subspace decompositions. The final two implications record exactly the
-additional dimension information needed by the strict variant. -/
+invariant-subspace decompositions. The trace identity records the first block's
+rank and lets the strict theorem derive both positivity bounds as corollaries. -/
 private theorem exists_twoBlock_decomp_of_lowerZero_aux
     (A : MPSTensor d D)
     (P : Matrix (Fin D) (Fin D) ℂ)
@@ -131,123 +122,54 @@ private theorem exists_twoBlock_decomp_of_lowerZero_aux
     ∃ (n m : ℕ) (_ : n + m = D)
       (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
       SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) ∧
-        (P ≠ 0 → 0 < n) ∧ (P ≠ 1 → 0 < m) := by
+        (n : ℂ) = Matrix.trace P := by
   classical
-  -- Diagonalize the projection `P`.
-  let hHerm : P.IsHermitian := hP.1
-  let U : ↥(Matrix.unitaryGroup (Fin D) ℂ) := hHerm.eigenvectorUnitary
-  let Umat : Matrix (Fin D) (Fin D) ℂ := (U : Matrix (Fin D) (Fin D) ℂ)
-  let Pdiag : Matrix (Fin D) (Fin D) ℂ := star Umat * P * Umat
-  let f : Fin D → ℂ := fun j => (↑(hHerm.eigenvalues j) : ℂ)
-  have hPdiag_eq : Pdiag = Matrix.diagonal f := by
-    -- unpack the spectral theorem statement
-    have h := hHerm.conjStarAlgAut_star_eigenvectorUnitary
-    -- rewrite the conjugation automorphism in matrix form
-    simpa [Pdiag, f, Unitary.conjStarAlgAut_star_apply, Function.comp_def] using h
-  -- `Pdiag` is idempotent, hence its diagonal entries are `0` or `1`.
-  have hU_mul_star : Umat * star Umat = 1 :=
-    Unitary.mul_star_self_of_mem U.2
-  have hPdiag_idem : Pdiag * Pdiag = Pdiag := by
-    -- `Pdiag` is conjugate to `P`, hence idempotent.
-    calc
-      Pdiag * Pdiag
-          = star Umat * P * (Umat * star Umat) * P * Umat := by
-              -- reassociate to expose `Umat * star Umat`
-              simp [Pdiag, Matrix.mul_assoc]
-      _ = star Umat * P * P * Umat := by
-              simp [hU_mul_star, Matrix.mul_assoc]
-      _ = star Umat * P * Umat := by
-              simp [hP.2, Matrix.mul_assoc]
-      _ = Pdiag := by
-              simp [Pdiag, Matrix.mul_assoc]
-  have hDiag_idem : Matrix.diagonal f * Matrix.diagonal f = Matrix.diagonal f := by
-    simpa [hPdiag_eq] using hPdiag_idem
-  have hf01 : ∀ j : Fin D, f j = 0 ∨ f j = 1 := by
-    intro j
-    -- extract the scalar idempotence from the diagonal idempotence
-    have hfun : (fun k => f k * f k) = f := by
-      -- compare diagonals
-      apply Matrix.diagonal_injective
-      simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
-    have hj : f j * f j = f j := by
-      simpa using congrArg (fun g => g j) hfun
-    exact IsIdempotentElem.iff_eq_zero_or_one.mp hj
-  -- Split the eigenbasis indices into the `1`-eigenspace and the `0`-eigenspace.
-  let p : Fin D → Prop := fun j => f j = 1
-  haveI : DecidablePred p := fun j => by
-    -- `p j` is an equality in `ℂ`, hence decidable.
-    infer_instance
-  let S : Type := { j : Fin D // p j }
-  let T : Type := { j : Fin D // ¬ p j }
-  let n : ℕ := Fintype.card S
-  let m : ℕ := Fintype.card T
+  obtain ⟨Umat, S, T, n, hn, eST, eS, hUU, hU'U, hPdiag_std, -, -, htrace, -⟩ :=
+    ProjectionSpectralSplit.ofOrthogonalProjection P hP
+  let m := Fintype.card T
   have hnm : n + m = D := by
-    -- Cardinality split induced by `Equiv.sumCompl p : S ⊕ T ≃ Fin D`.
-    have hST : Fintype.card (S ⊕ T) = D := by
-      -- Avoid `simp` rewriting `Fintype.card (S ⊕ T)` into `card S + card T`.
-      have h : Fintype.card (S ⊕ T) = Fintype.card (Fin D) :=
-        Fintype.card_congr (Equiv.sumCompl p)
-      have hfin : Fintype.card (Fin D) = D := by
-        simp [Fintype.card_fin]
-      exact h.trans hfin
-    have hsum : Fintype.card (S ⊕ T) = Fintype.card S + Fintype.card T := by
-      simp
-    -- rewrite the RHS in terms of `n` and `m`.
-    -- We avoid simp rewriting `Fintype.card T` into a subtraction form.
-    have hcard : Fintype.card S + Fintype.card T = D :=
-      hsum.symm.trans hST
-    simpa [n, m] using hcard
-  -- Auxiliary: `f` is `0` on the complement subtype.
-  have hfT : ∀ t : T, f t.1 = 0 := by
-    intro t
-    rcases hf01 t.1 with h0 | h1
-    · exact h0
-    · exfalso
-      exact t.2 h1
-  -- The basis equivalence `Fin D ≃ S ⊕ T`.
-  let eST : Fin D ≃ (S ⊕ T) := (Equiv.sumCompl p).symm
-  -- Conjugate the tensor by `U`.
-  let Aconj : MPSTensor d D := fun i => star Umat * A i * Umat
+    rw [hn]
+    simpa [m] using (Fintype.card_congr eST).symm
+  let Pdiag : Matrix (Fin D) (Fin D) ℂ := Umatᴴ * P * Umat
+  have hUmem : Umat ∈ Matrix.unitaryGroup (Fin D) ℂ :=
+    ⟨by simpa [Matrix.star_eq_conjTranspose] using hU'U,
+      by simpa [Matrix.star_eq_conjTranspose] using hUU⟩
+  let U : Matrix.unitaryGroup (Fin D) ℂ := ⟨Umat, hUmem⟩
+  let Aconj : MPSTensor d D := fun i => Umatᴴ * A i * Umat
   have hSame_conj : SameMPV A Aconj := sameMPV_conj_unitary (d := d) (D := D) A U
-  -- `Pdiag` is an orthogonal projection.
   have hPdiag : IsOrthogonalProjection Pdiag := by
-    refine ⟨?_, hPdiag_idem⟩
-    -- Since `Pdiag` is diagonal and idempotent, its diagonal entries are `0` or `1`, hence
-    -- self-adjoint, hence the whole matrix is Hermitian.
-    have hf_selfAdj : ∀ j : Fin D, IsSelfAdjoint (f j) := by
-      intro j
-      rcases hf01 j with h0 | h1
-      · simp [IsSelfAdjoint, h0]
-      · simp [IsSelfAdjoint, h1]
-    have hHermDiag : (Matrix.diagonal f).IsHermitian :=
-      (Matrix.isHermitian_diagonal_iff (d := f)).2 hf_selfAdj
-    simpa [hPdiag_eq] using hHermDiag
+    refine ⟨?_, ?_⟩
+    · change (Umatᴴ * P * Umat)ᴴ = Umatᴴ * P * Umat
+      simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+      rw [hP.1.eq]
+    · change (Umatᴴ * P * Umat) * (Umatᴴ * P * Umat) = Umatᴴ * P * Umat
+      calc
+        (Umatᴴ * P * Umat) * (Umatᴴ * P * Umat) =
+            Umatᴴ * P * (Umat * Umatᴴ) * P * Umat := by noncomm_ring
+        _ = Umatᴴ * P * P * Umat := by simp [hUU, Matrix.mul_assoc]
+        _ = Umatᴴ * P * Umat := by simp [Matrix.mul_assoc, hP.2]
   -- Lower-left block condition for the conjugated tensor.
   have hLower_conj : ∀ i : Fin d, (1 - Pdiag) * Aconj i * Pdiag = 0 := by
     intro i
-    have hStar_mul : star Umat * Umat = 1 := by
-      -- Avoid `simpa` simplifying the unitary identity to `True`.
-      simp [Umat]
-    have hOneSub : (1 - Pdiag) = star Umat * (1 - P) * Umat := by
-      -- `star U * (1-P) * U = 1 - star U * P * U`.
-      have : star Umat * (1 - P) * Umat = (1 - Pdiag) := by
-        simp [Pdiag, mul_sub, sub_mul, Matrix.mul_assoc, hStar_mul]
+    have hOneSub : (1 - Pdiag) = Umatᴴ * (1 - P) * Umat := by
+      have : Umatᴴ * (1 - P) * Umat = (1 - Pdiag) := by
+        simp [Pdiag, mul_sub, sub_mul, Matrix.mul_assoc, hU'U]
       exact this.symm
     calc
       (1 - Pdiag) * Aconj i * Pdiag
-          = (star Umat * (1 - P) * Umat) * (star Umat * A i * Umat) * (star Umat * P * Umat) := by
+          = (Umatᴴ * (1 - P) * Umat) * (Umatᴴ * A i * Umat) * (Umatᴴ * P * Umat) := by
               -- First rewrite `(1-Pdiag)` using `hOneSub`, then unfold `Aconj`/`Pdiag`.
               simp [hOneSub, Aconj, Pdiag]
-      _ = star Umat * ((1 - P) * A i * P) * Umat := by
-              -- Cancel `Umat * star Umat = 1`.
+      _ = Umatᴴ * ((1 - P) * A i * P) * Umat := by
+              -- Cancel `Umat * Umatᴴ = 1`.
               calc
-                (star Umat * (1 - P) * Umat) * (star Umat * A i * Umat) * (star Umat * P * Umat)
-                    = star Umat * (1 - P) * (Umat * star Umat) *
-                        A i * (Umat * star Umat) * P * Umat := by
+                (Umatᴴ * (1 - P) * Umat) * (Umatᴴ * A i * Umat) * (Umatᴴ * P * Umat)
+                    = Umatᴴ * (1 - P) * (Umat * Umatᴴ) *
+                        A i * (Umat * Umatᴴ) * P * Umat := by
                         noncomm_ring
-                _ = star Umat * (1 - P) * A i * P * Umat := by
-                        simp [hU_mul_star, Matrix.mul_assoc]
-                _ = star Umat * ((1 - P) * A i * P) * Umat := by
+                _ = Umatᴴ * (1 - P) * A i * P * Umat := by
+                        simp [hUU, Matrix.mul_assoc]
+                _ = Umatᴴ * ((1 - P) * A i * P) * Umat := by
                         noncomm_ring
       _ = 0 := by
               simp [hLower i]
@@ -259,45 +181,10 @@ private theorem exists_twoBlock_decomp_of_lowerZero_aux
   let A11raw : Fin d → Matrix S S ℂ := fun i => (X i).toBlocks₁₁
   let A22raw : Fin d → Matrix T T ℂ := fun i => (X i).toBlocks₂₂
   -- Convert the direct blocks to `Fin n` / `Fin m` indices.
-  let eS : S ≃ Fin n := Fintype.equivFin S
   let eT : T ≃ Fin m := Fintype.equivFin T
   let A₁ : MPSTensor d n := fun i => Matrix.reindex eS eS (A11raw i)
   let A₂ : MPSTensor d m := fun i => Matrix.reindex eT eT (A22raw i)
-  have hn_pos : P ≠ 0 → 0 < n := by
-    intro hP0
-    apply Fintype.card_pos_iff.mpr
-    by_contra hempty
-    rw [not_nonempty_iff] at hempty
-    apply hP0
-    have hf_zero : ∀ j, f j = 0 := fun j =>
-      (hf01 j).resolve_right (fun h1 => (IsEmpty.false (α := S) ⟨j, h1⟩).elim)
-    rw [orthProj_spectral_eq' P hHerm]
-    have hdiag0 : Matrix.diagonal f = 0 := by
-      ext i k
-      simp [Matrix.diagonal_apply, hf_zero]
-    rw [hdiag0, Matrix.mul_zero, Matrix.zero_mul]
-  have hm_pos : P ≠ 1 → 0 < m := by
-    intro hP1
-    apply Fintype.card_pos_iff.mpr
-    by_contra hempty
-    rw [not_nonempty_iff] at hempty
-    apply hP1
-    have hf_one : ∀ j, f j = 1 := fun j =>
-      (hf01 j).resolve_left
-        (fun h0 =>
-          (IsEmpty.false (α := T)
-            ⟨j, fun (h1 : f j = 1) => absurd (h0.symm.trans h1) zero_ne_one⟩).elim)
-    rw [orthProj_spectral_eq' P hHerm]
-    have hdiag1 : Matrix.diagonal f = 1 := by
-      ext i k
-      simp only [Matrix.diagonal_apply, Matrix.one_apply]
-      split_ifs with heq
-      · subst heq
-        exact hf_one i
-      · rfl
-    rw [hdiag1, Matrix.mul_one, ← Matrix.star_eq_conjTranspose]
-    simp
-  refine ⟨n, m, hnm, A₁, A₂, ?_, hn_pos, hm_pos⟩
+  refine ⟨n, m, hnm, A₁, A₂, ?_, htrace⟩
   -- Final MPV equality.
   intro N σ
   -- Chain: A ~ Aconj ~ diagPart Aconj Pdiag ~ blockDiag(A₁,A₂).
@@ -323,48 +210,6 @@ private theorem exists_twoBlock_decomp_of_lowerZero_aux
       _ = Matrix.trace (_root_.evalWord (fun i => Matrix.reindex eST eST
               ((diagPart (d := d) (D := D) Aconj Pdiag) i)) w) := by
                 simpa using congrArg Matrix.trace hEval_reindex.symm
-  -- Compute the projection matrix `Pdiag` in the `S ⊕ T` basis: it is `diag(1,0)`.
-  have hPdiag_std :
-      Matrix.reindex eST eST Pdiag =
-        Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ) := by
-    have hReindexDiag :
-        Matrix.reindex eST eST (Matrix.diagonal f) =
-          Matrix.diagonal (f ∘ eST.symm) := by
-      simp [Matrix.reindex_apply]
-    rw [hPdiag_eq, hReindexDiag]
-    ext x y
-    cases x with
-    | inl s =>
-        cases y with
-        | inl s' =>
-            by_cases h : s = s'
-            · subst h
-              -- On the `1`-eigenspace, the diagonal entries are `1`.
-              -- Here `s.2` is the defining property `f s.1 = 1`.
-              -- `Equiv.sumCompl p (Sum.inl s)` is definitionally `s.1`, so this is exactly `s.2`.
-              rw [Matrix.diagonal_apply_eq, Matrix.fromBlocks_apply₁₁]
-              change f ((Equiv.sumCompl p) (Sum.inl s)) = (1 : Matrix S S ℂ) s s
-              rw [Equiv.sumCompl_apply_inl]
-              simpa using s.2
-            · -- Off-diagonal entries vanish.
-              simp [Matrix.fromBlocks_apply₁₁, h]
-        | inr t =>
-            -- Off-diagonal blocks are zero.
-            simp [Matrix.fromBlocks_apply₁₂]
-    | inr t =>
-        cases y with
-        | inl s =>
-            simp [Matrix.fromBlocks_apply₂₁]
-        | inr t' =>
-            by_cases h : t = t'
-            · subst h
-              -- On the `0`-eigenspace, the diagonal entries are `0`.
-              -- On the `0`-eigenspace, `f t.1 = 0` by `hfT`.
-              rw [Matrix.diagonal_apply_eq, Matrix.fromBlocks_apply₂₂]
-              change f ((Equiv.sumCompl p) (Sum.inr t)) = (0 : Matrix T T ℂ) t t
-              rw [Equiv.sumCompl_apply_inr]
-              simpa using hfT t
-            · simp [Matrix.fromBlocks_apply₂₂, h]
   -- Show that the reindexed diagonal-part tensor is block diagonal with
   -- diagonal blocks `A11raw` and `A22raw`.
   have hLetter_block : ∀ i : Fin d,
@@ -495,7 +340,7 @@ theorem exists_twoBlock_decomp_of_lowerZero
       (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
       SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) := by
   rcases exists_twoBlock_decomp_of_lowerZero_aux A P hP hLower with
-    ⟨n, m, hnm, A₁, A₂, hSame, -, -⟩
+    ⟨n, m, hnm, A₁, A₂, hSame, -⟩
   exact ⟨n, m, hnm, A₁, A₂, hSame⟩
 
 
@@ -533,9 +378,24 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
       ∃ (A₁ : MPSTensor d n) (A₂ : MPSTensor d m),
         SameMPV₂ A (twoBlockTensor (d := d) (n := n) (m := m) A₁ A₂) := by
   rcases exists_twoBlock_decomp_of_lowerZero_aux A P hP hLower with
-    ⟨n, m, hnm, A₁, A₂, hSame, hn_pos, hm_pos⟩
-  have hn_pos' : 0 < n := hn_pos hP0
-  have hm_pos' : 0 < m := hm_pos hP1
+    ⟨n, m, hnm, A₁, A₂, hSame, htrace⟩
+  have hn_pos : 0 < n := by
+    rw [Nat.pos_iff_ne_zero]
+    intro hn
+    apply hP0
+    apply (isOrthogonalProjection_posSemidef hP).trace_eq_zero_iff.mp
+    rw [← htrace, hn]
+    norm_num
+  have hm_pos : 0 < m := by
+    rw [Nat.pos_iff_ne_zero]
+    intro hm
+    apply hP1
+    symm
+    apply sub_eq_zero.mp
+    apply (isOrthogonalProjection_posSemidef hP.one_sub).trace_eq_zero_iff.mp
+    rw [map_sub, Matrix.trace_one, Fintype.card_fin, ← htrace]
+    norm_num [hm] at hnm ⊢
+    exact_mod_cast hnm.symm
   have hn_lt : n < D := by omega
   have hm_lt : m < D := by omega
   exact ⟨n, m, hnm, hn_lt, hm_lt, A₁, A₂, hSame⟩


### PR DESCRIPTION
First completed slice of #4566.

Factors the common spectral-split construction and derives the strict theorem as a short corollary while preserving both public signatures. Removes 140 net lines from `InvariantSubspaceDecomp.lean`.

Verification:
- native Lean diagnostics: 0 errors/warnings/hints
- no new `sorry`, `admit`, or `axiom`
- public signatures unchanged
- `git diff --check`
- no local build/cache recreation; full build delegated to CI

Refs #4566. The independent Compression cleanup remains tracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor with unchanged public APIs and localized namespace hygiene; no auth, runtime, or data-path changes.
> 
> **Overview**
> **MPS invariant subspace decomposition** now pulls spectral splitting from `ProjectionSpectralSplit.ofOrthogonalProjection` in `TNLean.Channel.Peripheral.CyclicDecomposition.Basic` (new import), deleting the long inline Hermitian diagonalization and block-form proof in `InvariantSubspaceDecomp.lean`. The shared auxiliary lemma still proves MPV equivalence but also returns **`(n : ℂ) = Matrix.trace P`**; the strict **`n < D` / `m < D`** theorem is a short corollary via trace-zero criteria on `P` and `1 - P` instead of bundled `P ≠ 0 → 0 < n` hypotheses. Public theorem statements are unchanged.
> 
> **Channel determinant** files (`Bound`, `HeisenbergDual`, `HilbertSchmidt`, `UnitaryCharacterization`) drop a blanket `open ChannelDeterminant.Internal` in favor of **local notations** for `MatrixAlg` / `MatrixEnd` and an explicit `ChannelDeterminant.Internal.matrixSpaceBasis` reference where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2628d8a26842f3bb4161afda7c1bc17cb74e2835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->