### PR TITLE
refactor(MPS/BNT): bridge canonical-form carriers

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -355,6 +355,7 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic
+import TNLean.MPS.BNT.Bridge
 import TNLean.MPS.BNT.Separation
 import TNLean.MPS.BNT.PermutationRigidityPrimitive
 import TNLean.MPS.BNT.Construction

--- a/TNLean/MPS/BNT/Bridge.lean
+++ b/TNLean/MPS/BNT/Bridge.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.BNT.Basic
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.Periodic.NormalizedSelfOverlap
+
+/-!
+# Bridges between basis-of-normal-tensors predicates
+
+This module records the one-way connections between the three BNT surfaces used
+in TNLean:
+
+* `IsCPSVBasisOfNormalTensors`, the source-faithful CPSV16 spectral predicate;
+* `IsBNT`, the algebraic eventual-block-injectivity predicate; and
+* `IsBNTCanonicalForm`, the stronger sector-decomposition canonical form.
+
+The bridges are deliberately implications, not equivalences.  In particular,
+`IsNormalTensor` contains spectral-radius and peripheral-spectrum data that are
+not recoverable merely by unfolding `IsNormal`, while `IsBNTCanonicalForm`
+contains normalization, irreducibility, left-canonicality, and distinctness data
+absent from `IsBNT`.
+
+## Main results
+
+* `IsCPSVBasisOfNormalTensors.blocks_dim_pos`: every source BNT block has
+  positive bond dimension;
+* `IsCPSVBasisOfNormalTensors.isBNT`: a CPSV16 BNT gives an algebraic BNT;
+* `IsBNT.of_sameMPV₂Pos`: transport an algebraic BNT along positive-length MPV
+  equality;
+* `IsBNTCanonicalForm.basis_isNormal`: every canonical-form basis block is
+  algebraically normal;
+* `IsBNTCanonicalForm.isBNT`: forget a canonical form to its algebraic BNT.
+
+## References
+
+* CPSV16, arXiv:1606.00608, lines 231--235 and 271--274.
+* CPSV21, arXiv:2011.12127, Definition 4.2, lines 1846--1850.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- A tensor with a nonzero matrix product state has positive bond dimension. -/
+private theorem bondDim_pos_of_mpvState_ne_zero {A : MPSTensor d D} {N : ℕ}
+    (hA : mpvState (d := d) A N ≠ 0) :
+    0 < D := by
+  by_contra hD
+  have hD0 : D = 0 := Nat.eq_zero_of_not_pos hD
+  subst D
+  apply hA
+  ext σ
+  simp [mpvState, mpv, coeff, Matrix.trace]
+
+/-- Every tensor in a CPSV16 basis of normal tensors has positive bond
+ dimension.
+
+This follows from eventual linear independence: each sufficiently long matrix
+product state in the basis is nonzero.
+
+Source: arXiv:1606.00608, BNT definition at lines 271--274. -/
+theorem IsCPSVBasisOfNormalTensors.blocks_dim_pos
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    ∀ j, 0 < dim j := by
+  intro j
+  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
+  have hN : N₀ < N₀ + 1 := by omega
+  have hne : mpvState (d := d) (B j) (N₀ + 1) ≠ 0 :=
+    (hLI (N₀ + 1) hN).ne_zero j
+  exact bondDim_pos_of_mpvState_ne_zero hne
+
+/-- Forget the spectral normality data of a CPSV16 BNT to obtain the algebraic
+BNT predicate.
+
+This implication uses `IsNormalTensor.isNormal` blockwise.  No converse is
+asserted: algebraic eventual block injectivity alone does not carry the
+spectral-radius-one normalization stored by `IsNormalTensor`.
+
+Source: arXiv:1606.00608, lines 231--235 and 271--274. -/
+theorem IsCPSVBasisOfNormalTensors.isBNT
+    {g : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    IsBNT A g dim B := by
+  refine ⟨?_, hBNT.spans_mpv, hBNT.eventually_li⟩
+  intro j
+  letI : NeZero (dim j) := ⟨(hBNT.blocks_dim_pos j).ne'⟩
+  exact (hBNT.blocks_normal j).isNormal
+
+/-- Transport an algebraic BNT from `A` to a tensor `A'` with the same
+positive-length matrix product vectors.
+
+Only the spanning clause depends on the represented tensor; normality and
+eventual linear independence belong to the fixed basis family. -/
+theorem IsBNT.of_sameMPV₂Pos
+    {g D' : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {A' : MPSTensor d D'}
+    {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hBNT : IsBNT A g dim B) (hSame : SameMPV₂Pos A A') :
+    IsBNT A' g dim B := by
+  refine ⟨hBNT.normal, ?_, hBNT.eventually_li⟩
+  intro N hN
+  obtain ⟨c, hc⟩ := hBNT.spans_mpv N hN
+  exact ⟨c, fun σ => (hSame N hN σ).symm.trans (hc σ)⟩
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- Every basis tensor in BNT canonical form is algebraically normal.
+
+The canonical-form irreducibility, left-canonicality, normalized self-overlap,
+and positive bond dimension imply eventual block injectivity.
+
+Source: CPSV21, arXiv:2011.12127, lines 1815--1830. -/
+theorem basis_isNormal (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
+    IsNormal (P.basis j) := by
+  letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+  exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+    (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
+      (hCF.basis_normalized_self_overlap j)
+
+/-- Forget a BNT canonical form to the algebraic BNT carried by its basis.
+
+The sector coefficient formula supplies the spanning clause, while
+`HasBNTSectorData` supplies eventual linear independence.  This is only a
+projection: the weight normalization and canonical-form data cannot be
+reconstructed from `IsBNT`.
+
+Source: CPSV16, arXiv:1606.00608, lines 271--301; CPSV21,
+arXiv:2011.12127, lines 1846--1884. -/
+theorem isBNT (hCF : IsBNTCanonicalForm P) :
+    IsBNT P.toTensor P.basisCount P.basisDim P.basis := by
+  refine ⟨hCF.basis_isNormal, ?_, hCF.bnt_data⟩
+  intro N _hN
+  exact ⟨P.coeff N, fun σ => P.mpv_toTensor_eq_sum_coeff σ⟩
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/BNT/Bridge.lean
+++ b/TNLean/MPS/BNT/Bridge.lean
@@ -8,16 +8,17 @@ import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Periodic.NormalizedSelfOverlap
 
 /-!
-# Bridges between basis-of-normal-tensors predicates
+# Implications between basis-of-normal-tensors predicates
 
-This module records the one-way connections between the three BNT surfaces used
+This module records the one-way connections between the three BNT predicates used
 in TNLean:
 
 * `IsCPSVBasisOfNormalTensors`, the source-faithful CPSV16 spectral predicate;
 * `IsBNT`, the algebraic eventual-block-injectivity predicate; and
 * `IsBNTCanonicalForm`, the stronger sector-decomposition canonical form.
 
-The bridges are deliberately implications, not equivalences.  In particular,
+The carrier comparisons below prove `IsCPSVBasisOfNormalTensors → IsBNT` and
+`IsBNTCanonicalForm → IsBNT`; neither converse is asserted.  In particular,
 `IsNormalTensor` contains spectral-radius and peripheral-spectrum data that are
 not recoverable merely by unfolding `IsNormal`, while `IsBNTCanonicalForm`
 contains normalization, irreducibility, left-canonicality, and distinctness data

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -58,15 +58,14 @@ The TN-Review formulation (`Papers/2011.12127/TN-Review-main.tex:1827-1830`)
 "the transfer operator is a primitive channel" is the same clause and is not
 duplicated.
 
-## Connections to existing strong predicates
+## Connections to existing predicates
 
-A connection is intentionally not provided here:
-
-* A BNT connection `IsCPSVBasisOfNormalTensors.of_isBNT` would require the implication
-  `MPSTensor.IsNormal → IsNormalTensor` per block, i.e. from algebraic eventual
-  block injectivity to the CPSV16 conditions of no nontrivial invariant projection,
-  unit spectral radius, and unique peripheral eigenvalue. That equivalence requires
-  Wielandt-style spectral arguments not developed at this layer.
+The separate module `TNLean.MPS.BNT.Bridge` provides the source-faithful one-way
+implication `IsCPSVBasisOfNormalTensors.isBNT`, using the proved implication
+`IsNormalTensor.isNormal` on each positive-dimensional block.  The converse is
+intentionally absent: algebraic eventual block injectivity does not by itself
+supply the spectral-radius-one normalization and peripheral-spectrum data stored
+by `IsNormalTensor`.
 
 ## Style
 

--- a/TNLean/MPS/MPDO/SourceBNTBlocking.lean
+++ b/TNLean/MPS/MPDO/SourceBNTBlocking.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.BNT.Bridge
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.MPDO.PostBlockedRepresentativeSpan
 
@@ -21,34 +22,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-private theorem bondDim_pos_of_mpvState_ne_zero {A : MPSTensor d D} {N : ℕ}
-    (hA : mpvState (d := d) A N ≠ 0) :
-    0 < D := by
-  by_contra hD
-  have hD0 : D = 0 := Nat.eq_zero_of_not_pos hD
-  subst D
-  apply hA
-  ext σ
-  simp [mpvState, mpv, coeff, Matrix.trace]
-
-/-- Every tensor in a basis of normal tensors has positive bond dimension.
-
-This follows from the eventual linear independence in the source BNT
-definition: each sufficiently long matrix product vector is nonzero.
-
-Source: arXiv:1606.00608, BNT definition at lines 271--274. -/
-theorem IsCPSVBasisOfNormalTensors.blocks_dim_pos
-    {g : ℕ} {dim : Fin g → ℕ}
-    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
-    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
-    ∀ j, 0 < dim j := by
-  intro j
-  obtain ⟨N₀, hLI⟩ := hBNT.eventually_li
-  have hN : N₀ < N₀ + 1 := by omega
-  have hne : mpvState (d := d) (B j) (N₀ + 1) ≠ 0 :=
-    (hLI (N₀ + 1) hN).ne_zero j
-  exact bondDim_pos_of_mpvState_ne_zero hne
 
 /-- A simultaneous length-`L` word span becomes a simultaneous one-letter
 span after blocking `L` physical sites. -/

--- a/TNLean/MPS/MPDO/VerticalBNTConstruction.lean
+++ b/TNLean/MPS/MPDO/VerticalBNTConstruction.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.BNT.Bridge
 import TNLean.MPS.MPDO.RetainedClass
 
 /-!
@@ -116,10 +117,11 @@ variable {d D : ℕ}
 /-- The BNT representatives in a particular grouped vertical decomposition
 form an algebraic BNT for the vertical tensor.
 
-The hypotheses are precisely the dimension, isometry, intertwining,
-reconstruction, and spectral-BNT clauses returned by
-`IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.  The proof does not
-choose a second vertical grouping.
+The hypotheses are precisely the isometry, intertwining, reconstruction, and
+spectral-BNT clauses returned by
+`IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.  Positivity of the
+block dimensions follows from the spectral BNT hypothesis, so it is not an
+independent assumption.  The proof does not choose a second vertical grouping.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem isBNT_verticalTensor_of_grouping
@@ -127,7 +129,6 @@ theorem isBNT_verticalTensor_of_grouping
     {r : ℕ} {dim : Fin r → ℕ} (μ : Fin r → ℂ)
     (blocks : (k : Fin r) → MPSTensor (D * D) (dim k))
     (V : (k : Fin r) → Matrix (Fin d) (Fin (dim k)) ℂ)
-    (hdimPos : ∀ k, 0 < dim k)
     (hiso : ∀ k, (V k)ᴴ * V k = 1)
     (hinter : ∀ k v,
       (V k)ᴴ * verticalTensor M v = (μ k • blocks k v) * (V k)ᴴ)
@@ -146,16 +147,6 @@ theorem isBNT_verticalTensor_of_grouping
       (MPSTensor.toTensorFromBlocks (d := D * D) (μ := μ) blocks) :=
     MPSTensor.sameMPV₂Pos_toTensorFromBlocks_of_reconstruction
       (verticalTensor M) μ blocks V hiso hinter hreconstruct
-  change MPSTensor.IsBNT (verticalTensor M) C.g
-    (fun j => dim (C.repr j)) (fun j => blocks (C.repr j))
-  refine ⟨?_, ?_, hBNT.eventually_li⟩
-  · intro j
-    letI : NeZero (dim (C.repr j)) := ⟨(hdimPos (C.repr j)).ne'⟩
-    exact (hBNT.blocks_normal j).isNormal
-  · intro N hN
-    obtain ⟨c, hc⟩ := hBNT.spans_mpv N hN
-    refine ⟨c, fun σ => ?_⟩
-    rw [hPositive N hN σ]
-    exact hc σ
+  exact hBNT.isBNT.of_sameMPV₂Pos hPositive.symm
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -54,7 +54,7 @@ theorem verticalCF_of_horizontalCF (M : MPOTensor d D)
   let C := MPSTensor.mpvPhaseClassData blocks
   have hBNT : MPSTensor.IsBNT (verticalTensor M) C.g
       (fun j ↦ dim (C.repr j)) (fun j ↦ blocks (C.repr j)) :=
-    isBNT_verticalTensor_of_grouping M mu blocks V hDimPos hIso
+    isBNT_verticalTensor_of_grouping M mu blocks V hIso
       hInterStar hReconstruct hSpectralBNT
   obtain ⟨_, W, _, hWIso, hWOrth, hWInter, hWReconstruct⟩ :=
     hM.exists_normalized_grouped_sector_maps blocks hHorizontal mu V hDimPos

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.Periodic.NormalizedSelfOverlap
+import TNLean.MPS.BNT.Bridge
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.StructuralFull
 
@@ -397,14 +397,6 @@ namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
 
-/-- Every basis tensor in BNT canonical form is normal. -/
-private lemma basis_isNormal (hCF : IsBNTCanonicalForm P) (k : Fin P.basisCount) :
-    IsNormal (P.basis k) := by
-  letI : NeZero (P.basisDim k) := ⟨(hCF.basis_dim_pos k).ne'⟩
-  exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-    (P.basis k) (hCF.basis_irreducible k) (hCF.basis_left_canonical k)
-      (hCF.basis_normalized_self_overlap k)
-
 /-- **Multiplicity-one characterization for the basis of normal tensors.**
 
 If `P` is in BNT canonical form, then the direct sum of its distinct basis
@@ -426,7 +418,7 @@ theorem isTransferIdempotent_basisDirectSum_iff (hCF : IsBNTCanonicalForm P) :
           mixedTransferMap₂ (P.basis j) (P.basis j') = 0) := by
   letI : ∀ k : Fin P.basisCount, NeZero (P.basisDim k) :=
     fun k => ⟨(hCF.basis_dim_pos k).ne'⟩
-  exact isTransferIdempotent_directSumTensor_iff P.basis (basis_isNormal hCF)
+  exact isTransferIdempotent_directSumTensor_iff P.basis hCF.basis_isNormal
     hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct
 
 /-- **Residual isometry family for a BNT basis direct sum.**
@@ -456,7 +448,7 @@ theorem exists_residualIsometryFamily_of_isTransferIdempotent_basisDirectSum
   letI : ∀ k : Fin P.basisCount, NeZero (P.basisDim k) :=
     fun k => ⟨(hCF.basis_dim_pos k).ne'⟩
   exact exists_residualIsometryFamily_of_isTransferIdempotent_directSum P.basis
-    (basis_isNormal hCF) hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct hRFP
+    hCF.basis_isNormal hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct hRFP
 
 end IsBNTCanonicalForm
 

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -44,6 +44,7 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     \label{lem:cpsv_bnt_block_dimensions_positive}
     \lean{MPSTensor.IsCPSVBasisOfNormalTensors.blocks_dim_pos}
     \leanok
+    \uses{def:bnt_cpsv}
     Every block in a coefficient-form basis of normal tensors has positive
     bond dimension.
 \end{lemma}
@@ -387,6 +388,44 @@ multisets by Newton--Girard. The references are \cite{PerezGarcia2007Matrix},
     Apply Theorem~\ref{thm:cpsv_normal_tp_gauge}. The trace-preserving,
     primitive, irreducible representative is eventually block-injective, and
     gauge invariance transports this conclusion back to the original tensor.
+\end{proof}
+
+\begin{theorem}[A coefficient-form BNT is an algebraic BNT]
+    \label{thm:cpsv_bnt_is_bnt}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.isBNT}
+    \leanok
+    \uses{def:bnt, def:bnt_cpsv,
+        lem:cpsv_bnt_block_dimensions_positive,
+        thm:cpsv_normal_eventually_injective}
+    If $(A_j)_{j=1}^{g}$ is a coefficient-form basis of normal tensors for
+    $A$, then $(A_j)_{j=1}^{g}$ is an algebraic basis of normal tensors for
+    $A$. Only this implication from spectral normality to algebraic normality
+    is asserted.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:cpsv_bnt_block_dimensions_positive,
+        thm:cpsv_normal_eventually_injective}
+    Every block has positive bond dimension, so spectral normality implies
+    eventual block injectivity for each block. The spanning identities and
+    eventual linear independence are unchanged.
+\end{proof}
+
+\begin{lemma}[Transport of an algebraic BNT along positive-length MPV equality]
+    \label{lem:bnt_of_same_mpv2_pos}
+    \lean{MPSTensor.IsBNT.of_sameMPV₂Pos}
+    \leanok
+    \uses{def:bnt, def:same_mpv2_pos}
+    Let $A$ and $A'$ have the same matrix product vectors at every positive
+    length. If $(A_j)_{j=1}^{g}$ is a basis of normal tensors for $A$, then
+    the same family is a basis of normal tensors for $A'$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:bnt, def:same_mpv2_pos}
+    Substitute the positive-length MPV equality into the spanning identity
+    for $A$. Normality and eventual linear independence depend only on the
+    family $(A_j)_{j=1}^{g}$.
 \end{proof}
 
 \begin{theorem}[Non-decaying rectangular overlap determines the bond dimension]
@@ -1557,6 +1596,41 @@ single family.
     \leanok
     This is the normality conclusion of
     Theorem~\ref{thm:bnt_primitivity_normality_from_self_overlap}.
+\end{proof}
+
+\begin{corollary}[Basis blocks of a BNT canonical form are normal]
+    \label{cor:sector_bnt_cf_basis_normal}
+    \lean{MPSTensor.IsBNTCanonicalForm.basis_isNormal}
+    \leanok
+    \uses{def:sector_bnt_cf, thm:bnt_normality_from_self_overlap}
+    If $P$ is in BNT canonical form, then every basis block $P_j$ is normal
+    in the algebraic sense of Definition~\ref{def:normal}.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{thm:bnt_normality_from_self_overlap}
+    Each basis block has positive bond dimension, is irreducible and
+    left-canonical, and has normalized self-overlap converging to $1$.
+    Corollary~\ref{thm:bnt_normality_from_self_overlap} applies to each block.
+\end{proof}
+
+\begin{theorem}[A BNT canonical form determines an algebraic BNT]
+    \label{thm:sector_bnt_cf_is_bnt}
+    \lean{MPSTensor.IsBNTCanonicalForm.isBNT}
+    \leanok
+    \uses{def:bnt, def:sector_bnt_cf,
+        cor:sector_bnt_cf_basis_normal}
+    If $P$ is in BNT canonical form, then its basis blocks form an algebraic
+    basis of normal tensors for the total tensor associated with $P$. Only
+    this implication from canonical form to algebraic BNT is asserted.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{cor:sector_bnt_cf_basis_normal, def:sector_weight_data}
+    The preceding corollary gives normality of every basis block. The sector
+    coefficient formula expresses the total MPV as a linear combination of
+    the basis MPVs at each positive length, and the BNT sector data give their
+    eventual linear independence.
 \end{proof}
 
 \begin{theorem}[Positive blocking preserves BNT canonical form]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -3429,9 +3429,9 @@ tensor.  This is the contraction in
     \leanok
     \uses{def:horizontal_cf_mpdo, def:vertical_tensor_mpdo, def:bnt,
         def:bnt_cpsv, def:mpv_phase_class_data}
-    Let $M$ be in horizontal canonical form and put $T=\widetilde M$.  Suppose
-    that $B_k$ has positive bond dimension $d_k$, that $\mu_k\in\C$, and that
-    $V_k:\C^{d_k}\to\C^d$ is an isometry for $0\leq k<r$.  Assume, for every
+    Let $M$ be in horizontal canonical form and put $T=\widetilde M$.  Let
+    $B_k$ have bond dimension $d_k$, let $\mu_k\in\C$, and let
+    $V_k:\C^{d_k}\to\C^d$ be an isometry for $0\leq k<r$.  Assume, for every
     vertical letter $v$, that
     \[
         V_k^\dagger T_v=(\mu_k B_k^v)V_k^\dagger,
@@ -3455,7 +3455,8 @@ tensor.  This is the contraction in
 
 \begin{proof}
     \leanok
-    \uses{thm:cpsv_normal_eventually_injective, thm:mpv_decomposition}
+    \uses{thm:cpsv_bnt_is_bnt, lem:bnt_of_same_mpv2_pos,
+        thm:mpv_decomposition}
     Put $C_k^v=\mu_kB_k^v$.  Induction on a word $w$ gives
     \[
         V_k^\dagger T^w=C_k^wV_k^\dagger.
@@ -3469,11 +3470,11 @@ tensor.  This is the contraction in
           =\sum_k\mu_k^{|w|}\tr(B_k^w)
           =V^{(|w|)}(A_{\mathrm{ret}})_w.
     \end{align*}
-    Hence the spectral BNT spanning identity for $A_{\mathrm{ret}}$ gives the
-    algebraic spanning identity for $T$ at every positive length.  Spectral
-    normality implies algebraic normality for every representative,
-    and the eventual linear independence assertion is unchanged.  These are
-    the three algebraic BNT conditions.
+    Thus $T$ and $A_{\mathrm{ret}}$ have the same matrix product vectors at
+    every positive length.  The spectral BNT hypothesis gives an algebraic BNT
+    for $A_{\mathrm{ret}}$ by Theorem~\ref{thm:cpsv_bnt_is_bnt}; in particular,
+    it supplies the required positive bond dimensions.  Lemma~\ref{lem:bnt_of_same_mpv2_pos}
+    then gives the same algebraic BNT for $T$.
 \end{proof}
 
 \begin{theorem}[Horizontal canonical form implies vertical canonical form]

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -63,12 +63,16 @@ is deliberately source-faithful.
 - **Sources:** arXiv:1606.00608,
   `Papers/1606.00608/MPDO-22-12-17-2.tex:271-274`, and arXiv:2011.12127,
   Definition 4.2, `Papers/2011.12127/TN-Review-main.tex:1846-1850`.
-- **Sanctioned bridges:** use `MPSTensor.IsNormalTensor.isNormal` block by block
-  when `[NeZero (dim j)]` is available. There is no public equivalence between
-  the two BNT structures.
-- **Caveat:** their block index packaging also differs: the CPSV predicate uses
-  a sigma type of varying dimensions, whereas `IsBNT` takes an explicit
-  dimension family. Do not treat them as definitional aliases.
+- **Sanctioned bridges:**
+  `MPSTensor.IsCPSVBasisOfNormalTensors.blocks_dim_pos` derives the positive
+  block dimensions needed by `MPSTensor.IsNormalTensor.isNormal`, and
+  `MPSTensor.IsCPSVBasisOfNormalTensors.isBNT` then forgets the spectral
+  normality data to produce `MPSTensor.IsBNT`.
+- **Caveat:** this is a one-way implication, not an equivalence. Their block
+  index packaging also differs: the CPSV predicate uses a sigma type of varying
+  dimensions, whereas `IsBNT` takes an explicit dimension family. Algebraic
+  eventual block injectivity does not recover spectral-radius-one normalization
+  or peripheral-spectrum data. Do not treat the predicates as aliases.
 
 ## Primitivity
 
@@ -400,6 +404,10 @@ model different levels of data and different sources.
 - **Source:** arXiv:1606.00608 §II, lines 271--301, and arXiv:2011.12127
   Definition 4.2 and two-layer display, lines 1846--1884.
 - **Sanctioned bridges:**
+  `MPSTensor.IsBNTCanonicalForm.basis_isNormal` projects algebraic normality of
+  each basis block, and `MPSTensor.IsBNTCanonicalForm.isBNT` forgets the sector
+  weights and canonical-form data to produce the algebraic basis predicate.
+  Further bridges are
   `MPSTensor.SectorDecomposition.IsBNTCanonicalForm.blockTensor`,
   `MPSTensor.SectorDecomposition.IsBNTCanonicalForm.reindexPhysical`, and the
   supplier declarations


### PR DESCRIPTION
Advances #4520.

Adds a sanctioned one-way bridge module for the three basis-of-normal-tensors carriers and migrates the first consumers. The public implications are deliberately one-way: CPSV basis data forgets to `IsBNT`; positive-length state equality transports `IsBNT`; and paper-BNT canonical-form data forgets to `IsBNT`. No false equivalence between `IsNormal` and `IsNormalTensor` is claimed.

Consumers in source blocking, vertical BNT construction/canonical form, and residual isometry now use the shared bridges. Canonical-form documentation and the glossary record the supported implications and missing converses.

Verification (without recreating Mathlib caches): native diagnostics are clean on all six changed leaf files; no new `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`; no debug commands; `git diff --check` clean.

This completes the issue’s first bridge PR, but does not close #4520: long-term carrier selection and wider migration remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and proof relocation with no new axioms or semantic equivalence claims; API change is mainly dropping an explicit dimension hypothesis where it is now inferred from CPSV BNT data.
> 
> **Overview**
> Introduces **`TNLean.MPS.BNT.Bridge`** as the shared place for **one-way** links among the three basis-of-normal-tensors predicates: CPSV spectral **`IsCPSVBasisOfNormalTensors`**, algebraic **`IsBNT`**, and sector **`IsBNTCanonicalForm`**.
> 
> The module adds **`blocks_dim_pos`** and **`isBNT`** from CPSV data, **`IsBNT.of_sameMPV₂Pos`** to transport an algebraic BNT along positive-length MPV equality, and **`basis_isNormal`** / **`isBNT`** projections from canonical form. Docs and the glossary state explicitly that **no converses** are claimed (spectral normality is not recovered from algebraic BNT alone).
> 
> **Consumers** import the bridge instead of duplicating proofs: **`SourceBNTBlocking`** drops its local positive-dimension lemma; **`VerticalBNTConstruction`** shortens vertical grouped BNT by deriving bond positivity from the spectral hypothesis and chaining **`isBNT`** with MPV transport (so **`hdimPos`** is no longer a separate argument); **`ResidualIsometry`** uses **`hCF.basis_isNormal`** from the bridge. Blueprint chapters and **`docs/glossary.md`** record the new lemmas and supported implications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f621308ccb017fafb764346143342ae3ae8beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->