### PR TITLE
refactor(PEPS): extract configuration calculus

### DIFF
--- a/TNLean/PEPS.lean
+++ b/TNLean/PEPS.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.PEPS.Blocking
 import TNLean.PEPS.CoherentFrameInstance
 import TNLean.PEPS.CoherentFrameInstance2
+import TNLean.PEPS.ConfigurationCalculus
 import TNLean.PEPS.CycleArcRegion
 import TNLean.PEPS.CycleBlockingData
 import TNLean.PEPS.CycleFundamentalTheorem

--- a/TNLean/PEPS/ConfigurationCalculus.lean
+++ b/TNLean/PEPS/ConfigurationCalculus.lean
@@ -38,13 +38,11 @@ noncomputable def virtualConfigSplit (A : Tensor G d) (select : Edge G → Prop)
   Equiv.piEquivPiSubtypeProd select fun e => Fin (A.bondDim e)
 
 omit [Fintype V] in
-@[simp]
 theorem virtualConfigSplit_fst_apply (A : Tensor G d) (select : Edge G → Prop)
     [DecidablePred select] (ζ : VirtualConfig A) (e : {e : Edge G // select e}) :
     (virtualConfigSplit A select ζ).1 e = ζ e.1 := rfl
 
 omit [Fintype V] in
-@[simp]
 theorem virtualConfigSplit_snd_apply (A : Tensor G d) (select : Edge G → Prop)
     [DecidablePred select] (ζ : VirtualConfig A) (e : {e : Edge G // ¬ select e}) :
     (virtualConfigSplit A select ζ).2 e = ζ e.1 := rfl
@@ -55,7 +53,6 @@ noncomputable def virtualConfigCongr (A B : Tensor G d) (h : A.bondDim = B.bondD
   Equiv.piCongrRight fun e => finCongr (congrFun h e)
 
 omit [Fintype V] in
-@[simp]
 theorem virtualConfigCongr_apply (A B : Tensor G d) (h : A.bondDim = B.bondDim)
     (ζ : VirtualConfig A) (e : Edge G) :
     virtualConfigCongr A B h ζ e = Fin.cast (congrFun h e) (ζ e) := rfl
@@ -64,7 +61,7 @@ theorem virtualConfigCongr_apply (A B : Tensor G d) (h : A.bondDim = B.bondDim)
 
 /-- Merge two virtual configurations, reading `left` where `select` holds and `right`
 elsewhere. The fibers may depend on the selected edge, as virtual bond dimensions do. -/
-noncomputable abbrev mergeVirtualConfig (A : Tensor G d) (select : Edge G → Prop)
+noncomputable def mergeVirtualConfig (A : Tensor G d) (select : Edge G → Prop)
     [DecidablePred select] (left right : VirtualConfig A) : VirtualConfig A :=
   fun e => if select e then left e else right e
 
@@ -83,14 +80,12 @@ theorem mergeVirtualConfig_of_neg (A : Tensor G d) (select : Edge G → Prop)
   simp [mergeVirtualConfig, he]
 
 omit [Fintype V] in
-@[simp]
 theorem mergeVirtualConfig_self (A : Tensor G d) (select : Edge G → Prop)
     [DecidablePred select] (ζ : VirtualConfig A) : mergeVirtualConfig A select ζ ζ = ζ := by
   ext e
   by_cases he : select e <;> simp [mergeVirtualConfig, he]
 
 omit [Fintype V] in
-@[simp]
 theorem virtualConfigSplit_mergeVirtualConfig (A : Tensor G d) (select : Edge G → Prop)
     [DecidablePred select] (left right : VirtualConfig A) :
     virtualConfigSplit A select (mergeVirtualConfig A select left right) =

--- a/TNLean/PEPS/ConfigurationCalculus.lean
+++ b/TNLean/PEPS/ConfigurationCalculus.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.PEPS.NormalFundamentalTheorem
+import TNLean.PEPS.RegionBlock.Basic
 
 /-!
 # Piecewise calculus for PEPS virtual configurations
@@ -13,10 +13,9 @@ configurations. Given a predicate on edges, `mergeVirtualConfig` reads one confi
 where the predicate holds and another configuration elsewhere. The region-specific
 `regionMerge` specializes this operation to the edges incident to a region.
 
-The vertex-product lemmas are included here so that insertion and coarse-blocking arguments
-can share the same configuration calculus without an import cycle. The final lemma packages
-the common step that groups a finite sum by merged configuration and collapses fibers of
-constant cardinality.
+The vertex-product lemmas compare products before and after merging configurations. The
+final lemma groups a finite sum by its merged configuration and collapses fibers of constant
+cardinality.
 -/
 
 open scoped BigOperators
@@ -65,7 +64,7 @@ theorem virtualConfigCongr_apply (A B : Tensor G d) (h : A.bondDim = B.bondDim)
 
 /-- Merge two virtual configurations, reading `left` where `select` holds and `right`
 elsewhere. The fibers may depend on the selected edge, as virtual bond dimensions do. -/
-noncomputable def mergeVirtualConfig (A : Tensor G d) (select : Edge G → Prop)
+noncomputable abbrev mergeVirtualConfig (A : Tensor G d) (select : Edge G → Prop)
     [DecidablePred select] (left right : VirtualConfig A) : VirtualConfig A :=
   fun e => if select e then left e else right e
 

--- a/TNLean/PEPS/ConfigurationCalculus.lean
+++ b/TNLean/PEPS/ConfigurationCalculus.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.PEPS.NormalFundamentalTheorem
+
+/-!
+# Piecewise calculus for PEPS virtual configurations
+
+This file provides low-level operations for splitting, reindexing, and gluing virtual
+configurations. Given a predicate on edges, `mergeVirtualConfig` reads one configuration
+where the predicate holds and another configuration elsewhere. The region-specific
+`regionMerge` specializes this operation to the edges incident to a region.
+
+The vertex-product lemmas are included here so that insertion and coarse-blocking arguments
+can share the same configuration calculus without an import cycle. The final lemma packages
+the common step that groups a finite sum by merged configuration and collapses fibers of
+constant cardinality.
+-/
+
+open scoped BigOperators
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Split and reindex equivalences -/
+
+/-- Split a virtual configuration into its restrictions to the edges satisfying `select`
+and the edges not satisfying `select`. -/
+noncomputable def virtualConfigSplit (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] :
+    VirtualConfig A ≃
+      ((e : {e : Edge G // select e}) → Fin (A.bondDim e.1)) ×
+        ((e : {e : Edge G // ¬ select e}) → Fin (A.bondDim e.1)) :=
+  Equiv.piEquivPiSubtypeProd select fun e => Fin (A.bondDim e)
+
+omit [Fintype V] in
+@[simp]
+theorem virtualConfigSplit_fst_apply (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] (ζ : VirtualConfig A) (e : {e : Edge G // select e}) :
+    (virtualConfigSplit A select ζ).1 e = ζ e.1 := rfl
+
+omit [Fintype V] in
+@[simp]
+theorem virtualConfigSplit_snd_apply (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] (ζ : VirtualConfig A) (e : {e : Edge G // ¬ select e}) :
+    (virtualConfigSplit A select ζ).2 e = ζ e.1 := rfl
+
+/-- Reindex every virtual bond along equality of the bond-dimension families. -/
+noncomputable def virtualConfigCongr (A B : Tensor G d) (h : A.bondDim = B.bondDim) :
+    VirtualConfig A ≃ VirtualConfig B :=
+  Equiv.piCongrRight fun e => finCongr (congrFun h e)
+
+omit [Fintype V] in
+@[simp]
+theorem virtualConfigCongr_apply (A B : Tensor G d) (h : A.bondDim = B.bondDim)
+    (ζ : VirtualConfig A) (e : Edge G) :
+    virtualConfigCongr A B h ζ e = Fin.cast (congrFun h e) (ζ e) := rfl
+
+/-! ### Piecewise merge -/
+
+/-- Merge two virtual configurations, reading `left` where `select` holds and `right`
+elsewhere. The fibers may depend on the selected edge, as virtual bond dimensions do. -/
+noncomputable def mergeVirtualConfig (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] (left right : VirtualConfig A) : VirtualConfig A :=
+  fun e => if select e then left e else right e
+
+omit [Fintype V] in
+@[simp]
+theorem mergeVirtualConfig_of_pos (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] (left right : VirtualConfig A) {e : Edge G} (he : select e) :
+    mergeVirtualConfig A select left right e = left e := by
+  simp [mergeVirtualConfig, he]
+
+omit [Fintype V] in
+@[simp]
+theorem mergeVirtualConfig_of_neg (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] (left right : VirtualConfig A) {e : Edge G} (he : ¬ select e) :
+    mergeVirtualConfig A select left right e = right e := by
+  simp [mergeVirtualConfig, he]
+
+omit [Fintype V] in
+@[simp]
+theorem mergeVirtualConfig_self (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] (ζ : VirtualConfig A) : mergeVirtualConfig A select ζ ζ = ζ := by
+  ext e
+  by_cases he : select e <;> simp [mergeVirtualConfig, he]
+
+omit [Fintype V] in
+@[simp]
+theorem virtualConfigSplit_mergeVirtualConfig (A : Tensor G d) (select : Edge G → Prop)
+    [DecidablePred select] (left right : VirtualConfig A) :
+    virtualConfigSplit A select (mergeVirtualConfig A select left right) =
+      (fun e : {e : Edge G // select e} => left e.1,
+        fun e : {e : Edge G // ¬ select e} => right e.1) := by
+  apply Prod.ext
+  · funext e
+    exact mergeVirtualConfig_of_pos A select left right e.2
+  · funext e
+    exact mergeVirtualConfig_of_neg A select left right e.2
+
+omit [Fintype V] in
+/-- Reindexing virtual bonds commutes with a piecewise merge. -/
+theorem virtualConfigCongr_mergeVirtualConfig (A B : Tensor G d)
+    (h : A.bondDim = B.bondDim) (select : Edge G → Prop) [DecidablePred select]
+    (left right : VirtualConfig A) :
+    virtualConfigCongr A B h (mergeVirtualConfig A select left right) =
+      mergeVirtualConfig B select (virtualConfigCongr A B h left)
+        (virtualConfigCongr A B h right) := by
+  ext e
+  by_cases he : select e <;> simp [he]
+
+/-! ### Region specialization -/
+
+/-- Merge a pair of virtual configurations along a region: region-incident edges read the
+first configuration and all remaining edges read the second. -/
+noncomputable def regionMerge (A : Tensor G d) (R : Finset V)
+    (p : VirtualConfig A × VirtualConfig A) : VirtualConfig A :=
+  mergeVirtualConfig A (IsRegionIncidentEdge (G := G) R) p.1 p.2
+
+omit [Fintype V] in
+@[simp]
+theorem regionMerge_of_incident (A : Tensor G d) (R : Finset V)
+    (p : VirtualConfig A × VirtualConfig A) {e : Edge G}
+    (he : IsRegionIncidentEdge (G := G) R e) : regionMerge A R p e = p.1 e := by
+  exact mergeVirtualConfig_of_pos A _ _ _ he
+
+omit [Fintype V] in
+@[simp]
+theorem regionMerge_of_not_incident (A : Tensor G d) (R : Finset V)
+    (p : VirtualConfig A × VirtualConfig A) {e : Edge G}
+    (he : ¬ IsRegionIncidentEdge (G := G) R e) : regionMerge A R p e = p.2 e := by
+  exact mergeVirtualConfig_of_neg A _ _ _ he
+
+omit [Fintype V] in
+/-- The region vertex product reads the first input of `regionMerge`. -/
+theorem regionProd_eq_merge (A : Tensor G d) (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (p : VirtualConfig A × VirtualConfig A) :
+    (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => p.1 ie.1) (σ w)) =
+      ∏ w : {w : V // w ∈ R},
+        A.component w.1 (fun ie => regionMerge (G := G) A R p ie.1) (σ w) := by
+  classical
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  symm
+  apply regionMerge_of_incident
+  rcases ie.2 with hie | hie
+  · exact Or.inl (by rw [hie]; exact w.2)
+  · exact Or.inr (by rw [hie]; exact w.2)
+
+omit [Fintype V] in
+/-- A vertex product reads the second configuration through a region merge if the two
+configurations agree on every edge incident to both the merge region and the product region. -/
+theorem regionProd_p2_eq_merge_of_incident_agree (A : Tensor G d) (T B : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) B)
+    (p : VirtualConfig A × VirtualConfig A)
+    (hp : ∀ e : Edge G, IsRegionIncidentEdge (G := G) T e →
+      IsRegionIncidentEdge (G := G) B e → p.1 e = p.2 e) :
+    (∏ w : {w : V // w ∈ B}, A.component w.1 (fun ie => p.2 ie.1) (σ w)) =
+      ∏ w : {w : V // w ∈ B},
+        A.component w.1 (fun ie => regionMerge (G := G) A T p ie.1) (σ w) := by
+  classical
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  have hB : IsRegionIncidentEdge (G := G) B ie.1 := by
+    rcases ie.2 with hie | hie
+    · exact Or.inl (by rw [hie]; exact w.2)
+    · exact Or.inr (by rw [hie]; exact w.2)
+  by_cases hT : IsRegionIncidentEdge (G := G) T ie.1
+  · rw [regionMerge_of_incident A T p hT, hp ie.1 hT hB]
+  · rw [regionMerge_of_not_incident A T p hT]
+
+/-- The complement vertex product reads the second input of `regionMerge`, provided the two
+inputs agree on the boundary of the region. -/
+theorem complementProd_eq_merge (A : Tensor G d) (R : Finset V)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R))
+    (p : VirtualConfig A × VirtualConfig A)
+    (hp : regionBoundaryLabel (G := G) A R p.1 = regionBoundaryLabel (G := G) A R p.2) :
+    (∏ w : {w : V // w ∈ Finset.univ \ R},
+        A.component w.1 (fun ie => p.2 ie.1) (τ w)) =
+      ∏ w : {w : V // w ∈ Finset.univ \ R},
+        A.component w.1 (fun ie => regionMerge (G := G) A R p ie.1) (τ w) := by
+  apply regionProd_p2_eq_merge_of_incident_agree
+  intro e hR hcompl
+  have hbdry : IsRegionBoundaryEdge (G := G) R e := by
+    rcases hR with hR1 | hR2 <;> rcases hcompl with hc1 | hc2
+    · exact absurd hR1 (Finset.mem_sdiff.mp hc1).2
+    · exact Or.inl ⟨hR1, (Finset.mem_sdiff.mp hc2).2⟩
+    · exact Or.inr ⟨(Finset.mem_sdiff.mp hc1).2, hR2⟩
+    · exact absurd hR2 (Finset.mem_sdiff.mp hc2).2
+  exact congrFun hp ⟨e, hbdry⟩
+
+/-! ### Constant-cardinality fiber sums -/
+
+/-- Collapse a sum whose summand factors through a map to virtual configurations, when all
+fibers of that map on the indexing finset have the same cardinality. -/
+theorem sum_comp_of_config_fiber_card {A : Tensor G d} {ι M : Type*} [AddCommMonoid M]
+    (s : Finset ι) (merge : ι → VirtualConfig A) (n : ℕ)
+    (hcard : ∀ η : VirtualConfig A, (s.filter fun x => merge x = η).card = n)
+    (g : VirtualConfig A → M) :
+    (∑ x ∈ s, g (merge x)) = n • ∑ η : VirtualConfig A, g η := by
+  classical
+  rw [← Finset.sum_fiberwise s merge (fun x => g (merge x)), Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun η _ => ?_)
+  rw [Finset.sum_congr rfl (g := fun _ => g η)
+      (fun x hx => by rw [Finset.mem_filter] at hx; rw [hx.2]),
+    Finset.sum_const, hcard η]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/ConfigurationCalculus.lean
+++ b/TNLean/PEPS/ConfigurationCalculus.lean
@@ -106,7 +106,11 @@ theorem virtualConfigCongr_mergeVirtualConfig (A B : Tensor G d)
       mergeVirtualConfig B select (virtualConfigCongr A B h left)
         (virtualConfigCongr A B h right) := by
   ext e
-  by_cases he : select e <;> simp [he]
+  by_cases he : select e
+  · simp only [virtualConfigCongr_apply, mergeVirtualConfig_of_pos A select left right he,
+      mergeVirtualConfig_of_pos B select _ _ he]
+  · simp only [virtualConfigCongr_apply, mergeVirtualConfig_of_neg A select left right he,
+      mergeVirtualConfig_of_neg B select _ _ he]
 
 /-! ### Region specialization -/
 

--- a/TNLean/PEPS/RegionBlock/Algebra.lean
+++ b/TNLean/PEPS/RegionBlock/Algebra.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.Insertion
-import TNLean.PEPS.ConfigurationCalculus
 import TNLean.PEPS.EdgeGaugeExtraction
 import Mathlib.Algebra.Algebra.Equiv
 

--- a/TNLean/PEPS/RegionBlock/Algebra.lean
+++ b/TNLean/PEPS/RegionBlock/Algebra.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.Insertion
+import TNLean.PEPS.ConfigurationCalculus
 import TNLean.PEPS.EdgeGaugeExtraction
 import Mathlib.Algebra.Algebra.Equiv
 

--- a/TNLean/PEPS/RegionBlock/Basic.lean
+++ b/TNLean/PEPS/RegionBlock/Basic.lean
@@ -77,7 +77,7 @@ theorem isRegionBoundaryEdge_of_disjoint_incident (S T : Finset V)
 omit [Fintype V] [DecidableRel G.Adj] in
 /-- A boundary edge of `R` has at least one endpoint in `R`. -/
 theorem isRegionBoundaryEdge_touches (R : Finset V) {f : Edge G}
-    (hf : IsRegionBoundaryEdge (G := G) R f) : f.1.1 ∈ R ∨ f.1.2 ∈ R := by
+    (hf : IsRegionBoundaryEdge (G := G) R f) : IsRegionIncidentEdge (G := G) R f := by
   rcases hf with ⟨h1, _⟩ | ⟨_, h2⟩
   · exact Or.inl h1
   · exact Or.inr h2

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -132,11 +132,10 @@ two configurations to coincide. -/
 
 /-- **The three-way merge.** The global virtual configuration reading red-incident
 edges from `ζr`, the remaining blue-incident edges from `ζb`, and the rest from `ζc`. -/
-def triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+noncomputable def triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     (ζr ζb ζc : VirtualConfig A) : VirtualConfig A :=
-  fun e => if IsRegionIncidentEdge (G := G) F.frame.red e then ζr e
-    else if IsRegionIncidentEdge (G := G) F.frame.blue e then ζb e
-    else ζc e
+  mergeVirtualConfig A (IsRegionIncidentEdge (G := G) F.frame.red) ζr
+    (mergeVirtualConfig A (IsRegionIncidentEdge (G := G) F.frame.blue) ζb ζc)
 
 omit [DecidableEq V] in
 /-- The red vertex product reads the merge unchanged: red-incident edges read `ζr`. -/
@@ -152,7 +151,7 @@ theorem redProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     rcases ie.2 with hie | hie
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
-  rw [triMerge, if_pos hrinc]
+  rw [triMerge, mergeVirtualConfig, if_pos hrinc]
 
 /-- The blue vertex product reads the merge unchanged: a blue-incident edge that is
 also red-incident is a red-to-blue crossing edge, where the agreement coincides. -/
@@ -168,10 +167,10 @@ theorem blueProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     rcases ie.2 with hie | hie
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
-  rw [triMerge]
   by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
-  · rw [if_pos hr]; exact (h.rb F (isCrossing_rb_of_incident F hP hr hbinc)).symm
-  · rw [if_neg hr, if_pos hbinc]
+  · simp [triMerge, mergeVirtualConfig, hr, if_pos]
+    exact (h.rb F (isCrossing_rb_of_incident F hP hr hbinc)).symm
+  · simp [triMerge, mergeVirtualConfig, hr, hbinc, if_pos, if_neg]
 
 /-- The complement vertex product reads the merge unchanged: a complement-incident
 edge that is red-incident is a red-to-complement crossing edge, and one that is
@@ -189,13 +188,13 @@ theorem complProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     rcases ie.2 with hie | hie
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
-  rw [triMerge]
   by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
-  · rw [if_pos hr]; exact (h.rc F (isCrossing_rc_of_incident F hP hr hcinc)).symm
-  · rw [if_neg hr]
-    by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue ie.1
-    · rw [if_pos hb]; exact (h.bc F (isCrossing_bc_of_incident F hP hb hcinc)).symm
-    · rw [if_neg hb]
+  · simp [triMerge, mergeVirtualConfig, hr, if_pos]
+    exact (h.rc F (isCrossing_rc_of_incident F hP hr hcinc)).symm
+  · by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue ie.1
+    · simp [triMerge, mergeVirtualConfig, hr, hb, if_pos, if_neg]
+      exact (h.bc F (isCrossing_bc_of_incident F hP hb hcinc)).symm
+    · simp [triMerge, mergeVirtualConfig, hr, hb, if_neg]
 
 /-! ### The assembled physical configuration
 
@@ -433,7 +432,7 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
         isRegionBoundaryEdge_touches (G := G) F.frame.complement g.2.2
       rw [dif_pos hb, dif_pos hc]
     · funext e
-      simp only [triMerge, triFiberTriple]
+      simp only [triMerge, mergeVirtualConfig, triFiberTriple]
       by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
       · rw [if_pos hr, dif_pos hr]
       · rw [if_neg hr]
@@ -450,28 +449,32 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
       simp only [triFiberTriple, triFiberLegs]
       by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
       · rw [dif_pos hr]
-        have := hmerge' e; rw [triMerge, if_pos hr] at this; exact this.symm
+        have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, if_pos] at this; exact this.symm
       · rw [dif_neg hr]
     · funext e
       simp only [triFiberTriple, triFiberLegs]
       by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
       · rw [dif_pos hb]
         by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
-        · have := hmerge' e; rw [triMerge, if_pos hr] at this
+        · have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, if_pos] at this
           rw [← (hag.rb F (isCrossing_rb_of_incident F hP hr hb)), this]
-        · have := hmerge' e; rw [triMerge, if_neg hr, if_pos hb] at this; exact this.symm
+        · have := hmerge' e
+          simp [triMerge, mergeVirtualConfig, hr, hb, if_pos, if_neg] at this
+          exact this.symm
       · rw [dif_neg hb]
     · funext e
       simp only [triFiberTriple, triFiberLegs]
       by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
       · rw [dif_pos hc]
         by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
-        · have := hmerge' e; rw [triMerge, if_pos hr] at this
+        · have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, if_pos] at this
           rw [← (hag.rc F (isCrossing_rc_of_incident F hP hr hc)), this]
         · by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
-          · have := hmerge' e; rw [triMerge, if_neg hr, if_pos hb] at this
+          · have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, hb, if_pos, if_neg] at this
             rw [← (hag.bc F (isCrossing_bc_of_incident F hP hb hc)), this]
-          · have := hmerge' e; rw [triMerge, if_neg hr, if_neg hb] at this; exact this.symm
+          · have := hmerge' e
+            simp [triMerge, mergeVirtualConfig, hr, hb, if_neg] at this
+            exact this.symm
       · rw [dif_neg hc]
   · -- Reading the free indices of a reconstruction recovers them.
     intro legs _
@@ -533,17 +536,11 @@ theorem agreeingTripleSum_collapse (F : CoherentCoarseBlockingFrame (G := G) (d 
   rw [Finset.sum_congr rfl (fun t ht => agreeing_summand_eq F hP σr σb σc
     (by rw [Finset.mem_filter] at ht; exact ht.2))]
   -- Group by merged configuration, count each fiber, and reassemble the closed state.
-  conv_lhs => rw [← Finset.sum_fiberwise (Finset.univ.filter
-    (fun t : VirtualConfig A × VirtualConfig A × VirtualConfig A =>
-      TripleAgrees F t.1 t.2.1 t.2.2))
-    (fun t => triMerge F t.1 t.2.1 t.2.2)
-    (fun t => triMergedSummand F σr σb σc (triMerge F t.1 t.2.1 t.2.2))]
-  rw [← sum_triMergedSummand F hP σr σb σc, Finset.smul_sum]
-  refine Finset.sum_congr rfl (fun η _ => ?_)
-  rw [Finset.filter_filter,
-    Finset.sum_congr rfl (g := fun _ => triMergedSummand F σr σb σc η)
-      (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
-    Finset.sum_const, triFiber_card F hP η]
+  rw [← sum_triMergedSummand F hP σr σb σc]
+  apply sum_comp_of_config_fiber_card
+  intro η
+  simpa only [Finset.filter_filter, Finset.mem_univ, true_and] using
+    triFiber_card F hP η
 
 open scoped Classical in
 /-- **The global fiber-collapse bijection.** The closed-state coefficient of the coarse

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.CoarseThreeSite4
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # The three-region merge collapse for the normal PEPS theorem
@@ -151,7 +152,7 @@ theorem redProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     rcases ie.2 with hie | hie
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
-  rw [triMerge, mergeVirtualConfig, if_pos hrinc]
+  rw [triMerge, mergeVirtualConfig_of_pos A _ ζr _ hrinc]
 
 /-- The blue vertex product reads the merge unchanged: a blue-incident edge that is
 also red-incident is a red-to-blue crossing edge, where the agreement coincides. -/
@@ -168,9 +169,9 @@ theorem blueProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
   by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
-  · simp [triMerge, mergeVirtualConfig, hr, if_pos]
+  · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr]
     exact (h.rb F (isCrossing_rb_of_incident F hP hr hbinc)).symm
-  · simp [triMerge, mergeVirtualConfig, hr, hbinc, if_pos, if_neg]
+  · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hbinc]
 
 /-- The complement vertex product reads the merge unchanged: a complement-incident
 edge that is red-incident is a red-to-complement crossing edge, and one that is
@@ -189,12 +190,12 @@ theorem complProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
   by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
-  · simp [triMerge, mergeVirtualConfig, hr, if_pos]
+  · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr]
     exact (h.rc F (isCrossing_rc_of_incident F hP hr hcinc)).symm
   · by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue ie.1
-    · simp [triMerge, mergeVirtualConfig, hr, hb, if_pos, if_neg]
+    · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb]
       exact (h.bc F (isCrossing_bc_of_incident F hP hb hcinc)).symm
-    · simp [triMerge, mergeVirtualConfig, hr, hb, if_neg]
+    · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb]
 
 /-! ### The assembled physical configuration
 
@@ -432,13 +433,14 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
         isRegionBoundaryEdge_touches (G := G) F.frame.complement g.2.2
       rw [dif_pos hb, dif_pos hc]
     · funext e
-      simp only [triMerge, mergeVirtualConfig, triFiberTriple]
+      simp only [triMerge, triFiberTriple]
       by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
-      · rw [if_pos hr, dif_pos hr]
-      · rw [if_neg hr]
+      · rw [mergeVirtualConfig_of_pos A _ _ _ hr, dif_pos hr]
+      · rw [mergeVirtualConfig_of_neg A _ _ _ hr]
         by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
-        · rw [if_pos hb, dif_pos hb]
-        · rw [if_neg hb, dif_pos (complIncident_of_not_red_not_blue F hP hr hb)]
+        · rw [mergeVirtualConfig_of_pos A _ _ _ hb, dif_pos hb]
+        · rw [mergeVirtualConfig_of_neg A _ _ _ hb,
+            dif_pos (complIncident_of_not_red_not_blue F hP hr hb)]
   · -- Reconstructing from the free indices of a fiber triple recovers the triple.
     intro p hp
     simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hp
@@ -449,17 +451,20 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
       simp only [triFiberTriple, triFiberLegs]
       by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
       · rw [dif_pos hr]
-        have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, if_pos] at this; exact this.symm
+        have := hmerge' e
+        simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr] at this
+        exact this.symm
       · rw [dif_neg hr]
     · funext e
       simp only [triFiberTriple, triFiberLegs]
       by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
       · rw [dif_pos hb]
         by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
-        · have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, if_pos] at this
+        · have := hmerge' e
+          simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr] at this
           rw [← (hag.rb F (isCrossing_rb_of_incident F hP hr hb)), this]
         · have := hmerge' e
-          simp [triMerge, mergeVirtualConfig, hr, hb, if_pos, if_neg] at this
+          simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb] at this
           exact this.symm
       · rw [dif_neg hb]
     · funext e
@@ -467,13 +472,15 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
       by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
       · rw [dif_pos hc]
         by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
-        · have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, if_pos] at this
+        · have := hmerge' e
+          simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr] at this
           rw [← (hag.rc F (isCrossing_rc_of_incident F hP hr hc)), this]
         · by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
-          · have := hmerge' e; simp [triMerge, mergeVirtualConfig, hr, hb, if_pos, if_neg] at this
+          · have := hmerge' e
+            simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb] at this
             rw [← (hag.bc F (isCrossing_bc_of_incident F hP hb hc)), this]
           · have := hmerge' e
-            simp [triMerge, mergeVirtualConfig, hr, hb, if_neg] at this
+            simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb] at this
             exact this.symm
       · rw [dif_neg hc]
   · -- Reading the free indices of a reconstruction recovers them.

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite5.lean
@@ -169,9 +169,10 @@ theorem blueProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
   by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
-  · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr]
+  · rw [triMerge, mergeVirtualConfig_of_pos A _ _ _ hr]
     exact (h.rb F (isCrossing_rb_of_incident F hP hr hbinc)).symm
-  · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hbinc]
+  · rw [triMerge, mergeVirtualConfig_of_neg A _ _ _ hr,
+      mergeVirtualConfig_of_pos A _ _ _ hbinc]
 
 /-- The complement vertex product reads the merge unchanged: a complement-incident
 edge that is red-incident is a red-to-complement crossing edge, and one that is
@@ -190,12 +191,14 @@ theorem complProd_triMerge (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
     · exact Or.inl (by rw [hie]; exact w.2)
     · exact Or.inr (by rw [hie]; exact w.2)
   by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red ie.1
-  · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr]
+  · rw [triMerge, mergeVirtualConfig_of_pos A _ _ _ hr]
     exact (h.rc F (isCrossing_rc_of_incident F hP hr hcinc)).symm
   · by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue ie.1
-    · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb]
+    · rw [triMerge, mergeVirtualConfig_of_neg A _ _ _ hr,
+        mergeVirtualConfig_of_pos A _ _ _ hb]
       exact (h.bc F (isCrossing_bc_of_incident F hP hb hcinc)).symm
-    · simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb]
+    · rw [triMerge, mergeVirtualConfig_of_neg A _ _ _ hr,
+        mergeVirtualConfig_of_neg A _ _ _ hb]
 
 /-! ### The assembled physical configuration
 
@@ -452,7 +455,7 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
       by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
       · rw [dif_pos hr]
         have := hmerge' e
-        simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr] at this
+        rw [triMerge, mergeVirtualConfig_of_pos A _ _ _ hr] at this
         exact this.symm
       · rw [dif_neg hr]
     · funext e
@@ -461,10 +464,11 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
       · rw [dif_pos hb]
         by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
         · have := hmerge' e
-          simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr] at this
+          rw [triMerge, mergeVirtualConfig_of_pos A _ _ _ hr] at this
           rw [← (hag.rb F (isCrossing_rb_of_incident F hP hr hb)), this]
         · have := hmerge' e
-          simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb] at this
+          rw [triMerge, mergeVirtualConfig_of_neg A _ _ _ hr,
+            mergeVirtualConfig_of_pos A _ _ _ hb] at this
           exact this.symm
       · rw [dif_neg hb]
     · funext e
@@ -473,14 +477,16 @@ theorem triFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
       · rw [dif_pos hc]
         by_cases hr : IsRegionIncidentEdge (G := G) F.frame.red e
         · have := hmerge' e
-          simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr] at this
+          rw [triMerge, mergeVirtualConfig_of_pos A _ _ _ hr] at this
           rw [← (hag.rc F (isCrossing_rc_of_incident F hP hr hc)), this]
         · by_cases hb : IsRegionIncidentEdge (G := G) F.frame.blue e
           · have := hmerge' e
-            simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb] at this
+            rw [triMerge, mergeVirtualConfig_of_neg A _ _ _ hr,
+              mergeVirtualConfig_of_pos A _ _ _ hb] at this
             rw [← (hag.bc F (isCrossing_bc_of_incident F hP hb hc)), this]
           · have := hmerge' e
-            simp [triMerge, mergeVirtualConfig_of_pos, mergeVirtualConfig_of_neg, hr, hb] at this
+            rw [triMerge, mergeVirtualConfig_of_neg A _ _ _ hr,
+              mergeVirtualConfig_of_neg A _ _ _ hb] at this
             exact this.symm
       · rw [dif_neg hc]
   · -- Reading the free indices of a reconstruction recovers them.

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.CoarseThreeSite8
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # The relaxed-triple merge collapse for the normal PEPS theorem

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -395,19 +395,16 @@ theorem hostMergeFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A
       rw [dif_pos hc, dif_pos hg, dif_pos hc]
     · -- The reconstruction merges back to `η`.
       funext e
-      simp only [hostMerge, regionMerge, hostFiberPair]
+      simp only [hostFiberPair]
       by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
-      · rw [if_pos hc, dif_pos hc]
-      · rw [if_neg hc, dif_neg hc]
+      · rw [hostMerge_complement F hc, dif_pos hc]
+      · rw [hostMerge_not_complement F hc, dif_neg hc]
   · -- Reconstructing from the free indices of a fiber pair recovers the pair.
     intro p hp
     simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hp
     obtain ⟨hagree, hmerge⟩ := hp
-    -- `hostMerge p.1 p.2 = regionMerge complement (p.2, p.1)`: complement-incident reads
-    -- `p.2`, the rest `p.1`.
-    have hmerge' : ∀ e : Edge G,
-        (if IsRegionIncidentEdge (G := G) F.frame.complement e then p.2 e else p.1 e) = η e := by
-      intro e; have := congrFun hmerge e; rwa [hostMerge, regionMerge] at this
+    have hmerge' : ∀ e : Edge G, hostMerge F p.1 p.2 e = η e :=
+      fun e => congrFun hmerge e
     refine Prod.ext ?_ ?_
     · -- First component (the blue configuration `p.1`).
       funext e
@@ -417,17 +414,22 @@ theorem hostMergeFiber_card (F : CoherentCoarseBlockingFrame (G := G) (d := d) A
         by_cases hbc : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement e
         · -- On a blue-to-complement crossing the agreement and merge force `p.1 e = η e`.
           rw [dif_pos hbc]
-          have h1 := hmerge' e; rw [if_pos hc] at h1
+          have h1 := hmerge' e
+          rw [hostMerge_complement F hc] at h1
           rw [hagree e hbc, h1]
         · rw [dif_neg hbc]
       · rw [dif_neg hc]
-        have := hmerge' e; rw [if_neg hc] at this; exact this.symm
+        have := hmerge' e
+        rw [hostMerge_not_complement F hc] at this
+        exact this.symm
     · -- Second component (the complement configuration `p.2`).
       funext e
       simp only [hostFiberPair, hostFiberLegs]
       by_cases hc : IsRegionIncidentEdge (G := G) F.frame.complement e
       · rw [dif_pos hc]
-        have := hmerge' e; rw [if_pos hc] at this; exact this.symm
+        have := hmerge' e
+        rw [hostMerge_complement F hc] at this
+        exact this.symm
       · rw [dif_neg hc]
   · -- Reading the free indices of a reconstruction recovers them.
     intro legs _

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite9.lean
@@ -459,15 +459,10 @@ theorem hostMerge_fiberwise_collapse (F : CoherentCoarseBlockingFrame (G := G) (
         HostPairAgrees F p.1 p.2), g (hostMerge F p.1 p.2)) =
       hostMergeFiberProd F • ∑ η : VirtualConfig A, g η := by
   classical
-  rw [← Finset.sum_fiberwise (Finset.univ.filter
-      (fun p : VirtualConfig A × VirtualConfig A => HostPairAgrees F p.1 p.2))
-    (fun p => hostMerge F p.1 p.2) (fun p => g (hostMerge F p.1 p.2))]
-  rw [Finset.smul_sum]
-  refine Finset.sum_congr rfl (fun η _ => ?_)
-  rw [Finset.filter_filter,
-    Finset.sum_congr rfl (g := fun _ => g η)
-      (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
-    Finset.sum_const, hostMergeFiber_card F η]
+  apply sum_comp_of_config_fiber_card
+  intro η
+  simpa only [Finset.filter_filter, Finset.mem_univ, true_and] using
+    hostMergeFiber_card F η
 
 /-! ### The relaxed-triple merge collapse
 

--- a/TNLean/PEPS/RegionBlock/Recovery.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.Algebra
+import TNLean.PEPS.ConfigurationCalculus
 import TNLean.PEPS.NormalFundamentalTheorem
 
 /-!

--- a/TNLean/PEPS/RegionBlock/Recovery.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.Algebra
-import TNLean.PEPS.NormalFundamentalTheorem
 
 /-!
 # Region realization toward the region insertion transfer
@@ -218,94 +217,6 @@ noncomputable def regionInteriorBondProd (A : Tensor G d) (R : Finset V) : ℕ :
   ∏ e ∈ Finset.univ.filter (fun e : Edge G => ¬ IsRegionBoundaryEdge (G := G) R e),
     A.bondDim e
 
-open scoped Classical in
-/-- Merge an agreeing pair of global virtual configurations into one global
-configuration: the region-incident edges read the first configuration, the
-remaining edges read the second. -/
-noncomputable def regionMerge (A : Tensor G d) (R : Finset V)
-    (p : VirtualConfig A × VirtualConfig A) : VirtualConfig A :=
-  fun e => if IsRegionIncidentEdge (G := G) R e then p.1 e else p.2 e
-
-omit [Fintype V] in
-/-- A region merge reads its first configuration on an edge incident to the region. -/
-theorem regionMerge_of_incident (A : Tensor G d) (R : Finset V)
-    (p : VirtualConfig A × VirtualConfig A) {e : Edge G}
-    (he : IsRegionIncidentEdge (G := G) R e) :
-    regionMerge (G := G) A R p e = p.1 e := by
-  rw [regionMerge, if_pos he]
-
-omit [Fintype V] in
-/-- A region merge reads its second configuration on an edge not incident to the region. -/
-theorem regionMerge_of_not_incident (A : Tensor G d) (R : Finset V)
-    (p : VirtualConfig A × VirtualConfig A) {e : Edge G}
-    (he : ¬ IsRegionIncidentEdge (G := G) R e) :
-    regionMerge (G := G) A R p e = p.2 e := by
-  rw [regionMerge, if_neg he]
-
-omit [Fintype V] in
-/-- The region vertex product reads the first configuration only through the
-region-incident edges, so it agrees with the merged configuration. -/
-theorem regionProd_eq_merge (A : Tensor G d) (R : Finset V)
-    (σ : RegionPhysicalConfig (V := V) (d := d) R)
-    (p : VirtualConfig A × VirtualConfig A) :
-    (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => p.1 ie.1) (σ w)) =
-      ∏ w : {w : V // w ∈ R},
-        A.component w.1 (fun ie => regionMerge (G := G) A R p ie.1) (σ w) := by
-  classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  -- An edge incident to `w ∈ R` is region-incident, where merge reads `p.1`.
-  have hinc : IsRegionIncidentEdge (G := G) R ie.1 := by
-    rcases ie.2 with hie | hie
-    · exact Or.inl (by rw [hie]; exact w.2)
-    · exact Or.inr (by rw [hie]; exact w.2)
-  rw [regionMerge_of_incident A R p hinc]
-
-omit [Fintype V] in
-/-- A vertex product reads the second configuration through a region merge if the two
-configurations agree on every edge incident to both the merge region and the product region. -/
-theorem regionProd_p2_eq_merge_of_incident_agree (A : Tensor G d) (T B : Finset V)
-    (σ : RegionPhysicalConfig (V := V) (d := d) B)
-    (p : VirtualConfig A × VirtualConfig A)
-    (hp : ∀ e : Edge G, IsRegionIncidentEdge (G := G) T e →
-      IsRegionIncidentEdge (G := G) B e → p.1 e = p.2 e) :
-    (∏ w : {w : V // w ∈ B}, A.component w.1 (fun ie => p.2 ie.1) (σ w)) =
-      ∏ w : {w : V // w ∈ B},
-        A.component w.1 (fun ie => regionMerge (G := G) A T p ie.1) (σ w) := by
-  classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  have hB : IsRegionIncidentEdge (G := G) B ie.1 := by
-    rcases ie.2 with hie | hie
-    · exact Or.inl (by rw [hie]; exact w.2)
-    · exact Or.inr (by rw [hie]; exact w.2)
-  by_cases hT : IsRegionIncidentEdge (G := G) T ie.1
-  · rw [regionMerge_of_incident A T p hT, hp ie.1 hT hB]
-  · rw [regionMerge_of_not_incident A T p hT]
-
-/-- The complement vertex product reads the second configuration only through the
-complement-incident edges, so it agrees with the merged configuration: on the
-edges internal to the complement `merge` reads `p.2` by definition, and on the
-boundary edges `p.1` and `p.2` agree. -/
-theorem complementProd_eq_merge (A : Tensor G d) (R : Finset V)
-    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R))
-    (p : VirtualConfig A × VirtualConfig A)
-    (hp : regionBoundaryLabel (G := G) A R p.1 = regionBoundaryLabel (G := G) A R p.2) :
-    (∏ w : {w : V // w ∈ Finset.univ \ R}, A.component w.1 (fun ie => p.2 ie.1) (τ w)) =
-      ∏ w : {w : V // w ∈ Finset.univ \ R},
-        A.component w.1 (fun ie => regionMerge (G := G) A R p ie.1) (τ w) := by
-  apply regionProd_p2_eq_merge_of_incident_agree
-  intro e hR hcompl
-  have hbdry : IsRegionBoundaryEdge (G := G) R e := by
-    rcases hR with hR1 | hR2 <;> rcases hcompl with hc1 | hc2
-    · exact absurd hR1 (Finset.mem_sdiff.mp hc1).2
-    · exact Or.inl ⟨hR1, (Finset.mem_sdiff.mp hc2).2⟩
-    · exact Or.inr ⟨(Finset.mem_sdiff.mp hc1).2, hR2⟩
-    · exact absurd hR2 (Finset.mem_sdiff.mp hc2).2
-  exact congrFun hp ⟨e, hbdry⟩
-
 /-! ### The cardinality collapse to the closed state coefficient
 
 Over each merged configuration `η` the agreeing pairs of an `η`-fiber are
@@ -379,11 +290,10 @@ theorem regionFiber_card (A : Tensor G d) (R : Finset V) (η : VirtualConfig A) 
         rw [dif_pos (incident_of_boundary (G := G) R f.2), dif_pos f.2]
       · -- The reconstructed pair merges back to `η`.
         funext e
-        simp only [regionMerge, regionFiberPair]
         by_cases hinc : IsRegionIncidentEdge (G := G) R e
-        · rw [if_pos hinc, dif_pos hinc]
-        · rw [if_neg hinc, dif_neg (not_boundary_of_not_incident (G := G) R hinc),
-            dif_neg hinc]
+        · simp [regionMerge, mergeVirtualConfig, regionFiberPair, hinc]
+        · simp [regionMerge, mergeVirtualConfig, regionFiberPair, hinc,
+            not_boundary_of_not_incident (G := G) R hinc]
     · -- Reconstructing from the free indices of a fiber pair recovers the pair.
       intro p hp
       simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hp
@@ -489,18 +399,11 @@ theorem stateCoeff_eq_regionComplement (A : Tensor G d) (R : Finset V)
           regionBoundaryLabel (G := G) A R p.1 = regionBoundaryLabel (G := G) A R p.2),
         regionMergedSummand (G := G) A R σ τ (regionMerge (G := G) A R p) from ?_]
   · -- Group the agreeing pairs by their merged configuration.
-    rw [← Finset.sum_fiberwise (Finset.univ.filter
-        (fun p : VirtualConfig A × VirtualConfig A =>
-          regionBoundaryLabel (G := G) A R p.1 = regionBoundaryLabel (G := G) A R p.2))
-      (fun p => regionMerge (G := G) A R p)
-      (fun p => regionMergedSummand (G := G) A R σ τ (regionMerge (G := G) A R p))]
-    -- On each fiber the merged summand is constant, with the bond product as count.
-    rw [← sum_regionMergedSummand (G := G) A R σ τ, Finset.smul_sum]
-    refine Finset.sum_congr rfl (fun η _ => ?_)
-    rw [Finset.filter_filter,
-      Finset.sum_congr rfl (g := fun _ => regionMergedSummand (G := G) A R σ τ η)
-        (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
-      Finset.sum_const, regionFiber_card (G := G) A R η]
+    rw [← sum_regionMergedSummand (G := G) A R σ τ]
+    apply sum_comp_of_config_fiber_card
+    intro η
+    simpa only [Finset.filter_filter, Finset.mem_univ, true_and] using
+      regionFiber_card (G := G) A R η
   · -- Each agreeing summand is the merged summand at the merged configuration.
     refine Finset.sum_congr rfl (fun p hp => ?_)
     rw [Finset.mem_filter] at hp

--- a/TNLean/PEPS/RegionBlock/Recovery.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery.lean
@@ -293,17 +293,17 @@ theorem regionFiber_card (A : Tensor G d) (R : Finset V) (η : VirtualConfig A) 
       · -- The reconstructed pair merges back to `η`.
         funext e
         by_cases hinc : IsRegionIncidentEdge (G := G) R e
-        · simp [regionMerge, mergeVirtualConfig, regionFiberPair, hinc]
-        · simp [regionMerge, mergeVirtualConfig, regionFiberPair, hinc,
-            not_boundary_of_not_incident (G := G) R hinc]
+        · rw [regionMerge_of_incident (G := G) A R _ hinc]
+          simp [regionFiberPair, hinc]
+        · rw [regionMerge_of_not_incident (G := G) A R _ hinc]
+          simp [regionFiberPair, hinc, not_boundary_of_not_incident (G := G) R hinc]
     · -- Reconstructing from the free indices of a fiber pair recovers the pair.
       intro p hp
       simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hp
       obtain ⟨hagree, hmerge⟩ := hp
       have hagree' : ∀ f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f},
           p.1 f.1 = p.2 f.1 := fun f => congrFun hagree f
-      have hmerge' : ∀ e : Edge G,
-          (if IsRegionIncidentEdge (G := G) R e then p.1 e else p.2 e) = η e :=
+      have hmerge' : ∀ e : Edge G, regionMerge (G := G) A R p e = η e :=
         fun e => congrFun hmerge e
       refine Prod.ext ?_ ?_
       · -- First configuration.
@@ -311,7 +311,9 @@ theorem regionFiber_card (A : Tensor G d) (R : Finset V) (η : VirtualConfig A) 
         simp only [regionFiberPair, regionFiberLegs]
         by_cases hinc : IsRegionIncidentEdge (G := G) R e
         · rw [dif_pos hinc]
-          have := hmerge' e; rw [if_pos hinc] at this; exact this.symm
+          have := hmerge' e
+          rw [regionMerge_of_incident (G := G) A R p hinc] at this
+          exact this.symm
         · rw [dif_neg hinc, if_neg hinc]
       · -- Second configuration.
         funext e
@@ -320,14 +322,17 @@ theorem regionFiber_card (A : Tensor G d) (R : Finset V) (η : VirtualConfig A) 
         · rw [dif_pos hb]
           -- On a boundary edge the agreement and the merge identity force `p.2 e = η e`.
           have hinc := incident_of_boundary (G := G) R hb
-          have h1 := hmerge' e; rw [if_pos hinc] at h1
+          have h1 := hmerge' e
+          rw [regionMerge_of_incident (G := G) A R p hinc] at h1
           have h2 := hagree' ⟨e, hb⟩
           rw [← h1, h2]
         · rw [dif_neg hb]
           by_cases hinc : IsRegionIncidentEdge (G := G) R e
           · rw [dif_pos hinc, if_pos hinc]
           · rw [dif_neg hinc]
-            have := hmerge' e; rw [if_neg hinc] at this; exact this.symm
+            have := hmerge' e
+            rw [regionMerge_of_not_incident (G := G) A R p hinc] at this
+            exact this.symm
     · -- Reading the free indices of a reconstruction recovers them.
       intro h _
       funext e

--- a/TNLean/PEPS/RegionBlock/Recovery.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.Algebra
+import TNLean.PEPS.NormalFundamentalTheorem
 
 /-!
 # Region realization toward the region insertion transfer

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.PEPS.RegionBlock.Recovery11
 import TNLean.PEPS.RegionBlock.BlockRangeCoincidence
 import TNLean.PEPS.NormalEdgeBlockingData
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # The three-block resonate engine for the normal PEPS Fundamental Theorem
@@ -436,10 +437,10 @@ theorem blueProd_eq_regionMerge_complement
   · have hbdry : IsRegionBoundaryEdge (G := G) D.complement ie :=
       isRegionBoundaryEdge_of_disjoint_incident (G := G) D.blue D.complement
         D.blue_disjoint_complement hie hinc
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 
 /-- On a boundary edge of the host `univ \ red`, the blue-side global configuration
 `p.2` agrees with the configuration merged along the complement block, provided the
@@ -484,10 +485,10 @@ theorem hostLabel_p2_eq_hostLabel_regionMerge_complement
         rcases hinc with hc1 | hc2
         · exact absurd hc1 h1notcompl
         · refine Or.inr ⟨h1notcompl, hc2⟩
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨f.1, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 
 open scoped Classical in
 /-- **The host-relative fiber cardinality.** Among the boundary-agreeing pairs of

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.ThreeBlockResonate
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # Three-block resonate engine: the middle strip and the endpoint inversions
@@ -225,10 +226,10 @@ theorem complProd_eq_regionMerge_blue
   · have hbdry : IsRegionBoundaryEdge (G := G) D.blue ie :=
       isRegionBoundaryEdge_of_disjoint_incident (G := G) D.complement D.blue
         D.blue_disjoint_complement.symm hie hinc
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 
 /-- On a boundary edge of the host `univ \ red`, the complement-side configuration
 `p.2` agrees with the configuration merged along the blue block, provided the pair
@@ -268,10 +269,10 @@ theorem hostLabel_p2_eq_hostLabel_regionMerge_blue
         rcases hinc with hb1 | hb2
         · exact absurd hb1 h1notblue
         · refine Or.inr ⟨h1notblue, hb2⟩
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨f.1, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 
 open scoped Classical in
 /-- **The host-relative blue fiber cardinality.** The blue mirror of

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.Recovery11
 import TNLean.PEPS.RegionBlock.BlockRangeCoincidence
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # The general union-of-injective-regions lemma for normal PEPS
@@ -265,10 +266,10 @@ theorem ThreeBlockGeometry.blueProd_eq_regionMerge_complement
   · have hbdry : IsRegionBoundaryEdge (G := G) g.complement ie :=
       isRegionBoundaryEdge_of_disjoint_incident (G := G) g.blue g.complement
         g.blue_disjoint_complement hie hinc
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 /-- On a boundary edge of the host `univ \ red`, the blue-side global configuration
 `p.2` agrees with the configuration merged along the complement block, provided the
 pair agrees on the complement boundary. A host boundary edge has one endpoint in
@@ -311,10 +312,10 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_complement
         rcases hinc with hc1 | hc2
         · exact absurd hc1 h1notcompl
         · refine Or.inr ⟨h1notcompl, hc2⟩
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨f.1, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 open scoped Classical in
 /-- **The host-relative fiber cardinality.** Among the boundary-agreeing pairs of
 global configurations whose blue-side host label is `bdry`, the fiber over a merged

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.RegionBlock.UnionInjectivityGeneral
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # The general union lemma: the blue-side fiber-collapse factorization
@@ -54,10 +55,10 @@ theorem ThreeBlockGeometry.complProd_eq_regionMerge_blue
   · have hbdry : IsRegionBoundaryEdge (G := G) g.blue ie :=
       isRegionBoundaryEdge_of_disjoint_incident (G := G) g.complement g.blue
         g.blue_disjoint_complement.symm hie hinc
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 
 /-- On a boundary edge of the host `univ \ red`, the complement-side configuration
 `p.2` agrees with the configuration merged along the blue block, provided the pair
@@ -96,10 +97,10 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_blue
         rcases hinc with hb1 | hb2
         · exact absurd hb1 h1notblue
         · refine Or.inr ⟨h1notblue, hb2⟩
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨f.1, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 open scoped Classical in
 /-- **The host-relative blue fiber cardinality.** The blue mirror of
 `threeBlockFiber_card`: among the blue-boundary-agreeing pairs whose complement-side

--- a/TNLean/PEPS/TorusWindowChain4.lean
+++ b/TNLean/PEPS/TorusWindowChain4.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.PEPS.TorusWindowChain3
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # Transitivity of the corner extension across nested regions
@@ -98,7 +99,7 @@ theorem regionBoundaryLabel_regionMerge_of_subset_left {T H : Finset V} (hHT : H
     rcases isRegionBoundaryEdge_touches (G := G) H f.2 with h1 | h2
     · exact Or.inl (hHT h1)
     · exact Or.inr (hHT h2)
-  rw [regionMerge, if_pos hinc]
+  rw [regionMerge_of_incident (G := G) A _ p hinc]
 
 /-- A boundary edge of the host `univ \ K` with `K ⊆ univ \ T`, read off the merge
 `regionMerge A T p`, equals the value of `p.2`, provided the pair agrees on the `T`-boundary.
@@ -138,10 +139,10 @@ theorem regionBoundaryLabel_regionMerge_compl_of_subset {T K : Finset V}
         rcases hinc with hc1 | hc2
         · exact absurd hc1 h1notT
         · exact Or.inr ⟨h1notT, hc2⟩
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨f.1, hbdry⟩
     simpa [regionBoundaryLabel] using this
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 
 omit [Fintype V] in
 /-- A vertex product over `B ⊆ T` reads `p.1` through the merge `regionMerge A T p`: edges
@@ -158,7 +159,7 @@ theorem regionProd_p1_eq_merge_of_subset {T B : Finset V} (hBT : B ⊆ T)
   intro ie hie
   have hinc : IsRegionIncidentEdge (G := G) T ie :=
     hie.elim (fun h => Or.inl (hBT h)) (fun h => Or.inr (hBT h))
-  rw [regionMerge, if_pos hinc]
+  rw [regionMerge_of_incident (G := G) A _ p hinc]
 
 /-- A vertex product over `B ⊆ univ \ T` reads `p.2` through the merge `regionMerge A T p`, given
 the pair agrees on the `T`-boundary: an edge incident to `B` either misses `T` (where the merge
@@ -182,10 +183,10 @@ theorem regionProd_p2_eq_merge_of_compl {T B : Finset V} (hBT : B ⊆ Finset.uni
   · have hbdry : IsRegionBoundaryEdge (G := G) T ie :=
       isRegionBoundaryEdge_of_disjoint_incident (G := G) (Finset.univ \ T) T
         Finset.sdiff_disjoint hcompl hinc
-    rw [regionMerge, if_pos hinc]
+    rw [regionMerge_of_incident (G := G) A _ p hinc]
     have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge, if_neg hinc]
+  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
 
 /-! ### The two-sub-block merge collapse -/
 

--- a/blueprint/src/chapter/ch24_peps_ft_foundations.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_foundations.tex
@@ -74,6 +74,109 @@ together with the local inverse it provides.
     the corresponding bond space of dimension $D_e$.
 \end{definition}
 
+\begin{definition}[Splitting and reindexing virtual configurations]
+    \label{def:peps_virtual_config_split_reindex}
+    \lean{TNLean.PEPS.virtualConfigSplit}
+    \lean{TNLean.PEPS.virtualConfigCongr}
+    \leanok
+    \uses{def:peps_virtual_config}
+    A predicate on the edges splits a virtual configuration canonically into
+    its restrictions to the selected and unselected edges.  An equality
+    between two bond-dimension families also induces a canonical reindexing
+    between their virtual configurations.
+\end{definition}
+
+\begin{theorem}[Evaluation laws for splitting and reindexing]
+    \label{thm:peps_virtual_config_split_reindex_apply}
+    \lean{TNLean.PEPS.virtualConfigSplit_fst_apply}
+    \lean{TNLean.PEPS.virtualConfigSplit_snd_apply}
+    \lean{TNLean.PEPS.virtualConfigCongr_apply}
+    \lean{TNLean.PEPS.virtualConfigSplit_mergeVirtualConfig}
+    \lean{TNLean.PEPS.virtualConfigCongr_mergeVirtualConfig}
+    \leanok
+    \uses{def:peps_virtual_config_split_reindex, def:peps_virtual_config_merge}
+    The two restrictions recover the original edge labels on their respective
+    domains.  Reindexing acts edgewise by the corresponding identification of
+    bond indices, commutes with piecewise merging, and splitting a piecewise
+    merge recovers its selected and unselected inputs.
+\end{theorem}
+\begin{proof}\leanok
+    Each identity follows by evaluating at an edge and distinguishing whether
+    that edge satisfies the selection predicate.
+\end{proof}
+
+\begin{definition}[Piecewise and regionwise merge of virtual configurations]
+    \label{def:peps_virtual_config_merge}
+    \lean{TNLean.PEPS.mergeVirtualConfig}
+    \lean{TNLean.PEPS.regionMerge}
+    \leanok
+    \uses{def:peps_virtual_config}
+    Given two virtual configurations and a predicate on edges, their
+    \emph{piecewise merge} reads the first configuration on selected edges and
+    the second configuration elsewhere.  For a vertex region, the
+    \emph{regionwise merge} selects precisely the edges incident to that
+    region.
+\end{definition}
+
+\begin{theorem}[Readback laws for merged configurations]
+    \label{thm:peps_virtual_config_merge_readback}
+    \lean{TNLean.PEPS.mergeVirtualConfig_of_pos}
+    \lean{TNLean.PEPS.mergeVirtualConfig_of_neg}
+    \lean{TNLean.PEPS.mergeVirtualConfig_self}
+    \lean{TNLean.PEPS.regionMerge_of_incident}
+    \lean{TNLean.PEPS.regionMerge_of_not_incident}
+    \leanok
+    \uses{def:peps_virtual_config_merge}
+    A piecewise merge reads the first input on a selected edge and the second
+    input on an unselected edge; merging a configuration with itself leaves it
+    unchanged.  In particular, a regionwise merge reads the first input on
+    region-incident edges and the second input on all remaining edges.
+\end{theorem}
+\begin{proof}\leanok
+    Evaluate the merge at an edge and use the defining alternative according
+    to whether the edge is selected.
+\end{proof}
+
+\begin{theorem}[Vertex products through a regionwise merge]
+    \label{thm:peps_region_merge_products}
+    \lean{TNLean.PEPS.regionProd_eq_merge}
+    \lean{TNLean.PEPS.regionProd_p2_eq_merge_of_incident_agree}
+    \lean{TNLean.PEPS.complementProd_eq_merge}
+    \leanok
+    \uses{def:peps_virtual_config_merge}
+    The vertex product on a region reads the first input of its regionwise
+    merge.  A product on a second region reads the second input whenever the
+    two configurations agree on edges incident to both regions.  Consequently,
+    agreement on the boundary of a region lets the complementary product read
+    the second input through the same merge.
+\end{theorem}
+\begin{proof}\leanok
+    Compare the local tensor entry at every vertex.  Each incident edge is
+    read from the prescribed input, while an edge incident to both regions is
+    handled by the assumed agreement; a boundary edge is exactly the
+    corresponding special case for a region and its complement.
+\end{proof}
+
+\begin{theorem}[Constant-cardinality fiber sum]
+    \label{thm:peps_config_fiber_sum}
+    \lean{TNLean.PEPS.sum_comp_of_config_fiber_card}
+    \leanok
+    \uses{def:peps_virtual_config}
+    Let a finite set map to the virtual configurations so that every fiber has
+    cardinality $n$.  For every function $g$ into an additive commutative
+    monoid,
+    \[
+        \sum_x g(m(x)) = n\mathbin{\boldsymbol{\cdot}}
+            \sum_{\eta} g(\eta),
+    \]
+    where the first sum ranges over the finite set and the second over all
+    virtual configurations.
+\end{theorem}
+\begin{proof}\leanok
+    Group the first sum by the value of $m$.  Each grouped summand is repeated
+    exactly $n$ times by the common fiber-cardinality hypothesis.
+\end{proof}
+
 \begin{definition}[PEPS state coefficient]
     \label{def:peps_stateCoeff}
     \lean{TNLean.PEPS.stateCoeff}


### PR DESCRIPTION
Advances #4522.

Introduces `TNLean.PEPS.ConfigurationCalculus` with reusable split, reindex, piecewise-merge, region-specialization, and finite-fiber-collapse lemmas. Migrates `Recovery`, `CoarseThreeSite5`, and `CoarseThreeSite9`; `hostMerge` remains only as a compatibility wrapper over canonical `regionMerge`.

The slice removes duplicated merge/readback/fiber-sum calculations and establishes the common calculus needed for the later region-parametrized insertion interface.

Verification (without recreating Mathlib caches): native diagnostics clean on all five changed files; no proof-integrity markers; no new oversized or numbered-module debt; project-local import graph has no cycle and all changed modules are reachable; `git diff --check` clean.

This is the first configuration-calculus slice and does not close #4522; insertion/transfer interfaces and further consumer migrations remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactor touches many modules on the normal PEPS fundamental-theorem proof path; behavior should be unchanged but any import or lemma rename mistake could break downstream proofs.
> 
> **Overview**
> Introduces **`TNLean.PEPS.ConfigurationCalculus`** as shared infrastructure for PEPS virtual configurations: **`mergeVirtualConfig`** / **`regionMerge`**, split and bond-dimension reindexing equivalences, vertex-product readback lemmas, and **`sum_comp_of_config_fiber_card`** for collapsing sums over equal-cardinality merge fibers.
> 
> **`regionMerge`** and its incident-edge lemmas are **removed from `Recovery.lean`** and live only in the new module; **`Recovery`**, coarse three-site files, resonate/union injectivity, and torus window chain code **import it** and call **`regionMerge_of_incident`** / **`regionMerge_of_not_incident`** instead of unfolding `if` merges. **`triMerge`** is expressed as nested **`mergeVirtualConfig`**; **`hostMerge`** is **`regionMerge` along the complement block**. Repeated fiber-collapse proof blocks are replaced by **`sum_comp_of_config_fiber_card`** plus existing fiber-cardinality lemmas.
> 
> **`isRegionBoundaryEdge_touches`** now concludes **`IsRegionIncidentEdge`** (not endpoint membership). The PEPS aggregator and blueprint chapter document the new definitions and theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504a08fe5783dc4a094f0c0a03a4ae2a1edaa43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->