### PR TITLE
refactor(MPS): compress cyclic sectors by isometry

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -102,20 +102,16 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
         simp only [Matrix.mul_assoc]
       _ = P * A i * P := by rw [hV_range]
       _ = A i := hSupp i
+  have hPV : P * V = V := by
+    rw [← hV_range, Matrix.mul_assoc, hV_iso, Matrix.mul_one]
   have hIntertwineLetter : ∀ i : Fin d, A i * V = V * C i := by
     intro i
     calc
       A i * V = (P * A i * P) * V := by rw [hSupp i]
-      _ = (V * Vᴴ) * A i * (V * Vᴴ) * V := by rw [hV_range]
-      _ = ((V * Vᴴ) * A i * (V * Vᴴ)) * V := rfl
-      _ = ((V * Vᴴ) * A i) * ((V * Vᴴ) * V) := by rw [Matrix.mul_assoc]
-      _ = ((V * Vᴴ) * A i) * (V * (Vᴴ * V)) := by
-        rw [Matrix.mul_assoc V Vᴴ V]
-      _ = ((V * Vᴴ) * A i) * (V * 1) := by rw [hV_iso]
-      _ = ((V * Vᴴ) * A i) * V := by simp
-      _ = (V * (Vᴴ * A i)) * V := by rw [Matrix.mul_assoc V Vᴴ A i]
-      _ = V * ((Vᴴ * A i) * V) := by rw [Matrix.mul_assoc V (Vᴴ * A i) V]
-      _ = V * (Vᴴ * A i * V) := rfl
+      _ = P * A i * (P * V) := by rw [Matrix.mul_assoc (P * A i) P V]
+      _ = P * A i * V := by rw [hPV]
+      _ = (V * Vᴴ) * A i * V := by rw [hV_range]
+      _ = V * (Vᴴ * A i * V) := by simp only [Matrix.mul_assoc]
       _ = V * C i := rfl
   have hEvalCompression (w : List (Fin d)) :
       evalWord C w = Vᴴ * evalWord A w * V := by
@@ -130,7 +126,6 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
   · apply φ.injective
     apply Subtype.ext
     rw [hφ_apply, hφ_apply]
-    change expand (∑ i : Fin d, (C i)ᴴ * C i) = expand 1
     rw [map_sum]
     have hsum : (∑ i : Fin d, expand ((C i)ᴴ * C i)) = (∑ i : Fin d, (A i)ᴴ * A i) := by
       refine Finset.sum_congr rfl ?_

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -4,18 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Peripheral.CyclicDecomposition
-import TNLean.Channel.Peripheral.Conjugation
-import TNLean.MPS.Irreducible.FormII
-import TNLean.MPS.Structure.InvariantSubspaceDecomp
-import TNLean.MPS.Core.BlockingInfrastructure
-
-import Mathlib.Analysis.Matrix.Spectrum
-import Mathlib.Data.Fintype.EquivFin
-import Mathlib.Data.Fintype.Sum
-import Mathlib.Data.Matrix.Block
-import Mathlib.Data.Matrix.Diagonal
-import Mathlib.LinearAlgebra.Matrix.Reindex
-import Mathlib.Logic.Equiv.Sum
 
 /-!
 # Compression to cyclic sectors
@@ -45,18 +33,6 @@ variable {d D : ℕ}
 section Compression
 
 variable {P : MatrixAlg D}
-
-/-- Word evaluation of the unitary-conjugated tensor. -/
-private lemma evalWord_conj_unitary
-    (A : MPSTensor d D) (U : Matrix.unitaryGroup (Fin D) ℂ) :
-    ∀ w : List (Fin d),
-      evalWord (fun i => (↑U : MatrixAlg D)ᴴ * A i * (↑U : MatrixAlg D)) w =
-        (↑U : MatrixAlg D)ᴴ * evalWord A w * (↑U : MatrixAlg D) :=
-  evalWord_gauge
-    ⟨(↑U : MatrixAlg D)ᴴ, ↑U,
-      by simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U,
-      by simpa [Matrix.star_eq_conjTranspose] using Unitary.mul_star_self_of_mem U.prop⟩
-    fun _ => rfl
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.
@@ -91,336 +67,90 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       V * Vᴴ = P ∧
       (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ X).1 = V * X * Vᴴ) := by
   classical
-  -- Spectral splitting of `P` via the shared bundle.
-  obtain ⟨Umat, S, T, n, -, eST, eS, hUU, hU'U, hPdiag_std_lin, hP_decomp,
-    hPdiag_back, htrace, trace_conj⟩ :=
-    ProjectionSpectralSplit.ofOrthogonalProjection P hP
+  obtain ⟨Umat, S, T, n, -, eST, eS, hUU, hU'U, hPdiag_std, hP_decomp,
+    hPdiag_back, htrace, -⟩ := ProjectionSpectralSplit.ofOrthogonalProjection P hP
   let Pdiag : MatrixAlg D := Umatᴴ * P * Umat
-  -- The diagonalizing matrix as a unitary-group element.
-  have hUmem : Umat ∈ Matrix.unitaryGroup (Fin D) ℂ :=
-    ⟨by simpa [Matrix.star_eq_conjTranspose] using hU'U,
-      by simpa [Matrix.star_eq_conjTranspose] using hUU⟩
-  let U : Matrix.unitaryGroup (Fin D) ℂ := ⟨Umat, hUmem⟩
-  -- Conjugated tensor
-  let B : MPSTensor d D := fun i => Umatᴴ * A i * Umat
-  -- Algebra isomorphism for reindexing (renamed to avoid clashing with the
-  -- returned `φ` below).
-  let rAlg : MatrixAlg D ≃ₐ[ℂ] Matrix (S ⊕ T) (S ⊕ T) ℂ :=
-    Matrix.reindexAlgEquiv ℂ ℂ eST
   let P0 : Matrix (S ⊕ T) (S ⊕ T) ℂ :=
     Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ)
-  -- Pdiag in S⊕T basis
-  have hPdiag_std : rAlg Pdiag = P0 := hPdiag_std_lin
-  -- B_i is Pdiag-supported
-  have hBsupp : ∀ i : Fin d, Pdiag * B i * Pdiag = B i := by
-    intro i
-    have hkey : Pdiag * B i * Pdiag = Umatᴴ * (P * A i * P) * Umat := by
-      change Umatᴴ * P * Umat * (Umatᴴ * A i * Umat) * (Umatᴴ * P * Umat) =
-          Umatᴴ * (P * A i * P) * Umat
-      calc
-        Umatᴴ * P * Umat * (Umatᴴ * A i * Umat) * (Umatᴴ * P * Umat)
-            = Umatᴴ * (P * (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) * P) * Umat := by
-                simp only [Matrix.mul_assoc]
-        _ = Umatᴴ * (P * A i * P) * Umat := by rw [hUU, Matrix.mul_one, Matrix.mul_one]
-    rw [hkey, hSupp i]
-  -- Block structure
-  let X : Fin d → Matrix (S ⊕ T) (S ⊕ T) ℂ := fun i => rAlg (B i)
-  let B11 : Fin d → Matrix S S ℂ := fun i => (X i).toBlocks₁₁
-  have hX_block : ∀ i : Fin d,
-      X i = Matrix.fromBlocks (B11 i) 0 0 (0 : Matrix T T ℂ) := by
-    intro i
-    have hsupp_block : P0 * X i * P0 = X i := by
-      have := congrArg rAlg (hBsupp i)
-      simp only [map_mul, hPdiag_std] at this
-      exact this
-    rw [(Matrix.fromBlocks_toBlocks (X i)).symm]
-    rw [(Matrix.fromBlocks_toBlocks (X i)).symm] at hsupp_block
-    simp only [P0, Matrix.fromBlocks_multiply, Matrix.one_mul, Matrix.mul_one,
-      Matrix.zero_mul, Matrix.mul_zero, add_zero] at hsupp_block
-    -- `hsupp_block` forces all blocks outside the `S`-sector to vanish.
-    have extract (x y : S ⊕ T) := congrFun (congrFun hsupp_block x) y
-    have h12 : (X i).toBlocks₁₂ = 0 := by
-      ext s t
-      have h := extract (Sum.inl s) (Sum.inr t)
-      simp only [Matrix.fromBlocks_apply₁₂] at h
-      exact h.symm
-    have h21 : (X i).toBlocks₂₁ = 0 := by
-      ext t s
-      have h := extract (Sum.inr t) (Sum.inl s)
-      simp only [Matrix.fromBlocks_apply₂₁] at h
-      exact h.symm
-    have h22 : (X i).toBlocks₂₂ = 0 := by
-      ext t t'
-      have h := extract (Sum.inr t) (Sum.inr t')
-      simp only [Matrix.fromBlocks_apply₂₂] at h
-      exact h.symm
-    rw [h12, h21, h22]
-  -- Compressed tensor
-  let C : MPSTensor d n := fun i => Matrix.reindex eS eS (B11 i)
   let expand : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ] MatrixAlg D :=
     cornerCompressionExpand Umat eST eS
-  have hP0_def : P0 = Matrix.fromBlocks (1 : Matrix S S ℂ) 0 0 (0 : Matrix T T ℂ) := rfl
-  have hexpand_def : ∀ M : Matrix (Fin n) (Fin n) ℂ,
-      expand M = Umat *
-        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
-          (Matrix.fromBlocks (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm M)
-            (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) * Umatᴴ := by
-    intro M
-    exact cornerCompressionExpand_apply Umat eST eS M
-  have hPdiag_UPU : Pdiag = Umatᴴ * P * Umat := rfl
-  let cornerEmbed : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
-    cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
-      hP_decomp hPdiag_UPU hPdiag_std_lin hPdiag_back hU'U hUU
+  let φ : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
+    cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 rfl
+      hP_decomp rfl hPdiag_std hPdiag_back hU'U hUU
   let V : Matrix (Fin D) (Fin n) ℂ := cornerCompressionIsometry Umat eST eS
   have hV_iso : Vᴴ * V = 1 := by
     exact cornerCompressionIsometry_conjTranspose_mul Umat eST eS hU'U
-  have hExpand_one : cornerCompressionExpand Umat eST eS 1 = P :=
-    cornerCompressionExpand_one (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
+  have hExpand_one : expand 1 = P := by
+    exact cornerCompressionExpand_one (P := P) (Pdiag := Pdiag) Umat eST eS P0 rfl
       hP_decomp hPdiag_back
   have hV_range : V * Vᴴ = P := by
-    have h := cornerCompressionExpand_eq_isometry Umat eST eS
-      (1 : Matrix (Fin n) (Fin n) ℂ)
-    rw [hExpand_one] at h
-    simpa [V] using h.symm
-  have hEmbed_eq_V :
-      ∀ X : Matrix (Fin n) (Fin n) ℂ, (cornerEmbed X).1 = V * X * Vᴴ := by
-    intro X
-    change expand X = V * X * Vᴴ
-    simpa [V] using cornerCompressionExpand_eq_isometry Umat eST eS X
-  -- `A i = Umat * B i * Umatᴴ`.
-  have hA_i : ∀ i, A i = Umat * B i * Umatᴴ := by
-    intro i
-    change A i = Umat * (Umatᴴ * A i * Umat) * Umatᴴ
-    calc
-      A i = (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) := by rw [hUU]; simp
-      _ = Umat * (Umatᴴ * A i * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
-  -- `reindex eS.symm eS.symm (C i) = B11 i`.
-  have hExM_C : ∀ i, Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i) = B11 i :=
-    fun i => (Matrix.reindexLinearEquiv ℂ ℂ eS eS).symm_apply_apply (B11 i)
-  -- `reindex eST.symm eST.symm (X i) = B i`.
-  have hExST_X : ∀ i, Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i) = B i :=
-    fun i => (Matrix.reindexLinearEquiv ℂ ℂ eST eST).symm_apply_apply (B i)
+    rw [show V * Vᴴ = expand 1 by
+      simpa [V, expand] using
+        (cornerCompressionExpand_eq_isometry Umat eST eS
+          (1 : Matrix (Fin n) (Fin n) ℂ)).symm]
+    exact hExpand_one
+  have hφ_apply (X : Matrix (Fin n) (Fin n) ℂ) : (φ X).1 = expand X := rfl
+  have hExpand_eq_V (X : Matrix (Fin n) (Fin n) ℂ) : expand X = V * X * Vᴴ := by
+    simpa [expand, V] using cornerCompressionExpand_eq_isometry Umat eST eS X
+  let C : MPSTensor d n := fun i => Vᴴ * A i * V
   have hLetter : ∀ i : Fin d, expand (C i) = A i := by
     intro i
-    have hBlockBack :
-        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
-            (Matrix.fromBlocks
-              (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i))
-              (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) =
-          B i := by
-      rw [hExM_C i, ← hX_block i]
-      exact hExST_X i
+    rw [hExpand_eq_V]
+    change V * (Vᴴ * A i * V) * Vᴴ = A i
     calc
-      expand (C i) = Umat * B i * Umatᴴ := by
-        rw [hexpand_def, hBlockBack]
-      _ = A i := (hA_i i).symm
-  refine ⟨n, C, cornerEmbed, V, ?_, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range,
-    hEmbed_eq_V⟩
-  -- (1) Trace identity: n = tr P
-  · exact htrace
-  -- (2) TP condition: ∑ C_i† C_i = 1
-  · show ∑ i : Fin d, (C i)ᴴ * C i = 1
-    -- First: ∑ B_i† B_i = Pdiag
-    have hTPB : ∑ i : Fin d, (B i)ᴴ * B i = Pdiag := by
-      have hterm : ∀ i, (B i)ᴴ * B i = Umatᴴ * ((A i)ᴴ * A i) * Umat := by
-        intro i
-        change
-          (Umatᴴ * A i * Umat)ᴴ * (Umatᴴ * A i * Umat) = Umatᴴ * ((A i)ᴴ * A i) * Umat
-        -- (U† A U)† = U† A† U†† = U† A† U (note U†† = U)
-        have hconj : (Umatᴴ * A i * Umat)ᴴ = Umatᴴ * (A i)ᴴ * Umat := by
-          rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
-            Matrix.conjTranspose_conjTranspose]
-          rw [Matrix.mul_assoc]
-        rw [hconj]
-        -- U† A† U * U† A U = U† A† (UU†) A U = U† (A† A) U
+      V * (Vᴴ * A i * V) * Vᴴ = (V * Vᴴ) * A i * (V * Vᴴ) := by
+        simp only [Matrix.mul_assoc]
+      _ = P * A i * P := by rw [hV_range]
+      _ = A i := hSupp i
+  have hIntertwineLetter : ∀ i : Fin d, A i * V = V * C i := by
+    intro i
+    calc
+      A i * V = (P * A i * P) * V := by rw [hSupp i]
+      _ = (V * Vᴴ) * A i * (V * Vᴴ) * V := by rw [hV_range]
+      _ = V * (Vᴴ * A i * V) := by rw [hV_iso]; simp only [Matrix.mul_assoc, Matrix.mul_one]
+      _ = V * C i := rfl
+  have hEvalIntertwine : ∀ w : List (Fin d), evalWord A w * V = V * evalWord C w := by
+    intro w
+    induction w with
+    | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
+    | cons i w ih =>
+        rw [evalWord_cons, evalWord_cons]
         calc
-          Umatᴴ * (A i)ᴴ * Umat * (Umatᴴ * A i * Umat)
-              = Umatᴴ * ((A i)ᴴ * (Umat * Umatᴴ) * A i) * Umat := by
-                  simp only [Matrix.mul_assoc]
-          _ = Umatᴴ * ((A i)ᴴ * A i) * Umat := by rw [hUU, Matrix.mul_one]
-      simp_rw [hterm]
-      -- ∑ i, U† ((A i)† A i) U = U† (∑ (A i)† A i) U = U† P U = Pdiag
-      trans Umatᴴ * (∑ i : Fin d, (A i)ᴴ * A i) * Umat
-      · rw [Finset.mul_sum, Finset.sum_mul]
-      · rw [hTP]
-    -- Transport to S⊕T: ∑ B11_i† B11_i = 1_S
-    have hTPblock : ∑ i : Fin d, (B11 i)ᴴ * B11 i = (1 : Matrix S S ℂ) := by
-      -- φ(∑ B_i† B_i) = ∑ φ(B_i† * B_i) = ∑ (X_i)† (X_i) = P0
-      -- But we also need φ(B_i†) = (X_i)†
-      have hφ_ct : ∀ i, rAlg ((B i)ᴴ) = (X i)ᴴ := by
-        intro i
-        simp [rAlg, X, Matrix.coe_reindexAlgEquiv]
-      -- h : ∑ (X_i)† * X_i = P0
-      have h : ∑ i : Fin d, (X i)ᴴ * X i = P0 := by
-        have h0 := congrArg rAlg hTPB
-        rw [map_sum] at h0
-        simp only [map_mul] at h0
-        -- h0 : ∑ rAlg (B i)ᴴ * rAlg (B i) = rAlg Pdiag
-        -- rAlg (B i)ᴴ is actually rAlg((B i)ᴴ) after map_mul, which equals (X i)ᴴ by hφ_ct
-        simp only [show ∀ i, rAlg (B i) = X i from fun i => rfl] at h0
-        -- Now use the fact that rAlg preserves star/conjTranspose
-        rw [hPdiag_std] at h0
-        simpa [hφ_ct] using h0
-      -- Substitute block form X_i = fromBlocks(B11_i, 0, 0, 0)
-      have hblock : ∀ i, (X i)ᴴ * X i =
-          Matrix.fromBlocks ((B11 i)ᴴ * B11 i) 0 0 (0 : Matrix T T ℂ) := by
-        intro i; rw [hX_block i]
-        simp [Matrix.fromBlocks_conjTranspose, Matrix.fromBlocks_multiply]
-      simp_rw [hblock] at h
-      -- Extract (S,S) block from h
-      ext s s'
-      have h1 := congrFun (congrFun h (Sum.inl s)) (Sum.inl s')
-      -- LHS of h1: (∑ fromBlocks(...))(inl s)(inl s') = ∑ (fromBlocks(...))(inl s)(inl s')
-      -- = ∑ (B11 i)† * B11 i s s'
-      -- RHS of h1: P0 (inl s) (inl s') = 1 s s'
-      -- h1 : (∑ x, fromBlocks((B11 x)† * B11 x, 0, 0, 0))(inl s)(inl s') = 1 s s'
-      -- goal : (∑ i, (B11 i)† * B11 i) s s' = 1 s s'
-      have hsum : ∑ i : Fin d, (B11 i)ᴴ * B11 i = (1 : Matrix S S ℂ) := by
-        ext s1 s2
-        have h2 := congrFun (congrFun h (Sum.inl s1)) (Sum.inl s2)
-        simp only [P0, Matrix.fromBlocks_apply₁₁, Matrix.sum_apply,
-          Matrix.fromBlocks_apply₁₁] at h2
-        rwa [Matrix.sum_apply]
-      exact congrFun (congrFun hsum s) s'
-    -- Transport to Fin n
-    have hterm : ∀ i, (C i)ᴴ * C i = Matrix.reindex eS eS ((B11 i)ᴴ * B11 i) := by
-      intro i
-      change
-        (Matrix.reindex eS eS (B11 i))ᴴ * Matrix.reindex eS eS (B11 i) =
-          Matrix.reindex eS eS ((B11 i)ᴴ * B11 i)
-      rw [Matrix.conjTranspose_reindex]
-      simp only [Matrix.reindex_apply, Matrix.submatrix_mul_equiv]
-    simp_rw [hterm]
-    -- ∑ reindex eS eS (f i) = reindex eS eS (∑ f i)
-    ext a b
-    simp only [Matrix.sum_apply, Matrix.reindex_apply, Matrix.submatrix_apply,
-      Matrix.one_apply]
-    rw [show (∑ i : Fin d, ((B11 i)ᴴ * B11 i) (eS.symm a) (eS.symm b)) =
-        (∑ i : Fin d, (B11 i)ᴴ * B11 i) (eS.symm a) (eS.symm b) from
-      (Matrix.sum_apply (eS.symm a) (eS.symm b) _ _).symm]
-    rw [hTPblock, Matrix.one_apply]
-    simp only [EmbeddingLike.apply_eq_iff_eq]
-  -- (3) MPV identity
+          A i * evalWord A w * V = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
+          _ = A i * (V * evalWord C w) := by rw [ih]
+          _ = (A i * V) * evalWord C w := (Matrix.mul_assoc _ _ _).symm
+          _ = (V * C i) * evalWord C w := by rw [hIntertwineLetter i]
+          _ = V * (C i * evalWord C w) := Matrix.mul_assoc _ _ _
+  have hEvalCompression (w : List (Fin d)) :
+      evalWord C w = Vᴴ * evalWord A w * V := by
+    calc
+      evalWord C w = 1 * evalWord C w := (Matrix.one_mul _).symm
+      _ = (Vᴴ * V) * evalWord C w := by rw [hV_iso]
+      _ = Vᴴ * (V * evalWord C w) := Matrix.mul_assoc _ _ _
+      _ = Vᴴ * (evalWord A w * V) := by rw [hEvalIntertwine w]
+      _ = Vᴴ * evalWord A w * V := (Matrix.mul_assoc _ _ _).symm
+  refine ⟨n, C, φ, V, htrace, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range, ?_⟩
+  · apply φ.injective
+    apply Subtype.ext
+    rw [hφ_apply, hφ_apply]
+    change expand (∑ i : Fin d, (C i)ᴴ * C i) = expand 1
+    rw [map_sum]
+    simp_rw [cornerCompressionExpand_mul Umat eST eS hU'U,
+      ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
+    rw [hTP, hExpand_one]
   · intro N σ
-    set w := List.ofFn σ
-    -- mpv C σ = tr(evalWord B11 w) (by reindexing)
-    have hmpv_C : mpv C σ = Matrix.trace (_root_.evalWord B11 w) := by
-      simp only [mpv, coeff]
-      have : MPSTensor.evalWord C w = Matrix.reindex eS eS (_root_.evalWord B11 w) := by
-        simpa [C] using MPSTensor.evalWord_reindex (e := eS) (A := B11) w
-      rw [this]; exact Matrix.trace_reindex eS _
-    -- tr(evalWord B11 w) = tr(Pdiag * evalWord B w)
-    -- Proved entrywise using the block structure
-    have htr_key : Matrix.trace (_root_.evalWord B11 w) =
-        Matrix.trace (Pdiag * evalWord B w) := by
-      -- Both sides = ∑_{s:S} (evalWord B11 w) s s
-      -- Reindex RHS to S⊕T
-      have htrace_reindex :
-          Matrix.trace (Pdiag * evalWord B w) =
-            Matrix.trace (rAlg (Pdiag * evalWord B w)) := by
-        change Matrix.trace (Pdiag * evalWord B w) =
-          Matrix.trace (Matrix.reindex eST eST (Pdiag * evalWord B w))
-        rw [Matrix.trace_reindex]
-      rw [htrace_reindex]
-      rw [map_mul, hPdiag_std]
-      -- rAlg(evalWord B w) = evalWord X w
-      have hφ_eval : rAlg (evalWord B w) = _root_.evalWord X w := by
-        change Matrix.reindex eST eST (evalWord B w) = _root_.evalWord X w
-        have h := evalWord_reindex_fin (e := eST) (A := B) w
-        rw [show (fun i => Matrix.reindex eST eST (B i)) = X from by
-          ext i; simp [rAlg, X]] at h
-        exact h.symm
-      rw [hφ_eval]
-      -- Now: tr(P0 * evalWord X w) = tr(evalWord B11 w)
-      -- Entrywise argument
-      change Matrix.trace (_root_.evalWord B11 w) =
-        Matrix.trace (P0 * _root_.evalWord X w)
-      symm
-      -- tr(P0 * M) = ∑_{s:S} M (inl s) (inl s) for any M
-      rw [show Matrix.trace (P0 * _root_.evalWord X w) =
-          ∑ x : S ⊕ T, (P0 * _root_.evalWord X w) x x from rfl,
-        Fintype.sum_sum_type]
-      -- T part is zero since P0 has zero T-rows
-      have hT_zero : ∑ t : T, (P0 * _root_.evalWord X w) (Sum.inr t) (Sum.inr t) = 0 := by
-        apply Finset.sum_eq_zero; intro t _
-        change (P0 * _root_.evalWord X w) (Sum.inr t) (Sum.inr t) = 0
-        simp only [Matrix.mul_apply]
-        apply Finset.sum_eq_zero; intro y _
-        cases y with
-        | inl s => simp [P0, Matrix.fromBlocks_apply₂₁]
-        | inr t' => simp [P0, Matrix.fromBlocks_apply₂₂]
-      rw [hT_zero, add_zero]
-      -- S part: (P0 * M)(inl s)(inl s) = M(inl s)(inl s) since P0 is identity on S
-      have hS_eq : ∀ s : S, (P0 * _root_.evalWord X w) (Sum.inl s) (Sum.inl s) =
-          _root_.evalWord X w (Sum.inl s) (Sum.inl s) := by
-        intro s; simp only [Matrix.mul_apply]
-        rw [Fintype.sum_sum_type]
-        have hT : ∑ t : T, P0 (Sum.inl s) (Sum.inr t) *
-            _root_.evalWord X w (Sum.inr t) (Sum.inl s) = 0 := by
-          apply Finset.sum_eq_zero; intro t _
-          simp [P0, Matrix.fromBlocks_apply₁₂]
-        rw [hT, add_zero]
-        rw [Finset.sum_eq_single s]
-        · simp [P0, Matrix.fromBlocks_apply₁₁]
-        · intro s' _ hs'
-          have hsne : s ≠ s' := hs' ∘ Eq.symm
-          have hzero : P0 (Sum.inl s) (Sum.inl s') = 0 := by
-            simp [P0, Matrix.fromBlocks_apply₁₁, hsne]
-          simp [hzero]
-        · intro h; exact absurd (Finset.mem_univ s) h
-      simp_rw [hS_eq]
-      -- Now: ∑_{s:S} evalWord X w (inl s) (inl s) = ∑_{s:S} evalWord B11 w s s
-      -- This follows because (evalWord X w).toBlocks₁₁ = evalWord B11 w
-      -- (by induction, since each X_i = fromBlocks(B11_i, 0, 0, 0))
-      congr 1; ext s
-      -- evalWord X w (inl s) (inl s) = evalWord B11 w s s
-      suffices ∀ ww : List (Fin d), ∀ s1 s2 : S,
-          _root_.evalWord X ww (Sum.inl s1) (Sum.inl s2) =
-          _root_.evalWord B11 ww s1 s2 from this w s s
-      intro ww; induction ww with
-      | nil =>
-          intro s1 s2; simp [_root_.evalWord, Matrix.one_apply, Sum.inl.injEq]
-      | cons j ww ih =>
-          intro s1 s2
-          simp only [_root_.evalWord, Matrix.mul_apply, Fintype.sum_sum_type]
-          -- T contribution is zero
-          have : ∑ t : T, X j (Sum.inl s1) (Sum.inr t) *
-              _root_.evalWord X ww (Sum.inr t) (Sum.inl s2) = 0 := by
-            apply Finset.sum_eq_zero; intro t _
-            rw [show X j (Sum.inl s1) (Sum.inr t) = 0 from by
-              rw [hX_block j]; simp [Matrix.fromBlocks_apply₁₂]]
-            simp
-          rw [this, add_zero]
-          congr 1; ext s'
-          rw [show X j (Sum.inl s1) (Sum.inl s') = B11 j s1 s' from by
-            rw [hX_block j]; simp [Matrix.fromBlocks_apply₁₁]]
-          rw [ih s' s2]
-    -- tr(Pdiag * evalWord B w) = tr(P * evalWord A w) by unitary conjugation
-    have htr_conj : Matrix.trace (Pdiag * evalWord B w) =
-        Matrix.trace (P * evalWord A (List.ofFn σ)) := by
-      have hEvalB := evalWord_conj_unitary A U (List.ofFn σ)
-      rw [show (fun i => (↑U : MatrixAlg D)ᴴ * A i * (↑U : MatrixAlg D)) = B
-        from rfl] at hEvalB
-      rw [hEvalB]
-      change
-        Matrix.trace (Umatᴴ * P * Umat * (Umatᴴ * evalWord A (List.ofFn σ) * Umat)) =
-          Matrix.trace (P * evalWord A (List.ofFn σ))
-      set M := evalWord A (List.ofFn σ)
-      -- U†PU * U†MU = U†P(UU†)MU = U†(PM)U, tr = tr(PM) by trace_conj
-      have hprod : Umatᴴ * P * Umat * (Umatᴴ * M * Umat) = Umatᴴ * (P * M) * Umat := by
-        calc
-          Umatᴴ * P * Umat * (Umatᴴ * M * Umat)
-              = Umatᴴ * (P * (Umat * Umatᴴ) * M) * Umat := by
-                  simp only [Matrix.mul_assoc]
-          _ = Umatᴴ * (P * M) * Umat := by rw [hUU, Matrix.mul_one]
-      rw [hprod, trace_conj]
-    calc mpv C σ
-        = Matrix.trace (_root_.evalWord B11 w) := hmpv_C
-      _ = Matrix.trace (Pdiag * evalWord B w) := htr_key
-      _ = Matrix.trace (P * evalWord A (List.ofFn σ)) := htr_conj
-  -- (4) Intertwining identity:
-  --     (φ (transferMap (C†) Z)).1 = transferMap (A†) ((φ Z).1)
+    let w := List.ofFn σ
+    change Matrix.trace (evalWord C w) = Matrix.trace (P * evalWord A w)
+    rw [hEvalCompression]
+    calc
+      Matrix.trace (Vᴴ * evalWord A w * V) =
+          Matrix.trace ((evalWord A w * V) * Vᴴ) := by
+            rw [Matrix.mul_assoc]
+            exact Matrix.trace_mul_comm _ _
+      _ = Matrix.trace (evalWord A w * P) := by rw [Matrix.mul_assoc, hV_range]
+      _ = Matrix.trace (P * evalWord A w) := Matrix.trace_mul_comm _ _
   · intro Z
+    rw [hφ_apply]
     change expand (transferMap (d := d) (D := n) (fun j => (C j)ᴴ) Z) =
       transferMap (d := d) (D := D) (fun j => (A j)ᴴ) (expand Z)
     simp only [transferMap_apply, Matrix.conjTranspose_conjTranspose]
@@ -430,18 +160,17 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     rw [cornerCompressionExpand_mul Umat eST eS hU'U,
       cornerCompressionExpand_mul Umat eST eS hU'U,
       ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
-  -- (5) Multiplicativity: (φ (X * Y)).1 = (φ X).1 * (φ Y).1.
   · intro X Y
-    change expand (X * Y) = expand X * expand Y
+    simp only [hφ_apply]
     exact cornerCompressionExpand_mul Umat eST eS hU'U X Y
-  -- (6) Star-preservation: (φ Xᴴ).1 = ((φ X).1)ᴴ.
   · intro X
-    change expand Xᴴ = (expand X)ᴴ
+    simp only [hφ_apply]
     exact (cornerCompressionExpand_conjTranspose Umat eST eS X).symm
-  -- (7) Letter expansion: φ(C_i) is the original supported ambient letter.
   · intro i
-    change expand (C i) = A i
+    rw [hφ_apply]
     exact hLetter i
+  · intro X
+    rw [hφ_apply, hExpand_eq_V]
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -24,7 +24,7 @@ multiplicative, and star-preserving identities.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
-open Matrix Finset Complex KadisonSchwarz
+open Matrix Finset Complex
 
 namespace MPSTensor
 

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -107,27 +107,17 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     calc
       A i * V = (P * A i * P) * V := by rw [hSupp i]
       _ = (V * Vᴴ) * A i * (V * Vᴴ) * V := by rw [hV_range]
-      _ = V * (Vᴴ * A i * V) := by rw [hV_iso]; simp only [Matrix.mul_assoc, Matrix.mul_one]
+      _ = V * (Vᴴ * A i * V) * (Vᴴ * V) := by simp only [Matrix.mul_assoc]
+      _ = V * (Vᴴ * A i * V) := by rw [hV_iso, Matrix.mul_one]
       _ = V * C i := rfl
-  have hEvalIntertwine : ∀ w : List (Fin d), evalWord A w * V = V * evalWord C w := by
-    intro w
-    induction w with
-    | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
-    | cons i w ih =>
-        rw [evalWord_cons, evalWord_cons]
-        calc
-          A i * evalWord A w * V = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
-          _ = A i * (V * evalWord C w) := by rw [ih]
-          _ = (A i * V) * evalWord C w := (Matrix.mul_assoc _ _ _).symm
-          _ = (V * C i) * evalWord C w := by rw [hIntertwineLetter i]
-          _ = V * (C i * evalWord C w) := Matrix.mul_assoc _ _ _
   have hEvalCompression (w : List (Fin d)) :
       evalWord C w = Vᴴ * evalWord A w * V := by
     calc
       evalWord C w = 1 * evalWord C w := (Matrix.one_mul _).symm
       _ = (Vᴴ * V) * evalWord C w := by rw [hV_iso]
       _ = Vᴴ * (V * evalWord C w) := Matrix.mul_assoc _ _ _
-      _ = Vᴴ * (evalWord A w * V) := by rw [hEvalIntertwine w]
+      _ = Vᴴ * (evalWord A w * V) := by
+        rw [evalWord_intertwine A C V hIntertwineLetter w]
       _ = Vᴴ * evalWord A w * V := (Matrix.mul_assoc _ _ _).symm
   refine ⟨n, C, φ, V, htrace, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range, ?_⟩
   · apply φ.injective
@@ -135,9 +125,14 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     rw [hφ_apply, hφ_apply]
     change expand (∑ i : Fin d, (C i)ᴴ * C i) = expand 1
     rw [map_sum]
-    simp_rw [cornerCompressionExpand_mul Umat eST eS hU'U,
-      ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
-    rw [hTP, hExpand_one]
+    calc
+      ∑ i : Fin d, expand ((C i)ᴴ * C i) = ∑ i : Fin d, (A i)ᴴ * A i := by
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [cornerCompressionExpand_mul Umat eST eS hU'U,
+          ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
+      _ = P := hTP
+      _ = expand 1 := hExpand_one.symm
   · intro N σ
     let w := List.ofFn σ
     change Matrix.trace (evalWord C w) = Matrix.trace (P * evalWord A w)

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -104,20 +104,18 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       _ = A i := hSupp i
   have hIntertwineLetter : ∀ i : Fin d, A i * V = V * C i := by
     intro i
-    have htemp : (V * Vᴴ) * A i * (V * Vᴴ) * V = V * (Vᴴ * A i * V) := by
-      calc
-        (V * Vᴴ) * A i * (V * Vᴴ) * V = ((V * Vᴴ) * A i) * ((V * Vᴴ) * V) := by
-          rw [Matrix.mul_assoc]
-        _ = ((V * Vᴴ) * A i) * (V * (Vᴴ * V)) := by rw [Matrix.mul_assoc]
-        _ = ((V * Vᴴ) * A i) * (V * 1) := by rw [hV_iso]
-        _ = ((V * Vᴴ) * A i) * V := by simp
-        _ = (V * (Vᴴ * A i)) * V := by rw [Matrix.mul_assoc]
-        _ = V * ((Vᴴ * A i) * V) := by rw [Matrix.mul_assoc]
-        _ = V * (Vᴴ * A i * V) := rfl
     calc
       A i * V = (P * A i * P) * V := by rw [hSupp i]
       _ = (V * Vᴴ) * A i * (V * Vᴴ) * V := by rw [hV_range]
-      _ = V * (Vᴴ * A i * V) := by rw [htemp]
+      _ = ((V * Vᴴ) * A i * (V * Vᴴ)) * V := rfl
+      _ = ((V * Vᴴ) * A i) * ((V * Vᴴ) * V) := by rw [Matrix.mul_assoc]
+      _ = ((V * Vᴴ) * A i) * (V * (Vᴴ * V)) := by
+        rw [Matrix.mul_assoc V Vᴴ V]
+      _ = ((V * Vᴴ) * A i) * (V * 1) := by rw [hV_iso]
+      _ = ((V * Vᴴ) * A i) * V := by simp
+      _ = (V * (Vᴴ * A i)) * V := by rw [Matrix.mul_assoc V Vᴴ A i]
+      _ = V * ((Vᴴ * A i) * V) := by rw [Matrix.mul_assoc V (Vᴴ * A i) V]
+      _ = V * (Vᴴ * A i * V) := rfl
       _ = V * C i := rfl
   have hEvalCompression (w : List (Fin d)) :
       evalWord C w = Vᴴ * evalWord A w * V := by

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -24,7 +24,7 @@ multiplicative, and star-preserving identities.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
-open Matrix Finset Complex KadisonSchwarz
+open Matrix Finset Complex
 
 namespace MPSTensor
 
@@ -119,25 +119,14 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       _ = (V * Vᴴ) * A i * (V * Vᴴ) * V := by rw [hV_range]
       _ = V * (Vᴴ * A i * V) := by rw [htemp]
       _ = V * C i := rfl
-  have hEvalIntertwine : ∀ w : List (Fin d), evalWord A w * V = V * evalWord C w := by
-    intro w
-    induction w with
-    | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
-    | cons i w ih =>
-        rw [evalWord_cons, evalWord_cons]
-        calc
-          A i * evalWord A w * V = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
-          _ = A i * (V * evalWord C w) := by rw [ih]
-          _ = (A i * V) * evalWord C w := (Matrix.mul_assoc _ _ _).symm
-          _ = (V * C i) * evalWord C w := by rw [hIntertwineLetter i]
-          _ = V * (C i * evalWord C w) := Matrix.mul_assoc _ _ _
   have hEvalCompression (w : List (Fin d)) :
       evalWord C w = Vᴴ * evalWord A w * V := by
     calc
       evalWord C w = 1 * evalWord C w := (Matrix.one_mul _).symm
       _ = (Vᴴ * V) * evalWord C w := by rw [hV_iso]
       _ = Vᴴ * (V * evalWord C w) := Matrix.mul_assoc _ _ _
-      _ = Vᴴ * (evalWord A w * V) := by rw [hEvalIntertwine w]
+      _ = Vᴴ * (evalWord A w * V) := by
+        rw [evalWord_intertwine A C V hIntertwineLetter w]
       _ = Vᴴ * evalWord A w * V := (Matrix.mul_assoc _ _ _).symm
   refine ⟨n, C, φ, V, htrace, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range, ?_⟩
   · apply φ.injective

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -24,7 +24,7 @@ multiplicative, and star-preserving identities.
 -/
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
-open Matrix Finset Complex
+open Matrix Finset Complex KadisonSchwarz
 
 namespace MPSTensor
 
@@ -104,20 +104,40 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
       _ = A i := hSupp i
   have hIntertwineLetter : ∀ i : Fin d, A i * V = V * C i := by
     intro i
+    have htemp : (V * Vᴴ) * A i * (V * Vᴴ) * V = V * (Vᴴ * A i * V) := by
+      calc
+        (V * Vᴴ) * A i * (V * Vᴴ) * V = ((V * Vᴴ) * A i) * ((V * Vᴴ) * V) := by
+          rw [Matrix.mul_assoc]
+        _ = ((V * Vᴴ) * A i) * (V * (Vᴴ * V)) := by rw [Matrix.mul_assoc]
+        _ = ((V * Vᴴ) * A i) * (V * 1) := by rw [hV_iso]
+        _ = ((V * Vᴴ) * A i) * V := by simp
+        _ = (V * (Vᴴ * A i)) * V := by rw [Matrix.mul_assoc]
+        _ = V * ((Vᴴ * A i) * V) := by rw [Matrix.mul_assoc]
+        _ = V * (Vᴴ * A i * V) := rfl
     calc
       A i * V = (P * A i * P) * V := by rw [hSupp i]
       _ = (V * Vᴴ) * A i * (V * Vᴴ) * V := by rw [hV_range]
-      _ = V * (Vᴴ * A i * V) * (Vᴴ * V) := by simp only [Matrix.mul_assoc]
-      _ = V * (Vᴴ * A i * V) := by rw [hV_iso, Matrix.mul_one]
+      _ = V * (Vᴴ * A i * V) := by rw [htemp]
       _ = V * C i := rfl
+  have hEvalIntertwine : ∀ w : List (Fin d), evalWord A w * V = V * evalWord C w := by
+    intro w
+    induction w with
+    | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
+    | cons i w ih =>
+        rw [evalWord_cons, evalWord_cons]
+        calc
+          A i * evalWord A w * V = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
+          _ = A i * (V * evalWord C w) := by rw [ih]
+          _ = (A i * V) * evalWord C w := (Matrix.mul_assoc _ _ _).symm
+          _ = (V * C i) * evalWord C w := by rw [hIntertwineLetter i]
+          _ = V * (C i * evalWord C w) := Matrix.mul_assoc _ _ _
   have hEvalCompression (w : List (Fin d)) :
       evalWord C w = Vᴴ * evalWord A w * V := by
     calc
       evalWord C w = 1 * evalWord C w := (Matrix.one_mul _).symm
       _ = (Vᴴ * V) * evalWord C w := by rw [hV_iso]
       _ = Vᴴ * (V * evalWord C w) := Matrix.mul_assoc _ _ _
-      _ = Vᴴ * (evalWord A w * V) := by
-        rw [evalWord_intertwine A C V hIntertwineLetter w]
+      _ = Vᴴ * (evalWord A w * V) := by rw [hEvalIntertwine w]
       _ = Vᴴ * evalWord A w * V := (Matrix.mul_assoc _ _ _).symm
   refine ⟨n, C, φ, V, htrace, ?_, ?_, ?_, ?_, ?_, ?_, hV_iso, hV_range, ?_⟩
   · apply φ.injective
@@ -125,14 +145,15 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     rw [hφ_apply, hφ_apply]
     change expand (∑ i : Fin d, (C i)ᴴ * C i) = expand 1
     rw [map_sum]
+    have hsum : (∑ i : Fin d, expand ((C i)ᴴ * C i)) = (∑ i : Fin d, (A i)ᴴ * A i) := by
+      refine Finset.sum_congr rfl ?_
+      intro i _
+      rw [cornerCompressionExpand_mul Umat eST eS hU'U,
+        ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
     calc
-      ∑ i : Fin d, expand ((C i)ᴴ * C i) = ∑ i : Fin d, (A i)ᴴ * A i := by
-        apply Finset.sum_congr rfl
-        intro i _
-        rw [cornerCompressionExpand_mul Umat eST eS hU'U,
-          ← cornerCompressionExpand_conjTranspose Umat eST eS, hLetter]
+      (∑ i : Fin d, expand ((C i)ᴴ * C i)) = (∑ i : Fin d, (A i)ᴴ * A i) := hsum
       _ = P := hTP
-      _ = expand 1 := hExpand_one.symm
+      _ = expand 1 := by rw [hExpand_one]
   · intro N σ
     let w := List.ofFn σ
     change Matrix.trace (evalWord C w) = Matrix.trace (P * evalWord A w)

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/CornerBridge.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/CornerBridge.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.Peripheral.Conjugation
 import TNLean.MPS.CanonicalForm.CyclicSectors.Compression
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
@@ -158,22 +158,6 @@ theorem hasInvariantProjectorClosure_compress_of_commutes
   rw [hL, hR] at h4
   exact h4
 
-/-- Word evaluation is intertwined by an isometry that intertwines the letters. -/
-private lemma evalWord_intertwine {n : ℕ} (A : MPSTensor d D) (B : MPSTensor d n)
-    (V : Matrix (Fin D) (Fin n) ℂ) (hInt : ∀ i : Fin d, A i * V = V * B i) :
-    ∀ w : List (Fin d), evalWord A w * V = V * evalWord B w := by
-  intro w
-  induction w with
-  | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
-  | cons i w ihw =>
-      rw [evalWord_cons, evalWord_cons]
-      calc A i * evalWord A w * V
-          = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
-        _ = A i * (V * evalWord B w) := by rw [ihw]
-        _ = (A i * V) * evalWord B w := (Matrix.mul_assoc _ _ _).symm
-        _ = (V * B i) * evalWord B w := by rw [hInt i]
-        _ = V * (B i * evalWord B w) := Matrix.mul_assoc _ _ _
-
 /-- If isometries with ranges summing to the identity intertwine the tensor
 matrices with corner tensors, then the matrix product vectors of the tensor
 agree with those of the unit-weight direct sum of the corner tensors.

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -17,6 +17,11 @@ This file contains the core definitions used throughout the MPS development:
 notions of injectivity, block injectivity, and normality. It also proves the
 basic gauge-invariance lemmas for `evalWord`, `SameMPV`, and eventual block
 injectivity.
+
+## Main declarations
+
+* `evalWord` — the matrix product associated with a word of physical indices
+* `evalWord_intertwine` — a rectangular letter intertwiner also intertwines every word
 -/
 
 open scoped Matrix

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -45,6 +45,23 @@ def evalWord (A : MPSTensor d D) : List (Fin d) → Matrix (Fin D) (Fin D) ℂ
 @[simp] lemma evalWord_cons (A : MPSTensor d D) (i : Fin d) (w : List (Fin d)) :
     evalWord A (i :: w) = A i * evalWord A w := rfl
 
+/-- A rectangular matrix that intertwines every letter of two tensors also intertwines
+all their word evaluations. -/
+lemma evalWord_intertwine {n : ℕ} (A : MPSTensor d D) (B : MPSTensor d n)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hInt : ∀ i : Fin d, A i * V = V * B i) :
+    ∀ w : List (Fin d), evalWord A w * V = V * evalWord B w := by
+  intro w
+  induction w with
+  | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
+  | cons i w ih =>
+      rw [evalWord_cons, evalWord_cons]
+      calc
+        A i * evalWord A w * V = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
+        _ = A i * (V * evalWord B w) := by rw [ih]
+        _ = (A i * V) * evalWord B w := (Matrix.mul_assoc _ _ _).symm
+        _ = (V * B i) * evalWord B w := by rw [hInt i]
+        _ = V * (B i * evalWord B w) := Matrix.mul_assoc _ _ _
+
 /-- Multiplicativity of word evaluation:
 `evalWord A (w1 ++ w2) = evalWord A w1 * evalWord A w2`. -/
 lemma evalWord_append (A : MPSTensor d D) :


### PR DESCRIPTION
Completes the independent Compression half of #4566.

Defines the compressed tensor directly as $C_i = V^† A_i V$ using the shared corner-compression isometry API. Normalization and transfer-map intertwining now follow from the common expansion lemmas, and MPV preservation follows from the isometry intertwining plus rectangular trace cyclicity. The obsolete conjugated-tensor, block decomposition, reindexing, and entrywise trace machinery and twelve imports are removed.

All three public theorem signatures are unchanged. Net diff: 72 additions, 343 deletions (271-line reduction).

Verification (without recreating Mathlib caches): native diagnostics on the changed leaf file report 0 errors/warnings; no proof-integrity markers; `git diff --check` clean.

Together with #4620, this addresses all #4566 remediation items; close #4566 only after both merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor only: same public APIs and mathematical claims, with logic consolidated onto existing corner-compression lemmas and a relocated helper lemma.
> 
> **Overview**
> **Cyclic-sector compression** is reworked so the compressed tensor is **\(C_i = V^\dagger A_i V\)** on the corner isometry \(V\), instead of a unitary conjugation, block split on \(S \oplus T\), and reindexing to \(B_{11}\). Left-canonical normalization, transfer-map intertwining, and letter recovery use **`cornerCompressionExpand`** (mul, adjoint, one maps to \(P\)); MPV preservation uses **`evalWord_intertwine`** plus trace cyclicity. **`Compression.lean`** drops a large private proof block and **twelve imports**; exported theorem statements are unchanged.
> 
> **`evalWord_intertwine`** moves from a private copy in **`ProjectorClosureDecomposition.lean`** to a public lemma in **`TNLean/MPS/Defs.lean`**, so compression and projector-closure MPV arguments share one induction. **`CornerBridge.lean`** adds **`TNLean.Channel.Peripheral.Conjugation`** where that dependency no longer comes through compression imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9195069b4e8b44c7815dbe97043c0558b942fbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->