### PR TITLE
refactor(PEPS/RegionBlock): remove dead overlap wrappers

### DIFF
--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
@@ -164,13 +164,6 @@ theorem overlapRightGeometry_univ_sdiff_red (R₁ R₂ : Finset V) :
   ext v
   simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, not_not]
 
-omit [LinearOrder V] [DecidableRel G.Adj] in
-/-- The complement block is shared between the two overlap geometries: both read
-the residual coupling through `R₂ \ R₁`. -/
-theorem overlapRightGeometry_complement_eq_left (R₁ R₂ : Finset V) :
-    (overlapRightGeometry (V := V) R₁ R₂).complement =
-      (overlapLeftGeometry (V := V) R₁ R₂).complement := rfl
-
 /-! ### The two strips of the source two-step
 
 The source proof inverts the two injective regions in sequence. With the two

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap2.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap2.lean
@@ -54,23 +54,6 @@ variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 variable {A : Tensor G d}
 
-/-! ### `P₀ ⊆ R₂ᶜ`: the right geometry red block contains the difference block
-
-In the right geometry `overlapRightGeometry R₁ R₂` the red block is `R₂ᶜ`, the blue
-block is the overlap `R₁ ∩ R₂`, and the complement block is `R₂ \ R₁`. The difference
-block `P₀ = R₁ \ R₂` lies inside `R₂ᶜ = red`, so every internal `P₁`--`P₀` edge has one
-endpoint in the blue block and one in the red block: it is a blue/red crossing edge of
-the right geometry. -/
-
-omit [LinearOrder V] [DecidableRel G.Adj] in
-/-- The difference block `R₁ \ R₂` lies inside the right geometry red block `R₂ᶜ`. -/
-theorem overlapRightGeometry_sdiff_subset_red (R₁ R₂ : Finset V) :
-    R₁ \ R₂ ⊆ (overlapRightGeometry (V := V) R₁ R₂).red := by
-  rw [overlapRightGeometry_red]
-  intro v hv
-  rw [Finset.mem_sdiff] at hv ⊢
-  exact ⟨Finset.mem_univ _, hv.2⟩
-
 /-! ### The right geometry blue-side host-weight collapse
 
 The right geometry `g := overlapRightGeometry R₁ R₂` has host `univ \ g.red = R₂`, blue
@@ -167,8 +150,7 @@ the right geometry's host `R₂` boundary (`P₁ ⊆ R₂`, `P₀ ∩ R₂ = ∅
 `R₂` boundary edges with both endpoints in `R₁`.
 
 In the right geometry these are blue/red crossing edges: the overlap `P₁` is the blue
-block, and `P₀ = R₁ \ R₂` lies inside the red block `R₂ᶜ`
-(`overlapRightGeometry_sdiff_subset_red`). -/
+block, and `P₀ = R₁ \ R₂` lies inside the red block `R₂ᶜ`. -/
 
 /-- An edge is a `P₁`--`P₀` crossing edge when exactly one endpoint lies in the overlap
 `R₁ ∩ R₂` and the other lies in the difference `R₁ \ R₂`. Both endpoints lie in `R₁`. -/
@@ -186,27 +168,6 @@ theorem isOverlapCrossingEdge_both_mem_R₁ {R₁ R₂ : Finset V} {eg : Edge G}
   rcases h with ⟨h1, h2⟩ | ⟨h1, h2⟩
   · exact ⟨(Finset.mem_inter.mp h1).1, (Finset.mem_sdiff.mp h2).1⟩
   · exact ⟨(Finset.mem_sdiff.mp h1).1, (Finset.mem_inter.mp h2).1⟩
-
-omit [Fintype V] [DecidableRel G.Adj] in
-/-- A `P₁`--`P₀` crossing edge is a boundary edge of `R₂`: its overlap endpoint lies in
-`R₂` while its difference endpoint lies outside `R₂`. -/
-theorem isRegionBoundaryEdge_R₂_of_overlapCrossing {R₁ R₂ : Finset V} {eg : Edge G}
-    (h : IsOverlapCrossingEdge (G := G) R₁ R₂ eg) :
-    IsRegionBoundaryEdge (G := G) R₂ eg := by
-  rcases h with ⟨h1, h2⟩ | ⟨h1, h2⟩
-  · exact Or.inl ⟨(Finset.mem_inter.mp h1).2, (Finset.mem_sdiff.mp h2).2⟩
-  · exact Or.inr ⟨(Finset.mem_sdiff.mp h1).2, (Finset.mem_inter.mp h2).2⟩
-
-omit [Fintype V] [DecidableRel G.Adj] in
-/-- A `P₁`--`P₀` crossing edge is not a boundary edge of `R₁`: both endpoints lie in
-`R₁`. -/
-theorem not_isRegionBoundaryEdge_R₁_of_overlapCrossing {R₁ R₂ : Finset V} {eg : Edge G}
-    (h : IsOverlapCrossingEdge (G := G) R₁ R₂ eg) :
-    ¬ IsRegionBoundaryEdge (G := G) R₁ eg := by
-  obtain ⟨h1, h2⟩ := isOverlapCrossingEdge_both_mem_R₁ (G := G) h
-  rintro (⟨_, h2'⟩ | ⟨h1', _⟩)
-  · exact h2' h2
-  · exact h1' h1
 
 omit [Fintype V] [DecidableRel G.Adj] in
 /-- A `P₁`--`P₀` crossing edge is not a boundary edge of the union `R₁ ∪ R₂`: both

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3.lean
@@ -46,17 +46,6 @@ variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 variable {A : Tensor G d}
 
-/-! ### The shared complement block `P₂`
-
-Both overlap geometries have complement block `R₂ \ R₁ = P₂`, so both complement couplings
-read the same `P₂` blocked-region weights `regionBlockedWeight A (R₂ \ R₁)`. -/
-
-omit [LinearOrder V] [DecidableRel G.Adj] in
-/-- The two overlap geometries share the complement block `R₂ \ R₁`. -/
-theorem overlap_complement_eq (R₁ R₂ : Finset V) :
-    (overlapLeftGeometry (V := V) R₁ R₂).complement =
-      (overlapRightGeometry (V := V) R₁ R₂).complement := rfl
-
 /-! ### Reducing a coupling combination to the `P₂` blocked-region weights
 
 The landed crossing collapse `blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq` reads, for

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
@@ -123,18 +123,6 @@ theorem p0OuterLabel_eq_of_R₁ {R₁ R₂ : Finset V} {q q' : VirtualConfig A}
   rw [p0OuterLabel, p0OuterLabel, this]
 
 omit [Fintype V] in
-/-- The union host boundary label determines the `P₀`-outer label: the `P₀`-outer edges are union
-boundary edges, so a configuration's `P₀`-outer label is read off its union host label. -/
-theorem p0OuterLabel_eq_of_union {R₁ R₂ : Finset V} {q q' : VirtualConfig A}
-    (h : regionBoundaryLabel (G := G) A (R₁ ∪ R₂) q =
-      regionBoundaryLabel (G := G) A (R₁ ∪ R₂) q') :
-    p0OuterLabel A R₁ R₂ q = p0OuterLabel A R₁ R₂ q' := by
-  funext f
-  have := congrFun h ⟨f.1, f.2.1⟩
-  rw [regionBoundaryLabel_apply, regionBoundaryLabel_apply] at this
-  rw [p0OuterLabel, p0OuterLabel, this]
-
-omit [Fintype V] in
 /-- The union host boundary label is determined by the pair (`R₂` boundary label, `P₀`-outer
 label): the union boundary edges partition into `R₂` boundary edges and `P₀`-outer edges, so if
 two configurations share both their `R₂` and `P₀`-outer labels, they share their `R₁ ∪ R₂`
@@ -158,14 +146,6 @@ theorem regionBoundaryLabel_union_eq_of_R₂_p0Outer {R₁ R₂ : Finset V} {q q
 The `P₀`-restriction of a union host boundary configuration reads its values on the `P₀`-outer
 sub-edges. The fiber coefficient zeroes a coefficient family `c` off the `P₀`-fiber of a fixed
 reference `δ`. -/
-
-omit [Fintype V] in
-/-- The `P₀`-restriction of a union host boundary configuration: read off its `P₀`-outer
-sub-edges. A configuration's `P₀`-outer label is the `P₀`-restriction of its union host label. -/
-theorem p0OuterLabel_apply_subtype {R₁ R₂ : Finset V} (q : VirtualConfig A)
-    (f : {e : Edge G // IsP0OuterEdge (G := G) R₁ R₂ e}) :
-    p0OuterLabel A R₁ R₂ q f =
-      regionBoundaryLabel (G := G) A (R₁ ∪ R₂) q ⟨f.1, f.2.1⟩ := rfl
 
 /-- The `P₀`-restriction of a union host boundary configuration: its values on the `P₀`-outer
 sub-edges. -/


### PR DESCRIPTION
Closes #4567 once merged.

This follow-up to the already-merged main dead-route deletion removes the final seven zero-reference wrappers scattered across `UnionInjectivityOverlap{,2,3,6}`. It leaves the live `overlapLeftGeometry`/`overlapRightGeometry` and P0-outer proof route unchanged.

Deleted declarations: `overlapRightGeometry_complement_eq_left`, `overlapRightGeometry_sdiff_subset_red`, `isRegionBoundaryEdge_R₂_of_overlapCrossing`, `not_isRegionBoundaryEdge_R₁_of_overlapCrossing`, `overlap_complement_eq`, `p0OuterLabel_eq_of_union`, and `p0OuterLabel_apply_subtype`. Net: 78 lines removed.

Verification (without recreating Mathlib caches): native diagnostics clean on all four changed leaf files; removed names and `overlapHostGeometry` absent repo-wide; no import changes or new numbered debt; no proof-integrity markers; committed diff clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unreferenced lemmas and comments in leaf PEPS files; no behavioral or API surface change to the live overlap injectivity proof.
> 
> **Overview**
> Follow-up cleanup in the PEPS **RegionBlock** overlapping-union injectivity route: removes **seven declarations** that had **no remaining references** after earlier dead-route deletion.
> 
> Dropped items include trivial `rfl` facts about shared complement blocks (`overlapRightGeometry_complement_eq_left`, `overlap_complement_eq`), set inclusion for `P₀ ⊆ R₂ᶜ` (`overlapRightGeometry_sdiff_subset_red`), overlap-crossing boundary lemmas superseded by `isBlueRedCrossingEdge_right_of_overlapCrossing`, and redundant `P₀`-outer label lemmas (`p0OuterLabel_eq_of_union`, `p0OuterLabel_apply_subtype`). Doc comments are tightened where they cited the removed theorems (e.g. `P₁`–`P₀` crossing narrative in `UnionInjectivityOverlap2`).
> 
> **No import or proof-path changes**—`overlapLeftGeometry` / `overlapRightGeometry`, the bridge, and `regionBlockedTensorInjective_union_overlap` stay as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a799c855511fea252f395acfe050bb969843184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->