### PR TITLE
refactor(PEPS): consolidate repeated proof tactics

### DIFF
--- a/TNLean/PEPS/NormalFundamentalTheorem.lean
+++ b/TNLean/PEPS/NormalFundamentalTheorem.lean
@@ -86,31 +86,14 @@ omit [DecidableRel G.Adj] in
     exact this.2
   rw [assembleRegionσ, dif_neg hw]
 
-/-- An edge is incident to the region `R` when at least one endpoint lies in `R`.
-The vertex product over `R` reads a global virtual configuration only at the
-edges incident to `R`. -/
-def IsRegionIncidentEdge (R : Finset V) (e : Edge G) : Prop :=
-  e.1.1 ∈ R ∨ e.1.2 ∈ R
-
-instance (R : Finset V) (e : Edge G) : Decidable (IsRegionIncidentEdge (G := G) R e) := by
-  unfold IsRegionIncidentEdge; infer_instance
-
 omit [Fintype V] in
 /-- The vertex product over `R` reads a global virtual configuration only through
-the edges incident to `R`: two configurations agreeing on every `R`-incident edge
-give the same product. -/
+its `R`-incident edges. -/
 theorem regionProd_congr (R : Finset V) (σ : V → Fin d) {ζ ζ' : VirtualConfig A}
     (h : ∀ e : Edge G, IsRegionIncidentEdge (G := G) R e → ζ e = ζ' e) :
     (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w.1)) =
       ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ' ie.1) (σ w.1) := by
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  refine h ie.1 ?_
-  -- An edge incident to `w ∈ R` is incident to `R`.
-  rcases ie.2 with hie | hie
-  · exact Or.inl (by rw [hie]; exact w.2)
-  · exact Or.inr (by rw [hie]; exact w.2)
+  exact regionProd_subtype_congr R (fun w => σ w.1) h
 
 /-! ### Identity insertion on a region boundary edge
 

--- a/TNLean/PEPS/RegionBlock/Basic.lean
+++ b/TNLean/PEPS/RegionBlock/Basic.lean
@@ -54,6 +54,26 @@ def IsRegionBoundaryEdge (R : Finset V) (f : Edge G) : Prop :=
 instance (R : Finset V) (f : Edge G) : Decidable (IsRegionBoundaryEdge (G := G) R f) := by
   unfold IsRegionBoundaryEdge; infer_instance
 
+/-- An edge is incident to the region `R` when at least one endpoint lies in `R`. -/
+def IsRegionIncidentEdge (R : Finset V) (e : Edge G) : Prop :=
+  e.1.1 ∈ R ∨ e.1.2 ∈ R
+
+instance (R : Finset V) (e : Edge G) : Decidable (IsRegionIncidentEdge (G := G) R e) := by
+  unfold IsRegionIncidentEdge; infer_instance
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- An edge incident to each of two disjoint regions crosses the boundary of the second. -/
+theorem isRegionBoundaryEdge_of_disjoint_incident (S T : Finset V)
+    (hST : Disjoint S T) {e : Edge G}
+    (hS : IsRegionIncidentEdge (G := G) S e)
+    (hT : IsRegionIncidentEdge (G := G) T e) : IsRegionBoundaryEdge (G := G) T e := by
+  have hdis := Finset.disjoint_left.mp hST
+  rcases hS with hS1 | hS2 <;> rcases hT with hT1 | hT2
+  · exact (hdis hS1 hT1).elim
+  · exact Or.inr ⟨fun h => hdis hS1 h, hT2⟩
+  · exact Or.inl ⟨hT1, fun h => hdis hS2 h⟩
+  · exact (hdis hS2 hT2).elim
+
 omit [Fintype V] [DecidableRel G.Adj] in
 /-- A boundary edge of `R` has at least one endpoint in `R`. -/
 theorem isRegionBoundaryEdge_touches (R : Finset V) {f : Edge G}
@@ -86,6 +106,22 @@ abbrev RegionPhysicalConfig (R : Finset V) : Type _ :=
 instance instFintypeRegionPhysicalConfig (R : Finset V) :
     Fintype (RegionPhysicalConfig (V := V) (d := d) R) :=
   inferInstance
+
+omit [Fintype V] in
+/-- The vertex product over `R` reads a virtual configuration only through edges incident to
+`R`: two configurations agreeing on every `R`-incident edge give the same product. -/
+theorem regionProd_subtype_congr (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R) {ζ ζ' : VirtualConfig A}
+    (h : ∀ e : Edge G, IsRegionIncidentEdge (G := G) R e → ζ e = ζ' e) :
+    (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) =
+      ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ' ie.1) (σ w) := by
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  refine h ie.1 ?_
+  rcases ie.2 with hie | hie
+  · exact Or.inl (by rw [hie]; exact w.2)
+  · exact Or.inr (by rw [hie]; exact w.2)
 
 /-- The boundary configuration read off a global virtual configuration: the
 labels on the edges crossing the boundary of `R`. -/

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -465,14 +465,9 @@ theorem regionProd_insertOverwrite (A : Tensor G d) (R : Finset V) {v : V}
       ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1)
         (restrictInsertPhysical (V := V) (d := d) R σ w) := by
   classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  -- An edge incident to `w ∈ R` is `R`-incident, where the overwrite is the identity.
-  refine insertOverwrite_eq_of_regionIncident (G := G) A R μ ζ ?_
-  rcases ie.2 with hie | hie
-  · exact Or.inl (by rw [hie]; exact w.2)
-  · exact Or.inr (by rw [hie]; exact w.2)
+  apply regionProd_subtype_congr
+  intro ie hie
+  exact insertOverwrite_eq_of_regionIncident (G := G) A R μ ζ hie
 
 open scoped Classical in
 /-- **The inserted-site multiplicity collapse.** Under inserted-site consistency, the blocked

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -430,27 +430,14 @@ theorem blueProd_eq_regionMerge_complement
       ∏ w : {w : V // w ∈ D.blue},
         A.component w.1 (fun ie => regionMerge (G := G) A D.complement p ie.1) (σblue w) := by
   classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  -- `ie` is incident to `w ∈ blue`, so `w ∉ complement`.
-  have hwblue : w.1 ∈ D.blue := w.2
-  have hwnotcompl : w.1 ∉ D.complement := fun hc =>
-    (Finset.disjoint_left.mp D.blue_disjoint_complement) hwblue hc
-  have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-  by_cases hinc : IsRegionIncidentEdge (G := G) D.complement ie.1
-  · -- `ie` is complement-incident and touches `w ∉ complement`: a boundary edge of
-    -- the complement, where `p.1` and `p.2` agree.
-    have hbdry : IsRegionBoundaryEdge (G := G) D.complement ie.1 := by
-      rcases hinc with h1 | h2
-      · rcases hwinc with hw1 | hw2
-        · exact absurd (by rw [← hw1]; exact h1) hwnotcompl
-        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hwnotcompl
-      · rcases hwinc with hw1 | hw2
-        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hwnotcompl
-        · exact absurd (by rw [← hw2]; exact h2) hwnotcompl
+  apply regionProd_subtype_congr
+  intro ie hie
+  by_cases hinc : IsRegionIncidentEdge (G := G) D.complement ie
+  · have hbdry : IsRegionBoundaryEdge (G := G) D.complement ie :=
+      isRegionBoundaryEdge_of_disjoint_incident (G := G) D.blue D.complement
+        D.blue_disjoint_complement hie hinc
     rw [regionMerge, if_pos hinc]
-    have := congrFun hp ⟨ie.1, hbdry⟩
+    have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
   · rw [regionMerge, if_neg hinc]
 

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -219,27 +219,14 @@ theorem complProd_eq_regionMerge_blue
       ∏ w : {w : V // w ∈ D.complement},
         A.component w.1 (fun ie => regionMerge (G := G) A D.blue p ie.1) (σcompl w) := by
   classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  -- `ie` is incident to `w ∈ complement`, so `w ∉ blue`.
-  have hwcompl : w.1 ∈ D.complement := w.2
-  have hwnotblue : w.1 ∉ D.blue := fun hb =>
-    (Finset.disjoint_left.mp D.blue_disjoint_complement) hb hwcompl
-  have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-  by_cases hinc : IsRegionIncidentEdge (G := G) D.blue ie.1
-  · -- `ie` is blue-incident and touches `w ∉ blue`: a boundary edge of the blue block,
-    -- where `p.1` and `p.2` agree.
-    have hbdry : IsRegionBoundaryEdge (G := G) D.blue ie.1 := by
-      rcases hinc with h1 | h2
-      · rcases hwinc with hw1 | hw2
-        · exact absurd (by rw [← hw1]; exact h1) hwnotblue
-        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hwnotblue
-      · rcases hwinc with hw1 | hw2
-        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hwnotblue
-        · exact absurd (by rw [← hw2]; exact h2) hwnotblue
+  apply regionProd_subtype_congr
+  intro ie hie
+  by_cases hinc : IsRegionIncidentEdge (G := G) D.blue ie
+  · have hbdry : IsRegionBoundaryEdge (G := G) D.blue ie :=
+      isRegionBoundaryEdge_of_disjoint_incident (G := G) D.complement D.blue
+        D.blue_disjoint_complement.symm hie hinc
     rw [regionMerge, if_pos hinc]
-    have := congrFun hp ⟨ie.1, hbdry⟩
+    have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
   · rw [regionMerge, if_neg hinc]
 

--- a/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
@@ -378,18 +378,12 @@ theorem complProd_overwrite_blueRedCrossing_eq
     (h : ∀ g : Edge G, ¬ IsBlueRedCrossingEdge (A := A) (e := e) D g → ζ g = ζ' g) :
     (∏ w : {w : V // w ∈ D.complement}, A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
       ∏ w : {w : V // w ∈ D.complement}, A.component w.1 (fun ie => ζ' ie.1) (σcompl w) := by
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D ie.1
-  · have hinc : IsRegionIncidentEdge (G := G) D.complement ie.1 := by
-      have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-      rcases hwinc with hw | hw
-      · exact Or.inl (by rw [hw]; exact w.2)
-      · exact Or.inr (by rw [hw]; exact w.2)
-    exact absurd hinc
+  apply regionProd_subtype_congr
+  intro ie hie
+  by_cases hcross : IsBlueRedCrossingEdge (A := A) (e := e) D ie
+  · exact absurd hie
       (not_isRegionIncidentEdge_complement_of_blueRedCrossing (A := A) (e := e) D hcross)
-  · exact h ie.1 hcross
+  · exact h ie hcross
 
 open scoped Classical in
 /-- **The red/blue crossing fiber count.** Among the global configurations carrying the

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
@@ -259,27 +259,14 @@ theorem ThreeBlockGeometry.blueProd_eq_regionMerge_complement
       ∏ w : {w : V // w ∈ g.blue},
         A.component w.1 (fun ie => regionMerge (G := G) A g.complement p ie.1) (σblue w) := by
   classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  -- `ie` is incident to `w ∈ blue`, so `w ∉ complement`.
-  have hwblue : w.1 ∈ g.blue := w.2
-  have hwnotcompl : w.1 ∉ g.complement := fun hc =>
-    (Finset.disjoint_left.mp g.blue_disjoint_complement) hwblue hc
-  have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-  by_cases hinc : IsRegionIncidentEdge (G := G) g.complement ie.1
-  · -- `ie` is complement-incident and touches `w ∉ complement`: a boundary edge of
-    -- the complement, where `p.1` and `p.2` agree.
-    have hbdry : IsRegionBoundaryEdge (G := G) g.complement ie.1 := by
-      rcases hinc with h1 | h2
-      · rcases hwinc with hw1 | hw2
-        · exact absurd (by rw [← hw1]; exact h1) hwnotcompl
-        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hwnotcompl
-      · rcases hwinc with hw1 | hw2
-        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hwnotcompl
-        · exact absurd (by rw [← hw2]; exact h2) hwnotcompl
+  apply regionProd_subtype_congr
+  intro ie hie
+  by_cases hinc : IsRegionIncidentEdge (G := G) g.complement ie
+  · have hbdry : IsRegionBoundaryEdge (G := G) g.complement ie :=
+      isRegionBoundaryEdge_of_disjoint_incident (G := G) g.blue g.complement
+        g.blue_disjoint_complement hie hinc
     rw [regionMerge, if_pos hinc]
-    have := congrFun hp ⟨ie.1, hbdry⟩
+    have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
   · rw [regionMerge, if_neg hinc]
 /-- On a boundary edge of the host `univ \ red`, the blue-side global configuration

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean
@@ -350,18 +350,12 @@ theorem ThreeBlockGeometry.complProd_overwrite_blueRedCrossing_eq
     (h : ∀ eg : Edge G, ¬ g.IsBlueRedCrossingEdge A eg → ζ eg = ζ' eg) :
     (∏ w : {w : V // w ∈ g.complement}, A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
       ∏ w : {w : V // w ∈ g.complement}, A.component w.1 (fun ie => ζ' ie.1) (σcompl w) := by
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  by_cases hcross : g.IsBlueRedCrossingEdge A ie.1
-  · have hinc : IsRegionIncidentEdge (G := G) g.complement ie.1 := by
-      have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-      rcases hwinc with hw | hw
-      · exact Or.inl (by rw [hw]; exact w.2)
-      · exact Or.inr (by rw [hw]; exact w.2)
-    exact absurd hinc
+  apply regionProd_subtype_congr
+  intro ie hie
+  by_cases hcross : g.IsBlueRedCrossingEdge A ie
+  · exact absurd hie
       (g.not_isRegionIncidentEdge_complement_of_blueRedCrossing hcross)
-  · exact h ie.1 hcross
+  · exact h ie hcross
 
 open scoped Classical in
 /-- **The red/blue crossing fiber count.** Among the global configurations carrying the

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -48,27 +48,14 @@ theorem ThreeBlockGeometry.complProd_eq_regionMerge_blue
       ∏ w : {w : V // w ∈ g.complement},
         A.component w.1 (fun ie => regionMerge (G := G) A g.blue p ie.1) (σcompl w) := by
   classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  -- `ie` is incident to `w ∈ complement`, so `w ∉ blue`.
-  have hwcompl : w.1 ∈ g.complement := w.2
-  have hwnotblue : w.1 ∉ g.blue := fun hb =>
-    (Finset.disjoint_left.mp g.blue_disjoint_complement) hb hwcompl
-  have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-  by_cases hinc : IsRegionIncidentEdge (G := G) g.blue ie.1
-  · -- `ie` is blue-incident and touches `w ∉ blue`: a boundary edge of the blue block,
-    -- where `p.1` and `p.2` agree.
-    have hbdry : IsRegionBoundaryEdge (G := G) g.blue ie.1 := by
-      rcases hinc with h1 | h2
-      · rcases hwinc with hw1 | hw2
-        · exact absurd (by rw [← hw1]; exact h1) hwnotblue
-        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hwnotblue
-      · rcases hwinc with hw1 | hw2
-        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hwnotblue
-        · exact absurd (by rw [← hw2]; exact h2) hwnotblue
+  apply regionProd_subtype_congr
+  intro ie hie
+  by_cases hinc : IsRegionIncidentEdge (G := G) g.blue ie
+  · have hbdry : IsRegionBoundaryEdge (G := G) g.blue ie :=
+      isRegionBoundaryEdge_of_disjoint_incident (G := G) g.complement g.blue
+        g.blue_disjoint_complement.symm hie hinc
     rw [regionMerge, if_pos hinc]
-    have := congrFun hp ⟨ie.1, hbdry⟩
+    have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
   · rw [regionMerge, if_neg hinc]
 

--- a/TNLean/PEPS/TorusWindowChain4.lean
+++ b/TNLean/PEPS/TorusWindowChain4.lean
@@ -154,13 +154,10 @@ theorem regionProd_p1_eq_merge_of_subset {T B : Finset V} (hBT : B ⊆ T)
     (∏ w : {w : V // w ∈ B}, A.component w.1 (fun ie => p.1 ie.1) (σ w)) =
       ∏ w : {w : V // w ∈ B},
         A.component w.1 (fun ie => regionMerge (G := G) A T p ie.1) (σ w) := by
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  have hinc : IsRegionIncidentEdge (G := G) T ie.1 := by
-    rcases ie.2 with hie | hie
-    · exact Or.inl (hBT (by rw [hie]; exact w.2))
-    · exact Or.inr (hBT (by rw [hie]; exact w.2))
+  apply regionProd_subtype_congr
+  intro ie hie
+  have hinc : IsRegionIncidentEdge (G := G) T ie :=
+    hie.elim (fun h => Or.inl (hBT h)) (fun h => Or.inr (hBT h))
   rw [regionMerge, if_pos hinc]
 
 /-- A vertex product over `B ⊆ univ \ T` reads `p.2` through the merge `regionMerge A T p`, given
@@ -177,23 +174,16 @@ theorem regionProd_p2_eq_merge_of_compl {T B : Finset V} (hBT : B ⊆ Finset.uni
       ∏ w : {w : V // w ∈ B},
         A.component w.1 (fun ie => regionMerge (G := G) A T p ie.1) (σ w) := by
   classical
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  have hwnotT : w.1 ∉ T := by have := hBT w.2; rw [Finset.mem_sdiff] at this; exact this.2
-  by_cases hinc : IsRegionIncidentEdge (G := G) T ie.1
-  · -- `ie` is `T`-incident and touches `w ∉ T`: a boundary edge of `T`.
-    have hwinc : ie.1.1.1 = w.1 ∨ ie.1.1.2 = w.1 := ie.2
-    have hbdry : IsRegionBoundaryEdge (G := G) T ie.1 := by
-      rcases hinc with h1 | h2
-      · rcases hwinc with hw1 | hw2
-        · exact absurd (by rw [← hw1]; exact h1) hwnotT
-        · refine Or.inl ⟨h1, ?_⟩; rw [hw2]; exact hwnotT
-      · rcases hwinc with hw1 | hw2
-        · refine Or.inr ⟨?_, h2⟩; rw [hw1]; exact hwnotT
-        · exact absurd (by rw [← hw2]; exact h2) hwnotT
+  apply regionProd_subtype_congr
+  intro ie hie
+  have hcompl : IsRegionIncidentEdge (G := G) (Finset.univ \ T) ie :=
+    hie.elim (fun h => Or.inl (hBT h)) (fun h => Or.inr (hBT h))
+  by_cases hinc : IsRegionIncidentEdge (G := G) T ie
+  · have hbdry : IsRegionBoundaryEdge (G := G) T ie :=
+      isRegionBoundaryEdge_of_disjoint_incident (G := G) (Finset.univ \ T) T
+        Finset.sdiff_disjoint hcompl hinc
     rw [regionMerge, if_pos hinc]
-    have := congrFun hp ⟨ie.1, hbdry⟩
+    have := congrFun hp ⟨ie, hbdry⟩
     simpa [regionBoundaryLabel] using this.symm
   · rw [regionMerge, if_neg hinc]
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -36,6 +36,20 @@ abstracted — record why, so it is not re-proposed).
 - **Abstraction:** `@[mps_transfer]` simp set + `transfer_simp` macro
   (`TNLean/MPS/Tactic/Basic.lean`).
 
+### peps_prod_entry_congr — promoted
+- **Pattern:** product congruence followed by component-function extensionality:
+  `refine Finset.prod_congr rfl (fun w _ => ?_); congr 1; funext ie`.
+- **Seen:** 12 expanded occurrences across 10 PEPS files before promotion. Nine call sites
+  now use the shared lemma; one expanded occurrence is its proof, while the two occurrences
+  in `RegionBlock/Recovery.lean` remain for the #4522 owner (2026-07-22).
+- **Abstraction:** `regionProd_subtype_congr` in
+  `TNLean/PEPS/RegionBlock/Basic.lean`, supported by
+  `isRegionBoundaryEdge_of_disjoint_incident` for the repeated disjoint-region side goal.
+- **Notes:** the abstraction is a lemma rather than a tactic and quantifies over arbitrary
+  region physical configurations. The existing `regionProd_congr` statement is preserved
+  as a wrapper. The migrated PEPS slice loses 60 source lines (92 additions,
+  152 deletions); all existing theorem statements are unchanged.
+
 ### eta_cyclic_local_operator_transport — promoted
 - **Pattern:** reindexing a translated two-site bond into cyclic edge coordinates, then
   proving it is block diagonal with a single active edge factor.
@@ -124,29 +138,6 @@ spectral split → block extraction → MPV calculation → strict bounds
   embedding. Record before a third coordinate-transport proof appears; confirm
   that their product-family goal shapes agree before promotion.
 
-### matrix_entry_cases — candidate
-- **Pattern:**
-  ```
-  ext i j
-  by_cases hij : i = j
-  · subst hij
-    ...
-  ```
-- **Seen:** 10 occurrences across >= 4 files
-  (`TNLean/Algebra/HermitianHelpers.lean:115`,
-  `TNLean/Algebra/HermitianHelpers.lean:144`,
-  `TNLean/Channel/ChoiJamiolkowski.lean:407`,
-  `TNLean/Channel/ChoiTypeMap.lean:308`, +6 more).
-- **Abstraction (proposed):** cross-cutting macro `matrix_entry_cases`
-  (in a new `TNLean/Tactic/Basic.lean`) that performs the entrywise
-  extensionality plus diagonal/off-diagonal split, leaving the two goals
-  named. Check first whether the diagonal-matrix Mathlib API
-  (`Matrix.diagonal_apply_ne` etc.) turns specific call sites into lemmas
-  instead. Also try `ext i j <;> grind` at a few call sites (with
-  `Matrix.diagonal_apply`-family lemmas `@[grind =]`-tagged if needed) —
-  the case split and entry arithmetic are squarely in `grind`'s scope;
-  unverified pending a build-capable session.
-
 ### clm_norm_instances — candidate
 - **Pattern:**
   ```
@@ -164,21 +155,6 @@ spectral split → block extraction → MPV calculation → strict bounds
   need `letI` at all (likely an instance-resolution gap); either fix the
   underlying instance visibility once in a shared file, or provide a
   `clm_norm_instances` macro expanding to the block.
-
-### peps_prod_entry_congr — candidate
-- **Pattern:**
-  ```
-  refine Finset.prod_congr rfl (fun w _ => ?_)
-  congr 1
-  funext ie
-  ```
-- **Seen:** 12 occurrences across PEPS files
-  (`TNLean/PEPS/NormalFundamentalTheorem.lean:106`,
-  `TNLean/PEPS/RegionBlock/InsertResidual.lean:468`,
-  `TNLean/PEPS/RegionBlock/Recovery.lean:239`, +9 more).
-- **Abstraction (proposed):** likely a missing congruence lemma for
-  PEPS region products rather than a tactic; state it once in
-  `TNLean/PEPS/RegionBlock/` and `apply` it.
 
 ### filter_sum_split — candidate
 - **Pattern:**
@@ -249,6 +225,17 @@ spectral split → block extraction → MPV calculation → strict bounds
 ---
 
 ## Rejected
+
+### matrix_entry_cases — rejected
+- **Pattern:** matrix extensionality followed by a diagonal/off-diagonal split:
+  `ext i j; by_cases hij : i = j; · subst hij`.
+- **Seen:** 10 candidate occurrences across 8 files in the #4528 audit.
+- **Reason:** The prototype macro hid only two idiomatic structural lines at each call site,
+  required eight new imports and a new cross-cutting tactic module, and increased total
+  source by nine lines (49 additions, 40 deletions). Its `try subst` implementation also
+  violated the fail-fast rule for promoted tactics. The occurrences share no mathematical
+  conclusion from which to extract a lemma, so keeping the explicit case split is clearer
+  and more Mathlib-style.
 
 ### RFP structural semantic helper split — rejected
 - **Pattern:** split `rfp_nt_structural_full_sqSum` into private matrix-unit


### PR DESCRIPTION
Closes #4528.

Consolidates repeated PEPS proof patterns and records the reusable tactic guidance, without changing theorem statements.

Verification: `lake build TNLean.PEPS.NormalFundamentalTheorem` completed successfully (1910 jobs); `git diff --check` is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorem statements; net line reduction and a single shared congruence lemma lower duplication risk without touching runtime or external APIs.
> 
> **Overview**
> Extracts the repeated **region vertex-product congruence** pattern into shared lemmas in `RegionBlock/Basic.lean`, then rewires PEPS proofs to call them instead of inline `Finset.prod_congr` / `congr` / `funext` steps.
> 
> **`regionProd_subtype_congr`** is the main abstraction: a region product depends on a virtual configuration only through `R`-incident edges. **`IsRegionIncidentEdge`** moves from `NormalFundamentalTheorem.lean` into `Basic.lean` (with its `Decidable` instance). **`isRegionBoundaryEdge_of_disjoint_incident`** captures the disjoint-region case used when proving merge lemmas (incident to both blocks ⇒ boundary of the second).
> 
> `regionProd_congr` in `NormalFundamentalTheorem.lean` is now a one-line wrapper around `regionProd_subtype_congr`. Nine other theorems (insert overwrite, three-block merge, union injectivity, torus window chain, etc.) shrink to `apply regionProd_subtype_congr` plus edge-wise hypotheses.
> 
> `docs/tactic_patterns.md` records **`peps_prod_entry_congr` as promoted** and **`matrix_entry_cases` as rejected** (macro cost vs. clarity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4efdbae9f49bcbca7d246855382f718f7827b3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->