### PR TITLE
refactor(PEPS): define vertical torus windows by swap

### DIFF
--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -9,57 +9,28 @@ import TNLean.PEPS.TorusWindowFamily
 /-!
 # The staircase window family around a vertical edge
 
-The two-dimensional strengthening of the normal PEPS Fundamental Theorem
-(arXiv:1804.04964, the corollary at lines 2297--2318 of
-`Papers/1804.04964/paper_normal.tex`) compares, around a vertical edge, a family of
-`L + K` overlapping windows that turn the corner of the edge: the first `K + 1`
-descend across the edge one row at a time, then the last `L - 1` shift right one
-column at a time.  This is the column--row transpose of the horizontal-edge family
-of `TNLean/PEPS/TorusWindowFamily.lean`, with the roles of `L` and `K` and of the
-two coordinate axes interchanged throughout.  This file builds the full indexed
-family `W_0, …, W_{L+K-1}` interpolating between the two end windows, the
-consecutive-window unions `U_j = W_j ∪ W_{j+1}`, and the subset nesting
-`W_j ⊆ U_j ⊆ P` the open-boundary patch chaining consumes.  It is scoped in
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the section on the window family
-around an edge.
+The vertical staircase is the image of the horizontal staircase under coordinate
+interchange, with the side lengths exchanged.  This module keeps the public
+vertical API while deriving its geometry from `TorusWindowFamily` through
+`torusCoordinateSwapRegion`.
 
-## The family in staircase coordinates
-
-In the staircase coordinates `s = (a, b)` of the end pair the windows are the cyclic
+In staircase coordinates `s = (a, b)`, the resulting windows are the cyclic
 `L × K` rectangles
 
-* `W_j = [a + L - 1, a + 2L - 1) × [b + K - j, b + 2K - j)` for `j = 0, …, K`, the
-  descending arm sharing the column band `[a + L - 1, a + 2L - 1)`;
-* `W_{K + i} = [a + L - 1 - i, a + 2L - 1 - i) × [b, b + K)` for `i = 1, …, L - 1`,
-  the right-shifting arm sharing the row band `[b, b + K)`.
+* `W_j = [a + L - 1, a + 2L - 1) × [b + K - j, b + 2K - j)` for `j ≤ K`;
+* `W_{K+i} = [a + L - 1 - i, a + 2L - 1 - i) × [b, b + K)`.
 
-The corner window `W_K = [a + L - 1, a + 2L - 1) × [b, b + K)` is the meeting point of
-the two arms.  The first window `W_0` is the right end window
-`verticalStaircaseRightWindow` and the last `W_{L+K-1}` is the left end window
-`verticalStaircaseLeftWindow`.  The offsets are read with truncated subtraction: the
-row offset `K - j` collapses to `0` on the right-shifting arm and the column offset
-`(L - 1) - (j - K)` collapses to `L - 1` on the descending arm, so a single formula
-covers both arms with the corner window `W_K` shared.
-
-## The consecutive-window unions
-
-Two consecutive descending windows (`j < K`) differ by one row, so their union is the
-`L × (K + 1)` cyclic rectangle of `verticalAdjacentWindows_union`.  Two consecutive
-right-shifting windows (`K ≤ j`) differ by one column, so their union is the
-`(L + 1) × K` cyclic rectangle of `horizontalAdjacentWindows_union`.  The transition
-between the two arms is not a separate shape: the corner window `W_K` shares the row
-band `[b, b + K)` with its successor `W_{K+1}`, so the union `U_K` is an ordinary
-horizontal `(L + 1) × K` rectangle and the union `U_{K-1}` an ordinary vertical
-`L × (K + 1)` rectangle.
+The first arm descends and the second shifts horizontally.  All endpoint,
+consecutive-union, membership, nesting, and covering statements below are
+transported counterparts of the horizontal declarations.
 
 ## References
 
 * [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
-  pair states generating the same state*, arXiv:1804.04964, the corollary and
-  proof sketch at lines 2296--2445 of
-  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
-  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the
-  section on the window family around an edge.
+  pair states generating the same state*, arXiv:1804.04964, lines 2296--2445 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964).
+* `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the section on the window
+  family around an edge.
 -/
 
 namespace TNLean
@@ -67,168 +38,106 @@ namespace PEPS
 
 variable {width height : ℕ} [NeZero width] [NeZero height]
 
-/-! ### The end windows and the patch around a vertical edge
+/-! ### Transported end windows, patch, and family -/
 
-The column--row transpose of the horizontal end windows and patch of
-`TNLean/PEPS/TorusWindowChain.lean`.  The descending arm sweeps the `L × 2K` vertical
-band `[a + L - 1, a + 2L - 1) × [b, b + 2K)`; the right-shifting arm sweeps the
-`(2L - 1) × K` horizontal band `[a, a + 2L - 1) × [b, b + K)`. -/
-
-/-- The right/first end window `W_0 = [a + L - 1, a + 2L - 1) × [b + K, b + 2K)` of the
-vertical staircase, in the staircase coordinates `s = (a, b)`.
-
-Source: arXiv:1804.04964, the corollary and proof sketch at lines 2297--2445 of
-`Papers/1804.04964/paper_normal.tex` (the window family around the edge);
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the section on the window family. -/
+/-- The first vertical end window, obtained by transposing the first horizontal
+end window with exchanged side lengths. -/
 def verticalStaircaseRightWindow (s : TorusVertex width height) (L K : ℕ) :
     Finset (TorusVertex width height) :=
-  torusArcRectangle (s.1 + ((L - 1 : ℕ) : ZMod width), s.2 + (K : ZMod height)) L K
+  torusCoordinateSwapRegion (horizontalStaircaseRightWindow (s.2, s.1) K L)
 
-/-- The left/last end window `W_{L+K-1} = [a, a + L) × [b, b + K)` of the vertical
-staircase, in the staircase coordinates `s = (a, b)`.
-
-Source: arXiv:1804.04964, the corollary and proof sketch at lines 2297--2445 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-the section on the window family. -/
+/-- The last vertical end window, obtained by transposing the last horizontal
+end window with exchanged side lengths. -/
 def verticalStaircaseLeftWindow (s : TorusVertex width height) (L K : ℕ) :
     Finset (TorusVertex width height) :=
-  torusArcRectangle s L K
+  torusCoordinateSwapRegion (horizontalStaircaseLeftWindow (s.2, s.1) K L)
 
-/-- The vertical staircase patch `P`: the union of the `L × 2K` vertical band
-`[a + L - 1, a + 2L - 1) × [b, b + 2K)` and the `(2L - 1) × K` horizontal band
-`[a, a + 2L - 1) × [b, b + K)`, in the staircase coordinates `s = (a, b)`.
-
-Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex` (the patch `P = ⋃_j W_j`);
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the section on the window family. -/
+/-- The vertical staircase patch is the transpose of the horizontal patch with
+exchanged side lengths. -/
 def verticalStaircasePatch (s : TorusVertex width height) (L K : ℕ) :
     Finset (TorusVertex width height) :=
-  torusArcRectangle (s.1 + ((L - 1 : ℕ) : ZMod width), s.2) L (2 * K) ∪
-    torusArcRectangle s (2 * L - 1) K
+  torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L)
 
-/-! ### The staircase window family -/
-
-/-- The `j`-th window of the vertical staircase family around an edge, in the staircase
-coordinates `s = (a, b)` of the end pair.  It is the cyclic `L × K` rectangle with
-column start offset `(L - 1) - (j - K)` (truncated, so `L - 1` on the descending arm
-`j ≤ K`) and row start offset `K - j` (truncated, so `0` on the right-shifting arm
-`K ≤ j`):
-
-* `W_j = [a + L - 1, a + 2L - 1) × [b + K - j, b + 2K - j)` for `j ≤ K`;
-* `W_{K+i} = [a + L - 1 - i, a + 2L - 1 - i) × [b, b + K)` for `j = K + i`.
-
-The shared corner window `W_K = [a + L - 1, a + 2L - 1) × [b, b + K)` sits at the
-meeting of the two arms.  This is the column--row transpose of `staircaseWindow`.
-
-Source: arXiv:1804.04964, the corollary and proof sketch at lines 2297--2445 of
-`Papers/1804.04964/paper_normal.tex` (the window family around the edge);
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the section on the window family. -/
+/-- The `j`-th vertical staircase window is the transpose of the `j`-th
+horizontal staircase window with exchanged side lengths. -/
 def verticalStaircaseWindow (s : TorusVertex width height) (L K j : ℕ) :
     Finset (TorusVertex width height) :=
-  torusArcRectangle
-    (s.1 + ((L - 1 - (j - K) : ℕ) : ZMod width), s.2 + ((K - j : ℕ) : ZMod height)) L K
+  torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j)
 
 /-! ### Coordinate-swap covariance -/
 
-/-- The first vertical end window is the coordinate transpose of the first horizontal
-end window with exchanged side lengths. -/
+/-- The first vertical end window is the coordinate transpose of the first
+horizontal end window with exchanged side lengths. -/
 theorem torusCoordinateSwapRegion_horizontalStaircaseRightWindow
     (s : TorusVertex width height) (L K : ℕ) :
     torusCoordinateSwapRegion
         (horizontalStaircaseRightWindow (s.2, s.1) K L) =
-      verticalStaircaseRightWindow s L K := by
-  rw [horizontalStaircaseRightWindow, verticalStaircaseRightWindow,
-    torusCoordinateSwapRegion_torusArcRectangle]
+      verticalStaircaseRightWindow s L K :=
+  rfl
 
-/-- The last vertical end window is the coordinate transpose of the last horizontal
-end window with exchanged side lengths. -/
+/-- The last vertical end window is the coordinate transpose of the last
+horizontal end window with exchanged side lengths. -/
 theorem torusCoordinateSwapRegion_horizontalStaircaseLeftWindow
     (s : TorusVertex width height) (L K : ℕ) :
     torusCoordinateSwapRegion
         (horizontalStaircaseLeftWindow (s.2, s.1) K L) =
-      verticalStaircaseLeftWindow s L K := by
-  rw [horizontalStaircaseLeftWindow, verticalStaircaseLeftWindow,
-    torusCoordinateSwapRegion_torusArcRectangle]
+      verticalStaircaseLeftWindow s L K :=
+  rfl
 
 /-- The vertical staircase patch is the coordinate transpose of the horizontal
 staircase patch with exchanged side lengths. -/
 theorem torusCoordinateSwapRegion_horizontalStaircasePatch
     (s : TorusVertex width height) (L K : ℕ) :
     torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L) =
-      verticalStaircasePatch s L K := by
-  rw [horizontalStaircasePatch, verticalStaircasePatch, torusCoordinateSwapRegion_union,
-    torusCoordinateSwapRegion_torusArcRectangle,
-    torusCoordinateSwapRegion_torusArcRectangle]
+      verticalStaircasePatch s L K :=
+  rfl
 
-/-- Each vertical staircase window is the coordinate transpose of the corresponding
-horizontal staircase window with exchanged side lengths. -/
+/-- Each vertical staircase window is the coordinate transpose of the
+corresponding horizontal window with exchanged side lengths. -/
 theorem torusCoordinateSwapRegion_staircaseWindow
     (s : TorusVertex width height) (L K j : ℕ) :
     torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j) =
-      verticalStaircaseWindow s L K j := by
-  rw [staircaseWindow, verticalStaircaseWindow,
-    torusCoordinateSwapRegion_torusArcRectangle]
+      verticalStaircaseWindow s L K j :=
+  rfl
 
-/-- The first window of the family is the right end window: at `j = 0` the column
-offset is `L - 1` and the row offset `K`, the start of `verticalStaircaseRightWindow`. -/
+/-- The first window of the vertical family is its first end window. -/
 theorem verticalStaircaseWindow_zero (s : TorusVertex width height) (L K : ℕ) :
     verticalStaircaseWindow s L K 0 = verticalStaircaseRightWindow s L K := by
-  rw [verticalStaircaseWindow, verticalStaircaseRightWindow]
-  have hcol : (L - 1 - (0 - K) : ℕ) = (L - 1 : ℕ) := by omega
-  have hrow : (K - 0 : ℕ) = K := by omega
-  rw [hcol, hrow]
+  simp only [verticalStaircaseWindow, verticalStaircaseRightWindow, staircaseWindow_zero]
 
-/-- The last window of the family is the left end window: at `j = L + K - 1` both
-offsets collapse to `0`, the start of `verticalStaircaseLeftWindow`. -/
+/-- The last window of the vertical family is its last end window. -/
 theorem verticalStaircaseWindow_last (s : TorusVertex width height) {L K : ℕ}
     (hL : 0 < L) (hK : 0 < K) :
     verticalStaircaseWindow s L K (L + K - 1) = verticalStaircaseLeftWindow s L K := by
-  rw [verticalStaircaseWindow, verticalStaircaseLeftWindow]
-  have hcol : (L - 1 - ((L + K - 1) - K) : ℕ) = 0 := by omega
-  have hrow : (K - (L + K - 1) : ℕ) = 0 := by omega
-  rw [hcol, hrow]
-  simp
+  rw [verticalStaircaseWindow, verticalStaircaseLeftWindow, Nat.add_comm,
+    staircaseWindow_last (s.2, s.1) hK hL]
 
-/-- Every window of the staircase family is an `L × K` cyclic window, hence injective
-under the translation-invariant one-orientation window hypotheses.
-
-Source: arXiv:1804.04964, the corollary at lines 2297--2318 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-the section on the window family. -/
+/-- Every vertical staircase window is an `L × K` cyclic window, hence is
+injective under the window hypotheses. -/
 theorem NormalTorusArcWindowInjectivityHypotheses.verticalStaircaseWindow_injective
     {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
     (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
     (s : TorusVertex width height) (j : ℕ) :
-    κ.IsInjective (verticalStaircaseWindow s L K j) :=
-  h.arcWindow_injective _
+    κ.IsInjective (verticalStaircaseWindow s L K j) := by
+  rw [verticalStaircaseWindow, staircaseWindow,
+    torusCoordinateSwapRegion_torusArcRectangle]
+  exact h.arcWindow_injective _
 
-/-! ### The consecutive-window unions
+/-! ### Transported consecutive-window unions -/
 
-`verticalStaircaseUnion s L K j` is the union of the two consecutive windows `W_j` and
-`W_{j+1}`.  On the descending arm `j < K` the two windows share the column band and
-differ by one row, so the union is the `L × (K + 1)` cyclic rectangle of
-`verticalAdjacentWindows_union`.  On the right-shifting arm `K ≤ j` the two windows
-share the row band and differ by one column, so the union is the `(L + 1) × K` cyclic
-rectangle of `horizontalAdjacentWindows_union`. -/
-
-/-- The union of two consecutive windows of the staircase family.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex` (comparing consecutive windows);
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 1. -/
+/-- The union of two consecutive vertical staircase windows, defined as the
+coordinate transpose of the corresponding horizontal union. -/
 def verticalStaircaseUnion (s : TorusVertex width height) (L K j : ℕ) :
     Finset (TorusVertex width height) :=
-  verticalStaircaseWindow s L K j ∪ verticalStaircaseWindow s L K (j + 1)
+  torusCoordinateSwapRegion (staircaseUnion (s.2, s.1) K L j)
 
 /-- Each vertical consecutive-window union is the coordinate transpose of the
 corresponding horizontal union with exchanged side lengths. -/
 theorem torusCoordinateSwapRegion_staircaseUnion
     (s : TorusVertex width height) (L K j : ℕ) :
     torusCoordinateSwapRegion (staircaseUnion (s.2, s.1) K L j) =
-      verticalStaircaseUnion s L K j := by
-  rw [staircaseUnion, verticalStaircaseUnion, torusCoordinateSwapRegion_union,
-    torusCoordinateSwapRegion_staircaseWindow,
-    torusCoordinateSwapRegion_staircaseWindow]
+      verticalStaircaseUnion s L K j :=
+  rfl
 
 section GraphCovariance
 
@@ -239,34 +148,25 @@ theorem Region_map_torusCoordinateSwap_staircaseWindow
     (s : TorusVertex width height) (L K j : ℕ) :
     Region.map (torusCoordinateSwap (width := height) (height := width))
         (staircaseWindow (s.2, s.1) K L j) = verticalStaircaseWindow s L K j :=
-  torusCoordinateSwapRegion_staircaseWindow s L K j
+  rfl
 
 /-- Graph-isomorphism form of coordinate-swap covariance for consecutive unions. -/
 theorem Region_map_torusCoordinateSwap_staircaseUnion
     (s : TorusVertex width height) (L K j : ℕ) :
     Region.map (torusCoordinateSwap (width := height) (height := width))
         (staircaseUnion (s.2, s.1) K L j) = verticalStaircaseUnion s L K j :=
-  torusCoordinateSwapRegion_staircaseUnion s L K j
+  rfl
 
 /-- Graph-isomorphism form of coordinate-swap covariance for staircase patches. -/
 theorem Region_map_torusCoordinateSwap_horizontalStaircasePatch
     (s : TorusVertex width height) (L K : ℕ) :
     Region.map (torusCoordinateSwap (width := height) (height := width))
         (horizontalStaircasePatch (s.2, s.1) K L) = verticalStaircasePatch s L K :=
-  torusCoordinateSwapRegion_horizontalStaircasePatch s L K
+  rfl
 
 end GraphCovariance
 
-/-- **A descending-arm consecutive union is an `L × (K + 1)` cyclic rectangle.**
-
-For `j < K` the windows `W_j` and `W_{j+1}` share the column band
-`[a + L - 1, a + 2L - 1)` and differ by one row, so their union is the single
-`L × (K + 1)` cyclic rectangle with row start offset `K - (j + 1)`.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex` (the vertical-slide union is an
-$L\times(K+1)$ rectangle); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 1. -/
+/-- A descending-arm consecutive union is an `L × (K + 1)` cyclic rectangle. -/
 theorem verticalStaircaseUnion_eq_verticalRectangle {L K : ℕ} (hh : 1 < height)
     (s : TorusVertex width height) {j : ℕ} (hj : j < K) :
     verticalStaircaseUnion s L K j =
@@ -276,19 +176,10 @@ theorem verticalStaircaseUnion_eq_verticalRectangle {L K : ℕ} (hh : 1 < height
   have h := congrArg torusCoordinateSwapRegion
     (staircaseUnion_eq_horizontalRectangle (width := height) (height := width)
       (L := K) (K := L) hh (s.2, s.1) hj)
-  simpa only [torusCoordinateSwapRegion_staircaseUnion,
+  simpa only [verticalStaircaseUnion,
     torusCoordinateSwapRegion_torusArcRectangle] using h
 
-/-- **A right-shifting-arm consecutive union is an `(L + 1) × K` cyclic rectangle.**
-
-For `K ≤ j` the windows `W_j` and `W_{j+1}` share the row band `[b, b + K)` and differ
-by one column, so their union is the single `(L + 1) × K` cyclic rectangle with column
-start offset `(L - 1) - ((j + 1) - K)`.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex` (the consecutive-window union is an
-$(L+1)\times K$ rectangle); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 1. -/
+/-- A right-shifting-arm consecutive union is an `(L + 1) × K` cyclic rectangle. -/
 theorem verticalStaircaseUnion_eq_horizontalRectangle {L K : ℕ} (hw : 1 < width)
     (s : TorusVertex width height) {j : ℕ} (hj : K ≤ j) (hjK : j + 1 < L + K) :
     verticalStaircaseUnion s L K j =
@@ -297,16 +188,11 @@ theorem verticalStaircaseUnion_eq_horizontalRectangle {L K : ℕ} (hw : 1 < widt
   have h := congrArg torusCoordinateSwapRegion
     (staircaseUnion_eq_verticalRectangle (width := height) (height := width)
       (L := K) (K := L) hw (s.2, s.1) hj (by simpa [Nat.add_comm] using hjK))
-  simpa only [torusCoordinateSwapRegion_staircaseUnion,
+  simpa only [verticalStaircaseUnion,
     torusCoordinateSwapRegion_torusArcRectangle] using h
 
-/-- Each consecutive union of the staircase family is injective: on the descending arm
-it is the `L × (K + 1)` cyclic rectangle, on the right-shifting arm the `(L + 1) × K`
-cyclic rectangle, both injective under the translation-invariant window hypotheses.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 1. -/
+/-- Each vertical consecutive union is injective under the window and union
+closure hypotheses. -/
 theorem NormalTorusArcWindowInjectivityHypotheses.verticalStaircaseUnion_injective
     {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
     (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
@@ -314,99 +200,54 @@ theorem NormalTorusArcWindowInjectivityHypotheses.verticalStaircaseUnion_injecti
     (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height) (s : TorusVertex width height)
     {j : ℕ} (hjK : j + 1 < L + K) :
     κ.IsInjective (verticalStaircaseUnion s L K j) := by
-  by_cases harm : j < K
-  · rw [verticalStaircaseUnion_eq_verticalRectangle (by omega) s harm]
+  by_cases hj : j < K
+  · rw [verticalStaircaseUnion_eq_verticalRectangle (by omega) s hj]
     exact h.verticalUnion_injective hUnion hL hK hxw hyh _
   · rw [verticalStaircaseUnion_eq_horizontalRectangle (by omega) s (by omega) hjK]
     exact h.horizontalUnion_injective hUnion hL hK hxw hyh _
 
-/-! ### Membership in the family
+/-! ### Membership and transported nesting -/
 
-The cyclic distances of a window vertex from the staircase corner `s`, read back through
-`zmod_val_sub_shift`.  These reduce the subset facts below to natural-number
-arithmetic. -/
-
-/-- Membership in `verticalStaircaseWindow s L K j`, in terms of the cyclic distances
-from the staircase corner `s`.  On the descending arm `j ≤ K` the column distance lands
-in `[L - 1, 2L - 1)` and the row distance in `[K - j, 2K - j)`; on the right-shifting arm
-`K ≤ j` the row distance lands in `[0, K)` and the column distance in
-`[L - 1 - (j - K), 2L - 1 - (j - K))`.
-
-Source: arXiv:1804.04964, the corollary and proof sketch at lines 2297--2445 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-the section on the window family. -/
+/-- Membership in a vertical staircase window, expressed by cyclic distances
+from the staircase corner. -/
 theorem mem_verticalStaircaseWindow {L K j : ℕ} (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height)
     (s : TorusVertex width height) (v : TorusVertex width height) :
     v ∈ verticalStaircaseWindow s L K j ↔
       ((L - 1 - (j - K) : ℕ) ≤ (v.1 - s.1).val ∧
           (v.1 - s.1).val < (L - 1 - (j - K)) + L) ∧
         ((K - j : ℕ) ≤ (v.2 - s.2).val ∧ (v.2 - s.2).val < (K - j) + K) := by
-  rw [← torusCoordinateSwapRegion_staircaseWindow s L K j,
-    mem_torusCoordinateSwapRegion, mem_staircaseWindow hyh hxw]
+  rw [verticalStaircaseWindow, mem_torusCoordinateSwapRegion,
+    mem_staircaseWindow hyh hxw]
   exact and_comm
 
-/-! ### The subset nesting `W_j ⊆ U_j ⊆ P`
-
-The nesting consumed by the patch chaining. Each window sits in its consecutive union
-(definitionally), and every window — hence every union — sits in the staircase patch
-`P`. -/
-
-/-- The first window of a consecutive union sits in the union (definitionally). -/
+/-- The first window of a consecutive vertical union sits in that union. -/
 theorem verticalStaircaseWindow_subset_verticalStaircaseUnion
     (s : TorusVertex width height) (L K j : ℕ) :
     verticalStaircaseWindow s L K j ⊆ verticalStaircaseUnion s L K j :=
-  Finset.subset_union_left
+  torusCoordinateSwapRegion_mono (staircaseWindow_subset_staircaseUnion (s.2, s.1) K L j)
 
-/-- The second window of a consecutive union sits in the union (definitionally). -/
+/-- The second window of a consecutive vertical union sits in that union. -/
 theorem verticalStaircaseWindow_succ_subset_verticalStaircaseUnion
     (s : TorusVertex width height) (L K j : ℕ) :
     verticalStaircaseWindow s L K (j + 1) ⊆ verticalStaircaseUnion s L K j :=
-  Finset.subset_union_right
+  torusCoordinateSwapRegion_mono
+    (staircaseWindow_succ_subset_staircaseUnion (s.2, s.1) K L j)
 
-/-- **Each window sits in the staircase patch.**  A descending-arm window `W_j`
-(`j ≤ K`) sits in the vertical band `[a + L - 1, a + 2L - 1) × [b, b + 2K)` and a
-right-shifting-arm window `W_j` (`K ≤ j`) sits in the horizontal band
-`[a, a + 2L - 1) × [b, b + K)`; both bands are part of `P`.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex` (the patch `P = ⋃_j W_j`);
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 2. -/
+/-- Each vertical staircase window sits in the transported staircase patch. -/
 theorem verticalStaircaseWindow_subset_patch {L K j : ℕ} (hL : 0 < L)
     (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
-    verticalStaircaseWindow s L K j ⊆ verticalStaircasePatch s L K := by
-  rw [← torusCoordinateSwapRegion_staircaseWindow,
-    ← torusCoordinateSwapRegion_horizontalStaircasePatch]
-  exact torusCoordinateSwapRegion_mono
+    verticalStaircaseWindow s L K j ⊆ verticalStaircasePatch s L K :=
+  torusCoordinateSwapRegion_mono
     (staircaseWindow_subset_patch hL hyh hxw (s.2, s.1))
 
-/-- **Each consecutive union sits in the staircase patch.**  The union of two windows of
-the family, both of which sit in the patch.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 2. -/
+/-- Each vertical consecutive union sits in the transported staircase patch. -/
 theorem verticalStaircaseUnion_subset_patch {L K j : ℕ} (hL : 0 < L)
     (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
-    verticalStaircaseUnion s L K j ⊆ verticalStaircasePatch s L K := by
-  rw [← torusCoordinateSwapRegion_staircaseUnion,
-    ← torusCoordinateSwapRegion_horizontalStaircasePatch]
-  exact torusCoordinateSwapRegion_mono
+    verticalStaircaseUnion s L K j ⊆ verticalStaircasePatch s L K :=
+  torusCoordinateSwapRegion_mono
     (staircaseUnion_subset_patch hL hyh hxw (s.2, s.1))
 
-/-! ### The patch is the union of the family
-
-The staircase patch `P = ⋃_j W_j` is exactly the union of the `L + K` windows of the
-family. The result follows by transposing the corresponding horizontal family. -/
-
-/-- **The patch is the union of the staircase family.**  The staircase patch `P` equals
-the union of the `L + K` windows `W_0, …, W_{L+K-1}`: every window sits in `P`, and
-conversely every vertex of `P` lies in some window — a vertical-band vertex in a
-descending window `W_j` with `j ≤ K`, a horizontal-band vertex in a right-shifting window
-`W_{K+i}`.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex` (the patch `P = ⋃_j W_j`);
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the section on the window family. -/
+/-- The transported patch is exactly the union of the vertical staircase family. -/
 theorem biUnion_verticalStaircaseWindow_eq_patch {L K : ℕ} (hL : 0 < L) (hK : 0 < K)
     (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
     (Finset.range (L + K)).biUnion (verticalStaircaseWindow s L K) =
@@ -416,16 +257,13 @@ theorem biUnion_verticalStaircaseWindow_eq_patch {L K : ℕ} (hL : 0 < L) (hK : 
         (Finset.range (K + L)).biUnion
           (fun j => torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j)) := by
       rw [Nat.add_comm]
-      congr 1
-      funext j
-      exact (torusCoordinateSwapRegion_staircaseWindow s L K j).symm
+      rfl
     _ = torusCoordinateSwapRegion
         ((Finset.range (K + L)).biUnion (staircaseWindow (s.2, s.1) K L)) :=
       (torusCoordinateSwapRegion_biUnion _ _).symm
     _ = torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L) := by
       rw [biUnion_staircaseWindow_eq_patch hK hL hyh hxw]
-    _ = verticalStaircasePatch s L K :=
-      torusCoordinateSwapRegion_horizontalStaircasePatch s L K
+    _ = verticalStaircasePatch s L K := rfl
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -11,8 +11,8 @@ import TNLean.PEPS.TorusWindowFamily
 
 The vertical staircase is the image of the horizontal staircase under coordinate
 interchange, with the side lengths exchanged.  This module keeps the public
-vertical API while deriving its geometry from `TorusWindowFamily` through
-`torusCoordinateSwapRegion`.
+vertical family of declarations while deriving its geometry from
+`TorusWindowFamily` through `torusCoordinateSwapRegion`.
 
 In staircase coordinates `s = (a, b)`, the resulting windows are the cyclic
 `L × K` rectangles


### PR DESCRIPTION
Advances #4526.

Defines the five vertical staircase-window objects as coordinate-swapped horizontal objects and derives all 12 original vertical results plus eight covariance declarations as thin consequences of the horizontal family and swap API. All 25 public declaration signatures remain unchanged.

`TorusWindowFamilyVertical.lean` shrinks from 431 to 269 lines (-162, 37.6%). The public module remains because the root import surface exposes this API.

Verification (without recreating Mathlib caches): native diagnostics clean on the changed leaf; blueprint sync and changed-declaration coverage pass; prose/import/root exposure/signature/size/numbered-debt/proof-integrity checks pass; `git diff --check` clean.

Remaining #4526 work includes the `UnionInjectivityGeneralBlue` mirror and broader normal-square/torus geometry mirror clusters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean refactor with unchanged public types and theorems; risk is limited to proof correctness of the swap transport, not runtime or security behavior.
> 
> **Overview**
> **Vertical staircase window geometry** in `TorusWindowFamilyVertical.lean` is no longer built from explicit `torusArcRectangle` formulas. The five core objects (`verticalStaircaseRightWindow`, `verticalStaircaseLeftWindow`, `verticalStaircasePatch`, `verticalStaircaseWindow`, `verticalStaircaseUnion`) are now **`torusCoordinateSwapRegion` images** of the matching horizontal declarations from `TorusWindowFamily`, with coordinates `(s.2, s.1)` and side lengths `K`/`L` swapped.
> 
> **Proofs shrink** because covariance lemmas become definitional (`rfl`), and membership, nesting, union-as-rectangle, injectivity, and patch-covering results are obtained by **monotonicity / `congrArg` transport** from the horizontal theory instead of duplicated arithmetic on offsets.
> 
> The **public declaration surface is unchanged**; module docs are shortened to describe the transpose-and-transport story. The file drops ~162 lines (~38%).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3026dfdf32433fdf4734b7af5b79c77e8f587367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->