### PR TITLE
refactor(MPS): centralize BNT basis normality

### DIFF
--- a/TNLean/MPS/BNT/Bridge.lean
+++ b/TNLean/MPS/BNT/Bridge.lean
@@ -115,19 +115,6 @@ namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
 
-/-- Every basis tensor in BNT canonical form is algebraically normal.
-
-The canonical-form irreducibility, left-canonicality, normalized self-overlap,
-and positive bond dimension imply eventual block injectivity.
-
-Source: CPSV21, arXiv:2011.12127, lines 1815--1830. -/
-theorem basis_isNormal (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
-    IsNormal (P.basis j) := by
-  letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
-  exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-    (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-      (hCF.basis_normalized_self_overlap j)
-
 /-- Forget a BNT canonical form to the algebraic BNT carried by its basis.
 
 The sector coefficient formula supplies the spanning clause, while

--- a/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
+++ b/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
@@ -167,6 +167,19 @@ namespace MPSTensor.IsBNTCanonicalForm
 
 variable {d : ℕ} {P : SectorDecomposition d}
 
+/-- Every basis tensor in BNT canonical form is algebraically normal.
+
+The canonical-form irreducibility, left-canonicality, normalized self-overlap,
+and positive bond dimension imply eventual block injectivity.
+
+Source: CPSV21, arXiv:2011.12127, lines 1815--1830. -/
+theorem basis_isNormal (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
+    IsNormal (P.basis j) := by
+  letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+  exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+    (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
+      (hCF.basis_normalized_self_overlap j)
+
 /-- Every representative of a BNT canonical form is block injective at the
 common length $D^4$, where $D$ is the total bond dimension.
 
@@ -181,10 +194,7 @@ theorem basis_isNBlkInjective_totalDim_pow_four
       IsNBlkInjective (P.basis j) (P.totalDim ^ 4) := by
   intro j
   letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
-  have hNormal : IsNormal (P.basis j) :=
-    isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-      (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-        (hCF.basis_normalized_self_overlap j)
+  have hNormal : IsNormal (P.basis j) := hCF.basis_isNormal j
   have hOwn : IsNBlkInjective (P.basis j) ((P.basisDim j) ^ 4) :=
     isNBlkInjective_pow_four_of_isNormal_leftCanonical
       (P.basis j) (hCF.basis_left_canonical j) hNormal
@@ -207,12 +217,8 @@ lines 1815--1837. -/
 theorem exists_common_basis_isNBlkInjective
     (hCF : IsBNTCanonicalForm P) :
     ∃ L : ℕ, 0 < L ∧ ∀ j : Fin P.basisCount, IsNBlkInjective (P.basis j) L := by
-  have hNormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) := by
-    intro j
-    letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
-    exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-      (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-        (hCF.basis_normalized_self_overlap j)
+  have hNormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) :=
+    hCF.basis_isNormal
   exact exists_common_isNBlkInjective_of_isNormal_leftCanonical
     P.basis hCF.basis_left_canonical (fun j ↦ (hCF.basis_dim_pos j).ne') hNormal
 

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -378,11 +378,8 @@ theorem rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum
   · letI : NeZero d := ⟨hd⟩
     letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
       fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
-    have hnormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) := by
-      intro j
-      exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-        (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-          (hCF.basis_normalized_self_overlap j)
+    have hnormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) :=
+      hCF.basis_isNormal
     have hOne : WordTupleSpanTop P.basis 1 :=
       wordTupleSpanTop_one_of_isTransferIdempotent_directSum P.basis
         hnormal hCF.basis_irreducible hCF.basis_left_canonical


### PR DESCRIPTION
### Motivation

Follow-up to #4520. The common blockwise-normality consequence of a
paper-faithful BNT canonical form should live with the normalized self-overlap
result from which it follows, rather than in the carrier-comparison module.

### Description

- Move `IsBNTCanonicalForm.basis_isNormal` from
  `TNLean/MPS/BNT/Bridge.lean` to
  `TNLean/MPS/Periodic/NormalizedSelfOverlap.lean`.
- Reuse the public theorem in the BNT bridge and the multi-sector RFP proof
  instead of repeating its proof.
- Remove the stale `Bridge.lean` module-docstring entry identified in review.

The theorem name, statement, and blueprint declaration link are unchanged.

### Testing

- `lake build` (9,730 jobs; completed successfully)
- `git diff --check`
- proof-integrity scan of all three changed Lean files

`leanblueprint checkdecls` was not run locally because `leanblueprint` is not
installed in this environment; the pull-request blueprint check remains the
gate for that validation.
