### PR TITLE
refactor(PEPS): derive blue union mirrors by role swap

### DIFF
--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean
@@ -655,7 +655,8 @@ theorem ThreeBlockGeometry.blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq
           regionBlockedWeight (G := G) A g.complement bc' σcompl := by
   classical
   -- Group the constrained coupling sum by the complement boundary configuration.
-  rw [threeBlockComplCoeff, ← Finset.sum_fiberwise_of_maps_to
+  rw [threeBlockComplCoeff, ThreeBlockGeometry.threeBlockBlueCoeff,
+    ← Finset.sum_fiberwise_of_maps_to
     (s := Finset.univ.filter
       (fun q : VirtualConfig A =>
         regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q = bdry ∧

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -33,6 +33,39 @@ variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 variable {A : Tensor G d}
 variable (g : ThreeBlockGeometry V)
 
+/-- Exchange the blue and complement roles while leaving the red block fixed.
+
+This local geometry involution, rather than square-lattice coordinate swap, is the exact
+symmetry of the declarations below: they hold for an arbitrary graph and exchange two
+configuration fibers, not two coordinate axes. -/
+private def ThreeBlockGeometry.swapBlueComplementMirror (g : ThreeBlockGeometry V) :
+    ThreeBlockGeometry V where
+  red := g.red
+  blue := g.complement
+  complement := g.blue
+  red_disjoint_blue := g.red_disjoint_complement
+  red_disjoint_complement := g.red_disjoint_blue
+  blue_disjoint_complement := g.blue_disjoint_complement.symm
+  cover_univ := by rw [← g.cover_univ]; ac_rfl
+
+omit [LinearOrder V] in
+@[simp] private theorem ThreeBlockGeometry.swapBlueComplementMirror_complPhysical
+    (σblue : RegionPhysicalConfig (V := V) (d := d) g.blue)
+    (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement) :
+    g.swapBlueComplementMirror.complPhysical σcompl σblue =
+      g.complPhysical σblue σcompl := by
+  funext w
+  by_cases hb : w.1 ∈ g.blue
+  · have hc : w.1 ∉ g.complement := fun hw ↦
+      (Finset.disjoint_left.mp g.blue_disjoint_complement) hb hw
+    simp [ThreeBlockGeometry.complPhysical, swapBlueComplementMirror, hb, hc]
+  · have hc : w.1 ∈ g.complement := by
+      have hbc : w.1 ∈ g.blue ∪ g.complement := by
+        rw [← g.sdiff_red_eq_blue_union_complement]
+        exact w.2
+      exact (Finset.mem_union.mp hbc).resolve_left hb
+    simp [ThreeBlockGeometry.complPhysical, swapBlueComplementMirror, hb, hc]
+
 /-- The complement vertex product reads a global configuration only through the
 complement-incident edges, so it agrees with the configuration merged along the blue
 block, provided the two configurations agree on the blue boundary. This is the blue
@@ -48,17 +81,8 @@ theorem ThreeBlockGeometry.complProd_eq_regionMerge_blue
     (∏ w : {w : V // w ∈ g.complement}, A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
       ∏ w : {w : V // w ∈ g.complement},
         A.component w.1 (fun ie => regionMerge (G := G) A g.blue p ie.1) (σcompl w) := by
-  classical
-  apply regionProd_subtype_congr
-  intro ie hie
-  by_cases hinc : IsRegionIncidentEdge (G := G) g.blue ie
-  · have hbdry : IsRegionBoundaryEdge (G := G) g.blue ie :=
-      isRegionBoundaryEdge_of_disjoint_incident (G := G) g.complement g.blue
-        g.blue_disjoint_complement.symm hie hinc
-    rw [regionMerge_of_incident (G := G) A _ p hinc]
-    have := congrFun hp ⟨ie, hbdry⟩
-    simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
+  simpa [swapBlueComplementMirror] using
+    g.swapBlueComplementMirror.blueProd_eq_regionMerge_complement σcompl p hp
 
 /-- On a boundary edge of the host `univ \ red`, the complement-side configuration
 `p.2` agrees with the configuration merged along the blue block, provided the pair
@@ -74,33 +98,8 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_blue
     regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 =
       regionBoundaryLabel (G := G) A (Finset.univ \ g.red)
         (regionMerge (G := G) A g.blue p) := by
-  classical
-  funext f
-  simp only [regionBoundaryLabel_apply]
-  by_cases hinc : IsRegionIncidentEdge (G := G) g.blue f.1
-  · -- A blue-incident host boundary edge is a boundary edge of the blue block.
-    have hbdry : IsRegionBoundaryEdge (G := G) g.blue f.1 := by
-      rcases f.2 with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
-      · have h2red : f.1.1.2 ∈ g.red := by
-          have := h2nothost; rw [Finset.mem_sdiff] at this; push Not at this
-          exact this (Finset.mem_univ _)
-        have h2notblue : f.1.1.2 ∉ g.blue := fun hb =>
-          (Finset.disjoint_left.mp g.red_disjoint_blue) h2red hb
-        rcases hinc with hb1 | hb2
-        · refine Or.inl ⟨hb1, h2notblue⟩
-        · exact absurd hb2 h2notblue
-      · have h1red : f.1.1.1 ∈ g.red := by
-          have := h1nothost; rw [Finset.mem_sdiff] at this; push Not at this
-          exact this (Finset.mem_univ _)
-        have h1notblue : f.1.1.1 ∉ g.blue := fun hb =>
-          (Finset.disjoint_left.mp g.red_disjoint_blue) h1red hb
-        rcases hinc with hb1 | hb2
-        · exact absurd hb1 h1notblue
-        · refine Or.inr ⟨h1notblue, hb2⟩
-    rw [regionMerge_of_incident (G := G) A _ p hinc]
-    have := congrFun hp ⟨f.1, hbdry⟩
-    simpa [regionBoundaryLabel] using this.symm
-  · rw [regionMerge_of_not_incident (G := G) A _ p hinc]
+  simpa [swapBlueComplementMirror] using
+    g.swapBlueComplementMirror.hostLabel_p2_eq_hostLabel_regionMerge_complement p hp
 open scoped Classical in
 /-- **The host-relative blue fiber cardinality.** The blue mirror of
 `threeBlockFiber_card`: among the blue-boundary-agreeing pairs whose complement-side
@@ -119,32 +118,9 @@ theorem ThreeBlockGeometry.threeBlockBlueFiber_card
             regionMerge (G := G) A g.blue p = η))).card =
       if regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry then
         regionInteriorBondProd (G := G) A g.blue else 0 := by
-  classical
-  by_cases hcompat : regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry
-  · rw [if_pos hcompat]
-    rw [show (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
-          regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 = bdry ∧
-            (regionBoundaryLabel (G := G) A g.blue p.1 =
-                regionBoundaryLabel (G := G) A g.blue p.2 ∧
-              regionMerge (G := G) A g.blue p = η))) =
-        Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
-          (regionBoundaryLabel (G := G) A g.blue p.1 =
-              regionBoundaryLabel (G := G) A g.blue p.2 ∧
-            regionMerge (G := G) A g.blue p = η)) from ?_]
-    · exact regionFiber_card (G := G) A g.blue η
-    · refine Finset.filter_congr (fun p _ => ?_)
-      constructor
-      · rintro ⟨_, hagree, hmerge⟩; exact ⟨hagree, hmerge⟩
-      · rintro ⟨hagree, hmerge⟩
-        refine ⟨?_, hagree, hmerge⟩
-        rw [g.hostLabel_p2_eq_hostLabel_regionMerge_blue p hagree,
-          hmerge, hcompat]
-  · rw [if_neg hcompat]
-    rw [Finset.card_eq_zero, Finset.filter_eq_empty_iff]
-    rintro p _ ⟨hhost, hagree, hmerge⟩
-    apply hcompat
-    rw [← hmerge,
-      ← g.hostLabel_p2_eq_hostLabel_regionMerge_blue p hagree, hhost]
+  simpa [swapBlueComplementMirror] using
+    g.swapBlueComplementMirror.threeBlockFiber_card bdry η
+
 open scoped Classical in
 /-- **The host-relative blue merge collapse.** The blue mirror of
 `threeBlockDoubleSum_eq_smul_single`: the blue-boundary-agreeing double sum of the
@@ -175,102 +151,9 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_smul_single_blue
               A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
             ∏ w : {w : V // w ∈ g.complement},
               A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
-  classical
-  rw [show (∑ p ∈ Finset.univ.filter
-        (fun p : VirtualConfig A × VirtualConfig A =>
-          regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 = bdry ∧
-            regionBoundaryLabel (G := G) A g.blue p.1 =
-              regionBoundaryLabel (G := G) A g.blue p.2),
-      (∏ w : {w : V // w ∈ g.blue},
-          A.component w.1 (fun ie => p.1 ie.1) (σblue w)) *
-        ∏ w : {w : V // w ∈ g.complement},
-          A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
-      ∑ p ∈ Finset.univ.filter
-        (fun p : VirtualConfig A × VirtualConfig A =>
-          regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 = bdry ∧
-            regionBoundaryLabel (G := G) A g.blue p.1 =
-              regionBoundaryLabel (G := G) A g.blue p.2),
-        (∏ w : {w : V // w ∈ g.blue},
-            A.component w.1 (fun ie => regionMerge (G := G) A g.blue p ie.1) (σblue w)) *
-          ∏ w : {w : V // w ∈ g.complement},
-            A.component w.1
-              (fun ie => regionMerge (G := G) A g.blue p ie.1) (σcompl w) from ?_]
-  · rw [← Finset.sum_fiberwise (Finset.univ.filter
-        (fun p : VirtualConfig A × VirtualConfig A =>
-          regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 = bdry ∧
-            regionBoundaryLabel (G := G) A g.blue p.1 =
-              regionBoundaryLabel (G := G) A g.blue p.2))
-      (fun p => regionMerge (G := G) A g.blue p)
-      (fun p =>
-        (∏ w : {w : V // w ∈ g.blue},
-            A.component w.1 (fun ie => regionMerge (G := G) A g.blue p ie.1) (σblue w)) *
-          ∏ w : {w : V // w ∈ g.complement},
-            A.component w.1
-              (fun ie => regionMerge (G := G) A g.blue p ie.1) (σcompl w))]
-    rw [show (regionInteriorBondProd (G := G) A g.blue •
-          ∑ ζ ∈ Finset.univ.filter
-              (fun ζ : VirtualConfig A =>
-                regionBoundaryLabel (G := G) A (Finset.univ \ g.red) ζ = bdry),
-            (∏ w : {w : V // w ∈ g.blue},
-                A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
-              ∏ w : {w : V // w ∈ g.complement},
-                A.component w.1 (fun ie => ζ ie.1) (σcompl w)) =
-        ∑ η : VirtualConfig A,
-          regionInteriorBondProd (G := G) A g.blue •
-            (if regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry then
-              (∏ w : {w : V // w ∈ g.blue},
-                  A.component w.1 (fun ie => η ie.1) (σblue w)) *
-                ∏ w : {w : V // w ∈ g.complement},
-                  A.component w.1 (fun ie => η ie.1) (σcompl w)
-              else 0) from ?_]
-    · refine Finset.sum_congr rfl (fun η _ => ?_)
-      rw [Finset.filter_filter,
-        Finset.sum_congr rfl (g := fun _ =>
-            (∏ w : {w : V // w ∈ g.blue},
-                A.component w.1 (fun ie => η ie.1) (σblue w)) *
-              ∏ w : {w : V // w ∈ g.complement},
-                A.component w.1 (fun ie => η ie.1) (σcompl w))
-          (fun p hp => by rw [Finset.mem_filter] at hp; rw [hp.2.2]),
-        Finset.sum_const]
-      rw [show (Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
-            (regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 = bdry ∧
-                regionBoundaryLabel (G := G) A g.blue p.1 =
-                  regionBoundaryLabel (G := G) A g.blue p.2) ∧
-              regionMerge (G := G) A g.blue p = η)) =
-          Finset.univ.filter (fun p : VirtualConfig A × VirtualConfig A =>
-            regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 = bdry ∧
-              (regionBoundaryLabel (G := G) A g.blue p.1 =
-                  regionBoundaryLabel (G := G) A g.blue p.2 ∧
-                regionMerge (G := G) A g.blue p = η)) from by
-          refine Finset.filter_congr (fun p _ => ?_); tauto,
-        g.threeBlockBlueFiber_card bdry η]
-      by_cases hcompat : regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry
-      · rw [if_pos hcompat, if_pos hcompat]
-      · rw [if_neg hcompat, if_neg hcompat, zero_smul, smul_zero]
-    · rw [Finset.smul_sum, ← Finset.sum_filter_add_sum_filter_not Finset.univ
-          (fun η : VirtualConfig A =>
-            regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry)]
-      rw [show (∑ η ∈ Finset.univ.filter
-            (fun η : VirtualConfig A =>
-              ¬ regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry),
-          regionInteriorBondProd (G := G) A g.blue •
-            (if regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry then
-              (∏ w : {w : V // w ∈ g.blue},
-                  A.component w.1 (fun ie => η ie.1) (σblue w)) *
-                ∏ w : {w : V // w ∈ g.complement},
-                  A.component w.1 (fun ie => η ie.1) (σcompl w)
-              else 0)) = 0 from ?_,
-        add_zero]
-      · refine Finset.sum_congr rfl (fun η hη => ?_)
-        rw [Finset.mem_filter] at hη
-        rw [if_pos hη.2]
-      · refine Finset.sum_eq_zero (fun η hη => ?_)
-        rw [Finset.mem_filter] at hη
-        rw [if_neg hη.2, smul_zero]
-  · refine Finset.sum_congr rfl (fun p hp => ?_)
-    rw [Finset.mem_filter] at hp
-    rw [regionProd_eq_merge (G := G) A g.blue σblue p,
-      g.complProd_eq_regionMerge_blue σcompl p hp.2.2]
+  simpa [swapBlueComplementMirror] using
+    g.swapBlueComplementMirror.threeBlockDoubleSum_eq_smul_single bdry σcompl σblue
+
 open scoped Classical in
 /-- **The complement coupling coefficient.** The blue mirror of
 `threeBlockBlueCoeff`: the complement vertex product summed over all global
@@ -284,11 +167,7 @@ noncomputable def ThreeBlockGeometry.threeBlockComplCoeff
     (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red))
     (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement)
     (bβ : RegionBoundaryConfig (G := G) A g.blue) : ℂ :=
-  ∑ q ∈ Finset.univ.filter
-      (fun q : VirtualConfig A =>
-        regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q = bdry ∧
-          regionBoundaryLabel (G := G) A g.blue q = bβ),
-    ∏ w : {w : V // w ∈ g.complement}, A.component w.1 (fun ie => q ie.1) (σcompl w)
+  g.swapBlueComplementMirror.threeBlockBlueCoeff bdry σcompl bβ
 
 open scoped Classical in
 /-- **The host-relative blue decoupling.** The blue mirror of
@@ -315,33 +194,8 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_complCoeff_sum_blue
       ∑ bβ : RegionBoundaryConfig (G := G) A g.blue,
         regionBlockedWeight (G := G) A g.blue bβ σblue *
           g.threeBlockComplCoeff bdry σcompl bβ := by
-  classical
-  rw [← Finset.sum_fiberwise (Finset.univ.filter
-      (fun p : VirtualConfig A × VirtualConfig A =>
-        regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 = bdry ∧
-          regionBoundaryLabel (G := G) A g.blue p.1 =
-            regionBoundaryLabel (G := G) A g.blue p.2))
-    (fun p => regionBoundaryLabel (G := G) A g.blue p.1)
-    (fun p =>
-      (∏ w : {w : V // w ∈ g.blue},
-          A.component w.1 (fun ie => p.1 ie.1) (σblue w)) *
-        ∏ w : {w : V // w ∈ g.complement},
-          A.component w.1 (fun ie => p.2 ie.1) (σcompl w))]
-  refine Finset.sum_congr rfl (fun bβ _ => ?_)
-  rw [regionBlockedWeight, threeBlockComplCoeff, Finset.sum_mul_sum]
-  rw [Finset.filter_filter, ← Finset.sum_product']
-  refine Finset.sum_congr ?_ (fun _ _ => rfl)
-  ext x
-  rcases x with ⟨p, q⟩
-  constructor
-  · intro hpq
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
-    obtain ⟨⟨hhost, hagree⟩, hbβ⟩ := hpq
-    exact ⟨hbβ, hhost, hbβ ▸ hagree.symm⟩
-  · intro hpq
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
-    obtain ⟨hp, hhost, hq⟩ := hpq
-    exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩
+  simpa [swapBlueComplementMirror, threeBlockComplCoeff] using
+    g.swapBlueComplementMirror.threeBlockDoubleSum_eq_blueCoeff_sum bdry σcompl σblue
 
 namespace ThreeBlockGeometry
 
@@ -364,13 +218,10 @@ theorem regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_
       ∑ bβ : RegionBoundaryConfig (G := G) A g.blue,
         g.threeBlockComplCoeff bdry σcompl bβ •
           regionBlockedWeight (G := G) A g.blue bβ σblue := by
-  classical
-  rw [g.regionBlockedWeight_complPhysical_eq bdry σblue σcompl]
-  rw [smul_eq_mul, ← nsmul_eq_mul,
-    ← g.threeBlockDoubleSum_eq_smul_single_blue bdry σblue σcompl,
-    g.threeBlockDoubleSum_eq_complCoeff_sum_blue bdry σblue σcompl]
-  refine Finset.sum_congr rfl (fun bβ _ => ?_)
-  rw [smul_eq_mul, mul_comm]
+  simpa [swapBlueComplementMirror, threeBlockComplCoeff] using
+    g.swapBlueComplementMirror.
+      regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
+        bdry σcompl σblue
 
 end ThreeBlockGeometry
 
@@ -392,12 +243,9 @@ theorem regionInteriorBondProd_smul_geometryBlueWeight_eq
       ∑ bβ : RegionBoundaryConfig (G := G) A g.blue,
         g.threeBlockComplCoeff bdry σcompl bβ •
           regionBlockedWeight (G := G) A g.blue bβ := by
-  funext σblue
-  rw [Pi.smul_apply, Finset.sum_apply,
-    g.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
-      bdry σblue σcompl]
-  refine Finset.sum_congr rfl (fun bβ _ => ?_)
-  rw [Pi.smul_apply]
+  simpa [swapBlueComplementMirror, threeBlockComplCoeff] using
+    g.swapBlueComplementMirror.regionInteriorBondProd_smul_threeBlockComplWeight_eq
+      bdry σcompl
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -35,10 +35,10 @@ variable (g : ThreeBlockGeometry V)
 
 /-- Exchange the blue and complement roles while leaving the red block fixed.
 
-This local geometry involution, rather than square-lattice coordinate swap, is the exact
+This geometry involution, rather than square-lattice coordinate swap, is the exact
 symmetry of the declarations below: they hold for an arbitrary graph and exchange two
 configuration fibers, not two coordinate axes. -/
-private def ThreeBlockGeometry.swapBlueComplementMirror (g : ThreeBlockGeometry V) :
+abbrev ThreeBlockGeometry.swapBlueComplementMirror (g : ThreeBlockGeometry V) :
     ThreeBlockGeometry V where
   red := g.red
   blue := g.complement
@@ -49,7 +49,7 @@ private def ThreeBlockGeometry.swapBlueComplementMirror (g : ThreeBlockGeometry 
   cover_univ := by rw [← g.cover_univ]; ac_rfl
 
 omit [LinearOrder V] in
-@[simp] private theorem ThreeBlockGeometry.swapBlueComplementMirror_complPhysical
+@[simp] theorem ThreeBlockGeometry.swapBlueComplementMirror_complPhysical
     (σblue : RegionPhysicalConfig (V := V) (d := d) g.blue)
     (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement) :
     g.swapBlueComplementMirror.complPhysical σcompl σblue =

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -15,6 +15,14 @@ blue-side mirror of the complement-side fiber-collapse factorization, over a bar
 two-step inverse application of Lemma `injective_union` (arXiv:1804.04964, Section 3,
 lines 1324--1400 of `Papers/1804.04964/paper_normal.tex`) consumes.
 
+## Implementation notes
+
+The blue-side results are obtained from the complement-side results by interchanging
+the blue and complement blocks of `ThreeBlockGeometry`. The operation
+`ThreeBlockGeometry.swapBlueComplement` records this mathematical symmetry once; its
+reducible projections let later coupling identities unfold to the corresponding
+blue/complement formulas.
+
 ## References
 
 - [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
@@ -38,7 +46,7 @@ variable (g : ThreeBlockGeometry V)
 This geometry involution, rather than square-lattice coordinate swap, is the exact
 symmetry of the declarations below: they hold for an arbitrary graph and exchange two
 configuration fibers, not two coordinate axes. -/
-abbrev ThreeBlockGeometry.swapBlueComplementMirror (g : ThreeBlockGeometry V) :
+abbrev ThreeBlockGeometry.swapBlueComplement (g : ThreeBlockGeometry V) :
     ThreeBlockGeometry V where
   red := g.red
   blue := g.complement
@@ -49,22 +57,39 @@ abbrev ThreeBlockGeometry.swapBlueComplementMirror (g : ThreeBlockGeometry V) :
   cover_univ := by rw [← g.cover_univ]; ac_rfl
 
 omit [LinearOrder V] in
-@[simp] theorem ThreeBlockGeometry.swapBlueComplementMirror_complPhysical
+/-- Swapping the blue and complement blocks leaves the red block unchanged. -/
+@[simp] theorem ThreeBlockGeometry.swapBlueComplement_red :
+    g.swapBlueComplement.red = g.red := rfl
+
+omit [LinearOrder V] in
+/-- The blue block after swapping is the original complement block. -/
+@[simp] theorem ThreeBlockGeometry.swapBlueComplement_blue :
+    g.swapBlueComplement.blue = g.complement := rfl
+
+omit [LinearOrder V] in
+/-- The complement block after swapping is the original blue block. -/
+@[simp] theorem ThreeBlockGeometry.swapBlueComplement_complement :
+    g.swapBlueComplement.complement = g.blue := rfl
+
+omit [LinearOrder V] in
+/-- The physical configuration on the swapped complement agrees with the original fused
+configuration after interchanging the blue and complement arguments. -/
+@[simp] theorem ThreeBlockGeometry.swapBlueComplement_complPhysical
     (σblue : RegionPhysicalConfig (V := V) (d := d) g.blue)
     (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement) :
-    g.swapBlueComplementMirror.complPhysical σcompl σblue =
+    g.swapBlueComplement.complPhysical σcompl σblue =
       g.complPhysical σblue σcompl := by
   funext w
   by_cases hb : w.1 ∈ g.blue
   · have hc : w.1 ∉ g.complement := fun hw ↦
       (Finset.disjoint_left.mp g.blue_disjoint_complement) hb hw
-    simp [ThreeBlockGeometry.complPhysical, swapBlueComplementMirror, hb, hc]
+    simp [ThreeBlockGeometry.complPhysical, swapBlueComplement, hb, hc]
   · have hc : w.1 ∈ g.complement := by
       have hbc : w.1 ∈ g.blue ∪ g.complement := by
         rw [← g.sdiff_red_eq_blue_union_complement]
         exact w.2
       exact (Finset.mem_union.mp hbc).resolve_left hb
-    simp [ThreeBlockGeometry.complPhysical, swapBlueComplementMirror, hb, hc]
+    simp [ThreeBlockGeometry.complPhysical, swapBlueComplement, hb, hc]
 
 /-- The complement vertex product reads a global configuration only through the
 complement-incident edges, so it agrees with the configuration merged along the blue
@@ -81,7 +106,7 @@ theorem ThreeBlockGeometry.complProd_eq_regionMerge_blue
     (∏ w : {w : V // w ∈ g.complement}, A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
       ∏ w : {w : V // w ∈ g.complement},
         A.component w.1 (fun ie => regionMerge (G := G) A g.blue p ie.1) (σcompl w) := by
-  exact g.swapBlueComplementMirror.blueProd_eq_regionMerge_complement σcompl p hp
+  exact g.swapBlueComplement.blueProd_eq_regionMerge_complement σcompl p hp
 
 /-- On a boundary edge of the host `univ \ red`, the complement-side configuration
 `p.2` agrees with the configuration merged along the blue block, provided the pair
@@ -97,8 +122,8 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_blue
     regionBoundaryLabel (G := G) A (Finset.univ \ g.red) p.2 =
       regionBoundaryLabel (G := G) A (Finset.univ \ g.red)
         (regionMerge (G := G) A g.blue p) := by
-  simpa [swapBlueComplementMirror] using
-    g.swapBlueComplementMirror.hostLabel_p2_eq_hostLabel_regionMerge_complement p hp
+  simpa [swapBlueComplement] using
+    g.swapBlueComplement.hostLabel_p2_eq_hostLabel_regionMerge_complement p hp
 open scoped Classical in
 /-- **The host-relative blue fiber cardinality.** The blue mirror of
 `threeBlockFiber_card`: among the blue-boundary-agreeing pairs whose complement-side
@@ -117,8 +142,8 @@ theorem ThreeBlockGeometry.threeBlockBlueFiber_card
             regionMerge (G := G) A g.blue p = η))).card =
       if regionBoundaryLabel (G := G) A (Finset.univ \ g.red) η = bdry then
         regionInteriorBondProd (G := G) A g.blue else 0 := by
-  simpa [swapBlueComplementMirror] using
-    g.swapBlueComplementMirror.threeBlockFiber_card bdry η
+  simpa [swapBlueComplement] using
+    g.swapBlueComplement.threeBlockFiber_card bdry η
 
 open scoped Classical in
 /-- **The host-relative blue merge collapse.** The blue mirror of
@@ -151,7 +176,7 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_smul_single_blue
             ∏ w : {w : V // w ∈ g.complement},
               A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
   exact
-    g.swapBlueComplementMirror.threeBlockDoubleSum_eq_smul_single bdry σcompl σblue
+    g.swapBlueComplement.threeBlockDoubleSum_eq_smul_single bdry σcompl σblue
 
 open scoped Classical in
 /-- **The complement coupling coefficient.** The blue mirror of
@@ -166,7 +191,7 @@ noncomputable def ThreeBlockGeometry.threeBlockComplCoeff
     (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red))
     (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement)
     (bβ : RegionBoundaryConfig (G := G) A g.blue) : ℂ :=
-  g.swapBlueComplementMirror.threeBlockBlueCoeff bdry σcompl bβ
+  g.swapBlueComplement.threeBlockBlueCoeff bdry σcompl bβ
 
 open scoped Classical in
 /-- **The host-relative blue decoupling.** The blue mirror of
@@ -194,7 +219,7 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_complCoeff_sum_blue
         regionBlockedWeight (G := G) A g.blue bβ σblue *
           g.threeBlockComplCoeff bdry σcompl bβ := by
   exact
-    g.swapBlueComplementMirror.threeBlockDoubleSum_eq_blueCoeff_sum bdry σcompl σblue
+    g.swapBlueComplement.threeBlockDoubleSum_eq_blueCoeff_sum bdry σcompl σblue
 
 namespace ThreeBlockGeometry
 
@@ -217,10 +242,10 @@ theorem regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_
       ∑ bβ : RegionBoundaryConfig (G := G) A g.blue,
         g.threeBlockComplCoeff bdry σcompl bβ •
           regionBlockedWeight (G := G) A g.blue bβ σblue := by
-  rw [← g.swapBlueComplementMirror_complPhysical σblue σcompl]
+  rw [← g.swapBlueComplement_complPhysical σblue σcompl]
   exact
     ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
-      g.swapBlueComplementMirror bdry σcompl σblue
+      g.swapBlueComplement bdry σcompl σblue
 
 end ThreeBlockGeometry
 

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -81,8 +81,7 @@ theorem ThreeBlockGeometry.complProd_eq_regionMerge_blue
     (∏ w : {w : V // w ∈ g.complement}, A.component w.1 (fun ie => p.2 ie.1) (σcompl w)) =
       ∏ w : {w : V // w ∈ g.complement},
         A.component w.1 (fun ie => regionMerge (G := G) A g.blue p ie.1) (σcompl w) := by
-  simpa [swapBlueComplementMirror] using
-    g.swapBlueComplementMirror.blueProd_eq_regionMerge_complement σcompl p hp
+  exact g.swapBlueComplementMirror.blueProd_eq_regionMerge_complement σcompl p hp
 
 /-- On a boundary edge of the host `univ \ red`, the complement-side configuration
 `p.2` agrees with the configuration merged along the blue block, provided the pair
@@ -151,7 +150,7 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_smul_single_blue
               A.component w.1 (fun ie => ζ ie.1) (σblue w)) *
             ∏ w : {w : V // w ∈ g.complement},
               A.component w.1 (fun ie => ζ ie.1) (σcompl w) := by
-  simpa [swapBlueComplementMirror] using
+  exact
     g.swapBlueComplementMirror.threeBlockDoubleSum_eq_smul_single bdry σcompl σblue
 
 open scoped Classical in
@@ -194,7 +193,7 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_complCoeff_sum_blue
       ∑ bβ : RegionBoundaryConfig (G := G) A g.blue,
         regionBlockedWeight (G := G) A g.blue bβ σblue *
           g.threeBlockComplCoeff bdry σcompl bβ := by
-  simpa [swapBlueComplementMirror, threeBlockComplCoeff] using
+  exact
     g.swapBlueComplementMirror.threeBlockDoubleSum_eq_blueCoeff_sum bdry σcompl σblue
 
 namespace ThreeBlockGeometry
@@ -218,10 +217,10 @@ theorem regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_
       ∑ bβ : RegionBoundaryConfig (G := G) A g.blue,
         g.threeBlockComplCoeff bdry σcompl bβ •
           regionBlockedWeight (G := G) A g.blue bβ σblue := by
-  simpa [swapBlueComplementMirror, threeBlockComplCoeff] using
-    g.swapBlueComplementMirror.
-      regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
-        bdry σcompl σblue
+  rw [← g.swapBlueComplementMirror_complPhysical σblue σcompl]
+  exact
+    ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
+      g.swapBlueComplementMirror bdry σcompl σblue
 
 end ThreeBlockGeometry
 
@@ -243,9 +242,12 @@ theorem regionInteriorBondProd_smul_geometryBlueWeight_eq
       ∑ bβ : RegionBoundaryConfig (G := G) A g.blue,
         g.threeBlockComplCoeff bdry σcompl bβ •
           regionBlockedWeight (G := G) A g.blue bβ := by
-  simpa [swapBlueComplementMirror, threeBlockComplCoeff] using
-    g.swapBlueComplementMirror.regionInteriorBondProd_smul_threeBlockComplWeight_eq
-      bdry σcompl
+  funext σblue
+  rw [Pi.smul_apply, Finset.sum_apply,
+    g.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
+      bdry σblue σcompl]
+  refine Finset.sum_congr rfl (fun bβ _ => ?_)
+  rw [Pi.smul_apply]
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain5.lean
+++ b/TNLean/PEPS/TorusWindowChain5.lean
@@ -193,35 +193,6 @@ blue block taken to be the injective completed corner `Q`, it expresses the `σ_
 of the corner extension's coupling as a `Q`-blocked combination, the form `Q` injectivity
 inverts. -/
 
-/-- The blue/complement swap of a three-block geometry: the same red block with the blue and
-complement blocks interchanged.  Its host `univ \ red` is unchanged, so a host boundary
-configuration of `g` is a host boundary configuration of the swap.
-
-Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 3. -/
-def ThreeBlockGeometry.swapBlueComplement (g : ThreeBlockGeometry V) :
-    ThreeBlockGeometry V where
-  red := g.red
-  blue := g.complement
-  complement := g.blue
-  red_disjoint_blue := g.red_disjoint_complement
-  red_disjoint_complement := g.red_disjoint_blue
-  blue_disjoint_complement := g.blue_disjoint_complement.symm
-  cover_univ := by rw [← g.cover_univ]; ac_rfl
-
-omit [DecidableRel G.Adj] in
-@[simp] theorem ThreeBlockGeometry.swapBlueComplement_red (g : ThreeBlockGeometry V) :
-    g.swapBlueComplement.red = g.red := rfl
-
-omit [DecidableRel G.Adj] in
-@[simp] theorem ThreeBlockGeometry.swapBlueComplement_blue (g : ThreeBlockGeometry V) :
-    g.swapBlueComplement.blue = g.complement := rfl
-
-omit [DecidableRel G.Adj] in
-@[simp] theorem ThreeBlockGeometry.swapBlueComplement_complement (g : ThreeBlockGeometry V) :
-    g.swapBlueComplement.complement = g.blue := rfl
-
 /-- The blue coupling of `g` is the complement coupling of the swapped geometry: both filter
 the global configurations on the host label `bdry` and the `g.complement` boundary label
 `bc'` and take the product over `g.blue`.
@@ -273,7 +244,6 @@ theorem ThreeBlockGeometry.crossingBondProd_smul_threeBlockBlueCoeff_eq
   rw [g.threeBlockBlueCoeff_eq_swap_threeBlockComplCoeff bdry σblue bc',
     g.swapBlueComplement.blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq
       bdry bc' σblue]
-  rfl
 
 /-! ### The `S ⊔ Q` assembly bridge
 


### PR DESCRIPTION
Closes #4526.

Derives the blue union-injectivity mirror through the existing role-swap symmetry, removing the duplicated route.

No local Lean or Lake build was run because the shared artifact cache is intentionally not rebuilt during worktree triage; CI is the verification gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: same theorem statements, shorter proof paths via a documented symmetry; no auth or runtime behavior changes. Mathlib proof risk is typical for large deleted proof blocks—CI Lean build is the gate.
> 
> **Overview**
> **Centralizes blue/complement symmetry** by defining `ThreeBlockGeometry.swapBlueComplement` (with `@[simp]` block identities and `swapBlueComplement_complPhysical`) in `UnionInjectivityGeneralBlue.lean`, and **removing** the duplicate definition from `TorusWindowChain5.lean`.
> 
> **Replaces large hand proofs** in the blue mirror file with one-line appeals to the existing complement-side lemmas on `g.swapBlueComplement` (merge/host-label identities, fiber cardinality, double-sum collapse, decoupling, smul-factorization). **`threeBlockComplCoeff`** is now defined as the swapped geometry’s `threeBlockBlueCoeff` rather than an explicit filtered sum.
> 
> **Proof maintenance:** `blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq` in `UnionInjectivityGeneral2.lean` unfolds via `ThreeBlockGeometry.threeBlockBlueCoeff` before fiberwise grouping; a redundant `rfl` after a swap-based rewrite is dropped in `TorusWindowChain5.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50584d840c36c55c04836fc9001e132a202914e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->