### PR TITLE
feat(MPS/MPDO): derive BNT fusion clause from RFP

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -25,6 +25,7 @@ import TNLean.MPS.MPDO.BNTFourfoldFusionIndices
 import TNLean.MPS.MPDO.BNTFusionCoisometries
 import TNLean.MPS.MPDO.BNTFusionIsometries
 import TNLean.MPS.MPDO.BNTFusionTensorClause
+import TNLean.MPS.MPDO.BNTFusionTensorClauseFromRFP
 import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTMarkovKeyFormula
 import TNLean.MPS.MPDO.BNTMarkovSectorProjectors

--- a/TNLean/MPS/MPDO/BNTFusionCoisometries.lean
+++ b/TNLean/MPS/MPDO/BNTFusionCoisometries.lean
@@ -183,6 +183,53 @@ theorem mpo_mul_mpo_eq_sum (L : ℕ) (hL : 0 < L) (α β : Λ) :
   simp only [Matrix.sum_apply, Matrix.smul_apply, mpo_apply, mpoMatrixEntry,
     evalWord_ofFn, smul_eq_mul]
 
+/-- The concrete closed-chain operator family carried by a fusion
+coisometry family.
+
+Source: arXiv:1606.00608, lines 962--966. -/
+noncomputable def toOperatorFamily :
+    BNTLabelOperatorFamily Λ
+      (fun L ↦ Matrix (Fin L → Fin p) (Fin L → Fin p) ℂ) :=
+  ⟨fun L γ ↦ mpo (Fam.tensor γ) L⟩
+
+@[simp] lemma toOperatorFamily_operator (L : ℕ) (γ : Λ) :
+    Fam.toOperatorFamily.operator L γ = mpo (Fam.tensor γ) L := rfl
+
+/-- A fusion coisometry family satisfies the same-length product law with
+the coefficients determined by its positive diagonal chi matrices.
+
+Source: CPSV16, Theorem 4.14(ii)--(iii), lines 976--993, and Appendix C.4,
+lines 2020--2029. -/
+theorem toOperatorFamily_hasSameLengthProductForm :
+    Fam.toOperatorFamily.HasSameLengthProductForm
+      (BNTLabelCoefficientFamily.ofChi Fam.chi) := by
+  intro L hL α β
+  simpa [toOperatorFamily_operator, BNTLabelCoefficientFamily.ofChi_coeff]
+    using Fam.mpo_mul_mpo_eq_sum L hL α β
+
+/-- The positive chi witness determined by a fusion coisometry family.
+
+Source: CPSV16, Theorem 4.14(ii), lines 976--985. -/
+noncomputable def toPositiveChiWitness :
+    PositiveBNTLabelChiTracePowerForm
+      (BNTLabelCoefficientFamily.ofChi Fam.chi) :=
+  PositiveBNTLabelChiTracePowerForm.ofChi Fam.chi Fam.posEntries
+
+/-- The source-faithful active-support fusion clause, together with its
+idempotent trace-scalar law, implies the BNT algebra clause.
+
+Source: CPSV16, Theorem 4.14(ii)--(iii), lines 972--993, and Appendix C.4,
+lines 1929--1947 and 2020--2046. -/
+noncomputable def toBNTAlgebraClause
+    (m : BNTLabelTraceScalarFamily Λ)
+    (hIdempotent :
+      m.HasIdempotentCoefficientForm (BNTLabelCoefficientFamily.ofChi Fam.chi)) :
+    BNTAlgebraClause (BNTLabelCoefficientFamily.ofChi Fam.chi)
+      Fam.toOperatorFamily m where
+  positiveChi := Fam.toPositiveChiWitness
+  sameLengthProduct := Fam.toOperatorFamily_hasSameLengthProductForm
+  idempotent := hIdempotent
+
 /-- Under the additional assertion that every active-support projection is the
 identity, an active fusion coisometry gives the stronger full-support fusion
 family. -/

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -4,12 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
-import TNLean.MPS.MPDO.BNTFusionIsometries
+import TNLean.MPS.MPDO.BNTFusionCoisometries
 
 /-!
-# Fusion isometries attached to an MPO tensor
+# Fusion coisometries attached to an MPO tensor
 
-This file attaches the fusion-isometry clause of arXiv:1606.00608,
+This file attaches the active-support fusion clause of arXiv:1606.00608,
 Theorem 4.14(iii), to the basis of normal tensors in a chosen vertical
 canonical decomposition of the original MPO tensor. The positive diagonal
 matrices in the fusion identity determine the coefficients in the algebra
@@ -39,7 +39,7 @@ noncomputable section
 
 namespace MPOTensor
 
-/-- The fusion-isometry clause of Theorem 4.14(iii), attached to a chosen
+/-- The active-support fusion clause of Theorem 4.14(iii), attached to a chosen
 vertical canonical decomposition of the MPO tensor \(M\).
 
 The tensors in the fusion identity are precisely the basis of normal tensors
@@ -56,10 +56,10 @@ Source: arXiv:1606.00608, Proposition 4.13, lines 943--951;
 Theorem 4.14(iii), lines 986--993; and Appendix C.4, lines 1929--1947 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
 
-**Scope restriction (full-support fusion family):** The fusion map below
-satisfies $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$. The unrestricted
-source statement allows a zero product corner and instead gives a coisometry
-onto the active direct sum together with exact reconstruction. Documented in
+**Local fix (Figure-11 fusion coisometry):** The source uses the retained-row
+orientation of Proposition 4.13. Thus the fusion map satisfies
+$U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$, while exact reconstruction
+records that the discarded common corner is zero. Documented in
 `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
 structure BNTFusionTensorClause (M : MPOTensor d D) where
   /-- Number of BNT labels in the chosen vertical decomposition. -/
@@ -116,31 +116,38 @@ structure BNTFusionTensorClause (M : MPOTensor d D) where
 
   Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 976--993. -/
   chi_pos : chi.PosEntries
-  /-- The fusion isometry \(U_{\alpha,\beta}\) for each pair of BNT labels.
+  /-- The coisometry from a product bond space onto its active BNT sectors.
 
   Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993. -/
-  fusionIsometry : ∀ α β : Fin labelCount,
+  fusionCoisometry : ∀ α β : Fin labelCount,
     Matrix ((γ : Fin labelCount) × (Fin (chi.dim α β γ) × Fin (bondDim γ)))
       (Fin (bondDim α * bondDim β)) ℂ
-  /-- The additional full-support column-isometry condition on each fusion
-  map.
+  /-- Each fusion map is a coisometry onto the retained direct sum.
 
-  **Scope restriction (full-support fusion family):** The unrestricted source
-  statement permits a discarded common zero corner and does not assert this
-  identity. Documented in
-  `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
-  isometry : ∀ α β : Fin labelCount,
-    (fusionIsometry α β)ᴴ * fusionIsometry α β = 1
+  Source: CPSV16, Appendix C.4, lines 2020--2029. -/
+  fusionCoisometry_mul_conjTranspose : ∀ α β : Fin labelCount,
+    fusionCoisometry α β * (fusionCoisometry α β)ᴴ = 1
   /-- The sitewise fusion identity for the concrete vertical BNT tensors.
 
   Source: arXiv:1606.00608, Theorem 4.14(iii), label `Ualphabeta`,
   lines 986--993. -/
   fusion : ∀ (α β : Fin labelCount) (i j : Fin D),
-    fusionIsometry α β *
+    fusionCoisometry α β *
         (mulTensor (verticalBNTMPO (tensor α)) (verticalBNTMPO (tensor β))) i j *
-          (fusionIsometry α β)ᴴ =
+          (fusionCoisometry α β)ᴴ =
       Matrix.blockDiagonal' fun γ =>
         chi.matrix α β γ ⊗ₖ (verticalBNTMPO (tensor γ)) i j
+  /-- The active direct sum reconstructs each product letter, so any omitted
+  common corner is zero.
+
+  Source: CPSV16, Appendix C.4, lines 2020--2029. -/
+  fusionReconstruction : ∀ (α β : Fin labelCount) (i j : Fin D),
+    (mulTensor (verticalBNTMPO (tensor α))
+      (verticalBNTMPO (tensor β))) i j =
+        (fusionCoisometry α β)ᴴ *
+          (Matrix.blockDiagonal' fun γ ↦
+            chi.matrix α β γ ⊗ₖ (verticalBNTMPO (tensor γ)) i j) *
+          fusionCoisometry α β
   /-- The length-one idempotent identity for
   \(m_\alpha=\operatorname{tr}(\mu_\alpha)\).
 
@@ -154,16 +161,17 @@ namespace BNTFusionTensorClause
 
 variable {M : MPOTensor d D}
 
-/-- The fusion-isometry family carried by a tensor-attached fusion clause. -/
-def toBNTFusionIsometryFamily (H : BNTFusionTensorClause M) :
-    BNTFusionIsometryFamily (Fin H.labelCount) D where
+/-- The active-support fusion family carried by a tensor-attached clause. -/
+def toBNTFusionCoisometryFamily (H : BNTFusionTensorClause M) :
+    BNTFusionCoisometryFamily (Fin H.labelCount) D where
   bondDim := H.bondDim
   tensor := fun γ => verticalBNTMPO (H.tensor γ)
   chi := H.chi
   posEntries := H.chi_pos
-  fusionIsometry := H.fusionIsometry
-  isometry := H.isometry
+  fusionCoisometry := H.fusionCoisometry
+  coisometry := H.fusionCoisometry_mul_conjTranspose
   fusion := H.fusion
+  reconstruction := H.fusionReconstruction
 
 /-- **Tensor-attached implication (iii) to (ii) of Theorem 4.14.**
 
@@ -194,7 +202,7 @@ noncomputable def toBNTAlgebraTensorClause (H : BNTFusionTensorClause M) :
   forward := H.forward
   reconstruction := H.reconstruction
   coeffs := BNTLabelCoefficientFamily.ofChi H.chi
-  algebraClause := H.toBNTFusionIsometryFamily.toBNTAlgebraClause
+  algebraClause := H.toBNTFusionCoisometryFamily.toBNTAlgebraClause
     (verticalBNTTraceScalarFamily H.weight) H.idempotent
 
 /-- The chosen decomposition in a tensor-attached fusion clause is a vertical
@@ -205,7 +213,7 @@ theorem isVerticalCF (H : BNTFusionTensorClause M) : IsVerticalCF M :=
 
 end BNTFusionTensorClause
 
-/-- Existence of the fusion-isometry clause for a chosen vertical canonical
+/-- Existence of the active-support fusion clause for a chosen vertical canonical
 decomposition of \(M\).
 
 Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993, and
@@ -215,7 +223,7 @@ def HasBNTFusionTensorClause (M : MPOTensor d D) : Prop :=
 
 namespace HasBNTFusionTensorClause
 
-/-- The tensor-attached fusion-isometry clause implies the tensor-attached
+/-- The tensor-attached active-support fusion clause implies the tensor-attached
 algebra clause, using the same vertical decomposition and the same positive
 diagonal chi matrices.
 

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -175,7 +175,7 @@ def toBNTFusionCoisometryFamily (H : BNTFusionTensorClause M) :
 
 /-- **Tensor-attached implication (iii) to (ii) of Theorem 4.14.**
 
-The fusion isometries for the BNT tensors in a chosen vertical canonical
+The fusion coisometries for the BNT tensors in a chosen vertical canonical
 decomposition give the algebra clause for the same decomposition. Its
 coefficients are the trace powers of the same positive diagonal matrices
 \(\chi_{\alpha,\beta,\gamma}\), and its trace scalars are

--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -353,16 +353,15 @@ theorem of_isRFPViaTS (M : MPOTensor d D)
       D₁.reconstruction D₂.reconstruction
       sigma hDim V hLetter hL
   obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
-    transportedVerticalSector_exists_positiveFusionDecomposition
+    exists_positiveFusionDecomposition_of_unitaryBlockEquiv
       D₁.bondDim D₁.multiplicity D₁.weight
       D₂.bondDim D₂.multiplicity D₂.weight
       D₁.multiplicity_pos D₁.weight_pos
       D₂.multiplicity_pos D₂.weight_pos
-      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      M D₁.tensor D₂.tensor D₂.isCPSVBNT
       D₁.verticalCoisometry D₂.verticalCoisometry
-      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
-      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
-      hTphys hSphys hHorizontal hM
+      D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
+      sigma hDim V hLetter hHorizontal hM
   have hIdempotent := hasIdempotentCoefficientForm_of_blockedRepresentations
     D₁ D₂ sigma chi U hChiPos hU hFusion hFusionReconstruction
     hRepresentations

--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -1,0 +1,393 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.BNT.Bridge
+import TNLean.MPS.MPDO.BNTAssociativity
+import TNLean.MPS.MPDO.BNTFusionTensorClause
+import TNLean.MPS.MPDO.BNTMultiplicityNormalization
+import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
+
+/-!
+# The BNT fusion clause from the MPDO renormalization fixed-point condition
+
+This file completes the implication from statement (i) to statement (iii) of
+CPSV16, Theorem 4.14.  The transported one-site and two-site vertical forms
+give both representations of the blocked closed-chain operator.  Eventual
+linear independence of the BNT operators compares their coefficients, and
+the positive power-sum lemma gives the length-one trace-scalar identity.
+
+## Main result
+
+* `HasBNTFusionTensorClause.of_isRFPViaTS` constructs the source-faithful
+  active-support fusion clause from the Definition 4.1 RFP maps.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14 and Appendix C.4, lines 1929--2046
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- A CPSV16 basis of normal tensors gives eventual linear independence of
+the corresponding closed-chain MPO operators.
+
+Source: CPSV16, lines 271--275, used in Appendix C.4, lines 2030--2042. -/
+theorem eventuallyLinearIndependent_verticalBNTOperatorFamily
+    {g D d : ℕ} {dim : Fin g → ℕ}
+    {M : MPOTensor d D} {A : (γ : Fin g) → MPSTensor (D * D) (dim γ)}
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+      (fun γ ↦ ⟨dim γ, A γ⟩)) :
+    (verticalBNTOperatorFamily A).EventuallyLinearIndependent := by
+  obtain ⟨N₀, hli⟩ := hBNT.eventually_li
+  refine ⟨N₀, ?_⟩
+  intro L hL
+  apply Fintype.linearIndependent_iff.mpr
+  intro c hc γ
+  have hzero : ∑ j : Fin g, c j •
+      MPSTensor.mpvState (d := D * D) (A j) L = 0 := by
+    apply PiLp.ext
+    intro σ
+    let ket : Fin L → Fin D := fun l ↦ (finProdFinEquiv.symm (σ l)).1
+    let bra : Fin L → Fin D := fun l ↦ (finProdFinEquiv.symm (σ l)).2
+    have hentry := congrArg (fun X ↦ X ket bra) hc
+    change (∑ j, c j • mpo (verticalBNTMPO (A j)) L) ket bra =
+      (0 : Matrix (Fin L → Fin D) (Fin L → Fin D) ℂ) ket bra at hentry
+    simp only [Matrix.sum_apply, Matrix.smul_apply, Matrix.zero_apply] at hentry
+    simp_rw [← MPSTensor.mpv_toMPSTensor_pairConfig] at hentry
+    simp only [verticalBNTMPO_toMPSTensor] at hentry
+    have hcfg : (fun n ↦ finProdFinEquiv (ket n, bra n)) = σ := by
+      funext n
+      exact Equiv.apply_symm_apply finProdFinEquiv (σ n)
+    rw [hcfg] at hentry
+    simpa [PiLp.smul_apply, PiLp.zero_apply, MPSTensor.mpvState_apply,
+      smul_eq_mul, ket, bra, Equiv.apply_symm_apply] using hentry
+  exact Fintype.linearIndependent_iff.mp (hli L hL) c hzero γ
+
+/-- The simultaneous blocked-operator representations and the active-support
+fusion law imply the length-one idempotent trace-scalar identity.
+
+The proof is the coefficient comparison in CPSV16 Appendix C.4: eventual BNT
+linear independence identifies all sufficiently large power sums, positivity
+recovers the multiplicity multisets, and summing the resulting multiset
+identity gives the idempotent law.
+
+Source: CPSV16, Appendix C.4, lines 2030--2046, using the power-sum lemma at
+lines 1155--1163. -/
+theorem hasIdempotentCoefficientForm_of_blockedRepresentations
+    {d D : ℕ} {M : MPOTensor d D}
+    (D₁ : CPSVVerticalDecomposition M)
+    (D₂ : CPSVVerticalDecomposition (blockTwo M))
+    (sigma : Fin D₁.labelCount ≃ Fin D₂.labelCount)
+    (chi : DiagonalChiFamily (Fin D₁.labelCount))
+    (U : ∀ α β : Fin D₁.labelCount,
+      Matrix ((γ : Fin D₁.labelCount) ×
+        (Fin (chi.dim α β γ) × Fin (D₁.bondDim γ)))
+        (Fin (D₁.bondDim α * D₁.bondDim β)) ℂ)
+    (hChiPos : chi.PosEntries)
+    (hCoisometry : ∀ α β, U α β * (U α β)ᴴ = 1)
+    (hFusion : ∀ (α β : Fin D₁.labelCount) (i j : Fin D),
+      U α β *
+          (mulTensor (verticalBNTMPO (D₁.tensor α))
+            (verticalBNTMPO (D₁.tensor β))) i j *
+          (U α β)ᴴ =
+        Matrix.blockDiagonal' fun γ ↦
+          chi.matrix α β γ ⊗ₖ (verticalBNTMPO (D₁.tensor γ)) i j)
+    (hReconstruction : ∀ (α β : Fin D₁.labelCount) (i j : Fin D),
+      (mulTensor (verticalBNTMPO (D₁.tensor α))
+        (verticalBNTMPO (D₁.tensor β))) i j =
+        (U α β)ᴴ *
+          (Matrix.blockDiagonal' fun γ ↦
+            chi.matrix α β γ ⊗ₖ (verticalBNTMPO (D₁.tensor γ)) i j) *
+          U α β)
+    (hRepresentations : ∀ (L : ℕ), 0 < L →
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+          ∑ γ,
+            (((verticalMultiplicityTrace D₁.weight γ /
+                verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
+              (∑ r, D₂.weight (sigma γ) r ^ L)) •
+              mpo (verticalBNTMPO (D₁.tensor γ)) L ∧
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+        ∑ α, ∑ β,
+          ((∑ q, D₁.weight α q ^ L) * (∑ r, D₁.weight β r ^ L)) •
+            (mpo (verticalBNTMPO (D₁.tensor α)) L *
+              mpo (verticalBNTMPO (D₁.tensor β)) L)) :
+    (verticalBNTTraceScalarFamily D₁.weight).HasIdempotentCoefficientForm
+      (BNTLabelCoefficientFamily.ofChi chi) := by
+  classical
+  let Fam : BNTFusionCoisometryFamily (Fin D₁.labelCount) D := {
+    bondDim := D₁.bondDim
+    tensor := fun γ ↦ verticalBNTMPO (D₁.tensor γ)
+    chi := chi
+    posEntries := hChiPos
+    fusionCoisometry := U
+    coisometry := hCoisometry
+    fusion := hFusion
+    reconstruction := hReconstruction
+  }
+  let op := verticalBNTOperatorFamily D₁.tensor
+  let m := verticalBNTTraceScalarFamily D₁.weight
+  have hOpLI : op.EventuallyLinearIndependent :=
+    eventuallyLinearIndependent_verticalBNTOperatorFamily D₁.isCPSVBNT
+  obtain ⟨N₀, hN₀⟩ := hOpLI
+  have hCoeff : ∀ (L : ℕ), N₀ < L → ∀ γ,
+      ((verticalMultiplicityTrace D₁.weight γ /
+          verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
+        (∑ r, D₂.weight (sigma γ) r ^ L) =
+      ∑ α, ∑ β,
+        ((∑ q, D₁.weight α q ^ L) *
+          (∑ r, D₁.weight β r ^ L)) *
+          Fam.chi.tracePowerCoeff α β γ L := by
+    intro L hL γ
+    have hLpos : 0 < L := lt_of_le_of_lt (Nat.zero_le N₀) hL
+    obtain ⟨hFirst, hSecond⟩ := hRepresentations L hLpos
+    have hProduct (α β : Fin D₁.labelCount) :
+        mpo (verticalBNTMPO (D₁.tensor α)) L *
+            mpo (verticalBNTMPO (D₁.tensor β)) L =
+          ∑ γ, chi.tracePowerCoeff α β γ L •
+            mpo (verticalBNTMPO (D₁.tensor γ)) L := by
+      simpa only [Fam] using Fam.mpo_mul_mpo_eq_sum L hLpos α β
+    have hExpanded :
+        mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+          ∑ γ, (∑ α, ∑ β,
+            ((∑ q, D₁.weight α q ^ L) *
+              (∑ r, D₁.weight β r ^ L)) *
+              Fam.chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (D₁.tensor γ)) L := by
+      rw [hSecond]
+      simp_rw [hProduct, Finset.smul_sum, smul_smul]
+      calc
+        (∑ α, ∑ β, ∑ γ,
+            (((∑ q, D₁.weight α q ^ L) *
+              (∑ r, D₁.weight β r ^ L)) *
+              chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (D₁.tensor γ)) L) =
+            ∑ α, ∑ γ, ∑ β,
+              (((∑ q, D₁.weight α q ^ L) *
+                (∑ r, D₁.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L) •
+                  mpo (verticalBNTMPO (D₁.tensor γ)) L := by
+          apply Finset.sum_congr rfl
+          intro α _
+          rw [Finset.sum_comm]
+        _ = ∑ γ, ∑ α, ∑ β,
+              (((∑ q, D₁.weight α q ^ L) *
+                (∑ r, D₁.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L) •
+                  mpo (verticalBNTMPO (D₁.tensor γ)) L := by
+          rw [Finset.sum_comm]
+        _ = ∑ γ, (∑ α, ∑ β,
+              ((∑ q, D₁.weight α q ^ L) *
+                (∑ r, D₁.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L) •
+                  mpo (verticalBNTMPO (D₁.tensor γ)) L := by
+          apply Finset.sum_congr rfl
+          intro γ _
+          symm
+          calc
+            (∑ α, ∑ β,
+                ((∑ q, D₁.weight α q ^ L) *
+                  (∑ r, D₁.weight β r ^ L)) *
+                  chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (D₁.tensor γ)) L =
+              ∑ α, (∑ β,
+                ((∑ q, D₁.weight α q ^ L) *
+                  (∑ r, D₁.weight β r ^ L)) *
+                  chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (D₁.tensor γ)) L := by
+                  exact map_sum
+                    ((smulAddHom ℂ
+                      (Matrix (Fin L → Fin D) (Fin L → Fin D) ℂ)).flip
+                        (mpo (verticalBNTMPO (D₁.tensor γ)) L))
+                    (fun α ↦ ∑ β,
+                      ((∑ q, D₁.weight α q ^ L) *
+                        (∑ r, D₁.weight β r ^ L)) *
+                        chi.tracePowerCoeff α β γ L)
+                    Finset.univ
+            _ = ∑ α, ∑ β,
+                (((∑ q, D₁.weight α q ^ L) *
+                  (∑ r, D₁.weight β r ^ L)) *
+                  chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (D₁.tensor γ)) L := by
+                  apply Finset.sum_congr rfl
+                  intro α _
+                  exact map_sum
+                    ((smulAddHom ℂ
+                      (Matrix (Fin L → Fin D) (Fin L → Fin D) ℂ)).flip
+                        (mpo (verticalBNTMPO (D₁.tensor γ)) L))
+                    (fun β ↦ ((∑ q, D₁.weight α q ^ L) *
+                      (∑ r, D₁.weight β r ^ L)) *
+                      chi.tracePowerCoeff α β γ L)
+                    Finset.univ
+    have hsum :
+        ∑ γ,
+            (((verticalMultiplicityTrace D₁.weight γ /
+                verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
+              (∑ r, D₂.weight (sigma γ) r ^ L)) •
+              op.operator L γ =
+          ∑ γ, (∑ α, ∑ β,
+            ((∑ q, D₁.weight α q ^ L) *
+              (∑ r, D₁.weight β r ^ L)) *
+              Fam.chi.tracePowerCoeff α β γ L) •
+              op.operator L γ := by
+      simpa only [op, verticalBNTOperatorFamily_operator] using
+        hFirst.symm.trans hExpanded
+    exact congrFun
+      (linearIndependent_iff_injective_fintypeLinearCombination.mp
+        (hN₀ L hL) hsum) γ
+  let twoEntry : ∀ γ : Fin D₁.labelCount,
+      Fin (D₂.multiplicity (sigma γ)) → ℂ := fun γ r ↦
+    (verticalMultiplicityTrace D₁.weight γ /
+      verticalMultiplicityTrace D₂.weight (sigma γ)) *
+        D₂.weight (sigma γ) r
+  have hTwoPos : ∀ γ r, (0 : ℂ) < twoEntry γ r := by
+    intro γ r
+    exact mul_pos
+      (div_pos
+        (verticalMultiplicityTrace_pos D₁.multiplicity_pos D₁.weight_pos γ)
+        (verticalMultiplicityTrace_pos D₂.multiplicity_pos D₂.weight_pos
+          (sigma γ)))
+      (D₂.weight_pos (sigma γ) r)
+  let C := BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums
+    Fam.chi m Fam.posEntries
+    D₁.multiplicity D₁.weight D₁.weight_pos (fun _ ↦ rfl)
+    (fun γ ↦ D₂.multiplicity (sigma γ)) twoEntry hTwoPos
+    (L₀ := N₀) (by
+      intro γ L hL
+      rw [show (∑ r, twoEntry γ r ^ L) =
+          ((verticalMultiplicityTrace D₁.weight γ /
+            verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
+              ∑ r, D₂.weight (sigma γ) r ^ L by
+        simp only [twoEntry, mul_pow, Finset.mul_sum]]
+      rw [hCoeff L hL γ]
+      simp only [BNTProductMultiplicityIndex, Fintype.sum_sigma,
+        Fintype.sum_prod_type, DiagonalChiFamily.tracePowerCoeff, mul_pow]
+      apply Finset.sum_congr rfl
+      intro α _
+      apply Finset.sum_congr rfl
+      intro β _
+      rw [mul_assoc, Fintype.sum_mul_sum, Fintype.sum_mul_sum]
+      apply Finset.sum_congr rfl
+      intro q _
+      apply Finset.sum_congr rfl
+      intro r _
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro k _
+      ring)
+  intro γ
+  have hTwoTrace : ∑ r, C.twoEntry γ r = m.traceScalar γ := by
+    change ∑ r, twoEntry γ r = ∑ q, D₁.weight γ q
+    simp only [twoEntry]
+    rw [← Finset.mul_sum]
+    change (verticalMultiplicityTrace D₁.weight γ /
+        verticalMultiplicityTrace D₂.weight (sigma γ)) *
+        verticalMultiplicityTrace D₂.weight (sigma γ) =
+      verticalMultiplicityTrace D₁.weight γ
+    exact div_mul_cancel₀ _
+      (verticalMultiplicityTrace_pos D₂.multiplicity_pos
+        D₂.weight_pos (sigma γ)).ne'
+  rw [← hTwoTrace, C.sum_twoEntry_eq_sum_products]
+  simpa only [Fam, BNTLabelCoefficientFamily.ofChi_coeff] using
+    C.sum_products_eq γ
+
+namespace HasBNTFusionTensorClause
+
+/-- **Theorem 4.14(i) implies (iii).** A horizontal-canonical MPDO satisfying
+the Definition 4.1 renormalization fixed-point condition has the
+source-faithful active-support BNT fusion clause.
+
+The one-site vertical decomposition supplies the BNT tensors, multiplicities,
+and positive weights.
+The transported RFP maps compare it with the two-site decomposition, produce
+the positive chi matrices and fusion coisometries, and give both blocked
+operator representations.  The preceding coefficient comparison supplies the
+remaining length-one idempotent law.
+
+Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
+lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem of_isRFPViaTS (M : MPOTensor d D)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) : HasBNTFusionTensorClause M := by
+  classical
+  obtain ⟨D₁⟩ := hHorizontal.exists_cpsvVerticalDecomposition M hM
+  obtain ⟨D₂⟩ := hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
+    (blockTwo M) hM.blockTwo
+  obtain ⟨Smap, T, hSCPTP, hTCPTP, hSphys, hTphys⟩ := hRFP
+  obtain ⟨sigma, hDim, V, _hContract, hLetter⟩ :=
+    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
+      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
+      hTphys hSphys
+  have hRepresentations : ∀ (L : ℕ), 0 < L →
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+          ∑ γ,
+            (((verticalMultiplicityTrace D₁.weight γ /
+                verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
+              (∑ r, D₂.weight (sigma γ) r ^ L)) •
+              mpo (verticalBNTMPO (D₁.tensor γ)) L ∧
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+        ∑ α, ∑ β,
+          ((∑ q, D₁.weight α q ^ L) * (∑ r, D₁.weight β r ^ L)) •
+            (mpo (verticalBNTMPO (D₁.tensor α)) L *
+              mpo (verticalBNTMPO (D₁.tensor β)) L) := by
+    intro L hL
+    exact blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      M D₁.tensor D₂.tensor
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry
+      D₁.reconstruction D₂.reconstruction
+      sigma hDim V hLetter hL
+  obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
+    transportedVerticalSector_exists_positiveFusionDecomposition
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
+      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
+      hTphys hSphys hHorizontal hM
+  have hIdempotent := hasIdempotentCoefficientForm_of_blockedRepresentations
+    D₁ D₂ sigma chi U hChiPos hU hFusion hFusionReconstruction
+    hRepresentations
+  exact ⟨{
+    labelCount := D₁.labelCount
+    bondDim := D₁.bondDim
+    multiplicity := D₁.multiplicity
+    weight := D₁.weight
+    tensor := D₁.tensor
+    verticalCoisometry := D₁.verticalCoisometry
+    multiplicity_pos := D₁.multiplicity_pos
+    weight_pos := D₁.weight_pos
+    coisometry := D₁.coisometry
+    isBNT := D₁.isCPSVBNT.isBNT
+    forward := D₁.forward
+    reconstruction := D₁.reconstruction
+    chi := chi
+    chi_pos := hChiPos
+    fusionCoisometry := U
+    fusionCoisometry_mul_conjTranspose := hU
+    fusion := hFusion
+    fusionReconstruction := hFusionReconstruction
+    idempotent := hIdempotent
+  }⟩
+
+end HasBNTFusionTensorClause
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
@@ -258,6 +258,97 @@ end OriginalCornerFamily
 
 end RetainedProductSpectralFamily
 
+/-- A fixed one-site/two-site sector transport witness determines positive
+diagonal fusion data and coisometries onto the active product sectors.
+
+This is the Figure-11 construction with the sector bijection, dimension
+identifications, and unitary conjugacies supplied explicitly, so downstream
+coefficient comparisons can reuse the same transport witness.
+
+Source: CPSV16, Appendix C.4, lines 2001--2029. -/
+theorem exists_positiveFusionDecomposition_of_unitaryBlockEquiv
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (sigma : Fin g₁ ≃ Fin g₂)
+    (hDim : ∀ i, dim₁ i = dim₂ (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ)
+    (hLetter : ∀ (i : Fin g₁) (ab : Fin (D * D)),
+      A₂ (sigma i) ab =
+        (verticalMultiplicityTrace weight₁ i /
+          verticalMultiplicityTrace weight₂ (sigma i)) •
+        ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (A₁ i ab) *
+          (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ))
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    ∃ (chi : DiagonalChiFamily (Fin g₁))
+      (U : ∀ α β : Fin g₁,
+        Matrix
+          ((γ : Fin g₁) × (Fin (chi.dim α β γ) × Fin (dim₁ γ)))
+          (Fin (dim₁ α * dim₁ β)) ℂ),
+      chi.PosEntries ∧
+      (∀ α β, U α β * (U α β)ᴴ = 1) ∧
+      (∀ (α β : Fin g₁) (i j : Fin D),
+        U α β *
+            (mulTensor (verticalBNTMPO (A₁ α))
+              (verticalBNTMPO (A₁ β))) i j *
+            (U α β)ᴴ =
+          Matrix.blockDiagonal' fun γ =>
+            chi.matrix α β γ ⊗ₖ verticalBNTMPO (A₁ γ) i j) ∧
+      ∀ (α β : Fin g₁) (i j : Fin D),
+        (mulTensor (verticalBNTMPO (A₁ α))
+          (verticalBNTMPO (A₁ β))) i j =
+          (U α β)ᴴ *
+            (Matrix.blockDiagonal' fun γ =>
+              chi.matrix α β γ ⊗ₖ verticalBNTMPO (A₁ γ) i j) *
+            U α β := by
+  classical
+  obtain ⟨R⟩ := exists_retainedProductSpectralFamily
+    dim₁ mult₁ weight₁ A₁ M U₁ hU₁ hReconstruct₁ hHorizontal hM
+  letI : ∀ γ, NeZero (dim₂ γ) := fun γ ↦
+    ⟨(hBNT₂.blocks_dim_pos γ).ne'⟩
+  obtain ⟨C⟩ := R.exists_flatBlockedBNTComparison
+    M U₁ hU₁ hReconstruct₁ dim₂ A₂ hBNT₂
+  have hNormal₂ : ∀ γ, MPSTensor.IsNormalTensor (A₂ γ) := fun γ ↦
+    hBNT₂.blocks_normal γ
+  have hActivePos : ∀ j, (0 : ℂ) < R.flatCoefficient j * C.phase j := fun j ↦
+    C.activeCoefficient_mul_phase_pos M hHorizontal hM
+      U₁ hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂
+      U₂ hU₂ hReconstruct₂ hNormal₂ j
+  choose omega homega hGram _hQ using fun j ↦
+    C.exists_unitaryNormalization M hHorizontal hM
+      U₁ hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂
+      U₂ hU₂ hReconstruct₂ hNormal₂ j
+  obtain ⟨O⟩ := R.exists_originalCornerFamily C hMult₁ hWeight₁
+    mult₂ hMult₂ weight₂ hWeight₂ sigma hDim V hLetter
+    hActivePos omega homega hGram
+  let Fam := O.toBNTFusionCoisometryFamily hMult₁
+  exact ⟨Fam.chi, Fam.fusionCoisometry, Fam.posEntries,
+    Fam.coisometry, Fam.fusion, Fam.reconstruction⟩
+
 /-- The one-site vertical BNT is closed under pairwise products through
 positive diagonal multiplicity matrices and coisometries onto the active
 product sectors.  The adjoint coisometries reconstruct every product letter,
@@ -348,27 +439,10 @@ theorem transportedVerticalSector_exists_positiveFusionDecomposition
       hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₁ hBNT₂
       U₁ U₂ hU₁ hU₂ T Smap hTCPTP hSCPTP
       hForward₁ hReconstruct₁ hForward₂ hReconstruct₂ hTphys hSphys
-  obtain ⟨R⟩ := exists_retainedProductSpectralFamily
-    dim₁ mult₁ weight₁ A₁ M U₁ hU₁ hReconstruct₁ hHorizontal hM
-  letI : ∀ γ, NeZero (dim₂ γ) := fun γ ↦
-    ⟨(hBNT₂.blocks_dim_pos γ).ne'⟩
-  obtain ⟨C⟩ := R.exists_flatBlockedBNTComparison
-    M U₁ hU₁ hReconstruct₁ dim₂ A₂ hBNT₂
-  have hNormal₂ : ∀ γ, MPSTensor.IsNormalTensor (A₂ γ) := fun γ ↦
-    hBNT₂.blocks_normal γ
-  have hActivePos : ∀ j, (0 : ℂ) < R.flatCoefficient j * C.phase j := fun j ↦
-    C.activeCoefficient_mul_phase_pos M hHorizontal hM
-      U₁ hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂
-      U₂ hU₂ hReconstruct₂ hNormal₂ j
-  choose omega homega hGram _hQ using fun j ↦
-    C.exists_unitaryNormalization M hHorizontal hM
-      U₁ hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂
-      U₂ hU₂ hReconstruct₂ hNormal₂ j
-  obtain ⟨O⟩ := R.exists_originalCornerFamily C hMult₁ hWeight₁
-    mult₂ hMult₂ weight₂ hWeight₂ sigma hDim V hLetter
-    hActivePos omega homega hGram
-  let Fam := O.toBNTFusionCoisometryFamily hMult₁
-  exact ⟨Fam.chi, Fam.fusionCoisometry, Fam.posEntries,
-    Fam.coisometry, Fam.fusion, Fam.reconstruction⟩
+  exact exists_positiveFusionDecomposition_of_unitaryBlockEquiv
+    dim₁ mult₁ weight₁ dim₂ mult₂ weight₂
+    hMult₁ hWeight₁ hMult₂ hWeight₂ M A₁ A₂ hBNT₂
+    U₁ U₂ hU₁ hU₂ hReconstruct₁ hReconstruct₂
+    sigma hDim V hLetter hHorizontal hM
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -814,27 +814,36 @@ weights in the length-independent case at
     implications involving the renormalization fixed-point condition.
 \end{definition}
 
-\begin{definition}[Fusion isometries for a vertical canonical decomposition]%
+\begin{definition}[Active-sector fusion for a vertical canonical decomposition]%
     \label{def:mpdo_bnt_fusion_tensor_clause}
     \lean{MPOTensor.BNTFusionTensorClause}
     \lean{MPOTensor.HasBNTFusionTensorClause}
     \leanok
     \uses{def:vertical_cf_mpdo,
-        def:mpdo_bnt_fusion_isometry_family,
+        def:mpdo_bnt_fusion_coisometry_family,
         def:mpdo_bnt_label_idempotent_coefficient_form}
     Choose a vertical canonical decomposition
     \[
         U\widetilde M U^\dagger
         =\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
     \]
-    The fusion-isometry clause for this decomposition consists of positive
-    diagonal matrices $\chi_{\alpha,\beta,\gamma}$ and isometries
-    $U_{\alpha,\beta}$ satisfying
+    The fusion clause for this decomposition consists of positive diagonal
+    matrices $\chi_{\alpha,\beta,\gamma}$ and coisometries
+    $U_{\alpha,\beta}$ onto the active product sectors, satisfying
     \[
         U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
         U_{\alpha,\beta}^\dagger
         =\bigoplus_\gamma
         \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}.
+    \]
+    They obey $U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$, and the active
+    direct sum reconstructs the product tensor:
+    \[
+        (M_\alpha M_\beta)^{ij}
+        =U_{\alpha,\beta}^\dagger
+          \left(\bigoplus_\gamma
+            \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}\right)
+          U_{\alpha,\beta}.
     \]
     The trace scalars $m_\alpha=\operatorname{tr}(\mu_\alpha)$ satisfy the
     length-one idempotent identity for the coefficients determined by these
@@ -844,7 +853,40 @@ weights in the length-independent case at
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Fusion isometries imply the tensor-attached algebra clause]%
+\begin{theorem}[Renormalization fixed points have active-sector fusion]%
+    \label{thm:mpdo_rfp_to_bnt_fusion_tensor}
+    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}
+    \leanok
+    \uses{def:is_rfp_via_ts,
+        def:vertical_cf_mpdo,
+        def:mpdo_bnt_fusion_tensor_clause}
+    Let $M$ be a matrix product density operator in horizontal canonical form.
+    If the one-site and two-site physical closures are related in both
+    directions by trace-preserving completely positive maps as in
+    Definition~4.1, then a vertical canonical decomposition of $M$ has the
+    active-sector fusion clause above.  In particular, its positive diagonal
+    fusion matrices satisfy the length-one idempotent trace-scalar identity.
+\end{theorem}
+\begin{proof}\leanok
+    Choose vertical canonical decompositions of the one-site tensor and its
+    two-site blocking.  Transporting the two physical maps through these
+    decompositions identifies their normal sectors and yields the positive
+    active-sector fusion of each product $M_\alpha M_\beta$.  For every
+    positive length, the blocked operator is therefore both a sum over the
+    two-site multiplicity matrices and the product of the two one-site sums.
+    At all sufficiently large lengths, the normal-sector operators are
+    linearly independent, so their coefficients agree.  Equality of the
+    resulting positive power sums identifies the two multisets of
+    multiplicity entries.  Summing this multiset identity gives
+    \[
+      m_\gamma=\sum_{\alpha,\beta}
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
+        m_\alpha m_\beta,
+    \]
+    which completes the fusion clause.
+\end{proof}
+
+\begin{theorem}[Active-sector fusion implies the tensor-attached algebra clause]%
     \label{thm:mpdo_bnt_fusion_tensor_to_algebra_tensor}
     \lean{MPOTensor.BNTFusionTensorClause.toBNTAlgebraTensorClause}
     \lean{MPOTensor.HasBNTFusionTensorClause.to_hasBNTAlgebraTensorClause}
@@ -852,7 +894,7 @@ weights in the length-independent case at
     \uses{def:mpdo_bnt_algebra_tensor_clause,
         def:mpdo_bnt_fusion_algebra_clause,
         def:mpdo_bnt_fusion_tensor_clause}
-    Suppose the fusion-isometry clause holds for a chosen vertical canonical
+    Suppose the active-sector fusion clause holds for a chosen vertical canonical
     decomposition.  Then the algebra clause holds for the same decomposition,
     with coefficients, for every positive chain length $L$,
     \[

--- a/docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex
+++ b/docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex
@@ -104,11 +104,12 @@ The existing structure
 \leanid{MPOTensor.BNTFusionIsometryFamily} assumes
 $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=I$.  It remains mathematically
 valid as a conditional full-support structure, but it is not the unrestricted
-conclusion of the source theorem.  The tensor-attached structure
-\leanid{MPOTensor.BNTFusionTensorClause} inherits the same restriction.
+conclusion of the source theorem.  It is retained only for results whose
+hypotheses explicitly require full support.
 
-The source-facing construction tracked in \ghissue{4588} therefore uses a
-separate active-support fusion family with the following data:
+The source-facing construction tracked in \ghissue{4588} uses the
+active-support family \leanid{MPOTensor.BNTFusionCoisometryFamily} with the
+following data:
 \begin{enumerate}
   \item positive diagonal matrices $\chi_{\alpha,\beta,\gamma}$, allowing
     zero-dimensional multiplicity spaces;
@@ -122,9 +123,14 @@ the nonzero reducing corners give isometric inclusions into the product bond
 space, and their adjoints assemble into the required row coisometry.  No
 claim that the active projection is the identity is needed.
 
-A subsequent migration may replace uses of the stronger family by the
-active-support family after auditing which later results genuinely require
-full support.  Conversion to the former structure is permitted only under the
+The tensor-attached structure
+\leanid{MPOTensor.BNTFusionTensorClause} now uses this same active-support
+contract: it stores $UU^\dagger=I$, the forward fusion identity, and exact
+reconstruction.  The implication from the renormalization fixed-point maps is
+proved in
+\leanid{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}, completing the
+realignment tracked in \ghissue{4225}.  Conversion to the stronger
+\leanid{MPOTensor.BNTFusionIsometryFamily} remains permitted only under the
 additional identity $U^\dagger U=I$, or an equivalent assertion that the
 product tensor has no discarded zero reducing corner.
 
@@ -133,7 +139,9 @@ The phrase ``isometries $U_{\alpha,\beta}$'' in the source uses the same
 retained-row orientation as Proposition~4.13.  Interpreting it as
 $U^\dagger U=I$ strengthens the theorem and excludes legitimate zero product
 sectors.  The faithful Figure~11 conclusion is coisometry onto the active
-direct sum together with exact reconstruction.
+direct sum together with exact reconstruction.  The source-facing
+tensor-attached fusion clause and its renormalization-fixed-point construction
+now implement precisely this conclusion.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- Complete the implication from the Definition 4.1 renormalization fixed-point condition to the BNT fusion clause in CPSV16, Theorem 4.14(i) → (iii), Appendix C.4, lines 1929–2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.
- Keep the tensor-attached clause faithful to Figure 11: the retained-row fusion map obeys `U U† = 1` and exact reconstruction, while the stronger full-support `U† U = 1` family remains conditional. The orientation is documented in `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`.

### Description

- Add `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS` with exactly the source assumptions: horizontal canonical form, MPDO positivity, and `IsRFPViaTS`.
- Compare the simultaneous one-site and two-site blocked-operator representations using eventual linear independence of the BNT operator family; positive power-sum equality then yields the length-one idempotent trace-scalar law.
- Package the positive active-sector fusion coisometries and reconstruction supplied by the transported RFP maps into `BNTFusionTensorClause`.
- Add the coisometry-family operator/algebra bridges and a fully tagged blueprint theorem.

### Testing

- `lake build` — 9,711 jobs
- direct Lean checks for all changed Lean modules
- `leanblueprint checkdecls`
- `leanblueprint pdf` — 717 pages; changed pages 699–701 rendered and inspected
- paper-gap `latexmk -pdf` — 3 pages rendered and inspected
- blueprint Lean-sync CI check
- import-aggregator generation/check and policy tests
- reader-facing prose check
- tactic-pattern scan
- changed-file proof-integrity scan
- `git diff --check`

---
Closes #4225

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof surface in core MPDO/BNT theory with no runtime/security impact; mistakes would be mathematical incorrectness rather than operational risk. The fusion API change (isometry → coisometry) could affect downstream Lean imports that assumed full support.
> 
> **Overview**
> Completes **CPSV16 Theorem 4.14(i) → (iii)** by proving `HasBNTFusionTensorClause.of_isRFPViaTS` from horizontal canonical form, MPDO, and `IsRFPViaTS`, closing the RFP → active-sector fusion implication tracked in the paper-gap realignment.
> 
> **`BNTFusionTensorClause`** is switched from full-support fusion isometries (`U†U = 1`) to the Figure-11 **active-support** contract: fusion **coisometries** with `UU† = 1`, forward block-diagonal fusion, and **exact reconstruction** of product letters. Implication (iii) → (ii) now goes through `BNTFusionCoisometryFamily` and new algebra bridges on `BNTFusionCoisometries` (`toOperatorFamily`, `toBNTAlgebraClause`).
> 
> **`BNTFusionTensorClauseFromRFP`** assembles one- and two-site vertical decompositions and transported RFP maps, builds positive `χ` and coisometries via `exists_positiveFusionDecomposition_of_unitaryBlockEquiv`, and derives the length-one idempotent trace-scalar law by comparing dual blocked-operator expansions (eventual BNT linear independence + positive power-sum comparison). **`VerticalProductFusionDecomposition`** factors that existence lemma out for reuse.
> 
> Blueprint chapter 21 and **`cpsv16_figure11_fusion_coisometry.tex`** document the coisometry orientation and tag the new RFP theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55e78d0d7338e712cb6c6c66161f739f6abb7c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->