### PR TITLE
doc(tenkz): complete the 0.7 simplification gate

### DIFF
--- a/blueprint/src/Packages/tenkz_pic.py
+++ b/blueprint/src/Packages/tenkz_pic.py
@@ -52,14 +52,14 @@ Design decisions
    ``\newcounter{chapter}`` shim required because standalone is article-based
    and lacks the chapter counter that common's theorem numbering expects.
 
-TODO (G20, out of Phase-0 scope): the **whole-equation reroute** — running
-math containing ``\tnpic[inline]`` must be rerouted whole-equation to the
-SVG path, because MathJax cannot typeset the atom (spec §1.5, §9.4).
-Until it lands, ``\tnpic`` inside ``$...$``/``\[...\]`` and tenkz
-environments inside display math render an ``<img>`` inside MathJax input,
-which MathJax will not typeset; Phase-0 chapter style must keep pictures
-at top level or inside ``figure`` (display-adjacent usage, maintainer
-decision §9.4).
+5. **Equation rows (G20).**  Blueprint source marks a display-adjacent
+   diagram equation with ``tenkzequation``.  The wrapper keeps every captured
+   picture as its own SVG outside MathJax and lays the sibling pictures and
+   operator text out as one responsive row.  Equality signs and arrows remain
+   selectable instead of becoming part of one whole-equation image.  A bare
+   ``\tnpic`` inside ``$...$`` or ``\[...\]`` is still unsupported because
+   MathJax cannot typeset the emitted ``<img>``; ordinary TeX retains that
+   running-math capability.
 """
 
 from __future__ import annotations
@@ -407,7 +407,7 @@ except ImportError:  # standalone harness use; see the section comment above
 else:
 
     class tenkzequation(Environment):
-        """A text-mode row of independently rendered tenkz picture units."""
+        """A responsive text-mode row of independent SVG picture units."""
 
         blockType = True
         templateName = "TenkzEquation"
@@ -446,9 +446,8 @@ else:
                 return _missing_tools_html(unit_source)
             src = _svg_src(self, svg_path, output_dir)
             lang = _ENVIRONMENT_LANGS[self.nodeName]
-            # The verbatim unit source doubles as the alt text: it is the
-            # only faithful textual description available before the G20
-            # accessibility follow-up (maintainer decision §9.4).
+            # The verbatim unit source is the per-picture alternative text;
+            # tenkzequation keeps operators outside the image and selectable.
             return (
                 f'<img class="tenkz-pic tenkz-pic-{lang}" '
                 f'src="{escape(src, quote=True)}" '
@@ -493,10 +492,10 @@ else:
         ``\verb`` captures its argument, so cell separators (``&``),
         comments, and math inside the body survive untouched.
 
-        TODO (G20): running math containing ``\tnpic[inline]`` must be
-        rerouted whole-equation to the SVG path — MathJax cannot typeset
-        the atom this class emits.  Out of Phase-0 scope; until then
-        ``\tnpic`` is only supported outside math (see module docstring).
+        In blueprint source this command is supported at top level, including
+        as a child of ``tenkzequation``.  It must not appear inside MathJax
+        input: the explicit equation wrapper is the G20 web contract, while
+        ordinary TeX may continue to use the atom in running mathematics.
         """
 
         blockType = False

--- a/docs/tenkz/CHANGES-0.6.md
+++ b/docs/tenkz/CHANGES-0.6.md
@@ -94,10 +94,10 @@ and the `on-wire matrix` style name for `ring tensor`.
   geometrically incomplete closures diagnose the real open endpoints
   without inventing topology.
 - The package version string reads v0.6.
-- The periodic racetrack drop is per-obstruction: the base clearance
-  (0.30 pitch) covers only the glyph silhouette, and open legs, labelled
-  leg tips, and dot labels each add their own band. A bare ring hugs its
-  row; the old fixed 0.62 budgeted for labels that were often absent.
+- The periodic racetrack drop is measured per obstruction: the renderer
+  computes the row's actual silhouette, including glyphs, facing legs, and
+  labels, then adds the one 0.15-pitch daylight. A bare ring hugs its row;
+  labelled ink moves the return without a separate clearance budget.
 - The on-wire matrix capsule's corner radius is the named ratio
   `wireglyphcap` (= wireglyph/2). The 0.6-review spelling
   `0.5\tenkz@dim{...}` misparsed in pgf and drew lens-shaped capsules.

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -403,18 +403,18 @@ A command exists **iff** it introduces a new grammatical class: atom (`\tn`), on
 ```latex
 \[
   \begin{tenkz}[rows={op, ket}]
-    \tnfuse[rows=2]{V} & \tn[mpo]{O}\tnspan[brace above]{3}{n} & \tndots & \tn[mpo]{O} \\
+    \tnfuse[span=2]{V} & \tn[mpo]{O}\tnspan[brace above]{3}{n} & \tndots & \tn[mpo]{O} \\
                        & \tn{A}                                & \tndots & \tn{A}
   \end{tenkz}
   \;=\;
   \begin{tenkz}[rows={op, ket}]
-    \tn[mpo]{O}\tnspan[brace above]{3}{n} & \tndots & \tn[mpo]{O} & \tnfuse[rows=2, combined=east]{V} \\
+    \tn[mpo]{O}\tnspan[brace above]{3}{n} & \tndots & \tn[mpo]{O} & \tnfuse[span=2, combined=east]{V} \\
     \tn{B}                                & \tndots & \tn{B}      &
   \end{tenkz}
 \]
 ```
 
-`\tnfuse[rows=2]{V}` spans both wire rows: two east stubs feed the layer wires, one combined wire exits west in the fused doubled-stroke skin (mirrored via `combined=east` on the RHS). Axis defaults to the midline, so `=` aligns across both sides with no key.
+`\tnfuse[span=2]{V}` spans both wire rows: two east stubs feed the layer wires, one combined wire exits west in the fused doubled-stroke skin (mirrored via `combined=east` on the RHS). Axis defaults to the midline, so `=` aligns across both sides with no key.
 
 **B8 — Inline transfer-map atom inside `\sum` in running math**
 
@@ -481,7 +481,7 @@ One base: `pitch = 11mm` (display). Derived constants (name, value, motivation):
 | `label clearance` | 0.12·pitch | one constant for every quadrant (G7) |
 | `junction diameter` | ≥ 0.9mm (about 4.7 × the 0.55pt wire width) | the absolute print floor keeps a junction distinct from a wire crossing |
 | `region margin` (`\tenkz@r@latticemargin`) | 0.27·pitch | strictly < pitch/2 so single-site notches read; > glyph radius so hulls never clip glyphs |
-| `compact` / `inline` | 0.8 scale / em-based scale on pitch | profiles are one scale factor, not parallel constant lists — literals cannot bypass them |
+| `compact` / `inline` | 0.8 / 0.62 scale on pitch | profiles are one scale factor, not parallel constant lists — literals cannot bypass them |
 | `map column gap` | max(0.34·pitch, widest map-name band + 2·daylight) | the floor keeps a short composition compact; measured opaque label ink clears both adjacent objects without budgeting glyphs; explicit `column sep=` remains an opt-in override |
 | `map row gap` | 0.50·pitch | adjacent small multiples remain distinct without figure-scale leading; `row sep=` overrides it |
 

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -28,7 +28,7 @@
 | G16 | Literal-zero migration exit scan | tnplain | §6 |
 | G17 | Lint ban on literal `...`/`\ldots` inside picture bodies (must be `\tndots`) | tnplain | §5.7 |
 | G18 | Region-tracer day-1 fallback (fill mode = per-cell rounded squares; outline restricted to simply-connected sets until the notch algorithm matures) | tnplain | §1.3, §6 |
-| G19 | Governance: hard CI cap on the public API surface + "a new command requires a new grammatical class; a new builder key requires three existing figures it shortens" | tnplain | §2.7 |
+| G19 | Governance: measured public API surface + "a new command requires a new grammatical class; a new builder key requires three existing figures it shortens" | tnplain | §2.7 |
 | G20 | Explicit `tenkzequation` row keeps SVG diagram atoms outside MathJax while retaining copyable operator text | tnplain | §1.5 |
 | G21 | Sugar contract: every sugar and builder expands to primitives with byte-identical event streams | tncalc | §5.2 |
 | G22 | "Why this is a command and not a key" printed per command in the reference chapter | Quartet | §7 |
@@ -42,7 +42,7 @@
 1. **Winner split** (judge-author → Quartet; judges tufte + maintainer → tenkz). Resolved for tenkz on tally and 2/3 majority. Judge-author's preference is substantively honored: Quartet's five distinguishing assets (G1, G2/G3, G9, G10/G11, G23) are grafted, and his four concrete tenkz defects are fixed here — the `\tnfuse` signature contradiction (§2.1), the command-vs-key doctrine contradiction (§2.7), the polygon-mode honesty problem (§2.2), and the compressed Phase-1 hump (§6, split into scripted sub-batches with two gates).
 2. **Engine** (author: xelatex forecloses Lua for the hull tracer; tufte + maintainer: xelatex avoids a book-wide typography gamble). **Resolved: keep xelatex end-to-end** (print and corpus = xelatex; web = xelatex → .xdv → dvisvgm). Two judges explicitly scored this as a tenkz advantage. The tracer is written in expl3 over bounded grids (≤ 12×12) with tnplain's day-1 fallback (G18). Escalation path is Open Question 1.
 3. **Row pairing mechanism** (maintainer offered `rows=` typing *and/or* `\contract{±n}`). **Resolved: `rows=` typing only, no new command.** Adjacent-layer pairing is a row-policy default; the per-cell escape is a `pair=+1|-1|none` key on `\tn`. This keeps the API surface flat and is consistent with the doctrine in §2.7.
-4. **Line-budget governance** (author wanted tnplain's CI cap; tnplain's own 800-line cap was busted by its own table, per judge-maintainer). **Resolved: cap the API, not the line count.** CI enforces exactly 4 environments + 17 exported commands (counted mechanically); per-file line budgets are an advisory CI report. A quantikz-scale grid engine cannot honestly promise 800 lines.
+4. **Line-budget governance** (author wanted tnplain's CI cap; tnplain's own 800-line cap was busted by its own table, per judge-maintainer). **Resolved: measure the API, not the line count.** The shipped surface has five public environments across four sub-languages (the fifth is the `tenkzplanes` preset), 17 exported commands, and 143 leaf keys. The recurring simplification gate records that census; per-file line budgets remain advisory. A quantikz-scale grid engine cannot honestly promise 800 lines.
 5. **Migration regression mechanism** (pixel diff vs event-graph isomorphism). **Resolved: both.** Pixel diff with a whitelisted intentional-fix list (visual critique items) *and* the iso gate (G9); the iso gate is waivable per figure with a one-line justification, same discipline as paper-gap notes.
 
 ---
@@ -55,7 +55,7 @@
 tenkz.sty                 user entry point; version; loads all layers
 tenkz-core.code.tex       L0  /tenkz/ pgfkeys tree; two-layer theme/semantic styles COMPLETED
                               for all styles (closes the 14/31 gap); semantic hue table;
-                              metric system: ONE pitch (11mm) + 8 documented ratios (§4.4);
+                              metric system: ONE pitch (11mm) + 38 documented ratios (§4.4);
                               event stream v2 (.tnlog, expl3 iow, per-picture ids, currfile src);
                               port-type registry (virtual/physical ONLY — morphism deleted);
                               theme scope guard (rejects geometry keys in themes, G14)
@@ -112,7 +112,7 @@ One engine end-to-end: **xelatex** for print and the adopted corpus; **xelatex �
 
 ## 2. Complete public API
 
-**Surface: 4 environments + 17 commands + ~45 documented keys.** CI counts the exports; the cap is hard (G19). Every command's reference entry prints its "why not a key" justification (G22).
+**Surface: five public environments across four sub-languages + 17 commands + 143 documented leaf keys.** The recurring gate counts the surface (G19). Every command's reference entry prints its "why not a key" justification (G22).
 
 ### 2.1 `tenkz` — the contraction grid
 
@@ -444,12 +444,12 @@ Two-layer split: **semantic styles** (what a mark means) bind to **theme slots**
 | `mpo tensor` | `\tn[mpo]` | 0.55pt | operator-layer skin |
 | `peps tensor` | lattice sites, `\tn[peps]` | 0.55pt | leg geometry fixed in L1 (no double-stroke defect) |
 | `fusion map` | `\tnfuse` | 0.55pt | trivalent glyph |
-| `tree junction` | `\tntree` nodes | dot ≥ 0.9mm | = 3.2 × wire width (print floor) |
+| `tree junction` | `\tntree` nodes | dot ≥ 0.9mm | absolute print floor, about 4.7 wire widths |
 | `bond` | virtual wires | 0.55pt | identical stroke to physical (type = direction) |
 | `fused bond` | `:fused` rows, `\tnfuse` output, `\tnjoin[fused]` | doubled 0.55pt | RMP index-bundle convention (G3) |
 | `physical leg` | leg stubs | 0.55pt | length 0.38·pitch |
 | `bond arrow` | `bond dir=` marks | 0.55pt head | MPO orientation (G4) |
-| `trace` | `periodic`/`trace=` arcs | 0.55pt | racetrack, clearance 0.55·pitch |
+| `trace` | `periodic`/`trace=` arcs | 0.55pt | racetrack outside the measured silhouette plus 0.15·pitch daylight |
 | `cut` | `\tncut` | 0.40pt dashed | |
 | `brace` | `\tnspan[brace *]` | 0.40pt | annotation ink |
 | `group region` | `\tnspan[box]`, `\tnregion[group]` | 0.40pt dashed, no fill | one meaning and one measured renderer in grid and free tiers |
@@ -479,7 +479,7 @@ One base: `pitch = 11mm` (display). Derived constants (name, value, motivation):
 | `virtual stub` | 0.45·pitch | long enough to read as an open index, shorter than a bond so a dangling end is never mistaken for a contraction |
 | `daylight` | 0.15·pitch beyond the measured silhouette | pure separation keeps return and annotation ink from fusing with the ink it skirts |
 | `label clearance` | 0.12·pitch | one constant for every quadrant (G7) |
-| `junction diameter` | 3.2 × wire width (≥ 0.9mm) | below 3×, a junction is indistinguishable from a wire crossing at 600 dpi |
+| `junction diameter` | ≥ 0.9mm (about 4.7 × the 0.55pt wire width) | the absolute print floor keeps a junction distinct from a wire crossing |
 | `region margin` (`\tenkz@r@latticemargin`) | 0.27·pitch | strictly < pitch/2 so single-site notches read; > glyph radius so hulls never clip glyphs |
 | `compact` / `inline` | 0.8 scale / em-based scale on pitch | profiles are one scale factor, not parallel constant lists — literals cannot bypass them |
 | `map column gap` | max(0.34·pitch, widest map-name band + 2·daylight) | the floor keeps a short composition compact; measured opaque label ink clears both adjacent objects without budgeting glyphs; explicit `column sep=` remains an opt-in override |
@@ -651,7 +651,10 @@ Contexts/role/profile hand-entered metadata and their assert-equal churn (now de
 
 ### 5.9 Key-surface census (2026-07 gate)
 
-142 leaf `/tenkz` pgfkeys, across 14 families — counted by parsing every `/tenkz(...)/.code`, `.store~in`, and `.is~choice` declaration in `tex/tenkz/*.code.tex`, excluding choice-value branches and family roots:
+143 leaf `/tenkz` pgfkeys, across 14 families — counted by collecting direct
+`.code`, `.store~in`, and `.is~choice` leaf declarations and expanding every
+`\tenkz_install_core_forwards:nn` call in `tex/tenkz/*.code.tex`; choice-value
+branches, family roots, and `.unknown` handlers are excluded:
 
 | Family | Leaf keys | Source |
 |---|---:|---|
@@ -659,7 +662,7 @@ Contexts/role/profile hand-entered metadata and their assert-equal churn (now de
 | `/tenkz/grid` | 23 | `tenkz-grid.code.tex` |
 | `/tenkz/cell` | 23 | `tenkz-grid.code.tex` |
 | `/tenkz/span` | 4 | `tenkz-grid.code.tex` |
-| `/tenkz/lattice` | 27 | `tenkz-lattice.code.tex` |
+| `/tenkz/lattice` | 28 | `tenkz-lattice.code.tex` |
 | `/tenkz/region` | 7 | `tenkz-lattice.code.tex` |
 | `/tenkz/edge` | 5 | `tenkz-lattice.code.tex` |
 | `/tenkz/site` | 3 | `tenkz-lattice.code.tex` |
@@ -669,7 +672,7 @@ Contexts/role/profile hand-entered metadata and their assert-equal churn (now de
 | `/tenkz/cd` | 8 | `tenkz-cd.code.tex` |
 | `/tenkz/tree` | 6 | `tenkz-cd.code.tex` |
 | `/tenkz/arrow` | 5 | `tenkz-cd.code.tex` |
-| **total** | **142** | |
+| **total** | **143** | |
 
 For scale, quantikz's public key surface is roughly 40 — tenkz is a wider language by design (four sub-languages, not one), but the ratio is worth carrying forward rather than re-discovering at the next gate. No family here is flagged for removal: this is a measurement, not a verdict. Pruning candidates (a family whose keys have exactly one call site across `tex/tenkz/examples/` and the blueprint chapters) are **0.9-freeze material** — the manual and reference chapter become the binding contract at 0.9 (GOAL.md), and a key still resting on a single call site at that point is the moment to cut it, not before. Record the count at every gate (issue #4158); prune later.
 
@@ -1182,8 +1185,8 @@ both are a name hung off ink.
 keeps a return wire or a brace from fusing visually with the ink it
 skirts.  It clears nothing — what must be cleared is the silhouette's
 business and is measured.  0.15 pitch is about 1.7 mm at the default
-11 mm pitch (roughly three wire widths, so it reads at print size) and
-still about 1 mm at the inline pitch.  It replaces the former
+11 mm pitch (roughly 8.5 of the 0.55 pt wire widths) and still about
+1 mm (roughly 5.3 wire widths) at the inline pitch.  It replaces the former
 `traceclear = 0.30`, which budgeted a worst-case glyph inside a fixed
 drop, and the braces' unnamed 0.20 offset.
 

--- a/docs/tenkz/DESIGN.md
+++ b/docs/tenkz/DESIGN.md
@@ -29,7 +29,7 @@
 | G17 | Lint ban on literal `...`/`\ldots` inside picture bodies (must be `\tndots`) | tnplain | §5.7 |
 | G18 | Region-tracer day-1 fallback (fill mode = per-cell rounded squares; outline restricted to simply-connected sets until the notch algorithm matures) | tnplain | §1.3, §6 |
 | G19 | Governance: hard CI cap on the public API surface + "a new command requires a new grammatical class; a new builder key requires three existing figures it shortens" | tnplain | §2.7 |
-| G20 | Whole-equation SVG reroute for running math containing `\tnpic[inline]` (MathJax cannot typeset the atom) | tnplain | §1.5 |
+| G20 | Explicit `tenkzequation` row keeps SVG diagram atoms outside MathJax while retaining copyable operator text | tnplain | §1.5 |
 | G21 | Sugar contract: every sugar and builder expands to primitives with byte-identical event streams | tncalc | §5.2 |
 | G22 | "Why this is a command and not a key" printed per command in the reference chapter | Quartet | §7 |
 | G23 | Genre-ownership table (every brief use case mapped to exactly one sub-language) + Knuth-grade geometry-appendix format (constant, value, derivation, printed motivation) | Quartet | §4.4, §7 |
@@ -83,7 +83,7 @@ scripts/tenkz_lint.py     source lint: \ldots ban in picture bodies (G17), raw-i
 blueprint/src/Packages/tenkz_pic.py
                           plasTeX module: renders the four languages, tenkzplanes preset,
                           and \tnpic generically;
-                          per-body content-hash SVG cache; whole-equation reroute (G20)
+                          per-body content-hash SVG cache; explicit equation rows (G20)
 docs/tenkz/manual2.tex    the citable quantikz-style manual (§7)
 docs/tenkz/HACKING.md     operational build, audit, and visual-review guidance
 ```
@@ -106,7 +106,7 @@ Every environment and `\tnpic` yields a **slice**: a TeX box whose declared axis
 
 ### 1.5 Engine and web pipeline
 
-One engine end-to-end: **xelatex** for print and the adopted corpus; **xelatex → .xdv → dvisvgm** for web SVG (dvisvgm reads xdv natively). The library is engine-neutral internally (no unicode-math dependency). plasTeX registers the native environments + `\tnpic` as verbatim-captured, standalone-compiled SVG units with per-body content-hash caching — one edited figure invalidates one SVG, not the whole book. Running-math formulas containing `\tnpic[inline]` are rerouted whole-equation to the SVG path (G20); the accessibility trade-off is documented and scoped (only equations containing inline atoms).
+One engine end-to-end: **xelatex** for print and the adopted corpus; **xelatex → .xdv → dvisvgm** for web SVG (dvisvgm reads xdv natively). The library is engine-neutral internally (no unicode-math dependency). plasTeX registers the native environments + `\tnpic` as verbatim-captured, standalone-compiled SVG units with per-body content-hash caching — one edited figure invalidates one SVG, not the whole book. Blueprint equations containing diagram atoms use the explicit `tenkzequation` text-mode row (G20): every picture remains its own SVG outside MathJax, while equality signs, arrows, and other operator text remain selectable.
 
 ---
 
@@ -166,7 +166,7 @@ override and may deliberately undercut this automatic clearance.
 
 Typed-map rows belong to the categorical diagram language, not to the tensor-network language. Their vertices are mathematical objects and their joining strokes are maps, not contracted indices. A `\tnpic` occurring in an object cell remains an opaque mathematical object; the adjacent typed-map stroke does not acquire tensor ports or enter its contraction graph. The modes `maps` and `polygon` are disjoint, while ordinary grid mode retains the complete tikz-cd arrow grammar.
 
-A family is written as small multiples: one complete domain--codomain row for each member, with the same number of object columns in every row. A finite family is displayed in full, rather than by selected representatives. Parameters may remain symbolic when the displayed row asserts a formula uniformly over all their values. The matrix is a math object and requires no separate sizing mode. In an ordinary TeX document it may occur in displayed or running mathematics. In blueprint chapter source, until the whole-equation web reroute (G20) lands, a `tenkzcd` must instead be a top-level block outside `$...$` and `\[...\]`; use `\par\noindent\hfil ... \hfil\par` for a centered nonfloating diagram, or a `figure` when a genuine float is intended.
+A family is written as small multiples: one complete domain--codomain row for each member, with the same number of object columns in every row. A finite family is displayed in full, rather than by selected representatives. Parameters may remain symbolic when the displayed row asserts a formula uniformly over all their values. The matrix is a math object and requires no separate sizing mode. In an ordinary TeX document it may occur in displayed or running mathematics. In blueprint chapter source a single `tenkzcd` is a top-level block outside `$...$` and `\[...\]`; a row with operators or sibling pictures uses `tenkzequation`. A genuine float still uses `figure`.
 
 For the CPSV refinement, the middle-subspin Hilbert space is
 
@@ -424,7 +424,7 @@ $\E_A(X)=\sum_{i}\,\tnpic[sandwich, inline]{\tn{A^i} \\ \tn*{A^i}}\,(X)$
 and each summand is a congruence.
 ```
 
-On the web, any formula containing `\tnpic[inline]` is rerouted whole-equation to SVG (G20). **&-free fallback for hostile contexts** (`align`, footnotes, externalization): `\tndefine` the body outside the hostile context and use the defined macro inside — named explicitly in the troubleshooting chapter.
+Ordinary TeX may use this inline atom directly. Blueprint web source keeps it out of `$...$` and places display-adjacent diagram equations in `tenkzequation` (G20). The wrapper renders each picture independently and leaves its intervening operator text selectable. **&-free fallback for hostile contexts** (`align`, footnotes, externalization): state the same row explicitly with top-level siblings rather than placing an image inside MathJax input.
 
 ---
 
@@ -477,7 +477,7 @@ One base: `pitch = 11mm` (display). Derived constants (name, value, motivation):
 | `layer sep` | 0.80·pitch | double layers read as layers, not as two chains |
 | `physical leg` | 0.38·pitch | a labeled leg clears the bond label at script size |
 | `virtual stub` | 0.45·pitch | long enough to read as an open index, shorter than a bond so a dangling end is never mistaken for a contraction |
-| `trace clearance` | 0.55·pitch | racetrack clears leg labels on the outer row |
+| `daylight` | 0.15·pitch beyond the measured silhouette | pure separation keeps return and annotation ink from fusing with the ink it skirts |
 | `label clearance` | 0.12·pitch | one constant for every quadrant (G7) |
 | `junction diameter` | 3.2 × wire width (≥ 0.9mm) | below 3×, a junction is indistinguishable from a wire crossing at 600 dpi |
 | `region margin` (`\tenkz@r@latticemargin`) | 0.27·pitch | strictly < pitch/2 so single-site notches read; > glyph radius so hulls never clip glyphs |
@@ -736,7 +736,7 @@ keys are `periodic`, `sandwich`, `conjugate`, `fused`, never software jargon.
    canonical-spelling table as shared reference?
 3. **Slides scope.** Should the dark-theme slide deck migrate with the package,
    or should slide rendering remain a follow-up?
-4. **Inline-atom accessibility.** The whole-equation SVG reroute (G20) loses MathJax copyability/screen-reader text for every formula containing `\tnpic[inline]`. Acceptable for the public blueprint site as-is, or should chapter style restrict inline atoms to display-adjacent usage until an alt-text pipeline exists?
+4. **Inline-atom accessibility.** Should the web renderer turn an entire equation containing `\tnpic[inline]` into one SVG, or should source mark display-adjacent diagram rows explicitly so operator text remains selectable?
 5. **Publication.** Should tenkz ship as a standalone citable package at
    migration completion, or remain repository-internal for one release cycle?
 ---
@@ -749,8 +749,9 @@ The final outcomes are:
    stalls, `outline` restricts to simply-connected sets (fill mode covers notched figures).
 2. **The named dozen**: fully inlined; no catalogue-like house layer remains.
 3. **Slides**: migrated to the native package during catalogue demolition.
-4. **Inline-atom accessibility**: whole-equation SVG reroute accepted; style rule restricts inline
-   atoms to display-adjacent prose; alt-text pipeline is follow-up work.
+4. **Inline-atom accessibility**: explicit `tenkzequation` rows are the web contract. Each diagram
+   atom is an SVG with source-derived alternative text, while the operators between atoms remain
+   selectable; true running-text atoms stay an ordinary-TeX capability.
 5. **Publication**: repo-internal for one release cycle, then CTAN/arXiv.
 
 ## 10. Additional hard requirements (maintainer, 2026-07-16)
@@ -862,20 +863,19 @@ row-to-self form. Resolution is local-wins: cell > row > side > picture.
 
 ### 12.4 The trace-clearance correction
 
-The §4.4 table fixed `trace clearance` at 0.55·pitch; the shipped source used 0.62, and the
-manual's fact-check ruled that the source wins. The audit then proved every constant wrong:
-with open legs facing the racetrack, leg (0.38) + label clearance (0.12) + script-size text
-exceeds 0.62, and the rendered trace loop collided with physical ink. The decided fix computes
-the racetrack ordinate additively from the outer row's occupied band —
+The first table fixed `trace clearance` at 0.55·pitch, while the early source
+used 0.62. Both constants predicted the outer row's ink and both failed when a
+different glyph or label changed that ink. An intermediate additive budget
+made the dependencies visible but still duplicated the drawing passes' model.
+The final rule measures instead:
 
-    trace y = row y ± ( glyph half-extent
-                        + physical leg + label band   (only when open legs face the loop)
-                        + trace margin )
+    trace ordinate = row axis ± (measured silhouette + daylight)
 
-with one new named ratio `trace margin` = 0.24·pitch and no user-facing key. The §4.4
-trace-clearance row is superseded; the claim "the racetrack clears leg labels on the outer
-row" becomes true by construction, for every glyph skin.
-<!-- The 0.62 constant still guards the drawing site until the band rule lands in source. -->
+The silhouette includes the rendered glyph edge, each facing physical leg and
+label band, pair-trace cap, external bead label, and fusion overhang. The sole
+added distance is `daylight = 0.15·pitch`, pure separation beyond the measured
+ink. There is no trace-clearance ratio to retune and no consumer predicts what
+another pass draws.
 
 ## 13. Cups and the canonical channel spellings
 
@@ -1108,6 +1108,47 @@ The gate asks three questions after each migration slice.
    compatibility spelling of `boundary=open`. Keep it while migrated sources
    use it; once an in-repository search reaches zero, delete the alias and its
    reference row rather than maintaining two names for one policy.
+
+### 17.2 Recurring simplification gate (2026-07-22)
+
+This run covered the native package and its manual after the catalogue
+demolition.
+
+1. **What grew ad hoc?** Documentation facts drifted from the mechanisms they
+   described. The geometry appendix still printed a fixed trace clearance even
+   though the renderer measures a silhouette and adds one daylight; it also
+   claimed to transcribe every ratio while omitting most of the 38 named
+   ratios. The web specification promised automatic whole-equation rerouting,
+   while the shipped and tested contract is the explicit `tenkzequation` row.
+   The appendix and web contract now state the implemented mechanisms.
+2. **Which two things are secretly one thing?** The lattice and free-region
+   commands expose one region grammar, but their parsing has different state
+   effects and their renderers consume different geometry. Issue #4608 owns the
+   shared declarative surface and its byte-identical event gate; this pass does
+   not fold that medium-risk parser change into documentation repair. The six
+   remaining implementation twins likewise stay in issue #4614 until each call
+   site is audited. Similar slide bodies stay local: extracting whole figures
+   would recreate the catalogue and remove the body that each slide may extend.
+3. **What would be deleted in a redesign?** The following compatibility
+   spellings remain part of the 0.6 transition surface. Counts are non-comment
+   source lines at `a49dacc74` across examples, the adopted corpus, blueprint
+   chapters, slides, and the manual.
+
+   | Compatibility spelling | Canonical spelling | Lines | Files |
+   |---|---|---:|---:|
+   | `boundary legs` | `boundary=open` | 96 | 46 |
+   | `label at=` | `label pos=` | 39 | 17 |
+   | `route=curve` | `route=arc` | 70 | 25 |
+   | `legs at=` | explicit face data | 27 | 17 |
+   | `chain axis=` | `frame=` | 5 | 4 |
+   | `boundary=periodic` | `west=trace, east=trace` | 2 | 1 |
+   | `combined=` | explicit fused-face data | 48 | 28 |
+   | `\tnfuse[rows=2]` | `\tnfuse[span=2]` | 1 | 1 |
+
+   These spellings are kept because the manual does not become the binding
+   contract until the 0.9 freeze. Before that freeze, rewrite every non-fixture
+   client to the canonical form. Delete an alias only when that count reaches
+   zero, removing its compatibility probe and manual row in the same change.
 
 
 ## 18. The silhouette (recorded 2026-07-18)

--- a/docs/tenkz/REVIEW.md
+++ b/docs/tenkz/REVIEW.md
@@ -160,7 +160,9 @@ Headline decisions:
 2. **Repeated names**: chapter bodies are fully inline; no catalogue-like
    house layer remains.
 3. **Slides**: the dark theme uses the native package.
-4. **Web accessibility**: whole-equation SVG is accepted for display-adjacent
-   diagram atoms, with responsive reachability checked in browser tests.
+4. **Web accessibility**: display-adjacent diagram equations use the explicit
+   `tenkzequation` row. Each atom remains its own responsive SVG with
+   source-derived alternative text, while intervening operators remain
+   selectable; browser tests check the complete row.
 5. **Publication**: tenkz remains repository-internal for the present release
    cycle.

--- a/docs/tenkz/REVIEW.md
+++ b/docs/tenkz/REVIEW.md
@@ -10,7 +10,7 @@ Full reports: `wjchk4rdv.output` (source), `wyia43kx7.output` (visual), `ww2oeph
 
 ---
 
-## 1. Verdict on the current library
+## 1. Verdict on the retired library
 
 **The core calculus is genuinely good; everything above it institutionalizes the failure you
 sensed.** No published TN paper or package has typed ports, a semantic audit, or layout profiles —

--- a/docs/tenkz/REVIEW.md
+++ b/docs/tenkz/REVIEW.md
@@ -121,7 +121,8 @@ table) plus one-off wins from tncalc and tnplain — 26 grafts total, all record
 
 Headline decisions:
 
-- **Package `tenkz`**, 4 environments + 17 commands + ~45 keys, CI-capped API surface.
+- **Package `tenkz`**, five public environments across four sub-languages,
+  17 commands, and 143 leaf keys, measured at the recurring simplification gate.
   Sub-languages: `tenkz` (contraction grid: rows = layers, columns = sites, implicit bonds),
   `tenkzcd` (commutative diagrams: tikz-cd pass-through + `polygon=5` mode + `\tntree` fusion
   trees from bracketing words `(((a\,b)_x c)_y d)_e`), `tenkzlattice` (regions as cell-set
@@ -129,9 +130,10 @@ Headline decisions:
   the only place runtime port assertions remain).
 - **A 3-site periodic MPS word is one body line**; the transfer map is 2 lines with `sandwich`;
   no registration, no catalogue, no figure wrapper. `\tnpic{...}` is the bridge: an inline math
-  atom usable in running math, as a cd object, or as a lattice site skin.
+  atom usable in running math or as a cd object; the lattice sub-language owns its separate
+  `site=dot|none` policy.
 - **`morphism` port type deleted**; arrows live in tenkzcd with their own event species.
-- **Metrics**: one 11mm pitch + 8 documented ratios (each printed with its motivation);
+- **Metrics**: one 11mm pitch + 38 documented ratios (each printed with its motivation);
   profiles are a scale factor and *cannot* be bypassed by literals. Every visual-critique defect
   class is closed at the style/shape layer (junction ≥ 0.9mm, solid insertion ring, `pos=auto`
   label quadrants, dark theme recolors-never-reshapes, `\tndots` the only legal ellipsis).

--- a/docs/tenkz/chapters2/ch-house.tex
+++ b/docs/tenkz/chapters2/ch-house.tex
@@ -259,7 +259,7 @@ physical leg & $0.38$ & a labelled leg clears the bond-label band \\
 stub & $0.45$ & an open index: longer than a leg, shorter than a
   bond; also the reach of an inter-layer cup, so open and cup-closed
   ends share one silhouette \\
-daylight & $0.15$ & pure separation beyond measured ink: about three
+daylight & $0.15$ & pure separation beyond measured ink: about $8.5$
   wire widths at the default pitch, so a return cannot fuse visually
   with the silhouette it skirts \\
 label clearance & $0.12$ & the one clearance of every label band \\
@@ -368,7 +368,7 @@ wire width & $0.55$\,pt & the bond stroke, the reference width of
   the hierarchy \\
 emphasis width & $0.80$\,pt & region outlines and distinguished
   edges sit over wires \\
-junction floor & $0.9$\,mm & below about three wire widths a
+junction floor & $0.9$\,mm & below about $4.7$ wire widths a
   junction reads as dirt \\
 direction barb & $2.6$\,pt & the smallest direction mark that reads at
   print size \\

--- a/docs/tenkz/chapters2/ch-house.tex
+++ b/docs/tenkz/chapters2/ch-house.tex
@@ -1,12 +1,13 @@
 % chapters2/ch-house.tex — the house style: the closed glyph dictionary,
 % live over one source; the hue table in the package's own ink; the
 % label and ellipsis doctrines; the canonical spellings; and the
-% geometry appendix transcribed from the constants of
-% tenkz-core.code.tex.
+% geometry appendix transcribed from the constants of the five package
+% modules.
 %
 % Sources: the corrected atoms corpus (atoms_test.tex) for the skins,
 % channel_test.tex for the canonical channel spelling, and the ratio
-% comments of tenkz-core.code.tex for the geometry table.
+% comments beside the named ratios in tex/tenkz/*.code.tex for the
+% geometry table.
 
 % live hue chips for the table in \S(house-hues): each chip is filled
 % from the package's colour register, so a \colorlet theme re-inks the
@@ -227,10 +228,11 @@ bypass them.''  \S\ref{sec:modes-metric} varies and measures the
 system.}  The package states each ratio's motivation once, in a
 comment beside its definition; this table transcribes those
 comments, so the design argument is on the record where a reader can
-dispute it.
+dispute it.  File-local frame ratios multiply the lattice pitch, and
+the coincidence floor multiplies the bead diameter; their value rows
+say so explicitly.
 
-% the table is set as three group-tables so a page may break between
-% the groups; each repeats the head row
+% the table is split into groups so a page may break between them
 \medskip
 {\footnotesize
 \noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
@@ -250,15 +252,16 @@ base pitch & $11$\,mm & the one length; every ratio below
 \smallskip
 {\footnotesize
 \noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
-\multicolumn{3}{@{}l}{\emph{ratios of the pitch}} \\
+\multicolumn{3}{@{}l}{\emph{core spacing and label ratios}} \\
 \midrule
 layer gap & $0.80$ & layers read as layers, not as two chains \\
 physical leg & $0.38$ & a labelled leg clears the bond-label band \\
 stub & $0.45$ & an open index: longer than a leg, shorter than a
   bond; also the reach of an inter-layer cup, so open and cup-closed
   ends share one silhouette \\
-trace clearance & $0.62$ & the trace racetrack clears the leg labels
-  on the outer row \\
+daylight & $0.15$ & pure separation beyond measured ink: about three
+  wire widths at the default pitch, so a return cannot fuse visually
+  with the silhouette it skirts \\
 label clearance & $0.12$ & the one clearance of every label band \\
 dot-label band & $0.30$ & the depth of a script-size dot label:
   clearance plus text \\
@@ -277,13 +280,81 @@ pair-trace reach & $0.40$ & the per-column racetrack's reach east of
   the leg axis: under one half, so its straight clears the
   neighbouring column's bands; wide enough that the racetrack caps
   read as turnarounds, not kinks \\
-region margin & $0.36$ & under half a pitch, so notches read; over
-  the glyph radius \\
 corner radius & $0.14$ & the rounding of traces and hulls \\
 inline leg & $0.26$ & the inline profile shrinks legs faster than
   the pitch \\
 inline clearance & $0.05$ & inline labels hug the ink to spare line
   height \\
+\bottomrule
+\end{tabularx}\par}
+\smallskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
+\multicolumn{3}{@{}l}{\emph{glyph and fusion ratios}} \\
+\midrule
+inscribed glyph & $0.22$ & minimum side of a box and height of a pill;
+  also the lateral overhang of a span decoration \\
+on-wire glyph & $0.30$ & an insertion on a wire must read above the
+  wire it interrupts \\
+on-wire cap & $0.15$ & half the on-wire minimum closes its smallest
+  rectangle into a stadium \\
+fusion width & $0.075$ & a fusion bar reads as a wedge rather than a
+  second wire \\
+fusion overhang & $0.10$ & the bar visibly clasps its outer wire rows
+  and contributes the same amount to their silhouette \\
+\bottomrule
+\end{tabularx}\par}
+\smallskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{10mm}>{\raggedright\arraybackslash}X@{}}
+\multicolumn{3}{@{}l}{\emph{tree and typed-map ratios}} \\
+\midrule
+tree step & $0.55$ & sibling pitch and fusion depth agree, so a
+  balanced pair meets its junction at $45$ degrees \\
+tree root leg & $0.35$ & shorter than a fusion level, so the tree reads
+  as rooted rather than as one more leaf \\
+ribbon half-width & $0.065$ & a $0.13$-pitch band keeps two wire-weight
+  boundary curves distinct at compact scale \\
+tree-patch reach & $0.16$ & the three sectors stay distinct at the
+  sharpest four-leaf junction \\
+tree-patch control & $0.72$ & cubic controls leave a rounded nonzero
+  waist between the three sectors \\
+map column floor & $0.34$ & minimum air for an unlabelled map; measured
+  names enlarge the gap by their opaque band and two daylights \\
+map row separation & $0.50$ & adjacent family members remain distinct
+  small multiples \\
+\bottomrule
+\end{tabularx}\par}
+\smallskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}>{\raggedright\arraybackslash}p{26mm}p{18mm}>{\raggedright\arraybackslash}X@{}}
+\multicolumn{3}{@{}l}{\emph{lattice and projected-frame ratios}} \\
+\midrule
+lattice pitch & $0.75$ base & compacts a finite window relative to the base
+  pitch \\
+lattice margin & $0.27$ base & $0.36$ lattice pitches: below half a site
+  so notches read, beyond the bead radius so hulls do not clip \\
+region inset unit & $0.075$ base & separates nested or coincident region
+  boundaries \\
+boundary leg & $0.30$ base & a cut lattice bond remains legible at the rim \\
+oblique slant & $0.45$ lattice & a depth neighbour never reads as a column
+  neighbour \\
+oblique rise & $0.60$ lattice & clears the physical-leg crossing threshold
+  while retaining a foreshortened sheet \\
+slab slant & $0.60$ lattice & the full-pitch showcase frame buys lateral leg
+  clearance at the cost of width drift \\
+slab rise & $0.55$ lattice & pairs with the steeper slab slant above the leg
+  threshold \\
+double-layer slant & $0.40$ lattice & maximizes pairing-leg clearance for
+  sheets up to four row levels deep \\
+double-layer rise & $0.45$ lattice & the squat stack avoids the ambiguous
+  $0.48$--$0.52$ tangent band \\
+sheet gap & $0.70$ lattice & disjoint sheets retain about one row-rise of air;
+  the full separation also grows with the row count \\
+coincidence floor & $1.25$ bead & multiplier of the bead diameter below
+  which expert-frame sites read as one blob \\
+plane-trace reach & $0.20$ base & stays west of the next depth neighbour's
+  bead while a sheet-local trace crosses in-plane bonds \\
 \bottomrule
 \end{tabularx}\par}
 \smallskip
@@ -299,6 +370,11 @@ emphasis width & $0.80$\,pt & region outlines and distinguished
   edges sit over wires \\
 junction floor & $0.9$\,mm & below about three wire widths a
   junction reads as dirt \\
+direction barb & $2.6$\,pt & the smallest direction mark that reads at
+  print size \\
+fused barb & $3.8$\,pt & spans both strokes of a doubled wire \\
+brace amplitude & $2.6$\,pt & the smallest readable brace, numerically
+  equal to the barb floor but semantically independent \\
 \bottomrule
 \end{tabularx}\par}
 \medskip

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -56,10 +56,10 @@ padded with bare wire.
   one-row sugar for \texttt{ket|bra|op|wire} \\
 \texttt{sandwich} & --- & --- &
   \texttt{rows=\{ket, bra\}}, legs paired \\
-\texttt{boundary=} & \texttt{open|none} & \texttt{open} &
-  stubs at the row ends, or sealed \\
+\texttt{boundary=} & \texttt{open|none|}\newline \texttt{periodic} & \texttt{open} &
+  stubs at the row ends, sealed, or each row traced to itself \\
 \texttt{periodic} & --- & --- &
-  trace: each row closed to itself \\
+  compatibility alias for \texttt{boundary=periodic} \\
 \texttt{west label=}, \texttt{east label=} & \meta{math} & --- &
   boundary index at the stub tip \\
 \texttt{west=}, \texttt{east=} & \texttt{open|none|}\newline
@@ -209,6 +209,10 @@ An empty label, \tnval{\textbackslash tn\{\}}, is an anonymous tensor
   span $k$ columns \\
 \texttt{wires=} & \meta{k} & \texttt{1} &
   span and terminate $k$ wire rows (also on \tncmd{tnX}) \\
+\texttt{combined=} & \texttt{west|east} & --- &
+  on a \texttt{wires=}$k$ \tncmd{tn} or \tncmd{tnX}, replace that
+  virtual face by one centred fused stub; on \tncmd{tnfuse}, choose the
+  side of its combined stub \\
 \texttt{legs at=} & \texttt{\{c,\ldots\}} & centre &
   compatibility alias: the same physical ports on both faces \\
 \texttt{up at=}, \texttt{down at=} & \texttt{center|\{c,\ldots\}} & centre &
@@ -697,14 +701,15 @@ endpoints open rather than inventing a return path.
 \cmdsig{\textbackslash begin\{tenkzplanes\}[\meta{keys}]\
 \textbackslash end\{tenkzplanes\}}
 
-Two oblique sheets, ket over bra, with a site-wise pairing leg
-contracting each physical index --- the expectation-value object
-$\langle\Psi|\Psi\rangle$ of a two-dimensional state.  Cells listed
+The preset starts with an oblique ket sheet above an oblique bra sheet.
+A site-wise pairing leg contracts each physical index, giving the
+expectation-value object $\langle\Psi|\Psi\rangle$ of a two-dimensional state.  Cells listed
 in \tnkey{open=} keep their pairing legs dangling; cells listed in
 \tnkey{trace=} close by a wrap loop between the sheets, and trace
-beats open when a cell is listed in both.  The stack is fixed at
-\tnval{sheets=\{ket, bra\}}; anything else warns and draws the
-double layer (\S\ref{ch:trouble}).
+beats open when a cell is listed in both.  Every option is an ordinary
+\tnenv{tenkzlattice} key and overrides the corresponding preset state;
+in particular, \tnkey{sheets=} may replace the default
+\tnval{\{ket, bra\}} stack.
 
 \medskip
 {\footnotesize
@@ -713,8 +718,9 @@ double layer (\S\ref{ch:trouble}).
 \keyhead
 \texttt{rows=}, \texttt{cols=} & \meta{n} & --- &
   the window's extent \\
-\texttt{sheets=} & \texttt{\{ket, bra\}} & \texttt{\{ket, bra\}} &
-  the supported stack \\
+\texttt{sheets=} & \meta{n}\texttt{|}\newline
+  \texttt{\{ket,bra,\ldots\}} & \texttt{\{ket, bra\}} &
+  numeric sheets or a top-to-bottom role stack; overrides the preset stack \\
 \texttt{sheet sep=} & \meta{factor} & house &
   scales the inter-sheet gap \\
 \texttt{open=} & \texttt{\{(r,c),\ldots\}} & --- &

--- a/docs/tenkz/chapters2/ch-reference.tex
+++ b/docs/tenkz/chapters2/ch-reference.tex
@@ -78,6 +78,8 @@ padded with bare wire.
   per-site up-into-down trace (one-row pictures) \\
 \texttt{trace=} & \texttt{\{(physical, c-c)\}} & --- &
   per-column ket-into-bra trace \\
+\texttt{open=} & \texttt{\{(i,c),\ldots\}} & --- &
+  keep the selected inter-layer pairing legs open \\
 \texttt{bond dir=} & \texttt{right|left} & --- &
   arrows on every bond: out $=V$, in $=V^{*}$ \\
 \texttt{bond label=} & \texttt{\{\meta{m} at \meta{c}-\meta{c}\}} &
@@ -90,6 +92,8 @@ padded with bare wire.
   $0.8$ and $0.62$ pitch profiles \\
 \texttt{tensor style=} & \texttt{dot|box} & \texttt{dot} &
   glyph policy (Section~\ref{sec:ref-policy}) \\
+\texttt{species=} & \texttt{\{name,\ldots\}} & --- &
+  declare species names for atoms and typed lines \\
 \texttt{frame=} & \texttt{flat|vertical} & \texttt{flat} &
   rotates the whole grammar $90^\circ$: columns descend, legs point
   west/east, \tncmd{tndots} draws \texttt{\textbackslash vdots} \\
@@ -277,6 +281,7 @@ with a capsule in the ket row expects no partner beneath it.}  With
 \to\mathbb{C}^{D_1 D_2}$: it consumes its side's boundary and leaves
 \emph{one} combined stub.\whynote{No key may change a picture's
 open-index count; the wedge does.}
+The compatibility key \tnkey{rows=} is an alias of \tnkey{span=}.
 The combined stub counts as one open virtual index, so fused
 equations balance.
 
@@ -393,6 +398,23 @@ records the resolved skin.  Example~\ref{ex:modes-schools} shows one
 window under both policies; \S\ref{ch:house} states which school a
 document should pick, and why.
 
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{pitch=} & \meta{length} & \texttt{11mm} &
+  the metric unit from which all house lengths derive \\
+\texttt{compact}, \texttt{inline} & --- & --- &
+  $0.8$ and $0.62$ pitch profiles \\
+\texttt{tensor style=} & \texttt{dot|box} & \texttt{dot} &
+  the unadorned tensor glyph \\
+\texttt{species=} & \texttt{\{name,\ldots\}} & --- &
+  declare names and assign their semantic-cycle hues \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
+
 % =====================================================================
 \subsection{Maps, trees, and arrows: \tnenv{tenkzcd}}
 
@@ -429,8 +451,16 @@ arrow syntax of such matrices.
   slots on an $n$-gon; unset = matrix mode \\
 \texttt{radius=} & \meta{length} & \texttt{30mm} &
   circumradius of the polygon \\
-\multicolumn{4}{@{}l}{\emph{other keys pass through to the
-  picture} (\texttt{pitch=}, \texttt{tensor style=}, \ldots)} \\
+\texttt{pitch=} & \meta{length} & \texttt{11mm} &
+  the shared metric unit \\
+\texttt{compact}, \texttt{inline} & --- & --- &
+  the shared $0.8$ and $0.62$ pitch profiles \\
+\texttt{tensor style=} & \texttt{dot|box} & \texttt{dot} &
+  the shared glyph policy for embedded tensor pictures \\
+\texttt{species=} & \texttt{\{name,\ldots\}} & --- &
+  declare species names for trees and typed lines \\
+\multicolumn{4}{@{}l}{\emph{Other keys pass through to the underlying
+  commutative-diagram picture.}} \\
 \bottomrule
 \end{tabularx}\par}
 \medskip
@@ -457,6 +487,25 @@ floating or numbered figure is part of the grammar.
 \hspace*{2em}role=\meta{role}, species=\meta{name}]%
 \{\meta{bracketed word}\}\\
 \textbackslash tnarrow*[from=\meta{i}, to=\meta{j}]\{\meta{label}\}}
+
+\medskip
+{\footnotesize
+\noindent\begin{tabularx}{\linewidth}{@{}p{29mm}p{23mm}p{11mm}>{\raggedright\arraybackslash}X@{}}
+\toprule
+\keyhead
+\texttt{tree style=} & \texttt{wire|ribbon} & \texttt{wire} &
+  lines or their regular ribbon neighbourhood \\
+\texttt{role=} & \meta{role} & --- &
+  \texttt{operator}, \texttt{marked}, \texttt{extra}, or \texttt{passive} \\
+\texttt{species=} & \meta{name} & --- &
+  a species declared in the shared key space \\
+\texttt{pitch=} & \meta{length} & \texttt{11mm} &
+  the shared metric unit \\
+\texttt{compact}, \texttt{inline} & --- & --- &
+  the shared $0.8$ and $0.62$ pitch profiles \\
+\bottomrule
+\end{tabularx}\par}
+\medskip
 
 \noindent \tncmd{tntree} draws the fusion tree of a bracketed word,
 innermost pairs first: in
@@ -581,7 +630,8 @@ and \tnkey{label=}.  \tncmd{tnsite} removes a site and its bonds only with
   the region's fill-and-outline role \\
 \texttt{outline} & --- & --- &
   boundary only, no fill \\
-\texttt{label=}, \texttt{label at=} & \meta{math}, compass & --- &
+\texttt{label=}, \texttt{label pos=}, \texttt{label at=} &
+  \meta{math}, compass & --- &
   region label and its corner \\
 \texttt{name=} & \meta{id} & --- &
   bind the set for later set algebra \\
@@ -782,7 +832,8 @@ for example \tnval{group region/.append style=\{rounded corners=0pt\}}.
 \texttt{slot=} & \texttt{selected|secondary|} \texttt{complement|collar} &
   \texttt{selected} & semantic region skin \\
 \texttt{outline} & --- & --- & suppress the slot fill \\
-\texttt{label=}, \texttt{label pos=} & \meta{math}, \meta{compass} &
+\texttt{label=}, \texttt{label pos=}, \texttt{label at=} &
+  \meta{math}, \meta{compass} &
   ---, \texttt{north west} & outside label and its placement \\
 \texttt{name=} & \meta{name} & --- &
   expose this measured region to a later region \\

--- a/docs/tenkz/manual2.tex
+++ b/docs/tenkz/manual2.tex
@@ -289,7 +289,7 @@ whole language.
   \qritem{polygon=5, radius=}{slots on a polygon}
 
   \qrsection{Free placement (tenkzfree)}
-  \qritem{\textbackslash tnput[shape, ports=]\{n\}\{(x,y)\}\{A\}}{typed node}
+  \qritem{\textbackslash tnput[\meta{glyph}, ports=]\{n\}\{(x,y)\}\{A\}}{typed node}
   \qritem{\textbackslash tnjoin[name=, route=, \ldots]\{a.E\}\{b.W\}}{%
     named measured wire; routes straight|hv|vh|arc (curve is the 0.5 alias)}
   \qritem{\textbackslash tnregion[group|slot=, outline, label=,

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -57,10 +57,10 @@
                                % braces.  It separates, never clears: WHAT must
                                % be cleared is the silhouette's business, and
                                % is measured, not budgeted.  0.15 pitch is
-                               % ~1.7mm at the default 11mm pitch (~3x the
-                               % wire width, so wire-weight ink never fuses
-                               % with the return at print size) and still
-                               % ~1mm at the inline pitch
+                               % ~1.7mm at the default 11mm pitch (~8.5x the
+                               % 0.55pt wire width, so wire-weight ink never
+                               % fuses with the return at print size) and
+                               % still ~1mm (~5.3 wire widths) inline
 \def\tenkz@r@labelclear{0.12}  % ONE clearance for every label band
 \def\tenkz@r@dotlabelband{0.30}% ONE label band for every external label:
                                % clearance + one line of script-size text.
@@ -111,7 +111,8 @@
 \def\tenkz@wirewidth{0.55pt}
 \def\tenkz@annwidth{0.40pt}
 \def\tenkz@emphwidth{0.80pt}
-\def\tenkz@junctionfloor{0.9mm}% below ~3x wire width a junction reads as dirt
+\def\tenkz@junctionfloor{0.9mm}% ~4.7x the 0.55pt wire width: below this
+                               % absolute floor a junction reads as dirt
 \def\tenkz@barblen{2.6pt}      % directionality barb; a print-size floor, not
                                % a ratio: below this the barb reads as dirt
 \def\tenkz@fusedbarblen{3.8pt} % barb spanning a doubled (fused) wire


### PR DESCRIPTION
## Summary

- record the final 0.7 simplification gate over the complete native package and manual
- reconcile the 143-key public surface and reference tables with the implemented grammar
- replace stale fixed-clearance and automatic-equation-routing claims with the measured-silhouette and explicit `tenkzequation` contracts
- document why region parser twins, local slide bodies, and 0.6 compatibility aliases remain, including their owners and deletion triggers

## Gate result

1. **What grew ad hoc?** Documentation drift: the geometry appendix described a fixed trace clearance and an incomplete ratio inventory; the web specification promised automatic whole-equation rerouting; and the reference omitted or misstated implemented keys. This PR repairs those claims without adding package behavior.
2. **Which two things are secretly one thing?** Lattice and free regions share a grammar but retain distinct parser state and geometry consumers; LionSR/tenkz#62 owns possible unification. Six implementation twins remain in LionSR/tenkz#64. Similar slide bodies stay local so each body remains customizable and the catalogue is not recreated.
3. **What would be deleted in a redesign?** Eight 0.6 compatibility spellings are retained until the 0.9 manual-contract freeze. `docs/tenkz/DESIGN.md` records exact use counts, canonical replacements, and the zero-use deletion trigger.

## Validation

- `git diff --check`
- static gate sweeps: 143 leaf keys across 14 families; 38 motivated ratios; no unresolved `TODO`, `FIXME`, or `XXX`; manual reference reconciled
- 11 focused non-web tests, 21 acceptance examples, and native lint over 136 sources with 0 findings
- definitive manual: 48 pages, 79 audited pictures, 0 hard errors, and 9 expected repeated-topology advisories; all changed pages passed visual review
- full corpus: 257 PDFs / 259 pages compiled, audited, and rendered at 200 dpi; `SHA256SUMS` is byte-identical to the `aa5` baseline
- full `lake build`, blueprint declaration check, PDF and web builds, responsive-equation Playwright checks, and representative web screenshots
- demolition checker and its regression test

Addresses LionSR/tenkz#20
Addresses LionSR/TNLean#4158
Addresses LionSR/tenkz#12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits are limited to docs and comments; plasTeX/TeX behavior is unchanged, so risk is confined to documentation accuracy.
> 
> **Overview**
> Records the **0.7 simplification gate** in `DESIGN.md` §17.2: documentation drift fixes, measured public surface (**143** leaf keys, **38** ratios, five environments), and a compatibility-alias census with canonical replacements and zero-use deletion triggers before the 0.9 manual freeze.
> 
> **G20 (web):** Spec and `tenkz_pic.py` now describe the shipped contract—explicit **`tenkzequation`** rows with per-picture SVGs and selectable operator text—instead of a planned whole-equation SVG reroute; `\tnpic` in `$...$`/`\[...\]` stays unsupported on the blueprint site.
> 
> **Geometry narrative:** Fixed **trace clearance** is replaced everywhere by **measured silhouette + `daylight` (0.15·pitch)**; the house-style geometry appendix and `DESIGN.md` metric tables are expanded to transcribe the full ratio set and updated wire-width/junction commentary in `tenkz-core.code.tex`.
> 
> **Manual/reference:** `ch-reference.tex` and related chapters gain missing keys (`boundary=periodic`, `open=`, `combined=`, `species=`, `tenkzplanes` `sheets=`, etc.); `REVIEW.md` and `CHANGES-0.6.md` align with the measured API and racetrack rule. No package rendering behavior changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aba4c825f95006f2e06c97670ede67a3ee43e89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->