### PR TITLE
feat(MPS/MPDO): derive BNT fusion clause from RFP

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -25,6 +25,7 @@ import TNLean.MPS.MPDO.BNTFourfoldFusionIndices
 import TNLean.MPS.MPDO.BNTFusionCoisometries
 import TNLean.MPS.MPDO.BNTFusionIsometries
 import TNLean.MPS.MPDO.BNTFusionTensorClause
+import TNLean.MPS.MPDO.BNTFusionTensorClauseFromRFP
 import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTMarkovKeyFormula
 import TNLean.MPS.MPDO.BNTMarkovSectorProjectors

--- a/TNLean/MPS/MPDO/BNTFusionCoisometries.lean
+++ b/TNLean/MPS/MPDO/BNTFusionCoisometries.lean
@@ -183,6 +183,61 @@ theorem mpo_mul_mpo_eq_sum (L : ℕ) (hL : 0 < L) (α β : Λ) :
   simp only [Matrix.sum_apply, Matrix.smul_apply, mpo_apply, mpoMatrixEntry,
     evalWord_ofFn, smul_eq_mul]
 
+/-- The concrete MPO operator family of the labelled tensors in an active
+fusion decomposition.
+
+Source: arXiv:1606.00608, lines 962--966 and Appendix C.4,
+lines 2020--2029. -/
+noncomputable def toOperatorFamily :
+    BNTLabelOperatorFamily Λ
+      (fun L => Matrix (Fin L → Fin p) (Fin L → Fin p) ℂ) :=
+  ⟨fun L γ => mpo (Fam.tensor γ) L⟩
+
+@[simp]
+theorem toOperatorFamily_operator (L : ℕ) (γ : Λ) :
+    Fam.toOperatorFamily.operator L γ = mpo (Fam.tensor γ) L :=
+  rfl
+
+/-- An active fusion coisometry satisfies the same-length product law with
+the trace powers of its positive diagonal matrices.
+
+Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 976--993, and
+Appendix C.4, lines 2020--2029. -/
+theorem toOperatorFamily_hasSameLengthProductForm :
+    Fam.toOperatorFamily.HasSameLengthProductForm
+      (BNTLabelCoefficientFamily.ofChi Fam.chi) := by
+  intro L hL α β
+  simpa [BNTLabelCoefficientFamily.ofChi_coeff] using
+    Fam.mpo_mul_mpo_eq_sum L hL α β
+
+/-- The positive diagonal matrices of an active fusion decomposition give the
+positive trace-power witness for its coefficient family.
+
+Source: arXiv:1606.00608, Theorem 4.14(ii), lines 976--985. -/
+noncomputable def toPositiveChiWitness :
+    PositiveBNTLabelChiTracePowerForm
+      (BNTLabelCoefficientFamily.ofChi Fam.chi) :=
+  PositiveBNTLabelChiTracePowerForm.ofChi Fam.chi Fam.posEntries
+
+/-- An active fusion coisometry together with the length-one idempotent law
+gives the BNT algebra clause for its concrete closed-chain operators.
+
+This is the retained-support form of implication (iii) to (ii) in
+arXiv:1606.00608, Theorem 4.14. Exact reconstruction ensures that no nonzero
+part of a product tensor is discarded.
+
+Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 972--993, and
+Appendix C.4, lines 1929--1947 and 2020--2042. -/
+noncomputable def toBNTAlgebraClause
+    (m : BNTLabelTraceScalarFamily Λ)
+    (hIdempotent :
+      m.HasIdempotentCoefficientForm (BNTLabelCoefficientFamily.ofChi Fam.chi)) :
+    BNTAlgebraClause (BNTLabelCoefficientFamily.ofChi Fam.chi)
+      Fam.toOperatorFamily m where
+  positiveChi := Fam.toPositiveChiWitness
+  sameLengthProduct := Fam.toOperatorFamily_hasSameLengthProductForm
+  idempotent := hIdempotent
+
 /-- Under the additional assertion that every active-support projection is the
 identity, an active fusion coisometry gives the stronger full-support fusion
 family. -/

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -4,12 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
-import TNLean.MPS.MPDO.BNTFusionIsometries
+import TNLean.MPS.MPDO.BNTFusionCoisometries
 
 /-!
-# Fusion isometries attached to an MPO tensor
+# Fusion coisometries attached to an MPO tensor
 
-This file attaches the fusion-isometry clause of arXiv:1606.00608,
+This file attaches the active-support fusion clause of arXiv:1606.00608,
 Theorem 4.14(iii), to the basis of normal tensors in a chosen vertical
 canonical decomposition of the original MPO tensor. The positive diagonal
 matrices in the fusion identity determine the coefficients in the algebra
@@ -24,8 +24,9 @@ in the same vertical decomposition.
 * `HasBNTFusionTensorClause.to_hasBNTAlgebraTensorClause` gives the
   corresponding existential implication.
 
-This is one implication of Theorem 4.14. No assertion involving the
-renormalization fixed-point condition is made here.
+This file proves the implication from statement (iii) to statement (ii) of
+Theorem 4.14. The converse construction from the renormalization fixed-point
+condition is proved in `BNTFusionTensorClauseFromRFP`.
 
 ## References
 
@@ -39,7 +40,7 @@ noncomputable section
 
 namespace MPOTensor
 
-/-- The fusion-isometry clause of Theorem 4.14(iii), attached to a chosen
+/-- The active-support fusion clause of Theorem 4.14(iii), attached to a chosen
 vertical canonical decomposition of the MPO tensor \(M\).
 
 The tensors in the fusion identity are precisely the basis of normal tensors
@@ -56,10 +57,10 @@ Source: arXiv:1606.00608, Proposition 4.13, lines 943--951;
 Theorem 4.14(iii), lines 986--993; and Appendix C.4, lines 1929--1947 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
 
-**Scope restriction (full-support fusion family):** The fusion map below
-satisfies $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=1$. The unrestricted
-source statement allows a zero product corner and instead gives a coisometry
-onto the active direct sum together with exact reconstruction. Documented in
+**Local fix (Figure-11 fusion coisometry):** In the retained-row orientation,
+the fusion map below satisfies $U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$.
+Its adjoint reconstructs the complete product tensor, including when a common
+zero corner is omitted from the retained direct sum. Documented in
 `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
 structure BNTFusionTensorClause (M : MPOTensor d D) where
   /-- Number of BNT labels in the chosen vertical decomposition. -/
@@ -116,31 +117,39 @@ structure BNTFusionTensorClause (M : MPOTensor d D) where
 
   Source: arXiv:1606.00608, Theorem 4.14(ii)--(iii), lines 976--993. -/
   chi_pos : chi.PosEntries
-  /-- The fusion isometry \(U_{\alpha,\beta}\) for each pair of BNT labels.
+  /-- The fusion coisometry \(U_{\alpha,\beta}\) onto the retained sectors for
+  each pair of BNT labels.
 
   Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993. -/
-  fusionIsometry : ∀ α β : Fin labelCount,
+  fusionCoisometry : ∀ α β : Fin labelCount,
     Matrix ((γ : Fin labelCount) × (Fin (chi.dim α β γ) × Fin (bondDim γ)))
       (Fin (bondDim α * bondDim β)) ℂ
-  /-- The additional full-support column-isometry condition on each fusion
-  map.
+  /-- Each fusion map is a coisometry onto the retained direct sum.
 
-  **Scope restriction (full-support fusion family):** The unrestricted source
-  statement permits a discarded common zero corner and does not assert this
-  identity. Documented in
-  `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
-  isometry : ∀ α β : Fin labelCount,
-    (fusionIsometry α β)ᴴ * fusionIsometry α β = 1
+  Source: arXiv:1606.00608, Appendix C.4, lines 2020--2029. -/
+  fusionCoisometry_mul_conjTranspose : ∀ α β : Fin labelCount,
+    fusionCoisometry α β * (fusionCoisometry α β)ᴴ = 1
   /-- The sitewise fusion identity for the concrete vertical BNT tensors.
 
   Source: arXiv:1606.00608, Theorem 4.14(iii), label `Ualphabeta`,
   lines 986--993. -/
   fusion : ∀ (α β : Fin labelCount) (i j : Fin D),
-    fusionIsometry α β *
+    fusionCoisometry α β *
         (mulTensor (verticalBNTMPO (tensor α)) (verticalBNTMPO (tensor β))) i j *
-          (fusionIsometry α β)ᴴ =
+          (fusionCoisometry α β)ᴴ =
       Matrix.blockDiagonal' fun γ =>
         chi.matrix α β γ ⊗ₖ (verticalBNTMPO (tensor γ)) i j
+  /-- The retained direct sum reconstructs every product letter.
+
+  Source: arXiv:1606.00608, Theorem 4.14(iii), label `Ualphabeta`,
+  lines 986--993, and Appendix C.4, lines 2020--2029. -/
+  fusionReconstruction : ∀ (α β : Fin labelCount) (i j : Fin D),
+    (mulTensor (verticalBNTMPO (tensor α))
+        (verticalBNTMPO (tensor β))) i j =
+      (fusionCoisometry α β)ᴴ *
+        (Matrix.blockDiagonal' fun γ =>
+          chi.matrix α β γ ⊗ₖ (verticalBNTMPO (tensor γ)) i j) *
+        fusionCoisometry α β
   /-- The length-one idempotent identity for
   \(m_\alpha=\operatorname{tr}(\mu_\alpha)\).
 
@@ -154,16 +163,17 @@ namespace BNTFusionTensorClause
 
 variable {M : MPOTensor d D}
 
-/-- The fusion-isometry family carried by a tensor-attached fusion clause. -/
-def toBNTFusionIsometryFamily (H : BNTFusionTensorClause M) :
-    BNTFusionIsometryFamily (Fin H.labelCount) D where
+/-- The fusion-coisometry family carried by a tensor-attached fusion clause. -/
+def toBNTFusionCoisometryFamily (H : BNTFusionTensorClause M) :
+    BNTFusionCoisometryFamily (Fin H.labelCount) D where
   bondDim := H.bondDim
   tensor := fun γ => verticalBNTMPO (H.tensor γ)
   chi := H.chi
   posEntries := H.chi_pos
-  fusionIsometry := H.fusionIsometry
-  isometry := H.isometry
+  fusionCoisometry := H.fusionCoisometry
+  coisometry := H.fusionCoisometry_mul_conjTranspose
   fusion := H.fusion
+  reconstruction := H.fusionReconstruction
 
 /-- **Tensor-attached implication (iii) to (ii) of Theorem 4.14.**
 
@@ -194,7 +204,7 @@ noncomputable def toBNTAlgebraTensorClause (H : BNTFusionTensorClause M) :
   forward := H.forward
   reconstruction := H.reconstruction
   coeffs := BNTLabelCoefficientFamily.ofChi H.chi
-  algebraClause := H.toBNTFusionIsometryFamily.toBNTAlgebraClause
+  algebraClause := H.toBNTFusionCoisometryFamily.toBNTAlgebraClause
     (verticalBNTTraceScalarFamily H.weight) H.idempotent
 
 /-- The chosen decomposition in a tensor-attached fusion clause is a vertical
@@ -205,7 +215,7 @@ theorem isVerticalCF (H : BNTFusionTensorClause M) : IsVerticalCF M :=
 
 end BNTFusionTensorClause
 
-/-- Existence of the fusion-isometry clause for a chosen vertical canonical
+/-- Existence of the fusion-coisometry clause for a chosen vertical canonical
 decomposition of \(M\).
 
 Source: arXiv:1606.00608, Theorem 4.14(iii), lines 986--993, and
@@ -215,7 +225,7 @@ def HasBNTFusionTensorClause (M : MPOTensor d D) : Prop :=
 
 namespace HasBNTFusionTensorClause
 
-/-- The tensor-attached fusion-isometry clause implies the tensor-attached
+/-- The tensor-attached fusion-coisometry clause implies the tensor-attached
 algebra clause, using the same vertical decomposition and the same positive
 diagonal chi matrices.
 

--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTFusionTensorClause
+import TNLean.MPS.MPDO.BNTMultiplicityNormalization
+import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
+import TNLean.MPS.MPDO.VerticalBlockedOperatorRepresentations
+
+/-!
+# The BNT fusion clause from the renormalization fixed-point condition
+
+This file proves the implication from the physical renormalization
+fixed-point condition to the positive BNT fusion clause. The length-one
+trace-scalar identity is obtained by comparing the two closed-chain
+representations of the blocked vertical tensor and then applying the positive
+power-sum theorem.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14(i)--(iii), lines 972--993, and Appendix C.4,
+  lines 1951--2042
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The closed-chain operators of a CPSV16 basis of normal tensors are
+linearly independent at every sufficiently large length.
+
+This is the operator form of the eventual linear independence used to compare
+the coefficients in CPSV16, Appendix C.4, lines 2038--2042. -/
+private theorem eventually_linearIndependent_verticalBNTOperators
+    {g D : ℕ} {dim : Fin g → ℕ}
+    {T : MPSTensor (D * D) d}
+    (A : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors T
+      (fun α ↦ ⟨dim α, A α⟩)) :
+    ∃ L₀ : ℕ, ∀ L > L₀,
+      LinearIndependent ℂ (fun α ↦ mpo (verticalBNTMPO (A α)) L) := by
+  classical
+  obtain ⟨L₀, hLI⟩ := hBNT.eventually_li
+  refine ⟨L₀, fun L hL ↦ ?_⟩
+  rw [Fintype.linearIndependent_iff]
+  intro c hc α
+  apply Fintype.linearIndependent_iff.mp (hLI L hL) c
+  apply PiLp.ext
+  intro η
+  let σ : Fin L → Fin D := fun n ↦ (finProdFinEquiv.symm (η n)).1
+  let τ : Fin L → Fin D := fun n ↦ (finProdFinEquiv.symm (η n)).2
+  have hη : (fun n ↦ finProdFinEquiv (σ n, τ n)) = η := by
+    funext n
+    exact finProdFinEquiv.apply_symm_apply (η n)
+  have hEntry := congrFun (congrFun hc σ) τ
+  simp only [Matrix.sum_apply, Matrix.smul_apply, Matrix.zero_apply,
+    smul_eq_mul] at hEntry
+  simp only [WithLp.ofLp_sum, WithLp.ofLp_smul, Finset.sum_apply,
+    Pi.smul_apply, smul_eq_mul, MPSTensor.mpvState_apply, PiLp.zero_apply]
+  rw [← hη]
+  simpa only [← MPSTensor.mpv_toMPSTensor_pairConfig,
+    verticalBNTMPO_toMPSTensor] using hEntry
+
+namespace HasBNTFusionTensorClause
+
+/-- **Implication (i) to (iii) of CPSV16, Theorem 4.14.**
+
+A horizontally canonical matrix product density operator satisfying the
+physical renormalization fixed-point condition has a positive fusion
+coisometry for its vertical basis of normal tensors. The same diagonal
+matrices satisfy the length-one idempotent trace-scalar identity.
+
+The idempotent identity is derived from the two representations of the
+blocked closed-chain operator, eventual linear independence of the BNT
+operators, and the positive power-sum theorem.
+
+**Local fix (Figure-11 fusion coisometry):** The fusion map is written in the
+retained-row orientation, so it satisfies $UU^\dagger=1$ and its adjoint gives
+exact reconstruction. Documented in
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`.
+
+Source: arXiv:1606.00608, Theorem 4.14(i)--(iii), lines 972--993, and
+Appendix C.4, lines 1951--2042. -/
+theorem of_isRFP (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M)
+    (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
+    HasBNTFusionTensorClause M := by
+  classical
+  obtain ⟨D₁⟩ := hHorizontal.exists_cpsvVerticalDecomposition M hM
+  obtain ⟨D₂⟩ := hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
+    (blockTwo M) hM.blockTwo
+  obtain ⟨Smap, T, hSCPTP, hTCPTP, hSphys, hTphys⟩ := hRFP
+  obtain ⟨sigma, hDim, V, _hContract, hLetter⟩ :=
+    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
+      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
+      hTphys hSphys
+  obtain ⟨chi, U, hChi, hU, hFusion, hFusionReconstruction⟩ :=
+    transportedVerticalSector_exists_positiveFusionDecomposition
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
+      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
+      hTphys hSphys hHorizontal hM
+  let Fam : BNTFusionCoisometryFamily (Fin D₁.labelCount) D := {
+    bondDim := D₁.bondDim
+    tensor := fun γ ↦ verticalBNTMPO (D₁.tensor γ)
+    chi := chi
+    posEntries := hChi
+    fusionCoisometry := U
+    coisometry := hU
+    fusion := hFusion
+    reconstruction := hFusionReconstruction
+  }
+  have hIdempotent :
+      (verticalBNTTraceScalarFamily D₁.weight).HasIdempotentCoefficientForm
+        (BNTLabelCoefficientFamily.ofChi chi) := by
+    let m := verticalBNTTraceScalarFamily D₁.weight
+    let ratio : Fin D₁.labelCount → ℂ := fun γ ↦
+      verticalMultiplicityTrace D₁.weight γ /
+        verticalMultiplicityTrace D₂.weight (sigma γ)
+    let twoEntry : ∀ γ : Fin D₁.labelCount,
+        Fin (D₂.multiplicity (sigma γ)) → ℂ :=
+      fun γ q ↦ ratio γ * D₂.weight (sigma γ) q
+    have hRatioPos : ∀ γ, (0 : ℂ) < ratio γ := by
+      intro γ
+      exact div_pos
+        (verticalMultiplicityTrace_pos D₁.multiplicity_pos D₁.weight_pos γ)
+        (verticalMultiplicityTrace_pos D₂.multiplicity_pos D₂.weight_pos
+          (sigma γ))
+    have hTwoPos : ∀ γ q, (0 : ℂ) < twoEntry γ q := by
+      intro γ q
+      exact mul_pos (hRatioPos γ) (D₂.weight_pos (sigma γ) q)
+    obtain ⟨L₀, hLinearIndependent⟩ :=
+      eventually_linearIndependent_verticalBNTOperators D₁.tensor
+        D₁.isCPSVBNT
+    have hPowerSums : ∀ γ : Fin D₁.labelCount, ∀ L : ℕ, L₀ < L →
+        (∑ r, twoEntry γ r ^ L) =
+          ∑ x : BNTProductMultiplicityIndex chi D₁.multiplicity γ,
+            (D₁.weight x.1 x.2.2.1 * D₁.weight x.2.1 x.2.2.2.1 *
+              chi.entry x.1 x.2.1 γ x.2.2.2.2) ^ L := by
+      intro γ L hLarge
+      have hL : 0 < L := lt_of_le_of_lt (Nat.zero_le L₀) hLarge
+      obtain ⟨hFirst, hSecond⟩ :=
+        blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv
+          D₁.bondDim D₁.multiplicity D₁.weight
+          D₂.bondDim D₂.multiplicity D₂.weight
+          M D₁.tensor D₂.tensor D₁.verticalCoisometry
+          D₂.verticalCoisometry D₁.coisometry D₂.coisometry
+          D₁.reconstruction D₂.reconstruction sigma hDim V hLetter hL
+      have hCommon :
+          (∑ δ,
+              ((ratio δ ^ L) * (∑ q, D₂.weight (sigma δ) q ^ L)) •
+                mpo (verticalBNTMPO (D₁.tensor δ)) L) =
+            ∑ δ,
+              (∑ α, ∑ β,
+                ((∑ q, D₁.weight α q ^ L) *
+                    (∑ r, D₁.weight β r ^ L)) *
+                  chi.tracePowerCoeff α β δ L) •
+                mpo (verticalBNTMPO (D₁.tensor δ)) L := by
+        calc
+          _ = mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L := by
+            simpa only [ratio] using hFirst.symm
+          _ = ∑ α, ∑ β,
+              ((∑ q, D₁.weight α q ^ L) *
+                (∑ r, D₁.weight β r ^ L)) •
+                (mpo (verticalBNTMPO (D₁.tensor α)) L *
+                  mpo (verticalBNTMPO (D₁.tensor β)) L) := hSecond
+          _ = ∑ δ,
+              (∑ α, ∑ β,
+                ((∑ q, D₁.weight α q ^ L) *
+                    (∑ r, D₁.weight β r ^ L)) *
+                  chi.tracePowerCoeff α β δ L) •
+                mpo (verticalBNTMPO (D₁.tensor δ)) L := by
+            change (∑ α, ∑ β,
+              ((∑ q, D₁.weight α q ^ L) *
+                (∑ r, D₁.weight β r ^ L)) •
+                (mpo (Fam.tensor α) L * mpo (Fam.tensor β) L)) = _
+            simp_rw [Fam.mpo_mul_mpo_eq_sum L hL]
+            simp only [Fam]
+            simp only [Finset.smul_sum, Finset.sum_smul, smul_smul]
+            calc
+              _ = ∑ α, ∑ δ, ∑ β,
+                  (((∑ q, D₁.weight α q ^ L) *
+                      (∑ r, D₁.weight β r ^ L)) *
+                    chi.tracePowerCoeff α β δ L) •
+                    mpo (verticalBNTMPO (D₁.tensor δ)) L := by
+                apply Finset.sum_congr rfl
+                intro α _
+                rw [Finset.sum_comm]
+              _ = _ := by rw [Finset.sum_comm]
+      have hCoeff :
+          ratio γ ^ L * (∑ q, D₂.weight (sigma γ) q ^ L) =
+            ∑ α, ∑ β,
+              ((∑ q, D₁.weight α q ^ L) *
+                  (∑ r, D₁.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L :=
+        congrFun
+          (linearIndependent_iff_injective_fintypeLinearCombination.mp
+            (hLinearIndependent L hLarge) hCommon) γ
+      calc
+        (∑ r, twoEntry γ r ^ L) =
+            ratio γ ^ L * (∑ r, D₂.weight (sigma γ) r ^ L) := by
+          simp only [twoEntry, mul_pow, Finset.mul_sum]
+        _ = ∑ α, ∑ β,
+              ((∑ q, D₁.weight α q ^ L) *
+                  (∑ r, D₁.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L := hCoeff
+        _ = ∑ x : BNTProductMultiplicityIndex chi D₁.multiplicity γ,
+              (D₁.weight x.1 x.2.2.1 * D₁.weight x.2.1 x.2.2.2.1 *
+                chi.entry x.1 x.2.1 γ x.2.2.2.2) ^ L := by
+          simp only [BNTProductMultiplicityIndex, Fintype.sum_sigma,
+            Fintype.sum_prod_type, mul_pow,
+            DiagonalChiFamily.tracePowerCoeff]
+          apply Finset.sum_congr rfl
+          intro α _
+          apply Finset.sum_congr rfl
+          intro β _
+          symm
+          calc
+            (∑ i, ∑ j, ∑ k,
+                (D₁.weight α i ^ L * D₁.weight β j ^ L) *
+                  chi.entry α β γ k ^ L) =
+                ∑ i, ∑ j,
+                  (D₁.weight α i ^ L * D₁.weight β j ^ L) *
+                    ∑ k, chi.entry α β γ k ^ L := by
+              simp only [Finset.mul_sum, mul_assoc]
+            _ = (∑ i, D₁.weight α i ^ L) *
+                  ((∑ j, D₁.weight β j ^ L) *
+                    ∑ k, chi.entry α β γ k ^ L) := by
+              rw [Fintype.sum_mul_sum, Fintype.sum_mul_sum]
+              simp only [Finset.mul_sum, mul_assoc]
+            _ = ((∑ i, D₁.weight α i ^ L) *
+                    (∑ j, D₁.weight β j ^ L)) *
+                  ∑ k, chi.entry α β γ k ^ L := by
+              ring
+    let C : BNTMultiplicitySpectrumComparison chi m :=
+      BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums
+        chi m hChi D₁.multiplicity D₁.weight D₁.weight_pos
+        (fun α ↦ rfl) (fun γ ↦ D₂.multiplicity (sigma γ)) twoEntry
+        hTwoPos hPowerSums
+    have hTwoTrace : ∀ γ, ∑ r, twoEntry γ r = m.traceScalar γ := by
+      intro γ
+      change (∑ r, ratio γ * D₂.weight (sigma γ) r) =
+        verticalMultiplicityTrace D₁.weight γ
+      rw [← Finset.mul_sum]
+      change ratio γ * verticalMultiplicityTrace D₂.weight (sigma γ) = _
+      simp only [ratio]
+      exact div_mul_cancel₀ _
+        (verticalMultiplicityTrace_ne_zero (sigma γ)
+          (D₂.multiplicity_pos (sigma γ)) (D₂.weight_pos (sigma γ)))
+    intro γ
+    calc
+      m.traceScalar γ = ∑ r, C.twoEntry γ r := by
+        change m.traceScalar γ = ∑ r, twoEntry γ r
+        exact (hTwoTrace γ).symm
+      _ = ∑ x : BNTProductMultiplicityIndex chi C.oneDim γ,
+          C.oneEntry x.1 x.2.2.1 * C.oneEntry x.2.1 x.2.2.2.1 *
+            chi.entry x.1 x.2.1 γ x.2.2.2.2 :=
+        C.sum_twoEntry_eq_sum_products γ
+      _ = ∑ α, ∑ β,
+          chi.tracePowerCoeff α β γ 1 *
+            (m.traceScalar α * m.traceScalar β) :=
+        C.sum_products_eq γ
+  exact ⟨{
+    labelCount := D₁.labelCount
+    bondDim := D₁.bondDim
+    multiplicity := D₁.multiplicity
+    weight := D₁.weight
+    tensor := D₁.tensor
+    verticalCoisometry := D₁.verticalCoisometry
+    multiplicity_pos := D₁.multiplicity_pos
+    weight_pos := D₁.weight_pos
+    coisometry := D₁.coisometry
+    isBNT := D₁.isCPSVBNT.isBNT
+    forward := D₁.forward
+    reconstruction := D₁.reconstruction
+    chi := chi
+    chi_pos := hChi
+    fusionCoisometry := U
+    fusionCoisometry_mul_conjTranspose := hU
+    fusion := hFusion
+    fusionReconstruction := hFusionReconstruction
+    idempotent := hIdempotent
+  }⟩
+
+end HasBNTFusionTensorClause
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -782,16 +782,19 @@ weights in the length-independent case at
     coefficients $\operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{L})$.
 \end{proof}
 
-\begin{definition}[BNT algebra clause derived from fusion isometries]%
+\begin{definition}[BNT algebra clause derived from fusion maps]%
     \label{def:mpdo_bnt_fusion_algebra_clause}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.toBNTAlgebraClause}
     \lean{MPOTensor.BNTFusionIsometryFamily.toBNTAlgebraClause}
     \leanok
     \uses{def:mpdo_bnt_algebra_clause,
+        def:mpdo_bnt_fusion_coisometry_family,
         def:mpdo_bnt_fusion_isometry_family,
         def:mpdo_bnt_label_idempotent_coefficient_form,
         def:mpdo_positive_bnt_label_chi_trace_power_form,
         thm:mpdo_fusion_same_length_product}
-    Suppose the fusion-isometry identity holds with positive diagonal matrices
+    Suppose an active-support fusion identity holds with positive diagonal
+    matrices
     $\chi_{\alpha,\beta,\gamma}$, and suppose the trace scalars satisfy the
     length-one idempotent law for the corresponding trace-power coefficients.
     The resulting BNT algebra clause has coefficients, for $L>0$,
@@ -814,27 +817,36 @@ weights in the length-independent case at
     implications involving the renormalization fixed-point condition.
 \end{definition}
 
-\begin{definition}[Fusion isometries for a vertical canonical decomposition]%
+\begin{definition}[Fusion coisometries for a vertical canonical decomposition]%
     \label{def:mpdo_bnt_fusion_tensor_clause}
     \lean{MPOTensor.BNTFusionTensorClause}
     \lean{MPOTensor.HasBNTFusionTensorClause}
     \leanok
     \uses{def:vertical_cf_mpdo,
-        def:mpdo_bnt_fusion_isometry_family,
+        def:mpdo_bnt_fusion_coisometry_family,
         def:mpdo_bnt_label_idempotent_coefficient_form}
     Choose a vertical canonical decomposition
     \[
         U\widetilde M U^\dagger
         =\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
     \]
-    The fusion-isometry clause for this decomposition consists of positive
-    diagonal matrices $\chi_{\alpha,\beta,\gamma}$ and isometries
+    The fusion clause for this decomposition consists of positive diagonal
+    matrices $\chi_{\alpha,\beta,\gamma}$ and coisometries
     $U_{\alpha,\beta}$ satisfying
     \[
         U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
         U_{\alpha,\beta}^\dagger
         =\bigoplus_\gamma
         \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}.
+    \]
+    The maps obey $U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$, and their
+    adjoints reconstruct the product letters exactly:
+    \[
+        (M_\alpha M_\beta)^{ij}
+        =U_{\alpha,\beta}^\dagger
+          \left(\bigoplus_\gamma
+            \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}\right)
+          U_{\alpha,\beta}.
     \]
     The trace scalars $m_\alpha=\operatorname{tr}(\mu_\alpha)$ satisfy the
     length-one idempotent identity for the coefficients determined by these
@@ -844,7 +856,55 @@ weights in the length-independent case at
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Fusion isometries imply the tensor-attached algebra clause]%
+\begin{theorem}[Renormalization fixed points have a BNT fusion clause]
+    \label{thm:mpdo_rfp_to_bnt_fusion_tensor_clause}
+    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFP}
+    \leanok
+    \uses{def:is_rfp_via_ts,
+        def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_bnt_eventual_power_sums_multiplicity_comparison,
+        thm:mpdo_transported_vertical_product_positive_fusion_decomposition}
+    Let $M$ be a horizontally canonical matrix product density operator that
+    is a renormalization fixed point.  Then a vertical canonical decomposition
+    of $M$ admits positive diagonal matrices
+    $\chi_{\alpha,\beta,\gamma}$ and active-support fusion coisometries
+    satisfying the preceding fusion clause.  In particular, the trace scalars
+    $m_\alpha=\operatorname{tr}(\mu_\alpha)$ obey
+    \[
+        m_\gamma=\sum_{\alpha,\beta}
+        \operatorname{tr}(\chi_{\alpha,\beta,\gamma})
+        m_\alpha m_\beta.
+    \]
+    This is implication (i)$\Rightarrow$(iii) of
+    \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}, proved in
+    \cite[Appendix~C.4, lines~1951--2042]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row maps
+    are coisometries onto the active sectors, and exact reconstruction records
+    the common zero corner omitted from the retained direct sum.  See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    Choose vertical canonical decompositions of the one-site and two-site
+    tensors.  The two physical channels identify their normal sectors and
+    yield the positive active-support fusion decomposition.  At every
+    sufficiently large chain length, the two decompositions of the blocked
+    closed-chain operator have linearly independent normal-sector operators.
+    Equality of their coefficients gives, in each sector, equality between
+    the power sums of the two-site multiplicity entries and those of the
+    products
+    \[
+        \mu_{\alpha,i}\mu_{\beta,j}
+        \chi_{\alpha,\beta,\gamma,k}.
+    \]
+    Positivity and the finite power-sum theorem identify the corresponding
+    multisets.  Summing their entries and using the normalization of the
+    transported two-site multiplicity matrices gives the displayed
+    length-one identity.  The positive fusion decomposition and this identity
+    together furnish the claimed clause.
+\end{proof}
+
+\begin{theorem}[Fusion coisometries imply the tensor-attached algebra clause]%
     \label{thm:mpdo_bnt_fusion_tensor_to_algebra_tensor}
     \lean{MPOTensor.BNTFusionTensorClause.toBNTAlgebraTensorClause}
     \lean{MPOTensor.HasBNTFusionTensorClause.to_hasBNTAlgebraTensorClause}
@@ -852,7 +912,7 @@ weights in the length-independent case at
     \uses{def:mpdo_bnt_algebra_tensor_clause,
         def:mpdo_bnt_fusion_algebra_clause,
         def:mpdo_bnt_fusion_tensor_clause}
-    Suppose the fusion-isometry clause holds for a chosen vertical canonical
+    Suppose the fusion-coisometry clause holds for a chosen vertical canonical
     decomposition.  Then the algebra clause holds for the same decomposition,
     with coefficients, for every positive chain length $L$,
     \[

--- a/docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex
+++ b/docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex
@@ -100,15 +100,12 @@ hypothesis not present in Theorem~4.14 or Appendix~C.4.
 
 \section{Formal realignment}
 
-The existing structure
-\leanid{MPOTensor.BNTFusionIsometryFamily} assumes
+The structure \leanid{MPOTensor.BNTFusionIsometryFamily} assumes
 $U_{\alpha,\beta}^\dagger U_{\alpha,\beta}=I$.  It remains mathematically
 valid as a conditional full-support structure, but it is not the unrestricted
-conclusion of the source theorem.  The tensor-attached structure
-\leanid{MPOTensor.BNTFusionTensorClause} inherits the same restriction.
-
-The source-facing construction tracked in \ghissue{4588} therefore uses a
-separate active-support fusion family with the following data:
+conclusion of the source theorem.  The source-facing structures
+\leanid{MPOTensor.BNTFusionCoisometryFamily} and
+\leanid{MPOTensor.BNTFusionTensorClause} instead use the following data:
 \begin{enumerate}
   \item positive diagonal matrices $\chi_{\alpha,\beta,\gamma}$, allowing
     zero-dimensional multiplicity spaces;
@@ -122,9 +119,7 @@ the nonzero reducing corners give isometric inclusions into the product bond
 space, and their adjoints assemble into the required row coisometry.  No
 claim that the active projection is the identity is needed.
 
-A subsequent migration may replace uses of the stronger family by the
-active-support family after auditing which later results genuinely require
-full support.  Conversion to the former structure is permitted only under the
+Conversion to the stronger full-support structure is permitted only under the
 additional identity $U^\dagger U=I$, or an equivalent assertion that the
 product tensor has no discarded zero reducing corner.
 


### PR DESCRIPTION
## Summary

- Prove `MPOTensor.HasBNTFusionTensorClause.of_isRFP` from horizontal canonical form, MPDO positivity, and the physical `IsRFPViaTS` condition.
- Compare the one-site and two-site vertical canonical decompositions, use eventual linear independence of the closed BNT operators, and apply the positive power-sum theorem to derive the length-one idempotent trace identity.
- Extend active-support fusion coisometries to the concrete BNT operator and algebra clauses.
- Synchronize the MPO/RFP blueprint and the Figure 11 paper-gap note.

## Source faithfulness

Theorem 4.14(iii) and Appendix C.4 of arXiv:1606.00608 use the retained-row fusion map. Thus the unrestricted statement has

$$
U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1
$$

on the active direct sum, together with exact reconstruction of the product tensor. The previous tensor-attached structure instead required the stronger full-support identity $U_{\alpha,\beta}^{\dagger}U_{\alpha,\beta}=1$.

This pull request realigns `BNTFusionTensorClause` with the source by recording the active-support coisometry and reconstruction identity. The old field and conversion names are not retained as deprecated aliases because they encode the mathematically stronger full-support condition; `BNTFusionIsometryFamily` remains available for arguments that genuinely assume full support. The deviation and its resolution are documented in `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`.

Source: arXiv:1606.00608, Theorem 4.14, lines 972–993, and Appendix C.4, lines 1951–2042.

## Validation

- `lake build`
- focused Lean checks for all three changed proof modules
- `leanblueprint web`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity scan of the changed Lean files

Closes #4225.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof in core MPDO/BNT theory with API changes to `BNTFusionTensorClause`; correctness risk is mitigated by focused Lean checks and blueprint sync, but the proof chain is intricate.
> 
> **Overview**
> **Derives Theorem 4.14(i)⇒(iii)** for horizontally canonical MPDOs satisfying the physical renormalization fixed-point condition (`HasBNTFusionTensorClause.of_isRFP`). The proof compares one- and two-site vertical canonical decompositions, matches blocked closed-chain operators via eventual linear independence, and uses the positive power-sum theorem to obtain the length-one idempotent trace-scalar identity.
> 
> **Realigns fusion with CPSV16 Figure 11:** `BNTFusionTensorClause` now records **active-support coisometries** (`UU†=1`) and **exact reconstruction** of product letters, instead of the stronger full-support column-isometry (`U†U=1`). `BNTFusionCoisometryFamily` gains `toOperatorFamily`, `toBNTAlgebraClause`, and related lemmas so (iii)⇒(ii) goes through coisometries. The (iii)⇒(ii) path in `BNTFusionTensorClause` routes via `toBNTFusionCoisometryFamily`.
> 
> Blueprint chapter 21 and `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex` are updated to document the coisometry convention and the new RFP theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 033952b98ccd4408a65a5a1b88ba2ac986e7a844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->