### PR TITLE
feat(MPS/MPDO): prove physical one-layer projector

### DIFF
--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -21,11 +21,12 @@ projections, then
     = \bigoplus_\gamma
         \chi_{\alpha,\beta,\gamma}\otimes P_\gamma
 \]
-is a projection.  For the active-support fusion maps of the source,
-$U_{\alpha,\beta}^\dagger Q_{\alpha,\beta}U_{\alpha,\beta}$ is again an
-orthogonal projection because $U_{\alpha,\beta}$ is a coisometry onto the
-retained direct sum.  The earlier full-support formulation follows as a
-special case.
+is a projection.  The source terminal matrices $\operatorname{tr}(M_\gamma)$
+act on the common physical space of the vertically read tensors.  Transport
+through the sequential fusion circuit belongs to the arbitrary-chain
+construction.  The earlier full-support formulation instead gives a
+conditional projection statement for terminal operators on the virtual bond
+spaces.
 
 These are the one-fusion-step projector statements in the recursive
 construction at source lines 999--1010.  The spectral decomposition of the
@@ -55,13 +56,12 @@ operator at line 999 and its sequential fusion circuit are not asserted here.
 Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 noncomputable def projectorQBlock
-    (P : ∀ γ : Λ,
-      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (P : Λ → Matrix (Fin p) (Fin p) ℂ)
     (α β : Λ) :
     Matrix ((γ : Λ) ×
-        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ)))
+        (Fin (Fam.chi.dim α β γ) × Fin p))
       ((γ : Λ) ×
-        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ))) ℂ :=
+        (Fin (Fam.chi.dim α β γ) × Fin p)) ℂ :=
   Matrix.blockDiagonal' fun γ => Fam.chi.matrix α β γ ⊗ₖ P γ
 
 /-- In the length-independent case, the chi matrices in one active fusion
@@ -73,8 +73,7 @@ theorem projectorQBlock_eq_unweighted
     (c : BNTLabelCoefficientFamily Λ)
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
     (hLI : c.LengthIndependent)
-    (P : ∀ γ : Λ,
-      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (P : Λ → Matrix (Fin p) (Fin p) ℂ)
     (α β : Λ) :
     Fam.projectorQBlock P α β =
       Matrix.blockDiagonal' fun γ =>
@@ -94,8 +93,7 @@ theorem projectorQBlock_isStarProjection
     (c : BNTLabelCoefficientFamily Λ)
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
     (hLI : c.LengthIndependent)
-    (P : ∀ γ : Λ,
-      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (P : Λ → Matrix (Fin p) (Fin p) ℂ)
     (hP : ∀ γ : Λ, IsStarProjection (P γ))
     (α β : Λ) :
     IsStarProjection (Fam.projectorQBlock P α β) := by
@@ -113,46 +111,6 @@ theorem projectorQBlock_isStarProjection
     have hPγ : (P γ)ᴴ = P γ := by
       simpa [Matrix.star_eq_conjTranspose] using (hP γ).isSelfAdjoint.star_eq
     rw [hPγ]
-
-/-- The active fusion-layer operator transported to the product bond space by
-the fusion coisometry.
-
-Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-noncomputable def conjugatedProjectorQBlock
-    (P : ∀ γ : Λ,
-      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
-    (α β : Λ) :
-    Matrix (Fin (Fam.bondDim α * Fam.bondDim β))
-      (Fin (Fam.bondDim α * Fam.bondDim β)) ℂ :=
-  (Fam.fusionCoisometry α β)ᴴ * Fam.projectorQBlock P α β *
-    Fam.fusionCoisometry α β
-
-/-- Transporting a length-independent fusion-layer projection through the
-active-support fusion coisometry gives an orthogonal projection on the product
-bond space.
-
-Source: arXiv:1606.00608, the fusion map at lines 986--993 and the recursive
-projector at lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`.
-
-**Local fix (Figure-11 fusion coisometry):** The proof uses
-$U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$, the retained-row orientation of
-the source.  It does not assume that the active-support projection
-$U_{\alpha,\beta}^\dagger U_{\alpha,\beta}$ is the identity.  Documented in
-`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
-theorem conjugatedProjectorQBlock_isOrthogonalProjection
-    (c : BNTLabelCoefficientFamily Λ)
-    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
-    (hLI : c.LengthIndependent)
-    (P : ∀ γ : Λ,
-      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
-    (hP : ∀ γ : Λ, IsStarProjection (P γ))
-    (α β : Λ) :
-    IsOrthogonalProjection (Fam.conjugatedProjectorQBlock P α β) :=
-  (IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
-    (Fam.projectorQBlock_isStarProjection c hχ hLI P hP α β)
-    (Fam.fusionCoisometry α β) (Fam.coisometry α β)).isOrthogonalProjection
 
 end MPOTensor.BNTFusionCoisometryFamily
 
@@ -172,13 +130,12 @@ chain.  Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 noncomputable def projectorQBlock
     (H : BNTFusionTensorClause M)
-    (P : ∀ γ : Fin H.labelCount,
-      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (P : Fin H.labelCount → Matrix (Fin D) (Fin D) ℂ)
     (α β : Fin H.labelCount) :
     Matrix ((γ : Fin H.labelCount) ×
-        (Fin (H.chi.dim α β γ) × Fin (H.bondDim γ)))
+        (Fin (H.chi.dim α β γ) × Fin D))
       ((γ : Fin H.labelCount) ×
-        (Fin (H.chi.dim α β γ) × Fin (H.bondDim γ))) ℂ :=
+        (Fin (H.chi.dim α β γ) × Fin D)) ℂ :=
   H.toBNTFusionCoisometryFamily.projectorQBlock P α β
 
 /-- Length independence makes the tensor-attached active fusion layer a
@@ -190,51 +147,11 @@ Source: arXiv:1606.00608, lines 999--1010 of
 theorem projectorQBlock_isStarProjection
     (H : BNTFusionTensorClause M)
     (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
-    (P : ∀ γ : Fin H.labelCount,
-      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (P : Fin H.labelCount → Matrix (Fin D) (Fin D) ℂ)
     (hP : ∀ γ : Fin H.labelCount, IsStarProjection (P γ))
     (α β : Fin H.labelCount) :
     IsStarProjection (H.projectorQBlock P α β) :=
   H.toBNTFusionCoisometryFamily.projectorQBlock_isStarProjection
-    (BNTLabelCoefficientFamily.ofChi H.chi)
-    (BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm H.chi)
-    hLI P hP α β
-
-/-- The tensor-attached active fusion layer transported to the product bond
-space.
-
-Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-noncomputable def conjugatedProjectorQBlock
-    (H : BNTFusionTensorClause M)
-    (P : ∀ γ : Fin H.labelCount,
-      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
-    (α β : Fin H.labelCount) :
-    Matrix (Fin (H.bondDim α * H.bondDim β))
-      (Fin (H.bondDim α * H.bondDim β)) ℂ :=
-  H.toBNTFusionCoisometryFamily.conjugatedProjectorQBlock P α β
-
-/-- A length-independent tensor-attached active fusion layer becomes an
-orthogonal projection on the product bond space after transport by its fusion
-coisometry.
-
-Source: arXiv:1606.00608, the fusion map at lines 986--993 and the recursive
-projector at lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`.
-
-**Scope restriction (one fusion layer):** The arbitrary-chain recursion and
-the commuting Gibbs decomposition at lines 999--1016 remain separate.  This
-is documented in
-`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
-theorem conjugatedProjectorQBlock_isOrthogonalProjection
-    (H : BNTFusionTensorClause M)
-    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
-    (P : ∀ γ : Fin H.labelCount,
-      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
-    (hP : ∀ γ : Fin H.labelCount, IsStarProjection (P γ))
-    (α β : Fin H.labelCount) :
-    IsOrthogonalProjection (H.conjugatedProjectorQBlock P α β) :=
-  H.toBNTFusionCoisometryFamily.conjugatedProjectorQBlock_isOrthogonalProjection
     (BNTLabelCoefficientFamily.ofChi H.chi)
     (BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm H.chi)
     hLI P hP α β
@@ -246,11 +163,17 @@ namespace MPOTensor.BNTFusionIsometryFamily
 variable {g p : ℕ}
 variable (Fam : BNTFusionIsometryFamily (Fin g) p)
 
-/-- The single fusion layer of the operator $Q$ at source lines 999--1010,
-with terminal matrices $P_\gamma$.
+/-- A conditional single fusion layer with terminal matrices $P_\gamma$ on
+the virtual bond spaces.
 
 Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (virtual-bond terminal operators):** The source terminal
+matrices $\operatorname{tr}(M_\gamma)$ act on a common physical space.  This
+definition instead gives a mathematically valid virtual-bond construction for
+the older full-support fusion family.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 noncomputable def projectorQBlock
     (P : ∀ γ : Fin g,
       Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
@@ -265,7 +188,12 @@ noncomputable def projectorQBlock
 are identities.
 
 Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (virtual-bond terminal operators):** This identity
+concerns the conditional virtual-bond construction, not the physical terminal
+matrices in the source recursion.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 theorem projectorQBlock_eq_unweighted
     (c : BNTLabelCoefficientFamily (Fin g))
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
@@ -285,7 +213,12 @@ matrices are self-adjoint idempotents and the structure coefficients are
 length independent.
 
 Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (virtual-bond terminal operators):** This theorem concerns
+the conditional virtual-bond construction, not the physical terminal matrices
+in the source recursion.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 theorem projectorQBlock_isStarProjection
     (c : BNTLabelCoefficientFamily (Fin g))
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
@@ -314,7 +247,13 @@ theorem projectorQBlock_isStarProjection
 fusion map.
 
 Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (virtual-bond terminal operators):** This transport is
+defined only for the older full-support fusion family.  It is not the
+sequential physical-space transport in the source recursion.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex` and
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
 noncomputable def conjugatedProjectorQBlock
     (P : ∀ γ : Fin g,
       Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
@@ -330,7 +269,15 @@ orthogonal projection on the product bond space.
 
 Source: arXiv:1606.00608, BNT separation at lines 317--345, the fusion map at
 lines 986--993, and the recursive projector at lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (full-support virtual transport):** The BNT hypothesis and
+length independence imply the additional full-support relation needed here.
+The theorem concerns virtual-bond terminal operators, not the physical
+terminal matrices or the sequential circuit of the source recursion.
+Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex` and
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
 theorem conjugatedProjectorQBlock_isOrthogonalProjection
     {D : ℕ} {A : MPSTensor (p * p) D}
     (hBNT : MPSTensor.IsCPSVBasisOfNormalTensors A

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -5,12 +5,13 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.OrthogonalProjection
 import TNLean.Channel.Irreducible.Basic
+import TNLean.MPS.MPDO.BNTFusionTensorClause
 import TNLean.MPS.MPDO.BNTTripleFusionSeparation
 
 /-!
 # The local projectors in the length-independent fusion form
 
-For the length-independent case following Theorem IV.13 of
+For the length-independent case following Theorem 4.14 of
 arXiv:1606.00608, every structure matrix
 $\chi_{\alpha,\beta,\gamma}$ is the identity on its multiplicity space.
 Consequently, if the terminal matrices $P_\gamma$ are orthogonal
@@ -20,10 +21,11 @@ projections, then
     = \bigoplus_\gamma
         \chi_{\alpha,\beta,\gamma}\otimes P_\gamma
 \]
-is a projection.  If the labelled tensors form a basis of normal tensors,
-the corresponding fusion map is unitary, and
+is a projection.  For the active-support fusion maps of the source,
 $U_{\alpha,\beta}^\dagger Q_{\alpha,\beta}U_{\alpha,\beta}$ is again an
-orthogonal projection.
+orthogonal projection because $U_{\alpha,\beta}$ is a coisometry onto the
+retained direct sum.  The earlier full-support formulation follows as a
+special case.
 
 These are the one-fusion-step projector statements in the recursive
 construction at source lines 999--1010.  The spectral decomposition of the
@@ -36,6 +38,208 @@ decomposition are separate steps.
 -/
 
 open scoped Matrix Kronecker
+
+namespace MPOTensor.BNTFusionCoisometryFamily
+
+variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
+variable (Fam : BNTFusionCoisometryFamily Λ p)
+
+/-- The single fusion layer of the operator $Q$ on the active product sectors,
+with terminal matrices $P_\gamma$.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (one fusion layer):** The arbitrary-chain recursive
+operator at line 999 and its sequential fusion circuit are not asserted here.
+Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+noncomputable def projectorQBlock
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (α β : Λ) :
+    Matrix ((γ : Λ) ×
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ)))
+      ((γ : Λ) ×
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ))) ℂ :=
+  Matrix.blockDiagonal' fun γ => Fam.chi.matrix α β γ ⊗ₖ P γ
+
+/-- In the length-independent case, the chi matrices in one active fusion
+layer are identities.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem projectorQBlock_eq_unweighted
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (α β : Λ) :
+    Fam.projectorQBlock P α β =
+      Matrix.blockDiagonal' fun γ =>
+        (1 : Matrix (Fin (Fam.chi.dim α β γ))
+          (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ P γ := by
+  unfold projectorQBlock
+  simp_rw [DiagonalChiFamily.matrix_eq_one_of_forall_entry_eq_one
+    (hχ.entry_eq_one_of_lengthIndependent Fam.posEntries hLI)]
+
+/-- One active fusion layer is a self-adjoint idempotent when its terminal
+matrices are self-adjoint idempotents and the structure coefficients are
+length independent.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem projectorQBlock_isStarProjection
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (hP : ∀ γ : Λ, IsStarProjection (P γ))
+    (α β : Λ) :
+    IsStarProjection (Fam.projectorQBlock P α β) := by
+  rw [Fam.projectorQBlock_eq_unweighted c hχ hLI]
+  rw [isStarProjection_iff']
+  constructor
+  · rw [← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext γ
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, (hP γ).isIdempotentElem.eq]
+  · rw [Matrix.star_eq_conjTranspose, Matrix.blockDiagonal'_conjTranspose]
+    congr 1
+    funext γ
+    rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one]
+    have hPγ : (P γ)ᴴ = P γ := by
+      simpa [Matrix.star_eq_conjTranspose] using (hP γ).isSelfAdjoint.star_eq
+    rw [hPγ]
+
+/-- The active fusion-layer operator transported to the product bond space by
+the fusion coisometry.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def conjugatedProjectorQBlock
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (α β : Λ) :
+    Matrix (Fin (Fam.bondDim α * Fam.bondDim β))
+      (Fin (Fam.bondDim α * Fam.bondDim β)) ℂ :=
+  (Fam.fusionCoisometry α β)ᴴ * Fam.projectorQBlock P α β *
+    Fam.fusionCoisometry α β
+
+/-- Transporting a length-independent fusion-layer projection through the
+active-support fusion coisometry gives an orthogonal projection on the product
+bond space.
+
+Source: arXiv:1606.00608, the fusion map at lines 986--993 and the recursive
+projector at lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Local fix (Figure-11 fusion coisometry):** The proof uses
+$U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$, the retained-row orientation of
+the source.  It does not assume that the active-support projection
+$U_{\alpha,\beta}^\dagger U_{\alpha,\beta}$ is the identity.  Documented in
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
+theorem conjugatedProjectorQBlock_isOrthogonalProjection
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (hP : ∀ γ : Λ, IsStarProjection (P γ))
+    (α β : Λ) :
+    IsOrthogonalProjection (Fam.conjugatedProjectorQBlock P α β) :=
+  (IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+    (Fam.projectorQBlock_isStarProjection c hχ hLI P hP α β)
+    (Fam.fusionCoisometry α β) (Fam.coisometry α β)).isOrthogonalProjection
+
+end MPOTensor.BNTFusionCoisometryFamily
+
+namespace MPOTensor.BNTFusionTensorClause
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- The single active fusion layer associated with a chosen vertical canonical
+decomposition of an MPO tensor.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (one fusion layer):** This definition records one step of
+the recursive operator at line 999, not its iteration along an arbitrary
+chain.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+noncomputable def projectorQBlock
+    (H : BNTFusionTensorClause M)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (α β : Fin H.labelCount) :
+    Matrix ((γ : Fin H.labelCount) ×
+        (Fin (H.chi.dim α β γ) × Fin (H.bondDim γ)))
+      ((γ : Fin H.labelCount) ×
+        (Fin (H.chi.dim α β γ) × Fin (H.bondDim γ))) ℂ :=
+  H.toBNTFusionCoisometryFamily.projectorQBlock P α β
+
+/-- Length independence makes the tensor-attached active fusion layer a
+self-adjoint idempotent when its terminal matrices are self-adjoint
+idempotents.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem projectorQBlock_isStarProjection
+    (H : BNTFusionTensorClause M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (hP : ∀ γ : Fin H.labelCount, IsStarProjection (P γ))
+    (α β : Fin H.labelCount) :
+    IsStarProjection (H.projectorQBlock P α β) :=
+  H.toBNTFusionCoisometryFamily.projectorQBlock_isStarProjection
+    (BNTLabelCoefficientFamily.ofChi H.chi)
+    (BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm H.chi)
+    hLI P hP α β
+
+/-- The tensor-attached active fusion layer transported to the product bond
+space.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def conjugatedProjectorQBlock
+    (H : BNTFusionTensorClause M)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (α β : Fin H.labelCount) :
+    Matrix (Fin (H.bondDim α * H.bondDim β))
+      (Fin (H.bondDim α * H.bondDim β)) ℂ :=
+  H.toBNTFusionCoisometryFamily.conjugatedProjectorQBlock P α β
+
+/-- A length-independent tensor-attached active fusion layer becomes an
+orthogonal projection on the product bond space after transport by its fusion
+coisometry.
+
+Source: arXiv:1606.00608, the fusion map at lines 986--993 and the recursive
+projector at lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (one fusion layer):** The arbitrary-chain recursion and
+the commuting Gibbs decomposition at lines 999--1016 remain separate.  This
+is documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem conjugatedProjectorQBlock_isOrthogonalProjection
+    (H : BNTFusionTensorClause M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (hP : ∀ γ : Fin H.labelCount, IsStarProjection (P γ))
+    (α β : Fin H.labelCount) :
+    IsOrthogonalProjection (H.conjugatedProjectorQBlock P α β) :=
+  H.toBNTFusionCoisometryFamily.conjugatedProjectorQBlock_isOrthogonalProjection
+    (BNTLabelCoefficientFamily.ofChi H.chi)
+    (BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm H.chi)
+    hLI P hP α β
+
+end MPOTensor.BNTFusionTensorClause
 
 namespace MPOTensor.BNTFusionIsometryFamily
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1423,10 +1423,15 @@ separate step.
 
 \begin{definition}[One fusion layer of the topological projector]%
     \label{def:mpdo_topological_projector_one_fusion}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.conjugatedProjectorQBlock}
+    \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock}
+    \lean{MPOTensor.BNTFusionTensorClause.conjugatedProjectorQBlock}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock}
     \lean{MPOTensor.BNTFusionIsometryFamily.conjugatedProjectorQBlock}
     \leanok
-    \uses{def:mpdo_bnt_fusion_isometry_family}
+    \uses{def:mpdo_bnt_fusion_coisometry_family,
+        def:mpdo_bnt_fusion_tensor_clause}
     Let $P_\gamma$ be operators on the terminal bond spaces.  Define one
     fusion layer of the recursive operator $Q$ by
     \[
@@ -1439,17 +1444,31 @@ separate step.
         \widehat Q_{\alpha,\beta}
           =U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}.
     \]
+    This is one pairwise step in the recursion of
+    \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (one fusion layer):} The arbitrary-chain
+    operator, the sequential fusion circuit, and the commuting Gibbs
+    decomposition are not asserted here.  The remaining statements are
+    recorded in
+    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
 \end{definition}
 
 \begin{theorem}[Projection property of one fusion layer]%
     \label{thm:mpdo_topological_projector_one_fusion}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_eq_unweighted}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_isStarProjection}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.%
+        conjugatedProjectorQBlock_isOrthogonalProjection}
+    \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock_isStarProjection}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        conjugatedProjectorQBlock_isOrthogonalProjection}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_eq_unweighted}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_isStarProjection}
     \lean{MPOTensor.BNTFusionIsometryFamily.%
         conjugatedProjectorQBlock_isOrthogonalProjection}
     \leanok
     \uses{def:mpdo_topological_projector_one_fusion,
-        thm:mpdo_pair_fusion_bnt_completeness,
         thm:mpdo_bnt_length_independent_zipper,
         thm:star_projection_coisometric_transport,
         thm:orthogonal_projection_star_projection_channel}
@@ -1462,9 +1481,10 @@ separate step.
           =\bigoplus_\gamma
              1_{r_{\alpha,\beta}^{\gamma}}\otimes P_\gamma
     \]
-    is self-adjoint and idempotent.  If the labelled tensors form a basis of
-    normal tensors, then $\widehat Q_{\alpha,\beta}$ is an orthogonal
-    projection.  This is the single recursive fusion step in
+    is self-adjoint and idempotent.  Since the active-support fusion map
+    satisfies $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$,
+    $\widehat Q_{\alpha,\beta}$ is an orthogonal projection.  This is the
+    single recursive fusion step in
     \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
@@ -1479,7 +1499,7 @@ separate step.
         =\bigoplus_\gamma(1\otimes P_\gamma^{2})
         =Q_{\alpha,\beta}.
     \]
-    By Theorem~\ref{thm:mpdo_pair_fusion_bnt_completeness},
+    The active-support coisometry satisfies
     $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$.  Therefore
     \[
       \widehat Q_{\alpha,\beta}^{\dagger}=\widehat Q_{\alpha,\beta},

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1424,26 +1424,19 @@ separate step.
 \begin{definition}[One fusion layer of the topological projector]%
     \label{def:mpdo_topological_projector_one_fusion}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock}
-    \lean{MPOTensor.BNTFusionCoisometryFamily.conjugatedProjectorQBlock}
     \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock}
-    \lean{MPOTensor.BNTFusionTensorClause.conjugatedProjectorQBlock}
-    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock}
-    \lean{MPOTensor.BNTFusionIsometryFamily.conjugatedProjectorQBlock}
     \leanok
     \uses{def:mpdo_bnt_fusion_coisometry_family,
         def:mpdo_bnt_fusion_tensor_clause}
-    Let $P_\gamma$ be operators on the terminal bond spaces.  Define one
-    fusion layer of the recursive operator $Q$ by
+    Let $P_\gamma$ be operators on the common physical space of the vertically
+    read tensors.  Define one fusion layer of the recursive operator $Q$ by
     \[
         Q_{\alpha,\beta}
           =\bigoplus_\gamma
              \chi_{\alpha,\beta,\gamma}\otimes P_\gamma.
     \]
-    Its transport to the product bond space is
-    \[
-        \widehat Q_{\alpha,\beta}
-          =U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}.
-    \]
+    The source terminal matrices are
+    $P_\gamma=\operatorname{tr}(M_\gamma)$ after spectral refinement.
     This is one pairwise step in the recursion of
     \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
 
@@ -1458,21 +1451,12 @@ separate step.
     \label{thm:mpdo_topological_projector_one_fusion}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_eq_unweighted}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_isStarProjection}
-    \lean{MPOTensor.BNTFusionCoisometryFamily.%
-        conjugatedProjectorQBlock_isOrthogonalProjection}
     \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock_isStarProjection}
-    \lean{MPOTensor.BNTFusionTensorClause.%
-        conjugatedProjectorQBlock_isOrthogonalProjection}
-    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_eq_unweighted}
-    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_isStarProjection}
-    \lean{MPOTensor.BNTFusionIsometryFamily.%
-        conjugatedProjectorQBlock_isOrthogonalProjection}
     \leanok
     \uses{def:mpdo_topological_projector_one_fusion,
-        thm:mpdo_bnt_length_independent_zipper,
-        thm:star_projection_coisometric_transport,
-        thm:orthogonal_projection_star_projection_channel}
-    Let $P_\gamma$ be self-adjoint idempotents on the terminal bond spaces.
+        thm:mpdo_bnt_length_independent_zipper}
+    Let $P_\gamma$ be self-adjoint idempotents on the common terminal physical
+    space.
     Suppose that the matrices $\chi_{\alpha,\beta,\gamma}$ have the
     positive-length trace-power form of the label-coefficient family and that
     this family is independent of the positive chain length.  Then
@@ -1481,10 +1465,7 @@ separate step.
           =\bigoplus_\gamma
              1_{r_{\alpha,\beta}^{\gamma}}\otimes P_\gamma
     \]
-    is self-adjoint and idempotent.  Since the active-support fusion map
-    satisfies $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$,
-    $\widehat Q_{\alpha,\beta}$ is an orthogonal projection.  This is the
-    single recursive fusion step in
+    is self-adjoint and idempotent.  This is the single recursive fusion step in
     \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
@@ -1499,16 +1480,69 @@ separate step.
         =\bigoplus_\gamma(1\otimes P_\gamma^{2})
         =Q_{\alpha,\beta}.
     \]
-    The active-support coisometry satisfies
-    $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$.  Therefore
+\end{proof}
+
+\begin{definition}[Full-support virtual-bond projector block]%
+    \label{def:mpdo_full_support_virtual_projector_one_fusion}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock}
+    \lean{MPOTensor.BNTFusionIsometryFamily.conjugatedProjectorQBlock}
+    \leanok
+    \uses{def:mpdo_bnt_fusion_isometry_family}
+    For a full-support fusion family, let $P_\gamma$ instead act on the virtual
+    bond space of $M_\gamma$.  Define
     \[
-      \widehat Q_{\alpha,\beta}^{\dagger}=\widehat Q_{\alpha,\beta},
-      \qquad
-      \widehat Q_{\alpha,\beta}^{2}
-        =U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}
+        Q^{\mathrm{vir}}_{\alpha,\beta}
+          =\bigoplus_\gamma
+             \chi_{\alpha,\beta,\gamma}\otimes P_\gamma,
+        \qquad
+        \widehat Q^{\mathrm{vir}}_{\alpha,\beta}
+          =U_{\alpha,\beta}^{\dagger}
+             Q^{\mathrm{vir}}_{\alpha,\beta}U_{\alpha,\beta}.
+    \]
+    This is a conditional construction on the virtual bond spaces, not the
+    terminal physical-space operator of
+    \cite[line~1010]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (virtual-bond terminal operators):} The terminal
+    operators and the full-support identity are additional restrictions not
+    asserted in the arbitrary-chain source statement.  This distinction is
+    documented in
+    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
+\end{definition}
+
+\begin{theorem}[Projection property of the full-support virtual-bond block]%
+    \label{thm:mpdo_full_support_virtual_projector_one_fusion}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_eq_unweighted}
+    \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_isStarProjection}
+    \lean{MPOTensor.BNTFusionIsometryFamily.%
+        conjugatedProjectorQBlock_isOrthogonalProjection}
+    \leanok
+    \uses{def:mpdo_full_support_virtual_projector_one_fusion,
+        thm:mpdo_pair_fusion_bnt_completeness,
+        thm:star_projection_coisometric_transport,
+        thm:orthogonal_projection_star_projection_channel}
+    Suppose that the labelled tensors form a basis of normal tensors and the
+    positive trace-power coefficients are independent of the positive chain
+    length.  If each $P_\gamma$ is a self-adjoint idempotent on the virtual
+    bond space, then $Q^{\mathrm{vir}}_{\alpha,\beta}$ is a self-adjoint
+    idempotent and $\widehat Q^{\mathrm{vir}}_{\alpha,\beta}$ is an orthogonal
+    projection.
+\end{theorem}
+\begin{proof}\leanok
+    Length independence gives
+    $\chi_{\alpha,\beta,\gamma}=1$, hence
+    $(Q^{\mathrm{vir}}_{\alpha,\beta})^2
+      =Q^{\mathrm{vir}}_{\alpha,\beta}$ and
+    $(Q^{\mathrm{vir}}_{\alpha,\beta})^\dagger
+      =Q^{\mathrm{vir}}_{\alpha,\beta}$.
+    The basis-of-normal-tensors completeness theorem gives
+    $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$, so
+    \[
+      (\widehat Q^{\mathrm{vir}}_{\alpha,\beta})^2
+        =U_{\alpha,\beta}^{\dagger}Q^{\mathrm{vir}}_{\alpha,\beta}
           (U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger})
-          Q_{\alpha,\beta}U_{\alpha,\beta}
-        =\widehat Q_{\alpha,\beta}.
+          Q^{\mathrm{vir}}_{\alpha,\beta}U_{\alpha,\beta}
+        =\widehat Q^{\mathrm{vir}}_{\alpha,\beta}.
     \]
 \end{proof}
 

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -1,0 +1,102 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+
+\title{The Arbitrary-Chain Topological Projector Recursion}
+\author{}
+\date{2026-07-22}
+
+\begin{document}
+\maketitle
+
+\section{The source statement}
+
+After Theorem~4.14, the source applies the fusion maps successively along an
+arbitrary chain.  In the notation of lines~995--1010 of
+\cite{Cirac2016MPDO_arXiv}, this gives
+\begin{equation}
+  \rho^{(N)}(M)
+    = \mu^{\otimes N}\,\widetilde U Q_N\widetilde U^\dagger,
+  \label{eq:source-chain-decomposition}
+\end{equation}
+where $\widetilde U$ is a sequential circuit assembled from the pairwise
+fusion maps.  The same passage asserts
+\begin{equation}
+  [\mu^{\otimes N},\widetilde U Q_N\widetilde U^\dagger]=0.
+  \label{eq:source-commutator}
+\end{equation}
+When the coefficients are independent of the positive chain length, the
+diagonal entries of every $\chi_{\alpha,\beta,\gamma}$ belong to
+$\{0,1\}$.  Spectral decomposition of the terminal matrices then yields the
+length-independent form stated at lines~1013--1016:
+\begin{equation}
+  \rho^{(N)}(M)
+    = \sum_i \lambda_i P_i^{(N)}e^{-H_N},
+  \qquad
+  [P_i^{(N)},e^{-H_N}]=0,
+  \label{eq:source-gibbs-decomposition}
+\end{equation}
+where $H_N$ is a translationally invariant commuting nearest-neighbor
+Hamiltonian and the $P_i^{(N)}$ are orthogonal projections.
+
+\section{The formalized one-layer statement}
+
+For terminal orthogonal projections $P_\gamma$, one pairwise fusion step is
+the direct sum
+\begin{equation}
+  Q_{\alpha,\beta}
+    = \bigoplus_\gamma
+      \chi_{\alpha,\beta,\gamma}\otimes P_\gamma.
+  \label{eq:one-layer-q}
+\end{equation}
+Length independence and positivity imply
+$\chi_{\alpha,\beta,\gamma}=I$ on each retained multiplicity space, hence
+$Q_{\alpha,\beta}$ is an orthogonal projection.  For the active-support
+fusion coisometry of Figure~11,
+\begin{equation}
+  U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=I,
+  \label{eq:coisometry}
+\end{equation}
+and therefore
+\begin{equation}
+  \widehat Q_{\alpha,\beta}
+    = U_{\alpha,\beta}^\dagger
+      Q_{\alpha,\beta}U_{\alpha,\beta}
+  \label{eq:transported-q}
+\end{equation}
+is an orthogonal projection on the product bond space.  This result is
+formalized for \leanid{MPOTensor.BNTFusionCoisometryFamily} and for the
+tensor-attached clause \leanid{MPOTensor.BNTFusionTensorClause}.  It uses the
+retained-row relation \eqref{eq:coisometry}; it does not require the additional
+full-support identity $U^\dagger U=I$.  The orientation issue is documented in
+\path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+
+\section{Remaining proof}
+
+Equations \eqref{eq:source-chain-decomposition}--
+\eqref{eq:source-gibbs-decomposition} are not consequences of the one-layer
+projection calculation alone.  A faithful proof still requires:
+\begin{enumerate}
+  \item a recursively typed family $Q_N$ and the corresponding sequential
+    product of active-support fusion coisometries;
+  \item the arbitrary-chain density-operator identity
+    \eqref{eq:source-chain-decomposition};
+  \item the commutator identity \eqref{eq:source-commutator};
+  \item the terminal spectral decomposition and its compatibility with the
+    recursive sectors;
+  \item the construction of the commuting nearest-neighbor Hamiltonian and
+    the projections in \eqref{eq:source-gibbs-decomposition}.
+\end{enumerate}
+These steps are tracked in \ghissue{3950}.  Until they are proved, the
+one-layer projection theorem must not be cited as the arbitrary-chain theorem
+of lines~999--1016.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -21,11 +21,13 @@ arbitrary chain.  In the notation of lines~995--1010 of
 \cite{Cirac2016MPDO_arXiv}, this gives
 \begin{equation}
   \rho^{(N)}(M)
-    = \mu^{\otimes N}\,\widetilde U Q_N\widetilde U^\dagger,
+    \simeq_{\mathrm{LU}}
+      \mu^{\otimes N}\,\widetilde U Q_N\widetilde U^\dagger,
   \label{eq:source-chain-decomposition}
 \end{equation}
-where $\widetilde U$ is a sequential circuit assembled from the pairwise
-fusion maps.  The same passage asserts
+where $\simeq_{\mathrm{LU}}$ denotes local-unitary equivalence through the
+single-site unitaries of Proposition~4.13, and $\widetilde U$ is a sequential
+circuit assembled from the pairwise fusion maps.  The same passage asserts
 \begin{equation}
   [\mu^{\otimes N},\widetilde U Q_N\widetilde U^\dagger]=0.
   \label{eq:source-commutator}
@@ -54,27 +56,35 @@ the direct sum
       \chi_{\alpha,\beta,\gamma}\otimes P_\gamma.
   \label{eq:one-layer-q}
 \end{equation}
+Here each $P_\gamma$ acts on the common physical space of the vertically read
+tensor $M_\gamma$; in the source it is obtained from the terminal matrix
+$\operatorname{tr}(M_\gamma)$.  It does not act on the virtual bond space of
+$M_\gamma$.
 Length independence and positivity imply
 $\chi_{\alpha,\beta,\gamma}=I$ on each retained multiplicity space, hence
-$Q_{\alpha,\beta}$ is an orthogonal projection.  For the active-support
-fusion coisometry of Figure~11,
-\begin{equation}
-  U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=I,
-  \label{eq:coisometry}
-\end{equation}
-and therefore
-\begin{equation}
-  \widehat Q_{\alpha,\beta}
-    = U_{\alpha,\beta}^\dagger
-      Q_{\alpha,\beta}U_{\alpha,\beta}
-  \label{eq:transported-q}
-\end{equation}
-is an orthogonal projection on the product bond space.  This result is
-formalized for \leanid{MPOTensor.BNTFusionCoisometryFamily} and for the
-tensor-attached clause \leanid{MPOTensor.BNTFusionTensorClause}.  It uses the
-retained-row relation \eqref{eq:coisometry}; it does not require the additional
-full-support identity $U^\dagger U=I$.  The orientation issue is documented in
-\path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+$Q_{\alpha,\beta}$ is an orthogonal projection.  This statement is formalized
+for \leanid{MPOTensor.BNTFusionCoisometryFamily} and for the tensor-attached
+clause \leanid{MPOTensor.BNTFusionTensorClause}.
+
+The pairwise fusion coisometry acts on the virtual bond spaces of the tensors,
+whereas the terminal projections in \eqref{eq:one-layer-q} act on their common
+physical space.  Consequently, a direct conjugation of
+$Q_{\alpha,\beta}$ by one pairwise fusion map is not well typed.  The source
+instead inserts the fusion maps recursively into the tensor network and forms
+the sequential circuit $\widetilde U$.  The older virtual-bond construction in
+\leanid{MPOTensor.BNTFusionIsometryFamily} is a separate conditional statement:
+it assumes terminal projections on the bond spaces and a full-support fusion
+family.  It is not the terminal step of equation~\eqref{eq:source-chain-decomposition}.
+
+\paragraph{Local fix (Figure-11 fusion coisometry).}
+The active fusion map has the retained-row orientation
+$U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$ recorded in
+\path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.  An earlier
+one-layer formulation attempted to use this relation to conjugate
+\eqref{eq:one-layer-q}.  That formulation has been removed: the coisometry
+acts on virtual indices, while the terminal matrices act on physical indices.
+The remaining virtual-bond transport is stated only for the older
+full-support family and is not identified with the source operator $Q_N$.
 
 \section{Remaining proof}
 
@@ -84,7 +94,7 @@ projection calculation alone.  A faithful proof still requires:
 \begin{enumerate}
   \item a recursively typed family $Q_N$ and the corresponding sequential
     product of active-support fusion coisometries;
-  \item the arbitrary-chain density-operator identity
+  \item the arbitrary-chain local-unitary equivalence
     \eqref{eq:source-chain-decomposition};
   \item the commutator identity \eqref{eq:source-commutator};
   \item the terminal spectral decomposition and its compatibility with the


### PR DESCRIPTION
### Motivation

- In arXiv:1606.00608, line 1010, the terminal matrices `tr(M_γ)` act on the common physical space of the vertically read tensors.
- The previous one-layer statement placed those terminal matrices on label-dependent virtual bond spaces and then conjugated the block by a pairwise virtual fusion map. That transport is not the source construction and is not well typed for the physical terminal matrices.
- This is a narrow advance toward #3950. It does not prove the arbitrary-chain theorem or the projector–Gibbs decomposition at lines 1013–1016.

### Description

- Define
  ```text
  Q_{α,β} = ⨁_γ χ_{α,β,γ} ⊗ P_γ
  ```
  for a common physical-space family `P_γ`, both abstractly for `BNTFusionCoisometryFamily` and directly for a tensor-attached `BNTFusionTensorClause`.
- Prove that length independence makes this one-layer block self-adjoint and idempotent.
- Remove the active and tensor-attached claims that directly conjugated this physical terminal block by one virtual fusion coisometry.
- Retain the older virtual-bond construction only as a separate conditional result for `BNTFusionIsometryFamily`, with explicit full-support and virtual-terminal scope restrictions in Lean and the blueprint.
- Correct the paper-gap note to state the line-999 relation up to the local unitaries of Proposition 4.13 and to distinguish the sequential circuit from the pairwise virtual maps.

### Scope restriction

This PR formalizes only the projection property of one pairwise block from arXiv:1606.00608, lines 999–1010. It does not construct the recursively typed family `Q_N`, the sequential product of active-support fusion coisometries `\widetilde U_N`, the arbitrary-chain local-unitary equivalence at line 999, the commutator at lines 1000–1002, or the commuting nearest-neighbor Hamiltonian and spectral projectors at lines 1013–1016. Those are the remaining obligations in #3950; this PR does not close that issue and introduces no hypothesis standing in for them.

### Testing

- `lake env lean TNLean/MPS/MPDO/TopologicalProjectors.lean`
- `lake build TNLean.MPS.MPDO.TopologicalProjectors`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Addresses #3950