### PR TITLE
fix(MPS/Periodic): refresh overlap import aggregator

### DIFF
--- a/TNLean/MPS/Periodic.lean
+++ b/TNLean/MPS/Periodic.lean
@@ -17,12 +17,12 @@ import TNLean.MPS.Periodic.GlobalGauge
 import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
 import TNLean.MPS.Periodic.NormalizedSelfOverlap
 import TNLean.MPS.Periodic.Overlap
-import TNLean.MPS.Periodic.Overlap.Case1
-import TNLean.MPS.Periodic.Overlap.Case2
-import TNLean.MPS.Periodic.Overlap.Case3
-import TNLean.MPS.Periodic.Overlap.Case3Transport
 import TNLean.MPS.Periodic.Overlap.Dichotomy
+import TNLean.MPS.Periodic.Overlap.DifferentPeriod
 import TNLean.MPS.Periodic.Overlap.GaugePhase
+import TNLean.MPS.Periodic.Overlap.NoSectorMatch
+import TNLean.MPS.Periodic.Overlap.SectorMatch
+import TNLean.MPS.Periodic.Overlap.SectorOverlapTransport
 import TNLean.MPS.Periodic.Overlap.SelfOverlap
 import TNLean.MPS.Periodic.Overlap.SelfOverlapNonrep
 import TNLean.MPS.Periodic.Overlap.SelfOverlapSetup


### PR DESCRIPTION
### Motivation

PR #4633 renamed the four periodic-overlap route modules. The generated aggregator `TNLean/MPS/Periodic.lean` still imported their former names, so the import-completeness check on current pull requests fails with `out-of-date generated aggregator`.

### Description

- Regenerate `TNLean/MPS/Periodic.lean`.
- Replace the four retired numbered module imports by `DifferentPeriod`, `NoSectorMatch`, `SectorMatch`, and `SectorOverlapTransport`.

This pull request contains only the generated aggregator correction omitted from #4633.

### Testing

- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated import list only; no runtime or proof behavior changes.
> 
> **Overview**
> Updates the **generated** aggregator `TNLean/MPS/Periodic.lean` so its overlap imports match the module renames from #4633.
> 
> It drops `Overlap.Case1`–`Case3` and `Overlap.Case3Transport` and imports `Overlap.DifferentPeriod`, `NoSectorMatch`, `SectorMatch`, and `SectorOverlapTransport` instead. No Lean proof or API logic changes—only the aggregator list so `generate_import_aggregators.py --check` passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f2b06b4125ad14d4407d7a6c9fe18293588356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->