### PR TITLE
feat(MPS/RFP): prove direct-sum NNCPH commutation

### DIFF
--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -31,6 +31,7 @@ import TNLean.MPS.RFP.KroneckerTransport
 import TNLean.MPS.RFP.NNCPHGroundSpace
 import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
+import TNLean.MPS.RFP.ResidualFamilyCommutation
 import TNLean.MPS.RFP.ResidualFamilySupport
 import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.ResidualWordSpan

--- a/TNLean/MPS/RFP/AppendixBCommutation.lean
+++ b/TNLean/MPS/RFP/AppendixBCommutation.lean
@@ -295,15 +295,19 @@ private theorem AppendixBStructuralData.replaceVirtualBond12_eq_iff
 
 /-! ### Matrices of the physical and virtual two-site transports -/
 
-/-- The one-site physical isometry in the pair-index basis. -/
-private noncomputable def AppendixBStructuralData.physicalIsometryMatrix
+/-- The one-site physical isometry in the pair-index basis.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+noncomputable def AppendixBStructuralData.physicalIsometryMatrix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     Matrix (Fin d) (Fin D × Fin D) ℂ :=
   fun i p ↦ hStruct.U i p.1 p.2
 
 /-- The reindexed two-site tensor-power matrix is the Kronecker square of the
-one-site physical isometry. -/
-private theorem AppendixBStructuralData.physicalIsometryTensorPower_two_matrix
+one-site physical isometry.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+theorem AppendixBStructuralData.physicalIsometryTensorPower_two_matrix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin D × Fin D))
         (LinearMap.toMatrix' (hStruct.physicalIsometryTensorPower 2)) =
@@ -316,8 +320,10 @@ private theorem AppendixBStructuralData.physicalIsometryTensorPower_two_matrix
     Pi.single_apply, Fin.prod_univ_two]
 
 /-- The reindexed two-site coefficient-adjoint matrix is the Kronecker square
-of the conjugate transpose of the one-site physical isometry. -/
-private theorem AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse_two_matrix
+of the conjugate transpose of the one-site physical isometry.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+theorem AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse_two_matrix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D)) (finTwoArrowEquiv (Fin d))
         (LinearMap.toMatrix' (hStruct.physicalIsometryTensorPowerLeftInverse 2)) =
@@ -330,8 +336,10 @@ private theorem AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse_t
     Pi.single_apply, Fin.prod_univ_two, Matrix.conjTranspose_apply]
 
 /-- The reindexed two-site transported matrix is the virtual bond matrix
-sandwiched by the Kronecker square of the physical isometry. -/
-private theorem AppendixBStructuralData.transportedTwoSiteBondProjection_matrix
+sandwiched by the Kronecker square of the physical isometry.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+theorem AppendixBStructuralData.transportedTwoSiteBondProjection_matrix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
         (LinearMap.toMatrix' hStruct.transportedTwoSiteBondProjection) =
@@ -418,8 +426,10 @@ private theorem AppendixBStructuralData.rightVirtualBondProjection_matrix
       appendixBLastPairCfg, finThreeArrowEquiv, finTwoArrowEquiv,
       Pi.single_apply, hs]
 
-/-- The two standard pair matrices of the virtual bond projector commute. -/
-private theorem AppendixBStructuralData.virtualPairMatrices_comm
+/-- The two standard pair matrices of the virtual bond projector commute.
+
+Source: arXiv:1606.00608, Appendix B, lines 1305--1307. -/
+theorem AppendixBStructuralData.virtualPairMatrices_comm
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin D × Fin D))
           (finTwoArrowEquiv (Fin D × Fin D))

--- a/TNLean/MPS/RFP/KroneckerTransport.lean
+++ b/TNLean/MPS/RFP/KroneckerTransport.lean
@@ -15,7 +15,7 @@ particular virtual bond operator, but its exported names remain Appendix B
 specific because they support that argument.
 -/
 
-open scoped Matrix Kronecker
+open scoped Matrix BigOperators Kronecker
 
 namespace MPSTensor
 
@@ -47,6 +47,33 @@ noncomputable abbrev appendixBRightPairMatrix
     {a : Type*} [Fintype a] [DecidableEq a]
     (B : Matrix (a × a) (a × a) ℂ) :=
   appendixBRightPairMatrixAux (s := a) B
+
+/-- The standard left pair-matrix construction preserves finite sums.
+
+Source: arXiv:1606.00608, Appendix B, lines 1305--1307. -/
+theorem appendixBLeftPairMatrix_sum
+    {p ι : Type*} [Fintype p] [DecidableEq p] [Fintype ι]
+    (Q : ι → Matrix (p × p) (p × p) ℂ) :
+    appendixBLeftPairMatrix (∑ j, Q j) =
+      ∑ j, appendixBLeftPairMatrix (Q j) := by
+  classical
+  ext x y
+  simp [appendixBLeftPairMatrix, appendixBLeftPairMatrixAux,
+    Matrix.reindex_apply, Matrix.kroneckerMap_apply, Matrix.sum_apply,
+    Finset.sum_mul]
+
+/-- The standard right pair-matrix construction preserves finite sums.
+
+Source: arXiv:1606.00608, Appendix B, lines 1305--1307. -/
+theorem appendixBRightPairMatrix_sum
+    {p ι : Type*} [Fintype p] [DecidableEq p] [Fintype ι]
+    (Q : ι → Matrix (p × p) (p × p) ℂ) :
+    appendixBRightPairMatrix (∑ j, Q j) =
+      ∑ j, appendixBRightPairMatrix (Q j) := by
+  classical
+  ext x y
+  simp [appendixBRightPairMatrix, appendixBRightPairMatrixAux,
+    Matrix.kroneckerMap_apply, Matrix.sum_apply, Finset.mul_sum]
 
 /-- A right-associated Kronecker product of three matrices. -/
 private noncomputable def tripleMatrix

--- a/TNLean/MPS/RFP/KroneckerTransport.lean
+++ b/TNLean/MPS/RFP/KroneckerTransport.lean
@@ -342,13 +342,14 @@ theorem appendixB_transportedPairMatrices_comm
         appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) := by
   rw [transportedPairProduct_left U B hU, transportedPairProduct_right U B hU, hB]
 
-/-- Orthogonal one-site isometries make a left transported pair matrix from
-one sector annihilate a right transported pair matrix from the other sector.
+/-- Orthogonal one-site embeddings make a left transported pair matrix from
+one summand annihilate a right transported pair matrix from the other summand.
 
-This is the cross-sector part of the common-isometry calculation: the shared
+This is the mixed-summand part of the transport calculation: the shared
 one-site factor contains `Uᴴ * V`, hence vanishes.
 
-Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+Source: matrix identity underlying arXiv:1606.00608, Appendix B, lines
+1305--1307. -/
 theorem appendixB_leftTransportedPairMatrix_mul_right_eq_zero_of_orthogonal
     {p v w : Type*} [Fintype p] [DecidableEq p]
     [Fintype v] [Fintype w]
@@ -375,10 +376,11 @@ theorem appendixB_leftTransportedPairMatrix_mul_right_eq_zero_of_orthogonal
       simp only [Matrix.mul_assoc]
     _ = 0 := by rw [hCross]; simp
 
-/-- Orthogonal one-site isometries also make the reverse overlapping product
+/-- Orthogonal one-site embeddings also make the reverse overlapping product
 vanish.
 
-Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+Source: matrix identity underlying arXiv:1606.00608, Appendix B, lines
+1305--1307. -/
 theorem appendixB_rightTransportedPairMatrix_mul_left_eq_zero_of_orthogonal
     {p v w : Type*} [Fintype p] [DecidableEq p]
     [Fintype v] [Fintype w]

--- a/TNLean/MPS/RFP/KroneckerTransport.lean
+++ b/TNLean/MPS/RFP/KroneckerTransport.lean
@@ -315,4 +315,67 @@ theorem appendixB_transportedPairMatrices_comm
         appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) := by
   rw [transportedPairProduct_left U B hU, transportedPairProduct_right U B hU, hB]
 
+/-- Orthogonal one-site isometries make a left transported pair matrix from
+one sector annihilate a right transported pair matrix from the other sector.
+
+This is the cross-sector part of the common-isometry calculation: the shared
+one-site factor contains `Uᴴ * V`, hence vanishes.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+theorem appendixB_leftTransportedPairMatrix_mul_right_eq_zero_of_orthogonal
+    {p v w : Type*} [Fintype p] [DecidableEq p]
+    [Fintype v] [Fintype w]
+    (U : Matrix p v ℂ) (V : Matrix p w ℂ)
+    (B : Matrix (v × v) (v × v) ℂ) (C : Matrix (w × w) (w × w) ℂ)
+    (hUV : Uᴴ * V = 0) :
+    appendixBLeftPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) *
+        appendixBRightPairMatrix (((V ⊗ₖ V) * C) * (Vᴴ ⊗ₖ Vᴴ)) = 0 := by
+  rw [leftPairMatrix_transport, rightPairMatrix_transport]
+  let LA := tripleMatrix U U (1 : Matrix p p ℂ)
+  let LHA := tripleMatrix Uᴴ Uᴴ (1 : Matrix p p ℂ)
+  let RA := tripleMatrix (1 : Matrix p p ℂ) V V
+  let RHA := tripleMatrix (1 : Matrix p p ℂ) Vᴴ Vᴴ
+  let LB := appendixBLeftPairMatrixAux (s := p) B
+  let RC := appendixBRightPairMatrixAux (s := p) C
+  have hCross : LHA * RA = 0 := by
+    dsimp [LHA, RA]
+    rw [tripleMatrix_mul]
+    simp only [Matrix.mul_one, Matrix.one_mul, hUV]
+    simp [tripleMatrix]
+  change ((LA * LB) * LHA) * ((RA * RC) * RHA) = 0
+  calc
+    _ = LA * LB * (LHA * RA) * RC * RHA := by
+      simp only [Matrix.mul_assoc]
+    _ = 0 := by rw [hCross]; simp
+
+/-- Orthogonal one-site isometries also make the reverse overlapping product
+vanish.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+theorem appendixB_rightTransportedPairMatrix_mul_left_eq_zero_of_orthogonal
+    {p v w : Type*} [Fintype p] [DecidableEq p]
+    [Fintype v] [Fintype w]
+    (U : Matrix p v ℂ) (V : Matrix p w ℂ)
+    (B : Matrix (v × v) (v × v) ℂ) (C : Matrix (w × w) (w × w) ℂ)
+    (hUV : Uᴴ * V = 0) :
+    appendixBRightPairMatrix (((U ⊗ₖ U) * B) * (Uᴴ ⊗ₖ Uᴴ)) *
+        appendixBLeftPairMatrix (((V ⊗ₖ V) * C) * (Vᴴ ⊗ₖ Vᴴ)) = 0 := by
+  rw [rightPairMatrix_transport, leftPairMatrix_transport]
+  let RA := tripleMatrix (1 : Matrix p p ℂ) U U
+  let RHA := tripleMatrix (1 : Matrix p p ℂ) Uᴴ Uᴴ
+  let LA := tripleMatrix V V (1 : Matrix p p ℂ)
+  let LHA := tripleMatrix Vᴴ Vᴴ (1 : Matrix p p ℂ)
+  let RB := appendixBRightPairMatrixAux (s := p) B
+  let LC := appendixBLeftPairMatrixAux (s := p) C
+  have hCross : RHA * LA = 0 := by
+    dsimp [RHA, LA]
+    rw [tripleMatrix_mul]
+    simp only [Matrix.one_mul, Matrix.mul_one, hUV]
+    simp [tripleMatrix]
+  change ((RA * RB) * RHA) * ((LA * LC) * LHA) = 0
+  calc
+    _ = RA * RB * (RHA * LA) * LC * LHA := by
+      simp only [Matrix.mul_assoc]
+    _ = 0 := by rw [hCross]; simp
+
 end MPSTensor

--- a/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
+++ b/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
@@ -12,10 +12,10 @@ import TNLean.MPS.RFP.ResidualFamilySupport
 
 This file constructs the equal-sector virtual bond projector for the disjoint
 union of the residual-pair spaces of a BNT family.  Its adjacent placements
-commute sectorwise, while mixed-sector products vanish by the cross-sector
-isometry equation.  Transport by the common physical isometry then gives the
-adjacent commutation relation for the canonical two-site support of the
-multiplicity-one direct sum.
+commute sectorwise, while mixed-sector products vanish by orthogonality of the
+canonical summand inclusions.  Transport by the common physical isometry then
+gives the adjacent commutation relation for the canonical two-site support of
+the multiplicity-one direct sum.
 
 Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
 543--555, equations (3.16)--(3.18), lines 549--578, and Appendix B, lines

--- a/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
+++ b/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
@@ -74,33 +74,6 @@ noncomputable def virtualBondMatrix
       (BlockEntryIndex dim × BlockEntryIndex dim) ℂ :=
   ∑ j : Fin r, h.embeddedSectorVirtualBondMatrix j
 
-/-- The standard left pair-matrix construction preserves finite sums.
-
-Source: arXiv:1606.00608, Appendix B, lines 1305--1307. -/
-private theorem appendixBLeftPairMatrix_sum
-    {p ι : Type*} [Fintype p] [DecidableEq p] [Fintype ι]
-    (Q : ι → Matrix (p × p) (p × p) ℂ) :
-    appendixBLeftPairMatrix (∑ j, Q j) =
-      ∑ j, appendixBLeftPairMatrix (Q j) := by
-  classical
-  ext x y
-  simp [appendixBLeftPairMatrix, appendixBLeftPairMatrixAux,
-    Matrix.reindex_apply, Matrix.kroneckerMap_apply, Matrix.sum_apply,
-    Finset.sum_mul]
-
-/-- The standard right pair-matrix construction preserves finite sums.
-
-Source: arXiv:1606.00608, Appendix B, lines 1305--1307. -/
-private theorem appendixBRightPairMatrix_sum
-    {p ι : Type*} [Fintype p] [DecidableEq p] [Fintype ι]
-    (Q : ι → Matrix (p × p) (p × p) ℂ) :
-    appendixBRightPairMatrix (∑ j, Q j) =
-      ∑ j, appendixBRightPairMatrix (Q j) := by
-  classical
-  ext x y
-  simp [appendixBRightPairMatrix, appendixBRightPairMatrixAux,
-    Matrix.kroneckerMap_apply, Matrix.sum_apply, Finset.mul_sum]
-
 /-- The two adjacent placements of the equal-sector virtual bond projector
 commute.  The equal-sector terms are the single-sector Appendix B
 calculation; unequal-sector terms vanish by orthogonality of the canonical
@@ -557,19 +530,6 @@ theorem twoSiteBondSupportProjection_commute_lifts
         Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
           (LinearMap.toMatrix' (rightPairLift (twoSiteBondSupportProjection B)))
           (LinearMap.toMatrix' (leftPairLift (twoSiteBondSupportProjection B)))
-
-/-- The canonical two-site support projector of the direct sum is
-idempotent.
-
-Source: arXiv:1606.00608, parent construction, lines 511--524. -/
-theorem twoSiteBondSupportProjection_idempotent
-    (B : (j : Fin r) → MPSTensor d (dim j)) :
-    twoSiteBondSupportProjection B * twoSiteBondSupportProjection B =
-      twoSiteBondSupportProjection B := by
-  rw [twoSiteBondSupportProjection_eq_complement]
-  change IsIdempotentElem (1 - parentInteraction (directSumTensor B) 2)
-  exact (show IsIdempotentElem (parentInteraction (directSumTensor B) 2) from
-    parentInteraction_idempotent (directSumTensor B) 2).one_sub
 
 /-- The canonical parent interaction of the multiplicity-one direct sum has
 commuting overlapping placements on three sites.

--- a/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
+++ b/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
@@ -139,16 +139,20 @@ theorem virtualPairMatrices_comm
       (sectorPairInclusion (dim := dim) j)
       (sectorPairInclusion (dim := dim) k)
       (h.sectorVirtualBondMatrix j) (h.sectorVirtualBondMatrix k) horth]
-    symm
     have horth' :
         (sectorPairInclusion (dim := dim) k)ᴴ *
             sectorPairInclusion (dim := dim) j = 0 :=
       Matrix.sigmaBlockInclusion_conjTranspose_mul_of_ne
         (fun l ↦ Fin (dim l) × Fin (dim l)) (fun hkj ↦ hjk hkj.symm)
-    exact appendixB_rightTransportedPairMatrix_mul_left_eq_zero_of_orthogonal
-      (sectorPairInclusion (dim := dim) k)
-      (sectorPairInclusion (dim := dim) j)
-      (h.sectorVirtualBondMatrix k) (h.sectorVirtualBondMatrix j) horth'
+    have hreverseProduct :
+        appendixBRightPairMatrix (h.embeddedSectorVirtualBondMatrix k) *
+            appendixBLeftPairMatrix (h.embeddedSectorVirtualBondMatrix j) = 0 := by
+      simp only [embeddedSectorVirtualBondMatrix]
+      exact appendixB_rightTransportedPairMatrix_mul_left_eq_zero_of_orthogonal
+        (sectorPairInclusion (dim := dim) k)
+        (sectorPairInclusion (dim := dim) j)
+        (h.sectorVirtualBondMatrix k) (h.sectorVirtualBondMatrix j) horth'
+    simpa only [embeddedSectorVirtualBondMatrix] using hreverseProduct.symm
 
 /-- The common physical isometry belonging to simultaneous Appendix B data.
 

--- a/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
+++ b/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
@@ -1,0 +1,656 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.DependentBlockDiagonal
+import TNLean.MPS.RFP.AppendixBChainCommutation
+import TNLean.MPS.RFP.ResidualFamilySupport
+
+/-!
+# Commutation for a residual-isometry family
+
+This file constructs the equal-sector virtual bond projector for the disjoint
+union of the residual-pair spaces of a BNT family.  Its adjacent placements
+commute sectorwise, while mixed-sector products vanish by the cross-sector
+isometry equation.  Transport by the common physical isometry then gives the
+adjacent commutation relation for the canonical two-site support of the
+multiplicity-one direct sum.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
+543--555, equations (3.16)--(3.18), lines 549--578, and Appendix B, lines
+1305--1307.
+-/
+
+open scoped Matrix BigOperators Kronecker
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+namespace ResidualFamilyAppendixBData
+
+variable {B : (j : Fin r) → MPSTensor d (dim j)}
+
+/-- The canonical inclusion of one sector's residual-pair space into the
+common disjoint union of residual-pair spaces.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+noncomputable abbrev sectorPairInclusion
+    (j : Fin r) : Matrix (BlockEntryIndex dim) (Fin (dim j) × Fin (dim j)) ℂ :=
+  Matrix.sigmaBlockInclusion (fun k ↦ Fin (dim k) × Fin (dim k)) j
+
+/-- The rank-one bond projector of a sector, in its two residual-pair
+coordinates.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def sectorVirtualBondMatrix
+    (h : ResidualFamilyAppendixBData B) (j : Fin r) :
+    Matrix ((Fin (dim j) × Fin (dim j)) × (Fin (dim j) × Fin (dim j)))
+      ((Fin (dim j) × Fin (dim j)) × (Fin (dim j) × Fin (dim j))) ℂ :=
+  Matrix.reindex (finTwoArrowEquiv (Fin (dim j) × Fin (dim j)))
+    (finTwoArrowEquiv (Fin (dim j) × Fin (dim j)))
+    (LinearMap.toMatrix' (h.sector j).twoSiteVirtualBondProjection)
+
+/-- Extend one sector's virtual bond projector by zero to the common
+residual-pair square.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def embeddedSectorVirtualBondMatrix
+    (h : ResidualFamilyAppendixBData B) (j : Fin r) :
+    Matrix (BlockEntryIndex dim × BlockEntryIndex dim)
+      (BlockEntryIndex dim × BlockEntryIndex dim) ℂ :=
+  let E := sectorPairInclusion (dim := dim) j
+  ((E ⊗ₖ E) * h.sectorVirtualBondMatrix j) * (Eᴴ ⊗ₖ Eᴴ)
+
+/-- The equal-sector virtual bond projector on the common residual-pair
+space.  Cross-sector two-site pairs are absent from its range.
+
+Source: arXiv:1606.00608, equations `eq:III_isometry` and (3.17)--(3.18),
+lines 549--578. -/
+noncomputable def virtualBondMatrix
+    (h : ResidualFamilyAppendixBData B) :
+    Matrix (BlockEntryIndex dim × BlockEntryIndex dim)
+      (BlockEntryIndex dim × BlockEntryIndex dim) ℂ :=
+  ∑ j : Fin r, h.embeddedSectorVirtualBondMatrix j
+
+/-- The standard left pair-matrix construction preserves finite sums.
+
+Source: arXiv:1606.00608, Appendix B, lines 1305--1307. -/
+private theorem appendixBLeftPairMatrix_sum
+    {p ι : Type*} [Fintype p] [DecidableEq p] [Fintype ι]
+    (Q : ι → Matrix (p × p) (p × p) ℂ) :
+    appendixBLeftPairMatrix (∑ j, Q j) =
+      ∑ j, appendixBLeftPairMatrix (Q j) := by
+  classical
+  ext x y
+  simp [appendixBLeftPairMatrix, appendixBLeftPairMatrixAux,
+    Matrix.reindex_apply, Matrix.kroneckerMap_apply, Matrix.sum_apply,
+    Finset.sum_mul]
+
+/-- The standard right pair-matrix construction preserves finite sums.
+
+Source: arXiv:1606.00608, Appendix B, lines 1305--1307. -/
+private theorem appendixBRightPairMatrix_sum
+    {p ι : Type*} [Fintype p] [DecidableEq p] [Fintype ι]
+    (Q : ι → Matrix (p × p) (p × p) ℂ) :
+    appendixBRightPairMatrix (∑ j, Q j) =
+      ∑ j, appendixBRightPairMatrix (Q j) := by
+  classical
+  ext x y
+  simp [appendixBRightPairMatrix, appendixBRightPairMatrixAux,
+    Matrix.kroneckerMap_apply, Matrix.sum_apply, Finset.mul_sum]
+
+/-- The two adjacent placements of the equal-sector virtual bond projector
+commute.  The equal-sector terms are the single-sector Appendix B
+calculation; unequal-sector terms vanish by orthogonality of the canonical
+summand inclusions.
+
+Source: arXiv:1606.00608, equations `eq:III_isometry` and (3.17)--(3.18),
+lines 549--578. -/
+theorem virtualPairMatrices_comm
+    (h : ResidualFamilyAppendixBData B) :
+    appendixBLeftPairMatrix h.virtualBondMatrix *
+        appendixBRightPairMatrix h.virtualBondMatrix =
+      appendixBRightPairMatrix h.virtualBondMatrix *
+        appendixBLeftPairMatrix h.virtualBondMatrix := by
+  classical
+  rw [virtualBondMatrix, appendixBLeftPairMatrix_sum,
+    appendixBRightPairMatrix_sum, Finset.sum_mul, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [Finset.mul_sum, Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro k _
+  by_cases hjk : j = k
+  · subst k
+    exact appendixB_transportedPairMatrices_comm
+      (sectorPairInclusion (dim := dim) j) (h.sectorVirtualBondMatrix j)
+      (Matrix.sigmaBlockInclusion_isometry
+        (fun k ↦ Fin (dim k) × Fin (dim k)) j)
+      (h.sector j).virtualPairMatrices_comm
+  · have horth :
+        (sectorPairInclusion (dim := dim) j)ᴴ *
+            sectorPairInclusion (dim := dim) k = 0 :=
+      Matrix.sigmaBlockInclusion_conjTranspose_mul_of_ne
+        (fun l ↦ Fin (dim l) × Fin (dim l)) hjk
+    simp only [embeddedSectorVirtualBondMatrix]
+    rw [appendixB_leftTransportedPairMatrix_mul_right_eq_zero_of_orthogonal
+      (sectorPairInclusion (dim := dim) j)
+      (sectorPairInclusion (dim := dim) k)
+      (h.sectorVirtualBondMatrix j) (h.sectorVirtualBondMatrix k) horth]
+    symm
+    have horth' :
+        (sectorPairInclusion (dim := dim) k)ᴴ *
+            sectorPairInclusion (dim := dim) j = 0 :=
+      Matrix.sigmaBlockInclusion_conjTranspose_mul_of_ne
+        (fun l ↦ Fin (dim l) × Fin (dim l)) (fun hkj ↦ hjk hkj.symm)
+    exact appendixB_rightTransportedPairMatrix_mul_left_eq_zero_of_orthogonal
+      (sectorPairInclusion (dim := dim) k)
+      (sectorPairInclusion (dim := dim) j)
+      (h.sectorVirtualBondMatrix k) (h.sectorVirtualBondMatrix j) horth'
+
+/-- The common physical isometry belonging to simultaneous Appendix B data.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+noncomputable abbrev physicalIsometryMatrix
+    (h : ResidualFamilyAppendixBData B) :
+    Matrix (Fin d) (BlockEntryIndex dim) ℂ :=
+  residualFamilyPhysicalIsometryMatrix (fun j ↦ (h.sector j).U)
+
+/-- Restricting the common physical isometry to one canonical summand gives
+that sector's physical isometry.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+theorem physicalIsometryMatrix_mul_sectorPairInclusion
+    (h : ResidualFamilyAppendixBData B) (j : Fin r) :
+    h.physicalIsometryMatrix * sectorPairInclusion (dim := dim) j =
+      (h.sector j).physicalIsometryMatrix := by
+  classical
+  ext i p
+  simp [physicalIsometryMatrix, residualFamilyPhysicalIsometryMatrix,
+    sectorPairInclusion, Matrix.sigmaBlockInclusion, Matrix.mul_apply,
+    AppendixBStructuralData.physicalIsometryMatrix]
+
+/-- Distinct sectors have orthogonal one-site physical isometry ranges.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554. -/
+theorem sectorPhysicalIsometryMatrix_orthogonal
+    (h : ResidualFamilyAppendixBData B) {j k : Fin r} (hjk : j ≠ k) :
+    (h.sector j).physicalIsometryMatrixᴴ *
+        (h.sector k).physicalIsometryMatrix = 0 := by
+  let V := h.physicalIsometryMatrix
+  let E := sectorPairInclusion (dim := dim) j
+  let F := sectorPairInclusion (dim := dim) k
+  have hVE : V * E = (h.sector j).physicalIsometryMatrix :=
+    h.physicalIsometryMatrix_mul_sectorPairInclusion j
+  have hVF : V * F = (h.sector k).physicalIsometryMatrix :=
+    h.physicalIsometryMatrix_mul_sectorPairInclusion k
+  have hV : Vᴴ * V = 1 :=
+    h.residual.residualFamilyPhysicalIsometryMatrix_isometry
+  have hEF : Eᴴ * F = 0 :=
+    Matrix.sigmaBlockInclusion_conjTranspose_mul_of_ne
+      (fun l ↦ Fin (dim l) × Fin (dim l)) hjk
+  rw [← hVE, ← hVF, Matrix.conjTranspose_mul]
+  rw [Matrix.mul_assoc Eᴴ Vᴴ (V * F)]
+  rw [← Matrix.mul_assoc Vᴴ V F]
+  rw [hV, Matrix.one_mul, hEF]
+
+/-- Transporting one embedded sector bond by the common physical isometry is
+the same as transporting it by that sector's physical isometry.
+
+Source: arXiv:1606.00608, equations `eq:III_isometry` and (3.16)--(3.18),
+lines 549--578. -/
+theorem transport_embeddedSectorVirtualBondMatrix
+    (h : ResidualFamilyAppendixBData B) (j : Fin r) :
+    ((h.physicalIsometryMatrix ⊗ₖ h.physicalIsometryMatrix) *
+        h.embeddedSectorVirtualBondMatrix j) *
+          (h.physicalIsometryMatrixᴴ ⊗ₖ h.physicalIsometryMatrixᴴ) =
+      (((h.sector j).physicalIsometryMatrix ⊗ₖ
+          (h.sector j).physicalIsometryMatrix) * h.sectorVirtualBondMatrix j) *
+        ((h.sector j).physicalIsometryMatrixᴴ ⊗ₖ
+          (h.sector j).physicalIsometryMatrixᴴ) := by
+  let V := h.physicalIsometryMatrix
+  let E := sectorPairInclusion (dim := dim) j
+  let U := (h.sector j).physicalIsometryMatrix
+  have hVE : V * E = U := h.physicalIsometryMatrix_mul_sectorPairInclusion j
+  have hEV : Eᴴ * Vᴴ = Uᴴ := by
+    simpa [Matrix.conjTranspose_mul] using congrArg Matrix.conjTranspose hVE
+  simp only [embeddedSectorVirtualBondMatrix, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (V ⊗ₖ V) (E ⊗ₖ E)]
+  rw [← Matrix.mul_kronecker_mul, hVE]
+  rw [← Matrix.mul_kronecker_mul, hEV]
+
+/-- The matrix of a sector's canonical two-site support is its transported
+rank-one virtual bond matrix.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+theorem sectorSupportProjection_matrix
+    (h : ResidualFamilyAppendixBData B) (j : Fin r) :
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (h.sector j).twoSiteBasicSupportProjection) =
+      (((h.sector j).physicalIsometryMatrix ⊗ₖ
+          (h.sector j).physicalIsometryMatrix) * h.sectorVirtualBondMatrix j) *
+        ((h.sector j).physicalIsometryMatrixᴴ ⊗ₖ
+          (h.sector j).physicalIsometryMatrixᴴ) := by
+  rw [← (h.sector j).transportedTwoSiteBondProjection_eq_support]
+  exact (h.sector j).transportedTwoSiteBondProjection_matrix
+
+/-- Canonical two-site support projectors of distinct residual sectors have
+orthogonal ranges.
+
+Source: arXiv:1606.00608, equation `eq:III_isometry`, lines 549--554, and
+equations (3.16)--(3.18), lines 549--578. -/
+theorem sectorSupportProjection_mul_eq_zero
+    (h : ResidualFamilyAppendixBData B) {j k : Fin r} (hjk : j ≠ k) :
+    (h.sector j).twoSiteBasicSupportProjection *
+        (h.sector k).twoSiteBasicSupportProjection = 0 := by
+  apply LinearMap.toMatrix'.injective
+  apply (Matrix.reindexLinearEquiv ℂ ℂ (finTwoArrowEquiv (Fin d))
+    (finTwoArrowEquiv (Fin d))).injective
+  simp only [LinearMap.toMatrix'_mul, map_zero,
+    Matrix.coe_reindexLinearEquiv]
+  have horth := h.sectorPhysicalIsometryMatrix_orthogonal hjk
+  calc
+    Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (h.sector j).twoSiteBasicSupportProjection *
+          LinearMap.toMatrix' (h.sector k).twoSiteBasicSupportProjection) =
+      Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (h.sector j).twoSiteBasicSupportProjection) *
+        Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (h.sector k).twoSiteBasicSupportProjection) := by
+      symm
+      exact Matrix.reindexLinearEquiv_mul ℂ ℂ
+        (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (finTwoArrowEquiv (Fin d)) _ _
+    _ = 0 := by
+      rw [h.sectorSupportProjection_matrix j, h.sectorSupportProjection_matrix k]
+      let U := (h.sector j).physicalIsometryMatrix
+      let V := (h.sector k).physicalIsometryMatrix
+      let Q := h.sectorVirtualBondMatrix j
+      let R := h.sectorVirtualBondMatrix k
+      have hkron : (Uᴴ ⊗ₖ Uᴴ) * (V ⊗ₖ V) = 0 := by
+        rw [← Matrix.mul_kronecker_mul]
+        change ((h.sector j).physicalIsometryMatrixᴴ *
+            (h.sector k).physicalIsometryMatrix) ⊗ₖ
+          ((h.sector j).physicalIsometryMatrixᴴ *
+            (h.sector k).physicalIsometryMatrix) = 0
+        rw [horth]
+        simp
+      change (((U ⊗ₖ U) * Q) * (Uᴴ ⊗ₖ Uᴴ)) *
+          (((V ⊗ₖ V) * R) * (Vᴴ ⊗ₖ Vᴴ)) = 0
+      calc
+        _ = (U ⊗ₖ U) * Q * ((Uᴴ ⊗ₖ Uᴴ) * (V ⊗ₖ V)) *
+            R * (Vᴴ ⊗ₖ Vᴴ) := by
+          simp only [Matrix.mul_assoc]
+        _ = 0 := by rw [hkron]; simp
+
+/-- The sum of the canonical two-site support projectors of the sectors.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+noncomputable def sectorSupportSum
+    (h : ResidualFamilyAppendixBData B) :
+    NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
+  ∑ j : Fin r, (h.sector j).twoSiteBasicSupportProjection
+
+/-- The sector support sum is idempotent.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+theorem sectorSupportSum_idempotent
+    (h : ResidualFamilyAppendixBData B) :
+    h.sectorSupportSum * h.sectorSupportSum = h.sectorSupportSum := by
+  classical
+  rw [sectorSupportSum, Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [Finset.mul_sum]
+  rw [Finset.sum_eq_single j]
+  · exact (h.sector j).twoSiteBasicSupportProjection_idempotent
+  · intro k _ hkj
+    exact h.sectorSupportProjection_mul_eq_zero hkj.symm
+  · simp
+
+/-- The range of the sector support sum is the linear sum of the sector
+two-site ground spaces.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and (3.17)--(3.18), lines
+543--578. -/
+theorem sectorSupportSum_range
+    (h : ResidualFamilyAppendixBData B) :
+    LinearMap.range h.sectorSupportSum =
+      ⨆ j : Fin r, groundSpace (B j) 2 := by
+  classical
+  apply le_antisymm
+  · rintro ψ ⟨v, rfl⟩
+    rw [sectorSupportSum, LinearMap.sum_apply]
+    apply Submodule.sum_mem
+    intro j _
+    apply Submodule.mem_iSup_of_mem j
+    rw [(h.sector j).groundSpace_eq_coreTensor]
+    change (h.sector j).twoSiteBasicSupportProjection v ∈
+      (h.sector j).twoSiteBasicSpace
+    rw [← (h.sector j).twoSiteBasicSupportProjection_range]
+    exact ⟨v, rfl⟩
+  · refine iSup_le fun j ↦ ?_
+    intro ψ hψ
+    rw [(h.sector j).groundSpace_eq_coreTensor] at hψ
+    have hψRange : ψ ∈ LinearMap.range
+        (h.sector j).twoSiteBasicSupportProjection := by
+      rw [(h.sector j).twoSiteBasicSupportProjection_range]
+      exact hψ
+    obtain ⟨v, rfl⟩ := hψRange
+    refine ⟨(h.sector j).twoSiteBasicSupportProjection v, ?_⟩
+    rw [sectorSupportSum, LinearMap.sum_apply, Finset.sum_eq_single j]
+    · exact LinearMap.congr_fun
+        (h.sector j).twoSiteBasicSupportProjection_idempotent v
+    · intro k _ hkj
+      have hzero := LinearMap.congr_fun
+        (h.sectorSupportProjection_mul_eq_zero hkj)
+        v
+      simpa only [Module.End.mul_apply, LinearMap.zero_apply] using hzero
+    · simp
+
+/-- Conjugate a coefficient-space endomorphism by the standard Euclidean
+coordinate equivalence.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+private noncomputable def coefficientEuclideanEnd
+    (T : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    EuclideanSpace ℂ (Cfg d 2) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d 2) :=
+  (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm.toLinearMap.comp
+    (T.comp (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).toLinearMap)
+
+/-- The Euclidean form of the sector support sum.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+private noncomputable def sectorSupportSumES
+    (h : ResidualFamilyAppendixBData B) :
+    EuclideanSpace ℂ (Cfg d 2) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d 2) :=
+  coefficientEuclideanEnd h.sectorSupportSum
+
+/-- In Euclidean coordinates the sector support sum is the sum of the
+orthogonal projections onto the sector ground spaces.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+private theorem sectorSupportSumES_eq
+    (h : ResidualFamilyAppendixBData B) :
+    h.sectorSupportSumES =
+      ∑ j : Fin r, (groundSpaceES (h.sector j).coreTensor 2).starProjection.toLinearMap := by
+  classical
+  apply LinearMap.ext
+  intro v
+  simp [sectorSupportSumES, coefficientEuclideanEnd, sectorSupportSum,
+    AppendixBStructuralData.twoSiteBasicSupportProjection]
+
+/-- The Euclidean sector support sum is a symmetric projection.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.18), lines 549--578. -/
+private theorem sectorSupportSumES_isSymmetricProjection
+    (h : ResidualFamilyAppendixBData B) :
+    h.sectorSupportSumES.IsSymmetricProjection where
+  isIdempotentElem := by
+    apply LinearMap.ext
+    intro v
+    simpa [sectorSupportSumES, coefficientEuclideanEnd, Module.End.mul_apply] using
+      LinearMap.congr_fun h.sectorSupportSum_idempotent
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)) v)
+  isSymmetric := by
+    rw [h.sectorSupportSumES_eq]
+    exact Finset.sum_induction
+      (fun j : Fin r ↦
+        (groundSpaceES (h.sector j).coreTensor 2).starProjection.toLinearMap)
+      LinearMap.IsSymmetric
+      (fun _ _ ha hb ↦ ha.add hb)
+      LinearMap.IsSymmetric.zero
+      (fun j _ ↦ (groundSpaceES (h.sector j).coreTensor 2).starProjection_isSymmetric)
+
+/-- The Euclidean sector support sum has the direct-sum two-site ground space
+as its range.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and (3.16)--(3.18), lines
+543--578. -/
+private theorem sectorSupportSumES_range
+    (h : ResidualFamilyAppendixBData B) :
+    LinearMap.range h.sectorSupportSumES =
+      groundSpaceES (directSumTensor B) 2 := by
+  ext ψ
+  constructor
+  · rintro ⟨v, rfl⟩
+    apply (mem_groundSpaceES_iff (directSumTensor B) 2 _).2
+    change h.sectorSupportSum
+      ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)) v) ∈
+        groundSpace (directSumTensor B) 2
+    rw [← h.twoSiteBondEmbedding_range_eq_directSum_groundSpace,
+      h.twoSiteBondEmbedding_range, ← h.sectorSupportSum_range]
+    exact ⟨_, rfl⟩
+  · intro hψ
+    have hraw : (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)) ψ ∈
+        LinearMap.range h.sectorSupportSum := by
+      rw [h.sectorSupportSum_range, ← h.twoSiteBondEmbedding_range,
+        h.twoSiteBondEmbedding_range_eq_directSum_groundSpace]
+      exact (mem_groundSpaceES_iff (directSumTensor B) 2 ψ).1 hψ
+    obtain ⟨v, hv⟩ := hraw
+    refine ⟨(WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v, ?_⟩
+    apply (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).injective
+    simpa [sectorSupportSumES, coefficientEuclideanEnd] using hv
+
+/-- The canonical support of the direct sum is the sum of the mutually
+orthogonal sector supports.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and (3.16)--(3.18), lines
+543--578. -/
+theorem sectorSupportSum_eq_twoSiteBondSupportProjection
+    (h : ResidualFamilyAppendixBData B) :
+    h.sectorSupportSum = twoSiteBondSupportProjection B := by
+  have hEq : h.sectorSupportSumES =
+      (groundSpaceES (directSumTensor B) 2).starProjection.toLinearMap :=
+    h.sectorSupportSumES_isSymmetricProjection.ext
+      (Submodule.isSymmetricProjection_starProjection _)
+      (by
+        rw [Submodule.range_starProjection]
+        exact h.sectorSupportSumES_range)
+  apply LinearMap.ext
+  intro ψ
+  have hψ := LinearMap.congr_fun hEq
+    ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm ψ)
+  apply (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm.injective
+  simpa [sectorSupportSumES, coefficientEuclideanEnd,
+    twoSiteBondSupportProjection] using hψ
+
+/-- Transporting the equal-sector virtual bond matrix through the common
+physical isometry gives the matrix of the canonical direct-sum support
+projector.
+
+Source: arXiv:1606.00608, equations `eq:III_isometry` and (3.16)--(3.18),
+lines 549--578. -/
+theorem transportedVirtualBondMatrix_eq_supportMatrix
+    (h : ResidualFamilyAppendixBData B) :
+    ((h.physicalIsometryMatrix ⊗ₖ h.physicalIsometryMatrix) *
+        h.virtualBondMatrix) *
+          (h.physicalIsometryMatrixᴴ ⊗ₖ h.physicalIsometryMatrixᴴ) =
+      Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' (twoSiteBondSupportProjection B)) := by
+  classical
+  rw [← h.sectorSupportSum_eq_twoSiteBondSupportProjection]
+  calc
+    _ = ∑ j : Fin r,
+        ((h.physicalIsometryMatrix ⊗ₖ h.physicalIsometryMatrix) *
+          h.embeddedSectorVirtualBondMatrix j) *
+            (h.physicalIsometryMatrixᴴ ⊗ₖ h.physicalIsometryMatrixᴴ) := by
+      simp [virtualBondMatrix, Matrix.mul_sum, Matrix.sum_mul]
+    _ = ∑ j : Fin r,
+        Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (h.sector j).twoSiteBasicSupportProjection) := by
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [h.transport_embeddedSectorVirtualBondMatrix j]
+      exact (h.sectorSupportProjection_matrix j).symm
+    _ = Matrix.reindex (finTwoArrowEquiv (Fin d)) (finTwoArrowEquiv (Fin d))
+        (LinearMap.toMatrix' h.sectorSupportSum) := by
+      ext x y
+      simp [sectorSupportSum, Matrix.reindex_apply, Matrix.submatrix_apply,
+        Matrix.sum_apply]
+
+/-- The two adjacent lifts of the canonical support projector of the
+multiplicity-one direct sum commute on three sites.
+
+Source: arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, lines
+543--555, and Appendix B, lines 1305--1307. -/
+theorem twoSiteBondSupportProjection_commute_lifts
+    (h : ResidualFamilyAppendixBData B) :
+    leftPairLift (twoSiteBondSupportProjection B) *
+        rightPairLift (twoSiteBondSupportProjection B) =
+      rightPairLift (twoSiteBondSupportProjection B) *
+        leftPairLift (twoSiteBondSupportProjection B) := by
+  have hMatrix :
+      appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (twoSiteBondSupportProjection B))) *
+        appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (twoSiteBondSupportProjection B))) =
+      appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (twoSiteBondSupportProjection B))) *
+        appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (twoSiteBondSupportProjection B))) := by
+    rw [← h.transportedVirtualBondMatrix_eq_supportMatrix]
+    exact appendixB_transportedPairMatrices_comm h.physicalIsometryMatrix
+      h.virtualBondMatrix
+      h.residual.residualFamilyPhysicalIsometryMatrix_isometry
+      h.virtualPairMatrices_comm
+  apply LinearMap.toMatrix'.injective
+  simp only [LinearMap.toMatrix'_mul]
+  let e := finThreeArrowEquiv (Fin d)
+  apply (Matrix.reindexLinearEquiv ℂ ℂ e e).injective
+  simp only [Matrix.coe_reindexLinearEquiv]
+  calc
+    _ = Matrix.reindex e e
+          (LinearMap.toMatrix' (leftPairLift (twoSiteBondSupportProjection B))) *
+        Matrix.reindex e e
+          (LinearMap.toMatrix' (rightPairLift (twoSiteBondSupportProjection B))) := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        (Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
+          (LinearMap.toMatrix' (leftPairLift (twoSiteBondSupportProjection B)))
+          (LinearMap.toMatrix'
+            (rightPairLift (twoSiteBondSupportProjection B)))).symm
+    _ = appendixBLeftPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (twoSiteBondSupportProjection B))) *
+        appendixBRightPairMatrix (Matrix.reindex (finTwoArrowEquiv (Fin d))
+          (finTwoArrowEquiv (Fin d))
+          (LinearMap.toMatrix' (twoSiteBondSupportProjection B))) := by
+      rw [leftPairLift_toMatrix_reindex, rightPairLift_toMatrix_reindex]
+    _ = _ := hMatrix
+    _ = Matrix.reindex e e
+          (LinearMap.toMatrix' (rightPairLift (twoSiteBondSupportProjection B))) *
+        Matrix.reindex e e
+          (LinearMap.toMatrix' (leftPairLift (twoSiteBondSupportProjection B))) := by
+      rw [leftPairLift_toMatrix_reindex, rightPairLift_toMatrix_reindex]
+    _ = _ := by
+      simpa only [Matrix.coe_reindexLinearEquiv] using
+        Matrix.reindexLinearEquiv_mul ℂ ℂ e e e
+          (LinearMap.toMatrix' (rightPairLift (twoSiteBondSupportProjection B)))
+          (LinearMap.toMatrix' (leftPairLift (twoSiteBondSupportProjection B)))
+
+/-- The canonical two-site support projector of the direct sum is
+idempotent.
+
+Source: arXiv:1606.00608, parent construction, lines 511--524. -/
+theorem twoSiteBondSupportProjection_idempotent
+    (B : (j : Fin r) → MPSTensor d (dim j)) :
+    twoSiteBondSupportProjection B * twoSiteBondSupportProjection B =
+      twoSiteBondSupportProjection B := by
+  rw [twoSiteBondSupportProjection_eq_complement]
+  change IsIdempotentElem (1 - parentInteraction (directSumTensor B) 2)
+  exact (show IsIdempotentElem (parentInteraction (directSumTensor B) 2) from
+    parentInteraction_idempotent (directSumTensor B) 2).one_sub
+
+/-- The canonical parent interaction of the multiplicity-one direct sum has
+commuting overlapping placements on three sites.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--524, equations
+`III_CFI_RFP` and `eq:III_isometry`, lines 543--555, and Appendix B, lines
+1305--1307. -/
+theorem hasOverlappingTwoSiteCommutation
+    (h : ResidualFamilyAppendixBData B) :
+    HasOverlappingTwoSiteCommutation (d := d)
+      (parentInteraction (directSumTensor B) 2)
+      (parentInteraction (directSumTensor B) 2) := by
+  let hSupport : HasOverlappingTwoSiteCommutation (d := d)
+      (twoSiteBondSupportProjection B) (twoSiteBondSupportProjection B) :=
+    { left_idempotent := twoSiteBondSupportProjection_idempotent B
+      right_idempotent := twoSiteBondSupportProjection_idempotent B
+      commute_lifts := h.twoSiteBondSupportProjection_commute_lifts }
+  have hComplement := hSupport.complement
+  simpa [twoSiteBondSupportProjection_eq_complement] using hComplement
+
+/-- The first two translated parent interactions of the direct sum commute
+on the three-site chain.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--524, Theorem 3.10, lines
+534--541, and Appendix B, lines 1305--1307. -/
+theorem localTerm_two_three_zero_one_commute
+    (h : ResidualFamilyAppendixBData B) :
+    localTerm (directSumTensor B) 2 3 (0 : Fin 3) *
+        localTerm (directSumTensor B) 2 3 (1 : Fin 3) =
+      localTerm (directSumTensor B) 2 3 (1 : Fin 3) *
+        localTerm (directSumTensor B) 2 3 (0 : Fin 3) :=
+  localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation
+    (directSumTensor B) h.hasOverlappingTwoSiteCommutation
+
+/-- The residual-family form gives adjacent two-site commutation on every
+periodic chain of length greater than two.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--524, Theorem 3.10, lines
+534--541, and Appendix B, lines 1305--1307. -/
+theorem adjacent_twoSite_localTerms_commute
+    (h : ResidualFamilyAppendixBData B) {N : ℕ} (hN : 2 < N) (i : Fin N) :
+    localTerm (directSumTensor B) 2 N i *
+        localTerm (directSumTensor B) 2 N (cyclicForwardSite i 1) =
+      localTerm (directSumTensor B) 2 N (cyclicForwardSite i 1) *
+        localTerm (directSumTensor B) 2 N i :=
+  localTerm_adjacent_twoSite_commute_of_threeSite_zero_one_commute
+    h.localTerm_two_three_zero_one_commute (by omega) i
+
+/-- Simultaneous Appendix B data supplies the nearest-neighbor commuting
+parent Hamiltonian on every periodic chain of length greater than two.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--524, Theorem 3.10, lines
+534--541, and Appendix B, lines 1305--1307. -/
+theorem isNNCPH
+    (h : ResidualFamilyAppendixBData B) {N : ℕ} (hN : 2 < N) :
+    IsNNCPH (directSumTensor B) N :=
+  (HasProductPairLocalProjectors.of_adjacent_twoSite_commute (by omega)
+    (h.adjacent_twoSite_localTerms_commute hN)).isNNCPH
+
+end ResidualFamilyAppendixBData
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- A multiplicity-one direct sum of the distinct sectors of an RFP BNT
+canonical form has commuting nearest-neighbor parent interactions on every
+periodic chain of length greater than two.
+
+Source: arXiv:1606.00608, Definition 3.9, lines 517--524, Theorem 3.10, lines
+534--541, equations `III_CFI_RFP` and `eq:III_isometry`, lines 543--555, and
+Appendix B, lines 1305--1307.
+
+**Scope restriction (multiplicity-one distinct sectors):** the theorem treats
+the direct sum of the BNT basis tensors, with one copy of each distinct
+sector. Repeated copies and arbitrary raw sector weights remain outside this
+statement; see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem rfp_implies_nncph_basisDirectSum
+    (hCF : IsBNTCanonicalForm P)
+    (hRFP : IsTransferIdempotent (directSumTensor P.basis))
+    (N : ℕ) (hN : 2 < N) :
+    IsNNCPH (directSumTensor P.basis) N := by
+  obtain ⟨h⟩ := hCF.exists_residualFamilyAppendixBData hRFP
+  exact h.isNNCPH hN
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
+++ b/TNLean/MPS/RFP/ResidualFamilyCommutation.lean
@@ -89,10 +89,10 @@ theorem virtualPairMatrices_comm
         appendixBLeftPairMatrix h.virtualBondMatrix := by
   classical
   rw [virtualBondMatrix, appendixBLeftPairMatrix_sum,
-    appendixBRightPairMatrix_sum, Finset.sum_mul, Finset.mul_sum]
+    appendixBRightPairMatrix_sum, Finset.sum_mul, Finset.sum_mul]
   apply Finset.sum_congr rfl
   intro j _
-  rw [Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.mul_sum, Finset.mul_sum]
   apply Finset.sum_congr rfl
   intro k _
   by_cases hjk : j = k
@@ -112,20 +112,15 @@ theorem virtualPairMatrices_comm
       (sectorPairInclusion (dim := dim) j)
       (sectorPairInclusion (dim := dim) k)
       (h.sectorVirtualBondMatrix j) (h.sectorVirtualBondMatrix k) horth]
-    have horth' :
-        (sectorPairInclusion (dim := dim) k)ᴴ *
-            sectorPairInclusion (dim := dim) j = 0 :=
-      Matrix.sigmaBlockInclusion_conjTranspose_mul_of_ne
-        (fun l ↦ Fin (dim l) × Fin (dim l)) (fun hkj ↦ hjk hkj.symm)
-    have hreverseProduct :
-        appendixBRightPairMatrix (h.embeddedSectorVirtualBondMatrix k) *
-            appendixBLeftPairMatrix (h.embeddedSectorVirtualBondMatrix j) = 0 := by
+    have h_reverse_product :
+        appendixBRightPairMatrix (h.embeddedSectorVirtualBondMatrix j) *
+            appendixBLeftPairMatrix (h.embeddedSectorVirtualBondMatrix k) = 0 := by
       simp only [embeddedSectorVirtualBondMatrix]
       exact appendixB_rightTransportedPairMatrix_mul_left_eq_zero_of_orthogonal
-        (sectorPairInclusion (dim := dim) k)
         (sectorPairInclusion (dim := dim) j)
-        (h.sectorVirtualBondMatrix k) (h.sectorVirtualBondMatrix j) horth'
-    simpa only [embeddedSectorVirtualBondMatrix] using hreverseProduct.symm
+        (sectorPairInclusion (dim := dim) k)
+        (h.sectorVirtualBondMatrix j) (h.sectorVirtualBondMatrix k) horth
+    simpa only [embeddedSectorVirtualBondMatrix] using h_reverse_product.symm
 
 /-- The common physical isometry belonging to simultaneous Appendix B data.
 

--- a/TNLean/MPS/RFP/ResidualFamilySupport.lean
+++ b/TNLean/MPS/RFP/ResidualFamilySupport.lean
@@ -245,6 +245,19 @@ theorem twoSiteBondSupportProjection_eq_complement
   rw [Submodule.starProjection_orthogonal_val]
   simp
 
+/-- The canonical two-site support projector of the direct sum is
+idempotent.
+
+Source: arXiv:1606.00608, parent construction, lines 511--524. -/
+theorem twoSiteBondSupportProjection_idempotent
+    (B : (j : Fin r) → MPSTensor d (dim j)) :
+    twoSiteBondSupportProjection B * twoSiteBondSupportProjection B =
+      twoSiteBondSupportProjection B := by
+  rw [twoSiteBondSupportProjection_eq_complement]
+  change IsIdempotentElem (1 - parentInteraction (directSumTensor B) 2)
+  exact (show IsIdempotentElem (parentInteraction (directSumTensor B) 2) from
+    parentInteraction_idempotent (directSumTensor B) 2).one_sub
+
 end ResidualFamilyAppendixBData
 
 namespace IsBNTCanonicalForm

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1130,11 +1130,11 @@ specialization of that Appendix~D definition.
     \[
         L_jR_j=R_jL_j,
         \qquad
-        L_jR_k=0=R_kL_j \quad (j\ne k),
+        L_jR_k=0=R_jL_k \quad (j\ne k),
     \]
     where the latter identities follow from the shared one-site factor
-    $U_j^*U_k=0$. Summing over the sectors shows that the two adjacent
-    placements of $Q$ commute.
+    $E_j^*E_k=0$ for the canonical summand inclusions $E_j$. Summing over the
+    sectors shows that the two adjacent placements of $Q$ commute.
 
     If $U$ is the common isometry, then transport gives the identity
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1103,6 +1103,42 @@ specialization of that Appendix~D definition.
     two.
 \end{proof}
 
+\begin{theorem}[Commuting nearest-neighbor terms for distinct multiplicity-one RFP sectors]%
+    \label{thm:rfp_multiplicity_one_bnt_nncph}
+    \lean{MPSTensor.IsBNTCanonicalForm.rfp_implies_nncph_basisDirectSum}
+    \leanok
+    \uses{def:sector_bnt_cf, def:mps_transfer_idempotence, def:is_nncph,
+        lem:nncph_from_adjacent_two_site_commutation}
+    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
+    form, and let $B=\bigoplus_{j=1}^g A_j$ contain one copy of every basis
+    tensor. If $B$ is a renormalization fixed point, then for every $N>2$
+    its translated two-site parent interactions commute pairwise. Thus $B$
+    satisfies the nearest-neighbor commuting parent-Hamiltonian condition.
+
+    This statement treats one copy of every distinct sector. It does not
+    include repeated copies or arbitrary raw sector weights.
+\end{theorem}
+
+\begin{proof}\leanok
+    The fixed-point equation gives residual tensors $U_j$ whose matrix-entry
+    columns form one orthonormal family on the disjoint union of the sector
+    matrix spaces. On the tensor square of this disjoint union, let $Q$ be the
+    sum of the sector bond projectors, extended by zero between unequal
+    sectors. The two adjacent placements of $Q$ commute within each sector.
+    Mixed-sector products vanish because their shared one-site factor is
+    $U_j^*U_k=0$ for $j\ne k$.
+
+    Transporting $Q$ by the tensor square of the common isometry gives the
+    orthogonal projector onto
+    \[
+        \bigvee_j G_2(A_j)=G_2(B).
+    \]
+    Hence it is the complement of the canonical two-site parent interaction
+    of $B$. The two adjacent three-site parent terms therefore commute.
+    Cyclic transport gives adjacent commutation on every chain with $N>2$;
+    disjoint local terms commute by locality, which proves the claim.
+\end{proof}
+
 \begin{theorem}[Nearest-neighbor parent ground spaces for distinct multiplicity-one RFP sectors]%
     \label{thm:rfp_multiplicity_one_bnt_parent_ground_spaces}
     \lean{MPSTensor.IsBNTCanonicalForm.rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1124,12 +1124,23 @@ specialization of that Appendix~D definition.
     columns form one orthonormal family on the disjoint union of the sector
     matrix spaces. On the tensor square of this disjoint union, let $Q$ be the
     sum of the sector bond projectors, extended by zero between unequal
-    sectors. The two adjacent placements of $Q$ commute within each sector.
-    Mixed-sector products vanish because their shared one-site factor is
-    $U_j^*U_k=0$ for $j\ne k$.
+    sectors. Write $L_j$ and $R_j$ for the left and right overlapping lifts
+    of the sector-$j$ bond projector. The single-sector relation and the
+    mixed-sector orthogonality give
+    \[
+        L_jR_j=R_jL_j,
+        \qquad
+        L_jR_k=0=R_kL_j \quad (j\ne k),
+    \]
+    where the latter identities follow from the shared one-site factor
+    $U_j^*U_k=0$. Summing over the sectors shows that the two adjacent
+    placements of $Q$ commute.
 
-    Transporting $Q$ by the tensor square of the common isometry gives the
-    orthogonal projector onto
+    If $U$ is the common isometry, then transport gives the identity
+    \[
+        (U\otimes U)Q(U^*\otimes U^*)=P_{G_2(B)},
+    \]
+    since the range on either side is
     \[
         \bigvee_j G_2(A_j)=G_2(B).
     \]

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -111,6 +111,21 @@ now implies this reverse containment.  The resulting spanning theorem is
 \leanid{MPSTensor.IsBNTCanonicalForm.}
 \hspace{0pt}\leanid{rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum}.
 
+The commutation clause is also proved for this multiplicity-one direct sum.
+The residual matrix entries form one orthonormal family on the disjoint union
+of the within-sector matrix spaces.  The equal-sector virtual bond projector
+is the sum of the sector bond projectors, extended by zero between unequal
+sectors.  Its two adjacent placements commute sectorwise, while every mixed
+product vanishes by the cross-sector residual-isometry equation.  Transport
+by the common physical isometry identifies this virtual projector with the
+canonical projector onto the two-site space of the direct sum.  Complementing
+and transporting the resulting three-site relation around the periodic chain
+proves
+\leanid{MPSTensor.IsBNTCanonicalForm.}
+\hspace{0pt}\leanid{rfp_implies_nncph_basisDirectSum}.
+This result uses no comparison, crossing, repeated-copy, raw-weight, or
+externally supplied commutation hypothesis.
+
 These reductions alone do not prove the full source theorem.  The
 ground-space spanning condition for repeated copies and arbitrary raw sector
 weights, the three-way equivalence with ZCL, the complete canonical-form
@@ -232,8 +247,13 @@ chain spaces.  Combining this splitting with the single-block injective
 periodic-chain theorem proves
 \leanid{MPSTensor.IsBNTCanonicalForm.}
 \hspace{0pt}\leanid{rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum}.
-This is precisely the multiplicity-one distinct-sector forward case: it does
-not assert the result for repeated copies or arbitrary raw weights.
+The residual-family bond-projector argument independently proves the
+commutation clause
+\leanid{MPSTensor.IsBNTCanonicalForm.}
+\hspace{0pt}\leanid{rfp_implies_nncph_basisDirectSum}.
+Together these are precisely the multiplicity-one distinct-sector forward
+case. They do not assert the result for repeated copies or arbitrary raw
+weights.
 The reverse theorem requires both the explicit BNT relation
 \leanid{MPSTensor.IsBNT} and the named all-chain condition
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -116,9 +116,10 @@ The residual matrix entries form one orthonormal family on the disjoint union
 of the within-sector matrix spaces.  The equal-sector virtual bond projector
 is the sum of the sector bond projectors, extended by zero between unequal
 sectors.  Its two adjacent placements commute sectorwise, while every mixed
-product vanishes by the cross-sector residual-isometry equation.  Transport
-by the common physical isometry identifies this virtual projector with the
-canonical projector onto the two-site space of the direct sum.  Complementing
+product vanishes by orthogonality of the canonical summand inclusions.
+Transport by the common physical isometry identifies this virtual projector
+with the canonical projector onto the two-site space of the direct sum.
+Complementing
 and transporting the resulting three-site relation around the periodic chain
 proves
 \leanid{MPSTensor.IsBNTCanonicalForm.}


### PR DESCRIPTION
## Motivation

Closes #4436.

CPSV16 Theorem 3.10 gives the forward nearest-neighbor commuting-parent-Hamiltonian implication for a BNT renormalization fixed point. The multiplicity-one direct sum of the distinct BNT sectors already had the common residual-isometry and two-site support results, but lacked the equal-sector virtual projector and the commutation transport needed to derive `IsNNCPH`.

## Description

This PR proves exactly
```lean
theorem MPSTensor.IsBNTCanonicalForm.rfp_implies_nncph_basisDirectSum
    {P : SectorDecomposition d}
    (hCF : IsBNTCanonicalForm P)
    (hRFP : IsTransferIdempotent (directSumTensor P.basis))
    (N : ℕ) (hN : 2 < N) :
    IsNNCPH (directSumTensor P.basis) N
```

The proof:

- forms the equal-sector virtual bond projector on the disjoint union of the residual-pair spaces;
- uses the established single-sector Appendix B commutator for equal sectors;
- proves that mixed-sector products vanish from the residual-family orthogonality relation `U_jᴴ * U_k = 0`;
- transports the virtual projector through the common physical isometry and identifies it with the canonical projector onto the two-site direct-sum ground space;
- complements this support projector and transports the resulting three-site relation around every periodic chain with `N > 2`.

The theorem uses only `IsBNTCanonicalForm P`, transfer idempotence of `directSumTensor P.basis`, and `2 < N`. It introduces no comparison, crossing, repeated-copy, raw-weight, right-canonical, or externally supplied commutation hypothesis.

The source annotations cite arXiv:1606.00608, equations `III_CFI_RFP`, `eq:III_isometry`, (3.16)–(3.18), Theorem 3.10, and Appendix B. The blueprint and `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` now record precisely the multiplicity-one distinct-sector scope; repeated copies and arbitrary raw weights remain outside the statement.

## Validation

- `lake build TNLean.MPS.RFP.KroneckerTransport TNLean.MPS.RFP.AppendixBCommutation TNLean.MPS.RFP.ResidualFamilyCommutation`
- direct `lake env lean` checks of all three changed proof modules
- full `lake build` (9,711 jobs)
- `leanblueprint web`
- `leanblueprint checkdecls`
- blueprint–Lean synchronization check
- changed-file proof-integrity, reader-facing prose, line-length, whitespace, and tactic-pattern checks

No `sorry`, axiom, or kernel-bypass token is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean proofs and documentation with no runtime, auth, or data-path changes; scope is explicitly limited to multiplicity-one distinct sectors.
> 
> **Overview**
> Adds the **forward RFP ⇒ NNCPH commutation** result for a multiplicity-one direct sum of distinct BNT sectors: `IsBNTCanonicalForm.rfp_implies_nncph_basisDirectSum` (transfer idempotence and `N > 2` only; no extra commutation axioms).
> 
> **New `ResidualFamilyCommutation.lean`** builds the equal-sector virtual bond projector on the disjoint union of residual-pair spaces, proves adjacent pair matrices commute (single-sector Appendix B + mixed-sector zeros from orthogonal inclusions), transports through the common physical isometry to match `twoSiteBondSupportProjection`, then derives `IsNNCPH` via existing chain-commutation lemmas.
> 
> **Supporting matrix infrastructure:** `KroneckerTransport` gains sum laws for pair matrices and orthogonal mixed-summand vanishing; several `AppendixBCommutation` matrix lemmas are **exported** (no longer `private`) for reuse. **`twoSiteBondSupportProjection_idempotent`** is added in `ResidualFamilySupport`.
> 
> Blueprint theorem `thm:rfp_multiplicity_one_bnt_nncph` and `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` document the proved commutation clause and explicit multiplicity-one scope limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cfa3e2952a7d9789857e03b430f43cace2ac301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->