### PR TITLE
feat(MPS/MPDO): derive BNT multiplicity spectrum

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
+++ b/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
@@ -55,12 +55,17 @@ private lemma overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
       have hEq := congrArg (fun v : MPVSpace d N => v σ) (hState N)
       simpa [mpvState_apply, PiLp.smul_apply, smul_eq_mul] using hEq
 
-/-- A canonical-form phase class must occur among any basis of normal tensors
-spanning the same matrix product vectors.
+/-- Every sector of a full-support sector decomposition is represented in any
+basis of normal tensors for the same matrix product vectors.
 
-This is the forward implication of CPSV16, Proposition `prop:char-BNT`,
-lines 1135–1146. -/
-private theorem exists_phase_match_of_isCPSVBasisOfNormalTensors
+The nonzero copy weights make each sector coefficient nonzero infinitely
+often, excluding the unused-candidate counterexample to unrestricted BNT
+uniqueness.  This is the full-support direction used in the sector matching
+argument of CPSV16, Appendix A, lines 1135--1148 and 1182.
+
+Source: arXiv:1606.00608, Proposition 2.7 and Appendix A, lines 1135--1148
+and 1182 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem SectorDecomposition.exists_phase_match_of_isCPSVBasisOfNormalTensors
     {g : ℕ} {dimB : Fin g → ℕ} [∀ j, NeZero (dimB j)]
     {P : SectorDecomposition d} [∀ j, NeZero (P.basisDim j)]
     (B : (j : Fin g) → MPSTensor d (dimB j))
@@ -362,7 +367,7 @@ private theorem isCPSVBasisOfNormalTensors_iff_active_blocks_covered_and_minimal
       intro k
       obtain ⟨jClass, q, hEnum⟩ := classes.exists_enum_eq k
       obtain ⟨jBasis, hRepBasis⟩ :=
-        exists_phase_match_of_isCPSVBasisOfNormalTensors basis
+        P.exists_phase_match_of_isCPSVBasisOfNormalTensors basis
           hPNormal hPDistinct hBasisNormal hPBNT jClass
       have hBasisRep : MPVBlockPhaseEquiv (basis jBasis) (blocks (classes.repr jClass)) := by
         rw [← hPBasis jClass]

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
 import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.MPS.MPDO.BNTClosingSelection
 import TNLean.MPS.MPDO.BNTCoefficients

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean
@@ -174,8 +174,8 @@ structure BNTAlgebraTensorClause (M : MPOTensor d D) where
 
 namespace BNTAlgebraTensorClause
 
-/-- Forget the source BNT predicate carried by the tensor clause to the
-algebraic BNT predicate used by the vertical-canonical-form interface. -/
+/-- The source BNT predicate in the tensor clause entails the algebraic BNT
+predicate for its chosen vertical decomposition. -/
 theorem isBNT {M : MPOTensor d D} (H : BNTAlgebraTensorClause M) :
     MPSTensor.IsBNT (verticalTensor M) H.labelCount H.bondDim H.tensor :=
   H.isCPSVBNT.isBNT

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.BNT.Bridge
 import TNLean.MPS.MPDO.BNTTheoremData
 import TNLean.MPS.MPDO.VerticalCF
 
@@ -142,10 +143,11 @@ structure BNTAlgebraTensorClause (M : MPOTensor d D) where
 
   Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
   coisometry : verticalCoisometry * (verticalCoisometry)ᴴ = 1
-  /-- The chosen tensors form a basis of normal tensors of the vertical tensor.
+  /-- The chosen tensors form a CPSV16 basis of normal tensors of the vertical tensor.
 
   Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
-  isBNT : MPSTensor.IsBNT (verticalTensor M) labelCount bondDim tensor
+  isCPSVBNT : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+    (fun α ↦ ⟨bondDim α, tensor α⟩)
   /-- Conjugating the vertical tensor gives the weighted BNT direct sum.
 
   Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
@@ -171,6 +173,12 @@ structure BNTAlgebraTensorClause (M : MPOTensor d D) where
     (verticalBNTOperatorFamily tensor) (verticalBNTTraceScalarFamily weight)
 
 namespace BNTAlgebraTensorClause
+
+/-- Forget the source BNT predicate carried by the tensor clause to the
+algebraic BNT predicate used by the vertical-canonical-form interface. -/
+theorem isBNT {M : MPOTensor d D} (H : BNTAlgebraTensorClause M) :
+    MPSTensor.IsBNT (verticalTensor M) H.labelCount H.bondDim H.tensor :=
+  H.isCPSVBNT.isBNT
 
 /-- The chosen decomposition in a tensor-attached BNT algebra clause is a
 vertical canonical form of the underlying MPO tensor. -/

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -22,8 +22,8 @@ the algebra-to-RFP implication.
 * `MPOTensor.BNTAlgebraTensorClause.toTwoSiteMultiplicitySpectrum` derives a two-site
   vertical canonical decomposition, its sector relabelling, and the multiplicity-spectrum
   comparison directly from the tensor algebra clause.
-* `MPOTensor.BNTAlgebraTensorClause.toMultiplicitySpectrumComparison` forgets the
-  decomposition and retains the existing comparison interface.
+* `MPOTensor.BNTAlgebraTensorClause.toMultiplicitySpectrumComparison` retains the
+  resulting multiplicity-spectrum comparison alone.
 
 ## References
 
@@ -66,8 +66,8 @@ structure TwoSiteMultiplicitySpectrum {M : MPOTensor d D}
         H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
           H.algebraClause.positiveChi.chi.entry x.1 x.2.1 γ x.2.2.2.2
 
-/-- Forgetting the chosen two-site decomposition and relabelling gives the existing
-multiplicity-spectrum comparison interface.
+/-- The chosen two-site decomposition and relabelling determine the corresponding
+multiplicity-spectrum comparison.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -618,8 +618,8 @@ noncomputable def toTwoSiteMultiplicitySpectrum
         BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums] at hSpectrum
       convert hSpectrum using 1 <;> rfl }
 
-/-- The source-derived two-site multiplicity spectrum gives the existing comparison
-interface after forgetting its vertical decomposition and sector relabelling.
+/-- The source-derived two-site multiplicity spectrum entails the corresponding
+multiplicity-spectrum comparison.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -544,7 +544,6 @@ noncomputable def toTwoSiteMultiplicitySpectrum
     intro γ
     let L := max L₀ 1
     have hL : L₀ ≤ L := le_max_left _ _
-    have hLPos : 0 < L := lt_of_lt_of_le Nat.zero_lt_one (le_max_right _ _)
     have hCoeffL := hCoeffAfter L hL γ
     have hCoeffSucc := hCoeffAfter (L + 1) (by omega) γ
     have hCross : zeta γ *
@@ -561,7 +560,8 @@ noncomputable def toTwoSiteMultiplicitySpectrum
       mul_pos (hPCoeffPos γ (L + 1)) (hQCoeffPos (sigma γ) L)
     have hzetaPos : (0 : ℂ) < zeta γ := by
       apply pos_of_mul_pos_left
-      · rwa [hCross]
+      · rw [hCross]
+        exact hPositiveRight
       · exact hPositiveFactor.le
     obtain ⟨hzetaRePos, hzetaIm⟩ := Complex.pos_iff.mp hzetaPos
     have hzetaEqReal : ((zeta γ).re : ℂ) = zeta γ :=

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -17,6 +17,11 @@ blocking.  The same-length product law identifies the sectorwise power sums,
 and positivity turns them into the multiplicity-spectrum comparison used in
 the algebra-to-RFP implication.
 
+## Main results
+
+* `MPOTensor.BNTAlgebraTensorClause.toMultiplicitySpectrumComparison` derives the
+  two-site multiplicity-spectrum comparison directly from the tensor algebra clause.
+
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -1,0 +1,554 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.BNTUniqueness
+import TNLean.MPS.MPDO.BNTMultiplicityNormalization
+import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
+import TNLean.MPS.MPDO.VerticalBlockedOperatorRepresentations
+
+/-!
+# The two-site multiplicity spectrum from the BNT algebra clause
+
+This file compares the chosen one-site vertical basis in a tensor-attached
+BNT algebra clause with a vertical canonical decomposition of the two-site
+blocking.  The same-length product law identifies the sectorwise power sums,
+and positivity turns them into the multiplicity-spectrum comparison used in
+the algebra-to-RFP implication.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+open Filter
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause
+
+/-- The tensor-attached BNT algebra clause determines the multiplicity
+spectrum of a source-derived two-site vertical canonical decomposition.
+
+The chosen one-site tensors and multiplicity entries are exactly those stored
+in `H`.  No renormalization maps or pre-existing one-site/two-site sector
+correspondence are assumed: full support of the two positive vertical
+decompositions derives the sector relabelling, and eventual BNT linear
+independence derives the power-sum equality.
+
+Source: arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
+of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def toMultiplicitySpectrumComparison
+    {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    BNTMultiplicitySpectrumComparison H.algebraClause.positiveChi.chi
+      H.traceScalars := by
+  classical
+  let chi := H.algebraClause.positiveChi.chi
+  let productIndex (γ : Fin H.labelCount) :=
+    BNTProductMultiplicityIndex chi H.multiplicity γ
+  let productEquiv (γ : Fin H.labelCount) :
+      Fin (Fintype.card (productIndex γ)) ≃ productIndex γ :=
+    (Fintype.equivFin (productIndex γ)).symm
+  let productDim (γ : Fin H.labelCount) :=
+    Fintype.card (productIndex γ)
+  let productEntry : ∀ γ : Fin H.labelCount, Fin (productDim γ) → ℂ :=
+    fun γ r ↦
+      let x := productEquiv γ r
+      H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+        chi.entry x.1 x.2.1 γ x.2.2.2.2
+  have hProductPos : ∀ γ r, (0 : ℂ) < productEntry γ r := by
+    intro γ r
+    exact mul_pos
+      (mul_pos (H.weight_pos _ _) (H.weight_pos _ _))
+      (H.algebraClause.positiveChi.posEntries _ _ _ _)
+  have hProductSum : ∀ γ, ∑ r, productEntry γ r =
+      H.traceScalars.traceScalar γ := by
+    intro γ
+    change (∑ r, productEntry γ r) =
+      (verticalBNTTraceScalarFamily H.weight).traceScalar γ
+    rw [H.algebraClause.idempotent_coefficient_form_ofChi γ]
+    simp only [BNTLabelCoefficientFamily.ofChi_coeff]
+    change (∑ r, productEntry γ r) =
+      ∑ α, ∑ β, chi.tracePowerCoeff α β γ 1 *
+        ((∑ q, H.weight α q) * ∑ r, H.weight β r)
+    rw [show (∑ r, productEntry γ r) =
+        ∑ x : productIndex γ,
+          H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+            chi.entry x.1 x.2.1 γ x.2.2.2.2 by
+      exact productEquiv γ |>.sum_comp
+        (fun x : productIndex γ ↦
+          H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+            chi.entry x.1 x.2.1 γ x.2.2.2.2)]
+    simp only [productIndex, BNTProductMultiplicityIndex,
+      Fintype.sum_sigma, Fintype.sum_prod_type,
+      DiagonalChiFamily.tracePowerCoeff, pow_one]
+    apply Finset.sum_congr rfl
+    intro α _
+    apply Finset.sum_congr rfl
+    intro β _
+    simp only [← Finset.mul_sum, ← Finset.sum_mul, mul_assoc]
+    ring
+  have hProductDimPos : ∀ γ, 0 < productDim γ := by
+    intro γ
+    by_contra h
+    have hzero : productDim γ = 0 := Nat.eq_zero_of_not_pos h
+    have hsumZero : ∑ r, productEntry γ r = 0 := by
+      haveI : IsEmpty (Fin (productDim γ)) :=
+        Fintype.card_eq_zero_iff.mp (by simpa using hzero)
+      exact Finset.sum_eq_zero fun r _ ↦ isEmptyElim r
+    have hTracePos :
+        (0 : ℂ) < H.traceScalars.traceScalar γ := by
+      change (0 : ℂ) < verticalMultiplicityTrace H.weight γ
+      exact verticalMultiplicityTrace_pos H.multiplicity_pos H.weight_pos γ
+    exact hTracePos.ne' ((hProductSum γ).symm.trans hsumZero)
+  let P : MPSTensor.SectorDecomposition (D * D) := {
+    basisCount := H.labelCount
+    basisDim := H.bondDim
+    basis := H.tensor
+    sectors := {
+      copies := productDim
+      copies_pos := hProductDimPos
+      weight := productEntry
+      weight_ne_zero := fun γ r ↦ (hProductPos γ r).ne' }
+  }
+  have hBlockedExpansion : ∀ (L : ℕ), 0 < L →
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+        ∑ γ, P.coeff L γ • mpo (verticalBNTMPO (H.tensor γ)) L := by
+    intro L hL
+    have hOne := mpo_verticalBNTMPO_eq_sum_of_coisometry_reconstruction
+      H.weight H.tensor (verticalTensor M) H.verticalCoisometry
+      H.coisometry H.reconstruction hL
+    have hSecond :
+        mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+          ∑ α, ∑ β,
+            ((∑ q, H.weight α q ^ L) * (∑ r, H.weight β r ^ L)) •
+              (mpo (verticalBNTMPO (H.tensor α)) L *
+                mpo (verticalBNTMPO (H.tensor β)) L) := by
+      rw [verticalBNTMPO_verticalTensor_blockTwo, mpo_mulTensor, hOne]
+      rw [Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro α _
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro β _
+      rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+    have hProduct (α β : Fin H.labelCount) :
+        mpo (verticalBNTMPO (H.tensor α)) L *
+            mpo (verticalBNTMPO (H.tensor β)) L =
+          ∑ γ, chi.tracePowerCoeff α β γ L •
+            mpo (verticalBNTMPO (H.tensor γ)) L := by
+      change H.operators.operator L α * H.operators.operator L β =
+        ∑ γ, chi.tracePowerCoeff α β γ L • H.operators.operator L γ
+      simpa only [chi, BNTLabelCoefficientFamily.ofChi_coeff,
+        BNTAlgebraTensorClause.operators,
+        ← H.algebraClause.positiveChi.tracePower L hL] using
+          H.algebraClause.sameLengthProduct L hL α β
+    rw [hSecond]
+    simp_rw [hProduct, Finset.smul_sum, smul_smul]
+    calc
+      (∑ α, ∑ β, ∑ γ,
+          (((∑ q, H.weight α q ^ L) *
+            (∑ r, H.weight β r ^ L)) *
+            chi.tracePowerCoeff α β γ L) •
+              mpo (verticalBNTMPO (H.tensor γ)) L) =
+          ∑ α, ∑ γ, ∑ β,
+            (((∑ q, H.weight α q ^ L) *
+              (∑ r, H.weight β r ^ L)) *
+              chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (H.tensor γ)) L := by
+        apply Finset.sum_congr rfl
+        intro α _
+        rw [Finset.sum_comm]
+      _ = ∑ γ, ∑ α, ∑ β,
+            (((∑ q, H.weight α q ^ L) *
+              (∑ r, H.weight β r ^ L)) *
+              chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (H.tensor γ)) L := by
+        rw [Finset.sum_comm]
+      _ = ∑ γ, (∑ α, ∑ β,
+            ((∑ q, H.weight α q ^ L) *
+              (∑ r, H.weight β r ^ L)) *
+              chi.tracePowerCoeff α β γ L) •
+                mpo (verticalBNTMPO (H.tensor γ)) L := by
+        apply Finset.sum_congr rfl
+        intro γ _
+        symm
+        calc
+          (∑ α, ∑ β,
+              ((∑ q, H.weight α q ^ L) *
+                (∑ r, H.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L) •
+              mpo (verticalBNTMPO (H.tensor γ)) L =
+            ∑ α, (∑ β,
+              ((∑ q, H.weight α q ^ L) *
+                (∑ r, H.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L) •
+              mpo (verticalBNTMPO (H.tensor γ)) L := by
+                exact map_sum
+                  ((smulAddHom ℂ
+                    (Matrix (Fin L → Fin D) (Fin L → Fin D) ℂ)).flip
+                      (mpo (verticalBNTMPO (H.tensor γ)) L))
+                  (fun α ↦ ∑ β,
+                    ((∑ q, H.weight α q ^ L) *
+                      (∑ r, H.weight β r ^ L)) *
+                      chi.tracePowerCoeff α β γ L)
+                  Finset.univ
+          _ = ∑ α, ∑ β,
+              (((∑ q, H.weight α q ^ L) *
+                (∑ r, H.weight β r ^ L)) *
+                chi.tracePowerCoeff α β γ L) •
+              mpo (verticalBNTMPO (H.tensor γ)) L := by
+                apply Finset.sum_congr rfl
+                intro α _
+                exact map_sum
+                  ((smulAddHom ℂ
+                    (Matrix (Fin L → Fin D) (Fin L → Fin D) ℂ)).flip
+                      (mpo (verticalBNTMPO (H.tensor γ)) L))
+                  (fun β ↦ ((∑ q, H.weight α q ^ L) *
+                    (∑ r, H.weight β r ^ L)) *
+                    chi.tracePowerCoeff α β γ L)
+                  Finset.univ
+      _ = ∑ γ, P.coeff L γ •
+            mpo (verticalBNTMPO (H.tensor γ)) L := by
+        apply Finset.sum_congr rfl
+        intro γ _
+        congr 1
+        change (∑ α, ∑ β,
+            ((∑ q, H.weight α q ^ L) *
+              (∑ r, H.weight β r ^ L)) *
+              chi.tracePowerCoeff α β γ L) =
+          ∑ r, productEntry γ r ^ L
+        rw [show (∑ r, productEntry γ r ^ L) =
+            ∑ x : productIndex γ,
+              (H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+                chi.entry x.1 x.2.1 γ x.2.2.2.2) ^ L by
+          exact productEquiv γ |>.sum_comp
+            (fun x : productIndex γ ↦
+              (H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+                chi.entry x.1 x.2.1 γ x.2.2.2.2) ^ L)]
+        simp only [productIndex, BNTProductMultiplicityIndex,
+          Fintype.sum_sigma, Fintype.sum_prod_type,
+          DiagonalChiFamily.tracePowerCoeff, mul_pow]
+        apply Finset.sum_congr rfl
+        intro α _
+        apply Finset.sum_congr rfl
+        intro β _
+        rw [mul_assoc, Fintype.sum_mul_sum, Fintype.sum_mul_sum]
+        apply Finset.sum_congr rfl
+        intro q _
+        apply Finset.sum_congr rfl
+        intro r _
+        rw [Finset.mul_sum]
+        ring_nf
+  have hPBlocked : MPSTensor.SameMPV₂Pos
+      (verticalTensor (blockTwo M)) P.toTensor := by
+    intro L hL σ
+    let ket : Fin L → Fin D := fun l ↦ (finProdFinEquiv.symm (σ l)).1
+    let bra : Fin L → Fin D := fun l ↦ (finProdFinEquiv.symm (σ l)).2
+    have hEntry := congrFun (congrFun (hBlockedExpansion L hL) ket) bra
+    rw [← MPSTensor.mpv_toMPSTensor_pairConfig
+        (verticalBNTMPO (verticalTensor (blockTwo M))) ket bra]
+      at hEntry
+    simp only [verticalBNTMPO_toMPSTensor, Matrix.sum_apply,
+      Matrix.smul_apply, ← MPSTensor.mpv_toMPSTensor_pairConfig,
+      smul_eq_mul] at hEntry
+    have hPair : (fun l ↦ finProdFinEquiv (ket l, bra l)) = σ := by
+      funext l
+      exact finProdFinEquiv.apply_symm_apply (σ l)
+    rw [hPair] at hEntry
+    exact hEntry.trans (P.mpv_toTensor_eq_sum_coeff σ).symm
+  let D₂ : CPSVVerticalDecomposition (blockTwo M) := Classical.choice
+    (hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
+      (blockTwo M) hM.blockTwo)
+  let Q : MPSTensor.SectorDecomposition (D * D) := {
+    basisCount := D₂.labelCount
+    basisDim := D₂.bondDim
+    basis := D₂.tensor
+    sectors := {
+      copies := D₂.multiplicity
+      copies_pos := D₂.multiplicity_pos
+      weight := D₂.weight
+      weight_ne_zero := fun γ r ↦ (D₂.weight_pos γ r).ne' }
+  }
+  have hQAssembly : MPSTensor.SameMPV₂Pos Q.toTensor
+      (verticalAssembledTensor D₂.bondDim D₂.multiplicity
+        D₂.weight D₂.tensor) := by
+    apply sameMPV₂Pos_toTensorFromBlocks_verticalAssembledTensor_of_equiv
+      Q.flatWeight Q.flatBasis D₂.multiplicity D₂.weight D₂.tensor
+      Q.flatIndexEquiv.symm
+    · intro k
+      rfl
+    · intro k N hN σ
+      rfl
+  have hQBlocked : MPSTensor.SameMPV₂Pos
+      (verticalTensor (blockTwo M)) Q.toTensor :=
+    (MPSTensor.sameMPV₂Pos_of_coisometry_reconstruction
+      (verticalTensor (blockTwo M))
+      (verticalAssembledTensor D₂.bondDim D₂.multiplicity
+        D₂.weight D₂.tensor)
+      D₂.verticalCoisometry D₂.coisometry D₂.reconstruction).trans
+        hQAssembly.symm
+  have hPBNT : MPSTensor.IsCPSVBasisOfNormalTensors P.toTensor
+      (fun γ ↦ ⟨H.bondDim γ, H.tensor γ⟩) := {
+    blocks_normal := H.isCPSVBNT.blocks_normal
+    spans_mpv := fun L _ ↦
+      ⟨P.coeff L, fun σ ↦ P.mpv_toTensor_eq_sum_coeff σ⟩
+    eventually_li := H.isCPSVBNT.eventually_li
+  }
+  have hD₂BNTOnP : MPSTensor.IsCPSVBasisOfNormalTensors P.toTensor
+      (fun δ ↦ ⟨D₂.bondDim δ, D₂.tensor δ⟩) :=
+    D₂.isCPSVBNT.of_sameMPV₂Pos hPBlocked
+  have hHBNTOnQ : MPSTensor.IsCPSVBasisOfNormalTensors Q.toTensor
+      (fun γ ↦ ⟨H.bondDim γ, H.tensor γ⟩) :=
+    hPBNT.of_sameMPV₂Pos (hPBlocked.symm.trans hQBlocked)
+  letI : ∀ γ, NeZero (H.bondDim γ) := fun γ ↦
+    ⟨(H.isCPSVBNT.blocks_dim_pos γ).ne'⟩
+  letI : ∀ δ, NeZero (D₂.bondDim δ) := fun δ ↦
+    ⟨(D₂.isCPSVBNT.blocks_dim_pos δ).ne'⟩
+  have hForwardMatch : ∀ γ : Fin H.labelCount,
+      ∃ δ : Fin D₂.labelCount,
+        MPSTensor.MPVBlockPhaseEquiv (H.tensor γ) (D₂.tensor δ) := by
+    intro γ
+    exact P.exists_phase_match_of_isCPSVBasisOfNormalTensors
+      D₂.tensor H.isCPSVBNT.blocks_normal
+      H.isCPSVBNT.blocks_not_gaugePhaseEquiv
+      D₂.isCPSVBNT.blocks_normal hD₂BNTOnP γ
+  have hReverseMatch : ∀ δ : Fin D₂.labelCount,
+      ∃ γ : Fin H.labelCount,
+        MPSTensor.MPVBlockPhaseEquiv (D₂.tensor δ) (H.tensor γ) := by
+    intro δ
+    exact Q.exists_phase_match_of_isCPSVBasisOfNormalTensors
+      H.tensor D₂.isCPSVBNT.blocks_normal
+      D₂.isCPSVBNT.blocks_not_gaugePhaseEquiv
+      H.isCPSVBNT.blocks_normal hHBNTOnQ δ
+  choose f hfPhase using hForwardMatch
+  choose q hqPhase using hReverseMatch
+  have hfInjective : Function.Injective f := by
+    intro γ₁ γ₂ hEq
+    by_contra hNe
+    have h₂ : MPSTensor.MPVBlockPhaseEquiv
+        (H.tensor γ₂) (D₂.tensor (f γ₁)) := by
+      rw [hEq]
+      exact hfPhase γ₂
+    have hPhase := (hfPhase γ₁).trans h₂.symm
+    obtain ⟨hDim, hGauge⟩ :=
+      hPhase.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (H.isCPSVBNT.blocks_normal γ₁) (H.isCPSVBNT.blocks_normal γ₂)
+    exact H.isCPSVBNT.blocks_not_gaugePhaseEquiv γ₁ γ₂ hNe hDim hGauge
+  have hqInjective : Function.Injective q := by
+    intro δ₁ δ₂ hEq
+    by_contra hNe
+    have h₂ : MPSTensor.MPVBlockPhaseEquiv
+        (D₂.tensor δ₂) (H.tensor (q δ₁)) := by
+      rw [hEq]
+      exact hqPhase δ₂
+    have hPhase := (hqPhase δ₁).trans h₂.symm
+    obtain ⟨hDim, hGauge⟩ :=
+      hPhase.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (D₂.isCPSVBNT.blocks_normal δ₁) (D₂.isCPSVBNT.blocks_normal δ₂)
+    exact D₂.isCPSVBNT.blocks_not_gaugePhaseEquiv δ₁ δ₂ hNe hDim hGauge
+  have hCard : Fintype.card (Fin H.labelCount) =
+      Fintype.card (Fin D₂.labelCount) :=
+    Nat.le_antisymm (Fintype.card_le_of_injective f hfInjective)
+      (Fintype.card_le_of_injective q hqInjective)
+  have hfBijective : Function.Bijective f :=
+    (Fintype.bijective_iff_injective_and_card f).2 ⟨hfInjective, hCard⟩
+  let sigma : Fin H.labelCount ≃ Fin D₂.labelCount :=
+    Equiv.ofBijective f hfBijective
+  choose zeta hzetaNe hzetaMPV using fun γ ↦ hfPhase γ
+  have hzetaNorm : ∀ γ, ‖zeta γ‖ = 1 := by
+    intro γ
+    have hHH : Tendsto
+        (fun N ↦ ‖MPSTensor.mpvOverlap (d := D * D)
+          (H.tensor γ) (H.tensor γ) N‖) atTop (nhds (1 : ℝ)) := by
+      simpa using (H.isCPSVBNT.blocks_normal γ).selfOverlap_tendsto_one.norm
+    have hDD : Tendsto
+        (fun N ↦ ‖MPSTensor.mpvOverlap (d := D * D)
+          (D₂.tensor (f γ)) (D₂.tensor (f γ)) N‖)
+        atTop (nhds (1 : ℝ)) := by
+      simpa using
+        (D₂.isCPSVBNT.blocks_normal (f γ)).selfOverlap_tendsto_one.norm
+    exact MPSTensor.norm_eq_one_of_selfOverlap_scale_pos hHH hDD
+      (MPSTensor.mpvOverlap_self_scale_of_mpv_eq_pow_mul_pos
+        (hzetaMPV γ))
+  let a : ℕ → Fin H.labelCount → ℂ := fun L γ ↦ P.coeff L γ
+  let b : ℕ → Fin H.labelCount → ℂ := fun L γ ↦
+    zeta γ ^ L * Q.coeff L (sigma γ)
+  have hLI : ∀ᶠ L in atTop,
+      LinearIndependent ℂ
+        (fun γ : Fin H.labelCount ↦
+          MPSTensor.mpvState (d := D * D) (H.tensor γ) L) := by
+    obtain ⟨L₀, hL₀⟩ := H.isCPSVBNT.eventually_li
+    exact Filter.eventually_atTop.mpr
+      ⟨L₀ + 1, fun L hL ↦ hL₀ L (by omega)⟩
+  have hStateExpansionEq : ∀ᶠ L in atTop,
+      ∑ γ : Fin H.labelCount,
+          a L γ • MPSTensor.mpvState (d := D * D) (H.tensor γ) L =
+        ∑ γ : Fin H.labelCount,
+          b L γ • MPSTensor.mpvState (d := D * D) (H.tensor γ) L := by
+    refine Filter.eventually_atTop.mpr ⟨1, ?_⟩
+    intro L hL
+    have hLPos : 0 < L := Nat.zero_lt_of_lt hL
+    have hPState : MPSTensor.mpvState (d := D * D) P.toTensor L =
+        ∑ γ : Fin H.labelCount, P.coeff L γ •
+          MPSTensor.mpvState (d := D * D) (H.tensor γ) L := by
+      refine MPSTensor.mpvState_eq_sum_of_decomp (d := D * D)
+        P.toTensor H.tensor (N := L) (P.coeff L) ?_
+      intro σ
+      simpa [smul_eq_mul] using P.mpv_toTensor_eq_sum_coeff σ
+    have hQState : MPSTensor.mpvState (d := D * D) Q.toTensor L =
+        ∑ δ : Fin D₂.labelCount, Q.coeff L δ •
+          MPSTensor.mpvState (d := D * D) (D₂.tensor δ) L := by
+      refine MPSTensor.mpvState_eq_sum_of_decomp (d := D * D)
+        Q.toTensor D₂.tensor (N := L) (Q.coeff L) ?_
+      intro σ
+      simpa [smul_eq_mul] using Q.mpv_toTensor_eq_sum_coeff σ
+    have hPQState : MPSTensor.mpvState (d := D * D) P.toTensor L =
+        MPSTensor.mpvState (d := D * D) Q.toTensor L := by
+      apply PiLp.ext
+      intro σ
+      simpa [MPSTensor.mpvState_apply] using
+        (hPBlocked.symm.trans hQBlocked) L hLPos σ
+    have hQSubst :
+        (∑ δ : Fin D₂.labelCount, Q.coeff L δ •
+            MPSTensor.mpvState (d := D * D) (D₂.tensor δ) L) =
+          ∑ γ : Fin H.labelCount,
+            (zeta γ ^ L * Q.coeff L (sigma γ)) •
+              MPSTensor.mpvState (d := D * D) (H.tensor γ) L := by
+      calc
+        (∑ δ : Fin D₂.labelCount, Q.coeff L δ •
+            MPSTensor.mpvState (d := D * D) (D₂.tensor δ) L) =
+          ∑ δ : Fin D₂.labelCount,
+            (zeta (sigma.symm δ) ^ L * Q.coeff L δ) •
+              MPSTensor.mpvState (d := D * D)
+                (H.tensor (sigma.symm δ)) L := by
+            apply Finset.sum_congr rfl
+            intro δ _
+            have hMpvState : MPSTensor.mpvState (d := D * D)
+                (D₂.tensor δ) L =
+              zeta (sigma.symm δ) ^ L •
+                MPSTensor.mpvState (d := D * D)
+                  (H.tensor (sigma.symm δ)) L := by
+              apply PiLp.ext
+              intro σ
+              have hMpv := hzetaMPV (sigma.symm δ) L hLPos σ
+              have hfδ : f (sigma.symm δ) = δ :=
+                sigma.apply_symm_apply δ
+              rw [hfδ] at hMpv
+              simpa only [MPSTensor.mpvState_apply, PiLp.smul_apply,
+                smul_eq_mul] using hMpv
+            rw [hMpvState, smul_smul]
+            congr 1
+            ring
+        _ = ∑ γ : Fin H.labelCount,
+            (zeta γ ^ L * Q.coeff L (sigma γ)) •
+              MPSTensor.mpvState (d := D * D) (H.tensor γ) L := by
+            simpa only [Equiv.apply_symm_apply] using
+              (Equiv.sum_comp sigma.symm
+                (fun γ : Fin H.labelCount ↦
+                  (zeta γ ^ L * Q.coeff L (sigma γ)) •
+                    MPSTensor.mpvState (d := D * D) (H.tensor γ) L))
+    calc
+      ∑ γ, a L γ • MPSTensor.mpvState (d := D * D) (H.tensor γ) L =
+          MPSTensor.mpvState (d := D * D) P.toTensor L := by
+        simpa [a] using hPState.symm
+      _ = MPSTensor.mpvState (d := D * D) Q.toTensor L := hPQState
+      _ = ∑ δ, Q.coeff L δ •
+          MPSTensor.mpvState (d := D * D) (D₂.tensor δ) L := hQState
+      _ = ∑ γ, b L γ •
+          MPSTensor.mpvState (d := D * D) (H.tensor γ) L := by
+        simpa [b] using hQSubst
+  have hCoeff : ∀ᶠ L in atTop, ∀ γ : Fin H.labelCount,
+      a L γ = b L γ := by
+    exact MPSTensor.coefficient_eventually_eq_of_eventually_linearIndependent
+      (v := fun L γ ↦ MPSTensor.mpvState (d := D * D) (H.tensor γ) L)
+      (a := a) (b := b) hLI hStateExpansionEq
+  let hCoeffWitness := Filter.eventually_atTop.mp hCoeff
+  let L₀ := Classical.choose hCoeffWitness
+  have hCoeffAfter : ∀ L, L₀ ≤ L → ∀ γ : Fin H.labelCount,
+      a L γ = b L γ := Classical.choose_spec hCoeffWitness
+  have hPCoeffPos : ∀ γ L, (0 : ℂ) < P.coeff L γ := by
+    intro γ L
+    change (0 : ℂ) < ∑ r, productEntry γ r ^ L
+    apply Finset.sum_pos
+    · intro r _
+      exact pow_pos (hProductPos γ r) L
+    · exact Finset.univ_nonempty_iff.mpr
+        ⟨⟨0, hProductDimPos γ⟩⟩
+  have hQCoeffPos : ∀ δ L, (0 : ℂ) < Q.coeff L δ := by
+    intro δ L
+    change (0 : ℂ) < ∑ r, D₂.weight δ r ^ L
+    apply Finset.sum_pos
+    · intro r _
+      exact pow_pos (D₂.weight_pos δ r) L
+    · exact Finset.univ_nonempty_iff.mpr
+        ⟨⟨0, D₂.multiplicity_pos δ⟩⟩
+  have hzetaOne : ∀ γ, zeta γ = 1 := by
+    intro γ
+    let L := max L₀ 1
+    have hL : L₀ ≤ L := le_max_left _ _
+    have hLPos : 0 < L := lt_of_lt_of_le Nat.zero_lt_one (le_max_right _ _)
+    have hCoeffL := hCoeffAfter L hL γ
+    have hCoeffSucc := hCoeffAfter (L + 1) (by omega) γ
+    have hCross : zeta γ *
+        (P.coeff L γ * Q.coeff (L + 1) (sigma γ)) =
+      P.coeff (L + 1) γ * Q.coeff L (sigma γ) := by
+      dsimp only [a, b] at hCoeffL hCoeffSucc
+      rw [hCoeffL, hCoeffSucc]
+      ring
+    have hPositiveFactor : (0 : ℂ) <
+        P.coeff L γ * Q.coeff (L + 1) (sigma γ) :=
+      mul_pos (hPCoeffPos γ L) (hQCoeffPos (sigma γ) (L + 1))
+    have hPositiveRight : (0 : ℂ) <
+        P.coeff (L + 1) γ * Q.coeff L (sigma γ) :=
+      mul_pos (hPCoeffPos γ (L + 1)) (hQCoeffPos (sigma γ) L)
+    have hzetaPos : (0 : ℂ) < zeta γ := by
+      apply pos_of_mul_pos_left
+      · rwa [hCross]
+      · exact hPositiveFactor.le
+    obtain ⟨hzetaRePos, hzetaIm⟩ := Complex.pos_iff.mp hzetaPos
+    have hzetaEqReal : ((zeta γ).re : ℂ) = zeta γ :=
+      Complex.ext (Complex.ofReal_re (zeta γ).re)
+        (by rw [Complex.ofReal_im]; exact hzetaIm)
+    have hRealOne : (zeta γ).re = 1 := by
+      have hNorm := hzetaNorm γ
+      rw [← hzetaEqReal, Complex.norm_real,
+        Real.norm_of_nonneg hzetaRePos.le] at hNorm
+      exact hNorm
+    rw [← hzetaEqReal, hRealOne]
+    norm_num
+  have hPowerSums : ∀ γ : Fin H.labelCount, ∀ L : ℕ, L₀ < L →
+      (∑ r, D₂.weight (sigma γ) r ^ L) =
+        ∑ x : BNTProductMultiplicityIndex chi H.multiplicity γ,
+          (H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+            chi.entry x.1 x.2.1 γ x.2.2.2.2) ^ L := by
+    intro γ L hL
+    have hCoeffL := hCoeffAfter L (le_of_lt hL) γ
+    dsimp only [a, b] at hCoeffL
+    rw [hzetaOne γ, one_pow, one_mul] at hCoeffL
+    change (∑ r, productEntry γ r ^ L) =
+      (∑ r, D₂.weight (sigma γ) r ^ L) at hCoeffL
+    rw [← hCoeffL]
+    exact productEquiv γ |>.sum_comp
+      (fun x : productIndex γ ↦
+        (H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+          chi.entry x.1 x.2.1 γ x.2.2.2.2) ^ L)
+  simpa only [chi] using
+    (BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums
+      chi H.traceScalars H.algebraClause.positiveChi.posEntries
+      H.multiplicity H.weight H.weight_pos
+      (fun α ↦ (BNTAlgebraTensorClause.traceScalars_traceScalar H α).symm)
+      (fun γ ↦ D₂.multiplicity (sigma γ))
+      (fun γ r ↦ D₂.weight (sigma γ) r)
+      (fun γ r ↦ D₂.weight_pos (sigma γ) r)
+      hPowerSums)
+
+end BNTAlgebraTensorClause
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -19,8 +19,11 @@ the algebra-to-RFP implication.
 
 ## Main results
 
-* `MPOTensor.BNTAlgebraTensorClause.toMultiplicitySpectrumComparison` derives the
-  two-site multiplicity-spectrum comparison directly from the tensor algebra clause.
+* `MPOTensor.BNTAlgebraTensorClause.toTwoSiteMultiplicitySpectrum` derives a two-site
+  vertical canonical decomposition, its sector relabelling, and the multiplicity-spectrum
+  comparison directly from the tensor algebra clause.
+* `MPOTensor.BNTAlgebraTensorClause.toMultiplicitySpectrumComparison` forgets the
+  decomposition and retains the existing comparison interface.
 
 ## References
 
@@ -37,6 +40,50 @@ namespace MPOTensor
 
 namespace BNTAlgebraTensorClause
 
+/-- A source-derived two-site vertical canonical decomposition together with the
+sector relabelling and multiplicity-spectrum equality of Appendix C.4.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure TwoSiteMultiplicitySpectrum {M : MPOTensor d D}
+    (H : BNTAlgebraTensorClause M) where
+  /-- The vertical canonical decomposition of the two-site blocking from
+  arXiv:1606.00608, Appendix C.4, lines 2046--2049. -/
+  decomposition : CPSVVerticalDecomposition (blockTwo M)
+  /-- The bijection matching the one-site product sectors with the two-site sectors from
+  arXiv:1606.00608, Appendix C.4, lines 2050--2054. -/
+  relabel : Fin H.labelCount ≃ Fin decomposition.labelCount
+  /-- The matched one-site and two-site tensors generate the same positive-length matrix
+  product vectors, as in arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
+  sector_sameMPV : ∀ γ : Fin H.labelCount,
+    MPSTensor.SameMPV₂Pos (H.tensor γ) (decomposition.tensor (relabel γ))
+  /-- Equality with multiplicity between the matched two-site weights and the products of
+  one-site and chi weights from arXiv:1606.00608, Appendix C.4, lines 2054--2058. -/
+  spectrum_eq : ∀ γ : Fin H.labelCount,
+    Finset.univ.val.map (decomposition.weight (relabel γ)) =
+      Finset.univ.val.map fun x : BNTProductMultiplicityIndex
+          H.algebraClause.positiveChi.chi H.multiplicity γ =>
+        H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
+          H.algebraClause.positiveChi.chi.entry x.1 x.2.1 γ x.2.2.2.2
+
+/-- Forgetting the chosen two-site decomposition and relabelling gives the existing
+multiplicity-spectrum comparison interface.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def TwoSiteMultiplicitySpectrum.toComparison
+    {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+    (S : TwoSiteMultiplicitySpectrum H) :
+    BNTMultiplicitySpectrumComparison H.algebraClause.positiveChi.chi
+      H.traceScalars where
+  oneDim := H.multiplicity
+  oneEntry := H.weight
+  oneTrace := fun α =>
+    (BNTAlgebraTensorClause.traceScalars_traceScalar H α).symm
+  twoDim := fun γ => S.decomposition.multiplicity (S.relabel γ)
+  twoEntry := fun γ => S.decomposition.weight (S.relabel γ)
+  spectrum_eq := S.spectrum_eq
+
 /-- The tensor-attached BNT algebra clause determines the multiplicity
 spectrum of a source-derived two-site vertical canonical decomposition.
 
@@ -48,11 +95,10 @@ independence derives the power-sum equality.
 
 Source: arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-noncomputable def toMultiplicitySpectrumComparison
+noncomputable def toTwoSiteMultiplicitySpectrum
     {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
     (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
-    BNTMultiplicitySpectrumComparison H.algebraClause.positiveChi.chi
-      H.traceScalars := by
+    TwoSiteMultiplicitySpectrum H := by
   classical
   let chi := H.algebraClause.positiveChi.chi
   let productIndex (γ : Fin H.labelCount) :=
@@ -528,6 +574,14 @@ noncomputable def toMultiplicitySpectrumComparison
       exact hNorm
     rw [← hzetaEqReal, hRealOne]
     norm_num
+  have hSectorSameMPV : ∀ γ : Fin H.labelCount,
+      MPSTensor.SameMPV₂Pos (H.tensor γ) (D₂.tensor (sigma γ)) := by
+    intro γ L hL σ
+    have hMpv := hzetaMPV γ L hL σ
+    change (D₂.tensor (sigma γ)).mpv σ =
+      zeta γ ^ L * (H.tensor γ).mpv σ at hMpv
+    rw [hzetaOne γ, one_pow, one_mul] at hMpv
+    exact hMpv.symm
   have hPowerSums : ∀ γ : Fin H.labelCount, ∀ L : ℕ, L₀ < L →
       (∑ r, D₂.weight (sigma γ) r ^ L) =
         ∑ x : BNTProductMultiplicityIndex chi H.multiplicity γ,
@@ -544,15 +598,37 @@ noncomputable def toMultiplicitySpectrumComparison
       (fun x : productIndex γ ↦
         (H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
           chi.entry x.1 x.2.1 γ x.2.2.2.2) ^ L)
-  simpa only [chi] using
-    (BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums
+  let comparison :=
+    BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums
       chi H.traceScalars H.algebraClause.positiveChi.posEntries
       H.multiplicity H.weight H.weight_pos
       (fun α ↦ (BNTAlgebraTensorClause.traceScalars_traceScalar H α).symm)
       (fun γ ↦ D₂.multiplicity (sigma γ))
       (fun γ r ↦ D₂.weight (sigma γ) r)
       (fun γ r ↦ D₂.weight_pos (sigma γ) r)
-      hPowerSums)
+      hPowerSums
+  exact {
+    decomposition := D₂
+    relabel := sigma
+    sector_sameMPV := hSectorSameMPV
+    spectrum_eq := by
+      intro γ
+      have hSpectrum := comparison.spectrum_eq γ
+      dsimp only [comparison,
+        BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums] at hSpectrum
+      convert hSpectrum using 1 <;> rfl }
+
+/-- The source-derived two-site multiplicity spectrum gives the existing comparison
+interface after forgetting its vertical decomposition and sector relabelling.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def toMultiplicitySpectrumComparison
+    {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    BNTMultiplicitySpectrumComparison H.algebraClause.positiveChi.chi
+      H.traceScalars :=
+  (H.toTwoSiteMultiplicitySpectrum hHorizontal hM).toComparison
 
 end BNTAlgebraTensorClause
 

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -90,10 +90,11 @@ structure BNTFusionTensorClause (M : MPOTensor d D) where
 
   Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
   coisometry : verticalCoisometry * (verticalCoisometry)ᴴ = 1
-  /-- The chosen tensors form a basis of normal tensors of the vertical tensor.
+  /-- The chosen tensors form a CPSV16 basis of normal tensors of the vertical tensor.
 
   Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
-  isBNT : MPSTensor.IsBNT (verticalTensor M) labelCount bondDim tensor
+  isCPSVBNT : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor M)
+    (fun α ↦ ⟨bondDim α, tensor α⟩)
   /-- Conjugating the vertical tensor gives the weighted BNT direct sum.
 
   Source: arXiv:1606.00608, Proposition 4.13, lines 948--951. -/
@@ -161,6 +162,12 @@ namespace BNTFusionTensorClause
 
 variable {M : MPOTensor d D}
 
+/-- Forget the source BNT predicate carried by the fusion clause to the
+algebraic BNT predicate used by existing vertical-canonical-form consumers. -/
+theorem isBNT (H : BNTFusionTensorClause M) :
+    MPSTensor.IsBNT (verticalTensor M) H.labelCount H.bondDim H.tensor :=
+  H.isCPSVBNT.isBNT
+
 /-- The active-support fusion family carried by a tensor-attached clause. -/
 def toBNTFusionCoisometryFamily (H : BNTFusionTensorClause M) :
     BNTFusionCoisometryFamily (Fin H.labelCount) D where
@@ -198,7 +205,7 @@ noncomputable def toBNTAlgebraTensorClause (H : BNTFusionTensorClause M) :
   multiplicity_pos := H.multiplicity_pos
   weight_pos := H.weight_pos
   coisometry := H.coisometry
-  isBNT := H.isBNT
+  isCPSVBNT := H.isCPSVBNT
   forward := H.forward
   reconstruction := H.reconstruction
   coeffs := BNTLabelCoefficientFamily.ofChi H.chi

--- a/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClause.lean
@@ -162,8 +162,8 @@ namespace BNTFusionTensorClause
 
 variable {M : MPOTensor d D}
 
-/-- Forget the source BNT predicate carried by the fusion clause to the
-algebraic BNT predicate used by existing vertical-canonical-form consumers. -/
+/-- The source BNT predicate in the fusion clause entails the algebraic BNT
+predicate for its chosen vertical decomposition. -/
 theorem isBNT (H : BNTFusionTensorClause M) :
     MPSTensor.IsBNT (verticalTensor M) H.labelCount H.bondDim H.tensor :=
   H.isCPSVBNT.isBNT

--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -375,7 +375,7 @@ theorem of_isRFPViaTS (M : MPOTensor d D)
     multiplicity_pos := D₁.multiplicity_pos
     weight_pos := D₁.weight_pos
     coisometry := D₁.coisometry
-    isBNT := D₁.isCPSVBNT.isBNT
+    isCPSVBNT := D₁.isCPSVBNT
     forward := D₁.forward
     reconstruction := D₁.reconstruction
     chi := chi

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -149,10 +149,9 @@
         =\bigl\{\mu_{\alpha,i}\mu_{\beta,j}
           \chi_{\alpha,\beta,\gamma,k}:\alpha,\beta,i,j,k\bigr\}
     \]
-    as multisets.  Thus the returned data retain both the actual two-site
-    decomposition and its relabelling; forgetting them gives the
-    multiplicity-spectrum comparison of Appendix~C.4, lines~2046--2058 of
-    \cite{Cirac2016MPDO_arXiv}.
+    as multisets.  Thus this two-site decomposition and relabelling realize
+    the multiplicity-spectrum comparison of Appendix~C.4, lines~2046--2058
+    of \cite{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -95,14 +95,39 @@
     clause; constructing it from the MPDO tensor is a separate obligation.
 \end{definition}
 
+\begin{definition}[Source-derived two-site multiplicity spectrum]%
+    \label{def:mpdo_bnt_two_site_multiplicity_spectrum}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum}
+    \leanok
+    \uses{def:mpdo_bnt_algebra_tensor_clause}
+    For a tensor-attached BNT algebra clause, a source-derived two-site
+    multiplicity spectrum consists of a vertical canonical decomposition
+    \[
+        \widetilde{M^{(2)}}
+        =\bigoplus_\delta \nu_\delta\otimes A_\delta,
+    \]
+    a bijection $\sigma$ from the one-site sectors to its sectors such that
+    $M_\gamma$ and $A_{\sigma(\gamma)}$ generate the same matrix product
+    vectors at every positive length, and, for every $\gamma$, the multiset
+    equality
+    \[
+        \bigl\{\nu_{\sigma(\gamma),r}:r\bigr\}
+        =\bigl\{\mu_{\alpha,i}\mu_{\beta,j}
+          \chi_{\alpha,\beta,\gamma,k}:\alpha,\beta,i,j,k\bigr\}.
+    \]
+    This is the decomposition and comparison retained in
+    \cite[Appendix~C.4, lines~2046--2058]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{theorem}[The two-site multiplicity spectrum from the BNT algebra
     clause]%
     \label{thm:mpdo_bnt_algebra_tensor_clause_spectrum}
     \lean{MPOTensor.BNTAlgebraTensorClause.%
-        toMultiplicitySpectrumComparison}
+        toTwoSiteMultiplicitySpectrum}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo,
         def:mpdo_bnt_algebra_tensor_clause,
+        def:mpdo_bnt_two_site_multiplicity_spectrum,
         def:mpdo_bnt_multiplicity_spectrum_comparison,
         def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
     Let $M$ be an MPDO in horizontal canonical form, equipped with a
@@ -110,24 +135,24 @@
     \[
         \widetilde M=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
     \]
-    Choose a vertical canonical decomposition of the two-site blocking,
+    There is a vertical canonical decomposition of the two-site blocking,
     \[
         \widetilde{M^{(2)}}
         =\bigoplus_\delta \nu_\delta\otimes A_\delta.
     \]
-    Then the full-support one-site product expansion and the two-site
-    decomposition determine a bijection of their normal-tensor sectors.  With
-    this relabelling, positivity fixes the phase between matched sectors and,
-    for all sufficiently large $L$,
+    Its normal-tensor sectors admit a bijection $\sigma$ with the sectors of
+    the full-support one-site product expansion such that $M_\gamma$ and
+    $A_{\sigma(\gamma)}$ generate the same matrix product vectors at every
+    positive length and, for every $\gamma$,
     \[
-        \sum_r \nu_{\gamma,r}^{L}
-        =\sum_{\alpha,\beta,i,j,k}
-          \bigl(\mu_{\alpha,i}\mu_{\beta,j}
-            \chi_{\alpha,\beta,\gamma,k}\bigr)^L.
+        \bigl\{\nu_{\sigma(\gamma),r}:r\bigr\}
+        =\bigl\{\mu_{\alpha,i}\mu_{\beta,j}
+          \chi_{\alpha,\beta,\gamma,k}:\alpha,\beta,i,j,k\bigr\}
     \]
-    Consequently the two sides agree as multisets, giving the
-    multiplicity-spectrum comparison of Appendix~C.4,
-    lines~2046--2058 of \cite{Cirac2016MPDO_arXiv}.
+    as multisets.  Thus the returned data retain both the actual two-site
+    decomposition and its relabelling; forgetting them gives the
+    multiplicity-spectrum comparison of Appendix~C.4, lines~2046--2058 of
+    \cite{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -61,8 +61,9 @@
         =\operatorname{tr}(\mu_\alpha).
     \]
     The chosen decomposition satisfies the tensor-attached BNT algebra clause
-    when the BNT algebra clause holds for precisely these operators and these
-    trace scalars.  This is the data in
+    when the tensors $M_\alpha$ form a basis of normal tensors and the BNT
+    algebra clause holds for precisely these operators and these trace
+    scalars.  This is the data in
     \cite[Theorem~4.14(ii), lines~972--993, and Appendix~C.4,
         lines~2046--2064]{Cirac2016MPDO_arXiv}; it does not include a comparison
     with a two-site vertical canonical decomposition.
@@ -93,6 +94,60 @@
     definition does not require this comparison to follow from a BNT algebra
     clause; constructing it from the MPDO tensor is a separate obligation.
 \end{definition}
+
+\begin{theorem}[The two-site multiplicity spectrum from the BNT algebra
+    clause]%
+    \label{thm:mpdo_bnt_algebra_tensor_clause_spectrum}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        toMultiplicitySpectrumComparison}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:mpdo,
+        def:mpdo_bnt_algebra_tensor_clause,
+        def:mpdo_bnt_multiplicity_spectrum_comparison,
+        def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
+    Let $M$ be an MPDO in horizontal canonical form, equipped with a
+    tensor-attached BNT algebra clause
+    \[
+        \widetilde M=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha.
+    \]
+    Choose a vertical canonical decomposition of the two-site blocking,
+    \[
+        \widetilde{M^{(2)}}
+        =\bigoplus_\delta \nu_\delta\otimes A_\delta.
+    \]
+    Then the full-support one-site product expansion and the two-site
+    decomposition determine a bijection of their normal-tensor sectors.  With
+    this relabelling, positivity fixes the phase between matched sectors and,
+    for all sufficiently large $L$,
+    \[
+        \sum_r \nu_{\gamma,r}^{L}
+        =\sum_{\alpha,\beta,i,j,k}
+          \bigl(\mu_{\alpha,i}\mu_{\beta,j}
+            \chi_{\alpha,\beta,\gamma,k}\bigr)^L.
+    \]
+    Consequently the two sides agree as multisets, giving the
+    multiplicity-spectrum comparison of Appendix~C.4,
+    lines~2046--2058 of \cite{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Multiplying the two one-site decompositions and using the BNT algebra law
+    expresses the two-site closed chain in the basis $M_\gamma$, with
+    coefficient
+    \[
+      \sum_{\alpha,\beta,i,j,k}
+        \bigl(\mu_{\alpha,i}\mu_{\beta,j}
+          \chi_{\alpha,\beta,\gamma,k}\bigr)^L.
+    \]
+    All these coefficients are positive.  Hence every basis sector occurs,
+    and the characterization of bases of normal tensors matches these sectors
+    bijectively with those of the two-site vertical canonical decomposition.
+    Normalization makes each matching scalar have modulus one, while
+    positivity of two consecutive coefficients makes it positive; it is
+    therefore one.  Eventual linear independence of the basis vectors gives
+    the displayed equality of power sums.  The finite positive power-sum
+    identity then gives equality of the corresponding multisets.
+\end{proof}
 
 \begin{lemma}[Idempotence for the canonical chi coefficients]%
     \label{lem:mpdo_bnt_idempotent_coefficient_form_of_chi}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -222,6 +222,23 @@ spectral split → block extraction → MPV calculation → strict bounds
   `α i + t * β j`.  The repetition is presently confined to one file, so
   retain it as a candidate rather than adding a general tactic.
 
+### blocked_vertical_triple_sum_reassociation — candidate
+- **Pattern:** reassociate the three finite sector sums in a blocked vertical expansion,
+  then use `map_sum` for scalar multiplication to factor the inner coefficient sums:
+  ```
+  ∑ α, ∑ β, ∑ γ, c α β γ • O γ
+    = ∑ γ, (∑ α, ∑ β, c α β γ) • O γ
+  ```
+- **Seen:** 2 occurrences in
+  `TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean` and
+  `TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean` (2026-07-22).
+- **Abstraction (proposed):** first scout the finite-sum linear-map API for a general lemma
+  factoring a doubly indexed scalar sum out of a fixed vector. This remains below the ordinary
+  rule-of-three threshold, and no further occurrence is currently identified.
+- **Notes:** Both uses combine `Finset.sum_comm` with two `map_sum` calls for
+  `(smulAddHom ℂ _).flip`. Keep the explicit calculations until a third call site confirms that
+  their coefficient and codomain shapes support a materially smaller shared statement.
+
 ---
 
 ## Rejected

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -239,6 +239,22 @@ spectral split → block extraction → MPV calculation → strict bounds
   `(smulAddHom ℂ _).flip`. Keep the explicit calculations until a third call site confirms that
   their coefficient and codomain shapes support a materially smaller shared statement.
 
+### cpsv_matched_phase_coefficient_identity — candidate
+- **Pattern:** rewrite two sector-decomposition state expansions through a matched phase
+  bijection, then use eventual linear independence to identify their coefficients.
+- **Seen:** 2 occurrences in
+  `TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean` and
+  `TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean` (2026-07-22).
+- **Abstraction (proposed):** generalize `coeff_identity_via_matched_mpv_phase` to accept
+  eventual linear independence of the chosen basis directly, while retaining its current
+  `IsBNTCanonicalForm` wrapper for existing consumers.
+- **Notes:** The existing theorem cannot be reused by the MPDO spectrum proof: it requires
+  `IsBNTCanonicalForm`, whose left-canonical and weight-normalization fields are absent from
+  the source-faithful `IsCPSVBasisOfNormalTensors` contract. The MPDO proof already reuses the
+  lower-level `coefficient_eventually_eq_of_eventually_linearIndependent` lemma. Keep this as
+  a candidate until another consumer justifies widening the public coefficient-identity API;
+  do not add stronger hypotheses merely to reuse the existing wrapper.
+
 ---
 
 ## Rejected


### PR DESCRIPTION
Closes #4639.

## Summary

- strengthen the tensor-attached BNT algebra and fusion clauses to retain the source-level CPSV basis-of-normal-tensors contract, with derived `IsBNT` consequences;
- expose the full-support sector phase-matching theorem needed for the MPDO comparison;
- derive a two-site CPSV vertical canonical decomposition directly from horizontal canonical form and MPDO positivity;
- retain that decomposition, the exact matched-sector MPV relation, the sector relabelling, and the multiplicity multiset equality in `TwoSiteMultiplicitySpectrum`;
- retain `toMultiplicitySpectrumComparison` as the corresponding projection;
- register the theorem in the generated MPDO imports and Chapter 21 blueprint.

The main declaration is `MPOTensor.BNTAlgebraTensorClause.toTwoSiteMultiplicitySpectrum`. It assumes only the tensor-attached BNT algebra clause, horizontal canonical form, and `IsMPDO`; it does not assume `IsRFPViaTS` or a pre-existing relabelling or compatibility witness.

## Source contract

This follows CPSV16 Appendix C.4, local source lines 2046–2058. The one-site product expansion is compared with a source-derived two-site vertical canonical form; positivity removes the matching phase; eventual power-sum equality determines the multiplicity spectrum. The public result retains the actual blocked decomposition and identifies each relabelled sector by exact positive-length MPV equality, so the Chapter 21 statement and Lean signature have the same hypotheses and conclusion.

## Validation

- exact head `992644b9a2795634aba0e6137f212098107e3d38`
- `lake env lean TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean`
- changed-file proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`, or `maxHeartbeats`
- `python3 scripts/generate_import_aggregators.py --check`
- diff-scoped reader-facing prose check
- tactic-pattern scan; two below-threshold repetitions recorded as candidates
- blueprint Lean sync: Chapter 21 theorem-data file at 50/50 and global sync clean
- `leanblueprint checkdecls`
- `leanblueprint pdf`: 717 pages; visually inspected the new definition and theorem on printed pages 688–689
- an earlier pre-review head passed the full 9,712-job `lake build`; the final exact head is covered by PR CI

All review threads are answered and resolved. No paper-gap exception or temporary proof hole is introduced.
