### PR TITLE
fix(MPS/MPDO): restore bond-space projector terminal

### DIFF
--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -25,14 +25,14 @@ projections, then
 is a projection.  The source terminal matrix
 $\operatorname{tr}(M_\gamma)$ closes the horizontal operator leg of the
 vertically read tensor and therefore acts on its bond space.  In the present
-notation it is `physTraceTransfer (Fam.tensor γ)`.  This is distinct from the
-closed one-site operator `mpo (Fam.tensor γ) 1`, which acts on the common
+formalization this is the physical-trace transfer.  It is distinct from the
+closed one-site operator, which closes the bond leg and acts on the common
 horizontal space.
 
 **Local fix (terminal trace orientation):** The trace in the terminal matrix
 $\operatorname{tr}(M_\gamma)$ closes the horizontal operator leg and leaves
-the bond indices of $M_\gamma$.  It is `physTraceTransfer`, not the one-site
-closed operator `mpo _ 1`.  Documented in
+the bond indices of $M_\gamma$, rather than closing the bond leg to obtain a
+one-site operator.  Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`.
 
 These are the one-fusion-step projector statements in the recursive
@@ -85,8 +85,10 @@ theorem fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose
         physTraceTransfer (mulTensor (Fam.tensor α) (Fam.tensor β)) *
           (Fam.fusionCoisometry α β)ᴴ =
       Fam.projectorQBlock (fun γ => physTraceTransfer (Fam.tensor γ)) α β := by
+  -- Distribute the terminal trace and apply the sitewise fusion identity.
   rw [physTraceTransfer, Matrix.mul_sum, Matrix.sum_mul]
   simp_rw [Fam.fusion]
+  -- Assemble the resulting summands into the dependent direct sum.
   unfold projectorQBlock physTraceTransfer
   ext ⟨γ, a, x⟩ ⟨δ, b, y⟩
   by_cases hγδ : γ = δ

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -7,6 +7,7 @@ import TNLean.Algebra.OrthogonalProjection
 import TNLean.Channel.Irreducible.Basic
 import TNLean.MPS.MPDO.BNTFusionTensorClause
 import TNLean.MPS.MPDO.BNTTripleFusionSeparation
+import TNLean.MPS.MPDO.ZCL
 
 /-!
 # The local projectors in the length-independent fusion form
@@ -21,12 +22,12 @@ projections, then
     = \bigoplus_\gamma
         \chi_{\alpha,\beta,\gamma}\otimes P_\gamma
 \]
-is a projection.  The source terminal matrices $\operatorname{tr}(M_\gamma)$
-act on the common physical space of the vertically read tensors.  Transport
-through the sequential fusion circuit belongs to the arbitrary-chain
-construction.  The earlier full-support formulation instead gives a
-conditional projection statement for terminal operators on the virtual bond
-spaces.
+is a projection.  The source terminal matrix
+$\operatorname{tr}(M_\gamma)$ closes the horizontal operator leg of the
+vertically read tensor and therefore acts on its bond space.  In the present
+notation it is `physTraceTransfer (Fam.tensor γ)`.  This is distinct from the
+closed one-site operator `mpo (Fam.tensor γ) 1`, which acts on the common
+horizontal space.
 
 These are the one-fusion-step projector statements in the recursive
 construction at source lines 999--1010.  The spectral decomposition of the
@@ -46,7 +47,7 @@ variable {Λ : Type*} [Fintype Λ] [DecidableEq Λ] {p : ℕ}
 variable (Fam : BNTFusionCoisometryFamily Λ p)
 
 /-- The single fusion layer of the operator $Q$ on the active product sectors,
-with terminal matrices $P_\gamma$.
+with terminal matrices $P_\gamma$ on the bond spaces of the final sectors.
 
 Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
@@ -56,13 +57,44 @@ operator at line 999 and its sequential fusion circuit are not asserted here.
 Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 noncomputable def projectorQBlock
-    (P : Λ → Matrix (Fin p) (Fin p) ℂ)
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
     (α β : Λ) :
     Matrix ((γ : Λ) ×
-        (Fin (Fam.chi.dim α β γ) × Fin p))
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ)))
       ((γ : Λ) ×
-        (Fin (Fam.chi.dim α β γ) × Fin p)) ℂ :=
+        (Fin (Fam.chi.dim α β γ) × Fin (Fam.bondDim γ))) ℂ :=
   Matrix.blockDiagonal' fun γ => Fam.chi.matrix α β γ ⊗ₖ P γ
+
+/-- Fusing a pair and then closing its horizontal operator leg gives the
+one-layer block whose terminal matrices are the physical-trace transfers of
+the final sectors.
+
+Source: arXiv:1606.00608, the fusion identity at lines 986--993 and the
+terminal matrices in the recursive operator at lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Local fix (terminal trace orientation):** The trace in the terminal matrix
+$\operatorname{tr}(M_\gamma)$ closes the horizontal operator leg and leaves
+the bond indices of $M_\gamma$.  It is `physTraceTransfer`, not the one-site
+closed operator `mpo _ 1`.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose
+    (α β : Λ) :
+    Fam.fusionCoisometry α β *
+        physTraceTransfer (mulTensor (Fam.tensor α) (Fam.tensor β)) *
+          (Fam.fusionCoisometry α β)ᴴ =
+      Fam.projectorQBlock (fun γ => physTraceTransfer (Fam.tensor γ)) α β := by
+  rw [physTraceTransfer, Matrix.mul_sum, Matrix.sum_mul]
+  simp_rw [Fam.fusion]
+  unfold projectorQBlock physTraceTransfer
+  ext ⟨γ, a, x⟩ ⟨δ, b, y⟩
+  by_cases hγδ : γ = δ
+  · subst δ
+    simp only [Matrix.sum_apply, Matrix.blockDiagonal'_apply_eq,
+      Matrix.kroneckerMap_apply, Finset.mul_sum]
+  · simp only [Matrix.sum_apply,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hγδ, Finset.sum_const_zero]
 
 /-- In the length-independent case, the chi matrices in one active fusion
 layer are identities.
@@ -73,7 +105,8 @@ theorem projectorQBlock_eq_unweighted
     (c : BNTLabelCoefficientFamily Λ)
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
     (hLI : c.LengthIndependent)
-    (P : Λ → Matrix (Fin p) (Fin p) ℂ)
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
     (α β : Λ) :
     Fam.projectorQBlock P α β =
       Matrix.blockDiagonal' fun γ =>
@@ -93,7 +126,8 @@ theorem projectorQBlock_isStarProjection
     (c : BNTLabelCoefficientFamily Λ)
     (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
     (hLI : c.LengthIndependent)
-    (P : Λ → Matrix (Fin p) (Fin p) ℂ)
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
     (hP : ∀ γ : Λ, IsStarProjection (P γ))
     (α β : Λ) :
     IsStarProjection (Fam.projectorQBlock P α β) := by
@@ -111,6 +145,53 @@ theorem projectorQBlock_isStarProjection
     have hPγ : (P γ)ᴴ = P γ := by
       simpa [Matrix.star_eq_conjTranspose] using (hP γ).isSelfAdjoint.star_eq
     rw [hPγ]
+
+/-- The active fusion-layer operator transported to the product bond space by
+the fusion coisometry.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Local fix (terminal trace orientation):** The terminal operators act on the
+bond spaces of the final sectors, so this conjugation is well typed.  The
+opposite one-site closure `mpo _ 1` acts on the common horizontal space and is
+not used here.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+noncomputable def conjugatedProjectorQBlock
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (α β : Λ) :
+    Matrix (Fin (Fam.bondDim α * Fam.bondDim β))
+      (Fin (Fam.bondDim α * Fam.bondDim β)) ℂ :=
+  (Fam.fusionCoisometry α β)ᴴ * Fam.projectorQBlock P α β *
+    Fam.fusionCoisometry α β
+
+/-- Transporting a length-independent fusion-layer projection through the
+active-support fusion coisometry gives an orthogonal projection on the product
+bond space.
+
+Source: arXiv:1606.00608, the fusion map at lines 986--993 and the recursive
+projector at lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Local fix (Figure-11 fusion coisometry):** The proof uses
+$U_{\alpha,\beta}U_{\alpha,\beta}^\dagger=1$, the retained-row orientation of
+the source.  It does not assume that the active-support projection
+$U_{\alpha,\beta}^\dagger U_{\alpha,\beta}$ is the identity.  Documented in
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex` and
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem conjugatedProjectorQBlock_isOrthogonalProjection
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent)
+    (P : ∀ γ : Λ,
+      Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
+    (hP : ∀ γ : Λ, IsStarProjection (P γ))
+    (α β : Λ) :
+    IsOrthogonalProjection (Fam.conjugatedProjectorQBlock P α β) :=
+  (IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+    (Fam.projectorQBlock_isStarProjection c hχ hLI P hP α β)
+    (Fam.fusionCoisometry α β) (Fam.coisometry α β)).isOrthogonalProjection
 
 end MPOTensor.BNTFusionCoisometryFamily
 
@@ -130,13 +211,37 @@ chain.  Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 noncomputable def projectorQBlock
     (H : BNTFusionTensorClause M)
-    (P : Fin H.labelCount → Matrix (Fin D) (Fin D) ℂ)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
     (α β : Fin H.labelCount) :
     Matrix ((γ : Fin H.labelCount) ×
-        (Fin (H.chi.dim α β γ) × Fin D))
+        (Fin (H.chi.dim α β γ) × Fin (H.bondDim γ)))
       ((γ : Fin H.labelCount) ×
-        (Fin (H.chi.dim α β γ) × Fin D)) ℂ :=
+        (Fin (H.chi.dim α β γ) × Fin (H.bondDim γ))) ℂ :=
   H.toBNTFusionCoisometryFamily.projectorQBlock P α β
+
+/-- Fusing two tensor-attached BNT sectors and closing their horizontal
+operator leg gives the source terminal block for one fusion layer.
+
+Source: arXiv:1606.00608, the fusion identity at lines 986--993 and the
+terminal matrices in the recursive operator at lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Local fix (terminal trace orientation):** The trace closes the horizontal
+operator leg and leaves the dependent bond space of the final BNT sector.
+Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose
+    (H : BNTFusionTensorClause M)
+    (α β : Fin H.labelCount) :
+    H.fusionCoisometry α β *
+        physTraceTransfer (mulTensor (verticalBNTMPO (H.tensor α))
+          (verticalBNTMPO (H.tensor β))) *
+          (H.fusionCoisometry α β)ᴴ =
+      H.projectorQBlock
+        (fun γ => physTraceTransfer (verticalBNTMPO (H.tensor γ))) α β :=
+  BNTFusionCoisometryFamily.fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose
+    H.toBNTFusionCoisometryFamily α β
 
 /-- Length independence makes the tensor-attached active fusion layer a
 self-adjoint idempotent when its terminal matrices are self-adjoint
@@ -147,11 +252,55 @@ Source: arXiv:1606.00608, lines 999--1010 of
 theorem projectorQBlock_isStarProjection
     (H : BNTFusionTensorClause M)
     (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
-    (P : Fin H.labelCount → Matrix (Fin D) (Fin D) ℂ)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
     (hP : ∀ γ : Fin H.labelCount, IsStarProjection (P γ))
     (α β : Fin H.labelCount) :
     IsStarProjection (H.projectorQBlock P α β) :=
   H.toBNTFusionCoisometryFamily.projectorQBlock_isStarProjection
+    (BNTLabelCoefficientFamily.ofChi H.chi)
+    (BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm H.chi)
+    hLI P hP α β
+
+/-- The tensor-attached active fusion layer transported to the product bond
+space.
+
+Source: arXiv:1606.00608, lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Local fix (terminal trace orientation):** The terminal operators act on the
+dependent bond spaces of the final BNT sectors.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+noncomputable def conjugatedProjectorQBlock
+    (H : BNTFusionTensorClause M)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (α β : Fin H.labelCount) :
+    Matrix (Fin (H.bondDim α * H.bondDim β))
+      (Fin (H.bondDim α * H.bondDim β)) ℂ :=
+  H.toBNTFusionCoisometryFamily.conjugatedProjectorQBlock P α β
+
+/-- A length-independent tensor-attached active fusion layer becomes an
+orthogonal projection on the product bond space after transport by its fusion
+coisometry.
+
+Source: arXiv:1606.00608, the fusion map at lines 986--993 and the recursive
+projector at lines 999--1010 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (one fusion layer):** The arbitrary-chain recursion and
+the commuting Gibbs decomposition at lines 999--1016 remain separate.  This
+is documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem conjugatedProjectorQBlock_isOrthogonalProjection
+    (H : BNTFusionTensorClause M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
+    (P : ∀ γ : Fin H.labelCount,
+      Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ)
+    (hP : ∀ γ : Fin H.labelCount, IsStarProjection (P γ))
+    (α β : Fin H.labelCount) :
+    IsOrthogonalProjection (H.conjugatedProjectorQBlock P α β) :=
+  H.toBNTFusionCoisometryFamily.conjugatedProjectorQBlock_isOrthogonalProjection
     (BNTLabelCoefficientFamily.ofChi H.chi)
     (BNTLabelCoefficientFamily.ofChi_hasPositiveLengthChiTracePowerForm H.chi)
     hLI P hP α β
@@ -163,16 +312,15 @@ namespace MPOTensor.BNTFusionIsometryFamily
 variable {g p : ℕ}
 variable (Fam : BNTFusionIsometryFamily (Fin g) p)
 
-/-- A conditional single fusion layer with terminal matrices $P_\gamma$ on
-the virtual bond spaces.
+/-- The full-support specialization of a single fusion layer, with terminal
+matrices $P_\gamma$ on the bond spaces of the final sectors.
 
 Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
 
-**Scope restriction (virtual-bond terminal operators):** The source terminal
-matrices $\operatorname{tr}(M_\gamma)$ act on a common physical space.  This
-definition instead gives a mathematically valid virtual-bond construction for
-the older full-support fusion family.  Documented in
+**Scope restriction (full-support fusion family):** The terminal spaces agree
+with the source contraction, but this older fusion family requires the active
+support to be the whole product bond space.  Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 noncomputable def projectorQBlock
     (P : ∀ γ : Fin g,
@@ -190,9 +338,9 @@ are identities.
 Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
 
-**Scope restriction (virtual-bond terminal operators):** This identity
-concerns the conditional virtual-bond construction, not the physical terminal
-matrices in the source recursion.  Documented in
+**Scope restriction (full-support fusion family):** This identity uses the
+older fusion family in which the active support is the whole product bond
+space.  Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 theorem projectorQBlock_eq_unweighted
     (c : BNTLabelCoefficientFamily (Fin g))
@@ -215,9 +363,9 @@ length independent.
 Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
 
-**Scope restriction (virtual-bond terminal operators):** This theorem concerns
-the conditional virtual-bond construction, not the physical terminal matrices
-in the source recursion.  Documented in
+**Scope restriction (full-support fusion family):** This theorem uses the
+older fusion family in which the active support is the whole product bond
+space.  Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
 theorem projectorQBlock_isStarProjection
     (c : BNTLabelCoefficientFamily (Fin g))
@@ -249,9 +397,10 @@ fusion map.
 Source: arXiv:1606.00608, lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
 
-**Scope restriction (virtual-bond terminal operators):** This transport is
-defined only for the older full-support fusion family.  It is not the
-sequential physical-space transport in the source recursion.  Documented in
+**Scope restriction (full-support fusion family):** This transport is defined
+only for the older family in which the active support is the whole product
+bond space.  It is one fusion layer, not the arbitrary sequential circuit.
+Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex` and
 `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
 noncomputable def conjugatedProjectorQBlock
@@ -271,11 +420,10 @@ Source: arXiv:1606.00608, BNT separation at lines 317--345, the fusion map at
 lines 986--993, and the recursive projector at lines 999--1010 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`.
 
-**Scope restriction (full-support virtual transport):** The BNT hypothesis and
+**Scope restriction (full-support fusion family):** The BNT hypothesis and
 length independence imply the additional full-support relation needed here.
-The theorem concerns virtual-bond terminal operators, not the physical
-terminal matrices or the sequential circuit of the source recursion.
-Documented in
+The theorem concerns one fusion layer, not the arbitrary sequential circuit
+of the source recursion.  Documented in
 `docs/paper-gaps/cpsv16_topological_projector_recursion.tex` and
 `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
 theorem conjugatedProjectorQBlock_isOrthogonalProjection

--- a/TNLean/MPS/MPDO/TopologicalProjectors.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectors.lean
@@ -29,6 +29,12 @@ notation it is `physTraceTransfer (Fam.tensor γ)`.  This is distinct from the
 closed one-site operator `mpo (Fam.tensor γ) 1`, which acts on the common
 horizontal space.
 
+**Local fix (terminal trace orientation):** The trace in the terminal matrix
+$\operatorname{tr}(M_\gamma)$ closes the horizontal operator leg and leaves
+the bond indices of $M_\gamma$.  It is `physTraceTransfer`, not the one-site
+closed operator `mpo _ 1`.  Documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`.
+
 These are the one-fusion-step projector statements in the recursive
 construction at source lines 999--1010.  The spectral decomposition of the
 terminal matrices, iteration along an arbitrary chain, and the commuting Gibbs
@@ -72,13 +78,7 @@ the final sectors.
 
 Source: arXiv:1606.00608, the fusion identity at lines 986--993 and the
 terminal matrices in the recursive operator at lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`.
-
-**Local fix (terminal trace orientation):** The trace in the terminal matrix
-$\operatorname{tr}(M_\gamma)$ closes the horizontal operator leg and leaves
-the bond indices of $M_\gamma$.  It is `physTraceTransfer`, not the one-site
-closed operator `mpo _ 1`.  Documented in
-`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose
     (α β : Λ) :
     Fam.fusionCoisometry α β *
@@ -150,13 +150,8 @@ theorem projectorQBlock_isStarProjection
 the fusion coisometry.
 
 Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`.
-
-**Local fix (terminal trace orientation):** The terminal operators act on the
-bond spaces of the final sectors, so this conjugation is well typed.  The
-opposite one-site closure `mpo _ 1` acts on the common horizontal space and is
-not used here.  Documented in
-`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.  The terminal operators act on the
+bond spaces of the final sectors, as required by this conjugation. -/
 noncomputable def conjugatedProjectorQBlock
     (P : ∀ γ : Λ,
       Matrix (Fin (Fam.bondDim γ)) (Fin (Fam.bondDim γ)) ℂ)
@@ -225,12 +220,7 @@ operator leg gives the source terminal block for one fusion layer.
 
 Source: arXiv:1606.00608, the fusion identity at lines 986--993 and the
 terminal matrices in the recursive operator at lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`.
-
-**Local fix (terminal trace orientation):** The trace closes the horizontal
-operator leg and leaves the dependent bond space of the final BNT sector.
-Documented in
-`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose
     (H : BNTFusionTensorClause M)
     (α β : Fin H.labelCount) :
@@ -266,11 +256,8 @@ theorem projectorQBlock_isStarProjection
 space.
 
 Source: arXiv:1606.00608, lines 999--1010 of
-`Papers/1606.00608/MPDO-22-12-17-2.tex`.
-
-**Local fix (terminal trace orientation):** The terminal operators act on the
-dependent bond spaces of the final BNT sectors.  Documented in
-`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.  The terminal operators act on the
+dependent bond spaces of the final BNT sectors. -/
 noncomputable def conjugatedProjectorQBlock
     (H : BNTFusionTensorClause M)
     (P : ∀ γ : Fin H.labelCount,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1450,6 +1450,9 @@ separate step.
         \chi_{\alpha,\beta,\gamma}\otimes
           \operatorname{tr}(M_\gamma).
     \]
+    Indeed, summing the forward fusion identity over equal horizontal
+    operator indices and distributing matrix multiplication over this finite
+    sum gives the displayed terminal-trace identity.
     This is one pairwise step in the recursion of
     \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
 
@@ -1471,7 +1474,8 @@ separate step.
         conjugatedProjectorQBlock_isOrthogonalProjection}
     \leanok
     \uses{def:mpdo_topological_projector_one_fusion,
-        thm:mpdo_bnt_length_independent_zipper}
+        thm:mpdo_bnt_length_independent_zipper,
+        thm:star_projection_coisometric_transport}
     Let $P_\gamma$ be self-adjoint idempotents on the terminal bond space of
     $M_\gamma$.
     Suppose that the matrices $\chi_{\alpha,\beta,\gamma}$ have the
@@ -1501,6 +1505,11 @@ separate step.
         =\bigoplus_\gamma(1\otimes P_\gamma^{2})
         =Q_{\alpha,\beta}.
     \]
+    Finally, the coisometry identity
+    $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$ and
+    Theorem~\ref{thm:star_projection_coisometric_transport} show that
+    $U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}$ is an
+    orthogonal projection.
 \end{proof}
 
 \begin{definition}[Full-support specialization of one fusion layer]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1426,6 +1426,8 @@ separate step.
     \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock}
     \lean{MPOTensor.BNTFusionTensorClause.%
         fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.conjugatedProjectorQBlock}
+    \lean{MPOTensor.BNTFusionTensorClause.conjugatedProjectorQBlock}
     \leanok
     \uses{def:mpdo_bnt_fusion_coisometry_family,
         def:mpdo_bnt_fusion_tensor_clause}
@@ -1462,11 +1464,9 @@ separate step.
     \label{thm:mpdo_topological_projector_one_fusion}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_eq_unweighted}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_isStarProjection}
-    \lean{MPOTensor.BNTFusionCoisometryFamily.conjugatedProjectorQBlock}
     \lean{MPOTensor.BNTFusionCoisometryFamily.%
         conjugatedProjectorQBlock_isOrthogonalProjection}
     \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock_isStarProjection}
-    \lean{MPOTensor.BNTFusionTensorClause.conjugatedProjectorQBlock}
     \lean{MPOTensor.BNTFusionTensorClause.%
         conjugatedProjectorQBlock_isOrthogonalProjection}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -935,23 +935,20 @@ weights in the length-independent case at
     %         \operatorname{tr}(M_{\alpha_{r+1}}).
     % Source verdict: CPSV16 lines 999--1008 and MPDO_Structure.png give this
     %   recursive coefficient graph.  The image is the source for the open
-    %   copy rails, repeated-step ellipsis, and terminal virtual trace.
+    %   copy rails, repeated-step ellipsis, and terminal horizontal trace.
     % Ink-to-index map: the four east ports of X_s, from top to bottom, are
     %   k_s, alpha_s, beta_s, gamma_s.  The first three meet distinct open
     %   copy rails.  For consecutive steps, gamma_s and alpha_{s+1} are two
     %   incidences on the same rail, which remains open above and below; the
     %   rail is a diagonal copy register and does not sum that label.  The
     %   ellipsis repeats precisely this routing.  On the terminal rail,
-    %   gamma_r meets both X_r and the selector port of M_{gamma_r}.  Only the
-    %   two virtual ports of M_{gamma_r} are contracted with one another; its
-    %   physical input and output remain open.
+    %   gamma_r meets both X_r and the selector port of M_{gamma_r}.  The two
+    %   horizontal operator ports of M_{gamma_r} are contracted with one
+    %   another, while its two bond ports remain open.  Thus the terminal
+    %   matrix acts on the label-dependent bond space of M_{gamma_r}.
     % Boundary signature: the r coefficient boxes have 3r+1 unique open copy
-    %   rails.  With the terminal physical pair, Q_N has semantic signature
-    %   (virtual-west, virtual-east, physical-up, physical-down)
-    %   = (0,0,3r+2,3r+2) = (0,0,3N-1,3N-1).
-    %   The four visible X boxes separated by the ellipsis expose 14 copy-rail
-    %   pairs plus the terminal physical pair, so the displayed event graph
-    %   has finite signature (0,0,15,15).
+    %   rails, together with the open terminal bond pair.  The bond dimension
+    %   depends on the terminal label gamma_r.
     % Projector caveat: lines 1010--1015 require length-independent structure
     %   coefficients and projector terminal traces before Q is a projector;
     %   the contraction displayed here asserts only the operator Q_N.
@@ -1011,8 +1008,8 @@ weights in the length-independent case at
             {Selector}{(102mm,0mm)}{}
 
         \tnput[mpo,
-            ports={north:physical,south:physical,west:physical,
-                south west:virtual,south east:virtual}]
+            ports={north:virtual,south:virtual,west:physical,
+                south west:physical,south east:physical}]
             {Mlast}{(116mm,0mm)}{M_{\gamma_r}}
 
         \foreach \name/\x in {
@@ -1025,9 +1022,9 @@ weights in the length-independent case at
             \tnput[boundary, ports={north:physical}]
                 {\name Bottom}{(\x mm,-20mm)}{}
         }
-        \tnput[boundary, ports={south:physical}]
+        \tnput[boundary, ports={south:virtual}]
             {Mtop}{(116mm,18mm)}{}
-        \tnput[boundary, ports={north:physical}]
+        \tnput[boundary, ports={north:virtual}]
             {Mbottom}{(116mm,-20mm)}{}
 
         \tnjoin{Xone.20}{Kone.west}
@@ -1424,19 +1421,33 @@ separate step.
 \begin{definition}[One fusion layer of the topological projector]%
     \label{def:mpdo_topological_projector_one_fusion}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.%
+        fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose}
     \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose}
     \leanok
     \uses{def:mpdo_bnt_fusion_coisometry_family,
         def:mpdo_bnt_fusion_tensor_clause}
-    Let $P_\gamma$ be operators on the common physical space of the vertically
-    read tensors.  Define one fusion layer of the recursive operator $Q$ by
+    Let $P_\gamma$ be operators on the bond space of the vertically read
+    tensor $M_\gamma$.  Define one fusion layer of the recursive operator $Q$
+    by
     \[
         Q_{\alpha,\beta}
           =\bigoplus_\gamma
              \chi_{\alpha,\beta,\gamma}\otimes P_\gamma.
     \]
     The source terminal matrices are
-    $P_\gamma=\operatorname{tr}(M_\gamma)$ after spectral refinement.
+    $P_\gamma=\operatorname{tr}(M_\gamma)$ after spectral refinement, where
+    the trace closes the horizontal operator leg and leaves the bond indices.
+    Before spectral refinement, the fusion identity implies
+    \[
+      U_{\alpha,\beta}\operatorname{tr}(M_\alpha M_\beta)
+        U_{\alpha,\beta}^{\dagger}
+      =\bigoplus_\gamma
+        \chi_{\alpha,\beta,\gamma}\otimes
+          \operatorname{tr}(M_\gamma).
+    \]
     This is one pairwise step in the recursion of
     \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
 
@@ -1451,12 +1462,18 @@ separate step.
     \label{thm:mpdo_topological_projector_one_fusion}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_eq_unweighted}
     \lean{MPOTensor.BNTFusionCoisometryFamily.projectorQBlock_isStarProjection}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.conjugatedProjectorQBlock}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.%
+        conjugatedProjectorQBlock_isOrthogonalProjection}
     \lean{MPOTensor.BNTFusionTensorClause.projectorQBlock_isStarProjection}
+    \lean{MPOTensor.BNTFusionTensorClause.conjugatedProjectorQBlock}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        conjugatedProjectorQBlock_isOrthogonalProjection}
     \leanok
     \uses{def:mpdo_topological_projector_one_fusion,
         thm:mpdo_bnt_length_independent_zipper}
-    Let $P_\gamma$ be self-adjoint idempotents on the common terminal physical
-    space.
+    Let $P_\gamma$ be self-adjoint idempotents on the terminal bond space of
+    $M_\gamma$.
     Suppose that the matrices $\chi_{\alpha,\beta,\gamma}$ have the
     positive-length trace-power form of the label-coefficient family and that
     this family is independent of the positive chain length.  Then
@@ -1467,6 +1484,10 @@ separate step.
     \]
     is self-adjoint and idempotent.  This is the single recursive fusion step in
     \cite[lines~999--1010]{Cirac2016MPDO_arXiv}.
+    Since the active fusion map satisfies
+    $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$, the transported operator
+    $U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}$ is also an
+    orthogonal projection on the product bond space.
 \end{theorem}
 \begin{proof}\leanok
     The trace-power hypothesis and length independence give
@@ -1482,35 +1503,35 @@ separate step.
     \]
 \end{proof}
 
-\begin{definition}[Full-support virtual-bond projector block]%
+\begin{definition}[Full-support specialization of one fusion layer]%
     \label{def:mpdo_full_support_virtual_projector_one_fusion}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock}
     \lean{MPOTensor.BNTFusionIsometryFamily.conjugatedProjectorQBlock}
     \leanok
     \uses{def:mpdo_bnt_fusion_isometry_family}
-    For a full-support fusion family, let $P_\gamma$ instead act on the virtual
-    bond space of $M_\gamma$.  Define
+    For a full-support fusion family, let $P_\gamma$ act on the bond space of
+    $M_\gamma$.  Define
     \[
-        Q^{\mathrm{vir}}_{\alpha,\beta}
+        Q^{\mathrm{fs}}_{\alpha,\beta}
           =\bigoplus_\gamma
              \chi_{\alpha,\beta,\gamma}\otimes P_\gamma,
         \qquad
-        \widehat Q^{\mathrm{vir}}_{\alpha,\beta}
+        \widehat Q^{\mathrm{fs}}_{\alpha,\beta}
           =U_{\alpha,\beta}^{\dagger}
-             Q^{\mathrm{vir}}_{\alpha,\beta}U_{\alpha,\beta}.
+             Q^{\mathrm{fs}}_{\alpha,\beta}U_{\alpha,\beta}.
     \]
-    This is a conditional construction on the virtual bond spaces, not the
-    terminal physical-space operator of
-    \cite[line~1010]{Cirac2016MPDO_arXiv}.
+    The terminal contraction is the same as in the source operator.  The
+    additional condition is that the active support is the whole product bond
+    space.
 
-    \textbf{Scope restriction (virtual-bond terminal operators):} The terminal
-    operators and the full-support identity are additional restrictions not
-    asserted in the arbitrary-chain source statement.  This distinction is
+    \textbf{Scope restriction (full-support fusion family):} Full support is
+    not an additional hypothesis of the arbitrary-chain source statement.
+    This distinction is
     documented in
     \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
 \end{definition}
 
-\begin{theorem}[Projection property of the full-support virtual-bond block]%
+\begin{theorem}[Projection property of the full-support specialization]%
     \label{thm:mpdo_full_support_virtual_projector_one_fusion}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_eq_unweighted}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock_isStarProjection}
@@ -1523,26 +1544,26 @@ separate step.
         thm:orthogonal_projection_star_projection_channel}
     Suppose that the labelled tensors form a basis of normal tensors and the
     positive trace-power coefficients are independent of the positive chain
-    length.  If each $P_\gamma$ is a self-adjoint idempotent on the virtual
-    bond space, then $Q^{\mathrm{vir}}_{\alpha,\beta}$ is a self-adjoint
-    idempotent and $\widehat Q^{\mathrm{vir}}_{\alpha,\beta}$ is an orthogonal
+    length.  If each $P_\gamma$ is a self-adjoint idempotent on the bond space,
+    then $Q^{\mathrm{fs}}_{\alpha,\beta}$ is a self-adjoint idempotent and
+    $\widehat Q^{\mathrm{fs}}_{\alpha,\beta}$ is an orthogonal
     projection.
 \end{theorem}
 \begin{proof}\leanok
     Length independence gives
     $\chi_{\alpha,\beta,\gamma}=1$, hence
-    $(Q^{\mathrm{vir}}_{\alpha,\beta})^2
-      =Q^{\mathrm{vir}}_{\alpha,\beta}$ and
-    $(Q^{\mathrm{vir}}_{\alpha,\beta})^\dagger
-      =Q^{\mathrm{vir}}_{\alpha,\beta}$.
+    $(Q^{\mathrm{fs}}_{\alpha,\beta})^2
+      =Q^{\mathrm{fs}}_{\alpha,\beta}$ and
+    $(Q^{\mathrm{fs}}_{\alpha,\beta})^\dagger
+      =Q^{\mathrm{fs}}_{\alpha,\beta}$.
     The basis-of-normal-tensors completeness theorem gives
     $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$, so
     \[
-      (\widehat Q^{\mathrm{vir}}_{\alpha,\beta})^2
-        =U_{\alpha,\beta}^{\dagger}Q^{\mathrm{vir}}_{\alpha,\beta}
+      (\widehat Q^{\mathrm{fs}}_{\alpha,\beta})^2
+        =U_{\alpha,\beta}^{\dagger}Q^{\mathrm{fs}}_{\alpha,\beta}
           (U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger})
-          Q^{\mathrm{vir}}_{\alpha,\beta}U_{\alpha,\beta}
-        =\widehat Q^{\mathrm{vir}}_{\alpha,\beta}.
+          Q^{\mathrm{fs}}_{\alpha,\beta}U_{\alpha,\beta}
+        =\widehat Q^{\mathrm{fs}}_{\alpha,\beta}.
     \]
 \end{proof}
 

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -56,35 +56,45 @@ the direct sum
       \chi_{\alpha,\beta,\gamma}\otimes P_\gamma.
   \label{eq:one-layer-q}
 \end{equation}
-Here each $P_\gamma$ acts on the common physical space of the vertically read
-tensor $M_\gamma$; in the source it is obtained from the terminal matrix
-$\operatorname{tr}(M_\gamma)$.  It does not act on the virtual bond space of
-$M_\gamma$.
+Here each $P_\gamma$ acts on the bond space of the vertically read tensor
+$M_\gamma$.  The source terminal matrix $\operatorname{tr}(M_\gamma)$ closes
+the horizontal operator leg and leaves precisely these two bond indices.  In
+the formalization this matrix is the physical-trace transfer of $M_\gamma$.
 Length independence and positivity imply
 $\chi_{\alpha,\beta,\gamma}=I$ on each retained multiplicity space, hence
 $Q_{\alpha,\beta}$ is an orthogonal projection.  This statement is formalized
 for \leanid{MPOTensor.BNTFusionCoisometryFamily} and for the tensor-attached
 clause \leanid{MPOTensor.BNTFusionTensorClause}.
 
-The pairwise fusion coisometry acts on the virtual bond spaces of the tensors,
-whereas the terminal projections in \eqref{eq:one-layer-q} act on their common
-physical space.  Consequently, a direct conjugation of
-$Q_{\alpha,\beta}$ by one pairwise fusion map is not well typed.  The source
-instead inserts the fusion maps recursively into the tensor network and forms
-the sequential circuit $\widetilde U$.  The older virtual-bond construction in
-\leanid{MPOTensor.BNTFusionIsometryFamily} is a separate conditional statement:
-it assumes terminal projections on the bond spaces and a full-support fusion
-family.  It is not the terminal step of equation~\eqref{eq:source-chain-decomposition}.
+The pairwise fusion identity therefore gives the well-typed equality
+\begin{equation}
+  U_{\alpha,\beta}\,
+    \operatorname{tr}(M_\alpha M_\beta)\,
+    U_{\alpha,\beta}^{\dagger}
+  =\bigoplus_\gamma
+      \chi_{\alpha,\beta,\gamma}\otimes
+        \operatorname{tr}(M_\gamma).
+  \label{eq:one-layer-terminal-fusion}
+\end{equation}
+Moreover, $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$ implies that
+$U_{\alpha,\beta}^{\dagger}Q_{\alpha,\beta}U_{\alpha,\beta}$ is an
+orthogonal projection whenever $Q_{\alpha,\beta}$ is one.  The older family
+\leanid{MPOTensor.BNTFusionIsometryFamily} proves the same one-layer statement
+under the additional full-support hypothesis.  This is a specialization, not
+a construction with a different terminal space.
 
-\paragraph{Local fix (Figure-11 fusion coisometry).}
+\paragraph{Local fix (terminal trace orientation).}
 The active fusion map has the retained-row orientation
 $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=I$ recorded in
-\path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.  An earlier
-one-layer formulation attempted to use this relation to conjugate
-\eqref{eq:one-layer-q}.  That formulation has been removed: the coisometry
-acts on virtual indices, while the terminal matrices act on physical indices.
-The remaining virtual-bond transport is stated only for the older
-full-support family and is not identified with the source operator $Q_N$.
+\path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.  Pull request
+\#4640 temporarily interpreted the terminal trace as the one-site closed
+operator $O_1(M_\gamma)$.  That operator closes the bond leg and acts on the
+common horizontal space.  The terminal factor in the diagram defining $Q_N$
+has the opposite contraction: it closes the horizontal operator leg and acts
+on the bond space of $M_\gamma$.  The two contractions are visible separately
+in \path{Papers/1606.00608/MPDO_O_L_A_.png} and
+\path{Papers/1606.00608/MPDO_Structure.png}.  Equation
+\eqref{eq:one-layer-terminal-fusion} restores the latter contraction.
 
 \section{Remaining proof}
 


### PR DESCRIPTION
## Summary

This corrects the terminal contraction in the one-fusion-layer topological projector following CPSV16, Theorem 4.14(iii), lines 986–1010.

- Restore the terminal family P_γ to the label-dependent bond spaces of the final BNT sectors.
- Identify the source terminal matrix with `physTraceTransfer (tensor γ)`.
- Prove the one-layer fusion identity:
  `U_{α,β} tr(M_α M_β) U_{α,β}† = ⨁_γ χ_{α,β,γ} ⊗ tr(M_γ)`.
- Restore coisometric transport and its orthogonal-projection theorem using `UU† = 1`, without assuming `U†U = 1`.
- Recast the older full-support result as a specialization with the same terminal contraction.
- Correct the blueprint diagram and the paper-gap note.

## Root cause

PR #4640 interpreted the terminal `tr(M_γ)` in CPSV16 lines 999–1010 as the one-site closed operator `O₁(M_γ)`. These are different contractions.

- `Papers/1606.00608/MPDO_O_L_A_.png` depicts `O₁(M_γ)`: the bond leg is closed and the common horizontal operator space remains.
- `Papers/1606.00608/MPDO_Structure.png` depicts the terminal factor of `Q_N`: the horizontal operator leg is closed and the label-dependent bond space remains.

The former is `mpo _ 1`; the latter is `physTraceTransfer`. The previous common-`Fin D` formulation therefore had the source orientation reversed.

## Scope and faithfulness

This PR proves only the source-correct one-fusion-layer statement. The recursively typed `Q_N`, the sequential coisometry `U_tilde`, the arbitrary-chain identity, and the commuting Gibbs decomposition remain open in #3950.

This PR intentionally does **not** close #3950.

The correction is documented in `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`, with the source lines and both source figures identified explicitly.

## Validation

- `lake env lean TNLean/MPS/MPDO/TopologicalProjectors.lean`
- `python3 scripts/blueprint_lean_sync.py --ci --warn-missing-blueprint --diff-base main --changed-files TNLean/MPS/MPDO/TopologicalProjectors.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base main`
- `git diff --check`
- proof-integrity scan: no `sorry`, `admit`, `native_decide`, `unsafeCast`, or `axiom`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core typing and proofs for MPDO topological projectors and blueprint–Lean sync; impact is localized to formalization/docs, not runtime services, but errors would misstate CPSV16-aligned mathematics.
> 
> **Overview**
> **Corrects the one-fusion-layer topological projector** so terminal operators act on **label-dependent bond spaces**, matching CPSV16 lines 999–1010, after PR #4640 had used the wrong contraction (`O₁(M_γ)` on common physical space instead of `physTraceTransfer`).
> 
> `projectorQBlock` now takes `P : ∀ γ, Matrix (Fin (bondDim γ)) …` rather than a common `Fin p` physical dimension. New results tie fusion to terminals: **`fusionCoisometry_mul_physTraceTransfer_mul_conjTranspose`** (one-layer fusion identity with horizontal-leg trace) and **`conjugatedProjectorQBlock`** with **`conjugatedProjectorQBlock_isOrthogonalProjection`** (transport via coisometry using `UU† = 1` only). The same API is mirrored on **`BNTFusionTensorClause`**; **`BNTFusionIsometryFamily`** docs are reframed as a **full-support specialization** with the same terminal contraction, not a separate virtual-bond story.
> 
> Blueprint ch21 and **`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`** update the recursive `Q_N` diagram (horizontal trace, open bond ports) and document the root cause. Scope is still **one fusion layer**; full `Q_N` / sequential circuit remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8b79c9a8f80720cb86c33649f47dd022f41e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->