### PR TITLE
feat(MPS/MPDO): retain exact sector gauges

### DIFF
--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -45,6 +45,12 @@ namespace BNTAlgebraTensorClause
 /-- A source-derived two-site vertical canonical decomposition together with the
 sector relabelling and multiplicity-spectrum equality of Appendix C.4.
 
+**Scope restriction (invertible gauge):** This structure records the matched
+sector MPVs and spectrum, but not the line-2057 unitary gauge conclusion.  The
+invertible-gauge sub-result and the missing common-target normalization contract
+are documented in
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
 Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure TwoSiteMultiplicitySpectrum {M : MPOTensor d D}
@@ -56,7 +62,13 @@ structure TwoSiteMultiplicitySpectrum {M : MPOTensor d D}
   arXiv:1606.00608, Appendix C.4, lines 2050--2054. -/
   relabel : Fin H.labelCount ≃ Fin decomposition.labelCount
   /-- The matched one-site and two-site tensors generate the same positive-length matrix
-  product vectors, as in arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
+  product vectors.
+
+  **Scope restriction (invertible gauge):** This field does not record the
+  line-2057 unitary upgrade.  The restriction is documented in
+  `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
   sector_sameMPV : ∀ γ : Fin H.labelCount,
     MPSTensor.SameMPV₂Pos (H.tensor γ) (decomposition.tensor (relabel γ))
   /-- Equality with multiplicity between the matched two-site weights and the products of
@@ -71,6 +83,12 @@ structure TwoSiteMultiplicitySpectrum {M : MPOTensor d D}
 /-- A source-derived two-site multiplicity spectrum together with exact invertible
 conjugacies between its paired normal tensors.
 
+**Scope restriction (invertible gauge):** This structure retains the phase-one
+invertible conjugacy from Appendix C.4, but not the line-2057 conclusion that the
+gauge may be chosen unitary.  The missing common-target normalization contract is
+documented in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` and
+tracked in issue 4645.
+
 Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 structure TwoSiteExactSectorGauge {M : MPOTensor d D}
@@ -79,13 +97,23 @@ structure TwoSiteExactSectorGauge {M : MPOTensor d D}
   arXiv:1606.00608, Appendix C.4, lines 2053--2055. -/
   bondDim_eq : ∀ γ : Fin H.labelCount,
     H.bondDim γ = decomposition.bondDim (relabel γ)
-  /-- The invertible gauge identifying each pair of normal tensors from
-  arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
+  /-- The invertible gauge identifying each pair of normal tensors.
+
+  **Scope restriction (invertible gauge):** This field does not assert that the
+  gauge is unitary.  The line-2057 upgrade is documented in
+  `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
   gauge : ∀ γ : Fin H.labelCount,
     GL (Fin (decomposition.bondDim (relabel γ))) ℂ
   /-- The paired two-site tensor is the exact conjugate of the one-site tensor,
   with no residual scalar phase, as in arXiv:1606.00608, Appendix C.4,
-  lines 2053--2057. -/
+  lines 2053--2057.
+
+  **Scope restriction (invertible gauge):** Exactness here means phase one; the
+  conjugating gauge has not been proved unitary.  The missing line-2057 conclusion
+  is documented in
+  `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`. -/
   tensor_eq : ∀ (γ : Fin H.labelCount) (i : Fin (D * D)),
     decomposition.tensor (relabel γ) i =
       (gauge γ : Matrix (Fin (decomposition.bondDim (relabel γ)))
@@ -120,6 +148,12 @@ in `H`.  No renormalization maps or pre-existing one-site/two-site sector
 correspondence are assumed: full support of the two positive vertical
 decompositions derives the sector relabelling, and eventual BNT linear
 independence derives the power-sum equality.
+
+**Scope restriction (invertible gauge):** The result retains bond-dimension
+equality and phase-one invertible conjugacy, but does not prove the line-2057
+unitary upgrade.  The missing common-target normalization contract is documented
+in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` and tracked in
+issue 4645.
 
 Source: arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -22,6 +22,8 @@ the algebra-to-RFP implication.
 * `MPOTensor.BNTAlgebraTensorClause.toTwoSiteMultiplicitySpectrum` derives a two-site
   vertical canonical decomposition, its sector relabelling, and the multiplicity-spectrum
   comparison directly from the tensor algebra clause.
+* `MPOTensor.BNTAlgebraTensorClause.toTwoSiteExactSectorGauge` additionally retains the
+  bond-dimension identifications and exact invertible gauges of the paired sectors.
 * `MPOTensor.BNTAlgebraTensorClause.toMultiplicitySpectrumComparison` retains the
   resulting multiplicity-spectrum comparison alone.
 
@@ -66,6 +68,32 @@ structure TwoSiteMultiplicitySpectrum {M : MPOTensor d D}
         H.weight x.1 x.2.2.1 * H.weight x.2.1 x.2.2.2.1 *
           H.algebraClause.positiveChi.chi.entry x.1 x.2.1 γ x.2.2.2.2
 
+/-- A source-derived two-site multiplicity spectrum together with exact invertible
+conjugacies between its paired normal tensors.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+structure TwoSiteExactSectorGauge {M : MPOTensor d D}
+    (H : BNTAlgebraTensorClause M) extends TwoSiteMultiplicitySpectrum H where
+  /-- Equality of the paired one-site and two-site bond dimensions from
+  arXiv:1606.00608, Appendix C.4, lines 2053--2055. -/
+  bondDim_eq : ∀ γ : Fin H.labelCount,
+    H.bondDim γ = decomposition.bondDim (relabel γ)
+  /-- The invertible gauge identifying each pair of normal tensors from
+  arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
+  gauge : ∀ γ : Fin H.labelCount,
+    GL (Fin (decomposition.bondDim (relabel γ))) ℂ
+  /-- The paired two-site tensor is the exact conjugate of the one-site tensor,
+  with no residual scalar phase, as in arXiv:1606.00608, Appendix C.4,
+  lines 2053--2057. -/
+  tensor_eq : ∀ (γ : Fin H.labelCount) (i : Fin (D * D)),
+    decomposition.tensor (relabel γ) i =
+      (gauge γ : Matrix (Fin (decomposition.bondDim (relabel γ)))
+        (Fin (decomposition.bondDim (relabel γ))) ℂ) *
+      (cast (congrArg (MPSTensor (D * D)) (bondDim_eq γ)) (H.tensor γ)) i *
+      (↑((gauge γ)⁻¹) : Matrix (Fin (decomposition.bondDim (relabel γ)))
+        (Fin (decomposition.bondDim (relabel γ))) ℂ)
+
 /-- The chosen two-site decomposition and relabelling determine the corresponding
 multiplicity-spectrum comparison.
 
@@ -84,8 +112,8 @@ noncomputable def TwoSiteMultiplicitySpectrum.toComparison
   twoEntry := fun γ => S.decomposition.weight (S.relabel γ)
   spectrum_eq := S.spectrum_eq
 
-/-- The tensor-attached BNT algebra clause determines the multiplicity
-spectrum of a source-derived two-site vertical canonical decomposition.
+/-- The tensor-attached BNT algebra clause determines the two-site multiplicity
+spectrum together with exact invertible gauges of the paired normal tensors.
 
 The chosen one-site tensors and multiplicity entries are exactly those stored
 in `H`.  No renormalization maps or pre-existing one-site/two-site sector
@@ -95,10 +123,10 @@ independence derives the power-sum equality.
 
 Source: arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-noncomputable def toTwoSiteMultiplicitySpectrum
+noncomputable def toTwoSiteExactSectorGauge
     {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
     (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
-    TwoSiteMultiplicitySpectrum H := by
+    TwoSiteExactSectorGauge H := by
   classical
   let chi := H.algebraClause.positiveChi.chi
   let productIndex (γ : Fin H.labelCount) :=
@@ -412,7 +440,26 @@ noncomputable def toTwoSiteMultiplicitySpectrum
     (Fintype.bijective_iff_injective_and_card f).2 ⟨hfInjective, hCard⟩
   let sigma : Fin H.labelCount ≃ Fin D₂.labelCount :=
     Equiv.ofBijective f hfBijective
-  choose zeta hzetaNe hzetaMPV using fun γ ↦ hfPhase γ
+  have hGaugeExists : ∀ γ : Fin H.labelCount,
+      ∃ hdim : H.bondDim γ = D₂.bondDim (sigma γ),
+        MPSTensor.GaugePhaseEquiv
+          (cast (congrArg (MPSTensor (D * D)) hdim) (H.tensor γ))
+          (D₂.tensor (sigma γ)) := by
+    intro γ
+    exact (hfPhase γ).dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+      (H.isCPSVBNT.blocks_normal γ)
+      (D₂.isCPSVBNT.blocks_normal (sigma γ))
+  choose hdim hGaugePhase using hGaugeExists
+  choose gauge zeta hzetaNe hTensor using hGaugePhase
+  have hzetaMPV : ∀ (γ : Fin H.labelCount) (N : ℕ), 0 < N →
+      ∀ σ : Fin N → Fin (D * D),
+        MPSTensor.mpv (D₂.tensor (sigma γ)) σ =
+          zeta γ ^ N * MPSTensor.mpv (H.tensor γ) σ := by
+    intro γ N _hN σ
+    rw [MPSTensor.mpv_eq_pow_mul_of_gaugePhase
+      (A := cast (congrArg (MPSTensor (D * D)) (hdim γ)) (H.tensor γ))
+      (B := D₂.tensor (sigma γ)) (gauge γ) (zeta γ) (hTensor γ) N σ,
+      MPSTensor.mpv_cast_dim (hdim γ) (H.tensor γ) N σ]
   have hzetaNorm : ∀ γ, ‖zeta γ‖ = 1 := by
     intro γ
     have hHH : Tendsto
@@ -489,9 +536,7 @@ noncomputable def toTwoSiteMultiplicitySpectrum
               apply PiLp.ext
               intro σ
               have hMpv := hzetaMPV (sigma.symm δ) L hLPos σ
-              have hfδ : f (sigma.symm δ) = δ :=
-                sigma.apply_symm_apply δ
-              rw [hfδ] at hMpv
+              rw [sigma.apply_symm_apply δ] at hMpv
               simpa only [MPSTensor.mpvState_apply, PiLp.smul_apply,
                 smul_eq_mul] using hMpv
             rw [hMpvState, smul_smul]
@@ -616,7 +661,24 @@ noncomputable def toTwoSiteMultiplicitySpectrum
       have hSpectrum := comparison.spectrum_eq γ
       dsimp only [comparison,
         BNTMultiplicitySpectrumComparison.ofEventuallyEqualPowerSums] at hSpectrum
-      convert hSpectrum using 1 <;> rfl }
+      convert hSpectrum using 1 <;> rfl
+    bondDim_eq := hdim
+    gauge := gauge
+    tensor_eq := by
+      intro γ i
+      have hExact := hTensor γ i
+      rw [hzetaOne γ, one_smul] at hExact
+      exact hExact }
+
+/-- The exact sector gauges determine the source-derived two-site multiplicity spectrum.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+noncomputable def toTwoSiteMultiplicitySpectrum
+    {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    TwoSiteMultiplicitySpectrum H :=
+  (H.toTwoSiteExactSectorGauge hHorizontal hM).toTwoSiteMultiplicitySpectrum
 
 /-- The source-derived two-site multiplicity spectrum entails the corresponding
 multiplicity-spectrum comparison.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -119,15 +119,40 @@
     \cite[Appendix~C.4, lines~2046--2058]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{definition}[Exact gauges for the source-derived two-site sectors]%
+    \label{def:mpdo_bnt_two_site_exact_sector_gauge}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge}
+    \leanok
+    \uses{def:mpdo_bnt_two_site_multiplicity_spectrum}
+    An exact sector gauge for a source-derived two-site multiplicity spectrum
+    additionally records, for every one-site sector $\gamma$, equality of bond
+    dimensions
+    \[
+        d_\gamma=d_{\sigma(\gamma)}
+    \]
+    and an invertible matrix $Z_\gamma\in\operatorname{GL}(d_\gamma,\mathbb C)$
+    such that
+    \[
+        A_{\sigma(\gamma)}^i
+        =Z_\gamma M_\gamma^i Z_\gamma^{-1}
+    \]
+    for every physical index $i$.  Thus the matched normal tensors have no
+    residual scalar phase.  This is the exact invertible conjugacy retained
+    from \cite[Appendix~C.4, lines~2053--2057]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{theorem}[The two-site multiplicity spectrum from the BNT algebra
     clause]%
     \label{thm:mpdo_bnt_algebra_tensor_clause_spectrum}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        toTwoSiteExactSectorGauge}
     \lean{MPOTensor.BNTAlgebraTensorClause.%
         toTwoSiteMultiplicitySpectrum}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo,
         def:mpdo_bnt_algebra_tensor_clause,
         def:mpdo_bnt_two_site_multiplicity_spectrum,
+        def:mpdo_bnt_two_site_exact_sector_gauge,
         def:mpdo_bnt_multiplicity_spectrum_comparison,
         def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
     Let $M$ be an MPDO in horizontal canonical form, equipped with a
@@ -151,7 +176,13 @@
     \]
     as multisets.  Thus this two-site decomposition and relabelling realize
     the multiplicity-spectrum comparison of Appendix~C.4, lines~2046--2058
-    of \cite{Cirac2016MPDO_arXiv}.
+    of \cite{Cirac2016MPDO_arXiv}.  Moreover, the paired bond dimensions agree
+    and there are invertible matrices $Z_\gamma$ satisfying
+    \[
+        A_{\sigma(\gamma)}^i
+        =Z_\gamma M_\gamma^i Z_\gamma^{-1}
+    \]
+    exactly, as in lines~2053--2057.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -168,9 +199,12 @@
     bijectively with those of the two-site vertical canonical decomposition.
     Normalization makes each matching scalar have modulus one, while
     positivity of two consecutive coefficients makes it positive; it is
-    therefore one.  Eventual linear independence of the basis vectors gives
-    the displayed equality of power sums.  The finite positive power-sum
-    identity then gives equality of the corresponding multisets.
+    therefore one.  The normal-tensor matching theorem also supplies equality
+    of the paired bond dimensions and an invertible gauge; after the scalar is
+    one, its gauge-phase relation is precisely the displayed exact conjugacy.
+    Eventual linear independence of the basis vectors gives the displayed
+    equality of power sums.  The finite positive power-sum identity then gives
+    equality of the corresponding multisets.
 \end{proof}
 
 \begin{lemma}[Idempotence for the canonical chi coefficients]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -119,14 +119,14 @@
     \cite[Appendix~C.4, lines~2046--2058]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{definition}[Exact gauges for the source-derived two-site sectors]%
+\begin{definition}[Exact invertible gauges for the source-derived two-site sectors]%
     \label{def:mpdo_bnt_two_site_exact_sector_gauge}
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge}
     \leanok
     \uses{def:mpdo_bnt_two_site_multiplicity_spectrum}
-    An exact sector gauge for a source-derived two-site multiplicity spectrum
-    additionally records, for every one-site sector $\gamma$, equality of bond
-    dimensions
+    The invertible-gauge sub-result for a source-derived two-site multiplicity
+    spectrum additionally records, for every one-site sector $\gamma$, equality
+    of bond dimensions
     \[
         d_\gamma=d_{\sigma(\gamma)}
     \]
@@ -139,6 +139,10 @@
     for every physical index $i$.  Thus the matched normal tensors have no
     residual scalar phase.  This is the exact invertible conjugacy retained
     from \cite[Appendix~C.4, lines~2053--2057]{Cirac2016MPDO_arXiv}.
+    It does not include the further conclusion on line~2057 that $Z_\gamma$
+    may be chosen unitary; that strengthening remains open.
+    % The full line-2057 unitary source step is tracked in issue 4645 and
+    % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{definition}
 
 \begin{theorem}[The two-site multiplicity spectrum from the BNT algebra
@@ -165,8 +169,8 @@
         \widetilde{M^{(2)}}
         =\bigoplus_\delta \nu_\delta\otimes A_\delta.
     \]
-    Its normal-tensor sectors admit a bijection $\sigma$ with the sectors of
-    the full-support one-site product expansion such that $M_\gamma$ and
+    Its normal-tensor sectors are in bijection, via $\sigma$, with the sectors
+    of the full-support one-site product expansion such that $M_\gamma$ and
     $A_{\sigma(\gamma)}$ generate the same matrix product vectors at every
     positive length and, for every $\gamma$,
     \[
@@ -182,7 +186,11 @@
         A_{\sigma(\gamma)}^i
         =Z_\gamma M_\gamma^i Z_\gamma^{-1}
     \]
-    exactly, as in lines~2053--2057.
+    exactly.  This is only the invertible-gauge sub-result of
+    lines~2053--2057: the further conclusion that $Z_\gamma$ may be chosen
+    unitary is not part of this statement and remains open.
+    % The full line-2057 unitary source step is tracked in issue 4645 and
+    % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -1,0 +1,69 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Two-Site Sector Comparison Stops at an Invertible Gauge}
+\author{}
+\date{2026-07-23}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+Appendix~C.4 of \cite{Cirac2016MPDO_arXiv} first matches the one-site and
+two-site normal tensors, up to relabelling, by
+\begin{equation}
+  A_\gamma
+  =e^{i\theta_\gamma}Z_\gamma M_\gamma Z_\gamma^{-1}
+  \label{eq:gauge-phase}
+\end{equation}
+at lines~2053--2056.  Line~2057 then invokes the result labelled
+\path{Prop:IV.12} to conclude both
+\begin{equation}
+  e^{i\theta_\gamma}=1
+  \qquad\text{and}\qquad
+  Z_\gamma=U_\gamma\ \text{unitary}.
+  \label{eq:unitary-upgrade}
+\end{equation}
+
+\section{Formal boundary}
+
+The current two-site comparison retains equality of the matched bond
+dimensions and the invertible matrix $Z_\gamma$ in
+\eqref{eq:gauge-phase}.  Positivity of the coefficients at two consecutive
+lengths proves $e^{i\theta_\gamma}=1$, so the resulting conjugacy is exact.
+This proves the invertible-gauge sub-result of lines~2053--2057.
+
+It does not yet prove the second part of \eqref{eq:unitary-upgrade}.
+The result labelled \path{Prop:IV.12} obtains unitary representatives by
+comparing every copy of a normal tensor with a common canonical target and
+proving proportionality of the corresponding Gram matrices.  The present
+one-site and two-site decompositions are constructed independently.  The
+available normal-tensor matching theorem therefore supplies an invertible
+conjugacy, but no common target or Gram-normalization contract from which that
+particular conjugacy can be rescaled to a unitary one.
+
+\section{Elimination plan}
+
+The missing unitary conclusion is tracked in
+\href{https://github.com/LionSR/TNLean/issues/4645}{issue 4645}.  A faithful
+completion must specialize the positivity argument of \path{Prop:IV.12} to the
+matched one-site and two-site sectors, construct their common canonical target,
+and prove equality up to a positive scalar of the two gauge Gram matrices.
+Rescaling the retained invertible gauge will then give a unitary gauge without
+adding a left-canonical or preassembled-gauge hypothesis.
+
+Until that common-target contract is proved, the formal declaration and its
+blueprint entry are explicitly restricted to phase-one invertible conjugacy.
+The full line-2057 unitary upgrade remains unformalized.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
Closes #4646

## Summary

- retain the bond-dimension equality and invertible gauge supplied by the matched normal-tensor sectors
- use that same gauge-phase witness throughout the coefficient comparison, then record the phase-one exact conjugacy
- preserve the existing two-site multiplicity-spectrum API as a projection of the richer result
- update the Chapter 21 blueprint with the exact GL conjugacy from CPSV16 Appendix C.4, lines 2053-2057
- document the invertible-gauge scope restriction in docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex and keep the full unitary step open in #4645

This PR deliberately does not assert unitarity; that separate source step remains #4645.

## Validation

- lake env lean TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
- lake build TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
- lake build
- leanblueprint checkdecls
- leanblueprint web
- leanblueprint pdf
- standalone paper-gap PDF compile
- python3 scripts/generate_import_aggregators.py --check
- python3 scripts/tactic_pattern_scan.py
- exact-word proof-integrity scan on changed files
- visual inspection of the affected PDF pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is localized to formal MPDO/BNT spectrum proofs and blueprint text, but it refactors the main theorem API and tightens what is claimed relative to the paper (invertible vs unitary), so reviewers should confirm projections and gap documentation align with dependents.
> 
> **Overview**
> The two-site BNT algebra comparison now **formalizes the invertible-gauge sub-result** from CPSV16 Appendix C.4 (lines 2053–2057), not only the multiplicity spectrum.
> 
> A new structure **`TwoSiteExactSectorGauge`** extends the existing two-site multiplicity data with **paired bond-dimension equality**, an invertible **`GL` gauge** per sector, and **`tensor_eq`** stating exact conjugacy with no residual scalar phase (after the proof forces the gauge phase to 1). The main constructive proof is renamed to **`toTwoSiteExactSectorGauge`**, which extracts gauge witnesses from normal-tensor matching and threads them through the coefficient comparison; **`toTwoSiteMultiplicitySpectrum`** is now a thin projection of that richer result so downstream APIs stay unchanged.
> 
> Docstrings and blueprint Chapter 21 are updated to match, including a new definition for exact invertible gauges and theorem text for the GL conjugacy. A new **`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`** note states explicitly that **unitary** gauges (line 2057) remain open and tracked in issue 4645.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1098b3a19286fd0b62c01515e55fd44c9e01083d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
