### PR TITLE
feat(MPS/MPDO): prove cyclic-active Markov decomposition

### DIFF
--- a/TNLean/Algebra/KroneckerFactorPositivity.lean
+++ b/TNLean/Algebra/KroneckerFactorPositivity.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Analysis.Complex.Order
+import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.RCLike.Basic
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.LinearAlgebra.Matrix.PosDef
@@ -31,6 +32,8 @@ a complex matrix is determined by its quadratic form.
   the Hermitian property is automatic.
 - `Matrix.star_dotProduct_kronecker_mulVec_prod`: on a product vector the
   quadratic form of a Kronecker product factors.
+- `Matrix.finKronecker_posSemidef`: a finite Kronecker product of positive
+  semidefinite matrices is positive semidefinite.
 - `Matrix.exists_smul_posSemidef_of_kronecker_posSemidef`: the positive
   rescaling of the two factors of a nonzero positive semidefinite Kronecker
   product.
@@ -293,6 +296,38 @@ def finKronecker {N : ℕ} {α : Fin N → Type*} [∀ n, Fintype (α n)]
     (A : (n : Fin N) → Matrix (α n) (α n) ℂ) (x y : (n : Fin N) → α n) :
     finKronecker A x y = ∏ n, A n (x n) (y n) :=
   rfl
+
+/-- A finite Kronecker product of positive semidefinite matrices is positive
+semidefinite. -/
+theorem finKronecker_posSemidef :
+    ∀ {N : ℕ} {I : Fin N → Type*} [∀ i, Fintype (I i)]
+      (M : (i : Fin N) → Matrix (I i) (I i) ℂ),
+      (∀ i, (M i).PosSemidef) → (finKronecker M).PosSemidef := by
+  intro N
+  induction N with
+  | zero =>
+      intro I _ M hM
+      have hOne : finKronecker M = 1 := by
+        ext x y
+        have hxy : x = y := Subsingleton.elim x y
+        subst y
+        simp [finKronecker_apply]
+      rw [hOne]
+      exact PosSemidef.one
+  | succ N ih =>
+      intro I _ M hM
+      have htail := ih (Fin.tail M) (fun i ↦ hM i.succ)
+      have hprod := (hM 0).kronecker htail
+      rw [← posSemidef_submatrix_equiv (M := finKronecker M) (Fin.consEquiv I)]
+      have heq :
+          (finKronecker M).submatrix (Fin.consEquiv I) (Fin.consEquiv I) =
+            M 0 ⊗ₖ finKronecker (Fin.tail M) := by
+        ext ⟨a, x⟩ ⟨b, y⟩
+        rw [Matrix.submatrix_apply, finKronecker_apply,
+          Matrix.kroneckerMap_apply, Fin.prod_univ_succ]
+        simp [Fin.cons_zero, Fin.cons_succ, finKronecker_apply, Fin.tail]
+      rw [heq]
+      exact hprod
 
 /-- A finite Kronecker product of nonzero matrices is nonzero: the entry at a
 choice of nonzero-witnessing row/column pair for each factor is itself

--- a/TNLean/Algebra/PerronFrobenius/Idempotent.lean
+++ b/TNLean/Algebra/PerronFrobenius/Idempotent.lean
@@ -107,6 +107,20 @@ theorem IsPrimitive.smul_of_pos [DecidableEq n]
   rw [smul_pow, Matrix.smul_apply]
   exact mul_pos (pow_pos hc m) (hpos i j)
 
+/-- If a primitive real matrix has equal second and third powers, then its
+square is strictly positive entrywise. -/
+theorem IsPrimitive.pow_two_pos_of_pow_two_eq_pow_three
+    [DecidableEq n] [Nonempty n] {T : Matrix n n ℝ}
+    (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) (i j : n) :
+    0 < (T ^ 2) i j := by
+  obtain ⟨m, _, hpos⟩ := hT.exists_pos_pow
+  have htwom_pos : 0 < (T ^ (m + m)) i j := by
+    rw [pow_add, Matrix.mul_apply]
+    exact Finset.sum_pos (fun k _ ↦ mul_pos (hpos i k) (hpos k j))
+      Finset.univ_nonempty
+  rw [← pow_eq_pow_two_of_pow_two_eq_pow_three h (m + m) (by omega)]
+  exact htwom_pos
+
 /-- If a primitive nonnegative real matrix has equal second and third powers,
 then its square has rank one.
 
@@ -118,18 +132,11 @@ theorem IsPrimitive.rank_pow_two_eq_one_of_pow_two_eq_pow_three
     [DecidableEq n] [Nonempty n] {T : Matrix n n ℝ}
     (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :
     (T ^ 2).rank = 1 := by
-  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
-  have htwom_pos (i j : n) : 0 < (T ^ (m + m)) i j := by
-    rw [pow_add, Matrix.mul_apply]
-    exact Finset.sum_pos (fun k _ ↦ mul_pos (hpos i k) (hpos k j))
-      Finset.univ_nonempty
-  have hsq_pos (i j : n) : 0 < (T ^ 2) i j := by
-    rw [← pow_eq_pow_two_of_pow_two_eq_pow_three h (m + m) (by omega)]
-    exact htwom_pos i j
   have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
     rw [← pow_add]
     exact pow_eq_pow_two_of_pow_two_eq_pow_three h 4 (by omega)
-  exact rank_eq_one_of_pos_of_mul_self_eq_self hsq_pos hsq_idem
+  exact rank_eq_one_of_pos_of_mul_self_eq_self
+    (hT.pow_two_pos_of_pow_two_eq_pow_three h) hsq_idem
 
 /-- If a primitive nonnegative real matrix has equal second and third powers,
 then its square has the form $a b^{\mathsf T}$ for real vectors satisfying
@@ -140,20 +147,20 @@ coefficient in arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines
 1606--1616.  It factors `T ^ 2`, not the one-step matrix `T` printed at
 line 1613. -/
 theorem IsPrimitive.exists_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three
-    {N : ℕ} [NeZero N] {T : Matrix (Fin N) (Fin N) ℝ}
+    [DecidableEq n] [Nonempty n] {T : Matrix n n ℝ}
     (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :
-    ∃ a b : Fin N → ℝ, T ^ 2 = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
+    ∃ a b : n → ℝ, T ^ 2 = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
   have hsq_idem : T ^ 2 * T ^ 2 = T ^ 2 := by
     rw [← pow_add]
     exact pow_eq_pow_two_of_pow_two_eq_pow_three h 4 (by omega)
   have hrank := hT.rank_pow_two_eq_one_of_pow_two_eq_pow_three h
-  let f : (Fin N → ℝ) →ₗ[ℝ] (Fin N → ℝ) := Matrix.toLin' (T ^ 2)
+  let f : (n → ℝ) →ₗ[ℝ] (n → ℝ) := Matrix.toLin' (T ^ 2)
   have hf : IsIdempotentElem f := by
     change Matrix.toLin' (T ^ 2) ∘ₗ Matrix.toLin' (T ^ 2) = Matrix.toLin' (T ^ 2)
     rw [← Matrix.toLin'_mul, hsq_idem]
   have hrange : Module.finrank ℝ (LinearMap.range f) = 1 := by
     rw [Matrix.rank_eq_finrank_range_toLin (T ^ 2)
-      (Pi.basisFun ℝ (Fin N)) (Pi.basisFun ℝ (Fin N)), Matrix.toLin_eq_toLin'] at hrank
+      (Pi.basisFun ℝ n) (Pi.basisFun ℝ n), Matrix.toLin_eq_toLin'] at hrank
     exact hrank
   have htrace : Matrix.trace (T ^ 2) = 1 := by
     have hproj := (LinearMap.isProj_range_iff_isIdempotentElem f).2 hf |>.trace
@@ -165,5 +172,22 @@ theorem IsPrimitive.exists_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three
   refine ⟨a, b, hab, ?_⟩
   rw [← Matrix.trace_vecMulVec, ← hab]
   exact htrace
+
+/-- If a primitive nonnegative real matrix has equal second and third powers,
+then its square factors as an outer product of two strictly positive vectors
+whose dot product is one. -/
+theorem IsPrimitive.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three
+    [DecidableEq n] [Nonempty n] {T : Matrix n n ℝ}
+    (hT : T.IsPrimitive) (h : T ^ 2 = T ^ 3) :
+    ∃ a b : n → ℝ, (∀ i, 0 < a i) ∧ (∀ j, 0 < b j) ∧
+      T ^ 2 = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
+  obtain ⟨a, b, hab, hdot⟩ :=
+    hT.exists_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three h
+  have htrace : Matrix.trace (T ^ 2) = 1 := by
+    rw [hab, Matrix.trace_vecMulVec]
+    exact hdot
+  exact Matrix.HasRankOneFactorization.exists_pos_factorization_of_pos_of_trace_eq_one
+    (T := T ^ 2) ⟨a, b, hab⟩
+    (hT.pow_two_pos_of_pow_two_eq_pow_three h) htrace
 
 end Matrix

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -78,8 +78,8 @@ variable {n : ℕ}
 
 /-- A square real matrix has the rank-one factorization of Appendix C.2,
 Lemma C.4 if it is an outer product of two vectors. -/
-def HasRankOneFactorization (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
-  ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b
+def HasRankOneFactorization {ι : Type*} (T : Matrix ι ι ℝ) : Prop :=
+  ∃ a b : ι → ℝ, T = Matrix.vecMulVec a b
 
 /-- The traces of all positive powers of `T` agree with the trace of `T`
 itself. This is the matrix-theoretic consequence of the ZCL step used in
@@ -94,11 +94,12 @@ which is invisible to traces of powers.  It is the algebraic conclusion needed
 after retaining the operator-valued ZCL identity in arXiv:1606.00608,
 Appendix C.2, lines 1489--1497. -/
 theorem hasRankOneFactorization_of_mul_self_eq_self
-    {T : Matrix (Fin n) (Fin n) ℝ}
+    {ι : Type*} [Fintype ι]
+    {T : Matrix ι ι ℝ}
     (hTT : T * T = T) (hTrace : Matrix.trace T = 1) :
     HasRankOneFactorization T := by
   classical
-  let f : (Fin n → ℝ) →ₗ[ℝ] (Fin n → ℝ) := Matrix.toLin' T
+  let f : (ι → ℝ) →ₗ[ℝ] (ι → ℝ) := Matrix.toLin' T
   have hf : IsIdempotentElem f := by
     change Matrix.toLin' T ∘ₗ Matrix.toLin' T = Matrix.toLin' T
     rw [← Matrix.toLin'_mul, hTT]
@@ -107,7 +108,7 @@ theorem hasRankOneFactorization_of_mul_self_eq_self
     rw [Matrix.trace_toLin'_eq, hTrace] at h
     exact_mod_cast h.symm
   rcases finrank_eq_one_iff'.mp hrank with ⟨u, hu, hspan⟩
-  let b : Fin n → ℝ := fun j ↦
+  let b : ι → ℝ := fun j ↦
     Classical.choose (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
   refine ⟨u.1, b, ?_⟩
   ext i j
@@ -119,6 +120,34 @@ theorem hasRankOneFactorization_of_mul_self_eq_self
   change Classical.choose _ * u.1 i = f (Pi.single j 1) i at hb'
   rw [heval] at hb'
   simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
+
+/-- A strictly positive trace-one matrix with a rank-one factorization admits
+one whose two factors are strictly positive and have dot product one. -/
+theorem HasRankOneFactorization.exists_pos_factorization_of_pos_of_trace_eq_one
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {T : Matrix ι ι ℝ} (hT : HasRankOneFactorization T)
+    (hpos : ∀ i j, 0 < T i j) (htrace : Matrix.trace T = 1) :
+    ∃ a b : ι → ℝ, (∀ i, 0 < a i) ∧ (∀ j, 0 < b j) ∧
+      T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
+  classical
+  obtain ⟨u, v, huv⟩ := hT
+  let i₀ : ι := Classical.choice inferInstance
+  let a : ι → ℝ := fun i ↦ T i i₀
+  let b : ι → ℝ := fun j ↦ T i₀ j / T i₀ i₀
+  have hcross (i j : ι) : T i j * T i₀ i₀ = T i i₀ * T i₀ j := by
+    rw [huv]
+    simp only [Matrix.vecMulVec_apply]
+    ring
+  have hab : T = Matrix.vecMulVec a b := by
+    ext i j
+    simp only [a, b, Matrix.vecMulVec_apply]
+    rw [← mul_div_assoc]
+    rw [eq_div_iff (ne_of_gt (hpos i₀ i₀))]
+    exact hcross i j
+  refine ⟨a, b, fun i ↦ hpos i i₀,
+    fun j ↦ div_pos (hpos i₀ j) (hpos i₀ i₀), hab, ?_⟩
+  rw [← Matrix.trace_vecMulVec, ← hab]
+  exact htrace
 
 /-- An idempotent matrix has constant traces of positive powers.  This recovers
 the display tr(T^N) = tr(T) in the proof of Lemma C.5 (arXiv:1606.00608,

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -79,6 +79,16 @@ import TNLean.MPS.MPDO.CompleteZipperFusionFourfold
 import TNLean.MPS.MPDO.CompleteZipperFusionInverse
 import TNLean.MPS.MPDO.CompleteZipperFusionPentagon
 import TNLean.MPS.MPDO.CompleteZipperFusionSupport
+import TNLean.MPS.MPDO.CyclicActiveCutCoordinates
+import TNLean.MPS.MPDO.CyclicActiveCutRegrouping
+import TNLean.MPS.MPDO.CyclicActiveCutStates
+import TNLean.MPS.MPDO.CyclicActiveFourthRegion
+import TNLean.MPS.MPDO.CyclicActiveFourthRegionContraction
+import TNLean.MPS.MPDO.CyclicActiveFourthRegionFormula
+import TNLean.MPS.MPDO.CyclicActiveMarkov
+import TNLean.MPS.MPDO.CyclicActiveMarkovDecomposition
+import TNLean.MPS.MPDO.CyclicActiveMarkovNormalization
+import TNLean.MPS.MPDO.CyclicActiveRetainedCoordinates
 import TNLean.MPS.MPDO.CyclicActiveSectorRestriction
 import TNLean.MPS.MPDO.CyclicActiveThreeBoundaryTrace
 import TNLean.MPS.MPDO.CyclicEdgeWeightTensor

--- a/TNLean/MPS/MPDO/CyclicActiveCutCoordinates.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutCoordinates.lean
@@ -1,0 +1,831 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.HayashiMarkovStructure
+import TNLean.MPS.MPDO.CyclicActiveMarkovNormalization
+
+/-!
+# Coordinates for cyclic-active one-site cuts
+
+This file constructs the dependent left, middle, and right coordinate
+equivalences for separating a retained chain at an arbitrary one-site cut.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+universe u
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The left boundary factor produced by the separated two-step
+coefficient.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The sum is restricted to
+cyclic-active sectors. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveLeftBoundary
+    (F : PhysicalSectorFactorization K)
+    (b : F.CyclicActiveSector → ℝ) (kFirst : F.CyclicActiveSector) :
+    Matrix (Fin (F.leftDim kFirst)) (Fin (F.leftDim kFirst)) ℂ :=
+  ∑ h, ((b h : ℂ) •
+    Matrix.partialTraceLeft (F.neighboringOperator h kFirst))
+
+/-- The right boundary factor produced by the separated two-step
+coefficient.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The sum is restricted to
+cyclic-active sectors. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveRightBoundary
+    (F : PhysicalSectorFactorization K)
+    (a : F.CyclicActiveSector → ℝ) (kLast : F.CyclicActiveSector) :
+    Matrix (Fin (F.rightDim kLast)) (Fin (F.rightDim kLast)) ℂ :=
+  ∑ q, ((a q : ℂ) •
+    Matrix.partialTraceRight (F.neighboringOperator kLast q))
+
+/-- Nonnegative boundary weights make the left cyclic-active boundary factor
+positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** Positivity is proved after
+restricting the boundary sum to cyclic-active sectors. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveLeftBoundary_posSemidef
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (b : F.CyclicActiveSector → ℝ) (hb : ∀ h, 0 ≤ b h)
+    (kFirst : F.CyclicActiveSector) :
+    (F.cyclicActiveLeftBoundary b kFirst).PosSemidef := by
+  classical
+  apply Matrix.posSemidef_sum Finset.univ
+  intro h hh
+  exact (hpos h kFirst).partialTraceLeft.smul
+    (a := (b h : ℂ)) (by exact_mod_cast hb h)
+
+/-- Nonnegative boundary weights make the right cyclic-active boundary factor
+positive semidefinite.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** Positivity is proved after
+restricting the boundary sum to cyclic-active sectors. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveRightBoundary_posSemidef
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (a : F.CyclicActiveSector → ℝ) (ha : ∀ q, 0 ≤ a q)
+    (kLast : F.CyclicActiveSector) :
+    (F.cyclicActiveRightBoundary a kLast).PosSemidef := by
+  classical
+  apply Matrix.posSemidef_sum Finset.univ
+  intro q hq
+  exact (hpos kLast q).partialTraceRight.smul
+    (a := (a q : ℂ)) (by exact_mod_cast ha q)
+
+/-- The separated cyclic-active boundary is the Kronecker product of its
+right and left factors.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** Both factors come from the
+restricted two-step coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveSeparatedBoundary_eq_right_kronecker_left
+    (F : PhysicalSectorFactorization K)
+    (a b : F.CyclicActiveSector → ℝ)
+    (kFirst kLast : F.CyclicActiveSector) :
+    F.cyclicActiveSeparatedBoundary a b kFirst kLast =
+      F.cyclicActiveRightBoundary a kLast ⊗ₖ
+        F.cyclicActiveLeftBoundary b kFirst := by
+  rfl
+
+/-- Open-edge indices to the left of a distinguished final site.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** These coordinates describe the
+retained left path in the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+abbrev LeftOpenEdgeIndex (F : PhysicalSectorFactorization K) {A : ℕ}
+    (k : Fin (A + 1) → Fin F.sectorCount) :=
+  Fin (F.leftDim (k 0)) ×
+    ((i : Fin A) → F.NeighborIndex (k i.castSucc) (k i.succ))
+
+/-- Regroup the site factors preceding a distinguished final site into its
+left boundary coordinate and the intervening neighboring edges.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identification is used for
+the retained left path in the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def leftFiberOpenEdgeEquiv (F : PhysicalSectorFactorization K) {A : ℕ}
+    (k : Fin (A + 1) → Fin F.sectorCount) :
+    (((i : Fin A) → F.SectorIndex (k i.castSucc)) ×
+      Fin (F.leftDim (k (Fin.last A)))) ≃ F.LeftOpenEdgeIndex k := by
+  cases A with
+  | zero =>
+      exact {
+        toFun := fun x ↦ (x.2, finZeroElim)
+        invFun := fun z ↦ (finZeroElim, z.1)
+        left_inv := by
+          rintro ⟨x, l⟩
+          apply Prod.ext
+          · funext i; exact Fin.elim0 i
+          · rfl
+        right_inv := by
+          rintro ⟨l, z⟩
+          apply Prod.ext
+          · rfl
+          · funext i; exact Fin.elim0 i }
+  | succ n =>
+      exact {
+        toFun := fun x ↦
+          ((x.1 0).1, fun i ↦ ((x.1 i).2,
+            Fin.lastCases x.2 (fun p ↦ (x.1 p.succ).1) i))
+        invFun := fun z ↦
+          (fun i ↦ (Fin.cases z.1 (fun p ↦ (z.2 p.castSucc).2) i, (z.2 i).1),
+            (z.2 (Fin.last n)).2)
+        left_inv := by
+          rintro ⟨x, l⟩
+          apply Prod.ext
+          · funext i
+            apply Prod.ext
+            · apply Fin.ext
+              cases i using Fin.cases <;> simp
+            · rfl
+          · apply Fin.ext
+            simp
+        right_inv := by
+          rintro ⟨l, z⟩
+          apply Prod.ext
+          · apply Fin.ext
+            simp
+          · funext i
+            apply Prod.ext
+            · rfl
+            · apply Fin.ext
+              cases i using Fin.lastCases <;> simp }
+
+/-- Open-edge indices to the right of a distinguished initial site.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** These coordinates describe the
+retained right path in the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+abbrev RightOpenEdgeIndex (F : PhysicalSectorFactorization K) {C : ℕ}
+    (k : Fin (C + 1) → Fin F.sectorCount) :=
+  ((i : Fin C) → F.NeighborIndex (k i.castSucc) (k i.succ)) ×
+    Fin (F.rightDim (k (Fin.last C)))
+
+/-- Regroup the site factors following a distinguished initial site into the
+intervening neighboring edges and its right boundary coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identification is used for
+the retained right path in the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def rightFiberOpenEdgeEquiv (F : PhysicalSectorFactorization K) {C : ℕ}
+    (k : Fin (C + 1) → Fin F.sectorCount) :
+    (Fin (F.rightDim (k 0)) ×
+      ((i : Fin C) → F.SectorIndex (k i.succ))) ≃ F.RightOpenEdgeIndex k := by
+  cases C with
+  | zero =>
+      exact {
+        toFun := fun x ↦ (finZeroElim, x.1)
+        invFun := fun z ↦ (z.2, finZeroElim)
+        left_inv := by
+          rintro ⟨r, x⟩
+          apply Prod.ext
+          · rfl
+          · funext i; exact Fin.elim0 i
+        right_inv := by
+          rintro ⟨z, r⟩
+          apply Prod.ext
+          · funext i; exact Fin.elim0 i
+          · rfl }
+  | succ n =>
+      exact {
+        toFun := fun x ↦
+          (fun i ↦ (Fin.cases x.1 (fun p ↦ (x.2 p.castSucc).2) i, (x.2 i).1),
+            (x.2 (Fin.last n)).2)
+        invFun := fun z ↦
+          ((z.1 0).1, fun i ↦ ((z.1 i).2,
+            Fin.lastCases z.2 (fun p ↦ (z.1 p.succ).1) i))
+        left_inv := by
+          rintro ⟨r, x⟩
+          apply Prod.ext
+          · apply Fin.ext
+            simp
+          · funext i
+            apply Prod.ext
+            · rfl
+            · apply Fin.ext
+              cases i using Fin.lastCases <;> simp
+        right_inv := by
+          rintro ⟨z, r⟩
+          apply Prod.ext
+          · funext i
+            apply Prod.ext
+            · apply Fin.ext
+              cases i using Fin.cases <;> simp
+            · rfl
+          · apply Fin.ext
+            simp }
+
+/-- The one-site sector decomposition in the sector-coordinate physical
+basis.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The middle-site coordinates are
+those of the retained sector decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def sectorCoordinateMiddleEquiv
+    (F : PhysicalSectorFactorization K) :
+    Fin (Fintype.card (SectorSiteIndex F) ^ 1) ≃
+      Σ j : Fin F.sectorCount, Fin (F.leftDim j) × Fin (F.rightDim j) :=
+  ((Equiv.funUnique (Fin 1) (Fin (Fintype.card (SectorSiteIndex F)))).symm.trans
+    finFunctionFinEquiv).symm.trans F.sectorFinEquiv
+
+/-- The sector component of a chain coordinate at a site is the sector of
+the corresponding physical coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity supplies the sector
+coordinates for the retained decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem sectorCoordinateChainEquiv_apply_fst
+    (F : PhysicalSectorFactorization K) (N : ℕ)
+    (x : Fin N → Fin (Fintype.card (SectorSiteIndex F))) (i : Fin N) :
+    (F.sectorCoordinateChainEquiv N x).1 i = (F.sectorFinEquiv (x i)).1 := by
+  let s := F.sectorCoordinateChainEquiv N x
+  have h := F.sectorCoordinateChainEquiv_symm_apply N s.1 s.2 i
+  rw [show (F.sectorCoordinateChainEquiv N).symm s = x by
+    exact (F.sectorCoordinateChainEquiv N).symm_apply_apply x] at h
+  have he := congrArg F.sectorFinEquiv h
+  simpa [s] using (congrArg Sigma.fst he).symm
+
+/-- The fiber component of a chain coordinate at a site agrees with the fiber
+of the corresponding physical coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity supplies the
+dependent fiber coordinates for the retained decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem sectorCoordinateChainEquiv_apply_snd_heq
+    (F : PhysicalSectorFactorization K) (N : ℕ)
+    (x : Fin N → Fin (Fintype.card (SectorSiteIndex F))) (i : Fin N) :
+    (F.sectorCoordinateChainEquiv N x).2 i ≍
+      (F.sectorFinEquiv (x i)).2 := by
+  let s := F.sectorCoordinateChainEquiv N x
+  have h := F.sectorCoordinateChainEquiv_symm_apply N s.1 s.2 i
+  rw [show (F.sectorCoordinateChainEquiv N).symm s = x by
+    exact (F.sectorCoordinateChainEquiv N).symm_apply_apply x] at h
+  have he := congrArg F.sectorFinEquiv h
+  have he' : F.sectorFinEquiv (x i) = ⟨s.1 i, s.2 i⟩ := by
+    simpa using he
+  change s.2 i ≍ (F.sectorFinEquiv (x i)).2
+  exact (Sigma.mk.inj_iff.mp he').2.symm
+
+/-- Adjoin a distinguished final sector to a sector word.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The resulting word indexes a
+retained left path in the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def leftSectorWord (F : PhysicalSectorFactorization K) {A : ℕ}
+    (j : Fin F.sectorCount) (k : Fin A → Fin F.sectorCount) :
+    Fin (A + 1) → Fin F.sectorCount :=
+  Fin.lastCases j k
+
+/-- Adjoin a distinguished initial sector to a sector word.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The resulting word indexes a
+retained right path in the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def rightSectorWord (F : PhysicalSectorFactorization K) {C : ℕ}
+    (j : Fin F.sectorCount) (k : Fin C → Fin F.sectorCount) :
+    Fin (C + 1) → Fin F.sectorCount :=
+  Fin.cases j k
+
+/-- Regroup a fixed left sector fiber and the distinguished middle-left factor
+into left open-edge coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the left fiber
+identification for the retained decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def leftFixedFiberOpenEdgeEquiv
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (j : Fin F.sectorCount) (k : Fin A → Fin F.sectorCount) :
+    (F.SectorChainFiber k × Fin (F.leftDim j)) ≃
+      F.LeftOpenEdgeIndex (F.leftSectorWord j k) := by
+  let eFiber : F.SectorChainFiber k ≃
+      ((i : Fin A) → F.SectorIndex (F.leftSectorWord j k i.castSucc)) :=
+    Equiv.piCongrRight fun i ↦ Equiv.cast <| by simp [leftSectorWord]
+  exact (eFiber.prodCongr (Equiv.cast (by simp [leftSectorWord]))).trans
+    (F.leftFiberOpenEdgeEquiv (A := A) (F.leftSectorWord j k))
+
+/-- Regroup the distinguished middle-right factor and a fixed right sector
+fiber into right open-edge coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the right fiber
+identification for the retained decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def rightFixedFiberOpenEdgeEquiv
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (j : Fin F.sectorCount) (k : Fin C → Fin F.sectorCount) :
+    (Fin (F.rightDim j) × F.SectorChainFiber k) ≃
+      F.RightOpenEdgeIndex (F.rightSectorWord j k) := by
+  simpa only [SectorChainFiber, rightSectorWord, Fin.cases_zero,
+    Fin.cases_succ] using
+      F.rightFiberOpenEdgeEquiv (C := C) (F.rightSectorWord j k)
+
+/-- The left physical configurations and the middle left factor, regrouped
+as a direct sum of left open-edge configurations.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The direct sum is the left side of
+the retained cut decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def leftSectorOpenEdgeEquiv
+    (F : PhysicalSectorFactorization K) (A : ℕ) (j : Fin F.sectorCount) :
+    (Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j)) ≃
+      Σ k : Fin A → Fin F.sectorCount, F.LeftOpenEdgeIndex (F.leftSectorWord j k) :=
+  (finFunctionFinEquiv.symm.prodCongr (Equiv.refl _)).trans <|
+    ((F.sectorCoordinateChainEquiv A).prodCongr (Equiv.refl _)).trans <|
+      (Equiv.sigmaProdDistrib
+        (fun k : Fin A → Fin F.sectorCount ↦ F.SectorChainFiber k)
+        (Fin (F.leftDim j))).trans <|
+        Equiv.sigmaCongrRight fun k : Fin A → Fin F.sectorCount ↦
+          F.leftFixedFiberOpenEdgeEquiv j k
+
+/-- The middle right factor and right physical configurations, regrouped as
+a direct sum of right open-edge configurations.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The direct sum is the right side
+of the retained cut decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def rightSectorOpenEdgeEquiv
+    (F : PhysicalSectorFactorization K) (C : ℕ) (j : Fin F.sectorCount) :
+    (Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C)) ≃
+      Σ k : Fin C → Fin F.sectorCount, F.RightOpenEdgeIndex (F.rightSectorWord j k) :=
+  ((Equiv.refl _).prodCongr finFunctionFinEquiv.symm).trans <|
+    ((Equiv.refl _).prodCongr (F.sectorCoordinateChainEquiv C)).trans <|
+      (Equiv.prodComm _ _).trans <|
+        (Equiv.sigmaProdDistrib
+          (fun k : Fin C → Fin F.sectorCount ↦ F.SectorChainFiber k)
+          (Fin (F.rightDim j))).trans <|
+          (Equiv.sigmaCongrRight fun k : Fin C → Fin F.sectorCount ↦
+            Equiv.prodComm (F.SectorChainFiber k) (Fin (F.rightDim j))).trans <|
+            Equiv.sigmaCongrRight fun k : Fin C → Fin F.sectorCount ↦
+              F.rightFixedFiberOpenEdgeEquiv j k
+
+/-- The sector word of the left open-edge identification is the sector word
+of the left physical chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+left retained-sector word. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem leftSectorOpenEdgeEquiv_apply_fst
+    (F : PhysicalSectorFactorization K) (A : ℕ) (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j)) :
+    (F.leftSectorOpenEdgeEquiv A j l).1 =
+      (F.sectorCoordinateChainEquiv A (finFunctionFinEquiv.symm l.1)).1 := by
+  rfl
+
+/-- The sector word of the right open-edge identification is the sector word
+of the right physical chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+right retained-sector word. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem rightSectorOpenEdgeEquiv_apply_fst
+    (F : PhysicalSectorFactorization K) (C : ℕ) (j : Fin F.sectorCount)
+    (r : Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C)) :
+    (F.rightSectorOpenEdgeEquiv C j r).1 =
+      (F.sectorCoordinateChainEquiv C (finFunctionFinEquiv.symm r.2)).1 := by
+  rfl
+
+/-- The inverse left open-edge identification recovers the left chain fiber
+and the middle-left boundary coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+is used in the retained cut decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem leftSectorOpenEdgeEquiv_symm_fiber_heq
+    (F : PhysicalSectorFactorization K) (A : ℕ) (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j)) :
+    let s := F.leftSectorOpenEdgeEquiv A j l
+    (F.leftFixedFiberOpenEdgeEquiv j s.1).symm s.2 ≍
+      ((F.sectorCoordinateChainEquiv A (finFunctionFinEquiv.symm l.1)).2,
+        l.2) := by
+  let sL := F.sectorCoordinateChainEquiv A (finFunctionFinEquiv.symm l.1)
+  let tL : Σ k : Fin A → Fin F.sectorCount,
+      F.SectorChainFiber k × Fin (F.leftDim j) := ⟨sL.1, (sL.2, l.2)⟩
+  let eL : (Σ k : Fin A → Fin F.sectorCount,
+      F.SectorChainFiber k × Fin (F.leftDim j)) ≃
+      (Σ k : Fin A → Fin F.sectorCount,
+        F.LeftOpenEdgeIndex (F.leftSectorWord j k)) :=
+    Equiv.sigmaCongrRight fun k ↦ F.leftFixedFiberOpenEdgeEquiv j k
+  have hL0 := eL.symm_apply_apply tL
+  have hL1 :
+      (F.leftFixedFiberOpenEdgeEquiv j (eL tL).1).symm (eL tL).2 ≍
+        tL.2 := (Sigma.mk.inj_iff.mp hL0).2
+  convert hL1 using 1;
+    simp [leftSectorOpenEdgeEquiv, sL, tL, eL]; rfl
+
+/-- The inverse right open-edge identification recovers the middle-right
+boundary coordinate and the right chain fiber.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+is used in the retained cut decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem rightSectorOpenEdgeEquiv_symm_fiber_heq
+    (F : PhysicalSectorFactorization K) (C : ℕ) (j : Fin F.sectorCount)
+    (r : Fin (F.rightDim j) ×
+      Fin (Fintype.card (SectorSiteIndex F) ^ C)) :
+    let s := F.rightSectorOpenEdgeEquiv C j r
+    (F.rightFixedFiberOpenEdgeEquiv j s.1).symm s.2 ≍
+      (r.1, (F.sectorCoordinateChainEquiv C
+        (finFunctionFinEquiv.symm r.2)).2) := by
+  let sR := F.sectorCoordinateChainEquiv C (finFunctionFinEquiv.symm r.2)
+  let tR : Σ k : Fin C → Fin F.sectorCount,
+      Fin (F.rightDim j) × F.SectorChainFiber k := ⟨sR.1, (r.1, sR.2)⟩
+  let eR : (Σ k : Fin C → Fin F.sectorCount,
+      Fin (F.rightDim j) × F.SectorChainFiber k) ≃
+      (Σ k : Fin C → Fin F.sectorCount,
+        F.RightOpenEdgeIndex (F.rightSectorWord j k)) :=
+    Equiv.sigmaCongrRight fun k ↦ F.rightFixedFiberOpenEdgeEquiv j k
+  have hR0 := eR.symm_apply_apply tR
+  have hR1 :
+      (F.rightFixedFiberOpenEdgeEquiv j (eR tR).1).symm (eR tR).2 ≍
+        tR.2 := (Sigma.mk.inj_iff.mp hR0).2
+  convert hR1 using 1;
+    simp [rightSectorOpenEdgeEquiv, sR, tR, eR]; rfl
+
+/-- The inverse left open-edge identification recovers the prescribed
+middle-left boundary coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity belongs to
+the retained cut decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem leftSectorOpenEdgeEquiv_symm_last_eq
+    (F : PhysicalSectorFactorization K) (A : ℕ) (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j)) :
+    let s := F.leftSectorOpenEdgeEquiv A j l
+    ((F.leftFixedFiberOpenEdgeEquiv j s.1).symm s.2).2 = l.2 := by
+  let sL := F.sectorCoordinateChainEquiv A (finFunctionFinEquiv.symm l.1)
+  let tL : Σ k : Fin A → Fin F.sectorCount,
+      F.SectorChainFiber k × Fin (F.leftDim j) := ⟨sL.1, (sL.2, l.2)⟩
+  let eL : (Σ k : Fin A → Fin F.sectorCount,
+      F.SectorChainFiber k × Fin (F.leftDim j)) ≃
+      (Σ k : Fin A → Fin F.sectorCount,
+        F.LeftOpenEdgeIndex (F.leftSectorWord j k)) :=
+    Equiv.sigmaCongrRight fun k ↦ F.leftFixedFiberOpenEdgeEquiv j k
+  have hL0 := eL.symm_apply_apply tL
+  have hL1heq :
+      (F.leftFixedFiberOpenEdgeEquiv j (eL tL).1).symm (eL tL).2 ≍
+        tL.2 := (Sigma.mk.inj_iff.mp hL0).2
+  have hL1 :
+      (F.leftFixedFiberOpenEdgeEquiv j (eL tL).1).symm (eL tL).2 =
+        tL.2 := by simpa [eL] using eq_of_heq hL1heq
+  have hL2 := congrArg Prod.snd hL1
+  convert hL2 using 1;
+    simp [leftSectorOpenEdgeEquiv, sL, tL, eL]; rfl
+
+/-- The inverse right open-edge identification recovers the prescribed
+middle-right boundary coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity belongs to
+the retained cut decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem rightSectorOpenEdgeEquiv_symm_first_eq
+    (F : PhysicalSectorFactorization K) (C : ℕ) (j : Fin F.sectorCount)
+    (r : Fin (F.rightDim j) ×
+      Fin (Fintype.card (SectorSiteIndex F) ^ C)) :
+    let s := F.rightSectorOpenEdgeEquiv C j r
+    ((F.rightFixedFiberOpenEdgeEquiv j s.1).symm s.2).1 = r.1 := by
+  let sR := F.sectorCoordinateChainEquiv C (finFunctionFinEquiv.symm r.2)
+  let tR : Σ k : Fin C → Fin F.sectorCount,
+      Fin (F.rightDim j) × F.SectorChainFiber k := ⟨sR.1, (r.1, sR.2)⟩
+  let eR : (Σ k : Fin C → Fin F.sectorCount,
+      Fin (F.rightDim j) × F.SectorChainFiber k) ≃
+      (Σ k : Fin C → Fin F.sectorCount,
+        F.RightOpenEdgeIndex (F.rightSectorWord j k)) :=
+    Equiv.sigmaCongrRight fun k ↦ F.rightFixedFiberOpenEdgeEquiv j k
+  have hR0 := eR.symm_apply_apply tR
+  have hR1heq :
+      (F.rightFixedFiberOpenEdgeEquiv j (eR tR).1).symm (eR tR).2 ≍
+        tR.2 := (Sigma.mk.inj_iff.mp hR0).2
+  have hR1 :
+      (F.rightFixedFiberOpenEdgeEquiv j (eR tR).1).symm (eR tR).2 =
+        tR.2 := by simpa [eR] using eq_of_heq hR1heq
+  have hR2 := congrArg Prod.fst hR1
+  convert hR2 using 1;
+    simp [rightSectorOpenEdgeEquiv, sR, tR, eR]; rfl
+
+/-- The site coordinate recovered from a left open edge agrees with the site
+coordinate recovered in the fixed-sector fiber.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+is used for retained left paths. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem leftFiberOpenEdgeEquiv_symm_fst_heq
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (j : Fin F.sectorCount) (k : Fin A → Fin F.sectorCount)
+    (z : F.LeftOpenEdgeIndex (F.leftSectorWord j k)) (i : Fin A) :
+    let u := (F.leftFiberOpenEdgeEquiv (F.leftSectorWord j k)).symm z
+    let w := (F.leftFixedFiberOpenEdgeEquiv j k).symm z
+    u.1 i ≍ w.1 i := by
+  unfold leftFixedFiberOpenEdgeEquiv
+  exact (cast_heq _ _).symm
+
+/-- The final boundary coordinate recovered from a left open edge agrees with
+the boundary coordinate in the fixed-sector fiber.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+is used for retained left paths. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem leftFiberOpenEdgeEquiv_symm_snd_heq
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (j : Fin F.sectorCount) (k : Fin A → Fin F.sectorCount)
+    (z : F.LeftOpenEdgeIndex (F.leftSectorWord j k)) :
+    let u := (F.leftFiberOpenEdgeEquiv (F.leftSectorWord j k)).symm z
+    let w := (F.leftFixedFiberOpenEdgeEquiv j k).symm z
+    u.2 ≍ w.2 := by
+  unfold leftFixedFiberOpenEdgeEquiv
+  exact (cast_heq _ _).symm
+
+/-- The initial boundary coordinate recovered from a right open edge agrees
+with the boundary coordinate in the fixed-sector fiber.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+is used for retained right paths. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem rightFiberOpenEdgeEquiv_symm_fst_heq
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (j : Fin F.sectorCount) (k : Fin C → Fin F.sectorCount)
+    (z : F.RightOpenEdgeIndex (F.rightSectorWord j k)) :
+    let u := (F.rightFiberOpenEdgeEquiv (F.rightSectorWord j k)).symm z
+    let w := (F.rightFixedFiberOpenEdgeEquiv j k).symm z
+    u.1 ≍ w.1 := by
+  simp [rightFixedFiberOpenEdgeEquiv]
+  rfl
+
+/-- The site coordinate recovered from a right open edge agrees with the site
+coordinate recovered in the fixed-sector fiber.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+is used for retained right paths. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem rightFiberOpenEdgeEquiv_symm_snd_heq
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (j : Fin F.sectorCount) (k : Fin C → Fin F.sectorCount)
+    (z : F.RightOpenEdgeIndex (F.rightSectorWord j k)) (i : Fin C) :
+    let u := (F.rightFiberOpenEdgeEquiv (F.rightSectorWord j k)).symm z
+    let w := (F.rightFixedFiberOpenEdgeEquiv j k).symm z
+    u.2 i ≍ w.2 i := by
+  simp [rightFixedFiberOpenEdgeEquiv]
+  rfl
+
+/-- Along a left open path, the left endpoint of an edge is the right site
+coordinate at the same position.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This projection describes retained
+left-path coordinates. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem leftFiberOpenEdgeEquiv_symm_edge_fst
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (k : Fin (A + 1) → Fin F.sectorCount)
+    (z : F.LeftOpenEdgeIndex k) (i : Fin A) :
+    (((F.leftFiberOpenEdgeEquiv k).symm z).1 i).2 = (z.2 i).1 := by
+  cases A with
+  | zero => exact Fin.elim0 i
+  | succ A => simp [leftFiberOpenEdgeEquiv]
+
+/-- A left path of zero length has its open-edge boundary as its sole boundary
+coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity covers the
+empty retained left path. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem leftFiberOpenEdgeEquiv_symm_boundary_zero
+    (F : PhysicalSectorFactorization K)
+    (k : Fin 1 → Fin F.sectorCount) (z : F.LeftOpenEdgeIndex k) :
+    ((F.leftFiberOpenEdgeEquiv k).symm z).2 = z.1 := by
+  rfl
+
+/-- For a nonempty left path, the open-edge boundary is its first left site
+coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity describes a
+retained left path. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem leftFiberOpenEdgeEquiv_symm_boundary_succ
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (k : Fin (A + 2) → Fin F.sectorCount) (z : F.LeftOpenEdgeIndex k) :
+    (((F.leftFiberOpenEdgeEquiv k).symm z).1 0).1 = z.1 := by
+  simp [leftFiberOpenEdgeEquiv]
+
+/-- Before the last site of a left path, the right endpoint of an edge is the
+next left site coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This projection describes retained
+left-path coordinates. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem leftFiberOpenEdgeEquiv_symm_edge_snd_castSucc
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (k : Fin (A + 2) → Fin F.sectorCount)
+    (z : F.LeftOpenEdgeIndex k) (i : Fin A) :
+    (((F.leftFiberOpenEdgeEquiv k).symm z).1 i.succ).1 =
+      (z.2 i.castSucc).2 := by
+  simp [leftFiberOpenEdgeEquiv]
+
+/-- At the last site of a left path, the right endpoint of the final edge is
+the middle-left boundary coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity describes a
+retained left path. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem leftFiberOpenEdgeEquiv_symm_edge_snd_last
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (k : Fin (A + 2) → Fin F.sectorCount)
+    (z : F.LeftOpenEdgeIndex k) :
+    ((F.leftFiberOpenEdgeEquiv k).symm z).2 =
+      (z.2 (Fin.last A)).2 := by
+  simp [leftFiberOpenEdgeEquiv]
+
+/-- At the first site of a right path, the left endpoint of the first edge is
+the middle-right boundary coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity describes a
+retained right path. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem rightFiberOpenEdgeEquiv_symm_edge_fst_zero
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (k : Fin (C + 2) → Fin F.sectorCount)
+    (z : F.RightOpenEdgeIndex k) :
+    ((F.rightFiberOpenEdgeEquiv k).symm z).1 = (z.1 0).1 := by
+  simp [rightFiberOpenEdgeEquiv]
+
+/-- A right path of zero length has its open-edge boundary as its sole boundary
+coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity covers the
+empty retained right path. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem rightFiberOpenEdgeEquiv_symm_boundary_zero
+    (F : PhysicalSectorFactorization K)
+    (k : Fin 1 → Fin F.sectorCount) (z : F.RightOpenEdgeIndex k) :
+    ((F.rightFiberOpenEdgeEquiv k).symm z).1 = z.2 := by
+  rfl
+
+/-- For a nonempty right path, the open-edge boundary is its final right site
+coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity describes a
+retained right path. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem rightFiberOpenEdgeEquiv_symm_boundary_succ
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (k : Fin (C + 2) → Fin F.sectorCount) (z : F.RightOpenEdgeIndex k) :
+    (((F.rightFiberOpenEdgeEquiv k).symm z).2 (Fin.last C)).2 = z.2 := by
+  simp [rightFiberOpenEdgeEquiv]
+
+/-- After the first site of a right path, the left endpoint of an edge is the
+preceding right site coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This projection describes retained
+right-path coordinates. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem rightFiberOpenEdgeEquiv_symm_edge_fst_succ
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (k : Fin (C + 2) → Fin F.sectorCount)
+    (z : F.RightOpenEdgeIndex k) (i : Fin C) :
+    (((F.rightFiberOpenEdgeEquiv k).symm z).2 i.castSucc).2 =
+      (z.1 i.succ).1 := by
+  simp [rightFiberOpenEdgeEquiv]
+
+/-- Along a right open path, the right endpoint of an edge is the left site
+coordinate at the same position.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This projection describes retained
+right-path coordinates. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem rightFiberOpenEdgeEquiv_symm_edge_snd
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (k : Fin (C + 1) → Fin F.sectorCount)
+    (z : F.RightOpenEdgeIndex k) (i : Fin C) :
+    (((F.rightFiberOpenEdgeEquiv k).symm z).2 i).1 = (z.1 i).2 := by
+  cases C with
+  | zero => exact Fin.elim0 i
+  | succ C => simp [rightFiberOpenEdgeEquiv]
+
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveCutRegrouping.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutRegrouping.lean
@@ -1,0 +1,867 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveCutStates
+
+/-!
+# Regrouping the cyclic-active fourth-region blocks
+
+This file proves that separating a retained chain at one site transforms each
+fourth-region block into the corresponding Kronecker product of left and right
+path factors.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+universe u
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+private theorem sectorIndex_fst_heq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
+    (hxy : x ≍ y) : x.1 ≍ y.1 := by
+  subst h
+  exact heq_of_eq (congrArg Prod.fst (eq_of_heq hxy))
+
+private theorem sectorIndex_snd_heq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
+    (hxy : x ≍ y) : x.2 ≍ y.2 := by
+  subst h
+  exact heq_of_eq (congrArg Prod.snd (eq_of_heq hxy))
+
+private theorem neighboringOperator_entry_eq_of_heq
+    (F : PhysicalSectorFactorization K)
+    {k k' h h' : Fin F.sectorCount} (hk : k = k') (hh : h = h')
+    {x y : F.NeighborIndex k h} {x' y' : F.NeighborIndex k' h'}
+    (hx : x ≍ x') (hy : y ≍ y') :
+    F.neighboringOperator k h x y =
+      F.neighboringOperator k' h' x' y' := by
+  subst k'
+  subst h'
+  cases hx
+  cases hy
+  rfl
+
+private theorem cyclicActiveLeftBoundary_entry_eq_of_heq
+    (F : PhysicalSectorFactorization K)
+    (b : F.CyclicActiveSector → ℝ) {k h : F.CyclicActiveSector}
+    (hkh : k = h) {x y : Fin (F.leftDim k)}
+    {x' y' : Fin (F.leftDim h)} (hx : x ≍ x') (hy : y ≍ y') :
+    F.cyclicActiveLeftBoundary b k x y =
+      F.cyclicActiveLeftBoundary b h x' y' := by
+  subst h
+  cases hx
+  cases hy
+  rfl
+
+private theorem cyclicActiveRightBoundary_entry_eq_of_heq
+    (F : PhysicalSectorFactorization K)
+    (a : F.CyclicActiveSector → ℝ) {k h : F.CyclicActiveSector}
+    (hkh : k = h) {x y : Fin (F.rightDim k)}
+    {x' y' : Fin (F.rightDim h)} (hx : x ≍ x') (hy : y ≍ y') :
+    F.cyclicActiveRightBoundary a k x y =
+      F.cyclicActiveRightBoundary a h x' y' := by
+  subst h
+  cases hx
+  cases hy
+  rfl
+
+private theorem neighborIndex_heq_of_components
+    (F : PhysicalSectorFactorization K)
+    {k k' h h' : Fin F.sectorCount} (hk : k = k') (hh : h = h')
+    {x₁ : Fin (F.rightDim k)} {x₂ : Fin (F.leftDim h)}
+    {y₁ : Fin (F.rightDim k')} {y₂ : Fin (F.leftDim h')}
+    (h₁ : x₁ ≍ y₁) (h₂ : x₂ ≍ y₂) :
+    (x₁, x₂) ≍ (y₁, y₂) := by
+  subst k'
+  subst h'
+  cases h₁
+  cases h₂
+  rfl
+
+private theorem dependent_apply_heq {ι : Type} {α : ι → Type}
+    (f : (i : ι) → α i) {i j : ι} (h : i = j) : f i ≍ f j := by
+  subst j
+  rfl
+
+private theorem retainedLeftNeighboringEntry_eq
+    (F : PhysicalSectorFactorization K) {A C : ℕ}
+    (j : Fin F.sectorCount)
+    (k : Fin ((A + 1) + C + 1) → Fin F.sectorCount)
+    (kL : Fin (A + 1) → Fin F.sectorCount)
+    (z z' : F.RetainedOpenEdgeIndex (n := (A + 1) + C) k)
+    (zL zL' : F.LeftOpenEdgeIndex (F.leftSectorWord j kL))
+    (hkLeft : ∀ i : Fin (A + 1), k ⟨i, by omega⟩ = kL i)
+    (hkMiddle : k ⟨A + 1, by omega⟩ = j)
+    (hu : ∀ i : Fin (A + 1),
+      (F.retainedOpenEdgeEquiv k).symm z ⟨i, by omega⟩ ≍
+        ((F.leftFiberOpenEdgeEquiv (F.leftSectorWord j kL)).symm zL).1 i)
+    (hu' : ∀ i : Fin (A + 1),
+      (F.retainedOpenEdgeEquiv k).symm z' ⟨i, by omega⟩ ≍
+        ((F.leftFiberOpenEdgeEquiv (F.leftSectorWord j kL)).symm zL').1 i)
+    (huM : ((F.retainedOpenEdgeEquiv k).symm z ⟨A + 1, by omega⟩).1 ≍
+      ((F.leftFiberOpenEdgeEquiv (F.leftSectorWord j kL)).symm zL).2)
+    (huM' : ((F.retainedOpenEdgeEquiv k).symm z' ⟨A + 1, by omega⟩).1 ≍
+      ((F.leftFiberOpenEdgeEquiv (F.leftSectorWord j kL)).symm zL').2)
+    (i : Fin (A + 1)) :
+    let e := Fin.castAdd C i
+    F.neighboringOperator
+        (k ((Fin.last (A + 1 + C)).succAbove e))
+        (k ((Fin.last (A + 1 + C)).succAbove e + 1))
+        (z.1 e) (z'.1 e) =
+      F.neighboringOperator
+        (F.leftSectorWord j kL i.castSucc)
+        (F.leftSectorWord j kL i.succ)
+        (zL.2 i) (zL'.2 i) := by
+  classical
+  refine Fin.lastCases ?_ (fun p ↦ ?_) i
+  · let e := Fin.castAdd C (Fin.last A)
+    let v := (F.retainedOpenEdgeEquiv k).symm z
+    let v' := (F.retainedOpenEdgeEquiv k).symm z'
+    have he0 : (Fin.last (A + 1 + C)).succAbove e =
+        ⟨Fin.last A, by omega⟩ := by
+      ext
+      simp [e]
+    have he1 : (Fin.last (A + 1 + C)).succAbove e + 1 =
+        ⟨A + 1, by omega⟩ := by
+      ext
+      simp [e]
+    have hq : k ((Fin.last (A + 1 + C)).succAbove e) =
+        F.leftSectorWord j kL (Fin.last A).castSucc := by
+      rw [he0, hkLeft]
+      simp [leftSectorWord]
+    have hh : k ((Fin.last (A + 1 + C)).succAbove e + 1) =
+        F.leftSectorWord j kL (Fin.last A).succ := by
+      rw [he1, hkMiddle]
+      simp [leftSectorWord]
+    have hg := F.retainedOpenEdgeEquiv_symm_internal_edge k z e
+    have hg' := F.retainedOpenEdgeEquiv_symm_internal_edge k z' e
+    have huM_v : (v ⟨A + 1, by omega⟩).1 ≍
+        ((F.leftFiberOpenEdgeEquiv (F.leftSectorWord j kL)).symm zL).2 := huM
+    have huM_v' : (v' ⟨A + 1, by omega⟩).1 ≍
+        ((F.leftFiberOpenEdgeEquiv (F.leftSectorWord j kL)).symm zL').2 := huM'
+    apply neighboringOperator_entry_eq_of_heq F hq hh
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg).symm).trans ?_
+        exact (sectorIndex_snd_heq_of_heq F hq
+          ((dependent_apply_heq v he0).trans (hu (Fin.last A)))).trans
+            (heq_of_eq (F.leftFiberOpenEdgeEquiv_symm_edge_fst
+              (F.leftSectorWord j kL) zL (Fin.last A)))
+      · refine (heq_of_eq (congrArg Prod.snd hg).symm).trans ?_
+        exact ((sectorIndex_fst_heq_of_heq F (congrArg k he1)
+          (dependent_apply_heq v he1)).trans huM_v).trans (heq_of_eq
+            (F.leftFiberOpenEdgeEquiv_symm_edge_snd_last
+              (F.leftSectorWord j kL) zL))
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg').symm).trans ?_
+        exact (sectorIndex_snd_heq_of_heq F hq
+          ((dependent_apply_heq v' he0).trans (hu' (Fin.last A)))).trans
+            (heq_of_eq (F.leftFiberOpenEdgeEquiv_symm_edge_fst
+              (F.leftSectorWord j kL) zL' (Fin.last A)))
+      · refine (heq_of_eq (congrArg Prod.snd hg').symm).trans ?_
+        exact ((sectorIndex_fst_heq_of_heq F (congrArg k he1)
+          (dependent_apply_heq v' he1)).trans huM_v').trans (heq_of_eq
+            (F.leftFiberOpenEdgeEquiv_symm_edge_snd_last
+              (F.leftSectorWord j kL) zL'))
+  · let e := Fin.castAdd C p.castSucc
+    let v := (F.retainedOpenEdgeEquiv k).symm z
+    let v' := (F.retainedOpenEdgeEquiv k).symm z'
+    have he0 : (Fin.last (A + 1 + C)).succAbove e =
+        ⟨p.castSucc, by omega⟩ := by
+      ext
+      simp [e]
+    have he1 : (Fin.last (A + 1 + C)).succAbove e + 1 =
+        ⟨p.succ, by omega⟩ := by
+      ext
+      simp [e]
+    have hq : k ((Fin.last (A + 1 + C)).succAbove e) =
+        F.leftSectorWord j kL p.castSucc.castSucc := by
+      rw [he0, hkLeft]
+      simp [leftSectorWord]
+    have hh : k ((Fin.last (A + 1 + C)).succAbove e + 1) =
+        F.leftSectorWord j kL p.castSucc.succ := by
+      rw [he1, hkLeft]
+      change kL p.succ = Fin.lastCases j kL p.castSucc.succ
+      symm
+      exact Fin.lastCases_castSucc p.succ
+    have hg := F.retainedOpenEdgeEquiv_symm_internal_edge k z e
+    have hg' := F.retainedOpenEdgeEquiv_symm_internal_edge k z' e
+    apply neighboringOperator_entry_eq_of_heq F hq hh
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg).symm).trans ?_
+        exact (sectorIndex_snd_heq_of_heq F hq
+          ((dependent_apply_heq v he0).trans (hu p.castSucc))).trans
+            (heq_of_eq (F.leftFiberOpenEdgeEquiv_symm_edge_fst
+              (F.leftSectorWord j kL) zL p.castSucc))
+      · refine (heq_of_eq (congrArg Prod.snd hg).symm).trans ?_
+        exact (sectorIndex_fst_heq_of_heq F hh
+          ((dependent_apply_heq v he1).trans (hu p.succ))).trans (heq_of_eq
+            (F.leftFiberOpenEdgeEquiv_symm_edge_snd_castSucc
+              (F.leftSectorWord j kL) zL p))
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg').symm).trans ?_
+        exact (sectorIndex_snd_heq_of_heq F hq
+          ((dependent_apply_heq v' he0).trans (hu' p.castSucc))).trans
+            (heq_of_eq (F.leftFiberOpenEdgeEquiv_symm_edge_fst
+              (F.leftSectorWord j kL) zL' p.castSucc))
+      · refine (heq_of_eq (congrArg Prod.snd hg').symm).trans ?_
+        exact (sectorIndex_fst_heq_of_heq F hh
+          ((dependent_apply_heq v' he1).trans (hu' p.succ))).trans (heq_of_eq
+            (F.leftFiberOpenEdgeEquiv_symm_edge_snd_castSucc
+              (F.leftSectorWord j kL) zL' p))
+
+private theorem retainedRightNeighboringEntry_eq
+    (F : PhysicalSectorFactorization K) {A C : ℕ}
+    (j : Fin F.sectorCount)
+    (k : Fin (A + (C + 1) + 1) → Fin F.sectorCount)
+    (kR : Fin (C + 1) → Fin F.sectorCount)
+    (z z' : F.RetainedOpenEdgeIndex (n := A + (C + 1)) k)
+    (zR zR' : F.RightOpenEdgeIndex (F.rightSectorWord j kR))
+    (hkMiddle : k ⟨A, by omega⟩ = j)
+    (hkRight : ∀ i : Fin (C + 1), k ⟨A + 1 + i, by omega⟩ = kR i)
+    (hu : ∀ i : Fin (C + 1),
+      (F.retainedOpenEdgeEquiv k).symm z ⟨A + 1 + i, by omega⟩ ≍
+        ((F.rightFiberOpenEdgeEquiv (F.rightSectorWord j kR)).symm zR).2 i)
+    (hu' : ∀ i : Fin (C + 1),
+      (F.retainedOpenEdgeEquiv k).symm z' ⟨A + 1 + i, by omega⟩ ≍
+        ((F.rightFiberOpenEdgeEquiv (F.rightSectorWord j kR)).symm zR').2 i)
+    (huM : ((F.retainedOpenEdgeEquiv k).symm z ⟨A, by omega⟩).2 ≍
+      ((F.rightFiberOpenEdgeEquiv (F.rightSectorWord j kR)).symm zR).1)
+    (huM' : ((F.retainedOpenEdgeEquiv k).symm z' ⟨A, by omega⟩).2 ≍
+      ((F.rightFiberOpenEdgeEquiv (F.rightSectorWord j kR)).symm zR').1)
+    (i : Fin (C + 1)) :
+    let e := Fin.natAdd A i
+    F.neighboringOperator
+        (k ((Fin.last (A + (C + 1))).succAbove e))
+        (k ((Fin.last (A + (C + 1))).succAbove e + 1))
+        (z.1 e) (z'.1 e) =
+      F.neighboringOperator
+        (F.rightSectorWord j kR i.castSucc)
+        (F.rightSectorWord j kR i.succ)
+        (zR.1 i) (zR'.1 i) := by
+  classical
+  refine Fin.cases ?_ (fun p ↦ ?_) i
+  · let e := Fin.natAdd A (0 : Fin (C + 1))
+    let v := (F.retainedOpenEdgeEquiv k).symm z
+    let v' := (F.retainedOpenEdgeEquiv k).symm z'
+    have he0 : (Fin.last (A + (C + 1))).succAbove e = ⟨A, by omega⟩ := by
+      ext
+      simp [e]
+    have he1 : (Fin.last (A + (C + 1))).succAbove e + 1 =
+        ⟨A + 1, by omega⟩ := by
+      rw [he0]
+      apply Fin.ext
+      change (A + (1 % (A + (C + 1) + 1))) % (A + (C + 1) + 1) = A + 1
+      rw [Nat.mod_eq_of_lt (by omega : 1 < A + (C + 1) + 1)]
+      rw [Nat.mod_eq_of_lt (by omega : A + 1 < A + (C + 1) + 1)]
+    have hq : k ((Fin.last (A + (C + 1))).succAbove e) =
+        F.rightSectorWord j kR (0 : Fin (C + 1)).castSucc := by
+      rw [he0, hkMiddle]
+      simp [rightSectorWord]
+    have hh : k ((Fin.last (A + (C + 1))).succAbove e + 1) =
+        F.rightSectorWord j kR (0 : Fin (C + 1)).succ := by
+      rw [he1]
+      calc
+        k ⟨A + 1, by omega⟩ = k ⟨A + 1 + (0 : Fin (C + 1)), by omega⟩ := by
+          congr 1
+        _ = kR 0 := hkRight 0
+        _ = F.rightSectorWord j kR (0 : Fin (C + 1)).succ := by
+          change kR (0 : Fin (C + 1)) =
+            Fin.cases j kR (Fin.succ (0 : Fin (C + 1)))
+          exact (@Fin.cases_succ (C + 1) (fun _ ↦ Fin F.sectorCount)
+            j kR 0).symm
+    have hg := F.retainedOpenEdgeEquiv_symm_internal_edge k z e
+    have hg' := F.retainedOpenEdgeEquiv_symm_internal_edge k z' e
+    have huM_v : (v ⟨A, by omega⟩).2 ≍
+        ((F.rightFiberOpenEdgeEquiv (F.rightSectorWord j kR)).symm zR).1 := huM
+    have huM_v' : (v' ⟨A, by omega⟩).2 ≍
+        ((F.rightFiberOpenEdgeEquiv (F.rightSectorWord j kR)).symm zR').1 := huM'
+    apply neighboringOperator_entry_eq_of_heq F hq hh
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg).symm).trans ?_
+        exact ((sectorIndex_snd_heq_of_heq F (congrArg k he0)
+          (dependent_apply_heq v he0)).trans huM_v).trans (heq_of_eq
+            (F.rightFiberOpenEdgeEquiv_symm_edge_fst_zero
+              (F.rightSectorWord j kR) zR))
+      · refine (heq_of_eq (congrArg Prod.snd hg).symm).trans ?_
+        exact (sectorIndex_fst_heq_of_heq F hh
+          ((dependent_apply_heq v he1).trans (hu 0))).trans
+            (heq_of_eq (F.rightFiberOpenEdgeEquiv_symm_edge_snd
+              (F.rightSectorWord j kR) zR 0))
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg').symm).trans ?_
+        exact ((sectorIndex_snd_heq_of_heq F (congrArg k he0)
+          (dependent_apply_heq v' he0)).trans huM_v').trans (heq_of_eq
+            (F.rightFiberOpenEdgeEquiv_symm_edge_fst_zero
+              (F.rightSectorWord j kR) zR'))
+      · refine (heq_of_eq (congrArg Prod.snd hg').symm).trans ?_
+        exact (sectorIndex_fst_heq_of_heq F hh
+          ((dependent_apply_heq v' he1).trans (hu' 0))).trans
+            (heq_of_eq (F.rightFiberOpenEdgeEquiv_symm_edge_snd
+              (F.rightSectorWord j kR) zR' 0))
+  · let e := Fin.natAdd A p.succ
+    let v := (F.retainedOpenEdgeEquiv k).symm z
+    let v' := (F.retainedOpenEdgeEquiv k).symm z'
+    have he0 : (Fin.last (A + (C + 1))).succAbove e =
+        ⟨A + 1 + p, by omega⟩ := by
+      ext
+      simp [e]
+      omega
+    have he1 : (Fin.last (A + (C + 1))).succAbove e + 1 =
+        ⟨A + 1 + p.succ, by omega⟩ := by
+      rw [he0]
+      apply Fin.ext
+      change (A + 1 + p.val + (1 % (A + (C + 1) + 1))) %
+          (A + (C + 1) + 1) = A + 1 + (p.val + 1)
+      rw [Nat.mod_eq_of_lt (by omega : 1 < A + (C + 1) + 1)]
+      rw [Nat.mod_eq_of_lt (by omega :
+        A + 1 + p.val + 1 < A + (C + 1) + 1)]
+      omega
+    have hq : k ((Fin.last (A + (C + 1))).succAbove e) =
+        F.rightSectorWord j kR p.succ.castSucc := by
+      rw [he0]
+      calc
+        k ⟨A + 1 + p, by omega⟩ =
+            k ⟨A + 1 + (p.castSucc : Fin (C + 1)), by omega⟩ := by
+          congr 1
+        _ = kR p.castSucc := hkRight p.castSucc
+        _ = F.rightSectorWord j kR p.succ.castSucc := by
+          rw [show p.succ.castSucc = p.castSucc.succ by rfl]
+          change kR p.castSucc = Fin.cases j kR (Fin.succ p.castSucc)
+          exact (@Fin.cases_succ (C + 1) (fun _ ↦ Fin F.sectorCount)
+            j kR p.castSucc).symm
+    have hh : k ((Fin.last (A + (C + 1))).succAbove e + 1) =
+        F.rightSectorWord j kR p.succ.succ := by
+      rw [he1]
+      calc
+        k ⟨A + 1 + p.succ, by omega⟩ =
+            k ⟨A + 1 + (p.succ : Fin (C + 1)), by omega⟩ := by
+          congr 1
+        _ = kR p.succ := hkRight p.succ
+        _ = F.rightSectorWord j kR p.succ.succ := by
+          simp only [rightSectorWord, Fin.cases_succ]
+    have hg := F.retainedOpenEdgeEquiv_symm_internal_edge k z e
+    have hg' := F.retainedOpenEdgeEquiv_symm_internal_edge k z' e
+    apply neighboringOperator_entry_eq_of_heq F hq hh
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg).symm).trans ?_
+        exact (sectorIndex_snd_heq_of_heq F hq
+          ((dependent_apply_heq v he0).trans (hu p.castSucc))).trans (heq_of_eq
+            (F.rightFiberOpenEdgeEquiv_symm_edge_fst_succ
+              (F.rightSectorWord j kR) zR p))
+      · refine (heq_of_eq (congrArg Prod.snd hg).symm).trans ?_
+        exact (sectorIndex_fst_heq_of_heq F hh
+          ((dependent_apply_heq v he1).trans (hu p.succ))).trans
+            (heq_of_eq (F.rightFiberOpenEdgeEquiv_symm_edge_snd
+              (F.rightSectorWord j kR) zR p.succ))
+    · apply neighborIndex_heq_of_components F hq hh
+      · refine (heq_of_eq (congrArg Prod.fst hg').symm).trans ?_
+        exact (sectorIndex_snd_heq_of_heq F hq
+          ((dependent_apply_heq v' he0).trans (hu' p.castSucc))).trans (heq_of_eq
+            (F.rightFiberOpenEdgeEquiv_symm_edge_fst_succ
+              (F.rightSectorWord j kR) zR' p))
+      · refine (heq_of_eq (congrArg Prod.snd hg').symm).trans ?_
+        exact (sectorIndex_fst_heq_of_heq F hh
+          ((dependent_apply_heq v' he1).trans (hu' p.succ))).trans
+            (heq_of_eq (F.rightFiberOpenEdgeEquiv_symm_edge_snd
+              (F.rightSectorWord j kR) zR' p.succ))
+
+
+/-- Separating a retained chain at one physical site turns the complete
+fourth-region block into a direct sum of left and right path factors.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The blocks are those of the
+restricted two-step cyclic-active coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_cyclicActiveFourthRegionBlock_eq_cutRaw
+    (F : PhysicalSectorFactorization K) (A C : ℕ)
+    (lam : ℝ) (a b : F.CyclicActiveSector → ℝ) :
+    Matrix.reindex (F.retainedCutEquiv A C) (F.retainedCutEquiv A C)
+        (Matrix.blockDiagonal' fun k : Fin (A + C + 1) → Fin F.sectorCount ↦
+          F.cyclicActiveFourthRegionBlock (n := A + C) lam a b k) =
+      Matrix.blockDiagonal' fun j : Fin F.sectorCount ↦
+        F.cyclicActiveLeftCutRaw A lam b j ⊗ₖ
+          F.cyclicActiveRightCutRaw C a j := by
+  classical
+  ext x y
+  obtain ⟨j, l, r⟩ := x
+  obtain ⟨j', l', r'⟩ := y
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
+  by_cases hj : j = j'
+  · subst j'
+    simp only [Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply]
+    simp only [cyclicActiveLeftCutRaw, cyclicActiveRightCutRaw,
+      Matrix.reindex_apply, Matrix.submatrix_apply]
+    simp only [Equiv.symm_symm]
+    generalize hg : (F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩ = g
+    generalize hg' : (F.retainedCutEquiv A C).symm ⟨j, (l', r')⟩ = g'
+    generalize hsL : F.leftSectorOpenEdgeEquiv A j l = sL
+    generalize hsL' : F.leftSectorOpenEdgeEquiv A j l' = sL'
+    generalize hsR : F.rightSectorOpenEdgeEquiv C j r = sR
+    generalize hsR' : F.rightSectorOpenEdgeEquiv C j r' = sR'
+    obtain ⟨k, z⟩ := g
+    obtain ⟨k', z'⟩ := g'
+    obtain ⟨kL, zL⟩ := sL
+    obtain ⟨kL', zL'⟩ := sL'
+    obtain ⟨kR, zR⟩ := sR
+    obtain ⟨kR', zR'⟩ := sR'
+    by_cases hkL : kL = kL'
+    · subst kL'
+      by_cases hkR : kR = kR'
+      · subst kR'
+        have hword :
+            ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1 =
+              ((F.retainedCutEquiv A C).symm ⟨j, (l', r')⟩).1 := by
+          funext i
+          rcases lt_trichotomy i.val A with hi | hi | hi
+          · let iA : Fin A := ⟨i, hi⟩
+            calc
+              _ = kL iA := by
+                rw [F.retainedCutEquiv_symm_left_sector A C j l r iA]
+                simpa [hsL] using (congrFun
+                  (F.leftSectorOpenEdgeEquiv_apply_fst A j l) iA).symm
+              _ = _ := by
+                rw [F.retainedCutEquiv_symm_left_sector A C j l' r' iA]
+                simpa [hsL'] using congrFun
+                  (F.leftSectorOpenEdgeEquiv_apply_fst A j l') iA
+          · have hii : i = ⟨A, by omega⟩ := Fin.ext hi
+            rw [hii]
+            rw [F.retainedCutEquiv_symm_middle_sector A C j l r,
+              F.retainedCutEquiv_symm_middle_sector A C j l' r']
+          · let iC : Fin C := ⟨i.val - (A + 1), by omega⟩
+            have hii : i = ⟨A + 1 + iC, by omega⟩ := by ext; simp [iC]; omega
+            rw [hii]
+            calc
+              _ = kR iC := by
+                rw [F.retainedCutEquiv_symm_right_sector A C j l r iC]
+                simpa [hsR] using (congrFun
+                  (F.rightSectorOpenEdgeEquiv_apply_fst C j r) iC).symm
+              _ = _ := by
+                rw [F.retainedCutEquiv_symm_right_sector A C j l' r' iC]
+                simpa [hsR'] using congrFun
+                  (F.rightSectorOpenEdgeEquiv_apply_fst C j r') iC
+        have hkk : k = k' := by simpa [hg, hg'] using hword
+        subst k'
+        simp only [Matrix.blockDiagonal'_apply_eq]
+        have hkLeft (i : Fin A) : k ⟨i, by omega⟩ = kL i := by
+          have hglobal := F.retainedCutEquiv_symm_left_sector A C j l r i
+          rw [hg] at hglobal
+          have hlocal := congrFun
+            (F.leftSectorOpenEdgeEquiv_apply_fst A j l) i
+          rw [hsL] at hlocal
+          exact hglobal.trans hlocal.symm
+        have hkMiddle : k ⟨A, by omega⟩ = j := by
+          simpa [hg] using F.retainedCutEquiv_symm_middle_sector A C j l r
+        have hkRight (i : Fin C) : k ⟨A + 1 + i, by omega⟩ = kR i := by
+          have hglobal := F.retainedCutEquiv_symm_right_sector A C j l r i
+          rw [hg] at hglobal
+          have hlocal := congrFun
+            (F.rightSectorOpenEdgeEquiv_apply_fst C j r) i
+          rw [hsR] at hlocal
+          exact hglobal.trans hlocal.symm
+        have hkActive : F.IsCyclicActiveRetainedWord k ↔
+            F.IsCyclicActiveRetainedWord (F.leftSectorWord j kL) ∧
+              F.IsCyclicActiveRetainedWord (F.rightSectorWord j kR) := by
+          constructor
+          · intro hk
+            constructor
+            · intro i
+              refine Fin.lastCases ?_ (fun p ↦ ?_) i
+              · simpa [leftSectorWord, hkMiddle] using hk ⟨A, by omega⟩
+              · simpa [leftSectorWord, hkLeft p] using hk ⟨p, by omega⟩
+            · intro i
+              refine Fin.cases ?_ (fun p ↦ ?_) i
+              · simpa [rightSectorWord, hkMiddle] using hk ⟨A, by omega⟩
+              · simpa [rightSectorWord, hkRight p] using
+                  hk ⟨A + 1 + p, by omega⟩
+          · rintro ⟨hL, hR⟩ i
+            rcases lt_trichotomy i.val A with hi | hi | hi
+            · let iA : Fin A := ⟨i, hi⟩
+              have hii : i = ⟨iA, by omega⟩ := by ext; rfl
+              rw [hii, hkLeft iA]
+              simpa [leftSectorWord] using hL iA.castSucc
+            · have hii : i = ⟨A, by omega⟩ := Fin.ext hi
+              rw [hii, hkMiddle]
+              simpa [rightSectorWord] using hR 0
+            · let iC : Fin C := ⟨i.val - (A + 1), by omega⟩
+              have hii : i = ⟨A + 1 + iC, by omega⟩ := by ext; simp [iC]; omega
+              rw [hii, hkRight iC]
+              simpa [rightSectorWord] using hR iC.succ
+        by_cases hL : F.IsCyclicActiveRetainedWord (F.leftSectorWord j kL)
+        · by_cases hR : F.IsCyclicActiveRetainedWord (F.rightSectorWord j kR)
+          · let v := (F.retainedOpenEdgeEquiv k).symm z
+            let v' := (F.retainedOpenEdgeEquiv k).symm z'
+            let wL := (F.leftFixedFiberOpenEdgeEquiv j kL).symm zL
+            let wL' := (F.leftFixedFiberOpenEdgeEquiv j kL).symm zL'
+            let wR := (F.rightFixedFiberOpenEdgeEquiv j kR).symm zR
+            let wR' := (F.rightFixedFiberOpenEdgeEquiv j kR).symm zR'
+            let uL := (F.leftFiberOpenEdgeEquiv
+              (F.leftSectorWord j kL)).symm zL
+            let uL' := (F.leftFiberOpenEdgeEquiv
+              (F.leftSectorWord j kL)).symm zL'
+            let uR := (F.rightFiberOpenEdgeEquiv
+              (F.rightSectorWord j kR)).symm zR
+            let uR' := (F.rightFiberOpenEdgeEquiv
+              (F.rightSectorWord j kR)).symm zR'
+            have hvL (i : Fin A) : v ⟨i, by omega⟩ ≍ wL.1 i := by
+              have h := F.retainedCutEquiv_symm_left_fiber_heq A C j l r i
+              rw [hg, hsL] at h
+              exact h
+            have hvL' (i : Fin A) : v' ⟨i, by omega⟩ ≍ wL'.1 i := by
+              have h := F.retainedCutEquiv_symm_left_fiber_heq A C j l' r' i
+              rw [hg', hsL'] at h
+              exact h
+            have hvR (i : Fin C) : v ⟨A + 1 + i, by omega⟩ ≍ wR.2 i := by
+              have h := F.retainedCutEquiv_symm_right_fiber_heq A C j l r i
+              rw [hg, hsR] at h
+              exact h
+            have hvR' (i : Fin C) : v' ⟨A + 1 + i, by omega⟩ ≍ wR'.2 i := by
+              have h := F.retainedCutEquiv_symm_right_fiber_heq A C j l' r' i
+              rw [hg', hsR'] at h
+              exact h
+            have hvM : v ⟨A, by omega⟩ ≍ (wL.2, wR.1) := by
+              have hm := F.retainedCutEquiv_symm_middle_fiber_heq A C j l r
+              have hl2 := F.leftSectorOpenEdgeEquiv_symm_last_eq A j l
+              have hr1 := F.rightSectorOpenEdgeEquiv_symm_first_eq C j r
+              dsimp only at hm hl2 hr1
+              rw [hg] at hm
+              rw [hsL] at hl2
+              rw [hsR] at hr1
+              simpa [v, wL, wR, hl2, hr1] using hm
+            have hvM' : v' ⟨A, by omega⟩ ≍ (wL'.2, wR'.1) := by
+              have hm := F.retainedCutEquiv_symm_middle_fiber_heq A C j l' r'
+              have hl2 := F.leftSectorOpenEdgeEquiv_symm_last_eq A j l'
+              have hr1 := F.rightSectorOpenEdgeEquiv_symm_first_eq C j r'
+              dsimp only at hm hl2 hr1
+              rw [hg'] at hm
+              rw [hsL'] at hl2
+              rw [hsR'] at hr1
+              simpa [v', wL', wR', hl2, hr1] using hm
+            have huL (i : Fin A) : v ⟨i, by omega⟩ ≍ uL.1 i :=
+              (hvL i).trans
+                (F.leftFiberOpenEdgeEquiv_symm_fst_heq j kL zL i).symm
+            have huL' (i : Fin A) : v' ⟨i, by omega⟩ ≍ uL'.1 i :=
+              (hvL' i).trans
+                (F.leftFiberOpenEdgeEquiv_symm_fst_heq j kL zL' i).symm
+            have huR (i : Fin C) : v ⟨A + 1 + i, by omega⟩ ≍ uR.2 i :=
+              (hvR i).trans
+                (F.rightFiberOpenEdgeEquiv_symm_snd_heq j kR zR i).symm
+            have huR' (i : Fin C) : v' ⟨A + 1 + i, by omega⟩ ≍ uR'.2 i :=
+              (hvR' i).trans
+                (F.rightFiberOpenEdgeEquiv_symm_snd_heq j kR zR' i).symm
+            have huML : (v ⟨A, by omega⟩).1 ≍ uL.2 :=
+              (sectorIndex_fst_heq_of_heq F hkMiddle hvM).trans
+                (F.leftFiberOpenEdgeEquiv_symm_snd_heq j kL zL).symm
+            have huML' : (v' ⟨A, by omega⟩).1 ≍ uL'.2 :=
+              (sectorIndex_fst_heq_of_heq F hkMiddle hvM').trans
+                (F.leftFiberOpenEdgeEquiv_symm_snd_heq j kL zL').symm
+            have huMR : (v ⟨A, by omega⟩).2 ≍ uR.1 :=
+              (sectorIndex_snd_heq_of_heq F hkMiddle hvM).trans
+                (F.rightFiberOpenEdgeEquiv_symm_fst_heq j kR zR).symm
+            have huMR' : (v' ⟨A, by omega⟩).2 ≍ uR'.1 :=
+              (sectorIndex_snd_heq_of_heq F hkMiddle hvM').trans
+                (F.rightFiberOpenEdgeEquiv_symm_fst_heq j kR zR').symm
+            simp only [cyclicActiveFourthRegionBlock,
+              cyclicActiveLeftOpenBlock, cyclicActiveRightOpenBlock,
+              dif_pos (hkActive.mpr ⟨hL, hR⟩), dif_pos hL, dif_pos hR,
+              Matrix.smul_apply, smul_eq_mul, Matrix.kroneckerMap_apply,
+              Matrix.finKronecker_apply]
+            rw [F.cyclicActiveSeparatedBoundary_eq_right_kronecker_left]
+            simp only [Matrix.kroneckerMap_apply]
+            rw [retainedBulkProduct, Fin.prod_univ_add]
+            have hprodL :
+                (∏ i : Fin A,
+                  F.neighboringOperator
+                    (k ((Fin.last (A + C)).succAbove (Fin.castAdd C i)))
+                    (k ((Fin.last (A + C)).succAbove (Fin.castAdd C i) + 1))
+                    (z.1 (Fin.castAdd C i)) (z'.1 (Fin.castAdd C i))) =
+                  ∏ i : Fin A,
+                    F.neighboringOperator
+                      (F.leftSectorWord j kL i.castSucc)
+                      (F.leftSectorWord j kL i.succ) (zL.2 i) (zL'.2 i) := by
+              cases A with
+              | zero => simp
+              | succ A =>
+                  apply Fintype.prod_congr
+                  intro i
+                  exact retainedLeftNeighboringEntry_eq F j k kL z z' zL zL'
+                    hkLeft hkMiddle huL huL' huML huML' i
+            have hprodR :
+                (∏ i : Fin C,
+                  F.neighboringOperator
+                    (k ((Fin.last (A + C)).succAbove (Fin.natAdd A i)))
+                    (k ((Fin.last (A + C)).succAbove (Fin.natAdd A i) + 1))
+                    (z.1 (Fin.natAdd A i)) (z'.1 (Fin.natAdd A i))) =
+                  ∏ i : Fin C,
+                    F.neighboringOperator
+                      (F.rightSectorWord j kR i.castSucc)
+                      (F.rightSectorWord j kR i.succ) (zR.1 i) (zR'.1 i) := by
+              cases C with
+              | zero => simp
+              | succ C =>
+                  apply Fintype.prod_congr
+                  intro i
+                  exact retainedRightNeighboringEntry_eq F j k kR z z' zR zR'
+                    hkMiddle hkRight huR huR' huMR huMR' i
+            rw [hprodL, hprodR]
+            simp only [PhysicalSectorFactorization.neighboringOperator_apply]
+            have hfirst :
+                F.cyclicActiveRetainedWord (hkActive.mpr ⟨hL, hR⟩)
+                    (Fin.last (A + C) + 1) =
+                  F.cyclicActiveRetainedWord hL 0 := by
+              apply Subtype.ext
+              change k (Fin.last (A + C) + 1) = F.leftSectorWord j kL 0
+              rw [show Fin.last (A + C) + 1 = (0 : Fin (A + C + 1)) by
+                ext
+                simp]
+              by_cases hA : A = 0
+              · subst A
+                calc
+                  k 0 = j := hkMiddle
+                  _ = F.leftSectorWord j kL 0 := by
+                    rw [show (0 : Fin 1) = Fin.last 0 by rfl]
+                    exact (@Fin.lastCases_last 0 (fun _ ↦ Fin F.sectorCount)
+                      j kL).symm
+              · obtain ⟨A, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hA
+                calc
+                  k 0 = kL 0 := hkLeft 0
+                  _ = F.leftSectorWord j kL 0 := by
+                    rw [show (0 : Fin (A + 2)) =
+                      Fin.castSucc (0 : Fin (A + 1)) by rfl]
+                    exact (@Fin.lastCases_castSucc (A + 1)
+                      (fun _ ↦ Fin F.sectorCount) j kL 0).symm
+            have hlast :
+                F.cyclicActiveRetainedWord (hkActive.mpr ⟨hL, hR⟩)
+                    (Fin.last (A + C)) =
+                  F.cyclicActiveRetainedWord hR (Fin.last C) := by
+              apply Subtype.ext
+              change k (Fin.last (A + C)) =
+                F.rightSectorWord j kR (Fin.last C)
+              by_cases hC : C = 0
+              · subst C
+                have he : Fin.last A = ⟨A, by omega⟩ := by
+                  ext
+                  simp
+                calc
+                  k (Fin.last A) = k ⟨A, by omega⟩ := congrArg k he
+                  _ = j := hkMiddle
+                  _ = F.rightSectorWord j kR (Fin.last 0) := by
+                    exact (@Fin.cases_zero 0 (fun _ ↦ Fin F.sectorCount)
+                      j kR).symm
+              · obtain ⟨C, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hC
+                have he : Fin.last (A + (C + 1)) =
+                    ⟨A + 1 + Fin.last C, by omega⟩ := by
+                  ext
+                  simp
+                  omega
+                calc
+                  k (Fin.last (A + (C + 1))) =
+                      k ⟨A + 1 + Fin.last C, by omega⟩ := congrArg k he
+                  _ = kR (Fin.last C) := hkRight (Fin.last C)
+                  _ = F.rightSectorWord j kR (Fin.last (C + 1)) := by
+                    rw [show Fin.last (C + 1) = (Fin.last C).succ by
+                      ext
+                      simp]
+                    exact (@Fin.cases_succ (C + 1)
+                      (fun _ ↦ Fin F.sectorCount) j kR (Fin.last C)).symm
+            have hzLeft : z.2.2 ≍ zL.1 := by
+              refine (heq_of_eq
+                (F.retainedOpenEdgeEquiv_symm_first_left k z).symm).trans ?_
+              have he : Fin.last (A + C) + 1 = (0 : Fin (A + C + 1)) := by
+                ext
+                simp
+              by_cases hA : A = 0
+              · subst A
+                exact ((sectorIndex_fst_heq_of_heq F (congrArg k he)
+                  (dependent_apply_heq v he)).trans huML).trans (heq_of_eq
+                  (F.leftFiberOpenEdgeEquiv_symm_boundary_zero
+                    (F.leftSectorWord j kL) zL))
+              · obtain ⟨A, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hA
+                have hk0 : k (Fin.last (A + 1 + C) + 1) =
+                    F.leftSectorWord j kL 0 := by
+                  calc
+                    k (Fin.last (A + 1 + C) + 1) = k 0 := congrArg k he
+                    _ = kL 0 := hkLeft 0
+                    _ = F.leftSectorWord j kL 0 := by
+                      rw [show (0 : Fin (A + 2)) =
+                        Fin.castSucc (0 : Fin (A + 1)) by rfl]
+                      exact (@Fin.lastCases_castSucc (A + 1)
+                        (fun _ ↦ Fin F.sectorCount) j kL 0).symm
+                exact (sectorIndex_fst_heq_of_heq F hk0
+                  ((dependent_apply_heq v he).trans (huL 0))).trans (heq_of_eq
+                    (F.leftFiberOpenEdgeEquiv_symm_boundary_succ
+                      (F.leftSectorWord j kL) zL))
+            have hzLeft' : z'.2.2 ≍ zL'.1 := by
+              refine (heq_of_eq
+                (F.retainedOpenEdgeEquiv_symm_first_left k z').symm).trans ?_
+              have he : Fin.last (A + C) + 1 = (0 : Fin (A + C + 1)) := by
+                ext
+                simp
+              by_cases hA : A = 0
+              · subst A
+                exact ((sectorIndex_fst_heq_of_heq F (congrArg k he)
+                  (dependent_apply_heq v' he)).trans huML').trans (heq_of_eq
+                  (F.leftFiberOpenEdgeEquiv_symm_boundary_zero
+                    (F.leftSectorWord j kL) zL'))
+              · obtain ⟨A, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hA
+                have hk0 : k (Fin.last (A + 1 + C) + 1) =
+                    F.leftSectorWord j kL 0 := by
+                  calc
+                    k (Fin.last (A + 1 + C) + 1) = k 0 := congrArg k he
+                    _ = kL 0 := hkLeft 0
+                    _ = F.leftSectorWord j kL 0 := by
+                      rw [show (0 : Fin (A + 2)) =
+                        Fin.castSucc (0 : Fin (A + 1)) by rfl]
+                      exact (@Fin.lastCases_castSucc (A + 1)
+                        (fun _ ↦ Fin F.sectorCount) j kL 0).symm
+                exact (sectorIndex_fst_heq_of_heq F hk0
+                  ((dependent_apply_heq v' he).trans (huL' 0))).trans (heq_of_eq
+                    (F.leftFiberOpenEdgeEquiv_symm_boundary_succ
+                      (F.leftSectorWord j kL) zL'))
+            have hzRight : z.2.1 ≍ zR.2 := by
+              refine (heq_of_eq
+                (F.retainedOpenEdgeEquiv_symm_last_right k z).symm).trans ?_
+              by_cases hC : C = 0
+              · subst C
+                have he : Fin.last A = ⟨A, by omega⟩ := by
+                  ext
+                  simp
+                exact ((sectorIndex_snd_heq_of_heq F (congrArg k he)
+                  (dependent_apply_heq v he)).trans huMR).trans (heq_of_eq
+                    (F.rightFiberOpenEdgeEquiv_symm_boundary_zero
+                      (F.rightSectorWord j kR) zR))
+              · obtain ⟨C, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hC
+                have he : Fin.last (A + (C + 1)) =
+                    ⟨A + 1 + Fin.last C, by omega⟩ := by
+                  ext
+                  simp
+                  omega
+                have hkLast : k (Fin.last (A + (C + 1))) =
+                    F.rightSectorWord j kR (Fin.last (C + 1)) := by
+                  calc
+                    k (Fin.last (A + (C + 1))) =
+                        k ⟨A + 1 + Fin.last C, by omega⟩ := congrArg k he
+                    _ = kR (Fin.last C) := hkRight (Fin.last C)
+                    _ = F.rightSectorWord j kR (Fin.last (C + 1)) := by
+                      rw [show Fin.last (C + 1) = (Fin.last C).succ by
+                        ext
+                        simp]
+                      exact (@Fin.cases_succ (C + 1)
+                        (fun _ ↦ Fin F.sectorCount) j kR (Fin.last C)).symm
+                exact (sectorIndex_snd_heq_of_heq F hkLast
+                  ((dependent_apply_heq v he).trans (huR (Fin.last C)))).trans
+                    (heq_of_eq (F.rightFiberOpenEdgeEquiv_symm_boundary_succ
+                      (F.rightSectorWord j kR) zR))
+            have hzRight' : z'.2.1 ≍ zR'.2 := by
+              refine (heq_of_eq
+                (F.retainedOpenEdgeEquiv_symm_last_right k z').symm).trans ?_
+              by_cases hC : C = 0
+              · subst C
+                have he : Fin.last A = ⟨A, by omega⟩ := by
+                  ext
+                  simp
+                exact ((sectorIndex_snd_heq_of_heq F (congrArg k he)
+                  (dependent_apply_heq v' he)).trans huMR').trans (heq_of_eq
+                    (F.rightFiberOpenEdgeEquiv_symm_boundary_zero
+                      (F.rightSectorWord j kR) zR'))
+              · obtain ⟨C, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hC
+                have he : Fin.last (A + (C + 1)) =
+                    ⟨A + 1 + Fin.last C, by omega⟩ := by
+                  ext
+                  simp
+                  omega
+                have hkLast : k (Fin.last (A + (C + 1))) =
+                    F.rightSectorWord j kR (Fin.last (C + 1)) := by
+                  calc
+                    k (Fin.last (A + (C + 1))) =
+                        k ⟨A + 1 + Fin.last C, by omega⟩ := congrArg k he
+                    _ = kR (Fin.last C) := hkRight (Fin.last C)
+                    _ = F.rightSectorWord j kR (Fin.last (C + 1)) := by
+                      rw [show Fin.last (C + 1) = (Fin.last C).succ by
+                        ext
+                        simp]
+                      exact (@Fin.cases_succ (C + 1)
+                        (fun _ ↦ Fin F.sectorCount) j kR (Fin.last C)).symm
+                exact (sectorIndex_snd_heq_of_heq F hkLast
+                  ((dependent_apply_heq v' he).trans (huR' (Fin.last C)))).trans
+                    (heq_of_eq (F.rightFiberOpenEdgeEquiv_symm_boundary_succ
+                      (F.rightSectorWord j kR) zR'))
+            have hboundaryLeft := cyclicActiveLeftBoundary_entry_eq_of_heq
+              F b hfirst hzLeft hzLeft'
+            have hboundaryRight := cyclicActiveRightBoundary_entry_eq_of_heq
+              F a hlast hzRight hzRight'
+            rw [hboundaryLeft, hboundaryRight]
+            ring
+          · simp [cyclicActiveFourthRegionBlock, cyclicActiveLeftOpenBlock,
+              cyclicActiveRightOpenBlock, hkActive, hL, hR]
+        · simp [cyclicActiveFourthRegionBlock, cyclicActiveLeftOpenBlock,
+            cyclicActiveRightOpenBlock, hkActive, hL]
+      · have hword :
+            ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1 ≠
+              ((F.retainedCutEquiv A C).symm ⟨j, (l', r')⟩).1 := by
+          intro hword
+          apply hkR
+          funext i
+          have hi := congrFun hword ⟨A + 1 + i, by omega⟩
+          rw [F.retainedCutEquiv_symm_right_sector A C j l r,
+            F.retainedCutEquiv_symm_right_sector A C j l' r'] at hi
+          calc
+            kR i = (F.sectorCoordinateChainEquiv C
+                (finFunctionFinEquiv.symm r.2)).1 i := by
+              simpa [hsR] using congrFun
+                (F.rightSectorOpenEdgeEquiv_apply_fst C j r) i
+            _ = (F.sectorCoordinateChainEquiv C
+                (finFunctionFinEquiv.symm r'.2)).1 i := hi
+            _ = kR' i := by
+              simpa [hsR'] using (congrFun
+                (F.rightSectorOpenEdgeEquiv_apply_fst C j r') i).symm
+        have hkk : k ≠ k' := by simpa [hg, hg'] using hword
+        rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkk,
+          Matrix.blockDiagonal'_apply_ne _ _ _ hkR, mul_zero]
+    · have hword :
+          ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1 ≠
+            ((F.retainedCutEquiv A C).symm ⟨j, (l', r')⟩).1 := by
+        intro hword
+        apply hkL
+        funext i
+        have hi := congrFun hword ⟨i, by omega⟩
+        rw [F.retainedCutEquiv_symm_left_sector A C j l r,
+          F.retainedCutEquiv_symm_left_sector A C j l' r'] at hi
+        calc
+          kL i = (F.sectorCoordinateChainEquiv A
+              (finFunctionFinEquiv.symm l.1)).1 i := by
+            simpa [hsL] using congrFun
+              (F.leftSectorOpenEdgeEquiv_apply_fst A j l) i
+          _ = (F.sectorCoordinateChainEquiv A
+              (finFunctionFinEquiv.symm l'.1)).1 i := hi
+          _ = kL' i := by
+            simpa [hsL'] using (congrFun
+              (F.leftSectorOpenEdgeEquiv_apply_fst A j l') i).symm
+      have hkk : k ≠ k' := by simpa [hg, hg'] using hword
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkk,
+        Matrix.blockDiagonal'_apply_ne _ _ _ hkL, zero_mul]
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hj]
+    have hword :
+        ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1 ≠
+          ((F.retainedCutEquiv A C).symm ⟨j', (l', r')⟩).1 := by
+      intro h
+      apply hj
+      rw [← F.retainedCutEquiv_symm_middle_sector A C j l r,
+        ← F.retainedCutEquiv_symm_middle_sector A C j' l' r', h]
+    rw [Matrix.blockDiagonal'_apply_ne _ _ _ hword]
+
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveCutStates.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutStates.lean
@@ -1,0 +1,654 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveCutCoordinates
+
+/-!
+# Left and right states at cyclic-active cuts
+
+This file defines the positive path factors, their standard coordinate forms,
+the normalized conditional states, and the sector probabilities.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+universe u
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The unnormalized positive left path factor in fixed-sector open-edge
+coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This factor uses the left boundary
+of the restricted two-step coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveLeftOpenBlock
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (lam : ℝ) (b : F.CyclicActiveSector → ℝ)
+    (k : Fin (A + 1) → Fin F.sectorCount) :
+    Matrix (F.LeftOpenEdgeIndex k) (F.LeftOpenEdgeIndex k) ℂ := by
+  classical
+  exact if hk : F.IsCyclicActiveRetainedWord k then
+      let kC := F.cyclicActiveRetainedWord hk
+      ((lam : ℂ) ^ 2) •
+        (F.cyclicActiveLeftBoundary b (kC 0) ⊗ₖ
+          Matrix.finKronecker (fun i : Fin A ↦
+            F.neighboringOperator (k i.castSucc) (k i.succ)))
+    else 0
+
+/-- The unnormalized positive right path factor in fixed-sector open-edge
+coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This factor uses the right
+boundary of the restricted two-step coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveRightOpenBlock
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (a : F.CyclicActiveSector → ℝ)
+    (k : Fin (C + 1) → Fin F.sectorCount) :
+    Matrix (F.RightOpenEdgeIndex k) (F.RightOpenEdgeIndex k) ℂ := by
+  classical
+  exact if hk : F.IsCyclicActiveRetainedWord k then
+      let kC := F.cyclicActiveRetainedWord hk
+      Matrix.finKronecker (fun i : Fin C ↦
+          F.neighboringOperator (k i.castSucc) (k i.succ)) ⊗ₖ
+        F.cyclicActiveRightBoundary a (kC (Fin.last C))
+    else 0
+
+/-- The left open-chain factor is positive semidefinite when the neighbouring
+operators and left boundary weights are nonnegative.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the left positive factor
+for the restricted two-step coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveLeftOpenBlock_posSemidef
+    (F : PhysicalSectorFactorization K) {A : ℕ}
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (lam : ℝ) (b : F.CyclicActiveSector → ℝ) (hb : ∀ h, 0 ≤ b h)
+    (k : Fin (A + 1) → Fin F.sectorCount) :
+    (F.cyclicActiveLeftOpenBlock lam b k).PosSemidef := by
+  classical
+  by_cases hk : F.IsCyclicActiveRetainedWord k
+  · rw [cyclicActiveLeftOpenBlock, dif_pos hk]
+    apply Matrix.PosSemidef.smul
+    · exact (F.cyclicActiveLeftBoundary_posSemidef hpos b hb _).kronecker
+        (Matrix.finKronecker_posSemidef _ fun i ↦ hpos _ _)
+    · have hs : 0 ≤ lam ^ 2 := sq_nonneg lam
+      exact_mod_cast hs
+  · rw [cyclicActiveLeftOpenBlock, dif_neg hk]
+    exact Matrix.PosSemidef.zero
+
+/-- The right open-chain factor is positive semidefinite when the neighbouring
+operators and right boundary weights are nonnegative.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the right positive factor
+for the restricted two-step coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveRightOpenBlock_posSemidef
+    (F : PhysicalSectorFactorization K) {C : ℕ}
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (a : F.CyclicActiveSector → ℝ) (ha : ∀ q, 0 ≤ a q)
+    (k : Fin (C + 1) → Fin F.sectorCount) :
+    (F.cyclicActiveRightOpenBlock a k).PosSemidef := by
+  classical
+  by_cases hk : F.IsCyclicActiveRetainedWord k
+  · rw [cyclicActiveRightOpenBlock, dif_pos hk]
+    exact (Matrix.finKronecker_posSemidef _ fun i ↦ hpos _ _).kronecker
+      (F.cyclicActiveRightBoundary_posSemidef hpos a ha _)
+  · rw [cyclicActiveRightOpenBlock, dif_neg hk]
+    exact Matrix.PosSemidef.zero
+
+/-- The left path factor on the standard `A ⊗ B_jᴸ` coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The direct sum ranges over left
+paths retained by the cyclic-active restriction. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveLeftCutRaw
+    (F : PhysicalSectorFactorization K) (A : ℕ)
+    (lam : ℝ) (b : F.CyclicActiveSector → ℝ)
+    (j : Fin F.sectorCount) :
+    Matrix
+      (Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j))
+      (Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j)) ℂ :=
+  Matrix.reindex (F.leftSectorOpenEdgeEquiv A j).symm
+    (F.leftSectorOpenEdgeEquiv A j).symm <|
+      Matrix.blockDiagonal' fun k ↦
+        F.cyclicActiveLeftOpenBlock lam b (F.leftSectorWord j k)
+
+/-- The right path factor on the standard `B_jʳ ⊗ C` coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The direct sum ranges over right
+paths retained by the cyclic-active restriction. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveRightCutRaw
+    (F : PhysicalSectorFactorization K) (C : ℕ)
+    (a : F.CyclicActiveSector → ℝ)
+    (j : Fin F.sectorCount) :
+    Matrix
+      (Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C))
+      (Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C)) ℂ :=
+  Matrix.reindex (F.rightSectorOpenEdgeEquiv C j).symm
+    (F.rightSectorOpenEdgeEquiv C j).symm <|
+      Matrix.blockDiagonal' fun k ↦
+        F.cyclicActiveRightOpenBlock a (F.rightSectorWord j k)
+
+/-- The direct sum of the left open-chain factors is positive semidefinite in
+the standard left-cut coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The sum ranges over the retained
+cyclic-active sectors. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveLeftCutRaw_posSemidef
+    (F : PhysicalSectorFactorization K) (A : ℕ)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (lam : ℝ) (b : F.CyclicActiveSector → ℝ) (hb : ∀ h, 0 ≤ b h)
+    (j : Fin F.sectorCount) :
+    (F.cyclicActiveLeftCutRaw A lam b j).PosSemidef := by
+  classical
+  exact (Matrix.PosSemidef.blockDiagonal' _ fun k ↦
+    F.cyclicActiveLeftOpenBlock_posSemidef hpos lam b hb _).submatrix _
+
+/-- The direct sum of the right open-chain factors is positive semidefinite in
+the standard right-cut coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The sum ranges over the retained
+cyclic-active sectors. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveRightCutRaw_posSemidef
+    (F : PhysicalSectorFactorization K) (C : ℕ)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (a : F.CyclicActiveSector → ℝ) (ha : ∀ q, 0 ≤ a q)
+    (j : Fin F.sectorCount) :
+    (F.cyclicActiveRightCutRaw C a j).PosSemidef := by
+  classical
+  exact (Matrix.PosSemidef.blockDiagonal' _ fun k ↦
+    F.cyclicActiveRightOpenBlock_posSemidef hpos a ha _).submatrix _
+
+/-- The sector-coordinate periodic normalization is strictly positive at
+every positive length under source zero correlation length.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This positivity normalizes the
+restricted cut probabilities after the additional marginal replacement. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) {N : ℕ} (hN : 0 < N) :
+    0 < Matrix.trace (mpo F.sectorCoordinateTensor N) := by
+  letI : NeZero N := ⟨ne_of_gt hN⟩
+  have hpsd := F.mpo_sectorCoordinateTensor_posSemidef hpos (N := N)
+  have htrace : Matrix.trace (mpo F.sectorCoordinateTensor N) ≠ 0 := by
+    rw [F.sectorCoordinateTensor_eq_changePhysicalBasis,
+      trace_mpo_changePhysicalBasis_of_isometry F.physicalCoordinateMatrix
+        F.physicalCoordinateMatrix_isometry]
+    exact trace_mpo_ne_zero_of_isSourceZCL K hZCL hN
+  exact hpsd.trace_pos_of_ne_zero fun hzero ↦ htrace (by simp [hzero])
+
+/-- A fixed index used only in the zero-trace fallback normalization of a
+left cut block.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** Positive block traces make the
+fallback mathematically inactive; it makes normalization total.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveLeftCutFallback
+    (F : PhysicalSectorFactorization K) (A : ℕ) (j : Fin F.sectorCount) :
+    Fin (Fintype.card F.SectorSiteIndex ^ A) × Fin (F.leftDim j) :=
+  (⟨0, by
+    apply pow_pos
+    exact Fintype.card_pos_iff.mpr ⟨⟨j,
+      (⟨0, F.leftDim_pos j⟩, ⟨0, F.rightDim_pos j⟩)⟩⟩⟩,
+    ⟨0, F.leftDim_pos j⟩)
+
+/-- A fixed index used only in the zero-trace fallback normalization of a
+right cut block.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** Positive block traces make the
+fallback mathematically inactive; it makes normalization total.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveRightCutFallback
+    (F : PhysicalSectorFactorization K) (C : ℕ) (j : Fin F.sectorCount) :
+    Fin (F.rightDim j) × Fin (Fintype.card F.SectorSiteIndex ^ C) :=
+  (⟨0, F.rightDim_pos j⟩,
+    ⟨0, by
+      apply pow_pos
+      exact Fintype.card_pos_iff.mpr ⟨⟨j,
+        (⟨0, F.leftDim_pos j⟩, ⟨0, F.rightDim_pos j⟩)⟩⟩⟩)
+
+/-- The normalized left path state in a cyclic-active cut block.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The state normalizes the positive
+left factor of the restricted two-step coefficient.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveLeftCutState
+    (F : PhysicalSectorFactorization K) (A : ℕ) (lam : ℝ)
+    (b : F.CyclicActiveSector → ℝ) (j : Fin F.sectorCount) :=
+  Matrix.normalizePosSemidef (F.cyclicActiveLeftCutFallback A j)
+    (F.cyclicActiveLeftCutRaw A lam b j)
+
+/-- The normalized right path state in a cyclic-active cut block.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The state normalizes the positive
+right factor of the restricted two-step coefficient.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveRightCutState
+    (F : PhysicalSectorFactorization K) (C : ℕ)
+    (a : F.CyclicActiveSector → ℝ) (j : Fin F.sectorCount) :=
+  Matrix.normalizePosSemidef (F.cyclicActiveRightCutFallback C j)
+    (F.cyclicActiveRightCutRaw C a j)
+
+/-- The real periodic normalization used by the cut probabilities.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** Its length includes the additional
+marginal replacement.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveCutNormalization
+    (F : PhysicalSectorFactorization K) (A C : ℕ) : ℝ :=
+  (Matrix.trace (mpo F.sectorCoordinateTensor (A + C + 4))).re
+
+/-- The probability of a middle sector in the cyclic-active cut
+decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The weight uses the normalized
+restricted two-step coefficient.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveCutProbability
+    (F : PhysicalSectorFactorization K) (A C : ℕ) (lam : ℝ)
+    (a b : F.CyclicActiveSector → ℝ) (j : Fin F.sectorCount) : ℝ :=
+  (F.cyclicActiveCutNormalization A C)⁻¹ *
+    (F.cyclicActiveLeftCutRaw A lam b j).trace.re *
+    (F.cyclicActiveRightCutRaw C a j).trace.re
+
+/-- Reassociate a retained chain of lengths `A, 1, C` into the index used by
+the dependent blocks of the Hayashi decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identification separates the
+retained cyclic-active chain at its distinguished middle site. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def retainedCutEquiv
+    (F : PhysicalSectorFactorization K) (A C : ℕ) :
+    (Σ k : Fin (A + C + 1) → Fin F.sectorCount,
+      F.RetainedOpenEdgeIndex (n := A + C) k) ≃
+      Σ j : Fin F.sectorCount,
+        (Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j)) ×
+          (Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C)) :=
+  ((Equiv.sigmaCongrRight fun k ↦ F.retainedOpenEdgeEquiv k).symm.trans
+    (F.sectorCoordinateChainEquiv (A + C + 1)).symm).trans <|
+      (Equiv.arrowCongr (finCongr (by omega)) (Equiv.refl _)).trans <|
+      (tripartiteSplitEquiv (Fintype.card (SectorSiteIndex F)) A 1 C).trans <|
+        (Equiv.prodCongr (Equiv.refl _)
+          (Equiv.prodCongr
+            F.sectorCoordinateMiddleEquiv
+            (Equiv.refl _))).trans <|
+          (HayashiMarkov.sigmaAssoc
+            (dA := Fintype.card (SectorSiteIndex F) ^ A)
+            (dC := Fintype.card (SectorSiteIndex F) ^ C)
+            F.leftDim F.rightDim).symm
+
+/-- Under the inverse tripartite identification, the sector at the middle
+site is the prescribed cut sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity describes the
+sector coordinates of the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem retainedCutEquiv_symm_middle_sector
+    (F : PhysicalSectorFactorization K) (A C : ℕ)
+    (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j))
+    (r : Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C)) :
+    ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1 ⟨A, by omega⟩ = j := by
+  simp [retainedCutEquiv, sectorCoordinateMiddleEquiv,
+    HayashiMarkov.sigmaAssoc, tripartiteSplitEquiv, blockSplitEquiv,
+    show (⟨A, by omega⟩ : Fin (A + 1 + C)) =
+      Fin.castAdd C (Fin.last A) by ext; simp,
+    finSumFinEquiv_symm_apply_castAdd,
+    Equiv.sumArrowEquivProdArrow_symm_apply_inl]
+
+/-- Under the inverse tripartite identification, a sector to the left of the
+cut is the corresponding sector in the left chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity describes the
+sector coordinates of the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem retainedCutEquiv_symm_left_sector
+    (F : PhysicalSectorFactorization K) (A C : ℕ)
+    (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j))
+    (r : Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C))
+    (i : Fin A) :
+    ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1 ⟨i, by omega⟩ =
+      (F.sectorCoordinateChainEquiv A (finFunctionFinEquiv.symm l.1)).1 i := by
+  simp [retainedCutEquiv, sectorCoordinateMiddleEquiv,
+    HayashiMarkov.sigmaAssoc, tripartiteSplitEquiv, blockSplitEquiv,
+    show (⟨i, by omega⟩ : Fin (A + 1 + C)) =
+      Fin.castAdd C (Fin.castAdd 1 i) by ext; simp,
+    finSumFinEquiv_symm_apply_castAdd,
+    Equiv.sumArrowEquivProdArrow_symm_apply_inl]
+
+/-- Under the inverse tripartite identification, a sector to the right of the
+cut is the corresponding sector in the right chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity describes the
+sector coordinates of the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem retainedCutEquiv_symm_right_sector
+    (F : PhysicalSectorFactorization K) (A C : ℕ)
+    (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j))
+    (r : Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C))
+    (i : Fin C) :
+    ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1
+        ⟨A + 1 + i, by omega⟩ =
+      (F.sectorCoordinateChainEquiv C (finFunctionFinEquiv.symm r.2)).1 i := by
+  simp [retainedCutEquiv, sectorCoordinateMiddleEquiv,
+    HayashiMarkov.sigmaAssoc, tripartiteSplitEquiv, blockSplitEquiv,
+    show (⟨A + 1 + i, by omega⟩ : Fin (A + 1 + C)) =
+      Fin.natAdd (A + 1) i by ext; simp,
+    finSumFinEquiv_symm_apply_natAdd,
+    Equiv.sumArrowEquivProdArrow_symm_apply_inr]
+
+/-- At a site to the left of the cut, the retained-chain fiber coordinate
+agrees with the corresponding coordinate of the left open chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the dependent-coordinate
+identity for the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem retainedCutEquiv_symm_left_fiber_heq
+    (F : PhysicalSectorFactorization K) (A C : ℕ)
+    (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j))
+    (r : Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C))
+    (i : Fin A) :
+    let g := (F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩
+    let s := F.leftSectorOpenEdgeEquiv A j l
+    ((F.retainedOpenEdgeEquiv g.1).symm g.2 ⟨i, by omega⟩) ≍
+      ((F.leftFixedFiberOpenEdgeEquiv j s.1).symm s.2).1 i := by
+  let xG : Fin (A + C + 1) → Fin (Fintype.card (SectorSiteIndex F)) :=
+    ((finCongr (by omega)).arrowCongr (Equiv.refl _))
+      ((tripartiteSplitEquiv (Fintype.card (SectorSiteIndex F)) A 1 C).symm
+        (((Equiv.refl _).prodCongr
+          (F.sectorCoordinateMiddleEquiv.symm.prodCongr (Equiv.refl _)))
+            (HayashiMarkov.sigmaAssoc F.leftDim F.rightDim ⟨j, (l, r)⟩)))
+  let xL := finFunctionFinEquiv.symm l.1
+  let sG := F.sectorCoordinateChainEquiv (A + C + 1) xG
+  let eG : F.SectorChainIndex (A + C + 1) ≃
+      (Σ k : Fin (A + C + 1) → Fin F.sectorCount,
+        F.RetainedOpenEdgeIndex (n := A + C) k) :=
+    Equiv.sigmaCongrRight fun k ↦ F.retainedOpenEdgeEquiv k
+  have hG0 := eG.symm_apply_apply sG
+  have hG1heq :
+      (F.retainedOpenEdgeEquiv (eG sG).1).symm (eG sG).2 ≍ sG.2 :=
+    (Sigma.mk.inj_iff.mp hG0).2
+  have hG1 :
+      (F.retainedOpenEdgeEquiv (eG sG).1).symm (eG sG).2 = sG.2 := by
+    simpa [eG] using eq_of_heq hG1heq
+  have hG := congrFun hG1 ⟨i, by omega⟩
+  have hG' :
+      ((F.retainedOpenEdgeEquiv
+        ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1).symm
+          ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).2 ⟨i, by omega⟩) ≍
+        (F.sectorCoordinateChainEquiv (A + C + 1) xG).2 ⟨i, by omega⟩ := by
+    apply heq_of_eq
+    convert hG using 1 <;> simp [retainedCutEquiv, xG, sG, eG]; rfl
+  dsimp only
+  refine hG'.trans ?_
+  have hL :
+      ((F.leftFixedFiberOpenEdgeEquiv j
+        (F.leftSectorOpenEdgeEquiv A j l).1).symm
+          (F.leftSectorOpenEdgeEquiv A j l).2).1 i ≍
+        (F.sectorCoordinateChainEquiv A xL).2 i := by
+    let sL := F.sectorCoordinateChainEquiv A xL
+    let tL : Σ k : Fin A → Fin F.sectorCount,
+        F.SectorChainFiber k × Fin (F.leftDim j) := ⟨sL.1, (sL.2, l.2)⟩
+    let eL : (Σ k : Fin A → Fin F.sectorCount,
+        F.SectorChainFiber k × Fin (F.leftDim j)) ≃
+        (Σ k : Fin A → Fin F.sectorCount,
+          F.LeftOpenEdgeIndex (F.leftSectorWord j k)) :=
+      Equiv.sigmaCongrRight fun k ↦ F.leftFixedFiberOpenEdgeEquiv j k
+    have hL0 := eL.symm_apply_apply tL
+    have hL1heq :
+        (F.leftFixedFiberOpenEdgeEquiv j (eL tL).1).symm (eL tL).2 ≍
+          tL.2 := (Sigma.mk.inj_iff.mp hL0).2
+    have hL1 :
+        (F.leftFixedFiberOpenEdgeEquiv j (eL tL).1).symm (eL tL).2 =
+          tL.2 := by
+      simpa [eL] using eq_of_heq hL1heq
+    have hL2 := congrFun (congrArg Prod.fst hL1) i
+    apply heq_of_eq
+    convert hL2 using 1 <;>
+      simp [leftSectorOpenEdgeEquiv, xL, sL, tL, eL] <;> rfl
+  refine (F.sectorCoordinateChainEquiv_apply_snd_heq (A + C + 1) xG
+    ⟨i, by omega⟩).trans ?_
+  refine HEq.trans ?_ hL.symm
+  have hx : xG ⟨i, by omega⟩ = xL i := by
+    simp [xG, sectorCoordinateMiddleEquiv, HayashiMarkov.sigmaAssoc,
+      tripartiteSplitEquiv, blockSplitEquiv,
+      show (⟨i, by omega⟩ : Fin (A + 1 + C)) =
+        Fin.castAdd C (Fin.castAdd 1 i) by ext; simp,
+      finSumFinEquiv_symm_apply_castAdd,
+      Equiv.sumArrowEquivProdArrow_symm_apply_inl, xL]
+  have he := congrArg F.sectorFinEquiv hx
+  exact (Sigma.mk.inj_iff.mp he).2.trans
+    (F.sectorCoordinateChainEquiv_apply_snd_heq A xL i).symm
+
+/-- At a site to the right of the cut, the retained-chain fiber coordinate
+agrees with the corresponding coordinate of the right open chain.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the dependent-coordinate
+identity for the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem retainedCutEquiv_symm_right_fiber_heq
+    (F : PhysicalSectorFactorization K) (A C : ℕ)
+    (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j))
+    (r : Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C))
+    (i : Fin C) :
+    let g := (F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩
+    let s := F.rightSectorOpenEdgeEquiv C j r
+    ((F.retainedOpenEdgeEquiv g.1).symm g.2 ⟨A + 1 + i, by omega⟩) ≍
+      ((F.rightFixedFiberOpenEdgeEquiv j s.1).symm s.2).2 i := by
+  let xG : Fin (A + C + 1) → Fin (Fintype.card (SectorSiteIndex F)) :=
+    ((finCongr (by omega)).arrowCongr (Equiv.refl _))
+      ((tripartiteSplitEquiv (Fintype.card (SectorSiteIndex F)) A 1 C).symm
+        (((Equiv.refl _).prodCongr
+          (F.sectorCoordinateMiddleEquiv.symm.prodCongr (Equiv.refl _)))
+            (HayashiMarkov.sigmaAssoc F.leftDim F.rightDim ⟨j, (l, r)⟩)))
+  let xR := finFunctionFinEquiv.symm r.2
+  let sG := F.sectorCoordinateChainEquiv (A + C + 1) xG
+  let eG : F.SectorChainIndex (A + C + 1) ≃
+      (Σ k : Fin (A + C + 1) → Fin F.sectorCount,
+        F.RetainedOpenEdgeIndex (n := A + C) k) :=
+    Equiv.sigmaCongrRight fun k ↦ F.retainedOpenEdgeEquiv k
+  have hG0 := eG.symm_apply_apply sG
+  have hG1heq :
+      (F.retainedOpenEdgeEquiv (eG sG).1).symm (eG sG).2 ≍ sG.2 :=
+    (Sigma.mk.inj_iff.mp hG0).2
+  have hG1 :
+      (F.retainedOpenEdgeEquiv (eG sG).1).symm (eG sG).2 = sG.2 := by
+    simpa [eG] using eq_of_heq hG1heq
+  have hG := congrFun hG1 ⟨A + 1 + i, by omega⟩
+  have hG' :
+      ((F.retainedOpenEdgeEquiv
+        ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1).symm
+          ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).2
+            ⟨A + 1 + i, by omega⟩) ≍
+        (F.sectorCoordinateChainEquiv (A + C + 1) xG).2
+          ⟨A + 1 + i, by omega⟩ := by
+    apply heq_of_eq
+    convert hG using 1 <;> simp [retainedCutEquiv, xG, sG, eG]; rfl
+  dsimp only
+  refine hG'.trans ?_
+  have hR :
+      ((F.rightFixedFiberOpenEdgeEquiv j
+        (F.rightSectorOpenEdgeEquiv C j r).1).symm
+          (F.rightSectorOpenEdgeEquiv C j r).2).2 i ≍
+        (F.sectorCoordinateChainEquiv C xR).2 i := by
+    let sR := F.sectorCoordinateChainEquiv C xR
+    let tR : Σ k : Fin C → Fin F.sectorCount,
+        Fin (F.rightDim j) × F.SectorChainFiber k := ⟨sR.1, (r.1, sR.2)⟩
+    let eR : (Σ k : Fin C → Fin F.sectorCount,
+        Fin (F.rightDim j) × F.SectorChainFiber k) ≃
+        (Σ k : Fin C → Fin F.sectorCount,
+          F.RightOpenEdgeIndex (F.rightSectorWord j k)) :=
+      Equiv.sigmaCongrRight fun k ↦ F.rightFixedFiberOpenEdgeEquiv j k
+    have hR0 := eR.symm_apply_apply tR
+    have hR1heq :
+        (F.rightFixedFiberOpenEdgeEquiv j (eR tR).1).symm (eR tR).2 ≍
+          tR.2 := (Sigma.mk.inj_iff.mp hR0).2
+    have hR1 :
+        (F.rightFixedFiberOpenEdgeEquiv j (eR tR).1).symm (eR tR).2 =
+          tR.2 := by
+      simpa [eR] using eq_of_heq hR1heq
+    have hR2 := congrFun (congrArg Prod.snd hR1) i
+    apply heq_of_eq
+    convert hR2 using 1 <;>
+      simp [rightSectorOpenEdgeEquiv, xR, sR, tR, eR] <;> rfl
+  refine (F.sectorCoordinateChainEquiv_apply_snd_heq (A + C + 1) xG
+    ⟨A + 1 + i, by omega⟩).trans ?_
+  refine HEq.trans ?_ hR.symm
+  have hx : xG ⟨A + 1 + i, by omega⟩ = xR i := by
+    simp [xG, sectorCoordinateMiddleEquiv, HayashiMarkov.sigmaAssoc,
+      tripartiteSplitEquiv, blockSplitEquiv,
+      show (⟨A + 1 + i, by omega⟩ : Fin (A + 1 + C)) =
+        Fin.natAdd (A + 1) i by ext; simp,
+      finSumFinEquiv_symm_apply_natAdd,
+      Equiv.sumArrowEquivProdArrow_symm_apply_inr, xR]
+  have he := congrArg F.sectorFinEquiv hx
+  exact (Sigma.mk.inj_iff.mp he).2.trans
+    (F.sectorCoordinateChainEquiv_apply_snd_heq C xR i).symm
+
+/-- At the cut site, the retained-chain fiber coordinate is the pair of the
+left and right boundary indices.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the middle
+dependent-coordinate identity for the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem retainedCutEquiv_symm_middle_fiber_heq
+    (F : PhysicalSectorFactorization K) (A C : ℕ)
+    (j : Fin F.sectorCount)
+    (l : Fin (Fintype.card (SectorSiteIndex F) ^ A) × Fin (F.leftDim j))
+    (r : Fin (F.rightDim j) × Fin (Fintype.card (SectorSiteIndex F) ^ C)) :
+    let g := (F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩
+    ((F.retainedOpenEdgeEquiv g.1).symm g.2 ⟨A, by omega⟩) ≍
+      (l.2, r.1) := by
+  let xG : Fin (A + C + 1) → Fin (Fintype.card (SectorSiteIndex F)) :=
+    ((finCongr (by omega)).arrowCongr (Equiv.refl _))
+      ((tripartiteSplitEquiv (Fintype.card (SectorSiteIndex F)) A 1 C).symm
+        (((Equiv.refl _).prodCongr
+          (F.sectorCoordinateMiddleEquiv.symm.prodCongr (Equiv.refl _)))
+            (HayashiMarkov.sigmaAssoc F.leftDim F.rightDim ⟨j, (l, r)⟩)))
+  let sG := F.sectorCoordinateChainEquiv (A + C + 1) xG
+  let eG : F.SectorChainIndex (A + C + 1) ≃
+      (Σ k : Fin (A + C + 1) → Fin F.sectorCount,
+        F.RetainedOpenEdgeIndex (n := A + C) k) :=
+    Equiv.sigmaCongrRight fun k ↦ F.retainedOpenEdgeEquiv k
+  have hG0 := eG.symm_apply_apply sG
+  have hG1heq :
+      (F.retainedOpenEdgeEquiv (eG sG).1).symm (eG sG).2 ≍ sG.2 :=
+    (Sigma.mk.inj_iff.mp hG0).2
+  have hG1 :
+      (F.retainedOpenEdgeEquiv (eG sG).1).symm (eG sG).2 = sG.2 := by
+    simpa [eG] using eq_of_heq hG1heq
+  have hG := congrFun hG1 ⟨A, by omega⟩
+  have hG' :
+      ((F.retainedOpenEdgeEquiv
+        ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).1).symm
+          ((F.retainedCutEquiv A C).symm ⟨j, (l, r)⟩).2
+            ⟨A, by omega⟩) ≍
+        (F.sectorCoordinateChainEquiv (A + C + 1) xG).2
+          ⟨A, by omega⟩ := by
+    apply heq_of_eq
+    convert hG using 1 <;> simp [retainedCutEquiv, xG, sG, eG]; rfl
+  dsimp only
+  refine hG'.trans ?_
+  refine (F.sectorCoordinateChainEquiv_apply_snd_heq (A + C + 1) xG
+    ⟨A, by omega⟩).trans ?_
+  have hx : xG ⟨A, by omega⟩ =
+      F.sectorFinEquiv.symm ⟨j, (l.2, r.1)⟩ := by
+    simp [xG, sectorCoordinateMiddleEquiv, HayashiMarkov.sigmaAssoc,
+      tripartiteSplitEquiv, blockSplitEquiv,
+      show (⟨A, by omega⟩ : Fin (A + 1 + C)) =
+        Fin.castAdd C (Fin.last A) by ext; simp,
+      finSumFinEquiv_symm_apply_castAdd,
+      Equiv.sumArrowEquivProdArrow_symm_apply_inl]
+  have he := congrArg F.sectorFinEquiv hx
+  have he' : F.sectorFinEquiv (xG ⟨A, by omega⟩) =
+      ⟨j, (l.2, r.1)⟩ := by
+    simpa using he
+  exact (Sigma.mk.inj_iff.mp he').2
+
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegion.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegion.lean
@@ -1,0 +1,6 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveFourthRegionFormula

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
@@ -1,0 +1,791 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveRetainedCoordinates
+
+/-!
+# Contraction of the three discarded sites
+
+This file evaluates the contraction over the three discarded sites in
+retained open-edge coordinates and specializes it to cyclic-active sectors.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+private theorem fourthRegion_internal_index {n : ℕ} (i : Fin n) :
+    Fin.castAdd 3 (Fin.castAdd 1 i) =
+      Fin.castAdd 3 ((Fin.last n).succAbove i) := by
+  ext
+  simp [Fin.succAbove_last]
+
+private theorem fourthRegion_retained_internal_index {n : ℕ} (i : Fin n) :
+    Fin.castAdd 1 i = (Fin.last n).succAbove i := by
+  ext
+  simp [Fin.succAbove_last]
+
+private theorem fourthRegion_retained_internal_succ_index {n : ℕ} (i : Fin n) :
+    Fin.castAdd 1 i + 1 = (Fin.last n).succAbove i + 1 := by
+  ext
+  simp [Fin.succAbove_last, Fin.add_def]
+
+private theorem fourthRegion_internal_succ_index {n : ℕ} (i : Fin n) :
+    Fin.castAdd 3 (Fin.castAdd 1 i) + 1 =
+      Fin.castAdd 3 ((Fin.last n).succAbove i + 1) := by
+  rw [Fin.succAbove_last]
+  apply Fin.ext
+  have hn : 0 < n := lt_of_le_of_lt (Nat.zero_le i.val) i.isLt
+  have honeBig : ((1 : Fin (n + 1 + 3)) : ℕ) = 1 := by
+    simp
+  have honeSmall : ((1 : Fin (n + 1)) : ℕ) = 1 := by
+    change 1 % (n + 1) = 1
+    exact Nat.mod_eq_of_lt (by omega)
+  simp only [Fin.val_castAdd, Fin.val_add, Fin.val_castSucc,
+    honeBig, honeSmall]
+  rw [Nat.mod_eq_of_lt (by omega), Nat.mod_eq_of_lt (by omega)]
+
+private theorem fourthRegion_last_retained_index {n : ℕ} :
+    Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1)) =
+      Fin.castAdd 3 (Fin.last n) := by
+  ext
+  rfl
+
+private theorem fourthRegion_retained_last_index {n : ℕ} :
+    Fin.natAdd n (0 : Fin 1) = Fin.last n := by
+  ext
+  rfl
+
+private theorem fourthRegion_first_suffix_index {n : ℕ} :
+    Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1)) + 1 =
+      Fin.natAdd (n + 1) (0 : Fin 3) := by
+  ext
+  simp [Fin.add_def]
+
+private theorem fourthRegion_suffix_zero_succ {n : ℕ} :
+    Fin.natAdd (n + 1) (0 : Fin 3) + 1 =
+      Fin.natAdd (n + 1) (1 : Fin 3) := by
+  ext
+  simp [Fin.add_def]
+
+private theorem fourthRegion_suffix_one_succ {n : ℕ} :
+    Fin.natAdd (n + 1) (1 : Fin 3) + 1 =
+      Fin.natAdd (n + 1) (2 : Fin 3) := by
+  ext
+  simp [Fin.add_def]
+
+private theorem fourthRegion_suffix_two_succ {n : ℕ} :
+    Fin.natAdd (n + 1) (2 : Fin 3) + 1 =
+      Fin.castAdd 3 (Fin.last n + 1) := by
+  ext
+  simp [Fin.add_def]
+
+private theorem rightTensor_eq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) (a : Fin D)
+    {x y : Fin (F.rightDim k)} {x' y' : Fin (F.rightDim h)}
+    (hx : HEq x x') (hy : HEq y y') :
+    F.rightTensor k a x y = F.rightTensor h a x' y' := by
+  subst h
+  cases hx
+  cases hy
+  rfl
+
+private theorem leftTensor_eq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) (a : Fin D)
+    {x y : Fin (F.leftDim k)} {x' y' : Fin (F.leftDim h)}
+    (hx : HEq x x') (hy : HEq y y') :
+    F.leftTensor k a x y = F.leftTensor h a x' y' := by
+  subst h
+  cases hx
+  cases hy
+  rfl
+
+private theorem partialTraceRight_neighboringOperator_eq_of_right
+    (F : PhysicalSectorFactorization K)
+    (k h h' : Fin F.sectorCount) (hh : h = h')
+    (x y : Fin (F.rightDim k)) :
+    Matrix.partialTraceRight (F.neighboringOperator k h) x y =
+      Matrix.partialTraceRight (F.neighboringOperator k h') x y := by
+  subst h'
+  rfl
+
+private theorem partialTraceLeft_neighboringOperator_eq_of_left
+    (F : PhysicalSectorFactorization K)
+    (k k' h : Fin F.sectorCount) (hk : k = k')
+    (x y : Fin (F.leftDim h)) :
+    Matrix.partialTraceLeft (F.neighboringOperator k h) x y =
+      Matrix.partialTraceLeft (F.neighboringOperator k' h) x y := by
+  subst k'
+  rfl
+
+private theorem neighboringOperator_trace_eq_of_eq
+    (F : PhysicalSectorFactorization K)
+    (k k' h h' : Fin F.sectorCount) (hk : k = k') (hh : h = h') :
+    (F.neighboringOperator k h).trace =
+      (F.neighboringOperator k' h').trace := by
+  subst k'
+  subst h'
+  rfl
+
+private theorem sectorIndex_fst_heq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
+    (hxy : x ≍ y) : x.1 ≍ y.1 := by
+  subst h
+  exact heq_of_eq (congrArg Prod.fst (eq_of_heq hxy))
+
+private theorem sectorIndex_snd_heq_of_heq
+    (F : PhysicalSectorFactorization K) {k h : Fin F.sectorCount}
+    (kh : k = h) {x : F.SectorIndex k} {y : F.SectorIndex h}
+    (hxy : x ≍ y) : x.2 ≍ y.2 := by
+  subst h
+  exact heq_of_eq (congrArg Prod.snd (eq_of_heq hxy))
+
+private theorem dependent_prod_fst_heq {ι : Type*} {α β : ι → Type*}
+    (f : (i : ι) → α i × β i) {i j : ι} (h : i = j) :
+    (f i).1 ≍ (f j).1 := by
+  subst j
+  rfl
+
+private theorem dependent_prod_snd_heq {ι : Type*} {α β : ι → Type*}
+    (f : (i : ι) → α i × β i) {i j : ι} (h : i = j) :
+    (f i).2 ≍ (f j).2 := by
+  subst j
+  rfl
+
+private theorem appendSectorFiber_castAdd_heq
+    (F : PhysicalSectorFactorization K)
+    {L R : ℕ} {k : Fin L → Fin F.sectorCount}
+    {t : Fin R → Fin F.sectorCount}
+    (x : F.SectorChainFiber k) (z : F.SectorChainFiber t) (i : Fin L) :
+    F.appendSectorFiber x z (Fin.castAdd R i) ≍ x i := by
+  simp only [appendSectorFiber, Fin.addCases_left]
+  exact cast_heq _ _
+
+private theorem appendSectorFiber_natAdd_heq
+    (F : PhysicalSectorFactorization K)
+    {L R : ℕ} {k : Fin L → Fin F.sectorCount}
+    {t : Fin R → Fin F.sectorCount}
+    (x : F.SectorChainFiber k) (z : F.SectorChainFiber t) (i : Fin R) :
+    F.appendSectorFiber x z (Fin.natAdd L i) ≍ z i := by
+  simp only [appendSectorFiber, Fin.addCases_right]
+  exact cast_heq _ _
+
+private theorem appendSectorFiber_fst_castAdd_heq
+    (F : PhysicalSectorFactorization K)
+    {L R : ℕ} {k : Fin L → Fin F.sectorCount}
+    {t : Fin R → Fin F.sectorCount}
+    (x : F.SectorChainFiber k) (z : F.SectorChainFiber t)
+    {j : Fin (L + R)} (i : Fin L) (h : j = Fin.castAdd R i) :
+    (F.appendSectorFiber x z j).1 ≍ (x i).1 := by
+  refine (dependent_prod_fst_heq (F.appendSectorFiber x z) h).trans ?_
+  exact sectorIndex_fst_heq_of_heq F (by simp)
+    (F.appendSectorFiber_castAdd_heq x z i)
+
+private theorem appendSectorFiber_snd_castAdd_heq
+    (F : PhysicalSectorFactorization K)
+    {L R : ℕ} {k : Fin L → Fin F.sectorCount}
+    {t : Fin R → Fin F.sectorCount}
+    (x : F.SectorChainFiber k) (z : F.SectorChainFiber t)
+    {j : Fin (L + R)} (i : Fin L) (h : j = Fin.castAdd R i) :
+    (F.appendSectorFiber x z j).2 ≍ (x i).2 := by
+  refine (dependent_prod_snd_heq (F.appendSectorFiber x z) h).trans ?_
+  exact sectorIndex_snd_heq_of_heq F (by simp)
+    (F.appendSectorFiber_castAdd_heq x z i)
+
+private theorem appendSectorFiber_fst_natAdd_heq
+    (F : PhysicalSectorFactorization K)
+    {L R : ℕ} {k : Fin L → Fin F.sectorCount}
+    {t : Fin R → Fin F.sectorCount}
+    (x : F.SectorChainFiber k) (z : F.SectorChainFiber t)
+    {j : Fin (L + R)} (i : Fin R) (h : j = Fin.natAdd L i) :
+    (F.appendSectorFiber x z j).1 ≍ (z i).1 := by
+  refine (dependent_prod_fst_heq (F.appendSectorFiber x z) h).trans ?_
+  exact sectorIndex_fst_heq_of_heq F (by simp)
+    (F.appendSectorFiber_natAdd_heq x z i)
+
+private theorem appendSectorFiber_snd_natAdd_heq
+    (F : PhysicalSectorFactorization K)
+    {L R : ℕ} {k : Fin L → Fin F.sectorCount}
+    {t : Fin R → Fin F.sectorCount}
+    (x : F.SectorChainFiber k) (z : F.SectorChainFiber t)
+    {j : Fin (L + R)} (i : Fin R) (h : j = Fin.natAdd L i) :
+    (F.appendSectorFiber x z j).2 ≍ (z i).2 := by
+  refine (dependent_prod_snd_heq (F.appendSectorFiber x z) h).trans ?_
+  exact sectorIndex_snd_heq_of_heq F (by simp)
+    (F.appendSectorFiber_natAdd_heq x z i)
+
+private theorem fourthRegion_internal_neighboring_entry
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (t : Fin 3 → Fin F.sectorCount)
+    (x y : F.RetainedOpenEdgeIndex k)
+    (z : F.SectorChainFiber t) (i : Fin n) :
+    F.neighboringOperator
+        (Fin.append k t (Fin.castAdd 3 (Fin.castAdd 1 i)))
+        (Fin.append k t (Fin.castAdd 3 (Fin.castAdd 1 i) + 1))
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.castAdd 3 (Fin.castAdd 1 i))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.castAdd 3 (Fin.castAdd 1 i) + 1)).1)
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.castAdd 3 (Fin.castAdd 1 i))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.castAdd 3 (Fin.castAdd 1 i) + 1)).1) =
+      F.neighboringOperator
+        (k ((Fin.last n).succAbove i))
+        (k ((Fin.last n).succAbove i + 1)) (x.1 i) (y.1 i) := by
+  simp only [PhysicalSectorFactorization.neighboringOperator_apply]
+  apply Finset.sum_congr rfl
+  intro a ha
+  congr 1
+  · apply rightTensor_eq_of_heq F (by simp [fourthRegion_internal_index]) a
+    · refine (F.appendSectorFiber_snd_castAdd_heq _ _ (Fin.castAdd 1 i) rfl).trans ?_
+      refine (dependent_prod_snd_heq ((F.retainedOpenEdgeEquiv k).symm x)
+        (fourthRegion_retained_internal_index i)).trans ?_
+      exact heq_of_eq (congrArg Prod.fst
+        (F.retainedOpenEdgeEquiv_symm_internal_edge k x i))
+    · refine (F.appendSectorFiber_snd_castAdd_heq _ _ (Fin.castAdd 1 i) rfl).trans ?_
+      refine (dependent_prod_snd_heq ((F.retainedOpenEdgeEquiv k).symm y)
+        (fourthRegion_retained_internal_index i)).trans ?_
+      exact heq_of_eq (congrArg Prod.fst
+        (F.retainedOpenEdgeEquiv_symm_internal_edge k y i))
+  · apply leftTensor_eq_of_heq F (by simp [fourthRegion_internal_succ_index]) a
+    · refine (F.appendSectorFiber_fst_castAdd_heq _ _
+        ((Fin.last n).succAbove i + 1) (fourthRegion_internal_succ_index i)).trans ?_
+      exact heq_of_eq (congrArg Prod.snd
+        (F.retainedOpenEdgeEquiv_symm_internal_edge k x i))
+    · refine (F.appendSectorFiber_fst_castAdd_heq _ _
+        ((Fin.last n).succAbove i + 1) (fourthRegion_internal_succ_index i)).trans ?_
+      exact heq_of_eq (congrArg Prod.snd
+        (F.retainedOpenEdgeEquiv_symm_internal_edge k y i))
+
+private theorem fourthRegion_last_to_suffix_neighboring_entry
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (t : Fin 3 → Fin F.sectorCount)
+    (x y : F.RetainedOpenEdgeIndex k)
+    (z : F.SectorChainFiber t) :
+    F.neighboringOperator
+        (Fin.append k t (Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1))))
+        (Fin.append k t (Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1)) + 1))
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1)))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1)) + 1)).1)
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1)))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.castAdd 3 (Fin.natAdd n (0 : Fin 1)) + 1)).1) =
+      F.neighboringOperator (k (Fin.last n)) (t 0)
+        (x.2.1, (z 0).1) (y.2.1, (z 0).1) := by
+  simp only [PhysicalSectorFactorization.neighboringOperator_apply]
+  apply Finset.sum_congr rfl
+  intro a ha
+  congr 1
+  · apply rightTensor_eq_of_heq F (by simp [fourthRegion_last_retained_index]) a
+    · refine (F.appendSectorFiber_snd_castAdd_heq _ _ (Fin.last n)
+        fourthRegion_last_retained_index).trans ?_
+      exact heq_of_eq (F.retainedOpenEdgeEquiv_symm_last_right k x)
+    · refine (F.appendSectorFiber_snd_castAdd_heq _ _ (Fin.last n)
+        fourthRegion_last_retained_index).trans ?_
+      exact heq_of_eq (F.retainedOpenEdgeEquiv_symm_last_right k y)
+  · apply leftTensor_eq_of_heq F (by simp [fourthRegion_first_suffix_index]) a
+    · exact F.appendSectorFiber_fst_natAdd_heq _ _ 0 fourthRegion_first_suffix_index
+    · exact F.appendSectorFiber_fst_natAdd_heq _ _ 0 fourthRegion_first_suffix_index
+
+private theorem fourthRegion_suffix_zero_neighboring_entry
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (t : Fin 3 → Fin F.sectorCount)
+    (x y : F.RetainedOpenEdgeIndex k)
+    (z : F.SectorChainFiber t) :
+    F.neighboringOperator
+        (Fin.append k t (Fin.natAdd (n + 1) (0 : Fin 3)))
+        (Fin.append k t (Fin.natAdd (n + 1) (0 : Fin 3) + 1))
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.natAdd (n + 1) (0 : Fin 3))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.natAdd (n + 1) (0 : Fin 3) + 1)).1)
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.natAdd (n + 1) (0 : Fin 3))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.natAdd (n + 1) (0 : Fin 3) + 1)).1) =
+      F.neighboringOperator (t 0) (t 1)
+        ((z 0).2, (z 1).1) ((z 0).2, (z 1).1) := by
+  simp only [PhysicalSectorFactorization.neighboringOperator_apply]
+  apply Finset.sum_congr rfl
+  intro a ha
+  congr 1
+  · apply rightTensor_eq_of_heq F (by simp) a <;>
+      exact F.appendSectorFiber_snd_natAdd_heq _ _ 0 rfl
+  · apply leftTensor_eq_of_heq F (by simp [fourthRegion_suffix_zero_succ]) a <;>
+      exact F.appendSectorFiber_fst_natAdd_heq _ _ 1 fourthRegion_suffix_zero_succ
+
+private theorem fourthRegion_suffix_one_neighboring_entry
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (t : Fin 3 → Fin F.sectorCount)
+    (x y : F.RetainedOpenEdgeIndex k)
+    (z : F.SectorChainFiber t) :
+    F.neighboringOperator
+        (Fin.append k t (Fin.natAdd (n + 1) (1 : Fin 3)))
+        (Fin.append k t (Fin.natAdd (n + 1) (1 : Fin 3) + 1))
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.natAdd (n + 1) (1 : Fin 3))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.natAdd (n + 1) (1 : Fin 3) + 1)).1)
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.natAdd (n + 1) (1 : Fin 3))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.natAdd (n + 1) (1 : Fin 3) + 1)).1) =
+      F.neighboringOperator (t 1) (t 2)
+        ((z 1).2, (z 2).1) ((z 1).2, (z 2).1) := by
+  simp only [PhysicalSectorFactorization.neighboringOperator_apply]
+  apply Finset.sum_congr rfl
+  intro a ha
+  congr 1
+  · apply rightTensor_eq_of_heq F (by simp) a <;>
+      exact F.appendSectorFiber_snd_natAdd_heq _ _ 1 rfl
+  · apply leftTensor_eq_of_heq F (by simp [fourthRegion_suffix_one_succ]) a <;>
+      exact F.appendSectorFiber_fst_natAdd_heq _ _ 2 fourthRegion_suffix_one_succ
+
+private theorem fourthRegion_suffix_two_neighboring_entry
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (t : Fin 3 → Fin F.sectorCount)
+    (x y : F.RetainedOpenEdgeIndex k)
+    (z : F.SectorChainFiber t) :
+    F.neighboringOperator
+        (Fin.append k t (Fin.natAdd (n + 1) (2 : Fin 3)))
+        (Fin.append k t (Fin.natAdd (n + 1) (2 : Fin 3) + 1))
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.natAdd (n + 1) (2 : Fin 3))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z
+            (Fin.natAdd (n + 1) (2 : Fin 3) + 1)).1)
+        ((F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.natAdd (n + 1) (2 : Fin 3))).2,
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z
+            (Fin.natAdd (n + 1) (2 : Fin 3) + 1)).1) =
+      F.neighboringOperator (t 2) (k (Fin.last n + 1))
+        ((z 2).2, x.2.2) ((z 2).2, y.2.2) := by
+  simp only [PhysicalSectorFactorization.neighboringOperator_apply]
+  apply Finset.sum_congr rfl
+  intro a ha
+  congr 1
+  · apply rightTensor_eq_of_heq F (by simp) a <;>
+      exact F.appendSectorFiber_snd_natAdd_heq _ _ 2 rfl
+  · apply leftTensor_eq_of_heq F (by simp [fourthRegion_suffix_two_succ]) a
+    · refine (F.appendSectorFiber_fst_castAdd_heq _ _ (Fin.last n + 1)
+        fourthRegion_suffix_two_succ).trans ?_
+      exact heq_of_eq (F.retainedOpenEdgeEquiv_symm_first_left k x)
+    · refine (F.appendSectorFiber_fst_castAdd_heq _ _ (Fin.last n + 1)
+        fourthRegion_suffix_two_succ).trans ?_
+      exact heq_of_eq (F.retainedOpenEdgeEquiv_symm_first_left k y)
+
+/-- Trace the last three site fibers of a fixed retained sector block of the
+cyclic neighboring product, summing over all three discarded sector labels.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The suffix sum is later restricted
+to cyclic-active sector labels, producing the restricted two-step
+coefficient. See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def threeSuffixSectorContraction
+    (F : PhysicalSectorFactorization K) {L : ℕ}
+    (k : Fin L → Fin F.sectorCount) :
+    Matrix (F.SectorChainFiber k) (F.SectorChainFiber k) ℂ :=
+  fun x y ↦
+    ∑ t : Fin 3 → Fin F.sectorCount,
+      ∑ z : F.SectorChainFiber t,
+        F.cyclicNeighboringProduct (Fin.append k t)
+          (F.appendSectorFiber x z) (F.appendSectorFiber y z)
+
+private theorem sum_threeSuffixFiber_cyclicNeighboringProduct
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (t : Fin 3 → Fin F.sectorCount)
+    (x y : F.RetainedOpenEdgeIndex k) :
+    (∑ z : F.SectorChainFiber t,
+        F.cyclicNeighboringProduct (Fin.append k t)
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z)) =
+      F.retainedBulkProduct k x.1 y.1 *
+        (Matrix.partialTraceRight
+            (F.neighboringOperator (k (Fin.last n)) (t 0)) ⊗ₖ
+          Matrix.partialTraceLeft
+            (F.neighboringOperator (t 2) (k (Fin.last n + 1))))
+          x.2 y.2 *
+        (F.neighboringOperator (t 0) (t 1)).trace *
+        (F.neighboringOperator (t 1) (t 2)).trace := by
+  classical
+  calc
+    _ = ∑ z : F.SectorIndex (t 0) ×
+          (F.SectorIndex (t 1) × F.SectorIndex (t 2)),
+        F.cyclicNeighboringProduct (Fin.append k t)
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x)
+            ((F.threeSectorFiberEquiv t).symm z))
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y)
+            ((F.threeSectorFiberEquiv t).symm z)) := by
+      apply Fintype.sum_equiv (F.threeSectorFiberEquiv t)
+      intro z
+      rw [Equiv.symm_apply_apply]
+    _ = _ := by
+      simp only [Fintype.sum_prod_type, cyclicNeighboringProduct]
+      simp_rw [Fin.prod_univ_add]
+      simp_rw [Fin.prod_univ_one, Fin.prod_univ_three]
+      simp only [retainedBulkProduct, Matrix.kroneckerMap_apply,
+        Matrix.partialTraceRight_apply, Matrix.partialTraceLeft_apply,
+        Matrix.trace, Matrix.diag_apply]
+      simp_rw [fourthRegion_internal_neighboring_entry,
+        fourthRegion_last_to_suffix_neighboring_entry,
+        fourthRegion_suffix_zero_neighboring_entry,
+        fourthRegion_suffix_one_neighboring_entry,
+        fourthRegion_suffix_two_neighboring_entry]
+      simp only [
+        threeSectorFiberEquiv_symm_apply_zero,
+        threeSectorFiberEquiv_symm_apply_one,
+        threeSectorFiberEquiv_symm_apply_two]
+      simp only [Fintype.sum_prod_type]
+      simp_rw [Finset.mul_sum, Finset.sum_mul]
+      have sum_permute
+          (g : Fin (F.leftDim (t 0)) → Fin (F.rightDim (t 0)) →
+            Fin (F.leftDim (t 1)) → Fin (F.rightDim (t 1)) →
+            Fin (F.leftDim (t 2)) → Fin (F.rightDim (t 2)) → ℂ) :
+          (∑ a, ∑ b, ∑ c, ∑ d, ∑ e, ∑ f, g a b c d e f) =
+            ∑ d, ∑ e, ∑ b, ∑ c, ∑ f, ∑ a, g a b c d e f := by
+        calc
+          _ = ∑ a, ∑ b, ∑ d, ∑ c, ∑ e, ∑ f, g a b c d e f := by
+            congr 1 with a
+            congr 1 with b
+            rw [Finset.sum_comm]
+          _ = ∑ a, ∑ d, ∑ b, ∑ c, ∑ e, ∑ f, g a b c d e f := by
+            congr 1 with a
+            rw [Finset.sum_comm]
+          _ = ∑ d, ∑ a, ∑ b, ∑ c, ∑ e, ∑ f, g a b c d e f :=
+            Finset.sum_comm
+          _ = ∑ d, ∑ a, ∑ b, ∑ e, ∑ c, ∑ f, g a b c d e f := by
+            congr 1 with d
+            congr 1 with a
+            congr 1 with b
+            rw [Finset.sum_comm]
+          _ = ∑ d, ∑ a, ∑ e, ∑ b, ∑ c, ∑ f, g a b c d e f := by
+            congr 1 with d
+            congr 1 with a
+            rw [Finset.sum_comm]
+          _ = ∑ d, ∑ e, ∑ a, ∑ b, ∑ c, ∑ f, g a b c d e f := by
+            congr 1 with d
+            rw [Finset.sum_comm]
+          _ = ∑ d, ∑ e, ∑ b, ∑ a, ∑ c, ∑ f, g a b c d e f := by
+            congr 1 with d
+            congr 1 with e
+            rw [Finset.sum_comm]
+          _ = ∑ d, ∑ e, ∑ b, ∑ c, ∑ a, ∑ f, g a b c d e f := by
+            congr 1 with d
+            congr 1 with e
+            congr 1 with b
+            rw [Finset.sum_comm]
+          _ = _ := by
+            congr 1 with d
+            congr 1 with e
+            congr 1 with b
+            congr 1 with c
+            rw [Finset.sum_comm]
+      rw [sum_permute]
+      apply Finset.sum_congr rfl
+      intro d hd
+      apply Finset.sum_congr rfl
+      intro e he
+      apply Finset.sum_congr rfl
+      intro b hb
+      apply Finset.sum_congr rfl
+      intro c hc
+      apply Finset.sum_congr rfl
+      intro f hf
+      simp_rw [Finset.mul_sum, Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro a ha
+      ring
+
+
+/-- A retained sector word is cyclic-active when every one of its sectors
+lies on a positive-length directed cycle.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The source sum is represented on
+the sectors occurring in nonzero cyclic products. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def IsCyclicActiveRetainedWord
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount) : Prop :=
+  ∀ i, F.IsCyclicActiveSector (k i)
+
+/-- Regard a cyclic-active retained word as a word in the cyclic-active
+subtype.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This word belongs to the restricted
+sector set used in the fourth-region formula. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def cyclicActiveRetainedWord
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    {k : Fin (n + 1) → Fin F.sectorCount}
+    (hk : F.IsCyclicActiveRetainedWord k) :
+    Fin (n + 1) → F.CyclicActiveSector :=
+  fun i ↦ ⟨k i, (F.cyclicActiveWeight_ne_zero_iff (k i)).2 (hk i)⟩
+
+
+
+/-- In complete physical-sector coordinates, the marginal obtained by
+discarding three suffix sites is the direct sum of the corresponding
+three-suffix contractions of the cyclic neighboring products.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The direct sum is subsequently
+reduced to retained cyclic-active sector words. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_reducedBlockState_add_three_eq_threeSuffixSectorContraction
+    (F : PhysicalSectorFactorization K) (L : ℕ) :
+    Matrix.reindex (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateTensor.reducedBlockState (L + 3) L (by omega)) =
+      ((Matrix.trace (mpo F.sectorCoordinateTensor (L + 3)))⁻¹ : ℂ) •
+        Matrix.blockDiagonal' (fun k ↦ F.threeSuffixSectorContraction k) := by
+  classical
+  letI : NeZero (L + 3) := ⟨by omega⟩
+  have hblock :
+      F.sectorCoordinateTensor.reducedBlockState (L + 3) L (by omega) =
+        blockReducedState (Fintype.card (SectorSiteIndex F)) L 3
+          (F.sectorCoordinateTensor.normalizedMPO (L + 3)) := by
+    rw [MPOTensor.reducedBlockState]
+    simpa only [blockReindexEquiv] using
+      blockReducedState_submatrix_finCongr
+        (show L + 3 = L + (L + 3 - L) by omega)
+        (F.sectorCoordinateTensor.normalizedMPO (L + 3))
+  rw [hblock]
+  ext s t
+  obtain ⟨k, x⟩ := s
+  obtain ⟨h, y⟩ := t
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    blockReducedState, Matrix.partialTraceRight_apply,
+    normalizedMPO, Matrix.smul_apply, smul_eq_mul]
+  rw [← Finset.mul_sum]
+  congr 1
+  simp only [blockSplitEquiv_symm_apply]
+  change (∑ i : Fin 3 → Fin (Fintype.card (SectorSiteIndex F)),
+      mpo F.sectorCoordinateTensor (L + 3)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩) i)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩) i)) = _
+  have hconfig
+      (p : Fin L → Fin F.sectorCount) (u : F.SectorChainFiber p)
+      (q : Fin 3 → Fin F.sectorCount) (z : F.SectorChainFiber q) :
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv 3).symm ⟨q, z⟩) =
+        (F.sectorCoordinateChainEquiv (L + 3)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ := by
+    funext i
+    refine Fin.addCases (motive := fun i' : Fin (L + 3) ↦
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv 3).symm ⟨q, z⟩) i' =
+        (F.sectorCoordinateChainEquiv (L + 3)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ i')
+      (fun j ↦ ?_) (fun j ↦ ?_) i
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+  calc
+    _ = ∑ s : F.SectorChainIndex 3,
+        mpo F.sectorCoordinateTensor (L + 3)
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩)
+            ((F.sectorCoordinateChainEquiv 3).symm s))
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩)
+            ((F.sectorCoordinateChainEquiv 3).symm s)) := by
+      apply Fintype.sum_equiv (F.sectorCoordinateChainEquiv 3)
+      intro i
+      rw [Equiv.symm_apply_apply]
+    _ = _ := by
+      rw [Fintype.sum_sigma]
+      by_cases hkh : k = h
+      · subst h
+        rw [Matrix.blockDiagonal'_apply_eq]
+        simp only [threeSuffixSectorContraction]
+        apply Finset.sum_congr rfl
+        intro q _
+        apply Finset.sum_congr rfl
+        intro z _
+        rw [hconfig k x q z, hconfig k y q z]
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + 3))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append k q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_eq] using hentry
+      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+        apply Finset.sum_eq_zero
+        intro q _
+        apply Finset.sum_eq_zero
+        intro z _
+        rw [hconfig k x q z, hconfig h y q z]
+        have happend_ne : Fin.append k q ≠ Fin.append h q := by
+          intro heq
+          apply hkh
+          funext i
+          have hi := congrFun heq (Fin.castAdd 3 i)
+          simpa using hi
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + 3))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append h q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_ne _ _ _ happend_ne] using hentry
+
+/-- Source ZCL marginal replacement is preserved by the physical coordinate
+isometry defining the sector-coordinate tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This replacement supplies the
+extra marginal step used before restricting the sector sum. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem sectorCoordinateTensor_reducedBlockState_add_three_eq_succ_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) (hZCL : K.IsSourceZCL) (L : ℕ) :
+    F.sectorCoordinateTensor.reducedBlockState (L + 3) L (by omega) =
+      F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) := by
+  rw [F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  rw [reducedBlockState_changePhysicalBasis_of_isometry
+    F.physicalCoordinateMatrix F.physicalCoordinateMatrix_isometry]
+  rw [reducedBlockState_changePhysicalBasis_of_isometry
+    F.physicalCoordinateMatrix F.physicalCoordinateMatrix_isometry]
+  rw [K.reducedBlockState_add_three_eq_succ_of_isSourceZCL hZCL]
+
+/-- The three-site sector word determined by three cyclic-active sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The word ranges over the restricted
+cyclic-active sector set. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def activeThreeSectorWord
+    (F : PhysicalSectorFactorization K)
+    (q r h : F.CyclicActiveSector) : Fin 3 → Fin F.sectorCount :=
+  Fin.cons q <| Fin.cons r <| Fin.cons h finZeroElim
+
+/-- The first entry of the cyclic-active three-site word.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+first sector of the restricted suffix. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem activeThreeSectorWord_zero
+    (F : PhysicalSectorFactorization K) (q r h : F.CyclicActiveSector) :
+    F.activeThreeSectorWord q r h 0 = q := by
+  rfl
+
+/-- The second entry of the cyclic-active three-site word.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+middle sector of the restricted suffix. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem activeThreeSectorWord_one
+    (F : PhysicalSectorFactorization K) (q r h : F.CyclicActiveSector) :
+    F.activeThreeSectorWord q r h 1 = r := by
+  rfl
+
+/-- The third entry of the cyclic-active three-site word.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+last sector of the restricted suffix. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem activeThreeSectorWord_two
+    (F : PhysicalSectorFactorization K) (q r h : F.CyclicActiveSector) :
+    F.activeThreeSectorWord q r h 2 = h := by
+  rfl
+
+/-- Contract a three-site suffix whose sector labels are cyclic-active.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The contraction is evaluated only
+on the sectors surviving cyclic-active deletion. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem sum_threeSuffixFiber_cyclicNeighboringProduct_active
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (q r h : F.CyclicActiveSector)
+    (x y : F.RetainedOpenEdgeIndex k) :
+    (∑ z : F.SectorChainFiber (F.activeThreeSectorWord q r h),
+        F.cyclicNeighboringProduct
+          (Fin.append k (F.activeThreeSectorWord q r h))
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
+          (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z)) =
+      F.retainedBulkProduct k x.1 y.1 *
+        (Matrix.partialTraceRight
+            (F.neighboringOperator (k (Fin.last n)) q) ⊗ₖ
+          Matrix.partialTraceLeft
+            (F.neighboringOperator h (k (Fin.last n + 1))))
+          x.2 y.2 *
+        (F.neighboringOperator q r).trace *
+        (F.neighboringOperator r h).trace := by
+  calc
+    _ = F.retainedBulkProduct k x.1 y.1 *
+          (Matrix.partialTraceRight
+              (F.neighboringOperator (k (Fin.last n))
+                (F.activeThreeSectorWord q r h 0)) ⊗ₖ
+            Matrix.partialTraceLeft
+              (F.neighboringOperator (F.activeThreeSectorWord q r h 2)
+                (k (Fin.last n + 1)))) x.2 y.2 *
+          (F.neighboringOperator (F.activeThreeSectorWord q r h 0)
+            (F.activeThreeSectorWord q r h 1)).trace *
+          (F.neighboringOperator (F.activeThreeSectorWord q r h 1)
+            (F.activeThreeSectorWord q r h 2)).trace :=
+      F.sum_threeSuffixFiber_cyclicNeighboringProduct k
+        (F.activeThreeSectorWord q r h) x y
+    _ = _ := by
+      simp only [Matrix.kroneckerMap_apply]
+      rw [F.partialTraceRight_neighboringOperator_eq_of_right
+          (k (Fin.last n)) (F.activeThreeSectorWord q r h 0) q
+          (F.activeThreeSectorWord_zero q r h) x.2.1 y.2.1,
+        F.partialTraceLeft_neighboringOperator_eq_of_left
+          (F.activeThreeSectorWord q r h 2) h (k (Fin.last n + 1))
+          (F.activeThreeSectorWord_two q r h) x.2.2 y.2.2,
+        F.neighboringOperator_trace_eq_of_eq
+          (F.activeThreeSectorWord q r h 0) q
+          (F.activeThreeSectorWord q r h 1) r
+          (F.activeThreeSectorWord_zero q r h)
+          (F.activeThreeSectorWord_one q r h),
+        F.neighboringOperator_trace_eq_of_eq
+          (F.activeThreeSectorWord q r h 1) r
+          (F.activeThreeSectorWord q r h 2) h
+          (F.activeThreeSectorWord_one q r h)
+          (F.activeThreeSectorWord_two q r h)]
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
@@ -1,0 +1,359 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveFourthRegionContraction
+
+/-!
+# The cyclic-active fourth-region formula
+
+This file identifies every retained-sector block of the fourth-region marginal
+and derives the normalized block-diagonal formula from source zero correlation
+length.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+private theorem sum_eq_sum_subtype_of_eq_zero
+    {α M : Type*} [Fintype α] [AddCommMonoid M]
+    (p : α → Prop) [DecidablePred p] (f : α → M)
+    (hzero : ∀ x, ¬p x → f x = 0) :
+    ∑ x, f x = ∑ x : {x // p x}, f x := by
+  classical
+  calc
+    _ = ∑ x ∈ Finset.univ.filter p, f x := by
+      symm
+      apply Finset.sum_subset (Finset.filter_subset _ _)
+      intro x hx hxnot
+      rw [hzero x]
+      simpa using hxnot
+    _ = _ := Finset.sum_subtype _ (by simp) f
+
+private def cyclicActiveWordSubtypeEquiv
+    (F : PhysicalSectorFactorization K) (N : ℕ) :
+    {t : Fin N → Fin F.sectorCount // ∀ i, F.IsCyclicActiveSector (t i)} ≃
+      (Fin N → F.CyclicActiveSector) where
+  toFun t i :=
+    ⟨t.1 i, (F.cyclicActiveWeight_ne_zero_iff (t.1 i)).2 (t.2 i)⟩
+  invFun q :=
+    ⟨fun i ↦ q i, fun i ↦ (F.cyclicActiveWeight_ne_zero_iff (q i)).1 (q i).2⟩
+  left_inv t := by
+    ext i
+    rfl
+  right_inv q := by
+    funext i
+    rfl
+
+/-- The separated fourth-region block in a fixed retained sector word.  It
+vanishes unless every retained sector is cyclic-active.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The boundary factors come from
+$(\lambda^{-1}T_C)^2$ on the cyclic-active support.  Sectors outside that
+support contribute zero rather than being identified with cyclic-active
+sectors.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveFourthRegionBlock
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (lam : ℝ) (a b : F.CyclicActiveSector → ℝ)
+    (k : Fin (n + 1) → Fin F.sectorCount) :
+    Matrix (F.RetainedOpenEdgeIndex k) (F.RetainedOpenEdgeIndex k) ℂ := by
+  classical
+  exact if hk : F.IsCyclicActiveRetainedWord k then
+      let kC := F.cyclicActiveRetainedWord hk
+      ((lam : ℂ) ^ 2) •
+        (F.retainedBulkProduct k ⊗ₖ
+          F.cyclicActiveSeparatedBoundary a b
+            (kC (Fin.last n + 1)) (kC (Fin.last n)))
+    else 0
+
+/-- A retained word outside cyclic-active support has zero three-suffix
+contraction.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The vanishing follows from
+deleting sector words outside positive-length cyclic support.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem threeSuffixSectorContraction_eq_zero_of_not_isCyclicActiveRetainedWord
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (hk : ¬ F.IsCyclicActiveRetainedWord k) :
+    F.threeSuffixSectorContraction k = 0 := by
+  classical
+  ext x y
+  simp only [threeSuffixSectorContraction, Matrix.zero_apply]
+  apply Finset.sum_eq_zero
+  intro t _
+  apply Finset.sum_eq_zero
+  intro z _
+  have happend :
+      ¬ ∀ i, F.IsCyclicActiveSector ((Fin.append k t) i) := by
+    intro hall
+    apply hk
+    intro i
+    simpa using hall (Fin.castAdd 3 i)
+  rw [F.cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector
+    (Fin.append k t) happend]
+  rfl
+
+/-- On a cyclic-active retained word, tracing the three suffix sites gives the
+retained bulk product tensored with the unnormalized two-step boundary
+contraction.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The coefficient is the square of
+the restricted cyclic-active trace matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveUnnormalized
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (hk : F.IsCyclicActiveRetainedWord k) :
+    Matrix.reindex (F.retainedOpenEdgeEquiv k) (F.retainedOpenEdgeEquiv k)
+        (F.threeSuffixSectorContraction k) =
+      F.retainedBulkProduct k ⊗ₖ
+        F.cyclicActiveUnnormalizedTwoStepBoundaryContraction
+          (F.cyclicActiveRetainedWord hk (Fin.last n + 1))
+          (F.cyclicActiveRetainedWord hk (Fin.last n)) := by
+  classical
+  ext x y
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, threeSuffixSectorContraction,
+    Matrix.kroneckerMap_apply]
+  have hrestrict :
+      (∑ t : Fin 3 → Fin F.sectorCount,
+          ∑ z : F.SectorChainFiber t,
+            F.cyclicNeighboringProduct (Fin.append k t)
+              (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
+              (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z)) =
+        ∑ t : {t : Fin 3 → Fin F.sectorCount //
+            ∀ i, F.IsCyclicActiveSector (t i)},
+          ∑ z : F.SectorChainFiber t.1,
+            F.cyclicNeighboringProduct (Fin.append k t.1)
+              (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
+              (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z) := by
+    apply sum_eq_sum_subtype_of_eq_zero
+    intro t ht
+    apply Finset.sum_eq_zero
+    intro z hz
+    have happend :
+        ¬∀ j, F.IsCyclicActiveSector ((Fin.append k t) j) := by
+      intro hall
+      apply ht
+      intro i
+      simpa using hall (Fin.natAdd (n + 1) i)
+    rw [F.cyclicNeighboringProduct_eq_zero_of_not_forall_isCyclicActiveSector
+      (Fin.append k t) happend]
+    rfl
+  rw [hrestrict]
+  calc
+    _ = ∑ q : Fin 3 → F.CyclicActiveSector,
+        ∑ z : F.SectorChainFiber (fun i ↦ (q i : Fin F.sectorCount)),
+          F.cyclicNeighboringProduct
+            (Fin.append k (fun i ↦ (q i : Fin F.sectorCount)))
+            (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
+            (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z) := by
+      apply Fintype.sum_equiv (cyclicActiveWordSubtypeEquiv F 3)
+      intro q
+      rfl
+    _ = ∑ qrh : F.CyclicActiveSector ×
+          (F.CyclicActiveSector × F.CyclicActiveSector),
+        ∑ z : F.SectorChainFiber
+            (fun i ↦ (((_root_.finThreeArrowEquiv F.CyclicActiveSector).symm qrh) i :
+              Fin F.sectorCount)),
+          F.cyclicNeighboringProduct
+            (Fin.append k (fun i ↦
+              (((_root_.finThreeArrowEquiv F.CyclicActiveSector).symm qrh) i :
+                Fin F.sectorCount)))
+            (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
+            (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z) := by
+      apply Fintype.sum_equiv (_root_.finThreeArrowEquiv F.CyclicActiveSector)
+      intro q
+      rw [Equiv.symm_apply_apply]
+    _ = ∑ q : F.CyclicActiveSector,
+          ∑ r : F.CyclicActiveSector,
+          ∑ h : F.CyclicActiveSector,
+          ∑ z : F.SectorChainFiber (F.activeThreeSectorWord q r h),
+            F.cyclicNeighboringProduct
+              (Fin.append k (F.activeThreeSectorWord q r h))
+              (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm x) z)
+              (F.appendSectorFiber ((F.retainedOpenEdgeEquiv k).symm y) z) := by
+      simp only [Fintype.sum_prod_type]
+      apply Finset.sum_congr rfl
+      intro q hq
+      apply Finset.sum_congr rfl
+      intro r hr
+      apply Finset.sum_congr rfl
+      intro h hh
+      have ht :
+          (fun i ↦ (((_root_.finThreeArrowEquiv F.CyclicActiveSector).symm
+            (q, r, h)) i : Fin F.sectorCount)) =
+            F.activeThreeSectorWord q r h := by
+        funext i
+        fin_cases i <;> rfl
+      rw [ht]
+    _ = _ := by
+      simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul,
+        cyclicActiveUnnormalizedTwoStepBoundaryContraction]
+      simp_rw [F.sum_threeSuffixFiber_cyclicNeighboringProduct_active]
+      simp only [Matrix.kroneckerMap_apply]
+      have sum_swap (g : F.CyclicActiveSector → F.CyclicActiveSector →
+          F.CyclicActiveSector → ℂ) :
+          (∑ q, ∑ r, ∑ h, g q r h) = ∑ q, ∑ h, ∑ r, g q r h := by
+        congr 1 with q
+        rw [Finset.sum_comm]
+      rw [sum_swap]
+      have factor_sum (A : ℂ)
+          (u v : F.CyclicActiveSector → ℂ) :
+          (∑ r, A * u r * v r) = A * ∑ r, u r * v r := by
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl
+        intro r hr
+        ring
+      simp_rw [factor_sum]
+      simp_rw [F.sum_cyclicActive_trace_mul_trace_eq_pow_two hpos]
+      simp only [cyclicActiveRetainedWord]
+      have distribute (B : ℂ) (R : F.CyclicActiveSector → ℂ)
+          (L C : F.CyclicActiveSector → F.CyclicActiveSector → ℂ) :
+          (∑ q, B * (R q * ∑ h, L q h * C q h)) =
+            B * ∑ q, ∑ h, C q h * (R q * L q h) := by
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl
+        intro q hq
+        rw [Finset.mul_sum]
+        congr 1
+        apply Finset.sum_congr rfl
+        intro h hh
+        ring
+      exact distribute _ _ _ _
+
+/-- Every retained sector block of the three-suffix contraction has the
+separated fourth-region form, with blocks outside cyclic-active support equal
+to zero.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The two boundary factors arise
+from the normalized square of the restricted trace matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveFourthRegionBlock
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (lam : ℝ) (hlam : 0 < lam)
+    (a b : F.CyclicActiveSector → ℝ)
+    (hab : (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2 =
+      Matrix.vecMulVec a b)
+    (k : Fin (n + 1) → Fin F.sectorCount) :
+    Matrix.reindex (F.retainedOpenEdgeEquiv k) (F.retainedOpenEdgeEquiv k)
+        (F.threeSuffixSectorContraction k) =
+      F.cyclicActiveFourthRegionBlock lam a b k := by
+  classical
+  by_cases hk : F.IsCyclicActiveRetainedWord k
+  · rw [F.reindex_threeSuffixSectorContraction_eq_cyclicActiveUnnormalized
+      hpos k hk]
+    rw [F.cyclicActiveUnnormalizedTwoStepBoundaryContraction_eq_smul
+      lam hlam, F.cyclicActiveTwoStepBoundaryContraction_eq_separated
+      lam a b hab]
+    ext x y
+    simp only [cyclicActiveFourthRegionBlock, dif_pos hk,
+      Matrix.kroneckerMap_apply, Matrix.smul_apply, smul_eq_mul]
+    ring
+  · rw [F.threeSuffixSectorContraction_eq_zero_of_not_isCyclicActiveRetainedWord
+      k hk]
+    ext x y
+    simp [cyclicActiveFourthRegionBlock, hk]
+
+/-- The marginal obtained by tracing three suffix sites is block diagonal in
+retained open-edge coordinates, and every cyclic-active block has separated
+left and right boundary factors.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The block formula uses the
+normalized square of the restricted cyclic-active trace matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_reducedBlockState_add_three_eq_cyclicActiveFourthRegionBlock
+    (F : PhysicalSectorFactorization K) (n : ℕ)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (lam : ℝ) (hlam : 0 < lam)
+    (a b : F.CyclicActiveSector → ℝ)
+    (hab : (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2 =
+      Matrix.vecMulVec a b) :
+    Matrix.reindex (F.retainedOpenEdgeChainEquiv n)
+        (F.retainedOpenEdgeChainEquiv n)
+        (F.sectorCoordinateTensor.reducedBlockState (n + 4) (n + 1) (by omega)) =
+      ((Matrix.trace (mpo F.sectorCoordinateTensor (n + 4)))⁻¹ : ℂ) •
+        Matrix.blockDiagonal'
+          (fun k ↦ F.cyclicActiveFourthRegionBlock lam a b k) := by
+  classical
+  have hraw :=
+    F.reindex_reducedBlockState_add_three_eq_threeSuffixSectorContraction (n + 1)
+  ext sx sy
+  obtain ⟨k, x⟩ := sx
+  obtain ⟨h, y⟩ := sy
+  have hentry := congrFun (congrFun hraw
+    ⟨k, (F.retainedOpenEdgeEquiv k).symm x⟩)
+    ⟨h, (F.retainedOpenEdgeEquiv h).symm y⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Matrix.smul_apply] at hentry ⊢
+  change _ = _ at hentry
+  change _ = _
+  by_cases hkh : k = h
+  · subst h
+    simp only [Matrix.blockDiagonal'_apply_eq] at hentry ⊢
+    rw [← F.reindex_threeSuffixSectorContraction_eq_cyclicActiveFourthRegionBlock
+      hpos lam hlam a b hab k]
+    exact hentry
+  · simp only [Matrix.blockDiagonal'_apply_ne _ _ _ hkh] at hentry ⊢
+    exact hentry
+
+/-- Source ZCL supplies positive normalized factors for the exact
+fourth-region marginal with one discarded site.  The coefficient comes from
+the three-site representative of the same marginal.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** One additional source-ZCL
+marginal replacement is used, so the separated coefficient is the normalized
+square of the restricted cyclic-active trace matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem exists_cyclicActiveFourthRegion_formula_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hK : K.IsInjective)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) (n : ℕ) :
+    ∃ lam : ℝ, 0 < lam ∧
+      ∃ a b : F.CyclicActiveSector → ℝ,
+        (∀ q, 0 < a q) ∧ (∀ h, 0 < b h) ∧ a ⬝ᵥ b = 1 ∧
+          Matrix.reindex (F.retainedOpenEdgeChainEquiv n)
+              (F.retainedOpenEdgeChainEquiv n)
+              (F.sectorCoordinateTensor.reducedBlockState
+                (n + 2) (n + 1) (by omega)) =
+            ((Matrix.trace (mpo F.sectorCoordinateTensor (n + 4)))⁻¹ : ℂ) •
+              Matrix.blockDiagonal'
+                (fun k ↦ F.cyclicActiveFourthRegionBlock lam a b k) := by
+  obtain ⟨lam, hlam, a, b, ha, hb, hab, hdot⟩ :=
+    F.exists_normalized_cyclicActiveSectorTraceMatrix_pos_factorization_of_isSourceZCL
+      hK hpos hZCL
+  refine ⟨lam, hlam, a, b, ha, hb, hdot, ?_⟩
+  rw [← F.sectorCoordinateTensor_reducedBlockState_add_three_eq_succ_of_isSourceZCL
+    hZCL (n + 1)]
+  exact F.reindex_reducedBlockState_add_three_eq_cyclicActiveFourthRegionBlock
+    n hpos lam hlam a b hab
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveMarkov.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkov.lean
@@ -1,0 +1,6 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveMarkovDecomposition

--- a/TNLean/MPS/MPDO/CyclicActiveMarkovDecomposition.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkovDecomposition.lean
@@ -1,0 +1,467 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveCutRegrouping
+
+/-!
+# Hayashi decomposition in cyclic-active coordinates
+
+This file assembles the normalized path factors and sector probabilities into
+a Hayashi quantum-Markov decomposition at every one-site cut.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+universe u
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Reassociate the cut length `A + 1 + C` with the retained-chain length
+`A + C + 1`.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This reassociation is used for the
+retained cyclic-active chain after the additional marginal replacement. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveCutLengthEquiv
+    (F : PhysicalSectorFactorization K) (A C : ℕ) :
+    (Fin (A + C + 1) → Fin (Fintype.card F.SectorSiteIndex)) ≃
+      (Fin (A + 1 + C) → Fin (Fintype.card F.SectorSiteIndex)) :=
+  Equiv.arrowCongr (finCongr (show A + C + 1 = A + 1 + C by omega))
+    (Equiv.refl _)
+
+/-- The complete coordinate equivalence for the Hayashi decomposition at a
+one-site cut: reassociate the length, pass to retained open-edge coordinates,
+and split at the middle sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The retained coordinates use only
+positive-length cyclic sectors.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveHayashiCutEquiv
+    (F : PhysicalSectorFactorization K) (A C : ℕ) :
+    (Fin (A + 1 + C) → Fin (Fintype.card F.SectorSiteIndex)) ≃
+      Σ j : Fin F.sectorCount,
+        (Fin (Fintype.card F.SectorSiteIndex ^ A) × Fin (F.leftDim j)) ×
+          (Fin (F.rightDim j) × Fin (Fintype.card F.SectorSiteIndex ^ C)) :=
+  (F.cyclicActiveCutLengthEquiv A C).symm.trans <|
+    (F.retainedOpenEdgeChainEquiv (A + C)).trans
+      (F.retainedCutEquiv A C)
+
+/-- In direct physical coordinates, the complete cut equivalence is the
+tripartite split followed by the middle-site sector decomposition.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617. -/
+private theorem cyclicActiveHayashiCutEquiv_eq_direct
+    (F : PhysicalSectorFactorization K) (A C : ℕ) :
+    F.cyclicActiveHayashiCutEquiv A C =
+      (tripartiteSplitEquiv
+        (Fintype.card F.SectorSiteIndex) A 1 C).trans
+        ((Equiv.prodCongr (Equiv.refl _)
+          (Equiv.prodCongr F.sectorCoordinateMiddleEquiv
+            (Equiv.refl _))).trans
+          (HayashiMarkov.sigmaAssoc
+            (dA := Fintype.card F.SectorSiteIndex ^ A)
+            (dC := Fintype.card F.SectorSiteIndex ^ C)
+            F.leftDim F.rightDim).symm) := by
+  apply Equiv.ext
+  intro z
+  unfold cyclicActiveHayashiCutEquiv cyclicActiveCutLengthEquiv
+    retainedOpenEdgeChainEquiv retainedCutEquiv
+  simp only [Equiv.trans_apply, Equiv.prodCongr_apply, Equiv.coe_refl]
+  rw [Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+  have hcast := (F.cyclicActiveCutLengthEquiv A C).apply_symm_apply z
+  exact congrArg
+    (fun w ↦ (HayashiMarkov.sigmaAssoc F.leftDim F.rightDim).symm <|
+      Prod.map id (Prod.map (⇑F.sectorCoordinateMiddleEquiv) id)
+        (tripartiteSplitEquiv
+          (Fintype.card F.SectorSiteIndex) A 1 C w)) hcast
+
+/-- The normalized fourth-region marginal is block diagonal at an arbitrary
+one-site cut, with its blocks expressed as normalized left and right states.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The coefficient is restricted to
+positive-length cyclic sectors and uses one additional marginal replacement.
+See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+private theorem reindex_reducedBlockState_eq_cyclicActiveCut
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) (A C : ℕ) (lam : ℝ)
+    (a b : F.CyclicActiveSector → ℝ)
+    (ha : ∀ q, 0 < a q) (hb : ∀ h, 0 < b h)
+    (hfour :
+      Matrix.reindex (F.retainedOpenEdgeChainEquiv (A + C))
+          (F.retainedOpenEdgeChainEquiv (A + C))
+          (F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + C + 1) (by omega)) =
+        ((Matrix.trace
+          (mpo F.sectorCoordinateTensor (A + C + 4)))⁻¹ : ℂ) •
+          Matrix.blockDiagonal' (fun k ↦
+            F.cyclicActiveFourthRegionBlock lam a b k)) :
+    Matrix.reindex (F.cyclicActiveHayashiCutEquiv A C)
+        (F.cyclicActiveHayashiCutEquiv A C)
+        (F.sectorCoordinateTensor.reducedBlockState
+          (A + C + 2) (A + 1 + C) (by omega)) =
+      Matrix.blockDiagonal' (fun j : Fin F.sectorCount ↦
+        (F.cyclicActiveCutProbability A C lam a b j : ℂ) •
+          (F.cyclicActiveLeftCutState A lam b j ⊗ₖ
+            F.cyclicActiveRightCutState C a j)) := by
+  classical
+  let L := fun j : Fin F.sectorCount ↦ F.cyclicActiveLeftCutRaw A lam b j
+  let R := fun j : Fin F.sectorCount ↦ F.cyclicActiveRightCutRaw C a j
+  have hL (j : Fin F.sectorCount) : (L j).PosSemidef :=
+    F.cyclicActiveLeftCutRaw_posSemidef A hpos lam b (fun h ↦ (hb h).le) j
+  have hR (j : Fin F.sectorCount) : (R j).PosSemidef :=
+    F.cyclicActiveRightCutRaw_posSemidef C hpos a (fun q ↦ (ha q).le) j
+  let xL := F.cyclicActiveLeftCutFallback A
+  let xR := F.cyclicActiveRightCutFallback C
+  let ρL := F.cyclicActiveLeftCutState A lam b
+  let ρR := F.cyclicActiveRightCutState C a
+  let t := F.cyclicActiveCutNormalization A C
+  have htC : 0 < Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)) :=
+    F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL hpos hZCL (by omega)
+  have htEq : Matrix.trace (mpo F.sectorCoordinateTensor (A + C + 4)) =
+      (t : ℂ) := by
+    apply Complex.ext
+    · rfl
+    · simpa [t, cyclicActiveCutNormalization] using
+        (Complex.lt_def.mp htC).2.symm
+  let p := F.cyclicActiveCutProbability A C lam a b
+  have hcast :
+      Matrix.reindex (F.cyclicActiveCutLengthEquiv A C).symm
+          (F.cyclicActiveCutLengthEquiv A C).symm
+          (F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + 1 + C) (by omega)) =
+        F.sectorCoordinateTensor.reducedBlockState
+          (A + C + 2) (A + C + 1) (by omega) := by
+    ext W W'
+    have h := reducedBlockState_cast F.sectorCoordinateTensor
+      (N := A + C + 2) (k := A + C + 1) (k' := A + 1 + C)
+      (h := show A + 1 + C = A + C + 1 by omega)
+      (hk := by omega) W W'
+    change F.sectorCoordinateTensor.reducedBlockState
+        (A + C + 2) (A + 1 + C) _
+          (F.cyclicActiveCutLengthEquiv A C W)
+          (F.cyclicActiveCutLengthEquiv A C W') = _
+    have hW : F.cyclicActiveCutLengthEquiv A C W = W ∘ Fin.cast
+        (show A + 1 + C = A + C + 1 by omega) := by
+      funext i
+      rfl
+    have hW' : F.cyclicActiveCutLengthEquiv A C W' = W' ∘ Fin.cast
+        (show A + 1 + C = A + C + 1 by omega) := by
+      funext i
+      rfl
+    rw [hW, hW']
+    exact h.symm
+  have hcut :
+      Matrix.reindex (F.cyclicActiveHayashiCutEquiv A C)
+          (F.cyclicActiveHayashiCutEquiv A C)
+          (F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + 1 + C) (by omega)) =
+        ((Matrix.trace (mpo F.sectorCoordinateTensor (A + C + 4)))⁻¹ : ℂ) •
+          Matrix.blockDiagonal' (fun j : Fin F.sectorCount ↦ L j ⊗ₖ R j) := by
+    have hecomp :
+        Matrix.reindex (F.cyclicActiveHayashiCutEquiv A C)
+            (F.cyclicActiveHayashiCutEquiv A C)
+            (F.sectorCoordinateTensor.reducedBlockState
+              (A + C + 2) (A + 1 + C) (by omega)) =
+          Matrix.reindex
+            ((F.retainedOpenEdgeChainEquiv (A + C)).trans
+              (F.retainedCutEquiv A C))
+            ((F.retainedOpenEdgeChainEquiv (A + C)).trans
+              (F.retainedCutEquiv A C))
+            (Matrix.reindex (F.cyclicActiveCutLengthEquiv A C).symm
+              (F.cyclicActiveCutLengthEquiv A C).symm
+              (F.sectorCoordinateTensor.reducedBlockState
+                (A + C + 2) (A + 1 + C) (by omega))) := by
+      ext x y
+      simp only [cyclicActiveHayashiCutEquiv, Matrix.reindex_apply]
+      rfl
+    rw [hecomp, hcast]
+    have hraw := F.reindex_cyclicActiveFourthRegionBlock_eq_cutRaw
+      A C lam a b
+    ext x y
+    have hf := congrFun (congrFun hfour
+      ((F.retainedCutEquiv A C).symm x))
+      ((F.retainedCutEquiv A C).symm y)
+    calc
+      _ = ((Matrix.trace
+          (mpo F.sectorCoordinateTensor (A + C + 4)))⁻¹ : ℂ) *
+          Matrix.reindex (F.retainedCutEquiv A C)
+            (F.retainedCutEquiv A C)
+            (Matrix.blockDiagonal' (fun k ↦
+              F.cyclicActiveFourthRegionBlock lam a b k)) x y := by
+        simpa [Matrix.reindex_apply] using hf
+      _ = _ := by
+        rw [hraw]
+        rfl
+  rw [hcut]
+  ext ⟨j, x⟩ ⟨j', y⟩
+  change ((Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)))⁻¹ : ℂ) *
+        Matrix.blockDiagonal' (fun j : Fin F.sectorCount ↦ L j ⊗ₖ R j)
+          ⟨j, x⟩ ⟨j', y⟩ =
+      Matrix.blockDiagonal' (fun j : Fin F.sectorCount ↦
+        (p j : ℂ) • (ρL j ⊗ₖ ρR j)) ⟨j, x⟩ ⟨j', y⟩
+  by_cases hj : j = j'
+  · subst j'
+    rw [Matrix.blockDiagonal'_apply_eq, Matrix.blockDiagonal'_apply_eq]
+    have hkr := Matrix.kronecker_eq_trace_re_mul_normalized
+      (xL j) (xR j) (hL j) (hR j)
+    rw [hkr]
+    dsimp only [ρL, ρR, p, t, L, R, xL, xR,
+      cyclicActiveLeftCutState, cyclicActiveRightCutState,
+      cyclicActiveCutProbability]
+    rw [Matrix.smul_apply, Matrix.smul_apply, smul_eq_mul, smul_eq_mul]
+    rw [htEq]
+    rw [← Complex.ofReal_inv]
+    push_cast
+    rw [show F.cyclicActiveCutNormalization A C = t by rfl]
+    ring
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hj,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hj]
+    exact mul_zero _
+
+/-- Each normalized left cut block is a density matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617. -/
+private theorem cyclicActiveLeftCutState_isDensity
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (A : ℕ) (lam : ℝ) (b : F.CyclicActiveSector → ℝ)
+    (hb : ∀ h, 0 < b h) (j : Fin F.sectorCount) :
+    (F.cyclicActiveLeftCutState A lam b j).PosSemidef ∧
+      (F.cyclicActiveLeftCutState A lam b j).trace = 1 := by
+  have hL := F.cyclicActiveLeftCutRaw_posSemidef
+    A hpos lam b (fun h ↦ (hb h).le) j
+  exact ⟨Matrix.normalizePosSemidef_posSemidef
+      (F.cyclicActiveLeftCutFallback A j) hL,
+    Matrix.normalizePosSemidef_trace
+      (F.cyclicActiveLeftCutFallback A j) hL⟩
+
+/-- Each normalized right cut block is a density matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617. -/
+private theorem cyclicActiveRightCutState_isDensity
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (C : ℕ) (a : F.CyclicActiveSector → ℝ)
+    (ha : ∀ q, 0 < a q) (j : Fin F.sectorCount) :
+    (F.cyclicActiveRightCutState C a j).PosSemidef ∧
+      (F.cyclicActiveRightCutState C a j).trace = 1 := by
+  have hR := F.cyclicActiveRightCutRaw_posSemidef
+    C hpos a (fun q ↦ (ha q).le) j
+  exact ⟨Matrix.normalizePosSemidef_posSemidef
+      (F.cyclicActiveRightCutFallback C j) hR,
+    Matrix.normalizePosSemidef_trace
+      (F.cyclicActiveRightCutFallback C j) hR⟩
+
+/-- The cyclic-active cut coefficients are nonnegative.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617. -/
+private theorem cyclicActiveCutProbability_nonneg
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) (A C : ℕ) (lam : ℝ)
+    (a b : F.CyclicActiveSector → ℝ)
+    (ha : ∀ q, 0 < a q) (hb : ∀ h, 0 < b h)
+    (j : Fin F.sectorCount) :
+    0 ≤ F.cyclicActiveCutProbability A C lam a b j := by
+  have htC : 0 < Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)) :=
+    F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL hpos hZCL (by omega)
+  have ht : 0 < F.cyclicActiveCutNormalization A C := by
+    simpa [cyclicActiveCutNormalization] using (Complex.lt_def.mp htC).1
+  have hL := F.cyclicActiveLeftCutRaw_posSemidef
+    A hpos lam b (fun h ↦ (hb h).le) j
+  have hR := F.cyclicActiveRightCutRaw_posSemidef
+    C hpos a (fun q ↦ (ha q).le) j
+  exact mul_nonneg
+    (mul_nonneg (inv_nonneg.mpr ht.le)
+      (Complex.nonneg_iff.mp hL.trace_nonneg).1)
+    (Complex.nonneg_iff.mp hR.trace_nonneg).1
+
+/-- The cyclic-active cut coefficients have total mass one.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** The normalization is the trace of
+the fourth-region marginal before the final restriction.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+private theorem sum_cyclicActiveCutProbability_eq_one
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) (A C : ℕ) (lam : ℝ)
+    (a b : F.CyclicActiveSector → ℝ)
+    (ha : ∀ q, 0 < a q) (hb : ∀ h, 0 < b h)
+    (hnormalized :
+      Matrix.reindex (F.cyclicActiveHayashiCutEquiv A C)
+          (F.cyclicActiveHayashiCutEquiv A C)
+          (F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + 1 + C) (by omega)) =
+        Matrix.blockDiagonal' (fun j : Fin F.sectorCount ↦
+          (F.cyclicActiveCutProbability A C lam a b j : ℂ) •
+            (F.cyclicActiveLeftCutState A lam b j ⊗ₖ
+              F.cyclicActiveRightCutState C a j))) :
+    ∑ j : Fin F.sectorCount,
+      F.cyclicActiveCutProbability A C lam a b j = 1 := by
+  have htraceShort : Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 2)) ≠ 0 := by
+    have hposShort := F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL
+      hpos hZCL (N := A + C + 2) (by omega)
+    exact ne_of_gt hposShort
+  have hstateTrace : Matrix.trace
+      (F.sectorCoordinateTensor.reducedBlockState
+        (A + C + 2) (A + 1 + C) (by omega)) = 1 :=
+    reducedBlockState_trace F.sectorCoordinateTensor
+      (A + C + 2) (A + 1 + C) (by omega) htraceShort
+  have htr := congrArg Matrix.trace hnormalized
+  rw [Matrix.trace_reindex, hstateTrace, Matrix.trace_blockDiagonal'] at htr
+  simp_rw [Matrix.trace_smul, Matrix.trace_kronecker,
+    (F.cyclicActiveLeftCutState_isDensity hpos A lam b hb _).2,
+    (F.cyclicActiveRightCutState_isDensity hpos C a ha _).2,
+    mul_one] at htr
+  have hpR := congrArg Complex.re htr.symm
+  simpa using hpR
+
+/-- After the direct middle-site sector decomposition, the cyclic-active cut
+block matrix is the Hayashi block state.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the sector-coordinate
+statement; transport to the original physical basis lies outside this
+sector-coordinate result.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+private theorem cyclicActiveCut_transported_state_eq
+    (F : PhysicalSectorFactorization K) (A C : ℕ) (lam : ℝ)
+    (a b : F.CyclicActiveSector → ℝ)
+    (hnormalized :
+      Matrix.reindex (F.cyclicActiveHayashiCutEquiv A C)
+          (F.cyclicActiveHayashiCutEquiv A C)
+          (F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + 1 + C) (by omega)) =
+        Matrix.blockDiagonal' (fun j : Fin F.sectorCount ↦
+          (F.cyclicActiveCutProbability A C lam a b j : ℂ) •
+            (F.cyclicActiveLeftCutState A lam b j ⊗ₖ
+              F.cyclicActiveRightCutState C a j))) :
+    Matrix.reindex
+        (HayashiMarkov.abcEquiv F.sectorCoordinateMiddleEquiv)
+        (HayashiMarkov.abcEquiv F.sectorCoordinateMiddleEquiv)
+        ((F.sectorCoordinateTensor.reducedBlockState
+          (A + C + 2) (A + 1 + C) (by omega)).submatrix
+            (tripartiteSplitEquiv
+              (Fintype.card F.SectorSiteIndex) A 1 C).symm
+            (tripartiteSplitEquiv
+              (Fintype.card F.SectorSiteIndex) A 1 C).symm) =
+      HayashiMarkov.blockState F.leftDim F.rightDim
+        (F.cyclicActiveCutProbability A C lam a b)
+        (F.cyclicActiveLeftCutState A lam b)
+        (F.cyclicActiveRightCutState C a) := by
+  have hassoc := congrArg
+    (Matrix.reindex
+      (HayashiMarkov.sigmaAssoc
+        (dA := Fintype.card F.SectorSiteIndex ^ A)
+        (dC := Fintype.card F.SectorSiteIndex ^ C)
+        F.leftDim F.rightDim)
+      (HayashiMarkov.sigmaAssoc
+        (dA := Fintype.card F.SectorSiteIndex ^ A)
+        (dC := Fintype.card F.SectorSiteIndex ^ C)
+        F.leftDim F.rightDim)) hnormalized
+  have heq :
+      (⇑(F.cyclicActiveHayashiCutEquiv A C).symm ∘
+        ⇑(HayashiMarkov.sigmaAssoc
+          (dA := Fintype.card F.SectorSiteIndex ^ A)
+          (dC := Fintype.card F.SectorSiteIndex ^ C)
+          F.leftDim F.rightDim).symm) =
+        (⇑(tripartiteSplitEquiv
+          (Fintype.card F.SectorSiteIndex) A 1 C).symm ∘
+          Prod.map id
+            (Prod.map (⇑F.sectorCoordinateMiddleEquiv.symm) id)) := by
+    have heDirect := F.cyclicActiveHayashiCutEquiv_eq_direct A C
+    rw [heDirect]
+    rfl
+  ext x y
+  have hxy := congrFun (congrFun hassoc x) y
+  have hx := congrFun heq x
+  have hy := congrFun heq y
+  simp only [Function.comp_apply] at hx hy
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply] at hxy
+  rw [hx, hy] at hxy
+  simpa [HayashiMarkov.blockState, HayashiMarkov.abcEquiv] using hxy
+
+/-- Source zero correlation length gives an explicit quantum-Markov
+decomposition at every one-site cut of the fourth-region marginal.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The separating coefficient is the
+normalized square of the trace matrix restricted to positive-length cyclic
+sectors, and it is obtained after one additional marginal replacement.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hK : K.IsInjective)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) (A C : ℕ) :
+    let ρ_ABC :=
+      (F.sectorCoordinateTensor.reducedBlockState
+        (A + C + 2) (A + 1 + C) (by omega)).submatrix
+          (tripartiteSplitEquiv
+            (Fintype.card F.SectorSiteIndex) A 1 C).symm
+          (tripartiteSplitEquiv
+            (Fintype.card F.SectorSiteIndex) A 1 C).symm
+    Nonempty (HayashiMarkovDecomposition ρ_ABC) := by
+  classical
+  dsimp only
+  obtain ⟨lam, _, a, b, ha, hb, _, hfour⟩ :=
+    F.exists_cyclicActiveFourthRegion_formula_of_isSourceZCL
+      hK hpos hZCL (A + C)
+  have hnormalized :=
+    F.reindex_reducedBlockState_eq_cyclicActiveCut
+      hpos hZCL A C lam a b ha hb hfour
+  have hp_sum :=
+    F.sum_cyclicActiveCutProbability_eq_one
+      hpos hZCL A C lam a b ha hb hnormalized
+  refine ⟨{
+    m := F.sectorCount
+    dL := F.leftDim
+    dR := F.rightDim
+    decompB := F.sectorCoordinateMiddleEquiv
+    U_B := 1
+    p := F.cyclicActiveCutProbability A C lam a b
+    hp_nonneg := F.cyclicActiveCutProbability_nonneg
+      hpos hZCL A C lam a b ha hb
+    hp_sum := hp_sum
+    ρ_left := F.cyclicActiveLeftCutState A lam b
+    ρ_right := F.cyclicActiveRightCutState C a
+    hρ_left_dm := F.cyclicActiveLeftCutState_isDensity hpos A lam b hb
+    hρ_right_dm := F.cyclicActiveRightCutState_isDensity hpos C a ha
+    h_state := ?_ }⟩
+  simpa [HayashiMarkov.liftB] using
+    F.cyclicActiveCut_transported_state_eq A C lam a b hnormalized
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveMarkovNormalization.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkovNormalization.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveFourthRegion
+
+/-!
+# Positive normalization for cyclic-active Markov blocks
+
+This file collects the finite Kronecker-positivity and trace-normalization
+lemmas used to turn the left and right cut factors into density matrices.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace Matrix
+
+/-- Normalize a positive semidefinite matrix by its trace, using the maximally
+mixed state when the trace vanishes.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This total normalization is applied
+to the positive path factors of the restricted two-step coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def normalizePosSemidef
+    {n : Type*} [Fintype n] (_x₀ : n) (M : Matrix n n ℂ) :
+    Matrix n n ℂ := by
+  classical
+  exact if M.trace.re = 0 then
+      ((Fintype.card n : ℂ)⁻¹) • (1 : Matrix n n ℂ)
+    else
+      (((M.trace.re)⁻¹ : ℝ) : ℂ) • M
+
+/-- Trace normalization preserves positive semidefiniteness.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This positivity statement is used
+for the normalized path factors of the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem normalizePosSemidef_posSemidef
+    {n : Type*} [Fintype n] (x₀ : n)
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    (normalizePosSemidef x₀ M).PosSemidef := by
+  classical
+  letI : Nonempty n := ⟨x₀⟩
+  rw [normalizePosSemidef]
+  split_ifs with htr
+  · apply Matrix.PosSemidef.one.smul
+      (a := ((Fintype.card n : ℂ)⁻¹))
+    exact inv_nonneg_of_nonneg (by positivity : (0 : ℂ) ≤ Fintype.card n)
+  · apply hM.smul
+    exact_mod_cast inv_nonneg.mpr (Complex.nonneg_iff.mp hM.trace_nonneg).1
+
+/-- The total normalization has trace one.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This trace identity is used for the
+normalized path factors of the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem normalizePosSemidef_trace
+    {n : Type*} [Fintype n] (x₀ : n)
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    (normalizePosSemidef x₀ M).trace = 1 := by
+  classical
+  letI : Nonempty n := ⟨x₀⟩
+  have htrace : M.trace = (M.trace.re : ℂ) := by
+    apply Complex.ext
+    · simp
+    · simpa using (Complex.nonneg_iff.mp hM.trace_nonneg).2.symm
+  rw [normalizePosSemidef]
+  split_ifs with htr
+  · rw [Matrix.trace_smul, Matrix.trace_one]
+    exact inv_mul_cancel₀ (by exact_mod_cast Fintype.card_ne_zero)
+  · rw [Matrix.trace_smul, htrace]
+    change ((M.trace.re⁻¹ : ℝ) : ℂ) * (M.trace.re : ℂ) = 1
+    exact_mod_cast inv_mul_cancel₀ htr
+
+/-- Multiplying the normalized matrix by the real part of the original trace
+recovers a positive semidefinite matrix.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity recovers the
+unnormalized path factors of the restricted decomposition. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem trace_re_smul_normalizePosSemidef
+    {n : Type*} [Fintype n] (x₀ : n)
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    (M.trace.re : ℂ) • normalizePosSemidef x₀ M = M := by
+  classical
+  letI : Nonempty n := ⟨x₀⟩
+  have htrace : M.trace = (M.trace.re : ℂ) := by
+    apply Complex.ext
+    · simp
+    · simpa using (Complex.nonneg_iff.mp hM.trace_nonneg).2.symm
+  rw [normalizePosSemidef]
+  split_ifs with htr
+  · have htrace0 : M.trace = 0 := by
+      rw [htrace, htr]
+      exact Complex.ofReal_zero
+    have hM0 : M = 0 := hM.trace_eq_zero_iff.mp htrace0
+    rw [hM0]
+    simp
+  · rw [smul_smul]
+    rw [← Complex.ofReal_mul]
+    rw [mul_inv_cancel₀ htr]
+    simp
+
+/-- A Kronecker product of positive semidefinite matrices separates into the
+product of their traces and their normalized factors.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity normalizes the two
+positive path factors obtained from the restricted coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem kronecker_eq_trace_re_mul_normalized
+    {m n : Type*} [Fintype m] [Fintype n] (x₀ : m) (y₀ : n)
+    {L : Matrix m m ℂ} {R : Matrix n n ℂ}
+    (hL : L.PosSemidef) (hR : R.PosSemidef) :
+    L ⊗ₖ R =
+      ((L.trace.re * R.trace.re : ℝ) : ℂ) •
+        (normalizePosSemidef x₀ L ⊗ₖ normalizePosSemidef y₀ R) := by
+  ext ⟨xL, xR⟩ ⟨yL, yR⟩
+  have hLe := congrFun (congrFun
+    (trace_re_smul_normalizePosSemidef x₀ hL) xL) yL
+  have hRe := congrFun (congrFun
+    (trace_re_smul_normalizePosSemidef y₀ hR) xR) yR
+  simp only [smul_apply] at hLe hRe
+  simp only [Matrix.kroneckerMap_apply, smul_apply]
+  rw [← hLe, ← hRe]
+  push_cast
+  ring
+
+end Matrix

--- a/TNLean/MPS/MPDO/CyclicActiveRetainedCoordinates.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveRetainedCoordinates.lean
@@ -1,0 +1,284 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveThreeBoundaryTrace
+import TNLean.MPS.MPDO.PhysicalSectorProductRealization
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+import TNLean.MPS.MPDO.SourceZCLMarginal
+
+/-!
+# Retained coordinates for cyclic-active fourth-region marginals
+
+This file develops the dependent open-edge coordinates for a retained
+physical-sector chain, the boundary identities, and the contraction over the
+three discarded sites.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The open-edge coordinates of a retained chain with `n + 1` sites.  The
+first component contains the first `n` neighboring edges; the second is the
+edge from the last retained site back to the first.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** These coordinates retain only the
+sector words used in the cyclic-active fourth-region formula. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+abbrev RetainedOpenEdgeIndex (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount) :=
+  ((j : Fin n) →
+      F.NeighborIndex
+        (k ((Fin.last n).succAbove j))
+        (k ((Fin.last n).succAbove j + 1))) ×
+    F.NeighborIndex (k (Fin.last n)) (k (Fin.last n + 1))
+
+/-- Regroup retained site factors into the first `n` neighboring edges and
+the remaining boundary edge.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identification is applied to
+the retained cyclic-active sector words. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def retainedOpenEdgeEquiv (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount) :
+    F.SectorChainFiber k ≃ F.RetainedOpenEdgeIndex k :=
+  (F.cyclicEdgeEquiv k).trans <|
+    ((Fin.insertNthEquiv
+      (fun i : Fin (n + 1) ↦ F.NeighborIndex (k i) (k (i + 1)))
+      (Fin.last n)).symm.trans (Equiv.prodComm _ _))
+
+/-- The cyclic-edge coordinate at an internal retained edge is the
+corresponding open-edge coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity is used after
+restricting to retained cyclic-active words. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem cyclicEdgeEquiv_retainedOpenEdgeEquiv_symm_internal
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (x : F.RetainedOpenEdgeIndex k) (i : Fin n) :
+    F.cyclicEdgeEquiv k ((F.retainedOpenEdgeEquiv k).symm x)
+        ((Fin.last n).succAbove i) = x.1 i := by
+  simp [retainedOpenEdgeEquiv]
+
+/-- The two site coordinates adjacent to an internal retained edge recover
+that open-edge coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This identity is used after
+restricting to retained cyclic-active words. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem retainedOpenEdgeEquiv_symm_internal_edge
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (x : F.RetainedOpenEdgeIndex k) (i : Fin n) :
+    (((F.retainedOpenEdgeEquiv k).symm x
+        ((Fin.last n).succAbove i)).2,
+      ((F.retainedOpenEdgeEquiv k).symm x
+        ((Fin.last n).succAbove i + 1)).1) = x.1 i := by
+  simpa only [cyclicEdgeEquiv_apply] using
+    F.cyclicEdgeEquiv_retainedOpenEdgeEquiv_symm_internal k x i
+
+/-- The final cyclic edge of a retained chain is its remaining open-edge
+boundary coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity is used for
+retained cyclic-active words. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem cyclicEdgeEquiv_retainedOpenEdgeEquiv_symm_last
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (x : F.RetainedOpenEdgeIndex k) :
+    F.cyclicEdgeEquiv k ((F.retainedOpenEdgeEquiv k).symm x) (Fin.last n) =
+      x.2 := by
+  simp [retainedOpenEdgeEquiv]
+
+/-- The right coordinate of the last retained site is the left component of
+the remaining boundary edge.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity is used for
+retained cyclic-active words. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem retainedOpenEdgeEquiv_symm_last_right
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (x : F.RetainedOpenEdgeIndex k) :
+    ((F.retainedOpenEdgeEquiv k).symm x (Fin.last n)).2 = x.2.1 := by
+  have h := F.cyclicEdgeEquiv_retainedOpenEdgeEquiv_symm_last k x
+  simpa only [cyclicEdgeEquiv_apply] using congrArg Prod.fst h
+
+/-- The left coordinate of the first retained site is the right component of
+the remaining boundary edge.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This endpoint identity is used for
+retained cyclic-active words. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem retainedOpenEdgeEquiv_symm_first_left
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount)
+    (x : F.RetainedOpenEdgeIndex k) :
+    ((F.retainedOpenEdgeEquiv k).symm x (Fin.last n + 1)).1 = x.2.2 := by
+  have h := F.cyclicEdgeEquiv_retainedOpenEdgeEquiv_symm_last k x
+  simpa only [cyclicEdgeEquiv_apply] using congrArg Prod.snd h
+
+/-- The complete retained physical coordinate change: first decompose every
+site into a physical sector, then regroup each fixed-sector fiber into open
+neighboring edges.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The change of coordinates is used
+on the sector words surviving the cyclic-active restriction. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def retainedOpenEdgeChainEquiv
+    (F : PhysicalSectorFactorization K) (n : ℕ) :
+    (Fin (n + 1) → Fin (Fintype.card (SectorSiteIndex F))) ≃
+      Σ k : Fin (n + 1) → Fin F.sectorCount, F.RetainedOpenEdgeIndex k :=
+  (F.sectorCoordinateChainEquiv (n + 1)).trans <|
+    Equiv.sigmaCongrRight fun k ↦ F.retainedOpenEdgeEquiv k
+
+/-- The product on the first `n` retained neighboring edges in open-edge
+coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1614--1617.
+
+**Local fix (cyclic-active restriction):** This is the unchanged interior
+product on a retained cyclic-active sector word. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def retainedBulkProduct
+    (F : PhysicalSectorFactorization K) {n : ℕ}
+    (k : Fin (n + 1) → Fin F.sectorCount) :
+    Matrix
+      ((j : Fin n) → F.NeighborIndex
+        (k ((Fin.last n).succAbove j))
+        (k ((Fin.last n).succAbove j + 1)))
+      ((j : Fin n) → F.NeighborIndex
+        (k ((Fin.last n).succAbove j))
+        (k ((Fin.last n).succAbove j + 1))) ℂ :=
+  fun x y ↦ ∏ j : Fin n,
+    F.neighboringOperator
+      (k ((Fin.last n).succAbove j))
+      (k ((Fin.last n).succAbove j + 1)) (x j) (y j)
+
+/-- Concatenate two fixed-sector fiber configurations along a concatenated
+sector word.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This identification separates the
+retained word from the three traced boundary sites. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def appendSectorFiber (F : PhysicalSectorFactorization K)
+    {L R : ℕ} {k : Fin L → Fin F.sectorCount}
+    {t : Fin R → Fin F.sectorCount}
+    (x : F.SectorChainFiber k) (z : F.SectorChainFiber t) :
+    F.SectorChainFiber (Fin.append k t) :=
+  fun i ↦ Fin.addCases
+    (motive := fun i ↦ F.SectorIndex ((Fin.append k t) i))
+    (fun j ↦ by simpa using x j) (fun j ↦ by simpa using z j) i
+
+/-- Separate the three entries of a dependent three-site sector fiber.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** These are the three boundary sites
+traced after the cyclic-active restriction. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+def threeSectorFiberEquiv (F : PhysicalSectorFactorization K)
+    (t : Fin 3 → Fin F.sectorCount) :
+    F.SectorChainFiber t ≃
+      F.SectorIndex (t 0) ×
+        (F.SectorIndex (t 1) × F.SectorIndex (t 2)) where
+  toFun z := (z 0, z 1, z 2)
+  invFun z := Fin.cons z.1 <| Fin.cons z.2.1 <|
+    Fin.cons z.2.2 finZeroElim
+  left_inv z := by
+    funext i
+    fin_cases i <;> rfl
+  right_inv z := rfl
+
+/-- The first coordinate of the inverse three-site identification is its
+first sector coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+first traced boundary site. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem threeSectorFiberEquiv_symm_apply_zero
+    (F : PhysicalSectorFactorization K)
+    (t : Fin 3 → Fin F.sectorCount)
+    (z : F.SectorIndex (t 0) ×
+      (F.SectorIndex (t 1) × F.SectorIndex (t 2))) :
+    (F.threeSectorFiberEquiv t).symm z 0 = z.1 := by
+  rfl
+
+/-- The second coordinate of the inverse three-site identification is its
+second sector coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+second traced boundary site. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem threeSectorFiberEquiv_symm_apply_one
+    (F : PhysicalSectorFactorization K)
+    (t : Fin 3 → Fin F.sectorCount)
+    (z : F.SectorIndex (t 0) ×
+      (F.SectorIndex (t 1) × F.SectorIndex (t 2))) :
+    (F.threeSectorFiberEquiv t).symm z 1 = z.2.1 := by
+  rfl
+
+/-- The third coordinate of the inverse three-site identification is its
+third sector coordinate.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This projection identifies the
+third traced boundary site. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+@[simp] theorem threeSectorFiberEquiv_symm_apply_two
+    (F : PhysicalSectorFactorization K)
+    (t : Fin 3 → Fin F.sectorCount)
+    (z : F.SectorIndex (t 0) ×
+      (F.SectorIndex (t 1) × F.SectorIndex (t 2))) :
+    (F.threeSectorFiberEquiv t).symm z 2 = z.2.2 := by
+  rfl
+
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -658,6 +658,42 @@ theorem normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
     |>.smul_of_pos (inv_pos.mpr hlam)
     |>.rank_pow_two_eq_one_of_pow_two_eq_pow_three hpow
 
+/-- Source ZCL gives a strictly positive rank-one factorization of the
+normalized two-step trace coefficient on cyclic-active sectors:
+\[
+  (\lambda^{-1}T_C)^2 = a b^{\mathsf T},
+  \qquad a_q>0,\quad b_h>0,\quad a\mathbin{\cdot}b=1.
+\]
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The factors belong to the square
+of the restricted trace matrix.  This does not identify that square with the
+one-step matrix printed at source line 1613 or with the unreduced Beigi
+matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem exists_normalized_cyclicActiveSectorTraceMatrix_pos_factorization_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) [NeZero D] (hK : K.IsInjective)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (hZCL : K.IsSourceZCL) :
+    ∃ lam : ℝ, 0 < lam ∧
+      ∃ a b : F.CyclicActiveSector → ℝ,
+        (∀ q, 0 < a q) ∧ (∀ h, 0 < b h) ∧
+          (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2 =
+            Matrix.vecMulVec a b ∧
+          a ⬝ᵥ b = 1 := by
+  obtain ⟨lam, hlam, hpow, _⟩ :=
+    F.cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
+      hK hpos hZCL
+  letI : Nonempty F.CyclicActiveSector := F.nonempty_cyclicActiveSector hK
+  have hprimitive :
+      Matrix.IsPrimitive (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) :=
+    (F.cyclicActiveSectorTraceMatrix_isPrimitive hK hpos)
+      |>.smul_of_pos (inv_pos.mpr hlam)
+  obtain ⟨a, b, ha, hb, hab, hdot⟩ :=
+    hprimitive.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three hpow
+  exact ⟨lam, hlam, a, b, ha, hb, hab, hdot⟩
+
 /-- Source ZCL makes the normalized two-step trace coefficient on the
 cyclic-active sectors rank one.
 

--- a/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
@@ -29,13 +29,14 @@ decomposition.
 * `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_trace_mul_trace_eq_pow_two`.
 * `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_normalized_trace_mul_trace_eq_pow_two`.
 * `MPOTensor.PhysicalSectorFactorization.sum_cyclicActive_partialTraceRight_threeSiteSectorClosure`.
+* `MPOTensor.PhysicalSectorFactorization.cyclicActiveTwoStepBoundaryContraction_eq_separated`.
 
 ## Reference
 
 * arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1606--1617.
 -/
 
-open scoped Matrix BigOperators ComplexOrder
+open scoped Matrix BigOperators ComplexOrder Kronecker
 
 namespace MPOTensor.PhysicalSectorFactorization
 
@@ -144,5 +145,147 @@ theorem sum_cyclicActive_partialTraceRight_threeSiteSectorClosure
   classical
   simp_rw [F.partialTraceRight_threeSiteSectorClosure]
   rw [← Finset.sum_smul, F.sum_cyclicActive_trace_mul_trace_eq_pow_two hpos q h]
+
+/-- The unnormalized fourth-region boundary contraction on cyclic-active
+sectors.  Its coefficient is the restricted two-step trace matrix
+$T_C^2$.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The coefficient is the square of
+the restricted trace matrix.  It is not replaced by the one-step matrix
+printed at source line 1613.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveUnnormalizedTwoStepBoundaryContraction
+    (F : PhysicalSectorFactorization K)
+    (kFirst kLast : F.CyclicActiveSector) :
+    Matrix (Fin (F.rightDim kLast) × Fin (F.leftDim kFirst))
+      (Fin (F.rightDim kLast) × Fin (F.leftDim kFirst)) ℂ :=
+  ∑ q, ∑ h,
+    ((F.cyclicActiveSectorTraceMatrix ^ 2) q h : ℂ) •
+      (Matrix.partialTraceRight (F.neighboringOperator kLast q) ⊗ₖ
+        Matrix.partialTraceLeft (F.neighboringOperator h kFirst))
+
+/-- The fourth-region boundary contraction with the normalized two-step
+coefficient on cyclic-active sectors.  The two outer neighboring operators
+retain one partial trace each.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The coefficient is the square of
+the restricted normalized trace matrix, not the one-step coefficient printed
+at source line 1613.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveTwoStepBoundaryContraction
+    (F : PhysicalSectorFactorization K) (lam : ℝ)
+    (kFirst kLast : F.CyclicActiveSector) :
+    Matrix (Fin (F.rightDim kLast) × Fin (F.leftDim kFirst))
+      (Fin (F.rightDim kLast) × Fin (F.leftDim kFirst)) ℂ :=
+  ∑ q, ∑ h,
+    (((lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2) q h : ℂ) •
+      (Matrix.partialTraceRight (F.neighboringOperator kLast q) ⊗ₖ
+        Matrix.partialTraceLeft (F.neighboringOperator h kFirst))
+
+/-- Rescaling the restricted trace matrix by a positive scalar extracts the
+corresponding square from the unnormalized fourth-region boundary.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This identity relates $T_C^2$ to
+$(\lambda^{-1}T_C)^2$ and does not identify either square with $T_C$.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveUnnormalizedTwoStepBoundaryContraction_eq_smul
+    (F : PhysicalSectorFactorization K) (lam : ℝ) (hlam : 0 < lam)
+    (kFirst kLast : F.CyclicActiveSector) :
+    F.cyclicActiveUnnormalizedTwoStepBoundaryContraction kFirst kLast =
+      ((lam : ℂ) ^ 2) •
+        F.cyclicActiveTwoStepBoundaryContraction lam kFirst kLast := by
+  classical
+  ext x y
+  simp only [cyclicActiveUnnormalizedTwoStepBoundaryContraction,
+    cyclicActiveTwoStepBoundaryContraction, Matrix.sum_apply,
+    Matrix.smul_apply, smul_eq_mul]
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro q _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro h _
+  have hcoeff :
+      (F.cyclicActiveSectorTraceMatrix ^ 2) q h =
+        lam ^ 2 *
+          ((lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2) q h := by
+    rw [show F.cyclicActiveSectorTraceMatrix ^ 2 =
+        F.cyclicActiveSectorTraceMatrix * F.cyclicActiveSectorTraceMatrix by
+          simp [pow_two],
+      show (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2 =
+        (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) *
+          (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) by simp [pow_two],
+      Matrix.mul_apply, Matrix.mul_apply]
+    simp only [Matrix.smul_apply, smul_eq_mul]
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro r _
+    field_simp [ne_of_gt hlam]
+  rw [hcoeff, Complex.ofReal_mul]
+  push_cast
+  ring
+
+/-- The separated boundary operators associated with positive factors of the
+normalized two-step cyclic-active coefficient.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The factors belong to
+$(\lambda^{-1}T_C)^2$ and do not factor the one-step matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def cyclicActiveSeparatedBoundary
+    (F : PhysicalSectorFactorization K)
+    (a b : F.CyclicActiveSector → ℝ)
+    (kFirst kLast : F.CyclicActiveSector) :
+    Matrix (Fin (F.rightDim kLast) × Fin (F.leftDim kFirst))
+      (Fin (F.rightDim kLast) × Fin (F.leftDim kFirst)) ℂ :=
+  (∑ q, ((a q : ℂ) •
+      Matrix.partialTraceRight (F.neighboringOperator kLast q))) ⊗ₖ
+    (∑ h, ((b h : ℂ) •
+      Matrix.partialTraceLeft (F.neighboringOperator h kFirst)))
+
+/-- A rank-one factorization of the normalized two-step coefficient separates
+the two surviving fourth-region boundaries.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** This theorem uses a factorization
+of $(\lambda^{-1}T_C)^2$.  It neither identifies $T_C$ with its square nor
+uses the unreduced sector matrix.  See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem cyclicActiveTwoStepBoundaryContraction_eq_separated
+    (F : PhysicalSectorFactorization K) (lam : ℝ)
+    (a b : F.CyclicActiveSector → ℝ)
+    (hab : (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) ^ 2 =
+      Matrix.vecMulVec a b)
+    (kFirst kLast : F.CyclicActiveSector) :
+    F.cyclicActiveTwoStepBoundaryContraction lam kFirst kLast =
+      F.cyclicActiveSeparatedBoundary a b kFirst kLast := by
+  classical
+  ext x y
+  simp only [cyclicActiveTwoStepBoundaryContraction,
+    cyclicActiveSeparatedBoundary, Matrix.sum_apply, Matrix.smul_apply,
+    Matrix.kroneckerMap_apply, smul_eq_mul]
+  rw [Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro q _
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro h _
+  have hentry := congrFun (congrFun hab q) h
+  simp only [Matrix.vecMulVec_apply] at hentry
+  rw [hentry, Complex.ofReal_mul]
+  ring
 
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -3,10 +3,13 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingBondEtaCyclicCore
+
+open scoped ComplexOrder Matrix
 
 /-!
 # Product realization from physical-sector coordinates
@@ -37,7 +40,7 @@ private noncomputable def etaSectorFinEquiv
   (Equiv.sigmaCongrRight fun _ ↦ Equiv.prodComm _ _).trans F.sectorFinEquiv.symm
 
 /-- The pointwise finite encoding of the transformed physical chain. -/
-private noncomputable def physicalConfigEquiv
+noncomputable def physicalConfigEquiv
     (F : PhysicalSectorFactorization K) (N : ℕ) :
     (Fin N → Fin d) ≃ (Fin N → Fin (Fintype.card (SectorSiteIndex F))) :=
   Equiv.arrowCongr (Equiv.refl (Fin N)) F.physicalFinEquiv
@@ -45,14 +48,24 @@ private noncomputable def physicalConfigEquiv
 /-- The finite sector-coordinate chain is the transformed physical chain,
 followed by the sector decomposition already used in the all-length chain
 decomposition. -/
-private noncomputable def sectorCoordinateChainEquiv
+noncomputable def sectorCoordinateChainEquiv
     (F : PhysicalSectorFactorization K) (N : ℕ) :
     (Fin N → Fin (Fintype.card (SectorSiteIndex F))) ≃ SectorChainIndex F N :=
   (F.physicalConfigEquiv N).symm.trans (F.sectorChainEquiv N)
 
+@[simp] theorem sectorCoordinateChainEquiv_symm_apply
+    (F : PhysicalSectorFactorization K) (N : ℕ)
+    (k : Fin N → Fin F.sectorCount) (x : F.SectorChainFiber k)
+    (n : Fin N) :
+    (F.sectorCoordinateChainEquiv N).symm ⟨k, x⟩ n =
+      F.sectorFinEquiv.symm ⟨k n, x n⟩ := by
+  simp [sectorCoordinateChainEquiv, physicalConfigEquiv,
+    physicalFinEquiv, sectorChainEquiv]
+  rfl
+
 /-- Encoding the transformed one-site physical indices by `Fin` commutes with
 forming the periodic MPO. -/
-private theorem mpo_sectorCoordinateTensor_eq_reindex_conjugatePhysical
+theorem mpo_sectorCoordinateTensor_eq_reindex_conjugatePhysical
     (F : PhysicalSectorFactorization K) (N : ℕ) :
     mpo F.sectorCoordinateTensor N =
       Matrix.reindex (F.physicalConfigEquiv N) (F.physicalConfigEquiv N)
@@ -67,7 +80,7 @@ all-length physical-sector chain decomposition.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
 1581--1588. -/
-private theorem reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+theorem reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
     (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N] :
     Matrix.reindex (F.sectorCoordinateChainEquiv N)
         (F.sectorCoordinateChainEquiv N) (mpo F.sectorCoordinateTensor N) =
@@ -83,7 +96,7 @@ private theorem reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
 1586--1589. -/
-private def cyclicEdgeEquiv (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+def cyclicEdgeEquiv (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
     (k : Fin N → Fin F.sectorCount) :
     ((n : Fin N) → SectorIndex F (k n)) ≃
       ((n : Fin N) → NeighborIndex F (k n) (k (n + 1))) :=
@@ -98,7 +111,7 @@ private def cyclicEdgeEquiv (F : PhysicalSectorFactorization K) {N : ℕ} [NeZer
               (finCongr (congrArg F.leftDim
                 (congrArg k (finRotate_apply n))))
 
-@[simp] private theorem cyclicEdgeEquiv_apply
+@[simp] theorem cyclicEdgeEquiv_apply
     (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
     (k : Fin N → Fin F.sectorCount)
     (x : (n : Fin N) → SectorIndex F (k n)) (n : Fin N) :
@@ -109,7 +122,7 @@ private def cyclicEdgeEquiv (F : PhysicalSectorFactorization K) {N : ℕ} [NeZer
     change ((x (finRotate N n)).1 : ℕ) = ((x (n + 1)).1 : ℕ)
     rw [finRotate_apply]
 
-@[simp] private theorem cyclicEdgeEquiv_symm_edge
+@[simp] theorem cyclicEdgeEquiv_symm_edge
     (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
     (k : Fin N → Fin F.sectorCount)
     (x : (n : Fin N) → NeighborIndex F (k n) (k (n + 1)))
@@ -236,6 +249,30 @@ private theorem reindex_mpo_sectorCoordinateTensor_sectorEdgeChainEquiv
       (F.reindex_cyclicNeighboringProduct_cyclicEdgeEquiv k) x) y
   · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh,
       Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+
+/-- Positivity of all neighbouring blocks makes every positive-length
+sector-coordinate periodic operator positive semidefinite. -/
+theorem mpo_sectorCoordinateTensor_posSemidef
+    (F : PhysicalSectorFactorization K) {N : ℕ} [NeZero N]
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef) :
+    (mpo F.sectorCoordinateTensor N).PosSemidef := by
+  classical
+  rw [← Matrix.posSemidef_submatrix_equiv
+    (M := mpo F.sectorCoordinateTensor N) (F.sectorEdgeChainEquiv N).symm]
+  change (Matrix.reindex (F.sectorEdgeChainEquiv N) (F.sectorEdgeChainEquiv N)
+    (mpo F.sectorCoordinateTensor N)).PosSemidef
+  rw [F.reindex_mpo_sectorCoordinateTensor_sectorEdgeChainEquiv]
+  apply Matrix.PosSemidef.blockDiagonal'
+  intro k
+  have heq :
+      (fun x y ↦ ∏ n : Fin N,
+        F.neighboringOperator (k n) (k (n + 1)) (x n) (y n)) =
+        Matrix.finKronecker (fun n : Fin N ↦
+          F.neighboringOperator (k n) (k (n + 1))) := by
+    ext x y
+    simp [Matrix.finKronecker_apply]
+  rw [heq]
+  exact Matrix.finKronecker_posSemidef _ fun n ↦ hpos _ _
 
 /-- The sector-coordinate bond indexed by two-site configurations. -/
 noncomputable def sectorBond (F : PhysicalSectorFactorization K) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -1109,19 +1109,68 @@
     two trace factors by $\lambda^{-1}$ gives the normalized identity.
 \end{proof}
 
-% Tracked in https://github.com/LionSR/TNLean/issues/4445.
-\begin{remark}[Open fourth-region coordinate identification]
-    \notready
-    Theorem~\ref{thm:mpdo_source_zcl_iterated_marginal_stability} gives the
-    required equality of normalized marginals, while
-    Theorem~\ref{thm:mpdo_cyclic_active_three_boundary_trace} and
-    Theorem~\ref{thm:mpdo_cyclic_active_deletion} give the local coefficient
-    and the deletion of vanishing cyclic summands.  It remains to
-    transport the marginal equality through the complete physical-sector
-    direct sum, retaining the two outer partial traces.  This must be done
-    without identifying $T_C$ with $T_C^2$ or $T_C$ with the unreduced Beigi
-    matrix.
-\end{remark}
+\begin{theorem}[Cyclic-active fourth-region factorization]
+    \label{thm:mpdo_cyclic_active_fourth_region_factorization}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      exists_cyclicActiveFourthRegion_formula_of_isSourceZCL}
+    \leanok
+    \uses{thm:mpdo_source_zcl_iterated_marginal_stability,
+      thm:mpdo_cyclic_active_three_boundary_trace,
+      thm:mpdo_cyclic_active_deletion}
+    Let $\mathcal K$ be injective and have source zero correlation length,
+    and suppose its neighboring operators are positive semidefinite.  There
+    are $\lambda>0$ and strictly positive functions $a,b$ on the
+    cyclic-active sectors, normalized by $a\mathbin{\boldsymbol\cdot}b=1$,
+    such that every fourth-region marginal is a direct sum over retained
+    sector words of the unchanged interior neighboring product tensored with
+    the separated left and right boundary factors determined by $a$ and $b$.
+
+    % Local fix (cyclic-active restriction): the coefficient being factorized
+    % is $(\lambda^{-1}T_C)^2$, obtained from one additional source-ZCL
+    % marginal replacement and three traced boundary sites. No equality
+    % between $T_C$ and $T_C^2$ is used. This correction is recorded in
+    % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    The additional marginal replacement leaves the retained interior product
+    unchanged and produces the two-step coefficient on the cyclic-active
+    sectors.  Its positive rank-one factorization separates the two surviving
+    boundary sums.  All sector words leaving the cyclic-active support vanish
+    before the two outer partial traces are evaluated.
+\end{proof}
+
+\begin{theorem}[Cyclic-active Markov decomposition at every cut]
+    \label{thm:mpdo_cyclic_active_markov_all_cuts}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL}
+    \leanok
+    \uses{thm:mpdo_cyclic_active_fourth_region_factorization,
+      def:hayashi_markov_decomposition}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_cyclic_active_fourth_region_factorization}, for
+    arbitrary $A,C\geq 0$, the fourth-region marginal on consecutive regions
+    of lengths $A$, $1$, and $C$ admits a Hayashi Markov decomposition.
+    The middle site decomposes as the direct sum of its left and right sector
+    factors.  Each block is the tensor product of normalized positive left
+    and right path states, and its probability is the product of their
+    unnormalized traces divided by the positive periodic normalization.
+
+    % Local fix (cyclic-active restriction): the block weights and path states
+    % arise from the factorization of $(\lambda^{-1}T_C)^2$ described above.
+    % This correction is recorded in
+    % docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    Separate the retained chain at the distinguished middle site.  The
+    retained neighboring factors split into the left and right path products,
+    while the two cyclic endpoint factors become their respective boundary
+    matrices.  Normalize each positive block by its trace, using an arbitrary
+    trace-one positive matrix when the block vanishes.  The trace-one identity
+    for the full marginal shows that the resulting nonnegative block weights
+    sum to one.
+\end{proof}
 
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -443,13 +443,22 @@ shows that an arbitrary linear coordinate contraction preserves the deletion
 of every vanishing cyclic summand.  Thus the proved rank-one statement
 supplies the separating boundary coefficient in this three-boundary form.
 
-What remains is to transport the normalized marginal equality through the
-complete physical-sector direct sum while retaining the two outer partial
-traces, extract an explicit outer-product factorization of the restricted
-$\widehat T^2$, and construct the direct-sum Markov decomposition.  The
-present conditional theorem
-\leanid{Matrix.eta_fourth_region_trace_formula} still assumes a factorization
-of the one-step matrix and cannot be discharged directly by the new theorem.
+The normalized marginal equality has now been transported through the complete
+physical-sector direct sum while retaining the two outer partial traces.  The
+result is
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+exists_cyclicActiveFourthRegion_formula_of_isSourceZCL}.  Separating the
+retained chain at an arbitrary distinguished site, normalizing the positive
+left and right path factors, and collecting their trace products gives
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL}.  Thus the
+Markov decomposition for arbitrary left and right lengths is available in the
+physical-sector coordinates.  Substitution of the admissible entropy-cut
+lengths and transport to the original basis remain part of issue \#4175.  The
+older conditional theorem
+\leanid{Matrix.eta_fourth_region_trace_formula} remains a coordinate model for
+a one-step rank-one coefficient; it is not used to identify $T_C$ with
+$T_C^2$.
 
 Consequently the source implication
 \[
@@ -458,8 +467,10 @@ Consequently the source implication
   \Longrightarrow \text{SAL}
 \]
 is not yet formalized and must not carry a \texttt{\string\leanok} marker.
-The formal development proves only the final entropy-theoretic step: quantum
-Markov decompositions at all admissible cuts imply SAL.\footnote{This is
+The remaining work is to transport the all-cut witnesses from the
+physical-sector coordinates back to the original physical basis and apply the
+final entropy-theoretic step: quantum Markov decompositions at all admissible
+cuts imply SAL.\footnote{This is
 \leanid{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}.} Its
 direct-sum hypothesis is a marked scope restriction, not an additional
 hypothesis on the source proposition.
@@ -501,9 +512,10 @@ direct-sum implication.  It neither derives the sectorwise SAL premise nor
 uses ZCL.
 
 \paragraph{Verdict.}
-Proposition~\emph{4to2} is classified as an open gap.  The proved implication
-from quantum Markov decompositions at every admissible cut to SAL is a scope
-restriction that isolates only its final entropy-theoretic step.  The later
+Proposition~\emph{4to2} is classified as a transport gap.  The fourth-region
+factorization and the Markov decomposition at every admissible cut have been
+proved in physical-sector coordinates.  Transport to the original physical
+basis and the final application of the all-cut entropy theorem remain.  The later
 orthogonal direct-sum implication is likewise formalized only as a
 scope-restricted theorem assuming sectorwise SAL.  It neither supplies that
 sectorwise premise nor proves the printed assertion that the GSNNCH form alone
@@ -514,14 +526,8 @@ implies SAL.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Transport the proved second ZCL marginal replacement through the
-complete physical-sector direct sum.  Retain the two outer partial traces and
-insert the proved middle coefficient $\widehat T^2$.  The general linear
-deletion theorem already shows that discarded cyclic summands remain zero;
-the missing step is the dependent direct-sum reindexing of the full marginal.
-\item Extract an explicit outer-product factorization of
-$\widehat T^2$, separate the two remaining boundary sector sums, and construct
-the quantum Markov decomposition at each admissible cut.
+\item Transport the proved physical-sector all-cut Markov witnesses through
+the physical isometry to the original physical basis.
 \item Apply the all-cut Markov theorem.  Only then may the source proposition
 receive a formal declaration and a \texttt{\string\leanok} marker.
 \end{enumerate}


### PR DESCRIPTION
This PR proves the cyclic-active physical-sector fourth-region marginal and
its Hayashi Markov decomposition at an arbitrary one-site cut.

## Mathematical content

- derives the normalized cyclic-active trace-matrix factorization and the
  restricted two-step boundary contraction;
- evaluates the three discarded sites and obtains the separated
  fourth-region marginal;
- regroups an arbitrary retained chain as $A \otimes B \otimes C$, proves
  positivity and trace normalization of the left and right factors, and
  constructs the resulting Hayashi block state;
- adds the public theorem
  `exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL`.

The source is CPSV16, Appendix C.2, Proposition `4to2`, lines 1606--1617.
The proof uses the cyclic-active restriction and one additional source-ZCL
marginal replacement as a local repair.  This deviation is recorded in
`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.  Transport to the
original physical basis and the admissible entropy-cut substitution remain
separate work tracked in #4175.

The corresponding blueprint statements and declaration links are updated.
No `sorry`, `axiom`, or kernel bypass is introduced.

## Verification

- `lake build`
- `lake build TNLean.MPS.MPDO`
- `leanblueprint web`
- `leanblueprint checkdecls`
- import-aggregator, oversized-file, numbered-file, forbidden-token,
  reader-facing prose, and line-length checks

Closes #4445.
Closes #4651.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics additions (no runtime, auth, or data paths); risk is mainly proof maintenance and build time from many new large Lean modules.
> 
> **Overview**
> Proves the **cyclic-active fourth-region marginal** and its **Hayashi quantum-Markov decomposition** at an arbitrary one-site cut under source zero correlation length (CPSV16 Appendix C.2, Proposition 4to2), using the documented cyclic-active restriction and one extra marginal replacement.
> 
> **Supporting algebra:** adds `Matrix.finKronecker_posSemidef`, generalizes Perron–Frobenius rank-one lemmas to arbitrary index types, and extracts strictly positive outer-product factors for primitive matrices with \(T^2=T^3\).
> 
> **New MPDO chain:** a stack of `CyclicActive*` modules builds retained/open-edge coordinates, contracts three discarded suffix sites, derives the separated fourth-region block formula from the normalized trace-matrix factorization \((\lambda^{-1}T_C)^2 = ab^{\mathsf T}\), regroups cuts as \(A\otimes B\otimes C\) with PSD left/right path factors and trace normalization, and assembles sector probabilities into `exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL`. `MPDO.lean` wires the new imports; `exists_normalized_cyclicActiveSectorTraceMatrix_pos_factorization_of_isSourceZCL` is added on the sector-restriction side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a988d8f5e1dd8345239ab7d89d692b38719442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->