### PR TITLE
feat(MPS/RFP): assemble direct-sum NNCPH ground spaces

### DIFF
--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -29,6 +29,7 @@ import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.RFP.KroneckerTransport
 import TNLean.MPS.RFP.NNCPHGroundSpace
+import TNLean.MPS.RFP.NNCPHGroundSpacesMultiSector
 import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 import TNLean.MPS.RFP.ResidualFamilyCommutation

--- a/TNLean/MPS/RFP/NNCPHGroundSpacesMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHGroundSpacesMultiSector.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.RFP.NNCPHMultiSector
+import TNLean.MPS.RFP.ResidualFamilyCommutation
+
+/-!
+# Nearest-neighbor commuting parent ground spaces for distinct RFP sectors
+
+This file proves the forward nearest-neighbor commuting parent-Hamiltonian
+ground-space condition for the multiplicity-one direct sum of the distinct
+basis sectors of a BNT canonical form.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Definition 3.9
+  and Theorem 3.10, lines 517--541.
+* Perez-Garcia--Verstraete--Wolf--Cirac, arXiv:quant-ph/0608197, Theorem 12,
+  proof lines 1430--1456.
+-/
+
+namespace MPSTensor
+
+namespace IsBNTCanonicalForm
+
+variable {d : ℕ} {P : SectorDecomposition d}
+
+/-- The multiplicity-one direct sum of the distinct sectors of an RFP BNT
+canonical form satisfies the all-chain nearest-neighbor commuting
+parent-Hamiltonian ground-space condition.
+
+Source: arXiv:1606.00608, Definition 3.9 and Theorem 3.10, lines 517--541.
+The ground-space spanning argument follows arXiv:quant-ph/0608197, Theorem 12,
+proof lines 1430--1456.
+
+**Scope restriction (multiplicity-one distinct sectors):** the theorem treats
+the direct sum of the BNT basis tensors, with one copy of each distinct sector.
+Repeated copies and arbitrary raw sector weights remain outside this statement;
+see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem rfp_implies_hasNNCPHGroundSpaces_basisDirectSum
+    (hCF : IsBNTCanonicalForm P)
+    (hRFP : IsTransferIdempotent (directSumTensor P.basis)) :
+    HasNNCPHGroundSpaces (directSumTensor P.basis) P.basis := by
+  rw [hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning]
+  exact
+    ⟨fun N hN ↦ hCF.rfp_implies_nncph_basisDirectSum hRFP N hN,
+      hCF.rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum hRFP⟩
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -518,6 +518,7 @@ specialization of that Appendix~D definition.
 \end{definition}
 
 \begin{remark}[Elementary consequences of the commuting definition]
+    \label{rem:nncph_ground_spaces_decomposition}
     \lean{MPSTensor.IsNNCPH.isCommutingParentHam}
     \lean{MPSTensor.IsNNCPHGroundState.isNNCPH}
     \lean{MPSTensor.IsNNCPHGroundState.isFrustrationFree}
@@ -1216,7 +1217,8 @@ specialization of that Appendix~D definition.
 
 \begin{proof}\leanok
     \uses{thm:rfp_multiplicity_one_bnt_nncph,
-        thm:rfp_multiplicity_one_bnt_parent_ground_spaces}
+        thm:rfp_multiplicity_one_bnt_parent_ground_spaces,
+        rem:nncph_ground_spaces_decomposition}
     Theorem~\ref{thm:rfp_multiplicity_one_bnt_nncph} gives pairwise
     commutation of the translated two-site interactions for every $N>2$.
     The parent-Hamiltonian construction gives the zero-energy equation.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1191,6 +1191,40 @@ specialization of that Appendix~D definition.
     identity completes the proof.
 \end{proof}
 
+\begin{theorem}[Forward NNCPH ground spaces for distinct multiplicity-one RFP sectors]%
+    \label{thm:rfp_multiplicity_one_bnt_has_nncph_ground_spaces}
+    \lean{MPSTensor.IsBNTCanonicalForm.rfp_implies_hasNNCPHGroundSpaces_basisDirectSum}
+    \leanok
+    \uses{def:sector_bnt_cf, def:mps_transfer_idempotence,
+        def:has_nncph_ground_spaces}
+    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
+    form, and let $B=\bigoplus_{j=1}^g A_j$ contain one copy of every basis
+    tensor. If $B$ is a renormalization fixed point, then for every $N>2$ its
+    translated two-site parent interactions commute and
+    \[
+        H_2^{(N)}(B)V^{(N)}(B)=0,
+        \qquad
+        \ker H_2^{(N)}(B)
+        =\spn\bigl\{V^{(N)}(A_j):j=1,\ldots,g\bigr\}.
+    \]
+    Hence $B$ satisfies the all-chain nearest-neighbor commuting
+    parent-Hamiltonian ground-space condition. This is the multiplicity-one
+    distinct-sector forward implication in
+    \cite[Definition~3.9 and Theorem~3.10]{Cirac2016MPDO_arXiv}. It does not
+    include repeated copies or arbitrary raw sector weights.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:rfp_multiplicity_one_bnt_nncph,
+        thm:rfp_multiplicity_one_bnt_parent_ground_spaces}
+    Theorem~\ref{thm:rfp_multiplicity_one_bnt_nncph} gives pairwise
+    commutation of the translated two-site interactions for every $N>2$.
+    The parent-Hamiltonian construction gives the zero-energy equation.
+    Theorem~\ref{thm:rfp_multiplicity_one_bnt_parent_ground_spaces} identifies
+    its kernel with the span of the periodic matrix product vectors of the
+    distinct sectors. These are the three clauses of the all-chain condition.
+\end{proof}
+
 \begin{theorem}[Cyclic trace expansion for a closed MPS chain]\label{thm:trace_eval_word_eq_sum_cyclic}
     \lean{MPSTensor.trace_evalWord_eq_sum_cyclic}
     \leanok

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -124,10 +124,15 @@ and transporting the resulting three-site relation around the periodic chain
 proves
 \leanid{MPSTensor.IsBNTCanonicalForm.}
 \hspace{0pt}\leanid{rfp_implies_nncph_basisDirectSum}.
-This result uses no comparison, crossing, repeated-copy, raw-weight, or
-externally supplied commutation hypothesis.
+Combining this commutation result with the spanning theorem gives the complete
+all-chain condition at the same scope, recorded by
+\leanid{MPSTensor.IsBNTCanonicalForm.}
+\hspace{0pt}\leanid{rfp_implies_hasNNCPHGroundSpaces_basisDirectSum}.
+This implication uses only BNT canonical form and transfer idempotence of the
+whole multiplicity-one direct sum. It uses no comparison, crossing,
+repeated-copy, raw-weight, or externally supplied commutation hypothesis.
 
-These reductions alone do not prove the full source theorem.  The
+This scope-restricted implication does not prove the full source theorem.  The
 ground-space spanning condition for repeated copies and arbitrary raw sector
 weights, the three-way equivalence with ZCL, the complete canonical-form
 hypotheses from the source statement, and the identification of Beigi's loop
@@ -252,9 +257,11 @@ The residual-family bond-projector argument independently proves the
 commutation clause
 \leanid{MPSTensor.IsBNTCanonicalForm.}
 \hspace{0pt}\leanid{rfp_implies_nncph_basisDirectSum}.
-Together these are precisely the multiplicity-one distinct-sector forward
-case. They do not assert the result for repeated copies or arbitrary raw
-weights.
+Their conjunction is recorded by
+\leanid{MPSTensor.IsBNTCanonicalForm.}
+\hspace{0pt}\leanid{rfp_implies_hasNNCPHGroundSpaces_basisDirectSum}.
+This is precisely the multiplicity-one distinct-sector forward case. It does
+not assert the result for repeated copies or arbitrary raw weights.
 The reverse theorem requires both the explicit BNT relation
 \leanid{MPSTensor.IsBNT} and the named all-chain condition
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on


### PR DESCRIPTION
## Mathematical result

Closes #4342.

This PR proves the complete forward nearest-neighbor commuting parent-Hamiltonian ground-space condition for the multiplicity-one direct sum of the distinct BNT basis sectors:

```lean
theorem MPSTensor.IsBNTCanonicalForm.rfp_implies_hasNNCPHGroundSpaces_basisDirectSum
    {P : SectorDecomposition d}
    (hCF : IsBNTCanonicalForm P)
    (hRFP : IsTransferIdempotent (directSumTensor P.basis)) :
    HasNNCPHGroundSpaces (directSumTensor P.basis) P.basis
```

The proof uses the exact characterization of `HasNNCPHGroundSpaces` as all-chain `IsNNCPH` together with nearest-neighbor ground-space spanning. Its two inputs are the previously proved results:

- `rfp_implies_nncph_basisDirectSum` from #4436 / PR #4642;
- `rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum` from #4343 / PR #4350.

No comparison, crossing, repeated-copy, arbitrary raw-weight, or externally supplied commutation hypothesis is added.

## Source and scope

The statement follows CPSV16, Definition 3.9 and Theorem 3.10, arXiv:1606.00608, lines 517--541. The ground-space spanning component follows PGVWC07, Theorem 12, arXiv:quant-ph/0608197, proof lines 1430--1456.

The result concerns one copy of every distinct BNT basis sector. Repeated copies and arbitrary raw sector weights remain outside the statement, as recorded in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. The change is disjoint from the MPDO Markov-decomposition work in #4445 and the topological-projector Gibbs work in #3950.

## Documentation

- Adds a source-matched theorem and proof to Chapter 13 of the blueprint.
- Updates the existing paper-gap note to name the complete packaged implication and retain the multiplicity-one limitation.
- Regenerates the RFP import aggregate for the new theorem module.

## Validation

- `lake env lean TNLean/MPS/RFP/NNCPHGroundSpacesMultiSector.lean`
- `lake build TNLean.MPS.RFP.NNCPHGroundSpacesMultiSector TNLean.MPS.RFP` (9,130 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- generated-import, proof-integrity, reader-facing prose, line-length, whitespace, oversized-file, and tactic-pattern checks

No `sorry`, axiom, or kernel bypass is introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof is a thin conjunction of prior lemmas with documentation and aggregator updates only; no auth, infrastructure, or axiom changes.
> 
> **Overview**
> Adds **`rfp_implies_hasNNCPHGroundSpaces_basisDirectSum`**, which shows that for a BNT canonical form whose **multiplicity-one direct sum** of distinct basis sectors is an RFP, the full all-chain **`HasNNCPHGroundSpaces`** condition holds. The proof is a short assembly: rewrite via **`hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning`**, then combine the existing commutation theorem **`rfp_implies_nncph_basisDirectSum`** with **`rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum`**.
> 
> The new module is wired into the **`TNLean.MPS.RFP`** import aggregate. Chapter 13 of the blueprint gains a matching theorem and proof, and the CPSV16 scope note now names this packaged forward implication while keeping the **distinct-sector / one-copy** limitation explicit (repeated copies and arbitrary weights remain out of scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d46f26cd31b778506dfc548e57b3861d4fa2cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->