### PR TITLE
feat(MPS/RFP): prove period-two ordered-cycle formula

### DIFF
--- a/TNLean/MPS/RFP/BeigiEventuallyConstantSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiEventuallyConstantSectorGraph.lean
@@ -111,7 +111,8 @@ theorem hasEventuallyConstantCycleWeightSum_of_parentGroundSpace
   have htwo : 2 < N := (Nat.le_max_right N₀ 2).trans_lt hN
   rw [F.cycleWeightSum_edgeWeight_eq hNpos]
   simpa only [edgeWeight] using
-    (F.parentHamiltonianGroundSpaceES_finrank_eq htwo).symm.trans (hparent N hN₀)
+    (F.parentHamiltonianGroundSpaceES_finrank_eq (Nat.le_of_lt htwo)).symm.trans
+      (hparent N hN₀)
 
 /-- If the parent-ground-space dimension is eventually constant, then at
 every length greater than two it equals the number of positive sector loops.
@@ -132,7 +133,7 @@ theorem parentHamiltonianGroundSpaceES_finrank_eq_card_loop
         ∑ c : F.OrderedCycle N,
           ∏ n : Fin N,
             Module.finrank ℂ (F.edgeGroundSpace (c.1 n) (c.1 (n + 1))) :=
-      F.parentHamiltonianGroundSpaceES_finrank_eq hN
+      F.parentHamiltonianGroundSpaceES_finrank_eq (Nat.le_of_lt hN)
     _ = cycleWeightSum F.edgeWeight hNpos := by
       simpa only [edgeWeight] using (F.cycleWeightSum_edgeWeight_eq hNpos).symm
     _ = Fintype.card (Loop F.edgeWeight) := cycleWeightSum_eq_card_loop hconst hNpos

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -639,18 +639,19 @@ theorem mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self
   simpa [parentHamiltonianES, transport, complementProductTransport] using h
 
 /-- Beigi's finite-chain ground-space dimension formula: for a periodic chain
-of length greater than two, the dimension is the sum over ordered cyclic
+of length at least two, the dimension is the sum over ordered cyclic
 sector sequences of the products of the adjacent edge-ground-space
 dimensions.
 
 **Scope restriction (chain length):** Beigi's equations (3)--(4) apply to all
-periodic lengths, whereas this theorem treats the range `N > 2` used by the
-NNCPH clause of arXiv:1606.00608, Theorem 3.10(iii). Documented in
+periodic lengths, whereas this theorem treats `2 ≤ N`; the one-site periodic
+interaction convention remains open. Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equations (3)--(4), page 4. -/
+Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(4), source
+lines 451--512. -/
 theorem parentHamiltonianGroundSpaceES_finrank_eq
-    (F : BeigiSectorGraphData A) {N : ℕ} (hN : 2 < N) :
+    (F : BeigiSectorGraphData A) {N : ℕ} (hN : 2 ≤ N) :
     letI : NeZero N := ⟨by omega⟩
     Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 N) =
       ∑ c : F.OrderedCycle N,
@@ -682,6 +683,22 @@ theorem parentHamiltonianGroundSpaceES_finrank_eq
       exact Submodule.finrank_eq_zero.mpr hbot
     _ = ∑ c : {k // cycle k}, weight c.1 := by
       exact Finset.sum_subtype (Finset.univ.filter cycle) (by simp) weight
+
+/-- Beigi's ordered-cycle ground-space dimension formula at period two.  The
+two cyclic windows traverse the same pair of sites in opposite orders, so
+`(a, b)` and `(b, a)` remain distinct ordered cycles when `a ≠ b`.
+
+Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(4), source
+lines 451--512; the period-two ordered-cycle convention is explicit at source
+lines 509--512. -/
+theorem parentHamiltonianGroundSpaceES_finrank_eq_two
+    (F : BeigiSectorGraphData A) :
+    Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 2) =
+      ∑ c : F.OrderedCycle 2,
+        ∏ n : Fin 2,
+          Module.finrank ℂ (F.edgeGroundSpace (c.1 n) (c.1 (n + 1))) := by
+  apply F.parentHamiltonianGroundSpaceES_finrank_eq (N := 2)
+  omega
 
 end BeigiSectorGraphData
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2778,7 +2778,7 @@ specialization of that Appendix~D definition.
     \lean{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq}
     \leanok
     \uses{def:beigi_sector_graph}
-    For every $N>2$, the periodic ground-space dimension is
+    For every $N\geq 2$, the periodic ground-space dimension is
     \[
         \dim\ker H_N
         =
@@ -2787,8 +2787,9 @@ specialization of that Appendix~D definition.
         \dim\operatorname{ran}P_{a_n,a_{n+1}},
     \]
     where the sum is over ordered cycles and the indices are read modulo $N$.
-    This is the specialization to $N>2$ of equations~(3)--(4) of
-    \cite[Section~III]{Beigi2012Classification}.
+    This is equations~(3)--(4) of
+    \cite[Section~III]{Beigi2012Classification} for chains of length at least
+    two.  The one-site periodic interaction requires a separate convention.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2799,6 +2800,30 @@ specialization of that Appendix~D definition.
     tensor product of the adjacent projectors $P_{a_n,a_{n+1}}$.  Taking the
     trace gives the product of their ranks.  A sequence containing a missing
     edge contributes zero, leaving exactly the displayed ordered-cycle sum.
+\end{proof}
+
+\begin{theorem}[Period-two ordered-cycle ground-space dimension formula]
+    \label{thm:beigi_ordered_cycle_ground_space_dimension_two}
+    \lean{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq_two}
+    \leanok
+    \uses{def:beigi_sector_graph}
+    At period two, the ground-space dimension is
+    \[
+        \dim\ker H_2
+        =
+        \sum_{\substack{a\to b\\ b\to a}}
+        \dim\operatorname{ran}P_{a,b}\,
+        \dim\operatorname{ran}P_{b,a}.
+    \]
+    The sum is over ordered pairs: if $a\ne b$, then $(a,b)$ and $(b,a)$
+    are distinct summands.  This is the length-two convention stated after
+    equation~(4) of \cite[Section~III]{Beigi2012Classification}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:beigi_ordered_cycle_ground_space_dimension}
+    Specialize the ordered-cycle formula to $N=2$.  Its two cyclic factors are
+    $P_{a,b}$ and $P_{b,a}$, which gives the displayed product of ranks.
 \end{proof}
 
 \begin{theorem}[Classification of eventually constant weighted sector graphs]

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -27,9 +27,11 @@ conditions are equivalent:\footnote{Local source:
   \forall N>2,\; |V^{(N)}(A)\rangle
   \text{ is a ground state of a NNCPH}.
 \end{align}
-The formal implications below use the same range $N>2$. No claim is made for
-$N=2$, where the two periodic length-two windows traverse the same sites in
-opposite orders.
+The formal implications below use the same range $N>2$.  This range is
+independent of Beigi's ordered-cycle formula.  At $N=2$, the two periodic
+length-two windows traverse the same sites in opposite orders; the sector-graph
+dimension formula below now treats this convention without extending the CPSV
+equivalence to length two.
 The preceding definition constructs
 \begin{align}
   H_L^{(N)}=\sum_{j=0}^{N-1}\tau_j(P_L^\perp)
@@ -315,13 +317,16 @@ used in this construction.
 
 For a finite sector graph,
 \leanid{MPSTensor.BeigiSectorGraphData.parentHamiltonianGroundSpaceES_finrank_eq}
-constructs the finite directed graph and proves the $N>2$ specialization of
-Beigi's ordered-cycle ground-space dimension formula.  Beigi states this
-formula for every periodic length, while the present restriction matches the
-NNCPH range in Theorem~3.10(iii).  No chain-level ground-space equation,
-eventual degeneracy, or canonical-form datum is assumed in this sector-graph
-theorem.  The remaining lengths $N=1,2$ require separate periodic-window
-conventions and are tracked by \ghissue{4400}.
+proves Beigi's ordered-cycle ground-space dimension formula for every $N\geq2$.
+Its period-two specialization
+\leanid{MPSTensor.BeigiSectorGraphData.}
+\hspace{0pt}\leanid{parentHamiltonianGroundSpaceES_finrank_eq_two}
+retains the two orientations: if $a\ne b$, then $(a,b)$ and $(b,a)$ are
+distinct ordered cycles, exactly as stated in Beigi, arXiv:1105.1019v2,
+Section~III, equations~(2)--(4), source lines 509--512.  No chain-level
+ground-space equation, eventual degeneracy, or canonical-form datum is assumed
+in these sector-graph theorems.  Only $N=1$ still requires a separate
+periodic-interaction convention and remains open in \ghissue{4400}.
 
 The remaining finite graph comparison in Beigi's Section~IV is now proved
 without an axiom.  For a finite directed graph with nonnegative integral edge weights,


### PR DESCRIPTION
## Motivation

Issue #4650 asks for the period-two endpoint of Beigi's ordered-cycle ground-space formula. In arXiv:1105.1019v2, Section III, equations (2)--(4), source lines 451--512, the length-two convention explicitly counts `(a, b)` and `(b, a)` as distinct ordered cycles when `a != b`.

The `N > 2` range in CPSV16 Theorem 3.10(iii) is a separate NNCPH-equivalence scope restriction; it does not restrict Beigi's dimension formula.

## Description

- relax the general ordered-cycle formula from `2 < N` to the source-faithful range `2 <= N`
- add the explicit theorem `parentHamiltonianGroundSpaceES_finrank_eq_two`
- adapt the two downstream eventual-constancy callers to the relaxed hypothesis
- add a separate Chapter 13 blueprint theorem and update the paper-gap note
- retain #4400 for the unresolved one-site periodic-interaction convention

## Testing

- `lake env lean TNLean/MPS/RFP/BeigiSectorGraph.lean`
- `lake --old build TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph TNLean.MPS.RFP.BeigiLoopTensor`
- `lake build`
- reader-facing prose and forbidden-token checks
- blueprint/Lean synchronization and declaration coverage
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- standalone paper-gap `latexmk` build
- visual inspection of the affected blueprint and paper-gap PDF pages

The generated web build passed; visual browser inspection was unavailable because this environment exposed no browser backend.

Closes #4650

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation changes in formalized MPS/sector-graph theory; no runtime, auth, or data-handling impact. Call-site updates are minimal (`Nat.le_of_lt`).
> 
> **Overview**
> **Beigi’s ordered-cycle ground-space dimension formula** is no longer restricted to `N > 2`. `parentHamiltonianGroundSpaceES_finrank_eq` now takes `2 ≤ N`, matching Beigi Section III for chains of length at least two. A dedicated theorem `parentHamiltonianGroundSpaceES_finrank_eq_two` states the period-two case where `(a, b)` and `(b, a)` count as distinct ordered cycles when `a ≠ b`.
> 
> Downstream proofs in `BeigiEventuallyConstantSectorGraph` that still need strict `2 < N` call the general theorem via `Nat.le_of_lt`. Chapter 13 blueprint gains a period-two theorem; the CPSV16 paper-gap note clarifies that CPSV’s `N > 2` NNCPH scope is separate from Beigi’s formula and that only `N = 1` remains open (#4400).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97f8da6354990f7099f245fb7f36de2dce40825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->