### PR TITLE
feat(MPS/ParentHamiltonian): formalize one-site zero convention

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -183,8 +183,8 @@ second replacement. -/
 
 **Important:** When \(L > N\) the definition returns `0`, which makes
 `parentHamiltonian` trivially zero and `IsFrustrationFree` vacuously true.
-All meaningful lemmas in `Basic.lean` carry an explicit \(L ≤ N\)
-hypothesis, so this degenerate branch is never reached in verified results.
+The lemmas in `Basic.lean` carry an explicit \(L ≤ N\) hypothesis; the one-site
+two-site result below records the \(L > N\) convention separately.
 
 For \(f\) and output configuration \(\sigma\):
 ```
@@ -215,7 +215,8 @@ source lines 451--514, defines each interaction on two neighboring sites but
 does not specify its action when those sites coincide. The zero value here is
 the convention in `localTerm`, not a one-site case of Beigi's ordered-cycle
 formula. CPSV16, arXiv:1606.00608, Theorem 3.10(iii), source lines 534--540,
-only uses chain lengths greater than two. -/
+only uses chain lengths greater than two. This restriction is documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 @[simp] theorem parentHamiltonian_two_one_eq_zero (A : MPSTensor d D) :
     parentHamiltonian A 2 1 = 0 := by
   simp [parentHamiltonian, localTerm]

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -207,6 +207,19 @@ noncomputable def parentHamiltonian (A : MPSTensor d D) (L N : ℕ) :
     NSiteSpace d N →ₗ[ℂ] NSiteSpace d N :=
   ∑ i : Fin N, localTerm A L N i
 
+/-- The two-site parent Hamiltonian on a one-site periodic chain is zero under
+the project's convention for a local interaction larger than the chain.
+
+**Scope restriction (one-site chain):** Beigi, arXiv:1105.1019v2, Section III,
+source lines 451--514, defines each interaction on two neighboring sites but
+does not specify its action when those sites coincide. The zero value here is
+the convention in `localTerm`, not a one-site case of Beigi's ordered-cycle
+formula. CPSV16, arXiv:1606.00608, Theorem 3.10(iii), source lines 534--540,
+only uses chain lengths greater than two. -/
+@[simp] theorem parentHamiltonian_two_one_eq_zero (A : MPSTensor d D) :
+    parentHamiltonian A 2 1 = 0 := by
+  simp [parentHamiltonian, localTerm]
+
 /-- Frustration-free ground-state condition for the parent model:
 every local term annihilates the candidate vector. -/
 def IsFrustrationFree (A : MPSTensor d D) (L N : ℕ) (ψ : NSiteSpace d N) : Prop :=

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -154,7 +154,8 @@ one-site Hilbert space under the project's zero convention.
 `parentHamiltonian_two_one_eq_zero`. Beigi, arXiv:1105.1019v2, Section III,
 source lines 451--514, does not specify a one-site action for its two-site
 interaction, while CPSV16, arXiv:1606.00608, Theorem 3.10(iii), source lines
-534--540, only uses chain lengths greater than two. -/
+534--540, only uses chain lengths greater than two. This restriction is documented
+in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 @[simp] theorem parentHamiltonianGroundSpaceES_two_one_eq_top (A : MPSTensor d D) :
     parentHamiltonianGroundSpaceES A 2 1 = ⊤ := by
   simp [parentHamiltonianGroundSpaceES]

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -147,6 +147,18 @@ noncomputable def parentHamiltonianGroundSpaceES (A : MPSTensor d D)
   (LinearMap.ker (parentHamiltonian A L N)).map
     (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm.toLinearMap
 
+/-- The one-site ground space for the two-site parent interaction is the full
+one-site Hilbert space under the project's zero convention.
+
+**Scope restriction (one-site chain):** This is a consequence of
+`parentHamiltonian_two_one_eq_zero`. Beigi, arXiv:1105.1019v2, Section III,
+source lines 451--514, does not specify a one-site action for its two-site
+interaction, while CPSV16, arXiv:1606.00608, Theorem 3.10(iii), source lines
+534--540, only uses chain lengths greater than two. -/
+@[simp] theorem parentHamiltonianGroundSpaceES_two_one_eq_top (A : MPSTensor d D) :
+    parentHamiltonianGroundSpaceES A 2 1 = ⊤ := by
+  simp [parentHamiltonianGroundSpaceES]
+
 /-- The Euclidean-space representative of the parent Hamiltonian. -/
 noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -2826,6 +2826,32 @@ specialization of that Appendix~D definition.
     $P_{a,b}$ and $P_{b,a}$, which gives the displayed product of ranks.
 \end{proof}
 
+\begin{theorem}[Project-local one-site zero convention]
+    \label{thm:project_local_one_site_parent_hamiltonian_zero}
+    \lean{MPSTensor.parentHamiltonian_two_one_eq_zero}
+    \lean{MPSTensor.parentHamiltonianGroundSpaceES_two_one_eq_top}
+    \leanok
+    For the convention that an $L$-site interaction is zero when $L>N$, the
+    two-site parent Hamiltonian on a one-site periodic chain satisfies
+    \[
+        H_2^{(1)}=0,
+        \qquad
+        \ker H_2^{(1)}=\mathbb C^d.
+    \]
+    This convention is local to the present development.  The two-site terms
+    in \cite[Section~III]{Beigi2012Classification}, source lines 451--514, are
+    not assigned an action when both site labels denote the same site.  The
+    nearest-neighbor condition in
+    \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}, source lines 534--540, only
+    concerns $N>2$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Since $2>1$, the single translated interaction is zero by the stated
+    convention.  Its sum is therefore zero, and the kernel of the zero
+    operator is the full one-site Hilbert space.
+\end{proof}
+
 \begin{theorem}[Classification of eventually constant weighted sector graphs]
     \label{thm:beigi_eventually_constant_sector_graph}
     \lean{FiniteWeightedDigraph.cyclicEdgeWeight_eq_one}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -328,8 +328,44 @@ retains the two orientations: if $a\ne b$, then $(a,b)$ and $(b,a)$ are
 distinct ordered cycles, exactly as stated in Beigi, arXiv:1105.1019v2,
 Section~III, equations~(2)--(4), source lines 509--512.  No chain-level
 ground-space equation, eventual degeneracy, or canonical-form datum is assumed
-in these sector-graph theorems.  Only $N=1$ still requires a separate
-periodic-interaction convention and remains open in \ghissue{4400}.
+in these sector-graph theorems.
+
+At $N=1$, Beigi's two-site interaction has no specified action.  The source
+defines $P_{j,j+1}$ on sites $j,j+1$ and then separates the actions of
+$P_{j-1,j}$ and $P_{j,j+1}$ on the middle site; see
+arXiv:1105.1019v2, Section~III, source lines 451--476.  When $N=1$, these site
+labels all coincide, and lines 477--514 do not add a rule for turning the
+two-site operator into a one-site operator.  CPSV16 does not impose such a
+rule: Theorem~3.10(iii), local source lines 534--540, only concerns $N>2$.
+
+The present development uses the project-local convention that an $L$-site
+interaction is zero when $L>N$.  Accordingly,
+\leanid{MPSTensor.parentHamiltonian_two_one_eq_zero} proves
+$H_2^{(1)}=0$, and
+\leanid{MPSTensor.parentHamiltonianGroundSpaceES_two_one_eq_top} proves
+\begin{align}
+  \ker H_2^{(1)}=\mathbb C^d.
+\end{align}
+This convention does not extend Beigi's ordered-cycle equality.  An ordered
+cycle of length one is a self-loop, so the graph expression would instead be
+\begin{align}
+  \sum_a \dim\operatorname{ran}P_{a,a}.
+\end{align}
+The two-site block decomposition imposes no equality between this sum and $d$.
+For example, take
+\begin{align}
+  A^0=\begin{pmatrix}0&1\\0&0\end{pmatrix},
+  \qquad
+  A^1=\begin{pmatrix}0&0\\1&0\end{pmatrix}.
+\end{align}
+Its two-site ground space is spanned by $|01\rangle$ and $|10\rangle$.  The
+corresponding one-dimensional sectors have only the edges $0\to1$ and
+$1\to0$, so the self-loop sum is zero, whereas the project-local one-site
+ground space has dimension $d=2$.  Thus the project-local result is recorded
+separately, while Beigi's
+ordered-cycle theorem remains stated for $N\geq2$.  The source-level one-site
+convention remains open in \ghissue{4400}; \ghissue{4655} records the current
+project-local boundary.
 
 The remaining finite graph comparison in Beigi's Section~IV is now proved
 without an axiom.  For a finite directed graph with nonnegative integral edge weights,


### PR DESCRIPTION
## Motivation

Beigi Section III (arXiv:1105.1019v2, source lines 451--514) defines a two-site nearest-neighbor interaction but does not specify how it acts when both site labels coincide at N=1. CPSV16 Theorem 3.10(iii) (arXiv:1606.00608, source lines 534--540) only uses N>2.

This PR records the current project-local boundary without extending either source theorem. The source-level N=1 convention remains open in #4400.

## Description

- prove that the current localTerm convention gives parentHamiltonian A 2 1 = 0;
- prove that its one-site Euclidean ground space is the full space;
- add a Chapter 13 blueprint theorem with both Lean declarations;
- update the CPSV16 paper-gap note to separate this local convention from Beigi ordered-cycle equality, including a concrete counterexample to identifying the N=1 graph expression with d.

No PEPS declarations or source-level Beigi operator are introduced.

## Testing

- lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
- lake build TNLean.MPS.ParentHamiltonian.Martingale.Transport
- lake build
- cd blueprint && leanblueprint checkdecls
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main
- cd blueprint && leanblueprint pdf
- cd blueprint && leanblueprint web
- latexmk -pdf -interaction=nonstopmode -halt-on-error docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex

The generated Chapter 13 PDF page was visually inspected for clipping, overlap, formulas, citations, and declaration badges.

Closes #4655

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds simp proofs and documentation for an existing definitional convention; no changes to auth, data handling, or core Hamiltonian logic beyond N=1.
> 
> **Overview**
> Records the **project-local** boundary for two-site parent interactions on a **one-site** periodic chain: when `L > N`, `localTerm` is already zero, and this PR proves **`parentHamiltonian A 2 1 = 0`** and that the Euclidean ground space is the **full** one-site Hilbert space (`ker = ℂ^d`).
> 
> The work is explicitly **not** extending Beigi’s ordered-cycle formula or CPSV16 Theorem 3.10(iii) (which only uses `N > 2`). Lean docstrings, a new Chapter 13 blueprint theorem, and an expanded `cpsv16_nncph_ground_state_scope.tex` note separate this convention from source theorems and give a concrete example where a graph self-loop sum need not equal `d`.
> 
> Minor test updates in `scripts/test_tenkz_equation_web.py` adjust prose-boundary checks and page load behavior for blueprint equation web tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69053e43ba9006c98028da8d045ff2ea3624b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->