### PR TITLE
feat(MPS/MPDO): derive SAL from physical-sector ZCL

### DIFF
--- a/TNLean/MPS/MPDO/CyclicActiveMarkov.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkov.lean
@@ -65,8 +65,6 @@ theorem isSAL_of_isSourceZCL
     apply isSAL_of_quantumMarkovDecomposition_tripartite_m
       F.sectorCoordinateTensor hCoordinateMPDO hCoordinateTrace
     intro N m hm1 hmN
-    dsimp only
-    have hmN' : m ≤ N := hmN.trans (Nat.div_le_self N 2)
     let A := m - 1
     let C := N - m - 1
     have htotal : A + C + 2 = N := by

--- a/TNLean/MPS/MPDO/CyclicActiveMarkov.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkov.lean
@@ -4,3 +4,98 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.CyclicActiveMarkovDecomposition
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+import TNLean.MPS.MPDO.SALArbitraryCut
+
+/-!
+# Saturated area law from cyclic-active Markov decompositions
+
+This file combines the all-cut quantum-Markov decomposition in physical-sector
+coordinates with the entropy criterion for saturation of the area law and
+isometric physical-basis transport.
+
+## Main statement
+
+- `MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL`: an injective
+  source-ZCL tensor with a positive physical-sector factorization satisfies SAL.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1597--1619.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- An injective tensor with source zero correlation length satisfies the
+saturated area law when it admits a physical-sector factorization with
+positive semidefinite neighboring operators.
+
+The proof constructs the quantum-Markov decomposition of every admissible
+one-site cut in physical-sector coordinates, applies the all-cut entropy
+criterion there, and descends through the isometric physical-coordinate map.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1597--1619.
+
+**Scope restriction (physical-sector factorization):** The source assumes a
+single translation-invariant commuting positive bond, whereas this theorem
+assumes its physical-sector factorization explicitly. The missing construction
+from the source hypothesis is recorded in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem isSAL_of_isSourceZCL
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hK : K.IsInjective)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) :
+    IsSAL K := by
+  have hCoordinateMPDO : IsMPDO F.sectorCoordinateTensor := by
+    intro N hN
+    letI : NeZero N := ⟨ne_of_gt hN⟩
+    exact F.mpo_sectorCoordinateTensor_posSemidef hpos
+  have hCoordinateTrace : ∀ N, 0 < N →
+      (mpo F.sectorCoordinateTensor N).trace ≠ 0 := by
+    intro N hN
+    exact ne_of_gt (F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL
+      hpos hZCL hN)
+  have hCoordinateSAL : IsSAL F.sectorCoordinateTensor := by
+    apply isSAL_of_quantumMarkovDecomposition_tripartite_m
+      F.sectorCoordinateTensor hCoordinateMPDO hCoordinateTrace
+    intro N m hm1 hmN
+    dsimp only
+    have hmN' : m ≤ N := hmN.trans (Nat.div_le_self N 2)
+    let A := m - 1
+    let C := N - m - 1
+    have htotal : A + C + 2 = N := by
+      dsimp only [A, C]
+      omega
+    have hMarkov :=
+      F.exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL
+        hK hpos hZCL A C
+    let nAmbient : {n : ℕ // A + 1 + C ≤ n} := ⟨N, by omega⟩
+    let nCut : {n : ℕ // A + 1 + C ≤ n} := ⟨A + C + 2, by omega⟩
+    have hn : nAmbient = nCut := Subtype.ext htotal.symm
+    have hReducedBlockState :
+        F.sectorCoordinateTensor.reducedBlockState N (A + 1 + C) (by omega) =
+          F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + 1 + C) (by omega) := by
+      simpa only [nAmbient, nCut] using congrArg
+        (fun n : {n : ℕ // A + 1 + C ≤ n} ↦
+          F.sectorCoordinateTensor.reducedBlockState n.1 (A + 1 + C) n.2) hn
+    change Nonempty (Entropy.QuantumMarkovDecomposition
+      ((F.sectorCoordinateTensor.reducedBlockState N (A + 1 + C) _).submatrix
+        (tripartiteSplitEquiv
+          (Fintype.card F.SectorSiteIndex) A 1 C).symm
+        (tripartiteSplitEquiv
+          (Fintype.card F.SectorSiteIndex) A 1 C).symm))
+    rw [hReducedBlockState]
+    exact hMarkov
+  apply isSAL_of_changePhysicalBasis_isSAL_of_isometry
+    F.physicalCoordinateMatrix F.physicalCoordinateMatrix_isometry K
+  rw [← F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  exact hCoordinateSAL
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -1172,6 +1172,38 @@
     sum to one.
 \end{proof}
 
+\begin{theorem}[Physical-sector factorization and ZCL imply SAL]
+    \label{thm:mpdo_physical_sector_factorization_zcl_sal}
+    \lean{MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization, def:mpo_source_zcl,
+      def:is_sal, def:mpdo}
+    Let $\mathcal K$ be injective and have source zero correlation length.
+    Suppose that $\mathcal K$ admits a physical-sector factorization whose
+    neighboring operators $\eta_{k,h}$ are positive semidefinite.  Then
+    $\mathcal K$ saturates the area law.
+
+    % Scope restriction (physical-sector factorization): the source theorem
+    % assumes a single translation-invariant commuting positive bond, not an
+    % explicit physical-sector factorization. The remaining implication is
+    % recorded in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_cyclic_active_markov_all_cuts,
+      thm:mpdo_all_cut_markov_implies_sal}
+    In physical-sector coordinates, positivity of the neighboring operators
+    makes every positive-length periodic operator positive semidefinite, while
+    source zero correlation length makes its trace strictly positive.
+    Theorem~\ref{thm:mpdo_cyclic_active_markov_all_cuts} supplies a quantum
+    Markov decomposition at each admissible cut.  Hence
+    Theorem~\ref{thm:mpdo_all_cut_markov_implies_sal} gives saturation of the
+    area law in these coordinates.  The physical-coordinate inclusion is an
+    isometry, so it preserves the nonzero spectra of every periodic operator
+    and every contiguous marginal.  Their entropies, and therefore saturation
+    of the area law, are unchanged.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -1191,7 +1191,8 @@
 
 \begin{proof}\leanok
     \uses{thm:mpdo_cyclic_active_markov_all_cuts,
-      thm:mpdo_all_cut_markov_implies_sal}
+      thm:mpdo_all_cut_markov_implies_sal,
+      thm:mpdo_physical_support_restriction_sal}
     In physical-sector coordinates, positivity of the neighboring operators
     makes every positive-length periodic operator positive semidefinite, while
     source zero correlation length makes its trace strictly positive.

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -453,9 +453,24 @@ left and right path factors, and collecting their trace products gives
 \leanid{MPOTensor.PhysicalSectorFactorization.%
 exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL}.  Thus the
 Markov decomposition for arbitrary left and right lengths is available in the
-physical-sector coordinates.  Substitution of the admissible entropy-cut
-lengths and transport to the original basis remain part of issue \#4175.  The
-older conditional theorem
+physical-sector coordinates.  Substituting the admissible lengths
+$A=m-1$ and $C=N-m-1$ gives every cut required by the entropy theorem.
+Positivity of the neighboring operators makes the sector-coordinate periodic
+operators positive semidefinite, and source ZCL makes their traces strictly
+positive.  The all-cut entropy theorem therefore proves SAL in these
+coordinates.  Since the physical-coordinate inclusion is isometric, the
+nonzero spectra of every periodic operator and marginal agree with those in
+the original physical basis.  The resulting scope-restricted implication is
+now formalized.\footnote{Formal declaration:
+\leanid{MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL} in
+\doclink{TNLean/MPS/MPDO/CyclicActiveMarkov}.}
+
+This theorem assumes the physical-sector factorization explicitly.  It does
+not derive that factorization from the single translation-invariant commuting
+bond in Proposition~\emph{4to2}.  It also assumes one-site injectivity, whereas
+the source starts with a normal tensor; completing the source implication
+requires passing to an injective blocking and transporting SAL through that
+blocking.  The older conditional theorem
 \leanid{Matrix.eta_fourth_region_trace_formula} remains a coordinate model for
 a one-step rank-one coefficient; it is not used to identify $T_C$ with
 $T_C^2$.
@@ -467,13 +482,12 @@ Consequently the source implication
   \Longrightarrow \text{SAL}
 \]
 is not yet formalized and must not carry a \texttt{\string\leanok} marker.
-The remaining work is to transport the all-cut witnesses from the
-physical-sector coordinates back to the original physical basis and apply the
-final entropy-theoretic step: quantum Markov decompositions at all admissible
-cuts imply SAL.\footnote{This is
-\leanid{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}.} Its
-direct-sum hypothesis is a marked scope restriction, not an additional
-hypothesis on the source proposition.
+The entropy-theoretic step and physical-basis transport are complete under the
+explicit physical-sector-factorization hypothesis.  The remaining work is to
+derive such a factorization from the source commuting-bond hypothesis and to
+relate the normal, possibly blocked source tensor to the injective theorem
+above.  The explicit factorization is a marked scope restriction, not an
+additional hypothesis on the source proposition.
 
 \paragraph{Local fix (the later orthogonal-sector statement).}
 The proposition labelled \emph{prop4to2} at source lines~1801--1808 states
@@ -512,23 +526,27 @@ direct-sum implication.  It neither derives the sectorwise SAL premise nor
 uses ZCL.
 
 \paragraph{Verdict.}
-Proposition~\emph{4to2} is classified as a transport gap.  The fourth-region
-factorization and the Markov decomposition at every admissible cut have been
-proved in physical-sector coordinates.  Transport to the original physical
-basis and the final application of the all-cut entropy theorem remain.  The later
-orthogonal direct-sum implication is likewise formalized only as a
-scope-restricted theorem assuming sectorwise SAL.  It neither supplies that
-sectorwise premise nor proves the printed assertion that the GSNNCH form alone
-implies SAL.
+Proposition~\emph{4to2} remains an open implication gap.  Under an explicit
+positive physical-sector factorization and one-site injectivity, the
+fourth-region factorization, the Markov decomposition at every admissible cut,
+the all-cut entropy argument, and physical-basis transport now prove SAL.  This
+is a scope-restricted theorem, since the source assumes only the commuting-bond
+form and normality.  The later orthogonal direct-sum implication is likewise
+formalized only as a scope-restricted theorem assuming sectorwise SAL.  It
+neither supplies that sectorwise premise nor proves the printed assertion that
+the GSNNCH form alone implies SAL.
 
 \section{Elimination plan}
 
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Transport the proved physical-sector all-cut Markov witnesses through
-the physical isometry to the original physical basis.
-\item Apply the all-cut Markov theorem.  Only then may the source proposition
+\item Derive a positive physical-sector factorization from the fixed
+translation-invariant commuting bond and its common one-site spatial
+decomposition.
+\item Pass from the source normal tensor to an injective blocking and prove the
+required invariance of SAL under blocking.
+\item Apply the restricted theorem above.  Only then may the source proposition
 receive a formal declaration and a \texttt{\string\leanok} marker.
 \end{enumerate}
 


### PR DESCRIPTION
## Summary

- prove `MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL`
- assemble the cyclic-active all-cut Markov decompositions into coordinate SAL and transport it through the physical-coordinate isometry
- add a separate scope-restricted blueprint theorem and update the commuting-form-to-SAL paper-gap account

## Faithfulness and scope

This is a restricted corollary of CPSV16 Proposition `4to2` (arXiv:1606.00608, lines 1597–1619). It assumes an explicit `PhysicalSectorFactorization`, injectivity, and positive semidefinite neighboring operators.

It does not prove the source proposition from a single translation-invariant commuting positive bond, nor the normality/blocking reduction. The source-facing theorem remains `\notready`; only the separately stated restricted theorem carries `\leanok`. The remaining bridge is tracked in #4175 and documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.

## Validation

- `lake env lean TNLean/MPS/MPDO/CyclicActiveMarkov.lean`
- `lake build TNLean.MPS.MPDO.CyclicActiveMarkov`
- `lake build TNLean.MPS.MPDO`
- `lake build`
- blueprint synchronization and declaration checking
- blueprint PDF generation and rendered-page inspection
- module-policy, import-generator, prose, proof-integrity, line-length, and tactic-pattern checks

The local web renderer was unavailable because the installed Python `pygraphviz` package failed during import. Hosted blueprint CI is therefore a required publication gate for this draft.

Closes #4656.

Advances #4175 and #4459.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is a substantial formal proof in core MPDO/SAL theory (not auth or payments), but it composes several prior lemmas; a mistake in cut indexing or basis transport would mis-state a key paper corollary.
> 
> **Overview**
> Formalizes **`MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL`**: an injective MPO with source ZCL and a positive physical-sector factorization is shown to satisfy the saturated area law (SAL). The proof builds MPDO/trace hypotheses on the sector-coordinate tensor, instantiates cyclic-active Hayashi Markov decompositions at every admissible tripartite cut (`A = m−1`, `C = N−m−1`), applies the all-cut quantum-Markov → SAL criterion, then pulls SAL back to the original tensor via the isometric physical-coordinate change.
> 
> The blueprint gains a **scope-restricted** `\leanok` theorem (physical-sector factorization + ZCL ⇒ SAL); the full commuting-bond Proposition 4to2 statement stays `\notready`. **`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`** is updated to record that the entropy and isometric transport steps are done under the explicit factorization hypothesis, while deriving that factorization from the single commuting bond and normality/blocking remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dacc80e8267ae530c6630f863870eb17fbc48f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->