### PR TITLE
feat(MPS/MPDO): transport cyclic-active SAL to physical cuts

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -79,6 +79,7 @@ import TNLean.MPS.MPDO.CompleteZipperFusionFourfold
 import TNLean.MPS.MPDO.CompleteZipperFusionInverse
 import TNLean.MPS.MPDO.CompleteZipperFusionPentagon
 import TNLean.MPS.MPDO.CompleteZipperFusionSupport
+import TNLean.MPS.MPDO.CyclicActiveAreaLaw
 import TNLean.MPS.MPDO.CyclicActiveCutCoordinates
 import TNLean.MPS.MPDO.CyclicActiveCutRegrouping
 import TNLean.MPS.MPDO.CyclicActiveCutStates

--- a/TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean
@@ -33,7 +33,7 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 **Scope restriction (physical-sector factorization):** The theorem assumes the
 physical-sector factorization and positivity of its neighboring operators.
 The source derives this structure from a translation-invariant commuting bond.
-The missing non-circular bridge is documented in
+The missing non-circular construction is documented in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem isSAL_of_isSourceZCL (F : PhysicalSectorFactorization K) [NeZero D]
     (hK : K.IsInjective)

--- a/TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean
@@ -1,0 +1,68 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveMarkovDecomposition
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+import TNLean.MPS.MPDO.SALArbitraryCut
+
+/-!
+# Area law from the cyclic-active Markov decomposition
+
+This file transports the all-cut quantum-Markov decomposition in physical-sector
+coordinates back to the original physical basis.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1597--1619.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- A positive physical-sector factorization with source zero correlation
+length saturates the area law.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1597--1619.
+
+**Scope restriction (physical-sector factorization):** The theorem assumes the
+physical-sector factorization and positivity of its neighboring operators.
+The source derives this structure from a translation-invariant commuting bond.
+The missing non-circular bridge is documented in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem isSAL_of_isSourceZCL (F : PhysicalSectorFactorization K) [NeZero D]
+    (hK : K.IsInjective)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (hZCL : K.IsSourceZCL) : IsSAL K := by
+  have hMpdo : IsMPDO F.sectorCoordinateTensor := by
+    intro N hN
+    letI : NeZero N := ⟨ne_of_gt hN⟩
+    exact F.mpo_sectorCoordinateTensor_posSemidef hpos
+  have htrace : ∀ N, 0 < N → Matrix.trace
+      (mpo F.sectorCoordinateTensor N) ≠ 0 := by
+    intro N hN
+    exact ne_of_gt
+      (F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL hpos hZCL hN)
+  have hCoordinateSAL : IsSAL F.sectorCoordinateTensor := by
+    apply isSAL_of_quantumMarkovDecomposition_tripartite_m
+      F.sectorCoordinateTensor hMpdo htrace
+    intro N m hm1 hmN
+    dsimp only
+    have hlength : (m - 1) + (N - m - 1) + 2 = N := by omega
+    convert
+      F.exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL
+        hK hpos hZCL (m - 1) (N - m - 1) using 1
+    congr 1
+    ext x y
+    simp only [Matrix.submatrix_apply, hlength]
+  apply isSAL_of_changePhysicalBasis_isSAL_of_isometry
+    F.physicalCoordinateMatrix F.physicalCoordinateMatrix_isometry K
+  rw [← F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  exact hCoordinateSAL
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -1172,6 +1172,34 @@
     sum to one.
 \end{proof}
 
+\begin{theorem}[Physical-sector factorization and ZCL imply SAL]
+    \label{thm:mpdo_physical_sector_factorization_zcl_sal}
+    \lean{MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL}
+    \leanok
+    \uses{thm:mpdo_cyclic_active_markov_all_cuts,
+      thm:mpdo_all_cut_markov_implies_sal}
+    Let $\mathcal K$ have positive bond dimension and be injective, and let
+    $F$ be a physical-sector factorization of $\mathcal K$.  Suppose every
+    neighboring operator $\eta^F_{q,h}$ is positive semidefinite.  If the
+    physical-trace transfer of $\mathcal K$ has source zero correlation
+    length, then $\mathcal K$ saturates the area law.
+
+    % **Scope restriction (physical-sector factorization):** The theorem
+    % assumes the factorization F and positivity of every neighboring
+    % operator.  CPSV16 Proposition 4to2, lines 1597--1619, starts instead
+    % from a translation-invariant commuting bond.  The missing bridge is
+    % recorded in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    Positivity of the neighboring operators makes every nonempty
+    sector-coordinate chain operator positive.  Source zero correlation
+    length makes its trace nonzero.  Apply the preceding theorem with
+    $A=m-1$ and $C=N-m-1$ at every admissible cut, then use the all-cut
+    Markov criterion.  Finally transport saturation through the physical
+    isometry of $F$.
+\end{proof}
+
 \begin{theorem}[A translation-invariant commuting bond and ZCL imply SAL]
     \label{thm:mpdo_translation_invariant_commuting_form_zcl_sal}
     \notready

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -453,9 +453,12 @@ left and right path factors, and collecting their trace products gives
 \leanid{MPOTensor.PhysicalSectorFactorization.%
 exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL}.  Thus the
 Markov decomposition for arbitrary left and right lengths is available in the
-physical-sector coordinates.  Substitution of the admissible entropy-cut
-lengths and transport to the original basis remain part of issue \#4175.  The
-older conditional theorem
+physical-sector coordinates.  Substituting the admissible entropy-cut lengths,
+applying the all-cut Markov criterion, and transporting through the physical
+isometry gives
+\leanid{MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL}.
+The cut calculation and basis transport are therefore complete under an
+explicit positive physical-sector factorization.  The older conditional theorem
 \leanid{Matrix.eta_fourth_region_trace_formula} remains a coordinate model for
 a one-step rank-one coefficient; it is not used to identify $T_C$ with
 $T_C^2$.
@@ -467,13 +470,13 @@ Consequently the source implication
   \Longrightarrow \text{SAL}
 \]
 is not yet formalized and must not carry a \texttt{\string\leanok} marker.
-The remaining work is to transport the all-cut witnesses from the
-physical-sector coordinates back to the original physical basis and apply the
-final entropy-theoretic step: quantum Markov decompositions at all admissible
-cuts imply SAL.\footnote{This is
-\leanid{MPOTensor.isSAL_of_quantumMarkovDecomposition_tripartite_m}.} Its
-direct-sum hypothesis is a marked scope restriction, not an additional
-hypothesis on the source proposition.
+The remaining work is structural: construct a positive
+\leanid{MPOTensor.PhysicalSectorFactorization} non-circularly from the
+source-side \leanid{MPOTensor.EtaLocalStructureData}, and supply the
+normality and blocking reduction needed to reach that datum from the printed
+commuting-bond hypotheses.  The explicit factorization and positivity
+assumptions of the proved corollary are marked scope restrictions, not
+additional hypotheses on the source proposition.
 
 \paragraph{Local fix (the later orthogonal-sector statement).}
 The proposition labelled \emph{prop4to2} at source lines~1801--1808 states
@@ -512,10 +515,13 @@ direct-sum implication.  It neither derives the sectorwise SAL premise nor
 uses ZCL.
 
 \paragraph{Verdict.}
-Proposition~\emph{4to2} is classified as a transport gap.  The fourth-region
-factorization and the Markov decomposition at every admissible cut have been
-proved in physical-sector coordinates.  Transport to the original physical
-basis and the final application of the all-cut entropy theorem remain.  The later
+Proposition~\emph{4to2} is classified as a structural-bridge gap.  The
+fourth-region factorization, the Markov decomposition at every admissible cut,
+the all-cut entropy argument, and transport to the original physical basis are
+complete under an explicit positive physical-sector factorization.  The
+non-circular construction of that factorization from the source-side
+$\eta$-local structure, together with the normality and blocking reduction,
+remains.  The later
 orthogonal direct-sum implication is likewise formalized only as a
 scope-restricted theorem assuming sectorwise SAL.  It neither supplies that
 sectorwise premise nor proves the printed assertion that the GSNNCH form alone
@@ -526,10 +532,12 @@ implies SAL.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Transport the proved physical-sector all-cut Markov witnesses through
-the physical isometry to the original physical basis.
-\item Apply the all-cut Markov theorem.  Only then may the source proposition
-receive a formal declaration and a \texttt{\string\leanok} marker.
+\item Construct a positive physical-sector factorization non-circularly from
+the source-side $\eta$-local structure.
+\item Prove the normality and blocking reduction from the printed
+translation-invariant commuting-bond hypotheses to that $\eta$-local datum.
+Only then may the source proposition receive a formal declaration and a
+\texttt{\string\leanok} marker.
 \end{enumerate}
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
## Summary

- derive `IsSAL K` from a positive physical-sector factorization and source ZCL
- instantiate the cyclic-active Markov decomposition at every admissible physical cut and transport SAL through the physical isometry
- add a scope-restricted blueprint theorem and update the CPSV16 gap note to leave only the structural bridge and normality/blocking reduction

## Source fidelity

This is the explicitly marked physical-sector-factorization restriction of CPSV16 Proposition `4to2` (arXiv:1606.00608, Appendix C.2, lines 1597--1619). The unrestricted commuting-bond theorem remains `\notready`.

No `sorry` is introduced. The remaining source-faithful work is documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`: construct `EtaLocalStructureData -> PhysicalSectorFactorization` non-circularly with positivity, then discharge the normality/blocking reduction.

## Validation

- `lake env lean TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean`
- `lake build TNLean.MPS.MPDO.CyclicActiveAreaLaw`
- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- import-aggregator, forbidden-token, reader-facing-prose, blueprint-sync, tactic-pattern, and diff checks
- `leanblueprint web`
- `leanblueprint pdf` with rendered-page inspection
- standalone gap-note PDF build and inspection

Closes #4656.

#4175 and #4459 remain open: this PR closes only the physical-cut transport child, while the source-side structural bridge and the separate orthogonal-sector SAL premise are still outstanding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization and documentation; no runtime, auth, or data-path changes. Remaining source proposition stays explicitly `\notready` and scope-restricted.
> 
> **Overview**
> This PR **completes the physical-basis leg** of CPSV16 Proposition `4to2` under an explicit **scope restriction**: a positive `PhysicalSectorFactorization`, PSD neighboring operators, injectivity, and **source ZCL**.
> 
> New Lean module `CyclicActiveAreaLaw.lean` proves **`MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL`**. The proof gets **SAL in sector coordinates** by applying **`isSAL_of_quantumMarkovDecomposition_tripartite_m`** with cyclic-active **Hayashi Markov decompositions** at every admissible cut (`exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL`), then **pulls SAL back** to the original tensor via **`isSAL_of_changePhysicalBasis_isSAL_of_isometry`**.
> 
> The blueprint gains a **`\leanok` theorem** “Physical-sector factorization and ZCL imply SAL.” The CPSV16 gap note is revised: cut/Markov/all-cut entropy and **isometry transport** are **done** under the factorization hypothesis; what remains is a **structural-bridge gap** (non-circular `EtaLocalStructureData → PhysicalSectorFactorization` plus normality/blocking), not further transport work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a42a7e25ea53dd8f7a9fd07815c9c31eeaf842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->