### PR TITLE
doc(MPS/MPDO): correct cyclic-active SAL blueprint metadata

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -1177,7 +1177,8 @@
     \lean{MPOTensor.PhysicalSectorFactorization.isSAL_of_isSourceZCL}
     \leanok
     \uses{thm:mpdo_cyclic_active_markov_all_cuts,
-      thm:mpdo_all_cut_markov_implies_sal}
+      thm:mpdo_all_cut_markov_implies_sal,
+      thm:mpdo_physical_support_restriction_sal}
     Let $\mathcal K$ have positive bond dimension and be injective, and let
     $F$ be a physical-sector factorization of $\mathcal K$.  Suppose every
     neighboring operator $\eta^F_{q,h}$ is positive semidefinite.  If the
@@ -1187,8 +1188,8 @@
     % **Scope restriction (physical-sector factorization):** The theorem
     % assumes the factorization F and positivity of every neighboring
     % operator.  CPSV16 Proposition 4to2, lines 1597--1619, starts instead
-    % from a translation-invariant commuting bond.  The missing bridge is
-    % recorded in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+    % from a translation-invariant commuting bond.  The missing non-circular
+    % construction is recorded in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \end{theorem}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Motivation

- follow up the Blueprint Sync review of PR #4661 by using the mathematical description already adopted in the Lean docstring and paper-gap record
- record the existing physical-support SAL result used when saturation is transported through the physical isometry
- keep the scope-restricted theorem aligned with CPSV16 Proposition `4to2`, arXiv:1606.00608, Appendix C.2, lines 1597–1619

## Description

- replace “missing bridge” by “missing non-circular construction” in the restricted theorem's maintainer comment
- add `thm:mpdo_physical_support_restriction_sal` to the theorem's `\uses` dependencies
- leave the Lean theorem, its proof, the source-facing theorem statement, and `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` unchanged

The argument-free `dsimp only` in the merged Lean proof was tested rather than removed: on Lean 4.32 it unfolds `Entropy.QuantumMarkovDecomposition` and `SectorSiteIndex`; deleting it leaves an iff after `convert` and the proof fails.

## Validation

- `lake env lean TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean`
- blueprint source synchronization
- generated `blueprint/lean_decls` and ran `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf` and visual inspection of the affected page
- reader-facing prose, forbidden-token, and diff checks

The local web renderer still has the environment's `pygraphviz._graphviz` import failure, and the central olean cache predates nine declarations merged by #4657. Hosted web and declaration checks are therefore required gates for this draft.

Addresses the post-merge review of #4661.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint edits; no Lean or proof logic changes in this diff.
> 
> **Overview**
> Updates blueprint metadata for **Physical-sector factorization and ZCL imply SAL** so it matches the Lean proof and the documented CPSV16 gap.
> 
> Adds `thm:mpdo_physical_support_restriction_sal` to the theorem’s `\uses` list, naming the existing result used when saturation is carried through the physical-sector isometry. The scope-restriction maintainer comment now says **missing non-circular construction** instead of **missing bridge**, in line with the paper-gap record and Proposition 4to2 (Appendix C.2).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e0deb0830200c648758fc86a329657abfac25e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->