### PR TITLE
feat(MPS/MPDO): prove all-label projector density identity

### DIFF
--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -22,6 +22,7 @@ arbitrary remaining length.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
 * `finSuccArrowEquiv`: separates the first coordinate from a finite tuple.
 * `finAddTwoArrowEquiv`: separates the first two coordinates.
+* `piSigmaEquiv`: distributes a dependent sum pointwise over a dependent function.
 
 ## Main statements
 
@@ -45,6 +46,20 @@ initial coordinates from the remaining tuple.
 
 finite tuples, equivalence, product coordinates
 -/
+
+/-- Distribute a dependent sum pointwise over a dependent function. -/
+def piSigmaEquiv
+    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
+    ((i : ι) → Σ a, β i a) ≃
+      Σ a : (i : ι) → α i, (i : ι) → β i (a i) where
+  toFun x := ⟨fun i ↦ (x i).1, fun i ↦ (x i).2⟩
+  invFun x i := ⟨x.1 i, x.2 i⟩
+  left_inv x := by
+    funext i
+    exact Sigma.eta (x i)
+  right_inv x := by
+    obtain ⟨a, b⟩ := x
+    rfl
 
 /-- The canonical right-associated identification of a three-coordinate
 function with a triple. -/

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -22,7 +22,7 @@ arbitrary remaining length.
 * `finFourArrowEquiv`: identifies a function on `Fin 4` with a right-associated quadruple.
 * `finSuccArrowEquiv`: separates the first coordinate from a finite tuple.
 * `finAddTwoArrowEquiv`: separates the first two coordinates.
-* `piSigmaEquiv`: distributes a dependent sum pointwise over a dependent function.
+* `Equiv.piSigmaEquiv`: distributes a dependent sum pointwise over a dependent function.
 
 ## Main statements
 
@@ -47,6 +47,8 @@ initial coordinates from the remaining tuple.
 finite tuples, equivalence, product coordinates
 -/
 
+namespace Equiv
+
 /-- Distribute a dependent sum pointwise over a dependent function. -/
 def piSigmaEquiv
     {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
@@ -60,6 +62,8 @@ def piSigmaEquiv
   right_inv x := by
     obtain ⟨a, b⟩ := x
     rfl
+
+end Equiv
 
 /-- The canonical right-associated identification of a three-coordinate
 function with a triple. -/

--- a/TNLean/Algebra/FinTupleEquiv.lean
+++ b/TNLean/Algebra/FinTupleEquiv.lean
@@ -9,11 +9,12 @@ import Mathlib.Logic.Equiv.Fin.Basic
 import Mathlib.Tactic.FinCases
 
 /-!
-# Equivalences for finite tuples
+# Equivalences for finite tuples and dependent coordinates
 
-This file records canonical product coordinates for functions on finite index
-types.  It includes right-associated coordinates in lengths three and four,
-and equivalences separating the first one or two coordinates from a tuple of
+This file records product coordinates used for finite tuples and their
+dependent label--fiber descriptions.  It includes a pointwise dependent-sum
+reassociation, right-associated coordinates in lengths three and four, and
+equivalences separating the first one or two coordinates from a tuple of
 arbitrary remaining length.
 
 ## Main definitions
@@ -40,11 +41,13 @@ arbitrary remaining length.
 The fixed-length product coordinates are right-associated and are constructed
 recursively from Mathlib's `finTwoArrowEquiv` using `Fin.consEquiv`.  The
 variable-length equivalences use `Fin.consEquiv` to separate the prescribed
-initial coordinates from the remaining tuple.
+initial coordinates from the remaining tuple.  The pointwise dependent-sum
+equivalence is stated for an arbitrary index type so that finite-chain
+coordinates can reuse it without duplicating the same reassociation.
 
 ## Tags
 
-finite tuples, equivalence, product coordinates
+finite tuples, dependent functions, sigma types, equivalence, product coordinates
 -/
 
 namespace Equiv

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -30,6 +30,8 @@ Extracted from various files for reusability.
   trace form of the Frobenius norm
 - `Matrix.trace_conjTranspose_mul_self_kronecker`: Hilbert--Schmidt trace-form
   multiplicativity for Kronecker products
+- `Matrix.list_prod_smul_ofFn`: pull sitewise scalar factors out of an ordered
+  finite matrix product
 - `Matrix.piProduct_mulVec_pureTensor`: a dependent product of matrices acts
   componentwise on a pure tensor
 - `Matrix.reindex_mulVec`: matrix reindexing intertwines matrix--vector action
@@ -63,6 +65,20 @@ Extracted from various files for reusability.
 open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius MatrixOrder
 
 namespace Matrix
+
+/-! ## Ordered finite matrix products -/
+
+/-- Pull sitewise scalar factors out of an ordered finite matrix product. -/
+theorem list_prod_smul_ofFn {n : Type*} [Fintype n] [DecidableEq n]
+    {N : ℕ} (c : Fin N → ℂ) (A : Fin N → Matrix n n ℂ) :
+    (List.ofFn fun i : Fin N ↦ c i • A i).prod =
+      (∏ i : Fin N, c i) • (List.ofFn A).prod := by
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      simp only [List.ofFn_succ, List.prod_cons, ih, Fin.prod_univ_succ,
+        Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+      rw [mul_comm (c 0)]
 
 /-! ## Hermitian matrix action -/
 

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -206,6 +206,7 @@ import TNLean.MPS.MPDO.SourceBNTBlocking
 import TNLean.MPS.MPDO.SourceZCLMarginal
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
+import TNLean.MPS.MPDO.TopologicalProjectorDensity
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.TopologicalProjectors
 import TNLean.MPS.MPDO.TwoSiteVerticalCanonicalForm

--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.CommutingBondEtaDecomposition
 import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 
@@ -31,20 +32,6 @@ abbrev EtaSiteIndex (K : ℕ) (dl dr : Fin K → ℕ) :=
 /-- The neighboring index carried by the cyclic edge from sector \(q\) to sector \(h\). -/
 abbrev EtaEdgeIndex {K : ℕ} (dl dr : Fin K → ℕ) (q h : Fin K) :=
   Fin (dr q) × Fin (dl h)
-
-/-- Distribute a dependent sum pointwise over a finite family. -/
-private def etaPiSigmaEquiv
-    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
-    ((i : ι) → Σ a, β i a) ≃
-      Σ a : (i : ι) → α i, (i : ι) → β i (a i) where
-  toFun x := ⟨fun i ↦ (x i).1, fun i ↦ (x i).2⟩
-  invFun x i := ⟨x.1 i, x.2 i⟩
-  left_inv x := by
-    funext i
-    exact Sigma.eta (x i)
-  right_inv x := by
-    obtain ⟨a, b⟩ := x
-    rfl
 
 /-- For a fixed cyclic sector configuration, regroup the site factors
 \((R_n,L_n)\) into the edge factors \((R_n,L_{n+1})\). -/
@@ -87,7 +74,7 @@ def etaCyclicEdgeEquiv {K N d : ℕ} [NeZero N] (dl dr : Fin K → ℕ)
     (Fin N → Fin d) ≃
       Σ k : Fin N → Fin K,
         (n : Fin N) → EtaEdgeIndex dl dr (k n) (k (n + 1)) :=
-  ((Equiv.piCongrRight fun _ : Fin N ↦ e.symm).trans etaPiSigmaEquiv).trans <|
+  ((Equiv.piCongrRight fun _ : Fin N ↦ e.symm).trans piSigmaEquiv).trans <|
     Equiv.sigmaCongrRight fun k ↦ etaFixedSectorCyclicEdgeEquiv dl dr k
 
 @[simp] theorem etaCyclicEdgeEquiv_symm_apply {K N d : ℕ} [NeZero N]
@@ -99,7 +86,7 @@ def etaCyclicEdgeEquiv {K N d : ℕ} [NeZero N] (dl dr : Fin K → ℕ)
       e ⟨k n, (etaFixedSectorCyclicEdgeEquiv dl dr k).symm x n⟩ := by
   apply e.symm.injective
   simp [etaCyclicEdgeEquiv, Equiv.piCongrRight, Equiv.sigmaCongrRight,
-    etaPiSigmaEquiv]
+    piSigmaEquiv]
 
 end Matrix
 

--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
@@ -74,7 +74,7 @@ def etaCyclicEdgeEquiv {K N d : ℕ} [NeZero N] (dl dr : Fin K → ℕ)
     (Fin N → Fin d) ≃
       Σ k : Fin N → Fin K,
         (n : Fin N) → EtaEdgeIndex dl dr (k n) (k (n + 1)) :=
-  ((Equiv.piCongrRight fun _ : Fin N ↦ e.symm).trans piSigmaEquiv).trans <|
+  ((Equiv.piCongrRight fun _ : Fin N ↦ e.symm).trans Equiv.piSigmaEquiv).trans <|
     Equiv.sigmaCongrRight fun k ↦ etaFixedSectorCyclicEdgeEquiv dl dr k
 
 @[simp] theorem etaCyclicEdgeEquiv_symm_apply {K N d : ℕ} [NeZero N]
@@ -86,7 +86,7 @@ def etaCyclicEdgeEquiv {K N d : ℕ} [NeZero N] (dl dr : Fin K → ℕ)
       e ⟨k n, (etaFixedSectorCyclicEdgeEquiv dl dr k).symm x n⟩ := by
   apply e.symm.injective
   simp [etaCyclicEdgeEquiv, Equiv.piCongrRight, Equiv.sigmaCongrRight,
-    piSigmaEquiv]
+    Equiv.piSigmaEquiv]
 
 end Matrix
 

--- a/TNLean/MPS/MPDO/PhysicalSectorChainDecomposition.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorChainDecomposition.lean
@@ -67,7 +67,7 @@ physical chain with the direct sum of its sector fibers.
 Source: arXiv:1606.00608, Appendix C.2, lines 1435--1450. -/
 def sectorChainEquiv (F : PhysicalSectorFactorization K) (N : ℕ) :
     (Fin N → Fin d) ≃ SectorChainIndex F N :=
-  (Equiv.piCongrRight fun _ : Fin N ↦ F.sectorEquiv).trans piSigmaEquiv
+  (Equiv.piCongrRight fun _ : Fin N ↦ F.sectorEquiv).trans Equiv.piSigmaEquiv
 
 /-- The cyclic product of neighboring contractions in one sector fiber. Its
 factor at site `n` acts on the right factor of sector `k n` and the left

--- a/TNLean/MPS/MPDO/PhysicalSectorChainDecomposition.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorChainDecomposition.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
 import TNLean.MPS.MPDO.SectorEtaOperator
 
@@ -59,19 +60,6 @@ with an index in the corresponding left--right fiber.
 Source: arXiv:1606.00608, Appendix C.2, lines 1435--1450. -/
 abbrev SectorChainIndex (F : PhysicalSectorFactorization K) (N : ℕ) :=
   Σ k : Fin N → Fin F.sectorCount, SectorChainFiber F k
-
-private def piSigmaEquiv
-    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
-    ((i : ι) → Σ a, β i a) ≃
-      Σ a : (i : ι) → α i, (i : ι) → β i (a i) where
-  toFun x := ⟨fun i ↦ (x i).1, fun i ↦ (x i).2⟩
-  invFun x i := ⟨x.1 i, x.2 i⟩
-  left_inv x := by
-    funext i
-    exact Sigma.eta (x i)
-  right_inv x := by
-    obtain ⟨a, b⟩ := x
-    rfl
 
 /-- Applying the one-site sector decomposition at every site identifies the
 physical chain with the direct sum of its sector fibers.

--- a/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductTransport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.MPDO.PhysicalSectorProductRealization
 import TNLean.MPS.MPDO.PhysicalSectorBondTwoSite
 
@@ -113,18 +114,6 @@ private theorem list_prod_sum_ofFn {a n : Type*} [Fintype a]
       rw [Fintype.sum_prod_type] at h
       exact h
 
-private theorem list_prod_smul_ofFn {n : Type*} [Fintype n]
-    [DecidableEq n] {N : ℕ} (c : Fin N → ℂ)
-    (A : Fin N → Matrix n n ℂ) :
-    (List.ofFn fun i : Fin N ↦ c i • A i).prod =
-      (∏ i : Fin N, c i) • (List.ofFn A).prod := by
-  induction N with
-  | zero => simp
-  | succ N ih =>
-      simp only [List.ofFn_succ, List.prod_cons, ih, Fin.prod_univ_succ,
-        Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-      rw [mul_comm (c 0)]
-
 private def braKetFunctionsEquiv {i a b : Type*} :
     ((i → b) × (i → a)) ≃ (i → a × b) :=
   (Equiv.prodComm _ _).trans (Equiv.arrowProdEquivProdArrow i (fun _ ↦ a) (fun _ ↦ b)).symm
@@ -143,7 +132,7 @@ private theorem evalWord_changePhysicalBasis_ofFn {e : ℕ}
   rw [list_prod_sum_ofFn]
   apply Finset.sum_congr rfl
   intro x _
-  rw [list_prod_smul_ofFn, MPOTensor.evalWord_ofFn]
+  rw [Matrix.list_prod_smul_ofFn, MPOTensor.evalWord_ofFn]
 
 /-- The length-`N` MPO transforms by the sitewise physical coordinate
 matrix.

--- a/TNLean/MPS/MPDO/SectorEtaOperator.lean
+++ b/TNLean/MPS/MPDO/SectorEtaOperator.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.SectorEtaContraction
 
 /-!
@@ -45,19 +46,6 @@ together with one physical index in its corresponding fiber.
 Source: arXiv:1606.00608, Appendix C.2, lines 1434--1464. -/
 abbrev SectorChainIndex (hη : EtaStructure ρ) (N : ℕ) :=
   Σ k : Fin N → Fin hη.m, SectorFiber hη k
-
-private def piSigmaEquiv
-    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
-    ((i : ι) → Σ a, β i a) ≃
-      Σ a : (i : ι) → α i, (i : ι) → β i (a i) where
-  toFun x := ⟨fun i => (x i).1, fun i => (x i).2⟩
-  invFun x i := ⟨x.1 i, x.2 i⟩
-  left_inv x := by
-    funext i
-    exact Sigma.eta (x i)
-  right_inv x := by
-    obtain ⟨a, b⟩ := x
-    rfl
 
 /-- The sitewise Hayashi decomposition identifies physical chain indices with
 a sector configuration and an index in the corresponding sector fiber.

--- a/TNLean/MPS/MPDO/SectorEtaOperator.lean
+++ b/TNLean/MPS/MPDO/SectorEtaOperator.lean
@@ -54,7 +54,7 @@ Source: arXiv:1606.00608, Appendix C.2, lines 1434--1464. -/
 def sectorChainEquiv (hη : EtaStructure ρ) (N : ℕ) :
     (Fin N → Fin d) ≃ SectorChainIndex hη N :=
   (Equiv.piCongrRight fun _ : Fin N => hη.decompB).trans
-    piSigmaEquiv
+    Equiv.piSigmaEquiv
 
 /-- Forming the congruence $U\kappa_{\beta,\alpha}U^\dagger$ on every local
 MPO matrix leaves the horizontal bond space unchanged. When $U$ is unitary,

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 
 /-!
@@ -117,18 +118,6 @@ private theorem list_prod_sum_ofFn {a n : Type*} [Fintype a]
       rw [Fintype.sum_prod_type] at h
       exact h
 
-private theorem list_prod_smul_ofFn {n : Type*} [Fintype n]
-    [DecidableEq n] {N : ℕ} (c : Fin N → ℂ)
-    (A : Fin N → Matrix n n ℂ) :
-    (List.ofFn fun i : Fin N ↦ c i • A i).prod =
-      (∏ i : Fin N, c i) • (List.ofFn A).prod := by
-  induction N with
-  | zero => simp
-  | succ N ih =>
-      simp only [List.ofFn_succ, List.prod_cons, ih, Fin.prod_univ_succ,
-        Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-      rw [mul_comm (c 0)]
-
 private def braKetFunctionsEquiv {i a b : Type*} :
     ((i → b) × (i → a)) ≃ (i → a × b) :=
   (Equiv.prodComm _ _).trans
@@ -150,7 +139,7 @@ theorem evalWord_changePhysicalBasis_ofFn
   rw [list_prod_sum_ofFn]
   apply Finset.sum_congr rfl
   intro x _
-  rw [list_prod_smul_ofFn, evalWord_ofFn]
+  rw [Matrix.list_prod_smul_ofFn, evalWord_ofFn]
 
 /-- Acting on every site by `V` sends the MPO of `M` to the MPO obtained by
 changing every local physical matrix by `V`.

--- a/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
@@ -1,0 +1,487 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
+import TNLean.MPS.MPDO.TopologicalProjectorRecursion
+import TNLean.MPS.MPDO.VerticalProductPairBlocks
+
+/-!
+# The all-label topological-projector density identity
+
+This file sums the fixed-label recursion over every vertical-canonical label and every
+multiplicity copy.  The diagonal coefficient is the corresponding entry of
+`μ^{⊗ (N + 1)}`.  The second factor reconstructs each fixed-label transfer from the recursive
+operator `Q`.
+
+The result is the density identity at line 999 of arXiv:1606.00608 in the direct-sum
+coordinates selected by a `BNTFusionTensorClause`.  It does not prove the following
+commutator, the terminal spectral refinement, or the commuting-Hamiltonian theorem.
+
+## Main result
+
+* `reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul`:
+  the positive-length physical density, in the retained vertical coordinates, is
+  `μ^{⊗ (N + 1)}` times the reconstructed recursive operator.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Theorem IV.13 and
+  lines 986--999.
+-/
+
+open scoped Matrix BigOperators
+open MPOTensor.BNTFusionCoisometryFamily
+open MPOTensor.PhysicalSectorFactorization
+
+namespace MPOTensor.BNTFusionTensorClause
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- A vertical-canonical label together with one copy in its multiplicity space.
+
+Source: arXiv:1606.00608, the block label and diagonal entry of `μ` at line 999. -/
+abbrev TopologicalDensityLabel (H : BNTFusionTensorClause M) :=
+  (α : Fin H.labelCount) × Fin (H.multiplicity α)
+
+/-- A choice of a vertical-canonical label and multiplicity copy at every site.
+
+Source: arXiv:1606.00608, the label sectors of `μ^{⊗ N}` at line 999. -/
+abbrev TopologicalDensitySector (H : BNTFusionTensorClause M) (N : ℕ) :=
+  Fin (N + 1) → TopologicalDensityLabel H
+
+/-- The reverse list of labels appended to the initial label in the recursive convention.
+
+Source: arXiv:1606.00608, recursive application of equation `Ualphabeta` at line 999. -/
+def topologicalFusionPrevious (H : BNTFusionTensorClause M) :
+    {N : ℕ} → TopologicalDensitySector H N → List (Fin H.labelCount)
+  | 0, _ => []
+  | N + 1, q =>
+      (q (Fin.last (N + 1))).1 ::
+        topologicalFusionPrevious H (fun n : Fin (N + 1) => q n.castSucc)
+
+/-- The first label in the recursive prefix convention. -/
+def topologicalFusionInitial (H : BNTFusionTensorClause M) :
+    {N : ℕ} → TopologicalDensitySector H N → Fin H.labelCount
+  | 0, q => (q 0).1
+  | N + 1, q =>
+      topologicalFusionInitial H (fun n : Fin (N + 1) => q n.castSucc)
+
+/-- The sitewise product-bond space for one all-label sector. -/
+abbrev TopologicalSectorBond (H : BNTFusionTensorClause M) {N : ℕ}
+    (q : TopologicalDensitySector H N) :=
+  (n : Fin (N + 1)) → Fin (H.bondDim (q n).1)
+
+private def piSnocEquiv {N : ℕ} {α : Fin (N + 1) → Type*} :
+    ((n : Fin (N + 1)) → α n) ≃
+      ((n : Fin N) → α n.castSucc) × α (Fin.last N) where
+  toFun x := ⟨Fin.init x, x (Fin.last N)⟩
+  invFun x := Fin.snoc x.1 x.2
+  left_inv x := Fin.snoc_init_self x
+  right_inv x := by
+    apply Prod.ext
+    · exact Fin.init_snoc x.2 x.1
+    · exact Fin.snoc_last x.2 x.1
+
+/-- The bond dimension stored on the tensor-attached clause is the bond dimension of its
+fusion family. -/
+private def attachedBondEquiv (H : BNTFusionTensorClause M) (α : Fin H.labelCount) :
+    Fin (H.bondDim α) ≃ Fin (H.toBNTFusionCoisometryFamily.bondDim α) :=
+  finCongr rfl
+
+@[simp] private theorem attachedBondEquiv_apply
+    (H : BNTFusionTensorClause M) (α : Fin H.labelCount) (x : Fin (H.bondDim α)) :
+    attachedBondEquiv H α x = x :=
+  rfl
+
+@[simp] private theorem attachedFusionTensor_apply
+    (H : BNTFusionTensorClause M) (α : Fin H.labelCount) (a b : Fin D)
+    (x y : Fin (H.bondDim α)) :
+    H.toBNTFusionCoisometryFamily.tensor α a b x y =
+      H.tensor α (finProdFinEquiv (a, b)) x y :=
+  rfl
+
+/-- The canonical left-associated product-bond coordinate used by the fusion recursion. -/
+def fusionChainBondEquiv (H : BNTFusionTensorClause M) :
+    {N : ℕ} → (q : TopologicalDensitySector H N) →
+      TopologicalSectorBond H q ≃
+        Fin (BNTFusionCoisometryFamily.fusionChainBondDim
+          H.toBNTFusionCoisometryFamily (topologicalFusionInitial H q)
+            (topologicalFusionPrevious H q))
+  | 0, q =>
+      (piSnocEquiv.trans (Equiv.uniqueProd _ _)).trans
+        (finCongr (by
+          simp [topologicalFusionInitial, topologicalFusionPrevious,
+            BNTFusionCoisometryFamily.fusionChainBondDim]
+          rfl))
+  | N + 1, q =>
+      piSnocEquiv.trans <|
+        (((fusionChainBondEquiv H
+          (fun n : Fin (N + 1) => q n.castSucc)).prodCongr
+            (attachedBondEquiv H (q (Fin.last (N + 1))).1)).trans finProdFinEquiv)
+
+@[simp] private theorem fusionChainBondEquiv_zero_apply
+    (H : BNTFusionTensorClause M) (q : TopologicalDensitySector H 0)
+    (x : TopologicalSectorBond H q) :
+    fusionChainBondEquiv H q x = x 0 := by
+  apply Fin.ext
+  rfl
+
+@[simp] private theorem finProdFinEquiv_symm_fusionChainBondEquiv_succ
+    (H : BNTFusionTensorClause M) {N : ℕ}
+    (q : TopologicalDensitySector H (N + 1)) (x : TopologicalSectorBond H q) :
+    finProdFinEquiv.symm (fusionChainBondEquiv H q x) =
+      (fusionChainBondEquiv H (fun n : Fin (N + 1) => q n.castSucc) (Fin.init x),
+        attachedBondEquiv H (q (Fin.last (N + 1))).1 (x (Fin.last (N + 1)))) := by
+  change finProdFinEquiv.symm
+      (finProdFinEquiv
+        (fusionChainBondEquiv H (fun n : Fin (N + 1) => q n.castSucc) (Fin.init x),
+          attachedBondEquiv H (q (Fin.last (N + 1))).1
+            (x (Fin.last (N + 1))))) = _
+  exact finProdFinEquiv.symm_apply_apply _
+
+@[simp] private theorem fusionChainBondEquiv_succ_apply
+    (H : BNTFusionTensorClause M) {N : ℕ}
+    (q : TopologicalDensitySector H (N + 1)) (x : TopologicalSectorBond H q) :
+    fusionChainBondEquiv H q x =
+      finProdFinEquiv
+        (fusionChainBondEquiv H (fun n : Fin (N + 1) => q n.castSucc) (Fin.init x),
+          attachedBondEquiv H (q (Fin.last (N + 1))).1 (x (Fin.last (N + 1)))) :=
+  rfl
+
+private def piSigmaEquiv
+    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
+    ((i : ι) → (a : α i) × β i a) ≃
+      (a : (i : ι) → α i) × ((i : ι) → β i (a i)) where
+  toFun x := ⟨fun i => (x i).1, fun i => (x i).2⟩
+  invFun x i := ⟨x.1 i, x.2 i⟩
+  left_inv x := by
+    funext i
+    exact Sigma.eta (x i)
+  right_inv x := by
+    obtain ⟨a, b⟩ := x
+    rfl
+
+/-- Apply the retained vertical coordinate change at every site and group the result by its
+label and multiplicity sector. -/
+def topologicalDensityChainEquiv (H : BNTFusionTensorClause M) (N : ℕ) :
+    (Fin (N + 1) →
+      Fin (∑ q : Fin (∑ α : Fin H.labelCount, H.multiplicity α),
+        verticalCopyDim H.bondDim H.multiplicity q)) ≃
+      (q : TopologicalDensitySector H N) × TopologicalSectorBond H q :=
+  (Equiv.piCongrRight fun _ : Fin (N + 1) =>
+    verticalCopyCoordinateEquiv H.bondDim H.multiplicity).trans piSigmaEquiv
+
+/-- The diagonal entry of `μ^{⊗ (N + 1)}` selected by a sector.
+
+Source: arXiv:1606.00608, the tensor power of `μ` at line 999. -/
+noncomputable def topologicalSectorWeight (H : BNTFusionTensorClause M) {N : ℕ}
+    (q : TopologicalDensitySector H N) : ℂ :=
+  ∏ n, H.weight (q n).1 (q n).2
+
+/-- In one retained copy, the physically changed tensor is the corresponding weighted BNT
+letter. -/
+private theorem changePhysicalBasis_verticalCopy_same
+    (H : BNTFusionTensorClause M) (q : TopologicalDensityLabel H)
+    (x y : Fin (H.bondDim q.1)) :
+    changePhysicalBasis H.verticalCoisometry M
+        ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨q, x⟩)
+        ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨q, y⟩) =
+      H.weight q.1 q.2 •
+        fun a b => H.tensor q.1 (finProdFinEquiv (a, b)) x y := by
+  ext a b
+  have h := congrFun (congrFun (H.forward (finProdFinEquiv (a, b)))
+    ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨q, x⟩))
+    ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨q, y⟩)
+  have hv :
+      verticalTensor M (finProdFinEquiv (a, b)) = physicalSlice M a b := by
+    ext i j
+    exact verticalTensor_finProdFinEquiv M a b i j
+  rw [hv] at h
+  rw [verticalAssembledTensor_reindex_copyCoordinates] at h
+  simpa only [changePhysicalBasis, Matrix.reindex_apply,
+    Matrix.submatrix_apply, Equiv.symm_symm, Equiv.apply_symm_apply,
+    Matrix.blockDiagonal'_apply_eq, Matrix.smul_apply, Pi.smul_apply] using h
+
+/-- Distinct retained copies do not mix under the physical coordinate change. -/
+private theorem changePhysicalBasis_verticalCopy_ne
+    (H : BNTFusionTensorClause M) {q r : TopologicalDensityLabel H}
+    (hqr : q ≠ r) (x : Fin (H.bondDim q.1)) (y : Fin (H.bondDim r.1)) :
+    changePhysicalBasis H.verticalCoisometry M
+        ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨q, x⟩)
+        ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨r, y⟩) = 0 := by
+  ext a b
+  have h := congrFun (congrFun (H.forward (finProdFinEquiv (a, b)))
+    ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨q, x⟩))
+    ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨r, y⟩)
+  have hv :
+      verticalTensor M (finProdFinEquiv (a, b)) = physicalSlice M a b := by
+    ext i j
+    exact verticalTensor_finProdFinEquiv M a b i j
+  rw [hv] at h
+  rw [verticalAssembledTensor_reindex_copyCoordinates] at h
+  simpa only [changePhysicalBasis, Matrix.reindex_apply,
+    Matrix.submatrix_apply, Equiv.symm_symm, Equiv.apply_symm_apply,
+    Matrix.blockDiagonal'_apply_ne _ _ _ hqr, Matrix.zero_apply] using h
+
+/-- The retained vertical coordinate change reconstructs the original tensor when followed
+by its adjoint.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 943--951. -/
+theorem changePhysicalBasis_conjTranspose_verticalCoisometry
+    (H : BNTFusionTensorClause M) :
+    changePhysicalBasis H.verticalCoisometryᴴ
+        (changePhysicalBasis H.verticalCoisometry M) = M := by
+  ext i j a b
+  simp only [changePhysicalBasis, Matrix.conjTranspose_conjTranspose]
+  change
+    (H.verticalCoisometryᴴ *
+        (H.verticalCoisometry * physicalSlice M a b * H.verticalCoisometryᴴ) *
+        H.verticalCoisometry) i j =
+      M i j a b
+  have hv :
+      verticalTensor M (finProdFinEquiv (a, b)) = physicalSlice M a b := by
+    ext u v
+    exact verticalTensor_finProdFinEquiv M a b u v
+  rw [← hv, H.forward]
+  have h := congrFun (congrFun (H.reconstruction (finProdFinEquiv (a, b))) i) j
+  simpa only [verticalTensor_finProdFinEquiv] using h.symm
+
+/-- The horizontal matrix obtained by fixing the two simple-bond coordinates at one site. -/
+private def topologicalBondSlice (H : BNTFusionTensorClause M) {N : ℕ}
+    (q : TopologicalDensitySector H N) (x y : TopologicalSectorBond H q)
+    (n : Fin (N + 1)) : Matrix (Fin D) (Fin D) ℂ :=
+  fun a b => H.tensor (q n).1 (finProdFinEquiv (a, b)) (x n) (y n)
+
+/-- A fixed entry of the left-associated fusion tensor is the ordered product of the
+corresponding horizontal slices. -/
+private theorem fusionChainTensor_apply_fusionChainBondEquiv
+    (H : BNTFusionTensorClause M) {N : ℕ}
+    (q : TopologicalDensitySector H N) (x y : TopologicalSectorBond H q)
+    (a b : Fin D) :
+    BNTFusionCoisometryFamily.fusionChainTensor H.toBNTFusionCoisometryFamily
+          (topologicalFusionInitial H q) (topologicalFusionPrevious H q) a b
+          (fusionChainBondEquiv H q x) (fusionChainBondEquiv H q y) =
+      (List.ofFn fun n : Fin (N + 1) => topologicalBondSlice H q x y n).prod a b := by
+  induction N generalizing a b with
+  | zero =>
+      rw [fusionChainBondEquiv_zero_apply, fusionChainBondEquiv_zero_apply]
+      simp [topologicalFusionInitial, topologicalFusionPrevious,
+        BNTFusionCoisometryFamily.fusionChainTensor, topologicalBondSlice,
+        BNTFusionTensorClause.toBNTFusionCoisometryFamily]
+  | succ N ih =>
+      rw [List.ofFn_succ', List.prod_concat]
+      rw [fusionChainBondEquiv_succ_apply H q x,
+        fusionChainBondEquiv_succ_apply H q y]
+      simp only [topologicalFusionInitial, topologicalFusionPrevious,
+        BNTFusionCoisometryFamily.fusionChainTensor]
+      simp only [mulTensor_apply, Matrix.submatrix_apply]
+      rw [Equiv.symm_apply_apply, Equiv.symm_apply_apply]
+      rw [attachedBondEquiv_apply, attachedBondEquiv_apply]
+      rw [Matrix.sum_apply, Matrix.mul_apply]
+      simp only [Matrix.kroneckerMap_apply,
+        attachedFusionTensor_apply]
+      apply Finset.sum_congr rfl
+      intro j _
+      rw [ih (fun n : Fin (N + 1) => q n.castSucc)
+        (Fin.init x) (Fin.init y)]
+      rfl
+
+/-- The physical-trace transfer of a label sequence is the trace of its ordered horizontal
+slice product. -/
+private theorem reindex_physTraceTransfer_fusionChainTensor_apply
+    (H : BNTFusionTensorClause M) {N : ℕ}
+    (q : TopologicalDensitySector H N) (x y : TopologicalSectorBond H q) :
+    Matrix.reindex (fusionChainBondEquiv H q).symm
+          (fusionChainBondEquiv H q).symm
+          (physTraceTransfer
+            (BNTFusionCoisometryFamily.fusionChainTensor
+              H.toBNTFusionCoisometryFamily
+              (topologicalFusionInitial H q) (topologicalFusionPrevious H q))) x y =
+      Matrix.trace
+        (List.ofFn fun n : Fin (N + 1) => topologicalBondSlice H q x y n).prod := by
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Equiv.symm_symm,
+    physTraceTransfer, Matrix.sum_apply, Matrix.trace]
+  apply Finset.sum_congr rfl
+  intro a _
+  exact fusionChainTensor_apply_fusionChainBondEquiv H q x y a a
+
+private theorem prod_ofFn_smul_matrix {n N : ℕ}
+    (c : Fin N → ℂ) (A : Fin N → Matrix (Fin n) (Fin n) ℂ) :
+    (List.ofFn fun i => c i • A i).prod =
+      (∏ i, c i) • (List.ofFn A).prod := by
+  induction N with
+  | zero =>
+      simp
+  | succ N ih =>
+      rw [List.ofFn_succ, List.prod_cons, List.ofFn_succ, List.prod_cons,
+        Fin.prod_univ_succ, ih]
+      rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+
+@[simp] theorem topologicalDensityChainEquiv_symm_apply
+    (H : BNTFusionTensorClause M) (N : ℕ)
+    (q : TopologicalDensitySector H N) (x : TopologicalSectorBond H q)
+    (n : Fin (N + 1)) :
+    (topologicalDensityChainEquiv H N).symm ⟨q, x⟩ n =
+      (verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨q n, x n⟩ :=
+  rfl
+
+/-- The vertical weight `μ^{⊗ (N + 1)}` in all-label direct-sum coordinates.
+
+Source: arXiv:1606.00608, the first factor of the density identity at line 999. -/
+noncomputable def verticalWeightTensorPower (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix ((q : TopologicalDensitySector H N) × TopologicalSectorBond H q)
+      ((q : TopologicalDensitySector H N) × TopologicalSectorBond H q) ℂ :=
+  Matrix.blockDiagonal' fun q =>
+    topologicalSectorWeight H q •
+      (1 : Matrix (TopologicalSectorBond H q) (TopologicalSectorBond H q) ℂ)
+
+/-- The direct sum of the reconstructed recursive operators over all label sectors.
+
+The formal coisometry is the adjoint of the source circuit convention: its adjoint followed
+by `Q` and then the coisometry is the factor
+`\widetilde U Q\widetilde U^\dagger` at line 999 of arXiv:1606.00608.
+-/
+noncomputable def topologicalProjectorFactor (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix ((q : TopologicalDensitySector H N) × TopologicalSectorBond H q)
+      ((q : TopologicalDensitySector H N) × TopologicalSectorBond H q) ℂ :=
+  Matrix.blockDiagonal' fun q =>
+    let Fam := H.toBNTFusionCoisometryFamily
+    let W := BNTFusionCoisometryFamily.sequentialFusionCoisometry
+      Fam (topologicalFusionInitial H q) (topologicalFusionPrevious H q)
+    Matrix.reindex (fusionChainBondEquiv H q).symm
+      (fusionChainBondEquiv H q).symm <|
+        Wᴴ *
+          BNTFusionCoisometryFamily.recursiveProjectorQ Fam
+            (fun γ => physTraceTransfer (Fam.tensor γ))
+            (topologicalFusionInitial H q) (topologicalFusionPrevious H q) *
+          W
+
+/-- The all-label density in vertical-canonical direct-sum coordinates.
+
+Each sector is its `μ^{⊗ (N + 1)}` coefficient times the physical-trace transfer of the
+corresponding left-associated product tensor.
+
+Source: arXiv:1606.00608, the density identity at line 999. -/
+noncomputable def allLabelDensity (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix ((q : TopologicalDensitySector H N) × TopologicalSectorBond H q)
+      ((q : TopologicalDensitySector H N) × TopologicalSectorBond H q) ℂ :=
+  Matrix.blockDiagonal' fun q =>
+    let Fam := H.toBNTFusionCoisometryFamily
+    topologicalSectorWeight H q •
+      (Matrix.reindex (fusionChainBondEquiv H q).symm
+        (fusionChainBondEquiv H q).symm <|
+          physTraceTransfer
+            (BNTFusionCoisometryFamily.fusionChainTensor
+              Fam (topologicalFusionInitial H q) (topologicalFusionPrevious H q)))
+
+/-- Applying the vertical coisometry at every site identifies the physical density operator
+of the original tensor with the all-label density.
+
+Source: arXiv:1606.00608, Proposition 4.13 and Theorem IV.13, lines 943--951 and
+986--999. -/
+theorem reindex_mpo_changePhysicalBasis_eq_allLabelDensity
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix.reindex (topologicalDensityChainEquiv H N)
+        (topologicalDensityChainEquiv H N)
+        (mpo (changePhysicalBasis H.verticalCoisometry M) (N + 1)) =
+      allLabelDensity H N := by
+  classical
+  ext ⟨q, x⟩ ⟨r, y⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
+  by_cases hqr : q = r
+  · subst r
+    rw [mpo_apply, mpoMatrixEntry, evalWord_ofFn]
+    simp_rw [topologicalDensityChainEquiv_symm_apply]
+    have hlocal : ∀ i : Fin (N + 1),
+        changePhysicalBasis H.verticalCoisometry M
+            ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm
+              ⟨q i, x i⟩)
+            ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm
+              ⟨q i, y i⟩) =
+          H.weight (q i).1 (q i).2 • topologicalBondSlice H q x y i := by
+      intro i
+      change
+        changePhysicalBasis H.verticalCoisometry M
+            ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm
+              ⟨q i, x i⟩)
+            ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm
+              ⟨q i, y i⟩) =
+          H.weight (q i).1 (q i).2 •
+            (fun a b =>
+              H.tensor (q i).1 (finProdFinEquiv (a, b)) (x i) (y i))
+      exact changePhysicalBasis_verticalCopy_same H (q i) (x i) (y i)
+    simp_rw [hlocal]
+    rw [prod_ofFn_smul_matrix, Matrix.trace_smul]
+    unfold allLabelDensity
+    rw [Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.smul_apply, smul_eq_mul, topologicalSectorWeight]
+    rw [reindex_physTraceTransfer_fusionChainTensor_apply]
+  · unfold allLabelDensity
+    rw [Matrix.blockDiagonal'_apply_ne _ _ _ hqr]
+    have hsite : ∃ n, q n ≠ r n := by
+      by_contra h
+      apply hqr
+      funext n
+      exact not_ne_iff.mp (not_exists.mp h n)
+    obtain ⟨n, hn⟩ := hsite
+    rw [mpo_apply, mpoMatrixEntry, evalWord_ofFn]
+    have hzero :
+        changePhysicalBasis H.verticalCoisometry M
+            ((topologicalDensityChainEquiv H N).symm ⟨q, x⟩ n)
+            ((topologicalDensityChainEquiv H N).symm ⟨r, y⟩ n) = 0 := by
+      rw [topologicalDensityChainEquiv_symm_apply,
+        topologicalDensityChainEquiv_symm_apply]
+      exact changePhysicalBasis_verticalCopy_ne H hn (x n) (y n)
+    have hmem :
+        (0 : Matrix (Fin D) (Fin D) ℂ) ∈
+          List.ofFn (fun i : Fin (N + 1) =>
+            changePhysicalBasis H.verticalCoisometry M
+              ((topologicalDensityChainEquiv H N).symm ⟨q, x⟩ i)
+              ((topologicalDensityChainEquiv H N).symm ⟨r, y⟩ i)) :=
+      List.mem_ofFn.mpr ⟨n, hzero⟩
+    rw [List.prod_eq_zero hmem, Matrix.trace_zero]
+
+/-- The all-label vertical-canonical density is the tensor-power weight times the
+topological-projector factor.
+
+Source: arXiv:1606.00608, the identity
+`(μ^{⊗ N}) \widetilde U Q \widetilde U^\dagger` at line 999.
+
+**Scope restriction (direct-sum coordinates):** This theorem proves the density identity
+after the vertical-canonical coordinate change encoded by `BNTFusionTensorClause`.  The
+source commutator at lines 1000--1002 and the spectral refinement beginning at line 1010
+remain separate statements, as recorded in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem allLabelDensity_eq_verticalWeightTensorPower_mul_topologicalProjectorFactor
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    allLabelDensity H N =
+      verticalWeightTensorPower H N * topologicalProjectorFactor H N := by
+  unfold allLabelDensity verticalWeightTensorPower topologicalProjectorFactor
+  rw [← Matrix.blockDiagonal'_mul]
+  apply congrArg Matrix.blockDiagonal'
+  funext q
+  simp only [Matrix.smul_mul, Matrix.one_mul]
+  rw [conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_physTrace_mul]
+
+/-- The positive-length physical density operator, after the local vertical coordinate
+change, is `μ^{⊗ (N + 1)}` times the reconstructed recursive operator.
+
+Source: arXiv:1606.00608, the locally unitarily equivalent density
+`(μ^{⊗ N}) \widetilde U Q \widetilde U^\dagger` at line 999.
+
+**Scope restriction (vertical direct-sum coordinates):** The equality is stated after the
+sitewise coordinate equivalence induced by the retained-row vertical coisometry.  It does
+not assert the commutator at lines 1000--1002 or the spectral refinement beginning at
+line 1010; see `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix.reindex (topologicalDensityChainEquiv H N)
+        (topologicalDensityChainEquiv H N)
+        (mpo (changePhysicalBasis H.verticalCoisometry M) (N + 1)) =
+      verticalWeightTensorPower H N * topologicalProjectorFactor H N := by
+  rw [reindex_mpo_changePhysicalBasis_eq_allLabelDensity]
+  exact allLabelDensity_eq_verticalWeightTensorPower_mul_topologicalProjectorFactor H N
+
+end MPOTensor.BNTFusionTensorClause

--- a/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.VerticalProductPairBlocks
@@ -295,18 +296,6 @@ private theorem reindex_physTraceTransfer_fusionChainTensor_apply
   intro a _
   exact fusionChainTensor_apply_fusionChainBondEquiv H q x y a a
 
-private theorem prod_ofFn_smul_matrix {n N : ℕ}
-    (c : Fin N → ℂ) (A : Fin N → Matrix (Fin n) (Fin n) ℂ) :
-    (List.ofFn fun i => c i • A i).prod =
-      (∏ i, c i) • (List.ofFn A).prod := by
-  induction N with
-  | zero =>
-      simp
-  | succ N ih =>
-      rw [List.ofFn_succ, List.prod_cons, List.ofFn_succ, List.prod_cons,
-        Fin.prod_univ_succ, ih]
-      rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-
 @[simp] theorem topologicalDensityChainEquiv_symm_apply
     (H : BNTFusionTensorClause M) (N : ℕ)
     (q : TopologicalDensitySector H N) (x : TopologicalSectorBond H q)
@@ -401,7 +390,7 @@ theorem reindex_mpo_changePhysicalBasis_eq_allLabelDensity
               H.tensor (q i).1 (finProdFinEquiv (a, b)) (x i) (y i))
       exact changePhysicalBasis_verticalCopy_same H (q i) (x i) (y i)
     simp_rw [hlocal]
-    rw [prod_ofFn_smul_matrix, Matrix.trace_smul]
+    rw [Matrix.list_prod_smul_ofFn, Matrix.trace_smul]
     unfold allLabelDensity
     rw [Matrix.blockDiagonal'_apply_eq]
     simp only [Matrix.smul_apply, smul_eq_mul, topologicalSectorWeight]

--- a/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
@@ -80,17 +80,6 @@ abbrev TopologicalSectorBond (H : BNTFusionTensorClause M) {N : ℕ}
     (q : TopologicalDensitySector H N) :=
   (n : Fin (N + 1)) → Fin (H.bondDim (q n).1)
 
-private def piSnocEquiv {N : ℕ} {α : Fin (N + 1) → Type*} :
-    ((n : Fin (N + 1)) → α n) ≃
-      ((n : Fin N) → α n.castSucc) × α (Fin.last N) where
-  toFun x := ⟨Fin.init x, x (Fin.last N)⟩
-  invFun x := Fin.snoc x.1 x.2
-  left_inv x := Fin.snoc_init_self x
-  right_inv x := by
-    apply Prod.ext
-    · exact Fin.init_snoc x.2 x.1
-    · exact Fin.snoc_last x.2 x.1
-
 /-- The bond dimension stored on the tensor-attached clause is the bond dimension of its
 fusion family. -/
 private def attachedBondEquiv (H : BNTFusionTensorClause M) (α : Fin H.labelCount) :
@@ -117,13 +106,14 @@ def fusionChainBondEquiv (H : BNTFusionTensorClause M) :
           H.toBNTFusionCoisometryFamily (topologicalFusionInitial H q)
             (topologicalFusionPrevious H q))
   | 0, q =>
-      (piSnocEquiv.trans (Equiv.uniqueProd _ _)).trans
+      (((Fin.snocEquiv _).symm.trans (Equiv.prodComm _ _)).trans
+        (Equiv.uniqueProd _ _)).trans
         (finCongr (by
           simp [topologicalFusionInitial, topologicalFusionPrevious,
             BNTFusionCoisometryFamily.fusionChainBondDim]
           rfl))
   | N + 1, q =>
-      piSnocEquiv.trans <|
+      ((Fin.snocEquiv _).symm.trans (Equiv.prodComm _ _)).trans <|
         (((fusionChainBondEquiv H
           (fun n : Fin (N + 1) => q n.castSucc)).prodCongr
             (attachedBondEquiv H (q (Fin.last (N + 1))).1)).trans finProdFinEquiv)

--- a/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
@@ -18,6 +18,8 @@ multiplicity copy.  The diagonal coefficient is the corresponding entry of
 `μ^{⊗ (N + 1)}`.  The second factor reconstructs each fixed-label transfer from the recursive
 operator `Q`.
 
+Throughout, a declaration indexed by `N` describes the source chain of positive length `N + 1`.
+
 The conditional core proves the density identity in the direct-sum coordinates selected by
 a `BNTFusionTensorClause`.  The source-facing corollary obtains such a clause from the
 horizontal-canonical MPDO and renormalization fixed-point hypotheses of arXiv:1606.00608,

--- a/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.FinTupleEquiv
 import TNLean.Algebra.MatrixAux
+import TNLean.MPS.MPDO.BNTFusionTensorClauseFromRFP
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.VerticalProductPairBlocks
@@ -17,15 +18,19 @@ multiplicity copy.  The diagonal coefficient is the corresponding entry of
 `μ^{⊗ (N + 1)}`.  The second factor reconstructs each fixed-label transfer from the recursive
 operator `Q`.
 
-The result is the density identity at line 999 of arXiv:1606.00608 in the direct-sum
-coordinates selected by a `BNTFusionTensorClause`.  It does not prove the following
-commutator, the terminal spectral refinement, or the commuting-Hamiltonian theorem.
+The conditional core proves the density identity in the direct-sum coordinates selected by
+a `BNTFusionTensorClause`.  The source-facing corollary obtains such a clause from the
+horizontal-canonical MPDO and renormalization fixed-point hypotheses of arXiv:1606.00608,
+Theorem 4.14, and thereby proves the density identity at line 999.  It does not prove the
+following commutator, the terminal spectral refinement, or the commuting-Hamiltonian theorem.
 
 ## Main result
 
 * `reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul`:
   the positive-length physical density, in the retained vertical coordinates, is
   `μ^{⊗ (N + 1)}` times the reconstructed recursive operator.
+* `MPOTensor.exists_topologicalProjectorDensity_of_isRFPViaTS`:
+  the source hypotheses supply a vertical decomposition for which that identity holds.
 
 ## References
 
@@ -160,7 +165,7 @@ def topologicalDensityChainEquiv (H : BNTFusionTensorClause M) (N : ℕ) :
         verticalCopyDim H.bondDim H.multiplicity q)) ≃
       (q : TopologicalDensitySector H N) × TopologicalSectorBond H q :=
   (Equiv.piCongrRight fun _ : Fin (N + 1) =>
-    verticalCopyCoordinateEquiv H.bondDim H.multiplicity).trans piSigmaEquiv
+    verticalCopyCoordinateEquiv H.bondDim H.multiplicity).trans Equiv.piSigmaEquiv
 
 /-- The diagonal entry of `μ^{⊗ (N + 1)}` selected by a sector.
 
@@ -462,3 +467,29 @@ theorem reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul
   exact allLabelDensity_eq_verticalWeightTensorPower_mul_topologicalProjectorFactor H N
 
 end MPOTensor.BNTFusionTensorClause
+
+namespace MPOTensor
+
+open BNTFusionTensorClause
+
+/-- A horizontal-canonical matrix product density operator satisfying the
+renormalization fixed-point condition admits vertical direct-sum coordinates in which every
+positive-length density is the tensor-power weight times the reconstructed recursive
+operator.
+
+Source: CPSV16, Theorem 4.14(i),(iii) and the recursive density identity at line 999,
+lines 972--999 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem exists_topologicalProjectorDensity_of_isRFPViaTS
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) :
+    ∃ H : BNTFusionTensorClause M, ∀ N : ℕ,
+      Matrix.reindex (BNTFusionTensorClause.topologicalDensityChainEquiv H N)
+          (BNTFusionTensorClause.topologicalDensityChainEquiv H N)
+          (mpo (changePhysicalBasis H.verticalCoisometry M) (N + 1)) =
+        BNTFusionTensorClause.verticalWeightTensorPower H N *
+          BNTFusionTensorClause.topologicalProjectorFactor H N := by
+  obtain ⟨H⟩ :=
+    HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
+  exact ⟨H, reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul H⟩
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorDensity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinTupleEquiv
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.VerticalProductPairBlocks
@@ -149,19 +150,6 @@ def fusionChainBondEquiv (H : BNTFusionTensorClause M) :
         (fusionChainBondEquiv H (fun n : Fin (N + 1) => q n.castSucc) (Fin.init x),
           attachedBondEquiv H (q (Fin.last (N + 1))).1 (x (Fin.last (N + 1)))) :=
   rfl
-
-private def piSigmaEquiv
-    {ι : Type*} {α : ι → Type*} {β : (i : ι) → α i → Type*} :
-    ((i : ι) → (a : α i) × β i a) ≃
-      (a : (i : ι) → α i) × ((i : ι) → β i (a i)) where
-  toFun x := ⟨fun i => (x i).1, fun i => (x i).2⟩
-  invFun x i := ⟨x.1 i, x.2 i⟩
-  left_inv x := by
-    funext i
-    exact Sigma.eta (x i)
-  right_inv x := by
-    obtain ⟨a, b⟩ := x
-    rfl
 
 /-- Apply the retained vertical coordinate change at every site and group the result by its
 label and multiplicity sector. -/

--- a/TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean
+++ b/TNLean/MPS/MPDO/TopologicalProjectorRecursion.lean
@@ -462,6 +462,63 @@ private theorem appendFusionFirstStage_apply
     Matrix.sum_apply, Matrix.smul_apply, Matrix.kroneckerMap_apply, smul_eq_mul,
     Finset.mul_sum, mul_assoc]
 
+/-- Reconstructing through the first append stage recovers the product tensor before the
+preceding histories were compressed. -/
+private theorem appendFusionFirstStage_reconstruction
+    (Fam : BNTFusionCoisometryFamily Λ p) (α β : Λ) (previous : List Λ)
+    (A : MPOTensor p (fusionChainBondDim Fam α previous))
+    (W : Matrix (FusionHistoryIndex Fam α previous)
+      (Fin (fusionChainBondDim Fam α previous)) ℂ)
+    (hW : ∀ i j : Fin p,
+      Wᴴ * recursiveProjectorQ Fam (fun γ => Fam.tensor γ i j) α previous * W =
+        A i j)
+    (i k : Fin p) :
+    (appendFusionFirstStage Fam α β previous W)ᴴ *
+        (Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+          fusionHistoryWeight Fam α previous h.1 h.2 •
+            mulTensor (Fam.tensor (fusionHistoryFinalLabel Fam α previous h))
+              (Fam.tensor β) i k) *
+        appendFusionFirstStage Fam α β previous W =
+      mulTensor A (Fam.tensor β) i k := by
+  have hBlocks (j : Fin p) :
+      Wᴴ *
+          (Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+            fusionHistoryWeight Fam α previous h.1 h.2 •
+              Fam.tensor (fusionHistoryFinalLabel Fam α previous h) i j) *
+          W =
+        A i j := by
+    simpa only [recursiveProjectorQ] using hW i j
+  have hProductBlocks :
+      (Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+        fusionHistoryWeight Fam α previous h.1 h.2 •
+          mulTensor (Fam.tensor (fusionHistoryFinalLabel Fam α previous h))
+            (Fam.tensor β) i k) =
+        Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+          (∑ j : Fin p,
+            (fusionHistoryWeight Fam α previous h.1 h.2 •
+              Fam.tensor (fusionHistoryFinalLabel Fam α previous h) i j) ⊗ₖ
+                Fam.tensor β j k).submatrix finProdFinEquiv.symm finProdFinEquiv.symm := by
+    apply congrArg Matrix.blockDiagonal'
+    funext h
+    ext x y
+    simp only [Matrix.submatrix_apply, finProdFinEquiv_symm_apply, mulTensor_apply,
+      Matrix.sum_apply, Matrix.smul_apply, Matrix.kroneckerMap_apply, smul_eq_mul,
+      Finset.mul_sum, mul_assoc]
+  unfold appendFusionFirstStage
+  rw [Matrix.conjTranspose_submatrix]
+  rw [hProductBlocks]
+  rw [← appendHistoryBond_sum_blockDiagonal Fam α β previous
+    (fun h j => fusionHistoryWeight Fam α previous h.1 h.2 •
+      Fam.tensor (fusionHistoryFinalLabel Fam α previous h) i j)
+    (fun j => Fam.tensor β j k)]
+  rw [
+    Matrix.submatrix_mul_equiv _ _ _ (appendHistoryBondEquiv Fam α β previous).symm _,
+    Matrix.submatrix_mul_equiv _ _ _ (appendHistoryBondEquiv Fam α β previous).symm _,
+    Matrix.mul_sum, Matrix.sum_mul]
+  simp_rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+    Matrix.conjTranspose_one, Matrix.one_mul, Matrix.mul_one, hBlocks]
+  exact (mulTensor_apply A (Fam.tensor β) i k).symm
+
 /-- The second circuit stage when a label is appended: the direct sum of the active fusion
 coisometries over all preceding histories. -/
 private noncomputable def appendFusionSecondStage
@@ -520,6 +577,43 @@ private theorem appendFusionSecondStage_apply
   rw [hBlocks]
   exact appendFusionOutput_blockDiagonal Fam α β previous
     (fun γ => Fam.tensor γ i k)
+
+/-- Reconstructing through the second append stage recovers the preceding-history product
+blocks. -/
+private theorem appendFusionSecondStage_reconstruction
+    (Fam : BNTFusionCoisometryFamily Λ p) (α β : Λ) (previous : List Λ)
+    (i k : Fin p) :
+    (appendFusionSecondStage Fam α β previous)ᴴ *
+        recursiveProjectorQ Fam (fun γ => Fam.tensor γ i k) α (β :: previous) *
+        appendFusionSecondStage Fam α β previous =
+      Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+        fusionHistoryWeight Fam α previous h.1 h.2 •
+          mulTensor (Fam.tensor (fusionHistoryFinalLabel Fam α previous h))
+            (Fam.tensor β) i k := by
+  unfold appendFusionSecondStage
+  rw [Matrix.conjTranspose_submatrix]
+  rw [← appendFusionOutput_blockDiagonal Fam α β previous
+    (fun γ => Fam.tensor γ i k)]
+  rw [
+    Matrix.submatrix_mul_equiv _ _ _ (appendFusionOutputEquiv Fam α β previous).symm _,
+    Matrix.submatrix_mul_equiv _ _ _ (appendFusionOutputEquiv Fam α β previous).symm _,
+    Matrix.blockDiagonal'_conjTranspose, ← Matrix.blockDiagonal'_mul,
+    ← Matrix.blockDiagonal'_mul]
+  change
+    (Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+      (Fam.fusionCoisometry (fusionHistoryFinalLabel Fam α previous h) β)ᴴ *
+        (fusionHistoryWeight Fam α previous h.1 h.2 •
+          Matrix.blockDiagonal' fun γ =>
+            Fam.chi.matrix (fusionHistoryFinalLabel Fam α previous h) β γ ⊗ₖ
+              Fam.tensor γ i k) *
+        Fam.fusionCoisometry (fusionHistoryFinalLabel Fam α previous h) β) =
+      Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+        fusionHistoryWeight Fam α previous h.1 h.2 •
+          mulTensor (Fam.tensor (fusionHistoryFinalLabel Fam α previous h))
+            (Fam.tensor β) i k
+  apply congrArg Matrix.blockDiagonal'
+  funext h
+  rw [Matrix.mul_smul, Matrix.smul_mul, Fam.reconstruction]
 
 /-- The sequential active fusion coisometry for a left-associated chain.
 
@@ -685,6 +779,56 @@ theorem sequentialFusionCoisometry_mul_fusionChainTensor_mul_conjTranspose
         _ = recursiveProjectorQ Fam (fun γ => Fam.tensor γ i k) α (β :: previous) :=
           appendFusionSecondStage_apply Fam α β previous i k
 
+/-- The sequential fusion circuit reconstructs each product letter from its recursive
+history block.
+
+Source: arXiv:1606.00608, the factor
+$\widetilde U Q\widetilde U^\dagger$ at line 999. -/
+theorem conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_mul
+    (Fam : BNTFusionCoisometryFamily Λ p) (α : Λ) :
+    ∀ (previous : List Λ) (i k : Fin p),
+      (sequentialFusionCoisometry Fam α previous)ᴴ *
+          recursiveProjectorQ Fam (fun γ => Fam.tensor γ i k) α previous *
+          sequentialFusionCoisometry Fam α previous =
+        fusionChainTensor Fam α previous i k
+  | [], i, k => by
+      unfold sequentialFusionCoisometry fusionChainTensor
+      rw [recursiveProjectorQ_empty]
+      rw [Matrix.conjTranspose_submatrix,
+        Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv,
+        Matrix.conjTranspose_one]
+      change (1 : Matrix (Fin (Fam.bondDim α)) (Fin (Fam.bondDim α)) ℂ) *
+          Fam.tensor α i k * 1 = Fam.tensor α i k
+      rw [Matrix.one_mul, Matrix.mul_one]
+  | β :: previous, i, k => by
+      let W := sequentialFusionCoisometry Fam α previous
+      let F := appendFusionFirstStage Fam α β previous W
+      let S := appendFusionSecondStage Fam α β previous
+      change (S * F)ᴴ *
+          recursiveProjectorQ Fam (fun γ => Fam.tensor γ i k) α (β :: previous) *
+          (S * F) =
+        mulTensor (fusionChainTensor Fam α previous) (Fam.tensor β) i k
+      rw [Matrix.conjTranspose_mul]
+      calc
+        (Fᴴ * Sᴴ) *
+              recursiveProjectorQ Fam (fun γ => Fam.tensor γ i k) α (β :: previous) *
+              (S * F) =
+            Fᴴ * (Sᴴ *
+              recursiveProjectorQ Fam (fun γ => Fam.tensor γ i k) α (β :: previous) *
+              S) * F := by
+          simp only [Matrix.mul_assoc]
+        _ = Fᴴ *
+              (Matrix.blockDiagonal' fun h : FusionHistory Fam α previous =>
+                fusionHistoryWeight Fam α previous h.1 h.2 •
+                  mulTensor (Fam.tensor (fusionHistoryFinalLabel Fam α previous h))
+                    (Fam.tensor β) i k) * F := by
+          rw [appendFusionSecondStage_reconstruction Fam α β previous i k]
+        _ = mulTensor (fusionChainTensor Fam α previous) (Fam.tensor β) i k :=
+          appendFusionFirstStage_reconstruction Fam α β previous
+            (fusionChainTensor Fam α previous) W
+            (conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_mul
+              Fam α previous) i k
+
 /-- Closing the physical operator letter after sequential fusion gives the recursive operator
 whose terminal blocks are the fixed-label physical-trace transfers.
 
@@ -706,5 +850,32 @@ theorem sequentialFusionCoisometry_mul_physTraceTransfer_mul_conjTranspose
       Finset.smul_sum]
   · simp only [Matrix.sum_apply, Matrix.blockDiagonal'_apply_ne _ _ _ hh,
       Finset.sum_const_zero]
+
+/-- Closing the reconstructed recursive block recovers the fixed-label physical-trace
+transfer.
+
+Source: arXiv:1606.00608, the factor
+$\widetilde U Q\widetilde U^\dagger$ at line 999. -/
+theorem conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_physTrace_mul
+    (Fam : BNTFusionCoisometryFamily Λ p) (α : Λ) (previous : List Λ) :
+    (sequentialFusionCoisometry Fam α previous)ᴴ *
+          recursiveProjectorQ Fam (fun γ => physTraceTransfer (Fam.tensor γ)) α previous *
+          sequentialFusionCoisometry Fam α previous =
+      physTraceTransfer (fusionChainTensor Fam α previous) := by
+  rw [physTraceTransfer]
+  have hQ :
+      recursiveProjectorQ Fam (fun γ => physTraceTransfer (Fam.tensor γ)) α previous =
+        ∑ i : Fin p,
+          recursiveProjectorQ Fam (fun γ => Fam.tensor γ i i) α previous := by
+    unfold recursiveProjectorQ physTraceTransfer
+    ext ⟨h, b⟩ ⟨h', b'⟩
+    by_cases hh : h = h'
+    · subst h'
+      simp only [Matrix.sum_apply, Matrix.blockDiagonal'_apply_eq, Matrix.smul_apply,
+        Finset.smul_sum]
+    · simp only [Matrix.sum_apply, Matrix.blockDiagonal'_apply_ne _ _ _ hh,
+        Finset.sum_const_zero]
+  rw [hQ, Matrix.mul_sum, Matrix.sum_mul]
+  simp_rw [conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_mul Fam α]
 
 end MPOTensor.BNTFusionCoisometryFamily

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1653,11 +1653,10 @@ separate step.
     This is the density identity at
     \cite[line~999]{Cirac2016MPDO_arXiv}.
 
-    \textbf{Scope restriction (vertical direct-sum coordinates):} The theorem
-    does not prove the commutator at lines~1000--1002, the terminal spectral
-    refinement, or the commuting-Hamiltonian statement.  These remaining
-    steps are recorded in
-    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
+    % Scope restriction: this entry stops at the density identity on source
+    % line 999. The commutator at lines 1000--1002, terminal spectral
+    % refinement, and commuting-Hamiltonian statement remain tracked in
+    % docs/paper-gaps/cpsv16_topological_projector_recursion.tex.
 \end{theorem}
 \begin{proof}\leanok
     The vertical-canonical forward identity makes different label sectors

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1589,6 +1589,87 @@ separate step.
     by block.
 \end{proof}
 
+\begin{definition}[All-label vertical density factors]%
+    \label{def:mpdo_topological_projector_density}
+    \lean{MPOTensor.BNTFusionTensorClause.topologicalDensityChainEquiv}
+    \lean{MPOTensor.BNTFusionTensorClause.topologicalSectorWeight}
+    \lean{MPOTensor.BNTFusionTensorClause.verticalWeightTensorPower}
+    \lean{MPOTensor.BNTFusionTensorClause.topologicalProjectorFactor}
+    \lean{MPOTensor.BNTFusionTensorClause.allLabelDensity}
+    \leanok
+    \uses{def:mpdo_topological_projector_recursion}
+    For a positive chain length, choose at every site a vertical-canonical
+    label and one copy in its multiplicity space.  The corresponding
+    coefficient is the product of the selected diagonal entries of $\mu$.
+    On the product bond space for that label sequence, let
+    \[
+      R_{\boldsymbol\alpha}
+        =\widetilde U_{\boldsymbol\alpha}^{\dagger}
+          Q_{\boldsymbol\alpha}
+          \widetilde U_{\boldsymbol\alpha}.
+    \]
+    The diagonal weight and recursive factor over all label sequences are
+    \[
+      \mu_L=\bigoplus_{\boldsymbol\alpha}
+        \mu_{\boldsymbol\alpha}I,
+      \qquad
+      R_L=\bigoplus_{\boldsymbol\alpha}R_{\boldsymbol\alpha}.
+    \]
+    Here the displayed adjoints reflect that the retained-row fusion map in
+    the present convention is the adjoint of the circuit convention used in
+    the source.
+\end{definition}
+
+\begin{theorem}[All-label topological-projector density identity]%
+    \label{thm:mpdo_topological_projector_density}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.%
+        conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_mul}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.%
+        conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_physTrace_mul}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        changePhysicalBasis_conjTranspose_verticalCoisometry}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        reindex_mpo_changePhysicalBasis_eq_allLabelDensity}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        allLabelDensity_eq_verticalWeightTensorPower_mul_topologicalProjectorFactor}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul}
+    \leanok
+    \uses{def:mpdo_topological_projector_density,
+        thm:mpdo_topological_projector_recursion}
+    In the vertical direct-sum coordinates, the density over all label and
+    multiplicity sectors satisfies
+    \[
+      \rho_L^{\mathrm{vert}}=\mu_LR_L.
+    \]
+    Equivalently, in each label sector the fixed-label physical-trace
+    transfer is reconstructed as
+    $\widetilde U_{\boldsymbol\alpha}^{\dagger}
+      Q_{\boldsymbol\alpha}\widetilde U_{\boldsymbol\alpha}$, and its scalar
+    coefficient is the corresponding diagonal entry of $\mu^{\otimes L}$.
+    The sitewise retained vertical coisometry sends the physical density
+    operator to this direct sum, while applying its adjoint reconstructs the
+    original local tensor.
+    This is the density identity at
+    \cite[line~999]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (vertical direct-sum coordinates):} The theorem
+    does not prove the commutator at lines~1000--1002, the terminal spectral
+    refinement, or the commuting-Hamiltonian statement.  These remaining
+    steps are recorded in
+    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    The vertical-canonical forward identity makes different label sectors
+    vanish and identifies each diagonal sector with its multiplicity weight
+    times the corresponding product tensor.  Its reconstruction identity
+    recovers the original tensor after applying the adjoint coisometry.
+    Apply the reverse recursive-fusion identity in every fixed-label sector.
+    Matrix multiplication of the two block-diagonal factors then reduces to
+    scalar multiplication by the product of the selected diagonal entries of
+    $\mu$.
+\end{proof}
+
 \begin{definition}[Full-support specialization of one fusion layer]%
     \label{def:mpdo_full_support_virtual_projector_one_fusion}
     \lean{MPOTensor.BNTFusionIsometryFamily.projectorQBlock}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1623,6 +1623,18 @@ separate step.
 \begin{theorem}[All-label topological-projector density identity]%
     \label{thm:mpdo_topological_projector_density}
     \lean{MPOTensor.exists_topologicalProjectorDensity_of_isRFPViaTS}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.%
+        conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_mul}
+    \lean{MPOTensor.BNTFusionCoisometryFamily.%
+        conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_physTrace_mul}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        changePhysicalBasis_conjTranspose_verticalCoisometry}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        reindex_mpo_changePhysicalBasis_eq_allLabelDensity}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        allLabelDensity_eq_verticalWeightTensorPower_mul_topologicalProjectorFactor}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul}
     \leanok
     \uses{def:mpdo_topological_projector_density,
         thm:mpdo_rfp_to_bnt_fusion_tensor,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1622,23 +1622,15 @@ separate step.
 
 \begin{theorem}[All-label topological-projector density identity]%
     \label{thm:mpdo_topological_projector_density}
-    \lean{MPOTensor.BNTFusionCoisometryFamily.%
-        conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_mul}
-    \lean{MPOTensor.BNTFusionCoisometryFamily.%
-        conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_physTrace_mul}
-    \lean{MPOTensor.BNTFusionTensorClause.%
-        changePhysicalBasis_conjTranspose_verticalCoisometry}
-    \lean{MPOTensor.BNTFusionTensorClause.%
-        reindex_mpo_changePhysicalBasis_eq_allLabelDensity}
-    \lean{MPOTensor.BNTFusionTensorClause.%
-        allLabelDensity_eq_verticalWeightTensorPower_mul_topologicalProjectorFactor}
-    \lean{MPOTensor.BNTFusionTensorClause.%
-        reindex_mpo_changePhysicalBasis_eq_verticalWeightTensorPower_mul}
+    \lean{MPOTensor.exists_topologicalProjectorDensity_of_isRFPViaTS}
     \leanok
     \uses{def:mpdo_topological_projector_density,
+        thm:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_topological_projector_recursion}
-    In the vertical direct-sum coordinates, the density over all label and
-    multiplicity sectors satisfies
+    Let $M$ be a matrix product density operator in horizontal canonical form
+    that satisfies the renormalization fixed-point condition.  Then there is
+    a vertical canonical decomposition such that, for every positive chain
+    length, the density over all label and multiplicity sectors satisfies
     \[
       \rho_L^{\mathrm{vert}}=\mu_LR_L.
     \]
@@ -1659,6 +1651,8 @@ separate step.
     % docs/paper-gaps/cpsv16_topological_projector_recursion.tex.
 \end{theorem}
 \begin{proof}\leanok
+    The renormalization fixed-point condition supplies the active-sector
+    fusion clause for a vertical canonical decomposition.
     The vertical-canonical forward identity makes different label sectors
     vanish and identifies each diagonal sector with its multiplicity weight
     times the corresponding product tensor.  Its reconstruction identity

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -135,7 +135,13 @@ the adjoint of the circuit convention in
 \eqref{eq:formalized-all-label-density}.
 The sitewise vertical coisometry sends the physical MPO to this all-label
 matrix, and the adjoint coordinate change reconstructs the original tensor
-from the source reconstruction identity.  Thus
+from the source reconstruction identity.  For a matrix product density
+operator in horizontal canonical form satisfying the renormalization
+fixed-point condition, the formalized implication from Theorem~4.14(i) to
+Theorem~4.14(iii) supplies the required fusion clause.  The source-facing
+statement
+\leanid{MPOTensor.exists_topologicalProjectorDensity_of_isRFPViaTS}
+composes that implication with the all-label identity.  Thus
 \eqref{eq:formalized-all-label-density} completes the positive-length density
 identity at source line~999 in the retained vertical direct-sum coordinates;
 no additional local identification remains to be supplied.

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -121,17 +121,31 @@ Under length independence every history weight is one; consequently
 $Q_N(P)$ is an orthogonal projection whenever every terminal matrix
 $P_\gamma$ is one.
 
+The inverse reconstruction identity has also been proved from the pairwise
+fusion reconstruction law.  Summing it over every initial label and every
+vertical multiplicity copy gives the direct-sum density identity
+\begin{equation}
+  \rho_N^{\mathrm{vert}}
+    = \mu^{\otimes N}\,
+      \widetilde U Q_N\widetilde U^\dagger
+  \label{eq:formalized-all-label-density}
+\end{equation}
+in the vertical-canonical coordinates.  The formal retained-row coisometry is
+the adjoint of the circuit convention in
+\eqref{eq:formalized-all-label-density}.
+The sitewise vertical coisometry sends the physical MPO to this all-label
+matrix, and the adjoint coordinate change reconstructs the original tensor
+from the source reconstruction identity.  Thus
+\eqref{eq:formalized-all-label-density} completes the positive-length density
+identity at source line~999 in the retained vertical direct-sum coordinates;
+no additional local identification remains to be supplied.
+
 \section{Remaining proof}
 
-Equations \eqref{eq:source-chain-decomposition}--
-\eqref{eq:source-gibbs-decomposition} are not consequences of the fixed-label
-recursion alone.  A faithful proof still requires:
+The claims after the density identity are not consequences of the assembled
+all-label recursion alone.  A faithful proof still requires:
 \begin{enumerate}
-  \item the vertical-canonical assembly over the initial BNT labels, including
-    the factor $\mu^{\otimes N}$, and the identification of the assembled
-    matrix with the physical density operator in
-    \eqref{eq:source-chain-decomposition};
-  \item the commutator identity \eqref{eq:source-commutator} for that assembled
+  \item the commutator identity \eqref{eq:source-commutator} for the assembled
     operator;
   \item the terminal spectral decomposition and its compatibility with the
     recursive sectors;
@@ -139,8 +153,8 @@ recursion alone.  A faithful proof still requires:
     the projections in \eqref{eq:source-gibbs-decomposition}.
 \end{enumerate}
 These steps are tracked in \ghissue{3950}.  Until they are proved, the
-fixed-label recursion must not be cited as the vertical-canonical decomposition
-or the commuting Gibbs theorem of lines~995--1016.
+all-label density identity must not be cited for the commutator, terminal
+spectral refinement, or commuting Gibbs theorem of lines~1000--1016.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- prove the reverse arbitrary-chain fusion reconstruction from the pairwise `BNTFusionCoisometryFamily.reconstruction` law
- assemble every initial BNT label, vertical multiplicity copy, weight, and recursive sector into the positive-length physical MPO identity
- identify the retained vertical-coordinate density as `mu^(tensor (N + 1))` times the reconstructed recursive projector factor
- prove that applying the adjoint vertical coordinate change reconstructs the original local tensor
- link the exact public declarations in the blueprint and narrow the paper-gap note to the later commutator, spectral, and Gibbs steps

## Source boundary

This formalizes arXiv:1606.00608, Theorem IV.13 and the density identity at line 999, using the retained-row coisometry convention (the adjoint of the source circuit convention).

This PR intentionally stops before:

- the commutator at lines 1000-1002
- the terminal spectral refinement beginning at line 1010
- the commuting nearest-neighbor/Gibbs construction

Those remain tracked by #3950.

## Validation

- `lake build TNLean.MPS.MPDO.TopologicalProjectorDensity`
- `lake build`
- changed-file proof-integrity scan: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint web`
- `leanblueprint pdf`
- `leanblueprint checkdecls` (4,385 declarations)
- visually inspected blueprint PDF pages 707-709; no clipping, overlap, or illegible equations

Closes #4662

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new MPDO proof surface (~500 lines) and recursion API changes, but bounded to formal density algebra with explicit scope limits and no runtime/security paths.
> 
> **Overview**
> **Adds** the all-label topological-projector density formalization: after the retained vertical coisometry, the positive-length MPO equals **μ^⊗(N+1)** times the block-diagonal recursive factor **Ũ†QŨ**, with existence from horizontal canonical form plus `IsRFPViaTS`.
> 
> **Refactors** duplicated `piSigmaEquiv` and `list_prod_smul_ofFn` into `Equiv.piSigmaEquiv` (`FinTupleEquiv`) and `Matrix.list_prod_smul_ofFn` (`MatrixAux`), and wires MPDO sector/η transport files to those.
> 
> **Extends** `TopologicalProjectorRecursion` with reverse sequential-fusion reconstruction (`conjTranspose_sequentialFusionCoisometry_mul_recursiveProjectorQ_*`) used to match weighted trace transfers to the **Q** factor.
> 
> **Documents** the result in the blueprint and narrows the paper-gap note so later commutator, spectral, and Gibbs steps remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a52b7fa487299022acd14c4a21a3cb6700187bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->