### PR TITLE
feat(MPS/MPDO): expose fixed tensor positive sectors

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -101,6 +101,7 @@ import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.FixedBondPositivePhysicalSectorConstructor
+import TNLean.MPS.MPDO.FixedBondPositivePhysicalSectorRepresentative
 import TNLean.MPS.MPDO.FixedBondProductEtaTensor
 import TNLean.MPS.MPDO.FixedBondProductTensor
 import TNLean.MPS.MPDO.FusionIsometries

--- a/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorRepresentative.lean
+++ b/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorRepresentative.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.FixedBondProductEtaTensor
+
+/-!
+# Positive physical sectors of the selected fixed bond-product tensor
+
+This file records the positive physical-sector factorization of the exact
+fixed tensor selected for a positive translation-invariant commuting bond.
+The reconstructed physical bond is the original bond, and every neighboring
+operator is positive semidefinite.
+
+No zero-correlation-length, saturation-of-the-area-law, normality, or blocking
+statement is asserted.
+
+## Main statement
+
+* `TranslationInvariantBondData.exists_positive_physicalSectorFactorization_fixedProductTensorData`
+  gives the factorization of the exact selected fixed-product tensor.
+
+## References
+
+* arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1605.
+* S. Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, lines 395--415 and
+  456--476.
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace MPOTensor.TranslationInvariantBondData
+
+variable {d : ℕ}
+
+/-- The exact selected fixed-product tensor has a physical-sector
+factorization whose reconstructed bond is the input bond and whose neighboring
+operators are positive semidefinite.
+
+This concerns the selected tensor itself, not merely another tensor with the
+same closed operators.
+
+**Scope restriction (fixed representative):** This does not construct a
+factorization of an original MPDO tensor that is only proportional to the bond
+product, and it does not compare normality or blocking.  The remaining
+comparison is recorded in
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
+1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, lines
+395--415 and 456--476. -/
+theorem exists_positive_physicalSectorFactorization_fixedProductTensorData
+    (data : TranslationInvariantBondData d) :
+    ∃ F : PhysicalSectorFactorization data.fixedProductTensorData.tensor,
+      F.physicalBond = data.bond ∧
+        ∀ q h, (F.neighboringOperator q h).PosSemidef :=
+  ⟨data.fixedProductTensorDataPhysicalSectorFactorization,
+    data.fixedProductTensorDataPhysicalSectorFactorization_physicalBond_eq,
+    data.fixedProductTensorDataPhysicalSectorFactorization_neighboring_pos⟩
+
+end MPOTensor.TranslationInvariantBondData

--- a/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorRepresentative.lean
+++ b/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorRepresentative.lean
@@ -28,7 +28,7 @@ statement is asserted.
   456--476.
 -/
 
-open scoped ComplexOrder Matrix
+open scoped ComplexOrder
 
 namespace MPOTensor.TranslationInvariantBondData
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -574,11 +574,28 @@
 
 \begin{proof}\leanok
     Take the physical-sector factorization retained with $C$.  Its defining
-    one-site identity gives the displayed factorization of
-    $C_{\beta,\alpha}$, and the adjacent contraction of its right and left
-    factors gives $\eta_{q,h}$.  These neighboring operators are positive
-    semidefinite.  The retained bond identity says that transporting the
-    sector-coordinate bond through $U_2^\dagger$ reconstructs $B$ exactly.
+    one-site identity is
+    \[
+        U C_{\beta,\alpha}U^\dagger
+        =
+        \bigoplus_q L_\beta(q)\otimes R_\alpha(q).
+    \]
+    Contracting the adjacent right and left factors gives
+    \[
+        \eta_{q,h}=\sum_a R_a(q)\otimes L_a(h)\succeq0,
+    \]
+    where positivity is the retained neighboring-operator property.  Finally,
+    the retained bond identity is
+    \[
+        B
+        =
+        U_2^\dagger
+        \left[
+          \bigoplus_{q,h}
+          \Id_{H_q^L\otimes H_h^R}\otimes\eta_{q,h}
+        \right]
+        U_2.
+    \]
 \end{proof}
 
 \begin{remark}[The scalar edge formula depends on the one-site coordinates]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -483,21 +483,6 @@
     zero-correlation-length, or scalar normalization hypothesis is required.
 \end{theorem}
 
-% Blueprint deferral (#4664): the following constructor-support declarations
-% are intentionally not tagged here as completed results:
-% MPOTensor.TranslationInvariantBondData.
-%   PositivePhysicalSectorFixedProductTensorData,
-% MPOTensor.TranslationInvariantBondData.
-%   nonempty_positivePhysicalSectorFixedProductTensorData,
-% MPOTensor.TranslationInvariantBondData.
-%   fixedProductTensorDataPhysicalSectorFactorization_physicalBond_eq,
-% MPOTensor.TranslationInvariantBondData.
-%   fixedProductTensorDataPhysicalSectorFactorization_neighboring_pos,
-% MPOTensor.PhysicalSectorFactorization.etaSectorFinEquiv, and
-% MPOTensor.PhysicalSectorFactorization.
-%   sectorCoordinateBond_etaPair_decomposition.
-% Issue #4664 owns their paper-facing blueprint entries and source audit.
-
 \begin{proof}\leanok
     \uses{thm:mpdo_commuting_bond_positive_eta_decomposition}
     Choose Beigi's chain-independent one-site unitary and the positive
@@ -526,6 +511,74 @@
     virtual dimension.  For the zero-dimensional physical space, take one
     virtual state and no physical sectors.  The cyclic contraction formula
     then gives the product of the translates of $B$ at every length $N\geq2$.
+\end{proof}
+
+\begin{theorem}[Positive physical sectors of the selected fixed tensor]
+    \label{thm:mpdo_fixed_bond_positive_physical_sector_representative}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      exists_positive_physicalSectorFactorization_fixedProductTensorData}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      PositivePhysicalSectorFixedProductTensorData}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      nonempty_positivePhysicalSectorFixedProductTensorData}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      positivePhysicalSectorFixedProductTensorData}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      fixedProductTensorDataPhysicalSectorFactorization}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      fixedProductTensorDataPhysicalSectorFactorization_physicalBond_eq}
+    \lean{MPOTensor.TranslationInvariantBondData.%
+      fixedProductTensorDataPhysicalSectorFactorization_neighboring_pos}
+    \lean{MPOTensor.PhysicalSectorFactorization.etaSectorFinEquiv}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      sectorCoordinateBond_etaPair_decomposition}
+    \leanok
+    \uses{thm:mpdo_eta_fixed_bond_product_tensor}
+    Let $C$ be the selected fixed tensor of the preceding theorem.  There are
+    physical sectors
+    \[
+        \mathbb C^d
+        \cong
+        \bigoplus_{q=0}^{K-1}H_q^L\otimes H_q^R,
+    \]
+    a unitary $U$, and matrices $L_\beta(q)$ and $R_\alpha(q)$ such that,
+    writing $C_{\beta,\alpha}$ for the physical matrix at fixed virtual
+    indices,
+    \[
+        U C_{\beta,\alpha}U^\dagger
+        =
+        \bigoplus_{q=0}^{K-1}
+          L_\beta(q)\otimes R_\alpha(q).
+    \]
+    The neighboring operators
+    \[
+        \eta_{q,h}
+        =
+        \sum_a R_a(q)\otimes L_a(h)
+    \]
+    are positive semidefinite.  If $U_2$ denotes the induced two-site change
+    of coordinates, then
+    \[
+        B
+        =
+        U_2^\dagger
+        \left[
+          \bigoplus_{q,h}
+          \Id_{H_q^L\otimes H_h^R}\otimes\eta_{q,h}
+        \right]
+        U_2.
+    \]
+    Thus the physical-sector factorization belongs to the same tensor $C$
+    whose closed operators are the fixed products of $B$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Take the physical-sector factorization retained with $C$.  Its defining
+    one-site identity gives the displayed factorization of
+    $C_{\beta,\alpha}$, and the adjacent contraction of its right and left
+    factors gives $\eta_{q,h}$.  These neighboring operators are positive
+    semidefinite.  The retained bond identity says that transporting the
+    sector-coordinate bond through $U_2^\dagger$ reconstructs $B$ exactly.
 \end{proof}
 
 \begin{remark}[The scalar edge formula depends on the one-site coordinates]
@@ -1210,8 +1263,10 @@
     % **Scope restriction (physical-sector factorization):** The theorem
     % assumes the factorization F and positivity of every neighboring
     % operator.  CPSV16 Proposition 4to2, lines 1597--1619, starts instead
-    % from a translation-invariant commuting bond.  The missing non-circular
-    % construction is recorded in docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+    % from a translation-invariant commuting bond and the original source
+    % tensor.  The selected fixed tensor now has the required positive
+    % factorization, but the normality and blocking comparison with the source
+    % tensor remains; see docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -239,6 +239,19 @@ operators into a cyclic scalar weight in the transformed one-site coordinates,
 then conjugates the resulting tensor back through the same one-site unitary.
 It uses only positivity and commutation of the periodic translates.
 
+The selected fixed tensor now carries the same positive physical-sector
+factorization used in its construction.  More precisely,
+\leanid{MPOTensor.TranslationInvariantBondData.%
+exists_positive_physicalSectorFactorization_fixedProductTensorData}
+gives a factorization of the exact tensor in
+\leanid{MPOTensor.TranslationInvariantBondData.fixedProductTensorData};
+its neighboring operators are positive semidefinite and its reconstructed
+physical bond is the original commuting bond.  Thus no equality of closed
+matrix-product operators is used to replace one local tensor by another.
+This completes the fixed-representative construction only.  It neither
+factorizes the original source tensor nor proves a normality or blocking
+comparison between that tensor and the selected fixed tensor.
+
 The coordinate qualification is necessary.  In physical dimension $d=2$, let
 $X$ be the Pauli flip and $B=\Id+X\otimes X$.  Then $B\succeq0$, all periodic
 translates commute, and
@@ -518,10 +531,11 @@ uses ZCL.
 Proposition~\emph{4to2} is classified as a structural-bridge gap.  The
 fourth-region factorization, the Markov decomposition at every admissible cut,
 the all-cut entropy argument, and transport to the original physical basis are
-complete under an explicit positive physical-sector factorization.  The
-non-circular construction of that factorization from the source-side
-$\eta$-local structure, together with the normality and blocking reduction,
-remains.  The later
+complete under an explicit positive physical-sector factorization.  The exact
+fixed tensor selected from the source-side commuting bond now has such a
+factorization, with positive neighboring operators and the original physical
+bond.  The remaining gap is the normality and blocking comparison between the
+original source tensor and that selected fixed tensor.  The later
 orthogonal direct-sum implication is likewise formalized only as a
 scope-restricted theorem assuming sectorwise SAL.  It neither supplies that
 sectorwise premise nor proves the printed assertion that the GSNNCH form alone
@@ -532,8 +546,10 @@ implies SAL.
 The gap can be removed in the following stages.
 
 \begin{enumerate}
-\item Construct a positive physical-sector factorization non-circularly from
-the source-side $\eta$-local structure.
+\item The selected fixed tensor has a positive physical-sector factorization
+constructed non-circularly from the source-side commuting bond; this is
+\leanid{MPOTensor.TranslationInvariantBondData.%
+exists_positive_physicalSectorFactorization_fixedProductTensorData}.
 \item Prove the normality and blocking reduction from the printed
 translation-invariant commuting-bond hypotheses to that $\eta$-local datum.
 Only then may the source proposition receive a formal declaration and a

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -483,13 +483,15 @@ Consequently the source implication
   \Longrightarrow \text{SAL}
 \]
 is not yet formalized and must not carry a \texttt{\string\leanok} marker.
-The remaining work is structural: construct a positive
-\leanid{MPOTensor.PhysicalSectorFactorization} non-circularly from the
-source-side \leanid{MPOTensor.EtaLocalStructureData}, and supply the
-normality and blocking reduction needed to reach that datum from the printed
-commuting-bond hypotheses.  The explicit factorization and positivity
-assumptions of the proved corollary are marked scope restrictions, not
-additional hypotheses on the source proposition.
+The target-side construction recorded above is now complete for the exact
+selected fixed tensor: its positive physical-sector factorization is
+constructed from the fixed commuting bond in equation \emph{sigmaNK2} at
+source lines~1581--1605.  The remaining work is structural: supply the
+normality and blocking comparison from the original normal MPDO block and
+proportional bond-product hypotheses of Proposition~\emph{4to2}, at source
+lines~1597--1605, to that selected fixed representative.  The explicit
+factorization and positivity assumptions of the proved corollary are marked
+scope restrictions, not additional hypotheses on the source proposition.
 
 \paragraph{Local fix (the later orthogonal-sector statement).}
 The proposition labelled \emph{prop4to2} at source lines~1801--1808 states
@@ -547,11 +549,11 @@ The gap can be removed in the following stages.
 
 \begin{enumerate}
 \item The selected fixed tensor has a positive physical-sector factorization
-constructed non-circularly from the source-side commuting bond; this is
-\leanid{MPOTensor.TranslationInvariantBondData.%
-exists_positive_physicalSectorFactorization_fixedProductTensorData}.
-\item Prove the normality and blocking reduction from the printed
-translation-invariant commuting-bond hypotheses to that $\eta$-local datum.
+constructed non-circularly from the source-side commuting bond, as recorded by
+the fixed-tensor theorem identified above.
+\item Prove the normality and blocking comparison from the original normal
+MPDO block and the printed proportional commuting-bond hypotheses to the
+selected fixed representative.
 Only then may the source proposition receive a formal declaration and a
 \texttt{\string\leanok} marker.
 \end{enumerate}


### PR DESCRIPTION
## Summary

- expose the exact selected fixed-product tensor's positive physical-sector factorization as an existential theorem
- record that its reconstructed physical bond is the original commuting bond and every neighboring operator is positive semidefinite
- add a source-facing blueprint theorem and narrow the existing paper-gap note to the remaining original-tensor normality/blocking comparison

## Source scope

The statement follows CPSV16 Appendix C.2, lines 1571–1605, especially `sigmaNK2` at lines 1581–1589, together with Beigi's spatial decomposition at arXiv:1105.1019v2, lines 395–415 and 456–476.

This PR concerns only the exact selected fixed tensor. It does not identify the original MPDO tensor with that representative and does not claim or introduce ZCL, SAL, normality, or blocking.

## Validation

- `lake env lean TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorRepresentative.lean`
- `lake env lean TNLean/MPS/MPDO.lean`
- `lake build`
- `lake exe lint_style`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- proof-integrity scan of the new Lean file
- `python3 scripts/blueprint_lean_sync.py --ci`
- `lake exe checkdecls blueprint/lean_decls`
- repository-wide ChkTeX gate
- `leanblueprint web`
- `leanblueprint pdf`
- visual inspection of the generated PDF theorem and continuation pages; no clipping, overlap, or broken formulas
- generated HTML theorem/formula structure inspected; an interactive browser surface was unavailable in this session

Closes #4664

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a thin Lean packaging layer over existing proofs; no auth, runtime, or behavioral changes beyond formalization surfacing.
> 
> **Overview**
> **Exposes** the exact **selected fixed-product tensor**'s positive physical-sector factorization as the existential Lean theorem `exists_positive_physicalSectorFactorization_fixedProductTensorData`, wiring existing constructor data (reconstructed bond equals the commuting bond, neighboring operators PSD) through a new module and the `MPDO` import aggregator.
> 
> **Blueprint** gains theorem `thm:mpdo_fixed_bond_positive_physical_sector_representative` with `\leanok` links to that statement and related definitions; a deferred blueprint comment block for constructor-support declarations is removed.
> 
> **Paper-gap** text (`cpsv16_commuting_form_to_sal.tex`) is updated so the **fixed-representative** positive factorization is marked **done**; the open Proposition 4to2 work is narrowed to **normality and blocking comparison** between the original MPDO block and that representative—not building the factorization from η-local structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4053b0004ea446298422afb0c1d003ce4cc548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->