### PR TITLE
feat(MPS/MPDO): prove the line-1001 density-factor commutator

### DIFF
--- a/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
+++ b/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Algebra.Group.Commute.Hom
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.PiSigmaEquiv
 import TNLean.MPS.MPDO.BNTFusionTensorClauseFromRFP
@@ -26,7 +27,9 @@ In a fixed copy configuration, the diagonal entry of the tensor power of the mul
 matrix is the product of the chosen positive weights.  The remaining factor is the recursive
 terminal operator transported back through the adjoint sequential fusion coisometry.  Taking
 the direct sum over all copy configurations gives the density operator in retained vertical
-coordinates.  Applying the adjoint vertical map reconstructs the original density exactly.
+coordinates.  The multiplicity-weight factor is scalar on every copy block, and therefore
+commutes with the reconstructed recursive factor.  Applying the adjoint vertical map
+reconstructs the original density exactly.
 
 ## References
 
@@ -204,6 +207,110 @@ def topologicalDensityOperatorSucc (H : BNTFusionTensorClause M) (N : ℕ) :
   Matrix.reindex (H.verticalCopyChainEquiv N).symm
     (H.verticalCopyChainEquiv N).symm
       (Matrix.blockDiagonal' fun p ↦ H.topologicalDensityBlock p)
+
+/-- The multiplicity-weight tensor power in retained positive-chain coordinates.
+
+On the block selected by a BNT-copy configuration `p`, this operator is the scalar
+`verticalMultiplicityChainWeight H p` times the identity on the simple-bond chain fiber.
+Thus it is the factor `μ⁽⊗ⁿ⁺¹⁾`, completed by the identity on the coordinates where it
+does not act.
+
+Source: arXiv:1606.00608, the multiplicity-weight factor and commutator at lines 999--1002.
+-/
+def multiplicityWeightOperatorSucc (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix (Fin (N + 1) → Fin H.verticalRetainedDim)
+      (Fin (N + 1) → Fin H.verticalRetainedDim) ℂ :=
+  Matrix.reindex (H.verticalCopyChainEquiv N).symm
+    (H.verticalCopyChainEquiv N).symm
+      (Matrix.blockDiagonal' fun p ↦
+        H.verticalMultiplicityChainWeight p •
+          (1 : Matrix (H.VerticalCopyChainFiber p)
+            (H.VerticalCopyChainFiber p) ℂ))
+
+/-- The reconstructed recursive factor in retained positive-chain coordinates.
+
+On a fixed BNT-copy configuration, this is `Wᴴ Q W`.  The sequential fusion map `W` has
+the retained-row coisometry orientation, so the source embedding `\tilde U` is `Wᴴ`.
+The direct sum repeats the factor over the multiplicity coordinates on which it does not act.
+
+Source: arXiv:1606.00608, the recursive factor and commutator at lines 999--1002.
+-/
+def recursiveTopologicalFactorSucc (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix (Fin (N + 1) → Fin H.verticalRetainedDim)
+      (Fin (N + 1) → Fin H.verticalRetainedDim) ℂ :=
+  Matrix.reindex (H.verticalCopyChainEquiv N).symm
+    (H.verticalCopyChainEquiv N).symm
+      (Matrix.blockDiagonal' fun p ↦
+        (H.verticalCopyChainFusionCoisometry p)ᴴ *
+          H.verticalCopyChainProjectorQ p *
+            H.verticalCopyChainFusionCoisometry p)
+
+/-- The all-label density operator is the product of its multiplicity-weight and recursive
+factors.
+
+The parameter `N` represents source chain length `N + 1`.  No length-independence or
+projection hypothesis is used.
+
+Source: arXiv:1606.00608, the density factorization at line 999.
+-/
+theorem topologicalDensityOperatorSucc_eq_multiplicityWeightOperatorSucc_mul
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    H.topologicalDensityOperatorSucc N =
+      H.multiplicityWeightOperatorSucc N * H.recursiveTopologicalFactorSucc N := by
+  unfold topologicalDensityOperatorSucc multiplicityWeightOperatorSucc
+    recursiveTopologicalFactorSucc topologicalDensityBlock
+  change
+    (Matrix.reindexRingEquiv ℂ (H.verticalCopyChainEquiv N).symm)
+        (Matrix.blockDiagonal' fun p ↦
+          H.verticalMultiplicityChainWeight p •
+            ((H.verticalCopyChainFusionCoisometry p)ᴴ *
+              H.verticalCopyChainProjectorQ p *
+                H.verticalCopyChainFusionCoisometry p)) =
+      (Matrix.reindexRingEquiv ℂ (H.verticalCopyChainEquiv N).symm)
+          (Matrix.blockDiagonal' fun p ↦
+            H.verticalMultiplicityChainWeight p •
+              (1 : Matrix (H.VerticalCopyChainFiber p)
+                (H.VerticalCopyChainFiber p) ℂ)) *
+        (Matrix.reindexRingEquiv ℂ (H.verticalCopyChainEquiv N).symm)
+          (Matrix.blockDiagonal' fun p ↦
+            (H.verticalCopyChainFusionCoisometry p)ᴴ *
+              H.verticalCopyChainProjectorQ p *
+                H.verticalCopyChainFusionCoisometry p)
+  rw [← map_mul, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext p
+  simp only [Matrix.smul_mul, Matrix.one_mul]
+
+/-- The multiplicity-weight tensor power commutes with the reconstructed recursive factor.
+
+The parameter `N` represents source chain length `N + 1`.  The multiplicity-weight operator
+is scalar on every BNT-copy block, while the recursive factor preserves those blocks.  The
+commutator therefore vanishes without length independence, terminal spectral refinement, or
+any projection hypothesis.
+
+Source: arXiv:1606.00608, the commutator at lines 999--1002.
+-/
+theorem multiplicityWeightOperatorSucc_commute_recursiveTopologicalFactorSucc
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    Commute (H.multiplicityWeightOperatorSucc N)
+      (H.recursiveTopologicalFactorSucc N) := by
+  unfold multiplicityWeightOperatorSucc recursiveTopologicalFactorSucc
+  change Commute
+    ((Matrix.reindexRingEquiv ℂ (H.verticalCopyChainEquiv N).symm)
+      (Matrix.blockDiagonal' fun p ↦
+        H.verticalMultiplicityChainWeight p •
+          (1 : Matrix (H.VerticalCopyChainFiber p)
+            (H.VerticalCopyChainFiber p) ℂ)))
+    ((Matrix.reindexRingEquiv ℂ (H.verticalCopyChainEquiv N).symm)
+      (Matrix.blockDiagonal' fun p ↦
+        (H.verticalCopyChainFusionCoisometry p)ᴴ *
+          H.verticalCopyChainProjectorQ p *
+            H.verticalCopyChainFusionCoisometry p))
+  apply Commute.map
+  rw [commute_iff_eq, ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext p
+  simp only [Matrix.smul_mul, Matrix.mul_smul, Matrix.one_mul, Matrix.mul_one]
 
 /-- The horizontal matrix obtained by fixing the two simple-bond coordinates of one vertical
 BNT tensor.
@@ -549,5 +656,29 @@ theorem exists_topologicalDensityDecomposition_of_isRFPViaTS
     ∃ H : BNTFusionTensorClause M, H.HasTopologicalDensityDecomposition := by
   obtain ⟨H⟩ := HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
   exact ⟨H, H.hasTopologicalDensityDecomposition⟩
+
+/-- **Line-1001 density-factor commutator for an RFP MPDO.**
+
+A horizontal-canonical MPDO satisfying the source renormalization fixed-point condition
+admits one BNT fusion clause which gives both the all-label density decomposition and, at
+every positive chain length, the commutation of its multiplicity-weight tensor power with
+its reconstructed recursive factor.  The same clause is used for both assertions, with no
+caller-supplied compatibility hypothesis.
+
+Source: arXiv:1606.00608, Theorem 4.14 and the density-factor commutator at lines 999--1002.
+This theorem makes no length-independence, projection, spectral, Hamiltonian, or Gibbs-state
+assertion.
+-/
+theorem exists_topologicalDensityDecomposition_and_factorCommutation_of_isRFPViaTS
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) :
+    ∃ H : BNTFusionTensorClause M,
+      H.HasTopologicalDensityDecomposition ∧
+        ∀ N : ℕ, Commute (H.multiplicityWeightOperatorSucc N)
+          (H.recursiveTopologicalFactorSucc N) := by
+  obtain ⟨H, hDensity⟩ :=
+    exists_topologicalDensityDecomposition_of_isRFPViaTS M hHorizontal hM hRFP
+  exact ⟨H, hDensity,
+    H.multiplicityWeightOperatorSucc_commute_recursiveTopologicalFactorSucc⟩
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1738,8 +1738,7 @@ separate step.
     \lean{MPOTensor.%
         exists_topologicalDensityDecomposition_and_factorCommutation_of_isRFPViaTS}
     \leanok
-    \uses{def:mpdo_topological_density_operator,
-        thm:mpdo_topological_density_decomposition}
+    \uses{def:mpdo_topological_density_operator}
     Let $M$ be a matrix product density operator in horizontal canonical form
     satisfying the renormalization fixed-point condition.  There is one
     vertical canonical decomposition and one compatible family of fusion
@@ -1764,6 +1763,7 @@ separate step.
     No length-independence or projection hypothesis is imposed.
 \end{theorem}
 \begin{proof}\leanok
+    \uses{thm:mpdo_topological_density_decomposition}
     The two operators preserve the same direct-sum decomposition indexed by
     the configurations~$c$.  On each summand the first factor is a scalar
     multiple of the identity, so

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1635,6 +1635,8 @@ separate step.
     \lean{MPOTensor.BNTFusionTensorClause.verticalCopyChainProjectorQ}
     \lean{MPOTensor.BNTFusionTensorClause.topologicalDensityBlock}
     \lean{MPOTensor.BNTFusionTensorClause.topologicalDensityOperatorSucc}
+    \lean{MPOTensor.BNTFusionTensorClause.multiplicityWeightOperatorSucc}
+    \lean{MPOTensor.BNTFusionTensorClause.recursiveTopologicalFactorSucc}
     \leanok
     \uses{def:mpdo_topological_projector_recursion,
         def:mpdo_bnt_fusion_tensor_clause,
@@ -1725,6 +1727,57 @@ separate step.
     identity and its exact reverse identity, then sum over all configurations.
     The local reconstruction identity, applied at every site, gives the stated
     adjoint reconstruction of the original density operator.
+\end{proof}
+
+\begin{theorem}[Commutation of the all-label density factors]%
+    \label{thm:mpdo_topological_density_factor_commutation}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        topologicalDensityOperatorSucc_eq_multiplicityWeightOperatorSucc_mul}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        multiplicityWeightOperatorSucc_commute_recursiveTopologicalFactorSucc}
+    \lean{MPOTensor.%
+        exists_topologicalDensityDecomposition_and_factorCommutation_of_isRFPViaTS}
+    \leanok
+    \uses{def:mpdo_topological_density_operator,
+        thm:mpdo_topological_density_decomposition}
+    Let $M$ be a matrix product density operator in horizontal canonical form
+    satisfying the renormalization fixed-point condition.  There is one
+    vertical canonical decomposition and one compatible family of fusion
+    coisometries such that, at every chain length $N>0$, the retained density
+    operator factors as
+    \[
+      R_N=A_NB_N,
+      \qquad
+      [A_N,B_N]=0.
+    \]
+    On the summand selected by a sitewise BNT-copy configuration
+    $c=((\alpha_j,q_j))_{j=0}^{N-1}$, the two factors are
+    \[
+      (A_N)_c=m(c)I,
+      \qquad
+      (B_N)_c=W_{N,c}^{\dagger}Q_{N,c}W_{N,c}.
+    \]
+    Thus $A_N$ is the factor $\mu^{\otimes N}$ and $B_N$ is
+    $\widetilde U_NQ_N\widetilde U_N^\dagger$ in
+    \cite[lines~999--1002]{Cirac2016MPDO_arXiv}.  The source embedding is
+    $\widetilde U_N=W_{N,c}^{\dagger}$ in the retained-row convention.
+    No length-independence or projection hypothesis is imposed.
+\end{theorem}
+\begin{proof}\leanok
+    The two operators preserve the same direct-sum decomposition indexed by
+    the configurations~$c$.  On each summand the first factor is a scalar
+    multiple of the identity, so
+    \[
+      m(c)I\,
+        W_{N,c}^{\dagger}Q_{N,c}W_{N,c}
+      =
+        W_{N,c}^{\dagger}Q_{N,c}W_{N,c}\,m(c)I.
+    \]
+    Taking the direct sum and returning to the retained chain coordinates
+    proves the commutator.  The same block calculation identifies the product
+    with the all-label density operator.  The vertical decomposition and
+    fusion family are those already chosen for
+    Theorem~\ref{thm:mpdo_topological_density_decomposition}.
 \end{proof}
 
 \begin{definition}[Full-support specialization of one fusion layer]%

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -56,7 +56,7 @@ length-independent form stated at lines~1013--1016:
 where $H_N$ is a translationally invariant commuting nearest-neighbor
 Hamiltonian and the $P_i^{(N)}$ are orthogonal projections.
 
-\section{The formalized recursion and all-label density decomposition}
+\section{The formalized recursion, density decomposition, and commutator}
 
 For terminal orthogonal projections $P_\gamma$, one pairwise fusion step is
 the direct sum
@@ -181,31 +181,62 @@ $\mu^{\otimes N}$.  Hence
 line~999 with the source chain length~$N$ and no additional
 compatibility hypothesis.
 
-The assembled operator is
-\leanid{MPOTensor.BNTFusionTensorClause.topologicalDensityOperatorSucc}.  Its
-argument is one less than the positive source chain length.  The
-source-facing existence theorem is
-\leanid{MPOTensor.exists_topologicalDensityDecomposition_of_isRFPViaTS}; it
+In the namespace \leanid{MPOTensor.BNTFusionTensorClause}, the assembled
+operator is \leanid{topologicalDensityOperatorSucc}.  Its argument is one less
+than the positive source chain length.  The source-facing existence theorem
+is
+\path{MPOTensor.exists_topologicalDensityDecomposition_of_isRFPViaTS}; it
 chooses one vertical decomposition and proves both equalities in
 \eqref{eq:formalized-all-label-density} for every positive~$N$.
+
+\paragraph{The density-factor commutator.}
+In the same retained coordinates, the two factors are
+\begin{align}
+  A_N
+    &=
+      \bigoplus_c m(c)I_c,
+      \label{eq:formalized-multiplicity-factor}\\
+  B_N
+    &=
+      \bigoplus_c
+        W_{N,c}^{\dagger}Q_{N,c}W_{N,c}.
+      \label{eq:formalized-recursive-factor}
+\end{align}
+In the namespace \leanid{MPOTensor.BNTFusionTensorClause}, they are formalized
+as \leanid{multiplicityWeightOperatorSucc} and
+\leanid{recursiveTopologicalFactorSucc}.
+The first factor is scalar on every summand preserved by the second factor.
+Consequently,
+\begin{equation}
+  R_N=A_NB_N,
+  \qquad
+  [A_N,B_N]=0.
+  \label{eq:formalized-density-commutator}
+\end{equation}
+The source-facing theorem
+\path{MPOTensor.exists_topologicalDensityDecomposition_and_factorCommutation_of_isRFPViaTS}
+chooses the same vertical decomposition and fusion family for
+\eqref{eq:formalized-all-label-density} and
+\eqref{eq:formalized-density-commutator}.  This proves
+\eqref{eq:source-commutator} for every positive chain length.  It does not use
+length independence and does not assert that $Q_N$ or its transported factor
+is a projection.
 
 \section{Remaining proof}
 
 The all-label density identity
-\eqref{eq:source-chain-decomposition} is now formalized.  It does not by itself
-imply the next commutator or the later spectral statement.  A faithful proof
-of the remainder still requires:
+\eqref{eq:source-chain-decomposition} and its commutator
+\eqref{eq:source-commutator} are now formalized.  A faithful proof of the
+remainder still requires:
 \begin{enumerate}
-  \item the commutator identity \eqref{eq:source-commutator} for the assembled
-    operator;
   \item the terminal spectral decomposition and its compatibility with the
     recursive sectors;
   \item the construction of the commuting nearest-neighbor Hamiltonian and
     the projections in \eqref{eq:source-gibbs-decomposition}.
 \end{enumerate}
-The formalized density identity must not be cited as the commutator or the
-commuting Gibbs theorem of lines~1001--1016 until these remaining steps are
-proved.
+The formalized density identity and commutator must not be cited as the
+spectral refinement or the commuting Gibbs theorem of lines~1010--1016 until
+these remaining steps are proved.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Advances #4670
Advances #3950

## Summary

- define the multiplicity-weight and reconstructed recursive factors of the all-label topological density operator;
- prove blockwise that their product is the density operator and that the two factors commute;
- package the commutator with the same BNT fusion clause used for the RFP density decomposition;
- update the blueprint and the paper-gap account of the remaining argument.

The proof uses that, on every BNT-copy summand, the first factor is the scalar matrix $m(c)I$, while the second is $W_{N,c}^{\dagger}Q_{N,c}W_{N,c}$.

## Scope

This pull request proves the density-factor product and the commutator at arXiv:1606.00608, lines 999–1002. It does not prove or assume length independence, that the recursive factor is a projector, the terminal spectral refinement, or the commuting-Hamiltonian/Gibbs conclusions of lines 1010–1016.

## Validation

- `lake env lean TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean`
- `lake build TNLean.MPS.MPDO`
- `lake build`
- reader-facing prose, forbidden-token, import-aggregator, tactic-pattern, line-length, and diff checks
- serialized Python 3.9 `leanblueprint web`, `leanblueprint checkdecls`, and `leanblueprint pdf`
- visual inspection of the changed blueprint and paper-gap pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal definitions and proofs in an existing MPDO file plus blueprint/paper-gap prose; no auth, runtime, or API surface changes.
> 
> **Overview**
> Formalizes the **line-1001 density-factor identity** from arXiv:1606.00608 by naming the two summands of the retained all-label density operator: **`multiplicityWeightOperatorSucc`** (scalar \(m(c)I\) on each BNT-copy block) and **`recursiveTopologicalFactorSucc`** (\(W^\dagger Q W\) on each block).
> 
> **Lean:** Proves **`topologicalDensityOperatorSucc_eq_multiplicityWeightOperatorSucc_mul`** via block-diagonal algebra, and **`multiplicityWeightOperatorSucc_commute_recursiveTopologicalFactorSucc`** because the weight factor is scalar on every block the recursive factor preserves. Adds **`exists_topologicalDensityDecomposition_and_factorCommutation_of_isRFPViaTS`**, reusing the same BNT fusion clause as the existing density decomposition with no extra hypotheses (no length independence or projection assumptions).
> 
> **Docs:** Blueprint gains **Theorem: Commutation of the all-label density factors**; the paper-gap note now treats the commutator as formalized and narrows the remaining work to spectral refinement and the commuting Gibbs decomposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a4704f03137bbd1f756b0ade1d384500fb8d550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->