### PR TITLE
feat(MPS/MPDO): prove topological density commutator

### DIFF
--- a/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
+++ b/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
@@ -26,12 +26,15 @@ In a fixed copy configuration, the diagonal entry of the tensor power of the mul
 matrix is the product of the chosen positive weights.  The remaining factor is the recursive
 terminal operator transported back through the adjoint sequential fusion coisometry.  Taking
 the direct sum over all copy configurations gives the density operator in retained vertical
-coordinates.  Applying the adjoint vertical map reconstructs the original density exactly.
+coordinates.  The two global direct-sum factors commute because the multiplicity block is a
+scalar identity in every configuration.  Applying the adjoint vertical map reconstructs the
+original density exactly.
 
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Proposition 4.13, lines 943--951, and the density identity at line 999
+  Proposition 4.13, lines 943--951, and the density and commutator identities
+  at lines 999--1002
 -/
 
 open scoped Matrix BigOperators Kronecker
@@ -204,6 +207,70 @@ def topologicalDensityOperatorSucc (H : BNTFusionTensorClause M) (N : ℕ) :
   Matrix.reindex (H.verticalCopyChainEquiv N).symm
     (H.verticalCopyChainEquiv N).symm
       (Matrix.blockDiagonal' fun p ↦ H.topologicalDensityBlock p)
+
+/-- The all-label multiplicity-weight factor on a positive retained chain.
+
+In each copy-configuration block this is the selected diagonal coefficient of
+`μ⁽⊗ⁿ⁺¹⁾` times the identity on the simple-bond fiber.
+
+Source: arXiv:1606.00608, lines 999--1002. -/
+def topologicalMultiplicityWeightFactorSucc (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix (Fin (N + 1) → Fin H.verticalRetainedDim)
+      (Fin (N + 1) → Fin H.verticalRetainedDim) ℂ :=
+  Matrix.reindex (H.verticalCopyChainEquiv N).symm
+    (H.verticalCopyChainEquiv N).symm
+      (Matrix.blockDiagonal' fun p ↦ H.verticalMultiplicityChainWeight p • 1)
+
+/-- The all-label recursive topological factor on a positive retained chain.
+
+Its block in a copy configuration is `Wᴴ Q W`, where `W` is the retained-row
+sequential fusion coisometry.  Thus `Wᴴ` is the source embedding `\tilde U`.
+
+Source: arXiv:1606.00608, lines 999--1002. -/
+def topologicalRecursiveFactorSucc (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix (Fin (N + 1) → Fin H.verticalRetainedDim)
+      (Fin (N + 1) → Fin H.verticalRetainedDim) ℂ :=
+  Matrix.reindex (H.verticalCopyChainEquiv N).symm
+    (H.verticalCopyChainEquiv N).symm
+      (Matrix.blockDiagonal' fun p ↦
+        (H.verticalCopyChainFusionCoisometry p)ᴴ *
+          H.verticalCopyChainProjectorQ p *
+            H.verticalCopyChainFusionCoisometry p)
+
+/-- The all-label density operator is the product of its multiplicity-weight and recursive
+topological factors at every positive chain length.
+
+Source: arXiv:1606.00608, lines 999--1002. -/
+theorem topologicalDensityOperatorSucc_eq_multiplicityWeight_mul_recursiveFactor
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    H.topologicalDensityOperatorSucc N =
+      H.topologicalMultiplicityWeightFactorSucc N *
+        H.topologicalRecursiveFactorSucc N := by
+  unfold topologicalDensityOperatorSucc topologicalMultiplicityWeightFactorSucc
+    topologicalRecursiveFactorSucc topologicalDensityBlock
+  simp only [Matrix.reindex_apply]
+  rw [Matrix.submatrix_mul_equiv, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext p
+  simp
+
+/-- The all-label multiplicity-weight factor commutes with the reconstructed recursive
+topological factor at every positive chain length.
+
+Source: arXiv:1606.00608, commutator identity at lines 1000--1002. -/
+theorem topologicalMultiplicityWeightFactorSucc_commutes_recursiveFactor
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    H.topologicalMultiplicityWeightFactorSucc N *
+        H.topologicalRecursiveFactorSucc N =
+      H.topologicalRecursiveFactorSucc N *
+        H.topologicalMultiplicityWeightFactorSucc N := by
+  unfold topologicalMultiplicityWeightFactorSucc topologicalRecursiveFactorSucc
+  simp only [Matrix.reindex_apply]
+  rw [Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv,
+    ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext p
+  simp
 
 /-- The horizontal matrix obtained by fixing the two simple-bond coordinates of one vertical
 BNT tensor.
@@ -513,6 +580,18 @@ def HasTopologicalDensityDecomposition (H : BNTFusionTensorClause M) : Prop :=
       singleKrausMap (sitewisePhysicalMatrix H.verticalCoisometryᴴ (N + 1))
         (H.topologicalDensityOperatorSucc N) = mpo M (N + 1)
 
+/-- The line-1001 commutator for the same all-label factors at every positive chain length.
+
+The parameter `N` represents source chain length `N + 1`.
+
+Source: arXiv:1606.00608, commutator identity at lines 1000--1002. -/
+def HasTopologicalDensityFactorCommutator (H : BNTFusionTensorClause M) : Prop :=
+  ∀ N : ℕ,
+    H.topologicalMultiplicityWeightFactorSucc N *
+        H.topologicalRecursiveFactorSucc N =
+      H.topologicalRecursiveFactorSucc N *
+        H.topologicalMultiplicityWeightFactorSucc N
+
 /-- A chosen BNT fusion clause supplies the complete positive-length line-999 density
 decomposition, with no additional compatibility hypothesis.
 
@@ -523,6 +602,14 @@ theorem hasTopologicalDensityDecomposition (H : BNTFusionTensorClause M) :
   exact ⟨H.singleKrausMap_verticalCoisometry_mpo_eq_topologicalDensityOperatorSucc N,
     H.singleKrausMap_conjTranspose_verticalCoisometry_topologicalDensityOperatorSucc_eq_mpo
       N⟩
+
+/-- A chosen BNT fusion clause satisfies the all-label line-1001 commutator at every
+positive chain length, with no additional compatibility hypothesis.
+
+Source: arXiv:1606.00608, commutator identity at lines 1000--1002. -/
+theorem hasTopologicalDensityFactorCommutator (H : BNTFusionTensorClause M) :
+    H.HasTopologicalDensityFactorCommutator :=
+  H.topologicalMultiplicityWeightFactorSucc_commutes_recursiveFactor
 
 end MPOTensor.BNTFusionTensorClause
 
@@ -549,5 +636,25 @@ theorem exists_topologicalDensityDecomposition_of_isRFPViaTS
     ∃ H : BNTFusionTensorClause M, H.HasTopologicalDensityDecomposition := by
   obtain ⟨H⟩ := HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
   exact ⟨H, H.hasTopologicalDensityDecomposition⟩
+
+/-- **All-label density-factor commutator for an RFP MPDO.**
+
+A horizontal-canonical MPDO satisfying the source renormalization fixed-point condition
+admits one BNT fusion clause that gives both the exact all-label density decomposition and
+the commutator between its multiplicity-weight and reconstructed recursive factors at every
+positive chain length.  No caller-supplied fusion clause or compatibility hypothesis is
+required.
+
+Source: arXiv:1606.00608, density decomposition and commutator at lines 999--1002.
+This theorem makes no length-independence, terminal spectral, projector, or Gibbs-state
+assertion. -/
+theorem exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) :
+    ∃ H : BNTFusionTensorClause M,
+      H.HasTopologicalDensityDecomposition ∧ H.HasTopologicalDensityFactorCommutator := by
+  obtain ⟨H⟩ := HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
+  exact ⟨H, H.hasTopologicalDensityDecomposition,
+    H.hasTopologicalDensityFactorCommutator⟩
 
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1635,6 +1635,9 @@ separate step.
     \lean{MPOTensor.BNTFusionTensorClause.verticalCopyChainProjectorQ}
     \lean{MPOTensor.BNTFusionTensorClause.topologicalDensityBlock}
     \lean{MPOTensor.BNTFusionTensorClause.topologicalDensityOperatorSucc}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        topologicalMultiplicityWeightFactorSucc}
+    \lean{MPOTensor.BNTFusionTensorClause.topologicalRecursiveFactorSucc}
     \leanok
     \uses{def:mpdo_topological_projector_recursion,
         def:mpdo_bnt_fusion_tensor_clause,
@@ -1669,6 +1672,13 @@ separate step.
     $W_{N,c}^\dagger$.
     The all-label recursive density operator is the direct sum of these blocks
     over every sitewise label and diagonal coordinate; denote it by $R_N$.
+    On the same direct-sum coordinates, define
+    \[
+      A_N=\bigoplus_c m(c)I_c,
+      \qquad
+      T_N=\bigoplus_c W_{N,c}^{\dagger}Q_{N,c}W_{N,c}.
+    \]
+    Then $R_N=A_NT_N$.
     Its scalar coefficients are precisely the selected diagonal coefficients
     of the factor $\mu^{\otimes N}$ in
     \cite[line~999]{Cirac2016MPDO_arXiv}; the identities mentioned there act on
@@ -1682,6 +1692,7 @@ separate step.
     \lean{MPOTensor.BNTFusionTensorClause.%
         singleKrausMap_conjTranspose_verticalCoisometry_topologicalDensityOperatorSucc_eq_mpo}
     \lean{MPOTensor.BNTFusionTensorClause.HasTopologicalDensityDecomposition}
+    \lean{MPOTensor.BNTFusionTensorClause.hasTopologicalDensityDecomposition}
     \lean{MPOTensor.exists_topologicalDensityDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
@@ -1725,6 +1736,43 @@ separate step.
     identity and its exact reverse identity, then sum over all configurations.
     The local reconstruction identity, applied at every site, gives the stated
     adjoint reconstruction of the original density operator.
+\end{proof}
+
+\begin{corollary}[All-label density-factor commutator]%
+    \label{cor:mpdo_topological_density_factor_commutator}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        topologicalDensityOperatorSucc_eq_multiplicityWeight_mul_recursiveFactor}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        topologicalMultiplicityWeightFactorSucc_commutes_recursiveFactor}
+    \lean{MPOTensor.BNTFusionTensorClause.HasTopologicalDensityFactorCommutator}
+    \lean{MPOTensor.BNTFusionTensorClause.hasTopologicalDensityFactorCommutator}
+    \lean{MPOTensor.exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
+        def:mpdo_topological_density_operator,
+        thm:mpdo_topological_density_decomposition}
+    Let $M$ be a matrix product density operator in horizontal canonical form
+    and suppose that it satisfies the renormalization fixed-point condition.
+    One choice of the vertical canonical decomposition and fusion
+    coisometries satisfies, for every $N>0$,
+    \[
+      R_N=A_NT_N,
+      \qquad
+      A_NT_N=T_NA_N.
+    \]
+    Equivalently, $[A_N,T_N]=0$, as asserted in
+    \cite[lines~1000--1002]{Cirac2016MPDO_arXiv}.  No additional compatibility
+    hypothesis is imposed.  This statement makes no length-independence,
+    terminal spectral, projection, Hamiltonian, or Gibbs-state assertion.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:mpdo_rfp_to_bnt_fusion_tensor}
+    In every sitewise copy configuration, the factor $A_N$ is the scalar
+    $m(c)$ times the identity on the corresponding simple-bond space.
+    It therefore commutes with
+    $W_{N,c}^{\dagger}Q_{N,c}W_{N,c}$.  Multiplication of the two direct sums
+    proves both identities.  The renormalization fixed-point condition
+    supplies the same fusion family used in the density decomposition.
 \end{proof}
 
 \begin{definition}[Full-support specialization of one fusion layer]%

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -189,23 +189,49 @@ source-facing existence theorem is
 chooses one vertical decomposition and proves both equalities in
 \eqref{eq:formalized-all-label-density} for every positive~$N$.
 
+\section{The all-label commutator}
+
+On the same all-label coordinates, let
+\begin{equation}
+  A_N=\bigoplus_c m(c)I_c,
+  \qquad
+  T_N=\bigoplus_c W_{N,c}^{\dagger}Q_{N,c}W_{N,c}.
+  \label{eq:formalized-density-factors}
+\end{equation}
+The operator in \eqref{eq:formalized-all-label-density} is $R_N=A_NT_N$.
+Within every copy-configuration block, $A_N$ is a scalar multiple of the
+identity.  Hence direct-sum multiplication gives
+\begin{equation}
+  A_NT_N=T_NA_N.
+  \label{eq:formalized-density-commutator}
+\end{equation}
+This proves \eqref{eq:source-commutator} for every positive chain length,
+without length independence or a caller-supplied compatibility condition.
+The two factors are
+\leanid{MPOTensor.BNTFusionTensorClause.topologicalMultiplicityWeightFactorSucc}
+and
+\leanid{MPOTensor.BNTFusionTensorClause.topologicalRecursiveFactorSucc}.
+The source-facing theorem
+\leanid{MPOTensor.exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS}
+chooses the same fusion clause for
+\eqref{eq:formalized-all-label-density} and
+\eqref{eq:formalized-density-commutator}.
+
 \section{Remaining proof}
 
 The all-label density identity
-\eqref{eq:source-chain-decomposition} is now formalized.  It does not by itself
-imply the next commutator or the later spectral statement.  A faithful proof
-of the remainder still requires:
+\eqref{eq:source-chain-decomposition} and its commutator
+\eqref{eq:source-commutator} are now formalized.  A faithful proof of the
+remainder still requires:
 \begin{enumerate}
-  \item the commutator identity \eqref{eq:source-commutator} for the assembled
-    operator;
   \item the terminal spectral decomposition and its compatibility with the
     recursive sectors;
   \item the construction of the commuting nearest-neighbor Hamiltonian and
     the projections in \eqref{eq:source-gibbs-decomposition}.
 \end{enumerate}
-The formalized density identity must not be cited as the commutator or the
-commuting Gibbs theorem of lines~1001--1016 until these remaining steps are
-proved.
+The formalized commutator must not be cited as the terminal spectral
+refinement or the commuting Gibbs theorem of lines~1003--1016 until these
+remaining steps are proved.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

- define the all-label multiplicity-weight and reconstructed recursive topological factors in the landed retained-row coordinates
- prove their product is the line-999 density operator and that the two factors commute at every positive chain length
- add a source-facing CF + MPDO + RFP corollary that chooses the fusion clause internally, then update the blueprint and paper-gap boundary

## Source

CPSV16, arXiv:1606.00608, lines 999–1002. In the retained-row convention, the source embedding is the adjoint of the sequential fusion coisometry, so each recursive block is W† Q W.

## Scope

This stops before length independence, terminal spectral refinement, projector orthogonality, the commuting nearest-neighbor Hamiltonian, and the Gibbs decomposition.

## Validation

- lake env lean TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
- lake build TNLean.MPS.MPDO.TopologicalDensityDecomposition TNLean.MPS.MPDO
- lake build (9,732 jobs)
- proof-integrity, import-aggregator, reader-prose, and tactic-pattern checks
- blueprint synchronization, reverse coverage, and checkdecls
- leanblueprint web and pdf; visually inspected the rendered corollary page

Closes #4670

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in MPDO topology; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes the **all-label density operator** as a product of two global direct-sum factors on retained vertical coordinates: a **multiplicity-weight** block \(A_N\) (scalar \(m(c)\) times identity per copy configuration) and a **recursive topological** block \(T_N\) (\(W^\dagger Q W\) per configuration). New Lean definitions `topologicalMultiplicityWeightFactorSucc` and `topologicalRecursiveFactorSucc` prove **\(R_N = A_N T_N\)** and **\(A_N T_N = T_N A_N\)** via block-diagonal multiplication, matching CPSV16 lines 1000–1002.
> 
> Adds `HasTopologicalDensityFactorCommutator`, clause-level `hasTopologicalDensityFactorCommutator`, and **`exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS`** (same internally chosen BNT fusion clause as the line-999 decomposition). Blueprint gains corollary **All-label density-factor commutator** and the paper-gap note moves the commutator from “remaining proof” to formalized, while still excluding spectral/Gibbs steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e34fca791ab2e91e8d3940afef76fe2d47822e9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->