### PR TITLE
doc(MPS/MPDO): correct commutator dependency metadata

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1749,8 +1749,7 @@ separate step.
     \lean{MPOTensor.exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        def:mpdo_topological_density_operator,
-        thm:mpdo_topological_density_decomposition}
+        def:mpdo_topological_density_operator}
     Let $M$ be a matrix product density operator in horizontal canonical form
     and suppose that it satisfies the renormalization fixed-point condition.
     One choice of the vertical canonical decomposition and fusion


### PR DESCRIPTION
## Summary

- remove the density-decomposition theorem from the statement dependencies of the all-label density-factor commutator corollary
- retain the actual proof dependency on the RFP-to-BNT fusion theorem

The corollary statement uses only the definitions needed to formulate its hypotheses and factors. Its Lean proof obtains the fusion clause directly and does not call the density-decomposition theorem, so the removed dependency was neither a statement dependency nor a proof dependency.

No Lean source or mathematical prose changes.

## Validation

- change-scoped reader-facing prose check
- `leanblueprint web`
- `leanblueprint pdf` (rendered pages 708–710 inspected)
- `lake build TNLean.MPS.MPDO`
- `leanblueprint checkdecls`

Advances #3950

Related #4670

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint `\uses` edit with no Lean or formal proof changes.
> 
> **Overview**
> Updates **leanblueprint** dependency metadata on the all-label density-factor commutator corollary (`cor:mpdo_topological_density_factor_commutator`) in `ch21_mpdo_rfp_fusion_isometries.tex`.
> 
> **`thm:mpdo_topological_density_decomposition`** is dropped from the corollary’s `\uses` block. The corollary’s hypotheses and factors are still tied to **`def:mpdo_topological_density_operator`** (and the usual MPDO/RFP definitions); the Lean proof is described as going through the RFP→BNT fusion tensor clause, not the density-decomposition theorem.
> 
> No Lean sources or mathematical prose change—metadata alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ee02f940de0016428a528acec46a75b4b6e1122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->