### PR TITLE
refactor(MPS): centralize BNT basis normality

### DIFF
--- a/TNLean/MPS/BNT/Bridge.lean
+++ b/TNLean/MPS/BNT/Bridge.lean
@@ -115,19 +115,6 @@ namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
 
-/-- Every basis tensor in BNT canonical form is algebraically normal.
-
-The canonical-form irreducibility, left-canonicality, normalized self-overlap,
-and positive bond dimension imply eventual block injectivity.
-
-Source: CPSV21, arXiv:2011.12127, lines 1815--1830. -/
-theorem basis_isNormal (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
-    IsNormal (P.basis j) := by
-  letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
-  exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-    (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-      (hCF.basis_normalized_self_overlap j)
-
 /-- Forget a BNT canonical form to the algebraic BNT carried by its basis.
 
 The sector coefficient formula supplies the spanning clause, while

--- a/TNLean/MPS/BNT/Bridge.lean
+++ b/TNLean/MPS/BNT/Bridge.lean
@@ -31,8 +31,6 @@ absent from `IsBNT`.
 * `IsCPSVBasisOfNormalTensors.isBNT`: a CPSV16 BNT gives an algebraic BNT;
 * `IsBNT.of_sameMPV₂Pos`: transport an algebraic BNT along positive-length MPV
   equality;
-* `IsBNTCanonicalForm.basis_isNormal`: every canonical-form basis block is
-  algebraically normal;
 * `IsBNTCanonicalForm.isBNT`: forget a canonical form to its algebraic BNT.
 
 ## References

--- a/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
+++ b/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
@@ -167,6 +167,19 @@ namespace MPSTensor.IsBNTCanonicalForm
 
 variable {d : ℕ} {P : SectorDecomposition d}
 
+/-- Every basis tensor in BNT canonical form is algebraically normal.
+
+The canonical-form irreducibility, left-canonicality, normalized self-overlap,
+and positive bond dimension imply eventual block injectivity.
+
+Source: CPSV21, arXiv:2011.12127, lines 1815--1830. -/
+theorem basis_isNormal (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount) :
+    IsNormal (P.basis j) := by
+  letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+  exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
+    (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
+      (hCF.basis_normalized_self_overlap j)
+
 /-- Every representative of a BNT canonical form is block injective at the
 common length $D^4$, where $D$ is the total bond dimension.
 
@@ -181,10 +194,7 @@ theorem basis_isNBlkInjective_totalDim_pow_four
       IsNBlkInjective (P.basis j) (P.totalDim ^ 4) := by
   intro j
   letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
-  have hNormal : IsNormal (P.basis j) :=
-    isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-      (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-        (hCF.basis_normalized_self_overlap j)
+  have hNormal : IsNormal (P.basis j) := hCF.basis_isNormal j
   have hOwn : IsNBlkInjective (P.basis j) ((P.basisDim j) ^ 4) :=
     isNBlkInjective_pow_four_of_isNormal_leftCanonical
       (P.basis j) (hCF.basis_left_canonical j) hNormal
@@ -207,12 +217,8 @@ lines 1815--1837. -/
 theorem exists_common_basis_isNBlkInjective
     (hCF : IsBNTCanonicalForm P) :
     ∃ L : ℕ, 0 < L ∧ ∀ j : Fin P.basisCount, IsNBlkInjective (P.basis j) L := by
-  have hNormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) := by
-    intro j
-    letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
-    exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-      (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-        (hCF.basis_normalized_self_overlap j)
+  have hNormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) :=
+    hCF.basis_isNormal
   exact exists_common_isNBlkInjective_of_isNormal_leftCanonical
     P.basis hCF.basis_left_canonical (fun j ↦ (hCF.basis_dim_pos j).ne') hNormal
 

--- a/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
+++ b/TNLean/MPS/Periodic/NormalizedSelfOverlap.lean
@@ -21,6 +21,15 @@ normality.
 This is the implication needed to recover the block-injectivity content of a
 basis of normal tensors from the normalized representatives.
 
+## Main results
+
+* `isPrimitive_and_isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one`:
+  normalized self-overlap implies primitivity and normality;
+* `IsBNTCanonicalForm.basis_isNormal`: every canonical-form basis block is
+  algebraically normal;
+* `IsBNTCanonicalForm.exists_common_basis_isNBlkInjective`: all basis blocks
+  are block injective at one common length.
+
 ## References
 
 * [Cirac--Pérez-García--Schuch--Verstraete, arXiv:2011.12127, lines 1815--1837]

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -378,11 +378,8 @@ theorem rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum
   · letI : NeZero d := ⟨hd⟩
     letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
       fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
-    have hnormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) := by
-      intro j
-      exact isNormal_of_irreducible_leftCanonical_selfOverlap_tendsto_one
-        (P.basis j) (hCF.basis_irreducible j) (hCF.basis_left_canonical j)
-          (hCF.basis_normalized_self_overlap j)
+    have hnormal : ∀ j : Fin P.basisCount, IsNormal (P.basis j) :=
+      hCF.basis_isNormal
     have hOne : WordTupleSpanTop P.basis 1 :=
       wordTupleSpanTop_one_of_isTransferIdempotent_directSum P.basis
         hnormal hCF.basis_irreducible hCF.basis_left_canonical


### PR DESCRIPTION
### Motivation

Supersedes #4632, which GitHub would not reopen after its source branch was
rebased. The replacement preserves the same focused diff and review correction.

Follow-up to #4520. The common blockwise-normality consequence of a
paper-faithful BNT canonical form should live with the normalized self-overlap
result from which it follows, rather than in the carrier-comparison module.

### Description

- Move `IsBNTCanonicalForm.basis_isNormal` from
  `TNLean/MPS/BNT/Bridge.lean` to
  `TNLean/MPS/Periodic/NormalizedSelfOverlap.lean`.
- Reuse the public theorem in the BNT bridge and the multi-sector RFP proof
  instead of repeating its proof.
- Remove the stale `Bridge.lean` module-docstring entry identified in review.

The theorem name, statement, and blueprint declaration link are unchanged.

### Testing

- `lake build` (9,730 jobs; completed successfully)
- `git diff --check`
- proof-integrity scan of all three changed Lean files

`leanblueprint checkdecls` was not run locally because `leanblueprint` is not
installed in this environment; the pull-request blueprint check remains the
gate for that validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only relocation and reuse with no API or behavioral changes beyond module organization.
> 
> **Overview**
> **`IsBNTCanonicalForm.basis_isNormal`** is moved from `BNT/Bridge.lean` into `Periodic/NormalizedSelfOverlap.lean`, next to the normalized self-overlap → normality lemmas it uses. The theorem name and statement are unchanged.
> 
> Call sites in **`Bridge.isBNT`**, the block-injectivity lemmas in **`NormalizedSelfOverlap`**, and **`NNCPHMultiSector`** now invoke **`hCF.basis_isNormal`** instead of inlining the same proof. Module docstrings are updated so Bridge no longer lists the moved result and NormalizedSelfOverlap documents it under **Main results**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f913fe35b3b4c94112785e176a1b9cab42407a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->