### PR TITLE
feat(MPS/MPDO): prove terminal transfer positivity

### DIFF
--- a/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
+++ b/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
@@ -37,7 +37,7 @@ original density exactly.
   at lines 999--1002
 -/
 
-open scoped Matrix BigOperators Kronecker
+open scoped Matrix BigOperators Kronecker ComplexOrder
 
 noncomputable section
 
@@ -418,6 +418,52 @@ theorem changePhysicalBasis_verticalCoisometry_copy_ne
     Equiv.symm_symm, Equiv.apply_symm_apply,
     Matrix.blockDiagonal'_apply_ne _ _ _ hpq, Pi.zero_apply,
     Matrix.zero_apply] using hAssembled
+
+/-- The terminal physical-trace transfer of every vertical basis tensor is positive
+semidefinite.  It is obtained by restricting the positive one-site density operator to one
+positive multiplicity coordinate and removing its strictly positive scalar weight.
+
+Source: arXiv:1606.00608, the terminal matrices and their spectral decomposition at
+lines 1010--1012.  This positivity result supplies the spectral decomposition used before the
+projector and commuting Gibbs conclusions at lines 1013--1016; it assumes neither length
+independence nor any spectral or projection property.
+
+**Local fix (terminal trace orientation):** The physical trace closes the horizontal operator
+leg of the vertical basis tensor and leaves its bond pair open.  This is documented in
+`docs/paper-gaps/cpsv16_topological_projector_recursion.tex`. -/
+theorem physTraceTransfer_verticalBNTMPO_posSemidef
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M) (γ : Fin H.labelCount) :
+    (physTraceTransfer (verticalBNTMPO (H.tensor γ))).PosSemidef := by
+  classical
+  let q : Fin (H.multiplicity γ) := ⟨0, H.multiplicity_pos γ⟩
+  let p : H.VerticalCopy := ⟨γ, q⟩
+  let e : Fin (H.bondDim γ) → (Fin 1 → Fin H.verticalRetainedDim) :=
+    fun x _ ↦
+      (verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨p, x⟩
+  have hRetained :
+      (mpo (changePhysicalBasis H.verticalCoisometry M) 1).PosSemidef := by
+    rw [← singleKrausMap_sitewisePhysicalMatrix_mpo]
+    exact (singleKrausMap_isKrausCP _).map_posSemidef (hM 1 zero_lt_one)
+  have hPrincipalEq :
+      (mpo (changePhysicalBasis H.verticalCoisometry M) 1).submatrix e e =
+        H.weight γ q • physTraceTransfer (verticalBNTMPO (H.tensor γ)) := by
+    ext x y
+    simp only [Matrix.submatrix_apply, mpo_apply, mpoMatrixEntry, List.ofFn_succ,
+      List.ofFn_zero, evalWord_cons, evalWord_nil, Matrix.mul_one, e]
+    rw [H.changePhysicalBasis_verticalCoisometry_copy_same]
+    rw [Matrix.trace_smul, Matrix.smul_apply]
+    congr 1
+    simp [p, Matrix.trace, physTraceTransfer, Matrix.sum_apply, verticalCopyChainLetter,
+      verticalBNTMPO]
+  have hScaled :
+      (H.weight γ q • physTraceTransfer (verticalBNTMPO (H.tensor γ))).PosSemidef := by
+    rw [← hPrincipalEq]
+    exact hRetained.submatrix e
+  have hUnscaled :
+      ((H.weight γ q)⁻¹ •
+        (H.weight γ q • physTraceTransfer (verticalBNTMPO (H.tensor γ)))).PosSemidef :=
+    hScaled.smul (inv_nonneg_of_nonneg (H.weight_pos γ q).le)
+  simpa only [inv_smul_smul₀ (H.weight_pos γ q).ne'] using hUnscaled
 
 /-- The recursive line-999 block has the fixed-copy closed-chain matrix entries.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1628,6 +1628,44 @@ separate step.
     virtual product is the word evaluation of the original tensor.
 \end{proof}
 
+\begin{theorem}[Positivity of the terminal transfer matrices]%
+    \label{thm:mpdo_terminal_transfer_positivity}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        physTraceTransfer_verticalBNTMPO_posSemidef}
+    \leanok
+    \uses{def:mpdo, def:mpdo_bnt_fusion_tensor_clause,
+        def:mpo_physical_trace_transfer,
+        lem:mpdo_sitewise_physical_coordinate_congruence}
+    Let $M$ be a matrix product density operator, and choose a vertical
+    canonical decomposition with basis tensors $M_\gamma$ and positive
+    diagonal multiplicity matrices $\mu_\gamma$.  Then every terminal
+    transfer matrix
+    \[
+        T_\gamma=\operatorname{tr}(M_\gamma)
+    \]
+    is positive semidefinite.  This supplies the positivity needed for the
+    spectral decomposition invoked in
+    \cite[lines~1010--1016]{Cirac2016MPDO_arXiv}; it asserts neither that
+    $T_\gamma$ is a projection nor the subsequent spectral, Hamiltonian, or
+    Gibbs decomposition.
+
+    \textbf{Local fix (terminal trace orientation):} The trace closes the
+    horizontal operator leg and leaves the two bond indices of $M_\gamma$
+    open.  See
+    \path{docs/paper-gaps/cpsv16_topological_projector_recursion.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    At chain length one, conjugating the positive density operator by the
+    retained-row vertical coisometry preserves positivity.  Fix a label
+    $\gamma$ and a diagonal coordinate $q$ of $\mu_\gamma$.  The corresponding
+    principal block is
+    \[
+        (\mu_\gamma)_{q,q}\,T_\gamma.
+    \]
+    Since $(\mu_\gamma)_{q,q}>0$, multiplication by its reciprocal proves
+    $T_\gamma\geq0$.
+\end{proof}
+
 \begin{definition}[All-label recursive density operator]%
     \label{def:mpdo_topological_density_operator}
     \lean{MPOTensor.BNTFusionTensorClause.verticalMultiplicityChainWeight}

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -107,6 +107,25 @@ in \path{Papers/1606.00608/MPDO_O_L_A_.png} and
 \path{Papers/1606.00608/MPDO_Structure.png}.  Equation
 \eqref{eq:one-layer-terminal-fusion} restores the latter contraction.
 
+For a matrix product density operator, each terminal matrix in this
+orientation is now proved positive semidefinite:
+\begin{equation}
+  \operatorname{tr}(M_\gamma)\geq 0.
+  \label{eq:formalized-terminal-positivity}
+\end{equation}
+Indeed, at chain length one the retained vertical congruence preserves
+positivity.  Restricting to one label $\gamma$ and one diagonal coordinate
+$q$ of its positive multiplicity matrix gives the principal block
+\begin{equation}
+  (\mu_\gamma)_{q,q}\operatorname{tr}(M_\gamma)\geq0.
+\end{equation}
+Since $(\mu_\gamma)_{q,q}>0$, division by this scalar proves
+\eqref{eq:formalized-terminal-positivity}.  This is formalized by
+\leanid{MPOTensor.BNTFusionTensorClause.physTraceTransfer_verticalBNTMPO_posSemidef}.
+It supplies the positivity needed for the spectral decomposition invoked at
+lines~1010--1016, but does not assert that the terminal matrices are
+projections.
+
 The pairwise construction has now been iterated along an arbitrary finite
 chain with a fixed initial label.  For total chain length $N\geq1$, the
 appended-label list has length $N-1$; the symbols $Q_N$ and $W_N$ below refer
@@ -224,14 +243,15 @@ The all-label density identity
 \eqref{eq:source-commutator} are now formalized.  A faithful proof of the
 remainder still requires:
 \begin{enumerate}
-  \item the terminal spectral decomposition and its compatibility with the
-    recursive sectors;
+  \item the spectral refinement of the positive terminal matrices into
+    orthogonal projections and its compatibility with the recursive sectors;
   \item the construction of the commuting nearest-neighbor Hamiltonian and
     the projections in \eqref{eq:source-gibbs-decomposition}.
 \end{enumerate}
-The formalized commutator must not be cited as the terminal spectral
-refinement or the commuting Gibbs theorem of lines~1003--1016 until these
-remaining steps are proved.
+The positivity statement
+\eqref{eq:formalized-terminal-positivity} and the formalized commutator must
+not be cited as the terminal spectral refinement or the commuting Gibbs
+theorem of lines~1003--1016 until these remaining steps are proved.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

CPSV16 uses a spectral decomposition of the terminal matrices `tr(M_γ)` after the recursive density decomposition and commutator (arXiv:1606.00608, lines 1010–1016). This pull request proves the required positivity directly from the MPDO hypothesis. It does not assert the remaining spectral-projector compatibility or the commuting Hamiltonian and Gibbs decomposition.

### Description

- Prove `BNTFusionTensorClause.physTraceTransfer_verticalBNTMPO_posSemidef` for every vertical BNT basis tensor.
- At chain length one, restrict the positive retained-coordinate density matrix to one label and one positive multiplicity coordinate. The resulting principal block is `(μ_γ)_{q,q} • tr(M_γ)`; division by the strictly positive weight proves `tr(M_γ) ≥ 0`.
- Add the Chapter 21 blueprint theorem and proof, with `\lean` and `\leanok` annotations.
- Update `docs/paper-gaps/cpsv16_topological_projector_recursion.tex` to record positivity as complete while retaining the terminal spectral-projector refinement and commuting Gibbs theorem as open.
- Preserve the current-main commutator dependency correction from #4677.

The Lean theorem assumes only the BNT fusion clause, the MPDO condition, and a terminal label. It assumes no RFP condition, length independence, projection data, spectral decomposition, or desired conclusion.

### Validation

- `lake env lean TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean`
- `lake build TNLean.MPS.MPDO`
- `lake build`
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `PYTHONPATH=scripts python3 scripts/check_oversized_lean_files.py`
- `python3 scripts/check_numbered_lean_files.py --base-ref origin/main`
- Python 3.9: `leanblueprint web`, `leanblueprint checkdecls`, `leanblueprint pdf`
- Visually inspected the theorem and proof on PDF physical pages 709–710 (printed pages 708–709); no clipping, collision, or malformed mathematical glyphs.
- Compiled the updated standalone paper-gap note with `latexmk`.

The full blueprint build retains four pre-existing unresolved references to `thm:dim_preserved`; this change introduces no new unresolved reference.

Advances #4676
Advances #3950

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proof and documentation only; no runtime, auth, or API behavior changes. Assumptions stay within existing BNT fusion clause and MPDO hypotheses.
> 
> **Overview**
> Adds **`physTraceTransfer_verticalBNTMPO_posSemidef`**, showing that for an MPDO and each vertical BNT basis tensor, the terminal physical-trace transfer **`tr(M_γ)`** (horizontal leg closed, bond indices open) is positive semidefinite. The proof uses length-one positivity of the retained vertical density, identifies a principal block as **`(μ_γ)_{q,q} • tr(M_γ)`** for a positive multiplicity coordinate, then divides by that strictly positive weight.
> 
> Chapter 21 gains theorem **`thm:mpdo_terminal_transfer_positivity`** with `\lean` / `\leanok` links. The CPSV16 topological projector gap note records this as done and reframes what remains: spectral refinement into orthogonal projections and the commuting Gibbs decomposition—not projection or Gibbs conclusions yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19bafca21752ea9eaa8df46cfa0cc607ebb28d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->