### PR TITLE
feat(Analysis): prove support-domain relative-entropy integral

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -33,6 +33,7 @@ import TNLean.Analysis.PosSemidefCommute
 import TNLean.Analysis.ProbabilityEntropy
 import TNLean.Analysis.ProjectionGeometry
 import TNLean.Analysis.RelativeEntropyResolventIntegral
+import TNLean.Analysis.RelativeEntropySupportIntegral
 import TNLean.Analysis.ResolventFunctionalCalculus
 import TNLean.Analysis.RpowConvexity
 import TNLean.Analysis.SchattenNorm

--- a/TNLean/Analysis/RelativeEntropyResolventIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropyResolventIntegral.lean
@@ -9,16 +9,20 @@ import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 import Mathlib.LinearAlgebra.Matrix.Vec
 
 /-!
-# Resolvent integral representation of positive-definite relative entropy
+# Resolvent integral representations of relative entropy
 
 This file proves the scalar logarithmic integral and the finite-dimensional
-spectral identities needed to express positive-definite quantum relative
-entropy through the resolvents of `X ↦ A * X + t • (X * B)`.
+spectral identities needed for resolvent representations of quantum relative
+entropy. It includes the support-domain spectral integrand for
+positive-semidefinite matrices and the coordinate-free resolvent formula for
+positive-definite matrices.
 
 ## Main results
 
 * `relativeEntropyScalar_integrableOn` and `integral_relativeEntropyScalar`
   give the coefficient-correct scalar improper integral.
+* `supportRelativeEntropySpectralIntegrand` gives the support-domain spectral
+  integrand for positive-semidefinite matrices.
 * `sourceA_resolvent_quadratic_spectral` and
   `sourceB_resolvent_quadratic_spectral` identify the two resolvent quadratic
   forms in eigenvalue coordinates.
@@ -42,7 +46,10 @@ namespace Matrix
 \[
  \frac{a^2/(a+tb)-b+t b^2/(a+tb)}{1+t}.
 \]
-The coefficient `t` in the last term is essential. -/
+The coefficient `t` in the last term is essential.
+
+This is the scalar normalization `(intspec)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 406--413. -/
 noncomputable def relativeEntropyScalar (a b t : ℝ) : ℝ :=
   (a ^ 2 / (a + t * b) - b + t * b ^ 2 / (a + t * b)) / (1 + t)
 
@@ -153,8 +160,8 @@ private theorem relativeEntropyScalar_integrable_and_integral
 /-- The scalar (p=1) relative-entropy resolvent integrand is integrable on
 the positive half-line for positive `a` and `b`.
 
-This is the integrability part of Jenčová--Ruskai,
-arXiv:0903.2895v4, §4. -/
+This is the integrability part of `(intspec)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 406--413. -/
 theorem relativeEntropyScalar_integrableOn {a b : ℝ}
     (ha : 0 < a) (hb : 0 < b) :
     IntegrableOn (relativeEntropyScalar a b) (Ioi 0) :=
@@ -166,14 +173,88 @@ theorem relativeEntropyScalar_integrableOn {a b : ℝ}
  \frac{a^2/(a+tb)-b+t b^2/(a+tb)}{1+t}\,dt.
 \]
 
-This is the case `p=1` of the spectral integral in Jenčová--Ruskai,
-arXiv:0903.2895v4, §4.
+This is the scalar normalization `(intspec)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 406--413.
 -/
 theorem integral_relativeEntropyScalar {a b : ℝ}
     (ha : 0 < a) (hb : 0 < b) :
     ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t =
       a * (Real.log a - Real.log b) :=
   (relativeEntropyScalar_integrable_and_integral ha hb).2
+
+/-- If the first spectral value is zero and the reference spectral value and
+resolvent parameter are positive, then the scalar relative-entropy resolvent
+integrand vanishes.
+
+This is the zero-source boundary of `(intspec)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 406--413, used with the support convention
+in the positive-semidefinite extension at lines 717--720. -/
+theorem relativeEntropyScalar_zero_left {b t : ℝ} (hb : 0 < b) (ht : 0 < t) :
+    relativeEntropyScalar 0 b t = 0 := by
+  unfold relativeEntropyScalar
+  have htb : t * b ≠ 0 := mul_ne_zero ht.ne' hb.ne'
+  have h1 : 1 + t ≠ 0 := by positivity
+  field_simp
+  ring
+
+/-- If the reference scalar is zero and the weighted source scalar vanishes,
+then the complete weighted resolvent term vanishes for every parameter. -/
+theorem relativeEntropyScalar_mul_eq_zero_of_right_eq_zero
+    {a w t : ℝ} (haw : a * w = 0) :
+    relativeEntropyScalar a 0 t * w = 0 := by
+  rcases mul_eq_zero.mp haw with ha | hw
+  · subst a
+    simp [relativeEntropyScalar]
+  · subst w
+    simp
+
+/-- A weighted scalar resolvent term is integrable, with its
+expected logarithmic integral, provided a zero reference value annihilates
+the weighted source value.
+
+The logarithm is Mathlib's totalized logarithm, for which
+`Real.log 0 = 0`. When `b = 0`, the unweighted scalar factor is generally
+not integrable; the support hypothesis kills the complete weighted term
+before integration. The positive scalar identity is `(intspec)` in
+Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 406--413, while the
+zero-reference case implements the positive-semidefinite support extension
+at lines 717--720. -/
+theorem relativeEntropyScalar_mul_integrableOn_and_integral_of_nonneg
+    {a b w : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
+    (hsupport : b = 0 → a * w = 0) :
+    IntegrableOn (fun t : ℝ => relativeEntropyScalar a b t * w) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t * w =
+        a * (Real.log a - Real.log b) * w := by
+  by_cases hb0 : b ≠ 0
+  · have hbpos : 0 < b := lt_of_le_of_ne hb (Ne.symm hb0)
+    by_cases ha0 : a ≠ 0
+    · have hapos : 0 < a := lt_of_le_of_ne ha (Ne.symm ha0)
+      have hscalar := relativeEntropyScalar_integrable_and_integral hapos hbpos
+      refine ⟨hscalar.1.mul_const w, ?_⟩
+      rw [integral_mul_const, hscalar.2]
+    · simp only [not_ne_iff] at ha0
+      subst a
+      have hzero :
+          EqOn (fun t : ℝ => relativeEntropyScalar 0 b t * w) 0 (Ioi 0) := by
+        intro t ht
+        change relativeEntropyScalar 0 b t * w = 0
+        rw [relativeEntropyScalar_zero_left hbpos ht, zero_mul]
+      refine ⟨integrableOn_zero.congr_fun hzero.symm measurableSet_Ioi, ?_⟩
+      rw [setIntegral_congr_fun measurableSet_Ioi hzero]
+      simp
+  · simp only [not_ne_iff] at hb0
+    have haw : a * w = 0 := hsupport hb0
+    have hzero (t : ℝ) : relativeEntropyScalar a b t * w = 0 := by
+      rw [hb0]
+      exact relativeEntropyScalar_mul_eq_zero_of_right_eq_zero haw
+    refine ⟨integrableOn_zero.congr_fun ?_ measurableSet_Ioi, ?_⟩
+    · intro t _
+      change 0 = relativeEntropyScalar a b t * w
+      exact (hzero t).symm
+    · rw [setIntegral_congr_fun measurableSet_Ioi fun t _ => hzero t]
+      rw [integral_zero]
+      rw [hb0, Real.log_zero]
+      rw [sub_zero, mul_right_comm a (Real.log a) w, haw, zero_mul]
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
@@ -502,8 +583,8 @@ expansion
  \sum_{i,j}\frac{\alpha_i^2}{\alpha_i+t\beta_j}|W_{ij}|^2.
 \]
 
-This is the first resolvent term of Jenčová--Ruskai,
-arXiv:0903.2895v4, §4. -/
+This is the first resolvent term in the matrix lift `(intAB)` of
+Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 423--427. -/
 theorem sourceA_resolvent_quadratic_spectral {A B : Matrix n n ℂ}
     (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (ht : 0 < t) :
     sourceAResolventQuadratic A B t =
@@ -549,8 +630,8 @@ expansion
  \sum_{i,j}\frac{\beta_j^2}{\alpha_i+t\beta_j}|W_{ij}|^2.
 \]
 
-This is the second resolvent term of Jenčová--Ruskai,
-arXiv:0903.2895v4, §4. -/
+This is the second resolvent term in the matrix lift `(intAB)` of
+Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 423--427. -/
 theorem sourceB_resolvent_quadratic_spectral {A B : Matrix n n ℂ}
     (hA : A.PosDef) (hB : B.PosDef) {t : ℝ} (ht : 0 < t) :
     sourceBResolventQuadratic A B t =
@@ -649,48 +730,309 @@ theorem sourceBResolventQuadratic_continuousOn {A B : Matrix n n ℂ}
     sourceB_resolvent_quadratic_spectral hA hB ht
 
 open scoped Matrix.Norms.L2Operator in
-/-- For positive-definite matrices, relative entropy is the spectral double
-sum
+/-- If the kernel of a positive-semidefinite reference matrix `B` is contained
+in the kernel of `A`, then a zero eigenvector of `B` has zero overlap with
+each positive spectral component of `A`.
+
+This lemma implements the support convention in the positive-semidefinite
+extension of Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720. It removes
+the formally nonintegrable zero-reference-eigenvalue terms from the
+support-domain relative-entropy resolvent integral. -/
+theorem eigenvalue_mul_overlap_eq_zero_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) :
+    (hA.isHermitian.eigenvalues i : ℂ) *
+        (star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j = 0 := by
+  classical
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  have hBzero :
+      B *ᵥ ⇑(hB.isHermitian.eigenvectorBasis j) = 0 := by
+    rw [hB.isHermitian.mulVec_eigenvectorBasis, hβ, zero_smul]
+  have hAzero : A *ᵥ ⇑(hB.isHermitian.eigenvectorBasis j) = 0 :=
+    hker _ hBzero
+  have hAUBzero : (A * UB) *ᵥ Pi.single j 1 = 0 := by
+    rw [← Matrix.mulVec_mulVec]
+    change A *ᵥ
+      ((hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *ᵥ Pi.single j 1) = 0
+    rw [hB.isHermitian.eigenvectorUnitary_mulVec, hAzero]
+  have hstarAUBzero :
+      (star UA * (A * UB)) *ᵥ Pi.single j 1 = 0 := by
+    rw [← Matrix.mulVec_mulVec, hAUBzero, Matrix.mulVec_zero]
+  have hentryzero := congrFun hstarAUBzero i
+  simp only [Matrix.mulVec_single_one, Pi.zero_apply] at hentryzero
+  change (star UA * (A * UB)) i j = 0 at hentryzero
+  rw [hA.isHermitian.spectral_form] at hentryzero
+  have hUA : star UA * UA = 1 := by
+    simp [UA]
+  change
+    (star UA *
+      ((UA * Matrix.diagonal
+        (fun k => (hA.isHermitian.eigenvalues k : ℂ))) * star UA * UB)) i j = 0
+    at hentryzero
+  simp only [Matrix.mul_assoc] at hentryzero
+  rw [← Matrix.mul_assoc, hUA, Matrix.one_mul] at hentryzero
+  simp only [Matrix.diagonal_mul] at hentryzero
+  simpa only [UA, UB] using hentryzero
+
+open scoped Matrix.Norms.L2Operator in
+/-- Under the support inclusion `ker B ⊆ ker A`, a zero reference eigenvalue
+has zero weight in every spectral summand:
 \[
- D(A\Vert B)=\sum_{i,j}\alpha_i
-   (\log\alpha_i-\log\beta_j)|W_{ij}|^2.
+  \alpha_i\lvert (U_A^\ast U_B)_{ij}\rvert^2=0.
 \]
 
-This is the finite-dimensional spectral form of Jenčová--Ruskai,
-arXiv:0903.2895v4, §4, specialized to `p=1`. -/
-theorem quantumRelativeEntropy_posDef_spectral {A B : Matrix n n ℂ}
-    (hA : A.PosDef) (hB : B.PosDef) :
-    quantumRelativeEntropy A B =
-      ∑ i, ∑ j,
+This is the nonnegative spectral-coefficient form used to implement the
+support convention in the positive-semidefinite extension of
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720. -/
+theorem eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) :
+    hA.isHermitian.eigenvalues i *
+        Complex.normSq
+          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 := by
+  classical
+  have hcomp :=
+    eigenvalue_mul_overlap_eq_zero_of_kernel_le hA hB hker i j hβ
+  by_cases hα : hA.isHermitian.eigenvalues i ≠ 0
+  · have hαc : (hA.isHermitian.eigenvalues i : ℂ) ≠ 0 := by
+      exact_mod_cast hα
+    have hWij :
+        (star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j = 0 :=
+      (mul_eq_zero.mp hcomp).resolve_left hαc
+    simp [hWij]
+  · simp only [not_ne_iff] at hα
+    simp [hα]
+
+open scoped Matrix.Norms.L2Operator in
+/-- A zero eigenvalue of the reference matrix contributes identically zero to
+the support-domain scalar resolvent sum when `ker B ⊆ ker A`.
+
+The separate scalar factor need not be integrable when the reference
+eigenvalue is zero. The support condition instead annihilates its spectral
+weight before integration. This implements the support convention in the
+positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
+lines 717--720. -/
+theorem relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) (t : ℝ) :
+    relativeEntropyScalar
+          (hA.isHermitian.eigenvalues i)
+          (hB.isHermitian.eigenvalues j) t *
+        Complex.normSq
+          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 := by
+  classical
+  have hweight :=
+    eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le hA hB hker i j hβ
+  by_cases hα : hA.isHermitian.eigenvalues i ≠ 0
+  · have hnormSq :
+        Complex.normSq
+          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 :=
+      (mul_eq_zero.mp hweight).resolve_left hα
+    simp [hnormSq]
+  · simp only [not_ne_iff] at hα
+    simp [relativeEntropyScalar, hα, hβ]
+
+open scoped Matrix.Norms.L2Operator in
+/-- For `t > 0`, the spectral integrand for relative entropy on the support
+domain of positive-semidefinite `A` and `B` is the finite sum
+\[
+  \sum_{i,j} r(\alpha_i,\beta_j,t)
+    \lvert (U_A^\ast U_B)_{ij}\rvert^2,
+\]
+where `r` is `relativeEntropyScalar`.
+
+Under `ker B ⊆ ker A`, the terms with `β_j = 0` vanish by
+`relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le`. Thus this
+definition implements the support convention in the positive-semidefinite
+extension of Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720.
+
+This is a spectral-coordinate expression. It has not yet been identified
+with the coordinate-free form of the matrix lift `(intAB)`, lines 423--427.
+In the corresponding singular formula, `B⁺` occurs inside the shifted
+operator `t 1 + A ⊗ (B⁺)ᵀ`; for `t > 0`, the inverse of that shifted
+operator on the support is an ordinary inverse, not a pseudoinverse of the
+shifted operator. -/
+noncomputable def supportRelativeEntropySpectralIntegrand
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (t : ℝ) : ℝ :=
+  ∑ i, ∑ j,
+    relativeEntropyScalar
+        (hA.isHermitian.eigenvalues i)
+        (hB.isHermitian.eigenvalues j) t *
+      Complex.normSq
+        ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+
+open scoped Matrix.Norms.L2Operator in
+/-- Each weighted spectral term is integrable on the positive half-line and
+has the expected logarithmic integral when `ker B ⊆ ker A`.
+
+The zero-reference terms implement the support convention in the
+positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
+lines 717--720. The positive scalar terms use `(intspec)`, §2.1,
+lines 406--413. -/
+theorem
+    relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) :
+    IntegrableOn
+      (fun t : ℝ =>
+        relativeEntropyScalar
+            (hA.isHermitian.eigenvalues i)
+            (hB.isHermitian.eigenvalues j) t *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j))
+      (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0,
+        relativeEntropyScalar
+              (hA.isHermitian.eigenvalues i)
+              (hB.isHermitian.eigenvalues j) t *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) =
         hA.isHermitian.eigenvalues i *
           (Real.log (hA.isHermitian.eigenvalues i) -
             Real.log (hB.isHermitian.eigenvalues j)) *
           Complex.normSq
             ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
               (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  apply relativeEntropyScalar_mul_integrableOn_and_integral_of_nonneg
+  · exact hA.eigenvalues_nonneg i
+  · exact hB.eigenvalues_nonneg j
+  · exact eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le hA hB hker i j
+
+open scoped Matrix.Norms.L2Operator in
+/-- Each weighted scalar term in the support-domain spectral integrand is
+integrable on the positive half-line when `ker B ⊆ ker A`. -/
+theorem relativeEntropyScalar_mul_overlap_normSq_integrableOn_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) :
+    IntegrableOn
+      (fun t : ℝ =>
+        relativeEntropyScalar
+            (hA.isHermitian.eigenvalues i)
+            (hB.isHermitian.eigenvalues j) t *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j))
+      (Ioi 0) :=
+  (relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
+    hA hB hker i j).1
+
+open scoped Matrix.Norms.L2Operator in
+/-- The support-domain spectral integrand is integrable on the positive
+half-line, and its integral is the spectral relative-entropy sum, when
+`ker B ⊆ ker A`.
+
+The zero-reference terms implement the support convention in the
+positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
+lines 717--720; the finite matrix lift is `(intAB)`, §2.1,
+lines 423--427. -/
+theorem
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0) :
+    IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
+        ∑ i, ∑ j,
+          hA.isHermitian.eigenvalues i *
+            (Real.log (hA.isHermitian.eigenvalues i) -
+              Real.log (hB.isHermitian.eigenvalues j)) *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
   classical
-  let α : n → ℝ := hA.isHermitian.eigenvalues
-  let β : n → ℝ := hB.isHermitian.eigenvalues
+  have hterm (i j : n) :=
+    relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
+      hA hB hker i j
+  have hintegral :
+      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
+        ∑ i, ∑ j,
+          hA.isHermitian.eigenvalues i *
+            (Real.log (hA.isHermitian.eigenvalues i) -
+              Real.log (hB.isHermitian.eigenvalues j)) *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+    unfold supportRelativeEntropySpectralIntegrand
+    rw [integral_finsetSum Finset.univ]
+    · apply Finset.sum_congr rfl
+      intro i _
+      rw [integral_finsetSum Finset.univ]
+      · apply Finset.sum_congr rfl
+        intro j _
+        exact (hterm i j).2
+      · exact fun j _ => (hterm i j).1
+    · intro i _
+      apply integrable_finsetSum Finset.univ
+      exact fun j _ => (hterm i j).1
+  have hintegrable :
+      IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) := by
+    unfold supportRelativeEntropySpectralIntegrand
+    apply integrable_finsetSum Finset.univ
+    intro i _
+    apply integrable_finsetSum Finset.univ
+    exact fun j _ => (hterm i j).1
+  exact ⟨hintegrable, hintegral⟩
+
+open scoped Matrix.Norms.L2Operator in
+/-- For Hermitian matrices, the totalized trace-log relative entropy is the
+spectral double sum
+\[
+ D(A\Vert B)=\sum_{i,j}\alpha_i
+   (\log\alpha_i-\log\beta_j)|W_{ij}|^2.
+\]
+
+Here the logarithm is Mathlib's totalized `Real.log`, in particular
+`Real.log 0 = 0`. For positive-semidefinite matrices on the physical support
+domain, this is the usual finite-dimensional relative-entropy expression.
+
+This is the finite-dimensional spectral form of the trace-log expression
+`(J1)` in Jenčová--Ruskai, arXiv:0903.2895v4, lines 277--287. -/
+theorem quantumRelativeEntropy_spectral {A B : Matrix n n ℂ}
+    (hA : A.IsHermitian) (hB : B.IsHermitian) :
+    quantumRelativeEntropy A B =
+      ∑ i, ∑ j,
+        hA.eigenvalues i *
+          (Real.log (hA.eigenvalues i) -
+            Real.log (hB.eigenvalues j)) *
+          Complex.normSq
+            ((star (hA.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  classical
+  let α : n → ℝ := hA.eigenvalues
+  let β : n → ℝ := hB.eigenvalues
   let W : Matrix n n ℂ :=
-    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+    star (hA.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.eigenvectorUnitary : Matrix n n ℂ)
   let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
   have hWrow : W * star W = 1 := by
     simp only [W, star_mul, star_star, Matrix.mul_assoc]
-    rw [← Matrix.mul_assoc
-      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)]
+    rw [← Matrix.mul_assoc (hB.eigenvectorUnitary : Matrix n n ℂ)]
     rw [Unitary.mul_star_self_of_mem
-      hB.isHermitian.eigenvectorUnitary.prop, Matrix.one_mul]
-    exact Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+      hB.eigenvectorUnitary.prop, Matrix.one_mul]
+    exact Unitary.coe_star_mul_self hA.eigenvectorUnitary
   have hrow (i : n) : ∑ j, P i j = 1 := by
     exact TNLean.Klein.row_sum_normSq_eq_one hWrow i
   rw [quantumRelativeEntropy_eq_trace_mul_log_sub]
-  have hlogB : CFC.log B = hB.isHermitian.cfc Real.log := by
+  have hlogB : CFC.log B = hB.cfc Real.log := by
     rw [CFC.log]
-    exact Matrix.IsHermitian.cfc_eq hB.isHermitian Real.log
+    exact Matrix.IsHermitian.cfc_eq hB Real.log
   have hself : (Matrix.trace (A * CFC.log A)).re =
       ∑ i, ∑ j, α i * Real.log (α i) * P i j := by
-    have h := vonNeumannEntropy_eq_neg_trace_mul_log hA.isHermitian
+    have h := vonNeumannEntropy_eq_neg_trace_mul_log hA
     rw [vonNeumannEntropy] at h
     have hre : (Matrix.trace (A * CFC.log A)).re =
         ∑ i, α i * Real.log (α i) := by
@@ -707,13 +1049,53 @@ theorem quantumRelativeEntropy_posDef_spectral {A B : Matrix n n ℂ}
   have hcross : (Matrix.trace (A * CFC.log B)).re =
       ∑ i, ∑ j, α i * Real.log (β j) * P i j := by
     rw [hlogB, TNLean.Klein.re_trace_mul_cfc_eq_double_sum
-      hA.isHermitian hB.isHermitian Real.log]
+      hA hB Real.log]
   rw [hself, hcross, ← Finset.sum_sub_distrib]
   refine Finset.sum_congr rfl fun i _ => ?_
   rw [← Finset.sum_sub_distrib]
   refine Finset.sum_congr rfl fun j _ => ?_
   simp only [α, β, W, P]
   ring
+
+open scoped Matrix.Norms.L2Operator in
+/-- The positive-definite specialization of
+`quantumRelativeEntropy_spectral`. -/
+theorem quantumRelativeEntropy_posDef_spectral {A B : Matrix n n ℂ}
+    (hA : A.PosDef) (hB : B.PosDef) :
+    quantumRelativeEntropy A B =
+      ∑ i, ∑ j,
+        hA.isHermitian.eigenvalues i *
+          (Real.log (hA.isHermitian.eigenvalues i) -
+            Real.log (hB.isHermitian.eigenvalues j)) *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) :=
+  quantumRelativeEntropy_spectral hA.isHermitian hB.isHermitian
+
+open scoped Matrix.Norms.L2Operator in
+/-- For positive-semidefinite `A` and `B` with `ker B ⊆ ker A`, the
+support-domain spectral integrand is integrable on `(0, ∞)` and its integral
+is the totalized trace-log relative entropy:
+\[
+  \int_0^\infty I_{A,B}(t)\,dt = D(A\Vert B).
+\]
+
+The spectral trace-log identity is `(J1)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 277--287. The kernel condition and zero-reference
+terms implement the positive-semidefinite extension at lines 717--720. -/
+theorem
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0) :
+    IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
+        quantumRelativeEntropy A B := by
+  have hfinite :=
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_of_kernel_le
+      hA hB hker
+  refine ⟨hfinite.1, ?_⟩
+  rw [hfinite.2]
+  exact (quantumRelativeEntropy_spectral hA.isHermitian hB.isHermitian).symm
 
 open scoped Matrix.Norms.L2Operator in
 /-- Simultaneous multiplication of two positive-definite arguments by a
@@ -737,7 +1119,8 @@ theorem quantumRelativeEntropy_smul_posDef {A B : Matrix n n ℂ}
 
 /-- The two-source resolvent integrand for positive-definite relative entropy.
 The source-`B` term carries the coefficient `t` required by the scalar
-representation. -/
+representation. This is the matrix lift `(intAB)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 423--427. -/
 noncomputable def relativeEntropyResolventIntegrand
     (A B : Matrix n n ℂ) (t : ℝ) : ℝ :=
   (sourceAResolventQuadratic A B t - (Matrix.trace B).re +
@@ -799,8 +1182,8 @@ private lemma relativeEntropyResolventIntegrand_eq_spectral
 /-- The coefficient-correct positive-definite relative-entropy resolvent
 integrand is integrable on `(0, ∞)`.
 
-This is the integrability assertion accompanying Jenčová--Ruskai,
-arXiv:0903.2895v4, §4. -/
+This is the integrability assertion accompanying `(intAB)` in
+Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 423--427. -/
 theorem relativeEntropyResolventIntegrand_integrableOn
     {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef) :
     IntegrableOn (relativeEntropyResolventIntegrand A B) (Ioi 0) := by
@@ -868,8 +1251,8 @@ For positive-definite `A` and `B`,
 Both source families, and the coefficient `t` on the source-`B` family, are
 part of the statement.
 
-This is the finite-dimensional specialization of Jenčová--Ruskai,
-arXiv:0903.2895v4, §4, specialized to `p=1`. -/
+This is the finite-dimensional specialization of `(intAB)` in
+Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 423--427. -/
 theorem quantumRelativeEntropy_resolvent_integral
     {A B : Matrix n n ℂ} (hA : A.PosDef) (hB : B.PosDef) :
     quantumRelativeEntropy A B =

--- a/TNLean/Analysis/RelativeEntropyResolventIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropyResolventIntegral.lean
@@ -13,16 +13,13 @@ import Mathlib.LinearAlgebra.Matrix.Vec
 
 This file proves the scalar logarithmic integral and the finite-dimensional
 spectral identities needed for resolvent representations of quantum relative
-entropy. It includes the support-domain spectral integrand for
-positive-semidefinite matrices and the coordinate-free resolvent formula for
-positive-definite matrices.
+entropy. It includes the homogeneous Hermitian trace-log identity and the
+coordinate-free resolvent formula for positive-definite matrices.
 
 ## Main results
 
 * `relativeEntropyScalar_integrableOn` and `integral_relativeEntropyScalar`
   give the coefficient-correct scalar improper integral.
-* `supportRelativeEntropySpectralIntegrand` gives the support-domain spectral
-  integrand for positive-semidefinite matrices.
 * `sourceA_resolvent_quadratic_spectral` and
   `sourceB_resolvent_quadratic_spectral` identify the two resolvent quadratic
   forms in eigenvalue coordinates.
@@ -181,80 +178,6 @@ theorem integral_relativeEntropyScalar {a b : ℝ}
     ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t =
       a * (Real.log a - Real.log b) :=
   (relativeEntropyScalar_integrable_and_integral ha hb).2
-
-/-- If the first spectral value is zero and the reference spectral value and
-resolvent parameter are positive, then the scalar relative-entropy resolvent
-integrand vanishes.
-
-This is the zero-source boundary of `(intspec)` in Jenčová--Ruskai,
-arXiv:0903.2895v4, §2.1, lines 406--413, used with the support convention
-in the positive-semidefinite extension at lines 717--720. -/
-theorem relativeEntropyScalar_zero_left {b t : ℝ} (hb : 0 < b) (ht : 0 < t) :
-    relativeEntropyScalar 0 b t = 0 := by
-  unfold relativeEntropyScalar
-  have htb : t * b ≠ 0 := mul_ne_zero ht.ne' hb.ne'
-  have h1 : 1 + t ≠ 0 := by positivity
-  field_simp
-  ring
-
-/-- If the reference scalar is zero and the weighted source scalar vanishes,
-then the complete weighted resolvent term vanishes for every parameter. -/
-theorem relativeEntropyScalar_mul_eq_zero_of_right_eq_zero
-    {a w t : ℝ} (haw : a * w = 0) :
-    relativeEntropyScalar a 0 t * w = 0 := by
-  rcases mul_eq_zero.mp haw with ha | hw
-  · subst a
-    simp [relativeEntropyScalar]
-  · subst w
-    simp
-
-/-- A weighted scalar resolvent term is integrable, with its
-expected logarithmic integral, provided a zero reference value annihilates
-the weighted source value.
-
-The logarithm is Mathlib's totalized logarithm, for which
-`Real.log 0 = 0`. When `b = 0`, the unweighted scalar factor is generally
-not integrable; the support hypothesis kills the complete weighted term
-before integration. The positive scalar identity is `(intspec)` in
-Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 406--413, while the
-zero-reference case implements the positive-semidefinite support extension
-at lines 717--720. -/
-theorem relativeEntropyScalar_mul_integrableOn_and_integral_of_nonneg
-    {a b w : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
-    (hsupport : b = 0 → a * w = 0) :
-    IntegrableOn (fun t : ℝ => relativeEntropyScalar a b t * w) (Ioi 0) ∧
-      ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t * w =
-        a * (Real.log a - Real.log b) * w := by
-  by_cases hb0 : b ≠ 0
-  · have hbpos : 0 < b := lt_of_le_of_ne hb (Ne.symm hb0)
-    by_cases ha0 : a ≠ 0
-    · have hapos : 0 < a := lt_of_le_of_ne ha (Ne.symm ha0)
-      have hscalar := relativeEntropyScalar_integrable_and_integral hapos hbpos
-      refine ⟨hscalar.1.mul_const w, ?_⟩
-      rw [integral_mul_const, hscalar.2]
-    · simp only [not_ne_iff] at ha0
-      subst a
-      have hzero :
-          EqOn (fun t : ℝ => relativeEntropyScalar 0 b t * w) 0 (Ioi 0) := by
-        intro t ht
-        change relativeEntropyScalar 0 b t * w = 0
-        rw [relativeEntropyScalar_zero_left hbpos ht, zero_mul]
-      refine ⟨integrableOn_zero.congr_fun hzero.symm measurableSet_Ioi, ?_⟩
-      rw [setIntegral_congr_fun measurableSet_Ioi hzero]
-      simp
-  · simp only [not_ne_iff] at hb0
-    have haw : a * w = 0 := hsupport hb0
-    have hzero (t : ℝ) : relativeEntropyScalar a b t * w = 0 := by
-      rw [hb0]
-      exact relativeEntropyScalar_mul_eq_zero_of_right_eq_zero haw
-    refine ⟨integrableOn_zero.congr_fun ?_ measurableSet_Ioi, ?_⟩
-    · intro t _
-      change 0 = relativeEntropyScalar a b t * w
-      exact (hzero t).symm
-    · rw [setIntegral_congr_fun measurableSet_Ioi fun t _ => hzero t]
-      rw [integral_zero]
-      rw [hb0, Real.log_zero]
-      rw [sub_zero, mul_right_comm a (Real.log a) w, haw, zero_mul]
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
@@ -730,264 +653,6 @@ theorem sourceBResolventQuadratic_continuousOn {A B : Matrix n n ℂ}
     sourceB_resolvent_quadratic_spectral hA hB ht
 
 open scoped Matrix.Norms.L2Operator in
-/-- If the kernel of a positive-semidefinite reference matrix `B` is contained
-in the kernel of `A`, then a zero eigenvector of `B` has zero overlap with
-each positive spectral component of `A`.
-
-This lemma implements the support convention in the positive-semidefinite
-extension of Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720. It removes
-the formally nonintegrable zero-reference-eigenvalue terms from the
-support-domain relative-entropy resolvent integral. -/
-theorem eigenvalue_mul_overlap_eq_zero_of_kernel_le
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
-    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) :
-    (hA.isHermitian.eigenvalues i : ℂ) *
-        (star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j = 0 := by
-  classical
-  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
-  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
-  have hBzero :
-      B *ᵥ ⇑(hB.isHermitian.eigenvectorBasis j) = 0 := by
-    rw [hB.isHermitian.mulVec_eigenvectorBasis, hβ, zero_smul]
-  have hAzero : A *ᵥ ⇑(hB.isHermitian.eigenvectorBasis j) = 0 :=
-    hker _ hBzero
-  have hAUBzero : (A * UB) *ᵥ Pi.single j 1 = 0 := by
-    rw [← Matrix.mulVec_mulVec]
-    change A *ᵥ
-      ((hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *ᵥ Pi.single j 1) = 0
-    rw [hB.isHermitian.eigenvectorUnitary_mulVec, hAzero]
-  have hstarAUBzero :
-      (star UA * (A * UB)) *ᵥ Pi.single j 1 = 0 := by
-    rw [← Matrix.mulVec_mulVec, hAUBzero, Matrix.mulVec_zero]
-  have hentryzero := congrFun hstarAUBzero i
-  simp only [Matrix.mulVec_single_one, Pi.zero_apply] at hentryzero
-  change (star UA * (A * UB)) i j = 0 at hentryzero
-  rw [hA.isHermitian.spectral_form] at hentryzero
-  have hUA : star UA * UA = 1 := by
-    simp [UA]
-  change
-    (star UA *
-      ((UA * Matrix.diagonal
-        (fun k => (hA.isHermitian.eigenvalues k : ℂ))) * star UA * UB)) i j = 0
-    at hentryzero
-  simp only [Matrix.mul_assoc] at hentryzero
-  rw [← Matrix.mul_assoc, hUA, Matrix.one_mul] at hentryzero
-  simp only [Matrix.diagonal_mul] at hentryzero
-  simpa only [UA, UB] using hentryzero
-
-open scoped Matrix.Norms.L2Operator in
-/-- Under the support inclusion `ker B ⊆ ker A`, a zero reference eigenvalue
-has zero weight in every spectral summand:
-\[
-  \alpha_i\lvert (U_A^\ast U_B)_{ij}\rvert^2=0.
-\]
-
-This is the nonnegative spectral-coefficient form used to implement the
-support convention in the positive-semidefinite extension of
-Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720. -/
-theorem eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
-    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) :
-    hA.isHermitian.eigenvalues i *
-        Complex.normSq
-          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 := by
-  classical
-  have hcomp :=
-    eigenvalue_mul_overlap_eq_zero_of_kernel_le hA hB hker i j hβ
-  by_cases hα : hA.isHermitian.eigenvalues i ≠ 0
-  · have hαc : (hA.isHermitian.eigenvalues i : ℂ) ≠ 0 := by
-      exact_mod_cast hα
-    have hWij :
-        (star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j = 0 :=
-      (mul_eq_zero.mp hcomp).resolve_left hαc
-    simp [hWij]
-  · simp only [not_ne_iff] at hα
-    simp [hα]
-
-open scoped Matrix.Norms.L2Operator in
-/-- A zero eigenvalue of the reference matrix contributes identically zero to
-the support-domain scalar resolvent sum when `ker B ⊆ ker A`.
-
-The separate scalar factor need not be integrable when the reference
-eigenvalue is zero. The support condition instead annihilates its spectral
-weight before integration. This implements the support convention in the
-positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
-lines 717--720. -/
-theorem relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
-    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) (t : ℝ) :
-    relativeEntropyScalar
-          (hA.isHermitian.eigenvalues i)
-          (hB.isHermitian.eigenvalues j) t *
-        Complex.normSq
-          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 := by
-  classical
-  have hweight :=
-    eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le hA hB hker i j hβ
-  by_cases hα : hA.isHermitian.eigenvalues i ≠ 0
-  · have hnormSq :
-        Complex.normSq
-          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 :=
-      (mul_eq_zero.mp hweight).resolve_left hα
-    simp [hnormSq]
-  · simp only [not_ne_iff] at hα
-    simp [relativeEntropyScalar, hα, hβ]
-
-open scoped Matrix.Norms.L2Operator in
-/-- For `t > 0`, the spectral integrand for relative entropy on the support
-domain of positive-semidefinite `A` and `B` is the finite sum
-\[
-  \sum_{i,j} r(\alpha_i,\beta_j,t)
-    \lvert (U_A^\ast U_B)_{ij}\rvert^2,
-\]
-where `r` is `relativeEntropyScalar`.
-
-Under `ker B ⊆ ker A`, the terms with `β_j = 0` vanish by
-`relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le`. Thus this
-definition implements the support convention in the positive-semidefinite
-extension of Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720.
-
-This is a spectral-coordinate expression. It has not yet been identified
-with the coordinate-free form of the matrix lift `(intAB)`, lines 423--427.
-In the corresponding singular formula, `B⁺` occurs inside the shifted
-operator `t 1 + A ⊗ (B⁺)ᵀ`; for `t > 0`, the inverse of that shifted
-operator on the support is an ordinary inverse, not a pseudoinverse of the
-shifted operator. -/
-noncomputable def supportRelativeEntropySpectralIntegrand
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (t : ℝ) : ℝ :=
-  ∑ i, ∑ j,
-    relativeEntropyScalar
-        (hA.isHermitian.eigenvalues i)
-        (hB.isHermitian.eigenvalues j) t *
-      Complex.normSq
-        ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
-
-open scoped Matrix.Norms.L2Operator in
-/-- Each weighted spectral term is integrable on the positive half-line and
-has the expected logarithmic integral when `ker B ⊆ ker A`.
-
-The zero-reference terms implement the support convention in the
-positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
-lines 717--720. The positive scalar terms use `(intspec)`, §2.1,
-lines 406--413. -/
-theorem
-    relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
-    (i j : n) :
-    IntegrableOn
-      (fun t : ℝ =>
-        relativeEntropyScalar
-            (hA.isHermitian.eigenvalues i)
-            (hB.isHermitian.eigenvalues j) t *
-          Complex.normSq
-            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j))
-      (Ioi 0) ∧
-      ∫ t : ℝ in Ioi 0,
-        relativeEntropyScalar
-              (hA.isHermitian.eigenvalues i)
-              (hB.isHermitian.eigenvalues j) t *
-            Complex.normSq
-              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) =
-        hA.isHermitian.eigenvalues i *
-          (Real.log (hA.isHermitian.eigenvalues i) -
-            Real.log (hB.isHermitian.eigenvalues j)) *
-          Complex.normSq
-            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
-  apply relativeEntropyScalar_mul_integrableOn_and_integral_of_nonneg
-  · exact hA.eigenvalues_nonneg i
-  · exact hB.eigenvalues_nonneg j
-  · exact eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le hA hB hker i j
-
-open scoped Matrix.Norms.L2Operator in
-/-- Each weighted scalar term in the support-domain spectral integrand is
-integrable on the positive half-line when `ker B ⊆ ker A`. -/
-theorem relativeEntropyScalar_mul_overlap_normSq_integrableOn_of_kernel_le
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
-    (i j : n) :
-    IntegrableOn
-      (fun t : ℝ =>
-        relativeEntropyScalar
-            (hA.isHermitian.eigenvalues i)
-            (hB.isHermitian.eigenvalues j) t *
-          Complex.normSq
-            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j))
-      (Ioi 0) :=
-  (relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
-    hA hB hker i j).1
-
-open scoped Matrix.Norms.L2Operator in
-/-- The support-domain spectral integrand is integrable on the positive
-half-line, and its integral is the spectral relative-entropy sum, when
-`ker B ⊆ ker A`.
-
-The zero-reference terms implement the support convention in the
-positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
-lines 717--720; the finite matrix lift is `(intAB)`, §2.1,
-lines 423--427. -/
-theorem
-    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_of_kernel_le
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0) :
-    IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) ∧
-      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
-        ∑ i, ∑ j,
-          hA.isHermitian.eigenvalues i *
-            (Real.log (hA.isHermitian.eigenvalues i) -
-              Real.log (hB.isHermitian.eigenvalues j)) *
-            Complex.normSq
-              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
-  classical
-  have hterm (i j : n) :=
-    relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
-      hA hB hker i j
-  have hintegral :
-      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
-        ∑ i, ∑ j,
-          hA.isHermitian.eigenvalues i *
-            (Real.log (hA.isHermitian.eigenvalues i) -
-              Real.log (hB.isHermitian.eigenvalues j)) *
-            Complex.normSq
-              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
-    unfold supportRelativeEntropySpectralIntegrand
-    rw [integral_finsetSum Finset.univ]
-    · apply Finset.sum_congr rfl
-      intro i _
-      rw [integral_finsetSum Finset.univ]
-      · apply Finset.sum_congr rfl
-        intro j _
-        exact (hterm i j).2
-      · exact fun j _ => (hterm i j).1
-    · intro i _
-      apply integrable_finsetSum Finset.univ
-      exact fun j _ => (hterm i j).1
-  have hintegrable :
-      IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) := by
-    unfold supportRelativeEntropySpectralIntegrand
-    apply integrable_finsetSum Finset.univ
-    intro i _
-    apply integrable_finsetSum Finset.univ
-    exact fun j _ => (hterm i j).1
-  exact ⟨hintegrable, hintegral⟩
-
-open scoped Matrix.Norms.L2Operator in
 /-- For Hermitian matrices, the totalized trace-log relative entropy is the
 spectral double sum
 \[
@@ -995,12 +660,13 @@ spectral double sum
    (\log\alpha_i-\log\beta_j)|W_{ij}|^2.
 \]
 
-Here the logarithm is Mathlib's totalized `Real.log`, in particular
-`Real.log 0 = 0`. For positive-semidefinite matrices on the physical support
-domain, this is the usual finite-dimensional relative-entropy expression.
-
-This is the finite-dimensional spectral form of the trace-log expression
-`(J1)` in Jenčová--Ruskai, arXiv:0903.2895v4, lines 277--287. -/
+Here the logarithm is Mathlib's totalized `Real.log`: `Real.log 0 = 0`, and
+for a negative eigenvalue `x` its value is `Real.log |x|`. Thus the theorem
+is an algebraic totalized extension to arbitrary Hermitian matrices of the
+strictly positive trace-log identity `(J1)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 277--287. For positive-semidefinite matrices on the
+physical support domain, it gives the usual finite-dimensional spectral
+expression. -/
 theorem quantumRelativeEntropy_spectral {A B : Matrix n n ℂ}
     (hA : A.IsHermitian) (hB : B.IsHermitian) :
     quantumRelativeEntropy A B =
@@ -1071,31 +737,6 @@ theorem quantumRelativeEntropy_posDef_spectral {A B : Matrix n n ℂ}
             ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
               (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) :=
   quantumRelativeEntropy_spectral hA.isHermitian hB.isHermitian
-
-open scoped Matrix.Norms.L2Operator in
-/-- For positive-semidefinite `A` and `B` with `ker B ⊆ ker A`, the
-support-domain spectral integrand is integrable on `(0, ∞)` and its integral
-is the totalized trace-log relative entropy:
-\[
-  \int_0^\infty I_{A,B}(t)\,dt = D(A\Vert B).
-\]
-
-The spectral trace-log identity is `(J1)` in Jenčová--Ruskai,
-arXiv:0903.2895v4, lines 277--287. The kernel condition and zero-reference
-terms implement the positive-semidefinite extension at lines 717--720. -/
-theorem
-    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy
-    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0) :
-    IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) ∧
-      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
-        quantumRelativeEntropy A B := by
-  have hfinite :=
-    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_of_kernel_le
-      hA hB hker
-  refine ⟨hfinite.1, ?_⟩
-  rw [hfinite.2]
-  exact (quantumRelativeEntropy_spectral hA.isHermitian hB.isHermitian).symm
 
 open scoped Matrix.Norms.L2Operator in
 /-- Simultaneous multiplication of two positive-definite arguments by a

--- a/TNLean/Analysis/RelativeEntropySupportIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropySupportIntegral.lean
@@ -1,0 +1,397 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.RelativeEntropyResolventIntegral
+
+/-!
+# Support-domain spectral integral of relative entropy
+
+This file extends the scalar resolvent integral to positive-semidefinite
+matrices under the support inclusion `ker B ⊆ ker A`. Zero reference
+eigenvalues are removed only after multiplication by their spectral weights,
+so no nonintegrable unweighted zero-reference term is introduced.
+
+## Main results
+
+* `supportRelativeEntropySpectralIntegrand` is the finite support-domain
+  spectral integrand.
+* `supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy`
+  identifies its integral with the totalized trace-log relative entropy.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
+  Entropy and Related Trace Functions, with Conditions for Equality*,
+  arXiv:0903.2895v4, §2.1 and lines 717--720.
+-/
+
+open Filter MeasureTheory Set Topology
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+/-- If the first spectral value is zero and the reference spectral value and
+resolvent parameter are positive, then the scalar relative-entropy resolvent
+integrand vanishes.
+
+This is the zero-source boundary of `(intspec)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 406--413, used with the support convention
+in the positive-semidefinite extension at lines 717--720. -/
+theorem relativeEntropyScalar_zero_left {b t : ℝ} (hb : 0 < b) (ht : 0 < t) :
+    relativeEntropyScalar 0 b t = 0 := by
+  unfold relativeEntropyScalar
+  have htb : t * b ≠ 0 := mul_ne_zero ht.ne' hb.ne'
+  have h1 : 1 + t ≠ 0 := by positivity
+  field_simp
+  ring
+
+/-- If the reference scalar is zero and the weighted source scalar vanishes,
+then the complete weighted resolvent term vanishes for every parameter. -/
+theorem relativeEntropyScalar_mul_eq_zero_of_right_eq_zero
+    {a w t : ℝ} (haw : a * w = 0) :
+    relativeEntropyScalar a 0 t * w = 0 := by
+  rcases mul_eq_zero.mp haw with ha | hw
+  · subst a
+    simp [relativeEntropyScalar]
+  · subst w
+    simp
+
+/-- A weighted scalar resolvent term is integrable, with its
+expected logarithmic integral, provided a zero reference value annihilates
+the weighted source value.
+
+The logarithm is Mathlib's totalized logarithm, for which
+`Real.log 0 = 0`. When `b = 0`, the unweighted scalar factor is generally
+not integrable; the support hypothesis kills the complete weighted term
+before integration. The positive scalar identity is `(intspec)` in
+Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 406--413, while the
+zero-reference case implements the positive-semidefinite support extension
+at lines 717--720. -/
+theorem relativeEntropyScalar_mul_integrableOn_and_integral_of_nonneg
+    {a b w : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
+    (hsupport : b = 0 → a * w = 0) :
+    IntegrableOn (fun t : ℝ => relativeEntropyScalar a b t * w) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0, relativeEntropyScalar a b t * w =
+        a * (Real.log a - Real.log b) * w := by
+  by_cases hb0 : b ≠ 0
+  · have hbpos : 0 < b := lt_of_le_of_ne hb (Ne.symm hb0)
+    by_cases ha0 : a ≠ 0
+    · have hapos : 0 < a := lt_of_le_of_ne ha (Ne.symm ha0)
+      refine
+        ⟨(relativeEntropyScalar_integrableOn hapos hbpos).mul_const w, ?_⟩
+      rw [integral_mul_const, integral_relativeEntropyScalar hapos hbpos]
+    · simp only [not_ne_iff] at ha0
+      subst a
+      have hzero :
+          EqOn (fun t : ℝ => relativeEntropyScalar 0 b t * w) 0 (Ioi 0) := by
+        intro t ht
+        change relativeEntropyScalar 0 b t * w = 0
+        rw [relativeEntropyScalar_zero_left hbpos ht, zero_mul]
+      refine ⟨integrableOn_zero.congr_fun hzero.symm measurableSet_Ioi, ?_⟩
+      rw [setIntegral_congr_fun measurableSet_Ioi hzero]
+      simp
+  · simp only [not_ne_iff] at hb0
+    have haw : a * w = 0 := hsupport hb0
+    have hzero (t : ℝ) : relativeEntropyScalar a b t * w = 0 := by
+      rw [hb0]
+      exact relativeEntropyScalar_mul_eq_zero_of_right_eq_zero haw
+    refine ⟨integrableOn_zero.congr_fun ?_ measurableSet_Ioi, ?_⟩
+    · intro t _
+      change 0 = relativeEntropyScalar a b t * w
+      exact (hzero t).symm
+    · rw [setIntegral_congr_fun measurableSet_Ioi fun t _ => hzero t]
+      rw [integral_zero]
+      rw [hb0, Real.log_zero]
+      rw [sub_zero, mul_right_comm a (Real.log a) w, haw, zero_mul]
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+open scoped Matrix.Norms.L2Operator in
+/-- If the kernel of a positive-semidefinite reference matrix `B` is contained
+in the kernel of `A`, then a zero eigenvector of `B` has zero overlap with
+each positive spectral component of `A`.
+
+This lemma implements the support convention in the positive-semidefinite
+extension of Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720. It removes
+the formally nonintegrable zero-reference-eigenvalue terms from the
+support-domain relative-entropy resolvent integral. -/
+theorem eigenvalue_mul_overlap_eq_zero_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) :
+    (hA.isHermitian.eigenvalues i : ℂ) *
+        (star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j = 0 := by
+  classical
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  have hBzero :
+      B *ᵥ ⇑(hB.isHermitian.eigenvectorBasis j) = 0 := by
+    rw [hB.isHermitian.mulVec_eigenvectorBasis, hβ, zero_smul]
+  have hAzero : A *ᵥ ⇑(hB.isHermitian.eigenvectorBasis j) = 0 :=
+    hker _ hBzero
+  have hAUBzero : (A * UB) *ᵥ Pi.single j 1 = 0 := by
+    rw [← Matrix.mulVec_mulVec]
+    change A *ᵥ
+      ((hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *ᵥ Pi.single j 1) = 0
+    rw [hB.isHermitian.eigenvectorUnitary_mulVec, hAzero]
+  have hstarAUBzero :
+      (star UA * (A * UB)) *ᵥ Pi.single j 1 = 0 := by
+    rw [← Matrix.mulVec_mulVec, hAUBzero, Matrix.mulVec_zero]
+  have hentryzero := congrFun hstarAUBzero i
+  simp only [Matrix.mulVec_single_one, Pi.zero_apply] at hentryzero
+  change (star UA * (A * UB)) i j = 0 at hentryzero
+  rw [hA.isHermitian.spectral_form] at hentryzero
+  have hUA : star UA * UA = 1 := by
+    simp [UA]
+  change
+    (star UA *
+      ((UA * Matrix.diagonal
+        (fun k => (hA.isHermitian.eigenvalues k : ℂ))) * star UA * UB)) i j = 0
+    at hentryzero
+  simp only [Matrix.mul_assoc] at hentryzero
+  rw [← Matrix.mul_assoc, hUA, Matrix.one_mul] at hentryzero
+  simp only [Matrix.diagonal_mul] at hentryzero
+  simpa only [UA, UB] using hentryzero
+
+open scoped Matrix.Norms.L2Operator in
+/-- Under the support inclusion `ker B ⊆ ker A`, a zero reference eigenvalue
+has zero weight in every spectral summand:
+\[
+  \alpha_i\lvert (U_A^\ast U_B)_{ij}\rvert^2=0.
+\]
+
+This is the nonnegative spectral-coefficient form used to implement the
+support convention in the positive-semidefinite extension of
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720. -/
+theorem eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) :
+    hA.isHermitian.eigenvalues i *
+        Complex.normSq
+          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 := by
+  classical
+  have hcomp :=
+    eigenvalue_mul_overlap_eq_zero_of_kernel_le hA hB hker i j hβ
+  by_cases hα : hA.isHermitian.eigenvalues i ≠ 0
+  · have hαc : (hA.isHermitian.eigenvalues i : ℂ) ≠ 0 := by
+      exact_mod_cast hα
+    have hWij :
+        (star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j = 0 :=
+      (mul_eq_zero.mp hcomp).resolve_left hαc
+    simp [hWij]
+  · simp only [not_ne_iff] at hα
+    simp [hα]
+
+open scoped Matrix.Norms.L2Operator in
+/-- A zero eigenvalue of the reference matrix contributes identically zero to
+the support-domain scalar resolvent sum when `ker B ⊆ ker A`.
+
+The separate scalar factor need not be integrable when the reference
+eigenvalue is zero. The support condition instead annihilates its spectral
+weight before integration. This implements the support convention in the
+positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
+lines 717--720. -/
+theorem relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) (hβ : hB.isHermitian.eigenvalues j = 0) (t : ℝ) :
+    relativeEntropyScalar
+          (hA.isHermitian.eigenvalues i)
+          (hB.isHermitian.eigenvalues j) t *
+        Complex.normSq
+          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 := by
+  classical
+  have hweight :=
+    eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le hA hB hker i j hβ
+  by_cases hα : hA.isHermitian.eigenvalues i ≠ 0
+  · have hnormSq :
+        Complex.normSq
+          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) = 0 :=
+      (mul_eq_zero.mp hweight).resolve_left hα
+    simp [hnormSq]
+  · simp only [not_ne_iff] at hα
+    simp [relativeEntropyScalar, hα, hβ]
+
+open scoped Matrix.Norms.L2Operator in
+/-- For `t > 0`, the spectral integrand for relative entropy on the support
+domain of positive-semidefinite `A` and `B` is the finite sum
+\[
+  \sum_{i,j} r(\alpha_i,\beta_j,t)
+    \lvert (U_A^\ast U_B)_{ij}\rvert^2,
+\]
+where `r` is `relativeEntropyScalar`.
+
+Under `ker B ⊆ ker A`, the terms with `β_j = 0` vanish by
+`relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le`. Thus this
+definition implements the support convention in the positive-semidefinite
+extension of Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720.
+
+This is a spectral-coordinate expression. It has not yet been identified
+with the coordinate-free form of the matrix lift `(intAB)`, lines 423--427.
+In the corresponding singular formula, `B⁺` occurs inside the shifted
+operator `t 1 + A ⊗ (B⁺)ᵀ`; for `t > 0`, the inverse of that shifted
+operator on the support is an ordinary inverse, not a pseudoinverse of the
+shifted operator. -/
+noncomputable def supportRelativeEntropySpectralIntegrand
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (t : ℝ) : ℝ :=
+  ∑ i, ∑ j,
+    relativeEntropyScalar
+        (hA.isHermitian.eigenvalues i)
+        (hB.isHermitian.eigenvalues j) t *
+      Complex.normSq
+        ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+
+open scoped Matrix.Norms.L2Operator in
+/-- Each weighted spectral term is integrable on the positive half-line and
+has the expected logarithmic integral when `ker B ⊆ ker A`.
+
+The zero-reference terms implement the support convention in the
+positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
+lines 717--720. The positive scalar terms use `(intspec)`, §2.1,
+lines 406--413. -/
+theorem
+    relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) :
+    IntegrableOn
+      (fun t : ℝ =>
+        relativeEntropyScalar
+            (hA.isHermitian.eigenvalues i)
+            (hB.isHermitian.eigenvalues j) t *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j))
+      (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0,
+        relativeEntropyScalar
+              (hA.isHermitian.eigenvalues i)
+              (hB.isHermitian.eigenvalues j) t *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) =
+        hA.isHermitian.eigenvalues i *
+          (Real.log (hA.isHermitian.eigenvalues i) -
+            Real.log (hB.isHermitian.eigenvalues j)) *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  apply relativeEntropyScalar_mul_integrableOn_and_integral_of_nonneg
+  · exact hA.eigenvalues_nonneg i
+  · exact hB.eigenvalues_nonneg j
+  · exact eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le hA hB hker i j
+
+open scoped Matrix.Norms.L2Operator in
+/-- Each weighted scalar term in the support-domain spectral integrand is
+integrable on the positive half-line when `ker B ⊆ ker A`. -/
+theorem relativeEntropyScalar_mul_overlap_normSq_integrableOn_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (i j : n) :
+    IntegrableOn
+      (fun t : ℝ =>
+        relativeEntropyScalar
+            (hA.isHermitian.eigenvalues i)
+            (hB.isHermitian.eigenvalues j) t *
+          Complex.normSq
+            ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+              (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j))
+      (Ioi 0) :=
+  (relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
+    hA hB hker i j).1
+
+open scoped Matrix.Norms.L2Operator in
+/-- The support-domain spectral integrand is integrable on the positive
+half-line, and its integral is the spectral relative-entropy sum, when
+`ker B ⊆ ker A`.
+
+The zero-reference terms implement the support convention in the
+positive-semidefinite extension of Jenčová--Ruskai, arXiv:0903.2895v4,
+lines 717--720; the finite matrix lift is `(intAB)`, §2.1,
+lines 423--427. -/
+theorem
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0) :
+    IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
+        ∑ i, ∑ j,
+          hA.isHermitian.eigenvalues i *
+            (Real.log (hA.isHermitian.eigenvalues i) -
+              Real.log (hB.isHermitian.eigenvalues j)) *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+  classical
+  have hterm (i j : n) :=
+    relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
+      hA hB hker i j
+  have hintegral :
+      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
+        ∑ i, ∑ j,
+          hA.isHermitian.eigenvalues i *
+            (Real.log (hA.isHermitian.eigenvalues i) -
+              Real.log (hB.isHermitian.eigenvalues j)) *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+    unfold supportRelativeEntropySpectralIntegrand
+    rw [integral_finsetSum Finset.univ]
+    · apply Finset.sum_congr rfl
+      intro i _
+      rw [integral_finsetSum Finset.univ]
+      · apply Finset.sum_congr rfl
+        intro j _
+        exact (hterm i j).2
+      · exact fun j _ => (hterm i j).1
+    · intro i _
+      apply integrable_finsetSum Finset.univ
+      exact fun j _ => (hterm i j).1
+  have hintegrable :
+      IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) := by
+    unfold supportRelativeEntropySpectralIntegrand
+    apply integrable_finsetSum Finset.univ
+    intro i _
+    apply integrable_finsetSum Finset.univ
+    exact fun j _ => (hterm i j).1
+  exact ⟨hintegrable, hintegral⟩
+
+open scoped Matrix.Norms.L2Operator in
+/-- For positive-semidefinite `A` and `B` with `ker B ⊆ ker A`, the
+support-domain spectral integrand is integrable on `(0, ∞)` and its integral
+is the totalized trace-log relative entropy:
+\[
+  \int_0^\infty I_{A,B}(t)\,dt = D(A\Vert B).
+\]
+
+The spectral trace-log identity is `(J1)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 277--287. The positive spectral terms use the scalar
+normalization `(intspec)`, lines 406--413, and its finite spectral sum
+`(intAB)`, lines 423--427. The kernel condition and zero-reference terms
+implement the positive-semidefinite extension at lines 717--720. -/
+theorem
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0) :
+    IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
+        quantumRelativeEntropy A B := by
+  have hfinite :=
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_of_kernel_le
+      hA hB hker
+  refine ⟨hfinite.1, ?_⟩
+  rw [hfinite.2]
+  exact (quantumRelativeEntropy_spectral hA.isHermitian hB.isHermitian).symm
+
+end Matrix

--- a/TNLean/Analysis/RelativeEntropySupportIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropySupportIntegral.lean
@@ -228,12 +228,14 @@ domain of positive-semidefinite `A` and `B` is the finite sum
   \sum_{i,j} r(\alpha_i,\beta_j,t)
     \lvert (U_A^\ast U_B)_{ij}\rvert^2,
 \]
-where `r` is `relativeEntropyScalar`.
+where `r` is zero when `β_j = 0` and is `relativeEntropyScalar` when
+`β_j > 0`. Thus no zero-over-zero quotient occurs in the definition.
 
-Under `ker B ⊆ ker A`, the terms with `β_j = 0` vanish by
-`relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le`. Thus this
-definition implements the support convention in the positive-semidefinite
-extension of Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720.
+Under `ker B ⊆ ker A`, this convention agrees with the totalized scalar
+expression because the terms with `β_j = 0` vanish by
+`relativeEntropyScalar_mul_overlap_normSq_eq_zero_of_kernel_le`. This
+implements the support convention in the positive-semidefinite extension of
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720.
 
 This is a spectral-coordinate expression. It has not yet been identified
 with the coordinate-free form of the matrix lift `(intAB)`, lines 423--427.
@@ -245,12 +247,14 @@ noncomputable def supportRelativeEntropySpectralIntegrand
     {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
     (t : ℝ) : ℝ :=
   ∑ i, ∑ j,
-    relativeEntropyScalar
-        (hA.isHermitian.eigenvalues i)
-        (hB.isHermitian.eigenvalues j) t *
-      Complex.normSq
-        ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
-          (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+    if 0 < hB.isHermitian.eigenvalues j then
+      relativeEntropyScalar
+          (hA.isHermitian.eigenvalues i)
+          (hB.isHermitian.eigenvalues j) t *
+        Complex.normSq
+          ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+            (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+    else 0
 
 open scoped Matrix.Norms.L2Operator in
 /-- Each weighted spectral term is integrable on the positive half-line and
@@ -337,6 +341,46 @@ theorem
   have hterm (i j : n) :=
     relativeEntropyScalar_mul_overlap_normSq_integrableOn_and_integral_of_kernel_le
       hA hB hker i j
+  have hpiece (i j : n) :
+      IntegrableOn
+        (fun t : ℝ =>
+          if 0 < hB.isHermitian.eigenvalues j then
+            relativeEntropyScalar
+                (hA.isHermitian.eigenvalues i)
+                (hB.isHermitian.eigenvalues j) t *
+              Complex.normSq
+                ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                  (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+          else 0)
+        (Ioi 0) ∧
+        ∫ t : ℝ in Ioi 0,
+          (if 0 < hB.isHermitian.eigenvalues j then
+            relativeEntropyScalar
+                (hA.isHermitian.eigenvalues i)
+                (hB.isHermitian.eigenvalues j) t *
+              Complex.normSq
+                ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                  (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+          else 0) =
+          hA.isHermitian.eigenvalues i *
+            (Real.log (hA.isHermitian.eigenvalues i) -
+              Real.log (hB.isHermitian.eigenvalues j)) *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j) := by
+    by_cases hβpos : 0 < hB.isHermitian.eigenvalues j
+    · simpa only [hβpos, if_true] using hterm i j
+    · have hβzero : hB.isHermitian.eigenvalues j = 0 :=
+        le_antisymm (not_lt.mp hβpos) (hB.eigenvalues_nonneg j)
+      have hweight :=
+        eigenvalue_mul_overlap_normSq_eq_zero_of_kernel_le
+          hA hB hker i j hβzero
+      refine ⟨?_, ?_⟩
+      · simp only [hβpos, if_false]
+        exact integrableOn_zero
+      · simp only [hβzero, lt_self_iff_false, if_false, integral_zero, Real.log_zero,
+          sub_zero]
+        rw [mul_right_comm, hweight, zero_mul]
   have hintegral :
       ∫ t : ℝ in Ioi 0, supportRelativeEntropySpectralIntegrand hA hB t =
         ∑ i, ∑ j,
@@ -353,18 +397,18 @@ theorem
       rw [integral_finsetSum Finset.univ]
       · apply Finset.sum_congr rfl
         intro j _
-        exact (hterm i j).2
-      · exact fun j _ => (hterm i j).1
+        exact (hpiece i j).2
+      · exact fun j _ => (hpiece i j).1
     · intro i _
       apply integrable_finsetSum Finset.univ
-      exact fun j _ => (hterm i j).1
+      exact fun j _ => (hpiece i j).1
   have hintegrable :
       IntegrableOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) := by
     unfold supportRelativeEntropySpectralIntegrand
     apply integrable_finsetSum Finset.univ
     intro i _
     apply integrable_finsetSum Finset.univ
-    exact fun j _ => (hterm i j).1
+    exact fun j _ => (hpiece i j).1
   exact ⟨hintegrable, hintegral⟩
 
 open scoped Matrix.Norms.L2Operator in

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2544,8 +2544,9 @@ Theorem~\ref{thm:trace_norm_abs}.
       \frac{a^2/(a+tb)-b+t b^2/(a+tb)}{1+t}\,dt
       =a(\log a-\log b).
     \]
-    This is the scalar identity underlying the spectral representation in
-    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S4.
+    This is the scalar normalization $(\mathrm{intspec})$ in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S2.1,
+    lines~406--413.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -2558,6 +2559,96 @@ Theorem~\ref{thm:trace_norm_abs}.
     as $a-b$ is positive or negative, and is therefore integrable.  The
     fundamental theorem of calculus gives the stated value.
 \end{proof}
+
+\begin{theorem}[Hermitian trace-log spectral identity]
+    \label{thm:relative_entropy_hermitian_spectral}
+    \lean{Matrix.quantumRelativeEntropy_spectral}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    Let $A$ and $B$ be Hermitian matrices of the same size, with spectral
+    resolutions
+    \[
+        A=\sum_i\alpha_i|u_i\rangle\langle u_i|,
+        \qquad
+        B=\sum_j\beta_j|v_j\rangle\langle v_j|.
+    \]
+    Write $w_{ij}=\langle u_i,v_j\rangle$, and use the total real logarithm,
+    for which $\log 0=0$.  Then
+    \[
+        D(A\Vert B)
+        =\sum_{i,j}\alpha_i
+          \bigl(\log\alpha_i-\log\beta_j\bigr)|w_{ij}|^2.
+    \]
+    This is the spectral form of the homogeneous trace-log identity
+    $(\mathrm{J1})$ in Jen\v{c}ov\'a--Ruskai,
+    arXiv:0903.2895v4, lines~277--287.
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand both trace terms in eigenbases.  Unitarity of the overlap matrix
+    gives $\sum_j|w_{ij}|^2=1$, so
+    \[
+      \operatorname{Re}\operatorname{Tr}(A\log A)
+        =\sum_{i,j}\alpha_i\log(\alpha_i)|w_{ij}|^2,
+      \qquad
+      \operatorname{Re}\operatorname{Tr}(A\log B)
+        =\sum_{i,j}\alpha_i\log(\beta_j)|w_{ij}|^2.
+    \]
+    Subtraction gives the stated identity.
+\end{proof}
+
+\begin{theorem}[Support-domain spectral integral of relative entropy]
+    \label{thm:relative_entropy_support_spectral_integral}
+    \lean{Matrix.supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy}
+    \leanok
+    \uses{def:quantum_relative_entropy,
+        lem:relative_entropy_scalar_resolvent_integral,
+        thm:relative_entropy_hermitian_spectral}
+    Let $A$ and $B$ be positive semidefinite matrices of the same size and
+    suppose that $\ker B\subseteq\ker A$.  With the spectral notation of the
+    preceding theorem, define, for $t>0$,
+    \[
+      I_{A,B}(t)=
+      \sum_{i,j}
+      \frac{
+        \alpha_i^2/(\alpha_i+t\beta_j)-\beta_j
+          +t\beta_j^2/(\alpha_i+t\beta_j)}
+        {1+t}
+      |w_{ij}|^2.
+    \]
+    The terms with $\beta_j=0$ vanish after multiplication by
+    $|w_{ij}|^2$.  The function $I_{A,B}$ is integrable on $(0,\infty)$, and
+    \[
+        \int_0^\infty I_{A,B}(t)\,dt=D(A\Vert B).
+    \]
+    The trace-log identity $(\mathrm{J1})$, the scalar normalization
+    $(\mathrm{intspec})$, and its matrix form $(\mathrm{intAB})$ occur in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, at lines~277--287,
+    406--413, and 423--427, respectively.  The support-domain extension is
+    given at lines~717--720.
+
+    This theorem concerns the spectral expression $I_{A,B}$.  It does not
+    assert a coordinate-free support-resolvent formula or a finite-family
+    defect identity.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $\beta_j=0$, the kernel inclusion gives
+    $\alpha_i|w_{ij}|^2=0$, so the complete weighted term vanishes.  If
+    $\beta_j>0$, the scalar integral applies when $\alpha_i>0$, while the
+    term is identically zero when $\alpha_i=0$.  Since the double sum is
+    finite, integration term by term gives
+    \[
+      \int_0^\infty I_{A,B}(t)\,dt
+        =\sum_{i,j}\alpha_i
+          \bigl(\log\alpha_i-\log\beta_j\bigr)|w_{ij}|^2.
+    \]
+    The preceding theorem identifies the last sum with $D(A\Vert B)$.
+\end{proof}
+
+% Open in #4435: identify the spectral expression above with the
+% coordinate-free support-resolvent quadratic form, then prove the
+% finite-family defect identity.  Neither statement is claimed here.
 
 \begin{theorem}[Spectral resolvent representation of relative entropy]
     \label{thm:relative_entropy_resolvent_integral}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2572,15 +2572,16 @@ Theorem~\ref{thm:trace_norm_abs}.
         \qquad
         B=\sum_j\beta_j|v_j\rangle\langle v_j|.
     \]
-    Write $w_{ij}=\langle u_i,v_j\rangle$, and use the total real logarithm,
-    for which $\log 0=0$.  Then
+    Write $w_{ij}=\langle u_i,v_j\rangle$, and use the total real logarithm:
+    $\log 0=0$, while $\log x=\log|x|$ for $x<0$.  Then
     \[
         D(A\Vert B)
         =\sum_{i,j}\alpha_i
           \bigl(\log\alpha_i-\log\beta_j\bigr)|w_{ij}|^2.
     \]
-    This is the spectral form of the homogeneous trace-log identity
-    $(\mathrm{J1})$ in Jen\v{c}ov\'a--Ruskai,
+    This is an algebraic totalized extension to arbitrary Hermitian matrices
+    of the homogeneous trace-log identity $(\mathrm{J1})$, which
+    Jen\v{c}ov\'a--Ruskai state for strictly positive matrices in
     arXiv:0903.2895v4, lines~277--287.
 \end{theorem}
 
@@ -2608,18 +2609,33 @@ Theorem~\ref{thm:trace_norm_abs}.
     suppose that $\ker B\subseteq\ker A$.  With the spectral notation of the
     preceding theorem, define, for $t>0$,
     \[
-      I_{A,B}(t)=
-      \sum_{i,j}
-      \frac{
-        \alpha_i^2/(\alpha_i+t\beta_j)-\beta_j
-          +t\beta_j^2/(\alpha_i+t\beta_j)}
-        {1+t}
-      |w_{ij}|^2.
+      r_{ij}(t)=
+      \begin{cases}
+        0, & \beta_j=0,\\[2mm]
+        \displaystyle
+        \frac{
+          \alpha_i^2/(\alpha_i+t\beta_j)-\beta_j
+            +t\beta_j^2/(\alpha_i+t\beta_j)}
+          {1+t},
+          & \beta_j>0,
+      \end{cases}
+      \qquad
+      I_{A,B}(t)=\sum_{i,j}r_{ij}(t)|w_{ij}|^2.
     \]
-    The terms with $\beta_j=0$ vanish after multiplication by
-    $|w_{ij}|^2$.  The function $I_{A,B}$ is integrable on $(0,\infty)$, and
+    Thus no ordinary quotient with $\alpha_i=\beta_j=0$ is used.  Define also
     \[
-        \int_0^\infty I_{A,B}(t)\,dt=D(A\Vert B).
+      e_{ij}=
+      \begin{cases}
+        0, & \beta_j=0,\\
+        \alpha_i\bigl(\log\alpha_i-\log\beta_j\bigr)|w_{ij}|^2,
+          & \beta_j>0.
+      \end{cases}
+    \]
+    The function $I_{A,B}$ is integrable on $(0,\infty)$, and
+    \[
+        \int_0^\infty I_{A,B}(t)\,dt
+        =\sum_{i,j}e_{ij}
+        =D(A\Vert B).
     \]
     The trace-log identity $(\mathrm{J1})$, the scalar normalization
     $(\mathrm{intspec})$, and its matrix form $(\mathrm{intAB})$ occur in
@@ -2634,16 +2650,17 @@ Theorem~\ref{thm:trace_norm_abs}.
 
 \begin{proof}\leanok
     If $\beta_j=0$, the kernel inclusion gives
-    $\alpha_i|w_{ij}|^2=0$, so the complete weighted term vanishes.  If
-    $\beta_j>0$, the scalar integral applies when $\alpha_i>0$, while the
-    term is identically zero when $\alpha_i=0$.  Since the double sum is
-    finite, integration term by term gives
+    $\alpha_i|w_{ij}|^2=0$, and both $r_{ij}$ and $e_{ij}$ are defined to be
+    zero.  If $\beta_j>0$, the scalar integral applies when $\alpha_i>0$,
+    while the term is identically zero when $\alpha_i=0$.  Since the double
+    sum is finite, integration term by term gives
     \[
       \int_0^\infty I_{A,B}(t)\,dt
-        =\sum_{i,j}\alpha_i
-          \bigl(\log\alpha_i-\log\beta_j\bigr)|w_{ij}|^2.
+        =\sum_{i,j}e_{ij}.
     \]
-    The preceding theorem identifies the last sum with $D(A\Vert B)$.
+    The kernel inclusion also shows that replacing each $\beta_j=0$ summand
+    in the preceding theorem by zero does not change its value.  Hence that
+    theorem identifies the last sum with $D(A\Vert B)$.
 \end{proof}
 
 % Open in #4435: identify the spectral expression above with the

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -376,6 +376,18 @@ definition and convexity argument directly to positive semidefinite pairs with
 $\ker B\subseteq\ker A$; see arXiv:0903.2895v4, lines 717--720.  Their singular
 equality argument then obtains the common relative-modular resolvent on the
 reference support and passes through functional calculus; see lines 766--793.
+The support-domain spectral integral is now also proved.  For positive
+semidefinite $A,B$ with $\ker B\subseteq\ker A$, its finite spectral integrand
+is integrable on $(0,\infty)$ and has integral $D(A\Vert B)$.  This proves the
+spectral content of $(\mathrm{J1})$, $(\mathrm{intspec})$, and
+$(\mathrm{intAB})$ together with the support convention at lines 717--720.
+\footnote{Formal declarations:
+\leanid{Matrix.quantumRelativeEntropy_spectral} and
+\leanid{Matrix.supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy}
+in \path{TNLean/Analysis/RelativeEntropyResolventIntegral.lean}.}
+It does not yet identify that finite spectral sum with a coordinate-free
+support-resolvent quadratic form, and it gives no finite-family defect
+identity.
 Following the latter step, consider two positive semidefinite pairs $(A,B)$ and
 $(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
 $B$, and write
@@ -423,9 +435,14 @@ $\mathbf 1\otimes P_B^{\mathsf T}$, multiplication by
 $A\otimes\mathbf 1+t(\mathbf 1\otimes B^{\mathsf T})$ gives
 $\operatorname{vec}(B^{\mathsf T})$.  This uses only the generalized-inverse
 identity $(B^{-1/2}_{\mathrm{supp}})^2B=P_B$ and does not supply equality
-with the comparison resolver.  The remaining step is the support-domain
-relative-entropy defect identity and its zero-defect consequence, tracked in
-issue~\#4435.
+with the comparison resolver.  The new spectral integral theorem does not
+close this gap: one must first identify its integrand with the corresponding
+support-restricted quadratic form.  In the relative-modular formulation,
+$B^+=(B^{-1/2}_{\mathrm{supp}})^2$ occurs inside
+$t\mathbf 1+A\otimes(B^+)^{\mathsf T}$; for $t>0$, the inverse of this
+shifted operator on $\mathbf 1\otimes P_B^{\mathsf T}$ is an ordinary inverse.
+After this identification, the finite-family support-domain defect identity
+and its zero-defect consequence remain to be proved in issue~\#4435.
 
 The kernel inclusion belongs to the preceding source theorem that must derive
 the support-restricted common resolvents from equality in data processing.  That

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -384,7 +384,7 @@ $(\mathrm{intAB})$ together with the support convention at lines 717--720.
 \footnote{Formal declarations:
 \leanid{Matrix.quantumRelativeEntropy_spectral} and
 \leanid{Matrix.supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy}
-in \path{TNLean/Analysis/RelativeEntropyResolventIntegral.lean}.}
+in \path{TNLean/Analysis/RelativeEntropySupportIntegral.lean}.}
 It does not yet identify that finite spectral sum with a coordinate-free
 support-resolvent quadratic form, and it gives no finite-family defect
 identity.


### PR DESCRIPTION
### Motivation

The relative-entropy development needs the singular support-domain integral before the coordinate-free equality argument can be completed. This change formalizes the finite spectral core under the source-faithful kernel inclusion.

### Description

- Proves the homogeneous Hermitian trace-log spectral identity corresponding to Jenčová–Ruskai (J1).
- Extends the scalar resolvent integral term by term to positive-semidefinite matrices satisfying `ker B ⊆ ker A`, including the zero-reference spectral terms.
- Identifies the integral of the support-domain spectral expression with `D(A ‖ B)`.
- Adds exact blueprint statements and records the remaining mathematical step in the paper-gap note.

This pull request does not claim the coordinate-free support-resolvent identity or the finite-family defect endpoint. The remaining work is to identify the finite spectral integrand with the support-restricted quadratic form containing `B⁺`, and then prove the finite-family defect identity.

### Testing

- `lake env lean TNLean/Analysis/RelativeEntropyResolventIntegral.lean`
- `lake build TNLean.Analysis.RelativeEntropyResolventIntegral`
- `lake build`
- Python 3.9 `leanblueprint web`
- Python 3.9 `leanblueprint checkdecls`
- Python 3.9 `leanblueprint pdf`, followed by visual inspection of the affected entropy pages
- `python3.9 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/tactic_pattern_scan.py`

---

Advances LionSR/QICLean#245

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib analysis additions with no runtime, auth, or data paths; main caveat is mathematical scope (spectral-only, not full singular equality pipeline).
> 
> **Overview**
> Adds formal support for **positive-semidefinite** quantum relative entropy under `ker B ⊆ ker A`, on top of the existing positive-definite resolvent theory.
> 
> **`RelativeEntropyResolventIntegral.lean`** generalizes the spectral trace-log identity to arbitrary Hermitian pairs via Mathlib’s totalized `Real.log` (`quantumRelativeEntropy_spectral`), with `quantumRelativeEntropy_posDef_spectral` as a thin specialization. Jenčová–Ruskai citations are tightened to `(intspec)` / `(intAB)` in §2.1.
> 
> **New `RelativeEntropySupportIntegral.lean`** defines a support-domain spectral integrand that uses `relativeEntropyScalar` only when `β_j > 0`, and proves weighted scalar integrability—including cases where a zero reference eigenvalue would make the bare scalar term non-integrable—using kernel overlap lemmas. The main theorem shows \(\int_0^\infty I_{A,B}(t)\,dt = D(A\Vert B)\) by termwise integration and `quantumRelativeEntropy_spectral`. The file explicitly does **not** yet equate this sum with a coordinate-free support resolvent involving \(B^+\).
> 
> Blueprint chapter 19 and the CPSV16 paper-gap note document the Hermitian spectral identity, the support integral theorem, and that the coordinate-free defect step remains open (#4435).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abecc72d23ab0de0e61ee7f7f6e4f3916c8471a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->