### PR TITLE
feat(Analysis): identify the support left-right quadratic form

### DIFF
--- a/TNLean/Algebra/PosSemidefSupport.lean
+++ b/TNLean/Algebra/PosSemidefSupport.lean
@@ -20,6 +20,8 @@ are specializations of that construction.
   eigenspaces of a Hermitian matrix.
 * `Matrix.IsHermitian.supportProj_mul_self` and
   `Matrix.IsHermitian.mul_supportProj_self`: absorption on both sides.
+* `Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le`: right
+  absorption under kernel inclusion.
 * `Matrix.PosSemidef.supportProj`: the positive-semidefinite specialization.
 * `Matrix.PosSemidef.isOrthogonalProjection_supportProj`: orthogonality of the
   positive-semidefinite support projection.
@@ -144,6 +146,24 @@ theorem supportProj_mul_self (hA : A.IsHermitian) : hA.supportProj * A = A := by
 theorem mul_supportProj_self (hA : A.IsHermitian) : A * hA.supportProj = A := by
   have h2 := congrArg Matrix.conjTranspose hA.supportProj_mul_self
   rwa [Matrix.conjTranspose_mul, hA.supportProj_isHermitian.eq, hA.eq] at h2
+
+/-- If the kernel of a Hermitian matrix \(A\) is contained in the kernel of a
+matrix \(B\), then the support projection of \(A\) absorbs \(B\) on the
+right. -/
+theorem mul_supportProj_eq_self_of_mulVec_kernel_le
+    (hA : A.IsHermitian) {B : Matrix n n ℂ}
+    (hker : ∀ v : n → ℂ, A *ᵥ v = 0 → B *ᵥ v = 0) :
+    B * hA.supportProj = B := by
+  have hAcomp : A * (1 - hA.supportProj) = 0 := by
+    rw [Matrix.mul_sub, Matrix.mul_one, hA.mul_supportProj_self, sub_self]
+  have hBcomp : B * (1 - hA.supportProj) = 0 := by
+    rw [Matrix.ext_iff_mulVec]
+    intro v
+    rw [Matrix.zero_mulVec, ← Matrix.mulVec_mulVec]
+    apply hker
+    rw [Matrix.mulVec_mulVec, hAcomp, Matrix.zero_mulVec]
+  rw [Matrix.mul_sub, Matrix.mul_one, sub_eq_zero] at hBcomp
+  exact hBcomp.symm
 
 /-- The complementary projection of the support of a Hermitian matrix is
 Hermitian. -/

--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -34,6 +34,7 @@ import TNLean.Analysis.ProbabilityEntropy
 import TNLean.Analysis.ProjectionGeometry
 import TNLean.Analysis.RelativeEntropyResolventIntegral
 import TNLean.Analysis.RelativeEntropySupportIntegral
+import TNLean.Analysis.RelativeEntropySupportLeftRightQuadratic
 import TNLean.Analysis.ResolventFunctionalCalculus
 import TNLean.Analysis.RpowConvexity
 import TNLean.Analysis.SchattenNorm

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -28,6 +28,7 @@ theory development.
 * `Matrix.PosSemidef.blockDiagonal'`: a finite dependent block diagonal of
   positive-semidefinite matrices is positive semidefinite.
 * `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
+* `Matrix.PosSemidef.supportInv`: the generalized inverse on the support.
 * `Matrix.PosDef.supportInvSqrt_eq_inv_sqrt`: agreement with the ordinary
   inverse square root for positive-definite matrices.
 * `Matrix.PosSemidef.supportInvSqrt_smul`: compatibility with positive scaling.
@@ -35,6 +36,8 @@ theory development.
   unital left tensor embedding.
 * `Matrix.PosSemidef.supportInvSqrt_sq_mul_self` and
   `Matrix.PosSemidef.self_mul_supportInvSqrt_sq`: generalized-inverse identities.
+* `Matrix.PosSemidef.star_dotProduct_supportInv_mulVec_eq_of_mulVec_eq`:
+  evaluation of a support-inverse pairing from any solution.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder Kronecker
@@ -100,12 +103,28 @@ noncomputable def PosSemidef.supportInvSqrt {ρ : Matrix n n ℂ}
     (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
   hρ.isHermitian.cfc fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
 
+/-- The generalized inverse of a positive-semidefinite matrix on its support:
+the zero eigenspace is sent to zero and every positive eigenvalue \(x\) is sent
+to \(x^{-1}\).
+
+This is the generalized-inverse convention of Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 255--261. -/
+noncomputable def PosSemidef.supportInv {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
+  hρ.supportInvSqrt * hρ.supportInvSqrt
+
 /-- The support inverse square root is Hermitian. -/
 theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
     (hρ : ρ.PosSemidef) : hρ.supportInvSqrt.IsHermitian := by
   rw [PosSemidef.supportInvSqrt, ← hρ.isHermitian.cfc_eq]
   exact Matrix.isHermitian_iff_isSelfAdjoint.mpr
     (cfc_predicate (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ)
+
+/-- The generalized inverse on the support is Hermitian. -/
+theorem PosSemidef.supportInv_isHermitian {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) : hρ.supportInv.IsHermitian := by
+  simpa only [PosSemidef.supportInv, hρ.supportInvSqrt_isHermitian.eq] using
+    Matrix.isHermitian_conjTranspose_mul_self hρ.supportInvSqrt
 
 /-- The support inverse square root is positive semidefinite.
 
@@ -286,6 +305,44 @@ theorem PosSemidef.self_mul_supportInvSqrt_sq
     hρ.supportInvSqrt_isHermitian.eq,
     hρ.isHermitian.supportProj_isHermitian.eq] using
       congrArg Matrix.conjTranspose hρ.supportInvSqrt_sq_mul_self
+
+/-- The generalized inverse multiplied by the original matrix is the support
+projection. -/
+theorem PosSemidef.supportInv_mul_self
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInv * ρ = hρ.isHermitian.supportProj := by
+  simpa only [PosSemidef.supportInv] using hρ.supportInvSqrt_sq_mul_self
+
+/-- The original matrix multiplied by its generalized inverse is the support
+projection. -/
+theorem PosSemidef.self_mul_supportInv
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    ρ * hρ.supportInv = hρ.isHermitian.supportProj := by
+  simpa only [PosSemidef.supportInv] using hρ.self_mul_supportInvSqrt_sq
+
+/-- If \(Sx=b\) for a positive-semidefinite matrix \(S\), then pairing \(b\)
+with the support-generalized-inverse solution gives the pairing with \(x\):
+\[
+  \langle b,S^+b\rangle=\langle b,x\rangle .
+\]
+No choice of \(x\) is involved in the value, since \(b\) lies in the support
+of \(S\). -/
+theorem PosSemidef.star_dotProduct_supportInv_mulVec_eq_of_mulVec_eq
+    {S : Matrix n n ℂ} (hS : S.PosSemidef) (b x : n → ℂ)
+    (hx : S *ᵥ x = b) :
+    star b ⬝ᵥ (hS.supportInv *ᵥ b) = star b ⬝ᵥ x := by
+  let P := hS.isHermitian.supportProj
+  have hb : P *ᵥ b = b := by
+    rw [← hx, mulVec_mulVec]
+    exact congrArg (fun M : Matrix n n ℂ ↦ M *ᵥ x)
+      hS.isHermitian.supportProj_mul_self
+  calc
+    star b ⬝ᵥ (hS.supportInv *ᵥ b) =
+        star b ⬝ᵥ (P *ᵥ x) := by
+      rw [← hx, mulVec_mulVec, hS.supportInv_mul_self]
+    _ = star (P *ᵥ b) ⬝ᵥ x := by
+      rw [hS.isHermitian.supportProj_isHermitian.star_mulVec_dotProduct]
+    _ = star b ⬝ᵥ x := by rw [hb]
 
 /-- A finite dependent block diagonal of positive-semidefinite matrices is
 positive semidefinite. -/

--- a/TNLean/Analysis/RelativeEntropySupportIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropySupportIntegral.lean
@@ -239,7 +239,7 @@ Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720.
 
 The theorem `supportRelativeEntropyLeftRightIntegrand_eq_spectral` identifies
 this expression with the support-projected left-right quadratic form of the
-matrix lift `(intAB)`, lines 423--427. The bridge to the shifted
+matrix lift `(intAB)`, lines 423--427. The passage to the shifted
 relative-modular operator `t 1 + A ⊗ (B⁺)ᵀ` and the singular finite-family
 equality-to-common-resolvent passage remain open. -/
 noncomputable def supportRelativeEntropySpectralIntegrand

--- a/TNLean/Analysis/RelativeEntropySupportIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropySupportIntegral.lean
@@ -237,12 +237,11 @@ expression because the terms with `β_j = 0` vanish by
 implements the support convention in the positive-semidefinite extension of
 Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720.
 
-This is a spectral-coordinate expression. It has not yet been identified
-with the coordinate-free form of the matrix lift `(intAB)`, lines 423--427.
-In the corresponding singular formula, `B⁺` occurs inside the shifted
-operator `t 1 + A ⊗ (B⁺)ᵀ`; for `t > 0`, the inverse of that shifted
-operator on the support is an ordinary inverse, not a pseudoinverse of the
-shifted operator. -/
+The theorem `supportRelativeEntropyLeftRightIntegrand_eq_spectral` identifies
+this expression with the support-projected left-right quadratic form of the
+matrix lift `(intAB)`, lines 423--427. The bridge to the shifted
+relative-modular operator `t 1 + A ⊗ (B⁺)ᵀ` and the singular finite-family
+equality-to-common-resolvent passage remain open. -/
 noncomputable def supportRelativeEntropySpectralIntegrand
     {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
     (t : ℝ) : ℝ :=

--- a/TNLean/Analysis/RelativeEntropySupportLeftRightQuadratic.lean
+++ b/TNLean/Analysis/RelativeEntropySupportLeftRightQuadratic.lean
@@ -1,0 +1,776 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MatrixSqrt
+import TNLean.Analysis.RelativeEntropySupportIntegral
+
+/-!
+# Support-domain left-right quadratic forms
+
+For positive-semidefinite matrices \(A\) and \(B\), this file identifies the
+two quadratic forms associated with the left-right operator
+\[
+  X \longmapsto AX+tXB
+\]
+with the finite spectral integrand for relative entropy. The source in the
+first quadratic form is \(A P_B\), where \(P_B\) is the support projection of
+\(B\). This projection removes the zero-reference eigenspaces before forming
+the quadratic form. Under \(\ker B\subseteq\ker A\), one has \(A P_B=A\), so
+the projected form agrees with the unprojected source-\(A\) form.
+
+The generalized inverse used here is the support inverse of the left-right
+operator \(A\otimes 1+t(1\otimes B^{\mathsf T})\). It is distinct from the
+ordinary inverse of the shifted relative-modular operator
+\(t1+A\otimes(B^+)^{\mathsf T}\).
+
+## Main results
+
+* `Matrix.supportLeftRightSuperoperator_posSemidef` proves positivity of the
+  left-right operator.
+* `Matrix.supportSourceAQuadratic_spectral` and
+  `Matrix.supportSourceBQuadratic_spectral` give the two spectral expansions.
+* `Matrix.supportRelativeEntropyLeftRightIntegrand_eq_spectral` identifies the
+  coordinate-free quadratic expression with the support spectral integrand.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
+  Entropy and Related Trace Functions, with Conditions for Equality*,
+  arXiv:0903.2895v4, §2.1 and lines 717--720.
+-/
+
+open Set Topology
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The Kronecker matrix representing the left-right operator
+\(X\mapsto AX+tXB\) under \(X\mapsto\operatorname{vec}(X^{\mathsf T})\). -/
+noncomputable def supportLeftRightSuperoperator
+    (A B : Matrix n n ℂ) (t : ℝ) : Matrix (n × n) (n × n) ℂ :=
+  A ⊗ₖ (1 : Matrix n n ℂ) +
+    t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
+
+omit [Fintype n] in
+/-- The left-right operator \(X\mapsto AX+tXB\) is positive semidefinite
+when \(A\) and \(B\) are positive semidefinite and \(t\geq 0\).
+
+This is the positive-semidefinite form of the matrix lift `(intAB)` in
+Jenčová--Ruskai, arXiv:0903.2895v4, §2.1, lines 423--427. -/
+theorem supportLeftRightSuperoperator_posSemidef
+    [Finite n] {A B : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 ≤ t) :
+    (supportLeftRightSuperoperator A B t).PosSemidef := by
+  letI := Fintype.ofFinite n
+  have hI : (1 : Matrix n n ℂ).PosSemidef := Matrix.PosSemidef.one
+  exact (hA.kronecker hI).add ((hI.kronecker hB.transpose).smul ht)
+
+/-- The support inverse of the positive-semidefinite left-right operator.
+For negative \(t\) it is set to zero; all mathematical statements below use
+\(t>0\).
+
+This is the generalized inverse of \(A\otimes 1+t(1\otimes B^{\mathsf T})\),
+not the inverse of \(t1+A\otimes(B^+)^{\mathsf T}\). -/
+noncomputable def supportLeftRightSupportInv
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (t : ℝ) : Matrix (n × n) (n × n) ℂ :=
+  if ht : 0 ≤ t then
+    (supportLeftRightSuperoperator_posSemidef hA hB ht).supportInv
+  else 0
+
+/-- On the nonnegative half-line, the left-right support inverse is the
+generalized inverse furnished by positive semidefiniteness. -/
+theorem supportLeftRightSupportInv_eq
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 ≤ t) :
+    supportLeftRightSupportInv hA hB t =
+      (supportLeftRightSuperoperator_posSemidef hA hB ht).supportInv := by
+  simp only [supportLeftRightSupportInv, dif_pos ht]
+
+/-- The source-\(A\) quadratic form on the support of \(B\). Its source vector
+is \(\operatorname{vec}((A P_B)^{\mathsf T})\), so zero eigenvalues of \(B\)
+are removed before the generalized inverse is applied. -/
+noncomputable def supportSourceAQuadratic
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (t : ℝ) : ℝ :=
+  let b := vec (A * hB.isHermitian.supportProj)ᵀ
+  (star b ⬝ᵥ (supportLeftRightSupportInv hA hB t *ᵥ b)).re
+
+/-- The unprojected source-\(A\) quadratic form for a positive-semidefinite
+left-right operator. It agrees with `supportSourceAQuadratic` under
+\(\ker B\subseteq\ker A\), but not for arbitrary positive-semidefinite pairs. -/
+noncomputable def rawSupportSourceAQuadratic
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (t : ℝ) : ℝ :=
+  (star (vec Aᵀ) ⬝ᵥ
+    (supportLeftRightSupportInv hA hB t *ᵥ vec Aᵀ)).re
+
+/-- Under \(\ker B\subseteq\ker A\), projecting the source \(A\) to the
+support of \(B\) does not change the source-\(A\) quadratic form. -/
+theorem supportSourceAQuadratic_eq_raw_of_kernel_le
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0) (t : ℝ) :
+    supportSourceAQuadratic hA hB t =
+      rawSupportSourceAQuadratic hA hB t := by
+  rw [supportSourceAQuadratic, rawSupportSourceAQuadratic,
+    hB.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker]
+
+/-- The source-\(B\) quadratic form for the positive-semidefinite left-right
+operator. -/
+noncomputable def supportSourceBQuadratic
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (t : ℝ) : ℝ :=
+  (star (vec Bᵀ) ⬝ᵥ
+    (supportLeftRightSupportInv hA hB t *ᵥ vec Bᵀ)).re
+
+/-- The support-domain two-source left-right integrand. The coefficient \(t\)
+on the source-\(B\) form is the coefficient in the finite Weyl formulas
+`(intspec)` and `(intAB)` of Jenčová--Ruskai, arXiv:0903.2895v4, §2.1,
+lines 406--427. -/
+noncomputable def supportRelativeEntropyLeftRightIntegrand
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (t : ℝ) : ℝ :=
+  (supportSourceAQuadratic hA hB t - (Matrix.trace B).re +
+      t * supportSourceBQuadratic hA hB t) / (1 + t)
+
+private lemma spectral_support_sourceA_solution
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      if 0 < β j then
+        (α i / (α i + t * β j) : ℂ) * W i j
+      else 0
+    let X := UA * Y * star UB
+    A * X + t • (X * B) = A * hB.isHermitian.supportProj := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dα : Matrix n n ℂ := diagonal fun i => (α i : ℂ)
+  let Dβ : Matrix n n ℂ := diagonal fun j => (β j : ℂ)
+  let Qβ : Matrix n n ℂ :=
+    diagonal fun j => if 0 < β j then (1 : ℂ) else 0
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    if 0 < β j then
+      (α i / (α i + t * β j) : ℂ) * W i j
+    else 0
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hcore : Dα * Y + t • (Y * Dβ) = Dα * W * Qβ := by
+    ext i j
+    simp only [Dα, Dβ, Qβ, Y, Matrix.diagonal_mul, Matrix.mul_diagonal,
+      Matrix.add_apply, Matrix.smul_apply, Complex.real_smul]
+    by_cases hβ : 0 < β j
+    · simp only [hβ, if_true]
+      have hden : (α i : ℂ) + t * β j ≠ 0 := by
+        exact_mod_cast
+          (ne_of_gt (add_pos_of_nonneg_of_pos
+            (hA.eigenvalues_nonneg i) (mul_pos ht hβ)))
+      field_simp
+    · have hβzero : β j = 0 :=
+        le_antisymm (not_lt.mp hβ) (hB.eigenvalues_nonneg j)
+      simp [hβzero]
+  have hAform : A = UA * Dα * star UA := by
+    simpa only [UA, Dα, α] using hA.isHermitian.spectral_form
+  have hBform : B = UB * Dβ * star UB := by
+    simpa only [UB, Dβ, β] using hB.isHermitian.spectral_form
+  have hPform :
+      hB.isHermitian.supportProj = UB * Qβ * star UB := by
+    unfold Matrix.IsHermitian.supportProj
+    have hfun :
+        (fun j => if hB.isHermitian.eigenvalues j ≠ 0 then (1 : ℂ) else 0) =
+          fun j => if 0 < β j then (1 : ℂ) else 0 := by
+      funext j
+      by_cases hβ : 0 < β j
+      · simp [β, hβ, ne_of_gt hβ]
+      · have hβzero : β j = 0 :=
+          le_antisymm (not_lt.mp hβ) (hB.eigenvalues_nonneg j)
+        simp [β, hβzero]
+    rw [hfun]
+  have hUA : star UA * UA = 1 := by
+    simpa only [UA] using
+      Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+  have hstarUB : star UB * UB = 1 := by
+    simpa only [UB] using
+      Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  calc
+    A * X + t • (X * B) =
+        (UA * Dα * star UA) * X +
+          t • (X * (UB * Dβ * star UB)) := by rw [hAform, hBform]
+    _ = UA * (Dα * Y + t • (Y * Dβ)) * star UB := by
+      simp only [X, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc (star UA), hUA, Matrix.one_mul,
+        ← Matrix.mul_assoc (star UB) UB, hstarUB, Matrix.one_mul]
+      simp only [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc,
+        Matrix.mul_smul, Matrix.smul_mul]
+    _ = UA * (Dα * W * Qβ) * star UB := by rw [hcore]
+    _ = (UA * Dα * star UA) * (UB * Qβ * star UB) := by
+      simp only [W, Matrix.mul_assoc]
+    _ = A * hB.isHermitian.supportProj := by rw [hAform, hPform]
+
+private lemma spectral_support_sourceB_solution
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      if 0 < β j then
+        (β j / (α i + t * β j) : ℂ) * W i j
+      else 0
+    let X := UA * Y * star UB
+    A * X + t • (X * B) = B := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dα : Matrix n n ℂ := diagonal fun i => (α i : ℂ)
+  let Dβ : Matrix n n ℂ := diagonal fun j => (β j : ℂ)
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    if 0 < β j then
+      (β j / (α i + t * β j) : ℂ) * W i j
+    else 0
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hcore : Dα * Y + t • (Y * Dβ) = W * Dβ := by
+    ext i j
+    simp only [Dα, Dβ, Y, Matrix.diagonal_mul, Matrix.mul_diagonal,
+      Matrix.add_apply, Matrix.smul_apply, Complex.real_smul]
+    by_cases hβ : 0 < β j
+    · simp only [hβ, if_true]
+      have hden : (α i : ℂ) + t * β j ≠ 0 := by
+        exact_mod_cast
+          (ne_of_gt (add_pos_of_nonneg_of_pos
+            (hA.eigenvalues_nonneg i) (mul_pos ht hβ)))
+      rw [div_eq_mul_inv]
+      calc
+        (α i : ℂ) *
+              (((β j : ℂ) * ((α i : ℂ) + t * β j)⁻¹) * W i j) +
+            t * ((((β j : ℂ) * ((α i : ℂ) + t * β j)⁻¹) * W i j) * β j) =
+            W i j * β j *
+              (((α i : ℂ) + t * β j) *
+                ((α i : ℂ) + t * β j)⁻¹) := by ring
+        _ = W i j * β j := by rw [mul_inv_cancel₀ hden, mul_one]
+    · have hβzero : β j = 0 :=
+        le_antisymm (not_lt.mp hβ) (hB.eigenvalues_nonneg j)
+      simp [hβzero]
+  have hAform : A = UA * Dα * star UA := by
+    simpa only [UA, Dα, α] using hA.isHermitian.spectral_form
+  have hBform : B = UB * Dβ * star UB := by
+    simpa only [UB, Dβ, β] using hB.isHermitian.spectral_form
+  have hUA : star UA * UA = 1 := by
+    simpa only [UA] using
+      Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+  have hUAstar : UA * star UA = 1 := by
+    simpa only [UA] using
+      Unitary.mul_star_self_of_mem hA.isHermitian.eigenvectorUnitary.prop
+  have hstarUB : star UB * UB = 1 := by
+    simpa only [UB] using
+      Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  calc
+    A * X + t • (X * B) =
+        (UA * Dα * star UA) * X +
+          t • (X * (UB * Dβ * star UB)) := by rw [hAform, hBform]
+    _ = UA * (Dα * Y + t • (Y * Dβ)) * star UB := by
+      simp only [X, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc (star UA), hUA, Matrix.one_mul,
+        ← Matrix.mul_assoc (star UB) UB, hstarUB, Matrix.one_mul]
+      simp only [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc,
+        Matrix.mul_smul, Matrix.smul_mul]
+    _ = UA * (W * Dβ) * star UB := by rw [hcore]
+    _ = UB * Dβ * star UB := by
+      simp only [W, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc UA (star UA), hUAstar, Matrix.one_mul]
+    _ = B := hBform.symm
+
+private lemma spectral_support_sourceA_pairing
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (_ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      if 0 < β j then
+        (α i / (α i + t * β j) : ℂ) * W i j
+      else 0
+    let X := UA * Y * star UB
+    (star (vec (A * hB.isHermitian.supportProj)ᵀ) ⬝ᵥ vec Xᵀ).re =
+      ∑ i, ∑ j,
+        if 0 < β j then
+          α i ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+        else 0 := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dα : Matrix n n ℂ := diagonal fun i => (α i : ℂ)
+  let Qβ : Matrix n n ℂ :=
+    diagonal fun j => if 0 < β j then (1 : ℂ) else 0
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    if 0 < β j then
+      (α i / (α i + t * β j) : ℂ) * W i j
+    else 0
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hAform : A = UA * Dα * star UA := by
+    simpa only [UA, Dα, α] using hA.isHermitian.spectral_form
+  have hPform :
+      hB.isHermitian.supportProj = UB * Qβ * star UB := by
+    unfold Matrix.IsHermitian.supportProj
+    have hfun :
+        (fun j => if hB.isHermitian.eigenvalues j ≠ 0 then (1 : ℂ) else 0) =
+          fun j => if 0 < β j then (1 : ℂ) else 0 := by
+      funext j
+      by_cases hβ : 0 < β j
+      · simp [β, hβ, ne_of_gt hβ]
+      · have hβzero : β j = 0 :=
+          le_antisymm (not_lt.mp hβ) (hB.eigenvalues_nonneg j)
+        simp [β, hβzero]
+    rw [hfun]
+  have hUA : star UA * UA = 1 := by
+    simpa only [UA] using
+      Unitary.coe_star_mul_self hA.isHermitian.eigenvectorUnitary
+  have hUB : star UB * UB = 1 := by
+    simpa only [UB] using
+      Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  have hstarW : star W = star UB * UA := by
+    simp only [W, star_mul, star_star]
+  have hpair :
+      star (vec (A * hB.isHermitian.supportProj)ᵀ) ⬝ᵥ vec Xᵀ =
+        Matrix.trace (hB.isHermitian.supportProj * A * X) := by
+    rw [Matrix.star_vec_dotProduct_vec,
+      Matrix.conjTranspose_transpose_eq_transpose_conjTranspose,
+      ← Matrix.transpose_mul, Matrix.trace_transpose, Matrix.trace_mul_comm,
+      Matrix.conjTranspose_mul, hB.isHermitian.supportProj_isHermitian.eq,
+      hA.isHermitian.eq]
+  rw [hpair]
+  have htraceform :
+      Matrix.trace (hB.isHermitian.supportProj * A * X) =
+        Matrix.trace ((UB * Qβ * star UB) *
+          (UA * Dα * star UA) * X) := by
+    rw [hPform, hAform]
+  rw [htraceform]
+  simp only [X, Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (star UA), hUA, Matrix.one_mul]
+  rw [Matrix.trace_mul_comm UB]
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (star UB), hUB, Matrix.mul_one]
+  rw [← hstarW]
+  rw [← Matrix.mul_assoc (star W) Dα Y]
+  let Z : Matrix n n ℂ := fun i j => (α i : ℂ) * Y i j
+  have hDY : Dα * Y = Z := by
+    ext i j
+    simp only [Dα, Z, Matrix.diagonal_mul]
+  rw [Matrix.mul_assoc (star W) Dα Y, hDY]
+  have hQ : Qβ * (star W * Z) =
+      fun i j =>
+        (if 0 < β i then (1 : ℂ) else 0) *
+          (star W * Z) i j := by
+    ext i j
+    simp only [Qβ, Matrix.diagonal_mul]
+  rw [hQ]
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Z, Y,
+    Matrix.star_apply, Complex.star_def, Complex.re_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  change _ = ∑ i,
+    if 0 < β j then
+      α i ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+    else 0
+  by_cases hβ : 0 < β j
+  · simp only [hβ, if_true, one_mul, Complex.re_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    change
+      (star (W i j) *
+        ((α i : ℂ) *
+          (((α i : ℂ) / ((α i : ℂ) + t * β j)) * W i j))).re =
+        α i ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+    have hnorm : star (W i j) * W i j =
+        (Complex.normSq (W i j) : ℂ) := by
+      rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
+    rw [show
+      star (W i j) *
+          ((α i : ℂ) *
+            (((α i : ℂ) / ((α i : ℂ) + t * β j)) * W i j)) =
+        ((α i : ℂ) *
+          ((α i : ℂ) / ((α i : ℂ) + t * β j))) *
+            (star (W i j) * W i j) by ring, hnorm]
+    rw [← Complex.ofReal_mul t (β j),
+      ← Complex.ofReal_add (α i) (t * β j),
+      ← Complex.ofReal_div (α i) (α i + t * β j),
+      ← Complex.ofReal_mul (α i) (α i / (α i + t * β j)),
+      ← Complex.ofReal_mul
+        (α i * (α i / (α i + t * β j))) (Complex.normSq (W i j)),
+      Complex.ofReal_re]
+    ring
+  · simp [hβ]
+
+private lemma spectral_support_sourceB_pairing
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (_ht : 0 < t) :
+    let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+    let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+    let α : n → ℝ := hA.isHermitian.eigenvalues
+    let β : n → ℝ := hB.isHermitian.eigenvalues
+    let W := star UA * UB
+    let Y : Matrix n n ℂ := fun i j =>
+      if 0 < β j then
+        (β j / (α i + t * β j) : ℂ) * W i j
+      else 0
+    let X := UA * Y * star UB
+    (star (vec Bᵀ) ⬝ᵥ vec Xᵀ).re =
+      ∑ i, ∑ j,
+        if 0 < β j then
+          β j ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+        else 0 := by
+  classical
+  dsimp only
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let Dβ : Matrix n n ℂ := diagonal fun j => (β j : ℂ)
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    if 0 < β j then
+      (β j / (α i + t * β j) : ℂ) * W i j
+    else 0
+  let X : Matrix n n ℂ := UA * Y * star UB
+  have hBform : B = UB * Dβ * star UB := by
+    simpa only [UB, Dβ, β] using hB.isHermitian.spectral_form
+  have hUB : star UB * UB = 1 := by
+    simpa only [UB] using
+      Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  have hstarW : star W = star UB * UA := by
+    simp only [W, star_mul, star_star]
+  have hpair : star (vec Bᵀ) ⬝ᵥ vec Xᵀ = Matrix.trace (B * X) := by
+    rw [Matrix.star_vec_dotProduct_vec]
+    rw [hB.isHermitian.transpose.eq, ← Matrix.transpose_mul,
+      Matrix.trace_transpose, Matrix.trace_mul_comm]
+  rw [hpair]
+  have htraceform : Matrix.trace (B * X) =
+      Matrix.trace ((UB * Dβ * star UB) * X) := by
+    rw [hBform]
+  rw [htraceform]
+  simp only [X, Matrix.mul_assoc]
+  rw [Matrix.trace_mul_comm UB]
+  simp only [Matrix.mul_assoc]
+  rw [hUB, Matrix.mul_one]
+  rw [← Matrix.mul_assoc (star UB) UA Y, ← hstarW]
+  have hD : Dβ * (star W * Y) =
+      fun i j => (β i : ℂ) * (star W * Y) i j := by
+    ext i j
+    simp only [Dβ, Matrix.diagonal_mul]
+  rw [hD]
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Y,
+    Matrix.star_apply, Complex.star_def, Complex.re_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  change _ = ∑ i,
+    if 0 < β j then
+      β j ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+    else 0
+  by_cases hβ : 0 < β j
+  · simp only [hβ, if_true]
+    rw [Finset.mul_sum, Complex.re_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    change
+      ((β j : ℂ) * (star (W i j) *
+        (((β j : ℂ) / ((α i : ℂ) + t * β j)) * W i j))).re =
+        β j ^ 2 / (α i + t * β j) * Complex.normSq (W i j)
+    have hnorm : star (W i j) * W i j =
+        (Complex.normSq (W i j) : ℂ) := by
+      rw [Complex.star_def, ← Complex.normSq_eq_conj_mul_self]
+    rw [show
+      (β j : ℂ) * (star (W i j) *
+          (((β j : ℂ) / ((α i : ℂ) + t * β j)) * W i j)) =
+        ((β j : ℂ) *
+          ((β j : ℂ) / ((α i : ℂ) + t * β j))) *
+            (star (W i j) * W i j) by ring, hnorm]
+    rw [← Complex.ofReal_mul t (β j),
+      ← Complex.ofReal_add (α i) (t * β j),
+      ← Complex.ofReal_div (β j) (α i + t * β j),
+      ← Complex.ofReal_mul (β j) (β j / (α i + t * β j)),
+      ← Complex.ofReal_mul
+        (β j * (β j / (α i + t * β j))) (Complex.normSq (W i j)),
+      Complex.ofReal_re]
+    ring
+  · simp [hβ]
+
+/-- The projected source-\(A\) quadratic form has the spectral expansion
+\[
+  \sum_{i,j:\,\beta_j>0}
+    \frac{\alpha_i^2}{\alpha_i+t\beta_j}
+      \lvert (U_A^\ast U_B)_{ij}\rvert^2 .
+\]
+
+The restriction \(\beta_j>0\) is produced by the source \(A P_B\). This is the
+first term of `(intAB)` in Jenčová--Ruskai, arXiv:0903.2895v4, §2.1,
+lines 423--427, with the support convention at lines 717--720. -/
+theorem supportSourceAQuadratic_spectral
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    supportSourceAQuadratic hA hB t =
+      ∑ i, ∑ j,
+        if 0 < hB.isHermitian.eigenvalues j then
+          hA.isHermitian.eigenvalues i ^ 2 /
+              (hA.isHermitian.eigenvalues i +
+                t * hB.isHermitian.eigenvalues j) *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+        else 0 := by
+  classical
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    if 0 < β j then
+      (α i / (α i + t * β j) : ℂ) * W i j
+    else 0
+  let X : Matrix n n ℂ := UA * Y * star UB
+  let S : Matrix (n × n) (n × n) ℂ :=
+    supportLeftRightSuperoperator A B t
+  let b : n × n → ℂ := vec (A * hB.isHermitian.supportProj)ᵀ
+  have hsolution : A * X + t • (X * B) =
+      A * hB.isHermitian.supportProj := by
+    simpa only [UA, UB, α, β, W, Y, X] using
+      spectral_support_sourceA_solution hA hB ht
+  have hvec : S *ᵥ vec Xᵀ = b := by
+    change
+      (A ⊗ₖ (1 : Matrix n n ℂ) +
+        t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)) *ᵥ vec Xᵀ =
+          vec (A * hB.isHermitian.supportProj)ᵀ
+    rw [leftRight_mulVec_vec_transpose, hsolution]
+  have hS : S.PosSemidef := by
+    simpa only [S] using
+      supportLeftRightSuperoperator_posSemidef hA hB ht.le
+  have hpair :
+      star b ⬝ᵥ (hS.supportInv *ᵥ b) =
+        star b ⬝ᵥ vec Xᵀ :=
+    hS.star_dotProduct_supportInv_mulVec_eq_of_mulVec_eq b (vec Xᵀ) hvec
+  unfold supportSourceAQuadratic
+  rw [supportLeftRightSupportInv_eq hA hB ht.le]
+  change
+    (star b ⬝ᵥ
+      ((supportLeftRightSuperoperator_posSemidef hA hB ht.le).supportInv *ᵥ b)).re = _
+  rw [show
+    (supportLeftRightSuperoperator_posSemidef hA hB ht.le).supportInv =
+      hS.supportInv from rfl, hpair]
+  simpa only [UA, UB, α, β, W, Y, X, b] using
+    spectral_support_sourceA_pairing hA hB ht
+
+/-- The source-\(B\) quadratic form has the spectral expansion
+\[
+  \sum_{i,j:\,\beta_j>0}
+    \frac{\beta_j^2}{\alpha_i+t\beta_j}
+      \lvert (U_A^\ast U_B)_{ij}\rvert^2 .
+\]
+
+This is the second term of `(intAB)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 423--427, with the support convention at
+lines 717--720. -/
+theorem supportSourceBQuadratic_spectral
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    supportSourceBQuadratic hA hB t =
+      ∑ i, ∑ j,
+        if 0 < hB.isHermitian.eigenvalues j then
+          hB.isHermitian.eigenvalues j ^ 2 /
+              (hA.isHermitian.eigenvalues i +
+                t * hB.isHermitian.eigenvalues j) *
+            Complex.normSq
+              ((star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+                (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)) i j)
+        else 0 := by
+  classical
+  let UA : Matrix n n ℂ := hA.isHermitian.eigenvectorUnitary
+  let UB : Matrix n n ℂ := hB.isHermitian.eigenvectorUnitary
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ := star UA * UB
+  let Y : Matrix n n ℂ := fun i j =>
+    if 0 < β j then
+      (β j / (α i + t * β j) : ℂ) * W i j
+    else 0
+  let X : Matrix n n ℂ := UA * Y * star UB
+  let S : Matrix (n × n) (n × n) ℂ :=
+    supportLeftRightSuperoperator A B t
+  let b : n × n → ℂ := vec Bᵀ
+  have hsolution : A * X + t • (X * B) = B := by
+    simpa only [UA, UB, α, β, W, Y, X] using
+      spectral_support_sourceB_solution hA hB ht
+  have hvec : S *ᵥ vec Xᵀ = b := by
+    change
+      (A ⊗ₖ (1 : Matrix n n ℂ) +
+        t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)) *ᵥ vec Xᵀ = vec Bᵀ
+    rw [leftRight_mulVec_vec_transpose, hsolution]
+  have hS : S.PosSemidef := by
+    simpa only [S] using
+      supportLeftRightSuperoperator_posSemidef hA hB ht.le
+  have hpair :
+      star b ⬝ᵥ (hS.supportInv *ᵥ b) =
+        star b ⬝ᵥ vec Xᵀ :=
+    hS.star_dotProduct_supportInv_mulVec_eq_of_mulVec_eq b (vec Xᵀ) hvec
+  unfold supportSourceBQuadratic
+  rw [supportLeftRightSupportInv_eq hA hB ht.le]
+  change
+    (star b ⬝ᵥ
+      ((supportLeftRightSuperoperator_posSemidef hA hB ht.le).supportInv *ᵥ b)).re = _
+  rw [show
+    (supportLeftRightSuperoperator_posSemidef hA hB ht.le).supportInv =
+      hS.supportInv from rfl, hpair]
+  simpa only [UA, UB, α, β, W, Y, X, b] using
+    spectral_support_sourceB_pairing hA hB ht
+
+/-- For \(t>0\), the coordinate-free support left-right integrand is the
+existing support-domain spectral integrand:
+\[
+ \frac{Q_{A P_B}(t)-\operatorname{tr}B+tQ_B(t)}{1+t}
+ =
+ \sum_{i,j:\,\beta_j>0}
+ r(\alpha_i,\beta_j,t)\lvert(U_A^\ast U_B)_{ij}\rvert^2 .
+\]
+
+The statement holds for all positive-semidefinite \(A\) and \(B\). No kernel
+inclusion is required because the source in the first quadratic form is
+\(A P_B\). This is the support form of `(intAB)` in Jenčová--Ruskai,
+arXiv:0903.2895v4, §2.1, lines 423--427 and 717--720. -/
+theorem supportRelativeEntropyLeftRightIntegrand_eq_spectral
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    supportRelativeEntropyLeftRightIntegrand hA hB t =
+      supportRelativeEntropySpectralIntegrand hA hB t := by
+  classical
+  let α : n → ℝ := hA.isHermitian.eigenvalues
+  let β : n → ℝ := hB.isHermitian.eigenvalues
+  let W : Matrix n n ℂ :=
+    star (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ) *
+      (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let P : n → n → ℝ := fun i j => Complex.normSq (W i j)
+  have hWcol : star W * W = 1 := by
+    simp only [W, star_mul, star_star, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc
+      (hA.isHermitian.eigenvectorUnitary : Matrix n n ℂ)]
+    rw [Unitary.mul_star_self_of_mem
+      hA.isHermitian.eigenvectorUnitary.prop, Matrix.one_mul]
+    exact Unitary.coe_star_mul_self hB.isHermitian.eigenvectorUnitary
+  have hcol (j : n) : ∑ i, P i j = 1 :=
+    TNLean.Klein.col_sum_normSq_eq_one hWcol j
+  have htrace : (Matrix.trace B).re = ∑ i, ∑ j, β j * P i j := by
+    have htr : (Matrix.trace B).re = ∑ j, β j := by
+      rw [hB.isHermitian.trace_eq_sum_eigenvalues, Complex.re_sum]
+      exact Finset.sum_congr rfl fun j _ => Complex.ofReal_re _
+    rw [htr, Finset.sum_comm]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    conv_lhs => rw [← mul_one (β j), ← hcol j]
+    rw [Finset.mul_sum]
+  rw [supportRelativeEntropyLeftRightIntegrand,
+    supportSourceAQuadratic_spectral hA hB ht,
+    supportSourceBQuadratic_spectral hA hB ht]
+  unfold supportRelativeEntropySpectralIntegrand
+  change
+    ((∑ i, ∑ j,
+          if 0 < β j then
+            α i ^ 2 / (α i + t * β j) * P i j
+          else 0) -
+        (Matrix.trace B).re +
+        t * (∑ i, ∑ j,
+          if 0 < β j then
+            β j ^ 2 / (α i + t * β j) * P i j
+          else 0)) /
+      (1 + t) =
+        ∑ i, ∑ j,
+          if 0 < β j then
+            relativeEntropyScalar (α i) (β j) t * P i j
+          else 0
+  rw [htrace, ← Finset.sum_sub_distrib]
+  simp_rw [← Finset.sum_sub_distrib]
+  rw [Finset.mul_sum, ← Finset.sum_add_distrib, Finset.sum_div]
+  simp_rw [Finset.mul_sum, ← Finset.sum_add_distrib, Finset.sum_div]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  by_cases hβ : 0 < β j
+  · simp only [hβ, if_true, relativeEntropyScalar]
+    ring
+  · have hβzero : β j = 0 :=
+      le_antisymm (not_lt.mp hβ) (hB.eigenvalues_nonneg j)
+    simp [hβzero]
+
+/-- Under \(\ker B\subseteq\ker A\), the unprojected source-\(A\) left-right
+form may replace the projected source in the support-domain integrand. -/
+theorem rawSupportSourceAQuadratic_sub_trace_add_sourceB_eq_spectral
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    {t : ℝ} (ht : 0 < t) :
+    (rawSupportSourceAQuadratic hA hB t - (Matrix.trace B).re +
+        t * supportSourceBQuadratic hA hB t) / (1 + t) =
+      supportRelativeEntropySpectralIntegrand hA hB t := by
+  rw [← supportSourceAQuadratic_eq_raw_of_kernel_le hA hB hker t]
+  exact supportRelativeEntropyLeftRightIntegrand_eq_spectral hA hB ht
+
+/-- The support-domain spectral integrand is continuous for positive
+resolvent parameter. -/
+theorem supportRelativeEntropySpectralIntegrand_continuousOn
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    ContinuousOn (supportRelativeEntropySpectralIntegrand hA hB) (Ioi 0) := by
+  classical
+  unfold supportRelativeEntropySpectralIntegrand
+  apply continuousOn_finsetSum Finset.univ
+  intro i _
+  apply continuousOn_finsetSum Finset.univ
+  intro j _
+  by_cases hβ : 0 < hB.isHermitian.eigenvalues j
+  · simp only [hβ, if_true]
+    intro t ht
+    have ht0 : 0 < t := ht
+    have hden :
+        hA.isHermitian.eigenvalues i +
+            t * hB.isHermitian.eigenvalues j ≠ 0 := by
+      exact ne_of_gt (add_pos_of_nonneg_of_pos
+        (hA.eigenvalues_nonneg i) (mul_pos ht0 hβ))
+    have h1 : 1 + t ≠ 0 := ne_of_gt (by linarith)
+    apply ContinuousAt.continuousWithinAt
+    unfold relativeEntropyScalar
+    fun_prop
+  · simp only [hβ, if_false]
+    exact continuousOn_const
+
+/-- The support-domain left-right quadratic integrand is continuous on
+\((0,\infty)\). -/
+theorem supportRelativeEntropyLeftRightIntegrand_continuousOn
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    ContinuousOn (supportRelativeEntropyLeftRightIntegrand hA hB) (Ioi 0) := by
+  refine (supportRelativeEntropySpectralIntegrand_continuousOn hA hB).congr
+    (fun t ht => ?_)
+  exact supportRelativeEntropyLeftRightIntegrand_eq_spectral hA hB ht
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -2643,9 +2643,9 @@ Theorem~\ref{thm:trace_norm_abs}.
     406--413, and 423--427, respectively.  The support-domain extension is
     given at lines~717--720.
 
-    This theorem concerns the spectral expression $I_{A,B}$.  It does not
-    assert a coordinate-free support-resolvent formula or a finite-family
-    defect identity.
+    This theorem concerns the spectral expression $I_{A,B}$.  The next
+    theorem identifies it with the coordinate-free left-right quadratic form
+    underlying the finite Weyl formula.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -2663,9 +2663,111 @@ Theorem~\ref{thm:trace_norm_abs}.
     theorem identifies the last sum with $D(A\Vert B)$.
 \end{proof}
 
-% Open in #4435: identify the spectral expression above with the
-% coordinate-free support-resolvent quadratic form, then prove the
-% finite-family defect identity.  Neither statement is claimed here.
+\begin{theorem}[Support-domain left-right quadratic representation]
+    \label{thm:relative_entropy_support_left_right_quadratic}
+    \lean{Matrix.PosSemidef.supportInv}
+    \lean{Matrix.supportLeftRightSuperoperator}
+    \lean{Matrix.supportSourceAQuadratic}
+    \lean{Matrix.rawSupportSourceAQuadratic}
+    \lean{Matrix.supportSourceBQuadratic}
+    \lean{Matrix.supportRelativeEntropyLeftRightIntegrand}
+    \lean{Matrix.supportSourceAQuadratic_spectral}
+    \lean{Matrix.supportSourceBQuadratic_spectral}
+    \lean{Matrix.supportRelativeEntropyLeftRightIntegrand_eq_spectral}
+    \lean{Matrix.supportSourceAQuadratic_eq_raw_of_kernel_le}
+    \lean{Matrix.rawSupportSourceAQuadratic_sub_trace_add_sourceB_eq_spectral}
+    \lean{Matrix.supportRelativeEntropyLeftRightIntegrand_continuousOn}
+    \leanok
+    \uses{thm:relative_entropy_support_spectral_integral}
+    Let $A$ and $B$ be positive semidefinite matrices of the same size, let
+    $P_B$ be the orthogonal projection onto the support of $B$, and, for
+    $t>0$, set
+    \[
+        S_t=A\otimes\Id+t(\Id\otimes B^{\top}).
+    \]
+    Write $S_t^+$ for the generalized inverse that vanishes on $\ker S_t$.
+    Define
+    \[
+      Q_{A P_B}(t)
+        =\operatorname{Re}\left\langle
+            \operatorname{vec}((A P_B)^{\top}),
+            S_t^+\operatorname{vec}((A P_B)^{\top})
+          \right\rangle,
+      \qquad
+      Q_B(t)
+        =\operatorname{Re}\left\langle
+            \operatorname{vec}(B^{\top}),
+            S_t^+\operatorname{vec}(B^{\top})
+          \right\rangle.
+    \]
+    With the spectral notation of
+    Theorem~\ref{thm:relative_entropy_support_spectral_integral},
+    \[
+      Q_{A P_B}(t)
+        =\sum_{i,j:\,\beta_j>0}
+          \frac{\alpha_i^2}{\alpha_i+t\beta_j}|w_{ij}|^2,
+      \qquad
+      Q_B(t)
+        =\sum_{i,j:\,\beta_j>0}
+          \frac{\beta_j^2}{\alpha_i+t\beta_j}|w_{ij}|^2.
+    \]
+    Consequently,
+    \[
+      \frac{Q_{A P_B}(t)-\operatorname{Re}\operatorname{Tr}B+tQ_B(t)}{1+t}
+        =I_{A,B}(t).
+    \]
+    This function is continuous on $(0,\infty)$.  If
+    $\ker B\subseteq\ker A$, then $A P_B=A$, so $Q_{A P_B}(t)$ equals the
+    quadratic form with source $\operatorname{vec}(A^{\top})$.
+
+    This is the support-projected form of $(\mathrm{intAB})$ in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, \S2.1,
+    lines~423--427, with the support convention at lines~717--720.
+\end{theorem}
+
+\begin{proof}\leanok
+    Diagonalize $A$ and $B$ and write $W=U_A^\ast U_B$.  In these coordinates,
+    the two equations
+    \[
+      A X_A+tX_A B=A P_B,
+      \qquad
+      A X_B+tX_B B=B
+    \]
+    have entries
+    \[
+      (U_A^\ast X_AU_B)_{ij}
+        =
+        \begin{cases}
+          \dfrac{\alpha_i}{\alpha_i+t\beta_j}w_{ij},&\beta_j>0,\\
+          0,&\beta_j=0,
+        \end{cases}
+    \]
+    and
+    \[
+      (U_A^\ast X_BU_B)_{ij}
+        =
+        \begin{cases}
+          \dfrac{\beta_j}{\alpha_i+t\beta_j}w_{ij},&\beta_j>0,\\
+          0,&\beta_j=0.
+        \end{cases}
+    \]
+    For every positive semidefinite $S$, the identities
+    $S^+S=SS^+=P_S$ imply that $Sx=b$ gives
+    \[
+        \langle b,S^+b\rangle=\langle b,x\rangle.
+    \]
+    Applying this identity to the two displayed solutions gives the spectral
+    formulas.  Their coefficientwise combination is the scalar function
+    appearing in
+    Lemma~\ref{lem:relative_entropy_scalar_resolvent_integral}.  Continuity
+    follows term by term from the finite sums.
+\end{proof}
+
+% Open in #4435: the singular, support-domain passage from the finite-Weyl
+% equality above to the common-resolvent conclusion remains to be proved.
+% The positive-definite relative-modular theorem and the generic
+% support-residual identity and common-solution theorem below are already
+% established; this comment does not reopen them.
 
 \begin{theorem}[Spectral resolvent representation of relative entropy]
     \label{thm:relative_entropy_resolvent_integral}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -384,10 +384,20 @@ $(\mathrm{intAB})$ together with the support convention at lines 717--720.
 \footnote{Formal declarations:
 \leanid{Matrix.quantumRelativeEntropy_spectral} and
 \leanid{Matrix.supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy}
-in \path{TNLean/Analysis/RelativeEntropySupportIntegral.lean}.}
-It does not yet identify that finite spectral sum with a coordinate-free
-support-resolvent quadratic form, and it gives no finite-family defect
-identity.
+in \path{TNLean/Analysis/RelativeEntropySupportIntegral.lean}, and
+\leanid{Matrix.supportRelativeEntropyLeftRightIntegrand_eq_spectral} and
+\leanid{Matrix.rawSupportSourceAQuadratic_sub_trace_add_sourceB_eq_spectral}
+in
+\path{TNLean/Analysis/RelativeEntropySupportLeftRightQuadratic.lean}.}
+The finite spectral integrand is now identified pointwise with the
+support-projected left--right quadratic form: the source in its first
+quadratic term is $A P_B$.  Under the inclusion
+$\ker B\subseteq\ker A$, one has $A P_B=A$, so this term is the corresponding
+quadratic form with the unprojected source $A$.  The remaining gap is the
+bridge from this left--right expression to the shifted relative-modular
+resolvent containing the projected generalized inverse $B^+$, together with
+the singular finite-family passage from equality of the summed defects to a
+common relative-modular resolvent.
 Following the latter step, consider two positive semidefinite pairs $(A,B)$ and
 $(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
 $B$, and write
@@ -435,14 +445,14 @@ $\mathbf 1\otimes P_B^{\mathsf T}$, multiplication by
 $A\otimes\mathbf 1+t(\mathbf 1\otimes B^{\mathsf T})$ gives
 $\operatorname{vec}(B^{\mathsf T})$.  This uses only the generalized-inverse
 identity $(B^{-1/2}_{\mathrm{supp}})^2B=P_B$ and does not supply equality
-with the comparison resolver.  The new spectral integral theorem does not
-close this gap: one must first identify its integrand with the corresponding
-support-restricted quadratic form.  In the relative-modular formulation,
+with the comparison resolver.  The spectral integrand is now identified with
+the corresponding support-restricted left--right quadratic form.  What remains
+is its relation to the relative-modular formulation, where
 $B^+=(B^{-1/2}_{\mathrm{supp}})^2$ occurs inside
-$t\mathbf 1+A\otimes(B^+)^{\mathsf T}$; for $t>0$, the inverse of this
+$t\mathbf 1+A\otimes(B^+)^{\mathsf T}$ and, for $t>0$, the inverse of this
 shifted operator on $\mathbf 1\otimes P_B^{\mathsf T}$ is an ordinary inverse.
-After this identification, the finite-family support-domain defect identity
-and its zero-defect consequence remain to be proved in issue~\#4435.
+One must then pass from equality of the singular finite-family summed defects
+to equality of the corresponding common relative-modular resolvents.
 
 The kernel inclusion belongs to the preceding source theorem that must derive
 the support-restricted common resolvents from equality in data processing.  That

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -394,7 +394,7 @@ support-projected left--right quadratic form: the source in its first
 quadratic term is $A P_B$.  Under the inclusion
 $\ker B\subseteq\ker A$, one has $A P_B=A$, so this term is the corresponding
 quadratic form with the unprojected source $A$.  The remaining gap is the
-bridge from this left--right expression to the shifted relative-modular
+passage from this left--right expression to the shifted relative-modular
 resolvent containing the projected generalized inverse $B^+$, together with
 the singular finite-family passage from equality of the summed defects to a
 common relative-modular resolvent.


### PR DESCRIPTION
## Summary

This pull request identifies the support-domain left-right quadratic form underlying the finite spectral relative-entropy integrand. For positive-semidefinite matrices `A` and `B`, the first source is projected to `A P_B`; under `ker B ⊆ ker A`, this agrees with the unprojected source `A`.

It adds the support generalized inverse for positive-semidefinite matrices, proves its two support-projection identities, and records the pairing identity obtained from any solution of `Sx = b`. It then proves the two spectral quadratic expansions, their equality with the existing support relative-entropy integrand, and continuity on the positive half-line. The reusable kernel-to-right-support absorption lemma is placed with the support-projection theory. Chapter 19 is updated with the corresponding statement and source references to Jenčová–Ruskai `(intAB)` and the support-domain extension.

## Boundary

This pull request does not prove any of the following:

- the bridge to the shifted relative-modular resolvent involving `B⁺`;
- the singular finite-family equality-to-common-resolvent passage;
- Petz recovery or a Petz equality theorem.

The positive-definite relative-modular theorem and the generic support-residual identity and common-solution theorem already present in Chapter 19 are not reopened here.

Advances LionSR/QICLean#245

## Verification

- `lake env lean TNLean/Analysis/RelativeEntropySupportLeftRightQuadratic.lean`
- `lake build TNLean.Analysis`
- generated import-aggregator check
- blueprint declaration synchronization and `leanblueprint checkdecls`
- reader-facing prose and proof-integrity checks
- `leanblueprint web`
- `leanblueprint pdf`, followed by visual inspection of the affected pages

The blueprint PDF has only the pre-existing unresolved references to `thm:dim_preserved`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style analysis additions with no auth, I/O, or runtime behavior; risk is limited to proof correctness and import/blueprint sync in the Analysis layer.
> 
> **Overview**
> This PR **closes a formal gap** between the existing finite spectral relative-entropy integrand and a coordinate-free operator description: the support-projected left–right quadratic form built from the generalized inverse of \(A\otimes 1 + t(1\otimes B^{\mathsf T})\), with first source **\(A P_B\)**.
> 
> **New infrastructure:** `PosSemidef.supportInv` (support generalized inverse), support-projection identities, a pairing lemma from any solution of \(Sx=b\), and `mul_supportProj_eq_self_of_mulVec_kernel_le` for kernel absorption. **New file** `RelativeEntropySupportLeftRightQuadratic.lean` proves PSD of the left-right superoperator, spectral expansions of the two source quadratics, pointwise equality `supportRelativeEntropyLeftRightIntegrand_eq_spectral` for \(t>0\) (no \(\ker B\subseteq\ker A\) needed), a kernel-based unprojected variant, and continuity on \((0,\infty)\).
> 
> **Docs:** Chapter 19 blueprint theorem, paper-gaps text, and `RelativeEntropySupportIntegral` docstrings now record this identification; the bridge to shifted relative-modular resolvents with \(B^+\) and the singular finite-family passage remain explicitly open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1e42a2bc287ba0fd4352812ab69a4e51469a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->