### PR TITLE
feat(MPS/MPDO): add terminal spectral families

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -207,6 +207,7 @@ import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 import TNLean.MPS.MPDO.SourceBNTBlocking
 import TNLean.MPS.MPDO.SourceZCLMarginal
 import TNLean.MPS.MPDO.StackedLayers
+import TNLean.MPS.MPDO.TerminalSpectralFamily
 import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.TopologicalDensityDecomposition
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion

--- a/TNLean/MPS/MPDO/TerminalSpectralFamily.lean
+++ b/TNLean/MPS/MPDO/TerminalSpectralFamily.lean
@@ -1,0 +1,219 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.EigenvectorProjection
+import TNLean.MPS.MPDO.TopologicalDensityDecomposition
+
+/-!
+# Spectral families of terminal matrices
+
+The positive terminal matrices of a tensor-attached BNT fusion clause have
+rank-one spectral decompositions. This file indexes all eigenvectors across
+all BNT labels, including zero-eigenvalue modes, and extends each eigenvector
+projection by zero to the other labels.
+
+## Main statements
+
+* `MPOTensor.BNTFusionTensorClause.terminalEigenvalue_nonneg`: every terminal
+  eigenvalue is nonnegative.
+* `MPOTensor.BNTFusionTensorClause.terminalEigenvectorProjection_isOrthogonalProjection`:
+  the zero-extended family consists pointwise of orthogonal projections.
+* `MPOTensor.BNTFusionTensorClause.terminalEigenvectorProjection_mul_eq_zero_of_ne`:
+  distinct spectral indices give pointwise orthogonal projections.
+* `MPOTensor.BNTFusionTensorClause.sum_terminalEigenvectorProjection`: the
+  projections resolve the identity on every final bond space.
+* `MPOTensor.BNTFusionTensorClause.terminalMatrix_eq_sum`: the
+  eigenvalue-weighted family reconstructs every terminal matrix.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 1010--1012
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.BNTFusionTensorClause
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- The dependent type of a final BNT label together with one eigenvector
+index of its terminal matrix. Zero-eigenvalue modes are retained.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+abbrev TerminalSpectralIndex (H : BNTFusionTensorClause M) :=
+  (γ : Fin H.labelCount) × Fin (H.bondDim γ)
+
+/-- The terminal matrix obtained by closing the horizontal operator leg of a
+final BNT tensor and leaving its bond indices open.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+def terminalMatrix (H : BNTFusionTensorClause M) (γ : Fin H.labelCount) :
+    Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ :=
+  physTraceTransfer (verticalBNTMPO (H.tensor γ))
+
+/-- Every terminal matrix of an MPDO BNT fusion clause is positive
+semidefinite.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+theorem terminalMatrix_posSemidef
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M) (γ : Fin H.labelCount) :
+    (H.terminalMatrix γ).PosSemidef :=
+  H.physTraceTransfer_verticalBNTMPO_posSemidef hM γ
+
+/-- The eigenvalue attached to a terminal spectral index. The definition
+retains zero eigenvalues.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+noncomputable def terminalEigenvalue
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (s : H.TerminalSpectralIndex) : ℝ :=
+  (H.terminalMatrix_posSemidef hM s.1).isHermitian.eigenvalues s.2
+
+/-- Every terminal eigenvalue is nonnegative; zero modes remain members of
+the indexed family.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+theorem terminalEigenvalue_nonneg
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (s : H.TerminalSpectralIndex) :
+    0 ≤ H.terminalEigenvalue hM s :=
+  (H.terminalMatrix_posSemidef hM s.1).eigenvalues_nonneg s.2
+
+/-- The rank-one projection onto one eigenvector of a fixed terminal matrix.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+noncomputable def terminalEigenvectorProjectionAt
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (γ : Fin H.labelCount) (k : Fin (H.bondDim γ)) :
+    Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ :=
+  (H.terminalMatrix_posSemidef hM γ).isHermitian.eigenvectorProjection k
+
+/-- Every local terminal eigenvector projection is an orthogonal projection.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+theorem terminalEigenvectorProjectionAt_isOrthogonalProjection
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (γ : Fin H.labelCount) (k : Fin (H.bondDim γ)) :
+    IsOrthogonalProjection (H.terminalEigenvectorProjectionAt hM γ k) :=
+  (H.terminalMatrix_posSemidef hM γ).isHermitian
+    |>.isOrthogonalProjection_eigenvectorProjection k
+
+/-- A terminal eigenvector projection extended by zero to every different BNT
+label.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+noncomputable def terminalEigenvectorProjection
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (s : H.TerminalSpectralIndex) (γ : Fin H.labelCount) :
+    Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ :=
+  if h : s.1 = γ then
+    h ▸ H.terminalEigenvectorProjectionAt hM s.1 s.2
+  else
+    0
+
+/-- On its own BNT label, the zero-extended projection is the corresponding
+local eigenvector projection.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+@[simp]
+theorem terminalEigenvectorProjection_same
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (γ : Fin H.labelCount) (k : Fin (H.bondDim γ)) :
+    H.terminalEigenvectorProjection hM ⟨γ, k⟩ γ =
+      H.terminalEigenvectorProjectionAt hM γ k := by
+  simp [terminalEigenvectorProjection]
+
+/-- On a different BNT label, an extended terminal eigenvector projection
+vanishes.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+@[simp]
+theorem terminalEigenvectorProjection_of_ne
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (δ γ : Fin H.labelCount) (k : Fin (H.bondDim δ)) (hδγ : δ ≠ γ) :
+    H.terminalEigenvectorProjection hM ⟨δ, k⟩ γ = 0 := by
+  simp [terminalEigenvectorProjection, hδγ]
+
+/-- The zero-extended terminal spectral family consists pointwise of
+orthogonal projections.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+theorem terminalEigenvectorProjection_isOrthogonalProjection
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (s : H.TerminalSpectralIndex) (γ : Fin H.labelCount) :
+    IsOrthogonalProjection (H.terminalEigenvectorProjection hM s γ) := by
+  rcases s with ⟨δ, k⟩
+  by_cases hδγ : δ = γ
+  · subst γ
+    simpa using H.terminalEigenvectorProjectionAt_isOrthogonalProjection hM δ k
+  · simp [H.terminalEigenvectorProjection_of_ne hM δ γ k hδγ,
+      IsOrthogonalProjection]
+
+/-- Distinct terminal spectral indices give orthogonal projections at every
+BNT label.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+theorem terminalEigenvectorProjection_mul_eq_zero_of_ne
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (s t : H.TerminalSpectralIndex) (hst : s ≠ t)
+    (γ : Fin H.labelCount) :
+    H.terminalEigenvectorProjection hM s γ *
+        H.terminalEigenvectorProjection hM t γ = 0 := by
+  rcases s with ⟨δ, k⟩
+  rcases t with ⟨ε, l⟩
+  by_cases hδγ : δ = γ
+  · subst γ
+    by_cases hεδ : ε = δ
+    · subst ε
+      have hkl : k ≠ l := by
+        intro hkl
+        subst l
+        exact hst rfl
+      simpa [terminalEigenvectorProjectionAt] using
+        ((H.terminalMatrix_posSemidef hM δ).isHermitian
+          |>.eigenvectorProjection_mul_eq_zero_of_ne hkl)
+    · simp [H.terminalEigenvectorProjection_of_ne hM ε δ l hεδ]
+  · simp [H.terminalEigenvectorProjection_of_ne hM δ γ k hδγ]
+
+/-- The terminal eigenvector projections resolve the identity on every final
+bond space.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+theorem sum_terminalEigenvectorProjection
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (γ : Fin H.labelCount) :
+    ∑ s : H.TerminalSpectralIndex,
+        H.terminalEigenvectorProjection hM s γ = 1 := by
+  rw [Fintype.sum_sigma, Finset.sum_eq_single γ]
+  · simpa [terminalEigenvectorProjectionAt] using
+      (H.terminalMatrix_posSemidef hM γ).isHermitian.sum_eigenvectorProjection
+  · intro δ _ hδγ
+    simp [H.terminalEigenvectorProjection_of_ne hM δ γ _ hδγ]
+  · simp
+
+/-- The terminal matrix at each BNT label is the eigenvalue-weighted sum of
+the zero-extended eigenvector projections. Zero-eigenvalue modes remain in
+the sum and contribute zero.
+
+Source: arXiv:1606.00608, lines 1010--1012. -/
+theorem terminalMatrix_eq_sum
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (γ : Fin H.labelCount) :
+    H.terminalMatrix γ =
+      ∑ s : H.TerminalSpectralIndex,
+        H.terminalEigenvalue hM s •
+          H.terminalEigenvectorProjection hM s γ := by
+  rw [Fintype.sum_sigma, Finset.sum_eq_single γ]
+  · simpa [terminalEigenvalue, terminalEigenvectorProjectionAt] using
+      (H.terminalMatrix_posSemidef hM γ).isHermitian
+        |>.eq_sum_eigenvalues_smul_eigenvectorProjection
+  · intro δ _ hδγ
+    simp [H.terminalEigenvectorProjection_of_ne hM δ γ _ hδγ]
+  · simp
+
+end MPOTensor.BNTFusionTensorClause

--- a/TNLean/MPS/MPDO/TerminalSpectralFamily.lean
+++ b/TNLean/MPS/MPDO/TerminalSpectralFamily.lean
@@ -69,7 +69,7 @@ theorem terminalMatrix_posSemidef
 retains zero eigenvalues.
 
 Source: arXiv:1606.00608, lines 1010--1012. -/
-noncomputable def terminalEigenvalue
+def terminalEigenvalue
     (H : BNTFusionTensorClause M) (hM : IsMPDO M)
     (s : H.TerminalSpectralIndex) : ℝ :=
   (H.terminalMatrix_posSemidef hM s.1).isHermitian.eigenvalues s.2
@@ -87,7 +87,7 @@ theorem terminalEigenvalue_nonneg
 /-- The rank-one projection onto one eigenvector of a fixed terminal matrix.
 
 Source: arXiv:1606.00608, lines 1010--1012. -/
-noncomputable def terminalEigenvectorProjectionAt
+def terminalEigenvectorProjectionAt
     (H : BNTFusionTensorClause M) (hM : IsMPDO M)
     (γ : Fin H.labelCount) (k : Fin (H.bondDim γ)) :
     Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ :=
@@ -107,7 +107,7 @@ theorem terminalEigenvectorProjectionAt_isOrthogonalProjection
 label.
 
 Source: arXiv:1606.00608, lines 1010--1012. -/
-noncomputable def terminalEigenvectorProjection
+def terminalEigenvectorProjection
     (H : BNTFusionTensorClause M) (hM : IsMPDO M)
     (s : H.TerminalSpectralIndex) (γ : Fin H.labelCount) :
     Matrix (Fin (H.bondDim γ)) (Fin (H.bondDim γ)) ℂ :=

--- a/TNLean/MPS/MPDO/TerminalSpectralFamily.lean
+++ b/TNLean/MPS/MPDO/TerminalSpectralFamily.lean
@@ -14,6 +14,16 @@ rank-one spectral decompositions. This file indexes all eigenvectors across
 all BNT labels, including zero-eigenvalue modes, and extends each eigenvector
 projection by zero to the other labels.
 
+## Main definitions
+
+* `TerminalSpectralIndex`: the dependent type of a BNT label and a terminal
+  eigenvector index.
+* `terminalMatrix`: the terminal matrix at a fixed BNT label.
+* `terminalEigenvalue`: the eigenvalue attached to a terminal spectral index.
+* `terminalEigenvectorProjectionAt`: the local rank-one eigenvector projection.
+* `terminalEigenvectorProjection`: the projection extended by zero to the
+  other labels.
+
 ## Main statements
 
 * `MPOTensor.BNTFusionTensorClause.terminalEigenvalue_nonneg`: every terminal

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1666,6 +1666,74 @@ separate step.
     $T_\gamma\geq0$.
 \end{proof}
 
+\begin{theorem}[Spectral resolution of the terminal matrices]%
+    \label{thm:mpdo_terminal_spectral_family}
+    \lean{MPOTensor.BNTFusionTensorClause.terminalMatrix_eq_sum}
+    \lean{MPOTensor.BNTFusionTensorClause.sum_terminalEigenvectorProjection}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        terminalEigenvectorProjection_mul_eq_zero_of_ne}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        terminalEigenvectorProjection_isOrthogonalProjection}
+    \lean{MPOTensor.BNTFusionTensorClause.terminalEigenvalue_nonneg}
+    \lean{MPOTensor.BNTFusionTensorClause.terminalMatrix_posSemidef}
+    \lean{MPOTensor.BNTFusionTensorClause.TerminalSpectralIndex}
+    \lean{MPOTensor.BNTFusionTensorClause.terminalMatrix}
+    \lean{MPOTensor.BNTFusionTensorClause.terminalEigenvalue}
+    \lean{MPOTensor.BNTFusionTensorClause.terminalEigenvectorProjectionAt}
+    \lean{MPOTensor.BNTFusionTensorClause.terminalEigenvectorProjection}
+    \leanok
+    \uses{thm:mpdo_terminal_transfer_positivity,
+        thm:matrix_hermitian_rank_one_eigenvector_resolution}
+    Let $M$ be a matrix product density operator, and choose a BNT fusion
+    clause for $M$.  For each final label $\gamma$, let $D_\gamma$ be its
+    bond dimension and let
+    $T_\gamma=\operatorname{tr}(M_\gamma)$ be the terminal matrix.  Set
+    \[
+        {\cal S}=\bigsqcup_\delta\{(\delta,k):0\leq k<D_\delta\}.
+    \]
+    Choose a complete orthonormal eigenbasis
+    $(v_{\delta,k})_{k=0}^{D_\delta-1}$ of each $T_\delta$, with eigenvalues
+    $\lambda_{\delta,k}$, and retain the vectors whose eigenvalue is zero.
+    For $s=(\delta,k)\in{\cal S}$ define, at every final label $\gamma$,
+    \[
+        P_s^{(\gamma)}
+        =
+        \begin{cases}
+          \ketbra{v_{\delta,k}}{v_{\delta,k}},&\delta=\gamma,\\
+          0,&\delta\neq\gamma.
+        \end{cases}
+    \]
+    Then $\lambda_s\geq0$, every $P_s^{(\gamma)}$ is an orthogonal projection,
+    and for distinct $s,t\in{\cal S}$,
+    \[
+        P_s^{(\gamma)}P_t^{(\gamma)}=0.
+    \]
+    For every final label $\gamma$ these projections satisfy
+    \[
+        \sum_{s\in{\cal S}}P_s^{(\gamma)}=I_{D_\gamma},
+        \qquad
+        T_\gamma
+        =\sum_{s\in{\cal S}}\lambda_sP_s^{(\gamma)}.
+    \]
+    This pointwise statement assumes neither the renormalization fixed-point
+    condition nor length independence of the fusion coefficients.  It is the
+    pointwise terminal spectral resolution underlying
+    \cite[lines~1010--1012]{Cirac2016MPDO_arXiv}; no recursive transport or
+    Hamiltonian conclusion is asserted here.
+\end{theorem}
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_terminal_transfer_positivity,
+        thm:matrix_hermitian_rank_one_eigenvector_resolution}
+    Theorem~\ref{thm:mpdo_terminal_transfer_positivity} gives
+    $T_\delta\geq0$, so its eigenvalues are nonnegative.  Apply the
+    rank-one eigenvector resolution to every $T_\delta$.  Projections from
+    distinct eigenbasis vectors are orthogonal, and their sum is the
+    identity.  Extending each projection by zero makes every sum at a fixed
+    label $\gamma$ reduce to the summand $\delta=\gamma$, which gives both
+    displayed identities.
+\end{proof}
+
 \begin{definition}[All-label recursive density operator]%
     \label{def:mpdo_topological_density_operator}
     \lean{MPOTensor.BNTFusionTensorClause.verticalMultiplicityChainWeight}

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -142,7 +142,7 @@ rank-one eigenvector projection by zero to every different final label:
   P_s^{(\gamma)}
     =
     \begin{cases}
-      \lvert v_{\delta,k}\rangle\langle v_{\delta,k}\rvert,
+      \ketbra{v_{\delta,k}}{v_{\delta,k}},
         & \delta=\gamma,\\
       0,&\delta\neq\gamma.
     \end{cases}

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -120,11 +120,55 @@ $q$ of its positive multiplicity matrix gives the principal block
   (\mu_\gamma)_{q,q}\operatorname{tr}(M_\gamma)\geq0.
 \end{equation}
 Since $(\mu_\gamma)_{q,q}>0$, division by this scalar proves
-\eqref{eq:formalized-terminal-positivity}.  This is formalized by
-\leanid{MPOTensor.BNTFusionTensorClause.physTraceTransfer_verticalBNTMPO_posSemidef}.
+\eqref{eq:formalized-terminal-positivity}.  In the namespace
+\leanid{MPOTensor.BNTFusionTensorClause}, this is formalized by
+\leanid{physTraceTransfer_verticalBNTMPO_posSemidef}.
 It supplies the positivity needed for the spectral decomposition invoked at
 lines~1010--1016, but does not assert that the terminal matrices are
 projections.
+
+\paragraph{Pointwise terminal spectral refinement.}
+Fix a matrix product density operator $M$ and one tensor-attached BNT fusion
+clause for $M$.  If $D_\gamma$ is the bond dimension of the final label
+$\gamma$, the terminal spectral index is
+\begin{equation}
+  \mathcal S
+    =\bigsqcup_\delta\{(\delta,k):0\leq k<D_\delta\}.
+\end{equation}
+For $s=(\delta,k)$, let $\lambda_s$ be the $k$-th eigenvalue of
+$\operatorname{tr}(M_\delta)$, including the zero eigenvalues, and extend its
+rank-one eigenvector projection by zero to every different final label:
+\begin{equation}
+  P_s^{(\gamma)}
+    =
+    \begin{cases}
+      \lvert v_{\delta,k}\rangle\langle v_{\delta,k}\rvert,
+        & \delta=\gamma,\\
+      0,&\delta\neq\gamma.
+    \end{cases}
+\end{equation}
+The pointwise terminal spectral refinement is now formalized:
+\begin{equation}
+  \begin{gathered}
+    \lambda_s\geq0,
+    \qquad
+    P_s^{(\gamma)}P_t^{(\gamma)}=0\quad(s\neq t),
+    \qquad
+    \sum_{s\in\mathcal S}P_s^{(\gamma)}=I_{D_\gamma},\\
+    \operatorname{tr}(M_\gamma)
+      =\sum_{s\in\mathcal S}\lambda_sP_s^{(\gamma)}.
+  \end{gathered}
+  \label{eq:formalized-terminal-spectral-family}
+\end{equation}
+Every $P_s^{(\gamma)}$ is an orthogonal projection.  In the namespace
+\leanid{MPOTensor.BNTFusionTensorClause}, these facts are formalized by
+\leanid{terminalEigenvalue_nonneg},
+\leanid{terminalEigenvectorProjection_isOrthogonalProjection},
+\leanid{terminalEigenvectorProjection_mul_eq_zero_of_ne},
+\leanid{sum_terminalEigenvectorProjection}, and
+\leanid{terminalMatrix_eq_sum}.
+The statement assumes neither that $M$ is a renormalization fixed point nor
+that the fusion coefficients are independent of the positive chain length.
 
 The pairwise construction has now been iterated along an arbitrary finite
 chain with a fixed initial label.  For total chain length $N\geq1$, the
@@ -200,12 +244,12 @@ $\mu^{\otimes N}$.  Hence
 line~999 with the source chain length~$N$ and no additional
 compatibility hypothesis.
 
-The assembled operator is
-\leanid{MPOTensor.BNTFusionTensorClause.topologicalDensityOperatorSucc}.  Its
-argument is one less than the positive source chain length.  The
-source-facing existence theorem is
-\leanid{MPOTensor.exists_topologicalDensityDecomposition_of_isRFPViaTS}; it
-chooses one vertical decomposition and proves both equalities in
+In the namespace \leanid{MPOTensor.BNTFusionTensorClause}, the assembled
+operator is \leanid{topologicalDensityOperatorSucc}.  Its argument is one less
+than the positive source chain length.  In the namespace \leanid{MPOTensor},
+the source-facing existence theorem is
+\leanid{exists_topologicalDensityDecomposition_of_isRFPViaTS}; it chooses one
+vertical decomposition and proves both equalities in
 \eqref{eq:formalized-all-label-density} for every positive~$N$.
 
 \section{The all-label commutator}
@@ -226,12 +270,10 @@ identity.  Hence direct-sum multiplication gives
 \end{equation}
 This proves \eqref{eq:source-commutator} for every positive chain length,
 without length independence or a caller-supplied compatibility condition.
-The two factors are
-\leanid{MPOTensor.BNTFusionTensorClause.topologicalMultiplicityWeightFactorSucc}
-and
-\leanid{MPOTensor.BNTFusionTensorClause.topologicalRecursiveFactorSucc}.
-The source-facing theorem
-\leanid{MPOTensor.exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS}
+In the namespace \leanid{MPOTensor.BNTFusionTensorClause}, the two factors are
+\leanid{topologicalMultiplicityWeightFactorSucc} and
+\leanid{topologicalRecursiveFactorSucc}.  The source-facing theorem
+\path{MPOTensor.exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS}
 chooses the same fusion clause for
 \eqref{eq:formalized-all-label-density} and
 \eqref{eq:formalized-density-commutator}.
@@ -240,18 +282,20 @@ chooses the same fusion clause for
 
 The all-label density identity
 \eqref{eq:source-chain-decomposition} and its commutator
-\eqref{eq:source-commutator} are now formalized.  A faithful proof of the
-remainder still requires:
+\eqref{eq:source-commutator}, together with the pointwise terminal spectral
+refinement \eqref{eq:formalized-terminal-spectral-family}, are now formalized.
+A faithful proof of the remainder still requires:
 \begin{enumerate}
-  \item the spectral refinement of the positive terminal matrices into
-    orthogonal projections and its compatibility with the recursive sectors;
+  \item compatibility of the terminal spectral indices with the recursive
+    sectors, and transport of the resulting projection family through the
+    fixed-label recursion and the all-label density decomposition;
   \item the construction of the commuting nearest-neighbor Hamiltonian and
     the projections in \eqref{eq:source-gibbs-decomposition}.
 \end{enumerate}
-The positivity statement
-\eqref{eq:formalized-terminal-positivity} and the formalized commutator must
-not be cited as the terminal spectral refinement or the commuting Gibbs
-theorem of lines~1003--1016 until these remaining steps are proved.
+Equation \eqref{eq:formalized-terminal-spectral-family} may be cited as the
+pointwise terminal spectral refinement.  It must not be cited as the recursive
+projection transport or the commuting Hamiltonian and Gibbs theorem of
+lines~1003--1016 until these remaining steps are proved.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This pull request adds the pointwise terminal spectral family associated with an MPDO tensor and a chosen tensor-attached BNT fusion clause. For every final BNT label, it defines the positive terminal matrix, indexes a complete eigenbasis across all labels, extends each rank-one eigenvector projection by zero to the other labels, and proves pointwise orthogonality, resolution of the identity, and eigenvalue-weighted reconstruction of the terminal matrix.

The spectral index retains every zero-eigenvalue mode. Thus the family resolves the full final bond space rather than only the support of the terminal matrix.

This is exactly a pointwise statement at each final label. It assumes neither the renormalization fixed-point condition nor length independence of the fusion coefficients.

## Changed paths

- `TNLean/MPS/MPDO/TerminalSpectralFamily.lean`
- `TNLean/MPS/MPDO.lean`
- `blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex`
- `docs/paper-gaps/cpsv16_topological_projector_recursion.tex`

The blueprint and paper-gap note identify this as the pointwise terminal spectral resolution underlying CPSV16, lines 1010–1012.

## Explicit exclusions

This pull request does not prove:

- compatibility of the spectral indices with recursively fused sectors;
- transport of the projection family through the fixed-label recursion or the all-label density decomposition;
- compatibility arising from length independence of the fusion coefficients;
- the commuting nearest-neighbor Hamiltonian or Gibbs-projection conclusions.

These steps remain recorded in the paper-gap note.

## Validation

- `lake env lean TNLean/MPS/MPDO/TerminalSpectralFamily.lean`
- `lake build TNLean.MPS.MPDO.TerminalSpectralFamily`
- `lake env lean TNLean/MPS/MPDO.lean`
- `lake build TNLean` (9,735 jobs)
- generated-import aggregation check
- blueprint synchronization, `checkdecls`, and changed-declaration coverage checks
- reader-facing prose, forbidden-token, proof-integrity, line-length, style, and tactic-pattern checks
- `git diff --check`
- standalone paper-gap PDF build and visual inspection
- full blueprint PDF build and visual inspection of the revised theorem and adjacent pages

The full blueprint build retains four pre-existing unresolved references to `thm:dim_preserved`, unrelated to this change.

Advances #4676

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-style proofs building on existing terminal positivity; documentation and aggregator wiring only, with no changes to auth, runtime, or critical infrastructure.
> 
> **Overview**
> This PR introduces **`TerminalSpectralFamily.lean`**, formalizing the **pointwise terminal spectral family** for an MPDO and a tensor-attached BNT fusion clause: `TerminalSpectralIndex`, terminal matrices/eigenvalues, local and label-extended eigenvector projections, and proofs of nonnegativity, orthogonality, identity resolution, and eigenvalue-weighted reconstruction—**including zero-eigenvalue modes**, without assuming RFP or length-independent fusion coefficients.
> 
> The MPDO aggregator import is updated, and the **blueprint** gains theorem `thm:mpdo_terminal_spectral_family` linked to the new Lean names. The **paper-gap note** documents equation `\eqref{eq:formalized-terminal-spectral-family}`, tightens Lean cross-references, and reframes remaining work as spectral compatibility/transport and the Gibbs/Hamiltonian step—not redoing terminal positivity alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 694fe531475840a422e9f092a211baa1422560f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->