### PR TITLE
feat(Algebra): extract PSD finite-sum kernel lemma

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -47,7 +47,10 @@ Extracted from various files for reusability.
   vanishes only if every summand vanishes
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
   variant
-- `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
+- `Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero`: kernel containment for
+  finite sums of positive-semidefinite matrices
+- `Matrix.PosSemidef.mulVec_eq_zero_left/right`: binary specializations of kernel
+  containment for positive-semidefinite sums
 - `Matrix.PosSemidef.eq_nonneg_smul_vecMulVec_of_le_smul_vecMulVec`: a positive
   semidefinite matrix below a rank-one matrix belongs to the same nonnegative ray
 - `Matrix.faithfulDensity`: the faithful uniform density matrix on a nonempty
@@ -715,16 +718,43 @@ section KernelPSD
 
 open Matrix
 
-variable {D : ℕ}
+variable {n : Type*} [Fintype n]
 
 namespace Matrix.PosSemidef
+
+/-- If a finite sum of positive-semidefinite matrices annihilates a vector,
+then every summand in the finite set annihilates that vector. -/
+theorem mulVec_eq_zero_of_sum_mulVec_eq_zero_of_mem
+    {ι : Type*} {s : Finset ι} {B : ι → Matrix n n ℂ}
+    (hB : ∀ i ∈ s, (B i).PosSemidef)
+    {v : n → ℂ} (hv : (∑ i ∈ s, B i) *ᵥ v = 0)
+    {k : ι} (hk : k ∈ s) :
+    B k *ᵥ v = 0 := by
+  have hqk : star v ⬝ᵥ (B k *ᵥ v) = 0 := by
+    have hsum : ∑ i ∈ s, star v ⬝ᵥ (B i *ᵥ v) = 0 := by
+      have h := congrArg (fun w ↦ star v ⬝ᵥ w) hv
+      simpa only [sum_mulVec, dotProduct_sum, dotProduct_zero] using h
+    exact (Finset.sum_eq_zero_iff_of_nonneg
+      (fun i hi ↦ (hB i hi).dotProduct_mulVec_nonneg v)).mp hsum k hk
+  exact ((hB k hk).dotProduct_mulVec_zero_iff v).mp hqk
+
+/-- If a finite sum of positive-semidefinite matrices annihilates a vector,
+then every matrix in the family annihilates that vector. -/
+theorem mulVec_eq_zero_of_sum_mulVec_eq_zero
+    {ι : Type*} [Fintype ι] {B : ι → Matrix n n ℂ}
+    (hB : ∀ i, (B i).PosSemidef)
+    {v : n → ℂ} (hv : (∑ i, B i) *ᵥ v = 0)
+    (i : ι) :
+    B i *ᵥ v = 0 :=
+  mulVec_eq_zero_of_sum_mulVec_eq_zero_of_mem
+    (s := Finset.univ) (fun j _ ↦ hB j) hv (Finset.mem_univ i)
 
 /-- For PSD matrices `A` and `B`, `ker(A + B) ⊆ ker(A)`.
 Proof: `v†(A+B)v = v†Av + v†Bv = 0` with both nonneg implies `v†Av = 0`. -/
 theorem mulVec_eq_zero_left
-    {A B : Matrix (Fin D) (Fin D) ℂ}
+    {A B : Matrix n n ℂ}
     (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (v : Fin D → ℂ) (hv : (A + B) *ᵥ v = 0) :
+    (v : n → ℂ) (hv : (A + B) *ᵥ v = 0) :
     A *ᵥ v = 0 := by
   have hqf : star v ⬝ᵥ ((A + B) *ᵥ v) = 0 := by rw [hv]; simp
   rw [add_mulVec, dotProduct_add] at hqf
@@ -740,11 +770,13 @@ theorem mulVec_eq_zero_left
 
 /-- For PSD matrices `A` and `B`, `ker(A + B) ⊆ ker(B)`. -/
 theorem mulVec_eq_zero_right
-    {A B : Matrix (Fin D) (Fin D) ℂ}
+    {A B : Matrix n n ℂ}
     (hA : A.PosSemidef) (hB : B.PosSemidef)
-    (v : Fin D → ℂ) (hv : (A + B) *ᵥ v = 0) :
+    (v : n → ℂ) (hv : (A + B) *ᵥ v = 0) :
     B *ᵥ v = 0 := by
   exact mulVec_eq_zero_left hB hA v (by simpa [add_comm] using hv)
+
+variable {D : ℕ}
 
 /-- A positive semidefinite matrix dominated by a scalar multiple of the rank-one matrix
 $\psi\psi^*$ is itself a nonnegative scalar multiple of $\psi\psi^*$. -/

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -47,8 +47,10 @@ Extracted from various files for reusability.
   vanishes only if every summand vanishes
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
   variant
-- `Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero`: kernel containment for
-  finite sums of positive-semidefinite matrices
+- `Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero_of_mem`: kernel containment
+  for finite sums over a finite set
+- `Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero`: the finite-family
+  specialization
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: binary specializations of kernel
   containment for positive-semidefinite sums
 - `Matrix.PosSemidef.eq_nonneg_smul_vecMulVec_of_le_smul_vecMulVec`: a positive

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -756,17 +756,11 @@ theorem mulVec_eq_zero_left
     (hA : A.PosSemidef) (hB : B.PosSemidef)
     (v : n → ℂ) (hv : (A + B) *ᵥ v = 0) :
     A *ᵥ v = 0 := by
-  have hqf : star v ⬝ᵥ ((A + B) *ᵥ v) = 0 := by rw [hv]; simp
-  rw [add_mulVec, dotProduct_add] at hqf
-  have h1_re := hA.re_dotProduct_nonneg v
-  have h2_re := hB.re_dotProduct_nonneg v
-  have h3_re : (star v ⬝ᵥ (A *ᵥ v)).re + (star v ⬝ᵥ (B *ᵥ v)).re = 0 := by
-    have := congr_arg Complex.re hqf; simpa using this
-  change 0 ≤ (star v ⬝ᵥ (A *ᵥ v)).re at h1_re
-  change 0 ≤ (star v ⬝ᵥ (B *ᵥ v)).re at h2_re
-  have hre : (star v ⬝ᵥ (A *ᵥ v)).re = 0 := by linarith
-  exact (hA.dotProduct_mulVec_zero_iff v).mp
-    (Complex.ext hre (hA.isHermitian.im_star_dotProduct_mulVec_self v))
+  let C : Fin 2 → Matrix n n ℂ := fun i ↦ if i = 0 then A else B
+  apply mulVec_eq_zero_of_sum_mulVec_eq_zero (B := C) ?_ ?_ 0
+  · intro i
+    fin_cases i <;> simp [C, hA, hB]
+  · simpa [C] using hv
 
 /-- For PSD matrices `A` and `B`, `ker(A + B) ⊆ ker(B)`. -/
 theorem mulVec_eq_zero_right

--- a/TNLean/Channel/Irreducible/Growth/Exponential.lean
+++ b/TNLean/Channel/Irreducible/Growth/Exponential.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.MatrixAux
 import TNLean.Channel.Irreducible.Growth.KernelDescent
 import TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression
 import Mathlib.Analysis.Normed.Algebra.Exponential

--- a/TNLean/Channel/Irreducible/Growth/Exponential.lean
+++ b/TNLean/Channel/Irreducible/Growth/Exponential.lean
@@ -163,22 +163,6 @@ private theorem posSemidef_mulVec_eq_zero_of_not_dot_pos
     exact Complex.ext h_re_zero him_zero
   exact (hM.dotProduct_mulVec_zero_iff v).mp hq_zero
 
--- A vanishing PSD sum forces each summand to vanish.
-private theorem posSemidef_sum_mulVec_eq_zero_of_mem
-    {ι : Type*} {s : Finset ι}
-    {term : ι → Matrix (Fin D) (Fin D) ℂ}
-    (hterm : ∀ i ∈ s, (term i).PosSemidef)
-    {v : Fin D → ℂ} (hv : (∑ i ∈ s, term i) *ᵥ v = 0)
-    {k : ι} (hk : k ∈ s) :
-    (term k) *ᵥ v = 0 := by
-  have hqterm_zero : star v ⬝ᵥ ((term k) *ᵥ v) = 0 := by
-    have hsum_q_zero : ∑ i ∈ s, star v ⬝ᵥ ((term i) *ᵥ v) = 0 := by
-      have := congrArg (fun w => star v ⬝ᵥ w) hv
-      simpa only [sum_mulVec, dotProduct_sum, dotProduct_zero] using this
-    exact (Finset.sum_eq_zero_iff_of_nonneg
-        (fun i hi => (hterm i hi).dotProduct_mulVec_nonneg v)).mp hsum_q_zero k hk
-  exact ((hterm k hk).dotProduct_mulVec_zero_iff v).mp hqterm_zero
-
 -- Evaluates the operator exponential series at a matrix.
 private theorem exp_apply_terms_summable
     (Φ : TNLean.MatrixCLM (Fin D)) (A : Matrix (Fin D) (Fin D) ℂ) :
@@ -264,8 +248,8 @@ theorem exp_truncation_posDef_of_irreducible_cp
   have hterm_zero_F : ∀ k ∈ Finset.range D, ((F ^ k) A) *ᵥ v = 0 := by
     intro k hk
     have hterm_zero : (term k) *ᵥ v = 0 :=
-      posSemidef_sum_mulVec_eq_zero_of_mem
-        (s := Finset.range D) (term := term) (fun i _hi => hterm_psd i) hsum_zero hk
+      Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero_of_mem
+        (s := Finset.range D) (B := term) (fun i _hi => hterm_psd i) hsum_zero hk
     change (((k.factorial : ℂ)⁻¹) • ((F ^ k) A)) *ᵥ v = 0 at hterm_zero
     rw [Matrix.smul_mulVec] at hterm_zero
     exact (smul_eq_zero.mp hterm_zero).resolve_left


### PR DESCRIPTION
Advances LionSR/QICLean#245

## Summary

- add a finite-set kernel lemma for positive-semidefinite matrix sums on an arbitrary finite coordinate type;
- derive the finite-family form indexed by a `Fintype`;
- generalize the existing binary `PosSemidef.mulVec_eq_zero_left/right` statements from `Fin D` to arbitrary finite index types without changing their names or argument order;
- replace the private copy in `Channel/Irreducible/Growth/Exponential.lean` with the public algebra lemma.

## Motivation

The forthcoming support-resolvent family argument needs the elementary inclusion
\[
  \ker\!\left(\sum_i B_i\right)\subseteq\ker B_i
\]
for an arbitrary finite family of positive-semidefinite matrices. The proof is independent of relative entropy: pairing the vanishing sum with the vector gives a finite sum of nonnegative quadratic forms, so each form vanishes and hence each matrix annihilates the vector.

This extracts the argument from its existing private use into the lowest appropriate algebra module, where it can be reused by the singular support-resolvent proof.

This PR contains no relative-entropy theorem, Petz-recovery theorem, or blueprint claim.

## Validation

- `lake env lean TNLean/Algebra/MatrixAux.lean`
- `lake build TNLean.Algebra.MatrixAux`
- `lake env lean TNLean/Channel/Irreducible/Growth/Exponential.lean`
- `lake build TNLean.Algebra.PosSemidefSupport TNLean.Channel.Irreducible.Growth.KernelDescent TNLean.Channel.Irreducible.Growth.Exponential`
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`
- proof-integrity scan of the changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure algebra refactor and lemma extraction with no behavioral API break for existing `Fin D` call sites; risk is limited to proof/index-generalization correctness.
> 
> **Overview**
> Adds reusable **PSD kernel containment** for finite sums in `MatrixAux`: if \(\sum_i B_i\) annihilates a vector and each \(B_i\) is positive semidefinite, then each summand (on a `Finset` or over a `Fintype`) annihilates that vector.
> 
> **`mulVec_eq_zero_left` / `mulVec_eq_zero_right`** are generalized from `Matrix (Fin D)` to arbitrary finite index types `n` and are proved via the new finite-sum lemmas instead of inline quadratic-form arguments. Downstream rank-one code still uses `Fin D` where needed via a scoped `variable {D : ℕ}`.
> 
> **`Exponential.lean`** drops its private duplicate, imports `TNLean.Algebra.MatrixAux`, and calls `Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero_of_mem` in the exponential truncation proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419ceebbcbe7f3019df1cfa3135c214b1d8d1c9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->