### PR TITLE
fix(tenkz): repair RMP author-source pairings and extraction (L0b)

### DIFF
--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -69,7 +69,13 @@ TARGET_REQUIRED = {
     "paper_context_only",
     "placements",
 }
-TARGET_OPTIONAL = {"fixture", "author_source", "author_lines", "equivalent_to"}
+TARGET_OPTIONAL = {
+    "fixture",
+    "author_source",
+    "author_lines",
+    "equivalent_to",
+    "extraction_override",
+}
 FORBIDDEN_CASE_PATTERNS = (
     (re.compile(r"\\documentclass\b|\\usepackage\b|\\begin\{document\}"),
      "case must be a preamble-free fragment"),
@@ -149,6 +155,7 @@ class Target:
     author_source: Path | None
     author_lines: str | None
     equivalent_to: str | None
+    extraction_override: str | None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -354,6 +361,13 @@ def load_manifest(path: Path) -> list[Target]:
             )
             if equivalent_to == target_id:
                 fail(f"{where}.equivalent_to cannot name the target itself")
+        extraction_override = None
+        if "extraction_override" in raw:
+            extraction_override = nonempty_string(
+                raw["extraction_override"], field=f"{where}.extraction_override"
+            )
+            if author_lines is None:
+                fail(f"{where}.extraction_override requires author_lines")
         targets.append(
             Target(
                 id=target_id,
@@ -372,12 +386,14 @@ def load_manifest(path: Path) -> list[Target]:
                 author_source=author_source,
                 author_lines=author_lines,
                 equivalent_to=equivalent_to,
+                extraction_override=extraction_override,
             )
         )
     validate_census(targets)
     for target in targets:
         validate_case(target)
     validate_distinct_case_bodies(targets)
+    validate_author_ranges(targets)
     return targets
 
 
@@ -1281,7 +1297,57 @@ def transactional_render(
 
 def line_range(text: str) -> tuple[int, int]:
     start, separator, end = text.partition("-")
-    return int(start), int(end if separator else start)
+    first, last = int(start), int(end if separator else start)
+    if first < 1 or last < first:
+        fail(f"author line range {text!r} is not an ascending 1-based range")
+    return first, last
+
+
+def validate_author_ranges(targets: Sequence[Target]) -> None:
+    """Author line ranges within one corpus must not collide.
+
+    The workbench archives the published targets' blocks and sub-blocks, so
+    cross-corpus sharing is by design.  Within one corpus, a partial overlap
+    means a block boundary is wrong on at least one side -- the mechanism
+    behind every superimposed author panel found in review -- and an
+    identical range is legal only when every owner records
+    extraction_override: a shared composite block is a decision, never an
+    accident.
+    """
+    by_key: dict[tuple[str, Path], list[Target]] = {}
+    for target in targets:
+        if target.author_source is not None and target.author_lines is not None:
+            by_key.setdefault((target.corpus, target.author_source), []).append(target)
+    problems: list[str] = []
+    for (corpus, source), owners in sorted(by_key.items()):
+        spans = sorted(
+            (line_range(target.author_lines), target.id, target) for target in owners
+        )
+        for ((a_start, a_end), _, first), ((b_start, b_end), _, second) in zip(
+            spans, spans[1:]
+        ):
+            if b_start > a_end:
+                continue
+            if (a_start, a_end) == (b_start, b_end):
+                undeclared = [
+                    target.id
+                    for target in (first, second)
+                    if target.extraction_override is None
+                ]
+                if undeclared:
+                    problems.append(
+                        f"{corpus} {source.as_posix()}: {first.id} and "
+                        f"{second.id} share lines {a_start}-{a_end} without "
+                        "extraction_override on " + ", ".join(undeclared)
+                    )
+            else:
+                problems.append(
+                    f"{corpus} {source.as_posix()}: {first.id} "
+                    f"({a_start}-{a_end}) and {second.id} ({b_start}-{b_end}) "
+                    "overlap"
+                )
+    if problems:
+        fail("author line ranges collide:\n" + "\n".join(problems))
 
 
 def extract_author_block(target: Target, source_root: Path, destination: Path) -> None:

--- a/tests/tenkz/rmp/manifest.toml
+++ b/tests/tenkz/rmp/manifest.toml
@@ -51,12 +51,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-mps-marginal.tex"
 formula = "marginals rho_kept = Tr_traced |psi><psi|."
 ink = "Canonical public tenkz environment; no raw TikZ."
 boundary = "The state has five open physical legs; the marginal traces the last two ket-bra pairs."
-source = "paper TN-Review-main.tex line 327; author source ImagesReview Section II/ImagesReview Section II.tex lines 269-304"
+source = "paper TN-Review-main.tex line 327; author source ImagesReview Section II/ImagesReview Section II.tex lines 269-286"
 capabilities = ["grid", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/rmpfig2_test.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "269-304"
+author_lines = "269-286"
 placements = [{ order = 3, line = 327, asset = "fig2_fig2-pepe_sec2fig4aMPS.pdf" }]
 
 [[target]]
@@ -68,12 +68,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-marginal.tex"
 formula = "marginals rho_kept = Tr_traced |psi><psi|."
 ink = "Canonical public tenkzlattice, tenkzplanes environments; no raw TikZ."
 boundary = "The state sheet is open; the doubled sheet traces the declared complement."
-source = "paper TN-Review-main.tex line 331; author source ImagesReview Section II/ImagesReview Section II.tex lines 269-304"
+source = "paper TN-Review-main.tex line 331; author source ImagesReview Section II/ImagesReview Section II.tex lines 287-304"
 capabilities = ["lattice", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/rmpfig2_test.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "269-304"
+author_lines = "287-304"
 placements = [{ order = 4, line = 331, asset = "fig2_fig2-pepe_secfig4bPEPS.pdf" }]
 
 [[target]]
@@ -91,6 +91,7 @@ paper_context_only = false
 fixture = "tests/tenkz/t2_mpo.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "305-316"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 5, line = 361, asset = "fig2_fig2-pepe_sec2fig5MPO.pdf" }]
 
 [[target]]
@@ -108,6 +109,7 @@ paper_context_only = false
 fixture = "tests/tenkz/t2_pepo5.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "305-316"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 6, line = 363, asset = "fig2_fig2-pepe_sec2fig5PEPO.pdf" }]
 
 [[target]]
@@ -261,6 +263,7 @@ paper_context_only = false
 fixture = "tests/tenkz/hard03_v3.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "484-499"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 15, line = 421, asset = "fig2_fig2-pepe_sec2fig8.pdf" }]
 
 [[target]]
@@ -278,6 +281,7 @@ paper_context_only = false
 fixture = "tests/tenkz/hard04_v3.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "484-499"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 16, line = 425, asset = "fig2_fig2-pepe_fig9-1.pdf" }]
 
 [[target]]
@@ -457,12 +461,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-tangent-projector.tex"
 formula = "P_T(A) = sum_i P_L^(i-1) tensor I_i tensor P_R^(i+1) - sum_i P_L^i tensor P_R^(i+1)."
 ink = "Canonical public tenkz and tenkzfree environments; no raw TikZ."
 boundary = "Each block closes only at its internal cup; the identity wire and all displayed outer and physical endpoints stay open."
-source = "paper TN-Review-main.tex line 667; author source ImagesReview Section II/ImagesReview Section II.tex lines 572-589"
+source = "paper TN-Review-main.tex line 667; author source ImagesReview Section II/ImagesReview Section II.tex lines 208-236"
 capabilities = ["grid", "free-graph", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/hard10_v3.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "572-589"
+author_lines = "208-236"
 placements = [{ order = 27, line = 667, asset = "fig2_fig2-pepe_PTA.pdf" }]
 
 [[target]]
@@ -474,12 +478,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-lasso.tex"
 formula = "A^I = U^A_I sigma^A and B^Ibar = sigma^B U^B_Ibar."
 ink = "Canonical public tenkz environment; no raw TikZ."
 boundary = "The A lasso seals its west side; the B lasso seals its east side; physical legs stay open."
-source = "paper TN-Review-main.tex line 804; author source ImagesReview Section II/ImagesReview Section II.tex lines 597-617"
+source = "paper TN-Review-main.tex line 804; author source ImagesReview Section II/ImagesReview Section II.tex lines 618-649"
 capabilities = ["grid", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_lassodef.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "597-617"
+author_lines = "618-649"
 placements = [{ order = 28, line = 804, asset = "fig2_fig2-pepe_Figboundary-theorya-1.pdf" }]
 
 [[target]]
@@ -491,12 +495,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-region.tex"
 formula = "|psi> = sum_{I,Ibar} A^I_{partial R} B^Ibar_{partial R}."
 ink = "Canonical public tenkzlattice, tenkz environments; no raw TikZ."
 boundary = "The sheet exterior is open; the reduced pair seals outer virtual sides at partial R."
-source = "paper TN-Review-main.tex line 806; author source ImagesReview Section II/ImagesReview Section II.tex lines 650-684"
+source = "paper TN-Review-main.tex line 806; author source ImagesReview Section II/ImagesReview Section II.tex lines 597-617"
 capabilities = ["grid", "lattice", "regions", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_lassoC.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "650-684"
+author_lines = "597-617"
 placements = [{ order = 29, line = 806, asset = "fig2_fig2-pepe_Figboundary-theoryc.pdf" }]
 
 [[target]]
@@ -508,12 +512,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-state.tex"
 formula = "rho_R factorizes through the A and B boundary lassos and sigma_partial R."
 ink = "Canonical public tenkz environment; no raw TikZ."
 boundary = "The east cup closes the virtual pair, the west side is sealed, and physical legs stay open."
-source = "paper TN-Review-main.tex line 807; author source ImagesReview Section II/ImagesReview Section II.tex lines 618-649"
+source = "paper TN-Review-main.tex line 807; author source ImagesReview Section II/ImagesReview Section II.tex lines 650-684"
 capabilities = ["grid", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_rhoR.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "618-649"
+author_lines = "650-684"
 placements = [{ order = 30, line = 807, asset = "fig2_fig2-pepe_Figboundary-theoryb-1.pdf" }]
 
 [[target]]
@@ -661,12 +665,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-boundary-algebra-n.tex"
 formula = "A^(N) = {Tr[X A_1...A_N] : X} is the size-N MPO algebra."
 ink = "Canonical public tenkz periodic N-site word with boundary matrix X."
 boundary = "The virtual word is traced; all N physical indices are open."
-source = "paper TN-Review-main.tex line 1298; author source ImagesReview Section III/ImagesReview Section III.tex lines 133-163"
+source = "paper TN-Review-main.tex line 1298; author source ImagesReview Section III/ImagesReview Section III.tex lines 136-143"
 capabilities = ["grid", "periodic-closure", "boundary-insertion"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_ared_loop.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "133-163"
+author_lines = "136-143"
 placements = [{ order = 39, line = 1298, asset = "fig3_fig3-pepe_ANred.pdf" }]
 
 [[target]]
@@ -678,12 +682,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-boundary-algebra.tex"
 formula = "A = {Tr[X A] : X} is the size-independent local MPO algebra."
 ink = "Canonical public tenkz one-site periodic word with boundary matrix X."
 boundary = "The virtual index is traced; the one physical index is open."
-source = "paper TN-Review-main.tex line 1302; author source ImagesReview Section III/ImagesReview Section III.tex lines 133-163"
+source = "paper TN-Review-main.tex line 1302; author source ImagesReview Section III/ImagesReview Section III.tex lines 144-149"
 capabilities = ["grid", "periodic-closure", "boundary-insertion"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_ared.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "133-163"
+author_lines = "144-149"
 placements = [{ order = 40, line = 1302, asset = "fig3_fig3-pepe_Ared.pdf" }]
 
 [[target]]
@@ -801,12 +805,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-coproduct.tex"
 formula = "Delta sends the local boundary element XA to the two-site word XAA."
 ink = "Canonical public tenkz equation between one-site and two-site words."
 boundary = "Both sides have one open west and one open east virtual index."
-source = "paper TN-Review-main.tex line 1350; author source ImagesReview Section III/ImagesReview Section III.tex lines 133-248"
+source = "paper TN-Review-main.tex line 1350; author source ImagesReview Section III/ImagesReview Section III.tex lines 150-163"
 capabilities = ["grid", "equation-composition", "boundary-insertion"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_ared_loop.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "133-248"
+author_lines = "150-163"
 placements = [{ order = 48, line = 1350, asset = "fig3_fig3-pepe_DeltaAred.pdf" }]
 
 [[target]]
@@ -824,6 +828,7 @@ paper_context_only = false
 fixture = "tests/tenkz/t2_eq50_pull.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "414-447"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 49, line = 1356, asset = "fig3_fig3-pepe_eq50redarrows.pdf" }]
 
 [[target]]
@@ -926,6 +931,7 @@ paper_context_only = false
 fixture = "tests/tenkz/t2_czx.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "357-362"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 55, line = 1449, asset = "fig3_fig3-pepe_ghzdown.pdf" }]
 
 [[target]]
@@ -943,6 +949,7 @@ paper_context_only = false
 fixture = "tests/tenkz/t2_czx.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "357-362"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 56, line = 1449, asset = "fig3_fig3-pepe_Hmatrix.pdf" }]
 
 [[target]]
@@ -960,6 +967,7 @@ paper_context_only = false
 fixture = "tests/tenkz/t2_sptmpo_cross.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "414-447"
+extraction_override = "shared composite block; per-panel split pending"
 placements = [{ order = 57, line = 1459, asset = "fig3_fig3-pepe_newSPTMPO.pdf" }]
 
 [[target]]
@@ -1056,12 +1064,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-torus-two.tex"
 formula = "Enlarged horizontal O_g and vertical O_h strings cross on the PEPS."
 ink = "Canonical public tenkzlattice with orthogonal distinguished MPO paths."
 boundary = "The 5x5 PEPS patch is open; both MPO strings cross its boundary."
-source = "paper TN-Review-main.tex line 1594; author source ImagesReview Section III/ImagesReview Section III.tex lines 572-603"
+source = "paper TN-Review-main.tex line 1594; author source ImagesReview Section III/ImagesReview Section III.tex lines 572-602"
 capabilities = ["lattice", "orthogonal-strings", "crossing-tensor"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_sptintertwin.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "572-603"
+author_lines = "572-602"
 placements = [{ order = 63, line = 1594, asset = "fig3_fig3-pepe_Eq62.pdf" }]
 
 [[target]]
@@ -1073,12 +1081,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-torus-three.tex"
 formula = "Sliding O_g through O_h conjugates h to ghg^{-1} at the crossing."
 ink = "Canonical public tenkzfree before-and-after crossing equation."
 boundary = "Four MPO string ends are open on each side of the equation."
-source = "paper TN-Review-main.tex line 1605; author source ImagesReview Section III/ImagesReview Section III.tex lines 563-603"
+source = "paper TN-Review-main.tex line 1605; author source ImagesReview Section III/ImagesReview Section III.tex lines 563-571"
 capabilities = ["free-graph", "crossing-tensor", "string-slide"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_sptintertwin.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "563-603"
+author_lines = "563-571"
 placements = [{ order = 64, line = 1605, asset = "fig3_fig3-pepe_neweq60.pdf" }]
 
 [[target]]
@@ -1600,6 +1608,7 @@ capabilities = ["lattice", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "742-800"
+extraction_override = "shared composite block; per-panel split pending"
 placements = []
 fixture = "tests/tenkz/t2_rgfp4.tex"
 
@@ -1729,6 +1738,7 @@ capabilities = ["lattice", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "742-800"
+extraction_override = "shared composite block; per-panel split pending"
 placements = []
 fixture = "tests/tenkz/t2_renorm13.tex"
 
@@ -1842,6 +1852,7 @@ capabilities = ["free-graph", "rotated-action", "ring-closure"]
 paper_context_only = false
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "170-197"
+extraction_override = "shared composite block; per-panel split pending"
 placements = []
 
 [[target]]
@@ -1858,6 +1869,7 @@ capabilities = ["lattice", "regions", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "170-197"
+extraction_override = "shared composite block; per-panel split pending"
 placements = []
 
 [[target]]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-lasso.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-lasso.tex
@@ -4,7 +4,7 @@
 % Boundary: The A lasso seals its west side; the B lasso seals its east side; physical
 %   legs stay open.
 % Source: paper TN-Review-main.tex line 804; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 597-617
+%   II/ImagesReview Section II.tex lines 618-649
 % Capabilities: grid, typed-ports
 \[
   \begin{tenkz}[physical=up, west=none]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-region.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-region.tex
@@ -4,7 +4,7 @@
 % Boundary: The sheet exterior is open; the reduced pair seals outer virtual sides at
 %   partial R.
 % Source: paper TN-Review-main.tex line 806; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 650-684
+%   II/ImagesReview Section II.tex lines 597-617
 % Capabilities: grid, lattice, regions, typed-ports
 \[
   \begin{tenkzlattice}[rows=5, cols=6, frame=oblique,

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-state.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-state.tex
@@ -4,7 +4,7 @@
 % Boundary: The east cup closes the virtual pair, the west side is sealed, and physical
 %   legs stay open.
 % Source: paper TN-Review-main.tex line 807; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 618-649
+%   II/ImagesReview Section II.tex lines 650-684
 % Capabilities: grid, typed-ports
 \[
   \rho_R \;=\;

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mps-marginal.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mps-marginal.tex
@@ -4,7 +4,7 @@
 % Boundary: The state has five open physical legs; the marginal traces the last two
 %   ket-bra pairs.
 % Source: paper TN-Review-main.tex line 327; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 269-304
+%   II/ImagesReview Section II.tex lines 269-286
 % Capabilities: grid, typed-ports
 \[
 \begin{gathered}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-marginal.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-marginal.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkzlattice, tenkzplanes environments; no raw TikZ.
 % Boundary: The state sheet is open; the doubled sheet traces the declared complement.
 % Source: paper TN-Review-main.tex line 331; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 269-304
+%   II/ImagesReview Section II.tex lines 287-304
 % Capabilities: lattice, typed-ports
 \[
 \begin{gathered}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-tangent-projector.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-tangent-projector.tex
@@ -5,7 +5,7 @@
 % Boundary: Each block closes only at its internal cup; the identity wire and all
 %   displayed outer and physical endpoints stay open.
 % Source: paper TN-Review-main.tex line 667; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 572-589
+%   II/ImagesReview Section II.tex lines 208-236
 % Capabilities: grid, free-graph, typed-ports
 \[
 \begin{aligned}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-boundary-algebra-n.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-boundary-algebra-n.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkz periodic N-site word with boundary matrix X.
 % Boundary: The virtual word is traced; all N physical indices are open.
 % Source: paper TN-Review-main.tex line 1298; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 133-163
+%   III/ImagesReview Section III.tex lines 136-143
 % Capabilities: grid, periodic-closure, boundary-insertion
 \[
   \mathcal A^{(N)}=\left\{

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-boundary-algebra.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-boundary-algebra.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkz one-site periodic word with boundary matrix X.
 % Boundary: The virtual index is traced; the one physical index is open.
 % Source: paper TN-Review-main.tex line 1302; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 133-163
+%   III/ImagesReview Section III.tex lines 144-149
 % Capabilities: grid, periodic-closure, boundary-insertion
 \[
   \mathcal A=\left\{

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-coproduct.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-coproduct.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkz equation between one-site and two-site words.
 % Boundary: Both sides have one open west and one open east virtual index.
 % Source: paper TN-Review-main.tex line 1350; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 133-248
+%   III/ImagesReview Section III.tex lines 150-163
 % Capabilities: grid, equation-composition, boundary-insertion
 \[
   \Delta\!\left(

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-torus-three.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-torus-three.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkzfree before-and-after crossing equation.
 % Boundary: Four MPO string ends are open on each side of the equation.
 % Source: paper TN-Review-main.tex line 1605; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 563-603
+%   III/ImagesReview Section III.tex lines 563-571
 % Capabilities: free-graph, crossing-tensor, string-slide
 \[
   \begin{tenkzfree}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-torus-two.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-torus-two.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkzlattice with orthogonal distinguished MPO paths.
 % Boundary: The 5x5 PEPS patch is open; both MPO strings cross its boundary.
 % Source: paper TN-Review-main.tex line 1594; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 572-603
+%   III/ImagesReview Section III.tex lines 572-602
 % Capabilities: lattice, orthogonal-strings, crossing-tensor
 \[
   \begin{tenkzlattice}[rows=5, cols=5, frame=flat, physical=up]

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -2,7 +2,7 @@
 # Schema: scripts/tenkz_rmp.py (load_verdicts).  Any status may be
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
-campaign_sha256 = "023d1a6d67ad104d04ab70366c4465fca2c36ea0762bf55e74453f6b7222cde8"
+campaign_sha256 = "50d12a899c05646fc1945722707264e5abe7b92289b1b814bb772af72d6a2633"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"
@@ -137,14 +137,14 @@ pairing = "unverified"
 [[verdict]]
 id = "rmp-ii-tangent-projector"
 status = "unreviewed"
-pairing = "wrong-source"
-note = "Comparison page pairs this target with the wrong author figure; repair before judging."
+pairing = "unverified"
+note = "Author line range corrected in the harness repair; awaiting the pairing sweep."
 
 [[verdict]]
 id = "rmp-ii-boundary-lasso"
 status = "unreviewed"
-pairing = "wrong-source"
-note = "Comparison page pairs this target with the wrong author figure; repair before judging."
+pairing = "unverified"
+note = "Author line range corrected in the harness repair; awaiting the pairing sweep."
 
 [[verdict]]
 id = "rmp-ii-boundary-region"
@@ -188,10 +188,13 @@ pairing = "unverified"
 
 [[verdict]]
 id = "rmp-iii-a-symmetry-sector"
-status = "unreviewed"
-pairing = "wrong-source"
-note = "Comparison page pairs this target with the wrong author figure; repair before judging."
-
+status = "structural-gap"
+pairing = "unverified"
+defects = ["wrong-contraction"]
+case_sha256 = "f26371091985278de8fc2bc3b93ee63f542ec371ba86c3183b1b7947de3cefca"
+note = "The author block faithfully draws the string-order expectation of S_(alpha,g); the case draws a plain periodic MPS instead. Redraw the case to the string-order object once the kernel lands."
+reviewed = "2026-07-23"
+renderer = "maintainer-page-review-2026-07-23"
 [[verdict]]
 id = "rmp-iii-a-f-symbol"
 status = "unreviewed"
@@ -200,8 +203,8 @@ pairing = "unverified"
 [[verdict]]
 id = "rmp-iii-a-boundary-algebra-n"
 status = "unreviewed"
-pairing = "source-misrender"
-note = "The extracted author-source panel misrenders; repair extraction before judging."
+pairing = "unverified"
+note = "Superposed multi-panel range narrowed to the single panel in the harness repair; awaiting the pairing sweep."
 
 [[verdict]]
 id = "rmp-iii-a-boundary-algebra"
@@ -246,8 +249,8 @@ pairing = "context-only"
 [[verdict]]
 id = "rmp-iii-a-coproduct"
 status = "unreviewed"
-pairing = "source-misrender"
-note = "The extracted author-source panel misrenders; repair extraction before judging."
+pairing = "unverified"
+note = "Superposed multi-panel range narrowed to the single panel in the harness repair; awaiting the pairing sweep."
 
 [[verdict]]
 id = "rmp-iii-a-pulling-through"


### PR DESCRIPTION
Landing L0b of the 1.0 plan: the comparison harness told the truth about the wrong figures.

**Mechanism** (diagnosed, not guessed): `extract_author_block` re-activates every single-`%` line in `author_lines` and splices the whole range into one `tikzpicture` — a range spanning several archived panels superimposes them at the origin. All five maintainer-flagged defects and one unflagged one reduce to this plus three wrong ranges forming a 3-cycle in the boundary trio.

**Corrections** (11 targets): boundary 3-cycle rotated back into place; tangent-projector → the PT(A) block (blue index, lines 208-236); boundary-algebra-n/boundary-algebra/coproduct narrowed to their single panels (Eq51/Eq52/Diagram1); mps/peps-marginal and torus-two/-three ranges split.

**Hardening**: interval-math validation at manifest load — same-corpus partial overlaps are errors; identical ranges require `extraction_override` on every owner (12 recorded shared composite blocks); cross-corpus sharing stays legal (the workbench archives published blocks by design). No regex-on-TeX heuristics added.

**Verdicts**: repaired targets return to `pairing=unverified` awaiting the sweep; `symmetry-sector` recorded `structural-gap` / `wrong-contraction` (author block is the faithful ⟨S⟩ string-order figure; the tenkz case draws a plain MPS — redraw post-kernel, per maintainer decision).

**Verification**: comparison book rebuilt (`output/pdf/tenkz-rmp-comparison.pdf`); renderer inspected pages 27-30, 39-40; independent second-viewer agent countersigned all 12 repaired pages (3, 4, 27-30, 37, 39, 40, 48, 63, 64) — each author panel is now one coherent figure matching its target. `compare --all` green (exercises manifest+overlap validation, verdict ledger, and all 130 case compiles).

Next per plan: the 130-target pairing sweep (second-signed `pairing=verified` bits), then L0c — transcribing the maintainer's completed page review into the verdict campaign.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark manifest metadata and validation that gates all 130 RMP targets; incorrect ranges would break comparison builds, but scope is test/harness data rather than production runtime.
> 
> **Overview**
> Fixes **wrong or overlapping `author_lines` extractions** that made the RMP comparison harness show superimposed author panels, and **locks in the rules** so the same mistake cannot re-enter the manifest silently.
> 
> **Harness (`scripts/tenkz_rmp.py`):** Adds optional manifest field **`extraction_override`** (requires `author_lines`) for targets that intentionally share one TeX block. On load, **`validate_author_ranges`** rejects partial overlaps within the same corpus and source file; identical ranges are allowed only when every owner declares **`extraction_override`**. **`line_range`** now fails on invalid or non-ascending ranges.
> 
> **Manifest and cases:** Splits and reassigns line ranges for marginals, boundary trio (3-cycle fix), tangent-projector, Section III boundary-algebra/coproduct panels, and torus-two/three. Records **`extraction_override`** on twelve shared composite blocks (MPO/PEPO pairs, spectrum panels, pulling-through, GHZ/Hadamard, workbench composites). Case `% Source:` comments track the new ranges.
> 
> **Verdicts:** Updates **`campaign_sha256`**; repaired targets reset to **`pairing=unverified`** pending sweep; **`rmp-iii-a-symmetry-sector`** is **`structural-gap`** / **`wrong-contraction`** (author panel vs plain MPS case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b4cd5c33b9d73fd69b0cf2abfb3797dff747b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->