### PR TITLE
feat(MPS/MPDO): add retained one-site multiplicity energy

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -209,6 +209,7 @@ import TNLean.MPS.MPDO.SourceZCLMarginal
 import TNLean.MPS.MPDO.StackedLayers
 import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.TopologicalDensityDecomposition
+import TNLean.MPS.MPDO.TopologicalMultiplicityEnergy
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.TopologicalProjectors
 import TNLean.MPS.MPDO.TopologicalTerminalSpectral

--- a/TNLean/MPS/MPDO/TopologicalMultiplicityEnergy.lean
+++ b/TNLean/MPS/MPDO/TopologicalMultiplicityEnergy.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+import Mathlib.Analysis.SpecialFunctions.Exponential
+import TNLean.MPS.MPDO.TopologicalDensityDecomposition
+
+/-!
+# The retained one-site multiplicity energy
+
+For the topological decomposition of a length-independent renormalization
+fixed-point matrix product density operator, the multiplicity-weight factor
+comes from the strictly positive diagonal multiplicity matrices in the
+vertical canonical form. This file defines the corresponding one-site
+operator on the retained physical coordinates and its Hermitian logarithmic
+energy.
+
+The terminal eigenvalues in the spectral topological factor are not
+logarithms in this construction. They remain nonnegative coefficients of the
+topological projectors, so their possible zero values cause no difficulty for
+the finite logarithmic energy. This file treats only the retained one-site
+factor and does not construct the many-body Hamiltonian $H_N$.
+
+## Main results
+
+* `MPOTensor.BNTFusionTensorClause.retainedMultiplicityOperator_posDef`:
+  the retained multiplicity operator is positive definite.
+* `MPOTensor.BNTFusionTensorClause.retainedMultiplicityOperator_isUnit`:
+  the retained multiplicity operator is invertible.
+* `MPOTensor.BNTFusionTensorClause.exp_neg_retainedMultiplicityEnergy`:
+  exponentiating the negative one-site energy recovers the multiplicity
+  operator exactly.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13 (local source lines 943–951): positivity of the diagonal
+  multiplicity matrices.
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  local source lines 999–1002: the retained multiplicity tensor factor.
+* The many-body Gibbs theorem is stated later in the same source, local lines
+  1013–1016; it is not formalized in this file.
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.BNTFusionTensorClause
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- The positive multiplicity weight attached to one retained physical
+coordinate. The weight depends on its BNT label and multiplicity coordinate,
+and is independent of its simple-bond coordinate.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951) and
+local source lines 999–1002. -/
+def retainedMultiplicityWeightEntry (H : BNTFusionTensorClause M)
+    (u : Fin H.verticalRetainedDim) : ℂ :=
+  let px := verticalCopyCoordinateEquiv H.bondDim H.multiplicity u
+  H.weight px.1.1 px.1.2
+
+/-- In retained copy coordinates, the one-site entry is the corresponding
+diagonal entry of the multiplicity matrix.
+
+Source: CPSV16, local source lines 999–1002. -/
+@[simp]
+theorem retainedMultiplicityWeightEntry_verticalCopyCoordinateEquiv_symm
+    (H : BNTFusionTensorClause M) (p : H.VerticalCopy)
+    (x : Fin (H.bondDim p.1)) :
+    H.retainedMultiplicityWeightEntry
+        ((verticalCopyCoordinateEquiv H.bondDim H.multiplicity).symm ⟨p, x⟩) =
+      H.weight p.1 p.2 := by
+  unfold retainedMultiplicityWeightEntry
+  rw [Equiv.apply_symm_apply]
+
+/-- Every retained one-site multiplicity weight is strictly positive.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951). -/
+theorem retainedMultiplicityWeightEntry_pos (H : BNTFusionTensorClause M)
+    (u : Fin H.verticalRetainedDim) :
+    (0 : ℂ) < H.retainedMultiplicityWeightEntry u := by
+  unfold retainedMultiplicityWeightEntry
+  exact H.weight_pos _ _
+
+/-- The real part of every retained multiplicity weight is strictly positive.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951). -/
+theorem retainedMultiplicityWeightEntry_re_pos (H : BNTFusionTensorClause M)
+    (u : Fin H.verticalRetainedDim) :
+    0 < (H.retainedMultiplicityWeightEntry u).re :=
+  (Complex.pos_iff.mp (H.retainedMultiplicityWeightEntry_pos u)).1
+
+/-- The positive diagonal multiplicity operator on the retained one-site
+physical space.
+
+Its entry at the coordinate `u ↔ ((α, q), x)` is `H.weight α q`.
+Source: CPSV16, local source lines 999–1002. -/
+def retainedMultiplicityOperator (H : BNTFusionTensorClause M) :
+    Matrix (Fin H.verticalRetainedDim) (Fin H.verticalRetainedDim) ℂ :=
+  Matrix.diagonal H.retainedMultiplicityWeightEntry
+
+/-- The retained one-site multiplicity operator is positive definite.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951). -/
+theorem retainedMultiplicityOperator_posDef (H : BNTFusionTensorClause M) :
+    H.retainedMultiplicityOperator.PosDef := by
+  exact Matrix.PosDef.diagonal H.retainedMultiplicityWeightEntry_pos
+
+/-- The retained one-site multiplicity operator is invertible.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951). -/
+theorem retainedMultiplicityOperator_isUnit (H : BNTFusionTensorClause M) :
+    IsUnit H.retainedMultiplicityOperator :=
+  H.retainedMultiplicityOperator_posDef.isUnit
+
+/-- The real one-site energy associated with a retained multiplicity weight.
+
+Only the strictly positive multiplicity weight is logged. The terminal
+eigenvalues belong to the separate topological factor and are not part of
+this definition.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951) and
+local source lines 999–1002. -/
+def retainedMultiplicityEnergyEntry (H : BNTFusionTensorClause M)
+    (u : Fin H.verticalRetainedDim) : ℝ :=
+  -Real.log (H.retainedMultiplicityWeightEntry u).re
+
+/-- The Hermitian diagonal one-site multiplicity energy on the retained
+physical space.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951) and
+local source lines 999–1002. -/
+def retainedMultiplicityEnergy (H : BNTFusionTensorClause M) :
+    Matrix (Fin H.verticalRetainedDim) (Fin H.verticalRetainedDim) ℂ :=
+  Matrix.diagonal fun u ↦ (H.retainedMultiplicityEnergyEntry u : ℂ)
+
+/-- The retained one-site multiplicity energy is Hermitian.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951). -/
+theorem retainedMultiplicityEnergy_isHermitian (H : BNTFusionTensorClause M) :
+    H.retainedMultiplicityEnergy.IsHermitian := by
+  unfold retainedMultiplicityEnergy
+  apply Matrix.isHermitian_diagonal_of_self_adjoint
+  rw [isSelfAdjoint_iff]
+  ext u
+  simp [Complex.conj_ofReal]
+
+private theorem exp_log_retainedMultiplicityWeightEntry
+    (H : BNTFusionTensorClause M) (u : Fin H.verticalRetainedDim) :
+    NormedSpace.exp
+        ((Real.log (H.retainedMultiplicityWeightEntry u).re : ℝ) : ℂ) =
+      H.retainedMultiplicityWeightEntry u := by
+  rw [← NormedSpace.ofReal_exp_ℝ_ℝ,
+    ← Real.exp_eq_exp_ℝ,
+    Real.exp_log (H.retainedMultiplicityWeightEntry_re_pos u)]
+  apply Complex.ext
+  · rfl
+  · exact (Complex.pos_iff.mp (H.retainedMultiplicityWeightEntry_pos u)).2
+
+/-- Exponentiating the negative retained one-site energy gives the
+multiplicity operator exactly.
+
+Only the strictly positive multiplicity weights enter the logarithm. The
+possibly zero terminal eigenvalues remain coefficients of the separate
+topological factor.
+
+This identity concerns the retained one-site multiplicity factor only; it does
+not construct the many-body Hamiltonian $H_N$ from the Gibbs theorem at local
+source lines 1013–1016.
+
+Source: CPSV16, Proposition 4.13 (local source lines 943–951) and
+local source lines 999–1002. -/
+theorem exp_neg_retainedMultiplicityEnergy (H : BNTFusionTensorClause M) :
+    NormedSpace.exp (-H.retainedMultiplicityEnergy) =
+      H.retainedMultiplicityOperator := by
+  have hneg :
+      -H.retainedMultiplicityEnergy =
+        Matrix.diagonal fun u ↦
+          ((Real.log (H.retainedMultiplicityWeightEntry u).re : ℝ) : ℂ) := by
+    ext u v
+    by_cases huv : u = v
+    · subst v
+      simp [retainedMultiplicityEnergy, retainedMultiplicityEnergyEntry]
+    · simp [retainedMultiplicityEnergy, retainedMultiplicityEnergyEntry, huv]
+  rw [hneg, Matrix.exp_diagonal]
+  ext u v
+  by_cases huv : u = v
+  · subst v
+    simp [retainedMultiplicityOperator,
+      exp_log_retainedMultiplicityWeightEntry]
+  · simp [retainedMultiplicityOperator, huv]
+
+end MPOTensor.BNTFusionTensorClause


### PR DESCRIPTION
### Motivation

- Advance the one-site multiplicity-energy part of #4685 without claiming the later many-body Hamiltonian theorem.
- The mathematical source is `Papers/1606.00608/MPDO-22-12-17-2.tex`, Proposition 4.13, local lines 943–951: “where μ_α are diagonal and positive matrices.” Local lines 999–1002 identify the retained multiplicity tensor factor `μ^{⊗ N}` and its commutation with the topological factor.
- The Gibbs decomposition and the construction of the commuting nearest-neighbor Hamiltonian `H_N` occur only at local lines 1013–1016 and remain outside this pull request.
- Blueprint entries are intentionally deferred to the completing part of #4685 that formalizes the many-body `H_N` theorem. This scope-restricted one-site factor is therefore not presented as the formalization of the source Gibbs theorem.

### Description

- Define the retained one-site multiplicity weight and its exact expression in vertical-copy coordinates.
- Define the corresponding diagonal multiplicity operator and prove that it is positive definite and invertible.
- Define the real logarithmic energy entry and the Hermitian diagonal one-site energy.
- Prove the exact identity `exp (-retainedMultiplicityEnergy) = retainedMultiplicityOperator`.
- Record explicitly that terminal spectral eigenvalues belong to the separate topological factor and are not logarithm arguments.
- Add the new module to the generated `TNLean.MPS.MPDO` import aggregator.

### Testing

- `lake env lean TNLean/MPS/MPDO/TopologicalMultiplicityEnergy.lean`
- `lake build TNLean.MPS.MPDO`
- `lake env lean TNLean/MPS/MPDO.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`
- Proof-integrity and 100-column scans on the new module.

Addresses #4685

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization on existing `BNTFusionTensorClause` data; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TopologicalMultiplicityEnergy.lean`**, formalizing the retained one-site multiplicity factor from CPSV16 Proposition 4.13 (without the later many-body Gibbs / `H_N` construction).
> 
> On `BNTFusionTensorClause`, it introduces diagonal **multiplicity weights** on `verticalRetainedDim` (via `verticalCopyCoordinateEquiv`), the **multiplicity operator** `μ`, and the **logarithmic energy** `-log(re weight)` as a Hermitian diagonal matrix. Proved lemmas include strict positivity of weights, positive definiteness and invertibility of `μ`, Hermiticity of the energy, and **`exp(-retainedMultiplicityEnergy) = retainedMultiplicityOperator`**.
> 
> Documentation in the module stresses that **terminal spectral eigenvalues** stay in the separate topological factor and are **not** used as log arguments. The new module is wired into the generated **`TNLean.MPS.MPDO`** import aggregator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde994f0d76c0fde2d94db4b279e0d7cd1deeeaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->