### PR TITLE
fix(MPS/MPDO): restore retained-coordinate Gibbs scope

### DIFF
--- a/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
+++ b/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
@@ -19,6 +19,12 @@ The two-site local term depends only on its first site.  Its periodic translates
 therefore sum to the one-site logarithms, while still giving the two-site
 presentation used in the source definition of a nearest-neighbor Hamiltonian.
 
+All Hamiltonians and spectral projectors constructed here act on the retained
+vertical coordinates.  The exact sitewise reconstruction of the physical MPDO
+does not yet give a physical-space Hamiltonian or physical-space projectors.
+See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
@@ -184,7 +190,11 @@ private theorem sum_extend_smul_mul_zero
 /-- The all-label multiplicity factor is the diagonal product of its
 one-site weights.
 
-Source: arXiv:1606.00608, lines 999--1002 and 1013--1016. -/
+Source: arXiv:1606.00608, lines 999--1002 and 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This factor acts on
+the retained nonzero vertical sectors.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 theorem topologicalMultiplicityWeightFactorSucc_eq_diagonal
     (H : BNTFusionTensorClause M) (N : ℕ) :
     H.topologicalMultiplicityWeightFactorSucc N =
@@ -232,7 +242,11 @@ theorem topologicalMultiplicityWeightFactorSucc_eq_diagonal
 one-site energy on the first site and as the identity on the second.
 
 Source: arXiv:1606.00608, the nearest-neighbor Hamiltonian at
-lines 1013--1016. -/
+lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This local term acts
+on the retained nonzero vertical sectors.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 def topologicalGibbsLocalTerm (H : BNTFusionTensorClause M) :
     Matrix (Fin 2 → Fin H.verticalRetainedDim)
       (Fin 2 → Fin H.verticalRetainedDim) ℂ :=
@@ -242,7 +256,11 @@ def topologicalGibbsLocalTerm (H : BNTFusionTensorClause M) :
 /-- The translation-invariant two-site Gibbs term is Hermitian.
 
 Source: arXiv:1606.00608, the nearest-neighbor Hamiltonian at
-lines 1013--1016. -/
+lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This theorem concerns
+the retained local term.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 theorem topologicalGibbsLocalTerm_isHermitian
     (H : BNTFusionTensorClause M) :
     H.topologicalGibbsLocalTerm.IsHermitian := by
@@ -254,6 +272,10 @@ theorem topologicalGibbsLocalTerm_isHermitian
 retained chain of length `N + 2`.
 
 Source: arXiv:1606.00608, `H_N = sum_i h_{i,i+1}` at lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This Hamiltonian acts
+on the retained nonzero vertical sectors.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
 
 **Scope restriction (positive chains of length at least two):** Definition
 4.8 defines the local operator on two spins, so the present source-facing
@@ -281,7 +303,12 @@ def physicalIndexedTerminalEigenvalue
 `d`-element index.
 
 Source: arXiv:1606.00608, the projectors `P_i^(N)` with
-`i = 1, ..., d` at lines 1013--1016. -/
+`i = 1, ..., d` at lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** The index is padded
+to the physical one-site dimension, but each projector still acts on the
+retained chain.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 def physicalIndexedTopologicalSpectralProjectorSucc
     (H : BNTFusionTensorClause M) (hM : IsMPDO M)
     (N : ℕ) (i : Fin d) :
@@ -305,9 +332,13 @@ theorem physicalIndexedTerminalEigenvalue_nonneg
   · rw [physicalIndexedTerminalEigenvalue,
       Function.extend_apply' _ _ _ hi]
 
-/-- Every zero-padded physical-index projector is an orthogonal projection.
+/-- Every zero-padded physical-index retained projector is an orthogonal projection.
 
-Source: arXiv:1606.00608, lines 1010--1016. -/
+Source: arXiv:1606.00608, lines 1010--1016.
+
+**Scope restriction (retained vertical coordinates):** These projections act
+on the retained chain.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 theorem physicalIndexedTopologicalSpectralProjectorSucc_isOrthogonalProjection
     (H : BNTFusionTensorClause M) (hM : IsMPDO M)
     (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
@@ -330,7 +361,11 @@ theorem physicalIndexedTopologicalSpectralProjectorSucc_isOrthogonalProjection
 /-- Every translated local Hamiltonian term is diagonal in retained
 coordinates.
 
-Source: arXiv:1606.00608, the translated local terms at lines 1013--1016. -/
+Source: arXiv:1606.00608, the translated local terms at lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** These translated
+terms act on the retained chain.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 theorem topologicalGibbsBondSuccSucc_eq_diagonal
     (H : BNTFusionTensorClause M) (N : ℕ) (i : Fin (N + 2)) :
     MPOTensor.embedLocalOperator 2 (N + 2) (by omega) i
@@ -347,7 +382,11 @@ theorem topologicalGibbsBondSuccSucc_eq_diagonal
 /-- Periodic translates of the local Hamiltonian term commute pairwise.
 
 Source: arXiv:1606.00608, `[h_{i-1,i},h_{i,i+1}] = 0` at
-lines 1013--1016. -/
+lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** The commutation
+statement concerns translated terms on the retained chain.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 theorem topologicalGibbsBondSuccSucc_commute
     (H : BNTFusionTensorClause M) (N : ℕ)
     (i j : Fin (N + 2)) :
@@ -360,10 +399,14 @@ theorem topologicalGibbsBondSuccSucc_commute
     H.topologicalGibbsBondSuccSucc_eq_diagonal N j]
   exact Matrix.commute_diagonal _ _
 
-/-- The periodic Hamiltonian is diagonal, with one logarithmic energy per
+/-- The retained periodic Hamiltonian is diagonal, with one logarithmic energy per
 site.
 
-Source: arXiv:1606.00608, `H_N = sum_i h_{i,i+1}` at lines 1013--1016. -/
+Source: arXiv:1606.00608, `H_N = sum_i h_{i,i+1}` at lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This diagonal formula
+is for the retained Hamiltonian.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
 theorem topologicalGibbsHamiltonianSuccSucc_eq_diagonal
     (H : BNTFusionTensorClause M) (N : ℕ) :
     H.topologicalGibbsHamiltonianSuccSucc N =
@@ -383,6 +426,10 @@ multiplicity-weight factor.
 
 Source: arXiv:1606.00608, the identification of `e^{-H_N}` in the
 decomposition at lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This exponential
+identity is on the retained chain.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
 
 **Scope restriction (positive chains of length at least two):** The source
 local term is defined on two spins.  See
@@ -415,6 +462,10 @@ Gibbs factor.
 
 Source: arXiv:1606.00608, `[P_i,e^{-H}] = 0` at lines 1013--1016.
 
+**Scope restriction (retained vertical coordinates):** Both factors act on
+the retained chain.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
 **Scope restriction (positive chains of length at least two):** The source
 local term is defined on two spins.  See
 `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
@@ -435,6 +486,10 @@ Gibbs factor.
 
 Source: arXiv:1606.00608, `[P_i,e^{-H}] = 0` for
 `i = 1, ..., d` at lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** The physical index
+pads a family of projectors that still acts on the retained chain.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
 
 **Scope restriction (positive chains of length at least two):** The source
 local term is defined on two spins.  See
@@ -462,6 +517,10 @@ weighted sum of its topological projectors times the Gibbs factor.
 
 Source: arXiv:1606.00608, the density formula at lines 1013--1016.
 
+**Scope restriction (retained vertical coordinates):** This equality is for
+the retained density operator.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
 **Scope restriction (positive chains of length at least two):** The source
 local term is defined on two spins.  See
 `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
@@ -488,6 +547,11 @@ zero-padding the terminal spectral family.
 
 Source: arXiv:1606.00608, the displayed density formula with
 `i = 1, ..., d` at lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This equality is for
+the retained density operator, although the spectral family is padded to
+`Fin d`.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
 
 **Scope restriction (positive chains of length at least two):** The source
 local term is defined on two spins.  See
@@ -536,6 +600,11 @@ the adjoint of the retained-row coisometry, rather than treating that
 rectangular matrix as a square unitary.  See
 `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
 
+**Scope restriction (retained vertical coordinates):** The Hamiltonian and
+projectors inside the sitewise map act on the retained chain.  This theorem
+does not construct a physical-space Gibbs factor.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
 **Scope restriction (positive chains of length at least two):** The source
 local term is defined on two spins.  See
 `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
@@ -565,6 +634,11 @@ the `d`-term density formula at lines 1013--1016.
 **Local fix (rectangular vertical map):** Exact physical reconstruction uses
 the adjoint retained-row map.  See
 `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+**Scope restriction (retained vertical coordinates):** The Hamiltonian and
+projectors inside the sitewise map act on the retained chain.  This theorem
+does not construct a physical-space Gibbs factor.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
 
 **Scope restriction (positive chains of length at least two):** The source
 local term is defined on two spins.  See
@@ -596,6 +670,12 @@ terminal spectral projector commutes with that Gibbs factor, and their
 eigenvalue-weighted sum is the retained density operator.
 
 Source: arXiv:1606.00608, lines 1013--1016.
+
+**Scope restriction (retained vertical coordinates):** This predicate
+describes the Gibbs formula on the retained chain together with exact
+sitewise reconstruction of the physical MPDO.  It does not assert a
+physical-space Hamiltonian or physical-space projectors.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
 
 **Scope restriction (positive chains of length at least two):** Definition
 4.8 defines the local term on two spins, so this predicate covers lengths
@@ -654,6 +734,10 @@ Gibbs decomposition.
 
 Source: arXiv:1606.00608, lines 1013--1016.
 
+**Scope restriction (retained vertical coordinates):** The conclusion is the
+retained-coordinate Gibbs formula and its exact sitewise reconstruction.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
 **Scope restriction (positive chains of length at least two):** Definition
 4.8 defines the local term on two spins.  See
 `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
@@ -681,7 +765,7 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- **Commuting Gibbs decomposition for a length-independent RFP MPDO.**
+/-- **Retained-coordinate Gibbs decomposition for a length-independent RFP MPDO.**
 
 The BNT fusion clause, positive multiplicity weights, local Hamiltonian,
 terminal eigenweights, and topological projectors are all selected or
@@ -691,12 +775,18 @@ the retained commuting nearest-neighbor Gibbs formula.
 
 Source: arXiv:1606.00608, lines 999--1016.
 
+**Scope restriction (retained vertical coordinates):** The Gibbs
+Hamiltonian and projectors in the conclusion act on the retained vertical
+chain; the physical MPDO is obtained only by exact sitewise reconstruction.
+See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
 **Scope restriction (positive chains of length at least two):** Definition
 4.8 defines its local term on two spins, while the printed theorem does not
-state a separate length-one convention.  This theorem proves the
-nearest-neighbor conclusion for every chain of length `N + 2`; the already
-formalized density and spectral conclusions remain available at length one.
-See `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+state a separate length-one convention.  This theorem proves the retained
+nearest-neighbor conclusion for every chain of length `N + 2`; the density
+and spectral conclusions remain available at length one.  See
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
 theorem topologicalGibbsDecomposition_of_isRFPViaTS
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M)
     (hM : IsMPDO M) (hRFP : IsRFPViaTS M)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -1925,7 +1925,7 @@ separate step.
     $R_N$.
 \end{proof}
 
-\begin{definition}[Commuting topological Gibbs data above one site]%
+\begin{definition}[Retained-coordinate commuting Gibbs form above one site]%
     \label{def:mpdo_topological_gibbs_data_at_least_two}
     \lean{MPOTensor.BNTFusionTensorClause.%
         terminalSpectralIndex_card_le_physicalDim}
@@ -1958,13 +1958,21 @@ separate step.
     $\{1,\ldots,d\}$ and extend the remaining eigenvalues and projectors by
     zero.
 
+    \textbf{Scope restriction (retained vertical coordinates):}
+    the Hamiltonian and projectors act on the retained nonzero vertical
+    sectors.  Applying the adjoint retained-row map reconstructs the physical
+    density operator, but does not provide a Hamiltonian or projectors on the
+    original physical space.  This restriction is recorded in
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+
     \textbf{Scope restriction (positive chains of length at least two):}
     the local interaction is defined on two spins, so these data are indexed
     by $L=N+2$.  The length-one boundary is recorded in
     \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
 \end{definition}
 
-\begin{theorem}[Commuting Gibbs decomposition above one site]%
+\begin{theorem}[Retained-coordinate commuting Gibbs decomposition above one
+    site]%
     \label{thm:mpdo_topological_gibbs_at_least_two}
     \lean{MPOTensor.BNTFusionTensorClause.%
         topologicalGibbsLocalTerm_isHermitian}
@@ -1990,13 +1998,16 @@ separate step.
     satisfying the renormalization fixed-point condition.  Select the fusion
     clause supplied by that condition and suppose that its positive
     trace-power coefficients are independent of the positive chain length.
-    For every $L\geq2$, the same two-site matrix $h$ is Hermitian, its
-    periodic translates commute pairwise, and
+    There are nonnegative numbers $\lambda_1,\ldots,\lambda_d$, independent
+    of the chain length.  For every $L\geq2$, the same two-site matrix $h$ is
+    Hermitian, its periodic translates commute pairwise, and
     \[
+      H_L=\sum_{j=1}^{L}h_{j,j+1},
+      \qquad
       e^{-H_L}=\mu^{\otimes L}.
     \]
-    There are nonnegative numbers $\lambda_1,\ldots,\lambda_d$ and orthogonal
-    projections $P_1^{(L)},\ldots,P_d^{(L)}$ such that
+    There are orthogonal projections
+    $P_1^{(L)},\ldots,P_d^{(L)}$ such that
     \[
       [P_i^{(L)},e^{-H_L}]=0,
       \qquad
@@ -2004,6 +2015,14 @@ separate step.
     \]
     Applying the adjoint retained-row map at every site reconstructs
     $\rho^{(L)}(M)$ from the right-hand side.
+
+    \textbf{Scope restriction (retained vertical coordinates):}
+    the formula is an equality for $R_L$ on the retained vertical space, not
+    the literal physical-space equality asserted in
+    \cite[lines~1013--1016]{Cirac2016MPDO_arXiv}.  Exact reconstruction by the
+    adjoint retained-row map is weaker than the existence of physical
+    projectors and a finite physical Hamiltonian.  See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the conclusion is proved for $L=N+2$.  Definition~4.8 of
@@ -2030,6 +2049,36 @@ separate step.
     reconstruction of the retained density operator.
 \end{proof}
 
+\begin{theorem}[Physical-coordinate commuting Gibbs decomposition above one
+    site]%
+    \label{thm:mpdo_physical_coordinate_gibbs_at_least_two}
+    \uses{thm:mpdo_topological_gibbs_at_least_two}
+    Let $M$ be as in
+    Theorem~\ref{thm:mpdo_topological_gibbs_at_least_two}.  There are
+    nonnegative numbers $\lambda_1,\ldots,\lambda_d$ and one fixed Hermitian
+    two-site matrix $\widehat h$, all independent of the chain length.  For
+    every $L\geq2$, let
+    \[
+      \widehat H_L=\sum_{j=1}^{L}\widehat h_{j,j+1}.
+    \]
+    The translates of $\widehat h$ commute pairwise, and there are orthogonal
+    projections $\widehat P_1^{(L)},\ldots,\widehat P_d^{(L)}$ on the physical
+    chain such that
+    \[
+      [\widehat h_{j-1,j},\widehat h_{j,j+1}]=0,
+      [\widehat P_i^{(L)},e^{-\widehat H_L}]=0,
+      \qquad
+      \rho^{(L)}(M)=
+        \sum_{i=1}^{d}\lambda_i\widehat P_i^{(L)}
+          e^{-\widehat H_L}.
+    \]
+
+    This target is not yet marked complete.  The retained-coordinate theorem
+    does not construct $\widehat P_i^{(L)}$ or $\widehat H_L$ on the
+    complementary physical sectors; see
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+\end{theorem}
+
 \begin{remark}[Printed length-one domain boundary]%
     \label{rem:mpdo_topological_gibbs_length_one_boundary}
     Definition~4.8 of \cite{Cirac2016MPDO_arXiv} lets a local operator act on
@@ -2040,8 +2089,12 @@ separate step.
 
     Theorem~4.15 is printed without an explicit lower bound on $L$, but its
     $L=1$ instance is therefore undefined without an author or erratum
-    convention.  The preceding theorem covers the complete domain of
-    Definition~4.8; no length-one theorem is asserted.  See
+    convention.  The source construction is defined for $L\geq2$, and no
+    length-one theorem is asserted.  The retained-coordinate theorem above
+    proves its scoped analogue on this domain; the physical-coordinate
+    complement remains open.  See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}
+    and
     \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
 \end{remark}
 

--- a/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
+++ b/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
@@ -31,7 +31,7 @@ two-spin operator around the chain.  This construction has domain $N\geq2$:
 the periodic identification $N+1=1$ identifies site labels, but does not
 identify the two tensor factors on which $h$ acts.
 
-\section{The formalized range}
+\section{The retained-coordinate range}
 
 Let $\mu$ be the strictly positive diagonal one-site multiplicity matrix in
 the retained coordinates.  Define the two-site matrix
@@ -45,7 +45,11 @@ first site of a translated term, hence
   \exp\left(-\sum_i h_{i,i+1}\right)=\mu^{\otimes N}.
 \]
 Combining this equality with the terminal spectral refinement proves the
-displayed Gibbs decomposition for every $N\geq2$.
+retained-coordinate Gibbs decomposition for every $N\geq2$.  Applying the
+adjoint retained-row map reconstructs the physical density operator, but
+does not yet supply a physical-space Hamiltonian and physical-space
+projectors.  That independent gap is recorded in
+\path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
 
 The terminal spectral sectors are naturally indexed by pairs
 $(\gamma,k)$.  Positivity of every multiplicity shows that one such sector
@@ -75,9 +79,16 @@ The source construction therefore determines the theorem on the domain
 \]
 Theorem~4.15 is printed without stating this lower bound, but its $N=1$
 instance is undefined unless an author or erratum specifies both $H_1$ and
-the coincident-edge convention.  The theorem for $N\geq2$ is the complete
-formalization of the construction supplied by Definition~4.8.  No
-length-one theorem is asserted.
+the coincident-edge convention.  The retained-coordinate theorem resolves
+only this length-domain boundary for the scoped analogue on $N\geq2$.  No
+length-one theorem is asserted, and the physical-coordinate complement
+remains unformalized; see
+\path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+
+This printed-domain boundary is independent of the physical-coordinate
+complement described in
+\path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+Resolving either question would not resolve the other.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex
+++ b/docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex
@@ -1,0 +1,146 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+
+\title{The Physical Complement in the Topological Gibbs Decomposition}
+\author{}
+\date{2026-07-23}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+The theorem following Theorem~4.14 in
+\cite[lines~1013--1016]{Cirac2016MPDO_arXiv} states an equality on the
+physical chain:
+\begin{equation}
+  \rho^{(N)}(M)
+    =\sum_{i=1}^{d}\lambda_iP_i^{(N)}e^{-H_N},
+  \qquad
+  [P_i^{(N)},e^{-H_N}]=0.
+  \label{eq:physical-gibbs}
+\end{equation}
+Here the $P_i^{(N)}$ are orthogonal projections on the physical Hilbert
+space, and $H_N=\sum_jh_{j,j+1}$ is a translationally invariant commuting
+nearest-neighbor Hamiltonian on that space.
+
+The preceding derivation first applies the vertical canonical form from
+Proposition~4.13 and then suppresses the resulting local change of
+coordinates.  The formal vertical map is a retained-row coisometry
+\[
+  V:\mathbb C^d\longrightarrow\mathbb C^s,
+  \qquad
+  VV^\dagger=I_s,
+  \qquad
+  V^\dagger V=E.
+\]
+The projection $E$ need not be the identity because the original physical
+space may contain a zero sector.  This is documented in
+\path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
+
+\section{Retained-coordinate theorem}
+
+Let $k$ be the diagonal logarithmic multiplicity energy on
+$\mathbb C^s$.  For every $N\geq2$, the formalized two-site interaction on
+the retained space is
+\[
+  h=k\otimes I.
+\]
+Its periodic translates commute and satisfy
+\[
+  \exp\left(-\sum_jh_{j,j+1}\right)=\mu^{\otimes N}.
+\]
+The terminal spectral projections on the retained chain commute with this
+factor and give
+\begin{equation}
+  R_N=\sum_i\lambda_iP_{i,\mathrm{ret}}^{(N)}
+    e^{-H_{N,\mathrm{ret}}}.
+  \label{eq:retained-gibbs}
+\end{equation}
+Applying $(V^\dagger)^{\otimes N}$ and $V^{\otimes N}$ to the two sides of
+\eqref{eq:retained-gibbs} reconstructs $\rho^{(N)}(M)$ exactly.
+
+This reconstruction is not equation~\eqref{eq:physical-gibbs}.  The
+Hamiltonian $H_{N,\mathrm{ret}}$ and the projections
+$P_{i,\mathrm{ret}}^{(N)}$ act on $(\mathbb C^s)^{\otimes N}$, whereas the
+operators in equation~\eqref{eq:physical-gibbs} must act on
+$(\mathbb C^d)^{\otimes N}$.
+
+\section{Failure of direct compression and a finite physical extension}
+
+Direct transport of the retained Gibbs factor gives
+\[
+  V^\dagger e^{-k}V.
+\]
+This matrix vanishes on $(I-E)\mathbb C^d$ and is singular whenever
+$E\neq I$.  It therefore cannot equal the exponential of a finite matrix on
+the physical one-site space.
+
+A viable physical extension begins with
+\begin{equation}
+  k_{\mathrm{phys}}=V^\dagger kV,
+  \qquad
+  e^{-k_{\mathrm{phys}}}
+    =V^\dagger e^{-k}V+(I-E).
+  \label{eq:physical-energy-extension}
+\end{equation}
+The complementary summand supplies finite Gibbs weight one.  If
+$H_{L,\mathrm{phys}}$ is the sum of the periodic translates of
+$k_{\mathrm{phys}}\otimes I$, then
+\begin{equation}
+  e^{-H_{L,\mathrm{phys}}}
+    =\bigotimes_{j=1}^{L}
+      \left(V^\dagger e^{-k}V+I-E\right).
+  \label{eq:physical-chain-extension}
+\end{equation}
+This differs from the false global equality
+\[
+  e^{-H_{L,\mathrm{phys}}}
+    =(V^\dagger)^{\otimes L}e^{-H_{L,\mathrm{ret}}}V^{\otimes L},
+\]
+whose right-hand side vanishes on every complementary or mixed sector.
+
+The physical projectors are naturally defined by
+\[
+  \widehat P_i^{(N)}
+    =(V^\dagger)^{\otimes N}
+      P_{i,\mathrm{ret}}^{(N)}V^{\otimes N}.
+\]
+They are supported on $E^{\otimes N}$ and therefore annihilate every
+complementary and mixed-sector contribution.  The coisometry identity gives
+their projection identities, while equation~\eqref{eq:physical-chain-extension}
+reduces their commutation and the physical density formula to the retained
+equalities.  This finite physical extension is mathematically available; the
+remaining gap is its formalization.
+
+\section{Elimination plan}
+
+The missing formalization consists of the following steps.
+
+\begin{enumerate}
+  \item Prove equation~\eqref{eq:physical-energy-extension} from
+    $VV^\dagger=I_s$.
+  \item Define a fixed physical two-site interaction from
+    $k_{\mathrm{phys}}$ and prove the periodic exponential identity for every
+    chain length at least two.
+  \item Transport the retained terminal projections to the physical chain
+    and prove their projection and commutation identities.
+  \item Combine these identities with exact vertical reconstruction to obtain
+    equation~\eqref{eq:physical-gibbs}.
+\end{enumerate}
+
+The separate one-site ambiguity in the two-site periodic interaction is
+recorded in
+\path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.  Resolving
+either gap does not resolve the other.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
+++ b/docs/paper-gaps/cpsv16_topological_projector_recursion.tex
@@ -280,25 +280,31 @@ and hence
 This is formalized by
 \leanid{MPOTensor.terminalSpectralProjectorRefinement_of_isRFPViaTS}.
 
-\section{Commuting Gibbs conclusion}
+\section{Remaining physical-space construction}
 
 The all-label density identity
 \eqref{eq:source-chain-decomposition}, its commutator
 \eqref{eq:source-commutator}, and the terminal spectral refinement
 \eqref{eq:formalized-terminal-spectral-refinement} are now combined with an
-explicit commuting nearest-neighbor Hamiltonian.  For every chain length
-$N\geq2$, the two-site interaction is the logarithmic multiplicity energy on
-its first site and the identity on its second site.  Its periodic translates
-are diagonal and commute, and their negative exponential is
-$\mu^{\otimes N}$.  The terminal spectral family has cardinality at most the
-physical one-site dimension~$d$ and is extended by zero to exactly $d$
-indices.  This proves the Gibbs form in
-\eqref{eq:source-gibbs-decomposition} for $N\geq2$.
+explicit commuting nearest-neighbor Hamiltonian on the retained vertical
+space.  For every chain length $N\geq2$, the two-site interaction is the
+logarithmic multiplicity energy on its first site and the identity on its
+second site.  Its periodic translates are diagonal and commute, and their
+negative exponential is $\mu^{\otimes N}$.  The terminal spectral family has
+cardinality at most the physical one-site dimension~$d$ and is extended by
+zero to exactly $d$ indices.  This proves the retained-coordinate analogue of
+\eqref{eq:source-gibbs-decomposition}.
 
-The cited source defines the local term on two spins but gives no separate
-convention for a one-site periodic chain.  The remaining length-one boundary,
-and the reason that the unrestricted source statement is not yet marked
-complete, are recorded in
+The adjoint retained-row map reconstructs the physical density operator from
+that analogue.  It does not yet give physical projectors and a finite
+physical-space Hamiltonian because the rectangular vertical map can have a
+nontrivial complementary zero sector.  The necessary complementary-subspace
+extension is recorded in
+\path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+
+Independently, the cited source defines the local term on two spins but gives
+no separate convention for a one-site periodic chain.  This boundary is
+recorded in
 \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
## Summary

Merged PR #4711 constructs a commuting Gibbs Hamiltonian, terminal spectral projectors, and the projector-weighted density formula on the retained vertical coordinates for chain lengths `L >= 2`. It also proves that applying the rectangular sitewise retained-row map to the complete retained sum reconstructs the physical MPDO exactly. Those results do not yet establish the literal CPSV16 physical-space theorem at lines 1013–1016.

This change realigns the reader-facing statements with the proved mathematics:

- it propagates `**Scope restriction (retained vertical coordinates):**` through the 19 source-facing declarations for the multiplicity factor, local and periodic Hamiltonians, transported projectors, retained density formulas, exact reconstruction, bundled predicate, and final RFP theorem;
- it retains `\leanok` only for blueprint statements that explicitly assert both retained vertical coordinates and chain lengths at least two;
- it leaves the literal physical-space CPSV16 theorem without `\lean` or `\leanok`;
- it restores the physical complementary-subspace construction as an independent paper gap, separate from the length-one convention.

## Source faithfulness

The retained theorem now states that the terminal coefficients `lambda_i` are independent of the chain length. The unformalized physical theorem states that both the coefficients and one fixed Hermitian two-site interaction are chosen independently of `L`, with `H_L` defined as the periodic sum of its translates.

The physical-complement gap is documented in `docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. For the retained-row coisometry `V`, with `E = Vᴴ V` and retained logarithmic energy `k`, the viable finite physical extension begins with

```text
K = Vᴴ k V,
exp(-K) = Vᴴ exp(-k) V + I - E.
```

On a chain, the lifted terminal projectors are supported on `E^⊗L` and annihilate the complementary and mixed sectors. The remaining work is to formalize this physical extension, its projector identities, locality, commutation, and the literal physical density equality. The separate two-site convention at `L = 1` remains recorded in `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`.

## Validation

Validated exact head `3236cf41ee979541632860873d4b5d1690bfe1ec` against base `60b8e624d175db76ee3d75808a95768b657dc5cf`:

- `lake exe cache get`;
- `lake env lean TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean`;
- `lake build TNLean.MPS.MPDO.TopologicalGibbsHamiltonian` (9,124 jobs);
- `lake build TNLean` (9,740 jobs; existing unrelated warnings only);
- exact proof-body audit: stripping nested Lean comments/docstrings gives identical base/head code, with matching SHA-256 `85991abc18d425de51902fd5e506df81c10876504d01d88d043e419a18a5b460`;
- 19/19 retained-coordinate scope markers; no old all-positive-length blueprint label;
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`;
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`;
- import-aggregator tests/currentness and numbered-file policy;
- no new Lean lines over 100 characters; `git diff --check`;
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci --diff-base origin/main --diff-head HEAD` (affected chapter 213/213);
- `cd blueprint && leanblueprint checkdecls`;
- `leanblueprint web` and `leanblueprint pdf` (728-page PDF; only the repository-existing `thm:dim_preserved` reference warnings);
- standalone `latexmk -pdf` builds for all three changed paper-gap notes (2, 3, and 6 pages);
- visual inspection of blueprint printed pages 713--715, every changed standalone gap-note page, and the generated web rendering.

Addresses #4685

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint-only scope clarification; no Lean proof or API changes, so risk is limited to reader misinterpretation if prose drifts from formalized claims.
> 
> **Overview**
> **Realigns reader-facing statements** with what is already proved: the commuting Gibbs Hamiltonian, projectors, and density formula live on **retained vertical coordinates**; sitewise reconstruction of the physical MPDO does **not** yet establish the literal CPSV16 physical-space theorem at lines 1013–1016.
> 
> In `TopologicalGibbsHamiltonian.lean`, the module header and **19 source-facing docstrings** now carry `**Scope restriction (retained vertical coordinates):**` and point to `docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. Wording shifts from “physical-index” to **retained** where projectors still act on the retained chain (e.g. `physicalIndexedTopologicalSpectralProjectorSucc`). The top-level theorem doc is retitled **Retained-coordinate Gibbs decomposition**.
> 
> The blueprint renames the Gibbs definition/theorem to **retained-coordinate** form, adds scope restrictions, and states that adjoint retained-row reconstruction is weaker than physical-space projectors and a finite physical Hamiltonian. A new **physical-coordinate** theorem (`thm:mpdo_physical_coordinate_gibbs_at_least_two`) states the CPSV16 target **without** `\lean` or `\leanok`.
> 
> New gap doc `cpsv16_topological_gibbs_physical_complement.tex` documents the complementary zero sector, why direct compression fails, and a finite extension via `k_phys = V†kV` and `exp(-k_phys) = V† exp(-k) V + (I-E)`. Related updates in `cpsv16_topological_gibbs_length_one.tex` and `cpsv16_topological_projector_recursion.tex` separate the length-one boundary from this physical complement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3236cf41ee979541632860873d4b5d1690bfe1ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->