### PR TITLE
doc(MPS/MPDO): clarify Gibbs length-one source boundary

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -2030,18 +2030,20 @@ separate step.
     reconstruction of the retained density operator.
 \end{proof}
 
-\begin{theorem}[Source Gibbs statement at every positive length]%
-    \label{thm:mpdo_topological_gibbs_all_positive_lengths}
-    \uses{thm:mpdo_topological_gibbs_at_least_two}
-    Under the hypotheses of
-    Theorem~\ref{thm:mpdo_topological_gibbs_at_least_two}, the same conclusion
-    holds for every $L>0$, including $L=1$.
+\begin{remark}[Printed length-one domain boundary]%
+    \label{rem:mpdo_topological_gibbs_length_one_boundary}
+    Definition~4.8 of \cite{Cirac2016MPDO_arXiv} lets a local operator act on
+    the first two spins and translates it around the periodic chain.  Thus its
+    construction has domain $L\geq2$.  The periodic identification $L+1=1$
+    identifies site labels, but supplies neither a map from two-site operators
+    to one-site operators nor a multiplicity for the coincident edge.
 
-    The cited passage does not specify how the two-site local term is
-    interpreted on a one-site periodic chain.  Consequently this unrestricted
-    source statement is not yet marked complete; see
+    Theorem~4.15 is printed without an explicit lower bound on $L$, but its
+    $L=1$ instance is therefore undefined without an author or erratum
+    convention.  The preceding theorem covers the complete domain of
+    Definition~4.8; no length-one theorem is asserted.  See
     \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
-\end{theorem}
+\end{remark}
 
 \begin{definition}[Full-support specialization of one fusion layer]%
     \label{def:mpdo_full_support_virtual_projector_one_fusion}

--- a/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
+++ b/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
@@ -7,7 +7,7 @@
 
 \input{./command}
 
-\title{The Length-One Boundary of the Topological Gibbs Decomposition}
+\title{The Domain Boundary of the Topological Gibbs Decomposition}
 \author{}
 \date{2026-07-23}
 
@@ -16,8 +16,7 @@
 
 \section{Source range}
 
-The final paragraph of the proof following Theorem~4.14 in
-\cite[lines~1013--1016]{Cirac2016MPDO_arXiv} writes
+Theorem~4.15 in \cite[lines~999--1016]{Cirac2016MPDO_arXiv} writes
 \[
   \rho^{(N)}(M)
     =\sum_{i=1}^{d}\lambda_iP_i^{(N)}e^{-H_N},
@@ -26,9 +25,11 @@ The final paragraph of the proof following Theorem~4.14 in
 \]
 where $H_N=\sum_i h_{i,i+1}$ is a translationally invariant commuting
 nearest-neighbor Hamiltonian.  Definition~4.8
-\cite[lines~831--850]{Cirac2016MPDO_arXiv} defines the local interaction by
+\cite[lines~829--847]{Cirac2016MPDO_arXiv} defines the local interaction by
 letting a matrix $h$ act on the first two spins and translating that
-two-spin operator around the chain.
+two-spin operator around the chain.  This construction has domain $N\geq2$:
+the periodic identification $N+1=1$ identifies site labels, but does not
+identify the two tensor factors on which $h$ acts.
 
 \section{The formalized range}
 
@@ -58,21 +59,25 @@ self-adjoint idempotents and commute with the Gibbs factor, so this gives
 exactly $d$ summands without asserting that the number of nonzero terminal
 sectors equals~$d$.
 
-\section{Length one}
+\section{Printed domain boundary}
 
-At $N=1$, Definition~4.8 supplies neither a two-spin window nor a convention
-for the coincident periodic bond $h_{1,1}$.  Replacing it by the one-site
-matrix $\operatorname{diag}(-\log\mu)$, or collapsing the two tensor factors,
-would add a convention not stated in the cited passage.  The formal theorem
-therefore has the following explicit scope restriction:
+At $N=1$, Definition~4.8 supplies neither an operator on the one-site Hilbert
+space nor a convention for the coincident periodic bond $h_{1,1}$.  In
+particular, it gives no map from two-site operators to one-site operators and
+no multiplicity for the self-edge.  Replacing $h$ by
+$\operatorname{diag}(-\log\mu)$, tracing out a tensor factor, restricting to a
+diagonal subspace, or otherwise collapsing the two tensor factors would add a
+convention absent from the cited passage.
+
+The source-defined theorem therefore has the explicit domain
 \[
   N\geq2.
 \]
-The unrestricted source statement remains unmarked until a source-supported
-length-one convention is identified.  Such a convention would remove the
-restriction by defining $H_1$ and proving
-$e^{-H_1}=\mu$; no other part of the terminal spectral argument needs to
-change.
+Theorem~4.15 is printed without stating this lower bound, but its $N=1$
+instance is undefined unless an author or erratum specifies both $H_1$ and
+the coincident-edge convention.  The theorem for $N\geq2$ is the complete
+formalization of the construction supplied by Definition~4.8.  No
+length-one theorem is asserted.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
+++ b/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
@@ -69,7 +69,7 @@ $\operatorname{diag}(-\log\mu)$, tracing out a tensor factor, restricting to a
 diagonal subspace, or otherwise collapsing the two tensor factors would add a
 convention absent from the cited passage.
 
-The source-defined theorem therefore has the explicit domain
+The source construction therefore determines the theorem on the domain
 \[
   N\geq2.
 \]


### PR DESCRIPTION
### Motivation

- CPSV16 Definition 4.8 defines the local interaction by saying that
  “the \(h^{(x)}\) acts on the first two spins” in
  `Papers/1606.00608/MPDO-22-12-17-2.tex:829-847`.
- Theorem 4.15 writes \(H_N=\sum_{i=1}^N h_{i,i+1}\) at
  `Papers/1606.00608/MPDO-22-12-17-2.tex:999-1016`, but gives no map from
  two-site operators to one-site operators and no coincident-edge convention
  at \(N=1\).
- The [official arXiv v4](https://arxiv.org/abs/1606.00608v4) retains this
  wording. Its revision note concerns Theorem 4.9, not the domain of
  Definition 4.8 or Theorem 4.15. The cited background sources
  [arXiv:1511.08090](https://arxiv.org/abs/1511.08090) and
  [arXiv:1210.5601](https://arxiv.org/abs/1210.5601) do not supply a
  length-one folding or self-edge convention.

### Description

- Record in `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex` that
  Definition 4.8 has domain \(N\geq2\) by construction and that \(N=1\)
  requires an author or erratum clarification.
- Replace the blueprint's unsupported all-positive-length theorem entry with
  a remark recording the printed domain boundary, without `\lean{}` or
  `\leanok` tags.
- Leave the proved \(N\geq2\) theorem and all Lean sources unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint pdf`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 99209d7ff5a0a8a455a751cfdc2da3b7c48773c5 --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref 99209d7ff5a0a8a455a751cfdc2da3b7c48773c5`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base 99209d7ff5a0a8a455a751cfdc2da3b7c48773c5 --diff-head HEAD`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_topological_gibbs_length_one.tex`
- Visually inspected the rendered web remark, printed blueprint page 714
  (PDF file page 715), and both pages of the standalone paper-gap PDF.

---

Closes #4712

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX/blueprint documentation only; no Lean or runtime behavior changes.
> 
> **Overview**
> **Documentation-only scope correction** for the CPSV16 topological Gibbs formalization: the proved **L≥2** theorem and Lean proofs are unchanged.
> 
> The blueprint **drops** `thm:mpdo_topological_gibbs_all_positive_lengths` (which extended the Gibbs conclusion to every positive length including L=1 without a source-backed one-site convention) and **adds** `rem:mpdo_topological_gibbs_length_one_boundary`, stating that Definition 4.8 builds the local term on two spins (domain **L≥2**), that periodic wrap only identifies site labels—not two-site operators at L=1—and that Theorem 4.15’s L=1 case is undefined without an author/erratum convention. The remark has **no** `\lean{}` / `\leanok` tags.
> 
> `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex` is reframed from “length one” to **printed domain boundary**: it now argues N≥2 is the complete formalization of Definition 4.8 and explicitly **does not** assert a length-one theorem or leave the unrestricted source statement “unmarked.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1955bed02fa8b0dde93814d39e73699f87784256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->