### PR TITLE
feat(MPS/MPDO): prove physical Gibbs decomposition

### DIFF
--- a/TNLean/Analysis/CoisometricCompression.lean
+++ b/TNLean/Analysis/CoisometricCompression.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+import Mathlib.LinearAlgebra.Matrix.Bilinear
 import TNLean.Algebra.OrthogonalProjection
 import TNLean.Analysis.MarginalSupport
 
@@ -105,5 +107,98 @@ theorem trace_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
     Matrix.trace (Uᴴ * Z * U) = Matrix.trace (U * Uᴴ * Z) := by
       rw [Matrix.trace_mul_cycle]
     _ = Matrix.trace Z := by rw [hU, Matrix.one_mul]
+
+open scoped Norms.Operator in
+/-- Matrix exponential transports across a rectangular intertwiner. -/
+theorem mul_exp_eq_exp_mul_of_mul_eq
+    {r d : Type*} [Fintype r] [DecidableEq r] [Fintype d] [DecidableEq d]
+    (V : Matrix r d ℂ) (A : Matrix d d ℂ) (B : Matrix r r ℂ)
+    (h : V * A = B * V) :
+    V * NormedSpace.exp A = NormedSpace.exp B * V := by
+  have hpow : ∀ n : ℕ, V * A ^ n = B ^ n * V := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+      rw [pow_succ, pow_succ]
+      calc
+        V * (A ^ n * A) = (V * A ^ n) * A := by rw [Matrix.mul_assoc]
+        _ = (B ^ n * V) * A := by rw [ih]
+        _ = B ^ n * (B * V) := by rw [Matrix.mul_assoc, h]
+        _ = (B ^ n * B) * V := by rw [Matrix.mul_assoc]
+  have hleft :
+      HasSum (fun n : ℕ => V * (((n.factorial : ℂ)⁻¹) • A ^ n))
+        (V * NormedSpace.exp A) :=
+    (NormedSpace.exp_series_hasSum_exp' (𝕂 := ℂ) A).map
+      (mulLeftLinearMap d ℂ V)
+      (mulLeftLinearMap d ℂ V).continuous_of_finiteDimensional
+  have hright :
+      HasSum (fun n : ℕ => (((n.factorial : ℂ)⁻¹) • B ^ n) * V)
+        (NormedSpace.exp B * V) :=
+    (NormedSpace.exp_series_hasSum_exp' (𝕂 := ℂ) B).map
+      (mulRightLinearMap r ℂ V)
+      (mulRightLinearMap r ℂ V).continuous_of_finiteDimensional
+  have hseries :
+      (fun n : ℕ => V * (((n.factorial : ℂ)⁻¹) • A ^ n)) =
+        fun n : ℕ => (((n.factorial : ℂ)⁻¹) • B ^ n) * V := by
+    funext n
+    simpa only [Matrix.mul_smul, Matrix.smul_mul] using
+      congrArg (fun X => ((n.factorial : ℂ)⁻¹) • X) (hpow n)
+  have hleft' :
+      HasSum (fun n : ℕ => (((n.factorial : ℂ)⁻¹) • B ^ n) * V)
+        (V * NormedSpace.exp A) := by
+    rw [← hseries]
+    exact hleft
+  exact hleft'.unique hright
+
+/-- Let \(V\) be a coisometry and \(k\) an operator on its codomain. The exponential
+of the compressed negative operator is the expanded exponential on the initial
+space of \(V\), extended by the identity on its orthogonal complement.
+
+This general identity lifts the retained Gibbs factor occurring in CPSV16,
+lines 999–1002, to the ambient physical space. The complement extension is
+not stated in the paper; see
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem exp_neg_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+    {r d : Type*} [Fintype r] [DecidableEq r] [Fintype d] [DecidableEq d]
+    (V : Matrix r d ℂ) (k : Matrix r r ℂ) (hV : V * Vᴴ = 1) :
+    NormedSpace.exp (-(Vᴴ * k * V)) =
+      Vᴴ * NormedSpace.exp (-k) * V + (1 - Vᴴ * V) := by
+  let K := Vᴴ * k * V
+  let P := Vᴴ * V
+  let Q := 1 - P
+  have hVK : V * (-K) = (-k) * V := by
+    simp only [K, Matrix.mul_neg, Matrix.neg_mul, ← Matrix.mul_assoc, hV,
+      Matrix.one_mul]
+  have hPK : P * K = K := by
+    dsimp only [P, K]
+    rw [← Matrix.mul_assoc (Vᴴ * V) (Vᴴ * k) V,
+      Matrix.mul_assoc Vᴴ V (Vᴴ * k), ← Matrix.mul_assoc V Vᴴ k, hV,
+      Matrix.one_mul]
+  have hQnegK : Q * (-K) = (0 : Matrix d d ℂ) * Q := by
+    simp only [Q, Matrix.sub_mul, Matrix.one_mul, Matrix.mul_neg, hPK, sub_self,
+      Matrix.zero_mul, neg_zero]
+  have hVexp : V * NormedSpace.exp (-K) = NormedSpace.exp (-k) * V :=
+    mul_exp_eq_exp_mul_of_mul_eq V (-K) (-k) hVK
+  have hQexp : Q * NormedSpace.exp (-K) = Q := by
+    simpa only [NormedSpace.exp_zero, Matrix.one_mul] using
+      mul_exp_eq_exp_mul_of_mul_eq Q (-K) (0 : Matrix d d ℂ) hQnegK
+  have hPQ : P + Q = 1 := by
+    dsimp only [Q]
+    abel
+  change NormedSpace.exp (-K) = Vᴴ * NormedSpace.exp (-k) * V + Q
+  calc
+    NormedSpace.exp (-K) = 1 * NormedSpace.exp (-K) := by
+      rw [Matrix.one_mul]
+    _ = (P + Q) * NormedSpace.exp (-K) := by rw [hPQ]
+    _ = P * NormedSpace.exp (-K) + Q * NormedSpace.exp (-K) := by
+      rw [Matrix.add_mul]
+    _ = Vᴴ * (V * NormedSpace.exp (-K)) + Q := by
+      rw [hQexp]
+      change (Vᴴ * V) * NormedSpace.exp (-K) + Q =
+        Vᴴ * (V * NormedSpace.exp (-K)) + Q
+      rw [Matrix.mul_assoc]
+    _ = Vᴴ * (NormedSpace.exp (-k) * V) + Q := by rw [hVexp]
+    _ = Vᴴ * NormedSpace.exp (-k) * V + Q := by rw [Matrix.mul_assoc]
 
 end Matrix

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -135,6 +135,7 @@ import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.PhysicalBlocking
+import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondPairwise
@@ -211,6 +212,7 @@ import TNLean.MPS.MPDO.ThermodynamicLimitCounterexample
 import TNLean.MPS.MPDO.TopologicalDensityDecomposition
 import TNLean.MPS.MPDO.TopologicalGibbsHamiltonian
 import TNLean.MPS.MPDO.TopologicalMultiplicityEnergy
+import TNLean.MPS.MPDO.TopologicalPhysicalGibbs
 import TNLean.MPS.MPDO.TopologicalProjectorRecursion
 import TNLean.MPS.MPDO.TopologicalProjectors
 import TNLean.MPS.MPDO.TopologicalTerminalSpectral

--- a/TNLean/MPS/MPDO/PhysicalGibbsEmbedding.lean
+++ b/TNLean/MPS/MPDO/PhysicalGibbsEmbedding.lean
@@ -1,0 +1,406 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Matrix.Normed
+import TNLean.MPS.MPDO.TopologicalGibbsHamiltonian
+
+/-!
+# Generic physical Gibbs embedding
+
+This file develops generic one-site and first-site two-site operators, their
+periodic embeddings, and the exponential of a sum of commuting one-site
+energies.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 999--1016
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d N : ℕ}
+
+/-- A one-site matrix in the configuration indexing used by
+`embedLocalOperator`.
+
+This wrapper will carry the physical one-site energy in the complement
+construction for CPSV16, Definition 4.8, lines 831–847. See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+def oneSiteOperator (k : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin 1 → Fin d) (Fin 1 → Fin d) ℂ :=
+  fun x y ↦ k (x ⟨0, by omega⟩) (y ⟨0, by omega⟩)
+
+private def finOneArrowEquiv (d : ℕ) : (Fin 1 → Fin d) ≃ Fin d where
+  toFun x := x ⟨0, by omega⟩
+  invFun a := fun _ ↦ a
+  left_inv x := by
+    funext i
+    exact congrArg x (Subsingleton.elim _ _)
+  right_inv _ := rfl
+
+private theorem oneSiteOperator_eq_reindexAlgEquiv_symm
+    (A : Matrix (Fin d) (Fin d) ℂ) :
+    oneSiteOperator A =
+      (Matrix.reindexAlgEquiv ℂ ℂ (finOneArrowEquiv d)).symm A := by
+  ext x y
+  rfl
+
+open scoped Matrix.Norms.Operator in
+private theorem exp_oneSiteOperator
+    (A : Matrix (Fin d) (Fin d) ℂ) :
+    NormedSpace.exp (oneSiteOperator A) =
+      oneSiteOperator (NormedSpace.exp A) := by
+  rw [oneSiteOperator_eq_reindexAlgEquiv_symm,
+    oneSiteOperator_eq_reindexAlgEquiv_symm]
+  symm
+  exact NormedSpace.map_exp
+    (Matrix.reindexAlgEquiv ℂ ℂ (finOneArrowEquiv d)).symm
+    (LinearMap.continuous_of_finiteDimensional
+      (Matrix.reindexAlgEquiv ℂ ℂ
+        (finOneArrowEquiv d)).symm.toLinearMap) A
+
+/-- A two-site operator which acts by `k` on the first site and by the
+identity on the second.
+
+This is the fixed two-site form used for the physical Hamiltonian of CPSV16,
+Definition 4.8, lines 831–847. The ambient physical-complement construction
+is recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+def twoSiteFirstOperator (k : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ :=
+  fun x y ↦
+    k (x ⟨0, by omega⟩) (y ⟨0, by omega⟩) *
+      (1 : Matrix (Fin d) (Fin d) ℂ)
+        (x ⟨1, by omega⟩) (y ⟨1, by omega⟩)
+
+/-- A Hermitian first-site operator remains Hermitian when tensored with the
+identity on the second site.
+
+This is the Hermiticity property of the local term in CPSV16,
+Definition 4.8, lines 831–847. See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem twoSiteFirstOperator_isHermitian
+    {k : Matrix (Fin d) (Fin d) ℂ} (hk : k.IsHermitian) :
+    (twoSiteFirstOperator k).IsHermitian := by
+  ext x y
+  simp only [Matrix.conjTranspose_apply, twoSiteFirstOperator, star_mul,
+    Matrix.one_apply]
+  rw [hk.apply]
+  split <;> split <;> simp_all
+
+/-- Embedding a two-site operator which acts only on its first site is the
+one-site embedding at the same periodic position.
+
+This identifies the periodic translates in CPSV16, Definition 4.8,
+lines 831–847, for the physical-complement local term. See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem embedLocalOperator_twoSite_first
+    (hN : 2 ≤ N) (i : Fin N) (k : Matrix (Fin d) (Fin d) ℂ) :
+    embedLocalOperator 2 N hN i (twoSiteFirstOperator k) =
+      embedLocalOperator 1 N (by omega) i (oneSiteOperator k) := by
+  ext σ τ
+  simp only [embedLocalOperator_apply, twoSiteFirstOperator, oneSiteOperator]
+  let j : Fin N := MPSTensor.cyclicForwardSite i 1
+  have hjOffset : (j.val + N - i.val) % N = 1 := by
+    simpa only [j, MPSTensor.cyclicForwardSite] using
+      MPSTensor.offset_mod_eq i.isLt (by omega : 1 < N)
+  have hAgree :
+      AgreesOutsideWindow (d := d) 1 (by omega) i σ τ ↔
+        AgreesOutsideWindow (d := d) 2 hN i σ τ ∧ τ j = σ j := by
+    rw [agreesOutsideWindow_iff, agreesOutsideWindow_iff]
+    constructor
+    · intro h
+      constructor
+      · intro q hq
+        exact h q (fun hq' ↦ hq (by omega))
+      · exact h j (by omega)
+    · rintro ⟨h, hj⟩ q hq
+      by_cases hqTwo : (q.val + N - i.val) % N < 2
+      · have hqOffset : (q.val + N - i.val) % N = 1 := by omega
+        have hqj : q = j := by
+          rw [MPSTensor.eq_cyclic_site_of_offset_eq (Fin.pos i) hqOffset]
+          exact Fin.ext (by simp only [j, MPSTensor.cyclicForwardSite])
+        simpa only [hqj] using hj
+      · exact h q hqTwo
+  have hσZeroTwo :
+      MPSTensor.extractWindow 2 i σ ⟨0, by omega⟩ = σ i := by
+    simp [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt]
+  have hτZeroTwo :
+      MPSTensor.extractWindow 2 i τ ⟨0, by omega⟩ = τ i := by
+    simp [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt]
+  have hσZeroOne :
+      MPSTensor.extractWindow 1 i σ ⟨0, by omega⟩ = σ i := by
+    simp [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt]
+  have hτZeroOne :
+      MPSTensor.extractWindow 1 i τ ⟨0, by omega⟩ = τ i := by
+    simp [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt]
+  have hσOneTwo :
+      MPSTensor.extractWindow 2 i σ ⟨1, by omega⟩ = σ j := by
+    rfl
+  have hτOneTwo :
+      MPSTensor.extractWindow 2 i τ ⟨1, by omega⟩ = τ j := by
+    rfl
+  rw [hσZeroTwo, hτZeroTwo, hσZeroOne, hτZeroOne, hσOneTwo, hτOneTwo,
+    Matrix.one_apply]
+  by_cases hOne : AgreesOutsideWindow (d := d) 1 (by omega) i σ τ
+  · obtain ⟨hTwo, hj⟩ := hAgree.mp hOne
+    rw [if_pos hTwo, if_pos hOne, if_pos hj.symm, mul_one]
+  · by_cases hTwo : AgreesOutsideWindow (d := d) 2 hN i σ τ
+    · have hne : σ j ≠ τ j := by
+        intro hj
+        exact hOne (hAgree.mpr ⟨hTwo, hj.symm⟩)
+      rw [if_pos hTwo, if_neg hOne, if_neg hne, mul_zero]
+    · rw [if_neg hTwo, if_neg hOne]
+
+/-- Embedding a local zero operator gives the zero chain operator. -/
+@[simp]
+private theorem embedLocalOperator_zero
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+  embedLocalOperator (d := d) L N hLN i 0 = 0 := by
+  ext σ τ
+  simp [embedLocalOperator_apply]
+
+/-- Embedding preserves addition of local operators. -/
+private theorem embedLocalOperator_add
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (A B : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    embedLocalOperator (d := d) L N hLN i (A + B) =
+      embedLocalOperator L N hLN i A + embedLocalOperator L N hLN i B := by
+  ext σ τ
+  simp only [embedLocalOperator_apply, Matrix.add_apply]
+  by_cases h : AgreesOutsideWindow (d := d) L hLN i σ τ <;> simp [h]
+
+/-- Embedding preserves complex scalar multiplication. -/
+private theorem embedLocalOperator_smul
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) (c : ℂ)
+    (A : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    embedLocalOperator (d := d) L N hLN i (c • A) =
+      c • embedLocalOperator L N hLN i A := by
+  ext σ τ
+  simp [embedLocalOperator_apply]
+
+/-- Embedding the local identity gives the chain identity. -/
+@[simp]
+private theorem embedLocalOperator_one
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+    embedLocalOperator (d := d) L N hLN i 1 = 1 := by
+  let e := windowComplementEquiv (d := d) L N hLN i
+  apply (Matrix.reindex e e).injective
+  rw [reindex_embedLocalOperator_windowComplement]
+  ext x y
+  simp only [Matrix.reindex_apply, Matrix.one_apply, Matrix.kroneckerMap_apply,
+    mul_ite, mul_one, mul_zero]
+  change (if x.2 = y.2 then if x.1 = y.1 then 1 else 0 else 0) =
+    if e.symm x = e.symm y then 1 else 0
+  simp only [e.symm.injective.eq_iff]
+  by_cases hfst : x.1 = y.1 <;> by_cases hsnd : x.2 = y.2 <;>
+    simp_all [Prod.ext_iff]
+
+/-- Embedding into a fixed cyclic window is a complex algebra homomorphism. -/
+def embedLocalOperatorAlgHom
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
+    Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ →ₐ[ℂ]
+      ChainOperator d N where
+  toFun := embedLocalOperator L N hLN i
+  map_one' := embedLocalOperator_one L N hLN i
+  map_mul' A B := embedLocalOperator_mul L N hLN i A B
+  map_zero' := embedLocalOperator_zero L N hLN i
+  map_add' A B := embedLocalOperator_add L N hLN i A B
+  commutes' c := by
+    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one,
+      embedLocalOperator_smul, embedLocalOperator_one]
+
+open scoped Matrix.Norms.Operator in
+/-- Matrix exponential commutes with embedding into a cyclic window. -/
+theorem exp_embedLocalOperator
+    (L N : ℕ) (hLN : L ≤ N) (i : Fin N)
+    (A : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    NormedSpace.exp (embedLocalOperator L N hLN i A) =
+      embedLocalOperator L N hLN i (NormedSpace.exp A) := by
+  symm
+  exact NormedSpace.map_exp
+    (embedLocalOperatorAlgHom (d := d) L N hLN i)
+    (LinearMap.continuous_of_finiteDimensional
+      (embedLocalOperatorAlgHom (d := d) L N hLN i).toLinearMap) A
+
+/-- A heterogeneous tensor product of one matrix at each site. -/
+private noncomputable def sitewiseMatrixFamily
+    (A : Fin N → Matrix (Fin d) (Fin d) ℂ) : ChainOperator d N :=
+  fun σ τ ↦ ∏ n, A n (σ n) (τ n)
+
+private theorem sitewiseMatrixFamily_mul
+    (A B : Fin N → Matrix (Fin d) (Fin d) ℂ) :
+    sitewiseMatrixFamily A * sitewiseMatrixFamily B =
+      sitewiseMatrixFamily fun n ↦ A n * B n := by
+  classical
+  ext σ τ
+  simp only [Matrix.mul_apply, sitewiseMatrixFamily]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin d)))
+    (fun n a ↦ A n (σ n) a * B n a (τ n))]
+
+private theorem sitewiseMatrixFamily_one :
+    sitewiseMatrixFamily (fun _ : Fin N ↦
+      (1 : Matrix (Fin d) (Fin d) ℂ)) = 1 := by
+  classical
+  ext σ τ
+  simp only [sitewiseMatrixFamily, Matrix.one_apply]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact propext funext_iff.symm
+
+private def sitewiseMatrixFamilyMonoidHom :
+    (Fin N → Matrix (Fin d) (Fin d) ℂ) →*
+      ChainOperator d N where
+  toFun := sitewiseMatrixFamily
+  map_one' := sitewiseMatrixFamily_one
+  map_mul' A B := (sitewiseMatrixFamily_mul A B).symm
+
+private theorem sitewiseMatrixFamily_mulSingle
+    (hN : 1 ≤ N) (i : Fin N) (A : Matrix (Fin d) (Fin d) ℂ) :
+    sitewiseMatrixFamily (Pi.mulSingle i A) =
+      embedLocalOperator 1 N hN i (oneSiteOperator A) := by
+  classical
+  ext σ τ
+  simp only [sitewiseMatrixFamily, embedLocalOperator_apply, oneSiteOperator]
+  have hσ :
+      MPSTensor.extractWindow 1 i σ ⟨0, by omega⟩ = σ i := by
+    simp [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt]
+  have hτ :
+      MPSTensor.extractWindow 1 i τ ⟨0, by omega⟩ = τ i := by
+    simp [MPSTensor.extractWindow, Nat.mod_eq_of_lt i.isLt]
+  rw [hσ, hτ]
+  by_cases hAgree : AgreesOutsideWindow (d := d) 1 hN i σ τ
+  · rw [if_pos hAgree]
+    let S : Fin N → Matrix (Fin d) (Fin d) ℂ := Pi.mulSingle i A
+    change (∏ n, S n (σ n) (τ n)) = A (σ i) (τ i)
+    calc
+      (∏ n, S n (σ n) (τ n)) = S i (σ i) (τ i) := by
+        apply Finset.prod_eq_single i
+        · intro q _ hqi
+          rw [show S q = 1 by
+            simp only [S, Pi.mulSingle_eq_of_ne hqi],
+            Matrix.one_apply, if_pos]
+          rw [agreesOutsideWindow_iff] at hAgree
+          exact (hAgree q (fun hq ↦ hqi (by
+            have hqOffset : (q.val + N - i.val) % N = 0 := by omega
+            simpa [Nat.mod_eq_of_lt i.isLt] using
+              MPSTensor.eq_cyclic_site_of_offset_eq
+                (Fin.pos i) hqOffset))).symm
+        · intro hi
+          exact (hi (Finset.mem_univ i)).elim
+      _ = A (σ i) (τ i) := by
+        rw [show S i = A by simp only [S, Pi.mulSingle_eq_same]]
+  · rw [if_neg hAgree]
+    rw [agreesOutsideWindow_iff] at hAgree
+    push Not at hAgree
+    obtain ⟨q, hqOutside, hq⟩ := hAgree
+    apply Finset.prod_eq_zero (Finset.mem_univ q)
+    have hqi : q ≠ i := by
+      intro hqi
+      subst q
+      simp at hqOutside
+    rw [Pi.mulSingle_eq_of_ne hqi, Matrix.one_apply, if_neg]
+    exact fun h ↦ hq h.symm
+
+/-- Periodic embeddings of one-site operators commute at every pair of
+positions.
+
+This is the generic disjoint one-site commutation used to realize the local
+two-site convention of CPSV16, Definition 4.8, lines 831–847. Its use in the
+physical-complement construction is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem embedLocalOperator_one_commute
+    (hN : 1 ≤ N) (A : Matrix (Fin d) (Fin d) ℂ)
+    (i j : Fin N) :
+    Commute
+      (embedLocalOperator 1 N hN i (oneSiteOperator A))
+      (embedLocalOperator 1 N hN j (oneSiteOperator A)) := by
+  by_cases hij : i = j
+  · subst j
+    exact Commute.refl _
+  · apply embedLocalOperator_commute_of_not_cyclicWindowsOverlap
+    intro hover
+    rcases hover with ⟨q, hqi, hqj⟩
+    rw [MPSTensor.mem_cyclicWindowSupport_iff hN] at hqi hqj
+    have hqiOffset : (q.val + N - i.val) % N = 0 := by omega
+    have hqjOffset : (q.val + N - j.val) % N = 0 := by omega
+    have hqiEq : q = i := by
+      simpa [Nat.mod_eq_of_lt i.isLt] using
+        MPSTensor.eq_cyclic_site_of_offset_eq (Fin.pos i) hqiOffset
+    have hqjEq : q = j := by
+      simpa [Nat.mod_eq_of_lt j.isLt] using
+        MPSTensor.eq_cyclic_site_of_offset_eq (Fin.pos j) hqjOffset
+    exact hij (hqiEq.symm.trans hqjEq)
+
+/-- The exponential of a sum of identical one-site energies is their
+sitewise tensor power. -/
+theorem exp_sum_embedLocalOperator_one
+    (hN : 1 ≤ N) (A : Matrix (Fin d) (Fin d) ℂ) :
+    NormedSpace.exp
+        (∑ i : Fin N,
+          embedLocalOperator 1 N hN i (oneSiteOperator A)) =
+      sitewisePhysicalMatrix (NormedSpace.exp A) N := by
+  let f : Fin N → ChainOperator d N := fun i ↦
+    embedLocalOperator 1 N hN i (oneSiteOperator A)
+  have hpair :
+      ((Finset.univ : Finset (Fin N)) : Set (Fin N)).Pairwise
+        (fun i j ↦ Commute (f i) (f j)) := by
+    intro i _ j _ _
+    exact embedLocalOperator_one_commute hN A i j
+  let x : Fin N → Matrix (Fin d) (Fin d) ℂ :=
+    fun _ ↦ NormedSpace.exp A
+  let g : Fin N → (Fin N → Matrix (Fin d) (Fin d) ℂ) :=
+    fun i ↦ Pi.mulSingle i (x i)
+  have hgpair :
+      ((Finset.univ : Finset (Fin N)) : Set (Fin N)).Pairwise
+        (fun i j ↦ Commute (g i) (g j)) := by
+    intro i _ j _ _
+    exact Pi.mulSingle_apply_commute x i j
+  have hgcomm :
+      ∀ i ∈ (Finset.univ : Finset (Fin N)),
+        ∀ j ∈ (Finset.univ : Finset (Fin N)), i ≠ j →
+          Commute (g i) (g j) :=
+    fun i hi j hj hij ↦ hgpair hi hj hij
+  have hterm (i : Fin N) :
+      NormedSpace.exp (f i) = sitewiseMatrixFamily (g i) := by
+    calc
+      NormedSpace.exp (f i) =
+          embedLocalOperator 1 N hN i
+            (NormedSpace.exp (oneSiteOperator A)) :=
+        exp_embedLocalOperator 1 N hN i (oneSiteOperator A)
+      _ = embedLocalOperator 1 N hN i
+          (oneSiteOperator (NormedSpace.exp A)) := by
+        rw [exp_oneSiteOperator]
+      _ = sitewiseMatrixFamily (g i) := by
+        exact (sitewiseMatrixFamily_mulSingle hN i (NormedSpace.exp A)).symm
+  change NormedSpace.exp (∑ i ∈ Finset.univ, f i) = _
+  rw [Matrix.exp_sum_of_commute Finset.univ f hpair]
+  calc
+    _ = Finset.univ.noncommProd
+        (fun i ↦ sitewiseMatrixFamily (g i))
+        (fun i hi j hj hij ↦
+          Commute.map (hgcomm i hi j hj hij) sitewiseMatrixFamilyMonoidHom) :=
+      Finset.noncommProd_congr rfl (fun i _ ↦ hterm i) _
+    _ = sitewiseMatrixFamily x := by
+      have hmap := Finset.map_noncommProd Finset.univ g hgcomm
+        sitewiseMatrixFamilyMonoidHom
+      calc
+        _ = sitewiseMatrixFamilyMonoidHom
+            (Finset.univ.noncommProd g hgcomm) := hmap.symm
+        _ = sitewiseMatrixFamilyMonoidHom x := by
+          congr 1
+          exact Finset.noncommProd_mulSingle x
+        _ = sitewiseMatrixFamily x := rfl
+    _ = sitewisePhysicalMatrix (NormedSpace.exp A) N := rfl
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -41,7 +41,7 @@ end Matrix
 
 namespace MPOTensor
 
-variable {d D e : ℕ}
+variable {d D e f : ℕ}
 
 open PhysicalSectorFactorization
 
@@ -51,6 +51,21 @@ noncomputable def sitewisePhysicalMatrix
     (V : Matrix (Fin e) (Fin d) ℂ) (N : ℕ) :
     Matrix (Fin N → Fin e) (Fin N → Fin d) ℂ :=
   fun s t ↦ ∏ n : Fin N, V (s n) (t n)
+
+/-- Sitewise tensor powers preserve rectangular matrix multiplication. -/
+theorem sitewisePhysicalMatrix_mul
+    (V : Matrix (Fin e) (Fin d) ℂ)
+    (W : Matrix (Fin d) (Fin f) ℂ) (N : ℕ) :
+    sitewisePhysicalMatrix V N * sitewisePhysicalMatrix W N =
+      sitewisePhysicalMatrix (V * W) N := by
+  classical
+  ext s t
+  simp only [Matrix.mul_apply, sitewisePhysicalMatrix]
+  simp_rw [← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin d)))
+    (fun n a ↦ V (s n) a * W a (t n))]
 
 /-- Conjugate transpose commutes with the sitewise tensor power. -/
 theorem sitewisePhysicalMatrix_conjTranspose

--- a/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
@@ -1,0 +1,685 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.CoisometricCompression
+import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
+
+/-!
+# Physical-space topological Gibbs Hamiltonian
+
+This file extends the retained-coordinate Gibbs decomposition to the ambient
+physical chain. The retained-row coisometry supplies a finite energy on the
+physical support and zero energy on its orthogonal complement.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  lines 999--1016
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor.BNTFusionTensorClause
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- The one-site multiplicity energy compressed back to the ambient physical
+coordinates.
+
+The retained energy is the logarithmic factor from CPSV16, lines 999–1002.
+Its compression to the ambient physical space is the construction recorded
+in `docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`; the
+complement extension itself is not stated in CPSV16. -/
+def physicalMultiplicityEnergy (H : BNTFusionTensorClause M) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  H.verticalCoisometryᴴ * H.retainedMultiplicityEnergy *
+    H.verticalCoisometry
+
+/-- The ambient physical one-site energy is Hermitian.
+
+This supplies the Hermiticity required by CPSV16, Definition 4.8,
+lines 831–847, for the physical-complement construction documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem physicalMultiplicityEnergy_isHermitian
+    (H : BNTFusionTensorClause M) :
+    H.physicalMultiplicityEnergy.IsHermitian := by
+  exact Matrix.isHermitian_conjTranspose_mul_mul H.verticalCoisometry
+    H.retainedMultiplicityEnergy_isHermitian
+
+/-- The retained multiplicity weight transported to physical coordinates
+and extended by the identity on the orthogonal complement.
+
+The retained factor occurs in CPSV16, lines 999–1002. The identity extension
+on the physical complement is not stated there; it is recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+def physicalMultiplicityWeight (H : BNTFusionTensorClause M) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  H.verticalCoisometryᴴ * H.retainedMultiplicityOperator *
+      H.verticalCoisometry +
+    (1 - H.verticalCoisometryᴴ * H.verticalCoisometry)
+
+/-- Exponentiating the negative ambient one-site energy gives the retained
+weight transported to physical coordinates, with the identity on the
+orthogonal complement.
+
+The retained exponential identity is CPSV16, lines 999–1002. The complement
+extension is a general coisometric-compression identity, not a statement of
+CPSV16; see
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem exp_neg_physicalMultiplicityEnergy
+    (H : BNTFusionTensorClause M) :
+    NormedSpace.exp (-H.physicalMultiplicityEnergy) =
+      H.physicalMultiplicityWeight := by
+  rw [physicalMultiplicityEnergy, physicalMultiplicityWeight,
+    Matrix.exp_neg_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+      H.verticalCoisometry H.retainedMultiplicityEnergy H.coisometry,
+    H.exp_neg_retainedMultiplicityEnergy]
+
+/-- The retained-row coisometry intertwines the ambient physical Gibbs
+weight with the retained multiplicity operator.
+
+This is the one-site support identity used to lift the retained factor from
+CPSV16, lines 999–1002, to the physical complement. The complement extension
+is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem verticalCoisometry_mul_physicalMultiplicityWeight
+    (H : BNTFusionTensorClause M) :
+    H.verticalCoisometry * H.physicalMultiplicityWeight =
+      H.retainedMultiplicityOperator * H.verticalCoisometry := by
+  unfold physicalMultiplicityWeight
+  simp only [Matrix.mul_add, Matrix.mul_sub, Matrix.mul_one]
+  rw [← Matrix.mul_assoc H.verticalCoisometry H.verticalCoisometryᴴ,
+    H.coisometry, Matrix.one_mul]
+  rw [sub_self, add_zero]
+  simp only [← Matrix.mul_assoc, H.coisometry, Matrix.one_mul]
+
+/-- The adjoint retained-row map intertwines the retained multiplicity
+operator with the ambient physical Gibbs weight.
+
+This is the adjoint one-site support identity used to lift the retained
+factor from CPSV16, lines 999–1002. The complement extension is documented
+in `docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem physicalMultiplicityWeight_mul_conjTranspose_verticalCoisometry
+    (H : BNTFusionTensorClause M) :
+    H.physicalMultiplicityWeight * H.verticalCoisometryᴴ =
+      H.verticalCoisometryᴴ * H.retainedMultiplicityOperator := by
+  unfold physicalMultiplicityWeight
+  simp only [Matrix.add_mul, Matrix.sub_mul, Matrix.one_mul]
+  rw [Matrix.mul_assoc H.verticalCoisometryᴴ H.verticalCoisometry,
+    H.coisometry, Matrix.mul_one]
+  rw [sub_self, add_zero]
+  simp only [Matrix.mul_assoc, H.coisometry, Matrix.mul_one]
+
+/-- On every chain, the sitewise retained-row coisometry intertwines the
+ambient physical Gibbs factor with the retained multiplicity factor.
+
+This is the chain version of the support transport used in the physical
+formula of CPSV16, lines 1013–1016. Its complement construction is recorded
+in `docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem sitewiseVerticalCoisometry_mul_physicalMultiplicityWeight
+    (H : BNTFusionTensorClause M) (L : ℕ) :
+    MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry L *
+        MPOTensor.sitewisePhysicalMatrix H.physicalMultiplicityWeight L =
+      MPOTensor.sitewisePhysicalMatrix H.retainedMultiplicityOperator L *
+        MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry L := by
+  rw [MPOTensor.sitewisePhysicalMatrix_mul,
+    H.verticalCoisometry_mul_physicalMultiplicityWeight,
+    MPOTensor.sitewisePhysicalMatrix_mul]
+
+/-- On every chain, the sitewise adjoint retained-row map intertwines the
+retained multiplicity factor with the ambient physical Gibbs factor.
+
+This is the adjoint chain support transport used in the physical formula of
+CPSV16, lines 1013–1016. Its complement construction is recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem sitewisePhysicalMultiplicityWeight_mul_conjTranspose_verticalCoisometry
+    (H : BNTFusionTensorClause M) (L : ℕ) :
+    MPOTensor.sitewisePhysicalMatrix H.physicalMultiplicityWeight L *
+        MPOTensor.sitewisePhysicalMatrix H.verticalCoisometryᴴ L =
+      MPOTensor.sitewisePhysicalMatrix H.verticalCoisometryᴴ L *
+        MPOTensor.sitewisePhysicalMatrix H.retainedMultiplicityOperator L := by
+  rw [MPOTensor.sitewisePhysicalMatrix_mul,
+    H.physicalMultiplicityWeight_mul_conjTranspose_verticalCoisometry,
+    MPOTensor.sitewisePhysicalMatrix_mul]
+
+/-- The sitewise tensor power of the retained-row coisometry remains a
+coisometry.
+
+This is the chain-level coordinate property used in the physical
+reconstruction at CPSV16, lines 999 and 1013–1016. The rectangular
+orientation is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem sitewiseVerticalCoisometry_mul_conjTranspose
+    (H : BNTFusionTensorClause M) (L : ℕ) :
+    MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry L *
+        (MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry L)ᴴ =
+      1 := by
+  rw [MPOTensor.sitewisePhysicalMatrix_mul_conjTranspose,
+    H.coisometry, MPOTensor.sitewisePhysicalMatrix_one]
+
+/-- The fixed physical two-site Gibbs term: the ambient one-site energy on
+the first site and the identity on the second.
+
+This has the two-site form of CPSV16, Definition 4.8, lines 831–847, and is
+used for the Hamiltonian at lines 1013–1016. Its physical-complement
+construction is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+def physicalTopologicalGibbsLocalTerm (H : BNTFusionTensorClause M) :
+    Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ :=
+  MPOTensor.twoSiteFirstOperator H.physicalMultiplicityEnergy
+
+/-- The fixed physical two-site Gibbs term is Hermitian.
+
+This verifies the local Hermiticity condition in CPSV16, Definition 4.8,
+lines 831–847, for the physical-complement construction documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem physicalTopologicalGibbsLocalTerm_isHermitian
+    (H : BNTFusionTensorClause M) :
+    H.physicalTopologicalGibbsLocalTerm.IsHermitian :=
+  MPOTensor.twoSiteFirstOperator_isHermitian
+    H.physicalMultiplicityEnergy_isHermitian
+
+/-- The periodic translation-invariant physical Gibbs Hamiltonian on a chain
+of length `N + 2`.
+
+This is the physical-space `H_N = ∑ᵢ h_{i,i+1}` of CPSV16,
+lines 1013–1016, with the two-site convention of Definition 4.8,
+lines 831–847. The complement choice is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. The
+length-at-least-two scope is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+def physicalTopologicalGibbsHamiltonianSuccSucc
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    Matrix (Fin (N + 2) → Fin d) (Fin (N + 2) → Fin d) ℂ :=
+  ∑ i : Fin (N + 2),
+    MPOTensor.embedLocalOperator 2 (N + 2) (by omega) i
+      H.physicalTopologicalGibbsLocalTerm
+
+/-- Periodic translates of the physical two-site Gibbs term commute
+pairwise.
+
+This is `[h_{i-1,i}, h_{i,i+1}] = 0` from CPSV16, lines 1013–1016, for
+the physical-complement construction documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. The
+length-at-least-two scope is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem physicalTopologicalGibbsBondSuccSucc_commute
+    (H : BNTFusionTensorClause M) (N : ℕ)
+    (i j : Fin (N + 2)) :
+    Commute
+      (MPOTensor.embedLocalOperator 2 (N + 2) (by omega) i
+        H.physicalTopologicalGibbsLocalTerm)
+      (MPOTensor.embedLocalOperator 2 (N + 2) (by omega) j
+        H.physicalTopologicalGibbsLocalTerm) := by
+  rw [physicalTopologicalGibbsLocalTerm,
+    MPOTensor.embedLocalOperator_twoSite_first,
+    MPOTensor.embedLocalOperator_twoSite_first]
+  exact MPOTensor.embedLocalOperator_one_commute (by omega)
+    H.physicalMultiplicityEnergy i j
+
+/-- The physical Gibbs factor is the tensor power of the retained
+multiplicity weight transported to physical coordinates and extended by the
+identity on the orthogonal complement.
+
+This is the physical-space exponential factor `e^{-H_N}` in CPSV16,
+lines 1013–1016. The complement extension is not stated in CPSV16; see
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. The
+length-at-least-two scope is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem exp_neg_physicalTopologicalGibbsHamiltonianSuccSucc
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    NormedSpace.exp (-H.physicalTopologicalGibbsHamiltonianSuccSucc N) =
+      MPOTensor.sitewisePhysicalMatrix H.physicalMultiplicityWeight
+        (N + 2) := by
+  have hneg (i : Fin (N + 2)) :
+      -MPOTensor.embedLocalOperator 1 (N + 2) (by omega) i
+          (MPOTensor.oneSiteOperator H.physicalMultiplicityEnergy) =
+        MPOTensor.embedLocalOperator 1 (N + 2) (by omega) i
+          (MPOTensor.oneSiteOperator (-H.physicalMultiplicityEnergy)) := by
+    calc
+      -MPOTensor.embedLocalOperator 1 (N + 2) (by omega) i
+          (MPOTensor.oneSiteOperator H.physicalMultiplicityEnergy) =
+          MPOTensor.embedLocalOperator 1 (N + 2) (by omega) i
+            (-MPOTensor.oneSiteOperator H.physicalMultiplicityEnergy) :=
+        (map_neg
+          (MPOTensor.embedLocalOperatorAlgHom (d := d) 1 (N + 2)
+            (by omega) i)
+          (MPOTensor.oneSiteOperator H.physicalMultiplicityEnergy)).symm
+      _ = MPOTensor.embedLocalOperator 1 (N + 2) (by omega) i
+          (MPOTensor.oneSiteOperator (-H.physicalMultiplicityEnergy)) := by
+        congr 1
+  unfold physicalTopologicalGibbsHamiltonianSuccSucc
+  rw [← Finset.sum_neg_distrib]
+  simp_rw [physicalTopologicalGibbsLocalTerm,
+    MPOTensor.embedLocalOperator_twoSite_first, hneg]
+  rw [MPOTensor.exp_sum_embedLocalOperator_one,
+    H.exp_neg_physicalMultiplicityEnergy]
+
+/-- The `Fin d`-indexed terminal projector transported from retained
+coordinates to the ambient physical chain of length `N + 2`.
+
+This is the physical projector `P_i^(N)` in CPSV16, lines 1013–1016. Its
+transport through the rectangular retained-row coisometry is the construction
+recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. The
+length-at-least-two scope is recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+def physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (N : ℕ) (i : Fin d) :
+    Matrix (Fin (N + 2) → Fin d) (Fin (N + 2) → Fin d) ℂ :=
+  let W := MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry (N + 2)
+  Wᴴ *
+      H.physicalIndexedTopologicalSpectralProjectorSucc hM (N + 1) i *
+    W
+
+/-- Every transported `Fin d`-indexed ambient physical operator is an
+orthogonal projection.
+
+This proves the projection property required for `P_i^(N)` in CPSV16,
+lines 1013–1016. The physical-complement transport is recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`, and the
+length-at-least-two scope in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc_isOrthogonalProjection
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
+    (N : ℕ) (i : Fin d) :
+    (H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+        hM N i).IsHermitian ∧
+      H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+          hM N i *
+        H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+          hM N i =
+        H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+          hM N i := by
+  let W := MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry (N + 2)
+  let P :=
+    H.physicalIndexedTopologicalSpectralProjectorSucc hM (N + 1) i
+  have hP :
+      P.IsHermitian ∧ P * P = P :=
+    H.physicalIndexedTopologicalSpectralProjectorSucc_isOrthogonalProjection
+      hM hLI (N + 1) i
+  have hPstar : IsStarProjection P := by
+    rw [isStarProjection_iff']
+    exact ⟨hP.2, by
+      simpa [Matrix.star_eq_conjTranspose] using hP.1.eq⟩
+  have hW : W * Wᴴ = 1 :=
+    H.sitewiseVerticalCoisometry_mul_conjTranspose (N + 2)
+  have hLift :=
+    IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
+      hPstar W hW
+  rw [isStarProjection_iff'] at hLift
+  exact ⟨by
+    change (Wᴴ * P * W)ᴴ = Wᴴ * P * W
+    simpa [Matrix.star_eq_conjTranspose] using hLift.2, hLift.1⟩
+
+/-- Distinct zero-padded retained terminal projectors multiply to zero.
+
+This is the retained-coordinate orthogonality underlying the physical
+projectors in CPSV16, lines 1013–1016. The zero-padding and coordinate scope
+are documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`. -/
+theorem physicalIndexedTopologicalSpectralProjectorSucc_mul_eq_zero
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
+    (N : ℕ) {i j : Fin d} (hij : i ≠ j) :
+    H.physicalIndexedTopologicalSpectralProjectorSucc hM N i *
+        H.physicalIndexedTopologicalSpectralProjectorSucc hM N j =
+      0 := by
+  classical
+  by_cases hi : ∃ s, H.terminalSpectralEmbedding s = i
+  · obtain ⟨s, rfl⟩ := hi
+    rw [physicalIndexedTopologicalSpectralProjectorSucc,
+      H.terminalSpectralEmbedding.injective.extend_apply]
+    by_cases hj : ∃ t, H.terminalSpectralEmbedding t = j
+    · obtain ⟨t, rfl⟩ := hj
+      have hst : s ≠ t := by
+        intro hst
+        subst t
+        exact hij rfl
+      rw [physicalIndexedTopologicalSpectralProjectorSucc,
+        H.terminalSpectralEmbedding.injective.extend_apply]
+      exact
+        H.topologicalSpectralProjectorSucc_mul_eq_zero hM hLI N hst
+    · rw [physicalIndexedTopologicalSpectralProjectorSucc,
+        Function.extend_apply' _ _ _ hj, Matrix.mul_zero]
+  · rw [physicalIndexedTopologicalSpectralProjectorSucc,
+      Function.extend_apply' _ _ _ hi, Matrix.zero_mul]
+
+/-- Distinct transported `Fin d`-indexed ambient physical projectors multiply
+to zero.
+
+This is the pairwise orthogonality of the physical projectors in CPSV16,
+lines 1013–1016. Their transport and complement support are recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`, and the
+length-at-least-two scope in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc_mul_eq_zero
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent)
+    (N : ℕ) {i j : Fin d} (hij : i ≠ j) :
+    H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc hM N i *
+        H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc hM N j =
+      0 := by
+  let W := MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry (N + 2)
+  let P :=
+    H.physicalIndexedTopologicalSpectralProjectorSucc hM (N + 1) i
+  let Q :=
+    H.physicalIndexedTopologicalSpectralProjectorSucc hM (N + 1) j
+  have hW : W * Wᴴ = 1 :=
+    H.sitewiseVerticalCoisometry_mul_conjTranspose (N + 2)
+  have hPQ : P * Q = 0 :=
+    H.physicalIndexedTopologicalSpectralProjectorSucc_mul_eq_zero
+      hM hLI (N + 1) hij
+  change (Wᴴ * P * W) * (Wᴴ * Q * W) = 0
+  calc
+    (Wᴴ * P * W) * (Wᴴ * Q * W) =
+        Wᴴ * (P * ((W * Wᴴ) * (Q * W))) := by
+      simp only [Matrix.mul_assoc]
+    _ = Wᴴ * (P * (Q * W)) := by rw [hW, Matrix.one_mul]
+    _ = Wᴴ * ((P * Q) * W) := by rw [Matrix.mul_assoc]
+    _ = 0 := by rw [hPQ, Matrix.zero_mul, Matrix.mul_zero]
+
+/-- The retained sitewise multiplicity operator is the retained
+multiplicity-weight factor at chain length `N + 2`.
+
+This is the retained factor in CPSV16, lines 999–1002 and 1013–1016. The
+physical-coordinate use of this identity is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`, with the
+length-at-least-two scope in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem sitewiseRetainedMultiplicityOperator_eq_topologicalMultiplicityWeightFactorSucc
+    (H : BNTFusionTensorClause M) (N : ℕ) :
+    MPOTensor.sitewisePhysicalMatrix H.retainedMultiplicityOperator
+        (N + 2) =
+      H.topologicalMultiplicityWeightFactorSucc (N + 1) := by
+  rw [H.topologicalMultiplicityWeightFactorSucc_eq_diagonal]
+  ext x y
+  simp only [MPOTensor.sitewisePhysicalMatrix, retainedMultiplicityOperator,
+    Matrix.diagonal_apply]
+  by_cases hxy : x = y
+  · subst y
+    simp
+  · rw [if_neg hxy]
+    have hcoord : ∃ n, x n ≠ y n := by
+      simpa only [not_forall, not_not] using
+        (not_congr funext_iff).mp hxy
+    obtain ⟨n, hn⟩ := hcoord
+    apply Finset.prod_eq_zero (Finset.mem_univ n)
+    rw [if_neg hn]
+
+/-- Every transported `Fin d`-indexed ambient physical projector commutes
+with the ambient physical Gibbs factor.
+
+This is `[P_i^(N), e^{-H_N}] = 0` from CPSV16, lines 1013–1016. The
+physical-complement transport and mixed-sector cancellation are recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`, and the
+length-at-least-two scope in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc_commutes_gibbsFactor
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (N : ℕ) (i : Fin d) :
+    H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc hM N i *
+        NormedSpace.exp
+          (-H.physicalTopologicalGibbsHamiltonianSuccSucc N) =
+      NormedSpace.exp
+          (-H.physicalTopologicalGibbsHamiltonianSuccSucc N) *
+        H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+          hM N i := by
+  let W := MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry (N + 2)
+  let P :=
+    H.physicalIndexedTopologicalSpectralProjectorSucc hM (N + 1) i
+  let Gp :=
+    MPOTensor.sitewisePhysicalMatrix H.physicalMultiplicityWeight (N + 2)
+  let Gr :=
+    MPOTensor.sitewisePhysicalMatrix H.retainedMultiplicityOperator (N + 2)
+  have hleft : W * Gp = Gr * W :=
+    H.sitewiseVerticalCoisometry_mul_physicalMultiplicityWeight (N + 2)
+  have hright : Gp * Wᴴ = Wᴴ * Gr := by
+    dsimp only [W]
+    rw [MPOTensor.sitewisePhysicalMatrix_conjTranspose]
+    exact
+      H.sitewisePhysicalMultiplicityWeight_mul_conjTranspose_verticalCoisometry
+        (N + 2)
+  have hcomm : P * Gr = Gr * P := by
+    have h :=
+      H.physicalIndexedTopologicalSpectralProjectorSucc_commutes_gibbsFactor
+        hM N i
+    rw [H.exp_neg_topologicalGibbsHamiltonianSuccSucc,
+      ← H.sitewiseRetainedMultiplicityOperator_eq_topologicalMultiplicityWeightFactorSucc]
+      at h
+    exact h
+  rw [H.exp_neg_physicalTopologicalGibbsHamiltonianSuccSucc]
+  change (Wᴴ * P * W) * Gp = Gp * (Wᴴ * P * W)
+  calc
+    (Wᴴ * P * W) * Gp = Wᴴ * (P * (W * Gp)) := by
+      simp only [Matrix.mul_assoc]
+    _ = Wᴴ * (P * (Gr * W)) := by rw [hleft]
+    _ = Wᴴ * ((P * Gr) * W) := by rw [Matrix.mul_assoc]
+    _ = Wᴴ * ((Gr * P) * W) := by rw [hcomm]
+    _ = (Wᴴ * Gr) * (P * W) := by simp only [Matrix.mul_assoc]
+    _ = (Gp * Wᴴ) * (P * W) := by rw [hright]
+    _ = Gp * (Wᴴ * P * W) := by simp only [Matrix.mul_assoc]
+
+/-- Multiplying one transported physical projector by the ambient Gibbs
+factor is exactly the adjoint sitewise transport of the corresponding
+retained projector/Gibbs product.
+
+This is the per-sector transport behind the physical density formula in
+CPSV16, lines 1013–1016. The complement support argument is recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`, and the
+length-at-least-two scope in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem physicalIndexedAmbientProjector_mul_gibbsFactor_eq_transport
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (N : ℕ) (i : Fin d) :
+    H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc hM N i *
+        NormedSpace.exp
+          (-H.physicalTopologicalGibbsHamiltonianSuccSucc N) =
+      (MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry (N + 2))ᴴ *
+          (H.physicalIndexedTopologicalSpectralProjectorSucc
+              hM (N + 1) i *
+            NormedSpace.exp
+              (-H.topologicalGibbsHamiltonianSuccSucc N)) *
+        MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry
+          (N + 2) := by
+  let W := MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry (N + 2)
+  let P :=
+    H.physicalIndexedTopologicalSpectralProjectorSucc hM (N + 1) i
+  let Gp :=
+    MPOTensor.sitewisePhysicalMatrix H.physicalMultiplicityWeight (N + 2)
+  let Gr :=
+    MPOTensor.sitewisePhysicalMatrix H.retainedMultiplicityOperator (N + 2)
+  have hleft : W * Gp = Gr * W :=
+    H.sitewiseVerticalCoisometry_mul_physicalMultiplicityWeight (N + 2)
+  rw [H.exp_neg_physicalTopologicalGibbsHamiltonianSuccSucc,
+    H.exp_neg_topologicalGibbsHamiltonianSuccSucc,
+    ← H.sitewiseRetainedMultiplicityOperator_eq_topologicalMultiplicityWeightFactorSucc]
+  change (Wᴴ * P * W) * Gp = Wᴴ * (P * Gr) * W
+  calc
+    (Wᴴ * P * W) * Gp = Wᴴ * (P * (W * Gp)) := by
+      simp only [Matrix.mul_assoc]
+    _ = Wᴴ * (P * (Gr * W)) := by rw [hleft]
+    _ = Wᴴ * (P * Gr) * W := by simp only [Matrix.mul_assoc]
+
+/-- The physical MPDO on a chain of length `N + 2` is the `d`-term sum of
+transported physical projectors times the ambient commuting Gibbs factor.
+
+This is the literal physical-coordinate density formula in CPSV16,
+lines 1013–1016. The finite complement extension and projector transport are
+recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`; the
+length-at-least-two scope is recorded in
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem mpo_eq_sum_physicalIndexedAmbientProjector_mul_gibbsFactor
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M) (N : ℕ) :
+    mpo M (N + 2) =
+      ∑ i : Fin d,
+        (H.physicalIndexedTerminalEigenvalue hM i : ℂ) •
+          (H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+              hM N i *
+            NormedSpace.exp
+              (-H.physicalTopologicalGibbsHamiltonianSuccSucc N)) := by
+  let W := MPOTensor.sitewisePhysicalMatrix H.verticalCoisometry (N + 2)
+  have hreconstruct :=
+    H.singleKrausMap_physicalIndexedGibbsDecomposition_eq_mpo hM N
+  rw [← MPOTensor.sitewisePhysicalMatrix_conjTranspose] at hreconstruct
+  rw [← hreconstruct]
+  rw [map_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [map_smul]
+  congr 1
+  rw [singleKrausMap_apply]
+  rw [Matrix.conjTranspose_conjTranspose]
+  change Wᴴ *
+        (H.physicalIndexedTopologicalSpectralProjectorSucc
+            hM (N + 1) i *
+          NormedSpace.exp
+            (-H.topologicalGibbsHamiltonianSuccSucc N)) *
+      W =
+    H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc hM N i *
+      NormedSpace.exp
+        (-H.physicalTopologicalGibbsHamiltonianSuccSucc N)
+  exact
+    (H.physicalIndexedAmbientProjector_mul_gibbsFactor_eq_transport
+      hM N i).symm
+
+/-- The physical-coordinate commuting Gibbs decomposition above one site.
+
+One fixed Hermitian two-site term is translated on every chain of length
+`N + 2`; its translates commute. The `Fin d`-indexed nonnegative
+eigenweights and ambient physical projectors give pairwise orthogonal
+projections which commute with the physical Gibbs factor and reconstruct the
+physical MPDO exactly.
+
+Source: CPSV16, lines 1013–1016, with the local two-site convention of
+Definition 4.8, lines 831–847.
+
+**Local fix (physical complement):** The retained-row derivation is extended
+by zero energy on the orthogonal physical complement, and the retained
+projectors are transported through the adjoint sitewise coisometry. This
+finite extension is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
+**Scope restriction (positive chains of length at least two):** Definition
+4.8 does not specify a length-one two-site convention. See
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+def HasPhysicalTopologicalGibbsDecomposition
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M) : Prop :=
+  H.physicalTopologicalGibbsLocalTerm.IsHermitian ∧
+    ∀ N : ℕ,
+      (∀ i j : Fin (N + 2),
+        Commute
+          (MPOTensor.embedLocalOperator 2 (N + 2) (by omega) i
+            H.physicalTopologicalGibbsLocalTerm)
+          (MPOTensor.embedLocalOperator 2 (N + 2) (by omega) j
+            H.physicalTopologicalGibbsLocalTerm)) ∧
+      (∀ i : Fin d,
+        0 ≤ H.physicalIndexedTerminalEigenvalue hM i ∧
+          ((H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+              hM N i).IsHermitian ∧
+            H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+                hM N i *
+              H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+                hM N i =
+              H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+                hM N i)) ∧
+      (∀ i j : Fin d, i ≠ j →
+        H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+              hM N i *
+            H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+              hM N j =
+          0) ∧
+      (∀ i : Fin d,
+        H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+              hM N i *
+            NormedSpace.exp
+              (-H.physicalTopologicalGibbsHamiltonianSuccSucc N) =
+          NormedSpace.exp
+              (-H.physicalTopologicalGibbsHamiltonianSuccSucc N) *
+            H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+              hM N i) ∧
+      mpo M (N + 2) =
+        ∑ i : Fin d,
+          (H.physicalIndexedTerminalEigenvalue hM i : ℂ) •
+            (H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc
+                hM N i *
+              NormedSpace.exp
+                (-H.physicalTopologicalGibbsHamiltonianSuccSucc N))
+
+/-- A chosen BNT fusion clause has the physical-coordinate commuting Gibbs
+decomposition on every chain of length at least two.
+
+Source: CPSV16, lines 1013–1016, with the local two-site convention of
+Definition 4.8, lines 831–847.
+
+**Local fix (physical complement):** The retained-row derivation is extended
+by zero energy on the orthogonal physical complement, as documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
+**Scope restriction (positive chains of length at least two):** Definition
+4.8 does not specify a length-one two-site convention. See
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem hasPhysicalTopologicalGibbsDecomposition
+    (H : BNTFusionTensorClause M) (hM : IsMPDO M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi H.chi).LengthIndependent) :
+    H.HasPhysicalTopologicalGibbsDecomposition hM := by
+  refine ⟨H.physicalTopologicalGibbsLocalTerm_isHermitian, fun N ↦ ?_⟩
+  exact ⟨H.physicalTopologicalGibbsBondSuccSucc_commute N,
+    fun i ↦ ⟨H.physicalIndexedTerminalEigenvalue_nonneg hM i,
+      H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc_isOrthogonalProjection
+        hM hLI N i⟩,
+    fun _ _ hij ↦
+      H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc_mul_eq_zero
+        hM hLI N hij,
+    H.physicalIndexedAmbientTopologicalSpectralProjectorSuccSucc_commutes_gibbsFactor
+      hM N,
+    H.mpo_eq_sum_physicalIndexedAmbientProjector_mul_gibbsFactor hM N⟩
+
+end MPOTensor.BNTFusionTensorClause
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- **Physical-coordinate commuting Gibbs decomposition for a
+length-independent RFP MPDO above one site.**
+
+The BNT fusion clause, physical two-site Hamiltonian, nonnegative
+eigenweights, and ambient physical projector family are selected or
+constructed internally. For every chain of length `N + 2`, the local
+translates commute, the projectors are pairwise orthogonal and commute with
+the Gibbs factor, and their weighted Gibbs sum is the physical MPDO.
+
+Source: CPSV16, lines 1013–1016, with the local two-site convention of
+Definition 4.8, lines 831–847.
+
+**Local fix (physical complement):** The retained-row derivation is extended
+by zero energy on the orthogonal physical complement, and the retained
+projectors are transported through the adjoint sitewise coisometry. This
+finite extension is documented in
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
+**Scope restriction (positive chains of length at least two):** Definition
+4.8 does not specify a length-one two-site convention. This theorem covers
+exactly the source-defined chains of length `N + 2`; see
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem physicalTopologicalGibbsDecomposition_of_isRFPViaTS
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M)
+    (hM : IsMPDO M) (hRFP : IsRFPViaTS M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi
+      (rfpBNTFusionTensorClause M hHorizontal hM hRFP).chi).LengthIndependent) :
+    let H := rfpBNTFusionTensorClause M hHorizontal hM hRFP
+    H.HasPhysicalTopologicalGibbsDecomposition hM := by
+  dsimp only
+  exact
+    BNTFusionTensorClause.hasPhysicalTopologicalGibbsDecomposition
+      (rfpBNTFusionTensorClause M hHorizontal hM hRFP) hM hLI
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries.tex
@@ -2053,6 +2053,8 @@ separate step.
     site]%
     \label{thm:mpdo_physical_coordinate_gibbs_at_least_two}
     \uses{thm:mpdo_topological_gibbs_at_least_two}
+    \lean{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
+    \leanok
     Let $M$ be as in
     Theorem~\ref{thm:mpdo_topological_gibbs_at_least_two}.  There are
     nonnegative numbers $\lambda_1,\ldots,\lambda_d$ and one fixed Hermitian
@@ -2073,11 +2075,31 @@ separate step.
           e^{-\widehat H_L}.
     \]
 
-    This target is not yet marked complete.  The retained-coordinate theorem
-    does not construct $\widehat P_i^{(L)}$ or $\widehat H_L$ on the
-    complementary physical sectors; see
+    \textbf{Local fix (physical complement):}
+    the retained one-site energy is compressed to physical coordinates and
+    extended by zero energy on the orthogonal complement.  The retained
+    projectors are transported through the adjoint sitewise coisometry.  See
     \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
 \end{theorem}
+\begin{proof}\leanok
+    Put $V$ for the retained-row coisometry and $k$ for the retained
+    logarithmic multiplicity energy.  The physical energy
+    $K=V^\dagger kV$ is Hermitian and
+    \[
+      e^{-K}=V^\dagger e^{-k}V+(I-V^\dagger V).
+    \]
+    Taking the fixed two-site term $K\otimes I$, its periodic translates act
+    on separate one-site factors, hence commute, and their exponential is the
+    tensor power of the displayed physical weight.
+
+    For the sitewise coisometry $W=V^{\otimes L}$, transport each retained
+    projector by $\widehat P_i^{(L)}=W^\dagger P_i^{(L)}W$.  The identity
+    $WW^\dagger=I$ preserves self-adjointness, idempotence, and pairwise
+    orthogonality.  The one-site intertwining identities transport the
+    retained commutator to the physical Gibbs factor.  Applying the same
+    identities term by term to the retained density decomposition, and then
+    using exact adjoint reconstruction, gives the stated physical sum.
+\end{proof}
 
 \begin{remark}[Printed length-one domain boundary]%
     \label{rem:mpdo_topological_gibbs_length_one_boundary}
@@ -2090,9 +2112,9 @@ separate step.
     Theorem~4.15 is printed without an explicit lower bound on $L$, but its
     $L=1$ instance is therefore undefined without an author or erratum
     convention.  The source construction is defined for $L\geq2$, and no
-    length-one theorem is asserted.  The retained-coordinate theorem above
-    proves its scoped analogue on this domain; the physical-coordinate
-    complement remains open.  See
+    length-one theorem is asserted.  The physical-coordinate theorem above
+    proves the result on this domain; the undefined length-one convention
+    remains open.  See
     \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}
     and
     \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.

--- a/docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex
+++ b/docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex
@@ -14,6 +14,18 @@
 \begin{document}
 \maketitle
 
+\section{Status}
+
+Resolved for the source-defined domain of chain lengths $L\geq2$ by the
+source-facing theorem
+\begin{center}
+  \small\path{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}.
+\end{center}
+The theorem constructs the finite physical-complement extension, transports
+the retained projectors, and proves the literal physical density formula.
+The separate undefined length-one convention remains documented in
+\path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+
 \section{Source statement}
 
 The theorem following Theorem~4.14 in
@@ -116,29 +128,28 @@ They are supported on $E^{\otimes N}$ and therefore annihilate every
 complementary and mixed-sector contribution.  The coisometry identity gives
 their projection identities, while equation~\eqref{eq:physical-chain-extension}
 reduces their commutation and the physical density formula to the retained
-equalities.  This finite physical extension is mathematically available; the
-remaining gap is its formalization.
+equalities.  The resolution below formalizes this finite physical extension.
 
-\section{Elimination plan}
+\section{Resolution}
 
-The missing formalization consists of the following steps.
+The formalization resolves the gap by the following steps.
 
 \begin{enumerate}
-  \item Prove equation~\eqref{eq:physical-energy-extension} from
+  \item It proves equation~\eqref{eq:physical-energy-extension} from
     $VV^\dagger=I_s$.
-  \item Define a fixed physical two-site interaction from
-    $k_{\mathrm{phys}}$ and prove the periodic exponential identity for every
+  \item It defines a fixed physical two-site interaction from
+    $k_{\mathrm{phys}}$ and proves the periodic exponential identity for every
     chain length at least two.
-  \item Transport the retained terminal projections to the physical chain
-    and prove their projection and commutation identities.
-  \item Combine these identities with exact vertical reconstruction to obtain
-    equation~\eqref{eq:physical-gibbs}.
+  \item It transports the retained terminal projections to the physical chain
+    and proves their projection, orthogonality, and commutation identities.
+  \item It combines these identities with exact vertical reconstruction to
+    obtain equation~\eqref{eq:physical-gibbs}.
 \end{enumerate}
 
 The separate one-site ambiguity in the two-site periodic interaction is
 recorded in
-\path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.  Resolving
-either gap does not resolve the other.
+\path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}; it is not
+resolved by the physical-complement construction.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Formalize the physical-coordinate topological Gibbs decomposition for MPDO renormalization fixed points on the source-defined domain `L >= 2`.

The proof follows CPSV16, lines 999–1016, and resolves the physical-complement gap documented in `docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`:

- prove the finite physical-complement identity `exp (-V† k V) = V† exp (-k) V + (I - V† V)` for the retained-row coisometry;
- construct one fixed Hermitian two-site term and prove its periodic translates commute, with the required exponential tensor-power identity;
- transport the retained spectral projectors through the adjoint sitewise coisometry and prove their Hermiticity, idempotence, orthogonality, and commutation identities;
- combine those identities with exact retained-density reconstruction to obtain the literal physical density formula.

This PR proves the result only for `L >= 2`. The `L = 1` case remains the separate printed-source boundary recorded in `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. PEPS is out of scope.

## Validation

- `lake env lean TNLean/MPS/MPDO/PhysicalGibbsEmbedding.lean`
- `lake env lean TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean`
- `lake env lean TNLean.lean`
- `lake build` — 9,742 jobs
- `lake exe lint_style`
- changed-file proof-integrity scan — no `sorry`, `admit`, `native_decide`, `unsafeCast`, or `axiom`
- import aggregators current — 46 generated files covering 1,037 production modules
- oversized Lean files — 1,088 scanned, 0 nonexempt violations
- numbered Lean files — 1,080 tracked production files, 0 new violations
- reader-facing prose diff check — 0 violations
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- blueprint/Lean synchronization — 13,194 declarations, 5,464 references; fusion chapter 214/214; no changed declarations missing
- `leanblueprint web`
- `leanblueprint pdf` — 728 pages
- visual inspection of blueprint PDF pages 714–716, all three pages of the standalone physical-complement note, and the generated web theorem/proof/length-one remark

Closes #4685

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof surface in core MPDO/Gibbs theory with many dependencies on coisometry and embedding identities; incorrect lemmas would undermine paper-aligned claims, but changes are proof-only with no runtime or security impact.
> 
> **Overview**
> Adds Lean proofs for the **physical-coordinate commuting Gibbs decomposition** (CPSV16, lines 1013–1016) on the source domain **L ≥ 2**, extending retained-coordinate results to the full physical chain via a finite **physical-complement** construction (zero energy and identity extension off the retained-row support).
> 
> **New analysis:** `CoisometricCompression` gains matrix-exponential lemmas, including `exp_neg_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one` (`exp(-V†kV) = V† exp(-k) V + (I - V†V)` for coisometries).
> 
> **New embedding layer:** `PhysicalGibbsEmbedding` defines one-site / first-site two-site local terms, shows two-site periodic embeds reduce to one-site embeds, and proves `exp` of a sum of commuting embedded one-site energies is a sitewise tensor power.
> 
> **Main result:** `TopologicalPhysicalGibbs` builds the physical Hamiltonian, transported `Fin d` projectors, Gibbs-factor commutation, and the density formula `ρ = ∑ λᵢ Pᵢ e^{-H}`; exposes `HasPhysicalTopologicalGibbsDecomposition` and `physicalTopologicalGibbsDecomposition_of_isRFPViaTS` for length-independent RFP MPDOs. `sitewisePhysicalMatrix_mul` supports chain-level intertwining.
> 
> **Docs:** Blueprint theorem marked `\leanok` with proof; physical-complement gap note moved from open plan to **resolved** (length-one convention still separate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b30875d242936cbc7256de8ce91a467459d030f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->