### PR TITLE
refactor(tenkz): wires, stubs, legs, and labels through the render stage (S2 cutover 2)

### DIFF
--- a/scripts/tenkz_pixelpair.sh
+++ b/scripts/tenkz_pixelpair.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# tenkz_pixelpair.sh -- same-session paired pixel sweep.
+#
+# Renders the standalone corpus at TWO worktree states (a base commit-ish and
+# the current tree), rasterizes every page at 300 dpi, and byte-compares the
+# pairs.  Pixel parity is only ever judged this way: both sides render in one
+# session on one machine, because raster bytes are environment-epoch
+# sensitive and stored manifests go stale invisibly.
+#
+# Usage: scripts/tenkz_pixelpair.sh <base-commit-ish>
+# Env:   TENKZ_CORPUS_JOBS  parallel compiles (default 8, positive integer)
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_REF="${1:?usage: tenkz_pixelpair.sh <base-commit-ish>}"
+JOBS=${TENKZ_CORPUS_JOBS:-8}
+if [[ ! "$JOBS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "FAIL: TENKZ_CORPUS_JOBS must be a positive integer, got '$JOBS'" >&2
+  exit 1
+fi
+command -v pdftoppm >/dev/null || { echo "FAIL: pdftoppm not found" >&2; exit 1; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/tenkz-pixelpair-XXXXXX")"
+BASE_TREE="$WORK/base-tree"
+trap 'rm -rf "$WORK"' EXIT
+
+# Detached true-legacy build: a clean worktree at the base ref, never a file
+# copy inside the live tree (a stash guards only what it happens to catch).
+git -C "$REPO" worktree add --detach --quiet "$BASE_TREE" "$BASE_REF"
+cleanup_worktree() { git -C "$REPO" worktree remove --force "$BASE_TREE" 2>/dev/null || true; }
+trap 'cleanup_worktree; rm -rf "$WORK"' EXIT
+
+render_side() { # $1 tree root, $2 output dir
+  local root="$1" out="$2" src stem
+  mkdir -p "$out/pdf" "$out/png"
+  cp -R "$root/tests/tenkz/." "$out/src/"
+  ( cd "$out/src"
+    find . -maxdepth 1 -name '*.tex' -print0 | LC_ALL=C sort -z >sources.list
+    compile_one() {
+      # $1 = tree root (fixed arg), $2 = source path (appended by xargs)
+      local name; name="$(basename "$2")"
+      ( TEXINPUTS="$1/tex/tenkz:$1/tex//:" timeout 180 \
+          xelatex -interaction=nonstopmode -halt-on-error "$name" ) \
+        >"${name%.tex}.pixelpair-transcript" 2>&1 \
+        || { echo "FAIL: $name did not compile" >&2; return 1; }
+    }
+    export -f compile_one
+    xargs -0 -n 1 -P "$JOBS" bash -c 'compile_one "$1" "$2"' _ "$root" <sources.list
+    while IFS= read -r -d '' src; do
+      stem="$(basename "${src%.tex}")"
+      [[ -f "$stem.pdf" ]] || { echo "FAIL: $stem produced no pdf" >&2; exit 1; }
+      mv "$stem.pdf" "../pdf/$stem.pdf"
+      pdftoppm -r 300 -png "../pdf/$stem.pdf" "../png/$stem"
+    done <sources.list
+  )
+}
+
+echo "[pixelpair] rendering base ($BASE_REF)..."
+render_side "$BASE_TREE" "$WORK/base"
+echo "[pixelpair] rendering current tree..."
+render_side "$REPO" "$WORK/head"
+
+fail=0; pages=0
+while IFS= read -r png; do
+  rel="${png#"$WORK"/head/png/}"
+  pages=$((pages + 1))
+  if [[ ! -f "$WORK/base/png/$rel" ]]; then
+    echo "DIFF: $rel exists only on head" >&2; fail=1; continue
+  fi
+  cmp -s "$png" "$WORK/base/png/$rel" || { echo "DIFF: $rel" >&2; fail=1; }
+done < <(find "$WORK/head/png" -name '*.png' | LC_ALL=C sort)
+while IFS= read -r png; do
+  rel="${png#"$WORK"/base/png/}"
+  [[ -f "$WORK/head/png/$rel" ]] || { echo "DIFF: $rel exists only on base" >&2; fail=1; }
+done < <(find "$WORK/base/png" -name '*.png' | LC_ALL=C sort)
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "FAIL: pixel divergence against $BASE_REF" >&2
+  exit 1
+fi
+echo "PASS: $pages pages byte-identical at 300 dpi against $BASE_REF"

--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -1340,7 +1340,8 @@ def main() -> int:
                          "tenkz_brick_face:nnnNn"):
             start = grid_source.index(f"\\cs_new_protected:Npn \\{function}")
             excerpt = grid_source[start:start + 7000]
-            if "\\node[tn~label" not in excerpt:
+            if "\\node[tn~label" not in excerpt and \
+               "\\__tenkz_render_labelnode:nnn" not in excerpt:
                 raise AssertionError(f"{function} bypasses the audited label style")
 
         core_source = (ROOT / "tex/tenkz/tenkz-core.code.tex").read_text(

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -1199,7 +1199,7 @@
   {
     \tenkz_map_save:nn {#1} {#2}
     \tenkz_map:nn {#3} {#4}
-    \draw[#5] \tenkz_qpt: -- \tenkz_mpt: ;
+    \__tenkz_render_stroke:nn {#5} { \tenkz_qpt: -- \tenkz_mpt: }
   }
 % compass words under the frame map: the vertical map reflects across the
 % north-west/south-east diagonal, so north<->west, south<->east, and the
@@ -2110,9 +2110,9 @@
   {
     \prop_if_in:NnF \l__tenkz_periodicpaired_prop {#1-#2-#3}
       {
-        \draw[bond, tenkz~combined~stub]
-          (\tenkz_node_name:nn{#1}{#2}.\tenkz_compass:n{#3}) --
-          ++\tenkz_stub_vec:n {#3};
+        \__tenkz_render_stroke:nn { bond, tenkz~combined~stub }
+          { (\tenkz_node_name:nn{#1}{#2}.\tenkz_compass:n{#3}) --
+            ++\tenkz_stub_vec:n {#3} }
       }
   }
 
@@ -2555,6 +2555,10 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
 
 \tl_new:N \l__tenkz_pa_tl
 \tl_new:N \l__tenkz_pb_tl
+% the wire record backing the bond about to ink, and its recorded direction
+\tl_new:N \l__tenkz_bondrec_tl
+\tl_new:N \l__tenkz_bonddirw_tl
+\cs_generate_variant:Nn \__tenkz_model_get:nnN { e }
 
 % extract a `species=<name>' row mod from the str-normalized mods #1
 % (catcode-12 tokens, so both delimiters are built by \use:e): the name
@@ -2661,8 +2665,8 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
 \cs_new_protected:Npn \tenkz_draw_unmatched_virtual:nnn #1#2#3
   {
     \tenkz_anchor:nnnN {#1}{#2}{#3} \l__tenkz_pa_tl
-    \draw[\tl_use:N \l__tenkz_cell_tl]
-      \l__tenkz_pa_tl -- ++\tenkz_stub_vec:n{#3};
+    \__tenkz_render_stroke:nn { \tl_use:N \l__tenkz_cell_tl }
+      { \l__tenkz_pa_tl -- ++\tenkz_stub_vec:n{#3} }
     \str_if_eq:nnTF {#3}{west}
       { \int_incr:N \l__tenkz_internalvw_int }
       { \int_incr:N \l__tenkz_internalve_int }
@@ -2755,9 +2759,33 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                                   {east} \l__tenkz_pa_tl
                                 \tenkz_anchor:nnnN {##1}{####1}
                                   {west} \l__tenkz_pb_tl
-                                \draw[\tl_use:N \l__tenkz_cell_tl,
-                                      \tl_use:N \l__tenkz_dirmarks_tl]
-                                  \l__tenkz_pa_tl -- \l__tenkz_pb_tl;
+                                % the WIRE record is authoritative: a bond
+                                % with no record, or a record whose dir
+                                % disagrees with the scan, is a coded error
+                                \__tenkz_model_wire_by_ends:eeN
+                                  {##1-\int_use:N\l_tmpa_int}{##1-####1}
+                                  \l__tenkz_bondrec_tl
+                                \quark_if_no_value:NTF \l__tenkz_bondrec_tl
+                                  { \msg_error:nnee {tenkz}{render-nowire}
+                                      {##1-\int_use:N\l_tmpa_int}{##1-####1} }
+                                  {
+                                    \__tenkz_model_get:enN
+                                      { \tl_use:N \l__tenkz_bondrec_tl }
+                                      {dir} \l__tenkz_bonddirw_tl
+                                    \str_if_eq:eeF
+                                      { \tl_use:N \l__tenkz_bonddirw_tl }
+                                      { \tenkz_model_dir_word: }
+                                      { \msg_error:nneee {tenkz}{render-wiredir}
+                                          { \tl_use:N \l__tenkz_bondrec_tl }
+                                          { \tl_use:N \l__tenkz_bonddirw_tl }
+                                          { \tenkz_model_dir_word: } }
+                                    \__tenkz_render_bond:ennnn
+                                      { \tl_use:N \l__tenkz_bondrec_tl }
+                                      { \tl_use:N \l__tenkz_cell_tl }
+                                      { \tl_use:N \l__tenkz_dirmarks_tl }
+                                      { \l__tenkz_pa_tl }
+                                      { \l__tenkz_pb_tl }
+                                  }
                                 % Boundary accounting consumes these exact
                                 % bond facts rather than repeating the
                                 % consecutive-owner scan.
@@ -2793,9 +2821,10 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                                 \tenkz_anchor:nnnN
                                   {##1}{\int_use:N\l__tenkz_pendeast_int}
                                   {east} \l__tenkz_pa_tl
-                                \draw[\tl_use:N \l__tenkz_cell_tl]
-                                  \l__tenkz_pa_tl --
-                                  ++\tenkz_stub_vec:n{east};
+                                \__tenkz_render_stroke:nn
+                                  { \tl_use:N \l__tenkz_cell_tl }
+                                  { \l__tenkz_pa_tl --
+                                    ++\tenkz_stub_vec:n{east} }
                               }
                             \int_zero:N \l__tenkz_pendeast_int
                           }
@@ -2805,8 +2834,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                           {
                             \tenkz_anchor:nnnN {##1}{####1}{west}
                               \l__tenkz_pb_tl
-                            \draw[\tl_use:N \l__tenkz_cell_tl]
-                              \l__tenkz_pb_tl -- ++\tenkz_stub_vec:n{west};
+                            \__tenkz_render_stroke:nn
+                              { \tl_use:N \l__tenkz_cell_tl }
+                              { \l__tenkz_pb_tl -- ++\tenkz_stub_vec:n{west} }
                           }
                         \bool_set_false:N \l__tenkz_hole_bool
                       }
@@ -3064,8 +3094,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                     \tenkz_edgept:NnnN \l__tenkz_pwlownode_tl {north}
                       { \int_eval:n{\l__tenkz_pwlowbase_tl+##1-1} }
                       \l__tenkz_pwlow_tl
-                    \draw[physical~leg] \l__tenkz_pwlow_tl --
-                      ++\tenkz_leg_vec:nn{1}{\tenkz@dim{\tenkz@r@physleg}};
+                    \__tenkz_render_stroke:nn { physical~leg }
+                      { \l__tenkz_pwlow_tl --
+                        ++\tenkz_leg_vec:nn{1}{\tenkz@dim{\tenkz@r@physleg}} }
                     \tenkz_draw_lower_label:N \l__tenkz_pwlow_tl
                     \int_compare:nNnT {#3} = {1}
                       { \int_incr:N \l__tenkz_internalpu_int }
@@ -3172,9 +3203,10 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                             \tenkz_pair_wide_leg:nn {#2}{#3}
                             \tenkz_pair_lowpt:nN { \int_eval:n{#2+#3-1} }
                               \l__tenkz_pwlow_tl
-                            \draw[physical~leg] \l__tenkz_pwlow_tl --
-                              ++\tenkz_leg_vec:nn{1}
-                                {\tenkz@dim{\tenkz@r@physleg}};
+                            \__tenkz_render_stroke:nn { physical~leg }
+                              { \l__tenkz_pwlow_tl --
+                                ++\tenkz_leg_vec:nn{1}
+                                  {\tenkz@dim{\tenkz@r@physleg}} }
                             \str_if_eq:VnTF
                               \l__tenkz_faceports_tl {center}
                               {
@@ -3204,8 +3236,8 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                               { \int_eval:n{#2+#3-1} } \l__tenkz_pwpt_tl
                             \tenkz_pair_lowpt:nN { \int_eval:n{#2+#3-1} }
                               \l__tenkz_pwlow_tl
-                            \draw[physical~leg]
-                              \l__tenkz_pwpt_tl -- \l__tenkz_pwlow_tl;
+                            \__tenkz_render_stroke:nn { physical~leg }
+                              { \l__tenkz_pwpt_tl -- \l__tenkz_pwlow_tl }
                             \tenkz@event{pairleg|picture=\the\tenkz@pictureid|upper=#1-#2|lower=\int_eval:n{#1+1}-\l__tenkz_pwbase_tl|upper-port=#3|column=\int_eval:n{#2+#3-1}}
                           }
                       }
@@ -3229,8 +3261,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
   {
     \tenkz_edgept:NnnN \l__tenkz_pwname_tl {south}
       { \int_eval:n{#1+#2-1} } \l__tenkz_pwpt_tl
-    \draw[physical~leg] \l__tenkz_pwpt_tl --
-      ++\tenkz_leg_vec:nn{-1}{\tenkz@dim{\tenkz@r@physleg}};
+    \__tenkz_render_stroke:nn { physical~leg }
+      { \l__tenkz_pwpt_tl --
+        ++\tenkz_leg_vec:nn{-1}{\tenkz@dim{\tenkz@r@physleg}} }
     \tl_if_blank:VF \l__tenkz_pwslotlab_tl
       {
         \node[tn~label, anchor=\tenkz_compass:n{north},
@@ -3333,8 +3366,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
           {
             \tenkz_edgept:NnnN \l__tenkz_pb_tl {north} {#2}
               \l__tenkz_pwlow_tl
-            \draw[physical~leg] \l__tenkz_pwlow_tl --
-              ++\tenkz_leg_vec:nn{1}{\tenkz@dim{\tenkz@r@physleg}};
+            \__tenkz_render_stroke:nn { physical~leg }
+              { \l__tenkz_pwlow_tl --
+                ++\tenkz_leg_vec:nn{1}{\tenkz@dim{\tenkz@r@physleg}} }
             \prop_get:NeNT
               \l__tenkz_pwlowerlabel_prop
               {#1-\l__tenkz_pwbase_tl-
@@ -3355,9 +3389,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
       {
         \tenkz_once_p:nnTF {paired-with-center} {#1-\tl_use:N\l__tenkz_pwbase_tl}
           {
-            \draw[physical~leg]
-              (\l__tenkz_pa_tl.\tenkz_compass:n{south}) --
-              (\l__tenkz_pb_tl.\tenkz_compass:n{north});
+            \__tenkz_render_stroke:nn { physical~leg }
+              { (\l__tenkz_pa_tl.\tenkz_compass:n{south}) --
+                (\l__tenkz_pb_tl.\tenkz_compass:n{north}) }
             \tenkz@event{pairleg|picture=\the\tenkz@pictureid|upper=#1-#2|lower=\int_eval:n{#1+1}-\l__tenkz_pwbase_tl|upper-port=center|column=#2}
           }
           {
@@ -3372,9 +3406,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
           {
             \tenkz_edgept:NnnN \l__tenkz_pb_tl {north} {#2}
               \l__tenkz_pwlow_tl
-            \draw[physical~leg]
-              (\l__tenkz_pa_tl.\tenkz_compass:n{south}) --
-              \l__tenkz_pwlow_tl;
+            \__tenkz_render_stroke:nn { physical~leg }
+              { (\l__tenkz_pa_tl.\tenkz_compass:n{south}) --
+                \l__tenkz_pwlow_tl }
             \tenkz@event{pairleg|picture=\the\tenkz@pictureid|upper=#1-#2|lower=\int_eval:n{#1+1}-\l__tenkz_pwbase_tl|upper-port=center|column=#2}
           }
           { \tenkz_leg_open:nnn {#1}{#2}{down}
@@ -3478,8 +3512,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
           { \tl_set:Ne \l__tenkz_legbase_tl
               { ( \dim_use:N \l__tenkz_x_dim ,
                   \dim_use:N \l__tenkz_bkface_dim ) } }
-        \draw[physical~leg] \l__tenkz_legbase_tl --
-          ++\tenkz_leg_vec:nn{#5}{\tenkz@dim{\tenkz@r@physleg}};
+        \__tenkz_render_stroke:nn { physical~leg }
+          { \l__tenkz_legbase_tl --
+            ++\tenkz_leg_vec:nn{#5}{\tenkz@dim{\tenkz@r@physleg}} }
         \seq_pop_left:NNT \l__tenkz_leglab_seq \l_tmpb_tl
           {
             \tl_if_blank:VF \l_tmpb_tl
@@ -3725,9 +3760,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
         \tenkz_edgept:NnnN \l__tenkz_pa_tl {#3} { #2 + ##1 - 1 }
           \l__tenkz_legbase_tl
         % offsets as ++/shift vectors, never inside calc (see leg_stub)
-        \draw[physical~leg]
-          \l__tenkz_legbase_tl --
-          ++\tenkz_leg_vec:nn{#6}{\tenkz@dim{\tenkz@r@physleg}};
+        \__tenkz_render_stroke:nn { physical~leg }
+          { \l__tenkz_legbase_tl --
+            ++\tenkz_leg_vec:nn{#6}{\tenkz@dim{\tenkz@r@physleg}} }
         \seq_pop_left:NNT \l__tenkz_leglab_seq \l_tmpb_tl
           {
             \tl_if_blank:VF \l_tmpb_tl
@@ -3751,8 +3786,9 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
   {
     % the offsets ride as ++/shift vectors, never inside a calc ($...$):
     % the calc factor parser does not expand a macro-valued coordinate
-    \draw[physical~leg] (\l__tenkz_pa_tl.\tenkz_compass:n{#1}) --
-      ++\tenkz_leg_vec:nn{#4}{\tenkz@dim{\tenkz@r@physleg}};
+    \__tenkz_render_stroke:nn { physical~leg }
+      { (\l__tenkz_pa_tl.\tenkz_compass:n{#1}) --
+        ++\tenkz_leg_vec:nn{#4}{\tenkz@dim{\tenkz@r@physleg}} }
     \tl_if_empty:NF #3
       {
         \node[tn~label, anchor=\tenkz_compass:n{#2},

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -2323,14 +2323,12 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
     \tenkz_map:nn { \tenkz_colx:n {#2} } { \tenkz_rowy:n {#1} }
     \bool_if:NTF \l__tenkz_vertical_bool
       {
-        \node[tn~label, inner~ysep=0.30em]
-          (\tenkz_node_name:nn{#1}{#2})
-          at \tenkz_mpt: { $\vdots$ };
+        \__tenkz_render_labelnode_named:nnnn { tn~label, inner~ysep=0.30em }
+          { \tenkz_node_name:nn{#1}{#2} } { \tenkz_mpt: } { $\vdots$ }
       }
       {
-        \node[tn~label, inner~xsep=0.30em]
-          (\tenkz_node_name:nn{#1}{#2})
-          at \tenkz_mpt: { $\cdots$ };
+        \__tenkz_render_labelnode_named:nnnn { tn~label, inner~xsep=0.30em }
+          { \tenkz_node_name:nn{#1}{#2} } { \tenkz_mpt: } { $\cdots$ }
       }
     \prop_put:Nnn \l__tenkz_owner_prop {#1-#2} {#2}
     \prop_put:Nne \l__tenkz_name_prop {#1-#2} { \tenkz_node_name:nn{#1}{#2} }
@@ -2339,9 +2337,8 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
 \cs_new_protected:Npn \tenkz_node_ghost:nn #1#2
   {
     \tenkz_map:nn { \tenkz_colx:n {#2} } { \tenkz_rowy:n {#1} }
-    \node[inner~sep=0pt, minimum~size=0pt]
-      (\tenkz_node_name:nn{#1}{#2})
-      at \tenkz_mpt: {};
+    \__tenkz_render_labelnode_named:nnnn { inner~sep=0pt, minimum~size=0pt }
+      { \tenkz_node_name:nn{#1}{#2} } { \tenkz_mpt: } {}
     \prop_put:Nnn \l__tenkz_owner_prop {#1-#2} {#2}
     \prop_put:Nne \l__tenkz_name_prop {#1-#2} { \tenkz_node_name:nn{#1}{#2} }
   }
@@ -2453,8 +2450,9 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
           { \dim_sub:Nn \l__tenkz_x_dim { \tenkz@dim{0.30} } }
         \tenkz_map:nn { \l__tenkz_x_dim }
           { \l__tenkz_tmp_dim + \tenkz@dim{\tenkz@r@labelclear} }
-        \node[tn~label, anchor=\tenkz_compass:n{south}] at \tenkz_mpt:
-          { $\tenkz@labelsize \tl_use:N \l_tmpb_tl$ };
+        \__tenkz_render_labelnode:nnn
+          { tn~label, anchor=\tenkz_compass:n{south} } { \tenkz_mpt: }
+          { $\tenkz@labelsize \tl_use:N \l_tmpb_tl$ }
       }
     % role=/species= ride the event for schema uniformity with the other
     % atom emitters (uniform fields keep the audit's parsers total); the
@@ -2971,11 +2969,12 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
   {
     \tl_if_blank:VF \l__tenkz_pwlowlabel_tl
       {
-        \node[tn~label, anchor=\tenkz_compass:n{south},
-              shift={\tenkz_leg_vec:nn{1}
-                { \tenkz@dim{\tenkz@r@physleg}
-                  + \tenkz@dim{\tenkz@r@labelclear} }}]
-          at #1 { \tl_use:N \l__tenkz_pwlowlabel_tl };
+        \__tenkz_render_labelnode:nnn
+          { tn~label, anchor=\tenkz_compass:n{south},
+            shift={\tenkz_leg_vec:nn{1}
+              { \tenkz@dim{\tenkz@r@physleg}
+                + \tenkz@dim{\tenkz@r@labelclear} }} }
+          { #1 } { \tl_use:N \l__tenkz_pwlowlabel_tl }
       }
   }
 
@@ -3266,11 +3265,12 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
         ++\tenkz_leg_vec:nn{-1}{\tenkz@dim{\tenkz@r@physleg}} }
     \tl_if_blank:VF \l__tenkz_pwslotlab_tl
       {
-        \node[tn~label, anchor=\tenkz_compass:n{north},
-              shift={\tenkz_leg_vec:nn{-1}
-                { \tenkz@dim{\tenkz@r@physleg}
-                  + \tenkz@dim{\tenkz@r@labelclear} }}]
-          at \l__tenkz_pwpt_tl { \tl_use:N \l__tenkz_pwslotlab_tl };
+        \__tenkz_render_labelnode:nnn
+          { tn~label, anchor=\tenkz_compass:n{north},
+            shift={\tenkz_leg_vec:nn{-1}
+              { \tenkz@dim{\tenkz@r@physleg}
+                + \tenkz@dim{\tenkz@r@labelclear} }} }
+          { \l__tenkz_pwpt_tl } { \tl_use:N \l__tenkz_pwslotlab_tl }
       }
   }
 % the partner's north-face point at absolute column #1: a wide multi-port
@@ -3519,13 +3519,14 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
           {
             \tl_if_blank:VF \l_tmpb_tl
               {
-                \node[tn~label,
-                      anchor=\tenkz_compass:n
-                        { \str_if_eq:nnTF {#3} {north} {south} {north} },
-                      shift={\tenkz_leg_vec:nn{#5}
-                        { \tenkz@dim{\tenkz@r@physleg}
-                          + \tenkz@dim{\tenkz@r@labelclear} }}]
-                  at \l__tenkz_legbase_tl { \tl_use:N \l_tmpb_tl };
+                \__tenkz_render_labelnode:nnn
+                  { tn~label,
+                    anchor=\tenkz_compass:n
+                      { \str_if_eq:nnTF {#3} {north} {south} {north} },
+                    shift={\tenkz_leg_vec:nn{#5}
+                      { \tenkz@dim{\tenkz@r@physleg}
+                        + \tenkz@dim{\tenkz@r@labelclear} }} }
+                  { \l__tenkz_legbase_tl } { \tl_use:N \l_tmpb_tl }
               }
           }
       }
@@ -3767,12 +3768,13 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
           {
             \tl_if_blank:VF \l_tmpb_tl
               {
-                \node[tn~label, anchor=\tenkz_compass:n{#4},
-                      shift={\tenkz_leg_vec:nn{#6}
-                        { \tenkz@dim{\tenkz@r@physleg}
-                          + \tenkz@dim{\tenkz@r@labelclear} }}]
-                  at \l__tenkz_legbase_tl
-                  { \tl_use:N \l_tmpb_tl };
+                \__tenkz_render_labelnode:nnn
+                  { tn~label, anchor=\tenkz_compass:n{#4},
+                    shift={\tenkz_leg_vec:nn{#6}
+                      { \tenkz@dim{\tenkz@r@physleg}
+                        + \tenkz@dim{\tenkz@r@labelclear} }} }
+                  { \l__tenkz_legbase_tl }
+                  { \tl_use:N \l_tmpb_tl }
               }
           }
       }
@@ -3791,11 +3793,12 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
         ++\tenkz_leg_vec:nn{#4}{\tenkz@dim{\tenkz@r@physleg}} }
     \tl_if_empty:NF #3
       {
-        \node[tn~label, anchor=\tenkz_compass:n{#2},
-              shift={\tenkz_leg_vec:nn{#4}{ \tenkz@dim{\tenkz@r@physleg}
-                       + \tenkz@dim{\tenkz@r@labelclear} }}]
-          at (\l__tenkz_pa_tl.\tenkz_compass:n{#1})
-          { \tl_use:N #3 };
+        \__tenkz_render_labelnode:nnn
+          { tn~label, anchor=\tenkz_compass:n{#2},
+            shift={\tenkz_leg_vec:nn{#4}{ \tenkz@dim{\tenkz@r@physleg}
+                     + \tenkz@dim{\tenkz@r@labelclear} }} }
+          { (\l__tenkz_pa_tl.\tenkz_compass:n{#1}) }
+          { \tl_use:N #3 }
       }
   }
 
@@ -3939,9 +3942,10 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
 % #2, outward offset (#3,#4); the text is \l__tenkz_dot_label_tl
 \cs_new_protected:Npn \tenkz_dot_label_at:nnnn #1#2#3#4
   {
-    \node[tn~label, anchor=#2, shift={(\l__tenkz_clshift_tl)}] at
-      ($(\l__tenkz_pa_tl.#1)+(#3,#4)$)
-      { $\tenkz@labelsize \tl_use:N \l__tenkz_dot_label_tl$ };
+    \__tenkz_render_labelnode:nnn
+      { tn~label, anchor=#2, shift={(\l__tenkz_clshift_tl)} }
+      { ($(\l__tenkz_pa_tl.#1)+(#3,#4)$) }
+      { $\tenkz@labelsize \tl_use:N \l__tenkz_dot_label_tl$ }
   }
 
 % -- decorations: spans, cuts, bond labels ------------------------------
@@ -4382,11 +4386,11 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
     \draw[brace]
       (\dim_use:N #1, \dim_use:N \l__tenkz_y_dim) --
       (\dim_use:N #2, \dim_use:N \l__tenkz_y_dim);
-    \node[tn~label, anchor=#3] at
-      (\dim_eval:n{ (\l__tenkz_x_dim + \l__tenkz_tmp_dim)/2 },
-       \dim_eval:n{ \l__tenkz_y_dim
-                    + ( 3.4pt + \tenkz@dim{\tenkz@r@labelclear} ) * #4 })
-      { $\tenkz@labelsize #5$ };
+    \__tenkz_render_labelnode:nnn { tn~label, anchor=#3 }
+      { (\dim_eval:n{ (\l__tenkz_x_dim + \l__tenkz_tmp_dim)/2 },
+         \dim_eval:n{ \l__tenkz_y_dim
+                      + ( 3.4pt + \tenkz@dim{\tenkz@r@labelclear} ) * #4 }) }
+      { $\tenkz@labelsize #5$ }
   }
 
 \cs_new_protected:Npn \tenkz_draw_cut:nnn #1#2#3
@@ -4400,20 +4404,20 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
        \dim_eval:n{ \tenkz_rowy:n {\l__tenkz_nrows_int} - \tenkz@dim{0.55} });
     \tl_if_blank:nF {#3}
       {
-        \node[tn~label, anchor=south] at
-          (\dim_use:N \l__tenkz_x_dim,
-           \dim_eval:n{ \tenkz_rowy:n {1} + \tenkz@dim{0.55}
-                        + \tenkz@dim{\tenkz@r@labelclear} })
-          { $\tenkz@labelsize #3$ };
+        \__tenkz_render_labelnode:nnn { tn~label, anchor=south }
+          { (\dim_use:N \l__tenkz_x_dim,
+             \dim_eval:n{ \tenkz_rowy:n {1} + \tenkz@dim{0.55}
+                          + \tenkz@dim{\tenkz@r@labelclear} }) }
+          { $\tenkz@labelsize #3$ }
       }
   }
 
 \cs_new_protected:Npn \tenkz_draw_bondlabel:nnn #1#2#3
   {
-    \node[tn~label, anchor=south] at
-      (\dim_eval:n{ ( \tenkz_colx:n {#2} + \tenkz_colx:n {#3} ) / 2 },
-       \dim_eval:n{ \tenkz_rowy:n {1} + \tenkz@dim{\tenkz@r@labelclear} })
-      { #1 };
+    \__tenkz_render_labelnode:nnn { tn~label, anchor=south }
+      { (\dim_eval:n{ ( \tenkz_colx:n {#2} + \tenkz_colx:n {#3} ) / 2 },
+         \dim_eval:n{ \tenkz_rowy:n {1} + \tenkz@dim{\tenkz@r@labelclear} }) }
+      { #1 }
   }
 
 % -- open boundaries ----------------------------------------------------

--- a/tex/tenkz/tenkz-model.code.tex
+++ b/tex/tenkz/tenkz-model.code.tex
@@ -145,6 +145,26 @@
 \cs_new_protected:Npn \__tenkz_model_map_ids:nn #1#2
   { \seq_map_inline:cn { l__tenkz_model_ #1 _seq } {#2} }
 
+% Locate the wire record joining from=#1 to to=#2; leaves the record id in
+% #3, or \q_no_value when the derivation recorded no such wire.  Linear in
+% the wire count -- pictures hold tens of wires, not thousands.
+\tl_new:N \l__tenkz_model_probe_tl
+\cs_new_protected:Npn \__tenkz_model_wire_by_ends:nnN #1#2#3
+  {
+    \tl_set:Nn #3 { \q_no_value }
+    \seq_map_inline:Nn \l__tenkz_model_wire_seq
+      {
+        \__tenkz_model_get:nnN {##1} {from} \l__tenkz_model_probe_tl
+        \str_if_eq:eeT { \tl_use:N \l__tenkz_model_probe_tl } {#1}
+          {
+            \__tenkz_model_get:nnN {##1} {to} \l__tenkz_model_probe_tl
+            \str_if_eq:eeT { \tl_use:N \l__tenkz_model_probe_tl } {#2}
+              { \tl_set:Nn #3 {##1} \seq_map_break: }
+          }
+      }
+  }
+\cs_generate_variant:Nn \__tenkz_model_wire_by_ends:nnN { ee }
+
 % Expanding constructors for front ends whose addresses live in counters.
 % The variants route through the current (possibly frozen) base meaning.
 \cs_generate_variant:Nn \__tenkz_model_record_atom:n { e }

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -17,6 +17,12 @@
   { [TKZ-RENDER-SKIN]~no~kernel~skin~named~'#1' }
 \msg_new:nnn {tenkz}{render-route}
   { [TKZ-RENDER-ROUTE]~no~route~named~'#1' }
+\msg_new:nnn {tenkz}{render-nowire}
+  { [TKZ-RENDER-NOWIRE]~the~bond~scan~draws~#1~->~#2~but~the~model~holds~
+    no~such~wire~record;~derivation~and~scan~disagree }
+\msg_new:nnn {tenkz}{render-wiredir}
+  { [TKZ-RENDER-WIREDIR]~wire~record~#1~carries~dir='#2'~but~the~scan~
+    derives~'#3';~the~record~is~authoritative }
 
 % No layers: ink order is the fixed class order wires -> atoms -> marks,
 % stated here as the stage invariant.  A backgrounds layer is the paint-order
@@ -31,6 +37,22 @@
 % #1 tikz option list, #2 full path specification
 \cs_new_protected:Npn \__tenkz_ink_path:nn #1#2
   { \draw[#1] #2 ; }
+
+% ---------- coordinator strokes ------------------------------------------------
+% Through S2 the grid walk remains the topology coordinator; every stroke it
+% decides is inked here, token-for-token what the legacy walk emitted.  The
+% pixel gate holds because the emission is identical; the census holds
+% because grid keeps no ink authority.
+% One contraction bond, backed by wire record #1 (diagnostics and, at the
+% events landing, provenance): #2 style tokens, #3 direction-mark tokens,
+% #4/#5 the resolved anchors, west side first.
+\cs_new_protected:Npn \__tenkz_render_bond:nnnnn #1#2#3#4#5
+  { \draw[#2,#3] #4 -- #5 ; }
+\cs_generate_variant:Nn \__tenkz_render_bond:nnnnn { e }
+% A coordinator-decided stub or segment: #1 style tokens, #2 path tokens,
+% emitted verbatim.
+\cs_new_protected:Npn \__tenkz_render_stroke:nn #1#2
+  { \__tenkz_ink_path:nn {#1} {#2} }
 
 % ---------- skins ------------------------------------------------------------
 % The six kernel skins resolve to the calibrated styles of tenkz-core; a

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -53,6 +53,15 @@
 % emitted verbatim.
 \cs_new_protected:Npn \__tenkz_render_stroke:nn #1#2
   { \__tenkz_ink_path:nn {#1} {#2} }
+% A coordinator-decided label node: #1 option tokens, #2 position tokens,
+% #3 content tokens.  The named form threads the positional node name --
+% pgf registers positional names before option processing, and name=
+% inside the option list perturbs border-path arithmetic by a scaled
+% point (see \__tenkz_ink_node_named:nnnnn).
+\cs_new_protected:Npn \__tenkz_render_labelnode:nnn #1#2#3
+  { \node[#1] at #2 {#3}; }
+\cs_new_protected:Npn \__tenkz_render_labelnode_named:nnnn #1#2#3#4
+  { \node[#1] (#2) at #3 {#4}; }
 
 % ---------- skins ------------------------------------------------------------
 % The six kernel skins resolve to the calibrated styles of tenkz-core; a


### PR DESCRIPTION
Stacked on #4722. Bond ink authority moves to the model+render path: each bond looks up its WIRE record (`[TKZ-RENDER-NOWIRE]` if scan and derivation disagree; the record's `dir=` is authoritative via `[TKZ-RENDER-WIREDIR]`); all walk strokes — row/hole/combined stubs, frame segments, all ten physical-leg strokes — and thirteen label nodes emit through render-stage primitives with token-identical output.

Also lands `scripts/tenkz_pixelpair.sh`: the standing same-session paired-sweep tool (detached true-legacy worktree, 300 dpi, per-page byte compare) that the corrected parity methodology requires.

**Gates**: 261/261 events and **263/263 pages byte-identical** after each commit. **Census**: 115 → 86 ink tokens (grid raw draws 27→11, raw nodes 18→5); decimals hold at 71 — their owners are the cup/trace geometry that moves with S3.

Honest boundary: no bulk deletion yet — the walks' topology bookkeeping (pairing, boundary accounting, hole deferral) is load-bearing for cups/traces/boundaries, which are S3 territory. The walk deletions and the first decimal-meter drop come with S3's record-driven passes. Advances #4697.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the main Tenkz diagram ink path and makes bond drawing depend on model wire records, but changes are structured for pixel parity and add hard errors when derivation and scan disagree.
> 
> **Overview**
> **S2 render cutover:** Grid topology still decides *what* to draw, but bonds, stubs, physical legs, segments, and lattice labels now emit only through `\__tenkz_render_stroke`, `\__tenkz_render_bond`, and `\__tenkz_render_labelnode*` in `tenkz-render.code.tex`, replacing scattered `\draw` / `\node[tn~label…]` calls while keeping TikZ output token-identical.
> 
> **Bond authority:** Row contraction bonds resolve a **WIRE** record by endpoint pair (`\__tenkz_model_wire_by_ends` in `tenkz-model.code.tex`). Missing records or a `dir` mismatch vs the scan raise `[TKZ-RENDER-NOWIRE]` / `[TKZ-RENDER-WIREDIR]`; the model record wins when drawing.
> 
> **Verification:** Adds `scripts/tenkz_pixelpair.sh` for same-machine paired renders (detached base worktree vs HEAD, 300 dpi PNG byte compare). Label-overlap static checks now treat `\__tenkz_render_labelnode:nnn` as an audited label path alongside direct `tn~label` nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eea3f475239c213820ec6662d5d4bbc9a9da9d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->