### PR TITLE
fix(blueprint): restore symmetry PDF build

### DIFF
--- a/blueprint/src/chapter/ch12_symmetry_virtual_and_cohomology.tex
+++ b/blueprint/src/chapter/ch12_symmetry_virtual_and_cohomology.tex
@@ -177,7 +177,7 @@ on the bond space.
             \tn[role=operator,up=$i$]{U(g)} \\
             \tn{A}
         \end{tenkz}
-        \qquad \leadsto \qquad
+        \(\qquad \leadsto \qquad\)
         % Formula/source: Papers/0802.0447/StringOrder-v10.tex,
         % lines 328--349, especially Condition C1, gives the unitary u,V
         % specialization (V^\dagger = V^{-1}); the surrounding fundamental


### PR DESCRIPTION
Closes the post-merge Blueprint Pages failure introduced by #4719.

The symmetry diagram used `\leadsto` outside math mode. The PR CI web-only blueprint path accepted it, but the Pages workflow runs `leanblueprint pdf` first and failed with `Missing $ inserted`.

This wraps only the relation marker in inline math mode, preserving the two adjacent tenkz diagrams and their source-tracking comments.

Validation:
- `cd blueprint && leanblueprint pdf` (725 pages, exit 0)
- visually inspected the affected PDF page
- `cd blueprint && leanblueprint web` (exit 0; generated equation row keeps both SVGs and the inline relation)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line LaTeX formatting fix in blueprint source with no runtime or proof logic impact.
> 
> **Overview**
> Restores the Blueprint **PDF** build by fixing a LaTeX error in the virtual symmetry equation proof (`ch12_symmetry_virtual_and_cohomology.tex`).
> 
> The relation arrow between the two `tenkz` diagrams was written as `\qquad \leadsto \qquad` outside math mode. `\leadsto` requires math mode, so `leanblueprint pdf` failed with **Missing $ inserted** while the web-only CI path still passed.
> 
> The change wraps only that spacer and arrow in inline math: `\(\qquad \leadsto \qquad\)`, leaving the adjacent tensor-network figures and comments unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23da8d17730cffd6d6df6036171bd15c486f44c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->