### PR TITLE
fix(tenkz): split shared composite author blocks into per-target panels

### DIFF
--- a/tests/tenkz/rmp/manifest.toml
+++ b/tests/tenkz/rmp/manifest.toml
@@ -85,13 +85,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-mpo-sheet.tex"
 formula = "The 4-valent MPO tensor has directed virtual wire a: j -> k."
 ink = "Canonical public tenkz, tenkzfree environments; no raw TikZ."
 boundary = "West/east virtual and north/south physical ports are open in both depictions."
-source = "paper TN-Review-main.tex line 361; author source ImagesReview Section II/ImagesReview Section II.tex lines 305-316"
+source = "paper TN-Review-main.tex line 361; author source ImagesReview Section II/ImagesReview Section II.tex lines 305-309"
 capabilities = ["grid", "free-graph", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_mpo.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "305-316"
-extraction_override = "shared composite block; per-panel split pending"
+author_lines = "305-309"
 placements = [{ order = 5, line = 361, asset = "fig2_fig2-pepe_sec2fig5MPO.pdf" }]
 
 [[target]]
@@ -103,13 +102,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-ii-pepo-sheet.tex"
 formula = "O = sum_{s,s'} C(prod_r M_r^{s_r s'_r}) |s_1..s_N><s'_1..s'_N|."
 ink = "Canonical public tenkzlattice environment; no raw TikZ."
 boundary = "All sheet-edge virtual legs and both physical operator legs per site are open."
-source = "paper TN-Review-main.tex line 363; author source ImagesReview Section II/ImagesReview Section II.tex lines 305-316"
+source = "paper TN-Review-main.tex line 363; author source ImagesReview Section II/ImagesReview Section II.tex lines 311-314"
 capabilities = ["lattice", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_pepo5.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "305-316"
-extraction_override = "shared composite block; per-panel split pending"
+author_lines = "311-314"
 placements = [{ order = 6, line = 363, asset = "fig2_fig2-pepe_sec2fig5PEPO.pdf" }]
 
 [[target]]
@@ -263,7 +261,7 @@ paper_context_only = false
 fixture = "tests/tenkz/hard03_v3.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "484-499"
-extraction_override = "shared composite block; per-panel split pending"
+extraction_override = "shared racetrack; the spectrum panel adds only the eig wrapper"
 placements = [{ order = 15, line = 421, asset = "fig2_fig2-pepe_sec2fig8.pdf" }]
 
 [[target]]
@@ -281,7 +279,7 @@ paper_context_only = false
 fixture = "tests/tenkz/hard04_v3.tex"
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "484-499"
-extraction_override = "shared composite block; per-panel split pending"
+extraction_override = "shared racetrack; the spectrum panel adds only the eig wrapper"
 placements = [{ order = 16, line = 425, asset = "fig2_fig2-pepe_fig9-1.pdf" }]
 
 [[target]]
@@ -822,13 +820,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-pulling-through.tex"
 formula = "The full MPO-algebra string pulls through the PEPS plaquette."
 ink = "Canonical public tenkzfree four-arm ring before-and-after equation."
 boundary = "Four external PEPS legs and two MPO string ends remain open."
-source = "paper TN-Review-main.tex line 1356; author source ImagesReview Section III/ImagesReview Section III.tex lines 414-447"
+source = "paper TN-Review-main.tex line 1356; author source ImagesReview Section III/ImagesReview Section III.tex lines 170-197"
 capabilities = ["free-graph", "pulling-through", "rotated-action"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_eq50_pull.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "414-447"
-extraction_override = "shared composite block; per-panel split pending"
+author_lines = "170-197"
 placements = [{ order = 49, line = 1356, asset = "fig3_fig3-pepe_eq50redarrows.pdf" }]
 
 [[target]]
@@ -925,13 +922,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-tensor.tex"
 formula = "G_down = |0000> + |1111> is the four-leg GHZ copy tensor."
 ink = "Canonical public tenkz four-leg box with one physical orientation."
 boundary = "Two virtual and two physical GHZ indices remain open."
-source = "paper TN-Review-main.tex line 1449; author source ImagesReview Section III/ImagesReview Section III.tex lines 357-362"
+source = "paper TN-Review-main.tex line 1449; author source ImagesReview Section III/ImagesReview Section III.tex lines 357-358"
 capabilities = ["grid", "four-leg-atom", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_czx.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "357-362"
-extraction_override = "shared composite block; per-panel split pending"
+author_lines = "357-358"
 placements = [{ order = 55, line = 1449, asset = "fig3_fig3-pepe_ghzdown.pdf" }]
 
 [[target]]
@@ -943,13 +939,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-hadamard.tex"
 formula = "H = 2^-1/2 [[1,1],[1,-1]] is the local Hadamard map."
 ink = "Canonical public tenkz one-input one-output matrix box."
 boundary = "Exactly one input and one output matrix index remain open."
-source = "paper TN-Review-main.tex line 1449; author source ImagesReview Section III/ImagesReview Section III.tex lines 357-362"
+source = "paper TN-Review-main.tex line 1449; author source ImagesReview Section III/ImagesReview Section III.tex lines 359-360"
 capabilities = ["grid", "map-atom", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_czx.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "357-362"
-extraction_override = "shared composite block; per-panel split pending"
+author_lines = "359-360"
 placements = [{ order = 56, line = 1449, asset = "fig3_fig3-pepe_Hmatrix.pdf" }]
 
 [[target]]
@@ -961,13 +956,12 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-spt-mpo.tex"
 formula = "Pulling O_g through A deposits the physical action U_g on A."
 ink = "Canonical public tenkzfree PEPS star, crossing boxes, and g-string arcs."
 boundary = "Four virtual legs, one physical leg, and two g-string ends are open."
-source = "paper TN-Review-main.tex line 1459; author source ImagesReview Section III/ImagesReview Section III.tex lines 414-447"
+source = "paper TN-Review-main.tex line 1459; author source ImagesReview Section III/ImagesReview Section III.tex lines 414-444"
 capabilities = ["free-graph", "pulling-through", "crossing-order"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_sptmpo_cross.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "414-447"
-extraction_override = "shared composite block; per-panel split pending"
+author_lines = "414-444"
 placements = [{ order = 57, line = 1459, asset = "fig3_fig3-pepe_newSPTMPO.pdf" }]
 
 [[target]]
@@ -1608,7 +1602,6 @@ capabilities = ["lattice", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "742-800"
-extraction_override = "shared composite block; per-panel split pending"
 placements = []
 fixture = "tests/tenkz/t2_rgfp4.tex"
 
@@ -1733,12 +1726,12 @@ case = "tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-peps-fine-graining.tex
 formula = "One PEPS tensor is fine-grained into a 2x2 tensor patch."
 ink = "Canonical public tenkzlattice environments; no raw TikZ."
 boundary = "The one-site and 2x2 sheets expose matching outer virtual and physical boundaries."
-source = "author source ImagesReview Section II/ImagesReview Section II.tex lines 742-800; archival output figrenorm2D.pdf"
+source = "author source ImagesReview Section II/ImagesReview Section II.tex lines 801-831; archival output figrenorm2D.pdf"
 capabilities = ["lattice", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
-author_lines = "742-800"
-extraction_override = "shared composite block; per-panel split pending"
+author_lines = "801-831"
+extraction_override = "shared archival sheet; fine-graining is panel (b) of the historical composite"
 placements = []
 fixture = "tests/tenkz/t2_renorm13.tex"
 
@@ -1756,6 +1749,7 @@ capabilities = ["grid", "lattice", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section II/ImagesReview Section II.tex"
 author_lines = "801-831"
+extraction_override = "shared archival sheet; fine-graining is panel (b) of the historical composite"
 placements = []
 
 [[target]]
@@ -1852,7 +1846,7 @@ capabilities = ["free-graph", "rotated-action", "ring-closure"]
 paper_context_only = false
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "170-197"
-extraction_override = "shared composite block; per-panel split pending"
+extraction_override = "shared archival drawing; the historical PDF reuses the complete Diagram3 equality"
 placements = []
 
 [[target]]
@@ -1869,7 +1863,7 @@ capabilities = ["lattice", "regions", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
 author_lines = "170-197"
-extraction_override = "shared composite block; per-panel split pending"
+extraction_override = "shared archival drawing; the historical PDF reuses the complete Diagram3 equality"
 placements = []
 
 [[target]]
@@ -2011,11 +2005,11 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-ghz-up.tex"
 formula = "The upward GHZ copy tensor identifies its four binary indices."
 ink = "Canonical public tenkz four-leg atom with upward copy orientation."
 boundary = "Two virtual and two physical copy indices remain open."
-source = "author source ImagesReview Section III/ImagesReview Section III.tex lines 357-362; archival output ghzup.pdf"
+source = "author source ImagesReview Section III/ImagesReview Section III.tex lines 357-358; archival output ghzup.pdf"
 capabilities = ["grid", "four-leg-atom", "typed-ports"]
 paper_context_only = false
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "357-362"
+author_lines = "357-358"
 placements = []
 
 [[target]]
@@ -2027,11 +2021,11 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.t
 formula = "A virtual g-string pulls through a G-injective PEPS tensor."
 ink = "Canonical public tenkzfree PEPS star with opposite g-string corners."
 boundary = "Five PEPS legs and two g-string ends remain open on each side."
-source = "author source ImagesReview Section III/ImagesReview Section III.tex lines 414-447; archival output Ginjpullt.pdf"
+source = "author source ImagesReview Section III/ImagesReview Section III.tex lines 414-444; archival output Ginjpullt.pdf"
 capabilities = ["free-graph", "pulling-through", "open-string"]
 paper_context_only = false
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "414-447"
+author_lines = "414-444"
 placements = []
 fixture = "tests/tenkz/t2_eq50_pull.tex"
 

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpo-sheet.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpo-sheet.tex
@@ -4,7 +4,7 @@
 % Boundary: West/east virtual and north/south physical ports are open in both
 %   depictions.
 % Source: paper TN-Review-main.tex line 361; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 305-316
+%   II/ImagesReview Section II.tex lines 305-309
 % Capabilities: grid, free-graph, typed-ports
 % panel 1 - the same tensor in the grid language: an MPO site with open
 % virtual indices j (west), k (east) and physical legs m (up), n (down);

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-pepo-sheet.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-pepo-sheet.tex
@@ -4,7 +4,7 @@
 % Boundary: All sheet-edge virtual legs and both physical operator legs per site are
 %   open.
 % Source: paper TN-Review-main.tex line 363; author source ImagesReview Section
-%   II/ImagesReview Section II.tex lines 305-316
+%   II/ImagesReview Section II.tex lines 311-314
 % Capabilities: lattice, typed-ports
 \[
   O \;=\;

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-peps-fine-graining.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-peps-fine-graining.tex
@@ -4,7 +4,7 @@
 % Boundary: The one-site and 2x2 sheets expose matching outer virtual and physical
 %   boundaries.
 % Source: author source ImagesReview Section II/ImagesReview Section II.tex lines
-%   742-800; archival output figrenorm2D.pdf
+%   801-831; archival output figrenorm2D.pdf
 % Capabilities: lattice, typed-ports
 \[
   \begin{tenkzlattice}[rows=1,cols=1,frame=oblique,physical=up,

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-tensor.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-tensor.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkz four-leg box with one physical orientation.
 % Boundary: Two virtual and two physical GHZ indices remain open.
 % Source: paper TN-Review-main.tex line 1449; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 357-362
+%   III/ImagesReview Section III.tex lines 357-358
 % Capabilities: grid, four-leg-atom, typed-ports
 \[
   G_{\downarrow}=

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-hadamard.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-hadamard.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkz one-input one-output matrix box.
 % Boundary: Exactly one input and one output matrix index remain open.
 % Source: paper TN-Review-main.tex line 1449; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 357-362
+%   III/ImagesReview Section III.tex lines 359-360
 % Capabilities: grid, map-atom, typed-ports
 \[
   \begin{tenkz}[physical=updown, west=none, east=none, tensor style=box]

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-pulling-through.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-pulling-through.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkzfree four-arm ring before-and-after equation.
 % Boundary: Four external PEPS legs and two MPO string ends remain open.
 % Source: paper TN-Review-main.tex line 1356; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 414-447
+%   III/ImagesReview Section III.tex lines 170-197
 % Capabilities: free-graph, pulling-through, rotated-action
 \[
   \begin{tenkzfree}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-spt-mpo.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-spt-mpo.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkzfree PEPS star, crossing boxes, and g-string arcs.
 % Boundary: Four virtual legs, one physical leg, and two g-string ends are open.
 % Source: paper TN-Review-main.tex line 1459; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 414-447
+%   III/ImagesReview Section III.tex lines 414-444
 % Capabilities: free-graph, pulling-through, crossing-order
 \[
   \begin{tenkzfree}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkzfree PEPS star with opposite g-string corners.
 % Boundary: Five PEPS legs and two g-string ends remain open on each side.
 % Source: author source ImagesReview Section III/ImagesReview Section III.tex
-%   lines 414-447; archival output Ginjpullt.pdf
+%   lines 414-444; archival output Ginjpullt.pdf
 % Capabilities: free-graph, pulling-through, open-string
 \[
   \begin{tenkzfree}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-ghz-up.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-ghz-up.tex
@@ -3,7 +3,7 @@
 % Ink: Canonical public tenkz four-leg atom with upward copy orientation.
 % Boundary: Two virtual and two physical copy indices remain open.
 % Source: author source ImagesReview Section III/ImagesReview Section III.tex
-%   lines 357-362; archival output ghzup.pdf
+%   lines 357-358; archival output ghzup.pdf
 % Capabilities: grid, four-leg-atom, typed-ports
 \[
   G_{\uparrow}=\begin{tenkz}[physical=updown]

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -2,7 +2,7 @@
 # Schema: scripts/tenkz_rmp.py (load_verdicts).  Any status may be
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
-campaign_sha256 = "42dc917309993cce67409cbe7846508cc5dc0ce6836fa4d92cd44174e42305cb"
+campaign_sha256 = "2ddff10f7de9703dc9a8e3a9ae21f730286a176a3224c9ef965d1a10cd70d270"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"
@@ -52,9 +52,9 @@ id = "rmp-ii-mpo-sheet"
 status = "cosmetic-gap"
 pairing = "unverified"
 defects = ["label-collision"]
-case_sha256 = "c3882e18c2eda6cc2b65170ab3609a56fe9c74db894266ba776af679b1fb55d8"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
+case_sha256 = "02f15c77e9641b096ce8fae576f5eacb649ecd8188bb8bb7bf703b36c9a88fa8"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
 note = "wire label a overlaps ink"
 
 [[verdict]]
@@ -62,9 +62,9 @@ id = "rmp-ii-pepo-sheet"
 status = "faithful"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
-case_sha256 = "3af77fde1def2ea1dd5b575c13d5051c96b2e53bcb3a46b171188f7b11ca2520"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
+case_sha256 = "ea74f5bc2d43c9f670366c484dacff041e1480a8493a4e8d2a334129173c225d"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
 second_viewer = "pairing-sweep-two-viewers-2026-07-23"
 note = "maintainer: OK"
 
@@ -513,9 +513,9 @@ pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = ["text-substitution"]
 missing = ["pulling-through", "rotated-action"]
-case_sha256 = "85cfefb033d051019d6ace7c242539b3199eb872a286e0be6a60d864f091c45b"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
+case_sha256 = "55a3de450cf765a09bd2191833e63f42f749fe187ecbe360d310c38d928264a2"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
 note = "already judged"
 
 [[verdict]]
@@ -575,19 +575,19 @@ note = "slanted brick lattice + directed legs axis-aligned"
 id = "rmp-iii-a-ghz-tensor"
 status = "cosmetic-gap"
 pairing = "unverified"
-case_sha256 = "25e9eb9e6cb2dc636f04572fad6fa3146d7c63511d96559a479c09fe32087008"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
+case_sha256 = "515a44835e0eee4b37dd4a1976f1a120188931c80c1785599848cb77ffcc878c"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
 note = "box-G vs copy-dot; diagonal leg angle"
 
 [[verdict]]
 id = "rmp-iii-a-hadamard"
 status = "cosmetic-gap"
 pairing = "unverified"
-case_sha256 = "4ade62aa7efa99c2d6b5b492641675d8d3be9fbf00e0149aa23c1692136c101d"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
-note = "H matrix correct; shared author block (#4706)"
+case_sha256 = "ae3e69b02f579b42925b116697b02e2c5d0988578db1b0e41bb334576171b106"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
+note = "H matrix correct; author panel isolated from the GHZ copy tensor"
 
 [[verdict]]
 id = "rmp-iii-a-spt-mpo"
@@ -596,9 +596,9 @@ pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = ["placement-illegible"]
 missing = ["rotated-action", "strings"]
-case_sha256 = "85081030efcafb9593790da97409eef7b4b6b9799cc0c4ce2ca5916626830d1c"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
+case_sha256 = "ce29de07fbd5fa8b0081946c35dd1503d495ec6ab0931f8b7165c4c194ed2156"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
 note = "45-degree double strand as axis-aligned stubs"
 
 [[verdict]]
@@ -1099,10 +1099,10 @@ status = "blocked"
 pairing = "unverified"
 defects = ["missing-element"]
 missing = ["equation-composition"]
-case_sha256 = "e786d70146e02303415e0309cbe33681332bce0a00584a2f1653130adeef3ce7"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
-note = "(a)-(d) panels missing"
+case_sha256 = "b0cded7c1bee18eda923beceae990775328ef6f9e95c1e685715b91495bca607"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
+note = "archival panel (a) remains outside the canonical fine-graining case"
 
 [[verdict]]
 id = "rmp-workbench-ii-historical-composite"
@@ -1269,9 +1269,9 @@ note = "staggering and arrow legs flattened"
 id = "rmp-workbench-iii-ghz-up"
 status = "cosmetic-gap"
 pairing = "unverified"
-case_sha256 = "38c5f34dffa691a0b97ff194f5396a36a559240ba89653ec84489fb0b9f734a9"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
+case_sha256 = "8fdf3445428c6dce5f324dde05f98f95c028559a7f7bf0998359552dc6dfe8db"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
 note = "glyph and leg geometry"
 
 [[verdict]]
@@ -1280,9 +1280,9 @@ status = "blocked"
 pairing = "unverified"
 defects = ["missing-element"]
 missing = ["pulling-through", "strings"]
-case_sha256 = "8d68e821ae5f684af03548f9c7afbff60dae2b7f255dc70a9ad2dc84457606af"
-reviewed = "2026-07-23"
-renderer = "maintainer-page-review-2026-07-23"
+case_sha256 = "b6d5abc6a5a3c80785845334c1ca0d477676acb881a154f83213cb74a79edd8b"
+reviewed = "2026-07-24"
+renderer = "source-split-page-review-2026-07-24"
 note = "g string, hatched legs, U_g node absent"
 
 [[verdict]]


### PR DESCRIPTION
## Summary

Narrows the RMP author-source provenance to the labelled panel that each target actually owns. The manifest `source`, `author_lines`, and case `% Source:` headers now agree; affected verdict digests and the campaign digest are refreshed after page review.

`extract_author_block` activates every single-`%` line in a declared range. The old broad ranges therefore combined unrelated toggled panels into one reference figure. This change assigns clean sub-blocks where the author source is separable and replaces the temporary pending overrides with evidence-backed exceptions where the archival drawing is genuinely shared.

## Range audit

| Target | Old range | New range | Panel shown |
|---|---:|---:|---|
| `rmp-ii-mpo-sheet` | 305-316 | 305-309 | five-site MPO chain |
| `rmp-ii-pepo-sheet` | 305-316 | 311-314 | 4x4 PEPO sheet |
| `rmp-ii-reduced-density` | 484-499 | 484-499 | reduced-density racetrack; shared core retained |
| `rmp-ii-spectrum-rho` | 484-499 | 484-499 | the same racetrack with the `eig` wrapper; shared core retained |
| `rmp-iii-a-pulling-through` | 414-447 | 170-197 | four-arm lambda pulling-through equality |
| `rmp-iii-a-ghz-tensor` | 357-362 | 357-358 | GHZ copy-tensor cross |
| `rmp-iii-a-hadamard` | 357-362 | 359-360 | Hadamard dot on its horizontal wire |
| `rmp-iii-a-spt-mpo` | 414-447 | 414-444 | virtual `g` string pulled through the PEPS tensor |
| `rmp-workbench-ii-peps-rg-workbench` | 742-800 | 742-800 | coherent Fig. 14 panels (a)-(d) |
| `rmp-workbench-ii-peps-fine-graining` | 742-800 | 801-831 | labelled Fig. 15 one-to-two / one-to-four fine-graining sheet |
| `rmp-workbench-iii-diagram-three` | 170-197 | 170-197 | complete Diagram3 rotated-action equality |
| `rmp-workbench-iii-historical-composite` | 170-197 | 170-197 | archival target that reuses the complete Diagram3 equality |
| `rmp-workbench-iii-ghz-up` | 357-362 | 357-358 | workbench GHZ copy-tensor cross |
| `rmp-workbench-iii-g-injective-pull` | 414-447 | 414-444 | workbench `g`-string pull-through equality |

## Retained shared-drawing evidence

- Spectrum: lines 487-488 are only the `eig` wrapper; lines 489-498 are the common racetrack. The reduced-density and spectrum assets therefore share the same indivisible drawing core.
- Fig. 15: `figrenorm2D.pdf` and the historical Section II composite are the same two-panel sheet from lines 801-831. The fine-graining target is panel (b), so the archival composite ownership remains explicit.
- Diagram3: both workbench targets deliberately reuse the complete before/after equality at lines 170-197; there is no independent subpanel boundary that preserves either target.

These overrides no longer say "per-panel split pending"; they state the concrete shared-drawing reason.

## Validation

Validated exact commit `bc153c231d82438951c148fcc869c5b16fd1c165`:

- `python3 scripts/tenkz_rmp.py check --all` - 130/130 validated, compiled, linted, and audited
- `python3 scripts/tenkz_rmp.py compare --all --source-root /Users/siruilu/Local/agentFormalization/TNLean/tex/RMP_TIKZ_SOURCE_CODE` - wrote the 130-page comparison book
- visually inspected affected comparison pages 5, 6, 15, 16, 49, 55, 56, 57, 95, 103, 104, 110, 111, 120, and 121; every extracted author figure is coherent and the cleanly separable targets no longer superimpose panels
- confirmed the exact-head affected pages are pixel-identical to the inspected renders
- confirmed the forbidden tenkz implementation/golden paths are untouched

Closes LionSR/tenkz#67.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and verdict-ledger updates only; no changes to tenkz rendering or application logic.
> 
> **Overview**
> **RMP benchmark provenance** is tightened so each target’s `author_lines`, manifest `source`, and case `% Source:` comments point at the **single author panel** that target owns, instead of broad ranges that made `extract_author_block` superimpose unrelated toggled figures.
> 
> Separable composites are **split by line range** (e.g. MPO chain 305–309 vs PEPO sheet 311–314; GHZ 357–358 vs Hadamard 359–360; pulling-through moved to Diagram3 lines 170–197; fine-graining workbench to 801–831). Where one archival drawing is indivisible, generic `per-panel split pending` overrides are replaced with **explicit `extraction_override` notes** (shared racetrack / Fig. 15 sheet / Diagram3 equality).
> 
> **`verdicts.toml`** refreshes affected `case_sha256` digests, review metadata (`source-split-page-review-2026-07-24`), and **`campaign_sha256`** after re-page-review; tenkz case LaTeX content is unchanged aside from matching source-line comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc153c231d82438951c148fcc869c5b16fd1c165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->