### PR TITLE
refactor(tenkz): one event parser and one TeX reader for the checkers

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -24,6 +24,10 @@ on:
       - 'scripts/write_badges.py'
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_lint.py'
+      - 'scripts/tenkz_rmp.py'
+      - 'scripts/tenkzlib/**'
+      - 'scripts/test_tnlog.py'
+      - 'scripts/test_texcase.py'
       - 'scripts/test_tenkz_pic.py'
       - 'scripts/test_tenkz_equation_audit.py'
   workflow_dispatch:
@@ -61,6 +65,8 @@ jobs:
             'tex/tenkz/examples/*.tex'
           python3 scripts/test_tenkz_pic.py
           python3 scripts/test_tenkz_equation_audit.py
+          python3 scripts/test_tnlog.py
+          python3 scripts/test_texcase.py
 
       - name: Build blueprint bibliography
         run: python3 scripts/blueprint_bibtex.py

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -36,6 +36,8 @@ on:
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
+      - 'scripts/tenkz_rmp.py'
+      - 'scripts/tenkzlib/**'
       - 'scripts/tenkz_language.py'
       - 'scripts/tenkz_shrink.py'
       - 'scripts/test_tenkz_shrink.py'
@@ -55,6 +57,8 @@ on:
       - 'scripts/test_tenkz_peps_torus.py'
       - 'scripts/test_tenkz_index_routing.py'
       - 'scripts/test_tenkz_tree.py'
+      - 'scripts/test_tnlog.py'
+      - 'scripts/test_texcase.py'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -84,6 +88,8 @@ on:
       - 'scripts/blueprint_lean_sync.py'
       - 'scripts/check_reader_facing_prose.py'
       - 'scripts/tenkz_audit.py'
+      - 'scripts/tenkz_rmp.py'
+      - 'scripts/tenkzlib/**'
       - 'scripts/tenkz_language.py'
       - 'scripts/tenkz_shrink.py'
       - 'scripts/test_tenkz_shrink.py'
@@ -103,6 +109,8 @@ on:
       - 'scripts/test_tenkz_peps_torus.py'
       - 'scripts/test_tenkz_index_routing.py'
       - 'scripts/test_tenkz_tree.py'
+      - 'scripts/test_tnlog.py'
+      - 'scripts/test_texcase.py'
   workflow_dispatch:
 
 concurrency:
@@ -167,6 +175,8 @@ jobs:
               - 'scripts/blueprint_bibtex.py'
               - 'scripts/check_reader_facing_prose.py'
               - 'scripts/tenkz_audit.py'
+              - 'scripts/tenkz_rmp.py'
+              - 'scripts/tenkzlib/**'
               - 'scripts/tenkz_language.py'
               - 'scripts/tenkz_shrink.py'
               - 'scripts/test_tenkz_shrink.py'
@@ -181,10 +191,13 @@ jobs:
               - 'scripts/test_tenkz_peps_torus.py'
               - 'scripts/test_tenkz_index_routing.py'
               - 'scripts/test_tenkz_tree.py'
+              - 'scripts/test_tnlog.py'
+              - 'scripts/test_texcase.py'
             corpus:
               - 'tex/tenkz/**'
               - 'tests/tenkz/**'
               - 'scripts/tenkz_audit.py'
+              - 'scripts/tenkzlib/**'
               - 'scripts/tenkz_corpus.sh'
               - 'scripts/tenkz_golden.sh'
               - 'scripts/tenkz_render_corpus.py'
@@ -198,6 +211,7 @@ jobs:
               - 'scripts/tenkz_language.py'
               - 'scripts/tenkz_lint.py'
               - 'scripts/tenkz_shrink.py'
+              - 'scripts/tenkzlib/**'
               - 'scripts/test_tenkz_shrink.py'
             workflow:
               - '.github/workflows/pr-ci.yml'
@@ -447,6 +461,12 @@ jobs:
             'docs/tenkz/chapters2/*.tex' \
             'docs/slides/*.tex' \
             'tex/tenkz/examples/*.tex'
+
+      - name: Test shared tenkz parsers
+        if: env.TEX_CHANGED == 'true'
+        run: |
+          python3 scripts/test_tnlog.py
+          python3 scripts/test_texcase.py
 
       # Build the root manual as well as its input chapters.  This is the
       # syntax gate for manual2.tex, tenkzmanual2.sty, and the expl3 package

--- a/scripts/generate_badges.py
+++ b/scripts/generate_badges.py
@@ -61,7 +61,7 @@ def tracked_lean_files(repo_root: Path) -> list[Path]:
     ]
 
 
-def strip_comments_and_strings(source: str) -> str:
+def strip_lean_comments_and_strings(source: str) -> str:
     result: list[str] = []
     i = 0
     block_depth = 0
@@ -130,7 +130,7 @@ def count_pattern(files: list[Path], pattern: re.Pattern[str]) -> int:
     count = 0
     for path in files:
         source = path.read_text(encoding="utf-8")
-        count += len(pattern.findall(strip_comments_and_strings(source)))
+        count += len(pattern.findall(strip_lean_comments_and_strings(source)))
     return count
 
 

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -81,13 +81,23 @@ from __future__ import annotations
 import hashlib
 import re
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from fractions import Fraction
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 
-INT_RE = re.compile(r"-?\d+")
-CELL_RE = re.compile(r"-?\d+--?\d+")  # r-c with signed components
+from tenkzlib.texcase import Construct, scan_constructs, strip_comments
+from tenkzlib.tnlog import (
+    FIELD_VALIDATORS,
+    Event,
+    Picture,
+    _is_cell,
+    _is_int,
+    _is_nonnegative_int,
+    _is_pairleg_port,
+    _is_positive_int,
+    parse_log,
+)
 
 # The .tnlog dialect tag each tenkz environment logs -- the single
 # argument each sub-language's code passes to `\tenkz@beginpicture` in
@@ -126,68 +136,6 @@ DIALECT_KINDS = {
                 "pairtrace", "label-anchor-site", "boundary", "warning"},
     "cd": {"cdcell", "cdobject", "cdarrow", "cdmap", "tree"},
 }
-
-
-def _parse_int(v: str) -> Optional[int]:
-    if INT_RE.fullmatch(v) is None:
-        return None
-    try:
-        return int(v)
-    except ValueError:  # Python's configured decimal-digit safety limit
-        return None
-
-
-def _is_int(v: str) -> bool:
-    return _parse_int(v) is not None
-
-
-def _is_positive_int(v: str) -> bool:
-    parsed = _parse_int(v)
-    return parsed is not None and parsed > 0
-
-
-def _is_nonnegative_int(v: str) -> bool:
-    parsed = _parse_int(v)
-    return parsed is not None and parsed >= 0
-
-
-def _is_cell(v: str) -> bool:
-    return re.fullmatch(r"\d+-\d+", v) is not None
-
-
-def _is_lattice_cell(v: str) -> bool:
-    return re.fullmatch(r"\d+-\d+(?:-\d+)?", v) is not None
-
-
-def _is_lattice_cell_list(v: str) -> bool:
-    return bool(v) and all(_is_lattice_cell(cell.strip())
-                           for cell in v.split(","))
-
-
-def _is_region_cell_list(v: str) -> bool:
-    """A resolved region may be empty; non-empty memberships stay strict."""
-    return not v or _is_lattice_cell_list(v)
-
-
-def _is_pairleg_port(v: str) -> bool:
-    """A contraction starts at the centred face or a positive face slot."""
-    if v == "center":
-        return True
-    if not _is_int(v):
-        return False
-    try:
-        return int(v) > 0
-    except ValueError:
-        return False
-
-
-def _enum(*vals: str) -> Callable[[str], bool]:
-    allowed = set(vals)
-    return lambda v: v in allowed
-
-
-def _any(v: str) -> bool:
-    return v != ""
 
 
 Rect = tuple[int, int, int, int]
@@ -440,151 +388,6 @@ def _stroked_polygon_intersects_roundrect(
     )
 
 
-# kind -> {field: validator}; fields absent here are accepted as opaque.
-# Numeric slots are validated strictly: they are cell/row coordinates, and
-# a coordinate that is not an integer addresses nothing.
-FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
-    "picture": {"id": _is_int, "lang": _any},
-    "label-use": {"picture": _is_int},
-    "label-anchor-site": {"picture": _is_int, "label": _is_positive_int,
-                          "x": _is_int, "y": _is_int},
-    "ink-use": {"picture": _is_int, "class": _enum("glyph", "wire"),
-                "id": _is_positive_int,
-                "shape": _enum("rect", "circle", "roundrect", "triangle")},
-    "atom": {"picture": _is_int, "cell": _is_cell, "name": _any, "kind": _any},
-    "faceports": {"picture": _is_int, "cell": _is_cell,
-                  "face": _enum("up", "down", "west", "east"),
-                  "arity": _is_nonnegative_int, "at": _any},
-    "pairleg": {"picture": _is_int, "upper": _is_cell, "lower": _is_cell,
-                "upper-port": _is_pairleg_port,
-                "column": _is_int},
-    # The emitter normalizes the user-facing `bond dir=left|right` to
-    # forward/reverse (direction along the wire); accept both spellings.
-    "bond": {"picture": _is_int, "row": _is_int, "from": _is_int, "to": _is_int,
-             "dir": _enum("none", "left", "right", "forward", "reverse")},
-    "trace": {"picture": _is_int, "row": _is_int,
-              "side": _enum("above", "below"),
-              "lang": _enum("lattice"),
-              "axis": _enum("west-east", "north-south"),
-              "sheet": _is_nonnegative_int, "slot": _is_positive_int,
-              "from": _is_cell, "to": _is_cell},
-    "hooks": {"picture": _is_int, "row": _is_int, "side": _enum("above", "below")},
-    "pairtrace": {"picture": _is_int, "row": _is_int, "col": _is_int, "site": _is_cell},
-    "phtrace": {"picture": _is_int, "row": _is_int, "col": _is_int},
-    "cup": {"picture": _is_int, "lang": _enum("lattice"),
-            "side": _enum("west", "east", "north", "south"),
-            "top": _is_int, "bottom": _is_int, "cell": _is_cell,
-            "sheet-a": _is_int, "sheet-b": _is_int, "matrix": _is_int},
-    "hole": {"picture": _is_int, "row": _is_int, "col": _is_int},
-    "warning": {"picture": _is_int, "code": _any},
-    "boundary": {"picture": _is_int, "virtual-west": _is_int, "virtual-east": _is_int,
-                 "virtual-north": _is_int, "virtual-south": _is_int,
-                 "physical-up": _is_int, "physical-down": _is_int},
-    "bbox": {"picture": _is_int, "class": _enum("label", "wire"),
-             "id": _is_positive_int, "xmin": _is_int, "xmax": _is_int,
-             "ymin": _is_int, "ymax": _is_int,
-             "shape": _enum("rect", "roundrect"),
-             "radius": _is_nonnegative_int},
-    "glyph-geometry": {"picture": _is_int, "owner": _is_positive_int,
-                       "shape": _enum("rect", "circle", "roundrect", "triangle"),
-                       "xmin": _is_int, "xmax": _is_int,
-                       "ymin": _is_int, "ymax": _is_int,
-                       "radius": _is_nonnegative_int,
-                       "stroke": _is_nonnegative_int,
-                       "x1": _is_int, "y1": _is_int,
-                       "x2": _is_int, "y2": _is_int,
-                       "x3": _is_int, "y3": _is_int},
-    "wire-geometry": {"picture": _is_int, "owner": _is_positive_int,
-                      "shape": _enum("rect-minus-label"),
-                      "xmin": _is_int, "xmax": _is_int,
-                      "y": _is_int, "outer": _is_positive_int,
-                      "inner": _is_nonnegative_int,
-                      "cut-shape": _enum("rect", "roundrect"),
-                      "cut-xmin": _is_int, "cut-xmax": _is_int,
-                      "cut-ymin": _is_int, "cut-ymax": _is_int,
-                      "cut-radius": _is_nonnegative_int,
-                      "cut-id": _is_positive_int},
-    "lattice": {"picture": _is_int, "rows": _is_positive_int,
-                "cols": _is_positive_int, "sheets": _is_positive_int,
-                "roles": _any},
-    "site": {"picture": _is_int, "cell": _is_lattice_cell,
-             "mode": _enum("removed")},
-    "region": {"picture": _is_int, "lang": _enum("free", "lattice"),
-               "slot": _enum("selected", "secondary", "complement",
-                             "collar", "neutral", "group"),
-               "cells": _is_region_cell_list, "members": _any,
-               "outline": _enum("0", "1"), "name": _any},
-    "edge": {"picture": _is_int, "from": _is_lattice_cell,
-             "to": _is_lattice_cell,
-             "role": _enum("none", "operator", "marked", "extra", "passive")},
-    "cdcell": {"picture": _is_int, "index": _is_int},
-    "cdobject": {"picture": _is_int, "cell": _is_cell},
-    "cdarrow": {"picture": _is_int, "from": _any, "to": _any},
-    "cdmap": {"picture": _is_int, "from": _is_cell, "to": _is_cell,
-              "fused": _enum("0", "1"),
-              "role": _enum("none", "operator", "marked", "extra", "passive"),
-              "species": _any},
-    "tree": {"picture": _is_int, "id": _is_positive_int,
-             "style": _enum("wire", "ribbon"),
-             "leaves": _is_positive_int, "vertices": _is_nonnegative_int,
-             "topology": _any,
-             "role": _enum("none", "operator", "marked", "extra", "passive"),
-             "species": _any},
-    "join": {"picture": _is_int, "from": _any, "to": _any},
-    "span": {"picture": _is_int, "row": _is_positive_int,
-             "col": _is_positive_int, "length": _is_positive_int,
-             "kind": _enum("brace above", "brace below", "box")},
-}
-
-
-@dataclass
-class Event:
-    kind: str
-    attrs: dict[str, str]
-    line: int
-    raw: str
-
-
-@dataclass
-class Picture:
-    ident: int
-    lang: str
-    line: int
-    events: list[Event] = field(default_factory=list)
-
-    def content(self) -> list[Event]:
-        """Events that denote ink.  Derived boundaries and warning
-        diagnostics do not contribute to the canonical topology."""
-        return [e for e in self.events
-                if e.kind not in {"bbox", "label-use", "label-anchor-site",
-                                  "ink-use",
-                                  "glyph-geometry", "wire-geometry",
-                                  "boundary", "warning"}]
-
-    def boundary(self) -> Optional[tuple[int, int, int, int]]:
-        for e in self.events:
-            if e.kind == "boundary":
-                try:
-                    return tuple(int(e.attrs[k].strip()) for k in
-                                 ("virtual-west", "virtual-east",
-                                  "physical-up", "physical-down"))  # type: ignore[return-value]
-                except (KeyError, ValueError):
-                    return None
-        return None
-
-    def ncols(self) -> int:
-        n = 0
-        for e in self.events:
-            if e.kind == "atom" and "cell" in e.attrs and _is_cell(e.attrs["cell"].strip()):
-                n = max(n, int(e.attrs["cell"].strip().split("-")[1]))
-            elif e.kind == "bond":
-                for k in ("from", "to"):
-                    v = e.attrs.get(k, "").strip()
-                    if _is_int(v):
-                        n = max(n, int(v))
-        return n
-
-
 @dataclass
 class Finding:
     severity: str  # "HARD" | "ADV" | "NOTE"
@@ -640,69 +443,18 @@ class Audit:
     # ---------------- parsing ----------------
 
     def parse_log(self) -> None:
-        name = self.log_path.name
-        for lineno, raw in enumerate(
-                self.log_path.read_text(encoding="utf-8").splitlines(), 1):
-            line = raw.strip()
-            if not line:
-                continue
-            where = f"{name}:{lineno}"
-            parts = line.split("|")
-            kind = parts[0].strip()
-            attrs: dict[str, str] = {}
-            ok = True
-            for p in parts[1:]:
-                if "=" not in p:
-                    self.hard("malformed-event", where,
-                              f"bare field {p.strip()!r} (expected key=value): {line}")
-                    ok = False
-                    continue
-                k, v = p.split("=", 1)
-                attrs[k.strip()] = v.strip()
-            ev = Event(kind, attrs, lineno, line)
-            validators = FIELD_VALIDATORS.get(kind)
-            if validators is None:
-                self.adv("unknown-event", where, f"unrecognized event kind {kind!r}")
-            else:
-                for k, v in attrs.items():
-                    check = validators.get(k)
-                    if check is not None and not check(v):
-                        self.hard("malformed-event", where,
-                                  f"{kind} field {k}={v!r} fails validation: {line}")
-                        ok = False
-                if kind != "picture" and "picture" not in attrs:
-                    self.hard("malformed-event", where,
-                              f"{kind} event lacks required picture=: {line}")
-                    ok = False
-            if kind == "picture":
-                if not ok or "id" not in attrs or not _is_int(attrs["id"]):
-                    continue
-                pid = int(attrs["id"])
-                lang = attrs.get("lang", "")
-                if lang not in KNOWN_LANGS:
-                    self.adv("unknown-lang", where, f"picture {pid} has lang={lang!r}")
-                if pid in self.by_id:
-                    self.hard("duplicate-picture", where,
-                              f"picture id {pid} already declared at line "
-                              f"{self.by_id[pid].line}")
-                    continue
-                pic = Picture(pid, lang, lineno)
-                self.by_id[pid] = pic
-                self.pictures.append(pic)
-                continue
-            if kind == "tree":
-                self.check_tree_event(ev)
-            ref = attrs.get("picture", "")
-            if not _is_int(ref):
-                continue
-            pid = int(ref)
-            if pid == 0 and kind == "tree":
-                continue  # \tntree in running math, outside any picture
-            if pid not in self.by_id:
-                self.hard("dangling-picture-ref", where,
-                          f"{kind} references undeclared picture {pid}")
-                continue
-            self.by_id[pid].events.append(ev)
+        parsed = parse_log(
+            self.log_path.read_text(encoding="utf-8"),
+            source_name=self.log_path.name,
+            known_langs=KNOWN_LANGS,
+            hard=self.hard,
+            advisory=self.adv,
+            check_event=lambda event: (
+                self.check_tree_event(event) if event.kind == "tree" else None
+            ),
+        )
+        self.pictures = parsed.pictures
+        self.by_id = parsed.by_id
 
     def check_tree_event(self, event: Event) -> None:
         """Validate the tree event as structural data, not display text."""
@@ -1661,115 +1413,6 @@ def canonical_hash(pic: Picture) -> str:
 
 
 # ---------------- TeX source scanning ----------------
-
-@dataclass
-class Construct:
-    name: str      # environment name or "tnpic"
-    start: int     # offset of the construct's first character
-    end: int       # offset one past its last character
-    body: str
-    line: int
-
-
-def strip_comments(src: str) -> str:
-    """Replace unescaped `%`-comments with spaces, preserving offsets so
-    positions in the stripped text index the original file."""
-    out: list[str] = []
-    for line in src.split("\n"):
-        buf = list(line)
-        i = 0
-        while i < len(buf):
-            if buf[i] == "\\":
-                i += 2
-                continue
-            if buf[i] == "%":
-                for j in range(i, len(buf)):
-                    buf[j] = " "
-                break
-            i += 1
-        out.append("".join(buf))
-    return "\n".join(out)
-
-
-def _match_group(src: str, i: int, open_ch: str, close_ch: str) -> int:
-    """Offset one past the group opening at `src[i]`, brace-aware: a `]`
-    inside `{...}` does not close a `[...]` group.  Works for both brace
-    and bracket groups.  Returns -1 if unbalanced."""
-    depth_group = 0
-    depth_brace = 0
-    while i < len(src):
-        c = src[i]
-        if c == "\\":
-            i += 2
-            continue
-        if c == open_ch and (open_ch == "{" or depth_brace == 0):
-            depth_group += 1
-        elif c == close_ch and (close_ch == "}" or depth_brace == 0):
-            depth_group -= 1
-            if depth_group == 0:
-                return i + 1
-        elif c == "{":
-            depth_brace += 1
-        elif c == "}":
-            depth_brace -= 1
-        i += 1
-    return -1
-
-
-def _find_env_end(src: str, name: str, pos: int) -> Optional[re.Match[str]]:
-    """Match of the `\\end{name}` closing the `\\begin{name}` whose body
-    starts at `pos`, depth-counting nested same-name environments so an
-    inner `\\end` never closes the outer construct.  None if unclosed."""
-    token_re = re.compile(r"\\(begin|end)\{" + re.escape(name) + r"\}")
-    depth = 1
-    for tok in token_re.finditer(src, pos):
-        depth += 1 if tok.group(1) == "begin" else -1
-        if depth == 0:
-            return tok
-    return None
-
-
-def scan_constructs(src: str) -> list[Construct]:
-    """Picture-producing constructs in source order.  tenkz assigns picture
-    ids at `\\begin` time, so source order of construct starts equals log
-    order even when a `\\tnpic` nests inside a `tenkzcd` cell."""
-    found: list[Construct] = []
-    env_re = re.compile(r"\\begin\{(tenkz(?:cd|lattice|free|planes)?)\}")
-    for m in env_re.finditer(src):
-        name = m.group(1)
-        end_m = _find_env_end(src, name, m.end())
-        end = end_m.end() if end_m else len(src)
-        body_start = m.end()
-        if src[body_start:body_start + 1] == "[":
-            closed = _match_group(src, body_start, "[", "]")
-            if closed != -1:
-                body_start = closed
-        body_end = end_m.start() if end_m else len(src)
-        found.append(Construct(name, m.start(), end,
-                               src[body_start:body_end],
-                               src.count("\n", 0, m.start()) + 1))
-    for m in re.finditer(r"\\tnpic\b", src):
-        i = m.end()
-        while i < len(src) and src[i] in " \t\n":
-            i += 1
-        if src[i:i + 1] == "[":
-            closed = _match_group(src, i, "[", "]")
-            if closed == -1:
-                continue
-            i = closed
-            while i < len(src) and src[i] in " \t\n":
-                i += 1
-        if src[i:i + 1] != "{":
-            continue
-        closed = _match_group(src, i, "{", "}")
-        if closed == -1:
-            continue
-        found.append(Construct("tnpic", m.start(), closed,
-                               src[i + 1:closed - 1],
-                               src.count("\n", 0, m.start()) + 1))
-    found.sort(key=lambda c: c.start)
-    return found
-
 
 _INLINE_EQUALITY_SPACE = r"(?:\s|\\[,;:!]|\\(?:quad|qquad)\b)*"
 _INLINE_EQUALITY_GLUE = re.compile(

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -51,6 +51,7 @@ from pathlib import Path
 
 from tenkz_audit import ENVIRONMENT_LANGS
 from tenkz_language import load_registry, parse_status
+from tenkzlib.texcase import _match_group, scan_constructs, strip_comments
 
 # Bodies scanned for the dots rule: the grid languages whose cells feed
 # the implicit wire.  (tenkzcd cells are math objects and tenkzfree has
@@ -114,50 +115,6 @@ class Finding:
     reason: str = ""
 
 
-def strip_comments(src: str) -> str:
-    """Blank out unescaped `%`-comments, preserving offsets/line numbers."""
-    out: list[str] = []
-    for line in src.split("\n"):
-        buf = list(line)
-        i = 0
-        while i < len(buf):
-            if buf[i] == "\\":
-                i += 2
-                continue
-            if buf[i] == "%":
-                for j in range(i, len(buf)):
-                    buf[j] = " "
-                break
-            i += 1
-        out.append("".join(buf))
-    return "\n".join(out)
-
-
-def _match_group(src: str, i: int, open_ch: str, close_ch: str) -> int:
-    """Offset one past the group opening at `src[i]`, brace-aware: a `]`
-    inside `{...}` does not close a `[...]` group.  Works for both brace
-    and bracket groups.  Returns -1 if unbalanced."""
-    depth_group = 0
-    depth_brace = 0
-    while i < len(src):
-        c = src[i]
-        if c == "\\":
-            i += 2
-            continue
-        if c == open_ch and (open_ch == "{" or depth_brace == 0):
-            depth_group += 1
-        elif c == close_ch and (close_ch == "}" or depth_brace == 0):
-            depth_group -= 1
-            if depth_group == 0:
-                return i + 1
-        elif c == "{":
-            depth_brace += 1
-        elif c == "}":
-            depth_brace -= 1
-        i += 1
-    return -1
-
-
 @dataclass
 class Body:
     name: str
@@ -165,52 +122,13 @@ class Body:
     text: str
 
 
-def _find_env_end(src: str, name: str, pos: int) -> "re.Match[str] | None":
-    """Match of the `\\end{name}` closing the `\\begin{name}` whose body
-    starts at `pos`, depth-counting nested same-name environments so an
-    inner `\\end` never closes the outer body.  None if unclosed."""
-    token_re = re.compile(r"\\(begin|end)\{" + re.escape(name) + r"\}")
-    depth = 1
-    for tok in token_re.finditer(src, pos):
-        depth += 1 if tok.group(1) == "begin" else -1
-        if depth == 0:
-            return tok
-    return None
-
-
 def scan_bodies(src: str) -> list[Body]:
     """tenkz-family bodies in a comment-stripped source: environment
     bodies (options group excluded) and balanced `\\tnpic` arguments."""
-    bodies: list[Body] = []
-    env_re = re.compile(r"\\begin\{(tenkz(?:cd|lattice|free|planes)?)\}")
-    for m in env_re.finditer(src):
-        name = m.group(1)
-        end_m = _find_env_end(src, name, m.end())
-        body_start = m.end()
-        if src[body_start:body_start + 1] == "[":
-            closed = _match_group(src, body_start, "[", "]")
-            if closed != -1:
-                body_start = closed
-        body_end = end_m.start() if end_m else len(src)
-        bodies.append(Body(name, body_start, src[body_start:body_end]))
-    for m in re.finditer(r"\\tnpic\b", src):
-        i = m.end()
-        while i < len(src) and src[i] in " \t\n":
-            i += 1
-        if src[i:i + 1] == "[":
-            closed = _match_group(src, i, "[", "]")
-            if closed == -1:
-                continue
-            i = closed
-            while i < len(src) and src[i] in " \t\n":
-                i += 1
-        if src[i:i + 1] != "{":
-            continue
-        closed = _match_group(src, i, "{", "}")
-        if closed == -1:
-            continue
-        bodies.append(Body("tnpic", i + 1, src[i + 1:closed - 1]))
-    return bodies
+    return [
+        Body(construct.name, construct.body_start, construct.body)
+        for construct in scan_constructs(src)
+    ]
 
 
 def mask_option_groups(body: str) -> str:

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -31,6 +31,8 @@ from tenkzlib.tnlog import ParsedLog, parse_log
 REPO = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST = REPO / "tests" / "tenkz" / "rmp" / "manifest.toml"
 DEFAULT_VERDICT = REPO / "tests" / "tenkz" / "rmp" / "verdicts.toml"
+PAPER_SOURCE = REPO / "Papers" / "2011.12127" / "TN-Review-main.tex"
+FROZEN_TARGET_COUNT = 130
 BOOK_SOURCE = REPO / "docs" / "tenkz" / "rmp-benchmark.tex"
 BOOK_OUTPUT = REPO / "output" / "pdf" / "tenkz-rmp-benchmark.pdf"
 COMPARE_OUTPUT = REPO / "output" / "pdf" / "tenkz-rmp-comparison.pdf"
@@ -92,6 +94,9 @@ FORBIDDEN_CASE_PATTERNS = (
      "case uses a whole-figure definition"),
     (re.compile(r"\\coordinate\b|\\pgf(?:point|path|extra)\b"),
      "case uses an undocumented coordinate escape"),
+)
+INCLUDEGRAPHICS_RE = re.compile(
+    r"\\includegraphics(?:\s*\[[^\]]*\])?\s*\{([^}]*)\}"
 )
 
 
@@ -398,6 +403,7 @@ def load_manifest(path: Path) -> list[Target]:
             )
         )
     validate_census(targets, corpus)
+    validate_source_placements(targets)
     for target in targets:
         validate_case(target)
     validate_distinct_case_bodies(targets)
@@ -411,6 +417,13 @@ def duplicates(values: Iterable[Any]) -> list[Any]:
 
 
 def validate_census(targets: list[Target], census: dict[str, Any]) -> None:
+    # M4 is explicitly defined over a frozen benchmark denominator.  The
+    # manifest derives the detailed census, but it cannot redefine that gate.
+    if len(targets) != FROZEN_TARGET_COUNT:
+        fail(
+            f"manifest has {len(targets)} targets; "
+            f"the benchmark denominator is frozen at {FROZEN_TARGET_COUNT}"
+        )
     if len(targets) != census["total_targets"]:
         fail(
             f"manifest has {len(targets)} targets; "
@@ -462,6 +475,29 @@ def validate_census(targets: list[Target], census: dict[str, Any]) -> None:
         fail(
             f"manifest has {context_only} paper-context-only targets; "
             f"[corpus] declares {census['paper_context_only']}"
+        )
+
+
+def validate_source_placements(targets: Sequence[Target]) -> None:
+    """Keep the manifest's placement census anchored to the source paper."""
+    try:
+        source = strip_comments(PAPER_SOURCE.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError) as exc:
+        fail(f"cannot read source paper {PAPER_SOURCE}: {exc}")
+    expected = [
+        (source.count("\n", 0, match.start()) + 1, match.group(1))
+        for match in INCLUDEGRAPHICS_RE.finditer(source)
+    ]
+    ordered = sorted(
+        (placement["order"], placement["line"], placement["asset"])
+        for target in targets
+        for placement in target.placements
+    )
+    actual = [(line, asset) for _, line, asset in ordered]
+    if actual != expected:
+        fail(
+            "paper placements must match the source paper's "
+            f"{len(expected)} includegraphics occurrences"
         )
 
 

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -499,6 +499,20 @@ def validate_source_placements(targets: Sequence[Target]) -> None:
             "paper placements must match the source paper's "
             f"{len(expected)} includegraphics occurrences"
         )
+    expected_published = len({asset for _, asset in expected})
+    published = sum(target.corpus == "published" for target in targets)
+    if published != expected_published:
+        fail(
+            f"manifest has {published} published targets; the source paper has "
+            f"{expected_published} distinct graphics"
+        )
+    expected_workbench = FROZEN_TARGET_COUNT - expected_published
+    workbench = sum(target.corpus == "author-workbench" for target in targets)
+    if workbench != expected_workbench:
+        fail(
+            f"manifest has {workbench} author-workbench targets; "
+            f"the frozen remainder is {expected_workbench}"
+        )
 
 
 def case_headers(lines: list[str], *, path: Path) -> dict[str, str]:
@@ -817,6 +831,8 @@ def campaign_digest(targets: Sequence[Target]) -> str:
         REPO / "scripts" / "tenkz_rmp.py",
         REPO / "scripts" / "tenkz_lint.py",
         REPO / "scripts" / "tenkz_audit.py",
+        REPO / "scripts" / "tenkzlib" / "texcase.py",
+        REPO / "scripts" / "tenkzlib" / "tnlog.py",
     }
     paths.update((REPO / "tex" / "tenkz").glob("*.tex"))
     paths.update((REPO / "tex" / "tenkz").glob("*.sty"))

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -24,6 +24,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 
+from tenkzlib.texcase import strip_comments
+from tenkzlib.tnlog import ParsedLog, parse_log
+
 
 REPO = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST = REPO / "tests" / "tenkz" / "rmp" / "manifest.toml"
@@ -47,14 +50,14 @@ REQUIRED_HEADERS = (
     "Source",
     "Capabilities",
 )
-EXPECTED_CORPUS = {
-    "published_targets": 92,
-    "paper_placements": 94,
-    "author_workbench_targets": 38,
-    "total_targets": 130,
-    "author_source_mapped": 82,
-    "paper_context_only": 10,
-}
+CORPUS_FIELDS = (
+    "published_targets",
+    "paper_placements",
+    "author_workbench_targets",
+    "total_targets",
+    "author_source_mapped",
+    "paper_context_only",
+)
 TARGET_REQUIRED = {
     "id",
     "corpus",
@@ -263,11 +266,15 @@ def load_manifest(path: Path) -> list[Target]:
     corpus = data.get("corpus")
     if not isinstance(corpus, dict):
         fail("manifest needs a [corpus] table")
-    if set(corpus) != set(EXPECTED_CORPUS):
-        fail("[corpus] fields must be exactly: " + ", ".join(EXPECTED_CORPUS))
-    for field, expected in EXPECTED_CORPUS.items():
-        if corpus[field] != expected:
-            fail(f"corpus.{field} must be {expected}, got {corpus[field]!r}")
+    if set(corpus) != set(CORPUS_FIELDS):
+        fail("[corpus] fields must be exactly: " + ", ".join(CORPUS_FIELDS))
+    for field in CORPUS_FIELDS:
+        if (
+            not isinstance(corpus[field], int)
+            or isinstance(corpus[field], bool)
+            or corpus[field] < 0
+        ):
+            fail(f"corpus.{field} must be a nonnegative integer")
 
     raw_targets = data.get("target")
     if not isinstance(raw_targets, list):
@@ -390,7 +397,7 @@ def load_manifest(path: Path) -> list[Target]:
                 extraction_override=extraction_override,
             )
         )
-    validate_census(targets)
+    validate_census(targets, corpus)
     for target in targets:
         validate_case(target)
     validate_distinct_case_bodies(targets)
@@ -403,9 +410,12 @@ def duplicates(values: Iterable[Any]) -> list[Any]:
     return sorted(value for value, count in counts.items() if count > 1)
 
 
-def validate_census(targets: list[Target]) -> None:
-    if len(targets) != EXPECTED_CORPUS["total_targets"]:
-        fail(f"manifest has {len(targets)} targets; expected 130")
+def validate_census(targets: list[Target], census: dict[str, Any]) -> None:
+    if len(targets) != census["total_targets"]:
+        fail(
+            f"manifest has {len(targets)} targets; "
+            f"[corpus] declares {census['total_targets']}"
+        )
     repeated_ids = duplicates(target.id for target in targets)
     repeated_cases = duplicates(target.case for target in targets)
     if repeated_ids:
@@ -413,31 +423,46 @@ def validate_census(targets: list[Target]) -> None:
     if repeated_cases:
         repeated = ", ".join(path.as_posix() for path in repeated_cases)
         fail("manifest repeats case files: " + repeated)
-    for corpus, expected_count in (
-        ("published", EXPECTED_CORPUS["published_targets"]),
-        ("author-workbench", EXPECTED_CORPUS["author_workbench_targets"]),
+    for corpus_name, expected_count in (
+        ("published", census["published_targets"]),
+        ("author-workbench", census["author_workbench_targets"]),
     ):
-        members = [target for target in targets if target.corpus == corpus]
+        members = [target for target in targets if target.corpus == corpus_name]
         if len(members) != expected_count:
-            fail(f"manifest has {len(members)} {corpus} targets; expected {expected_count}")
+            fail(
+                f"manifest has {len(members)} {corpus_name} targets; "
+                f"[corpus] declares {expected_count}"
+            )
         orders = sorted(target.order for target in members)
         if orders != list(range(1, expected_count + 1)):
-            fail(f"{corpus} order must be exactly 1..{expected_count}")
+            fail(f"{corpus_name} order must be exactly 1..{expected_count}")
     placement_count = sum(len(target.placements) for target in targets)
-    if placement_count != EXPECTED_CORPUS["paper_placements"]:
-        fail(f"manifest has {placement_count} paper placements; expected 94")
+    if placement_count != census["paper_placements"]:
+        fail(
+            f"manifest has {placement_count} paper placements; "
+            f"[corpus] declares {census['paper_placements']}"
+        )
     placement_orders = sorted(
         placement["order"] for target in targets for placement in target.placements
     )
-    if placement_orders != list(range(1, EXPECTED_CORPUS["paper_placements"] + 1)):
-        fail("paper placement order must be exactly 1..94")
+    if placement_orders != list(range(1, census["paper_placements"] + 1)):
+        fail(
+            "paper placement order must be exactly "
+            f"1..{census['paper_placements']}"
+        )
     published = [target for target in targets if target.corpus == "published"]
     mapped = sum(target.author_source is not None for target in published)
     context_only = sum(target.paper_context_only for target in published)
-    if mapped != EXPECTED_CORPUS["author_source_mapped"]:
-        fail(f"manifest has {mapped} mapped published targets; expected 82")
-    if context_only != EXPECTED_CORPUS["paper_context_only"]:
-        fail(f"manifest has {context_only} paper-context-only targets; expected 10")
+    if mapped != census["author_source_mapped"]:
+        fail(
+            f"manifest has {mapped} mapped published targets; "
+            f"[corpus] declares {census['author_source_mapped']}"
+        )
+    if context_only != census["paper_context_only"]:
+        fail(
+            f"manifest has {context_only} paper-context-only targets; "
+            f"[corpus] declares {census['paper_context_only']}"
+        )
 
 
 def case_headers(lines: list[str], *, path: Path) -> dict[str, str]:
@@ -465,30 +490,10 @@ def case_headers(lines: list[str], *, path: Path) -> dict[str, str]:
     return headers
 
 
-def strip_tex_comments(text: str) -> str:
-    """Remove unescaped TeX comments while preserving line boundaries."""
-    stripped: list[str] = []
-    for line in text.splitlines():
-        end = len(line)
-        for index, character in enumerate(line):
-            if character != "%":
-                continue
-            backslashes = 0
-            cursor = index - 1
-            while cursor >= 0 and line[cursor] == "\\":
-                backslashes += 1
-                cursor -= 1
-            if backslashes % 2 == 0:
-                end = index
-                break
-        stripped.append(line[:end])
-    return "\n".join(stripped)
-
-
 def normalized_case_body(target: Target) -> str:
     """Return semantic case source with provenance comments and layout removed."""
     text = (REPO / target.case).read_text(encoding="utf-8")
-    return re.sub(r"\s+", "", strip_tex_comments(text))
+    return re.sub(r"\s+", "", strip_comments(text))
 
 
 def validate_distinct_case_bodies(targets: list[Target]) -> None:
@@ -564,7 +569,7 @@ def validate_case(target: Target) -> None:
     if wide:
         details = ", ".join(f"{number} ({width})" for number, width in wide[:8])
         fail(f"{target.case.as_posix()}: lines exceed 88 characters: {details}")
-    syntax = strip_tex_comments(text)
+    syntax = strip_comments(text)
     for pattern, reason in FORBIDDEN_CASE_PATTERNS:
         match = pattern.search(syntax)
         if match:
@@ -634,37 +639,28 @@ def pdf_dimensions(pdf: Path) -> tuple[str, str, int]:
     return size_match.group(1), size_match.group(2), int(pages_match.group(1))
 
 
-def resolved_event_signatures(tnlog_text: str) -> tuple[str, ...]:
-    """Return concise signatures from the exact event stream used to render.
-
-    Grid pictures already emit an aggregate ``boundary`` record.  Other
-    dialects expose their topology as atoms, joins, bonds, regions, and other
-    model events instead.  For those pictures, retain a deterministic census
-    and the number of explicit boundary atoms rather than claiming that a
-    boundary event exists.
-    """
-    lines = [line.strip() for line in tnlog_text.splitlines() if line.strip()]
-    boundaries = tuple(line for line in lines if line.startswith("boundary|"))
+def event_signatures(parsed: ParsedLog) -> tuple[str, ...]:
+    """Return concise signatures from a parsed render event stream."""
+    boundaries = tuple(
+        event.raw for event in parsed.events if event.kind == "boundary"
+    )
     if boundaries:
         return boundaries
 
     languages: dict[str, str] = {}
     counts: dict[str, Counter[str]] = {}
     boundary_atoms: Counter[str] = Counter()
-    for line in lines:
-        parts = line.split("|")
-        event = parts[0]
-        fields = dict(part.split("=", 1) for part in parts[1:] if "=" in part)
-        if event == "picture":
-            picture = fields.get("id", "?")
-            languages[picture] = fields.get("lang", "unknown")
+    for event in parsed.events:
+        if event.kind == "picture":
+            picture = event.attrs.get("id", "?")
+            languages[picture] = event.attrs.get("lang", "unknown")
             counts.setdefault(picture, Counter())
             continue
-        picture = fields.get("picture")
+        picture = event.attrs.get("picture")
         if picture is None:
             continue
-        counts.setdefault(picture, Counter())[event] += 1
-        if event == "atom" and fields.get("kind") == "boundary":
+        counts.setdefault(picture, Counter())[event.kind] += 1
+        if event.kind == "atom" and event.attrs.get("kind") == "boundary":
             boundary_atoms[picture] += 1
 
     signatures: list[str] = []
@@ -727,7 +723,8 @@ def compile_one(target: Target, root: Path, env: dict[str, str]) -> BuildResult:
         )
         (target_work / f"{target.id}.audit.txt").write_text(audit.stdout, encoding="utf-8")
         width, height, pages = pdf_dimensions(pdf)
-        signatures = resolved_event_signatures(tnlog.read_text(encoding="utf-8"))
+        parsed = parse_log(tnlog.read_text(encoding="utf-8"), source_name=tnlog.name)
+        signatures = event_signatures(parsed)
         return BuildResult(target, wrapper, pdf, tnlog, width, height, pages, signatures)
     except RMPError as exc:
         if not transcript.exists():
@@ -955,7 +952,7 @@ def validate_verdict_consistency(targets: Sequence[Target], verdicts: dict[str, 
     """
     problems: list[str] = []
     for target in targets:
-        body = strip_tex_comments((REPO / target.case).read_text(encoding="utf-8"))
+        body = strip_comments((REPO / target.case).read_text(encoding="utf-8"))
         verdict = verdicts[target.id]
         # Literal prose standing in for a declared diagram.
         if "\\text{" in body:

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -826,6 +826,7 @@ def campaign_digest(targets: Sequence[Target]) -> str:
     """Hash every committed input whose change invalidates visual verdicts."""
     paths = {
         DEFAULT_MANIFEST,
+        PAPER_SOURCE,
         BOOK_SOURCE,
         REPO / "docs" / "tenkz" / "tenkzrmpbenchmark.sty",
         REPO / "scripts" / "tenkz_rmp.py",

--- a/scripts/tenkz_shrink.py
+++ b/scripts/tenkz_shrink.py
@@ -37,6 +37,7 @@ from tenkz_language import (  # noqa: E402
     _parser_leaf_keys,
     _parser_leaf_keys_from_texts,
 )
+from tenkzlib.texcase import strip_comments  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[1]
 BASELINE = ROOT / "tests/tenkz/census-baseline.json"
@@ -57,18 +58,6 @@ _SCOPE_COMMANDS = {
 _SETUP_COMMAND_FORWARDS = {
     "tntree": {"pitch", "compact", "inline"},
 }
-
-
-def strip_comments(text: str) -> str:
-    out = []
-    for line in text.splitlines():
-        cut = len(line)
-        for index, char in enumerate(line):
-            if char == "%" and (index == 0 or line[index - 1] != "\\"):
-                cut = index
-                break
-        out.append(line[:cut])
-    return "\n".join(out)
 
 
 def manifest_case_paths() -> list[Path]:

--- a/scripts/tenkzlib/__init__.py
+++ b/scripts/tenkzlib/__init__.py
@@ -1,0 +1,1 @@
+"""Shared Python support for the tenkz checkers."""

--- a/scripts/tenkzlib/texcase.py
+++ b/scripts/tenkzlib/texcase.py
@@ -1,0 +1,133 @@
+"""Shared comment stripping and construct scanning for tenkz TeX sources."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class Construct:
+    name: str
+    start: int
+    end: int
+    body: str
+    line: int
+    body_start: int
+
+
+def strip_comments(source: str) -> str:
+    """Blank unescaped TeX comments while preserving offsets and lines."""
+    output: list[str] = []
+    for line in source.split("\n"):
+        buffer = list(line)
+        index = 0
+        while index < len(buffer):
+            if buffer[index] == "\\":
+                index += 2
+                continue
+            if buffer[index] == "%":
+                for tail in range(index, len(buffer)):
+                    buffer[tail] = " "
+                break
+            index += 1
+        output.append("".join(buffer))
+    return "\n".join(output)
+
+
+def _match_group(
+    source: str, index: int, open_character: str, close_character: str
+) -> int:
+    """Return the offset after a balanced brace-aware group, or -1."""
+    group_depth = 0
+    brace_depth = 0
+    while index < len(source):
+        character = source[index]
+        if character == "\\":
+            index += 2
+            continue
+        if character == open_character and (
+            open_character == "{" or brace_depth == 0
+        ):
+            group_depth += 1
+        elif character == close_character and (
+            close_character == "}" or brace_depth == 0
+        ):
+            group_depth -= 1
+            if group_depth == 0:
+                return index + 1
+        elif character == "{":
+            brace_depth += 1
+        elif character == "}":
+            brace_depth -= 1
+        index += 1
+    return -1
+
+
+def _find_env_end(
+    source: str, name: str, position: int
+) -> re.Match[str] | None:
+    """Find the depth-matched closing token for a tenkz environment."""
+    token_pattern = re.compile(r"\\(begin|end)\{" + re.escape(name) + r"\}")
+    depth = 1
+    for token in token_pattern.finditer(source, position):
+        depth += 1 if token.group(1) == "begin" else -1
+        if depth == 0:
+            return token
+    return None
+
+
+def scan_constructs(source: str) -> list[Construct]:
+    """Return picture-producing constructs in source order."""
+    constructs: list[Construct] = []
+    environment_pattern = re.compile(
+        r"\\begin\{(tenkz(?:cd|lattice|free|planes)?)\}"
+    )
+    for match in environment_pattern.finditer(source):
+        name = match.group(1)
+        end_match = _find_env_end(source, name, match.end())
+        end = end_match.end() if end_match else len(source)
+        body_start = match.end()
+        if source[body_start : body_start + 1] == "[":
+            closed = _match_group(source, body_start, "[", "]")
+            if closed != -1:
+                body_start = closed
+        body_end = end_match.start() if end_match else len(source)
+        constructs.append(
+            Construct(
+                name,
+                match.start(),
+                end,
+                source[body_start:body_end],
+                source.count("\n", 0, match.start()) + 1,
+                body_start,
+            )
+        )
+    for match in re.finditer(r"\\tnpic\b", source):
+        index = match.end()
+        while index < len(source) and source[index] in " \t\n":
+            index += 1
+        if source[index : index + 1] == "[":
+            closed = _match_group(source, index, "[", "]")
+            if closed == -1:
+                continue
+            index = closed
+            while index < len(source) and source[index] in " \t\n":
+                index += 1
+        if source[index : index + 1] != "{":
+            continue
+        closed = _match_group(source, index, "{", "}")
+        if closed == -1:
+            continue
+        constructs.append(
+            Construct(
+                "tnpic",
+                match.start(),
+                closed,
+                source[index + 1 : closed - 1],
+                source.count("\n", 0, match.start()) + 1,
+                index + 1,
+            )
+        )
+    constructs.sort(key=lambda construct: construct.start)
+    return constructs

--- a/scripts/tenkzlib/tnlog.py
+++ b/scripts/tenkzlib/tnlog.py
@@ -1,0 +1,431 @@
+"""Typed parser for the line-oriented tenkz event log."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable
+
+
+INT_RE = re.compile(r"-?\d+")
+
+
+def _parse_int(value: str) -> int | None:
+    if INT_RE.fullmatch(value) is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _is_int(value: str) -> bool:
+    return _parse_int(value) is not None
+
+
+def _is_positive_int(value: str) -> bool:
+    parsed = _parse_int(value)
+    return parsed is not None and parsed > 0
+
+
+def _is_nonnegative_int(value: str) -> bool:
+    parsed = _parse_int(value)
+    return parsed is not None and parsed >= 0
+
+
+def _is_cell(value: str) -> bool:
+    return re.fullmatch(r"\d+-\d+", value) is not None
+
+
+def _is_lattice_cell(value: str) -> bool:
+    return re.fullmatch(r"\d+-\d+(?:-\d+)?", value) is not None
+
+
+def _is_lattice_cell_list(value: str) -> bool:
+    return bool(value) and all(
+        _is_lattice_cell(cell.strip()) for cell in value.split(",")
+    )
+
+
+def _is_region_cell_list(value: str) -> bool:
+    """A resolved region may be empty; non-empty memberships stay strict."""
+    return not value or _is_lattice_cell_list(value)
+
+
+def _is_pairleg_port(value: str) -> bool:
+    """A contraction starts at the centred face or a positive face slot."""
+    if value == "center":
+        return True
+    parsed = _parse_int(value)
+    return parsed is not None and parsed > 0
+
+
+def _enum(*values: str) -> Callable[[str], bool]:
+    allowed = set(values)
+    return lambda value: value in allowed
+
+
+def _any(value: str) -> bool:
+    return value != ""
+
+
+# kind -> {field: validator}; fields absent here are accepted as opaque.
+# Numeric slots are validated strictly: they are cell/row coordinates, and
+# a coordinate that is not an integer addresses nothing.
+FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
+    "picture": {"id": _is_int, "lang": _any},
+    "label-use": {"picture": _is_int},
+    "label-anchor-site": {
+        "picture": _is_int,
+        "label": _is_positive_int,
+        "x": _is_int,
+        "y": _is_int,
+    },
+    "ink-use": {
+        "picture": _is_int,
+        "class": _enum("glyph", "wire"),
+        "id": _is_positive_int,
+        "shape": _enum("rect", "circle", "roundrect", "triangle"),
+    },
+    "atom": {"picture": _is_int, "cell": _is_cell, "name": _any, "kind": _any},
+    "faceports": {
+        "picture": _is_int,
+        "cell": _is_cell,
+        "face": _enum("up", "down", "west", "east"),
+        "arity": _is_nonnegative_int,
+        "at": _any,
+    },
+    "pairleg": {
+        "picture": _is_int,
+        "upper": _is_cell,
+        "lower": _is_cell,
+        "upper-port": _is_pairleg_port,
+        "column": _is_int,
+    },
+    "bond": {
+        "picture": _is_int,
+        "row": _is_int,
+        "from": _is_int,
+        "to": _is_int,
+        "dir": _enum("none", "left", "right", "forward", "reverse"),
+    },
+    "trace": {
+        "picture": _is_int,
+        "row": _is_int,
+        "side": _enum("above", "below"),
+        "lang": _enum("lattice"),
+        "axis": _enum("west-east", "north-south"),
+        "sheet": _is_nonnegative_int,
+        "slot": _is_positive_int,
+        "from": _is_cell,
+        "to": _is_cell,
+    },
+    "hooks": {
+        "picture": _is_int,
+        "row": _is_int,
+        "side": _enum("above", "below"),
+    },
+    "pairtrace": {
+        "picture": _is_int,
+        "row": _is_int,
+        "col": _is_int,
+        "site": _is_cell,
+    },
+    "phtrace": {"picture": _is_int, "row": _is_int, "col": _is_int},
+    "cup": {
+        "picture": _is_int,
+        "lang": _enum("lattice"),
+        "side": _enum("west", "east", "north", "south"),
+        "top": _is_int,
+        "bottom": _is_int,
+        "cell": _is_cell,
+        "sheet-a": _is_int,
+        "sheet-b": _is_int,
+        "matrix": _is_int,
+    },
+    "hole": {"picture": _is_int, "row": _is_int, "col": _is_int},
+    "warning": {"picture": _is_int, "code": _any},
+    "boundary": {
+        "picture": _is_int,
+        "virtual-west": _is_int,
+        "virtual-east": _is_int,
+        "virtual-north": _is_int,
+        "virtual-south": _is_int,
+        "physical-up": _is_int,
+        "physical-down": _is_int,
+    },
+    "bbox": {
+        "picture": _is_int,
+        "class": _enum("label", "wire"),
+        "id": _is_positive_int,
+        "xmin": _is_int,
+        "xmax": _is_int,
+        "ymin": _is_int,
+        "ymax": _is_int,
+        "shape": _enum("rect", "roundrect"),
+        "radius": _is_nonnegative_int,
+    },
+    "glyph-geometry": {
+        "picture": _is_int,
+        "owner": _is_positive_int,
+        "shape": _enum("rect", "circle", "roundrect", "triangle"),
+        "xmin": _is_int,
+        "xmax": _is_int,
+        "ymin": _is_int,
+        "ymax": _is_int,
+        "radius": _is_nonnegative_int,
+        "stroke": _is_nonnegative_int,
+        "x1": _is_int,
+        "y1": _is_int,
+        "x2": _is_int,
+        "y2": _is_int,
+        "x3": _is_int,
+        "y3": _is_int,
+    },
+    "wire-geometry": {
+        "picture": _is_int,
+        "owner": _is_positive_int,
+        "shape": _enum("rect-minus-label"),
+        "xmin": _is_int,
+        "xmax": _is_int,
+        "y": _is_int,
+        "outer": _is_positive_int,
+        "inner": _is_nonnegative_int,
+        "cut-shape": _enum("rect", "roundrect"),
+        "cut-xmin": _is_int,
+        "cut-xmax": _is_int,
+        "cut-ymin": _is_int,
+        "cut-ymax": _is_int,
+        "cut-radius": _is_nonnegative_int,
+        "cut-id": _is_positive_int,
+    },
+    "lattice": {
+        "picture": _is_int,
+        "rows": _is_positive_int,
+        "cols": _is_positive_int,
+        "sheets": _is_positive_int,
+        "roles": _any,
+    },
+    "site": {"picture": _is_int, "cell": _is_lattice_cell, "mode": _enum("removed")},
+    "region": {
+        "picture": _is_int,
+        "lang": _enum("free", "lattice"),
+        "slot": _enum(
+            "selected", "secondary", "complement", "collar", "neutral", "group"
+        ),
+        "cells": _is_region_cell_list,
+        "members": _any,
+        "outline": _enum("0", "1"),
+        "name": _any,
+    },
+    "edge": {
+        "picture": _is_int,
+        "from": _is_lattice_cell,
+        "to": _is_lattice_cell,
+        "role": _enum("none", "operator", "marked", "extra", "passive"),
+    },
+    "cdcell": {"picture": _is_int, "index": _is_int},
+    "cdobject": {"picture": _is_int, "cell": _is_cell},
+    "cdarrow": {"picture": _is_int, "from": _any, "to": _any},
+    "cdmap": {
+        "picture": _is_int,
+        "from": _is_cell,
+        "to": _is_cell,
+        "fused": _enum("0", "1"),
+        "role": _enum("none", "operator", "marked", "extra", "passive"),
+        "species": _any,
+    },
+    "tree": {
+        "picture": _is_int,
+        "id": _is_positive_int,
+        "style": _enum("wire", "ribbon"),
+        "leaves": _is_positive_int,
+        "vertices": _is_nonnegative_int,
+        "topology": _any,
+        "role": _enum("none", "operator", "marked", "extra", "passive"),
+        "species": _any,
+    },
+    "join": {"picture": _is_int, "from": _any, "to": _any},
+    "span": {
+        "picture": _is_int,
+        "row": _is_positive_int,
+        "col": _is_positive_int,
+        "length": _is_positive_int,
+        "kind": _enum("brace above", "brace below", "box"),
+    },
+}
+
+
+@dataclass
+class Event:
+    kind: str
+    attrs: dict[str, str]
+    line: int
+    raw: str
+
+
+@dataclass
+class Picture:
+    ident: int
+    lang: str
+    line: int
+    events: list[Event] = field(default_factory=list)
+
+    def content(self) -> list[Event]:
+        """Return events that denote ink rather than derived diagnostics."""
+        excluded = {
+            "bbox",
+            "label-use",
+            "label-anchor-site",
+            "ink-use",
+            "glyph-geometry",
+            "wire-geometry",
+            "boundary",
+            "warning",
+        }
+        return [event for event in self.events if event.kind not in excluded]
+
+    def boundary(self) -> tuple[int, int, int, int] | None:
+        for event in self.events:
+            if event.kind == "boundary":
+                try:
+                    return tuple(
+                        int(event.attrs[key].strip())
+                        for key in (
+                            "virtual-west",
+                            "virtual-east",
+                            "physical-up",
+                            "physical-down",
+                        )
+                    )
+                except (KeyError, ValueError):
+                    return None
+        return None
+
+    def ncols(self) -> int:
+        columns = 0
+        for event in self.events:
+            if (
+                event.kind == "atom"
+                and "cell" in event.attrs
+                and _is_cell(event.attrs["cell"].strip())
+            ):
+                columns = max(columns, int(event.attrs["cell"].strip().split("-")[1]))
+            elif event.kind == "bond":
+                for key in ("from", "to"):
+                    value = event.attrs.get(key, "").strip()
+                    if _is_int(value):
+                        columns = max(columns, int(value))
+        return columns
+
+
+@dataclass
+class ParsedLog:
+    events: list[Event]
+    pictures: list[Picture]
+    by_id: dict[int, Picture]
+
+
+FindingCallback = Callable[[str, str, str], None]
+EventCallback = Callable[[Event], None]
+
+
+def _ignore_finding(_rule: str, _where: str, _message: str) -> None:
+    pass
+
+
+def parse_log(
+    text: str,
+    *,
+    source_name: str = "<tnlog>",
+    known_langs: set[str] | None = None,
+    hard: FindingCallback = _ignore_finding,
+    advisory: FindingCallback = _ignore_finding,
+    check_event: EventCallback | None = None,
+) -> ParsedLog:
+    """Parse and validate one complete event stream."""
+    events: list[Event] = []
+    pictures: list[Picture] = []
+    by_id: dict[int, Picture] = {}
+    for line_number, raw in enumerate(text.splitlines(), 1):
+        line = raw.strip()
+        if not line:
+            continue
+        where = f"{source_name}:{line_number}"
+        parts = line.split("|")
+        kind = parts[0].strip()
+        attrs: dict[str, str] = {}
+        valid = True
+        for part in parts[1:]:
+            if "=" not in part:
+                hard(
+                    "malformed-event",
+                    where,
+                    f"bare field {part.strip()!r} (expected key=value): {line}",
+                )
+                valid = False
+                continue
+            key, value = part.split("=", 1)
+            attrs[key.strip()] = value.strip()
+        event = Event(kind, attrs, line_number, line)
+        events.append(event)
+        validators = FIELD_VALIDATORS.get(kind)
+        if validators is None:
+            advisory("unknown-event", where, f"unrecognized event kind {kind!r}")
+        else:
+            for key, value in attrs.items():
+                validator = validators.get(key)
+                if validator is not None and not validator(value):
+                    hard(
+                        "malformed-event",
+                        where,
+                        f"{kind} field {key}={value!r} fails validation: {line}",
+                    )
+                    valid = False
+            if kind != "picture" and "picture" not in attrs:
+                hard(
+                    "malformed-event",
+                    where,
+                    f"{kind} event lacks required picture=: {line}",
+                )
+                valid = False
+        if kind == "picture":
+            if not valid or "id" not in attrs or not _is_int(attrs["id"]):
+                continue
+            picture_id = int(attrs["id"])
+            lang = attrs.get("lang", "")
+            if known_langs is not None and lang not in known_langs:
+                advisory(
+                    "unknown-lang",
+                    where,
+                    f"picture {picture_id} has lang={lang!r}",
+                )
+            if picture_id in by_id:
+                hard(
+                    "duplicate-picture",
+                    where,
+                    f"picture id {picture_id} already declared at line "
+                    f"{by_id[picture_id].line}",
+                )
+                continue
+            picture = Picture(picture_id, lang, line_number)
+            by_id[picture_id] = picture
+            pictures.append(picture)
+            continue
+        if check_event is not None:
+            check_event(event)
+        reference = attrs.get("picture", "")
+        if not _is_int(reference):
+            continue
+        picture_id = int(reference)
+        if picture_id == 0 and kind == "tree":
+            continue
+        if picture_id not in by_id:
+            hard(
+                "dangling-picture-ref",
+                where,
+                f"{kind} references undeclared picture {picture_id}",
+            )
+            continue
+        by_id[picture_id].events.append(event)
+    return ParsedLog(events, pictures, by_id)

--- a/scripts/test_texcase.py
+++ b/scripts/test_texcase.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Focused contract tests for the shared tenkz TeX case reader."""
+
+from tenkz_audit import scan_constructs as audit_scan_constructs
+from tenkz_audit import strip_comments as audit_strip_comments
+from tenkz_lint import scan_bodies
+from tenkzlib.texcase import scan_constructs, strip_comments
+
+
+def main() -> int:
+    source = (
+        "before % hidden \\begin{tenkz}\\tn{X}\\end{tenkz}\n"
+        "\\% visible percent\n"
+        "\\\\% hidden after an even number of slashes\n"
+        "\\begin{tenkz}[rows={ket,op,bra}]\n"
+        "  \\tn{A} % hidden atom\n"
+        "  \\begin{tenkz}\\tn{B}\\end{tenkz}\n"
+        "\\end{tenkz}\n"
+        "\\tnpic[label={x]y}]{\\tn{C}}\n"
+    )
+    stripped = strip_comments(source)
+    assert len(stripped) == len(source)
+    assert stripped.count("\n") == source.count("\n")
+    assert "\\% visible percent" in stripped
+    assert "hidden after" not in stripped
+    assert "hidden atom" not in stripped
+
+    constructs = scan_constructs(stripped)
+    assert [construct.name for construct in constructs] == [
+        "tenkz",
+        "tenkz",
+        "tnpic",
+    ]
+    outer, inner, inline = constructs
+    assert "\\tn{A}" in outer.body
+    assert "\\tn{B}" in inner.body
+    assert inline.body == "\\tn{C}"
+    for construct in constructs:
+        assert stripped[construct.body_start : construct.body_start + len(construct.body)] == (
+            construct.body
+        )
+        assert construct.line == source.count("\n", 0, construct.start) + 1
+
+    bodies = scan_bodies(stripped)
+    assert [(body.name, body.start, body.text) for body in bodies] == [
+        (construct.name, construct.body_start, construct.body)
+        for construct in constructs
+    ]
+    assert audit_strip_comments is strip_comments
+    assert audit_scan_constructs is scan_constructs
+    print("texcase: comment parity, nested constructs, offsets, and shims passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_tnlog.py
+++ b/scripts/test_tnlog.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Focused contract tests for the shared tenkz event parser."""
+
+from tenkz_audit import Event as AuditEvent
+from tenkz_audit import FIELD_VALIDATORS as AUDIT_FIELD_VALIDATORS
+from tenkz_audit import Picture as AuditPicture
+from tenkz_audit import parse_log as audit_parse_log
+from tenkzlib.tnlog import Event, FIELD_VALIDATORS, Picture, parse_log
+
+
+def main() -> int:
+    hard: list[tuple[str, str, str]] = []
+    advisory: list[tuple[str, str, str]] = []
+    parsed = parse_log(
+        "\n".join(
+            (
+                "picture|id=1|lang=grid",
+                "atom|picture=1|cell=1-2|name=A|kind=tensor",
+                "bond|picture=1|row=1|from=2|to=3|dir=none",
+                "boundary|picture=1|virtual-west=1|virtual-east=2|"
+                "physical-up=3|physical-down=4",
+                "tree|picture=0|id=1|style=wire|leaves=2|vertices=1|"
+                "topology=(1,2)|role=none|species=plain",
+            )
+        ),
+        source_name="case.tnlog",
+        known_langs={"grid"},
+        hard=lambda *finding: hard.append(finding),
+        advisory=lambda *finding: advisory.append(finding),
+    )
+    assert not hard
+    assert not advisory
+    assert [event.kind for event in parsed.events] == [
+        "picture",
+        "atom",
+        "bond",
+        "boundary",
+        "tree",
+    ]
+    assert len(parsed.pictures) == 1
+    picture = parsed.pictures[0]
+    assert picture is parsed.by_id[1]
+    assert [event.kind for event in picture.content()] == ["atom", "bond"]
+    assert picture.boundary() == (1, 2, 3, 4)
+    assert picture.ncols() == 3
+
+    malformed: list[tuple[str, str, str]] = []
+    notes: list[tuple[str, str, str]] = []
+    parse_log(
+        "\n".join(
+            (
+                "picture|id=1|lang=future",
+                "picture|id=1|lang=grid",
+                "atom|picture=oops|cell=1-1|name=A|kind=tensor",
+                "mystery|picture=2|bare",
+            )
+        ),
+        source_name="bad.tnlog",
+        known_langs={"grid"},
+        hard=lambda *finding: malformed.append(finding),
+        advisory=lambda *finding: notes.append(finding),
+    )
+    assert {finding[0] for finding in malformed} == {
+        "duplicate-picture",
+        "malformed-event",
+        "dangling-picture-ref",
+    }
+    assert {finding[0] for finding in notes} == {"unknown-event", "unknown-lang"}
+
+    assert AuditEvent is Event
+    assert AuditPicture is Picture
+    assert AUDIT_FIELD_VALIDATORS is FIELD_VALIDATORS
+    assert audit_parse_log is parse_log
+    print("tnlog: typed parsing, diagnostics, picture grouping, and shims passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- move the typed `.tnlog` schema, `Event`/`Picture` model, validators, and parser into `scripts/tenkzlib/tnlog.py`, with compatibility re-exports from `tenkz_audit.py`
- make the RMP signature path consume the shared event parser instead of splitting the log again
- move comment stripping, balanced-group matching, environment matching, and construct scanning into `scripts/tenkzlib/texcase.py`, then route audit, lint, RMP, and shrink consumers through it
- validate computed RMP corpus counts against the manifest's own `[corpus]` block instead of Python constants
- add focused `test_tnlog.py` and `test_texcase.py` coverage

## Parser census

- TeX readers: **5 → 1**
- `.tnlog` parsers: **2 → 1**

The TeX-side format-version emitter remains as a follow-up; this PR is intentionally Python-side only.

## Validation

- `python3 scripts/tenkz_rmp.py check --all` — 130/130 targets passed
- `bash scripts/tenkz_corpus.sh` — 261/261 standalone files passed
- all `scripts/test_tenkz_*.py`, plus `scripts/test_tnlog.py` and `scripts/test_texcase.py` passed
- `git grep -n "def strip_comments" scripts/ | wc -l` — 1

Closes #4693.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes parsing used by audit, RMP benchmarks, and CI; behavior changes would affect many gates, though focused contract tests and unchanged audit semantics limit exposure.
> 
> **Overview**
> Introduces **`scripts/tenkzlib/tnlog.py`** and **`scripts/tenkzlib/texcase.py`** as the single implementations for `.tnlog` parsing (validators, `Event`/`Picture`, `parse_log`) and TeX comment stripping plus picture construct scanning. **`tenkz_audit.py`**, **`tenkz_lint.py`**, **`tenkz_rmp.py`**, and **`tenkz_shrink.py`** drop their duplicated logic and import the shared modules instead; audit still exposes the same symbols for existing callers via its imports.
> 
> **`tenkz_rmp.py`** now parses logs through `parse_log` for event signatures, uses shared `strip_comments`, validates **`[corpus]`** counts from the manifest (with a frozen **130**-target gate), and cross-checks paper **`\\includegraphics`** placements against **`Papers/2011.12127/TN-Review-main.tex`**. **`generate_badges.py`** only renames its Lean comment stripper for clarity.
> 
> CI (**`blueprint.yml`**, **`pr-ci.yml`**) watches **`tenkzlib/**`** and runs **`test_tnlog.py`** / **`test_texcase.py`** alongside the existing tenkz checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1bf3a9e857626a129996bc5838e50f4e7abb132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->