### PR TITLE
fix(tenkz): align wave-2 boundary capability demand

### DIFF
--- a/docs/tenkz/wave2-targets.md
+++ b/docs/tenkz/wave2-targets.md
@@ -160,16 +160,16 @@ by the RMP manifest.
 | `rmp-w2-four-peps-plaquette` | Section V, 256–264 | Four PEPS tensors occupy the edges of one renormalization plaquette. | `free-graph`, `four-site-plaquette`, `renormalization` |
 | `rmp-w2-peps-block-renormalization` | Section V, 265–277 | A two-by-two PEPS block renormalizes to one effective four-leg tensor. | `lattice`, `blocking`, `equation-composition` |
 | `rmp-w2-f-symbol-tensor` | Section V, 278–280 | One F-symbol tensor carries the trivalent fusion data and its labelled legs. | `coherence`, `fusion-tree` |
-| `rmp-w2-right-intersection-word` | Section V, 281–288 | The right word joins boundary tensor R to tensors B and C and closes both virtual ends into R. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-left-intersection-word` | Section V, 289–296 | The left word joins tensors A and B to boundary tensor L and closes both virtual ends into L. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-right-intersection-after-inverse` | Section V, 297–304 | Applying the inverse of B leaves R, one exposed site, and C. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-left-intersection-after-inverse` | Section V, 305–312 | Applying the inverse of B leaves A, one exposed site, and L. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-left-intersection-regrown` | Section V, 313–321 | Growing B back gives A joined to B, one exposed site, and boundary tensor L. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-right-intersection-regrown` | Section V, 322–331 | Growing B back gives boundary tensor R, B, one exposed site, and C. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-right-intersection-with-s` | Section V, 332–343 | S acts on the right word formed by an uncovered wire, B, and C inside boundary tensor R. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-left-intersection-after-s-inverse` | Section V, 344–351 | The inverse of S removes the jointly injective A–B pair from the L side. | `free-graph`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-left-boundary-two-indices` | Section V, 352–357 | After inversion, boundary tensor L retains two open indices. | `grid`, `typed-ports`, `enclosure-marks` |
-| `rmp-w2-right-boundary-x` | Section V, 358–365 | The right boundary reduces to X attached to tensor C inside boundary tensor R. | `free-graph`, `closure`, `typed-ports`, `enclosure-marks` |
+| `rmp-w2-right-intersection-word` | Section V, 281–288 | The right word joins boundary tensor R to tensors B and C and closes both virtual ends into R. | `free-graph`, `closure`, `typed-ports` |
+| `rmp-w2-left-intersection-word` | Section V, 289–296 | The left word joins tensors A and B to boundary tensor L and closes both virtual ends into L. | `free-graph`, `closure`, `typed-ports` |
+| `rmp-w2-right-intersection-after-inverse` | Section V, 297–304 | Applying the inverse of B leaves R, one exposed site, and C. | `free-graph`, `closure`, `typed-ports` |
+| `rmp-w2-left-intersection-after-inverse` | Section V, 305–312 | Applying the inverse of B leaves A, one exposed site, and L. | `free-graph`, `closure`, `typed-ports` |
+| `rmp-w2-left-intersection-regrown` | Section V, 313–321 | Growing B back gives A joined to B, one exposed site, and boundary tensor L. | `free-graph`, `closure`, `typed-ports` |
+| `rmp-w2-right-intersection-regrown` | Section V, 322–331 | Growing B back gives boundary tensor R, B, one exposed site, and C. | `free-graph`, `closure`, `typed-ports` |
+| `rmp-w2-right-intersection-with-s` | Section V, 332–343 | S acts on the right word formed by an uncovered wire, B, and C inside boundary tensor R. | `free-graph`, `closure`, `typed-ports` |
+| `rmp-w2-left-intersection-after-s-inverse` | Section V, 344–351 | The inverse of S removes the jointly injective A–B pair from the L side. | `free-graph`, `typed-ports` |
+| `rmp-w2-left-boundary-two-indices` | Section V, 352–357 | After inversion, boundary tensor L retains two open indices. | `grid`, `typed-ports` |
+| `rmp-w2-right-boundary-x` | Section V, 358–365 | The right boundary reduces to X attached to tensor C inside boundary tensor R. | `free-graph`, `closure`, `typed-ports` |
 | `rmp-w2-right-boundary-window` | Section V, 366–383 | A two-dimensional R-boundary window surrounds its retained B–C interior. | `lattice`, `regions`, `typed-ports` |
 | `rmp-w2-left-boundary-window` | Section V, 384–402 | A two-dimensional L-boundary window surrounds its retained B–A interior. | `lattice`, `regions`, `typed-ports` |
 
@@ -178,7 +178,11 @@ by the RMP manifest.
 The existing column counts blocked targets whose `missing` list names the
 capability in `tests/tenkz/rmp/verdicts.toml`. The wave-2 column counts proposed
 consumers above. The combined column is their sum; it is the demand to use when
-ordering language work.
+ordering language work. These are deliberately different populations: the sum
+combines planned source-block consumers with current blocked targets, not all
+current manifest consumers. A repeated figure block remains a separate proposed
+consumer because this inventory assigns coverage to each author-source
+occurrence; the table does not deduplicate mathematically equivalent blocks.
 
 | Capability | Wave-2 proposed consumers | Existing blocked targets | Combined demand |
 |---|---:|---:|---:|
@@ -188,7 +192,7 @@ ordering language work.
 | `cluster-groups` | 0 | 1 | 1 |
 | `coherence` | 1 | 0 | 1 |
 | `crossing-order` | 0 | 9 | 9 |
-| `enclosure-marks` | 10 | 10 | 20 |
+| `enclosure-marks` | 0 | 10 | 10 |
 | `equation-composition` | 2 | 2 | 4 |
 | `four-site-plaquette` | 2 | 0 | 2 |
 | `free-graph` | 12 | 0 | 12 |

--- a/docs/tenkz/wave2-targets.md
+++ b/docs/tenkz/wave2-targets.md
@@ -214,3 +214,10 @@ occurrence; the table does not deduplicate mathematically equivalent blocks.
 | `strings` | 0 | 7 | 7 |
 | `torus-cycle` | 0 | 4 | 4 |
 | `typed-ports` | 13 | 0 | 13 |
+
+The `enclosure-marks` row is an audit exception rather than language demand.
+Its ten existing blockers are stale Section IV intersection verdicts: their
+manifest capabilities and cases use boundary atoms, in agreement with
+`docs/tenkz/LANGUAGE-1.0.md` Section 14. Treat the semantic demand for
+`enclosure-marks` as zero. Reclassifying those verdicts is separate work and is
+deliberately outside this inventory-only change.


### PR DESCRIPTION
## Summary

- remove `enclosure-marks` from the ten Section V intersection proposals because boundary operators are wide atoms under `LANGUAGE-1.0.md` §14
- recompute the wave-2 and combined `enclosure-marks` demand from 10/20 to 0/10
- clarify that proposed demand is source-block keyed, retains repeated author-source occurrences, and is intentionally combined with current blocked-target counts

Follow-up to #4729 and its post-merge review.

## Verification

```text
PASS inventory=107 owned=90 unowned=17 proposed=17
PASS ranges=in-bounds exhaustive and unowned-vs-manifest-overlaps=0
PASS capability-demand-rows=28
```

```text
python3 scripts/check_reader_facing_prose.py --root . --diff-base HEAD --ci
✓ No newly added reader-facing prose violations found.

git diff --check
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and planning inventory only; no manifest, verdict, or runtime behavior changes.
> 
> **Overview**
> Updates **`docs/tenkz/wave2-targets.md`** so wave-2 capability demand matches **LANGUAGE-1.0 §14**: Section V intersection proposals no longer list **`enclosure-marks`** (boundary operators are wide atoms), and the demand table’s **`enclosure-marks`** row moves from **10 / 20** to **0 / 10** wave-2 vs combined counts.
> 
> Adds short prose on how proposed vs blocked populations are combined (per author-source occurrence, no dedup of equivalent blocks) and documents that the ten existing **`enclosure-marks`** blockers are **stale Section IV verdicts**—semantic language demand should be treated as **zero**; reclassifying verdicts is explicitly out of scope for this inventory-only edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d1c0273369b7868b8c8e339ce480687a7e5aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->