### PR TITLE
refactor(blueprint): pilot Chapter 4 technical appendix

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch04_positive_maps.tex
+++ b/blueprint/src/appendix/ft_mps/ch04_positive_maps.tex
@@ -133,7 +133,7 @@ These results supply the deferred technical steps in
 Lemma~\ref{lem:making_positive_maps_trace_preserving}: the inverse-square-root
 filter satisfies the normalization identity and is invertible.
 
-\section{Support for Ky Fan's maximum principle}
+\section{Attainment and upper bounds for largest-eigenvalue sums}
 
 The next two results prove attainment and the matching upper bound used in
 Theorem~\ref{thm:ky_fan_maximum_principle}.
@@ -184,7 +184,7 @@ Together, Theorems~\ref{thm:ky_fan_achievability} and
 \ref{thm:ky_fan_upper_bound} give the two inequalities in
 Theorem~\ref{thm:ky_fan_maximum_principle}.
 
-\section{Complete-positivity bridges}
+\section{From Kraus representations to complete positivity}
 
 These results connect the Kraus formulation in
 Definition~\ref{def:cp_map} with entrywise positivity on block matrices and

--- a/blueprint/src/appendix/ft_mps/ch04_positive_maps.tex
+++ b/blueprint/src/appendix/ft_mps/ch04_positive_maps.tex
@@ -1,0 +1,235 @@
+\chapter{Technical Complements on Positive Maps}
+\label{ch:positive_maps_technical_complements}
+
+This appendix collects three groups of technical results used in
+Chapter~\ref{ch:channels}.  They establish the inverse-square-root
+normalization of positive maps, the two bounds behind Ky Fan's maximum
+principle, and the passage from Kraus representations to entrywise complete
+positivity.
+
+Throughout, $T^*$ denotes the adjoint for the trace pairing, $\Id$ is the
+identity matrix, and $A^{-1/2}$ denotes the inverse of the positive square
+root of a positive definite matrix.  The notation $S_k(A)$ is that of
+Definition~\ref{def:ky_fan_norm}.
+
+\section{Trace normalization by an inverse square root}
+
+The following results provide the normalization and invertibility steps used
+in the proof of Lemma~\ref{lem:making_positive_maps_trace_preserving}.
+
+\begin{lemma}[Trace-normalization criterion, trace-preservation component]
+    \label{lem:trace_normalization_criterion_trace}
+    \lean{trace_comp_unitaryConjLM_of_conj_traceAdjointMap_one}
+    \leanok
+    \uses{def:trace_preserving_rectangular, def:trace_pairing_adjoint}
+    Let $T:\MN{D}\to\MN{D'}$ be a linear map and let $X\in\MN{D}$ satisfy
+    $X^\dagger T^*(\Id)X=\Id$. Then, for every $\rho\in\MN{D}$,
+    \begin{align}
+        \tr\!(T(X\rho X^\dagger))
+        &=\tr(\rho).
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Expanding with the trace-pairing adjoint gives
+    \begin{align}
+        \tr\!(T(X\rho X^\dagger))
+        &=\tr\!(X\rho X^\dagger T^*(\Id))
+        =\tr\!(\rho X^\dagger T^*(\Id)X)
+        =\tr(\rho).
+        \notag
+    \end{align}
+\end{proof}
+
+\begin{theorem}[Filtered trace-normalization criterion]
+    \label{thm:filtered_trace_normalization_criterion}
+    \lean{comp_unitaryConjLM_positive_tracePreserving_of_conj_traceAdjointMap_one}
+    \leanok
+    \uses{def:positive_map_rectangular, def:trace_preserving_rectangular,
+        def:trace_pairing_adjoint, lem:trace_normalization_criterion_trace,
+        thm:conjugation_filters_preserve_positivity}
+    Let $T:\MN{D}\to\MN{D'}$ be a positive map between matrix algebras of
+    possibly different dimensions, and let $X\in\MN{D}$ satisfy
+    $X^\dagger T^*(\Id)X=\Id$, where $T^*$ is the trace-pairing adjoint.
+    Then $\rho\mapsto T(X\rho X^\dagger)$ is positive and trace-preserving.
+
+    This is the algebraic trace-normalization step in the proof of
+    \cite[Chapter~3, Lemma ``Making positive maps trace preserving'']
+    {Wolf2012Quantum}. The inverse-square-root choice is recorded in the
+    next theorem.
+\end{theorem}
+
+\begin{proof}\leanok
+    Positivity follows because $X\rho X^\dagger$ is positive whenever
+    $\rho$ is positive, and $T$ is positive. For trace preservation, the
+    trace-pairing adjoint identity and cyclicity of the trace give
+    \begin{align}
+        \tr\!(T(X\rho X^\dagger))
+        &=\tr\!(T^*(\Id)X\rho X^\dagger)
+        =\tr\!(X^\dagger T^*(\Id)X\rho)
+        =\tr(\rho).
+        \notag
+    \end{align}
+\end{proof}
+
+\begin{lemma}[Normalizing conjugation by inverse square root]
+    \label{lem:conj_inv_sqrt_normalizes}
+    \lean{Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef}
+    \leanok
+    \uses{}
+    Let $A\in\MN{D}$ be positive definite and set $S=A^{1/2}$. Then
+    \begin{align}
+        (S^{-1})^\dagger A S^{-1}
+        &=\Id.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Since $A$ is positive definite, $S$ is invertible and self-adjoint, and
+    $S^2=A$. Therefore
+    $(S^{-1})^\dagger A S^{-1}=S^{-1}S^2S^{-1}=\Id$.
+\end{proof}
+
+\begin{lemma}[Inverse square root of a positive definite matrix is invertible]
+    \label{lem:pos_def_inv_sqrt_invertible}
+    \lean{Matrix.PosDef.isUnit_det_inv_sqrt}
+    \leanok
+    \uses{}
+    If $A\in\MN{D}$ is positive definite, then $(A^{1/2})^{-1}$ is
+    invertible.
+\end{lemma}
+
+\begin{proof}\leanok
+    A positive definite matrix is invertible, hence so is its square root
+    $A^{1/2}$, and the inverse of an invertible matrix is invertible.
+\end{proof}
+
+\begin{theorem}[Trace normalization by inverse square root]
+    \label{thm:trace_normalization_inverse_square_root}
+    \lean{comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one}
+    \leanok
+    \uses{def:positive_map_rectangular, def:trace_preserving_rectangular,
+        def:trace_pairing_adjoint,
+        thm:filtered_trace_normalization_criterion, lem:conj_inv_sqrt_normalizes}
+    Let $T:\MN{D}\to\MN{D'}$ be a positive map such that $T^*(\Id)$ is positive
+    definite. Put $X=(T^*(\Id))^{-1/2}$. Then
+    $\rho\mapsto T(X\rho X^\dagger)$ is positive and trace-preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    Let $S=(T^*(\Id))^{1/2}$. Since $T^*(\Id)$ is positive definite, $S$ is
+    invertible and self-adjoint, and $S^2=T^*(\Id)$. For $X=S^{-1}$,
+    \begin{align}
+        X^\dagger T^*(\Id)X
+        &=S^{-1}S^2S^{-1}=\Id.
+        \notag
+    \end{align}
+    Theorem~\ref{thm:filtered_trace_normalization_criterion} applies.
+\end{proof}
+
+These results supply the deferred technical steps in
+Lemma~\ref{lem:making_positive_maps_trace_preserving}: the inverse-square-root
+filter satisfies the normalization identity and is invertible.
+
+\section{Support for Ky Fan's maximum principle}
+
+The next two results prove attainment and the matching upper bound used in
+Theorem~\ref{thm:ky_fan_maximum_principle}.
+
+\begin{theorem}[Achievability of the largest-eigenvalue sum]
+    \label{thm:ky_fan_achievability}
+    \lean{Matrix.IsHermitian.exists_isProj_trace_eq_kyFanNorm}
+    \leanok
+    \uses{def:ky_fan_norm}
+    For every Hermitian $A\in\MN{D}$ and every $k\ge0$, there is an orthogonal
+    projection $P$ of rank $\min(k,D)$ with $\re\tr(PA)=S_k(A)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:ky_fan_norm}
+    Diagonalize $A=U\diag(\lambda_i)U^\dagger$ and take $P$ to be the
+    projection onto the span of the eigenvectors with the $\min(k,D)$ largest
+    eigenvalues. Then $\re\tr(PA)=\sum_{i\le k}\lambda_i=S_k(A)$.
+\end{proof}
+
+\begin{theorem}[Upper bound for the largest-eigenvalue sum]
+    \label{thm:ky_fan_upper_bound}
+    \lean{Matrix.IsHermitian.trace_mul_re_le_kyFanNorm}
+    \leanok
+    \uses{def:ky_fan_norm}
+    For every Hermitian $A\in\MN{D}$ and every orthogonal projection $P$ of
+    rank $k<D$, one has $\re\tr(PA)\le S_k(A)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:ky_fan_norm}
+    Conjugating $P$ by $U$ gives an orthogonal projection $Q$ of the same
+    rank, and $\re\tr(PA)=\sum_iw_i\lambda_i$, where $w_i$ are the diagonal
+    entries of $Q$. Each $w_i$ lies in $[0,1]$ and the weights sum to
+    $\tr(P)=k$. With the threshold $c=\lambda_{k+1}$,
+    \begin{align}
+        \sum_{i\le k}\lambda_i-\sum_iw_i\lambda_i
+        &=\sum_{i\le k}(\lambda_i-c)(1-w_i)
+          +\sum_{i>k}(c-\lambda_i)w_i
+        \ge0,
+        \notag
+    \end{align}
+    since for $i\le k$ the eigenvalues dominate $c$ while $1-w_i\ge0$, and
+    for $i>k$ they are dominated by $c$ while $w_i\ge0$.
+\end{proof}
+
+Together, Theorems~\ref{thm:ky_fan_achievability} and
+\ref{thm:ky_fan_upper_bound} give the two inequalities in
+Theorem~\ref{thm:ky_fan_maximum_principle}.
+
+\section{Complete-positivity bridges}
+
+These results connect the Kraus formulation in
+Definition~\ref{def:cp_map} with entrywise positivity on block matrices and
+with the corresponding completely positive map between matrix
+$C^*$-algebras.
+
+\begin{theorem}[Entrywise complete positivity from a Kraus representation]
+    \label{thm:cp_map_entrywise_complete_positive}
+    \lean{IsCPMap.map_cstarMatrix_nonneg}
+    \leanok
+    \uses{def:cp_map}
+    Let $E : \MN{D} \to \MN{D}$ be completely positive in the Kraus sense.
+    For every $k$ and every positive block matrix
+    $M \in M_k(\MN{D})$, the entrywise image
+    $(E(M_{ab}))_{a,b}$ is again positive in $M_k(\MN{D})$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write $E$ in the Kraus form (\ref{eq:channel_kraus_representation}).
+    For each $i$, let $d_i$ be the block-diagonal matrix with $K_i$ on every
+    diagonal block. Then
+    \begin{align}
+        (E(M_{ab}))_{a,b}
+        &=\sum_i d_i M d_i^\dagger.
+        \notag
+    \end{align}
+    Each term on the right is positive because conjugation preserves
+    positivity, and a finite sum of positive matrices is positive.
+\end{proof}
+
+\begin{theorem}[Kraus maps as abstract completely positive maps]
+    \label{thm:cp_map_to_abstract_completely_positive}
+    \lean{IsCPMap.toCompletelyPositiveMap}
+    \leanok
+    \uses{def:cp_map, thm:cp_map_entrywise_complete_positive}
+    Every Kraus-represented completely positive map
+    $E : \MN{D} \to \MN{D}$ determines a completely positive map between
+    the matrix $C^*$-algebras in the entrywise positivity sense.
+\end{theorem}
+
+\begin{proof}\leanok
+    The defining entrywise positivity condition is exactly
+    Theorem~\ref{thm:cp_map_entrywise_complete_positive}.
+\end{proof}
+
+Thus the Kraus formulation of Definition~\ref{def:cp_map} has the two
+consequences cited there: entrywise complete positivity and the associated
+abstract completely positive map.

--- a/blueprint/src/appendix/ft_mps_appendices.tex
+++ b/blueprint/src/appendix/ft_mps_appendices.tex
@@ -1,0 +1,3 @@
+\appendix
+\part{Technical Complements}
+\input{appendix/ft_mps/ch04_positive_maps}

--- a/blueprint/src/chapter/ch04_channels_ft_core.tex
+++ b/blueprint/src/chapter/ch04_channels_ft_core.tex
@@ -8,6 +8,13 @@
     means that $X$ is positive semidefinite.
 \end{definition}
 
+\begin{definition}[Trace-preserving map]\label{def:trace_preserving}
+    \lean{IsTracePreservingMap}
+    \leanok
+    A linear map $E : \MN{D} \to \MN{D}$ is \emph{trace-preserving}
+    if $\tr(E(X)) = \tr(X)$ for all $X$.
+\end{definition}
+
 \begin{remark}\leanok
     We use the Loewner order on matrices: $X \le Y$ means
     $Y - X \ge 0$.
@@ -26,8 +33,47 @@
         \label{eq:channel_kraus_representation}
     \end{align}
     By Choi's theorem, this is equivalent
-    to $E \otimes \id_n$ being positive for all~$n$.
+    to $E \otimes \id_n$ being positive for all~$n$. The Kraus
+    representation also gives entrywise positivity on every positive block
+    matrix by Theorem~\ref{thm:cp_map_entrywise_complete_positive}, and hence
+    the associated completely positive map between matrix $C^*$-algebras in
+    Theorem~\ref{thm:cp_map_to_abstract_completely_positive}.
 \end{definition}
+
+\begin{definition}[Quantum channel]\label{def:channel}
+    \lean{IsChannel}
+    \leanok
+    \uses{def:cp_map, def:trace_preserving}
+    A linear map $E : \MN{D} \to \MN{D}$ is a \emph{quantum channel}
+    if it is both completely positive and trace-preserving (CPTP),
+    following~\cite{Wolf2012Quantum}.
+\end{definition}
+
+\begin{theorem}[CP maps are positive]\label{thm:cp_is_positive}
+    \lean{IsCPMap.isPositiveMap}
+    \leanok
+    \uses{def:cp_map, def:positive_map}
+    Every completely positive map is positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    By the Kraus representation (\ref{eq:channel_kraus_representation}), if
+    $X \ge 0$, then each summand $K_i X K_i^\dagger \ge 0$ because
+    conjugation preserves positive semidefiniteness. Hence their sum is
+    positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Channels are positive]\label{thm:channel_positive}
+    \lean{IsChannel.pos}
+    \leanok
+    \uses{def:channel, def:positive_map}
+    Every quantum channel is positive.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:cp_is_positive}
+    A quantum channel is completely positive by definition, so
+    Theorem~\ref{thm:cp_is_positive} applies.
+\end{proof}
 
 \section{Irreducibility}
 

--- a/blueprint/src/chapter/ch04_channels_positive_maps_auxiliary.tex
+++ b/blueprint/src/chapter/ch04_channels_positive_maps_auxiliary.tex
@@ -10,13 +10,6 @@
     $A,B\in\MN{n}$ and $A \le B$, then $E(A) \le E(B)$ in $\MN{m}$.
 \end{definition}
 
-\begin{definition}[Trace-preserving map]\label{def:trace_preserving}
-    \lean{IsTracePreservingMap}
-    \leanok
-    A linear map $E : \MN{D} \to \MN{D}$ is \emph{trace-preserving}
-    if $\tr(E(X)) = \tr(X)$ for all $X$.
-\end{definition}
-
 \begin{theorem}[Transposition is positive and trace-preserving]
     \label{thm:transpose_positive_trace_preserving}
     \lean{Matrix.transposeLinearMapComplex_isPositiveMap,
@@ -140,118 +133,6 @@
     Definition~\ref{def:trace_preserving}.
 \end{definition}
 
-\begin{lemma}[Trace-normalization criterion, trace-preservation component]
-    \label{lem:trace_normalization_criterion_trace}
-    \lean{trace_comp_unitaryConjLM_of_conj_traceAdjointMap_one}
-    \leanok
-    \uses{def:trace_preserving_rectangular, def:trace_pairing_adjoint}
-    Let $T:\MN{D}\to\MN{D'}$ be a linear map and let $X\in\MN{D}$ satisfy
-    $X^\dagger T^*(\Id)X=\Id$. Then, for every $\rho\in\MN{D}$,
-    \begin{align}
-        \tr\!(T(X\rho X^\dagger))
-        &=\tr(\rho).
-        \notag
-    \end{align}
-\end{lemma}
-
-\begin{proof}\leanok
-    Expanding with the trace-pairing adjoint gives
-    \begin{align}
-        \tr\!(T(X\rho X^\dagger))
-        &=\tr\!(X\rho X^\dagger T^*(\Id))
-        =\tr\!(\rho X^\dagger T^*(\Id)X)
-        =\tr(\rho).
-        \notag
-    \end{align}
-\end{proof}
-
-\begin{theorem}[Filtered trace-normalization criterion]
-    \label{thm:filtered_trace_normalization_criterion}
-    \lean{comp_unitaryConjLM_positive_tracePreserving_of_conj_traceAdjointMap_one}
-    \leanok
-    \uses{def:positive_map_rectangular, def:trace_preserving_rectangular,
-        def:trace_pairing_adjoint, lem:trace_normalization_criterion_trace,
-        thm:conjugation_filters_preserve_positivity}
-    Let $T:\MN{D}\to\MN{D'}$ be a positive map between matrix algebras of
-    possibly different dimensions, and let $X\in\MN{D}$ satisfy
-    $X^\dagger T^*(\Id)X=\Id$, where $T^*$ is the trace-pairing adjoint.
-    Then $\rho\mapsto T(X\rho X^\dagger)$ is positive and trace-preserving.
-
-    This is the algebraic trace-normalization step in the proof of
-    \cite[Chapter~3, Lemma ``Making positive maps trace preserving'']
-    {Wolf2012Quantum}. The inverse-square-root choice is recorded in the
-    next theorem.
-\end{theorem}
-
-\begin{proof}\leanok
-    Positivity follows because $X\rho X^\dagger$ is positive whenever
-    $\rho$ is positive, and $T$ is positive. For trace preservation, the
-    trace-pairing adjoint identity and cyclicity of the trace give
-    \begin{align}
-        \tr\!(T(X\rho X^\dagger))
-        &=\tr\!(T^*(\Id)X\rho X^\dagger)
-        =\tr\!(X^\dagger T^*(\Id)X\rho)
-        =\tr(\rho).
-        \notag
-    \end{align}
-\end{proof}
-
-\begin{lemma}[Normalizing conjugation by inverse square root]
-    \label{lem:conj_inv_sqrt_normalizes}
-    \lean{Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef}
-    \leanok
-    \uses{}
-    Let $A\in\MN{D}$ be positive definite and set $S=A^{1/2}$. Then
-    \begin{align}
-        (S^{-1})^\dagger A S^{-1}
-        &=\Id.
-        \notag
-    \end{align}
-\end{lemma}
-
-\begin{proof}\leanok
-    Since $A$ is positive definite, $S$ is invertible and self-adjoint, and
-    $S^2=A$. Therefore
-    $(S^{-1})^\dagger A S^{-1}=S^{-1}S^2S^{-1}=\Id$.
-\end{proof}
-
-\begin{lemma}[Inverse square root of a positive definite matrix is invertible]
-    \label{lem:pos_def_inv_sqrt_invertible}
-    \lean{Matrix.PosDef.isUnit_det_inv_sqrt}
-    \leanok
-    \uses{}
-    If $A\in\MN{D}$ is positive definite, then $(A^{1/2})^{-1}$ is
-    invertible.
-\end{lemma}
-
-\begin{proof}\leanok
-    A positive definite matrix is invertible, hence so is its square root
-    $A^{1/2}$, and the inverse of an invertible matrix is invertible.
-\end{proof}
-
-\begin{theorem}[Trace normalization by inverse square root]
-    \label{thm:trace_normalization_inverse_square_root}
-    \lean{comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one}
-    \leanok
-    \uses{def:positive_map_rectangular, def:trace_preserving_rectangular,
-        def:trace_pairing_adjoint,
-        thm:filtered_trace_normalization_criterion, lem:conj_inv_sqrt_normalizes}
-    Let $T:\MN{D}\to\MN{D'}$ be a positive map such that $T^*(\Id)$ is positive
-    definite. Put $X=(T^*(\Id))^{-1/2}$. Then
-    $\rho\mapsto T(X\rho X^\dagger)$ is positive and trace-preserving.
-\end{theorem}
-
-\begin{proof}\leanok
-    Let $S=(T^*(\Id))^{1/2}$. Since $T^*(\Id)$ is positive definite, $S$ is
-    invertible and self-adjoint, and $S^2=T^*(\Id)$. For $X=S^{-1}$,
-    \begin{align}
-        X^\dagger T^*(\Id)X
-        &=S^{-1}S^2S^{-1}=\Id.
-        \notag
-    \end{align}
-    Theorem~\ref{thm:filtered_trace_normalization_criterion} applies.
-\end{proof}
-
 \begin{lemma}[Making positive maps trace preserving]
     \label{lem:making_positive_maps_trace_preserving}
     \lean{exists_isUnit_det_comp_unitaryConjLM_positive_tracePreserving}
@@ -268,11 +149,20 @@
 \end{lemma}
 
 \begin{proof}\leanok
-    Take $X=(T^*(\Id))^{-1/2}$, which is invertible by
-    Lemma~\ref{lem:pos_def_inv_sqrt_invertible} because $T^*(\Id)$ is
-    positive definite. By
-    Theorem~\ref{thm:trace_normalization_inverse_square_root},
-    $\rho\mapsto T(X\rho X^\dagger)$ is positive and trace-preserving.
+    Take $X=(T^*(\Id))^{-1/2}$. It is invertible by
+    Lemma~\ref{lem:pos_def_inv_sqrt_invertible}. The inverse-square-root
+    normalization in
+    Theorem~\ref{thm:trace_normalization_inverse_square_root} gives
+    $X^\dagger T^*(\Id)X=\Id$. Hence the trace-pairing identity and
+    cyclicity give, for every $\rho$,
+    \begin{align}
+        \tr\!(T(X\rho X^\dagger))
+        &=\tr\!(\rho X^\dagger T^*(\Id)X)
+        =\tr(\rho).
+        \notag
+    \end{align}
+    Conjugation by $X$ preserves positive semidefiniteness, and $T$ is
+    positive, so $\rho\mapsto T(X\rho X^\dagger)$ is also positive.
 \end{proof}
 
 \begin{theorem}[The trace bounds a positive matrix]
@@ -373,48 +263,6 @@
     positive-semidefinite cone they are statements about the Ky-Fan norm.
 \end{definition}
 
-\begin{theorem}[Achievability of the largest-eigenvalue sum]
-    \label{thm:ky_fan_achievability}
-    \lean{Matrix.IsHermitian.exists_isProj_trace_eq_kyFanNorm}
-    \leanok
-    \uses{def:ky_fan_norm}
-    For every Hermitian $A\in\MN{D}$ and every $k\ge0$, there is an orthogonal
-    projection $P$ of rank $\min(k,D)$ with $\re\tr(PA)=S_k(A)$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:ky_fan_norm}
-    Diagonalize $A=U\diag(\lambda_i)U^\dagger$ and take $P$ to be the
-    projection onto the span of the eigenvectors with the $\min(k,D)$ largest
-    eigenvalues. Then $\re\tr(PA)=\sum_{i\le k}\lambda_i=S_k(A)$.
-\end{proof}
-
-\begin{theorem}[Upper bound for the largest-eigenvalue sum]
-    \label{thm:ky_fan_upper_bound}
-    \lean{Matrix.IsHermitian.trace_mul_re_le_kyFanNorm}
-    \leanok
-    \uses{def:ky_fan_norm}
-    For every Hermitian $A\in\MN{D}$ and every orthogonal projection $P$ of
-    rank $k<D$, one has $\re\tr(PA)\le S_k(A)$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:ky_fan_norm}
-    Conjugating $P$ by $U$ gives an orthogonal projection $Q$ of the same
-    rank, and $\re\tr(PA)=\sum_iw_i\lambda_i$, where $w_i$ are the diagonal
-    entries of $Q$. Each $w_i$ lies in $[0,1]$ and the weights sum to
-    $\tr(P)=k$. With the threshold $c=\lambda_{k+1}$,
-    \begin{align}
-        \sum_{i\le k}\lambda_i-\sum_iw_i\lambda_i
-        &=\sum_{i\le k}(\lambda_i-c)(1-w_i)
-          +\sum_{i>k}(c-\lambda_i)w_i
-        \ge0,
-        \notag
-    \end{align}
-    since for $i\le k$ the eigenvalues dominate $c$ while $1-w_i\ge0$, and
-    for $i>k$ they are dominated by $c$ while $w_i\ge0$.
-\end{proof}
-
 \begin{theorem}[Ky Fan's maximum principle]
     \label{thm:ky_fan_maximum_principle}
     \lean{Matrix.IsHermitian.kyFanNorm_eq_sup_trace}
@@ -502,71 +350,6 @@
     contradicting positive semidefiniteness.
 \end{proof}
 
-\begin{theorem}[Entrywise complete positivity from a Kraus representation]
-    \label{thm:cp_map_entrywise_complete_positive}
-    \lean{IsCPMap.map_cstarMatrix_nonneg}
-    \leanok
-    \uses{def:cp_map}
-    Let $E : \MN{D} \to \MN{D}$ be completely positive in the Kraus sense.
-    For every $k$ and every positive block matrix
-    $M \in M_k(\MN{D})$, the entrywise image
-    $(E(M_{ab}))_{a,b}$ is again positive in $M_k(\MN{D})$.
-\end{theorem}
-
-\begin{proof}\leanok
-    Write $E$ in the Kraus form (\ref{eq:channel_kraus_representation}).
-    For each $i$, let $d_i$ be the block-diagonal matrix with $K_i$ on every
-    diagonal block. Then
-    \begin{align}
-        (E(M_{ab}))_{a,b}
-        &=\sum_i d_i M d_i^\dagger.
-        \notag
-    \end{align}
-    Each term on the right is positive because conjugation preserves
-    positivity, and a finite sum of positive matrices is positive.
-\end{proof}
-
-\begin{theorem}[Kraus maps as abstract completely positive maps]
-    \label{thm:cp_map_to_abstract_completely_positive}
-    \lean{IsCPMap.toCompletelyPositiveMap}
-    \leanok
-    \uses{def:cp_map, thm:cp_map_entrywise_complete_positive}
-    Every Kraus-represented completely positive map
-    $E : \MN{D} \to \MN{D}$ determines a completely positive map between
-    the matrix $C^*$-algebras in the entrywise positivity sense.
-\end{theorem}
-
-\begin{proof}\leanok
-    The defining entrywise positivity condition is exactly
-    Theorem~\ref{thm:cp_map_entrywise_complete_positive}.
-\end{proof}
-
-\begin{theorem}[CP maps are positive]\label{thm:cp_is_positive}
-    \lean{IsCPMap.isPositiveMap}
-    \leanok
-    \uses{def:cp_map, def:positive_map}
-    Every completely positive map is positive.
-\end{theorem}
-
-\begin{proof}\leanok
-    By the Kraus representation (\ref{eq:channel_kraus_representation}), if
-    $X \ge 0$, then each summand $K_i X K_i^\dagger \ge 0$ because
-    conjugation preserves positive semidefiniteness. Hence their sum is
-    positive semidefinite.
-\end{proof}
-
-\begin{theorem}[Channels are positive]\label{thm:channel_positive}
-    \lean{IsChannel.pos}
-    \leanok
-    \uses{def:channel, def:positive_map}
-    Every quantum channel is positive.
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:cp_is_positive}
-    A quantum channel is completely positive by definition, so
-    Theorem~\ref{thm:cp_is_positive} applies.
-\end{proof}
-
 \begin{theorem}[Positive maps preserve Hermiticity]
     \label{thm:positive_map_preserves_hermitian}
     \lean{IsPositiveMap.map_isHermitian}
@@ -584,15 +367,6 @@
     Since $X=X^\dagger$ means $X=X^\ast$, one obtains
     $E(X)^\dagger=E(X)^\ast=E(X^\ast)=E(X)$.
 \end{proof}
-
-\begin{definition}[Quantum channel]\label{def:channel}
-    \lean{IsChannel}
-    \leanok
-    \uses{def:cp_map, def:trace_preserving}
-    A linear map $E : \MN{D} \to \MN{D}$ is a \emph{quantum channel}
-    if it is both completely positive and trace-preserving (CPTP),
-    following~\cite{Wolf2012Quantum}.
-\end{definition}
 
 \begin{definition}[Density matrices]\label{def:density_matrices}
     \lean{densityMatrices, mem_densityMatrices}

--- a/blueprint/src/chapter/ch04_channels_positive_maps_auxiliary.tex
+++ b/blueprint/src/chapter/ch04_channels_positive_maps_auxiliary.tex
@@ -149,20 +149,22 @@
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:pos_def_inv_sqrt_invertible, lem:conj_inv_sqrt_normalizes,
+        thm:trace_normalization_inverse_square_root}
     Take $X=(T^*(\Id))^{-1/2}$. It is invertible by
-    Lemma~\ref{lem:pos_def_inv_sqrt_invertible}. The inverse-square-root
-    normalization in
-    Theorem~\ref{thm:trace_normalization_inverse_square_root} gives
-    $X^\dagger T^*(\Id)X=\Id$. Hence the trace-pairing identity and
-    cyclicity give, for every $\rho$,
+    Lemma~\ref{lem:pos_def_inv_sqrt_invertible}, and
+    Theorem~\ref{thm:trace_normalization_inverse_square_root} gives directly
+    that $\rho\mapsto T(X\rho X^\dagger)$ is positive and trace-preserving.
+    The normalization behind that theorem is
+    Lemma~\ref{lem:conj_inv_sqrt_normalizes}, which gives
+    $X^\dagger T^*(\Id)X=\Id$. Indeed, the trace-pairing identity and
+    cyclicity then give, for every $\rho$,
     \begin{align}
         \tr\!(T(X\rho X^\dagger))
         &=\tr\!(\rho X^\dagger T^*(\Id)X)
         =\tr(\rho).
         \notag
     \end{align}
-    Conjugation by $X$ preserves positive semidefiniteness, and $T$ is
-    positive, so $\rho\mapsto T(X\rho X^\dagger)$ is also positive.
 \end{proof}
 
 \begin{theorem}[The trace bounds a positive matrix]

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -26,3 +26,5 @@
 % \input{chapter/ch22_periodic_ft}
 % \input{chapter/ch23_algebraic_ft}
 % \input{chapter/ch24_peps_ft}
+
+\input{appendix/ft_mps_appendices}

--- a/blueprint/src/content_ft_mps.tex
+++ b/blueprint/src/content_ft_mps.tex
@@ -12,3 +12,5 @@
 \input{chapter/ch10_bnt}
 \input{chapter/ch11_fundamental_theorem_proof}
 \input{chapter/ch12_symmetry}
+
+\input{appendix/ft_mps_appendices}

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -504,7 +504,7 @@ def print_missing_blueprint_warnings(missing: list[LeanDecl]) -> None:
                 "::warning "
                 f"file={decl.file},line={decl.line},title=Blueprint update suggested::"
                 f"{decl.fqn} is changed in this PR but has no corresponding "
-                "\\lean{} tag in blueprint/src/chapter."
+                "\\lean{} tag in blueprint/src/chapter or blueprint/src/appendix."
             )
     print()
 

--- a/scripts/blueprint_lean_sync.py
+++ b/scripts/blueprint_lean_sync.py
@@ -234,14 +234,17 @@ def collect_lean_decls(lean_root: Path) -> dict[str, LeanDecl]:
 # Parse blueprint .tex files
 # ---------------------------------------------------------------------------
 
+def _blueprint_content_files(blueprint_src: Path) -> list[Path]:
+    """Return theorem-bearing chapter and appendix sources in stable order."""
+    files = list((blueprint_src / "chapter").glob("*.tex"))
+    files.extend((blueprint_src / "appendix").rglob("*.tex"))
+    return sorted(files)
+
+
 def collect_blueprint_lean_refs(blueprint_src: Path) -> list[BlueprintEntry]:
     """Return all raw declaration references appearing in ``\\lean{...}`` tags."""
-    chapter_dir = blueprint_src / "chapter"
-    if not chapter_dir.exists():
-        return []
-
     refs: list[BlueprintEntry] = []
-    for tex_file in sorted(chapter_dir.glob("*.tex")):
+    for tex_file in _blueprint_content_files(blueprint_src):
         text = tex_file.read_text(errors="replace")
         rel = str(tex_file.relative_to(blueprint_src.parent))
         for lm in _TEX_LEAN_RE.finditer(text):
@@ -262,11 +265,7 @@ def collect_blueprint_lean_refs(blueprint_src: Path) -> list[BlueprintEntry]:
 def collect_blueprint_entries(blueprint_src: Path) -> list[BlueprintEntry]:
     """Parse theorem-like blueprint environments for ``\\lean{}`` and ``\\leanok``."""
     entries: list[BlueprintEntry] = []
-    chapter_dir = blueprint_src / "chapter"
-    if not chapter_dir.exists():
-        return entries
-
-    for tex_file in sorted(chapter_dir.glob("*.tex")):
+    for tex_file in _blueprint_content_files(blueprint_src):
         text = tex_file.read_text(errors="replace")
         lines = text.splitlines()
         lean_decls_by_line: dict[int, list[str]] = {}

--- a/scripts/check_reader_facing_prose.py
+++ b/scripts/check_reader_facing_prose.py
@@ -315,8 +315,9 @@ def check_blueprint_line(path: Path, line_no: int, text: str) -> list[Finding]:
 
 def is_blueprint_prose_path(path: Path) -> bool:
     return path in BLUEPRINT_ENTRYPOINTS or (
-        len(path.parts) == 4
-        and path.parts[:3] == ("blueprint", "src", "chapter")
+        len(path.parts) >= 4
+        and path.parts[:2] == ("blueprint", "src")
+        and path.parts[2] in {"chapter", "appendix"}
         and path.suffix == ".tex"
     )
 

--- a/scripts/check_reader_facing_prose.py
+++ b/scripts/check_reader_facing_prose.py
@@ -71,7 +71,9 @@ BLUEPRINT_LABEL_TEXTTT_RE = re.compile(r"\\texttt\{(?:thm|lem|def|prop|cor|eq):[
 IGNORED_TEX_MACRO_RE = re.compile(r"\\(?:label|ref|eqref|uses|lean)\{[^}]*\}")
 BLUEPRINT_ENTRYPOINTS = {
     Path("blueprint/src/content.tex"),
+    Path("blueprint/src/content_ft_mps.tex"),
     Path("blueprint/src/print.tex"),
+    Path("blueprint/src/print_ft_mps.tex"),
     Path("blueprint/src/web.tex"),
 }
 
@@ -113,9 +115,12 @@ def _git_diff(base_ref: str) -> str:
             "TNLean.lean",
             ":(glob)TNLean/**/*.lean",
             "blueprint/src/content.tex",
+            "blueprint/src/content_ft_mps.tex",
             "blueprint/src/print.tex",
+            "blueprint/src/print_ft_mps.tex",
             "blueprint/src/web.tex",
             ":(glob)blueprint/src/chapter/*.tex",
+            ":(glob)blueprint/src/appendix/**/*.tex",
         ],
         check=True,
         stdout=subprocess.PIPE,
@@ -165,7 +170,9 @@ def blueprint_files(root: Path) -> Iterable[Path]:
         path = root / rel_path
         if path.exists():
             yield path
-    yield from (root / "blueprint" / "src" / "chapter").glob("*.tex")
+    blueprint_src = root / "blueprint" / "src"
+    yield from (blueprint_src / "chapter").glob("*.tex")
+    yield from (blueprint_src / "appendix").rglob("*.tex")
 
 
 def lean_comment_lines(path: Path) -> set[int]:


### PR DESCRIPTION
## Summary
- move three narrowly classified Chapter 4 proof-support clusters into a shared mathematical appendix:
  - inverse-square-root trace normalization
  - Ky Fan attainment and upper-bound support
  - Kraus-to-complete-positivity bridges
- keep Wolf's named trace-normalization lemma, Ky Fan's maximum principle, the CP definition, and all central statements in the main chapter
- strengthen main-text prose and proofs with the mathematical mechanism and exact appendix references
- move trace preservation, channels, and their positivity consequences into the Chapter 4 core before first use
- include the same appendix at the end of both the complete and focused FT/SPT builds

This PR is stacked on #4731, which documents the governing appendix policy. It intentionally does not reorganize any chapter other than Chapter 4.

## Validation
- independent source/Lean classification of all 113 Chapter 4 entries
- independent post-edit mathematical and metadata audit
- all nine relocated entries remain byte-identical, including labels, hypotheses, proofs, citations, `\lean`, `\leanok`, and `\uses`
- Chapter 4 retains the same 128 unique Lean-tag items
- no duplicate labels, missing static inputs, or new unresolved `\ref`/`\uses` targets
- `git diff --check`
- isolated two-pass LuaLaTeX build of `print.tex` passed
- isolated two-pass LuaLaTeX build of `print_ft_mps.tex` passed

## Existing focused-build reference baseline

The pilot introduces no new undefined references. The focused FT/SPT build already has nine labels defined only in excluded later chapters (`def:flip_operator`, `def:fin_two_antisymm_vec`, `thm:choi_transpose_flip`, `thm:cp_iff_choi_posSemidef`, `thm:rankone_ray_scalar_rigidity`, `ch:parent_hamiltonian`, `thm:kadison_schwarz_2positive`, `thm:dim_preserved`, and `thm:sharp_bnt_block_separation`). Their closure is deliberately deferred to a separate follow-up so this pilot remains narrow and reviewable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX structure only; no Lean or runtime behavior changes, with labels and `\lean` metadata preserved on relocated entries.
> 
> **Overview**
> **Pilot Chapter 4 appendix:** Nine byte-identical technical results (inverse-square-root trace normalization, Ky Fan attainment/upper bounds, Kraus-to-entrywise CP) move from `ch04_channels_positive_maps_auxiliary.tex` into `appendix/ft_mps/ch04_positive_maps.tex`, included via `ft_mps_appendices.tex` at the end of both `content.tex` and `content_ft_mps.tex`.
> 
> **Main chapter reshuffle:** Trace-preserving maps, quantum channels, and CP/channel positivity theorems move into `ch04_channels_ft_core.tex` ahead of first use; the CP definition now cites the appendix theorems for Kraus consequences. The Wolf trace-normalization lemma proof is shortened to point at appendix labels while keeping central statements (Ky Fan maximum principle, etc.) in the auxiliary chapter.
> 
> **Tooling:** `blueprint_lean_sync.py` and `check_reader_facing_prose.py` scan `blueprint/src/appendix/**` and the FT/MPS content entrypoints so Lean tags and prose checks stay aligned with the new appendix layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33364be1cd25dcb38442ace7f1b0c6928e92f421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->