### PR TITLE
ci(tenkz): compile manual examples standalone

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -201,6 +201,7 @@ jobs:
               - 'tex/tenkz/**'
               - 'tests/tenkz/**'
               - 'docs/tenkz/chapters2/**'
+              - 'docs/tenkz/tenkzmanual2.sty'
               - 'scripts/tenkz_manual_doctest.py'
               - 'scripts/test_tenkz_manual_doctest.py'
               - 'scripts/tenkz_audit.py'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -201,6 +201,7 @@ jobs:
               - 'tex/tenkz/**'
               - 'tests/tenkz/**'
               - 'docs/tenkz/chapters2/**'
+              - 'docs/tenkz/manual2.tex'
               - 'docs/tenkz/tenkzmanual2.sty'
               - 'scripts/tenkz_manual_doctest.py'
               - 'scripts/test_tenkz_manual_doctest.py'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -38,6 +38,8 @@ on:
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_rmp.py'
       - 'scripts/tenkzlib/**'
+      - 'scripts/tenkz_manual_doctest.py'
+      - 'scripts/test_tenkz_manual_doctest.py'
       - 'scripts/tenkz_language.py'
       - 'scripts/tenkz_shrink.py'
       - 'scripts/test_tenkz_shrink.py'
@@ -90,6 +92,8 @@ on:
       - 'scripts/tenkz_audit.py'
       - 'scripts/tenkz_rmp.py'
       - 'scripts/tenkzlib/**'
+      - 'scripts/tenkz_manual_doctest.py'
+      - 'scripts/test_tenkz_manual_doctest.py'
       - 'scripts/tenkz_language.py'
       - 'scripts/tenkz_shrink.py'
       - 'scripts/test_tenkz_shrink.py'
@@ -196,6 +200,9 @@ jobs:
             corpus:
               - 'tex/tenkz/**'
               - 'tests/tenkz/**'
+              - 'docs/tenkz/chapters2/**'
+              - 'scripts/tenkz_manual_doctest.py'
+              - 'scripts/test_tenkz_manual_doctest.py'
               - 'scripts/tenkz_audit.py'
               - 'scripts/tenkzlib/**'
               - 'scripts/tenkz_corpus.sh'
@@ -273,8 +280,14 @@ jobs:
       - name: Test tenkz render baseline replacement
         run: python3 scripts/test_tenkz_corpus_render.py
 
+      - name: Test tenkz manual extraction and reference coverage
+        run: python3 scripts/test_tenkz_manual_doctest.py
+
       - name: Install TeX dependencies
         uses: texra-ai/lean-env-action/blueprint-system-deps@v1
+
+      - name: Compile tenkz manual examples standalone
+        run: python3 scripts/tenkz_manual_doctest.py
 
       - name: Compile and audit tenkz corpus
         run: TENKZ_CORPUS_JOBS=4 scripts/tenkz_corpus.sh

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -17,6 +17,7 @@ timeout 120 env TEXINPUTS="<repo>/tex/tenkz//:" \
 Build the compact manual twice for contents and references:
 
 ```sh
+python3 scripts/tenkz_manual_doctest.py
 cd docs/tenkz
 timeout 150 env TEXINPUTS="../../tex/tenkz//:" \
   xelatex -interaction=nonstopmode -halt-on-error manual2.tex

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -51,7 +51,7 @@ from pathlib import Path
 
 from tenkz_audit import ENVIRONMENT_LANGS
 from tenkz_language import load_registry, parse_status
-from tenkzlib.texcase import _match_group, scan_constructs, strip_comments
+from tenkzlib.texcase import match_group, scan_constructs, strip_comments
 
 # Bodies scanned for the dots rule: the grid languages whose cells feed
 # the implicit wire.  (tenkzcd cells are math objects and tenkzfree has
@@ -142,7 +142,7 @@ def mask_option_groups(body: str) -> str:
             i += 2
             continue
         if c == "[":
-            closed = _match_group(body, i, "[", "]")
+            closed = match_group(body, i, "[", "]")
             if closed == -1:
                 break
             for j in range(i, closed):

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import tempfile
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 
 
@@ -158,6 +159,7 @@ def _multiple_variants(options: str | None) -> list[tuple[str, str]]:
     return variants
 
 
+@cache
 def _registry_vocabulary() -> tuple[list[str], list[str]]:
     registry = REGISTRY.read_text(encoding="utf-8")
     commands = re.findall(

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -27,20 +27,32 @@ class Example:
     document: str
 
 
+def _is_escaped(text: str, offset: int) -> bool:
+    backslashes = 0
+    cursor = offset - 1
+    while cursor >= 0 and text[cursor] == "\\":
+        backslashes += 1
+        cursor -= 1
+    return backslashes % 2 == 1
+
+
 def _read_optional_argument(text: str, offset: int) -> tuple[int, str | None]:
     while offset < len(text) and text[offset].isspace():
         offset += 1
     if offset == len(text) or text[offset] != "[":
         return offset, None
 
-    depth = 0
-    for index in range(offset, len(text)):
-        if text[index] == "[" and (index == 0 or text[index - 1] != "\\"):
-            depth += 1
-        elif text[index] == "]" and (index == 0 or text[index - 1] != "\\"):
-            depth -= 1
-            if depth == 0:
-                return index + 1, text[offset + 1:index]
+    brace_depth = 0
+    for index in range(offset + 1, len(text)):
+        escaped = _is_escaped(text, index)
+        if text[index] == "{" and not escaped:
+            brace_depth += 1
+        elif text[index] == "}" and not escaped:
+            brace_depth -= 1
+            if brace_depth < 0:
+                raise ValueError("unbalanced brace in optional environment argument")
+        elif text[index] == "]" and not escaped and brace_depth == 0:
+            return index + 1, text[offset + 1:index]
     raise ValueError("unterminated optional environment argument")
 
 
@@ -48,23 +60,18 @@ def _split_top_level(text: str) -> list[str]:
     pieces: list[str] = []
     start = 0
     brace_depth = 0
-    bracket_depth = 0
     for index, character in enumerate(text):
-        escaped = index > 0 and text[index - 1] == "\\"
+        escaped = _is_escaped(text, index)
         if character == "{" and not escaped:
             brace_depth += 1
         elif character == "}" and not escaped:
             brace_depth -= 1
-        elif character == "[" and not escaped:
-            bracket_depth += 1
-        elif character == "]" and not escaped:
-            bracket_depth -= 1
-        elif character == "," and brace_depth == 0 and bracket_depth == 0:
+        elif character == "," and brace_depth == 0:
             pieces.append(text[start:index].strip())
             start = index + 1
-        if brace_depth < 0 or bracket_depth < 0:
+        if brace_depth < 0:
             raise ValueError("unbalanced option group")
-    if brace_depth or bracket_depth:
+    if brace_depth:
         raise ValueError("unbalanced option group")
     pieces.append(text[start:].strip())
     return pieces
@@ -77,7 +84,7 @@ def _read_braced(text: str, offset: int) -> tuple[int, str]:
         raise ValueError("expected braced group")
     depth = 0
     for index in range(offset, len(text)):
-        escaped = index > 0 and text[index - 1] == "\\"
+        escaped = _is_escaped(text, index)
         if text[index] == "{" and not escaped:
             depth += 1
         elif text[index] == "}" and not escaped:
@@ -136,10 +143,46 @@ def _is_tenkz_verbatim(body: str) -> bool:
     )
 
 
+def _is_commented(text: str, offset: int) -> bool:
+    line_start = text.rfind("\n", 0, offset) + 1
+    line = text[line_start:offset]
+    for index, character in enumerate(line):
+        if character == "%" and not _is_escaped(line, index):
+            return True
+    return False
+
+
+def _find_uncommented(text: str, marker: str, offset: int) -> int:
+    while True:
+        found = text.find(marker, offset)
+        if found < 0 or not _is_commented(text, found):
+            return found
+        offset = found + len(marker)
+
+
+def _variant_definitions(variant_style: str) -> list[str]:
+    return [
+        rf"\pgfqkeys{{/tenkz/grid}}{{variant/.style={{{variant_style}}}}}",
+        rf"\pgfqkeys{{/tenkz/cell}}{{variant/.style={{{variant_style}}}}}",
+    ]
+
+
 def _standalone_document(body: str, variant_style: str | None = None) -> str:
+    body = body.strip()
+    has_document_class = bool(re.search(r"\\documentclass(?:\[.*?\])?\{", body))
+    has_document = r"\begin{document}" in body and r"\end{document}" in body
+    if has_document_class:
+        if not has_document:
+            raise ValueError("displayed document class has no complete document body")
+        if variant_style is None:
+            return body + "\n"
+        begin = body.index(r"\begin{document}")
+        definitions = "\n".join(_variant_definitions(variant_style)) + "\n"
+        return body[:begin] + definitions + body[begin:] + "\n"
+
     preamble: list[str] = []
     content: list[str] = []
-    for line in body.strip().splitlines():
+    for line in body.splitlines():
         if line.lstrip().startswith(r"\usepackage"):
             preamble.append(line.strip())
         else:
@@ -147,12 +190,7 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
     if not any(r"\usepackage{tenkz}" in line for line in preamble):
         preamble.append(r"\usepackage{tenkz}")
     if variant_style is not None:
-        preamble.extend(
-            [
-                rf"\pgfqkeys{{/tenkz/grid}}{{variant/.style={{{variant_style}}}}}",
-                rf"\pgfqkeys{{/tenkz/cell}}{{variant/.style={{{variant_style}}}}}",
-            ]
-        )
+        preamble.extend(_variant_definitions(variant_style))
     return "\n".join(
         [
             r"\documentclass{article}",
@@ -175,10 +213,13 @@ def extract_displayed_examples(path: Path) -> list[Example]:
     offset = 0
     ordinal = 0
     while match := begin_pattern.search(text, offset):
+        if _is_commented(text, match.start()):
+            offset = match.end()
+            continue
         environment = match.group(1)
         body_start, options = _read_optional_argument(text, match.end())
         end_marker = rf"\end{{{environment}}}"
-        body_end = text.find(end_marker, body_start)
+        body_end = _find_uncommented(text, end_marker, body_start)
         if body_end < 0:
             line = text.count("\n", 0, match.start()) + 1
             raise ValueError(f"{path}:{line}: missing {end_marker}")

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
 
-from tenkzlib.texcase import strip_comments
+from tenkzlib.texcase import match_group, strip_comments
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -30,6 +30,7 @@ class Example:
     source: Path
     line: int
     document: str
+    coverage_marker: str | None = None
 
 
 def _is_escaped(text: str, offset: int) -> bool:
@@ -63,27 +64,10 @@ def _read_optional_argument(text: str, offset: int) -> tuple[int, str | None]:
     offset = _skip_space_and_comments(text, offset)
     if offset == len(text) or text[offset] != "[":
         return offset, None
-
-    brace_depth = 0
-    index = offset + 1
-    while index < len(text):
-        if text[index] == "%" and not _is_escaped(text, index):
-            newline = text.find("\n", index)
-            if newline < 0:
-                break
-            index = newline + 1
-            continue
-        escaped = _is_escaped(text, index)
-        if text[index] == "{" and not escaped:
-            brace_depth += 1
-        elif text[index] == "}" and not escaped:
-            brace_depth -= 1
-            if brace_depth < 0:
-                raise ValueError("unbalanced brace in optional environment argument")
-        elif text[index] == "]" and not escaped and brace_depth == 0:
-            return index + 1, _strip_tex_comments(text[offset + 1:index])
-        index += 1
-    raise ValueError("unterminated optional environment argument")
+    end = match_group(text, offset, "[", "]")
+    if end < 0:
+        raise ValueError("unterminated or unbalanced optional environment argument")
+    return end, _strip_tex_comments(text[offset + 1 : end - 1])
 
 
 def _split_top_level(text: str) -> list[str]:
@@ -112,16 +96,10 @@ def _read_braced(text: str, offset: int) -> tuple[int, str]:
         offset += 1
     if offset == len(text) or text[offset] != "{":
         raise ValueError("expected braced group")
-    depth = 0
-    for index in range(offset, len(text)):
-        escaped = _is_escaped(text, index)
-        if text[index] == "{" and not escaped:
-            depth += 1
-        elif text[index] == "}" and not escaped:
-            depth -= 1
-            if depth == 0:
-                return index + 1, text[offset + 1:index]
-    raise ValueError("unterminated braced group")
+    end = match_group(text, offset, "{", "}")
+    if end < 0:
+        raise ValueError("unterminated braced group")
+    return end, text[offset + 1 : end - 1]
 
 
 def _multiple_variants(options: str | None) -> list[tuple[str, str]]:
@@ -167,7 +145,7 @@ def _is_tenkz_verbatim(body: str) -> bool:
     commands, environments = _registry_vocabulary()
     environment_pattern = "|".join(re.escape(environment) for environment in environments)
     packages, _ = _extract_usepackages(body)
-    scan = _mask_nonexecuted_tokens(body)
+    scan = _mask_nonexecuted_tokens(strip_comments(body))
     environment_matches = re.finditer(
         rf"\\begin\{{(?:{environment_pattern})\}}", scan
     )
@@ -269,7 +247,7 @@ def _package_names(declaration: str) -> list[str]:
         cursor, _ = _read_optional_argument(declaration, cursor)
     cursor = _skip_space_and_comments(declaration, cursor)
     _, names = _read_braced(declaration, cursor)
-    return [name.strip() for name in names.split(",")]
+    return [name.strip() for name in strip_comments(names).split(",")]
 
 
 def _find_environment_end(text: str, environment: str, offset: int) -> re.Match[str] | None:
@@ -298,6 +276,83 @@ def _mask_display_environments(text: str) -> str:
     return "".join(masked)
 
 
+def _blank_range(masked: list[str], start: int, end: int) -> None:
+    for index in range(start, end):
+        if masked[index] != "\n":
+            masked[index] = " "
+
+
+def _mask_false_branches(text: str) -> str:
+    masked = list(text)
+    scan = strip_comments(text)
+    tokens = list(re.finditer(r"\\(?:if[A-Za-z@]*|fi)(?![A-Za-z@])", scan))
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token.group(0) != r"\iffalse" or _is_escaped(scan, token.start()):
+            index += 1
+            continue
+        depth = 1
+        cursor = index + 1
+        while cursor < len(tokens) and depth:
+            nested = tokens[cursor]
+            if not _is_escaped(scan, nested.start()):
+                depth += -1 if nested.group(0) == r"\fi" else 1
+            cursor += 1
+        end = tokens[cursor - 1].end() if depth == 0 else len(text)
+        _blank_range(masked, token.start(), end)
+        index = cursor
+    return "".join(masked)
+
+
+def _mask_macro_definitions(text: str) -> str:
+    masked = list(text)
+    scan = strip_comments(text)
+    pattern = re.compile(
+        r"\\(?:(?:new|renew|provide)command|(?:g|e|x)?def)\*?(?![A-Za-z@])"
+    )
+    offset = 0
+    while match := pattern.search(scan, offset):
+        if _is_escaped(scan, match.start()):
+            offset = match.end()
+            continue
+        cursor = _skip_space_and_comments(scan, match.end())
+        is_command = "command" in match.group(0)
+        if is_command:
+            if cursor < len(scan) and scan[cursor] == "{":
+                cursor, _ = _read_braced(scan, cursor)
+            else:
+                control = re.match(r"\\(?:[A-Za-z@]+|.)", scan[cursor:])
+                if control is None:
+                    offset = match.end()
+                    continue
+                cursor += control.end()
+            for _ in range(2):
+                cursor = _skip_space_and_comments(scan, cursor)
+                if cursor < len(scan) and scan[cursor] == "[":
+                    cursor, _ = _read_optional_argument(scan, cursor)
+        else:
+            control = re.match(r"\\(?:[A-Za-z@]+|.)", scan[cursor:])
+            if control is None:
+                offset = match.end()
+                continue
+            cursor += control.end()
+            while cursor < len(scan) and scan[cursor] != "{":
+                cursor += 1
+        cursor = _skip_space_and_comments(scan, cursor)
+        if cursor >= len(scan) or scan[cursor] != "{":
+            offset = match.end()
+            continue
+        end, _ = _read_braced(scan, cursor)
+        _blank_range(masked, cursor, end)
+        offset = end
+    return "".join(masked)
+
+
+def _mask_inert_tex(text: str) -> str:
+    return _mask_macro_definitions(_mask_false_branches(text))
+
+
 def _mask_nonexecuted_tokens(text: str) -> str:
     masked = list(_mask_inline_verbatim(text))
     scan = "".join(masked)
@@ -313,6 +368,30 @@ def _has_executable_command(text: str, command: str) -> bool:
     scan = _mask_nonexecuted_tokens(strip_comments(text))
     pattern = re.compile(rf"\\{re.escape(command)}(?![A-Za-z@:_])")
     return any(not _is_escaped(scan, match.start()) for match in pattern.finditer(scan))
+
+
+def _instrument_command(document: str, command: str) -> tuple[str, str]:
+    packages, _ = _extract_usepackages(document)
+    declaration = next(
+        (
+            package
+            for package in packages
+            if "tenkz" in _package_names(package)
+        ),
+        None,
+    )
+    if declaration is None:
+        raise ValueError(f"reference for \\{command} does not load tenkz")
+    end = document.find(declaration) + len(declaration)
+    marker = f"TENKZ-DOCTEST-EXECUTED-{command}"
+    original = f"tenkzdoctestoriginal{command}"
+    instrumentation = "\n".join(
+        [
+            rf"\expandafter\let\csname {original}\endcsname\{command}",
+            rf"\def\{command}{{\typeout{{{marker}}}\csname {original}\endcsname}}",
+        ]
+    )
+    return document[:end] + "\n" + instrumentation + document[end:], marker
 
 
 def _source_label(path: Path) -> str:
@@ -368,6 +447,7 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
 
 def extract_displayed_examples(path: Path) -> list[Example]:
     text = path.read_text(encoding="utf-8")
+    scan_text = _mask_inert_tex(text)
     begin_pattern = re.compile(
         r"^[ \t]*\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}",
         re.MULTILINE,
@@ -375,8 +455,8 @@ def extract_displayed_examples(path: Path) -> list[Example]:
     examples: list[Example] = []
     offset = 0
     ordinal = 0
-    while match := begin_pattern.search(text, offset):
-        if _is_commented(text, match.start()):
+    while match := begin_pattern.search(scan_text, offset):
+        if _is_commented(scan_text, match.start()):
             offset = match.end()
             continue
         environment = match.group(1)
@@ -428,7 +508,9 @@ def _manual_sources() -> list[Path]:
             continue
         visited.add(source)
         raw = source.read_text(encoding="utf-8")
-        text = strip_comments(_mask_inline_verbatim(_mask_display_environments(raw)))
+        text = strip_comments(
+            _mask_inline_verbatim(_mask_display_environments(_mask_inert_tex(raw)))
+        )
         for match in input_pattern.finditer(text):
             if _is_escaped(text, match.start()):
                 continue
@@ -493,12 +575,14 @@ def reference_examples() -> list[Example]:
             raise ValueError(
                 f"{source}: example mapped to \\{command} does not invoke that command"
             )
+        instrumented, marker = _instrument_command(document, command)
         examples.append(
             Example(
                 label=f"reference-{command}",
                 source=source,
                 line=1,
-                document=document,
+                document=instrumented,
+                coverage_marker=marker,
             )
         )
     return examples
@@ -528,6 +612,11 @@ def compile_example(example: Example, engine: str, work: Path) -> None:
         raise RuntimeError(
             f"{example.source}:{example.line}: standalone compilation failed "
             f"for {example.label}\n{tail}"
+        )
+    if example.coverage_marker and example.coverage_marker not in run.stdout:
+        raise RuntimeError(
+            f"{example.source}:{example.line}: \\{example.label.removeprefix('reference-')} "
+            "was not executed during standalone compilation"
         )
 
 

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Compile every displayed tenkz manual example as a standalone document."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAPTERS = ROOT / "docs" / "tenkz" / "chapters2"
+REGISTRY = ROOT / "tex" / "tenkz" / "tenkz-language-registry.tex"
+REFERENCE = CHAPTERS / "generated-language-reference.tex"
+DISPLAY_ENVIRONMENTS = ("tnexample", "tnmultiples", "Verbatim")
+TEX_VERBATIM_MARKERS = (
+    r"\begin{tenkz",
+    r"\tnpic",
+    r"\tndeclareatom",
+    r"\usepackage{tenkz}",
+)
+
+
+@dataclass(frozen=True)
+class Example:
+    label: str
+    source: Path
+    line: int
+    document: str
+
+
+def _skip_optional_argument(text: str, offset: int) -> int:
+    while offset < len(text) and text[offset].isspace():
+        offset += 1
+    if offset == len(text) or text[offset] != "[":
+        return offset
+
+    depth = 0
+    for index in range(offset, len(text)):
+        if text[index] == "[" and (index == 0 or text[index - 1] != "\\"):
+            depth += 1
+        elif text[index] == "]" and (index == 0 or text[index - 1] != "\\"):
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    raise ValueError("unterminated optional environment argument")
+
+
+def _standalone_document(body: str) -> str:
+    preamble: list[str] = []
+    content: list[str] = []
+    for line in body.strip().splitlines():
+        if line.lstrip().startswith(r"\usepackage"):
+            preamble.append(line.strip())
+        else:
+            content.append(line)
+    if not any(r"\usepackage{tenkz}" in line for line in preamble):
+        preamble.append(r"\usepackage{tenkz}")
+    return "\n".join(
+        [
+            r"\documentclass{article}",
+            *preamble,
+            r"\pagestyle{empty}",
+            r"\begin{document}",
+            *content,
+            r"\end{document}",
+            "",
+        ]
+    )
+
+
+def extract_displayed_examples(path: Path) -> list[Example]:
+    text = path.read_text(encoding="utf-8")
+    begin_pattern = re.compile(
+        r"\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}"
+    )
+    examples: list[Example] = []
+    offset = 0
+    ordinal = 0
+    while match := begin_pattern.search(text, offset):
+        environment = match.group(1)
+        body_start = _skip_optional_argument(text, match.end())
+        end_marker = rf"\end{{{environment}}}"
+        body_end = text.find(end_marker, body_start)
+        if body_end < 0:
+            line = text.count("\n", 0, match.start()) + 1
+            raise ValueError(f"{path}:{line}: missing {end_marker}")
+        body = text[body_start:body_end].strip()
+        offset = body_end + len(end_marker)
+        if environment == "Verbatim" and not any(
+            marker in body for marker in TEX_VERBATIM_MARKERS
+        ):
+            continue
+        ordinal += 1
+        line = text.count("\n", 0, match.start()) + 1
+        examples.append(
+            Example(
+                label=f"manual-{path.stem}-{ordinal}",
+                source=path,
+                line=line,
+                document=_standalone_document(body),
+            )
+        )
+    return examples
+
+
+def displayed_examples() -> list[Example]:
+    examples: list[Example] = []
+    for path in sorted(CHAPTERS.glob("*.tex")):
+        if path.name == "generated-language-reference.tex":
+            continue
+        examples.extend(extract_displayed_examples(path))
+    return examples
+
+
+def reference_examples() -> list[Example]:
+    registry = REGISTRY.read_text(encoding="utf-8")
+    commands = re.findall(
+        r"\\__tenkz_language_registry_command:nnnnn\s*\{([^{}]+)\}", registry
+    )
+    mappings = re.findall(
+        r"\\__tenkz_language_registry_example:nnn\s*"
+        r"\{([^{}]+)\}\s*\{([^{}]+)\}",
+        registry,
+    )
+    mapping_by_command = dict(mappings)
+    if len(mapping_by_command) != len(mappings):
+        raise ValueError(f"{REGISTRY}: duplicate command example mapping")
+    missing = sorted(set(commands) - mapping_by_command.keys())
+    extra = sorted(mapping_by_command.keys() - set(commands))
+    if missing or extra:
+        raise ValueError(
+            f"{REGISTRY}: command/example mismatch; missing={missing}, extra={extra}"
+        )
+
+    generated_paths = re.findall(
+        r"Example:\s*\\texttt\{\\detokenize\{([^{}]+)\}\}",
+        REFERENCE.read_text(encoding="utf-8"),
+    )
+    registry_paths = [mapping_by_command[command] for command in commands]
+    if generated_paths != registry_paths:
+        raise ValueError(
+            f"{REFERENCE}: generated example list differs from the registry"
+        )
+
+    examples: list[Example] = []
+    for command in commands:
+        relative = Path(mapping_by_command[command])
+        source = ROOT / relative
+        if not source.is_file():
+            raise ValueError(f"{REGISTRY}: example for \\{command} is missing: {relative}")
+        examples.append(
+            Example(
+                label=f"reference-{command}",
+                source=source,
+                line=1,
+                document=source.read_text(encoding="utf-8"),
+            )
+        )
+    return examples
+
+
+def compile_example(example: Example, engine: str, work: Path) -> None:
+    case_dir = work / example.label
+    case_dir.mkdir()
+    driver = case_dir / "example.tex"
+    driver.write_text(example.document, encoding="utf-8")
+    env = os.environ.copy()
+    env["TEXINPUTS"] = f"{ROOT / 'tex' / 'tenkz'}//:{env.get('TEXINPUTS', '')}"
+    run = subprocess.run(
+        [engine, "-interaction=nonstopmode", "-halt-on-error", driver.name],
+        cwd=case_dir,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=120,
+    )
+    if run.returncode:
+        tail = "\n".join(run.stdout.splitlines()[-60:])
+        raise RuntimeError(
+            f"{example.source}:{example.line}: standalone compilation failed "
+            f"for {example.label}\n{tail}"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--engine", default="xelatex", help="TeX engine (default: xelatex)")
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="list extracted examples and validate coverage without compiling",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    manual = displayed_examples()
+    reference = reference_examples()
+    if not manual:
+        raise ValueError(f"{CHAPTERS}: no displayed TeX examples found")
+
+    if args.list:
+        for example in [*manual, *reference]:
+            print(f"{example.label}\t{example.source.relative_to(ROOT)}:{example.line}")
+    else:
+        with tempfile.TemporaryDirectory(prefix="tenkz-manual-doctest-") as tmp:
+            work = Path(tmp)
+            for example in [*manual, *reference]:
+                print(f"compile {example.label}")
+                compile_example(example, args.engine, work)
+
+    print(
+        f"PASS: {len(manual)} displayed manual examples and "
+        f"{len(reference)} reference examples"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
 
+from tenkzlib.texcase import strip_comments
+
 
 ROOT = Path(__file__).resolve().parents[1]
 MANUAL_DIR = ROOT / "docs" / "tenkz"
@@ -40,19 +42,7 @@ def _is_escaped(text: str, offset: int) -> bool:
 
 
 def _strip_tex_comments(text: str) -> str:
-    output: list[str] = []
-    offset = 0
-    while offset < len(text):
-        if text[offset] == "%" and not _is_escaped(text, offset):
-            newline = text.find("\n", offset)
-            if newline < 0:
-                break
-            output.append("\n")
-            offset = newline + 1
-        else:
-            output.append(text[offset])
-            offset += 1
-    return "".join(output)
+    return strip_comments(text)
 
 
 def _skip_space_and_comments(text: str, offset: int) -> int:

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -320,7 +320,7 @@ def _variant_definitions(variant_style: str) -> list[str]:
 def _standalone_document(body: str, variant_style: str | None = None) -> str:
     body = body.strip()
     scan_body = _mask_inline_verbatim(body)
-    has_document_class = _find_uncommented(scan_body, r"\documentclass", 0) >= 0
+    has_document_class = _find_control_word(scan_body, "documentclass", 0) >= 0
     has_document = (
         _find_uncommented(scan_body, r"\begin{document}", 0) >= 0
         and _find_uncommented(scan_body, r"\end{document}", 0) >= 0
@@ -399,15 +399,14 @@ def extract_displayed_examples(path: Path) -> list[Example]:
 
 def displayed_examples() -> list[Example]:
     examples: list[Example] = []
-    for path in _manual_chapter_sources():
+    for path in _manual_sources():
         examples.extend(extract_displayed_examples(path))
     return examples
 
 
-def _manual_chapter_sources() -> list[Path]:
+def _manual_sources() -> list[Path]:
     pending = [MANUAL]
     visited: set[Path] = set()
-    chapters: set[Path] = set()
     input_pattern = re.compile(r"\\input\s*\{([^{}]+)\}")
     while pending:
         source = pending.pop()
@@ -424,9 +423,7 @@ def _manual_chapter_sources() -> list[Path]:
             if not included.is_file():
                 raise ValueError(f"{source}: missing manual input {relative}")
             pending.append(included)
-            if included.is_relative_to(CHAPTERS):
-                chapters.add(included)
-    return sorted(chapters)
+    return sorted(visited)
 
 
 def reference_examples() -> list[Example]:

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -178,10 +178,11 @@ def _is_tenkz_verbatim(body: str) -> bool:
     command_pattern = "|".join(re.escape(command) for command in commands)
     environment_pattern = "|".join(re.escape(environment) for environment in environments)
     packages, _ = _extract_usepackages(body)
+    uncommented = _strip_tex_comments(body)
     return bool(
         any("tenkz" in _package_names(package) for package in packages)
-        or re.search(rf"\\(?:{command_pattern})(?![A-Za-z@:_])", body)
-        or re.search(rf"\\begin\{{(?:{environment_pattern})\}}", body)
+        or re.search(rf"\\(?:{command_pattern})(?![A-Za-z@:_])", uncommented)
+        or re.search(rf"\\begin\{{(?:{environment_pattern})\}}", uncommented)
     )
 
 

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -17,12 +17,6 @@ CHAPTERS = ROOT / "docs" / "tenkz" / "chapters2"
 REGISTRY = ROOT / "tex" / "tenkz" / "tenkz-language-registry.tex"
 REFERENCE = CHAPTERS / "generated-language-reference.tex"
 DISPLAY_ENVIRONMENTS = ("tnexample", "tnmultiples", "Verbatim")
-TEX_VERBATIM_MARKERS = (
-    r"\begin{tenkz",
-    r"\tnpic",
-    r"\tndeclareatom",
-    r"\usepackage{tenkz}",
-)
 
 
 @dataclass(frozen=True)
@@ -33,11 +27,11 @@ class Example:
     document: str
 
 
-def _skip_optional_argument(text: str, offset: int) -> int:
+def _read_optional_argument(text: str, offset: int) -> tuple[int, str | None]:
     while offset < len(text) and text[offset].isspace():
         offset += 1
     if offset == len(text) or text[offset] != "[":
-        return offset
+        return offset, None
 
     depth = 0
     for index in range(offset, len(text)):
@@ -46,11 +40,103 @@ def _skip_optional_argument(text: str, offset: int) -> int:
         elif text[index] == "]" and (index == 0 or text[index - 1] != "\\"):
             depth -= 1
             if depth == 0:
-                return index + 1
+                return index + 1, text[offset + 1:index]
     raise ValueError("unterminated optional environment argument")
 
 
-def _standalone_document(body: str) -> str:
+def _split_top_level(text: str) -> list[str]:
+    pieces: list[str] = []
+    start = 0
+    brace_depth = 0
+    bracket_depth = 0
+    for index, character in enumerate(text):
+        escaped = index > 0 and text[index - 1] == "\\"
+        if character == "{" and not escaped:
+            brace_depth += 1
+        elif character == "}" and not escaped:
+            brace_depth -= 1
+        elif character == "[" and not escaped:
+            bracket_depth += 1
+        elif character == "]" and not escaped:
+            bracket_depth -= 1
+        elif character == "," and brace_depth == 0 and bracket_depth == 0:
+            pieces.append(text[start:index].strip())
+            start = index + 1
+        if brace_depth < 0 or bracket_depth < 0:
+            raise ValueError("unbalanced option group")
+    if brace_depth or bracket_depth:
+        raise ValueError("unbalanced option group")
+    pieces.append(text[start:].strip())
+    return pieces
+
+
+def _read_braced(text: str, offset: int) -> tuple[int, str]:
+    while offset < len(text) and text[offset].isspace():
+        offset += 1
+    if offset == len(text) or text[offset] != "{":
+        raise ValueError("expected braced group")
+    depth = 0
+    for index in range(offset, len(text)):
+        escaped = index > 0 and text[index - 1] == "\\"
+        if text[index] == "{" and not escaped:
+            depth += 1
+        elif text[index] == "}" and not escaped:
+            depth -= 1
+            if depth == 0:
+                return index + 1, text[offset + 1:index]
+    raise ValueError("unterminated braced group")
+
+
+def _multiple_variants(options: str | None) -> list[tuple[str, str]]:
+    if options is None:
+        raise ValueError("tnmultiples requires a variants option")
+    variants_value = None
+    for option in _split_top_level(options):
+        key, separator, value = option.partition("=")
+        if separator and key.strip() == "variants":
+            variants_value = value.strip()
+            break
+    if variants_value is None:
+        raise ValueError("tnmultiples requires a variants option")
+    end, variants_group = _read_braced(variants_value, 0)
+    if variants_value[end:].strip():
+        raise ValueError("unexpected text after tnmultiples variants")
+
+    variants: list[tuple[str, str]] = []
+    for entry in _split_top_level(variants_group):
+        offset, label = _read_braced(entry, 0)
+        offset, style = _read_braced(entry, offset)
+        if entry[offset:].strip():
+            raise ValueError("unexpected text after tnmultiples variant")
+        variants.append((label, style))
+    if not variants:
+        raise ValueError("tnmultiples variants list is empty")
+    return variants
+
+
+def _registry_vocabulary() -> tuple[list[str], list[str]]:
+    registry = REGISTRY.read_text(encoding="utf-8")
+    commands = re.findall(
+        r"\\__tenkz_language_registry_command:nnnnn\s*\{([^{}]+)\}", registry
+    )
+    environments = re.findall(
+        r"\\__tenkz_language_registry_environment:nnnn\s*\{([^{}]+)\}", registry
+    )
+    return commands, environments
+
+
+def _is_tenkz_verbatim(body: str) -> bool:
+    commands, environments = _registry_vocabulary()
+    command_pattern = "|".join(re.escape(command) for command in commands)
+    environment_pattern = "|".join(re.escape(environment) for environment in environments)
+    return bool(
+        re.search(r"\\usepackage\s*\{tenkz\}", body)
+        or re.search(rf"\\(?:{command_pattern})(?![A-Za-z@:_])", body)
+        or re.search(rf"\\begin\{{(?:{environment_pattern})\}}", body)
+    )
+
+
+def _standalone_document(body: str, variant_style: str | None = None) -> str:
     preamble: list[str] = []
     content: list[str] = []
     for line in body.strip().splitlines():
@@ -60,6 +146,13 @@ def _standalone_document(body: str) -> str:
             content.append(line)
     if not any(r"\usepackage{tenkz}" in line for line in preamble):
         preamble.append(r"\usepackage{tenkz}")
+    if variant_style is not None:
+        preamble.extend(
+            [
+                rf"\pgfqkeys{{/tenkz/grid}}{{variant/.style={{{variant_style}}}}}",
+                rf"\pgfqkeys{{/tenkz/cell}}{{variant/.style={{{variant_style}}}}}",
+            ]
+        )
     return "\n".join(
         [
             r"\documentclass{article}",
@@ -83,7 +176,7 @@ def extract_displayed_examples(path: Path) -> list[Example]:
     ordinal = 0
     while match := begin_pattern.search(text, offset):
         environment = match.group(1)
-        body_start = _skip_optional_argument(text, match.end())
+        body_start, options = _read_optional_argument(text, match.end())
         end_marker = rf"\end{{{environment}}}"
         body_end = text.find(end_marker, body_start)
         if body_end < 0:
@@ -91,20 +184,25 @@ def extract_displayed_examples(path: Path) -> list[Example]:
             raise ValueError(f"{path}:{line}: missing {end_marker}")
         body = text[body_start:body_end].strip()
         offset = body_end + len(end_marker)
-        if environment == "Verbatim" and not any(
-            marker in body for marker in TEX_VERBATIM_MARKERS
-        ):
+        if environment == "Verbatim" and not _is_tenkz_verbatim(body):
             continue
-        ordinal += 1
         line = text.count("\n", 0, match.start()) + 1
-        examples.append(
-            Example(
-                label=f"manual-{path.stem}-{ordinal}",
-                source=path,
-                line=line,
-                document=_standalone_document(body),
-            )
+        variants = (
+            _multiple_variants(options)
+            if environment == "tnmultiples"
+            else [(None, None)]
         )
+        for variant_index, (_, variant_style) in enumerate(variants, start=1):
+            ordinal += 1
+            suffix = f"-variant-{variant_index}" if environment == "tnmultiples" else ""
+            examples.append(
+                Example(
+                    label=f"manual-{path.stem}-{ordinal}{suffix}",
+                    source=path,
+                    line=line,
+                    document=_standalone_document(body, variant_style),
+                )
+            )
     return examples
 
 
@@ -119,9 +217,7 @@ def displayed_examples() -> list[Example]:
 
 def reference_examples() -> list[Example]:
     registry = REGISTRY.read_text(encoding="utf-8")
-    commands = re.findall(
-        r"\\__tenkz_language_registry_command:nnnnn\s*\{([^{}]+)\}", registry
-    )
+    commands, _ = _registry_vocabulary()
     mappings = re.findall(
         r"\\__tenkz_language_registry_example:nnn\s*"
         r"\{([^{}]+)\}\s*\{([^{}]+)\}",
@@ -142,6 +238,8 @@ def reference_examples() -> list[Example]:
         REFERENCE.read_text(encoding="utf-8"),
     )
     registry_paths = [mapping_by_command[command] for command in commands]
+    if len(set(registry_paths)) != len(registry_paths):
+        raise ValueError(f"{REGISTRY}: command example paths must be distinct")
     if generated_paths != registry_paths:
         raise ValueError(
             f"{REFERENCE}: generated example list differs from the registry"
@@ -153,12 +251,18 @@ def reference_examples() -> list[Example]:
         source = ROOT / relative
         if not source.is_file():
             raise ValueError(f"{REGISTRY}: example for \\{command} is missing: {relative}")
+        document = source.read_text(encoding="utf-8")
+        uncommented = re.sub(r"(?<!\\)%.*", "", document)
+        if not re.search(rf"\\{re.escape(command)}(?![A-Za-z@:_])", uncommented):
+            raise ValueError(
+                f"{source}: example mapped to \\{command} does not invoke that command"
+            )
         examples.append(
             Example(
                 label=f"reference-{command}",
                 source=source,
                 line=1,
-                document=source.read_text(encoding="utf-8"),
+                document=document,
             )
         )
     return examples

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -36,14 +36,50 @@ def _is_escaped(text: str, offset: int) -> bool:
     return backslashes % 2 == 1
 
 
+def _strip_tex_comments(text: str) -> str:
+    output: list[str] = []
+    offset = 0
+    while offset < len(text):
+        if text[offset] == "%" and not _is_escaped(text, offset):
+            newline = text.find("\n", offset)
+            if newline < 0:
+                break
+            output.append("\n")
+            offset = newline + 1
+        else:
+            output.append(text[offset])
+            offset += 1
+    return "".join(output)
+
+
+def _skip_space_and_comments(text: str, offset: int) -> int:
+    while offset < len(text):
+        if text[offset].isspace():
+            offset += 1
+        elif text[offset] == "%" and not _is_escaped(text, offset):
+            newline = text.find("\n", offset)
+            if newline < 0:
+                return len(text)
+            offset = newline + 1
+        else:
+            break
+    return offset
+
+
 def _read_optional_argument(text: str, offset: int) -> tuple[int, str | None]:
-    while offset < len(text) and text[offset].isspace():
-        offset += 1
+    offset = _skip_space_and_comments(text, offset)
     if offset == len(text) or text[offset] != "[":
         return offset, None
 
     brace_depth = 0
-    for index in range(offset + 1, len(text)):
+    index = offset + 1
+    while index < len(text):
+        if text[index] == "%" and not _is_escaped(text, index):
+            newline = text.find("\n", index)
+            if newline < 0:
+                break
+            index = newline + 1
+            continue
         escaped = _is_escaped(text, index)
         if text[index] == "{" and not escaped:
             brace_depth += 1
@@ -52,7 +88,8 @@ def _read_optional_argument(text: str, offset: int) -> tuple[int, str | None]:
             if brace_depth < 0:
                 raise ValueError("unbalanced brace in optional environment argument")
         elif text[index] == "]" and not escaped and brace_depth == 0:
-            return index + 1, text[offset + 1:index]
+            return index + 1, _strip_tex_comments(text[offset + 1:index])
+        index += 1
     raise ValueError("unterminated optional environment argument")
 
 
@@ -169,14 +206,17 @@ def _variant_definitions(variant_style: str) -> list[str]:
 
 def _standalone_document(body: str, variant_style: str | None = None) -> str:
     body = body.strip()
-    has_document_class = bool(re.search(r"\\documentclass(?:\[.*?\])?\{", body))
-    has_document = r"\begin{document}" in body and r"\end{document}" in body
+    has_document_class = _find_uncommented(body, r"\documentclass", 0) >= 0
+    has_document = (
+        _find_uncommented(body, r"\begin{document}", 0) >= 0
+        and _find_uncommented(body, r"\end{document}", 0) >= 0
+    )
     if has_document_class:
         if not has_document:
             raise ValueError("displayed document class has no complete document body")
         if variant_style is None:
             return body + "\n"
-        begin = body.index(r"\begin{document}")
+        begin = _find_uncommented(body, r"\begin{document}", 0)
         definitions = "\n".join(_variant_definitions(variant_style)) + "\n"
         return body[:begin] + definitions + body[begin:] + "\n"
 
@@ -315,7 +355,10 @@ def compile_example(example: Example, engine: str, work: Path) -> None:
     driver = case_dir / "example.tex"
     driver.write_text(example.document, encoding="utf-8")
     env = os.environ.copy()
-    env["TEXINPUTS"] = f"{ROOT / 'tex' / 'tenkz'}//:{env.get('TEXINPUTS', '')}"
+    env["TEXINPUTS"] = (
+        f"{example.source.parent}//:{ROOT / 'tex' / 'tenkz'}//:"
+        f"{env.get('TEXINPUTS', '')}"
+    )
     run = subprocess.run(
         [engine, "-interaction=nonstopmode", "-halt-on-error", driver.name],
         cwd=case_dir,

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+MANUAL_DIR = ROOT / "docs" / "tenkz"
+MANUAL = MANUAL_DIR / "manual2.tex"
 CHAPTERS = ROOT / "docs" / "tenkz" / "chapters2"
 REGISTRY = ROOT / "tex" / "tenkz" / "tenkz-language-registry.tex"
 REFERENCE = CHAPTERS / "generated-language-reference.tex"
@@ -175,8 +177,9 @@ def _is_tenkz_verbatim(body: str) -> bool:
     commands, environments = _registry_vocabulary()
     command_pattern = "|".join(re.escape(command) for command in commands)
     environment_pattern = "|".join(re.escape(environment) for environment in environments)
+    packages, _ = _extract_usepackages(body)
     return bool(
-        re.search(r"\\usepackage\s*\{tenkz\}", body)
+        any("tenkz" in _package_names(package) for package in packages)
         or re.search(rf"\\(?:{command_pattern})(?![A-Za-z@:_])", body)
         or re.search(rf"\\begin\{{(?:{environment_pattern})\}}", body)
     )
@@ -199,11 +202,35 @@ def _find_uncommented(text: str, marker: str, offset: int) -> int:
         offset = found + len(marker)
 
 
+def _mask_inline_verbatim(text: str) -> str:
+    masked = list(text)
+    offset = 0
+    while (start := text.find(r"\verb", offset)) >= 0:
+        delimiter_offset = start + len(r"\verb")
+        if delimiter_offset < len(text) and text[delimiter_offset] == "*":
+            delimiter_offset += 1
+        if delimiter_offset >= len(text):
+            break
+        delimiter = text[delimiter_offset]
+        if delimiter.isspace() or delimiter.isalnum():
+            offset = delimiter_offset
+            continue
+        end = text.find(delimiter, delimiter_offset + 1)
+        if end < 0:
+            break
+        for index in range(start, end + 1):
+            if masked[index] != "\n":
+                masked[index] = " "
+        offset = end + 1
+    return "".join(masked)
+
+
 def _extract_usepackages(body: str) -> tuple[list[str], str]:
     ranges: list[tuple[int, int]] = []
     offset = 0
     marker = r"\usepackage"
-    while (start := _find_uncommented(body, marker, offset)) >= 0:
+    scan_body = _mask_inline_verbatim(body)
+    while (start := _find_uncommented(scan_body, marker, offset)) >= 0:
         cursor = _skip_space_and_comments(body, start + len(marker))
         if cursor < len(body) and body[cursor] == "[":
             cursor, _ = _read_optional_argument(body, cursor)
@@ -223,6 +250,15 @@ def _extract_usepackages(body: str) -> tuple[list[str], str]:
     return packages, "".join(chunks)
 
 
+def _package_names(declaration: str) -> list[str]:
+    cursor = _skip_space_and_comments(declaration, len(r"\usepackage"))
+    if cursor < len(declaration) and declaration[cursor] == "[":
+        cursor, _ = _read_optional_argument(declaration, cursor)
+    cursor = _skip_space_and_comments(declaration, cursor)
+    _, names = _read_braced(declaration, cursor)
+    return [name.strip() for name in names.split(",")]
+
+
 def _find_environment_end(text: str, environment: str, offset: int) -> re.Match[str] | None:
     pattern = re.compile(
         rf"^[ \t]*\\end\{{{re.escape(environment)}\}}[ \t]*$",
@@ -240,25 +276,23 @@ def _variant_definitions(variant_style: str) -> list[str]:
 
 def _standalone_document(body: str, variant_style: str | None = None) -> str:
     body = body.strip()
-    has_document_class = _find_uncommented(body, r"\documentclass", 0) >= 0
+    scan_body = _mask_inline_verbatim(body)
+    has_document_class = _find_uncommented(scan_body, r"\documentclass", 0) >= 0
     has_document = (
-        _find_uncommented(body, r"\begin{document}", 0) >= 0
-        and _find_uncommented(body, r"\end{document}", 0) >= 0
+        _find_uncommented(scan_body, r"\begin{document}", 0) >= 0
+        and _find_uncommented(scan_body, r"\end{document}", 0) >= 0
     )
     if has_document_class:
         if not has_document:
             raise ValueError("displayed document class has no complete document body")
         if variant_style is None:
             return body + "\n"
-        begin = _find_uncommented(body, r"\begin{document}", 0)
+        begin = _find_uncommented(scan_body, r"\begin{document}", 0)
         definitions = "\n".join(_variant_definitions(variant_style)) + "\n"
         return body[:begin] + definitions + body[begin:] + "\n"
 
     preamble, content = _extract_usepackages(body)
-    tenkz_package = re.compile(
-        r"\\usepackage(?:\s*\[[\s\S]*?\])?\s*\{[^{}]*\btenkz\b[^{}]*\}"
-    )
-    if not any(tenkz_package.search(package) for package in preamble):
+    if not any("tenkz" in _package_names(package) for package in preamble):
         preamble.append(r"\usepackage{tenkz}")
     if variant_style is not None:
         preamble.extend(_variant_definitions(variant_style))
@@ -322,11 +356,33 @@ def extract_displayed_examples(path: Path) -> list[Example]:
 
 def displayed_examples() -> list[Example]:
     examples: list[Example] = []
-    for path in sorted(CHAPTERS.glob("*.tex")):
-        if path.name == "generated-language-reference.tex":
-            continue
+    for path in _manual_chapter_sources():
         examples.extend(extract_displayed_examples(path))
     return examples
+
+
+def _manual_chapter_sources() -> list[Path]:
+    pending = [MANUAL]
+    visited: set[Path] = set()
+    chapters: set[Path] = set()
+    input_pattern = re.compile(r"\\input\s*\{([^{}]+)\}")
+    while pending:
+        source = pending.pop()
+        if source in visited:
+            continue
+        visited.add(source)
+        text = _strip_tex_comments(_mask_inline_verbatim(source.read_text(encoding="utf-8")))
+        for match in input_pattern.finditer(text):
+            relative = Path(match.group(1))
+            if not relative.suffix:
+                relative = relative.with_suffix(".tex")
+            included = (MANUAL_DIR / relative).resolve()
+            if not included.is_file():
+                raise ValueError(f"{source}: missing manual input {relative}")
+            pending.append(included)
+            if included.is_relative_to(CHAPTERS):
+                chapters.add(included)
+    return sorted(chapters)
 
 
 def reference_examples() -> list[Example]:

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -196,7 +196,9 @@ def _find_uncommented(text: str, marker: str, offset: int) -> int:
 def _find_control_word(text: str, name: str, offset: int) -> int:
     pattern = re.compile(rf"\\{re.escape(name)}(?![A-Za-z@])")
     while match := pattern.search(text, offset):
-        if not _is_commented(text, match.start()):
+        if not _is_commented(text, match.start()) and not _is_escaped(
+            text, match.start()
+        ):
             return match.start()
         offset = match.end()
     return -1
@@ -229,7 +231,7 @@ def _extract_usepackages(body: str) -> tuple[list[str], str]:
     ranges: list[tuple[int, int]] = []
     offset = 0
     marker = r"\usepackage"
-    scan_body = _mask_inline_verbatim(body)
+    scan_body = _mask_nonexecuted_tokens(body)
     while (start := _find_control_word(scan_body, "usepackage", offset)) >= 0:
         cursor = _skip_space_and_comments(body, start + len(marker))
         if cursor < len(body) and body[cursor] == "[":
@@ -307,7 +309,8 @@ def _source_label(path: Path) -> str:
         relative = path.relative_to(CHAPTERS)
     except ValueError:
         relative = Path(path.name)
-    return re.sub(r"[^A-Za-z0-9]+", "-", relative.with_suffix("").as_posix()).strip("-")
+    source_key = relative.with_suffix("").as_posix()
+    return source_key.encode("utf-8").hex()
 
 
 def _variant_definitions(variant_style: str) -> list[str]:
@@ -319,7 +322,7 @@ def _variant_definitions(variant_style: str) -> list[str]:
 
 def _standalone_document(body: str, variant_style: str | None = None) -> str:
     body = body.strip()
-    scan_body = _mask_inline_verbatim(body)
+    scan_body = _mask_nonexecuted_tokens(body)
     has_document_class = _find_control_word(scan_body, "documentclass", 0) >= 0
     has_document = (
         _find_uncommented(scan_body, r"\begin{document}", 0) >= 0
@@ -407,7 +410,7 @@ def displayed_examples() -> list[Example]:
 def _manual_sources() -> list[Path]:
     pending = [MANUAL]
     visited: set[Path] = set()
-    input_pattern = re.compile(r"\\input\s*\{([^{}]+)\}")
+    input_pattern = re.compile(r"\\input(?![A-Za-z@])")
     while pending:
         source = pending.pop()
         if source in visited:
@@ -416,7 +419,19 @@ def _manual_sources() -> list[Path]:
         raw = source.read_text(encoding="utf-8")
         text = strip_comments(_mask_inline_verbatim(_mask_display_environments(raw)))
         for match in input_pattern.finditer(text):
-            relative = Path(match.group(1))
+            if _is_escaped(text, match.start()):
+                continue
+            cursor = match.end()
+            while cursor < len(text) and text[cursor].isspace():
+                cursor += 1
+            if cursor < len(text) and text[cursor] == "{":
+                cursor, target = _read_braced(text, cursor)
+            else:
+                target_match = re.match(r"[^\s%{}]+", text[cursor:])
+                if target_match is None:
+                    raise ValueError(f"{source}: input command has no filename")
+                target = target_match.group(0)
+            relative = Path(target)
             if not relative.suffix:
                 relative = relative.with_suffix(".tex")
             included = (MANUAL_DIR / relative).resolve()

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -153,7 +153,7 @@ def _multiple_variants(options: str | None) -> list[tuple[str, str]]:
 
 @cache
 def _registry_vocabulary() -> tuple[list[str], list[str]]:
-    registry = REGISTRY.read_text(encoding="utf-8")
+    registry = strip_comments(REGISTRY.read_text(encoding="utf-8"))
     commands = re.findall(
         r"\\__tenkz_language_registry_command:nnnnn\s*\{([^{}]+)\}", registry
     )
@@ -193,6 +193,15 @@ def _find_uncommented(text: str, marker: str, offset: int) -> int:
         offset = found + len(marker)
 
 
+def _find_control_word(text: str, name: str, offset: int) -> int:
+    pattern = re.compile(rf"\\{re.escape(name)}(?![A-Za-z@])")
+    while match := pattern.search(text, offset):
+        if not _is_commented(text, match.start()):
+            return match.start()
+        offset = match.end()
+    return -1
+
+
 def _mask_inline_verbatim(text: str) -> str:
     masked = list(text)
     offset = 0
@@ -221,7 +230,7 @@ def _extract_usepackages(body: str) -> tuple[list[str], str]:
     offset = 0
     marker = r"\usepackage"
     scan_body = _mask_inline_verbatim(body)
-    while (start := _find_uncommented(scan_body, marker, offset)) >= 0:
+    while (start := _find_control_word(scan_body, "usepackage", offset)) >= 0:
         cursor = _skip_space_and_comments(body, start + len(marker))
         if cursor < len(body) and body[cursor] == "[":
             cursor, _ = _read_optional_argument(body, cursor)
@@ -256,6 +265,49 @@ def _find_environment_end(text: str, environment: str, offset: int) -> re.Match[
         re.MULTILINE,
     )
     return pattern.search(text, offset)
+
+
+def _mask_display_environments(text: str) -> str:
+    masked = list(text)
+    pattern = re.compile(
+        r"^[ \t]*\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}",
+        re.MULTILINE,
+    )
+    offset = 0
+    while match := pattern.search(text, offset):
+        end = _find_environment_end(text, match.group(1), match.end())
+        if end is None:
+            break
+        for index in range(match.start(), end.end()):
+            if masked[index] != "\n":
+                masked[index] = " "
+        offset = end.end()
+    return "".join(masked)
+
+
+def _mask_nonexecuted_tokens(text: str) -> str:
+    masked = list(_mask_inline_verbatim(text))
+    scan = "".join(masked)
+    string_pattern = re.compile(r"\\string\s*\\(?:[A-Za-z@]+|.)")
+    for match in string_pattern.finditer(scan):
+        for index in range(match.start(), match.end()):
+            if masked[index] != "\n":
+                masked[index] = " "
+    return "".join(masked)
+
+
+def _has_executable_command(text: str, command: str) -> bool:
+    scan = _mask_nonexecuted_tokens(strip_comments(text))
+    pattern = re.compile(rf"\\{re.escape(command)}(?![A-Za-z@:_])")
+    return any(not _is_escaped(scan, match.start()) for match in pattern.finditer(scan))
+
+
+def _source_label(path: Path) -> str:
+    try:
+        relative = path.relative_to(CHAPTERS)
+    except ValueError:
+        relative = Path(path.name)
+    return re.sub(r"[^A-Za-z0-9]+", "-", relative.with_suffix("").as_posix()).strip("-")
 
 
 def _variant_definitions(variant_style: str) -> list[str]:
@@ -336,7 +388,7 @@ def extract_displayed_examples(path: Path) -> list[Example]:
             suffix = f"-variant-{variant_index}" if environment == "tnmultiples" else ""
             examples.append(
                 Example(
-                    label=f"manual-{path.stem}-{ordinal}{suffix}",
+                    label=f"manual-{_source_label(path)}-{ordinal}{suffix}",
                     source=path,
                     line=line,
                     document=_standalone_document(body, variant_style),
@@ -362,7 +414,8 @@ def _manual_chapter_sources() -> list[Path]:
         if source in visited:
             continue
         visited.add(source)
-        text = _strip_tex_comments(_mask_inline_verbatim(source.read_text(encoding="utf-8")))
+        raw = source.read_text(encoding="utf-8")
+        text = strip_comments(_mask_inline_verbatim(_mask_display_environments(raw)))
         for match in input_pattern.finditer(text):
             relative = Path(match.group(1))
             if not relative.suffix:
@@ -377,7 +430,7 @@ def _manual_chapter_sources() -> list[Path]:
 
 
 def reference_examples() -> list[Example]:
-    registry = REGISTRY.read_text(encoding="utf-8")
+    registry = strip_comments(REGISTRY.read_text(encoding="utf-8"))
     commands, _ = _registry_vocabulary()
     mappings = re.findall(
         r"\\__tenkz_language_registry_example:nnn\s*"
@@ -413,8 +466,7 @@ def reference_examples() -> list[Example]:
         if not source.is_file():
             raise ValueError(f"{REGISTRY}: example for \\{command} is missing: {relative}")
         document = source.read_text(encoding="utf-8")
-        uncommented = _strip_tex_comments(document)
-        if not re.search(rf"\\{re.escape(command)}(?![A-Za-z@:_])", uncommented):
+        if not _has_executable_command(document, command):
             raise ValueError(
                 f"{source}: example mapped to \\{command} does not invoke that command"
             )

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -199,6 +199,38 @@ def _find_uncommented(text: str, marker: str, offset: int) -> int:
         offset = found + len(marker)
 
 
+def _extract_usepackages(body: str) -> tuple[list[str], str]:
+    ranges: list[tuple[int, int]] = []
+    offset = 0
+    marker = r"\usepackage"
+    while (start := _find_uncommented(body, marker, offset)) >= 0:
+        cursor = _skip_space_and_comments(body, start + len(marker))
+        if cursor < len(body) and body[cursor] == "[":
+            cursor, _ = _read_optional_argument(body, cursor)
+        cursor = _skip_space_and_comments(body, cursor)
+        end, _ = _read_braced(body, cursor)
+        ranges.append((start, end))
+        offset = end
+
+    packages = [body[start:end].strip() for start, end in ranges]
+    chunks: list[str] = []
+    offset = 0
+    for start, end in ranges:
+        chunks.append(body[offset:start])
+        chunks.append("\n" * body[start:end].count("\n"))
+        offset = end
+    chunks.append(body[offset:])
+    return packages, "".join(chunks)
+
+
+def _find_environment_end(text: str, environment: str, offset: int) -> re.Match[str] | None:
+    pattern = re.compile(
+        rf"^[ \t]*\\end\{{{re.escape(environment)}\}}[ \t]*$",
+        re.MULTILINE,
+    )
+    return pattern.search(text, offset)
+
+
 def _variant_definitions(variant_style: str) -> list[str]:
     return [
         rf"\pgfqkeys{{/tenkz/grid}}{{variant/.style={{{variant_style}}}}}",
@@ -222,14 +254,11 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
         definitions = "\n".join(_variant_definitions(variant_style)) + "\n"
         return body[:begin] + definitions + body[begin:] + "\n"
 
-    preamble: list[str] = []
-    content: list[str] = []
-    for line in body.splitlines():
-        if line.lstrip().startswith(r"\usepackage"):
-            preamble.append(line.strip())
-        else:
-            content.append(line)
-    if not any(r"\usepackage{tenkz}" in line for line in preamble):
+    preamble, content = _extract_usepackages(body)
+    tenkz_package = re.compile(
+        r"\\usepackage(?:\s*\[[\s\S]*?\])?\s*\{[^{}]*\btenkz\b[^{}]*\}"
+    )
+    if not any(tenkz_package.search(package) for package in preamble):
         preamble.append(r"\usepackage{tenkz}")
     if variant_style is not None:
         preamble.extend(_variant_definitions(variant_style))
@@ -239,7 +268,7 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
             *preamble,
             r"\pagestyle{empty}",
             r"\begin{document}",
-            *content,
+            content,
             r"\end{document}",
             "",
         ]
@@ -249,7 +278,8 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
 def extract_displayed_examples(path: Path) -> list[Example]:
     text = path.read_text(encoding="utf-8")
     begin_pattern = re.compile(
-        r"\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}"
+        r"^[ \t]*\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}",
+        re.MULTILINE,
     )
     examples: list[Example] = []
     offset = 0
@@ -261,12 +291,13 @@ def extract_displayed_examples(path: Path) -> list[Example]:
         environment = match.group(1)
         body_start, options = _read_optional_argument(text, match.end())
         end_marker = rf"\end{{{environment}}}"
-        body_end = _find_uncommented(text, end_marker, body_start)
-        if body_end < 0:
+        end_match = _find_environment_end(text, environment, body_start)
+        if end_match is None:
             line = text.count("\n", 0, match.start()) + 1
             raise ValueError(f"{path}:{line}: missing {end_marker}")
+        body_end = end_match.start()
         body = text[body_start:body_end].strip()
-        offset = body_end + len(end_marker)
+        offset = end_match.end()
         if environment == "Verbatim" and not _is_tenkz_verbatim(body):
             continue
         line = text.count("\n", 0, match.start()) + 1
@@ -335,7 +366,7 @@ def reference_examples() -> list[Example]:
         if not source.is_file():
             raise ValueError(f"{REGISTRY}: example for \\{command} is missing: {relative}")
         document = source.read_text(encoding="utf-8")
-        uncommented = re.sub(r"(?<!\\)%.*", "", document)
+        uncommented = _strip_tex_comments(document)
         if not re.search(rf"\\{re.escape(command)}(?![A-Za-z@:_])", uncommented):
             raise ValueError(
                 f"{source}: example mapped to \\{command} does not invoke that command"

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -165,14 +165,16 @@ def _registry_vocabulary() -> tuple[list[str], list[str]]:
 
 def _is_tenkz_verbatim(body: str) -> bool:
     commands, environments = _registry_vocabulary()
-    command_pattern = "|".join(re.escape(command) for command in commands)
     environment_pattern = "|".join(re.escape(environment) for environment in environments)
     packages, _ = _extract_usepackages(body)
-    uncommented = _strip_tex_comments(body)
+    scan = _mask_nonexecuted_tokens(body)
+    environment_matches = re.finditer(
+        rf"\\begin\{{(?:{environment_pattern})\}}", scan
+    )
     return bool(
         any("tenkz" in _package_names(package) for package in packages)
-        or re.search(rf"\\(?:{command_pattern})(?![A-Za-z@:_])", uncommented)
-        or re.search(rf"\\begin\{{(?:{environment_pattern})\}}", uncommented)
+        or any(_has_executable_command(body, command) for command in commands)
+        or any(not _is_escaped(scan, match.start()) for match in environment_matches)
     )
 
 
@@ -207,7 +209,12 @@ def _find_control_word(text: str, name: str, offset: int) -> int:
 def _mask_inline_verbatim(text: str) -> str:
     masked = list(text)
     offset = 0
-    while (start := text.find(r"\verb", offset)) >= 0:
+    verb_pattern = re.compile(r"\\verb(?![A-Za-z@])")
+    while match := verb_pattern.search(text, offset):
+        start = match.start()
+        if _is_escaped(text, start):
+            offset = match.end()
+            continue
         delimiter_offset = start + len(r"\verb")
         if delimiter_offset < len(text) and text[delimiter_offset] == "*":
             delimiter_offset += 1
@@ -217,9 +224,13 @@ def _mask_inline_verbatim(text: str) -> str:
         if delimiter.isspace() or delimiter.isalnum():
             offset = delimiter_offset
             continue
-        end = text.find(delimiter, delimiter_offset + 1)
+        line_end = text.find("\n", delimiter_offset + 1)
+        if line_end < 0:
+            line_end = len(text)
+        end = text.find(delimiter, delimiter_offset + 1, line_end)
         if end < 0:
-            break
+            offset = delimiter_offset + 1
+            continue
         for index in range(start, end + 1):
             if masked[index] != "\n":
                 masked[index] = " "

--- a/scripts/tenkzlib/texcase.py
+++ b/scripts/tenkzlib/texcase.py
@@ -35,16 +35,22 @@ def strip_comments(source: str) -> str:
     return "\n".join(output)
 
 
-def _match_group(
+def match_group(
     source: str, index: int, open_character: str, close_character: str
 ) -> int:
-    """Return the offset after a balanced brace-aware group, or -1."""
+    """Return the offset after a comment- and brace-aware group, or -1."""
     group_depth = 0
     brace_depth = 0
     while index < len(source):
         character = source[index]
         if character == "\\":
             index += 2
+            continue
+        if character == "%":
+            newline = source.find("\n", index)
+            if newline < 0:
+                return -1
+            index = newline + 1
             continue
         if character == open_character and (
             open_character == "{" or brace_depth == 0
@@ -60,6 +66,8 @@ def _match_group(
             brace_depth += 1
         elif character == "}":
             brace_depth -= 1
+            if brace_depth < 0:
+                return -1
         index += 1
     return -1
 
@@ -89,7 +97,7 @@ def scan_constructs(source: str) -> list[Construct]:
         end = end_match.end() if end_match else len(source)
         body_start = match.end()
         if source[body_start : body_start + 1] == "[":
-            closed = _match_group(source, body_start, "[", "]")
+            closed = match_group(source, body_start, "[", "]")
             if closed != -1:
                 body_start = closed
         body_end = end_match.start() if end_match else len(source)
@@ -108,7 +116,7 @@ def scan_constructs(source: str) -> list[Construct]:
         while index < len(source) and source[index] in " \t\n":
             index += 1
         if source[index : index + 1] == "[":
-            closed = _match_group(source, index, "[", "]")
+            closed = match_group(source, index, "[", "]")
             if closed == -1:
                 continue
             index = closed
@@ -116,7 +124,7 @@ def scan_constructs(source: str) -> list[Construct]:
                 index += 1
         if source[index : index + 1] != "{":
             continue
-        closed = _match_group(source, index, "{", "}")
+        closed = match_group(source, index, "{", "}")
         if closed == -1:
             continue
         constructs.append(

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -47,6 +47,9 @@ def main() -> int:
 \verb|\documentclass{standalone}| \tntree{(ab)}
 \end{Verbatim}
 \begin{Verbatim}
+shell command % \tntree{commented}
+\end{Verbatim}
+\begin{Verbatim}
 \usepackage[
   draft
 ]{graphicx}

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -60,6 +60,11 @@ shell command % \tntree{commented}
 % \begin{tnexample}
 % \begin{tenkz} \tn{commented} \end{tenkz}
 % \end{tnexample}
+\iffalse
+\begin{tnexample}
+\begin{tenkz} \tn{false-branch} \end{tenkz}
+\end{tnexample}
+\fi
 \begin{Verbatim}
 \documentclass[
   border=2pt
@@ -100,7 +105,7 @@ shell command % \tntree{commented}
 
     def capture_run(*args: object, **kwargs: object) -> SimpleNamespace:
         captured.update(kwargs)
-        return SimpleNamespace(returncode=0, stdout="")
+        return SimpleNamespace(returncode=0, stdout=reference[0].coverage_marker)
 
     DOCTEST.subprocess.run = capture_run
     try:
@@ -119,6 +124,13 @@ shell command % \tntree{commented}
         raise AssertionError("a non-executed command spelling satisfied reference coverage")
     if DOCTEST._is_tenkz_verbatim(r"\verb|\tn| \string\tn \\tn"):
         raise AssertionError("a non-executed command spelling classified a Verbatim block")
+    if DOCTEST._is_tenkz_verbatim(r"% \begin{tenkz} \tn{commented} \end{tenkz}"):
+        raise AssertionError("a commented environment classified a Verbatim block")
+    package_names = DOCTEST._package_names(
+        "\\usepackage{amsmath,% package note\n tenkz}"
+    )
+    if "tenkz" not in package_names:
+        raise AssertionError("a comment hid tenkz in a multi-package declaration")
     escaped_verb = (
         "Write \\\\verb|without a closing delimiter on this line\n"
         "\\usepackage{tenkz}\n"
@@ -148,7 +160,11 @@ shell command % \tntree{commented}
         chapters.mkdir()
         root = manual_dir / "manual2.tex"
         child = chapters / "child.tex"
-        root.write_text(r"\input chapters2/child", encoding="utf-8")
+        root.write_text(
+            "\\newcommand{\\optionalchapter}{\\input{missing.tex}}\n"
+            "\\input chapters2/child\n",
+            encoding="utf-8",
+        )
         child.write_text("", encoding="utf-8")
         original_manual = DOCTEST.MANUAL
         original_manual_dir = DOCTEST.MANUAL_DIR

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -44,7 +44,8 @@ def main() -> int:
 \tntree{((ab)c)}
 \end{Verbatim}
 \begin{Verbatim}
-\verb|\documentclass{standalone}| \documentclasswrapper \usepackagewrapper{foo} \tntree{(ab)}
+\verb|\documentclass{standalone}| \documentclasswrapper \usepackagewrapper{foo}
+\string\usepackage{missing-package} \\usepackage{also-missing} \tntree{(ab)}
 \end{Verbatim}
 \begin{Verbatim}
 shell command % \tntree{commented}
@@ -120,6 +121,12 @@ shell command % \tntree{commented}
     second_label = DOCTEST._source_label(DOCTEST.CHAPTERS / "advanced" / "example.tex")
     if first_label == second_label:
         raise AssertionError("chapter-relative case labels are not unique")
+    colliding_labels = {
+        DOCTEST._source_label(DOCTEST.CHAPTERS / relative)
+        for relative in ("basic/a_b.tex", "basic/a-b.tex", "a/b.tex", "a-b.tex")
+    }
+    if len(colliding_labels) != 4:
+        raise AssertionError("source labels are not injective over paths")
     displayed_input = r"""
 \begin{Verbatim}
 \input{missing-example.tex}
@@ -133,7 +140,7 @@ shell command % \tntree{commented}
         chapters.mkdir()
         root = manual_dir / "manual2.tex"
         child = chapters / "child.tex"
-        root.write_text(r"\input{chapters2/child}", encoding="utf-8")
+        root.write_text(r"\input chapters2/child", encoding="utf-8")
         child.write_text("", encoding="utf-8")
         original_manual = DOCTEST.MANUAL
         original_manual_dir = DOCTEST.MANUAL_DIR

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -44,7 +44,7 @@ def main() -> int:
 \tntree{((ab)c)}
 \end{Verbatim}
 \begin{Verbatim}
-\verb|\documentclass{standalone}| \usepackagewrapper{foo} \tntree{(ab)}
+\verb|\documentclass{standalone}| \documentclasswrapper \usepackagewrapper{foo} \tntree{(ab)}
 \end{Verbatim}
 \begin{Verbatim}
 shell command % \tntree{commented}
@@ -81,7 +81,9 @@ shell command % \tntree{commented}
         raise AssertionError("tnmultiples variants were not installed independently")
     if r"\tntree" not in extracted[2].document:
         raise AssertionError("a registry command in Verbatim was not recognized as TeX")
-    if extracted[3].document.count(r"\documentclass") != 2:
+    if not extracted[3].document.startswith(r"\documentclass{article}") or (
+        r"\documentclasswrapper" not in extracted[3].document
+    ):
         raise AssertionError("a documentclass spelling inside verb was executed")
     multiline_package = extracted[4].document
     if multiline_package.index("]{graphicx}") > multiline_package.index(
@@ -125,6 +127,28 @@ shell command % \tntree{commented}
 """
     if r"\input" in DOCTEST._mask_display_environments(displayed_input):
         raise AssertionError("a displayed input spelling remained in the structural graph")
+    with tempfile.TemporaryDirectory(prefix="tenkz-doctest-graph-") as tmp:
+        manual_dir = Path(tmp)
+        chapters = manual_dir / "chapters2"
+        chapters.mkdir()
+        root = manual_dir / "manual2.tex"
+        child = chapters / "child.tex"
+        root.write_text(r"\input{chapters2/child}", encoding="utf-8")
+        child.write_text("", encoding="utf-8")
+        original_manual = DOCTEST.MANUAL
+        original_manual_dir = DOCTEST.MANUAL_DIR
+        original_chapters = DOCTEST.CHAPTERS
+        DOCTEST.MANUAL = root
+        DOCTEST.MANUAL_DIR = manual_dir
+        DOCTEST.CHAPTERS = chapters
+        try:
+            sources = DOCTEST._manual_sources()
+        finally:
+            DOCTEST.MANUAL = original_manual
+            DOCTEST.MANUAL_DIR = original_manual_dir
+            DOCTEST.CHAPTERS = original_chapters
+    if {source.resolve() for source in sources} != {root.resolve(), child.resolve()}:
+        raise AssertionError("the manual root or a traversed source was omitted")
 
     print("PASS: tenkz manual doctest extraction and reference coverage")
     return 0

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Regression checks for tenkz manual example extraction and coverage."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "tenkz_manual_doctest.py"
+SPEC = importlib.util.spec_from_file_location("tenkz_manual_doctest", SCRIPT)
+assert SPEC and SPEC.loader
+DOCTEST = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = DOCTEST
+SPEC.loader.exec_module(DOCTEST)
+
+
+def main() -> int:
+    manual = DOCTEST.displayed_examples()
+    reference = DOCTEST.reference_examples()
+    if len(manual) != 9:
+        raise AssertionError(f"expected 9 displayed TeX examples, found {len(manual)}")
+    if len(reference) != 18:
+        raise AssertionError(f"expected 18 reference examples, found {len(reference)}")
+    if any(r"\begin{document}" not in example.document for example in manual):
+        raise AssertionError("a displayed example was not wrapped as a document")
+    if any("tenkz_rmp.sh" in example.document for example in manual):
+        raise AssertionError("the displayed shell session was treated as TeX")
+
+    fixture = r"""
+\begin{tnmultiples}[
+  variants={a={title={A [nested] title}},b={title=B}}]
+\begin{tenkz} \tn{A} \end{tenkz}
+\end{tnmultiples}
+"""
+    with tempfile.TemporaryDirectory(prefix="tenkz-doctest-unit-") as tmp:
+        path = Path(tmp) / "fixture.tex"
+        path.write_text(fixture, encoding="utf-8")
+        extracted = DOCTEST.extract_displayed_examples(path)
+    if len(extracted) != 1 or r"\begin{tenkz}" not in extracted[0].document:
+        raise AssertionError("nested tnmultiple options confused body extraction")
+
+    print("PASS: tenkz manual doctest extraction and reference coverage")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 import tempfile
+from types import SimpleNamespace
 from pathlib import Path
 
 
@@ -31,8 +32,10 @@ def main() -> int:
         raise AssertionError("the displayed shell session was treated as TeX")
 
     fixture = r"""
-\begin{tnmultiples}[
-  caption={domain [0,1)},
+\begin{tnmultiples}% a commented } must not affect the option scanner
+[
+  caption={domain [0,1)}, % nor may this commented } affect it
+  index={options={[some key=val, other=x]}},
   variants={{dot}{dot},{box}{box}}]
 \begin{tenkz} \tn[variant]{A} \end{tenkz}
 \end{tnmultiples}
@@ -43,7 +46,9 @@ def main() -> int:
 % \begin{tenkz} \tn{commented} \end{tenkz}
 % \end{tnexample}
 \begin{Verbatim}
-\documentclass{standalone}
+\documentclass[
+  border=2pt
+]{standalone}
 \usepackage{tenkz}
 \begin{document}
 \begin{tenkz} \tn{complete} \end{tenkz}
@@ -65,6 +70,23 @@ def main() -> int:
     complete = extracted[3].document
     if complete.count(r"\documentclass") != 1 or r"\tn{commented}" in complete:
         raise AssertionError("complete or commented Verbatim documents were mishandled")
+
+    captured: dict[str, object] = {}
+    original_run = DOCTEST.subprocess.run
+
+    def capture_run(*args: object, **kwargs: object) -> SimpleNamespace:
+        captured.update(kwargs)
+        return SimpleNamespace(returncode=0, stdout="")
+
+    DOCTEST.subprocess.run = capture_run
+    try:
+        with tempfile.TemporaryDirectory(prefix="tenkz-doctest-path-") as tmp:
+            DOCTEST.compile_example(reference[0], "xelatex", Path(tmp))
+    finally:
+        DOCTEST.subprocess.run = original_run
+    texinputs = str(captured["env"]["TEXINPUTS"])
+    if not texinputs.startswith(f"{reference[0].source.parent}//:"):
+        raise AssertionError("a reference example cannot resolve files beside its source")
 
     print("PASS: tenkz manual doctest extraction and reference coverage")
     return 0

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -37,10 +37,17 @@ def main() -> int:
   caption={domain [0,1)}, % nor may this commented } affect it
   index={options={[some key=val, other=x]}},
   variants={{dot}{dot},{box}{box}}]
+\verb|\end{tnmultiples}|
 \begin{tenkz} \tn[variant]{A} \end{tenkz}
 \end{tnmultiples}
 \begin{Verbatim}
 \tntree{((ab)c)}
+\end{Verbatim}
+\begin{Verbatim}
+\usepackage[
+  draft
+]{graphicx}
+\begin{tenkz} \tn{multiline-package} \end{tenkz}
 \end{Verbatim}
 % \begin{tnexample}
 % \begin{tenkz} \tn{commented} \end{tenkz}
@@ -59,7 +66,7 @@ def main() -> int:
         path = Path(tmp) / "fixture.tex"
         path.write_text(fixture, encoding="utf-8")
         extracted = DOCTEST.extract_displayed_examples(path)
-    if len(extracted) != 4 or any(
+    if len(extracted) != 5 or any(
         r"\begin{tenkz}" not in example.document for example in extracted[:2]
     ):
         raise AssertionError("nested tnmultiple options confused body extraction")
@@ -67,7 +74,12 @@ def main() -> int:
         raise AssertionError("tnmultiples variants were not installed independently")
     if r"\tntree" not in extracted[2].document:
         raise AssertionError("a registry command in Verbatim was not recognized as TeX")
-    complete = extracted[3].document
+    multiline_package = extracted[3].document
+    if multiline_package.index("]{graphicx}") > multiline_package.index(
+        r"\begin{document}"
+    ):
+        raise AssertionError("a multiline package declaration was split across the body")
+    complete = extracted[4].document
     if complete.count(r"\documentclass") != 1 or r"\tn{commented}" in complete:
         raise AssertionError("complete or commented Verbatim documents were mishandled")
 
@@ -87,6 +99,10 @@ def main() -> int:
     texinputs = str(captured["env"]["TEXINPUTS"])
     if not texinputs.startswith(f"{reference[0].source.parent}//:"):
         raise AssertionError("a reference example cannot resolve files beside its source")
+    if r"\tnarrow" in DOCTEST._strip_tex_comments(r"\\% \tnarrow"):
+        raise AssertionError("an even-backslash percent did not start a TeX comment")
+    if r"\tnarrow" not in DOCTEST._strip_tex_comments(r"\% \tnarrow"):
+        raise AssertionError("an escaped percent incorrectly started a TeX comment")
 
     print("PASS: tenkz manual doctest extraction and reference coverage")
     return 0

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -32,19 +32,29 @@ def main() -> int:
 
     fixture = r"""
 \begin{tnmultiples}[
-  caption={A [nested] title},
+  caption={domain [0,1)},
   variants={{dot}{dot},{box}{box}}]
 \begin{tenkz} \tn[variant]{A} \end{tenkz}
 \end{tnmultiples}
 \begin{Verbatim}
 \tntree{((ab)c)}
 \end{Verbatim}
+% \begin{tnexample}
+% \begin{tenkz} \tn{commented} \end{tenkz}
+% \end{tnexample}
+\begin{Verbatim}
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\begin{tenkz} \tn{complete} \end{tenkz}
+\end{document}
+\end{Verbatim}
 """
     with tempfile.TemporaryDirectory(prefix="tenkz-doctest-unit-") as tmp:
         path = Path(tmp) / "fixture.tex"
         path.write_text(fixture, encoding="utf-8")
         extracted = DOCTEST.extract_displayed_examples(path)
-    if len(extracted) != 3 or any(
+    if len(extracted) != 4 or any(
         r"\begin{tenkz}" not in example.document for example in extracted[:2]
     ):
         raise AssertionError("nested tnmultiple options confused body extraction")
@@ -52,6 +62,9 @@ def main() -> int:
         raise AssertionError("tnmultiples variants were not installed independently")
     if r"\tntree" not in extracted[2].document:
         raise AssertionError("a registry command in Verbatim was not recognized as TeX")
+    complete = extracted[3].document
+    if complete.count(r"\documentclass") != 1 or r"\tn{commented}" in complete:
+        raise AssertionError("complete or commented Verbatim documents were mishandled")
 
     print("PASS: tenkz manual doctest extraction and reference coverage")
     return 0

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -44,9 +44,13 @@ def main() -> int:
 \tntree{((ab)c)}
 \end{Verbatim}
 \begin{Verbatim}
+\verb|\documentclass{standalone}| \tntree{(ab)}
+\end{Verbatim}
+\begin{Verbatim}
 \usepackage[
   draft
 ]{graphicx}
+\usepackage{amsmath,tenkz}
 \begin{tenkz} \tn{multiline-package} \end{tenkz}
 \end{Verbatim}
 % \begin{tnexample}
@@ -66,7 +70,7 @@ def main() -> int:
         path = Path(tmp) / "fixture.tex"
         path.write_text(fixture, encoding="utf-8")
         extracted = DOCTEST.extract_displayed_examples(path)
-    if len(extracted) != 5 or any(
+    if len(extracted) != 6 or any(
         r"\begin{tenkz}" not in example.document for example in extracted[:2]
     ):
         raise AssertionError("nested tnmultiple options confused body extraction")
@@ -74,12 +78,14 @@ def main() -> int:
         raise AssertionError("tnmultiples variants were not installed independently")
     if r"\tntree" not in extracted[2].document:
         raise AssertionError("a registry command in Verbatim was not recognized as TeX")
-    multiline_package = extracted[3].document
+    if extracted[3].document.count(r"\documentclass") != 2:
+        raise AssertionError("a documentclass spelling inside verb was executed")
+    multiline_package = extracted[4].document
     if multiline_package.index("]{graphicx}") > multiline_package.index(
         r"\begin{document}"
     ):
         raise AssertionError("a multiline package declaration was split across the body")
-    complete = extracted[4].document
+    complete = extracted[5].document
     if complete.count(r"\documentclass") != 1 or r"\tn{commented}" in complete:
         raise AssertionError("complete or commented Verbatim documents were mishandled")
 

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -32,16 +32,26 @@ def main() -> int:
 
     fixture = r"""
 \begin{tnmultiples}[
-  variants={a={title={A [nested] title}},b={title=B}}]
-\begin{tenkz} \tn{A} \end{tenkz}
+  caption={A [nested] title},
+  variants={{dot}{dot},{box}{box}}]
+\begin{tenkz} \tn[variant]{A} \end{tenkz}
 \end{tnmultiples}
+\begin{Verbatim}
+\tntree{((ab)c)}
+\end{Verbatim}
 """
     with tempfile.TemporaryDirectory(prefix="tenkz-doctest-unit-") as tmp:
         path = Path(tmp) / "fixture.tex"
         path.write_text(fixture, encoding="utf-8")
         extracted = DOCTEST.extract_displayed_examples(path)
-    if len(extracted) != 1 or r"\begin{tenkz}" not in extracted[0].document:
+    if len(extracted) != 3 or any(
+        r"\begin{tenkz}" not in example.document for example in extracted[:2]
+    ):
         raise AssertionError("nested tnmultiple options confused body extraction")
+    if not all("variant/.style" in example.document for example in extracted[:2]):
+        raise AssertionError("tnmultiples variants were not installed independently")
+    if r"\tntree" not in extracted[2].document:
+        raise AssertionError("a registry command in Verbatim was not recognized as TeX")
 
     print("PASS: tenkz manual doctest extraction and reference coverage")
     return 0

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -44,7 +44,7 @@ def main() -> int:
 \tntree{((ab)c)}
 \end{Verbatim}
 \begin{Verbatim}
-\verb|\documentclass{standalone}| \tntree{(ab)}
+\verb|\documentclass{standalone}| \usepackagewrapper{foo} \tntree{(ab)}
 \end{Verbatim}
 \begin{Verbatim}
 shell command % \tntree{commented}
@@ -112,6 +112,19 @@ shell command % \tntree{commented}
         raise AssertionError("an even-backslash percent did not start a TeX comment")
     if r"\tnarrow" not in DOCTEST._strip_tex_comments(r"\% \tnarrow"):
         raise AssertionError("an escaped percent incorrectly started a TeX comment")
+    if DOCTEST._has_executable_command(r"\verb|\tn| \string\tn \\tn", "tn"):
+        raise AssertionError("a non-executed command spelling satisfied reference coverage")
+    first_label = DOCTEST._source_label(DOCTEST.CHAPTERS / "basic" / "example.tex")
+    second_label = DOCTEST._source_label(DOCTEST.CHAPTERS / "advanced" / "example.tex")
+    if first_label == second_label:
+        raise AssertionError("chapter-relative case labels are not unique")
+    displayed_input = r"""
+\begin{Verbatim}
+\input{missing-example.tex}
+\end{Verbatim}
+"""
+    if r"\input" in DOCTEST._mask_display_environments(displayed_input):
+        raise AssertionError("a displayed input spelling remained in the structural graph")
 
     print("PASS: tenkz manual doctest extraction and reference coverage")
     return 0

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -117,6 +117,14 @@ shell command % \tntree{commented}
         raise AssertionError("an escaped percent incorrectly started a TeX comment")
     if DOCTEST._has_executable_command(r"\verb|\tn| \string\tn \\tn", "tn"):
         raise AssertionError("a non-executed command spelling satisfied reference coverage")
+    if DOCTEST._is_tenkz_verbatim(r"\verb|\tn| \string\tn \\tn"):
+        raise AssertionError("a non-executed command spelling classified a Verbatim block")
+    escaped_verb = (
+        "Write \\\\verb|without a closing delimiter on this line\n"
+        "\\usepackage{tenkz}\n"
+    )
+    if r"\usepackage{tenkz}" not in DOCTEST._mask_inline_verbatim(escaped_verb):
+        raise AssertionError("an escaped verb spelling masked a later source line")
     first_label = DOCTEST._source_label(DOCTEST.CHAPTERS / "basic" / "example.tex")
     second_label = DOCTEST._source_label(DOCTEST.CHAPTERS / "advanced" / "example.tex")
     if first_label == second_label:


### PR DESCRIPTION
Part of LionSR/tenkz#12 and tracked by LionSR/tenkz#13.

This PR addresses only the mechanical manual doc-test checkbox. It deliberately leaves prose review, deprecation policy, interface freeze, and release decisions for separate work.

What changed:
- extract every TeX display from docs/tenkz/chapters2 (tnexample, tnmultiples, and TeX Verbatim blocks)
- compile each extracted display as an independent document
- require a one-to-one registry example for all 18 public commands and verify the generated reference lists those exact paths
- compile all 18 reference examples independently
- run parser/coverage checks before TeX installation and the 27-document compile beside the corpus CI gate

Validation:
- python3 scripts/test_tenkz_manual_doctest.py
- python3 scripts/tenkz_manual_doctest.py
- actionlint .github/workflows/pr-ci.yml
- python3 scripts/test_tenkz_corpus_provenance.py
- python3 scripts/test_tenkz_corpus_render.py
- TENKZ_CORPUS_JOBS=4 scripts/tenkz_corpus.sh (261/261)
- TENKZ_CORPUS_JOBS=4 scripts/tenkz_golden.sh --check (261/261 byte-identical)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI, docs, and test tooling around manual examples; shared `match_group` behavior is tightened but covered by existing texcase tests and lint callers.
> 
> **Overview**
> Adds a **manual doc-test pipeline** that pulls every displayed example from `docs/tenkz` (`tnexample`, `tnmultiples`, and tenkz-related `Verbatim` blocks), wraps each as a standalone document, and compiles them with xelatex—plus **registry-backed reference checks** for all 18 public commands.
> 
> **`scripts/tenkz_manual_doctest.py`** walks `manual2.tex` via `\input`, masks inactive TeX (comments, `\iffalse`, macros, `\verb`, etc.), handles `tnmultiples` variants, and for registry examples instruments commands so compilation must actually execute them. **`scripts/test_tenkz_manual_doctest.py`** locks extraction edge cases and expected counts (9 manual + 18 reference).
> 
> **CI (`tenkz-corpus`)** runs the unit test before TeX install, then the full compile; path filters include manual sources and the new scripts. **`docs/tenkz/HACKING.md`** documents running the doctest before building the manual.
> 
> **`tenkzlib.texcase`**: `_match_group` is public as `match_group`, with `%` comment skipping and stricter brace handling; **`tenkz_lint.py`** uses the new name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d342d10fc8f235afc62afe16cdca4b42e1faafd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->