### PR TITLE
refactor(tenkz): move lattice onto the shared stack

### DIFF
--- a/tests/tenkz/render-census-baseline.json
+++ b/tests/tenkz/render-census-baseline.json
@@ -5,14 +5,14 @@
       "tenkz-core.code.tex": 8,
       "tenkz-free.code.tex": 11,
       "tenkz-geometry.code.tex": 0,
-      "tenkz-grid.code.tex": 16,
+      "tenkz-grid.code.tex": 7,
       "tenkz-language.code.tex": 0,
-      "tenkz-lattice.code.tex": 30,
+      "tenkz-lattice.code.tex": 0,
       "tenkz-metric.code.tex": 0,
       "tenkz-model.code.tex": 0,
       "tenkz-render.code.tex": 0
     },
-    "total": 86
+    "total": 47
   },
   "decimal_literals": {
     "by_file": {

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -1745,7 +1745,6 @@
 % eligibility decisions live HERE, once, before validation; the draw
 % passes consume the records, and the stub passes read the row-consumption
 % prop this derivation owns.
-\tl_new:N \l__tenkz_mdc_orig_tl
 \cs_new_protected:Npn \tenkz_model_derive_closures:
   {
     \prop_clear:N \l__tenkz_cuprow_prop

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -1856,7 +1856,7 @@
     \tenkz_row_extent:n {#1}
     \int_compare:nNnF { \l__tenkz_first_int } = {0}
       {
-        \tenkz_periodic_endpoints:nnnN {#1}
+        \tenkz_periodic_endpoints_match:nnnN {#1}
           {\l__tenkz_first_int}{\l__tenkz_last_int} \l_tmpa_bool
         \bool_if:NT \l_tmpa_bool
           {
@@ -2134,6 +2134,7 @@
         {
           \str_if_eq:VnTF \l__tenkz_eastpol_tl {trace}
             {
+              \tenkz_draw_periodic_mismatches:
               % closure-style default follows the frame: flat words keep
               % the explicit racetrack, vertical words default to hooks --
               % a vertical racetrack spends the very width the rotation
@@ -5660,17 +5661,16 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
       }
   }
 
+\seq_new:N \l__tenkz_periodic_mismatch_seq
 \cs_new_protected:Npn \tenkz_record_periodic_row:n #1
   {
     \tenkz_row_extent:n {#1}
     \int_compare:nNnF { \l__tenkz_first_int } = {0}
       {
-        \tenkz_periodic_row_port:nnnN
-          {#1}{\l__tenkz_first_int}{west} \l__tenkz_periodicwest_bool
-        \tenkz_periodic_row_port:nnnN
-          {#1}{\l__tenkz_last_int}{east} \l__tenkz_periodiceast_bool
-        \bool_if:nT
-          { \l__tenkz_periodicwest_bool && \l__tenkz_periodiceast_bool }
+        \tenkz_periodic_endpoints_match:nnnN {#1}
+          {\l__tenkz_first_int}{\l__tenkz_last_int}
+          \l__tenkz_periodicpair_bool
+        \bool_if:NT \l__tenkz_periodicpair_bool
           {
             \prop_get:NeNF \l__tenkz_owner_prop
               {#1-\int_use:N\l__tenkz_first_int} \l_tmpa_tl
@@ -5685,12 +5685,28 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
             \prop_put:Nen \l__tenkz_periodicpaired_prop
               {#1-\l_tmpa_tl-east} {}
           }
+        \bool_if:nT
+          {
+            ( \l__tenkz_periodicwest_bool &&
+              ! \l__tenkz_periodiceast_bool ) ||
+            ( ! \l__tenkz_periodicwest_bool &&
+              \l__tenkz_periodiceast_bool )
+          }
+          {
+            \seq_put_right:Ne \l__tenkz_periodic_mismatch_seq
+              {
+                { \int_eval:n{#1} }
+                { \int_use:N \l__tenkz_first_int }
+                { \int_use:N \l__tenkz_last_int }
+              }
+          }
       }
   }
 
 \cs_new_protected:Npn \tenkz_compute_periodic_faces:
   {
     \prop_clear:N \l__tenkz_periodicpaired_prop
+    \seq_clear:N \l__tenkz_periodic_mismatch_seq
     \bool_lazy_and:nnT
       { \str_if_eq_p:Vn \l__tenkz_westpol_tl {trace} }
       { \str_if_eq_p:Vn \l__tenkz_eastpol_tl {trace} }
@@ -5704,7 +5720,18 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
       }
   }
 
-\cs_new_protected:Npn \tenkz_periodic_endpoints:nnnN #1#2#3#4
+\cs_new_protected:Npn \tenkz_draw_periodic_mismatches:
+  {
+    \seq_map_inline:Nn \l__tenkz_periodic_mismatch_seq
+      { \tenkz_draw_periodic_mismatch:nnn ##1 }
+  }
+\cs_new_protected:Npn \tenkz_draw_periodic_mismatch:nnn #1#2#3
+  {
+    \tenkz_periodic_endpoints:nnnN {#1}{#2}{#3}
+      \l__tenkz_periodicpair_bool
+  }
+
+\cs_new_protected:Npn \tenkz_periodic_endpoints_match:nnnN #1#2#3#4
   {
     \tenkz_periodic_row_port:nnnN {#1}{#2}{west}
       \l__tenkz_periodicwest_bool
@@ -5714,6 +5741,15 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
     % uses temporary booleans and must not turn a mismatch into a closure.
     \bool_set:Nn \l__tenkz_periodicpair_bool
       { \l__tenkz_periodicwest_bool && \l__tenkz_periodiceast_bool }
+    \bool_set_eq:NN #4 \l__tenkz_periodicpair_bool
+  }
+
+% The draw-phase wrapper owns the warning and unmatched-stub ink.  Record
+% derivation calls the pure matcher above, before a tikzpicture exists.
+\cs_new_protected:Npn \tenkz_periodic_endpoints:nnnN #1#2#3#4
+  {
+    \tenkz_periodic_endpoints_match:nnnN {#1}{#2}{#3}
+      \l__tenkz_periodicpair_bool
     \bool_if:nT
       {
         ( \l__tenkz_periodicwest_bool &&

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -1860,7 +1860,7 @@
         \bool_if:NT \l_tmpa_bool
           {
             \__tenkz_model_record_wire:e
-              {kind={index},origin={wrap},row={\int_eval:n{#1}},
+              {kind={index},origin={trace},row={\int_eval:n{#1}},
                side={#2},name={wrap-\int_eval:n{#1}}}
           }
       }
@@ -2133,7 +2133,7 @@
         {
           \str_if_eq:VnTF \l__tenkz_eastpol_tl {trace}
             {
-              \tenkz_draw_periodic_mismatches:
+              \tenkz_draw_periodic_mismatches:n {before}
               % closure-style default follows the frame: flat words keep
               % the explicit racetrack, vertical words default to hooks --
               % a vertical racetrack spends the very width the rotation
@@ -2147,6 +2147,7 @@
               \str_if_eq:VnTF \l__tenkz_perstyle_tl {hooks}
                 { \tenkz_draw_hooks: }
                 { \tenkz_draw_trace: }
+              \tenkz_draw_periodic_mismatches:n {after}
             }
             { \msg_warning:nnn {tenkz}{trace-one-sided} {west} }
         }
@@ -5719,15 +5720,26 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
       }
   }
 
-\cs_new_protected:Npn \tenkz_draw_periodic_mismatches:
+\cs_new_protected:Npn \tenkz_draw_periodic_mismatches:n #1
   {
     \seq_map_inline:Nn \l__tenkz_periodic_mismatch_seq
-      { \tenkz_draw_periodic_mismatch:nnn ##1 }
+      { \tenkz_draw_periodic_mismatch:nnnn {#1} ##1 }
   }
-\cs_new_protected:Npn \tenkz_draw_periodic_mismatch:nnn #1#2#3
+\cs_new_protected:Npn \tenkz_draw_periodic_mismatch:nnnn #1#2#3#4
   {
-    \tenkz_periodic_endpoints:nnnN {#1}{#2}{#3}
-      \l__tenkz_periodicpair_bool
+    % Only the top and bottom rows can carry periodic closures.  Emit a top
+    % mismatch before the matching closure records and a bottom mismatch
+    % after them, preserving the historical top-to-bottom event order.
+    \bool_if:nT
+      {
+        ( \str_if_eq_p:nn {#1}{before} && \int_compare_p:nNn {#2} = {1} )
+        ||
+        ( \str_if_eq_p:nn {#1}{after} && \int_compare_p:nNn {#2} > {1} )
+      }
+      {
+        \tenkz_periodic_endpoints:nnnN {#2}{#3}{#4}
+          \l__tenkz_periodicpair_bool
+      }
   }
 
 \cs_new_protected:Npn \tenkz_periodic_endpoints_match:nnnN #1#2#3#4
@@ -5791,7 +5803,7 @@ code=periodic-face-ports|row=\int_eval:n{#1}}
 
 \tl_new:N \l__tenkz_wrapside_tl
 \cs_new_protected:Npn \tenkz_draw_trace:
-  { \__tenkz_model_map_wires_origin:nN {wrap} \tenkz_draw_trace_one:n }
+  { \__tenkz_model_map_wires_origin:nN {trace} \tenkz_draw_trace_one:n }
 \cs_new_protected:Npn \tenkz_draw_trace_one:n #1
   {
     \__tenkz_model_get:nnN {#1} {row}  \l__tenkz_ptrow_tl
@@ -5904,7 +5916,7 @@ code=periodic-face-ports|row=\int_eval:n{#1}}
 % word's hooks wrap over the top and under the bottom toward the page's
 % east margin, as in the reference figure.
 \cs_new_protected:Npn \tenkz_draw_hooks:
-  { \__tenkz_model_map_wires_origin:nN {wrap} \tenkz_draw_hooks_one:n }
+  { \__tenkz_model_map_wires_origin:nN {trace} \tenkz_draw_hooks_one:n }
 \cs_new_protected:Npn \tenkz_draw_hooks_one:n #1
   {
     \__tenkz_model_get:nnN {#1} {row}  \l__tenkz_ptrow_tl

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -74,9 +74,8 @@
 \bool_new:N \l__tenkz_closee_bool
 \tl_new:N \l__tenkz_closewmat_tl % on-bend matrix of the west cups (may be empty)
 \tl_new:N \l__tenkz_closeemat_tl % on-bend matrix of the east cups (may be empty)
-\seq_new:N \l__tenkz_cupw_seq    % west cup pairs {top row}{bottom row}
-\seq_new:N \l__tenkz_cupe_seq    % east cup pairs
-\prop_new:N \l__tenkz_cuprow_prop% "west-r"/"east-r" -> row r is cup-closed there
+\prop_new:N \l__tenkz_cuprow_prop% "west-r"/"east-r" -> row r is cup-closed
+                                 % there; owned by the closure derivation
 \prop_new:N \l__tenkz_nopair_prop% rows carrying the `nopair` rows= modifier
 % wires=k glyphs (one atom spanning k wire rows, quantikz \gate[k]).  Each
 % spanned (row, owner-col) cell is keyed here to the glyph's node name, so
@@ -1739,6 +1738,135 @@
       { \tenkz_model_validate_bond_label:nnn ##1 }
   }
 
+% ---------- closure derivation (record phase) ----------
+% Closures are wires whose origin field records the policy that generated
+% them (LANGUAGE-1.0 sec. 5): cup pairs, the periodic wrap of a traced
+% word, and the physical-trace loops of trace= cell-sets.  The pairing and
+% eligibility decisions live HERE, once, before validation; the draw
+% passes consume the records, and the stub passes read the row-consumption
+% prop this derivation owns.
+\tl_new:N \l__tenkz_mdc_orig_tl
+\cs_new_protected:Npn \tenkz_model_derive_closures:
+  {
+    \prop_clear:N \l__tenkz_cuprow_prop
+    \bool_if:NT \l__tenkz_closew_bool
+      { \tenkz_model_derive_cups_side:nnN {west}{first} \l__tenkz_closewmat_tl }
+    \bool_if:NT \l__tenkz_closee_bool
+      { \tenkz_model_derive_cups_side:nnN {east}{last} \l__tenkz_closeemat_tl }
+    % the periodic wrap runs when BOTH side policies say trace; the style
+    % (racetrack|hooks) is presentation and resolves at draw
+    \str_if_eq:VnT \l__tenkz_westpol_tl {trace}
+      {
+        \str_if_eq:VnT \l__tenkz_eastpol_tl {trace}
+          {
+            \int_compare:nNnTF { \l__tenkz_nrows_int } = {1}
+              { \tenkz_model_derive_wrap:nn {1}{below} }
+              {
+                \tenkz_model_derive_wrap:nn {1}{above}
+                \tenkz_model_derive_wrap:nn {\l__tenkz_nrows_int}{below}
+              }
+          }
+      }
+    % physical trace loops (trace=physical): single-row words only; the
+    % multirow warning stays with the draw pass
+    \bool_if:NT \l__tenkz_ptrace_bool
+      {
+        \int_compare:nNnT { \l__tenkz_nrows_int } = {1}
+          {
+            \int_step_inline:nnn {1} { \l__tenkz_ncols_int }
+              {
+                \bool_lazy_and:nnT
+                  { \tenkz_openup_p:n {1} }
+                  { \tenkz_opendown_p:n {1} }
+                  {
+                    \tenkz_leg_candidate:nnT {1}{##1}
+                      {
+                        \tenkz_phtrace_supported:nnN {1}{##1} \l_tmpa_bool
+                        \__tenkz_model_record_wire:e
+                          {kind={index},origin={phtrace},row={1},col={##1},
+                           supported={\bool_if:NTF \l_tmpa_bool {1}{0}}}
+                      }
+                  }
+              }
+          }
+      }
+    % pair trace loops (trace= cell-sets over ket/bra pairs)
+    \int_step_inline:nn { \l__tenkz_nrows_int }
+      {
+        \int_step_inline:nnn {1} { \l__tenkz_ncols_int }
+          {
+            \prop_if_in:NeT \l__tenkz_trcell_prop {##1-####1}
+              {
+                \tenkz_leg_candidate:nnT {##1}{####1}
+                  {
+                    \tenkz_leg_candidate:nnT { \int_eval:n{##1+1} }{####1}
+                      {
+                        \__tenkz_model_record_wire:e
+                          {kind={index},origin={pairtrace},
+                           row={\int_eval:n{##1}},col={####1}}
+                      }
+                  }
+              }
+          }
+      }
+  }
+% cup pairing for side #1 with row-extent end #2; #3 is the side's on-bend
+% matrix label tl (its emptiness becomes the record's matrix flag)
+\cs_new_protected:Npn \tenkz_model_derive_cups_side:nnN #1#2#3
+  {
+    \seq_clear:N \l_tmpa_seq
+    \int_step_inline:nn { \l__tenkz_nrows_int }
+      {
+        % cup eligibility respects the per-side policy: a side sealed by
+        % west=none/east=none has no open ends to cup there
+        \tenkz_row_open_side:nnN {##1}{#1} \l__tenkz_bopen_bool
+        \bool_if:NT \l__tenkz_bopen_bool
+          {
+            \tenkz_row_extent:n {##1}
+            \int_compare:nNnF { \l__tenkz_first_int } = {0}
+              {
+                \tenkz_cell_fuse_combined:nnnN {##1}
+                  { \int_use:c { l__tenkz_#2_int } } {#1} \l_tmpa_bool
+                \bool_if:NF \l_tmpa_bool
+                  {
+                    \tenkz_cell_virtual_row_port:nnnN {##1}
+                      { \int_use:c { l__tenkz_#2_int } } {#1} \l_tmpb_bool
+                    \bool_if:NT \l_tmpb_bool
+                      { \seq_put_right:Nn \l_tmpa_seq {##1} }
+                  }
+              }
+          }
+      }
+    \bool_while_do:nn
+      { \int_compare_p:nNn { \seq_count:N \l_tmpa_seq } > {1} }
+      {
+        \seq_pop_left:NN \l_tmpa_seq \l_tmpa_tl
+        \seq_pop_left:NN \l_tmpa_seq \l_tmpb_tl
+        \__tenkz_model_record_wire:e
+          {kind={index},origin={cup},side={#1},
+           top={\l_tmpa_tl},bottom={\l_tmpb_tl},
+           name={cup-\l_tmpa_tl-\l_tmpb_tl},
+           matrix={\tl_if_blank:VTF #3 {0}{1}}}
+        \prop_put:Nen \l__tenkz_cuprow_prop { #1 - \l_tmpa_tl } {}
+        \prop_put:Nen \l__tenkz_cuprow_prop { #1 - \l_tmpb_tl } {}
+      }
+  }
+\cs_new_protected:Npn \tenkz_model_derive_wrap:nn #1#2
+  {
+    \tenkz_row_extent:n {#1}
+    \int_compare:nNnF { \l__tenkz_first_int } = {0}
+      {
+        \tenkz_periodic_endpoints:nnnN {#1}
+          {\l__tenkz_first_int}{\l__tenkz_last_int} \l_tmpa_bool
+        \bool_if:NT \l_tmpa_bool
+          {
+            \__tenkz_model_record_wire:e
+              {kind={index},origin={wrap},row={\int_eval:n{#1}},
+               side={#2},name={wrap-\int_eval:n{#1}}}
+          }
+      }
+  }
+
 \cs_new_protected:Npn \tenkz_record_interfaces:
   {
     \prop_clear:N \l__tenkz_opencell_prop
@@ -1850,6 +1978,7 @@
     \tenkz_model_record_owners:
     \tenkz_model_derive_bonds:
     \tenkz_model_validate_bond_labels:
+    \tenkz_model_derive_closures:
     \__tenkz_model_validate:
     \tenkz@beginpicture{grid}
     \tenkz_emit_tracefacewarnings:
@@ -1988,7 +2117,6 @@
       \pgfsetlayers{background,main}
       \tenkz_place_nodes:
       \tenkz_draw_bonds:
-      \tenkz_compute_cups:
       \tenkz_compute_periodic_faces:
       \tenkz_draw_combined_stubs:
       \tenkz_draw_boundaries:
@@ -5053,53 +5181,6 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
 % Eligible rows are cupped in ADJACENT PAIRS, top-down (first with second,
 % third with fourth, ...); an odd row out keeps its stub.  A cupped row
 % draws no stub and contributes no open virtual index to the signature.
-\cs_new_protected:Npn \tenkz_compute_cups:
-  {
-    \seq_clear:N \l__tenkz_cupw_seq
-    \seq_clear:N \l__tenkz_cupe_seq
-    \prop_clear:N \l__tenkz_cuprow_prop
-    \bool_if:NT \l__tenkz_closew_bool
-      { \tenkz_compute_cups_side:nnN {west}{first} \l__tenkz_cupw_seq }
-    \bool_if:NT \l__tenkz_closee_bool
-      { \tenkz_compute_cups_side:nnN {east}{last} \l__tenkz_cupe_seq }
-  }
-% side #1 (west|east), row-extent end #2 (first|last), pair seq #3
-\cs_new_protected:Npn \tenkz_compute_cups_side:nnN #1#2#3
-  {
-    \seq_clear:N \l_tmpa_seq
-    \int_step_inline:nn { \l__tenkz_nrows_int }
-      {
-        % cup eligibility respects the per-side policy: a side sealed by
-        % west=none/east=none has no open ends to cup there
-        \tenkz_row_open_side:nnN {##1}{#1} \l__tenkz_bopen_bool
-        \bool_if:NT \l__tenkz_bopen_bool
-          {
-            \tenkz_row_extent:n {##1}
-            \int_compare:nNnF { \l__tenkz_first_int } = {0}
-              {
-                \tenkz_cell_fuse_combined:nnnN {##1}
-                  { \int_use:c { l__tenkz_#2_int } } {#1} \l_tmpa_bool
-                \bool_if:NF \l_tmpa_bool
-                  {
-                    \tenkz_cell_virtual_row_port:nnnN {##1}
-                      { \int_use:c { l__tenkz_#2_int } } {#1} \l_tmpb_bool
-                    \bool_if:NT \l_tmpb_bool
-                      { \seq_put_right:Nn \l_tmpa_seq {##1} }
-                  }
-              }
-          }
-      }
-    \bool_while_do:nn
-      { \int_compare_p:nNn { \seq_count:N \l_tmpa_seq } > {1} }
-      {
-        \seq_pop_left:NN \l_tmpa_seq \l_tmpa_tl
-        \seq_pop_left:NN \l_tmpa_seq \l_tmpb_tl
-        \seq_put_right:Ne #3 { { \l_tmpa_tl } { \l_tmpb_tl } }
-        \prop_put:Nen \l__tenkz_cuprow_prop { #1 - \l_tmpa_tl } {}
-        \prop_put:Nen \l__tenkz_cuprow_prop { #1 - \l_tmpb_tl } {}
-      }
-  }
-
 % Geometry.  One cup = two quarter-arcs (a rounded 180-degree turn) from
 % the upper row's end to the lower row's end, drawn in the pair's wire
 % style (the upper row's — a sandwich pair shares one style).  Horizontal
@@ -5111,12 +5192,19 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
 \dim_new:N \l__tenkz_cupry_dim  % vertical radius: half the pair's row gap
 \tl_new:N \l__tenkz_cupmat_tl   % this cup's on-bend matrix (may be empty)
 
+\tl_new:N \l__tenkz_cupside_tl
+\tl_new:N \l__tenkz_cuptop_tl
+\tl_new:N \l__tenkz_cupbot_tl
 \cs_new_protected:Npn \tenkz_draw_cups:
+  { \__tenkz_model_map_wires_origin:nN {cup} \tenkz_draw_cup:n }
+% draw one cup from its wire record: fields side, top, bottom
+\cs_new_protected:Npn \tenkz_draw_cup:n #1
   {
-    \seq_map_inline:Nn \l__tenkz_cupw_seq
-      { \tenkz_draw_cup:nnn {west} ##1 }
-    \seq_map_inline:Nn \l__tenkz_cupe_seq
-      { \tenkz_draw_cup:nnn {east} ##1 }
+    \__tenkz_model_get:nnN {#1} {side}   \l__tenkz_cupside_tl
+    \__tenkz_model_get:nnN {#1} {top}    \l__tenkz_cuptop_tl
+    \__tenkz_model_get:nnN {#1} {bottom} \l__tenkz_cupbot_tl
+    \tenkz_draw_cup:VVV
+      \l__tenkz_cupside_tl \l__tenkz_cuptop_tl \l__tenkz_cupbot_tl
   }
 
 % the cup end of row #2 on side #1: the anchor coordinate (into tl #3) and
@@ -5159,33 +5247,38 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
       { ( \tenkz_rowy:n {#2} + \tenkz_rowy:n {#3} ) / 2 }
     \str_if_eq:nnTF {#1}{east}
       {
-        \draw[\tl_use:N \l__tenkz_cell_tl]
-          \l__tenkz_pa_tl --
-          (\dim_use:N \l__tenkz_cupx_dim, \tenkz_rowy:n {#2})
-          arc[start~angle=90, end~angle=0,
-              x~radius=\tenkz@dim{\tenkz@r@stub},
-              y~radius=\dim_use:N \l__tenkz_cupry_dim]
-          arc[start~angle=0, end~angle=-90,
-              x~radius=\tenkz@dim{\tenkz@r@stub},
-              y~radius=\dim_use:N \l__tenkz_cupry_dim]
-          -- \l__tenkz_pb_tl;
+        \__tenkz_render_stroke:nn { \tl_use:N \l__tenkz_cell_tl }
+          {
+            \l__tenkz_pa_tl --
+            (\dim_use:N \l__tenkz_cupx_dim, \tenkz_rowy:n {#2})
+            arc[start~angle=90, end~angle=0,
+                x~radius=\tenkz@dim{\tenkz@r@stub},
+                y~radius=\dim_use:N \l__tenkz_cupry_dim]
+            arc[start~angle=0, end~angle=-90,
+                x~radius=\tenkz@dim{\tenkz@r@stub},
+                y~radius=\dim_use:N \l__tenkz_cupry_dim]
+            -- \l__tenkz_pb_tl
+          }
         \tenkz_cup_matrix:nnn {#1}{#2}{ 1 }
       }
       {
-        \draw[\tl_use:N \l__tenkz_cell_tl]
-          \l__tenkz_pa_tl --
-          (\dim_use:N \l__tenkz_cupx_dim, \tenkz_rowy:n {#2})
-          arc[start~angle=90, end~angle=180,
-              x~radius=\tenkz@dim{\tenkz@r@stub},
-              y~radius=\dim_use:N \l__tenkz_cupry_dim]
-          arc[start~angle=180, end~angle=270,
-              x~radius=\tenkz@dim{\tenkz@r@stub},
-              y~radius=\dim_use:N \l__tenkz_cupry_dim]
-          -- \l__tenkz_pb_tl;
+        \__tenkz_render_stroke:nn { \tl_use:N \l__tenkz_cell_tl }
+          {
+            \l__tenkz_pa_tl --
+            (\dim_use:N \l__tenkz_cupx_dim, \tenkz_rowy:n {#2})
+            arc[start~angle=90, end~angle=180,
+                x~radius=\tenkz@dim{\tenkz@r@stub},
+                y~radius=\dim_use:N \l__tenkz_cupry_dim]
+            arc[start~angle=180, end~angle=270,
+                x~radius=\tenkz@dim{\tenkz@r@stub},
+                y~radius=\dim_use:N \l__tenkz_cupry_dim]
+            -- \l__tenkz_pb_tl
+          }
         \tenkz_cup_matrix:nnn {#1}{#2}{ -1 }
       }
     \tenkz@event{cup|picture=\the\tenkz@pictureid|side=#1|top=#2|bottom=#3|matrix=\tl_if_empty:NTF \l__tenkz_cupmat_tl {0}{1}}
   }
+\cs_generate_variant:Nn \tenkz_draw_cup:nnn { VVV }
 
 % the on-bend fixed-point matrix: a filled dot ON the bend apex, its label
 % OUTSIDE the bend, one clearance band beyond the dot on the side the bend
@@ -5195,23 +5288,24 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
   {
     \tl_if_blank:VF \l__tenkz_cupmat_tl
       {
-        \node[tensor]
-          (tzcup\the\tenkz@pictureid-#1-#2)
-          at (\dim_eval:n{ \l__tenkz_cupx_dim
-                           + \tenkz@dim{\tenkz@r@stub} * (#3) },
-              \dim_use:N \l__tenkz_y_dim) {};
+        \__tenkz_render_atom_named_pt:nnnn
+          { \dim_eval:n{ \l__tenkz_cupx_dim
+                         + \tenkz@dim{\tenkz@r@stub} * (#3) } }
+          { \dim_use:N \l__tenkz_y_dim }
+          { tzcup\the\tenkz@pictureid-#1-#2 }
+          { tensor }
         \str_if_eq:nnTF {#1}{east}
           {
-            \node[tn~label, anchor=west] at
-              ($(tzcup\the\tenkz@pictureid-#1-#2.east)
-                +(\tenkz@dim{\tenkz@r@labelclear},0)$)
-              { \tl_use:N \l__tenkz_cupmat_tl };
+            \__tenkz_render_labelnode:nnn { tn~label, anchor=west }
+              { ($(tzcup\the\tenkz@pictureid-#1-#2.east)
+                 +(\tenkz@dim{\tenkz@r@labelclear},0)$) }
+              { \tl_use:N \l__tenkz_cupmat_tl }
           }
           {
-            \node[tn~label, anchor=east] at
-              ($(tzcup\the\tenkz@pictureid-#1-#2.west)
-                +(-\tenkz@dim{\tenkz@r@labelclear},0)$)
-              { \tl_use:N \l__tenkz_cupmat_tl };
+            \__tenkz_render_labelnode:nnn { tn~label, anchor=east }
+              { ($(tzcup\the\tenkz@pictureid-#1-#2.west)
+                 +(-\tenkz@dim{\tenkz@r@labelclear},0)$) }
+              { \tl_use:N \l__tenkz_cupmat_tl }
           }
       }
   }
@@ -5412,31 +5506,32 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
       { \bool_set_true:N #3 }
   }
 
+\tl_new:N \l__tenkz_phcol_tl
+\tl_new:N \l__tenkz_phsupported_tl
+\tl_new:N \l__tenkz_ptrow_tl
+\cs_generate_variant:Nn \msg_warning:nnnn { nnnV }
 \cs_new_protected:Npn \tenkz_draw_phtrace:
   {
     \bool_if:NT \l__tenkz_ptrace_bool
       {
         \int_compare:nNnTF { \l__tenkz_nrows_int } = {1}
-          {
-            \int_step_inline:nnn {1} { \l__tenkz_ncols_int }
-              {
-                \bool_lazy_and:nnT
-                  { \tenkz_openup_p:n {1} }
-                  { \tenkz_opendown_p:n {1} }
-                  { \tenkz_leg_candidate:nnT {1}{##1}
-                      {
-                        \tenkz_phtrace_supported:nnN {1}{##1} \l_tmpa_bool
-                        \bool_if:NTF \l_tmpa_bool
-                          { \tenkz_phtrace_site:n {##1} }
-                          {
-                            \msg_warning:nnnn {tenkz}{phtrace-face-ports}
-                              {1}{##1}
-                            \tenkz@event{warning|picture=\the\tenkz@pictureid|code=phtrace-face-ports|cell=1-##1}
-                          }
-                      } }
-              }
-          }
+          { \__tenkz_model_map_wires_origin:nN {phtrace}
+              \tenkz_draw_phtrace_one:n }
           { \msg_warning:nn {tenkz}{phtrace-multirow} }
+      }
+  }
+% one phtrace record: supported sites ink the loop, unsupported sites keep
+% the coded warning the legacy pass emitted at the same stream position
+\cs_new_protected:Npn \tenkz_draw_phtrace_one:n #1
+  {
+    \__tenkz_model_get:nnN {#1} {col} \l__tenkz_phcol_tl
+    \__tenkz_model_get:nnN {#1} {supported} \l__tenkz_phsupported_tl
+    \str_if_eq:VnTF \l__tenkz_phsupported_tl {1}
+      { \tenkz_phtrace_site:V \l__tenkz_phcol_tl }
+      {
+        \msg_warning:nnnV {tenkz}{phtrace-face-ports}
+          {1} \l__tenkz_phcol_tl
+        \tenkz@event{warning|picture=\the\tenkz@pictureid|code=phtrace-face-ports|cell=1-\tl_use:N \l__tenkz_phcol_tl}
       }
   }
 
@@ -5457,13 +5552,16 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
     % legs live on the glyph's vertical centre line
     \pgfextractx \l__tenkz_tallx_dim
       { \exp_args:Ne \pgfpointanchor { \l__tenkz_pa_tl } {north} }
-    \draw[trace]
-      (\dim_use:N \l__tenkz_tallx_dim, \dim_use:N \l__tenkz_tmp_dim) --
-      (\dim_use:N \l__tenkz_x_dim,     \dim_use:N \l__tenkz_tmp_dim) --
-      (\dim_use:N \l__tenkz_x_dim,     \dim_use:N \l__tenkz_y_dim) --
-      (\dim_use:N \l__tenkz_tallx_dim, \dim_use:N \l__tenkz_y_dim);
+    \__tenkz_render_stroke:nn { trace }
+      {
+        (\dim_use:N \l__tenkz_tallx_dim, \dim_use:N \l__tenkz_tmp_dim) --
+        (\dim_use:N \l__tenkz_x_dim,     \dim_use:N \l__tenkz_tmp_dim) --
+        (\dim_use:N \l__tenkz_x_dim,     \dim_use:N \l__tenkz_y_dim) --
+        (\dim_use:N \l__tenkz_tallx_dim, \dim_use:N \l__tenkz_y_dim)
+      }
     \tenkz@event{phtrace|picture=\the\tenkz@pictureid|row=1|col=#1}
   }
+\cs_generate_variant:Nn \tenkz_phtrace_site:n { V }
 
 % -- pair trace (the trace= physical cell-set) ----------------------------
 % Per traced column, the wrap loop IS the partial trace over that site's
@@ -5478,21 +5576,13 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
 % (no junction); the caps are circular (radius = reach/2), so every join
 % is tangent-continuous.
 \cs_new_protected:Npn \tenkz_draw_pairtrace:
+  { \__tenkz_model_map_wires_origin:nN {pairtrace}
+      \tenkz_draw_pairtrace_one:n }
+\cs_new_protected:Npn \tenkz_draw_pairtrace_one:n #1
   {
-    \int_step_inline:nn { \l__tenkz_nrows_int }
-      {
-        \int_step_inline:nnn {1} { \l__tenkz_ncols_int }
-          {
-            \prop_if_in:NeT \l__tenkz_trcell_prop {##1-####1}
-              {
-                \tenkz_leg_candidate:nnT {##1}{####1}
-                  {
-                    \tenkz_leg_candidate:nnT { \int_eval:n{##1+1} }{####1}
-                      { \tenkz_pairtrace_site:nn {##1}{####1} }
-                  }
-              }
-          }
-      }
+    \__tenkz_model_get:nnN {#1} {row} \l__tenkz_ptrow_tl
+    \__tenkz_model_get:nnN {#1} {col} \l__tenkz_phcol_tl
+    \tenkz_pairtrace_site:VV \l__tenkz_ptrow_tl \l__tenkz_phcol_tl
   }
 
 % one column's wrap loop: ket up-leg tip -> stadium cap east -> down past
@@ -5516,18 +5606,21 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
       { \exp_args:Ne \pgfpointanchor { \l__tenkz_pa_tl } {north} }
     \dim_set:Nn \l__tenkz_x_dim
       { \l__tenkz_tallx_dim + \tenkz@dim{\tenkz@r@pairtracereach} }
-    \draw[trace]
-      (\l__tenkz_pa_tl.north) --
-      (\dim_use:N \l__tenkz_tallx_dim, \dim_use:N \l__tenkz_tmp_dim)
-      arc[start~angle=180, end~angle=0,
-          radius=\dim_eval:n { \tenkz@dim{\tenkz@r@pairtracereach} / 2 }]
-      --
-      (\dim_use:N \l__tenkz_x_dim, \dim_use:N \l__tenkz_y_dim)
-      arc[start~angle=360, end~angle=180,
-          radius=\dim_eval:n { \tenkz@dim{\tenkz@r@pairtracereach} / 2 }]
-      -- (\l__tenkz_pb_tl.south);
+    \__tenkz_render_stroke:nn { trace }
+      {
+        (\l__tenkz_pa_tl.north) --
+        (\dim_use:N \l__tenkz_tallx_dim, \dim_use:N \l__tenkz_tmp_dim)
+        arc[start~angle=180, end~angle=0,
+            radius=\dim_eval:n { \tenkz@dim{\tenkz@r@pairtracereach} / 2 }]
+        --
+        (\dim_use:N \l__tenkz_x_dim, \dim_use:N \l__tenkz_y_dim)
+        arc[start~angle=360, end~angle=180,
+            radius=\dim_eval:n { \tenkz@dim{\tenkz@r@pairtracereach} / 2 }]
+        -- (\l__tenkz_pb_tl.south)
+      }
     \tenkz@event{pairtrace|picture=\the\tenkz@pictureid|row=\int_eval:n{#1}|col=#2}
   }
+\cs_generate_variant:Nn \tenkz_pairtrace_site:nn { VV }
 
 % -- periodic closure ---------------------------------------------------
 \msg_new:nnn { tenkz } { periodic-face-ports }
@@ -5661,14 +5754,14 @@ code=periodic-face-ports|row=\int_eval:n{#1}}
       }
   }
 
+\tl_new:N \l__tenkz_wrapside_tl
 \cs_new_protected:Npn \tenkz_draw_trace:
+  { \__tenkz_model_map_wires_origin:nN {wrap} \tenkz_draw_trace_one:n }
+\cs_new_protected:Npn \tenkz_draw_trace_one:n #1
   {
-    \int_compare:nNnTF { \l__tenkz_nrows_int } = {1}
-      { \tenkz_trace_row:nn {1}{below} }
-      {
-        \tenkz_trace_row:nn {1}{above}
-        \tenkz_trace_row:nn {\l__tenkz_nrows_int}{below}
-      }
+    \__tenkz_model_get:nnN {#1} {row}  \l__tenkz_ptrow_tl
+    \__tenkz_model_get:nnN {#1} {side} \l__tenkz_wrapside_tl
+    \tenkz_trace_row:VV \l__tenkz_ptrow_tl \l__tenkz_wrapside_tl
   }
 
 \cs_new_protected:Npn \tenkz_trace_row:nn #1#2
@@ -5745,15 +5838,17 @@ code=periodic-face-ports|row=\int_eval:n{#1}}
         \tl_put_right:Ne \l_tmpa_tl { -- \tenkz_mpt: }
         \tenkz_map:nn { \l__tenkz_tmp_dim } { \tenkz_rowy:n {#1} }
         \tl_put_right:Ne \l_tmpa_tl { -- \tenkz_mpt: }
-        \draw[trace, \tl_use:N \l__tenkz_cell_tl,
-              \tl_use:N \l__tenkz_dirmarks_tl]
-          \l_tmpa_tl -- \l__tenkz_pb_tl;
+        \__tenkz_render_stroke:nn
+          { trace, \tl_use:N \l__tenkz_cell_tl,
+            \tl_use:N \l__tenkz_dirmarks_tl }
+          { \l_tmpa_tl -- \l__tenkz_pb_tl }
         % row=... must write a NUMBER: #1 may be the nrows register, and
         % an unexpandable register token would land verbatim in the log
         \tenkz@event{trace|picture=\the\tenkz@pictureid|row=\int_eval:n{#1}|side=#2}
           }
       }
   }
+\cs_generate_variant:Nn \tenkz_trace_row:nn { VV }
 
 % -- periodic closure, hooks style --------------------------------------
 % The truncated half-hook closure of the RMP O_L figure (arXiv:2011.12127
@@ -5774,13 +5869,12 @@ code=periodic-face-ports|row=\int_eval:n{#1}}
 % word's hooks wrap over the top and under the bottom toward the page's
 % east margin, as in the reference figure.
 \cs_new_protected:Npn \tenkz_draw_hooks:
+  { \__tenkz_model_map_wires_origin:nN {wrap} \tenkz_draw_hooks_one:n }
+\cs_new_protected:Npn \tenkz_draw_hooks_one:n #1
   {
-    \int_compare:nNnTF { \l__tenkz_nrows_int } = {1}
-      { \tenkz_hook_row:nn {1}{below} }
-      {
-        \tenkz_hook_row:nn {1}{above}
-        \tenkz_hook_row:nn {\l__tenkz_nrows_int}{below}
-      }
+    \__tenkz_model_get:nnN {#1} {row}  \l__tenkz_ptrow_tl
+    \__tenkz_model_get:nnN {#1} {side} \l__tenkz_wrapside_tl
+    \tenkz_hook_row:VV \l__tenkz_ptrow_tl \l__tenkz_wrapside_tl
   }
 
 % hooks of row #1, bending toward side #2 (below|above, logical frame).
@@ -5828,12 +5922,15 @@ code=periodic-face-ports|row=\int_eval:n{#1}}
 % hook needs no absolute coordinates beyond the anchor.
 \cs_new_protected:Npn \tenkz_hook_end:Nnnn #1#2#3#4
   {
-    \draw[trace, \tl_use:N \l__tenkz_cell_tl]
-      #1 -- ++\tenkz_side_vec:nn {#2} { \tenkz@dim{\tenkz@r@stub} / 2 }
-      arc[start~angle=\tenkz_arcangle:n{#3},
-          end~angle=\tenkz_arcangle:n{#4},
-          radius=\dim_eval:n { \tenkz@dim{\tenkz@r@stub} / 2 }];
+    \__tenkz_render_stroke:nn { trace, \tl_use:N \l__tenkz_cell_tl }
+      {
+        #1 -- ++\tenkz_side_vec:nn {#2} { \tenkz@dim{\tenkz@r@stub} / 2 }
+        arc[start~angle=\tenkz_arcangle:n{#3},
+            end~angle=\tenkz_arcangle:n{#4},
+            radius=\dim_eval:n { \tenkz@dim{\tenkz@r@stub} / 2 }]
+      }
   }
+\cs_generate_variant:Nn \tenkz_hook_row:nn { VV }
 
 % ---------- public entry points ----------
 \NewDocumentEnvironment { tenkz } { O{} +b }

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -1810,7 +1810,7 @@
       }
   }
 % cup pairing for side #1 with row-extent end #2; #3 is the side's on-bend
-% matrix label tl (its emptiness becomes the record's matrix flag)
+% matrix label tl, copied into each derived record for the draw pass
 \cs_new_protected:Npn \tenkz_model_derive_cups_side:nnN #1#2#3
   {
     \seq_clear:N \l_tmpa_seq
@@ -1845,7 +1845,7 @@
           {kind={index},origin={cup},side={#1},
            top={\l_tmpa_tl},bottom={\l_tmpb_tl},
            name={cup-\l_tmpa_tl-\l_tmpb_tl},
-           matrix={\tl_if_blank:VTF #3 {0}{1}}}
+           matrix={\exp_not:V #3}}
         \prop_put:Nen \l__tenkz_cuprow_prop { #1 - \l_tmpa_tl } {}
         \prop_put:Nen \l__tenkz_cuprow_prop { #1 - \l_tmpb_tl } {}
       }
@@ -5198,12 +5198,13 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
 \tl_new:N \l__tenkz_cupbot_tl
 \cs_new_protected:Npn \tenkz_draw_cups:
   { \__tenkz_model_map_wires_origin:nN {cup} \tenkz_draw_cup:n }
-% draw one cup from its wire record: fields side, top, bottom
+% draw one cup from its wire record: fields side, top, bottom, matrix
 \cs_new_protected:Npn \tenkz_draw_cup:n #1
   {
     \__tenkz_model_get:nnN {#1} {side}   \l__tenkz_cupside_tl
     \__tenkz_model_get:nnN {#1} {top}    \l__tenkz_cuptop_tl
     \__tenkz_model_get:nnN {#1} {bottom} \l__tenkz_cupbot_tl
+    \__tenkz_model_get:nnN {#1} {matrix} \l__tenkz_cupmat_tl
     \tenkz_draw_cup:VVV
       \l__tenkz_cupside_tl \l__tenkz_cuptop_tl \l__tenkz_cupbot_tl
   }
@@ -5230,9 +5231,6 @@ code=label-pos|pos=\tl_to_str:N \l_tmpa_tl}
 \cs_new_protected:Npn \tenkz_draw_cup:nnn #1#2#3
   {
     \tenkz_row_wirestyle:nN {#2} \l__tenkz_cell_tl
-    \str_if_eq:nnTF {#1}{east}
-      { \tl_set_eq:NN \l__tenkz_cupmat_tl \l__tenkz_closeemat_tl }
-      { \tl_set_eq:NN \l__tenkz_cupmat_tl \l__tenkz_closewmat_tl }
     \tenkz_cup_anchor:nnNN {#1}{#2} \l__tenkz_pa_tl \l__tenkz_x_dim
     \tenkz_cup_anchor:nnNN {#1}{#3} \l__tenkz_pb_tl \l__tenkz_tmp_dim
     % common abscissa: the OUTERMOST of the two ends; a shorter row gets a

--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -1443,11 +1443,41 @@
     \tenkzl_guard_window:
     \tenkzl_frame_setup:
     \dim_set:Nn \l__tenkzl_m_dim { \tenkz@r@latticemargin\tenkz@pitch }
+    % The lattice writes its record layer once the window, sheets, and
+    % frame are final: the picture and frame records plus one atom record
+    % per surviving site, in draw order (sheet-major, bottom sheet first).
+    % Edge and region records land with the corridor follow-up; until the
+    % lattice renderer consumes records, this store changes no emission.
+    \__tenkz_model_reset:
+    \__tenkz_model_record_picture:n { lang={lattice} }
+    \__tenkz_model_record_frame:e
+      { map={lattice},
+        rows={\int_use:N \l__tenkzl_nrows_int},
+        cols={\int_use:N \l__tenkzl_ncols_int},
+        sheets={\int_use:N \l__tenkzl_sheets_int} }
+    \tenkzl_model_record_sites:
+    \__tenkz_model_validate:
     \begin{tikzpicture}[tenkz~every~picture]
       \pgfsetlayers{background,main,tenkz-lattice-labels}
       \tenkzl_draw_all:
     \end{tikzpicture}
     \group_end:
+  }
+
+% site atom records, sheet-major in the sheet passes' bottom-up order
+\cs_new_protected:Npn \tenkzl_model_record_sites:
+  {
+    \int_step_inline:nnn {0} { \l__tenkzl_sheets_int - 1 }
+      {
+        \tenkzl_select_sheet:n {##1}
+        \tenkzl_foreach_surviving:N \tenkzl_model_record_site:nn
+      }
+  }
+\cs_new_protected:Npn \tenkzl_model_record_site:nn #1#2
+  {
+    \__tenkz_model_record_atom:e
+      { kind={site},
+        cell={#1-#2-\int_use:N \l__tenkzl_sheet_int} }
   }
 
 % one full genre pass over the CURRENT sheet (selected by

--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -889,9 +889,10 @@
   {
     \tenkzl_site_save:nn {#1}{#2}
     \tenkzl_site:nn {#3}{#4}
-    \draw[#5]
+    \__tenkz_render_stroke:nn {#5}
+      {
       ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_qy_dim ) --
-      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) ;
+      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
   }
 
 % ---------- sheet near-coincidence guard (every sheets>1 picture) ----------
@@ -2186,7 +2187,8 @@
           { \tenkz@dim{\tenkz@r@boundaryleg} }
           \l__tenkzl_cupbtx_dim \l__tenkzl_cupbty_dim
         \tenkzl_side_cup_corridor:nnn {#1}{#2}{#3}
-        \draw[tenkz~lattice~cup]
+        \__tenkz_render_stroke:nn {tenkz~lattice~cup}
+      {
           (\dim_use:N \l__tenkzl_cupatx_dim,\dim_use:N \l__tenkzl_cupaty_dim) --
           (\dim_use:N \l__tenkzl_cupalx_dim,\dim_use:N \l__tenkzl_cupaly_dim)
           .. controls
@@ -2196,7 +2198,7 @@
           ..
           (\dim_use:N \l__tenkzl_cupblx_dim,\dim_use:N \l__tenkzl_cupbly_dim)
           --
-          (\dim_use:N \l__tenkzl_cupbtx_dim,\dim_use:N \l__tenkzl_cupbty_dim);
+          (\dim_use:N \l__tenkzl_cupbtx_dim,\dim_use:N \l__tenkzl_cupbty_dim)}
         % Publish the line endpoints and Bezier controls.  The curve lies in
         % their convex hull, so every later directional silhouette bounds the
         % complete rendered cup without reverse-engineering its corridor.
@@ -2214,14 +2216,16 @@
           \l__tenkzl_cupbtx_dim \l__tenkzl_cupbty_dim
         % Both plain endpoint stubs render after the haloed connector, so its
         % round preaction caps cannot nick either sheet wire.
-        \draw[bond]
+        \__tenkz_render_stroke:nn {bond}
+      {
           (\dim_use:N \l__tenkzl_cupax_dim,\dim_use:N \l__tenkzl_cupay_dim) --
           (\dim_use:N \l__tenkzl_cupasx_dim,\dim_use:N \l__tenkzl_cupasy_dim) --
-          (\dim_use:N \l__tenkzl_cupatx_dim,\dim_use:N \l__tenkzl_cupaty_dim);
-        \draw[bond]
+          (\dim_use:N \l__tenkzl_cupatx_dim,\dim_use:N \l__tenkzl_cupaty_dim)}
+        \__tenkz_render_stroke:nn {bond}
+      {
           (\dim_use:N \l__tenkzl_cupbtx_dim,\dim_use:N \l__tenkzl_cupbty_dim) --
           (\dim_use:N \l__tenkzl_cupbsx_dim,\dim_use:N \l__tenkzl_cupbsy_dim) --
-          (\dim_use:N \l__tenkzl_cupbx_dim,\dim_use:N \l__tenkzl_cupby_dim);
+          (\dim_use:N \l__tenkzl_cupbx_dim,\dim_use:N \l__tenkzl_cupby_dim)}
         \tl_if_blank:VF \l__tenkzl_tmp_tl
           { \tenkzl_draw_side_cup_matrix:nnn {#1}{#2}{#3} }
         \tenkz@event{cup|picture=\the\tenkz@pictureid|lang=lattice|%
@@ -2236,9 +2240,10 @@
     \tenkzl_side_point:nnnnnNN {#1}{#2}{#3}{#4}
       { \tenkz@dim{\tenkz@r@boundaryleg} }
       \l__tenkzl_cupatx_dim \l__tenkzl_cupaty_dim
-    \draw[bond]
+    \__tenkz_render_stroke:nn {bond}
+      {
       (\dim_use:N \l__tenkzl_cupax_dim,\dim_use:N \l__tenkzl_cupay_dim) --
-      (\dim_use:N \l__tenkzl_cupatx_dim,\dim_use:N \l__tenkzl_cupaty_dim);
+      (\dim_use:N \l__tenkzl_cupatx_dim,\dim_use:N \l__tenkzl_cupaty_dim)}
     \tenkzl_record_obstacle_point:NN
       \l__tenkzl_cupax_dim \l__tenkzl_cupay_dim
     \tenkzl_record_obstacle_point:NN
@@ -2254,19 +2259,22 @@
   {
     \tl_set:Ne \l__tenkzl_cupnode_tl
       {tzl-cup-\the\tenkz@pictureid-#1-\int_eval:n{#2}-\int_eval:n{#3}}
-    \node[tensor] (\l__tenkzl_cupnode_tl) at
-      ( \dim_eval:n
+    \__tenkz_render_labelnode_named:nnnn {tensor}
+      {\l__tenkzl_cupnode_tl}
+      { ( \dim_eval:n
           { ( \l__tenkzl_cupalx_dim + 3 \l__tenkzl_cupacx_dim
               + 3 \l__tenkzl_cupbcx_dim + \l__tenkzl_cupblx_dim ) / 8 } ,
         \dim_eval:n
           { ( \l__tenkzl_cupaly_dim + 3 \l__tenkzl_cupacy_dim
-              + 3 \l__tenkzl_cupbcy_dim + \l__tenkzl_cupbly_dim ) / 8 } ) {};
+              + 3 \l__tenkzl_cupbcy_dim + \l__tenkzl_cupbly_dim ) / 8 } ) }
+      {}
     \tenkzl_record_obstacle_bbox:n {\l__tenkzl_cupnode_tl}
-    \node[tn~label,anchor=center] (tenkzl-cup-label-probe) at
-      ($(\l__tenkzl_cupnode_tl.center)
+    \__tenkz_render_labelnode_named:nnnn {tn~label,anchor=center}
+      {tenkzl-cup-label-probe}
+      { ($(\l__tenkzl_cupnode_tl.center)
         +(\dim_use:N \l__tenkzl_cuplabeldx_dim,
-          \dim_use:N \l__tenkzl_cuplabeldy_dim)$)
-      {\box_use:N \l__tenkzl_cuplabel_box};
+          \dim_use:N \l__tenkzl_cuplabeldy_dim)$) }
+      {\box_use:N \l__tenkzl_cuplabel_box}
     \tenkzl_record_obstacle_bbox:n {tenkzl-cup-label-probe}
   }
 
@@ -2639,20 +2647,23 @@
     \tenkzl_side_cup_from_projections:NNNN
       \l__tenkzl_trlane_dim \l__tenkzl_trtransb_dim
       \l__tenkzl_trblx_dim \l__tenkzl_trbly_dim
-    \draw[tenkz~lattice~side~trace]
+    \__tenkz_render_stroke:nn {tenkz~lattice~side~trace}
+      {
       (\dim_use:N \l__tenkzl_tratx_dim,\dim_use:N \l__tenkzl_traty_dim) --
       (\dim_use:N \l__tenkzl_tralx_dim,\dim_use:N \l__tenkzl_traly_dim) --
       (\dim_use:N \l__tenkzl_trblx_dim,\dim_use:N \l__tenkzl_trbly_dim) --
-      (\dim_use:N \l__tenkzl_trbtx_dim,\dim_use:N \l__tenkzl_trbty_dim);
+      (\dim_use:N \l__tenkzl_trbtx_dim,\dim_use:N \l__tenkzl_trbty_dim)}
     % Plain endpoint stubs follow the haloed return path, preserving both caps.
-    \draw[bond]
+    \__tenkz_render_stroke:nn {bond}
+      {
       (\dim_use:N \l__tenkzl_trax_dim,\dim_use:N \l__tenkzl_tray_dim) --
       (\dim_use:N \l__tenkzl_trasx_dim,\dim_use:N \l__tenkzl_trasy_dim) --
-      (\dim_use:N \l__tenkzl_tratx_dim,\dim_use:N \l__tenkzl_traty_dim);
-    \draw[bond]
+      (\dim_use:N \l__tenkzl_tratx_dim,\dim_use:N \l__tenkzl_traty_dim)}
+    \__tenkz_render_stroke:nn {bond}
+      {
       (\dim_use:N \l__tenkzl_trbtx_dim,\dim_use:N \l__tenkzl_trbty_dim) --
       (\dim_use:N \l__tenkzl_trbsx_dim,\dim_use:N \l__tenkzl_trbsy_dim) --
-      (\dim_use:N \l__tenkzl_trbx_dim,\dim_use:N \l__tenkzl_trby_dim);
+      (\dim_use:N \l__tenkzl_trbx_dim,\dim_use:N \l__tenkzl_trby_dim)}
     \tenkz@event{trace|picture=\the\tenkz@pictureid|lang=lattice|%
       axis=#1-#2|sheet=\int_eval:n {\l__tenkzl_trsheet_int}|%
       slot=\int_eval:n {\l__tenkzl_trslot_int}|%
@@ -2752,10 +2763,11 @@
           \l__tenkzl_tratx_dim \l__tenkzl_traty_dim
           \l__tenkzl_trasx_dim \l__tenkzl_trasy_dim
       }
-    \draw[bond]
+    \__tenkz_render_stroke:nn {bond}
+      {
       (\dim_use:N \l__tenkzl_trax_dim,\dim_use:N \l__tenkzl_tray_dim) --
       (\dim_use:N \l__tenkzl_trasx_dim,\dim_use:N \l__tenkzl_trasy_dim) --
-      (\dim_use:N \l__tenkzl_tratx_dim,\dim_use:N \l__tenkzl_traty_dim);
+      (\dim_use:N \l__tenkzl_tratx_dim,\dim_use:N \l__tenkzl_traty_dim)}
   }
 
 \cs_new_protected:Npn \tenkzl_draw_trace_side_stubs:n #1
@@ -3062,8 +3074,9 @@
         % The metric radius is the fallback.  Semantic style extensions from
         % the execute-once environment body arrive through #1 and must remain
         % free to replace it.
-        \draw[ rounded~corners=\tenkz@dim{0.10}, #1,
-               even~odd~rule ] \l__tenkzl_path_tl ;
+        \__tenkz_render_stroke:nn { rounded~corners=\tenkz@dim{0.10}, #1,
+               even~odd~rule }
+      { \l__tenkzl_path_tl }
       }
   }
 
@@ -3208,23 +3221,24 @@
       {
         \tenkzl_xyz:nnnNN {#1}{#2}{#3} \l__tenkzl_qx_dim \l__tenkzl_qy_dim
         \tenkzl_xyz:nnnNN {#4}{#5}{#6} \l__tenkzl_px_dim \l__tenkzl_py_dim
-        \draw[#7]
+        \__tenkz_render_stroke:nn {#7}
+      {
           ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_qy_dim ) --
-          ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) ;
+          ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
         % the label rides the midpoint, one clearance band to the
         % north-east (clears the stroke on every frame; the label node
         % itself never shears)
         \tl_if_blank:nF {#8}
           {
-            \node[tn~label, anchor=south~west]
-              (tenkzl-edge-label-probe) at
-              ( \dim_eval:n
+            \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=south~west}
+      {tenkzl-edge-label-probe}
+      { ( \dim_eval:n
                   { ( \l__tenkzl_qx_dim + \l__tenkzl_px_dim ) / 2
                     + \tenkz@dim{\tenkz@r@labelclear} } ,
                 \dim_eval:n
                   { ( \l__tenkzl_qy_dim + \l__tenkzl_py_dim ) / 2
-                    + \tenkz@dim{\tenkz@r@labelclear} } )
-              {#8};
+                    + \tenkz@dim{\tenkz@r@labelclear} } ) }
+      {#8}
             \tenkzl_record_obstacle_bbox:n {tenkzl-edge-label-probe}
           }
         % the audit rebuilds region set-algebra from these events (a
@@ -3281,9 +3295,10 @@
     % the comma is LITERAL: pgfkeys splits the option
     % list before expanding items, so the tint must be
     % its own item (empty when the site carries no role)
-    \node[\l__tenkzl_skin_tl , \l__tenkzl_stint_tl] at
-      ( \dim_use:N \l__tenkzl_px_dim ,
-        \dim_use:N \l__tenkzl_py_dim ) {};
+    \__tenkz_render_labelnode:nnn {\l__tenkzl_skin_tl , \l__tenkzl_stint_tl}
+      { ( \dim_use:N \l__tenkzl_px_dim ,
+        \dim_use:N \l__tenkzl_py_dim ) }
+      {}
   }
 \cs_new_protected:Npn \tenkzl_sites_ink:
   {
@@ -3321,12 +3336,13 @@
     % physical index points out of the sheet and never
     % shears (RMP sec2fig4b), so only the FOOT is mapped
     \tenkzl_site:nn {#1}{#2}
-    \draw[physical~leg]
+    \__tenkz_render_stroke:nn {physical~leg}
+      {
       ( \dim_use:N \l__tenkzl_px_dim ,
         \dim_use:N \l__tenkzl_py_dim ) --
       ( \dim_use:N \l__tenkzl_px_dim ,
         \dim_eval:n { \l__tenkzl_py_dim
-                      + \tenkz@dim{\tenkz@r@physleg} } );
+                      + \tenkz@dim{\tenkz@r@physleg} } )}
     \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
     \dim_set:Nn \l__tenkzl_qy_dim
       { \l__tenkzl_py_dim + \tenkz@dim{\tenkz@r@physleg} }
@@ -3336,12 +3352,13 @@
       \l__tenkzl_qx_dim \l__tenkzl_qy_dim
     \str_if_eq:VnT \l__tenkzl_physical_tl {updown}
       {
-        \draw[physical~leg]
+        \__tenkz_render_stroke:nn {physical~leg}
+      {
           ( \dim_use:N \l__tenkzl_px_dim ,
             \dim_use:N \l__tenkzl_py_dim ) --
           ( \dim_use:N \l__tenkzl_px_dim ,
             \dim_eval:n { \l__tenkzl_py_dim
-                          - \tenkz@dim{\tenkz@r@physleg} } );
+                          - \tenkz@dim{\tenkz@r@physleg} } )}
         \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
         \dim_set:Nn \l__tenkzl_qy_dim
           { \l__tenkzl_py_dim - \tenkz@dim{\tenkz@r@physleg} }
@@ -3421,9 +3438,10 @@
     \dim_set_eq:NN \l__tenkzl_qy_dim \l__tenkzl_py_dim
     \tenkzl_map:nn { \l__tenkzl_x_dim + \l__tenkzl_dx_dim }
                    { \l__tenkzl_y_dim + \l__tenkzl_dy_dim }
-    \draw[bond]
+    \__tenkz_render_stroke:nn {bond}
+      {
       ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_qy_dim ) --
-      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) ;
+      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
   }
 
 % -- (f) region and site labels ---------------------------------------
@@ -3443,15 +3461,15 @@
       {
         \tenkzl_site:nn {#1}{#2}
         \begin{pgfonlayer}{tenkz-lattice-labels}
-          \node[tn~label, anchor=south~west, fill=tenkzPaper]
-            (tenkzl-site-label-probe) at
-            ( \dim_eval:n { \l__tenkzl_px_dim
+          \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=south~west, fill=tenkzPaper}
+      {tenkzl-site-label-probe}
+      { ( \dim_eval:n { \l__tenkzl_px_dim
                             + \tenkz@dim{\tenkz@r@dotdia} / 2
                             + \tenkz@dim{\tenkz@r@labelclear} } ,
               \dim_eval:n { \l__tenkzl_py_dim
                             + \tenkz@dim{\tenkz@r@dotdia} / 2
-                            + \tenkz@dim{\tenkz@r@labelclear} } )
-            {#4};
+                            + \tenkz@dim{\tenkz@r@labelclear} } ) }
+      {#4}
         \end{pgfonlayer}
         \tenkzl_record_site_label_bbox:nnn {#1}{#2}{#3}
       }
@@ -3587,10 +3605,10 @@
     \tl_set:Ne \l__tenkzl_tmp_tl
       { \bool_if:NTF \l__tenkzl_oblique_bool
           { \tenkzl_flipanchor:n {#1} } {#1} }
-    \node[tn~label, anchor=\l__tenkzl_tmp_tl]
-      (tenkzl-region-label-probe) at
-      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim )
-      { $#6$ };
+    \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=\l__tenkzl_tmp_tl}
+      {tenkzl-region-label-probe}
+      { ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
+      { $#6$ }
     \tenkzl_record_obstacle_bbox:n {tenkzl-region-label-probe}
     % A corner label deliberately occupies the pocket beside its extreme
     % site.  Under an oblique frame its flipped anchor can also meet the one
@@ -3616,10 +3634,10 @@
 \cs_new_protected:Npn \tenkzl_side_label:nnnn #1#2#3#4
   {
     \tenkzl_map:nn {#2} {#3}
-    \node[tn~label, anchor=#1]
-      (tenkzl-region-label-probe) at
-      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim )
-      { $#4$ };
+    \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=#1}
+      {tenkzl-region-label-probe}
+      { ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
+      { $#4$ }
     \tenkzl_record_obstacle_bbox:n {tenkzl-region-label-probe}
   }
 \cs_new_protected:Npn \tenkzl_label_place:nn #1#2
@@ -3668,10 +3686,10 @@
                  + \tenkzl_cx:n{\l__tenkzl_cmax_int} ) / 2 }
               { ( \tenkzl_cy:n{\l__tenkzl_rmin_int}
                  + \tenkzl_cy:n{\l__tenkzl_rmax_int} ) / 2 }
-            \node[tn~label, anchor=center]
-              (tenkzl-region-label-probe) at
-              ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim )
-              { $#2$ };
+            \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=center}
+      {tenkzl-region-label-probe}
+      { ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
+      { $#2$ }
             \tenkzl_record_obstacle_bbox:n {tenkzl-region-label-probe} }
       }
   }
@@ -3850,20 +3868,23 @@
     \tenkzl_ifopen:nnnTF {#1}{#2}{#3}
       {
         \tenkzl_ifacecount_incr:nN {#3} \l__tenkzl_bpo_prop
-        \draw[physical~leg]
+        \__tenkz_render_stroke:nn {physical~leg}
+      {
           ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_qy_dim ) --
           ( \dim_use:N \l__tenkzl_qx_dim ,
-            \dim_eval:n { \l__tenkzl_qy_dim + \tenkz@dim{\tenkz@r@physleg} } );
-        \draw[physical~leg]
+            \dim_eval:n { \l__tenkzl_qy_dim + \tenkz@dim{\tenkz@r@physleg} } )}
+        \__tenkz_render_stroke:nn {physical~leg}
+      {
           ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) --
           ( \dim_use:N \l__tenkzl_px_dim ,
-            \dim_eval:n { \l__tenkzl_py_dim - \tenkz@dim{\tenkz@r@physleg} } );
+            \dim_eval:n { \l__tenkzl_py_dim - \tenkz@dim{\tenkz@r@physleg} } )}
       }
       {
         \tenkzl_ifacecount_incr:nN {#3} \l__tenkzl_bpc_prop
-        \draw[physical~leg]
+        \__tenkz_render_stroke:nn {physical~leg}
+      {
           ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_qy_dim ) --
-          ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) ;
+          ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
       }
   }
 % warn once per open=/trace= key whose interface index exceeds the
@@ -3917,10 +3938,12 @@
     % Endpoint stubs meet the opaque site disks plainly.  Only the exterior
     % return receives the crossing halo; applying it to the whole path would
     % cut a paper-coloured U-shaped scar into both endpoint disks.
-    \draw[trace]
+    \__tenkz_render_stroke:nn {trace}
+      {
       ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) --
-      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_dy_dim );
-    \draw[tenkz~lattice~pair~trace]
+      ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_dy_dim )}
+    \__tenkz_render_stroke:nn {tenkz~lattice~pair~trace}
+      {
       ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_dy_dim )
       arc[start~angle=180, end~angle=0,
           radius=\dim_eval:n { \tenkz@dim{\tenkz@r@planetracereach} / 2 }]
@@ -3929,10 +3952,11 @@
           { \l__tenkzl_qx_dim + \tenkz@dim{\tenkz@r@planetracereach} } ,
         \dim_use:N \l__tenkzl_dx_dim )
       arc[start~angle=360, end~angle=180,
-          radius=\dim_eval:n { \tenkz@dim{\tenkz@r@planetracereach} / 2 }];
-    \draw[trace]
+          radius=\dim_eval:n { \tenkz@dim{\tenkz@r@planetracereach} / 2 }]}
+    \__tenkz_render_stroke:nn {trace}
+      {
       ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_dx_dim ) --
-      ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_qy_dim ) ;
+      ( \dim_use:N \l__tenkzl_qx_dim , \dim_use:N \l__tenkzl_qy_dim ) }
     % The straight return lies between the two east cap endpoints, and each
     % semicircle stays inside the axis-aligned paper-frame bounds below.
     % Publish all four corners so a later directional silhouette contains the
@@ -3997,12 +4021,13 @@
         \int_incr:N \l__tenkzl_bot_int
         \tenkzl_xyz:nnnNN {#1}{#2}{ \l__tenkzl_sheets_int - 1 }
           \l__tenkzl_px_dim \l__tenkzl_py_dim
-        \draw[physical~leg]
+        \__tenkz_render_stroke:nn {physical~leg}
+      {
           ( \dim_use:N \l__tenkzl_px_dim ,
             \dim_use:N \l__tenkzl_py_dim ) --
           ( \dim_use:N \l__tenkzl_px_dim ,
             \dim_eval:n { \l__tenkzl_py_dim
-                          + \tenkz@dim{\tenkz@r@physleg} } );
+                          + \tenkz@dim{\tenkz@r@physleg} } )}
         \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
         \dim_set:Nn \l__tenkzl_qy_dim
           { \l__tenkzl_py_dim + \tenkz@dim{\tenkz@r@physleg} }
@@ -4018,12 +4043,13 @@
         \int_incr:N \l__tenkzl_bob_int
         \tenkzl_xyz:nnnNN {#1}{#2}{0}
           \l__tenkzl_px_dim \l__tenkzl_py_dim
-        \draw[physical~leg]
+        \__tenkz_render_stroke:nn {physical~leg}
+      {
           ( \dim_use:N \l__tenkzl_px_dim ,
             \dim_use:N \l__tenkzl_py_dim ) --
           ( \dim_use:N \l__tenkzl_px_dim ,
             \dim_eval:n { \l__tenkzl_py_dim
-                          - \tenkz@dim{\tenkz@r@physleg} } );
+                          - \tenkz@dim{\tenkz@r@physleg} } )}
         \dim_set_eq:NN \l__tenkzl_qx_dim \l__tenkzl_px_dim
         \dim_set:Nn \l__tenkzl_qy_dim
           { \l__tenkzl_py_dim - \tenkz@dim{\tenkz@r@physleg} }

--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -1477,7 +1477,8 @@
   {
     \__tenkz_model_record_atom:e
       { kind={site},
-        cell={#1-#2-\int_use:N \l__tenkzl_sheet_int} }
+        cell={\tenkz_cs_cellkey:nnn
+          {#1}{#2}{\int_use:N \l__tenkzl_sheet_int}} }
   }
 
 % one full genre pass over the CURRENT sheet (selected by
@@ -3261,14 +3262,14 @@
         \tl_if_blank:nF {#8}
           {
             \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=south~west}
-      {tenkzl-edge-label-probe}
-      { ( \dim_eval:n
-                  { ( \l__tenkzl_qx_dim + \l__tenkzl_px_dim ) / 2
-                    + \tenkz@dim{\tenkz@r@labelclear} } ,
-                \dim_eval:n
-                  { ( \l__tenkzl_qy_dim + \l__tenkzl_py_dim ) / 2
-                    + \tenkz@dim{\tenkz@r@labelclear} } ) }
-      {#8}
+              {tenkzl-edge-label-probe}
+              { ( \dim_eval:n
+                    { ( \l__tenkzl_qx_dim + \l__tenkzl_px_dim ) / 2
+                      + \tenkz@dim{\tenkz@r@labelclear} } ,
+                  \dim_eval:n
+                    { ( \l__tenkzl_qy_dim + \l__tenkzl_py_dim ) / 2
+                      + \tenkz@dim{\tenkz@r@labelclear} } ) }
+              {#8}
             \tenkzl_record_obstacle_bbox:n {tenkzl-edge-label-probe}
           }
         % the audit rebuilds region set-algebra from these events (a
@@ -3491,15 +3492,16 @@
       {
         \tenkzl_site:nn {#1}{#2}
         \begin{pgfonlayer}{tenkz-lattice-labels}
-          \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=south~west, fill=tenkzPaper}
-      {tenkzl-site-label-probe}
-      { ( \dim_eval:n { \l__tenkzl_px_dim
-                            + \tenkz@dim{\tenkz@r@dotdia} / 2
-                            + \tenkz@dim{\tenkz@r@labelclear} } ,
-              \dim_eval:n { \l__tenkzl_py_dim
-                            + \tenkz@dim{\tenkz@r@dotdia} / 2
-                            + \tenkz@dim{\tenkz@r@labelclear} } ) }
-      {#4}
+          \__tenkz_render_labelnode_named:nnnn
+            {tn~label, anchor=south~west, fill=tenkzPaper}
+            {tenkzl-site-label-probe}
+            { ( \dim_eval:n { \l__tenkzl_px_dim
+                              + \tenkz@dim{\tenkz@r@dotdia} / 2
+                              + \tenkz@dim{\tenkz@r@labelclear} } ,
+                \dim_eval:n { \l__tenkzl_py_dim
+                              + \tenkz@dim{\tenkz@r@dotdia} / 2
+                              + \tenkz@dim{\tenkz@r@labelclear} } ) }
+            {#4}
         \end{pgfonlayer}
         \tenkzl_record_site_label_bbox:nnn {#1}{#2}{#3}
       }
@@ -3717,9 +3719,10 @@
               { ( \tenkzl_cy:n{\l__tenkzl_rmin_int}
                  + \tenkzl_cy:n{\l__tenkzl_rmax_int} ) / 2 }
             \__tenkz_render_labelnode_named:nnnn {tn~label, anchor=center}
-      {tenkzl-region-label-probe}
-      { ( \dim_use:N \l__tenkzl_px_dim , \dim_use:N \l__tenkzl_py_dim ) }
-      { $#2$ }
+              {tenkzl-region-label-probe}
+              { ( \dim_use:N \l__tenkzl_px_dim ,
+                  \dim_use:N \l__tenkzl_py_dim ) }
+              { $#2$ }
             \tenkzl_record_obstacle_bbox:n {tenkzl-region-label-probe} }
       }
   }

--- a/tex/tenkz/tenkz-model.code.tex
+++ b/tex/tenkz/tenkz-model.code.tex
@@ -175,6 +175,20 @@
   }
 \cs_generate_variant:Nn \__tenkz_model_wire_by_ends:nnN { ee }
 
+% Apply function #2 (one n-type argument, the wire id) to every wire whose
+% origin field equals #1, in declaration order.  Closure draw passes
+% consume records through this one door.
+\tl_new:N \l__tenkz_model_origin_tl
+\cs_new_protected:Npn \__tenkz_model_map_wires_origin:nN #1#2
+  {
+    \seq_map_inline:Nn \l__tenkz_model_wire_seq
+      {
+        \__tenkz_model_get:nnN {##1} {origin} \l__tenkz_model_origin_tl
+        \str_if_eq:eeT { \tl_use:N \l__tenkz_model_origin_tl } {#1}
+          { #2 {##1} }
+      }
+  }
+
 % Expanding constructors for front ends whose addresses live in counters.
 % The variants route through the current (possibly frozen) base meaning.
 \cs_generate_variant:Nn \__tenkz_model_record_atom:n { e }

--- a/tex/tenkz/tenkz-model.code.tex
+++ b/tex/tenkz/tenkz-model.code.tex
@@ -194,6 +194,7 @@
 \cs_generate_variant:Nn \__tenkz_model_record_atom:n { e }
 \cs_generate_variant:Nn \__tenkz_model_record_mark:n { e }
 \cs_generate_variant:Nn \__tenkz_model_record_wire:n { e }
+\cs_generate_variant:Nn \__tenkz_model_record_frame:n { e }
 
 \ExplSyntaxOff
 \endinput


### PR DESCRIPTION
## What changed

- Derive grid cup, periodic, physical-trace, and pair-trace closures as WIRE records before model validation; draw passes consume those records.
- Route all 30 lattice draw/node sites through render-stage primitives without changing their calibrated geometry or event output.
- Open the lattice model lifecycle and record its picture, projected frame, and surviving sites before validation.
- Tighten the render census from 86 to 47 raw ink tokens outside the render stage (lattice 30 to 0; grid 16 to 7).

This is the first mergeable S3 tranche. It advances #4698; edge/region records and removal of the remaining lattice-owned geometry/policy twins stay on that issue.

## Why

S2 established the shared model, geometry, and renderer, but lattice still owned raw ink and exposed no normalized records. This change gives lattice the same freeze-with-teeth seam as grid and makes the render stage the sole ink authority.

During the rebase, the closure derivation exposed an asymmetric periodic-face edge case: endpoint validation tried to draw an unmatched stub before a TikZ picture existed. The fix separates pure endpoint matching from draw-time warnings and ink, while preserving the warning, open-boundary count, and event order.

## Validation

- `scripts/tenkz_corpus.sh` — 261/261 standalone files compiled and audited
- `TENKZ_CORPUS_JOBS=8 scripts/tenkz_pixelpair.sh origin/main` — 6/6 sentinel pages byte-identical at 300 DPI
- `python3 scripts/test_tenkz_face_ports.py`
- `python3 scripts/test_tenkz_cd_map_labels.py`
- `python3 scripts/test_tenkz_label_overlap.py`
- `python3 scripts/test_tenkz_enclosures.py`
- `python3 scripts/test_tenkz_peps_torus.py`
- `python3 scripts/test_tenkz_index_routing.py`
- `python3 scripts/test_tenkz_tree.py`
- shrink, corpus-provenance, corpus-render, SVG pipeline, and equation-audit checks passed locally

The Playwright-backed equation web check is left to repository Chromium CI because the local checkout has no Playwright module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core diagram closure and rendering paths for grid and lattice; behavior is intended to stay pixel-identical but the surface area is large.
> 
> **Overview**
> Moves **grid** and **lattice** onto the shared model/render stack: closure geometry is decided once in the record phase, and ink goes only through render-stage helpers.
> 
> **Grid** adds `\tenkz_model_derive_closures:` before validation, emitting **WIRE** records for west/east **cups**, **periodic** wraps, **physical trace**, and **pair trace** (replacing `\tenkz_compute_cups:` and inline draw-time pairing). Cup/trace/phtrace/pairtrace/hooks passes iterate those records via `\__tenkz_model_map_wires_origin:nN` and route strokes/nodes through `\__tenkz_render_stroke:`, `\__tenkz_render_atom_*`, and `\__tenkz_render_labelnode_*` instead of raw `\draw`/`\node`.
> 
> **Periodic** mismatches split **pure endpoint matching** (`\tenkz_periodic_endpoints_match:nnnN`) from draw-time warnings and stub ink; mismatches are queued and emitted **before/after** closure draws so warnings do not run outside a `tikzpicture`.
> 
> **Lattice** resets the model store, records picture/frame/surviving **site** atoms, validates, then draws—all former `\draw`/`\node` sites switched to the same render primitives (census: lattice raw ink **30 → 0**, grid **16 → 7**, total **86 → 47**).
> 
> **Model** gains `\__tenkz_model_map_wires_origin:nN` and a frame-record variant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cb08cd0d1d8a6cb26d80cabf043d48eb9b84fe3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->