### PR TITLE
fix(tenkz): close manual doctest followups

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -201,6 +201,7 @@ jobs:
               - 'tex/tenkz/**'
               - 'tests/tenkz/**'
               - 'docs/tenkz/chapters2/**'
+              - 'docs/tenkz/**/*.tex'
               - 'docs/tenkz/manual2.tex'
               - 'docs/tenkz/tenkzmanual2.sty'
               - 'scripts/tenkz_manual_doctest.py'

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -23,6 +23,12 @@ CHAPTERS = ROOT / "docs" / "tenkz" / "chapters2"
 REGISTRY = ROOT / "tex" / "tenkz" / "tenkz-language-registry.tex"
 REFERENCE = CHAPTERS / "generated-language-reference.tex"
 DISPLAY_ENVIRONMENTS = ("tnexample", "tnmultiples", "Verbatim")
+TEX_PRIMITIVE_CONDITIONALS = (
+    "if", "ifcat", "ifnum", "ifdim", "ifodd", "ifvmode", "ifhmode",
+    "ifmmode", "ifinner", "ifvoid", "ifhbox", "ifvbox", "ifx", "ifeof",
+    "iftrue", "iffalse", "ifcase", "ifdefined", "ifcsname", "iffontchar",
+    "ifincsname",
+)
 
 
 @dataclass(frozen=True)
@@ -296,12 +302,6 @@ def _mask_false_branches(
     start_scan = _display_comment_scan(
         _mask_macro_definitions(text, strict=False)
     )
-    primitive_conditionals = (
-        "if", "ifcat", "ifnum", "ifdim", "ifodd", "ifvmode", "ifhmode",
-        "ifmmode", "ifinner", "ifvoid", "ifhbox", "ifvbox", "ifx", "ifeof",
-        "iftrue", "iffalse", "ifcase", "ifdefined", "ifcsname", "iffontchar",
-        "ifincsname",
-    )
     newif_pattern = re.compile(
         r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])"
     )
@@ -337,7 +337,11 @@ def _mask_false_branches(
         ]
         declared_conditionals = [match.group(1) for match in active_newifs]
         known_conditionals = set(
-            (*primitive_conditionals, *inherited_conditionals, *declared_conditionals)
+            (
+                *TEX_PRIMITIVE_CONDITIONALS,
+                *inherited_conditionals,
+                *declared_conditionals,
+            )
         )
         while True:
             additions = {
@@ -629,10 +633,12 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
     )
 
 
-def extract_displayed_examples(path: Path) -> list[Example]:
+def extract_displayed_examples(
+    path: Path, inherited_conditionals: tuple[str, ...] = ()
+) -> list[Example]:
     text = path.read_text(encoding="utf-8")
     scan_text = _mask_inert_tex(
-        text, path.parent, _manual_conditionals()
+        text, path.parent, inherited_conditionals
     )
     begin_pattern = re.compile(
         r"^[ \t]*\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}",
@@ -679,36 +685,53 @@ def extract_displayed_examples(path: Path) -> list[Example]:
 
 def displayed_examples() -> list[Example]:
     examples: list[Example] = []
-    for path in _manual_sources():
-        examples.extend(extract_displayed_examples(path))
+    for path, inherited_conditionals in _manual_source_contexts():
+        examples.extend(extract_displayed_examples(path, inherited_conditionals))
     return examples
 
 
-@cache
-def _manual_conditionals_for(directory: Path) -> tuple[str, ...]:
-    declarations: set[str] = set()
-    for source in directory.rglob("*.tex"):
-        scan = _display_comment_scan(source.read_text(encoding="utf-8"))
-        declarations.update(
-            re.findall(r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])", scan)
+def _conditionals_before(
+    text: str, offset: int, inherited_conditionals: tuple[str, ...]
+) -> tuple[str, ...]:
+    executable = _display_comment_scan(
+        _mask_macro_definitions(
+            _mask_false_branches(text, inherited_conditionals), strict=False
         )
-    return tuple(sorted(declarations))
+    )
+    newif_pattern = re.compile(r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])")
+    let_pattern = re.compile(
+        r"\\let\s*\\(if[A-Za-z@]+)\s*=?\s*\\(if[A-Za-z@]*)"
+        r"(?![A-Za-z@])"
+    )
+    newifs = [
+        match
+        for match in newif_pattern.finditer(executable)
+        if match.start() < offset
+    ]
+    lets = [
+        match for match in let_pattern.finditer(executable) if match.start() < offset
+    ]
+    known = set((*TEX_PRIMITIVE_CONDITIONALS, *inherited_conditionals))
+    known.update(match.group(1) for match in newifs)
+    while True:
+        additions = {
+            match.group(1) for match in lets if match.group(2) in known
+        } - known
+        if not additions:
+            break
+        known.update(additions)
+    return tuple(sorted(known - set(TEX_PRIMITIVE_CONDITIONALS)))
 
 
-def _manual_conditionals() -> tuple[str, ...]:
-    return _manual_conditionals_for(MANUAL_DIR)
-
-
-def _manual_sources() -> list[Path]:
-    pending = [MANUAL]
-    visited: set[Path] = set()
-    inherited_conditionals = _manual_conditionals()
+def _manual_source_contexts() -> list[tuple[Path, tuple[str, ...]]]:
+    pending = [(MANUAL, ())]
+    visited: dict[Path, tuple[str, ...]] = {}
     input_pattern = re.compile(r"\\input(?![A-Za-z@])")
     while pending:
-        source = pending.pop()
+        source, inherited_conditionals = pending.pop()
         if source in visited:
             continue
-        visited.add(source)
+        visited[source] = inherited_conditionals
         raw = source.read_text(encoding="utf-8")
         text = strip_comments(
             _mask_inline_verbatim(
@@ -738,8 +761,17 @@ def _manual_sources() -> list[Path]:
             included = _resolve_tex_file(relative, source.parent)
             if included is None:
                 raise ValueError(f"{source}: missing manual input {relative}")
-            pending.append(included)
-    return sorted(visited)
+            pending.append(
+                (
+                    included,
+                    _conditionals_before(raw, match.start(), inherited_conditionals),
+                )
+            )
+    return sorted(visited.items())
+
+
+def _manual_sources() -> list[Path]:
+    return [source for source, _ in _manual_source_contexts()]
 
 
 def reference_examples() -> list[Example]:

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -288,7 +288,9 @@ def _blank_range(masked: list[str], start: int, end: int) -> None:
 
 def _mask_false_branches(text: str) -> str:
     masked = list(text)
-    scan = strip_comments(_mask_display_environments(text))
+    scan = _display_comment_scan(
+        _mask_macro_definitions(text, strict=False)
+    )
     primitive_conditionals = (
         "if", "ifcat", "ifnum", "ifdim", "ifodd", "ifvmode", "ifhmode",
         "ifmmode", "ifinner", "ifvoid", "ifhbox", "ifvbox", "ifx", "ifeof",
@@ -300,13 +302,24 @@ def _mask_false_branches(text: str) -> str:
     )
     newif_matches = list(newif_pattern.finditer(scan))
     declared_conditionals = [match.group(1) for match in newif_matches]
-    primitive_pattern = "|".join(primitive_conditionals)
     let_pattern = re.compile(
-        rf"\\let\s*\\(if[A-Za-z@]+)\s*=?\s*\\({primitive_pattern})"
+        r"\\let\s*\\(if[A-Za-z@]+)\s*=?\s*\\(if[A-Za-z@]+)"
         r"(?![A-Za-z@])"
     )
     let_matches = list(let_pattern.finditer(scan))
-    aliased_conditionals = [match.group(1) for match in let_matches]
+    known_conditionals = set((*primitive_conditionals, *declared_conditionals))
+    while True:
+        additions = {
+            match.group(1)
+            for match in let_matches
+            if match.group(2) in known_conditionals
+        } - known_conditionals
+        if not additions:
+            break
+        known_conditionals.update(additions)
+    aliased_conditionals = sorted(
+        known_conditionals - set(primitive_conditionals) - set(declared_conditionals)
+    )
     conditionals = (
         *primitive_conditionals,
         *declared_conditionals,
@@ -326,7 +339,11 @@ def _mask_false_branches(text: str) -> str:
     index = 0
     while index < len(tokens):
         token = tokens[index]
-        if token.group(0) != r"\iffalse" or _is_escaped(scan, token.start()):
+        if (
+            token.group(0) != r"\iffalse"
+            or token.start() in declaration_operands
+            or _is_escaped(scan, token.start())
+        ):
             index += 1
             continue
         depth = 1
@@ -345,25 +362,50 @@ def _mask_false_branches(text: str) -> str:
     return "".join(masked)
 
 
-def _tex_file_exists(relative: Path, source_dir: Path) -> bool:
-    roots = [source_dir, MANUAL_DIR, ROOT / "tex" / "tenkz"]
+def _tex_search_roots(source_dir: Path) -> list[tuple[Path, bool]]:
+    roots = [
+        (source_dir, True),
+        (MANUAL_DIR, True),
+        (ROOT / "tex" / "tenkz", True),
+    ]
     for entry in os.environ.get("TEXINPUTS", "").split(":"):
+        recursive = entry.endswith("//")
         normalized = entry.removesuffix("//")
         if normalized:
-            roots.append(Path(normalized))
-    for root in dict.fromkeys(path.resolve() for path in roots if path.is_dir()):
+            roots.append((Path(normalized), recursive))
+    unique: dict[Path, bool] = {}
+    for root, recursive in roots:
+        if root.is_dir():
+            resolved = root.resolve()
+            unique[resolved] = unique.get(resolved, False) or recursive
+    return list(unique.items())
+
+
+def _resolve_tex_file(relative: Path, source_dir: Path) -> Path | None:
+    for root, recursive in _tex_search_roots(source_dir):
         if (root / relative).is_file():
-            return True
-        if any(candidate.is_file() for candidate in root.rglob(relative.as_posix())):
-            return True
-    return False
+            return (root / relative).resolve()
+        if recursive:
+            candidate = next(
+                (
+                    path
+                    for path in root.rglob(relative.as_posix())
+                    if path.is_file()
+                ),
+                None,
+            )
+            if candidate is not None:
+                return candidate.resolve()
+    return None
+
+
+def _tex_file_exists(relative: Path, source_dir: Path) -> bool:
+    return _resolve_tex_file(relative, source_dir) is not None
 
 
 def _mask_inactive_file_branches(text: str, source_dir: Path) -> str:
     masked = list(text)
-    scan = _mask_nonexecuted_tokens(
-        strip_comments(_mask_display_environments(text))
-    )
+    scan = _mask_nonexecuted_tokens(_display_comment_scan(text))
     pattern = re.compile(r"\\IfFileExists(?![A-Za-z@])")
     offset = 0
     while match := pattern.search(scan, offset):
@@ -395,9 +437,15 @@ def _mask_inactive_file_branches(text: str, source_dir: Path) -> str:
     return "".join(masked)
 
 
-def _mask_macro_definitions(text: str) -> str:
+def _display_comment_scan(text: str) -> str:
+    return strip_comments(
+        _mask_inline_verbatim(_mask_display_environments(text))
+    )
+
+
+def _mask_macro_definitions(text: str, *, strict: bool = True) -> str:
     masked = list(text)
-    scan = strip_comments(_mask_display_environments(text))
+    scan = _display_comment_scan(text)
     pattern = re.compile(
         r"\\(?:(?:new|renew|provide)command|(?:g|e|x)?def)\*?(?![A-Za-z@])"
     )
@@ -433,16 +481,22 @@ def _mask_macro_definitions(text: str) -> str:
         if cursor >= len(scan) or scan[cursor] != "{":
             offset = match.end()
             continue
-        end, _ = _read_braced(scan, cursor)
+        try:
+            end, _ = _read_braced(scan, cursor)
+        except ValueError:
+            if strict:
+                raise
+            offset = match.end()
+            continue
         _blank_range(masked, cursor, end)
         offset = end
     return "".join(masked)
 
 
 def _mask_inert_tex(text: str, source_dir: Path) -> str:
-    without_macros = _mask_macro_definitions(text)
-    without_false_branches = _mask_false_branches(without_macros)
-    return _mask_inactive_file_branches(without_false_branches, source_dir)
+    without_false_branches = _mask_false_branches(text)
+    without_macros = _mask_macro_definitions(without_false_branches)
+    return _mask_inactive_file_branches(without_macros, source_dir)
 
 
 def _mask_nonexecuted_tokens(text: str) -> str:
@@ -620,8 +674,8 @@ def _manual_sources() -> list[Path]:
             relative = Path(target)
             if not relative.suffix:
                 relative = relative.with_suffix(".tex")
-            included = (MANUAL_DIR / relative).resolve()
-            if not included.is_file():
+            included = _resolve_tex_file(relative, source.parent)
+            if included is None:
                 raise ValueError(f"{source}: missing manual input {relative}")
             pending.append(included)
     return sorted(visited)

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -295,10 +295,28 @@ def _mask_false_branches(text: str) -> str:
         "iftrue", "iffalse", "ifcase", "ifdefined", "ifcsname", "iffontchar",
         "ifincsname",
     )
-    declared_conditionals = re.findall(
-        r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])", scan
+    newif_pattern = re.compile(
+        r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])"
     )
-    conditionals = (*primitive_conditionals, *declared_conditionals)
+    newif_matches = list(newif_pattern.finditer(scan))
+    declared_conditionals = [match.group(1) for match in newif_matches]
+    primitive_pattern = "|".join(primitive_conditionals)
+    let_pattern = re.compile(
+        rf"\\let\s*\\(if[A-Za-z@]+)\s*=?\s*\\({primitive_pattern})"
+        r"(?![A-Za-z@])"
+    )
+    let_matches = list(let_pattern.finditer(scan))
+    aliased_conditionals = [match.group(1) for match in let_matches]
+    conditionals = (
+        *primitive_conditionals,
+        *declared_conditionals,
+        *aliased_conditionals,
+    )
+    declaration_operands = {
+        match.start(group) - 1
+        for match in (*newif_matches, *let_matches)
+        for group in range(1, len(match.groups()) + 1)
+    }
     tokens = list(
         re.finditer(
             r"\\(?:" + "|".join(conditionals) + r"|fi)(?![A-Za-z@])",
@@ -315,7 +333,10 @@ def _mask_false_branches(text: str) -> str:
         cursor = index + 1
         while cursor < len(tokens) and depth:
             nested = tokens[cursor]
-            if not _is_escaped(scan, nested.start()):
+            if (
+                nested.start() not in declaration_operands
+                and not _is_escaped(scan, nested.start())
+            ):
                 depth += -1 if nested.group(0) == r"\fi" else 1
             cursor += 1
         end = tokens[cursor - 1].end() if depth == 0 else len(text)

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -289,12 +289,16 @@ def _blank_range(masked: list[str], start: int, end: int) -> None:
 def _mask_false_branches(text: str) -> str:
     masked = list(text)
     scan = strip_comments(text)
-    conditionals = (
+    primitive_conditionals = (
         "if", "ifcat", "ifnum", "ifdim", "ifodd", "ifvmode", "ifhmode",
         "ifmmode", "ifinner", "ifvoid", "ifhbox", "ifvbox", "ifx", "ifeof",
         "iftrue", "iffalse", "ifcase", "ifdefined", "ifcsname", "iffontchar",
         "ifincsname",
     )
+    declared_conditionals = re.findall(
+        r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])", scan
+    )
+    conditionals = (*primitive_conditionals, *declared_conditionals)
     tokens = list(
         re.finditer(
             r"\\(?:" + "|".join(conditionals) + r"|fi)(?![A-Za-z@])",
@@ -322,10 +326,13 @@ def _mask_false_branches(text: str) -> str:
 
 def _mask_inactive_file_branches(text: str) -> str:
     masked = list(text)
-    scan = strip_comments(text)
+    scan = _mask_nonexecuted_tokens(strip_comments(text))
     pattern = re.compile(r"\\IfFileExists(?![A-Za-z@])")
     offset = 0
     while match := pattern.search(scan, offset):
+        if _is_escaped(scan, match.start()):
+            offset = match.end()
+            continue
         cursor = _skip_space_and_comments(scan, match.end())
         file_start = cursor
         file_end, filename = _read_braced(scan, file_start)
@@ -333,16 +340,23 @@ def _mask_inactive_file_branches(text: str) -> str:
         true_end, _ = _read_braced(scan, true_start)
         false_start = _skip_space_and_comments(scan, true_end)
         false_end, _ = _read_braced(scan, false_start)
-        relative = Path(filename.strip())
+        normalized_filename = re.sub(r"\s+", "", strip_comments(filename))
+        relative = Path(normalized_filename)
         candidates = [MANUAL_DIR / relative]
         if not relative.suffix:
             candidates.append(MANUAL_DIR / relative.with_suffix(".tex"))
         if any(candidate.is_file() for candidate in candidates):
+            active_start, active_end = true_start, true_end
             _blank_range(masked, match.start(), true_start + 1)
             _blank_range(masked, true_end - 1, false_end)
         else:
+            active_start, active_end = false_start, false_end
             _blank_range(masked, match.start(), false_start + 1)
             _blank_range(masked, false_end - 1, false_end)
+        active = text[active_start + 1 : active_end - 1]
+        masked[active_start + 1 : active_end - 1] = _mask_inactive_file_branches(
+            active
+        )
         offset = false_end
     return "".join(masked)
 

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -29,6 +29,68 @@ TEX_PRIMITIVE_CONDITIONALS = (
     "iftrue", "iffalse", "ifcase", "ifdefined", "ifcsname", "iffontchar",
     "ifincsname",
 )
+LATEX_CORE_CONDITIONAL_FALLBACK = ("if@twocolumn",)
+
+
+@cache
+def _latex_format_conditionals() -> tuple[str, ...]:
+    known = set(LATEX_CORE_CONDITIONAL_FALLBACK)
+    if not shutil.which("kpsewhich") or not shutil.which("xelatex"):
+        return tuple(sorted(known))
+    lookup = subprocess.run(
+        ["kpsewhich", "latex.ltx"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        timeout=15,
+    )
+    source = Path(lookup.stdout.strip())
+    if lookup.returncode != 0 or not source.is_file():
+        return tuple(sorted(known))
+    candidates = sorted(
+        set(re.findall(r"\\(if[A-Za-z@]+)", source.read_text(encoding="utf-8")))
+    )
+    with tempfile.TemporaryDirectory(prefix="tenkz-format-conditionals-") as tmp:
+        work = Path(tmp)
+        probe = work / "probe.tex"
+        lines = [r"\documentclass{article}"]
+        lines.extend(
+            rf"\typeout{{TENKZ-COND-{index}="
+            rf"\expandafter\meaning\csname {name}\endcsname}}"
+            for index, name in enumerate(candidates)
+        )
+        lines.append(r"\stop")
+        probe.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        result = subprocess.run(
+            [
+                "xelatex",
+                "-interaction=batchmode",
+                f"-output-directory={work}",
+                probe.as_posix(),
+            ],
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+        )
+        log = work / "probe.log"
+        if result.returncode != 0 or not log.is_file():
+            return tuple(sorted(known))
+        meanings = {
+            int(index): meaning.strip()
+            for index, meaning in re.findall(
+                r"^TENKZ-COND-(\d+)=(.*)$",
+                log.read_text(encoding="utf-8", errors="replace"),
+                re.MULTILINE,
+            )
+        }
+    primitive_meanings = {rf"\{name}" for name in TEX_PRIMITIVE_CONDITIONALS}
+    known.update(
+        name
+        for index, name in enumerate(candidates)
+        if meanings.get(index) in primitive_meanings
+    )
+    return tuple(sorted(known))
 
 
 @dataclass(frozen=True)
@@ -339,6 +401,7 @@ def _mask_false_branches(
         known_conditionals = set(
             (
                 *TEX_PRIMITIVE_CONDITIONALS,
+                *_latex_format_conditionals(),
                 *inherited_conditionals,
                 *declared_conditionals,
             )
@@ -527,9 +590,12 @@ def _mask_inert_tex(
     source_dir: Path,
     inherited_conditionals: tuple[str, ...] = (),
 ) -> str:
-    without_false_branches = _mask_false_branches(text, inherited_conditionals)
+    selected_file_branches = _mask_inactive_file_branches(text, source_dir)
+    without_false_branches = _mask_false_branches(
+        selected_file_branches, inherited_conditionals
+    )
     without_macros = _mask_macro_definitions(without_false_branches)
-    return _mask_inactive_file_branches(without_macros, source_dir)
+    return without_macros
 
 
 def _mask_nonexecuted_tokens(text: str) -> str:
@@ -691,11 +757,18 @@ def displayed_examples() -> list[Example]:
 
 
 def _conditionals_before(
-    text: str, offset: int, inherited_conditionals: tuple[str, ...]
+    text: str,
+    offset: int,
+    inherited_conditionals: tuple[str, ...],
+    source_dir: Path,
 ) -> tuple[str, ...]:
+    selected_file_branches = _mask_inactive_file_branches(text, source_dir)
     executable = _display_comment_scan(
         _mask_macro_definitions(
-            _mask_false_branches(text, inherited_conditionals), strict=False
+            _mask_false_branches(
+                selected_file_branches, inherited_conditionals
+            ),
+            strict=False,
         )
     )
     newif_pattern = re.compile(r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])")
@@ -764,7 +837,12 @@ def _manual_source_contexts() -> list[tuple[Path, tuple[str, ...]]]:
             pending.append(
                 (
                     included,
-                    _conditionals_before(raw, match.start(), inherited_conditionals),
+                    _conditionals_before(
+                        raw,
+                        match.start(),
+                        inherited_conditionals,
+                        source.parent,
+                    ),
                 )
             )
     return sorted(visited.items())

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -288,7 +288,7 @@ def _blank_range(masked: list[str], start: int, end: int) -> None:
 
 def _mask_false_branches(text: str) -> str:
     masked = list(text)
-    scan = strip_comments(text)
+    scan = strip_comments(_mask_display_environments(text))
     primitive_conditionals = (
         "if", "ifcat", "ifnum", "ifdim", "ifodd", "ifvmode", "ifhmode",
         "ifmmode", "ifinner", "ifvoid", "ifhbox", "ifvbox", "ifx", "ifeof",
@@ -324,9 +324,25 @@ def _mask_false_branches(text: str) -> str:
     return "".join(masked)
 
 
-def _mask_inactive_file_branches(text: str) -> str:
+def _tex_file_exists(relative: Path, source_dir: Path) -> bool:
+    roots = [source_dir, MANUAL_DIR, ROOT / "tex" / "tenkz"]
+    for entry in os.environ.get("TEXINPUTS", "").split(":"):
+        normalized = entry.removesuffix("//")
+        if normalized:
+            roots.append(Path(normalized))
+    for root in dict.fromkeys(path.resolve() for path in roots if path.is_dir()):
+        if (root / relative).is_file():
+            return True
+        if any(candidate.is_file() for candidate in root.rglob(relative.as_posix())):
+            return True
+    return False
+
+
+def _mask_inactive_file_branches(text: str, source_dir: Path) -> str:
     masked = list(text)
-    scan = _mask_nonexecuted_tokens(strip_comments(text))
+    scan = _mask_nonexecuted_tokens(
+        strip_comments(_mask_display_environments(text))
+    )
     pattern = re.compile(r"\\IfFileExists(?![A-Za-z@])")
     offset = 0
     while match := pattern.search(scan, offset):
@@ -342,10 +358,7 @@ def _mask_inactive_file_branches(text: str) -> str:
         false_end, _ = _read_braced(scan, false_start)
         normalized_filename = re.sub(r"\s+", "", strip_comments(filename))
         relative = Path(normalized_filename)
-        candidates = [MANUAL_DIR / relative]
-        if not relative.suffix:
-            candidates.append(MANUAL_DIR / relative.with_suffix(".tex"))
-        if any(candidate.is_file() for candidate in candidates):
+        if _tex_file_exists(relative, source_dir):
             active_start, active_end = true_start, true_end
             _blank_range(masked, match.start(), true_start + 1)
             _blank_range(masked, true_end - 1, false_end)
@@ -354,8 +367,8 @@ def _mask_inactive_file_branches(text: str) -> str:
             _blank_range(masked, match.start(), false_start + 1)
             _blank_range(masked, false_end - 1, false_end)
         active = text[active_start + 1 : active_end - 1]
-        masked[active_start + 1 : active_end - 1] = _mask_inactive_file_branches(
-            active
+        masked[active_start + 1 : active_end - 1] = (
+            _mask_inactive_file_branches(active, source_dir)
         )
         offset = false_end
     return "".join(masked)
@@ -363,7 +376,7 @@ def _mask_inactive_file_branches(text: str) -> str:
 
 def _mask_macro_definitions(text: str) -> str:
     masked = list(text)
-    scan = strip_comments(text)
+    scan = strip_comments(_mask_display_environments(text))
     pattern = re.compile(
         r"\\(?:(?:new|renew|provide)command|(?:g|e|x)?def)\*?(?![A-Za-z@])"
     )
@@ -405,9 +418,10 @@ def _mask_macro_definitions(text: str) -> str:
     return "".join(masked)
 
 
-def _mask_inert_tex(text: str) -> str:
-    active = _mask_inactive_file_branches(text)
-    return _mask_macro_definitions(_mask_false_branches(active))
+def _mask_inert_tex(text: str, source_dir: Path) -> str:
+    without_macros = _mask_macro_definitions(text)
+    without_false_branches = _mask_false_branches(without_macros)
+    return _mask_inactive_file_branches(without_false_branches, source_dir)
 
 
 def _mask_nonexecuted_tokens(text: str) -> str:
@@ -503,7 +517,7 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
 
 def extract_displayed_examples(path: Path) -> list[Example]:
     text = path.read_text(encoding="utf-8")
-    scan_text = _mask_inert_tex(text)
+    scan_text = _mask_inert_tex(text, path.parent)
     begin_pattern = re.compile(
         r"^[ \t]*\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}",
         re.MULTILINE,
@@ -565,7 +579,9 @@ def _manual_sources() -> list[Path]:
         visited.add(source)
         raw = source.read_text(encoding="utf-8")
         text = strip_comments(
-            _mask_inline_verbatim(_mask_display_environments(_mask_inert_tex(raw)))
+            _mask_inline_verbatim(
+                _mask_display_environments(_mask_inert_tex(raw, source.parent))
+            )
         )
         for match in input_pattern.finditer(text):
             if _is_escaped(text, match.start()):

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -216,7 +216,7 @@ def _mask_inline_verbatim(text: str) -> str:
     return "".join(masked)
 
 
-def _extract_usepackages(body: str) -> tuple[list[str], str]:
+def _usepackage_ranges(body: str) -> list[tuple[int, int]]:
     ranges: list[tuple[int, int]] = []
     offset = 0
     marker = r"\usepackage"
@@ -229,7 +229,11 @@ def _extract_usepackages(body: str) -> tuple[list[str], str]:
         end, _ = _read_braced(body, cursor)
         ranges.append((start, end))
         offset = end
+    return ranges
 
+
+def _extract_usepackages(body: str) -> tuple[list[str], str]:
+    ranges = _usepackage_ranges(body)
     packages = [body[start:end].strip() for start, end in ranges]
     chunks: list[str] = []
     offset = 0
@@ -285,7 +289,18 @@ def _blank_range(masked: list[str], start: int, end: int) -> None:
 def _mask_false_branches(text: str) -> str:
     masked = list(text)
     scan = strip_comments(text)
-    tokens = list(re.finditer(r"\\(?:if[A-Za-z@]*|fi)(?![A-Za-z@])", scan))
+    conditionals = (
+        "if", "ifcat", "ifnum", "ifdim", "ifodd", "ifvmode", "ifhmode",
+        "ifmmode", "ifinner", "ifvoid", "ifhbox", "ifvbox", "ifx", "ifeof",
+        "iftrue", "iffalse", "ifcase", "ifdefined", "ifcsname", "iffontchar",
+        "ifincsname",
+    )
+    tokens = list(
+        re.finditer(
+            r"\\(?:" + "|".join(conditionals) + r"|fi)(?![A-Za-z@])",
+            scan,
+        )
+    )
     index = 0
     while index < len(tokens):
         token = tokens[index]
@@ -302,6 +317,33 @@ def _mask_false_branches(text: str) -> str:
         end = tokens[cursor - 1].end() if depth == 0 else len(text)
         _blank_range(masked, token.start(), end)
         index = cursor
+    return "".join(masked)
+
+
+def _mask_inactive_file_branches(text: str) -> str:
+    masked = list(text)
+    scan = strip_comments(text)
+    pattern = re.compile(r"\\IfFileExists(?![A-Za-z@])")
+    offset = 0
+    while match := pattern.search(scan, offset):
+        cursor = _skip_space_and_comments(scan, match.end())
+        file_start = cursor
+        file_end, filename = _read_braced(scan, file_start)
+        true_start = _skip_space_and_comments(scan, file_end)
+        true_end, _ = _read_braced(scan, true_start)
+        false_start = _skip_space_and_comments(scan, true_end)
+        false_end, _ = _read_braced(scan, false_start)
+        relative = Path(filename.strip())
+        candidates = [MANUAL_DIR / relative]
+        if not relative.suffix:
+            candidates.append(MANUAL_DIR / relative.with_suffix(".tex"))
+        if any(candidate.is_file() for candidate in candidates):
+            _blank_range(masked, match.start(), true_start + 1)
+            _blank_range(masked, true_end - 1, false_end)
+        else:
+            _blank_range(masked, match.start(), false_start + 1)
+            _blank_range(masked, false_end - 1, false_end)
+        offset = false_end
     return "".join(masked)
 
 
@@ -350,7 +392,8 @@ def _mask_macro_definitions(text: str) -> str:
 
 
 def _mask_inert_tex(text: str) -> str:
-    return _mask_macro_definitions(_mask_false_branches(text))
+    active = _mask_inactive_file_branches(text)
+    return _mask_macro_definitions(_mask_false_branches(active))
 
 
 def _mask_nonexecuted_tokens(text: str) -> str:
@@ -371,18 +414,17 @@ def _has_executable_command(text: str, command: str) -> bool:
 
 
 def _instrument_command(document: str, command: str) -> tuple[str, str]:
-    packages, _ = _extract_usepackages(document)
-    declaration = next(
+    selected = next(
         (
-            package
-            for package in packages
-            if "tenkz" in _package_names(package)
+            (start, end)
+            for start, end in _usepackage_ranges(document)
+            if "tenkz" in _package_names(document[start:end])
         ),
         None,
     )
-    if declaration is None:
+    if selected is None:
         raise ValueError(f"reference for \\{command} does not load tenkz")
-    end = document.find(declaration) + len(declaration)
+    _, end = selected
     marker = f"TENKZ-DOCTEST-EXECUTED-{command}"
     original = f"tenkzdoctestoriginal{command}"
     instrumentation = "\n".join(
@@ -595,7 +637,7 @@ def compile_example(example: Example, engine: str, work: Path) -> None:
     driver.write_text(example.document, encoding="utf-8")
     env = os.environ.copy()
     env["TEXINPUTS"] = (
-        f"{example.source.parent}//:{ROOT / 'tex' / 'tenkz'}//:"
+        f"{example.source.parent}//:{MANUAL_DIR}//:{ROOT / 'tex' / 'tenkz'}//:"
         f"{env.get('TEXINPUTS', '')}"
     )
     run = subprocess.run(

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -210,10 +210,10 @@ def _registry_vocabulary() -> tuple[list[str], list[str]]:
     return commands, environments
 
 
-def _is_tenkz_verbatim(body: str) -> bool:
+def _is_tenkz_verbatim(body: str, source_dir: Path) -> bool:
     commands, environments = _registry_vocabulary()
     environment_pattern = "|".join(re.escape(environment) for environment in environments)
-    packages, _ = _extract_usepackages(body)
+    packages, _ = _extract_usepackages(body, source_dir)
     scan = _mask_nonexecuted_tokens(strip_comments(body))
     environment_matches = re.finditer(
         rf"\\begin\{{(?:{environment_pattern})\}}", scan
@@ -285,11 +285,11 @@ def _mask_inline_verbatim(text: str) -> str:
     return "".join(masked)
 
 
-def _usepackage_ranges(body: str) -> list[tuple[int, int]]:
+def _usepackage_ranges(body: str, source_dir: Path) -> list[tuple[int, int]]:
     ranges: list[tuple[int, int]] = []
     offset = 0
     marker = r"\usepackage"
-    executable = _mask_macro_definitions(_mask_false_branches(body))
+    executable = _mask_inert_tex(body, source_dir)
     scan_body = _mask_nonexecuted_tokens(executable)
     while (start := _find_control_word(scan_body, "usepackage", offset)) >= 0:
         cursor = _skip_space_and_comments(body, start + len(marker))
@@ -302,8 +302,8 @@ def _usepackage_ranges(body: str) -> list[tuple[int, int]]:
     return ranges
 
 
-def _extract_usepackages(body: str) -> tuple[list[str], str]:
-    ranges = _usepackage_ranges(body)
+def _extract_usepackages(body: str, source_dir: Path) -> tuple[list[str], str]:
+    ranges = _usepackage_ranges(body, source_dir)
     packages = [body[start:end].strip() for start, end in ranges]
     chunks: list[str] = []
     offset = 0
@@ -495,12 +495,23 @@ def _tex_file_exists(relative: Path, source_dir: Path) -> bool:
     return _resolve_tex_file(relative, source_dir) is not None
 
 
-def _mask_inactive_file_branches(text: str, source_dir: Path) -> str:
+def _mask_inactive_file_branches(
+    text: str,
+    source_dir: Path,
+    inherited_conditionals: tuple[str, ...] = (),
+) -> str:
     masked = list(text)
-    scan = _mask_nonexecuted_tokens(_display_comment_scan(text))
     pattern = re.compile(r"\\IfFileExists(?![A-Za-z@])")
     offset = 0
-    while match := pattern.search(scan, offset):
+    while True:
+        current = "".join(masked)
+        structural = _mask_macro_definitions(
+            _mask_false_branches(current, inherited_conditionals), strict=False
+        )
+        scan = _mask_nonexecuted_tokens(_display_comment_scan(structural))
+        match = pattern.search(scan, offset)
+        if match is None:
+            break
         if _is_escaped(scan, match.start()):
             offset = match.end()
             continue
@@ -521,9 +532,11 @@ def _mask_inactive_file_branches(text: str, source_dir: Path) -> str:
             active_start, active_end = false_start, false_end
             _blank_range(masked, match.start(), false_start + 1)
             _blank_range(masked, false_end - 1, false_end)
-        active = text[active_start + 1 : active_end - 1]
+        active = current[active_start + 1 : active_end - 1]
         masked[active_start + 1 : active_end - 1] = (
-            _mask_inactive_file_branches(active, source_dir)
+            _mask_inactive_file_branches(
+                active, source_dir, inherited_conditionals
+            )
         )
         offset = false_end
     return "".join(masked)
@@ -590,7 +603,9 @@ def _mask_inert_tex(
     source_dir: Path,
     inherited_conditionals: tuple[str, ...] = (),
 ) -> str:
-    selected_file_branches = _mask_inactive_file_branches(text, source_dir)
+    selected_file_branches = _mask_inactive_file_branches(
+        text, source_dir, inherited_conditionals
+    )
     without_false_branches = _mask_false_branches(
         selected_file_branches, inherited_conditionals
     )
@@ -625,11 +640,13 @@ def _has_executable_command(text: str, command: str) -> bool:
     return any(not _is_escaped(scan, match.start()) for match in pattern.finditer(scan))
 
 
-def _instrument_command(document: str, command: str) -> tuple[str, str]:
+def _instrument_command(
+    document: str, command: str, source_dir: Path
+) -> tuple[str, str]:
     selected = next(
         (
             (start, end)
-            for start, end in _usepackage_ranges(document)
+            for start, end in _usepackage_ranges(document, source_dir)
             if "tenkz" in _package_names(document[start:end])
         ),
         None,
@@ -664,7 +681,9 @@ def _variant_definitions(variant_style: str) -> list[str]:
     ]
 
 
-def _standalone_document(body: str, variant_style: str | None = None) -> str:
+def _standalone_document(
+    body: str, source_dir: Path, variant_style: str | None = None
+) -> str:
     body = body.strip()
     scan_body = _mask_nonexecuted_tokens(body)
     has_document_class = _find_control_word(scan_body, "documentclass", 0) >= 0
@@ -681,7 +700,7 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
         definitions = "\n".join(_variant_definitions(variant_style)) + "\n"
         return body[:begin] + definitions + body[begin:] + "\n"
 
-    preamble, content = _extract_usepackages(body)
+    preamble, content = _extract_usepackages(body, source_dir)
     if not any("tenkz" in _package_names(package) for package in preamble):
         preamble.append(r"\usepackage{tenkz}")
     if variant_style is not None:
@@ -727,7 +746,9 @@ def extract_displayed_examples(
         body_end = end_match.start()
         body = text[body_start:body_end].strip()
         offset = end_match.end()
-        if environment == "Verbatim" and not _is_tenkz_verbatim(body):
+        if environment == "Verbatim" and not _is_tenkz_verbatim(
+            body, path.parent
+        ):
             continue
         line = text.count("\n", 0, match.start()) + 1
         variants = (
@@ -743,7 +764,9 @@ def extract_displayed_examples(
                     label=f"manual-{_source_label(path)}-{ordinal}{suffix}",
                     source=path,
                     line=line,
-                    document=_standalone_document(body, variant_style),
+                    document=_standalone_document(
+                        body, path.parent, variant_style
+                    ),
                 )
             )
     return examples
@@ -762,7 +785,9 @@ def _conditionals_before(
     inherited_conditionals: tuple[str, ...],
     source_dir: Path,
 ) -> tuple[str, ...]:
-    selected_file_branches = _mask_inactive_file_branches(text, source_dir)
+    selected_file_branches = _mask_inactive_file_branches(
+        text, source_dir, inherited_conditionals
+    )
     executable = _display_comment_scan(
         _mask_macro_definitions(
             _mask_false_branches(
@@ -784,7 +809,13 @@ def _conditionals_before(
     lets = [
         match for match in let_pattern.finditer(executable) if match.start() < offset
     ]
-    known = set((*TEX_PRIMITIVE_CONDITIONALS, *inherited_conditionals))
+    known = set(
+        (
+            *TEX_PRIMITIVE_CONDITIONALS,
+            *_latex_format_conditionals(),
+            *inherited_conditionals,
+        )
+    )
     known.update(match.group(1) for match in newifs)
     while True:
         additions = {
@@ -893,7 +924,9 @@ def reference_examples() -> list[Example]:
             raise ValueError(
                 f"{source}: example mapped to \\{command} does not invoke that command"
             )
-        instrumented, marker = _instrument_command(document, command)
+        instrumented, marker = _instrument_command(
+            document, command, source.parent
+        )
         examples.append(
             Example(
                 label=f"reference-{command}",

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -220,7 +221,8 @@ def _usepackage_ranges(body: str) -> list[tuple[int, int]]:
     ranges: list[tuple[int, int]] = []
     offset = 0
     marker = r"\usepackage"
-    scan_body = _mask_nonexecuted_tokens(body)
+    executable = _mask_macro_definitions(_mask_false_branches(body))
+    scan_body = _mask_nonexecuted_tokens(executable)
     while (start := _find_control_word(scan_body, "usepackage", offset)) >= 0:
         cursor = _skip_space_and_comments(body, start + len(marker))
         if cursor < len(body) and body[cursor] == "[":
@@ -286,9 +288,12 @@ def _blank_range(masked: list[str], start: int, end: int) -> None:
             masked[index] = " "
 
 
-def _mask_false_branches(text: str) -> str:
+def _mask_false_branches(
+    text: str, inherited_conditionals: tuple[str, ...] = ()
+) -> str:
     masked = list(text)
-    scan = _display_comment_scan(
+    scan = _display_comment_scan(text)
+    start_scan = _display_comment_scan(
         _mask_macro_definitions(text, strict=False)
     )
     primitive_conditionals = (
@@ -307,7 +312,9 @@ def _mask_false_branches(text: str) -> str:
         r"(?![A-Za-z@])"
     )
     let_matches = list(let_pattern.finditer(scan))
-    known_conditionals = set((*primitive_conditionals, *declared_conditionals))
+    known_conditionals = set(
+        (*primitive_conditionals, *inherited_conditionals, *declared_conditionals)
+    )
     while True:
         additions = {
             match.group(1)
@@ -342,6 +349,7 @@ def _mask_false_branches(text: str) -> str:
         if (
             token.group(0) != r"\iffalse"
             or token.start() in declaration_operands
+            or start_scan[token.start() : token.end()] != token.group(0)
             or _is_escaped(scan, token.start())
         ):
             index += 1
@@ -396,6 +404,17 @@ def _resolve_tex_file(relative: Path, source_dir: Path) -> Path | None:
             )
             if candidate is not None:
                 return candidate.resolve()
+    if shutil.which("kpsewhich"):
+        lookup = subprocess.run(
+            ["kpsewhich", relative.as_posix()],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+        resolved = Path(lookup.stdout.strip())
+        if lookup.returncode == 0 and resolved.is_file():
+            return resolved.resolve()
     return None
 
 
@@ -493,8 +512,12 @@ def _mask_macro_definitions(text: str, *, strict: bool = True) -> str:
     return "".join(masked)
 
 
-def _mask_inert_tex(text: str, source_dir: Path) -> str:
-    without_false_branches = _mask_false_branches(text)
+def _mask_inert_tex(
+    text: str,
+    source_dir: Path,
+    inherited_conditionals: tuple[str, ...] = (),
+) -> str:
+    without_false_branches = _mask_false_branches(text, inherited_conditionals)
     without_macros = _mask_macro_definitions(without_false_branches)
     return _mask_inactive_file_branches(without_macros, source_dir)
 
@@ -507,6 +530,16 @@ def _mask_nonexecuted_tokens(text: str) -> str:
         for index in range(match.start(), match.end()):
             if masked[index] != "\n":
                 masked[index] = " "
+    scan = "".join(masked)
+    offset = 0
+    while (start := _find_control_word(scan, "detokenize", offset)) >= 0:
+        cursor = _skip_space_and_comments(scan, start + len(r"\detokenize"))
+        if cursor >= len(scan) or scan[cursor] != "{":
+            offset = cursor
+            continue
+        end, _ = _read_braced(scan, cursor)
+        _blank_range(masked, start, end)
+        offset = end
     return "".join(masked)
 
 
@@ -592,7 +625,9 @@ def _standalone_document(body: str, variant_style: str | None = None) -> str:
 
 def extract_displayed_examples(path: Path) -> list[Example]:
     text = path.read_text(encoding="utf-8")
-    scan_text = _mask_inert_tex(text, path.parent)
+    scan_text = _mask_inert_tex(
+        text, path.parent, _manual_conditionals()
+    )
     begin_pattern = re.compile(
         r"^[ \t]*\\begin\{(" + "|".join(DISPLAY_ENVIRONMENTS) + r")\}",
         re.MULTILINE,
@@ -643,9 +678,25 @@ def displayed_examples() -> list[Example]:
     return examples
 
 
+@cache
+def _manual_conditionals_for(directory: Path) -> tuple[str, ...]:
+    declarations: set[str] = set()
+    for source in directory.rglob("*.tex"):
+        scan = _display_comment_scan(source.read_text(encoding="utf-8"))
+        declarations.update(
+            re.findall(r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])", scan)
+        )
+    return tuple(sorted(declarations))
+
+
+def _manual_conditionals() -> tuple[str, ...]:
+    return _manual_conditionals_for(MANUAL_DIR)
+
+
 def _manual_sources() -> list[Path]:
     pending = [MANUAL]
     visited: set[Path] = set()
+    inherited_conditionals = _manual_conditionals()
     input_pattern = re.compile(r"\\input(?![A-Za-z@])")
     while pending:
         source = pending.pop()
@@ -655,7 +706,11 @@ def _manual_sources() -> list[Path]:
         raw = source.read_text(encoding="utf-8")
         text = strip_comments(
             _mask_inline_verbatim(
-                _mask_display_environments(_mask_inert_tex(raw, source.parent))
+                _mask_display_environments(
+                    _mask_inert_tex(
+                        raw, source.parent, inherited_conditionals
+                    )
+                )
             )
         )
         for match in input_pattern.finditer(text):

--- a/scripts/tenkz_manual_doctest.py
+++ b/scripts/tenkz_manual_doctest.py
@@ -305,68 +305,74 @@ def _mask_false_branches(
     newif_pattern = re.compile(
         r"\\newif\s*\\(if[A-Za-z@]+)(?![A-Za-z@])"
     )
-    newif_matches = list(newif_pattern.finditer(scan))
-    declared_conditionals = [match.group(1) for match in newif_matches]
+    newif_matches = list(newif_pattern.finditer(start_scan))
     let_pattern = re.compile(
-        r"\\let\s*\\(if[A-Za-z@]+)\s*=?\s*\\(if[A-Za-z@]+)"
+        r"\\let\s*\\(if[A-Za-z@]+)\s*=?\s*\\(if[A-Za-z@]*)"
         r"(?![A-Za-z@])"
     )
-    let_matches = list(let_pattern.finditer(scan))
-    known_conditionals = set(
-        (*primitive_conditionals, *inherited_conditionals, *declared_conditionals)
-    )
-    while True:
-        additions = {
-            match.group(1)
-            for match in let_matches
-            if match.group(2) in known_conditionals
-        } - known_conditionals
-        if not additions:
-            break
-        known_conditionals.update(additions)
-    aliased_conditionals = sorted(
-        known_conditionals - set(primitive_conditionals) - set(declared_conditionals)
-    )
-    conditionals = (
-        *primitive_conditionals,
-        *declared_conditionals,
-        *aliased_conditionals,
-    )
+    let_matches = list(let_pattern.finditer(start_scan))
     declaration_operands = {
         match.start(group) - 1
         for match in (*newif_matches, *let_matches)
         for group in range(1, len(match.groups()) + 1)
     }
-    tokens = list(
-        re.finditer(
-            r"\\(?:" + "|".join(conditionals) + r"|fi)(?![A-Za-z@])",
-            scan,
-        )
-    )
-    index = 0
-    while index < len(tokens):
-        token = tokens[index]
+    false_tokens = list(re.finditer(r"\\iffalse(?![A-Za-z@])", start_scan))
+    for token in false_tokens:
         if (
-            token.group(0) != r"\iffalse"
+            masked[token.start()] != "\\"
             or token.start() in declaration_operands
             or start_scan[token.start() : token.end()] != token.group(0)
             or _is_escaped(scan, token.start())
         ):
-            index += 1
             continue
+        active_newifs = [
+            match
+            for match in newif_matches
+            if match.start() < token.start() and masked[match.start()] == "\\"
+        ]
+        active_lets = [
+            match
+            for match in let_matches
+            if match.start() < token.start() and masked[match.start()] == "\\"
+        ]
+        declared_conditionals = [match.group(1) for match in active_newifs]
+        known_conditionals = set(
+            (*primitive_conditionals, *inherited_conditionals, *declared_conditionals)
+        )
+        while True:
+            additions = {
+                match.group(1)
+                for match in active_lets
+                if match.group(2) in known_conditionals
+            } - known_conditionals
+            if not additions:
+                break
+            known_conditionals.update(additions)
+        tokens = list(
+            re.finditer(
+                r"\\(?:"
+                + "|".join(sorted(known_conditionals, key=len, reverse=True))
+                + r"|fi)(?![A-Za-z@])",
+                scan[token.start() :],
+            )
+        )
         depth = 1
-        cursor = index + 1
+        cursor = 1
         while cursor < len(tokens) and depth:
             nested = tokens[cursor]
+            nested_start = token.start() + nested.start()
             if (
-                nested.start() not in declaration_operands
-                and not _is_escaped(scan, nested.start())
+                nested_start not in declaration_operands
+                and not _is_escaped(scan, nested_start)
             ):
                 depth += -1 if nested.group(0) == r"\fi" else 1
             cursor += 1
-        end = tokens[cursor - 1].end() if depth == 0 else len(text)
+        end = (
+            token.start() + tokens[cursor - 1].end()
+            if depth == 0
+            else len(text)
+        )
         _blank_range(masked, token.start(), end)
-        index = cursor
     return "".join(masked)
 
 

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -255,6 +255,23 @@ shell command % \tntree{commented}
             DOCTEST.MANUAL = original_manual
             DOCTEST.MANUAL_DIR = original_manual_dir
             DOCTEST.CHAPTERS = original_chapters
+    ordered_parent = "\\input{child.tex}\n\\newif\\iflaterparent\n"
+    child_offset = ordered_parent.index(r"\input")
+    inherited = DOCTEST._conditionals_before(ordered_parent, child_offset, ())
+    if "iflaterparent" in inherited:
+        raise AssertionError("a declaration after input was inherited by the child")
+    ordered_child = (
+        "\\def\\iflaterparent{ordinary command}\n"
+        "\\iffalse\n\\iflaterparent\n\\fi\n"
+        "\\begin{tnexample}\n"
+        "\\begin{tenkz}\\tn{ordered inheritance}\\end{tenkz}\n"
+        "\\end{tnexample}\n"
+    )
+    with tempfile.TemporaryDirectory(prefix="tenkz-doctest-order-") as tmp:
+        order_path = Path(tmp) / "child.tex"
+        order_path.write_text(ordered_child, encoding="utf-8")
+        if len(DOCTEST.extract_displayed_examples(order_path, inherited)) != 1:
+            raise AssertionError("a later parent declaration hid a live child example")
     if {source.resolve() for source in sources} != {
         root.resolve(),
         child.resolve(),

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -177,10 +177,13 @@ shell command % \tntree{commented}
         root.write_text(
             "\\newcommand{\\optionalchapter}{\\input{missing.tex}}\n"
             "\\verb|\\IfFileExists| \\string\\IfFileExists \\\\IfFileExists\n"
+            "\\begin{Verbatim}\n\\IfFileExists\n\\end{Verbatim}\n"
             "\\IfFileExists{chapters2/% continued\nchild.tex}"
-            "{\\IfFileExists{chapters2/missing-generated.tex}"
+            "{\\IfFileExists{chapters2/child}"
+            "{\\input{chapters2/wrong-extensionless-branch.tex}}"
+            "{\\IfFileExists{missing-generated.tex}"
             "{\\input{chapters2/missing-generated.tex}}"
-            "{\\input chapters2/child}}"
+            "{\\input chapters2/child}}}"
             "{\\input{chapters2/also-missing.tex}}\n",
             encoding="utf-8",
         )

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -60,8 +60,11 @@ shell command % \tntree{commented}
 % \begin{tnexample}
 % \begin{tenkz} \tn{commented} \end{tenkz}
 % \end{tnexample}
+\newif\ifdraft
 \iffalse
+\ifdraft
 \ifthenelse{ignored}{ignored}{ignored}
+\fi
 \begin{tnexample}
 \begin{tenkz} \tn{false-branch} \end{tenkz}
 \end{tnexample}
@@ -173,9 +176,12 @@ shell command % \tntree{commented}
         child = chapters / "child.tex"
         root.write_text(
             "\\newcommand{\\optionalchapter}{\\input{missing.tex}}\n"
-            "\\IfFileExists{chapters2/missing-generated.tex}"
+            "\\verb|\\IfFileExists| \\string\\IfFileExists \\\\IfFileExists\n"
+            "\\IfFileExists{chapters2/% continued\nchild.tex}"
+            "{\\IfFileExists{chapters2/missing-generated.tex}"
             "{\\input{chapters2/missing-generated.tex}}"
-            "{\\input chapters2/child}\n",
+            "{\\input chapters2/child}}"
+            "{\\input{chapters2/also-missing.tex}}\n",
             encoding="utf-8",
         )
         child.write_text("", encoding="utf-8")

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -61,6 +61,7 @@ shell command % \tntree{commented}
 % \begin{tenkz} \tn{commented} \end{tenkz}
 % \end{tnexample}
 \iffalse
+\ifthenelse{ignored}{ignored}{ignored}
 \begin{tnexample}
 \begin{tenkz} \tn{false-branch} \end{tenkz}
 \end{tnexample}
@@ -116,6 +117,8 @@ shell command % \tntree{commented}
     texinputs = str(captured["env"]["TEXINPUTS"])
     if not texinputs.startswith(f"{reference[0].source.parent}//:"):
         raise AssertionError("a reference example cannot resolve files beside its source")
+    if f":{DOCTEST.MANUAL_DIR}//:" not in texinputs:
+        raise AssertionError("a manual example cannot resolve files from the manual root")
     if r"\tnarrow" in DOCTEST._strip_tex_comments(r"\\% \tnarrow"):
         raise AssertionError("an even-backslash percent did not start a TeX comment")
     if r"\tnarrow" not in DOCTEST._strip_tex_comments(r"\% \tnarrow"):
@@ -131,6 +134,14 @@ shell command % \tntree{commented}
     )
     if "tenkz" not in package_names:
         raise AssertionError("a comment hid tenkz in a multi-package declaration")
+    repeated_package = (
+        "% \\usepackage{tenkz}\n"
+        "\\usepackage{tenkz}\n"
+        "\\begin{document}\\tn{A}\\end{document}\n"
+    )
+    instrumented, marker = DOCTEST._instrument_command(repeated_package, "tn")
+    if instrumented.index(marker) < instrumented.index("\n\\usepackage{tenkz}"):
+        raise AssertionError("runtime instrumentation used a commented package spelling")
     escaped_verb = (
         "Write \\\\verb|without a closing delimiter on this line\n"
         "\\usepackage{tenkz}\n"
@@ -162,7 +173,9 @@ shell command % \tntree{commented}
         child = chapters / "child.tex"
         root.write_text(
             "\\newcommand{\\optionalchapter}{\\input{missing.tex}}\n"
-            "\\input chapters2/child\n",
+            "\\IfFileExists{chapters2/missing-generated.tex}"
+            "{\\input{chapters2/missing-generated.tex}}"
+            "{\\input chapters2/child}\n",
             encoding="utf-8",
         )
         child.write_text("", encoding="utf-8")

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -63,11 +63,15 @@ shell command % \tntree{commented}
 \newif\ifdraft
 \let\ifalias\ifdraft
 \let\ifnever\iffalse
+\let\ifbare\if
 \iffalse
 \newif\iflocal
+\let\iflocalbare\if
 \iftrue
 \newcommand{\stored}{\fi}
 \ifalias
+\fi
+\ifbare ab
 \fi
 \ifdraft
 \ifthenelse{ignored}{ignored}{ignored}
@@ -76,6 +80,14 @@ shell command % \tntree{commented}
 \begin{tenkz} \tn{false-branch} \end{tenkz}
 \end{tnexample}
 \fi
+\def\iflate{not yet a conditional}
+\iffalse
+\iflate
+\fi
+\begin{tnexample}
+\begin{tenkz} \tn{declaration-order} \end{tenkz}
+\end{tnexample}
+\newif\iflate
 \begin{Verbatim}
 \documentclass[
   border=2pt
@@ -90,7 +102,7 @@ shell command % \tntree{commented}
         path = Path(tmp) / "fixture.tex"
         path.write_text(fixture, encoding="utf-8")
         extracted = DOCTEST.extract_displayed_examples(path)
-    if len(extracted) != 6 or any(
+    if len(extracted) != 7 or any(
         r"\begin{tenkz}" not in example.document for example in extracted[:2]
     ):
         raise AssertionError("nested tnmultiple options confused body extraction")
@@ -107,7 +119,9 @@ shell command % \tntree{commented}
         r"\begin{document}"
     ):
         raise AssertionError("a multiline package declaration was split across the body")
-    complete = extracted[5].document
+    if r"\tn{declaration-order}" not in extracted[5].document:
+        raise AssertionError("a later newif declaration changed an earlier false branch")
+    complete = extracted[6].document
     if complete.count(r"\documentclass") != 1 or r"\tn{commented}" in complete:
         raise AssertionError("complete or commented Verbatim documents were mishandled")
 

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -65,7 +65,8 @@ shell command % \tntree{commented}
 \let\ifnever\iffalse
 \iffalse
 \newif\iflocal
-\newcommand{\broken}{
+\iftrue
+\newcommand{\stored}{\fi}
 \ifalias
 \fi
 \ifdraft
@@ -144,12 +145,13 @@ shell command % \tntree{commented}
     if "tenkz" not in package_names:
         raise AssertionError("a comment hid tenkz in a multi-package declaration")
     repeated_package = (
+        "\\iffalse\n\\usepackage{tenkz}\n\\fi\n"
         "% \\usepackage{tenkz}\n"
         "\\usepackage{tenkz}\n"
         "\\begin{document}\\tn{A}\\end{document}\n"
     )
     instrumented, marker = DOCTEST._instrument_command(repeated_package, "tn")
-    if instrumented.index(marker) < instrumented.index("\n\\usepackage{tenkz}"):
+    if instrumented.index(marker) < instrumented.rindex("\\usepackage{tenkz}"):
         raise AssertionError("runtime instrumentation used a commented package spelling")
     escaped_verb = (
         "Write \\\\verb|without a closing delimiter on this line\n"
@@ -183,8 +185,10 @@ shell command % \tntree{commented}
         child = chapters / "child.tex"
         local = chapters / "local.tex"
         root.write_text(
+            "\\newif\\ifshared\n"
             "\\newcommand{\\optionalchapter}{\\input{missing.tex}}\n"
             "\\verb|\\IfFileExists| \\string\\IfFileExists \\\\IfFileExists\n"
+            "\\texttt{\\detokenize{\\IfFileExists}}\n"
             "\\begin{Verbatim}\n\\IfFileExists\n\\end{Verbatim}\n"
             "\\verb|100%|\\IfFileExists{missing-after-verb.tex}"
             "{\\input{missing-after-verb.tex}}"
@@ -198,6 +202,8 @@ shell command % \tntree{commented}
             encoding="utf-8",
         )
         child.write_text(
+            "\\iffalse\\ifshared\\fi"
+            "\\input{missing-shared-conditional.tex}\\fi\n"
             "\\IfFileExists{local.tex}{\\input{local.tex}}"
             "{\\input{missing-local.tex}}\n",
             encoding="utf-8",
@@ -222,6 +228,11 @@ shell command % \tntree{commented}
             DOCTEST.os.environ["TEXINPUTS"] = f"{ambient}//"
             if not DOCTEST._tex_file_exists(Path("ambient-only.tex"), manual_dir):
                 raise AssertionError("a recursive TEXINPUTS root was not searched")
+            DOCTEST.os.environ.pop("TEXINPUTS", None)
+            if DOCTEST.shutil.which("kpsewhich") and not DOCTEST._tex_file_exists(
+                Path("article.cls"), manual_dir
+            ):
+                raise AssertionError("the default TeX search path was omitted")
         finally:
             if original_texinputs is None:
                 DOCTEST.os.environ.pop("TEXINPUTS", None)

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -61,9 +61,11 @@ shell command % \tntree{commented}
 % \begin{tenkz} \tn{commented} \end{tenkz}
 % \end{tnexample}
 \newif\ifdraft
-\let\ifalias\iftrue
+\let\ifalias\ifdraft
+\let\ifnever\iffalse
 \iffalse
 \newif\iflocal
+\newcommand{\broken}{
 \ifalias
 \fi
 \ifdraft
@@ -173,38 +175,66 @@ shell command % \tntree{commented}
     if r"\input" in DOCTEST._mask_display_environments(displayed_input):
         raise AssertionError("a displayed input spelling remained in the structural graph")
     with tempfile.TemporaryDirectory(prefix="tenkz-doctest-graph-") as tmp:
-        manual_dir = Path(tmp)
+        manual_dir = Path(tmp) / "manual"
+        manual_dir.mkdir()
         chapters = manual_dir / "chapters2"
         chapters.mkdir()
         root = manual_dir / "manual2.tex"
         child = chapters / "child.tex"
+        local = chapters / "local.tex"
         root.write_text(
             "\\newcommand{\\optionalchapter}{\\input{missing.tex}}\n"
             "\\verb|\\IfFileExists| \\string\\IfFileExists \\\\IfFileExists\n"
             "\\begin{Verbatim}\n\\IfFileExists\n\\end{Verbatim}\n"
-            "\\IfFileExists{chapters2/% continued\nchild.tex}"
+            "\\verb|100%|\\IfFileExists{missing-after-verb.tex}"
+            "{\\input{missing-after-verb.tex}}"
+            "{\\IfFileExists{chapters2/% continued\nchild.tex}"
             "{\\IfFileExists{chapters2/child}"
             "{\\input{chapters2/wrong-extensionless-branch.tex}}"
             "{\\IfFileExists{missing-generated.tex}"
             "{\\input{chapters2/missing-generated.tex}}"
             "{\\input chapters2/child}}}"
-            "{\\input{chapters2/also-missing.tex}}\n",
+            "{\\input{chapters2/also-missing.tex}}}\n",
             encoding="utf-8",
         )
-        child.write_text("", encoding="utf-8")
+        child.write_text(
+            "\\IfFileExists{local.tex}{\\input{local.tex}}"
+            "{\\input{missing-local.tex}}\n",
+            encoding="utf-8",
+        )
+        local.write_text("", encoding="utf-8")
+        ambient = Path(tmp) / "ambient"
+        nested = ambient / "nested"
+        nested.mkdir(parents=True)
+        (nested / "ambient-only.tex").write_text("", encoding="utf-8")
         original_manual = DOCTEST.MANUAL
         original_manual_dir = DOCTEST.MANUAL_DIR
         original_chapters = DOCTEST.CHAPTERS
         DOCTEST.MANUAL = root
         DOCTEST.MANUAL_DIR = manual_dir
         DOCTEST.CHAPTERS = chapters
+        original_texinputs = DOCTEST.os.environ.get("TEXINPUTS")
         try:
             sources = DOCTEST._manual_sources()
+            DOCTEST.os.environ["TEXINPUTS"] = str(ambient)
+            if DOCTEST._tex_file_exists(Path("ambient-only.tex"), manual_dir):
+                raise AssertionError("a plain TEXINPUTS root was searched recursively")
+            DOCTEST.os.environ["TEXINPUTS"] = f"{ambient}//"
+            if not DOCTEST._tex_file_exists(Path("ambient-only.tex"), manual_dir):
+                raise AssertionError("a recursive TEXINPUTS root was not searched")
         finally:
+            if original_texinputs is None:
+                DOCTEST.os.environ.pop("TEXINPUTS", None)
+            else:
+                DOCTEST.os.environ["TEXINPUTS"] = original_texinputs
             DOCTEST.MANUAL = original_manual
             DOCTEST.MANUAL_DIR = original_manual_dir
             DOCTEST.CHAPTERS = original_chapters
-    if {source.resolve() for source in sources} != {root.resolve(), child.resolve()}:
+    if {source.resolve() for source in sources} != {
+        root.resolve(),
+        child.resolve(),
+        local.resolve(),
+    }:
         raise AssertionError("the manual root or a traversed source was omitted")
 
     print("PASS: tenkz manual doctest extraction and reference coverage")

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -61,7 +61,11 @@ shell command % \tntree{commented}
 % \begin{tenkz} \tn{commented} \end{tenkz}
 % \end{tnexample}
 \newif\ifdraft
+\let\ifalias\iftrue
 \iffalse
+\newif\iflocal
+\ifalias
+\fi
 \ifdraft
 \ifthenelse{ignored}{ignored}{ignored}
 \fi

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -61,10 +61,12 @@ shell command % \tntree{commented}
 % \begin{tenkz} \tn{commented} \end{tenkz}
 % \end{tnexample}
 \newif\ifdraft
+\newcommand{\storedguard}{\IfFileExists}
 \let\ifalias\ifdraft
 \let\ifnever\iffalse
 \let\ifbare\if
 \iffalse
+\IfFileExists
 \newif\iflocal
 \let\iflocalbare\if
 \iftrue
@@ -169,9 +171,13 @@ shell command % \tntree{commented}
         raise AssertionError("an escaped percent incorrectly started a TeX comment")
     if DOCTEST._has_executable_command(r"\verb|\tn| \string\tn \\tn", "tn"):
         raise AssertionError("a non-executed command spelling satisfied reference coverage")
-    if DOCTEST._is_tenkz_verbatim(r"\verb|\tn| \string\tn \\tn"):
+    if DOCTEST._is_tenkz_verbatim(
+        r"\verb|\tn| \string\tn \\tn", Path.cwd()
+    ):
         raise AssertionError("a non-executed command spelling classified a Verbatim block")
-    if DOCTEST._is_tenkz_verbatim(r"% \begin{tenkz} \tn{commented} \end{tenkz}"):
+    if DOCTEST._is_tenkz_verbatim(
+        r"% \begin{tenkz} \tn{commented} \end{tenkz}", Path.cwd()
+    ):
         raise AssertionError("a commented environment classified a Verbatim block")
     package_names = DOCTEST._package_names(
         "\\usepackage{amsmath,% package note\n tenkz}"
@@ -180,11 +186,15 @@ shell command % \tntree{commented}
         raise AssertionError("a comment hid tenkz in a multi-package declaration")
     repeated_package = (
         "\\iffalse\n\\usepackage{tenkz}\n\\fi\n"
+        "\\IfFileExists{missing-instrumentation.tex}"
+        "{\\usepackage{tenkz}}{}\n"
         "% \\usepackage{tenkz}\n"
         "\\usepackage{tenkz}\n"
         "\\begin{document}\\tn{A}\\end{document}\n"
     )
-    instrumented, marker = DOCTEST._instrument_command(repeated_package, "tn")
+    instrumented, marker = DOCTEST._instrument_command(
+        repeated_package, "tn", Path.cwd()
+    )
     if instrumented.index(marker) < instrumented.rindex("\\usepackage{tenkz}"):
         raise AssertionError("runtime instrumentation used a commented package spelling")
     escaped_verb = (
@@ -275,13 +285,19 @@ shell command % \tntree{commented}
             DOCTEST.MANUAL = original_manual
             DOCTEST.MANUAL_DIR = original_manual_dir
             DOCTEST.CHAPTERS = original_chapters
-    ordered_parent = "\\input{child.tex}\n\\newif\\iflaterparent\n"
+    ordered_parent = (
+        "\\let\\ifformat\\if@twocolumn\n"
+        "\\input{child.tex}\n"
+        "\\newif\\iflaterparent\n"
+    )
     child_offset = ordered_parent.index(r"\input")
     inherited = DOCTEST._conditionals_before(
         ordered_parent, child_offset, (), Path.cwd()
     )
     if "iflaterparent" in inherited:
         raise AssertionError("a declaration after input was inherited by the child")
+    if "ifformat" not in inherited:
+        raise AssertionError("an alias to a format conditional was not inherited")
     guarded_parent = (
         "\\IfFileExists{missing-conditional.tex}"
         "{\\newif\\ifguarded}{}\\input{child.tex}\n"

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -71,6 +71,8 @@ shell command % \tntree{commented}
 \newcommand{\stored}{\fi}
 \ifalias
 \fi
+\if@twocolumn
+\fi
 \ifbare ab
 \fi
 \ifdraft
@@ -78,6 +80,21 @@ shell command % \tntree{commented}
 \fi
 \begin{tnexample}
 \begin{tenkz} \tn{false-branch} \end{tenkz}
+\end{tnexample}
+\fi
+\IfFileExists{missing-conditional.tex}{\newif\ifghost}{}
+\iffalse
+\ifghost
+\fi
+\begin{tnexample}
+\begin{tenkz} \tn{inactive-file-declaration} \end{tenkz}
+\end{tnexample}
+\IfFileExists{present-conditional.tex}{\newif\ifpresent}{}
+\iffalse
+\ifpresent
+\fi
+\begin{tnexample}
+\begin{tenkz} \tn{active-file-declaration} \end{tenkz}
 \end{tnexample}
 \fi
 \def\iflate{not yet a conditional}
@@ -100,9 +117,10 @@ shell command % \tntree{commented}
 """
     with tempfile.TemporaryDirectory(prefix="tenkz-doctest-unit-") as tmp:
         path = Path(tmp) / "fixture.tex"
+        (Path(tmp) / "present-conditional.tex").write_text("", encoding="utf-8")
         path.write_text(fixture, encoding="utf-8")
         extracted = DOCTEST.extract_displayed_examples(path)
-    if len(extracted) != 7 or any(
+    if len(extracted) != 8 or any(
         r"\begin{tenkz}" not in example.document for example in extracted[:2]
     ):
         raise AssertionError("nested tnmultiple options confused body extraction")
@@ -119,9 +137,11 @@ shell command % \tntree{commented}
         r"\begin{document}"
     ):
         raise AssertionError("a multiline package declaration was split across the body")
-    if r"\tn{declaration-order}" not in extracted[5].document:
+    if r"\tn{inactive-file-declaration}" not in extracted[5].document:
+        raise AssertionError("an inactive file branch declared a conditional")
+    if r"\tn{declaration-order}" not in extracted[6].document:
         raise AssertionError("a later newif declaration changed an earlier false branch")
-    complete = extracted[6].document
+    complete = extracted[7].document
     if complete.count(r"\documentclass") != 1 or r"\tn{commented}" in complete:
         raise AssertionError("complete or commented Verbatim documents were mishandled")
 
@@ -257,9 +277,21 @@ shell command % \tntree{commented}
             DOCTEST.CHAPTERS = original_chapters
     ordered_parent = "\\input{child.tex}\n\\newif\\iflaterparent\n"
     child_offset = ordered_parent.index(r"\input")
-    inherited = DOCTEST._conditionals_before(ordered_parent, child_offset, ())
+    inherited = DOCTEST._conditionals_before(
+        ordered_parent, child_offset, (), Path.cwd()
+    )
     if "iflaterparent" in inherited:
         raise AssertionError("a declaration after input was inherited by the child")
+    guarded_parent = (
+        "\\IfFileExists{missing-conditional.tex}"
+        "{\\newif\\ifguarded}{}\\input{child.tex}\n"
+    )
+    guarded_offset = guarded_parent.index(r"\input")
+    guarded_inherited = DOCTEST._conditionals_before(
+        guarded_parent, guarded_offset, (), Path.cwd()
+    )
+    if "ifguarded" in guarded_inherited:
+        raise AssertionError("an inactive file branch leaked a child conditional")
     ordered_child = (
         "\\def\\iflaterparent{ordinary command}\n"
         "\\iffalse\n\\iflaterparent\n\\fi\n"


### PR DESCRIPTION
Closes the five review findings posted after #4735 merged.

- recognize only actual TeX conditional primitives while masking literal false branches
- instrument the selected executable tenkz package occurrence by offset
- preserve the manual root on `TEXINPUTS`
- trigger corpus CI for every TeX source below `docs/tenkz`
- follow the active branch of literal `\IfFileExists` guards

Validation:
- `python3 scripts/test_tenkz_manual_doctest.py`
- `python3 scripts/tenkz_manual_doctest.py` (9 manual + 18 runtime-instrumented reference examples)
- `python3 scripts/tenkz_lint.py --census`
- `python3 scripts/test_tenkz_language.py`
- `actionlint .github/workflows/pr-ci.yml`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to heuristic TeX parsing that decide which manual examples compile in CI; wrong masking could skip or mis-wrap examples without obvious compile failures.
> 
> **Overview**
> Addresses post-merge review follow-ups for **tenkz manual doctest** extraction and CI gating.
> 
> **TeX static analysis** in `tenkz_manual_doctest.py` now models more of what actually runs: it resolves `\IfFileExists` using manual roots, `TEXINPUTS` (including `//`), and `kpsewhich`; walks `\input` with per-file inherited conditionals; and masks `\iffalse` branches using real TeX/LaTeX conditionals (including a probe of `latex.ltx` via XeLaTeX) instead of treating arbitrary `\if…` tokens as structure. Executable `\usepackage{tenkz}` is chosen by offset (ignoring false branches and comments), and compile `TEXINPUTS` adds `docs/tenkz//` so examples can resolve manual-local files.
> 
> **CI** corpus path filtering now includes all `docs/tenkz/**/*.tex`, not only `chapters2/`.
> 
> **Tests** in `test_tenkz_manual_doctest.py` cover conditionals, file guards, instrumentation, input graph traversal, and `TEXINPUTS` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68128d483f9ec017f209bfd809698c4651effc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->