### PR TITLE
refactor(tenkz): freeze lattice edges and regions

### DIFF
--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -1444,10 +1444,9 @@
     \tenkzl_frame_setup:
     \dim_set:Nn \l__tenkzl_m_dim { \tenkz@r@latticemargin\tenkz@pitch }
     % The lattice writes its record layer once the window, sheets, and
-    % frame are final: the picture and frame records plus one atom record
-    % per surviving site, in draw order (sheet-major, bottom sheet first).
-    % Edge and region records land with the corridor follow-up; until the
-    % lattice renderer consumes records, this store changes no emission.
+    % frame are final: the picture and frame records, one atom record per
+    % surviving site, and the body's explicit edge and region declarations.
+    % The record order matches the corresponding draw passes.
     \__tenkz_model_reset:
     \__tenkz_model_record_picture:n { lang={lattice} }
     \__tenkz_model_record_frame:e
@@ -1456,6 +1455,8 @@
         cols={\int_use:N \l__tenkzl_ncols_int},
         sheets={\int_use:N \l__tenkzl_sheets_int} }
     \tenkzl_model_record_sites:
+    \tenkzl_model_record_edges:
+    \tenkzl_model_record_regions:
     \__tenkz_model_validate:
     \begin{tikzpicture}[tenkz~every~picture]
       \pgfsetlayers{background,main,tenkz-lattice-labels}
@@ -1479,6 +1480,39 @@
       { kind={site},
         cell={\tenkz_cs_cellkey:nnn
           {#1}{#2}{\int_use:N \l__tenkzl_sheet_int}} }
+  }
+
+% Explicit \tnedge declarations become ordinary WIRE records.  The implicit
+% nearest-neighbour bonds remain a separate derivation until the final S3
+% corridor; `origin=edge` keeps the two sources distinguishable meanwhile.
+\cs_new_protected:Npn \tenkzl_model_record_edges:
+  {
+    \seq_map_inline:Nn \l__tenkzl_edges_seq
+      { \tenkzl_model_record_edge:nnnnnnnnn ##1 }
+  }
+\cs_new_protected:Npn \tenkzl_model_record_edge:nnnnnnnnn
+    #1#2#3#4#5#6#7#8#9
+  {
+    \__tenkz_model_record_wire:e
+      { kind={index}, origin={edge},
+        from={\tenkz_cs_cellkey:nnn {#1}{#2}{#3}},
+        to={\tenkz_cs_cellkey:nnn {#4}{#5}{#6}},
+        style={\exp_not:n {#7}}, label={\exp_not:n {#8}}, role={#9} }
+  }
+
+% A lattice region is the LANGUAGE-1.0 enclosure MARK: membership, tint,
+% outline policy, nesting inset, and label placement are frozen together.
+\cs_new_protected:Npn \tenkzl_model_record_regions:
+  {
+    \seq_map_inline:Nn \l__tenkzl_regions_seq
+      { \tenkzl_model_record_region:nnnnnn ##1 }
+  }
+\cs_new_protected:Npn \tenkzl_model_record_region:nnnnnn #1#2#3#4#5#6
+  {
+    \__tenkz_model_record_mark:e
+      { form={enclosure}, slot={#1}, outline={#2},
+        label={\exp_not:n {#3}}, label-pos={#4},
+        members={\exp_not:n {#5}}, inset={#6} }
   }
 
 % one full genre pass over the CURRENT sheet (selected by
@@ -2887,8 +2921,26 @@
 % -- (a) regions ------------------------------------------------------
 \cs_new_protected:Npn \tenkzl_draw_regions:
   {
-    \seq_map_inline:Nn \l__tenkzl_regions_seq
-      { \tenkzl_region:nnnnnn ##1 }
+    \__tenkz_model_map_marks_form:nN {enclosure}
+      \tenkzl_draw_region_record:n
+  }
+\tl_new:N \l__tenkzl_model_outline_tl
+\tl_new:N \l__tenkzl_model_members_tl
+\cs_new_protected:Npn \tenkzl_draw_region_record:n #1
+  {
+    \__tenkz_model_get:nnN {#1} {slot}      \l__tenkzl_rslot_tl
+    \__tenkz_model_get:nnN {#1} {outline}   \l__tenkzl_model_outline_tl
+    \__tenkz_model_get:nnN {#1} {label}     \l__tenkzl_rlabel_tl
+    \__tenkz_model_get:nnN {#1} {label-pos} \l__tenkzl_rlabelat_tl
+    \__tenkz_model_get:nnN {#1} {members}   \l__tenkzl_model_members_tl
+    \__tenkz_model_get:nnN {#1} {inset}     \l__tenkzl_rinset_tl
+    \tenkzl_region:VVVVVV
+      \l__tenkzl_rslot_tl
+      \l__tenkzl_model_outline_tl
+      \l__tenkzl_rlabel_tl
+      \l__tenkzl_rlabelat_tl
+      \l__tenkzl_model_members_tl
+      \l__tenkzl_rinset_tl
   }
 
 % slot -> style
@@ -2978,6 +3030,7 @@
     \int_compare:nNnT { \l__tenkzl_sheet_int } = {0}
       { \tenkz@event{region|picture=\the\tenkz@pictureid|lang=lattice|slot=#1|cells=#5} }
   }
+\cs_generate_variant:Nn \tenkzl_region:nnnnnn { VVVVVV }
 
 % =====================================================================
 % rectilinear boundary tracer
@@ -3236,8 +3289,50 @@
 % -- (c) distinguished edges ------------------------------------------
 \cs_new_protected:Npn \tenkzl_draw_edges:
   {
-    \seq_map_inline:Nn \l__tenkzl_edges_seq
-      { \tenkzl_edge:nnnnnnnnn ##1 }
+    \__tenkz_model_map_wires_origin:nN {edge}
+      \tenkzl_draw_edge_record:n
+  }
+\tl_new:N \l__tenkzl_model_from_tl
+\tl_new:N \l__tenkzl_model_to_tl
+\tl_new:N \l__tenkzl_model_from_row_tl
+\tl_new:N \l__tenkzl_model_from_col_tl
+\tl_new:N \l__tenkzl_model_from_sheet_tl
+\tl_new:N \l__tenkzl_model_to_row_tl
+\tl_new:N \l__tenkzl_model_to_col_tl
+\tl_new:N \l__tenkzl_model_to_sheet_tl
+\cs_new_protected:Npn \tenkzl_draw_edge_record:n #1
+  {
+    \__tenkz_model_get:nnN {#1} {from}  \l__tenkzl_model_from_tl
+    \__tenkz_model_get:nnN {#1} {to}    \l__tenkzl_model_to_tl
+    \__tenkz_model_get:nnN {#1} {style} \l__tenkzl_estyle_tl
+    \__tenkz_model_get:nnN {#1} {label} \l__tenkzl_edgelabel_tl
+    \__tenkz_model_get:nnN {#1} {role}  \l__tenkzl_erole_tl
+    \exp_args:NV \tenkzl_cellkey_sheet:nN
+      \l__tenkzl_model_from_tl \l__tenkzl_hsel_int
+    \tl_set:Ne \l__tenkzl_model_from_row_tl
+      { \seq_item:Nn \l__tenkzl_parts_seq {1} }
+    \tl_set:Ne \l__tenkzl_model_from_col_tl
+      { \seq_item:Nn \l__tenkzl_parts_seq {2} }
+    \tl_set:Ne \l__tenkzl_model_from_sheet_tl
+      { \int_use:N \l__tenkzl_hsel_int }
+    \exp_args:NV \tenkzl_cellkey_sheet:nN
+      \l__tenkzl_model_to_tl \l__tenkzl_hsel_int
+    \tl_set:Ne \l__tenkzl_model_to_row_tl
+      { \seq_item:Nn \l__tenkzl_parts_seq {1} }
+    \tl_set:Ne \l__tenkzl_model_to_col_tl
+      { \seq_item:Nn \l__tenkzl_parts_seq {2} }
+    \tl_set:Ne \l__tenkzl_model_to_sheet_tl
+      { \int_use:N \l__tenkzl_hsel_int }
+    \tenkzl_edge:VVVVVVVVV
+      \l__tenkzl_model_from_row_tl
+      \l__tenkzl_model_from_col_tl
+      \l__tenkzl_model_from_sheet_tl
+      \l__tenkzl_model_to_row_tl
+      \l__tenkzl_model_to_col_tl
+      \l__tenkzl_model_to_sheet_tl
+      \l__tenkzl_estyle_tl
+      \l__tenkzl_edgelabel_tl
+      \l__tenkzl_erole_tl
   }
 % one recorded edge (r,c,h)-(r',c',h') in resolved style #7 with label
 % #8 and role word #9 (`none' when unhued), each endpoint mapped with
@@ -3278,6 +3373,7 @@
           {#1}{#2}{#3}|to=\tenkz_cs_cellkey:nnn {#4}{#5}{#6}|role=#9}
       }
   }
+\cs_generate_variant:Nn \tenkzl_edge:nnnnnnnnn { VVVVVVVVV }
 
 % -- (d) site glyphs --------------------------------------------------
 % An op sheet's boxes defer to the cover pass (\tenkzl_draw_opsites:,

--- a/tex/tenkz/tenkz-model.code.tex
+++ b/tex/tenkz/tenkz-model.code.tex
@@ -189,6 +189,19 @@
       }
   }
 
+% Apply function #2 to every mark of form #1.  Dialect render passes use the
+% shared MARK class without accidentally consuming unrelated annotations.
+\tl_new:N \l__tenkz_model_form_tl
+\cs_new_protected:Npn \__tenkz_model_map_marks_form:nN #1#2
+  {
+    \seq_map_inline:Nn \l__tenkz_model_mark_seq
+      {
+        \__tenkz_model_get:nnN {##1} {form} \l__tenkz_model_form_tl
+        \str_if_eq:eeT { \tl_use:N \l__tenkz_model_form_tl } {#1}
+          { #2 {##1} }
+      }
+  }
+
 % Expanding constructors for front ends whose addresses live in counters.
 % The variants route through the current (possibly frozen) base meaning.
 \cs_generate_variant:Nn \__tenkz_model_record_atom:n { e }


### PR DESCRIPTION
## What changed

- Normalize every explicit lattice edge into a shared WIRE record before model validation.
- Normalize every lattice region into a shared enclosure MARK record before validation.
- Render explicit edges and regions exclusively from the frozen records.
- Decode canonical from/to addresses in the lattice layout instead of duplicating coordinate fields.
- Add a shared form-filtered MARK iterator so dialect passes cannot consume unrelated annotations.

This is the second mergeable S3 tranche and advances #4698. Implicit lattice bonds and the remaining side-policy/silhouette twins stay on the final S3 corridor.

## Why

PR #4737 established lattice picture, frame, and site records. Explicit edges and regions were still rendered from their pre-normalized declaration sequences, leaving two semantic sources. This cutover makes the validated WIRE/MARK store authoritative for those passes while preserving established rendering and events.

## Validation

- scripts/tenkz_corpus.sh — 261/261 standalone files compiled and audited
- TENKZ_CORPUS_JOBS=8 scripts/tenkz_golden.sh --check — 261/261 event streams byte-identical
- TENKZ_CORPUS_JOBS=8 scripts/tenkz_pixelpair.sh origin/main — 6/6 sentinel pages byte-identical at 300 DPI
- python3 scripts/test_tenkz_enclosures.py
- python3 scripts/test_tenkz_label_overlap.py
- python3 scripts/test_tenkz_peps_torus.py
- language, shrink, corpus-provenance, and corpus-render checks passed locally

The Playwright-backed web-layout check remains delegated to repository Chromium CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the lattice render path to a single authoritative model store; behavior is intended to be unchanged (corpus/golden checks in PR), but any gap in record fields or draw-order assumptions could affect diagrams without compile errors.
> 
> **Overview**
> **Lattice explicit `\tnedge` and `\tnregion` declarations are normalized into the shared validated model** before `\__tenkz_model_validate:`, then region and distinguished-edge draw passes read only those records—not the legacy `\l__tenkzl_edges_seq` / `\l__tenkzl_regions_seq` sequences.
> 
> At end-of-picture setup, after site atoms, the renderer now calls `\tenkzl_model_record_edges:` and `\tenkzl_model_record_regions:`. Edges become **WIRE** records with `origin=edge`, canonical `from`/`to` cell keys, and preserved style/label/role. Regions become **enclosure MARK** records with slot, outline, members, inset, and label placement frozen together.
> 
> **Draw passes were rewired:** `\tenkzl_draw_regions:` uses new `\__tenkz_model_map_marks_form:nN {enclosure}`; `\tenkzl_draw_edges:` uses existing `\__tenkz_model_map_wires_origin:nN {edge}`. Record handlers decode cell keys via `\tenkzl_cellkey_sheet:nN` and delegate to `\tenkzl_region` / `\tenkzl_edge` through `VVVVVV` / `VVVVVVVVV` variants.
> 
> **`tenkz-model.code.tex`** adds `\__tenkz_model_map_marks_form:nN` so dialect passes can filter MARK records by `form` without touching unrelated annotations (parallel to wire `origin` filtering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb93a0cc0409f19ab7c1219b3574d7da0e6cec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->