### PR TITLE
refactor(tenkz): share lattice corridor geometry

### DIFF
--- a/tests/tenkz/render-census-baseline.json
+++ b/tests/tenkz/render-census-baseline.json
@@ -20,13 +20,13 @@
       "tenkz-core.code.tex": 25,
       "tenkz-free.code.tex": 4,
       "tenkz-geometry.code.tex": 0,
-      "tenkz-grid.code.tex": 28,
+      "tenkz-grid.code.tex": 18,
       "tenkz-language.code.tex": 0,
-      "tenkz-lattice.code.tex": 13,
+      "tenkz-lattice.code.tex": 10,
       "tenkz-metric.code.tex": 0,
       "tenkz-model.code.tex": 0,
       "tenkz-render.code.tex": 0
     },
-    "total": 71
+    "total": 58
   }
 }

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -401,6 +401,128 @@
                      {#1}{#2}{#3}{#4}{#5}{#8} ) } }
   }
 
+% ---------- corridors --------------------------------------------------------
+% A corridor is the exterior routing lane beside a measured obstacle set.
+% One axis at a time: a caller sets the outward direction, folds the paper
+% points and boxes it owns, and reads three resolved measures -- the outward
+% silhouette (farthest along-projection), the transverse interval (min and
+% max across-projections), and escape displacements around forbidden
+% intervals.  The walk is closed-form like the placement graph: no
+% iteration, no search, and the caller decides WHICH points matter.  All
+% quantities are paper dimensions because obstacles arrive as rendered
+% geometry, not pitch factors.
+\dim_new:N \l__tenkz_geom_cor_dx_dim
+\dim_new:N \l__tenkz_geom_cor_dy_dim
+\dim_new:N \l__tenkz_geom_cor_norm_dim
+\dim_new:N \l__tenkz_geom_cor_sil_dim
+\dim_new:N \l__tenkz_geom_cor_tmin_dim
+\dim_new:N \l__tenkz_geom_cor_tmax_dim
+\dim_new:N \l__tenkz_geom_cor_scratch_dim
+
+\cs_new_protected:Npn \__tenkz_geom_corridor_axis:nn #1#2
+  {
+    \dim_set:Nn \l__tenkz_geom_cor_dx_dim {#1}
+    \dim_set:Nn \l__tenkz_geom_cor_dy_dim {#2}
+    \dim_set:Nn \l__tenkz_geom_cor_norm_dim
+      { \fp_to_dim:n
+          { sqrt( \l__tenkz_geom_cor_dx_dim ^ 2
+                  + \l__tenkz_geom_cor_dy_dim ^ 2 ) } }
+  }
+\cs_new_protected:Npn \__tenkz_geom_corridor_reset:
+  {
+    \dim_set:Nn \l__tenkz_geom_cor_sil_dim  { -\c_max_dim }
+    \dim_set:Nn \l__tenkz_geom_cor_tmin_dim {  \c_max_dim }
+    \dim_set:Nn \l__tenkz_geom_cor_tmax_dim { -\c_max_dim }
+  }
+
+% Projections onto the outward axis and its left-hand transverse; the
+% formulas are the lattice originals verbatim so resolved routes keep their
+% exact rounding.
+\cs_new_protected:Npn \__tenkz_geom_corridor_along:nnN #1#2#3
+  {
+    \dim_set:Nn #3
+      { \fp_to_dim:n
+          { ( (#1) * \l__tenkz_geom_cor_dx_dim
+              + (#2) * \l__tenkz_geom_cor_dy_dim )
+              / \l__tenkz_geom_cor_norm_dim } }
+  }
+\cs_new_protected:Npn \__tenkz_geom_corridor_trans:nnN #1#2#3
+  {
+    \dim_set:Nn #3
+      { \fp_to_dim:n
+          { ( -(#1) * \l__tenkz_geom_cor_dy_dim
+              + (#2) * \l__tenkz_geom_cor_dx_dim )
+              / \l__tenkz_geom_cor_norm_dim } }
+  }
+% Reconstruct the paper point with the given along and transverse
+% coordinates in the current corridor frame.
+\cs_new_protected:Npn \__tenkz_geom_corridor_point:nnNN #1#2#3#4
+  {
+    \dim_set:Nn #3
+      { \fp_to_dim:n
+          { ( (#1) * \l__tenkz_geom_cor_dx_dim
+              - (#2) * \l__tenkz_geom_cor_dy_dim )
+              / \l__tenkz_geom_cor_norm_dim } }
+    \dim_set:Nn #4
+      { \fp_to_dim:n
+          { ( (#1) * \l__tenkz_geom_cor_dy_dim
+              + (#2) * \l__tenkz_geom_cor_dx_dim )
+              / \l__tenkz_geom_cor_norm_dim } }
+  }
+
+% Fold one paper point: silhouette takes the along maximum, the transverse
+% interval widens to cover the across-projection.
+\cs_new_protected:Npn \__tenkz_geom_corridor_include:nn #1#2
+  {
+    \__tenkz_geom_corridor_along:nnN {#1}{#2} \l__tenkz_geom_cor_scratch_dim
+    \dim_set:Nn \l__tenkz_geom_cor_sil_dim
+      { \dim_max:nn { \l__tenkz_geom_cor_sil_dim }
+          { \l__tenkz_geom_cor_scratch_dim } }
+    \__tenkz_geom_corridor_trans:nnN {#1}{#2} \l__tenkz_geom_cor_scratch_dim
+    \dim_set:Nn \l__tenkz_geom_cor_tmin_dim
+      { \dim_min:nn { \l__tenkz_geom_cor_tmin_dim }
+          { \l__tenkz_geom_cor_scratch_dim } }
+    \dim_set:Nn \l__tenkz_geom_cor_tmax_dim
+      { \dim_max:nn { \l__tenkz_geom_cor_tmax_dim }
+          { \l__tenkz_geom_cor_scratch_dim } }
+  }
+% Fold the transverse span only: cup routing measures a site's across
+% extent without letting it push the outward lane.
+\cs_new_protected:Npn \__tenkz_geom_corridor_include_trans:nn #1#2
+  {
+    \__tenkz_geom_corridor_trans:nnN {#1}{#2} \l__tenkz_geom_cor_scratch_dim
+    \dim_set:Nn \l__tenkz_geom_cor_tmin_dim
+      { \dim_min:nn { \l__tenkz_geom_cor_tmin_dim }
+          { \l__tenkz_geom_cor_scratch_dim } }
+    \dim_set:Nn \l__tenkz_geom_cor_tmax_dim
+      { \dim_max:nn { \l__tenkz_geom_cor_tmax_dim }
+          { \l__tenkz_geom_cor_scratch_dim } }
+  }
+\cs_new_protected:Npn \__tenkz_geom_corridor_include_bbox:nnnn #1#2#3#4
+  {
+    \__tenkz_geom_corridor_include:nn {#1} {#3}
+    \__tenkz_geom_corridor_include:nn {#1} {#4}
+    \__tenkz_geom_corridor_include:nn {#2} {#3}
+    \__tenkz_geom_corridor_include:nn {#2} {#4}
+  }
+
+% Escape a forbidden transverse interval: when the tip projection lands
+% within bulge of [min,max], displace it to the nearer clear side plus
+% bulge; otherwise it is already clear and stays.  #1 tip register
+% (adjusted in place), #2 interval min, #3 interval max, #4 bulge.
+\cs_new_protected:Npn \__tenkz_geom_corridor_escape:Nnnn #1#2#3#4
+  {
+    \bool_lazy_and:nnT
+      { ! \dim_compare_p:nNn {#1} < { (#2) - (#4) } }
+      { ! \dim_compare_p:nNn {#1} > { (#3) + (#4) } }
+      {
+        \dim_compare:nNnTF
+          { #1 - (#2) } < { (#3) - #1 }
+          { \dim_set:Nn #1 { (#2) - (#4) } }
+          { \dim_set:Nn #1 { (#3) + (#4) } }
+      }
+  }
+
 % ---------- probes -----------------------------------------------------------
 % Test fixtures assert geometry through the event stream; six decimals keep
 % the hashes stable and the assertions honest.

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -2668,16 +2668,16 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
             \str_if_eq:nnTF {##1} {east}
               {
                 \tenkz_seg:nnnnn
-                  { \l__tenkz_x_dim + \tenkz@dim{0.04} }
+                  { \l__tenkz_x_dim + \tenkz@dim{\tenkz@r@cupmouth} }
                   { \l__tenkz_tmp_dim }
-                  { \l__tenkz_x_dim + \tenkz@dim{0.50} }
+                  { \l__tenkz_x_dim + \tenkz@dim{\tenkz@r@cupdepth} }
                   { \l__tenkz_tmp_dim } { bond }
               }
               {
                 \tenkz_seg:nnnnn
-                  { \l__tenkz_x_dim - \tenkz@dim{0.04} }
+                  { \l__tenkz_x_dim - \tenkz@dim{\tenkz@r@cupmouth} }
                   { \l__tenkz_tmp_dim }
-                  { \l__tenkz_x_dim - \tenkz@dim{0.50} }
+                  { \l__tenkz_x_dim - \tenkz@dim{\tenkz@r@cupdepth} }
                   { \l__tenkz_tmp_dim } { bond }
               }
           }
@@ -2687,8 +2687,8 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
     \tl_if_blank:VF \l_tmpb_tl
       {
         \str_if_eq:VnTF \l__tenkz_fcombined_tl {east}
-          { \dim_add:Nn \l__tenkz_x_dim { \tenkz@dim{0.30} } }
-          { \dim_sub:Nn \l__tenkz_x_dim { \tenkz@dim{0.30} } }
+          { \dim_add:Nn \l__tenkz_x_dim { \tenkz@dim{\tenkz@r@wireclear} } }
+          { \dim_sub:Nn \l__tenkz_x_dim { \tenkz@dim{\tenkz@r@wireclear} } }
         \tenkz_map:nn { \l__tenkz_x_dim }
           { \l__tenkz_tmp_dim + \tenkz@dim{\tenkz@r@labelclear} }
         \__tenkz_render_labelnode:nnn
@@ -2732,7 +2732,7 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
             \tenkz_map:nn
               { \tenkz_colx:n{\l__tenkz_pwbase_tl}
                 + \str_if_eq:nnTF {#3}{east}
-                    {\tenkz@dim{0.50}}{-\tenkz@dim{0.50}} }
+                    {\tenkz@dim{\tenkz@r@cupdepth}}{-\tenkz@dim{\tenkz@r@cupdepth}} }
               { ( \tenkz_rowy:n {\l__tenkz_fusebase_int}
                   + \tenkz_rowy:n
                     {\l__tenkz_fusebase_int + \l__tenkz_frows_int - 1} ) / 2 }
@@ -2740,10 +2740,10 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
           {
             \str_if_eq:nnTF {#3} {east}
               { \tenkz_map:nn
-                  { \tenkz_colx:n{\l__tenkz_pwbase_tl} + \tenkz@dim{0.04} }
+                  { \tenkz_colx:n{\l__tenkz_pwbase_tl} + \tenkz@dim{\tenkz@r@cupmouth} }
                   { \tenkz_rowy:n {#1} } }
               { \tenkz_map:nn
-                  { \tenkz_colx:n{\l__tenkz_pwbase_tl} - \tenkz@dim{0.04} }
+                  { \tenkz_colx:n{\l__tenkz_pwbase_tl} - \tenkz@dim{\tenkz@r@cupmouth} }
                   { \tenkz_rowy:n {#1} } }
           }
         \tl_set:Ne #4 { \tenkz_mpt: }

--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -612,8 +612,8 @@
   {
     \cs_set:Npn \tenkz@r@planeslant {#1}
     \bool_lazy_and:nnF
-      { \fp_compare_p:nNn {#1} > {0.30} }
-      { \fp_compare_p:nNn {#1} < {0.65} }
+      { \fp_compare_p:nNn {#1} > {\tenkz@r@slantmin} }
+      { \fp_compare_p:nNn {#1} < {\tenkz@r@slantmax} }
       {
         \msg_warning:nnn { tenkz } { plane-slant-band } {#1}
         \tenkz@event{warning|picture=\the\tenkz@pictureid|%
@@ -3130,7 +3130,7 @@
         % The metric radius is the fallback.  Semantic style extensions from
         % the execute-once environment body arrive through #1 and must remain
         % free to replace it.
-        \__tenkz_render_stroke:nn { rounded~corners=\tenkz@dim{0.10}, #1,
+        \__tenkz_render_stroke:nn { rounded~corners=\tenkz@dim{\tenkz@r@regioncorner}, #1,
                even~odd~rule }
       { \l__tenkzl_path_tl }
       }

--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -1693,14 +1693,16 @@
 \dim_new:N \l__tenkzl_cupbly_dim
 \dim_new:N \l__tenkzl_cupbcx_dim
 \dim_new:N \l__tenkzl_cupbcy_dim
-\dim_new:N \l__tenkzl_cupdx_dim
-\dim_new:N \l__tenkzl_cupdy_dim
-\dim_new:N \l__tenkzl_cupnorm_dim
-\dim_new:N \l__tenkzl_cupsil_dim
+% Corridor measures live in the shared geometry service; the lattice keeps
+% its historical spellings as bridges so every call site reads unchanged.
+\cs_new_eq:NN \l__tenkzl_cupdx_dim   \l__tenkz_geom_cor_dx_dim
+\cs_new_eq:NN \l__tenkzl_cupdy_dim   \l__tenkz_geom_cor_dy_dim
+\cs_new_eq:NN \l__tenkzl_cupnorm_dim \l__tenkz_geom_cor_norm_dim
+\cs_new_eq:NN \l__tenkzl_cupsil_dim  \l__tenkz_geom_cor_sil_dim
 \dim_new:N \l__tenkzl_cupproj_dim
 \dim_new:N \l__tenkzl_cupbulge_dim
-\dim_new:N \l__tenkzl_cuptransmin_dim
-\dim_new:N \l__tenkzl_cuptransmax_dim
+\cs_new_eq:NN \l__tenkzl_cuptransmin_dim \l__tenkz_geom_cor_tmin_dim
+\cs_new_eq:NN \l__tenkzl_cuptransmax_dim \l__tenkz_geom_cor_tmax_dim
 \dim_new:N \l__tenkzl_cuptransmid_dim
 \dim_new:N \l__tenkzl_cuptranstarget_dim
 \dim_new:N \l__tenkzl_cuplane_dim
@@ -1810,30 +1812,19 @@
             \dim_set:Nn \l__tenkzl_cupdy_dim
               { -\l__tenkzl_ayy_tl \l__tenkzl_lp_dim } }
       }
-    \dim_set:Nn \l__tenkzl_cupnorm_dim
-      { \fp_to_dim:n
-          { sqrt( \l__tenkzl_cupdx_dim ^ 2 + \l__tenkzl_cupdy_dim ^ 2 ) } }
+    \__tenkz_geom_corridor_axis:nn
+      { \l__tenkzl_cupdx_dim } { \l__tenkzl_cupdy_dim }
   }
 
 % Project paper point (#1,#2) onto the current side's outward unit axis.
 \cs_new_protected:Npn \tenkzl_side_cup_project:NNN #1#2#3
-  {
-    \dim_set:Nn #3
-      { \fp_to_dim:n
-          { ( #1 * \l__tenkzl_cupdx_dim + #2 * \l__tenkzl_cupdy_dim )
-              / \l__tenkzl_cupnorm_dim } }
-  }
+  { \__tenkz_geom_corridor_along:nnN {#1} {#2} #3 }
 
 % Project a paper point onto the unit axis perpendicular to the current
 % side direction.  Together with \tenkzl_side_cup_project:NNN this is an
 % orthonormal paper-frame coordinate system for obstacle routing.
 \cs_new_protected:Npn \tenkzl_side_cup_project_trans:NNN #1#2#3
-  {
-    \dim_set:Nn #3
-      { \fp_to_dim:n
-          { ( -#1 * \l__tenkzl_cupdy_dim + #2 * \l__tenkzl_cupdx_dim )
-              / \l__tenkzl_cupnorm_dim } }
-  }
+  { \__tenkz_geom_corridor_trans:nnN {#1} {#2} #3 }
 
 \cs_new_protected:Npn \tenkzl_side_cup_site_silhouette:nnn #1#2#3
   {
@@ -1841,14 +1832,8 @@
       {
         \tenkzl_xyz:nnnNN {#1}{#2}{#3}
           \l__tenkzl_cupax_dim \l__tenkzl_cupay_dim
-        \tenkzl_side_cup_project_trans:NNN
-          \l__tenkzl_cupax_dim \l__tenkzl_cupay_dim \l__tenkzl_cupproj_dim
-        \dim_set:Nn \l__tenkzl_cuptransmin_dim
-          { \dim_min:nn { \l__tenkzl_cuptransmin_dim }
-              { \l__tenkzl_cupproj_dim } }
-        \dim_set:Nn \l__tenkzl_cuptransmax_dim
-          { \dim_max:nn { \l__tenkzl_cuptransmax_dim }
-              { \l__tenkzl_cupproj_dim } }
+        \__tenkz_geom_corridor_include_trans:nn
+          { \l__tenkzl_cupax_dim } { \l__tenkzl_cupay_dim }
       }
   }
 
@@ -1883,9 +1868,7 @@
 \cs_new_protected:Npn \tenkzl_side_cup_silhouette:n #1
   {
     \tenkzl_side_cup_direction:n {#1}
-    \dim_set:Nn \l__tenkzl_cupsil_dim { -\c_max_dim }
-    \dim_set:Nn \l__tenkzl_cuptransmin_dim { \c_max_dim }
-    \dim_set:Nn \l__tenkzl_cuptransmax_dim { -\c_max_dim }
+    \__tenkz_geom_corridor_reset:
     % Named loop registers make the row/column/sheet ownership explicit;
     % nested inline placeholders are too easy to permute at this depth.
     \int_step_variable:nnNn {0} { \l__tenkzl_sheets_int - 1 }
@@ -2211,16 +2194,7 @@
 % projections.  The side direction has already passed through the single
 % lattice frame map, so this is metric resolution rather than a second map.
 \cs_new_protected:Npn \tenkzl_side_cup_from_projections:NNNN #1#2#3#4
-  {
-    \dim_set:Nn #3
-      { \fp_to_dim:n
-          { ( #1 * \l__tenkzl_cupdx_dim - #2 * \l__tenkzl_cupdy_dim )
-              / \l__tenkzl_cupnorm_dim } }
-    \dim_set:Nn #4
-      { \fp_to_dim:n
-          { ( #1 * \l__tenkzl_cupdy_dim + #2 * \l__tenkzl_cupdx_dim )
-              / \l__tenkzl_cupnorm_dim } }
-  }
+  { \__tenkz_geom_corridor_point:nnNN {#1} {#2} #3 #4 }
 
 \cs_new_protected:Npn \tenkzl_draw_side_cup_at:nnn #1#2#3
   {
@@ -2519,9 +2493,7 @@
 \cs_new_protected:Npn \tenkzl_trace_silhouette:n #1
   {
     \tenkzl_side_cup_direction:n {#1}
-    \dim_set:Nn \l__tenkzl_cupsil_dim { -\c_max_dim }
-    \dim_set:Nn \l__tenkzl_cuptransmin_dim { \c_max_dim }
-    \dim_set:Nn \l__tenkzl_cuptransmax_dim { -\c_max_dim }
+    \__tenkz_geom_corridor_reset:
     \int_step_variable:nnNn {0}{\l__tenkzl_sheets_int - 1}
       \l__tenkzl_cupscansheet_int
       {

--- a/tex/tenkz/tenkz-metric.code.tex
+++ b/tex/tenkz/tenkz-metric.code.tex
@@ -23,6 +23,8 @@
   { [TKZ-METRIC-UNKNOWN]~no~metric~entry~named~'#1' }
 \msg_new:nnn {tenkz}{metric-redeclared}
   { [TKZ-METRIC-REDECLARED]~metric~entry~'#1'~already~exists }
+\msg_new:nnn {tenkz}{metric-legacy-kind}
+  { [TKZ-METRIC-LEGACY-KIND]~length~metric~'#1'~has~a~ratio-style~legacy~macro }
 \msg_new:nnnn {tenkz}{metric-drift}
   { [TKZ-METRIC-DRIFT]~registry~'#1'~and~its~legacy~macro~disagree }
   { Registry~value~#2;~legacy~value~#3.~One~truth,~two~spellings:~fix~one. }
@@ -34,10 +36,21 @@
     \prop_gput:Nnn \g__tenkz_metric_value_prop {#2} {#3}
     \prop_gput:Nnn \g__tenkz_metric_kind_prop  {#2} {#1}
     \prop_gput:Nnn \g__tenkz_metric_why_prop   {#2} {#4}
-    % A registry-first entry mints its legacy spelling; a legacy-first
-    % entry keeps its \def and the drift assertion holds the two equal.
-    \cs_if_exist:cF { tenkz@r@#2 }
-      { \cs_new:cpn { tenkz@r@#2 } {#3} }
+    % A registry-first entry mints the kind-correct legacy spelling; a
+    % legacy-first entry keeps its \def and the drift assertion holds the
+    % two equal.  Ratios use \tenkz@r@<name>; absolute lengths use
+    % \tenkz@<name> and must never acquire the ratio spelling.
+    \str_if_eq:nnTF {#1} {ratio}
+      {
+        \cs_if_exist:cF { tenkz@r@#2 }
+          { \cs_new:cpn { tenkz@r@#2 } {#3} }
+      }
+      {
+        \cs_if_exist:cF { tenkz@#2 }
+          { \cs_new:cpn { tenkz@#2 } {#3} }
+        \cs_if_exist:cT { tenkz@r@#2 }
+          { \msg_error:nnn {tenkz}{metric-legacy-kind} {#2} }
+      }
   }
 \cs_new_protected:Npn \__tenkz_metric_declare:nnn #1#2#3
   { \__tenkz_metric_declare_aux:nnnn {ratio} {#1} {#2} {#3} }

--- a/tex/tenkz/tenkz-metric.code.tex
+++ b/tex/tenkz/tenkz-metric.code.tex
@@ -34,6 +34,10 @@
     \prop_gput:Nnn \g__tenkz_metric_value_prop {#2} {#3}
     \prop_gput:Nnn \g__tenkz_metric_kind_prop  {#2} {#1}
     \prop_gput:Nnn \g__tenkz_metric_why_prop   {#2} {#4}
+    % A registry-first entry mints its legacy spelling; a legacy-first
+    % entry keeps its \def and the drift assertion holds the two equal.
+    \cs_if_exist:cF { tenkz@r@#2 }
+      { \cs_new:cpn { tenkz@r@#2 } {#3} }
   }
 \cs_new_protected:Npn \__tenkz_metric_declare:nnn #1#2#3
   { \__tenkz_metric_declare_aux:nnnn {ratio} {#1} {#2} {#3} }
@@ -92,6 +96,21 @@
   { open~index:~longer~than~a~leg,~shorter~than~a~bond;~also~the~cup~reach }
 \__tenkz_metric_declare:nnn {daylight} {0.15}
   { the~one~gap~between~a~silhouette~and~closure~or~annotation~ink }
+\__tenkz_metric_declare:nnn {cupmouth} {0.04}
+  { horizontal~lead-in~of~a~trace~mouth:~just~enough~bend~to~read~as~a~turn }
+\__tenkz_metric_declare:nnn {cupdepth} {0.50}
+  { racetrack~half-depth:~the~closure~clears~half~a~cell~beyond~the~word }
+\__tenkz_metric_declare:nnn {wireclear} {0.30}
+  { lateral~escape~of~an~interrupted~wire~around~an~on-wire~glyph }
+\__tenkz_metric_declare:nnn {regioncorner} {0.10}
+  { region-loop~corner~radius:~tighter~than~a~glyph~corner~so~a~nested~
+    boundary~reads~as~an~outline,~not~a~pill }
+\__tenkz_metric_declare:nnn {slantmin} {0.30}
+  { plane~slant~floor:~below~it~depth~bonds~steepen~past~61~degrees~and~
+    become~confusable~with~vertical~physical~legs }
+\__tenkz_metric_declare:nnn {slantmax} {0.65}
+  { plane~slant~cap:~above~it~a~receding~row~lands~on~the~next~row's~
+    sites~under~rotation }
 \__tenkz_metric_declare:nnn {labelclear} {0.12}
   { one~clearance~for~every~label~band }
 \__tenkz_metric_declare:nnn {dotlabelband} {0.30}


### PR DESCRIPTION
## What changed

- Move the lattice cup/trace corridor frame, projections, reconstruction, silhouette folds, and interval escape into the shared geometry service.
- Keep one-line lattice adapters so established call sites retain their exact routing order while duplicated mathematical bodies disappear.
- Register six motivated metric ratios (cup mouth/depth, wire clearance, region corner radius, and plane slant bounds) and replace their raw literals.
- Ratchet the render census from 71 to 58 stray decimals while raw non-render ink remains 47.

This is the final shared-geometry corridor for #4698, recovered as two unpicked commits from agent/tenkz-s3-corridor and replayed on current main after #4737 and #4742.

## Why

Lattice cup and trace routing used the same outward-axis, along/transverse projection, reconstruction, silhouette, and forbidden-interval mathematics behind separate lattice-prefixed helpers. Centralizing that closed-form service gives grid/lattice follow-ups one geometry owner without changing which obstacles the lattice supplies or how routes are selected.

## Validation

- scripts/tenkz_corpus.sh — 261/261 standalone files compiled and audited
- TENKZ_CORPUS_JOBS=8 scripts/tenkz_golden.sh --check — 261/261 event streams byte-identical
- TENKZ_CORPUS_JOBS=8 scripts/tenkz_pixelpair.sh origin/main — 6/6 sentinel pages byte-identical at 300 DPI
- python3 scripts/test_tenkz_enclosures.py
- python3 scripts/test_tenkz_label_overlap.py
- python3 scripts/test_tenkz_peps_torus.py
- python3 scripts/test_tenkz_face_ports.py
- language, shrink, and render-census gates passed locally

The Playwright-backed web-layout check remains delegated to repository Chromium CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lattice cup/trace routing and shared geometry projections; behavior is intended to be identical (golden/pixel validation), but rounding-sensitive path code is a moderate regression surface.
> 
> **Overview**
> Cup/trace **corridor** math (outward axis, along/transverse projections, point reconstruction, silhouette folds, forbidden-interval escape) moves into **`tenkz-geometry`** as `\__tenkz_geom_corridor_*`. Lattice keeps thin adapters—shared dims via `\cs_new_eq:NN` and one-line forwards—so call sites and rounding behavior stay the same while duplicate bodies are removed.
> 
> The **metric registry** gains six ratio entries (`cupmouth`, `cupdepth`, `wireclear`, `regioncorner`, `slantmin`, `slantmax`); grid and lattice swap hard-coded decimals for `\tenkz@dim{\tenkz@r@…}`. Declaration now mints kind-correct legacy macros (`\tenkz@r@` vs `\tenkz@`) and errors if a length metric gets a ratio-style legacy name.
> 
> **Render census** decimal-literal total drops **71 → 58** (grid/lattice counts ratcheted in the baseline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c4c1dd91003f8f6251f6e92caa667ae4c86c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->