### PR TITLE
refactor(tenkz): consolidate S4 front ends

### DIFF
--- a/tests/tenkz/LOCAL_FIXTURES.tsv
+++ b/tests/tenkz/LOCAL_FIXTURES.tsv
@@ -3,3 +3,5 @@ zz_geomdag.tex	tests/tenkz/zz_geomdag.tex	local geometry DAG regression; compile
 zz_geomframe.tex	tests/tenkz/zz_geomframe.tex	local geometry frame regression; compiles, emits tnlog, and passes tenkz_audit
 zz_geomsupport.tex	tests/tenkz/zz_geomsupport.tex	local support-function regression; compiles, emits tnlog, and passes tenkz_audit
 zz_renderslice.tex	tests/tenkz/zz_renderslice.tex	local shared-renderer regression; compiles, emits tnlog, and passes tenkz_audit
+zz_vertprune.tex	tests/tenkz/zz_vertprune.tex	local vertical-pruning regression; compiles, emits tnlog, and passes tenkz_audit
+zz_wirescan.tex	tests/tenkz/zz_wirescan.tex	local wire-scan sentinel regression; compiles, emits tnlog, and passes tenkz_audit

--- a/tests/tenkz/free_test.tex
+++ b/tests/tenkz/free_test.tex
@@ -4,6 +4,36 @@
 \usepackage{amsmath}
 \usepackage{tenkz}
 \begin{document}
+\ExplSyntaxOn
+\int_new:N \g__tenkz_test_free_picture_int
+\int_new:N \l__tenkz_test_free_atom_int
+\int_new:N \l__tenkz_test_free_wire_int
+\cs_new_eq:NN \__tenkz_test_free_validate: \__tenkz_model_validate:
+\cs_set_protected:Npn \__tenkz_model_validate:
+  {
+    \int_gincr:N \g__tenkz_test_free_picture_int
+    \__tenkz_model_count:nN {atom} \l__tenkz_test_free_atom_int
+    \__tenkz_model_count:nN {wire} \l__tenkz_test_free_wire_int
+    \int_compare:nNnF {\l__tenkz_test_free_atom_int} = {2}
+      {
+        \PackageError{tenkz-test}
+          {Free~picture~\int_use:N\g__tenkz_test_free_picture_int~
+            recorded~\int_use:N\l__tenkz_test_free_atom_int~atoms}
+          {Both~free~atoms~must~survive~their~command-local~groups.}
+      }
+    \int_compare:nNnF
+      {\l__tenkz_test_free_wire_int}
+      =
+      {\int_compare:nNnTF {\g__tenkz_test_free_picture_int} = {1} {2} {1}}
+      {
+        \PackageError{tenkz-test}
+          {Free~picture~\int_use:N\g__tenkz_test_free_picture_int~
+            recorded~\int_use:N\l__tenkz_test_free_wire_int~wires}
+          {Every~valid~join~must~survive~its~command-local~group.}
+      }
+    \__tenkz_test_free_validate:
+  }
+\ExplSyntaxOff
 \begin{tenkzfree}
   \tnput[ports={east:virtual, north:physical}]{a}{(0,0)}{A}
   \tnput[ports={west:virtual}]{b}{(14mm,0)}{B}

--- a/tests/tenkz/render-census-baseline.json
+++ b/tests/tenkz/render-census-baseline.json
@@ -3,7 +3,7 @@
     "by_file": {
       "tenkz-cd.code.tex": 21,
       "tenkz-core.code.tex": 8,
-      "tenkz-free.code.tex": 11,
+      "tenkz-free.code.tex": 0,
       "tenkz-geometry.code.tex": 0,
       "tenkz-grid.code.tex": 7,
       "tenkz-language.code.tex": 0,
@@ -12,12 +12,12 @@
       "tenkz-model.code.tex": 0,
       "tenkz-render.code.tex": 0
     },
-    "total": 47
+    "total": 36
   },
   "decimal_literals": {
     "by_file": {
       "tenkz-cd.code.tex": 1,
-      "tenkz-core.code.tex": 25,
+      "tenkz-core.code.tex": 18,
       "tenkz-free.code.tex": 4,
       "tenkz-geometry.code.tex": 0,
       "tenkz-grid.code.tex": 18,
@@ -27,6 +27,6 @@
       "tenkz-model.code.tex": 0,
       "tenkz-render.code.tex": 0
     },
-    "total": 58
+    "total": 51
   }
 }

--- a/tests/tenkz/zz_wirescan.tex
+++ b/tests/tenkz/zz_wirescan.tex
@@ -1,12 +1,12 @@
-% Regression: zz_wirescan — a wire lookup that misses must return the
-% no-value sentinel without expanding it, even when closure wires (which
-% carry no from/to fields) sit in the model store.
+% Regression: zz_wirescan — wire lookup misses retain the no-value sentinel,
+% and record-derived virtual pairings survive into the boundary pass.
 % Formula: Tr[A B] — the periodic wrap is the from/to-less closure record.
 \documentclass[varwidth=10cm, border=6pt]{standalone}
 \usepackage{tenkz}
 \begin{document}
 \ExplSyntaxOn
 \cs_new_eq:NN \__tenkz_test_validate: \__tenkz_model_validate:
+\cs_new_eq:NN \__tenkz_test_draw_bonds: \tenkz_draw_bonds:
 \cs_set_protected:Npn \__tenkz_model_validate:
   {
     % The store now holds one bond wire and one wrap closure.  A miss must
@@ -20,6 +20,22 @@
             sentinel~for~a~miss.}
       }
     \__tenkz_test_validate:
+  }
+\cs_set_protected:Npn \tenkz_draw_bonds:
+  {
+    \__tenkz_test_draw_bonds:
+    \prop_if_in:NnF \l__tenkz_virtualpaired_prop {1-1-east}
+      {
+        \PackageError{tenkz-test}
+          {Record-derived~east~pairing~was~discarded}
+          {The~bond~WIRE~fill~must~survive~until~boundary~resolution.}
+      }
+    \prop_if_in:NnF \l__tenkz_virtualpaired_prop {1-2-west}
+      {
+        \PackageError{tenkz-test}
+          {Record-derived~west~pairing~was~discarded}
+          {The~bond~WIRE~fill~must~survive~until~boundary~resolution.}
+      }
   }
 \ExplSyntaxOff
 \begin{tenkz}[rows={ket}, west=trace, east=trace]

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -110,18 +110,9 @@
                                % cover its wires); also the bar's silhouette
                                % contribution, so drawing and clearance read
                                % one number
-% absolute floors and ink hierarchy
-\def\tenkz@wirewidth{0.55pt}
-\def\tenkz@annwidth{0.40pt}
-\def\tenkz@emphwidth{0.80pt}
-\def\tenkz@junctionfloor{0.9mm}% ~4.7x the 0.55pt wire width: below this
-                               % absolute floor a junction reads as dirt
-\def\tenkz@barblen{2.6pt}      % directionality barb; a print-size floor, not
-                               % a ratio: below this the barb reads as dirt
-\def\tenkz@fusedbarblen{3.8pt} % barb spanning a doubled (fused) wire
-\def\tenkz@braceamp{2.6pt}     % brace amplitude; numerically the barb floor
-                               % (both are the smallest mark that reads at
-                               % print size), semantically independent
+% absolute floors and ink hierarchy: the metric registry owns the values
+% (tenkz-metric.code.tex); these spellings resolve through it lazily so
+% the styles below keep reading \tenkz@wirewidth et al. unchanged.
 
 \def\tenkz@dim#1{\dimexpr#1\tenkz@pitch\relax}
 

--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -221,21 +221,21 @@
     \begin{scope}[local~bounding~box=\l__tenkz_fbound_tl]
       \str_case:Vn \l__tenkz_fshape_tl
         {
-          {dot}  { \__tenkz_render_free_node:nnnn
+          {dot}  { \__tenkz_render_labelnode_named:nnnn
                      {tensor, \l__tenkz_frolesty_tl} {#2} {#3} {}
                    \tl_if_blank:nF {#4}
                      { \exp_args:NV \tenkz_free_dot_label:nnn
                          \l__tenkz_flpos_tl {#2} {#4} } }
-          {box}  { \__tenkz_render_free_node:nnnn
+          {box}  { \__tenkz_render_labelnode_named:nnnn
                      {box~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
-          {pill} { \__tenkz_render_free_node:nnnn
+          {pill} { \__tenkz_render_labelnode_named:nnnn
                      {pill~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
-          {mpo}  { \__tenkz_render_free_node:nnnn
+          {mpo}  { \__tenkz_render_labelnode_named:nnnn
                      {mpo~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
-          {ring} { \__tenkz_render_free_node:nnnn
+          {ring} { \__tenkz_render_labelnode_named:nnnn
                      {on-wire~matrix, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
           {boundary}

--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -48,6 +48,7 @@
 \bool_new:N \l__tenkz_fkeys_valid_bool
 \tl_new:N \l__tenkz_frolesty_tl  % resolved role/species style (or empty)
 \tl_new:N \l__tenkz_fbound_tl    % measured glyph + external-label box
+\tl_new:N \g__tenkz_free_atom_record_tl
 \pgfkeys{
   /tenkz/put/.is~family,
   /tenkz/put/dot/.code={\tl_set:Nn \l__tenkz_fshape_tl {dot}},
@@ -169,6 +170,7 @@
 
 \NewDocumentCommand \tnput { O{} m m m }
   {
+    \tl_gclear:N \g__tenkz_free_atom_record_tl
     \group_begin:
     % the default skin is the glyph policy (tensor style=dot|box); an
     % explicit skin key overrides it below
@@ -199,7 +201,7 @@
       }
     \bool_if:NT \l__tenkz_fcommit_bool
       {
-    \__tenkz_model_record_atom:e
+    \tl_gset:Ne \g__tenkz_free_atom_record_tl
       { kind={put}, name={\exp_not:n{#2}}, at={\exp_not:n{#3}},
         skin={\tl_use:N \l__tenkz_fshape_tl},
         ports={\tl_use:N \l__tenkz_fports_tl},
@@ -259,6 +261,12 @@
     \tenkz@event{atom|picture=\the\tenkz@pictureid|name=#2|kind=\tl_use:N \l__tenkz_fshape_tl|role=\tenkz_free_word:N \l__tenkz_frole_tl|species=\tenkz_free_word:N \l__tenkz_fspec_tl}
       }
     \group_end:
+    \tl_if_empty:NF \g__tenkz_free_atom_record_tl
+      {
+        \exp_args:NV \__tenkz_model_record_atom:n
+          \g__tenkz_free_atom_record_tl
+        \tl_gclear:N \g__tenkz_free_atom_record_tl
+      }
   }
 \use:e
   {
@@ -287,6 +295,7 @@
 \tl_new:N \l__tenkz_jrolesty_tl % resolved role/species bond style (or empty)
 \tl_new:N \l__tenkz_jname_tl    % optional enclosure-visible join name
 \tl_new:N \l__tenkz_jbound_tl   % measured path + label box
+\tl_new:N \g__tenkz_free_wire_record_tl
 \bool_new:N \l__tenkz_jfused_bool
 \bool_new:N \l__tenkz_jdir_bool
 \bool_new:N \l__tenkz_jroute_valid_bool
@@ -369,6 +378,7 @@
 
 \NewDocumentCommand \tnjoin { O{} m m }
   {
+    \tl_gclear:N \g__tenkz_free_wire_record_tl
     \group_begin:
     \tl_set:Nn \l__tenkz_jroute_tl {straight}
     \tl_clear:N \l__tenkz_jlabel_tl
@@ -474,7 +484,7 @@
       }
     \bool_if:NT \l__tenkz_jcommit_bool
       {
-        \__tenkz_model_record_wire:e
+        \tl_gset:Ne \g__tenkz_free_wire_record_tl
           { kind={index}, origin={join},
             from={\exp_not:n{#2}}, to={\exp_not:n{#3}},
             route={\tl_use:N \l__tenkz_jroute_tl},
@@ -488,6 +498,12 @@
       }
       }
     \group_end:
+    \tl_if_empty:NF \g__tenkz_free_wire_record_tl
+      {
+        \exp_args:NV \__tenkz_model_record_wire:n
+          \g__tenkz_free_wire_record_tl
+        \tl_gclear:N \g__tenkz_free_wire_record_tl
+      }
   }
 
 \cs_new_protected:Npn \tenkz_free_join_route:nn #1#2

--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -18,13 +18,21 @@
   {
     \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz}{#1} }
     \tenkz@beginpicture{free}
+    % The free tier records imperatively: atoms and joins write as the
+    % body executes, so validation seals the store at the environment's
+    % END.  Write-only until the free renderer consumes records.
+    \__tenkz_model_reset:
+    \__tenkz_model_record_picture:n { lang={free} }
     % NFSS sets math fonts up lazily; force them before reading the axis
     \check@mathfonts
     \begin{tikzpicture}[tenkz~every~picture,
       baseline={(0pt,\dim_eval:n{-\fontdimen22\textfont2})}]
       \pgfsetlayers{background,main}
   }
-  { \end{tikzpicture} }
+  {
+    \__tenkz_model_validate:
+    \end{tikzpicture}
+  }
 
 % \tnput[<glyph keys>]{<name>}{<coordinate>}{<label>}
 %   glyph keys: dot|box|pill|mpo|ring|boundary (skin),
@@ -104,18 +112,18 @@
   {
     \str_case:nn {#1}
       {
-        {south} { \node[tn~label, anchor=north] at
-                    ($(#2.south)-(0,\tenkz@dim{\tenkz@r@labelclear})$)
-                    { $\tenkz@labelsize #3$ }; }
-        {north} { \node[tn~label, anchor=south] at
-                    ($(#2.north)+(0,\tenkz@dim{\tenkz@r@labelclear})$)
-                    { $\tenkz@labelsize #3$ }; }
-        {east}  { \node[tn~label, anchor=west] at
-                    ($(#2.east)+(\tenkz@dim{\tenkz@r@labelclear},0)$)
-                    { $\tenkz@labelsize #3$ }; }
-        {west}  { \node[tn~label, anchor=east] at
-                    ($(#2.west)-(\tenkz@dim{\tenkz@r@labelclear},0)$)
-                    { $\tenkz@labelsize #3$ }; }
+        {south} { \__tenkz_render_labelnode:nnn {tn~label, anchor=north}
+                    {($(#2.south)-(0,\tenkz@dim{\tenkz@r@labelclear})$)}
+                    { $\tenkz@labelsize #3$ } }
+        {north} { \__tenkz_render_labelnode:nnn {tn~label, anchor=south}
+                    {($(#2.north)+(0,\tenkz@dim{\tenkz@r@labelclear})$)}
+                    { $\tenkz@labelsize #3$ } }
+        {east}  { \__tenkz_render_labelnode:nnn {tn~label, anchor=west}
+                    {($(#2.east)+(\tenkz@dim{\tenkz@r@labelclear},0)$)}
+                    { $\tenkz@labelsize #3$ } }
+        {west}  { \__tenkz_render_labelnode:nnn {tn~label, anchor=east}
+                    {($(#2.west)-(\tenkz@dim{\tenkz@r@labelclear},0)$)}
+                    { $\tenkz@labelsize #3$ } }
       }
   }
 
@@ -191,6 +199,12 @@
       }
     \bool_if:NT \l__tenkz_fcommit_bool
       {
+    \__tenkz_model_record_atom:e
+      { kind={put}, name={\exp_not:n{#2}}, at={\exp_not:n{#3}},
+        skin={\tl_use:N \l__tenkz_fshape_tl},
+        ports={\tl_use:N \l__tenkz_fports_tl},
+        role={\tenkz_free_word:N \l__tenkz_frole_tl},
+        species={\tenkz_free_word:N \l__tenkz_fspec_tl} }
     % the role/species style rides its own literal option slot (an
     % empty slot is an inert trailing option); beads resolve through
     % the tensor family, inscribed-label skins through outline
@@ -205,26 +219,30 @@
     \begin{scope}[local~bounding~box=\l__tenkz_fbound_tl]
       \str_case:Vn \l__tenkz_fshape_tl
         {
-          {dot}  { \node[tensor, \l__tenkz_frolesty_tl] (#2) at #3 {};
+          {dot}  { \__tenkz_render_free_node:nnnn
+                     {tensor, \l__tenkz_frolesty_tl} {#2} {#3} {}
                    \tl_if_blank:nF {#4}
                      { \exp_args:NV \tenkz_free_dot_label:nnn
                          \l__tenkz_flpos_tl {#2} {#4} } }
-          {box}  { \node[box~tensor, \l__tenkz_frolesty_tl] (#2) at #3
-                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
-          {pill} { \node[pill~tensor, \l__tenkz_frolesty_tl] (#2) at #3
-                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
-          {mpo}  { \node[mpo~tensor, \l__tenkz_frolesty_tl] (#2) at #3
-                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
-          {ring} { \node[on-wire~matrix, \l__tenkz_frolesty_tl] (#2) at #3
-                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ }; }
+          {box}  { \__tenkz_render_free_node:nnnn
+                     {box~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
+                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
+          {pill} { \__tenkz_render_free_node:nnnn
+                     {pill~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
+                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
+          {mpo}  { \__tenkz_render_free_node:nnnn
+                     {mpo~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
+                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
+          {ring} { \__tenkz_render_free_node:nnnn
+                     {on-wire~matrix, \l__tenkz_frolesty_tl} {#2} {#3}
+                     { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
           {boundary}
             {
-              \coordinate (#2) at #3;
+              \__tenkz_render_free_coordinate:nn {#2} {#3}
               % A coordinate alone does not establish a usable local bounding
               % box.  Add a zero-size, zero-ink path node so a named boundary
               % endpoint remains a valid measured region member.
-              \path (#2) node[inner~sep=0pt, outer~sep=0pt,
-                minimum~size=0pt] {};
+              \__tenkz_render_free_marker:n {#2}
               \tl_if_blank:nF {#4}
                 { \exp_args:NV \tenkz_free_dot_label:nnn
                     \l__tenkz_flpos_tl {#2} {#4} }
@@ -455,7 +473,18 @@
           { \bool_set_false:N \l__tenkz_jcommit_bool }
       }
     \bool_if:NT \l__tenkz_jcommit_bool
-      { \tenkz@event{join|picture=\the\tenkz@pictureid|from=#2|to=#3|dir=\bool_if:NTF \l__tenkz_jdir_bool {forward}{none}|role=\tenkz_free_word:N \l__tenkz_jrole_tl|species=\tenkz_free_word:N \l__tenkz_jspec_tl\tl_if_empty:NF \l__tenkz_jname_tl {|name=\tl_use:N \l__tenkz_jname_tl}} }
+      {
+        \__tenkz_model_record_wire:e
+          { kind={index}, origin={join},
+            from={\exp_not:n{#2}}, to={\exp_not:n{#3}},
+            route={\tl_use:N \l__tenkz_jroute_tl},
+            dir={\bool_if:NTF \l__tenkz_jdir_bool {to}{none}},
+            role={\tenkz_free_word:N \l__tenkz_jrole_tl},
+            species={\tenkz_free_word:N \l__tenkz_jspec_tl}
+            \tl_if_empty:NF \l__tenkz_jname_tl
+              { ,name={\tl_use:N \l__tenkz_jname_tl} } }
+        \tenkz@event{join|picture=\the\tenkz@pictureid|from=#2|to=#3|dir=\bool_if:NTF \l__tenkz_jdir_bool {forward}{none}|role=\tenkz_free_word:N \l__tenkz_jrole_tl|species=\tenkz_free_word:N \l__tenkz_jspec_tl\tl_if_empty:NF \l__tenkz_jname_tl {|name=\tl_use:N \l__tenkz_jname_tl}}
+      }
       }
       }
     \group_end:
@@ -497,18 +526,7 @@
 % literal `node' and never expand a macro in that position.  Only the
 % \exp_not:V splice expands; every other token passes through inert.
 \cs_new_protected:Npn \tenkz_free_join_draw:nnnn #1#2#3#4
-  {
-    \use:e
-      {
-        \exp_not:n
-          { \draw [ \tl_use:N \l__tenkz_jstyle_tl,
-                    \tl_use:N \l__tenkz_jmarks_tl,
-                    \tl_use:N \l__tenkz_jrolesty_tl, #1 ]
-              (#2) #3 }
-        \exp_not:V \l__tenkz_jlabelnode_tl
-        \exp_not:n { (#4) ; }
-      }
-  }
+  { \__tenkz_render_free_join:nnnn {#1}{#2}{#3}{#4} }
 
 % the arc route (DESIGN spells it `arc'; `curve' survives as the 0.5
 % alias): an out=/in= curve.  Public preflight has already rejected an

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -2999,7 +2999,6 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
   {
     \int_zero:N \l__tenkz_internalvw_int
     \int_zero:N \l__tenkz_internalve_int
-    \prop_clear:N \l__tenkz_virtualpaired_prop
     \int_step_inline:nn { \l__tenkz_nrows_int }
       {
         \tenkz_row_wirestyle:nN {##1} \l__tenkz_cell_tl

--- a/tex/tenkz/tenkz-grid.code.tex
+++ b/tex/tenkz/tenkz-grid.code.tex
@@ -102,13 +102,12 @@
 \tl_new:N \l__tenkz_bonddir_tl
 \tl_new:N \l__tenkz_dir_tl
 \tl_new:N \l__tenkz_dirmarks_tl
-% \tnskip holes: pending-west-stub flag of the bond scan, the deferred
-% east-stub column (a gap frees the indices facing it only once a later
-% tensor proves it INTERIOR -- a run reaching the row end belongs to the
-% side policy), and a scratch tl for partner-cell kinds at pairing
-% interfaces
-\bool_new:N \l__tenkz_hole_bool
-\int_new:N \l__tenkz_pendeast_int
+% \tnskip holes are record-time facts (\tenkz_model_derive_gapstubs:);
+% the walk reads them where it once threaded pending-east and hole flags.
+% Scratch: the flushed east-stub column, a partner-cell kind tl, and the
+% legacy-combined marker that still owns its pairing commit.
+\tl_new:N \l__tenkz_gapeast_tl
+\bool_new:N \l__tenkz_bond_legacy_bool
 \tl_new:N \l__tenkz_pkind_tl
 % The FRAME (frame=).  ONE linear map routes every drawn coordinate
 % from the logical frame (columns run east, rows descend) to the paper
@@ -1698,6 +1697,74 @@
       }
   }
 
+% Interior-gap stubs become record-time facts.  A \tnskip run is interior
+% exactly when owners exist on both sides; then the pre-gap tensor's east
+% index and the post-gap tensor's west index face the gap and stay OPEN.
+% A run reaching the row's end has no tensor beyond it: the facing index
+% is the row's BOUNDARY index and the side policy already owns it.  The
+% draw pass reads these facts where it once threaded pending-east and
+% hole flags through the walk; port checks stay at draw time so sparse
+% fusion faces keep suppressing their undeclared slots in one place.
+\prop_new:N \l__tenkz_gapstub_prop
+\int_new:N \l__tenkz_mgs_prev_int
+\bool_new:N \l__tenkz_mgs_gap_bool
+\tl_new:N \l__tenkz_mgs_kind_tl
+\cs_new_protected:Npn \tenkz_model_derive_gapstubs:
+  {
+    \prop_clear:N \l__tenkz_gapstub_prop
+    \int_step_inline:nn { \l__tenkz_nrows_int }
+      {
+        \int_zero:N \l__tenkz_mgs_prev_int
+        \bool_set_false:N \l__tenkz_mgs_gap_bool
+        \int_step_inline:nnn {1} { \l__tenkz_ncols_int }
+          {
+            \tenkz_get:NeN \l__tenkz_kind_prop {##1-####1} \l__tenkz_mgs_kind_tl
+            \str_if_eq:VnTF \l__tenkz_mgs_kind_tl {skip}
+              {
+                \int_compare:nNnT { \l__tenkz_mgs_prev_int } > {0}
+                  { \bool_set_true:N \l__tenkz_mgs_gap_bool }
+              }
+              {
+                \prop_if_in:NeT \l__tenkz_owner_prop {##1-####1}
+                  {
+                    \bool_if:NT \l__tenkz_mgs_gap_bool
+                      {
+                        \prop_put:Nee \l__tenkz_gapstub_prop {##1-####1}
+                          { \int_use:N \l__tenkz_mgs_prev_int }
+                      }
+                    \bool_set_false:N \l__tenkz_mgs_gap_bool
+                    \int_set:Nn \l__tenkz_mgs_prev_int {####1}
+                  }
+              }
+          }
+      }
+  }
+
+% Virtual pairing is a fact of the derived bond WIRE records, not of ink
+% commit order: both endpoint faces of every origin=bond record are paired.
+% The legacy-combined fallback keeps its commit-time entry until fused
+% attachments land as records.
+\tl_new:N \l__tenkz_mvp_from_tl
+\tl_new:N \l__tenkz_mvp_to_tl
+\tl_new:N \l__tenkz_mvp_origin_tl
+\cs_new_protected:Npn \tenkz_model_fill_virtualpaired:
+  {
+    \prop_clear:N \l__tenkz_virtualpaired_prop
+    \__tenkz_model_map_ids:nn {wire}
+      {
+        \__tenkz_model_get:nnN {##1}{origin} \l__tenkz_mvp_origin_tl
+        \str_if_eq:eeT { \tl_use:N \l__tenkz_mvp_origin_tl } {bond}
+          {
+            \__tenkz_model_get:nnN {##1}{from} \l__tenkz_mvp_from_tl
+            \__tenkz_model_get:nnN {##1}{to} \l__tenkz_mvp_to_tl
+            \prop_put:Nen \l__tenkz_virtualpaired_prop
+              { \tl_use:N \l__tenkz_mvp_from_tl -east } {}
+            \prop_put:Nen \l__tenkz_virtualpaired_prop
+              { \tl_use:N \l__tenkz_mvp_to_tl -west } {}
+          }
+      }
+  }
+
 \msg_new:nnn {tenkz}{model-bond-label}
   {
     [TKZ-MODEL-UNRESOLVED-BOND]~Bond~label~target~'#1'~has~no~
@@ -1987,6 +2054,8 @@
     \tenkz_record_interfaces:
     \tenkz_model_record_owners:
     \tenkz_model_derive_bonds:
+    \tenkz_model_derive_gapstubs:
+    \tenkz_model_fill_virtualpaired:
     \tenkz_model_validate_bond_labels:
     \tenkz_model_derive_closures:
     \__tenkz_model_validate:
@@ -2936,8 +3005,6 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
         \tenkz_row_wirestyle:nN {##1} \l__tenkz_cell_tl
         \tenkz_row_dir:nN {##1} \l__tenkz_dir_tl
         \tenkz_dir_marks:NN \l__tenkz_cell_tl \l__tenkz_dirmarks_tl
-        \bool_set_false:N \l__tenkz_hole_bool
-        \int_zero:N \l__tenkz_pendeast_int
         % connect consecutive occupied columns
         \int_zero:N \l_tmpa_int
         \int_step_inline:nnn {1} { \l__tenkz_ncols_int }
@@ -2959,11 +3026,6 @@ code=combined-side|value=\tl_to_str:N \l__tenkz_fcombined_tl}
                 % row).  The east stub is therefore DEFERRED until a later
                 % tensor proves the gap interior, and the west stub draws
                 % only when ink preceded the run.
-                \int_compare:nNnT { \l_tmpa_int } > {0}
-                  {
-                    \int_set_eq:NN \l__tenkz_pendeast_int \l_tmpa_int
-                    \bool_set_true:N \l__tenkz_hole_bool
-                  }
                 \int_zero:N \l_tmpa_int
                 \tenkz@event{hole|picture=\the\tenkz@pictureid|row=##1|col=####1}
               }
@@ -3037,9 +3099,13 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                                   {west} \l__tenkz_pb_tl
                                 \bool_set_false:N
                                   \l__tenkz_bond_rendered_bool
+                                \bool_set_false:N
+                                  \l__tenkz_bond_legacy_bool
                                 \bool_if:NTF
                                   \l__tenkz_combined_attach_bool
                                   {
+                                    \bool_set_true:N
+                                      \l__tenkz_bond_legacy_bool
                                     % This warning-only compatibility path is
                                     % intentionally absent from the frozen
                                     % model: one centred multi-row face is not
@@ -3127,13 +3193,19 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                                   }
                                 \bool_if:NT \l__tenkz_bond_rendered_bool
                                   {
-                                    % Pairing and events commit only after ink.
-                                    \prop_put:Nen
-                                      \l__tenkz_virtualpaired_prop
-                                      {##1-\int_use:N\l_tmpa_int-east} {}
-                                    \prop_put:Nen
-                                      \l__tenkz_virtualpaired_prop
-                                      {##1-####1-west} {}
+                                    % The record fill owns pairing; the
+                                    % legacy-combined fallback has no WIRE
+                                    % record yet, so its pairing commits
+                                    % here until fused attachments land.
+                                    \bool_if:NT \l__tenkz_bond_legacy_bool
+                                      {
+                                        \prop_put:Nen
+                                          \l__tenkz_virtualpaired_prop
+                                          {##1-\int_use:N\l_tmpa_int-east} {}
+                                        \prop_put:Nen
+                                          \l__tenkz_virtualpaired_prop
+                                          {##1-####1-west} {}
+                                      }
                                     \tenkz@event{bond|picture=\the\tenkz@pictureid|row=##1|from=\int_use:N\l_tmpa_int|to=####1|dir=\tenkz_dir_word:|role=\tenkz_rowrole_word:|species=\tenkz_rowspec_word:}
                                   }
                                   }
@@ -3145,30 +3217,25 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                               }
                           }
                       }
-                    % first tensor after an interior hole: flush the
-                    % deferred east stub of the tensor before the gap,
-                    % then this tensor's west index faces the gap and
-                    % stays open
-                    \bool_lazy_and:nnT
-                      { \l__tenkz_hole_bool }
-                      { \int_compare_p:nNn { \l_tmpa_int } = {0} }
+                    % first tensor after an interior hole: the derived
+                    % gap-stub fact names the pre-gap tensor whose east
+                    % index it frees; this tensor's west index faces the
+                    % gap and stays open
+                    \prop_get:NeNT \l__tenkz_gapstub_prop {##1-####1}
+                        \l__tenkz_gapeast_tl
                       {
-                        \int_compare:nNnT { \l__tenkz_pendeast_int } > {0}
+                        \tenkz_cell_virtual_row_port:nnnN {##1}
+                          {\tl_use:N \l__tenkz_gapeast_tl}{east}
+                          \l_tmpa_bool
+                        \bool_if:NT \l_tmpa_bool
                           {
-                            \tenkz_cell_virtual_row_port:nnnN {##1}
-                              {\int_use:N\l__tenkz_pendeast_int}{east}
-                              \l_tmpa_bool
-                            \bool_if:NT \l_tmpa_bool
-                              {
-                                \tenkz_anchor:nnnN
-                                  {##1}{\int_use:N\l__tenkz_pendeast_int}
-                                  {east} \l__tenkz_pa_tl
-                                \__tenkz_render_stroke:nn
-                                  { \tl_use:N \l__tenkz_cell_tl }
-                                  { \l__tenkz_pa_tl --
-                                    ++\tenkz_stub_vec:n{east} }
-                              }
-                            \int_zero:N \l__tenkz_pendeast_int
+                            \tenkz_anchor:nnnN
+                              {##1}{\tl_use:N \l__tenkz_gapeast_tl}
+                              {east} \l__tenkz_pa_tl
+                            \__tenkz_render_stroke:nn
+                              { \tl_use:N \l__tenkz_cell_tl }
+                              { \l__tenkz_pa_tl --
+                                ++\tenkz_stub_vec:n{east} }
                           }
                         \tenkz_cell_virtual_row_port:nnnN {##1}{####1}{west}
                           \l_tmpa_bool
@@ -3180,7 +3247,6 @@ picture=\the\tenkz@pictureid|code=combined-attach|row=##1}
                               { \tl_use:N \l__tenkz_cell_tl }
                               { \l__tenkz_pb_tl -- ++\tenkz_stub_vec:n{west} }
                           }
-                        \bool_set_false:N \l__tenkz_hole_bool
                       }
                     \int_set:Nn \l_tmpa_int { ####1 }
                   }

--- a/tex/tenkz/tenkz-metric.code.tex
+++ b/tex/tenkz/tenkz-metric.code.tex
@@ -185,13 +185,8 @@
     {wireglyph}, {wireglyphcap}, {fusionwidth}, {fuseover}
   }
   { \exp_args:Nne \__tenkz_metric_assert:nn {#1} { \use:c { tenkz@r@ #1 } } }
-\__tenkz_metric_assert:nn {wirewidth}    { \tenkz@wirewidth }
-\__tenkz_metric_assert:nn {annwidth}     { \tenkz@annwidth }
-\__tenkz_metric_assert:nn {emphwidth}    { \tenkz@emphwidth }
-\__tenkz_metric_assert:nn {junctionfloor}{ \tenkz@junctionfloor }
-\__tenkz_metric_assert:nn {barblen}      { \tenkz@barblen }
-\__tenkz_metric_assert:nn {fusedbarblen} { \tenkz@fusedbarblen }
-\__tenkz_metric_assert:nn {braceamp}     { \tenkz@braceamp }
+% The registry owns the floors: with core's \def table retired, the
+% declare_length entries above mint the legacy spellings themselves.
 
 \ExplSyntaxOff
 \endinput

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -69,8 +69,6 @@
 % the join body reads the free tier's resolved j* locals exactly as the
 % legacy site did (the language landing replaces the locals with record
 % fields).
-\cs_new_protected:Npn \__tenkz_render_free_node:nnnn #1#2#3#4
-  { \node[#1] (#2) at #3 {#4}; }
 \cs_new_protected:Npn \__tenkz_render_free_coordinate:nn #1#2
   { \coordinate (#1) at #2; }
 \cs_new_protected:Npn \__tenkz_render_free_marker:n #1

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -63,6 +63,32 @@
 \cs_new_protected:Npn \__tenkz_render_labelnode_named:nnnn #1#2#3#4
   { \node[#1] (#2) at #3 {#4}; }
 
+% ---------- free-tier coordinators --------------------------------------------
+% The free tier places named nodes at author coordinates and routes joins
+% with spliced label nodes.  Ink ownership moves here token-identically;
+% the join body reads the free tier's resolved j* locals exactly as the
+% legacy site did (the language landing replaces the locals with record
+% fields).
+\cs_new_protected:Npn \__tenkz_render_free_node:nnnn #1#2#3#4
+  { \node[#1] (#2) at #3 {#4}; }
+\cs_new_protected:Npn \__tenkz_render_free_coordinate:nn #1#2
+  { \coordinate (#1) at #2; }
+\cs_new_protected:Npn \__tenkz_render_free_marker:n #1
+  { \path (#1) node[inner~sep=0pt, outer~sep=0pt, minimum~size=0pt] {}; }
+\cs_new_protected:Npn \__tenkz_render_free_join:nnnn #1#2#3#4
+  {
+    \use:e
+      {
+        \exp_not:n
+          { \draw [ \tl_use:N \l__tenkz_jstyle_tl,
+                    \tl_use:N \l__tenkz_jmarks_tl,
+                    \tl_use:N \l__tenkz_jrolesty_tl, #1 ]
+              (#2) #3 }
+        \exp_not:V \l__tenkz_jlabelnode_tl
+        \exp_not:n { (#4) ; }
+      }
+  }
+
 % ---------- skins ------------------------------------------------------------
 % The six kernel skins resolve to the calibrated styles of tenkz-core; a
 % skin is a silhouette, never new ink semantics.


### PR DESCRIPTION
## Summary

Checkpoint the interrupted S4 front-end consolidation as a stacked draft on `agent/tenkz-s3-lattice`.

- derive interior-gap stubs and virtual pairing as model-record facts
- make the free front end reset, populate, and validate the shared model
- move free-tier node, coordinate, label, marker, and join ink behind render-stage coordinators
- retire duplicate core metric floors in favor of the metric registry

## Status

This preserves the failed agent's coherent partial work; it is intentionally a draft. The free renderer still consumes resolved front-end locals, and the remaining S4 language cutover must replace those locals with normalized record fields before this is ready to merge.

## Validation

- `git diff --check`
- five focused free-tier standalone fixtures compile and audit: `free.tex`, `free_modes.tex`, `free_test.tex`, `free_typed_joins_ex.tex`, and `p_usagefree.tex`
- render census passes at 36 raw-ink tokens and 51 decimal literals
- exact-head regression-corpus and Blueprint/web-layout CI pass

## Stack

Base: `agent/tenkz-s3-lattice` (`5fc65b925`). This PR contains the recovered S4 checkpoint commits and their review follow-ups on top of that prerequisite.

Advances LionSR/TNLean#4699 — S4 partial checkpoint; the remaining free/cd language cutover lands before this can close it. Part of LionSR/tenkz#13 Wave 1.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches grid bond topology derivation and free-tier model lifecycle on a draft stack; behavior is regression-tested but full free/cd record-driven rendering is still incomplete per the PR status.
> 
> **Overview**
> **Partial S4 checkpoint** that pushes grid and free tiers toward a shared model store and shared render coordinators, with tests and census baselines updated to match.
> 
> The **grid** path now derives **interior-gap stubs** and **virtual pairing** at record time (`tenkz_model_derive_gapstubs:` / `tenkz_model_fill_virtualpaired:`), so the bond walk reads derived facts instead of threading hole/pending-east state; legacy combined bonds still commit pairing at draw time until fused attachments become records.
> 
> The **free** tier resets the model at `tenkzfree` begin, records atoms and joins after command-local groups (so records survive `\group_begin:`), and validates at environment end; TikZ for labels, nodes, coordinates, markers, and joins is routed through **`tenkz-render`** helpers (dropping raw ink from `tenkz-free` in the census).
> 
> **Metrics:** duplicate absolute floors (`wirewidth`, barb lengths, etc.) are removed from `tenkz-core` and owned solely by **`tenkz-metric`** via lazy resolution.
> 
> **Tests:** `free_test` asserts model atom/wire counts across two pictures; `zz_wirescan` checks record-derived virtual pairings through the boundary pass; `zz_vertprune` and `zz_wirescan` join `LOCAL_FIXTURES.tsv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 622685f232a33b94c855a0761ea5d8e521323350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


