### PR TITLE
refactor(PEPS): derive vertex-complement injectivity from region theorem

### DIFF
--- a/TNLean/PEPS/ConfigurationCalculus.lean
+++ b/TNLean/PEPS/ConfigurationCalculus.lean
@@ -12,6 +12,8 @@ This file provides low-level operations for splitting, reindexing, and gluing vi
 configurations. Given a predicate on edges, `mergeVirtualConfig` reads one configuration
 where the predicate holds and another configuration elsewhere. The region-specific
 `regionMerge` specializes this operation to the edges incident to a region.
+The equivalence `vertexConfigSplitAt` separates the labels incident to one vertex from all
+remaining edge labels.
 
 The vertex-product lemmas compare products before and after merging configurations. The
 final lemma groups a finite sum by its merged configuration and collapses fibers of constant
@@ -46,6 +48,43 @@ omit [Fintype V] in
 theorem virtualConfigSplit_snd_apply (A : Tensor G d) (select : Edge G → Prop)
     [DecidablePred select] (ζ : VirtualConfig A) (e : {e : Edge G // ¬ select e}) :
     (virtualConfigSplit A select ζ).2 e = ζ e.1 := rfl
+
+/-! ### Split at one vertex -/
+
+/-- The predicate on edges singling out those incident to `j`. -/
+def IsIncidentEdge (j : V) (f : Edge G) : Prop :=
+  f.1.1 = j ∨ f.1.2 = j
+
+instance (j : V) (f : Edge G) : Decidable (IsIncidentEdge (G := G) j f) := by
+  unfold IsIncidentEdge
+  infer_instance
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- An edge underlying an incidence at `j` satisfies the vertex-incidence predicate. -/
+theorem isIncidentEdge_of_incident (j : V) (ie : IncidentEdge G j) :
+    IsIncidentEdge (G := G) j ie.1 := ie.2
+
+/-- Split a virtual configuration into its labels on the edges incident to `j`
+and its labels on all remaining edges. -/
+noncomputable def vertexConfigSplitAt (A : Tensor G d) (j : V) :
+    VirtualConfig A ≃
+      LocalVirtualConfig A j ×
+        ((f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1)) :=
+  virtualConfigSplit A fun f => IsIncidentEdge (G := G) j f
+
+omit [Fintype V] in
+@[simp] theorem vertexConfigSplitAt_fst (A : Tensor G d) (j : V) (ζ : VirtualConfig A)
+    (ie : IncidentEdge G j) :
+    (vertexConfigSplitAt (G := G) A j ζ).1 ie = ζ ie.1 := rfl
+
+omit [Fintype V] in
+@[simp] theorem vertexConfigSplitAt_symm_apply_incident (A : Tensor G d) (j : V)
+    (η : LocalVirtualConfig A j)
+    (r : (f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1))
+    (ie : IncidentEdge G j) :
+    (vertexConfigSplitAt (G := G) A j).symm (η, r) ie.1 = η ie := by
+  unfold vertexConfigSplitAt virtualConfigSplit IsIncidentEdge
+  rw [Equiv.piEquivPiSubtypeProd_symm_apply, dif_pos ie.2]
 
 /-- Reindex every virtual bond along equality of the bond-dimension families. -/
 noncomputable def virtualConfigCongr (A B : Tensor G d) (h : A.bondDim = B.bondDim) :

--- a/TNLean/PEPS/RegionBlock/KernelDescent.lean
+++ b/TNLean/PEPS/RegionBlock/KernelDescent.lean
@@ -3,17 +3,13 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.PEPS.RegionBlock.Basic
-import TNLean.PEPS.VertexComplement.KernelDescent
+import TNLean.PEPS.ConfigurationCalculus
 
 /-!
 # Kernel descent for the blocked-region tensor
 
 This file proves that the blocked-region tensor family of an arbitrary finite
-region `R` is linearly independent, by finite kernel descent. The descent
-generalizes the vertex-complement descent of
-`TNLean.PEPS.VertexComplement.KernelDescent` from the region `V\{v}` to an
-arbitrary region `R`.
+region `R` is linearly independent, by finite kernel descent.
 
 The contraction region is `R`. Deleting one vertex `j ∈ R` at a time uses the
 one-sided inverse at `j`; the terminal empty region forces every boundary

--- a/TNLean/PEPS/VertexComplement/KernelDescent.lean
+++ b/TNLean/PEPS/VertexComplement/KernelDescent.lean
@@ -3,25 +3,26 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.PEPS.VertexComplement.Basic
+import TNLean.PEPS.RegionBlock.KernelDescent
 
 /-!
-# Kernel descent for the vertex-complement block
+# Vertex-complement injectivity as a region specialization
 
-This file proves that the vertex-complement tensor family is linearly
-independent by finite kernel descent. The descent is adapted to the vertex star:
-the open boundary is the family of virtual bonds incident to \(v\).
+The complement of one vertex is a finite region. Its boundary edges are exactly
+the edges incident to the omitted vertex, and its physical vertices are exactly
+the vertices distinct from the omitted vertex. The equivalences below identify
+the boundary and physical configurations under these two descriptions.
 
-The contraction region is $V\setminus\{v\}$. Deleting one complement vertex
-$j\ne v$ at a time uses the one-sided inverse at $j$; the terminal empty region
-forces every boundary coefficient to vanish, using positive bond dimensions to
-fill the interior virtual indices.
+The vertex-complement tensor is consequently the blocked-region tensor of
+$V\setminus\{v\}$. Its linear independence follows from the arbitrary-region
+theorem, with no second kernel-descent argument.
 
 ## References
 
 - [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
   entangled pair states generating the same state*, arXiv:1804.04964,
-  Section 3, lines 205--250 and 1205--1210](https://arxiv.org/abs/1804.04964)
+  Section 3](https://arxiv.org/abs/1804.04964)
+- `Papers/1804.04964/paper_normal.tex`, lines 979--981 and 1207--1210.
 -/
 
 open scoped BigOperators Matrix
@@ -32,452 +33,92 @@ namespace PEPS
 variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 
-/-! ### Star-bond split equivalence at a complement vertex -/
-
-/-- The predicate on edges singling out those incident to a complement vertex
-`j`. -/
-def IsIncidentEdge (j : V) (f : Edge G) : Prop :=
-  f.1.1 = j ∨ f.1.2 = j
-
-instance (j : V) (f : Edge G) : Decidable (IsIncidentEdge (G := G) j f) := by
-  unfold IsIncidentEdge; infer_instance
-
-omit [Fintype V] [DecidableRel G.Adj] in
-/-- For a vertex `j` and an incident edge `ie` at `j`, the underlying edge is
-incident to `j`. -/
-theorem isIncidentEdge_of_incident (j : V) (ie : IncidentEdge G j) :
-    IsIncidentEdge (G := G) j ie.1 := ie.2
-
-/-- The split equivalence at a complement vertex `j`: a global virtual
-configuration is the local configuration at `j` together with the configuration
-on the edges not incident to `j`. -/
-noncomputable def vertexConfigSplitAt (A : Tensor G d) (j : V) :
-    VirtualConfig A ≃
-      LocalVirtualConfig A j ×
-        ((f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1)) :=
-  Equiv.piEquivPiSubtypeProd (fun f : Edge G => IsIncidentEdge (G := G) j f)
-    (fun f => Fin (A.bondDim f))
-
-omit [Fintype V] in
-@[simp] theorem vertexConfigSplitAt_fst (A : Tensor G d) (j : V) (ζ : VirtualConfig A)
-    (ie : IncidentEdge G j) :
-    (vertexConfigSplitAt (G := G) A j ζ).1 ie = ζ ie.1 := rfl
-
-omit [Fintype V] in
-@[simp] theorem vertexConfigSplitAt_symm_apply_incident (A : Tensor G d) (j : V)
-    (η : LocalVirtualConfig A j)
-    (r : (f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1))
-    (ie : IncidentEdge G j) :
-    (vertexConfigSplitAt (G := G) A j).symm (η, r) ie.1 = η ie := by
-  unfold vertexConfigSplitAt IsIncidentEdge
-  rw [Equiv.piEquivPiSubtypeProd_symm_apply, dif_pos ie.2]
-
-/-! ### Kernel condition -/
-
-/-- The exposed-agreement indicator at stage `S`: `1` if `ζ` agrees with `ζ₀` on
-every edge that touches no vertex of `S`, and `0` otherwise. -/
-noncomputable def vcExposedIndicator (A : Tensor G d) (S : Finset V)
-    (ζ ζ₀ : VirtualConfig A) : ℂ :=
-  if (∀ f : Edge G, f.1.1 ∉ S → f.1.2 ∉ S → ζ f = ζ₀ f) then 1 else 0
-
-/-- The guarded local factor at `w` in the kernel condition: the tensor at `w`
-contracted along the global configuration when `w \ne v`, and `1` at `v`. -/
-noncomputable def vcFactor (A : Tensor G d) (v : V) (w : V)
-    (ζ : VirtualConfig A) (τ : V → Fin d) : ℂ :=
-  if w ≠ v then A.component w (fun ie => ζ ie.1) (τ w) else 1
-
-/-- The kernel condition at stage `S` for the coefficient family `c`. -/
-noncomputable def vertexComplementKernelCondition (A : Tensor G d) (v : V)
-    (c : LocalVirtualConfig A v →₀ ℂ) (S : Finset V) : Prop :=
-  ∀ (ζ₀ : VirtualConfig A) (τ : V → Fin d),
-    ∑ ζ : VirtualConfig A,
-      vcExposedIndicator (G := G) A S ζ ζ₀ *
-        c (vertexStarLabel (G := G) A v ζ) *
-        ∏ w ∈ S, vcFactor (G := G) A v w ζ τ = 0
-
-/-! ### Kernel-condition descent: the erase-vertex step -/
-
-variable (A : Tensor G d) (v : V)
-
-/-- The extra-agreement indicator on the `j`-incident edges newly exposed when
-`j` is removed from `S`. -/
-noncomputable def vcExtraIndicator (S : Finset V) (j : V)
-    (ζ ζ₀ : VirtualConfig A) : ℂ :=
-  if (∀ f : Edge G, (f.1.1 = j ∨ f.1.2 = j) →
-      f.1.1 ∉ S.erase j → f.1.2 ∉ S.erase j → ζ f = ζ₀ f) then 1 else 0
-
-/-- Removing `j` from `S` factors the exposed indicator into the `S`-indicator
-and the extra-agreement indicator on the `j`-incident edges. -/
-theorem vcExposedIndicator_erase (S : Finset V) (j : V) (ζ ζ₀ : VirtualConfig A) :
-    vcExposedIndicator (G := G) A (S.erase j) ζ ζ₀ =
-      vcExposedIndicator (G := G) A S ζ ζ₀ * vcExtraIndicator (G := G) A S j ζ ζ₀ := by
-  classical
-  unfold vcExposedIndicator vcExtraIndicator
-  by_cases hAll : ∀ f : Edge G, f.1.1 ∉ S.erase j → f.1.2 ∉ S.erase j → ζ f = ζ₀ f
-  · rw [if_pos hAll]
-    have hS : ∀ f : Edge G, f.1.1 ∉ S → f.1.2 ∉ S → ζ f = ζ₀ f := by
-      intro f hf1 hf2
-      exact hAll f
-        (fun h => hf1 (Finset.mem_of_mem_erase h))
-        (fun h => hf2 (Finset.mem_of_mem_erase h))
-    have hE : ∀ f : Edge G, (f.1.1 = j ∨ f.1.2 = j) →
-        f.1.1 ∉ S.erase j → f.1.2 ∉ S.erase j → ζ f = ζ₀ f := by
-      intro f _ hf1 hf2
-      exact hAll f hf1 hf2
-    rw [if_pos hS, if_pos hE, one_mul]
-  · rw [if_neg hAll]
-    by_cases hS : ∀ f : Edge G, f.1.1 ∉ S → f.1.2 ∉ S → ζ f = ζ₀ f
-    · rw [if_pos hS, one_mul, if_neg]
-      intro hE
-      apply hAll
-      intro f hf1 hf2
-      by_cases hj1 : f.1.1 = j
-      · exact hE f (Or.inl hj1) hf1 hf2
-      · by_cases hj2 : f.1.2 = j
-        · exact hE f (Or.inr hj2) hf1 hf2
-        · have h1 : f.1.1 ∉ S := fun h => hf1 (Finset.mem_erase.mpr ⟨hj1, h⟩)
-          have h2 : f.1.2 ∉ S := fun h => hf2 (Finset.mem_erase.mpr ⟨hj2, h⟩)
-          exact hS f h1 h2
-    · rw [if_neg hS, zero_mul]
-
-/-- The extra indicator on a split configuration depends only on the local
-configuration `η` at `j`. -/
-noncomputable def vcExtraIndicatorη (S : Finset V) {j : V}
-    (η : LocalVirtualConfig A j) (ζ₀ : VirtualConfig A) : ℂ :=
-  if (∀ f : Edge G, (h : f.1.1 = j ∨ f.1.2 = j) →
-      f.1.1 ∉ S.erase j → f.1.2 ∉ S.erase j →
-        η ⟨f, h⟩ = ζ₀ f) then 1 else 0
-
-/-- After splitting a virtual boundary configuration into the labels incident to `j` and
-the complementary labels, the extra compatibility factor for erasing `j` is determined
-only by the incident labels. -/
-theorem vcExtraIndicator_split (S : Finset V) {j : V}
-    (η : LocalVirtualConfig A j)
-    (r : (f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1))
-    (ζ₀ : VirtualConfig A) :
-    vcExtraIndicator (G := G) A S j ((vertexConfigSplitAt (G := G) A j).symm (η, r)) ζ₀ =
-      vcExtraIndicatorη (G := G) A S η ζ₀ := by
-  classical
-  unfold vcExtraIndicator vcExtraIndicatorη
-  have hval : ∀ (f : Edge G) (hinc : f.1.1 = j ∨ f.1.2 = j),
-      (vertexConfigSplitAt (G := G) A j).symm (η, r) f = η ⟨f, hinc⟩ := by
-    intro f hinc
-    have hIs : IsIncidentEdge (G := G) j f := hinc
-    change (if hh : IsIncidentEdge (G := G) j f then η ⟨f, hh⟩ else r ⟨f, hh⟩) =
-      η ⟨f, hinc⟩
-    rw [dif_pos hIs]
-  congr 1
-  apply propext
+omit [DecidableRel G.Adj] in
+/-- The boundary edges of $V\setminus\{v\}$ are precisely the edges incident to
+$v$. -/
+theorem isRegionBoundaryEdge_vertexComplementVertices_iff (v : V) (f : Edge G) :
+    IsRegionBoundaryEdge (G := G) (vertexComplementVertices (V := V) v) f ↔
+      IsIncidentEdge (G := G) v f := by
+  rw [IsRegionBoundaryEdge, IsIncidentEdge]
+  simp only [mem_vertexComplementVertices_iff, not_not]
   constructor
-  · intro h f hinc hf1 hf2
-    rw [← hval f hinc]
-    exact h f hinc hf1 hf2
-  · intro h f hinc hf1 hf2
-    rw [hval f hinc]
-    exact h f hinc hf1 hf2
+  · rintro (⟨_, h⟩ | ⟨h, _⟩)
+    · exact Or.inr h
+    · exact Or.inl h
+  · rintro (h | h)
+    · refine Or.inr ⟨h, ?_⟩
+      intro h'
+      exact (ne_of_lt f.2.1) (h.trans h'.symm)
+    · refine Or.inl ⟨?_, h⟩
+      intro h'
+      exact (ne_of_lt f.2.1) (h'.trans h.symm)
 
-omit [Fintype V] in
-/-- On a split configuration, the guarded local factor at `j \ne v` is the tensor
-at `j` evaluated on the local virtual configuration `η`. -/
-theorem vcFactor_split_mid {j : V} (hjv : j ≠ v)
-    (η : LocalVirtualConfig A j)
-    (r : (f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1))
-    (τ : V → Fin d) :
-    vcFactor (G := G) A v j ((vertexConfigSplitAt (G := G) A j).symm (η, r)) τ =
-      A.component j η (τ j) := by
-  classical
-  unfold vcFactor
-  rw [if_pos hjv]
-  congr 1
+/-- Boundary edges of the complement of `v`, identified with edges incident to
+`v`. -/
+def vertexComplementBoundaryEdgeEquiv (v : V) :
+    {f : Edge G // IsRegionBoundaryEdge (G := G)
+      (vertexComplementVertices (V := V) v) f} ≃ IncidentEdge G v :=
+  Equiv.subtypeEquivRight fun f =>
+    isRegionBoundaryEdge_vertexComplementVertices_iff (G := G) v f
+
+/-- Boundary configurations of the complement of `v`, identified with local
+virtual configurations at `v`. -/
+noncomputable def vertexComplementBoundaryConfigEquiv (A : Tensor G d) (v : V) :
+    RegionBoundaryConfig (G := G) A (vertexComplementVertices (V := V) v) ≃
+      LocalVirtualConfig A v :=
+  Equiv.piCongrLeft (fun ie : IncidentEdge G v => Fin (A.bondDim ie.1))
+    (vertexComplementBoundaryEdgeEquiv (G := G) v)
+
+/-- The vertices of the complement of `v`, identified with vertices distinct
+from `v`. -/
+def vertexComplementVertexEquiv (v : V) :
+    {w : V // w ∈ vertexComplementVertices (V := V) v} ≃ {w : V // w ≠ v} :=
+  Equiv.subtypeEquivRight fun w => mem_vertexComplementVertices_iff (V := V) v w
+
+/-- Physical configurations of the complement region, identified with physical
+configurations on the vertices distinct from `v`. -/
+noncomputable def vertexComplementPhysicalConfigEquiv (v : V) :
+    RegionPhysicalConfig (V := V) (d := d) (vertexComplementVertices (V := V) v) ≃
+      VertexComplementPhysicalConfig (V := V) (d := d) v :=
+  Equiv.piCongrLeft (fun _ : {w : V // w ≠ v} => Fin d) (vertexComplementVertexEquiv v)
+
+@[simp]
+theorem vertexComplementBoundaryConfigEquiv_regionBoundaryLabel
+    (A : Tensor G d) (v : V) (ζ : VirtualConfig A) :
+    vertexComplementBoundaryConfigEquiv (G := G) A v
+        (regionBoundaryLabel (G := G) A (vertexComplementVertices (V := V) v) ζ) =
+      vertexStarLabel (G := G) A v ζ := by
   funext ie
-  exact vertexConfigSplitAt_symm_apply_incident (G := G) A j η r ie
+  rfl
 
-/-- The marginal coefficient family at `j` obtained from the kernel condition at
-`S` by summing over the non-`j` star coordinates. -/
-noncomputable def vcMarginal
-    (c : LocalVirtualConfig A v →₀ ℂ) (S : Finset V) (j : V)
-    (ζ₀ : VirtualConfig A) (τ : V → Fin d) (η : LocalVirtualConfig A j) : ℂ :=
-  ∑ r : (f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1),
-    vcExposedIndicator (G := G) A S ((vertexConfigSplitAt (G := G) A j).symm (η, r)) ζ₀ *
-      c (vertexStarLabel (G := G) A v ((vertexConfigSplitAt (G := G) A j).symm (η, r))) *
-      ∏ w ∈ S.erase j, vcFactor (G := G) A v w
-          ((vertexConfigSplitAt (G := G) A j).symm (η, r)) τ
-
-/-- The marginal coefficient family vanishes, by injectivity at `j` and the
-kernel condition at `S`. -/
-theorem vcMarginal_eq_zero (hA : IsVertexInjective A)
-    (c : LocalVirtualConfig A v →₀ ℂ) (S : Finset V) (j : V)
-    (hjv : j ≠ v) (hjS : j ∈ S)
-    (hK : vertexComplementKernelCondition (G := G) A v c S)
-    (ζ₀ : VirtualConfig A) (τ : V → Fin d) :
-    vcMarginal (G := G) A v c S j ζ₀ τ = 0 := by
+/-- Blocking the complement of one vertex gives the vertex-complement tensor
+after identifying its open virtual and physical indices. -/
+theorem regionBlockedWeight_vertexComplement (A : Tensor G d) (v : V)
+    (bdry : RegionBoundaryConfig (G := G) A (vertexComplementVertices (V := V) v))
+    (τ : RegionPhysicalConfig (V := V) (d := d)
+      (vertexComplementVertices (V := V) v)) :
+    regionBlockedWeight (G := G) A (vertexComplementVertices (V := V) v) bdry τ =
+      vertexComplementWeight (G := G) A v
+        (vertexComplementBoundaryConfigEquiv (G := G) A v bdry)
+        (vertexComplementPhysicalConfigEquiv (d := d) v τ) := by
   classical
-  apply hA.localCoeff_eq_zero_of_contract_zero j
-  intro τj'
-  have hKS := hK ζ₀ (Function.update τ j τj')
-  rw [← Equiv.sum_comp (vertexConfigSplitAt (G := G) A j).symm,
-      Fintype.sum_prod_type] at hKS
-  rw [← hKS]
-  refine Finset.sum_congr rfl ?_
-  intro η _
-  unfold vcMarginal
-  rw [smul_eq_mul, Finset.sum_mul]
-  refine Finset.sum_congr rfl ?_
-  intro r _
-  have hAj : A.component j η τj' =
-      vcFactor (G := G) A v j ((vertexConfigSplitAt (G := G) A j).symm (η, r))
-        (Function.update τ j τj') := by
-    rw [vcFactor_split_mid (G := G) A v hjv η r (Function.update τ j τj')]
-    rw [Function.update_self]
-  have hProdErase : ∀ x : VirtualConfig A,
-      (∏ w ∈ S.erase j, vcFactor (G := G) A v w x τ) =
-        ∏ w ∈ S.erase j, vcFactor (G := G) A v w x (Function.update τ j τj') := by
-    intro x
-    refine Finset.prod_congr rfl ?_
-    intro w hw
-    have hwj : w ≠ j := Finset.ne_of_mem_erase hw
-    unfold vcFactor
-    by_cases hwv : w ≠ v
-    · rw [if_pos hwv, if_pos hwv, Function.update_of_ne hwj]
-    · rw [if_neg hwv, if_neg hwv]
-  rw [hProdErase, hAj]
-  rw [show (vcExposedIndicator (G := G) A S
-        ((vertexConfigSplitAt (G := G) A j).symm (η, r)) ζ₀ *
-      c (vertexStarLabel (G := G) A v ((vertexConfigSplitAt (G := G) A j).symm (η, r))) *
-      ∏ w ∈ S.erase j, vcFactor (G := G) A v w
-          ((vertexConfigSplitAt (G := G) A j).symm (η, r)) (Function.update τ j τj')) *
-      vcFactor (G := G) A v j
-          ((vertexConfigSplitAt (G := G) A j).symm (η, r)) (Function.update τ j τj') =
-      vcExposedIndicator (G := G) A S
-        ((vertexConfigSplitAt (G := G) A j).symm (η, r)) ζ₀ *
-      c (vertexStarLabel (G := G) A v ((vertexConfigSplitAt (G := G) A j).symm (η, r))) *
-      ((∏ w ∈ S.erase j, vcFactor (G := G) A v w
-          ((vertexConfigSplitAt (G := G) A j).symm (η, r)) (Function.update τ j τj')) *
-        vcFactor (G := G) A v j
-          ((vertexConfigSplitAt (G := G) A j).symm (η, r)) (Function.update τ j τj'))
-      by ring]
-  rw [Finset.prod_erase_mul S _ hjS]
-
-/-- The kernel condition descends when a complement vertex `j \ne v` in `S` is
-removed. -/
-theorem vertexComplementKernelCondition_erase (hA : IsVertexInjective A)
-    (c : LocalVirtualConfig A v →₀ ℂ) (S : Finset V) {j : V}
-    (hjv : j ≠ v) (hjS : j ∈ S)
-    (hK : vertexComplementKernelCondition (G := G) A v c S) :
-    vertexComplementKernelCondition (G := G) A v c (S.erase j) := by
-  classical
-  intro ζ₀ τ
-  rw [← Equiv.sum_comp (vertexConfigSplitAt (G := G) A j).symm,
-      Fintype.sum_prod_type]
-  apply Finset.sum_eq_zero
-  intro η _
-  have hMarg := vcMarginal_eq_zero (G := G) A v hA c S j hjv hjS hK ζ₀ τ
-  have hpull :
-      (∑ r, vcExposedIndicator (G := G) A (S.erase j)
-            ((vertexConfigSplitAt (G := G) A j).symm (η, r)) ζ₀ *
-          c (vertexStarLabel (G := G) A v ((vertexConfigSplitAt (G := G) A j).symm (η, r))) *
-          ∏ w ∈ S.erase j, vcFactor (G := G) A v w
-            ((vertexConfigSplitAt (G := G) A j).symm (η, r)) τ) =
-      vcExtraIndicatorη (G := G) A S η ζ₀ * vcMarginal (G := G) A v c S j ζ₀ τ η := by
-    unfold vcMarginal
-    rw [Finset.mul_sum]
-    refine Finset.sum_congr rfl ?_
-    intro r _
-    rw [vcExposedIndicator_erase (G := G) A S j,
-      vcExtraIndicator_split (G := G) A S η r]
-    ring
-  change (∑ r, vcExposedIndicator (G := G) A (S.erase j)
-        ((vertexConfigSplitAt (G := G) A j).symm (η, r)) ζ₀ *
-      c (vertexStarLabel (G := G) A v ((vertexConfigSplitAt (G := G) A j).symm (η, r))) *
-      ∏ w ∈ S.erase j, vcFactor (G := G) A v w
-        ((vertexConfigSplitAt (G := G) A j).symm (η, r)) τ) = 0
-  rw [hpull, congrFun hMarg η, Pi.zero_apply, mul_zero]
-
-/-! ### The terminal relation -/
-
-/-- A global virtual configuration witnessing a given v-star label, filling the
-non-star edges with the bottom index using positive bond dimensions. -/
-noncomputable def starWitness (hpos : ∀ f : Edge G, 0 < A.bondDim f)
-    (ρ : LocalVirtualConfig A v) : VirtualConfig A :=
-  fun f =>
-    if h : f.1.1 = v ∨ f.1.2 = v then
-      ρ ⟨f, h⟩
-    else
-      ⟨0, hpos f⟩
-
-omit [Fintype V] in
-/-- The v-star label of the witness configuration is the given label. -/
-theorem vertexStarLabel_starWitness (hpos : ∀ f : Edge G, 0 < A.bondDim f)
-    (ρ : LocalVirtualConfig A v) :
-    vertexStarLabel (G := G) A v (starWitness (G := G) A v hpos ρ) = ρ := by
-  funext ie
-  change starWitness (G := G) A v hpos ρ ie.1 = ρ ie
-  have h : ie.1.1.1 = v ∨ ie.1.1.2 = v := ie.2
-  rw [starWitness, dif_pos h]
-
-/-- The kernel condition at the empty region forces the coefficient family to
-vanish. -/
-theorem vertexComplementKernelCondition_empty_eq_zero (hA : IsVertexInjective A)
-    (hpos : ∀ f : Edge G, 0 < A.bondDim f)
-    (c : LocalVirtualConfig A v →₀ ℂ)
-    (hK : vertexComplementKernelCondition (G := G) A v c ∅) :
-    c = 0 := by
-  classical
-  obtain ⟨τ0⟩ : Nonempty (Fin d) := by
-    have hne : Nonempty (LocalVirtualConfig A v) := ⟨fun ie => ⟨0, hpos ie.1⟩⟩
-    obtain ⟨η₀⟩ := hne
-    have hnz : A.component v η₀ ≠ 0 := (hA v).ne_zero η₀
-    by_contra hc
-    rw [not_nonempty_iff] at hc
-    exact hnz (Subsingleton.elim _ _)
-  ext ρ
-  have hKρ := hK (starWitness (G := G) A v hpos ρ) (fun _ => τ0)
-  rw [show (∑ ζ : VirtualConfig A,
-        vcExposedIndicator (G := G) A ∅ ζ (starWitness (G := G) A v hpos ρ) *
-          c (vertexStarLabel (G := G) A v ζ) *
-          ∏ w ∈ (∅ : Finset V), vcFactor (G := G) A v w ζ (fun _ => τ0)) =
-      ∑ ζ : VirtualConfig A,
-        vcExposedIndicator (G := G) A ∅ ζ (starWitness (G := G) A v hpos ρ) *
-          c (vertexStarLabel (G := G) A v ζ) from by
-    refine Finset.sum_congr rfl ?_
-    intro ζ _
-    rw [Finset.prod_empty, mul_one]] at hKρ
-  have hExp : ∀ ζ : VirtualConfig A,
-      vcExposedIndicator (G := G) A ∅ ζ (starWitness (G := G) A v hpos ρ) =
-        if ζ = starWitness (G := G) A v hpos ρ then 1 else 0 := by
-    intro ζ
-    unfold vcExposedIndicator
-    congr 1
-    apply propext
+  unfold regionBlockedWeight vertexComplementWeight
+  refine Finset.sum_congr ?_ ?_
+  · ext ζ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
     constructor
     · intro h
-      funext f
-      exact h f (by simp) (by simp)
-    · intro h _ _ _
-      rw [h]
-  simp_rw [hExp, ite_mul, one_mul, zero_mul] at hKρ
-  rw [Finset.sum_ite_eq' Finset.univ (starWitness (G := G) A v hpos ρ)
-      (fun ζ => c (vertexStarLabel (G := G) A v ζ))] at hKρ
-  simp only [Finset.mem_univ, if_true] at hKρ
-  rw [vertexStarLabel_starWitness (G := G) A v hpos ρ] at hKρ
-  simpa using hKρ
+      rw [← vertexComplementBoundaryConfigEquiv_regionBoundaryLabel A v, h]
+    · intro h
+      apply (vertexComplementBoundaryConfigEquiv (G := G) A v).injective
+      simpa using h
+  · intro ζ _
+    apply Fintype.prod_equiv (vertexComplementVertexEquiv v)
+    intro w
+    rfl
 
-/-! ### The initial relation -/
-
-/-- Restrict a global physical configuration to the complement region. -/
-def vertexComplementPhysicalConfigOf (v : V) (τ : V → Fin d) :
-    VertexComplementPhysicalConfig (V := V) (d := d) v :=
-  fun w => τ w.1
-
-/-- At the full complement region, the exposed indicator is identically `1`: no
-edge has both endpoints outside `V\{v}` (that would force both to equal `v`). -/
-theorem vcExposedIndicator_vertexComplementVertices (ζ ζ₀ : VirtualConfig A) :
-    vcExposedIndicator (G := G) A (vertexComplementVertices (V := V) v) ζ ζ₀ = 1 := by
-  classical
-  unfold vcExposedIndicator
-  rw [if_pos]
-  intro f hf1 hf2
-  simp only [mem_vertexComplementVertices_iff, not_not] at hf1 hf2
-  exact absurd (hf1.trans hf2.symm) (ne_of_lt f.2.1)
-
-/-- The kernel-condition product over the full complement region equals the
-complement-family product. -/
-theorem vcProd_eq_family_prod (ζ : VirtualConfig A) (τ : V → Fin d) :
-    (∏ w ∈ vertexComplementVertices (V := V) v, vcFactor (G := G) A v w ζ τ) =
-      ∏ w : {w : V // w ≠ v}, A.component w.1 (fun ie => ζ ie.1) (τ w.1) := by
-  classical
-  rw [Finset.prod_subtype (F := inferInstance) (s := vertexComplementVertices (V := V) v)
-    (p := fun w => w ≠ v)
-    (h := by intro w; exact mem_vertexComplementVertices_iff (V := V) v w)
-    (f := fun w => vcFactor (G := G) A v w ζ τ)]
-  refine Finset.prod_congr rfl ?_
-  intro w _
-  unfold vcFactor
-  rw [if_pos w.2]
-
-/-- The complement tensor family as a fibered sum over global configurations with
-a given star label. -/
-theorem vertexComplementTensorFamily_eq_fiber_sum
-    (ρ : LocalVirtualConfig A v) (τ : V → Fin d) :
-    vertexComplementTensorFamily (G := G) A v ρ
-        (vertexComplementPhysicalConfigOf (V := V) (d := d) v τ) =
-      ∑ ζ ∈ Finset.univ.filter
-          (fun ζ : VirtualConfig A => vertexStarLabel (G := G) A v ζ = ρ),
-        ∏ w : {w : V // w ≠ v}, A.component w.1 (fun ie => ζ ie.1) (τ w.1) := by
-  rfl
-
-/-- A vanishing linear combination of the complement tensor family gives the
-kernel condition at the full complement region. -/
-theorem vertexComplement_initial_kernelCondition (c : LocalVirtualConfig A v →₀ ℂ)
-    (hc : Finsupp.linearCombination ℂ (vertexComplementTensorFamily (G := G) A v) c = 0) :
-    vertexComplementKernelCondition (G := G) A v c (vertexComplementVertices (V := V) v) := by
-  classical
-  intro ζ₀ τ
-  have hstep : (∑ ζ : VirtualConfig A,
-        vcExposedIndicator (G := G) A (vertexComplementVertices (V := V) v) ζ ζ₀ *
-          c (vertexStarLabel (G := G) A v ζ) *
-          ∏ w ∈ vertexComplementVertices (V := V) v, vcFactor (G := G) A v w ζ τ) =
-      ∑ ζ : VirtualConfig A,
-        c (vertexStarLabel (G := G) A v ζ) *
-          ∏ w : {w : V // w ≠ v}, A.component w.1 (fun ie => ζ ie.1) (τ w.1) := by
-    refine Finset.sum_congr rfl ?_
-    intro ζ _
-    rw [vcExposedIndicator_vertexComplementVertices A v ζ ζ₀, one_mul,
-      vcProd_eq_family_prod A v ζ τ]
-  rw [hstep]
-  rw [← Finset.sum_fiberwise Finset.univ
-      (fun ζ : VirtualConfig A => vertexStarLabel (G := G) A v ζ)
-      (fun ζ => c (vertexStarLabel (G := G) A v ζ) *
-        ∏ w : {w : V // w ≠ v}, A.component w.1 (fun ie => ζ ie.1) (τ w.1))]
-  have hfib : ∀ ρ : LocalVirtualConfig A v,
-      (∑ ζ ∈ Finset.univ.filter
-          (fun ζ : VirtualConfig A => vertexStarLabel (G := G) A v ζ = ρ),
-        c (vertexStarLabel (G := G) A v ζ) *
-          ∏ w : {w : V // w ≠ v}, A.component w.1 (fun ie => ζ ie.1) (τ w.1)) =
-        c ρ * vertexComplementTensorFamily (G := G) A v ρ
-          (vertexComplementPhysicalConfigOf (V := V) (d := d) v τ) := by
-    intro ρ
-    rw [vertexComplementTensorFamily_eq_fiber_sum A v ρ τ, Finset.mul_sum]
-    refine Finset.sum_congr rfl ?_
-    intro ζ hζ
-    rw [Finset.mem_filter] at hζ
-    rw [hζ.2]
-  simp_rw [hfib]
-  have hval : (∑ ρ : LocalVirtualConfig A v,
-        c ρ * vertexComplementTensorFamily (G := G) A v ρ
-          (vertexComplementPhysicalConfigOf (V := V) (d := d) v τ)) =
-      (Finsupp.linearCombination ℂ (vertexComplementTensorFamily (G := G) A v) c)
-        (vertexComplementPhysicalConfigOf (V := V) (d := d) v τ) := by
-    rw [Finsupp.linearCombination_apply, Finsupp.sum_fintype]
-    · simp only [Finset.sum_apply, Pi.smul_apply, smul_eq_mul]
-    · intro i; simp
-  rw [hval, hc]
-  rfl
-
-/-! ### Kernel-descent datum and complement injectivity -/
-
-/-- The finite kernel-descent datum for the vertex-complement block, restricting
-the kernel condition to the complement vertices and erasing one at a time. -/
-noncomputable def vertexComplementKernelDescent (hA : IsVertexInjective A)
-    (c : LocalVirtualConfig A v →₀ ℂ) : FiniteRegionKernelDescent V where
-  kernelCondition S :=
-    vertexComplementKernelCondition (G := G) A v c (S ∩ vertexComplementVertices (V := V) v)
-  erase_vertex := by
-    intro S j hjS hK
-    rw [Finset.erase_inter]
-    by_cases hjv : j ≠ v
-    · exact vertexComplementKernelCondition_erase (G := G) A v hA c
-        (S ∩ vertexComplementVertices (V := V) v) hjv
-        (Finset.mem_inter.mpr ⟨hjS,
-          (mem_vertexComplementVertices_iff (V := V) v j).mpr hjv⟩) hK
-    · rw [not_not] at hjv
-      rw [Finset.erase_eq_of_notMem (fun h => by
-        exact ((mem_vertexComplementVertices_iff (V := V) v j).mp
-          (Finset.mem_inter.mp h).2) hjv)]
-      exact hK
-
-/-- The vertex-complement tensor family is linearly independent: a contraction of
-injective tensors over the complement region $V\setminus\{v\}$ is injective.
+/-- The vertex-complement tensor family is linearly independent: a contraction
+of injective tensors over $V\setminus\{v\}$ is injective.
 
 **Positive-bond hypothesis (faithfulness fix).** The source works with injective
 PEPS, whose virtual bond spaces are nonzero-dimensional. Without the positivity
@@ -486,31 +127,32 @@ empty, breaking linear independence. The hypothesis `∀ f, 0 < A.bondDim f`
 restores the source assumption; the gap is recorded in
 `docs/paper-gaps/peps_injective_ft_section3_route.tex`.
 
-Source: arXiv:1804.04964, Section 3, a contraction of injective tensors is
-injective (`Papers/1804.04964/paper_normal.tex`, lines 205--250), applied to the
-complement block of the one-vertex-versus-complement comparison (lines
-1205--1210). -/
+Source: arXiv:1804.04964, Section 3. Lines 979--981 state that contracting
+injective tensors gives an injective tensor; lines 1207--1210 select one tensor
+and block all remaining tensors into the second injective tensor
+(`Papers/1804.04964/paper_normal.tex`). -/
 theorem vertexComplementTensorInjective_of_isVertexInjective
-    (hA : IsVertexInjective A) (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
+    (A : Tensor G d) (v : V) (hA : IsVertexInjective A)
+    (hpos : ∀ f : Edge G, 0 < A.bondDim f) :
     VertexComplementTensorInjective (G := G) A v := by
-  rw [VertexComplementTensorInjective, linearIndependent_iff]
-  intro c hc
-  have hInit : vertexComplementKernelCondition (G := G) A v c
-      (vertexComplementVertices (V := V) v) :=
-    vertexComplement_initial_kernelCondition (G := G) A v c hc
-  set descent := vertexComplementKernelDescent (G := G) A v hA c with hdescent
-  have hStart : descent.kernelCondition (vertexComplementVertices (V := V) v) := by
-    change vertexComplementKernelCondition (G := G) A v c
-      (vertexComplementVertices (V := V) v ∩ vertexComplementVertices (V := V) v)
-    rwa [Finset.inter_self]
-  have hEmpty : descent.kernelCondition ∅ := descent.descend_to_empty hStart
-  have hEmpty' : vertexComplementKernelCondition (G := G) A v c ∅ := by
-    have heq : (∅ : Finset V) ∩ vertexComplementVertices (V := V) v = ∅ :=
-      Finset.empty_inter _
-    have hE2 : vertexComplementKernelCondition (G := G) A v c
-        ((∅ : Finset V) ∩ vertexComplementVertices (V := V) v) := hEmpty
-    rwa [heq] at hE2
-  exact vertexComplementKernelCondition_empty_eq_zero (G := G) A v hA hpos c hEmpty'
+  let R := vertexComplementVertices (V := V) v
+  let Ψ := vertexComplementBoundaryConfigEquiv (G := G) A v
+  let Φ := vertexComplementPhysicalConfigEquiv (V := V) (d := d) v
+  have hR : LinearIndependent ℂ (regionBlockedTensorFamily (G := G) A R) :=
+    regionBlockedTensorInjective_of_isVertexInjective (G := G) A R hA hpos
+  have hfam : (LinearEquiv.funCongrLeft ℂ ℂ Φ) ∘
+      (vertexComplementTensorFamily (G := G) A v ∘ Ψ) =
+        regionBlockedTensorFamily (G := G) A R := by
+    funext bdry
+    funext τ
+    exact (regionBlockedWeight_vertexComplement A v bdry τ).symm
+  have hcomp : LinearIndependent ℂ ((LinearEquiv.funCongrLeft ℂ ℂ Φ) ∘
+      (vertexComplementTensorFamily (G := G) A v ∘ Ψ)) := by
+    rw [hfam]
+    exact hR
+  have hΨ : LinearIndependent ℂ (vertexComplementTensorFamily (G := G) A v ∘ Ψ) :=
+    LinearIndependent.of_comp _ hcomp
+  exact (linearIndependent_equiv Ψ).mp hΨ
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_foundations.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_foundations.tex
@@ -77,19 +77,26 @@ together with the local inverse it provides.
 \begin{definition}[Splitting and reindexing virtual configurations]
     \label{def:peps_virtual_config_split_reindex}
     \lean{TNLean.PEPS.virtualConfigSplit}
+    \lean{TNLean.PEPS.IsIncidentEdge}
+    \lean{TNLean.PEPS.vertexConfigSplitAt}
     \lean{TNLean.PEPS.virtualConfigCongr}
     \leanok
     \uses{def:peps_virtual_config}
     A predicate on the edges splits a virtual configuration canonically into
     its restrictions to the selected and unselected edges. An equality
     between two bond-dimension families also induces a canonical reindexing
-    between their virtual configurations.
+    between their virtual configurations.  For a vertex $v$, selecting the
+    incident edges splits a virtual configuration into its local labels at $v$
+    and the labels on all nonincident edges.
 \end{definition}
 
 \begin{theorem}[Evaluation laws for splitting and reindexing]
     \label{thm:peps_virtual_config_split_reindex_apply}
     \lean{TNLean.PEPS.virtualConfigSplit_fst_apply}
     \lean{TNLean.PEPS.virtualConfigSplit_snd_apply}
+    \lean{TNLean.PEPS.isIncidentEdge_of_incident}
+    \lean{TNLean.PEPS.vertexConfigSplitAt_fst}
+    \lean{TNLean.PEPS.vertexConfigSplitAt_symm_apply_incident}
     \lean{TNLean.PEPS.virtualConfigCongr_apply}
     \lean{TNLean.PEPS.virtualConfigSplit_mergeVirtualConfig}
     \lean{TNLean.PEPS.virtualConfigCongr_mergeVirtualConfig}

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
@@ -213,17 +213,33 @@
     \uses{def:peps_vertexComplementRegionEquivs, def:peps_complementTwoBlock}
     Under the preceding identifications, the blocked tensor of
     $V\setminus\{v\}$ is the vertex-complement tensor:
-    \[
+    \begin{align}
         T_{A,V\setminus\{v\}}^{\rho}(\tau)
-        =
+        &=
         A_{v^c}(\Psi_v\rho,\Phi_v\tau).
-    \]
+        \notag
+    \end{align}
 \end{theorem}
 \begin{proof}\leanok
-    Both sides sum over the same global virtual configurations. The boundary
-    identification turns the crossing-edge constraint into the prescribed
-    incident-edge labels, and the vertex identification reindexes the product
-    over the vertices distinct from $v$.
+    Expanding the blocked contraction as a sum over the virtual
+    configurations of the complement,
+    \begin{align}
+        T_{A,V\setminus\{v\}}^{\rho}(\tau)
+        &=
+        \textstyle
+        \sum_{\zeta:\,\zeta|_{\partial}=\rho}\;
+        \prod_{w\neq v} A_w(\zeta|_w,\tau_w)
+        =
+        A_{v^c}(\Psi_v\rho,\Phi_v\tau),
+        \notag
+    \end{align}
+    where $\zeta$ runs over the virtual configurations of the complement
+    whose boundary restriction $\zeta|_{\partial}$ is the prescribed boundary
+    configuration $\rho$. The boundary identification $\Psi_v$ turns the
+    crossing-edge constraint $\zeta|_{\partial}=\rho$ into the prescribed
+    incident-edge labels, and the vertex identification $\Phi_v$ reindexes
+    the product over the vertices distinct from $v$; both bijections match
+    the summation sets and their factors termwise.
 \end{proof}
 
 \begin{theorem}[Injectivity of the vertex-complement contraction]%

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer_covariance.tex
@@ -188,6 +188,44 @@
     $T_{v^c}(*,\eta,\tau)=A_{v^c}(\eta,\tau)$.
 \end{definition}
 
+\begin{definition}[Complement-region index identifications]%
+    \label{def:peps_vertexComplementRegionEquivs}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_vertexComplementVertices_iff}
+    \lean{TNLean.PEPS.vertexComplementBoundaryEdgeEquiv}
+    \lean{TNLean.PEPS.vertexComplementBoundaryConfigEquiv}
+    \lean{TNLean.PEPS.vertexComplementVertexEquiv}
+    \lean{TNLean.PEPS.vertexComplementPhysicalConfigEquiv}
+    \leanok
+    \uses{def:peps_complementTwoBlock}
+    For a vertex $v$, the edges crossing the boundary of
+    $V\setminus\{v\}$ are precisely the edges incident to $v$. Hence the
+    boundary configurations of $V\setminus\{v\}$ identify with the local
+    virtual configurations at $v$. Similarly, the vertices in
+    $V\setminus\{v\}$ identify with the vertices distinct from $v$, giving
+    the corresponding identification of physical configurations.
+\end{definition}
+
+\begin{theorem}[Vertex-complement contraction as a blocked region]%
+    \label{thm:peps_regionBlockedWeight_vertexComplement}
+    \lean{TNLean.PEPS.vertexComplementBoundaryConfigEquiv_regionBoundaryLabel}
+    \lean{TNLean.PEPS.regionBlockedWeight_vertexComplement}
+    \leanok
+    \uses{def:peps_vertexComplementRegionEquivs, def:peps_complementTwoBlock}
+    Under the preceding identifications, the blocked tensor of
+    $V\setminus\{v\}$ is the vertex-complement tensor:
+    \[
+        T_{A,V\setminus\{v\}}^{\rho}(\tau)
+        =
+        A_{v^c}(\Psi_v\rho,\Phi_v\tau).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    Both sides sum over the same global virtual configurations. The boundary
+    identification turns the crossing-edge constraint into the prescribed
+    incident-edge labels, and the vertex identification reindexes the product
+    over the vertices distinct from $v$.
+\end{proof}
+
 \begin{theorem}[Injectivity of the vertex-complement contraction]%
     \label{thm:peps_vertexComplementTensorInjective}
     \lean{TNLean.PEPS.vertexComplementTensorInjective_of_isVertexInjective}
@@ -199,28 +237,13 @@
     of the vertex-complement contraction is linearly independent.
 \end{theorem}
 \begin{proof}\leanok
-    Let $c=(c_\eta)_\eta$ be a finite coefficient family on the open star of
-    $v$. For a set $S\subseteq V\setminus\{v\}$, let $K_S(c)$ be the assertion
-    that for every virtual configuration $\zeta_0$ and physical configuration
-    $\tau$,
-    \begin{align}
-        \sum_{\zeta}
-        \mathbf 1[
-                \zeta_f=\zeta_{0,f}\text{ for every edge }f
-                \text{ whose endpoints are outside }S]
-        c_{\zeta|_{\operatorname{Star}(v)}}
-        \prod_{w\in S} A_w(\zeta|_{\operatorname{Star}(w)},\tau_w)
-        &=0.
-        \notag
-    \end{align}
-    The initial vanishing of the complement contraction is exactly
-    $K_{V\setminus\{v\}}(c)$. If $j\in S$ and $j\neq v$, the one-sided inverse at
-    the vertex $j$ separates the local tensor $A_j$ and gives
-    $K_S(c)\Rightarrow K_{S\setminus\{j\}}(c)$. Iterating this implication over
-    the complement vertices gives $K_\varnothing(c)$. At $S=\varnothing$ the
-    exposed virtual indices are all fixed by $\zeta_0$; positive bond dimensions
-    allow $\zeta_0$ to realize any prescribed star configuration at $v$. Hence
-    every coefficient $c_\eta$ is zero.
+    \uses{thm:peps_regionBlockedWeight_vertexComplement,
+        thm:peps_regionBlockedTensorInjective_of_isVertexInjective}
+    Apply the injectivity theorem for an arbitrary finite region to
+    $R=V\setminus\{v\}$. Theorem~\ref{thm:peps_regionBlockedWeight_vertexComplement}
+    identifies the resulting blocked tensor with the vertex-complement tensor.
+    Reindexing the boundary family and the physical coordinates by bijections
+    preserves linear independence.
 \end{proof}
 
 \begin{theorem}[Injectivity of the complement two-block tensor]%

--- a/docs/paper-gaps/peps_injective_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_injective_ft_section3_route.tex
@@ -395,15 +395,15 @@ edgeBlockedThreeSiteInjective_all_two_lt_card}
   $V\setminus\{v\}$ opened along the star $\textsf{IncidentEdge}(G,v)$ as the
   shared boundary; its injectivity
   \leanid{TNLean.PEPS.isTwoBlockInjective_complementTwoBlock} follows from vertex
-  injectivity and positive bond dimensions through the star-boundary kernel
-  descent \leanid{TNLean.PEPS.vertexComplementTensorInjective_of_isVertexInjective}.
-  This is the same contraction-of-injective-tensors fact used for the edge-middle
-  block, with the single distinguished vertex $v$ replacing the two endpoints of
-  a distinguished edge: a global virtual configuration is split at each
-  complement vertex $j\ne v$
-  (\leanid{TNLean.PEPS.vertexConfigSplitAt}), the kernel condition descends by
-  the one-sided inverse at $j$, and the terminal empty-region step uses positive
-  bond dimensions to fill the interior virtual indices.
+  injectivity and positive bond dimensions through
+  \leanid{TNLean.PEPS.regionBlockedTensorInjective_of_isVertexInjective},
+  specialized to $V\setminus\{v\}$. The boundary-edge and physical-vertex
+  identifications in
+  \leanid{TNLean.PEPS.regionBlockedWeight_vertexComplement} identify this blocked
+  tensor with the vertex-complement tensor. Thus
+  \leanid{TNLean.PEPS.vertexComplementTensorInjective_of_isVertexInjective}
+  is the same contraction-of-injective-tensors fact, rather than a second
+  kernel-descent argument.
 \item The final two-tensor comparison is applied by blocking one vertex against
   its complement. The paper uses this to prove
   $A_i=\lambda_i\widetilde B_i$ at each vertex, and then incorporates the


### PR DESCRIPTION
## What changed
- REVIVES validated #4637 rebased onto current main (original -509/+214 line delta, now -510/+217)
- Moves `vertexConfigSplitAt` from `VertexComplement/KernelDescent` to `ConfigurationCalculus` (generic configuration calculus)
- Region kernel descent no longer imports the vertex-complement special case
- Names boundary/vertex/physical configuration equivalences between a vertex complement and the corresponding region
- `vertexComplementTensorInjective_of_isVertexInjective` is derived from the general region theorem instead of a duplicate kernel-descent argument
- Deletes ~500 lines of duplicate complement-only kernel-descent implementation
- Public complement theorem keeps its EXACT statement
- Blueprint proof-route synchronization updated

## Validation
- `lake build`: 9742/9742 jobs, all green
- `cd blueprint/src && lualatex -interaction=nonstopmode -halt-on-error print.tex` (×2): 690 pages, 0 undefined references (citation-only standalone warnings as expected)
- `leanblueprint checkdecls`: 0 missing (no new vs baseline)
- `python3 scripts/check_oversized_lean_files.py`: all pass
- `python3 scripts/check_numbered_lean_files.py`: all pass
- `python3 scripts/check_forbidden_lean_tokens.py`: all pass
- `python3 scripts/tactic_pattern_scan.py`: all pass
- `git diff --check`: clean
- `git diff` contains no sorry/admit/axiom/native_decide

Advances #4522

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large deletion in a formal proof library with import-graph changes; mathematical content is preserved by equivalence to the existing region theorem, but regressions would show up as Lean build or blueprint check failures rather than silent behavior changes.
> 
> **Overview**
> **Refactors PEPS kernel descent** so vertex-complement linear independence is a specialization of the arbitrary-region blocked-tensor theorem, not a second ~500-line descent proof.
> 
> `IsIncidentEdge`, `vertexConfigSplitAt`, and their evaluation lemmas move from `VertexComplement/KernelDescent` into **`ConfigurationCalculus`**, built on generic `virtualConfigSplit`. **`RegionBlock/KernelDescent`** now imports `ConfigurationCalculus` only (no vertex-complement import). The complement file is replaced by boundary/physical **equivalences** (`vertexComplementBoundaryConfigEquiv`, `regionBlockedWeight_vertexComplement`, etc.) and a short proof that **`vertexComplementTensorInjective_of_isVertexInjective`** follows from `regionBlockedTensorInjective_of_isVertexInjective` after reindexing—the public theorem statement is unchanged.
> 
> Blueprint (`ch24_peps_ft_foundations`, `ch24_peps_ft_region_transfer_covariance`) and `docs/paper-gaps/peps_injective_ft_section3_route.tex` are updated to document the region identification and the shortened proof route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac3265f118058b7d174c76c28e4214217da94f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->