### PR TITLE
refactor(MPS): replace inline mixed-transfer self-case duplicates by named lemmas

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -222,9 +222,8 @@ theorem mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one
     -- `mixedTransferMap` and `mixedTransferMap₂` agree on `D × D` matrices.
     have hagree :
         mixedTransferMap (d := d) (D := D) A B =
-          mixedTransferMap₂ (d := d) (D₁ := D) (D₂ := D) A B := by
-      ext X
-      simp
+          mixedTransferMap₂ (d := d) (D₁ := D) (D₂ := D) A B :=
+      (mixedTransferMap₂_same_dim A B).symm
     rw [← hagree]; exact hsq
   have hzero :
       Filter.Tendsto (fun N => mpvOverlap (d := d) A B N) Filter.atTop

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -455,10 +455,8 @@ private lemma mixedTransferSpectralRadius₂_lt_one_of_dim_eq
     mixedTransferSpectralRadius₂ A B < 1 := by
   subst hD
   simp only [cast_eq] at hgpe
-  have hagree : mixedTransferMap₂ (d := d) (D₁ := D₁) (D₂ := D₁) A B =
-      mixedTransferMap A B := by
-    ext X; simp
-  rw [mixedTransferSpectralRadius₂_eq, hagree, ← mixedTransferSpectralRadius_eq]
+  rw [mixedTransferSpectralRadius₂_eq, mixedTransferMap₂_same_dim,
+    ← mixedTransferSpectralRadius_eq]
   exact spectralRadius_mixedTransfer_lt_one_of_irreducible_TP A B hA_irr hB_irr
     hA_left hB_left hgpe
 


### PR DESCRIPTION
## What changed

Two pre-existing inline duplicates of `mixedTransferMap₂_same_dim` (rectangular → square mixed-transfer identification on equal bond dimensions) are replaced by the named lemma. All surrounding statements are byte-identical; proof-only change in two files.

- `MPS/RFP/BNTOrthogonality.lean` (`mixedTransferSpectralRadius₂_lt_one_of_dim_eq`): dropped the local `have hagree : mixedTransferMap₂ A B = mixedTransferMap A B := by ext X; simp` and rewrote the subsequent rewrite chain as `rw [mixedTransferSpectralRadius₂_eq, mixedTransferMap₂_same_dim, ← mixedTransferSpectralRadius_eq]`.
- `MPS/FundamentalTheorem/Proportional.lean` (`mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one`): the symmetric inline identity `mixedTransferMap A B = mixedTransferMap₂ A B`, previously proved by `ext X; simp`, is now the term `(mixedTransferMap₂_same_dim A B).symm`.

Archaeology: `mixedTransferMap₂_self` was extracted in #3604 (`617972aae`), which converted the two `ResidualIsometry` consumers; `c10ce8737` later added the third consumer in `BNTOrthogonality`. The rectangular↔square identification `mixedTransferMap₂_same_dim` was introduced in #4628 (`26a2c4ffe`), which converted the `TransferOperatorGapNT`/`TransferOperatorGapNormalized` square-case sites and re-routed `mixedTransferMap₂_self` through it — but missed these two inline duplicates, which predate the lemma (`BNTOrthogonality` from #3600, `Proportional` from `011391410`). This PR converts the two remaining sites; no other inline self-case or same-dimension duplicates remain (verified by repo-wide search for equal-argument `mixedTransferMap₂` uses and for `mixedTransferMap₂_apply`+`transferMap_apply` inline proofs).

## Validation

- `lake build TNLean.MPS.RFP.BNTOrthogonality TNLean.MPS.FundamentalTheorem.Proportional` — green (targeted build; reverse importers covered by the full build below)
- `lake build` — green, 9742 jobs
- `git diff --check` — clean
- Diff contains no `sorry`/`admit`/`axiom`/`native_decide`
- `python3 scripts/check_oversized_lean_files.py` — pass (0 over limit)
- `python3 scripts/check_numbered_lean_files.py` — pass (0 new violations)
- `python3 scripts/check_forbidden_lean_tokens.py` — pass
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && python3 scripts/blueprint_lean_sync.py --root . --ci` — 5493/5496 in sync
- `cd blueprint && leanblueprint checkdecls` (on the regenerated `lean_decls`) — exit 0, no missing declarations

Advances #4521

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no changes to theorem statements or runtime code; only reuses an existing simp lemma.
> 
> **Overview**
> **Proof-only deduplication:** two places that re-proved `mixedTransferMap` = `mixedTransferMap₂` on equal bond dimension now call the existing lemma `mixedTransferMap₂_same_dim` instead of inline `ext X; simp`.
> 
> In `mixedTransferSpectralRadius_ge_one_of_mpvOverlap_norm_tendsto_one` (`Proportional.lean`), the agreement step is `(mixedTransferMap₂_same_dim A B).symm`. In `mixedTransferSpectralRadius₂_lt_one_of_dim_eq` (`BNTOrthogonality.lean`), the local `have hagree` block is dropped in favor of `rw [mixedTransferSpectralRadius₂_eq, mixedTransferMap₂_same_dim, ← mixedTransferSpectralRadius_eq]`.
> 
> No statement or API changes; behavior of the surrounding theorems is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 244caab9c15c9796f8e5d0550c2959e56ba1a8f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->