### PR TITLE
refactor(PEPS): derive hbond internally in the torus fundamental theorem

### DIFF
--- a/TNLean/PEPS/TorusFundamentalTheorem2.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem2.lean
@@ -16,9 +16,11 @@ import TNLean.PEPS.NormalBondDimension
 
 This file proves the torus Fundamental Theorem with no conditional per-vertex hypothesis: from
 the source hypotheses alone --- translation
-invariance, matched bond dimensions, positive bonds, the same state, the
+invariance, positive bonds, the same state, the
 rectangular-injectivity hypotheses (the union closure of injective regions is derived from the
-positive bonds), and the source's own sizes `n, m ≥ 7` --- it produces a per-edge gauge family
+positive bonds, and the bond-dimension equality from the rectangular-injectivity hypotheses
+via `bondDim_eq_of_normalTorusRectangle`), and the source's own sizes `n, m ≥ 7` --- it
+produces a per-edge gauge family
 `X` and a single scalar `λ` with
 
 * the translation covariance of `X` (the faithful torus form of the source's *"the same matrix
@@ -263,13 +265,16 @@ theorem bondDim_eq_of_normalTorusRectangle
 /-- **Unconditional normal PEPS Fundamental Theorem on the torus.**
 
 For a translation-invariant pair `A`, `B` on the discrete `n × m` torus with `n, m ≥ 7` (the
-source's own sizes), matched bond dimensions, positive bonds, the same state, and both
+source's own sizes), positive bonds, the same state, and both
 satisfying the rectangular-injectivity hypotheses,
+the bond dimensions of `A` and `B` agree on every edge and
 there are a translation-covariant per-edge gauge family `X` realizing the
 bare-edge absorbed equality at every edge, and a single scalar `λ` with the per-vertex relation
 `A_v = λ · (gauge action of B at v)` at every torus vertex and `λ^{width·height} = 1`.  The
 union closure of injective regions is derived from the positive bonds
-(`regionInjectivityUnionClosure_of_overlap`), not assumed.
+(`regionInjectivityUnionClosure_of_overlap`), and the bond-dimension equality is derived
+from the rectangular injectivity hypotheses (`bondDim_eq_of_normalTorusRectangle`); neither
+is assumed.
 
 This is the torus form of Theorem 3 (arXiv:1804.04964, Section 3, lines 1453--1471 of
 `Papers/1804.04964/paper_normal.tex`): `B = λ · (X, Y\text{-action on } A)` with
@@ -298,10 +303,11 @@ theorem fundamentalTheorem_normalTorusPEPS_unconditional
     (hBr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) B))
     (hw : 7 ≤ width) (hh : 7 ≤ height)
-    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
-    ∃ X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
+    ∃ (hbond : A.bondDim = B.bondDim)
+        (X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ),
       IsTranslationCovariantGaugeFamily B X ∧
       (∀ (e : Edge (torusGraph width height)) (σ : TorusVertex width height → Fin d)
         (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
@@ -323,6 +329,9 @@ theorem fundamentalTheorem_normalTorusPEPS_unconditional
   have hUB : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B) :=
     regionInjectivityUnionClosure_of_overlap B hposB
+  -- The bond-dimension equality, from the rectangular injectivity hypotheses.
+  have hbond : A.bondDim = B.bondDim :=
+    bondDim_eq_of_normalTorusRectangle hA hB hAr hBr hUA hUB hw hh hAB hd hposA hposB
   -- The translation-covariant absorbed gauge family, at the seam-touching reference anchors.
   obtain ⟨X, hXcov, hedge⟩ := exists_torusCovariantAbsorbedGaugeFamily
     (xhStart := width - 5) (yhStart := height - 5) (xvStart := width - 5) (yvStart := height - 5)
@@ -388,7 +397,7 @@ theorem fundamentalTheorem_normalTorusPEPS_unconditional
   -- The per-vertex relation with the single ratio `λ = c_S / c_R`.
   have hPV := component_eq_gaugeVertex_of_cornerProportional hA hB hXcov hbond hposA hw hh
     hcR0 hRB hcRprop hcSprop
-  exact ⟨X, hXcov, hedge, cS / cR, hPV,
+  exact ⟨hbond, X, hXcov, hedge, cS / cR, hPV,
     lambda_pow_card_torus_eq_one A B cornerRegion hRA hCRA hposA hAB X hbond (cS / cR) hPV⟩
 
 end PEPS

--- a/blueprint/src/chapter/ch24_peps_ft_torus_staircase_geometry_and_ft.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_staircase_geometry_and_ft.tex
@@ -185,7 +185,10 @@
         unique crossing edge and gives
         \begin{align}
             D_A(e_h)=D_B(e_h),
-            \qquad\text{and at the rotated frame}\qquad
+            \notag
+        \end{align}
+        and the rotated datum at $e_v$ gives
+        \begin{align}
             D_A(e_v)=D_B(e_v).
             \notag
         \end{align}
@@ -248,12 +251,14 @@
         thm:peps_sameState_transport,
         thm:peps_stateCoeff_translationInvariant,
         thm:peps_torusUniformBondDim_of_translationInvariant,
+        def:peps_torusRectangleInjectivityHypotheses,
         def:GaugeEquivPEPS}
     Let $A$ and $B$ be translationally invariant PEPS tensors on the discrete
-    $n\times m$ torus with $n,m\geq 7$, with positive physical dimension, equal
-    and positive bond dimensions,
+    $n\times m$ torus with $n,m\geq 7$, with positive physical dimension and
+    positive bond dimensions,
     generating the same state, and such that every contiguous $2\times 3$ and
-    $3\times 2$ coordinate rectangle of either tensor is injective. Then there
+    $3\times 2$ coordinate rectangle of either tensor is injective. Then the
+    bond dimensions of $A$ and $B$ agree on every edge, and there
     are a family of invertible matrices, one on each edge, carried onto each
     edge by the torus translations from a single matrix on a reference
     horizontal edge and a single matrix on a reference vertical edge, and a
@@ -284,9 +289,14 @@
     per-vertex relation itself).
     \begin{proof}
         \leanok
-        \uses{lem:peps_injectiveRegion_union_pos}
+        \uses{lem:peps_injectiveRegion_union_pos,
+            thm:peps_bondDim_eq_of_normalTorusRectangularInjectivity}
         The union closure of injective regions follows from the positive bond
-        dimensions and Lemma~\ref{lem:peps_injectiveRegion_union_pos}. The
+        dimensions and Lemma~\ref{lem:peps_injectiveRegion_union_pos}, and
+        the bond-dimension equality $D_A=D_B$ is derived from the rectangular
+        injectivity hypotheses and the same-state hypothesis by
+        Theorem~\ref{thm:peps_bondDim_eq_of_normalTorusRectangularInjectivity};
+        neither is assumed. The
         reference blockings are anchored against the far seam: the removed
         blocks keep a margin of at least two rows and columns below and to
         the left and end exactly at the seam above and to the right, so the


### PR DESCRIPTION
## What changed

Follow-up to #4763 (merged at 8653e7640; this commit was pushed minutes after the merge captured the stale head, so it did not land). It addresses the remaining **must-fix** from the #4763 proof review: the torus fundamental theorem still assumed `hbond : A.bondDim = B.bondDim`.

- `fundamentalTheorem_normalTorusPEPS_unconditional` no longer takes `hbond` as a hypothesis. It derives the equality from the rectangular injectivity hypotheses via `bondDim_eq_of_normalTorusRectangle` — all of that lemma's inputs (translation invariance, rectangular injectivity, union closure from positive bonds via `regionInjectivityUnionClosure_of_overlap`, `n,m ≥ 7`, same state, positive bonds) are already in the theorem's context — and returns the equality as the first component of the existential conclusion, so the statement's casts still refer to a named `hbond`.
- No Lean call sites needed adjustment (the theorem is referenced only from docstrings and the blueprint).
- The square fundamental theorem keeps `hbond` assumed: `bondDim_apply_eq_of_normalSquareInteriorEdge` reaches only interior-margin edges, so boundary edges stay outside its documented scope restriction (per the same review's analysis).
- Blueprint: the unconditional-FT entry drops the equal-bond-dimensions hypothesis, gains `def:peps_torusRectangleInjectivityHypotheses` in its statement `\uses`, and its proof records the derivation through `thm:peps_bondDim_eq_of_normalTorusRectangularInjectivity`; the torus bond-dimension proof sketch splits a `\qquad`-joined display into one `align` line per equation (bugbot style rule).
- Module and theorem docstrings updated (matched bond dimensions no longer listed as a source hypothesis).

## Validation

- `lake build` — 9742/9742 jobs, green (pre-existing `sorry`s only in MPS/Periodic/Overlap/* — unrelated)
- Blueprint compiles (double `lualatex`) — 0 undefined references
- `leanblueprint checkdecls` — exit 0 on a regenerated `lean_decls`
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `git diff --check` — clean
- No `sorry`/`admit`/`axiom`/`native_decide` in diff

Advances #4518

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor only: existing lemma `bondDim_eq_of_normalTorusRectangle` is wired in place of an assumed hypothesis, with no Lean call-site signature changes beyond the theorem itself.
> 
> **Overview**
> **The torus unconditional fundamental theorem** (`fundamentalTheorem_normalTorusPEPS_unconditional`) no longer takes matched bond dimensions as input. Bond equality on every edge is proved inside the proof via `bondDim_eq_of_normalTorusRectangle` (using translation invariance, rectangular injectivity, union closure from positive bonds, same state, and `n,m ≥ 7`), and the existential conclusion now leads with that equality as `hbond` so casts in the gauge and per-vertex clauses still typecheck.
> 
> Module and theorem docstrings drop “matched bond dimensions” from the listed hypotheses and note that bond equality is derived like union closure. The blueprint unconditional FT statement and proof are aligned: equal bond dimensions are a **conclusion**, not an assumption; the proof cites `thm:peps_bondDim_eq_of_normalTorusRectangularInjectivity`. A minor display fix splits two bond-dimension equations in the rectangular-injectivity proof sketch into separate `align` blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23656d9d7a9a5b2b01e58dd0a0736dc707f31b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->