### PR TITLE
fix(tenkz): address S4 review follow-ups

### DIFF
--- a/tex/tenkz/tenkz-free.code.tex
+++ b/tex/tenkz/tenkz-free.code.tex
@@ -1,8 +1,8 @@
-% Input: validated free atoms, typed ports, joins, regions, and positions.
-% Output: normalized graph records plus free-layout routing ink.
-% Owned state: named atoms, port types, routed joins, and enclosure membership.
-% Invariants: every join resolves two compatible ports before drawing.
-% Next stage: shared event services emit the resolved model used for rendering.
+% Input: public free atoms, typed ports, joins, regions, and author positions.
+% Output: normalized model records plus validated free-layout render requests.
+% Owned state: command staging, named port types, routed joins, and enclosures.
+% Invariants: every committed atom and join records before validation; no raw ink.
+% Next stage: model validation freezes topology; render coordinators emit the ink.
 % tenkz-free supports genuinely non-grid diagrams and is the only tier with runtime
 % port-type assertions: the grid languages are type-safe by construction.
 %
@@ -18,9 +18,10 @@
   {
     \tl_if_empty:nF {#1} { \pgfqkeys{/tenkz}{#1} }
     \tenkz@beginpicture{free}
-    % The free tier records imperatively: atoms and joins write as the
-    % body executes, so validation seals the store at the environment's
-    % END.  Write-only until the free renderer consumes records.
+    % The free tier records imperatively: atoms and joins write as the body
+    % executes, so validation seals the picture-local store before TikZ closes.
+    % This draft still renders from resolved locals; the S4 cutover tracked in
+    % #4699 makes the renderer consume these records directly.
     \__tenkz_model_reset:
     \__tenkz_model_record_picture:n { lang={free} }
     % NFSS sets math fonts up lazily; force them before reading the axis
@@ -221,21 +222,21 @@
     \begin{scope}[local~bounding~box=\l__tenkz_fbound_tl]
       \str_case:Vn \l__tenkz_fshape_tl
         {
-          {dot}  { \__tenkz_render_free_node:nnnn
+          {dot}  { \__tenkz_render_labelnode_named:nnnn
                      {tensor, \l__tenkz_frolesty_tl} {#2} {#3} {}
                    \tl_if_blank:nF {#4}
                      { \exp_args:NV \tenkz_free_dot_label:nnn
                          \l__tenkz_flpos_tl {#2} {#4} } }
-          {box}  { \__tenkz_render_free_node:nnnn
+          {box}  { \__tenkz_render_labelnode_named:nnnn
                      {box~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
-          {pill} { \__tenkz_render_free_node:nnnn
+          {pill} { \__tenkz_render_labelnode_named:nnnn
                      {pill~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
-          {mpo}  { \__tenkz_render_free_node:nnnn
+          {mpo}  { \__tenkz_render_labelnode_named:nnnn
                      {mpo~tensor, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
-          {ring} { \__tenkz_render_free_node:nnnn
+          {ring} { \__tenkz_render_labelnode_named:nnnn
                      {on-wire~matrix, \l__tenkz_frolesty_tl} {#2} {#3}
                      { $\tenkz@labelsize \tenkz@glyphstrut #4$ } }
           {boundary}

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -69,8 +69,6 @@
 % the join body reads the free tier's resolved j* locals exactly as the
 % legacy site did (the language landing replaces the locals with record
 % fields).
-\cs_new_protected:Npn \__tenkz_render_free_node:nnnn #1#2#3#4
-  { \node[#1] (#2) at #3 {#4}; }
 \cs_new_protected:Npn \__tenkz_render_free_coordinate:nn #1#2
   { \coordinate (#1) at #2; }
 \cs_new_protected:Npn \__tenkz_render_free_marker:n #1


### PR DESCRIPTION
## Summary

Follow up the S4 checkpoint merged through #4762 after its original draft #4756 was closed as superseded.

- reuse the shared named-node renderer instead of keeping a byte-identical free-tier primitive
- align the five-line free-stage contract with the model writes and render requests the file now owns
- state the remaining picture-local record-to-render cutover explicitly and link it to #4699

This PR does not claim the S4 cutover is complete: the free renderer still consumes resolved front-end locals.

## Validation

- `python3 scripts/tenkz_lint.py --census`
- `git diff --check`
- compile and audit `free.tex`, `free_modes.tex`, `free_test.tex`, `free_typed_joins_ex.tex`, and `p_usagefree.tex`

Follow-up to #4762 and superseded draft #4756.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor is documentation plus delegating to an existing shared renderer with identical TikZ output; no auth, data, or topology logic changes.
> 
> **Overview**
> **Documentation and comments** in `tenkz-free.code.tex` now describe the free stage as producing normalized model records and validated render requests (with validation sealing the picture-local store before TikZ closes), and they explicitly note that rendering still uses resolved locals until the S4 record-to-render cutover in #4699.
> 
> **Rendering cleanup:** `\tnput` for dot, box, pill, mpo, and ring skins no longer calls a free-tier-only `\__tenkz_render_free_node` wrapper; it uses the shared `\__tenkz_render_labelnode_named` coordinator. The byte-identical `\__tenkz_render_free_node` definition is **removed** from `tenkz-render.code.tex`, leaving free-specific helpers only for coordinates, markers, and joins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2964c88332835aee3a68c67ba52c2adff32681e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->