### PR TITLE
refactor(blueprint): organize Chapter 5 supporting results

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
+++ b/blueprint/src/appendix/ft_mps/ch05_schwarz.tex
@@ -1,11 +1,221 @@
 \chapter{Schwarz Inequalities and Multiplicative Domains: Supporting Results}
 \label{ch:schwarz_supporting_results}
 
-This appendix supports Chapter~\ref{ch:schwarz}. It records the rank-one
-rigidity argument used to identify the scalar factor in a positive retraction.
+This appendix supports Chapter~\ref{ch:schwarz} by collecting the elementary
+order, trace-duality, rank-one, and weighted-trace arguments used there.
 
-The following theorem supplies the scalarity step in
-Theorem~\ref{thm:positive_retraction_one_matrix_factor}.
+\section{Trace duality and elementary order preservation}
+\label{sec:app_schwarz_trace_order}
+
+Let $T$ denote a positive linear map between matrix algebras. For a linear map
+$E:\MN{D}\to\MN{D'}$, write $E^*$ for the trace-pairing adjoint of
+Definition~\ref{def:trace_pairing_adjoint}. The results below supply the
+order step in Theorem~\ref{thm:positive_map_image_bounded}, the adjointness step
+in Theorem~\ref{thm:trace_pairing_adjoint_ampliation}, and the positivity step
+in Theorem~\ref{thm:k_positive_trace_pairing_adjoint}. Adjoint preservation is
+also used in Theorem~\ref{thm:maximalSupport_fixedPoint_of_bounded_orbits}.
+
+\begin{theorem}[Positive maps are monotone]
+    \label{thm:positive_map_monotone}
+    \lean{IsPositiveMap.map_le_map}
+    \leanok
+    \uses{def:positive_map}
+    If $T:\MN{n}\to\MN{m}$ is positive and
+    $A,B\in\MN{n}$ satisfy $A\le B$, then $T(A)\le T(B)$ in $\MN{m}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $B-A\ge0$, positivity gives $T(B-A)\ge0$.
+    By linearity, this is $T(B)-T(A)\ge0$.
+\end{proof}
+
+\begin{theorem}[Positive maps preserve adjoints]
+    \label{thm:positive_map_conjTranspose}
+    \lean{IsPositiveMap.map_conjTranspose}
+    \leanok
+    \uses{def:positive_map_is_positive_linear_map}
+    If $T:\MN{n}\to\MN{m}$ is positive, then
+    $T(A^\dagger)=T(A)^\dagger$ for all $A\in\MN{n}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Regard $T$ as the associated positive linear map
+    (Definition~\ref{def:positive_map_is_positive_linear_map}). For positive
+    linear maps between matrix $C^*$-algebras, $T(A^\ast)=T(A)^\ast$.
+    Since the star on each matrix algebra is the conjugate transpose,
+    $T(A^\dagger)=T(A^\ast)=T(A)^\ast=T(A)^\dagger$.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoint identity]\label{thm:trace_pairing_adjoint_identity}
+    \lean{Matrix.trace_traceAdjointMap_mul}
+    \leanok
+    \uses{def:trace_pairing_adjoint}
+    For every linear map $E : \MN{D} \to \MN{D'}$, every $\rho \in \MN{D'}$,
+    and every $X \in \MN{D}$, one has
+    \begin{align}
+        \tr(E^*(\rho)X)
+         & =\tr(\rho E(X)).
+        \label{eq:schwarz_trace_adjoint_pairing}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $X=\sum_{i,j}X_{ij}e_{ij}$ in the standard matrix units and use
+    linearity in $X$. For $X=e_{ij}$ one has
+    $\tr(E^*(\rho)e_{ij})=(E^*(\rho))_{ji}$, while the definition of $E^*$
+    gives $(E^*(\rho))_{ji}=\tr(\rho E(e_{ij}))$.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoint is involutive]\label{thm:trace_pairing_adjoint_involutive}
+    \lean{Matrix.traceAdjointMap_traceAdjointMap}
+    \leanok
+    \uses{def:trace_pairing_adjoint, thm:trace_nondeg}
+    For every linear map $E : \MN{D} \to \MN{D'}$, the trace-pairing adjoint
+    of $E^*$ is $E$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Fix $X\in\MN{D}$ and an arbitrary matrix $N\in\MN{D'}$. Applying
+    (\ref{eq:schwarz_trace_adjoint_pairing}) first to
+    $E^* : \MN{D'} \to \MN{D}$ and then to $E$ gives
+    \begin{align}
+        \tr((E^*)^*(X)N)
+         & =\tr(XE^*(N))
+        =\tr(E^*(N)X)
+        =\tr(NE(X))
+        =\tr(E(X)N).
+        \notag
+    \end{align}
+    Both $(E^*)^*(X)$ and $E(X)$ lie in $\MN{D'}$, so, since this holds for
+    every $N\in\MN{D'}$, nondegeneracy of the trace pairing on $\MN{D'}$
+    gives $(E^*)^*=E$.
+\end{proof}
+
+\begin{theorem}[Self-duality of the positive semidefinite cone]
+    \label{thm:psd_trace_pairing_self_dual}
+    \lean{Matrix.PosSemidef.of_forall_trace_mul_nonneg}
+    \leanok
+    Let $A \in \MN{D}$ be Hermitian. If $\tr(AB)\geq 0$ for every
+    positive semidefinite matrix $B$, then $A\geq 0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Test the hypothesis on rank-one positive semidefinite matrices
+    $B=xx^\dagger$. The identity $\tr(Axx^\dagger)=x^\dagger A x$ and the
+    hypothesis give $x^\dagger A x\geq 0$ for every vector $x$, so the
+    Hermitian matrix $A$ is positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoint of a positive map]\label{thm:trace_pairing_adjoint_positive}
+    \lean{IsPositiveMap.traceAdjointMap}
+    \leanok
+    \uses{def:trace_pairing_adjoint, thm:psd_trace_pairing_self_dual}
+    If $E : \MN{D}\to\MN{D}$ is positive, then its trace-pairing adjoint $E^*$
+    is positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:positive_map_conjTranspose}
+    Let $\rho\geq 0$. First $E^*(\rho)$ is Hermitian. Indeed,
+    Theorem~\ref{thm:positive_map_conjTranspose} gives
+    $E(A^\dagger)=E(A)^\dagger$, and hence, for matrix units
+    $e_{ij}$,
+    \begin{align}
+        \overline{\tr(\rho E(e_{ij}))}
+         & =\tr(E(e_{ij})^\dagger\rho)
+        =\tr(E(e_{ji})\rho)
+        =\tr(\rho E(e_{ji})).
+        \notag
+    \end{align}
+    For every $B\geq 0$, (\ref{eq:schwarz_trace_adjoint_pairing}) gives
+    $\tr(E^*(\rho)B)=\tr(\rho E(B))$.
+    Since $E(B)\geq 0$, the right-hand side is non-negative by positivity of
+    the trace product of two positive semidefinite matrices. Self-duality of
+    the positive semidefinite cone therefore gives $E^*(\rho)\geq 0$.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoints preserve positivity exactly]\label{thm:trace_pairing_adjoint_positive_iff}
+    \lean{isPositiveMap_traceAdjointMap_iff}
+    \leanok
+    \uses{thm:trace_pairing_adjoint_positive, thm:trace_pairing_adjoint_involutive}
+    A linear map is positive if and only if its trace-pairing adjoint is
+    positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    One direction is Theorem~\ref{thm:trace_pairing_adjoint_positive}. The
+    other follows by applying the same theorem to $E^*$ and using
+    Theorem~\ref{thm:trace_pairing_adjoint_involutive}.
+\end{proof}
+
+\section{Positive functionals and rank-one retractions}
+\label{sec:app_schwarz_retractions}
+
+The next three results provide, respectively, the density, support, and
+scalarity steps in Theorem~\ref{thm:positive_retraction_one_matrix_factor} and
+hence in its finite-star-algebra extension,
+Theorem~\ref{thm:positive_retraction_finite_star_algebra}.
+
+\begin{theorem}[Density representation of positive matrix functionals]
+    \label{thm:positive_functional_density_representation}
+    \lean{Matrix.exists_density_of_positive_functional}
+    \leanok
+    Let $f : \MN{D} \to \C$ be a complex-linear functional, where $D>0$. If
+    $f(X) \geq 0$ for every $X \geq 0$ and $f(\Id)=1$, then there is a density
+    matrix $\rho \in \MN{D}$ such that
+    $f(X) = \tr(\rho X)$ for every $X \in \MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:trace_pairing_adjoint_identity, thm:trace_pairing_adjoint_positive}
+    Define $F : \MN{D} \to \MN{D}$ by $F(X) = f(X)\Id$. For $X \geq 0$ one has
+    $f(X) \geq 0$, so $F(X) = f(X)\Id \geq 0$ and $F$ is positive.
+    Set $\sigma = D^{-1}\Id$ and $\rho = F^*(\sigma)$. Positivity of the
+    trace-pairing adjoint gives $\rho \geq 0$, while
+    (\ref{eq:schwarz_trace_adjoint_pairing}) gives
+    \begin{align}
+        \tr(\rho X)
+         & =\tr(\sigma F(X))
+        =f(X).
+        \notag
+    \end{align}
+    Taking $X = \Id$ yields $\tr(\rho) = 1$.
+\end{proof}
+
+\begin{lemma}[Rank-one domination]
+    \label{lem:posSemidef_rankone_domination}
+    \lean{Matrix.PosSemidef.eq_nonneg_smul_vecMulVec_of_le_smul_vecMulVec}
+    \leanok
+    Let $A\in\MN{D}$ be positive semidefinite, let $c\in\C$, and let
+    $\psi\in\C^D$. If $A\leq c\ketbra{\psi}{\psi}$, then there is a
+    non-negative scalar $a$ such that $A=a\ketbra{\psi}{\psi}$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The assertion is immediate when $\psi=0$. Otherwise set
+    $s=\langle\psi,\psi\rangle$, $P=\ketbra{\psi}{\psi}$, and $Q=s^{-1}P$.
+    Then $Q$ is the orthogonal projection onto $\C\psi$. Write
+    $B=cP-A\geq0$. Since $A+B=cP$ vanishes on the kernel of $Q$, positivity
+    implies $A(\Id-Q)=0$.
+    Taking adjoints gives $(\Id-Q)A=0$, and therefore $A=QAQ$. Finally,
+    \begin{align}
+        PAP
+         & =\langle\psi,A\psi\rangle P, \notag \\
+        A
+         & =s^{-2}\langle\psi,A\psi\rangle P.
+        \notag
+    \end{align}
+    The coefficient is non-negative because $A\geq0$ and $s>0$.
+\end{proof}
 
 \begin{theorem}[Rank-one ray scalar rigidity]
     \label{thm:rankone_ray_scalar_rigidity}
@@ -60,6 +270,28 @@ Theorem~\ref{thm:positive_retraction_one_matrix_factor}.
     gives $T(E_{ij})=cE_{ij}$. Thus $T=c\,\id$ on every matrix unit.
 \end{proof}
 
-Thus rank-one domination in
-Theorem~\ref{thm:positive_retraction_one_matrix_factor} produces one scalar
-functional rather than a vector-dependent family of coefficients.
+The rank-one domination and rigidity results turn the vector-dependent
+coefficients in the one-factor retraction into a single positive functional;
+the density representation identifies that functional with a density matrix.
+
+\section{Faithful weighted traces and peripheral Schwarz equality}
+\label{sec:app_schwarz_weighted_ks}
+
+These two trace facts provide the adjointness and faithfulness steps in
+Theorem~\ref{thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint}. For the
+Kraus map $E$, write $E^*$ for its Kraus adjoint and let $\rho>0$ denote the
+faithful fixed point used there.
+
+\begin{lemma}[Trace pairing for Kraus map and adjoint map]\label{lem:trace_mul_map_eq_trace_adjointMap_mul}
+    \lean{Kraus.trace_mul_map_eq_trace_adjointMap_mul}
+    \leanok
+    \uses{def:kraus_map, def:kraus_adjoint_map}
+    For all $X, Y \in \MN{D}$,
+    $\tr\!(X\,E(Y)) = \tr\!(E^*(X)\,Y)$.
+\end{lemma}
+
+\begin{lemma}[Positive-definite trace test]\label{lem:posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}
+    \lean{Kraus.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}
+    \leanok
+    If $A > 0$, $X \ge 0$, and $\tr(A X) = 0$, then $X = 0$.
+\end{lemma}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -10,7 +10,7 @@
     inequality if, for every $A\in\MN{D}$,
     \begin{align}
         E(A^\dagger A)-E(A^\dagger)E(A)
-        &\succeq 0.
+         & \succeq 0.
         \label{eq:schwarz_abstract_inequality}
     \end{align}
     This is \cite[Equation~(5.2)]{Wolf2012Quantum}.
@@ -25,11 +25,11 @@
     For a complex-linear map $E:\MN{D}\to\MN{D}$, set
     \begin{align}
         \mc{A}_R(E)
-        &=\{A:E(XA)=E(X)E(A)\text{ for every }X\}, \notag\\
+         & =\{A:E(XA)=E(X)E(A)\text{ for every }X\}, \notag \\
         \mc{A}_L(E)
-        &=\{A:E(AX)=E(A)E(X)\text{ for every }X\}, \notag\\
+         & =\{A:E(AX)=E(A)E(X)\text{ for every }X\}, \notag \\
         \mc{A}(E)
-        &=\mc{A}_R(E)\cap\mc{A}_L(E).
+         & =\mc{A}_R(E)\cap\mc{A}_L(E).
         \notag
     \end{align}
     These are \cite[Equations~(5.11)--(5.12)]{Wolf2012Quantum}, with the
@@ -48,10 +48,10 @@
     If $E$ satisfies the Schwarz inequality, then
     \begin{align}
         A\in\mc{A}_R(E)
-        &\quad\Longleftrightarrow\quad
-        E(A^\dagger A)=E(A^\dagger)E(A), \notag\\
+         & \quad\Longleftrightarrow\quad
+        E(A^\dagger A)=E(A^\dagger)E(A), \notag \\
         A\in\mc{A}_L(E)
-        &\quad\Longleftrightarrow\quad
+         & \quad\Longleftrightarrow\quad
         E(AA^\dagger)=E(A)E(A^\dagger).
         \notag
     \end{align}
@@ -66,22 +66,22 @@
     (\ref{eq:schwarz_abstract_inequality}) to $A+tY$ and $A+itY$ for real
     $t$. Set
     \begin{align}
-        L&=E(A^\dagger Y)-E(A^\dagger)E(Y), \notag\\
-        R&=E(Y^\dagger A)-E(Y^\dagger)E(A), \notag\\
-        Q&=E(Y^\dagger Y)-E(Y^\dagger)E(Y)\succeq0.
+        L & =E(A^\dagger Y)-E(A^\dagger)E(Y), \notag  \\
+        R & =E(Y^\dagger A)-E(Y^\dagger)E(A), \notag  \\
+        Q & =E(Y^\dagger Y)-E(Y^\dagger)E(Y)\succeq0.
         \notag
     \end{align}
     Expansion and the equality at $A^\dagger A$ give, for every real $t$,
     \begin{align}
-        t(L+R)+t^2Q&\succeq0, \notag\\
-        it(L-R)+t^2Q&\succeq0.
+        t(L+R)+t^2Q  & \succeq0, \notag \\
+        it(L-R)+t^2Q & \succeq0.
         \notag
     \end{align}
     Nonnegativity for both signs of every real parameter forces $L+R=0$ and
     $L-R=0$. Hence $L=R=0$, which is precisely
     \begin{align}
-        E(A^\dagger Y)&=E(A^\dagger)E(Y), \notag\\
-        E(Y^\dagger A)&=E(Y^\dagger)E(A).
+        E(A^\dagger Y) & =E(A^\dagger)E(Y), \notag \\
+        E(Y^\dagger A) & =E(Y^\dagger)E(A).
         \notag
     \end{align}
     Replacing $Y$ by $X^\dagger$ yields $E(XA)=E(X)E(A)$.
@@ -107,7 +107,7 @@
     (\ref{eq:schwarz_kadison}) therefore gives, for every $A\in\MN{D}$,
     \begin{align}
         E(A^\dagger A)-E(A^\dagger)E(A)
-        &=E(A^\dagger A)-E(A)^\dagger E(A)\succeq0.
+         & =E(A^\dagger A)-E(A)^\dagger E(A)\succeq0.
         \notag
     \end{align}
 \end{proof}
@@ -123,10 +123,10 @@
     For a Kraus map $E$, define
     \begin{align}
         \mc{A}_R(E)
-        &:=\{X\in\MN{D}:\forall Y\in\MN{D},\
-        E(XY)=E(X)E(Y)\}, \notag\\
+         & :=\{X\in\MN{D}:\forall Y\in\MN{D},\
+        E(XY)=E(X)E(Y)\}, \notag               \\
         \mc{A}_L(E)
-        &:=\{X\in\MN{D}:\forall Y\in\MN{D},\
+         & :=\{X\in\MN{D}:\forall Y\in\MN{D},\
         E(YX)=E(Y)E(X)\}.
         \notag
     \end{align}
@@ -161,9 +161,9 @@
     Kraus convention of this subsection. For the linear map associated with
     a Kraus family,
     \begin{align}
-        \mc{A}_R^{\mathrm W}&=\mc{A}_L^{\mathrm K}, \notag\\
-        \mc{A}_L^{\mathrm W}&=\mc{A}_R^{\mathrm K}, \notag\\
-        \mc{A}^{\mathrm W}&=\mc{A}^{\mathrm K}.
+        \mc{A}_R^{\mathrm W} & =\mc{A}_L^{\mathrm K}, \notag \\
+        \mc{A}_L^{\mathrm W} & =\mc{A}_R^{\mathrm K}, \notag \\
+        \mc{A}^{\mathrm W}   & =\mc{A}^{\mathrm K}.
         \notag
     \end{align}
 \end{remark}
@@ -177,10 +177,10 @@
     Let $E$ be a unital Kraus map. Then
     \begin{align}
         X\in\mc{A}_R(E)
-        &\quad\Longleftrightarrow\quad
-        E(XX^\dagger)=E(X)E(X)^\dagger, \notag\\
+         & \quad\Longleftrightarrow\quad
+        E(XX^\dagger)=E(X)E(X)^\dagger, \notag \\
         X\in\mc{A}_L(E)
-        &\quad\Longleftrightarrow\quad
+         & \quad\Longleftrightarrow\quad
         E(X^\dagger X)=E(X)^\dagger E(X).
         \notag
     \end{align}
@@ -235,8 +235,8 @@
     \uses{thm:md_characterization, thm:one_sided_md_subalgebras}
     If $X\in\mc{A}(E)=\mc{A}_R(E)\cap\mc{A}_L(E)$, then
     \begin{align}
-        E(X^\dagger X)&=E(X)^\dagger E(X), \notag\\
-        E(XX^\dagger)&=E(X)E(X)^\dagger.
+        E(X^\dagger X) & =E(X)^\dagger E(X), \notag \\
+        E(XX^\dagger)  & =E(X)E(X)^\dagger.
         \notag
     \end{align}
     The characterization of Theorem~\ref{thm:md_characterization} shows that
@@ -267,38 +267,8 @@
 
 \subsection{Positive maps preserve order and spectral intervals}
 
-\begin{theorem}[Positive maps are monotone]
-    \label{thm:positive_map_monotone}
-    \lean{IsPositiveMap.map_le_map}
-    \leanok
-    \uses{def:positive_map}
-    If $T:\MN{n}\to\MN{m}$ is positive and
-    $A,B\in\MN{n}$ satisfy $A\le B$, then $T(A)\le T(B)$ in $\MN{m}$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Since $B-A\ge0$, positivity gives $T(B-A)\ge0$.
-    By linearity, this is $T(B)-T(A)\ge0$.
-\end{proof}
-
-\begin{theorem}[Positive maps preserve adjoints]
-    \label{thm:positive_map_conjTranspose}
-    \lean{IsPositiveMap.map_conjTranspose}
-    \leanok
-    \uses{def:positive_map_is_positive_linear_map}
-    If $T:\MN{n}\to\MN{m}$ is positive, then
-    $T(A^\dagger)=T(A)^\dagger$ for all $A\in\MN{n}$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Regard $T$ as the associated positive linear map
-    (Definition~\ref{def:positive_map_is_positive_linear_map}). For positive
-    linear maps between matrix $C^*$-algebras, $T(A^\ast)=T(A)^\ast$.
-    Since the star on each matrix algebra is the conjugate transpose,
-    $T(A^\dagger)=T(A^\ast)=T(A)^\ast=T(A)^\dagger$.
-\end{proof}
+The elementary order-preservation results used below are proved in
+Section~\ref{sec:app_schwarz_trace_order}.
 
 \begin{theorem}[Order intervals are preserved]
     \label{thm:positive_map_image_bounded}
@@ -309,7 +279,7 @@
     If $a\le0\le b$ and $a\Id\le A\le b\Id$, then
     \begin{align}
         a\Id
-        &\le T(A)\le b\Id.
+         & \le T(A)\le b\Id.
         \label{eq:schwarz_order_interval}
     \end{align}
     This is the matrix form of \cite[Equation~(5.21)]{Wolf2012Quantum}.
@@ -318,7 +288,8 @@
 \begin{proof}
     \leanok
     \uses{thm:positive_map_monotone}
-    By monotonicity, $T(a\Id)\le T(A)\le T(b\Id)$.
+    By Theorem~\ref{thm:positive_map_monotone},
+    $T(a\Id)\le T(A)\le T(b\Id)$.
     For the lower bound, $T(a\Id)=aT(\Id)$.
     Since $a\le0$ and $T(\Id)\le\Id$, one has $aT(\Id)\ge a\Id$.
     For the upper bound, $T(b\Id)=bT(\Id)\le b\Id$ since $b\ge0$.
@@ -335,7 +306,7 @@
     If $\spec(A)\subseteq[a,b]$ with $a\le0\le b$, then
     \begin{align}
         \spec(T(A))
-        &\subseteq[a,b].
+         & \subseteq[a,b].
         \notag
     \end{align}
     This is \cite[Equation~(5.21)]{Wolf2012Quantum}.

--- a/blueprint/src/chapter/ch05_schwarz_two_positive_maps_ii.tex
+++ b/blueprint/src/chapter/ch05_schwarz_two_positive_maps_ii.tex
@@ -25,7 +25,7 @@
     $V\in\MN{D,k}(\C)$,
     \begin{align}
         R_{VV^\dagger}\tau R_{VV^\dagger}^\dagger
-        &=R_V^\dagger(R_V\tau R_V^\dagger)R_V.
+         & =R_V^\dagger(R_V\tau R_V^\dagger)R_V.
         \label{eq:schwarz_factorized_choi_sandwich}
     \end{align}
 \end{lemma}
@@ -53,7 +53,7 @@
     \leanok
     By (\ref{eq:schwarz_factorized_choi_sandwich}),
     $R_{VV^\dagger}\tau R_{VV^\dagger}^\dagger
-    =R_V^\dagger(R_V\tau R_V^\dagger)R_V$.
+        =R_V^\dagger(R_V\tau R_V^\dagger)R_V$.
     The factor $R_V\tau R_V^\dagger$ is positive by
     Theorem~\ref{thm:k_positive_right_tensor_choi_sandwiches}, and positive
     semidefiniteness is preserved under compression by $R_V$.
@@ -153,149 +153,10 @@
     $(A,B)\mapsto \tr(AB)$.
 \end{definition}
 
-\begin{theorem}[Trace-pairing adjoint identity]\label{thm:trace_pairing_adjoint_identity}
-    \lean{Matrix.trace_traceAdjointMap_mul}
-    \leanok
-    \uses{def:trace_pairing_adjoint}
-    For every linear map $E : \MN{D} \to \MN{D'}$, every $\rho \in \MN{D'}$,
-    and every $X \in \MN{D}$, one has
-    \begin{align}
-        \tr(E^*(\rho)X)
-        &=\tr(\rho E(X)).
-        \label{eq:schwarz_trace_adjoint_pairing}
-    \end{align}
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Write $X=\sum_{i,j}X_{ij}e_{ij}$ in the standard matrix units and use
-    linearity in $X$. For $X=e_{ij}$ one has
-    $\tr(E^*(\rho)e_{ij})=(E^*(\rho))_{ji}$, while the definition of $E^*$
-    gives $(E^*(\rho))_{ji}=\tr(\rho E(e_{ij}))$.
-\end{proof}
-
-\begin{theorem}[Trace-pairing adjoint is involutive]\label{thm:trace_pairing_adjoint_involutive}
-    \lean{Matrix.traceAdjointMap_traceAdjointMap}
-    \leanok
-    \uses{def:trace_pairing_adjoint, thm:trace_nondeg}
-    For every linear map $E : \MN{D} \to \MN{D'}$, the trace-pairing adjoint
-    of $E^*$ is $E$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Fix $X\in\MN{D}$ and an arbitrary matrix $N\in\MN{D'}$. Applying
-    (\ref{eq:schwarz_trace_adjoint_pairing}) first to
-    $E^* : \MN{D'} \to \MN{D}$ and then to $E$ gives
-    \begin{align}
-        \tr((E^*)^*(X)N)
-        &=\tr(XE^*(N))
-        =\tr(E^*(N)X)
-        =\tr(NE(X))
-        =\tr(E(X)N).
-        \notag
-    \end{align}
-    Both $(E^*)^*(X)$ and $E(X)$ lie in $\MN{D'}$, so, since this holds for
-    every $N\in\MN{D'}$, nondegeneracy of the trace pairing on $\MN{D'}$
-    gives $(E^*)^*=E$.
-\end{proof}
-
-\begin{theorem}[Self-duality of the positive semidefinite cone]
-    \label{thm:psd_trace_pairing_self_dual}
-    \lean{Matrix.PosSemidef.of_forall_trace_mul_nonneg}
-    \leanok
-    Let $A \in \MN{D}$ be Hermitian. If $\tr(AB)\geq 0$ for every
-    positive semidefinite matrix $B$, then $A\geq 0$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Test the hypothesis on rank-one positive semidefinite matrices
-    $B=xx^\dagger$. The identity $\tr(Axx^\dagger)=x^\dagger A x$ and the
-    hypothesis give $x^\dagger A x\geq 0$ for every vector $x$, so the
-    Hermitian matrix $A$ is positive semidefinite.
-\end{proof}
-
-\begin{theorem}[Trace-pairing adjoint of a positive map]\label{thm:trace_pairing_adjoint_positive}
-    \lean{IsPositiveMap.traceAdjointMap}
-    \leanok
-    \uses{def:trace_pairing_adjoint, thm:psd_trace_pairing_self_dual}
-    If $E : \MN{D}\to\MN{D}$ is positive, then its trace-pairing adjoint $E^*$
-    is positive.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Let $\rho\geq 0$. First $E^*(\rho)$ is Hermitian. Indeed, positivity of
-    $E$ gives $E(A^\dagger)=E(A)^\dagger$, and hence, for matrix units
-    $e_{ij}$,
-    \begin{align}
-        \overline{\tr(\rho E(e_{ij}))}
-        &=\tr(E(e_{ij})^\dagger\rho)
-        =\tr(E(e_{ji})\rho)
-        =\tr(\rho E(e_{ji})).
-        \notag
-    \end{align}
-    For every $B\geq 0$, (\ref{eq:schwarz_trace_adjoint_pairing}) gives
-    $\tr(E^*(\rho)B)=\tr(\rho E(B))$.
-    Since $E(B)\geq 0$, the right-hand side is non-negative by positivity of
-    the trace product of two positive semidefinite matrices. Self-duality of
-    the positive semidefinite cone therefore gives $E^*(\rho)\geq 0$.
-\end{proof}
-
-\begin{theorem}[Density representation of positive matrix functionals]
-    \label{thm:positive_functional_density_representation}
-    \lean{Matrix.exists_density_of_positive_functional}
-    \leanok
-    Let $f : \MN{D} \to \C$ be a complex-linear functional, where $D>0$. If
-    $f(X) \geq 0$ for every $X \geq 0$ and $f(\Id)=1$, then there is a density
-    matrix $\rho \in \MN{D}$ such that
-    $f(X) = \tr(\rho X)$ for every $X \in \MN{D}$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:trace_pairing_adjoint_identity, thm:trace_pairing_adjoint_positive}
-    Define $F : \MN{D} \to \MN{D}$ by $F(X) = f(X)\Id$. For $X \geq 0$ one has
-    $f(X) \geq 0$, so $F(X) = f(X)\Id \geq 0$ and $F$ is positive.
-    Set $\sigma = D^{-1}\Id$ and $\rho = F^*(\sigma)$. Positivity of the
-    trace-pairing adjoint gives $\rho \geq 0$, while
-    (\ref{eq:schwarz_trace_adjoint_pairing}) gives
-    \begin{align}
-        \tr(\rho X)
-        &=\tr(\sigma F(X))
-        =f(X).
-        \notag
-    \end{align}
-    Taking $X = \Id$ yields $\tr(\rho) = 1$.
-\end{proof}
-
-\begin{lemma}[Rank-one domination]
-    \label{lem:posSemidef_rankone_domination}
-    \lean{Matrix.PosSemidef.eq_nonneg_smul_vecMulVec_of_le_smul_vecMulVec}
-    \leanok
-    Let $A\in\MN{D}$ be positive semidefinite, let $c\in\C$, and let
-    $\psi\in\C^D$. If $A\leq c\ketbra{\psi}{\psi}$, then there is a
-    non-negative scalar $a$ such that $A=a\ketbra{\psi}{\psi}$.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    The assertion is immediate when $\psi=0$. Otherwise set
-    $s=\langle\psi,\psi\rangle$, $P=\ketbra{\psi}{\psi}$, and $Q=s^{-1}P$.
-    Then $Q$ is the orthogonal projection onto $\C\psi$. Write
-    $B=cP-A\geq0$. Since $A+B=cP$ vanishes on the kernel of $Q$, positivity
-    implies $A(\Id-Q)=0$.
-    Taking adjoints gives $(\Id-Q)A=0$, and therefore $A=QAQ$. Finally,
-    \begin{align}
-        PAP
-        &=\langle\psi,A\psi\rangle P, \notag\\
-        A
-        &=s^{-2}\langle\psi,A\psi\rangle P.
-        \notag
-    \end{align}
-    The coefficient is non-negative because $A\geq0$ and $s>0$.
-\end{proof}
+The trace-duality identities and positivity results behind the applications
+below are proved in Section~\ref{sec:app_schwarz_trace_order}. The density and
+rank-one support arguments for the retraction theorem are collected in
+Section~\ref{sec:app_schwarz_retractions}.
 
 % Scope restriction documented in
 % docs/paper-gaps/wolf_prop1_5_one_factor_scope.tex.
@@ -310,7 +171,7 @@
     a density matrix $\rho\in\MN{m}$ such that, for every $A\in\MN{md}$,
     \begin{align}
         E(A)
-        &=\Id_m\otimes
+         & =\Id_m\otimes
         \tr_m\!\left((\rho\otimes\Id_d)A\right).
         \label{eq:schwarz_positive_retraction_factor}
     \end{align}
@@ -321,19 +182,20 @@
 \begin{proof}
     \leanok
     \uses{lem:posSemidef_rankone_domination,
-      thm:positive_functional_density_representation,
-      thm:rankone_ray_scalar_rigidity}
+        thm:positive_functional_density_representation,
+        thm:rankone_ray_scalar_rigidity}
     Let $R(A)$ be the right tensor factor of $E(A)$, so that
     $E(A)=\Id_m\otimes R(A)$. For $Y\geq0$ and
     $P_\psi=\ketbra{\psi}{\psi}$, the inequality
     $Y\leq\tr(Y)\Id_m$ and positivity give
     \begin{align}
         0
-        &\leq R(Y\otimes P_\psi)
+         & \leq R(Y\otimes P_\psi)
         \leq\tr(Y)P_\psi.
         \notag
     \end{align}
-    Hence, for each $v\in\C^d$, there is a scalar $c_v$ such that
+    By Lemma~\ref{lem:posSemidef_rankone_domination}, for each
+    $v\in\C^d$ there is a scalar $c_v$ such that
     $R(Y\otimes P_v)=c_vP_v$.
     By Theorem~\ref{thm:rankone_ray_scalar_rigidity}, applied to the map
     $X\mapsto R(Y\otimes X)$, there is a scalar $c_Y$ such that
@@ -343,14 +205,14 @@
     $f(Y)=R(Y\otimes P_0)_{00}$. Rank-one polarization gives
     $R(Y\otimes X)=f(Y)X$ for all $Y\in\MN{m}$ and $X\in\MN{d}$.
     Positivity of $R$ gives $f(Y)\geq0$ when $Y\geq0$, and the retraction
-    property gives $f(\Id_m)=1$. The density representation of positive
-    matrix functionals therefore supplies a density matrix $\rho$ satisfying
-    $f(Y)=\tr(\rho Y)$.
+    property gives $f(\Id_m)=1$.
+    Theorem~\ref{thm:positive_functional_density_representation} therefore
+    supplies a density matrix $\rho$ satisfying $f(Y)=\tr(\rho Y)$.
 
     Finally, on simple tensors,
     \begin{align}
         \tr_m\!\left((\rho\otimes\Id_d)(Y\otimes X)\right)
-        &=\tr(\rho Y)X
+         & =\tr(\rho Y)X
         =R(Y\otimes X).
         \notag
     \end{align}
@@ -372,14 +234,14 @@
     $\rho_k\in\MN{m_k}$ such that
     \begin{align}
         U^*SU
-        &=\bigoplus_k \Id_{m_k}\otimes\MN{d_k},
+         & =\bigoplus_k \Id_{m_k}\otimes\MN{d_k},
         \label{eq:schwarz_star_algebra_blocks}
     \end{align}
     and, for every $A\in\MN{D}$,
     \begin{align}
         E(A)
-        &=U\left(\bigoplus_k \Id_{m_k}\otimes
-        \tr_{m_k}\!\left((\rho_k\otimes\Id_{d_k})(U^*AU)_{kk}\right)\right)U^*.
+         & =U\left(\bigoplus_k \Id_{m_k}\otimes
+             \tr_{m_k}\!\left((\rho_k\otimes\Id_{d_k})(U^*AU)_{kk}\right)\right)U^*.
         \label{eq:schwarz_star_algebra_retraction}
     \end{align}
     Equivalently, cyclicity of the partial trace permits the factor
@@ -390,7 +252,7 @@
 \begin{proof}
     \leanok
     \uses{thm:positive_retraction_one_matrix_factor,
-      thm:starSubalgebra_unitary_block_diagonal_iff}
+        thm:starSubalgebra_unitary_block_diagonal_iff}
     Conjugate by $U$ and use (\ref{eq:schwarz_star_algebra_blocks}) to
     identify the ambient space with
     $\bigoplus_k\C^{m_k}\otimes\C^{d_k}$. Let $P_k$ be the central projection
@@ -405,24 +267,9 @@
     partial trace gives
     \begin{align}
         \tr_{m_k}((\rho_k\otimes\Id)A_{kk})
-        &=\tr_{m_k}(A_{kk}(\rho_k\otimes\Id)).
+         & =\tr_{m_k}(A_{kk}(\rho_k\otimes\Id)).
         \notag
     \end{align}
-\end{proof}
-
-\begin{theorem}[Trace-pairing adjoints preserve positivity exactly]\label{thm:trace_pairing_adjoint_positive_iff}
-    \lean{isPositiveMap_traceAdjointMap_iff}
-    \leanok
-    \uses{thm:trace_pairing_adjoint_positive, thm:trace_pairing_adjoint_involutive}
-    A linear map is positive if and only if its trace-pairing adjoint is
-    positive.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    One direction is Theorem~\ref{thm:trace_pairing_adjoint_positive}. The
-    other follows by applying the same theorem to $E^*$ and using
-    Theorem~\ref{thm:trace_pairing_adjoint_involutive}.
 \end{proof}
 
 \begin{theorem}[Trace-pairing adjoint of an ampliation]
@@ -435,7 +282,7 @@
     commutes with ampliation:
     \begin{align}
         (E^{(k)})^*
-        &=(E^*)^{(k)}.
+         & =(E^*)^{(k)}.
         \label{eq:schwarz_trace_adjoint_ampliation}
     \end{align}
 \end{theorem}
@@ -447,7 +294,7 @@
     (\ref{eq:schwarz_trace_adjoint_pairing}) gives
     \begin{align}
         \tr((E^*)^{(k)}(\rho)X)
-        &=\sum_{p,q}\tr(E^*(\rho_{pq})X_{qp})
+         & =\sum_{p,q}\tr(E^*(\rho_{pq})X_{qp})
         =\sum_{p,q}\tr(\rho_{pq}E(X_{qp}))
         =\tr(\rho E^{(k)}(X)).
         \notag
@@ -608,20 +455,6 @@
     Trace preservation gives $\tr(E(X^\dagger X)) = \tr(X^\dagger X)$.
 \end{proof}
 
-\begin{lemma}[Trace pairing for Kraus map and adjoint map]\label{lem:trace_mul_map_eq_trace_adjointMap_mul}
-    \lean{Kraus.trace_mul_map_eq_trace_adjointMap_mul}
-    \leanok
-    \uses{def:kraus_map, def:kraus_adjoint_map}
-    For all $X, Y \in \MN{D}$,
-    $\tr\!(X\,E(Y)) = \tr\!(E^*(X)\,Y)$.
-\end{lemma}
-
-\begin{lemma}[Positive-definite trace test]\label{lem:posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}
-    \lean{Kraus.posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}
-    \leanok
-    If $A > 0$, $X \ge 0$, and $\tr(A X) = 0$, then $X = 0$.
-\end{lemma}
-
 \begin{theorem}[Fixed-point peripheral eigenvectors satisfy KS equality]
     \label{thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint}
     \lean{Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint}
@@ -632,3 +465,30 @@
     definite fixed point $\rho > 0$. If $E(X) = \mu X$ with $|\mu| = 1$, then
     $E(X^\dagger X) = E(X)^\dagger E(X)$.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kadison_schwarz,
+        lem:trace_mul_map_eq_trace_adjointMap_mul,
+        lem:posSemidef_eq_zero_of_posDef_trace_mul_eq_zero}
+    Define the Kadison--Schwarz gap
+    $G=E(X^\dagger X)-E(X)^\dagger E(X)$. By
+    Theorem~\ref{thm:kadison_schwarz}, $G\succeq0$. The adjointness identity of
+    Lemma~\ref{lem:trace_mul_map_eq_trace_adjointMap_mul}, the fixed-point
+    equation $E^*(\rho)=\rho$, the eigenvalue equation $E(X)=\mu X$, and
+    $|\mu|=1$ give
+    \begin{align}
+        \tr(\rho G)
+         & =\tr(\rho E(X^\dagger X))
+        -\tr(\rho E(X)^\dagger E(X)) \notag     \\
+         & =\tr(E^*(\rho)X^\dagger X)
+        -\tr(\rho(\mu X)^\dagger(\mu X)) \notag \\
+         & =\tr(\rho X^\dagger X)
+        -|\mu|^2\tr(\rho X^\dagger X)
+        =0.
+        \notag
+    \end{align}
+    Since $\rho>0$ and $G\succeq0$,
+    Lemma~\ref{lem:posSemidef_eq_zero_of_posDef_trace_mul_eq_zero} yields
+    $G=0$, which is the asserted equality.
+\end{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp_schmidt_number_and_schwarz_maps.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_schmidt_number_and_schwarz_maps.tex
@@ -5,9 +5,9 @@ a convex decomposition into pure states each of Schmidt rank at most $n$. Separa
 states are precisely those of Schmidt number one, and a state of Schmidt number at
 most $n$ satisfies the reduction criterion
 \begin{align}
-    n\,\rho_1\otimes\Id&\ge\rho,
-    \notag\\
-    n\,\Id\otimes\rho_2&\ge\rho,
+    n\,\rho_1\otimes\Id & \ge\rho,
+    \notag                         \\
+    n\,\Id\otimes\rho_2 & \ge\rho,
     \notag
 \end{align}
 which is \cite[Equation~(3.18)]{Wolf2012Quantum}. The bound on the Schmidt number is
@@ -23,9 +23,9 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     A bipartite matrix $\rho$ on $\MN{d}\otimes\MN{d'}$ has Schmidt number at most $n$
     when it is a finite sum of pure-state projectors of Schmidt rank at most $n$,
     \begin{align}
-        \rho&=\sum_i\ket{\psi_i}\bra{\psi_i},
-        \notag\\
-        \SR(\psi_i)&\le n.
+        \rho        & =\sum_i\ket{\psi_i}\bra{\psi_i},
+        \notag                                         \\
+        \SR(\psi_i) & \le n.
         \notag
     \end{align}
 \end{definition}
@@ -248,11 +248,11 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     On a general bipartite system $\MN{d}\otimes\MN{d'}$, a state of Schmidt number at
     most $n$ satisfies the reduction criterion
     \begin{align}
-        n\,\Id\otimes\rho_2&\ge\rho
-        &&(1\le n<d),
-        \notag\\
-        n\,\rho_1\otimes\Id&\ge\rho
-        &&(1\le n<d'),
+        n\,\Id\otimes\rho_2 & \ge\rho
+                            &         & (1\le n<d),
+        \notag                                       \\
+        n\,\rho_1\otimes\Id & \ge\rho
+                            &         & (1\le n<d'),
         \notag
     \end{align}
     with $\rho_1$ and $\rho_2$ the reduced densities on the first and second factors.
@@ -308,9 +308,9 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     Then there is a Hermitian operator $W$ such that, for every $\psi$ of Schmidt rank
     at most $n$,
     \begin{align}
-        \re\tr(W\rho)&<0,
-        \notag\\
-        \re\bra{\psi}W\ket{\psi}&\ge 0.
+        \re\tr(W\rho)            & <0,
+        \notag                            \\
+        \re\bra{\psi}W\ket{\psi} & \ge 0.
         \notag
     \end{align}
     This is the only-if direction of Wolf's Proposition~3.3
@@ -343,9 +343,9 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     $\rho$ exceeds $n$ if and only if there is a Hermitian operator $W$ such that, for
     every $\psi$ of Schmidt rank at most $n$,
     \begin{align}
-        \re\tr(W\rho)&<0,
-        \notag\\
-        \re\bra{\psi}W\ket{\psi}&\ge 0.
+        \re\tr(W\rho)            & <0,
+        \notag                            \\
+        \re\bra{\psi}W\ket{\psi} & \ge 0.
         \notag
     \end{align}
     This is Wolf's Proposition~3.3 \cite[Chapter~3, Proposition~3.3]{Wolf2012Quantum}: a
@@ -415,7 +415,7 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     matrix $\rho$ on $\C^D\otimes\C^D$,
     \begin{align}
         \tr(\tau_T\,\rho)
-        &=\bra{\Omega}(T^{*}\otimes\Id)(\rho)\ket{\Omega},
+         & =\bra{\Omega}(T^{*}\otimes\Id)(\rho)\ket{\Omega},
         \notag
     \end{align}
     where $T^{*}$ is the trace-pairing adjoint of $T$.
@@ -437,7 +437,7 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \leanok
     \uses{def:k_positive_map, def:has_schmidt_number_le,
         thm:exists_entanglement_witness, thm:exists_isNPositiveMap_choiMatrix_eq,
-        thm:trace_pairing_adjoint_positive, thm:trace_choiMatrix_omega_quadratic_adjoint}
+        thm:k_positive_trace_pairing_adjoint, thm:trace_choiMatrix_omega_quadratic_adjoint}
     Let $\rho$ be a trace-one Hermitian bipartite state on $\C^D\otimes\C^D$ whose Schmidt
     number exceeds $n$. Then there is an $n$-positive map $T\colon\MN{D}\to\MN{D}$ such that
     $(T\otimes\Id)(\rho)$ is not positive semidefinite. This is the if direction of Wolf's
@@ -449,7 +449,7 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     The entanglement witness $W$ for $\rho$ (\ref{thm:exists_entanglement_witness}) is the
     Choi matrix of an $n$-positive map $P$ (\ref{thm:exists_isNPositiveMap_choiMatrix_eq}).
     Its trace-pairing adjoint $T=P^{*}$ is again $n$-positive
-    (\ref{thm:trace_pairing_adjoint_positive}). By the Choi trace pairing through the
+    (\ref{thm:k_positive_trace_pairing_adjoint}). By the Choi trace pairing through the
     trace-pairing adjoint (\ref{thm:trace_choiMatrix_omega_quadratic_adjoint}),
     $\bra{\Omega}(T\otimes\Id)(\rho)\ket{\Omega}=\tr(W\rho)$, whose real part is
     negative. A positive semidefinite matrix has non-negative quadratic forms, so
@@ -468,7 +468,7 @@ positivity.
     \leanok
     Consider the linear map $T : \MN{2} \to \MN{2}$ defined by
     \begin{align}
-        T(A)&=\frac{1}{2} A^T+\frac{1}{4}\tr(A)\Id.
+        T(A) & =\frac{1}{2} A^T+\frac{1}{4}\tr(A)\Id.
         \notag
     \end{align}
     This is the map from \cite[Example~5.3]{Wolf2012Quantum}.


### PR DESCRIPTION
## Summary

- expand the Chapter 5 appendix into three coherent sections for trace duality/order preservation, rank-one retractions, and faithful weighted traces
- move routine support results while retaining the Kadison--Schwarz, multiplicative-domain, two-positive, and source-level positive-retraction mechanisms in main text
- add the missing mathematical proof of peripheral fixed-point Kadison--Schwarz equality
- correct a Chapter 25 dependency to use trace-adjoint invariance of $n$-positivity rather than ordinary positivity
- leave the Wolf Chapter 3 Schmidt-rank/Choi-compression hierarchy in place for a dedicated Chapter 25 reorganization

## Relocated support

Moved with statements, proofs, labels, and formalization metadata preserved:

- positive-map monotonicity and adjoint preservation
- trace-adjoint identity, involutivity, cone self-duality, positivity, and the positivity equivalence
- density representation of positive functionals
- rank-one domination, alongside the existing rank-one rigidity result
- Kraus/adjoint trace pairing and positive-definite weighted-trace faithfulness

The main chapter retains complete proofs of the one-factor and finite-star-algebra retraction theorems, including the support, scalarity, density, block, and partial-trace mechanisms.

## Proof and dependency fixes

- `thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint` now defines the KS gap, proves its weighted trace vanishes using the faithful adjoint fixed point and peripheral eigenvalue equation, and concludes the gap vanishes by weighted-trace faithfulness
- `thm:exists_isNPositiveMap_detects` now depends on `thm:k_positive_trace_pairing_adjoint`, the exact theorem needed to preserve $n$-positivity

## Validation

- independent mathematical review: no substantive findings
- repository formatting and reader-facing prose checks pass on every touched file
- blueprint/Lean synchronization passes; Chapter 5 appendix is fully linked
- no duplicate labels, missing references, or missing dependency targets
- complete blueprint compiled twice: 693 pages, zero undefined cross-references
- focused Chapters 1--12 blueprint compiled twice: 206 pages, zero undefined cross-references

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint/LaTeX documentation only; changes are relocations, one added proof, and a corrected theorem reference with no application or security impact.
> 
> **Overview**
> **Reorganizes Chapter 5 blueprint material** by expanding the Schwarz appendix into three sections (trace duality/order, rank-one retractions, weighted traces) and **relocating** elementary results that lived in the main chapter—positive-map monotonicity and adjoints, trace-pairing adjoint identities and positivity, density representation, rank-one domination, and Kraus weighted-trace lemmas—while **keeping** Kadison–Schwarz, multiplicative-domain, Choi compression, and the full one-factor / finite-star-algebra retraction proofs in the main text with **pointers** to the appendix.
> 
> **Adds the missing proof** of `thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint`: define the Kadison–Schwarz gap, show \(\tr(\rho G)=0\) via faithful \(\rho\) and \(|\mu|=1\), conclude \(G=0\).
> 
> **Fixes a Chapter 25 proof dependency**: `thm:exists_isNPositiveMap_detects` now uses `thm:k_positive_trace_pairing_adjoint` so the detecting map’s trace adjoint is **\(n\)-positive**, not merely positive.
> 
> Minor **align** formatting tweaks appear in several touched `.tex` files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e194571478a329e05ce64d081518b102bff91d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->