### PR TITLE
refactor(SectorBNT): deduplicate StrongMatch proofs through the proportional route

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/MatchAux.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/MatchAux.lean
@@ -152,4 +152,109 @@ lemma restricted_combined_family_eventually_li
   rw [← key]
   exact hN
 
+/-- **Shared bijection construction from forward and backward existential matches.**
+Given two injective maps built from per-sector existential matches, finite
+cardinality comparison turns the forward injection into a bijection
+`β : Fin Q.basisCount ≃ Fin P.basisCount`.
+
+This lemma is shared between the equal-MPV and proportional sector-matching
+proofs (`StrongMatch.lean` and `ProportionalMatch.lean`). -/
+lemma bijection_from_matches {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hFwd : ∀ k : Fin Q.basisCount,
+      ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
+        GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis j)) (Q.basis k) ∧
+        ¬ Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0))
+    (hBwd : ∀ j : Fin P.basisCount,
+      ∃ (k : Fin Q.basisCount) (h : Q.basisDim k = P.basisDim j),
+        GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (Q.basis k)) (P.basis j) ∧
+        ¬ Tendsto (fun N : ℕ => mpvOverlap (d := d) (Q.basis k) (P.basis j) N) atTop (𝓝 0)) :
+    ∃ β : Fin Q.basisCount ≃ Fin P.basisCount,
+      ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
+        GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k) ∧
+        ¬ Tendsto (fun N : ℕ => mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N) atTop (𝓝 0) := by
+  classical
+  let φ₀ : Fin Q.basisCount → Fin P.basisCount := fun k => (hFwd k).choose
+  have φ₀_spec : ∀ k : Fin Q.basisCount,
+      ∃ h : P.basisDim (φ₀ k) = Q.basisDim k,
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) h) (P.basis (φ₀ k)))
+            (Q.basis k) ∧
+        ¬ Tendsto (fun N : ℕ =>
+            mpvOverlap (d := d) (P.basis (φ₀ k)) (Q.basis k) N)
+          atTop (𝓝 0) := fun k => (hFwd k).choose_spec
+  have rebase_centre_P :
+      ∀ (j j' : Fin P.basisCount) (_hj : j = j')
+        {kv : Fin Q.basisCount}
+        (h_t : P.basisDim j' = Q.basisDim kv)
+        (_GE : GaugePhaseEquiv
+                  (cast (congr_arg (MPSTensor d) h_t) (P.basis j')) (Q.basis kv)),
+        ∃ h_t' : P.basisDim j = Q.basisDim kv,
+          GaugePhaseEquiv
+              (cast (congr_arg (MPSTensor d) h_t') (P.basis j)) (Q.basis kv) := by
+    rintro _ _ rfl _ h_t GE
+    exact ⟨h_t, GE⟩
+  have hφ₀_inj : Function.Injective φ₀ := by
+    intro k₁ k₂ hjEq
+    obtain ⟨h₁, GE₁, _⟩ := φ₀_spec k₁
+    obtain ⟨h₂, GE₂, _⟩ := φ₀_spec k₂
+    by_contra hne
+    obtain ⟨h₂', GE₂'⟩ :=
+      rebase_centre_P (φ₀ k₁) (φ₀ k₂) hjEq h₂ GE₂
+    have hQdim : Q.basisDim k₁ = Q.basisDim k₂ := h₁.symm.trans h₂'
+    have hQGE :
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) hQdim) (Q.basis k₁))
+            (Q.basis k₂) :=
+      gaugePhaseEquiv_cast_compose_via_centre (A := P.basis (φ₀ k₁))
+        (B := Q.basis k₁) (C := Q.basis k₂) h₁ h₂' GE₁ GE₂'
+    exact hQ.basis_distinct k₁ k₂ hne hQdim hQGE
+  let ψ₀ : Fin P.basisCount → Fin Q.basisCount := fun j => (hBwd j).choose
+  have ψ₀_spec : ∀ j : Fin P.basisCount,
+      ∃ h : Q.basisDim (ψ₀ j) = P.basisDim j,
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) h) (Q.basis (ψ₀ j)))
+            (P.basis j) ∧
+        ¬ Tendsto (fun N : ℕ =>
+            mpvOverlap (d := d) (Q.basis (ψ₀ j)) (P.basis j) N)
+          atTop (𝓝 0) := fun j => (hBwd j).choose_spec
+  have rebase_centre_Q :
+      ∀ (k k' : Fin Q.basisCount) (_hk : k = k')
+        {jv : Fin P.basisCount}
+        (h_t : Q.basisDim k' = P.basisDim jv)
+        (_GE : GaugePhaseEquiv
+                  (cast (congr_arg (MPSTensor d) h_t) (Q.basis k')) (P.basis jv)),
+        ∃ h_t' : Q.basisDim k = P.basisDim jv,
+          GaugePhaseEquiv
+              (cast (congr_arg (MPSTensor d) h_t') (Q.basis k)) (P.basis jv) := by
+    rintro _ _ rfl _ h_t GE
+    exact ⟨h_t, GE⟩
+  have hψ₀_inj : Function.Injective ψ₀ := by
+    intro j₁ j₂ hkEq
+    obtain ⟨h₁, GE₁, _⟩ := ψ₀_spec j₁
+    obtain ⟨h₂, GE₂, _⟩ := ψ₀_spec j₂
+    by_contra hne
+    obtain ⟨h₂', GE₂'⟩ :=
+      rebase_centre_Q (ψ₀ j₁) (ψ₀ j₂) hkEq h₂ GE₂
+    have hPdim : P.basisDim j₁ = P.basisDim j₂ := h₁.symm.trans h₂'
+    have hPGE :
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) hPdim) (P.basis j₁))
+            (P.basis j₂) :=
+      gaugePhaseEquiv_cast_compose_via_centre (A := Q.basis (ψ₀ j₁))
+        (B := P.basis j₁) (C := P.basis j₂) h₁ h₂' GE₁ GE₂'
+    exact hP.basis_distinct j₁ j₂ hne hPdim hPGE
+  have hCardQP : Fintype.card (Fin Q.basisCount) ≤ Fintype.card (Fin P.basisCount) :=
+    Fintype.card_le_of_injective φ₀ hφ₀_inj
+  have hCardPQ : Fintype.card (Fin P.basisCount) ≤ Fintype.card (Fin Q.basisCount) :=
+    Fintype.card_le_of_injective ψ₀ hψ₀_inj
+  have hCard : Fintype.card (Fin Q.basisCount) = Fintype.card (Fin P.basisCount) :=
+    le_antisymm hCardQP hCardPQ
+  have hφ₀_bij : Function.Bijective φ₀ :=
+    (Fintype.bijective_iff_injective_and_card φ₀).2 ⟨hφ₀_inj, hCard⟩
+  let β : Fin Q.basisCount ≃ Fin P.basisCount := Equiv.ofBijective φ₀ hφ₀_bij
+  refine ⟨β, ?_⟩
+  intro k
+  simpa [β] using φ₀_spec k
+
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/MatchAux.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/MatchAux.lean
@@ -155,10 +155,7 @@ lemma restricted_combined_family_eventually_li
 /-- **Shared bijection construction from forward and backward existential matches.**
 Given two injective maps built from per-sector existential matches, finite
 cardinality comparison turns the forward injection into a bijection
-`β : Fin Q.basisCount ≃ Fin P.basisCount`.
-
-This lemma is shared between the equal-MPV and proportional sector-matching
-proofs (`StrongMatch.lean` and `ProportionalMatch.lean`). -/
+`β : Fin Q.basisCount ≃ Fin P.basisCount`. -/
 lemma bijection_from_matches {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     (hFwd : ∀ k : Fin Q.basisCount,

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -33,9 +33,9 @@ variable {d : ℕ}
 
 /-! ### Bijective matching from per-block existentials in both directions
 
-The forward and backward existential matches (now in `ProportionalMatch/Core.lean`
-as `forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional`) are fed
-into the shared bijection construction `bijection_from_matches` (in
+The forward and backward existential matches (in `ProportionalMatch/Core.lean`
+as `forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional`) provide
+the input to the shared bijection construction `bijection_from_matches` (in
 `MatchAux.lean`).  The cast-aware symmetry and transitivity lemmas
 (`gaugePhaseEquiv_symm_same_dim`, `gaugePhaseEquiv_swap_cast`,
 `gaugePhaseEquiv_trans_same_dim`, `gaugePhaseEquiv_cast_compose_via_centre`)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -31,50 +31,15 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ### Full-basis proportional matching (Q → P direction)
-
-For every sector `k` of `Q`, there exists a sector `j` of `P` of equal
-bond dimension, gauge-phase equivalent in the cast-compatible shape, and
-with non-decaying cross-overlap.  This is the proportional analogue of
-`StrongMatch.forall_k_exists_j_nondecaying_overlap_of_sameMPV`.
-
-Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`);
-Appendix MPV theorem statement lines 1167–1170 and Appendix MPV proof
-line 1182 (matching). -/
-theorem forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
-    {P Q : SectorDecomposition d}
-    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
-    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
-    ∀ k : Fin Q.basisCount,
-      ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis j))
-            (Q.basis k) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
-          atTop (𝓝 0) := by
-  classical
-  intro k
-  have hProp_symm : EventuallyNonzeroProportionalMPV₂ Q.toTensor P.toTensor :=
-    hProp.symm
-  obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
-    exists_block_match_exact_of_eventuallyProportional
-      (P := Q) (Q := P) hQ hP k hProp_symm
-  refine ⟨j, hsymDim.symm, ?_, ?_⟩
-  · exact gaugePhaseEquiv_swap_cast hsymDim.symm
-      (by simpa using hGE_swapped)
-  · intro hTend
-    apply hNonDecay_swapped
-    exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
-
 /-! ### Bijective matching from per-block existentials in both directions
 
-The bijection construction composes two gauge-phase equivalences through a
-common centre.  The cast-aware symmetry and transitivity lemmas
+The forward and backward existential matches (now in `ProportionalMatch/Core.lean`
+as `forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional`) are fed
+into the shared bijection construction `bijection_from_matches` (in
+`MatchAux.lean`).  The cast-aware symmetry and transitivity lemmas
 (`gaugePhaseEquiv_symm_same_dim`, `gaugePhaseEquiv_swap_cast`,
 `gaugePhaseEquiv_trans_same_dim`, `gaugePhaseEquiv_cast_compose_via_centre`)
-are shared with the equal-MPV variant in
-`SectorBNT/StrongMatch.lean`. -/
+are shared with the equal-MPV variant in `SectorBNT/StrongMatch.lean`. -/
 
 /-- **Bijective proportional matching.**
 
@@ -98,106 +63,11 @@ theorem bijective_match_of_eventuallyProportional
         ¬ Tendsto (fun N : ℕ =>
             mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
           atTop (𝓝 0) := by
-  classical
-  have hFwd :=
-    forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
-      hP hQ hProp
   have hProp_symm : EventuallyNonzeroProportionalMPV₂ Q.toTensor P.toTensor :=
     hProp.symm
-  have hBwd :=
-    forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
-      hQ hP hProp_symm
-  let φ₀ : Fin Q.basisCount → Fin P.basisCount := fun k => (hFwd k).choose
-  have φ₀_spec : ∀ k : Fin Q.basisCount,
-      ∃ h : P.basisDim (φ₀ k) = Q.basisDim k,
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis (φ₀ k)))
-            (Q.basis k) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis (φ₀ k)) (Q.basis k) N)
-          atTop (𝓝 0) := fun k => (hFwd k).choose_spec
-  have rebase_centre_P :
-      ∀ (j j' : Fin P.basisCount) (_hj : j = j')
-        {kv : Fin Q.basisCount}
-        (h_t : P.basisDim j' = Q.basisDim kv)
-        (_GE : GaugePhaseEquiv
-                  (cast (congr_arg (MPSTensor d) h_t) (P.basis j'))
-                  (Q.basis kv)),
-        ∃ h_t' : P.basisDim j = Q.basisDim kv,
-          GaugePhaseEquiv
-              (cast (congr_arg (MPSTensor d) h_t') (P.basis j))
-              (Q.basis kv) := by
-    rintro _ _ rfl _ h_t GE
-    exact ⟨h_t, GE⟩
-  have hφ₀_inj : Function.Injective φ₀ := by
-    intro k₁ k₂ hjEq
-    obtain ⟨h₁, GE₁, _⟩ := φ₀_spec k₁
-    obtain ⟨h₂, GE₂, _⟩ := φ₀_spec k₂
-    by_contra hne
-    obtain ⟨h₂', GE₂'⟩ :=
-      rebase_centre_P (φ₀ k₁) (φ₀ k₂) hjEq h₂ GE₂
-    have hQdim : Q.basisDim k₁ = Q.basisDim k₂ := h₁.symm.trans h₂'
-    have hQGE :
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hQdim) (Q.basis k₁))
-            (Q.basis k₂) :=
-      gaugePhaseEquiv_cast_compose_via_centre
-        (A := P.basis (φ₀ k₁))
-        (B := Q.basis k₁) (C := Q.basis k₂) h₁ h₂' GE₁ GE₂'
-    exact hQ.basis_distinct k₁ k₂ hne hQdim hQGE
-  let ψ₀ : Fin P.basisCount → Fin Q.basisCount := fun j => (hBwd j).choose
-  have ψ₀_spec : ∀ j : Fin P.basisCount,
-      ∃ h : Q.basisDim (ψ₀ j) = P.basisDim j,
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (Q.basis (ψ₀ j)))
-            (P.basis j) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (Q.basis (ψ₀ j)) (P.basis j) N)
-          atTop (𝓝 0) := fun j => (hBwd j).choose_spec
-  have rebase_centre_Q :
-      ∀ (k k' : Fin Q.basisCount) (_hk : k = k')
-        {jv : Fin P.basisCount}
-        (h_t : Q.basisDim k' = P.basisDim jv)
-        (_GE : GaugePhaseEquiv
-                  (cast (congr_arg (MPSTensor d) h_t) (Q.basis k'))
-                  (P.basis jv)),
-        ∃ h_t' : Q.basisDim k = P.basisDim jv,
-          GaugePhaseEquiv
-              (cast (congr_arg (MPSTensor d) h_t') (Q.basis k))
-              (P.basis jv) := by
-    rintro _ _ rfl _ h_t GE
-    exact ⟨h_t, GE⟩
-  have hψ₀_inj : Function.Injective ψ₀ := by
-    intro j₁ j₂ hkEq
-    obtain ⟨h₁, GE₁, _⟩ := ψ₀_spec j₁
-    obtain ⟨h₂, GE₂, _⟩ := ψ₀_spec j₂
-    by_contra hne
-    obtain ⟨h₂', GE₂'⟩ :=
-      rebase_centre_Q (ψ₀ j₁) (ψ₀ j₂) hkEq h₂ GE₂
-    have hPdim : P.basisDim j₁ = P.basisDim j₂ := h₁.symm.trans h₂'
-    have hPGE :
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hPdim) (P.basis j₁))
-            (P.basis j₂) :=
-      gaugePhaseEquiv_cast_compose_via_centre
-        (A := Q.basis (ψ₀ j₁))
-        (B := P.basis j₁) (C := P.basis j₂) h₁ h₂' GE₁ GE₂'
-    exact hP.basis_distinct j₁ j₂ hne hPdim hPGE
-  have hCardQP :
-      Fintype.card (Fin Q.basisCount) ≤ Fintype.card (Fin P.basisCount) :=
-    Fintype.card_le_of_injective φ₀ hφ₀_inj
-  have hCardPQ :
-      Fintype.card (Fin P.basisCount) ≤ Fintype.card (Fin Q.basisCount) :=
-    Fintype.card_le_of_injective ψ₀ hψ₀_inj
-  have hCard :
-      Fintype.card (Fin Q.basisCount) = Fintype.card (Fin P.basisCount) :=
-    le_antisymm hCardQP hCardPQ
-  have hφ₀_bij : Function.Bijective φ₀ :=
-    (Fintype.bijective_iff_injective_and_card φ₀).2 ⟨hφ₀_inj, hCard⟩
-  let β : Fin Q.basisCount ≃ Fin P.basisCount := Equiv.ofBijective φ₀ hφ₀_bij
-  refine ⟨β, ?_⟩
-  intro k
-  simpa [β] using φ₀_spec k
+  have hFwd := forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional hP hQ hProp
+  have hBwd := forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional hQ hP hProp_symm
+  exact bijection_from_matches hP hQ hFwd hBwd
 
 /-! ### Final theorem: proportional sector matching with basis-count equality -/
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch.lean
@@ -33,13 +33,13 @@ variable {d : ℕ}
 
 /-! ### Bijective matching from per-block existentials in both directions
 
-The forward and backward existential matches (in `ProportionalMatch/Core.lean`
-as `forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional`) provide
-the input to the shared bijection construction `bijection_from_matches` (in
-`MatchAux.lean`).  The cast-aware symmetry and transitivity lemmas
+The forward and backward existential matches
+`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` provide the
+input to the shared bijection construction `bijection_from_matches`.  The
+cast-aware symmetry and transitivity lemmas
 (`gaugePhaseEquiv_symm_same_dim`, `gaugePhaseEquiv_swap_cast`,
 `gaugePhaseEquiv_trans_same_dim`, `gaugePhaseEquiv_cast_compose_via_centre`)
-are shared with the equal-MPV variant in `SectorBNT/StrongMatch.lean`. -/
+are shared with the equal-MPV bijection theorem. -/
 
 /-- **Bijective proportional matching.**
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -287,7 +287,7 @@ theorem exists_block_match_exact_of_eventuallyProportional
 For every sector `k` of `Q`, there exists a sector `j` of `P` of equal
 bond dimension, gauge-phase equivalent in the cast-compatible shape, and
 with non-decaying cross-overlap.  This is the proportional analogue of
-`StrongMatch.forall_k_exists_j_nondecaying_overlap_of_sameMPV`.
+the strong existential matching theorem (equal-MPV case).
 
 Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`);
 Appendix MPV theorem statement lines 1167–1170 and Appendix MPV proof

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -282,4 +282,40 @@ theorem exists_block_match_exact_of_eventuallyProportional
         (hNot := hNot)
   exact ⟨k₀, hDim, hGPE, hk₀⟩
 
+/-! ### Full-basis proportional matching (Q → P direction)
+
+For every sector `k` of `Q`, there exists a sector `j` of `P` of equal
+bond dimension, gauge-phase equivalent in the cast-compatible shape, and
+with non-decaying cross-overlap.  This is the proportional analogue of
+`StrongMatch.forall_k_exists_j_nondecaying_overlap_of_sameMPV`.
+
+Paper anchor: CPSV16 §II.C lines 349–352 (theorem `thm1`);
+Appendix MPV theorem statement lines 1167–1170 and Appendix MPV proof
+line 1182 (matching). -/
+theorem forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor) :
+    ∀ k : Fin Q.basisCount,
+      ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
+        GaugePhaseEquiv
+            (cast (congr_arg (MPSTensor d) h) (P.basis j))
+            (Q.basis k) ∧
+        ¬ Tendsto (fun N : ℕ =>
+            mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
+          atTop (𝓝 0) := by
+  classical
+  intro k
+  have hProp_symm : EventuallyNonzeroProportionalMPV₂ Q.toTensor P.toTensor :=
+    hProp.symm
+  obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
+    exists_block_match_exact_of_eventuallyProportional
+      (P := Q) (Q := P) hQ hP k hProp_symm
+  refine ⟨j, hsymDim.symm, ?_, ?_⟩
+  · exact gaugePhaseEquiv_swap_cast hsymDim.symm
+      (by simpa using hGE_swapped)
+  · intro hTend
+    apply hNonDecay_swapped
+    exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
+
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -10,10 +10,11 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch.Core
 
 The strong existential matching theorem states the CPSV16 Appendix MPV proof,
 line 1182, matching conclusion directly on the original pair `(P, Q)` of BNT
-canonical forms.  In the equal-MPV case both theorems reduce to their
-proportional-sector counterparts via the
+canonical forms.  In the equal-MPV case the existential theorem reduces to
+its proportional-sector counterpart via the
 `SameMPV₂Pos → EventuallyNonzeroProportionalMPV₂` conversion, and the
-bijection step is the shared construction `bijection_from_matches`.
+bijection theorem applies that reduction in both directions through the
+shared construction `bijection_from_matches`.
 
 The coefficient identity of CPSV16 Appendix MPV proof, lines 1187–1188
 (Corollary substitution) lives in the companion module
@@ -73,10 +74,9 @@ the forward injection into an equivalence `β : Fin Q.basisCount ≃
 Fin P.basisCount`, carrying the matched bond-dimension equality,
 gauge-phase equivalence, and non-decaying overlap for every sector of `Q`.
 
-The proof derives both directions from the proportional matching lemma
-`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` using the
-`SameMPV₂Pos → NonzeroProportionalMPV₂` conversion, then delegates to the
-shared bijection construction `bijection_from_matches`. -/
+The bijection step is the shared construction `bijection_from_matches`,
+applied to both directions of
+`forall_k_exists_j_nondecaying_overlap_of_sameMPV`. -/
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -89,12 +89,8 @@ theorem bijective_match_of_sameMPV
         ¬ Tendsto (fun N : ℕ =>
             mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
           atTop (𝓝 0) := by
-  have hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor :=
-    hEqual.toNonzeroProportionalMPV₂.eventually
-  have hProp_symm : EventuallyNonzeroProportionalMPV₂ Q.toTensor P.toTensor :=
-    hProp.symm
-  have hFwd := forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional hP hQ hProp
-  have hBwd := forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional hQ hP hProp_symm
-  exact bijection_from_matches hP hQ hFwd hBwd
+  exact bijection_from_matches hP hQ
+    (forall_k_exists_j_nondecaying_overlap_of_sameMPV hP hQ hEqual)
+    (forall_k_exists_j_nondecaying_overlap_of_sameMPV hQ hP hEqual.symm)
 
 end MPSTensor

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -10,11 +10,10 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.ExactMatch
 
 The strong existential matching theorem states the CPSV16 Appendix MPV proof,
 line 1182, matching conclusion directly on the original pair `(P, Q)` of BNT
-canonical forms.  In the equal-MPV case both theorems are derived from the
-proportional-sector matching lemmas (now in `ProportionalMatch/Core.lean`)
-via the `SameMPV₂Pos → EventuallyNonzeroProportionalMPV₂` conversion.  The
-bijection construction is shared with the proportional route through
-`bijection_from_matches` in `MatchAux.lean`.
+canonical forms.  In the equal-MPV case both theorems reduce to their
+proportional-sector counterparts via the
+`SameMPV₂Pos → EventuallyNonzeroProportionalMPV₂` conversion, and the
+bijection step is the shared construction `bijection_from_matches`.
 
 The coefficient identity of CPSV16 Appendix MPV proof, lines 1187–1188
 (Corollary substitution) lives in the companion module

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.FundamentalTheorem.SectorBNT.ExactMatch
+import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch.Core
 
 /-!
 # Strong existential and bijective sector matching
@@ -27,7 +27,6 @@ index $j_k$ with $|V^{(N)}(B_k)\rangle = |V^{(N)}(A_{j_k})\rangle$, and the
 single-block fundamental theorem gives $B_k = X_k A_{j_k} X_k^{-1}$.
 -/
 
-open scoped Matrix BigOperators
 open Filter Topology
 
 namespace MPSTensor
@@ -44,9 +43,8 @@ of `P` of equal bond dimension, gauge-phase equivalent to `Q.basis k` after the
 dimension cast, and with non-decaying cross-overlap.
 
 This is derived from the proportional sector-matching lemma
-`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` (now in
-`ProportionalMatch/Core.lean`) using the conversion
-`SameMPV₂Pos.toNonzeroProportionalMPV₂.eventually`.
+`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` using the
+conversion `SameMPV₂Pos.toNonzeroProportionalMPV₂.eventually`.
 
 Paper anchor: CPSV16 Appendix MPV proof, line 1182 (arXiv:1606.00608), CPSV21
 Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884. -/
@@ -76,10 +74,9 @@ Fin P.basisCount`, carrying the matched bond-dimension equality,
 gauge-phase equivalence, and non-decaying overlap for every sector of `Q`.
 
 The proof derives both directions from the proportional matching lemma
-`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` (now in
-`ProportionalMatch/Core.lean`) using the `SameMPV₂Pos → NonzeroProportionalMPV₂`
-conversion, then delegates to the shared bijection construction
-`bijection_from_matches` in `MatchAux.lean`. -/
+`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` using the
+`SameMPV₂Pos → NonzeroProportionalMPV₂` conversion, then delegates to the
+shared bijection construction `bijection_from_matches`. -/
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/StrongMatch.lean
@@ -10,9 +10,11 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.ExactMatch
 
 The strong existential matching theorem states the CPSV16 Appendix MPV proof,
 line 1182, matching conclusion directly on the original pair `(P, Q)` of BNT
-canonical forms.  In the equal-MPV case the matching is now obtained from the
-exact coefficient-comparison matcher, so no per-sector unit-modulus copy-weight
-hypotheses are required.
+canonical forms.  In the equal-MPV case both theorems are derived from the
+proportional-sector matching lemmas (now in `ProportionalMatch/Core.lean`)
+via the `SameMPV₂Pos → EventuallyNonzeroProportionalMPV₂` conversion.  The
+bijection construction is shared with the proportional route through
+`bijection_from_matches` in `MatchAux.lean`.
 
 The coefficient identity of CPSV16 Appendix MPV proof, lines 1187–1188
 (Corollary substitution) lives in the companion module
@@ -21,43 +23,9 @@ The coefficient identity of CPSV16 Appendix MPV proof, lines 1187–1188
 ## Paper anchor
 
 CPSV16 (arXiv:1606.00608) Appendix MPV proof, line 1182, gives the matching
-step of the proportional theorem proof. In mathematical terms, this step
-fixes a block $B_k$ and observes that its overlaps with the $A_j$ blocks cannot
-all decay to zero, since then the two MPV families would fail to be eventually
-proportional. The equal-vector corollary then gives an index $j_k$ with
-$|V^{(N)}(B_k)\rangle = e^{i\phi_k N} |V^{(N)}(A_{j_k})\rangle$, and the
-single-block fundamental theorem gives
-$B_k = e^{i\phi_k} X_k A_{j_k} X_k^{-1}$.
-
-## Proof structure
-
-The result is a **single `∀ k, ∃ j` existential statement** on the
-original pair. The equal-MPV proof applies `exists_block_match_exact` with
-`P` and `Q` swapped, then flips the cast direction and overlap order.
-
-The bijective matching (`bijective_match_of_sameMPV`) now applies the
-exact block matcher in both directions — once with `(Q, P)` for a map
-`Fin Q.basisCount → Fin P.basisCount` and once with `(P, Q)` for the
-reverse map — to derive `P.basisCount = Q.basisCount` and the full bijection
-`β : Fin Q.basisCount ≃ Fin P.basisCount` without per-sector unit-modulus
-copy-weight hypotheses.
-
-## Proof of the existential
-
-Given a sector `k` of `Q`, apply the exact matcher
-`exists_block_match_exact` **with `P` and `Q` swapped**:
-
-* feed `hQ`, `hP` (in that order);
-* supply the selected sector `k`; and
-* supply `SameMPV₂Pos Q.toTensor P.toTensor` via the symmetric flip of `hEqual`
-  (pointwise `.symm`).
-
-The result is a `j₀ : Fin P.basisCount` with `Q.basisDim k = P.basisDim j₀`,
-a gauge-phase equivalence in the `Q → P` cast direction, and a
-non-decaying overlap in the `(Q.basis k, P.basis j₀)` order.  Two
-local auxiliary lemmas (`gaugePhaseEquiv_swap_cast` and
-`tendsto_mpvOverlap_zero_swap`) flip those into the `(P, Q)`-ordered
-conclusion.
+step of the proportional theorem proof.  The equal-vector corollary gives an
+index $j_k$ with $|V^{(N)}(B_k)\rangle = |V^{(N)}(A_{j_k})\rangle$, and the
+single-block fundamental theorem gives $B_k = X_k A_{j_k} X_k^{-1}$.
 -/
 
 open scoped Matrix BigOperators
@@ -76,9 +44,10 @@ every positive length.  For every sector `k` of `Q`, there exists a sector `j`
 of `P` of equal bond dimension, gauge-phase equivalent to `Q.basis k` after the
 dimension cast, and with non-decaying cross-overlap.
 
-The proof applies `exists_block_match_exact` to the swapped pair `(Q, P)` and
-then flips the gauge-phase equivalence and overlap order back to the displayed
-`(P, Q)` orientation.
+This is derived from the proportional sector-matching lemma
+`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` (now in
+`ProportionalMatch/Core.lean`) using the conversion
+`SameMPV₂Pos.toNonzeroProportionalMPV₂.eventually`.
 
 Paper anchor: CPSV16 Appendix MPV proof, line 1182 (arXiv:1606.00608), CPSV21
 Definition 4.2 lines 1846–1850, and the two-layer display at lines 1864–1884. -/
@@ -92,19 +61,9 @@ theorem forall_k_exists_j_nondecaying_overlap_of_sameMPV
           (Q.basis k) ∧
       ¬ Tendsto (fun N : ℕ =>
           mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
-        atTop (𝓝 0) := by
-  classical
-  intro k
-  have hEqual_symm : SameMPV₂Pos Q.toTensor P.toTensor := hEqual.symm
-  obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
-    exists_block_match_exact
-      (P := Q) (Q := P) hQ hP k hEqual_symm
-  refine ⟨j, hsymDim.symm, ?_, ?_⟩
-  · exact gaugePhaseEquiv_swap_cast hsymDim.symm
-      (by simpa using hGE_swapped)
-  · intro hTend
-    apply hNonDecay_swapped
-    exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
+        atTop (𝓝 0) :=
+  forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional hP hQ
+    (hEqual.toNonzeroProportionalMPV₂.eventually)
 
 /-! ### Bijective sector matching by symmetry -/
 
@@ -117,12 +76,11 @@ the forward injection into an equivalence `β : Fin Q.basisCount ≃
 Fin P.basisCount`, carrying the matched bond-dimension equality,
 gauge-phase equivalence, and non-decaying overlap for every sector of `Q`.
 
-This is the Lean counterpart of the CPSV16 symmetry step "$g_A \geq g_B$
-and $g_B \geq g_A$".  The proof invokes the exact block matcher once with $(Q,P)$ for the
-`Q → P` map and once with $(P,Q)$ for the `P → Q` map.  Since the exact
-matcher uses exact coefficient comparison rather than the dominant
-coefficient asymptotic argument, no per-sector unit-modulus copy-weight
-hypotheses are needed in the equal-MPV case. -/
+The proof derives both directions from the proportional matching lemma
+`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` (now in
+`ProportionalMatch/Core.lean`) using the `SameMPV₂Pos → NonzeroProportionalMPV₂`
+conversion, then delegates to the shared bijection construction
+`bijection_from_matches` in `MatchAux.lean`. -/
 theorem bijective_match_of_sameMPV
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -135,125 +93,12 @@ theorem bijective_match_of_sameMPV
         ¬ Tendsto (fun N : ℕ =>
             mpvOverlap (d := d) (P.basis (β k)) (Q.basis k) N)
           atTop (𝓝 0) := by
-  classical
-  have hEqual_symm : SameMPV₂Pos Q.toTensor P.toTensor := hEqual.symm
-  have hFwd : ∀ k : Fin Q.basisCount,
-      ∃ (j : Fin P.basisCount) (h : P.basisDim j = Q.basisDim k),
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis j))
-            (Q.basis k) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis j) (Q.basis k) N)
-          atTop (𝓝 0) := by
-    intro k
-    obtain ⟨j, hsymDim, hGE_swapped, hNonDecay_swapped⟩ :=
-      exists_block_match_exact
-        (P := Q) (Q := P) hQ hP k hEqual_symm
-    refine ⟨j, hsymDim.symm, ?_, ?_⟩
-    · exact gaugePhaseEquiv_swap_cast hsymDim.symm
-        (by simpa using hGE_swapped)
-    · intro hTend
-      apply hNonDecay_swapped
-      exact tendsto_mpvOverlap_zero_swap (P.basis j) (Q.basis k) hTend
-  have hBwd : ∀ j : Fin P.basisCount,
-      ∃ (k : Fin Q.basisCount) (h : Q.basisDim k = P.basisDim j),
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (Q.basis k))
-            (P.basis j) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (Q.basis k) (P.basis j) N)
-          atTop (𝓝 0) := by
-    intro j
-    obtain ⟨k, hDim, hGE, hNonDecay⟩ :=
-      exists_block_match_exact
-        (P := P) (Q := Q) hP hQ j hEqual
-    refine ⟨k, hDim.symm, ?_, ?_⟩
-    · exact gaugePhaseEquiv_swap_cast hDim.symm
-        (by simpa using hGE)
-    · intro hTend
-      apply hNonDecay
-      exact tendsto_mpvOverlap_zero_swap (Q.basis k) (P.basis j) hTend
-  let φ₀ : Fin Q.basisCount → Fin P.basisCount := fun k => (hFwd k).choose
-  have φ₀_spec : ∀ k : Fin Q.basisCount,
-      ∃ h : P.basisDim (φ₀ k) = Q.basisDim k,
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (P.basis (φ₀ k)))
-            (Q.basis k) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (P.basis (φ₀ k)) (Q.basis k) N)
-          atTop (𝓝 0) := fun k => (hFwd k).choose_spec
-  have rebase_centre_P :
-      ∀ (j j' : Fin P.basisCount) (_hj : j = j')
-        {kv : Fin Q.basisCount}
-        (h_t : P.basisDim j' = Q.basisDim kv)
-        (_GE : GaugePhaseEquiv
-                  (cast (congr_arg (MPSTensor d) h_t) (P.basis j')) (Q.basis kv)),
-        ∃ h_t' : P.basisDim j = Q.basisDim kv,
-          GaugePhaseEquiv
-              (cast (congr_arg (MPSTensor d) h_t') (P.basis j)) (Q.basis kv) := by
-    rintro _ _ rfl _ h_t GE
-    exact ⟨h_t, GE⟩
-  have hφ₀_inj : Function.Injective φ₀ := by
-    intro k₁ k₂ hjEq
-    obtain ⟨h₁, GE₁, _⟩ := φ₀_spec k₁
-    obtain ⟨h₂, GE₂, _⟩ := φ₀_spec k₂
-    by_contra hne
-    obtain ⟨h₂', GE₂'⟩ :=
-      rebase_centre_P (φ₀ k₁) (φ₀ k₂) hjEq h₂ GE₂
-    have hQdim : Q.basisDim k₁ = Q.basisDim k₂ := h₁.symm.trans h₂'
-    have hQGE :
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hQdim) (Q.basis k₁))
-            (Q.basis k₂) :=
-      gaugePhaseEquiv_cast_compose_via_centre (A := P.basis (φ₀ k₁))
-        (B := Q.basis k₁) (C := Q.basis k₂) h₁ h₂' GE₁ GE₂'
-    exact hQ.basis_distinct k₁ k₂ hne hQdim hQGE
-  let ψ₀ : Fin P.basisCount → Fin Q.basisCount := fun j => (hBwd j).choose
-  have ψ₀_spec : ∀ j : Fin P.basisCount,
-      ∃ h : Q.basisDim (ψ₀ j) = P.basisDim j,
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) h) (Q.basis (ψ₀ j)))
-            (P.basis j) ∧
-        ¬ Tendsto (fun N : ℕ =>
-            mpvOverlap (d := d) (Q.basis (ψ₀ j)) (P.basis j) N)
-          atTop (𝓝 0) := fun j => (hBwd j).choose_spec
-  have rebase_centre_Q :
-      ∀ (k k' : Fin Q.basisCount) (_hk : k = k')
-        {jv : Fin P.basisCount}
-        (h_t : Q.basisDim k' = P.basisDim jv)
-        (_GE : GaugePhaseEquiv
-                  (cast (congr_arg (MPSTensor d) h_t) (Q.basis k')) (P.basis jv)),
-        ∃ h_t' : Q.basisDim k = P.basisDim jv,
-          GaugePhaseEquiv
-              (cast (congr_arg (MPSTensor d) h_t') (Q.basis k)) (P.basis jv) := by
-    rintro _ _ rfl _ h_t GE
-    exact ⟨h_t, GE⟩
-  have hψ₀_inj : Function.Injective ψ₀ := by
-    intro j₁ j₂ hkEq
-    obtain ⟨h₁, GE₁, _⟩ := ψ₀_spec j₁
-    obtain ⟨h₂, GE₂, _⟩ := ψ₀_spec j₂
-    by_contra hne
-    obtain ⟨h₂', GE₂'⟩ :=
-      rebase_centre_Q (ψ₀ j₁) (ψ₀ j₂) hkEq h₂ GE₂
-    have hPdim : P.basisDim j₁ = P.basisDim j₂ := h₁.symm.trans h₂'
-    have hPGE :
-        GaugePhaseEquiv
-            (cast (congr_arg (MPSTensor d) hPdim) (P.basis j₁))
-            (P.basis j₂) :=
-      gaugePhaseEquiv_cast_compose_via_centre (A := Q.basis (ψ₀ j₁))
-        (B := P.basis j₁) (C := P.basis j₂) h₁ h₂' GE₁ GE₂'
-    exact hP.basis_distinct j₁ j₂ hne hPdim hPGE
-  have hCardQP : Fintype.card (Fin Q.basisCount) ≤ Fintype.card (Fin P.basisCount) :=
-    Fintype.card_le_of_injective φ₀ hφ₀_inj
-  have hCardPQ : Fintype.card (Fin P.basisCount) ≤ Fintype.card (Fin Q.basisCount) :=
-    Fintype.card_le_of_injective ψ₀ hψ₀_inj
-  have hCard : Fintype.card (Fin Q.basisCount) = Fintype.card (Fin P.basisCount) :=
-    le_antisymm hCardQP hCardPQ
-  have hφ₀_bij : Function.Bijective φ₀ :=
-    (Fintype.bijective_iff_injective_and_card φ₀).2 ⟨hφ₀_inj, hCard⟩
-  let β : Fin Q.basisCount ≃ Fin P.basisCount := Equiv.ofBijective φ₀ hφ₀_bij
-  refine ⟨β, ?_⟩
-  intro k
-  simpa [β] using φ₀_spec k
+  have hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor :=
+    hEqual.toNonzeroProportionalMPV₂.eventually
+  have hProp_symm : EventuallyNonzeroProportionalMPV₂ Q.toTensor P.toTensor :=
+    hProp.symm
+  have hFwd := forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional hP hQ hProp
+  have hBwd := forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional hQ hP hProp_symm
+  exact bijection_from_matches hP hQ hFwd hBwd
 
 end MPSTensor

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -96,6 +96,25 @@ abstracted — record why, so it is not re-proposed).
   lines fell from 666 to 481 (185 lines net). The public theorem statement and
   blueprint link are unchanged.
 
+### Bijective sector matching from directional existentials
+- **Pattern:** The equal-MPV (`bijective_match_of_sameMPV`) and proportional
+  (`bijective_match_of_eventuallyProportional`) bijection constructions each
+  rebuilt the same injective-map-plus-cardinality argument (the `φ₀`-centred
+  rebase, `Fintype.card_le_of_injective`, `Equiv.ofBijective`), about 75
+  lines verbatim in both files.
+- **Reuse:** Both theorems now call `bijection_from_matches` in
+  `SectorBNT/MatchAux.lean`, parameterized by the forward and backward
+  existential-match hypotheses. The equal-MPV existentials are obtained from
+  the proportional matcher through
+  `SameMPV₂Pos.toNonzeroProportionalMPV₂.eventually`, and the proportional
+  matcher itself moved down to `ProportionalMatch/Core.lean` so both routes
+  sit above it in the import graph.
+- **Result:** `StrongMatch.lean` fell from 259 to 72 lines and
+  `ProportionalMatch.lean` from 267 to 140; `MatchAux.lean` grew by 85 lines
+  and `ProportionalMatch/Core.lean` by 34. Net 176 insertions against 320
+  deletions (144 lines net). All public theorem statements and blueprint
+  links are unchanged.
+
 ### Cyclic-sector compression transport
 - **Pattern:** the transfer-intertwining branch in
   `exists_compressedTensor_of_supported_projection_with_letter_and_isometry`


### PR DESCRIPTION
## Summary

Carries out the remaining named fork of #4521 (ledger D5): `StrongMatch.lean` (SameMPV route) re-proved what `ProportionalMatch.lean`/`Core.lean` (eventuallyProportional route) already proves — a 23-line near-verbatim matcher copy plus ~75 lines of verbatim bijection machinery (φ₀/rebase/inj/card/Equiv.ofBijective) forked across a 131-line theorem.

The import graph is a valid DAG (no cycle), but `StrongMatch` cannot import `ProportionalMatch`, so the shared content moves DOWN to the common ancestors both routes already import:

- `forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional` moved from `ProportionalMatch.lean` → `ProportionalMatch/Core.lean` (unchanged statement; its deps were already below Core).
- New shared lemma `MPSTensor.bijection_from_matches` in `MatchAux.lean`, parameterized by `hFwd`/`hBwd`, capturing the bijection machinery once.
- `forall_k_exists_j_nondecaying_overlap_of_sameMPV` and `bijective_match_of_sameMPV` are now DERIVED from the proportional versions via the existing `SameMPV₂Pos.toNonzeroProportionalMPV₂.eventually` bridge (the same conversion `ExactMatch.lean` uses) — the forked proofs are deleted.
- `bijective_match_of_eventuallyProportional` delegates to `bijection_from_matches`.

All public declaration names and statements are preserved (blueprint `\lean{}` tags and downstream consumers unaffected). Net **−144 lines** (+176/−320): StrongMatch 259→72, ProportionalMatch 267→140, Core +34, MatchAux +85.

## Validation

- `lake build` green: 9740 jobs (rebased onto 70c29531c)
- `blueprint_lean_sync.py --update-lean-decls` + `leanblueprint checkdecls`: exit 0, zero misses
- `blueprint_lean_sync.py --ci`: in sync (5520/5523; 3 pre-existing Periodic/Overlap misses)
- `git diff --check` clean; no sorry/axiom

Residual #4521 duplication noted in the PR thread: the ~22-line `hDim`/`hGPE` dichotomy tail shared by `Core.lean` and `MatchAux.lean` is left for a follow-up — extracting it would restructure both callers' conclusions.

Advances #4521

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor only: no API or statement changes, same mathematical conclusions with consolidated proof paths.
> 
> **Overview**
> Deduplicates sector BNT matching by lifting shared logic into **`MatchAux.bijection_from_matches`** and routing the equal-MPV (`SameMPV₂Pos`) theorems through the proportional core instead of duplicating proofs.
> 
> **`forall_k_exists_j_nondecaying_overlap_of_eventuallyProportional`** moves from `ProportionalMatch.lean` to **`ProportionalMatch/Core.lean`**. **`bijective_match_of_eventuallyProportional`** and **`bijective_match_of_sameMPV`** each call **`bijection_from_matches`** with forward/backward existential hypotheses (~75 lines of injective-map/cardinality proof removed from both files).
> 
> **`StrongMatch.lean`** now imports **`ProportionalMatch.Core`** (not `ExactMatch`); **`forall_k_exists_j_nondecaying_overlap_of_sameMPV`** is a one-liner via **`hEqual.toNonzeroProportionalMPV₂.eventually`**, and the bijection theorem delegates to the shared lemma. Public theorem names and statements are unchanged; net **−144 lines**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e57fa5fa54c1741beb3e57eb6229a786f6796e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->