### PR TITLE
feat(MPS/RFP): prove the corrected multiplicity-one RFP-implies-ZCL forward direction

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -32,6 +32,8 @@ tensor.
   trace-preserving Perron gauge.
 * `IsNormalTensor.isNormal`: spectral normality implies eventual block
   injectivity.
+* `isNormalTensor_of_isNormal_leftCanonical`: an algebraically normal
+  left-canonical tensor is a spectrally normalized normal tensor.
 * `MPVBlockPhaseEquiv.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor`: exact MPV
   phase equivalence between normal tensors is realized by an invertible gauge.
 * `IsCPSVBasisOfNormalTensors.blocks_not_gaugePhaseEquiv`: distinct members of
@@ -146,6 +148,34 @@ theorem IsNormalTensor.isNormal [NeZero D]
   have hNormalGauge : IsNormal (tpGauge (d := d) (D := D) A σ) :=
     isNormal_of_tp_primitive_irreducible _ hTP hPrim hIrr
   exact isNormal_of_gaugeEquiv hNormalGauge hGauge.symm
+
+/-- An algebraically normal left-canonical tensor is a spectrally normalized normal tensor.
+
+Algebraic normality and left-canonical normalization imply strong irreducibility by
+arXiv:0909.5347, Proposition 3. Thus the transfer map has a positive-definite fixed point and
+has no unit-modulus eigenvalue other than one. The spectral normalization of
+arXiv:1606.00608, lines 224--235, then has Perron value one and does not rescale the tensor.
+This conversion is an input to the BNT identification invoked at arXiv:1606.00608, line 1307.
+-/
+theorem isNormalTensor_of_isNormal_leftCanonical [NeZero D]
+    (A : MPSTensor d D) (hNormal : IsNormal A) (hLeft : IsLeftCanonical A) :
+    IsNormalTensor A := by
+  have hStrong : IsStronglyIrreduciblePaper A :=
+    isNormal_implies_stronglyIrreducible A hLeft hNormal
+  obtain ⟨ρ, hρ, hρfix⟩ := hStrong.posDef_fixedPoint
+  have hIrr : IsIrreducibleTensor A :=
+    isIrreducibleTensor_of_isIrreducibleMap A hStrong.isIrreducibleMap
+  have huniq : ∀ μ : ℂ, Module.End.HasEigenvalue (transferMap A) μ →
+      ‖μ‖ = (1 : ℝ) → μ = (1 : ℂ) := by
+    intro μ hμ hμnorm
+    have hmem : μ ∈ peripheralEigenvalues (transferMap A) := ⟨hμ, hμnorm⟩
+    rw [hStrong.peripheralEigenvalues_eq] at hmem
+    simpa using hmem
+  have hScaled : IsNormalTensor (fun i =>
+      (((Real.sqrt (1 : ℝ) : ℝ) : ℂ))⁻¹ • A i) :=
+    isNormalTensor_invSqrt_smul_of_unique_peripheral A hIrr ρ 1 hρ (by norm_num)
+      (by simpa using hρfix) huniq
+  simpa using hScaled
 
 /-- A normal tensor has a nonzero letter.
 

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -17,12 +17,14 @@ import TNLean.Wielandt.Primitivity.Equivalence
 This file develops the normal-tensor comparison needed to identify the loop-product ground
 states in Beigi's classification with the basis of normal tensors of a matrix product state.
 
-The conversion lemmas below relate the project's algebraic normality predicate to the spectral
-normal-tensor predicate of Cirac--Pérez-García--Schuch--Verstraete. They are inputs to the
-identification asserted in arXiv:1606.00608, line 1307. Their primitive-transfer ingredient is
+The conversion lemma below relates the project's algebraic normality predicate to the spectral
+normal-tensor predicate of Cirac--Pérez-García--Schuch--Verstraete. It is an input to the
+identification asserted in arXiv:1606.00608, line 1307. Its primitive-transfer ingredient is
 the equivalence between eventual full Kraus rank and strong irreducibility in
 arXiv:0909.5347, Proposition 3, together with the Perron--Frobenius theorem for irreducible
-completely positive maps (Wolf, Theorem 6.3).
+completely positive maps (Wolf, Theorem 6.3). The companion conversion from an algebraically
+normal left-canonical tensor is `isNormalTensor_of_isNormal_leftCanonical` in
+`TNLean/MPS/CanonicalForm/NormalTensorGauge.lean`.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -31,34 +33,6 @@ open FiniteWeightedDigraph
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-- An algebraically normal left-canonical tensor is a spectrally normalized normal tensor.
-
-Algebraic normality and left-canonical normalization imply strong irreducibility by
-arXiv:0909.5347, Proposition 3. Thus the transfer map has a positive-definite fixed point and
-has no unit-modulus eigenvalue other than one. The spectral normalization of
-arXiv:1606.00608, lines 224--235, then has Perron value one and does not rescale the tensor.
-This conversion is an input to the BNT identification invoked at arXiv:1606.00608, line 1307.
--/
-theorem isNormalTensor_of_isNormal_leftCanonical [NeZero D]
-    (A : MPSTensor d D) (hNormal : IsNormal A) (hLeft : IsLeftCanonical A) :
-    IsNormalTensor A := by
-  have hStrong : IsStronglyIrreduciblePaper A :=
-    isNormal_implies_stronglyIrreducible A hLeft hNormal
-  obtain ⟨ρ, hρ, hρfix⟩ := hStrong.posDef_fixedPoint
-  have hIrr : IsIrreducibleTensor A :=
-    isIrreducibleTensor_of_isIrreducibleMap A hStrong.isIrreducibleMap
-  have huniq : ∀ μ : ℂ, Module.End.HasEigenvalue (transferMap A) μ →
-      ‖μ‖ = (1 : ℝ) → μ = (1 : ℂ) := by
-    intro μ hμ hμnorm
-    have hmem : μ ∈ peripheralEigenvalues (transferMap A) := ⟨hμ, hμnorm⟩
-    rw [hStrong.peripheralEigenvalues_eq] at hmem
-    simpa using hmem
-  have hScaled : IsNormalTensor (fun i =>
-      (((Real.sqrt (1 : ℝ) : ℝ) : ℂ))⁻¹ • A i) :=
-    isNormalTensor_invSqrt_smul_of_unique_peripheral A hIrr ρ 1 hρ (by norm_num)
-      (by simpa using hρfix) huniq
-  simpa using hScaled
 
 /-- A transfer-idempotent algebraically normal tensor is a spectrally normalized normal tensor.
 

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -398,6 +398,70 @@ theorem rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum
         rfp_nt_structural (P.basis j) (hnormal j) hBlockRFP
       exact chainGroundSpace_eq_mpvSubmodule hInj (by omega) (by omega) (by omega)
 
+/-- The distinct basis tensors of a BNT canonical form are a basis of normal
+tensors for their direct-sum tensor.
+
+Each basis block of a BNT canonical form is irreducible and left-canonical
+with normalized self-overlap, hence a spectrally normalized normal tensor; the
+MPV family of the unit-weight direct sum is the plain sum of the block MPV
+families; and the eventual linear independence of the basis MPV states is part
+of the canonical form. This is the basis-of-normal-tensors relation of
+arXiv:1606.00608, lines 271--274, at the explicit multiplicity-one unit-weight
+representative $A=\bigoplus_j A_j$ used in the proof of Theorem
+`thm:main-MPS`, lines 534--541.
+
+**Scope restriction (multiplicity-one unit weights):** the statement covers
+the direct sum of the distinct basis tensors with one unit-weight copy each.
+Repeated copies and raw sector weights remain outside this statement; see
+docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex. -/
+theorem isCPSVBasisOfNormalTensors_basisDirectSum
+    (hCF : IsBNTCanonicalForm P) :
+    IsCPSVBasisOfNormalTensors (directSumTensor P.basis)
+      (fun j => ⟨P.basisDim j, P.basis j⟩) := by
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  refine {
+    blocks_normal := fun j ↦
+      isNormalTensor_of_isNormal_leftCanonical (P.basis j)
+        (hCF.basis_isNormal j) (hCF.basis_left_canonical j)
+    spans_mpv := ?_
+    eventually_li := by exact hCF.bnt_data }
+  intro N _hN
+  refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
+  rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis,
+    mpv_toTensorFromBlocks_eq_sum]
+  simp
+
+/-- **Corrected forward direction of the main MPS theorem (RFP ⟹ ZCL) at the
+multiplicity-one representative.**
+
+Let $P$ be a BNT canonical form. If the direct sum of its distinct basis
+tensors $\bigoplus_j A_j$ is a renormalization fixed point, i.e. its transfer
+matrix satisfies $\mathbb E^2=\mathbb E$, then it has zero correlation length
+in the positive-gap form: the physical correlations are independent of the
+separation whenever both complementary gaps are positive (CID), and the mixed
+transfer matrices of distinct BNT components vanish,
+$\mathbb E_{j,j'}=0$ for $j\neq j'$ (local orthogonality).
+
+This is the implication (i) ⟹ (ii) of Theorem `thm:main-MPS` at
+arXiv:1606.00608, lines 534--541, for the explicit multiplicity-one
+unit-weight direct-sum representative, with the corrections forced by the
+raw-weight counterexample
+`halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp` (issue #2597):
+the source CID quantifies over all disjoint regions, including adjacent ones,
+and the source theorem permits raw sector weights and repeated copies. Both
+restrictions are recorded in
+docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex. -/
+theorem isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL
+    (hCF : IsBNTCanonicalForm P)
+    (hRFP : IsTransferIdempotent (directSumTensor P.basis)) :
+    IsPositiveGapBNTZCL (directSumTensor P.basis) P.basis := by
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  exact isPositiveGapBNTZCL_of_isTransferIdempotent_directSum P.basis
+    hCF.isCPSVBasisOfNormalTensors_basisDirectSum
+    hCF.basis_irreducible hCF.basis_left_canonical hCF.basis_distinct hRFP
+
 end IsBNTCanonicalForm
 
 end MPSTensor

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -447,11 +447,11 @@ This is the implication (i) ⟹ (ii) of Theorem `thm:main-MPS` at
 arXiv:1606.00608, lines 534--541, for the explicit multiplicity-one
 unit-weight direct-sum representative, with the corrections forced by the
 raw-weight counterexample
-`halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp` (issue #2597):
-the source CID quantifies over all disjoint regions, including adjacent ones,
-and the source theorem permits raw sector weights and repeated copies. Both
-restrictions are recorded in
-docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex. -/
+`halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp`, recorded in
+docs/paper-gaps/cpsv16_pure_zcl_raw_weight_counterexample.tex: the source CID
+quantifies over all disjoint regions, including adjacent ones, and the source
+theorem permits raw sector weights and repeated copies. Both restrictions are
+recorded in docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex. -/
 theorem isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL
     (hCF : IsBNTCanonicalForm P)
     (hRFP : IsTransferIdempotent (directSumTensor P.basis)) :

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -163,3 +163,70 @@
     $\E_{j,j'}^2=\E_{j,j'}$ and $\rho(\E_{j,j'})<1$ imply
     $\E_{j,j'}=0$.
 \end{proof}
+
+\begin{lemma}[BNT basis of a canonical form is a basis of normal tensors for
+    its direct sum]%
+    \label{lem:bnt_cf_basis_is_bnt_for_direct_sum}
+    \lean{MPSTensor.IsBNTCanonicalForm.isCPSVBasisOfNormalTensors_basisDirectSum}
+    \leanok
+    \uses{def:bnt_cpsv, def:sector_bnt_cf}
+    Let $P$ be a BNT canonical form with distinct basis tensors $(A_j)_j$, and
+    let $A=\bigoplus_j A_j$ be their direct sum with one unit-weight copy of
+    each sector. Then $(A_j)_j$ is a basis of normal tensors for $A$: every
+    $A_j$ is a normal tensor, at every positive system length $N$
+    \begin{align}
+        V^{(N)}(A)
+        &=\sum_j V^{(N)}(A_j),
+        \notag
+    \end{align}
+    and the states $\{|V^{(N)}(A_j)\rangle\}_j$ are linearly independent for
+    all sufficiently large $N$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{cor:sector_bnt_cf_basis_normal, thm:mpv_decomposition}
+    Every basis block is irreducible and left-canonical with normalized
+    self-overlap converging to $1$, hence a normal tensor by
+    Corollary~\ref{cor:sector_bnt_cf_basis_normal}. The direct sum is the
+    unit-weight block-diagonal tensor, so its length-$N$ matrix-product vector
+    splits as the sum of the block vectors by
+    Theorem~\ref{thm:mpv_decomposition}. Eventual linear independence is part
+    of the canonical-form data of $P$.
+\end{proof}
+
+\begin{theorem}[Corrected forward direction of the main MPS theorem,
+    multiplicity-one representative]%
+    \label{thm:rfp_implies_positive_gap_bnt_zcl_cf_basis_direct_sum}
+    \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL}
+    \leanok
+    \uses{def:is_positive_gap_bnt_zcl, def:sector_bnt_cf,
+        def:mps_transfer_idempotence}
+    Let $P$ be a BNT canonical form with distinct basis tensors $(A_j)_j$, and
+    let $A=\bigoplus_j A_j$ be their direct sum with one unit-weight copy of
+    each sector. If $A$ is a renormalization fixed point,
+    \begin{align}
+        \E_A^2&=\E_A,
+        \notag
+    \end{align}
+    then $A$ has positive-gap BNT zero correlation length: its physical
+    correlations are independent of the separation whenever both complementary
+    gaps are positive, and for all distinct BNT components $j\ne j'$
+    \begin{align}
+        \E_{j,j'}&=0.
+        \notag
+    \end{align}
+    This is the implication (i)$\implies$(ii) of
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv} at the explicit multiplicity-one
+    unit-weight representative. The raw-weight unrestricted biconditional is
+    false by Theorem~\ref{thm:halved_weight_zcl_not_rfp}, and the
+    adjacent-region cases of the source CID are excluded by
+    Definition~\ref{def:is_positive_gap_bnt_zcl}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:bnt_cf_basis_is_bnt_for_direct_sum,
+        thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}
+    By Lemma~\ref{lem:bnt_cf_basis_is_bnt_for_direct_sum}, the distinct basis
+    tensors of $P$ are a basis of normal tensors for $A$. The basis blocks are
+    irreducible, left-canonical, and pairwise gauge-phase distinct, so
+    Theorem~\ref{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum} applies to
+    the direct sum.
+\end{proof}


### PR DESCRIPTION
## What changed

Closes #4771. Advances #2633.

- `MPSTensor.IsBNTCanonicalForm.isCPSVBasisOfNormalTensors_basisDirectSum` (new, `RFP/NNCPHMultiSector.lean:417`): the distinct basis tensors of a BNT canonical form are a basis of normal tensors (arXiv:1606.00608, lines 271-274) for their multiplicity-one unit-weight direct sum. Blocks are normal via `basis_isNormal` + the relocated left-canonical conversion; MPV spanning via `toTensorFromBlocks_one_eq_directSumTensor` + `mpv_toTensorFromBlocks_eq_sum` with coefficients `fun _ ↦ 1`; eventual linear independence from `bnt_data`.
- `MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL` (new, `RFP/NNCPHMultiSector.lean:455`): the corrected (i) ⟹ (ii) of Theorem `thm:main-MPS` (lines 534-541) at the explicit multiplicity-one representative, packaged through `isPositiveGapBNTZCL_of_isTransferIdempotent_directSum`. Docstring records the #2597 raw-weight counterexample and the positive-gap CID scope.
- `isNormalTensor_of_isNormal_leftCanonical` moved verbatim from `RFP/BeigiLoopBNTIdentification.lean` to `CanonicalForm/NormalTensorGauge.lean` (its only prior user was that file; the move avoids dragging the heavy MPDO/entropy subtree into the new consumer). Zero new import edges.
- Blueprint: two `\leanok` entries in `ch26_mps_rfp_zero_correlation_length.tex` (`lem:bnt_cf_basis_is_bnt_for_direct_sum`, `thm:rfp_implies_positive_gap_bnt_zcl_cf_basis_direct_sum`), formula-first with the raw-statement counterexample left non-`\leanok`. The reverse direction and the biconditional are deferred per the issue (new mathematics; see #2633 assessment).

## Validation

- Full `lake build` green: 9742 jobs (all importers of the 3 changed modules covered).
- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only; no `sorry`/axiom/`native_decide`.
- `leanblueprint checkdecls` exit 0 after regenerating `lean_decls`; CI-style sync scan delta = exactly the 2 new resolved entries.
- Blueprint double-`lualatex` (`TEXINPUTS="../../tex/tenkz//:"`): 0 undefined References; `print.pdf` reverted, `print.tnlog` removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New theorems sit on a long chain of prior MPS/RFP lemmas; mistakes would affect the formal main-theorem forward direction, but changes are mostly packaging and a verbatim lemma move with documented scope limits.
> 
> **Overview**
> Proves the **corrected (i) ⟹ (ii)** of CPSV16 Theorem 3.8 at the **multiplicity-one unit-weight** direct sum \(\bigoplus_j A_j\) of a BNT canonical form’s distinct basis blocks: transfer idempotence on that sum yields **positive-gap BNT zero correlation length** (positive-gap physical CID plus \(\mathbb E_{j,j'}=0\) for \(j\neq j'\)).
> 
> Adds **`isCPSVBasisOfNormalTensors_basisDirectSum`**, showing each basis block is spectrally normal (via relocated conversion), the direct-sum MPV is the sum of block MPVs with unit weights, and eventual linear independence comes from canonical-form data. The main result is **`isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL`**, routed through the existing direct-sum RFP ⟹ ZCL lemma; docstrings cite raw-weight counterexamples and scope gaps.
> 
> **`isNormalTensor_of_isNormal_leftCanonical`** moves unchanged from `BeigiLoopBNTIdentification.lean` to **`NormalTensorGauge.lean`** so the new consumer does not pull in the heavier Beigi/MDPO import tree. Blueprint chapter 26 gains matching `\leanok` lemma and theorem entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16fd51f8cafb5da1c6dbd8b3c35dadb9a4c4aa54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->