### PR TITLE
refactor(blueprint): unify Schwarz theory in Chapter 5

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch04_channels.tex
+++ b/blueprint/src/appendix/ft_mps/ch04_channels.tex
@@ -3,8 +3,8 @@
 
 This appendix supports Chapter~\ref{ch:channels}. It collects the
 supporting results for complete positivity, trace normalization, density
-matrices, mean-ergodic projections, Kadison--Schwarz identities, and
-idempotent retractions.
+matrices, mean-ergodic projections, weighted traces, and idempotent
+retractions.
 
 \section{Kraus representations and complete positivity}
 
@@ -463,38 +463,6 @@ the second identifies its range and fixed points, completing the adjoint
 retraction argument in
 Theorem~\ref{thm:positive_unital_adjoint_mean_ergodic_retraction}.
 
-\section{Kadison--Schwarz square expansion}
-
-This section proves the sum-of-squares identity used in
-Theorem~\ref{thm:kraus_commute_channels}. For a unital Kraus map
-$E(X)=\sum_iK_iXK_i^\dagger$, the identity resolves its Kadison--Schwarz gap
-into nonnegative square terms.
-
-\begin{theorem}[KS gap decomposition]
-    \label{thm:ks_gap_decomp_channels}
-    \lean{KadisonSchwarz.ks_gap_eq_sum_squares}
-    \leanok
-    \uses{def:kraus_map_channels}
-    For a unital Kraus map,
-    \begin{align}
-        E(X^\dagger X)-E(X)^\dagger E(X)
-         & =\sum_iR_i^\dagger R_i,
-        \label{eq:channel_ks_gap}           \\
-        R_i
-         & :=XK_i^\dagger-K_i^\dagger E(X).
-        \label{eq:channel_ks_remainder}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-    Expand the right-hand side of (\ref{eq:channel_ks_gap}), substitute
-    (\ref{eq:channel_ks_remainder}), distribute the products, and use
-    $\sum_iK_iK_i^\dagger=\Id$ to recover the Kadison--Schwarz gap.
-\end{proof}
-
-Thus equality in the Kadison--Schwarz inequality forces each remainder to
-vanish, exactly as used in Theorem~\ref{thm:kraus_commute_channels}.
-
 \section{Weighted traces and idempotent retractions}
 
 This section proves the weighted-trace lemma used in
@@ -522,7 +490,7 @@ Theorem~\ref{thm:map_mem_multiplicativeDomain_of_idempotent}.
 \begin{theorem}[Choi--Effros left absorption]
     \label{thm:choi_effros_left}
     \lean{Kraus.choi_effros_left}\leanok
-    \uses{def:kraus_fixed_points, def:kraus_map_channels}
+    \uses{def:kraus_fixed_points, def:kraus_map}
     Under the same hypotheses, for all $X,Y\in\MN{D}$,
     $E(E(X)Y)=E(E(X)E(Y))$.
 \end{theorem}
@@ -539,7 +507,7 @@ Theorem~\ref{thm:map_mem_multiplicativeDomain_of_idempotent}.
 \begin{theorem}[Choi--Effros right absorption]
     \label{thm:choi_effros_right}
     \lean{Kraus.choi_effros_right}\leanok
-    \uses{def:kraus_fixed_points, def:kraus_map_channels}
+    \uses{def:kraus_fixed_points, def:kraus_map}
     Under the same hypotheses, for all $X,Y\in\MN{D}$,
     $E(XE(Y))=E(E(X)E(Y))$.
 \end{theorem}
@@ -556,7 +524,7 @@ Theorem~\ref{thm:map_mem_multiplicativeDomain_of_idempotent}.
 \begin{theorem}[Choi--Effros symmetric absorption]
     \label{thm:choi_effros_left_eq_right}
     \lean{Kraus.choi_effros_left_eq_right}\leanok
-    \uses{def:kraus_fixed_points, def:kraus_map_channels}
+    \uses{def:kraus_fixed_points, def:kraus_map}
     Under the same hypotheses, for all $X,Y\in\MN{D}$,
     $E(E(X)Y)=E(XE(Y))$.
 \end{theorem}

--- a/blueprint/src/chapter/ch04_channels_ergodic_peripheral_auxiliary.tex
+++ b/blueprint/src/chapter/ch04_channels_ergodic_peripheral_auxiliary.tex
@@ -584,7 +584,7 @@ both unital and trace-preserving.
 \begin{remark}[Bi-canonical special case]\label{rem:bicanonical_special_case}\leanok
     When a Kraus map happens to be both unital and trace-preserving
     (the ``bi-canonical'' case), the Kadison--Schwarz equality at peripheral
-    eigenvectors (Theorem~\ref{thm:ks_peripheral_channels}) shows directly that the
+    eigenvectors (Theorem~\ref{thm:ks_peripheral}) shows directly that the
     peripheral eigenvalues are closed under powers, and hence are roots of unity
     by Theorem~\ref{thm:peripheral_powers}. It
     requires both normalizations simultaneously. The more general adjoint-fixed-point
@@ -592,174 +592,23 @@ both unital and trace-preserving.
     adjoint fixed point are available.
 \end{remark}
 
-\subsection{The Kadison--Schwarz inequality and the multiplicative domain}
-\label{subsec:ks_input_channels}
-
-\begin{definition}[Kraus maps, adjoints, and normalizations]
-    \label{def:kraus_map_channels}
-    \lean{KadisonSchwarz.krausMap, KadisonSchwarz.krausAdjointMap,
-        KadisonSchwarz.IsUnitalKraus, KadisonSchwarz.IsTPKraus}
-    \leanok
-    For operators $\{K_i\}_{i=0}^{d-1}\subseteq\MN{D}$, the associated
-    \emph{Kraus map} and \emph{adjoint Kraus map} are
-    \begin{align}
-        E(X)   & =\sum_iK_iXK_i^\dagger, \notag \\
-        E^*(X) & =\sum_iK_i^\dagger XK_i.
-        \label{eq:channel_kraus_maps}
-    \end{align}
-    The Kraus family is \emph{unital} when
-    $\sum_iK_iK_i^\dagger=\Id$ and \emph{trace-preserving} when
-    $\sum_iK_i^\dagger K_i=\Id$.
-\end{definition}
-
-\begin{theorem}[Kadison--Schwarz inequality]
-    \label{thm:kadison_schwarz_channels}
-    \lean{KadisonSchwarz.kadison_schwarz}
-    \leanok
-    \uses{def:kraus_map_channels}
-    Let $E(X)=\sum_iK_iXK_i^\dagger$ be a unital Kraus map.
-    Then, for every $X\in\MN{D}$,
-    \begin{align}
-        E(X^\dagger X)
-         & \geq E(X)^\dagger E(X).
-        \label{eq:channel_kadison_schwarz}
-    \end{align}
-    This is \cite[Equation~(5.2)]{Wolf2012Quantum}.
-\end{theorem}
-
-\begin{proof}\leanok
-    Apply the unital completely positive map entrywise to the positive
-    $2\times2$ block matrix
-    $(\begin{smallmatrix}X^\dagger X&X^\dagger\\X&\Id\end{smallmatrix})$
-    and take the Schur complement of the lower-right block.
-\end{proof}
-
-\begin{theorem}[Hilbert--Schmidt contraction]
-    \label{thm:hs_contraction_channels}
-    \lean{KadisonSchwarz.hilbertSchmidt_contraction}
-    \leanok
-    \uses{def:kraus_map_channels, thm:kadison_schwarz_channels}
-    If a Kraus map is both unital and trace-preserving, then, for every
-    $X\in\MN{D}$,
-    \begin{align}
-        \tr(E(X)^\dagger E(X))
-         & \leq\tr(X^\dagger X).
-        \label{eq:channel_hs_contraction}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:kadison_schwarz_channels}
-    The Kadison--Schwarz gap is positive semidefinite by
-    (\ref{eq:channel_kadison_schwarz}). Trace preservation then identifies
-    the traces of its two terms, giving (\ref{eq:channel_hs_contraction}).
-\end{proof}
-
-\begin{theorem}[KS equality implies Kraus commutation]
-    \label{thm:kraus_commute_channels}
-    \lean{KadisonSchwarz.kraus_commute_of_ks_equality}
-    \leanok
-    \uses{thm:ks_gap_decomp_channels}
-    Let $E$ be a unital Kraus map.
-    If $E(X^\dagger X)=E(X)^\dagger E(X)$, then, for every~$i$,
-    \begin{align}
-        XK_i^\dagger
-         & =K_i^\dagger E(X).
-        \label{eq:channel_ks_kraus_relation}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:ks_gap_decomp_channels}
-    Theorem~\ref{thm:ks_gap_decomp_channels} gives the sum-of-squares formula
-    \begin{align}
-        E(X^\dagger X)-E(X)^\dagger E(X)
-         & =\sum_iR_i^\dagger R_i.
-        \notag
-    \end{align}
-    Every summand is positive semidefinite. If the gap
-    vanishes, each $R_i$ must vanish. Substitution in
-    (\ref{eq:channel_ks_remainder}) gives
-    (\ref{eq:channel_ks_kraus_relation}).
-\end{proof}
-
-\begin{theorem}[KS equality for peripheral eigenvectors]
-    \label{thm:ks_peripheral_channels}
-    \lean{KadisonSchwarz.ks_equality_of_peripheral_eigenvector}
-    \leanok
-    \uses{def:kraus_map_channels, thm:kadison_schwarz_channels}
-    Let $E$ be a Kraus map that is both unital and trace-preserving.
-    If $E(X)=\mu X$ with $|\mu|=1$, then
-    \begin{align}
-        E(X^\dagger X)
-         & =E(X)^\dagger E(X).
-        \label{eq:channel_ks_peripheral}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-    The Kadison--Schwarz gap is positive semidefinite by
-    (\ref{eq:channel_kadison_schwarz}). Trace preservation and
-    $E(X)=\mu X$ with $|\mu|=1$ show that its trace is zero, hence the gap
-    vanishes and (\ref{eq:channel_ks_peripheral}) follows.
-\end{proof}
-
-\begin{theorem}[Left multiplicative identity from KS equality]
-    \label{thm:left_multiplicative_identity_channels}
-    \lean{KadisonSchwarz.multiplicative_domain_left}
-    \leanok
-    \uses{thm:kraus_commute_channels}
-    Let $E$ be a unital Kraus map.
-    If $E(X^\dagger X)=E(X)^\dagger E(X)$, then, for every
-    $Y\in\MN{D}$,
-    \begin{align}
-        E(X^\dagger Y)
-         & =E(X)^\dagger E(Y).
-        \label{eq:channel_left_multiplicative}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:kraus_commute_channels}
-    The relation (\ref{eq:channel_ks_kraus_relation}) lets one move
-    $X^\dagger$ past each Kraus operator inside the sum
-    (\ref{eq:channel_kraus_maps}), yielding
-    (\ref{eq:channel_left_multiplicative}).
-\end{proof}
-
-\begin{definition}[Multiplicative domain]
-    \label{def:multiplicative_domain_channels}
-    \lean{KadisonSchwarz.multiplicativeDomain}
-    \leanok
-    \uses{def:kraus_map_channels}
-    The \emph{multiplicative domain} of a Kraus map $E$ is the set of matrices
-    that are simultaneously left- and right-multiplicative for $E$.
-\end{definition}
-
-\begin{theorem}[Multiplicative domain is a $*$-subalgebra]
-    \label{thm:md_star_subalgebra_channels}
-    \lean{KadisonSchwarz.multiplicativeDomainStarSubalgebra}
-    \leanok
-    \uses{def:multiplicative_domain_channels, def:kraus_map_channels}
-    For a unital Kraus map, the multiplicative domain is a $*$-subalgebra of
-    $\MN{D}$.
-\end{theorem}
-
-\begin{proof}\leanok
-    The multiplicative identities are stable under addition, multiplication,
-    and adjoint, and they contain the identity matrix.
-\end{proof}
-
 \subsection{Peripheral closure via adjoint fixed point}%
 \label{subsec:peripheral_closure_fixedpoint}
 
-The following results replace the trace-preservation hypothesis by the existence
-of a positive definite fixed point for the \emph{adjoint} Kraus map,
-matching the weighted-trace argument in
+The Kraus map, its adjoint, and the unital normalization are those of
+Definitions~\ref{def:kraus_map}, \ref{def:kraus_adjoint_map}, and
+\ref{def:unital_kraus}. The following results combine the canonical
+Kadison--Schwarz and multiplicative-domain theorems of Chapter~\ref{ch:schwarz}
+with a positive definite fixed point of the adjoint map, replacing trace
+preservation by the weighted-trace argument in
 \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{lemma}[Peripheral closure via adjoint fixed point]%
     \label{lem:peripheral_closed_powers_irred_fp}
     \lean{MPSTensor.peripheralEigenvalues_pow_mem_of_irreducible_unital_of_adjoint_fixedPoint}
     \leanok
-    \uses{def:kraus_map_channels, def:irreducible_cp}
+    \uses{def:kraus_map, def:kraus_adjoint_map, def:unital_kraus,
+        def:irreducible_cp}
     Let $E(X)=\sum_iK_iXK_i^\dagger$ be a Kraus map that is
     unital ($\sum_iK_iK_i^\dagger=\Id$), and assume:
     \begin{enumerate}
@@ -773,11 +622,11 @@ matching the weighted-trace argument in
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{thm:kadison_schwarz_channels, thm:psd_fp_pd_irred,
-        thm:kraus_commute_channels, thm:left_multiplicative_identity_channels}
+    \uses{thm:kadison_schwarz, thm:psd_fp_pd_irred,
+        thm:kraus_commute, thm:right_multiplicative_identity}
     Let $E(X)=\mu X$ with $|\mu|=1$, and set
     $G:=E(X^\dagger X)-E(X)^\dagger E(X)$.
-    By (\ref{eq:channel_kadison_schwarz}), $G\geq0$.
+    By (\ref{eq:schwarz_kadison}), $G\geq0$.
     Since $E^*(\rho)=\rho$,
     \begin{align}
         \tr(\rho G)
@@ -794,10 +643,10 @@ matching the weighted-trace argument in
     Hence $X^\dagger X$ is a positive semidefinite fixed point, which is
     positive definite by irreducibility
     (Theorem~\ref{thm:psd_fp_pd_irred}). Thus $X$ is invertible.
-    Theorem~\ref{thm:kraus_commute_channels} gives the corresponding
+    Theorem~\ref{thm:kraus_commute} gives the corresponding
     intertwining relation with each Kraus operator. Iterating the
     multiplicative identity of
-    Theorem~\ref{thm:left_multiplicative_identity_channels} gives
+    Theorem~\ref{thm:right_multiplicative_identity} gives
     $E(X^n)=\mu^nX^n$, so $\mu^n$ is peripheral.
 \end{proof}
 
@@ -805,7 +654,8 @@ matching the weighted-trace argument in
     \label{thm:peripheral_roots_irred_fp}
     \lean{MPSTensor.peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint}
     \leanok
-    \uses{def:kraus_map_channels, def:irreducible_cp, def:peripheral_eigenvalues}
+    \uses{def:kraus_map, def:kraus_adjoint_map, def:unital_kraus,
+        def:irreducible_cp, def:peripheral_eigenvalues}
     Let $E(X)=\sum_iK_iXK_i^\dagger$ be a Kraus map that is
     unital, and assume that the adjoint Kraus map
     $E^*(X)=\sum_iK_i^\dagger XK_i$ has a positive definite fixed

--- a/blueprint/src/chapter/ch04_channels_fixed_point_algebra_auxiliary.tex
+++ b/blueprint/src/chapter/ch04_channels_fixed_point_algebra_auxiliary.tex
@@ -75,7 +75,7 @@
 
 \begin{definition}[Kraus fixed points]\label{def:kraus_fixed_points}
     \lean{Kraus.fixedPoints}\leanok
-    \uses{def:kraus_map_channels}
+    \uses{def:kraus_map}
     The \emph{fixed-point set} of a Kraus map
     $E(X)=\sum_iK_iXK_i^\dagger$ is
     $\Fix(E)=\{X\in\MN{D}:E(X)=X\}$.
@@ -91,8 +91,8 @@
     \label{thm:fixedPoints_in_multiplicativeDomain}
     \lean{Kraus.fixedPoints_in_multiplicativeDomain}
     \leanok
-    \uses{def:kraus_fixed_points, def:multiplicative_domain_channels,
-        def:kraus_map_channels}
+    \uses{def:kraus_fixed_points, def:kraus_adjoint_map, def:tp_kraus,
+        def:full_multiplicative_domain}
     Let $E$ be a trace-preserving Kraus map whose Schr{\"o}dinger-picture map has a
     positive definite fixed point $\rho>0$.
     Then every adjoint fixed point belongs to the multiplicative domain of the
@@ -170,7 +170,8 @@
 \begin{theorem}[Projected elements lie in the multiplicative domain]
     \label{thm:map_mem_multiplicativeDomain_of_idempotent}
     \lean{Kraus.map_mem_multiplicativeDomain_of_idempotent}\leanok
-    \uses{def:kraus_fixed_points, def:kraus_map_channels}
+    \uses{def:kraus_fixed_points, def:kraus_adjoint_map, def:unital_kraus,
+        def:full_multiplicative_domain}
     Let $E$ be a unital Kraus map whose adjoint map has a positive definite
     fixed point, and suppose $E^2=E$. Then $E(X)$ lies in the multiplicative
     domain of $E$ for every $X\in\MN{D}$.
@@ -193,7 +194,7 @@
 \begin{theorem}[Choi--Effros projected product]
     \label{thm:choi_effros_sandwich}
     \lean{Kraus.choi_effros_sandwich}\leanok
-    \uses{def:kraus_fixed_points, def:kraus_map_channels}
+    \uses{def:kraus_fixed_points, def:kraus_map}
     Under the same hypotheses, for all $X,Y\in\MN{D}$,
     $E(E(X)E(Y))=E(X)E(Y)$.
 \end{theorem}
@@ -211,7 +212,7 @@ Theorems~\ref{thm:choi_effros_left}, \ref{thm:choi_effros_right}, and
 
 \begin{definition}[Adjoint fixed points]\label{def:adjoint_fixed_points}
     \lean{Kraus.adjointFixedPoints}\leanok
-    \uses{def:kraus_map_channels}
+    \uses{def:kraus_adjoint_map}
     The \emph{adjoint fixed-point set} is
     $\Fix(E^*)=\{X\in\MN{D}:E^*(X)=X\}$, where
     $E^*(X)=\sum_iK_i^\dagger XK_i$.
@@ -220,7 +221,7 @@ Theorems~\ref{thm:choi_effros_left}, \ref{thm:choi_effros_right}, and
 \begin{theorem}[Fixed points form a $*$-subalgebra in the Heisenberg picture]
     \label{thm:adjointFixedPointsStarSubalgebra}
     \lean{Kraus.adjointFixedPointsStarSubalgebra, Kraus.fixedPoints_starSubalgebra}\leanok
-    \uses{def:adjoint_fixed_points, def:kraus_map_channels}
+    \uses{def:adjoint_fixed_points, def:tp_kraus}
     If the Kraus map is trace-preserving and has a positive definite
     fixed point $\rho>0$ with $E(\rho)=\rho$, then $\Fix(E^*)$ is a
     $*$-subalgebra of $\MN{D}$.
@@ -234,7 +235,7 @@ Theorems~\ref{thm:choi_effros_left}, \ref{thm:choi_effros_right}, and
 
 \begin{definition}[Kraus commutant]\label{def:kraus_commutant}
     \lean{Kraus.krausCommutant, Kraus.krausCommutantStarSubalgebra}\leanok
-    \uses{def:kraus_map_channels}
+    \uses{def:kraus_map}
     The \emph{Kraus commutant} is
     \begin{align}
         \{K_i,K_i^\dagger\}'
@@ -247,7 +248,7 @@ Theorems~\ref{thm:choi_effros_left}, \ref{thm:choi_effros_right}, and
 \begin{theorem}[Adjoint fixed points equal the Kraus commutant]
     \label{thm:adjointFixedPoints_eq_krausCommutant}
     \lean{Kraus.adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra}\leanok
-    \uses{def:adjoint_fixed_points, def:kraus_commutant, def:kraus_map_channels}
+    \uses{def:adjoint_fixed_points, def:kraus_commutant, def:tp_kraus}
     Under the hypotheses of Theorem~\ref{thm:adjointFixedPointsStarSubalgebra},
     the adjoint fixed-point $*$-subalgebra equals the Kraus commutant:
     \begin{align}

--- a/blueprint/src/chapter/ch05_schwarz_ft_core.tex
+++ b/blueprint/src/chapter/ch05_schwarz_ft_core.tex
@@ -122,6 +122,22 @@ maps.
     Apply Theorem~\ref{thm:kadison_schwarz} to $\{K_i^\dagger\}$.
 \end{proof}
 
+\begin{theorem}[Hilbert--Schmidt contraction]\label{thm:hs_contraction}
+    \lean{KadisonSchwarz.hilbertSchmidt_contraction}
+    \leanok
+    \uses{def:unital_kraus, def:tp_kraus}
+    If a Kraus map is both unital and trace-preserving, then
+    $\tr(E(X)^\dagger E(X)) \le \tr(X^\dagger X)$
+    for all $X \in \MN{D}$.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:kadison_schwarz}
+    By (\ref{eq:schwarz_kadison}),
+    $E(X^\dagger X) - E(X)^\dagger E(X) \ge 0$, so
+    $\tr(E(X^\dagger X)) \ge \tr(E(X)^\dagger E(X))$.
+    Trace preservation gives $\tr(E(X^\dagger X)) = \tr(X^\dagger X)$.
+\end{proof}
+
 \section{Multiplicative domain}
 
 \begin{theorem}[KS gap decomposition]\label{thm:ks_gap_decomp}

--- a/blueprint/src/chapter/ch05_schwarz_two_positive_maps_ii.tex
+++ b/blueprint/src/chapter/ch05_schwarz_two_positive_maps_ii.tex
@@ -439,22 +439,6 @@ Section~\ref{sec:app_schwarz_retractions}.
     there exists $C$ with $A = B C$.
 \end{theorem}
 
-\begin{theorem}[Hilbert--Schmidt contraction]\label{thm:hs_contraction}
-    \lean{KadisonSchwarz.hilbertSchmidt_contraction}
-    \leanok
-    \uses{def:unital_kraus, def:tp_kraus}
-    If a Kraus map is both unital and trace-preserving, then
-    $\tr(E(X)^\dagger E(X)) \le \tr(X^\dagger X)$
-    for all $X \in \MN{D}$.
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:kadison_schwarz}
-    By (\ref{eq:schwarz_kadison}),
-    $E(X^\dagger X) - E(X)^\dagger E(X) \ge 0$, so
-    $\tr(E(X^\dagger X)) \ge \tr(E(X)^\dagger E(X))$.
-    Trace preservation gives $\tr(E(X^\dagger X)) = \tr(X^\dagger X)$.
-\end{proof}
-
 \begin{theorem}[Fixed-point peripheral eigenvectors satisfy KS equality]
     \label{thm:ks_equality_of_peripheral_eigenvector_of_fixedPoint}
     \lean{Kraus.ks_equality_of_peripheral_eigenvector_of_fixedPoint}

--- a/blueprint/src/chapter/ch07_spectral_direct_sum_schwarz_maps.tex
+++ b/blueprint/src/chapter/ch07_spectral_direct_sum_schwarz_maps.tex
@@ -511,7 +511,8 @@ the ambient fixed-point space a zero-block representation.
     \label{thm:cornerFixedPoints_block_form}
     \lean{Kraus.cornerFixedPoints_blockDiagonal_iff}
     \leanok
-    \uses{def:support_proj, def:kraus_map_channels}
+    \uses{def:support_proj, def:kraus_map, def:kraus_adjoint_map,
+        def:tp_kraus}
     Let $E(X)=\sum_iK_iXK_i^\dagger$ be a trace-preserving Kraus map on
     $\MN{D}$, with Heisenberg-picture adjoint
     $E^*(Y)=\sum_iK_i^\dagger YK_i$, let $\rho\succeq0$ satisfy

--- a/blueprint/src/chapter/ch07_spectral_wedderburn_ii.tex
+++ b/blueprint/src/chapter/ch07_spectral_wedderburn_ii.tex
@@ -699,7 +699,7 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     \label{thm:adjointFixedPoints_block_form}
     \lean{Kraus.adjointFixedPoints_blockDiagonal_iff}
     \leanok
-    \uses{def:adjoint_fixed_points, def:kraus_map_channels}
+    \uses{def:adjoint_fixed_points, def:tp_kraus}
     Let $E$ be a trace-preserving Kraus map on $\MN{D}$ with a positive
     definite fixed point $\rho>0$, $E(\rho)=\rho$. There are $n\in\N$,
     positive dimensions $d_0,\ldots,d_{n-1}$ and multiplicities
@@ -745,7 +745,7 @@ equals the block algebra $\bigoplus_k\Id_{m_k}\otimes\MN{d_k}$.
     \label{thm:fixedPoints_block_form}
     \lean{Kraus.fixedPoints_blockDiagonal_iff}
     \leanok
-    \uses{def:kraus_fixed_points, def:kraus_map_channels}
+    \uses{def:kraus_fixed_points, def:kraus_adjoint_map, def:unital_kraus}
     Let $E$ be a unital Kraus map on $\MN{D}$ whose adjoint map $E^*$ has a
     positive definite fixed point $\rho>0$. There are $n\in\N$, positive
     dimensions $d_k$ and multiplicities $m_k$ with


### PR DESCRIPTION
## What changed

- removes the duplicate Chapter 4 presentation of the Kadison--Schwarz, equality, Kraus-relation, Hilbert--Schmidt contraction, and multiplicative-domain family
- redirects peripheral, fixed-point, and Chapter 7 consumers to the canonical Chapter 5 definitions, theorems, and equations
- removes the duplicate Chapter 4 appendix proof of the KS gap decomposition
- moves the single `thm:hs_contraction` blueprint entry into the Chapter 5 core so it remains on the focused route when the two-positive material is later rehomed
- corrects the peripheral-power proof to invoke the right multiplicative identity, which directly yields `E(X^{n+1}) = E(X^n)E(X)`

This is the first narrow preparatory step in the Chapter 4 ownership cleanup. It changes no routers and moves no other subject matter.

## Validation

- `latexindent -w -s -l=blueprint/latexindent.yaml` on all touched TeX files
- retired-label/equation scan: zero occurrences
- duplicate labels: zero
- missing `\ref` / `\uses` targets: zero in full and focused routers
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- full blueprint: direct LuaLaTeX twice, 693 pages, zero undefined cross-references
- focused blueprint: direct LuaLaTeX twice, 205 pages, zero undefined cross-references
- independent mathematical/reference review completed; its sole finding (left-vs-right multiplicative identity in the inherited peripheral-power prose) was fixed before push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint-only TeX and `\uses`/`\ref` rewiring with no Lean router or runtime changes; risk is limited to broken cross-references or a wrong theorem cite in proofs if validation missed an edge case.
> 
> **Overview**
> **Removes duplicate Kadison–Schwarz material from Chapter 4** (definitions, KS inequality, gap decomposition, Hilbert–Schmidt contraction, multiplicative domain, and peripheral KS lemmas) and **points Chapter 4 peripheral/fixed-point prose and Chapter 7 spectral blocks at the canonical Chapter 5 labels** (`def:kraus_map`, `thm:kadison_schwarz`, `thm:kraus_commute`, `def:full_multiplicative_domain`, etc.).
> 
> The **KS gap appendix section** in `ch04_channels.tex` is dropped; **Hilbert–Schmidt contraction** is kept once in `ch05_schwarz_ft_core.tex` (removed from the two-positive-maps chapter). The **peripheral power proof** now cites **`thm:right_multiplicative_identity`** instead of the left identity so powers of peripheral eigenvectors iterate correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549e24c2531fc6140911402d37582a9dd832b05d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->