### PR TITLE
fix(tenkz): retain crossing points for labels

### DIFF
--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2176,39 +2176,47 @@
   }
 
 % `crossing of a and b` is where the two strings actually meet, so the
-% address asks the ink, not the author: the engine intersects the two saved
-% routes and the first solution IS the point.
-%
-% INCOMPLETE.  This answers only for routes that were never operated on.
-% Surgery cuts the under route's gap AT the crossing, so afterwards the two
-% routes no longer meet and this asks a question the ink can no longer
-% answer -- exactly the declared crossings a label most wants to name.  The
-% point is a property of the routes, and the engine holds it at the moment
-% it cuts: the fix is for the string engine to publish its crossing points
-% as it makes them, and for this production to read that ledger.  Until
-% then a label on a declared crossing raises the diagnostic below.
+% address asks the string engine for the point saved before crossing surgery.
+% Undeclared pairs still read the live intersection of their routes.
 \cs_new_protected:Npn \__tenkz_kernel_r_crossing:nnn #1#2#3
   {
-    \bool_if:NTF \l__tenkz_kernel_r_cut_bool
-      { \int_zero:N \l__tenkz_kernel_r_cross_int }
-      { \__tenkz_string_count:nnN {#2} {#3} \l__tenkz_kernel_r_cross_int }
-    \int_compare:nNnTF { \l__tenkz_kernel_r_cross_int } > {0}
+    \__tenkz_string_crossing_point:nnN
+      {#2} {#3} \l__tenkz_kernel_r_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_r_tl
       {
-        \pgfpointintersectionsolution {1}
-        \__tenkz_geom_store:nnn {#1}
-          { \dim_to_fp:n { \use:c {pgf@x} } / \dim_to_fp:n { \tenkz@pitch } }
-          { \dim_to_fp:n { \use:c {pgf@y} } / \dim_to_fp:n { \tenkz@pitch } }
+        \__tenkz_string_count:nnN
+          {#2} {#3} \l__tenkz_kernel_r_cross_int
+        \int_compare:nNnTF { \l__tenkz_kernel_r_cross_int } > {0}
+          {
+            \pgfpointintersectionsolution {1}
+            \__tenkz_geom_store:nnn {#1}
+              {
+                \dim_to_fp:n { \use:c {pgf@x} }
+                / \dim_to_fp:n { \tenkz@pitch }
+              }
+              {
+                \dim_to_fp:n { \use:c {pgf@y} }
+                / \dim_to_fp:n { \tenkz@pitch }
+              }
+          }
+          { \msg_error:nnnn {tenkz}{kernel-render-nocross} {#2} {#3} }
       }
-      { \msg_error:nnnn {tenkz}{kernel-render-nocross} {#2} {#3} }
+      {
+        \__tenkz_geom_store:nnn {#1}
+          {
+            \dim_to_fp:n { \tl_item:Nn \l__tenkz_kernel_r_tl {1} }
+            / \dim_to_fp:n { \tenkz@pitch }
+          }
+          {
+            \dim_to_fp:n { \tl_item:Nn \l__tenkz_kernel_r_tl {2} }
+            / \dim_to_fp:n { \tenkz@pitch }
+          }
+      }
   }
 \int_new:N \l__tenkz_kernel_r_cross_int
-\bool_new:N \l__tenkz_kernel_r_cut_bool
 \msg_new:nnn {tenkz}{kernel-render-nocross}
   { [TKZ-KERNEL-RENDER-NOCROSS]~an~address~names~the~crossing~of~'#1'~and~
-    '#2',~but~the~picture~cannot~say~where~they~meet:~either~the~routes~
-    never~meet,~or~a~declared~crossing~has~already~cut~the~gap~that~held~
-    the~answer.~The~string~engine~must~publish~its~crossing~points~before~
-    this~address~can~name~a~declared~crossing. }
+    '#2',~but~their~saved~routes~do~not~meet. }
 
 % A port is a cell of its atom's span: n/s slots walk the spanned columns,
 % e/w slots walk the spanned rows.  The wire it anchors runs under the
@@ -3080,13 +3088,6 @@
       { \__tenkz_kernel_r_string_declare:n {##1} }
     \seq_map_inline:Nn \l__tenkz_kernel_r_strings_seq
       { \__tenkz_kernel_r_crossings:n {##1} }
-    % surgery has run if any crossing was declared; see the crossing address
-    \seq_map_inline:Nn \l__tenkz_kernel_r_strings_seq
-      {
-        \__tenkz_model_get:nnN {##1} {cross} \l__tenkz_kernel_r_tl
-        \quark_if_no_value:NF \l__tenkz_kernel_r_tl
-          { \bool_set_true:N \l__tenkz_kernel_r_cut_bool }
-      }
     \bool_lazy_or:nnT
       { ! \seq_if_empty_p:N \l__tenkz_kernel_r_strings_seq }
       { ! \prop_if_empty_p:N \l__tenkz_kernel_r_legdrawn_prop }

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -75,6 +75,7 @@
 \seq_new:N \l__tenkz_string_segments_seq
 \prop_new:N \l__tenkz_string_self_gap_prop   % self id -> component boundary
 \prop_new:N \l__tenkz_string_external_gap_prop % under id -> component boundaries
+\prop_new:N \l__tenkz_string_crossing_point_prop % {under}{over} -> {x}{y}
 \prop_new:N \l__tenkz_string_selector_seen_prop
 \seq_new:N \l__tenkz_string_before_components_seq
 \seq_new:N \l__tenkz_string_after_components_seq
@@ -145,6 +146,7 @@
     \seq_clear:N \l__tenkz_string_processed_seq
     \prop_clear:N \l__tenkz_string_self_gap_prop
     \prop_clear:N \l__tenkz_string_external_gap_prop
+    \prop_clear:N \l__tenkz_string_crossing_point_prop
   }
 
 \cs_new_protected:Npn \__tenkz_string_require_libs:
@@ -425,6 +427,19 @@
       { \exp_args:Nc \pgfsetpath { \l__tikzspath_prefix_tl #1 } }
       { \exp_args:Nc \pgfsetpath { \l__tikzspath_prefix_tl #2 } }
     \int_set:Nn #3 { \pgfintersectionsolutions }
+  }
+
+% A crossing is symmetric to its reader, while the ledger keeps the declared
+% under--over order used by surgery.
+\cs_new_protected:Npn \__tenkz_string_crossing_point:nnN #1#2#3
+  {
+    \prop_get:NnNTF
+      \l__tenkz_string_crossing_point_prop { {#1} {#2} } #3
+      { }
+      {
+        \prop_get:NnN
+          \l__tenkz_string_crossing_point_prop { {#2} {#1} } #3
+      }
   }
 
 % A planar cubic has at most one proper self-intersection.  If
@@ -966,6 +981,12 @@
         \pgf@process{\pgfpointintersectionsolution{1}}
         \dim_set:Nn \l__tenkz_string_intersection_x_dim {\pgf@x}
         \dim_set:Nn \l__tenkz_string_intersection_y_dim {\pgf@y}
+        \prop_put:Nne
+          \l__tenkz_string_crossing_point_prop { {#1} {#2} }
+          {
+            { \dim_use:N \l__tenkz_string_intersection_x_dim }
+            { \dim_use:N \l__tenkz_string_intersection_y_dim }
+          }
         \dim_set:Nn \l__tenkz_string_nearest_dim {\maxdimen}
         \seq_map_indexed_inline:Nn
           \l__tenkz_string_after_components_seq


### PR DESCRIPTION
### Motivation

- A declared crossing cuts a gap from the under-strand, so the two visible
  routes no longer meet where a crossing label must be placed.
- The string engine already knows the intersection while it locates that gap;
  retaining the point avoids reconstructing it after the cut.

### Description

- Record each declared crossing point with its ordered pair of operands.
- Read the point in either operand order.
- Resolve a crossing address from the recorded point first, falling back to a
  live route intersection only for an undeclared pair.
- Remove the cut-state flag that previously refused every crossing address
  after any declared crossing.

The braid example already contains its crossing label on `main`, so its source
does not change.

### Testing

Exact head `b66f50514eaf35ae54ca7c8814402a4b03eee59a`:

```text
$ bash scripts/tenkz_golden.sh --check
PASS: 263 event streams byte-identical to the golden baseline
```

The CI corpus job stops before its TeX checks at an unchanged `main` failure.
The same command and output reproduce on pristine `774076c7b`:

```text
$ python3 scripts/test_tenkz_corpus_provenance.py
AssertionError: canonical source-name digest depended on TSV row order:
tenkz-census: tenkz-kernel.code.tex: 1 ink token(s), 0 decimal literal(s) outside the metric table
tenkz-census: WARN totals: 44 ink token(s) outside the render stage, 51 stray decimal literal(s)
tests/tenkz/render-census-baseline.json: FAIL: render census differs from the recorded baseline; shrink the debt or update the manifest in the same change
```

This change neither modifies that pre-existing `\path` use nor updates the
corpus baseline.

The exact-head kernel probes reach the known LionSR/tenkz#70 failure:

```text
$ bash scripts/tenkz_kernel_probes.sh
FAIL: k_braid.tex did not compile
! Missing number, treated as zero.
<to be read again>
                   p
l.20 \end{tenkz}
No pages of output.
Transcript written on k_braid.log.
```

A temporary combined checkout placed the local LionSR/tenkz#70 candidate
`a329d226cddb38137035215ec1373061a12b2f5b` before this commit:

```text
$ TEXINPUTS=.//:$PWD/tex/tenkz//: xelatex -interaction=nonstopmode \
    -output-directory=/tmp/tnlean-4775-after tests/tenkz/kernel/k_braid.tex
Output written on /tmp/tnlean-4775-after/k_braid.pdf (1 page).
Transcript written on /tmp/tnlean-4775-after/k_braid.log.
```

The combined kernel probes pass the braid and R-operator examples, then reach
the independent cell-policy limitation:

```text
$ bash scripts/tenkz_kernel_probes.sh
FAIL: r_cell_policy.tex did not compile
! Package tenkz Error: [TKZ-KERNEL-RENDER-TODO] 'trace side=interface' does
(tenkz)                not draw yet (record wire-8)
l.11 ...et,bra}, cols=2, trace={(1,2)}]\end{tenkz}
No pages of output.
Transcript written on r_cell_policy.log.
```

At 300 dpi, the output before the prerequisite is 434 by 219 pixels: the
strands cross near the bottom while \(R\) is stranded at the upper left.
With LionSR/tenkz#70 followed by this change, the clean output is 434 by 133 pixels:
the blue over-strand is continuous, the red under-strand has its gap at the
intersection, and \(R\) sits immediately northeast of that intersection.
Nothing is clipped.

Closes LionSR/tenkz#71
