### PR TITLE
fix(tenkz): resolve enclosure ranges through the picture frame

### DIFF
--- a/tests/tenkz/kernel/regression/r_frame_margins.tex
+++ b/tests/tenkz/kernel/regression/r_frame_margins.tex
@@ -1,0 +1,45 @@
+% Traced rails and open string tips use the picture frame's boundary.
+\documentclass[border=5pt]{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[
+    rows={wire,wire}, cols=3, bonds=none,
+    west=trace, east=trace]
+  \tn[at=(1,1), skin=box]{A}
+  \tn[at=(1,3), skin=box]{B}
+  \tn[at=(2,1), skin=box]{C}
+  \tn[at=(2,3), skin=box]{D}
+\end{tenkz}
+\qquad
+\begin{tenkz}[
+    rows={wire,wire}, cols=3, bonds=none,
+    north=trace, south=trace]
+  \tn[at=(1,1), skin=box]{A}
+  \tn[at=(1,2), skin=box]{B}
+  \tn[at=(1,3), skin=box]{C}
+  \tn[at=(2,1), skin=box]{D}
+  \tn[at=(2,2), skin=box]{E}
+  \tn[at=(2,3), skin=box]{F}
+\end{tenkz}
+\qquad
+\begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none]
+  \tn[at=(1,1), skin=box]{A}
+  \tn[at=(1,2), skin=box]{B}
+  \tn[at=(1,3), skin=box]{C}
+  \tnwire[kind=string, route=orth, via={(2,1),(2,3)}]{open w}{open e}
+\end{tenkz}
+\qquad
+\begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none]
+  \tn[at=(1,1), skin=box]{A}
+  \tn[at=(2,1), skin=box]{B}
+  \tn[at=(3,1), skin=box]{C}
+  \tnwire[kind=string, route=orth, via={(1,2),(3,2)}]{open n}{open s}
+\end{tenkz}
+\qquad
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2008,11 +2008,8 @@
 
 % ---------- placement resolution --------------------------------------------------------------
 % The picture frame: logical (row, col) to page (x, y) with rows downward.
-% The offset stays zero while the enclosure mark still maps (r, c) to a
-% rectangle by hand instead of asking the frame: shifting the frame alone
-% would slide the atoms out from under their own enclosures.
 \cs_new_protected:Npn \__tenkz_kernel_r_frame:
-  { \__tenkz_geom_frame_declare_affine:nnnnnnn {kpic} {0}{1}{-1}{0} {0}{0} }
+  { \__tenkz_geom_frame_declare_affine:nnnnnnn {kpic} {0}{1}{-1}{0} {-1}{1} }
 
 \cs_generate_variant:Nn \__tenkz_geom_place_rel:nnnn { nnee, nVee, neee }
 \cs_generate_variant:Nn \__tenkz_geom_place_mid:nnn { nVV, nee }
@@ -3368,14 +3365,40 @@
         \( \s* (\d+) \s* , \s* (\d+) \s* \) \s* \Z }
       \l__tenkz_kernel_r_tl \l__tenkz_kernel_match_seq
       {
-        \fp_set:Nn \l__tenkz_kernel_r_x_fp
-          { \seq_item:Nn \l__tenkz_kernel_match_seq {3} }
+        \tl_set:Ne \l__tenkz_kernel_r_row_tl
+          {
+            ( \seq_item:Nn \l__tenkz_kernel_match_seq {2} ,
+              \seq_item:Nn \l__tenkz_kernel_match_seq {3} )
+          }
+        \tl_set:Ne \l__tenkz_kernel_r_col_tl
+          {
+            ( \seq_item:Nn \l__tenkz_kernel_match_seq {4} ,
+              \seq_item:Nn \l__tenkz_kernel_match_seq {5} )
+          }
+        \__tenkz_kernel_addr:VN \l__tenkz_kernel_r_row_tl
+          \l__tenkz_kernel_r_node_tl
+        \__tenkz_kernel_r_node:V \l__tenkz_kernel_r_node_tl
+        \__tenkz_kernel_r_xy:nNN
+          { \tl_use:N \l__tenkz_kernel_r_node_tl }
+          \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+        \__tenkz_kernel_addr:VN \l__tenkz_kernel_r_col_tl
+          \l__tenkz_kernel_r_node_tl
+        \__tenkz_kernel_r_node:V \l__tenkz_kernel_r_node_tl
+        \__tenkz_kernel_r_xy:nNN
+          { \tl_use:N \l__tenkz_kernel_r_node_tl }
+          \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
+        \fp_set:Nn \l__tenkz_kernel_r_xc_fp
+          { min( \l__tenkz_kernel_r_x_fp , \l__tenkz_kernel_r_xb_fp ) }
         \fp_set:Nn \l__tenkz_kernel_r_xb_fp
-          { \seq_item:Nn \l__tenkz_kernel_match_seq {5} }
+          { max( \l__tenkz_kernel_r_x_fp , \l__tenkz_kernel_r_xb_fp ) }
+        \fp_set:Nn \l__tenkz_kernel_r_x_fp
+          { \l__tenkz_kernel_r_xc_fp }
+        \fp_set:Nn \l__tenkz_kernel_r_yc_fp
+          { min( \l__tenkz_kernel_r_y_fp , \l__tenkz_kernel_r_yb_fp ) }
         \fp_set:Nn \l__tenkz_kernel_r_yb_fp
-          { - \seq_item:Nn \l__tenkz_kernel_match_seq {2} }
+          { max( \l__tenkz_kernel_r_y_fp , \l__tenkz_kernel_r_yb_fp ) }
         \fp_set:Nn \l__tenkz_kernel_r_y_fp
-          { - \seq_item:Nn \l__tenkz_kernel_match_seq {4} }
+          { \l__tenkz_kernel_r_yc_fp }
         \fp_set:Nn \l__tenkz_kernel_r_reach_fp
           { \__tenkz_metric_ratio:n {enclosepad} }
       }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2011,6 +2011,14 @@
 \cs_new_protected:Npn \__tenkz_kernel_r_frame:
   { \__tenkz_geom_frame_declare_affine:nnnnnnn {kpic} {0}{1}{-1}{0} {-1}{1} }
 
+\cs_new_protected:Npn \__tenkz_kernel_r_frame_xy:nnNN #1#2#3#4
+  {
+    \__tenkz_geom_apply:nnnNN {kpic} {#1} {#2}
+      \l__tenkz_kernel_r_x_tl \l__tenkz_kernel_r_y_tl
+    \fp_set:Nn #3 { \l__tenkz_kernel_r_x_tl + 0 }
+    \fp_set:Nn #4 { \l__tenkz_kernel_r_y_tl + 0 }
+  }
+
 \cs_generate_variant:Nn \__tenkz_geom_place_rel:nnnn { nnee, nVee, neee }
 \cs_generate_variant:Nn \__tenkz_geom_place_mid:nnn { nVV, nee }
 \cs_generate_variant:Nn \__tenkz_render_atom_labelled:nnn { nen }
@@ -2494,35 +2502,51 @@
         {west-east}
           {
             \__tenkz_model_get:nnN {#1} {row} \l__tenkz_kernel_r_row_tl
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_row_tl }
+              { 1 - \__tenkz_metric_ratio:n {wrapreach} }
+              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_row_tl }
+              {
+                \l__tenkz_kernel_r_cols_int
+                + \__tenkz_metric_ratio:n {wrapreach}
+              }
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \__tenkz_render_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
-                  { 1 - \__tenkz_metric_ratio:n {wrapreach} }
-                  { - \l__tenkz_kernel_r_row_tl }
+                  { \l__tenkz_kernel_r_x_fp }
+                  { \l__tenkz_kernel_r_y_fp }
                 --
                 \__tenkz_kernel_r_pair:nn
-                  {
-                    \l__tenkz_kernel_r_cols_int
-                    + \__tenkz_metric_ratio:n {wrapreach}
-                  }
-                  { - \l__tenkz_kernel_r_row_tl }
+                  { \l__tenkz_kernel_r_xb_fp }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
         {north-south}
           {
             \__tenkz_model_get:nnN {#1} {col} \l__tenkz_kernel_r_col_tl
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { 1 - \__tenkz_metric_ratio:n {wrapreach} }
+              { \l__tenkz_kernel_r_col_tl }
+              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \__tenkz_kernel_r_frame_xy:nnNN
+              {
+                \l__tenkz_kernel_r_rows_int
+                + \__tenkz_metric_ratio:n {wrapreach}
+              }
+              { \l__tenkz_kernel_r_col_tl }
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \__tenkz_render_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_col_tl }
-                  { - 1 + \__tenkz_metric_ratio:n {wrapreach} }
+                  { \l__tenkz_kernel_r_x_fp }
+                  { \l__tenkz_kernel_r_y_fp }
                 --
                 \__tenkz_kernel_r_pair:nn
-                  { \l__tenkz_kernel_r_col_tl }
-                  {
-                    - \l__tenkz_kernel_r_rows_int
-                    - \__tenkz_metric_ratio:n {wrapreach}
-                  }
+                  { \l__tenkz_kernel_r_xb_fp }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
       }
@@ -2815,43 +2839,57 @@
       {
         {n}
           {
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { 1 - \__tenkz_metric_ratio:n {stub} } {1}
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \tl_set:Ne #2
               {
                 \__tenkz_kernel_r_ppt:nn
                   { \l__tenkz_kernel_r_xc_fp }
-                  { -1 + \__tenkz_metric_ratio:n {stub} }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
         {s}
           {
+            \__tenkz_kernel_r_frame_xy:nnNN
+              {
+                \l__tenkz_kernel_r_rows_int
+                + \__tenkz_metric_ratio:n {stub}
+              }
+              {1}
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \tl_set:Ne #2
               {
                 \__tenkz_kernel_r_ppt:nn
                   { \l__tenkz_kernel_r_xc_fp }
-                  {
-                    - \l__tenkz_kernel_r_rows_int
-                    - \__tenkz_metric_ratio:n {stub}
-                  }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
         {w}
           {
+            \__tenkz_kernel_r_frame_xy:nnNN
+              {1} { 1 - \__tenkz_metric_ratio:n {stub} }
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \tl_set:Ne #2
               {
                 \__tenkz_kernel_r_ppt:nn
-                  { 1 - \__tenkz_metric_ratio:n {stub} }
+                  { \l__tenkz_kernel_r_xb_fp }
                   { \l__tenkz_kernel_r_yc_fp }
               }
           }
         {e}
           {
+            \__tenkz_kernel_r_frame_xy:nnNN
+              {1}
+              {
+                \l__tenkz_kernel_r_cols_int
+                + \__tenkz_metric_ratio:n {stub}
+              }
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \tl_set:Ne #2
               {
                 \__tenkz_kernel_r_ppt:nn
-                  {
-                    \l__tenkz_kernel_r_cols_int
-                    + \__tenkz_metric_ratio:n {stub}
-                  }
+                  { \l__tenkz_kernel_r_xb_fp }
                   { \l__tenkz_kernel_r_yc_fp }
               }
           }


### PR DESCRIPTION
## Motivation

Range enclosures converted `(row, column)` targets directly to `(column, -row)` coordinates. That bypassed the picture frame, unlike named targets, and forced the frame offset to remain zero so atoms would not move away from their enclosures.

Moving the frame also exposed two remaining page-coordinate calculations: traced rails and open string tips still used the old unshifted margins, leaving their ink one cell away from the framed atoms.

## Description

- Parse both corners of a range enclosure as address nodes.
- Resolve both nodes through the picture frame before taking the padded coordinate extent.
- Set the affine frame offset to `(-1, 1)`, so cell `(1,1)` is the origin.
- Resolve both trace orientations and all four open-tip margins through the same picture frame.
- Add a focused framed-box case for traced rails and open west, east, north, and south tips; the existing kernel probe glob includes it without changing the golden corpus.
- Keep the change to two files: `tex/tenkz/tenkz-kernel.code.tex` and `tests/tenkz/kernel/regression/r_frame_margins.tex`.

## Testing

Exact head: `7d6c94ca183ea3cec6867b4e840f8acc808b3f3e`

```text
$ python3 scripts/test_tenkz_enclosures.py
== tenkz audit: enclosure-regression.tnlog -- 8 picture(s); tex: enclosure-regression.tex (linked) ==
  ADV  [repeated-topology] enclosure-regression.tnlog: pictures 1, 2 (lang=grid) share canonical topology 02a4b475c9d9; keep it inline or use ordinary TeX composition
  ok: no hard errors (1 advisory(ies))
PASS: measured enclosure grammar, records, and failures are stable
```

```text
$ TENKZ_CORPUS_JOBS=8 scripts/tenkz_golden.sh --check
PASS: 263 event streams byte-identical to the golden baseline
```

The focused `r_frame_margins.tex` case compiles as a one-page PDF under the same XeLaTeX settings used by `scripts/tenkz_kernel_probes.sh`. The existing probe copies every `regression/r_*.tex` file, so no script, manifest, or baseline changed.

The exact-head kernel probe reaches the known LionSR/tenkz#70 failure before the focused cases:

```text
$ scripts/tenkz_kernel_probes.sh
FAIL: k_braid.tex did not compile
! Missing number, treated as zero.
<to be read again>
                   p
l.20 \end{tenkz}
```

In a separate checkout, adding the current LionSR/tenkz#70 candidate `a329d226cddb38137035215ec1373061a12b2f5b` advances the same probe beyond `k_braid` to the independent `r_cell_policy` failure:

```text
FAIL: r_cell_policy.tex did not compile
! Package tenkz Error: [TKZ-KERNEL-RENDER-TODO] 'trace side=interface' does
(tenkz)                not draw yet (record wire-8)
```

### Visual review

Fresh before/after renders were generated at 300 dpi from exact `origin/main` (`5b0401c9f46fea636d250751d781593474e4ed6b`) and this head.

- In the anchored `r_frame_margins` case, the old horizontal rails sat below the top row and the old vertical rails began below and to the right of the top anchors. At this head, both trace orientations pass through the intended framed rows and columns.
- The open west/east and north/south string tips move from the old page margins to the corresponding framed margins.
- A 5 pt border keeps every outer side visible and unclipped.
- In `k_blocking`, the rounded enclosure surrounds the four-cell chain with the same padding; the three physical legs, tensor labels, dots, and west label remain aligned and unclipped.
- In `k_czx`, the blue rounded enclosure remains centered on the four inner spins with unchanged clearance from the surrounding lattice dots.
- The `k_blocking` and `k_czx` page sizes remain unchanged (`165.1 × 68.73 pt` and `46.27 × 42.95 pt`), and their event streams remain byte-identical (`466c1be8…` and `7f635dc8…`).

Closes LionSR/tenkz#72

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7d6c94ca183ea3cec6867b4e840f8acc808b3f3e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->