### PR TITLE
refactor(blueprint): move positive-map examples to Chapter 25

### DIFF
--- a/blueprint/src/chapter/ch04_channels_positive_maps_auxiliary.tex
+++ b/blueprint/src/chapter/ch04_channels_positive_maps_auxiliary.tex
@@ -1,4 +1,4 @@
-\section{Additional results on positive maps and channels}
+\section{Rectangular positive maps, trace normalization, matrix inequalities, and density matrices}
 
 \begin{definition}[Associated positive linear map]
     \label{def:positive_map_is_positive_linear_map}
@@ -9,89 +9,6 @@
     linear map regarded as a positive linear map: if
     $A,B\in\MN{n}$ and $A \le B$, then $E(A) \le E(B)$ in $\MN{m}$.
 \end{definition}
-
-\begin{theorem}[Transposition is positive and trace-preserving]
-    \label{thm:transpose_positive_trace_preserving}
-    \lean{Matrix.transposeLinearMapComplex_isPositiveMap,
-        Matrix.transposeLinearMapComplex_isTracePreservingMap}
-    \leanok
-    \uses{def:positive_map, def:trace_preserving}
-    The matrix transposition map $\theta(X)=X^T$ on $\MN{D}$ is positive
-    and trace-preserving.
-\end{theorem}
-
-\begin{proof}\leanok
-    If $X \ge 0$, write $X=C^\dagger C$. Then
-    $X^T=C^T\overline C=\overline C^\dagger\overline C$, so $X^T \ge 0$.
-    Trace preservation is the identity $\tr(X^T)=\tr(X)$.
-\end{proof}
-
-\begin{definition}[Reduction map]
-    \label{def:reduction_map}
-    \lean{Matrix.reductionMap}
-    \leanok
-    The reduction map on $\MN{D}$, for $k\in\N$, is
-    \begin{align}
-        T_k(X)
-         & =\tr(X)\Id-k^{-1}X.
-        \label{eq:channel_reduction_map}
-    \end{align}
-\end{definition}
-
-\begin{theorem}[The first reduction map is positive]
-    \label{thm:reduction_map_one_positive}
-    \lean{Matrix.reductionMap_one_isPositiveMap}
-    \leanok
-    \uses{def:positive_map, def:reduction_map}
-    For $D\ge 1$, the map $T_1(X)=\tr(X)\Id-X$ on $\MN{D}$ is positive.
-\end{theorem}
-
-\begin{proof}\leanok
-    If $X\ge 0$, diagonalize $X$. Its eigenvalues
-    $\lambda_1,\ldots,\lambda_D$ are non-negative, and each satisfies
-    $\lambda_j\le \sum_{i=1}^D\lambda_i=\tr(X)$. Therefore all eigenvalues
-    of $\tr(X)\Id-X$ are non-negative.
-\end{proof}
-
-\begin{theorem}[Self-duality of the reduction map]
-    \label{thm:reduction_map_self_dual}
-    \lean{Matrix.traceAdjointMap_reductionMap}
-    \leanok
-    \uses{def:reduction_map}
-    The reduction map is self-dual for the trace pairing:
-    \begin{align}
-        \tr(T_k(\rho)X)
-         & =\tr(\rho T_k(X)).
-        \label{eq:channel_reduction_self_dual}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-    Expanding both sides of (\ref{eq:channel_reduction_self_dual}) using
-    (\ref{eq:channel_reduction_map}) and bilinearity of the trace gives
-    $\tr(\rho)\tr(X)-k^{-1}\tr(\rho X)$ in each case.
-\end{proof}
-
-\begin{theorem}[Choi matrix of the reduction map]
-    \label{thm:choi_matrix_reduction_map}
-    \lean{ChoiJamiolkowski.choiMatrix_reductionMap}
-    \leanok
-    \uses{def:reduction_map}
-    For $D\ge 1$, the Choi matrix of the reduction map is
-    \begin{align}
-        \tau(T_k)
-         & =D^{-1}\Id-k^{-1}\ket{\Omega}\bra{\Omega}.
-        \label{eq:channel_reduction_choi}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok
-    The trace term sends the $(a,b)$ slice of
-    $\ket{\Omega}\bra{\Omega}$ to its trace times the identity, giving
-    the contribution $D^{-1}\Id$. The second term is the Choi matrix of
-    $k^{-1}$ times the identity map, namely
-    $k^{-1}\ket{\Omega}\bra{\Omega}$.
-\end{proof}
 
 \begin{definition}[Positive map between matrix algebras]
     \label{def:positive_map_rectangular}
@@ -268,65 +185,6 @@
     whose trace against $A$ equals $S_k(A)$, so the value is attained.
     Theorem~\ref{thm:ky_fan_upper_bound} shows that no rank-$k$ projection
     exceeds it. Hence $S_k(A)$ is the maximum.
-\end{proof}
-
-\begin{definition}[Maps preserving the positive semidefinite cone]
-    \label{def:maps_psd_cone_onto}
-    \lean{MapsPSDConeOnto}
-    \leanok
-    \uses{def:positive_map}
-    A linear map $T:\MN{D}\to\MN{D}$ \emph{maps the positive semidefinite cone
-        onto itself} if $T$ is positive and every positive semidefinite matrix is
-    the image under $T$ of a positive semidefinite matrix. This is condition
-    (1) of \cite[Proposition~3.8]{Wolf2012Quantum}.
-\end{definition}
-
-\begin{theorem}[Conjugations preserve the positive semidefinite cone]
-    \label{thm:conjugation_maps_psd_cone_onto}
-    \lean{unitaryConjLM_mapsPSDConeOnto,
-        unitaryConjLM_comp_transpose_mapsPSDConeOnto}
-    \leanok
-    \uses{def:maps_psd_cone_onto}
-    Let $Y\in\MN{D}$ be invertible. Then the map $X\mapsto YXY^\dagger$ and the
-    map $X\mapsto YX^TY^\dagger$ each map the positive semidefinite cone onto
-    itself. This is the implication (3) $\Rightarrow$ (1) of
-    \cite[Proposition~3.8]{Wolf2012Quantum}.
-\end{theorem}
-
-\begin{proof}\leanok
-    Conjugation by any matrix preserves positive semidefiniteness, and the
-    transpose of a positive semidefinite matrix is positive semidefinite, so
-    both maps send the cone into itself. For surjectivity onto the cone, given
-    a positive semidefinite $A$, set
-    $W=Y^{-1}A(Y^{-1})^\dagger$, which is again positive semidefinite. Then
-    $YWY^\dagger=A$ proves the conjugation case, and
-    $Y(W^T)^TY^\dagger=A$ proves the transpose case, with $W$ and $W^T$
-    positive semidefinite.
-\end{proof}
-
-\begin{theorem}[Transposition is not completely positive]
-    \label{thm:transpose_not_completely_positive}
-    \lean{ChoiJamiolkowski.transposeLinearMapComplex_not_isCPMap}
-    \leanok
-    \uses{def:cp_map, def:flip_operator, def:fin_two_antisymm_vec,
-        thm:choi_transpose_flip, thm:cp_iff_choi_posSemidef}
-    If $D \ge 2$, the matrix transposition map $\theta(X)=X^T$ on $\MN{D}$
-    is not completely positive.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{def:flip_operator, def:fin_two_antisymm_vec, thm:choi_transpose_flip,
-        thm:cp_iff_choi_posSemidef}
-    If $\theta$ were completely positive, its Choi matrix would be positive
-    semidefinite. By Theorem~\ref{thm:choi_transpose_flip}, this Choi matrix is
-    $D^{-1}F$. For the antisymmetric vector
-    $v=\ket{01}-\ket{10}$,
-    \begin{align}
-        \bra{v}\,D^{-1}F\,\ket{v}
-         & =-\frac{2}{D}<0,
-        \notag
-    \end{align}
-    contradicting positive semidefiniteness.
 \end{proof}
 
 \begin{theorem}[Positive maps preserve Hermiticity]

--- a/blueprint/src/chapter/ch25_positive_not_cp_choi_and_decomposable_maps.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_choi_and_decomposable_maps.tex
@@ -4,7 +4,7 @@ The Choi-type maps in Wolf's Example~3.1 are built from the diagonal projection
 $D(X)$ and cyclic shifts $U_{k0}$:
 \begin{align}
     T_C(X)
-    &=(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}).
+     & =(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}).
     \notag
 \end{align}
 The formal statements below record the map and the rank-one reduction used in
@@ -28,7 +28,7 @@ the boundary of a projective simplex.
     On the cyclic index set $\Z/d\Z$, the Choi-type map is
     \begin{align}
         T_C(X)
-        &=(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}),
+         & =(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}),
         \notag
     \end{align}
     where $D$ keeps the diagonal of a matrix and $U_{k0}$ is the cyclic shift by
@@ -43,7 +43,7 @@ the boundary of a projective simplex.
     For a vector $v$ on $\Z/d\Z$,
     \begin{align}
         T_C(\ketbra{v}{v})
-        &=
+         & =
         \diag\!\left((d-n)|v_i|^2+\sum_{k=1}^n |v_{i-k}|^2\right)
         -\ketbra{v}{v}.
         \notag
@@ -66,7 +66,7 @@ the boundary of a projective simplex.
     For a vector $v$ on $\Z/d\Z$, set
     \begin{align}
         a_i
-        &=(d-n)|v_i|^2+\sum_{k=1}^n |v_{i-k}|^2.
+         & =(d-n)|v_i|^2+\sum_{k=1}^n |v_{i-k}|^2.
         \notag
     \end{align}
 \end{definition}
@@ -83,7 +83,7 @@ the boundary of a projective simplex.
     \leanok
     For every vector $w$,
     $\bra{w}(\Id-\ketbra{p}{p})\ket{w}
-    =\|w\|^2-|\braket{p}{w}|^2$.
+        =\|w\|^2-|\braket{p}{w}|^2$.
     Since $\|p\|^2=\sum_i |p_i|^2\le 1$, Cauchy's inequality gives
     $|\braket{p}{w}|^2\le \|p\|^2\|w\|^2\le \|w\|^2$, so the quadratic form is
     non-negative.
@@ -105,9 +105,9 @@ the boundary of a projective simplex.
     Put $p_i=0$ when $a_i=0$ and $p_i=v_i/\sqrt{a_i}$ otherwise. Then
     \begin{align}
         \|p\|^2
-        &=\sum_i |p_i|^2
-          =\sum_i \frac{|v_i|^2}{a_i}
-          \le 1
+         & =\sum_i |p_i|^2
+        =\sum_i \frac{|v_i|^2}{a_i}
+        \le 1
         \notag
     \end{align}
     under the same zero-term convention.
@@ -152,7 +152,7 @@ the boundary of a projective simplex.
     $x=|v_0|^2$, $y=|v_1|^2$, and $z=|v_2|^2$, the needed cyclic estimate is
     \begin{align}
         \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}
-        &\le1.
+         & \le1.
         \notag
     \end{align}
     The zero-denominator terms are read as $0$, as in the preceding
@@ -218,7 +218,7 @@ the boundary of a projective simplex.
     summands read as $0$,
     \begin{align}
         \sum_i \frac{x_i}{T+x_i-x_{\sigma(i)}}
-        &\le 1.
+         & \le 1.
         \notag
     \end{align}
 \end{lemma}
@@ -229,15 +229,15 @@ the boundary of a projective simplex.
     $\delta_i=x_i-x_{\sigma(i)}$. Each summand obeys
     \begin{align}
         \frac{x_i}{T+\delta_i}
-        &\le\frac{x_iT-x_i\delta_i+\delta_i^2/2}{T^2}.
+         & \le\frac{x_iT-x_i\delta_i+\delta_i^2/2}{T^2}.
         \notag
     \end{align}
     For $\sigma(i)=i$ both sides equal $x_i/T$, and for $\sigma(i)\ne i$ the
     difference of the two sides is
     \begin{align}
         \frac{\delta_i^2(T-x_i-x_{\sigma(i)})}
-             {2T^2(T+\delta_i)}
-        &\ge0,
+        {2T^2(T+\delta_i)}
+         & \ge0,
         \notag
     \end{align}
     by the pair bound $x_i+x_{\sigma(i)}\le T$ and
@@ -248,7 +248,7 @@ the boundary of a projective simplex.
     therefore yields
     \begin{align}
         \sum_i\frac{x_i}{T+\delta_i}
-        &\le
+         & \le
         \frac{T^2-\sum_i x_i\delta_i+\tfrac12\sum_i\delta_i^2}{T^2}
         =1.
         \notag
@@ -265,8 +265,8 @@ the boundary of a projective simplex.
     rank-one diagonal weight equals
     \begin{align}
         a_i
-        &=(d-n)x_i+\sum_{k=1}^{n}x_{i-k}
-          =T+x_i-x_{i+1}.
+         & =(d-n)x_i+\sum_{k=1}^{n}x_{i-k}
+        =T+x_i-x_{i+1}.
         \notag
     \end{align}
 \end{lemma}
@@ -314,6 +314,53 @@ the boundary of a projective simplex.
     \leanok
     Combine Lemma~\ref{lem:choi_type_rankone_positive_top} with
     Lemma~\ref{lem:positive_map_from_rankone}.
+\end{proof}
+
+\section{Transposition}
+
+Transposition is the basic example of a positive map that is not completely
+positive. Its positivity is used in the decomposable-map construction below,
+while the failure of complete positivity follows from its Choi matrix.
+
+\begin{theorem}[Transposition is positive and trace-preserving]
+    \label{thm:transpose_positive_trace_preserving}
+    \lean{Matrix.transposeLinearMapComplex_isPositiveMap,
+        Matrix.transposeLinearMapComplex_isTracePreservingMap}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving}
+    The matrix transposition map $\theta(X)=X^T$ on $\MN{D}$ is positive
+    and trace-preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $X \ge 0$, write $X=C^\dagger C$. Then
+    $X^T=C^T\overline C=\overline C^\dagger\overline C$, so $X^T \ge 0$.
+    Trace preservation is the identity $\tr(X^T)=\tr(X)$.
+\end{proof}
+
+\begin{theorem}[Transposition is not completely positive]
+    \label{thm:transpose_not_completely_positive}
+    \lean{ChoiJamiolkowski.transposeLinearMapComplex_not_isCPMap}
+    \leanok
+    \uses{def:cp_map, def:flip_operator, def:fin_two_antisymm_vec,
+        thm:choi_transpose_flip, thm:cp_iff_choi_posSemidef}
+    If $D \ge 2$, the matrix transposition map $\theta(X)=X^T$ on $\MN{D}$
+    is not completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:flip_operator, def:fin_two_antisymm_vec, thm:choi_transpose_flip,
+        thm:cp_iff_choi_posSemidef}
+    If $\theta$ were completely positive, its Choi matrix would be positive
+    semidefinite. By Theorem~\ref{thm:choi_transpose_flip}, this Choi matrix is
+    $D^{-1}F$. For the antisymmetric vector
+    $v=\ket{01}-\ket{10}$,
+    \begin{align}
+        \bra{v}\,D^{-1}F\,\ket{v}
+         & =-\frac{2}{D}<0,
+        \notag
+    \end{align}
+    contradicting positive semidefiniteness.
 \end{proof}
 
 \section{Decomposable positive maps}

--- a/blueprint/src/chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall.tex
@@ -1,3 +1,120 @@
+\section{Elementary positive-map examples}
+
+The reduction map and the automorphisms of the positive semidefinite cone are
+basic structural examples of positive maps. The reduction map has a simple
+trace form and an explicit Choi matrix; the automorphisms preserve the order
+cone and map it onto itself.
+
+\subsection{The reduction map}
+
+\begin{definition}[Reduction map]
+    \label{def:reduction_map}
+    \lean{Matrix.reductionMap}
+    \leanok
+    The reduction map on $\MN{D}$, for $k\in\N$, is
+    \begin{align}
+        T_k(X)
+         & =\tr(X)\Id-k^{-1}X.
+        \label{eq:channel_reduction_map}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[The first reduction map is positive]
+    \label{thm:reduction_map_one_positive}
+    \lean{Matrix.reductionMap_one_isPositiveMap}
+    \leanok
+    \uses{def:positive_map, def:reduction_map}
+    For $D\ge 1$, the map $T_1(X)=\tr(X)\Id-X$ on $\MN{D}$ is positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $X\ge 0$, diagonalize $X$. Its eigenvalues
+    $\lambda_1,\ldots,\lambda_D$ are non-negative, and each satisfies
+    $\lambda_j\le \sum_{i=1}^D\lambda_i=\tr(X)$. Therefore all eigenvalues
+    of $\tr(X)\Id-X$ are non-negative.
+\end{proof}
+
+\begin{theorem}[Self-duality of the reduction map]
+    \label{thm:reduction_map_self_dual}
+    \lean{Matrix.traceAdjointMap_reductionMap}
+    \leanok
+    \uses{def:reduction_map}
+    The reduction map is self-dual for the trace pairing:
+    \begin{align}
+        \tr(T_k(\rho)X)
+         & =\tr(\rho T_k(X)).
+        \label{eq:channel_reduction_self_dual}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Expanding both sides of (\ref{eq:channel_reduction_self_dual}) using
+    (\ref{eq:channel_reduction_map}) and bilinearity of the trace gives
+    $\tr(\rho)\tr(X)-k^{-1}\tr(\rho X)$ in each case.
+\end{proof}
+
+\begin{theorem}[Choi matrix of the reduction map]
+    \label{thm:choi_matrix_reduction_map}
+    \lean{ChoiJamiolkowski.choiMatrix_reductionMap}
+    \leanok
+    \uses{def:reduction_map}
+    For $D\ge 1$, the Choi matrix of the reduction map is
+    \begin{align}
+        \tau(T_k)
+         & =D^{-1}\Id-k^{-1}\ket{\Omega}\bra{\Omega}.
+        \label{eq:channel_reduction_choi}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The trace term sends the $(a,b)$ slice of
+    $\ket{\Omega}\bra{\Omega}$ to its trace times the identity, giving
+    the contribution $D^{-1}\Id$. The second term is the Choi matrix of
+    $k^{-1}$ times the identity map, namely
+    $k^{-1}\ket{\Omega}\bra{\Omega}$.
+\end{proof}
+
+\subsection{Automorphisms of the positive semidefinite cone}
+
+Invertible conjugations, with or without transposition, do more than preserve
+positivity: they are surjective on the positive semidefinite cone.
+
+\begin{definition}[Maps preserving the positive semidefinite cone]
+    \label{def:maps_psd_cone_onto}
+    \lean{MapsPSDConeOnto}
+    \leanok
+    \uses{def:positive_map}
+    A linear map $T:\MN{D}\to\MN{D}$ \emph{maps the positive semidefinite cone
+        onto itself} if $T$ is positive and every positive semidefinite matrix is
+    the image under $T$ of a positive semidefinite matrix. This is condition
+    (1) of \cite[Proposition~3.8]{Wolf2012Quantum}.
+\end{definition}
+
+\begin{theorem}[Conjugations preserve the positive semidefinite cone]
+    \label{thm:conjugation_maps_psd_cone_onto}
+    \lean{unitaryConjLM_mapsPSDConeOnto,
+        unitaryConjLM_comp_transpose_mapsPSDConeOnto}
+    \leanok
+    \uses{def:maps_psd_cone_onto}
+    Let $Y\in\MN{D}$ be invertible. Then the map $X\mapsto YXY^\dagger$ and the
+    map $X\mapsto YX^TY^\dagger$ each map the positive semidefinite cone onto
+    itself. This is the implication (3) $\Rightarrow$ (1) of
+    \cite[Proposition~3.8]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Conjugation by any matrix preserves positive semidefiniteness. Moreover,
+    if $W=C^\dagger C$, then
+    $W^T=C^T\overline C=\overline C^\dagger\overline C\geq0$;
+    hence transposition also preserves positive semidefiniteness, and both maps
+    send the cone into itself. For surjectivity onto the cone, given
+    a positive semidefinite $A$, set
+    $W=Y^{-1}A(Y^{-1})^\dagger$, which is again positive semidefinite. Then
+    $YWY^\dagger=A$ proves the conjugation case, and
+    $Y(W^T)^TY^\dagger=A$ proves the transpose case, with $W$ and $W^T$
+    positive semidefinite.
+\end{proof}
+
 \section{Positivity hierarchy and two-positive maps}
 
 The following family exhibits the strict hierarchy of positivity conditions
@@ -19,7 +136,7 @@ adjacent cones.
     \leanok
     For a real parameter $\eta$, the map $T_\eta$ on $\MN{D}$ is
     \begin{align}
-        T_\eta(\rho)&=\tr(\rho) \Id-\eta^{-1}\rho.
+        T_\eta(\rho) & =\tr(\rho) \Id-\eta^{-1}\rho.
         \notag
     \end{align}
     The map is defined for every real $\eta$; at $\eta=0$ it reduces to
@@ -34,7 +151,7 @@ adjacent cones.
     \uses{def:t_eta, thm:choi_matrix_reduction_map}
     For $D\ge 1$, the Choi matrix of $T_\eta$ is
     \begin{align}
-        \tau_\eta&=D^{-1}\Id-\eta^{-1}\ket{\Omega}\bra{\Omega}.
+        \tau_\eta & =D^{-1}\Id-\eta^{-1}\ket{\Omega}\bra{\Omega}.
         \notag
     \end{align}
 \end{theorem}
@@ -70,7 +187,7 @@ adjacent cones.
     normalized such vector $\psi$, the Choi matrix
     $\tau_\eta=D^{-1}\Id-\eta^{-1}\ket{\Omega}\bra{\Omega}$ gives
     $\bra{\psi}\tau_\eta\ket{\psi}
-    =D^{-1}-\eta^{-1}|\braket{\Omega}{\psi}|^2$.
+        =D^{-1}-\eta^{-1}|\braket{\Omega}{\psi}|^2$.
     The reduced density of $\ket\Omega$ on the first factor is $\Id/D$, so by the
     maximal-overlap principle the supremum of $|\braket{\Omega}{\psi}|^2$ over
     Schmidt-rank-$k$ normalized vectors is $\|\Id/D\|_{(k)}=k/D$. The infimum of
@@ -127,7 +244,7 @@ adjacent cones.
     Let $K=(K_i)_{i=0}^{d-1}$ be a unital Kraus family, that is,
     $\sum_i K_i K_i^\dagger=\Id$. Then for all $X\in\MN{D}$,
     $\mathcal{K}(X^\dagger X)\ge
-    \mathcal{K}(X)^\dagger\mathcal{K}(X)$,
+        \mathcal{K}(X)^\dagger\mathcal{K}(X)$,
     where $\mathcal{K}(Y)=\sum_i K_i Y K_i^\dagger$.
 \end{theorem}
 
@@ -208,7 +325,7 @@ of a bipartite state whose Schmidt number is at most $n$.
     \leanok
     The reduction witness on $\MN{D}\otimes\MN{D}$, for $n\in\N$, is
     \begin{align}
-        W_n&=D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}.
+        W_n & =D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}.
         \notag
     \end{align}
 \end{definition}
@@ -221,7 +338,7 @@ of a bipartite state whose Schmidt number is at most $n$.
         thm:choi_matrix_t_eta}
     For $D\ge 1$ the Choi matrix of $T_n$ is the reduction witness:
     \begin{align}
-        \tau(T_n)&=W_n=D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}.
+        \tau(T_n) & =W_n=D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}.
         \notag
     \end{align}
 \end{theorem}
@@ -239,7 +356,7 @@ of a bipartite state whose Schmidt number is at most $n$.
     \uses{def:t_eta}
     Applying $T_\eta$ to the first factor of a bipartite matrix $\rho$ gives
     \begin{align}
-        (T_\eta\otimes\id)(\rho)&=\Id\otimes\rho_2-\eta^{-1}\rho,
+        (T_\eta\otimes\id)(\rho) & =\Id\otimes\rho_2-\eta^{-1}\rho,
         \notag
     \end{align}
     where $\rho_2$ is the reduced density of $\rho$ on the second factor.
@@ -252,18 +369,18 @@ of a bipartite state whose Schmidt number is at most $n$.
     on the first factor. Its trace is the corresponding entry of $\rho_2$:
     \begin{align}
         \tr(\rho^{(i_2,j_2)})
-        &=\sum_{i_1}\rho_{(i_1,i_2),(i_1,j_2)}
-          =(\rho_2)_{i_2 j_2}.
+         & =\sum_{i_1}\rho_{(i_1,i_2),(i_1,j_2)}
+        =(\rho_2)_{i_2 j_2}.
         \notag
     \end{align}
     Applying $T_\eta$ entry by entry gives
     \begin{align}
         ((T_\eta\otimes\id)(\rho))_{(i_1,i_2),(j_1,j_2)}
-        &=\tr(\rho^{(i_2,j_2)}) \delta_{i_1 j_1}
-            -\eta^{-1}\rho_{(i_1,i_2),(j_1,j_2)}
-        \notag\\
-        &=(\rho_2)_{i_2 j_2} \delta_{i_1 j_1}
-            -\eta^{-1}\rho_{(i_1,i_2),(j_1,j_2)},
+         & =\tr(\rho^{(i_2,j_2)}) \delta_{i_1 j_1}
+        -\eta^{-1}\rho_{(i_1,i_2),(j_1,j_2)}
+        \notag                                     \\
+         & =(\rho_2)_{i_2 j_2} \delta_{i_1 j_1}
+        -\eta^{-1}\rho_{(i_1,i_2),(j_1,j_2)},
         \notag
     \end{align}
     and the first term is exactly the $(i_1,i_2),(j_1,j_2)$ entry of
@@ -284,7 +401,7 @@ of a bipartite state whose Schmidt number is at most $n$.
     densities of $\rho$ on the first and second factors. Because the factor
     swap is a unitary reindexing,
     $(\id\otimes T_n)(\rho)\ge0
-    \iff(T_n\otimes\id)(\rho^{F})\ge0$, so the second hypothesis is Wolf's
+        \iff(T_n\otimes\id)(\rho^{F})\ge0$, so the second hypothesis is Wolf's
     symmetric condition
     $(\id\otimes T_n)(\rho)\ge0$ expressed through the swap.
 
@@ -308,7 +425,7 @@ of a bipartite state whose Schmidt number is at most $n$.
     the order, and it exchanges the reduced densities and the two tensor slots:
     $(\rho^{F})_2=\rho_1$ and
     $(\Id\otimes(\rho^{F})_2-n^{-1}\rho^{F})^{F}
-    =\rho_1\otimes\Id-n^{-1}\rho$.
+        =\rho_1\otimes\Id-n^{-1}\rho$.
     Applying the first form to $\rho^{F}$ gives
     $n\,\Id\otimes(\rho^{F})_2-\rho^{F}\ge0$; conjugating by $F$ turns this into
     $n\,\rho_1\otimes\Id-\rho\ge0$.
@@ -330,7 +447,7 @@ fails to be completely positive, are not treated here.
     \leanok
     For a matrix $U$ on $\MN{D}$, the Breuer--Hall map on $\MN{D}$ is
     \begin{align}
-        T_{\mathrm{BH}}(X)&=\tr(X) \Id-X-U\,X^{\mathsf T}U^{\dagger}.
+        T_{\mathrm{BH}}(X) & =\tr(X) \Id-X-U\,X^{\mathsf T}U^{\dagger}.
         \notag
     \end{align}
 \end{definition}
@@ -352,30 +469,30 @@ fails to be completely positive, are not treated here.
     On $\ket{v}\bra{v}$ the image is
     \begin{align}
         T_{\mathrm{BH}}(\ket{v}\bra{v})
-        &=\lVert v\rVert^{2} \Id-\ket{v}\bra{v}
-          -\ket{U\overline{v}}\bra{U\overline{v}},
+         & =\lVert v\rVert^{2} \Id-\ket{v}\bra{v}
+        -\ket{U\overline{v}}\bra{U\overline{v}},
         \notag
     \end{align}
     with $\overline{v}$ the entrywise conjugate of $v$. The two vectors $v$ and
     $U\overline{v}$ are orthogonal: antisymmetry of $U$ gives
     \begin{align}
         \braket{v}{U\overline{v}}
-        &=\overline{v}^{\,\mathsf T}U\,\overline{v}
-          =\overline{v}^{\,\mathsf T}(-U^{\mathsf T})\overline{v}
-          =-\braket{v}{U\overline{v}},
+         & =\overline{v}^{\,\mathsf T}U\,\overline{v}
+        =\overline{v}^{\,\mathsf T}(-U^{\mathsf T})\overline{v}
+        =-\braket{v}{U\overline{v}},
         \notag
     \end{align}
     hence $\braket{v}{U\overline{v}}=0$. The contraction bound gives
     $\lVert U\overline{v}\rVert\le\lVert v\rVert$. For any
     $w$ the quadratic form is
     $\lVert v\rVert^{2}\lVert w\rVert^{2}
-    -\lvert\braket{v}{w}\rvert^{2}
-    -\lvert\braket{U\overline{v}}{w}\rvert^{2}$,
+        -\lvert\braket{v}{w}\rvert^{2}
+        -\lvert\braket{U\overline{v}}{w}\rvert^{2}$,
     which is non-negative because the two-vector Bessel inequality for the
     orthogonal pair $v$, $U\overline{v}$ with
     $\lVert U\overline{v}\rVert\le\lVert v\rVert$ gives
     $\lvert\braket{v}{w}\rvert^{2} +\lvert\braket{U\overline{v}}{w}\rvert^{2}
-    \le\lVert v\rVert^{2}\lVert w\rVert^{2}$.
+        \le\lVert v\rVert^{2}\lVert w\rVert^{2}$.
 \end{proof}
 
 \begin{theorem}[The Breuer--Hall map is positive]


### PR DESCRIPTION
## What changed

- moves the reduction map, its positivity and self-duality, and its Choi matrix from Chapter 4 to Chapter 25 before the `T_\eta` hierarchy that consumes them
- moves transposition positivity/trace preservation and the transposition-not-CP example into Chapter 25 before decomposable maps
- moves the positive-semidefinite-cone automorphism definition and conjugation theorem into Chapter 25
- replaces Chapter 4's “Additional results” heading with a descriptive title for the material that remains there
- preserves all theorem labels, Lean tags, equations, proofs, and source attributions; routers are unchanged

This is the second narrow step in the Chapter 4 ownership cleanup. Ky Fan, Lorentz, normalization, and two-positive material are intentionally deferred to later atomic moves.

## Validation

- `latexindent -w -s -l=blueprint/latexindent.yaml` on all touched files
- moved labels and Lean tags occur exactly once
- zero duplicate labels and zero missing routed `\ref` / `\uses` targets
- reader-facing prose check passed
- blueprint/Lean synchronization passed
- full blueprint: direct LuaLaTeX twice, 693 pages, zero undefined cross-references
- focused blueprint: direct LuaLaTeX twice, 204 pages, zero undefined cross-references
- independent review found one minor ordering issue in the cone-automorphism proof; the proof was made self-contained before push by deriving positivity of the transpose from a factorization `W=C^\dagger C`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint reshuffle with preserved cross-references and labels; no Lean or runtime code changes.
> 
> **Overview**
> **Chapter 4** drops the “additional results” block (reduction map, transposition, PSD-cone automorphisms) and retitles the section to match what stays: rectangular maps, trace normalization, matrix inequalities, Ky Fan, and density matrices.
> 
> **Chapter 25** gains that material in reader order: a new **Elementary positive-map examples** section (reduction map + cone automorphisms) ahead of the `T_\eta` / reduction-criterion thread; a **Transposition** section before decomposable maps; plus short intro prose tying each block to what follows. Labels, Lean tags, and proofs are unchanged aside from the conjugation proof, which now derives transpose positivity from `W=C^\dagger C` so it does not depend on material moved out of Chapter 4.
> 
> Touched Choi-type and Breuer–Hall files only get **latexindent** alignment on `align`/`&` lines—no mathematical edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 048e2c066a818c704095d88f511d4916f535dddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->