### PR TITLE
fix(tenkz): align cup closures with the picture frame

### DIFF
--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2402,21 +2402,35 @@
               \l__tenkz_kernel_r_row_tl
             \__tenkz_model_get:nnN {#1} {bottom}
               \l__tenkz_kernel_r_col_tl
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_row_tl } {1}
+              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_col_tl } {1}
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \__tenkz_render_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
-                  {1} {-\l__tenkz_kernel_r_row_tl}
+                  { \l__tenkz_kernel_r_x_fp }
+                  { \l__tenkz_kernel_r_y_fp }
                 .. controls
                   \__tenkz_kernel_r_pair:nn
-                    {1 - \__tenkz_metric_ratio:n {stub}}
-                    {-\l__tenkz_kernel_r_row_tl}
+                    {
+                      \l__tenkz_kernel_r_x_fp
+                      - \__tenkz_metric_ratio:n {stub}
+                    }
+                    { \l__tenkz_kernel_r_y_fp }
                   and
                   \__tenkz_kernel_r_pair:nn
-                    {1 - \__tenkz_metric_ratio:n {stub}}
-                    {-\l__tenkz_kernel_r_col_tl}
+                    {
+                      \l__tenkz_kernel_r_xb_fp
+                      - \__tenkz_metric_ratio:n {stub}
+                    }
+                    { \l__tenkz_kernel_r_yb_fp }
                 ..
                 \__tenkz_kernel_r_pair:nn
-                  {1} {-\l__tenkz_kernel_r_col_tl}
+                  { \l__tenkz_kernel_r_xb_fp }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
         {east}
@@ -2425,29 +2439,37 @@
               \l__tenkz_kernel_r_row_tl
             \__tenkz_model_get:nnN {#1} {bottom}
               \l__tenkz_kernel_r_col_tl
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_row_tl }
+              { \l__tenkz_kernel_r_cols_int }
+              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_col_tl }
+              { \l__tenkz_kernel_r_cols_int }
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \__tenkz_render_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
-                  {\l__tenkz_kernel_r_cols_int}
-                  {-\l__tenkz_kernel_r_row_tl}
+                  { \l__tenkz_kernel_r_x_fp }
+                  { \l__tenkz_kernel_r_y_fp }
                 .. controls
                   \__tenkz_kernel_r_pair:nn
                     {
-                      \l__tenkz_kernel_r_cols_int
+                      \l__tenkz_kernel_r_x_fp
                       + \__tenkz_metric_ratio:n {stub}
                     }
-                    {-\l__tenkz_kernel_r_row_tl}
+                    { \l__tenkz_kernel_r_y_fp }
                   and
                   \__tenkz_kernel_r_pair:nn
                     {
-                      \l__tenkz_kernel_r_cols_int
+                      \l__tenkz_kernel_r_xb_fp
                       + \__tenkz_metric_ratio:n {stub}
                     }
-                    {-\l__tenkz_kernel_r_col_tl}
+                    { \l__tenkz_kernel_r_yb_fp }
                 ..
                 \__tenkz_kernel_r_pair:nn
-                  {\l__tenkz_kernel_r_cols_int}
-                  {-\l__tenkz_kernel_r_col_tl}
+                  { \l__tenkz_kernel_r_xb_fp }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
         {north}
@@ -2456,21 +2478,35 @@
               \l__tenkz_kernel_r_row_tl
             \__tenkz_model_get:nnN {#1} {right}
               \l__tenkz_kernel_r_col_tl
+            \__tenkz_kernel_r_frame_xy:nnNN
+              {1} { \l__tenkz_kernel_r_row_tl }
+              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \__tenkz_kernel_r_frame_xy:nnNN
+              {1} { \l__tenkz_kernel_r_col_tl }
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \__tenkz_render_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
-                  {\l__tenkz_kernel_r_row_tl} {-1}
+                  { \l__tenkz_kernel_r_x_fp }
+                  { \l__tenkz_kernel_r_y_fp }
                 .. controls
                   \__tenkz_kernel_r_pair:nn
-                    {\l__tenkz_kernel_r_row_tl}
-                    {-1 + \__tenkz_metric_ratio:n {stub}}
+                    { \l__tenkz_kernel_r_x_fp }
+                    {
+                      \l__tenkz_kernel_r_y_fp
+                      + \__tenkz_metric_ratio:n {stub}
+                    }
                   and
                   \__tenkz_kernel_r_pair:nn
-                    {\l__tenkz_kernel_r_col_tl}
-                    {-1 + \__tenkz_metric_ratio:n {stub}}
+                    { \l__tenkz_kernel_r_xb_fp }
+                    {
+                      \l__tenkz_kernel_r_yb_fp
+                      + \__tenkz_metric_ratio:n {stub}
+                    }
                 ..
                 \__tenkz_kernel_r_pair:nn
-                  {\l__tenkz_kernel_r_col_tl} {-1}
+                  { \l__tenkz_kernel_r_xb_fp }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
         {south}
@@ -2479,29 +2515,37 @@
               \l__tenkz_kernel_r_row_tl
             \__tenkz_model_get:nnN {#1} {right}
               \l__tenkz_kernel_r_col_tl
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_rows_int }
+              { \l__tenkz_kernel_r_row_tl }
+              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \__tenkz_kernel_r_frame_xy:nnNN
+              { \l__tenkz_kernel_r_rows_int }
+              { \l__tenkz_kernel_r_col_tl }
+              \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
             \__tenkz_render_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
-                  {\l__tenkz_kernel_r_row_tl}
-                  {-\l__tenkz_kernel_r_rows_int}
+                  { \l__tenkz_kernel_r_x_fp }
+                  { \l__tenkz_kernel_r_y_fp }
                 .. controls
                   \__tenkz_kernel_r_pair:nn
-                    {\l__tenkz_kernel_r_row_tl}
+                    { \l__tenkz_kernel_r_x_fp }
                     {
-                      -\l__tenkz_kernel_r_rows_int
+                      \l__tenkz_kernel_r_y_fp
                       - \__tenkz_metric_ratio:n {stub}
                     }
                   and
                   \__tenkz_kernel_r_pair:nn
-                    {\l__tenkz_kernel_r_col_tl}
+                    { \l__tenkz_kernel_r_xb_fp }
                     {
-                      -\l__tenkz_kernel_r_rows_int
+                      \l__tenkz_kernel_r_yb_fp
                       - \__tenkz_metric_ratio:n {stub}
                     }
                 ..
                 \__tenkz_kernel_r_pair:nn
-                  {\l__tenkz_kernel_r_col_tl}
-                  {-\l__tenkz_kernel_r_rows_int}
+                  { \l__tenkz_kernel_r_xb_fp }
+                  { \l__tenkz_kernel_r_yb_fp }
               }
           }
       }


### PR DESCRIPTION
## Motivation

Cup closures were drawn one pitch east and one pitch south of their grid anchors. The landed renderer used raw `(column, -row)` coordinates, while the picture frame maps a cell to `(column - 1, 1 - row)`. The existing wire-only cup fixtures compiled successfully but did not contain visible cell anchors that could expose the displacement.

## Description

Resolve all west, east, north, and south cup endpoints through the declared picture frame before drawing them. The existing cubic half-ellipse construction and its outward `stub` reach are unchanged; only the endpoint and control-point coordinates now come from the resolved frame.

This changes one renderer file. It does not change records, language syntax, metrics, tracked fixtures, scripts, manifests, tools, or baselines.

## Testing

- Exact base: `0d1baddf47ce13bb558fca5fe845dfe769503819`
- Exact head: `b089085e5ea876b014b82c3d7d4ef8cbdd2836d3`
- `r_cup.tex` and `r_cup_both.tex` compile with XeLaTeX.
- `bash scripts/tenkz_kernel_probes.sh`
  - `PASS: forty-five review regressions hold`
  - `PASS: 8 sugar spellings byte-identical to their expansions`
  - `PASS: 7 kernel record streams byte-identical`
- `bash scripts/tenkz_golden.sh --check`
  - `PASS: 264 event streams byte-identical to the golden baseline`
- `git diff --check 0d1baddf47ce13bb558fca5fe845dfe769503819..b089085e5ea876b014b82c3d7d4ef8cbdd2836d3`

The visual check used the same temporary, untracked two-by-two picture with populated cells and cups on all four sides:

- Before: `/private/tmp/tnlean-cup-audit/main-700c/anchored-all-four.png`, `79.44 × 79.44 pt`; three cell dots sit northwest of the displaced cups and only the southeast dot meets a cup junction. SHA-256 `0911991ef9bf143d9bb3c5bfb28862f0a37acb8b7a0dfd5e895a209ac0844fc5`.
- After: `/private/tmp/tnlean-cup-audit/post4792/anchored-all-four.png`, `59.79 × 59.79 pt`; all four cell dots meet their cup junctions with symmetric outward bends. SHA-256 `8b15c97e89c1a4031297c8410de4c5a650e89a6a2e7ed2e4ec54f7cb63eea409`.

The visual source and rendered files remain untracked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file renderer coordinate fix with no model, syntax, or baseline changes; regression probes and golden streams are reported unchanged.
> 
> **Overview**
> **Cup boundary closures** were drawn with ad hoc `(column, -row)` coordinates while the rest of the kernel maps cells through the declared `kpic` frame (`column - 1`, `1 - row`), which shifted cups about one pitch east and south relative to their grid anchors.
> 
> This change routes **west, east, north, and south** cup endpoints and their `stub`-offset control points through `\__tenkz_kernel_r_frame_xy:nnNN` before `\__tenkz_render_stroke`. The half-ellipse path shape is unchanged; only the coordinate source matches trace wires and cell placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b089085e5ea876b014b82c3d7d4ef8cbdd2836d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->