### PR TITLE
fix(tenkz): diagnose missing physical trace glyph

### DIFF
--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1885,6 +1885,9 @@
 \msg_new:nnn {tenkz}{kernel-render-crossref}
   { [TKZ-KERNEL-RENDER-CROSSREF]~crossing~operand~'#1'~names~no~string~or~
     leg~of~this~picture }
+\msg_new:nnn {tenkz}{kernel-render-phtrace}
+  { [TKZ-KERNEL-RENDER-PHTRACE]~physical~trace~record~'#1'~has~no~rendered~
+    atom~at~row~1,~column~#2 }
 
 % variants this pass leans on; generation is idempotent where l3 already
 % ships the form
@@ -3488,24 +3491,39 @@
               { \tl_set:Nn \l__tenkz_kernel_r_tl {##1} }
           }
       }
-    \pgfextractx \l__tenkz_kernel_r_north_x_dim
-      { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{north} }
-    \pgfextracty \l__tenkz_kernel_r_north_y_dim
-      { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{north} }
-    \pgfextracty \l__tenkz_kernel_r_south_y_dim
-      { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{south} }
-    \pgfextractx \l__tenkz_kernel_r_east_x_dim
-      { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{east} }
-    \dim_add:Nn \l__tenkz_kernel_r_east_x_dim
-      { \__tenkz_dim:n {phtracereach} }
-    \__tenkz_render_stroke:nn { trace }
+    \bool_set_false:N \l_tmpa_bool
+    \quark_if_no_value:NF \l__tenkz_kernel_r_tl
       {
-        ( \l__tenkz_kernel_r_north_x_dim , \l__tenkz_kernel_r_north_y_dim )
-        -- ++( 0 , \__tenkz_dim:n {physleg} )
-        -| ( \l__tenkz_kernel_r_east_x_dim ,
-             \l__tenkz_kernel_r_south_y_dim - \__tenkz_dim:n {physleg} )
-        -| ( \l__tenkz_kernel_r_north_x_dim ,
-             \l__tenkz_kernel_r_south_y_dim )
+        \cs_if_exist:cT
+          { pgf@sh@ns@\tl_use:N \l__tenkz_kernel_r_tl }
+          { \bool_set_true:N \l_tmpa_bool }
+      }
+    \bool_if:NTF \l_tmpa_bool
+      {
+        \pgfextractx \l__tenkz_kernel_r_north_x_dim
+          { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{north} }
+        \pgfextracty \l__tenkz_kernel_r_north_y_dim
+          { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{north} }
+        \pgfextracty \l__tenkz_kernel_r_south_y_dim
+          { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{south} }
+        \pgfextractx \l__tenkz_kernel_r_east_x_dim
+          { \pgfpointanchor{\tl_use:N \l__tenkz_kernel_r_tl}{east} }
+        \dim_add:Nn \l__tenkz_kernel_r_east_x_dim
+          { \__tenkz_dim:n {phtracereach} }
+        \__tenkz_render_stroke:nn { trace }
+          {
+            ( \l__tenkz_kernel_r_north_x_dim ,
+              \l__tenkz_kernel_r_north_y_dim )
+            -- ++( 0 , \__tenkz_dim:n {physleg} )
+            -| ( \l__tenkz_kernel_r_east_x_dim ,
+                 \l__tenkz_kernel_r_south_y_dim - \__tenkz_dim:n {physleg} )
+            -| ( \l__tenkz_kernel_r_north_x_dim ,
+                 \l__tenkz_kernel_r_south_y_dim )
+          }
+      }
+      {
+        \msg_error:nnee {tenkz}{kernel-render-phtrace}
+          {#1} { \tl_use:N \l__tenkz_kernel_r_col_tl }
       }
   }
 \cs_new_protected:Npn \__tenkz_kernel_r_atom_ink:n #1


### PR DESCRIPTION
## Motivation

The one-row physical-trace renderer introduced in #4792 reads live TikZ
anchors from the atom occupying the traced cell.  The public `skin=none`
spelling claims that cell but deliberately draws no node, so the anchor query
fell through to an opaque PGF “No shape named” error.

## Description

- add the coded `TKZ-KERNEL-RENDER-PHTRACE` diagnostic
- verify that the resolved atom has a rendered TikZ shape before querying its
  north, south, and east anchors
- report the exact physical-trace record and logical cell when no rendered
  atom exists

The change is confined to `tex/tenkz/tenkz-kernel.code.tex`.  It changes no
language files, manifests, fixtures, probes, scripts, or golden baselines.

## Testing

Exact base: `20f6972805e0188723eae1a32414aa256a4075a8`

Exact head: `2807e6bfa5ad84a1f26c9279533a965c524b8ade`

- temporary `skin=none`, one-column `trace=physical` probe exits with
  `[TKZ-KERNEL-RENDER-PHTRACE] physical trace record 'wire-2' has no rendered
  atom at row 1, column 1`
- the same probe contains no low-level `No shape named` error
- temporary positive `wide=3` render remains 119.142 by 46.745 pt
- `scripts/tenkz_kernel_probes.sh`: 45 review regressions, 8 sugar spellings,
  and 7 kernel record streams pass
- `scripts/tenkz_golden.sh --check`: 264 event streams match the golden baseline
- `git diff --check`

The golden-tested `tex/tenkz`, `tests/tenkz`, and `scripts` subtrees at
`1076099970a40aa6f756e69837db7092012721de` are byte-identical at the exact
base; the intervening main change is outside those subtrees.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized render-path guard and diagnostic in tenkz-kernel; no auth, data, or API surface changes.
> 
> **Overview**
> One-row **physical trace** rendering used to query TikZ anchors on the atom in the traced cell even when that atom never placed a node (e.g. **`skin=none`**), which surfaced as an opaque PGF “No shape named” failure.
> 
> The kernel now adds **`TKZ-KERNEL-RENDER-PHTRACE`**, checks that the resolved row‑1 atom has a rendered shape (`pgf@sh@ns@…`) before reading **north/south/east**, and otherwise errors with the **trace record id** and **column**. Successful paths still draw the same trace stroke from those anchors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2807e6bfa5ad84a1f26c9279533a965c524b8ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->