### PR TITLE
refactor(blueprint): move Cesaro fixed points to Chapter 6

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch04_channels.tex
+++ b/blueprint/src/appendix/ft_mps/ch04_channels.tex
@@ -2,8 +2,8 @@
 \label{ch:channels_supporting_results}
 
 This appendix supports Chapter~\ref{ch:channels}. It collects the
-supporting results for complete positivity, density matrices, mean-ergodic
-projections, weighted traces, and idempotent retractions.
+supporting results for complete positivity, mean-ergodic projections,
+weighted traces, and idempotent retractions.
 
 \section{Kraus representations and complete positivity}
 
@@ -53,72 +53,6 @@ associated completely positive map between matrix $C^*$-algebras.
 Thus the Kraus formulation of Definition~\ref{def:cp_map} has the two
 consequences cited there: entrywise complete positivity and the associated
 abstract completely positive map.
-
-\section{Density matrices and the Ces\`aro construction}
-
-This section proves the compactness, convexity, nonemptiness, and invariance
-facts used in Theorem~\ref{thm:cesaro_fixedpoint}. Write $\mc{D}_D$ for the
-density matrices of Definition~\ref{def:density_matrices}; the Ces\`aro means
-$\sigma_N$ and their telescope identity remain in
-Definition~\ref{def:cesaro_mean} and Theorem~\ref{thm:cesaro_telescope}.
-
-\begin{theorem}[Density matrices are compact]\label{thm:density_compact}
-    \lean{densityMatrices_isCompact}
-    \leanok
-    \uses{def:density_matrices}
-    $\mc{D}_D$ is compact in the entrywise topology on $\MN{D}$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    The positive semidefinite cone is closed, being the preimage of the closed
-    non-negative cone under continuous quadratic forms. If $\rho \ge 0$ with
-    $\tr(\rho) = 1$, then each entry satisfies
-    $|\rho_{ij}|^2 \le \rho_{ii}\rho_{jj} \le 1$: the diagonal entries are
-    non-negative and sum to~$1$, and the off-diagonal bound is the positive
-    semidefinite Cauchy--Schwarz inequality. Hence the matrix entries are
-    uniformly bounded, and Heine--Borel gives compactness.
-\end{proof}
-
-\begin{theorem}[Density matrices are convex]\label{thm:density_convex}
-    \lean{densityMatrices_isConvex}
-    \leanok
-    \uses{def:density_matrices}
-    $\mc{D}_D$ is convex.
-\end{theorem}
-
-\begin{proof}\leanok
-    A convex combination of positive semidefinite matrices is positive
-    semidefinite, and the trace is linear.
-\end{proof}
-
-\begin{theorem}[Density matrices are nonempty]\label{thm:density_nonempty}
-    \lean{densityMatrices_nonempty}
-    \leanok
-    \uses{def:density_matrices}
-    For $D \ge 1$, $\mc{D}_D \neq \varnothing$.
-\end{theorem}
-
-\begin{proof}\leanok
-    $\frac{1}{D}\Id_D$ is a density matrix.
-\end{proof}
-
-\begin{theorem}[Channels preserve density matrices]\label{thm:channel_preserves_density}
-    \lean{IsChannel.map_densityMatrices}
-    \leanok
-    \uses{def:channel, def:density_matrices}
-    If $E$ is a quantum channel, then
-    $E(\mc{D}_D) \subseteq \mc{D}_D$.
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:cp_is_positive}
-    Complete positivity implies positivity by
-    Theorem~\ref{thm:cp_is_positive}, so $E(\rho) \ge 0$; trace preservation
-    gives $\tr(E(\rho)) = \tr(\rho) = 1$.
-\end{proof}
-
-Together these results keep the Ces\`aro orbit inside a compact nonempty set of
-density matrices, as required in Theorem~\ref{thm:cesaro_fixedpoint}.
 
 \section{Preservation under the mean-ergodic projection}
 

--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -1,0 +1,71 @@
+\chapter{Perron--Frobenius Theory for Channels and Transfer Maps: Supporting Results}
+\label{ch:qpf_supporting_results}
+
+This appendix supports Chapter~\ref{ch:qpf}. It proves the density-matrix
+properties used in the elementary channel fixed-point existence theorem.
+
+\section{Density matrices and the Ces\`aro construction}
+
+This section proves the compactness, convexity, nonemptiness, and invariance
+facts used in Theorem~\ref{thm:cesaro_fixedpoint}. Write $\mc{D}_D$ for the
+density matrices of Definition~\ref{def:density_matrices}; the Ces\`aro means
+$\sigma_N$ and their telescope identity remain in
+Definition~\ref{def:cesaro_mean} and Theorem~\ref{thm:cesaro_telescope}.
+
+\begin{theorem}[Density matrices are compact]\label{thm:density_compact}
+    \lean{densityMatrices_isCompact}
+    \leanok
+    \uses{def:density_matrices}
+    $\mc{D}_D$ is compact in the entrywise topology on $\MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The positive semidefinite cone is closed, being the preimage of the closed
+    non-negative cone under continuous quadratic forms. If $\rho \ge 0$ with
+    $\tr(\rho) = 1$, then each entry satisfies
+    $|\rho_{ij}|^2 \le \rho_{ii}\rho_{jj} \le 1$: the diagonal entries are
+    non-negative and sum to~$1$, and the off-diagonal bound is the positive
+    semidefinite Cauchy--Schwarz inequality. Hence the matrix entries are
+    uniformly bounded, and Heine--Borel gives compactness.
+\end{proof}
+
+\begin{theorem}[Density matrices are convex]\label{thm:density_convex}
+    \lean{densityMatrices_isConvex}
+    \leanok
+    \uses{def:density_matrices}
+    $\mc{D}_D$ is convex.
+\end{theorem}
+
+\begin{proof}\leanok
+    A convex combination of positive semidefinite matrices is positive
+    semidefinite, and the trace is linear.
+\end{proof}
+
+\begin{theorem}[Density matrices are nonempty]\label{thm:density_nonempty}
+    \lean{densityMatrices_nonempty}
+    \leanok
+    \uses{def:density_matrices}
+    For $D \ge 1$, $\mc{D}_D \neq \varnothing$.
+\end{theorem}
+
+\begin{proof}\leanok
+    $\frac{1}{D}\Id_D$ is a density matrix.
+\end{proof}
+
+\begin{theorem}[Channels preserve density matrices]\label{thm:channel_preserves_density}
+    \lean{IsChannel.map_densityMatrices}
+    \leanok
+    \uses{def:channel, def:density_matrices}
+    If $E$ is a quantum channel, then
+    $E(\mc{D}_D) \subseteq \mc{D}_D$.
+\end{theorem}
+
+\begin{proof}\leanok\uses{thm:cp_is_positive}
+    Complete positivity implies positivity by
+    Theorem~\ref{thm:cp_is_positive}, so $E(\rho) \ge 0$; trace preservation
+    gives $\tr(E(\rho)) = \tr(\rho) = 1$.
+\end{proof}
+
+Together these results keep the Ces\`aro orbit inside a compact nonempty set of
+density matrices, as required in Theorem~\ref{thm:cesaro_fixedpoint}.

--- a/blueprint/src/appendix/ft_mps_appendices.tex
+++ b/blueprint/src/appendix/ft_mps_appendices.tex
@@ -2,4 +2,5 @@
 \part{Appendices}
 \input{appendix/ft_mps/ch04_channels}
 \input{appendix/ft_mps/ch05_schwarz}
+\input{appendix/ft_mps/ch06_qpf}
 \input{appendix/ft_mps/ch07_spectral}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -6,6 +6,6 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \input{chapter/ch04_channels_positive_map_and_channel_foundations}
 \input{chapter/ch04_channels_choi_foundations}
 \input{chapter/ch04_channels_transfer_map_foundations}
-\input{chapter/ch04_channels_cesaro_and_mean_ergodic_theory}
+\input{chapter/ch04_channels_mean_ergodic_theory}
 \input{chapter/ch04_channels_peripheral_spectrum_and_primitivity}
 \input{chapter/ch04_channels_fixed_point_algebras}

--- a/blueprint/src/chapter/ch04_channels_mean_ergodic_theory.tex
+++ b/blueprint/src/chapter/ch04_channels_mean_ergodic_theory.tex
@@ -1,35 +1,4 @@
-\section{Ces\`aro fixed-point theorem}
-
-\begin{definition}[Ces\`aro mean]\label{def:cesaro_mean}
-    \lean{cesaroMean}
-    \leanok
-    The \emph{Ces\`aro mean} of a linear map $E$ at order $N$,
-    applied to a starting matrix $\rho_0$, is
-    \begin{align}
-        \sigma_N
-         & =\frac{1}{N}\sum_{n=0}^{N-1}E^n(\rho_0).
-        \label{eq:channel_cesaro_mean}
-    \end{align}
-\end{definition}
-
-\begin{theorem}[Ces\`aro telescope]\label{thm:cesaro_telescope}
-    \lean{cesaroMean_telescope}
-    \leanok
-    \uses{def:cesaro_mean}
-    The Ces\`aro mean satisfies
-    \begin{align}
-        E(\sigma_N)-\sigma_N
-         & =\frac{1}{N}(E^N(\rho_0)-\rho_0).
-        \label{eq:channel_cesaro_telescope}
-    \end{align}
-\end{theorem}
-
-\begin{proof}\leanok\uses{def:cesaro_mean}
-    Applying $E$ to (\ref{eq:channel_cesaro_mean}) gives
-    $E(\sigma_N)=N^{-1}\sum_{n=1}^{N}E^n(\rho_0)$.
-    Subtracting $\sigma_N$ cancels all but the first and last terms, yielding
-    (\ref{eq:channel_cesaro_telescope}).
-\end{proof}
+\section{Mean-ergodic theory and fixed-point structure}
 
 \begin{definition}[Bounded-orbit endomorphism]
     \label{def:has_bounded_orbits}
@@ -263,38 +232,4 @@
     coefficient annihilates the corresponding basis vector. Applying this to
     $P_++Y$ or $P_-+Y$ shows that $Y$ annihilates the entire eigenbasis.
     Thus $Y=0$, and consequently $E(P_\pm)=P_\pm$.
-\end{proof}
-
-\begin{theorem}[Ces\`aro fixed-point theorem]\label{thm:cesaro_fixedpoint}
-    \lean{IsChannel.exists_posSemidef_fixedPoint}
-    \leanok
-    \uses{def:channel, def:density_matrices, def:cesaro_mean}
-    Every quantum channel $E:\MN{D}\to\MN{D}$, with $D\geq1$, has a nonzero
-    positive semidefinite fixed point: there exists $\rho\geq0$, $\rho\neq0$,
-    with $E(\rho)=\rho$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:density_compact, thm:density_convex, thm:density_nonempty,
-        thm:channel_preserves_density, thm:cesaro_telescope}
-    Start with any $\rho_0\in\mc{D}_D$
-    (Theorem~\ref{thm:density_nonempty}).
-    By Theorem~\ref{thm:channel_preserves_density}, every iterate
-    $E^n(\rho_0)$ lies in $\mc{D}_D$. For $N\geq1$,
-    Theorem~\ref{thm:density_convex} therefore places the finite average
-    $\sigma_N$ in $\mc{D}_D$.
-    By compactness (Theorem~\ref{thm:density_compact}),
-    extract a convergent subsequence $\sigma_{N_k}\to\rho$.
-    The telescope identity (\ref{eq:channel_cesaro_telescope}) gives
-    \begin{align}
-        \lVert E(\sigma_N)-\sigma_N\rVert
-         & =\frac{1}{N}\lVert E^N(\rho_0)-\rho_0\rVert
-        \longrightarrow0,
-        \notag
-    \end{align}
-    so $E(\rho)=\rho$ by continuity.
-    In~\cite[Theorem~6.11]{Wolf2012Quantum}, existence is proved
-    via Brouwer's fixed-point theorem; we use the Ces\`aro
-    argument instead.
 \end{proof}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -1,8 +1,8 @@
 \chapter{Perron--Frobenius Theory for Channels and Transfer Maps}\label{ch:qpf}
 
-This chapter establishes the Perron--Frobenius theory:
-existence, positive definiteness, and uniqueness of
-fixed points for injective and irreducible transfer maps, canonical
+This chapter establishes elementary fixed-point existence for quantum channels
+and the Perron--Frobenius theory: existence, positive definiteness, and uniqueness
+of fixed points for injective and irreducible transfer maps, canonical
 gauge constructions, ergodicity of irreducible channels, the
 spectral-radius identification of Perron eigenvalues, and Wolf's
 spectral characterization of irreducibility.
@@ -28,6 +28,8 @@ and~\cite{Evans1978Spectral}.
     finite-dimensional real normed spaces. The density-matrix set is
     such a compact retract, using the explicit density retraction.
 \end{proof}
+
+\input{chapter/ch06_qpf_cesaro_fixed_points}
 
 \section{Positive definiteness}
 

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -1,0 +1,66 @@
+\section{Ces\`aro fixed points for quantum channels}
+
+\begin{definition}[Ces\`aro mean]\label{def:cesaro_mean}
+    \lean{cesaroMean}
+    \leanok
+    The \emph{Ces\`aro mean} of a linear map $E$ at order $N$,
+    applied to a starting matrix $\rho_0$, is
+    \begin{align}
+        \sigma_N
+         & =\frac{1}{N}\sum_{n=0}^{N-1}E^n(\rho_0).
+        \label{eq:channel_cesaro_mean}
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Ces\`aro telescope]\label{thm:cesaro_telescope}
+    \lean{cesaroMean_telescope}
+    \leanok
+    \uses{def:cesaro_mean}
+    The Ces\`aro mean satisfies
+    \begin{align}
+        E(\sigma_N)-\sigma_N
+         & =\frac{1}{N}(E^N(\rho_0)-\rho_0).
+        \label{eq:channel_cesaro_telescope}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok\uses{def:cesaro_mean}
+    Applying $E$ to (\ref{eq:channel_cesaro_mean}) gives
+    $E(\sigma_N)=N^{-1}\sum_{n=1}^{N}E^n(\rho_0)$.
+    Subtracting $\sigma_N$ cancels all but the first and last terms, yielding
+    (\ref{eq:channel_cesaro_telescope}).
+\end{proof}
+
+\begin{theorem}[Ces\`aro fixed-point theorem]\label{thm:cesaro_fixedpoint}
+    \lean{IsChannel.exists_posSemidef_fixedPoint}
+    \leanok
+    \uses{def:channel, def:density_matrices, def:cesaro_mean}
+    Every quantum channel $E:\MN{D}\to\MN{D}$, with $D\geq1$, has a nonzero
+    positive semidefinite fixed point: there exists $\rho\geq0$, $\rho\neq0$,
+    with $E(\rho)=\rho$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:density_compact, thm:density_convex, thm:density_nonempty,
+        thm:channel_preserves_density, thm:cesaro_telescope}
+    Start with any $\rho_0\in\mc{D}_D$
+    (Theorem~\ref{thm:density_nonempty}).
+    By Theorem~\ref{thm:channel_preserves_density}, every iterate
+    $E^n(\rho_0)$ lies in $\mc{D}_D$. For $N\geq1$,
+    Theorem~\ref{thm:density_convex} therefore places the finite average
+    $\sigma_N$ in $\mc{D}_D$.
+    By compactness (Theorem~\ref{thm:density_compact}),
+    extract a convergent subsequence $\sigma_{N_k}\to\rho$.
+    The telescope identity (\ref{eq:channel_cesaro_telescope}) gives
+    \begin{align}
+        \lVert E(\sigma_N)-\sigma_N\rVert
+         & =\frac{1}{N}\lVert E^N(\rho_0)-\rho_0\rVert
+        \longrightarrow0,
+        \notag
+    \end{align}
+    so $E(\rho)=\rho$ by continuity.
+    In~\cite[Theorem~6.11]{Wolf2012Quantum}, existence is proved
+    via Brouwer's fixed-point theorem; we use the Ces\`aro
+    argument instead.
+\end{proof}


### PR DESCRIPTION
## What changed

- moves the Cesàro mean, telescope identity, and elementary quantum-channel fixed-point theorem from Chapter 4 to Chapter 6, immediately after Brouwer's density-matrix fixed-point theorem
- leaves general mean-ergodic theory isolated in Chapter 4 for the planned full-only Chapter 27 move
- moves the complete four-result density-matrix support chain—compactness, convexity, nonemptiness, and channel invariance—from the Chapter 4 appendix to a new Chapter 6 supporting appendix
- routes the new appendix between Chapters 5 and 7, preserving the one-appendix/one-main-chapter ownership rule
- preserves every moved statement, proof, equation, label, Lean tag, dependency annotation, and source citation exactly once

## Validation

- byte-identical hashes verified for all three main-text blocks, the complete Chapter 4 remainder, and the four-result appendix chain
- no removed labels or metadata; the only new label is `ch:qpf_supporting_results`
- no duplicate labels, unresolved routed references or dependencies, or obsolete source paths
- blueprint/Lean synchronization passes: Chapter 4 mean-ergodic 18/18, Chapter 6 Cesàro 3/3, Chapter 6 appendix 4/4
- full blueprint: direct LuaLaTeX twice, 699 pages, zero undefined cross-references and zero duplicate labels
- focused blueprint: direct LuaLaTeX twice, 192 pages, zero undefined cross-references and zero duplicate labels
- all touched files are below 1000 lines; maximum 893
- independent mathematical review found no high-, medium-, or low-priority findings
- whitespace and reader-facing prose checks pass

No Lean code changes are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/blueprint structure only; no Lean or runtime code. Cross-reference risk is low if builds already pass as described in the PR.
> 
> **Overview**
> **Reorganizes the blueprint** so elementary quantum-channel fixed-point material lives with Chapter 6 (Perron–Frobenius) instead of Chapter 4 (channels).
> 
> The **Cesàro mean**, **telescope identity**, and **Cesàro fixed-point theorem** move out of `ch04_channels_mean_ergodic_theory.tex` into a new `ch06_qpf_cesaro_fixed_points.tex`, placed in Chapter 6 right after Brouwer on density matrices. Chapter 4’s mean-ergodic input is renamed to `ch04_channels_mean_ergodic_theory.tex` and keeps only general mean-ergodic theory (no Cesàro fixed-point block).
> 
> The **four density-matrix appendix lemmas** (compactness, convexity, nonemptiness, channel invariance) move from the Chapter 4 appendix to a new **`ch06_qpf`** supporting appendix (`ch:qpf_supporting_results`), wired in `ft_mps_appendices.tex` between chapters 5 and 7. Chapter 4’s appendix intro drops density-matrix/Cesàro wording; Chapter 6’s intro now mentions elementary channel fixed-point existence.
> 
> Moved statements, labels, Lean tags, and proofs are **unchanged in content**—only location and `\input` routing change. No Lean code in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e57be144662627ad4e1bfb608870eecb23ae07b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->