### PR TITLE
refactor(SectorBNT): extract shared hDim/hGPE dichotomy tail

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/MatchAux.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/MatchAux.lean
@@ -20,19 +20,16 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- If the overlap of two irreducible normalized BNT blocks does not decay,
-then the left MPV state is an exact scalar multiple of the right MPV state at
-every length. -/
-lemma exists_state_scalar_of_nondecaying_overlap
+/-- Equal bond dimension and gauge-phase equivalence from a non-decaying overlap:
+the two irreducible-TP overlap dichotomies, applied by contradiction. -/
+lemma dim_and_gaugePhase_of_nondecaying_overlap
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
     {j : Fin P.basisCount} {k : Fin Q.basisCount}
     (hnd : ¬ Tendsto (fun N : ℕ =>
       mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0)) :
-    ∃ α : ℕ → ℂ, ∀ N : ℕ,
-      mpvState (d := d) (P.basis j) N =
-        α N • mpvState (d := d) (Q.basis k) N := by
-  classical
+    ∃ h : P.basisDim j = Q.basisDim k,
+      GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis j)) (Q.basis k) := by
   haveI hjdim : NeZero (P.basisDim j) := ⟨(hP.basis_dim_pos j).ne'⟩
   haveI hkdim : NeZero (Q.basisDim k) := ⟨(hQ.basis_dim_pos k).ne'⟩
   have hDim : P.basisDim j = Q.basisDim k := by
@@ -55,6 +52,22 @@ lemma exists_state_scalar_of_nondecaying_overlap
         (hA_norm := hP.basis_left_canonical j)
         (hB_norm := hQ.basis_left_canonical k)
         (hNot := hNot)
+  exact ⟨hDim, hGPE⟩
+
+/-- If the overlap of two irreducible normalized BNT blocks does not decay,
+then the left MPV state is an exact scalar multiple of the right MPV state at
+every length. -/
+lemma exists_state_scalar_of_nondecaying_overlap
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
+    {j : Fin P.basisCount} {k : Fin Q.basisCount}
+    (hnd : ¬ Tendsto (fun N : ℕ =>
+      mpvOverlap (d := d) (P.basis j) (Q.basis k) N) atTop (𝓝 0)) :
+    ∃ α : ℕ → ℂ, ∀ N : ℕ,
+      mpvState (d := d) (P.basis j) N =
+        α N • mpvState (d := d) (Q.basis k) N := by
+  classical
+  obtain ⟨hDim, hGPE⟩ := dim_and_gaugePhase_of_nondecaying_overlap hP hQ hnd
   obtain ⟨X, ζ, hζ, hConj⟩ := hGPE
   refine ⟨fun N : ℕ => (ζ ^ N)⁻¹, ?_⟩
   intro N

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -258,28 +258,7 @@ theorem exists_block_match_exact_of_eventuallyProportional
   classical
   obtain ⟨k₀, hk₀⟩ := exists_nondecaying_overlap_exact_of_eventuallyProportional
     (P := P) (Q := Q) hP hQ j₀ hProp
-  haveI hj₀dim : NeZero (P.basisDim j₀) := ⟨(hP.basis_dim_pos j₀).ne'⟩
-  haveI hk₀dim : NeZero (Q.basisDim k₀) := ⟨(hQ.basis_dim_pos k₀).ne'⟩
-  have hDim : P.basisDim j₀ = Q.basisDim k₀ := by
-    by_contra hne
-    exact hk₀ <|
-      mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP
-        (P.basis j₀) (Q.basis k₀)
-        (hP.basis_irreducible j₀) (hQ.basis_irreducible k₀)
-        (hP.basis_left_canonical j₀) (hQ.basis_left_canonical k₀)
-        hne
-  have hGPE :
-      GaugePhaseEquiv
-        (cast (congr_arg (MPSTensor d) hDim) (P.basis j₀)) (Q.basis k₀) := by
-    by_contra hNot
-    exact hk₀ <|
-      mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP
-        (hdim := hDim) (A := P.basis j₀) (B := Q.basis k₀)
-        (hA_irr := hP.basis_irreducible j₀)
-        (hB_irr := hQ.basis_irreducible k₀)
-        (hA_norm := hP.basis_left_canonical j₀)
-        (hB_norm := hQ.basis_left_canonical k₀)
-        (hNot := hNot)
+  obtain ⟨hDim, hGPE⟩ := dim_and_gaugePhase_of_nondecaying_overlap hP hQ hk₀
   exact ⟨k₀, hDim, hGPE, hk₀⟩
 
 /-! ### Full-basis proportional matching (Q → P direction)

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -80,6 +80,21 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Non-decaying-overlap dimension and gauge-phase dichotomy
+- **Pattern:** The `hDim`/`hGPE` tails of
+  `exists_state_scalar_of_nondecaying_overlap` (`MatchAux.lean`) and
+  `exists_block_match_exact_of_eventuallyProportional`
+  (`ProportionalMatch/Core.lean`) each re-ran the same two by-contradiction
+  applications of the irreducible-TP overlap dichotomies
+  (`mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP` and
+  `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`),
+  about 22 lines verbatim in both files.
+- **Reuse:** Both proofs now obtain `⟨hDim, hGPE⟩` from
+  `dim_and_gaugePhase_of_nondecaying_overlap` in `SectorBNT/MatchAux.lean`,
+  with the two `NeZero` instances moved inside the shared lemma.
+- **Result:** 2 files changed, 22 insertions against 30 deletions (8 lines
+  net). All public theorem statements and blueprint links are unchanged.
+
 ### Exact-sector matching through the proportional core
 - **Pattern:** The equal-MPV sector matcher repeated the eventually-proportional
   matcher's fixed-length linear-independence and coefficient-comparison proof


### PR DESCRIPTION
## Summary

Carries out #4804, the residual #4521 duplication that #4781 explicitly deferred: `exists_block_match_exact_of_eventuallyProportional` (`ProportionalMatch/Core.lean`) and `exists_state_scalar_of_nondecaying_overlap` (`MatchAux.lean`) shared a ~22-line tail — given a non-decaying overlap between two irreducible, normalized BNT blocks, prove equal bond dimension via `mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP` and gauge-phase equivalence via `mpvOverlap_tendsto_zero_of_not_gaugePhaseEquiv_cast_left_of_irreducible_TP`, both by contradiction.

- New shared lemma `MPSTensor.dim_and_gaugePhase_of_nondecaying_overlap` in `MatchAux.lean`, returning `∃ h : P.basisDim j = Q.basisDim k, GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis j)) (Q.basis k)`; the two `NeZero` instances move inside it.
- Both callers now `obtain ⟨hDim, hGPE⟩` from it. All public declaration names and statements are byte-identical (verified against `origin/main`), so blueprint `\\lean{}` tags and downstream consumers are unaffected.
- Net **−8 lines** (+22/−30). Ledger entry added to `docs/tactic_patterns.md` per the completed-refactors convention.

## Validation

- `lake build` green: 9740 jobs
- `blueprint_lean_sync.py --update-lean-decls` + `leanblueprint checkdecls`: exit 0, zero misses
- `blueprint_lean_sync.py --ci`: in sync
- `lake exe lint_style`: exit 0; `git diff --check` clean; no sorry/axiom

Closes #4804. Advances #4521.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only deduplication with unchanged public APIs; no runtime or security impact.
> 
> **Overview**
> Pulls a duplicated ~22-line proof fragment into **`dim_and_gaugePhase_of_nondecaying_overlap`** in `MatchAux.lean`. From a non-decaying overlap between two irreducible BNT blocks, that lemma derives equal bond dimension and gauge-phase equivalence via the two irreducible-TP overlap dichotomies (by contradiction).
> 
> **`exists_state_scalar_of_nondecaying_overlap`** and **`exists_block_match_exact_of_eventuallyProportional`** now `obtain ⟨hDim, hGPE⟩` from the shared lemma instead of inlining the same argument; the two `NeZero` instances live inside the new lemma. Public theorem names and statements are unchanged. **`docs/tactic_patterns.md`** records the completed refactor (−8 lines net).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d63864c08329780e4fc2071084c860302c22a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->