### PR TITLE
Expand Chapter 6 supporting results

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch06_qpf.tex
+++ b/blueprint/src/appendix/ft_mps/ch06_qpf.tex
@@ -1,16 +1,15 @@
 \chapter{Perron--Frobenius Theory for Channels and Transfer Maps: Supporting Results}
 \label{ch:qpf_supporting_results}
 
-This appendix supports Chapter~\ref{ch:qpf}. It proves the density-matrix
-properties used in the elementary channel fixed-point existence theorem.
+This appendix supplies the compactness, gauge, similarity, and finite-sum
+calculations used in Chapter~\ref{ch:qpf}.
 
-\section{Density matrices and the Ces\`aro construction}
+\section{Density matrices, Brouwer's theorem, and Ces\`aro limits}
+\label{sec:app_qpf_density}
 
-This section proves the compactness, convexity, nonemptiness, and invariance
-facts used in Theorem~\ref{thm:cesaro_fixedpoint}. Write $\mc{D}_D$ for the
-density matrices of Definition~\ref{def:density_matrices}; the Ces\`aro means
-$\sigma_N$ and their telescope identity remain in
-Definition~\ref{def:cesaro_mean} and Theorem~\ref{thm:cesaro_telescope}.
+Write $\mc{D}_D$ for the density matrices of
+Definition~\ref{def:density_matrices}. The next results provide the compact
+convex domain and the limit argument used for channel fixed points.
 
 \begin{theorem}[Density matrices are compact]\label{thm:density_compact}
     \lean{densityMatrices_isCompact}
@@ -67,5 +66,259 @@ Definition~\ref{def:cesaro_mean} and Theorem~\ref{thm:cesaro_telescope}.
     gives $\tr(E(\rho)) = \tr(\rho) = 1$.
 \end{proof}
 
-Together these results keep the Ces\`aro orbit inside a compact nonempty set of
-density matrices, as required in Theorem~\ref{thm:cesaro_fixedpoint}.
+\begin{theorem}[Brouwer fixed point on density matrices]%
+    \label{thm:brouwer_density_matrices}
+    \lean{brouwer_fixedPoint_densityMatrices}
+    \lean{fixedPoint_of_compact_retract, fixedPoint_of_compact_retract_fin}
+    \lean{exists_fixedPoint_closedCube, exists_fixedPoint_unitCube}
+    \leanok
+    \uses{def:density_matrices, thm:density_compact}
+    Let $D > 0$. Every continuous map from the compact convex set of
+    density matrices in $\MN{D}$ to itself has a fixed point.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The proof starts from Brouwer's theorem for products of simplices,
+    transfers it to closed cubes, and then to compact retracts of
+    finite-dimensional real normed spaces. The density-matrix set is
+    such a compact retract, using the explicit density retraction.
+\end{proof}
+
+\begin{lemma}[Ces\`aro means remain density matrices]
+    \label{lem:cesaro_mean_density}
+    \lean{IsChannel.cesaroMean_mem_densityMatrices}
+    \leanok
+    \uses{def:cesaro_mean, thm:channel_preserves_density, thm:density_convex}
+    Let $E$ be a quantum channel and $\rho\in\mc{D}_D$. Then, for every
+    $N\geq0$,
+    \begin{align}
+        \frac{1}{N+1}\sum_{n=0}^{N}E^n(\rho)
+         & \in\mc{D}_D.
+        \label{eq:qpf_cesaro_density}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Every iterate $E^n(\rho)$ belongs to $\mc{D}_D$ by
+    Theorem~\ref{thm:channel_preserves_density}. Equation
+    (\ref{eq:qpf_cesaro_density}) is their convex average: positivity is
+    preserved by sums and multiplication by $(N+1)^{-1}$, while its trace is
+    $(N+1)^{-1}\sum_{n=0}^{N}1=1$.
+\end{proof}
+
+\begin{lemma}[Subsequential Ces\`aro limits are fixed points]
+    \label{lem:cesaro_subseq_fixed}
+    \lean{IsChannel.cesaroMean_subseq_limit_fixedPoint}
+    \leanok
+    \uses{lem:cesaro_mean_density, thm:density_compact,
+        thm:cesaro_telescope}
+    Let $E$ be a quantum channel, $\rho\in\mc{D}_D$, and
+    $\psi:\N\to\N$ satisfy $\psi(k)\to\infty$. If
+    \begin{align}
+        \frac{1}{\psi(k)+1}\sum_{n=0}^{\psi(k)}E^n(\rho)
+         & \longrightarrow\sigma,
+        \notag
+    \end{align}
+    then $\sigma\in\mc{D}_D$ and $E(\sigma)=\sigma$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Lemma~\ref{lem:cesaro_mean_density} and closedness of the compact set
+    $\mc{D}_D$ give $\sigma\in\mc{D}_D$. The telescope identity yields
+    \begin{align}
+        E(\sigma_{\psi(k)+1})-\sigma_{\psi(k)+1}
+         & =\frac{E^{\psi(k)+1}(\rho)-\rho}{\psi(k)+1}.
+        \notag
+    \end{align}
+    Both $E^{\psi(k)+1}(\rho)$ and $\rho$ lie in the compact set
+    $\mc{D}_D$, so their difference is uniformly bounded. The right-hand
+    side tends to zero. Continuity of $E$ and convergence of the subsequence
+    therefore give $E(\sigma)-\sigma=0$.
+\end{proof}
+
+\section{Canonical-gauge algebra}
+\label{sec:app_qpf_gauge}
+
+For the right-canonical gauge in
+Theorem~\ref{thm:right_canonical_gauge}, each summand becomes
+\begin{align}
+    (S^{-1}A^iS)(S^{-1}A^iS)^\dagger
+     & =S^{-1}A^iSS^\dagger(A^i)^\dagger(S^\dagger)^{-1}
+    \notag                                               \\
+     & =S^{-1}A^i\rho(A^i)^\dagger(S^\dagger)^{-1}.
+    \notag
+\end{align}
+Hence
+\begin{align}
+    \sum_iA'^i(A'^i)^\dagger
+     & =S^{-1}\E_A(\rho)(S^\dagger)^{-1}
+    =S^{-1}\rho(S^\dagger)^{-1}
+    =\Id.
+    \notag
+\end{align}
+For the left-canonical gauge in Theorem~\ref{thm:left_canonical_gauge},
+\begin{align}
+    (SA^iS^{-1})^\dagger(SA^iS^{-1})
+     & =(S^\dagger)^{-1}(A^i)^\dagger S^\dagger SA^iS^{-1}
+    \notag                                                 \\
+     & =(S^\dagger)^{-1}(A^i)^\dagger\sigma A^iS^{-1},
+    \notag
+\end{align}
+and therefore
+\begin{align}
+    \sum_i(A'^i)^\dagger A'^i
+     & =(S^\dagger)^{-1}
+    \left(\sum_i(A^i)^\dagger\sigma A^i\right)S^{-1}
+    =(S^\dagger)^{-1}\sigma S^{-1}
+    =\Id.
+    \notag
+\end{align}
+Finally, for the square-root gauge
+(\ref{eq:qpf_tp_gauge}), self-adjointness of $\sigma^{1/2}$ gives
+\begin{align}
+    (B^i)^\dagger B^i
+     & =\sigma^{-1/2}(A^i)^\dagger
+    \sigma^{1/2}\sigma^{1/2}A^i\sigma^{-1/2}
+    \notag                                                 \\
+     & =\sigma^{-1/2}(A^i)^\dagger\sigma A^i\sigma^{-1/2}.
+    \notag
+\end{align}
+Summing, substituting the adjoint fixed-point equation, and cancelling the
+outer square-root factors yields
+\begin{align}
+    \sum_i(B^i)^\dagger B^i
+     & =\sigma^{-1/2}
+    \left(\sum_i(A^i)^\dagger\sigma A^i\right)\sigma^{-1/2}
+    =\sigma^{-1/2}\sigma\sigma^{-1/2}
+    =\Id.
+    \notag
+\end{align}
+
+\begin{lemma}[Square-root trace-preserving gauge is a gauge equivalence]%
+    \label{lem:tp_gauge_equiv}
+    \lean{MPSTensor.gaugeEquiv_tpGauge}
+    \leanok
+    \uses{def:gauge_equiv}
+    If $\sigma$ is positive definite and $B$ is defined by
+    (\ref{eq:qpf_tp_gauge}), then $A$ and $B$ are gauge equivalent.
+\end{lemma}
+
+\begin{proof}\leanok
+    The gauge matrix is $\sigma^{1/2}$, which is invertible because
+    $\sigma$ is positive definite. Thus (\ref{eq:qpf_tp_gauge}) has the form
+    of the gauge relation (\ref{eq:mps_gauge_equiv}).
+\end{proof}
+
+\section{Similarity bookkeeping}
+\label{sec:app_qpf_similarity}
+
+\begin{lemma}[Similarity is an involution]%
+    \label{lem:similarity_involution}
+    \lean{similarityMap_similarityMap_inv}
+    \leanok
+    For any invertible $C \in \MN{D}$ and any linear map $E$ on $\MN{D}$,
+    write $S_C(E)(X)=C^{-1}E(CXC^\dagger)(C^\dagger)^{-1}$ for the
+    similarity transform by $C$. The transforms by $C$ and $C^{-1}$ compose
+    to the identity:
+    \begin{align}
+        S_{C^{-1}}(S_C(E))(X)
+         & =C\left[C^{-1}E\!\left(C(C^{-1}X(C^\dagger)^{-1})C^\dagger\right)
+                 (C^\dagger)^{-1}\right]C^\dagger \notag \\
+         & =E(X).
+        \label{eq:qpf_similarity_involution}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Direct computation: the inner conjugation
+    $C(C^{-1}X(C^\dagger)^{-1})C^\dagger$ collapses to $X$
+    using $CC^{-1} = \Id$ and $(C^\dagger)^{-1}C^\dagger = \Id$, and the
+    outer conjugation by $C(\,\cdot\,)C^\dagger$ then cancels the inner
+    $C^{-1}(\,\cdot\,)(C^\dagger)^{-1}$ on $E(X)$ for the same reason.
+\end{proof}
+
+\begin{lemma}[Irreducibility is invariant under similarity]%
+    \label{lem:similarity_irred_iff}
+    \lean{isIrreducibleMap_similarity_iff}
+    \leanok
+    \uses{def:irreducible_cp, lem:similarity_irred, lem:similarity_involution}
+    For any invertible $C \in \MN{D}$ and any linear map $E$ on $\MN{D}$,
+    the similarity transform
+    $X \mapsto C^{-1}E(CXC^\dagger)(C^\dagger)^{-1}$
+    is irreducible if and only if $E$ is.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:similarity_irred, lem:similarity_involution}
+    The forward direction follows from Lemma~\ref{lem:similarity_irred}
+    applied with the inverse $C^{-1}$, whose determinant is also nonzero:
+    if the similarity transform of $E$ by $C$ is irreducible, then so is its
+    similarity transform by $C^{-1}$, which equals $E$ by
+    (\ref{eq:qpf_similarity_involution}). The reverse direction is
+    Lemma~\ref{lem:similarity_irred} itself with $c = 1$.
+\end{proof}
+
+\section{Auxiliary Perron reductions}
+\label{sec:app_qpf_perron}
+
+\begin{theorem}[Adjoint transfer map is nonzero]%
+    \label{thm:adjoint_transfer_ne_zero}
+    \lean{MPSTensor.adjointTransferMap_ne_zero_of_nonzero}
+    \leanok
+    \uses{def:transfer_map}
+    If some Kraus operator $A^i \neq 0$, then the adjoint transfer
+    map $\E_A^\dagger(X) = \sum_i (A^i)^\dagger X A^i$ is nonzero.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $\E_A^\dagger = 0$ then $\E_A^\dagger(\Id) = 0$,
+    so $\sum_i (A^i)^\dagger A^i = 0$.
+    Since each summand $(A^i)^\dagger A^i$ is positive semidefinite,
+    each $(A^i)^\dagger A^i = 0$ and hence each $A^i = 0$.
+\end{proof}
+
+\begin{theorem}[Real spectral-radius identity]
+    \label{thm:spectral_radius_real_pf_irred}
+    \lean{spectralRadius_toReal_eq_of_posDef_eigenvector_of_irreducible_cp}
+    \leanok
+    \uses{thm:spectral_radius_pf_irred}
+    Under the hypotheses of Theorem~\ref{thm:spectral_radius_pf_irred}, the
+    real-valued spectral radius of $E$ is also equal to~$r$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    This is the real-valued reformulation of
+    Theorem~\ref{thm:spectral_radius_pf_irred}.
+\end{proof}
+
+\section{Exponential truncation and scalar reformulations}
+\label{sec:app_qpf_exponential}
+
+\begin{theorem}[Exponential truncation is positive definite]
+    \label{thm:exp_truncation_pd_irred}
+    \lean{exp_truncation_posDef_of_irreducible_cp}
+    \leanok
+    \uses{def:irreducible_cp, thm:growth_pd_irred}
+    Let $E$ be an irreducible completely positive map on $\MN{D}$,
+    let $A \ge 0$ be nonzero, and let $t > 0$.
+    Then the finite exponential truncation satisfies
+    \begin{align}
+        \sum_{k=0}^{D-1}\frac{t^k}{k!}E^k(A)
+         & >0.
+        \label{eq:qpf_exp_truncation}
+    \end{align}
+    This is the finite-sum core of the completely positive specialization of
+    \cite[Theorem~6.2(3)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:growth_pd_irred}
+    If a nonzero vector $v$ annihilated the quadratic form in
+    (\ref{eq:qpf_exp_truncation}), positivity of every summand would make
+    $E^k(A)v=0$ for $0\leq k\leq D-1$. Expanding
+    $(\Id+E)^{D-1}(A)$ by the binomial theorem would then make it annihilate
+    $v$, contrary to Theorem~\ref{thm:growth_pd_irred}.
+\end{proof}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -38,8 +38,9 @@ and~\cite{Evans1978Spectral}.
          & =\sum_i K_iXK_i^\dagger
         \notag
     \end{align}
-    and set $T(B)=B+E(B)$ for nonzero $B\geq0$. If $B$ is not positive
-    definite, irreducibility forces
+    and set $T(B)=B+E(B)$ for nonzero $B\geq0$. Since $E(B)\geq0$, one has
+    $T(B)\geq B$ and hence $\ker T(B)\subseteq\ker B$. If $B$ is not
+    positive definite, irreducibility forces
     \begin{align}
         \dim\ker T(B)
          & <\dim\ker B.
@@ -112,13 +113,14 @@ and~\cite{Evans1978Spectral}.
     \label{thm:psd_fp_pd}
     \lean{MPSTensor.posSemidef_fixedPoint_isPosDef}
     \leanok
-    \uses{def:injective, def:transfer_map, thm:psd_fp_pd_irred}
+    \uses{def:injective, def:transfer_map}
     Let $A$ be an injective MPS tensor and let $\rho \ge 0$,
     $\rho \neq 0$, be a fixed point of $\E_A$. Then $\rho$ is positive
     definite.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:psd_fp_pd_irred}
     Injectivity implies irreducibility of the transfer map. Apply
     Theorem~\ref{thm:psd_fp_pd_irred}.
 \end{proof}
@@ -126,7 +128,7 @@ and~\cite{Evans1978Spectral}.
 \begin{theorem}[Orthogonal trace condition]\label{thm:orthogonal_trace_cond}
     \lean{orthogonal_trace_pos_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp, thm:growth_pd_irred}
+    \uses{def:irreducible_cp}
     Let $E$ be an irreducible completely positive map on $\MN{D}$,
     and let $A, B \ge 0$ be nonzero positive semidefinite matrices
     with $\tr(BA) = 0$.
@@ -136,6 +138,7 @@ and~\cite{Evans1978Spectral}.
 
 \begin{proof}
     \leanok
+    \uses{thm:growth_pd_irred}
     Theorem~\ref{thm:growth_pd_irred} gives
     $(\Id + E)^{D-1}(A) > 0$.
     Since $B \ge 0$ is nonzero,
@@ -162,13 +165,14 @@ and~\cite{Evans1978Spectral}.
     \label{thm:psd_fp_unique_irred}
     \lean{MPSTensor.posSemidef_fixedPoint_unique_of_irreducible}
     \leanok
-    \uses{def:irreducible_cp, def:transfer_map, thm:psd_fp_pd_irred}
+    \uses{def:irreducible_cp, def:transfer_map}
     Let $A$ be an MPS tensor whose transfer map is irreducible. If
     $\rho,\sigma\geq0$ are fixed points of $\E_A$ and $\rho\neq0$, then
     $\sigma=c\rho$ for some $c\in\C$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:psd_fp_pd_irred}
     If $\sigma=0$, take $c=0$. Otherwise,
     Theorem~\ref{thm:psd_fp_pd_irred} makes both $\rho$ and $\sigma$
     positive definite. Write $\rho=SS^\dagger$ and set
@@ -198,12 +202,13 @@ and~\cite{Evans1978Spectral}.
     \label{thm:psd_fp_unique}
     \lean{MPSTensor.posSemidef_fixedPoint_unique}
     \leanok
-    \uses{def:injective, def:transfer_map, thm:psd_fp_unique_irred}
+    \uses{def:injective, def:transfer_map}
     Let $A$ be an injective MPS tensor. If $\rho,\sigma\geq0$ are nonzero
     fixed points of $\E_A$, then $\sigma=c\rho$ for some $c\in\C$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:psd_fp_unique_irred}
     Injectivity implies irreducibility of the transfer map. Apply
     Theorem~\ref{thm:psd_fp_unique_irred}.
 \end{proof}
@@ -298,8 +303,7 @@ and~\cite{Evans1978Spectral}.
     \label{thm:qpf_irreducible}
     \lean{MPSTensor.quantum_perron_frobenius_irreducible}
     \leanok
-    \uses{def:irreducible_cp, def:transfer_map, thm:psd_fp_exists,
-        thm:psd_fp_pd_irred, thm:psd_fp_unique_irred}
+    \uses{def:irreducible_cp, def:transfer_map}
     Assume $D\ge 1$. Let $A$ be an MPS tensor such that its transfer map is
     irreducible and $\sum_i (A^i)^\dagger A^i=\Id$, so that $\E_A$ is
     trace-preserving.
@@ -308,6 +312,8 @@ and~\cite{Evans1978Spectral}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:psd_fp_exists, thm:psd_fp_pd_irred,
+        thm:psd_fp_unique_irred}
     Existence is the channel fixed-point theorem
     (Theorem~\ref{thm:psd_fp_exists}). Irreducibility upgrades the fixed point
     to positive definite, and Theorem~\ref{thm:psd_fp_unique_irred} gives
@@ -463,7 +469,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:pf_eigenvector_existence_general}
     \lean{exists_posSemidef_eigenvector_general}
     \leanok
-    \uses{def:positive_map, thm:pf_eigenvector_existence}
+    \uses{def:positive_map}
     Let $E:\MN{D}\to\MN{D}$ be a positive linear map with $D>0$. Then
     there are a nonzero positive semidefinite matrix $\rho$ and a real number
     $r\geq0$ such that
@@ -478,6 +484,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:pf_eigenvector_existence}
     If $E$ annihilates a nonzero positive semidefinite matrix $\rho$, take
     $r=0$. Otherwise $E(\sigma)\neq0$ for every nonzero
     $\sigma\geq0$, and Theorem~\ref{thm:pf_eigenvector_existence} gives
@@ -488,7 +495,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:pf_eigenvector_existence}
     \lean{exists_posSemidef_eigenvector}
     \leanok
-    \uses{def:positive_map, thm:brouwer_density_matrices}
+    \uses{def:positive_map}
     Let $E:\MN{D}\to\MN{D}$ be a positive linear map with $D>0$, and assume
     that $E(\sigma)\neq0$ for every nonzero positive semidefinite matrix
     $\sigma$. Then there are a nonzero positive semidefinite matrix $\rho$
@@ -496,6 +503,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:brouwer_density_matrices}
     Normalize $E$ on the density matrices by
     \begin{align}
         \rho
@@ -632,7 +640,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:exp_pd_irred}
     \lean{exp_posDef_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp, thm:exp_truncation_pd_irred}
+    \uses{def:irreducible_cp}
     Let $E$ be an irreducible completely positive map on $\MN{D}$,
     let $A \ge 0$ be nonzero, and let $t > 0$.
     Then
@@ -647,6 +655,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{proof}
     \leanok
+    \uses{thm:exp_truncation_pd_irred}
     By Theorem~\ref{thm:exp_truncation_pd_irred}, the first $D$ terms in
     (\ref{eq:qpf_exp_positive}) already form a positive definite matrix.
     Every remaining term is positive semidefinite, so the full exponential
@@ -658,7 +667,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:wolf_6_2_item_3}
     \lean{irreducible_iff_exp_posDef_forall}
     \leanok
-    \uses{def:irreducible_cp, thm:exp_pd_irred}
+    \uses{def:irreducible_cp}
     Let $E$ be a completely positive map on $\MN{D}$. Then $E$ is
     irreducible if and only if, for every $t>0$ and every nonzero
     $A\geq0$, one has $\exp(tE)(A)>0$.
@@ -668,6 +677,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:exp_pd_irred}
     The forward implication is Theorem~\ref{thm:exp_pd_irred}. Conversely,
     let $P$ be an invariant orthogonal projection. If $P\neq0$, invariance
     of the generator keeps $\exp(tE)(P)$ in the corner $P\MN{D}P$ for
@@ -683,8 +693,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:channel_density_fp_irred}
     \lean{IsChannel.exists_unique_density_fixedPoint_of_irreducible}
     \leanok
-    \uses{def:channel, def:irreducible_cp, thm:psd_fp_pd_irred,
-        thm:psd_fp_unique_irred}
+    \uses{def:channel, def:irreducible_cp}
     Let $E$ be an irreducible quantum channel on $\MN{D}$ with $D > 0$.
     Then there exists a unique density matrix $\sigma$ such that
     $E(\sigma) = \sigma$.
@@ -711,8 +720,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:channel_cesaro_irred}
     \lean{IsChannel.cesaroMean_tendsto_of_irreducible}
     \leanok
-    \uses{def:channel, def:irreducible_cp, def:cesaro_mean,
-        thm:channel_density_fp_irred}
+    \uses{def:channel, def:irreducible_cp, def:cesaro_mean}
     Let $E$ be an irreducible quantum channel on $\MN{D}$ with $D > 0$,
     and let $\rho$ be any density matrix.
     Then the Ces\`aro means (\ref{eq:channel_cesaro_mean}) converge to the
@@ -723,6 +731,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{proof}
     \leanok
+    \uses{thm:channel_density_fp_irred}
     Every subsequential limit of the Ces\`aro means is again a density-matrix
     fixed point.
     By Theorem~\ref{thm:channel_density_fp_irred}, there is only one such
@@ -736,8 +745,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:spectral_radius_pf_irred}
     \lean{spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp, thm:posDef_adjoint_eigenvector,
-        thm:tp_gauge_from_adjoint_fixed, thm:spectral_radius_le_one}
+    \uses{def:irreducible_cp}
     Let $E$ be an irreducible completely positive map on $\MN{D}$.
     Suppose $\rho > 0$ and $E(\rho) = r\rho$ with $r > 0$.
     Then the spectral radius of $E$ is $r$.
@@ -804,9 +812,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:has_spectral_properties_irred}
     \lean{hasSpectralProperties_of_irreducible_cp}
     \leanok
-    \uses{def:has_spectral_properties, def:irreducible_cp,
-        thm:pf_eigenvector_existence, thm:psd_fp_unique_irred,
-        thm:spectral_radius_pf_irred}
+    \uses{def:has_spectral_properties, def:irreducible_cp}
     Every nonzero irreducible completely positive map on $\MN{D}$ has the
     restricted CP spectral properties of Definition~\ref{def:has_spectral_properties}.
 \end{theorem}
@@ -825,8 +831,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:irred_from_spectral_properties}
     \lean{isIrreducibleMap_of_hasSpectralProperties}
     \leanok
-    \uses{def:has_spectral_properties, thm:tp_gauge_from_adjoint_fixed,
-        lem:cesaro_subseq_fixed}
+    \uses{def:has_spectral_properties}
     If a completely positive map on $\MN{D}$ has the restricted CP spectral properties of
     Definition~\ref{def:has_spectral_properties}, then it is irreducible.
 \end{theorem}
@@ -847,8 +852,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:irred_iff_spectral_properties}
     \lean{isIrreducibleMap_iff_spectral_properties}
     \leanok
-    \uses{def:has_spectral_properties, def:irreducible_cp,
-        thm:has_spectral_properties_irred, thm:irred_from_spectral_properties}
+    \uses{def:has_spectral_properties, def:irreducible_cp}
     Let $E$ be a nonzero completely positive map on $\MN{D}$.
     Then $E$ is irreducible if and only if it has the restricted CP spectral properties of
     Definition~\ref{def:has_spectral_properties}. This is a CP-map variant of
@@ -860,6 +864,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{proof}
     \leanok
+    \uses{thm:has_spectral_properties_irred, thm:irred_from_spectral_properties}
     Combine Theorems~\ref{thm:has_spectral_properties_irred}
     and~\ref{thm:irred_from_spectral_properties}.
 \end{proof}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -43,10 +43,14 @@ and~\cite{Evans1978Spectral}.
     Equivalently, $\supp B$ would be invariant under every $K_i$, making the
     support projection of $B$ a nontrivial invariant projection.
 
-    Induct on an upper bound $n$ for $\dim\ker B$. The case $n=0$ is
-    immediate. In the induction step, either $B>0$, in which case
-    positivity of $E$ gives $T^n(B)>0$, or the strict kernel decrease places
-    $T(B)$ under the induction hypothesis. Since $A\neq0$, rank--nullity gives
+    We prove by induction on $n$ that every nonzero $B\geq0$ with
+    $\dim\ker B\leq n$ satisfies $T^n(B)>0$. For $n=0$, the kernel is
+    trivial, so $B>0$. Suppose the claim holds for $n$ and let
+    $\dim\ker B\leq n+1$. If $B>0$, then $T(B)=B+E(B)>0$, and every
+    subsequent iterate remains positive definite. Otherwise the strict
+    kernel decrease gives $\dim\ker T(B)\leq n$; the induction hypothesis
+    applied to $T(B)$ yields
+    $T^n(T(B))=T^{n+1}(B)>0$. Since $A\neq0$, rank--nullity gives
     $\dim\ker A\leq D-1$, which proves (\ref{eq:qpf_growth_pd}).
 \end{proof}
 

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -15,7 +15,7 @@ and~\cite{Evans1978Spectral}.
 
 \section{Positive definiteness}
 
-\begin{theorem}[CP growth criterion from Wolf Theorem~6.2(2)]
+\begin{theorem}[Positive-definite growth for irreducible CP maps]
     \label{thm:growth_pd_irred}
     \lean{growth_posDef_of_irreducible_cp}
     \leanok
@@ -32,14 +32,26 @@ and~\cite{Evans1978Spectral}.
 \end{theorem}
 
 \begin{proof}\leanok
-    For a nonzero positive semidefinite matrix $B$, set $T(B)=B+E(B)$.
-    If $B$ is not positive definite, irreducibility forces
+    Choose a Kraus decomposition
+    \begin{align}
+        E(X)
+         & =\sum_i K_iXK_i^\dagger
+        \notag
+    \end{align}
+    and set $T(B)=B+E(B)$ for nonzero $B\geq0$. If $B$ is not positive
+    definite, irreducibility forces
     \begin{align}
         \dim\ker T(B)
          & <\dim\ker B.
         \notag
     \end{align}
-    Indeed, equality would make $\ker B$ invariant under every $K_i^\dagger$.
+    Indeed, equality would imply
+    \begin{align}
+        K_i^\dagger(\ker B)
+         & \subseteq\ker B
+        \qquad\text{for every }i.
+        \notag
+    \end{align}
     Equivalently, $\supp B$ would be invariant under every $K_i$, making the
     support projection of $B$ a nontrivial invariant projection.
 
@@ -67,16 +79,34 @@ and~\cite{Evans1978Spectral}.
     \leanok
     \uses{def:irreducible_cp}
     Suppose $\rho$ is not positive definite, and let $Q$ be its support
-    projection. The fixed-point equation implies
+    projection. Since $\rho=Q\rho Q$ and
+    $\rho=\sum_iA^i\rho(A^i)^\dagger$, the $(\Id-Q)$ corner satisfies
     \begin{align}
-        Q\E_A(QXQ)Q
-         & =\E_A(QXQ)
+        0
+         & =(\Id-Q)\rho(\Id-Q) \notag \\
+         & =\sum_i
+        \bigl((\Id-Q)A^iQ\bigr)\rho
+        \bigl((\Id-Q)A^iQ\bigr)^\dagger.
         \notag
     \end{align}
-    for every $X$, so $Q$ is invariant. Irreducibility forces
-    $Q=0$ or $Q=\Id$. The first case contradicts $\rho\neq0$, while the
-    second says that $\rho$ is positive definite. This is the
-    support-projection mechanism of
+    Every summand is positive semidefinite, so each vanishes. The restriction
+    of $\rho$ to its support is positive definite; hence
+    \begin{align}
+        (\Id-Q)A^iQ
+         & =0
+        \qquad\text{for every }i.
+        \notag
+    \end{align}
+    Thus $A^iQ=QA^iQ$, and for every $X$ each summand
+    $A^iQXQ(A^i)^\dagger$ lies in the $Q$ corner. Therefore
+    \begin{align}
+        Q\E_A(QXQ)Q
+         & =\E_A(QXQ),
+        \notag
+    \end{align}
+    so $Q$ is invariant. Irreducibility forces $Q=0$ or $Q=\Id$. The first
+    case contradicts $\rho\neq0$, while the second says that $\rho$ is
+    positive definite. This is the support-projection mechanism of
     \cite[Theorem~6.2(1)]{Wolf2012Quantum}.
 \end{proof}
 
@@ -108,8 +138,7 @@ and~\cite{Evans1978Spectral}.
 
 \begin{proof}
     \leanok
-    The growth theorem for irreducible CP maps
-    (\cite[Theorem~6.2(2)]{Wolf2012Quantum}) gives
+    Theorem~\ref{thm:growth_pd_irred} gives
     $(\Id + E)^{D-1}(A) > 0$.
     Since $B \ge 0$ is nonzero,
     $\tr(B(\Id + E)^{D-1}(A)) > 0$.
@@ -144,16 +173,24 @@ and~\cite{Evans1978Spectral}.
 \begin{proof}\leanok
     If $\sigma=0$, take $c=0$. Otherwise,
     Theorem~\ref{thm:psd_fp_pd_irred} makes both $\rho$ and $\sigma$
-    positive definite. Write $\rho=SS^\dagger$ and let $c_0>0$ be the
-    smallest eigenvalue of
-    $H=(S^\dagger)^{-1}\sigma S^{-1}$. Then
+    positive definite. Write $\rho=SS^\dagger$ and set
+    \begin{align}
+        H
+         & =S^{-1}\sigma(S^\dagger)^{-1}.
+        \notag
+    \end{align}
+    If $c_0>0$ is the smallest eigenvalue of $H$, then
+    $H-c_0\Id\geq0$ and $H-c_0\Id$ is singular. Since $S$ is invertible,
+    congruence by $S$ preserves positivity and singularity and gives
     \begin{align}
         \tau
          & =\sigma-c_0\rho
+        =S(H-c_0\Id)S^\dagger,
         \notag
     \end{align}
-    is a positive semidefinite fixed point with a zero eigenvalue. If
-    $\tau\neq0$, Theorem~\ref{thm:psd_fp_pd_irred} would make it positive
+    so $\tau$ is positive semidefinite and singular. Linearity makes $\tau$
+    a fixed point. If $\tau\neq0$,
+    Theorem~\ref{thm:psd_fp_pd_irred} would make it positive
     definite, a contradiction. Thus $\tau=0$ and $\sigma=c_0\rho$.
     This is the minimal-eigenvalue mechanism of
     \cite[Theorem~6.3(2)]{Wolf2012Quantum}.
@@ -738,13 +775,13 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \section{A CP spectral characterization of irreducibility}
 
-\begin{definition}[CP spectral package]
+\begin{definition}[Restricted CP spectral properties]
     \label{def:has_spectral_properties}
     \lean{HasSpectralProperties}
     \leanok
     \uses{def:cp_map}
-    A completely positive map $E$ on $\MN{D}$ has the \emph{CP spectral
-        package} used here if there exist a positive real number $r$, a positive
+    A completely positive map $E$ on $\MN{D}$ has the \emph{restricted CP
+        spectral properties} used here if there exist a positive real number $r$, a positive
     definite right eigenvector $\rho$, and a positive definite left eigenvector
     $\sigma$ for the adjoint map such that
     \begin{align}
@@ -762,7 +799,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     eigenvector at $r$ is proportional to $\rho$.
 \end{definition}
 
-\begin{theorem}[Irreducibility gives the CP spectral package]
+\begin{theorem}[Irreducibility gives the restricted CP spectral properties]
     \label{thm:has_spectral_properties_irred}
     \lean{hasSpectralProperties_of_irreducible_cp}
     \leanok
@@ -770,7 +807,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
         thm:pf_eigenvector_existence, thm:psd_fp_unique_irred,
         thm:spectral_radius_pf_irred}
     Every nonzero irreducible completely positive map on $\MN{D}$ has the
-    CP spectral package of Definition~\ref{def:has_spectral_properties}.
+    restricted CP spectral properties of Definition~\ref{def:has_spectral_properties}.
 \end{theorem}
 
 \begin{proof}
@@ -783,13 +820,13 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     Theorem~\ref{thm:spectral_radius_pf_irred}.
 \end{proof}
 
-\begin{theorem}[The CP spectral package implies irreducibility]
+\begin{theorem}[Restricted CP spectral properties imply irreducibility]
     \label{thm:irred_from_spectral_properties}
     \lean{isIrreducibleMap_of_hasSpectralProperties}
     \leanok
     \uses{def:has_spectral_properties, thm:tp_gauge_from_adjoint_fixed,
         lem:cesaro_subseq_fixed}
-    If a completely positive map on $\MN{D}$ has the CP spectral package of
+    If a completely positive map on $\MN{D}$ has the restricted CP spectral properties of
     Definition~\ref{def:has_spectral_properties}, then it is irreducible.
 \end{theorem}
 
@@ -805,18 +842,18 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     Definition~\ref{def:has_spectral_properties}.
 \end{proof}
 
-\begin{theorem}[Irreducibility iff the CP spectral package holds]
+\begin{theorem}[Irreducibility iff the restricted CP spectral properties hold]
     \label{thm:irred_iff_spectral_properties}
     \lean{isIrreducibleMap_iff_spectral_properties}
     \leanok
     \uses{def:has_spectral_properties, def:irreducible_cp,
         thm:has_spectral_properties_irred, thm:irred_from_spectral_properties}
     Let $E$ be a nonzero completely positive map on $\MN{D}$.
-    Then $E$ is irreducible if and only if it has the CP spectral package of
+    Then $E$ is irreducible if and only if it has the restricted CP spectral properties of
     Definition~\ref{def:has_spectral_properties}. This is a CP-map variant of
     \cite[Theorem~6.4]{Wolf2012Quantum}: uniqueness is required only among
     positive semidefinite Perron eigenvectors, not on the full eigenspace.
-    That restricted package is nevertheless sufficient for the
+    Those restricted properties are nevertheless sufficient for the
     irreducibility equivalence.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -4,83 +4,54 @@ This chapter establishes elementary fixed-point existence for quantum channels
 and the Perron--Frobenius theory: existence, positive definiteness, and uniqueness
 of fixed points for injective and irreducible transfer maps, canonical
 gauge constructions, ergodicity of irreducible channels, the
-spectral-radius identification of Perron eigenvalues, and Wolf's
-spectral characterization of irreducibility.
+spectral-radius identification of Perron eigenvalues, and a CP-map
+irreducibility criterion modeled on Wolf's spectral characterization.
 The conceptual source is Wolf's treatment of irreducible positive
 maps~\cite[Chapter~6, especially Theorems~6.2--6.5 and Corollary~6.3]{Wolf2012Quantum}
 and~\cite{Evans1978Spectral}.
 
-\begin{theorem}[Brouwer fixed point on density matrices]%
-    \label{thm:brouwer_density_matrices}
-    \lean{brouwer_fixedPoint_densityMatrices}
-    \lean{fixedPoint_of_compact_retract, fixedPoint_of_compact_retract_fin}
-    \lean{exists_fixedPoint_closedCube, exists_fixedPoint_unitCube}
-    \leanok
-    \uses{def:density_matrices, thm:density_compact}
-    Let $D > 0$. Every continuous map from the compact convex set of
-    density matrices in $\MN{D}$ to itself has a fixed point.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    The proof starts from Brouwer's theorem for products of simplices,
-    transfers it to closed cubes, and then to compact retracts of
-    finite-dimensional real normed spaces. The density-matrix set is
-    such a compact retract, using the explicit density retraction.
-\end{proof}
 
 \input{chapter/ch06_qpf_cesaro_fixed_points}
 
 \section{Positive definiteness}
 
-\begin{remark}\leanok
-    Wolf's general theory treats irreducible positive maps first
-    (\cite[Theorem~6.2]{Wolf2012Quantum}), then derives non-degeneracy
-    and positive definiteness (\cite[Theorem~6.3]{Wolf2012Quantum}).
-    The injective-tensor version (Theorem~\ref{thm:psd_fp_pd}) uses
-    a shorter direct kernel argument; the irreducible
-    CP-map version (Theorem~\ref{thm:psd_fp_pd_irred}) follows
-    via the support-projection argument of~\cite[Theorem~6.2]{Wolf2012Quantum}.
-\end{remark}
-
-\begin{theorem}[PSD fixed point is positive definite]\label{thm:psd_fp_pd}
-    \lean{MPSTensor.posSemidef_fixedPoint_isPosDef}
+\begin{theorem}[CP growth criterion from Wolf Theorem~6.2(2)]
+    \label{thm:growth_pd_irred}
+    \lean{growth_posDef_of_irreducible_cp}
     \leanok
-    \uses{def:injective, def:transfer_map}
-    Let $A$ be an injective MPS tensor and let $\rho \ge 0$,
-    $\rho \neq 0$, be a fixed point of the transfer map
-    $\E_A(\rho) = \rho$.
-    Then $\rho$ is positive definite.
+    \uses{def:irreducible_cp}
+    Let $E$ be an irreducible completely positive map on $\MN{D}$ and let
+    $A\geq0$ be nonzero. Then
+    \begin{align}
+        (\Id+E)^{D-1}(A)
+         & >0.
+        \label{eq:qpf_growth_pd}
+    \end{align}
+    This is the completely positive specialization of the implication
+    (1)$\Rightarrow$(2) in \cite[Theorem~6.2]{Wolf2012Quantum}.
 \end{theorem}
 
-\begin{proof}
-    \leanok
-    Suppose $v^\dagger \rho v = 0$ for some $v \neq 0$.
-    Since $\rho \ge 0$, this implies $\rho v = 0$.
-    Substituting the transfer-map formula
-    (\ref{eq:mps_transfer_map}) into the fixed-point equation gives
+\begin{proof}\leanok
+    For a nonzero positive semidefinite matrix $B$, set $T(B)=B+E(B)$.
+    If $B$ is not positive definite, irreducibility forces
     \begin{align}
-        v^\dagger \rho v
-        &= \sum_i ((A^i)^\dagger v)^\dagger
-        \rho ((A^i)^\dagger v).
+        \dim\ker T(B)
+         & <\dim\ker B.
         \notag
     \end{align}
-    Each term is non-negative; if the sum is zero, then
-    $\rho (A^i)^\dagger v = 0$ for all~$i$:
-    the kernel of $\rho$ is invariant under all $(A^i)^\dagger$.
-    Since the $\{A^i\}$ span $\MN{D}$, we have $\rho M v = 0$
-    for every matrix $M$. Given any vector $w$, choose $M$ with
-    $Mv = w$. Then $\rho w = 0$ for every $w$, so $\rho = 0$,
-    contradicting $\rho \neq 0$.
-    In~\cite[Theorem~6.3(2)]{Wolf2012Quantum},
-    the same conclusion is reached via the
-    growth condition $(\Id + \E_A)^{D-1}(\rho) > 0$
-    of~\cite[Theorem~6.2(2)]{Wolf2012Quantum};
-    here the direct kernel argument is shorter under
-    injectivity.
+    Indeed, equality would make $\ker B$ invariant under every $K_i^\dagger$.
+    Equivalently, $\supp B$ would be invariant under every $K_i$, making the
+    support projection of $B$ a nontrivial invariant projection.
+
+    Induct on an upper bound $n$ for $\dim\ker B$. The case $n=0$ is
+    immediate. In the induction step, either $B>0$, in which case
+    positivity of $E$ gives $T^n(B)>0$, or the strict kernel decrease places
+    $T(B)$ under the induction hypothesis. Since $A\neq0$, rank--nullity gives
+    $\dim\ker A\leq D-1$, which proves (\ref{eq:qpf_growth_pd}).
 \end{proof}
 
-\begin{theorem}[PSD fixed point is positive definite --- irreducible version]\label{thm:psd_fp_pd_irred}
+\begin{theorem}[PSD fixed point is positive definite --- irreducible version]
+    \label{thm:psd_fp_pd_irred}
     \lean{MPSTensor.posSemidef_fixedPoint_isPosDef_of_irreducible}
     \leanok
     \uses{def:irreducible_cp, def:transfer_map}
@@ -91,29 +62,39 @@ and~\cite{Evans1978Spectral}.
 \begin{proof}
     \leanok
     \uses{def:irreducible_cp}
-    Suppose $\rho$ is not positive definite.
-    Then $\rho$ has a nontrivial kernel; let $Q$ be the
-    orthogonal projection onto the support of $\rho$
-    (the complement of the kernel).
-    A direct computation using the fixed-point equation
-    $\E_A(\rho) = \rho$ shows that $Q$ is an invariant
-    projection for $\E_A$: for every $X$,
-    $Q\E_A(QXQ)Q=\E_A(QXQ)$.
-    By irreducibility of $\E_A$
-    (Definition~\ref{def:irreducible_cp}),
-    every invariant projection is $0$ or $\Id$.
-    If $Q = 0$ then $\rho = 0$, contradicting $\rho \neq 0$.
-    If $Q = \Id$ then $\rho$ is positive definite,
-    contradicting our assumption.
-    Hence $\rho$ must be positive definite.
-    This is the support-projection direction
-    of~\cite[Theorem~6.2(1)]{Wolf2012Quantum}.
+    Suppose $\rho$ is not positive definite, and let $Q$ be its support
+    projection. The fixed-point equation implies
+    \begin{align}
+        Q\E_A(QXQ)Q
+         & =\E_A(QXQ)
+        \notag
+    \end{align}
+    for every $X$, so $Q$ is invariant. Irreducibility forces
+    $Q=0$ or $Q=\Id$. The first case contradicts $\rho\neq0$, while the
+    second says that $\rho$ is positive definite. This is the
+    support-projection mechanism of
+    \cite[Theorem~6.2(1)]{Wolf2012Quantum}.
+\end{proof}
+
+\begin{theorem}[PSD fixed point is positive definite]
+    \label{thm:psd_fp_pd}
+    \lean{MPSTensor.posSemidef_fixedPoint_isPosDef}
+    \leanok
+    \uses{def:injective, def:transfer_map, thm:psd_fp_pd_irred}
+    Let $A$ be an injective MPS tensor and let $\rho \ge 0$,
+    $\rho \neq 0$, be a fixed point of $\E_A$. Then $\rho$ is positive
+    definite.
+\end{theorem}
+
+\begin{proof}\leanok
+    Injectivity implies irreducibility of the transfer map. Apply
+    Theorem~\ref{thm:psd_fp_pd_irred}.
 \end{proof}
 
 \begin{theorem}[Orthogonal trace condition]\label{thm:orthogonal_trace_cond}
     \lean{orthogonal_trace_pos_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp}
+    \uses{def:irreducible_cp, thm:growth_pd_irred}
     Let $E$ be an irreducible completely positive map on $\MN{D}$,
     and let $A, B \ge 0$ be nonzero positive semidefinite matrices
     with $\tr(BA) = 0$.
@@ -131,7 +112,7 @@ and~\cite{Evans1978Spectral}.
     Expanding by the binomial theorem gives
     \begin{align}
         \tr\!\left(B\sum_{k=0}^{D-1}\binom{D-1}{k}E^k(A)\right)
-        &> 0.
+         & > 0.
         \notag
     \end{align}
     Each term $\tr(BE^k(A))$ is non-negative since both factors are
@@ -146,56 +127,46 @@ and~\cite{Evans1978Spectral}.
 
 \section{Uniqueness}
 
-\begin{theorem}[Uniqueness of PSD fixed point]\label{thm:psd_fp_unique}
-    \lean{MPSTensor.posSemidef_fixedPoint_unique}
-    \leanok
-    \uses{def:injective, def:transfer_map}
-    Let $A$ be an injective MPS tensor.
-    If $\rho, \sigma \ge 0$ are both nonzero fixed points of
-    $\E_A$, then $\sigma = c\rho$ for some $c \in \C$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:psd_fp_pd}
-    Both $\rho$ and $\sigma$ are positive definite by
-    Theorem~\ref{thm:psd_fp_pd}.
-    Write $\rho = SS^\dagger$ via a spectral square root and set
-    $H = (S^\dagger)^{-1}\sigma S^{-1}$, which is Hermitian
-    and positive definite.
-    Let $c_0$ be the minimal eigenvalue of~$H$.
-    Then $\tau := \sigma - c_0\rho$ is a positive semidefinite fixed point
-    which is not positive definite
-    (it has a zero eigenvalue by construction of~$c_0$).
-    By Theorem~\ref{thm:psd_fp_pd}, $\tau$ must be zero,
-    giving $\sigma = c_0\rho$.
-    In~\cite[Theorem~6.3(2)]{Wolf2012Quantum}, uniqueness is proved
-    via the growth condition of~\cite[Theorem~6.2]{Wolf2012Quantum};
-    the same minimal-eigenvalue argument applies here, using the
-    injective-tensor positive-definiteness
-    (Theorem~\ref{thm:psd_fp_pd}) in place of the growth condition.
-\end{proof}
-
-\begin{remark}\leanok
-    The proof produces a positive real scalar $c_0 > 0$:
-    it is the minimal eigenvalue of the positive definite Hermitian
-    matrix $H = (S^\dagger)^{-1}\sigma S^{-1}$.
-\end{remark}
-
-\begin{theorem}[Irreducible fixed-point uniqueness]\label{thm:psd_fp_unique_irred}
+\begin{theorem}[Irreducible fixed-point uniqueness]
+    \label{thm:psd_fp_unique_irred}
     \lean{MPSTensor.posSemidef_fixedPoint_unique_of_irreducible}
     \leanok
     \uses{def:irreducible_cp, def:transfer_map, thm:psd_fp_pd_irred}
-    Let $A$ be an MPS tensor whose transfer map is irreducible.
-    If $\rho,\sigma\ge 0$ are fixed points of $\E_A$, and if
-    $\rho$ is nonzero, then $\sigma=c\rho$ for some scalar $c$.
+    Let $A$ be an MPS tensor whose transfer map is irreducible. If
+    $\rho,\sigma\geq0$ are fixed points of $\E_A$ and $\rho\neq0$, then
+    $\sigma=c\rho$ for some $c\in\C$.
 \end{theorem}
 
 \begin{proof}\leanok
-    The irreducible positive-definiteness theorem
-    (Theorem~\ref{thm:psd_fp_pd_irred}) upgrades every nonzero positive
-    semidefinite fixed point to a positive definite one. The same minimal
-    eigenvalue argument used in Theorem~\ref{thm:psd_fp_unique} then applies.
+    If $\sigma=0$, take $c=0$. Otherwise,
+    Theorem~\ref{thm:psd_fp_pd_irred} makes both $\rho$ and $\sigma$
+    positive definite. Write $\rho=SS^\dagger$ and let $c_0>0$ be the
+    smallest eigenvalue of
+    $H=(S^\dagger)^{-1}\sigma S^{-1}$. Then
+    \begin{align}
+        \tau
+         & =\sigma-c_0\rho
+        \notag
+    \end{align}
+    is a positive semidefinite fixed point with a zero eigenvalue. If
+    $\tau\neq0$, Theorem~\ref{thm:psd_fp_pd_irred} would make it positive
+    definite, a contradiction. Thus $\tau=0$ and $\sigma=c_0\rho$.
+    This is the minimal-eigenvalue mechanism of
+    \cite[Theorem~6.3(2)]{Wolf2012Quantum}.
+\end{proof}
+
+\begin{theorem}[Uniqueness of PSD fixed point]
+    \label{thm:psd_fp_unique}
+    \lean{MPSTensor.posSemidef_fixedPoint_unique}
+    \leanok
+    \uses{def:injective, def:transfer_map, thm:psd_fp_unique_irred}
+    Let $A$ be an injective MPS tensor. If $\rho,\sigma\geq0$ are nonzero
+    fixed points of $\E_A$, then $\sigma=c\rho$ for some $c\in\C$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Injectivity implies irreducibility of the transfer map. Apply
+    Theorem~\ref{thm:psd_fp_unique_irred}.
 \end{proof}
 
 \begin{theorem}[Uniqueness of positive eigenvalue for irreducible CP maps]%
@@ -228,7 +199,7 @@ and~\cite{Evans1978Spectral}.
     trace-pairing identity (\ref{eq:schwarz_trace_adjoint_pairing}) yields
     \begin{align}
         s\tr(\tau X)
-        &= \tr(\tau E(X))
+         & = \tr(\tau E(X))
         = \tr(E^\dagger(\tau)X)
         = t\tr(\tau X).
         \notag
@@ -237,9 +208,10 @@ and~\cite{Evans1978Spectral}.
     $\tr(\tau X) > 0$, so $s = t$.
     Applying this to both $(\rho,r_1)$ and $(\sigma,r_2)$
     gives $r_1 = t = r_2$.
-    This is~\cite[Theorem~6.3(3)]{Wolf2012Quantum}, the
-    non-degeneracy of the spectral-radius eigenvalue for irreducible
-    CP maps; the proof follows Wolf's dual-map trace argument.
+    This is the completely positive specialization of
+    \cite[Theorem~6.3(3)]{Wolf2012Quantum}: uniqueness of a positive
+    eigenvalue admitting a nonzero positive semidefinite eigenvector.
+    The proof follows Wolf's dual-map trace argument.
 \end{proof}
 
 \section{Existence and the Perron--Frobenius theorem}
@@ -315,19 +287,14 @@ and~\cite{Evans1978Spectral}.
     Kraus map is unital. This is the right-canonical normalization.
 \end{theorem}
 
-\begin{proof}
-    \leanok
-    For each~$i$,
+\begin{proof}\leanok
+    Conjugating each summand gives
     $(S^{-1}A^iS)(S^{-1}A^iS)^\dagger
-    =S^{-1}A^i\rho(A^i)^\dagger(S^\dagger)^{-1}$.
-    Summing over~$i$ and using the fixed-point equation gives
-    \begin{align}
-        \sum_i A'^i(A'^i)^\dagger
-        &= S^{-1}\E_A(\rho)(S^\dagger)^{-1}
-        = S^{-1}\rho(S^\dagger)^{-1}
-        = \Id.
-        \notag
-    \end{align}
+        =S^{-1}A^i\rho(A^i)^\dagger(S^\dagger)^{-1}$.
+    The substitution $\E_A(\rho)=\rho$ leaves
+    $S^{-1}\rho(S^\dagger)^{-1}$, and $\rho=SS^\dagger$ cancels the
+    outer factors. The term-by-term calculation is in
+    Section~\ref{sec:app_qpf_gauge}.
 \end{proof}
 
 \begin{theorem}[Left-canonical (trace-preserving) gauge]\label{thm:left_canonical_gauge}
@@ -342,18 +309,14 @@ and~\cite{Evans1978Spectral}.
     normalization.
 \end{theorem}
 
-\begin{proof}
-    \leanok
-    For each~$i$,
+\begin{proof}\leanok
+    Conjugating each summand gives
     $(SA^iS^{-1})^\dagger(SA^iS^{-1})
-    =(S^\dagger)^{-1}(A^i)^\dagger\sigma A^iS^{-1}$.
-    Summing over~$i$ and using the adjoint fixed-point equation gives
-    \begin{align}
-        \sum_i(A'^i)^\dagger A'^i
-        &= (S^\dagger)^{-1}\sigma S^{-1}
-        = \Id.
-        \notag
-    \end{align}
+        =(S^\dagger)^{-1}(A^i)^\dagger\sigma A^iS^{-1}$.
+    The adjoint fixed-point substitution leaves
+    $(S^\dagger)^{-1}\sigma S^{-1}$, and $\sigma=S^\dagger S$ cancels
+    the outer factors. See Section~\ref{sec:app_qpf_gauge} for the full
+    calculation.
 \end{proof}
 
 \begin{theorem}[Square-root trace-preserving gauge from an adjoint fixed point]%
@@ -366,7 +329,7 @@ and~\cite{Evans1978Spectral}.
     Define
     \begin{align}
         B^i
-        &= \sigma^{1/2}A^i\sigma^{-1/2}.
+         & = \sigma^{1/2}A^i\sigma^{-1/2}.
         \label{eq:qpf_tp_gauge}
     \end{align}
     Then $B$ is trace-preserving:
@@ -374,33 +337,14 @@ and~\cite{Evans1978Spectral}.
 \end{theorem}
 
 \begin{proof}\leanok
-    Since $\sigma^{1/2}$ is self-adjoint and
-    $\sigma^{1/2}\sigma^{1/2}=\sigma$, summing the products obtained from
-    (\ref{eq:qpf_tp_gauge}) gives
-    \begin{align}
-        \sum_i(B^i)^\dagger B^i
-        &= \sigma^{-1/2}
-        \left(\sum_i(A^i)^\dagger\sigma A^i\right)\sigma^{-1/2}
-        = \sigma^{-1/2}\sigma\sigma^{-1/2}
-        = \Id.
-        \notag
-    \end{align}
+    Each conjugated summand is
+    $(B^i)^\dagger B^i
+        =\sigma^{-1/2}(A^i)^\dagger\sigma A^i\sigma^{-1/2}$.
+    Substituting $\sum_i(A^i)^\dagger\sigma A^i=\sigma$ and cancelling
+    the outer inverse square roots gives $\Id$. The complete calculation
+    appears in Section~\ref{sec:app_qpf_gauge}.
 \end{proof}
 
-\begin{lemma}[Square-root trace-preserving gauge is a gauge equivalence]%
-    \label{lem:tp_gauge_equiv}
-    \lean{MPSTensor.gaugeEquiv_tpGauge}
-    \leanok
-    \uses{def:gauge_equiv}
-    If $\sigma$ is positive definite and $B$ is defined by
-    (\ref{eq:qpf_tp_gauge}), then $A$ and $B$ are gauge equivalent.
-\end{lemma}
-
-\begin{proof}\leanok
-    The gauge matrix is $\sigma^{1/2}$, which is invertible because
-    $\sigma$ is positive definite. Thus (\ref{eq:qpf_tp_gauge}) has the form
-    of the gauge relation (\ref{eq:mps_gauge_equiv}).
-\end{proof}
 
 \begin{remark}\leanok
     The right-canonical gauge of Theorem~\ref{thm:right_canonical_gauge}
@@ -424,7 +368,7 @@ and~\cite{Evans1978Spectral}.
     Define the similarity-transformed map by
     \begin{align}
         E'(X)
-        &= cC^{-1}E(CXC^\dagger)(C^\dagger)^{-1}.
+         & = cC^{-1}E(CXC^\dagger)(C^\dagger)^{-1}.
         \notag
     \end{align}
     Then $E'$ is also irreducible.
@@ -440,55 +384,12 @@ and~\cite{Evans1978Spectral}.
     Irreducibility of $E$ forces $P = 0$ or $P = \Id$.
     The invertibility of $C$ then forces $Q = 0$ or $Q = \Id$,
     a contradiction.
-    This is the full similarity version of~\cite[Proposition~6.6]{Wolf2012Quantum};
-    the scalar case $C = \Id$ gives the scaling result stated next.
+    This is the completely positive specialization of the similarity result
+    in~\cite[Proposition~6.6]{Wolf2012Quantum}; the scalar case $C=\Id$
+    gives the scaling result stated next.
 \end{proof}
 
-\begin{lemma}[Similarity is an involution]%
-    \label{lem:similarity_involution}
-    \lean{similarityMap_similarityMap_inv}
-    \leanok
-    For any invertible $C \in \MN{D}$ and any linear map $E$ on $\MN{D}$,
-    write $S_C(E)(X)=C^{-1}E(CXC^\dagger)(C^\dagger)^{-1}$ for the
-    similarity transform by $C$. The transforms by $C$ and $C^{-1}$ compose
-    to the identity:
-    \begin{align}
-        S_{C^{-1}}(S_C(E))(X)
-        &=C\left[C^{-1}E\!\left(C(C^{-1}X(C^\dagger)^{-1})C^\dagger\right)
-          (C^\dagger)^{-1}\right]C^\dagger \notag\\
-        &=E(X).
-        \label{eq:qpf_similarity_involution}
-    \end{align}
-\end{lemma}
 
-\begin{proof}\leanok
-    Direct computation: the inner conjugation
-    $C(C^{-1}X(C^\dagger)^{-1})C^\dagger$ collapses to $X$
-    using $CC^{-1} = \Id$ and $(C^\dagger)^{-1}C^\dagger = \Id$, and the
-    outer conjugation by $C(\,\cdot\,)C^\dagger$ then cancels the inner
-    $C^{-1}(\,\cdot\,)(C^\dagger)^{-1}$ on $E(X)$ for the same reason.
-\end{proof}
-
-\begin{lemma}[Irreducibility is invariant under similarity]%
-    \label{lem:similarity_irred_iff}
-    \lean{isIrreducibleMap_similarity_iff}
-    \leanok
-    \uses{def:irreducible_cp, lem:similarity_irred, lem:similarity_involution}
-    For any invertible $C \in \MN{D}$ and any linear map $E$ on $\MN{D}$,
-    the similarity transform
-    $X \mapsto C^{-1}E(CXC^\dagger)(C^\dagger)^{-1}$
-    is irreducible if and only if $E$ is.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{lem:similarity_irred, lem:similarity_involution}
-    The forward direction follows from Lemma~\ref{lem:similarity_irred}
-    applied with the inverse $C^{-1}$, whose determinant is also nonzero:
-    if the similarity transform of $E$ by $C$ is irreducible, then so is its
-    similarity transform by $C^{-1}$, which equals $E$ by
-    (\ref{eq:qpf_similarity_involution}). The reverse direction is
-    Lemma~\ref{lem:similarity_irred} itself with $c = 1$.
-\end{proof}
 
 \begin{theorem}[Scaling preserves irreducibility]%
     \label{thm:irred_map_smul}
@@ -497,8 +398,9 @@ and~\cite{Evans1978Spectral}.
     \uses{def:irreducible_cp}
     If $E$ is an irreducible map and $c \neq 0$, then $cE$
     is also irreducible.
-    This is the scalar special case $C = \Id$ of
-    \cite[Proposition~6.6]{Wolf2012Quantum}.
+    For positive real $c$, this is the scalar completely positive case of
+    \cite[Proposition~6.6]{Wolf2012Quantum}; the abstract irreducibility
+    statement above also allows any nonzero complex $c$.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -518,39 +420,55 @@ The PSD-eigenvector step corresponds to~\cite[Theorem~6.5]{Wolf2012Quantum}
 definiteness uses the irreducible-map theory of~\cite[Theorem~6.3]{Wolf2012Quantum}.
 The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
-\begin{theorem}[PSD eigenvector for positive maps]%
-    \label{thm:pf_eigenvector_existence}
-    \lean{exists_posSemidef_eigenvector}
+\begin{theorem}[PSD eigenvector existence for a positive map]
+    \label{thm:pf_eigenvector_existence_general}
+    \lean{exists_posSemidef_eigenvector_general}
     \leanok
-    \uses{def:positive_map}
-    Let $E : \MN{D} \to \MN{D}$ be a positive linear map with
-    $D > 0$, and assume that $E(\sigma) \neq 0$ for every nonzero
-    positive semidefinite matrix $\sigma$.
-    Then there exist a nonzero positive semidefinite matrix $\rho$ and a
-    positive real $r > 0$ such that $E(\rho) = r\rho$.
-
-    This is the finite-dimensional Perron--Frobenius theorem for
-    positive maps on matrix algebras
-    (\cite[Theorem~6.5]{Wolf2012Quantum}; see also~\cite{Evans1978Spectral}).
-    The proof applies Brouwer's fixed-point theorem to the
-    normalization map $\rho \mapsto E(\rho)/\tr(E(\rho))$ on the
-    compact convex set of density matrices.
-\end{theorem}
-
-\begin{theorem}[Adjoint transfer map is nonzero]%
-    \label{thm:adjoint_transfer_ne_zero}
-    \lean{MPSTensor.adjointTransferMap_ne_zero_of_nonzero}
-    \leanok
-    \uses{def:transfer_map}
-    If some Kraus operator $A^i \neq 0$, then the adjoint transfer
-    map $\E_A^\dagger(X) = \sum_i (A^i)^\dagger X A^i$ is nonzero.
+    \uses{def:positive_map, thm:pf_eigenvector_existence}
+    Let $E:\MN{D}\to\MN{D}$ be a positive linear map with $D>0$. Then
+    there are a nonzero positive semidefinite matrix $\rho$ and a real number
+    $r\geq0$ such that
+    \begin{align}
+        E(\rho)
+         & =r\rho.
+        \label{eq:qpf_general_psd_eigenvector}
+    \end{align}
+    This is the eigenvector-existence part of
+    \cite[Theorem~6.5]{Wolf2012Quantum}. It does not by itself identify $r$
+    with the spectral radius.
 \end{theorem}
 
 \begin{proof}\leanok
-    If $\E_A^\dagger = 0$ then $\E_A^\dagger(\Id) = 0$,
-    so $\sum_i (A^i)^\dagger A^i = 0$.
-    Since each summand $(A^i)^\dagger A^i$ is positive semidefinite,
-    each $(A^i)^\dagger A^i = 0$ and hence each $A^i = 0$.
+    If $E$ annihilates a nonzero positive semidefinite matrix $\rho$, take
+    $r=0$. Otherwise $E(\sigma)\neq0$ for every nonzero
+    $\sigma\geq0$, and Theorem~\ref{thm:pf_eigenvector_existence} gives
+    (\ref{eq:qpf_general_psd_eigenvector}) with $r>0$.
+\end{proof}
+
+\begin{theorem}[Positive-eigenvalue specialization]
+    \label{thm:pf_eigenvector_existence}
+    \lean{exists_posSemidef_eigenvector}
+    \leanok
+    \uses{def:positive_map, thm:brouwer_density_matrices}
+    Let $E:\MN{D}\to\MN{D}$ be a positive linear map with $D>0$, and assume
+    that $E(\sigma)\neq0$ for every nonzero positive semidefinite matrix
+    $\sigma$. Then there are a nonzero positive semidefinite matrix $\rho$
+    and a real number $r>0$ such that $E(\rho)=r\rho$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Normalize $E$ on the density matrices by
+    \begin{align}
+        \rho
+         & \longmapsto\frac{E(\rho)}{\tr(E(\rho))}.
+        \notag
+    \end{align}
+    Positivity and the nonvanishing hypothesis make this a continuous
+    self-map. Theorem~\ref{thm:brouwer_density_matrices} gives a fixed point
+    $\rho$. Clearing the positive denominator yields
+    $E(\rho)=r\rho$ with $r=\tr(E(\rho))>0$. Thus this theorem is the
+    positive-eigenvalue specialization of
+    Theorem~\ref{thm:pf_eigenvector_existence_general}.
 \end{proof}
 
 \begin{theorem}[Positive-definite adjoint eigenvector for irreducible tensors]%
@@ -564,8 +482,8 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     and a positive real $r > 0$ such that
     $\E_A^\dagger(\sigma) = r\sigma$.
 
-    This combines the general Perron--Frobenius existence
-    (\cite[Theorem~6.5]{Wolf2012Quantum}) with the
+    This combines the eigenvector-existence part of
+    \cite[Theorem~6.5]{Wolf2012Quantum} with the
     irreducible upgrade to positive definiteness
     (\cite[Theorem~6.3(2)]{Wolf2012Quantum});
     the application to the adjoint transfer map follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
@@ -609,7 +527,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     and a tensor~$B$ gauge-equivalent to $r^{-1/2}A$ such that
     \begin{align}
         B^i
-        &= \sigma^{1/2}(r^{-1/2}A^i)\sigma^{-1/2},
+         & = \sigma^{1/2}(r^{-1/2}A^i)\sigma^{-1/2},
         \label{eq:qpf_irred_tp_gauge}
     \end{align}
     and $\sum_i (B^i)^\dagger B^i = \Id$.
@@ -646,7 +564,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     and a tensor~$B$ gauge-equivalent to $r^{-1/2}A$ such that
     \begin{align}
         B^i
-        &= r^{-1/2}\rho^{-1/2}A^i\rho^{1/2},
+         & = r^{-1/2}\rho^{-1/2}A^i\rho^{1/2},
         \label{eq:qpf_irred_unital_gauge}
     \end{align}
     and $\sum_i B^i(B^i)^\dagger = \Id$.
@@ -670,35 +588,6 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \section{Exponential positivity for irreducible CP maps}
 
-\begin{theorem}[Exponential truncation is positive definite]
-    \label{thm:exp_truncation_pd_irred}
-    \lean{exp_truncation_posDef_of_irreducible_cp}
-    \leanok
-    \uses{def:irreducible_cp}
-    Let $E$ be an irreducible completely positive map on $\MN{D}$,
-    let $A \ge 0$ be nonzero, and let $t > 0$.
-    Then the finite exponential truncation satisfies
-    \begin{align}
-        \sum_{k=0}^{D-1}\frac{t^k}{k!}E^k(A)
-        &>0.
-        \label{eq:qpf_exp_truncation}
-    \end{align}
-    This is the finite-sum core of~\cite[Theorem~6.2(3)]{Wolf2012Quantum}.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    \uses{thm:orthogonal_trace_cond}
-    If a nonzero vector $v$ annihilated the quadratic form in
-    (\ref{eq:qpf_exp_truncation}), then every term $E^k(A)$ with
-    $0 \le k \le D-1$ would annihilate $v$.
-    The growth theorem for irreducible CP maps, namely
-    $(\Id + E)^{D-1}(A) > 0$ for irreducible $E$ and nonzero
-    positive semidefinite $A$, as established in the proof of
-    Theorem~\ref{thm:orthogonal_trace_cond}, would then force
-    $(\Id + E)^{D-1}(A)$ to annihilate $v$, contradicting its positive
-    definiteness.
-\end{proof}
 
 \begin{theorem}[Exponential positivity for irreducible CP maps]
     \label{thm:exp_pd_irred}
@@ -710,10 +599,11 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     Then
     \begin{align}
         \exp(tE)(A)
-        &= \sum_{k=0}^{\infty}\frac{t^k}{k!}E^k(A)>0.
+         & = \sum_{k=0}^{\infty}\frac{t^k}{k!}E^k(A)>0.
         \label{eq:qpf_exp_positive}
     \end{align}
-    This is~\cite[Theorem~6.2(3)]{Wolf2012Quantum}.
+    This is the completely positive specialization of the forward implication
+    in~\cite[Theorem~6.2(3)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -725,23 +615,50 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     semidefinite tail.
 \end{proof}
 
+\begin{theorem}[Exponential characterization of irreducibility]
+    \label{thm:wolf_6_2_item_3}
+    \lean{irreducible_iff_exp_posDef_forall}
+    \leanok
+    \uses{def:irreducible_cp, thm:exp_pd_irred}
+    Let $E$ be a completely positive map on $\MN{D}$. Then $E$ is
+    irreducible if and only if, for every $t>0$ and every nonzero
+    $A\geq0$, one has $\exp(tE)(A)>0$.
+    This is the completely positive specialization of the equivalence in
+    \cite[Theorem~6.2(3)]{Wolf2012Quantum};
+    Theorem~\ref{thm:exp_pd_irred} is its forward implication.
+\end{theorem}
+
+\begin{proof}\leanok
+    The forward implication is Theorem~\ref{thm:exp_pd_irred}. Conversely,
+    let $P$ be an invariant orthogonal projection. If $P\neq0$, invariance
+    of the generator keeps $\exp(tE)(P)$ in the corner $P\MN{D}P$ for
+    every $t\geq0$. At $t=1$ the assumed positive definiteness is impossible
+    unless $P=\Id$, because a positive definite matrix cannot be supported
+    on a proper corner. Thus every invariant projection is $0$ or $\Id$,
+    so $E$ is irreducible.
+\end{proof}
+
 \section{Ergodicity of irreducible channels}
 
 \begin{theorem}[Unique density-matrix fixed point for an irreducible channel]
     \label{thm:channel_density_fp_irred}
     \lean{IsChannel.exists_unique_density_fixedPoint_of_irreducible}
     \leanok
-    \uses{def:channel, def:irreducible_cp}
+    \uses{def:channel, def:irreducible_cp, thm:psd_fp_pd_irred,
+        thm:psd_fp_unique_irred}
     Let $E$ be an irreducible quantum channel on $\MN{D}$ with $D > 0$.
     Then there exists a unique density matrix $\sigma$ such that
     $E(\sigma) = \sigma$.
-    Moreover, $\sigma$ is positive definite.
-    This is the qualitative form of~\cite[Corollary~6.3]{Wolf2012Quantum}.
+    The fixed point $\sigma$ is positive definite.
+    This is the fixed-point conclusion in the forward direction of
+    \cite[Corollary~6.3]{Wolf2012Quantum}, specialized to completely
+    positive trace-preserving maps.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:cesaro_fixedpoint}
+    \uses{lem:cesaro_mean_density, lem:cesaro_subseq_fixed,
+        thm:psd_fp_pd_irred, thm:psd_fp_unique_irred}
     Every Ces\`aro mean (\ref{eq:channel_cesaro_mean}) of a density matrix
     stays inside the compact convex set of density matrices, so a subsequence
     converges.
@@ -761,7 +678,8 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     and let $\rho$ be any density matrix.
     Then the Ces\`aro means (\ref{eq:channel_cesaro_mean}) converge to the
     unique positive definite density-matrix fixed point of~$E$.
-    This is~\cite[Corollary~6.3]{Wolf2012Quantum}.
+    This is the Ces\`aro-convergence conclusion in the forward direction of
+    \cite[Corollary~6.3]{Wolf2012Quantum}, specialized to quantum channels.
 \end{theorem}
 
 \begin{proof}
@@ -779,92 +697,101 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \label{thm:spectral_radius_pf_irred}
     \lean{spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp}
     \leanok
-    \uses{def:irreducible_cp}
+    \uses{def:irreducible_cp, thm:posDef_adjoint_eigenvector,
+        thm:tp_gauge_from_adjoint_fixed, thm:spectral_radius_le_one}
     Let $E$ be an irreducible completely positive map on $\MN{D}$.
     Suppose $\rho > 0$ and $E(\rho) = r\rho$ with $r > 0$.
     Then the spectral radius of $E$ is $r$.
-    This is~\cite[Theorem~6.3(4)]{Wolf2012Quantum}.
+    This is the completely positive specialization of
+    \cite[Theorem~6.3(4)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Choose a positive definite eigenvector for the adjoint map with the same
-    eigenvalue, gauge by its square root, and rescale by $r^{-1}$.
-    The resulting map is trace-preserving and has a positive definite fixed
-    point, so $1$ is an eigenvalue. The spectral radius of a trace-preserving
-    map $F$ satisfies $\rho(F) \le 1$, since
-    $\tr(F^n(X)) = \tr(X)$ for all~$n$ bounds the growth of iterates.
-    Hence its spectral radius is~$1$.
-    Undoing the similarity and scalar rescaling recovers the spectral radius
-    of~$E$.
+    \uses{thm:posDef_adjoint_eigenvector,
+        thm:tp_gauge_from_adjoint_fixed, thm:spectral_radius_le_one}
+    Choose a positive definite adjoint eigenvector $\sigma>0$, say
+    $E^\dagger(\sigma)=t\sigma$. The weighted trace pairing with $\rho$ gives
+    \begin{align}
+        r\tr(\sigma\rho)
+         & =\tr(\sigma E(\rho))
+        =\tr(E^\dagger(\sigma)\rho)
+        =t\tr(\sigma\rho).
+        \notag
+    \end{align}
+    Since $\tr(\sigma\rho)>0$, one has $t=r$. Rescale by $r^{-1}$ and
+    conjugate by $\sigma^{1/2}$ as in
+    Theorem~\ref{thm:tp_gauge_from_adjoint_fixed}; this produces a
+    trace-preserving Kraus map $F$ similar to $r^{-1}E$.
+    The transfer-operator contraction
+    (Theorem~\ref{thm:spectral_radius_le_one}) gives $\rho_{\spec}(F)\leq1$.
+    The conjugate of $\rho$ is a nonzero fixed point of $F$, so $1$ is an
+    eigenvalue and $\rho_{\spec}(F)\geq1$. Hence
+    $\rho_{\spec}(F)=1$. Similarity preserves the spectrum, and undoing the
+    scalar rescaling gives $\rho_{\spec}(E)=r$.
 \end{proof}
 
-\begin{theorem}[Real spectral-radius identity]
-    \label{thm:spectral_radius_real_pf_irred}
-    \lean{spectralRadius_toReal_eq_of_posDef_eigenvector_of_irreducible_cp}
-    \leanok
-    \uses{thm:spectral_radius_pf_irred}
-    Under the hypotheses of Theorem~\ref{thm:spectral_radius_pf_irred}, the
-    real-valued spectral radius of $E$ is also equal to~$r$.
-\end{theorem}
 
-\begin{proof}
-    \leanok
-    This is the real-valued reformulation of
-    Theorem~\ref{thm:spectral_radius_pf_irred}.
-\end{proof}
+\section{A CP spectral characterization of irreducibility}
 
-\section{Spectral characterization of irreducibility}
-
-\begin{definition}[Spectral properties]
+\begin{definition}[CP spectral package]
     \label{def:has_spectral_properties}
     \lean{HasSpectralProperties}
     \leanok
     \uses{def:cp_map}
-    A completely positive map $E$ on $\MN{D}$ has the \emph{spectral properties}
-    of~\cite[Theorem~6.4]{Wolf2012Quantum} if there exist a positive real number $r$,
-    a positive definite right eigenvector $\rho$, and a positive definite left
-    eigenvector $\sigma$ for the adjoint map such that
+    A completely positive map $E$ on $\MN{D}$ has the \emph{CP spectral
+        package} used here if there exist a positive real number $r$, a positive
+    definite right eigenvector $\rho$, and a positive definite left eigenvector
+    $\sigma$ for the adjoint map such that
     \begin{align}
         E(\rho)
-        &=r\rho, \notag\\
+         & =r\rho, \notag \\
         E^\dagger(\sigma)
-        &=r\sigma,
+         & =r\sigma,
         \label{eq:qpf_spectral_eigenvectors}
     \end{align}
     every positive semidefinite right eigenvector for eigenvalue $r$ is a
     scalar multiple of $\rho$, and the spectral radius of $E$ is equal to~$r$.
+    The uniqueness clause concerns only positive semidefinite Perron
+    eigenvectors. Unlike the full nondegenerate-eigenspace statement in
+    \cite[Theorem~6.4]{Wolf2012Quantum}, it does not assert that every complex
+    eigenvector at $r$ is proportional to $\rho$.
 \end{definition}
 
-\begin{theorem}[Irreducibility gives the spectral properties]
+\begin{theorem}[Irreducibility gives the CP spectral package]
     \label{thm:has_spectral_properties_irred}
     \lean{hasSpectralProperties_of_irreducible_cp}
     \leanok
-    \uses{def:has_spectral_properties, def:irreducible_cp}
+    \uses{def:has_spectral_properties, def:irreducible_cp,
+        thm:pf_eigenvector_existence, thm:psd_fp_unique_irred,
+        thm:spectral_radius_pf_irred}
     Every nonzero irreducible completely positive map on $\MN{D}$ has the
-    spectral properties of Definition~\ref{def:has_spectral_properties}.
+    CP spectral package of Definition~\ref{def:has_spectral_properties}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:spectral_radius_pf_irred}
+    \uses{thm:pf_eigenvector_existence, thm:psd_fp_unique_irred,
+        thm:spectral_radius_pf_irred}
     Combine Perron--Frobenius existence for the map and its adjoint with the
     uniqueness theorem for positive semidefinite Perron eigenvectors and the
     spectral-radius identity of
     Theorem~\ref{thm:spectral_radius_pf_irred}.
 \end{proof}
 
-\begin{theorem}[Spectral properties imply irreducibility]
+\begin{theorem}[The CP spectral package implies irreducibility]
     \label{thm:irred_from_spectral_properties}
     \lean{isIrreducibleMap_of_hasSpectralProperties}
     \leanok
-    \uses{def:has_spectral_properties}
-    If a completely positive map on $\MN{D}$ has the spectral properties of
+    \uses{def:has_spectral_properties, thm:tp_gauge_from_adjoint_fixed,
+        lem:cesaro_subseq_fixed}
+    If a completely positive map on $\MN{D}$ has the CP spectral package of
     Definition~\ref{def:has_spectral_properties}, then it is irreducible.
 \end{theorem}
 
 \begin{proof}
     \leanok
+    \uses{thm:tp_gauge_from_adjoint_fixed, lem:cesaro_subseq_fixed}
     Gauge by the positive definite left eigenvector in
     (\ref{eq:qpf_spectral_eigenvectors}) and rescale by the Perron eigenvalue
     to obtain a trace-preserving map with a positive definite fixed point.
@@ -874,16 +801,19 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     Definition~\ref{def:has_spectral_properties}.
 \end{proof}
 
-\begin{theorem}[Irreducibility iff the spectral properties hold]
+\begin{theorem}[Irreducibility iff the CP spectral package holds]
     \label{thm:irred_iff_spectral_properties}
     \lean{isIrreducibleMap_iff_spectral_properties}
     \leanok
     \uses{def:has_spectral_properties, def:irreducible_cp,
         thm:has_spectral_properties_irred, thm:irred_from_spectral_properties}
     Let $E$ be a nonzero completely positive map on $\MN{D}$.
-    Then $E$ is irreducible if and only if it has the spectral properties of
-    Definition~\ref{def:has_spectral_properties}.
-    This is~\cite[Theorem~6.4]{Wolf2012Quantum}.
+    Then $E$ is irreducible if and only if it has the CP spectral package of
+    Definition~\ref{def:has_spectral_properties}. This is a CP-map variant of
+    \cite[Theorem~6.4]{Wolf2012Quantum}: uniqueness is required only among
+    positive semidefinite Perron eigenvectors, not on the full eigenspace.
+    That restricted package is nevertheless sufficient for the
+    irreducibility equivalence.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -715,12 +715,19 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \begin{proof}\leanok
     \uses{thm:exp_pd_irred}
     The forward implication is Theorem~\ref{thm:exp_pd_irred}. Conversely,
-    let $P$ be an invariant orthogonal projection. If $P\neq0$, invariance
-    of the generator keeps $\exp(tE)(P)$ in the corner $P\MN{D}P$ for
-    every $t\geq0$. At $t=1$ the assumed positive definiteness is impossible
-    unless $P=\Id$, because a positive definite matrix cannot be supported
-    on a proper corner. Thus every invariant projection is $0$ or $\Id$,
-    so $E$ is irreducible.
+    let $P$ be an invariant orthogonal projection. Invariance gives
+    $E(P\MN{D}P)\subseteq P\MN{D}P$, so induction yields
+    $E^k(P)\in P\MN{D}P$ for every $k\geq0$. Therefore every term, and hence
+    the convergent series
+    \begin{align}
+        \exp(tE)(P)
+         & =\sum_{k=0}^{\infty}\frac{t^k}{k!}E^k(P),
+        \notag
+    \end{align}
+    lies in the same corner. If $P\neq0$, then at $t=1$ the assumed positive
+    definiteness is impossible unless $P=\Id$, because a positive definite
+    matrix cannot be supported on a proper corner. Thus every invariant
+    projection is $0$ or $\Id$, so $E$ is irreducible.
 \end{proof}
 
 \section{Ergodicity of irreducible channels}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -38,15 +38,29 @@ and~\cite{Evans1978Spectral}.
          & =\sum_i K_iXK_i^\dagger
         \notag
     \end{align}
-    and set $T(B)=B+E(B)$ for nonzero $B\geq0$. Since $E(B)\geq0$, one has
-    $T(B)\geq B$ and hence $\ker T(B)\subseteq\ker B$. If $B$ is not
-    positive definite, irreducibility forces
+    and set $T(B)=B+E(B)$ for nonzero $B\geq0$. Always
+    $\ker T(B)\subseteq\ker B$: if $v\in\ker T(B)$, then
+    \begin{align}
+        0
+         & =v^\dagger Bv+v^\dagger E(B)v,
+        \notag
+    \end{align}
+    and both terms are non-negative, so $v^\dagger Bv=0$ and hence $Bv=0$.
+    If $B$ is not positive definite, irreducibility forces
     \begin{align}
         \dim\ker T(B)
          & <\dim\ker B.
         \notag
     \end{align}
-    Indeed, equality would imply, for every~$i$,
+    Indeed, equality of the kernel dimensions would turn the inclusion above
+    into $\ker B\subseteq\ker T(B)$. Thus, for $v\in\ker B$,
+    \begin{align}
+        0
+         & =v^\dagger E(B)v
+        =\sum_i(K_i^\dagger v)^\dagger B(K_i^\dagger v).
+        \notag
+    \end{align}
+    Every summand is non-negative, so equality would imply, for every~$i$,
     \begin{align}
         K_i^\dagger(\ker B)
          & \subseteq\ker B.
@@ -256,6 +270,28 @@ and~\cite{Evans1978Spectral}.
     \cite[Theorem~6.3(3)]{Wolf2012Quantum}: uniqueness of a positive
     eigenvalue admitting a nonzero positive semidefinite eigenvector.
     The proof follows Wolf's dual-map trace argument.
+\end{proof}
+
+\begin{theorem}[PSD eigenvector uniqueness for irreducible CP maps]
+    \label{thm:psd_eigenvector_unique_irred}
+    \lean{posSemidef_eigenvector_unique_of_irreducible_cp}
+    \leanok
+    \uses{def:irreducible_cp}
+    Let $E$ be an irreducible completely positive map on $\MN{D}$. Suppose
+    $\rho\neq0$ and $\rho,\sigma\geq0$ satisfy
+    $E(\rho)=r\rho$ and $E(\sigma)=r\sigma$ for a real number $r>0$.
+    Then $\sigma=c\rho$ for some $c\in\C$.
+    This is the completely positive specialization of the
+    positive-eigenvector uniqueness in
+    \cite[Theorem~6.3(2--3)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:irred_map_smul, thm:psd_fp_unique_irred}
+    Choose Kraus operators for $E$ and rescale each by $r^{-1/2}$. Their
+    transfer map is $r^{-1}E$, so both $\rho$ and $\sigma$ are fixed points.
+    The rescaled map remains irreducible, and
+    Theorem~\ref{thm:psd_fp_unique_irred} gives the claimed proportionality.
 \end{proof}
 
 \section{Existence and the Perron--Frobenius theorem}
@@ -819,7 +855,7 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 
 \begin{proof}
     \leanok
-    \uses{thm:pf_eigenvector_existence, thm:psd_fp_unique_irred,
+    \uses{thm:pf_eigenvector_existence, thm:psd_eigenvector_unique_irred,
         thm:spectral_radius_pf_irred}
     Combine Perron--Frobenius existence for the map and its adjoint with the
     uniqueness theorem for positive semidefinite Perron eigenvectors and the

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -45,11 +45,10 @@ and~\cite{Evans1978Spectral}.
          & <\dim\ker B.
         \notag
     \end{align}
-    Indeed, equality would imply
+    Indeed, equality would imply, for every~$i$,
     \begin{align}
         K_i^\dagger(\ker B)
-         & \subseteq\ker B
-        \qquad\text{for every }i.
+         & \subseteq\ker B.
         \notag
     \end{align}
     Equivalently, $\supp B$ would be invariant under every $K_i$, making the
@@ -90,11 +89,10 @@ and~\cite{Evans1978Spectral}.
         \notag
     \end{align}
     Every summand is positive semidefinite, so each vanishes. The restriction
-    of $\rho$ to its support is positive definite; hence
+    of $\rho$ to its support is positive definite; hence, for every~$i$,
     \begin{align}
         (\Id-Q)A^iQ
-         & =0
-        \qquad\text{for every }i.
+         & =0.
         \notag
     \end{align}
     Thus $A^iQ=QA^iQ$, and for every $X$ each summand
@@ -751,7 +749,10 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     \leanok
     \uses{thm:posDef_adjoint_eigenvector,
         thm:tp_gauge_from_adjoint_fixed, thm:spectral_radius_le_one}
-    Choose a positive definite adjoint eigenvector $\sigma>0$, say
+    Choose Kraus operators $\{K_i\}$ for $E$. Regarded as an MPS tensor,
+    they have transfer map $E$, and irreducibility of $E$ is precisely
+    irreducibility of this tensor. Theorem~\ref{thm:posDef_adjoint_eigenvector}
+    therefore gives a positive definite matrix $\sigma>0$ and $t>0$ such that
     $E^\dagger(\sigma)=t\sigma$. The weighted trace pairing with $\rho$ gives
     \begin{align}
         r\tr(\sigma\rho)

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -16,7 +16,7 @@
     \lean{cesaroMean_telescope}
     \leanok
     \uses{def:cesaro_mean}
-    The Ces\`aro mean satisfies
+    For $N\geq1$, the Ces\`aro mean satisfies
     \begin{align}
         E(\sigma_N)-\sigma_N
          & =\frac{1}{N}(E^N(\rho_0)-\rho_0).
@@ -42,25 +42,24 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:density_compact, thm:density_convex, thm:density_nonempty,
-        thm:channel_preserves_density, thm:cesaro_telescope}
+    \uses{thm:density_nonempty, lem:cesaro_mean_density,
+        lem:cesaro_subseq_fixed}
     Start with any $\rho_0\in\mc{D}_D$
     (Theorem~\ref{thm:density_nonempty}).
-    By Theorem~\ref{thm:channel_preserves_density}, every iterate
-    $E^n(\rho_0)$ lies in $\mc{D}_D$. For $N\geq1$,
-    Theorem~\ref{thm:density_convex} therefore places the finite average
-    $\sigma_N$ in $\mc{D}_D$.
-    By compactness (Theorem~\ref{thm:density_compact}),
-    extract a convergent subsequence $\sigma_{N_k}\to\rho$.
-    The telescope identity (\ref{eq:channel_cesaro_telescope}) gives
+    Lemma~\ref{lem:cesaro_mean_density} keeps every $\sigma_N$, $N\geq1$,
+    in the compact set $\mc{D}_D$, so a subsequence converges to some
+    $\rho\in\mc{D}_D$. The telescope identity
+    (\ref{eq:channel_cesaro_telescope}) gives
     \begin{align}
         \lVert E(\sigma_N)-\sigma_N\rVert
          & =\frac{1}{N}\lVert E^N(\rho_0)-\rho_0\rVert
         \longrightarrow0,
         \notag
     \end{align}
-    so $E(\rho)=\rho$ by continuity.
-    In~\cite[Theorem~6.11]{Wolf2012Quantum}, existence is proved
+    because the iterates $E^N(\rho_0)$ lie in the compact set
+    $\mc{D}_D$ and are therefore uniformly bounded. Equivalently,
+    Lemma~\ref{lem:cesaro_subseq_fixed} identifies the subsequential limit
+    as a fixed point. In~\cite[Theorem~6.11]{Wolf2012Quantum}, existence is proved
     via Brouwer's fixed-point theorem; we use the Ces\`aro
     argument instead.
 \end{proof}

--- a/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
+++ b/blueprint/src/chapter/ch06_qpf_cesaro_fixed_points.tex
@@ -43,7 +43,7 @@
 \begin{proof}
     \leanok
     \uses{thm:density_nonempty, lem:cesaro_mean_density,
-        lem:cesaro_subseq_fixed}
+        thm:cesaro_telescope}
     Start with any $\rho_0\in\mc{D}_D$
     (Theorem~\ref{thm:density_nonempty}).
     Lemma~\ref{lem:cesaro_mean_density} keeps every $\sigma_N$, $N\geq1$,
@@ -57,9 +57,9 @@
         \notag
     \end{align}
     because the iterates $E^N(\rho_0)$ lie in the compact set
-    $\mc{D}_D$ and are therefore uniformly bounded. Equivalently,
-    Lemma~\ref{lem:cesaro_subseq_fixed} identifies the subsequential limit
-    as a fixed point. In~\cite[Theorem~6.11]{Wolf2012Quantum}, existence is proved
+    $\mc{D}_D$ and are therefore uniformly bounded. Along the convergent
+    subsequence, continuity of $E$ now gives $E(\rho)=\rho$.
+    In~\cite[Theorem~6.11]{Wolf2012Quantum}, existence is proved
     via Brouwer's fixed-point theorem; we use the Ces\`aro
     argument instead.
 \end{proof}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -78,7 +78,7 @@
     density matrices $\sigma_k\in\MN{m_k}$ such that
     \begin{align}
         \Fix(\widetilde T)
-        &=U\left(\bigoplus_k\sigma_k\otimes\MN{d_k}\right)U^*.
+         & =U\left(\bigoplus_k\sigma_k\otimes\MN{d_k}\right)U^*.
         \label{eq:spectral_max_support_blocks}
     \end{align}
     This is the maximal-support application of the full-support step in the
@@ -109,7 +109,7 @@
     is positive definite and has the form
     \begin{align}
         U^*\rho_{\mathrm{full}}U
-        &=\bigoplus_k\sigma_k\otimes X_k.
+         & =\bigoplus_k\sigma_k\otimes X_k.
         \notag
     \end{align}
     Hence every principal block $\sigma_k\otimes X_k$ is positive definite.
@@ -130,12 +130,12 @@
     associated with a decomposition
     \begin{align}
         \C^D
-        &=\C^{d_0}\oplus
-          \bigoplus_k\C^{m_k}\otimes\C^{d_k},
-        \notag\\
+         & =\C^{d_0}\oplus
+        \bigoplus_k\C^{m_k}\otimes\C^{d_k},
+        \notag                   \\
         \Fix(T)
-        &=U\left(0_{d_0}\oplus
-          \bigoplus_k\sigma_k\otimes\MN{d_k}\right)U^*.
+         & =U\left(0_{d_0}\oplus
+        \bigoplus_k\sigma_k\otimes\MN{d_k}\right)U^*.
         \label{eq:spectral_fixed_density_blocks}
     \end{align}
     This is \cite[Theorem~6.14 and Equation~(6.63)]{Wolf2012Quantum}.
@@ -154,8 +154,8 @@
     (\ref{eq:spectral_max_support_blocks}) give
     \begin{align}
         \Fix(T)
-        &=VU_c\left(\bigoplus_k
-          \sigma_k\otimes\MN{d_k}\right)U_c^*V^*.
+         & =VU_c\left(\bigoplus_k
+        \sigma_k\otimes\MN{d_k}\right)U_c^*V^*.
         \notag
     \end{align}
     Put $W=VU_c$. Then $W^*W=\Id_n$. Compare $W$ with the canonical
@@ -166,7 +166,7 @@
     $A\in\MN{n}$,
     \begin{align}
         WAW^*
-        &=U(0_{D-n}\oplus A)U^*.
+         & =U(0_{D-n}\oplus A)U^*.
         \label{eq:spectral_zero_extension}
     \end{align}
     Substituting the compressed density-block description into
@@ -236,9 +236,9 @@ support projection.
     invertible matrices $U$ and $U^\dagger$ preserves the rank, and
     \begin{align}
         \rank\diag(\mathbf 1_{\lambda>0})
-        &=\#\{i\mid\lambda_i>0\}
-          =\#\{i\mid\lambda_i\neq0\}
-          =\rank\diag(\lambda),
+         & =\#\{i\mid\lambda_i>0\}
+        =\#\{i\mid\lambda_i\neq0\}
+        =\rank\diag(\lambda),
         \notag
     \end{align}
     where the middle equality follows because the eigenvalues of
@@ -260,9 +260,9 @@ support projection.
     With $\rho=U\diag(\lambda)U^\dagger$ as above,
     \begin{align}
         \tr\!\left(U\diag(\mathbf 1_{\lambda>0})U^\dagger\right)
-        &=\tr\diag(\mathbf 1_{\lambda>0})
-          =\#\{i\mid\lambda_i>0\}
-          =\rank\rho,
+         & =\tr\diag(\mathbf 1_{\lambda>0})
+        =\#\{i\mid\lambda_i>0\}
+        =\rank\rho,
         \notag
     \end{align}
     where the last equality follows because the rank of a positive
@@ -270,7 +270,7 @@ support projection.
 \end{proof}
 
 \begin{theorem}[The support of a fixed point of maximum rank carries every fixed
-    point]%
+        point]%
     \label{thm:maximalSupport_of_maximalRank}
     \lean{Kraus.maximalSupport_of_maximalRank}
     \leanok
@@ -300,9 +300,9 @@ support projection.
     $\rank\rho_0\leq\rank\rho$. Conversely, $Q_0\rho Q_0=\rho$, so
     \begin{align}
         \rank\rho
-        &=\rank(Q_0\rho Q_0)
-          \leq\rank Q_0
-          =\rank\rho_0,
+         & =\rank(Q_0\rho Q_0)
+        \leq\rank Q_0
+        =\rank\rho_0,
         \notag
     \end{align}
     where the last equality is
@@ -312,18 +312,18 @@ support projection.
     $\Id-Q_0$ lies in the kernel of $\rho$. The support projection $P$ of
     $\rho$ vanishes on that kernel, and therefore
     \begin{align}
-        P(\Id-Q_0)&=0,
-        &
-        PQ_0&=P,
-        &
-        Q_0P&=P.
+        P(\Id-Q_0) & =0,
+                   &
+        PQ_0       & =P,
+                   &
+        Q_0P       & =P.
         \notag
     \end{align}
     The last identity follows by taking conjugate transposes. The difference
     $R=Q_0-P$ is Hermitian and idempotent, since
     \begin{align}
         R^2
-        &=Q_0-P-P+P=R.
+         & =Q_0-P-P+P=R.
         \notag
     \end{align}
     Its trace vanishes by Lemma~\ref{lem:trace_stationaryProj} and the
@@ -367,21 +367,10 @@ of Corollary~6.7 of~\cite{Wolf2012Quantum}.
 
 \section{Further irreducibility and primitivity equivalences}
 
-This section collects several criteria and equivalences from
-\cite[Theorems~6.2, 6.7, 6.8]{Wolf2012Quantum} that are used later.
-
-\begin{theorem}[Exponential positivity condition]%
-    \label{thm:wolf_6_2_item_3}
-    \lean{exp_posDef_of_irreducible_cp}
-    \lean{irreducible_iff_exp_posDef_forall}
-    \leanok
-    \uses{def:irreducible_cp}
-    Let $E$ be an irreducible completely positive map, $A\geq0$ with
-    $A\neq0$, and $t>0$. Then $\exp(tE)(A)$ is positive definite.
-    Conversely, if $\exp(tE)(A)$ is positive definite for every such $t$
-    and $A$, then $E$ is irreducible (full equivalence
-    \lean{irreducible_iff_exp_posDef_forall}).
-\end{theorem}
+This section collects criteria and equivalences from
+\cite[Theorems~6.7 and~6.8]{Wolf2012Quantum} that are used later. The
+completely positive exponential characterization corresponding to Wolf's
+Theorem~6.2 appears in Theorem~\ref{thm:wolf_6_2_item_3}.
 
 \begin{theorem}[Kraus-span equivalence]%
     \label{thm:wolf_6_8_kraus_span}
@@ -439,9 +428,9 @@ arbitrary peripheral periods.
     $\sigma\in\mathrm{Sym}(\iota)$, not necessarily a single cycle, such
     that, for every $k\in\iota$ and $X\in\MN{D}$,
     \begin{align}
-        T(P_{\sigma(k)})&=P_k, \notag\\
-        T(P_kX)&=T(P_k)T(X), \notag\\
-        T(XP_k)&=T(X)T(P_k).
+        T(P_{\sigma(k)}) & =P_k, \notag        \\
+        T(P_kX)          & =T(P_k)T(X), \notag \\
+        T(XP_k)          & =T(X)T(P_k).
         \notag
     \end{align}
     In general, $\sigma$ may have multiple disjoint cycles.


### PR DESCRIPTION
## What changed
- expand the Chapter 6 appendix into five coherent sections covering density/Brouwer/Cesàro support, canonical-gauge algebra, similarity bookkeeping, Perron reductions, and exponential/scalar support
- keep Perron–Frobenius, irreducibility, gauge, ergodicity, and spectral-characterization results in main text while moving seven auxiliary blocks and three detailed gauge calculations
- add the formal CP growth theorem, positive-map PSD eigenvector-existence result, and Cesàro subsequence bridge; correct the spectral-radius proof and Cesàro boundedness argument
- consolidate the CP exponential irreducibility characterization in Chapter 6 and remove its duplicate Chapter 27 presentation
- align Wolf Chapter 6 attributions with the exact CP specializations and PSD-eigenvector uniqueness surface formalized here

## Validation
- independent mathematical/source review: no high/medium findings; final low attribution issue fixed
- Blueprint/source sync: Chapter 6 main 29/29, appendix 17/17
- full/focused route scans: zero duplicate labels or unresolved `\\ref`, `\\eqref`, or `\\uses` targets
- direct double LuaLaTeX: 706 / 159 pages, zero specific undefined cross-references
- exact `latexindent -k` checks and `git diff --check`

No Lean source changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX blueprint exposition and cross-reference reorganization only; no executable Lean or runtime code changes.
> 
> **Overview**
> **Reorganizes Chapter 6 (Perron–Frobenius / irreducible CP maps)** by growing the appendix into five sections (density/Brouwer/Cesàro, gauge algebra, similarity, Perron auxiliaries, exponential truncation) and **moving** Brouwer, detailed gauge sums, similarity lemmas, adjoint-transfer nonzero, real spectral-radius corollary, and finite exponential truncation out of the main chapter.
> 
> The **main chapter** keeps the narrative theorems but **adds** formal `growth_posDef_of_irreducible_cp`, splits PSD eigenvector existence into general vs positive-eigenvalue cases, adds PSD eigenvector uniqueness and the **full CP exponential irreducibility equivalence** (`irreducible_iff_exp_posDef_forall`), and **reorders** injectivity results to reduce to irreducible versions. Gauge and similarity proofs in main are shortened with pointers to the appendix.
> 
> **Proof fixes:** Cesàro channel fixed-point existence now cites Cesàro-density lemmas and **uniform boundedness in** `\mathcal{D}_D`; spectral-radius = Perron eigenvalue is rewritten with explicit dual trace pairing and TP-gauge rescaling. Wolf attributions are tightened to **CP specializations** and **restricted** spectral properties (PSD Perron uniqueness only, not full eigenspace).
> 
> **Chapter 27** drops the duplicate Wolf 6.2(3) block and cross-references Chapter 6. Minor align-environment formatting elsewhere. No Lean changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3539ac3d816941ca61930740d24a2d06be47030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->