### PR TITLE
refactor(Algebra): finish the gauge-extraction ladder migration (#4595 follow-up)

### DIFF
--- a/TNLean/Algebra/SkolemNoether.lean
+++ b/TNLean/Algebra/SkolemNoether.lean
@@ -25,6 +25,12 @@ This file provides the "abstract algebra" ingredients for the Fundamental Theore
   `Matrix n n ℂ` is inner (conjugation by an invertible matrix).
 * **`linearMapToAlgHom`**: Promotes a multiplicative surjective linear map to an algebra
   homomorphism (proving `T 1 = 1`).
+* `linearMap_ne_zero_of_map_one`: a unital linear endomorphism of a matrix algebra
+  is nonzero.
+* **`exists_inner_of_linear_mul_endomorphism`**: the packaged gauge-extraction ladder —
+  a nonzero multiplicative linear endomorphism is inner (simplicity gives bijectivity,
+  and Skolem–Noether turns the resulting algebra equivalence into conjugation by an
+  invertible matrix).
 -/
 
 open scoped Matrix
@@ -60,6 +66,16 @@ theorem linear_mul_endomorphism_bijective
       intro A B hAB
       exact (TwoSidedIdeal.ker_eq_bot (f := f)).1 hker hAB
     exact ⟨hinj, LinearMap.surjective_of_injective hinj⟩
+
+/-- A unital linear endomorphism of a matrix algebra is nonzero. -/
+theorem linearMap_ne_zero_of_map_one {D : ℕ} [NeZero D]
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hOne : T 1 = 1) : T ≠ 0 := by
+  intro h0
+  have h10 : (1 : Matrix (Fin D) (Fin D) ℂ) = 0 := by
+    rw [← hOne, h0]
+    rfl
+  exact one_ne_zero h10
 
 /-- Full matrix algebras over `ℂ` can be algebra-isomorphic only when their
 matrix sizes agree.
@@ -178,5 +194,26 @@ noncomputable def linearMapToAlgHom
         { toFun := T, map_one' := hOne, map_mul' := hMul,
           map_zero' := by simp, map_add' := T.map_add }
       commutes' := fun c => by simp [Algebra.algebraMap_eq_smul_one, hOne] }
+
+/-- A nonzero multiplicative $\C$-linear endomorphism of a full matrix algebra is inner.
+
+Simplicity makes the endomorphism bijective. Its surjectivity promotes it to an algebra
+homomorphism, bijectivity upgrades that homomorphism to an algebra equivalence, and
+Skolem--Noether realizes the equivalence as conjugation by an invertible matrix. -/
+theorem exists_inner_of_linear_mul_endomorphism
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hMul : ∀ M N, T (M * N) = T M * T N)
+    (hNonzero : T ≠ 0) :
+    ∃ X : GL (Fin D) ℂ, ∀ M : Matrix (Fin D) (Fin D) ℂ,
+      T M = (X : Matrix (Fin D) (Fin D) ℂ) * M *
+        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+  classical
+  have hBij := linear_mul_endomorphism_bijective T hMul hNonzero
+  let fHom := linearMapToAlgHom T hMul hBij.surjective
+  let f := AlgEquiv.ofBijective fHom hBij
+  obtain ⟨X, hX⟩ := skolemNoether_matrix f
+  refine ⟨X, fun M => ?_⟩
+  change f M = _
+  exact hX M
 
 end MPSTensor

--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -190,16 +190,9 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   -- Td is multiplicative
   have hMul :=
     ChannelDeterminant.Internal.heisenberg_dual_multiplicative hT hdet hall K hK hK_tp Td hTd_def
-  have hTd_ne : Td ≠ 0 := by
-    intro h
-    have := congr_fun (congr_arg DFunLike.coe h) 1
-    simp only [hTd_one, LinearMap.zero_apply, one_ne_zero] at this
-  -- Td is bijective (nonzero multiplicative map on simple algebra)
-  have hTd_bij := MPSTensor.linear_mul_endomorphism_bijective Td hMul hTd_ne
-  -- Skolem–Noether: Td(X) = PXP⁻¹
-  let Td_alg := MPSTensor.linearMapToAlgHom Td hMul hTd_bij.2
-  let Td_equiv : MatrixAlg d ≃ₐ[ℂ] MatrixAlg d := AlgEquiv.ofBijective Td_alg hTd_bij
-  obtain ⟨P, hP⟩ := MPSTensor.skolemNoether_matrix Td_equiv
+  have hTd_ne : Td ≠ 0 := MPSTensor.linearMap_ne_zero_of_map_one Td hTd_one
+  -- Skolem–Noether: Td(X) = PXP⁻¹ (nonzero multiplicative endomorphisms are inner)
+  obtain ⟨P, hP⟩ := MPSTensor.exists_inner_of_linear_mul_endomorphism Td hMul hTd_ne
   -- Key identities for P
   have hPinvP : (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * (↑P : MatrixAlg d) = 1 := by
     have : (P⁻¹ * P : GL (Fin d) ℂ) = 1 := inv_mul_cancel _
@@ -227,7 +220,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
     change trace (A * Td B) =
       trace ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A *
         (↑P : MatrixAlg d) * B)
-    rw [show Td B = Td_equiv B from rfl, hP B]
+    rw [hP B]
     simpa only [Matrix.mul_assoc] using
       (Matrix.trace_mul_cycle (A * (↑P : MatrixAlg d)) B
         ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)))
@@ -241,8 +234,7 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
           (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ * Xᴴ * (↑P : MatrixAlg d)ᴴ := by
       intro X
       have h := hTd_star X
-      rw [show Td Xᴴ = Td_equiv Xᴴ from rfl, hP Xᴴ] at h
-      rw [show Td X = Td_equiv X from rfl, hP X] at h
+      rw [hP Xᴴ, hP X] at h
       simpa only [coe_units_inv, Matrix.mul_assoc, conjTranspose_mul] using h
     have hPstarPinvstar :
         (↑P : MatrixAlg d)ᴴ * (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)ᴴ = 1 := by

--- a/TNLean/MPS/Chain/AlgebraIsomorphism.lean
+++ b/TNLean/MPS/Chain/AlgebraIsomorphism.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.MPS.Chain.Defs
 import TNLean.MPS.Structure.LinearExtension
-import TNLean.MPS.FundamentalTheorem.Basic
+import TNLean.Algebra.SkolemNoether
 /-!
 # Algebra isomorphism between virtual bond algebras
 

--- a/TNLean/MPS/FundamentalTheorem/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/Basic.lean
@@ -69,27 +69,6 @@ theorem fundamentalTheorem_singleBlock {A B : MPSTensor d D}
         exact hT i
       simpa [hfi] using hX (A i)
 
-/-- A nonzero multiplicative complex-linear endomorphism of a full matrix algebra is inner.
-
-Simplicity makes the endomorphism bijective. Its surjectivity promotes it to an algebra
-homomorphism, bijectivity upgrades that homomorphism to an algebra equivalence, and
-Skolem--Noether realizes the equivalence as conjugation by an invertible matrix. -/
-theorem exists_inner_of_linear_mul_endomorphism
-    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (hMul : ∀ M N, T (M * N) = T M * T N)
-    (hNonzero : T ≠ 0) :
-    ∃ X : GL (Fin D) ℂ, ∀ M : Matrix (Fin D) (Fin D) ℂ,
-      T M = (X : Matrix (Fin D) (Fin D) ℂ) * M *
-        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
-  classical
-  have hBij := linear_mul_endomorphism_bijective T hMul hNonzero
-  let fHom := linearMapToAlgHom T hMul hBij.surjective
-  let f := AlgEquiv.ofBijective fHom hBij
-  obtain ⟨X, hX⟩ := skolemNoether_matrix f
-  refine ⟨X, fun M => ?_⟩
-  change f M = _
-  exact hX M
-
 /-- For injective `A`, MPV equality with any `B` is equivalent to gauge equivalence. -/
 theorem sameMPV_iff_gaugeEquiv_of_injective {A B : MPSTensor d D}
     (hA : IsInjective A) :

--- a/TNLean/MPS/FundamentalTheorem/Basic.lean
+++ b/TNLean/MPS/FundamentalTheorem/Basic.lean
@@ -54,20 +54,13 @@ theorem fundamentalTheorem_singleBlock {A B : MPSTensor d D}
   | succ D' =>
       -- Obtain the linear extension `T` with `T (A i) = B i`.
       rcases linearExtension_exists_unique hA hAB with ⟨T, hT, -⟩
-      -- Multiplicativity + nonzero → bijective.
+      -- Multiplicativity + nonzero → inner by the packaged gauge ladder.
       have hMul := linearExtension_mul hA hAB hT
-      have hBij := linear_mul_endomorphism_bijective T hMul (linearExtension_nonzero hA hAB hT)
-      -- Promote `T` to an algebra equivalence and apply Skolem–Noether.
-      let fHom := linearMapToAlgHom T hMul hBij.surjective
-      let f := AlgEquiv.ofBijective fHom hBij
-      rcases skolemNoether_matrix f with ⟨X, hX⟩
+      obtain ⟨X, hX⟩ := exists_inner_of_linear_mul_endomorphism T hMul
+        (linearExtension_nonzero hA hAB hT)
       refine ⟨X, fun i => ?_⟩
-      -- `B i = T (A i) = f (A i) = X * A i * X⁻¹`.
-      have hfi : f (A i) = B i := by
-        change fHom (A i) = B i
-        change T (A i) = B i
-        exact hT i
-      simpa [hfi] using hX (A i)
+      -- `B i = T (A i) = X * A i * X⁻¹`.
+      exact (hT i).symm.trans (hX (A i))
 
 /-- For injective `A`, MPV equality with any `B` is equivalent to gauge equivalence. -/
 theorem sameMPV_iff_gaugeEquiv_of_injective {A B : MPSTensor d D}

--- a/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
@@ -578,23 +578,9 @@ theorem exists_conjugation_of_sameState [NeZero n] {L : ℕ} (hL : 0 < L)
     rwa [show p + (n - L) + L = p + n by omega, arcEval_add_n,
       arcEval_add_n] at h
   -- `Φ` is unital, hence nonzero, hence an automorphism, hence inner.
-  have hΦne : Φ ≠ 0 := by
-    intro h0
-    haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
-    apply (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)
-    rw [← hΦone, h0]
-    rfl
-  have hBij := MPSTensor.linear_mul_endomorphism_bijective Φ hΦmul hΦne
-  let fHom := MPSTensor.linearMapToAlgHom Φ hΦmul hBij.surjective
-  let f := AlgEquiv.ofBijective fHom hBij
-  obtain ⟨P, hP⟩ := MPSTensor.skolemNoether_matrix f
-  have hΦP : ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      Φ X = (P : Matrix (Fin D) (Fin D) ℂ) * X *
-        ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
-    intro X
-    have : f X = Φ X := rfl
-    rw [← this]
-    exact hP X
+  haveI : NeZero D := NeZero.of_pos hD
+  have hΦne : Φ ≠ 0 := MPSTensor.linearMap_ne_zero_of_map_one Φ hΦone
+  obtain ⟨P, hΦP⟩ := MPSTensor.exists_inner_of_linear_mul_endomorphism Φ hΦmul hΦne
   -- Strip the insertions: the arc products are conjugate.
   refine ⟨P, fun w hw => ?_⟩
   have hAw : arcEval A p w =

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -164,6 +164,30 @@ abstracted — record why, so it is not re-proposed).
   body, is unchanged; the `triFiber_card`, `agreeing_summand_eq`, and
   `agreeingTripleSum_collapse` consumers compile untouched.
 
+### Gauge-extraction ladder packaged for matrix-algebra endomorphisms
+- **Pattern:** three sites re-ran the same four-step gauge ladder —
+  simplicity-bijectivity (`linear_mul_endomorphism_bijective`) →
+  `linearMapToAlgHom` → `AlgEquiv.ofBijective` → `skolemNoether_matrix` → inner —
+  plus per-site shims unwrapping the algebra equivalence back to the linear map:
+  four `change`-shims in `fundamentalTheorem_singleBlock`
+  (`MPS/FundamentalTheorem/Basic.lean`), a 7-line `f`↦`Φ` unwrap in
+  `exists_conjugation_of_sameState` (`PEPS/CycleMPSChainOverlapInsertion.lean`),
+  and three `show … from rfl` rewrites in
+  `forward_det_one_implies_unitaryChannel`
+  (`Channel/Determinant/UnitaryCharacterization.lean`). Two sites also
+  duplicated a 5–6-line unital⇒nonzero inline proof.
+- **Reuse:** `MPSTensor.exists_inner_of_linear_mul_endomorphism` relocated from
+  `FundamentalTheorem/Basic.lean` to `Algebra/SkolemNoether.lean` beside its
+  three ingredients; all three sites now obtain the gauge matrix in one
+  `obtain`, and the unital⇒nonzero duplications use the new
+  `MPSTensor.linearMap_ne_zero_of_map_one` (`T 1 = 1 → T ≠ 0`).
+  `Chain/AlgebraIsomorphism.lean` now imports `Algebra.SkolemNoether` directly
+  (its `FundamentalTheorem.Basic` import existed solely for the lemma).
+- **Result:** 5 files changed, 51 insertions against 64 deletions (13 lines
+  net; 29 lines net at the three migration sites). All theorem statements and
+  blueprint links unchanged. This finishes #4595's migration and discharges
+  the last open item of #4518 (ledger D2).
+
 ---
 
 ## Candidates


### PR DESCRIPTION
## Summary

Finishes #4595's gauge-engine migration, discharging the last open item of #4518 (proof-debt ledger D2). The packaged ladder `MPSTensor.exists_inner_of_linear_mul_endomorphism` had only 1 of 4 call sites migrated; the three surviving inline copies of the identical 4-line ladder (simplicity-bijectivity → `linearMapToAlgHom` → `AlgEquiv.ofBijective` → `skolemNoether_matrix` → inner) are now migrated, and the lemma moves to its natural home beside its ingredients.

Closes #4518. Scoped per the scout report posted on the issue (comment); the issue's other three items already landed (`SameStateBridgeHyp` deleted with the capstone work, `*InjectivityHypotheses` unified by #4763/#4767, TI-mirror collapse `35cea690e`).

## What changes (5 files, net −13; −29 at the migration sites)

- **`Algebra/SkolemNoether.lean`** (+37): `exists_inner_of_linear_mul_endomorphism` relocated here verbatim (name + `MPSTensor` namespace unchanged), plus new micro-lemma `linearMap_ne_zero_of_map_one` (a unital linear endomorphism of a matrix algebra is nonzero — kills two duplicated 5–6-line inline proofs), plus module-doc bullets.
- **`MPS/FundamentalTheorem/Basic.lean`** (−28 net): `fundamentalTheorem_singleBlock` now obtains the gauge matrix in one `obtain`; the inline ladder and four `change`-shims are gone. The private `linearExtension_nonzero` (trace-contradiction) stays.
- **`PEPS/CycleMPSChainOverlapInsertion.lean`** (−14 net): `exists_conjugation_of_sameState` migrates; the ladder and the 7-line `f`↦`Φ` unwrap are deleted wholesale (`NeZero.of_pos hD` supplies the instance).
- **`Channel/Determinant/UnitaryCharacterization.lean`** (−8 net): `forward_det_one_implies_unitaryChannel` migrates; the three `show Td _ = Td_equiv _ from rfl` shims become direct rewrites (`MatrixAlg`/`MatrixEnd` are `abbrev`s, zero cast friction).
- **`MPS/Chain/AlgebraIsomorphism.lean`** (+1/−1): import swapped to `Algebra.SkolemNoether` — its `FundamentalTheorem.Basic` import existed solely for the relocated lemma (#4595 blame).
- `docs/tactic_patterns.md` completed-refactors entry.

Every migrated theorem statement is **byte-identical** (verified in the diff: no signature line appears in any hunk). The surviving Skolem–Noether sites the scout classified as non-specializable (`PairHomogenization`, `BlockPermutation`, `DirectSumBlockPermutation`, the PEPS stack) are documented in the issue comment as irreducible 1-liners — nothing left to extract.

## Verification

- Full `lake build` green (9741 jobs) on the rebased head (over `8e5b1113`, includes #4811).
- `blueprint_lean_sync.py --update-lean-decls` + `--ci` exit 0; no `\lean{}` tag references the moved lemma (grep-verified).
- `generate_import_aggregators.py --check` exit 0 (46/1036 unchanged); module-policy and oversized/numbered-file checks exit 0.
- No `sorry`/`admit`/`axiom`; `lake exe lint_style` exit 0; `git diff --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with lemmas relocated and duplicated tactics removed; no API or behavioral changes beyond import paths.
> 
> **Overview**
> **Centralizes** the Skolem–Noether “gauge-extraction” pipeline in `Algebra/SkolemNoether.lean`: `exists_inner_of_linear_mul_endomorphism` moves out of `MPS/FundamentalTheorem/Basic.lean`, and **`linearMap_ne_zero_of_map_one`** (`T 1 = 1 → T ≠ 0`) replaces repeated inline unital⇒nonzero proofs.
> 
> **Call sites** in the fundamental theorem, PEPS `exists_conjugation_of_sameState`, and channel `forward_det_one_implies_unitaryChannel` now get the conjugating `GL` matrix in a single `obtain` instead of re-running bijectivity → `linearMapToAlgHom` → `AlgEquiv.ofBijective` → `skolemNoether_matrix` (and drop `change` / `show … from rfl` shims). `MPS/Chain/AlgebraIsomorphism.lean` imports `Algebra.SkolemNoether` directly instead of pulling the lemma via `FundamentalTheorem.Basic`.
> 
> Theorem statements are unchanged; `docs/tactic_patterns.md` records the completed refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556ff7a5a6c53d4200c843b11b4f90ac624880ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->