### PR TITLE
refactor(PEPS): remove dead union-injectivity wrappers

### DIFF
--- a/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
@@ -82,113 +82,6 @@ def NormalEdgeBlockingData.toThreeBlockGeometry
   blue_disjoint_complement := D.blue_disjoint_complement
   cover_univ := D.cover_univ
 
-/-! ### The blue inversion of the host annihilation
-
-A coefficient family `c` annihilating the blocked-region weight family of the host
-`univ \ red` annihilates, at every fused blue/complement physical leg, the host
-weight. Reading the resulting identity as a function of the blue physical leg and
-applying the blue block's chosen left inverse strips the blue block, leaving the
-`c`-weighted complement coupling coefficients vanishing for every complement physical
-leg and blue boundary configuration. -/
-
-open scoped Classical in
-/-- The blue block strips out of the host annihilation. If the coefficient family `c`
-annihilates the blocked-region weight family of the host `univ \ red`, then for every
-complement physical leg `σcompl` and blue boundary configuration `bβ`, the
-`c`-weighted sum of complement coupling coefficients
-`threeBlockComplCoeff D bdry σcompl bβ` vanishes.
-
-The annihilation, evaluated at the fused leg `threeBlockComplPhysical D σblue σcompl`,
-holds for every blue leg `σblue`. Scaling by the nonzero blue interior bond product
-and applying the blue scalar-multiplication factorization
-(`regionInteriorBondProd_smul_threeBlockBlueWeight_eq`) rewrites the host weights as
-the complement-coupling combination of the blue blocked-region weights; the blue
-block's chosen left inverse then reads off the complement coupling row.
-
-Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
-`Papers/1804.04964/paper_normal.tex`. -/
-theorem complCoeff_combination_eq_zero
-    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
-    (c : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red) → ℂ)
-    (hc : ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
-        c bdry • regionBlockedWeight (G := G) A (Finset.univ \ D.red) bdry = 0)
-    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
-    (bβ : RegionBoundaryConfig (G := G) A D.blue) :
-    ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red),
-        c bdry • threeBlockComplCoeff (A := A) (e := e) D bdry σcompl bβ = 0 :=
-  D.toThreeBlockGeometry.complCoeff_combination_eq_zero
-    (regionBlockedTensorInjective_blue (A := A) (e := e) D) c hc σcompl bβ
-
-/-! ### The blue/red crossing multiplicity collapse of the complement coupling
-
-The complement coupling coefficient `threeBlockComplCoeff D bdry σcompl bβ`, read as a
-function of the complement physical leg `σcompl`, lies in the range of the complement
-block's blocked-region tensor map, with the coefficient row supported on the single
-host residual `bdry` reconstructed from `bβ` and the complement boundary configuration.
-
-The route mirrors `stateCoeff_eq_regionComplement` at the level of the constrained
-coupling sum. Grouping the global configurations of `threeBlockComplCoeff` by the
-complement boundary configuration `bc'` they induce, each inner sum runs over the
-configurations carrying the three prescribed boundary labels (host `bdry`, blue `bβ`,
-complement `bc'`). The complement blocked-region weight at `bc'` runs over the larger
-family of configurations carrying only the complement label `bc'`; the difference is
-the free virtual indices on the red/blue crossing edges, which the complement vertex
-product ignores. Projecting away those crossing indices collapses the larger sum onto
-the constrained sum with the red/blue crossing bond product as the constant fiber
-multiplicity. When no configuration carries the three labels (the host residual is not
-the one reconstructed from `bβ` and `bc'`, or `bβ` and `bc'` clash on a blue/complement
-crossing edge) the constrained sum is empty and the collapse is the zero identity. -/
-
-/-- The red/blue crossing edges: the boundary edges of the red block that are also
-boundary edges of the blue block. These are the free virtual indices distinguishing the
-complement blocked-region weight from the constrained complement coupling sum. -/
-def IsBlueRedCrossingEdge
-    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) (g : Edge G) :
-    Prop :=
-  IsRegionBoundaryEdge (G := G) D.red g ∧ IsRegionBoundaryEdge (G := G) D.blue g
-
-instance
-    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) (g : Edge G) :
-    Decidable (IsBlueRedCrossingEdge (A := A) (e := e) D g) := by
-  unfold IsBlueRedCrossingEdge; infer_instance
-
-/-- The bond-dimension product over the red/blue crossing edges: the constant fiber
-multiplicity of the complement coupling collapse. -/
-noncomputable def blueRedCrossingBondProd
-    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e) : ℕ :=
-  ∏ g ∈ Finset.univ.filter (fun g : Edge G => IsBlueRedCrossingEdge (A := A) (e := e) D g),
-    A.bondDim g
-
-open scoped Classical in
-/-- **The per-fiber complement weight collapse.** When some global configuration `q₀`
-carries the three boundary labels (host `bdry`, blue `bβ`, complement `bc'`), the
-complement blocked-region weight at `bc'` is the red/blue crossing bond product times
-the constrained complement coupling sum over the configurations carrying the three
-labels. Grouping the complement-labelled configurations by overwriting their red/blue
-crossing indices with those of `q₀`, the complement vertex product is constant on each
-fiber and each fiber has cardinality the red/blue crossing bond product. -/
-theorem regionBlockedWeight_complement_eq_smul_constrained
-    (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
-    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ D.red))
-    (bβ : RegionBoundaryConfig (G := G) A D.blue)
-    (bc' : RegionBoundaryConfig (G := G) A D.complement)
-    (σcompl : RegionPhysicalConfig (V := V) (d := d) D.complement)
-    (q₀ : VirtualConfig A)
-    (hq0host : regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q₀ = bdry)
-    (hq0blue : regionBoundaryLabel (G := G) A D.blue q₀ = bβ)
-    (hq0compl : regionBoundaryLabel (G := G) A D.complement q₀ = bc') :
-    regionBlockedWeight (G := G) A D.complement bc' σcompl =
-      blueRedCrossingBondProd (A := A) (e := e) D •
-        ∑ q ∈ Finset.univ.filter
-            (fun q : VirtualConfig A =>
-              regionBoundaryLabel (G := G) A (Finset.univ \ D.red) q = bdry ∧
-                regionBoundaryLabel (G := G) A D.blue q = bβ ∧
-                  regionBoundaryLabel (G := G) A D.complement q = bc'),
-          ∏ w : {w : V // w ∈ D.complement},
-            A.component w.1 (fun ie => q ie.1) (σcompl w) :=
-  D.toThreeBlockGeometry.regionBlockedWeight_complement_eq_smul_constrained
-    bdry bβ bc' σcompl q₀ hq0host hq0blue hq0compl
-
 /-! ### The union of the blue and complement blocks is injective
 
 Assembling the blue inversion, the complement coupling collapse, and the host boundary
@@ -202,7 +95,8 @@ open scoped Classical in
 `NormalEdgeBlockingData`, is blocked-tensor injective.
 
 A coefficient family `c` annihilating the host blocked-region weight family is stripped
-of the blue block (`complCoeff_combination_eq_zero`), leaving the `c`-weighted complement
+of the blue block (`ThreeBlockGeometry.complCoeff_combination_eq_zero`), leaving the
+`c`-weighted complement
 coupling coefficients vanishing for every complement physical leg and blue boundary
 configuration. The complement coupling collapse
 (`ThreeBlockGeometry.blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq`) reads each as
@@ -216,8 +110,6 @@ Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 o
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem regionBlockedTensorInjective_union
     (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
-    (_hblue : RegionBlockedTensorInjective (G := G) A D.blue)
-    (_hcompl : RegionBlockedTensorInjective (G := G) A D.complement)
     (hpos : ∀ g : Edge G, 0 < A.bondDim g) :
     RegionBlockedTensorInjective (G := G) A (Finset.univ \ D.red) :=
   D.toThreeBlockGeometry.regionBlockedTensorInjective_union
@@ -235,9 +127,7 @@ theorem regionBlockedTensorInjective_compl_red
     (D : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
     (hpos : ∀ g : Edge G, 0 < A.bondDim g) :
     RegionBlockedTensorInjective (G := G) A (Finset.univ \ D.red) :=
-  regionBlockedTensorInjective_union (A := A) (e := e) D
-    (regionBlockedTensorInjective_blue (A := A) (e := e) D)
-    (regionBlockedTensorInjective_complement (A := A) (e := e) D) hpos
+  regionBlockedTensorInjective_union (A := A) (e := e) D hpos
 
 end PEPS
 end TNLean

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -212,6 +212,17 @@ abstracted — record why, so it is not re-proposed).
   `regionBlockedTensorInjective_compl_red` and the blueprint ch24 `\lean{}` tags
   are untouched; the two surviving docstring citations are re-pointed at the
   `ThreeBlockGeometry` twins.
+- **Follow-up (#4822):** the two surviving wrappers were code-dead (no Lean
+  consumers; all call sites use the `ThreeBlockGeometry` twins), so they were
+  dropped together with their section docs, and the `IsBlueRedCrossingEdge` +
+  `blueRedCrossingBondProd` D-side support chain cascaded with them (its only
+  consumer was the deleted collapse wrapper; the live consumers all use the
+  `ThreeBlockGeometry` versions). The vestigial `_hblue`/`_hcompl` hypotheses
+  came off `regionBlockedTensorInjective_union`'s signature (the proof already
+  re-derives both internally via `regionBlockedTensorInjective_blue`/
+  `regionBlockedTensorInjective_complement`), and the sole consumer
+  `regionBlockedTensorInjective_compl_red` stops passing them.
+  `UnionInjectivity.lean` is now 133 lines (net −110 on the follow-up).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Issue #4822 identifies two public wrappers with no remaining consumers and two hypotheses that are not used by the union-injectivity argument.
- The surviving union theorem continues to represent the argument from arXiv:1804.04964, Section 3, Lemma injective_union, lines 1324--1400 of Papers/1804.04964/paper_normal.tex.

### Description
- Delete complCoeff_combination_eq_zero and regionBlockedWeight_complement_eq_smul_constrained from UnionInjectivity.lean; their ThreeBlockGeometry counterparts remain the canonical statements.
- Remove the unused blue- and complement-injectivity hypotheses from regionBlockedTensorInjective_union and simplify its sole consumer.
- Record the completed cleanup in docs/tactic_patterns.md. No blueprint declaration tag is removed or redirected.

### Testing
- lake env lean TNLean/PEPS/RegionBlock/UnionInjectivity.lean
- python3 scripts/blueprint_lean_sync.py --ci
- python3 scripts/tactic_pattern_scan.py
- git diff --check

Closes #4822

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal and API surface cleanup; the union-injectivity argument and blueprint-linked theorems are unchanged, with canonical statements still in `ThreeBlockGeometry`.
> 
> **Overview**
> Follow-up to the `UnionInjectivity` ↔ `ThreeBlockGeometry` mirror migration: **`UnionInjectivity.lean` no longer re-exports duplicate lemmas**—`complCoeff_combination_eq_zero`, `regionBlockedWeight_complement_eq_smul_constrained`, and the D-side `IsBlueRedCrossingEdge` / `blueRedCrossingBondProd` chain are removed because nothing in Lean called them (live code uses the `ThreeBlockGeometry` versions in `UnionInjectivityGeneral2`).
> 
> **`regionBlockedTensorInjective_union`** now only takes blocking data and positive bond dimensions; the unused `_hblue` / `_hcompl` arguments are gone since the proof already obtains blue and complement injectivity internally. **`regionBlockedTensorInjective_compl_red`** is updated to match. Docstrings on the surviving union theorems cite the `ThreeBlockGeometry` names instead of the deleted wrappers.
> 
> The tactic-pattern ledger records that the file shrinks to ~133 lines on this follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04cf2310ff8806909aa0f2e4c0feb2edb9e89db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->