### PR TITLE
feat(Channel/Schwarz): identify support relative-modular solution

### DIFF
--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -37,6 +37,7 @@ import TNLean.Channel.Schwarz.SchwarzNormal
 import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.SchwarzSubnormal
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
+import TNLean.Channel.Schwarz.SupportLeftRightRelativeModular
 import TNLean.Channel.Schwarz.SupportRelativeModular
 import TNLean.Channel.Schwarz.SupportResolvent
 import TNLean.Channel.Schwarz.TwoPositive

--- a/TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Analysis.RelativeEntropySupportLeftRightQuadratic
 import TNLean.Channel.Schwarz.SupportRelativeModular
 
 /-!
@@ -79,29 +78,13 @@ theorem supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular
   let y : n × n → ℂ := P *ᵥ (res⁻¹ *ᵥ e)
   have hBplus_mul : Bplus * B = hB.isHermitian.supportProj := by
     simpa only [Bplus] using hB.supportInv_mul_self
-  have hBplusPSD : Bplus.PosSemidef := by
-    simpa only [Bplus, PosSemidef.supportInv,
-      hB.supportInvSqrt_isHermitian.eq] using
-        posSemidef_conjTranspose_mul_self hB.supportInvSqrt
-  have hdelta : delta.PosSemidef := hA.kronecker hBplusPSD.transpose
-  have hres : res.PosDef :=
-    (Matrix.PosDef.one.smul ht).add_posSemidef hdelta
+  have hres : res.PosDef := by
+    simpa only [res, delta, Bplus] using
+      supportRelativeModular_resolvent_posDef hA hB ht
   letI : Invertible res := hres.isUnit.invertible
-  have hCdelta :
-      C * delta = A ⊗ₖ hB.isHermitian.supportProjᵀ := by
-    dsimp only [C, delta]
-    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
-      ← Matrix.transpose_mul, hBplus_mul]
-  have hBTP : Bᵀ * hB.isHermitian.supportProjᵀ = Bᵀ := by
-    rw [← Matrix.transpose_mul, hB.isHermitian.supportProj_mul_self]
   have hSP : S * P = C * res := by
-    dsimp only [S, supportLeftRightSuperoperator, P, C, res]
-    rw [Matrix.add_mul, Matrix.smul_mul,
-      ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
-      Matrix.mul_one, Matrix.one_mul, hBTP,
-      Matrix.mul_add, Matrix.mul_smul, Matrix.mul_one, hCdelta]
-    simp only [Matrix.mul_one]
-    abel
+    simpa only [S, P, C, res, delta, Bplus] using
+      supportLeftRightSuperoperator_mul_supportProj_eq (A := A) hB t
   have hCD : C * D = P := by
     dsimp only [C, D, P]
     rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,

--- a/TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.RelativeEntropySupportLeftRightQuadratic
+import TNLean.Channel.Schwarz.SupportRelativeModular
+
+/-!
+# Support left-right and relative-modular resolvents
+
+For positive-semidefinite matrices \(A\) and \(B\), let
+\[
+  S=A\otimes 1+t(1\otimes B^{\mathsf T}),\qquad
+  P=1\otimes P_B^{\mathsf T},
+\]
+and let
+\[
+  R=t1+A\otimes(B^+)^{\mathsf T},
+\]
+where \(P_B\) is the support projection of \(B\) and \(B^+\) is its generalized
+inverse on the support. This file proves that the support-generalized-inverse
+solution \(S^+\operatorname{vec}(B^{\mathsf T})\) is the canonical projected
+relative-modular solution
+\[
+  P R^{-1}\operatorname{vec}(1^{\mathsf T}).
+\]
+
+## Main results
+
+* `Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular`
+  identifies the two source-\(B\) solution vectors.
+* `Matrix.supportSourceBQuadratic_eq_projected_relativeModular` gives the
+  corresponding equality of quadratic forms.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, *A Unified Treatment of Convexity of Relative
+  Entropy and Related Trace Functions, with Conditions for Equality*,
+  arXiv:0903.2895v4, lines 255--261 and 783--790.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+
+namespace Matrix
+
+/-- The support-generalized-inverse source-\(B\) solution of the left-right
+operator is the projected shifted relative-modular solution:
+\[
+  S^+\operatorname{vec}(B^{\mathsf T})
+  =
+  (1\otimes P_B^{\mathsf T})
+  \bigl(t1+A\otimes(B^+)^{\mathsf T}\bigr)^{-1}
+  \operatorname{vec}(1^{\mathsf T}).
+\]
+
+This is the one-pair algebraic identity used in the singular equality argument
+of Jenčová--Ruskai, arXiv:0903.2895v4, lines 783--790, with the generalized
+inverse convention from lines 255--261. It does not derive a common resolvent
+from equality of relative entropies. -/
+theorem supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    supportLeftRightSupportInv hA hB t *ᵥ Matrix.vec Bᵀ =
+      ((1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ) *ᵥ
+        ((t • (1 : Matrix (n × n) (n × n) ℂ) +
+          A ⊗ₖ hB.supportInvᵀ)⁻¹ *ᵥ
+            Matrix.vec (1 : Matrix n n ℂ)ᵀ) := by
+  let Bplus := hB.supportInv
+  let delta := A ⊗ₖ Bplusᵀ
+  let res := t • (1 : Matrix (n × n) (n × n) ℂ) + delta
+  let P := (1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ
+  let S := supportLeftRightSuperoperator A B t
+  let C := (1 : Matrix n n ℂ) ⊗ₖ Bᵀ
+  let D := (1 : Matrix n n ℂ) ⊗ₖ Bplusᵀ
+  let e : n × n → ℂ := Matrix.vec (1 : Matrix n n ℂ)ᵀ
+  let b : n × n → ℂ := Matrix.vec Bᵀ
+  let y : n × n → ℂ := P *ᵥ (res⁻¹ *ᵥ e)
+  have hBplus_mul : Bplus * B = hB.isHermitian.supportProj := by
+    simpa only [Bplus] using hB.supportInv_mul_self
+  have hBplusPSD : Bplus.PosSemidef := by
+    simpa only [Bplus, PosSemidef.supportInv,
+      hB.supportInvSqrt_isHermitian.eq] using
+        posSemidef_conjTranspose_mul_self hB.supportInvSqrt
+  have hdelta : delta.PosSemidef := hA.kronecker hBplusPSD.transpose
+  have hres : res.PosDef :=
+    (Matrix.PosDef.one.smul ht).add_posSemidef hdelta
+  letI : Invertible res := hres.isUnit.invertible
+  have hCdelta :
+      C * delta = A ⊗ₖ hB.isHermitian.supportProjᵀ := by
+    dsimp only [C, delta]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, hBplus_mul]
+  have hBTP : Bᵀ * hB.isHermitian.supportProjᵀ = Bᵀ := by
+    rw [← Matrix.transpose_mul, hB.isHermitian.supportProj_mul_self]
+  have hSP : S * P = C * res := by
+    dsimp only [S, supportLeftRightSuperoperator, P, C, res]
+    rw [Matrix.add_mul, Matrix.smul_mul,
+      ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+      Matrix.mul_one, Matrix.one_mul, hBTP,
+      Matrix.mul_add, Matrix.mul_smul, Matrix.mul_one, hCdelta]
+    simp only [Matrix.mul_one]
+    abel
+  have hCD : C * D = P := by
+    dsimp only [C, D, P]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, hBplus_mul]
+  have hPidem : P * P = P := by
+    dsimp only [P]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, hB.isHermitian.supportProj_idem]
+  have hyP : P *ᵥ y = y := by
+    calc
+      P *ᵥ y = (P * P) *ᵥ (res⁻¹ *ᵥ e) := by
+        exact Matrix.mulVec_mulVec (res⁻¹ *ᵥ e) P P
+      _ = y := by rw [hPidem]
+  have hsolution : S *ᵥ y = b := by
+    simpa only [Bplus, PosSemidef.supportInv, delta, res, P, S,
+      supportLeftRightSuperoperator, e, b, y] using
+        supportRelativeModular_sourceB_solution hA hB ht
+  let w : n × n → ℂ := P *ᵥ (res⁻¹ *ᵥ (D *ᵥ y))
+  have hrange : S *ᵥ w = y := by
+    calc
+      S *ᵥ w = (S * P) *ᵥ (res⁻¹ *ᵥ (D *ᵥ y)) := by
+        exact Matrix.mulVec_mulVec (res⁻¹ *ᵥ (D *ᵥ y)) S P
+      _ = (C * res) *ᵥ (res⁻¹ *ᵥ (D *ᵥ y)) := by rw [hSP]
+      _ = C *ᵥ ((res * res⁻¹) *ᵥ (D *ᵥ y)) := by
+        simp only [Matrix.mulVec_mulVec, Matrix.mul_assoc]
+      _ = C *ᵥ (D *ᵥ y) := by
+        rw [Matrix.mul_inv_of_invertible]
+        simp
+      _ = (C * D) *ᵥ y := Matrix.mulVec_mulVec y C D
+      _ = P *ᵥ y := by rw [hCD]
+      _ = y := hyP
+  have hS : S.PosSemidef := by
+    simpa only [S] using
+      supportLeftRightSuperoperator_posSemidef hA hB ht.le
+  have hySupport : hS.isHermitian.supportProj *ᵥ y = y := by
+    rw [← hrange]
+    conv_lhs => rw [Matrix.mulVec_mulVec]
+    rw [hS.isHermitian.supportProj_mul_self]
+  have hsupportInv : hS.supportInv *ᵥ b = y := by
+    calc
+      hS.supportInv *ᵥ b =
+          hS.supportInv *ᵥ (S *ᵥ y) := by rw [hsolution]
+      _ = (hS.supportInv * S) *ᵥ y := Matrix.mulVec_mulVec y hS.supportInv S
+      _ = y := by rw [hS.supportInv_mul_self, hySupport]
+  rw [supportLeftRightSupportInv_eq hA hB ht.le]
+  change
+    (supportLeftRightSuperoperator_posSemidef hA hB ht.le).supportInv *ᵥ b = y
+  rw [show
+    (supportLeftRightSuperoperator_posSemidef hA hB ht.le).supportInv =
+      hS.supportInv from rfl]
+  exact hsupportInv
+
+/-- The source-\(B\) quadratic form of the support left-right operator equals
+its evaluation on the projected shifted relative-modular solution.
+
+This is the quadratic-form consequence of the one-pair identity used in
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 783--790. It contains no implication
+from equality of relative entropies. -/
+theorem supportSourceBQuadratic_eq_projected_relativeModular
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    supportSourceBQuadratic hA hB t =
+      (star (Matrix.vec Bᵀ) ⬝ᵥ
+        (((1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ) *ᵥ
+          ((t • (1 : Matrix (n × n) (n × n) ℂ) +
+            A ⊗ₖ hB.supportInvᵀ)⁻¹ *ᵥ
+              Matrix.vec (1 : Matrix n n ℂ)ᵀ))).re := by
+  unfold supportSourceBQuadratic
+  rw [supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular
+    hA hB ht]
+
+end Matrix

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.RelativeEntropySupportLeftRightQuadratic
 import TNLean.Analysis.ResolventFunctionalCalculus
-import TNLean.Analysis.MatrixSqrt
 
 /-!
 # Relative modular square roots on singular supports
@@ -18,6 +18,9 @@ reference matrix is represented as the square of its support inverse square root
 * `Matrix.one_kronecker_transpose_mulVec_vec_transpose` identifies the
   Kronecker matrix that represents right multiplication on a transposed
   vectorization.
+* `Matrix.supportRelativeModular_resolvent_posDef` and
+  `Matrix.supportLeftRightSuperoperator_mul_supportProj_eq` give positivity and
+  the support-resolvent intertwining identity.
 * `Matrix.supportRelativeModular_sqrt_mulVec_vec_one` evaluates the positive
   square root of the support relative-modular matrix on the vectorized identity.
 * `Matrix.supportRelativeModular_sourceB_solution` gives the canonical
@@ -51,6 +54,43 @@ theorem one_kronecker_transpose_mulVec_vec_transpose
   rw [Matrix.kronecker_mulVec_vec]
   simp only [Matrix.transpose_mul, Matrix.transpose_one, Matrix.mul_one]
 
+/-- A positive shift of the support relative-modular matrix is positive definite. -/
+theorem supportRelativeModular_resolvent_posDef
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    (t • (1 : Matrix (n × n) (n × n) ℂ) +
+      A ⊗ₖ hB.supportInvᵀ).PosDef := by
+  have hBplusPSD : hB.supportInv.PosSemidef := by
+    simpa only [PosSemidef.supportInv, hB.supportInvSqrt_isHermitian.eq] using
+      posSemidef_conjTranspose_mul_self hB.supportInvSqrt
+  exact (Matrix.PosDef.one.smul ht).add_posSemidef
+    (hA.kronecker hBplusPSD.transpose)
+
+/-- The support projection intertwines the left-right operator with the shifted
+support relative-modular matrix. -/
+theorem supportLeftRightSuperoperator_mul_supportProj_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hB : B.PosSemidef) (t : ℝ) :
+    supportLeftRightSuperoperator A B t *
+        ((1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ) =
+      ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ) *
+        (t • (1 : Matrix (n × n) (n × n) ℂ) +
+          A ⊗ₖ hB.supportInvᵀ) := by
+  have hCdelta :
+      ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ) * (A ⊗ₖ hB.supportInvᵀ) =
+        A ⊗ₖ hB.isHermitian.supportProjᵀ := by
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, hB.supportInv_mul_self]
+  have hBTP : Bᵀ * hB.isHermitian.supportProjᵀ = Bᵀ := by
+    rw [← Matrix.transpose_mul, hB.isHermitian.supportProj_mul_self]
+  rw [supportLeftRightSuperoperator, Matrix.add_mul, Matrix.smul_mul,
+    ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+    Matrix.mul_one, Matrix.one_mul, hBTP, Matrix.mul_add,
+    Matrix.mul_smul, Matrix.mul_one, hCdelta]
+  simp only [Matrix.mul_one]
+  abel
+
 /-- The canonical support-domain vector built from the generalized relative
 modular resolvent solves the singular source equation.
 
@@ -78,30 +118,14 @@ theorem supportRelativeModular_sourceB_solution
   let S := A ⊗ₖ (1 : Matrix n n ℂ) +
     t • ((1 : Matrix n n ℂ) ⊗ₖ Bᵀ)
   let C := (1 : Matrix n n ℂ) ⊗ₖ Bᵀ
-  have hBplus : Bplus * B = hB.isHermitian.supportProj := by
-    simpa only [Bplus] using hB.supportInvSqrt_sq_mul_self
-  have hBplusPSD : Bplus.PosSemidef := by
-    simpa only [Bplus, hB.supportInvSqrt_isHermitian.eq] using
-      posSemidef_conjTranspose_mul_self hB.supportInvSqrt
-  have hdelta : delta.PosSemidef := hA.kronecker hBplusPSD.transpose
-  have hres : res.PosDef :=
-    (Matrix.PosDef.one.smul ht).add_posSemidef hdelta
+  have hres : res.PosDef := by
+    simpa only [res, delta, Bplus, PosSemidef.supportInv] using
+      supportRelativeModular_resolvent_posDef hA hB ht
   letI : Invertible res := hres.isUnit.invertible
-  have hCdelta : C * delta =
-      A ⊗ₖ hB.isHermitian.supportProjᵀ := by
-    dsimp only [C, delta]
-    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
-      ← Matrix.transpose_mul, hBplus]
-  have hBTP : Bᵀ * hB.isHermitian.supportProjᵀ = Bᵀ := by
-    rw [← Matrix.transpose_mul, hB.isHermitian.supportProj_mul_self]
   have hSP : S * P = C * res := by
-    dsimp only [S, P, C, res]
-    rw [Matrix.add_mul, Matrix.smul_mul,
-      ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
-      Matrix.mul_one, Matrix.one_mul, hBTP,
-      Matrix.mul_add, Matrix.mul_smul, Matrix.mul_one, hCdelta]
-    simp only [Matrix.mul_one]
-    abel
+    simpa only [S, supportLeftRightSuperoperator, P, C, res, delta, Bplus,
+      PosSemidef.supportInv] using
+        supportLeftRightSuperoperator_mul_supportProj_eq (A := A) hB t
   have hCe : C *ᵥ Matrix.vec (1 : Matrix n n ℂ)ᵀ = Matrix.vec Bᵀ := by
     simpa only [C, Matrix.one_mul] using
       one_kronecker_transpose_mulVec_vec_transpose (1 : Matrix n n ℂ) B

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -357,6 +357,73 @@
     $C\opvec(\mathbf 1^{\mathsf T})=\opvec(B^{\mathsf T})$, which is the claim.
 \end{proof}
 
+\begin{lemma}[Support left-right solution as a projected relative-modular resolvent]
+    \label{lem:support_left_right_projected_relative_modular}
+    \lean{Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular}
+    \lean{Matrix.supportSourceBQuadratic_eq_projected_relativeModular}
+    \leanok
+    \uses{lem:support_relative_modular_source_solution,
+      lem:support_inverse_square_root_generalized_inverse}
+    Let $A,B$ be positive semidefinite, let $t>0$, set
+    \begin{align}
+        S&=A\otimes\mathbf 1+t(\mathbf 1\otimes B^{\mathsf T}),&
+        R&=t\mathbf 1+A\otimes(B^+)^{\mathsf T},
+        \notag
+    \end{align}
+    and let $P_B$ be the support projection of $B$. Then
+    \begin{align}
+        S^+\opvec(B^{\mathsf T})
+        &=
+        (\mathbf 1\otimes P_B^{\mathsf T})R^{-1}
+          \opvec(\mathbf 1^{\mathsf T}).
+        \notag
+    \end{align}
+    Consequently,
+    \begin{align}
+        \re\left\langle
+          \opvec(B^{\mathsf T}),S^+\opvec(B^{\mathsf T})
+        \right\rangle
+        &=
+        \re\left\langle
+          \opvec(B^{\mathsf T}),
+          (\mathbf 1\otimes P_B^{\mathsf T})R^{-1}
+            \opvec(\mathbf 1^{\mathsf T})
+        \right\rangle.
+        \notag
+    \end{align}
+    This is the one-pair algebraic identification used in the singular
+    equality argument of Jen\v{c}ov\'a--Ruskai,
+    arXiv:0903.2895v4, lines~783--790. It does not assert that equality of
+    relative entropies gives a common resolvent for a finite family.
+\end{lemma}
+
+\begin{proof}\leanok
+    Put
+    \begin{align}
+        P&=\mathbf 1\otimes P_B^{\mathsf T},&
+        C&=\mathbf 1\otimes B^{\mathsf T},&
+        D&=\mathbf 1\otimes(B^+)^{\mathsf T}.
+        \notag
+    \end{align}
+    The generalized-inverse identities give $SP=CR$, $CD=P$, and $P^2=P$.
+    The preceding lemma shows that
+    $y=PR^{-1}\opvec(\mathbf 1^{\mathsf T})$ satisfies
+    $Sy=\opvec(B^{\mathsf T})$, and $Py=y$.
+    Every vector $v$ satisfying $Pv=v$ lies in the range of $S$, since
+    \begin{align}
+        S\bigl(PR^{-1}Dv\bigr)&=CDv=Pv=v.
+        \notag
+    \end{align}
+    In particular, $y$ lies in the range of $S$, so the support projection
+    $P_S$ of $S$ satisfies $P_Sy=y$. Therefore
+    \begin{align}
+        S^+\opvec(B^{\mathsf T})=S^+Sy=P_Sy=y.
+        \notag
+    \end{align}
+    Pairing this vector equality with $\opvec(B^{\mathsf T})$ and taking
+    real parts gives the quadratic identity.
+\end{proof}
+
 \begin{lemma}[Support relative-modular square-root evaluation]
     \label{lem:support_relative_modular_sqrt_evaluation}
     \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -362,8 +362,6 @@
     \lean{Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular}
     \lean{Matrix.supportSourceBQuadratic_eq_projected_relativeModular}
     \leanok
-    \uses{lem:support_relative_modular_source_solution,
-      lem:support_inverse_square_root_generalized_inverse}
     Let $A,B$ be positive semidefinite, let $t>0$, set
     \begin{align}
         S&=A\otimes\mathbf 1+t(\mathbf 1\otimes B^{\mathsf T}),&
@@ -398,6 +396,8 @@
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{lem:support_relative_modular_source_solution,
+      lem:support_inverse_square_root_generalized_inverse}
     Put
     \begin{align}
         P&=\mathbf 1\otimes P_B^{\mathsf T},&

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -357,8 +357,8 @@
     $C\opvec(\mathbf 1^{\mathsf T})=\opvec(B^{\mathsf T})$, which is the claim.
 \end{proof}
 
-\begin{lemma}[Support left-right solution as a projected relative-modular resolvent]
-    \label{lem:support_left_right_projected_relative_modular}
+\begin{theorem}[Support left-right solution as a projected relative-modular resolvent]
+    \label{thm:support_left_right_projected_relative_modular}
     \lean{Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular}
     \lean{Matrix.supportSourceBQuadratic_eq_projected_relativeModular}
     \leanok
@@ -393,7 +393,7 @@
     equality argument of Jen\v{c}ov\'a--Ruskai,
     arXiv:0903.2895v4, lines~783--790. It does not assert that equality of
     relative entropies gives a common resolvent for a finite family.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     \uses{lem:support_relative_modular_source_solution,

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -393,11 +393,22 @@ The finite spectral integrand is now identified pointwise with the
 support-projected left--right quadratic form: the source in its first
 quadratic term is $A P_B$.  Under the inclusion
 $\ker B\subseteq\ker A$, one has $A P_B=A$, so this term is the corresponding
-quadratic form with the unprojected source $A$.  The remaining gap is the
-passage from this left--right expression to the shifted relative-modular
-resolvent containing the projected generalized inverse $B^+$, together with
-the singular finite-family passage from equality of the summed defects to a
-common relative-modular resolvent.
+quadratic form with the unprojected source $A$.  For a single pair, the
+source-$B$ support-generalized-inverse solution is now identified with the
+projected shifted relative-modular vector
+\[
+  (\mathbf 1\otimes P_B^{\mathsf T})
+  \bigl(t\mathbf 1+A\otimes(B^+)^{\mathsf T}\bigr)^{-1}
+  \operatorname{vec}(\mathbf 1^{\mathsf T}).
+\]
+The corresponding source-$B$ quadratic forms are therefore equal.
+\footnote{Formal declarations:
+\leanid{Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular}
+and
+\leanid{Matrix.supportSourceBQuadratic_eq_projected_relativeModular} in
+\path{TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean}.}
+The remaining gap is the singular finite-family passage from equality of the
+summed defects to a common relative-modular resolvent.
 Following the latter step, consider two positive semidefinite pairs $(A,B)$ and
 $(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
 $B$, and write
@@ -439,20 +450,17 @@ trace is automatic, whereas the comparison pair formed from its marginal is
 full rank.  Thus the ambient resolvent equality is not a consequence of the
 singular equality theorem.
 
-The canonical source-side projected resolver is now known to solve its
-singular left--right equation: after projection by
+The canonical source-side projected resolvent is known to solve its singular
+left--right equation: after projection by
 $\mathbf 1\otimes P_B^{\mathsf T}$, multiplication by
 $A\otimes\mathbf 1+t(\mathbf 1\otimes B^{\mathsf T})$ gives
 $\operatorname{vec}(B^{\mathsf T})$.  This uses only the generalized-inverse
-identity $(B^{-1/2}_{\mathrm{supp}})^2B=P_B$ and does not supply equality
-with the comparison resolver.  The spectral integrand is now identified with
-the corresponding support-restricted left--right quadratic form.  What remains
-is its relation to the relative-modular formulation, where
-$B^+=(B^{-1/2}_{\mathrm{supp}})^2$ occurs inside
-$t\mathbf 1+A\otimes(B^+)^{\mathsf T}$ and, for $t>0$, the inverse of this
-shifted operator on $\mathbf 1\otimes P_B^{\mathsf T}$ is an ordinary inverse.
-One must then pass from equality of the singular finite-family summed defects
-to equality of the corresponding common relative-modular resolvents.
+identity $(B^{-1/2}_{\mathrm{supp}})^2B=P_B$.  The one-pair identity above
+also identifies this vector with the support-generalized-inverse solution of
+the left--right equation, and hence identifies the two source-$B$ quadratic
+forms.  It does not supply equality with a second pair's resolvent.  One must
+still pass from equality of the singular finite-family summed defects to
+equality of the corresponding common relative-modular resolvents.
 
 The kernel inclusion belongs to the preceding source theorem that must derive
 the support-restricted common resolvents from equality in data processing.  That

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -80,6 +80,21 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Support left-right and relative-modular intertwining
+- **Pattern:** `supportRelativeModular_sourceB_solution` and
+  `supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular`
+  each proved positive definiteness of
+  `t • 1 + A ⊗ₖ hB.supportInvᵀ` and expanded the same matrix calculation
+  \(S(1 \otimes P_B^{\mathsf T}) = (1 \otimes B^{\mathsf T})R\).
+- **Reuse:** Both proofs now use `supportRelativeModular_resolvent_posDef` and
+  `supportLeftRightSuperoperator_mul_supportProj_eq` from
+  `Channel/Schwarz/SupportRelativeModular.lean`. The intertwining theorem only
+  assumes positivity of `B`; positivity of `A` is confined to the positive-definiteness
+  theorem.
+- **Result:** The two Lean files have 49 insertions and 45 deletions: the repeated
+  derivations are replaced by two source-facing algebraic lemmas and their call sites.
+  All pre-existing public theorem statements and mathematical scope are unchanged.
+
 ### Non-decaying-overlap dimension and gauge-phase dichotomy
 - **Pattern:** The `hDim`/`hGPE` tails of
   `exists_state_scalar_of_nondecaying_overlap` (`MatchAux.lean`) and


### PR DESCRIPTION
### Motivation

The singular equality route for issue LionSR/QICLean#245 requires the support inverse of the left-right superoperator to be identified with the projected shifted relative-modular resolvent. This is the one-pair identity used by Jenčová--Ruskai, arXiv:0903.2895v4, lines 255--261 and 783--790; it is an algebraic input and does not by itself prove the finite-family equality implication.

### Description

- add `SupportLeftRightRelativeModular`, proving the support-inverse solution identity and its quadratic-form evaluation;
- expose the module through `TNLean.Channel.Schwarz`;
- add the corresponding blueprint results with source references;
- revise the CPSV16 paper-gap note to distinguish the completed one-pair calculation from the remaining finite-family equality theorem.

### Testing

- `lake env lean TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean`
- `git diff --check`

The local `leanblueprint web` installation fails while importing its own Python package before processing the modified sources; the repository CI is therefore the final blueprint rendering check.

Addresses LionSR/QICLean#245.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics in the Schwarz/support-modular layer with no runtime, auth, or data paths; public theorem statements are preserved aside from the new results.
> 
> **Overview**
> Adds **`SupportLeftRightRelativeModular.lean`** with Lean proofs that \(S^+\mathrm{vec}(B^{\mathsf T})\) equals \((\mathbf 1\otimes P_B^{\mathsf T})R^{-1}\mathrm{vec}(\mathbf 1^{\mathsf T})\) and the matching **source-\(B\) quadratic form** identity (single-pair algebra only; not finite-family resolvent equality from relative entropy).
> 
> **Refactors** `SupportRelativeModular.lean` by extracting **`supportRelativeModular_resolvent_posDef`** and **`supportLeftRightSuperoperator_mul_supportProj_eq`**, then reusing them in **`supportRelativeModular_sourceB_solution`** and the new file. Wires the module through **`TNLean.Channel.Schwarz`**.
> 
> **Docs:** new blueprint theorem in ch19; CPSV16 gap note marks this one-pair step done and leaves the singular finite-family defect→common resolvent passage open; tactic ledger records the deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e730cac1045b3a9f77447efed88eb04c96fac5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->