### PR TITLE
docs(blueprint): record the CPSV16 Lemma C.5 obstruction

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -415,14 +415,16 @@
 % tr(eta_{k,h}) = a_k b_h. It proves the conditional implication (iv) => (v),
 % not Proposition prop2to5 from SAL and ZCL alone. The missing rank-one step is
 % documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[Two-site blocking of the original tensor is a renormalization fixed point]
+\begin{theorem}[Conditional two-site blocking theorem from neighboring trace factorization]
     \label{thm:mpdo_blocked_original_tensor_is_rfp_via_ts}
     \lean{MPOTensor.PhysicalSectorFactorization.NeighboringTraceFactorization.blockTwo_isRFPViaTS}
     \leanok
     \uses{def:is_rfp_via_ts, def:mpdo_two_site_blocking}
-    Let $\mathcal K^{[2]}$ be the tensor obtained by blocking two adjacent
-    sites of the original tensor $\mathcal K$. Then $\mathcal K^{[2]}$ is a
-    renormalization fixed point in the sense of
+    Assume that the neighboring operators are positive semidefinite and that
+    there are real families $(a_k)_k,(b_k)_k$ satisfying
+    $\tr(\eta_{k,h})=a_kb_h$ and $\sum_k a_kb_k=1$. Let $\mathcal K^{[2]}$ be
+    the tensor obtained by blocking two adjacent sites of $\mathcal K$. Then
+    $\mathcal K^{[2]}$ is a renormalization fixed point in the sense of
     Definition~\ref{def:is_rfp_via_ts}. This is
     \cite[Theorem~4.9, (iv)$\Rightarrow$(v)]{Cirac2016MPDO_arXiv}.
 \end{theorem}
@@ -448,12 +450,11 @@
 % conditional blocking theorem thm:mpdo_blocked_original_tensor_is_rfp_via_ts
 % instead assumes a neighboring trace factorization.
 % Documented in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[SAL and ZCL give the two blocking channels]
+\begin{theorem}[Blocking channels from SAL and ZCL (open)]
     \label{thm:mpdo_sal_zcl_blocking_channels}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl, def:is_rfp_via_ts,
-        def:mpdo_two_site_blocking,
-        thm:mpdo_sal_zcl_bnt_sector_structure}
+        def:mpdo_two_site_blocking}
     Let $K$ be a simple tensor in block-injective canonical form (biCF),
     equipped with a basis-of-normal-tensors decomposition and satisfying the
     strong area law and zero correlation length. Let $M=K^{[2]}$ be its
@@ -465,6 +466,11 @@
     \cite[Theorem~4.9 and Appendix~C.2, lines~1810--1825]
       {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
     imposed at lines~849--850 and restated at line~1628 of the same source.
+    Proposition~\emph{prop2to5} refers back to the construction of
+    Proposition~C.7 after projection to each local sector. That construction
+    requires the rank-one neighboring-trace factorization supplied in the
+    printed argument by the refuted Lemma~C.5. No proof under SAL and ZCL alone
+    is presently known.
 \end{theorem}
 
 % Correct equation, not a figure: the cited source draws the two-to-three

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -441,7 +441,7 @@
 \end{proof}
 
 % **Refuted prerequisite (Lemma C.5):**
-% lem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
+% rem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
 % SAL and ZCL hypotheses by thm:mpdo_sal_zcl_rank_one_counterexample. Hence the
 % printed proof through prop2to3 does not establish implication (ii) => (v),
 % which remains unformalized rather than refuted. A conditional construction of

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex
@@ -466,11 +466,11 @@
     \cite[Theorem~4.9 and Appendix~C.2, lines~1810--1825]
       {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
     imposed at lines~849--850 and restated at line~1628 of the same source.
-    Proposition~\emph{prop2to5} refers back to the construction of
-    Proposition~C.7 after projection to each local sector. That construction
-    requires the rank-one neighboring-trace factorization supplied in the
-    printed argument by the refuted Lemma~C.5. No proof under SAL and ZCL alone
-    is presently known.
+    The printed proof of implication (ii)$\Rightarrow$(v) refers back to the
+    construction of Proposition~C.7 after projection to each local sector.
+    That construction requires the rank-one neighboring-trace factorization
+    supplied in the printed argument by the refuted Lemma~C.5. No proof under
+    SAL and ZCL alone is presently known.
 \end{theorem}
 
 % Correct equation, not a figure: the cited source draws the two-to-three

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -27,7 +27,7 @@
 % failed conclusion is T_{k,h}=a_k b_h from equation Apptralktrrk.  Documented
 % in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{remark}[Printed Lemma C.5 is refuted]
-    \label{lem:mpdo_sal_zcl_rank_one_trace_matrix}
+    \label{rem:mpdo_sal_zcl_rank_one_trace_matrix}
     Lemma~C.5 of
     \cite[Appendix~C.2, lines~1484--1499]{Cirac2016MPDO_arXiv} claims that an
     injective matrix product density operator tensor satisfying the strong area
@@ -147,7 +147,7 @@
 \end{proof}
 
 % **Refuted prerequisite (Lemma C.5):**
-% lem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
+% rem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
 % SAL and ZCL hypotheses by thm:mpdo_sal_zcl_rank_one_counterexample. Hence its
 % use in the printed derivation of the source corollary fails, and that
 % corollary remains unformalized under the source hypotheses. A conditional
@@ -265,7 +265,7 @@ This is the calculation in
 \cite[Appendix~C.2, lines~1745--1751]{Cirac2016MPDO_arXiv}.
 
 % **Refuted prerequisite (Lemma C.5):**
-% lem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
+% rem:mpdo_sal_zcl_rank_one_trace_matrix is formally refuted under its printed
 % SAL and ZCL hypotheses by thm:mpdo_sal_zcl_rank_one_counterexample. Hence its
 % use in the printed derivation of this proposition fails, and the proposition
 % remains unformalized under the source hypotheses. A conditional construction

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -26,23 +26,20 @@
 % ZCL, but its active trace matrix has no rank-one factorization.  The exact
 % failed conclusion is T_{k,h}=a_k b_h from equation Apptralktrrk.  Documented
 % in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{lemma}[SAL and ZCL give a rank-one sector trace matrix]
+\begin{remark}[Printed Lemma C.5 is refuted]
     \label{lem:mpdo_sal_zcl_rank_one_trace_matrix}
-    \notready
-    \uses{def:is_sal, def:mpo_source_zcl,
-        thm:mpdo_active_trace_matrix_zcl_relations}
-    Let $\mathcal K$ be an injective matrix product density operator tensor
-    satisfying the strong area law and zero correlation length. For the
-    neighboring operators obtained from its inverse-map sector decomposition,
-    define $T_{k,h}=\tr(\eta_{k,h})$. Then there are real families $(a_k)_k$
-    and $(b_k)_k$ such that
+    Lemma~C.5 of
+    \cite[Appendix~C.2, lines~1484--1499]{Cirac2016MPDO_arXiv} claims that an
+    injective matrix product density operator tensor satisfying the strong area
+    law and zero correlation length has real families $(a_k)_k,(b_k)_k$ with
     \begin{align}
-        T_{k,h}&=a_kb_h, \notag\\
+        T_{k,h}=\tr(\eta_{k,h})&=a_kb_h, \notag\\
         \sum_k a_kb_k&=1. \notag
     \end{align}
-    This is Lemma~C.5 at
-    \cite[Appendix~C.2, lines~1473--1499]{Cirac2016MPDO_arXiv}.
-\end{lemma}
+    This claim is false under the printed hypotheses. Theorem~\ref{thm:mpdo_sal_zcl_rank_one_counterexample}
+    gives a four-sector counterexample with the source inverse-map
+    factorization and with no such families $a,b$.
+\end{remark}
 
 \begin{theorem}[Counterexample to the printed SAL--ZCL rank-one inference]
     \label{thm:mpdo_sal_zcl_rank_one_counterexample}
@@ -158,10 +155,10 @@
 % semidefiniteness or linear independence is given by
 % thm:simple_mpdo_local_structure_data_of_sal_zcl. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{corollary}[Local sector structure from SAL and ZCL]
+\begin{corollary}[Local sector structure from SAL and ZCL (open)]
     \label{cor:mpdo_sal_zcl_local_sector_structure}
     \notready
-    \uses{lem:mpdo_sal_zcl_rank_one_trace_matrix,
+    \uses{def:is_sal, def:mpo_source_zcl, thm:sal_implies_eta_structure,
         thm:mpdo_active_trace_matrix_zcl_relations}
     Let $\mathcal K$ be an injective matrix product density operator tensor
     satisfying the strong area law and zero correlation length. Then there are
@@ -173,7 +170,9 @@
         \sum_k a_kb_k&=1. \notag
     \end{align}
     This is the structural corollary at
-    \cite[Appendix~C.2, lines~1501--1505]{Cirac2016MPDO_arXiv}.
+    \cite[Appendix~C.2, lines~1501--1505]{Cirac2016MPDO_arXiv}. Its printed
+    derivation combines Lemma~C.4 with the refuted Lemma~C.5, so the conclusion
+    remains open under the printed hypotheses.
 \end{corollary}
 
 % **Scope restriction (rank-one trace matrix):** the two constructors below
@@ -182,15 +181,15 @@
 % does not formalize Lemma SALZCL, its structural corollary, or Proposition
 % prop2to3 from those hypotheses alone. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[Local simple-MPDO structure from corrected rank-one criteria]
+\begin{theorem}[Conditional local simple-MPDO structure under stronger rank-one hypotheses]
     \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef}
     \leanok
     \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
         thm:psd_trace_powers_rank_one_t, thm:pairing_idempotent_rank_one_t}
-    There are two sufficient forms of the local conclusion associated with
-    \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv}. In the first,
+    These are conditional constructions under hypotheses stronger than SAL and
+    ZCL; neither is the printed Lemma~C.5 or its corollary. In the first,
     $T$ is positive semidefinite, $\tr(T)=1$, and $\tr(T^m)=1$ for every
     positive integer $m$; the spectral theorem then gives the rank-one
     factorization $T=ab^\top$ with $a\cdot b=1$. In the second, $T$ is the
@@ -274,11 +273,10 @@ This is the calculation in
 % independence is given by
 % thm:simple_mpdo_local_structure_data_of_sal_zcl. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[SAL and ZCL give the BNT sector structure]
+\begin{theorem}[BNT sector structure from SAL and ZCL (open)]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}
     \notready
-    \uses{def:is_sal, def:mpo_source_zcl,
-        cor:mpdo_sal_zcl_local_sector_structure}
+    \uses{def:is_sal, def:mpo_source_zcl}
     Let $K$ be a simple tensor in block-injective canonical form (biCF),
     equipped with a basis-of-normal-tensors decomposition. If $K$ satisfies
     the strong area law and zero correlation length, then its basis tensors
@@ -293,4 +291,7 @@ This is the calculation in
     \cite[Theorem~4.9 and Appendix~C.2, lines~1740--1788]
       {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
     imposed at lines~849--850 and restated at line~1628 of the same source.
+    The proof at lines~1745--1785 applies the structural corollary after
+    establishing SAL and ZCL for each basis tensor. Since that corollary uses
+    the refuted Lemma~C.5, the printed proof does not establish this proposition.
 \end{theorem}


### PR DESCRIPTION
## Historical change

This pull request reorganized the Chapter 21 blueprint around the rank-one step in CPSV16 Appendix C.2:

- it exposed the four-sector obstruction at the Lemma C.5 node;
- kept the structural corollary, `prop2to3`, and `prop2to5` visibly unformalized;
- labelled the positive-semidefinite and linear-independence constructions as conditional;
- removed dependency edges that treated an unavailable rank-one theorem as an established premise.

## Retrospective normalization correction (2026-08-03)

The original pull-request description called Lemma C.5 refuted. PR #5389 showed that the four-sector tensor is not a full-hypothesis counterexample: the raw representative has literal fixed-tensor ZCL but lacks the standing normal unit-weight convention, whereas its normal rescaling has unit weight but fails literal fixed-tensor ZCL.

Accordingly, the maintained mathematical classification is **unsettled at the normalization boundary**, not refuted. The current blueprint retains `\notready` for the source lemma and its dependent statements and records the valid restricted criteria separately.

Historical validation included blueprint-to-Lean synchronization, declaration checks, reference checks, double LuaLaTeX, and visual inspection.

Closes the historical documentation task #4840; corrected by #5389.