### PR TITLE
doc(PEPS): re-point the two-strips doc citation to the surviving ThreeBlockGeometry lemma

### DIFF
--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
@@ -168,7 +168,7 @@ theorem overlapRightGeometry_univ_sdiff_red (R₁ R₂ : Finset V) :
 
 The source proof inverts the two injective regions in sequence. With the two
 overlap geometries this is two applications of the landed blue strip
-(`complCoeff_combination_eq_zero`), one for each region: stripping `R₁` leaves the
+(`ThreeBlockGeometry.complCoeff_combination_eq_zero`), one for each region: stripping `R₁` leaves the
 residual coupling through `R₂ \ R₁`, and stripping `R₂` leaves the residual
 coupling through `R₁ \ R₂`. -/
 

--- a/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
@@ -401,7 +401,8 @@ every finite union of injective regions.
     Fix an edge $e$ and a partition of the vertex set into the three
     edge-centred blocks $R$, $B$, $C$ (red, blue, complementary) of the normal
     PEPS proof, with the red block carrying one endpoint of $e$ and the blue
-    block the other. If every virtual bond dimension is positive, then their
+    block the other. If the blue block $B$ and the complementary block $C$ are
+    each injective and every virtual bond dimension is positive, then their
     union $B\cup C=V\setminus R$ is injective.
 \end{lemma}
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
@@ -401,8 +401,7 @@ every finite union of injective regions.
     Fix an edge $e$ and a partition of the vertex set into the three
     edge-centred blocks $R$, $B$, $C$ (red, blue, complementary) of the normal
     PEPS proof, with the red block carrying one endpoint of $e$ and the blue
-    block the other. If the blue block $B$ and the complementary block $C$ are
-    each injective and every virtual bond dimension is positive, then their
+    block the other. If every virtual bond dimension is positive, then their
     union $B\cup C=V\setminus R$ is injective.
 \end{lemma}
 \begin{proof}\leanok


### PR DESCRIPTION
### Motivation

- #4836 (merged as `d2337e280`, closing #4822) deleted `complCoeff_combination_eq_zero`; the two-strips section doc in `UnionInjectivityOverlap.lean` still cited it. Re-pointed to the surviving `ThreeBlockGeometry` twin.
- (Withdrawn per review: an earlier revision of this PR also dropped the blue/complement injectivity clause from the ch24 statement of `lem:peps_injectiveRegion_union_edgeBlocked`. Review traced `NormalEdgeBlockingData`'s structure fields — `blue_injective`/`complement_injective` — showing the premise is genuinely assumed by the Lean theorem; the #4836 signature change was presentational. That edit was reverted in `3fac8e3fd`.)

### Description

- `TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean`: the two-strips section doc cited the deleted `complCoeff_combination_eq_zero`; re-pointed to `ThreeBlockGeometry.complCoeff_combination_eq_zero`.

### Testing

- `lake build` — 9740 jobs green (5m23s, hot cache).
- `lualatex print.tex` ×2 (`TEXINPUTS="../../tex/tenkz//:"`) — exit 0, zero undefined references (on the earlier two-file revision; the blueprint file is now byte-identical to main).
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` exit 0; `--ci` exit 0; `leanblueprint checkdecls` exit 0.
- `lake exe lint_style` exit 0; `git diff --check` clean; `blueprint/src/print.pdf` reverted (source-only commit).

---
Addresses #4522

Agent-generated (orchestrated lane; human-accountable). Scoped under #4522 (proof-debt ledger D6 residual of #4822).
