### PR TITLE
chore(tenkz): delete what no longer has a consumer

### DIFF
--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -35,12 +35,12 @@ fallback so a clean pre-generation checkout still compiles.
 The RMP book has a separate driver and interface:
 
 ```sh
-scripts/tenkz_rmp.sh check --id <target>
-scripts/tenkz_rmp.sh check --section <section>
-scripts/tenkz_rmp.sh check --all
-scripts/tenkz_rmp.sh book --all
-scripts/tenkz_rmp.sh render --all
-scripts/tenkz_rmp.sh compare --all --source-root tex/RMP_TIKZ_SOURCE_CODE
+python3 scripts/tenkz_rmp.py check --id <target>
+python3 scripts/tenkz_rmp.py check --section <section>
+python3 scripts/tenkz_rmp.py check --all
+python3 scripts/tenkz_rmp.py book --all
+python3 scripts/tenkz_rmp.py render --all
+python3 scripts/tenkz_rmp.py compare --all --source-root tex/RMP_TIKZ_SOURCE_CODE
 ```
 
 Per-target verdicts are stored in `tests/tenkz/rmp/verdicts.toml`, one

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -668,3 +668,87 @@ crossing. It arrives with the route that derives a crossing set from the side a
 string passes on, and `cross=` stays as the per-crossing exception for the one
 crossing that goes against the habit. Consumers: rmp-iii-a-pulling-through,
 rmp-workbench-iii-g-injective-pull, rmp-workbench-iii-mpo-injective-white.
+
+### 2026-07-25 — deletions outside the language
+
+This entry is not a shrink session and does not open one. It retires no
+registry row, moves no meter and re-examines no flag, so the verdicts above
+stand as they are and are not restated here: repeating a hundred and
+twenty-eight unchanged rows to satisfy a reader that nothing changed is the
+bookkeeping this ledger exists to refuse. What follows is a record of
+deletions in the harness around the language and in three implementation
+files beneath it, neither of which any meter here measures.
+
+The work subtracts and does nothing else. It takes no position the surface
+swap has not already taken: the commutative-diagram, free-placement and
+lattice tiers keep their fourteen, eighty-six and seventy-seven benchmark
+cases, and they retire after the redraw campaign, not before it. No spelling
+was retired, no meter was added, no baseline was re-frozen.
+
+The census is unmoved — 192 before and 192 after — and it should be. The
+language was not touched.
+
+#### Tombstones: none are due
+
+Every alias row in the registry carries `sunset=1.0` — `periodic`, `chain
+axis`, `legs at`, `rows`, `boundary legs`, `label at`, and the value alias
+`route=curve` — and the package is at 0.7. Not one has expired. Nothing was
+retired here, and the empty result is recorded so that the next session does
+not derive it again.
+
+#### The harness, measured before it was judged
+
+Thirty files carrying 16,709 lines stand beside a package of 24,541. Every
+one was traced to its caller: the continuous-integration workflows, another
+script, or nothing. Twenty-seven are reached from a workflow step and do work
+no other gate repeats — the corpus driver and its provenance and render
+tests, the golden and kernel and string pins, the audit, the source lint, the
+registry and shrink gates, the manual extraction, the benchmark driver, and
+eleven measured-geometry regressions that each assert a different mechanism
+(label bands, label overlap, face ports, enclosures, index routing, fusion
+trees, the torus, the equation audit and its web layout, the picture
+pipeline, the shared parsers). None of them is a second opinion on another's
+question. The two census meters that sound alike are not: one counts drawing
+ink in the package sources, the other counts rows of public vocabulary.
+
+Three are reached from nowhere. Two of them are kept for reasons recorded
+below. The third had no second job either, and it goes.
+
+#### What went
+
+| what | lines | what it was for | why it is no longer needed |
+|---|---:|---|---|
+| `scripts/tenkz_rmp.sh` | 6 | a shell frontend for the benchmark driver; its whole body was one line handing its arguments to `scripts/tenkz_rmp.py` | both workflows already call the driver directly, so the frontend served only four blocks of documentation, which now name the driver. Its removal also retires a false sentence in the benchmark index, which credited the frontend with defining the generated-index control sequence that the driver defines. |
+| `\__tenkz_render_atom:nnn` | 2 | the unscaled atom, forwarding to the scaled one with an empty size | every caller passes the size argument; the forwarding form was never reached. The scaled entry now carries the whole comment. |
+| `\__tenkz_render_wire:nnnn` and its two point registers, with the `render-route` diagnostic | 52 | a three-way straight, orthogonal and arc router in the shared render stage | no stage ever called it. Wires reach paper through `\__tenkz_render_stroke:nn` and the string stage's saved routes; the three-way case analysis was written against a routing contract the wire record replaced. The diagnostic it raised had no other raiser and goes with it. |
+| `\__tenkz_render_atom_named:nn` | 8 | a named atom placed from a pitch-fraction coordinate | the named atoms that reach paper all take the point-exact entries beside it, because the fraction round trip loses a scaled point and the pixel gate sees it. The comment above those entries says so; this form contradicted it and had no caller. |
+| `\__tenkz_render_label:nnnn` and its three dimension registers | 24 | a label placed at an angular offset with its own inner clearance | the kernel calls only the anchor helper above it and computes its own offset. Nothing called the placer. |
+| `\__tenkz_geom_require_kind:nnn` | 5 | a three-argument convenience over the frame-kind check | all seven real call sites use the four-argument form, which names the flag it sets. |
+| `\__tenkz_geom_corridor_include:nn` and `\__tenkz_geom_corridor_include_bbox:nnnn` | 23 | folding a paper point, and a bounding box's four corners, into the corridor silhouette and transverse interval | a two-function island: the box form's only caller was itself dead, and the point form's only caller was the box form. Cup routing uses the transverse-only fold beside them, which stays. |
+| `\__tenkz_geom_corridor_escape:Nnnn` | 16 | displacing a tip out of a forbidden transverse interval | the offset hull does this work now; nothing called the register-adjusting form. |
+| `\l__tenkz_geom_xb_tl`, `\l__tenkz_geom_yb_tl` | 1 | a second point in the placement graph | the graph resolves one point at a time into the `a` pair beside them. |
+| `\l__tenkz_model_scratch_tl` | 1 | scratch text in the record store | never written and never read. |
+
+Totals: the harness falls from 16,709 lines to 16,703 and from thirty files
+to twenty-nine; the package falls from 24,541 lines to 24,407, of which the
+render stage gives up 87 of its 290 — thirty parts in a hundred — the
+geometry stage 46 of 590, and the record store one.
+
+The ink and decimal censuses are unchanged at 44 and 51, so no baseline was
+re-frozen. The deletions took no drawing with them: what left the render
+stage never drew, and what left the geometry stage only ever computed.
+
+#### What was considered and kept
+
+| what | verdict |
+|---|---|
+| `scripts/tenkz_pixelpair.sh` (109 lines) | keep-because: no caller, no documentation, and a manifest of six fixtures against the corpus renderer's two hundred and fifty-seven — but it is the only place the detached true-legacy build is written down, and the redraw campaign is the moment that build is needed. Delete it at the campaign's close, when the last comparison against an old package tree is behind us; expiry 1.0 |
+| `scripts/check_tenkz_demolition.py` and its self-test (245 lines, with a workflow of its own) | keep-because: it refuses the retired catalogue's paths and calls in every tracked file. Three days old, and the branches that predate the demolition are still in flight; a restored file that nothing loads compiles clean, which is the one failure no other gate sees. Retire it at the 0.8 close, when those branches have landed or died; expiry 0.8 |
+| `scripts/test_tenkz_language.py` (89 lines) | keep-because: no workflow step runs it, and its first probe repeats a step that one does. Its other two do not repeat anything: the typed-port refusal at the extension door, and the equality of the legacy closure word's event stream with the canonical spelling's. Both are dormant, which is a wiring question and not a deletion question; a subtract-only change is the wrong place to settle it. Raise it at the 0.8 close: wire the two probes to a step or retire them; expiry 0.8 |
+| `tex/tenkz/tenkz-grid.code.tex` (6,142 lines) | keep: the premise that it holds the drawing path the shared renderer replaced does not survive contact with the file. Twenty-seven of its four hundred and twenty-seven control sequences are called from outside it, the blueprint chapters among the callers, and every one of the remaining four hundred is reachable from those and from the two public entry points at its end. There is no unreachable cluster. The shared render stage is a service beneath the live dialects, not a replacement for them. |
+| the leaf keys of the option parsers, and the role-prefixed silhouette styles | keep: their full names appear once each, at their definition, because they are assembled at use from a role word and a suffix, or dispatched by the option machinery from an author's key. Absence of a literal mention is not absence of a consumer. The instrument for those rows is this ledger and the registry gate, never a search. |
+
+Handed to the next session: the three expiries above; and a question this
+entry could not answer, which is whether the eleven measured-geometry
+regressions want to become one harness with eleven fixtures. They repeat no
+assertion, but they repeat a great deal of scaffolding.

--- a/docs/tenkz/chapters2/ch-rmp.tex
+++ b/docs/tenkz/chapters2/ch-rmp.tex
@@ -22,12 +22,12 @@ prior verdict stale automatically.
 Use the shared frontend:
 
 \begin{Verbatim}[fontsize=\footnotesize,frame=leftline]
-scripts/tenkz_rmp.sh check --id <target>
-scripts/tenkz_rmp.sh check --section <section>
-scripts/tenkz_rmp.sh check --all
-scripts/tenkz_rmp.sh book --all
-scripts/tenkz_rmp.sh render --all
-scripts/tenkz_rmp.sh compare --all --source-root tex/RMP_TIKZ_SOURCE_CODE
+python3 scripts/tenkz_rmp.py check --id <target>
+python3 scripts/tenkz_rmp.py check --section <section>
+python3 scripts/tenkz_rmp.py check --all
+python3 scripts/tenkz_rmp.py book --all
+python3 scripts/tenkz_rmp.py render --all
+python3 scripts/tenkz_rmp.py compare --all --source-root tex/RMP_TIKZ_SOURCE_CODE
 \end{Verbatim}
 
 The benchmark style controls typography only.  It does not extend tenkz.

--- a/docs/tenkz/rmp-benchmark.tex
+++ b/docs/tenkz/rmp-benchmark.tex
@@ -1,6 +1,6 @@
 % rmp-benchmark.tex -- generated-index driver for the tenkz RMP benchmark.
 %
-% Compile through scripts/tenkz_rmp.sh.  The script defines
+% Compile through scripts/tenkz_rmp.py.  The driver defines
 % \TenkzRMPGeneratedIndex to a temporary file assembled from manifest.toml;
 % this document never contains or copies a benchmark case body.
 \documentclass[10pt,twoside]{article}

--- a/scripts/tenkz_rmp.sh
+++ b/scripts/tenkz_rmp.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-REPO=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
-exec python3 "$REPO/scripts/tenkz_rmp.py" "$@"

--- a/scripts/test_tenkz_manual_doctest.py
+++ b/scripts/test_tenkz_manual_doctest.py
@@ -28,7 +28,7 @@ def main() -> int:
         raise AssertionError(f"expected 25 reference examples, found {len(reference)}")
     if any(r"\begin{document}" not in example.document for example in manual):
         raise AssertionError("a displayed example was not wrapped as a document")
-    if any("tenkz_rmp.sh" in example.document for example in manual):
+    if any("tenkz_rmp.py" in example.document for example in manual):
         raise AssertionError("the displayed shell session was treated as TeX")
 
     fixture = r"""

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -84,11 +84,6 @@
   }
 \tl_new:N \l__tenkz_geom_tmp_tl
 \bool_new:N \l__tenkz_geom_kind_ok_bool
-\cs_new_protected:Npn \__tenkz_geom_require_kind:nnn #1#2#3
-  {
-    \__tenkz_geom_require_kind:nnnN {#1}{#2}{#3}
-      \l__tenkz_geom_kind_ok_bool
-  }
 
 % new = outer applied after inner: M = Mo Mi, t = Mo ti + to
 \cs_new_protected:Npn \__tenkz_geom_frame_compose:nnn #1#2#3
@@ -262,7 +257,6 @@
 \prop_new:N \l__tenkz_geom_state_prop  % id -> visiting
 \seq_new:N  \l__tenkz_geom_trail_seq
 \tl_new:N \l__tenkz_geom_xa_tl \tl_new:N \l__tenkz_geom_ya_tl
-\tl_new:N \l__tenkz_geom_xb_tl \tl_new:N \l__tenkz_geom_yb_tl
 \bool_new:N \l__tenkz_geom_ok_bool
 
 \cs_new_protected:Npn \__tenkz_geom_reset:
@@ -525,22 +519,6 @@
               / \l__tenkz_geom_cor_norm_dim } }
   }
 
-% Fold one paper point: silhouette takes the along maximum, the transverse
-% interval widens to cover the across-projection.
-\cs_new_protected:Npn \__tenkz_geom_corridor_include:nn #1#2
-  {
-    \__tenkz_geom_corridor_along:nnN {#1}{#2} \l__tenkz_geom_cor_scratch_dim
-    \dim_set:Nn \l__tenkz_geom_cor_sil_dim
-      { \dim_max:nn { \l__tenkz_geom_cor_sil_dim }
-          { \l__tenkz_geom_cor_scratch_dim } }
-    \__tenkz_geom_corridor_trans:nnN {#1}{#2} \l__tenkz_geom_cor_scratch_dim
-    \dim_set:Nn \l__tenkz_geom_cor_tmin_dim
-      { \dim_min:nn { \l__tenkz_geom_cor_tmin_dim }
-          { \l__tenkz_geom_cor_scratch_dim } }
-    \dim_set:Nn \l__tenkz_geom_cor_tmax_dim
-      { \dim_max:nn { \l__tenkz_geom_cor_tmax_dim }
-          { \l__tenkz_geom_cor_scratch_dim } }
-  }
 % Fold the transverse span only: cup routing measures a site's across
 % extent without letting it push the outward lane.
 \cs_new_protected:Npn \__tenkz_geom_corridor_include_trans:nn #1#2
@@ -552,30 +530,6 @@
     \dim_set:Nn \l__tenkz_geom_cor_tmax_dim
       { \dim_max:nn { \l__tenkz_geom_cor_tmax_dim }
           { \l__tenkz_geom_cor_scratch_dim } }
-  }
-\cs_new_protected:Npn \__tenkz_geom_corridor_include_bbox:nnnn #1#2#3#4
-  {
-    \__tenkz_geom_corridor_include:nn {#1} {#3}
-    \__tenkz_geom_corridor_include:nn {#1} {#4}
-    \__tenkz_geom_corridor_include:nn {#2} {#3}
-    \__tenkz_geom_corridor_include:nn {#2} {#4}
-  }
-
-% Escape a forbidden transverse interval: when the tip projection lands
-% within bulge of [min,max], displace it to the nearer clear side plus
-% bulge; otherwise it is already clear and stays.  #1 tip register
-% (adjusted in place), #2 interval min, #3 interval max, #4 bulge.
-\cs_new_protected:Npn \__tenkz_geom_corridor_escape:Nnnn #1#2#3#4
-  {
-    \bool_lazy_and:nnT
-      { ! \dim_compare_p:nNn {#1} < { (#2) - (#4) } }
-      { ! \dim_compare_p:nNn {#1} > { (#3) + (#4) } }
-      {
-        \dim_compare:nNnTF
-          { #1 - (#2) } < { (#3) - #1 }
-          { \dim_set:Nn #1 { (#2) - (#4) } }
-          { \dim_set:Nn #1 { (#3) + (#4) } }
-      }
   }
 
 % ---------- probes -----------------------------------------------------------

--- a/tex/tenkz/tenkz-model.code.tex
+++ b/tex/tenkz/tenkz-model.code.tex
@@ -22,7 +22,6 @@
 \int_new:N  \l__tenkz_model_next_int
 \bool_new:N \l__tenkz_model_validated_bool
 \tl_new:N   \l__tenkz_model_last_tl       % id of the most recent record
-\tl_new:N   \l__tenkz_model_scratch_tl
 
 \msg_new:nnn {tenkz}{model-frozen}
   { [TKZ-MODEL-FROZEN]~Topology~cannot~change~after~validation. }

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -15,8 +15,6 @@
 
 \msg_new:nnn {tenkz}{render-skin}
   { [TKZ-RENDER-SKIN]~no~kernel~skin~named~'#1' }
-\msg_new:nnn {tenkz}{render-route}
-  { [TKZ-RENDER-ROUTE]~no~route~named~'#1' }
 \msg_new:nnn {tenkz}{render-nowire}
   { [TKZ-RENDER-NOWIRE]~the~bond~scan~draws~#1~->~#2~but~the~model~holds~
     no~such~wire~record;~derivation~and~scan~disagree }
@@ -109,11 +107,9 @@
 \tl_new:N \l__tenkz_render_x_tl
 \tl_new:N \l__tenkz_render_y_tl
 \tl_new:N \l__tenkz_render_content_tl
-\cs_new_protected:Npn \__tenkz_render_atom:nnn #1#2#3
-  { \__tenkz_render_atom_scaled:nnnn {#1} {#2} {#3} { } }
-% The same atom drawn on a sub-frame: #4 carries the size the frame asks
-% for.  A glyph belongs to the frame it sits on, so a frame that shrinks
-% shrinks its glyphs -- the size is never a skin of its own.
+% #4 carries the size the frame asks for.  A glyph belongs to the frame it
+% sits on, so a frame that shrinks shrinks its glyphs -- the size is never a
+% skin of its own; an unscaled atom passes an empty fourth argument.
 \cs_new_protected:Npn \__tenkz_render_atom_scaled:nnnn #1#2#3#4
   {
     \__tenkz_geom_xy:nNN {#2} \l__tenkz_render_x_tl \l__tenkz_render_y_tl
@@ -129,57 +125,6 @@
       { \l__tenkz_render_x_tl \tenkz@pitch }
       { \l__tenkz_render_y_tl \tenkz@pitch }
       { \l__tenkz_render_content_tl }
-  }
-
-% Draw one wire between resolved placements: #1 route word, #2 from id,
-% #3 to id, #4 extra tikz options.  Orthogonal routes corner at (x2, y1);
-% arcs bend by the tikz bend-left amount the caller resolved.
-\tl_new:N \l__tenkz_render_xb_tl
-\tl_new:N \l__tenkz_render_yb_tl
-\cs_new_protected:Npn \__tenkz_render_wire:nnnn #1#2#3#4
-  {
-    \__tenkz_geom_xy:nNN {#2} \l__tenkz_render_x_tl \l__tenkz_render_y_tl
-    \__tenkz_geom_xy:nNN {#3} \l__tenkz_render_xb_tl \l__tenkz_render_yb_tl
-    \str_case:nnF {#1}
-      {
-        {straight}
-          {
-            \__tenkz_ink_path:nn { line~width = \__tenkz_dim:n {wirewidth} , #4 }
-              {
-                ( \l__tenkz_render_x_tl \tenkz@pitch ,
-                  \l__tenkz_render_y_tl \tenkz@pitch )
-                --
-                ( \l__tenkz_render_xb_tl \tenkz@pitch ,
-                  \l__tenkz_render_yb_tl \tenkz@pitch )
-              }
-          }
-        {orth}
-          {
-            \__tenkz_ink_path:nn { line~width = \__tenkz_dim:n {wirewidth} , #4 }
-              {
-                ( \l__tenkz_render_x_tl \tenkz@pitch ,
-                  \l__tenkz_render_y_tl \tenkz@pitch )
-                --
-                ( \l__tenkz_render_xb_tl \tenkz@pitch ,
-                  \l__tenkz_render_y_tl \tenkz@pitch )
-                --
-                ( \l__tenkz_render_xb_tl \tenkz@pitch ,
-                  \l__tenkz_render_yb_tl \tenkz@pitch )
-              }
-          }
-        {arc}
-          {
-            \__tenkz_ink_path:nn { line~width = \__tenkz_dim:n {wirewidth} , #4 }
-              {
-                ( \l__tenkz_render_x_tl \tenkz@pitch ,
-                  \l__tenkz_render_y_tl \tenkz@pitch )
-                to [ bend~left ]
-                ( \l__tenkz_render_xb_tl \tenkz@pitch ,
-                  \l__tenkz_render_yb_tl \tenkz@pitch )
-              }
-          }
-      }
-      { \msg_error:nnn {tenkz}{render-route} {#1} }
   }
 
 % ---------- named atoms -------------------------------------------------------
@@ -198,14 +143,6 @@
   { \__tenkz_ink_node_named:nnnnn {#4} {#3} {#1} {#2} { } }
 \cs_new_protected:Npn \__tenkz_render_atom_labelled_pt:nnnnn #1#2#3#4#5
   { \__tenkz_ink_node_named:nnnnn {#4} {#3} {#1} {#2} {#5} }
-\cs_new_protected:Npn \__tenkz_render_atom_named:nn #1#2
-  {
-    \__tenkz_geom_xy:nNN {#1} \l__tenkz_render_x_tl \l__tenkz_render_y_tl
-    \__tenkz_ink_node:nnnn {#2}
-      { \fp_to_decimal:n { \l__tenkz_render_x_tl * \dim_to_fp:n { \tenkz@pitch } } pt }
-      { \fp_to_decimal:n { \l__tenkz_render_y_tl * \dim_to_fp:n { \tenkz@pitch } } pt }
-      { }
-  }
 
 % ---------- labelled atoms ----------------------------------------------------
 % #1 placement id, #2 the caller's complete option list (style, hue, name),
@@ -249,30 +186,6 @@
           }
           { \fp_compare:nNnTF { sind(#1) } > { 0 } { south } { north } }
       }
-  }
-% #1 placement id, #2 outward angle (degrees), #3 clearance metric name,
-% #4 label content.  The angular offset is computed here in fp -- pgfmath
-% never sees a direction function.
-\dim_new:N \l__tenkz_render_dx_dim
-\dim_new:N \l__tenkz_render_dy_dim
-\dim_new:N \l__tenkz_render_label_inner_sep_dim
-\cs_new_protected:Npn \__tenkz_render_label:nnnn #1#2#3#4
-  {
-    \__tenkz_geom_xy:nNN {#1} \l__tenkz_render_x_tl \l__tenkz_render_y_tl
-    \dim_set:Nn \l__tenkz_render_dx_dim
-      { \fp_to_decimal:n { cosd(#2) } \__tenkz_dim:n {#3} }
-    \dim_set:Nn \l__tenkz_render_dy_dim
-      { \fp_to_decimal:n { sind(#2) } \__tenkz_dim:n {#3} }
-    \dim_set:Nn \l__tenkz_render_label_inner_sep_dim
-      { \__tenkz_dim:n {labelclear} / 2 }
-    \__tenkz_ink_node:nnnn
-      {
-        anchor = \__tenkz_render_label_anchor:n {#2} ,
-        inner~sep = \l__tenkz_render_label_inner_sep_dim
-      }
-      { \l__tenkz_render_x_tl \tenkz@pitch + \l__tenkz_render_dx_dim }
-      { \l__tenkz_render_y_tl \tenkz@pitch + \l__tenkz_render_dy_dim }
-      { $ \tenkz@labelsize #4 $ }
   }
 
 % ---------- strings -----------------------------------------------------------


### PR DESCRIPTION
Advances LionSR/tenkz#13.

Deletion only. Nothing was added: no script, no checker, no meter, no pin, no
baseline. The dialects with live corpus consumers are untouched — commutative
diagrams, free placement and lattice keep their 14, 86 and 77 cases and retire
after the redraw, not before.

## Before and after

| category | before | after | net |
|---|---:|---:|---:|
| harness (`scripts/*tenkz*`, excluding `scripts/tenkzlib/`) | 30 files, 16,709 lines | 29 files, 16,703 lines | **−1 file, −6 lines** |
| package sources (`tex/tenkz/*.code.tex` + `tenkz.sty`) | 24,215 lines | 24,081 lines | **−134 lines** |
| retired spellings | — | — | **0** (none due) |
| registry census M1 | 192 | 192 | 0 |
| ink / decimal census | 44 / 51 | 44 / 51 | 0 |

140 lines of code leave. That is the honest number, and the reason it is small
is in the next section.

## The harness is mostly load-bearing

Every one of the 30 files was traced to its caller — a workflow step, another
script, or nothing. **27 are reached from a workflow step and do work no other
gate repeats.** The corpus driver and its provenance and render tests; the
golden, kernel and string pins; the audit; the source lint; the registry and
shrink gates; the manual extraction; the benchmark driver; and eleven
measured-geometry regressions that each assert a different mechanism (label
bands, label overlap, face ports, enclosures, index routing, fusion trees, the
torus, the equation audit and its web layout, the picture pipeline, the shared
parsers). None is a second opinion on another's question. The two census meters
that sound alike are not: one counts drawing ink in the package sources, the
other counts rows of public vocabulary.

Three are reached from nowhere. Two are kept, for the reasons recorded below.
The third had no second job either, and it is deleted.

One standing premise is worth correcting: `tenkz-grid.code.tex` is **not** the
drawing path the shared renderer replaced. 27 of its 427 control sequences are called from outside it —
the blueprint chapters among the callers — and every one of the remaining 400
is reachable from those plus the two public entry points at its end. There is
no unreachable cluster. The shared render stage is a service *beneath* the live
dialects, not a replacement for them. Its raw-ink census is 7 tokens; the
migration already happened, downward.

## Deletions, with reasons

**Harness**

| what | lines | what it was for | why it can go |
|---|---:|---|---|
| `scripts/tenkz_rmp.sh` | 6 | shell frontend for the benchmark driver; its whole body handed its arguments to `scripts/tenkz_rmp.py` | both workflows already call the driver directly. The frontend served only four blocks of documentation, which now name the driver. Its removal also retires a false sentence in the benchmark index, which credited the frontend with defining the generated-index control sequence that the driver defines. |

**Package — dead declarations, verified by exact boundary-aware reference count
across `tex/`, `tests/`, `docs/`, `blueprint/`, `scripts/`, `Notes/`,
`.github/`. Each name occurs exactly once in the repository: at its own
definition.**

| what | lines | what it was for | why it can go |
|---|---:|---|---|
| `\__tenkz_render_atom:nnn` | 2 | the unscaled atom, forwarding to the scaled one with an empty size | every caller passes the size; the forwarding form was never reached |
| `\__tenkz_render_wire:nnnn` + 2 point registers + the `render-route` diagnostic | 52 | a three-way straight/orth/arc router in the shared render stage | no stage called it. Wires reach paper through `\__tenkz_render_stroke:nn` and the string stage's saved routes; the case analysis was written against a routing contract the wire record replaced. The diagnostic had no other raiser. |
| `\__tenkz_render_atom_named:nn` | 8 | a named atom placed from a pitch-fraction coordinate | the named atoms that reach paper all take the point-exact entries beside it, because the fraction round trip loses a scaled point and the pixel gate sees it. The comment above those entries says so; this form contradicted it. |
| `\__tenkz_render_label:nnnn` + 3 dimension registers | 24 | a label placed at an angular offset with its own inner clearance | the kernel calls only the anchor helper above it and computes its own offset |
| `\__tenkz_geom_require_kind:nnn` | 5 | 3-argument convenience over the frame-kind check | all seven real call sites use the 4-argument form, which names the flag it sets |
| `\__tenkz_geom_corridor_include:nn` + `..._include_bbox:nnnn` | 23 | folding a paper point, and a box's four corners, into the corridor silhouette | a two-function island: the box form's only caller was itself dead, and the point form's only caller was the box form. The transverse-only fold beside them is live (lattice cup routing) and stays. |
| `\__tenkz_geom_corridor_escape:Nnnn` | 16 | displacing a tip out of a forbidden transverse interval | the offset hull does this now |
| `\l__tenkz_geom_xb_tl`, `\l__tenkz_geom_yb_tl` | 1 | a second point in the placement graph | the graph resolves one point at a time into the `a` pair beside them |
| `\l__tenkz_model_scratch_tl` | 1 | scratch text in the record store | never written, never read |

`tenkz-render.code.tex` gives up 87 of 290 lines (30%), `tenkz-geometry.code.tex`
46 of 590, `tenkz-model.code.tex` 1.

## Considered and kept, with reasons

| what | why it stayed |
|---|---|
| `scripts/tenkz_pixelpair.sh` (109) | No caller, no documentation, 6 fixtures against the corpus renderer's 257 — a real duplication of `tenkz_corpus.sh --render` before/after. **Kept anyway:** it is the only place the detached true-legacy build is written down, and the redraw campaign is exactly when that build is needed. Ledgered with expiry 1.0 — delete at the campaign's close. |
| `scripts/check_tenkz_demolition.py` + self-test (245, own workflow) | A pin on a structure that was replaced — the category the task names for deletion. **Kept anyway:** it is three days old, the branches predating the demolition are still in flight, and a restored file that nothing loads compiles clean, which is the one failure no other gate sees. Ledgered with expiry 0.8. |
| `scripts/test_tenkz_language.py` (89) | No workflow runs it, and its first probe repeats a step that one does. Its other two do not repeat anything: the typed-port refusal at the extension door, and the equality of the legacy closure word's event stream with the canonical spelling's. Dormant is a wiring question, not a deletion question, and a subtract-only change is the wrong place to settle it. Ledgered with expiry 0.8. |
| leaf keys of the option parsers; role-prefixed silhouette styles | Their full names appear once each, at their definition, because they are assembled at use from a role word and a suffix, or dispatched by the option machinery from an author's key. Absence of a literal mention is not absence of a consumer. The instrument for those rows is the ledger and the registry gate, never a search. |
| tombstoned spellings | None are due. Every alias row carries `sunset=1.0` and the package is at 0.7. |

## Ledger

`docs/tenkz/SHRINK.md` carries a dated entry recording every deletion with its
reason, the keep-becauses above with their expiries, and the empty tombstone
result.

It is recorded as a dated **entry**, not a new `## Session` — deliberately. The
gate reads flag verdicts from the latest `##` section, so opening a session
would have required restating 128 unchanged verdicts to satisfy a parser. This
change retires no registry row and re-examines no flag; claiming a session it
did not run, at a cost of 128 lines of copied bookkeeping, would be the growth
this PR argues against.

## Continuous integration

No workflow step changed. The deleted script is referenced by no workflow — both
`pr-ci.yml` and `blueprint.yml` already invoke `scripts/tenkz_rmp.py` directly,
including in their path filters.

## Gate output

**Every tenkz gate passes on CI, on this tree**
([job](https://github.com/LionSR/TNLean/actions/runs/30174730237/job/89721574994),
6m35s):

| step | result |
|---|---|
| Test tenkz provenance invariant | success |
| Test tenkz render baseline replacement | success |
| Test tenkz manual extraction and reference coverage | success |
| Compile tenkz manual examples standalone | success |
| Check tenkz kernel record contracts | success |
| Compile and audit tenkz corpus | success |
| **Check golden event baselines** | **success** — byte-identical |
| Check string-engine event and pixel probes | success |

`Check tenkz shrink ratchets` passes (18s). `Check retired tenkz catalogue
stays absent` passes (8s).

**Locally, on this tree:**

```
$ python3 scripts/tenkz_language.py check
PASS: tenkz language registry (218 records)
$ python3 scripts/test_tenkz_shrink.py
PASS test_verdict_parser_requires_an_exact_table_row
$ python3 scripts/tenkz_shrink.py gate
tenkz-shrink: PASS: census stable at 192 and all 128 flag(s) carry verdicts
$ python3 scripts/tenkz_lint.py --census
tenkz-census: WARN totals: 44 ink token(s) outside the render stage, 51 stray decimal literal(s)
$ python3 scripts/test_tenkz_corpus_provenance.py
PASS: tenkz provenance source-name invariant
$ python3 scripts/test_tenkz_manual_doctest.py
PASS: tenkz manual doctest extraction and reference coverage
$ TENKZ_CORPUS_VALIDATE_ONLY=1 scripts/tenkz_corpus.sh
PASS: validated provenance and metadata for 264 standalone tenkz corpus files
```

**Locally, on `origin/main`, before the change** — for comparison:

```
$ scripts/tenkz_kernel_probes.sh
PASS: forty-five review regressions hold
PASS: 8 sugar spellings byte-identical to their expansions
PASS: 10 kernel record streams byte-identical

$ scripts/tenkz_string_probes.sh
PASS: 30 string-probe event and pixel artifacts byte-identical
```

The golden gate is the one that matters here: every `.tnlog` in the corpus is
byte-identical to its pinned baseline. Nothing the change deleted was ever
reached, and the event streams prove it.
