### PR TITLE
feat(MPDO): bound periodic-cut operator-Schmidt rank by D²

### DIFF
--- a/TNLean/MPS/MPDO/MutualInfoBridge.lean
+++ b/TNLean/MPS/MPDO/MutualInfoBridge.lean
@@ -55,7 +55,8 @@ noncomputable def periodicCutLeftFactor (M : MPOTensor d D) (N L : ℕ)
         (List.ofFn (finFunctionFinEquiv.symm x')) a b
 
 /-- The right-block factor obtained by opening the two virtual bonds of a
-periodic MPO at a contiguous cut.  Its virtual indices are reversed because \(\operatorname{tr}(AB) = \sum_{a,b} A_{ab} B_{ba}\). -/
+periodic MPO at a contiguous cut. Its virtual indices are reversed because
+\(\operatorname{tr}(AB) = \sum_{a,b} A_{ab} B_{ba}\). -/
 noncomputable def periodicCutRightFactor (M : MPOTensor d D) (K : ℕ)
     (a b : Fin D) : Matrix (Fin (d ^ K)) (Fin (d ^ K)) ℂ :=
   fun y y' ↦

--- a/TNLean/MPS/MPDO/MutualInfoBridge.lean
+++ b/TNLean/MPS/MPDO/MutualInfoBridge.lean
@@ -55,8 +55,7 @@ noncomputable def periodicCutLeftFactor (M : MPOTensor d D) (N L : ℕ)
         (List.ofFn (finFunctionFinEquiv.symm x')) a b
 
 /-- The right-block factor obtained by opening the two virtual bonds of a
-periodic MPO at a contiguous cut.  Its virtual indices are reversed because
-`trace (A * B) = ∑ a, b, A a b * B b a`. -/
+periodic MPO at a contiguous cut.  Its virtual indices are reversed because \(\operatorname{tr}(AB) = \sum_{a,b} A_{ab} B_{ba}\). -/
 noncomputable def periodicCutRightFactor (M : MPOTensor d D) (K : ℕ)
     (a b : Fin D) : Matrix (Fin (d ^ K)) (Fin (d ^ K)) ℂ :=
   fun y y' ↦
@@ -68,8 +67,8 @@ operator-Schmidt decomposition of a normalized periodic MPO with `D * D`
 product terms.
 
 The statement is purely algebraic: it requires neither positivity nor a
-nonzero trace.  Under the totalized inverse convention in `normalizedMPO`, a
-zero trace simply makes every left factor zero. -/
+nonzero trace. The factor `(mpo M N).trace⁻¹` uses the convention \(0⁻¹ = 0\),
+so a zero trace makes every left factor zero. -/
 theorem bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition
     (M : MPOTensor d D) (N L K : ℕ) (h : N = L + K) :
     Matrix.HasOperatorSchmidtDecomposition

--- a/TNLean/MPS/MPDO/MutualInfoBridge.lean
+++ b/TNLean/MPS/MPDO/MutualInfoBridge.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.OperatorSchmidt
 import TNLean.Entropy.MutualInformation
 import TNLean.MPS.MPDO.MutualInfoMonotone
 
@@ -42,6 +43,58 @@ noncomputable def bipartitionedNormalizedMPO (M : MPOTensor d D)
     Matrix (Fin (d ^ L) × Fin (d ^ K)) (Fin (d ^ L) × Fin (d ^ K)) ℂ :=
   (normalizedMPO M N).submatrix (chainBipartitionEquiv d N L K h).symm
     (chainBipartitionEquiv d N L K h).symm
+
+/-- The left-block factor obtained by opening the two virtual bonds of a
+periodic MPO at a contiguous cut.  The normalization scalar is absorbed into
+this factor. -/
+noncomputable def periodicCutLeftFactor (M : MPOTensor d D) (N L : ℕ)
+    (a b : Fin D) : Matrix (Fin (d ^ L)) (Fin (d ^ L)) ℂ :=
+  fun x x' ↦
+    (mpo M N).trace⁻¹ *
+      evalWord M (List.ofFn (finFunctionFinEquiv.symm x))
+        (List.ofFn (finFunctionFinEquiv.symm x')) a b
+
+/-- The right-block factor obtained by opening the two virtual bonds of a
+periodic MPO at a contiguous cut.  Its virtual indices are reversed because
+`trace (A * B) = ∑ a, b, A a b * B b a`. -/
+noncomputable def periodicCutRightFactor (M : MPOTensor d D) (K : ℕ)
+    (a b : Fin D) : Matrix (Fin (d ^ K)) (Fin (d ^ K)) ℂ :=
+  fun y y' ↦
+    evalWord M (List.ofFn (finFunctionFinEquiv.symm y))
+      (List.ofFn (finFunctionFinEquiv.symm y')) b a
+
+/-- Opening the two virtual bonds at a contiguous cut gives an explicit
+operator-Schmidt decomposition of a normalized periodic MPO with `D * D`
+product terms.
+
+The statement is purely algebraic: it requires neither positivity nor a
+nonzero trace.  Under the totalized inverse convention in `normalizedMPO`, a
+zero trace simply makes every left factor zero. -/
+theorem bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition
+    (M : MPOTensor d D) (N L K : ℕ) (h : N = L + K) :
+    Matrix.HasOperatorSchmidtDecomposition
+      (bipartitionedNormalizedMPO M N L K h) (D * D) := by
+  subst N
+  refine ⟨fun t ↦ periodicCutLeftFactor M (L + K) L
+      (finProdFinEquiv.symm t).1 (finProdFinEquiv.symm t).2,
+    fun t ↦ periodicCutRightFactor M K
+      (finProdFinEquiv.symm t).1 (finProdFinEquiv.symm t).2, ?_⟩
+  ext ⟨x, y⟩ ⟨x', y'⟩
+  rw [← finProdFinEquiv.sum_comp]
+  simp [bipartitionedNormalizedMPO, normalizedMPO, chainBipartitionEquiv,
+    biSplitEquiv, blockSplitEquiv_symm_apply, Matrix.sum_apply,
+    Matrix.kroneckerMap_apply, periodicCutLeftFactor, periodicCutRightFactor,
+    mpoMatrixEntry, List.ofFn_fin_append, evalWord_append, Matrix.trace,
+    Matrix.mul_apply, Fintype.sum_prod_type, Finset.mul_sum, mul_assoc]
+
+/-- The operator-Schmidt rank across a contiguous cut of a normalized periodic
+MPO is at most the number `D * D` of ordered pairs of virtual-boundary indices.
+No positivity or local-purification hypothesis is used. -/
+theorem operatorSchmidtRank_bipartitionedNormalizedMPO_le
+    (M : MPOTensor d D) (N L K : ℕ) (h : N = L + K) :
+    Matrix.operatorSchmidtRank (bipartitionedNormalizedMPO M N L K h) ≤ D * D :=
+  Matrix.operatorSchmidtRank_le_of_hasOperatorSchmidtDecomposition
+    (bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition M N L K h)
 
 /-- Positivity of the normalized state is preserved by the bipartition
 reindexing. -/

--- a/TNLean/MPS/MPDO/MutualInfoBridge.lean
+++ b/TNLean/MPS/MPDO/MutualInfoBridge.lean
@@ -88,7 +88,7 @@ theorem bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition
     Matrix.mul_apply, Fintype.sum_prod_type, Finset.mul_sum, mul_assoc]
 
 /-- The operator-Schmidt rank across a contiguous cut of a normalized periodic
-MPO is at most the number `D * D` of ordered pairs of virtual-boundary indices.
+MPO is at most the number \(D^2\) of ordered pairs of virtual-boundary indices.
 No positivity or local-purification hypothesis is used. -/
 theorem operatorSchmidtRank_bipartitionedNormalizedMPO_le
     (M : MPOTensor d D) (N L K : ℕ) (h : N = L + K) :

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -318,8 +318,8 @@
     same formula defines the rank of an arbitrary complex bipartite matrix.
 \end{definition}
 
-\begin{lemma}[Two virtual boundaries bound the operator-Schmidt rank]
-    \label{lem:mpdo_periodic_cut_operator_schmidt_rank}
+\begin{theorem}[Two virtual boundaries bound the operator-Schmidt rank]
+    \label{thm:mpdo_periodic_cut_operator_schmidt_rank}
     \lean{MPOTensor.periodicCutLeftFactor,
       MPOTensor.periodicCutRightFactor,
       MPOTensor.bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition,
@@ -331,7 +331,7 @@
     $N=L+K$. Opening the two virtual bonds at the consecutive cut gives
     \begin{align}
         \sigma^{(N)}_{L:K}
-        &=\sum_{a,b=1}^{D} X_{ab}\otimes Y_{ab},
+        &=\sum_{a,b=0}^{D-1} X_{ab}\otimes Y_{ab},
         \notag
     \end{align}
     and
@@ -343,13 +343,13 @@
     \begin{align}
         (X_{ab})_{x,x'}
         &=\tr[\rho^{(N)}(M)]^{-1}
-          \bigl(M^{x_1x'_1}\cdots M^{x_Lx'_L}\bigr)_{ab},
+          \bigl(M^{x_0x'_0}\cdots M^{x_{L-1}x'_{L-1}}\bigr)_{ab},
         \notag
     \end{align}
     and
     \begin{align}
         (Y_{ab})_{y,y'}
-        &=\bigl(M^{y_1y'_1}\cdots M^{y_Ky'_K}\bigr)_{ba}.
+        &=\bigl(M^{y_0y'_0}\cdots M^{y_{K-1}y'_{K-1}}\bigr)_{ba}.
         \notag
     \end{align}
     This is the identity
@@ -365,7 +365,7 @@
     $I_L\leq4\log D$: such a conclusion would require an entropy bound in
     terms of the operator-Schmidt rank.
     % The unresolved analytic inequality is tracked in issue #4295.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Split each closed virtual word into its left and right products. Expanding

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -318,6 +318,63 @@
     same formula defines the rank of an arbitrary complex bipartite matrix.
 \end{definition}
 
+\begin{lemma}[Two virtual boundaries bound the operator-Schmidt rank]
+    \label{lem:mpdo_periodic_cut_operator_schmidt_rank}
+    \lean{MPOTensor.periodicCutLeftFactor,
+      MPOTensor.periodicCutRightFactor,
+      MPOTensor.bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition,
+      MPOTensor.operatorSchmidtRank_bipartitionedNormalizedMPO_le}
+    \leanok
+    \uses{def:mpdo_split_normalized_mpo,
+      def:bipartite_operator_schmidt_rank}
+    Let $M$ be an MPO tensor of operator bond dimension $D$, and let
+    $N=L+K$. Opening the two virtual bonds at the consecutive cut gives
+    \begin{align}
+        \sigma^{(N)}_{L:K}
+        &=\sum_{a,b=1}^{D} X_{ab}\otimes Y_{ab},
+        \notag
+    \end{align}
+    and
+    \begin{align}
+        \operatorname{OSR}(\sigma^{(N)}_{L:K})&\leq D^2.
+        \notag
+    \end{align}
+    For left-block words $x,x'$ and right-block words $y,y'$, the factors are
+    \begin{align}
+        (X_{ab})_{x,x'}
+        &=\tr[\rho^{(N)}(M)]^{-1}
+          \bigl(M^{x_1x'_1}\cdots M^{x_Lx'_L}\bigr)_{ab},
+        \notag
+    \end{align}
+    and
+    \begin{align}
+        (Y_{ab})_{y,y'}
+        &=\bigl(M^{y_1y'_1}\cdots M^{y_Ky'_K}\bigr)_{ba}.
+        \notag
+    \end{align}
+    This is the identity
+    $\tr(AB)=\sum_{a,b}A_{ab}B_{ba}$, with the normalization scalar
+    absorbed into the left factor. The algebraic decomposition does not use
+    positivity. Since $0^{-1}=0$, it also remains valid when the trace
+    vanishes; a nonzero trace is needed only to interpret
+    $\sigma^{(N)}_{L:K}$ as the normalized physical state.
+
+    This is the two-virtual-boundary algebraic step toward the finite
+    mutual-information estimate in
+    \cite[Proposition~4.5]{Cirac2016MPDO_arXiv}. It does not by itself prove
+    $I_L\leq4\log D$: such a conclusion would require an entropy bound in
+    terms of the operator-Schmidt rank.
+    % The unresolved analytic inequality is tracked in issue #4295.
+\end{lemma}
+
+\begin{proof}\leanok
+    Split each closed virtual word into its left and right products. Expanding
+    the trace over the two exposed virtual indices gives the displayed sum of
+    $D^2$ product matrices. The minimality property of the operator-Schmidt
+    rank then bounds it by the number of displayed terms.
+\end{proof}
+
+
 \begin{theorem}[Coefficient-space characterization of operator-Schmidt rank]
     \label{thm:operator_schmidt_coefficient_space}
     \lean{Matrix.range_operatorSchmidtMap_eq_operatorBlockSpan,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -408,16 +408,22 @@
     \begin{align}
         \sigma^{(N)}_{L:K}
         &=\sum_{a,b=1}^{D} X_{ab}\otimes Y_{ab},
-        &
-        \operatorname{OSR}(\sigma^{(N)}_{L:K})&\leq D^2,
         \notag
     \end{align}
-    where, for left-block words $x,x'$ and right-block words $y,y'$,
+    and
+    \begin{align}
+        \operatorname{OSR}(\sigma^{(N)}_{L:K})&\leq D^2.
+        \notag
+    \end{align}
+    For left-block words $x,x'$ and right-block words $y,y'$, the factors are
     \begin{align}
         (X_{ab})_{x,x'}
         &=\tr[\rho^{(N)}(M)]^{-1}
           \bigl(M^{x_1x'_1}\cdots M^{x_Lx'_L}\bigr)_{ab},
-        &
+        \notag
+    \end{align}
+    and
+    \begin{align}
         (Y_{ab})_{y,y'}
         &=\bigl(M^{y_1y'_1}\cdots M^{y_Ky'_K}\bigr)_{ba}.
         \notag

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -395,6 +395,54 @@
     $\widehat{\mathcal S}_K$.
 \end{definition}
 
+\begin{lemma}[Two virtual boundaries bound the operator-Schmidt rank]
+    \label{lem:mpdo_periodic_cut_operator_schmidt_rank}
+    \lean{MPOTensor.periodicCutLeftFactor,
+      MPOTensor.periodicCutRightFactor,
+      MPOTensor.bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition,
+      MPOTensor.operatorSchmidtRank_bipartitionedNormalizedMPO_le}
+    \leanok
+    \uses{def:mpdo_split_normalized_mpo}
+    Let $M$ be an MPO tensor of operator bond dimension $D$, and let
+    $N=L+K$. Opening the two virtual bonds at the consecutive cut gives
+    \begin{align}
+        \sigma^{(N)}_{L:K}
+        &=\sum_{a,b=1}^{D} X_{ab}\otimes Y_{ab},
+        &
+        \operatorname{OSR}(\sigma^{(N)}_{L:K})&\leq D^2,
+        \notag
+    \end{align}
+    where, for left-block words $x,x'$ and right-block words $y,y'$,
+    \begin{align}
+        (X_{ab})_{x,x'}
+        &=\tr[\rho^{(N)}(M)]^{-1}
+          \bigl(M^{x_1x'_1}\cdots M^{x_Lx'_L}\bigr)_{ab},
+        &
+        (Y_{ab})_{y,y'}
+        &=\bigl(M^{y_1y'_1}\cdots M^{y_Ky'_K}\bigr)_{ba}.
+        \notag
+    \end{align}
+    This is the identity
+    $\tr(AB)=\sum_{a,b}A_{ab}B_{ba}$, with the normalization scalar
+    absorbed into the left factor. The algebraic decomposition does not use
+    positivity. With the totalized inverse convention it also remains valid
+    when the trace vanishes; a nonzero trace is needed only to interpret
+    $\sigma^{(N)}_{L:K}$ as the normalized physical state.
+
+    This lemma is the two-virtual-boundary algebraic step toward the finite
+    mutual-information bound asserted in CPSV16 Proposition~\texttt{PropILILp1}.
+    It does not prove $I_L\leq4\log D$: the required quantum inequality
+    $I(A:B)\leq2\log\operatorname{OSR}(\rho)$ remains open.
+    % The analytic obstruction is tracked in issue #4295.
+\end{lemma}
+
+\begin{proof}\leanok
+    Split each closed virtual word into its left and right products. Expanding
+    the trace over the two exposed virtual indices gives the displayed sum of
+    $D^2$ product matrices. The minimality property of the operator-Schmidt
+    rank then bounds it by the number of displayed terms.
+\end{proof}
+
 \begin{lemma}[Chain mutual information across a consecutive cut]
     \label{lem:mpdo_chain_mutual_information_bipartition}
     \lean{MPOTensor.reducedBlockState_full,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -395,60 +395,6 @@
     $\widehat{\mathcal S}_K$.
 \end{definition}
 
-\begin{lemma}[Two virtual boundaries bound the operator-Schmidt rank]
-    \label{lem:mpdo_periodic_cut_operator_schmidt_rank}
-    \lean{MPOTensor.periodicCutLeftFactor,
-      MPOTensor.periodicCutRightFactor,
-      MPOTensor.bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition,
-      MPOTensor.operatorSchmidtRank_bipartitionedNormalizedMPO_le}
-    \leanok
-    \uses{def:mpdo_split_normalized_mpo}
-    Let $M$ be an MPO tensor of operator bond dimension $D$, and let
-    $N=L+K$. Opening the two virtual bonds at the consecutive cut gives
-    \begin{align}
-        \sigma^{(N)}_{L:K}
-        &=\sum_{a,b=1}^{D} X_{ab}\otimes Y_{ab},
-        \notag
-    \end{align}
-    and
-    \begin{align}
-        \operatorname{OSR}(\sigma^{(N)}_{L:K})&\leq D^2.
-        \notag
-    \end{align}
-    For left-block words $x,x'$ and right-block words $y,y'$, the factors are
-    \begin{align}
-        (X_{ab})_{x,x'}
-        &=\tr[\rho^{(N)}(M)]^{-1}
-          \bigl(M^{x_1x'_1}\cdots M^{x_Lx'_L}\bigr)_{ab},
-        \notag
-    \end{align}
-    and
-    \begin{align}
-        (Y_{ab})_{y,y'}
-        &=\bigl(M^{y_1y'_1}\cdots M^{y_Ky'_K}\bigr)_{ba}.
-        \notag
-    \end{align}
-    This is the identity
-    $\tr(AB)=\sum_{a,b}A_{ab}B_{ba}$, with the normalization scalar
-    absorbed into the left factor. The algebraic decomposition does not use
-    positivity. With the totalized inverse convention it also remains valid
-    when the trace vanishes; a nonzero trace is needed only to interpret
-    $\sigma^{(N)}_{L:K}$ as the normalized physical state.
-
-    This lemma is the two-virtual-boundary algebraic step toward the finite
-    mutual-information bound asserted in CPSV16 Proposition~\texttt{PropILILp1}.
-    It does not prove $I_L\leq4\log D$: the required quantum inequality
-    $I(A:B)\leq2\log\operatorname{OSR}(\rho)$ remains open.
-    % The analytic obstruction is tracked in issue #4295.
-\end{lemma}
-
-\begin{proof}\leanok
-    Split each closed virtual word into its left and right products. Expanding
-    the trace over the two exposed virtual indices gives the displayed sum of
-    $D^2$ product matrices. The minimality property of the operator-Schmidt
-    rank then bounds it by the number of displayed terms.
-\end{proof}
-
 \begin{lemma}[Chain mutual information across a consecutive cut]
     \label{lem:mpdo_chain_mutual_information_bipartition}
     \lean{MPOTensor.reducedBlockState_full,


### PR DESCRIPTION
## What changed

- opens the two virtual bonds of a periodic MPO cut to construct an explicit `D²`-term operator-Schmidt decomposition
- proves `operatorSchmidtRank ≤ D * D` without positivity or local-purification assumptions
- adds the Chapter 21 algebraic boundary step toward CPSV16 `PropILILp1`
- states explicitly that the entropy-versus-OSR inequality in #4295 remains open, so this does not claim `I_L ≤ 4 log D`

## Validation

- targeted build: 3185/3185
- full `lake build`: 9740/9740
- blueprint sync, declaration checks, and double LuaLaTeX
- style, prose, tenkz, chktex, diff, sorry, and axiom gates
- displayed equations split to the repository one-equation-per-`align` convention

Closes #4841
Advances #4242, #4295, and #4169

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and blueprint text in an existing MPDO mutual-information bridge; no auth, data, or runtime behavior changes, with full build validation reported.
> 
> **Overview**
> Adds the **two virtual-boundary** step for a normalized periodic MPO at a contiguous `L | K` cut: opening both bonds yields an explicit operator-Schmidt sum with **at most `D²` terms**, formalized via `periodicCutLeftFactor` / `periodicCutRightFactor` and `bipartitionedNormalizedMPO_hasOperatorSchmidtDecomposition`, then `operatorSchmidtRank_bipartitionedNormalizedMPO_le`. The proof is **purely algebraic** (no positivity or local purification); normalization uses `trace⁻¹` with the `0⁻¹ = 0` convention when the trace vanishes.
> 
> `MutualInfoBridge.lean` now imports `TNLean.Algebra.OperatorSchmidt`. Chapter 21 gains matching blueprint theorem `thm:mpdo_periodic_cut_operator_schmidt_rank`, positioned as progress toward CPSV16 Prop. 4.5 while **not** claiming `I_L ≤ 4 log D` (entropy vs. OSR remains open, #4295).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2a16705c7721a0ee3ee36520991e691a15da65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->