### PR TITLE
refactor(Algebra): drop the MatrixAux import of DependentBlockDiagonal

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -14,7 +14,6 @@ import Mathlib.Analysis.MeanInequalities
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 import Mathlib.LinearAlgebra.Matrix.Transvection
 import Mathlib.Topology.Instances.Matrix
-import TNLean.Algebra.DependentBlockDiagonal
 
 /-!
 # Auxiliary matrix lemmas

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.DependentBlockDiagonal
 import TNLean.Channel.FixedPoint.FullSupportBlockRetraction
 
 /-!

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.DependentBlockDiagonal
 import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.SharedInfra.Scaling

--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.DependentBlockDiagonal
 import TNLean.Algebra.MatrixAux
 import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.SharedInfra.BlockAssembly


### PR DESCRIPTION
### Motivation

- `Algebra.MatrixAux` imported `Algebra.DependentBlockDiagonal` without using it, putting MatrixAux's entire reverse cone on the rebuild path of every DependentBlockDiagonal edit (scout data in #4847: cone 630 of 1039 handwritten modules).
- First executable item of #4847 (P1). The scout's "dead edge, cone → 2" claim was tested by deletion + full build and found **half-wrong**: the edge is dead for MatrixAux itself, but three downstream modules laundered `Matrix.trace_blockDiagonal'_mul` / `Matrix.sigmaBlockInclusion` through it transitively.

### Description

- `TNLean/Algebra/MatrixAux.lean`: drop the `TNLean.Algebra.DependentBlockDiagonal` import (no declaration of the 13 named, no instance, and the single `@[simp]` lemma's pattern constant never appears in MatrixAux's statements).
- `TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean`, `TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean`, `TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean`: import `DependentBlockDiagonal` directly instead of relying on the transitive path.
- Measured effect (graph surgery on the scout's module graph, verified by build): the rebuild cone of `DependentBlockDiagonal` shrinks **630 → 88** modules (the 88 = the three consumers' subtrees plus the one pre-existing direct importer `MPS.RFP.ResidualFamilyCommutation`). No declaration renamed or moved; blueprint `\lean{}` tags unaffected.

### Testing

- `lake build` — 9740 jobs green (the first deletion-only attempt failed on exactly the three laundered consumers; adding their direct imports fixed all three with no further fallout).
- `lake exe lint_style` exit 0; `python3 scripts/blueprint_lean_sync.py --root . --ci` exit 0; `git diff --check` clean.

Lesson for the P3 wave (recorded on #4847): name-based dead-edge scans miss transitive laundering — every candidate edge needs the delete-and-build test, and "cone → k" claims must account for the consumer-subtree union.

---
Addresses #4847

Agent-generated (orchestrated lane; human-accountable), scoped in #4847 per the #4833 contribution policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure import dependency refactor with no logic changes; risk is limited to a possible missed transitive consumer if the build graph were incomplete (addressed by full `lake build` in the PR).
> 
> **Overview**
> **Import-graph cleanup:** `TNLean/Algebra/MatrixAux.lean` no longer imports `TNLean.Algebra.DependentBlockDiagonal` because nothing in that file uses it. That edge had been inflating how many modules rebuild when `DependentBlockDiagonal` changes.
> 
> **Explicit consumers:** `TraceAdjointDensityBlocks`, `ProjectorClosureSpectral`, and `BlockSumGroundSpace` now import `DependentBlockDiagonal` directly (for lemmas such as `Matrix.trace_blockDiagonal'_mul` and `Matrix.sigmaBlockInclusion` that they already depended on via the transitive path through `MatrixAux`).
> 
> No declarations are renamed, moved, or re-proved—only import lines change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e0ef99c863d8abbe090100c600963132a9c7c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->