### PR TITLE
feat(RFP): realize sector-supported physical observables

### DIFF
--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -34,6 +34,7 @@ import TNLean.MPS.RFP.NNCPHGroundSpace
 import TNLean.MPS.RFP.NNCPHGroundSpacesMultiSector
 import TNLean.MPS.RFP.NNCPHMultiSector
 import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
+import TNLean.MPS.RFP.PhysicalObservableRealization
 import TNLean.MPS.RFP.ResidualFamilyCommutation
 import TNLean.MPS.RFP.ResidualFamilySupport
 import TNLean.MPS.RFP.ResidualIsometry

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
-import TNLean.MPS.RFP.PhysicalObservableRealization
 import TNLean.MPS.RFP.ResidualWordSpan
 
 /-!

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
+import TNLean.MPS.RFP.PhysicalObservableRealization
 import TNLean.MPS.RFP.ResidualWordSpan
 
 /-!

--- a/TNLean/MPS/RFP/PhysicalObservableRealization.lean
+++ b/TNLean/MPS/RFP/PhysicalObservableRealization.lean
@@ -1,0 +1,340 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
+import TNLean.MPS.RFP.BNTOrthogonality
+import TNLean.MPS.RFP.ZeroCorrelationLength
+
+/-!
+# Physical observables from simultaneous block injectivity
+
+This file proves the physical-observable realization used in the converse
+zero-correlation-length argument of arXiv:1606.00608, lines 1250--1258.
+A simultaneous word span allows one physical observable to select one BNT
+sector and one virtual matrix unit on both sides of the inserted transfer map.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+/-- A simultaneous length-`L` word span has a coefficient family which selects
+one block label and one matrix entry.
+
+This is the length-`L` form of the simultaneous inverse supplied by the
+block-injective proposition at arXiv:1606.00608, lines 340--345. -/
+theorem WordTupleSpanTop.exists_simultaneous_left_inverse
+    {A : (k : Fin r) → MPSTensor d (dim k)} {L : ℕ}
+    (hSpan : WordTupleSpanTop A L) :
+    ∃ C : Matrix (BlockEntryIndex dim) (Fin L → Fin d) ℂ,
+      ∀ (k j : Fin r) (x y : Fin (dim k))
+        (x' y' : Fin (dim j)),
+        (∑ w : Fin L → Fin d,
+          C ⟨k, x, y⟩ w * evalWord (A j) (List.ofFn w) x' y') =
+            if h : k = j then
+              if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
+            else 0 := by
+  classical
+  let target (k : Fin r) (x y : Fin (dim k)) :
+      (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j x' y' =>
+      if h : k = j then
+        if _ : h ▸ x = x' then if _ : h ▸ y = y' then 1 else 0 else 0
+      else 0
+  have htarget (k : Fin r) (x y : Fin (dim k)) :
+      target k x y ∈ Submodule.span ℂ (Set.range (wordTuple A L)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  have hcoeff (k : Fin r) (x y : Fin (dim k)) :
+      ∃ c : (Fin L → Fin d) → ℂ,
+        ∑ w, c w • wordTuple A L w = target k x y :=
+    (Submodule.mem_span_range_iff_exists_fun ℂ).mp (htarget k x y)
+  choose C hC using hcoeff
+  refine ⟨fun z w ↦ C z.1 z.2.1 z.2.2 w, ?_⟩
+  intro k j x y x' y'
+  have hentry := congrArg (fun M ↦ M j x' y') (hC k x y)
+  simpa [wordTuple, target, Fintype.linearCombination_apply,
+    Matrix.sum_apply, Matrix.smul_apply] using hentry
+
+/-- The physical observable transfer as a double sum of word insertions. -/
+private theorem physicalObservableTransfer_apply
+    (A : MPSTensor d D) (L : ℕ)
+    (O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    physicalObservableTransfer A L O X =
+      ∑ σ : Fin L → Fin d, ∑ τ : Fin L → Fin d,
+        O τ σ • (evalWord A (List.ofFn σ) * X *
+          (evalWord A (List.ofFn τ))ᴴ) := by
+  classical
+  simp only [physicalObservableTransfer, LinearMap.sum_apply, LinearMap.smul_apply,
+    LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
+  simp only [Matrix.mul_assoc]
+
+/-- Inserted transfer maps preserve finite linear combinations of physical
+observables. -/
+private theorem physicalObservableTransfer_sum_smul
+    {ι : Type*} [Fintype ι] (A : MPSTensor d D) (L : ℕ)
+    (q : ι → ℂ)
+    (O : ι → Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    physicalObservableTransfer A L (∑ i, q i • O i) =
+      ∑ i, q i • physicalObservableTransfer A L (O i) := by
+  classical
+  apply LinearMap.ext
+  intro X
+  rw [physicalObservableTransfer_apply]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, LinearMap.sum_apply,
+    LinearMap.smul_apply, smul_eq_mul, Finset.sum_smul]
+  conv_lhs =>
+    rw [Finset.sum_comm]
+    enter [2, σ]
+    rw [Finset.sum_comm]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [physicalObservableTransfer_apply]
+  conv_rhs => rw [Finset.sum_comm]
+  simp [Finset.smul_sum, smul_smul]
+
+/-- A word of a direct-sum tensor is the direct sum of the corresponding block
+words. -/
+private theorem evalWord_directSumTensor
+    (A : (k : Fin r) → MPSTensor d (dim k)) (w : List (Fin d)) :
+    evalWord (directSumTensor A) w =
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockDiagonal' fun k ↦ evalWord (A k) w) := by
+  have hDirect : directSumTensor A = toTensorFromBlocks (fun _ ↦ 1) A := by
+    funext i
+    simp [directSumTensor, toTensorFromBlocks]
+  rw [hDirect, evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal]
+  simp
+
+/-- Submatrices commute with finite sums. -/
+private theorem submatrix_sum {ι l m p q : Type*}
+    (s : Finset ι) (M : ι → Matrix m p ℂ) (f : l → m) (g : q → p) :
+    (∑ i ∈ s, M i).submatrix f g = ∑ i ∈ s, (M i).submatrix f g := by
+  ext a b
+  simp only [Matrix.submatrix_apply, Matrix.sum_apply]
+
+/-- The inserted transfer map of a direct sum is the reindexing of the
+corresponding block-diagonal word sum. -/
+private theorem physicalObservableTransfer_directSum_reindex
+    (A : (k : Fin r) → MPSTensor d (dim k)) (L : ℕ)
+    (O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ)
+    (Y : Matrix ((k : Fin r) × Fin (dim k))
+      ((k : Fin r) × Fin (dim k)) ℂ) :
+    physicalObservableTransfer (directSumTensor A) L O
+        (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv Y) =
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (∑ σ : Fin L → Fin d, ∑ τ : Fin L → Fin d,
+          O τ σ •
+            (Matrix.blockDiagonal' (fun k ↦ evalWord (A k) (List.ofFn σ)) * Y *
+              (Matrix.blockDiagonal' (fun k ↦
+                evalWord (A k) (List.ofFn τ)))ᴴ)) := by
+  classical
+  rw [physicalObservableTransfer_apply]
+  simp only [evalWord_directSumTensor, Matrix.reindex_apply]
+  rw [submatrix_sum]
+  apply Finset.sum_congr rfl
+  intro σ _
+  rw [submatrix_sum]
+  apply Finset.sum_congr rfl
+  intro τ _
+  rw [Matrix.conjTranspose_submatrix,
+    Matrix.submatrix_mul_equiv _ _ _ finSigmaFinEquiv.symm _,
+    Matrix.submatrix_mul_equiv _ _ _ finSigmaFinEquiv.symm _]
+  rfl
+
+/-- A simultaneous length-`L` word span realizes a sector-supported virtual
+matrix-unit map by a physical observable on `L` sites.
+
+For the direct-sum tensor, the inserted transfer map sends the chosen input
+entry in sector `j` to the chosen output entry in the same sector and vanishes
+on every other sector pair. By linearity, these matrix-unit realizations give
+the rank-one maps $|R_j)(l_j|$ and $|r_j)(L_j|$ in equations (1252) and (1256)
+of arXiv:1606.00608.
+-/
+theorem WordTupleSpanTop.exists_physicalObservableTransfer_directSum_matrixUnit
+    {A : (k : Fin r) → MPSTensor d (dim k)} {L : ℕ}
+    (hSpan : WordTupleSpanTop A L)
+    (j : Fin r) (a b c e : Fin (dim j)) :
+    ∃ O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ,
+      ∀ X : Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ,
+        physicalObservableTransfer (directSumTensor A) L O X =
+          Matrix.single
+            (finSigmaFinEquiv ⟨j, a⟩) (finSigmaFinEquiv ⟨j, c⟩)
+            (X (finSigmaFinEquiv ⟨j, b⟩) (finSigmaFinEquiv ⟨j, e⟩)) := by
+  classical
+  obtain ⟨C, hC⟩ := hSpan.exists_simultaneous_left_inverse
+  let W : (Fin L → Fin d) →
+      Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ :=
+    fun σ ↦ Matrix.blockDiagonal' (fun k ↦ evalWord (A k) (List.ofFn σ))
+  let M₁ := ∑ σ : Fin L → Fin d, C ⟨j, a, b⟩ σ • W σ
+  let M₂ := ∑ τ : Fin L → Fin d, C ⟨j, c, e⟩ τ • W τ
+  have hM₁ : M₁ = Matrix.single ⟨j, a⟩ ⟨j, b⟩ 1 := by
+    ext ⟨k, x⟩ ⟨l, y⟩
+    by_cases hkl : k = l
+    · subst l
+      simp only [M₁, Matrix.sum_apply, Matrix.smul_apply, W,
+        Matrix.blockDiagonal'_apply_eq, smul_eq_mul]
+      rw [hC]
+      by_cases hjk : j = k
+      · subst k
+        by_cases hx : a = x <;> by_cases hy : b = y <;>
+          simp [hx, hy]
+      · simp [hjk]
+    · have hnot : ¬ ((j = k ∧ HEq a x) ∧ j = l ∧ HEq b y) := by
+        rintro ⟨⟨hjk, _⟩, hjl, _⟩
+        exact hkl (hjk.symm.trans hjl)
+      simp only [M₁, Matrix.sum_apply, Matrix.smul_apply, W]
+      rw [Finset.sum_eq_zero]
+      · simp [hnot]
+      · intro σ _
+        simp [Matrix.blockDiagonal'_apply_ne _ _ _ hkl]
+  have hM₂ : M₂ = Matrix.single ⟨j, c⟩ ⟨j, e⟩ 1 := by
+    ext ⟨k, x⟩ ⟨l, y⟩
+    by_cases hkl : k = l
+    · subst l
+      simp only [M₂, Matrix.sum_apply, Matrix.smul_apply, W,
+        Matrix.blockDiagonal'_apply_eq, smul_eq_mul]
+      rw [hC]
+      by_cases hjk : j = k
+      · subst k
+        by_cases hx : c = x <;> by_cases hy : e = y <;>
+          simp [hx, hy]
+      · simp [hjk]
+    · have hnot : ¬ ((j = k ∧ HEq c x) ∧ j = l ∧ HEq e y) := by
+        rintro ⟨⟨hjk, _⟩, hjl, _⟩
+        exact hkl (hjk.symm.trans hjl)
+      simp only [M₂, Matrix.sum_apply, Matrix.smul_apply, W]
+      rw [Finset.sum_eq_zero]
+      · simp [hnot]
+      · intro τ _
+        simp [Matrix.blockDiagonal'_apply_ne _ _ _ hkl]
+  let O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ := fun τ σ ↦
+    C ⟨j, a, b⟩ σ * starRingEnd ℂ (C ⟨j, c, e⟩ τ)
+  refine ⟨O, ?_⟩
+  intro X
+  let Y := Matrix.reindex finSigmaFinEquiv.symm finSigmaFinEquiv.symm X
+  have hX : X = Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv Y := by
+    ext u v
+    simp [Y, Matrix.reindex_apply]
+  have hSum :
+      (∑ σ : Fin L → Fin d, ∑ τ : Fin L → Fin d,
+        O τ σ • (W σ * Y * (W τ)ᴴ)) = M₁ * Y * M₂ᴴ := by
+    simp only [mul_assoc, Matrix.sum_mul, Algebra.smul_mul_assoc,
+      Matrix.conjTranspose_sum, Matrix.conjTranspose_smul, RCLike.star_def,
+      Matrix.mul_sum, Algebra.mul_smul_comm, Finset.smul_sum, smul_smul,
+      mul_comm, O, M₁, M₂]
+    rw [Finset.sum_comm]
+  rw [hX, physicalObservableTransfer_directSum_reindex]
+  change Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+      (∑ σ, ∑ τ, O τ σ • (W σ * Y * (W τ)ᴴ)) = _
+  rw [hSum, hM₁, hM₂]
+  ext u v
+  simp only [Matrix.reindex_apply]
+  simp [Matrix.single_apply, Equiv.eq_symm_apply]
+
+/-- A physical observable can realize an arbitrary linear combination of
+virtual matrix-unit maps supported on one BNT sector.
+
+This is the linear extension of
+`WordTupleSpanTop.exists_physicalObservableTransfer_directSum_matrixUnit`.
+It is the sector-selection content of arXiv:1606.00608, lines 1250--1258. -/
+theorem WordTupleSpanTop.exists_physicalObservableTransfer_directSum_sectorSupported
+    {A : (k : Fin r) → MPSTensor d (dim k)} {L : ℕ}
+    (hSpan : WordTupleSpanTop A L) (j : Fin r)
+    (q : Fin (dim j) × Fin (dim j) × Fin (dim j) × Fin (dim j) → ℂ) :
+    ∃ O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ,
+      ∀ X : Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ,
+        physicalObservableTransfer (directSumTensor A) L O X =
+          ∑ z, q z • Matrix.single
+            (finSigmaFinEquiv ⟨j, z.1⟩)
+            (finSigmaFinEquiv ⟨j, z.2.2.1⟩)
+            (X (finSigmaFinEquiv ⟨j, z.2.1⟩)
+              (finSigmaFinEquiv ⟨j, z.2.2.2⟩)) := by
+  classical
+  have hUnit : ∀ z : Fin (dim j) × Fin (dim j) × Fin (dim j) × Fin (dim j),
+      ∃ O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ,
+        ∀ X : Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ,
+          physicalObservableTransfer (directSumTensor A) L O X =
+            Matrix.single
+              (finSigmaFinEquiv ⟨j, z.1⟩)
+              (finSigmaFinEquiv ⟨j, z.2.2.1⟩)
+              (X (finSigmaFinEquiv ⟨j, z.2.1⟩)
+                (finSigmaFinEquiv ⟨j, z.2.2.2⟩)) := by
+    rintro ⟨a, b, c, e⟩
+    exact hSpan.exists_physicalObservableTransfer_directSum_matrixUnit j a b c e
+  choose O hO using hUnit
+  refine ⟨∑ z, q z • O z, ?_⟩
+  intro X
+  rw [physicalObservableTransfer_sum_smul]
+  simp only [LinearMap.sum_apply, LinearMap.smul_apply]
+  apply Finset.sum_congr rfl
+  intro z _
+  rw [hO z X]
+
+/-- The two virtual rank-one insertions used in equations (1252) and (1256) of
+arXiv:1606.00608 are physical observables supported on the common
+block-injective length.
+
+The coefficient `R a c * l e b` is the matrix-entry expansion of
+$|R)(l|$: it sends an input matrix `X` to
+$\operatorname{tr}(lX)R$. The conclusion is supported only on the selected
+sector `j`; all other diagonal and off-diagonal sector pairs vanish. -/
+theorem WordTupleSpanTop.exists_physicalObservableTransfer_directSum_rankOne
+    {A : (k : Fin r) → MPSTensor d (dim k)} {L : ℕ}
+    (hSpan : WordTupleSpanTop A L) (j : Fin r)
+    (R l : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
+    ∃ O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ,
+      ∀ X : Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ,
+        physicalObservableTransfer (directSumTensor A) L O X =
+          ∑ z : Fin (dim j) × Fin (dim j) × Fin (dim j) × Fin (dim j),
+            (R z.1 z.2.2.1 * l z.2.2.2 z.2.1) • Matrix.single
+              (finSigmaFinEquiv ⟨j, z.1⟩)
+              (finSigmaFinEquiv ⟨j, z.2.2.1⟩)
+              (X (finSigmaFinEquiv ⟨j, z.2.1⟩)
+                (finSigmaFinEquiv ⟨j, z.2.2.2⟩)) :=
+  hSpan.exists_physicalObservableTransfer_directSum_sectorSupported j
+    (fun z ↦ R z.1 z.2.2.1 * l z.2.2.2 z.2.1)
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- A BNT canonical form admits the sector-supported rank-one physical
+observables of equations (1252) and (1256) on a common region of size at most
+$3D^5$, where $D$ is the total bond dimension.
+
+This is the physical-observable consequence of Proposition `propblockinj` used
+at arXiv:1606.00608, lines 1250--1258. It selects one BNT sector and realizes
+an arbitrary virtual rank-one insertion there, while all other sector pairs
+vanish. -/
+theorem exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five
+    (hCF : IsBNTCanonicalForm P) :
+    ∃ L : ℕ, 0 < L ∧ L ≤ 3 * P.totalDim ^ 5 ∧
+      ∀ (j : Fin P.basisCount)
+        (R l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ),
+        ∃ O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ,
+          ∀ X : Matrix (Fin (∑ k : Fin P.basisCount, P.basisDim k))
+              (Fin (∑ k : Fin P.basisCount, P.basisDim k)) ℂ,
+            physicalObservableTransfer (directSumTensor P.basis) L O X =
+              ∑ z : Fin (P.basisDim j) × Fin (P.basisDim j) ×
+                  Fin (P.basisDim j) × Fin (P.basisDim j),
+                (R z.1 z.2.2.1 * l z.2.2.2 z.2.1) • Matrix.single
+                  (finSigmaFinEquiv ⟨j, z.1⟩)
+                  (finSigmaFinEquiv ⟨j, z.2.2.1⟩)
+                  (X (finSigmaFinEquiv ⟨j, z.2.1⟩)
+                    (finSigmaFinEquiv ⟨j, z.2.2.2⟩)) := by
+  obtain ⟨L, hL, hLbound, hSpan⟩ :=
+    hCF.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five
+  refine ⟨L, hL, hLbound, ?_⟩
+  intro j R l
+  exact hSpan.exists_physicalObservableTransfer_directSum_rankOne j R l
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/RFP/PhysicalObservableRealization.lean
+++ b/TNLean/MPS/RFP/PhysicalObservableRealization.lean
@@ -10,10 +10,11 @@ import TNLean.MPS.RFP.ZeroCorrelationLength
 /-!
 # Physical observables from simultaneous block injectivity
 
-This file proves the physical-observable realization used in the converse
-zero-correlation-length argument of arXiv:1606.00608, lines 1250--1258.
-A simultaneous word span allows one physical observable to select one BNT
-sector and one virtual matrix unit on both sides of the inserted transfer map.
+This file proves the multiplicity-one, unit-weight specialization of the
+physical-observable realization used in the converse zero-correlation-length
+argument of arXiv:1606.00608, lines 1250--1258. A simultaneous word span allows
+one physical observable to select one BNT basis sector and one virtual matrix
+unit on both sides of the inserted transfer map.
 -/
 
 open scoped Matrix BigOperators
@@ -277,9 +278,9 @@ theorem WordTupleSpanTop.exists_physicalObservableTransfer_directSum_sectorSuppo
   intro z _
   rw [hO z X]
 
-/-- The two virtual rank-one insertions used in equations (1252) and (1256) of
-arXiv:1606.00608 are physical observables supported on the common
-block-injective length.
+/-- In the multiplicity-one, unit-weight direct sum, the two virtual rank-one
+insertions corresponding to equations (1252) and (1256) of arXiv:1606.00608
+are physical observables supported on the common block-injective length.
 
 The coefficient `R a c * l e b` is the matrix-entry expansion of
 $|R)(l|$: it sends an input matrix `X` to
@@ -305,14 +306,15 @@ namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
 
-/-- A BNT canonical form admits the sector-supported rank-one physical
-observables of equations (1252) and (1256) on a common region of size at most
-$3D^5$, where $D$ is the total bond dimension.
+/-- The multiplicity-one, unit-weight direct sum of a BNT basis admits
+sector-supported rank-one physical observables on a common region of size at
+most $3D^5$, where $D$ is the total bond dimension.
 
-This is the physical-observable consequence of Proposition `propblockinj` used
-at arXiv:1606.00608, lines 1250--1258. It selects one BNT sector and realizes
-an arbitrary virtual rank-one insertion there, while all other sector pairs
-vanish. -/
+This is the multiplicity-one specialization of the physical-observable
+consequence of Proposition `propblockinj` used at arXiv:1606.00608, lines
+1250--1258. It selects one BNT basis sector and realizes an arbitrary virtual
+rank-one insertion there, while all other sector pairs vanish. The raw-weight
+repeated-copy tensor `P.toTensor` is not the tensor in this conclusion. -/
 theorem exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five
     (hCF : IsBNTCanonicalForm P) :
     ∃ L : ℕ, 0 < L ∧ L ≤ 3 * P.totalDim ^ 5 ∧

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -297,3 +297,92 @@
     Theorem~\ref{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum} applies to
     the direct sum.
 \end{proof}
+
+\begin{theorem}[Simultaneous inverse for BNT word evaluations]%
+    \label{thm:bnt_word_tuple_simultaneous_inverse}
+    \lean{MPSTensor.WordTupleSpanTop.exists_simultaneous_left_inverse}
+    \leanok
+    \uses{rem:word_tuple_span_top}
+    Suppose the simultaneous length-$L$ word evaluations of $(A_j)_j$ span
+    $\bigoplus_j\MN{D_j}$. There are coefficients
+    $C_{(j,a,b),w}$ such that, for every sector $k$,
+    \begin{align}
+        \sum_{|w|=L} C_{(j,a,b),w}(A_k^w)_{x,y}
+        &=\delta_{j,k}\delta_{a,x}\delta_{b,y}.
+        \notag
+    \end{align}
+\end{theorem}
+\begin{proof}\leanok
+    The tuple whose $j$-th component is the matrix unit
+    $\ketbra{a}{b}$ and whose other components vanish belongs to the full
+    simultaneous word span. Reading its $(k,x,y)$ entry gives the displayed
+    identity.
+\end{proof}
+
+\begin{theorem}[Sector-supported physical observable realization]%
+    \label{thm:bnt_sector_supported_physical_observable}
+    \lean{MPSTensor.WordTupleSpanTop.exists_physicalObservableTransfer_directSum_matrixUnit}
+    \lean{MPSTensor.WordTupleSpanTop.exists_physicalObservableTransfer_directSum_sectorSupported}
+    \lean{MPSTensor.WordTupleSpanTop.exists_physicalObservableTransfer_directSum_rankOne}
+    \leanok
+    \uses{def:physical_observable_transfer, rem:word_tuple_span_top}
+    Let $A=\bigoplus_k A_k$, and suppose the simultaneous length-$L$ word
+    evaluations span $\bigoplus_k\MN{D_k}$. For every sector $j$ and matrices
+    $R,l\in\MN{D_j}$, there is an observable $O$ on $L$ sites whose inserted
+    transfer map vanishes on every sector pair except $(j,j)$ and satisfies
+    \begin{align}
+        \E_O(X)_{j,j}
+        &=R\,\tr(lX_{j,j}).
+        \label{eq:zcl_sector_rank_one}
+    \end{align}
+    In particular, arbitrary virtual matrix-unit maps supported on one sector
+    are realized by physical observables.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:bnt_word_tuple_simultaneous_inverse}
+    Apply Theorem~\ref{thm:bnt_word_tuple_simultaneous_inverse} independently
+    to the left and right word evaluations. The observable with coefficients
+    \begin{align}
+        O_{\tau,\sigma}
+        &=C_{(j,a,b),\sigma}\,
+          \overline{C_{(j,c,e),\tau}}
+        \notag
+    \end{align}
+    sends the $(b,e)$ entry of $X_{j,j}$ to the $(a,c)$ entry and annihilates
+    every other entry and sector pair. Summing these matrix-unit observables
+    with coefficients $R_{a,c}l_{e,b}$ gives
+    (\ref{eq:zcl_sector_rank_one}).
+\end{proof}
+
+\begin{theorem}[BNT rank-one observables at the sharp blocking length]%
+    \label{thm:bnt_rank_one_observables_sharp_length}
+    \lean{MPSTensor.IsBNTCanonicalForm.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five}
+    \leanok
+    \uses{def:sector_bnt_cf, def:physical_observable_transfer}
+    Let $P$ be a BNT canonical form of total bond dimension $D$. There is a
+    positive length $L\leq3D^5$ such that, for every BNT sector $j$ and every
+    $R,l\in\MN{D_j}$, a physical observable on $L$ sites realizes the
+    sector-supported insertion (\ref{eq:zcl_sector_rank_one}). This is the
+    block-injective physical-observable assertion used in
+    \cite[proof of Theorem~3.8]{Cirac2016MPDO_arXiv}, equations (1252) and
+    (1256) in the local source.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:sharp_bnt_block_separation,
+        thm:bnt_sector_supported_physical_observable}
+    Theorem~\ref{thm:sharp_bnt_block_separation} gives a positive
+    $L\leq3D^5$ for which the simultaneous word evaluations span the product
+    matrix algebra. Apply
+    Theorem~\ref{thm:bnt_sector_supported_physical_observable} at this length.
+\end{proof}
+
+\begin{remark}[Remaining obstruction in the printed converse]
+    The sector-supported observables of source lines 1250--1258 therefore
+    require no additional hypothesis. The preceding claim that
+    $\E_j^2\ne\E_j$ yields a nonzero eigenvalue $\lambda$ with
+    $|\lambda|<1$ is not valid for a non-idempotent operator with a nilpotent
+    Jordan part at eigenvalue zero. Hence these observable realizations do not
+    prove the unconditional converse in Theorem~3.8. A proof following the
+    source must still derive the nonzero subleading left and right eigenvectors
+    used in the correlation calculation at lines 1260--1268.
+\end{remark}

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -354,18 +354,21 @@
     (\ref{eq:zcl_sector_rank_one}).
 \end{proof}
 
-\begin{theorem}[BNT rank-one observables at the sharp blocking length]%
+\begin{theorem}[Multiplicity-one BNT rank-one observables at the sharp blocking length]%
     \label{thm:bnt_rank_one_observables_sharp_length}
     \lean{MPSTensor.IsBNTCanonicalForm.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five}
     \leanok
     \uses{def:sector_bnt_cf, def:physical_observable_transfer}
-    Let $P$ be a BNT canonical form of total bond dimension $D$. There is a
-    positive length $L\leq3D^5$ such that, for every BNT sector $j$ and every
-    $R,l\in\MN{D_j}$, a physical observable on $L$ sites realizes the
-    sector-supported insertion (\ref{eq:zcl_sector_rank_one}). This is the
-    block-injective physical-observable assertion used in
+    Let $P$ be a BNT canonical form of total bond dimension $D$, and form the
+    direct sum $A=\bigoplus_j A_j$ with one unit-weight copy of each BNT basis
+    tensor. There is a positive length $L\leq3D^5$ such that, for every basis
+    sector $j$ and every $R,l\in\MN{D_j}$, a physical observable on $L$ sites
+    realizes the sector-supported insertion
+    (\ref{eq:zcl_sector_rank_one}). This is the multiplicity-one specialization
+    of the block-injective physical-observable assertion used in
     \cite[proof of Theorem~3.8]{Cirac2016MPDO_arXiv}, equations (1252) and
-    (1256) in the local source.
+    (1256) in the local source. It does not realize the weighted copy-pair
+    insertions for the raw canonical-form tensor $P.\mathrm{toTensor}$.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:sharp_bnt_block_separation,
@@ -376,13 +379,16 @@
     Theorem~\ref{thm:bnt_sector_supported_physical_observable} at this length.
 \end{proof}
 
-\begin{remark}[Remaining obstruction in the printed converse]
-    The sector-supported observables of source lines 1250--1258 therefore
-    require no additional hypothesis. The preceding claim that
-    $\E_j^2\ne\E_j$ yields a nonzero eigenvalue $\lambda$ with
-    $|\lambda|<1$ is not valid for a non-idempotent operator with a nilpotent
-    Jordan part at eigenvalue zero. Hence these observable realizations do not
-    prove the unconditional converse in Theorem~3.8. A proof following the
+\begin{remark}[Remaining obstructions in the printed converse]
+    For the multiplicity-one unit-weight representative, the sector-supported
+    observables require no additional hypothesis. The full canonical-form
+    equations (1252) and (1256) also contain all repeated-copy pairs and their
+    raw weight powers; the theorem above does not realize those weighted
+    insertions. Moreover, the preceding claim that $\E_j^2\ne\E_j$ yields a
+    nonzero eigenvalue $\lambda$ with $|\lambda|<1$ is not valid for a
+    non-idempotent operator with a nilpotent Jordan part at eigenvalue zero.
+    Hence these observable realizations do not prove the unconditional
+    converse in Theorem~3.8. Even at multiplicity one, a proof following the
     source must still derive the nonzero subleading left and right eigenvectors
     used in the correlation calculation at lines 1260--1268.
 \end{remark}

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -197,15 +197,18 @@ a scope restriction, not the full forward implication of the source theorem
 at lines 498--502.
 The older predicate \leanid{MPSTensor.IsCID} instead quantifies directly over
 arbitrary virtual matrices $X,Y$.  Its converse to idempotence is valid, but it
-is stronger than physical CID.  The simultaneous block-injectivity theorem now
-supplies the physical observables asserted at source lines 1250--1258.  More
-precisely,
+is stronger than physical CID. For the multiplicity-one unit-weight direct sum,
+the simultaneous block-injectivity theorem now supplies the corresponding
+physical observables from source lines 1250--1258. More precisely,
 \leanid{MPSTensor.IsBNTCanonicalForm.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five}
-selects any one BNT sector and realizes the insertion $|R)(l|$ there on a
+selects any one BNT basis sector and realizes the insertion $|R)(l|$ there on a
 region of size at most $3D^5$, with zero insertion on every other sector pair.
-Thus sector selection is no longer a missing assumption.
+This theorem acts on \leanid{directSumTensor P.basis}, not the raw weighted
+repeated-copy tensor \leanid{P.toTensor}. The source equations contain all copy
+pairs and their weight powers, so their unrestricted realization remains
+separate.
 
-The remaining obstruction occurs in the preceding sentence at source line
+A further obstruction occurs in the preceding sentence at source line
 1250.  The source claims that
 $\mathbb E_1^2\ne\mathbb E_1$ implies a nonzero eigenvalue $\lambda$ with
 $|\lambda|<1$.  This implication is false for a non-idempotent operator whose

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -197,22 +197,33 @@ a scope restriction, not the full forward implication of the source theorem
 at lines 498--502.
 The older predicate \leanid{MPSTensor.IsCID} instead quantifies directly over
 arbitrary virtual matrices $X,Y$.  Its converse to idempotence is valid, but it
-is stronger than physical CID: the source obtains the required virtual
-insertions from physical observables by block injectivity
-(lines 1250--1258).  For a corrected statement which removes the raw-copy
-obstruction, the reverse implication would still require a formal
-physical-realization theorem for block observables, followed by the nonzero
-power-sum argument in lines 1260--1268.  One must not identify the two CID
-predicates before that realization theorem is proved.  Since the older
-predicate universally quantifies over positive definite fixed points, it is
-also vacuous for a tensor without such a fixed point.  The periodic-chain
-predicate avoids this boundary-state issue.  Even after a physical-realization
-theorem is supplied, the source proof cannot establish the unrestricted
-reverse implication: the step from non-idempotence of the full transfer matrix
-to non-idempotence of a normal BNT component ignores the eigenvalues contributed
-by the raw copy weights.  A theorem restricted to one unit-weight copy per BNT
-component would still require the physical-realization and power-sum arguments,
-but it would be a different statement.
+is stronger than physical CID.  The simultaneous block-injectivity theorem now
+supplies the physical observables asserted at source lines 1250--1258.  More
+precisely,
+\leanid{MPSTensor.IsBNTCanonicalForm.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five}
+selects any one BNT sector and realizes the insertion $|R)(l|$ there on a
+region of size at most $3D^5$, with zero insertion on every other sector pair.
+Thus sector selection is no longer a missing assumption.
+
+The remaining obstruction occurs in the preceding sentence at source line
+1250.  The source claims that
+$\mathbb E_1^2\ne\mathbb E_1$ implies a nonzero eigenvalue $\lambda$ with
+$|\lambda|<1$.  This implication is false for a non-idempotent operator whose
+only subleading spectral value is zero but whose generalized zero-eigenspace
+has a nontrivial nilpotent Jordan part.  Consequently the unconditional reverse
+direction is not obtained from the printed proof, even for the multiplicity-one
+unit-weight representative.  A source-faithful conditional statement would
+have to assume or derive exactly the nonzero subleading left and right
+eigenvectors used in lines 1250--1262; replacing that step by a different
+trace-nondegeneracy argument would not formalize the cited proof.
+
+Since the older predicate universally quantifies over positive definite fixed
+points, it is also vacuous for a tensor without such a fixed point.  The
+periodic-chain predicate avoids this boundary-state issue.  For the
+unrestricted raw-weight statement there is an additional obstruction: the
+step from non-idempotence of the full transfer matrix to non-idempotence of a
+normal BNT component ignores the eigenvalues contributed by the raw copy
+weights.
 
 Accordingly, \leanid{MPSTensor.IsBNTZCL} remains the virtual-insertion
 surrogate, while \leanid{MPSTensor.IsPositiveGapBNTZCL} names the physical


### PR DESCRIPTION
## What changed

- derives a simultaneous left inverse from the BNT `WordTupleSpanTop` datum
- realizes arbitrary sector-supported virtual matrix-unit and rank-one inserted transfer maps by physical observables
- specializes the construction to the sharp `L ≤ 3 D^5` CPSV16 `propblockinj` bound
- updates Chapter 26 and the paper-gap note: sector selection at lines 1250–1258 is complete
- leaves the unconditional reverse theorem open because CPSV16 line 1250 incorrectly infers a nonzero subleading eigenvalue from non-idempotence in the possible presence of a nilpotent zero Jordan part

## Validation

- targeted realization and integrating RFP builds
- full `lake build`: 9741 jobs
- blueprint sync, declaration checks, and double LuaLaTeX with zero undefined cross-references
- style, forbidden-token, diff, no-sorry/no-axiom, and declaration gates
- rebased onto current `origin/main` and targeted consumers rebuilt

Advances #4786 and #2633
Updates #2380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are formal proofs and documentation only; no runtime, auth, or data paths. Risk is mainly mathematical correctness of the new Lean arguments, which the PR’s full build and gates are intended to validate.
> 
> **Overview**
> **Formalizes** the multiplicity-one CPSV16 block-injectivity step (arXiv:1606.00608, ~1250–1258): from `WordTupleSpanTop` it builds a simultaneous left inverse, then physical observables whose inserted transfer on `directSumTensor` realizes sector-local matrix units, linear combinations, and rank-one maps \(|R)(l|\), with a BNT canonical-form corollary at length \(L \le 3D^5\). The new module is wired through the RFP aggregator.
> 
> **Blueprint Chapter 26** adds theorems for the simultaneous inverse, sector-supported observables, and the sharp-length multiplicity-one bound, plus a remark that weighted copy-pair insertions on `P.toTensor` and the source’s non-idempotence \(\Rightarrow\) subleading eigenvalue step are still open.
> 
> **Paper-gap note** replaces “physical realization still needed” with pointers to the new theorem on `directSumTensor P.basis`, and records the nilpotent-Jordan obstruction at source line 1250 and remaining raw-weight gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46939eb8690c2f91dd4f8ecf3614a115d167f562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->