### PR TITLE
refactor(MPS): register the mps_transfer simp set in MPS.Defs

### DIFF
--- a/TNLean/MPS/CanonicalForm/Existence.lean
+++ b/TNLean/MPS/CanonicalForm/Existence.lean
@@ -8,7 +8,6 @@ import TNLean.Channel.PerronFrobenius.Existence
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Overlap.PeripheralToTransferMapGap
 import TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank
-import TNLean.MPS.Tactic.Basic
 
 /-!
 # Canonical form existence reductions from the source proofs

--- a/TNLean/MPS/Core/Transfer.lean
+++ b/TNLean/MPS/Core/Transfer.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Defs
-import TNLean.MPS.Tactic.Basic
 
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.PosDef

--- a/TNLean/MPS/Core/Transfer.lean
+++ b/TNLean/MPS/Core/Transfer.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Defs
+import TNLean.MPS.Tactic.Attr
 
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.PosDef

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -8,6 +8,7 @@ import Mathlib.Data.List.OfFn
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Order.Filter.AtTopBot.Basic
+import Mathlib.Tactic.Attr.Register
 
 /-!
 # Basic definitions for matrix product state tensors
@@ -547,3 +548,6 @@ theorem isNormal_of_gaugeEquiv {A B : MPSTensor d D}
   exact ⟨N, hNpos, isNBlkInjective_of_gaugeEquiv hN hGauge⟩
 
 end MPSTensor
+
+/-- Simp set for transfer map unfoldings. -/
+register_simp_attr mps_transfer

--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -8,7 +8,6 @@ import Mathlib.Data.List.OfFn
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Order.Filter.AtTopBot.Basic
-import Mathlib.Tactic.Attr.Register
 
 /-!
 # Basic definitions for matrix product state tensors
@@ -548,6 +547,3 @@ theorem isNormal_of_gaugeEquiv {A B : MPSTensor d D}
   exact ⟨N, hNpos, isNBlkInjective_of_gaugeEquiv hN hGauge⟩
 
 end MPSTensor
-
-/-- Simp set for transfer map unfoldings. -/
-register_simp_attr mps_transfer

--- a/TNLean/MPS/MPDO/VerticalProductReconstruction.lean
+++ b/TNLean/MPS/MPDO/VerticalProductReconstruction.lean
@@ -15,7 +15,6 @@ import TNLean.MPS.MPDO.NormalizedGroupedSectors
 import TNLean.MPS.MPDO.VerticalBNTConstruction
 import TNLean.MPS.MPDO.VerticalBNT
 import TNLean.MPS.MPDO.VerticalSpectral
-import TNLean.MPS.Tactic.Basic
 
 /-!
 # Coisometric reconstruction of retained vertical products

--- a/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
+++ b/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.RFP.BeigiLoopInjectivity
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.SharedInfra.Scaling
+import TNLean.MPS.Tactic.Basic
 import TNLean.Spectral.FrobeniusNorm
 
 /-!

--- a/TNLean/MPS/Tactic.lean
+++ b/TNLean/MPS/Tactic.lean
@@ -8,4 +8,5 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.MPS.Tactic
 
+import TNLean.MPS.Tactic.Attr
 import TNLean.MPS.Tactic.Basic

--- a/TNLean/MPS/Tactic/Attr.lean
+++ b/TNLean/MPS/Tactic/Attr.lean
@@ -1,0 +1,23 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Tactic.Attr.Register
+
+/-!
+# Simp attribute sets for tensor-network proofs
+
+This module registers the custom `simp` attribute sets used by the tactic macros
+in `TNLean.MPS.Tactic.Basic` and by tagging sites such as
+`TNLean.MPS.Core.Transfer`. It is intentionally a leaf module: both the tactic
+macros and the tagging sites import it, so every `transfer_simp` call site keeps
+the registration in its import closure.
+
+## Custom simp attributes
+
+* `mps_transfer` : transfer map unfoldings
+-/
+
+/-- Simp set for transfer map unfoldings. -/
+register_simp_attr mps_transfer

--- a/TNLean/MPS/Tactic/Basic.lean
+++ b/TNLean/MPS/Tactic/Basic.lean
@@ -8,12 +8,8 @@ import Mathlib.Tactic.Attr.Register
 /-!
 # Tactics for tensor-network proofs
 
-This file provides small custom `simp` attribute sets and thin tactic macros
-for recurring proof patterns in MPS / channel / overlap files.
-
-## Custom simp attributes
-
-* `mps_transfer` : transfer map unfoldings
+This file provides tactic macros for recurring proof patterns in MPS /
+channel / overlap files.
 
 ## Tactic macros
 
@@ -23,16 +19,11 @@ for recurring proof patterns in MPS / channel / overlap files.
 ## Design
 
 The tactics are intentionally simple. They do not search; when the normal form does
-not apply, they leave clear unsolved goals. The `simp` attribute sets are the primary
-mechanism; the tactic macros are thin sugar over the attributes.
+not apply, they leave clear unsolved goals. Each macro expands to a `simp` call over
+the `mps_transfer` simp set.
 -/
 
 open Lean Elab Tactic Meta
-
-/-! ### Custom simp attribute sets -/
-
-/-- Simp set for transfer map unfoldings. -/
-register_simp_attr mps_transfer
 
 /-! ### Tactic macros -/
 

--- a/TNLean/MPS/Tactic/Basic.lean
+++ b/TNLean/MPS/Tactic/Basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Tactic.Attr.Register
+import TNLean.MPS.Tactic.Attr
 
 /-!
 # Tactics for tensor-network proofs
@@ -20,7 +20,7 @@ channel / overlap files.
 
 The tactics are intentionally simple. They do not search; when the normal form does
 not apply, they leave clear unsolved goals. Each macro expands to a `simp` call over
-the `mps_transfer` simp set.
+the `mps_transfer` simp set, which is registered in `TNLean.MPS.Tactic.Attr`.
 -/
 
 open Lean Elab Tactic Meta


### PR DESCRIPTION
### Motivation

- `MPS.Tactic.Basic` (84 lines: one simp-attribute registration plus the `mpv_ext`/`transfer_simp` macros) sits at rebuild cone 535 of 1039 handwritten modules (scout data in #4847): any tactic-file edit re-elaborates a quarter of the library, and the dependency direction is backwards — tactic infrastructure should sit above the MPS foundation, not inside it.
- Second executable item of #4847 (P2). P1 landed as #4851.

### Description

- `MPS/Tactic/Attr.lean` (new leaf module): owns `register_simp_attr mps_transfer`. It is imported by `Tactic.Basic` — keeping the simp set in the import closure of every `transfer_simp` call site, including clients of the `MPS.Tactic` aggregator (review feedback; the registration briefly lived in `MPS.Defs` at the first revision, which left aggregator-only clients expanding `transfer_simp` to an unregistered simp set) — and by the tagging site `Core.Transfer`.
- `MPS/Core/Transfer.lean`: keeps its `@[mps_transfer]` tag via the Attr module; drops the `Tactic.Basic` import.
- `MPS/CanonicalForm/Existence.lean`, `MPS/MPDO/VerticalProductReconstruction.lean`: name none of the attribute or the tactics — dead edges, dropped (build-verified).
- `MPS/RFP/BeigiLoopFixedPoint.lean`: used `transfer_simp` through the fragile transitive path `RFP.Defs → Core.Transfer → Tactic.Basic`; now imports `Tactic.Basic` directly.
- `MPS/Tactic/Basic.lean`: keeps both tactic macros; module doc updated to describe only what the file still provides.
- `MPS/Defs.lean`: untouched in the final diff.

Measured effect (graph surgery on the scout's module graph): rebuild cone of `MPS.Tactic.Basic` **535 → 215** (−320 modules ≈ −2900 jobs per tactic-file edit). The new `Tactic.Attr` leaf has a wide reverse cone by construction but is effectively frozen — the same trade `Mathlib.Tactic.Attr.Register` makes. No declaration renamed; the attribute and tactic names are unchanged; blueprint `\lean{}` tags unaffected.

### Testing

- `lake build` — 9741 jobs green at the final head (delete-and-build verification of all three dropped edges).
- `lake exe lint_style` exit 0; aggregator generator `--check` current; module-policy tests 16/16 OK; oversized-file check clean; `python3 scripts/blueprint_lean_sync.py --root . --ci` exit 0; `git diff --check` clean.
- Regression probe for the review scenario: `import TNLean.MPS.Tactic` + `example : True := by transfer_simp` failed pre-fix (`unknown identifier mps_transfer`), compiles at HEAD.

---
Addresses #4847

Agent-generated (orchestrated lane; human-accountable), scoped in #4847 per the #4833 contribution policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor with unchanged attribute and tactic names; no proof or API changes beyond dependency edges.
> 
> **Overview**
> Moves **`register_simp_attr mps_transfer`** from `MPS.Tactic.Basic` into **`MPS.Defs`**, so the transfer simp set is available anywhere the MPS foundation is imported without pulling in tactic macros.
> 
> **Import graph cleanup:** `CanonicalForm/Existence`, `Core/Transfer`, and `MPDO/VerticalProductReconstruction` drop `Tactic.Basic` (they did not need tactics). **`BeigiLoopFixedPoint`** now imports `Tactic.Basic` directly because it uses **`transfer_simp`**, instead of relying on a transitive path through `Core.Transfer`.
> 
> `MPS.Tactic.Basic` keeps **`mpv_ext`** and **`transfer_simp`**; its module doc no longer describes registering the simp attribute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5202805b4bb53e55a7809a6acbd43baeba7c7e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
