### PR TITLE
doc(blueprint): split parent-Hamiltonian foundations

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -1,52 +1,30 @@
-\chapter{Parent Hamiltonians}\label{ch:parent_hamiltonian}
+\chapter{Parent-Hamiltonian Foundations: Injective and Normal Ground Spaces}\label{ch:parent_hamiltonian}
 
 For a translation-invariant matrix product state with tensor $A$, the
 \emph{parent Hamiltonian} is the translation-invariant sum of local terms, each
 the orthogonal projector onto the complement of the length-$L$ local space
-$G_L(A) = \mathrm{im}(\Gamma_L)$. This is the space $\mathcal G_L^A$ of
+$G_L(A)=\operatorname{im}(\Gamma_L)$. This is the space $\mathcal G_L^A$ of
 \cite{PerezGarcia2007Matrix}; we write
-$\Gamma_L(X)(\sigma) = \tr(A^\sigma X)$, which is the same as the source
-convention $\tr(XA^\sigma)$ by cyclicity of the trace. We follow the
-construction of \cite{PerezGarcia2007Matrix} and
-\cite{Cirac2021Matrix}, identifying the $N$-site space with functions
-$\{0,\ldots,d{-}1\}^N \to \C$ on the computational basis rather than as an
-explicit tensor product.
+$\Gamma_L(X)(\sigma)=\tr(A^\sigma X)$, which agrees with the source convention
+$\tr(XA^\sigma)$ by cyclicity of the trace. Following
+\cite{PerezGarcia2007Matrix,Cirac2021Matrix}, we identify the $N$-site space
+with functions $\{0,\ldots,d{-}1\}^N\to\C$ on the computational basis.
 
-The chapter establishes the ground-space structure in increasing generality. For
-an injective tensor, when $N\ge2$ and $1<L\le N$, the parent Hamiltonian is
-frustration-free and the periodic MPS vector $V^{(N)}(A)$ is its unique ground
-state, obtained from the intersection property of the local ground spaces. For a
-normal tensor the corresponding conclusion follows, under the stated
-closure-property and length hypotheses, from the inverting-and-growing-back
-argument at the injectivity length.
-The nearest-neighbor section separates the translated parent-term commutation
-and zero-energy equations for $V^{(N)}(A)$ from the source ground-space spanning
-clause in the pure-state theorem relating renormalization fixed points, zero
-correlation length, and nearest-neighbor commuting parent Hamiltonians in
-\cite{Cirac2016MPDO_arXiv}. The spectral-gap section records the source
-anticommutator martingale condition for overlapping local terms, together with
-cyclic norm-compression estimates as sufficient stronger hypotheses. For a tensor
-in block-injective canonical form
-$A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
-\cite[Theorem~IV.16]{Cirac2021Matrix}
-and \cite[Theorem~12]{PerezGarcia2007Matrix} state that the periodic
-parent-Hamiltonian ground space is spanned by the vectors
-$\{V^{(N)}(A_j)\}$. The sections below record the open-segment recursion and the
-intersection and closure steps, together with separate conditional statements
-for the block-diagonal boundary-condition comparison in the periodic ring.
+The first part proves the intersection property for the local spaces and uses it
+to identify the periodic ground space of an injective tensor. For $N\ge2$ and
+$1<L\le N$, the parent Hamiltonian is frustration-free and the periodic matrix
+product vector $V^{(N)}(A)$ is its unique ground state. The periodic-boundary
+comparison reduces an arbitrary boundary matrix to the commutant of the tensor.
+
+For a normal tensor, injectivity is available after a finite blocking length.
+The remaining sections develop the inverting-and-growing-back argument at
+this length and the closure property needed to pass from open intervals to the
+periodic ring, including the comparison in both directions. The next chapter
+studies commutation, spectral gaps, and the degenerate ground spaces arising
+from several normal blocks.
 
 \input{chapter/ch13_parent_hamiltonian_injective_ground_spaces}
 \input{chapter/ch13_parent_hamiltonian_injective_boundary}
 \input{chapter/ch13_parent_hamiltonian_normal_boundary}
 \input{chapter/ch13_parent_hamiltonian_normal_closing}
 \input{chapter/ch13_parent_hamiltonian_normal_closing_reverse}
-\input{chapter/ch13_parent_hamiltonian_commuting_gap}
-\input{chapter/ch13_parent_hamiltonian_decorrelation}
-\input{chapter/ch13_parent_hamiltonian_spectral_gap}
-\input{chapter/ch13_parent_hamiltonian_spectral_gap_martingale}
-\input{chapter/ch13_parent_hamiltonian_block_intersections}
-\input{chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences}
-\input{chapter/ch13_parent_hamiltonian_block_diagonal}
-\input{chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing}
-\input{chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality}
-\input{chapter/ch13_parent_hamiltonian_bnt_consequences}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_gap_and_blocks.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_gap_and_blocks.tex
@@ -1,0 +1,36 @@
+\chapter{Commutation, Spectral Gaps, and Degenerate Ground Spaces}
+\label{ch:parent_hamiltonian_gap_and_blocks}
+
+The relation between local parent terms and the structure of the underlying
+tensor begins with nearest-neighbor commutation. For normal tensors, the first
+sections compare commuting length-two parent terms with renormalization fixed
+points and zero correlation length, keeping separate the local commutation and
+ground-space assertions in \cite{Cirac2016MPDO_arXiv}. The decorrelation
+argument is expressed through commuting support projectors and their
+idempotent product.
+
+The spectral-gap sections state the anticommutator form of the martingale
+criterion for overlapping local projectors and derive stronger sufficient
+conditions from cyclic norm-compression estimates. These estimates turn local
+control of neighboring ground spaces into a lower bound for the gap above the
+frustration-free ground space.
+
+The final sections treat a block-injective canonical tensor
+$A^i=\bigoplus_j\mu_jA_j^i$. They establish the open-segment intersection
+relations for the spaces $G_N(A_j)$, analyze block-diagonal boundary conditions
+across the periodic cut, and reduce the periodic ground space to
+$\spn\{V^{(N)}(A_j)\}_j$ under the stated length and closure hypotheses, as in
+\cite[Theorem~IV.16]{Cirac2021Matrix} and
+\cite[Theorem~12]{PerezGarcia2007Matrix}. This completes the Hamiltonian
+analysis before the study of correlation functions in the next chapter.
+
+\input{chapter/ch13_parent_hamiltonian_commuting_gap}
+\input{chapter/ch13_parent_hamiltonian_decorrelation}
+\input{chapter/ch13_parent_hamiltonian_spectral_gap}
+\input{chapter/ch13_parent_hamiltonian_spectral_gap_martingale}
+\input{chapter/ch13_parent_hamiltonian_block_intersections}
+\input{chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences}
+\input{chapter/ch13_parent_hamiltonian_block_diagonal}
+\input{chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing}
+\input{chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality}
+\input{chapter/ch13_parent_hamiltonian_bnt_consequences}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -11,6 +11,7 @@
 \input{chapter/ch11_fundamental_theorem_proof}
 \input{chapter/ch12_symmetry}
 \input{chapter/ch13_parent_hamiltonian}
+\input{chapter/ch13_parent_hamiltonian_gap_and_blocks}
 \input{chapter/ch14_correlations}
 \input{chapter/ch15_examples}
 \input{chapter/ch16_channel_representations}


### PR DESCRIPTION
## What changed

- separate the injective and normal ground-space foundations from the later parent-Hamiltonian material
- preserve the existing `ch:parent_hamiltonian` label and every included mathematical section
- add a second chapter wrapper for commutation, spectral gaps, and degenerate ground spaces
- route the new chapter immediately before correlations

This is the first of two stacked readability PRs. The follow-up will split the second chapter once more into commuting/spectral-gap and block-injective chapters.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` (5,527 unique declaration references; in sync)
- `TEXINPUTS="../../tex/tenkz//:" lualatex -interaction=nonstopmode -halt-on-error print.tex` (twice; 0 undefined cross-references)
- input inventory: all 15 prior section inputs occur exactly once and in their original order
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX restructuring with preserved chapter label and unchanged section inputs; no Lean or runtime code.
> 
> **Overview**
> **Splits the monolithic parent-Hamiltonian chapter** into a foundations chapter and a follow-on chapter for commutation, gaps, and block degeneracy, without moving or dropping any `\input` sections.
> 
> The existing `ch13_parent_hamiltonian.tex` is retitled to **Parent-Hamiltonian Foundations: Injective and Normal Ground Spaces**, keeps `\label{ch:parent_hamiltonian}`, and its opening prose is tightened to cover only injective/normal ground-space material (with a forward pointer to the new chapter). The five injective/normal section files stay here; the ten commuting/gap/block `\input`s move out.
> 
> A new wrapper **`ch13_parent_hamiltonian_gap_and_blocks.tex`** introduces **Commutation, Spectral Gaps, and Degenerate Ground Spaces** (`\label{ch:parent_hamiltonian_gap_and_blocks}`) and hosts those ten sections in the same order as before. **`content.tex`** inserts this chapter immediately after the foundations chapter and before correlations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78ed4651759be9ff0dec77687aa267b448904d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->