### PR TITLE
doc(blueprint): match the union lemma prose to the reduced hypotheses

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
@@ -401,9 +401,9 @@ every finite union of injective regions.
     Fix an edge $e$ and a partition of the vertex set into the three
     edge-centred blocks $R$, $B$, $C$ (red, blue, complementary) of the normal
     PEPS proof, with the red block carrying one endpoint of $e$ and the blue
-    block the other. If the blue block $B$ and the complementary block $C$ are
-    each injective and every virtual bond dimension is positive, then their
-    union $B\cup C=V\setminus R$ is injective.
+    block the other. The injectivity of the blue and complementary blocks is
+    part of the edge-centred blocking data; if every virtual bond dimension
+    is positive, then their union $B\cup C=V\setminus R$ is injective.
 \end{lemma}
 \begin{proof}\leanok
     This is Lemma~\ref{lem:peps_injectiveRegion_union} for the


### PR DESCRIPTION
Follow-up to #4836, closes #4842.

`regionBlockedTensorInjective_union` no longer takes the blue/complement injectivity as explicit hypotheses — both are derived internally from the `NormalEdgeBlockingData` fields — but the blueprint entry `lem:peps_injectiveRegion_union_edgeBlocked` still presented them as premises. The prose now says the blocks' injectivity is part of the edge-centred blocking data and states only the bond-positivity condition, matching the Lean signature. The `\lean{}` pointer, `\leanok`, and `\uses` are unchanged.

Gates: full `lake build` 9742 jobs green; `leanblueprint checkdecls` exit 0 (fresh `lean_decls`); `blueprint_lean_sync.py --ci` exit 0; double `lualatex` (TENKZ path) exit 0 ×2, 0 undefined References.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edit with no code or proof logic changes.
> 
> **Overview**
> Updates the blueprint statement of **`lem:peps_injectiveRegion_union_edgeBlocked`** so it matches **`TNLean.PEPS.regionBlockedTensorInjective_union`** after the Lean refactor in #4836.
> 
> The lemma no longer lists blue-block and complement-block injectivity as separate “if” premises; those are now described as **part of the edge-centred blocking data**. The only explicit hypothesis left in the prose is **positive virtual bond dimensions**, from which injectivity of **\(B \cup C = V \setminus R\)** follows.
> 
> No change to `\lean{}`, `\leanok`, or `\uses`—documentation-only sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2be079b1cf67ce088695891aa3d40909766efbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->