### PR TITLE
feat(RFP): prove conditional positive-gap ZCL converse

### DIFF
--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -12,6 +12,7 @@ import TNLean.MPS.RFP.AppendixBChainCommutation
 import TNLean.MPS.RFP.AppendixBCommutation
 import TNLean.MPS.RFP.AppendixBSupport
 import TNLean.MPS.RFP.Assembly
+import TNLean.MPS.RFP.BNTDirectSumBasis
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.BNTWeightCounterexample
 import TNLean.MPS.RFP.BeigiEventuallyConstantSectorGraph

--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -41,4 +41,5 @@ import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.ResidualWordSpan
 import TNLean.MPS.RFP.StructuralForm
 import TNLean.MPS.RFP.StructuralFull
+import TNLean.MPS.RFP.ZCLReverse
 import TNLean.MPS.RFP.ZeroCorrelationLength

--- a/TNLean/MPS/RFP/BNTDirectSumBasis.lean
+++ b/TNLean/MPS/RFP/BNTDirectSumBasis.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.RFP.BNTOrthogonality
+
+/-!
+# BNT basis data for the unit-weight direct sum
+
+This file packages a BNT canonical form as a CPSV basis of normal tensors for
+its multiplicity-one unit-weight direct-sum representative.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+/-- The unit-weight block tensor is the direct-sum tensor. -/
+theorem toTensorFromBlocks_one_eq_directSumTensor
+    (A : (j : Fin r) → MPSTensor d (dim j)) :
+    toTensorFromBlocks (d := d) (fun _ ↦ 1) A = directSumTensor A := by
+  funext i
+  simp [toTensorFromBlocks, directSumTensor]
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- The distinct basis tensors of a BNT canonical form are a basis of normal
+tensors for their direct-sum tensor.
+
+Each basis block of a BNT canonical form is irreducible and left-canonical
+with normalized self-overlap, hence a spectrally normalized normal tensor; the
+MPV family of the unit-weight direct sum is the plain sum of the block MPV
+families; and the eventual linear independence of the basis MPV states is part
+of the canonical form. This is the basis-of-normal-tensors relation of
+arXiv:1606.00608, lines 271--274, at the explicit multiplicity-one unit-weight
+representative $A=\bigoplus_j A_j$ used in the proof of Theorem
+`thm:main-MPS`, lines 534--541.
+
+**Scope restriction (multiplicity-one unit weights):** the statement covers
+the direct sum of the distinct basis tensors with one unit-weight copy each.
+Repeated copies and raw sector weights remain outside this statement; see
+docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex. -/
+theorem isCPSVBasisOfNormalTensors_basisDirectSum
+    (hCF : IsBNTCanonicalForm P) :
+    IsCPSVBasisOfNormalTensors (directSumTensor P.basis)
+      (fun j => ⟨P.basisDim j, P.basis j⟩) := by
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  refine {
+    blocks_normal := fun j ↦
+      isNormalTensor_of_isNormal_leftCanonical (P.basis j)
+        (hCF.basis_isNormal j) (hCF.basis_left_canonical j)
+    spans_mpv := ?_
+    eventually_li := by exact hCF.bnt_data }
+  intro N _hN
+  refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
+  rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis,
+    mpv_toTensorFromBlocks_eq_sum]
+  simp
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/RFP/BNTDirectSumBasis.lean
+++ b/TNLean/MPS/RFP/BNTDirectSumBasis.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.Periodic.NormalizedSelfOverlap
 import TNLean.MPS.RFP.BNTOrthogonality
 
 /-!

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalBoundaryClosing
 import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
+import TNLean.MPS.RFP.BNTDirectSumBasis
 import TNLean.MPS.RFP.ResidualWordSpan
 
 /-!
@@ -339,13 +340,6 @@ theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_wordTupleSpanTop_one
   exact chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing
     μ A hμ (by omega) (by omega) hClose
 
-/-- The unit-weight block tensor is the direct-sum tensor. -/
-theorem toTensorFromBlocks_one_eq_directSumTensor
-    (A : (j : Fin r) → MPSTensor d (dim j)) :
-    toTensorFromBlocks (d := d) (fun _ ↦ 1) A = directSumTensor A := by
-  funext i
-  simp [toTensorFromBlocks, directSumTensor]
-
 namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
@@ -397,40 +391,6 @@ theorem rfp_hasParentHamiltonianGroundSpaceSpanning_basisDirectSum
       have hInj : IsInjective (P.basis j) :=
         rfp_nt_structural (P.basis j) (hnormal j) hBlockRFP
       exact chainGroundSpace_eq_mpvSubmodule hInj (by omega) (by omega) (by omega)
-
-/-- The distinct basis tensors of a BNT canonical form are a basis of normal
-tensors for their direct-sum tensor.
-
-Each basis block of a BNT canonical form is irreducible and left-canonical
-with normalized self-overlap, hence a spectrally normalized normal tensor; the
-MPV family of the unit-weight direct sum is the plain sum of the block MPV
-families; and the eventual linear independence of the basis MPV states is part
-of the canonical form. This is the basis-of-normal-tensors relation of
-arXiv:1606.00608, lines 271--274, at the explicit multiplicity-one unit-weight
-representative $A=\bigoplus_j A_j$ used in the proof of Theorem
-`thm:main-MPS`, lines 534--541.
-
-**Scope restriction (multiplicity-one unit weights):** the statement covers
-the direct sum of the distinct basis tensors with one unit-weight copy each.
-Repeated copies and raw sector weights remain outside this statement; see
-docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex. -/
-theorem isCPSVBasisOfNormalTensors_basisDirectSum
-    (hCF : IsBNTCanonicalForm P) :
-    IsCPSVBasisOfNormalTensors (directSumTensor P.basis)
-      (fun j => ⟨P.basisDim j, P.basis j⟩) := by
-  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
-    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
-  refine {
-    blocks_normal := fun j ↦
-      isNormalTensor_of_isNormal_leftCanonical (P.basis j)
-        (hCF.basis_isNormal j) (hCF.basis_left_canonical j)
-    spans_mpv := ?_
-    eventually_li := by exact hCF.bnt_data }
-  intro N _hN
-  refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
-  rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis,
-    mpv_toTensorFromBlocks_eq_sum]
-  simp
 
 /-- **Corrected forward direction of the main MPS theorem (RFP ⟹ ZCL) at the
 multiplicity-one representative.**

--- a/TNLean/MPS/RFP/ZCLReverse.lean
+++ b/TNLean/MPS/RFP/ZCLReverse.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.StationarySupport
-import TNLean.MPS.RFP.NNCPHMultiSector
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.RFP.PhysicalObservableRealization
 
 /-!
@@ -73,7 +73,6 @@ theorem directSumSectorInclusion_eq_sum (j : Fin r)
   rw [Matrix.trace_traceAdjointMap_mul]
   simp only [Matrix.sum_mul, Matrix.trace_sum, Matrix.trace_single_mul]
   simp [directSumSectorCompression, Matrix.trace, Matrix.diag, Matrix.mul_apply]
-
 
 @[simp] theorem directSumSectorCompression_inclusion (j : Fin r)
     (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
@@ -153,9 +152,7 @@ theorem directSumSectorRankOne_apply (j : Fin r)
     · simp [Matrix.sum_apply, Sigma.mk.injEq, Ne.symm hk']
   · simp [Matrix.sum_apply, Sigma.mk.injEq, Ne.symm hk]
 
-
-
-@[simp] theorem directSumSectorCompression_reindex
+private theorem directSumSectorCompression_reindex
     (j : Fin r)
     (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
     directSumSectorCompression dim j
@@ -223,7 +220,7 @@ section Eigenvectors
 
 /-- A left eigenvector for the trace-pairing adjoint evaluates a power of the
 original map by the corresponding eigenvalue power. -/
-theorem trace_mul_pow_apply_of_traceAdjointMap_hasEigenvector
+private theorem trace_mul_pow_apply_of_traceAdjointMap_hasEigenvector
     {D : ℕ} (E : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
     {ν : ℂ} {l : Matrix (Fin D) (Fin D) ℂ}
     (hl : Module.End.HasEigenvector (Matrix.traceAdjointMap E) ν l)
@@ -262,8 +259,8 @@ theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
   classical
   letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
   let E := transferMap (P.basis j)
-  have hCh : IsChannel E := by
-    exact transferMap_isChannel (P.basis j) (hCF.basis_left_canonical j)
+  have hCh : IsChannel E :=
+    transferMap_isChannel (P.basis j) (hCF.basis_left_canonical j)
   have hIrr : IsIrreducibleMap E :=
     isIrreducibleCP_transferMap_of_isIrreducibleTensor
       (P.basis j) (hCF.basis_irreducible j)
@@ -312,12 +309,9 @@ theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
             directSumSectorCompression_transferMap_pow (dim := P.basisDim)
               (B := P.basis) (j := j) n₁ X]
         exact trace_mul_pow_apply_of_traceAdjointMap_hasEigenvector E hl n₁ _
-      have hρ_pow_all : ∀ n : ℕ, (E ^ n) ρ = ρ := by
-        intro n
-        induction n with
-        | zero => simp
-        | succ n ih => rw [pow_succ', Module.End.mul_apply, ih, hρ_fixed]
-      have hρ_pow : (E ^ n₂) ρ = ρ := hρ_pow_all n₂
+      have hρ_pow : (E ^ n₂) ρ = ρ := by
+        rw [Module.End.pow_apply]
+        exact Function.IsFixedPt.iterate hρ_fixed n₂
       have hmid : directSumSectorCompression P.basisDim j
           (((transferMap (directSumTensor P.basis)) ^ n₂)
             (c • directSumSectorInclusion P.basisDim j ρ)) = c • ρ := by
@@ -393,7 +387,28 @@ theorem isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent_of_spectral_
   constructor
   · exact hCF.isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair
       hspectral
-  · exact hCF.isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL
+  · intro hRFP
+    letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+      fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+    apply isPositiveGapBNTZCL_of_isTransferIdempotent_directSum P.basis
+    · refine {
+        blocks_normal := fun j ↦
+          isNormalTensor_of_isNormal_leftCanonical (P.basis j)
+            (hCF.basis_isNormal j) (hCF.basis_left_canonical j)
+        spans_mpv := ?_
+        eventually_li := hCF.bnt_data }
+      intro N _hN
+      refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
+      rw [← show toTensorFromBlocks (d := d) (fun _ ↦ 1) P.basis =
+          directSumTensor P.basis by
+        funext i
+        simp [toTensorFromBlocks, directSumTensor],
+        mpv_toTensorFromBlocks_eq_sum]
+      simp
+    · exact hCF.basis_irreducible
+    · exact hCF.basis_left_canonical
+    · exact hCF.basis_distinct
+    · exact hRFP
 
 /-- Source physical BNT zero correlation length implies transfer idempotence at
 the multiplicity-one representative under the line-1250 spectral assertion. -/

--- a/TNLean/MPS/RFP/ZCLReverse.lean
+++ b/TNLean/MPS/RFP/ZCLReverse.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.StationarySupport
-import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.RFP.BNTDirectSumBasis
 import TNLean.MPS.RFP.PhysicalObservableRealization
 
 /-!
@@ -410,20 +410,7 @@ theorem isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent_of_spectral_
     letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
       fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
     apply isPositiveGapBNTZCL_of_isTransferIdempotent_directSum P.basis
-    · refine {
-        blocks_normal := fun j ↦
-          isNormalTensor_of_isNormal_leftCanonical (P.basis j)
-            (hCF.basis_isNormal j) (hCF.basis_left_canonical j)
-        spans_mpv := ?_
-        eventually_li := hCF.bnt_data }
-      intro N _hN
-      refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
-      rw [← show toTensorFromBlocks (d := d) (fun _ ↦ 1) P.basis =
-          directSumTensor P.basis by
-        funext i
-        simp [toTensorFromBlocks, directSumTensor],
-        mpv_toTensorFromBlocks_eq_sum]
-      simp
+    · exact hCF.isCPSVBasisOfNormalTensors_basisDirectSum
     · exact hCF.basis_irreducible
     · exact hCF.basis_left_canonical
     · exact hCF.basis_distinct

--- a/TNLean/MPS/RFP/ZCLReverse.lean
+++ b/TNLean/MPS/RFP/ZCLReverse.lean
@@ -342,7 +342,14 @@ theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
 
 /-- Conditional reverse implication at the multiplicity-one representative.
 The additional hypothesis is precisely the spectral assertion invoked at
-arXiv:1606.00608, line 1250 for a non-idempotent normal block. -/
+arXiv:1606.00608, line 1250 for a non-idempotent normal block.
+
+**Scope restriction (arXiv:1606.00608, Theorem `TheoremZCLPure`, lines
+1248--1268):** this theorem uses positive-gap CID, one unit-weight copy of each
+BNT basis tensor, and the normalized nonzero subleading spectral pair asserted
+at line 1250. It does not prove that spectral assertion or cover raw weighted
+repeated copies. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair
     (hCF : IsBNTCanonicalForm P)
     (hspectral : ∀ j : Fin P.basisCount,
@@ -371,7 +378,13 @@ theorem isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_p
     exact IsIdempotentElem.zero
 
 /-- Conditional equivalence between positive-gap BNT zero correlation length
-and transfer idempotence for the multiplicity-one representative. -/
+and transfer idempotence for the multiplicity-one representative.
+
+**Scope restriction (arXiv:1606.00608, Theorem `TheoremZCLPure`, lines
+1248--1268):** the reverse implication assumes the normalized nonzero
+subleading spectral pair from line 1250 and excludes adjacent-gap CID and raw
+weighted repeated copies. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent_of_spectral_pair
     (hCF : IsBNTCanonicalForm P)
     (hspectral : ∀ j : Fin P.basisCount,
@@ -411,7 +424,14 @@ theorem isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent_of_spectral_
     · exact hRFP
 
 /-- Source physical BNT zero correlation length implies transfer idempotence at
-the multiplicity-one representative under the line-1250 spectral assertion. -/
+the multiplicity-one representative under the line-1250 spectral assertion.
+
+**Scope restriction (arXiv:1606.00608, Theorem `TheoremZCLPure`, lines
+1248--1268):** although the premise uses source physical CID, the tensor is the
+multiplicity-one unit-weight representative and the proof assumes the
+normalized nonzero subleading spectral pair from line 1250. Raw weighted
+repeated copies remain outside the conclusion. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem isTransferIdempotent_basisDirectSum_of_isPhysicalBNTZCL_of_spectral_pair
     (hCF : IsBNTCanonicalForm P)
     (hspectral : ∀ j : Fin P.basisCount,

--- a/TNLean/MPS/RFP/ZCLReverse.lean
+++ b/TNLean/MPS/RFP/ZCLReverse.lean
@@ -54,32 +54,6 @@ private theorem sectorSingleSum_apply_same (j : Fin r)
     simp [hx]
   · simp
 
-private theorem sectorSingleSum_apply_left_ne (j k : Fin r) (hjk : j ≠ k)
-    (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
-    (a : Fin (dim k)) (v : Fin (∑ x, dim x)) :
-    (∑ x, ∑ y, Matrix.single (finSigmaFinEquiv ⟨j, x⟩)
-      (finSigmaFinEquiv ⟨j, y⟩) (R x y)) (finSigmaFinEquiv ⟨k, a⟩) v = 0 := by
-  classical
-  simp only [Matrix.sum_apply]
-  apply Finset.sum_eq_zero
-  intro x _
-  apply Finset.sum_eq_zero
-  intro y _
-  simp [hjk]
-
-private theorem sectorSingleSum_apply_right_ne (j k : Fin r) (hjk : j ≠ k)
-    (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
-    (u : Fin (∑ x, dim x)) (c : Fin (dim k)) :
-    (∑ x, ∑ y, Matrix.single (finSigmaFinEquiv ⟨j, x⟩)
-      (finSigmaFinEquiv ⟨j, y⟩) (R x y)) u (finSigmaFinEquiv ⟨k, c⟩) = 0 := by
-  classical
-  simp only [Matrix.sum_apply]
-  apply Finset.sum_eq_zero
-  intro x _
-  apply Finset.sum_eq_zero
-  intro y _
-  simp [hjk]
-
 /-- Inclusion of a matrix into one diagonal sector of a direct-sum bond space. -/
 noncomputable def directSumSectorInclusion (j : Fin r) :
     Matrix (Fin (dim j)) (Fin (dim j)) ℂ →ₗ[ℂ]
@@ -280,13 +254,12 @@ theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
     (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount)
     {ν : ℂ} {r l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ}
     (hν_ne : ν ≠ 0) (hν_norm : ‖ν‖ < 1)
-    (hr : Module.End.HasEigenvector (transferMap (P.basis j)) ν r)
+    (_hr : Module.End.HasEigenvector (transferMap (P.basis j)) ν r)
     (hl : Module.End.HasEigenvector
       (Matrix.traceAdjointMap (transferMap (P.basis j))) ν l)
     (hlr : Matrix.trace (l * r) = 1) :
     ¬ IsPositiveGapPhysicalCID (directSumTensor P.basis) := by
   classical
-  have _hr_ne : r ≠ 0 := hr.2
   letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
   let E := transferMap (P.basis j)
   have hCh : IsChannel E := by
@@ -315,7 +288,7 @@ theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
   intro hCID
   have hEq := hCID L L O₁ O₂ 1 2 2 1 hL_pos hL_pos
     (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
-  have hExpectation (n₁ n₂ : ℕ) (hn₂ : 0 < n₂) :
+  have hExpectation (n₁ n₂ : ℕ) :
       physicalTwoPointExpectation (directSumTensor P.basis) L L O₁ O₂ n₁ n₂ =
         ν ^ n₁ := by
     unfold physicalTwoPointExpectation
@@ -366,7 +339,7 @@ theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
       simp [smul_smul]
     rw [hcomp, map_smul, trace_directSumSectorRankOne, hlr]
     simp
-  rw [hExpectation 1 2 (by norm_num), hExpectation 2 1 (by norm_num),
+  rw [hExpectation 1 2, hExpectation 2 1,
     pow_one, pow_two] at hEq
   have hν_one : ν = 1 := by
     exact (mul_left_cancel₀ hν_ne (by simpa [mul_assoc] using hEq)).symm

--- a/TNLean/MPS/RFP/ZCLReverse.lean
+++ b/TNLean/MPS/RFP/ZCLReverse.lean
@@ -1,0 +1,444 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.StationarySupport
+import TNLean.MPS.RFP.NNCPHMultiSector
+import TNLean.MPS.RFP.PhysicalObservableRealization
+
+/-!
+# Conditional converse from zero correlation length to a renormalization fixed point
+
+This file formalizes the multiplicity-one correlation contradiction in the proof of
+arXiv:1606.00608, Theorem 3.8, lines 1250--1268. The converse is conditional on the
+spectral assertion made at line 1250: every non-idempotent normal block has a nonzero
+subleading eigenvalue with normalized left and right eigenvectors.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+
+section SectorMaps
+
+variable (dim)
+
+/-- Compression of a matrix on a direct-sum bond space to one diagonal sector. -/
+noncomputable def directSumSectorCompression (j : Fin r) :
+    Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ →ₗ[ℂ]
+      Matrix (Fin (dim j)) (Fin (dim j)) ℂ where
+  toFun X := X.submatrix
+    (fun a ↦ finSigmaFinEquiv ⟨j, a⟩) (fun a ↦ finSigmaFinEquiv ⟨j, a⟩)
+  map_add' X Y := by ext a b; simp
+  map_smul' c X := by ext a b; simp
+
+private theorem sectorSingleSum_apply_same (j : Fin r)
+    (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) (a c : Fin (dim j)) :
+    (∑ x, ∑ y, Matrix.single (finSigmaFinEquiv ⟨j, x⟩)
+      (finSigmaFinEquiv ⟨j, y⟩) (R x y))
+        (finSigmaFinEquiv ⟨j, a⟩) (finSigmaFinEquiv ⟨j, c⟩) = R a c := by
+  classical
+  simp only [Matrix.sum_apply]
+  rw [Finset.sum_eq_single a]
+  · rw [Finset.sum_eq_single c]
+    · simp
+    · intro y _ hy
+      simp [hy]
+    · simp
+  · intro x _ hx
+    apply Finset.sum_eq_zero
+    intro y _
+    simp [hx]
+  · simp
+
+private theorem sectorSingleSum_apply_left_ne (j k : Fin r) (hjk : j ≠ k)
+    (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (a : Fin (dim k)) (v : Fin (∑ x, dim x)) :
+    (∑ x, ∑ y, Matrix.single (finSigmaFinEquiv ⟨j, x⟩)
+      (finSigmaFinEquiv ⟨j, y⟩) (R x y)) (finSigmaFinEquiv ⟨k, a⟩) v = 0 := by
+  classical
+  simp only [Matrix.sum_apply]
+  apply Finset.sum_eq_zero
+  intro x _
+  apply Finset.sum_eq_zero
+  intro y _
+  simp [hjk]
+
+private theorem sectorSingleSum_apply_right_ne (j k : Fin r) (hjk : j ≠ k)
+    (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (u : Fin (∑ x, dim x)) (c : Fin (dim k)) :
+    (∑ x, ∑ y, Matrix.single (finSigmaFinEquiv ⟨j, x⟩)
+      (finSigmaFinEquiv ⟨j, y⟩) (R x y)) u (finSigmaFinEquiv ⟨k, c⟩) = 0 := by
+  classical
+  simp only [Matrix.sum_apply]
+  apply Finset.sum_eq_zero
+  intro x _
+  apply Finset.sum_eq_zero
+  intro y _
+  simp [hjk]
+
+/-- Inclusion of a matrix into one diagonal sector of a direct-sum bond space. -/
+noncomputable def directSumSectorInclusion (j : Fin r) :
+    Matrix (Fin (dim j)) (Fin (dim j)) ℂ →ₗ[ℂ]
+      Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ :=
+  Matrix.traceAdjointMap (directSumSectorCompression dim j)
+
+/-- Entrywise formula for inclusion into one diagonal sector. -/
+theorem directSumSectorInclusion_eq_sum (j : Fin r)
+    (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
+    directSumSectorInclusion dim j R = ∑ a, ∑ c,
+      Matrix.single (finSigmaFinEquiv ⟨j, a⟩) (finSigmaFinEquiv ⟨j, c⟩) (R a c) := by
+  classical
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro X
+  change Matrix.trace
+    (Matrix.traceAdjointMap (directSumSectorCompression dim j) R * X) = _
+  rw [Matrix.trace_traceAdjointMap_mul]
+  simp only [Matrix.sum_mul, Matrix.trace_sum, Matrix.trace_single_mul]
+  simp [directSumSectorCompression, Matrix.trace, Matrix.diag, Matrix.mul_apply]
+
+
+@[simp] theorem directSumSectorCompression_inclusion (j : Fin r)
+    (R : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
+    directSumSectorCompression dim j (directSumSectorInclusion dim j R) = R := by
+  rw [directSumSectorInclusion_eq_sum]
+  ext a c
+  exact sectorSingleSum_apply_same (dim := dim) j R a c
+
+/-- A sector-supported rank-one map sends `X` to
+`trace (l * X_jj) • R`, included in sector `j`. -/
+noncomputable def directSumSectorRankOne (j : Fin r)
+    (R l : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
+    Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ →ₗ[ℂ]
+      Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ :=
+  (((Matrix.traceLinearMap (Fin (dim j)) ℂ ℂ).comp
+      (LinearMap.mulLeft ℂ l)).comp (directSumSectorCompression dim j)).smulRight
+    (directSumSectorInclusion dim j R)
+
+/-- The matrix-entry formula produced by simultaneous block injectivity is the
+sector-supported rank-one map. -/
+theorem directSumSectorRankOne_apply (j : Fin r)
+    (R l : Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (X : Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ) :
+    directSumSectorRankOne dim j R l X =
+      ∑ z : Fin (dim j) × Fin (dim j) × Fin (dim j) × Fin (dim j),
+        (R z.1 z.2.2.1 * l z.2.2.2 z.2.1) • Matrix.single
+          (finSigmaFinEquiv ⟨j, z.1⟩)
+          (finSigmaFinEquiv ⟨j, z.2.2.1⟩)
+          (X (finSigmaFinEquiv ⟨j, z.2.1⟩)
+            (finSigmaFinEquiv ⟨j, z.2.2.2⟩)) := by
+  classical
+  change Matrix.trace (l * directSumSectorCompression dim j X) •
+      directSumSectorInclusion dim j R = _
+  have htrace : Matrix.trace (l * directSumSectorCompression dim j X) =
+      ∑ e, ∑ b, l e b * X (finSigmaFinEquiv ⟨j, b⟩)
+        (finSigmaFinEquiv ⟨j, e⟩) := by
+    rfl
+  rw [htrace, directSumSectorInclusion_eq_sum]
+  conv_rhs =>
+    rw [Fintype.sum_prod_type]
+    enter [2, a]
+    rw [Fintype.sum_prod_type]
+    enter [2, b]
+    rw [Fintype.sum_prod_type]
+  ext u v
+  rw [← finSigmaFinEquiv.apply_symm_apply u, ← finSigmaFinEquiv.apply_symm_apply v]
+  obtain ⟨k, a⟩ := finSigmaFinEquiv.symm u
+  obtain ⟨k', c⟩ := finSigmaFinEquiv.symm v
+  by_cases hk : k = j
+  · subst k
+    by_cases hk' : k' = j
+    · subst k'
+      simp only [Matrix.smul_apply, smul_eq_mul]
+      rw [sectorSingleSum_apply_same (dim := dim)]
+      simp only [Matrix.smul_single, smul_eq_mul, Matrix.sum_apply,
+        Matrix.single_apply, Equiv.apply_eq_iff_eq, Sigma.mk.injEq, heq_iff_eq]
+      simp only [ite_and, Finset.sum_ite_irrel, Finset.sum_ite_eq',
+        Finset.mem_univ, if_true, Finset.sum_const_zero]
+      calc
+        (∑ e, ∑ b, l e b * X (finSigmaFinEquiv ⟨j, b⟩)
+            (finSigmaFinEquiv ⟨j, e⟩)) * R a c =
+            ∑ e, ∑ b, (l e b * X (finSigmaFinEquiv ⟨j, b⟩)
+              (finSigmaFinEquiv ⟨j, e⟩)) * R a c := by
+                rw [Finset.sum_mul]
+                apply Finset.sum_congr rfl
+                intro e _
+                rw [Finset.sum_mul]
+        _ = ∑ b, ∑ e, (l e b * X (finSigmaFinEquiv ⟨j, b⟩)
+              (finSigmaFinEquiv ⟨j, e⟩)) * R a c := Finset.sum_comm
+        _ = ∑ b, ∑ e, R a c * l e b * X (finSigmaFinEquiv ⟨j, b⟩)
+              (finSigmaFinEquiv ⟨j, e⟩) := by
+                apply Finset.sum_congr rfl
+                intro b _
+                apply Finset.sum_congr rfl
+                intro e _
+                ring
+    · simp [Matrix.sum_apply, Sigma.mk.injEq, Ne.symm hk']
+  · simp [Matrix.sum_apply, Sigma.mk.injEq, Ne.symm hk]
+
+
+
+@[simp] theorem directSumSectorCompression_reindex
+    (j : Fin r)
+    (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
+    directSumSectorCompression dim j
+        (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv Y) =
+      Y.submatrix (blockIncl j dim) (blockIncl j dim) := by
+  ext a b
+  simp [directSumSectorCompression, blockIncl, Matrix.reindex_apply]
+
+/-- Compression to a diagonal sector intertwines the direct-sum transfer map
+with the transfer map of that sector. -/
+theorem directSumSectorCompression_transferMap
+    (B : (k : Fin r) → MPSTensor d (dim k)) (j : Fin r)
+    (X : Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ) :
+    directSumSectorCompression dim j (transferMap (directSumTensor B) X) =
+      transferMap (B j) (directSumSectorCompression dim j X) := by
+  classical
+  let e := finSigmaFinEquiv (m := r) (n := dim)
+  let Y := Matrix.reindex e.symm e.symm X
+  have hXY : Matrix.reindex e e Y = X := by
+    ext u v
+    simp [Y, e, Matrix.reindex_apply]
+  have hblock := blockDiagonal'_transferSum_toBlock B Y j j
+  calc
+    directSumSectorCompression dim j (transferMap (directSumTensor B) X) =
+        directSumSectorCompression dim j
+          (transferMap (directSumTensor B) (Matrix.reindex e e Y)) := by rw [hXY]
+    _ = directSumSectorCompression dim j
+          (Matrix.reindex e e (blockTransferSum B Y)) := by
+            rw [transferMap_directSumTensor_reindex]
+    _ = transferMap (B j)
+          (Y.submatrix (blockIncl j dim) (blockIncl j dim)) := by
+            rw [directSumSectorCompression_reindex]
+            simpa only [blockTransferSum, mixedTransferMap₂_self] using hblock
+    _ = transferMap (B j) (directSumSectorCompression dim j X) := by
+            apply congrArg (transferMap (B j))
+            ext a b
+            simp [directSumSectorCompression, blockIncl, Y, e, Matrix.reindex_apply]
+
+/-- Compression to one sector intertwines every power of the two transfer maps. -/
+theorem directSumSectorCompression_transferMap_pow
+    (B : (k : Fin r) → MPSTensor d (dim k)) (j : Fin r) (n : ℕ)
+    (X : Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ) :
+    directSumSectorCompression dim j (((transferMap (directSumTensor B)) ^ n) X) =
+      ((transferMap (B j)) ^ n) (directSumSectorCompression dim j X) := by
+  induction n generalizing X with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, pow_succ, Module.End.mul_apply, Module.End.mul_apply,
+        ih, directSumSectorCompression_transferMap]
+
+/-- The operator trace of a sector-supported rank-one map is the matrix trace
+of the product of its two defining matrices. -/
+theorem trace_directSumSectorRankOne (j : Fin r)
+    (R l : Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
+    LinearMap.trace ℂ (Matrix (Fin (∑ k, dim k)) (Fin (∑ k, dim k)) ℂ)
+      (directSumSectorRankOne dim j R l) = Matrix.trace (l * R) := by
+  rw [directSumSectorRankOne, LinearMap.trace_smulRight,
+    LinearMap.comp_apply, LinearMap.comp_apply,
+    directSumSectorCompression_inclusion, LinearMap.mulLeft_apply,
+    Matrix.traceLinearMap_apply]
+
+end SectorMaps
+
+section Eigenvectors
+
+/-- A left eigenvector for the trace-pairing adjoint evaluates a power of the
+original map by the corresponding eigenvalue power. -/
+theorem trace_mul_pow_apply_of_traceAdjointMap_hasEigenvector
+    {D : ℕ} (E : Module.End ℂ (Matrix (Fin D) (Fin D) ℂ))
+    {ν : ℂ} {l : Matrix (Fin D) (Fin D) ℂ}
+    (hl : Module.End.HasEigenvector (Matrix.traceAdjointMap E) ν l)
+    (n : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (l * (E ^ n) X) = ν ^ n * Matrix.trace (l * X) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ', Module.End.mul_apply, ← Matrix.trace_traceAdjointMap_mul,
+        hl.apply_eq_smul, Matrix.smul_mul, Matrix.trace_smul, ih,
+        pow_succ]
+      ring
+
+end Eigenvectors
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- The literal two-point calculation in arXiv:1606.00608, lines 1250--1268:
+a selected block with a nonzero subleading left/right eigenvector pair is
+incompatible with positive-gap physical correlation independence.
+
+The right eigenvector is retained because the source argument assumes the full
+normalized pair. The displayed orientation of the two observables uses the left
+eigenvector equation. -/
+theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
+    (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount)
+    {ν : ℂ} {r l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ}
+    (hν_ne : ν ≠ 0) (hν_norm : ‖ν‖ < 1)
+    (hr : Module.End.HasEigenvector (transferMap (P.basis j)) ν r)
+    (hl : Module.End.HasEigenvector
+      (Matrix.traceAdjointMap (transferMap (P.basis j))) ν l)
+    (hlr : Matrix.trace (l * r) = 1) :
+    ¬ IsPositiveGapPhysicalCID (directSumTensor P.basis) := by
+  classical
+  have _hr_ne : r ≠ 0 := hr.2
+  letI : NeZero (P.basisDim j) := ⟨(hCF.basis_dim_pos j).ne'⟩
+  let E := transferMap (P.basis j)
+  have hCh : IsChannel E := by
+    exact transferMap_isChannel (P.basis j) (hCF.basis_left_canonical j)
+  have hIrr : IsIrreducibleMap E :=
+    isIrreducibleCP_transferMap_of_isIrreducibleTensor
+      (P.basis j) (hCF.basis_irreducible j)
+  let ρ := Channel.stationaryState E hCh hIrr (hCF.basis_dim_pos j)
+  have hρ := Channel.stationaryState_spec hCh hIrr (hCF.basis_dim_pos j)
+  have hρ_trace : Matrix.trace ρ = 1 := hρ.1.2
+  have hρ_fixed : E ρ = ρ := hρ.2.2
+  obtain ⟨L, hL_pos, _, hObs⟩ :=
+    hCF.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five
+  obtain ⟨O₁, hO₁⟩ := hObs j ρ l
+  obtain ⟨O₂, hO₂⟩ := hObs j r 1
+  have hO₁_map : physicalObservableTransfer (directSumTensor P.basis) L O₁ =
+      directSumSectorRankOne P.basisDim j ρ l := by
+    apply LinearMap.ext
+    intro X
+    rw [hO₁ X, directSumSectorRankOne_apply]
+  have hO₂_map : physicalObservableTransfer (directSumTensor P.basis) L O₂ =
+      directSumSectorRankOne P.basisDim j r 1 := by
+    apply LinearMap.ext
+    intro X
+    rw [hO₂ X, directSumSectorRankOne_apply]
+  intro hCID
+  have hEq := hCID L L O₁ O₂ 1 2 2 1 hL_pos hL_pos
+    (by norm_num) (by norm_num) (by norm_num) (by norm_num) (by norm_num)
+  have hExpectation (n₁ n₂ : ℕ) (hn₂ : 0 < n₂) :
+      physicalTwoPointExpectation (directSumTensor P.basis) L L O₁ O₂ n₁ n₂ =
+        ν ^ n₁ := by
+    unfold physicalTwoPointExpectation
+    rw [hO₁_map, hO₂_map]
+    have hcomp : directSumSectorRankOne P.basisDim j r 1 ∘ₗ
+          ((transferMap (directSumTensor P.basis)) ^ n₂) ∘ₗ
+          directSumSectorRankOne P.basisDim j ρ l ∘ₗ
+          ((transferMap (directSumTensor P.basis)) ^ n₁) =
+        (ν ^ n₁) • directSumSectorRankOne P.basisDim j r l := by
+      apply LinearMap.ext
+      intro X
+      let c := Matrix.trace (l * directSumSectorCompression P.basisDim j
+        (((transferMap (directSumTensor P.basis)) ^ n₁) X))
+      have hc : c = ν ^ n₁ * Matrix.trace
+          (l * directSumSectorCompression P.basisDim j X) := by
+        change Matrix.trace (l * directSumSectorCompression P.basisDim j
+          (((transferMap (directSumTensor P.basis)) ^ n₁) X)) = _
+        rw [show directSumSectorCompression P.basisDim j
+            (((transferMap (directSumTensor P.basis)) ^ n₁) X) =
+          (E ^ n₁) (directSumSectorCompression P.basisDim j X) from
+            directSumSectorCompression_transferMap_pow (dim := P.basisDim)
+              (B := P.basis) (j := j) n₁ X]
+        exact trace_mul_pow_apply_of_traceAdjointMap_hasEigenvector E hl n₁ _
+      have hρ_pow_all : ∀ n : ℕ, (E ^ n) ρ = ρ := by
+        intro n
+        induction n with
+        | zero => simp
+        | succ n ih => rw [pow_succ', Module.End.mul_apply, ih, hρ_fixed]
+      have hρ_pow : (E ^ n₂) ρ = ρ := hρ_pow_all n₂
+      have hmid : directSumSectorCompression P.basisDim j
+          (((transferMap (directSumTensor P.basis)) ^ n₂)
+            (c • directSumSectorInclusion P.basisDim j ρ)) = c • ρ := by
+        calc
+          _ = (E ^ n₂) (directSumSectorCompression P.basisDim j
+                (c • directSumSectorInclusion P.basisDim j ρ)) :=
+            directSumSectorCompression_transferMap_pow (dim := P.basisDim)
+              (B := P.basis) (j := j) n₂ _
+          _ = (E ^ n₂) (c • ρ) := by rw [map_smul, directSumSectorCompression_inclusion]
+          _ = c • (E ^ n₂) ρ := by rw [map_smul]
+          _ = c • ρ := by rw [hρ_pow]
+      change Matrix.trace (1 * directSumSectorCompression P.basisDim j
+          (((transferMap (directSumTensor P.basis)) ^ n₂)
+            (c • directSumSectorInclusion P.basisDim j ρ))) •
+          directSumSectorInclusion P.basisDim j r =
+        ν ^ n₁ • (Matrix.trace (l * directSumSectorCompression P.basisDim j X) •
+          directSumSectorInclusion P.basisDim j r)
+      rw [hmid, Matrix.one_mul, Matrix.trace_smul, hρ_trace, hc]
+      simp [smul_smul]
+    rw [hcomp, map_smul, trace_directSumSectorRankOne, hlr]
+    simp
+  rw [hExpectation 1 2 (by norm_num), hExpectation 2 1 (by norm_num),
+    pow_one, pow_two] at hEq
+  have hν_one : ν = 1 := by
+    exact (mul_left_cancel₀ hν_ne (by simpa [mul_assoc] using hEq)).symm
+  rw [hν_one, norm_one] at hν_norm
+  exact (lt_irrefl 1 hν_norm)
+
+/-- Conditional reverse implication at the multiplicity-one representative.
+The additional hypothesis is precisely the spectral assertion invoked at
+arXiv:1606.00608, line 1250 for a non-idempotent normal block. -/
+theorem isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair
+    (hCF : IsBNTCanonicalForm P)
+    (hspectral : ∀ j : Fin P.basisCount,
+      ¬ IsTransferIdempotent (P.basis j) →
+        ∃ (ν : ℂ) (r l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ),
+          ν ≠ 0 ∧ ‖ν‖ < 1 ∧
+          Module.End.HasEigenvector (transferMap (P.basis j)) ν r ∧
+          Module.End.HasEigenvector
+            (Matrix.traceAdjointMap (transferMap (P.basis j))) ν l ∧
+          Matrix.trace (l * r) = 1)
+    (hZCL : IsPositiveGapBNTZCL (directSumTensor P.basis) P.basis) :
+    IsTransferIdempotent (directSumTensor P.basis) := by
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  apply (isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem
+    P.basis).2
+  intro j j'
+  by_cases hEq : j = j'
+  · subst j'
+    rw [mixedTransferMap₂_self]
+    by_contra hnot
+    obtain ⟨ν, r, l, hν_ne, hν_norm, hr, hl, hlr⟩ := hspectral j hnot
+    exact hCF.not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
+      j hν_ne hν_norm hr hl hlr hZCL.2.1
+  · rw [hZCL.2.2 j j' hEq]
+    exact IsIdempotentElem.zero
+
+/-- Conditional equivalence between positive-gap BNT zero correlation length
+and transfer idempotence for the multiplicity-one representative. -/
+theorem isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent_of_spectral_pair
+    (hCF : IsBNTCanonicalForm P)
+    (hspectral : ∀ j : Fin P.basisCount,
+      ¬ IsTransferIdempotent (P.basis j) →
+        ∃ (ν : ℂ) (r l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ),
+          ν ≠ 0 ∧ ‖ν‖ < 1 ∧
+          Module.End.HasEigenvector (transferMap (P.basis j)) ν r ∧
+          Module.End.HasEigenvector
+            (Matrix.traceAdjointMap (transferMap (P.basis j))) ν l ∧
+          Matrix.trace (l * r) = 1) :
+    IsPositiveGapBNTZCL (directSumTensor P.basis) P.basis ↔
+      IsTransferIdempotent (directSumTensor P.basis) := by
+  constructor
+  · exact hCF.isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair
+      hspectral
+  · exact hCF.isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL
+
+/-- Source physical BNT zero correlation length implies transfer idempotence at
+the multiplicity-one representative under the line-1250 spectral assertion. -/
+theorem isTransferIdempotent_basisDirectSum_of_isPhysicalBNTZCL_of_spectral_pair
+    (hCF : IsBNTCanonicalForm P)
+    (hspectral : ∀ j : Fin P.basisCount,
+      ¬ IsTransferIdempotent (P.basis j) →
+        ∃ (ν : ℂ) (r l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ),
+          ν ≠ 0 ∧ ‖ν‖ < 1 ∧
+          Module.End.HasEigenvector (transferMap (P.basis j)) ν r ∧
+          Module.End.HasEigenvector
+            (Matrix.traceAdjointMap (transferMap (P.basis j))) ν l ∧
+          Matrix.trace (l * r) = 1)
+    (hZCL : IsPhysicalBNTZCL (directSumTensor P.basis) P.basis) :
+    IsTransferIdempotent (directSumTensor P.basis) :=
+  hCF.isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair
+    hspectral (isPositiveGapBNTZCL_of_isPhysicalBNTZCL _ _ hZCL)
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/RFP/ZCLReverse.lean
+++ b/TNLean/MPS/RFP/ZCLReverse.lean
@@ -246,7 +246,13 @@ incompatible with positive-gap physical correlation independence.
 
 The right eigenvector is retained because the source argument assumes the full
 normalized pair. The displayed orientation of the two observables uses the left
-eigenvector equation. -/
+eigenvector equation.
+
+**Scope restriction (arXiv:1606.00608, Theorem `TheoremZCLPure`, lines
+1248--1268):** the conclusion negates `IsPositiveGapPhysicalCID`, rather than
+the source's unrestricted physical CID, and the spectral package is an explicit
+premise. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair
     (hCF : IsBNTCanonicalForm P) (j : Fin P.basisCount)
     {ν : ℂ} {r l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ}

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -379,6 +379,53 @@
     Theorem~\ref{thm:bnt_sector_supported_physical_observable} at this length.
 \end{proof}
 
+\begin{lemma}[Sector compression calculus for the direct sum]%
+    \label{lem:zcl_direct_sum_sector_calculus}
+    \lean{MPSTensor.directSumSectorCompression}
+    \lean{MPSTensor.directSumSectorInclusion}
+    \lean{MPSTensor.directSumSectorInclusion_eq_sum}
+    \lean{MPSTensor.directSumSectorCompression_inclusion}
+    \lean{MPSTensor.directSumSectorRankOne}
+    \lean{MPSTensor.directSumSectorRankOne_apply}
+    \lean{MPSTensor.directSumSectorCompression_reindex}
+    \lean{MPSTensor.directSumSectorCompression_transferMap}
+    \lean{MPSTensor.directSumSectorCompression_transferMap_pow}
+    \lean{MPSTensor.trace_directSumSectorRankOne}
+    \lean{MPSTensor.trace_mul_pow_apply_of_traceAdjointMap_hasEigenvector}
+    \leanok
+    \uses{def:transfer_map}
+    Let $A=\bigoplus_k A_k$. Denote compression to the $(j,j)$ bond block by
+    $C_j$ and its trace-pairing adjoint by $I_j$. Then
+    \begin{align}
+        C_jI_j&=\id.
+        \notag
+    \end{align}
+    If $\E_A$ and $\E_j$ are the transfer maps of $A$ and $A_j$, respectively,
+    then, for every $n\geq0$,
+    \begin{align}
+        C_j\E_A^n&=\E_j^nC_j.
+        \notag
+    \end{align}
+    The sector-supported rank-one map
+    $\mathcal R_{j;R,l}(X)=I_j(R)\tr(lC_j(X))$ has operator trace
+    \begin{align}
+        \Tr_{\End}(\mathcal R_{j;R,l})&=\tr(lR).
+        \notag
+    \end{align}
+    Finally, if $\E_j^*(l)=\lambda l$, then
+    \begin{align}
+        \tr\!\bigl(l\E_j^n(X)\bigr)&=\lambda^n\tr(lX).
+        \notag
+    \end{align}
+\end{lemma}
+\begin{proof}\leanok
+    The inclusion is the trace-pairing adjoint of compression; expanding it in
+    matrix units gives $C_jI_j=\id$ and the rank-one trace formula. The
+    block-diagonal form of $A$ gives $C_j\E_A=\E_jC_j$, and induction gives the
+    identity for every power. Moving one factor of $\E_j$ across the trace
+    pairing and iterating proves the eigenvector formula.
+\end{proof}
+
 \begin{theorem}[Subleading spectral pair excludes positive-gap CID]%
     \label{thm:zcl_subleading_pair_excludes_cid}
     \lean{MPSTensor.IsBNTCanonicalForm.not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair}
@@ -396,7 +443,8 @@
     Then $A$ does not have positive-gap physical CID.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:bnt_rank_one_observables_sharp_length}
+    \uses{lem:zcl_direct_sum_sector_calculus,
+        thm:bnt_rank_one_observables_sharp_length}
     Let $\rho_j$ be the trace-one positive fixed point of $\E_j$. At the
     common blocking length, choose physical observables with inserted transfer
     maps

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -379,6 +379,104 @@
     Theorem~\ref{thm:bnt_sector_supported_physical_observable} at this length.
 \end{proof}
 
+\begin{theorem}[Subleading spectral pair excludes positive-gap CID]%
+    \label{thm:zcl_subleading_pair_excludes_cid}
+    \lean{MPSTensor.IsBNTCanonicalForm.not_isPositiveGapPhysicalCID_basisDirectSum_of_basis_spectral_pair}
+    \leanok
+    \uses{def:is_positive_gap_physical_cid, def:sector_bnt_cf,
+        thm:bnt_rank_one_observables_sharp_length}
+    Let $P$ be a BNT canonical form, let $A=\bigoplus_k A_k$, and fix a
+    sector $j$. Suppose there are matrices $r,l\in\MN{D_j}$ and a scalar
+    $\lambda\ne0$ with $|\lambda|<1$ such that
+    \begin{align}
+        \bigl(\E_j(r),\E_j^*(l),\tr(lr)\bigr)
+        &=\bigl(\lambda r,\lambda l,1\bigr).
+        \notag
+    \end{align}
+    Then $A$ does not have positive-gap physical CID.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:bnt_rank_one_observables_sharp_length}
+    Let $\rho_j$ be the trace-one positive fixed point of $\E_j$. At the
+    common blocking length, choose physical observables with inserted transfer
+    maps
+    \begin{align}
+        \bigl(\E_{O_1}(X),\E_{O_2}(X)\bigr)
+        &=\bigl(\rho_j\tr(lX_{j,j}),r\tr(X_{j,j})\bigr).
+        \notag
+    \end{align}
+    The left eigenvector equation, together with
+    $\E_j(\rho_j)=\rho_j$, $\tr(\rho_j)=1$, and $\tr(lr)=1$, gives
+    \begin{align}
+        \langle O_1 O_2\rangle_{n_1,n_2}&=\lambda^{n_1}.
+        \notag
+    \end{align}
+    Positive-gap CID compares $(n_1,n_2)=(1,2)$ with $(2,1)$, so
+    $\lambda=\lambda^2$. Since $\lambda\ne0$, this forces $\lambda=1$,
+    contrary to $|\lambda|<1$.
+\end{proof}
+
+\begin{theorem}[Conditional converse and equivalence at the multiplicity-one representative]%
+    \label{thm:positive_gap_bnt_zcl_conditional_converse}
+    \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair}
+    \lean{MPSTensor.IsBNTCanonicalForm.isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent_of_spectral_pair}
+    \leanok
+    \uses{def:is_positive_gap_bnt_zcl, def:mps_transfer_idempotence,
+        def:sector_bnt_cf}
+    Let $P$ be a BNT canonical form and $A=\bigoplus_j A_j$. Assume that every
+    non-idempotent block $\E_j^2\ne\E_j$ has matrices $r_j,l_j$ and a scalar
+    $\lambda_j$ satisfying the five spectral conditions in
+    Theorem~\ref{thm:zcl_subleading_pair_excludes_cid}. Then
+    \begin{align}
+        A\text{ has positive-gap BNT ZCL}
+        &\Longleftrightarrow \E_A^2=\E_A.
+        \notag
+    \end{align}
+    % CPSV16 local source line 1250.
+    The extra spectral assumption is the assertion used in the proof of
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}; it is not a consequence
+    of non-idempotence for a general linear operator.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:zcl_subleading_pair_excludes_cid,
+        thm:direct_sum_transfer_idempotent_iff_pairwise_mixed,
+        thm:rfp_implies_positive_gap_bnt_zcl_cf_basis_direct_sum}
+    If some $\E_j$ were not idempotent, its assumed spectral pair would
+    contradict physical CID by
+    Theorem~\ref{thm:zcl_subleading_pair_excludes_cid}. Thus every diagonal
+    mixed transfer map is idempotent. Local orthogonality makes every
+    off-diagonal mixed transfer map zero, so
+    Theorem~\ref{thm:direct_sum_transfer_idempotent_iff_pairwise_mixed} gives
+    $\E_A^2=\E_A$. The reverse implication is
+    Theorem~\ref{thm:rfp_implies_positive_gap_bnt_zcl_cf_basis_direct_sum}.
+\end{proof}
+
+\begin{theorem}[Source physical ZCL implies idempotence under the spectral assumption]%
+    \label{thm:physical_bnt_zcl_conditional_converse}
+    \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_of_isPhysicalBNTZCL_of_spectral_pair}
+    \leanok
+    \uses{def:mps_transfer_idempotence, def:sector_bnt_cf}
+    Under the assumptions of
+    Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse}, source
+    physical BNT zero correlation length for $A=\bigoplus_j A_j$ implies
+    $\E_A^2=\E_A$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:positive_gap_bnt_zcl_conditional_converse}
+    Source physical CID includes all positive-gap configurations. Apply the
+    forward implication in
+    Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse}.
+\end{proof}
+
+\begin{theorem}[Unconditional reverse implication at the multiplicity-one representative]%
+    \label{thm:positive_gap_bnt_zcl_unconditional_converse}
+    \notready
+    \uses{def:is_positive_gap_bnt_zcl, def:mps_transfer_idempotence,
+        def:sector_bnt_cf}
+    Let $P$ be a BNT canonical form and $A=\bigoplus_j A_j$. If $A$ has
+    positive-gap BNT zero correlation length, then $\E_A^2=\E_A$.
+\end{theorem}
+
 \begin{remark}[Remaining obstructions in the printed converse]
     For the multiplicity-one unit-weight representative, the sector-supported
     observables require no additional hypothesis. The full canonical-form

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -486,7 +486,7 @@
 \begin{proof}\leanok
     \uses{thm:zcl_subleading_pair_excludes_cid,
         thm:direct_sum_transfer_idempotent_iff_pairwise_mixed,
-        thm:rfp_implies_positive_gap_bnt_zcl_cf_basis_direct_sum}
+        thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}
     If some $\E_j$ were not idempotent, its assumed spectral pair would
     contradict physical CID by
     Theorem~\ref{thm:zcl_subleading_pair_excludes_cid}. Thus every diagonal
@@ -494,7 +494,7 @@
     off-diagonal mixed transfer map zero, so
     Theorem~\ref{thm:direct_sum_transfer_idempotent_iff_pairwise_mixed} gives
     $\E_A^2=\E_A$. The reverse implication is
-    Theorem~\ref{thm:rfp_implies_positive_gap_bnt_zcl_cf_basis_direct_sum}.
+    Theorem~\ref{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}.
 \end{proof}
 
 \begin{theorem}[Source physical ZCL implies idempotence under the spectral assumption]%
@@ -508,7 +508,8 @@
     $\E_A^2=\E_A$.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:positive_gap_bnt_zcl_conditional_converse}
+    \uses{thm:positive_gap_bnt_zcl_conditional_converse,
+        lem:is_positive_gap_bnt_zcl_of_source_bnt_zcl}
     Source physical CID includes all positive-gap configurations. Apply the
     forward implication in
     Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse}.

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -387,11 +387,9 @@
     \lean{MPSTensor.directSumSectorCompression_inclusion}
     \lean{MPSTensor.directSumSectorRankOne}
     \lean{MPSTensor.directSumSectorRankOne_apply}
-    \lean{MPSTensor.directSumSectorCompression_reindex}
     \lean{MPSTensor.directSumSectorCompression_transferMap}
     \lean{MPSTensor.directSumSectorCompression_transferMap_pow}
     \lean{MPSTensor.trace_directSumSectorRankOne}
-    \lean{MPSTensor.trace_mul_pow_apply_of_traceAdjointMap_hasEigenvector}
     \leanok
     \uses{def:transfer_map}
     Let $A=\bigoplus_k A_k$. Denote compression to the $(j,j)$ bond block by


### PR DESCRIPTION
## Motivation

CPSV16 lines 1250–1268 prove the reverse ZCL-to-RFP implication by assuming that every non-idempotent normal-sector transfer map supplies a normalized nonzero subleading left/right eigenpair. The unconditional inference is false in the presence of a nilpotent Jordan component at eigenvalue zero, but the source's conditional physical-observable argument can now be formalized using the sector-supported observables from #4852.

## Description

- adds direct-sum sector compression, inclusion, rank-one-map, transfer-power, and operator-trace calculus
- proves that positive-gap physical CID excludes the exact CPSV16 spectral package
  \(\lambda\ne0\), \(|\lambda|<1\), matched left/right eigenvectors, and \(\operatorname{tr}(lr)=1\)
- evaluates the physical two-point function as \(\lambda^{n_1}\) and compares gaps \((1,2)\) and \((2,1)\) to obtain the contradiction \(\lambda=\lambda^2\)
- proves the conditional positive-gap BNT ZCL converse, conditional biconditional, and source-physical-ZCL corollary for the multiplicity-one unit-weight direct sum
- updates Chapter 26 while keeping the unconditional converse visibly `\notready` and documenting the line-1250 Jordan obstruction

This does not claim the unconditional reverse implication and does not cover the raw weighted repeated-copy tensor.

## Testing

- `lake build TNLean.MPS.RFP.ZCLReverse` — 8936 jobs
- `lake build` — 9744 jobs
- declaration lint — 13 declarations, 14 linters, 0 errors
- generated import aggregators — 46 files / 1039 production modules, current
- blueprint sync and declaration checks — Chapter 26 41/41
- double LuaLaTeX — 717 pages, 0 undefined cross-references
- prose/style, module-policy, `sorry`/axiom, and `git diff --check` gates

Advances #4786 and #2633.

Authored with an AI agent under maintainer direction; the source-faithfulness, Lean, blueprint, and full-build gates were independently reviewed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in core MPS/RFP transfer/ZCL theory; scope is explicitly conditional and multiplicity-one, but errors could affect downstream theorem statements and blueprint linkage.
> 
> **Overview**
> Formalizes the **conditional** CPSV16 reverse implication (ZCL ⇒ transfer idempotence) for the multiplicity-one unit-weight direct sum \(\bigoplus_j A_j\), assuming the line-1250 spectral package on non-idempotent blocks—not the unconditional converse.
> 
> **Refactor:** `toTensorFromBlocks_one_eq_directSumTensor` and `isCPSVBasisOfNormalTensors_basisDirectSum` move from `NNCPHMultiSector.lean` into new **`BNTDirectSumBasis.lean`**; the RFP aggregator imports that module and **`ZCLReverse`**.
> 
> **New `ZCLReverse.lean`:** direct-sum sector compression/inclusion, rank-one physical maps, and identities intertwining \(\mathcal E_A^n\) with block transfer powers; a two-point calculation shows a normalized subleading eigenpair with \(|\lambda|<1\) contradicts positive-gap physical CID; under an explicit spectral hypothesis, positive-gap BNT ZCL implies \(\mathcal E_A^2=\mathcal E_A\) (biconditional and source-physical-ZCL corollary).
> 
> **Blueprint (Ch. 26):** matching sector-calculus lemma, spectral-pair obstruction, conditional converse/equivalence, and a **`\notready`** unconditional converse with the Jordan/nilpotent obstruction noted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e573e3b797bd34ed7e65895c8079fb774f8b2ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->