### PR TITLE
fix(tests/tenkz/rmp): redraw the structured-grid figures against the source panels

### DIFF
--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-region.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-region.tex
@@ -8,7 +8,7 @@
 % Capabilities: grid, lattice, regions, typed-ports
 \[
   \begin{tenkzlattice}[rows=5, cols=6, frame=oblique,
-                       physical=up, outer legs=both]
+                       physical=up, boundary=open]
     \tnregion[label=$R$, label pos=center]{(2-4,2-5)}
   \end{tenkzlattice}
   \;=\;

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-state.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-boundary-state.tex
@@ -6,14 +6,17 @@
 % Source: paper TN-Review-main.tex line 807; author source ImagesReview Section
 %   II/ImagesReview Section II.tex lines 650-684
 % Capabilities: grid, typed-ports
+%
+% west=none seals the west side on its own; boundary=none silently
+% outranked the east cup word beside it, so the pair drew unclosed.
 \[
   \rho_R \;=\;
-  \begin{tenkz}[rows={ket:nopair, bra}, boundary=none, east=cup]
-    \tn{} & \tnX{}\\
-    \tn*{} & \tnX{}
+  \begin{tenkz}[rows={ket:nopair, bra}, west=none, east=cup]
+    \tn{} & \tnX{B^{\bar I}}\\
+    \tn*{} & \tnX{B^{\bar I}}
   \end{tenkz}
   \;=\;
-  \begin{tenkz}[rows={ket:nopair, bra}, boundary=none, east=cup]
+  \begin{tenkz}[rows={ket:nopair, bra}, west=none, east=cup]
     \tn[box]{U^{A}_{I}} &
       \tnX{\sigma^{A}}\tnspan[brace above]{2}{\sigma_{\partial R}} &
       \tnX{\sigma^{B}}\\

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-inverse-renormalization.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-inverse-renormalization.tex
@@ -21,13 +21,13 @@
   \qquad\qquad
   (b)\quad
   % one PEPS site: 5-leg tensor on the sheared sheet
-  \begin{tenkzlattice}[rows=1, cols=1, outer legs=both, physical=up,
+  \begin{tenkzlattice}[rows=1, cols=1, boundary=open, physical=up,
                        frame=oblique]
     \tnsite{(1,1)}
 \end{tenkzlattice}
   \;\longrightarrow\;
   % the would-be sqrt(D) fine-graining: a 2x2 patch
-  \begin{tenkzlattice}[rows=2, cols=2, outer legs=both, physical=up,
+  \begin{tenkzlattice}[rows=2, cols=2, boundary=open, physical=up,
                        frame=oblique]
     \tnsite{(1,1)}
 \end{tenkzlattice}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-local-purification.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-local-purification.tex
@@ -12,9 +12,13 @@
     \tn[box]{O}
   \end{tenkz}
   \;=\;
-  % RHS: X^{-1} capsule | A over conj(A) | X capsule
+  % RHS: X^{-1} capsule | A over conj(A) | X capsule.  A gauge transform
+  % and its inverse are one operator and its inverse: the two capsules
+  % carry the same claim on the page, so the X label is padded to the
+  % width of X^{-1} and both capsules come out the same size.
   \begin{tenkz}[rows={op, op}]
-    \tnX[wires=2]{X^{-1}} & \tn[box]{A} & \tnX[wires=2]{X}\\
+    \tnX[wires=2]{X^{-1}} & \tn[box]{A} &
+      \tnX[wires=2]{\hphantom{{}^{-}}X\hphantom{{}^{1}}}\\
     & \tn*[box]{A} &
   \end{tenkz}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpdo-ol.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpdo-ol.tex
@@ -8,16 +8,8 @@
 % Capabilities: grid, typed-ports
 \[
   O_L(M) \;=\;
-  \begin{tenkz}[frame=vertical, physical=updown, boundary=periodic]
-    \tn[box]{M} & \tndots & \tn[box]{M}
-  \end{tenkz}
-\]
-
-racetrack override, for contrast:
-\[
-  O_L(M) \;=\;
-  \begin{tenkz}[frame=vertical, physical=updown,
-                boundary=periodic, trace style=racetrack]
+  \begin{tenkz}[frame=vertical, physical=updown, boundary=periodic,
+                compact]
     \tn[box]{M} & \tndots & \tn[box]{M}
   \end{tenkz}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpo-sheet.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpo-sheet.tex
@@ -18,12 +18,15 @@
 
 % panel 2 - the fat-graph depiction, free tier: the two directed wires
 % crossing with no glyph at the crossing (the fat graph IS the tensor).
+% The physical wire pierces the virtual one away from its midpoint, so
+% the level name a - which a join always sets at mid-wire - reads over
+% clear paper instead of over the physical wire.
 \[
   \begin{tenkzfree}
-    \tnput[dot, label pos=west,  ports={east:virtual}]{j}{(0,0)}{j}
-    \tnput[dot, label pos=east,  ports={west:virtual}]{k}{(26mm,0)}{k}
-    \tnput[dot, label pos=south, ports={north:physical}]{n}{(13mm,-13mm)}{n}
-    \tnput[dot, label pos=north, ports={south:physical}]{m}{(13mm,13mm)}{m}
+    \tnput[dot, label pos=west,  ports={east:virtual}]{j}{(0mm,0mm)}{j}
+    \tnput[dot, label pos=east,  ports={west:virtual}]{k}{(26mm,0mm)}{k}
+    \tnput[dot, label pos=south, ports={north:physical}]{n}{(18mm,-9mm)}{n}
+    \tnput[dot, label pos=north, ports={south:physical}]{m}{(18mm,9mm)}{m}
     \tnjoin[dir, label=a]{j.east}{k.west}
     \tnjoin[dir]{n.north}{m.south}
   \end{tenkzfree}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-splitting.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-splitting.tex
@@ -32,17 +32,23 @@
     \tnjoin{w.east}{v.west}
   \end{tenkzfree}
   \;=\;
+  % third panel: the MIRRORED splitting, as in the source - u now reaches
+  % WEST and v EAST, so the two factorizations are the even-odd and the
+  % odd-even one.  The bead labels sit on the free side of each bead,
+  % clear of both the vertical wire and the bead's own leg.
   \begin{tenkzfree}
-    \tnput[dot,role=marked,ports={north:physical,south:virtual,east:physical}]
+    \tnput[dot,role=marked,label pos=east,
+           ports={north:physical,south:virtual,west:physical}]
       {u}{(0mm,4mm)}{u}
-    \tnput[dot,role=extra,ports={north:virtual,south:physical,west:physical}]
+    \tnput[dot,role=extra,label pos=west,
+           ports={north:virtual,south:physical,east:physical}]
       {v}{(0mm,-4mm)}{v}
     \tnput[boundary,ports={south:physical}]{n}{(0mm,11mm)}{}
     \tnput[boundary,ports={north:physical}]{s}{(0mm,-11mm)}{}
-    \tnput[boundary,ports={west:physical}]{e}{(9mm,4mm)}{}
-    \tnput[boundary,ports={east:physical}]{w}{(-9mm,-4mm)}{}
+    \tnput[boundary,ports={east:physical}]{w}{(-9mm,4mm)}{}
+    \tnput[boundary,ports={west:physical}]{e}{(9mm,-4mm)}{}
     \tnjoin{n.south}{u.north} \tnjoin{u.south}{v.north}
-    \tnjoin{v.south}{s.north} \tnjoin{u.east}{e.west}
-    \tnjoin{w.east}{v.west}
+    \tnjoin{v.south}{s.north} \tnjoin{w.east}{u.west}
+    \tnjoin{v.east}{e.west}
   \end{tenkzfree}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-wrap.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-wrap.tex
@@ -6,26 +6,32 @@
 % Source: paper TN-Review-main.tex line 391; author source ImagesReview Section
 %   II/ImagesReview Section II.tex lines 465-472
 % Capabilities: free-graph, typed-ports
+%
+% Every placement is a whole multiple of one step: neighbouring sites two
+% steps apart, every leg one step long, as in the source.  The shift site
+% is a SQUARE there; an unlabelled inscribed glyph here is strut-tall and
+% glyphbox-wide, so its label carries a width pad that squares the site
+% and makes the two quarter turns inside it congruent.
 \[
   \begin{tenkzfree}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {s1}{(0mm,0mm)}{}
+      {s1}{(0mm,0mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {s2}{(14mm,0mm)}{}
+      {s2}{(12mm,0mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {s3}{(28mm,0mm)}{}
+      {s3}{(24mm,0mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {s4}{(42mm,0mm)}{}
-    \tnput[boundary,ports={south:virtual}]{n1}{(0mm,9mm)}{}
-    \tnput[boundary,ports={south:virtual}]{n2}{(14mm,9mm)}{}
-    \tnput[boundary,ports={south:virtual}]{n3}{(28mm,9mm)}{}
-    \tnput[boundary,ports={south:virtual}]{n4}{(42mm,9mm)}{}
-    \tnput[boundary,ports={north:virtual}]{b1}{(0mm,-9mm)}{}
-    \tnput[boundary,ports={north:virtual}]{b2}{(14mm,-9mm)}{}
-    \tnput[boundary,ports={north:virtual}]{b3}{(28mm,-9mm)}{}
-    \tnput[boundary,ports={north:virtual}]{b4}{(42mm,-9mm)}{}
-    \tnput[boundary,ports={east:virtual}]{w}{(-7mm,0mm)}{}
-    \tnput[boundary,ports={west:virtual}]{e}{(49mm,0mm)}{}
+      {s4}{(36mm,0mm)}{\hphantom{W}}
+    \tnput[boundary,ports={south:virtual}]{n1}{(0mm,6mm)}{}
+    \tnput[boundary,ports={south:virtual}]{n2}{(12mm,6mm)}{}
+    \tnput[boundary,ports={south:virtual}]{n3}{(24mm,6mm)}{}
+    \tnput[boundary,ports={south:virtual}]{n4}{(36mm,6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{b1}{(0mm,-6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{b2}{(12mm,-6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{b3}{(24mm,-6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{b4}{(36mm,-6mm)}{}
+    \tnput[boundary,ports={east:virtual}]{w}{(-6mm,0mm)}{}
+    \tnput[boundary,ports={west:virtual}]{e}{(42mm,0mm)}{}
     \tnjoin{n1.south}{s1.north} \tnjoin{s1.south}{b1.north}
     \tnjoin{n2.south}{s2.north} \tnjoin{s2.south}{b2.north}
     \tnjoin{n3.south}{s3.north} \tnjoin{s3.south}{b3.north}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-pepo-sheet.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-pepo-sheet.tex
@@ -9,7 +9,7 @@
 \[
   O \;=\;
   \begin{tenkzlattice}[rows=4, cols=4, frame=oblique,
-                       physical=updown, outer legs=both]
+                       physical=updown, boundary=open]
     \tnsite{(1,1)}
 \end{tenkzlattice}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-marginal.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-marginal.tex
@@ -7,11 +7,12 @@
 % Capabilities: lattice, typed-ports
 \[
 \begin{gathered}
-  \begin{tenkzlattice}[rows=4, cols=4, frame=oblique, physical=up]
+  \begin{tenkzlattice}[rows=4, cols=4, frame=oblique, boundary=open,
+                       physical=up]
     \tnsite{(1,1)}
   \end{tenkzlattice}
   \\[1em]
-  \begin{tenkzplanes}[rows=4, cols=4, sheets={ket, bra},
+  \begin{tenkzplanes}[rows=4, cols=4, sheets={ket, bra}, boundary=open,
                       open={(1-4,1-3)}, trace={(1-4,4)}]
   \end{tenkzplanes}
 \end{gathered}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-projection.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-projection.tex
@@ -7,7 +7,7 @@
 %   II/ImagesReview Section II.tex lines 237-257
 % Capabilities: lattice, typed-ports
 \[
-\begin{tenkzlattice}[rows=4, cols=4, frame=oblique, outer legs=both,
+\begin{tenkzlattice}[rows=4, cols=4, frame=oblique, boundary=open,
                      physical=up]
   \tnsite{(1,1)}
 \end{tenkzlattice}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-rg.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-peps-rg.tex
@@ -7,17 +7,17 @@
 % Source: paper TN-Review-main.tex line 1025; author source ImagesReview Section
 %   II/ImagesReview Section II.tex lines 742-800
 % Capabilities: grid, lattice, typed-ports
-(a) the renormalized plaquette:
+(a)
 \[
-  \begin{tenkzlattice}[rows=2, cols=2, frame=oblique, outer legs=both,
+  \begin{tenkzlattice}[rows=2, cols=2, frame=oblique, boundary=open,
                        physical=up]
     \tnsite{(1,1)}
 \end{tenkzlattice}
 \]
 
-(b) original tensor $\otimes$ disentangled product states:
+(b)
 \[
-  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, outer legs=both,
+  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, boundary=open,
                        physical=up]
     \tnsite{(1,1)}
 \end{tenkzlattice}
@@ -36,9 +36,9 @@
   \end{tenkz}
 \]
 
-(c) original tensor $\otimes$ a generating matrix product:
+(c)
 \[
-  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, outer legs=both,
+  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, boundary=open,
                        physical=up]
     \tnsite{(1,1)}
 \end{tenkzlattice}
@@ -49,14 +49,14 @@
   \end{tenkz}
 \]
 
-(d) two copies of the original tensor $\otimes$ the traced bead:
+(d)
 \[
-  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, outer legs=both,
+  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, boundary=open,
                        physical=up]
     \tnsite{(1,1)}
 \end{tenkzlattice}
   \;\otimes\;
-  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, outer legs=both,
+  \begin{tenkzlattice}[rows=1, cols=1, frame=oblique, boundary=open,
                        physical=up]
     \tnsite{(1,1)}
 \end{tenkzlattice}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-rfp-isometry.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-rfp-isometry.tex
@@ -12,10 +12,11 @@
     \tn[box]{A} & \tn[box]{A}
   \end{tenkz}
   \;=\;
-  % RHS: sum_j U_{(i_1 i_2), j} A^j - U keeps one leg per blocked
-  % site; the vertical U-A bond is the summed physical index j
+  % RHS: sum_j U_{(i_1 i_2), j} A^j - U keeps one OPEN leg per blocked
+  % site (i_1, i_2) on its upper face, and the single vertical U-A bond
+  % below it is the summed physical index j
   \begin{tenkz}[rows={op:none, ket}]
-    \tn[pill, wide=2, down at={1,2}]{U} & \\
+    \tn[pill, wide=2, up at={1,2}]{U} & \\
     \tn[box, wide=2]{A} &
   \end{tenkz}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-spectrum-fixed-points.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-spectrum-fixed-points.tex
@@ -7,16 +7,20 @@
 %   II/ImagesReview Section II.tex lines 519-534
 % Capabilities: grid, typed-ports
 \[
+  % Both fixed points ride the doubled virtual wire: the product is the
+  % object whose spectrum is taken, and the cup is the fold at which the
+  % two orders differ.  boundary=none silently outranked the cup word, so
+  % each side used to draw one capsule and no closure at all.
   \mathrm{eig}\left(
-  \begin{tenkz}[rows={ket:nopair,bra}, boundary=none, west=cup]
-    \tnX[wires=2]{\rho^L}\\
+  \begin{tenkz}[rows={ket:nopair,bra}, west=cup]
+    \tnX[wires=2]{\rho^R} & \tnX[wires=2]{\rho^L}\\
     &
   \end{tenkz}
   \right)
   \;=\;
   \mathrm{eig}\left(
-  \begin{tenkz}[rows={ket:nopair,bra}, boundary=none, east=cup]
-    \tnX[wires=2]{\rho^R}\\
+  \begin{tenkz}[rows={ket:nopair,bra}, east=cup]
+    \tnX[wires=2]{\rho^L} & \tnX[wires=2]{\rho^R}\\
     &
   \end{tenkz}
   \right)

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-triangle-network.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-triangle-network.tex
@@ -11,16 +11,22 @@
   \psi_{ijk} \;=\;
   \begin{tenkzfree}
     % the three tensors at the triangle corners
-    \tnput[dot]{t}{(0,9mm)}{}
-    \tnput[dot]{r}{(8mm,-4.5mm)}{}
-    \tnput[dot]{l}{(-8mm,-4.5mm)}{}
+    \tnput[dot]{t}{(0mm,8mm)}{}
+    \tnput[dot]{r}{(7mm,-4mm)}{}
+    \tnput[dot]{l}{(-7mm,-4mm)}{}
+    % the open physical indices end in named tips, so i, j and k are read
+    % at the tips as in the source; a join sets its label at mid-wire and
+    % on the vertical spoke that would put i ON the spoke
+    \tnput[boundary, label pos=north, ports={south:physical}]{ti}{(0mm,15mm)}{i}
+    \tnput[boundary, label pos=south, ports={north:physical}]{rj}{(13mm,-9mm)}{j}
+    \tnput[boundary, label pos=south, ports={north:physical}]{lk}{(-13mm,-9mm)}{k}
     % contracted virtual loop: alpha, beta, gamma
     \tnjoin[label=\alpha]{t}{r}
     \tnjoin[label=\beta]{r}{l}
     \tnjoin[label=\gamma]{l}{t}
     % open physical indices i, j, k, radially outward
-    \tnjoin[label=i]{t}{0,17mm}
-    \tnjoin[label=j]{r}{14mm,-10mm}
-    \tnjoin[label=k]{l}{-14mm,-10mm}
+    \tnjoin{ti.south}{t}
+    \tnjoin{r}{rj.north}
+    \tnjoin{l}{lk.north}
   \end{tenkzfree}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-boundary-a-old.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-boundary-a-old.tex
@@ -8,7 +8,7 @@
 % Capabilities: grid, lattice, regions, typed-ports
 \[
   \begin{tenkzlattice}[rows=5,cols=6,frame=oblique,physical=up,
-                       outer legs=both]
+                       boundary=open]
     \tnregion[label=$R$,label pos=center]{(2-4,2-5)}
   \end{tenkzlattice}
   \;=\;

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-historical-composite.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-historical-composite.tex
@@ -19,12 +19,12 @@
     \\[1em]
     (b)\quad
     \begin{tenkzlattice}[rows=1,cols=1,frame=oblique,physical=up,
-                         outer legs=both]
+                         boundary=open]
       \tnsite{(1,1)}
     \end{tenkzlattice}
     \;\longrightarrow\;
     \begin{tenkzlattice}[rows=2,cols=2,frame=oblique,physical=up,
-                         outer legs=both]
+                         boundary=open]
       \tnsite{(1,1)}
     \end{tenkzlattice}
   \end{gathered}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-mpu-wrap-second.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-mpu-wrap-second.tex
@@ -6,44 +6,50 @@
 % Source: author source ImagesReview Section II/ImagesReview Section II.tex lines
 %   473-483; archival output sec2fig7c (b).pdf
 % Capabilities: free-graph, typed-ports
+%
+% One step throughout: sites two steps apart, every leg one step long,
+% the two rows three steps apart so the upper row's down legs and the
+% lower row's up legs read as four open indices rather than one wire.
+% The shift site is a SQUARE, as in the source; an unlabelled inscribed
+% glyph is strut-tall and glyphbox-wide, so its label carries a width pad.
 \[
   \begin{tenkzfree}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {a1}{(0mm,0mm)}{}
+      {a1}{(0mm,0mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {a2}{(14mm,0mm)}{}
+      {a2}{(12mm,0mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {a3}{(28mm,0mm)}{}
+      {a3}{(24mm,0mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {a4}{(42mm,0mm)}{}
+      {a4}{(36mm,0mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {b1}{(0mm,16mm)}{}
+      {b1}{(0mm,18mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {b2}{(14mm,16mm)}{}
+      {b2}{(12mm,18mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {b3}{(28mm,16mm)}{}
+      {b3}{(24mm,18mm)}{\hphantom{W}}
     \tnput[box,ports={north:virtual,south:virtual,east:virtual,west:virtual}]
-      {b4}{(42mm,16mm)}{}
-    \tnput[boundary,ports={east:virtual}]{aw}{(-7mm,0mm)}{}
-    \tnput[boundary,ports={west:virtual}]{ae}{(49mm,0mm)}{}
-    \tnput[boundary,ports={east:virtual}]{bw}{(-7mm,16mm)}{}
-    \tnput[boundary,ports={west:virtual}]{be}{(49mm,16mm)}{}
-    \tnput[boundary,ports={south:virtual}]{an1}{(0mm,7mm)}{}
-    \tnput[boundary,ports={south:virtual}]{an2}{(14mm,7mm)}{}
-    \tnput[boundary,ports={south:virtual}]{an3}{(28mm,7mm)}{}
-    \tnput[boundary,ports={south:virtual}]{an4}{(42mm,7mm)}{}
-    \tnput[boundary,ports={north:virtual}]{as1}{(0mm,-7mm)}{}
-    \tnput[boundary,ports={north:virtual}]{as2}{(14mm,-7mm)}{}
-    \tnput[boundary,ports={north:virtual}]{as3}{(28mm,-7mm)}{}
-    \tnput[boundary,ports={north:virtual}]{as4}{(42mm,-7mm)}{}
-    \tnput[boundary,ports={south:virtual}]{bn1}{(0mm,23mm)}{}
-    \tnput[boundary,ports={south:virtual}]{bn2}{(14mm,23mm)}{}
-    \tnput[boundary,ports={south:virtual}]{bn3}{(28mm,23mm)}{}
-    \tnput[boundary,ports={south:virtual}]{bn4}{(42mm,23mm)}{}
-    \tnput[boundary,ports={north:virtual}]{bs1}{(0mm,9mm)}{}
-    \tnput[boundary,ports={north:virtual}]{bs2}{(14mm,9mm)}{}
-    \tnput[boundary,ports={north:virtual}]{bs3}{(28mm,9mm)}{}
-    \tnput[boundary,ports={north:virtual}]{bs4}{(42mm,9mm)}{}
+      {b4}{(36mm,18mm)}{\hphantom{W}}
+    \tnput[boundary,ports={east:virtual}]{aw}{(-6mm,0mm)}{}
+    \tnput[boundary,ports={west:virtual}]{ae}{(42mm,0mm)}{}
+    \tnput[boundary,ports={east:virtual}]{bw}{(-6mm,18mm)}{}
+    \tnput[boundary,ports={west:virtual}]{be}{(42mm,18mm)}{}
+    \tnput[boundary,ports={south:virtual}]{an1}{(0mm,6mm)}{}
+    \tnput[boundary,ports={south:virtual}]{an2}{(12mm,6mm)}{}
+    \tnput[boundary,ports={south:virtual}]{an3}{(24mm,6mm)}{}
+    \tnput[boundary,ports={south:virtual}]{an4}{(36mm,6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{as1}{(0mm,-6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{as2}{(12mm,-6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{as3}{(24mm,-6mm)}{}
+    \tnput[boundary,ports={north:virtual}]{as4}{(36mm,-6mm)}{}
+    \tnput[boundary,ports={south:virtual}]{bn1}{(0mm,24mm)}{}
+    \tnput[boundary,ports={south:virtual}]{bn2}{(12mm,24mm)}{}
+    \tnput[boundary,ports={south:virtual}]{bn3}{(24mm,24mm)}{}
+    \tnput[boundary,ports={south:virtual}]{bn4}{(36mm,24mm)}{}
+    \tnput[boundary,ports={north:virtual}]{bs1}{(0mm,12mm)}{}
+    \tnput[boundary,ports={north:virtual}]{bs2}{(12mm,12mm)}{}
+    \tnput[boundary,ports={north:virtual}]{bs3}{(24mm,12mm)}{}
+    \tnput[boundary,ports={north:virtual}]{bs4}{(36mm,12mm)}{}
     \tnjoin{aw.east}{a1.west} \tnjoin{a1.east}{a2.west}
     \tnjoin{a2.east}{a3.west} \tnjoin{a3.east}{a4.west}
     \tnjoin{a4.east}{ae.west}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-peps-fine-graining.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-peps-fine-graining.tex
@@ -8,12 +8,12 @@
 % Capabilities: lattice, typed-ports
 \[
   \begin{tenkzlattice}[rows=1,cols=1,frame=oblique,physical=up,
-                       outer legs=both]
+                       boundary=open]
     \tnsite{(1,1)}
   \end{tenkzlattice}
   \;\longrightarrow\;
   \begin{tenkzlattice}[rows=2,cols=2,frame=oblique,physical=up,
-                       outer legs=both]
+                       boundary=open]
     \tnsite{(1,1)}
   \end{tenkzlattice}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-peps-rg-workbench.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-peps-rg-workbench.tex
@@ -9,7 +9,7 @@
 \[
   \underset{U(A^{\otimes 4})}{
   \begin{tenkzlattice}[rows=2,cols=2,frame=oblique,physical=up,
-                       outer legs=both]
+                       boundary=open]
     \tnsite{(1,1)}
   \end{tenkzlattice}}
 \]

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-positive-mpo-old.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-positive-mpo-old.tex
@@ -25,8 +25,10 @@
       {A}{(0mm,5mm)}{A}
     \tnput[box,ports={west:virtual,east:virtual,north:physical,south:physical}]
       {Ab}{(0mm,-5mm)}{\bar A}
+    % the X capsule is padded to the width of X^{-1}: an operator and its
+    % inverse carry the same claim, so they carry the same glyph
     \tnput[pill,ports={north west:virtual,south west:virtual,east:virtual}]
-      {x}{(14mm,0mm)}{X}
+      {x}{(14mm,0mm)}{\hphantom{{}^{-}}X\hphantom{{}^{1}}}
     \tnput[boundary,ports={east:virtual}]{w}{(-24mm,0mm)}{}
     \tnput[boundary,ports={west:virtual}]{e}{(24mm,0mm)}{}
     \tnput[boundary,ports={south:physical}]{n}{(0mm,13mm)}{}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-projector-on-pta.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-projector-on-pta.tex
@@ -16,7 +16,7 @@
       \tn*[tri=r]{} & \tn*[tri=r]{}
   \end{tenkz}
   \;-\;\sum_{i=1}^{n}
-  \begin{tenkz}[rows={ket:nopair,bra},boundary=none,east=cup]
+  \begin{tenkz}[rows={ket:nopair,bra},west=none,east=cup]
     \tn[tri=l]{} & \tn[tri=l]{}\\
     \tn*[tri=l]{} & \tn*[tri=l]{}
   \end{tenkz}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-v-tensor-definition.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-workbench-ii-v-tensor-definition.tex
@@ -7,7 +7,10 @@
 %   590-596; archival output DefV.pdf
 % Capabilities: grid, typed-ports
 \[
-  \begin{tenkz}[rows={ket:nopair,bra},boundary=none,
+  % boundary=none silently outranks the two cup words below it, so the
+  % declared closure drew as two free-floating glyphs; the cup words are
+  % the closure and state the boundary on their own
+  \begin{tenkz}[rows={ket:nopair,bra},
                 west={cup=$l^{1/2}$},east=cup]
     \tn[box]{V}\\
     \tn*[box]{A}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-mpo-tensor.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-mpo-tensor.tex
@@ -17,12 +17,15 @@
 
 % panel 2 — the fat-graph depiction, free tier: the two directed wires
 % crossing with no glyph at the crossing (the fat graph IS the tensor).
+% The physical wire pierces the virtual one away from its midpoint, so
+% the level name a — which a join always sets at mid-wire — reads over
+% clear paper instead of over the physical wire.
 \[
   \begin{tenkzfree}
-    \tnput[dot, label pos=west,  ports={east:virtual}]{j}{(0,0)}{j}
-    \tnput[dot, label pos=east,  ports={west:virtual}]{k}{(26mm,0)}{k}
-    \tnput[dot, label pos=south, ports={north:physical}]{n}{(13mm,-13mm)}{n}
-    \tnput[dot, label pos=north, ports={south:physical}]{m}{(13mm,13mm)}{m}
+    \tnput[dot, label pos=west,  ports={east:virtual}]{j}{(0mm,0mm)}{j}
+    \tnput[dot, label pos=east,  ports={west:virtual}]{k}{(26mm,0mm)}{k}
+    \tnput[dot, label pos=south, ports={north:physical}]{n}{(18mm,-9mm)}{n}
+    \tnput[dot, label pos=north, ports={south:physical}]{m}{(18mm,9mm)}{m}
     \tnjoin[dir, label=a]{j.east}{k.west}
     \tnjoin[dir]{n.north}{m.south}
   \end{tenkzfree}


### PR DESCRIPTION
## What I did

Rendered every `rmp-ii-*` and `rmp-workbench-ii-*` target from current `main`
myself (48 targets, PNG at 300 dpi), read each one beside the authors' own
drawing in `tex/RMP_TIKZ_SOURCE_CODE/ImagesReview Section II/` and the
published assets in `Papers/2011.12127/`, and redrew what the pictures showed
to be wrong. Every judgement below was formed by looking at an image.

## First: the canonical-form pages still beat the authors

The maintainer's praise holds and has not regressed.

* `rmp-ii-canonical-left` / `rmp-ii-canonical-right` — the authors' `AL.pdf`
  and `AR.pdf` are cramped: the `α` label sits on the leg and the physical
  index leaves as a short hook. Ours has an unlabelled-free triangle, a
  straight physical leg, labels off every wire, and names the tensor. Better.
* `rmp-ii-ortho-left` / `rmp-ii-ortho-right` — `∑ A†A = 1` and `∑ AA† = 1`
  are both drawn correctly (cup on the contracted side, identity cup on the
  open side), and both are far more legible than `orthoL.pdf`/`orthoR.pdf`.
* `rmp-ii-spectrum-rho` and `rmp-ii-reduced-density` reproduce `fig9-1`
  exactly and read better.

## Wrong mathematics, repaired

**One cause, nine panels.** Lattice cases asked for `outer legs=both`, which
lifts *physical* legs to a stack's outer faces. The open in-plane virtual
boundary is `boundary=open`. A 4×4 sheet was therefore drawn as a closed mesh
— sixteen open virtual indices missing — and a single PEPS site as a bead with
one leg instead of the source's five-leg glyph. Fixed in `peps-projection`,
`pepo-sheet`, `peps-marginal`, `peps-rg`, `inverse-renormalization`,
`boundary-region`, `boundary-a-old`, `peps-fine-graining`,
`historical-composite`, `peps-rg-workbench`. `pepo-sheet` was carrying a
`faithful` verdict while missing sixteen indices its own Boundary line
claimed.

**A second cause, four panels.** `boundary=none` silently outranks the
per-side `cup` words written beside it. Four cases declared a cup and drew
none: `v-tensor-definition` lost both and its two glyphs floated free,
`boundary-state`'s ρ_R lasso and `projector-on-pta`'s second summand were
left unclosed, and `spectrum-fixed-points` lost its fold.

**`rfp-isometry`** put U's two blocked outputs on its *lower* face, so the
panel showed one open physical index where `AA=UA` shows two, plus a dangling
leg and a spurious diagonal crossing. `up at={1,2}` and one bond down into A
now match `fig2_fig2-pepe_AAeqUA` exactly.

**`mpu-splitting`**'s third panel was a byte copy of its second. The source
mirrors it — u reaches west, v east — because those are the two splittings.

**`spectrum-fixed-points`** drew `eig(ρ^L) = eig(ρ^R)`, a relation the source
does not assert. Both fixed points now ride the doubled wire.

## Ungraceful ink, repaired

* `local-purification`, `positive-mpo-old` — X and X⁻¹ were different sizes.
  The X label is padded to the width of X⁻¹.
* `mpu-wrap`, `mpu-wrap-second` — the shift site was strut-tall and
  glyphbox-wide, a 1:1.8 rectangle where the source draws a square, which
  also distorted the two quarter turns inside it. Squared; every placement is
  now a whole multiple of one step. In `mpu-wrap-second` the rows also sat so
  close that the upper row's down legs and the lower row's up legs read as one
  wire; they are three steps apart now.
* `mpo-sheet`, `triangle-network` — a join always sets its label at mid-wire,
  so `a` sat on the physical wire and `i` sat on its own vertical spoke. The
  physical wire now pierces the virtual one off-centre, and the triangle's
  open indices end in named tips carrying i, j, k where the source puts them.
* `mpdo-ol` carried a second "racetrack override, for contrast" diagram with
  an English caption, neither in the source; `peps-rg` carried four English
  panel captions where the source has bare (a)–(d). Removed.
* `boundary-state`'s first panel had two content-free capsules; the source
  names that object, so it is named.

## Coupled change outside the family

`rmp-iii-a-mpo-tensor` is manifest-declared `equivalent_to`
`rmp-ii-mpo-sheet`, so it takes the identical body change or the corpus audit
fails. No other section-iii file is touched.

## Verdict flips proposed (needs the second signature)

I did not touch `verdicts.toml` or `manifest.toml`. Twenty-two recorded
`case_sha256` values are now stale by construction. Proposed statuses, with
the evidence being the re-rendered panel beside the named source asset:

| target | recorded | proposed | evidence |
|---|---|---|---|
| rmp-ii-rfp-isometry | structural-gap (wrong-contraction) | faithful | matches `fig2_fig2-pepe_AAeqUA` leg for leg |
| rmp-ii-pepo-sheet | faithful | faithful (re-hash only) | now actually has the 16 boundary legs it claimed |
| rmp-ii-peps-projection | structural-gap | structural-gap | boundary repaired; projector/entangled-bond layer still absent |
| rmp-ii-peps-marginal | cosmetic-gap | cosmetic-gap | boundary repaired; trace loops still tall brackets |
| rmp-ii-peps-rg | structural-gap | structural-gap | (a) and the PEPS-site factors repaired; (b)–(d) second factors still flat |
| rmp-ii-inverse-renormalization | blocked (rotated-action) | cosmetic-gap or faithful | both panels now match `newfig13` |
| rmp-ii-mpu-splitting | cosmetic-gap (label-collision) | faithful | mirrored panel + labels clear of all ink |
| rmp-ii-mpu-wrap | cosmetic-gap (weight-mismatch) | faithful | square site, congruent turns, source step grid |
| rmp-ii-local-purification | cosmetic-gap (weight-mismatch) | faithful | X and X⁻¹ identical |
| rmp-ii-mpo-sheet | cosmetic-gap (label-collision) | faithful | `a` clear of the physical wire |
| rmp-ii-triangle-network | cosmetic-gap (label-collision, weight) | faithful | every label at a spoke tip, as in `sec2fig3` |
| rmp-ii-mpdo-ol | cosmetic-gap (extra-element) | cosmetic-gap | contrast panel gone; hooks still wider than source |
| rmp-ii-boundary-state | cosmetic-gap | cosmetic-gap | lasso now closes; σ_∂R brace vs dotted box remains |
| rmp-ii-spectrum-fixed-points | structural-gap | cosmetic-gap | the asserted relation is now the source's |
| rmp-ii-boundary-region | cosmetic-gap | cosmetic-gap | sheet boundary repaired; contour shape remains |
| rmp-workbench-ii-positive-mpo-old | cosmetic-gap | cosmetic-gap | X sizes equal; rounding remains |
| rmp-workbench-ii-v-tensor-definition | structural-gap | structural-gap | cups now draw; the source contracts V to Ā, this panel does not (see below) |
| rmp-workbench-ii-projector-on-pta | cosmetic-gap | cosmetic-gap | east cup now draws; 2-vs-4 triangles remains |
| rmp-workbench-ii-mpu-wrap-second | blocked | blocked | squared and re-stepped; the two-colour strings still absent |
| rmp-workbench-ii-boundary-a-old, -peps-fine-graining, -historical-composite, -peps-rg-workbench | as recorded | as recorded | boundary repaired only |
| rmp-iii-a-mpo-tensor | faithful | faithful (re-hash only) | equivalence twin |

## Not fixed, and why

* **`rmp-ii-circuit`** is the worst remaining panel. The paper's caption for
  `sec2fig11b` is "Tree tensor network": a binary tree, 1+2+4 boxes, eight
  open outputs. The case draws a four-wire staircase circuit with two
  outputs. The manifest pins its Ink to "Canonical public tenkz environment
  with rotated gate frames" and its capability to `rotated-action`; a tree
  branches and the grid tier cannot express it. Redrawing needs the free tier,
  which needs a manifest edit I am not permitted to make.
* **`rmp-ii-mpu-brickwork`** — the source's circuit has two dangling half-v
  legs at its ends, matching the two open virtual indices on the U chain
  opposite. Our RHS has none, so the two sides carry 14 and 12 open indices.
  The grid tier can only place whole `wires=k` bricks inside the row range;
  there is no half-gate at a circuit edge. Fabricating one would be worse than
  the honest gap.
* **`rmp-ii-mpu-two-shift`** — the source draws one row of tensors carrying
  both shifts as two coloured strings; ours draws two rows, one per shift.
  Needs declared crossings (already recorded `blocked`).
* **`rmp-workbench-ii-v-tensor-definition`** — the source contracts V to Ā
  and closes only the west with the l^{1/2} bead, leaving both east legs
  open. That is `sandwich, west={cup=$l^{1/2}$}` and it renders correctly. The
  manifest's Boundary line says "West **and east** cups close the virtual
  pair", which is the other figure. I shipped what the manifest declares.

## Demands on the language

1. **Trace strokes cross virtual wires with no break.** The authors white out
   every such crossing (`preaction={draw, line width=1.2pt, white}`); we draw
   a hard junction. In a tensor diagram a crossing without a break reads as a
   contraction. Visible in `mps-marginal`, `peps-marginal` and `zcl-mpdo`. The
   library already owns the calibrated break — `crossgap = 0.10` in
   `tenkz-metric.code.tex` — but only the string tier uses it. One change in
   `\tenkz_pairtrace_site:nn` / `\tenkz_trace_row:nn` fixes all three. Not
   done here: it would move golden event streams for fixtures this PR does not
   touch.
2. **An unlabelled inscribed glyph inherits the label strut.** A `box` with an
   empty label comes out `glyphbox` wide and strut tall — 1:1.8 — so every
   unlabelled square site in the corpus is a tall rectangle. Two cases here
   pad the label to square it, which is a workaround, not a fix.
3. **`boundary=none` silently outranks a per-side `cup`.** Four cases declared
   a closure and got none, with no warning. A how-key should not win over the
   explicit side word, and a dropped cup should warn.
4. **A join label has one position.** `pos=0.5, above` — which lands on the
   wire for a vertical join and on the crossing for a symmetric cross. Both
   fixes here move the geometry instead of the label.
5. **The free tier has no pitch-relative placement.** Every `tenkzfree` case
   in the corpus is written in millimetres. The redraws here at least make
   every coordinate a whole multiple of one step.

## Gates

`scripts/tenkz_corpus.sh` and `scripts/tenkz_golden.sh --check` both walk
`tests/tenkz` at `-maxdepth 1`. Every file in this PR lives under
`tests/tenkz/rmp/*/cases`, so no fixture event stream moves and no baseline is
re-pinned. Both were run in the foreground on a clean worktree of this branch.

`scripts/tenkz_rmp.py check --section section-ii` passes on `main` and, with
this branch, fails only on the stale `case_sha256` values listed above — the
designed countersign prompt.

https://claude.ai/code/session_01Gk8pthhGGnaCaUZTRMGjBk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to RMP corpus test LaTeX under `tests/tenkz/rmp`; library code is untouched and golden baselines at repo root are unaffected.
> 
> **Overview**
> Updates **RMP section-ii** (and one **section-iii-a** twin) **tenkz** test fixtures so rendered diagrams match the authors’ panels and correct boundary semantics.
> 
> **Boundary API:** Lattice sheets switch from `outer legs=both` to **`boundary=open`** so in-plane virtual indices stay open instead of being drawn as a closed mesh. Several **`tenkz`** cases drop **`boundary=none`**, which was overriding per-side **`cup`** / **`west=none`** and leaving virtual pairs unclosed (`boundary-state`, `spectrum-fixed-points`, `v-tensor-definition`, `projector-on-pta`).
> 
> **Math / topology:** **`rfp-isometry`** moves **U**’s blocked outputs to the upper face; **`spectrum-fixed-points`** puts both **ρ^L** and **ρ^R** on the doubled wire; **`mpu-splitting`** replaces a duplicate third panel with the mirrored **u**-west / **v**-east factorization.
> 
> **Ink / layout:** Equal-size **X** / **X⁻¹** capsules, squared MPU sites via label padding and step-aligned coordinates, off-center MPO crossing so label **a** clears the physical wire, triangle **i,j,k** on boundary tips, **`mpdo-ol`** drops the extra racetrack diagram and uses **`compact`**, **`peps-rg`** drops English panel captions. **`rmp-iii-a-mpo-tensor`** mirrors **`rmp-ii-mpo-sheet`** for manifest equivalence.
> 
> Expect stale **`case_sha256`** until verdicts are re-signed; no golden fixture streams under `tests/tenkz` maxdepth-1 per author notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9500b7bbbcda9cbd48392d64f5d056be335cc033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->