### PR TITLE
refactor(MPS/MPDO): reduce compilation hotspots

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -238,6 +238,7 @@ import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorCoordinates
 import TNLean.MPS.MPDO.VerticalSectorDensityBlocks
 import TNLean.MPS.MPDO.VerticalSectorFixedGenerators
+import TNLean.MPS.MPDO.VerticalSectorFixedPointProductSpan
 import TNLean.MPS.MPDO.VerticalSectorGeneration
 import TNLean.MPS.MPDO.VerticalSectorIdentity
 import TNLean.MPS.MPDO.VerticalSectorImagePreservation

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -99,6 +99,7 @@ import TNLean.MPS.MPDO.DiagonalCutRank
 import TNLean.MPS.MPDO.DiagonalFiniteChain
 import TNLean.MPS.MPDO.EtaPreparation
 import TNLean.MPS.MPDO.FigureEightPairwise
+import TNLean.MPS.MPDO.FirstSite
 import TNLean.MPS.MPDO.FirstSiteBlocking
 import TNLean.MPS.MPDO.FixedBondPositivePhysicalSectorConstructor
 import TNLean.MPS.MPDO.FixedBondPositivePhysicalSectorRepresentative

--- a/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
@@ -87,6 +87,35 @@ theorem hasFinalLabelSelectorWords_of_hasBlockSelectorWords
     Fam.HasFinalLabelSelectorWords S :=
   hSel
 
+/-- Finite scalar sums commute with a dependent block diagonal whose blocks
+have a fixed identity Kronecker factor. -/
+private theorem sum_sum_smul_blockDiagonal'_one_kronecker
+    {ι κ₁ κ₂ : Type*} [DecidableEq ι] [Fintype κ₁] [Fintype κ₂]
+    (m n : ι → ℕ) (c : κ₁ → κ₂ → ℂ)
+    (A : (i : ι) → κ₁ → κ₂ → Matrix (Fin (n i)) (Fin (n i)) ℂ) :
+    (∑ a : κ₁, ∑ b : κ₂, c a b • Matrix.blockDiagonal' (fun i =>
+      (1 : Matrix (Fin (m i)) (Fin (m i)) ℂ) ⊗ₖ A i a b)) =
+      Matrix.blockDiagonal' (fun i =>
+        (1 : Matrix (Fin (m i)) (Fin (m i)) ℂ) ⊗ₖ
+          (∑ a : κ₁, ∑ b : κ₂, c a b • A i a b)) := by
+  classical
+  simp_rw [← Matrix.blockDiagonal'_smul]
+  let blockDiagonalHom :=
+    Matrix.blockDiagonal'AddMonoidHom
+      (fun i => Fin (m i) × Fin (n i)) (fun i => Fin (m i) × Fin (n i)) ℂ
+  change (∑ a : κ₁, ∑ b : κ₂, blockDiagonalHom (fun i =>
+      c a b • ((1 : Matrix (Fin (m i)) (Fin (m i)) ℂ) ⊗ₖ A i a b))) =
+    blockDiagonalHom (fun i =>
+      (1 : Matrix (Fin (m i)) (Fin (m i)) ℂ) ⊗ₖ
+        (∑ a : κ₁, ∑ b : κ₂, c a b • A i a b))
+  simp_rw [← map_sum blockDiagonalHom]
+  congr 1
+  funext i
+  ext x y
+  by_cases hxy : x.1 = y.1
+  · simp [Matrix.sum_apply, Matrix.smul_apply, Matrix.one_apply, hxy]
+  · simp [Matrix.sum_apply, Matrix.smul_apply, hxy]
+
 /-- **Positive-length final-label selectors make every pair fusion map surjective.**
 
 Suppose that the positive trace-power coefficients are independent of the positive chain
@@ -185,13 +214,11 @@ theorem fusionIsometry_mul_conjTranspose_eq_one_of_lengthIndependent_of_selector
               (∑ ε : Λ, ∑ w : Fin (n + 1) → Fin (p * p),
                 coeff ε w •
                   MPSTensor.evalWord (Fam.tensor γ).toMPSTensor (List.ofFn w)) := by
-        ext ⟨γ, μ, b⟩ ⟨γ', μ', b'⟩
-        by_cases hγ : γ = γ'
-        · subst γ'
-          simp [Matrix.sum_apply, Matrix.smul_apply, hDword,
-            Matrix.blockDiagonal'_apply, Finset.mul_sum, mul_left_comm]
-        · simp [Matrix.sum_apply, Matrix.smul_apply, hDword,
-            Matrix.blockDiagonal'_apply, hγ]
+        simp_rw [hDword]
+        exact sum_sum_smul_blockDiagonal'_one_kronecker
+          (fun γ => Fam.chi.dim α β γ) Fam.bondDim coeff
+          (fun γ _ w =>
+            MPSTensor.evalWord (Fam.tensor γ).toMPSTensor (List.ofFn w))
       _ = Matrix.blockDiagonal' fun γ =>
           (1 : Matrix (Fin (Fam.chi.dim α β γ))
             (Fin (Fam.chi.dim α β γ)) ℂ) ⊗ₖ
@@ -451,6 +478,38 @@ theorem conjTranspose_mul_tripleFusionComparison_eq_one_of_lengthIndependent_of_
     Fam.rightFusionIsometry_mul_conjTranspose_eq_one_of_lengthIndependent_of_selectorWords
       c hχ hLI hS hSel]
 
+/-- The fixed-final matrix entries of the triple-fusion comparison intertwine
+the corresponding final-label tensor entries.
+
+Source: arXiv:1511.08090, equations `zippercondition2` and `Fmove`, lines
+237--277; arXiv:1606.00608, lines 995--1010. -/
+private theorem tripleFusionComparison_final_entry_intertwines_of_lengthIndependent
+    (c : BNTLabelCoefficientFamily Λ)
+    (hχ : c.HasPositiveLengthChiTracePowerForm Fam.chi)
+    (hLI : c.LengthIndependent) (α β γ ε ε' δL δR : Λ)
+    (μL : Fin (Fam.chi.dim α β δL)) (νL : Fin (Fam.chi.dim δL γ ε))
+    (μR : Fin (Fam.chi.dim β γ δR)) (νR : Fin (Fam.chi.dim α δR ε'))
+    (bL : Fin (Fam.bondDim ε)) (bR : Fin (Fam.bondDim ε'))
+    (ij : Fin (p * p)) :
+    (∑ b, (Fam.tensor ε).toMPSTensor ij bL b *
+        Fam.tripleFusionComparison α β γ
+          (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, b⟩)
+          (Fam.rightFinalRow α β γ ε' ⟨δR, μR, νR, bR⟩)) =
+      ∑ b, Fam.tripleFusionComparison α β γ
+          (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, bL⟩)
+          (Fam.rightFinalRow α β γ ε' ⟨δR, μR, νR, b⟩) *
+        (Fam.tensor ε').toMPSTensor ij b bR := by
+  obtain ⟨⟨i, k⟩, rfl⟩ := finProdFinEquiv.surjective ij
+  have hFull := Fam.tripleFusionComparison_intertwines_of_lengthIndependent
+    c hχ hLI α β γ i k
+  have hEntry := congrArg
+    (fun X => X (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, bL⟩)
+      (Fam.rightFinalRow α β γ ε' ⟨δR, μR, νR, bR⟩)) hFull
+  simpa [Matrix.mul_apply, Matrix.blockDiagonal'_apply,
+    leftFinalRow, rightFinalRow, Fintype.sum_sigma,
+    Fintype.sum_prod_type, Matrix.one_apply, MPOTensor.toMPSTensor]
+    using hEntry
+
 private theorem rectangularIntertwiner_eq_zero_of_selectorWords
     {d D₁ D₂ S : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (C : Matrix (Fin D₁) (Fin D₂) ℂ)
@@ -524,17 +583,10 @@ theorem tripleFusionComparison_finalSector_submatrix_eq_zero
       (Fam.tensor ε).toMPSTensor ij * Cblock =
         Cblock * (Fam.tensor ε').toMPSTensor ij := by
     intro ij
-    obtain ⟨⟨i, k⟩, rfl⟩ := finProdFinEquiv.surjective ij
-    have hFull := Fam.tripleFusionComparison_intertwines_of_lengthIndependent
-      c hχ hLI α β γ i k
     ext b b'
-    have hEntry := congrArg
-      (fun X => X (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, b⟩)
-        (Fam.rightFinalRow α β γ ε' ⟨δR, μR, νR, b'⟩)) hFull
-    simpa [Cblock, C, Matrix.mul_apply, Matrix.blockDiagonal'_apply,
-      leftFinalRow, rightFinalRow, Fintype.sum_sigma, Fintype.sum_prod_type,
-      Matrix.one_apply, MPOTensor.toMPSTensor]
-      using hEntry
+    simpa [Cblock, C, Matrix.mul_apply] using
+      Fam.tripleFusionComparison_final_entry_intertwines_of_lengthIndependent
+        c hχ hLI α β γ ε ε' δL δR μL νL μR νR b b' ij
   obtain ⟨coeff, hSelf, hOther⟩ := hSel ε
   have hZero := rectangularIntertwiner_eq_zero_of_selectorWords
     (Fam.tensor ε).toMPSTensor (Fam.tensor ε').toMPSTensor Cblock hLetter
@@ -594,19 +646,12 @@ theorem exists_tripleFusionComparison_finalSector_eq_kronecker_one_of_separation
             (Fam.RightFinalMultiplicity α β γ ε) ℂ) ⊗ₖ
             (Fam.tensor ε).toMPSTensor ij) := by
     intro ij
-    obtain ⟨⟨i, k⟩, rfl⟩ := finProdFinEquiv.surjective ij
-    have hFull := Fam.tripleFusionComparison_intertwines_of_lengthIndependent
-      c hχ hLI α β γ i k
     ext ⟨⟨δL, μL, νL⟩, bL⟩ ⟨⟨δR, μR, νR⟩, bR⟩
-    simp [C, Matrix.mul_apply, MPOTensor.toMPSTensor,
+    simpa [C, Matrix.mul_apply,
       leftFinalIndexEquiv_symm_apply, rightFinalIndexEquiv_symm_apply,
-      Fintype.sum_prod_type, Matrix.one_apply]
-    have hEntry := congrArg
-      (fun X => X (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, bL⟩)
-        (Fam.rightFinalRow α β γ ε ⟨δR, μR, νR, bR⟩)) hFull
-    simpa [Matrix.mul_apply, Matrix.blockDiagonal'_apply,
-      leftFinalRow, rightFinalRow, Fintype.sum_sigma,
-      Fintype.sum_prod_type, Matrix.one_apply] using hEntry
+      Fintype.sum_prod_type, Matrix.one_apply] using
+      Fam.tripleFusionComparison_final_entry_intertwines_of_lengthIndependent
+        c hχ hLI α β γ ε ε δL δR μL νL μR νR bL bR ij
   obtain ⟨F, hF⟩ :=
     Fam.exists_reindexed_intertwiner_eq_kronecker_one_of_isInjective
       α β γ ε hε C hC

--- a/TNLean/MPS/MPDO/FirstSite.lean
+++ b/TNLean/MPS/MPDO/FirstSite.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.LinearAlgebra.Trace
+import TNLean.MPS.MPDO.Defs
+
+/-!
+# First-site actions on matrix product density operators
+
+This file defines multiplication of an MPO tensor or density operator on its
+first physical site.  These identities are common to the invariant-projection
+and sector-trace arguments and require no canonical-form hypotheses.
+
+## Main definitions
+
+* `MPOTensor.ketLeftMul` and `MPOTensor.braRightMul`: multiplication on the two
+  physical legs of a vertically viewed MPO tensor.
+* `MPOTensor.firstSiteMatrix`: a one-site matrix acting on the first site of a chain.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1874--1902.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- The vertically viewed product $P\widetilde M$.  Viewing the MPO tensor as
+the family of physical-space operators $(\widetilde M_{ab})_{ij}=M^{ij}_{ab}$
+indexed by the virtual indices, multiply each operator by `P` on the left:
+$(P\widetilde M)^{ij}=\sum_kP_{ik}M^{kj}$.
+
+The invariant-projection step in the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1874--1887, considers an orthogonal projector $P$ with
+$P\widetilde M=P\widetilde M P$ in this sense. -/
+noncomputable def ketLeftMul (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) :
+    MPOTensor d D :=
+  fun i j => ∑ k : Fin d, P i k • M k j
+
+/-- The vertically viewed product $\widetilde M P$: multiply each
+physical-space operator $\widetilde M_{ab}$ by `P` on the right,
+$(\widetilde M P)^{ij}=\sum_kP_{kj}M^{ik}$.
+
+Together with `ketLeftMul` this expresses the hypothesis
+$P\widetilde M=P\widetilde M P$ in the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1874--1887. -/
+noncomputable def braRightMul (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) :
+    MPOTensor d D :=
+  fun i j => ∑ k : Fin d, P k j • M i k
+
+/-- Splitting off the first site of a density-operator entry:
+$H^{(N+1)}_{(i,\sigma),(j,\tau)}
+=\tr(M^{ij}M^{\sigma_0\tau_0}\cdots M^{\sigma_{N-1}\tau_{N-1}})$. -/
+theorem mpo_cons_cons (M : MPOTensor d D) {N : ℕ} (i j : Fin d)
+    (σ τ : Fin N → Fin d) :
+    mpo M (N + 1) (Fin.cons i σ) (Fin.cons j τ) =
+      Matrix.trace (M i j * evalWord M (List.ofFn σ) (List.ofFn τ)) := by
+  simp only [mpo_apply, mpoMatrixEntry]
+  congr 1
+  rw [List.ofFn_succ, List.ofFn_succ]
+  simp only [Fin.cons_zero, Fin.cons_succ, evalWord_cons]
+
+/-- The one-site matrix `P` acting on the first spin of an $(N+1)$-site chain,
+$P_1=P\otimes\Id^{\otimes N}$.  The products $P_1H^{(N+1)}$,
+$P_1H^{(N+1)}P_1$, and $H^{(N+1)}P_1$ in the displayed chain
+eq1:proof.IV.12 of arXiv:1606.00608, lines 1874--1887, are formed with this
+operator. -/
+noncomputable def firstSiteMatrix (P : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
+    Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ :=
+  fun σ τ => P (σ 0) (τ 0) * (if σ ∘ Fin.succ = τ ∘ Fin.succ then 1 else 0)
+
+/-- Acting by the identity on the first site gives the identity on the full
+chain. -/
+@[simp] theorem firstSiteMatrix_one (N : ℕ) :
+    firstSiteMatrix (1 : Matrix (Fin d) (Fin d) ℂ) N = 1 := by
+  ext σ τ
+  by_cases hστ : σ = τ
+  · subst τ
+    simp [firstSiteMatrix]
+  · have hne : σ 0 ≠ τ 0 ∨ σ ∘ Fin.succ ≠ τ ∘ Fin.succ := by
+      by_contra h
+      push Not at h
+      apply hστ
+      funext i
+      refine Fin.cases h.1 (fun j ↦ ?_) i
+      exact congrFun h.2 j
+    rcases hne with hhead | htail
+    · simp [firstSiteMatrix, hστ, hhead]
+    · simp [firstSiteMatrix, Matrix.one_apply, hστ, htail]
+
+/-- The first-spin action of a Hermitian matrix is Hermitian. -/
+theorem firstSiteMatrix_isHermitian {P : Matrix (Fin d) (Fin d) ℂ}
+    (hP : P.IsHermitian) (N : ℕ) : (firstSiteMatrix P N).IsHermitian := by
+  refine Matrix.ext fun σ τ => ?_
+  simp only [Matrix.conjTranspose_apply, firstSiteMatrix]
+  by_cases h : σ ∘ Fin.succ = τ ∘ Fin.succ
+  · rw [if_pos h, if_pos h.symm, mul_one, mul_one]
+    exact hP.apply _ _
+  · rw [if_neg h, if_neg fun hh => h hh.symm, mul_zero, mul_zero, star_zero]
+
+/-- Reindex a sum over an $(N+1)$-site configuration by its first value and
+its remaining $N$ values. -/
+theorem sum_fin_succ_eq_sum_cons {β : Type*} [AddCommMonoid β] {N : ℕ}
+    (F : (Fin (N + 1) → Fin d) → β) :
+    ∑ σ : Fin (N + 1) → Fin d, F σ =
+      ∑ i : Fin d, ∑ ρ : Fin N → Fin d, F (Fin.cons i ρ) := by
+  rw [← Fintype.sum_prod_type']
+  exact ((Fin.consEquiv fun _ : Fin (N + 1) => Fin d).sum_comp F).symm
+
+/-- Left multiplication by the first-spin action, entrywise:
+$(P_1G)_{\sigma\tau}=\sum_iP_{\sigma_0i}G_{(i,\sigma'),\tau}$, where
+$\sigma'$ is the tail of $\sigma$. -/
+theorem firstSiteMatrix_mul_apply (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
+    (G : Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ)
+    (σ τ : Fin (N + 1) → Fin d) :
+    (firstSiteMatrix P N * G) σ τ =
+      ∑ i : Fin d, P (σ 0) i * G (Fin.cons i (σ ∘ Fin.succ)) τ := by
+  rw [Matrix.mul_apply, sum_fin_succ_eq_sum_cons]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  simp only [firstSiteMatrix, Fin.cons_zero, Function.comp_def, Fin.cons_succ]
+  rw [Fintype.sum_eq_single (fun n : Fin N => σ (Fin.succ n))]
+  · rw [if_pos rfl, mul_one]
+  · intro ρ hρ
+    rw [if_neg fun hh => hρ hh.symm, mul_zero, zero_mul]
+
+/-- Right multiplication by the first-spin action, entrywise:
+$(GP_1)_{\sigma\tau}=\sum_jG_{\sigma,(j,\tau')}P_{j\tau_0}$, where
+$\tau'$ is the tail of $\tau$. -/
+theorem mul_firstSiteMatrix_apply (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
+    (G : Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ)
+    (σ τ : Fin (N + 1) → Fin d) :
+    (G * firstSiteMatrix P N) σ τ =
+      ∑ j : Fin d, G σ (Fin.cons j (τ ∘ Fin.succ)) * P j (τ 0) := by
+  rw [Matrix.mul_apply, sum_fin_succ_eq_sum_cons]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  simp only [firstSiteMatrix, Fin.cons_zero, Function.comp_def, Fin.cons_succ]
+  rw [Fintype.sum_eq_single (fun n : Fin N => τ (Fin.succ n))]
+  · rw [if_pos rfl, mul_one]
+  · intro ρ hρ
+    rw [if_neg hρ, mul_zero, mul_zero]
+
+/-- First-site actions compose site by site:
+$P_1Q_1 = (PQ)_1$ on an $(N+1)$-site chain. -/
+theorem firstSiteMatrix_mul_firstSiteMatrix
+    (P Q : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
+    firstSiteMatrix P N * firstSiteMatrix Q N = firstSiteMatrix (P * Q) N := by
+  refine Matrix.ext fun σ τ => ?_
+  rw [firstSiteMatrix_mul_apply]
+  have hcons : ∀ i : Fin d,
+      (Fin.cons i (σ ∘ Fin.succ) : Fin (N + 1) → Fin d) ∘ Fin.succ =
+        σ ∘ Fin.succ := by
+    intro i
+    funext n
+    simp [Fin.cons_succ]
+  by_cases hcond : σ ∘ Fin.succ = τ ∘ Fin.succ
+  · simp only [firstSiteMatrix, Fin.cons_zero, hcons, if_pos hcond, mul_one,
+      Matrix.mul_apply]
+  · simp only [firstSiteMatrix, Fin.cons_zero, hcons, if_neg hcond, mul_zero,
+      Finset.sum_const_zero]
+
+/-- Move a finite scalar-weighted sum inside a trace pairing. -/
+theorem sum_mul_trace_eq_trace_sum_smul (c : Fin d → ℂ)
+    (B : Fin d → Matrix (Fin D) (Fin D) ℂ) (W : Matrix (Fin D) (Fin D) ℂ) :
+    ∑ i : Fin d, c i * Matrix.trace (B i * W) =
+      Matrix.trace ((∑ i : Fin d, c i • B i) * W) := by
+  rw [Finset.sum_mul, Matrix.trace_sum]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.MPDO.FirstSite
 import TNLean.MPS.MPDO.HorizontalCFMPVRepresentation
 import TNLean.MPS.MPDO.PerCopyHorizontalCF
-import TNLean.Algebra.TracePairing
 
 /-!
 # One-sided invariant matrices for matrix product density operators
@@ -62,29 +62,6 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- The vertically viewed product $P\widetilde M$.  Viewing the MPO tensor as
-the family of physical-space operators $(\widetilde M_{ab})_{ij}=M^{ij}_{ab}$
-indexed by the virtual indices, multiply each operator by `P` on the left:
-$(P\widetilde M)^{ij}=\sum_kP_{ik}M^{kj}$.
-
-The invariant-projection step in the proof of Proposition 4.13 of
-arXiv:1606.00608, lines 1874--1887, considers an orthogonal projector $P$ with
-$P\widetilde M=P\widetilde M P$ in this sense. -/
-noncomputable def ketLeftMul (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) :
-    MPOTensor d D :=
-  fun i j => ∑ k : Fin d, P i k • M k j
-
-/-- The vertically viewed product $\widetilde M P$: multiply each
-physical-space operator $\widetilde M_{ab}$ by `P` on the right,
-$(\widetilde M P)^{ij}=\sum_kP_{kj}M^{ik}$.
-
-Together with `ketLeftMul` this expresses the hypothesis
-$P\widetilde M=P\widetilde M P$ in the proof of Proposition 4.13 of
-arXiv:1606.00608, lines 1874--1887. -/
-noncomputable def braRightMul (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ) :
-    MPOTensor d D :=
-  fun i j => ∑ k : Fin d, P k j • M i k
-
 /-- The letters of $P\widetilde M$ are the letters of $\widetilde M$
 multiplied by `P` on the left.  This identifies the one-site action
 `ketLeftMul` with left multiplication on the vertically viewed tensor of
@@ -105,125 +82,6 @@ theorem verticalTensor_braRightMul (M : MPOTensor d D)
   ext i j
   simp [verticalTensor, braRightMul, Matrix.mul_apply, Matrix.sum_apply,
     mul_comm]
-
-/-- Splitting off the first site of a density-operator entry:
-$H^{(N+1)}_{(i,\sigma),(j,\tau)}
-=\tr(M^{ij}M^{\sigma_0\tau_0}\cdots M^{\sigma_{N-1}\tau_{N-1}})$. -/
-theorem mpo_cons_cons (M : MPOTensor d D) {N : ℕ} (i j : Fin d)
-    (σ τ : Fin N → Fin d) :
-    mpo M (N + 1) (Fin.cons i σ) (Fin.cons j τ) =
-      Matrix.trace (M i j * evalWord M (List.ofFn σ) (List.ofFn τ)) := by
-  simp only [mpo_apply, mpoMatrixEntry]
-  congr 1
-  rw [List.ofFn_succ, List.ofFn_succ]
-  simp only [Fin.cons_zero, Fin.cons_succ, evalWord_cons]
-
-/-- The one-site matrix `P` acting on the first spin of an $(N+1)$-site chain,
-$P_1=P\otimes\Id^{\otimes N}$.  The products $P_1H^{(N+1)}$,
-$P_1H^{(N+1)}P_1$, and $H^{(N+1)}P_1$ in the displayed chain
-eq1:proof.IV.12 of arXiv:1606.00608, lines 1874--1887, are formed with this
-operator. -/
-noncomputable def firstSiteMatrix (P : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
-    Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ :=
-  fun σ τ => P (σ 0) (τ 0) * (if σ ∘ Fin.succ = τ ∘ Fin.succ then 1 else 0)
-
-/-- Acting by the identity on the first site gives the identity on the full
-chain. -/
-@[simp] theorem firstSiteMatrix_one (N : ℕ) :
-    firstSiteMatrix (1 : Matrix (Fin d) (Fin d) ℂ) N = 1 := by
-  ext σ τ
-  by_cases hστ : σ = τ
-  · subst τ
-    simp [firstSiteMatrix]
-  · have hne : σ 0 ≠ τ 0 ∨ σ ∘ Fin.succ ≠ τ ∘ Fin.succ := by
-      by_contra h
-      push Not at h
-      apply hστ
-      funext i
-      refine Fin.cases h.1 (fun j ↦ ?_) i
-      exact congrFun h.2 j
-    rcases hne with hhead | htail
-    · simp [firstSiteMatrix, hστ, hhead]
-    · simp [firstSiteMatrix, Matrix.one_apply, hστ, htail]
-
-/-- The first-spin action of a Hermitian matrix is Hermitian. -/
-theorem firstSiteMatrix_isHermitian {P : Matrix (Fin d) (Fin d) ℂ}
-    (hP : P.IsHermitian) (N : ℕ) : (firstSiteMatrix P N).IsHermitian := by
-  refine Matrix.ext fun σ τ => ?_
-  simp only [Matrix.conjTranspose_apply, firstSiteMatrix]
-  by_cases h : σ ∘ Fin.succ = τ ∘ Fin.succ
-  · rw [if_pos h, if_pos h.symm, mul_one, mul_one]
-    exact hP.apply _ _
-  · rw [if_neg h, if_neg fun hh => h hh.symm, mul_zero, mul_zero, star_zero]
-
-/-- Reindex a sum over an $(N+1)$-site configuration by its first value and
-its remaining $N$ values. -/
-theorem sum_fin_succ_eq_sum_cons {β : Type*} [AddCommMonoid β] {N : ℕ}
-    (F : (Fin (N + 1) → Fin d) → β) :
-    ∑ σ : Fin (N + 1) → Fin d, F σ =
-      ∑ i : Fin d, ∑ ρ : Fin N → Fin d, F (Fin.cons i ρ) := by
-  rw [← Fintype.sum_prod_type']
-  exact ((Fin.consEquiv fun _ : Fin (N + 1) => Fin d).sum_comp F).symm
-
-/-- Left multiplication by the first-spin action, entrywise:
-$(P_1G)_{\sigma\tau}=\sum_iP_{\sigma_0i}G_{(i,\sigma'),\tau}$, where
-$\sigma'$ is the tail of $\sigma$. -/
-theorem firstSiteMatrix_mul_apply (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
-    (G : Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ)
-    (σ τ : Fin (N + 1) → Fin d) :
-    (firstSiteMatrix P N * G) σ τ =
-      ∑ i : Fin d, P (σ 0) i * G (Fin.cons i (σ ∘ Fin.succ)) τ := by
-  rw [Matrix.mul_apply, sum_fin_succ_eq_sum_cons]
-  refine Finset.sum_congr rfl fun i _ => ?_
-  simp only [firstSiteMatrix, Fin.cons_zero, Function.comp_def, Fin.cons_succ]
-  rw [Fintype.sum_eq_single (fun n : Fin N => σ (Fin.succ n))]
-  · rw [if_pos rfl, mul_one]
-  · intro ρ hρ
-    rw [if_neg fun hh => hρ hh.symm, mul_zero, zero_mul]
-
-/-- Right multiplication by the first-spin action, entrywise:
-$(GP_1)_{\sigma\tau}=\sum_jG_{\sigma,(j,\tau')}P_{j\tau_0}$, where
-$\tau'$ is the tail of $\tau$. -/
-theorem mul_firstSiteMatrix_apply (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ}
-    (G : Matrix (Fin (N + 1) → Fin d) (Fin (N + 1) → Fin d) ℂ)
-    (σ τ : Fin (N + 1) → Fin d) :
-    (G * firstSiteMatrix P N) σ τ =
-      ∑ j : Fin d, G σ (Fin.cons j (τ ∘ Fin.succ)) * P j (τ 0) := by
-  rw [Matrix.mul_apply, sum_fin_succ_eq_sum_cons]
-  refine Finset.sum_congr rfl fun j _ => ?_
-  simp only [firstSiteMatrix, Fin.cons_zero, Function.comp_def, Fin.cons_succ]
-  rw [Fintype.sum_eq_single (fun n : Fin N => τ (Fin.succ n))]
-  · rw [if_pos rfl, mul_one]
-  · intro ρ hρ
-    rw [if_neg hρ, mul_zero, mul_zero]
-
-/-- First-site actions compose site by site:
-$P_1Q_1 = (PQ)_1$ on an $(N+1)$-site chain. -/
-theorem firstSiteMatrix_mul_firstSiteMatrix
-    (P Q : Matrix (Fin d) (Fin d) ℂ) (N : ℕ) :
-    firstSiteMatrix P N * firstSiteMatrix Q N = firstSiteMatrix (P * Q) N := by
-  refine Matrix.ext fun σ τ => ?_
-  rw [firstSiteMatrix_mul_apply]
-  have hcons : ∀ i : Fin d,
-      (Fin.cons i (σ ∘ Fin.succ) : Fin (N + 1) → Fin d) ∘ Fin.succ =
-        σ ∘ Fin.succ := by
-    intro i
-    funext n
-    simp [Fin.cons_succ]
-  by_cases hcond : σ ∘ Fin.succ = τ ∘ Fin.succ
-  · simp only [firstSiteMatrix, Fin.cons_zero, hcons, if_pos hcond, mul_one,
-      Matrix.mul_apply]
-  · simp only [firstSiteMatrix, Fin.cons_zero, hcons, if_neg hcond, mul_zero,
-      Finset.sum_const_zero]
-
-/-- Move a finite scalar-weighted sum inside a trace pairing. -/
-theorem sum_mul_trace_eq_trace_sum_smul (c : Fin d → ℂ)
-    (B : Fin d → Matrix (Fin D) (Fin D) ℂ) (W : Matrix (Fin D) (Fin D) ℂ) :
-    ∑ i : Fin d, c i * Matrix.trace (B i * W) =
-      Matrix.trace ((∑ i : Fin d, c i • B i) * W) := by
-  rw [Finset.sum_mul, Matrix.trace_sum]
-  refine Finset.sum_congr rfl fun i _ => ?_
-  rw [Matrix.smul_mul, Matrix.trace_smul, smul_eq_mul]
 
 /-- If the vertically viewed tensor satisfies $P\widetilde M=P\widetilde M P$,
 then for every tail length $N$ the density operator satisfies

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -31,14 +31,6 @@ tensor in literal horizontal canonical form, one noncommuting length suffices
 for the periodic-sector contradiction, so the stronger all-length condition is
 not required.
 
-## Main definitions
-
-* `ketLeftMul` and `braRightMul`: the vertically viewed products
-  $P\widetilde M$ and $\widetilde M P$.
-* `firstSiteMatrix`: the operator $P\otimes\Id^{\otimes N}$ on an
-  $(N+1)$-site chain; these operators compose site by site,
-  $P_1Q_1=(PQ)_1$.
-
 ## Main results
 
 * `firstSiteMatrix_mul_mpo_of_ketLeftMul_invariant`: one-sided tensor

--- a/TNLean/MPS/MPDO/LocalOrthogonalSumAreaLaw.lean
+++ b/TNLean/MPS/MPDO/LocalOrthogonalSumAreaLaw.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.EntropyDecomposition
+import TNLean.Algebra.HermitianHelpers
 import TNLean.MPS.MPDO.AreaLaw
-import TNLean.MPS.MPDO.InvariantProjection
+import TNLean.MPS.MPDO.FirstSite
 
 /-!
 # Saturated area law for local orthogonal sums

--- a/TNLean/MPS/MPDO/SectorTrace.lean
+++ b/TNLean/MPS/MPDO/SectorTrace.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.LinearAlgebra.Trace
-import TNLean.MPS.MPDO.InvariantProjection
+import TNLean.Algebra.ListProduct
+import TNLean.MPS.MPDO.FirstSite
+import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.ZCL
 
 /-!
@@ -192,29 +194,9 @@ along the horizontal bond. -/
 theorem sum_evalWord_diag_eq_verticalLoop_pow (M : MPOTensor d D) (N : ℕ) :
     ∑ σ : Fin N → Fin d, evalWord M (List.ofFn σ) (List.ofFn σ) =
       verticalLoop M ^ N := by
-  induction N with
-  | zero =>
-      simp only [pow_zero, Fintype.sum_unique, List.ofFn_zero, evalWord_nil]
-  | succ N ih =>
-      rw [sum_fin_succ_eq_sum_cons
-        (fun σ : Fin (N + 1) → Fin d => evalWord M (List.ofFn σ) (List.ofFn σ))]
-      have hof : ∀ (a : Fin d) (ρ : Fin N → Fin d),
-          List.ofFn (Fin.cons a ρ : Fin (N + 1) → Fin d) = a :: List.ofFn ρ := by
-        intro a ρ
-        simp [List.ofFn_succ, Fin.cons_zero, Fin.cons_succ]
-      calc
-        ∑ a : Fin d, ∑ ρ : Fin N → Fin d,
-            evalWord M (List.ofFn (Fin.cons a ρ)) (List.ofFn (Fin.cons a ρ))
-            = ∑ a : Fin d, ∑ ρ : Fin N → Fin d,
-                M a a * evalWord M (List.ofFn ρ) (List.ofFn ρ) := by
-              refine Finset.sum_congr rfl fun a _ => Finset.sum_congr rfl fun ρ _ => ?_
-              rw [hof a ρ, evalWord_cons]
-        _ = (∑ a : Fin d, M a a) *
-              ∑ ρ : Fin N → Fin d, evalWord M (List.ofFn ρ) (List.ofFn ρ) :=
-              (Finset.sum_mul_sum _ _ _ _).symm
-        _ = verticalLoop M ^ (N + 1) := by
-              rw [ih, pow_succ']
-              rfl
+  rw [verticalLoop, physTraceTransfer, ← List.prod_replicate,
+    ← List.ofFn_const, List.prod_ofFn_sum]
+  exact Finset.sum_congr rfl fun σ _ => evalWord_ofFn M σ σ
 
 /-- **The trace of the density operator is a chain of vertical loops:**
 $\tr H^{(N)} = \tr(E^N)$ with `E` the single-site vertical loop.  This is the

--- a/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorDensityBlocks.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.DirectSumBlockRetraction
-import TNLean.MPS.MPDO.VerticalSectorGeneration
+import TNLean.MPS.MPDO.VerticalSectorFixedPointProductSpan
 
 /-!
 # Product spans of density-weighted fixed points

--- a/TNLean/MPS/MPDO/VerticalSectorFixedPointProductSpan.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorFixedPointProductSpan.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorRetractions
+import Mathlib.LinearAlgebra.FixedSubmodule
+
+/-!
+# Product spans of fixed points on vertical-sector algebras
+
+This file defines the span of pointwise products of fixed points of a linear
+endomorphism on a direct product of matrix algebras.
+
+## Main declarations
+
+* `MPOTensor.fixedPointProductSpan`: the span of fixed-point products of a
+  prescribed length.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 1980--1993.
+-/
+
+open scoped Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- The span of all $L$-fold products of fixed points of a linear
+endomorphism of the vertical-sector algebra.
+
+This is the space denoted by $C_L(\mathcal F)$ in the dimension argument of the
+general MPDO renormalization fixed-point theorem.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
+def fixedPointProductSpan
+    {g : ℕ} {dim : Fin g → ℕ} (L : ℕ)
+    (F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim) :
+    Submodule ℂ (VerticalSectorAlgebra dim) :=
+  Submodule.span ℂ (Set.range fun X : Fin L → F.fixedSubmodule =>
+    fun α => (List.ofFn fun t => (X t : VerticalSectorAlgebra dim) α).prod)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorGeneration.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.SourceBNTBlocking
 import TNLean.MPS.MPDO.VerticalSectorCoordinates
-import Mathlib.LinearAlgebra.FixedSubmodule
+import TNLean.MPS.MPDO.VerticalSectorFixedPointProductSpan
 
 /-!
 # Generation of vertical BNT sector algebras
@@ -227,20 +227,6 @@ theorem one_mem_product_span_of_weightedVerticalBondContractions
       rfl
   rw [← hRange]
   exact hOneRaw
-
-/-- The span of all $L$-fold products of fixed points of a linear
-endomorphism of the vertical-sector algebra.
-
-This is the space denoted by $C_L(\mathcal F)$ in the dimension argument of the
-general MPDO renormalization fixed-point theorem.
-
-Source: arXiv:1606.00608, Appendix C.4, lines 1980--1993. -/
-def fixedPointProductSpan
-    {g : ℕ} {dim : Fin g → ℕ} (L : ℕ)
-    (F : VerticalSectorAlgebra dim →ₗ[ℂ] VerticalSectorAlgebra dim) :
-    Submodule ℂ (VerticalSectorAlgebra dim) :=
-  Submodule.span ℂ (Set.range fun X : Fin L → F.fixedSubmodule =>
-    fun α => (List.ofFn fun t => (X t : VerticalSectorAlgebra dim) α).prod)
 
 /-- Sectorwise multiplication by nonzero scalars is a linear equivalence of
 the direct product of the BNT matrix algebras. -/


### PR DESCRIPTION
### Motivation

Several MPDO/periodic modules showed pathological build times during a full local build. Process inspection showed that the original 500–1,000 second observations were inflated by a concurrent full build, but profiling also found two real structural causes: low-level definitions hidden behind very broad imports, and repeated dependent-index expansion in the triple-fusion proofs.

### Description

This batches three bisectable compilation-performance refactors:

- move dependency-light first-site primitives into `FirstSite`, leaving `VerticalCF` bridges in `InvariantProjection`;
- move `fixedPointProductSpan` into a lightweight vertical-sector module so density-block consumers do not import the full generation tower;
- share the dependent block-diagonal scalar-entry expansion used by the BNT triple-fusion final-sector proofs.

Public declaration names and theorem signatures are preserved.

### Measured impact

In the integrated full build:

| Module | Earlier observed wall time* | This branch |
| --- | ---: | ---: |
| `MPDO.SectorTrace` | 852s | 20s |
| `MPDO.SourceZCLMarginal` | 1,051s | 15s |
| `MPDO.ThermodynamicLimitCounterexample` | 1,077s | 17s |
| `MPDO.ActiveSectorSpanningAreaLaw` | 859s | 15s |
| `MPDO.LocalOrthogonalSumAreaLaw` | 560s | 17s |
| `MPDO.VerticalSectorDensityBlocks` | 561s | 28s |
| `MPDO.VerticalSectorInvertibility` | 1,059s | 28s |
| `Periodic.Overlap` | 721s | 26s |
| `MPDO.BNTTripleFusionSeparation` | 831s | 98s; 50s on the warm incremental rebuild |

*The earlier wall times were recorded while another full `lake build` and unrelated TeX/test workloads were active, so they are diagnostic observations rather than clean benchmarks.

Isolated profiler comparisons:

- `SectorTrace`: imports 302s -> 9.27s; CPU 50.37s -> 8.31s.
- `BNTTripleFusionSeparation`: user CPU 37.99s -> 19.65s; `simp` 14.9s -> 4.8s; typeclass synthesis 23.7s -> 12.5s.
- `VerticalSectorDensityBlocks` static TNLean closure: 321 -> 63 modules.

### Validation

- exact direct Lean checks for all eight affected module boundaries
- combined `lake build`: 9,745 jobs, success
- post-linter-cleanup incremental `lake build`: 9,745 jobs, success
- import aggregator generation check and all nine import-aggregator regression tests
- Blueprint/Lean sync generation and CI check
- `lake exe checkdecls blueprint/lean_decls`
- proof-integrity grep and `git diff --check`

The full build still identifies additional independent hotspots (notably `Algebra.SpinCover`, examples, and channel/PEPS modules); those are intentionally left for a follow-up measured batch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical module splits and proof refactors with unchanged APIs; no auth, runtime, or data-path changes—risk is limited to accidental proof/import regressions, which the PR’s build checks target.
> 
> **Overview**
> This PR is a **compilation-performance refactor** that preserves public declaration names and theorem signatures while shrinking what heavy MPDO modules pull in at build time.
> 
> **New modules:** `FirstSite` holds first-site MPO actions (`ketLeftMul`, `braRightMul`, `firstSiteMatrix`, and their lemmas) previously living in `InvariantProjection`. `VerticalSectorFixedPointProductSpan` defines only `fixedPointProductSpan`, so density-block code no longer imports the full vertical-sector generation tower.
> 
> **Import rewiring:** `InvariantProjection` keeps invariant-projection theorems but imports `FirstSite`. `SectorTrace`, `LocalOrthogonalSumAreaLaw`, and related consumers import `FirstSite` directly instead of the heavier `InvariantProjection` chain. `VerticalSectorDensityBlocks` now depends on `VerticalSectorFixedPointProductSpan` rather than `VerticalSectorGeneration`. The `MPDO` aggregator registers the two new modules.
> 
> **Proof cleanup:** In `BNTTripleFusionSeparation`, a shared lemma `sum_sum_smul_blockDiagonal'_one_kronecker` replaces repeated dependent `ext`/`simp` on block-diagonal sums, and `tripleFusionComparison_final_entry_intertwines_of_lengthIndependent` centralizes final-entry intertwining used in off-diagonal and Kronecker-form arguments. `SectorTrace.sum_evalWord_diag_eq_verticalLoop_pow` is shortened via `ListProduct` utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdfb8de10397be2f88391ba001e40d151b859848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->