### PR TITLE
chore(build): add local Lake build reuse tools

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -364,6 +364,7 @@ jobs:
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |
+          set -o pipefail
           timing_status=0
           git fetch --no-tags origin \
             "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" \
@@ -373,6 +374,20 @@ jobs:
               --merge-base --name-only --diff-filter=AMR "$BASE_REF" -- '*.lean' \
               > "$RUNNER_TEMP/changed-lean-files.txt" \
               || timing_status=$?
+          fi
+          if [ "$timing_status" -eq 0 ]; then
+            while IFS= read -r path; do
+              case "$path" in
+                TNLean/Archive/*.lean)
+                  module="${path%.lean}"
+                  module="${module//\//.}"
+                  lake build "$module" 2>&1 \
+                    | tee -a "$RUNNER_TEMP/lake-build.log" \
+                    || timing_status=$?
+                  ;;
+              esac
+              [ "$timing_status" -eq 0 ] || break
+            done < "$RUNNER_TEMP/changed-lean-files.txt"
           fi
           if [ "$timing_status" -eq 0 ]; then
             python3 scripts/lake_build_hotspots.py \

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -317,7 +317,7 @@ jobs:
   build:
     needs: changes
     outputs:
-      compilation-time-result: ${{ steps.compilation-time.outcome }}
+      compilation-time-result: ${{ steps.compilation-time.outputs.result }}
     if: |
       !cancelled() && (
         github.event_name != 'pull_request' ||
@@ -355,17 +355,30 @@ jobs:
       - name: Check changed Lean compilation times
         id: compilation-time
         if: github.event_name == 'pull_request'
-        continue-on-error: true
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |
+          timing_status=0
           git fetch --no-tags origin \
-            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
-          git diff --merge-base --name-only --diff-filter=AMR "$BASE_REF" -- '*.lean' \
-            > "$RUNNER_TEMP/changed-lean-files.txt"
-          python3 scripts/lake_build_hotspots.py \
-            "$RUNNER_TEMP/lake-build.log" \
-            --changed-files-from "$RUNNER_TEMP/changed-lean-files.txt"
+            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" \
+            || timing_status=$?
+          if [ "$timing_status" -eq 0 ]; then
+            git diff --merge-base --name-only --diff-filter=AMR "$BASE_REF" -- '*.lean' \
+              > "$RUNNER_TEMP/changed-lean-files.txt" \
+              || timing_status=$?
+          fi
+          if [ "$timing_status" -eq 0 ]; then
+            python3 scripts/lake_build_hotspots.py \
+              "$RUNNER_TEMP/lake-build.log" \
+              --changed-files-from "$RUNNER_TEMP/changed-lean-files.txt" \
+              || timing_status=$?
+          fi
+          case "$timing_status" in
+            0) result=success ;;
+            50) result=limit ;;
+            *) result=error ;;
+          esac
+          echo "result=$result" >> "$GITHUB_OUTPUT"
 
       - name: Run text-based style linter
         run: lake exe lint_style --github
@@ -392,10 +405,17 @@ jobs:
         env:
           TIMING_RESULT: ${{ needs.build.outputs.compilation-time-result }}
         run: |
-          if [ "$TIMING_RESULT" != "success" ]; then
-            echo "::error::A changed Lean module reached the 50-second compilation limit"
-            exit 1
-          fi
+          case "$TIMING_RESULT" in
+            success) ;;
+            limit)
+              echo "::error::A changed Lean module reached the 50-second compilation limit"
+              exit 1
+              ;;
+            *)
+              echo "::error::The changed-module compilation-time checker failed"
+              exit 1
+              ;;
+          esac
 
   file-length:
     name: Check Lean module policies

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -22,6 +22,8 @@ on:
       - 'scripts/check_oversized_lean_files.py'
       - 'scripts/lean_import_syntax.py'
       - 'scripts/test_lean_file_policies.py'
+      - 'scripts/lake_build_hotspots.py'
+      - 'scripts/test_lake_build_hotspots.py'
       - 'docs/ci-automation.md'
       - 'docs/CONTRIBUTING.md'
       - '.github/workflows/pr-ci.yml'
@@ -78,6 +80,8 @@ on:
       - 'scripts/check_oversized_lean_files.py'
       - 'scripts/lean_import_syntax.py'
       - 'scripts/test_lean_file_policies.py'
+      - 'scripts/lake_build_hotspots.py'
+      - 'scripts/test_lake_build_hotspots.py'
       - 'docs/ci-automation.md'
       - 'docs/CONTRIBUTING.md'
       - '.github/workflows/pr-ci.yml'
@@ -166,6 +170,8 @@ jobs:
               - 'lake-manifest.json'
               - 'scripts/LintStyle.lean'
               - 'scripts/nolints-style.txt'
+              - 'scripts/lake_build_hotspots.py'
+              - 'scripts/test_lake_build_hotspots.py'
             module_policy:
               - 'scripts/check_numbered_lean_files.py'
               - 'scripts/check_oversized_lean_files.py'
@@ -320,6 +326,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Restore Lean build cache
         uses: actions/cache/restore@v4
@@ -331,7 +339,29 @@ jobs:
 
       - uses: leanprover/lean-action@v1
         with:
+          build: false
           use-github-cache: false
+
+      - name: Build Lean project and capture timings
+        run: |
+          set -o pipefail
+          lake build 2>&1 | tee "$RUNNER_TEMP/lake-build.log"
+
+      - name: Check changed Lean compilation times
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch --no-tags origin \
+            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
+          git diff --merge-base --name-only --diff-filter=AMR "$BASE_REF" -- '*.lean' \
+            > "$RUNNER_TEMP/changed-lean-files.txt"
+          python3 scripts/lake_build_hotspots.py \
+            "$RUNNER_TEMP/lake-build.log" \
+            --changed-files-from "$RUNNER_TEMP/changed-lean-files.txt"
+
+      - name: Test Lean compilation-time checker
+        run: python3 scripts/test_lake_build_hotspots.py
 
       - name: Run text-based style linter
         run: lake exe lint_style --github

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -480,7 +480,9 @@ jobs:
         run: python3 scripts/test_lake_build_hotspots.py
 
       - name: Check local cache-seeding shell syntax
-        run: bash -n scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh
+        run: |
+          bash -n scripts/seed_lake_build.sh
+          bash -n scripts/test_seed_lake_build.sh
 
       # Ordinary Lean modules over 1000 lines fail. The exact root aggregator
       # exemption is accepted only while its uncommented content is import-only.

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -380,6 +380,8 @@ jobs:
           if [ "$timing_status" -eq 0 ]; then
             while IFS= read -r path; do
               case "$path" in
+                # Keep this aligned with EXCLUDED_TOP_LEVEL_DIRECTORIES in
+                # scripts/generate_import_aggregators.py.
                 TNLean/Archive/*.lean)
                   module="${path%.lean}"
                   module="${module//\//.}"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -362,13 +362,14 @@ jobs:
         id: compilation-time
         if: github.event_name == 'pull_request'
         env:
+          BASE_REF_NAME: ${{ github.event.pull_request.base.ref }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |
           set -o pipefail
           timing_status=0
           archive_build_failed=false
           git fetch --no-tags origin \
-            "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" \
+            "+refs/heads/$BASE_REF_NAME:refs/remotes/origin/$BASE_REF_NAME" \
             || timing_status=$?
           if [ "$timing_status" -eq 0 ]; then
             git -c core.quotePath=false diff \

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -366,6 +366,7 @@ jobs:
         run: |
           set -o pipefail
           timing_status=0
+          archive_build_failed=false
           git fetch --no-tags origin \
             "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" \
             || timing_status=$?
@@ -383,7 +384,10 @@ jobs:
                   module="${module//\//.}"
                   lake build "$module" 2>&1 \
                     | tee -a "$RUNNER_TEMP/lake-build.log" \
-                    || timing_status=$?
+                    || {
+                      timing_status=$?
+                      archive_build_failed=true
+                    }
                   ;;
               esac
               [ "$timing_status" -eq 0 ] || break
@@ -401,6 +405,9 @@ jobs:
             *) result=error ;;
           esac
           echo "result=$result" >> "$GITHUB_OUTPUT"
+          if [ "$archive_build_failed" = true ]; then
+            exit 1
+          fi
 
       - name: Run text-based style linter
         run: lake exe lint_style --github

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -346,8 +346,11 @@ jobs:
 
       - name: Build Lean project and capture timings
         run: |
-          set -o pipefail
-          lake build 2>&1 | tee "$RUNNER_TEMP/lake-build.log"
+          set -eo pipefail
+          {
+            lake build
+            lake build lint_style
+          } 2>&1 | tee "$RUNNER_TEMP/lake-build.log"
 
       - name: Check changed Lean compilation times
         id: compilation-time

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -170,13 +170,13 @@ jobs:
               - 'lake-manifest.json'
               - 'scripts/LintStyle.lean'
               - 'scripts/nolints-style.txt'
-              - 'scripts/lake_build_hotspots.py'
-              - 'scripts/test_lake_build_hotspots.py'
             module_policy:
               - 'scripts/check_numbered_lean_files.py'
               - 'scripts/check_oversized_lean_files.py'
               - 'scripts/lean_import_syntax.py'
               - 'scripts/test_lean_file_policies.py'
+              - 'scripts/lake_build_hotspots.py'
+              - 'scripts/test_lake_build_hotspots.py'
               - 'docs/ci-automation.md'
               - 'docs/CONTRIBUTING.md'
             blueprint:
@@ -316,6 +316,8 @@ jobs:
 
   build:
     needs: changes
+    outputs:
+      compilation-time-result: ${{ steps.compilation-time.outcome }}
     if: |
       !cancelled() && (
         github.event_name != 'pull_request' ||
@@ -348,7 +350,9 @@ jobs:
           lake build 2>&1 | tee "$RUNNER_TEMP/lake-build.log"
 
       - name: Check changed Lean compilation times
+        id: compilation-time
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: |
@@ -359,9 +363,6 @@ jobs:
           python3 scripts/lake_build_hotspots.py \
             "$RUNNER_TEMP/lake-build.log" \
             --changed-files-from "$RUNNER_TEMP/changed-lean-files.txt"
-
-      - name: Test Lean compilation-time checker
-        run: python3 scripts/test_lake_build_hotspots.py
 
       - name: Run text-based style linter
         run: lake exe lint_style --github
@@ -374,6 +375,24 @@ jobs:
         with:
           path: ${{ env.BUILD_CACHE_PATHS }}
           key: tnlean-build-${{ hashFiles('lean-toolchain', 'lake-manifest.json', 'lakefile.toml') }}-${{ github.sha }}
+
+  compile-time:
+    name: Check changed Lean compilation times
+    needs: [changes, build]
+    if: |
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce changed-module timing limit
+        env:
+          TIMING_RESULT: ${{ needs.build.outputs.compilation-time-result }}
+        run: |
+          if [ "$TIMING_RESULT" != "success" ]; then
+            echo "::error::A changed Lean module reached the 50-second compilation limit"
+            exit 1
+          fi
 
   file-length:
     name: Check Lean module policies
@@ -401,6 +420,9 @@ jobs:
 
       - name: Test Lean module-policy checkers
         run: PYTHONPATH=scripts python3 scripts/test_lean_file_policies.py -v
+
+      - name: Test Lean compilation-time checker
+        run: python3 scripts/test_lake_build_hotspots.py
 
       # Ordinary Lean modules over 1000 lines fail. The exact root aggregator
       # exemption is accepted only while its uncommented content is import-only.

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -363,7 +363,8 @@ jobs:
             "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}" \
             || timing_status=$?
           if [ "$timing_status" -eq 0 ]; then
-            git diff --merge-base --name-only --diff-filter=AMR "$BASE_REF" -- '*.lean' \
+            git -c core.quotePath=false diff \
+              --merge-base --name-only --diff-filter=AMR "$BASE_REF" -- '*.lean' \
               > "$RUNNER_TEMP/changed-lean-files.txt" \
               || timing_status=$?
           fi

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -24,6 +24,8 @@ on:
       - 'scripts/test_lean_file_policies.py'
       - 'scripts/lake_build_hotspots.py'
       - 'scripts/test_lake_build_hotspots.py'
+      - 'scripts/seed_lake_build.sh'
+      - 'scripts/test_seed_lake_build.sh'
       - 'docs/ci-automation.md'
       - 'docs/CONTRIBUTING.md'
       - '.github/workflows/pr-ci.yml'
@@ -82,6 +84,8 @@ on:
       - 'scripts/test_lean_file_policies.py'
       - 'scripts/lake_build_hotspots.py'
       - 'scripts/test_lake_build_hotspots.py'
+      - 'scripts/seed_lake_build.sh'
+      - 'scripts/test_seed_lake_build.sh'
       - 'docs/ci-automation.md'
       - 'docs/CONTRIBUTING.md'
       - '.github/workflows/pr-ci.yml'
@@ -177,6 +181,8 @@ jobs:
               - 'scripts/test_lean_file_policies.py'
               - 'scripts/lake_build_hotspots.py'
               - 'scripts/test_lake_build_hotspots.py'
+              - 'scripts/seed_lake_build.sh'
+              - 'scripts/test_seed_lake_build.sh'
               - 'docs/ci-automation.md'
               - 'docs/CONTRIBUTING.md'
             blueprint:
@@ -447,6 +453,9 @@ jobs:
 
       - name: Test Lean compilation-time checker
         run: python3 scripts/test_lake_build_hotspots.py
+
+      - name: Check local cache-seeding shell syntax
+        run: bash -n scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh
 
       # Ordinary Lean modules over 1000 lines fail. The exact root aggregator
       # exemption is accepted only while its uncommented content is import-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Detailed conventions live in `docs/`. Read the relevant file before working in t
 | [`docs/blueprint_style_guide.md`](docs/blueprint_style_guide.md) | LaTeX conventions, `\lean{}`/`\leanok` tags, notation table, `\uses` rules, blueprint build commands |
 | [`docs/prose_style.md`](docs/prose_style.md) | Prose conventions: no Lean jargon in the leanblueprint, banned software-engineering terms, banned LLM writing patterns (applies to `.tex` AND Lean docstrings/comments) |
 | [`docs/ci-automation.md`](docs/ci-automation.md) | CI workflows, auto-fix loops, iteration caps, commit message conventions |
+| [`docs/lake_build_cache.md`](docs/lake_build_cache.md) | Local Lake cache reuse and changed-module compilation-time limits |
 | [`docs/tactic_development.md`](docs/tactic_development.md) | Tactic self-improvement loop: detecting repeated proof patterns, promotion criteria, design rules for custom tactics/simp sets |
 | [`docs/tactic_patterns.md`](docs/tactic_patterns.md) | Living pattern ledger: promoted tactics, candidate patterns awaiting abstraction |
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -14,7 +14,7 @@ This repository uses [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
   - [CI Failure Auto-Fix](#ci-failure-auto-fix-auto-fixyml)
   - [Blueprint Auto-Fix](#blueprint-auto-fix-auto-fixyml)
   - [Lean Module Policy](#lean-module-policy-pr-ciyml-file-length-job)
-  - [Changed Lean Compilation-Time Gate](#changed-lean-compilation-time-gate-pr-ciyml-build-job)
+  - [Changed Lean Compilation-Time Gate](#changed-lean-compilation-time-gate-pr-ciyml)
   - [Lean Linter-Warning Sweep](#lean-linter-warning-sweep-housekeepingyml-linter-sweep-job)
   - [Lean Linter-Warning Auto-Fix](#lean-linter-warning-auto-fix-lean-linter-warning-autofixyml)
   - [Review Comment Auto-Fix](#review-comment-auto-fix-auto-fixyml)
@@ -169,14 +169,16 @@ Here is exactly what happens:
 
 ---
 
-### Changed Lean Compilation-Time Gate (`pr-ci.yml`, `build` job)
+### Changed Lean Compilation-Time Gate (`pr-ci.yml`)
 
 After `lake build`, PR CI parses the captured Lake job timings for changed
 `.lean` files. A changed module taking at least 25 seconds receives a GitHub
 warning annotation; a changed module taking at least 50 seconds receives an
-error annotation and fails the build job. Unchanged modules do not affect this
-PR ratchet. The local commands and cache-reuse procedure are documented in
-[`lake_build_cache.md`](lake_build_cache.md).
+error annotation and fails the separate `compile-time` job. Keeping the timing
+gate separate prevents a performance regression from invoking the Lean
+proof-error auto-fixer, which only handles failures of the `build` job.
+Unchanged modules do not affect this PR ratchet. The local commands and
+cache-reuse procedure are documented in [`lake_build_cache.md`](lake_build_cache.md).
 
 ---
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -83,7 +83,7 @@ When you push to a PR branch, several things happen in parallel:
   ├──┤                                                              │
   │  │  PR CI — build job                                           │
   │  │  Runs `lake build` to check that the code compiles.          │
-  │  │  Warns at 25s per changed Lean file; fails at 50s.           │
+  │  │  Separate `compile-time`: warn at 25s; fail at 50s.          │
   │  │                                                              │
   │  └───────────┬──────────────────────────────────────────────────┘
   │              │

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -14,6 +14,7 @@ This repository uses [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
   - [CI Failure Auto-Fix](#ci-failure-auto-fix-auto-fixyml)
   - [Blueprint Auto-Fix](#blueprint-auto-fix-auto-fixyml)
   - [Lean Module Policy](#lean-module-policy-pr-ciyml-file-length-job)
+  - [Changed Lean Compilation-Time Gate](#changed-lean-compilation-time-gate-pr-ciyml-build-job)
   - [Lean Linter-Warning Sweep](#lean-linter-warning-sweep-housekeepingyml-linter-sweep-job)
   - [Lean Linter-Warning Auto-Fix](#lean-linter-warning-auto-fix-lean-linter-warning-autofixyml)
   - [Review Comment Auto-Fix](#review-comment-auto-fix-auto-fixyml)
@@ -82,6 +83,7 @@ When you push to a PR branch, several things happen in parallel:
   ├──┤                                                              │
   │  │  PR CI — build job                                           │
   │  │  Runs `lake build` to check that the code compiles.          │
+  │  │  Warns at 25s per changed Lean file; fails at 50s.           │
   │  │                                                              │
   │  └───────────┬──────────────────────────────────────────────────┘
   │              │
@@ -164,6 +166,17 @@ Here is exactly what happens:
 **Thread management**: When triggered by a new push (`synchronize`), the review checks its own previous comments. If a previous bot comment has been addressed by the new commits, it resolves that thread automatically. It never resolves threads authored by humans.
 
 **Concurrency**: One review pipeline per PR at a time; later completions queue rather than cancel a review in progress.
+
+---
+
+### Changed Lean Compilation-Time Gate (`pr-ci.yml`, `build` job)
+
+After `lake build`, PR CI parses the captured Lake job timings for changed
+`.lean` files. A changed module taking at least 25 seconds receives a GitHub
+warning annotation; a changed module taking at least 50 seconds receives an
+error annotation and fails the build job. Unchanged modules do not affect this
+PR ratchet. The local commands and cache-reuse procedure are documented in
+[`lake_build_cache.md`](lake_build_cache.md).
 
 ---
 

--- a/docs/ci-automation.md
+++ b/docs/ci-automation.md
@@ -180,6 +180,12 @@ proof-error auto-fixer, which only handles failures of the `build` job.
 Unchanged modules do not affect this PR ratchet. The local commands and
 cache-reuse procedure are documented in [`lake_build_cache.md`](lake_build_cache.md).
 
+`TNLean/Archive/*.lean` is excluded from the default root target, so changed
+Archive modules are built explicitly before their timings are checked. A
+genuine Archive compilation error fails the `build` job and follows the normal
+Lean proof-error auto-fix path; a timing-only breach still fails only the
+separate `compile-time` job.
+
 ---
 
 ### Issue Automation (`issue-automation.yml`)

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -29,17 +29,21 @@ will reuse unchanged artifacts and rebuild files changed on the branch.
 
 ## Sort build timings
 
-Save a build log and list every job taking at least 50 seconds:
+Save a build log and list every job taking at least 25 seconds:
 
 ```bash
 lake build 2>&1 | tee /tmp/tnlean-build.log
 python3 scripts/lake_build_hotspots.py /tmp/tnlean-build.log
 ```
 
-The report is tab-separated and sorted from slowest to fastest. To make the
-same 50-second limit a local or CI gate, add `--fail-over-threshold`; use
-`--threshold` to override the limit. Timings are local diagnostic evidence,
-not benchmarks comparable across machines.
+The report is tab-separated and sorted from slowest to fastest. It exits
+unsuccessfully if any reported job takes at least 50 seconds. Use
+`--warn-threshold` and `--error-threshold` to override these limits.
+
+Pull-request CI applies the same policy only to changed Lean files: 25 seconds
+creates a warning annotation on the file, and 50 seconds fails the build job.
+Timings are local diagnostic evidence, not benchmarks comparable across
+machines.
 
 Lightweight tests do not run Lean:
 

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -23,11 +23,14 @@ directories, and an absent target `.lake`. Git dependency checkouts must be
 clean and at the revisions recorded in `lake-manifest.json`; nested Lake build
 directories must not be symlinks; and Mathlib's prebuilt `Mathlib.olean` must
 already be present. If it is missing, run `lake exe cache get` in the source
-worktree before seeding.
+worktree before seeding. The seed command also runs `lake exe cache get` itself
+to verify that the prebuilt artifacts match the current manifest revision.
 macOS `/bin/cp -c` creates independent writable files and fails instead of
 falling back to a full copy when APFS cloning is unavailable. The absolute path
 keeps Homebrew GNU coreutils from shadowing the APFS-aware command. Do not seed
-while the source worktree is running a Lake command.
+while the source worktree is running a Lake command. The target `.lake` is an
+inaccessible reservation until the completed clone is atomically swapped into
+place, so a target Lake process cannot observe a partial cache.
 
 After seeding, run the desired `lake build` or `lake env lean` command. Lake
 will reuse unchanged artifacts and rebuild files changed on the branch.

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -53,7 +53,8 @@ creates a warning annotation on the file, and 50 seconds fails the separate
 `compile-time` job. Timings are local diagnostic evidence, not benchmarks
 comparable across machines.
 
-Lightweight tests do not run Lean:
+Lightweight tests do not run Lean. The shell integration test is macOS-only
+because it exercises the APFS clone operation, so run it manually on macOS:
 
 ```bash
 python3 scripts/test_lake_build_hotspots.py

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -20,7 +20,10 @@ The command requires both paths to belong to the same repository, identical
 `lean-toolchain`, `lake-manifest.json`, and `lakefile.toml` files, an existing
 regular, non-symlinked source `.lake`, `.lake/build`, and `.lake/packages`
 directories, and an absent target `.lake`. Git dependency checkouts must be
-clean and at the revisions recorded in `lake-manifest.json`.
+clean and at the revisions recorded in `lake-manifest.json`; nested Lake build
+directories must not be symlinks; and Mathlib's prebuilt `Mathlib.olean` must
+already be present. If it is missing, run `lake exe cache get` in the source
+worktree before seeding.
 macOS `/bin/cp -c` creates independent writable files and fails instead of
 falling back to a full copy when APFS cloning is unavailable. The absolute path
 keeps Homebrew GNU coreutils from shadowing the APFS-aware command. Do not seed

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -1,0 +1,47 @@
+# Reusing a local Lake build
+
+Fresh worktrees can reuse an existing TNLean `.lake` without sharing writable
+build directories. The seed command uses APFS copy-on-write cloning:
+
+```bash
+git worktree add -b agent/my-branch /private/tmp/tnlean-my-branch origin/main
+scripts/seed_lake_build.sh /private/tmp/tnlean-my-branch --dry-run
+scripts/seed_lake_build.sh /private/tmp/tnlean-my-branch
+```
+
+The source defaults to the repository's primary worktree. Pass another source
+worktree as the second argument when needed:
+
+```bash
+scripts/seed_lake_build.sh TARGET_WORKTREE SOURCE_WORKTREE
+```
+
+The command requires both paths to belong to the same repository, identical
+`lean-toolchain`, `lake-manifest.json`, and `lakefile.toml` files, an existing
+source `.lake/build` and `.lake/packages`, and an absent target `.lake`.
+`cp -c` creates independent writable files and fails instead of falling back
+to a full copy when APFS cloning is unavailable. Do not seed while the source
+worktree is running a Lake command.
+
+After seeding, run the desired `lake build` or `lake env lean` command. Lake
+will reuse unchanged artifacts and rebuild files changed on the branch.
+
+## Sort build timings
+
+Save a build log and rank jobs above a chosen duration:
+
+```bash
+lake build 2>&1 | tee /tmp/tnlean-build.log
+python3 scripts/lake_build_hotspots.py /tmp/tnlean-build.log \
+  --threshold 30 --limit 25
+```
+
+The report is tab-separated and sorted from slowest to fastest. Timings are
+local diagnostic evidence, not benchmarks comparable across machines.
+
+Lightweight tests do not run Lean:
+
+```bash
+python3 scripts/test_lake_build_hotspots.py
+scripts/test_seed_lake_build.sh
+```

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -18,9 +18,9 @@ scripts/seed_lake_build.sh TARGET_WORKTREE SOURCE_WORKTREE
 
 The command requires both paths to belong to the same repository, identical
 `lean-toolchain`, `lake-manifest.json`, and `lakefile.toml` files, an existing
-non-symlinked source `.lake/build` and `.lake/packages`, and an absent target
-`.lake`. Git dependency checkouts must be clean and at the revisions recorded
-in `lake-manifest.json`.
+regular, non-symlinked source `.lake`, `.lake/build`, and `.lake/packages`
+directories, and an absent target `.lake`. Git dependency checkouts must be
+clean and at the revisions recorded in `lake-manifest.json`.
 macOS `/bin/cp -c` creates independent writable files and fails instead of
 falling back to a full copy when APFS cloning is unavailable. The absolute path
 keeps Homebrew GNU coreutils from shadowing the APFS-aware command. Do not seed

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -19,25 +19,27 @@ scripts/seed_lake_build.sh TARGET_WORKTREE SOURCE_WORKTREE
 The command requires both paths to belong to the same repository, identical
 `lean-toolchain`, `lake-manifest.json`, and `lakefile.toml` files, an existing
 source `.lake/build` and `.lake/packages`, and an absent target `.lake`.
-`cp -c` creates independent writable files and fails instead of falling back
-to a full copy when APFS cloning is unavailable. Do not seed while the source
-worktree is running a Lake command.
+macOS `/bin/cp -c` creates independent writable files and fails instead of
+falling back to a full copy when APFS cloning is unavailable. The absolute path
+keeps Homebrew GNU coreutils from shadowing the APFS-aware command. Do not seed
+while the source worktree is running a Lake command.
 
 After seeding, run the desired `lake build` or `lake env lean` command. Lake
 will reuse unchanged artifacts and rebuild files changed on the branch.
 
 ## Sort build timings
 
-Save a build log and rank jobs above a chosen duration:
+Save a build log and list every job taking at least 50 seconds:
 
 ```bash
 lake build 2>&1 | tee /tmp/tnlean-build.log
-python3 scripts/lake_build_hotspots.py /tmp/tnlean-build.log \
-  --threshold 30 --limit 25
+python3 scripts/lake_build_hotspots.py /tmp/tnlean-build.log
 ```
 
-The report is tab-separated and sorted from slowest to fastest. Timings are
-local diagnostic evidence, not benchmarks comparable across machines.
+The report is tab-separated and sorted from slowest to fastest. To make the
+same 50-second limit a local or CI gate, add `--fail-over-threshold`; use
+`--threshold` to override the limit. Timings are local diagnostic evidence,
+not benchmarks comparable across machines.
 
 Lightweight tests do not run Lean:
 

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -43,9 +43,9 @@ unsuccessfully if any reported job takes at least 50 seconds. Use
 `--warn-threshold` and `--error-threshold` to override these limits.
 
 Pull-request CI applies the same policy only to changed Lean files: 25 seconds
-creates a warning annotation on the file, and 50 seconds fails the build job.
-Timings are local diagnostic evidence, not benchmarks comparable across
-machines.
+creates a warning annotation on the file, and 50 seconds fails the separate
+`compile-time` job. Timings are local diagnostic evidence, not benchmarks
+comparable across machines.
 
 Lightweight tests do not run Lean:
 

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -18,7 +18,9 @@ scripts/seed_lake_build.sh TARGET_WORKTREE SOURCE_WORKTREE
 
 The command requires both paths to belong to the same repository, identical
 `lean-toolchain`, `lake-manifest.json`, and `lakefile.toml` files, an existing
-source `.lake/build` and `.lake/packages`, and an absent target `.lake`.
+non-symlinked source `.lake/build` and `.lake/packages`, and an absent target
+`.lake`. Git dependency checkouts must be clean and at the revisions recorded
+in `lake-manifest.json`.
 macOS `/bin/cp -c` creates independent writable files and fails instead of
 falling back to a full copy when APFS cloning is unavailable. The absolute path
 keeps Homebrew GNU coreutils from shadowing the APFS-aware command. Do not seed

--- a/scripts/lake_build_hotspots.py
+++ b/scripts/lake_build_hotspots.py
@@ -81,9 +81,12 @@ def render_github_annotations(
     for job in jobs:
         if job.seconds < warn_threshold:
             continue
+        path = module_paths.get(job.job)
+        if path is None:
+            continue
         level = "error" if job.seconds >= error_threshold else "warning"
         lines.append(
-            f"::{level} file={module_paths[job.job]}::"
+            f"::{level} file={path}::"
             f"{job.job} compiled in {job.seconds:.3f}s "
             f"(warning at {warn_threshold:g}s, error at {error_threshold:g}s)"
         )

--- a/scripts/lake_build_hotspots.py
+++ b/scripts/lake_build_hotspots.py
@@ -53,10 +53,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--threshold",
         type=float,
-        default=30.0,
-        help="minimum elapsed seconds to report (default: 30)",
+        default=50.0,
+        help="minimum elapsed seconds to report (default: 50)",
     )
     parser.add_argument("--limit", type=int, help="maximum number of jobs to report")
+    parser.add_argument(
+        "--fail-over-threshold",
+        action="store_true",
+        help="exit unsuccessfully when any job reaches the threshold",
+    )
     args = parser.parse_args(argv)
     if args.threshold < 0:
         parser.error("--threshold must be nonnegative")
@@ -64,7 +69,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("--limit must be positive")
     jobs = parse_timed_jobs(args.log.read_text(encoding="utf-8", errors="replace"))
     print(render_tsv(jobs, args.threshold, args.limit), end="")
-    return 0
+    return int(args.fail_over_threshold and any(job.seconds >= args.threshold for job in jobs))
 
 
 if __name__ == "__main__":

--- a/scripts/lake_build_hotspots.py
+++ b/scripts/lake_build_hotspots.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Rank timed Lake build jobs from a build log."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+TIMED_JOB_RE = re.compile(
+    r"^\s*(?:[✔⚠✖]\s+)?(?:\[\d+/\d+\]\s+)?(?:Built|Replayed)\s+"
+    r"(?P<job>.+?)\s+\((?P<duration>\d+(?:\.\d+)?)"
+    r"(?P<unit>ms|s|m|h)\)\s*$"
+)
+SECONDS_PER_UNIT = {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}
+
+
+@dataclass(frozen=True)
+class TimedJob:
+    """One timed Lake job."""
+
+    job: str
+    seconds: float
+
+
+def parse_timed_jobs(log_text: str) -> list[TimedJob]:
+    """Extract timed build jobs, sorted from slowest to fastest."""
+    jobs: list[TimedJob] = []
+    for raw_line in log_text.splitlines():
+        line = ANSI_ESCAPE_RE.sub("", raw_line)
+        if match := TIMED_JOB_RE.match(line):
+            seconds = float(match.group("duration")) * SECONDS_PER_UNIT[match.group("unit")]
+            jobs.append(TimedJob(job=match.group("job"), seconds=seconds))
+    return sorted(jobs, key=lambda job: (-job.seconds, job.job))
+
+
+def render_tsv(jobs: Sequence[TimedJob], threshold: float, limit: int | None) -> str:
+    """Render jobs at or above threshold as a deterministic TSV report."""
+    selected = [job for job in jobs if job.seconds >= threshold]
+    if limit is not None:
+        selected = selected[:limit]
+    lines = ["seconds\tjob"]
+    lines.extend(f"{job.seconds:.3f}\t{job.job}" for job in selected)
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path, help="Lake build log")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=30.0,
+        help="minimum elapsed seconds to report (default: 30)",
+    )
+    parser.add_argument("--limit", type=int, help="maximum number of jobs to report")
+    args = parser.parse_args(argv)
+    if args.threshold < 0:
+        parser.error("--threshold must be nonnegative")
+    if args.limit is not None and args.limit < 1:
+        parser.error("--limit must be positive")
+    jobs = parse_timed_jobs(args.log.read_text(encoding="utf-8", errors="replace"))
+    print(render_tsv(jobs, args.threshold, args.limit), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lake_build_hotspots.py
+++ b/scripts/lake_build_hotspots.py
@@ -37,17 +37,20 @@ def parse_timed_jobs(log_text: str) -> list[TimedJob]:
     return sorted(jobs, key=lambda job: (-job.seconds, job.job))
 
 
-def lean_module(path: str) -> str | None:
-    """Return the Lake module name for a Lean source path."""
+def lean_modules(path: str) -> set[str]:
+    """Return possible Lake module names for a Lean source path."""
     normalized = path.strip().replace("\\", "/")
     if not normalized.endswith(".lean"):
-        return None
-    return normalized.removesuffix(".lean").replace("/", ".")
+        return set()
+    modules = {normalized.removesuffix(".lean").replace("/", ".")}
+    if normalized.startswith("scripts/"):
+        modules.add(Path(normalized).stem)
+    return modules
 
 
 def changed_jobs(jobs: Sequence[TimedJob], paths: Sequence[str]) -> list[TimedJob]:
     """Keep jobs corresponding to changed Lean source files."""
-    modules = {module for path in paths if (module := lean_module(path)) is not None}
+    modules = {module for path in paths for module in lean_modules(path)}
     return [job for job in jobs if job.job in modules]
 
 
@@ -71,7 +74,7 @@ def render_github_annotations(
     module_paths = {
         module: path.strip()
         for path in paths
-        if (module := lean_module(path)) is not None
+        for module in lean_modules(path)
     }
     lines = []
     for job in jobs:

--- a/scripts/lake_build_hotspots.py
+++ b/scripts/lake_build_hotspots.py
@@ -16,6 +16,7 @@ TIMED_JOB_RE = re.compile(
     r"(?P<unit>ms|s|m|h)\)\s*$"
 )
 SECONDS_PER_UNIT = {"ms": 0.001, "s": 1.0, "m": 60.0, "h": 3600.0}
+TIMING_LIMIT_EXIT = 50
 
 
 @dataclass(frozen=True)
@@ -133,7 +134,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
             end="",
         )
-    return int(any(job.seconds >= args.error_threshold for job in jobs))
+    if any(job.seconds >= args.error_threshold for job in jobs):
+        return TIMING_LIMIT_EXIT
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/lake_build_hotspots.py
+++ b/scripts/lake_build_hotspots.py
@@ -52,7 +52,7 @@ def lean_modules(path: str) -> set[str]:
 def changed_jobs(jobs: Sequence[TimedJob], paths: Sequence[str]) -> list[TimedJob]:
     """Keep jobs corresponding to changed Lean source files."""
     modules = {module for path in paths for module in lean_modules(path)}
-    return [job for job in jobs if job.job in modules]
+    return [job for job in jobs if job.job.partition(":")[0] in modules]
 
 
 def render_tsv(jobs: Sequence[TimedJob], threshold: float, limit: int | None) -> str:
@@ -81,7 +81,7 @@ def render_github_annotations(
     for job in jobs:
         if job.seconds < warn_threshold:
             continue
-        path = module_paths.get(job.job)
+        path = module_paths.get(job.job.partition(":")[0])
         if path is None:
             continue
         level = "error" if job.seconds >= error_threshold else "warning"

--- a/scripts/lake_build_hotspots.py
+++ b/scripts/lake_build_hotspots.py
@@ -37,6 +37,20 @@ def parse_timed_jobs(log_text: str) -> list[TimedJob]:
     return sorted(jobs, key=lambda job: (-job.seconds, job.job))
 
 
+def lean_module(path: str) -> str | None:
+    """Return the Lake module name for a Lean source path."""
+    normalized = path.strip().replace("\\", "/")
+    if not normalized.endswith(".lean"):
+        return None
+    return normalized.removesuffix(".lean").replace("/", ".")
+
+
+def changed_jobs(jobs: Sequence[TimedJob], paths: Sequence[str]) -> list[TimedJob]:
+    """Keep jobs corresponding to changed Lean source files."""
+    modules = {module for path in paths if (module := lean_module(path)) is not None}
+    return [job for job in jobs if job.job in modules]
+
+
 def render_tsv(jobs: Sequence[TimedJob], threshold: float, limit: int | None) -> str:
     """Render jobs at or above threshold as a deterministic TSV report."""
     selected = [job for job in jobs if job.seconds >= threshold]
@@ -47,29 +61,76 @@ def render_tsv(jobs: Sequence[TimedJob], threshold: float, limit: int | None) ->
     return "\n".join(lines) + "\n"
 
 
+def render_github_annotations(
+    jobs: Sequence[TimedJob],
+    paths: Sequence[str],
+    warn_threshold: float,
+    error_threshold: float,
+) -> str:
+    """Render GitHub annotations for slow changed Lean modules."""
+    module_paths = {
+        module: path.strip()
+        for path in paths
+        if (module := lean_module(path)) is not None
+    }
+    lines = []
+    for job in jobs:
+        if job.seconds < warn_threshold:
+            continue
+        level = "error" if job.seconds >= error_threshold else "warning"
+        lines.append(
+            f"::{level} file={module_paths[job.job]}::"
+            f"{job.job} compiled in {job.seconds:.3f}s "
+            f"(warning at {warn_threshold:g}s, error at {error_threshold:g}s)"
+        )
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("log", type=Path, help="Lake build log")
     parser.add_argument(
-        "--threshold",
+        "--warn-threshold",
+        type=float,
+        default=25.0,
+        help="minimum elapsed seconds to warn and report (default: 25)",
+    )
+    parser.add_argument(
+        "--error-threshold",
         type=float,
         default=50.0,
-        help="minimum elapsed seconds to report (default: 50)",
+        help="minimum elapsed seconds to fail (default: 50)",
     )
     parser.add_argument("--limit", type=int, help="maximum number of jobs to report")
     parser.add_argument(
-        "--fail-over-threshold",
-        action="store_true",
-        help="exit unsuccessfully when any job reaches the threshold",
+        "--changed-files-from",
+        type=Path,
+        help="only check Lean source paths listed in this newline-delimited file",
     )
     args = parser.parse_args(argv)
-    if args.threshold < 0:
-        parser.error("--threshold must be nonnegative")
+    if args.warn_threshold < 0:
+        parser.error("--warn-threshold must be nonnegative")
+    if args.error_threshold < args.warn_threshold:
+        parser.error("--error-threshold must be at least --warn-threshold")
     if args.limit is not None and args.limit < 1:
         parser.error("--limit must be positive")
     jobs = parse_timed_jobs(args.log.read_text(encoding="utf-8", errors="replace"))
-    print(render_tsv(jobs, args.threshold, args.limit), end="")
-    return int(args.fail_over_threshold and any(job.seconds >= args.threshold for job in jobs))
+    paths = None
+    if args.changed_files_from is not None:
+        paths = args.changed_files_from.read_text(encoding="utf-8").splitlines()
+        jobs = changed_jobs(jobs, paths)
+    print(render_tsv(jobs, args.warn_threshold, args.limit), end="")
+    if paths is not None:
+        print(
+            render_github_annotations(
+                jobs,
+                paths,
+                args.warn_threshold,
+                args.error_threshold,
+            ),
+            end="",
+        )
+    return int(any(job.seconds >= args.error_threshold for job in jobs))
 
 
 if __name__ == "__main__":

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# APFS-clone an existing TNLean .lake into a fresh worktree.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/seed_lake_build.sh TARGET_WORKTREE [SOURCE_WORKTREE] [--dry-run]
+
+SOURCE_WORKTREE defaults to the repository's primary worktree. The target must
+belong to the same repository and must not already contain .lake.
+EOF
+}
+
+die() {
+  echo "seed-lake-build: $*" >&2
+  exit 1
+}
+
+canonical_dir() {
+  (cd "$1" && pwd -P)
+}
+
+worktree_root() {
+  git -C "$1" rev-parse --show-toplevel 2>/dev/null
+}
+
+common_dir() {
+  local root="$1"
+  canonical_dir "$(git -C "$root" rev-parse --path-format=absolute --git-common-dir)"
+}
+
+validate_root() {
+  local path="$1"
+  local root
+  test -d "$path" || die "not a directory: $path"
+  root="$(worktree_root "$path")" || die "not a Git worktree: $path"
+  test "$(canonical_dir "$path")" = "$(canonical_dir "$root")" ||
+    die "path must name the worktree root: $path"
+  test "$(common_dir "$root")" = "$REPO_COMMON_DIR" ||
+    die "worktree belongs to a different repository: $path"
+}
+
+cleanup() {
+  if test -n "${STAGING_DIR:-}" && test -d "$STAGING_DIR"; then
+    find "$STAGING_DIR" -depth -delete
+  fi
+}
+trap cleanup EXIT
+
+SCRIPT_DIR="$(canonical_dir "$(dirname "${BASH_SOURCE[0]}")")"
+SCRIPT_ROOT="$(worktree_root "$SCRIPT_DIR")"
+REPO_COMMON_DIR="$(common_dir "$SCRIPT_ROOT")"
+PRIMARY_ROOT="$(
+  git -C "$SCRIPT_ROOT" worktree list --porcelain |
+    sed -n 's/^worktree //p' |
+    head -n 1
+)"
+STAGING_DIR=""
+DRY_RUN="false"
+
+test "$#" -ge 1 || {
+  usage
+  exit 2
+}
+
+TARGET_PATH="$1"
+shift
+SOURCE_PATH="$PRIMARY_ROOT"
+if test "$#" -gt 0 && test "$1" != "--dry-run"; then
+  SOURCE_PATH="$1"
+  shift
+fi
+if test "$#" -gt 0 && test "$1" = "--dry-run"; then
+  DRY_RUN="true"
+  shift
+fi
+test "$#" -eq 0 || die "unknown argument: $1"
+
+validate_root "$SOURCE_PATH"
+validate_root "$TARGET_PATH"
+SOURCE_ROOT="$(canonical_dir "$SOURCE_PATH")"
+TARGET_ROOT="$(canonical_dir "$TARGET_PATH")"
+test "$SOURCE_ROOT" != "$TARGET_ROOT" || die "source and target worktrees must differ"
+test -d "$SOURCE_ROOT/.lake/build" || die "source has no .lake/build"
+test -d "$SOURCE_ROOT/.lake/packages" || die "source has no .lake/packages"
+test ! -e "$TARGET_ROOT/.lake" && test ! -L "$TARGET_ROOT/.lake" ||
+  die "target already has .lake"
+
+for input in lean-toolchain lake-manifest.json lakefile.toml; do
+  cmp -s "$SOURCE_ROOT/$input" "$TARGET_ROOT/$input" ||
+    die "build input differs between source and target: $input"
+done
+
+if test "$DRY_RUN" = "true"; then
+  echo "seed-lake-build: dry-run passed"
+  echo "seed-lake-build: source: $SOURCE_ROOT/.lake"
+  echo "seed-lake-build: target: $TARGET_ROOT/.lake"
+  exit 0
+fi
+
+STAGING_DIR="$TARGET_ROOT/.lake.seed.$$"
+cp -cR "$SOURCE_ROOT/.lake" "$STAGING_DIR"
+mv "$STAGING_DIR" "$TARGET_ROOT/.lake"
+STAGING_DIR=""
+echo "seed-lake-build: cloned $SOURCE_ROOT/.lake into $TARGET_ROOT/.lake"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -16,6 +16,9 @@ die() {
   exit 1
 }
 
+test "$(/usr/bin/uname -s)" = "Darwin" ||
+  die "requires macOS with APFS clone support"
+
 canonical_dir() {
   (CDPATH='' cd -- "$1" && pwd -P)
 }
@@ -148,7 +151,8 @@ test -d "$SOURCE_ROOT/.lake/packages" && test ! -L "$SOURCE_ROOT/.lake/packages"
   die "source has no regular .lake/packages"
 NESTED_CACHE_LINK="$(
   find "$SOURCE_ROOT/.lake" -type l \
-    \( -name .lake -o -name build -o -name packages -o -path '*/.lake/build/*' \) \
+    \( -name .lake -o -name build -o -name packages \
+      -o -path '*/.lake/build/*' -o -path '*/.lake/lakefile.*' \) \
     -print -quit
 )"
 test -z "$NESTED_CACHE_LINK" ||

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -99,7 +99,7 @@ if test "$DRY_RUN" = "true"; then
 fi
 
 STAGING_DIR="$TARGET_ROOT/.lake.seed.$$"
-cp -cR "$SOURCE_ROOT/.lake" "$STAGING_DIR"
+/bin/cp -cR "$SOURCE_ROOT/.lake" "$STAGING_DIR"
 mv "$STAGING_DIR" "$TARGET_ROOT/.lake"
 STAGING_DIR=""
 echo "seed-lake-build: cloned $SOURCE_ROOT/.lake into $TARGET_ROOT/.lake"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -40,6 +40,36 @@ validate_root() {
     die "worktree belongs to a different repository: $path"
 }
 
+validate_packages() {
+  local source_root="$1"
+  local package_name
+  local expected_rev
+  local package_root
+  local actual_rev
+  while IFS=$'\t' read -r package_name expected_rev; do
+    package_root="$source_root/.lake/packages/$package_name"
+    test -d "$package_root" && test ! -L "$package_root" ||
+      die "Git package is missing or symlinked: $package_name"
+    actual_rev="$(git -C "$package_root" rev-parse HEAD 2>/dev/null)" ||
+      die "Git package is not a checkout: $package_name"
+    test "$actual_rev" = "$expected_rev" ||
+      die "Git package revision differs from lake-manifest.json: $package_name"
+    test -z "$(git -C "$package_root" status --porcelain --untracked-files=all)" ||
+      die "Git package has local changes: $package_name"
+  done < <(
+    python3 - "$source_root/lake-manifest.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as manifest_file:
+    manifest = json.load(manifest_file)
+for package in manifest.get("packages", []):
+    if package.get("type") == "git":
+        print(f"{package['name']}\t{package['rev']}")
+PY
+  )
+}
+
 cleanup() {
   if test -n "${STAGING_DIR:-}" && test -d "$STAGING_DIR"; then
     find "$STAGING_DIR" -depth -delete
@@ -81,6 +111,7 @@ validate_root "$TARGET_PATH"
 SOURCE_ROOT="$(canonical_dir "$SOURCE_PATH")"
 TARGET_ROOT="$(canonical_dir "$TARGET_PATH")"
 test "$SOURCE_ROOT" != "$TARGET_ROOT" || die "source and target worktrees must differ"
+test ! -L "$SOURCE_ROOT/.lake" || die "source .lake must not be a symlink"
 test -d "$SOURCE_ROOT/.lake/build" || die "source has no .lake/build"
 test -d "$SOURCE_ROOT/.lake/packages" || die "source has no .lake/packages"
 test ! -e "$TARGET_ROOT/.lake" && test ! -L "$TARGET_ROOT/.lake" ||
@@ -90,6 +121,7 @@ for input in lean-toolchain lake-manifest.json lakefile.toml; do
   cmp -s "$SOURCE_ROOT/$input" "$TARGET_ROOT/$input" ||
     die "build input differs between source and target: $input"
 done
+validate_packages "$SOURCE_ROOT"
 
 if test "$DRY_RUN" = "true"; then
   echo "seed-lake-build: dry-run passed"
@@ -98,8 +130,8 @@ if test "$DRY_RUN" = "true"; then
   exit 0
 fi
 
-STAGING_DIR="$TARGET_ROOT/.lake.seed.$$"
-/bin/cp -cR "$SOURCE_ROOT/.lake" "$STAGING_DIR"
-mv "$STAGING_DIR" "$TARGET_ROOT/.lake"
+STAGING_DIR="$TARGET_ROOT/.lake"
+mkdir "$STAGING_DIR" 2>/dev/null || die "target already has .lake"
+/bin/cp -cR "$SOURCE_ROOT/.lake/." "$STAGING_DIR"
 STAGING_DIR=""
 echo "seed-lake-build: cloned $SOURCE_ROOT/.lake into $TARGET_ROOT/.lake"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -69,6 +69,8 @@ PY
     package_root="$source_root/.lake/packages/$package_name"
     test -d "$package_root" && test ! -L "$package_root" ||
       die "Git package is missing or symlinked: $package_name"
+    test -d "$package_root/.git" && test ! -L "$package_root/.git" ||
+      die "Git package metadata is not self-contained: $package_name"
     actual_rev="$(git -C "$package_root" rev-parse HEAD 2>/dev/null)" ||
       die "Git package is not a checkout: $package_name"
     test "$actual_rev" = "$expected_rev" ||

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -46,6 +46,7 @@ validate_packages() {
   local expected_rev
   local package_root
   local actual_rev
+  local package_status
   PACKAGE_LIST_FILE="$(mktemp "${TMPDIR:-/tmp}/tnlean-lake-packages.XXXXXX")" ||
     die "cannot create temporary package list"
   if ! python3 - "$source_root/lake-manifest.json" >"$PACKAGE_LIST_FILE" <<'PY'
@@ -69,7 +70,12 @@ PY
       die "Git package is not a checkout: $package_name"
     test "$actual_rev" = "$expected_rev" ||
       die "Git package revision differs from lake-manifest.json: $package_name"
-    test -z "$(git -C "$package_root" status --porcelain --untracked-files=all)" ||
+    if ! package_status="$(
+      git -C "$package_root" status --porcelain --untracked-files=all
+    )"; then
+      die "cannot read Git package status: $package_name"
+    fi
+    test -z "$package_status" ||
       die "Git package has local changes: $package_name"
   done <"$PACKAGE_LIST_FILE"
   find "$PACKAGE_LIST_FILE" -delete
@@ -79,6 +85,10 @@ PY
 cleanup() {
   if test -n "${PACKAGE_LIST_FILE:-}" && test -f "$PACKAGE_LIST_FILE"; then
     find "$PACKAGE_LIST_FILE" -delete
+  fi
+  if test -n "${RESERVATION_DIR:-}" && test -d "$RESERVATION_DIR"; then
+    chmod 700 "$RESERVATION_DIR"
+    find "$RESERVATION_DIR" -depth -delete
   fi
   if test -n "${STAGING_DIR:-}" && test -d "$STAGING_DIR"; then
     find "$STAGING_DIR" -depth -delete
@@ -96,6 +106,7 @@ PRIMARY_ROOT="$(
 )"
 STAGING_DIR=""
 PACKAGE_LIST_FILE=""
+RESERVATION_DIR=""
 DRY_RUN="false"
 
 test "$#" -ge 1 || {
@@ -131,8 +142,6 @@ NESTED_CACHE_LINK="$(
 )"
 test -z "$NESTED_CACHE_LINK" ||
   die "source contains a symlinked Lake cache directory: $NESTED_CACHE_LINK"
-test -f "$SOURCE_ROOT/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" ||
-  die "source lacks prebuilt Mathlib artifacts; run 'lake exe cache get' first"
 test ! -e "$TARGET_ROOT/.lake" && test ! -L "$TARGET_ROOT/.lake" ||
   die "target already has .lake"
 
@@ -140,6 +149,12 @@ for input in lean-toolchain lake-manifest.json lakefile.toml; do
   cmp -s "$SOURCE_ROOT/$input" "$TARGET_ROOT/$input" ||
     die "build input differs between source and target: $input"
 done
+(
+  cd "$SOURCE_ROOT"
+  lake exe cache get
+) || die "failed to fetch current prebuilt Mathlib artifacts"
+test -f "$SOURCE_ROOT/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" ||
+  die "source lacks prebuilt Mathlib artifacts after 'lake exe cache get'"
 validate_packages "$SOURCE_ROOT"
 
 if test "$DRY_RUN" = "true"; then
@@ -149,8 +164,40 @@ if test "$DRY_RUN" = "true"; then
   exit 0
 fi
 
-STAGING_DIR="$TARGET_ROOT/.lake"
-mkdir "$STAGING_DIR" 2>/dev/null || die "target already has .lake"
+RESERVATION_DIR="$TARGET_ROOT/.lake"
+mkdir "$RESERVATION_DIR" 2>/dev/null || die "target already has .lake"
+chmod 000 "$RESERVATION_DIR"
+STAGING_DIR="$TARGET_ROOT/.lake.seed.$$"
 /bin/cp -cR "$SOURCE_ROOT/.lake/." "$STAGING_DIR"
+python3 - "$STAGING_DIR" "$RESERVATION_DIR" <<'PY'
+import ctypes
+import os
+import sys
+
+libc = ctypes.CDLL(None, use_errno=True)
+renameatx_np = libc.renameatx_np
+renameatx_np.argtypes = [
+    ctypes.c_int,
+    ctypes.c_char_p,
+    ctypes.c_int,
+    ctypes.c_char_p,
+    ctypes.c_uint,
+]
+renameatx_np.restype = ctypes.c_int
+result = renameatx_np(
+    -2,
+    os.fsencode(sys.argv[1]),
+    -2,
+    os.fsencode(sys.argv[2]),
+    0x00000002,
+)
+if result != 0:
+    error = ctypes.get_errno()
+    raise OSError(error, os.strerror(error))
+PY
+RESERVATION_DIR="$STAGING_DIR"
+chmod 700 "$RESERVATION_DIR"
+find "$RESERVATION_DIR" -depth -delete
 STAGING_DIR=""
+RESERVATION_DIR=""
 echo "seed-lake-build: cloned $SOURCE_ROOT/.lake into $TARGET_ROOT/.lake"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -50,6 +50,7 @@ validate_packages() {
   local package_root
   local actual_rev
   local package_status
+  local metadata_link
   PACKAGE_LIST_FILE="$(mktemp "${TMPDIR:-/tmp}/tnlean-lake-packages.XXXXXX")" ||
     die "cannot create temporary package list"
   if ! python3 - "$source_root/lake-manifest.json" >"$PACKAGE_LIST_FILE" <<'PY'
@@ -71,6 +72,14 @@ PY
       die "Git package is missing or symlinked: $package_name"
     test -d "$package_root/.git" && test ! -L "$package_root/.git" ||
       die "Git package metadata is not self-contained: $package_name"
+    test ! -e "$package_root/.git/objects/info/alternates" &&
+      test ! -L "$package_root/.git/objects/info/alternates" ||
+      die "Git package uses external object storage: $package_name"
+    metadata_link="$(
+      find "$package_root/.git" -type l -print -quit
+    )"
+    test -z "$metadata_link" ||
+      die "Git package metadata contains a symlink: $package_name"
     actual_rev="$(git -C "$package_root" rev-parse HEAD 2>/dev/null)" ||
       die "Git package is not a checkout: $package_name"
     test "$actual_rev" = "$expected_rev" ||

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -17,7 +17,7 @@ die() {
 }
 
 canonical_dir() {
-  (cd "$1" && pwd -P)
+  (CDPATH='' cd -- "$1" && pwd -P)
 }
 
 worktree_root() {

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -126,6 +126,13 @@ test -d "$SOURCE_ROOT/.lake/build" && test ! -L "$SOURCE_ROOT/.lake/build" ||
   die "source has no regular .lake/build"
 test -d "$SOURCE_ROOT/.lake/packages" && test ! -L "$SOURCE_ROOT/.lake/packages" ||
   die "source has no regular .lake/packages"
+NESTED_CACHE_LINK="$(
+  find "$SOURCE_ROOT/.lake" -type l \( -name build -o -name packages \) -print -quit
+)"
+test -z "$NESTED_CACHE_LINK" ||
+  die "source contains a symlinked Lake cache directory: $NESTED_CACHE_LINK"
+test -f "$SOURCE_ROOT/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" ||
+  die "source lacks prebuilt Mathlib artifacts; run 'lake exe cache get' first"
 test ! -e "$TARGET_ROOT/.lake" && test ! -L "$TARGET_ROOT/.lake" ||
   die "target already has .lake"
 

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -87,8 +87,12 @@ cleanup() {
     find "$PACKAGE_LIST_FILE" -delete
   fi
   if test -n "${RESERVATION_DIR:-}" && test -d "$RESERVATION_DIR"; then
-    chmod 700 "$RESERVATION_DIR"
-    find "$RESERVATION_DIR" -depth -delete
+    reservation_inode="$(stat -f %i "$RESERVATION_DIR" 2>/dev/null || true)"
+    if test -n "$reservation_inode" &&
+      test "$reservation_inode" = "${RESERVATION_INODE:-}"; then
+      chmod 700 "$RESERVATION_DIR"
+      find "$RESERVATION_DIR" -depth -delete
+    fi
   fi
   if test -n "${STAGING_DIR:-}" && test -d "$STAGING_DIR"; then
     find "$STAGING_DIR" -depth -delete
@@ -107,6 +111,7 @@ PRIMARY_ROOT="$(
 STAGING_DIR=""
 PACKAGE_LIST_FILE=""
 RESERVATION_DIR=""
+RESERVATION_INODE=""
 DRY_RUN="false"
 
 test "$#" -ge 1 || {
@@ -166,6 +171,7 @@ fi
 
 RESERVATION_DIR="$TARGET_ROOT/.lake"
 mkdir "$RESERVATION_DIR" 2>/dev/null || die "target already has .lake"
+RESERVATION_INODE="$(stat -f %i "$RESERVATION_DIR")"
 chmod 000 "$RESERVATION_DIR"
 STAGING_DIR="$TARGET_ROOT/.lake.seed.$$"
 /bin/cp -cR "$SOURCE_ROOT/.lake/." "$STAGING_DIR"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -143,7 +143,9 @@ test -d "$SOURCE_ROOT/.lake/build" && test ! -L "$SOURCE_ROOT/.lake/build" ||
 test -d "$SOURCE_ROOT/.lake/packages" && test ! -L "$SOURCE_ROOT/.lake/packages" ||
   die "source has no regular .lake/packages"
 NESTED_CACHE_LINK="$(
-  find "$SOURCE_ROOT/.lake" -type l \( -name build -o -name packages \) -print -quit
+  find "$SOURCE_ROOT/.lake" -type l \
+    \( -name .lake -o -name build -o -name packages -o -path '*/.lake/build/*' \) \
+    -print -quit
 )"
 test -z "$NESTED_CACHE_LINK" ||
   die "source contains a symlinked Lake cache directory: $NESTED_CACHE_LINK"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -51,6 +51,7 @@ validate_packages() {
   local actual_rev
   local package_status
   local metadata_link
+  local reported_root
   PACKAGE_LIST_FILE="$(mktemp "${TMPDIR:-/tmp}/tnlean-lake-packages.XXXXXX")" ||
     die "cannot create temporary package list"
   if ! python3 - "$source_root/lake-manifest.json" >"$PACKAGE_LIST_FILE" <<'PY'
@@ -80,6 +81,10 @@ PY
     )"
     test -z "$metadata_link" ||
       die "Git package metadata contains a symlink: $package_name"
+    reported_root="$(git -C "$package_root" rev-parse --show-toplevel 2>/dev/null)" ||
+      die "Git package is not a checkout: $package_name"
+    test "$(canonical_dir "$reported_root")" = "$(canonical_dir "$package_root")" ||
+      die "Git package worktree points outside its package root: $package_name"
     actual_rev="$(git -C "$package_root" rev-parse HEAD 2>/dev/null)" ||
       die "Git package is not a checkout: $package_name"
     test "$actual_rev" = "$expected_rev" ||

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -73,6 +73,9 @@ PY
       die "Git package is missing or symlinked: $package_name"
     test -d "$package_root/.git" && test ! -L "$package_root/.git" ||
       die "Git package metadata is not self-contained: $package_name"
+    test ! -e "$package_root/.git/commondir" &&
+      test ! -L "$package_root/.git/commondir" ||
+      die "Git package uses external common metadata: $package_name"
     test ! -e "$package_root/.git/objects/info/alternates" &&
       test ! -L "$package_root/.git/objects/info/alternates" ||
       die "Git package uses external object storage: $package_name"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -95,7 +95,11 @@ cleanup() {
     fi
   fi
   if test -n "${STAGING_DIR:-}" && test -d "$STAGING_DIR"; then
-    find "$STAGING_DIR" -depth -delete
+    staging_inode="$(stat -f %i "$STAGING_DIR" 2>/dev/null || true)"
+    if test -n "$staging_inode" &&
+      test "$staging_inode" = "${STAGING_INODE:-}"; then
+      find "$STAGING_DIR" -depth -delete
+    fi
   fi
 }
 trap cleanup EXIT
@@ -109,6 +113,7 @@ PRIMARY_ROOT="$(
     head -n 1
 )"
 STAGING_DIR=""
+STAGING_INODE=""
 PACKAGE_LIST_FILE=""
 RESERVATION_DIR=""
 RESERVATION_INODE=""
@@ -175,8 +180,11 @@ RESERVATION_DIR="$TARGET_ROOT/.lake"
 mkdir "$RESERVATION_DIR" 2>/dev/null || die "target already has .lake"
 RESERVATION_INODE="$(stat -f %i "$RESERVATION_DIR")"
 chmod 000 "$RESERVATION_DIR"
-STAGING_DIR="$TARGET_ROOT/.lake.seed.$$"
+STAGING_DIR="$(/usr/bin/mktemp -d "$TARGET_ROOT/.lake.seed.XXXXXX")"
+STAGING_INODE="$(stat -f %i "$STAGING_DIR")"
 /bin/cp -cR "$SOURCE_ROOT/.lake/." "$STAGING_DIR"
+test "$(stat -f %i "$STAGING_DIR")" = "$STAGING_INODE" ||
+  die "staging directory changed during clone"
 python3 - "$STAGING_DIR" "$RESERVATION_DIR" <<'PY'
 import ctypes
 import os
@@ -203,9 +211,11 @@ if result != 0:
     error = ctypes.get_errno()
     raise OSError(error, os.strerror(error))
 PY
-RESERVATION_DIR="$STAGING_DIR"
-chmod 700 "$RESERVATION_DIR"
-find "$RESERVATION_DIR" -depth -delete
-STAGING_DIR=""
+STAGING_INODE="$RESERVATION_INODE"
 RESERVATION_DIR=""
+RESERVATION_INODE=""
+chmod 700 "$STAGING_DIR"
+find "$STAGING_DIR" -depth -delete
+STAGING_DIR=""
+STAGING_INODE=""
 echo "seed-lake-build: cloned $SOURCE_ROOT/.lake into $TARGET_ROOT/.lake"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -107,10 +107,9 @@ trap cleanup EXIT
 SCRIPT_DIR="$(canonical_dir "$(dirname "${BASH_SOURCE[0]}")")"
 SCRIPT_ROOT="$(worktree_root "$SCRIPT_DIR")"
 REPO_COMMON_DIR="$(common_dir "$SCRIPT_ROOT")"
+WORKTREE_LIST="$(git -C "$SCRIPT_ROOT" worktree list --porcelain)"
 PRIMARY_ROOT="$(
-  git -C "$SCRIPT_ROOT" worktree list --porcelain |
-    sed -n 's/^worktree //p' |
-    head -n 1
+  sed -n '/^worktree / { s/^worktree //; p; q; }' <<<"$WORKTREE_LIST"
 )"
 STAGING_DIR=""
 STAGING_INODE=""
@@ -161,20 +160,23 @@ for input in lean-toolchain lake-manifest.json lakefile.toml; do
   cmp -s "$SOURCE_ROOT/$input" "$TARGET_ROOT/$input" ||
     die "build input differs between source and target: $input"
 done
+validate_packages "$SOURCE_ROOT"
+
+if test "$DRY_RUN" = "true"; then
+  test -f "$SOURCE_ROOT/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" ||
+    die "source lacks prebuilt Mathlib artifacts"
+  echo "seed-lake-build: dry-run passed"
+  echo "seed-lake-build: source: $SOURCE_ROOT/.lake"
+  echo "seed-lake-build: target: $TARGET_ROOT/.lake"
+  exit 0
+fi
+
 (
   cd "$SOURCE_ROOT"
   lake exe cache get
 ) || die "failed to fetch current prebuilt Mathlib artifacts"
 test -f "$SOURCE_ROOT/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" ||
   die "source lacks prebuilt Mathlib artifacts after 'lake exe cache get'"
-validate_packages "$SOURCE_ROOT"
-
-if test "$DRY_RUN" = "true"; then
-  echo "seed-lake-build: dry-run passed"
-  echo "seed-lake-build: source: $SOURCE_ROOT/.lake"
-  echo "seed-lake-build: target: $TARGET_ROOT/.lake"
-  exit 0
-fi
 
 RESERVATION_DIR="$TARGET_ROOT/.lake"
 mkdir "$RESERVATION_DIR" 2>/dev/null || die "target already has .lake"

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -46,6 +46,21 @@ validate_packages() {
   local expected_rev
   local package_root
   local actual_rev
+  PACKAGE_LIST_FILE="$(mktemp "${TMPDIR:-/tmp}/tnlean-lake-packages.XXXXXX")" ||
+    die "cannot create temporary package list"
+  if ! python3 - "$source_root/lake-manifest.json" >"$PACKAGE_LIST_FILE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as manifest_file:
+    manifest = json.load(manifest_file)
+for package in manifest.get("packages", []):
+    if package.get("type") == "git":
+        print(f"{package['name']}\t{package['rev']}")
+PY
+  then
+    die "cannot parse Git packages from lake-manifest.json"
+  fi
   while IFS=$'\t' read -r package_name expected_rev; do
     package_root="$source_root/.lake/packages/$package_name"
     test -d "$package_root" && test ! -L "$package_root" ||
@@ -56,21 +71,15 @@ validate_packages() {
       die "Git package revision differs from lake-manifest.json: $package_name"
     test -z "$(git -C "$package_root" status --porcelain --untracked-files=all)" ||
       die "Git package has local changes: $package_name"
-  done < <(
-    python3 - "$source_root/lake-manifest.json" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], encoding="utf-8") as manifest_file:
-    manifest = json.load(manifest_file)
-for package in manifest.get("packages", []):
-    if package.get("type") == "git":
-        print(f"{package['name']}\t{package['rev']}")
-PY
-  )
+  done <"$PACKAGE_LIST_FILE"
+  find "$PACKAGE_LIST_FILE" -delete
+  PACKAGE_LIST_FILE=""
 }
 
 cleanup() {
+  if test -n "${PACKAGE_LIST_FILE:-}" && test -f "$PACKAGE_LIST_FILE"; then
+    find "$PACKAGE_LIST_FILE" -delete
+  fi
   if test -n "${STAGING_DIR:-}" && test -d "$STAGING_DIR"; then
     find "$STAGING_DIR" -depth -delete
   fi
@@ -86,6 +95,7 @@ PRIMARY_ROOT="$(
     head -n 1
 )"
 STAGING_DIR=""
+PACKAGE_LIST_FILE=""
 DRY_RUN="false"
 
 test "$#" -ge 1 || {
@@ -112,8 +122,10 @@ SOURCE_ROOT="$(canonical_dir "$SOURCE_PATH")"
 TARGET_ROOT="$(canonical_dir "$TARGET_PATH")"
 test "$SOURCE_ROOT" != "$TARGET_ROOT" || die "source and target worktrees must differ"
 test ! -L "$SOURCE_ROOT/.lake" || die "source .lake must not be a symlink"
-test -d "$SOURCE_ROOT/.lake/build" || die "source has no .lake/build"
-test -d "$SOURCE_ROOT/.lake/packages" || die "source has no .lake/packages"
+test -d "$SOURCE_ROOT/.lake/build" && test ! -L "$SOURCE_ROOT/.lake/build" ||
+  die "source has no regular .lake/build"
+test -d "$SOURCE_ROOT/.lake/packages" && test ! -L "$SOURCE_ROOT/.lake/packages" ||
+  die "source has no regular .lake/packages"
 test ! -e "$TARGET_ROOT/.lake" && test ! -L "$TARGET_ROOT/.lake" ||
   die "target already has .lake"
 

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Unit tests for the Lake build hotspot parser."""
+
+from __future__ import annotations
+
+import unittest
+
+import lake_build_hotspots as hotspots
+
+
+class LakeBuildHotspotTests(unittest.TestCase):
+    def test_parses_units_ansi_and_optional_progress_prefix(self) -> None:
+        jobs = hotspots.parse_timed_jobs(
+            "\n".join(
+                [
+                    "✔ [9622/9713] Built TNLean.Slow (831s)",
+                    "\x1b[32m⚠ [2/3] Built TNLean.Fast:c.o (250ms)\x1b[0m",
+                    "Replayed TNLean.Middle (1.5m)",
+                    "✖ [3/3] Built TNLean.Failed (98s)",
+                    "info: unrelated output",
+                ]
+            )
+        )
+        self.assertEqual(
+            jobs,
+            [
+                hotspots.TimedJob("TNLean.Slow", 831.0),
+                hotspots.TimedJob("TNLean.Failed", 98.0),
+                hotspots.TimedJob("TNLean.Middle", 90.0),
+                hotspots.TimedJob("TNLean.Fast:c.o", 0.25),
+            ],
+        )
+
+    def test_report_is_ranked_filtered_and_limited(self) -> None:
+        jobs = [
+            hotspots.TimedJob("TNLean.A", 10.0),
+            hotspots.TimedJob("TNLean.B", 5.0),
+            hotspots.TimedJob("TNLean.C", 1.0),
+        ]
+        self.assertEqual(
+            hotspots.render_tsv(jobs, threshold=5.0, limit=1),
+            "seconds\tjob\n10.000\tTNLean.A\n",
+        )
+
+    def test_equal_timings_are_deterministic(self) -> None:
+        jobs = hotspots.parse_timed_jobs(
+            "[1/2] Built TNLean.Z (12s)\n[2/2] Built TNLean.A (12s)\n"
+        )
+        self.assertEqual([job.job for job in jobs], ["TNLean.A", "TNLean.Z"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -74,7 +74,7 @@ class LakeBuildHotspotTests(unittest.TestCase):
             output = io.StringIO()
             with contextlib.redirect_stdout(output):
                 status = hotspots.main([str(log), "--changed-files-from", str(changed)])
-        self.assertEqual(status, 1)
+        self.assertEqual(status, hotspots.TIMING_LIMIT_EXIT)
         self.assertEqual(
             output.getvalue(),
             "\n".join(

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -109,6 +109,17 @@ class LakeBuildHotspotTests(unittest.TestCase):
                 status = hotspots.main([str(log), "--changed-files-from", str(changed)])
         self.assertEqual(status, 0)
 
+    def test_annotations_ignore_jobs_without_a_matching_path(self) -> None:
+        self.assertEqual(
+            hotspots.render_github_annotations(
+                [hotspots.TimedJob("TNLean.Unchanged", 80.0)],
+                ["TNLean/Changed.lean"],
+                warn_threshold=25.0,
+                error_threshold=50.0,
+            ),
+            "",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
+import tempfile
 import unittest
+from pathlib import Path
 
 import lake_build_hotspots as hotspots
 
@@ -47,6 +51,27 @@ class LakeBuildHotspotTests(unittest.TestCase):
             "[1/2] Built TNLean.Z (12s)\n[2/2] Built TNLean.A (12s)\n"
         )
         self.assertEqual([job.job for job in jobs], ["TNLean.A", "TNLean.Z"])
+
+    def test_gate_fails_when_job_reaches_default_fifty_second_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "lake.log"
+            log.write_text(
+                "Built TNLean.Acceptable (49.9s)\nBuilt TNLean.TooSlow (50s)\n",
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                status = hotspots.main([str(log), "--fail-over-threshold"])
+        self.assertEqual(status, 1)
+        self.assertEqual(output.getvalue(), "seconds\tjob\n50.000\tTNLean.TooSlow\n")
+
+    def test_gate_passes_when_all_jobs_are_below_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "lake.log"
+            log.write_text("Built TNLean.Acceptable (49.9s)\n", encoding="utf-8")
+            with contextlib.redirect_stdout(io.StringIO()):
+                status = hotspots.main([str(log), "--fail-over-threshold"])
+        self.assertEqual(status, 0)
 
 
 if __name__ == "__main__":

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -120,6 +120,15 @@ class LakeBuildHotspotTests(unittest.TestCase):
             "",
         )
 
+    def test_changed_file_gate_includes_native_facets(self) -> None:
+        jobs = [hotspots.TimedJob("LintStyle:c.o", 51.0)]
+        paths = ["scripts/LintStyle.lean"]
+        self.assertEqual(hotspots.changed_jobs(jobs, paths), jobs)
+        self.assertIn(
+            "::error file=scripts/LintStyle.lean::LintStyle:c.o compiled in 51.000s",
+            hotspots.render_github_annotations(jobs, paths, 25.0, 50.0),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -52,25 +52,52 @@ class LakeBuildHotspotTests(unittest.TestCase):
         )
         self.assertEqual([job.job for job in jobs], ["TNLean.A", "TNLean.Z"])
 
-    def test_gate_fails_when_job_reaches_default_fifty_second_threshold(self) -> None:
+    def test_changed_file_gate_warns_at_twenty_five_and_fails_at_fifty(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             log = Path(directory) / "lake.log"
+            changed = Path(directory) / "changed.txt"
             log.write_text(
-                "Built TNLean.Acceptable (49.9s)\nBuilt TNLean.TooSlow (50s)\n",
+                "\n".join(
+                    [
+                        "Built TNLean.Unchanged (80s)",
+                        "Built TNLean.Warning (25s)",
+                        "Built TNLean.TooSlow (50s)",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            changed.write_text(
+                "TNLean/Warning.lean\nTNLean/TooSlow.lean\nREADME.md\n",
                 encoding="utf-8",
             )
             output = io.StringIO()
             with contextlib.redirect_stdout(output):
-                status = hotspots.main([str(log), "--fail-over-threshold"])
+                status = hotspots.main([str(log), "--changed-files-from", str(changed)])
         self.assertEqual(status, 1)
-        self.assertEqual(output.getvalue(), "seconds\tjob\n50.000\tTNLean.TooSlow\n")
+        self.assertEqual(
+            output.getvalue(),
+            "\n".join(
+                [
+                    "seconds\tjob",
+                    "50.000\tTNLean.TooSlow",
+                    "25.000\tTNLean.Warning",
+                    "::error file=TNLean/TooSlow.lean::TNLean.TooSlow compiled in 50.000s "
+                    "(warning at 25s, error at 50s)",
+                    "::warning file=TNLean/Warning.lean::TNLean.Warning compiled in 25.000s "
+                    "(warning at 25s, error at 50s)",
+                    "",
+                ]
+            ),
+        )
 
-    def test_gate_passes_when_all_jobs_are_below_threshold(self) -> None:
+    def test_changed_file_gate_ignores_unmodified_slow_modules(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             log = Path(directory) / "lake.log"
-            log.write_text("Built TNLean.Acceptable (49.9s)\n", encoding="utf-8")
+            changed = Path(directory) / "changed.txt"
+            log.write_text("Built TNLean.Unchanged (80s)\n", encoding="utf-8")
+            changed.write_text("TNLean/Changed.lean\n", encoding="utf-8")
             with contextlib.redirect_stdout(io.StringIO()):
-                status = hotspots.main([str(log), "--fail-over-threshold"])
+                status = hotspots.main([str(log), "--changed-files-from", str(changed)])
         self.assertEqual(status, 0)
 
 

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -62,12 +62,13 @@ class LakeBuildHotspotTests(unittest.TestCase):
                         "Built TNLean.Unchanged (80s)",
                         "Built TNLean.Warning (25s)",
                         "Built TNLean.TooSlow (50s)",
+                        "Built LintStyle (30s)",
                     ]
                 ),
                 encoding="utf-8",
             )
             changed.write_text(
-                "TNLean/Warning.lean\nTNLean/TooSlow.lean\nREADME.md\n",
+                "TNLean/Warning.lean\nTNLean/TooSlow.lean\nscripts/LintStyle.lean\nREADME.md\n",
                 encoding="utf-8",
             )
             output = io.StringIO()
@@ -80,8 +81,11 @@ class LakeBuildHotspotTests(unittest.TestCase):
                 [
                     "seconds\tjob",
                     "50.000\tTNLean.TooSlow",
+                    "30.000\tLintStyle",
                     "25.000\tTNLean.Warning",
                     "::error file=TNLean/TooSlow.lean::TNLean.TooSlow compiled in 50.000s "
+                    "(warning at 25s, error at 50s)",
+                    "::warning file=scripts/LintStyle.lean::LintStyle compiled in 30.000s "
                     "(warning at 25s, error at 50s)",
                     "::warning file=TNLean/Warning.lean::TNLean.Warning compiled in 25.000s "
                     "(warning at 25s, error at 50s)",

--- a/scripts/test_lake_build_hotspots.py
+++ b/scripts/test_lake_build_hotspots.py
@@ -63,12 +63,14 @@ class LakeBuildHotspotTests(unittest.TestCase):
                         "Built TNLean.Warning (25s)",
                         "Built TNLean.TooSlow (50s)",
                         "Built LintStyle (30s)",
+                        "Built TNLean.Σlow (26s)",
                     ]
                 ),
                 encoding="utf-8",
             )
             changed.write_text(
-                "TNLean/Warning.lean\nTNLean/TooSlow.lean\nscripts/LintStyle.lean\nREADME.md\n",
+                "TNLean/Warning.lean\nTNLean/TooSlow.lean\nscripts/LintStyle.lean\n"
+                "TNLean/Σlow.lean\nREADME.md\n",
                 encoding="utf-8",
             )
             output = io.StringIO()
@@ -82,10 +84,13 @@ class LakeBuildHotspotTests(unittest.TestCase):
                     "seconds\tjob",
                     "50.000\tTNLean.TooSlow",
                     "30.000\tLintStyle",
+                    "26.000\tTNLean.Σlow",
                     "25.000\tTNLean.Warning",
                     "::error file=TNLean/TooSlow.lean::TNLean.TooSlow compiled in 50.000s "
                     "(warning at 25s, error at 50s)",
                     "::warning file=scripts/LintStyle.lean::LintStyle compiled in 30.000s "
+                    "(warning at 25s, error at 50s)",
+                    "::warning file=TNLean/Σlow.lean::TNLean.Σlow compiled in 26.000s "
                     "(warning at 25s, error at 50s)",
                     "::warning file=TNLean/Warning.lean::TNLean.Warning compiled in 25.000s "
                     "(warning at 25s, error at 50s)",

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -28,16 +28,19 @@ git -C "$REPO" worktree add --detach -q "$TARGET" HEAD
 
 mkdir -p "$REPO/.lake/build" "$REPO/.lake/packages"
 printf 'compiled\n' >"$REPO/.lake/build/example.olean"
-mkdir "$REPO/.lake/packages/example"
-git -C "$REPO/.lake/packages/example" init -q
-printf 'dependency\n' >"$REPO/.lake/packages/example/tracked"
-git -C "$REPO/.lake/packages/example" add tracked
-git -C "$REPO/.lake/packages/example" \
+mkdir "$REPO/.lake/packages/mathlib"
+git -C "$REPO/.lake/packages/mathlib" init -q
+printf '/.lake/\n' >"$REPO/.lake/packages/mathlib/.gitignore"
+printf 'dependency\n' >"$REPO/.lake/packages/mathlib/tracked"
+git -C "$REPO/.lake/packages/mathlib" add .gitignore tracked
+git -C "$REPO/.lake/packages/mathlib" \
   -c user.name=Test \
   -c user.email=test@example.com \
   commit -qm "Initialize dependency"
-DEPENDENCY_REV="$(git -C "$REPO/.lake/packages/example" rev-parse HEAD)"
-printf '{"packages":[{"name":"example","type":"git","rev":"%s"}]}\n' \
+DEPENDENCY_REV="$(git -C "$REPO/.lake/packages/mathlib" rev-parse HEAD)"
+mkdir -p "$REPO/.lake/packages/mathlib/.lake/build/lib/lean"
+printf 'prebuilt\n' >"$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean"
+printf '{"packages":[{"name":"mathlib","type":"git","rev":"%s"}]}\n' \
   "$DEPENDENCY_REV" >"$REPO/lake-manifest.json"
 cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
 
@@ -72,6 +75,28 @@ for cache_child in build packages; do
   mv "$REPO/.lake/$cache_child.real" "$REPO/.lake/$cache_child"
 done
 
+mv "$REPO/.lake/packages/mathlib/.lake/build" \
+  "$REPO/.lake/packages/mathlib/.lake/build.real"
+ln -s build.real "$REPO/.lake/packages/mathlib/.lake/build"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "nested symlinked dependency cache unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
+unlink "$REPO/.lake/packages/mathlib/.lake/build"
+mv "$REPO/.lake/packages/mathlib/.lake/build.real" \
+  "$REPO/.lake/packages/mathlib/.lake/build"
+
+mv "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" \
+  "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean.missing"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "missing prebuilt Mathlib cache unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "source lacks prebuilt Mathlib artifacts" "$TEST_ROOT/error.log"
+mv "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean.missing" \
+  "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean"
+
 printf '{\n' >"$REPO/lake-manifest.json"
 printf '{\n' >"$TARGET/lake-manifest.json"
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
@@ -79,17 +104,17 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   exit 1
 fi
 rg -q "cannot parse Git packages from lake-manifest.json" "$TEST_ROOT/error.log"
-printf '{"packages":[{"name":"example","type":"git","rev":"%s"}]}\n' \
+printf '{"packages":[{"name":"mathlib","type":"git","rev":"%s"}]}\n' \
   "$DEPENDENCY_REV" >"$REPO/lake-manifest.json"
 cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
 
-printf 'modified\n' >>"$REPO/.lake/packages/example/tracked"
+printf 'modified\n' >>"$REPO/.lake/packages/mathlib/tracked"
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
   echo "modified dependency unexpectedly passed" >&2
   exit 1
 fi
-rg -q "Git package has local changes: example" "$TEST_ROOT/error.log"
-printf 'dependency\n' >"$REPO/.lake/packages/example/tracked"
+rg -q "Git package has local changes: mathlib" "$TEST_ROOT/error.log"
+printf 'dependency\n' >"$REPO/.lake/packages/mathlib/tracked"
 
 (
   cd "$REPO"
@@ -98,7 +123,8 @@ printf 'dependency\n' >"$REPO/.lake/packages/example/tracked"
 "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run >/dev/null
 PATH="$TEST_ROOT/bin:$PATH" "$REPO/scripts/seed_lake_build.sh" "$TARGET" >/dev/null
 test -f "$TARGET/.lake/build/example.olean"
-test -f "$TARGET/.lake/packages/example/tracked"
+test -f "$TARGET/.lake/packages/mathlib/tracked"
+test -f "$TARGET/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean"
 test ! -L "$TARGET/.lake"
 
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" 2>"$TEST_ROOT/error.log"; then

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -93,6 +93,18 @@ unlink "$REPO/.lake/packages/mathlib/.lake/build"
 mv "$REPO/.lake/packages/mathlib/.lake/build.real" \
   "$REPO/.lake/packages/mathlib/.lake/build"
 
+mv "$REPO/.lake/packages/mathlib/.lake" \
+  "$REPO/.lake/packages/mathlib/.lake.real"
+ln -s .lake.real "$REPO/.lake/packages/mathlib/.lake"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "symlinked dependency .lake unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
+unlink "$REPO/.lake/packages/mathlib/.lake"
+mv "$REPO/.lake/packages/mathlib/.lake.real" \
+  "$REPO/.lake/packages/mathlib/.lake"
+
 mv "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" \
   "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean.missing"
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -54,7 +54,10 @@ EOF
 chmod +x "$TEST_ROOT/bin/cp"
 cat >"$TEST_ROOT/bin/lake" <<'EOF'
 #!/usr/bin/env bash
-test "$*" = "exe cache get"
+if test "$*" != "exe cache get"; then
+  echo "unexpected lake arguments: $*" >&2
+  exit 2
+fi
 printf 'called\n' >>"$LAKE_CALL_LOG"
 EOF
 chmod +x "$TEST_ROOT/bin/lake"
@@ -158,6 +161,19 @@ fi
 rg -q "cannot read Git package status: mathlib" "$TEST_ROOT/error.log"
 mv "$REPO/.lake/packages/mathlib/.git/index.saved" \
   "$REPO/.lake/packages/mathlib/.git/index"
+
+mv "$REPO/.lake/packages/mathlib/.git" \
+  "$REPO/.lake/packages/mathlib/.git.real"
+printf 'gitdir: %s\n' "$REPO/.lake/packages/mathlib/.git.real" \
+  >"$REPO/.lake/packages/mathlib/.git"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "linked dependency worktree unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "Git package metadata is not self-contained" "$TEST_ROOT/error.log"
+find "$REPO/.lake/packages/mathlib/.git" -delete
+mv "$REPO/.lake/packages/mathlib/.git.real" \
+  "$REPO/.lake/packages/mathlib/.git"
 
 (
   cd "$REPO"

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Lightweight integration test for seed_lake_build.sh.
+set -euo pipefail
+
+SCRIPT_SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/tnlean-lake-seed-test.XXXXXX")"
+
+cleanup() {
+  find "$TEST_ROOT" -depth -delete
+}
+trap cleanup EXIT
+
+REPO="$TEST_ROOT/repo"
+TARGET="$TEST_ROOT/target"
+mkdir -p "$REPO/scripts"
+cp "$SCRIPT_SOURCE/seed_lake_build.sh" "$REPO/scripts/seed_lake_build.sh"
+printf 'leanprover/lean4:v4.32.0\n' >"$REPO/lean-toolchain"
+printf '{}\n' >"$REPO/lake-manifest.json"
+printf 'name = "LakeSeedTest"\n' >"$REPO/lakefile.toml"
+printf '/.lake/\n' >"$REPO/.gitignore"
+git -C "$REPO" init -q
+git -C "$REPO" add .
+git -C "$REPO" \
+  -c user.name=Test \
+  -c user.email=test@example.com \
+  commit -qm "Initialize test repository"
+git -C "$REPO" worktree add --detach -q "$TARGET" HEAD
+
+mkdir -p "$REPO/.lake/build" "$REPO/.lake/packages"
+printf 'compiled\n' >"$REPO/.lake/build/example.olean"
+printf 'dependency\n' >"$REPO/.lake/packages/example"
+
+"$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run >/dev/null
+"$REPO/scripts/seed_lake_build.sh" "$TARGET" >/dev/null
+test -f "$TARGET/.lake/build/example.olean"
+test -f "$TARGET/.lake/packages/example"
+test ! -L "$TARGET/.lake"
+
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" 2>"$TEST_ROOT/error.log"; then
+  echo "second seed unexpectedly succeeded" >&2
+  exit 1
+fi
+rg -q "target already has .lake" "$TEST_ROOT/error.log"
+
+echo "Lake build seed integration test passed"

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -55,8 +55,10 @@ chmod +x "$TEST_ROOT/bin/cp"
 cat >"$TEST_ROOT/bin/lake" <<'EOF'
 #!/usr/bin/env bash
 test "$*" = "exe cache get"
+printf 'called\n' >>"$LAKE_CALL_LOG"
 EOF
 chmod +x "$TEST_ROOT/bin/lake"
+export LAKE_CALL_LOG="$TEST_ROOT/lake-calls.log"
 PATH="$TEST_ROOT/bin:$PATH"
 
 mv "$REPO/.lake" "$REPO/.lake.real"
@@ -150,7 +152,9 @@ mv "$REPO/.lake/packages/mathlib/.git/index.saved" \
   CDPATH="$TEST_ROOT" scripts/seed_lake_build.sh "$TARGET" --dry-run >/dev/null
 )
 "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run >/dev/null
+test ! -e "$LAKE_CALL_LOG"
 PATH="$TEST_ROOT/bin:$PATH" "$REPO/scripts/seed_lake_build.sh" "$TARGET" >/dev/null
+test -s "$LAKE_CALL_LOG"
 test -f "$TARGET/.lake/build/example.olean"
 test -f "$TARGET/.lake/packages/mathlib/tracked"
 test -f "$TARGET/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean"

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -70,7 +70,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "symlinked source cache unexpectedly passed" >&2
   exit 1
 fi
-rg -q "source .lake must not be a symlink" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "source .lake must not be a symlink" "$TEST_ROOT/error.log"
 unlink "$REPO/.lake"
 mv "$REPO/.lake.real" "$REPO/.lake"
 
@@ -81,7 +81,7 @@ for cache_child in build packages; do
     echo "symlinked source cache child unexpectedly passed: $cache_child" >&2
     exit 1
   fi
-  rg -q "source has no regular .lake/$cache_child" "$TEST_ROOT/error.log"
+  /usr/bin/grep -q "source has no regular .lake/$cache_child" "$TEST_ROOT/error.log"
   unlink "$REPO/.lake/$cache_child"
   mv "$REPO/.lake/$cache_child.real" "$REPO/.lake/$cache_child"
 done
@@ -93,7 +93,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "nested symlinked dependency cache unexpectedly passed" >&2
   exit 1
 fi
-rg -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
 unlink "$REPO/.lake/packages/mathlib/.lake/build"
 mv "$REPO/.lake/packages/mathlib/.lake/build.real" \
   "$REPO/.lake/packages/mathlib/.lake/build"
@@ -105,7 +105,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "symlinked dependency .lake unexpectedly passed" >&2
   exit 1
 fi
-rg -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
 unlink "$REPO/.lake/packages/mathlib/.lake"
 mv "$REPO/.lake/packages/mathlib/.lake.real" \
   "$REPO/.lake/packages/mathlib/.lake"
@@ -118,7 +118,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "symlinked Lakefile artifact unexpectedly passed" >&2
   exit 1
 fi
-rg -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
 unlink "$REPO/.lake/packages/mathlib/.lake/lakefile.olean"
 find "$REPO/.lake/packages/mathlib/.lake/lakefile.olean.real" -delete
 
@@ -128,7 +128,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "missing prebuilt Mathlib cache unexpectedly passed" >&2
   exit 1
 fi
-rg -q "source lacks prebuilt Mathlib artifacts" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "source lacks prebuilt Mathlib artifacts" "$TEST_ROOT/error.log"
 mv "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean.missing" \
   "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean"
 
@@ -138,7 +138,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "invalid manifest unexpectedly passed" >&2
   exit 1
 fi
-rg -q "cannot parse Git packages from lake-manifest.json" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "cannot parse Git packages from lake-manifest.json" "$TEST_ROOT/error.log"
 printf '{"packages":[{"name":"mathlib","type":"git","rev":"%s"}]}\n' \
   "$DEPENDENCY_REV" >"$REPO/lake-manifest.json"
 /bin/cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
@@ -148,7 +148,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "modified dependency unexpectedly passed" >&2
   exit 1
 fi
-rg -q "Git package has local changes: mathlib" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "Git package has local changes: mathlib" "$TEST_ROOT/error.log"
 printf 'dependency\n' >"$REPO/.lake/packages/mathlib/tracked"
 
 /bin/cp "$REPO/.lake/packages/mathlib/.git/index" \
@@ -158,7 +158,7 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "unreadable dependency status unexpectedly passed" >&2
   exit 1
 fi
-rg -q "cannot read Git package status: mathlib" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "cannot read Git package status: mathlib" "$TEST_ROOT/error.log"
 mv "$REPO/.lake/packages/mathlib/.git/index.saved" \
   "$REPO/.lake/packages/mathlib/.git/index"
 
@@ -170,10 +170,19 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
   echo "linked dependency worktree unexpectedly passed" >&2
   exit 1
 fi
-rg -q "Git package metadata is not self-contained" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "Git package metadata is not self-contained" "$TEST_ROOT/error.log"
 find "$REPO/.lake/packages/mathlib/.git" -delete
 mv "$REPO/.lake/packages/mathlib/.git.real" \
   "$REPO/.lake/packages/mathlib/.git"
+
+printf '%s\n' "$TEST_ROOT/external-objects" \
+  >"$REPO/.lake/packages/mathlib/.git/objects/info/alternates"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "shared dependency object storage unexpectedly passed" >&2
+  exit 1
+fi
+/usr/bin/grep -q "Git package uses external object storage" "$TEST_ROOT/error.log"
+find "$REPO/.lake/packages/mathlib/.git/objects/info/alternates" -delete
 
 (
   cd "$REPO"
@@ -192,6 +201,6 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" 2>"$TEST_ROOT/error.log"; then
   echo "second seed unexpectedly succeeded" >&2
   exit 1
 fi
-rg -q "target already has .lake" "$TEST_ROOT/error.log"
+/usr/bin/grep -q "target already has .lake" "$TEST_ROOT/error.log"
 
 echo "Lake build seed integration test passed"

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -175,6 +175,15 @@ find "$REPO/.lake/packages/mathlib/.git" -delete
 mv "$REPO/.lake/packages/mathlib/.git.real" \
   "$REPO/.lake/packages/mathlib/.git"
 
+printf '%s\n' "$TEST_ROOT/external-common-metadata" \
+  >"$REPO/.lake/packages/mathlib/.git/commondir"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "external dependency common metadata unexpectedly passed" >&2
+  exit 1
+fi
+/usr/bin/grep -q "Git package uses external common metadata" "$TEST_ROOT/error.log"
+find "$REPO/.lake/packages/mathlib/.git/commondir" -delete
+
 printf '%s\n' "$TEST_ROOT/external-objects" \
   >"$REPO/.lake/packages/mathlib/.git/objects/info/alternates"
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -107,6 +107,18 @@ unlink "$REPO/.lake/packages/mathlib/.lake"
 mv "$REPO/.lake/packages/mathlib/.lake.real" \
   "$REPO/.lake/packages/mathlib/.lake"
 
+printf 'artifact\n' \
+  >"$REPO/.lake/packages/mathlib/.lake/lakefile.olean.real"
+ln -s lakefile.olean.real \
+  "$REPO/.lake/packages/mathlib/.lake/lakefile.olean"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "symlinked Lakefile artifact unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "source contains a symlinked Lake cache directory" "$TEST_ROOT/error.log"
+unlink "$REPO/.lake/packages/mathlib/.lake/lakefile.olean"
+find "$REPO/.lake/packages/mathlib/.lake/lakefile.olean.real" -delete
+
 mv "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean" \
   "$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean.missing"
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -184,6 +184,18 @@ fi
 /usr/bin/grep -q "Git package uses external object storage" "$TEST_ROOT/error.log"
 find "$REPO/.lake/packages/mathlib/.git/objects/info/alternates" -delete
 
+mkdir "$TEST_ROOT/external-worktree"
+git --git-dir="$REPO/.lake/packages/mathlib/.git" \
+  config core.worktree "$TEST_ROOT/external-worktree"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "external dependency worktree unexpectedly passed" >&2
+  exit 1
+fi
+/usr/bin/grep -q "Git package worktree points outside its package root" \
+  "$TEST_ROOT/error.log"
+git --git-dir="$REPO/.lake/packages/mathlib/.git" \
+  config --unset core.worktree
+
 (
   cd "$REPO"
   CDPATH="$TEST_ROOT" scripts/seed_lake_build.sh "$TARGET" --dry-run >/dev/null

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -42,7 +42,7 @@ mkdir -p "$REPO/.lake/packages/mathlib/.lake/build/lib/lean"
 printf 'prebuilt\n' >"$REPO/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean"
 printf '{"packages":[{"name":"mathlib","type":"git","rev":"%s"}]}\n' \
   "$DEPENDENCY_REV" >"$REPO/lake-manifest.json"
-cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
+/bin/cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
 
 mkdir -p "$TEST_ROOT/scripts"
 mkdir -p "$TEST_ROOT/bin"
@@ -52,6 +52,12 @@ echo "PATH cp must not be used" >&2
 exit 99
 EOF
 chmod +x "$TEST_ROOT/bin/cp"
+cat >"$TEST_ROOT/bin/lake" <<'EOF'
+#!/usr/bin/env bash
+test "$*" = "exe cache get"
+EOF
+chmod +x "$TEST_ROOT/bin/lake"
+PATH="$TEST_ROOT/bin:$PATH"
 
 mv "$REPO/.lake" "$REPO/.lake.real"
 ln -s .lake.real "$REPO/.lake"
@@ -106,7 +112,7 @@ fi
 rg -q "cannot parse Git packages from lake-manifest.json" "$TEST_ROOT/error.log"
 printf '{"packages":[{"name":"mathlib","type":"git","rev":"%s"}]}\n' \
   "$DEPENDENCY_REV" >"$REPO/lake-manifest.json"
-cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
+/bin/cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
 
 printf 'modified\n' >>"$REPO/.lake/packages/mathlib/tracked"
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
@@ -115,6 +121,17 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.lo
 fi
 rg -q "Git package has local changes: mathlib" "$TEST_ROOT/error.log"
 printf 'dependency\n' >"$REPO/.lake/packages/mathlib/tracked"
+
+/bin/cp "$REPO/.lake/packages/mathlib/.git/index" \
+  "$REPO/.lake/packages/mathlib/.git/index.saved"
+: >"$REPO/.lake/packages/mathlib/.git/index"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "unreadable dependency status unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "cannot read Git package status: mathlib" "$TEST_ROOT/error.log"
+mv "$REPO/.lake/packages/mathlib/.git/index.saved" \
+  "$REPO/.lake/packages/mathlib/.git/index"
 
 (
   cd "$REPO"

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -30,6 +30,11 @@ mkdir -p "$REPO/.lake/build" "$REPO/.lake/packages"
 printf 'compiled\n' >"$REPO/.lake/build/example.olean"
 printf 'dependency\n' >"$REPO/.lake/packages/example"
 
+mkdir -p "$TEST_ROOT/scripts"
+(
+  cd "$REPO"
+  CDPATH="$TEST_ROOT" scripts/seed_lake_build.sh "$TARGET" --dry-run >/dev/null
+)
 "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run >/dev/null
 "$REPO/scripts/seed_lake_build.sh" "$TARGET" >/dev/null
 test -f "$TARGET/.lake/build/example.olean"

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -31,12 +31,19 @@ printf 'compiled\n' >"$REPO/.lake/build/example.olean"
 printf 'dependency\n' >"$REPO/.lake/packages/example"
 
 mkdir -p "$TEST_ROOT/scripts"
+mkdir -p "$TEST_ROOT/bin"
+cat >"$TEST_ROOT/bin/cp" <<'EOF'
+#!/usr/bin/env bash
+echo "PATH cp must not be used" >&2
+exit 99
+EOF
+chmod +x "$TEST_ROOT/bin/cp"
 (
   cd "$REPO"
   CDPATH="$TEST_ROOT" scripts/seed_lake_build.sh "$TARGET" --dry-run >/dev/null
 )
 "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run >/dev/null
-"$REPO/scripts/seed_lake_build.sh" "$TARGET" >/dev/null
+PATH="$TEST_ROOT/bin:$PATH" "$REPO/scripts/seed_lake_build.sh" "$TARGET" >/dev/null
 test -f "$TARGET/.lake/build/example.olean"
 test -f "$TARGET/.lake/packages/example"
 test ! -L "$TARGET/.lake"

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -60,6 +60,29 @@ rg -q "source .lake must not be a symlink" "$TEST_ROOT/error.log"
 unlink "$REPO/.lake"
 mv "$REPO/.lake.real" "$REPO/.lake"
 
+for cache_child in build packages; do
+  mv "$REPO/.lake/$cache_child" "$REPO/.lake/$cache_child.real"
+  ln -s "$cache_child.real" "$REPO/.lake/$cache_child"
+  if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+    echo "symlinked source cache child unexpectedly passed: $cache_child" >&2
+    exit 1
+  fi
+  rg -q "source has no regular .lake/$cache_child" "$TEST_ROOT/error.log"
+  unlink "$REPO/.lake/$cache_child"
+  mv "$REPO/.lake/$cache_child.real" "$REPO/.lake/$cache_child"
+done
+
+printf '{\n' >"$REPO/lake-manifest.json"
+printf '{\n' >"$TARGET/lake-manifest.json"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "invalid manifest unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "cannot parse Git packages from lake-manifest.json" "$TEST_ROOT/error.log"
+printf '{"packages":[{"name":"example","type":"git","rev":"%s"}]}\n' \
+  "$DEPENDENCY_REV" >"$REPO/lake-manifest.json"
+cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
+
 printf 'modified\n' >>"$REPO/.lake/packages/example/tracked"
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
   echo "modified dependency unexpectedly passed" >&2

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -28,7 +28,18 @@ git -C "$REPO" worktree add --detach -q "$TARGET" HEAD
 
 mkdir -p "$REPO/.lake/build" "$REPO/.lake/packages"
 printf 'compiled\n' >"$REPO/.lake/build/example.olean"
-printf 'dependency\n' >"$REPO/.lake/packages/example"
+mkdir "$REPO/.lake/packages/example"
+git -C "$REPO/.lake/packages/example" init -q
+printf 'dependency\n' >"$REPO/.lake/packages/example/tracked"
+git -C "$REPO/.lake/packages/example" add tracked
+git -C "$REPO/.lake/packages/example" \
+  -c user.name=Test \
+  -c user.email=test@example.com \
+  commit -qm "Initialize dependency"
+DEPENDENCY_REV="$(git -C "$REPO/.lake/packages/example" rev-parse HEAD)"
+printf '{"packages":[{"name":"example","type":"git","rev":"%s"}]}\n' \
+  "$DEPENDENCY_REV" >"$REPO/lake-manifest.json"
+cp "$REPO/lake-manifest.json" "$TARGET/lake-manifest.json"
 
 mkdir -p "$TEST_ROOT/scripts"
 mkdir -p "$TEST_ROOT/bin"
@@ -38,6 +49,25 @@ echo "PATH cp must not be used" >&2
 exit 99
 EOF
 chmod +x "$TEST_ROOT/bin/cp"
+
+mv "$REPO/.lake" "$REPO/.lake.real"
+ln -s .lake.real "$REPO/.lake"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "symlinked source cache unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "source .lake must not be a symlink" "$TEST_ROOT/error.log"
+unlink "$REPO/.lake"
+mv "$REPO/.lake.real" "$REPO/.lake"
+
+printf 'modified\n' >>"$REPO/.lake/packages/example/tracked"
+if "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run 2>"$TEST_ROOT/error.log"; then
+  echo "modified dependency unexpectedly passed" >&2
+  exit 1
+fi
+rg -q "Git package has local changes: example" "$TEST_ROOT/error.log"
+printf 'dependency\n' >"$REPO/.lake/packages/example/tracked"
+
 (
   cd "$REPO"
   CDPATH="$TEST_ROOT" scripts/seed_lake_build.sh "$TARGET" --dry-run >/dev/null
@@ -45,7 +75,7 @@ chmod +x "$TEST_ROOT/bin/cp"
 "$REPO/scripts/seed_lake_build.sh" "$TARGET" --dry-run >/dev/null
 PATH="$TEST_ROOT/bin:$PATH" "$REPO/scripts/seed_lake_build.sh" "$TARGET" >/dev/null
 test -f "$TARGET/.lake/build/example.olean"
-test -f "$TARGET/.lake/packages/example"
+test -f "$TARGET/.lake/packages/example/tracked"
 test ! -L "$TARGET/.lake"
 
 if "$REPO/scripts/seed_lake_build.sh" "$TARGET" 2>"$TEST_ROOT/error.log"; then


### PR DESCRIPTION
### Motivation

Fresh worktrees should reuse an existing local TNLean build instead of recompiling unchanged dependencies, and full builds should produce a simple ranked hotspot list.

### Description

- add `seed_lake_build.sh` to APFS copy-on-write clone an existing worktree's complete `.lake` directory into a fresh worktree;
- default the source to the repository's primary checkout, while allowing an explicit source;
- require the same repository and identical Lean/Lake dependency inputs, and refuse targets that already contain `.lake`;
- add a small parser that sorts real Lake `✔`/`⚠`/`✖` timing lines by duration;
- document the two commands and add lightweight tests.

The cloned artifacts are independent writable files, not shared symlinks. A stale source cache remains correct—Lake rebuilds stale artifacts—but is not necessarily fast; use a source checkout that has completed the desired build.

### Validation

- `bash -n scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh`
- `shellcheck scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh`
- `ruff check scripts/lake_build_hotspots.py scripts/test_lake_build_hotspots.py`
- parser unit tests with exact real Lake status-prefix lines
- synthetic dry-run, APFS CoW seed, and existing-target refusal integration test
- seeded the compilation-hotspot batch from the primary checkout and completed a 9,745-job build
- parsed that saved build log into a correctly ranked hotspot report
- `git diff --check`

No Lean or Mathlib source is changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PR CI’s build path and a new failing gate affect every Lean-touching PR; mis-parsed timings or Archive edge cases could cause false positives, though Lean sources are unchanged.
> 
> **Overview**
> Adds **local developer tooling** and a **PR compilation-time ratchet** on top of the existing Lean build.
> 
> **Local workflow:** `scripts/seed_lake_build.sh` APFS-clones a source worktree’s `.lake` into a fresh target (with strict validation and `--dry-run`). `scripts/lake_build_hotspots.py` parses Lake timing lines into a ranked TSV and optional GitHub annotations. New docs in `docs/lake_build_cache.md` plus index links in `CLAUDE.md` and `docs/ci-automation.md`.
> 
> **PR CI:** The `build` job disables lean-action’s built-in build, runs `lake build` / `lint_style` with a captured log, and on pull requests diffs changed `.lean` files (with explicit builds for `TNLean/Archive/*`). Hotspot analysis warns at **25s** and records a **50s** breach via job output without failing `build` (so proof auto-fix does not run on perf-only failures). A separate **`compile-time`** job fails the check when a changed module hits the limit. Module-policy CI runs unit tests for the parser and `bash -n` on the seed scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ef84d0908ec3cae522be3a657ac2a313669ee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->