### PR TITLE
refactor(blueprint): organize Chapter 11 supporting results

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -242,14 +242,24 @@ leading one), the off-diagonal contributions that obstructed the one-copy
 peeling argument vanish exactly here, and the comparison is the clean
 full-basis linear-independence identity.
 
-This identity is *not* the `SectorBNTCopyWeightMatching.of_coeff_identity` input:
-that lemma needs the scalar-free identity `P.coeff N (β k) = (ζ k)^N * Q.coeff N
-k`.  Eliminating `c N` — equivalently, showing `c N = ξ^N` for a single fixed
-phase `ξ`, so the power can be absorbed into `ζ` — is the residual
-length-scalar control step that the present lemma isolates.  It is documented in
-`docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex`; until it is
-discharged, the proportional global gauge remains the conditional theorem
-`ft_sector_bnt_proportional_global_gauge_of_coeff_identity`. -/
+This scalar-threaded identity is the complete coefficient conclusion under the
+proportional hypotheses.  In general `c N` need not equal `ξ^N` for any fixed
+phase `ξ`: if `C` is a normalized normal tensor, then
+`P = C ⊕ (1/2) C` and `Q = C ⊕ (1/3) C` have proportional positive-length MPV
+families with
+
+`c N = (1 + 2⁻ᴺ) / (1 + 3⁻ᴺ)`,
+
+which is not geometric.  The counterexample and its consequences are recorded
+in `docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex`.
+
+The scalar-free identity required by
+`SectorBNTCopyWeightMatching.of_coeff_identity`, and hence copy-weight matching
+or a global gauge, therefore needs an extra hypothesis.  It holds in the
+equal-MPV case, where the global scalar is `1`.  The theorem
+`ft_sector_bnt_proportional_global_gauge_of_coeff_identity` records the valid
+conditional implication rather than a residual step of the proportional
+fundamental theorem. -/
 theorem coeff_identity_via_matched_mpv_phase_proportional
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean
@@ -559,7 +559,7 @@ length, their literal total tensors are related by a unitary gauge.  The gauge
 is the product of the block-diagonal direct sum of the matched sector unitaries
 and the unitary permutation that restores the original sector coordinates.
 
-Source: Cirac et al., arXiv:1606.00608, Corollary C.5, lines 1197--1199. -/
+Source: Cirac et al., arXiv:1606.00608, Corollary A.6, lines 1197--1199. -/
 private theorem ft_sector_bnt_equal_mps_unitaryGauge_literal
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -690,7 +690,7 @@ Two BNT canonical forms generating the same MPV family at every positive
 length are related by one unitary global gauge after identifying their equal
 total bond dimensions.
 
-Source: Cirac et al., arXiv:1606.00608, Corollary C.5, lines 1197--1199. -/
+Source: Cirac et al., arXiv:1606.00608, Corollary A.6, lines 1197--1199. -/
 theorem fundamentalTheorem_equal_canonicalForm_unitary
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
@@ -16,7 +16,7 @@ BNT canonical form hypotheses of left-canonicity and irreducibility, the
 matched gauges may be chosen unitary.
 
 This is the proportional part of Canonical Form II in Cirac et al.,
-arXiv:1606.00608, Corollary C.5, lines 1197–1199.
+arXiv:1606.00608, Corollary A.6, lines 1197–1199.
 -/
 
 open scoped Matrix BigOperators
@@ -36,7 +36,7 @@ The BNT hypotheses already include left canonicity and irreducibility for each
 basis tensor.  Thus no hypothesis beyond those of the proportional BNT theorem
 is needed for this refinement.
 
-Source: Cirac et al., arXiv:1606.00608, Corollary C.5, lines 1197–1199. -/
+Source: Cirac et al., arXiv:1606.00608, Corollary A.6, lines 1197–1199. -/
 theorem ft_sector_bnt_proportional_unitary_sector_match_witnesses
     {P Q : SectorDecomposition d}
     (hP : IsBNTCanonicalForm P) (hQ : IsBNTCanonicalForm Q)
@@ -93,7 +93,7 @@ is the same phase that occurs in the copy-weight identity. Repeating each
 sector unitary over its matched copies therefore gives a unitary block-diagonal
 global gauge in matched flattened coordinates.
 
-Source: arXiv:1606.00608, Corollary C.5 and Appendix MPV proof,
+Source: arXiv:1606.00608, Corollary A.6 and Appendix MPV proof,
 lines 1182--1199. -/
 theorem ft_sector_bnt_equal_unitary_global_gauge_witnesses
     {P Q : SectorDecomposition d}

--- a/TNLean/MPS/FundamentalTheorem/UnitaryGauge.lean
+++ b/TNLean/MPS/FundamentalTheorem/UnitaryGauge.lean
@@ -54,7 +54,7 @@ uniqueness of the positive semidefinite fixed point up to scale.  Hence
 \]
 
 This is the unitary-gauge input used both in the Fundamental Theorem refinement
-of arXiv:1606.00608, Corollary C.5, and in the periodic corner-unitary argument
+of arXiv:1606.00608, Corollary A.6, and in the periodic corner-unitary argument
 of arXiv:1708.00029, Appendix A, lines 1110--1117.
 -/
 
@@ -159,7 +159,7 @@ unitary matrix \(U\) without changing \(\zeta\), and \(|\zeta|=1\):
 
 Retaining the phase is needed in the equal-MPV case because the same phase
 occurs in the matched copy-weight identity. Source: arXiv:1606.00608,
-Corollary C.5, lines 1197--1199. -/
+Corollary A.6, lines 1197--1199. -/
 theorem exists_unitaryConj_of_gaugePhase_data_of_leftCanonical_irreducible
     [NeZero D] {A B : MPSTensor d D}
     (X : GL (Fin D) ℂ) (ζ : ℂ) (hζ_ne : ζ ≠ 0)
@@ -320,7 +320,7 @@ theorem exists_unitaryConj_of_gaugePhase_data_of_leftCanonical_irreducible
 
 /-- **Per-sector unitarity of the canonical-form gauge.**
 
-Source: arXiv:1606.00608, Corollary C.5; arXiv:1708.00029, Appendix A.
+Source: arXiv:1606.00608, Corollary A.6; arXiv:1708.00029, Appendix A.
 
 If \(A=(A^i)_i\) and \(B=(B^i)_i\) are left-canonical irreducible MPS tensors
 related by a gauge-phase equivalence, then the gauge can be taken unitary: there

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
@@ -1,0 +1,304 @@
+\section{Matched phases and coefficient extraction}
+\label{sec:app_ft_matched_phases}
+
+This section isolates two elementary steps used by the main proof. First, the
+sector partners obtained in both directions determine a finite bijection.
+Second, normalization of the matched normal tensors forces every gauge scalar
+to be a phase.
+
+\begin{theorem}[Bijective matching under eventual proportionality]
+    \label{thm:sector_bnt_proportional_bijective_match}
+    \lean{MPSTensor.bijective_match_of_eventuallyProportional}
+    \leanok
+    \uses{def:sector_bnt_cf, thm:sector_bnt_proportional_full_basis_match,
+        lem:sector_bnt_bijection_from_matches}
+    Let $P$ and $Q$ be BNT canonical forms whose total MPV families are
+    eventually nonzero and proportional. There is a bijection
+    $\beta:J(Q)\simeq J(P)$ such that every $Q_k$ has an equal-dimensional,
+    gauge-phase-equivalent partner $P_{\beta(k)}$, and their cross-overlap does
+    not tend to zero.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the full-basis matching theorem first from $Q$ to $P$ and then to the
+    reverse proportionality from $P$ to $Q$. If two sectors had the same
+    partner, transitivity of gauge-phase equivalence would contradict BNT basis
+    separation. Both partner maps are therefore injective. The two finite
+    sector sets have equal cardinality, so the forward map is bijective and
+    retains its dimension, gauge, and nondecay properties.
+\end{proof}
+
+\begin{lemma}[Unit phase from matched normalized BNT blocks]%
+    \label{lem:sector_bnt_norm_phase_of_matched_mpv}
+    \lean{MPSTensor.IsBNTCanonicalForm.norm_phase_of_matched_mpv}
+    \leanok
+    \uses{def:sector_bnt_cf}
+    Let $P$ and $Q$ be BNT canonical forms. If, for every positive length $N$
+    and word $\sigma$, a sector $P_j$ and a sector $Q_k$ have MPV families
+    related by
+    \begin{align}
+        V^{(N)}(Q_k)_\sigma
+        &= \zeta^N V^{(N)}(P_j)_\sigma,
+        \label{eq:ft_matched_mpv_phase_norm}
+    \end{align}
+    then $|\zeta|=1$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The BNT normalization gives self-overlap limits of modulus $1$ for both
+    sectors. The MPV identity (\ref{eq:ft_matched_mpv_phase_norm}) gives, for
+    every positive $N$,
+    \begin{align}
+        O_{Q_kQ_k}(N)
+        &= |\zeta|^{2N}\,O_{P_jP_j}(N).
+        \notag
+    \end{align}
+    Since $O_{Q_kQ_k}(N)\to1$ and $O_{P_jP_j}(N)\to1$, taking limits forces
+    $|\zeta|^{2N}\to1$ and hence $|\zeta|=1$.
+\end{proof}
+
+
+\section{Coefficient identities from gauge data}
+\label{sec:app_ft_coefficient_wrappers}
+
+The main coefficient theorem takes the matched phases as data. The next result
+shows how those phases are selected from gauge-phase equivalences before the
+linear-independence argument is applied.
+
+\begin{lemma}[Full-basis coefficient identity from matched sectors]%
+    \label{lem:sector_bnt_coeff_identity_via_global_gauge}
+    \lean{MPSTensor.coeff_identity_via_global_gauge}
+    \leanok
+    \uses{def:sector_bnt_cf,
+        def:gauge_phase_equiv}
+    Let $P$ and $Q$ be BNT canonical forms with the same MPV family at every
+    positive length, matched by a bijection $\beta:J(Q)\simeq J(P)$ with
+    bond-dimension equalities and a
+    gauge-phase equivalence between $Q_k$ and $P_{\beta(k)}$ for every $k$. Then
+    each sector carries a unit-modulus phase $\zeta_k$, and eventually
+    \begin{align}
+        c_N^{(\beta(k))}(P)
+        &= \zeta_k^N\,c_N^{(k)}(Q).
+        \label{eq:ft_coeff_identity}
+    \end{align}
+    This is the equal-MPV coefficient comparison of
+    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:sector_bnt_norm_phase_of_matched_mpv,
+        lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
+    For each matched sector, the gauge-phase equivalence gives
+    $V^{(N)}(Q_k)_\sigma=\zeta_k^NV^{(N)}(P_{\beta(k)})_\sigma$.
+    Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv} gives
+    $|\zeta_k|=1$. Applying
+    Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase} to the
+    same phases gives
+    $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ for all sufficiently
+    large $N$.
+\end{proof}
+
+
+\section{The scalar-threaded proportional identity}
+\label{sec:app_ft_proportional_scalar}
+
+For proportional total MPVs, coefficient extraction retains the one scalar
+that relates the two total vectors at each length. This identity is exact, but
+it does not imply the scalar-free identity needed to recover copy weights; the
+counterexample in Remark~\ref{rem:proportional_length_scalar_gap} shows that no
+such implication is possible.
+
+\begin{lemma}[Proportional matched-phase coefficient identity, scalar-threaded]%
+    \label{lem:sector_bnt_coeff_identity_via_matched_mpv_phase_proportional}
+    \lean{MPSTensor.coeff_identity_via_matched_mpv_phase_proportional}
+    \leanok
+    \uses{def:sector_bnt_cf, lem:eventual_coeff_eq_of_eventual_li}
+    Let $P$ be a BNT canonical form and $Q$ a sector decomposition whose total
+    tensors generate eventually nonzero proportional MPV families. Suppose a
+    bijection $\beta:J(Q)\simeq J(P)$ and scalars $\zeta_k$ satisfy the matched
+    MPV phase identities (\ref{eq:ft_phase_relation_hyp}) for every sector $k$.
+    Then there is a single eventually-nonzero scalar sequence $c_N$ and a
+    threshold $N_0$ such that, for all $N>N_0$ and every $k\in J(Q)$,
+    \begin{align}
+        c_N^{(\beta(k))}(P)
+        &= c_N\,\zeta_k^N\,c_N^{(k)}(Q).
+        \label{eq:ft_coeff_identity_threaded}
+    \end{align}
+    The scalar $c_N$ is the same for every sector $k$: it is the single global
+    proportionality scalar of \cite[Theorem~\texttt{thm1}, lines~1167--1170]%
+    {Cirac2016MPDO_arXiv} at length $N$.
+\end{lemma}
+
+\begin{proof}\leanok
+    For each $N$ on the proportionality tail, expand both total MPVs in their
+    sector bases and use the global proportionality scalar $c_N$:
+    \begin{align}
+        \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
+        &=
+        c_N\sum_{k\in J(Q)} c_N^{(k)}(Q)\ket{V^{(N)}(Q_k)}.
+        \notag
+    \end{align}
+    The matched phase identities (\ref{eq:ft_phase_relation_hyp}) give
+    $\ket{V^{(N)}(Q_k)}=\zeta_k^N\ket{V^{(N)}(P_{\beta(k)})}$; because every
+    sector is matched, reindexing the $Q$-sum by $\beta$ rewrites the right-hand
+    side entirely in the $P$-basis. The BNT eventual linear independence of the
+    $P$-basis and Lemma~\ref{lem:eventual_coeff_eq_of_eventual_li} then extract
+    the coefficient identities (\ref{eq:ft_coeff_identity_threaded}) for all
+    sufficiently large $N$.
+\end{proof}
+
+
+\section{Direct-sum conjugation}
+\label{sec:app_ft_direct_sum_conjugation}
+
+We now prove the general block-matrix identities used by the global gauge in
+Section~\ref{sec:ft_equal_global_gauge}. These statements do not choose or
+match sectors; they only combine conjugacies that have already been obtained.
+
+\begin{definition}[Invertible matrix associated to a unitary]
+    \label{def:unitary_gl}
+    \lean{MPSTensor.unitaryGL}
+    \leanok
+    A unitary matrix $U$ determines an invertible matrix whose inverse is
+    $U^\dagger$.
+\end{definition}
+
+\begin{lemma}[Unitary block-diagonal gauges]
+    \label{lem:unitary_global_gauge_of_blocks}
+    \lean{MPSTensor.globalGaugeOfBlocks_unitaryGL_mem}
+    \leanok
+    \uses{def:unitary_gl, def:global_gauge_of_blocks}
+    If every block gauge $U_k$ is unitary, then the flattened block-diagonal
+    gauge $U=\bigoplus_k U_k$ is unitary.
+\end{lemma}
+\begin{proof}\leanok
+    The products are computed blockwise:
+    \begin{align}
+        U U^\dagger
+        &= \bigoplus_k U_kU_k^\dagger
+        = \bigoplus_k\mathbb 1
+        = \mathbb 1.
+        \notag
+    \end{align}
+\end{proof}
+
+\begin{lemma}[Direct-sum conjugation by the flattened gauge]%
+    \label{lem:tensor_from_blocks_globalGauge_conj}
+    \lean{MPSTensor.toTensorFromBlocks_eq_globalGaugeOfBlocks_conj,
+        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockConj}
+    \leanok
+    \uses{def:global_gauge_of_blocks, def:block_diagonal_tensor, def:gauge_equiv}
+    If, for every block $k$ and physical index $i$,
+    $B_k^i=X_kA_k^iX_k^{-1}$, then the weighted direct sums satisfy
+    \begin{align}
+        \bigoplus_k \mu_k B_k^i
+        &=
+        X\left(\bigoplus_k \mu_k A_k^i\right)X^{-1},
+        \notag
+    \end{align}
+    where $X$ is the flattened block-diagonal gauge from
+    Definition~\ref{def:global_gauge_of_blocks}. Hence the two assembled
+    tensors are gauge equivalent.
+\end{lemma}
+
+\begin{proof}\leanok
+    Multiplication of block-diagonal matrices is computed blockwise. The scalar
+    weight $\mu_k$ commutes with the conjugation on the $k$th block, and the
+    reindexing from dependent block coordinates to the flattened bond index
+    preserves products and inverses.
+\end{proof}
+
+\begin{theorem}[Global gauge from a copy-weight matching]%
+    \label{thm:sector_bnt_global_gauge_of_copy_weight_matching}
+    \lean{MPSTensor.sector_bnt_global_gauge_of_copy_weight_matching}
+    \leanok
+    \uses{def:sector_bnt_copy_weight_matching,
+        thm:sector_bnt_global_gauge_of_matched_weights}
+    Suppose that the sectors of $P$ and $Q$ are matched, with
+    bond-dimension equalities, nonzero phases, and block gauges satisfying
+    $Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}$.
+    If the same phases also give a copy-weight matching, then the flattened
+    $Q$-tensor is obtained from the matched-coordinate $P$-tensor by the
+    direct-sum gauge $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
+    This is only a reformulation of
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The copy-weight matching supplies
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$. Together with
+    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$, these are exactly the two
+    hypotheses (\ref{eq:ft_matched_weights_hypotheses}) of
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
+\end{proof}
+
+
+\section{Additional proportional consequences}
+\label{sec:app_ft_conditional_proportional}
+
+The following implications are useful when copy weights satisfy extra
+relations. They are not conclusions of CPSV16 Theorem~2.10. In particular,
+their additional hypotheses fail for the proportional BNT forms in
+Remark~\ref{rem:proportional_length_scalar_gap}.
+
+\begin{theorem}[Additional proportional global gauge under copy-weight matching]%
+    \label{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    \leanok
+    \uses{def:sector_bnt_copy_weight_matching,
+        thm:sector_bnt_proportional_sector_match_witnesses,
+        thm:sector_bnt_global_gauge_of_copy_weight_matching}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
+    eventually nonzero proportional MPV families.
+    Then the proportional sector-matching theorem gives $\beta$, the
+    bond-dimension equalities, the unit phases $\zeta_k$, and the block gauges
+    $X_k$. If one additionally assumes a copy-weight matching for these same phases, then the flattened
+    $Q$-tensor is obtained from the matched-coordinate $P$-tensor by the
+    direct-sum gauge $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
+    % Per-sector unit-modulus restriction eliminated by the exact matcher;
+    % closure recorded in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    The proportional sector-matching theorem supplies $\beta$, $X_k$, and
+    unit phases $\zeta_k$ satisfying
+    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$. Since $|\zeta_k|=1$, each
+    $\zeta_k$ is nonzero. A copy-weight matching gives
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$, so
+    Theorem~\ref{thm:sector_bnt_global_gauge_of_copy_weight_matching} gives the
+    direct-sum gauge.
+\end{proof}
+
+\begin{theorem}[Additional proportional global gauge under coefficient identities]%
+    \label{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}
+    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity}
+    \leanok
+    \uses{lem:sector_bnt_copy_weight_matching_of_coeff_identity,
+        thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
+    eventually nonzero proportional MPV families.
+    Then there are a bijection $\beta:J(Q)\simeq J(P)$, bond-dimension
+    equalities, unit-modulus phases $\zeta_k$, and block gauges $X_k$ such that
+    $Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}$ for every sector $k$ and physical
+    index $i$. If one additionally assumes that these same phases satisfy the matched-sector coefficient
+    identities $c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q)$ for all
+    sufficiently large $N$, then they determine a copy-weight matching and
+    hence the flattened $Q$-tensor is obtained from the matched-coordinate
+    $P$-tensor by the direct-sum gauge
+    $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
+    % Per-sector unit-modulus restriction eliminated by the exact matcher;
+    % closure recorded in
+    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    The sector-matching theorem gives $\beta$, $X_k$, and $|\zeta_k|=1$ with
+    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$. Since $\zeta_k\ne0$, the
+    coefficient identities
+    $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ produce
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$ by
+    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}.
+    Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
+    then applies to this copy-weight matching.
+\end{proof}

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
@@ -59,7 +59,7 @@ to be a phase.
 
 
 \section{Coefficient identities from gauge data}
-\label{sec:app_ft_coefficient_wrappers}
+\label{sec:app_ft_coefficient_identities}
 
 The main coefficient theorem takes the matched phases as data. The next result
 shows how those phases are selected from gauge-phase equivalences before the
@@ -274,7 +274,7 @@ Remark~\ref{rem:proportional_length_scalar_gap}.
     \label{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}
     \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity}
     \leanok
-    \uses{lem:sector_bnt_copy_weight_matching_of_coeff_identity,
+    \uses{def:sector_bnt_copy_weight_matching_of_coeff_identity,
         thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
     eventually nonzero proportional MPV families.
@@ -298,7 +298,7 @@ Remark~\ref{rem:proportional_length_scalar_gap}.
     coefficient identities
     $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ produce
     $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$ by
-    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}.
+    Definition~\ref{def:sector_bnt_copy_weight_matching_of_coeff_identity}.
     Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
     then applies to this copy-weight matching.
 \end{proof}

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
@@ -15,17 +15,27 @@ to be a phase.
     Let $P$ and $Q$ be BNT canonical forms whose total MPV families are
     eventually nonzero and proportional. There is a bijection
     $\beta:J(Q)\simeq J(P)$ such that every $Q_k$ has an equal-dimensional,
-    gauge-phase-equivalent partner $P_{\beta(k)}$, and their cross-overlap does
-    not tend to zero.
+    gauge-phase-equivalent partner $P_{\beta(k)}$ satisfying
+    \begin{align}
+        O_{P_{\beta(k)}Q_k}(N)
+         & \not\longrightarrow 0.
+        \notag
+    \end{align}
 \end{theorem}
 
 \begin{proof}\leanok
     Apply the full-basis matching theorem first from $Q$ to $P$ and then to the
-    reverse proportionality from $P$ to $Q$. If two sectors had the same
-    partner, transitivity of gauge-phase equivalence would contradict BNT basis
-    separation. Both partner maps are therefore injective. The two finite
-    sector sets have equal cardinality, so the forward map is bijective and
-    retains its dimension, gauge, and nondecay properties.
+    reverse proportionality from $P$ to $Q$. If $P_j$ and $P_{j'}$ had the same
+    partner $Q_k$, then symmetry and transitivity would give
+    \begin{align}
+        P_j\sim_{\mathrm{gp}}Q_k\sim_{\mathrm{gp}}P_{j'}
+         & \Longrightarrow P_j\sim_{\mathrm{gp}}P_{j'},
+        \notag
+    \end{align}
+    contradicting BNT basis separation. Both partner maps are therefore
+    injective. The two finite sector sets have equal cardinality, so the forward
+    map is bijective and retains the displayed overlap limit together with the
+    dimension and gauge data.
 \end{proof}
 
 \begin{lemma}[Unit phase from matched normalized BNT blocks]%
@@ -58,10 +68,10 @@ to be a phase.
 \end{proof}
 
 
-\section{Coefficient identities from gauge data}
+\section{Coefficient identities from gauge-phase equalities}
 \label{sec:app_ft_coefficient_identities}
 
-The main coefficient theorem takes the matched phases as data. The next result
+The main coefficient theorem takes the matched phases as input. The next result
 shows how those phases are selected from gauge-phase equivalences before the
 linear-independence argument is applied.
 

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks.tex
@@ -38,7 +38,7 @@ to be a phase.
     related by
     \begin{align}
         V^{(N)}(Q_k)_\sigma
-        &= \zeta^N V^{(N)}(P_j)_\sigma,
+         & = \zeta^N V^{(N)}(P_j)_\sigma,
         \label{eq:ft_matched_mpv_phase_norm}
     \end{align}
     then $|\zeta|=1$.
@@ -50,7 +50,7 @@ to be a phase.
     every positive $N$,
     \begin{align}
         O_{Q_kQ_k}(N)
-        &= |\zeta|^{2N}\,O_{P_jP_j}(N).
+         & = |\zeta|^{2N}\,O_{P_jP_j}(N).
         \notag
     \end{align}
     Since $O_{Q_kQ_k}(N)\to1$ and $O_{P_jP_j}(N)\to1$, taking limits forces
@@ -78,7 +78,7 @@ linear-independence argument is applied.
     each sector carries a unit-modulus phase $\zeta_k$, and eventually
     \begin{align}
         c_N^{(\beta(k))}(P)
-        &= \zeta_k^N\,c_N^{(k)}(Q).
+         & = \zeta_k^N\,c_N^{(k)}(Q).
         \label{eq:ft_coeff_identity}
     \end{align}
     This is the equal-MPV coefficient comparison of
@@ -121,7 +121,7 @@ such implication is possible.
     threshold $N_0$ such that, for all $N>N_0$ and every $k\in J(Q)$,
     \begin{align}
         c_N^{(\beta(k))}(P)
-        &= c_N\,\zeta_k^N\,c_N^{(k)}(Q).
+         & = c_N\,\zeta_k^N\,c_N^{(k)}(Q).
         \label{eq:ft_coeff_identity_threaded}
     \end{align}
     The scalar $c_N$ is the same for every sector $k$: it is the single global
@@ -134,7 +134,7 @@ such implication is possible.
     sector bases and use the global proportionality scalar $c_N$:
     \begin{align}
         \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
-        &=
+         & =
         c_N\sum_{k\in J(Q)} c_N^{(k)}(Q)\ket{V^{(N)}(Q_k)}.
         \notag
     \end{align}
@@ -175,7 +175,7 @@ match sectors; they only combine conjugacies that have already been obtained.
     The products are computed blockwise:
     \begin{align}
         U U^\dagger
-        &= \bigoplus_k U_kU_k^\dagger
+         & = \bigoplus_k U_kU_k^\dagger
         = \bigoplus_k\mathbb 1
         = \mathbb 1.
         \notag
@@ -192,7 +192,7 @@ match sectors; they only combine conjugacies that have already been obtained.
     $B_k^i=X_kA_k^iX_k^{-1}$, then the weighted direct sums satisfy
     \begin{align}
         \bigoplus_k \mu_k B_k^i
-        &=
+         & =
         X\left(\bigoplus_k \mu_k A_k^i\right)X^{-1},
         \notag
     \end{align}

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
@@ -7,7 +7,7 @@ matched $P$-data on that index are the weight and tensor
 \begin{align}
     \widetilde\mu_{k,q}
      & =\mu_{\beta(k),\tau_k(q)},
-    &
+     &
     \widetilde P_{k,q}
      & =P_{\beta(k)},
     \notag
@@ -122,7 +122,7 @@ Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
     \begin{align}
         \Pi_\rho\Pi_{\rho^{-1}}
          & =\Id,
-        &
+         &
         \Pi_\rho^\dagger
          & =\Pi_{\rho^{-1}}.
         \notag
@@ -165,7 +165,7 @@ existential form and then repeat the construction over every matched copy.
     unitary: there are a unitary matrix $U$ and a scalar $\zeta$ with
     $|\zeta|=1$ such that, for every physical index~$i$,
     \begin{align}
-        B^i&=\zeta\,UA^iU^\dagger. \notag
+        B^i & =\zeta\,UA^iU^\dagger. \notag
     \end{align}
 \end{lemma}
 
@@ -192,13 +192,13 @@ existential form and then repeat the construction over every matched copy.
     and a unitary block-diagonal matrix $X$ such that
     \begin{align}
         Q_k^i
-        &= \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
-        \notag\\
+         & = \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
+        \notag                                     \\
         \nu_{k,q}
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)},
-        \notag\\
+         & = \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)},
+        \notag                                     \\
         |\zeta_k|
-        &= 1.
+         & = 1.
         \notag
     \end{align}
     The matched sectors and copies have equal bond dimensions and
@@ -217,8 +217,8 @@ existential form and then repeat the construction over every matched copy.
     $(k,q)$,
     \begin{align}
         \nu_{k,q}Q_k^i
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}
-          \zeta_k U_kP_{\beta(k)}^iU_k^\dagger
+         & = \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}
+        \zeta_k U_kP_{\beta(k)}^iU_k^\dagger
         = \mu_{\beta(k),\tau_k(q)}U_kP_{\beta(k)}^iU_k^\dagger.
         \notag
     \end{align}

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
@@ -1,0 +1,227 @@
+\section{Matched flattened coordinates}
+\label{sec:app_ft_matched_coordinates}
+
+Let $\beta:J(Q)\simeq J(P)$ match the basis sectors and let $\tau_k$ match the
+copies in sector $k$. Flatten the pair $(k,q)$ to the copy index of $Q$. The
+matched $P$-data on that index are the weight and tensor
+\begin{align}
+    \widetilde\mu_{k,q}
+     & =\mu_{\beta(k),\tau_k(q)},
+    &
+    \widetilde P_{k,q}
+     & =P_{\beta(k)},
+    \notag
+\end{align}
+where the second expression is read after the matched bond-dimension
+identification. The block gauge repeats $X_k$ on every copy $q$.
+
+\begin{definition}[Matched weights, tensors, and repeated gauges]
+    \label{def:ft_matched_flat_data}
+    \lean{MPSTensor.matched_p_weight,
+        MPSTensor.matched_p_basis,
+        MPSTensor.matched_block_gauge}
+    \leanok
+    The matched flattened data are the functions
+    $\widetilde\mu$, $\widetilde P$, and $(k,q)\mapsto X_k$ defined above on
+    the flattened copy coordinates of $Q$.
+\end{definition}
+
+\begin{lemma}[Equality of the matched total bond dimensions]
+    \label{lem:ft_total_dim_eq_of_match}
+    \lean{MPSTensor.SectorDecomposition.totalDim_eq_of_match}
+    \leanok
+    \uses{def:ft_matched_flat_data}
+    If matched sectors have equal bond dimensions and matched copy sets are
+    bijective, then $P$ and $Q$ have the same total bond dimension.
+\end{lemma}
+
+\begin{proof}\leanok
+    Reindex first by the sector bijection and then by each copy bijection.
+    Every summand $\dim P_{\beta(k)}$ becomes $\dim Q_k$, so
+    \begin{align}
+        \sum_{j\in J(P)}r_j(P)\dim P_j
+         & =\sum_{k\in J(Q)}r_k(Q)\dim Q_k.
+        \notag
+    \end{align}
+\end{proof}
+
+\begin{definition}[Sector and bond-coordinate equivalences]
+    \label{def:ft_sector_flat_equiv}
+    \lean{MPSTensor.SectorDecomposition.sectorFlatSigmaEquiv,
+        MPSTensor.SectorDecomposition.sectorFlatDimEquiv}
+    \leanok
+    \uses{lem:ft_total_dim_eq_of_match}
+    The sector bijection, copy bijections, and bond-dimension equalities induce
+    an equivalence of the dependent triples $(j,q,a)$ and $(k,q',a')$. After
+    flattening the dependent bond coordinate, this gives an equivalence of the
+    standard total bond-index sets.
+\end{definition}
+
+\begin{proof}\leanok
+    Send $(k,q,a)$ to
+    $(\beta(k),\tau_k(q),a)$, using the bond-dimension equality to identify the
+    last coordinate. The inverse uses $\beta^{-1}$ and $\tau_k^{-1}$. Both
+    composites are the identity componentwise. Conjugating by the standard
+    equivalence between dependent triples and a finite interval gives the
+    flattened bond-coordinate equivalence.
+\end{proof}
+
+\begin{theorem}[Equal-MPV gauge with all matched witnesses]
+    \label{thm:sector_bnt_equal_mps_gaugeEquiv_witnesses}
+    \lean{MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_witnesses}
+    \leanok
+    \uses{thm:sector_bnt_equal_global_gauge,
+        lem:ft_total_dim_eq_of_match, def:ft_matched_flat_data}
+    Under the hypotheses of the equal-MPV theorem, one may choose
+    simultaneously the sector bijection, bond-dimension equalities, copy
+    bijections, phases, block gauges, total-dimension equality, and the
+    flattened global gauge. They satisfy the matched block and weight
+    identities of Theorem~\ref{thm:sector_bnt_equal_global_gauge}, together
+    with the conjugation of $Q$ by the matched-coordinate $P$-tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    Theorem~\ref{thm:sector_bnt_equal_global_gauge} supplies all witnesses
+    except the displayed equality of total dimensions. Apply
+    Lemma~\ref{lem:ft_total_dim_eq_of_match} to its sector and copy bijections.
+    The resulting equality identifies the total bond spaces, while the global
+    conjugation equation is unchanged.
+\end{proof}
+
+\section{Permutation gauges and literal coordinates}
+\label{sec:app_ft_permutation_gauges}
+
+The matched $P$-tensor has the correct blocks but lists them in $Q$-order. A
+permutation matrix restores the literal order of $P$. We record its invertible
+and unitary forms before proving the coordinate conversion used in
+Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
+
+\begin{definition}[Invertible permutation gauge]
+    \label{def:ft_perm_gl}
+    \lean{MPSTensor.permGL}
+    \leanok
+    For a permutation $\rho$ of a finite bond-index set, let $\Pi_\rho$ be its
+    permutation matrix. The corresponding element of the general linear group
+    is denoted $G_\rho$.
+\end{definition}
+
+\begin{lemma}[Matrix, inverse, and unitary identities for a permutation gauge]
+    \label{lem:ft_perm_gl_identities}
+    \lean{MPSTensor.permGL_val,
+        MPSTensor.permGL_inv_val,
+        MPSTensor.permGL_mem_unitaryGroup}
+    \leanok
+    \uses{def:ft_perm_gl}
+    The matrix of $G_\rho$ is $\Pi_\rho$, its inverse is
+    $\Pi_{\rho^{-1}}$, and it is unitary.
+\end{lemma}
+
+\begin{proof}\leanok
+    Every row and every column of $\Pi_\rho$ contains exactly one nonzero
+    entry, equal to $1$. Hence
+    \begin{align}
+        \Pi_\rho\Pi_{\rho^{-1}}
+         & =\Id,
+        &
+        \Pi_\rho^\dagger
+         & =\Pi_{\rho^{-1}}.
+        \notag
+    \end{align}
+    These identities give both the inverse formula and unitarity.
+\end{proof}
+
+The coordinate equivalence of Definition~\ref{def:ft_sector_flat_equiv}
+induces a permutation $\rho$ after the total-dimension identification. For any
+matrix $M$, conjugation by its permutation gauge reindexes both matrix
+coordinates:
+\begin{align}
+    G_\rho M G_\rho^{-1}
+     & =M\circ(\rho^{-1}\times\rho^{-1}).
+    \label{eq:app_ft_perm_conjugation}
+\end{align}
+Applying (\ref{eq:app_ft_perm_conjugation}) to $P_{\mathrm{tot}}^i$ gives the
+matched-coordinate tensor. Composing $G_\rho$ with the block-diagonal gauge
+therefore gives the literal gauge of
+Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}. This also explains
+why the total-dimension cast and the sector permutation must occur in that
+order.
+
+\section{Unitary witness refinements}
+\label{sec:app_ft_unitary_witnesses}
+
+The main text proves that a specified gauge between left-canonical irreducible
+sectors can be replaced by a unitary without changing its phase. We record the
+existential form and then repeat the construction over every matched copy.
+
+\begin{lemma}[Unitary gauge for left-canonical irreducible tensors]
+    \label{lem:left_canonical_irreducible_unitary_gauge}
+    \lean{MPSTensor.exists_unitaryConj_gaugePhase_of_leftCanonical_irreducible}
+    \leanok
+    \uses{def:left_canonical_tensor, def:gauge_phase_equiv,
+        def:irreducible_tensor,
+        lem:left_canonical_irreducible_same_phase_unitary_gauge}
+    Let $A$ and $B$ be left-canonical irreducible tensors of common positive bond
+    dimension that are gauge-phase equivalent. Then the gauge can be taken
+    unitary: there are a unitary matrix $U$ and a scalar $\zeta$ with
+    $|\zeta|=1$ such that, for every physical index~$i$,
+    \begin{align}
+        B^i&=\zeta\,UA^iU^\dagger. \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:left_canonical_irreducible_same_phase_unitary_gauge}
+    Unpack the gauge-phase equivalence as
+    $B^i=\zeta XA^iX^{-1}$ with $X$ invertible and $\zeta\ne0$.
+    Lemma~\ref{lem:left_canonical_irreducible_same_phase_unitary_gauge}
+    replaces $X$ by a unitary $U$ while retaining this same phase and proves
+    $|\zeta|=1$.
+\end{proof}
+
+\begin{lemma}[Unitary gauge in matched sector coordinates]
+    \label{lem:sector_bnt_equal_unitary_matched_gauge}
+    \lean{MPSTensor.ft_sector_bnt_equal_unitary_global_gauge_witnesses}
+    \leanok
+    \uses{lem:sector_bnt_equal_matched_copy_weight_witnesses,
+        lem:left_canonical_irreducible_same_phase_unitary_gauge,
+        thm:sector_bnt_global_gauge_of_copy_weight_matching,
+        lem:unitary_global_gauge_of_blocks}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate the
+    same MPV family at every positive length. There are a sector bijection
+    $\beta$, copy bijections $\tau_k$, phases $\zeta_k$, sector unitaries $U_k$,
+    and a unitary block-diagonal matrix $X$ such that
+    \begin{align}
+        Q_k^i
+        &= \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
+        \notag\\
+        \nu_{k,q}
+        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)},
+        \notag\\
+        |\zeta_k|
+        &= 1.
+        \notag
+    \end{align}
+    The matched sectors and copies have equal bond dimensions and
+    multiplicities. If $P_{\mathrm{match}}$ denotes the corresponding
+    reordered block assembly, then
+    $Q_{\mathrm{flat}}^i=XP_{\mathrm{match}}^iX^{-1}$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:sector_bnt_equal_matched_copy_weight_witnesses,
+        lem:left_canonical_irreducible_same_phase_unitary_gauge,
+        lem:unitary_global_gauge_of_blocks}
+    Apply Lemma~\ref{lem:left_canonical_irreducible_same_phase_unitary_gauge}
+    to each matched sector, retaining the phase in the copy-weight identity.
+    Repeating $U_k$ on every copy gives $X=\bigoplus_{k,q}U_k$, which is unitary
+    by Lemma~\ref{lem:unitary_global_gauge_of_blocks}. For every matched copy
+    $(k,q)$,
+    \begin{align}
+        \nu_{k,q}Q_k^i
+        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}
+          \zeta_k U_kP_{\beta(k)}^iU_k^\dagger
+        = \mu_{\beta(k),\tau_k(q)}U_kP_{\beta(k)}^iU_k^\dagger.
+        \notag
+    \end{align}
+    These are precisely the blocks of
+    $Q_{\mathrm{flat}}^i=XP_{\mathrm{match}}^iX^{-1}$.
+\end{proof}

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
@@ -123,7 +123,7 @@ Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
 
 \begin{lemma}[Unitarity of a permutation gauge]
     \label{lem:ft_perm_gl_unitary}
-    \uses{lem:ft_perm_gl_identities}
+    \uses{def:ft_perm_gl, lem:ft_perm_gl_identities}
     The permutation gauge $G_\rho$ is unitary.
 \end{lemma}
 

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
@@ -121,42 +121,37 @@ Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
     $G_\rho^{-1}=G_{\rho^{-1}}$, which gives the second identity.
 \end{proof}
 
-\begin{lemma}[Unitarity of a permutation gauge]
-    \label{lem:ft_perm_gl_unitary}
-    \uses{def:ft_perm_gl, lem:ft_perm_gl_identities}
-    The permutation gauge $G_\rho$ is unitary.
-\end{lemma}
-
-\begin{proof}
-    Every row and every column of $\Pi_\rho$ contains exactly one nonzero
-    entry, equal to $1$. Hence
-    \begin{align}
-        \Pi_\rho\Pi_{\rho^{-1}}
-         & =\Id,
-         &
-        \Pi_\rho^\dagger
-         & =\Pi_{\rho^{-1}}.
-        \notag
-    \end{align}
-    Together with Lemma~\ref{lem:ft_perm_gl_identities}, these identities show
-    that $G_\rho^\dagger=G_\rho^{-1}$.
-\end{proof}
+Every row and every column of $\Pi_\rho$ contains exactly one nonzero entry,
+equal to $1$. Hence
+\begin{align}
+    \Pi_\rho\Pi_{\rho^{-1}}
+     & =\Id,
+     &
+    \Pi_\rho^\dagger
+     & =\Pi_{\rho^{-1}}.
+    \notag
+\end{align}
+Together with Lemma~\ref{lem:ft_perm_gl_identities}, these identities show that
+$G_\rho^\dagger=G_\rho^{-1}$, so the permutation gauge is unitary.
 
 The coordinate equivalence of Definition~\ref{def:ft_sector_flat_equiv}
-induces a permutation $\rho$ after the total-dimension identification. For any
-matrix $M$, conjugation by its permutation gauge reindexes both matrix
-coordinates:
+induces a permutation $\rho$ after the total-dimension identification. With the
+permutation-matrix convention used here, conjugation reindexes both matrix
+coordinates by $\rho$:
 \begin{align}
-    G_\rho M G_\rho^{-1}
-     & =M\circ(\rho^{-1}\times\rho^{-1}).
+    \bigl(G_\rho M G_\rho^{-1}\bigr)_{ij}
+     & =M_{\rho(i),\rho(j)}.
     \label{eq:app_ft_perm_conjugation}
 \end{align}
-Applying (\ref{eq:app_ft_perm_conjugation}) to $P_{\mathrm{tot}}^i$ gives the
-matched-coordinate tensor. Composing $G_\rho$ with the block-diagonal gauge
-therefore gives the literal gauge of
-Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}. This also explains
-why the total-dimension cast and the sector permutation must occur in that
-order.
+Equivalently, the right-hand side is the submatrix of $M$ along
+$\rho\times\rho$. A convention with inverse indices merely replaces the chosen
+permutation by $\rho^{-1}$; we use the convention in
+(\ref{eq:app_ft_perm_conjugation}) to match the formal coordinate identity.
+Applying that identity to $P_{\mathrm{tot}}^i$ gives the matched-coordinate
+tensor. Composing $G_\rho$ with the block-diagonal gauge therefore gives the
+literal gauge of Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
+This also explains why the total-dimension cast and the sector permutation must
+occur in that order.
 
 \section{Unitary witness refinements}
 \label{sec:app_ft_unitary_witnesses}

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries.tex
@@ -105,18 +105,29 @@ Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
     is denoted $G_\rho$.
 \end{definition}
 
-\begin{lemma}[Matrix, inverse, and unitary identities for a permutation gauge]
+\begin{lemma}[Matrix and inverse identities for a permutation gauge]
     \label{lem:ft_perm_gl_identities}
     \lean{MPSTensor.permGL_val,
-        MPSTensor.permGL_inv_val,
-        MPSTensor.permGL_mem_unitaryGroup}
+        MPSTensor.permGL_inv_val}
     \leanok
     \uses{def:ft_perm_gl}
-    The matrix of $G_\rho$ is $\Pi_\rho$, its inverse is
-    $\Pi_{\rho^{-1}}$, and it is unitary.
+    The matrix of $G_\rho$ is $\Pi_\rho$, and the matrix of its inverse is
+    $\Pi_{\rho^{-1}}$.
 \end{lemma}
 
 \begin{proof}\leanok
+    The first identity is the definition of the permutation gauge. Since the
+    inverse permutation reverses the coordinate relabelling,
+    $G_\rho^{-1}=G_{\rho^{-1}}$, which gives the second identity.
+\end{proof}
+
+\begin{lemma}[Unitarity of a permutation gauge]
+    \label{lem:ft_perm_gl_unitary}
+    \uses{lem:ft_perm_gl_identities}
+    The permutation gauge $G_\rho$ is unitary.
+\end{lemma}
+
+\begin{proof}
     Every row and every column of $\Pi_\rho$ contains exactly one nonzero
     entry, equal to $1$. Hence
     \begin{align}
@@ -127,7 +138,8 @@ Theorem~\ref{thm:sector_bnt_equal_mps_gaugeEquiv_literal}.
          & =\Pi_{\rho^{-1}}.
         \notag
     \end{align}
-    These identities give both the inverse formula and unitarity.
+    Together with Lemma~\ref{lem:ft_perm_gl_identities}, these identities show
+    that $G_\rho^\dagger=G_\rho^{-1}$.
 \end{proof}
 
 The coordinate equivalence of Definition~\ref{def:ft_sector_flat_equiv}

--- a/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/appendix/ft_mps/ch11_fundamental_theorem_proof.tex
@@ -1,0 +1,12 @@
+\chapter{Proof of the Fundamental Theorem: Supporting Results}
+\label{ch:ft_proof_supporting_results}
+
+This appendix supports Chapter~\ref{ch:ft_proof}. It proves phase
+normalization, coefficient extraction from matched gauges, direct-sum
+conjugation, the exact consequences of length-dependent proportionality,
+coordinate reindexing, and unitary refinements. The first part concerns
+coefficients and block gauges; the second identifies matched coordinates with
+the literal total bond space.
+
+\input{appendix/ft_mps/ch11_fundamental_theorem_coefficients_and_blocks}
+\input{appendix/ft_mps/ch11_fundamental_theorem_coordinates_and_unitaries}

--- a/blueprint/src/appendix/ft_mps_appendices.tex
+++ b/blueprint/src/appendix/ft_mps_appendices.tex
@@ -6,3 +6,4 @@
 \input{appendix/ft_mps/ch08_wielandt}
 \input{appendix/ft_mps/ch09_canonical}
 \input{appendix/ft_mps/ch10_bnt}
+\input{appendix/ft_mps/ch11_fundamental_theorem_proof}

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -378,8 +378,22 @@ and~\cite{Evans1978Spectral}.
     Section~\ref{sec:app_qpf_gauge}.
 \end{proof}
 
+\begin{definition}[Left-canonical normalization]
+    \label{def:left_canonical_tensor}
+    \lean{MPSTensor.IsLeftCanonical}
+    \leanok
+    An MPS tensor $A=(A^i)_i$ is left-canonical when
+    \begin{align}
+        \sum_i (A^i)^\dagger A^i
+         & =\Id.
+        \notag
+    \end{align}
+    Equivalently, its Kraus map is trace-preserving.
+\end{definition}
+
 \begin{theorem}[Left-canonical (trace-preserving) gauge]\label{thm:left_canonical_gauge}
     \lean{gauged_tracePreserving}
+    \uses{def:left_canonical_tensor}
     \leanok
     Let $\sigma$ be a fixed point of the adjoint transfer map
     $\sum_i (A^i)^\dagger \sigma A^i = \sigma$,

--- a/blueprint/src/chapter/ch10_bnt_matching.tex
+++ b/blueprint/src/chapter/ch10_bnt_matching.tex
@@ -21,11 +21,13 @@ $\mu_{j,q} = \nu_{j,q}\, e^{i\varphi_j}$ recovery of
 % Source: matched normal sectors at Cirac2016MPDO_arXiv line 1182; equal-MPV
 % coefficient comparison at lines 1184--1188; global-gauge construction at
 % lines 1189--1192.
-The coefficient identity is supplied, in the equal-MPV case, by
-Lemma~\ref{lem:sector_bnt_coeff_identity_via_global_gauge} of
-Chapter~\ref{ch:ft_proof}; in the proportional case it is the remaining
-hypothesis of the conditional proportional global gauge
-(Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}).
+In the equal-MPV case, Chapter~\ref{ch:ft_proof} obtains this coefficient
+identity by expanding both total MPVs in the matched BNT basis and applying
+eventual linear independence
+(Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase}). For merely
+proportional total MPVs, a common length-dependent scalar remains in every
+matched coefficient identity and the scalar-free comparison need not hold; see
+Remark~\ref{rem:proportional_length_scalar_gap}.
 
 \begin{lemma}[Matched-sector weight multiset equality]%
     \label{lem:sector_bnt_matched_sector_weight_multiset_eq}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
@@ -27,16 +27,11 @@
 
 \begin{proof}\leanok
     \uses{thm:sector_bnt_proportional_sector_match_witnesses}
-    Fix $Q_k$. Nondecay against at least one $P_j$ follows by contradiction:
-    if every cross-overlap decayed, eventual linear independence of the
-    combined family would force the nonzero $Q_k$ coefficient in the global
-    proportionality relation to vanish. The normal-overlap dichotomy then
-    identifies an equal-dimensional gauge-phase-equivalent partner. Repeating
-    the argument from $P$ to $Q$ gives injections in both directions, and
-    finiteness promotes the forward partners to a bijection $\beta$.
-    Choosing the gauge-phase witnesses gives $Y_k$ and $\zeta_k$; the word
-    trace identity supplies the power $\zeta_k^N$, and normalized self-overlaps
-    force $|\zeta_k|=1$.
+    Apply Theorem~\ref{thm:sector_bnt_proportional_sector_match_witnesses}.
+    Its partition-and-substitution argument gives a bijection
+    $\beta:J(Q)\simeq J(P)$, equal bond dimensions, invertible block gauges
+    $X_k$, and phases $\zeta_k$ of unit modulus. Taking $Y_k=X_k$ gives exactly
+    the asserted relations.
 \end{proof}
 
 This is \cite[Theorem~2.10]{Cirac2016MPDO_arXiv}; see also

--- a/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
@@ -1,11 +1,6 @@
-\section{The equal and proportional cases}\label{sec:ft_equal_proportional_cases}
+\section{The proportional and equal source theorems}
+\label{sec:ft_equal_proportional_cases}
 
-% The CPSV16 proportional theorem is proved here for BNT canonical forms,
-% using the sector-matching witnesses of Chapter~\ref{ch:bnt}. The
-% per-block phases are not collapsed into a single global gauge on the total
-% tensor; that additional step needs the proportional coefficient identity and
-% is recorded conditionally above
-% (thm:sector_bnt_proportional_global_gauge_of_coeff_identity).
 \begin{theorem}[Multi-block fundamental theorem for normal tensors]%
     \label{thm:cpgsv_multiblock_ft_source}
     \lean{MPSTensor.fundamentalTheorem_proportional_canonicalForm}
@@ -32,32 +27,32 @@
 
 \begin{proof}\leanok
     \uses{thm:sector_bnt_proportional_sector_match_witnesses}
-    The proportional sector-matching
-    Theorem~\ref{thm:sector_bnt_proportional_sector_match_witnesses}, applied to
-    the BNT canonical forms $P$ and $Q$, supplies the bijection $\beta$, the
-    bond-dimension equalities, the unit phases $\zeta_k$, and the block gauges
-    $Y_k$ with $Q_k^i=\zeta_kY_kP_{\beta(k)}^iY_k^{-1}$; the matching needs
-    no per-sector unit-modulus hypothesis.
+    Fix $Q_k$. Nondecay against at least one $P_j$ follows by contradiction:
+    if every cross-overlap decayed, eventual linear independence of the
+    combined family would force the nonzero $Q_k$ coefficient in the global
+    proportionality relation to vanish. The normal-overlap dichotomy then
+    identifies an equal-dimensional gauge-phase-equivalent partner. Repeating
+    the argument from $P$ to $Q$ gives injections in both directions, and
+    finiteness promotes the forward partners to a bijection $\beta$.
+    Choosing the gauge-phase witnesses gives $Y_k$ and $\zeta_k$; the word
+    trace identity supplies the power $\zeta_k^N$, and normalized self-overlaps
+    force $|\zeta_k|=1$.
 \end{proof}
 
 This is \cite[Theorem~2.10]{Cirac2016MPDO_arXiv}; see also
-\cite[Theorem~IV.4 and Corollary~IV.5]{Cirac2021Matrix}. The statement is given on
-the BNT canonical-form surface (Definition~\ref{def:sector_bnt_cf}), which is the
-paper's ``$A$ and $B$ in canonical form'' with chosen bases of normal tensors;
-the reduction of an \emph{arbitrary} proportional-MPV pair to a common primitive
-block decomposition is
+\cite[Theorem~IV.4 and Corollary~IV.5]{Cirac2021Matrix}. The theorem proved
+here uses the normalized, left-canonical, aperiodic BNT surface of
+Definition~\ref{def:sector_bnt_cf}. The source canonical form is brought to
+this surface by the reductions and normalizations of Chapters~\ref{ch:canonical}
+and~\ref{ch:bnt}. Our hypothesis only requires eventual nonzero projective
+proportionality, so the source assumption at every positive length
+is a special case. The reduction of an \emph{arbitrary} proportional-MPV pair
+to a common primitive block decomposition is
 Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} of
 Chapter~\ref{ch:canonical}.
 
-\begin{definition}[Left-canonical normalization]
-    \label{def:left_canonical_tensor}
-    \lean{MPSTensor.IsLeftCanonical}
-    \leanok
-    An MPS tensor $A=(A^i)_i$ is left-canonical when
-    \begin{align}
-        \sum_i (A^i)^\dagger A^i&=\Id. \notag
-    \end{align}
-\end{definition}
+\subsection{Unitary gauges on normalized sectors}
+\label{subsec:ft_unitary_sector_gauges}
 
 \begin{lemma}[Phase normalization for an irreducible gauge]
     \label{lem:left_canonical_irreducible_phase_norm}
@@ -107,31 +102,6 @@ Chapter~\ref{ch:canonical}.
     \end{align}
 \end{proof}
 
-\begin{lemma}[Unitary gauge for left-canonical irreducible tensors]
-    \label{lem:left_canonical_irreducible_unitary_gauge}
-    \lean{MPSTensor.exists_unitaryConj_gaugePhase_of_leftCanonical_irreducible}
-    \leanok
-    \uses{def:left_canonical_tensor, def:gauge_phase_equiv,
-        def:irreducible_tensor,
-        lem:left_canonical_irreducible_same_phase_unitary_gauge}
-    Let $A$ and $B$ be left-canonical irreducible tensors of common positive bond
-    dimension that are gauge-phase equivalent. Then the gauge can be taken
-    unitary: there are a unitary matrix $U$ and a scalar $\zeta$ with
-    $|\zeta|=1$ such that, for every physical index~$i$,
-    \begin{align}
-        B^i&=\zeta\,UA^iU^\dagger. \notag
-    \end{align}
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{lem:left_canonical_irreducible_same_phase_unitary_gauge}
-    Unpack the gauge-phase equivalence as
-    $B^i=\zeta XA^iX^{-1}$ with $X$ invertible and $\zeta\ne0$.
-    Lemma~\ref{lem:left_canonical_irreducible_same_phase_unitary_gauge}
-    replaces $X$ by a unitary $U$ while retaining this same phase and proves
-    $|\zeta|=1$.
-\end{proof}
-
 \begin{corollary}[Canonical Form II unitary refinement of proportional matching]%
     \label{cor:sector_bnt_proportional_unitary_sector_match}
     \lean{MPSTensor.ft_sector_bnt_proportional_unitary_sector_match_witnesses}
@@ -148,7 +118,7 @@ Chapter~\ref{ch:canonical}.
         &=\zeta_k\,U_k\,P_{\beta(k)}^i\,U_k^\dagger. \notag
     \end{align}
     This is the proportional part of
-    \cite[Corollary~C.5]{Cirac2016MPDO_arXiv}.
+    \cite[Corollary~A.6, lines~1197--1199]{Cirac2016MPDO_arXiv}.
 \end{corollary}
 
 \begin{proof}\leanok
@@ -164,11 +134,8 @@ Chapter~\ref{ch:canonical}.
     $Q_k^i=\zeta_kU_kP_{\beta(k)}^iU_k^\dagger$.
 \end{proof}
 
-% In the equal case the per-block phases and copy-weight identities assemble
-% into the unitary global gauge of
-% cor:sector_bnt_equal_unitary_global_gauge. Under proportional input, the
-% analogous total-tensor statement remains conditional on the proportional
-% coefficient identity.
+\subsection{The equal case}
+\label{subsec:ft_equal_case}
 
 \begin{theorem}[Equal BNT canonical forms are globally conjugate]%
     \label{thm:cpgsv_equal_case_source}
@@ -185,8 +152,10 @@ Chapter~\ref{ch:canonical}.
         &=X\,P_{\mathrm{tot}}^i\,X^{-1}. \notag
     \end{align}
 
-    This is \cite[Corollary~2.11]{Cirac2016MPDO_arXiv} on the BNT
-    canonical-form surface; the canonical form of
+    This is \cite[Corollary~2.11]{Cirac2016MPDO_arXiv} on the
+    normalized BNT surface; the literal source surface is reached by the
+    reduction and normalization of Chapters~\ref{ch:canonical} and~\ref{ch:bnt}.
+    Moreover, the canonical form of
     \cite[Section~2.3]{Cirac2016MPDO_arXiv}, a direct sum of normal tensors with
     scalar weights, is a BNT canonical form. The reduction of an \emph{arbitrary}
     pair of same-MPV tensors to a common BNT canonical form is
@@ -204,3 +173,68 @@ Chapter~\ref{ch:canonical}.
 \end{proof}
 
 This is also \cite[Corollary~IV.5]{Cirac2021Matrix}.
+
+\begin{corollary}[Canonical Form II unitary refinement in the equal case]%
+    \label{cor:sector_bnt_equal_unitary_global_gauge}
+    \lean{MPSTensor.fundamentalTheorem_equal_canonicalForm_unitary}
+    \leanok
+    \uses{lem:sector_bnt_equal_unitary_matched_gauge,
+        thm:sector_bnt_equal_mps_gaugeEquiv_literal}
+    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate the
+    same MPV family at every positive length. Their total bond dimensions
+    agree; writing the common value as $D$, there is a unitary matrix
+    $U\in\mathrm{U}(D)$ such that, for every physical index~$i$,
+    \begin{align}
+        Q_{\mathrm{tot}}^i
+        &= U P_{\mathrm{tot}}^i U^\dagger.
+        \notag
+    \end{align}
+    This is the equal case of
+    \cite[Corollary~A.6, lines~1197--1199]{Cirac2016MPDO_arXiv}.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{lem:sector_bnt_equal_unitary_matched_gauge}
+    For each matched sector, retain the phase in both identities
+    \begin{align}
+        Q_k^i
+        &= \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
+        \notag\\
+        \nu_{k,q}
+        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
+        \notag
+    \end{align}
+    For every matched copy $(k,q)$,
+    \begin{align}
+        \nu_{k,q}\zeta_k
+        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}\zeta_k
+        = \mu_{\beta(k),\tau_k(q)}.
+        \notag
+    \end{align}
+    Hence $Q_{\mathrm{flat}}^i=XP_{\mathrm{match}}^iX^{-1}$. Repeating $U_k$
+    on its matched copies gives
+    \begin{align}
+        X
+        &= \bigoplus_{k,q}U_k,
+        \notag\\
+        X^\dagger X
+        &= \mathbb 1.
+        \notag
+    \end{align}
+    If $\Pi$ is the permutation matrix restoring the original sector and copy
+    order, then $\Pi^\dagger\Pi=\mathbb 1$. Hence
+    \begin{align}
+        U
+        &= X\Pi,
+        \notag\\
+        U^\dagger U
+        &= \mathbb 1,
+        \notag
+    \end{align}
+    and the permutation of matched coordinates gives
+    \begin{align}
+        Q_{\mathrm{tot}}^i
+        &= UP_{\mathrm{tot}}^iU^\dagger.
+        \notag
+    \end{align}
+\end{proof}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
@@ -19,7 +19,7 @@
     every physical index~$i$,
     \begin{align}
         Q_k^i
-        &=\zeta_k\,Y_k\,P_{\beta(k)}^i\,Y_k^{-1}. \notag
+         & =\zeta_k\,Y_k\,P_{\beta(k)}^i\,Y_k^{-1}. \notag
     \end{align}
     Thus the paired normal tensors have the same bond dimension
     ($\dim P_{\beta(k)}=\dim Q_k$) and the same gauge-phase class.
@@ -90,14 +90,14 @@ Chapter~\ref{ch:canonical}.
     Lemma~\ref{lem:left_canonical_irreducible_phase_norm} gives
     $|\zeta|=1$. Substitution into the left-canonical identities gives
     \begin{align}
-        \sum_i A^{i\dagger}(X^\dagger X)A^i&=X^\dagger X. \notag
+        \sum_i A^{i\dagger}(X^\dagger X)A^i & =X^\dagger X. \notag
     \end{align}
     Thus $X^\dagger X$ is a positive-semidefinite fixed point of the adjoint
     transfer map of $A$. Irreducibility gives $X^\dagger X=c\Id$ for some
     $c>0$, so $X^{-1}=c^{-1}X^\dagger$ and $U=c^{-1/2}X$ is unitary. Moreover,
     \begin{align}
         UA^iU^\dagger
-        &=c^{-1}XA^iX^\dagger
+         & =c^{-1}XA^iX^\dagger
         =XA^iX^{-1}. \notag
     \end{align}
 \end{proof}
@@ -115,7 +115,7 @@ Chapter~\ref{ch:canonical}.
     and every physical index~$i$,
     \begin{align}
         Q_k^i
-        &=\zeta_k\,U_k\,P_{\beta(k)}^i\,U_k^\dagger. \notag
+         & =\zeta_k\,U_k\,P_{\beta(k)}^i\,U_k^\dagger. \notag
     \end{align}
     This is the proportional part of
     \cite[Corollary~A.6, lines~1197--1199]{Cirac2016MPDO_arXiv}.
@@ -149,7 +149,7 @@ Chapter~\ref{ch:canonical}.
     invertible matrix $X\in\GL_D(\C)$ such that, for every physical index~$i$,
     \begin{align}
         Q_{\mathrm{tot}}^i
-        &=X\,P_{\mathrm{tot}}^i\,X^{-1}. \notag
+         & =X\,P_{\mathrm{tot}}^i\,X^{-1}. \notag
     \end{align}
 
     This is \cite[Corollary~2.11]{Cirac2016MPDO_arXiv} on the
@@ -186,7 +186,7 @@ This is also \cite[Corollary~IV.5]{Cirac2021Matrix}.
     $U\in\mathrm{U}(D)$ such that, for every physical index~$i$,
     \begin{align}
         Q_{\mathrm{tot}}^i
-        &= U P_{\mathrm{tot}}^i U^\dagger.
+         & = U P_{\mathrm{tot}}^i U^\dagger.
         \notag
     \end{align}
     This is the equal case of
@@ -198,16 +198,16 @@ This is also \cite[Corollary~IV.5]{Cirac2021Matrix}.
     For each matched sector, retain the phase in both identities
     \begin{align}
         Q_k^i
-        &= \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
-        \notag\\
+         & = \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
+        \notag                                     \\
         \nu_{k,q}
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
+         & = \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
         \notag
     \end{align}
     For every matched copy $(k,q)$,
     \begin{align}
         \nu_{k,q}\zeta_k
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}\zeta_k
+         & = \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}\zeta_k
         = \mu_{\beta(k),\tau_k(q)}.
         \notag
     \end{align}
@@ -215,26 +215,26 @@ This is also \cite[Corollary~IV.5]{Cirac2021Matrix}.
     on its matched copies gives
     \begin{align}
         X
-        &= \bigoplus_{k,q}U_k,
-        \notag\\
+         & = \bigoplus_{k,q}U_k,
+        \notag                   \\
         X^\dagger X
-        &= \mathbb 1.
+         & = \mathbb 1.
         \notag
     \end{align}
     If $\Pi$ is the permutation matrix restoring the original sector and copy
     order, then $\Pi^\dagger\Pi=\mathbb 1$. Hence
     \begin{align}
         U
-        &= X\Pi,
-        \notag\\
+         & = X\Pi,
+        \notag          \\
         U^\dagger U
-        &= \mathbb 1,
+         & = \mathbb 1,
         \notag
     \end{align}
     and the permutation of matched coordinates gives
     \begin{align}
         Q_{\mathrm{tot}}^i
-        &= UP_{\mathrm{tot}}^iU^\dagger.
+         & = UP_{\mathrm{tot}}^iU^\dagger.
         \notag
     \end{align}
 \end{proof}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -65,19 +65,55 @@ for its sector-level conclusion.
 \begin{proof}\leanok
     \uses{thm:sector_bnt_proportional_bijective_match,
         lem:sector_bnt_norm_phase_of_matched_mpv}
-    Fix a sector $Q_k$. If its overlap with every $P_j$ decayed, the combined
-    family of the $P$-sectors and $Q_k$ would be linearly independent for all
-    sufficiently large lengths. Expanding the proportionality relation in that
-    family would then make the nonzero coefficient of $Q_k$ vanish, a
-    contradiction. Hence some overlap does not decay. The normal-tensor overlap
-    dichotomy gives a partner $P_j$ of the same bond dimension and a
-    gauge-phase relation.
+    Fix $j_0\in J(P)$ and suppose, for contradiction, that the overlap of
+    $P_{j_0}$ with every $Q$-sector decays. Define
+    \begin{align}
+        T
+         & =\bigl\{j\in J(P):
+        O_{P_jQ_k}(N)\longrightarrow 0\text{ for every }k\in J(Q)\bigr\}.
+        \notag
+    \end{align}
+    Thus $j_0\in T$. For each $j\notin T$, choose a sector $Q_{k(j)}$ for
+    which the overlap does not decay. The normal-overlap analysis then supplies
+    scalars $\alpha_j(N)$ such that, at every length,
+    \begin{align}
+        \ket{V^{(N)}(P_j)}
+         & =\alpha_j(N)\ket{V^{(N)}(Q_{k(j)})}.
+        \notag
+    \end{align}
 
-    Apply the same argument with $P$ and $Q$ interchanged. Basis separation
-    makes the resulting partner maps injective: two sectors with one partner
-    would be gauge-phase equivalent to each other. The injections in both
-    directions force equal finite cardinalities, and the forward partners may
-    therefore be chosen as a bijection $\beta:J(Q)\simeq J(P)$.
+    At a sufficiently large length $N$, write the full proportionality equation
+    as
+    \begin{align}
+        \sum_{j\in J(P)}c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
+         & =c_N\sum_{k\in J(Q)}c_N^{(k)}(Q)
+        \ket{V^{(N)}(Q_k)},
+        \notag
+    \end{align}
+    where $c_N\ne0$. Split the left-hand sum into $T$ and its complement,
+    substitute the displayed scalar relations for all $j\notin T$, and group
+    their contributions according to the common value of $k(j)$. The result is
+    a zero linear combination of
+    \begin{align}
+        \bigl\{\ket{V^{(N)}(P_j)}:j\in T\bigr\}
+        \mathbin{\cup}
+        \bigl\{\ket{V^{(N)}(Q_k)}:k\in J(Q)\bigr\}.
+        \notag
+    \end{align}
+    All cross-overlaps between the two displayed parts decay by the definition
+    of $T$, so this restricted union is linearly independent for all
+    sufficiently large $N$. Extracting the coefficient of
+    $\ket{V^{(N)}(P_{j_0})}$ gives $c_N^{(j_0)}(P)=0$ eventually, contradicting
+    the nonvanishing property of a BNT basis coefficient. Therefore every
+    $P$-sector has a $Q$-sector with nondecaying overlap.
+
+    Interchange $P$ and $Q$ to obtain partners in the reverse direction. For
+    each nondecaying pair, the normal-overlap dichotomy gives equality of bond
+    dimensions and gauge-phase equivalence. Basis separation makes either
+    chosen partner map injective: if two basis sectors had the same partner,
+    they would be gauge-phase equivalent to one another. The injections in both
+    directions and finiteness yield a bijection
+    $\beta:J(Q)\simeq J(P)$.
 
     Choose an invertible matrix $X_k$ and a nonzero scalar $\zeta_k$ from each
     matched gauge-phase relation. This gives

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -30,7 +30,7 @@ for its sector-level conclusion.
     every sector $k$ and physical index $i$,
     \begin{align}
         Q_k^i
-        &= \zeta_k X_k P_{\beta(k)}^i X_k^{-1}.
+         & = \zeta_k X_k P_{\beta(k)}^i X_k^{-1}.
         \label{eq:ft_gauge_relation}
     \end{align}
     Diagrammatically, the gauge relation (\ref{eq:ft_gauge_relation}) reads
@@ -52,7 +52,7 @@ for its sector-level conclusion.
     Equivalently, for every positive length $N$ and word $\sigma$,
     \begin{align}
         V^{(N)}(Q_k)_\sigma
-        &= \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma.
+         & = \zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma.
         \notag
     \end{align}
     This is \cite[Appendix MPV theorem statement, lines~1167--1170, and proof
@@ -110,7 +110,7 @@ for its sector-level conclusion.
     $N$, and every spin configuration $\sigma$ of length $N$,
     \begin{align}
         V^{(N)}(Q_k)_\sigma
-        &= \zeta_k^N\,V^{(N)}(P_{\beta(k)})_\sigma.
+         & = \zeta_k^N\,V^{(N)}(P_{\beta(k)})_\sigma.
         \label{eq:ft_phase_relation_hyp}
     \end{align}
     Then for every $k \in J(Q)$ there is $N_0$ such that, for all $N>N_0$,
@@ -125,7 +125,7 @@ for its sector-level conclusion.
     For every $N$, expand the equality of total MPVs as
     \begin{align}
         \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
-        &=
+         & =
         \sum_{k\in J(Q)} c_N^{(k)}(Q)\ket{V^{(N)}(Q_k)}.
         \notag
     \end{align}
@@ -134,7 +134,7 @@ for its sector-level conclusion.
     the $Q$-sum by $\beta$ onto the $P$-basis yields
     \begin{align}
         \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
-        &=
+         & =
         \sum_{j\in J(P)}
         \zeta_{\beta^{-1}(j)}^N
         c_N^{(\beta^{-1}(j))}(Q)\ket{V^{(N)}(P_j)}.
@@ -170,7 +170,7 @@ for its sector-level conclusion.
     nonzero sector phases $\zeta_k$. If the matched-sector coefficient identities
     \begin{align}
         c_N^{(\beta(k))}(P)
-        &= \zeta_k^N\,c_N^{(k)}(Q)
+         & = \zeta_k^N\,c_N^{(k)}(Q)
         \label{eq:ft_sector_coeff_identity_hyp}
     \end{align}
     hold eventually, then the phases $\zeta_k$ determine a copy-weight matching
@@ -183,7 +183,7 @@ for its sector-level conclusion.
     (\ref{eq:ft_sector_coeff_identity_hyp}) in sector $k$ reads
     \begin{align}
         \sum_r \mu_{\beta(k),r}^{\,N}
-        &= \zeta_k^N\sum_q\nu_{k,q}^{\,N}
+         & = \zeta_k^N\sum_q\nu_{k,q}^{\,N}
         = \sum_q(\zeta_k\nu_{k,q})^{N}.
         \notag
     \end{align}
@@ -212,7 +212,7 @@ for its sector-level conclusion.
     \begin{align}
         Q_k^i
          & =\zeta_kX_kP_{\beta(k)}^iX_k^{-1},
-        \notag\\
+        \notag                                    \\
         \nu_{k,q}
          & =\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
         \notag
@@ -273,19 +273,19 @@ cancel before the block gauges are assembled.
     $X_k$. If, for every sector $k$, copy $q$, and physical index $i$,
     \begin{align}
         Q_k^i
-        &= \zeta_k\,X_k P_{\beta(k)}^i X_k^{-1},
-        \notag\\
+         & = \zeta_k\,X_k P_{\beta(k)}^i X_k^{-1},
+        \notag                                      \\
         \nu_{k,q}
-        &= \zeta_k^{-1} \mu_{\beta(k),\tau_k(q)},
+         & = \zeta_k^{-1} \mu_{\beta(k),\tau_k(q)},
         \label{eq:ft_matched_weights_hypotheses}
     \end{align}
     then, in the flattened $Q$-coordinates,
     \begin{align}
         Q_{\mathrm{flat}}^i
-        &= X\,P_{\mathrm{matched}}^i\,X^{-1},
-        \notag\\
+         & = X\,P_{\mathrm{matched}}^i\,X^{-1},
+        \notag                                         \\
         X
-        &= \bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
+         & = \bigoplus_k(\mathbf{1}_{r_k}\otimes X_k).
         \notag
     \end{align}
     This is the direct-sum gauge construction of
@@ -297,7 +297,7 @@ cancel before the block gauges are assembled.
     For each matched copy,
     \begin{align}
         \nu_{k,q}Q_k^i
-        &= (\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)})
+         & = (\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)})
         (\zeta_kX_kP_{\beta(k)}^iX_k^{-1})
         = \mu_{\beta(k),\tau_k(q)}X_kP_{\beta(k)}^iX_k^{-1}.
         \notag
@@ -331,7 +331,7 @@ cancel before the block gauges are assembled.
     self-overlap comparison
     \begin{align}
         \langle V_N(Q_k),V_N(Q_k)\rangle
-        &=
+         & =
         |\zeta_k|^{2N}
         \langle V_N(P_{\beta(k)}),V_N(P_{\beta(k)})\rangle
         \notag
@@ -364,10 +364,10 @@ cancel before the block gauges are assembled.
     such that, for every sector $k$, copy $q$, and physical index $i$,
     \begin{align}
         Q_k^i
-        &= \zeta_k\,X_k P_{\beta(k)}^i X_k^{-1},
-        \notag\\
+         & = \zeta_k\,X_k P_{\beta(k)}^i X_k^{-1},
+        \notag                                      \\
         \nu_{k,q}
-        &= \zeta_k^{-1} \mu_{\beta(k),\tau_k(q)}.
+         & = \zeta_k^{-1} \mu_{\beta(k),\tau_k(q)}.
         \notag
     \end{align}
     Moreover, if $X=\bigoplus_k (\mathbf{1}_{r_k}\otimes X_k)$ is the flattened
@@ -375,7 +375,7 @@ cancel before the block gauges are assembled.
     $Q$-coordinates satisfy
     \begin{align}
         Q_{\mathrm{flat}}^i
-        &= X\,P_{\mathrm{matched}}^i\,X^{-1}.
+         & = X\,P_{\mathrm{matched}}^i\,X^{-1}.
         \notag
     \end{align}
     This is the explicit direct-sum gauge construction of
@@ -407,13 +407,13 @@ cancel before the block gauges are assembled.
     write their common value as $D$. There is
     \begin{align}
         Y
-        &\in \GL_D(\C)
+         & \in \GL_D(\C)
         \label{eq:ft_literal_gauge_Y}
     \end{align}
     such that, for every physical index $i$,
     \begin{align}
         Q_{\mathrm{tot}}^i
-        &= Y\,P_{\mathrm{tot}}^i\,Y^{-1},
+         & = Y\,P_{\mathrm{tot}}^i\,Y^{-1},
         \notag
     \end{align}
     where $P_{\mathrm{tot}}^i$ and $Q_{\mathrm{tot}}^i$ are both regarded as
@@ -444,7 +444,7 @@ cancel before the block gauges are assembled.
     \begin{align}
         P
          & =C\oplus \tfrac12 C,
-        &
+         &
         Q
          & =C\oplus \tfrac13 C.
         \notag
@@ -453,7 +453,7 @@ cancel before the block gauges are assembled.
     \begin{align}
         V^{(N)}(P)
          & =(1+2^{-N})V^{(N)}(C),
-        &
+         &
         V^{(N)}(Q)
          & =(1+3^{-N})V^{(N)}(C).
         \notag

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -65,10 +65,16 @@ for its sector-level conclusion.
         lem:sector_bnt_norm_phase_of_matched_mpv}
     Theorem~\ref{thm:sector_bnt_proportional_bijective_match} gives a bijection
     $\beta:J(Q)\simeq J(P)$ together with equal bond dimensions, gauge-phase
-    equivalence, and nondecaying overlap for every matched pair. Its proof
-    partitions the decaying $P$-sectors, substitutes exact $Q$-sector relations
-    for the complement, applies linear independence to the restricted decaying
-    $P$-family together with all $Q$-sectors, and then reverses direction; basis
+    equivalence, and
+    \begin{align}
+        O_{P_{\beta(k)}Q_k}(N)
+         & \not\longrightarrow 0
+        \notag
+    \end{align}
+    for every matched pair. Its proof defines
+    $T=\{j\in J(P):O_{P_jQ_k}(N)\to0\text{ for every }k\}$, substitutes exact
+    $Q$-sector relations for $j\notin T$, applies linear independence to
+    $\{P_j:j\in T\}\cup\{Q_k:k\in J(Q)\}$, and reverses direction; basis
     separation and finiteness turn the resulting matches into $\beta$.
 
     Unpack each matched gauge-phase equivalence to choose an invertible matrix
@@ -191,7 +197,7 @@ for its sector-level conclusion.
 \end{proof}
 
 \begin{theorem}[Equal-case sector and copy matching with differing bond dimensions]%
-    \label{lem:ft_sector_bnt_equal_sector_data_different_dims}
+    \label{thm:ft_sector_bnt_equal_sector_data_different_dims}
     \lean{MPSTensor.ft_sector_bnt_equal_sector_data}
     \leanok
     \uses{def:same_mpv2_pos, def:sector_bnt_cf, def:gauge_phase_equiv,

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -18,8 +18,6 @@ for its sector-level conclusion.
     \lean{MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses}
     \leanok
     \uses{def:sector_bnt_cf,
-        def:gauge_phase_equiv,
-        thm:gauge_phase_mpv_scaling,
         thm:sector_bnt_proportional_bijective_match,
         lem:sector_bnt_norm_phase_of_matched_mpv}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
@@ -65,58 +63,16 @@ for its sector-level conclusion.
 \begin{proof}\leanok
     \uses{thm:sector_bnt_proportional_bijective_match,
         lem:sector_bnt_norm_phase_of_matched_mpv}
-    Fix $j_0\in J(P)$ and suppose, for contradiction, that the overlap of
-    $P_{j_0}$ with every $Q$-sector decays. Define
-    \begin{align}
-        T
-         & =\bigl\{j\in J(P):
-        O_{P_jQ_k}(N)\longrightarrow 0\text{ for every }k\in J(Q)\bigr\}.
-        \notag
-    \end{align}
-    Thus $j_0\in T$. For each $j\notin T$, choose a sector $Q_{k(j)}$ for
-    which the overlap does not decay. The normal-overlap analysis then supplies
-    scalars $\alpha_j(N)$ such that, at every length,
-    \begin{align}
-        \ket{V^{(N)}(P_j)}
-         & =\alpha_j(N)\ket{V^{(N)}(Q_{k(j)})}.
-        \notag
-    \end{align}
+    Theorem~\ref{thm:sector_bnt_proportional_bijective_match} gives a bijection
+    $\beta:J(Q)\simeq J(P)$ together with equal bond dimensions, gauge-phase
+    equivalence, and nondecaying overlap for every matched pair. Its proof
+    partitions the decaying $P$-sectors, substitutes exact $Q$-sector relations
+    for the complement, applies linear independence to the restricted decaying
+    $P$-family together with all $Q$-sectors, and then reverses direction; basis
+    separation and finiteness turn the resulting matches into $\beta$.
 
-    At a sufficiently large length $N$, write the full proportionality equation
-    as
-    \begin{align}
-        \sum_{j\in J(P)}c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
-         & =c_N\sum_{k\in J(Q)}c_N^{(k)}(Q)
-        \ket{V^{(N)}(Q_k)},
-        \notag
-    \end{align}
-    where $c_N\ne0$. Split the left-hand sum into $T$ and its complement,
-    substitute the displayed scalar relations for all $j\notin T$, and group
-    their contributions according to the common value of $k(j)$. The result is
-    a zero linear combination of
-    \begin{align}
-        \bigl\{\ket{V^{(N)}(P_j)}:j\in T\bigr\}
-        \mathbin{\cup}
-        \bigl\{\ket{V^{(N)}(Q_k)}:k\in J(Q)\bigr\}.
-        \notag
-    \end{align}
-    All cross-overlaps between the two displayed parts decay by the definition
-    of $T$, so this restricted union is linearly independent for all
-    sufficiently large $N$. Extracting the coefficient of
-    $\ket{V^{(N)}(P_{j_0})}$ gives $c_N^{(j_0)}(P)=0$ eventually, contradicting
-    the nonvanishing property of a BNT basis coefficient. Therefore every
-    $P$-sector has a $Q$-sector with nondecaying overlap.
-
-    Interchange $P$ and $Q$ to obtain partners in the reverse direction. For
-    each nondecaying pair, the normal-overlap dichotomy gives equality of bond
-    dimensions and gauge-phase equivalence. Basis separation makes either
-    chosen partner map injective: if two basis sectors had the same partner,
-    they would be gauge-phase equivalent to one another. The injections in both
-    directions and finiteness yield a bijection
-    $\beta:J(Q)\simeq J(P)$.
-
-    Choose an invertible matrix $X_k$ and a nonzero scalar $\zeta_k$ from each
-    matched gauge-phase relation. This gives
+    Unpack each matched gauge-phase equivalence to choose an invertible matrix
+    $X_k$ and a nonzero scalar $\zeta_k$. This gives
     $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$ and, by taking traces around a
     positive-length word,
     \begin{align}
@@ -124,13 +80,14 @@ for its sector-level conclusion.
          & =\zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma.
         \notag
     \end{align}
-    The normalized self-overlap limits then satisfy
+    Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv} applies to this MPV
+    identity. Equivalently, the normalized self-overlaps satisfy
     \begin{align}
         O_{Q_kQ_k}(N)
          & =|\zeta_k|^{2N}O_{P_{\beta(k)}P_{\beta(k)}}(N),
         \notag
     \end{align}
-    and both outer sequences tend to $1$. Thus $|\zeta_k|=1$.
+    and both outer sequences tend to $1$, which forces $|\zeta_k|=1$.
 \end{proof}
 
 \begin{lemma}[Full-basis coefficient identity from matched phases]%
@@ -477,6 +434,8 @@ cancel before the block gauges are assembled.
 
 \begin{remark}[Proportional sector matching does not determine copy weights]%
     \label{rem:proportional_length_scalar_gap}
+    % Correction documented in
+    % docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex.
     The proportional theorem determines the normal sectors, but it does not
     determine the copy weights or imply conjugacy of the total tensors. Let
     $C$ be a normalized normal tensor and consider the one-sector BNT forms

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -197,20 +197,23 @@ for its sector-level conclusion.
 \end{definition}
 
 \begin{definition}[Copy-weight matching from matched-sector coefficient identities]%
-    \label{lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+    \label{def:sector_bnt_copy_weight_matching_of_coeff_identity}
     \lean{MPSTensor.SectorBNTCopyWeightMatching.of_coeff_identity}
     \leanok
     \uses{def:sector_bnt_copy_weight_matching,
         lem:sector_bnt_matched_sector_weight_equiv}
-    Let the sectors of $P$ and $Q$ be matched by $\beta:J(Q)\simeq J(P)$, with
-    nonzero sector phases $\zeta_k$. If the matched-sector coefficient identities
+    The construction takes as input a sector matching
+    $\beta:J(Q)\simeq J(P)$, nonzero sector phases $\zeta_k$, and the eventual
+    matched-sector coefficient identities
     \begin{align}
         c_N^{(\beta(k))}(P)
-         & = \zeta_k^N\,c_N^{(k)}(Q)
+         & = \zeta_k^N\,c_N^{(k)}(Q).
         \label{eq:ft_sector_coeff_identity_hyp}
     \end{align}
-    hold eventually, then the phases $\zeta_k$ determine a copy-weight matching
-    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$. This is, sector by sector,
+    It returns the copy-weight matching obtained by choosing, in every sector,
+    a copy permutation $\tau_k$ satisfying
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$. This is the sectorwise
+    construction in
     \cite[Appendix MPV proof, line~1188]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
@@ -237,7 +240,7 @@ for its sector-level conclusion.
     \uses{def:same_mpv2_pos, def:sector_bnt_cf, def:gauge_phase_equiv,
         thm:sector_bnt_bijective_match_of_sameMPV,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
-        lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+        def:sector_bnt_copy_weight_matching_of_coeff_identity}
     Let $P$ and $Q$ be BNT canonical forms, possibly with different sector
     counts and different bond dimensions before matching. If their total
     tensors generate the same MPV family at every positive length, then there
@@ -362,7 +365,7 @@ cancel before the block gauges are assembled.
 \begin{proof}\leanok
     \uses{thm:sector_bnt_bijective_match_of_sameMPV,
         lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
-        lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+        def:sector_bnt_copy_weight_matching_of_coeff_identity}
     The full-basis matching theorem gives the bijection and block gauges. The
     self-overlap comparison
     \begin{align}
@@ -376,7 +379,7 @@ cancel before the block gauges are assembled.
     $|\zeta_k|=1$. The matched MPV phase identities also give the eventual
     coefficient identities
     $c_N^{(\beta(k))}(P)=\zeta_k^N c_N^{(k)}(Q)$.
-    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity} applies
+    Definition~\ref{def:sector_bnt_copy_weight_matching_of_coeff_identity} applies
     the finite power-sum comparison in each sector and gives the copy-weight
     identities.
 \end{proof}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_core.tex
@@ -1,42 +1,17 @@
-\section{Coefficient identity, copy weights, and the block-diagonal gauge}
+\section{Coefficient identities and copy weights}
 \label{sec:sector_bnt_full_basis_global_gauge}
 
-The bijective matching theorem of Chapter~\ref{ch:bnt}
-(Theorem~\ref{thm:sector_bnt_bijective_match_of_sameMPV}) gives the sector
-phases $\zeta_k$ and block gauges $X_k$. The coefficient comparison of
-\cite[Appendix MPV proof, lines~1187--1188]{Cirac2016MPDO_arXiv} then turns the
-equality of total MPV families into the per-sector coefficient identity
-$c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q)$. Neither
-step uses a per-sector unit-modulus hypothesis.
+Let $P$ and $Q$ be BNT canonical forms. Their basis sectors are normalized,
+left-canonical, and aperiodic, and their raw copy weights satisfy the global
+normalization of Definition~\ref{def:sector_bnt_cf}. This is the normalized
+surface used for the proof. The literal CPSV canonical form is brought to this
+surface by the reduction and normalization of Chapters~\ref{ch:canonical}
+and~\ref{ch:bnt}.
 
-\begin{lemma}[Unit phase from matched normalized BNT blocks]%
-    \label{lem:sector_bnt_norm_phase_of_matched_mpv}
-    \lean{MPSTensor.IsBNTCanonicalForm.norm_phase_of_matched_mpv}
-    \leanok
-    \uses{def:sector_bnt_cf}
-    Let $P$ and $Q$ be BNT canonical forms. If, for every positive length $N$
-    and word $\sigma$, a sector $P_j$ and a sector $Q_k$ have MPV families
-    related by
-    \begin{align}
-        V^{(N)}(Q_k)_\sigma
-        &= \zeta^N V^{(N)}(P_j)_\sigma,
-        \label{eq:ft_matched_mpv_phase_norm}
-    \end{align}
-    then $|\zeta|=1$.
-\end{lemma}
-
-\begin{proof}\leanok
-    The BNT normalization gives self-overlap limits of modulus $1$ for both
-    sectors. The MPV identity (\ref{eq:ft_matched_mpv_phase_norm}) gives, for
-    every positive $N$,
-    \begin{align}
-        O_{Q_kQ_k}(N)
-        &= |\zeta|^{2N}\,O_{P_jP_j}(N).
-        \notag
-    \end{align}
-    Since $O_{Q_kQ_k}(N)\to1$ and $O_{P_jP_j}(N)\to1$, taking limits forces
-    $|\zeta|^{2N}\to1$ and hence $|\zeta|=1$.
-\end{proof}
+The proportional statement below allows nonzero projective proportionality for
+all sufficiently large lengths. The source assumption of proportionality at
+every positive length is a special case. No copy-weight comparison is needed
+for its sector-level conclusion.
 
 \begin{theorem}[Proportional sector matching with unit phases]%
     \label{thm:sector_bnt_proportional_sector_match_witnesses}
@@ -45,6 +20,7 @@ step uses a per-sector unit-modulus hypothesis.
     \uses{def:sector_bnt_cf,
         def:gauge_phase_equiv,
         thm:gauge_phase_mpv_scaling,
+        thm:sector_bnt_proportional_bijective_match,
         lem:sector_bnt_norm_phase_of_matched_mpv}
     Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
     eventually nonzero proportional MPV families.
@@ -86,53 +62,39 @@ step uses a per-sector unit-modulus hypothesis.
     % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
 \end{theorem}
 
-\begin{proof}\leanok\uses{lem:sector_bnt_norm_phase_of_matched_mpv}
-    Apply the proportional sector-matching theorem to obtain the bijection and
-    dimension-compatible gauge-phase equivalences. Choosing the gauges and
-    scalars gives $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$, and therefore
+\begin{proof}\leanok
+    \uses{thm:sector_bnt_proportional_bijective_match,
+        lem:sector_bnt_norm_phase_of_matched_mpv}
+    Fix a sector $Q_k$. If its overlap with every $P_j$ decayed, the combined
+    family of the $P$-sectors and $Q_k$ would be linearly independent for all
+    sufficiently large lengths. Expanding the proportionality relation in that
+    family would then make the nonzero coefficient of $Q_k$ vanish, a
+    contradiction. Hence some overlap does not decay. The normal-tensor overlap
+    dichotomy gives a partner $P_j$ of the same bond dimension and a
+    gauge-phase relation.
+
+    Apply the same argument with $P$ and $Q$ interchanged. Basis separation
+    makes the resulting partner maps injective: two sectors with one partner
+    would be gauge-phase equivalent to each other. The injections in both
+    directions force equal finite cardinalities, and the forward partners may
+    therefore be chosen as a bijection $\beta:J(Q)\simeq J(P)$.
+
+    Choose an invertible matrix $X_k$ and a nonzero scalar $\zeta_k$ from each
+    matched gauge-phase relation. This gives
+    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$ and, by taking traces around a
+    positive-length word,
     \begin{align}
-        O_{Q_kQ_k}(N)
-        &= |\zeta_k|^{2N}O_{P_{\beta(k)}P_{\beta(k)}}(N).
+        V^{(N)}(Q_k)_\sigma
+         & =\zeta_k^N V^{(N)}(P_{\beta(k)})_\sigma.
         \notag
     \end{align}
-    The normalized self-overlap limits give
-    $O_{Q_kQ_k}(N)\to1$ and $O_{P_{\beta(k)}P_{\beta(k)}}(N)\to1$, so
-    $|\zeta_k|^{2N}\to1$ and hence $|\zeta_k|=1$. The MPV scalar-power
-    identity follows from the same gauge equation (\ref{eq:ft_gauge_relation}):
-    $V^{(N)}(Q_k)_\sigma=\zeta_k^NV^{(N)}(P_{\beta(k)})_\sigma$.
-\end{proof}
-
-\begin{lemma}[Full-basis coefficient identity from matched sectors]%
-    \label{lem:sector_bnt_coeff_identity_via_global_gauge}
-    \lean{MPSTensor.coeff_identity_via_global_gauge}
-    \leanok
-    \uses{def:sector_bnt_cf,
-        def:gauge_phase_equiv}
-    Let $P$ and $Q$ be BNT canonical forms with the same MPV family at every
-    positive length, matched by a bijection $\beta:J(Q)\simeq J(P)$ with
-    bond-dimension equalities and a
-    gauge-phase equivalence between $Q_k$ and $P_{\beta(k)}$ for every $k$. Then
-    each sector carries a unit-modulus phase $\zeta_k$, and eventually
+    The normalized self-overlap limits then satisfy
     \begin{align}
-        c_N^{(\beta(k))}(P)
-        &= \zeta_k^N\,c_N^{(k)}(Q).
-        \label{eq:ft_coeff_identity}
+        O_{Q_kQ_k}(N)
+         & =|\zeta_k|^{2N}O_{P_{\beta(k)}P_{\beta(k)}}(N),
+        \notag
     \end{align}
-    This is the equal-MPV coefficient comparison of
-    \cite[Appendix MPV proof, lines~1187--1188]{Cirac2016MPDO_arXiv}.
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{lem:sector_bnt_norm_phase_of_matched_mpv,
-        lem:sector_bnt_coeff_identity_via_matched_mpv_phase}
-    For each matched sector, the gauge-phase equivalence gives
-    $V^{(N)}(Q_k)_\sigma=\zeta_k^NV^{(N)}(P_{\beta(k)})_\sigma$.
-    Lemma~\ref{lem:sector_bnt_norm_phase_of_matched_mpv} gives
-    $|\zeta_k|=1$. Applying
-    Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase} to the
-    same phases gives
-    $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ for all sufficiently
-    large $N$.
+    and both outer sequences tend to $1$. Thus $|\zeta_k|=1$.
 \end{proof}
 
 \begin{lemma}[Full-basis coefficient identity from matched phases]%
@@ -186,9 +148,6 @@ step uses a per-sector unit-modulus hypothesis.
     independence, for all sufficiently large $N$.
 \end{proof}
 
-The coefficient identity (\ref{eq:ft_coeff_identity}) is now converted, sector
-by sector, into a matching of the individual copy weights.
-
 \begin{definition}[Copy-weight matching for matched BNT sectors]%
     \label{def:sector_bnt_copy_weight_matching}
     \lean{MPSTensor.SectorBNTCopyWeightMatching}
@@ -201,7 +160,7 @@ by sector, into a matching of the individual copy weights.
     \cite[Appendix MPV proof, line~1188]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{lemma}[Copy-weight matching from matched-sector coefficient identities]%
+\begin{definition}[Copy-weight matching from matched-sector coefficient identities]%
     \label{lem:sector_bnt_copy_weight_matching_of_coeff_identity}
     \lean{MPSTensor.SectorBNTCopyWeightMatching.of_coeff_identity}
     \leanok
@@ -217,7 +176,7 @@ by sector, into a matching of the individual copy weights.
     hold eventually, then the phases $\zeta_k$ determine a copy-weight matching
     $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$. This is, sector by sector,
     \cite[Appendix MPV proof, line~1188]{Cirac2016MPDO_arXiv}.
-\end{lemma}
+\end{definition}
 
 \begin{proof}\leanok
     Eventually the coefficient identity
@@ -235,8 +194,61 @@ by sector, into a matching of the individual copy weights.
     $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$.
 \end{proof}
 
-The matched block gauges and copy weights now combine into a single
-block-diagonal gauge.
+\begin{theorem}[Equal-case sector and copy matching with differing bond dimensions]%
+    \label{lem:ft_sector_bnt_equal_sector_data_different_dims}
+    \lean{MPSTensor.ft_sector_bnt_equal_sector_data}
+    \leanok
+    \uses{def:same_mpv2_pos, def:sector_bnt_cf, def:gauge_phase_equiv,
+        thm:sector_bnt_bijective_match_of_sameMPV,
+        lem:sector_bnt_coeff_identity_via_matched_mpv_phase,
+        lem:sector_bnt_copy_weight_matching_of_coeff_identity}
+    Let $P$ and $Q$ be BNT canonical forms, possibly with different sector
+    counts and different bond dimensions before matching. If their total
+    tensors generate the same MPV family at every positive length, then there
+    is a bijection $\beta:J(Q)\simeq J(P)$ such that each matched basis pair
+    has equal bond dimension and is gauge-phase equivalent. The matched copy
+    multiplicities agree, and there are unit phases $\zeta_k$ and copy
+    bijections $\tau_k$ satisfying
+    \begin{align}
+        Q_k^i
+         & =\zeta_kX_kP_{\beta(k)}^iX_k^{-1},
+        \notag\\
+        \nu_{k,q}
+         & =\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
+        \notag
+    \end{align}
+    Only the global weight normalization in
+    Definition~\ref{def:sector_bnt_cf} is assumed; no unit-modulus copy is
+    required in each sector. This is the sector-data form of
+    \cite[Corollary~2.11 and Appendix~A, lines~1182--1188]
+    {Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    First, Theorem~\ref{thm:sector_bnt_bijective_match_of_sameMPV} gives the
+    sector bijection, the bond-dimension equalities, and the gauge-phase
+    relations. Choose their phases $\zeta_k$ and use the normalized
+    self-overlaps to obtain $|\zeta_k|=1$. Second,
+    Lemma~\ref{lem:sector_bnt_coeff_identity_via_matched_mpv_phase} expands the
+    equality of the two total MPVs in the matched $P$-basis. Eventual linear
+    independence gives, for every $k$ and all sufficiently large $N$,
+    \begin{align}
+        c_N^{(\beta(k))}(P)
+         & =\zeta_k^N c_N^{(k)}(Q).
+        \notag
+    \end{align}
+    Third, expand both coefficients as finite power sums. Their eventual
+    equality determines the two multisets of nonzero copy weights, so the
+    multiplicities agree and a copy bijection $\tau_k$ realizes the identity
+    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$.
+\end{proof}
+
+\section{The equal-MPV global gauge}
+\label{sec:ft_equal_global_gauge}
+
+For equal MPV families, the sector phases occur twice: in the matched tensor
+relation and with the inverse power in the matched copy weights. They therefore
+cancel before the block gauges are assembled.
 
 \begin{definition}[Flattened block-diagonal gauge]%
     \label{def:global_gauge_of_blocks}
@@ -249,53 +261,6 @@ block-diagonal gauge.
     $\{0,\ldots,\sum_k D_k-1\}$ of the assembled tensor. The result is an
     element of $\GL_{\sum_k D_k}(\C)$.
 \end{definition}
-
-\begin{lemma}[Unitary block-diagonal gauges]
-    \label{lem:unitary_global_gauge_of_blocks}
-    \lean{MPSTensor.unitaryGL,
-        MPSTensor.globalGaugeOfBlocks_unitaryGL_mem}
-    \leanok
-    \uses{def:global_gauge_of_blocks}
-    A unitary matrix $U_k$ defines an invertible block gauge with inverse
-    $U_k^\dagger$. If every block gauge is unitary, then the flattened
-    block-diagonal gauge $U=\bigoplus_k U_k$ is unitary.
-\end{lemma}
-\begin{proof}\leanok
-    The products are computed blockwise:
-    \begin{align}
-        U U^\dagger
-        &= \bigoplus_k U_kU_k^\dagger
-        = \bigoplus_k\mathbb 1
-        = \mathbb 1.
-        \notag
-    \end{align}
-\end{proof}
-
-\begin{lemma}[Direct-sum conjugation by the flattened gauge]%
-    \label{lem:tensor_from_blocks_globalGauge_conj}
-    \lean{MPSTensor.toTensorFromBlocks_eq_globalGaugeOfBlocks_conj,
-        MPSTensor.gaugeEquiv_toTensorFromBlocks_of_blockConj}
-    \leanok
-    \uses{def:global_gauge_of_blocks, def:block_diagonal_tensor, def:gauge_equiv}
-    If, for every block $k$ and physical index $i$,
-    $B_k^i=X_kA_k^iX_k^{-1}$, then the weighted direct sums satisfy
-    \begin{align}
-        \bigoplus_k \mu_k B_k^i
-        &=
-        X\left(\bigoplus_k \mu_k A_k^i\right)X^{-1},
-        \notag
-    \end{align}
-    where $X$ is the flattened block-diagonal gauge from
-    Definition~\ref{def:global_gauge_of_blocks}. Hence the two assembled
-    tensors are gauge equivalent.
-\end{lemma}
-
-\begin{proof}\leanok
-    Multiplication of block-diagonal matrices is computed blockwise. The scalar
-    weight $\mu_k$ commutes with the conjugation on the $k$th block, and the
-    reindexing from dependent block coordinates to the flattened bond index
-    preserves products and inverses.
-\end{proof}
 
 \begin{theorem}[Global gauge from matched sectors and copy weights]%
     \label{thm:sector_bnt_global_gauge_of_matched_weights}
@@ -342,168 +307,6 @@ block-diagonal gauge.
     block conjugacies into the direct-sum gauge
     $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
 \end{proof}
-
-\begin{theorem}[Global gauge from a copy-weight matching]%
-    \label{thm:sector_bnt_global_gauge_of_copy_weight_matching}
-    \lean{MPSTensor.sector_bnt_global_gauge_of_copy_weight_matching}
-    \leanok
-    \uses{def:sector_bnt_copy_weight_matching,
-        thm:sector_bnt_global_gauge_of_matched_weights}
-    Suppose that the sectors of $P$ and $Q$ are matched, with
-    bond-dimension equalities, nonzero phases, and block gauges satisfying
-    $Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}$.
-    If the same phases also give a copy-weight matching, then the flattened
-    $Q$-tensor is obtained from the matched-coordinate $P$-tensor by the
-    direct-sum gauge $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
-    This is only a reformulation of
-    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
-\end{theorem}
-
-\begin{proof}\leanok
-    The copy-weight matching supplies
-    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$. Together with
-    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$, these are exactly the two
-    hypotheses (\ref{eq:ft_matched_weights_hypotheses}) of
-    Theorem~\ref{thm:sector_bnt_global_gauge_of_matched_weights}.
-\end{proof}
-
-We can now state the proportional global gauge, first from a copy-weight
-matching and then from the coefficient identities that produce one.
-
-\begin{theorem}[Conditional proportional global gauge from a copy-weight matching]%
-    \label{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
-    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching}
-    \leanok
-    \uses{def:sector_bnt_copy_weight_matching,
-        thm:sector_bnt_proportional_sector_match_witnesses,
-        thm:sector_bnt_global_gauge_of_copy_weight_matching}
-    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
-    eventually nonzero proportional MPV families.
-    Then the proportional sector-matching theorem gives $\beta$, the
-    bond-dimension equalities, the unit phases $\zeta_k$, and the block gauges
-    $X_k$. If the remaining proportional coefficient comparison supplies a
-    copy-weight matching for these same phases, then the flattened
-    $Q$-tensor is obtained from the matched-coordinate $P$-tensor by the
-    direct-sum gauge $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
-    % Per-sector unit-modulus restriction eliminated by the exact matcher;
-    % closure recorded in
-    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
-\end{theorem}
-
-\begin{proof}\leanok
-    The proportional sector-matching theorem supplies $\beta$, $X_k$, and
-    unit phases $\zeta_k$ satisfying
-    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$. Since $|\zeta_k|=1$, each
-    $\zeta_k$ is nonzero. A copy-weight matching gives
-    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$, so
-    Theorem~\ref{thm:sector_bnt_global_gauge_of_copy_weight_matching} gives the
-    direct-sum gauge.
-\end{proof}
-
-\begin{theorem}[Conditional proportional global gauge from coefficient identities]%
-    \label{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}
-    \lean{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity}
-    \leanok
-    \uses{lem:sector_bnt_copy_weight_matching_of_coeff_identity,
-        thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
-    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate
-    eventually nonzero proportional MPV families.
-    Then there are a bijection $\beta:J(Q)\simeq J(P)$, bond-dimension
-    equalities, unit-modulus phases $\zeta_k$, and block gauges $X_k$ such that
-    $Q_k^i=\zeta_k X_kP_{\beta(k)}^iX_k^{-1}$ for every sector $k$ and physical
-    index $i$. If these same phases satisfy the matched-sector coefficient
-    identities $c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q)$ for all
-    sufficiently large $N$, then they determine a copy-weight matching and
-    hence the flattened $Q$-tensor is obtained from the matched-coordinate
-    $P$-tensor by the direct-sum gauge
-    $X=\bigoplus_k(\mathbf{1}_{r_k}\otimes X_k)$.
-    % Per-sector unit-modulus restriction eliminated by the exact matcher;
-    % closure recorded in
-    % docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex.
-\end{theorem}
-
-\begin{proof}\leanok
-    The sector-matching theorem gives $\beta$, $X_k$, and $|\zeta_k|=1$ with
-    $Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$. Since $\zeta_k\ne0$, the
-    coefficient identities
-    $c_N^{(\beta(k))}(P)=\zeta_k^Nc_N^{(k)}(Q)$ produce
-    $\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$ by
-    Lemma~\ref{lem:sector_bnt_copy_weight_matching_of_coeff_identity}.
-    Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_copy_weight_matching}
-    then applies to this copy-weight matching.
-\end{proof}
-
-The coefficient-identity hypothesis of
-Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity} is the
-scalar-free identity (\ref{eq:ft_coeff_identity}). From the proportional MPV
-hypothesis alone one obtains the same identity carrying the global length-scalar
-of the proportionality, recorded next.
-
-\begin{lemma}[Proportional matched-phase coefficient identity, scalar-threaded]%
-    \label{lem:sector_bnt_coeff_identity_via_matched_mpv_phase_proportional}
-    \lean{MPSTensor.coeff_identity_via_matched_mpv_phase_proportional}
-    \leanok
-    \uses{def:sector_bnt_cf, lem:eventual_coeff_eq_of_eventual_li}
-    Let $P$ be a BNT canonical form and $Q$ a sector decomposition whose total
-    tensors generate eventually nonzero proportional MPV families. Suppose a
-    bijection $\beta:J(Q)\simeq J(P)$ and scalars $\zeta_k$ satisfy the matched
-    MPV phase identities (\ref{eq:ft_phase_relation_hyp}) for every sector $k$.
-    Then there is a single eventually-nonzero scalar sequence $c_N$ and a
-    threshold $N_0$ such that, for all $N>N_0$ and every $k\in J(Q)$,
-    \begin{align}
-        c_N^{(\beta(k))}(P)
-        &= c_N\,\zeta_k^N\,c_N^{(k)}(Q).
-        \label{eq:ft_coeff_identity_threaded}
-    \end{align}
-    The scalar $c_N$ is the same for every sector $k$: it is the single global
-    proportionality scalar of \cite[Theorem~\texttt{thm1}, lines~1167--1170]%
-    {Cirac2016MPDO_arXiv} at length $N$.
-\end{lemma}
-
-\begin{proof}\leanok
-    For each $N$ on the proportionality tail, expand both total MPVs in their
-    sector bases and use the global proportionality scalar $c_N$:
-    \begin{align}
-        \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
-        &=
-        c_N\sum_{k\in J(Q)} c_N^{(k)}(Q)\ket{V^{(N)}(Q_k)}.
-        \notag
-    \end{align}
-    The matched phase identities (\ref{eq:ft_phase_relation_hyp}) give
-    $\ket{V^{(N)}(Q_k)}=\zeta_k^N\ket{V^{(N)}(P_{\beta(k)})}$; because every
-    sector is matched, reindexing the $Q$-sum by $\beta$ rewrites the right-hand
-    side entirely in the $P$-basis. The BNT eventual linear independence of the
-    $P$-basis and Lemma~\ref{lem:eventual_coeff_eq_of_eventual_li} then extract
-    the coefficient identities (\ref{eq:ft_coeff_identity_threaded}) for all
-    sufficiently large $N$.
-\end{proof}
-
-\begin{remark}[Residual length-scalar control]%
-    \label{rem:proportional_length_scalar_gap}
-    The identity (\ref{eq:ft_coeff_identity_threaded}) discharges the hypothesis
-    of Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}
-    --- equivalently (\ref{eq:ft_coeff_identity}) --- precisely when
-    $c_N\equiv1$ on the proportionality tail. More generally, if $c_N=\xi^N$ for one fixed phase
-    $\xi$, then the coefficient identity uses the phases $\xi\zeta_k$, whereas
-    the matched block relation still uses $\zeta_k$. Copy-weight recovery and
-    block-gauge assembly therefore leave the common factor $\xi^{-1}$ and yield
-    conjugacy up to that phase, not the exact conjugacy asserted by the current
-    conditional theorem. Establishing such a pure phase-power form for the
-    global proportionality scalar is a separate length-scalar control statement
-    requiring peripheral-spectrum or almost-periodicity analysis of the bounded
-    power sums $c_N^{(j)}(\cdot)$; it is not derivable from
-    (\ref{eq:ft_coeff_identity_threaded}) alone. This distinction is consistent
-    with the sectorwise gauge-phase conclusion of
-    \cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}. Until an appropriate
-    full-tensor theorem allowing the residual common phase is supplied, the
-    unconditional full-tensor proportional gauge equivalence is not stated; the
-    unconditional per-normal-tensor proportional fundamental theorem is
-    Theorem~\ref{thm:cpgsv_multiblock_ft_source}.
-    % Paper-gap note:
-    % docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex.
-\end{remark}
-
-In the equal-MPV case all ingredients are unconditional.
 
 \begin{lemma}[Equal-MPV matched copy-weight witnesses]%
     \label{lem:sector_bnt_equal_matched_copy_weight_witnesses}
@@ -633,113 +436,43 @@ In the equal-MPV case all ingredients are unconditional.
     (\ref{eq:ft_literal_gauge_Y}).
 \end{proof}
 
-\begin{lemma}[Unitary gauge in matched sector coordinates]
-    \label{lem:sector_bnt_equal_unitary_matched_gauge}
-    \lean{MPSTensor.ft_sector_bnt_equal_unitary_global_gauge_witnesses}
-    \leanok
-    \uses{thm:sector_bnt_equal_global_gauge,
-        lem:left_canonical_irreducible_same_phase_unitary_gauge,
-        lem:unitary_global_gauge_of_blocks}
-    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate the
-    same MPV family at every positive length. There are a sector bijection
-    $\beta$, copy bijections $\tau_k$, phases $\zeta_k$, sector unitaries $U_k$,
-    and a unitary block-diagonal matrix $X$ such that
+\begin{remark}[Proportional sector matching does not determine copy weights]%
+    \label{rem:proportional_length_scalar_gap}
+    The proportional theorem determines the normal sectors, but it does not
+    determine the copy weights or imply conjugacy of the total tensors. Let
+    $C$ be a normalized normal tensor and consider the one-sector BNT forms
     \begin{align}
-        Q_k^i
-        &= \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
-        \notag\\
-        \nu_{k,q}
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)},
-        \notag\\
-        |\zeta_k|
-        &= 1.
+        P
+         & =C\oplus \tfrac12 C,
+        &
+        Q
+         & =C\oplus \tfrac13 C.
         \notag
     \end{align}
-    The matched sectors and copies have equal bond dimensions and
-    multiplicities. If $P_{\mathrm{match}}$ denotes the corresponding
-    reordered block assembly, then
-    $Q_{\mathrm{flat}}^i=XP_{\mathrm{match}}^iX^{-1}$.
-\end{lemma}
-\begin{proof}\leanok
-    \uses{lem:sector_bnt_equal_matched_copy_weight_witnesses,
-        lem:left_canonical_irreducible_same_phase_unitary_gauge,
-        lem:unitary_global_gauge_of_blocks}
-    Apply Lemma~\ref{lem:left_canonical_irreducible_same_phase_unitary_gauge}
-    to each matched sector, retaining the phase in the copy-weight identity.
-    Repeating $U_k$ on every copy gives $X=\bigoplus_{k,q}U_k$, which is unitary
-    by Lemma~\ref{lem:unitary_global_gauge_of_blocks}. For every matched copy
-    $(k,q)$,
+    Their positive-length MPV families are
     \begin{align}
-        \nu_{k,q}Q_k^i
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}
-          \zeta_k U_kP_{\beta(k)}^iU_k^\dagger
-        = \mu_{\beta(k),\tau_k(q)}U_kP_{\beta(k)}^iU_k^\dagger.
+        V^{(N)}(P)
+         & =(1+2^{-N})V^{(N)}(C),
+        &
+        V^{(N)}(Q)
+         & =(1+3^{-N})V^{(N)}(C).
         \notag
     \end{align}
-    These are precisely the blocks of
-    $Q_{\mathrm{flat}}^i=XP_{\mathrm{match}}^iX^{-1}$.
-\end{proof}
+    They are nonzero and proportional with
+    \begin{align}
+        c_N
+         & =\frac{1+2^{-N}}{1+3^{-N}},
+        \notag
+    \end{align}
+    but $(c_N)_N$ is not a geometric sequence $\xi^N$. For a one-dimensional
+    choice of $C$, the total matrices have eigenvalue multisets
+    $\{1,\tfrac12\}$ and $\{1,\tfrac13\}$, so they are not conjugate, even
+    after multiplication by a common phase.
 
-\begin{corollary}[Canonical Form II unitary refinement in the equal case]%
-    \label{cor:sector_bnt_equal_unitary_global_gauge}
-    \lean{MPSTensor.fundamentalTheorem_equal_canonicalForm_unitary}
-    \leanok
-    \uses{lem:sector_bnt_equal_unitary_matched_gauge}
-    Let $P$ and $Q$ be BNT canonical forms whose total tensors generate the
-    same MPV family at every positive length. Their total bond dimensions
-    agree; writing the common value as $D$, there is a unitary matrix
-    $U\in\mathrm{U}(D)$ such that, for every physical index~$i$,
-    \begin{align}
-        Q_{\mathrm{tot}}^i
-        &= U P_{\mathrm{tot}}^i U^\dagger.
-        \notag
-    \end{align}
-    This is the equal case of
-    \cite[Corollary~C.5]{Cirac2016MPDO_arXiv}.
-\end{corollary}
-
-\begin{proof}\leanok
-    \uses{lem:sector_bnt_equal_unitary_matched_gauge}
-    For each matched sector, retain the phase in both identities
-    \begin{align}
-        Q_k^i
-        &= \zeta_k U_kP_{\beta(k)}^iU_k^\dagger,
-        \notag\\
-        \nu_{k,q}
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}.
-        \notag
-    \end{align}
-    For every matched copy $(k,q)$,
-    \begin{align}
-        \nu_{k,q}\zeta_k
-        &= \zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}\zeta_k
-        = \mu_{\beta(k),\tau_k(q)}.
-        \notag
-    \end{align}
-    Hence $Q_{\mathrm{flat}}^i=XP_{\mathrm{match}}^iX^{-1}$. Repeating $U_k$
-    on its matched copies gives
-    \begin{align}
-        X
-        &= \bigoplus_{k,q}U_k,
-        \notag\\
-        X^\dagger X
-        &= \mathbb 1.
-        \notag
-    \end{align}
-    If $\Pi$ is the permutation matrix restoring the original sector and copy
-    order, then $\Pi^\dagger\Pi=\mathbb 1$. Hence
-    \begin{align}
-        U
-        &= X\Pi,
-        \notag\\
-        U^\dagger U
-        &= \mathbb 1,
-        \notag
-    \end{align}
-    and the permutation of matched coordinates gives
-    \begin{align}
-        Q_{\mathrm{tot}}^i
-        &= UP_{\mathrm{tot}}^iU^\dagger.
-        \notag
-    \end{align}
-\end{proof}
+    Thus the scalar-free coefficient identity used in copy-weight recovery is
+    an additional hypothesis in the proportional setting, not a consequence
+    awaiting an analytic estimate. CPSV16 Theorem~2.10 asserts the sector
+    matching proved in Theorem~\ref{thm:cpgsv_multiblock_ft_source}. The
+    copy-weight recovery and global block gauge belong to the equal-MPV
+    Corollary~2.11, where the proportionality scalar is identically $1$.
+\end{remark}

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -1,32 +1,32 @@
 \chapter{Proof of the Fundamental Theorem}\label{ch:ft_proof}
 
 For BNT canonical forms $P$ and $Q$, write the weighted direct sums over
-normal-tensor sectors $P^i=\bigoplus_j\mu_jP_j^i$ and $Q^i=\bigoplus_k\nu_kQ_k^i$.
-The proportional theorem gives a bijection $\beta$ of the normal-tensor
-sectors with unit-modulus phases $\zeta_k$, invertible matrices $X_k$, and
-$Q_k^i=\zeta_kX_kP_{\beta(k)}^iX_k^{-1}$;
-the equal-MPV corollary collapses the per-block phases into a single $X$ with
-$Q_{\mathrm{tot}}^i=XP_{\mathrm{tot}}^iX^{-1}$. Given the sector matching of
-Chapter~\ref{ch:bnt}, extract the per-sector coefficient identities
-$c_N^{(\beta(k))}(P)=\zeta_k^N\,c_N^{(k)}(Q)$ from eventual linear independence,
-recover the copy weights by finite power-sum comparison, and
-combine the block gauges into $X=\bigoplus_k(\mathbf 1_{r_k}\otimes X_k)$.
+normal-tensor sectors as $P^i=\bigoplus_{j,q}\mu_{j,q}P_j^i$ and
+$Q^i=\bigoplus_{k,q}\nu_{k,q}Q_k^i$. The proportional theorem matches the
+normal sectors by a bijection $\beta$, unit phases $\zeta_k$, and invertible
+matrices $X_k$ satisfying
+\begin{align}
+    Q_k^i
+     & =\zeta_kX_kP_{\beta(k)}^iX_k^{-1}.
+    \notag
+\end{align}
+It does not determine the copy weights. In the equal-MPV case, eventual linear
+independence gives
+\begin{align}
+    c_N^{(\beta(k))}(P)
+     & =\zeta_k^N c_N^{(k)}(Q).
+    \notag
+\end{align}
+Finite power-sum comparison then gives
+$\nu_{k,q}=\zeta_k^{-1}\mu_{\beta(k),\tau_k(q)}$. Thus the sector phases do
+not become equal: each phase cancels against the inverse phase in its matched
+copy weight. The remaining block conjugacies assemble into
+$X=\bigoplus_k(\mathbf 1_{r_k}\otimes X_k)$, and a sector-coordinate
+permutation yields the literal global gauge.
 
-Throughout, ``eventually'' abbreviates ``for all sufficiently large $N$'': there
-is $N_0$ such that the stated relation holds for every $N>N_0$. The comparison is
-made at a fixed such $N$, where BNT linear independence detects a vanishing
-coefficient even when $|\mu|<1$ lets it decay.
-
-% NOTE: The Fundamental Theorem proof is formalised on the BNT
-% canonical-form statements of Chapter~\ref{ch:bnt}. The Lean targets are
-% MPSTensor.ft_sector_bnt_equal_global_gauge and
-% MPSTensor.ft_sector_bnt_equal_mps_gaugeEquiv_literal in
-% TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean. The two
-% canonical-form source theorems of this chapter are
-% MPSTensor.fundamentalTheorem_proportional_canonicalForm (proportional,
-% Theorem II.1) and MPSTensor.fundamentalTheorem_equal_canonicalForm
-% (equal, Corollary II.2) in
-% TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean.
+Throughout, ``eventually'' means ``for all sufficiently large $N$''. At a
+fixed length in that range, BNT linear independence detects exact coefficient
+equalities even when a weight of modulus less than $1$ makes its powers decay.
 
 \input{chapter/ch11_fundamental_theorem_core}
 \input{chapter/ch11_fundamental_theorem_cases}

--- a/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
@@ -153,7 +153,7 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     Explicitly, for $X=\bigoplus_k X_k$,
     \begin{align}
         \bigoplus_k \mu_k B_k^i
-        &= X \left(\bigoplus_k \mu_k A_k^i\right) X^{-1}.
+         & = X \left(\bigoplus_k \mu_k A_k^i\right) X^{-1}.
         \label{eq:aft_multiBlock_global_conj}
     \end{align}
 \end{lemma}
@@ -247,7 +247,7 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
     by reindexing the blocks along $e$:
     \begin{align}
         V^{(N)}\!\left(\bigoplus_k \mu_k A_k\right)_\sigma
-        &=
+         & =
         V^{(N)}\!\left(\bigoplus_k \mu_{e(k)} A_{e(k)}\right)_\sigma.
         \notag
     \end{align}
@@ -466,7 +466,7 @@ scalar factor.
         % tensor.  The upper leg is i; both terms have signature (1,1,1,0).
         \begin{tenkz}[physical=up]
             \tnX{X(h)X(g)} & \tn[up=$i$]{A} &
-                \tnX{(X(h)X(g))^{-1}}
+            \tnX{(X(h)X(g))^{-1}}
         \end{tenkz}
         $ = $
         \begin{tenkz}[physical=up]

--- a/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
@@ -336,7 +336,7 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 
 The same-index lemmas above assume a fixed block correspondence. The equal-case
 sector matching with initially different sector counts and bond dimensions is
-Theorem~\ref{lem:ft_sector_bnt_equal_sector_data_different_dims} of
+Theorem~\ref{thm:ft_sector_bnt_equal_sector_data_different_dims} of
 Chapter~\ref{ch:ft_proof}; its global-gauge consequence is
 Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 

--- a/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
+++ b/blueprint/src/chapter/ch23_algebraic_ft_direct_sums_and_symmetry.tex
@@ -334,49 +334,11 @@ Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 \subsection{Equal-case block matching with differing bond dimensions}%
 \label{sec:different_bond_dimension_equal_case_ft}
 
-The same-index lemmas above assume a fixed block correspondence. The
-equal-case theorem on the BNT canonical form instead derives the
-sector matching from the same-MPV hypothesis alone, allowing different
-sector counts and bond dimensions before matching.
-
-\begin{lemma}[Equal-case block matching with differing bond dimensions]%
-    \label{lem:ft_sector_bnt_equal_sector_data_different_dims}
-    \lean{MPSTensor.ft_sector_bnt_equal_sector_data}
-    \leanok
-    \uses{def:same_mpv2_pos, def:sector_bnt_cf, def:gauge_phase_equiv}
-    Let $P$ and $Q$ be two BNT canonical forms
-    (Definition~\ref{def:sector_bnt_cf}), each admitting a unit-modulus copy
-    weight in every basis sector, possibly with different sector counts and
-    different bond dimensions before matching.
-    If their block-diagonal tensors generate the same MPV family at every
-    positive length (Definition~\ref{def:same_mpv2_pos}), then the basis
-    sectors are bijectively matched by a permutation $\beta$, each matched
-    basis pair is gauge-phase equivalent
-    (Definition~\ref{def:gauge_phase_equiv}), the matched copy multiplicities
-    agree, and the copy weights agree up to a unit-modulus phase $\zeta$ and a
-    copy-index reindexing.
-    This is the sector-data form of the equal-case theorem
-    \cite[Corollary~2.11, lines 354--361 and appendix 1172--1192]{Cirac2016MPDO_arXiv};
-    the corresponding global gauge corollary is recorded in
-    Chapter~\ref{ch:ft_proof}.
-    % Maintainer note (Lean): the global-gauge companion is
-    % MPSTensor.ft_sector_bnt_equal_global_gauge in
-    % TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    On the BNT canonical form, the proof proceeds in three steps:
-    bijective block matching from non-decaying cross-overlaps, coefficient
-    identity via the global-gauge phase $\zeta$, and multiset comparison of
-    the scalar power sums recovering matched copy multiplicities and
-    weights up to $\zeta^{-1}$.
-    % Maintainer note (Lean): the three steps are formalised as
-    % StrongMatch.bijective_match_of_sameMPV,
-    % CoeffIdentity.coeff_identity_via_global_gauge, and
-    % WeightEquiv.matched_sector_weight_equiv in
-    % TNLean/MPS/FundamentalTheorem/SectorBNT/.
-\end{proof}
+The same-index lemmas above assume a fixed block correspondence. The equal-case
+sector matching with initially different sector counts and bond dimensions is
+Theorem~\ref{lem:ft_sector_bnt_equal_sector_data_different_dims} of
+Chapter~\ref{ch:ft_proof}; its global-gauge consequence is
+Theorem~\ref{thm:sector_bnt_equal_global_gauge}.
 
 %% ---------------------------------------------------------
 \section{Translation-invariant reduction and global symmetry}%

--- a/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
+++ b/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
@@ -47,7 +47,7 @@ Write
 \begin{align}
     c_N^{(j)}(P)
      & =\sum_q\mu_{j,q}^N,
-    &
+     &
     c_N^{(k)}(Q)
      & =\sum_q\nu_{k,q}^N.
 \end{align}
@@ -76,7 +76,7 @@ Let $C$ be a normalized normal tensor and consider the one-sector BNT forms
 \begin{align}
     P
      & =C\oplus\tfrac12C,
-    &
+     &
     Q
      & =C\oplus\tfrac13C.
 \end{align}
@@ -85,7 +85,7 @@ most $1$, and each form has a unit-modulus weight. Their MPV families are
 \begin{align}
     V^{(N)}(P)
      & =(1+2^{-N})V^{(N)}(C),
-    &
+     &
     V^{(N)}(Q)
      & =(1+3^{-N})V^{(N)}(C).
 \end{align}

--- a/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
+++ b/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
@@ -6,150 +6,129 @@
 
 \input{./command}
 
-\title{The Length-Dependent Proportionality Scalar in the CPSV16 Proportional
-BNT Coefficient Comparison}
+\title{Length-Dependent Scalars Do Not Determine Copy Weights in the
+Proportional BNT Theorem}
 \author{}
-\date{2026-06-23}
+\date{2026-07-26}
 
 \begin{document}
 \maketitle
 
 \section{The source statement}
 
-Cirac--Perez-Garcia--Schuch--Verstraete 2016 (arXiv:1606.00608), Theorem
-\texttt{thm1} (lines 1167--1170), assumes that two translationally invariant
-matrix product states generate \emph{proportional} matrix product vectors: for
-every length \(N\) there is a nonzero scalar \(c_N\) with
-\[
-  V^{(N)}(P_{\mathrm{tot}})_\sigma = c_N\, V^{(N)}(Q_{\mathrm{tot}})_\sigma
-  \qquad \text{for all } \sigma \in \{1,\dots,d\}^N .
-\]
-The formal predicate is \texttt{EventuallyNonzeroProportionalMPV\textsubscript{2}}
-(the eventual form used in the proof, after the linear-independence Lemma
-\texttt{Lem1} at line 1182).  The conclusion of Theorem \texttt{thm1} is a global
-gauge equivalence \emph{up to a single phase}.
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete state in
+\cite[Theorem~2.10 and Appendix~A, lines~1167--1183]
+{Cirac2016MPDO_arXiv} that proportional matrix-product-vector families in
+canonical form have bijectively matched bases of normal tensors. For each
+matched pair there are a phase $\zeta_k$ and an invertible matrix $X_k$ such
+that
+\begin{align}
+    Q_k^i
+     & =\zeta_kX_kP_{\beta(k)}^iX_k^{-1}.
+    \label{eq:sector-match}
+\end{align}
+The theorem does not assert that the two total tensors are conjugate, even up
+to a common phase. Copy-weight recovery and the block-diagonal global gauge
+occur in the equal-MPV Corollary~2.11, not in the proportional theorem.
 
-\section{What the new BNT surface already proves}
+The formal proportional theorem uses eventual nonzero projective
+proportionality: for all sufficiently large $N$, one nonzero scalar $c_N$
+satisfies
+\begin{align}
+    V^{(N)}(P_{\mathrm{tot}})
+     & =c_NV^{(N)}(Q_{\mathrm{tot}}).
+    \label{eq:proportional-total}
+\end{align}
+The source assumption at every positive length is a special case.
 
-On the \texttt{SectorDecomposition} / \texttt{IsBNTCanonicalForm} surface the
-proportional sector-matching theorem
-(\texttt{ft\_sector\_bnt\_proportional\_sector\_match\_witnesses}) already
-supplies, for two BNT canonical forms \(P\) and \(Q\):
+\section{The coefficient identity retaining the global scalar}
+
+Write
+\begin{align}
+    c_N^{(j)}(P)
+     & =\sum_q\mu_{j,q}^N,
+    &
+    c_N^{(k)}(Q)
+     & =\sum_q\nu_{k,q}^N.
+\end{align}
+Substituting the matched-sector relation (\ref{eq:sector-match}) into
+(\ref{eq:proportional-total}), reindexing by $\beta$, and applying eventual
+linear independence of the $P$-basis gives
+\begin{align}
+    c_N^{(\beta(k))}(P)
+     & =c_N\zeta_k^N c_N^{(k)}(Q)
+    \label{eq:threaded}
+\end{align}
+for every sector $k$ and all sufficiently large $N$. The same $c_N$ occurs in
+every sector because it is the scalar relating the two total vectors.
+
+The equal-MPV argument has $c_N=1$. It then compares the two finite power sums
+\begin{align}
+    \sum_q\mu_{\beta(k),q}^N
+     & =\sum_q(\zeta_k\nu_{k,q})^N
+\end{align}
+and recovers the copy-weight multiset. For a general proportional family,
+(\ref{eq:threaded}) does not supply this scalar-free identity.
+
+\section{Counterexample}
+
+Let $C$ be a normalized normal tensor and consider the one-sector BNT forms
+\begin{align}
+    P
+     & =C\oplus\tfrac12C,
+    &
+    Q
+     & =C\oplus\tfrac13C.
+\end{align}
+Both forms obey the canonical weight normalization: every weight has modulus at
+most $1$, and each form has a unit-modulus weight. Their MPV families are
+\begin{align}
+    V^{(N)}(P)
+     & =(1+2^{-N})V^{(N)}(C),
+    &
+    V^{(N)}(Q)
+     & =(1+3^{-N})V^{(N)}(C).
+\end{align}
+Thus they are nonzero and proportional at every positive length with
+\begin{align}
+    c_N
+     & =\frac{1+2^{-N}}{1+3^{-N}}.
+\end{align}
+This sequence is not of the form $\xi^N$ for a fixed phase $\xi$.
+
+For a one-dimensional choice of $C$, the two total matrices have eigenvalue
+multisets
+\begin{align}
+    \left\{1,\tfrac12\right\}
+    \quad\text{and}\quad
+    \left\{1,\tfrac13\right\}.
+\end{align}
+Similarity preserves eigenvalues, and multiplication by a common phase merely
+multiplies both eigenvalues by that phase. Consequently the two total tensors
+are not conjugate, even up to a common phase.
+
+\section{Conclusion}
+
+There is no missing theorem asserting that the proportionality scalar of two
+BNT canonical forms must be a geometric phase sequence. The counterexample
+shows that such a statement is false under the proportional theorem's
+hypotheses. The valid conclusions are:
 \begin{itemize}
-  \item a bijection \(\beta : J(Q) \simeq J(P)\) between the normal-tensor
-        sectors;
-  \item per-sector bond-dimension equalities \(\dim P_{\beta(k)} = \dim Q_k\);
-  \item per-sector unit-modulus phases \(\zeta_k\), \(|\zeta_k| = 1\), and block
-        gauges \(X_k\) with
-        \[
-          Q_k^i = \zeta_k\, X_k\, P_{\beta(k)}^i\, X_k^{-1};
-        \]
-  \item the matched MPV power identities, for \emph{every} sector \(k\),
-        \[
-          V^{(N)}(Q_k)_\sigma = \zeta_k^N\, V^{(N)}(P_{\beta(k)})_\sigma .
-        \]
+    \item proportional total MPVs determine a bijection and gauge-phase
+          equivalence of the normal sectors;
+    \item the coefficient identity retains one arbitrary length-dependent
+          global scalar $c_N$;
+    \item scalar-free coefficient identities, copy-weight matching, and a
+          global block gauge require additional hypotheses;
+    \item in the equal-MPV corollary, $c_N=1$, so power-sum recovery and the
+          global gauge follow.
 \end{itemize}
 
-Because every sector --- not only the leading pair --- is matched with its own
-phase identity, the off-diagonal contributions that obstructed the one-copy
-peeling argument of the 2026-05-13 probe
-(\texttt{docs/audits/2026-05-13\_cpsv16\_ft\_exact\_leading\_coeff.md}) vanish
-\emph{exactly}, not merely asymptotically.  The full-basis linear-independence
-coefficient comparison therefore goes through cleanly.  Writing
-\[
-  c_N^{(j)}(P) = \sum_{q} \mu_{j,q}^N, \qquad
-  c_N^{(k)}(Q) = \sum_{q} \nu_{k,q}^N,
-\]
-substituting the per-sector phase identities into the proportional MPV identity,
-reindexing the \(Q\)-sum by \(\beta\), and applying the BNT eventual linear
-independence of the \(P\)-basis gives, for a single eventually-nonzero scalar
-sequence \(c_N\) shared across all sectors and all sufficiently large \(N\),
-\begin{equation}\label{eq:threaded}
-  c_N^{(\beta(k))}(P) = c_N \,\zeta_k^N\, c_N^{(k)}(Q)
-  \qquad \text{for every } k \in J(Q).
-\end{equation}
-This is the content of
-\texttt{MPSTensor.coeff\_identity\_via\_matched\_mpv\_phase\_proportional}.  The
-scalar \(c_N\) is the \emph{same} for every sector \(k\) because it is the single
-global proportionality scalar of Theorem \texttt{thm1}.
+The conditional implications from scalar-free coefficient identities to a
+global gauge remain correct. They are additional consequences, not unfinished
+parts of CPSV16 Theorem~2.10.
 
-\section{The residual obstruction}
-
-The copy-weight recovery step
-(\texttt{SectorBNTCopyWeightMatching.of\_coeff\_identity}, Appendix MPV proof
-line 1188) compares the per-copy power-sum multisets through
-\[
-  \sum_q \mu_{\beta(k),q}^N = \zeta_k^N \sum_q \nu_{k,q}^N
-  = \sum_q (\zeta_k \nu_{k,q})^N ,
-\]
-and extracts the copy permutation by finite power-sum uniqueness.  This requires
-the \emph{scalar-free} identity
-\begin{equation}\label{eq:scalarfree}
-  c_N^{(\beta(k))}(P) = \zeta_k^N\, c_N^{(k)}(Q),
-\end{equation}
-i.e.\ exactly~(\ref{eq:threaded}) with \(c_N \equiv 1\).  A length-dependent
-factor \(c_N\) breaks the multiset comparison: distinct lengths would impose
-incompatible scalings.
-
-Equation~(\ref{eq:threaded}) holds with \(c_N \equiv 1\) if and only if
-\(c_N = \xi^N\) for a single fixed phase \(\xi\): then the power \(\xi^N\) is
-absorbed into the sector phases by replacing \(\zeta_k\) with \(\xi^{-1}\zeta_k\),
-recovering~(\ref{eq:scalarfree}).  (The gauge-phase conclusion of Theorem
-\texttt{thm1}, \(Q^i = \xi\, Y\, P^i\, Y^{-1}\), itself \emph{forces}
-\(c_N = \xi^N\) on the trace, so this is the necessary and sufficient form.)
-
-The missing step is therefore:
-\begin{quote}
-  the global proportionality scalar \(c_N\) of two BNT canonical forms is a pure
-  phase power \(\xi^N\) with \(|\xi| = 1\).
-\end{quote}
-This is a length-scalar control statement.  Under the BNT normalization
-\(|\mu_{j,q}| \le 1\), \(|\nu_{k,q}| \le 1\), with a global unit witness on each
-side, the sector coefficients \(c_N^{(j)}(\cdot)\) are bounded almost-periodic
-power sums that do not decay.  Pinning \(c_N\) to a single geometric phase
-sequence requires peripheral-spectrum / almost-periodicity analysis of these
-power sums that is not currently available in the library; it cannot be derived
-from~(\ref{eq:threaded}) alone, since~(\ref{eq:threaded}) determines \(c_N\) only
-up to the joint scaling of the matched coefficient pairs.
-
-\section{Status and elimination plan}
-
-\begin{itemize}
-  \item \textbf{Proved (faithful, sorry-free):} the threaded identity
-        (\ref{eq:threaded}),
-        \texttt{coeff\_identity\_via\_matched\_mpv\_phase\_proportional} in
-        \path{TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean}.  No
-        hypothesis absent from Theorem \texttt{thm1} is added.
-  \item \textbf{Conditional (already on \texttt{main}):}
-        \texttt{ft\_sector\_bnt\_proportional\_global\_gauge\_of\_coeff\_identity}
-        takes the scalar-free identity~(\ref{eq:scalarfree}) as an explicit
-        hypothesis and concludes the direct-sum global gauge.
-  \item \textbf{Open:} prove \(c_N = \xi^N\) for a fixed phase \(\xi\), discharge
-        the hypothesis of the conditional theorem, and hence obtain the
-        unconditional proportional global-gauge theorem at the full-tensor level
-        (the literal Theorem \texttt{thm1}).
-\end{itemize}
-
-Until the length-scalar control statement is proved, the unconditional
-full-tensor proportional gauge equivalence cannot be stated faithfully: omitting
-the control would require either a \texttt{sorry} or a hypothesis absent from
-Theorem \texttt{thm1}.  The per-sector (basis-level) proportional fundamental
-theorem,
-\texttt{MPSTensor.fundamentalTheorem\_proportional\_canonicalForm}, is
-unconditional and records the per-normal-tensor gauge-phase conclusion that does
-not need the copy-weight comparison.
-
-\section{References}
-
-\begin{itemize}
-  \item arXiv:1606.00608, Theorem \texttt{thm1}, lines 1167--1170 (statement),
-        line 1182 (matching), lines 1184--1192 (Appendix MPV coefficient
-        comparison and global gauge).
-  \item arXiv:2011.12127, Definition 4.2 (two-layer BNT canonical form).
-  \item \path{docs/audits/2026-05-13_cpsv16_ft_exact_leading_coeff.md}
-        (the one-copy-surface obstruction superseded by full sector matching).
-  \item \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}
-        (the BNT weight normalization used above).
-\end{itemize}
+\bibliographystyle{alpha}
+\bibliography{references}
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
+++ b/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
@@ -39,7 +39,10 @@ satisfies
      & =c_NV^{(N)}(Q_{\mathrm{tot}}).
     \label{eq:proportional-total}
 \end{align}
-The source assumption at every positive length is a special case.
+The source assumption at every positive length is a special case.\footnote{The
+    formal proportional theorem is
+    \leanid{MPSTensor.fundamentalTheorem_proportional_canonicalForm} in
+    \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord}.}
 
 \section{The coefficient identity retaining the global scalar}
 
@@ -59,8 +62,12 @@ linear independence of the $P$-basis gives
      & =c_N\zeta_k^N c_N^{(k)}(Q)
     \label{eq:threaded}
 \end{align}
-for every sector $k$ and all sufficiently large $N$. The same $c_N$ occurs in
-every sector because it is the scalar relating the two total vectors.
+for every sector $k$ and all sufficiently large $N$.\footnote{The formal
+    coefficient identity that retains the global scalar is
+    \leanid{MPSTensor.coeff_identity_via_matched_mpv_phase_proportional} in
+    \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity}.}
+The same $c_N$ occurs in every sector because it is the scalar relating the two
+total vectors.
 
 The equal-MPV argument has $c_N=1$. It then compares the two finite power sums
 \begin{align}
@@ -109,10 +116,13 @@ are not conjugate, even up to a common phase.
 
 \section{Conclusion}
 
-There is no missing theorem asserting that the proportionality scalar of two
-BNT canonical forms must be a geometric phase sequence. The counterexample
-shows that such a statement is false under the proportional theorem's
-hypotheses. The valid conclusions are:
+\textbf{Verdict: correction of a prior mathematical assessment; there is no
+    mathematical gap.} The source proportional theorem never requires copy-weight
+recovery or a global gauge, and the counterexample proves that this stronger
+claim is false under the proportional theorem's hypotheses. In particular,
+there is no missing theorem asserting that the proportionality scalar of two
+BNT canonical forms must be a geometric phase sequence. The valid conclusions
+are:
 \begin{itemize}
     \item proportional total MPVs determine a bijection and gauge-phase
           equivalence of the normal sectors;
@@ -125,8 +135,12 @@ hypotheses. The valid conclusions are:
 \end{itemize}
 
 The conditional implications from scalar-free coefficient identities to a
-global gauge remain correct. They are additional consequences, not unfinished
-parts of CPSV16 Theorem~2.10.
+global gauge remain correct.\footnote{The formal conditional global-gauge
+    construction is
+    \leanid{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity}
+    in \doclink{TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental}.}
+They are additional consequences, not unfinished parts of CPSV16
+Theorem~2.10.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- Added the substantial common appendix **Proof of the Fundamental Theorem: Supporting Results**, split into two subfiles covering coefficient/block-gauge support and coordinate/permutation/unitary support.
- Refocused Chapter 11 main text on the source-facing proportional and equal Fundamental Theorems, sector matching, coefficient and copy-weight recovery, phase cancellation, block-gauge assembly, literal coordinate restoration, and unitary refinements.
- Restored the full proportional matching mechanism in main: partition decaying sectors, substitute exact relations for the complementary sectors, apply eventual linear independence to the restricted family together with all opposite-family sectors, then obtain the two-sided finite bijection and gauge-phase witnesses.
- Moved the central equal-sector-data theorem from inactive Chapter 23 into Chapter 11, removed its false per-sector unit-weight premise, and preserved the proof order matching → coefficient identity → power-sum recovery.
- Corrected the proportional-family scope: proportional MPV families need not have a geometric length scalar or globally conjugate total tensors. The explicit example $C\oplus\frac12 C$ versus $C\oplus\frac13 C$ now replaces the former open-gap narrative in both the chapter and paper-gap note.
- Rehomed the left-canonical tensor definition to Chapter 6, retained stable labels, and updated Chapter 10/23 references to the new ownership.
- Corrected the source unitary refinement to CPSV16 arXiv **Corollary A.6, lines 1197--1199**.
- Kept private coordinate results untagged; corrected stale CPSV16/scalar-control Lean docstrings without changing any declaration, theorem statement, definition, or proof.

## Validation

- Independent mathematical/source review: approved after the partition-proof and private-target corrections.
- Blueprint–Lean source synchronization: green; 5,572 unique `\lean{}` references before the correction pass and 5,582/5,585 theorem-like entries after final regeneration.
- Duplicate labels: 0; duplicate changed-file Lean presentations: 0; no private Lean targets.
- Full route: 204 files, 3,595 labels, 0 duplicate labels, 0 missing `\ref`/`\uses` targets.
- Focused route: 58 files, 920 labels, 0 duplicate labels, 0 missing targets.
- Targeted Lean build for all four documentation-touched modules: green (8,782 jobs); comment-stripped token stream unchanged.
- Full Blueprint: double LuaLaTeX, 729 pages, 0 ordinary undefined references.
- Focused FT-MPS Blueprint: double LuaLaTeX, 177 pages, 0 ordinary undefined references.
- Every changed source is below 1,000 lines; `latexindent` is stable; `git diff --check` is clean; generated artifacts removed.

Lean changes are documentation-only: no declaration, theorem statement, definition, or proof changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are primarily blueprint/documentation and Lean docstrings; no proof logic changes identified in the diff.
> 
> **Overview**
> Reorganizes the Fundamental Theorem write-up: a new appendix chapter holds coefficient extraction, block gauges, matched coordinates, permutation/unitary refinements, and proportional conditional consequences, while Chapter 11 main text stays on proportional sector matching, equal-MPV copy-weight recovery, and global gauge assembly.
> 
> **Proportional vs equal scope** is corrected throughout. The scalar-threaded coefficient identity is the full proportional conclusion; scalar-free copy-weight matching and global conjugacy are framed as **extra hypotheses** (valid in the equal case). The former “open length-scalar gap” is replaced by the explicit counterexample `C ⊕ ½C` vs `C ⊕ ⅓C` in the chapter and `docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex`.
> 
> Other edits: equal-sector-data theorem moved from Chapter 23 into Chapter 11 (dropping a false per-sector unit-weight premise); **left-canonical** definition rehomed to Chapter 6; CPSV16 unitary refinement citations fixed to **Corollary A.6** in blueprint and Lean docstrings; `CoeffIdentity.lean` module comment updated to match the new narrative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 352e54ccd260ebcc02c845a1b73f7e7edcd1e903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

