### PR TITLE
fix(readme): repoint CI badge at pr-ci.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <b>Tensor-network theory, formalized in Lean 4.</b>
 </p>
 
-[![Lean Action CI](https://github.com/LionSR/TNLean/actions/workflows/lean_action_ci.yml/badge.svg)](https://github.com/LionSR/TNLean/actions/workflows/lean_action_ci.yml)
+[![PR CI](https://github.com/LionSR/TNLean/actions/workflows/pr-ci.yml/badge.svg)](https://github.com/LionSR/TNLean/actions/workflows/pr-ci.yml)
 [![Compile blueprint](https://github.com/LionSR/TNLean/actions/workflows/blueprint.yml/badge.svg)](https://github.com/LionSR/TNLean/actions/workflows/blueprint.yml)
 ![sorries](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/sorries.json)
 ![axioms](https://img.shields.io/endpoint?url=https://sirui-lu.com/TNLean/badges/axioms.json)


### PR DESCRIPTION
The Lean Action CI badge still linked to lean_action_ci.yml, which was
consolidated into pr-ci.yml (along with lint-blueprint.yml and
oversized-lean-files.yml) and no longer exists, leaving the badge dead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016ty8Uy98G1SeLVzXgqhgDT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only badge URL change with no runtime or build impact.
> 
> **Overview**
> Updates the README status badge so it points at the consolidated **`pr-ci.yml`** workflow instead of the removed **`lean_action_ci.yml`**, restoring a live CI status link after those pipelines were merged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f3e019f269223916d866a50b86a03bc6d9f49a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->