### PR TITLE
fix(blueprint): resolve Chapter 12 post-merge review

### DIFF
--- a/blueprint/src/appendix/ft_mps/ch12_symmetry.tex
+++ b/blueprint/src/appendix/ft_mps/ch12_symmetry.tex
@@ -1,10 +1,10 @@
-\chapter{Symmetries and String Order: Supporting Results}
+\chapter{Symmetries and Virtual-Boundary Nondecay: Supporting Results}
 \label{ch:symmetry_supporting_results}
 
 This appendix supports Chapter~\ref{ch:symmetry}.  It collects permutation
 and gauge bookkeeping, factor-system identities, stationary-boundary twist
 calculations, common trace-preserving gauges, and the finite-dimensional limit
-arguments used in the string-order results.  The notation is introduced
+arguments used in the virtual-boundary nondecay results. The notation is introduced
 locally in each part, and every reference to the main development is given by
 its stable label.
 

--- a/blueprint/src/appendix/ft_mps/ch12_symmetry_transfer_and_limits.tex
+++ b/blueprint/src/appendix/ft_mps/ch12_symmetry_transfer_and_limits.tex
@@ -43,17 +43,20 @@ physical endpoint correlator of Definition~\ref{def:physical_string_order_param}
     \label{lem:transfer_map_twisted_companion}
     \lean{MPSTensor.transferMap_twistedMixedCompanion_eq}
     \leanok
-    \uses{def:twisted_mixed_companion, thm:kraus_rectangular_freedom}
-    If $uu^\dagger=\Id_d$, then the companion family $B_u$ satisfies
+    \uses{def:twisted_mixed_companion, def:transfer_map}
+    If $uu^\dagger=\Id_d$, then for every $X\in\MN{D}$ the companion family
+    $B_u$ satisfies
     \begin{align}
-        \E_{B_u}(X) & =\E_A(X)
-        \qquad (X\in\MN{D}).
+        \E_{B_u}(X) & =\E_A(X).
         \notag
     \end{align}
 \end{lemma}
 
 \begin{proof}\leanok
-    Expand $B_u^n=\sum_{n'}\overline{u_{n'n}}A^{n'}$.  The coefficient of
+    \uses{thm:kraus_same_map_of_unitary_combination}
+    Theorem~\ref{thm:kraus_same_map_of_unitary_combination} applies to the
+    unitary combination defining $B_u$. Equivalently, expand
+    $B_u^n=\sum_{n'}\overline{u_{n'n}}A^{n'}$. The coefficient of
     $A^jX(A^k)^\dagger$ in $\E_{B_u}(X)$ is
     \begin{align}
         \sum_n\overline{u_{jn}}u_{kn}
@@ -63,20 +66,21 @@ physical endpoint correlator of Definition~\ref{def:physical_string_order_param}
     All off-diagonal terms vanish and the diagonal terms sum to $\E_A(X)$.
 \end{proof}
 
-\begin{definition}[Boundary string order parameter]%
+\begin{definition}[Virtual-boundary twist functional]%
     \label{def:string_order_boundary_param}
     \lean{MPSTensor.stringOrderBoundaryParam}
     \leanok
     \uses{def:twisted_transfer_map, def:string_order_param}
     For a boundary state $\Lambda$ and boundary matrices $X,Y \in \MN{D}$, the
-    \emph{boundary string order parameter} is
+    \emph{virtual-boundary twist functional} is
     \begin{align}
         R_L(u;X,Y)
          & := \tr\!(\Lambda X \E_u^L(Y)).
         \label{eq:symmetry_boundary_string}
     \end{align}
-    The ordinary string order parameter is the special case $X=Y=\Id$.
-    The matrices $X,Y$ act on the virtual level. In the string correlator
+    The special case $X=Y=\Id$ is the stationary-boundary block-twist
+    functional of Definition~\ref{def:string_order_param}. The matrices $X,Y$
+    act on the virtual level. In the physical string correlator
     of~\cite{PerezGarcia2008StringOrder} the string of twists is instead
     flanked by local operators $x,y$ acting on physical sites; expanding
     such operators in the transfer picture produces particular virtual
@@ -87,14 +91,14 @@ physical endpoint correlator of Definition~\ref{def:physical_string_order_param}
     % Deviation recorded in docs/paper-gaps/pgwsvc08_string_order_virtual_boundary.tex.
 \end{definition}
 
-\begin{lemma}[String order prevents decay to zero]
+\begin{lemma}[Virtual-boundary nondecay prevents convergence to zero]
     \label{lem:not_tendsto_zero_of_hasStringOrder}
     \lean{MPSTensor.not_tendsto_zero_of_hasStringOrder}
     \leanok
     \uses{def:has_string_order}
-    If $A$ has string order for $u$ with respect to a boundary state
-    $\Lambda$, then for some boundary matrices $X,Y$ the sequence
-    $R_L(u;X,Y)$ does not tend to $0$ as $L \to \infty$.
+    If virtual-boundary nondecay holds for $A,u,\Lambda$, then for some boundary
+    matrices $X,Y$ the sequence $R_L(u;X,Y)$ does not tend to $0$ as
+    $L\to\infty$.
 \end{lemma}
 
 \begin{proof}
@@ -140,30 +144,47 @@ placed in one trace-preserving gauge obtained from their common transfer map.
     \lean{MPSTensor.TwistedTPGaugeSetup}
     \leanok
     \uses{def:twisted_mixed_companion}
-    A \emph{common trace-preserving gauge setup} for $(A,u)$ consists of the
-    companion $B_u$, a positive definite fixed point $\sigma$ of the adjoint
-    transfer map, its positive square root $S=\sigma^{1/2}$, and the gauged
-    tensors
+    A \emph{common trace-preserving gauge setup} for $(A,u)$ consists of a
+    tensor $B$ equal to the companion $B_u$ and satisfying
+    $\E_B(X)=\E_A(X)$ for every $X\in\MN{D}$. It also includes a positive
+    definite matrix $\sigma$ fixed by the adjoint transfer map of $B$, its
+    positive square root $S$, and gauged tensors $A',B'$ satisfying
     \begin{align}
-        A'^i & =SA^iS^{-1}, & B'^i & =SB_u^iS^{-1},
+        B & =B_u,
+          & \E_B(X)                & =\E_A(X),
+          & \E_{B^\dagger}(\sigma) & =\sigma,
+          & \sigma                 & >0,          \\
+        S & =\sigma^{1/2},
+          & S^\dagger              & =S,
+          & A'^i                   & =SA^iS^{-1},
+          & B'^i                   & =SB^iS^{-1}.
         \notag
     \end{align}
-    together with
-    $\sum_i(A'^i)^\dagger A'^i=\sum_i(B'^i)^\dagger B'^i=\Id$ and
-    irreducibility of both gauged tensors, together with the inverse and
-    adjoint identities for $S$ used in these calculations.
+    In addition,
+    \begin{align}
+        SS^{-1}                   & =S^{-1}S=\Id,
+                                  & S^\dagger(S^\dagger)^{-1} & =\Id,
+                                  & (S^{-1})^\dagger          & =S^{-1}, \\
+        \sum_i(A'^i)^\dagger A'^i & =\Id,
+                                  & \sum_i(B'^i)^\dagger B'^i & =\Id,
+        \notag
+    \end{align}
+    together with irreducibility of both $A'$ and $B'$. These identities
+    complete the common trace-preserving gauge data.
 \end{definition}
 
-\begin{theorem}[Construction of the common trace-preserving gauge]
-    \label{thm:twisted_tp_gauge_setup}
+\begin{definition}[Construction of the common trace-preserving gauge]
+    \label{def:twisted_tp_gauge_setup_construction}
     \lean{MPSTensor.twistedTPGaugeSetup}
     \leanok
     \uses{def:twisted_tp_gauge_setup, lem:transfer_map_twisted_companion,
         thm:psd_fp_unique}
-    Let $D>0$.  If $A$ is injective, $uu^\dagger=\Id_d$, and
-    $\E_A(\Id)=\Id$, then $(A,u)$ admits the setup of
+    Let $D>0$. If $A$ is injective, $uu^\dagger=\Id_d$, and
+    $\E_A(\Id)=\Id$, define the common trace-preserving gauge setup for
+    $(A,u)$ by choosing the unique positive definite stationary state of the
+    adjoint channel and using the data in
     Definition~\ref{def:twisted_tp_gauge_setup}.
-\end{theorem}
+\end{definition}
 
 \begin{proof}\leanok
     Injectivity makes $\E_A$ irreducible.  The adjoint channel therefore has a
@@ -180,15 +201,15 @@ placed in one trace-preserving gauge obtained from their common transfer map.
     the asserted properties.
 \end{proof}
 
-\begin{lemma}[Twisted eigenvalues survive the common gauge]
-    \label{lem:twisted_tp_gauge_has_eigenvalue}
+\begin{theorem}[Twisted eigenvalues survive the common gauge]
+    \label{thm:twisted_tp_gauge_has_eigenvalue}
     \lean{MPSTensor.twistedTPGaugeSetup_hasEigenvalue}
     \leanok
     \uses{def:twisted_tp_gauge_setup,
         lem:twisted_transfer_eq_mixed_transfer}
     If $V\ne0$ and $\E_u(V)=\lambda V$, then $\lambda$ is an eigenvalue of the
     mixed transfer map $F_{A',B'}$ in any common trace-preserving gauge setup.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     By Lemma~\ref{lem:twisted_transfer_eq_mixed_transfer}, the original
@@ -204,7 +225,7 @@ placed in one trace-preserving gauge obtained from their common transfer map.
 \section{Boundary and limit support}
 \label{sec:app_symmetry_boundary_limits}
 
-\begin{lemma}[Spectral radius $<1$ forces boundary-string decay]%
+\begin{lemma}[Spectral radius $<1$ forces virtual-boundary decay]%
     \label{lem:boundary_string_order_tendsto_zero}
     \lean{MPSTensor.stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one}
     \leanok
@@ -238,8 +259,8 @@ and the canonical fixed-point hypotheses from the main chapter.
     definite, $\tr(\Lambda_A)=1$, $\tr(\Lambda_B)=1$,
     $\E_A^\dagger(\Lambda_A)=\Lambda_A$, and
     $\E_B^\dagger(\Lambda_B)=\Lambda_B$, then for every $g \in G$,
-    string order exists for $A$ with twist $U(g)$ if and only if it
-    exists for~$B$. In particular, since
+    virtual-boundary nondecay holds for $A$ with twist $U(g)$ if and only if it
+    holds for~$B$. In particular, since
     Definition~\ref{def:is_same_spt_phase} implies on-site symmetry
     for both tensors, this theorem applies to tensors in the same SPT
     phase; it applies equally to symmetric tensors in different SPT
@@ -250,6 +271,6 @@ and the canonical fixed-point hypotheses from the main chapter.
     \uses{thm:has_string_order_of_symmetric_injective}
     Both directions follow from
     Theorem~\ref{thm:has_string_order_of_symmetric_injective}, which
-    shows that string order holds universally for injective symmetric
-    tensors with canonical normalisations.
+    shows that virtual-boundary nondecay holds universally for injective
+    symmetric tensors with canonical normalisations.
 \end{proof}

--- a/blueprint/src/chapter/ch12_symmetry.tex
+++ b/blueprint/src/chapter/ch12_symmetry.tex
@@ -1,11 +1,11 @@
 %% =========================================================
-%% Chapter: Symmetries and String Order
+%% Chapter: Symmetries, Physical String Order, and Virtual-Boundary Nondecay
 %% Develops the symmetry-theoretic consequences of the MPS Fundamental
-%% Theorem: virtual gauges, projective bond representations, and
-%% string-order criteria for injective tensors.
+%% Theorem: virtual gauges, projective bond representations, physical endpoint
+%% string order, and virtual-boundary nondecay for injective tensors.
 %% =========================================================
 
-\chapter{Symmetries and String Order}\label{ch:symmetry}
+\chapter{Symmetries, Physical String Order, and Virtual-Boundary Nondecay}\label{ch:symmetry}
 
 This chapter collects the symmetry-theoretic consequences of the MPS
 Fundamental Theorem~\cite{PerezGarcia2007Matrix}, following the symmetry

--- a/blueprint/src/chapter/ch12_symmetry_spt.tex
+++ b/blueprint/src/chapter/ch12_symmetry_spt.tex
@@ -1,10 +1,11 @@
-\section{SPT Phase Labels and String-Order Universality}
+\section{SPT Phase Labels and Virtual-Boundary Nondecay}
 %% ---------------------------------------------------------
 
 The predicate in Definition~\ref{def:is_same_spt_phase} compares virtual
-cocycle labels.  Physical phase equivalence instead uses symmetric gapped
-Hamiltonian paths, with the endpoint representations embedded into a common
-physical space as in~\cite{Schuch2011Phases}.
+cocycle labels. The source classification below concerns symmetric paths that
+remain within the MPS and corresponding parent-Hamiltonian framework, with the
+endpoint representations embedded into a common physical space as
+in~\cite{Schuch2011Phases}.
 
 \begin{definition}[Equality of virtual cocycle labels]
     \label{def:is_same_spt_phase}
@@ -17,11 +18,11 @@ physical space as in~\cite{Schuch2011Phases}.
     $\omega_A,\omega_B:G\times G\to\C^\times$ and projective bond
     representations $\rho_A,\rho_B$ such that
     \begin{align}
-      \widetilde A_g^i
-        &=\rho_A(g^{-1})A^i\rho_A(g^{-1})^{-1},\\
-      \widetilde B_g^i
-        &=\rho_B(g^{-1})B^i\rho_B(g^{-1})^{-1},
-      \notag
+        \widetilde A_g^i
+         & =\rho_A(g^{-1})A^i\rho_A(g^{-1})^{-1}, \\
+        \widetilde B_g^i
+         & =\rho_B(g^{-1})B^i\rho_B(g^{-1})^{-1},
+        \notag
     \end{align}
     exactly, and $\omega_A\sim\omega_B$.  Thus the predicate is equality of
     virtual factor-system classes.  It neither quantifies over Hamiltonian
@@ -42,64 +43,68 @@ physical space as in~\cite{Schuch2011Phases}.
     distinct hypotheses.
 \end{remark}
 
-\begin{theorem}[One-dimensional symmetric gapped-phase classification]
+\begin{theorem}[Classification along symmetric MPS parent-Hamiltonian paths]
     \label{thm:spt_classification}
     \notready
     \uses{def:is_same_spt_phase, def:h2_cx}
-    For $p=0,1$, let $H_p$ be a translationally invariant, finite-range,
-    bounded-strength Hamiltonian that is uniformly gapped above a unique
-    injective-MPS ground state on $\mc H_p^{\otimes N}$.  Suppose that $H_p$
-    commutes with $(U_g^p)^{\otimes N}$, where $U^p$ is a unitary
-    representation of $G$ on $\mc H_p$, and choose the endpoint phase gauges.
-    After a common finite blocking, there exist a path-sector Hilbert space
-    $\mc H_{\mathrm{path}}$ and a linear representation
+    For $p=0,1$, let $A_p$ be an injective MPS tensor whose parent Hamiltonian
+    $H_p$ has a unique ground state and is symmetric under a unitary
+    representation $U^p$ of $G$ on $\mc H_p$. Choose the endpoint phase
+    gauges. After a common finite blocking, the embedded endpoints admit a
+    continuous symmetric MPS path with corresponding translationally invariant,
+    finite-range parent Hamiltonians that vary smoothly and remain uniformly
+    gapped if and only if their virtual projective representations determine
+    the same class in $H^2(G,\mathrm U(1))$.
+
+    More precisely, for the forward construction there exist a path-sector
+    Hilbert space $\mc H_{\mathrm{path}}$ and a linear representation
     $U^{\mathrm{path}}$ such that the endpoints embed into
     \begin{align}
-       \mc H&=\mc H_0\oplus\mc H_1\oplus\mc H_{\mathrm{path}},&
-       U_g&=U_g^0\oplus U_g^1\oplus U_g^{\mathrm{path}},
-       \notag
+        \mc H & =\mc H_0\oplus\mc H_1\oplus\mc H_{\mathrm{path}}, &
+        U_g   & =U_g^0\oplus U_g^1\oplus U_g^{\mathrm{path}}.
+        \notag
     \end{align}
-    and are connected by a continuous path of translationally invariant,
-    finite-range, bounded-strength Hamiltonians commuting with
-    $U_g^{\otimes N}$ and having a gap bounded uniformly below in the system
-    size and path parameter, if and only if the virtual projective
-    representations of the blocked injective MPS ground states determine the
-    same class in
-    $H^2(G,\mathrm U(1))$~\cite[Section~II.F]{Schuch2011Phases}.
+    The converse quantifies over smooth paths whose unique ground states remain
+    MPS and whose Hamiltonians are the corresponding parent Hamiltonians, as in
+    \cite[Section~II.F, lines~929--953]{Schuch2011Phases}. It does not assert
+    invariance along an arbitrary gapped Hamiltonian path.
 \end{theorem}
 
 \begin{proof}
     First deform each blocked injective MPS to its isometric form; the
     deformation preserves the symmetry relation
     \begin{align}
-       U_g\mc P&=\mc P(V_g\otimes\overline{V_g}).
-       \notag
+        U_g\mc P & =\mc P(V_g\otimes\overline{V_g}).
+        \notag
     \end{align}
-    Along any continuous symmetric MPS path, the tensor and its induced
-    virtual action $V_g$ vary continuously.  The cohomology class is discrete,
-    so it cannot change along the path.  This proves necessity.
+    Along any continuous symmetric MPS path quantified in the theorem, the
+    tensor and its induced virtual action $V_g$ vary continuously. The
+    cohomology class is discrete, so it cannot change along that path. This
+    proves necessity within the MPS/parent-Hamiltonian framework.
 
     Conversely, let the endpoint isometric forms have virtual actions
     $V_g^0$ and $V_g^1$ in the same cohomology class.  Embed their bond spaces
     into the direct sum and interpolate between the maximally entangled bonds
     by
+    % Local fix: the second range ends at D_0+D_1, not D_1; see
+    % docs/paper-gaps/schuch2011_spt_interpolation_upper_range.tex.
     \begin{align}
-       |\omega(\gamma)\rangle
-       &=(1-\gamma)\sum_{i=1}^{D_0}|i,i\rangle
-         +\gamma\sum_{i=D_0+1}^{D_0+D_1}|i,i\rangle.
-       \notag
+        |\omega(\gamma)\rangle
+         & =(1-\gamma)\sum_{i=1}^{D_0}|i,i\rangle
+        +\gamma\sum_{i=D_0+1}^{D_0+D_1}|i,i\rangle.
+        \notag
     \end{align}
     The commuting parent Hamiltonians along this interpolation remain gapped.
     Their symmetry is
     \begin{align}
-      (V_g^0\oplus V_g^1)\otimes
-      (\overline{V_g^0}\oplus\overline{V_g^1})
-      &=\widehat U_g^0\oplus\widehat U_g^1
-        \oplus\widehat U_g^{\mathrm{path}},\\
-      \widehat U_g^{\mathrm{path}}
-      &=(V_g^0\otimes\overline{V_g^1})
+        (V_g^0\oplus V_g^1)\otimes
+        (\overline{V_g^0}\oplus\overline{V_g^1})
+         & =\widehat U_g^0\oplus\widehat U_g^1
+        \oplus\widehat U_g^{\mathrm{path}},    \\
+        \widehat U_g^{\mathrm{path}}
+         & =(V_g^0\otimes\overline{V_g^1})
         \oplus(V_g^1\otimes\overline{V_g^0}).
-      \notag
+        \notag
     \end{align}
     Equality of the cohomology classes is exactly what makes the cross-term
     action $\widehat U^{\mathrm{path}}$ a linear representation.  Conjugating
@@ -130,7 +135,7 @@ physical space as in~\cite{Schuch2011Phases}.
     The virtual representation theorem produces
     $\rho(g^{-1}) \in \GL_{D}(\C)$ satisfying
     $\sum_j U(g)_{ij}\,A^j
-    = \rho(g^{-1})\,A^i\,\rho(g^{-1})^{-1}$.
+        = \rho(g^{-1})\,A^i\,\rho(g^{-1})^{-1}$.
     A direct computation using $\E_A(\Id)=\Id$ shows that
     $\E_{U(g)}(\rho(g^{-1}))=\rho(g^{-1})$, so
     $\rho(g^{-1})$ is a nonzero eigenvector with eigenvalue~$1$.

--- a/blueprint/src/chapter/ch12_symmetry_string_order.tex
+++ b/blueprint/src/chapter/ch12_symmetry_string_order.tex
@@ -14,7 +14,7 @@ physical state symmetry requires additional hypotheses.
     \emph{twisted transfer map} is
     \begin{align}
         \E_u(X)
-        &:= \sum_{n,n'} \bra{n'} u \ket{n}
+         & := \sum_{n,n'} \bra{n'} u \ket{n}
         A_n\, X\, A_{n'}^\dagger.
         \label{eq:symmetry_twisted_transfer}
     \end{align}
@@ -36,11 +36,11 @@ physical state symmetry requires additional hypotheses.
     % free because the map has not consumed X.
     % boundary|virtual-west=2|virtual-east=2|physical-up=0|physical-down=0.
     \begin{align}
-        &\begin{tenkz}[rows={ket,op:none,bra}]
-            \tn{A_n} \\
-            \tn[role=operator]{u} \\
-            \tn*{A_{n'}}
-        \end{tenkz}.
+         & \begin{tenkz}[rows={ket,op:none,bra}]
+               \tn{A_n} \\
+               \tn[role=operator]{u} \\
+               \tn*{A_{n'}}
+           \end{tenkz}.
         \notag
     \end{align}
     The upper and lower black nodes denote $A_n$ and $A_{n'}^\dagger$, and the
@@ -53,7 +53,7 @@ physical state symmetry requires additional hypotheses.
     \uses{def:twisted_transfer_map}
     The \emph{stationary-boundary block-twist functional} is
     \begin{align}
-        T_L(A,u,\Lambda) &:= \tr\!(\Lambda \cdot \E_u^L(\Id)).
+        T_L(A,u,\Lambda) & := \tr\!(\Lambda \cdot \E_u^L(\Id)).
         \label{eq:symmetry_string_parameter}
     \end{align}
     In tensor-network notation this is the length-$L$ doubled chain with a
@@ -70,14 +70,14 @@ physical state symmetry requires additional hypotheses.
     % Boundary signature: virtual-west=0 | virtual-east=0 |
     % physical-up=0 | physical-down=0.
     \begin{align}
-        &\begin{tenkz}[rows={ket,op:none,bra},
-                      west={cup=$\Lambda$}, east=cup]
-            \tn{A} & \tn{A} & \tndots & \tn{A} \\
-            \tn[role=operator]{u} & \tn[role=operator]{u} & \tndots &
-                \tn[role=operator]{u} \\
-            \tn*{A}\tnspan[brace below]{4}{$L\text{ sites}$} &
-                \tn*{A} & \tndots & \tn*{A}
-        \end{tenkz}.
+         & \begin{tenkz}[rows={ket,op:none,bra},
+                   west={cup=$\Lambda$}, east=cup]
+               \tn{A} & \tn{A} & \tndots & \tn{A} \\
+               \tn[role=operator]{u} & \tn[role=operator]{u} & \tndots &
+               \tn[role=operator]{u} \\
+               \tn*{A}\tnspan[brace below]{4}{$L\text{ sites}$} &
+               \tn*{A} & \tndots & \tn*{A}
+           \end{tenkz}.
         \notag
     \end{align}
     The boundary matrix $\Lambda$ is contracted into the virtual boundary, the
@@ -92,8 +92,8 @@ physical state symmetry requires additional hypotheses.
     For the periodic length-$L$ matrix product vector $|\Psi_L(A)\rangle$, the
     source quantity is literally
     \begin{align}
-       R_L(u)&:=\langle\Psi_L(A)|u^{\otimes L}|\Psi_L(A)\rangle.
-       \label{eq:symmetry_source_periodic_RL}
+        R_L(u) & :=\langle\Psi_L(A)|u^{\otimes L}|\Psi_L(A)\rangle.
+        \label{eq:symmetry_source_periodic_RL}
     \end{align}
     Identifying this periodic overlap with the normalized stationary-boundary
     functional $T_L(A,u,\Lambda)$ requires a thermodynamic-boundary and
@@ -111,7 +111,7 @@ physical state symmetry requires additional hypotheses.
     \cite[display~SOPMP, lines~176--181]{PerezGarcia2008StringOrder} is
     \begin{align}
         S_N(x,y,u)
-        &:= \tr\!(\Lambda\,\E_x\,\E_u^N(\E_y(\Id))).
+         & := \tr\!(\Lambda\,\E_x\,\E_u^N(\E_y(\Id))).
         \label{eq:symmetry_physical_string}
     \end{align}
     This is the physical-endpoint expression corresponding to
@@ -149,17 +149,17 @@ physical state symmetry requires additional hypotheses.
     $\E_A(\Id)=\Id$, $\E_A^*(\Lambda)=\Lambda$, with $\Lambda>0$ and
     $\tr(\Lambda)=1$.  For every physical unitary $u$,
     \begin{align}
-       \rho(\E_u)&\le1.
-       \notag
+        \rho(\E_u) & \le1.
+        \notag
     \end{align}
     Equality holds if and only if there are a unitary $V$ and
-    $\theta\in[0,2\pi)$ satisfying, in an eigenbasis
-    $u=\sum_j e^{i\theta_j}|\widetilde j\rangle\langle\widetilde j|$,
+    $\theta\in[0,2\pi)$ satisfying the following identity for every $j$ in an
+    eigenbasis
+    $u=\sum_j e^{i\theta_j}|\widetilde j\rangle\langle\widetilde j|$:
     \begin{align}
-       V^\dagger\widetilde A_j
-       &=e^{i(\theta-\theta_j)}\widetilde A_jV^\dagger
-       \qquad\text{for every $j$}.
-       \label{eq:pgwsvc08_lemma1_condition}
+        V^\dagger\widetilde A_j
+         & =e^{i(\theta-\theta_j)}\widetilde A_jV^\dagger.
+        \label{eq:pgwsvc08_lemma1_condition}
     \end{align}
     Moreover, $\E_u$ has at most one eigenvalue of modulus one.
 \end{lemma}
@@ -168,14 +168,14 @@ physical state symmetry requires additional hypotheses.
     Let $\E_u(V)=\lambda V$.  Multiplication by $\Lambda V^\dagger$, the
     trace, and Cauchy--Schwarz give
     \begin{align}
-      |\lambda|\tr(V\Lambda V^\dagger)
-      &\le
-      \left(\sum_j\tr(V\widetilde A_j^\dagger\Lambda
-          \widetilde A_jV^\dagger)\right)^{1/2}
-      \left(\sum_j\tr(\widetilde A_j^\dagger V\Lambda V^\dagger
-          \widetilde A_j)\right)^{1/2}\\
-      &=\tr(V\Lambda V^\dagger).
-      \notag
+        |\lambda|\tr(V\Lambda V^\dagger)
+         & \le
+        \left(\sum_j\tr(V\widetilde A_j^\dagger\Lambda
+        \widetilde A_jV^\dagger)\right)^{1/2}
+        \left(\sum_j\tr(\widetilde A_j^\dagger V\Lambda V^\dagger
+        \widetilde A_j)\right)^{1/2} \\
+         & =\tr(V\Lambda V^\dagger).
+        \notag
     \end{align}
     Faithfulness of $\Lambda$ yields $|\lambda|\le1$.  Equality in
     Cauchy--Schwarz is equivalent to
@@ -190,9 +190,9 @@ physical state symmetry requires additional hypotheses.
     $e^{i\theta},e^{i\theta'}$, respectively, the equality relations give the
     exact identity
     \begin{align}
-       \E_A(V^\dagger V')
-       &=e^{i(\theta'-\theta)}V^\dagger V'.
-       \notag
+        \E_A(V^\dagger V')
+         & =e^{i(\theta'-\theta)}V^\dagger V'.
+        \notag
     \end{align}
     Purity leaves only the peripheral eigenvalue $1$, hence
     $\theta'=\theta$ modulo $2\pi$.  The one-dimensional fixed space then
@@ -210,9 +210,9 @@ physical state symmetry requires additional hypotheses.
     there exist a unitary $\widetilde u\ne\Id$, a unitary virtual matrix $V$,
     and physical indices $n,m$ such that
     \begin{align}
-       \E_{\widetilde u}(V)&=V,
-       &\tr(V\Lambda A_nA_m^\dagger)&\ne0.
-       \label{eq:pgwsvc08_theorem1}
+        \E_{\widetilde u}(V) & =V,
+                             & \tr(V\Lambda A_nA_m^\dagger) & \ne0.
+        \label{eq:pgwsvc08_theorem1}
     \end{align}
     The transfer criteria below assume one-site injectivity.  The literal
     physical equivalence additionally requires that sufficiently long physical
@@ -225,22 +225,24 @@ physical state symmetry requires additional hypotheses.
     $Y$ are the corresponding right and left eigenmatrices, then
     $Y=\Lambda V^\dagger$, and the leading term retains its length-dependent
     phase:
+    % Local fix: restore the omitted peripheral factor e^{iN\theta}; see
+    % docs/paper-gaps/pgwsvc08_string_order_virtual_boundary.tex.
     \begin{align}
-       S_N(x,y,u)
-       &=e^{iN\theta}
-       \tr\!\bigl(Y\E_y(\Id)\bigr)
-       \tr\!\bigl(\Lambda\E_x(V)\bigr)+o(1).
-       \notag
+        S_N(x,y,u)
+         & =e^{iN\theta}
+        \tr\!\bigl(Y\E_y(\Id)\bigr)
+        \tr\!\bigl(\Lambda\E_x(V)\bigr)+o(1).
+        \notag
     \end{align}
     In the eigenbasis $u=\sum_j e^{i\theta_j}|\widetilde
-    j\rangle\langle\widetilde j|$, shift the string unitary by the
+        j\rangle\langle\widetilde j|$, shift the string unitary by the
     peripheral phase,
     \begin{align}
-       \widetilde u
-       &:=e^{-i\theta}u
+        \widetilde u
+         & :=e^{-i\theta}u
         =\sum_j e^{i(\theta_j-\theta)}
-          |\widetilde j\rangle\langle\widetilde j|.
-       \notag
+        |\widetilde j\rangle\langle\widetilde j|.
+        \notag
     \end{align}
     Then $\E_{\widetilde u}(V)=V$.  Choosing
     $y=x^\dagger\widetilde u$ reduces nonvanishing to the second condition
@@ -258,7 +260,7 @@ physical state symmetry requires additional hypotheses.
     state is invariant under $u^{\otimes N}$ on every $N$-site reduced density
     operator if and only if
     \begin{align}
-        \rho(\E_u)&=1.
+        \rho(\E_u) & =1.
         \notag
     \end{align}
     The theorem below gives the corresponding virtual local-covariance
@@ -278,9 +280,9 @@ physical state symmetry requires additional hypotheses.
     Conversely, physical invariance gives, for length-independent boundary
     tensors $L,R$,
     \begin{align}
-      D^{-2}&\le\tr(\varrho_N^2)
-       =\tr\!\left[L(\E_u\otimes\E_{u^\dagger})^N(R)\right].
-       \notag
+        D^{-2} & \le\tr(\varrho_N^2)
+        =\tr\!\left[L(\E_u\otimes\E_{u^\dagger})^N(R)\right].
+        \notag
     \end{align}
     Exponential decay would contradict this bound, so $\rho(\E_u)=1$.
 \end{proof}
@@ -295,7 +297,7 @@ physical state symmetry requires additional hypotheses.
     $V^\dagger \Lambda V = \Lambda$ and, for every physical index~$i$,
     \begin{align}
         \sum_j u_{ij}\, A^j
-        &= \mu\, V\, A^i\, V^\dagger.
+         & = \mu\, V\, A^i\, V^\dagger.
         \label{eq:symmetry_local_covariance}
     \end{align}
     The unitary $V$ intertwines the physical action of~$u$ with a virtual
@@ -306,20 +308,25 @@ physical state symmetry requires additional hypotheses.
     \lean{MPSTensor.HasStringOrder}
     \leanok
     \uses{def:string_order_boundary_param}
+    For boundary matrices $X,Y\in\MN{D}$, set explicitly
+    \begin{align}
+        R_L(u;X,Y)
+         & :=\tr\!\bigl(\Lambda X\E_u^L(Y)\bigr).
+        \notag
+    \end{align}
     The virtual-boundary nondecay predicate holds for $u$ and
-    $\Lambda$ if there exist boundary matrices $X,Y$ and a
-    positive constant $c > 0$ such that
-    $c \le \|R_L(u;X,Y)\|$ for all $L$, where
-    $R_L(u;X,Y)$ is the boundary-refined string-order parameter.
-    Thus some boundary-refined string-order sequence does not decay to zero.
+    $\Lambda$ if there exist $X,Y$ and a positive constant $c>0$ such that
+    $c\le\|R_L(u;X,Y)\|$ for every $L$. Thus some virtual-boundary sequence
+    does not decay to zero.
 
-    String order is here an existence statement over the virtual matrices
-    $X,Y$, for a fixed twist $u$; no claim is made for any particular
+    Virtual-boundary nondecay is an existence statement over the virtual
+    matrices $X,Y$, for a fixed twist $u$; no claim is made for any particular
     boundary choice. Definition~\ref{def:has_physical_string_order} records
-    the physical-endpoint source definition, which quantifies existentially
-    over $u,x,y$ and requires a positive limit rather than a lower bound
-    uniform in the length; that paper also notes that the correlator for a
-    particular endpoint choice can vanish even when the symmetry is present.
+    the physical-endpoint string-order notion from the source, which quantifies
+    existentially over $u,x,y$ and requires a positive limit rather than a lower
+    bound uniform in the length. That paper also notes that the correlator for
+    a particular endpoint choice can vanish even when the physical symmetry is
+    present.
     % Deviation recorded in docs/paper-gaps/pgwsvc08_string_order_virtual_boundary.tex.
 \end{definition}
 
@@ -371,7 +378,7 @@ physical state symmetry requires additional hypotheses.
     virtual conjugation:
     \begin{align}
         \E(V X V^\dagger)
-        &= V\, \E(X)\, V^\dagger.
+         & = V\, \E(X)\, V^\dagger.
         \label{eq:symmetry_transfer_covariance}
     \end{align}
     In doubled-layer notation, the virtual operators slide through the local
@@ -415,7 +422,7 @@ physical state symmetry requires additional hypotheses.
     $E = \sum_i A_i \otimes \bar A_i$ with $V \otimes \bar V$ is
     \begin{align}
         V\, \E_1(X)\, V^\dagger
-        &= \E_1(V X V^\dagger).
+         & = \E_1(V X V^\dagger).
         \label{eq:symmetry_doubled_commutation}
     \end{align}
 \end{definition}
@@ -602,7 +609,7 @@ physical state symmetry requires additional hypotheses.
     satisfy $u u^\dagger = \Id$.
     If
     \begin{align}
-        \E_u(X) &= \lambda X
+        \E_u(X) & = \lambda X
         \label{eq:symmetry_twisted_eigen_mod_one}
     \end{align}
     for some nonzero $X \in \MN{D}$ with $|\lambda|=1$, then $A$ is
@@ -635,8 +642,9 @@ physical state symmetry requires additional hypotheses.
         def:gauge_phase_equiv, def:injective}
     Let $A$ be injective, let $\Lambda \in \MN{D}$, and assume
     $u u^\dagger = \Id$ and $\E_A(\Id)=\Id$.
-    If string order exists for $u$ with boundary parameter $\Lambda$, then $A$
-    is gauge-phase equivalent to the companion tensor $B_u$.
+    If virtual-boundary nondecay holds for $u$ with boundary parameter
+    $\Lambda$, then $A$ is gauge-phase equivalent to the companion tensor
+    $B_u$.
 \end{theorem}
 
 \begin{proof}
@@ -645,7 +653,7 @@ physical state symmetry requires additional hypotheses.
         thm:twisted_transfer_spectral_radius_le_one,
         thm:twisted_transfer_modulus_one_gauge_phase}
     If $\rho(\E_u) < 1$, Lemma~\ref{lem:boundary_string_order_tendsto_zero}
-    forces every boundary string-order sequence to decay to zero, contradicting
+    forces every virtual-boundary sequence to decay to zero, contradicting
     Definition~\ref{def:has_string_order}.
     Hence $\rho(\E_u) \ge 1$.
     Theorem~\ref{thm:twisted_transfer_spectral_radius_le_one} shows that every
@@ -666,7 +674,7 @@ physical state symmetry requires additional hypotheses.
     physical index~$i$,
     \begin{align}
         \sum_j u_{ij} A^j
-        &= \mu\, V A^i V^\dagger.
+         & = \mu\, V A^i V^\dagger.
         \label{eq:symmetry_phased_covariance}
     \end{align}
 \end{theorem}
@@ -695,7 +703,7 @@ physical state symmetry requires additional hypotheses.
     $\sum_j u_{ij} A^j = \mu\, V A^i V^\dagger$ with $V$ unitary.
     Then $V$ is an eigenmatrix of the twisted transfer map:
     \begin{align}
-        \E_u(V) &= \mu V.
+        \E_u(V) & = \mu V.
         \label{eq:symmetry_virtual_eigenmatrix}
     \end{align}
 \end{theorem}
@@ -719,12 +727,12 @@ physical state symmetry requires additional hypotheses.
     index~$i$,
     \begin{align}
         \sum_j u_{ij} A^j
-        &= \mu\, V A^i V^\dagger,
+         & = \mu\, V A^i V^\dagger,
         \label{eq:symmetry_boundary_covariance}
     \end{align}
     then
     \begin{align}
-        V^\dagger \Lambda V &= \Lambda.
+        V^\dagger \Lambda V & = \Lambda.
         \label{eq:symmetry_boundary_invariance}
     \end{align}
 \end{theorem}
@@ -747,8 +755,8 @@ physical state symmetry requires additional hypotheses.
     \leanok
     \uses{def:local_symmetry, def:has_string_order}
     Assume $\tr(\Lambda)=1$ and $\E_A(\Id)=\Id$.
-    If $u$ is a local symmetry of $A$ with respect to $\Lambda$, then string
-    order exists for $u$.
+    If $A,u,\Lambda$ satisfy virtual local covariance, then virtual-boundary
+    nondecay holds for $u$.
 \end{lemma}
 
 \begin{proof}
@@ -756,14 +764,14 @@ physical state symmetry requires additional hypotheses.
     \uses{thm:twisted_transfer_eigen_of_virtual_unitary,
         def:string_order_boundary_param}
     Choose the boundary matrices $X = V^\dagger$ and $Y = V$, where $V$ is the
-    unitary from the local-symmetry datum.
+    unitary from the virtual local-covariance datum.
     By Theorem~\ref{thm:twisted_transfer_eigen_of_virtual_unitary},
     one has $\E_u^L(V)=\mu^L V$.
     Therefore
     \begin{align}
         R_L(u;V^\dagger,V)
-        &= \mu^L \tr(\Lambda)
-         = \mu^L,
+         & = \mu^L \tr(\Lambda)
+        = \mu^L,
         \notag
     \end{align}
     whose norm is constantly $1$.
@@ -778,7 +786,7 @@ physical state symmetry requires additional hypotheses.
     Let $A$ be injective, and assume $u u^\dagger = \Id$, $\E_A(\Id)=\Id$,
     $\Lambda$ is positive definite, $\tr(\Lambda)=1$, and
     $\E_A^\dagger(\Lambda)=\Lambda$.
-    Then $u$ is a local symmetry if and only if there exist a unitary
+    Then virtual local covariance holds if and only if there exist a unitary
     $V \in \MN{D}$ and a phase $\mu$ with $|\mu|=1$ such that
     $\E_u(V) = \mu V$.
     By Theorem~\ref{thm:twisted_transfer_spectral_radius_le_one}, this witness
@@ -799,7 +807,7 @@ physical state symmetry requires additional hypotheses.
     Theorem~\ref{thm:virtual_unitary_of_twisted_gauge_phase} yields a virtual
     unitary and phase satisfying the local covariance relation, and
     Theorem~\ref{thm:boundary_state_invariant_of_virtual_unitary} gives the
-    boundary-state invariance needed for local symmetry.
+    boundary-state invariance needed for virtual local covariance.
 \end{proof}
 
 \begin{theorem}[Virtual-boundary nondecay $\Leftrightarrow$ virtual local covariance]%
@@ -809,8 +817,9 @@ physical state symmetry requires additional hypotheses.
     \uses{def:has_string_order, def:local_symmetry, def:injective}
     For an injective MPS, assume $u u^\dagger = \Id$,
     $\E_A(\Id)=\Id$, $\Lambda$ is positive definite,
-    $\tr(\Lambda)=1$, and $\E_A^\dagger(\Lambda)=\Lambda$. Then string
-    order for $u$ exists iff $u$ is a local symmetry.
+    $\tr(\Lambda)=1$, and $\E_A^\dagger(\Lambda)=\Lambda$. Then
+    virtual-boundary nondecay for $u$ holds if and only if $A,u,\Lambda$
+    satisfy virtual local covariance.
 \end{theorem}
 
 \begin{proof}
@@ -819,14 +828,15 @@ physical state symmetry requires additional hypotheses.
         thm:virtual_unitary_of_twisted_gauge_phase,
         thm:boundary_state_invariant_of_virtual_unitary,
         lem:has_string_order_of_local_symmetry}
-    If string order exists, Theorem~\ref{thm:string_order_implies_twisted_gauge_phase}
-    gives a gauge-phase equivalence with the companion tensor.
+    If virtual-boundary nondecay holds,
+    Theorem~\ref{thm:string_order_implies_twisted_gauge_phase} gives a
+    gauge-phase equivalence with the companion tensor.
     Theorem~\ref{thm:virtual_unitary_of_twisted_gauge_phase} extracts a virtual
     unitary and phase from that equivalence, and
     Theorem~\ref{thm:boundary_state_invariant_of_virtual_unitary} shows that the
-    same unitary preserves the boundary state, so one obtains local symmetry.
-    Conversely, Lemma~\ref{lem:has_string_order_of_local_symmetry} turns local
-    symmetry into a non-decaying boundary string-order sequence.
+    same unitary preserves the boundary state, so one obtains virtual local
+    covariance. Conversely, Lemma~\ref{lem:has_string_order_of_local_symmetry}
+    turns virtual local covariance into a nondecaying virtual-boundary sequence.
 \end{proof}
 
 \begin{theorem}[Virtual unitary from virtual-boundary nondecay]%
@@ -836,8 +846,9 @@ physical state symmetry requires additional hypotheses.
     \uses{def:has_string_order, def:injective}
     For an injective MPS, let $\Lambda \in \MN{D}$, and assume
     $u u^\dagger = \Id$ and $\E_A(\Id)=\Id$.
-    If string order exists for $u$ with boundary parameter $\Lambda$, then
-    there exists a virtual unitary $V$ and a unit-modulus scalar $\mu$ such that
+    If virtual-boundary nondecay holds for $u$ with boundary parameter
+    $\Lambda$, then there exists a virtual unitary $V$ and a unit-modulus
+    scalar $\mu$ such that
     $\sum_j u_{ij} A^j = \mu\, V A^i V^\dagger$ for all~$i$.
     Diagrammatically this is the same local intertwining relation,
     but only up to an overall unit scalar on the virtual side:
@@ -867,7 +878,8 @@ physical state symmetry requires additional hypotheses.
     \leanok
     \uses{thm:string_order_implies_twisted_gauge_phase,
         thm:virtual_unitary_of_twisted_gauge_phase}
-    String order first gives gauge-phase equivalence with the companion tensor by
+    Virtual-boundary nondecay first gives gauge-phase equivalence with the
+    companion tensor by
     Theorem~\ref{thm:string_order_implies_twisted_gauge_phase}.
     Theorem~\ref{thm:virtual_unitary_of_twisted_gauge_phase} then normalizes the
     resulting intertwiner to a unitary and produces the phase $\mu$.

--- a/blueprint/src/chapter/ch12_symmetry_virtual_and_cohomology.tex
+++ b/blueprint/src/chapter/ch12_symmetry_virtual_and_cohomology.tex
@@ -140,13 +140,14 @@ on the bond space.
     \label{rem:injective_symmetry_ft_route}
     \uses{thm:ft_single, lem:gauge_equiv_twisted, lem:gauge_unique_up_to_scalar,
         lem:twisted_tensor_mul, thm:virtual_rep_injective}
-    The injective virtual-representation theorem is not proved from string-order
-    rigidity. The on-site symmetry condition first identifies $A$ and
-    $\widetilde{A}_g$ as the same MPV family; the single-block Fundamental
-    Theorem gives the gauge in Lemma~\ref{lem:gauge_equiv_twisted}. Gauge
-    uniqueness and the twist composition law then give
-    Theorem~\ref{thm:virtual_rep_injective}. The string-order results later in
-    this chapter use this virtual representation as an input.
+    The injective virtual-representation theorem is not proved from
+    virtual-boundary nondecay. The on-site symmetry condition first identifies
+    $A$ and $\widetilde{A}_g$ as the same MPV family; the single-block
+    Fundamental Theorem gives the gauge in
+    Lemma~\ref{lem:gauge_equiv_twisted}. Gauge uniqueness and the twist
+    composition law then give Theorem~\ref{thm:virtual_rep_injective}. The
+    virtual-boundary nondecay results later in this chapter use this virtual
+    representation as an input.
 \end{remark}
 
 \begin{theorem}[Virtual symmetry equation]\label{thm:virtual_symmetry_eq}
@@ -429,7 +430,7 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
     representations $\rho_1,\rho_2$ (with cocycles
     $\omega_1,\omega_2$) both arise as virtual representations of the
     same injective MPS tensor $A$ under an on-site symmetry~$U$, then
-    $\omega_1 \sim \omega_2$.
+    $\omega_2\sim\omega_1$, and hence also $\omega_1\sim\omega_2$ by symmetry.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -470,18 +471,27 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
             \tnX{X_2(g^{-1})^{-1}}
         \end{tenkz}
     \end{tenkzequation}
-    describe the same twisted tensor, so they differ by a scalar.
-    Substituting into the projective law
-    (\ref{eq:symmetry_projective_law}) and cancelling $X_1(g\cdot h)$
-    yields
+    describe the same twisted tensor, so they differ by a scalar. Set
+    $\alpha(g):=f(g^{-1})$. Substituting
+    $\rho_2(g)=\alpha(g)\rho_1(g)$ into the projective law
+    (\ref{eq:symmetry_projective_law}) and cancelling the invertible matrix
+    $X_1((gh)^{-1})=\rho_1(gh)$ yields
     \begin{align}
         \omega_2(g,h)
-         & =f(g^{-1})\,f(h^{-1})\,f((gh)^{-1})^{-1}
-        \omega_1(g,h).
+         & =\alpha(g)\alpha(h)\alpha(gh)^{-1}\omega_1(g,h).
         \label{eq:symmetry_gauge_coboundary}
     \end{align}
-    Thus, (\ref{eq:symmetry_gauge_coboundary}) has precisely the form
-    required by (\ref{eq:symmetry_cohomologous}).
+    Thus $\omega_2$ is the coboundary multiple of $\omega_1$ with cochain
+    $\alpha$. This is precisely the orientation required by
+    (\ref{eq:symmetry_cohomologous}) for the stated relation
+    $\omega_2\sim\omega_1$. Equivalently,
+    \begin{align}
+        \omega_1(g,h)
+         & =\alpha(g)^{-1}\alpha(h)^{-1}\alpha(gh)\omega_2(g,h),
+        \notag
+    \end{align}
+    so the inverse cochain also gives the symmetric conclusion
+    $\omega_1\sim\omega_2$.
 \end{proof}
 
 \begin{definition}[Multiplicative 2-cocycle condition]\label{def:is_cocycle}
@@ -558,8 +568,8 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
 \subsection{Non-triviality via the commutator phase}
 
 For an abelian symmetry group, the antisymmetric commutator phase is invariant
-under a change of cocycle representative.  A nonunit value therefore witnesses
-non-triviality; no converse is asserted here.
+under a change of cocycle representative. A value not equal to $1$ therefore
+witnesses non-triviality; no converse is asserted here.
 
 \begin{definition}[Commutator phase]\label{def:comm_phase}
     \lean{TNLean.Algebra.ScalarCocycle.commPhase}

--- a/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_irreducible_rotation.tex
@@ -18,7 +18,7 @@
     A tensor $A$ is in \emph{irreducible form} if it is block-diagonal,
     \begin{align}
         A^i
-        &=\bigoplus_{j\in J}\mu_j A_j^i,
+         & =\bigoplus_{j\in J}\mu_j A_j^i,
         \notag
     \end{align}
     where each block $A_j$ is an $m_j$-periodic tensor. Following
@@ -35,9 +35,9 @@
 
 \begin{remark}[Normal canonical form gives irreducible form]
     \label{rem:irr_form_vs_ncf}
-\lean{MPSTensor.toIsIrreducibleFormOfPhaseNormalized,
-    MPSTensor.toIsIrreducibleFormOfPhaseNormalized_period_eq_one}
-\leanok
+    \lean{MPSTensor.toIsIrreducibleFormOfPhaseNormalized,
+        MPSTensor.toIsIrreducibleFormOfPhaseNormalized_period_eq_one}
+    \leanok
     Let $A^i=\bigoplus_j\mu_j A_j^i$ be a normal canonical block family with
     nonzero complex weights. Replacing $\mu_j$ by $|\mu_j|$ and $A_j$ by
     $(\mu_j/|\mu_j|)A_j$ gives the positive-weight irreducible form convention
@@ -49,7 +49,7 @@
 
 \begin{remark}[Irreducible form allows higher periods]
     \label{rem:irreducible_form_higher_periods}
-\notready
+    \notready
     The converse containment is not part of the implication above.
     Irreducible form permits periodic blocks with period larger than~$1$; for
     instance, the antiferromagnetic example has period~$2$.
@@ -149,7 +149,7 @@ of~\cite{DeLasCuevas2017Irreducible}.
     The rotated block-diagonal tensor satisfies
     \begin{align}
         \left(\bigoplus_k\mu_k A_k\right)_u
-        &=\bigoplus_k\mu_k(A_k)_u.
+         & =\bigoplus_k\mu_k(A_k)_u.
         \notag
     \end{align}
 \end{theorem}
@@ -192,12 +192,11 @@ of~\cite{DeLasCuevas2017Irreducible}.
     Assume the periodic equal-case theorem: tensors in irreducible form~II
     with equal MPV families are $Z$-gauge equivalent.  Let $A$ be in
     irreducible form~II, and suppose $B:=A_M$ is also in irreducible form~II
-    with $\mc V(A)=\mc V(B)$.  Then there are $m>0$, an invertible matrix $Y$,
-    and a matrix $Z\in\MN D$ such that
+    with $\mc V(A)=\mc V(B)$. Then there are $m>0$, an invertible matrix $Y$,
+    and a matrix $Z\in\MN D$ such that, for every physical index $i$,
     \begin{align}
-       [Z,A^i]&=0,& Z^m&=\Id_D,& ZA^i&=YB^iY^{-1}
-       \qquad\text{for every $i$}.
-       \notag
+        [Z,A^i] & =0, & Z^m & =\Id_D, & ZA^i & =YB^iY^{-1}.
+        \notag
     \end{align}
     Thus $A$ and $B$ are related by a genuine $\mathbb Z_m$ virtual gauge,
     not merely by a scalar root of unity.

--- a/docs/paper-gaps/pgwsvc08_string_order_virtual_boundary.tex
+++ b/docs/paper-gaps/pgwsvc08_string_order_virtual_boundary.tex
@@ -6,8 +6,7 @@
 
 \input{command}
 
-\title{PGWSVC08 String Order: Physical Endpoints versus Virtual Boundary
-  Witnesses}
+\title{PGWSVC08 Physical String Order versus Virtual-Boundary Nondecay}
 \author{}
 \date{2026-06-11}
 
@@ -68,7 +67,34 @@ $S_m := \operatorname{span}\{A_{n_1}\cdots A_{n_m} A_{m_m}^\dagger
 matrix algebra $M_D(\mathbb C)$, so endpoint operators on sufficiently
 many physical sites reach every $D \times D$ matrix.
 
-\section{The formalized physical and virtual forms}
+\section{The restored peripheral phase}
+
+The source passage at lines~241--255 chooses right and left peripheral
+matrices $V,Y$ for an eigenvalue $\lambda=e^{i\theta}$. Iterating the twisted
+transfer map contributes $\lambda^N$, so the leading asymptotic term is
+\begin{align}
+  S_N(x,y,u,\Psi_\infty)
+  &=e^{iN\theta}
+    \tr\bigl[Y\mathcal E_y(\mathbb 1)\bigr]
+    \tr\bigl[\Lambda\mathcal E_x(V)\bigr]+o(1).
+  \tag{corrected asymptotic}
+\end{align}
+Lines~249--250 of the source display only the product of the two traces and
+omit $e^{iN\theta}$. The factor is required before the subsequent rephasing
+$\widetilde u=e^{-i\theta}u$. Its omission does not affect the absolute-value
+nonvanishing criterion because $|e^{iN\theta}|=1$, but it does affect the
+complex asymptotic formula itself.
+
+The blueprint therefore restores the factor in the proof of
+\path{thm:pgwsvc08_physical_string_order} in
+\path{blueprint/src/chapter/ch12_symmetry_string_order.tex}. The correlator is
+formalized as \leanid{MPSTensor.physicalStringOrderParam}; the source theorem
+and this asymptotic argument remain marked \path{notready}, so no Lean theorem
+is claimed for the restored expansion. The status is a deliberate local source
+correction, documented by the inline \path{Local fix} comment at the corrected
+display.
+
+\section{The formalized physical and virtual-boundary forms}
 
 The transfer-form physical correlator is now a formal definition:
 \[
@@ -83,23 +109,24 @@ unitary $u\ne \mathbb 1$, physical endpoint operators $x,y$, and a
 number $s>0$ such that $|S_N(x,y,u)|\to s$.\footnote{\leanid{MPSTensor.HasPhysicalStringOrder},
   same file.}
 
-The main theorems presently use a virtual-boundary form.  The boundary
-string-order expression is
+The main theorems presently use virtual-boundary nondecay. Its
+virtual-boundary twist functional is
 $\tr(\Lambda X\, \mathcal E_u^L(Y))$ with arbitrary
 $X, Y \in M_D(\mathbb C)$,\footnote{\leanid{MPSTensor.stringOrderBoundaryParam},
-  \path{TNLean/MPS/Symmetry/StringOrderDefs.lean}.} and string order is
-the existence of such $X, Y$ together with a constant $c > 0$ bounding
+  \path{TNLean/MPS/Symmetry/StringOrderDefs.lean}.} and the nondecay predicate
+is the existence of such $X,Y$ together with a constant $c>0$ bounding
 $\lVert \tr(\Lambda X\, \mathcal E_u^L(Y)) \rVert$ from below at every
-length $L$.\footnote{\leanid{MPSTensor.HasStringOrder}, same file.}  The
-equivalence of string order with local symmetry, and the universality of
-string order for injective on-site-symmetric tensors with canonical
-normalisations, are proved for this virtual
-form.\footnote{\leanid{MPSTensor.stringOrder_iff_localSymmetry},
+length $L$.\footnote{\leanid{MPSTensor.HasStringOrder}, same file.} The
+formal development proves the equivalence of virtual-boundary nondecay with
+virtual local covariance, and the universality of virtual-boundary nondecay for
+injective on-site-symmetric tensors with canonical normalisations.\footnote{
+  \leanid{MPSTensor.stringOrder_iff_localSymmetry},
   \leanid{MPSTensor.hasStringOrder_of_symmetric_injective},
   \leanid{MPSTensor.hasStringOrder_iff_of_symmetric_injective},
   \path{TNLean/MPS/Symmetry/StringOrder.lean}.}
 
-The virtual statement differs from the physical source statement in four ways.
+Virtual-boundary nondecay differs from physical endpoint string order in four
+ways.
 
 \begin{enumerate}
   \item \emph{Physical versus virtual endpoints.}  The source
@@ -120,23 +147,23 @@ The virtual statement differs from the physical source statement in four ways.
         same expressive range when $\Lambda$ is positive definite, as it
         is in all theorems concerned, but the formal expression is not
         the literal transfer form of the source.
-  \item \emph{Fixed versus existential twist.}  The source's ``has
-        string order'' quantifies existentially over the unitary $u$;
-        the formal predicate fixes $u$ as a parameter, in the style of
-        the source's Theorem~2.  The formal version is the finer
-        statement, and the existential form is recoverable from it.
+  \item \emph{Fixed versus existential twist.} Physical endpoint string order
+        quantifies existentially over the unitary $u$, whereas
+        virtual-boundary nondecay fixes $u$ as a parameter, in the style of
+        the source's Theorem~2. The fixed-twist version is the finer statement,
+        and an existential version is recoverable from it.
 \end{enumerate}
 
 \section{Verdict}
 
-The virtual-boundary reformulation is mathematically sound, and for the
-injective tensors that all concerned theorems treat, the existential
-physical-endpoint and existential virtual-boundary criteria are
-equivalent by the source's own span argument.  The physical correlator
-and the positive-limit source predicate are now formal definitions, but
-that equivalence is still the part with no formal counterpart: the
-development proves its string-order theorems for the virtual form only.
-Elimination: prove the realizability of virtual boundary matrices by
+Virtual-boundary nondecay is mathematically sound, and for the injective tensors
+that all concerned theorems treat, the existential physical-endpoint
+string-order and existential virtual-boundary criteria are equivalent by the
+source's own span argument. The physical correlator and the positive-limit
+source predicate are now formal definitions, but that equivalence is still the
+part with no formal counterpart: the development proves its nondecay theorems
+for virtual boundary witnesses only. Elimination requires proving the
+realizability of virtual boundary matrices by
 physical endpoint operators for injective tensors (a starting point is the
 single-site realization
 \leanid{MPSTensor.physRealize}\footnote{\path{TNLean/MPS/Chain/VirtualInsertion.lean},

--- a/docs/paper-gaps/schuch2011_spt_interpolation_upper_range.tex
+++ b/docs/paper-gaps/schuch2011_spt_interpolation_upper_range.tex
@@ -1,0 +1,74 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Schuch--P\'erez-Garc{\'\i}a--Cirac SPT Interpolation: Upper-Range Correction}
+\author{}
+\date{2026-07-26}
+
+\begin{document}
+\maketitle
+
+\section{Source construction}
+
+Section~II.F of arXiv:1010.3732 connects two symmetric injective matrix
+product states after passing to their isometric forms. Let their bond
+dimensions be $D_0$ and $D_1$. The two bond spaces are embedded as consecutive
+summands of a space of dimension $D_0+D_1$, and the interpolation is intended
+to move between maximally entangled vectors supported on those two summands.
+The source display in
+\path{Papers/1010.3732/paper_v3.tex}, lines~900--903, reads
+\begin{align}
+  |\omega(\gamma)\rangle
+  &=(1-\gamma)\sum_{i=1}^{D_0}|i,i\rangle +\gamma\sum_{i=D_0+1}^{D_1}|i,i\rangle,
+  \tag{source display}
+\end{align}
+and immediately says that this state has bond dimension $D_0+D_1$.
+
+\section{Issue and correction}
+
+The second summand must occupy the $D_1$ coordinates following the first
+$D_0$ coordinates. Its index set is therefore
+\begin{align}
+  \{D_0+1,\ldots,D_0+D_1\},
+\end{align}
+not $\{D_0+1,\ldots,D_1\}$. The corrected interpolation is
+\begin{align}
+  |\omega(\gamma)\rangle
+  &=(1-\gamma)\sum_{i=1}^{D_0}|i,i\rangle +\gamma\sum_{i=D_0+1}^{D_0+D_1}|i,i\rangle.
+  \tag{corrected interpolation}
+\end{align}
+At $\gamma=0$ this is the maximally entangled vector on the first bond
+summand, while at $\gamma=1$ it is the maximally entangled vector on the
+second bond summand. The corrected upper limit also agrees with the stated
+ambient bond dimension $D_0+D_1$. The source upper limit can otherwise make
+the second sum empty, for example when $D_0\geq D_1$.
+
+\section{Blueprint and formal status}
+
+The corrected display occurs in the proof of the blueprint theorem
+\path{thm:spt_classification} in
+\path{blueprint/src/chapter/ch12_symmetry_spt.tex}, where an inline
+\path{Local fix} comment points to this note. The nearby separation argument
+at source lines~929--953 is explicitly restricted to smooth MPS paths. The
+blueprint theorem is correspondingly restricted to symmetric MPS paths and
+their parent Hamiltonians; it does not claim invariance under arbitrary gapped
+Hamiltonian paths.
+
+The formal predicate \leanid{MPSTensor.IsSameSPTPhase} records equality of the
+virtual cocycle labels, not the interpolation. The blueprint classification
+theorem is marked \path{notready}; no Lean declaration implements this path or
+relies on the corrected summation range.
+
+\section{Verdict}
+
+The replacement of $D_1$ by $D_0+D_1$ is a local source correction. It restores
+the intended direct-sum coordinates and is the version used in the blueprint.
+The MPS/parent-Hamiltonian path restriction is a scope clarification matching
+the source proof.
+
+\end{document}


### PR DESCRIPTION
## What changed

- Resolved every post-merge Chapter 12 review finding from PR #4870.
- Made the virtual theorem chain consistently distinguish **physical endpoint string order**, **virtual-boundary nondecay**, and **virtual local covariance**.
- Restated the central main-text notation
  \[
  R_L(u;X,Y)=\operatorname{tr}(\Lambda X\mathcal E_u^L(Y))
  \]
  without duplicating its Lean-linked appendix definition.
- Corrected the cocycle gauge-independence calculation: it cancels $X_1((gh)^{-1})=\rho_1(gh)$, uses the correct cochain orientation, and states the exact `CohomologousTo ω₂ ω₁` conclusion before symmetry.
- Aligned the common trace-preserving gauge setup, constructor, and eigenvalue result with their Lean declaration kinds and complete signatures; corrected the transfer-companion dependency to unitary Kraus mixing.
- Restricted the SPT classification statement to the symmetric MPS and corresponding parent-Hamiltonian paths actually treated by Schuch–Pérez-García–Cirac.
- Added auditable Local-fix documentation for the corrected SPT interpolation range $D_0+D_1$ and the restored PGWSVC08 peripheral phase $e^{iN\theta}$.
- Synchronized the PGWSVC08 paper-gap note with the chapter's physical/virtual terminology and cleaned remaining display-quantifier and commutator-phase wording.

## Validation

- Independent mathematical/source re-review: approved; no high/medium findings.
- Blueprint–Lean synchronization: green; 5,580 unique `\lean{}` references and 5,591/5,594 theorem-like entries complete.
- Full route: 207 files, 3,625 labels, 4,223 `\lean` groups; 0 duplicate labels, missing targets, or self-uses.
- Focused route: 61 files, 950 labels, 711 `\lean` groups; 0 duplicate labels, missing targets, or self-uses.
- Full Blueprint: double LuaLaTeX, 739 pages, 0 ordinary undefined references.
- Focused FT-MPS Blueprint: double LuaLaTeX, 186 pages, 0 ordinary undefined references.
- Standalone paper-gap builds: PGWSVC08 note 4 pages; SPT interpolation note 2 pages.
- All changed blueprint sources are below 1,000 lines; `latexindent`, branch-scoped prose checks, and `git diff --check` pass; generated artifacts removed.

No Lean or Parent Hamiltonian source changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint and documentation-only edits; mathematical content is clarified and corrected but does not change executable Lean or runtime code.
> 
> **Overview**
> Resolves post-merge Chapter 12 blueprint review by **separating three notions**: physical endpoint string order, **virtual-boundary nondecay**, and **virtual local covariance**, with renamed chapter/appendix titles and consistent wording through the symmetry theorem chain.
> 
> **Definitions and Lean alignment:** The virtual-boundary functional \(R_L(u;X,Y)=\tr(\Lambda X \mathcal E_u^L(Y))\) is named explicitly in main text (`def:has_string_order`) without duplicating the appendix Lean-linked definition; companion transfer-map and common trace-preserving gauge material is expanded and retyped (construction as **definition**, eigenvalue survival as **theorem**) with corrected Kraus-mixing dependencies.
> 
> **Proof/math fixes:** Cocycle gauge-independence now cancels \(\rho_1(gh)\) and states **`ω₂ ∼ ω₁`** with the right cochain orientation; SPT classification is scoped to **symmetric MPS / parent-Hamiltonian paths** (not arbitrary gapped paths); Schuch et al. interpolation uses summation to **`D₀+D₁`**; PGWSVC08 physical string-order asymptotics restore **`e^{iNθ}`**, documented in updated paper-gap notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19efe42902b434102c6d5e10c8aadd00eaa849d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->