### PR TITLE
feat(MPS/CanonicalForm): define literal CPSV canonical forms

### DIFF
--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -24,13 +24,14 @@ operators: Renormalization fixed points and boundary theories"):
 * canonical form II (CFII), `MPSTensor.IsCPSVCanonicalFormII`, and
 * basis of normal tensors (BNT), `MPSTensor.IsCPSVBasisOfNormalTensors`.
 
-The canonical-form (CF) decomposition of arXiv:1606.00608 eq. `II_CF1` and its
-normalization paragraph (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`) are
-recorded by `MPSTensor.CPSVCanonicalFormData` and
-`MPSTensor.IsCPSVCanonicalForm`.  This source-level predicate retains equality
-of positive-length MPV families and allows the sum of the retained block bond
-dimensions to be smaller than the original bond dimension.  It does not add
-left-canonical normalization, weight ordering, or BNT separation.
+The literal canonical-form (CF) decomposition of arXiv:1606.00608 eq. `II_CF1`
+is recorded by `MPSTensor.CPSVCanonicalFormData` and
+`MPSTensor.IsCPSVCanonicalForm`.  A coisometry embeds the retained weighted
+direct sum into the original bond space, whose remaining coordinates are zero.
+The line-246 normalization convention is the separate predicate
+`MPSTensor.CPSVCanonicalFormData.IsWeightNormalized`; it is not part of literal
+CF membership.  None of these definitions adds weight ordering or BNT
+separation.
 
 The existing canonical-form layer (`TNLean.PiAlgebra.CanonicalFormSepAux`,
 `TNLean.MPS.BNT.Construction`) contains several strengthenings of these definitions
@@ -167,41 +168,56 @@ theorem isNormalTensor_of_bondDim_one_of_transferMap_eq_id
 
 /-! ## CPSV canonical form (CF) -/
 
-/-- Witness data for the CPSV canonical form of `A`.
+/-- Witness data for the literal CPSV canonical form of `A`.
 
-This is arXiv:1606.00608, Section 2.3, lines 214--246: the positive-length MPV
-family of `A` is represented by weighted normal blocks.  Blocks that contribute
-only to the length-zero trace may be omitted, so the retained total bond
-dimension is bounded above by `D` rather than required to equal it.  The empty
-family represents the identically-zero positive-length MPV family; consequently
-the unit-modulus normalization is conditional on `0 < r`. -/
+This is arXiv:1606.00608, Section 2.3, lines 214--245 and eq. `II_CF1`.
+The retained weighted direct sum occupies a coisometrically embedded subspace
+of the original bond space.  Its orthogonal complement consists literally of
+the omitted zero coordinates. -/
 structure CPSVCanonicalFormData (A : MPSTensor d D) where
-  /-- Number of retained normal blocks. -/
+  /-- Number of retained normal blocks (CPSV16, lines 214--225). -/
   r : ℕ
-  /-- Bond dimension of each retained block. -/
+  /-- Bond dimension of each retained block (CPSV16, lines 219--225). -/
   dim : Fin r → ℕ
-  /-- Scalar weight of each retained block. -/
+  /-- Every retained block has positive bond dimension (CPSV16, lines 219--225). -/
+  dim_pos : ∀ k, 0 < dim k
+  /-- Scalar weight of each retained block (CPSV16, eq. `II_Aiplusk1`). -/
   weights : Fin r → ℂ
-  /-- Retained normal blocks. -/
+  /-- Retained normal blocks (CPSV16, eq. `II_CF1`). -/
   blocks : (k : Fin r) → MPSTensor d (dim k)
-  /-- Every retained block is normal in the sense of CPSV16, lines 233--235. -/
+  /-- Every retained block is normal (CPSV16, lines 233--245 and eq. `II_CF1`). -/
   blocks_normal : ∀ k, IsNormalTensor (blocks k)
-  /-- The weighted direct sum represents the same MPV family at every positive length. -/
-  sameMPV_pos : SameMPV₂Pos A (toTensorFromBlocks (d := d) weights blocks)
-  /-- Removing length-zero-only blocks cannot increase the total bond dimension. -/
-  bondDim_le : ∑ k : Fin r, dim k ≤ D
-  /-- CPSV16, line 246: all retained weights have modulus at most one. -/
-  weight_norm_le_one : ∀ k, ‖weights k‖ ≤ 1
-  /-- CPSV16, line 246, with the empty-family exception for the zero MPV family. -/
-  weight_unit_exists : 0 < r → ∃ k, ‖weights k‖ = 1
+  /-- The retained direct sum fits inside the original bond space (CPSV16, lines 219--225). -/
+  total_dim_le : ∑ k : Fin r, dim k ≤ D
+  /-- Coisometric inclusion implementing the zero ambient coordinates of CPSV16, lines 219--225. -/
+  ambient_coisometry : Matrix (Fin (∑ k : Fin r, dim k)) (Fin D) ℂ
+  /-- The retained coordinates embed coisometrically (CPSV16, lines 214--225). -/
+  coisometric : ambient_coisometry * ambient_coisometryᴴ = 1
+  /-- Exact eq. `II_CF1` reconstruction, including the zero coordinates of
+  CPSV16, lines 219--225. -/
+  reconstruct : ∀ i,
+    A i = ambient_coisometryᴴ * toTensorFromBlocks (d := d) weights blocks i *
+      ambient_coisometry
 
-/-- A tensor is in CPSV canonical form when it admits retained-block witness data.
+/-- A tensor is in literal CPSV canonical form when it has an exact retained-block
+reconstruction in its ambient bond space.
 
-Source: arXiv:1606.00608, Section 2.3, lines 214--246. -/
+Source: arXiv:1606.00608, Section 2.3, lines 214--245 and eq. `II_CF1`. -/
 def IsCPSVCanonicalForm (A : MPSTensor d D) : Prop :=
   Nonempty (CPSVCanonicalFormData A)
 
 namespace CPSVCanonicalFormData
+
+/-- CPSV16 line 246's weight convention, separated from literal canonical-form
+membership.  The unit weight is required exactly when the ambient tensor is
+nonzero; no retained weight is required to be nonzero.
+
+Source: arXiv:1606.00608, Section 2.3, line 246. -/
+structure IsWeightNormalized (data : CPSVCanonicalFormData A) : Prop where
+  /-- Every retained weight has modulus at most one (CPSV16, line 246). -/
+  weight_norm_le_one : ∀ k, ‖data.weights k‖ ≤ 1
+  /-- A nonzero ambient tensor has a retained unit-modulus weight (CPSV16, line 246). -/
+  weight_unit_exists : A ≠ 0 → ∃ k, ‖data.weights k‖ = 1
 
 /-- Witness data determine the corresponding CPSV canonical-form predicate. -/
 theorem isCPSVCanonicalForm (data : CPSVCanonicalFormData A) :
@@ -220,21 +236,23 @@ end IsCPSVCanonicalForm
 
 /-! ## CPSV canonical form II (CFII) -/
 
-/-- Witness data for CPSV canonical form II.
+/-- Witness data for literal CPSV canonical form II.
 
-This is arXiv:1606.00608, Appendix A, lines 1054--1077.  It uses the same
-retained-block canonical-form witness as `CPSVCanonicalFormData` and adds the
-two blockwise normalization conditions: left-canonical form and a diagonal
-positive-definite fixed point of the transfer map. -/
+This is arXiv:1606.00608, Appendix A, lines 1054--1077.  It extends the exact
+ambient reconstruction in `CPSVCanonicalFormData` by the two blockwise
+normalization conditions: left-canonical form and a diagonal positive-definite
+fixed point of the transfer map. -/
 structure CPSVCanonicalFormIIData (A : MPSTensor d D) extends CPSVCanonicalFormData A where
-  /-- Every retained block is left-canonical, as in CPSV16 Appendix A. -/
-  blocks_leftCanonical : ∀ k, IsLeftCanonical (blocks k)
-  /-- Every retained block has diagonal positive-definite Perron data fixed by its transfer map. -/
-  blocks_fixedPoint :
+  /-- Every retained block is left-canonical (CPSV16, Appendix A, eq. `TP`). -/
+  blocks_left_canonical : ∀ k, IsLeftCanonical (blocks k)
+  /-- Every block has diagonal positive-definite fixed-point data (CPSV16,
+  Appendix A, eq. `Lambda`). -/
+  blocks_fixed_point :
     ∀ k, ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
       Λ.PosDef ∧ Λ.IsDiag ∧ transferMap (blocks k) Λ = Λ
 
-/-- A tensor is in CPSV canonical form II when it admits normalized retained-block data.
+/-- A tensor is in literal CPSV canonical form II when it admits exactly
+reconstructed, blockwise normalized retained-block data.
 
 Source: arXiv:1606.00608, Appendix A, lines 1054--1077. -/
 def IsCPSVCanonicalFormII (A : MPSTensor d D) : Prop :=
@@ -247,7 +265,7 @@ theorem isCPSVCanonicalFormII (data : CPSVCanonicalFormIIData A) :
     IsCPSVCanonicalFormII A :=
   ⟨data⟩
 
-/-- Forgetting the blockwise normalization leaves CPSV canonical-form data. -/
+/-- Forgetting the blockwise normalization leaves literal CPSV canonical-form data. -/
 theorem isCPSVCanonicalForm (data : CPSVCanonicalFormIIData A) :
     IsCPSVCanonicalForm A :=
   data.toCPSVCanonicalFormData.isCPSVCanonicalForm
@@ -260,7 +278,7 @@ namespace IsCPSVCanonicalFormII
 noncomputable def data (h : IsCPSVCanonicalFormII A) : CPSVCanonicalFormIIData A :=
   Classical.choice h
 
-/-- Canonical form II is, in particular, CPSV canonical form. -/
+/-- Canonical form II is, in particular, literal CPSV canonical form. -/
 theorem isCPSVCanonicalForm (h : IsCPSVCanonicalFormII A) : IsCPSVCanonicalForm A :=
   ⟨h.data.toCPSVCanonicalFormData⟩
 

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -4,19 +4,24 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.Core.CanonicalNormalization
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Overlap.Basic
 import TNLean.MPS.SharedInfra.BlockAssembly
 import TNLean.Channel.Peripheral.Spectrum
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.LinearAlgebra.Matrix.IsDiag
 
 /-!
-# Normal tensor and basis of normal tensors (CPSV16)
+# CPSV canonical forms and normal tensors
 
-This module records the definitions of two of the central notions
+This module records four central notions
 from arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete, "Matrix product density
 operators: Renormalization fixed points and boundary theories"):
 
-* normal tensor (NT), `MPSTensor.IsNormalTensor`, and
+* normal tensor (NT), `MPSTensor.IsNormalTensor`,
+* canonical form (CF), `MPSTensor.IsCPSVCanonicalForm`,
+* canonical form II (CFII), `MPSTensor.IsCPSVCanonicalFormII`, and
 * basis of normal tensors (BNT), `MPSTensor.IsCPSVBasisOfNormalTensors`.
 
 The canonical-form (CF) decomposition of arXiv:1606.00608 eq. `II_CF1` and its
@@ -71,7 +76,7 @@ by `IsNormalTensor`.
 Follows `docs/MATHLIB_style.md` and `docs/MATHLIB_naming.md`.
 -/
 
-open scoped Matrix BigOperators Matrix.Norms.Operator
+open scoped Matrix BigOperators Matrix.Norms.Operator ComplexOrder MatrixOrder
 
 namespace MPSTensor
 
@@ -212,6 +217,54 @@ noncomputable def data (h : IsCPSVCanonicalForm A) : CPSVCanonicalFormData A :=
   Classical.choice h
 
 end IsCPSVCanonicalForm
+
+/-! ## CPSV canonical form II (CFII) -/
+
+/-- Witness data for CPSV canonical form II.
+
+This is arXiv:1606.00608, Appendix A, lines 1054--1077.  It uses the same
+retained-block canonical-form witness as `CPSVCanonicalFormData` and adds the
+two blockwise normalization conditions: left-canonical form and a diagonal
+positive-definite fixed point of the transfer map. -/
+structure CPSVCanonicalFormIIData (A : MPSTensor d D) extends CPSVCanonicalFormData A where
+  /-- Every retained block is left-canonical, as in CPSV16 Appendix A. -/
+  blocks_leftCanonical : ∀ k, IsLeftCanonical (blocks k)
+  /-- Every retained block has diagonal positive-definite Perron data fixed by its transfer map. -/
+  blocks_fixedPoint :
+    ∀ k, ∃ Λ : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+      Λ.PosDef ∧ Λ.IsDiag ∧ transferMap (blocks k) Λ = Λ
+
+/-- A tensor is in CPSV canonical form II when it admits normalized retained-block data.
+
+Source: arXiv:1606.00608, Appendix A, lines 1054--1077. -/
+def IsCPSVCanonicalFormII (A : MPSTensor d D) : Prop :=
+  Nonempty (CPSVCanonicalFormIIData A)
+
+namespace CPSVCanonicalFormIIData
+
+/-- Canonical-form-II witness data determine the corresponding predicate. -/
+theorem isCPSVCanonicalFormII (data : CPSVCanonicalFormIIData A) :
+    IsCPSVCanonicalFormII A :=
+  ⟨data⟩
+
+/-- Forgetting the blockwise normalization leaves CPSV canonical-form data. -/
+theorem isCPSVCanonicalForm (data : CPSVCanonicalFormIIData A) :
+    IsCPSVCanonicalForm A :=
+  data.toCPSVCanonicalFormData.isCPSVCanonicalForm
+
+end CPSVCanonicalFormIIData
+
+namespace IsCPSVCanonicalFormII
+
+/-- Choose normalized retained-block data from a canonical-form-II predicate. -/
+noncomputable def data (h : IsCPSVCanonicalFormII A) : CPSVCanonicalFormIIData A :=
+  Classical.choice h
+
+/-- Canonical form II is, in particular, CPSV canonical form. -/
+theorem isCPSVCanonicalForm (h : IsCPSVCanonicalFormII A) : IsCPSVCanonicalForm A :=
+  ⟨h.data.toCPSVCanonicalFormData⟩
+
+end IsCPSVCanonicalFormII
 
 /-! ## Basis of normal tensors (BNT) -/
 

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Overlap.Basic
+import TNLean.MPS.SharedInfra.BlockAssembly
 import TNLean.Channel.Peripheral.Spectrum
 
 /-!
@@ -18,15 +19,13 @@ operators: Renormalization fixed points and boundary theories"):
 * normal tensor (NT), `MPSTensor.IsNormalTensor`, and
 * basis of normal tensors (BNT), `MPSTensor.IsCPSVBasisOfNormalTensors`.
 
-The canonical-form (CF) decomposition of arXiv:1606.00608 eq. `II_CF1` plus the
-normalization paragraph (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`) is not
-introduced here as a separate predicate.  The later normal canonical form
-predicate `MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm` records the
-strengthened form used in the Fundamental Theorem: normal blocks together with
-left-canonical normalization, non-increasing nonzero weight moduli, primitive
-transfer maps, and positive block dimensions.  The global CPSV normalization
-`‖μ k‖ ≤ 1` with a unit-modulus witness remains a separate source hypothesis
-when it is needed.
+The canonical-form (CF) decomposition of arXiv:1606.00608 eq. `II_CF1` and its
+normalization paragraph (`Papers/1606.00608/MPDO-22-12-17-2.tex:237-246`) are
+recorded by `MPSTensor.CPSVCanonicalFormData` and
+`MPSTensor.IsCPSVCanonicalForm`.  This source-level predicate retains equality
+of positive-length MPV families and allows the sum of the retained block bond
+dimensions to be smaller than the original bond dimension.  It does not add
+left-canonical normalization, weight ordering, or BNT separation.
 
 The existing canonical-form layer (`TNLean.PiAlgebra.CanonicalFormSepAux`,
 `TNLean.MPS.BNT.Construction`) contains several strengthenings of these definitions
@@ -160,6 +159,59 @@ theorem isNormalTensor_of_bondDim_one_of_transferMap_eq_id
       simp only [LinearMap.id_apply, Matrix.smul_apply, smul_eq_mul] at hEq00
       apply mul_right_cancel₀ hX00
       simpa using hEq00.symm
+
+/-! ## CPSV canonical form (CF) -/
+
+/-- Witness data for the CPSV canonical form of `A`.
+
+This is arXiv:1606.00608, Section 2.3, lines 214--246: the positive-length MPV
+family of `A` is represented by weighted normal blocks.  Blocks that contribute
+only to the length-zero trace may be omitted, so the retained total bond
+dimension is bounded above by `D` rather than required to equal it.  The empty
+family represents the identically-zero positive-length MPV family; consequently
+the unit-modulus normalization is conditional on `0 < r`. -/
+structure CPSVCanonicalFormData (A : MPSTensor d D) where
+  /-- Number of retained normal blocks. -/
+  r : ℕ
+  /-- Bond dimension of each retained block. -/
+  dim : Fin r → ℕ
+  /-- Scalar weight of each retained block. -/
+  weights : Fin r → ℂ
+  /-- Retained normal blocks. -/
+  blocks : (k : Fin r) → MPSTensor d (dim k)
+  /-- Every retained block is normal in the sense of CPSV16, lines 233--235. -/
+  blocks_normal : ∀ k, IsNormalTensor (blocks k)
+  /-- The weighted direct sum represents the same MPV family at every positive length. -/
+  sameMPV_pos : SameMPV₂Pos A (toTensorFromBlocks (d := d) weights blocks)
+  /-- Removing length-zero-only blocks cannot increase the total bond dimension. -/
+  bondDim_le : ∑ k : Fin r, dim k ≤ D
+  /-- CPSV16, line 246: all retained weights have modulus at most one. -/
+  weight_norm_le_one : ∀ k, ‖weights k‖ ≤ 1
+  /-- CPSV16, line 246, with the empty-family exception for the zero MPV family. -/
+  weight_unit_exists : 0 < r → ∃ k, ‖weights k‖ = 1
+
+/-- A tensor is in CPSV canonical form when it admits retained-block witness data.
+
+Source: arXiv:1606.00608, Section 2.3, lines 214--246. -/
+def IsCPSVCanonicalForm (A : MPSTensor d D) : Prop :=
+  Nonempty (CPSVCanonicalFormData A)
+
+namespace CPSVCanonicalFormData
+
+/-- Witness data determine the corresponding CPSV canonical-form predicate. -/
+theorem isCPSVCanonicalForm (data : CPSVCanonicalFormData A) :
+    IsCPSVCanonicalForm A :=
+  ⟨data⟩
+
+end CPSVCanonicalFormData
+
+namespace IsCPSVCanonicalForm
+
+/-- Choose retained-block witness data from a CPSV canonical-form predicate. -/
+noncomputable def data (h : IsCPSVCanonicalForm A) : CPSVCanonicalFormData A :=
+  Classical.choice h
+
+end IsCPSVCanonicalForm
 
 /-! ## Basis of normal tensors (BNT) -/
 

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -317,40 +317,38 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     so condition~(ii) alone does not characterize normality.
 \end{remark}
 
-\begin{definition}[CPSV canonical form and basis of normal tensors]
+\begin{definition}[CPSV canonical form]
     \label{def:cpsv_canonical_form}
-    \notready
+    \lean{MPSTensor.IsCPSVCanonicalForm}
+    \leanok
     \uses{def:nt_cpsv}
-    In the canonical form of \cite[Section~2.3]{Cirac2016MPDO_arXiv},
+    In the canonical form of \cite[Section~2.3]{Cirac2016MPDO_arXiv}, the
+    positive-length MPV family of $A$ has a retained-block representation
     \begin{align}
-        A^i
-         & =\bigoplus_{k=1}^r\mu_kA_k^i,
+        V^{(N)}(A)
+         & =V^{(N)}\!\left(\bigoplus_{k=1}^r\mu_kA_k\right),
+        && N>0,
         \tag{CF}\label{eq:cpsv_canonical_form}
     \end{align}
-    where every $A_k$ is a normal tensor. For a nonzero positive-length MPV
-    family, the states are not normalized, so the common scalar may be chosen
-    such that $|\mu_k|\le1$ for every~$k$ and at least one weight has modulus
-    one.
+    where every $A_k$ is a normal tensor. If $D_k$ is the bond dimension of
+    $A_k$ and $D$ is the bond dimension of $A$, then
+    $\sum_{k=1}^r D_k\le D$. The weights satisfy $|\mu_k|\le1$; when $r>0$,
+    at least one weight has modulus one.
 
     \textbf{Local fix (zero-family normalization):} The source states the
     unit-modulus convention without an exception. An identically zero
-    positive-length MPV family has no nonempty retained family on which a
-    unit-modulus weight can be attained, so here it is represented by the empty
-    family. This deviation is recorded in
+    positive-length MPV family is represented here by the empty family, for
+    which the unit-modulus condition is vacuous. This deviation is recorded in
     \path{docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex}.
 
-    A basis of normal tensors for $A$ is a family $(C_j)_{j=1}^g$ of normal
-    tensors such that $V^{(N)}(A)$ lies in the span of the
-    $V^{(N)}(C_j)$ for every~$N$, and these vectors are linearly independent for
-    every sufficiently large~$N$. Equivalently, each normal block $A_k$ in
-    (\ref{eq:cpsv_canonical_form}) is gauge-phase equivalent to some $C_j$, and
-    the family $(C_j)$ is minimal under gauge-phase equivalence.
-
-    A sufficient criterion for (\ref{eq:cpsv_canonical_form}) is that $A$ have
-    no nontrivial periodic vectors and that every orthogonal projection $P$
-    satisfying $PA^i=PA^iP$ also satisfy $A^iP=PA^iP$. This is the criterion
-    proved in Theorem~\ref{thm:projector_closure_canonical_form}.
+    The basis-of-normal-tensors refinement is
+    Definition~\ref{def:bnt}; it is not part of canonical form itself.
 \end{definition}
+
+A sufficient criterion for (\ref{eq:cpsv_canonical_form}) is that $A$ have
+no nontrivial periodic vectors and that every orthogonal projection $P$
+satisfying $PA^i=PA^iP$ also satisfy $A^iP=PA^iP$. This criterion is proved in
+Theorem~\ref{thm:projector_closure_canonical_form}.
 
 This source definition is distinct from the stronger normal-canonical-form
 conditions below. The renormalization fixed-point analysis uses a separate

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -323,11 +323,11 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \leanok
     \uses{def:nt_cpsv}
     In the canonical form of \cite[Section~2.3]{Cirac2016MPDO_arXiv}, the
-    positive-length MPV family of $A$ has a retained-block representation
+    positive-length MPV family of $A$ has the following retained-block
+    representation for every $N>0$:
     \begin{align}
         V^{(N)}(A)
-         & =V^{(N)}\!\left(\bigoplus_{k=1}^r\mu_kA_k\right),
-        && N>0,
+         & =V^{(N)}\!\left(\bigoplus_{k=1}^r\mu_kA_k\right).
         \tag{CF}\label{eq:cpsv_canonical_form}
     \end{align}
     where every $A_k$ is a normal tensor. If $D_k$ is the bond dimension of

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -359,8 +359,9 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 
 The projector-closure result in
 Theorem~\ref{thm:projector_closure_canonical_form} gives normal blocks and
-orthogonal ambient embeddings under the source hypotheses. Its conclusion does
-not yet establish Definition~\ref{def:cpsv_canonical_form}.
+orthogonal ambient embeddings under the source hypotheses. Combining these
+embeddings into one coisometry gives
+Definition~\ref{def:cpsv_canonical_form}.
 
 This source definition is distinct from the stronger normal-canonical-form
 conditions below. The renormalization fixed-point analysis uses a separate

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -319,36 +319,50 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 
 \begin{definition}[CPSV canonical form]
     \label{def:cpsv_canonical_form}
+    \lean{MPSTensor.CPSVCanonicalFormData}
     \lean{MPSTensor.IsCPSVCanonicalForm}
+    \lean{MPSTensor.CPSVCanonicalFormData.IsWeightNormalized}
     \leanok
-    \uses{def:nt_cpsv}
-    In the canonical form of \cite[Section~2.3]{Cirac2016MPDO_arXiv}, the
-    positive-length MPV family of $A$ has the following retained-block
-    representation for every $N>0$:
+    \uses{def:nt_cpsv, def:block_diagonal_tensor}
+    Let $A=(A^i)_{i=1}^d$ have bond dimension $D$. It is in the canonical
+    form of \cite[Section~2.3]{Cirac2016MPDO_arXiv} if there are positive
+    integers $D_1,\ldots,D_r$, normal tensors $A_k$ of bond dimension $D_k$,
+    weights $\mu_k\in\C$, and, writing $S=\sum_kD_k$, a matrix
+    $U\in\C^{S\times D}$ such that $S\le D$,
     \begin{align}
-        V^{(N)}(A)
-         & =V^{(N)}\!\left(\bigoplus_{k=1}^r\mu_kA_k\right).
+        UU^\dagger
+         & =\Id_S,
+        \notag\\
+        A^i
+         & =U^\dagger\!\left(\bigoplus_{k=1}^r\mu_kA_k^i\right)U
+        \qquad (1\le i\le d).
         \tag{CF}\label{eq:cpsv_canonical_form}
     \end{align}
-    where every $A_k$ is a normal tensor. If $D_k$ is the bond dimension of
-    $A_k$ and $D$ is the bond dimension of $A$, then
-    $\sum_{k=1}^r D_k\le D$. The weights satisfy $|\mu_k|\le1$; when $r>0$,
-    at least one weight has modulus one.
+    Thus the complement of the retained direct sum consists literally of zero
+    bond-space coordinates. In particular, $r=0$ is possible only when $A=0$.
 
-    \textbf{Local fix (zero-family normalization):} The source states the
-    unit-modulus convention without an exception. An identically zero
-    positive-length MPV family is represented here by the empty family, for
-    which the unit-modulus condition is vacuous. This deviation is recorded in
-    \path{docs/paper-gaps/cpsv16_cf_normalization_and_proportional_comparison.tex}.
+    The convention in line~246 of \cite{Cirac2016MPDO_arXiv} is a separate
+    normalization of these data, not part of canonical-form membership:
+    \begin{align}
+        |\mu_k|
+         & \le1\quad\text{for every }k,
+        \notag\\
+        A\ne0
+         & \Longrightarrow\exists k,\ |\mu_k|=1.
+        \label{eq:cpsv_weight_normalization}
+    \end{align}
+    No weight is required to be nonzero, and no ordering or separation condition
+    is imposed.
 
     The basis-of-normal-tensors refinement is
     Definition~\ref{def:bnt}; it is not part of canonical form itself.
 \end{definition}
 
-A sufficient criterion for (\ref{eq:cpsv_canonical_form}) is that $A$ have
-no nontrivial periodic vectors and that every orthogonal projection $P$
-satisfying $PA^i=PA^iP$ also satisfy $A^iP=PA^iP$. This criterion is proved in
-Theorem~\ref{thm:projector_closure_canonical_form}.
+The projector-closure result in
+Theorem~\ref{thm:projector_closure_canonical_form} constructs the normal blocks
+and their orthogonal ambient embeddings under the source hypotheses. It does
+not yet package those witnesses as the bundled predicate in
+Definition~\ref{def:cpsv_canonical_form}.
 
 This source definition is distinct from the stronger normal-canonical-form
 conditions below. The renormalization fixed-point analysis uses a separate

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -358,10 +358,9 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \end{definition}
 
 The projector-closure result in
-Theorem~\ref{thm:projector_closure_canonical_form} constructs the normal blocks
-and their orthogonal ambient embeddings under the source hypotheses. It does
-not yet package those witnesses as the bundled predicate in
-Definition~\ref{def:cpsv_canonical_form}.
+Theorem~\ref{thm:projector_closure_canonical_form} gives normal blocks and
+orthogonal ambient embeddings under the source hypotheses. Its conclusion does
+not yet establish Definition~\ref{def:cpsv_canonical_form}.
 
 This source definition is distinct from the stronger normal-canonical-form
 conditions below. The renormalization fixed-point analysis uses a separate

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -324,18 +324,17 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \lean{MPSTensor.CPSVCanonicalFormData.IsWeightNormalized}
     \leanok
     \uses{def:nt_cpsv, def:block_diagonal_tensor}
-    Let $A=(A^i)_{i=1}^d$ have bond dimension $D$. It is in the canonical
+    Let $A$ have bond dimension $D$. It is in the canonical
     form of \cite[Section~2.3]{Cirac2016MPDO_arXiv} if there are positive
     integers $D_1,\ldots,D_r$, normal tensors $A_k$ of bond dimension $D_k$,
     weights $\mu_k\in\C$, and, writing $S=\sum_kD_k$, a matrix
-    $U\in\C^{S\times D}$ such that $S\le D$,
+    $U\in\C^{S\times D}$ such that $S\le D$ and, for every physical index~$i$,
     \begin{align}
         UU^\dagger
          & =\Id_S,
         \notag\\
         A^i
-         & =U^\dagger\!\left(\bigoplus_{k=1}^r\mu_kA_k^i\right)U
-        \qquad (1\le i\le d).
+         & =U^\dagger\!\left(\bigoplus_{k=1}^r\mu_kA_k^i\right)U.
         \tag{CF}\label{eq:cpsv_canonical_form}
     \end{align}
     Thus the complement of the retained direct sum consists literally of zero

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -53,25 +53,37 @@
 
 
 \begin{definition}[CPSV canonical form II]\label{def:cpsv_cfii}
+    \lean{MPSTensor.CPSVCanonicalFormIIData}
     \lean{MPSTensor.IsCPSVCanonicalFormII}
     \leanok
-    \uses{def:cpsv_canonical_form}
-    In canonical form II of \cite[Appendix~A]{Cirac2016MPDO_arXiv}, the same
-    retained normal blocks and weights as in
-    (\ref{eq:cpsv_canonical_form}) are normalized blockwise. For every retained
-    block $A_k$,
+    \uses{def:cpsv_canonical_form, def:nt_cpsv, def:block_diagonal_tensor}
+    In canonical form II of \cite[Appendix~A]{Cirac2016MPDO_arXiv}, there are
+    positive retained dimensions $D_k$, normal tensors $A_k$, weights $\mu_k$,
+    and, for $S=\sum_kD_k\le D$, a matrix $U\in\C^{S\times D}$ such that
+    \begin{align}
+        UU^\dagger
+         & =\Id_S,
+        \notag\\
+        A^i
+         & =U^\dagger\!\left(\bigoplus_k\mu_kA_k^i\right)U
+        \qquad (1\le i\le d).
+        \label{eq:cpsv_cfii_ambient}
+    \end{align}
+    Thus omitted bond-space coordinates are literally zero. Every retained
+    block additionally satisfies
     \begin{align}
         \sum_i(A_k^i)^\dagger A_k^i
-         & =\Id,
-        \notag         \\
+         & =\Id_{D_k},
+        \notag\\
         \E_{A_k}(\Lambda_k)
          & =\Lambda_k,
         \notag
     \end{align}
-    where $\Lambda_k>0$ is diagonal. Thus CFII retains the positive-length MPV
-    representation, the bond-dimension inequality, and the weight normalization
-    of canonical form; the displayed identities are its additional blockwise
-    normalization conditions.
+    where $\Lambda_k$ is diagonal and positive definite. These are exactly the
+    additional blockwise conditions: no ordering, injectivity, gauge data, or
+    basis-of-normal-tensors assumptions are included. The line-246 convention
+    (\ref{eq:cpsv_weight_normalization}) remains a separate condition on the
+    underlying canonical-form data.
 \end{definition}
 
 \begin{theorem}[Diagonal Perron normalization for an irreducible TP tensor]

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -53,22 +53,25 @@
 
 
 \begin{definition}[CPSV canonical form II]\label{def:cpsv_cfii}
-    \notready
+    \lean{MPSTensor.IsCPSVCanonicalFormII}
+    \leanok
     \uses{def:cpsv_canonical_form}
-    A tensor is in \emph{canonical form II} (CFII) if it is in the CPSV
-    canonical form (\ref{eq:cpsv_canonical_form}) and, for every normal block
-    $A_k$, the associated completely positive map is trace-preserving and has a
-    full-rank diagonal fixed point:
+    In canonical form II of \cite[Appendix~A]{Cirac2016MPDO_arXiv}, the same
+    retained normal blocks and weights as in
+    (\ref{eq:cpsv_canonical_form}) are normalized blockwise. For every retained
+    block $A_k$,
     \begin{align}
         \sum_i(A_k^i)^\dagger A_k^i
          & =\Id,
         \notag         \\
         \E_{A_k}(\Lambda_k)
-         & =\Lambda_k.
+         & =\Lambda_k,
         \notag
     \end{align}
-    Here $\Lambda_k>0$ is diagonal. Thus CFII includes the canonical-form and normal-block hypotheses; the two
-    displayed identities alone are only its normalization component.
+    where $\Lambda_k>0$ is diagonal. Thus CFII retains the positive-length MPV
+    representation, the bond-dimension inequality, and the weight normalization
+    of canonical form; the displayed identities are its additional blockwise
+    normalization conditions.
 \end{definition}
 
 \begin{theorem}[Diagonal Perron normalization for an irreducible TP tensor]

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -59,14 +59,14 @@
     \uses{def:cpsv_canonical_form, def:nt_cpsv, def:block_diagonal_tensor}
     In canonical form II of \cite[Appendix~A]{Cirac2016MPDO_arXiv}, there are
     positive retained dimensions $D_k$, normal tensors $A_k$, weights $\mu_k$,
-    and, for $S=\sum_kD_k\le D$, a matrix $U\in\C^{S\times D}$ such that
+    and, for $S=\sum_kD_k\le D$, a matrix $U\in\C^{S\times D}$ such
+    that, for every physical index~$i$,
     \begin{align}
         UU^\dagger
          & =\Id_S,
         \notag\\
         A^i
-         & =U^\dagger\!\left(\bigoplus_k\mu_kA_k^i\right)U
-        \qquad (1\le i\le d).
+         & =U^\dagger\!\left(\bigoplus_k\mu_kA_k^i\right)U.
         \label{eq:cpsv_cfii_ambient}
     \end{align}
     Thus omitted bond-space coordinates are literally zero. Every retained

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -79,9 +79,10 @@
          & =\Lambda_k,
         \notag
     \end{align}
-    where $\Lambda_k$ is diagonal and positive definite. These are exactly the
-    additional blockwise conditions: no ordering, injectivity, gauge data, or
-    basis-of-normal-tensors assumptions are included. The line-246 convention
+    where $\Lambda_k$ is diagonal and positive definite. The two displayed
+    equations are the only additional blockwise conditions; no ordering,
+    injectivity, gauges, or basis-of-normal-tensors assumptions are included.
+    The line-246 convention
     (\ref{eq:cpsv_weight_normalization}) remains a separate condition on the
     underlying canonical-form data.
 \end{definition}


### PR DESCRIPTION
## What changed

- add literal CPSV canonical-form witness data and `MPSTensor.IsCPSVCanonicalForm`;
- represent omitted zero bond-space coordinates by an exact coisometric ambient reconstruction
  \[
  A^i=U^\dagger\left(\bigoplus_k \mu_k A_k^i\right)U,
  \qquad UU^\dagger=I,
  \]
  with positive retained dimensions and \(\sum_k D_k\le D\);
- separate CPSV16 line 246's weight normalization convention from literal CF membership;
- add `MPSTensor.CPSVCanonicalFormIIData` and `MPSTensor.IsCPSVCanonicalFormII`, extending literal CF by exactly the blockwise left-canonical and diagonal positive-definite fixed-point conditions from Appendix A;
- synchronize the two Chapter 9 definitions and correct CFII's source location to Appendix A.

The exact reconstruction ensures an empty retained family witnesses only the literal zero tensor; it no longer identifies arbitrary presentations merely from equality of positive-length MPV families. No weight ordering, nonzero-weight condition, injectivity, gauge separation, or BNT data is added.

## Source

- CPSV16 lines 214–250: retained blocks, omitted zero coordinates, literal CF definition, and the separate line-246 convention;
- CPSV16 Appendix A lines 1054–1077: CFII definition and equations.

## Validation

- `lake build TNLean.MPS.CanonicalForm.Definitions` — 3065 jobs
- `lake build` — 9748 jobs
- blueprint source sync — all new declarations resolve; both Chapter 9 entries 100%
- `leanblueprint checkdecls` — exit 0
- double LuaLaTeX — zero undefined cross-references
- reader-facing prose and proof-integrity checks
- `git diff --check origin/main...HEAD`
- independent Lean/source and blueprint re-reviews — no blockers; PR-ready

Closes #4861.
Closes #4862.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal definitions and documentation sync only; no changes to proof logic or runtime behavior, though these predicates will underpin later canonical-form theorems.
> 
> **Overview**
> Introduces **literal CPSV canonical form** in Lean via `CPSVCanonicalFormData` and `IsCPSVCanonicalForm`: retained normal blocks, weights, and an **ambient coisometry** so each physical slice satisfies \(A^i = U^\dagger(\bigoplus_k \mu_k A_k^i)U\) with omitted bond coordinates **exactly zero** (not merely MPV equivalence). **Line-246 weight bounds** (\(|\mu_k|\le 1\), unit modulus when \(A\ne 0\)) live in a separate `IsWeightNormalized` predicate, not in CF membership.
> 
> Adds **CFII** as `CPSVCanonicalFormIIData` / `IsCPSVCanonicalFormII`, extending CF with per-block left-canonical form and a diagonal positive-definite transfer fixed point, plus the implication CFII \(\Rightarrow\) CF.
> 
> **Blueprint Chapter 9** replaces `\notready` stubs: CF is split from BNT, the coisometric \((\mathrm{CF})\) equation is stated explicitly, and CFII is anchored to **Appendix A** with the same ambient embedding. Module docs and imports (`BlockAssembly`, canonical normalization, PosDef/IsDiag) support the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5da7cf6ecca3ddb02d4f543c45ec44195f8c1c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->