### PR TITLE
refactor(Algebra): isolate finite matrix equivalence corollary

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -29,6 +29,7 @@ import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.Algebra.ListProduct
+import TNLean.Algebra.MatrixAlgEquiv
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.MatrixOperatorSpace

--- a/TNLean/Algebra/MatrixAlgEquiv.lean
+++ b/TNLean/Algebra/MatrixAlgEquiv.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.SkolemNoether
+
+/-!
+# Algebra isomorphisms between finite matrix algebras
+
+This file shows that an algebra isomorphism between finite full matrix algebras is inner after
+identifying their matrix sizes.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+/-- An algebra isomorphism between full matrix algebras is conjugation by an
+invertible matrix after the matrix sizes are identified.
+
+Source: arXiv:1804.04964, Section 3, lines 582--586:
+after the insertion correspondence is shown to be an algebra isomorphism
+between full matrix algebras, the paper identifies the two matrix sizes and
+applies Skolem--Noether to obtain an invertible gauge matrix. -/
+theorem matrixAlgEquiv_inner_of_fin {D E : ℕ}
+    (φ : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ) :
+    ∃ h : D = E, ∃ X : GL (Fin E) ℂ,
+      ∀ M : Matrix (Fin D) (Fin D) ℂ,
+        φ M = (X : Matrix (Fin E) (Fin E) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr h) M *
+            ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := by
+  classical
+  have hDE : D = E := matrixAlgEquiv_fin_eq φ
+  let e : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ :=
+    Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDE)
+  let f : Matrix (Fin E) (Fin E) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ :=
+    e.symm.trans φ
+  obtain ⟨X, hX⟩ := skolemNoether_matrix (f := f)
+  refine ⟨hDE, X, ?_⟩
+  intro M
+  calc φ M
+      = f (e M) := by
+          change φ (e.symm (e M)) = φ M
+          rw [AlgEquiv.symm_apply_apply]
+    _ = (X : Matrix (Fin E) (Fin E) ℂ) * e M *
+          ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := hX (e M)
+    _ = (X : Matrix (Fin E) (Fin E) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDE) M *
+          ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := by rfl
+
+end MPSTensor

--- a/TNLean/Algebra/SkolemNoether.lean
+++ b/TNLean/Algebra/SkolemNoether.lean
@@ -19,8 +19,6 @@ This file provides the "abstract algebra" ingredients for the Fundamental Theore
   in a simple ring.
 * `matrixAlgEquiv_fin_eq`: an algebra isomorphism between full matrix algebras
   forces the same matrix size.
-* `matrixAlgEquiv_inner_of_fin`: after this size identification, such an
-  isomorphism is inner.
 * **Skolem–Noether** (`skolemNoether_matrix`): Every algebra automorphism of
   `Matrix n n ℂ` is inner (conjugation by an invertible matrix).
 * **`linearMapToAlgHom`**: Promotes a multiplicative surjective linear map to an algebra
@@ -140,39 +138,6 @@ theorem skolemNoether_matrix {n : Type*} [Fintype n] [DecidableEq n]
     _ = e (X : Matrix n n ℂ) * e M * e ((X⁻¹ : GL n ℂ) : Matrix n n ℂ) := by
         rw [← hX_lin, ← hX_lin_inv]; simp [Module.End.mul_eq_comp, LinearMap.comp_assoc]
     _ = e ((X : Matrix n n ℂ) * M * ((X⁻¹ : GL n ℂ) : Matrix n n ℂ)) := by simp [mul_assoc]
-
-/-- An algebra isomorphism between full matrix algebras is conjugation by an
-invertible matrix after the matrix sizes are identified.
-
-Source: arXiv:1804.04964, Section 3, lines 582--586:
-after the insertion correspondence is shown to be an algebra isomorphism
-between full matrix algebras, the paper identifies the two matrix sizes and
-applies Skolem--Noether to obtain an invertible gauge matrix. -/
-theorem matrixAlgEquiv_inner_of_fin {D E : ℕ}
-    (φ : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ) :
-    ∃ h : D = E, ∃ X : GL (Fin E) ℂ,
-      ∀ M : Matrix (Fin D) (Fin D) ℂ,
-        φ M = (X : Matrix (Fin E) (Fin E) ℂ) *
-            Matrix.reindexAlgEquiv ℂ ℂ (finCongr h) M *
-            ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := by
-  classical
-  have hDE : D = E := matrixAlgEquiv_fin_eq φ
-  let e : Matrix (Fin D) (Fin D) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ :=
-    Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDE)
-  let f : Matrix (Fin E) (Fin E) ℂ ≃ₐ[ℂ] Matrix (Fin E) (Fin E) ℂ :=
-    e.symm.trans φ
-  obtain ⟨X, hX⟩ := skolemNoether_matrix (f := f)
-  refine ⟨hDE, X, ?_⟩
-  intro M
-  calc φ M
-      = f (e M) := by
-          change φ (e.symm (e M)) = φ M
-          rw [AlgEquiv.symm_apply_apply]
-    _ = (X : Matrix (Fin E) (Fin E) ℂ) * e M *
-          ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := hX (e M)
-    _ = (X : Matrix (Fin E) (Fin E) ℂ) *
-          Matrix.reindexAlgEquiv ℂ ℂ (finCongr hDE) M *
-          ((X⁻¹ : GL (Fin E) ℂ) : Matrix (Fin E) (Fin E) ℂ) := by rfl
 
 /-- Promote a multiplicative surjective $\C$-linear map
 $T : \MN{D} \to \MN{D}$ to a $\C$-algebra homomorphism. The key step is

--- a/TNLean/PEPS/EdgeGaugeExtraction.lean
+++ b/TNLean/PEPS/EdgeGaugeExtraction.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.SkolemNoether
+import TNLean.Algebra.MatrixAlgEquiv
 import TNLean.PEPS.Defs
 
 /-!


### PR DESCRIPTION
## What changed

- move `MPSTensor.matrixAlgEquiv_inner_of_fin` unchanged from the Skolem--Noether core into a dedicated `TNLean.Algebra.MatrixAlgEquiv` leaf;
- update its sole Lean consumer, `TNLean.PEPS.EdgeGaugeExtraction`, to import that leaf;
- export the new module from the generated Algebra aggregator;
- preserve the theorem's fully qualified name, statement, proof, and Chapter 24 blueprint tag.

This is the conservative P5 design from #4847: edits to the consumer-facing corollary now rebuild a 129-module handwritten cone rather than the former 559-module core cone (about 77% smaller). It does **not** claim to shrink the reverse cone of `SkolemNoether` itself; the new leaf still imports that core.

## Validation

- `lake build TNLean.Algebra.MatrixAlgEquiv`
- `lake build TNLean.PEPS.EdgeGaugeExtraction`
- `lake build TNLean.Algebra`
- `lake build` — 9748 jobs
- generated import aggregators current: 46 aggregators / 1043 production modules
- module-policy, oversized-module, numbered-module, proof-integrity, and Lean text-style checks
- blueprint source sync and declaration checks; both Chapter 24 tags resolve
- `git diff --check origin/main...HEAD`
- independent no-edit review: no blockers; PR-ready after rebase

Advances #4847 (P5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-preserving module move with a single consumer import update; no logic or API changes beyond where the theorem lives.
> 
> **Overview**
> **`MPSTensor.matrixAlgEquiv_inner_of_fin`** is moved unchanged from `TNLean.Algebra.SkolemNoether` into a new leaf module **`TNLean.Algebra.MatrixAlgEquiv`**, which still depends on Skolem–Noether for `matrixAlgEquiv_fin_eq` and `skolemNoether_matrix`.
> 
> **`TNLean.PEPS.EdgeGaugeExtraction`** now imports **`MatrixAlgEquiv`** instead of the full Skolem–Noether core, and the generated **`TNLean.Algebra`** aggregator exports the new module. The theorem name, statement, proof, and blueprint references stay the same—this is an import-graph split so PEPS edge-gauge work rebuilds a much smaller cone when only that corollary changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d371f5bbc2358f8fdf8265d52abc3369190900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->