### PR TITLE
fix(tenkz): close post-merge review gaps

### DIFF
--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -80,6 +80,43 @@ and~\cite{Evans1978Spectral}.
     $\dim\ker A\leq D-1$, which proves (\ref{eq:qpf_growth_pd}).
 \end{proof}
 
+\begin{theorem}[Kernel inclusion forces positive definiteness]
+    \label{thm:kernel_inclusion_pd_irred}
+    \lean{posDef_of_ker_subset_irreducible_cp}
+    \leanok
+    \uses{def:irreducible_cp}
+    Let $E$ be an irreducible completely positive map on $\MN{D}$.
+    If $\rho\geq0$, $\rho\neq0$, and
+    \begin{align}
+        \ker\rho
+         & \subseteq\ker E(\rho),
+        \notag
+    \end{align}
+    then $\rho$ is positive definite.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $E(X)=\sum_i K_iXK_i^\dagger$ and let $Q$ be the support
+    projection of $\rho$.  For $v\in\ker\rho$, the kernel inclusion gives
+    \begin{align}
+        0
+         & =v^\dagger E(\rho)v
+          =\sum_i(K_i^\dagger v)^\dagger\rho(K_i^\dagger v).
+        \notag
+    \end{align}
+    Every summand is non-negative, so
+    $K_i^\dagger(\ker\rho)\subseteq\ker\rho$ for every~$i$.  Equivalently,
+    \begin{align}
+        Q E(QXQ)Q
+         & =E(QXQ)
+        \qquad\text{for every }X.
+        \notag
+    \end{align}
+    Irreducibility forces $Q\in\{0,I\}$, while $\rho\neq0$ rules out
+    $Q=0$.  Thus $Q=I$, so $\ker\rho=\{0\}$ and $\rho>0$.
+\end{proof}
+
 \begin{theorem}[PSD eigenvectors are positive definite]
     \label{thm:psd_eigenvector_pd_irred}
     \lean{posDef_of_posSemidef_eigenvector_irreducible_cp}
@@ -92,6 +129,7 @@ and~\cite{Evans1978Spectral}.
 
 \begin{proof}
     \leanok
+    \uses{thm:kernel_inclusion_pd_irred}
     The eigenvector equation gives
     \begin{align}
         \ker\rho
@@ -273,7 +311,7 @@ and~\cite{Evans1978Spectral}.
     The Perron--Frobenius existence theorem
     (Theorem~\ref{thm:pf_eigenvector_existence}) together with the
     irreducible positive-definiteness upgrade
-    (Theorem~\ref{thm:psd_fp_pd_irred}) gives a positive definite
+    (Theorem~\ref{thm:psd_eigenvector_pd_irred}) gives a positive definite
     eigenvector $\tau > 0$ with eigenvalue $t > 0$:
     $E^\dagger(\tau) = t\tau$.
     For any nonzero positive semidefinite $X$ with $E(X) = sX$, the

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -107,10 +107,10 @@ and~\cite{Evans1978Spectral}.
     \end{align}
     Every summand is non-negative, so
     $K_i^\dagger(\ker\rho)\subseteq\ker\rho$ for every~$i$.  Equivalently,
+    for every~$X$,
     \begin{align}
         Q E(QXQ)Q
-         & =E(QXQ)
-        \qquad\text{for every }X.
+         & =E(QXQ).
         \notag
     \end{align}
     Irreducibility forces $Q\in\{0,I\}$, while $\rho\neq0$ rules out

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -136,9 +136,9 @@ and~\cite{Evans1978Spectral}.
          & =\ker E(\rho).
         \notag
     \end{align}
-    Hence $\ker\rho\subseteq\ker E(\rho)$.  Irreducibility forces every
-    nonzero positive semidefinite matrix with this kernel inclusion to have
-    trivial kernel, so $\rho$ is positive definite.
+    Hence $\ker\rho\subseteq\ker E(\rho)$.
+    Theorem~\ref{thm:kernel_inclusion_pd_irred} then forces $\rho$ to be
+    positive definite.
 \end{proof}
 
 \begin{theorem}[PSD fixed point is positive definite --- irreducible version]

--- a/blueprint/src/chapter/ch06_qpf.tex
+++ b/blueprint/src/chapter/ch06_qpf.tex
@@ -80,6 +80,29 @@ and~\cite{Evans1978Spectral}.
     $\dim\ker A\leq D-1$, which proves (\ref{eq:qpf_growth_pd}).
 \end{proof}
 
+\begin{theorem}[PSD eigenvectors are positive definite]
+    \label{thm:psd_eigenvector_pd_irred}
+    \lean{posDef_of_posSemidef_eigenvector_irreducible_cp}
+    \leanok
+    \uses{def:irreducible_cp}
+    Let $E$ be an irreducible completely positive map on $\MN{D}$.
+    If $\rho\geq0$, $\rho\neq0$, $r>0$, and
+    $E(\rho)=r\rho$, then $\rho$ is positive definite.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The eigenvector equation gives
+    \begin{align}
+        \ker\rho
+         & =\ker E(\rho).
+        \notag
+    \end{align}
+    Hence $\ker\rho\subseteq\ker E(\rho)$.  Irreducibility forces every
+    nonzero positive semidefinite matrix with this kernel inclusion to have
+    trivial kernel, so $\rho$ is positive definite.
+\end{proof}
+
 \begin{theorem}[PSD fixed point is positive definite --- irreducible version]
     \label{thm:psd_fp_pd_irred}
     \lean{MPSTensor.posSemidef_fixedPoint_isPosDef_of_irreducible}
@@ -134,7 +157,7 @@ and~\cite{Evans1978Spectral}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:psd_fp_pd_irred}
+    \uses{thm:injective_irreducible, thm:psd_fp_pd_irred}
     Injectivity implies irreducibility of the transfer map. Apply
     Theorem~\ref{thm:psd_fp_pd_irred}.
 \end{proof}
@@ -222,7 +245,7 @@ and~\cite{Evans1978Spectral}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:psd_fp_unique_irred}
+    \uses{thm:injective_irreducible, thm:psd_fp_unique_irred}
     Injectivity implies irreducibility of the transfer map. Apply
     Theorem~\ref{thm:psd_fp_unique_irred}.
 \end{proof}
@@ -242,7 +265,7 @@ and~\cite{Evans1978Spectral}.
 
 \begin{proof}
     \leanok
-    \uses{thm:pf_eigenvector_existence, thm:psd_fp_pd_irred}
+    \uses{thm:pf_eigenvector_existence, thm:psd_eigenvector_pd_irred}
     Extract Kraus operators $K$ for $E$.
     Irreducibility of $E$ passes to the adjoint transfer map
     $E^\dagger(X) = \sum_i K_i^\dagger X K_i$,
@@ -763,14 +786,15 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
 \begin{proof}
     \leanok
     \uses{lem:cesaro_mean_density, lem:cesaro_subseq_fixed,
-        thm:psd_fp_pd_irred, thm:psd_fp_unique_irred}
+        thm:psd_eigenvector_pd_irred, thm:psd_eigenvector_unique_irred}
     Every Ces\`aro mean (\ref{eq:channel_cesaro_mean}) of a density matrix
     stays inside the compact convex set of density matrices, so a subsequence
-    converges.
-    Its limit is a fixed point by the telescope identity
-    (\ref{eq:channel_cesaro_telescope}), positive definiteness follows from
-    irreducibility, and uniqueness comes from the uniqueness of positive
-    semidefinite Perron eigenvectors at eigenvalue~$1$.
+    converges to a density matrix~$\sigma$.  The telescope identity
+    (\ref{eq:channel_cesaro_telescope}) gives
+    $E(\sigma)=\sigma$.  Theorem~\ref{thm:psd_eigenvector_pd_irred}
+    makes $\sigma$ positive definite.  If $\tau$ is another density-matrix
+    fixed point, Theorem~\ref{thm:psd_eigenvector_unique_irred} gives
+    $\tau=c\sigma$.  Taking traces yields $1=c$, hence $\tau=\sigma$.
 \end{proof}
 
 \begin{theorem}[Ces\`aro convergence for irreducible channels]

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -512,7 +512,7 @@ grep -Fq 'check|relation=3|result=off|reason=third' \
   echo "FAIL: the later equation opt-out was silently dropped" >&2
   exit 1
 }
-echo "PASS: forty-five review regressions hold"
+echo "PASS: forty-seven review regressions hold"
 
 fail=0
 for pair in s1 s2 s3 s4 s5 s6 s7 s8; do

--- a/tests/tenkz/kernel/regression/r_midway.tex
+++ b/tests/tenkz/kernel/regression/r_midway.tex
@@ -1,0 +1,16 @@
+% Regression: midway resolves both named operands before placing the atom.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={ket}, cols=2, bonds=none]
+  \tn[name=A]{A} & \tn[name=B]{B}
+  \tn[at={midway A and B}, name=M]{M}
+\end{tenkz}
+\mbox{parsed}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_route_all_faces.tex
+++ b/tests/tenkz/kernel/regression/r_route_all_faces.tex
@@ -1,0 +1,30 @@
+% Regression: an all-side route gives each crossed leg the lane of the face
+% that leg leaves, even when the measured hull is asymmetric.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\ExplSyntaxOn
+\prop_clear:N \l__tenkz_kernel_ro_legs_prop
+\fp_set:Nn \l__tenkz_kernel_ro_y_fp {-1}
+\fp_set:Nn \l__tenkz_kernel_ro_yb_fp {4}
+\tl_set:Nn \l__tenkz_kernel_ro_lane_tl {4}
+\tl_set:Nn \l__tenkz_kernel_ro_tau_tl {0}
+\__tenkz_kernel_r_route_leg:nn {{n}{1}{1}} {wire-1}
+\__tenkz_kernel_r_route_leg:nn {{s}{2}{1}} {wire-1}
+\prop_get:NnN \l__tenkz_kernel_ro_legs_prop
+  {leg-n-1-1} \l_tmpa_tl
+\tl_if_eq:NnF \l_tmpa_tl {{{4}{0}}}
+  { \errmessage{the north leg did not receive the north lane} }
+\prop_get:NnN \l__tenkz_kernel_ro_legs_prop
+  {leg-s-2-1} \l_tmpa_tl
+\tl_if_eq:NnF \l_tmpa_tl {{{-1}{0}}}
+  { \errmessage{the south leg received the north lane} }
+\ExplSyntaxOff
+\mbox{parsed}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -4567,6 +4567,14 @@
           \l__tenkz_kernel_ro_lane_tl
         \quark_if_no_value:NF \l__tenkz_kernel_ro_lane_tl
           {
+            % The drawn route needs one lane coordinate, but its crossing
+            % legs need the coordinate of the face each leg leaves.  Restore
+            % the whole measured box here so an all-side route does not make
+            % a south leg chase its north edge.
+            \prop_get:NnN \l__tenkz_kernel_ro_box_prop {##1}
+              \l__tenkz_kernel_ro_b_tl
+            \exp_last_unbraced:NV \__tenkz_kernel_r_route_box:nnnnn
+              \l__tenkz_kernel_ro_b_tl
             \seq_map_inline:Nn \l__tenkz_kernel_ro_leg_seq
               { \__tenkz_kernel_r_route_leg:nn {####1} {##1} }
           }
@@ -4583,9 +4591,26 @@
       }
     \prop_put:NVn \l__tenkz_kernel_r_legref_prop
       \l__tenkz_kernel_ro_b_tl {#2}
-    % Every lane travels with the axes it is a coordinate in.  Bare lane
-    % scalars from differently turned selections cannot be ordered, so retain
-    % all pairs and let the leg project each one into its own direction.
+    % Every lane travels with the axes it is a coordinate in.  For an
+    % all-side route, choose the edge of the face this leg actually leaves:
+    % north and south are distinct coordinates whenever the hull is not
+    % symmetric.  Bare lane scalars from differently turned selections cannot
+    % be ordered, so retain all pairs and let the leg project each one into
+    % its own direction.
+    \tl_set:Ne \l__tenkz_kernel_ro_side_tl { \tl_item:nn {#1} {1} }
+    \str_case:Vn \l__tenkz_kernel_ro_side_tl
+      {
+        {n}
+          {
+            \tl_set:Ne \l__tenkz_kernel_ro_lane_tl
+              { \fp_eval:n { \l__tenkz_kernel_ro_yb_fp } }
+          }
+        {s}
+          {
+            \tl_set:Ne \l__tenkz_kernel_ro_lane_tl
+              { \fp_eval:n { \l__tenkz_kernel_ro_y_fp } }
+          }
+      }
     \tl_set:Ne \l__tenkz_kernel_ro_row_tl
       {
         {


### PR DESCRIPTION
## Summary

Closes the late review gaps discovered after the tenkz/RMP campaign merged:

- makes the Chapter 6 QPF dependency graph and proofs match the stated generality;
- fixes all-side route crossing legs to use their own measured north/south faces;
- adds direct regressions for asymmetric all-face routes and `at={midway A and B}`;
- updates the kernel regression census to 47.

## Regression evidence

- `scripts/tenkz_kernel_probes.sh --check`
- historical route fixture fails on the merged #4825 head and passes here
- historical midway fixture fails before the placement fix and passes here
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `leanblueprint pdf`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `lake build`

Follow-up to #4807, #4820, and #4825. The source-digest concern on #4826 was separately revalidated against the committed case files: 17/17 section checks and 130/130 comparison mappings pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to blueprint exposition/Lean sync and tenkz kernel routing with targeted regressions; no auth, data, or production runtime paths.
> 
> **Overview**
> Aligns **Chapter 6 QPF** with the stated generality for irreducible CP maps: new results that kernel inclusion \(\ker\rho\subseteq\ker E(\rho)\) and positive eigenvectors \(E(\rho)=r\rho\) force \(\rho>0\), with proofs wired through **Lean** labels. Downstream proofs now cite these eigenvector theorems (e.g. uniqueness of positive eigenvalues and irreducible channel fixed points) instead of fixed-point-only upgrades, and injective cases explicitly use **injectivity \(\Rightarrow\) irreducibility**.
> 
> In **tenkz**, all-side **route** crossing legs no longer inherit a single route lane for every side: north legs use the measured **north** edge (\(y_b\)) and south legs the **south** edge (\(y\)), with the full measured box restored before leg routing. Adds kernel regressions for asymmetric all-face routes and `at={midway A and B}`; bumps the probe census to **47**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968122745eecd0644e4ef4e4329c2e3fdc550a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->