### PR TITLE
test(tenkz): assert midway coordinates

### DIFF
--- a/tests/tenkz/kernel/regression/r_midway.tex
+++ b/tests/tenkz/kernel/regression/r_midway.tex
@@ -4,6 +4,51 @@
 \makeatletter
 \ExplSyntaxOn
 \file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOn
+\fp_new:N \l__tenkz_test_ax_fp
+\fp_new:N \l__tenkz_test_ay_fp
+\fp_new:N \l__tenkz_test_bx_fp
+\fp_new:N \l__tenkz_test_by_fp
+\fp_new:N \l__tenkz_test_mx_fp
+\fp_new:N \l__tenkz_test_my_fp
+\tl_new:N \l__tenkz_test_id_tl
+\cs_new_protected:Npn \__tenkz_test_xy:nNN #1#2#3
+  {
+    \prop_get:NnN \l__tenkz_kernel_named_prop {#1}
+      \l__tenkz_test_id_tl
+    \exp_args:NV \__tenkz_kernel_r_xy:nNN \l__tenkz_test_id_tl #2#3
+  }
+\cs_new_eq:NN \__tenkz_test_render: \__tenkz_kernel_render:
+\cs_set_protected:Npn \__tenkz_kernel_render:
+  {
+    \__tenkz_test_render:
+    \__tenkz_test_xy:nNN {A}
+      \l__tenkz_test_ax_fp \l__tenkz_test_ay_fp
+    \__tenkz_test_xy:nNN {B}
+      \l__tenkz_test_bx_fp \l__tenkz_test_by_fp
+    \__tenkz_test_xy:nNN {M}
+      \l__tenkz_test_mx_fp \l__tenkz_test_my_fp
+    \fp_compare:nNnF
+      {
+        abs
+          (
+            \l__tenkz_test_mx_fp
+            - ( \l__tenkz_test_ax_fp + \l__tenkz_test_bx_fp ) / 2
+          )
+      }
+      < { 0.000001 }
+      { \errmessage{midway~x-coordinate~is~not~the~operand~midpoint} }
+    \fp_compare:nNnF
+      {
+        abs
+          (
+            \l__tenkz_test_my_fp
+            - ( \l__tenkz_test_ay_fp + \l__tenkz_test_by_fp ) / 2
+          )
+      }
+      < { 0.000001 }
+      { \errmessage{midway~y-coordinate~is~not~the~operand~midpoint} }
+  }
 \ExplSyntaxOff
 \makeatother
 \begin{document}


### PR DESCRIPTION
## Summary

Closes the final post-merge advisory on #4876 by making the `midway` regression verify geometry, not merely parsing:

- reads the resolved coordinates of `A`, `B`, and `M` after rendering;
- asserts both coordinates of `M` equal the corresponding operand midpoint;
- emits a hard test error when either coordinate drifts.

## Evidence

- the unchanged fixture compiles under XeLaTeX;
- a temporary copy with `M.x` perturbed by `0.1` fails with `midway x-coordinate is not the operand midpoint`;
- `scripts/tenkz_kernel_probes.sh --check`.

Follow-up to #4876.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a kernel regression fixture; no production tenkz code is modified.
> 
> **Overview**
> Strengthens the **`midway`** kernel regression so it checks **geometry**, not only that the fixture parses.
> 
> The test hooks `\__tenkz_kernel_render:` after the normal render path, reads resolved **x/y** for named atoms **A**, **B**, and **M** via the named-prop and `\__tenkz_kernel_r_xy:nNN`, then **fails compilation** with `\errmessage` if **M** is not within `1e-6` of the midpoint of **A** and **B** on either axis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccc1532d715b653febb1ab78bb76f453bbee9289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->