### PR TITLE
feat(canonical-form): expose the CPSV closed-chain expansion

### DIFF
--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -208,6 +208,49 @@ def IsCPSVCanonicalForm (A : MPSTensor d D) : Prop :=
 
 namespace CPSVCanonicalFormData
 
+/-- The weighted direct sum of positive-dimensional normal blocks is in literal
+CPSV canonical form, with the retained coordinates equal to the ambient
+coordinates.
+
+Source: arXiv:1606.00608, eq. `II_CF1`, lines 237--244. -/
+noncomputable def ofBlocks {r : ℕ} {dim : Fin r → ℕ}
+    (dim_pos : ∀ k, 0 < dim k) (weights : Fin r → ℂ)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (blocks_normal : ∀ k, IsNormalTensor (blocks k)) :
+    CPSVCanonicalFormData (toTensorFromBlocks (d := d) weights blocks) where
+  r := r
+  dim := dim
+  dim_pos := dim_pos
+  weights := weights
+  blocks := blocks
+  blocks_normal := blocks_normal
+  total_dim_le := le_rfl
+  ambient_coisometry := 1
+  coisometric := by simp
+  reconstruct := by simp
+
+/-- Literal CPSV canonical-form data reconstruct the same positive-length MPV
+family as their retained weighted direct sum.
+
+Source: arXiv:1606.00608, eq. `II_CF1`, lines 237--244. -/
+theorem sameMPV₂Pos_toTensorFromBlocks (data : CPSVCanonicalFormData A) :
+    SameMPV₂Pos A (toTensorFromBlocks (d := d) data.weights data.blocks) :=
+  sameMPV₂Pos_of_coisometry_reconstruction A
+    (toTensorFromBlocks (d := d) data.weights data.blocks)
+    data.ambient_coisometry data.coisometric data.reconstruct
+
+/-- The closed-chain coefficients of a CPSV canonical-form tensor are the
+sum of the block coefficients weighted by the corresponding powers.
+
+Source: arXiv:1606.00608, eq. `II_Psi_k`, lines 259--263. -/
+theorem mpv_eq_sum_weight_pow (data : CPSVCanonicalFormData A)
+    {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin d) :
+    mpv A σ =
+      ∑ k : Fin data.r, data.weights k ^ N * mpv (data.blocks k) σ := by
+  rw [data.sameMPV₂Pos_toTensorFromBlocks N hN σ]
+  simpa [smul_eq_mul] using
+    mpv_toTensorFromBlocks_eq_sum data.weights data.blocks σ
+
 /-- CPSV16 line 246's weight convention, separated from literal canonical-form
 membership.  The unit weight is required exactly when the ambient tensor is
 nonzero; no retained weight is required to be nonzero.

--- a/TNLean/MPS/MPDO/VerticalBlockedOperatorRepresentations.lean
+++ b/TNLean/MPS/MPDO/VerticalBlockedOperatorRepresentations.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
 import TNLean.MPS.MPDO.VerticalSectorCoefficientComparison
-import TNLean.Analysis.CoisometricCompression
+import TNLean.MPS.SharedInfra.BlockAssembly
 import TNLean.MPS.Tactic.Basic
 
 /-!
@@ -45,48 +45,6 @@ theorem verticalBNTMPO_verticalTensor_blockTwo (M : MPOTensor d D) :
     Matrix.mul_apply, Matrix.sum_apply, Matrix.submatrix_apply,
     Matrix.kroneckerMap_apply]
 
-end MPOTensor
-
-namespace MPSTensor
-
-/-- A tensor reconstructed through a coisometry has the same positive-length
-closed-chain coefficients as the tensor on the retained space.
-
-The positive-length restriction is necessary because the two tensors may
-have different bond dimensions. This is the trace-preserving reconstruction
-used for CPSV16, Appendix C.4, lines 2011--2018; the reconstruction itself is
-the vertical canonical-form relation of Proposition 4.13, lines 1863--1870. -/
-theorem sameMPV₂Pos_of_coisometry_reconstruction
-    {s d n : ℕ} (T : MPSTensor s d) (B : MPSTensor s n)
-    (U : Matrix (Fin n) (Fin d) ℂ)
-    (hU : U * Uᴴ = 1)
-    (hReconstruct : ∀ v, T v = Uᴴ * B v * U) :
-    SameMPV₂Pos T B := by
-  mpv_ext
-  have hEval : ∀ (v : Fin s) (w : List (Fin s)),
-      evalWord T (v :: w) = Uᴴ * evalWord B (v :: w) * U := by
-    intro v w
-    induction w generalizing v with
-    | nil => simp [hReconstruct]
-    | cons v' w ih =>
-      change T v * evalWord T (v' :: w) =
-        Uᴴ * (B v * evalWord B (v' :: w)) * U
-      rw [hReconstruct v, ih v']
-      simp only [Matrix.mul_assoc]
-      rw [← Matrix.mul_assoc U Uᴴ, hU, Matrix.one_mul]
-  have hword : List.ofFn σ ≠ [] := by
-    intro hzero
-    have hlength := congrArg List.length hzero
-    simp only [List.length_ofFn, List.length_nil] at hlength
-    omega
-  obtain ⟨v, w, hw⟩ := List.exists_cons_of_ne_nil hword
-  simp only [mpv, coeff, hw]
-  rw [hEval v w]
-  exact Matrix.trace_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one U hU _
-
-end MPSTensor
-
-namespace MPOTensor
 
 variable {D g : ℕ} {dim mult : Fin g → ℕ}
 

--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -3,16 +3,19 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Analysis.CoisometricCompression
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.Overlap.Basic
+import TNLean.MPS.Tactic.Basic
 
 /-!
 # Shared direct-sum tensor infrastructure for MPS tensors
 
 This file factors out the lightweight block-diagonal tensor constructor
-`toTensorFromBlocks`, its word-evaluation expansion, and its MPV expansion
-formula so shared infrastructure can depend on direct-sum tensor formulas
-without importing gauge-equivalence theorems.
+`toTensorFromBlocks`, its word-evaluation and MPV expansions, and
+`sameMPV₂Pos_of_coisometry_reconstruction`. Shared infrastructure can therefore
+use direct-sum and coisometric-reconstruction formulas without importing
+gauge-equivalence theorems.
 -/
 
 open scoped Matrix BigOperators
@@ -54,6 +57,39 @@ theorem evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal
         (Matrix.blockDiagonal' fun k => (μ k) ^ w.length • evalWord (A k) w) := by
       congr 1
       simpa [BD] using evalWord_blockDiagonal'_smul (μ := μ) (A := A) w
+
+/-- A tensor reconstructed through a coisometry has the same positive-length
+closed-chain coefficients as the tensor on the retained space.
+
+The positive-length restriction is necessary because the tensors may have
+different bond dimensions, hence different length-zero traces. -/
+theorem sameMPV₂Pos_of_coisometry_reconstruction
+    {s d n : ℕ} (T : MPSTensor s d) (B : MPSTensor s n)
+    (U : Matrix (Fin n) (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ v, T v = Uᴴ * B v * U) :
+    SameMPV₂Pos T B := by
+  mpv_ext
+  have hEval : ∀ (v : Fin s) (w : List (Fin s)),
+      evalWord T (v :: w) = Uᴴ * evalWord B (v :: w) * U := by
+    intro v w
+    induction w generalizing v with
+    | nil => simp [hReconstruct]
+    | cons v' w ih =>
+      change T v * evalWord T (v' :: w) =
+        Uᴴ * (B v * evalWord B (v' :: w)) * U
+      rw [hReconstruct v, ih v']
+      simp only [Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc U Uᴴ, hU, Matrix.one_mul]
+  have hword : List.ofFn σ ≠ [] := by
+    intro hzero
+    have hlength := congrArg List.length hzero
+    simp only [List.length_ofFn, List.length_nil] at hlength
+    omega
+  obtain ⟨v, w, hw⟩ := List.exists_cons_of_ne_nil hword
+  simp only [mpv, coeff, hw]
+  rw [hEval v w]
+  exact Matrix.trace_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one U hU _
 
 /-- MPV of `toTensorFromBlocks` expands as a sum over blocks. -/
 theorem mpv_toTensorFromBlocks_eq_sum

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -320,6 +320,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \begin{definition}[CPSV canonical form]
     \label{def:cpsv_canonical_form}
     \lean{MPSTensor.CPSVCanonicalFormData}
+    \lean{MPSTensor.CPSVCanonicalFormData.ofBlocks}
+    \lean{MPSTensor.CPSVCanonicalFormData.sameMPV₂Pos_toTensorFromBlocks}
     \lean{MPSTensor.IsCPSVCanonicalForm}
     \lean{MPSTensor.CPSVCanonicalFormData.IsWeightNormalized}
     \leanok
@@ -356,6 +358,52 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     The basis-of-normal-tensors refinement is
     Definition~\ref{def:bnt}; it is not part of canonical form itself.
 \end{definition}
+
+\begin{theorem}[Closed-chain expansion of CPSV canonical form]
+    \label{thm:cpsv_canonical_form_mpv_expansion}
+    \lean{MPSTensor.CPSVCanonicalFormData.mpv_eq_sum_weight_pow}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:mpv}
+    % Maintainer source anchor: CPSV16 eq:II_Psi_k, lines 259--263.
+    For canonical-form data as in~(\ref{eq:cpsv_canonical_form}), every
+    positive length~$N$ and every configuration~$\sigma$ satisfy
+    \begin{align}
+        V^{(N)}(A)_\sigma
+         & =\sum_{k=1}^{r}\mu_k^N V^{(N)}(A_k)_\sigma.
+        \label{eq:cpsv_canonical_form_mpv_expansion}
+    \end{align}
+    Equivalently,
+    $\ket{V^{(N)}(A)}=\sum_{k=1}^{r}\mu_k^N\ket{V^{(N)}(A_k)}$.
+    This is the identity immediately following the canonical-form definition
+    in~\cite[Section~2.3]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:cpsv_canonical_form, thm:mpv_decomposition}
+    Induction on a nonempty physical word~$w$ of length~$N$, using
+    (\ref{eq:cpsv_canonical_form}) at each letter and
+    $UU^\dagger=\Id_S$ between adjacent letters, gives
+    \begin{align}
+        A^w
+         & =U^\dagger
+            \left(\bigoplus_{k=1}^{r}\mu_k^N A_k^w\right)U.
+        \label{eq:cpsv_canonical_form_word_reconstruction}
+    \end{align}
+    Applying cyclicity of the trace and $UU^\dagger=\Id_S$ to
+    (\ref{eq:cpsv_canonical_form_word_reconstruction}) gives
+    \begin{align}
+        \tr(A^w)
+         & =\tr\!\left(
+            \left(\bigoplus_{k=1}^{r}\mu_k^N A_k^w\right)UU^\dagger
+            \right)
+          =\tr\!\left(\bigoplus_{k=1}^{r}\mu_k^N A_k^w\right).
+        \label{eq:cpsv_canonical_form_trace_reconstruction}
+    \end{align}
+    Applying Theorem~\ref{thm:mpv_decomposition} to the right-hand side of
+    (\ref{eq:cpsv_canonical_form_trace_reconstruction}) yields
+    $\tr(A^w)=\sum_{k=1}^{r}\mu_k^N\tr(A_k^w)$, which is
+    (\ref{eq:cpsv_canonical_form_mpv_expansion}).
+\end{proof}
 
 The projector-closure result in
 Theorem~\ref{thm:projector_closure_canonical_form} gives normal blocks and


### PR DESCRIPTION
## What changed

- add the identity-coordinate `CPSVCanonicalFormData.ofBlocks` constructor for weighted direct sums of positive-dimensional normal blocks
- derive positive-length MPV equality from the literal CPSV reconstruction data
- expose the exact CPSV16 `eq:II_Psi_k` expansion
  \[
  \operatorname{mpv}(A,\sigma)=\sum_k \mu_k^N\operatorname{mpv}(A_k,\sigma),\qquad N>0
  \]
- move the generic coisometric-reconstruction lemma from the MPDO module to shared block-assembly infrastructure
- add formula-first Chapter 9 coverage without adding BNT, spectral-ordering, injectivity, or weight-normalization assumptions

## Source

CPSV16 `eq:II_CF1` (lines 237--244), line 246, and `eq:II_Psi_k` (lines 259--263) in `Papers/1606.00608/MPDO-22-12-17-2.tex`.

## Validation

- targeted canonical-form, shared-infrastructure, and downstream MPDO builds
- full `lake build` (9748 jobs)
- generated-import and Lean module-policy gates
- style and proof-integrity checks
- blueprint declaration regeneration, synchronization, and `checkdecls`
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'`
- independent source/API review; no blockers

Closes #4880. Advances #2380 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and module-layer refactor only; MPDO callers keep the same lemma via `BlockAssembly`. No auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds **literal CPSV canonical-form API** on top of existing `CPSVCanonicalFormData`: `ofBlocks` shows a weighted direct sum of positive-dimensional normal blocks is canonical with identity coisometry; `sameMPV₂Pos_toTensorFromBlocks` and **`mpv_eq_sum_weight_pow`** give the CPSV16 positive-length identity \(\mathrm{mpv}(A,\sigma)=\sum_k \mu_k^N \mathrm{mpv}(A_k,\sigma)\).
> 
> **Refactors** `sameMPV₂Pos_of_coisometry_reconstruction` from `VerticalBlockedOperatorRepresentations` into **`BlockAssembly`** (with `CoisometricCompression` / tactic imports), so canonical-form and MPDO code share coisometric MPV invariance without duplicating the proof.
> 
> **Blueprint** Chapter 9 links the new Lean names and adds a theorem/proof for the closed-chain expansion (`eq:II_Psi_k`), without extra BNT or weight-normalization assumptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95797711ecd7d5609a63f90f7db3d016fc75c9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->