### PR TITLE
docs(blueprint): align Chapter 26 with literal CPSV terminology

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_appendix_b_supports.tex
@@ -473,7 +473,7 @@
     \lean{MPSTensor.ResidualFamilyAppendixBData.twoSiteBondSupportProjection_eq_complement}
     \lean{MPSTensor.IsBNTCanonicalForm.exists_residualFamilyAppendixBData}
     \leanok
-    \uses{lem:residual_isometry_family_one_gram,
+    \uses{thm:residual_isometry_family_one_gram,
         def:residual_family_two_site_support,
         thm:appendixB_two_site_basic_embedding_range,
         def:parent_interaction}

--- a/blueprint/src/chapter/ch26_mps_rfp.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp.tex
@@ -8,7 +8,7 @@
 
 This chapter develops renormalization fixed points for matrix product vectors.
 It compares physical two-site blocking, idempotence of the transfer map, and
-zero correlation length, and then gives the isometry canonical form of the
+zero correlation length, and then gives the square-root fixed-point form of the
 fixed points.  The organization follows the pure-state analysis of
 \cite[Section~3]{Cirac2016MPDO_arXiv}.
 

--- a/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_direct_sums_residual_isometries.tex
@@ -1,4 +1,4 @@
-\section{Direct sums and residual isometries}
+\section{Direct sums and the joint isometry condition}
 
 \begin{lemma}[Block decomposition of the direct-sum transfer map]%
     \label{lem:block_diagonal_transfer_sum_to_block}
@@ -150,7 +150,7 @@
     =\mu_{q'}$.
 
 % Scope note: this is the corrected literal-block conclusion from
-% \cite[Theorem~III, lines~543--563]{Cirac2016MPDO_arXiv}; the printed
+% \cite[Theorem~3.11, lines~543--563]{Cirac2016MPDO_arXiv}; the printed
 % independent-phase statement requires a physical-space construction not
 % specified by an equation in that passage.
 \end{proof}
@@ -167,8 +167,8 @@
     distinct components the mixed transfer operator vanishes,
     $\E_{j,j'}=\sum_iA_j^i\otimes\overline{A_{j'}^i}=0$.
     This is the cross-block ($\delta_{j,j'}$) content of the isometry condition
-    of \cite[Theorem~III \& Corollary~III.3]{Cirac2016MPDO_arXiv} at the level of
-    the normal-tensor blocks; converting it to the residual isometries $U_j$ is a
+    of \cite[Theorem~3.11 and Corollary~3.12]{Cirac2016MPDO_arXiv} at the level of
+    the normal-tensor blocks; converting it to the isometries $U_j$ is a
     further step left open.
 % The U-level conversion is recorded in docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
 \end{theorem}
@@ -196,12 +196,11 @@
     \end{align}
 \end{proof}
 
-\begin{definition}[Residual isometry family]%
+\begin{definition}[Joint isometry condition]%
     \label{def:is_residual_isometry_family}
     \lean{MPSTensor.IsResidualIsometryFamily}
     \leanok
-    A family of residual tensors $(U_j)_j$ is a \emph{residual isometry family}
-    when it satisfies the source isometry condition
+    A family $(U_j)_j$ satisfies the \emph{joint isometry condition} when
     \begin{align}
         \sum_i(U_j^i)_{\alpha,\beta}
             \overline{(U_{j'}^i)_{\alpha',\beta'}}
@@ -210,12 +209,12 @@
     \end{align}
     Each block satisfies the within-block pair-index orthonormality, and the
     cross-block sums between distinct blocks vanish. This is the isometry
-    condition of \cite[Theorem~III]{Cirac2016MPDO_arXiv}, split into its $j=j'$
+    condition of \cite[Theorem~3.11]{Cirac2016MPDO_arXiv}, split into its $j=j'$
     and $j\ne j'$ cases.
 \end{definition}
 
-\begin{lemma}[One-letter Gram matrix of a residual isometry family]%
-    \label{lem:residual_isometry_family_one_gram}
+\begin{theorem}[One-letter Gram matrix under the joint isometry condition]%
+    \label{thm:residual_isometry_family_one_gram}
     \lean{MPSTensor.IsResidualIsometryFamily.wordEntryFamily_one_gram}
     \leanok
     \uses{def:is_residual_isometry_family}
@@ -223,11 +222,11 @@
     union of the within-sector virtual pairs. For $x=(j,\alpha,\beta)$ in
     $\mathcal V$, set $u_x(i)=(U_j^i)_{\alpha,\beta}$. Then
     $\sum_i u_x(i)\overline{u_y(i)}=\delta_{x,y}$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     If $x$ and $y$ belong to the same sector, the assertion is the
-    within-sector part of the residual isometry condition. If they belong to
+    within-sector part of the joint isometry condition. If they belong to
     distinct sectors, it is the cross-sector vanishing condition.
 \end{proof}
 
@@ -238,7 +237,7 @@
     \uses{def:mixed_transfer_rect}
     For decompositions $A^i=X_AD_AU^iX_A^{-1}$ and
     $B^i=X_BD_BV^iX_B^{-1}$, the mixed transfer operator of $A,B$ is the
-    mixed transfer operator of the residual tensors $U,V$ conjugated by the outer
+    mixed transfer operator of the tensors $U,V$ conjugated by the outer
     factors:
     \begin{align}
         \E_{A,B}(Y)
@@ -252,7 +251,7 @@
     which are independent of the summation index, outside the sum.
 \end{proof}
 
-\begin{lemma}[Vanishing of the residual transfer operator]%
+\begin{lemma}[Vanishing after removing the diagonal factors]%
     \label{lem:mixed_transfer_eq_zero_of_conj}
     \lean{MPSTensor.mixedTransferMap₂_eq_zero_of_conj}
     \leanok
@@ -268,7 +267,7 @@
     $X_AD_A$ and $(X_BD_B)^\dagger$, so $\E_{A,B}=0$ forces $\E_{U,V}=0$.
 \end{proof}
 
-\begin{lemma}[Entrywise residual isometry sum]%
+\begin{lemma}[Entrywise cross-block isometry sum]%
     \label{lem:residual_isometry_entry}
     \lean{MPSTensor.residual_isometry_entry_of_mixedTransferMap₂_eq_zero}
     \leanok
@@ -302,7 +301,7 @@
     renormalization fixed-point condition for $B_j$.
 \end{proof}
 
-\begin{theorem}[Residual-isometry form of the cross-block structure]%
+\begin{theorem}[Joint isometry condition for a direct-sum fixed point]%
     \label{thm:residual_isometry_of_rfp_direct_sum}
     \lean{MPSTensor.exists_residualIsometryFamily_of_isTransferIdempotent_directSum}
     \leanok
@@ -311,17 +310,15 @@
     Let $(A_j)_j$ be a family of normal, irreducible, left-canonical blocks, no
     two of which are gauge-phase equivalent, with $\dim_j\ge1$ for all $j$, and
     suppose the direct sum $\bigoplus_j A_j$ is a renormalization fixed point.
-    Then there are invertible
-    $X_j$, positive trace-normalized diagonal weights $\Lambda_j$, and residual
-    tensors $U_j$ with
+    Then there are invertible matrices $X_j$, trace-one positive diagonal
+    matrices $\rho_j=\diag(\lambda_{j,\alpha})$, and tensors $U_j$ with
     \begin{align}
-        A_j^i&=X_j\sqrt{\Lambda_j}\,U_j^iX_j^{-1},
+        A_j^i&=X_j\sqrt{\rho_j}\,U_j^iX_j^{-1},
         \notag
     \end{align}
-    such that $(U_j)_j$ is a residual isometry family. This is the
-    residual-isometry content of Corollary~III.cor3
-    \cite[Corollary~III.3]{Cirac2016MPDO_arXiv} at the level of the normal-tensor
-    blocks.
+    such that $(U_j)_j$ satisfies the joint isometry condition. These are the
+    isometry equations of \cite[Corollary~3.12]{Cirac2016MPDO_arXiv} for the
+    direct sum of distinct normal-tensor blocks.
 % Scope restriction: the Lean theorem takes the per-block normality,
 % irreducibility, left-canonical condition, and gauge-phase distinctness as
 % explicit hypotheses; extracting these from a single canonical-form RFP
@@ -335,9 +332,9 @@
         lem:residual_isometry_entry}
     Whole-tensor idempotence makes the diagonal mixed transfer operator of each
     block its own transfer map, hence each block is a renormalization fixed
-    point; the isometry canonical form
+    point; the square-root fixed-point form
     (Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt}) supplies the
-    decomposition $A_j^i=X_j\sqrt{\Lambda_j}U_j^iX_j^{-1}$ with the within-block
+    decomposition $A_j^i=X_j\sqrt{\rho_j}U_j^iX_j^{-1}$ with the within-block
     orthonormality, which is the $j=j'$ case. For $j\ne j'$,
     Theorem~\ref{thm:bnt_locally_orthogonal_of_rfp_direct_sum} gives
     $\E_{A_j,A_{j'}}=0$; by the covariance
@@ -348,20 +345,21 @@
     \overline{(U_{j'}^i)_{\alpha',\beta'}}=0$.
 \end{proof}
 
-\begin{theorem}[A direct sum of isometry-canonical-form blocks is a renormalization fixed point]%
+\begin{theorem}[Direct sum of square-root fixed-point blocks]%
     \label{thm:is_rfp_of_isometry_canonical_form_direct_sum}
     \lean{MPSTensor.isTransferIdempotent_directSumTensor_of_isIsometryCanonicalForm}
     \leanok
     \uses{def:is_isometry_canonical_form, def:mps_transfer_idempotence,
         def:mixed_transfer_rect}
-    Let $(B_k)_k$ be a family of tensors, each in isometry canonical form, whose
-    cross-block mixed transfer operators vanish, $\E_{j,j'}=0$ for $j\ne j'$. Then
+    Let $(B_k)_k$ be a family of tensors, each in the square-root fixed-point
+    form, whose cross-block mixed transfer operators vanish,
+    $\E_{j,j'}=0$ for $j\ne j'$. Then
     the direct sum $\bigoplus_k B_k$ is a renormalization fixed point. This is the
     backward direction of the structural characterization of pure-state
     renormalization fixed points \cite[Section~3]{Cirac2016MPDO_arXiv}, in the
     distinct-blocks case where each normal tensor appears once; the cross-block
     vanishing is the $j\ne j'$ part of the isometry condition of that
-    characterization, so it belongs to the source isometry form.
+    characterization, so it is part of the source joint isometry condition.
 % Scope restriction (multiplicity-one): the source canonical form allows each
 % normal tensor to repeat with a multiplicity and a phase; this is the
 % single-copy case (docs/paper-gaps/cpsv16_rfp_isometry_scope.tex).
@@ -388,7 +386,7 @@
     sum is a renormalization fixed point.
 \end{proof}
 
-\begin{theorem}[Distinct-blocks renormalization fixed-point characterization]%
+\begin{theorem}[Distinct-block fixed-point characterization]%
     \label{thm:rfp_directSumTensor_iff}
     \lean{MPSTensor.isTransferIdempotent_directSumTensor_iff}
     \leanok
@@ -398,19 +396,19 @@
     Let $(B_k)_k$ be a family of normal, irreducible, left-canonical blocks with
     $\dim_k\ge1$ for all $k$, no two of which are gauge-phase equivalent. Then
     the direct sum $\bigoplus_k B_k$ is a renormalization fixed point if and only
-    if each block is in isometry canonical form and the mixed transfer operators
-    between distinct blocks vanish:
+    if each block is in the square-root fixed-point form and the mixed transfer
+    operators between distinct blocks vanish:
     \begin{align}
         \left(\bigoplus_k B_k\text{ is a RFP}\right)
         &\iff
-        \left(\forall k,\ B_k\text{ in isometry CF}\right)
+        \left(\forall k,\ B_k\text{ in square-root form}\right)
         \wedge
         \left(\forall j\ne j',\ \E_{j,j'}=0\right).
         \notag
     \end{align}
     This is the distinct-blocks (multiplicity-one, phase-one) case of the
     structural characterization of pure-state renormalization fixed points
-    \cite[Theorem~III]{Cirac2016MPDO_arXiv}, combining its forward and backward
+    \cite[Theorem~3.11]{Cirac2016MPDO_arXiv}, combining its forward and backward
     directions.
 % Scope restriction (multiplicity-one): the source canonical form
 % A^i = \oplus_j \oplus_q mu_{j,q} X_{j,q} Lambda_j U^i_j X_{j,q}^{-1} allows
@@ -426,11 +424,11 @@
     For the forward direction, whole-tensor idempotence makes each diagonal mixed
     transfer operator the transfer map of its block
     (Lemma~\ref{lem:isrfp_block_of_rfp_direct_sum}), so each block is a
-    renormalization fixed point and hence in isometry canonical form
+    renormalization fixed point and hence in the square-root fixed-point form
     (Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt}), while the off-diagonal
     operators vanish, $\E_{j,j'}=0$ for $j\ne j'$, by
     Theorem~\ref{thm:bnt_locally_orthogonal_of_rfp_direct_sum}. Conversely, a
-    direct sum of isometry-canonical-form blocks whose cross-block operators
+    direct sum of square-root fixed-point blocks whose cross-block operators
     vanish is a renormalization fixed point
     (Theorem~\ref{thm:is_rfp_of_isometry_canonical_form_direct_sum}).
 \end{proof}
@@ -443,20 +441,20 @@
     \uses{def:sector_bnt_cf, def:mps_transfer_idempotence,
         def:is_isometry_canonical_form, def:mixed_transfer_rect,
         def:is_residual_isometry_family}
-    Let $P$ be in BNT canonical form, with distinct basis tensors $(B_j)_j$.
+    Let $P$ satisfy the auxiliary BNT sector hypotheses, with distinct basis tensors $(B_j)_j$.
     Then the direct sum containing one copy of each basis tensor is a
-    renormalization fixed point if and only if every $B_j$ is in isometry
-    canonical form and $\E_{j,j'}=0$ for $j\ne j'$.
+    renormalization fixed point if and only if every $B_j$ has the square-root
+    fixed-point form and $\E_{j,j'}=0$ for $j\ne j'$.
     This is the multiplicity-one, phase-one specialization of
-    \cite[Theorem~III and Corollary~III.3]{Cirac2016MPDO_arXiv}. It concerns
+    \cite[Theorem~3.11 and Corollary~3.12]{Cirac2016MPDO_arXiv}. It concerns
     the direct sum of the basis representatives, not the repeated-copy tensor
     carrying the weights $\mu_{j,q}$.
 
     If the basis direct sum is a renormalization fixed point, there are also
-    invertible matrices $X_j$, positive trace-normalized diagonal weights
-    $\Lambda_j$, and residual tensors $U_j$ such that
-    $B_j^i=X_j\sqrt{\Lambda_j}\,U_j^iX_j^{-1}$, and the family $(U_j)_j$
-    satisfies the full residual isometry condition, including the cross-block
+    invertible matrices $X_j$, trace-one positive diagonal matrices
+    $\rho_j=\diag(\lambda_{j,\alpha})$, and tensors $U_j$ such that
+    $B_j^i=X_j\sqrt{\rho_j}\,U_j^iX_j^{-1}$, and the family $(U_j)_j$
+    satisfies the joint isometry condition, including the cross-block
     equations for $j\ne j'$.
 % The physical-space construction of the repeated-copy index is recorded in
 % docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
@@ -467,8 +465,9 @@
         thm:primitive_iff_period_one,
         thm:normal_tp_primitive_irred}
     Positive basis dimensions supply the nonzero bond spaces. For each basis
-    tensor, irreducibility and left-canonical normalization are part of the BNT
-    canonical form. If $m_j>0$ is the peripheral period of $B_j$, the
+    tensor, irreducibility and left-canonical normalization are part of the
+    auxiliary BNT sector hypotheses. If $m_j>0$ is the peripheral period of
+    $B_j$, the
     normalized self-overlap hypothesis and the periodic self-overlap formula
     used in Theorem~\ref{thm:postblocked_representative_grouped_insert_eq} give,
     along the same subsequence,
@@ -481,11 +480,99 @@
     Hence $m_j=1$. The transfer map is primitive by
     Theorem~\ref{thm:primitive_iff_period_one}, and normality follows from
     Theorem~\ref{thm:normal_tp_primitive_irred}. Gauge-phase distinctness is
-    also part of the BNT canonical form. The equivalence now follows from
+    also part of the auxiliary BNT sector hypotheses. The equivalence now
+    follows from
     Theorem~\ref{thm:rfp_directSumTensor_iff}; the same derived hypotheses in
-    Theorem~\ref{thm:residual_isometry_of_rfp_direct_sum} give the residual
-    isometry family.
+    Theorem~\ref{thm:residual_isometry_of_rfp_direct_sum} gives the joint
+    isometry condition.
 \end{proof}
+
+
+
+% CPSV16 Theorem 3.11 (`thm:charact-MPS`), lines 543--562.
+% No Lean theorem currently derives this repeated-copy statement from literal
+% `IsCPSVCanonicalForm`; the proved direct-sum result below the source level has
+% one unit-weight copy of each distinct block.  The missing q-routing data are
+% the documented source obstruction in closed issue #2598 and
+% docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
+% Formalization note: `CPSVCanonicalFormData` permits an omitted zero ambient
+% bond complement, but this implementation detail is not added to the source
+% theorem as a new hypothesis.
+\begin{theorem}[Square-root characterization of fixed points]
+    \label{thm:cpsv_charact_mps_status}
+    \notready
+    \uses{def:cpsv_canonical_form, def:bnt_cpsv,
+        def:mps_transfer_idempotence, def:is_isometry_canonical_form,
+        def:is_residual_isometry_family, thm:phase_flip_tensor_not_rfp}
+    CPSV asserts that a tensor $A$ in canonical form is a renormalization fixed
+    point if and only if it can be written as
+    \begin{align}
+        A^i
+        &=\bigoplus_{j=1}^g\bigoplus_{q=1}^{r_j}
+          \mu_{j,q}X_{j,q}\sqrt{\rho_j}\,U_j^iX_{j,q}^{-1},
+        \notag
+    \end{align}
+    where $|\mu_{j,q}|=1$, each $\rho_j$ is positive diagonal with
+    $\tr(\rho_j)=1$, and
+    \begin{align}
+        \sum_i(U_j^i)_{\alpha,\beta}
+          \overline{(U_{j'}^i)_{\alpha',\beta'}}
+        &=\delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+        \notag
+    \end{align}
+    The source specifies that $\bigoplus_{j,q}$ is a simultaneous direct sum in
+    the physical and virtual spaces, not an ordinary virtual block diagonal at
+    each fixed physical letter $i$ \cite[Theorem~3.11,
+    lines~561--562]{Cirac2016MPDO_arXiv}. It does not provide a coordinate map
+    for the physical routing of $q$, a corresponding dimension hypothesis, or
+    a $q$-indexed isometry equation. Consequently the display does not yet
+    determine a source-faithful coordinate-level predicate. Under the naive
+    fixed-$i$ virtual-block interpretation, the claimed converse is false by
+    Theorem~\ref{thm:phase_flip_tensor_not_rfp}. The routed characterization
+    therefore remains not ready pending a source clarification or erratum.
+
+    \textbf{Local fix (square-root diagonal).} CPSV prints a bare $\Lambda_j$
+    in Theorem~3.11, whereas the reference tensor at line~1300 has coefficients
+    $\sqrt{(\rho_j)_{\alpha,\alpha}}$, which forces the factor $\sqrt{\rho_j}$
+    used above. This repair is documented in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+\end{theorem}
+
+% CPSV16 Corollary 3.12 (`III_cor3`), lines 583--590.
+% The proved distinct-block theorem `thm:residual_isometry_of_rfp_direct_sum`
+% supplies the displayed equations under explicit normality, irreducibility,
+% left-canonical, and gauge-phase-distinctness hypotheses, but does not derive
+% the literal repeated-copy CPSV statement.
+\begin{corollary}[Basis tensors of a fixed point]
+    \label{cor:cpsv_iii_cor3_status}
+    \notready
+    \uses{def:cpsv_canonical_form, def:bnt_cpsv,
+        def:mps_transfer_idempotence, def:is_isometry_canonical_form,
+        def:is_residual_isometry_family, thm:cpsv_charact_mps_status}
+    Let $A$ be a CPSV canonical-form renormalization fixed point, and let
+    $(A_j)_j$ be a basis of normal tensors for $A$. CPSV asserts that there are
+    invertible matrices $X_j$, positive diagonal matrices $\rho_j$ with
+    $\tr(\rho_j)=1$, and tensors $U_j$ such that
+    \begin{align}
+        A_j^i
+        &=X_j\sqrt{\rho_j}\,U_j^iX_j^{-1},
+        \notag\\
+        \sum_i(U_j^i)_{\alpha,\beta}
+          \overline{(U_{j'}^i)_{\alpha',\beta'}}
+        &=\delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+        \notag
+    \end{align}
+    Thus the BNT-basis tensors share the physical index $i$, and the family
+    $(U_j)_j$ satisfies the source joint-isometry condition. This is the
+    square-root-consistent form of
+    \cite[Corollary~3.12]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Local fix (square-root diagonal).} CPSV prints a bare $\Lambda_j$
+    in Corollary~3.12, whereas the reference tensor at line~1300 has
+    coefficients $\sqrt{(\rho_j)_{\alpha,\alpha}}$, which forces the factor
+    $\sqrt{\rho_j}$ used above. This repair is documented in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+\end{corollary}
 
 \begin{theorem}[Ambiguity of the literal repeated-phase display]%
     \label{thm:phase_flip_tensor_not_rfp}
@@ -498,7 +585,7 @@
         A^0&=\begin{pmatrix}1&0\\0&-1\end{pmatrix}.
         \notag
     \end{align}
-    The representative $B$ is in isometry canonical form, and both copy
+    The representative $B$ is in the square-root fixed-point form, and both copy
     coefficients have unit modulus. Thus $A$ satisfies the literal virtual
     block-diagonal reading of the displayed repeated-copy formula in
     \cite[Section~3]{Cirac2016MPDO_arXiv}. It does not, however, satisfy the
@@ -514,7 +601,7 @@
 \begin{proof}\leanok
     Taking the witness data of
     Definition~\ref{def:is_isometry_canonical_form} to be
-    $X=\Lambda=U^0=(1)$, the scalar representative is in isometry canonical
+    $X=\rho=U^0=(1)$, the scalar representative is in square-root fixed-point
     form, and $|1|=|-1|=1$.
     Direct multiplication gives $(A^0)^2=I$. Comparing diagonal entries in
     $I=vA^0$ would give simultaneously $v=1$ and $v=-1$, which is impossible.

--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -1,19 +1,22 @@
-\section{Normal tensors and isometry canonical forms}
+\section{Normal tensors and fixed-point isometries}
 
-\subsection{Block-injective canonical-form conditions}
+\subsection{Auxiliary block-family hypotheses}
 \label{subsec:rfp_project_canonical_form}
 
-The following conditions are stronger and differently normalized than the CPSV
-canonical form of Definition~\ref{def:cpsv_canonical_form}; the two should not
-be identified.
+The next predicate is an auxiliary hypothesis on an indexed block family. It is
+not the literal CPSV canonical form of Definition~\ref{def:cpsv_canonical_form}
+or canonical form~II of Definition~\ref{def:cpsv_cfii}. In particular, it
+starts from injective left-canonical blocks, orders nonzero weights, and imposes
+a self-overlap limit; it does not reconstruct a tensor from normal blocks in an
+ambient bond space.
 
-\begin{definition}[Canonical form conditions]\label{def:is_canonical_form}
+\begin{definition}[Auxiliary injective block-family hypotheses]\label{def:is_canonical_form}
     \lean{MPSTensor.IsCanonicalForm}
     \leanok
     \uses{def:injective}
     A collection of scaling factors $(\mu_k)_{k=1}^r$ and
     block tensors $(A_k)_{k=1}^r$ satisfies the
-    \emph{canonical form conditions} if:
+    \emph{auxiliary block-family hypotheses} if:
     \begin{enumerate}
         \item each $A_k$ is injective,
         \item each $A_k$ satisfies the TP normalization
@@ -38,7 +41,7 @@ be identified.
     proof.
 \end{definition}
 
-\begin{lemma}[Canonical form from peripheral primitivity]%
+\begin{theorem}[Auxiliary block-family hypotheses from peripheral primitivity]%
     \label{thm:canonical_from_primitive}
     \lean{MPSTensor.IsCanonicalForm.of_peripheral_primitive}
     \leanok
@@ -48,9 +51,9 @@ be identified.
     blocks with positive bond dimensions, non-increasing moduli
     $|\mu_1|\ge\cdots\ge|\mu_r|>0$, and
     $\sigma_\partial(\E_{A_k})=\{1\}$. Then $(\mu_k,A_k)_{k=1}^r$ satisfies
-    the canonical-form conditions of Definition~\ref{def:is_canonical_form},
+    the auxiliary hypotheses of Definition~\ref{def:is_canonical_form},
     and $O_{A_kA_k}(N)\to1$ for every~$k$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}
     \leanok
@@ -151,15 +154,15 @@ be identified.
     $n \to \infty$ gives $\E_A = P_\rho$.
 \end{proof}
 
-\begin{theorem}[Full structural form for RFP tensors]%
+\begin{theorem}[Diagonal Kraus form for a normal fixed point]%
     \label{thm:rfp_nt_structural_full}
     \lean{MPSTensor.rfp_nt_structural_full}
     \leanok
     \uses{thm:rfp_nt_structural_of_left_canonical,
         thm:rfp_nt_cfii_diagonal_fixed_point,
         thm:transferMap_eq_fixedPointProj_of_isTransferIdempotent_injective}
-    A normal tensor $A$ in canonical form~II that is a renormalization fixed
-    point admits a decomposition $A^i = X \Lambda U^i X^{-1}$, where
+    A normal left-canonical renormalization fixed-point tensor $A$ admits a
+    decomposition $A^i=X\Lambda U^iX^{-1}$, where
     $\Lambda$ is diagonal positive, $\sum_i (U^i)^\dagger U^i=I$, and
     \begin{align}
         \sum_i \overline{(U^i)_{\alpha,\beta}}
@@ -209,15 +212,14 @@ be identified.
     Conjugating back gives $A^i=X\Lambda U^iX^{-1}$.
 \end{proof}
 
-\begin{theorem}[Structural form with diagonal square-sum identity]%
+\begin{theorem}[Diagonal Kraus form with square-sum normalization]%
     \label{thm:rfp_nt_structural_full_sq_sum}
     \lean{MPSTensor.rfp_nt_structural_full_sqSum}
     \leanok
     \uses{thm:rfp_nt_structural_of_left_canonical,
         thm:rfp_nt_cfii_diagonal_fixed_point,
         thm:transferMap_eq_fixedPointProj_of_isTransferIdempotent_injective}
-    The same decomposition as the full structural form
-    (Theorem~\ref{thm:rfp_nt_structural_full}) additionally records that the
+    The decomposition in Theorem~\ref{thm:rfp_nt_structural_full} additionally records that the
     diagonal weights satisfy $\sum_\alpha \Lambda_\alpha^2 = D$. This square-sum
     identity is the trace-normalization seed: the explicit weights are
     $\Lambda_\alpha = \sqrt{D\,\rho_{\alpha,\alpha}/\tr\rho}$, and
@@ -236,13 +238,13 @@ be identified.
     $\sum_\alpha \Lambda_\alpha^2 = D$.
 \end{proof}
 
-\begin{theorem}[Unit pair-index form for RFP tensors]%
+\begin{theorem}[Unit pair-index form for a normal fixed point]%
     \label{thm:rfp_nt_structural_full_unit_pair}
     \lean{MPSTensor.rfp_nt_structural_full_unit_pair}
     \leanok
     \uses{thm:rfp_nt_structural_full}
-    A normal tensor $A$ in canonical form~II that is a renormalization fixed
-    point admits a decomposition $A^i = X \Lambda U^i X^{-1}$, where
+    A normal left-canonical renormalization fixed-point tensor $A$ admits a
+    decomposition $A^i=X\Lambda U^iX^{-1}$, where
     $\Lambda$ is diagonal positive and
     \begin{align}
         \sum_i \overline{(U^i)_{\alpha,\beta}}
@@ -264,7 +266,7 @@ be identified.
     positive; the decomposition and the pair-index condition are immediate.
 \end{proof}
 
-\begin{theorem}[Per-block isometry canonical form]%
+\begin{theorem}[Per-block diagonal Kraus form]%
     \label{thm:rfp_nt_structural_full_blocks}
     \lean{MPSTensor.rfp_nt_structural_full_blocks}
     \leanok
@@ -282,15 +284,15 @@ be identified.
         D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
         \notag
     \end{align}
-    This is the blockwise form of the isometry canonical form
+    This is the blockwise form of the diagonal Kraus decomposition
     (Theorem~\ref{thm:rfp_nt_structural_full}); see
     \cite[Section~3]{Cirac2016MPDO_arXiv}. The source additionally imposes the
     normalization $\tr(\Lambda_k) = 1$; the statement here gives positive
     $\Lambda_k$ without it. That normalization is genuine rather than a
     conjugation gauge, since rescaling $\Lambda_k \mapsto \Lambda_k/\tr(\Lambda_k)$
     factors out as an overall scalar on $A_k^i$ (conjugation by $X_k$ preserves
-    the scale); the statement is thus the un-normalized isometry form.
-    \emph{Scope restriction (source isometry).} Corollary~III.cor3 also
+    the scale); the statement is thus the unnormalized diagonal Kraus form.
+    \emph{Scope restriction (source isometry).} Corollary~3.12 also
     invokes the joint isometry condition
     \begin{align}
         \sum_i (U_k^i)_{\alpha,\beta}
@@ -314,11 +316,12 @@ be identified.
     Apply Theorem~\ref{thm:rfp_nt_structural_full} to each block.
 \end{proof}
 
-\begin{theorem}[Per-block unit pair-index form]%
+\begin{theorem}[Per-block unit pair-index decomposition]%
     \label{thm:rfp_nt_structural_full_blocks_unit_pair}
     \lean{MPSTensor.rfp_nt_structural_full_blocks_unit_pair}
     \leanok
-    \uses{thm:rfp_nt_structural_full_unit_pair}
+    \uses{thm:rfp_nt_structural_full_blocks,
+        thm:rfp_nt_structural_full_unit_pair}
     Under the hypotheses of
     Theorem~\ref{thm:rfp_nt_structural_full_blocks}, each block admits a
     decomposition $A_k^i = X_k \Lambda_k U_k^i X_k^{-1}$ with
@@ -330,7 +333,7 @@ be identified.
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
         \notag
     \end{align}
-    This is a blockwise unit pair-index comparison. It still does not impose
+    This is a blockwise unit pair-index decomposition. It still does not impose
     the source trace-normalization of $\Lambda_k$ or the cross-block
     orthogonality equations for distinct blocks.
 \end{theorem}
@@ -339,56 +342,59 @@ be identified.
     Apply Theorem~\ref{thm:rfp_nt_structural_full_unit_pair} to each block.
 \end{proof}
 
-\begin{definition}[Isometry canonical form]%
+\begin{definition}[Square-root fixed-point form]%
     \label{def:is_isometry_canonical_form}
     \lean{MPSTensor.IsIsometryCanonicalForm}
     \leanok
-    A normal tensor $A$ is in \emph{isometry canonical form} when there are an
-    invertible $X$, a positive diagonal weight $\Lambda$ with the trace
-    normalization $\sum_\alpha \Lambda_\alpha = 1$, and a residual tensor $U$
-    satisfying the unit pair-index isometry
+    Let $\lambda_\alpha>0$ satisfy $\sum_\alpha\lambda_\alpha=1$, and set
+    $\rho=\diag(\lambda_\alpha)$. A normal tensor $A$ has the
+    \emph{square-root fixed-point form} when there are an invertible matrix
+    $X$ and a tensor $U$ satisfying the unit pair-index isometry
     \begin{align}
         \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
          & = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
         \notag
     \end{align}
-    such that $A^i = X\,\sqrt\Lambda\,U^i\,X^{-1}$.
-    The square root dresses the unit isometry because the reference tensor of
-    \cite[Section~3]{Cirac2016MPDO_arXiv} is
+    such that
+    \begin{align}
+        A^i&=X\sqrt{\rho}\,U^iX^{-1}.
+        \notag
+    \end{align}
+    \textbf{Local fix (square-root diagonal).} The display at line~1278 uses
+    the bare diagonal $\Lambda$, while lines~1281--1283 impose a unit
+    pair-index isometry and line~1300 constructs the reference tensor with
+    coefficients $\sqrt{\Lambda_\alpha}$. These equations force the repaired
+    form $A^i=X\sqrt{\rho}\,U^iX^{-1}$ used in this definition. The correction
+    is documented in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+
+    Explicitly, the reference tensor is
     \begin{align}
         \widehat A^{(\alpha',\beta')}_{\alpha,\beta}
          & = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}
-        \sqrt{\Lambda_\alpha}.
+        \sqrt{\lambda_\alpha}.
         \notag
     \end{align}
-    The normalization $\tr(\Lambda)=1$ is imposed on $\Lambda$, equivalently on
-    the normalized diagonal fixed point $\rho=\diag(\Lambda)$ of the transfer
-    map. The displayed source form writes $A^i=X\Lambda U^iX^{-1}$ with the bare
-    diagonal; that pairing forces a non-unit residual, so the consistent
-    decomposition keeps the square root $\sqrt\Lambda$ while the trace
-    normalization stays on $\Lambda$. This records the diagonal $j=j'$ case of
-    the source isometry condition.
-    % Square-root correction documented in
-    % docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+    Thus $\rho=\diag(\lambda_\alpha)$ is the trace-one diagonal fixed point.
+    This records the $j=j'$ part of the joint isometry condition
+    \cite[Appendix~B, lines~1278, 1281--1283, 1300]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Trace-normalized isometry canonical form for RFP tensors]%
+\begin{theorem}[Trace-normalized square-root form for a normal fixed point]%
     \label{thm:isometry_canonical_form_of_rfp_nt}
     \lean{MPSTensor.isIsometryCanonicalForm_of_rfp_nt}
     \leanok
     \uses{def:is_isometry_canonical_form, thm:rfp_nt_structural_full_sq_sum}
-    A normal tensor in canonical form~II that is a renormalization fixed point
-    is in isometry canonical form: it admits a decomposition
-    $A^i = X\sqrt\Lambda\,U^i X^{-1}$ with $\Lambda$ diagonal, positive,
-    trace-normalized ($\sum_\alpha \Lambda_\alpha = 1$, the source condition
-    $\tr(\Lambda)=1$), and $U$ a unit pair-index isometry. The diagonal weight
-    is $\Lambda_\alpha = \rho_{\alpha,\alpha}/\tr\rho$, the normalized diagonal
-    fixed point of the transfer map; trace-normalization is then the trace
-    identity $\sum_\alpha \rho_{\alpha,\alpha} = \tr\rho$. This is the
-    single-block normal-tensor case of the structural characterization of
-    pure-state renormalization fixed points in
-    \cite[Section~3]{Cirac2016MPDO_arXiv}, recovering the diagonal part of the
-    isometry condition there.
+    A normal left-canonical renormalization fixed-point tensor has the
+    square-root fixed-point form. With
+    $\lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$ and
+    $\rho_0=\diag(\lambda_\alpha)$, it admits
+    $A^i=X\sqrt{\rho_0}\,U^iX^{-1}$, where $\rho_0$ is positive and
+    trace-normalized and $U$ is a unit pair-index isometry. Trace normalization
+    is the identity $\sum_\alpha \rho_{\alpha,\alpha}=\tr\rho$. This is the
+    normal-tensor statement corresponding to lines~1278 and~1281--1283,
+    with the square-root correction dictated by the reference tensor at
+    line~1300 \cite[Appendix~B]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_full_sq_sum}
@@ -396,26 +402,32 @@ be identified.
     (Theorem~\ref{thm:rfp_nt_structural_full_sq_sum}) supplies a positive
     diagonal weight $\widetilde\Lambda$ with
     $\sum_\alpha \widetilde\Lambda_\alpha^2 = D$. Rescaling to the unit
-    pair-index convention by $U^i\mapsto\sqrt D\,U^i$ and setting
-    $\Lambda_\alpha=(\widetilde\Lambda_\alpha/\sqrt D)^2$ gives
-    $\sum_\alpha \Lambda_\alpha
+    pair-index convention by $U^i\mapsto\sqrt D\,U^i$, set
+    \begin{align}
+        \rho_0
+         & =\diag\left(\left(\frac{\widetilde\Lambda_\alpha}{\sqrt D}\right)^2\right).
+        \notag
+    \end{align}
+    Then
+    $\tr(\rho_0)
         = D^{-1}\sum_\alpha \widetilde\Lambda_\alpha^2
         = D^{-1}\cdot D = 1$, while
-    $\sqrt{\Lambda_\alpha}=\widetilde\Lambda_\alpha/\sqrt D$ recovers the
-    decomposition $A^i = X\sqrt\Lambda\,U^i X^{-1}$.
+    $\sqrt{(\rho_0)_{\alpha,\alpha}}
+        =\widetilde\Lambda_\alpha/\sqrt D$ recovers the decomposition
+    $A^i = X\sqrt{\rho_0}\,U^i X^{-1}$.
 \end{proof}
 
 \begin{figure}[ht]
     \centering
-    $A=X\sqrt\Lambda\,U\,X^{-1}$
+    $A=X\sqrt\rho\,U\,X^{-1}$
     \begin{center}
-        % A^i = X sqrt(Lambda) U^i X^{-1} (eq_III_NT_RFP, CPSV16 Lemma
-        % lem:charact-NT-pure-RFP, lines 1275-1289; chapter's corrected
-        % sqrt(Lambda) weight, docs/paper-gaps/cpsv16_rfp_isometry_scope.tex):
+        % A^i = X sqrt(rho) U^i X^{-1} (the corrected local packaging of
+        % eq_III_NT_RFP, CPSV16 Lemma lem:charact-NT-pure-RFP, lines
+        % 1275-1289; docs/paper-gaps/cpsv16_rfp_isometry_scope.tex):
         % X and X^{-1} are plain gauge matrices on the wire (no physical
-        % leg); sqrt(Lambda) is the diagonal weight, also a matrix on the
-        % wire; U carries the physical leg i and both bond legs alpha
-        % (west, into sqrt(Lambda)) and beta (east, into X^{-1}).  Both
+        % leg); sqrt(rho) is the diagonal weight, also a matrix on the wire;
+        % U carries the physical leg i and both bond legs alpha
+        % (west, into sqrt(rho)) and beta (east, into X^{-1}).  Both
         % sides carry the same boundary signature
         % (virtual-west=1 | virtual-east=1 | physical-up=1).
         \begin{tenkz}[physical=up]
@@ -423,14 +435,14 @@ be identified.
         \end{tenkz}
         $ = $
         \begin{tenkz}[physical=up]
-            \tnX{X} & \tnX{\sqrt\Lambda} & \tn[up=$i$]{U} & \tnX{X^{-1}}
+            \tnX{X} & \tnX{\sqrt\rho} & \tn[up=$i$]{U} & \tnX{X^{-1}}
         \end{tenkz}
     \end{center}
-    \caption{The isometry canonical form of a normal renormalization fixed
-        point: $A^i = X\sqrt\Lambda\,U^i X^{-1}$, with the diagonal weight
-        $\sqrt\Lambda$ and the isometry $U$ carrying the
-        physical index
-        \cite[Appendix~B, lines~1275--1289]{Cirac2016MPDO_arXiv}.}
+    \caption{The square-root form of a normal renormalization fixed point:
+        $\rho=\diag(\lambda_\alpha)$ and
+        $A^i=X\sqrt\rho\,U^iX^{-1}$. The pair-index isometry is the one in
+        lines~1281--1283, and the square root follows from the reference tensor
+        at line~1300 \cite[Appendix~B]{Cirac2016MPDO_arXiv}.}
     \label{fig:rfp_isometry_canonical_form}
 \end{figure}
 % The source expression carries a bare $\Lambda$; the square root is the
@@ -462,42 +474,42 @@ be identified.
         = \delta_{x,y} \tr(Z)$, which is the $(x,y)$ entry of $\tr(Z)\,I$.
 \end{proof}
 
-\begin{theorem}[Isometry canonical form implies the renormalization fixed-point property]%
+\begin{theorem}[The square-root form implies the fixed-point property]%
     \label{thm:is_rfp_of_isometry_canonical_form}
     \lean{MPSTensor.isTransferIdempotent_of_isIsometryCanonicalForm}
     \leanok
     \uses{def:is_isometry_canonical_form, def:mps_transfer_idempotence}
-    A tensor in isometry canonical form is a renormalization fixed point. This is
+    A tensor in the square-root fixed-point form is a renormalization fixed point. This is
     the backward direction of the structural characterization of pure-state
     renormalization fixed points in \cite[Section~3]{Cirac2016MPDO_arXiv}, which
     the source states as immediate.
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:unit_pair_isometry_transfer}
-    Write $A^i = X\sqrt\Lambda\,U^i X^{-1}$. Substituting into the transfer map
-    and pulling the index-independent factors $X\sqrt\Lambda$ and
-    $\sqrt\Lambda\,X^\dagger$ outside the sum, the unit pair-index isometry
+    Write $A^i = X\sqrt\rho\,U^i X^{-1}$. Substituting into the transfer map
+    and pulling the index-independent factors $X\sqrt\rho$ and
+    $\sqrt\rho\,X^\dagger$ outside the sum, the unit pair-index isometry
     identity (Lemma~\ref{lem:unit_pair_isometry_transfer}) gives the rank-one form
     \begin{align}
         \E_A(Y)
          & = \tr\!(X^{-1} Y (X^{-1})^\dagger)\,R,
         \notag                                    \\
         R
-         & = X\,\Lambda\,X^\dagger.
+         & = X\,\rho\,X^\dagger.
         \notag
     \end{align}
     Idempotence then reduces to
-    $\tr\!(X^{-1} R (X^{-1})^\dagger) = \tr(\Lambda) = 1$, the trace
+    $\tr\!(X^{-1} R (X^{-1})^\dagger) = \tr(\rho) = 1$, the trace
     normalization, so $\E_A \circ \E_A = \E_A$.
 \end{proof}
 
-\begin{theorem}[Per-block trace-normalized isometry canonical form]%
+\begin{theorem}[Per-block trace-normalized square-root form]%
     \label{thm:isometry_canonical_form_of_rfp_nt_blocks}
     \lean{MPSTensor.isIsometryCanonicalForm_of_rfp_nt_blocks}
     \leanok
     \uses{def:is_isometry_canonical_form, thm:isometry_canonical_form_of_rfp_nt}
     Each block of a multi-block tensor whose blocks are normal, left-canonical
-    renormalization fixed points is in isometry canonical form, with a
+    renormalization fixed points has the square-root fixed-point form, with a
     trace-normalized diagonal weight and a unit pair-index isometry. This is
     the single-block trace-normalized form applied to each block; it omits the
     cross-block orthogonality between distinct normal-tensor blocks.
@@ -509,7 +521,8 @@ be identified.
     Apply Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt} to each block.
 \end{proof}
 
-Across all blocks, the canonical form has the following routed representation.
+Across all blocks, the repaired trace-normalized decomposition has the following
+representation.
 \begin{figure}[ht]
     \centering
     \begin{center}
@@ -524,7 +537,7 @@ Across all blocks, the canonical form has the following routed representation.
             \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
             {rfpX}{(0,0)}{X}
             \tnput[box, ports={west:virtual,east:virtual,south:virtual}]
-            {rfpLambda}{(14mm,0)}{\sqrt\Lambda}
+            {rfpLambda}{(14mm,0)}{\sqrt\rho}
             \tnput[box,
                 ports={south west:virtual,south:virtual,
                         south east:virtual,north:physical}]
@@ -598,17 +611,17 @@ Across all blocks, the canonical form has the following routed representation.
         \end{tenkzfree}
         % TENKZ-II-RFP-END
     \end{center}
-    \caption{Block-and-multiplicity routing in the isometry canonical form.
+    \caption{Block and multiplicity indices in the fixed-point decomposition.
         The independent rails $j$ and $q$ pass through the coefficient
         network without being fused: $X$ and $X^{-1}$ depend on both,
-        $\sqrt\Lambda$ and $U$ carry the block label $j$, and $M$ carries
+        $\sqrt\rho$ and $U$ carry the block label $j$, and $M$ carries
         the multiplicity label $q$. The upper leg of $U$ is the physical
         index, as in the source figure
         \cite[Section~3.4, lines~543--563]{Cirac2016MPDO_arXiv}.}
     \label{fig:rfp_block_multiplicity_routing}
 \end{figure}
 Here $j$ labels the normal-tensor block and $q$ its repeated representation;
-the residual isometries in
+the isometries in
 \cite[Section~3.4, lines~543--561]{Cirac2016MPDO_arXiv} also satisfy
 cross-block physical orthogonality. Those additional equations are not part
 of the per-block theorem above.

--- a/blueprint/src/chapter/ch26_mps_rfp_renormalization_flow_correlations.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_renormalization_flow_correlations.tex
@@ -1,30 +1,35 @@
 \section{Renormalization flow and physical correlations}
 
-\begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
+\begin{theorem}[Injectivity in the auxiliary block family]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok
     \uses{def:is_canonical_form, def:injective}
-    For a family of tensors in canonical form, every block is injective.
-    This is part of the canonical-form hypotheses in
-    \cite[Section~2.3]{Cirac2016MPDO_arXiv}.
+    Every block satisfying the auxiliary hypotheses of
+    Definition~\ref{def:is_canonical_form} is injective. This is an immediate
+    projection of that auxiliary predicate, not a theorem about literal CPSV
+    canonical form.
 \end{theorem}
 \begin{proof}\leanok
-    The canonical-form hypotheses include injectivity of each block.
+    Injectivity is one of the defining auxiliary hypotheses.
 \end{proof}
 
 
-\begin{theorem}[RG flow convergence for canonical-form tensors]%
+\begin{theorem}[Primitive-transfer convergence for each auxiliary block]%
     \label{thm:rg_flow_converges_of_cf}
     \lean{MPSTensor.rg_flow_converges_of_cf}
     \leanok
     \uses{def:is_canonical_form, def:transfer_map, def:fixed_point_proj,
         thm:exponential_convergence_primitive}
-    For a tensor in canonical form with blocks $(A_k)$ and weights $(\mu_k)$,
-    the iterated blocking $\E_{A_k}^{2^n}$ converges pointwise to an
-    idempotent linear map $\E_\infty$ as $n\to\infty$.
-    That is, there exists $\E_\infty$ with $\E_\infty^2=\E_\infty$ such that
-    $\E_{A_k}^{2^n}(\rho)\to\E_\infty(\rho)$ for all density matrices $\rho$.
-    This is \cite[Appendix~B]{Cirac2016MPDO_arXiv}.
+    Fix one block $A_k$ in a family satisfying
+    Definition~\ref{def:is_canonical_form}. Then the primitive transfer map of
+    that block satisfies: $\E_{A_k}^{2^n}$ converges pointwise to an idempotent
+    linear map $\E_{k,\infty}$ as $n\to\infty$.
+    Thus there exists $\E_{k,\infty}$ with
+    $\E_{k,\infty}^2=\E_{k,\infty}$ such that
+    $\E_{A_k}^{2^n}(\rho)\to\E_{k,\infty}(\rho)$ for every bond matrix $\rho$.
+    This is the per-block primitive convergence used in the Appendix~B
+    discussion, not convergence of the full weighted canonical-family transfer
+    matrix \cite[Appendix~B, lines~1211--1244]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     Each block is injective and left-canonical, so its transfer map is a
@@ -34,7 +39,7 @@
     (Theorem~\ref{thm:exponential_convergence_primitive}) then gives
     pointwise convergence $\E^n(X)\to P(X)$, and composing with the
     subsequence $2^n\to\infty$ yields the result.
-    The witness $\E_\infty=P$ is the rank-one fixed-point projection,
+    The witness $\E_{k,\infty}=P_k$ is the rank-one fixed-point projection,
     which is idempotent.
 \end{proof}
 
@@ -48,13 +53,13 @@
     is deferred here.
 \end{remark}
 
-\begin{definition}[Virtual-insertion distance independence]\label{def:is_cid}
+\begin{definition}[Virtual-insertion auxiliary condition]\label{def:is_cid}
     \lean{MPSTensor.IsCID}
     \leanok
     \uses{def:connected_correlator}
-    For a positive definite right fixed point $\rho^R>0$, the virtual
-    insertion expression is independent of distance when for all virtual bond
-    matrices $X$ and $Y$ and all separations $n,m\ge 1$,
+    For every positive-definite right fixed point $\rho^R>0$, every pair of
+    virtual bond matrices $X,Y$, and all separations $n,m\geq1$, the
+    virtual-insertion expression is independent of distance:
     $C(X,Y;n)=C(X,Y;m)$.
 \end{definition}
 
@@ -113,7 +118,7 @@
     \cite[Definition~3.3 and lines~490--496]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{definition}[Positive-gap physical distance independence]%
+\begin{definition}[Positive-gap restriction of physical distance independence]%
     \label{def:is_positive_gap_physical_cid}
     \lean{MPSTensor.IsPositiveGapPhysicalCID}
     \leanok
@@ -138,7 +143,7 @@
         \Tr_{\MN{D}}\!\left(\E_{O_2}\circ\E_A^{m_2}\circ\E_{O_1}\circ\E_A^{m_1}\right).
         \notag
     \end{align}
-    This is the transfer-matrix form of
+    This positive-gap restriction is the transfer-matrix form of
     \cite[Definition~3.3 and the correlation formula preceding
     Theorem~3.8]{Cirac2016MPDO_arXiv}, restricted to positive complementary
     gaps. It excludes adjacent regions.
@@ -179,15 +184,15 @@
     \end{align}
 \end{proof}
 
-\begin{definition}[Zero correlation length]\label{def:is_zcl}
+\begin{definition}[Virtual-insertion one-block auxiliary condition]\label{def:is_zcl}
     \lean{MPSTensor.IsZCL}
     \leanok
-    \uses{def:is_locally_orthogonal, def:is_bnt_zcl, def:is_cid}
-    In the single-block convention, an MPS tensor has \emph{zero correlation
-        length} when $\E_A^2=\E_A$ and $\operatorname{CID}(A)$ both hold.
-    The source definition is
-    Definition~\ref{def:source_bnt_zcl}; the present condition uses virtual
-    insertions instead.
+    \uses{def:is_locally_orthogonal, def:is_bnt_zcl, def:is_cid,
+        def:source_bnt_zcl}
+    This auxiliary one-block predicate is the conjunction of
+    $\E_A^2=\E_A$ and virtual-insertion distance independence. It is not the
+    physical zero-correlation-length condition of
+    Definition~\ref{def:source_bnt_zcl}.
 \end{definition}
 
 \begin{theorem}[Virtual-insertion distance independence implies RFP]%
@@ -195,9 +200,9 @@
     \lean{MPSTensor.isCID_implies_isTransferIdempotent}
     \leanok
     \uses{def:is_cid, def:mps_transfer_idempotence, def:transfer_map}
-    If an MPS tensor admits a positive definite right fixed point and its
-    virtual-insertion correlator is independent of distance, then its transfer
-    map is idempotent.
+    Suppose $\rho^R>0$ is a right fixed point of the transfer map. If the
+    virtual-insertion condition holds for every positive-definite right fixed
+    point, then the transfer map is idempotent.
     % The reverse direction of Theorem 3.8 in arXiv:1606.00608 additionally
     % fails for raw repeated-copy weights. A corrected restricted theorem would
     % additionally require realizing virtual insertions by physical observables.
@@ -212,20 +217,16 @@
     $\E_A^2(Z)=\E_A(Z)$ for every $Z$, hence $\E_A^2=\E_A$.
 \end{proof}
 
-\begin{theorem}[Zero correlation length iff idempotent transfer]%
+\begin{theorem}[Redundancy of the one-block auxiliary condition]%
     \label{thm:zcl_iff_idempotent_transfer}
     \lean{MPSTensor.zcl_iff_idempotent_transfer}
     \leanok
     \uses{def:mps_transfer_idempotence, def:is_cid, def:is_locally_orthogonal}
-    Under the single-block convention above,
-    $(\E_A^2=\E_A\ \text{and}\ \operatorname{CID}(A))
-    \Longleftrightarrow\E_A^2=\E_A$.
-    This is the idempotence/CID part of
-    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}. The full source theorem for
-    canonical-form tensors instead uses the unrestricted physical condition in
-    Definition~\ref{def:source_bnt_zcl}; under its stated raw-weight
-    normalization, that biconditional is false by
-    Theorem~\ref{thm:halved_weight_zcl_not_rfp}.
+    The auxiliary conjunction
+    $(\E_A^2=\E_A\ \text{and virtual-insertion distance independence})$
+    is equivalent to $\E_A^2=\E_A$. This is a logical simplification of the
+    auxiliary convention, not the physical ZCL theorem of
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     The forward direction extracts the idempotence hypothesis. Conversely,
@@ -247,23 +248,21 @@
     separation.
 \end{proof}
 
-\begin{theorem}[Single-block RFP iff ZCL inside a canonical form]%
+\begin{theorem}[Per-block auxiliary equivalence]%
     \label{thm:rfp_iff_zcl}
     \lean{MPSTensor.rfp_iff_zcl}
     \leanok
-    \uses{def:is_canonical_form, def:mps_transfer_idempotence, def:is_zcl}
-    Let $A^i=\bigoplus_k \mu_k A_k^i$ be a tensor in canonical form. For each
-    $k$, the tensor $A_k$ is a renormalization fixed point if and only if
-    $A_k$ has zero correlation length.
-
-    This is the single-block consequence of
-    \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}. The ZCL condition in the source
-    theorem is the BNT-family condition: CID together with the local
-    orthogonality equations $\mathbb E_{j,j'}=0$ for all $j\ne j'$,
-    as in Definition~\ref{def:source_bnt_zcl}.
+    \uses{def:is_canonical_form, def:mps_transfer_idempotence, def:is_zcl,
+        thm:zcl_iff_idempotent_transfer}
+    Let $(A_k)_k$ satisfy the auxiliary block-family hypotheses of
+    Definition~\ref{def:is_canonical_form}. For each $k$, the transfer map of
+    $A_k$ is idempotent if and only if $A_k$ satisfies the one-block auxiliary
+    conjunction of Definition~\ref{def:is_zcl}. The block-family hypothesis is
+    unused; this is Theorem~\ref{thm:zcl_iff_idempotent_transfer} applied to one
+    block. It should not be read as the BNT-family ZCL assertion in
+    \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:zcl_iff_idempotent_transfer}
-    Apply Theorem~\ref{thm:zcl_iff_idempotent_transfer} to the chosen
-    canonical-form block.
+    Apply Theorem~\ref{thm:zcl_iff_idempotent_transfer} to the chosen block.
 \end{proof}

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -1,15 +1,13 @@
 \section{Zero-correlation-length conditions}
 
-\begin{definition}[Single-block local orthogonality convention]%
+\begin{definition}[Virtual one-block idempotence convention]%
     \label{def:is_locally_orthogonal}
     \lean{MPSTensor.IsLocallyOrthogonal}
     \leanok
     \uses{def:mps_transfer_idempotence}
-    For the single-block convention used here, local orthogonality means
-    $\E_A^2=\E_A$. The source local-orthogonality condition for a BNT family is
-    instead the collection of mixed-sector equations $\E_{j,j'}=0$ for distinct
-    components. Thus this definition records the one-block idempotence
-    convention.
+    This auxiliary one-block convention means $\E_A^2=\E_A$. It is not
+    local orthogonality in the sense of the source, which is the family of
+    mixed-sector equations $\E_{j,j'}=0$ for distinct BNT components.
 \end{definition}
 
 \begin{definition}[BNT local orthogonality]%
@@ -17,7 +15,7 @@
     \lean{MPSTensor.IsBNTLocallyOrthogonal}
     \leanok
     \uses{def:mixed_transfer_rect}
-    Let $(A_j)_j$ be the BNT components of a tensor in canonical form. The
+    Let $(A_j)_j$ be a basis of normal tensors. The
     family is \emph{locally orthogonal} when, for every pair of distinct
     components,
     \begin{align}
@@ -29,20 +27,19 @@
     \cite[Definition~3.5]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{definition}[Virtual-insertion BNT zero correlation length]%
+\begin{definition}[Virtual-insertion auxiliary BNT condition]%
     \label{def:is_bnt_zcl}
     \lean{MPSTensor.IsBNTZCL}
     \leanok
     \uses{def:bnt_cpsv, def:is_cid, def:is_bnt_locally_orthogonal}
-    Let $(A_j)_j$ be a basis of normal tensors for $A$. The BNT
-    zero-correlation-length condition is that $\operatorname{CID}(A)$ and, for
-    every pair of distinct BNT components, $\E_{j,j'}=0$. This
-    virtual-insertion condition is not
+    Let $(A_j)_j$ be a basis of normal tensors for $A$. This auxiliary
+    condition requires virtual-insertion distance independence and
+    $\E_{j,j'}=0$ for every pair of distinct BNT components. It is not
     \cite[Definition~3.6]{Cirac2016MPDO_arXiv}, which quantifies over physical
     observables on all disjoint regions.
 \end{definition}
 
-\begin{definition}[Positive-gap BNT zero correlation length]%
+\begin{definition}[Positive-gap restriction of BNT zero correlation length]%
     \label{def:is_positive_gap_bnt_zcl}
     \lean{MPSTensor.IsPositiveGapBNTZCL}
     \leanok
@@ -56,12 +53,12 @@
     are not included.
 \end{definition}
 
-\begin{lemma}[Positive-gap BNT zero correlation length, unfolded]%
+\begin{lemma}[Positive-gap restriction, unfolded]%
     \label{lem:is_positive_gap_bnt_zcl_iff}
     \lean{MPSTensor.isPositiveGapBNTZCL_iff}
     \leanok
     \uses{def:is_positive_gap_bnt_zcl}
-    Positive-gap BNT zero correlation length is equivalent to the conjunction
+    The positive-gap restriction is equivalent to the conjunction
     of the BNT relation, positive-gap physical distance independence, and BNT
     local orthogonality.
 \end{lemma}
@@ -69,7 +66,7 @@
     This is the defining conjunction.
 \end{proof}
 
-\begin{definition}[BNT zero correlation length]%
+\begin{definition}[Physical BNT zero correlation length]%
     \label{def:source_bnt_zcl}
     \lean{MPSTensor.IsPhysicalBNTZCL}
     \leanok
@@ -81,7 +78,116 @@
     \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Unequal raw weights obstruct the ZCL--RFP equivalence]%
+% CPSV16 Theorem 3.8 (`TheoremZCLPure`), lines 498--503 and 1248--1268.
+% Adjacent-gap source-gap record:
+% docs/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.tex.
+% The raw-weight counterexample is implemented through the auxiliary BNT sector
+% data; no duplicate `CPSVCanonicalFormData` package has been added.
+\begin{theorem}[Two source gaps in the zero-correlation-length characterization]
+    \label{thm:cpsv_theorem_zcl_pure_status}
+    \uses{def:cpsv_canonical_form, def:bnt_cpsv,
+        def:source_bnt_zcl, def:mps_transfer_idempotence,
+        thm:halved_weight_zcl_not_rfp, thm:bell_pair_chain_not_cid,
+        thm:is_positive_gap_physical_cid_of_is_rfp}
+    \notready
+    CPSV asserts that a tensor $A$ in canonical form has physical BNT zero
+    correlation length if and only if
+    \begin{align}
+        \E_A^2&=\E_A.
+        \notag
+    \end{align}
+    Both directions fail as printed.
+
+    For the reverse implication, let $C^0=(1)$ and form the direct sum of two
+    scalar copies with weights $1$ and $1/2$. The resulting tensor is
+    \begin{align}
+        A^0
+        &=\begin{pmatrix}1&0\\0&\tfrac12\end{pmatrix}.
+        \notag
+    \end{align}
+    The scalar tensor $C$ is normal, and the weights obey the source convention
+    $|\mu_k|\leq 1$, with at least one weight of modulus one. The singleton BNT
+    family $(C)$ is locally orthogonal and gives $A$ physical BNT zero
+    correlation length, whereas
+    \begin{align}
+        \E_A^2&\neq\E_A.
+        \notag
+    \end{align}
+    Thus zero correlation length does not imply transfer idempotence under the
+    source's raw weight normalization.
+
+    Independently, the Bell-pair chain of
+    Theorem~\ref{thm:bell_pair_chain_not_cid} is a single normal block. Taking
+    its weight to be $1$ and the ambient coisometry to be the identity gives a
+    literal CPSV canonical-form tensor. Its transfer map is idempotent, but its
+    adjacent two-region expectation is $1$, while the expectation after an
+    allowed one-site shift is $0$.
+    Hence transfer idempotence does not imply physical zero correlation length
+    for the unrestricted quantification over disjoint regions.
+
+    \textbf{Source gap (adjacent regions).} The printed forward argument uses
+    $\E_A^n=\E_A$, which follows from idempotence only for $n\geq1$. Adjacent
+    regions insert $\E_A^0=\Id$ and are included in the source definition. This
+    gap is recorded in
+    \path{docs/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.tex}.
+    Theorem~\ref{thm:is_positive_gap_physical_cid_of_is_rfp} proves the repaired
+    forward implication when both complementary gaps are positive. It does not
+    prove the unrestricted biconditional in
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}. The converse and equivalence results
+    below require their stated unit-weight, multiplicity-one, or spectral
+    hypotheses. The printed biconditional is recorded here as refuted, not as a
+    theorem awaiting proof.
+\end{theorem}
+\begin{proof}
+    \uses{thm:halved_weight_zcl_not_rfp, thm:bell_pair_chain_not_cid}
+    Theorem~\ref{thm:halved_weight_zcl_not_rfp} refutes the reverse implication.
+    Theorem~\ref{thm:bell_pair_chain_not_cid} refutes the forward implication.
+\end{proof}
+
+% CPSV16 Theorem 3.10 (`thm:main-MPS`), lines 532--541.
+% The adjacent-gap source-gap record is
+% docs/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.tex.
+\begin{theorem}[The adjacent gap refutes the printed three-way equivalence]
+    \label{thm:cpsv_main_mps_status}
+    \uses{def:cpsv_canonical_form, def:source_bnt_zcl,
+        def:mps_transfer_idempotence, def:has_nncph_ground_spaces,
+        thm:halved_weight_zcl_not_rfp, thm:bell_pair_chain_not_cid,
+        thm:is_positive_gap_physical_cid_of_is_rfp}
+    \notready
+    CPSV asserts that, for a tensor $A$ in canonical form, the following are
+    equivalent: $A$ is a renormalization fixed point; $A$ has physical zero
+    correlation length; and, for every $N>2$, the vector
+    $|V^{(N)}(A)\rangle$ belongs to the ground space of a nearest-neighbor
+    commuting parent Hamiltonian
+    \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}.
+
+    This three-way equivalence is false with the unrestricted physical
+    zero-correlation-length definition. The Bell-pair chain is a single normal
+    block and becomes a literal CPSV canonical-form tensor by taking unit weight
+    and the identity ambient coisometry. Its transfer map is idempotent, so it
+    is a renormalization fixed point, but its adjacent-region
+    correlations are not independent of distance. Thus the implication from
+    renormalization fixed points to zero correlation length fails, regardless
+    of the commuting-parent condition. The raw-weight example of
+    Theorem~\ref{thm:halved_weight_zcl_not_rfp} separately refutes the reverse
+    implication from zero correlation length to renormalization fixed points.
+
+    \textbf{Source gap (adjacent regions).} The obstruction and its scope are
+    recorded in
+    \path{docs/paper-gaps/cpsv16_pure_zcl_adjacent_gap_cid_scope.tex}.
+    Theorem~\ref{thm:is_positive_gap_physical_cid_of_is_rfp} repairs only the
+    forward correlation statement when both complementary gaps are positive;
+    it does not establish the printed unrestricted three-way equivalence. That
+    equivalence is recorded here as refuted, not as a theorem awaiting proof.
+\end{theorem}
+\begin{proof}
+    \uses{thm:halved_weight_zcl_not_rfp, thm:bell_pair_chain_not_cid}
+    The Bell-pair chain refutes the implication from fixed points to zero
+    correlation length. The halved-weight tensor refutes the reverse
+    implication.
+\end{proof}
+
+\begin{theorem}[Auxiliary weighted-sector example]%
     \label{thm:halved_weight_zcl_not_rfp}
     \lean{MPSTensor.halvedWeightTensor_counterexample_to_unrestricted_zcl_iff_rfp}
     \lean{MPSTensor.halvedWeightTensor_isPhysicalBNTZCL}
@@ -90,11 +196,11 @@
     \lean{MPSTensor.halvedWeightTensor_sameMPV₂_halvedDecomp}
     \lean{MPSTensor.halvedWeightTensor_not_isTransferIdempotent}
     \leanok
-    \uses{def:source_bnt_zcl, def:mps_transfer_idempotence, def:sector_bnt_cf}
-    Let $P$ be the canonical decomposition with one scalar basis tensor
-    $C^0=(1)$, two one-dimensional copies, and respective weights $1$ and
-    $1/2$. Write $A=\mathcal A(P)$ for the tensor represented by $P$. Relative
-    to these sector coordinates, $A^0$ has block form
+    \uses{def:source_bnt_zcl, def:mps_transfer_idempotence,
+        def:sector_bnt_cf, def:same_mpv2}
+    Let $P$ be the auxiliary BNT sector decomposition with one scalar basis
+    tensor $C^0=(1)$, two one-dimensional copies, and weights $1$ and $1/2$.
+    Let $A=\mathcal A(P)$, so
     \begin{align}
         A^0
         &=
@@ -104,23 +210,46 @@
         \end{pmatrix}.
         \notag
     \end{align}
-    The weights $(1,1/2)$ satisfy the raw-weight BNT canonical-form
-    normalization, and the corresponding canonical decomposition represents
-    $A$. Its MPV coefficient at length~$N$ is $V^{(N)}(A)=1+2^{-N}$. The BNT
-    has one component, so local orthogonality is vacuous. Since the physical
-    space has dimension one, all physical correlations are independent of
-    separation. Thus $A$ has zero correlation length in the sense of
-    Definition~\ref{def:source_bnt_zcl}, but $A$ is not a renormalization fixed
-    point. Consequently \cite[Theorem~3.8]{Cirac2016MPDO_arXiv} is false under
-    its stated raw-weight BNT normalization.
+    Then $P$ satisfies the auxiliary BNT sector hypotheses,
+    $A=\mathcal A(P)$, and $A$ and $\mathcal A(P)$ generate the same
+    matrix-product vectors. Moreover, the singleton family $(C)$ is a physical
+    BNT zero-correlation-length family for $A$, while
+    \begin{align}
+        \E_A^2&\neq\E_A.
+        \notag
+    \end{align}
+    Its length-$N$ matrix-product-vector coefficient is
+    $V^{(N)}(A)=1+2^{-N}$.
 \end{theorem}
+% The theorem above is implemented through the auxiliary
+% `IsBNTCanonicalForm` interface; a duplicate `CPSVCanonicalFormData` package
+% for these matrices has not been added.
 \begin{proof}\leanok
-    The $(0,0)$ and $(1,1)$ entries of the one-letter blocking equation
-    $(A^0)^2=vA^0$ would give $1=v\cdot 1$ and
-    $\frac14=v\cdot\frac12$. The first equality forces $v=1$, while
-    substitution in the second gives $1/4=1/2$, a contradiction. Hence no such
-    scalar exists. The physical distance-independence assertion follows because
-    every observable on a one-letter physical space is scalar.
+    The unique basis block has bond dimension one. It is irreducible and
+    left-canonical, its self-overlap is identically $1$, and its singleton MPV
+    family is linearly independent. Pairwise distinctness is vacuous. The two
+    weights have moduli at most $1$, and the first has modulus $1$; hence $P$
+    satisfies the auxiliary BNT sector hypotheses.
+
+    The two one-dimensional weighted copies assemble exactly to
+    $A^0=\diag(1,1/2)$. This equality gives equality of the generated
+    matrix-product vectors at every length, and therefore at every positive
+    length. The sector power sum is
+    \begin{align}
+        1^N+\left(\tfrac12\right)^N
+        &=1+2^{-N}.
+        \notag
+    \end{align}
+    The scalar block is a normal tensor, the displayed coefficient spans the
+    MPV of $A$, and the singleton family is eventually linearly independent.
+    Since $d=1$, every physical observable is scalar and each two-point
+    expectation depends only on the total gap length. Thus physical
+    correlations are independent of distance, while local orthogonality is
+    vacuous for the singleton BNT family.
+
+    Finally, if $\E_A$ were idempotent, the one-letter blocking equation would
+    give $(A^0)^2=vA^0$ for some scalar $v$. Its two diagonal entries yield
+    $1=v$ and $1/4=v/2$, respectively, which is impossible.
 \end{proof}
 
 \begin{theorem}[Adjacent regions obstruct the RFP--CID forward implication]%
@@ -170,11 +299,9 @@
         \notag
     \end{align}
     Thus $A$ is a renormalization fixed point whose correlations are not
-    independent of the distance in the unrestricted sense of
-    Definition~\ref{def:source_physical_cid}: the forward implication of
-    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv} is false for adjacent regions,
-    because the block $\E_A^{0}=1$ between adjacent observables is not
-    governed by idempotence.
+    independent of distance in the unrestricted sense of
+    Definition~\ref{def:source_physical_cid}. The block $\E_A^{0}=1$ between
+    adjacent observables is not governed by idempotence.
 \end{theorem}
 \begin{proof}\leanok
     The letters are the rescaled matrix units
@@ -230,13 +357,13 @@
     $\E_{j,j'}=0$.
 \end{proof}
 
-\begin{lemma}[BNT basis of a canonical form is a basis of normal tensors for
-    its direct sum]%
-    \label{lem:bnt_cf_basis_is_bnt_for_direct_sum}
+\begin{theorem}[Auxiliary BNT basis gives a basis for its direct sum]%
+    \label{thm:bnt_cf_basis_is_bnt_for_direct_sum}
     \lean{MPSTensor.IsBNTCanonicalForm.isCPSVBasisOfNormalTensors_basisDirectSum}
     \leanok
     \uses{def:bnt_cpsv, def:sector_bnt_cf}
-    Let $P$ be a BNT canonical form with distinct basis tensors $(A_j)_j$, and
+    Let $P$ be an auxiliary BNT sector decomposition with distinct basis
+    tensors $(A_j)_j$, and
     let $A=\bigoplus_j A_j$ be their direct sum with one unit-weight copy of
     each sector. Then $(A_j)_j$ is a basis of normal tensors for $A$: every
     $A_j$ is a normal tensor, at every positive system length $N$
@@ -247,7 +374,7 @@
     \end{align}
     and the states $\{|V^{(N)}(A_j)\rangle\}_j$ are linearly independent for
     all sufficiently large $N$.
-\end{lemma}
+\end{theorem}
 \begin{proof}\leanok
     \uses{cor:sector_bnt_cf_basis_normal, thm:mpv_decomposition}
     Every basis block is irreducible and left-canonical with normalized
@@ -256,42 +383,38 @@
     unit-weight block-diagonal tensor, so its length-$N$ matrix-product vector
     splits as the sum of the block vectors by
     Theorem~\ref{thm:mpv_decomposition}. Eventual linear independence is part
-    of the canonical-form data of $P$.
+    of the auxiliary BNT sector hypotheses.
 \end{proof}
 
-\begin{theorem}[Corrected forward direction of the main MPS theorem,
-    multiplicity-one representative]%
+\begin{theorem}[Multiplicity-one fixed point implies positive-gap ZCL]%
     \label{thm:rfp_implies_positive_gap_bnt_zcl_cf_basis_direct_sum}
     \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_isPositiveGapBNTZCL}
     \leanok
     \uses{def:is_positive_gap_bnt_zcl, def:sector_bnt_cf,
         def:mps_transfer_idempotence}
-    Let $P$ be a BNT canonical form with distinct basis tensors $(A_j)_j$, and
+    Let $P$ be an auxiliary BNT sector decomposition with distinct basis
+    tensors $(A_j)_j$, and
     let $A=\bigoplus_j A_j$ be their direct sum with one unit-weight copy of
     each sector. If $A$ is a renormalization fixed point,
     \begin{align}
         \E_A^2&=\E_A,
         \notag
     \end{align}
-    then $A$ has positive-gap BNT zero correlation length: its physical
+    then the following restricted conclusion holds: its physical
     correlations are independent of the separation whenever both complementary
     gaps are positive, and for all distinct BNT components $j\ne j'$
     \begin{align}
         \E_{j,j'}&=0.
         \notag
     \end{align}
-    This is the implication (i)$\implies$(ii) of
-    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv} at the explicit multiplicity-one
-    unit-weight representative. The raw-weight unrestricted biconditional is
-    false by Theorem~\ref{thm:halved_weight_zcl_not_rfp}, and the
-    adjacent-region cases of the source CID are excluded by
-    Definition~\ref{def:is_positive_gap_bnt_zcl}; they do not follow from
-    idempotence in general, by Theorem~\ref{thm:bell_pair_chain_not_cid}.
+    This is a multiplicity-one, unit-weight, positive-gap statement. It does
+    not assert the physical zero-correlation-length conclusion of
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{lem:bnt_cf_basis_is_bnt_for_direct_sum,
+    \uses{thm:bnt_cf_basis_is_bnt_for_direct_sum,
         thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}
-    By Lemma~\ref{lem:bnt_cf_basis_is_bnt_for_direct_sum}, the distinct basis
+    By Theorem~\ref{thm:bnt_cf_basis_is_bnt_for_direct_sum}, the distinct basis
     tensors of $P$ are a basis of normal tensors for $A$. The basis blocks are
     irreducible, left-canonical, and pairwise gauge-phase distinct, so
     Theorem~\ref{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum} applies to
@@ -358,8 +481,10 @@
     \label{thm:bnt_rank_one_observables_sharp_length}
     \lean{MPSTensor.IsBNTCanonicalForm.exists_basis_physicalObservableTransfer_rankOne_le_three_totalDim_pow_five}
     \leanok
-    \uses{def:sector_bnt_cf, def:physical_observable_transfer}
-    Let $P$ be a BNT canonical form of total bond dimension $D$, and form the
+    \uses{def:sector_bnt_cf, def:physical_observable_transfer,
+        thm:bnt_sector_supported_physical_observable}
+    Let $P$ be an auxiliary BNT sector decomposition of total bond dimension
+    $D$, and form the
     direct sum $A=\bigoplus_j A_j$ with one unit-weight copy of each BNT basis
     tensor. There is a positive length $L\leq3D^5$ such that, for every basis
     sector $j$ and every $R,l\in\MN{D_j}$, a physical observable on $L$ sites
@@ -368,7 +493,7 @@
     of the block-injective physical-observable assertion used in
     \cite[proof of Theorem~3.8]{Cirac2016MPDO_arXiv}, equations (1252) and
     (1256) in the local source. It does not realize the weighted copy-pair
-    insertions for the raw canonical-form tensor $P.\mathrm{toTensor}$.
+    insertions for the full weighted tensor represented by $P$.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:sharp_bnt_block_separation,
@@ -430,7 +555,8 @@
     \leanok
     \uses{def:is_positive_gap_physical_cid, def:sector_bnt_cf,
         thm:bnt_rank_one_observables_sharp_length}
-    Let $P$ be a BNT canonical form, let $A=\bigoplus_k A_k$, and fix a
+    Let $P$ be an auxiliary BNT sector decomposition, let
+    $A=\bigoplus_k A_k$, and fix a
     sector $j$. Suppose there are matrices $r,l\in\MN{D_j}$ and a scalar
     $\lambda\ne0$ with $|\lambda|<1$ such that
     \begin{align}
@@ -462,14 +588,15 @@
     contrary to $|\lambda|<1$.
 \end{proof}
 
-\begin{theorem}[Conditional converse and equivalence at the multiplicity-one representative]%
+\begin{theorem}[Conditional positive-gap equivalence at the multiplicity-one representative]%
     \label{thm:positive_gap_bnt_zcl_conditional_converse}
     \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair}
     \lean{MPSTensor.IsBNTCanonicalForm.isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent_of_spectral_pair}
     \leanok
     \uses{def:is_positive_gap_bnt_zcl, def:mps_transfer_idempotence,
-        def:sector_bnt_cf}
-    Let $P$ be a BNT canonical form and $A=\bigoplus_j A_j$. Assume that every
+        def:sector_bnt_cf, thm:zcl_subleading_pair_excludes_cid}
+    Let $P$ be an auxiliary BNT sector decomposition and
+    $A=\bigoplus_j A_j$. Assume that every
     non-idempotent block $\E_j^2\ne\E_j$ has matrices $r_j,l_j$ and a scalar
     $\lambda_j$ satisfying the five spectral conditions in
     Theorem~\ref{thm:zcl_subleading_pair_excludes_cid}. Then
@@ -478,10 +605,10 @@
         &\Longleftrightarrow \E_A^2=\E_A.
         \notag
     \end{align}
-    % CPSV16 local source line 1250.
-    The extra spectral assumption is the assertion used in the proof of
-    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}; it is not a consequence
-    of non-idempotence for a general linear operator.
+    The spectral-pair hypothesis is assumed explicitly.
+% CPSV16 line 1250 uses such a pair without deriving it from non-idempotence;
+% a general non-idempotent operator may instead have only a nilpotent Jordan
+% part at eigenvalue zero.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:zcl_subleading_pair_excludes_cid,
@@ -497,14 +624,15 @@
     Theorem~\ref{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}.
 \end{proof}
 
-\begin{theorem}[Source physical ZCL implies idempotence under the spectral assumption]%
+\begin{theorem}[Physical ZCL implies idempotence under the spectral assumption]%
     \label{thm:physical_bnt_zcl_conditional_converse}
     \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_of_isPhysicalBNTZCL_of_spectral_pair}
     \leanok
-    \uses{def:mps_transfer_idempotence, def:sector_bnt_cf}
-    Under the assumptions of
-    Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse}, source
-    physical BNT zero correlation length for $A=\bigoplus_j A_j$ implies
+    \uses{def:mps_transfer_idempotence, def:sector_bnt_cf,
+        thm:positive_gap_bnt_zcl_conditional_converse}
+    Under the spectral-pair hypotheses of
+    Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse}, physical BNT
+    zero correlation length for $A=\bigoplus_j A_j$ implies
     $\E_A^2=\E_A$.
 \end{theorem}
 \begin{proof}\leanok
@@ -520,14 +648,16 @@
     \notready
     \uses{def:is_positive_gap_bnt_zcl, def:mps_transfer_idempotence,
         def:sector_bnt_cf}
-    Let $P$ be a BNT canonical form and $A=\bigoplus_j A_j$. If $A$ has
+    Let $P$ be an auxiliary BNT sector decomposition and
+    $A=\bigoplus_j A_j$. If $A$ has
     positive-gap BNT zero correlation length, then $\E_A^2=\E_A$.
 \end{theorem}
 
 \begin{remark}[Remaining obstructions in the printed converse]
     For the multiplicity-one unit-weight representative, the sector-supported
-    observables require no additional hypothesis. The full canonical-form
-    equations (1252) and (1256) also contain all repeated-copy pairs and their
+    observables require no additional hypothesis. The full literal CPSV
+    canonical-form equations (1252) and (1256) also contain all repeated-copy
+    pairs and their
     raw weight powers; the theorem above does not realize those weighted
     insertions. Moreover, the preceding claim that $\E_j^2\ne\E_j$ yields a
     nonzero eigenvalue $\lambda$ with $|\lambda|<1$ is not valid for a


### PR DESCRIPTION
## What changed

- separate the legacy one-block/virtual-insertion predicates from literal CPSV CF, CFII, physical CID, local orthogonality, and ZCL
- state the existing RG result only for each selected primitive block
- replace invented source-facing packaging terms by the source's square-root fixed-point and joint-isometry formulas
- correct the normal-tensor square-root form using the line-1300 reference tensor
- add mathematical, cited `\notready` entries for CPSV16 Theorems 3.8, 3.10, 3.11, and Corollary 3.12
- state the multiplicity-one, unit-weight, positive-gap ZCL result as a restricted theorem rather than a repair of the literal source theorem
- keep the halved-weight example exactly on its proved auxiliary `IsBNTCanonicalForm` surface
- align theorem environments, labels, references, and dependency metadata

## Source

`Papers/1606.00608/MPDO-22-12-17-2.tex`, especially lines 237--246, 437--590, 1211--1300, and the Appendix-A canonical-form definitions.

## Validation

- declaration inventory regeneration and blueprint-Lean synchronization
- `leanblueprint checkdecls`
- repository-wide duplicate-label, missing-reference, missing-dependency, and self-dependency scans
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'` and no undefined cross-references
- independent source/type review through three rounds; no remaining findings
- `git diff --check`

Closes #4884. Advances #2380 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX blueprint and cross-reference/metadata edits only; no Lean proof logic changes. Main risk is documentation drift or broken refs if labels are inconsistent elsewhere.
> 
> **Overview**
> **Chapter 26** is reframed so auxiliary one-block/virtual-insertion predicates are clearly separated from literal CPSV canonical form, physical CID, and BNT zero correlation length. Proved results are labeled as **restricted** (per-block primitive RG flow, multiplicity-one unit-weight **positive-gap** ZCL) instead of standing in for the printed CPSV theorems.
> 
> **Terminology and packaging** now follow the source: *isometry canonical form* becomes **square-root fixed-point form** with \(A^i=X\sqrt{\rho}\,U^iX^{-1}\) and trace-one \(\rho\); *residual isometry family* becomes the **joint isometry condition**; block-family and BNT packaging is **auxiliary** relative to literal `def:cpsv_canonical_form`. CPSV citations move to **Theorem/Corollary 3.8–3.12**; the one-letter Gram identity is promoted from lemma to **`thm:residual_isometry_family_one_gram`** (including the ch13 `\uses` fix).
> 
> **New `\notready` entries** record CPSV Theorems **3.8, 3.10, 3.11** and Corollary **3.12** as refuted or incomplete as printed (halved-weight raw weights, Bell-pair adjacent gaps, repeated-copy routing), while distinct-block direct-sum characterizations stay at the proved multiplicity-one level. Figures and narrative use \(\sqrt\rho\) and document the square-root diagonal repair via `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e6a2481ba9f3b60a22b7090e53cc7aeaee66c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->