### PR TITLE
feat(canonical-form): specialize the CPSV BNT characterization

### DIFF
--- a/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
+++ b/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
@@ -536,4 +536,37 @@ theorem isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal
     simpa [dimActive, blocksActive] using
       hCover (activeEquiv k) (activeEquiv k).property
 
+/-- Characterization of a basis of normal tensors for literal CPSV canonical-form data.
+
+This specializes arXiv:1606.00608, Proposition 2.7 (`prop:char-BNT`, lines
+271--301 and 1137--1148), to the data of eq. `II_CF1`.
+
+**Local fix (active blocks):** Only blocks with nonzero weight are covered: a
+syntactically listed zero-weight block contributes nothing to any positive-length
+matrix product vector. See
+`docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`. -/
+theorem CPSVCanonicalFormData.isCPSVBasisOfNormalTensors_iff_covered_and_minimal
+    {g : ℕ} {dimB : Fin g → ℕ} [∀ j, NeZero (dimB j)]
+    (data : CPSVCanonicalFormData A)
+    (basis : (j : Fin g) → MPSTensor d (dimB j)) :
+    IsCPSVBasisOfNormalTensors A (fun j ↦ ⟨dimB j, basis j⟩) ↔
+      (∀ j, IsNormalTensor (basis j)) ∧
+      (∀ k : Fin data.r, data.weights k ≠ 0 →
+        ∃ j : Fin g, ∃ hdim : dimB j = data.dim k,
+        ∃ X : GL (Fin (data.dim k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, data.blocks k i = ζ •
+            ((X : Matrix (Fin (data.dim k)) (Fin (data.dim k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis j)) i *
+              (↑(X⁻¹) : Matrix (Fin (data.dim k)) (Fin (data.dim k)) ℂ))) ∧
+      (∀ j k : Fin g, j ≠ k → ∀ hdim : dimB j = dimB k,
+        ¬ ∃ X : GL (Fin (dimB k)) ℂ, ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+          ∀ i, basis k i = ζ •
+            ((X : Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ) *
+              (cast (congr_arg (MPSTensor d) hdim) (basis j)) i *
+              (↑(X⁻¹) : Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ))) := by
+  letI : ∀ k, NeZero (data.dim k) := fun k ↦ ⟨Nat.ne_of_gt (data.dim_pos k)⟩
+  exact isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal
+    A data.weights data.blocks basis data.blocks_normal
+      data.sameMPV₂Pos_toTensorFromBlocks
+
 end MPSTensor

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -485,6 +485,52 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     (\ref{eq:cpsv_canonical_form_mpv_expansion}).
 \end{proof}
 
+\begin{theorem}[BNT characterization for CPSV canonical form]
+    \label{thm:cpsv_canonical_form_bnt_characterization}
+    \lean{MPSTensor.CPSVCanonicalFormData.isCPSVBasisOfNormalTensors_iff_covered_and_minimal}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:bnt_cpsv}
+    % Maintainer source anchors: CPSV16 prop:char-BNT, lines 278--301 and 1137--1148.
+    Let $A$ have canonical-form data as in~(\ref{eq:cpsv_canonical_form}), and
+    let $(B_j)_{j=1}^{g}$ have positive bond dimensions. With
+    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$, the family $(B_j)_{j=1}^{g}$ is a
+    basis of normal tensors for $A$ if and only if
+    \begin{align}
+        &\bigl(\forall j,\ B_j\text{ is normal}\bigr)
+        \notag\\
+        &\quad\land
+        \bigl(\forall k\in K_{\mathrm{act}},\ \exists j,X_k,\phi_k,\
+        \forall i,\ A_k^i=e^{i\phi_k}X_kB_j^iX_k^{-1}\bigr)
+        \notag\\
+        &\quad\land
+        \bigl(\forall j\ne j',\ \nexists X,\phi,\ \forall i,\
+        B_{j'}^i=e^{i\phi}XB_j^iX^{-1}\bigr).
+        \label{eq:cpsv_cf_bnt_characterization}
+    \end{align}
+    Each displayed conjugacy also requires the two bond dimensions to agree,
+    and every scalar $e^{i\phi}$ has modulus one. This is
+    \cite[Proposition~2.7 and Appendix~A]{Cirac2016MPDO_arXiv}, specialized to
+    the literal canonical-form data.
+
+    \textbf{Local fix (active blocks):} coverage in
+    (\ref{eq:cpsv_cf_bnt_characterization}) applies only to listed blocks with
+    $\mu_k\ne0$. The display defining canonical form permits $\mu_k=0$, and a
+    zero-weight block contributes nothing to any positive-length matrix product
+    vector. Thus the theorem does not claim coverage of every syntactically
+    listed block. The comparison is recorded in
+    \path{docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:cpsv_canonical_form, thm:cpsv_bnt_characterization}
+    The canonical-form data supply normality of every $A_k$ and the
+    positive-length identity
+    $\ket{V^{(N)}(A)}=\sum_k\mu_k^N\ket{V^{(N)}(A_k)}$.
+    Substitution of these two facts into
+    Theorem~\ref{thm:cpsv_bnt_characterization} gives
+    (\ref{eq:cpsv_cf_bnt_characterization}).
+\end{proof}
+
 The projector-closure result in
 Theorem~\ref{thm:projector_closure_canonical_form} gives normal blocks and
 orthogonal ambient embeddings under the source hypotheses. Combining these


### PR DESCRIPTION
## What changed

- specialize the proved BNT characterization directly to `CPSVCanonicalFormData`
- reuse literal canonical-form block normality and positive-length MPV equality from #4883
- retain the proved active-block boundary
  \[
  K_{\mathrm{act}}=\{k\mid \mu_k\ne0\},
  \]
  so only nonzero-weight listed blocks require gauge-phase coverage
- add formula-first Chapter 9 coverage and explicitly record why zero-weight listed blocks cannot be recovered from positive-length MPVs

## Source

CPSV16 lines 271--301 and 1137--1148 (`prop:char-BNT`, `eq:II_ABasicTensors`, `eq:II_X`, and `decBSV`).

## Validation

- targeted `BNTCharacterization` build and full `lake build` (9748 jobs)
- import-aggregator, module-policy, style, proof-integrity, and prose gates
- declaration regeneration, blueprint sync, and `checkdecls`
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'`
- independent source/API review: approved with no findings

Depends on merged PR #4883. Closes #4882. Advances #2380 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive theorem and prose only; no changes to existing BNT proof logic beyond instantiating the general characterization with canonical-form fields.
> 
> **Overview**
> Adds a **Lean iff** on `CPSVCanonicalFormData` stating when a candidate family is a basis of normal tensors for the ambient tensor: every candidate is normal, each **nonzero-weight** canonical block is gauge–phase equivalent to some candidate, and distinct candidates are not gauge–phase equivalent. The proof is a one-line specialization of `isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal`, using block normality and positive-length MPV equality already carried by the data type.
> 
> **Blueprint (Chapter 9)** gets a matching theorem and short proof (via `thm:cpsv_bnt_characterization`), with an explicit **active-block** note: coverage is only for \(K_{\mathrm{act}}=\{k:\mu_k\ne0\}\), since zero-weight listed blocks do not affect positive-length MPVs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7797e91a748c39b29767749f02e9300a1c46045d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

