### PR TITLE
refactor(Channel/Irreducible): isolate scaling from Perron-Frobenius existence

### DIFF
--- a/TNLean/Channel/Irreducible.lean
+++ b/TNLean/Channel/Irreducible.lean
@@ -19,6 +19,7 @@ import TNLean.Channel.Irreducible.Growth.OrthogonalTrace
 import TNLean.Channel.Irreducible.Growth.Preservation
 import TNLean.Channel.Irreducible.KrausSetup
 import TNLean.Channel.Irreducible.PerronFrobenius
+import TNLean.Channel.Irreducible.Scaling
 import TNLean.Channel.Irreducible.Similarity
 import TNLean.Channel.Irreducible.SpectralRadius
 import TNLean.Channel.Irreducible.TraceAdjoint

--- a/TNLean/Channel/Irreducible/Scaling.lean
+++ b/TNLean/Channel/Irreducible/Scaling.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Irreducible.Basic
+
+/-!
+# Scaling irreducible maps
+
+This module isolates the elementary fact that a nonzero scalar multiple of an
+irreducible map remains irreducible.  Keeping it separate from Perron--Frobenius
+existence avoids loading the fixed-point and MPS normalization development in
+consumers that only need scaling.
+-/
+
+open scoped Matrix
+
+variable {D : ℕ}
+
+/-- Irreducibility is preserved under scaling by a nonzero complex number.
+This is the scalar case of Wolf Proposition 6.6. -/
+theorem isIrreducibleMap_smul {c : ℂ} (hc : c ≠ 0)
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hIrr : IsIrreducibleMap E) :
+    IsIrreducibleMap (c • E) := by
+  intro P hP_proj hP_inv
+  apply hIrr P hP_proj
+  intro X
+  have h := hP_inv X
+  simp only [LinearMap.smul_apply] at h
+  have h1 : c • (P * E (P * X * P) * P) = c • E (P * X * P) := by
+    calc
+      c • (P * E (P * X * P) * P) =
+          (c • (P * E (P * X * P))) * P := (smul_mul_assoc c _ P).symm
+      _ = (P * (c • E (P * X * P))) * P := by rw [mul_smul_comm]
+      _ = P * (c • E (P * X * P)) * P := by rw [Matrix.mul_assoc]
+      _ = c • E (P * X * P) := h
+  exact (smul_right_injective _ hc) h1

--- a/TNLean/Channel/Irreducible/Similarity.lean
+++ b/TNLean/Channel/Irreducible/Similarity.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.PerronFrobenius.Existence
+import TNLean.Channel.Irreducible.Scaling
 import TNLean.Algebra.PosSemidefSupport
 
 /-!

--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.PerronFrobenius.Normalization
+import TNLean.Channel.Irreducible.Scaling
 import TNLean.Algebra.MatrixAux
 import TNLean.Axioms.BrouwerFixedPoint
 import TNLean.MPS.Irreducible.Adjoint
@@ -165,34 +166,6 @@ theorem exists_posSemidef_eigenvector_general
     push Not at hNZ
     obtain ⟨ρ₀, hρ₀_psd, hρ₀_ne, hEρ₀⟩ := hNZ
     exact ⟨ρ₀, 0, hρ₀_psd, hρ₀_ne, le_refl 0, by simp [hEρ₀]⟩
-
-/-! ## Scaling preserves irreducibility -/
-
-/-- Irreducibility is preserved under scaling by a nonzero complex number.
-This is a special case of Wolf Proposition 6.6 (similarity transformations
-preserving irreducibility) restricted to scalar similarity. -/
-theorem isIrreducibleMap_smul {c : ℂ} (hc : c ≠ 0)
-    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hIrr : IsIrreducibleMap E) :
-    IsIrreducibleMap (c • E) := by
-  intro P hP_proj hP_inv
-  apply hIrr P hP_proj
-  intro X
-  have h := hP_inv X
-  simp only [LinearMap.smul_apply] at h
-  -- h : P * (c • E (P * X * P)) * P = c • E (P * X * P)
-  -- We need: P * E(PXP) * P = E(PXP)
-  -- h : P * (c • E(PXP)) * P = c • E(PXP)
-  -- Goal: P * E(PXP) * P = E(PXP)
-  -- From: c • (P * E(PXP) * P) = P * (c • E(PXP)) * P (by smul_mul_assoc/mul_smul_comm)
-  --       = c • E(PXP) (by h)
-  have h1 : c • (P * E (P * X * P) * P) = c • E (P * X * P) := by
-    calc c • (P * E (P * X * P) * P)
-        = (c • (P * E (P * X * P))) * P := (smul_mul_assoc c _ P).symm
-      _ = (P * (c • E (P * X * P))) * P := by rw [mul_smul_comm]
-      _ = P * (c • E (P * X * P)) * P := by rw [Matrix.mul_assoc]
-      _ = c • E (P * X * P) := h
-  exact (smul_right_injective _ hc) h1
 
 /-! ## Application to MPS tensors -/
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -135,7 +135,7 @@ Uses Brouwer's fixed-point theorem on density matrices (proved in
 
 ### Wolf Proposition 6.6 (Similarity preserving irreducibility) — FORMALIZED
 
-* Scalar case: `isIrreducibleMap_smul` — `TNLean.Channel.PerronFrobenius.Existence`
+* Scalar case: `isIrreducibleMap_smul` — `TNLean.Channel.Irreducible.Scaling`
 * Similarity case: `isIrreducibleMap_similarity` — `TNLean.Channel.Irreducible.Similarity`
 * Full Wolf form `T' = c C⁻¹ T(C · C†) C⁻†`:
   `isIrreducibleMap_full_similarity` (and the stronger


### PR DESCRIPTION
## Summary

- move `isIrreducibleMap_smul` unchanged into a small `Channel.Irreducible.Scaling` leaf module
- make `Similarity` import that leaf instead of the full Perron–Frobenius existence and MPS-normalization development
- keep the public declaration name and theorem statements unchanged
- regenerate the irreducible-channel import aggregator

## Why

Profiling on current `main` showed that `Similarity` spent only about 9 seconds elaborating its own declarations; most of its standalone wall time came from loading `Channel.PerronFrobenius.Existence`. `SpectralRadius` and `FromSpectral` import `Similarity`, so that overly broad edge propagated into both hotspots.

Observed measurements in the isolated seeded worktree:

| Module | Current-main standalone wall | Refactored targeted Lake job |
| --- | ---: | ---: |
| `Channel.Irreducible.Similarity` | 60s | 7.4s |
| `Channel.Irreducible.SpectralRadius` | 84s | 15s |
| `Channel.Irreducible.FromSpectral` | 94s | 16s |

These two columns use different runners/modes and are not presented as controlled benchmark ratios. A comparable standalone rerun of `Similarity` after the refactor was 39s versus the 60s current-main observation. The exact PR CI changed-module timing is the authoritative threshold evidence. The structural result is deterministic: `Similarity` no longer loads the Perron–Frobenius existence, Brouwer, and MPS-normalization cone.

The older issue measurements were also contention-inflated. This addresses #4866.

## Validation

- `lake build TNLean.Channel.Irreducible.Scaling TNLean.Channel.Irreducible.Similarity`
- `lake build TNLean.Channel.PerronFrobenius.Existence TNLean.Channel.Irreducible.SpectralRadius TNLean.Channel.Irreducible.FromSpectral`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity grep on changed Lean files
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-preserving module split and import rewiring only; no changes to theorem statements or proof logic beyond relocation.
> 
> **Overview**
> Moves **`isIrreducibleMap_smul`** into a new leaf module **`TNLean.Channel.Irreducible.Scaling`** (still only importing **`Irreducible.Basic`**), with the proof unchanged.
> 
> **`Similarity`** now depends on **`Scaling`** instead of **`Channel.PerronFrobenius.Existence`**, so similarity and downstream modules (**`SpectralRadius`**, **`FromSpectral`**) no longer pull in Brouwer fixed-point, MPS normalization, and the rest of the existence development when they only need scalar scaling. **`Existence`** imports **`Scaling`** for the same theorem where MPS rescaling proofs still need it.
> 
> The irreducible-channel import aggregator and **`WolfChapter6Index`** point the scalar Wolf Prop. 6.6 case at **`Irreducible.Scaling`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ea0e261db6caf00254ed5a042392343e6434c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->