### PR TITLE
refactor(MPS/Examples): reduce concrete matrix proof costs

### DIFF
--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -23,31 +23,6 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Equivalence between `N`-block injectivity and injectivity of the blocked
-tensor `blockTensor A N`. -/
-lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
-    IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
-  classical
-  have hRange :
-      Set.range (fun i : Fin (blockPhysDim d N) =>
-        evalWord A (List.ofFn (decodeBlock d N i))) =
-        Set.range (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
-    ext M
-    constructor
-    · rintro ⟨i, rfl⟩
-      exact ⟨decodeBlock d N i, rfl⟩
-    · rintro ⟨σ, rfl⟩
-      exact ⟨Fin.cast (blockPhysDim_eq_pow d N).symm (finFunctionFinEquiv σ), by
-        simp [decodeBlock, Fin.cast_cast]⟩
-  unfold IsNBlkInjective IsInjective blockTensor
-  have hSpan :
-      Submodule.span ℂ
-          (Set.range fun i : Fin (blockPhysDim d N) =>
-            evalWord A (List.ofFn (decodeBlock d N i))) =
-        Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
-    simp [hRange]
-  exact ⟨hSpan.trans, hSpan.symm.trans⟩
-
 end MPSTensor
 
 namespace MPSChainTensor

--- a/TNLean/MPS/Chain/BlockedChainFT.lean
+++ b/TNLean/MPS/Chain/BlockedChainFT.lean
@@ -19,12 +19,6 @@ blocked tensors.
 * [arXiv:1804.04964](https://arxiv.org/abs/1804.04964)
 -/
 
-namespace MPSTensor
-
-variable {d D : ℕ}
-
-end MPSTensor
-
 namespace MPSChainTensor
 
 variable {d D : ℕ}

--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -149,6 +149,31 @@ noncomputable def blockTensor (A : MPSTensor d D) (L : ℕ) :
     blockTensor (d := d) (D := D) A 1 i = A (singleBlockEquiv d i) := by
   simp [blockTensor, MPSTensor.evalWord]
 
+/-- Equivalence between `N`-block injectivity and injectivity of the blocked
+tensor `blockTensor A N`. -/
+lemma isNBlkInjective_iff_blockTensor_isInjective (A : MPSTensor d D) (N : ℕ) :
+    IsNBlkInjective A N ↔ IsInjective (blockTensor A N) := by
+  classical
+  have hRange :
+      Set.range (fun i : Fin (blockPhysDim d N) =>
+        evalWord A (List.ofFn (decodeBlock d N i))) =
+        Set.range (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
+    ext M
+    constructor
+    · rintro ⟨i, rfl⟩
+      exact ⟨decodeBlock d N i, rfl⟩
+    · rintro ⟨σ, rfl⟩
+      exact ⟨Fin.cast (blockPhysDim_eq_pow d N).symm (finFunctionFinEquiv σ), by
+        simp [decodeBlock, Fin.cast_cast]⟩
+  unfold IsNBlkInjective IsInjective blockTensor
+  have hSpan :
+      Submodule.span ℂ
+          (Set.range fun i : Fin (blockPhysDim d N) =>
+            evalWord A (List.ofFn (decodeBlock d N i))) =
+        Submodule.span ℂ (Set.range fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) := by
+    simp [hRange]
+  exact ⟨hSpan.trans, hSpan.symm.trans⟩
+
 /-- Flatten a word in blocked indices into an ordinary word in `Fin d` (list-level). -/
 noncomputable def flattenBlockedWord (d L : ℕ) : List (Fin (blockPhysDim d L)) → List (Fin d)
   | w => (w.map (wordOfBlock d L)).flatten

--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -222,17 +222,16 @@ private lemma single_10_in_wordSpan :
 
 /-- The AKLT tensor is 2-block injective: products of length 2 span M₂(ℂ). -/
 theorem aklt_isNBlkInjective_two : IsNBlkInjective akltTensor 2 := by
-  rw [IsNBlkInjective, eq_top_iff]
-  intro M _
-  have hM : M = M 0 0 • Matrix.single 0 0 1 + M 0 1 • Matrix.single 0 1 1 +
-      M 1 0 • Matrix.single 1 0 1 + M 1 1 • Matrix.single 1 1 1 := by
-    ext a b; fin_cases a <;> fin_cases b <;> simp [Matrix.single]
-  rw [hM]
-  exact Submodule.add_mem _ (Submodule.add_mem _ (Submodule.add_mem _
-    (Submodule.smul_mem _ _ single_00_in_wordSpan)
-    (Submodule.smul_mem _ _ single_01_in_wordSpan))
-    (Submodule.smul_mem _ _ single_10_in_wordSpan))
-    (Submodule.smul_mem _ _ single_11_in_wordSpan)
+  rw [IsNBlkInjective]
+  apply (Submodule.eq_top_iff_forall_basis_mem
+    (Matrix.stdBasis ℂ (Fin 2) (Fin 2))).2
+  rintro ⟨i, j⟩
+  rw [Matrix.stdBasis_eq_single]
+  fin_cases i <;> fin_cases j
+  · exact single_00_in_wordSpan
+  · exact single_01_in_wordSpan
+  · exact single_10_in_wordSpan
+  · exact single_11_in_wordSpan
 
 /-- The AKLT tensor is normal: it is `2`-block-injective. -/
 theorem aklt_isNormal : IsNormal akltTensor :=
@@ -352,6 +351,16 @@ private lemma akltPhysP1P2_comm : akltPhysP1 * akltPhysP2 = akltPhysP2 * akltPhy
   ext i j; fin_cases i <;> fin_cases j <;>
     simp [akltPhysP1, akltPhysP2, Matrix.mul_apply, Fin.sum_univ_three]
 
+private lemma akltPhysP1_conjTranspose : akltPhysP1ᴴ = akltPhysP1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [akltPhysP1, Matrix.conjTranspose_apply]
+
+private lemma akltPhysP2_conjTranspose : akltPhysP2ᴴ = akltPhysP2 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [akltPhysP2, Matrix.conjTranspose_apply]
+
 /-- The `Z₂ × Z₂` on-site representation on the spin-1 physical space.  The two
 generators act by two commuting spin-1 `π`-rotations about orthogonal axes. -/
 def akltZ2Z2Action :
@@ -361,16 +370,19 @@ def akltZ2Z2Action :
 
 @[simp] private lemma akltZ2Z2Action_10 :
     akltZ2Z2Action (Multiplicative.ofAdd ((1, 0) : ZMod 2 × ZMod 2)) = akltPhysP1 := by
-  simp only [akltZ2Z2Action, ofCommutingInvolutions_ofAdd_10]
+  exact ofCommutingInvolutions_ofAdd_10 akltPhysP1 akltPhysP2
+    akltPhysP1_sq akltPhysP2_sq akltPhysP1P2_comm
 
 @[simp] private lemma akltZ2Z2Action_01 :
     akltZ2Z2Action (Multiplicative.ofAdd ((0, 1) : ZMod 2 × ZMod 2)) = akltPhysP2 := by
-  simp only [akltZ2Z2Action, ofCommutingInvolutions_ofAdd_01]
+  exact ofCommutingInvolutions_ofAdd_01 akltPhysP1 akltPhysP2
+    akltPhysP1_sq akltPhysP2_sq akltPhysP1P2_comm
 
 @[simp] private lemma akltZ2Z2Action_11 :
     akltZ2Z2Action (Multiplicative.ofAdd ((1, 1) : ZMod 2 × ZMod 2)) =
       akltPhysP1 * akltPhysP2 := by
-  simp only [akltZ2Z2Action, ofCommutingInvolutions_ofAdd_11]
+  exact ofCommutingInvolutions_ofAdd_11 akltPhysP1 akltPhysP2
+    akltPhysP1_sq akltPhysP2_sq akltPhysP1P2_comm
 
 /-! #### Virtual gauges `σz` and `iσy σz` -/
 
@@ -498,18 +510,10 @@ generators act by real symmetric involutive matrices, so each group element equa
 its own adjoint inverse. -/
 theorem aklt_isUnitary_Z2Z2 (g : Multiplicative (ZMod 2 × ZMod 2)) :
     akltZ2Z2Action g * (akltZ2Z2Action g)ᴴ = 1 := by
-  rcases zmod2sq_cases g with rfl | rfl | rfl | rfl
-  · simp
-  · rw [akltZ2Z2Action_10]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [akltPhysP1, Matrix.mul_apply, Fin.sum_univ_three, Matrix.conjTranspose_apply]
-  · rw [akltZ2Z2Action_01]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [akltPhysP2, Matrix.mul_apply, Fin.sum_univ_three, Matrix.conjTranspose_apply]
-  · rw [akltZ2Z2Action_11]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [akltPhysP1, akltPhysP2, Matrix.mul_apply, Fin.sum_univ_three,
-        Matrix.conjTranspose_apply]
+  exact ofCommutingInvolutions_mul_conjTranspose akltPhysP1 akltPhysP2
+    akltPhysP1_sq akltPhysP2_sq akltPhysP1P2_comm
+    (by rw [akltPhysP1_conjTranspose, akltPhysP1_sq])
+    (by rw [akltPhysP2_conjTranspose, akltPhysP2_sq]) g
 
 /-! ### The AKLT factor system is the non-trivial class of `H²(Z₂ × Z₂, U(1))`
 

--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -200,17 +200,16 @@ private lemma cluster_single_11_in_wordSpan :
 
 /-- The cluster tensor is `2`-block injective: products of length `2` span `M₂(ℂ)`. -/
 theorem cluster_isNBlkInjective_two : IsNBlkInjective clusterTensor 2 := by
-  rw [IsNBlkInjective, eq_top_iff]
-  intro M _
-  have hM : M = M 0 0 • Matrix.single 0 0 1 + M 0 1 • Matrix.single 0 1 1 +
-      M 1 0 • Matrix.single 1 0 1 + M 1 1 • Matrix.single 1 1 1 := by
-    ext a b; fin_cases a <;> fin_cases b <;> simp [Matrix.single]
-  rw [hM]
-  exact Submodule.add_mem _ (Submodule.add_mem _ (Submodule.add_mem _
-    (Submodule.smul_mem _ _ cluster_single_00_in_wordSpan)
-    (Submodule.smul_mem _ _ cluster_single_01_in_wordSpan))
-    (Submodule.smul_mem _ _ cluster_single_10_in_wordSpan))
-    (Submodule.smul_mem _ _ cluster_single_11_in_wordSpan)
+  rw [IsNBlkInjective]
+  apply (Submodule.eq_top_iff_forall_basis_mem
+    (Matrix.stdBasis ℂ (Fin 2) (Fin 2))).2
+  rintro ⟨i, j⟩
+  rw [Matrix.stdBasis_eq_single]
+  fin_cases i <;> fin_cases j
+  · exact cluster_single_00_in_wordSpan
+  · exact cluster_single_01_in_wordSpan
+  · exact cluster_single_10_in_wordSpan
+  · exact cluster_single_11_in_wordSpan
 
 /-- The cluster tensor is normal: it is `2`-block-injective. -/
 theorem cluster_isNormal : IsNormal clusterTensor :=
@@ -274,37 +273,18 @@ private lemma decode_3 : decodeBlock 2 2 (Fin.cast cluster_blockPhysDim.symm 3) 
 /-- The length-`2` blocked cluster tensor is injective: its four matrices span
 `M₂(ℂ)`.  This is the blocked-tensor form of `cluster_isNBlkInjective_two`. -/
 theorem clusterBlocked_isInjective : IsInjective clusterBlocked := by
-  rw [IsInjective, eq_top_iff]
-  intro M _
-  have hspan : ∀ p q : Fin 2, Matrix.single p q (1 : ℂ) ∈
-      Submodule.span ℂ (Set.range clusterBlocked) := by
-    have mem : ∀ i : Fin 4, clusterBlocked i ∈ Submodule.span ℂ (Set.range clusterBlocked) :=
-      fun i => Submodule.subset_span ⟨i, rfl⟩
-    intro p q
-    fin_cases p <;> fin_cases q
-    · refine (show Matrix.single (0 : Fin 2) 0 (1 : ℂ) = clusterBlocked 0 + clusterBlocked 1 from
-        by ext a b; fin_cases a <;> fin_cases b <;>
-          simp [Matrix.single, Matrix.add_apply, smul_eq_mul]; norm_num) ▸
-        Submodule.add_mem _ (mem 0) (mem 1)
-    · refine (show Matrix.single (0 : Fin 2) 1 (1 : ℂ) = clusterBlocked 2 - clusterBlocked 3 from
-        by ext a b; fin_cases a <;> fin_cases b <;>
-          simp [Matrix.single, Matrix.sub_apply, smul_eq_mul]; norm_num) ▸
-        Submodule.sub_mem _ (mem 2) (mem 3)
-    · refine (show Matrix.single (1 : Fin 2) 0 (1 : ℂ) = clusterBlocked 0 - clusterBlocked 1 from
-        by ext a b; fin_cases a <;> fin_cases b <;>
-          simp [Matrix.single, Matrix.sub_apply, smul_eq_mul]; norm_num) ▸
-        Submodule.sub_mem _ (mem 0) (mem 1)
-    · refine (show Matrix.single (1 : Fin 2) 1 (1 : ℂ) = clusterBlocked 2 + clusterBlocked 3 from
-        by ext a b; fin_cases a <;> fin_cases b <;>
-          simp [Matrix.single, Matrix.add_apply, smul_eq_mul]; norm_num) ▸
-        Submodule.add_mem _ (mem 2) (mem 3)
-  have hM : M = M 0 0 • Matrix.single 0 0 1 + M 0 1 • Matrix.single 0 1 1 +
-      M 1 0 • Matrix.single 1 0 1 + M 1 1 • Matrix.single 1 1 1 := by
-    ext a b; fin_cases a <;> fin_cases b <;> simp [Matrix.single]
-  rw [hM]
-  exact Submodule.add_mem _ (Submodule.add_mem _ (Submodule.add_mem _
-    (Submodule.smul_mem _ _ (hspan 0 0)) (Submodule.smul_mem _ _ (hspan 0 1)))
-    (Submodule.smul_mem _ _ (hspan 1 0))) (Submodule.smul_mem _ _ (hspan 1 1))
+  have hRange :
+      Set.range clusterBlocked = Set.range (blockTensor clusterTensor 2) := by
+    ext M
+    constructor
+    · rintro ⟨i, rfl⟩
+      exact ⟨Fin.cast cluster_blockPhysDim.symm i, rfl⟩
+    · rintro ⟨i, rfl⟩
+      exact ⟨Fin.cast cluster_blockPhysDim i, by
+        simp [clusterBlocked, Fin.cast_cast]⟩
+  rw [IsInjective, hRange]
+  exact (isNBlkInjective_iff_blockTensor_isInjective clusterTensor 2).1
+    cluster_isNBlkInjective_two
 
 /-! ### The Z₂ × Z₂ on-site symmetry of the blocked tensor
 
@@ -336,6 +316,16 @@ private lemma clusterPhysX1X2_comm :
   ext i j; fin_cases i <;> fin_cases j <;>
     simp [clusterPhysX1, clusterPhysX2, Matrix.mul_apply, Fin.sum_univ_four]
 
+private lemma clusterPhysX1_conjTranspose : clusterPhysX1ᴴ = clusterPhysX1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [clusterPhysX1, Matrix.conjTranspose_apply]
+
+private lemma clusterPhysX2_conjTranspose : clusterPhysX2ᴴ = clusterPhysX2 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [clusterPhysX2, Matrix.conjTranspose_apply]
+
 /-- The `Z₂ × Z₂` on-site representation on the blocked physical space.  The two
 generators act by `σx ⊗ I` and `I ⊗ σx`. -/
 def clusterZ2Z2Action :
@@ -345,16 +335,19 @@ def clusterZ2Z2Action :
 
 @[simp] private lemma clusterZ2Z2Action_10 :
     clusterZ2Z2Action (Multiplicative.ofAdd ((1, 0) : ZMod 2 × ZMod 2)) = clusterPhysX1 := by
-  simp only [clusterZ2Z2Action, ofCommutingInvolutions_ofAdd_10]
+  exact ofCommutingInvolutions_ofAdd_10 clusterPhysX1 clusterPhysX2
+    clusterPhysX1_sq clusterPhysX2_sq clusterPhysX1X2_comm
 
 @[simp] private lemma clusterZ2Z2Action_01 :
     clusterZ2Z2Action (Multiplicative.ofAdd ((0, 1) : ZMod 2 × ZMod 2)) = clusterPhysX2 := by
-  simp only [clusterZ2Z2Action, ofCommutingInvolutions_ofAdd_01]
+  exact ofCommutingInvolutions_ofAdd_01 clusterPhysX1 clusterPhysX2
+    clusterPhysX1_sq clusterPhysX2_sq clusterPhysX1X2_comm
 
 @[simp] private lemma clusterZ2Z2Action_11 :
     clusterZ2Z2Action (Multiplicative.ofAdd ((1, 1) : ZMod 2 × ZMod 2)) =
       clusterPhysX1 * clusterPhysX2 := by
-  simp only [clusterZ2Z2Action, ofCommutingInvolutions_ofAdd_11]
+  exact ofCommutingInvolutions_ofAdd_11 clusterPhysX1 clusterPhysX2
+    clusterPhysX1_sq clusterPhysX2_sq clusterPhysX1X2_comm
 
 /-! #### Virtual gauges `σz`, `σx`, and `σz σx` -/
 
@@ -626,18 +619,10 @@ two generators act by real symmetric involutive permutation matrices, so each
 group element equals its own adjoint inverse. -/
 private theorem clusterZ2Z2Action_unitary (g : Multiplicative (ZMod 2 × ZMod 2)) :
     clusterZ2Z2Action g * (clusterZ2Z2Action g)ᴴ = 1 := by
-  rcases zmod2sq_cases g with rfl | rfl | rfl | rfl
-  · simp
-  · rw [clusterZ2Z2Action_10]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [clusterPhysX1, Matrix.mul_apply, Fin.sum_univ_four, Matrix.conjTranspose_apply]
-  · rw [clusterZ2Z2Action_01]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [clusterPhysX2, Matrix.mul_apply, Fin.sum_univ_four, Matrix.conjTranspose_apply]
-  · rw [clusterZ2Z2Action_11]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [clusterPhysX1, clusterPhysX2, Matrix.mul_apply, Fin.sum_univ_four,
-        Matrix.conjTranspose_apply]
+  exact ofCommutingInvolutions_mul_conjTranspose clusterPhysX1 clusterPhysX2
+    clusterPhysX1_sq clusterPhysX2_sq clusterPhysX1X2_comm
+    (by rw [clusterPhysX1_conjTranspose, clusterPhysX1_sq])
+    (by rw [clusterPhysX2_conjTranspose, clusterPhysX2_sq]) g
 
 /-- **The cluster state has string order under its `Z₂ × Z₂` symmetry.**
 

--- a/TNLean/MPS/Examples/ZMod2.lean
+++ b/TNLean/MPS/Examples/ZMod2.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Group.TypeTags.Basic
 import Mathlib.Algebra.Group.TypeTags.Finite
 import Mathlib.Data.Matrix.Mul
 import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.Matrix.ConjTranspose
 
 /-!
 # Z₂ and Z₂ × Z₂ group lemmas for MPS examples
@@ -22,6 +23,8 @@ on-site symmetry by a pair of commuting involutions on the physical space.
 * `ofCommutingInvolutions` : the `Z₂ × Z₂` representation built from two
   commuting involutions `P₁`, `P₂` on a finite-dimensional space.
 -/
+
+open scoped Matrix
 
 namespace MPSTensor
 
@@ -111,5 +114,21 @@ lemma ofCommutingInvolutions_ofAdd_11 (P₁ P₂ : Matrix n n ℂ) (h₁ : P₁ 
       P₁ * P₂ := by
   simp only [ofCommutingInvolutions_apply, toAdd_ofAdd, show (1 : ZMod 2) ≠ 0 from by decide,
     ↓reduceIte]
+
+/-- A representation built from two commuting involutions is unitary when both
+generators are unitary. -/
+lemma ofCommutingInvolutions_mul_conjTranspose (P₁ P₂ : Matrix n n ℂ)
+    (h₁ : P₁ * P₁ = 1) (h₂ : P₂ * P₂ = 1) (hc : P₁ * P₂ = P₂ * P₁)
+    (h₁U : P₁ * (P₁)ᴴ = 1) (h₂U : P₂ * (P₂)ᴴ = 1)
+    (g : Multiplicative (ZMod 2 × ZMod 2)) :
+    ofCommutingInvolutions P₁ P₂ h₁ h₂ hc g *
+        (ofCommutingInvolutions P₁ P₂ h₁ h₂ hc g)ᴴ = 1 := by
+  rcases zmod2sq_cases g with rfl | rfl | rfl | rfl
+  · simp
+  · simpa only [ofCommutingInvolutions_ofAdd_10] using h₁U
+  · simpa only [ofCommutingInvolutions_ofAdd_01] using h₂U
+  · rw [ofCommutingInvolutions_ofAdd_11, Matrix.conjTranspose_mul,
+      mul_assoc P₁ P₂ ((P₂)ᴴ * (P₁)ᴴ), ← mul_assoc P₂ (P₂)ᴴ (P₁)ᴴ,
+      h₂U, one_mul, h₁U]
 
 end MPSTensor

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -76,6 +76,16 @@ abstracted — record why, so it is not re-proposed).
   imports the algebra module directly.  The two older symmetry proofs now pass through
   `evalWord_ofFn_eq_prod` and these shared identities.
 
+### ofCommutingInvolutions_mul_conjTranspose — promoted
+- **Pattern:** split a `Z₂ × Z₂` element into four cases, expand the representation,
+  and prove unitarity from two unitary commuting involutions.
+- **Seen:** the cluster-state and AKLT examples each used a four-case finite-matrix
+  proof for their physical action.
+- **Abstraction:** `ofCommutingInvolutions_mul_conjTranspose` in
+  `TNLean/MPS/Examples/ZMod2.lean`.
+- **Notes:** each example now supplies only the involution, commutation, and generator
+  unitarity facts. The public action and unitarity theorem statements are unchanged.
+
 ---
 
 ## Completed refactors
@@ -94,6 +104,15 @@ abstracted — record why, so it is not re-proposed).
 - **Result:** The two Lean files have 49 insertions and 45 deletions: the repeated
   derivations are replaced by two source-facing algebraic lemmas and their call sites.
   All pre-existing public theorem statements and mathematical scope are unchanged.
+
+### Concrete two-block injectivity through the standard matrix basis
+- **Pattern:** prove that an arbitrary `2 × 2` matrix lies in a range span by
+  expanding its four entries as a hand-written linear combination of matrix units.
+- **Reuse:** `cluster_isNBlkInjective_two` and `aklt_isNBlkInjective_two` now use
+  `Submodule.eq_top_iff_forall_basis_mem` with `Matrix.stdBasis`, discharging the
+  four basis cases from their existing matrix-unit membership lemmas.
+- **Result:** both theorem statements are unchanged, and their previously profiled
+  multi-second declarations fall below the one-second profiler threshold.
 
 ### Non-decaying-overlap dimension and gauge-phase dichotomy
 - **Pattern:** The `hDim`/`hGPE` tails of


### PR DESCRIPTION
## Motivation

`MPS.Examples.Cluster` was a compilation hotspot in the #4866 profiling campaign. Declaration profiling identified duplicated concrete matrix-span and finite-group unitarity proofs in Cluster and AKLT.

Addresses #4866.

## Description

- prove the Cluster and AKLT two-block injectivity theorems through `Matrix.stdBasis` instead of reconstructing arbitrary `2 × 2` matrices entry by entry
- derive `clusterBlocked_isInjective` from the general block-tensor equivalence instead of repeating a second concrete span proof
- move that general equivalence to `MPS.Core.Blocking`, its dependency-neutral conceptual home
- add a shared unitarity lemma for representations built from two commuting involutions and use it in both examples
- record both proof patterns in the tactic-pattern ledger

All public theorem statements are unchanged.

## Performance

On the same seeded worktree, the untouched warm Cluster declaration trace took 80.7s. The best controlled warm optimized profile took 39.3s, including 20.3s in imports. The previously multi-second declarations `cluster_isNBlkInjective_two`, `clusterBlocked_isInjective`, and `clusterZ2Z2Action_unitary` each fell below the one-second declaration-profiler threshold.

AKLT source checking fell from 28.8s to 20.7s in the comparable normal run; its injectivity and unitarity declarations also fell below the one-second trace threshold. Host contention makes individual wall-clock samples noisy, so the declaration-level removals and import floor are the primary evidence.

The ~20s Cluster import floor consumes most of the 25s warning threshold. The resulting ~39s total is below the campaign hard gate but remains warning-tier follow-up work; further reductions should target the import graph and remaining gauge/symmetry declarations separately.

## Testing

- `lake build TNLean.MPS.Chain.BlockedChainFT TNLean.MPS.Examples.GHZ TNLean.MPS.Examples.Cluster TNLean.MPS.Examples.AKLT -q --log-level=info` on exact rebased head
- `lake env lean TNLean/MPS/Examples/Cluster.lean -Dprofiler=true -Dprofiler.threshold=1000`
- `lake build TNLean.MPS.Chain.BlockedChainFT -q --log-level=info` after review cleanup
- `git diff --check`
- proof-integrity grep over all changed Lean files
- `python3 scripts/tactic_pattern_scan.py`

Mathlib artifacts were fetched/sealed with `lake exe cache get` before building; Mathlib was not rebuilt from source.