### PR TITLE
feat(canonical-form): construct a CPSV representative after blocking

### DIFF
--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -13,6 +13,7 @@ import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.BNTTransport
 import TNLean.MPS.CanonicalForm.BNTUniqueness
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
+import TNLean.MPS.CanonicalForm.CPSVAfterBlocking
 import TNLean.MPS.CanonicalForm.CommonPeriodCyclicSectors
 import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.MPS.CanonicalForm.CyclicSectors.Basic

--- a/TNLean/MPS/CanonicalForm/CPSVAfterBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVAfterBlocking.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorTransport
+
+/-!
+# CPSV canonical-form representative after blocking
+
+This module constructs the canonical-form representative stated after the
+canonical-form definition in Cirac--Pérez-García--Schuch--Verstraete,
+arXiv:1606.00608, lines 249--251.
+
+## Main statement
+
+* `exists_cpsvCanonicalForm_representative_after_blocking` gives, after a
+  positive blocking length, a tensor in literal CPSV canonical form with the same
+  positive-length MPV family as the blocked input tensor.
+
+## References
+
+* [Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608, Section 2.3]
+
+## Tags
+
+matrix product states, canonical form, blocking, normal tensor
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor
+
+/-- After a positive blocking length, every tensor has a possibly different
+representative in literal CPSV canonical form which generates the same
+positive-length MPV family.
+
+The representative is the weighted direct sum of the primitive irreducible
+left-canonical blocks. It need not equal the blocked input tensor in the
+input tensor's original bond coordinates.
+
+Source: arXiv:1606.00608, lines 214--251, especially eqs. `II_Aiplusk1` and
+`II_CF1` and the proposition at lines 249--251. -/
+theorem exists_cpsvCanonicalForm_representative_after_blocking
+    (A : MPSTensor d D) :
+    ∃ p : ℕ, 0 < p ∧
+      ∃ D' : ℕ, ∃ B : MPSTensor (blockPhysDim d p) D',
+        IsCPSVCanonicalForm B ∧
+        SameMPV₂Pos (blockTensor A p) B := by
+  have hRefl : SameMPV₂Pos A A := by
+    intro N _hN σ
+    rfl
+  obtain ⟨p, hp, rA, dimA, μA, blocksA, rB, dimB, μB, blocksB,
+      hABlocks, _hBBlocks, _hBlocksAgree, _hμA, _hμB, hLeftA, _hLeftB,
+      hPrimitiveA, _hPrimitiveB, hIrreducibleA, _hIrreducibleB,
+      hDimA, _hDimB⟩ :=
+    unconditional_commonPrimitiveIrreducibleBlocks A A hRefl
+  let B : MPSTensor (blockPhysDim d p) (∑ k : Fin rA, dimA k) :=
+    toTensorFromBlocks (d := blockPhysDim d p) μA blocksA
+  have hNormalA : ∀ k, IsNormalTensor (blocksA k) := by
+    intro k
+    letI : NeZero (dimA k) := ⟨Nat.ne_of_gt (hDimA k)⟩
+    exact isNormalTensor_of_isNormal_leftCanonical (blocksA k)
+      (isNormal_of_tp_primitive_irreducible (blocksA k)
+        (hLeftA k) (hPrimitiveA k) (hIrreducibleA k))
+      (hLeftA k)
+  refine ⟨p, hp, ∑ k : Fin rA, dimA k, B, ?_, ?_⟩
+  · exact (CPSVCanonicalFormData.ofBlocks hDimA μA blocksA hNormalA).isCPSVCanonicalForm
+  · exact hABlocks
+
+end MPSTensor

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -317,6 +317,32 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     so condition~(ii) alone does not characterize normality.
 \end{remark}
 
+\begin{theorem}[Algebraically normal left-canonical tensors are CPSV normal]
+    \label{thm:is_normal_tensor_of_is_normal_left_canonical}
+    \lean{MPSTensor.isNormalTensor_of_isNormal_leftCanonical}
+    \leanok
+    \uses{def:normal, def:left_canonical_tensor, def:nt_cpsv,
+        def:strongly_irreducible_paper}
+    Let $D>0$. If $A$ is algebraically normal and left-canonical, then
+    \begin{align}
+        A
+         & \text{ is a CPSV normal tensor}.
+        \label{eq:is_normal_tensor_of_is_normal_left_canonical}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:normal, def:left_canonical_tensor, def:nt_cpsv,
+        def:strongly_irreducible_paper}
+    Algebraic normality together with
+    $\sum_i(A^i)^\dagger A^i=\Id$ makes the transfer map strongly irreducible.
+    It consequently has a positive-definite fixed point, no nontrivial
+    invariant projection, and peripheral spectrum $\{1\}$. The fixed-point
+    eigenvalue and left-canonical normalization give $r(\E_A)=1$. Thus no
+    scalar rescaling remains, and the two conditions in
+    Definition~\ref{def:nt_cpsv} hold for $A$ itself.
+\end{proof}
+
 \begin{definition}[CPSV canonical form]
     \label{def:cpsv_canonical_form}
     \lean{MPSTensor.CPSVCanonicalFormData}
@@ -358,6 +384,60 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     The basis-of-normal-tensors refinement is
     Definition~\ref{def:bnt}; it is not part of canonical form itself.
 \end{definition}
+
+\begin{theorem}[CPSV canonical-form representative after blocking]
+    \label{thm:cpsv_canonical_form_representative_after_blocking}
+    \lean{MPSTensor.exists_cpsvCanonicalForm_representative_after_blocking}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:blocked_tensor, def:same_mpv2_pos,
+        thm:unconditional_common_primitive_irreducible_blocks,
+        thm:normal_tp_primitive_irred,
+        thm:is_normal_tensor_of_is_normal_left_canonical}
+    % Maintainer source anchor: CPSV16 lines 214--251, especially
+    % eq:II_Aiplusk1, eq:II_CF1, and the proposition at lines 249--251.
+    For every tensor $A$, there are a positive integer $p$, a bond dimension
+    $D'$, and a tensor $B$ of physical dimension $d^p$ and bond dimension
+    $D'$ such that $B\in\mathrm{CF}$ and, for every $N\ge1$,
+    \begin{align}
+        V^{(N)}(A^{[p]})_\sigma
+         & =V^{(N)}(B)_\sigma.
+        \label{eq:cpsv_canonical_form_representative_after_blocking}
+    \end{align}
+    Here $B$ is another tensor generating the same positive-length MPV family.
+    The assertion $B\in\mathrm{CF}$ is literal in the bond coordinates of $B$;
+    no assertion is made that $A^{[p]}$ itself is literally in canonical form
+    in its original bond coordinates.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:unconditional_common_primitive_irreducible_blocks,
+        thm:normal_tp_primitive_irred,
+        thm:is_normal_tensor_of_is_normal_left_canonical,
+        def:cpsv_canonical_form}
+    Apply Theorem~\ref{thm:unconditional_common_primitive_irreducible_blocks}
+    to $A$ and itself. It gives $p\ge1$, weights $\mu_k$, and
+    left-canonical, primitive, tensor-irreducible blocks $C_k$ such that, for
+    every $N\ge1$,
+    \begin{align}
+        V^{(N)}(A^{[p]})_\sigma
+         & =V^{(N)}\!\left(\bigoplus_k\mu_kC_k\right)_\sigma.
+        \label{eq:cpsv_after_blocking_direct_sum}
+    \end{align}
+    First, Theorem~\ref{thm:normal_tp_primitive_irred} makes each $C_k$
+    algebraically normal. Second,
+    Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical} combines
+    this conclusion with the left-canonical identity to make each $C_k$ a CPSV
+    normal tensor. Hence
+    \begin{align}
+        B
+         & :=\bigoplus_k\mu_kC_k
+        \label{eq:cpsv_after_blocking_representative}
+    \end{align}
+    satisfies the literal block-diagonal equation~\eqref{eq:cpsv_canonical_form},
+    so $B\in\mathrm{CF}$. Equation~\eqref{eq:cpsv_after_blocking_direct_sum}
+    gives the second part of
+    \eqref{eq:cpsv_canonical_form_representative_after_blocking}.
+\end{proof}
 
 \begin{theorem}[Closed-chain expansion of CPSV canonical form]
     \label{thm:cpsv_canonical_form_mpv_expansion}


### PR DESCRIPTION
## What changed

- prove that every tensor has, after a positive blocking length, **another** tensor in literal CPSV canonical form with the same positive-length MPV family
- build the representative from the existing common primitive/irreducible block decomposition
- record the nontrivial two-step conversion from algebraic normality and left-canonical normalization to the CPSV normal-tensor predicate
- construct the literal weighted direct sum using the API merged in #4883
- add formula-first Chapter 9 coverage that distinguishes literal canonical-form membership of the representative from MPV equivalence to the original blocked tensor

## Source

CPSV16 lines 214--251, especially `eq:II_Aiplusk1`, `eq:II_CF1`, and the proposition at lines 249--251.

## Validation

- targeted canonical-form builds and full `lake build` (9749 jobs)
- import-aggregator, module-policy, style, proof-integrity, and prose gates
- declaration regeneration, blueprint synchronization, reverse coverage, and `checkdecls`
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'`
- independent source/API re-review: approved with no findings

Closes #4881. Advances #2380 and #232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core canonical-form theory by composing several structural decomposition lemmas; scope is a single focused theorem with no runtime or security surface.
> 
> **Overview**
> Adds **`exists_cpsvCanonicalForm_representative_after_blocking`**: for any MPS tensor, some positive blocking length yields a **different** tensor `B` in **literal** CPSV canonical form with the same positive-length MPV family as the blocked tensor (not necessarily equal to `A^{[p]}` in the original bond basis).
> 
> The proof instantiates **`unconditional_commonPrimitiveIrreducibleBlocks`** on `A`, forms `B` as the weighted direct sum **`toTensorFromBlocks`**, upgrades each primitive left-canonical block to **`IsNormalTensor`** via **`isNormal_of_tp_primitive_irreducible`** and **`isNormalTensor_of_isNormal_leftCanonical`**, then packages **`CPSVCanonicalFormData.ofBlocks`**.
> 
> Chapter 9 blueprint now states the blocking representative theorem (CPSV16 §2.3) and documents the algebraic→CPSV normality bridge; the canonical-form aggregator imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51008c769a400683c9eb35ccb437029c53a80b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->