### PR TITLE
feat(Channel/PetzRecovery): factor completed maximally mixed channel

### DIFF
--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -50,6 +50,12 @@ reference matrix.
 * `Matrix.partialTraceRightPetzMap_maximallyMixedTensor`: the raw Petz map for
   the maximally mixed tensor reference factors as the identity on the first
   tensor factor and the Petz map on the remaining factors.
+* `Matrix.partialTraceRightPetzComplementMap_maximallyMixedTensor`: the
+  complementary support-completion term has the same factorization.
+* `Matrix.partialTraceRightPetzChannel_maximallyMixedTensor`: the completed
+  Petz channel factors as the identity tensored with the local channel.
+* `Matrix.partialTraceRightPetzChannel_maximallyMixedTensor_isKrausCPTP`: the
+  completed channel is CPTP when the local reference has trace one.
 
 ## References
 
@@ -529,6 +535,35 @@ theorem cfcSqrt_maximallyMixedTensorReference
   rw [((maximallyMixedOn_posDef (dA := dA)).posSemidef.kronecker
     hρ).isHermitian.cfc_eq, cfcSqrt_maximallyMixedOn_kronecker ρ hρ]
 
+omit [Fintype C] [DecidableEq B] [DecidableEq C] in
+/-- Tracing out the untouched $A\times B$ factors from the maximally mixed
+specialization of HJPW equation (10) gives the $C$ marginal of $\rho_{BC}$. -/
+theorem partialTraceLeft_maximallyMixedTensorReference
+    (ρ : Matrix (B × C) (B × C) ℂ) :
+    partialTraceLeft (maximallyMixedTensorReference (dA := dA) ρ) =
+      partialTraceLeft ρ := by
+  ext c c'
+  simp only [maximallyMixedTensorReference, maximallyMixedOn,
+    partialTraceLeft_apply, Matrix.kroneckerMap_apply, Matrix.smul_apply,
+    Matrix.submatrix_apply, Equiv.prodAssoc_apply, smul_eq_mul,
+    Fintype.sum_prod_type]
+  rw [Finset.sum_comm]
+  simp only [one_apply_eq, mul_one, Finset.sum_const, Finset.card_univ,
+    Fintype.card_fin, nsmul_eq_mul]
+  have hd : (dA : ℂ) ≠ 0 := by exact_mod_cast NeZero.ne dA
+  apply Finset.sum_congr rfl
+  intro b _
+  rw [← mul_assoc, mul_inv_cancel₀ hd, one_mul]
+
+omit [DecidableEq B] [DecidableEq C] in
+/-- The maximally mixed tensor reference has the same trace as $\rho_{BC}$. -/
+theorem trace_maximallyMixedTensorReference
+    (ρ : Matrix (B × C) (B × C) ℂ) :
+    Matrix.trace (maximallyMixedTensorReference (dA := dA) ρ) =
+      Matrix.trace ρ := by
+  rw [← trace_partialTraceLeft,
+    partialTraceLeft_maximallyMixedTensorReference, trace_partialTraceLeft]
+
 omit [DecidableEq C] in
 /-- For the maximally mixed specialization of HJPW equation (10), the support
 inverse square root of the $AB$ marginal is $\sqrt{d_A}\,\mathbf 1_A\otimes\rho_B^{-1/2}$ on its
@@ -566,6 +601,65 @@ theorem supportInvSqrt_partialTraceRight_maximallyMixedTensorReference
   congr 1
   exact Matrix.PosSemidef.supportInvSqrt_one_kronecker
     (PosSemidef.partialTraceRight hρ)
+
+omit [DecidableEq C] in
+/-- The support projector of the $AB$ marginal in the maximally mixed
+specialization of HJPW equation (10) is the identity on $A$ tensored with the
+support projector of $\rho_B$.
+
+The proof uses the support-inverse sandwich
+$\tau^{-1/2}\tau\tau^{-1/2}=P_{\operatorname{supp}\tau}$ together with the
+specialized support-inverse factorization above. -/
+theorem supportProj_partialTraceRight_maximallyMixedTensorReference
+    (ρ : Matrix (B × C) (B × C) ℂ) (hρ : ρ.PosSemidef) :
+    (PosSemidef.partialTraceRight
+      (maximallyMixedTensorReference_posSemidef
+        (dA := dA) hρ)).isHermitian.supportProj =
+      (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ
+        (PosSemidef.partialTraceRight hρ).isHermitian.supportProj := by
+  let hτ := PosSemidef.partialTraceRight
+    (maximallyMixedTensorReference_posSemidef (dA := dA) hρ)
+  have hsupport := hτ.supportInvSqrt_mul_self_mul_supportInvSqrt
+  rw [← hsupport]
+  rw [supportInvSqrt_partialTraceRight_maximallyMixedTensorReference ρ hρ,
+    partialTraceRight_maximallyMixedTensorReference]
+  simp only [maximallyMixedOn, Matrix.smul_mul, Matrix.mul_smul]
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+    Matrix.one_mul, Matrix.mul_one,
+    (PosSemidef.partialTraceRight hρ).supportInvSqrt_mul_self_mul_supportInvSqrt]
+  have hc : (0 : ℝ) < (dA : ℝ)⁻¹ := inv_pos.mpr (by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dA))
+  have hs : Real.sqrt ((dA : ℝ)⁻¹) ≠ 0 := Real.sqrt_ne_zero'.mpr hc
+  have hcancelR : (Real.sqrt ((dA : ℝ)⁻¹))⁻¹ *
+      (Real.sqrt ((dA : ℝ)⁻¹))⁻¹ * (dA : ℝ)⁻¹ = 1 := by
+    calc
+      _ = (Real.sqrt ((dA : ℝ)⁻¹) *
+          Real.sqrt ((dA : ℝ)⁻¹))⁻¹ * (dA : ℝ)⁻¹ := by
+        rw [mul_inv]
+      _ = ((dA : ℝ)⁻¹)⁻¹ * (dA : ℝ)⁻¹ := by
+        rw [← pow_two, Real.sq_sqrt hc.le]
+      _ = 1 := inv_mul_cancel₀ (ne_of_gt hc)
+  have hcancelC : (((Real.sqrt ((dA : ℝ)⁻¹))⁻¹ : ℝ) : ℂ) *
+      (((Real.sqrt ((dA : ℝ)⁻¹))⁻¹ : ℝ) : ℂ) * (dA : ℂ)⁻¹ = 1 := by
+    simpa only [Complex.ofReal_mul, Complex.ofReal_inv,
+      Complex.ofReal_natCast, Complex.ofReal_one] using
+      congrArg (fun x : ℝ ↦ (x : ℂ)) hcancelR
+  ext i j
+  simp only [Matrix.smul_apply, Matrix.kroneckerMap_apply, one_apply,
+    smul_eq_mul]
+  by_cases hij : i.1 = j.1
+  · simp only [hij, if_pos, Complex.real_smul]
+    rw [mul_one, one_mul]
+    change (((Real.sqrt ((dA : ℝ)⁻¹))⁻¹ : ℝ) : ℂ) *
+      ((((Real.sqrt ((dA : ℝ)⁻¹))⁻¹ : ℝ) : ℂ) *
+        ((dA : ℂ)⁻¹ *
+          (PosSemidef.partialTraceRight hρ).isHermitian.supportProj i.2 j.2)) = _
+    calc
+      _ = ((((Real.sqrt ((dA : ℝ)⁻¹))⁻¹ : ℝ) : ℂ) *
+          (((Real.sqrt ((dA : ℝ)⁻¹))⁻¹ : ℝ) : ℂ) * (dA : ℂ)⁻¹) *
+          (PosSemidef.partialTraceRight hρ).isHermitian.supportProj i.2 j.2 := by ring
+      _ = _ := by rw [hcancelC, one_mul]
+  · simp [hij]
 
 /-- **Maximally mixed specialization of HJPW equation (10), elementary-tensor
 algebra.** For the reference
@@ -675,6 +769,42 @@ theorem partialTraceRightPetzMap_maximallyMixedTensor_kronecker
         (A i.1 j.1 * Z) := by ring
     _ = A i.1 j.1 * Z := by rw [hcancel, one_mul]
 
+/-- **Complementary-term compatibility, elementary-tensor form.** For the
+maximally mixed tensor reference, TNLean's complementary measure-and-prepare
+term acts as the identity on $A$ and as the local complementary term on $B$,
+after canonical reassociation.
+
+This statement concerns TNLean's support completion; it is not part of HJPW
+equation (10). -/
+theorem partialTraceRightPetzComplementMap_maximallyMixedTensor_kronecker
+    (ρ : Matrix (B × C) (B × C) ℂ) (hρ : ρ.PosSemidef)
+    (A : Matrix (Fin dA) (Fin dA) ℂ) (X : Matrix B B ℂ) :
+    equivReindexMap (Equiv.prodAssoc (Fin dA) B C)
+        (partialTraceRightPetzComplementMap
+          (maximallyMixedTensorReference (dA := dA) ρ)
+          (maximallyMixedTensorReference_posSemidef (dA := dA) hρ)
+          (A ⊗ₖ X)) =
+      A ⊗ₖ partialTraceRightPetzComplementMap ρ hρ X := by
+  rw [partialTraceRightPetzComplementMap_apply,
+    partialTraceRightPetzComplementMap_apply]
+  rw [supportProj_partialTraceRight_maximallyMixedTensorReference ρ hρ,
+    partialTraceLeft_maximallyMixedTensorReference]
+  let P := (PosSemidef.partialTraceRight hρ).isHermitian.supportProj
+  have hQ : (1 : Matrix (Fin dA × B) (Fin dA × B) ℂ) -
+      (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ P =
+      (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ (1 - P) := by
+    ext ⟨a, b⟩ ⟨a', b'⟩
+    by_cases haa : a = a' <;> by_cases hbb : b = b' <;>
+      simp [haa, hbb, Matrix.kroneckerMap_apply]
+  rw [hQ, ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+    Matrix.one_mul, Matrix.mul_one]
+  ext ⟨a, bc⟩ ⟨a', bc'⟩
+  simp only [equivReindexMap, LinearEquiv.coe_toLinearMap,
+    Matrix.coe_reindexLinearEquiv, Matrix.reindex_apply,
+    Matrix.submatrix_apply, Matrix.kroneckerMap_apply,
+    Equiv.prodAssoc_symm_apply]
+  rw [Matrix.partialTraceLeft_apply, mul_assoc]
+
 /-- **Maximally mixed specialization of HJPW equation (10), raw Petz-map
 factorization.** For
 $\sigma_{ABC}=d_A^{-1}\mathbf 1_A\otimes\rho_{BC}$, the raw partial-trace
@@ -707,6 +837,66 @@ theorem partialTraceRightPetzMap_maximallyMixedTensor
   rw [idTensorMapLM_apply, idTensorMap_kronecker]
   exact partialTraceRightPetzMap_maximallyMixedTensor_kronecker
     ρ hρ (A i) (Y i)
+
+/-- **Complementary-term compatibility.** For the maximally mixed tensor
+reference, TNLean's complementary measure-and-prepare term factors as the
+identity on $A$ tensored with the local complementary term on $B$, after
+canonical reassociation.
+
+This is a compatibility property of TNLean's support completion, not a claim
+from HJPW equation (10). -/
+theorem partialTraceRightPetzComplementMap_maximallyMixedTensor
+    (ρ : Matrix (B × C) (B × C) ℂ) (hρ : ρ.PosSemidef) :
+    equivReindexMap (Equiv.prodAssoc (Fin dA) B C) ∘ₗ
+        partialTraceRightPetzComplementMap
+          (maximallyMixedTensorReference (dA := dA) ρ)
+          (maximallyMixedTensorReference_posSemidef (dA := dA) hρ) =
+      idTensorMapLM (δ := Fin dA)
+        (partialTraceRightPetzComplementMap ρ hρ) := by
+  apply LinearMap.ext
+  intro X
+  obtain ⟨A, Y, hX⟩ :=
+    hasOperatorSchmidtDecomposition_operatorSchmidtRank X
+  rw [hX]
+  simp only [LinearMap.comp_apply, map_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [idTensorMapLM_apply, idTensorMap_kronecker]
+  exact partialTraceRightPetzComplementMap_maximallyMixedTensor_kronecker
+    ρ hρ (A i) (Y i)
+
+/-- **Completed-channel factorization.** For the maximally mixed tensor
+reference, TNLean's completed partial-trace Petz channel is the identity on
+$A$ tensored with the completed local channel on $B$, after canonical
+reassociation.
+
+The raw support-map summand is the maximally mixed specialization of HJPW
+equation (10). The complementary summand is TNLean's support-completion
+compatibility and is not asserted by that equation. This theorem does not
+invoke or assert a Koashi--Imoto decomposition. -/
+theorem partialTraceRightPetzChannel_maximallyMixedTensor
+    (ρ : Matrix (B × C) (B × C) ℂ) (hρ : ρ.PosSemidef) :
+    equivReindexMap (Equiv.prodAssoc (Fin dA) B C) ∘ₗ
+        partialTraceRightPetzChannel
+          (maximallyMixedTensorReference (dA := dA) ρ)
+          (maximallyMixedTensorReference_posSemidef (dA := dA) hρ) =
+      idTensorMapLM (δ := Fin dA) (partialTraceRightPetzChannel ρ hρ) := by
+  rw [partialTraceRightPetzChannel, LinearMap.comp_add,
+    partialTraceRightPetzMap_maximallyMixedTensor,
+    partialTraceRightPetzComplementMap_maximallyMixedTensor,
+    partialTraceRightPetzChannel, idTensorMapLM_add]
+
+/-- The completed Petz channel for the maximally mixed tensor reference is
+trace-preserving and completely positive whenever $\rho_{BC}$ has trace one. -/
+theorem partialTraceRightPetzChannel_maximallyMixedTensor_isKrausCPTP
+    (ρ : Matrix (B × C) (B × C) ℂ) (hρ : ρ.PosSemidef)
+    (hρtrace : Matrix.trace ρ = 1) :
+    IsKrausCPTP
+      (partialTraceRightPetzChannel
+        (maximallyMixedTensorReference (dA := dA) ρ)
+        (maximallyMixedTensorReference_posSemidef (dA := dA) hρ)) := by
+  apply partialTraceRightPetzChannel_isKrausCPTP
+  rw [trace_maximallyMixedTensorReference, hρtrace]
 
 end HJPWTensorFactorization
 

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -634,7 +634,6 @@ theorem supportProj_partialTraceRight_maximallyMixedTensorReference
     (PosSemidef.partialTraceRight hρ).supportInvSqrt_mul_self_mul_supportInvSqrt]
   have hc : (0 : ℝ) < (dA : ℝ)⁻¹ := inv_pos.mpr (by
     exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dA))
-  have hs : Real.sqrt ((dA : ℝ)⁻¹) ≠ 0 := Real.sqrt_ne_zero'.mpr hc
   have hcancelR : (Real.sqrt ((dA : ℝ)⁻¹))⁻¹ *
       (Real.sqrt ((dA : ℝ)⁻¹))⁻¹ * (dA : ℝ)⁻¹ = 1 := by
     calc

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -45,6 +45,11 @@ reference matrix.
   completed channel.
 * `Matrix.maximallyMixedTensorReference`: the maximally mixed tensor-product
   reference from HJPW equation (10), with reassociated product indices.
+* `Matrix.partialTraceLeft_maximallyMixedTensorReference`: the retained
+  marginal of the maximally mixed tensor reference.
+* `Matrix.trace_maximallyMixedTensorReference`: the reference trace identity.
+* `Matrix.supportProj_partialTraceRight_maximallyMixedTensorReference`: the
+  factorization of the marginal support projector.
 * `Matrix.partialTraceRightPetzMap_maximallyMixedTensor_kronecker`:
   factorization of the raw Petz map on elementary tensors.
 * `Matrix.partialTraceRightPetzMap_maximallyMixedTensor`: the raw Petz map for

--- a/TNLean/Channel/TensorMap.lean
+++ b/TNLean/Channel/TensorMap.lean
@@ -231,6 +231,17 @@ theorem idTensorMapLM_id :
   rw [← swapFactorsLinearEquiv_symm]
   exact (swapFactorsLinearEquiv δ α).symm_apply_apply X
 
+/-- Tensoring the identity on the first factor with a sum of linear maps
+preserves the sum. -/
+theorem idTensorMapLM_add
+    (T S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) :
+    idTensorMapLM (δ := δ) (T + S) =
+      idTensorMapLM (δ := δ) T + idTensorMapLM (δ := δ) S := by
+  apply LinearMap.ext
+  intro X
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rfl
+
 /-- Tensoring the identity on the first factor with a linear map preserves
 composition. -/
 theorem idTensorMapLM_comp

--- a/TNLean/Channel/TensorMap.lean
+++ b/TNLean/Channel/TensorMap.lean
@@ -35,6 +35,7 @@ act trivially on an ancillary factor.
 * `Matrix.tensorMapIdLM_comp`: the lift preserves composition.
 * `Matrix.idTensorMap_kronecker`: `(id ⊗ T)(A ⊗ B) = A ⊗ T(B)`
 * `Matrix.idTensorMapLM_id`: the second-factor identity lift is the identity.
+* `Matrix.idTensorMapLM_add`: the second-factor lift preserves addition.
 * `Matrix.idTensorMapLM_comp`: the second-factor lift preserves composition.
 
 ## References

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -210,47 +210,6 @@
     $(A\times B)\times C$, the right partial trace removes $C$.
 \end{definition}
 
-\begin{theorem}[Petz factorization for a maximally mixed factor]
-    \label{thm:entropy_petz_maximally_mixed_tensor}
-    \lean{Matrix.partialTraceRightPetzMap_maximallyMixedTensor}
-    \leanok
-    \uses{def:entropy_maximally_mixed_tensor_reference,
-        def:partial_trace_support_petz_map}
-    For the reference in~(\ref{eq:entropy_hjpw_product_reference}), the support
-    Petz map for $\tr_C$ factors as
-    \begin{align}
-        \mathcal R_{\sigma_{ABC}}
-        &=\operatorname{id}_A\otimes\mathcal R_{\rho_{BC}}.
-        \label{eq:entropy_hjpw_petz_factorization}
-    \end{align}
-    after the canonical identification
-    $(H_A\otimes H_B)\otimes H_C\cong
-    H_A\otimes(H_B\otimes H_C)$. This is the maximally mixed specialization
-    of \cite[equation~(10)]{Hayden2004Structure}. It is the tensor-product
-    identity for the raw Petz support formula, not the
-    Hayashi--Koashi--Imoto block decomposition.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{lem:partial_trace_support_petz_map_apply,
-        lem:support_inverse_square_root_maximally_mixed,
-        def:bipartite_operator_schmidt_rank}
-    The marginal of~(\ref{eq:entropy_hjpw_product_reference}) is
-    $d_A^{-1}\mathbf 1_A\otimes\rho_B$. Functional calculus gives
-    \begin{align}
-        \sqrt{\sigma_{ABC}}
-        &=d_A^{-1/2}\mathbf 1_A\otimes\sqrt{\rho_{BC}},
-        \notag\\
-        \sigma_{AB,\mathrm{supp}}^{-1/2}
-        &=d_A^{1/2}\mathbf 1_A\otimes
-          \rho_{B,\mathrm{supp}}^{-1/2}.
-        \notag
-    \end{align}
-    The scalar factors cancel in the Petz sandwich. The identity follows first
-    for $A_0\otimes X_B$ and then for every operator by a finite sum of product
-    operators.
-\end{proof}
-
 \begin{theorem}[Marginals and trace of the maximally mixed reference]
     \label{thm:entropy_maximally_mixed_tensor_marginals}
     \lean{Matrix.partialTraceRight_maximallyMixedTensorReference,
@@ -258,7 +217,7 @@
         Matrix.trace_maximallyMixedTensorReference}
     \leanok
     \uses{def:entropy_maximally_mixed_tensor_reference,
-        def:partial_trace_left}
+        def:partial_trace, def:partial_trace_left}
     For the reference in~(\ref{eq:entropy_hjpw_product_reference}),
     \begin{align}
         \tr_C\sigma_{ABC}
@@ -279,12 +238,73 @@
     a partial trace then gives the last identity.
 \end{proof}
 
+\begin{theorem}[Support inverse square root of the maximally mixed marginal]
+    \label{thm:entropy_maximally_mixed_support_inverse}
+    \lean{Matrix.supportInvSqrt_partialTraceRight_maximallyMixedTensorReference}
+    \leanok
+    \uses{thm:entropy_maximally_mixed_tensor_marginals,
+        lem:support_inverse_square_root_maximally_mixed,
+        def:support_inverse_square_root}
+    If $\rho_{BC}$ is positive semidefinite and $\rho_B=\tr_C\rho_{BC}$, then
+    \begin{align}
+        \sigma_{AB,\mathrm{supp}}^{-1/2}
+        &=\sqrt{d_A}\,\mathbf 1_A\otimes
+          \rho_{B,\mathrm{supp}}^{-1/2}.
+        \label{eq:entropy_mixed_reference_support_inverse}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_maximally_mixed_tensor_marginals,
+        lem:support_inverse_square_root_maximally_mixed}
+    The marginal identity gives
+    $\sigma_{AB}=d_A^{-1}\mathbf 1_A\otimes\rho_B$.
+    Apply the support-inverse scaling identity and the tensor identity for an
+    auxiliary left factor. Since $d_A>0$,
+    $(\sqrt{d_A^{-1}})^{-1}=\sqrt{d_A}$.
+\end{proof}
+
+\begin{theorem}[Petz factorization for a maximally mixed factor]
+    \label{thm:entropy_petz_maximally_mixed_tensor}
+    \lean{Matrix.partialTraceRightPetzMap_maximallyMixedTensor_kronecker,
+        Matrix.partialTraceRightPetzMap_maximallyMixedTensor}
+    \leanok
+    \uses{def:entropy_maximally_mixed_tensor_reference,
+        def:partial_trace_support_petz_map,
+        thm:entropy_maximally_mixed_support_inverse}
+    For the reference in~(\ref{eq:entropy_hjpw_product_reference}), the support
+    Petz map for $\tr_C$ factors as
+    \begin{align}
+        \mathcal R_{\sigma_{ABC}}
+        &=\operatorname{id}_A\otimes\mathcal R_{\rho_{BC}}.
+        \label{eq:entropy_hjpw_petz_factorization}
+    \end{align}
+    after the canonical identification
+    $(H_A\otimes H_B)\otimes H_C\cong
+    H_A\otimes(H_B\otimes H_C)$. This is the maximally mixed specialization
+    of \cite[equation~(10)]{Hayden2004Structure}. It is the tensor-product
+    identity for the raw Petz support formula, not the
+    Hayashi--Koashi--Imoto block decomposition.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_maximally_mixed_support_inverse}
+    Functional calculus gives
+    $\sqrt{\sigma_{ABC}}
+      =d_A^{-1/2}\mathbf 1_A\otimes\sqrt{\rho_{BC}}$.
+    Theorem~\ref{thm:entropy_maximally_mixed_support_inverse} gives the
+    corresponding factorization of the marginal support inverse.
+    The scalar factors cancel in the Petz sandwich. The identity follows first
+    for $A_0\otimes X_B$ and then for every operator by a finite sum of product
+    operators.
+\end{proof}
+
 \begin{theorem}[Support projector of the maximally mixed marginal]
     \label{thm:entropy_maximally_mixed_support_projector}
     \lean{Matrix.supportProj_partialTraceRight_maximallyMixedTensorReference}
     \leanok
     \uses{thm:entropy_maximally_mixed_tensor_marginals,
-        lem:support_inverse_square_root_maximally_mixed, def:support_proj}
+        thm:entropy_maximally_mixed_support_inverse, def:support_proj}
     If $P_B$ is the support projector of $\rho_B$, then the support projector of
     $d_A^{-1}\mathbf 1_A\otimes\rho_B$ is
     \begin{align}
@@ -296,7 +316,7 @@
 
 \begin{proof}\leanok
     \uses{lem:support_inverse_square_root_sandwich,
-        lem:support_inverse_square_root_maximally_mixed}
+        thm:entropy_maximally_mixed_support_inverse}
     Insert the factorized support inverse into
     $P_{AB}=\sigma_{AB,\mathrm{supp}}^{-1/2}
     \sigma_{AB}\sigma_{AB,\mathrm{supp}}^{-1/2}$. The scalar factors cancel,
@@ -470,8 +490,8 @@
         &=\operatorname{id}_A\otimes\mathcal C_{\rho_{BC}}.
         \label{eq:entropy_petz_complement_factorization}
     \end{align}
-    after the canonical reassociation of the three tensor factors. This is a
-    property of the support completion in
+    after the canonical reassociation of the three tensor factors. This is
+    TNLean-specific support-completion algebra from
     (\ref{eq:entropy_petz_complement}), not a statement of
     \cite[equation~(10)]{Hayden2004Structure}.
 \end{theorem}
@@ -507,10 +527,12 @@
           \widehat{\mathcal R}_{\rho_{BC}}.
         \label{eq:entropy_completed_petz_factorization}
     \end{align}
-    The raw support-map summand is the maximally mixed specialization of
-    \cite[equation~(10)]{Hayden2004Structure}. The complementary summand is the
-    support completion in~(\ref{eq:entropy_petz_complement}). This theorem does
-    not assert a Koashi--Imoto decomposition.
+    after canonical reassociation of the three tensor factors. The raw
+    support-map summand is the maximally mixed specialization of
+    \cite[equation~(10)]{Hayden2004Structure}. The complementary summand is
+    TNLean-specific support-completion algebra from
+    (\ref{eq:entropy_petz_complement}). This theorem does not assert a
+    Hayashi--Koashi--Imoto decomposition.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -288,7 +288,9 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:entropy_maximally_mixed_support_inverse}
+    \uses{thm:entropy_maximally_mixed_support_inverse,
+        lem:partial_trace_support_petz_map_apply,
+        def:bipartite_operator_schmidt_rank}
     Functional calculus gives
     $\sqrt{\sigma_{ABC}}
       =d_A^{-1/2}\mathbf 1_A\otimes\sqrt{\rho_{BC}}$.
@@ -498,7 +500,8 @@
 
 \begin{proof}\leanok
     \uses{thm:entropy_maximally_mixed_support_projector,
-        thm:entropy_maximally_mixed_tensor_marginals}
+        thm:entropy_maximally_mixed_tensor_marginals,
+        def:bipartite_operator_schmidt_rank}
     From~(\ref{eq:entropy_mixed_reference_support}),
     $Q_{AB}=\mathbf 1_A\otimes Q_B$, while
     $\tr_{AB}\sigma_{ABC}=\rho_C$. Hence

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -251,6 +251,61 @@
     operators.
 \end{proof}
 
+\begin{theorem}[Marginals and trace of the maximally mixed reference]
+    \label{thm:entropy_maximally_mixed_tensor_marginals}
+    \lean{Matrix.partialTraceRight_maximallyMixedTensorReference,
+        Matrix.partialTraceLeft_maximallyMixedTensorReference,
+        Matrix.trace_maximallyMixedTensorReference}
+    \leanok
+    \uses{def:entropy_maximally_mixed_tensor_reference,
+        def:partial_trace_left}
+    For the reference in~(\ref{eq:entropy_hjpw_product_reference}),
+    \begin{align}
+        \tr_C\sigma_{ABC}
+        &=d_A^{-1}\mathbf 1_A\otimes\rho_B,
+        \notag\\
+        \tr_{AB}\sigma_{ABC}
+        &=\rho_C,
+        \notag\\
+        \tr(\sigma_{ABC})
+        &=\tr(\rho_{BC}).
+        \label{eq:entropy_mixed_reference_trace}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand the two partial traces in a product basis. The sum over the
+    $d_A$ diagonal entries cancels the factor $d_A^{-1}$. Trace invariance under
+    a partial trace then gives the last identity.
+\end{proof}
+
+\begin{theorem}[Support projector of the maximally mixed marginal]
+    \label{thm:entropy_maximally_mixed_support_projector}
+    \lean{Matrix.supportProj_partialTraceRight_maximallyMixedTensorReference}
+    \leanok
+    \uses{thm:entropy_maximally_mixed_tensor_marginals,
+        lem:support_inverse_square_root_maximally_mixed, def:support_proj}
+    If $P_B$ is the support projector of $\rho_B$, then the support projector of
+    $d_A^{-1}\mathbf 1_A\otimes\rho_B$ is
+    \begin{align}
+        P_{AB}
+        &=\mathbf 1_A\otimes P_B.
+        \label{eq:entropy_mixed_reference_support}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:support_inverse_square_root_sandwich,
+        lem:support_inverse_square_root_maximally_mixed}
+    Insert the factorized support inverse into
+    $P_{AB}=\sigma_{AB,\mathrm{supp}}^{-1/2}
+    \sigma_{AB}\sigma_{AB,\mathrm{supp}}^{-1/2}$. The scalar factors cancel,
+    and the remaining sandwich is
+    $\mathbf 1_A\otimes
+    (\rho_{B,\mathrm{supp}}^{-1/2}\rho_B
+    \rho_{B,\mathrm{supp}}^{-1/2})=\mathbf 1_A\otimes P_B$.
+\end{proof}
+
 \begin{theorem}[Complete positivity of the support Petz map]
     \label{thm:partial_trace_support_petz_map_cp}
     \lean{Matrix.partialTraceRightPetzMap_isKrausCP}
@@ -398,6 +453,92 @@
     (\ref{eq:entropy_petz_complement_trace}). Adding
     (\ref{eq:entropy_petz_complement_trace}) to
     (\ref{eq:entropy_support_petz_trace}) gives trace preservation.
+\end{proof}
+
+\begin{theorem}[Factorization of the complementary preparation term]
+    \label{thm:entropy_petz_complement_maximally_mixed_tensor}
+    \lean{Matrix.partialTraceRightPetzComplementMap_maximallyMixedTensor_kronecker,
+        Matrix.partialTraceRightPetzComplementMap_maximallyMixedTensor}
+    \leanok
+    \uses{def:partial_trace_petz_complement,
+        thm:entropy_maximally_mixed_support_projector,
+        thm:entropy_maximally_mixed_tensor_marginals}
+    For the reference in~(\ref{eq:entropy_hjpw_product_reference}), the chosen
+    complementary preparation term factors as
+    \begin{align}
+        \mathcal C_{\sigma_{ABC}}
+        &=\operatorname{id}_A\otimes\mathcal C_{\rho_{BC}}.
+        \label{eq:entropy_petz_complement_factorization}
+    \end{align}
+    after the canonical reassociation of the three tensor factors. This is a
+    property of the support completion in
+    (\ref{eq:entropy_petz_complement}), not a statement of
+    \cite[equation~(10)]{Hayden2004Structure}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_maximally_mixed_support_projector,
+        thm:entropy_maximally_mixed_tensor_marginals}
+    From~(\ref{eq:entropy_mixed_reference_support}),
+    $Q_{AB}=\mathbf 1_A\otimes Q_B$, while
+    $\tr_{AB}\sigma_{ABC}=\rho_C$. Hence
+    \begin{align}
+        \mathcal C_{\sigma_{ABC}}(A_0\otimes X_B)
+        &=(\mathbf 1_A\otimes Q_B)(A_0\otimes X_B)
+          (\mathbf 1_A\otimes Q_B)\otimes\rho_C
+        \notag\\
+        &=A_0\otimes\mathcal C_{\rho_{BC}}(X_B).
+        \notag
+    \end{align}
+    A finite product-operator decomposition gives the result for every input.
+\end{proof}
+
+\begin{theorem}[Factorization of the completed Petz channel]
+    \label{thm:entropy_completed_petz_maximally_mixed_tensor}
+    \lean{Matrix.partialTraceRightPetzChannel_maximallyMixedTensor}
+    \leanok
+    \uses{def:partial_trace_petz_channel,
+        thm:entropy_petz_maximally_mixed_tensor,
+        thm:entropy_petz_complement_maximally_mixed_tensor}
+    For the reference in~(\ref{eq:entropy_hjpw_product_reference}),
+    \begin{align}
+        \widehat{\mathcal R}_{\sigma_{ABC}}
+        &=\operatorname{id}_A\otimes
+          \widehat{\mathcal R}_{\rho_{BC}}.
+        \label{eq:entropy_completed_petz_factorization}
+    \end{align}
+    The raw support-map summand is the maximally mixed specialization of
+    \cite[equation~(10)]{Hayden2004Structure}. The complementary summand is the
+    support completion in~(\ref{eq:entropy_petz_complement}). This theorem does
+    not assert a Koashi--Imoto decomposition.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:entropy_petz_maximally_mixed_tensor,
+        thm:entropy_petz_complement_maximally_mixed_tensor}
+    Add~(\ref{eq:entropy_hjpw_petz_factorization}) and
+    (\ref{eq:entropy_petz_complement_factorization}), and use additivity of the
+    tensor product of linear maps.
+\end{proof}
+
+\begin{theorem}[Channel property for the maximally mixed reference]
+    \label{thm:entropy_completed_petz_maximally_mixed_cptp}
+    \lean{Matrix.partialTraceRightPetzChannel_maximallyMixedTensor_isKrausCPTP}
+    \leanok
+    \uses{thm:partial_trace_petz_channel_cptp,
+        thm:entropy_maximally_mixed_tensor_marginals,
+        def:is_kraus_cptp}
+    If $\rho_{BC}$ is positive semidefinite with trace one, then
+    $\widehat{\mathcal R}_{\sigma_{ABC}}$ is completely positive and trace
+    preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:partial_trace_petz_channel_cptp,
+        thm:entropy_maximally_mixed_tensor_marginals}
+    By~(\ref{eq:entropy_mixed_reference_trace}),
+    $\tr(\sigma_{ABC})=\tr(\rho_{BC})=1$. Apply the channel property of the
+    completed Petz map.
 \end{proof}
 
 \begin{theorem}[Agreement on the marginal support]

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -477,6 +477,8 @@
     (\ref{eq:entropy_support_petz_trace}) gives trace preservation.
 \end{proof}
 
+% Source boundary: the complementary factorization is support-completion algebra,
+% not part of HJPW equation (10).
 \begin{theorem}[Factorization of the complementary preparation term]
     \label{thm:entropy_petz_complement_maximally_mixed_tensor}
     \lean{Matrix.partialTraceRightPetzComplementMap_maximallyMixedTensor_kronecker,
@@ -492,9 +494,9 @@
         &=\operatorname{id}_A\otimes\mathcal C_{\rho_{BC}}.
         \label{eq:entropy_petz_complement_factorization}
     \end{align}
-    after the canonical reassociation of the three tensor factors. This is
-    TNLean-specific support-completion algebra from
-    (\ref{eq:entropy_petz_complement}), not a statement of
+    after the canonical reassociation of the three tensor factors. This follows
+    from the chosen support completion in
+    (\ref{eq:entropy_petz_complement}), not from
     \cite[equation~(10)]{Hayden2004Structure}.
 \end{theorem}
 
@@ -516,6 +518,8 @@
     A finite product-operator decomposition gives the result for every input.
 \end{proof}
 
+% Source boundary: only the raw summand is attributed to HJPW equation (10);
+% the complementary summand is the chosen support completion.
 \begin{theorem}[Factorization of the completed Petz channel]
     \label{thm:entropy_completed_petz_maximally_mixed_tensor}
     \lean{Matrix.partialTraceRightPetzChannel_maximallyMixedTensor}
@@ -532,8 +536,8 @@
     \end{align}
     after canonical reassociation of the three tensor factors. The raw
     support-map summand is the maximally mixed specialization of
-    \cite[equation~(10)]{Hayden2004Structure}. The complementary summand is
-    TNLean-specific support-completion algebra from
+    \cite[equation~(10)]{Hayden2004Structure}. The complementary summand comes
+    from the chosen support completion in
     (\ref{eq:entropy_petz_complement}). This theorem does not assert a
     Hayashi--Koashi--Imoto decomposition.
 \end{theorem}


### PR DESCRIPTION
## What changed

- Prove the left marginal and trace identities for the maximally mixed tensor reference.
- Factor the marginal support projector as $I_A \otimes P_B$ without assuming full support.
- Factor TNLean's complementary measure-and-prepare Petz term first on elementary tensors and then on arbitrary operators.
- Combine the raw support-map factorization from #4877 with the complementary factorization to obtain
  $\widehat{\mathcal R}_{d_A^{-1}I_A\otimes\rho_{BC}}
   = \operatorname{id}_A\otimes\widehat{\mathcal R}_{\rho_{BC}}$
  after canonical reassociation.
- Certify the completed map as CPTP when $\rho_{BC}$ is positive semidefinite with trace one.
- Record the marginal, support, complementary, completed-channel, and CPTP results in Chapter 19 with an explicit dependency order.

## Source boundary

The raw summand is the maximally mixed specialization of HJPW equation (10), as documented by #4877 and `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. The complementary and completed-channel identities are TNLean-specific support-completion algebra. This PR does not claim the unrestricted product-reference factorization or the Koashi--Imoto/Hayashi direct-sum decomposition.

## Validation

- `lake build TNLean.Channel.TensorMap` — passed.
- `lake build TNLean.Channel.PetzRecovery` — passed.
- `lake build TNLean.Channel.Schwarz` — passed.
- `lake build TNLean.MPS.MPDO` — passed.
- `lake build TNLean` — passed, 9749 jobs on the reviewed stack.
- Post-final rebase: the latest-main canonical/spectral modules and the changed Channel targets rebuilt successfully.
- Generated-import, module-policy, hotspot, size, numbered-file, proof-integrity, style, and prose checks passed.
- Blueprint generation, synchronization, and declaration resolution passed; Chapter 19 is 53/53.
- Blueprint compiled twice with zero undefined mathematical cross-references.
- Independent proof/source/blueprint review: APPROVE, no blockers.

Advances #4229; does not close it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics in channel/Petz recovery modules and blueprint prose; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Extends the maximally mixed HJPW tensor reference** with Lean proofs that the left marginal and trace match ρ_{BC}, and that the AB marginal support projector factors as **I_A ⊗ P_B** (via a new support-inverse sandwich argument).
> 
> **Factors TNLean’s support-completion pieces** the same way as the raw Petz map: the complementary measure-and-prepare term and the **completed** partial-trace Petz channel satisfy **id_A ⊗** the local maps after canonical reassociation. **`idTensorMapLM_add`** in `TensorMap.lean` is what lets the channel proof add the two summands on the lifted tensor product.
> 
> **CPTP** for the completed map when tr(ρ_{BC}) = 1 is reduced to the existing channel theorem using the new trace identity.
> 
> **Chapter 19** is reorganized with explicit theorem dependencies (marginals, support inverse/projector, complementary and completed factorizations, CPTP), with source boundaries called out (HJPW eq. (10) vs TNLean completion; no Koashi–Imoto claim).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93bfd8e71030f8c547e7c9dba13e356c1d20dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->