### PR TITLE
refactor(Channel/Schwarz): speed up normal decomposition

### DIFF
--- a/TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean
@@ -75,9 +75,6 @@ private lemma commute_parts_of_normal
     OfNat.ofNat_ne_zero, or_self, not_false_eq_true, Commute.smul_right_iff₀] using
     (hsum_sub.smul_left (1 / 2 : ℂ)).smul_right (Complex.I / 2 : ℂ)
 
-set_option maxHeartbeats 800000 in
--- Elaborating the simultaneous-diagonalization argument expands enough basis-level
--- definitions that the default heartbeat limit times out during `whnf`.
 private lemma exists_diagonal_family_of_normal
     {A : Mat} (hA : Aᴴ * A = A * Aᴴ) :
     ∃ (s : Type) (_ : Fintype s) (_ : DecidableEq s)
@@ -227,16 +224,10 @@ private lemma exists_diagonal_family_of_normal
   have hAstarAb (a : s) : Matrix.toEuclideanLin (Aᴴ * A) (b a) =
       (star (eig a) * eig a) • b a := by
     apply (WithLp.ofLp_injective 2)
-    have hmul : Aᴴ.mulVec (A.mulVec (b a).ofLp) = ((star (eig a) * eig a) • b a).ofLp := by
-      rw [hAb_ofLp a]
-      calc
-        Aᴴ.mulVec (eig a • (b a).ofLp) = eig a • (Aᴴ.mulVec (b a).ofLp) := by
-          rw [Matrix.mulVec_smul]
-        _ = eig a • (star (eig a) • (b a).ofLp) := by rw [hAstarb_ofLp a]
-        _ = ((star (eig a) * eig a) • b a).ofLp := by
-            simp only [WithLp.ofLp_smul, smul_smul, mul_comm]
-    simpa only [Matrix.ofLp_toLpLin (p := 2) (q := 2), Matrix.toLin'_apply,
-      Matrix.mulVec_mulVec, WithLp.ofLp_smul] using hmul
+    change (Aᴴ * A).mulVec (b a).ofLp =
+      ((star (eig a) * eig a) • b a).ofLp
+    rw [← Matrix.mulVec_mulVec, hAb_ofLp a, Matrix.mulVec_smul, hAstarb_ofLp a]
+    rw [WithLp.ofLp_smul, smul_smul, mul_comm]
   have hAstarA_matrix : Aᴴ * A = ∑ i, (star (eig i) * eig i) • P i := by
     apply Matrix.toEuclideanLin.injective
     simpa only [P, map_sum, map_smul, LinearEquiv.apply_symm_apply] using


### PR DESCRIPTION
### Motivation
- `TNLean.Channel.Schwarz.PositiveOnAbelian.Consequences` is a ranked compilation hotspot.
- Profiling showed the module is declaration-bound: one basis-level `simpa` spent 43.1 seconds simplifying a `mulVec` conversion.

### Description
- Replace the intermediate `hmul` proof and broad conversion `simpa` with a direct `change` and deterministic rewrite chain.
- Remove the 800,000-heartbeat override; the refactored proof passes under the default limit.
- Preserve every theorem statement and mathematical argument.

### Testing
- `lake env lean TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean`
- `lake build TNLean.Channel.Schwarz.PositiveOnAbelian.Consequences -q --log-level=info`
- Direct profiler: simplifier time fell from 45.1s to 5.91s; user CPU fell from 23.61s to 15.28s.
- `git diff --check origin/main...HEAD`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean || true`
- `python3 scripts/tactic_pattern_scan.py`

---
Addresses #4866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only proof tactics change in one private lemma; no API or mathematical content changes.
> 
> **Overview**
> **Proof-only performance fix** in `exists_diagonal_family_of_normal`: the `hAstarAb` step no longer builds an intermediate `hmul` lemma and closes with a broad `simpa` on `mulVec`/`ofLp` conversions.
> 
> Instead it uses `change` plus a short rewrite chain (`mulVec_mulVec`, `hAb_ofLp`, `hAstarb_ofLp`, `smul_smul`, `mul_comm`), which cuts simplifier time on this hotspot.
> 
> The **`set_option maxHeartbeats 800000`** on that declaration is removed; the refactored proof typechecks under the default heartbeat limit. **Theorem statements and the mathematical argument are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84504f9c650f56ded67f24ff196a0a44f1506311. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->