### PR TITLE
refactor(MPS/FT): narrow coefficient identity imports

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -3,8 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.FundamentalTheorem.SectorBNT.StrongMatch
+import TNLean.MPS.BNT.Basic
 import TNLean.MPS.CanonicalForm.PhaseCover
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 
 /-!
 # Coefficient identity for full BNT basis matching

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
+import TNLean.MPS.FundamentalTheorem.SectorBNT.StrongMatch
 import TNLean.MPS.FundamentalTheorem.Multi
 
 /-!


### PR DESCRIPTION
## Motivation

`SectorBNT/CoeffIdentity.lean` was paying for the broad `StrongMatch` import even though its declarations only use the BNT coefficient lemma, SectorBNT basics, and phase-cover machinery. This contributes directly to the compilation-hotspot campaign in #4866.

## Description

- replace the broad `SectorBNT.StrongMatch` import with the precise `MPS.BNT.Basic` and `SectorBNT.Basic` dependencies
- retain `MPS.CanonicalForm.PhaseCover`, which supplies the phase-equivalence construction used by the proof
- leave every declaration and proof unchanged

## Performance

Controlled warmed direct-module profiles on the same worktree:

- before: 26.71s total, 16.3s imports
- after: 14.34s total, 7.19s imports

## Testing

- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity -q --log-level=info`
- `git diff --check`
- proof-integrity grep for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`

Addresses #4866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-graph-only refactor with no Mathlib or proof edits; behavior should be unchanged aside from build graph and compile time.
> 
> **Overview**
> **`SectorBNT/CoeffIdentity.lean`** no longer imports the heavy **`SectorBNT.StrongMatch`** module. It now depends only on **`MPS.BNT.Basic`**, **`SectorBNT.Basic`**, and the existing **`CanonicalForm.PhaseCover`** import. Proofs and theorem statements are unchanged; the goal is faster compilation of this hotspot (roughly halved import time in the PR’s profiles).
> 
> **`SectorBNT/Fundamental.lean`** gains a direct **`StrongMatch`** import so full-basis matching (`bijective_match_of_sameMPV`, etc.) still resolves after **`CoeffIdentity`** stops re-exporting that dependency transitively.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c64974a1193e6421f9cb57d7ce2ce85ea89ecb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->