### PR TITLE
fix(build): avoid stale TNLean cache reuse

### DIFF
--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -38,9 +38,10 @@ validated dependency packages, including prebuilt Mathlib artifacts, and
 leaves the target without `.lake/build`. This prevents Lean from loading stale
 TNLean `.olean` files whose declarations no longer match the target source.
 
-After seeding, run the desired `lake build` or `lake env lean` command. At an
-identical commit Lake reuses the full build. At a different commit it rebuilds
-TNLean against the seeded dependencies.
+At an identical commit, run the desired `lake build` or `lake env lean`
+command and Lake will reuse the full build. After a cross-commit seed, run
+`lake build` first so TNLean is rebuilt against the seeded dependencies; only
+then run targeted `lake env lean` checks.
 
 ## Sort build timings
 

--- a/docs/lake_build_cache.md
+++ b/docs/lake_build_cache.md
@@ -32,8 +32,15 @@ while the source worktree is running a Lake command. The target `.lake` is an
 inaccessible reservation until the completed clone is atomically swapped into
 place, so a target Lake process cannot observe a partial cache.
 
-After seeding, run the desired `lake build` or `lake env lean` command. Lake
-will reuse unchanged artifacts and rebuild files changed on the branch.
+TNLean build artifacts are reused only when the source and target worktrees are
+at the same Git commit. If their commits differ, the command seeds only the
+validated dependency packages, including prebuilt Mathlib artifacts, and
+leaves the target without `.lake/build`. This prevents Lean from loading stale
+TNLean `.olean` files whose declarations no longer match the target source.
+
+After seeding, run the desired `lake build` or `lake env lean` command. At an
+identical commit Lake reuses the full build. At a different commit it rebuilds
+TNLean against the seeded dependencies.
 
 ## Sort build timings
 

--- a/scripts/seed_lake_build.sh
+++ b/scripts/seed_lake_build.sh
@@ -163,6 +163,14 @@ validate_root "$TARGET_PATH"
 SOURCE_ROOT="$(canonical_dir "$SOURCE_PATH")"
 TARGET_ROOT="$(canonical_dir "$TARGET_PATH")"
 test "$SOURCE_ROOT" != "$TARGET_ROOT" || die "source and target worktrees must differ"
+SOURCE_REV="$(git -C "$SOURCE_ROOT" rev-parse HEAD)" ||
+  die "cannot read source revision"
+TARGET_REV="$(git -C "$TARGET_ROOT" rev-parse HEAD)" ||
+  die "cannot read target revision"
+REUSE_TNLEAN_BUILD="false"
+if test "$SOURCE_REV" = "$TARGET_REV"; then
+  REUSE_TNLEAN_BUILD="true"
+fi
 test ! -L "$SOURCE_ROOT/.lake" || die "source .lake must not be a symlink"
 test -d "$SOURCE_ROOT/.lake/build" && test ! -L "$SOURCE_ROOT/.lake/build" ||
   die "source has no regular .lake/build"
@@ -191,6 +199,11 @@ if test "$DRY_RUN" = "true"; then
   echo "seed-lake-build: dry-run passed"
   echo "seed-lake-build: source: $SOURCE_ROOT/.lake"
   echo "seed-lake-build: target: $TARGET_ROOT/.lake"
+  if test "$REUSE_TNLEAN_BUILD" = "true"; then
+    echo "seed-lake-build: TNLean build artifacts will be reused"
+  else
+    echo "seed-lake-build: TNLean build artifacts will be omitted (different revisions)"
+  fi
   exit 0
 fi
 
@@ -207,7 +220,11 @@ RESERVATION_INODE="$(stat -f %i "$RESERVATION_DIR")"
 chmod 000 "$RESERVATION_DIR"
 STAGING_DIR="$(/usr/bin/mktemp -d "$TARGET_ROOT/.lake.seed.XXXXXX")"
 STAGING_INODE="$(stat -f %i "$STAGING_DIR")"
-/bin/cp -cR "$SOURCE_ROOT/.lake/." "$STAGING_DIR"
+if test "$REUSE_TNLEAN_BUILD" = "true"; then
+  /bin/cp -cR "$SOURCE_ROOT/.lake/." "$STAGING_DIR"
+else
+  /bin/cp -cR "$SOURCE_ROOT/.lake/packages" "$STAGING_DIR/packages"
+fi
 test "$(stat -f %i "$STAGING_DIR")" = "$STAGING_INODE" ||
   die "staging directory changed during clone"
 python3 - "$STAGING_DIR" "$RESERVATION_DIR" <<'PY'
@@ -243,4 +260,9 @@ chmod 700 "$STAGING_DIR"
 find "$STAGING_DIR" -depth -delete
 STAGING_DIR=""
 STAGING_INODE=""
-echo "seed-lake-build: cloned $SOURCE_ROOT/.lake into $TARGET_ROOT/.lake"
+if test "$REUSE_TNLEAN_BUILD" = "true"; then
+  echo "seed-lake-build: cloned $SOURCE_ROOT/.lake into $TARGET_ROOT/.lake"
+else
+  echo "seed-lake-build: cloned dependency packages into $TARGET_ROOT/.lake"
+  echo "seed-lake-build: omitted TNLean build artifacts from different source revision"
+fi

--- a/scripts/test_seed_lake_build.sh
+++ b/scripts/test_seed_lake_build.sh
@@ -12,6 +12,7 @@ trap cleanup EXIT
 
 REPO="$TEST_ROOT/repo"
 TARGET="$TEST_ROOT/target"
+MISMATCH_TARGET="$TEST_ROOT/mismatch-target"
 mkdir -p "$REPO/scripts"
 cp "$SCRIPT_SOURCE/seed_lake_build.sh" "$REPO/scripts/seed_lake_build.sh"
 printf 'leanprover/lean4:v4.32.0\n' >"$REPO/lean-toolchain"
@@ -223,5 +224,27 @@ if "$REPO/scripts/seed_lake_build.sh" "$TARGET" 2>"$TEST_ROOT/error.log"; then
   exit 1
 fi
 /usr/bin/grep -q "target already has .lake" "$TEST_ROOT/error.log"
+
+git -C "$REPO" add lake-manifest.json
+git -C "$REPO" \
+  -c user.name=Test \
+  -c user.email=test@example.com \
+  commit -qm "Pin dependency revision"
+git -C "$REPO" worktree add --detach -q "$MISMATCH_TARGET" HEAD
+printf 'new revision\n' >"$REPO/revision-marker"
+git -C "$REPO" add revision-marker
+git -C "$REPO" \
+  -c user.name=Test \
+  -c user.email=test@example.com \
+  commit -qm "Advance source revision"
+PATH="$TEST_ROOT/bin:$PATH" \
+  "$REPO/scripts/seed_lake_build.sh" "$MISMATCH_TARGET" \
+  >"$TEST_ROOT/mismatch.log"
+test -f "$MISMATCH_TARGET/.lake/packages/mathlib/tracked"
+test -f \
+  "$MISMATCH_TARGET/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.olean"
+test ! -e "$MISMATCH_TARGET/.lake/build"
+/usr/bin/grep -q "omitted TNLean build artifacts from different source revision" \
+  "$TEST_ROOT/mismatch.log"
 
 echo "Lake build seed integration test passed"


### PR DESCRIPTION
### Motivation

`seed_lake_build.sh` currently clones TNLean `.olean` files even when the source and target
worktrees are at different commits. Matching Lean/Lake dependency inputs do not make project
artifacts source-compatible: a stale `TransferOperatorGapRect.olean` reproduced a duplicate
declaration failure after the declaration moved to `TransferOperatorGapRectNormalized`.

### Description

- compare the source and target Git revisions before cloning;
- retain the existing full `.lake` APFS clone when the revisions match;
- when they differ, clone only the already-validated dependency packages and omit the root
  `.lake/build`;
- report the selected mode in dry-run and normal output;
- add a synthetic cross-commit regression proving Mathlib artifacts are retained while the
  stale TNLean artifact is not copied;
- document the same-commit and cross-commit behavior.

This is local developer tooling only and does not change GitHub Actions behavior.

### Validation

- `bash -n scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh`
- `shellcheck scripts/seed_lake_build.sh scripts/test_seed_lake_build.sh`
- `scripts/test_seed_lake_build.sh`
- real-worktree cross-commit dry run
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local macOS developer script and docs only; no CI or production runtime changes.
> 
> **Overview**
> **`seed_lake_build.sh` now gates TNLean artifact reuse on matching Git commits.** When source and target worktrees share `HEAD`, behavior is unchanged: the full `.lake` tree (including `.lake/build`) is APFS-cloned. When revisions differ, only validated `.lake/packages` (e.g. prebuilt Mathlib) are copied and the target is left without `.lake/build`, so Lean cannot load TNLean `.olean` files from another revision.
> 
> Dry-run and post-seed messages state whether TNLean build output will be reused or omitted. **`docs/lake_build_cache.md`** documents that cross-commit seeds require `lake build` before targeted `lake env lean` checks. A new integration scenario in **`test_seed_lake_build.sh`** asserts Mathlib artifacts are present and `.lake/build` is absent when seeding across commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c2af4adb43c1ee2ed44e8d454bb89cc29bc8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->