### PR TITLE
refactor(MPS/RFP): streamline tensor-power inverse proof

### DIFF
--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -109,15 +109,17 @@ Source: arXiv:1606.00608, equations (3.16)--(3.17), lines 549--578. -/
     (∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) *
       ∑ q : Fin N → Fin D × Fin D,
         (∏ t : Fin N, hStruct.U (σ t) (q t).1 (q t).2) * v q) = v p
-  let g (q : Fin N → Fin D × Fin D) (t : Fin N) (i : Fin d) : ℂ :=
-    star (hStruct.U i (p t).1 (p t).2) * hStruct.U i (q t).1 (q t).2
   have hfactor (q : Fin N → Fin D × Fin D) :
-      Finset.univ.sum (fun σ : Cfg d N ↦
-        Finset.univ.prod fun t : Fin N ↦ g q t (σ t)) =
-        Finset.univ.prod (fun t : Fin N ↦ Finset.univ.sum fun i : Fin d ↦ g q t i) := by
+      (∑ σ : Cfg d N, ∏ t : Fin N,
+        star (hStruct.U (σ t) (p t).1 (p t).2) *
+          hStruct.U (σ t) (q t).1 (q t).2) =
+        ∏ t : Fin N, ∑ i : Fin d,
+          star (hStruct.U i (p t).1 (p t).2) *
+            hStruct.U i (q t).1 (q t).2 := by
     simpa only [Fintype.piFinset_univ] using
       (Finset.sum_prod_piFinset (R := ℂ) (Finset.univ : Finset (Fin d))
-        (fun t i ↦ g q t i))
+        (fun t i ↦
+          star (hStruct.U i (p t).1 (p t).2) * hStruct.U i (q t).1 (q t).2))
   have hdelta (q : Fin N → Fin D × Fin D) :
       (∏ t : Fin N, if p t = q t then (1 : ℂ) else 0) =
         if p = q then 1 else 0 := by
@@ -162,11 +164,15 @@ Source: arXiv:1606.00608, equations (3.16)--(3.17), lines 549--578. -/
           ∏ t : Fin N, ∑ i : Fin d,
             star (hStruct.U i (p t).1 (p t).2) *
               hStruct.U i (q t).1 (q t).2 by
-        simpa [g] using hfactor q]
+        exact hfactor q]
     _ = v p := by
       simp_rw [hStruct.hU_pair]
       simp_rw [hdelta]
-      simp
+      rw [Finset.sum_eq_single p]
+      · simp
+      · intro q _ hqp
+        simp [Ne.symm hqp]
+      · simp
 
 /-- Every tensor power of the physical map is injective.
 


### PR DESCRIPTION
## Motivation

`MPS/RFP/AppendixBSupport.lean` remains one of the ranked compilation-cost modules in #4866. Profiling identified `physicalIsometryTensorPowerLeftInverse_comp` as its largest individual proof declaration.

## Description

- state the finite product-of-sums factorization directly instead of introducing a local `g` and later unfolding it with a broad `simpa`
- reuse the factorization by exact matching
- evaluate the final Kronecker-delta sum with `Finset.sum_eq_single` instead of a broad `simp` that performs an expensive failed `Nonempty` synthesis search
- leave the theorem statement and mathematical argument unchanged

## Performance

Two alternating warmed direct-module A/B profiles for `physicalIsometryTensorPowerLeftInverse_comp`:

- 1.006s -> 0.460s (54% reduction)
- 1.596s -> 0.751s (53% reduction)

## Testing

- `lake env lean TNLean/MPS/RFP/AppendixBSupport.lean`
- `lake build TNLean.MPS.RFP.AppendixBSupport -q --log-level=info`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- proof-integrity grep for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`

Addresses #4866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-tactic changes only; no API or mathematical statement changes, with downstream theorems still invoking the same `@[simp]` lemma.
> 
> **Overview**
> Refactors the proof of **`physicalIsometryTensorPowerLeftInverse_comp`** in `AppendixBSupport.lean` for faster Lean compilation (~53% on that declaration). The theorem statement and argument are unchanged.
> 
> **`hfactor`** now states the finite product-of-sums factorization inline (no local `g`), and the calc step reuses it with **`exact hfactor q`** instead of a broad **`simpa [g]`**. The closing Kronecker-delta sum uses **`Finset.sum_eq_single`** instead of **`simp`**, avoiding expensive failed **`Nonempty`** synthesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced6d809d57ddbcead2ebdbfb39cea74d58e20a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->