### PR TITLE
chore(linter): clear compilation warnings

### DIFF
--- a/TNLean/Analysis/TraceNormVariational.lean
+++ b/TNLean/Analysis/TraceNormVariational.lean
@@ -207,7 +207,7 @@ theorem exists_mem_unitaryGroup_trace_conjTranspose_mul_eq (A : Matrix (Fin D) (
       rw [hf]
       simp only [inner_smul_left, inner_smul_right]
       ring
-    show ⟪f i, f j⟫_ℂ = _
+    change ⟪f i, f j⟫_ℂ = _
     rw [hinner, hgg i j]
     rcases eq_or_ne i j with rfl | hij
     · have hlpos : 0 < lam i := (hlam0 i).lt_of_ne (Ne.symm hi)

--- a/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
+++ b/TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean
@@ -443,7 +443,7 @@ private theorem nonempty_markovDecomposition_tripartite
     mul_one, Matrix.kroneckerMap_one_one, one_div, Matrix.submatrix_diagonal_equiv,
     one_mul, Matrix.conjTranspose_one, HayashiMarkov.abcEquiv, markovMiddleEquiv,
     oneSiteEquiv, Equiv.symm_trans, Equiv.symm_symm, sectorEquiv, Fin.isValue,
-    Equiv.prodCongr_symm, Equiv.refl_symm, Equiv.symm_mk, Nat.reduceAdd,
+    Equiv.prodCongr_symm, Equiv.refl_symm, Equiv.symm_mk,
     Fin.zero_eta, Equiv.prodCongr_apply, Equiv.coe_refl, Equiv.coe_trans,
     Equiv.funUnique_symm_apply, Equiv.coe_fn_mk, Prod.map_apply, id_eq,
     Function.comp_apply, Matrix.diagonal_mul, p, Complex.ofReal_inv,

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -146,8 +146,7 @@ theorem tensorMapBoth_bipartitionedNormalizedMPO
   ext p q
   rcases p with ⟨pA, pB⟩
   rcases q with ⟨qA, qB⟩
-  simp only [Matrix.tensorMapBoth, Matrix.idTensorMap, Matrix.submatrix_apply,
-    Matrix.tensorMapId_apply, Prod.swap_prod_mk]
+  simp only [Matrix.tensorMapBoth, Matrix.idTensorMap]
   simp only [coarsenFirstBlock, Matrix.equivReindexMap]
   let uA : Fin (a + 2) → Fin d := finFunctionFinEquiv.symm pA
   let vA : Fin (a + 2) → Fin d := finFunctionFinEquiv.symm qA
@@ -212,8 +211,7 @@ theorem tensorMapBoth_bipartitionedNormalizedMPO_reverse
   ext p q
   rcases p with ⟨pA, pB⟩
   rcases q with ⟨qA, qB⟩
-  simp only [Matrix.tensorMapBoth, Matrix.idTensorMap, Matrix.submatrix_apply,
-    Matrix.tensorMapId_apply, Prod.swap_prod_mk]
+  simp only [Matrix.tensorMapBoth, Matrix.idTensorMap]
   simp only [refineFirstBlock, Matrix.equivReindexMap]
   let uA : Fin (a + 1) → Fin d := finFunctionFinEquiv.symm pA
   let vA : Fin (a + 1) → Fin d := finFunctionFinEquiv.symm qA

--- a/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
@@ -592,9 +592,12 @@ theorem mulTensor_verticalAssembledTensor_reindex
   rcases x with ⟨⟨⟨α, q⟩, ⟨β, r⟩⟩, ⟨i, j⟩⟩
   rcases y with ⟨⟨⟨α', q'⟩, ⟨β', r'⟩⟩, ⟨i', j'⟩⟩
   simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
-  simp [productRetainedEquiv, verticalProductSectorEquiv,
-    retainedVerticalProductTensor, weightedVerticalProductBlock,
-    toMPSTensor, mulTensor_apply, verticalBNTMPO_apply]
+  simp only [retainedVerticalProductTensor, toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat, productRetainedEquiv, verticalProductSectorEquiv,
+    Equiv.symm_trans, Equiv.symm_mk, Equiv.prodCongr_symm, Equiv.symm_symm,
+    Equiv.trans_apply, Equiv.coe_fn_mk, Equiv.prodCongr_apply, Prod.map_apply,
+    mulTensor_apply, verticalBNTMPO_apply, Matrix.submatrix_apply,
+    Equiv.symm_apply_apply, weightedVerticalProductBlock]
   by_cases hp :
       ((⟨α, q⟩ : (α : Fin g) × Fin (mult α)),
         (⟨β, r⟩ : (α : Fin g) × Fin (mult α))) =

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -222,9 +222,11 @@ private theorem groundBond_eq_one_sub_toMatrix' :
     groundBond A = 1 - LinearMap.toMatrix' (parentInteraction A 2) := by
   classical
   ext x y
-  simp [groundBond, twoSiteParentGroundProjectorMatrix,
+  simp only [groundBond, twoSiteParentGroundProjectorMatrix,
     twoSiteParentInteractionMatrix, Matrix.reindex_apply,
-    Matrix.submatrix_apply, Matrix.one_apply]
+    finTwoArrowEquiv_symm_apply, Equiv.symm_symm, finTwoArrowEquiv_apply,
+    Equiv.toFun_as_coe, piFinTwoEquiv_apply, Fin.isValue, Matrix.submatrix_apply,
+    Matrix.sub_apply, Matrix.one_apply, Prod.mk.injEq, LinearMap.toMatrix'_apply]
   · have hx : ![x 0, x 1] = x := by
       funext j
       fin_cases j <;> rfl
@@ -263,10 +265,12 @@ private theorem embedLocalOperator_groundBond_eq_one_sub {N : ℕ} (hN : 2 ≤ N
         rw [← replaceWindow_extractWindow 2 hN i τ]
         rw [← h, hστ]
       simp [hEq, hExtract]
-  · simp [MPOTensor.embedLocalOperator_apply, hστ, Matrix.one_apply]
-    intro hEq
-    subst τ
-    exact hστ (by simp [MPOTensor.AgreesOutsideWindow])
+  · have hne : σ ≠ τ := by
+      intro hEq
+      subst τ
+      exact hστ (by simp [MPOTensor.AgreesOutsideWindow])
+    simp only [MPOTensor.embedLocalOperator_apply, hστ, if_false,
+      Matrix.sub_apply, Matrix.one_apply, hne, sub_zero]
 
 private theorem singleKrausMap_groundBond_eq_transformedGroundBond
     (F : BeigiSectorGraphData A) :

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -269,8 +269,7 @@ private theorem embedLocalOperator_groundBond_eq_one_sub {N : ℕ} (hN : 2 ≤ N
       intro hEq
       subst τ
       exact hστ (by simp [MPOTensor.AgreesOutsideWindow])
-    simp only [MPOTensor.embedLocalOperator_apply, hστ, if_false,
-      Matrix.sub_apply, Matrix.one_apply, hne, sub_zero]
+    simp [MPOTensor.embedLocalOperator_apply, hστ, hne]
 
 private theorem singleKrausMap_groundBond_eq_transformedGroundBond
     (F : BeigiSectorGraphData A) :

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap.lean
@@ -19,10 +19,10 @@ source's four-region two-step inverse application.
 
 The source decomposes the vertex set into four pairwise-disjoint blocks
 `P₀ = A \ B`, `P₁ = A ∩ B`, `P₂ = B \ A`, and `P₃ = (A ∪ B)ᶜ`, with
-`A = P₀ ∪ P₁`, `B = P₁ ∪ P₂`, and `A ∪ B = P₀ ∪ P₁ ∪ P₂`. A coefficient family
-`c` annihilating the blocked weights of `A ∪ B` is stripped of `A` by its left
-inverse (the host weight, read as a function of the `A` physical leg, factors
-through the `A`-block map; the blocks `A` and `B \ A` form a disjoint
+`A = P₀ ∪ P₁`, `B = P₁ ∪ P₂`, and `A ∪ B = P₀ ∪ P₁ ∪ P₂`. A coefficient
+family `c` annihilating the blocked weights of `A ∪ B` is stripped of `A` by
+its left inverse (the host weight, read as a function of the `A` physical leg,
+factors through the `A`-block map; the blocks `A` and `B \ A` form a disjoint
 two-block split of the host, so this is the landed three-block blue strip with
 `blue := A`, `complement := B \ A`). The residual is a coupling through the
 `B \ A` block. Re-inserting the overlap `A ∩ B` rebuilds the `B`-block weight,
@@ -168,9 +168,9 @@ theorem overlapRightGeometry_univ_sdiff_red (R₁ R₂ : Finset V) :
 
 The source proof inverts the two injective regions in sequence. With the two
 overlap geometries this is two applications of the landed blue strip
-(`ThreeBlockGeometry.complCoeff_combination_eq_zero`), one for each region: stripping `R₁` leaves the
-residual coupling through `R₂ \ R₁`, and stripping `R₂` leaves the residual
-coupling through `R₁ \ R₂`. -/
+(`ThreeBlockGeometry.complCoeff_combination_eq_zero`), one for each region:
+stripping `R₁` leaves the residual coupling through `R₂ \ R₁`, and stripping
+`R₂` leaves the residual coupling through `R₁ \ R₂`. -/
 
 open scoped Classical in
 /-- **The first strip (region `R₁`).** A coefficient family `c` annihilating the

--- a/TNLean/PEPS/TorusFundamentalTheorem2.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem2.lean
@@ -225,7 +225,7 @@ theorem bondDim_eq_of_normalTorusRectangle
         A.bondDim (torusRightEdge p) = A.bondDim (
             translateEdge (p.1 - xref) (p.2 - yref) (torusRightEdge (xref, yref))) := by
           rw [translateEdge_torusRightEdge (p.1 - xref) (p.2 - yref) (xref, yref)]
-          simp [sub_add_cancel]
+          simp
         _ = A.bondDim (torusRightEdge (xref, yref)) :=
           bondDim_translateEdge_of_translationInvariant hA _ _ _
         _ = A.bondDim eh := by rw [← heh_eq]
@@ -234,7 +234,7 @@ theorem bondDim_eq_of_normalTorusRectangle
         B.bondDim (torusRightEdge p) = B.bondDim (
             translateEdge (p.1 - xref) (p.2 - yref) (torusRightEdge (xref, yref))) := by
           rw [translateEdge_torusRightEdge (p.1 - xref) (p.2 - yref) (xref, yref)]
-          simp [sub_add_cancel]
+          simp
         _ = B.bondDim (torusRightEdge (xref, yref)) :=
           bondDim_translateEdge_of_translationInvariant hB _ _ _
         _ = B.bondDim eh := by rw [← heh_eq]
@@ -247,7 +247,7 @@ theorem bondDim_eq_of_normalTorusRectangle
         A.bondDim (torusUpEdge p) = A.bondDim (
             translateEdge (p.1 - xvref) (p.2 - yvref) (torusUpEdge (xvref, yvref))) := by
           rw [translateEdge_torusUpEdge (p.1 - xvref) (p.2 - yvref) (xvref, yvref)]
-          simp [sub_add_cancel]
+          simp
         _ = A.bondDim (torusUpEdge (xvref, yvref)) :=
           bondDim_translateEdge_of_translationInvariant hA _ _ _
         _ = A.bondDim ev := by rw [← hev_eq]
@@ -256,7 +256,7 @@ theorem bondDim_eq_of_normalTorusRectangle
         B.bondDim (torusUpEdge p) = B.bondDim (
             translateEdge (p.1 - xvref) (p.2 - yvref) (torusUpEdge (xvref, yvref))) := by
           rw [translateEdge_torusUpEdge (p.1 - xvref) (p.2 - yvref) (xvref, yvref)]
-          simp [sub_add_cancel]
+          simp
         _ = B.bondDim (torusUpEdge (xvref, yvref)) :=
           bondDim_translateEdge_of_translationInvariant hB _ _ _
         _ = B.bondDim ev := by rw [← hev_eq]

--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -262,8 +262,8 @@ theorem posSemidef_fixedPoint_unique_of_irreducible
         (posSemidef_fixedPoint_isPosDef_of_irreducible A hIrr τ hτ_psd hτ_ne hτ_fix)
         hτ_not_pd
 
-/-- **Uniqueness** (Wolf Theorem 6.3(2), non-degeneracy): any two nonzero PSD
-fixed points of an injective transfer map are proportional. -/
+/-- **Uniqueness** (Wolf Theorem 6.3(2), non-degeneracy): any PSD fixed point
+of an injective transfer map is proportional to a given nonzero PSD fixed point. -/
 theorem posSemidef_fixedPoint_unique
     (A : MPSTensor d D) (hA : IsInjective A)
     (ρ σ : Matrix (Fin D) (Fin D) ℂ)

--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -268,7 +268,7 @@ theorem posSemidef_fixedPoint_unique
     (A : MPSTensor d D) (hA : IsInjective A)
     (ρ σ : Matrix (Fin D) (Fin D) ℂ)
     (hρ_psd : ρ.PosSemidef) (hρ_ne : ρ ≠ 0)
-    (hσ_psd : σ.PosSemidef) (hσ_ne : σ ≠ 0)
+    (hσ_psd : σ.PosSemidef)
     (hρ_fix : transferMap (d := d) (D := D) A ρ = ρ)
     (hσ_fix : transferMap (d := d) (D := D) A σ = σ) :
     ∃ c : ℂ, σ = c • ρ := by


### PR DESCRIPTION
### Motivation

- The repository build reported unused hypotheses, unused simplification arguments, flexible simplification tactics, a goal-changing `show`, and an overlong line.
- Removing these diagnostics keeps the build output focused on substantive mathematical gaps, in particular the documented `SectorMatch` contraction proof.

### Description

- Remove unused simplification lemmas and replace flexible `simp` calls by explicit `simp only` sets.
- Replace a goal-changing `show` by `change` and reflow the affected PEPS documentation.
- Remove the redundant nonzero hypothesis on the second fixed point in `posSemidef_fixedPoint_unique`; the invoked irreducible uniqueness theorem already proves the stronger statement for an arbitrary positive semidefinite second fixed point.
- Preserve all other theorem statements and proof conclusions. No linter is disabled.

### Testing

- `lake build TNLean`
- `git diff --check`
- Checked the eight modified files for `sorry`, `admit`, `native_decide`, `unsafeCast`, and `axiom`.
- The complete build succeeds. Its only remaining warning is the pre-existing, documented `sorry` in `TNLean/MPS/Periodic/Overlap/SectorMatch.lean`.

### Agent assistance

- OpenAI Codex (GPT-5) produced the warning-cleanup edits, selected the explicit simplification sets using Lean diagnostics, and ran the verification commands. The pull request was opened through the maintainer account, whose holder remains accountable for review and merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only and documentation reflow changes with a slightly weaker (more general) theorem statement; no runtime or security impact.
> 
> **Overview**
> Cleans up Lean build warnings by tightening proof scripts: **`show` → `change`** in trace-norm orthonormality, **explicit `simp only` lists** (dropping unused lemmas) in MPDO/RFP, vertical product pair blocks, and Beigi sector graph proofs, and **simpler `simp`** in torus bond-dimension transport.
> 
> **`posSemidef_fixedPoint_unique`** drops the redundant **`hσ_ne : σ ≠ 0`** hypothesis; the irreducible uniqueness lemma already handles arbitrary PSD fixed points (including zero). Docstrings are reflowed in PEPS overlap injectivity commentary only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795aecc3ed7e52399e0bd7077c712e74f416430f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->