### PR TITLE
refactor(Channel): localize Kraus Gram simplification

### DIFF
--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -156,7 +156,7 @@ theorem kraus_rectangular_freedom
             if c = x₁ then star (K α a b) else 0 := by
           rw [Finset.sum_eq_single a (fun x _ hx => by simp [Ne.symm hx])
               (fun h => absurd (Finset.mem_univ _) h)]
-          split_ifs <;> simp_all
+          simp
         rw [h_inner]; split_ifs <;> simp
       simp_rw [step₁]; simp [Finset.sum_ite_eq, Finset.mem_univ]
     rw [collapse, collapse] at h_entry


### PR DESCRIPTION
## Motivation

The definitive exact-main clean-root census measured `TNLean.Channel.KrausFreedom` at 42s, making it the highest remaining compilation hotspot in #4866. Profiler evidence localized nearly all declaration cost to the Kronecker-delta collapse inside `kraus_rectangular_freedom`.

## Description

Replace `split_ifs <;> simp_all` with the local `simp` normalization after `Finset.sum_eq_single`. At that point the selected-index equality and membership facts already reduce the expression directly; splitting conditionals and simplifying every hypothesis repeatedly is unnecessary. The theorem statement and mathematical proof are unchanged.

## Performance

- definitive clean-root full-build census: 42s
- `kraus_rectangular_freedom` direct profiler: 5.652s -> 0.325s
- direct module wall time: 16.22s -> 2.78s
- post-change Lake target compile: 3.3s

The changed module is therefore below the 25s warning gate in the local Lake measurement.

## Testing

- `lake env lean TNLean/Channel/KrausFreedom.lean`
- `lake build TNLean.Channel.KrausFreedom --log-level=info`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- proof-integrity grep for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`

Addresses #4866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line tactic change in a proof step with no API or logical changes; risk is limited to proof stability, which the author validated with builds and profiling.
> 
> **Overview**
> **Compilation-only tweak** in the Kronecker-delta collapse inside `kraus_rectangular_freedom` (Gram-matrix entry proof): after `Finset.sum_eq_single`, the inner sum step now uses **`simp`** instead of **`split_ifs <;> simp_all`**.
> 
> The mathematical proof and theorem statements are unchanged; the goal is to avoid redundant conditional splitting and global simplification once the selected-index facts are already available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9089c2b92d347ab684183ca797cb20d1fbb1527b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->