### PR TITLE
refactor(Channel/Semigroup): speed exponential remainder proof

### DIFF
--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -5,21 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Algebra.MatrixOperatorSpace
 import TNLean.Channel.Basic
-
-import Mathlib.Analysis.Normed.Algebra.Exponential
-import Mathlib.Analysis.Normed.Operator.Basic
-import Mathlib.Analysis.Normed.Operator.Mul
-import Mathlib.Analysis.SpecialFunctions.Exponential
-import Mathlib.Analysis.ODE.Gronwall
 import Mathlib.Analysis.ODE.ExistUnique
-import Mathlib.Topology.Algebra.Module.FiniteDimension
-import Mathlib.Topology.Metrizable.Uniformity
-import Mathlib.Analysis.Complex.RealDeriv
-import Mathlib.Analysis.Calculus.Deriv.Mul
-import Mathlib.Analysis.Calculus.Deriv.Slope
-import Mathlib.Analysis.Calculus.Deriv.Shift
-import Mathlib.Analysis.Normed.Ring.Units
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 
 /-!
 # Quantum Dynamical Semigroups — Definitions and Proposition 7.1
@@ -78,8 +64,9 @@ theorem norm_exp_sub_one_sub_self_le
   rw [htail_eq]
   have hsummable_tail : Summable (fun n : ℕ =>
       ‖((Nat.factorial (n + 2) : ℂ)⁻¹) • x ^ (n + 2)‖) := by
-    exact (summable_nat_add_iff 2).2
-      (by simpa using NormedSpace.norm_expSeries_summable' (𝕂 := ℂ) x)
+    simpa [Function.comp_def] using
+      (NormedSpace.norm_expSeries_summable' (𝕂 := ℂ) x).comp_injective
+        (fun _ _ h ↦ Nat.add_right_cancel h)
   have hsummable_cmp : Summable (fun n : ℕ => ‖x‖ ^ 2 * (‖x‖ ^ n / Nat.factorial n)) :=
     (Real.summable_pow_div_factorial ‖x‖).mul_left (‖x‖ ^ 2)
   have hterm : ∀ n : ℕ,


### PR DESCRIPTION
### Motivation

- The exact-main compilation census in #4866 measured
  `TNLean.Channel.Semigroup.Basic` at 37 seconds.
- Profiling localized 3--4 seconds of isolated elaboration to typeclass
  synthesis for the shifted exponential series in
  `norm_exp_sub_one_sub_self_le`.

### Description

- Reindex the norm-summable exponential series directly along the injective
  map `n ↦ n + 2`, instead of routing through `summable_nat_add_iff`.
- Remove 13 redundant direct Mathlib imports; retain
  `Mathlib.Analysis.ODE.ExistUnique`, the only direct Mathlib import required
  beyond the two TNLean imports.
- Preserve all public declarations and theorem statements.

### Testing

- `lake env lean TNLean/Channel/Semigroup/Basic.lean`
- `lake build TNLean.Channel.Semigroup.Basic`
  - exact rebased head: 12 seconds
  - prior focused runs: 3.2--4.1 seconds
  - exact-main census baseline: 37 seconds
- `lake build TNLean.Channel.Semigroup.Basic TNLean.Channel.Semigroup.LindbladForm.EulerStep TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis`
- `lake build` (9,751 jobs; no Mathlib compilation)
- `python3 scripts/tactic_pattern_scan.py`
- `rg -n "sorry|axiom" TNLean/Channel/Semigroup/Basic.lean || true`
- `git diff --check`

---
Addresses #4866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor and import cleanup; no behavioral or API changes beyond faster elaboration of an existing bound.
> 
> **Overview**
> **Speeds compilation of** `TNLean.Channel.Semigroup.Basic` by trimming imports and simplifying one proof step in `norm_exp_sub_one_sub_self_le`, with no change to public APIs or theorem statements.
> 
> Thirteen direct Mathlib imports are removed; only `Mathlib.Analysis.ODE.ExistUnique` remains beyond the two TNLean imports (other Mathlib still arrives transitively). For summability of the tail of the exponential series, the proof now reindexes `NormedSpace.norm_expSeries_summable'` with `comp_injective` along `n ↦ n + 2` instead of going through `summable_nat_add_iff`, which cuts heavy typeclass synthesis during elaboration of that lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424dc712e8651eab38c2b67a405a191e486a3b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->