### PR TITLE
refactor(MPS/MPDO): constrain pentagon simplification

### DIFF
--- a/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
+++ b/TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean
@@ -921,19 +921,22 @@ theorem inversePrintedFMatrix_pentagon
     (fun M => M ⟨f, g, mu, nu, rho⟩ ⟨j, i, gamma, delta, kappa⟩)
     (Fus.threeEdgeInversePrintedFMatrix_eq_twoEdgeInversePrintedFMatrix
       a b c d e)
-  simpa [threeEdgeInversePrintedFMatrix, twoEdgeInversePrintedFMatrix,
-    leftInnerToLeftAssocInversePrintedFMatrix,
-    middleToLeftInnerInversePrintedFMatrix,
-    rightAssocToMiddleInversePrintedFMatrix,
-    pairToLeftAssocInversePrintedFMatrix,
-    rightAssocToPairInversePrintedFMatrix,
-    leftPathFirstSourceEquiv, leftPathFirstTargetEquiv,
-    leftPathSecondSourceEquiv, leftPathSecondTargetEquiv,
-    leftPathThirdSourceEquiv, leftPathThirdTargetEquiv,
+  simpa only [mul_assoc, threeEdgeInversePrintedFMatrix,
+    leftInnerToLeftAssocInversePrintedFMatrix, leftPathFirstSourceEquiv,
+    Equiv.coe_fn_mk, leftPathFirstTargetEquiv,
+    middleToLeftInnerInversePrintedFMatrix, leftPathSecondSourceEquiv,
+    Prod.mk.eta, leftPathSecondTargetEquiv,
+    rightAssocToMiddleInversePrintedFMatrix, leftPathThirdSourceEquiv,
+    leftPathThirdTargetEquiv, Matrix.mul_apply, submatrix_apply,
+    blockDiagonal'_apply, kroneckerMap_apply, Matrix.one_apply, mul_ite,
+    mul_one, mul_zero, ite_mul, one_mul, zero_mul, mul_dite, dite_mul,
+    Fintype.sum_sigma, Finset.sum_dite_irrel, Fintype.sum_prod_type,
+    Finset.sum_const_zero, Finset.sum_dite_eq', Finset.mem_univ,
+    ↓reduceIte, cast_eq, Finset.sum_ite_eq', Finset.sum_dite_eq,
+    Finset.sum_ite_irrel, Finset.sum_ite_eq, Finset.mul_sum,
+    twoEdgeInversePrintedFMatrix, pairToLeftAssocInversePrintedFMatrix,
     rightPathFirstSourceEquiv, rightPathFirstTargetEquiv,
-    rightPathSecondSourceEquiv, rightPathSecondTargetEquiv,
-    Matrix.mul_apply, Fintype.sum_sigma, Fintype.sum_prod_type,
-    Matrix.blockDiagonal'_apply, Matrix.one_apply, Finset.mul_sum,
-    mul_assoc] using h
+    rightAssocToPairInversePrintedFMatrix, rightPathSecondSourceEquiv,
+    rightPathSecondTargetEquiv] using h
 
 end MPOTensor.CompleteZipperFusionFamily


### PR DESCRIPTION
## Motivation

The definitive clean-root census measured `TNLean.MPS.MPDO.CompleteZipperFusionPentagon` at 36s, placing it fourth in the current compilation-hotspot queue in #4866. Profiling localized the largest declaration cost to the final indexed pentagon proof.

## Description

Replace the unrestricted `simpa` in `inversePrintedFMatrix_pentagon` with the exact `simp only` normalization set suggested by Lean. The previous call searched the global simp set and repeatedly attempted unavailable `Nonempty` instances for dependent fusion multiplicities. The constrained proof performs only the matrix, reindexing, finite-sum, conditional, and cast reductions required to read the matrix identity entrywise. The theorem statement and mathematical argument are unchanged.

## Performance

- definitive clean-root full-build census: 36s
- `inversePrintedFMatrix_pentagon` direct profiler: 8.798s -> 2.166s
- direct module wall time: 20.49s -> 5.10s
- post-change Lake target compile: 3.3s

The changed module is therefore below the 25s warning gate in the local Lake measurement.

## Testing

- `lake env lean TNLean/MPS/MPDO/CompleteZipperFusionPentagon.lean`
- `lake build TNLean.MPS.MPDO.CompleteZipperFusionPentagon --log-level=info`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- proof-integrity grep for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`

Addresses #4866

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tactic-only change to an existing proof; no API, semantics, or axiom changes.
> 
> **Overview**
> Speeds up compilation of **`inversePrintedFMatrix_pentagon`** by replacing an unrestricted **`simpa`** with **`simpa only`** and an explicit list of matrix, reindexing, finite-sum, and cast lemmas.
> 
> The proof still applies **`congrArg`** on a matrix entry of **`threeEdgeInversePrintedFMatrix_eq_twoEdgeInversePrintedFMatrix`**; only the normalization step is narrowed so Lean no longer searches the global simp set or retries unavailable **`Nonempty`** instances for fusion multiplicities. The theorem statement and mathematical content are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35853946e9bb6f5cdd313df66977586d89ab5333. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->