### PR TITLE
doc(tenkz): append the audit-record corrections for the symmetry-redraw entry

### DIFF
--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -868,3 +868,30 @@ pictures that have since been redrawn from the sources directly.
 | flag:lonely-type:positive-integer|role-list | keep-because: the union type serves `sheets=` alone now that the condensation panel left the planes genre for the oblique sheet; the type is the planes genre's spelling and follows that genre's fate at the front-end consolidation; expiry 0.8 |
 
 No ledger row changes and no other flag verdict is re-examined here.
+
+### 2026-07-26 — corrections to the symmetry-redraw entry's audit record
+
+The entry "the symmetry redraw raises the escape meter by thirty-six"
+above carries two record errors, found in review (#4906). The ledger is
+append-only, so the original stands and this section corrects it.
+
+**The per-panel escape breakdown was wrong.** The entry credited thirteen
+pairs to the self-braiding panel and five each to the idempotent and the
+first two braids; recounted from the pre-redraw tree, those panels gained
+nothing. The true breakdown of the eighteen `out=`/`in=` pairs: twelve in
+pulling through, three in the fourth braid, two each in the first braid
+and both R-tensors, one in the third braid, and four *removed* from the
+first torus panel, whose wrapped word no longer hand-routes. The total
+the meter recorded was and remains correct.
+
+**The tngroup verdict lacked its machine token.** The prose asserted the
+same 0.8 tenure as the two frame keys but omitted the parsable token, and
+the lexical lifetime parser satisfied itself on the word "permanent" from
+the neighbouring sugar-shape flag's history. The row is re-stated with
+the token:
+
+| flag | verdict |
+|---|---|
+| flag:consumers:command:tngroup | keep-because: the command carrying the group transform, with two demand-corpus consumers from the anyon panels; its shape was already affirmed against the sugar detector, and its consumer tenure follows the same 0.8 close as the two frame keys; expiry 0.8 |
+
+No meters move and no ledger row changes here.


### PR DESCRIPTION
Reworked after CI: the shrink ledger is append-only (the gate rejects any edit to a pre-change session), so the two record errors LionSR/tenkz#86 names are corrected by a new dated section while the original entry stands.

**The per-panel escape breakdown, recounted from the diffs.** Counting `out=` occurrences per case across the LionSR/TNLean#4867 merge: pulling-through +12, braid-four +3, braid-one +2, r-tensor-left +2, r-tensor-right +2, braid-three +1, torus-one −4 — net +18 pairs = +36 occurrences, matching the recorded rise. The panels the original prose credited (self-braiding 13, idempotent 5, braid-two) all measure zero.

**The tngroup verdict re-stated with its `; expiry 0.8` token** so the lexical lifetime parser stops satisfying itself on the word 'permanent' from a neighbouring flag's history.

Gates (run on the committed diff this time): shrink gate PASS (census 192, 133 flags), test_tenkz_shrink 28/28.

Closes LionSR/tenkz#86.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ledger correction; no registry, meter, or runtime behavior changes.
> 
> **Overview**
> Adds a **2026-07-26 append-only section** to `docs/tenkz/SHRINK.md` that fixes two mistakes in the earlier “symmetry redraw raises the escape meter by thirty-six” entry (#4906), without editing that original text or moving any shrink meters.
> 
> The correction **replaces the wrong per-panel `out=`/`in=` pair attribution** (self-braiding, idempotent, and early braids credited incorrectly) with a recount from the pre-redraw tree: net +18 pairs still matches the recorded +36 escape occurrences, including four pairs removed from the first torus panel.
> 
> It also **re-states the `flag:consumers:command:tngroup` verdict** with an explicit `; expiry 0.8` machine token so the lexical lifetime parser does not inherit “permanent” from a neighboring sugar-shape flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 056063abe2ee7e92082631d6b5097d5aa3d26e5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->