### PR TITLE
fix(blueprint): separate literal CPSV and refined MPDO forms

### DIFF
--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
@@ -9,8 +9,7 @@
     \label{def:horizontal_cf_mpdo}
     \lean{MPOTensor.IsHorizontalCF}
     \leanok
-    \uses{def:mpo_tensor, def:sector_bnt_cf, def:gauge_equiv,
-        def:cpsv_canonical_form}
+    \uses{def:mpo_tensor, def:sector_bnt_cf, def:gauge_equiv}
     An MPO tensor is in \emph{normalized BNT-refined horizontal form} if its
     doubled-index MPS tensor is a BNT sector decomposition with an independent
     gauge on every repeated copy:

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
@@ -5,13 +5,15 @@
 % The three examples after Theorem 4.9 are numbered 4.10--4.12; hence
 % `Prop:IV.12` is Proposition 4.13 in the arXiv source.
 
-\begin{definition}[Horizontal canonical form for an MPO]\label{def:horizontal_cf_mpdo}
+\begin{definition}[Normalized BNT-refined horizontal form for an MPO]
+    \label{def:horizontal_cf_mpdo}
     \lean{MPOTensor.IsHorizontalCF}
     \leanok
-    \uses{def:mpo_tensor, def:sector_bnt_cf, def:gauge_equiv}
-    An MPO tensor is in \emph{horizontal canonical form} if its doubled-index
-    MPS tensor is a BNT sector decomposition with an independent gauge on
-    every repeated copy:
+    \uses{def:mpo_tensor, def:sector_bnt_cf, def:gauge_equiv,
+        def:cpsv_canonical_form}
+    An MPO tensor is in \emph{normalized BNT-refined horizontal form} if its
+    doubled-index MPS tensor is a BNT sector decomposition with an independent
+    gauge on every repeated copy:
     \begin{align}
         M^{ab}
          & =\bigoplus_{j=0}^{g-1}\bigoplus_{q=0}^{r_j-1}
@@ -36,8 +38,15 @@
          & =\bigoplus_{j,q}X_{j,q}.
         \notag
     \end{align}
-    This is the canonical form and its BNT decomposition in
-    \cite[lines~237--246 and 281--301]{Cirac2016MPDO_arXiv}.
+    This is a strengthened representative-grouped form of the canonical
+    decomposition in \cite[Section~2.3]{Cirac2016MPDO_arXiv}. In contrast with
+    Definition~\ref{def:cpsv_canonical_form}, the retained direct sum has the
+    full bond dimension, every copy weight is nonzero and normalized, and
+    gauge-equivalent normal blocks are grouped over a BNT representative with
+    a separate gauge for each copy. It is therefore not the literal CPSV
+    canonical-form hypothesis.
+    % Source anchors: CPSV16 lines 214--246 for literal CF and lines 281--301
+    % for the BNT representative decomposition.
 \end{definition}
 
 \begin{definition}[MPV representation associated with horizontal canonical form]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -668,14 +668,33 @@
     $T$.
 \end{proof}
 
-\begin{theorem}[Horizontal canonical form implies vertical canonical form]
+% Source anchor: CPSV16 Proposition 4.13, statement at lines 1863--1870.
+\begin{theorem}[Vertical canonical form of a canonical MPDO]
+    \label{thm:vertical_cf_of_cpsv_canonical_form}
+    \notready
+    \uses{def:mpdo, def:cpsv_canonical_form, def:vertical_cf_mpdo}
+    Let $M$ be an MPO tensor whose doubled-index MPS tensor is in the literal
+    CPSV canonical form. If $M$ generates matrix product density operators,
+    then $M$ is in canonical form in the vertical direction. More precisely,
+    there is a basis of normal tensors $\{M_\alpha\}_\alpha$ for the vertically
+    viewed tensor $\widetilde M$, together with positive diagonal matrices
+    $\mu_\alpha$ and an isometry $U$ such that
+    \begin{align}
+        U\widetilde M U^\dagger
+         &=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha.
+        \label{eq:cpsv_prop_4_13_vertical_form}
+    \end{align}
+    This is \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{theorem}[BNT-refined horizontal form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \lean{MPOTensor.verticalCF_of_horizontalCF}
     \lean{MPOTensor.IsHorizontalCF.exists_cpsvVerticalDecomposition}
     \leanok
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo}
-    A tensor in horizontal canonical form that generates matrix product
-    density operators is also in canonical form in the vertical direction:
+    A tensor in normalized BNT-refined horizontal form that generates matrix
+    product density operators is also in canonical form in the vertical direction:
     there exist a basis of normal tensors $\{M_\alpha\}_\alpha$ for the
     vertically viewed tensor $\widetilde M$, positive diagonal matrices
     $\mu_\alpha$, and a coisometry $U$ from the physical space onto the
@@ -689,9 +708,12 @@
         \widetilde M&=U^\dagger BU.
         \notag
     \end{align}
-    The latter declaration retains the literal CPSV16 basis-of-normal-tensors
-    predicate together with these same positive and coisometric data.
-    This is \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+    The conclusion includes the CPSV16 basis-of-normal-tensors condition,
+    together with the positive weights and the coisometric realization. Its
+    hypothesis is the normalized BNT-refined form of
+    Definition~\ref{def:horizontal_cf_mpdo}, rather than the literal CPSV
+    canonical form assumed in
+    Theorem~\ref{thm:vertical_cf_of_cpsv_canonical_form}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -708,8 +708,9 @@
         \widetilde M&=U^\dagger BU.
         \notag
     \end{align}
-    The conclusion includes the CPSV16 basis-of-normal-tensors condition,
-    together with the positive weights and the coisometric realization. Its
+    The conclusion includes the basis-of-normal-tensors condition in
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, together with the positive
+    weights and the coisometric realization. Its
     hypothesis is the normalized BNT-refined form of
     Definition~\ref{def:horizontal_cf_mpdo}, rather than the literal CPSV
     canonical form assumed in


### PR DESCRIPTION
## What changed

- distinguish literal `MPSTensor.IsCPSVCanonicalForm` from the stronger normalized BNT-refined `MPOTensor.IsHorizontalCF` in Chapter 20
- retain the proved vertical-canonical-form theorem on the refined hypothesis
- add a separate source-shaped CPSV16 Proposition 4.13 node from literal canonical form, marked `\notready` without a nonexistent Lean tag

This corrects the source boundary exposed by #4874 and updates the line-945 classification in #2380 without downgrading the existing proved theorem.

## Validation

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- two `lualatex` passes with `TEXINPUTS="../../tex/tenkz//:"`
- `git diff --check origin/main...HEAD`
- independent blueprint review: approved, no blockers

Advances #2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint LaTeX with no Lean proof changes; it clarifies definitions and theorem boundaries for reviewers and source alignment.
> 
> **Overview**
> **Chapter 20** now draws a clear line between the **literal CPSV canonical form** (`def:cpsv_canonical_form` / doubled-index `IsCPSVCanonicalForm`) and the **stronger normalized BNT-refined horizontal form** still tied to `MPOTensor.IsHorizontalCF`.
> 
> The horizontal definition is renamed and expanded so it is explicit that the Lean-backed form keeps full bond dimension, normalized nonzero copy weights, and BNT representative grouping—it is **not** the literal CPSV hypothesis.
> 
> A new **source-shaped** theorem `thm:vertical_cf_of_cpsv_canonical_form` states CPSV16 Proposition 4.13 from literal canonical form and is marked `\notready` without a fake Lean declaration. The existing vertical conclusion is kept as **BNT-refined horizontal form implies vertical canonical form**, with the same Lean tags and proof, and cross-references that spell out the weaker vs stronger hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b29971d1935b559d4796ec82c50b7a0c81949d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->