### PR TITLE
feat(Channel): localize Kraus CPTP maps on second factor

### DIFF
--- a/TNLean/Channel/LocalizedKrausCPTP.lean
+++ b/TNLean/Channel/LocalizedKrausCPTP.lean
@@ -16,7 +16,9 @@ identity map on a finite matrix factor.
 ## Main results
 
 * `Matrix.tensorMapIdLM_isKrausCPTP`: tensoring a Kraus-form channel with the
-  identity preserves its Kraus-form channel structure.
+  identity on the second factor preserves its Kraus-form channel structure.
+* `Matrix.idTensorMapLM_isKrausCPTP`: tensoring the identity on the first factor
+  with a Kraus-form channel preserves its Kraus-form channel structure.
 
 This is the finite-dimensional localization operation used when a physical
 channel acts on one site of a blocked matrix-product density operator while
@@ -63,5 +65,21 @@ theorem tensorMapIdLM_isKrausCPTP
     rw [← map_sum ((Matrix.kroneckerBilinear (R := ℂ)).flip
       (1 : Matrix δ δ ℂ)), hAtp]
     exact Matrix.one_kronecker_one
+
+/-- Tensoring the identity on a finite matrix factor with a trace-preserving
+completely positive matrix map preserves the trace-preserving completely
+positive property. -/
+theorem idTensorMapLM_isKrausCPTP
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    (hS : IsKrausCPTP S) :
+    IsKrausCPTP (idTensorMapLM (δ := δ) S) := by
+  change IsKrausCPTP
+    (equivReindexMap (Equiv.prodComm β δ) ∘ₗ tensorMapIdLM S ∘ₗ
+      equivReindexMap (Equiv.prodComm δ α))
+  exact isKrausCPTP_comp
+    (isKrausCPTP_comp
+      (equivReindexMap_isKrausCPTP (Equiv.prodComm δ α))
+      (tensorMapIdLM_isKrausCPTP hS))
+    (equivReindexMap_isKrausCPTP (Equiv.prodComm β δ))
 
 end Matrix

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -267,20 +267,26 @@ section.
 \begin{theorem}[Tensor extension preserves trace-preserving complete positivity]
     \label{thm:mpdo_tensor_map_id_cptp}
     \lean{Matrix.tensorMapIdLM_isKrausCPTP}
+    \lean{Matrix.idTensorMapLM_isKrausCPTP}
     \leanok
-    \uses{def:tensor_map_id, def:is_kraus_cptp}
+    \uses{def:tensor_map_id, def:mpdo_id_tensor_map, def:is_kraus_cptp,
+        thm:mpdo_equiv_reindex_cptp, lem:is_kraus_cptp_comp}
     Let $\mathcal S:\End_{\C}(H)\to
         \End_{\C}(K)$ be trace-preserving and completely positive,
     and let $R$ be another finite-dimensional space. Then
     \begin{align}
         \mathcal S\otimes\id_R:
         \End_{\C}(H\otimes R)&\longrightarrow
-        \End_{\C}(K\otimes R)
+        \End_{\C}(K\otimes R),
+        \notag\\
+        \id_R\otimes\mathcal S:
+        \End_{\C}(R\otimes H)&\longrightarrow
+        \End_{\C}(R\otimes K)
         \notag
     \end{align}
-    is trace-preserving and completely positive. If $(A_a)_a$ is a Kraus
-    family for $\mathcal S$, then
-    $(A_a\otimes I_R)_a$ is a Kraus family for its tensor extension.
+    are trace-preserving and completely positive. If $(A_a)_a$ is a Kraus
+    family for $\mathcal S$, then $(A_a\otimes I_R)_a$ and
+    $(I_R\otimes A_a)_a$ are Kraus families for the two tensor extensions.
 \end{theorem}
 \begin{proof}
     \leanok
@@ -297,6 +303,8 @@ section.
           =I_H\otimes I_R.
         \notag
     \end{align}
+    Conjugating by the canonical factor swaps gives the second extension,
+    whose Kraus operators are $I_R\otimes A_a$.
 \end{proof}
 
 \begin{definition}[Rectangular Kraus map]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -284,27 +284,23 @@ section.
         \End_{\C}(R\otimes K)
         \notag
     \end{align}
-    are trace-preserving and completely positive. If $(A_a)_a$ is a Kraus
-    family for $\mathcal S$, then $(A_a\otimes I_R)_a$ and
-    $(I_R\otimes A_a)_a$ are Kraus families for the two tensor extensions.
+    are trace-preserving and completely positive.
 \end{theorem}
 \begin{proof}
     \leanok
-    The tensor extension has the Kraus form
+    The first assertion is the tensor-extension closure theorem. For the
+    second, let $\tau_H:R\otimes H\simeq H\otimes R$ and
+    $\tau_K:K\otimes R\simeq R\otimes K$ be the canonical factor swaps. Then
     \begin{align}
-        (\mathcal S\otimes\id_R)(X)
-        &=\sum_a(A_a\otimes I_R)X(A_a\otimes I_R)^\dagger.
+        \id_R\otimes\mathcal S
+        &=\mathcal R_{\tau_K}\circ
+          (\mathcal S\otimes\id_R)\circ\mathcal R_{\tau_H},
         \notag
     \end{align}
-    Its normalization follows from that of the original family:
-    \begin{align}
-        \sum_a(A_a\otimes I_R)^\dagger(A_a\otimes I_R)
-        &=\left(\sum_a A_a^\dagger A_a\right)\otimes I_R
-          =I_H\otimes I_R.
-        \notag
-    \end{align}
-    Conjugating by the canonical factor swaps gives the second extension,
-    whose Kraus operators are $I_R\otimes A_a$.
+    where $\mathcal R_\tau$ denotes reindexing both matrix coordinates along
+    $\tau$. Both reindexing maps are trace-preserving and completely positive,
+    so closure under composition proves the claim. No choice of Kraus family
+    is needed for this preservation statement.
 \end{proof}
 
 \begin{definition}[Rectangular Kraus map]


### PR DESCRIPTION
## What changed

- prove `Matrix.idTensorMapLM_isKrausCPTP`
- derive the second-factor localization from `tensorMapIdLM_isKrausCPTP` through the canonical factor swaps and CPTP reindexing/composition API
- document both tensor orders and their exact dependency graph in Chapter 21

No duplicate Kraus calculation is introduced. This supplies the generic channel fact needed for the corrected tensor-compatible HJPW extension tracked by #4890.

## Validation

- `lake build TNLean.Channel.LocalizedKrausCPTP`
- `lake build TNLean` (9751 jobs on the implementation head)
- import/module/prose/policy gates
- blueprint sync and two compilation passes
- integrity and diff checks
- independent Lean review: approved, no blockers

Advances #4890 and #4229.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive Lean proof and blueprint sync in channel theory; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds **`Matrix.idTensorMapLM_isKrausCPTP`**, showing that tensoring the identity on the first factor with a Kraus CPTP map stays trace-preserving and completely positive. The proof rewrites `idTensorMapLM` as canonical factor swaps, `tensorMapIdLM`, and `equivReindexMap`, then chains existing **CPTP composition** and **reindexing** lemmas—no new Kraus normalization.
> 
> **Chapter 21** (`thm:mpdo_tensor_map_id_cptp`) now states both orders \(\mathcal S\otimes\mathrm{id}_R\) and \(\mathrm{id}_R\otimes\mathcal S\), links the second Lean name, and replaces the old Kraus-only proof with the swap-and-composition argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7605f47a42e8430fb8e4fd9227973561511859f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->