### PR TITLE
feat(MPS/CanonicalForm): construct CPSV BNT representatives

### DIFF
--- a/TNLean/Algebra/ComplexPhasePositivity.lean
+++ b/TNLean/Algebra/ComplexPhasePositivity.lean
@@ -21,6 +21,10 @@ noncomputable section
 
 namespace Complex
 
+/-- A complex scalar of unit norm is nonzero. -/
+theorem ne_zero_of_norm_eq_one {z : ℂ} (h : ‖z‖ = 1) : z ≠ 0 :=
+  norm_ne_zero_iff.mp (by rw [h]; exact one_ne_zero)
+
 /-- The unit-modulus part of a nonzero complex number, as a multiplicative map. -/
 def unitsPhase : Units ℂ →* Circle where
   toFun z := ⟨(z : ℂ) / ‖(z : ℂ)‖, by

--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Channel.Peripheral.CyclicDecomposition
 import Mathlib.RingTheory.RootsOfUnity.Basic
 import Mathlib.GroupTheory.SpecificGroups.Cyclic
@@ -335,7 +336,7 @@ theorem peripheral_eigenvalues_cyclic_structure
   -- Elements of peripheralEigenvalues are nonzero (they have norm 1)
   have hne_zero : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → μ ≠ 0 := by
     intro μ ⟨_, hμ_norm⟩
-    exact norm_ne_zero_iff.mp (by rw [hμ_norm]; exact one_ne_zero)
+    exact Complex.ne_zero_of_norm_eq_one hμ_norm
   -- Step 1: Construct a finite subgroup of ℂˣ from peripheral eigenvalues
   let periphSubgroup : Subgroup ℂˣ :=
     { carrier := {u : ℂˣ | (u : ℂ) ∈ peripheralEigenvalues E}

--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.MPS.CanonicalForm
 
 import TNLean.MPS.CanonicalForm.BNTCharacterization
+import TNLean.MPS.CanonicalForm.BNTExistence
 import TNLean.MPS.CanonicalForm.BNTGrouping
 import TNLean.MPS.CanonicalForm.BNTTransport
 import TNLean.MPS.CanonicalForm.BNTUniqueness

--- a/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
+++ b/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
@@ -50,7 +50,7 @@ private lemma overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
   · exfalso
     apply hNot
     refine ⟨ζ, ?_, ?_⟩
-    · exact norm_ne_zero_iff.mp (by rw [hζ]; exact one_ne_zero)
+    · exact Complex.ne_zero_of_norm_eq_one hζ
     · intro N _hN σ
       have hEq := congrArg (fun v : MPVSpace d N => v σ) (hState N)
       simpa [mpvState_apply, PiLp.smul_apply, smul_eq_mul] using hEq
@@ -388,7 +388,7 @@ private theorem isCPSVBasisOfNormalTensors_iff_active_blocks_covered_and_minimal
     · intro j k hjk hdim hUnit
       obtain ⟨X, ζ, hζnorm, hrel⟩ := hUnit
       exact hBasisDistinct j k hjk hdim
-        ⟨X, ζ, norm_ne_zero_iff.mp (by rw [hζnorm]; exact one_ne_zero), hrel⟩
+        ⟨X, ζ, Complex.ne_zero_of_norm_eq_one hζnorm, hrel⟩
   · rintro ⟨hBasisNormal, hCover, hUnitDistinct⟩
     have hDistinct : BlocksNotGaugePhaseEquiv (d := d) basis := by
       intro j k hjk hdim hGPE
@@ -404,7 +404,7 @@ private theorem isCPSVBasisOfNormalTensors_iff_active_blocks_covered_and_minimal
           (cast (congr_arg (MPSTensor d) (hdimOf k)) (basis (jOf k)))
           (blocks k) := fun k =>
       ⟨XOf k, ζOf k,
-        norm_ne_zero_iff.mp (by rw [hζnormOf k]; exact one_ne_zero), hrelOf k⟩
+        Complex.ne_zero_of_norm_eq_one (hζnormOf k), hrelOf k⟩
     have hPhase : ∀ k : Fin r,
         MPVBlockPhaseEquiv (basis (jOf k)) (blocks k) := fun k =>
       MPVBlockPhaseEquiv.of_gaugePhaseEquiv_cast

--- a/TNLean/MPS/CanonicalForm/BNTExistence.lean
+++ b/TNLean/MPS/CanonicalForm/BNTExistence.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.BNTCharacterization
+
+/-!
+# Existence of a basis of normal tensors
+
+This module constructs a basis of normal tensors from literal CPSV canonical-form data.
+It first restricts the displayed canonical-form blocks to those with nonzero weight and
+then chooses one representative from each MPV phase-equivalence class.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+/-- Literal CPSV canonical-form data admit a basis of normal tensors obtained by
+restricting to nonzero-weight blocks and choosing one representative from each
+MPV phase-equivalence class.
+
+Zero-weight blocks are not covered: they contribute nothing to any positive-length
+matrix product vector. The conclusion is the existence part of the construction
+underlying arXiv:1606.00608, Proposition `prop:char-BNT`, lines 271--280 and
+1137--1146, with this active-block restriction made explicit. -/
+theorem CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors
+    (data : CPSVCanonicalFormData A) :
+    ∃ g : ℕ, ∃ dimB : Fin g → ℕ,
+      ∃ basis : (j : Fin g) → MPSTensor d (dimB j),
+        (∀ j, 0 < dimB j) ∧
+        IsCPSVBasisOfNormalTensors A (fun j ↦ ⟨dimB j, basis j⟩) := by
+  classical
+  letI : ∀ k, NeZero (data.dim k) :=
+    fun k ↦ ⟨Nat.ne_of_gt (data.dim_pos k)⟩
+  let Active := {k : Fin data.r // data.weights k ≠ 0}
+  let activeEquiv : Fin (Fintype.card Active) ≃ Active :=
+    (Fintype.equivFin Active).symm
+  let dimActive : Fin (Fintype.card Active) → ℕ :=
+    fun k ↦ data.dim (activeEquiv k)
+  let blocksActive : (k : Fin (Fintype.card Active)) → MPSTensor d (dimActive k) :=
+    fun k ↦ data.blocks (activeEquiv k)
+  let classes := mpvPhaseClassData blocksActive
+  let dimB : Fin classes.g → ℕ := fun j ↦ dimActive (classes.repr j)
+  let basis : (j : Fin classes.g) → MPSTensor d (dimB j) :=
+    fun j ↦ blocksActive (classes.repr j)
+  have hdimB : ∀ j, 0 < dimB j := by
+    intro j
+    exact data.dim_pos (activeEquiv (classes.repr j))
+  letI : ∀ j, NeZero (dimB j) := fun j ↦ ⟨Nat.ne_of_gt (hdimB j)⟩
+  refine ⟨classes.g, dimB, basis, hdimB, ?_⟩
+  apply (data.isCPSVBasisOfNormalTensors_iff_covered_and_minimal basis).2
+  refine ⟨?_, ?_, ?_⟩
+  · intro j
+    exact data.blocks_normal (activeEquiv (classes.repr j))
+  · intro k hk
+    let kActive : Active := ⟨k, hk⟩
+    let l : Fin (Fintype.card Active) := activeEquiv.symm kActive
+    obtain ⟨j, q, hEnum⟩ := classes.exists_enum_eq l
+    have hl : (activeEquiv l : Fin data.r) = k := by
+      exact congrArg Subtype.val (activeEquiv.apply_symm_apply kActive)
+    have hPhase : MPVBlockPhaseEquiv (basis j) (data.blocks k) := by
+      change MPVBlockPhaseEquiv
+        (blocksActive (classes.repr j)) (data.blocks k)
+      rw [← hl, ← hEnum]
+      exact classes.enum_phase j q
+    obtain ⟨hdim, hGauge⟩ :=
+      hPhase.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (data.blocks_normal (activeEquiv (classes.repr j)))
+        (data.blocks_normal k)
+    obtain ⟨X, ζ, _hζ, hrel⟩ := hGauge
+    refine ⟨j, hdim, X, ζ, ?_, hrel⟩
+    exact norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
+      (data.blocks_normal (activeEquiv (classes.repr j)))
+      (data.blocks_normal k) hdim hrel
+  · intro j k hjk hdim hUnit
+    obtain ⟨X, ζ, hζnorm, hrel⟩ := hUnit
+    apply classes.blocks_not_equiv j k hjk hdim
+    exact ⟨X, ζ,
+      norm_ne_zero_iff.mp (by rw [hζnorm]; exact one_ne_zero), hrel⟩
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/BNTExistence.lean
+++ b/TNLean/MPS/CanonicalForm/BNTExistence.lean
@@ -23,10 +23,15 @@ variable {d D : ℕ} {A : MPSTensor d D}
 restricting to nonzero-weight blocks and choosing one representative from each
 MPV phase-equivalence class.
 
-Zero-weight blocks are not covered: they contribute nothing to any positive-length
-matrix product vector. The conclusion is the existence part of the construction
-underlying arXiv:1606.00608, Proposition `prop:char-BNT`, lines 271--280 and
-1137--1146, with this active-block restriction made explicit. -/
+**Scope restriction (active blocks):** Literal canonical-form syntax permits
+zero-weight listed blocks. The formal theorem covers only blocks with nonzero
+weight because zero-weight blocks contribute nothing to any positive-length
+matrix product vector. See
+`docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`.
+
+The conclusion is the existence part of the construction underlying
+arXiv:1606.00608, Proposition `prop:char-BNT`, lines 271--280 and 1137--1146,
+with this active-block restriction made explicit. -/
 theorem CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors
     (data : CPSVCanonicalFormData A) :
     ∃ g : ℕ, ∃ dimB : Fin g → ℕ,

--- a/TNLean/MPS/CanonicalForm/BNTExistence.lean
+++ b/TNLean/MPS/CanonicalForm/BNTExistence.lean
@@ -85,6 +85,6 @@ theorem CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors
     obtain ⟨X, ζ, hζnorm, hrel⟩ := hUnit
     apply classes.blocks_not_equiv j k hjk hdim
     exact ⟨X, ζ,
-      norm_ne_zero_iff.mp (by rw [hζnorm]; exact one_ne_zero), hrel⟩
+      Complex.ne_zero_of_norm_eq_one hζnorm, hrel⟩
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
+++ b/TNLean/MPS/CanonicalForm/BNTUniqueness.lean
@@ -219,10 +219,10 @@ theorem IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage
     obtain ⟨k, hdim₂, X₂, ζ₂, hζ₂, hrel₂⟩ := hCover₂ l hl
     have hGE₁ : GaugePhaseEquiv
         (cast (congr_arg (MPSTensor d) hdim₁) (basis₁ j)) (blocks l) :=
-      ⟨X₁, ζ₁, norm_ne_zero_iff.mp (by rw [hζ₁]; exact one_ne_zero), hrel₁⟩
+      ⟨X₁, ζ₁, Complex.ne_zero_of_norm_eq_one hζ₁, hrel₁⟩
     have hGE₂ : GaugePhaseEquiv
         (cast (congr_arg (MPSTensor d) hdim₂) (basis₂ k)) (blocks l) :=
-      ⟨X₂, ζ₂, norm_ne_zero_iff.mp (by rw [hζ₂]; exact one_ne_zero), hrel₂⟩
+      ⟨X₂, ζ₂, Complex.ne_zero_of_norm_eq_one hζ₂, hrel₂⟩
     refine ⟨k, hdim₁.trans hdim₂.symm, ?_⟩
     simpa using gaugePhaseEquiv_cast_compose_via_centre
       hdim₁.symm hdim₂.symm
@@ -259,10 +259,10 @@ theorem IsCPSVBasisOfNormalTensors.equiv_of_converse_coverage
     obtain ⟨k, hdim₁, X₁, ζ₁, hζ₁, hrel₁⟩ := hCover₁ l hl
     have hGE₂ : GaugePhaseEquiv
         (cast (congr_arg (MPSTensor d) hdim₂) (basis₂ j)) (blocks l) :=
-      ⟨X₂, ζ₂, norm_ne_zero_iff.mp (by rw [hζ₂]; exact one_ne_zero), hrel₂⟩
+      ⟨X₂, ζ₂, Complex.ne_zero_of_norm_eq_one hζ₂, hrel₂⟩
     have hGE₁ : GaugePhaseEquiv
         (cast (congr_arg (MPSTensor d) hdim₁) (basis₁ k)) (blocks l) :=
-      ⟨X₁, ζ₁, norm_ne_zero_iff.mp (by rw [hζ₁]; exact one_ne_zero), hrel₁⟩
+      ⟨X₁, ζ₁, Complex.ne_zero_of_norm_eq_one hζ₁, hrel₁⟩
     refine ⟨k, hdim₂.trans hdim₁.symm, ?_⟩
     simpa using gaugePhaseEquiv_cast_compose_via_centre
       hdim₂.symm hdim₁.symm

--- a/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalTensorGauge.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.CanonicalForm.PhaseCover
 import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -130,7 +130,7 @@ private lemma overlap_tendsto_zero_of_not_mpvBlockPhaseEquiv
   · exact hZero
   · exfalso
     apply hNot
-    refine ⟨ζ, norm_ne_zero_iff.mp (by rw [hζ]; exact one_ne_zero), ?_⟩
+    refine ⟨ζ, Complex.ne_zero_of_norm_eq_one hζ, ?_⟩
     intro N _hN σ
     have hEq := congrArg (fun v : MPVSpace d N => v σ) (hState N)
     simpa [mpvState_apply, PiLp.smul_apply, smul_eq_mul] using hEq

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -143,6 +143,37 @@ single family.
     bijection with the original block indices.
 \end{definition}
 
+\begin{theorem}[Active-block BNT existence for CPSV canonical form]
+    \label{thm:cpsv_canonical_form_bnt_existence}
+    \lean{MPSTensor.CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:bnt_cpsv}
+    % Maintainer source anchors: CPSV16 prop:char-BNT, lines 271--280 and 1137--1146.
+    Every tensor with literal CPSV canonical-form data admits a finite basis of
+    normal tensors $(B_j)_{j=1}^{g}$, each of positive bond dimension. The
+    family is obtained from
+    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$ by choosing one representative from
+    each matrix-product-vector phase class of the active blocks.
+
+    This statement does not cover zero-weight listed blocks: they contribute
+    nothing to any positive-length matrix product vector. It also makes no
+    unrestricted uniqueness claim about arbitrary bases of normal tensors.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_canonical_form_bnt_characterization,
+        def:mpv_phase_class_data, thm:cpsv_normal_mpv_phase_gauge}
+    Discard the zero-weight blocks and partition the remaining finite family by
+    matrix-product-vector phase equivalence. Choose one representative from
+    each class. The representatives are normal and have positive bond
+    dimensions. Distinct representatives are not gauge-phase equivalent. For
+    every active block, the normal-tensor phase theorem identifies its bond
+    dimension with that of its representative and realizes their phase
+    relation by a similarity and a unit-modulus scalar.
+    Theorem~\ref{thm:cpsv_canonical_form_bnt_characterization} now gives the
+    basis-of-normal-tensors conditions.
+\end{proof}
+
 \begin{definition}[BNT canonical form]%
     \label{def:sector_bnt_cf}
     \lean{MPSTensor.IsBNTCanonicalForm}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_coherent_positive_rephasing.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_coherent_positive_rephasing.tex
@@ -75,6 +75,7 @@
 
 \begin{theorem}[Uniqueness of the positive rescaling phase]%
     \label{thm:positive_rescaling_phase_unique}
+    \lean{Complex.ne_zero_of_norm_eq_one}
     \lean{Complex.unitsPhase}
     \lean{Complex.phase}
     \lean{Complex.phase_smul_posSemidef}
@@ -84,9 +85,10 @@
     \uses{lem:possemidef_and_neg_possemidef}
     Let $M\ne0$. If $c_1,c_2\ne0$ and both $c_1M$ and $c_2M$ are positive
     semidefinite, then $c_1=t c_2$ for some positive real number $t$.
-    In particular, every nonzero scalar $c$ has a unit-modulus part
-    $u=c/|c|$, positivity of $cM$ implies positivity of $uM$, and there is
-    at most one such unit scalar when $M\ne0$.
+    Every complex scalar of unit modulus is nonzero. In particular, every
+    nonzero scalar $c$ has a unit-modulus part $u=c/|c|$, positivity of $cM$
+    implies positivity of $uM$, and there is at most one such unit scalar when
+    $M\ne0$.
 \end{theorem}
 
 \begin{proof}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -100,6 +100,16 @@ abstracted — record why, so it is not re-proposed).
   is replaced by one exact application; its previously profiled 31-second
   declaration falls below the 200-millisecond profiler threshold.
 
+### Unit-norm complex scalars are nonzero
+- **Pattern:** proofs repeatedly converted `h : ‖z‖ = 1` into `z ≠ 0` with
+  `norm_ne_zero_iff.mp (by rw [h]; exact one_ne_zero)`.
+- **Reuse:** `Complex.ne_zero_of_norm_eq_one` in
+  `TNLean/Algebra/ComplexPhasePositivity.lean` now states this scalar fact once.
+- **Result:** ten call sites across `BNTCharacterization.lean`,
+  `BNTUniqueness.lean`, `BNTExistence.lean`, `BeigiLoopBNTIdentification.lean`,
+  and `GroupStructure.lean` use the shared lemma. All theorem statements and
+  mathematical scopes are unchanged.
+
 ### Support left-right and relative-modular intertwining
 - **Pattern:** `supportRelativeModular_sourceB_solution` and
   `supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular`
@@ -288,6 +298,21 @@ current counts and full location lists).
   appears.
 - **Notes:** Below the rule-of-three promotion threshold; keep the explicit
   rewrites until another consumer fixes the common statement's useful shape.
+
+### active canonical-form block restriction — candidate
+- **Pattern:** restrict a finite canonical-form block family to indices with
+  nonzero weight, choose `Fintype.equivFin` coordinates for that subtype, and
+  pull back the dependent bond dimensions and blocks along the equivalence.
+- **Seen:** 2 occurrences, in
+  `isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal`
+  (`BNTCharacterization.lean`) and
+  `CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors`
+  (`BNTExistence.lean`). This remains below the rule-of-three threshold.
+- **Abstraction (proposed):** if a third occurrence appears, package the active
+  subtype, finite equivalence, dimensions, and dependent block family in a
+  reusable low-level construction.
+- **Notes:** Any promotion must preserve the restriction to nonzero-weight
+  blocks; it must not assert coverage of zero-weight listed blocks.
 
 ### invariant-subspace two-block fork — candidate
 - **Pattern:** the general and strict invariant-subspace decompositions repeated the


### PR DESCRIPTION
## What changed

- add `CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors`
- restrict to nonzero-weight canonical blocks, quotient them by MPV phase equivalence, and choose one normal representative per active class
- prove active-block coverage and gauge-phase minimality through the literal CPSV characterization
- add a Chapter 10 source-facing entry anchored at CPSV16 lines 271–280 and 1137–1146

The theorem does not claim coverage of zero-weight listed blocks or unrestricted BNT uniqueness.

## Validation

- `lake build TNLean.MPS.CanonicalForm.BNTExistence`
- `lake build TNLean` (9752 jobs)
- import/module/prose/policy gates
- blueprint sync/checkdecls and two compilation passes
- integrity and diff checks
- independent Lean review: approved, no blockers

Advances #2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formalization and proof refactors in MPS canonical form with no runtime, auth, or data-path impact; theorem scopes are narrowly documented (active blocks only).
> 
> **Overview**
> This PR adds the **existence** half of the CPSV BNT construction: `CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors` builds a finite family of normal tensors by keeping only **nonzero-weight** canonical blocks, partitioning them by MPV phase equivalence, and taking one representative per class. Coverage and gauge-phase minimality are discharged via the existing characterization (`isCPSVBasisOfNormalTensors_iff_covered_and_minimal`); zero-weight listed blocks are explicitly out of scope.
> 
> Supporting cleanup introduces **`Complex.ne_zero_of_norm_eq_one`** in `TNLean/Algebra/ComplexPhasePositivity.lean` and replaces repeated `norm_ne_zero_iff` boilerplate across BNT characterization, uniqueness, existence, Beigi loop identification, and peripheral group structure. The canonical-form aggregator imports the new module; Chapter 10 gains a source-facing existence theorem and Chapter 21 links the scalar lemma to the positive rescaling phase statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f56eddd37faf7864f936cc799c2ee206dc8475d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->