### PR TITLE
feat(MPS/RFP): add conditional CPSV capstone

### DIFF
--- a/TNLean/MPS/RFP.lean
+++ b/TNLean/MPS/RFP.lean
@@ -31,6 +31,7 @@ import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.RFP.KroneckerTransport
+import TNLean.MPS.RFP.MainMPSConditional
 import TNLean.MPS.RFP.NNCPHGroundSpace
 import TNLean.MPS.RFP.NNCPHGroundSpacesMultiSector
 import TNLean.MPS.RFP.NNCPHMultiSector

--- a/TNLean/MPS/RFP/BNTDirectSumBasis.lean
+++ b/TNLean/MPS/RFP/BNTDirectSumBasis.lean
@@ -10,8 +10,9 @@ import TNLean.MPS.RFP.BNTOrthogonality
 /-!
 # BNT basis data for the unit-weight direct sum
 
-This file packages a BNT canonical form as a CPSV basis of normal tensors for
-its multiplicity-one unit-weight direct-sum representative.
+This file proves that the multiplicity-one unit-weight direct-sum representative
+of a BNT canonical form is in literal CPSV canonical form and that its distinct
+blocks form a CPSV basis of normal tensors.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/RFP/BNTDirectSumBasis.lean
+++ b/TNLean/MPS/RFP/BNTDirectSumBasis.lean
@@ -31,6 +31,27 @@ namespace IsBNTCanonicalForm
 
 variable {P : SectorDecomposition d}
 
+/-- The multiplicity-one unit-weight direct sum of the distinct basis tensors
+is in literal CPSV canonical form.
+
+Each basis tensor is normal because it is irreducible and left-canonical, and
+its retained coordinates are exactly the ambient direct-sum coordinates.
+
+**Scope restriction (multiplicity-one unit weights):** the statement covers
+one unit-weight copy of each distinct basis tensor. It does not reconstruct the
+raw weighted repeated-copy tensor of arXiv:1606.00608, eq. `II_CF1`; see
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
+theorem isCPSVCanonicalForm_basisDirectSum
+    (hCF : IsBNTCanonicalForm P) :
+    IsCPSVCanonicalForm (directSumTensor P.basis) := by
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis]
+  exact
+    (CPSVCanonicalFormData.ofBlocks hCF.basis_dim_pos (fun _ ↦ 1) P.basis
+      (fun j ↦ isNormalTensor_of_isNormal_leftCanonical (P.basis j)
+        (hCF.basis_isNormal j) (hCF.basis_left_canonical j))).isCPSVCanonicalForm
+
 /-- The distinct basis tensors of a BNT canonical form are a basis of normal
 tensors for their direct-sum tensor.
 

--- a/TNLean/MPS/RFP/MainMPSConditional.lean
+++ b/TNLean/MPS/RFP/MainMPSConditional.lean
@@ -12,9 +12,12 @@ import TNLean.MPS.RFP.ZCLReverse
 This file proves the corrected positive-gap implication from zero correlation
 length to nearest-neighbor commuting parent-Hamiltonian ground spaces for the
 multiplicity-one unit-weight representative.
--/
 
-open scoped Matrix
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Theorem 3.10,
+  lines 534--541, and its proof in Appendix B, lines 1248--1268.
+-/
 
 namespace MPSTensor
 

--- a/TNLean/MPS/RFP/MainMPSConditional.lean
+++ b/TNLean/MPS/RFP/MainMPSConditional.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.RFP.NNCPHGroundSpacesMultiSector
+import TNLean.MPS.RFP.ZCLReverse
+
+/-!
+# Conditional zero-correlation-length implication for commuting parent ground spaces
+
+This file proves the corrected positive-gap implication from zero correlation
+length to nearest-neighbor commuting parent-Hamiltonian ground spaces for the
+multiplicity-one unit-weight representative.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+namespace IsBNTCanonicalForm
+
+variable {d : ℕ} {P : SectorDecomposition d}
+
+/-- Positive-gap BNT zero correlation length implies the all-chain
+nearest-neighbor commuting parent-Hamiltonian ground-space condition at the
+multiplicity-one representative, under the normalized nonzero subleading
+spectral-pair assertion used in CPSV16.
+
+This is the conditional corrected implication (ii) to (iii) of
+arXiv:1606.00608, Theorem `thm:main-MPS`, lines 534--541. It first applies the
+conditional reverse argument of lines 1248--1268 and then the fixed-point
+ground-space theorem.
+
+**Scope restriction (multiplicity-one unit weights and CPSV16 line 1250):**
+the tensor is the direct sum of the distinct BNT basis tensors with one
+unit-weight copy each, and every non-idempotent block is assumed to have the
+normalized nonzero subleading left/right eigenpair asserted at line 1250. The
+theorem does not derive that assertion or establish the printed three-way
+equivalence. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
+theorem isPositiveGapBNTZCL_implies_hasNNCPHGroundSpaces_basisDirectSum_of_spectral_pair
+    (hCF : IsBNTCanonicalForm P)
+    (hspectral : ∀ j : Fin P.basisCount,
+      ¬ IsTransferIdempotent (P.basis j) →
+        ∃ (ν : ℂ) (r l : Matrix (Fin (P.basisDim j)) (Fin (P.basisDim j)) ℂ),
+          ν ≠ 0 ∧ ‖ν‖ < 1 ∧
+          Module.End.HasEigenvector (transferMap (P.basis j)) ν r ∧
+          Module.End.HasEigenvector
+            (Matrix.traceAdjointMap (transferMap (P.basis j))) ν l ∧
+          Matrix.trace (l * r) = 1)
+    (hZCL : IsPositiveGapBNTZCL (directSumTensor P.basis) P.basis) :
+    HasNNCPHGroundSpaces (directSumTensor P.basis) P.basis :=
+  hCF.rfp_implies_hasNNCPHGroundSpaces_basisDirectSum
+    (hCF.isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL_of_spectral_pair
+      hspectral hZCL)
+
+end IsBNTCanonicalForm
+
+end MPSTensor

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -357,6 +357,27 @@
     $\E_{j,j'}=0$.
 \end{proof}
 
+\begin{theorem}[Basis direct sum is in literal CPSV canonical form]%
+    \label{thm:bnt_cf_basis_direct_sum_is_cpsv_cf}
+    \lean{MPSTensor.IsBNTCanonicalForm.isCPSVCanonicalForm_basisDirectSum}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:sector_bnt_cf}
+    Let $P$ be an auxiliary BNT sector decomposition with distinct basis
+    tensors $(A_j)_j$. The multiplicity-one unit-weight tensor
+    $A=\bigoplus_j A_j$ is in literal CPSV canonical form, with retained
+    weights all equal to $1$, retained blocks $(A_j)_j$, and the identity
+    ambient coisometry. This statement does not reconstruct the raw weighted
+    repeated-copy tensor represented by $P$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{cor:sector_bnt_cf_basis_normal}
+    Every retained dimension is positive. Each $A_j$ is irreducible and
+    left-canonical, hence normal by
+    Corollary~\ref{cor:sector_bnt_cf_basis_normal}. The unit-weight retained
+    direct sum equals $A$, so the identity coisometry gives the required exact
+    reconstruction.
+\end{proof}
+
 \begin{theorem}[Auxiliary BNT basis gives a basis for its direct sum]%
     \label{thm:bnt_cf_basis_is_bnt_for_direct_sum}
     \lean{MPSTensor.IsBNTCanonicalForm.isCPSVBasisOfNormalTensors_basisDirectSum}
@@ -622,6 +643,38 @@
     Theorem~\ref{thm:direct_sum_transfer_idempotent_iff_pairwise_mixed} gives
     $\E_A^2=\E_A$. The reverse implication is
     Theorem~\ref{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}.
+\end{proof}
+
+\begin{theorem}[Conditional positive-gap ZCL implication for commuting parent ground spaces]%
+    \label{thm:positive_gap_bnt_zcl_conditional_nncph}
+    \lean{MPSTensor.IsBNTCanonicalForm.isPositiveGapBNTZCL_implies_hasNNCPHGroundSpaces_basisDirectSum_of_spectral_pair}
+    \leanok
+    \uses{def:is_positive_gap_bnt_zcl, def:sector_bnt_cf,
+        def:has_nncph_ground_spaces}
+    Let $P$ and $A=\bigoplus_j A_j$ satisfy the multiplicity-one unit-weight
+    hypotheses of
+    Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse}, including its
+    normalized nonzero subleading spectral pair for every non-idempotent
+    block. If $A$ has positive-gap BNT zero correlation length, then for every
+    $N>2$ its translated two-site parent interactions commute and their common
+    kernel is
+    \begin{align}
+        \ker H_N&=\spn_{\C}\{\ket{V^{(N)}(A_j)}:j\}.
+        \notag
+    \end{align}
+    This is only the conditional corrected implication from (ii) to (iii) of
+    \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}, not a three-way equivalence.
+% The normalized nonzero subleading spectral pair remains an explicit
+% hypothesis; CPSV16 line 1250 does not exclude a nilpotent zero-Jordan part.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:positive_gap_bnt_zcl_conditional_converse,
+        thm:rfp_multiplicity_one_bnt_has_nncph_ground_spaces}
+    Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse} gives
+    $\E_A^2=\E_A$. The multiplicity-one fixed-point theorem
+    \ref{thm:rfp_multiplicity_one_bnt_has_nncph_ground_spaces} then gives the
+    commuting parent interactions and the stated common kernel for every
+    $N>2$.
 \end{proof}
 
 \begin{theorem}[Physical ZCL implies idempotence under the spectral assumption]%

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -659,7 +659,7 @@
     $N>2$ its translated two-site parent interactions commute and their common
     kernel is
     \begin{align}
-        \ker H_N&=\spn_{\C}\{\ket{V^{(N)}(A_j)}:j\}.
+        \ker H_2^{(N)}&=\spn_{\C}\{\ket{V^{(N)}(A_j)}:j\}.
         \notag
     \end{align}
     This is only the conditional corrected implication from (ii) to (iii) of


### PR DESCRIPTION
## What changed

- prove that the multiplicity-one unit-weight BNT direct sum is in literal CPSV canonical form
- add the conditional positive-gap ZCL → full all-chain NNCPH capstone under the exact normalized nonzero subleading eigenpair hypothesis already required by the corrected reverse theorem
- document this only as the conditional corrected `(ii) → (iii)` edge of CPSV16 Theorem 3.10

This PR does not derive the CPSV16 line-1250 spectral assertion, does not introduce an eigenvalue-free substitute, and does not claim a three-way equivalence or completion of #2633/#4786.

## Validation

- `lake build TNLean.MPS.RFP.BNTDirectSumBasis TNLean.MPS.RFP.MainMPSConditional TNLean.MPS.RFP` (9146 jobs)
- import aggregator and blueprint sync gates
- integrity and diff checks
- independent Lean review: approved, no blockers

Advances #4786 and #2380; #4786 remains blocked on the nilpotent zero-Jordan case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New proofs in the MPS renormalization-fixed-point / ZCL / parent-Hamiltonian chain; risk is moderated because the capstone composes existing lemmas and keeps spectral assumptions explicit rather than changing runtime or auth paths.
> 
> **Overview**
> Adds two formal results for the **multiplicity-one unit-weight** BNT direct sum \(A=\bigoplus_j A_j\), with scope documented in Lean and the blueprint (not the raw weighted repeated-copy tensor).
> 
> **Literal CPSV canonical form:** `isCPSVCanonicalForm_basisDirectSum` shows \(A\) is in literal CPSV canonical form via unit-weight `toTensorFromBlocks` and normal left-canonical basis blocks.
> 
> **Conditional CPSV16 (ii)→(iii):** New module `MainMPSConditional` proves positive-gap BNT ZCL implies **all-chain NNCPH ground spaces** when the existing **normalized nonzero subleading spectral-pair** hypothesis holds: ZCL → transfer idempotence (reverse theorem) → `HasNNCPHGroundSpaces`. This is only the corrected edge of Theorem 3.10, not a three-way equivalence.
> 
> Blueprint chapter 26 gains matching theorem entries; `TNLean.MPS.RFP` imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 128c6a92e4125d55b2c1adba91dc3f596a47cf70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->