### PR TITLE
feat(analysis): factor support calculus over Kronecker products

### DIFF
--- a/TNLean/Analysis/CfcConjugation.lean
+++ b/TNLean/Analysis/CfcConjugation.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Analysis.CStarAlgebra.Classes
+import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
 import Mathlib.LinearAlgebra.Matrix.Reindex
 
@@ -26,7 +28,10 @@ quantum relative-entropy stack.
   calculus under reindexing.
 * `Matrix.cfc_conj_unitary` — covariance of the continuous functional calculus
   under conjugation by a unitary.
+* `Matrix.cfc_diagonal` — entrywise functional calculus for real diagonal matrices.
 -/
+
+open scoped Matrix.Norms.L2Operator
 
 namespace Matrix
 
@@ -99,5 +104,91 @@ theorem cfc_conj_unitary {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → 
   have hconj := StarAlgHomClass.map_cfc φ f A hcont hcontφ hsa hsa'
   rw [happ, happ] at hconj
   exact hconj.symm
+
+section Diagonal
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The `C⋆`-algebra structure on matrices from the `L²`-operator norm, used
+locally to identify the abstract continuous functional calculus on a diagonal
+matrix. -/
+noncomputable local instance diagonalMatrixCStarAlgebra : CStarAlgebra (Matrix n n ℂ) where
+
+/-- The real spectrum of a real-valued diagonal matrix is the range of its diagonal. -/
+private lemma spectrum_real_ofReal_diagonal (g : n → ℝ) :
+    spectrum ℝ (diagonal (fun i => (g i : ℂ))) = Set.range g := by
+  ext x
+  rw [← spectrum.algebraMap_mem_iff (S := ℂ), Complex.coe_algebraMap, spectrum_diagonal]
+  simp only [Set.mem_range, Complex.ofReal_inj]
+
+/-- Membership of a diagonal entry in the real spectrum of the diagonal matrix. -/
+private lemma mem_spectrum_real_ofReal_diagonal (g : n → ℝ) (i : n) :
+    g i ∈ spectrum ℝ (diagonal (fun i => (g i : ℂ))) :=
+  (spectrum_real_ofReal_diagonal g).symm ▸ ⟨i, rfl⟩
+
+/-- The star-algebra homomorphism
+`C(spectrum ℝ (diagonal (g·)), ℝ) →⋆ₐ[ℝ] Matrix n n ℂ` that evaluates a function
+along the diagonal entries. It coincides with `cfcHom` of the
+diagonal matrix by uniqueness, which is the content of `cfc_diagonal`. -/
+private noncomputable def diagonalCfcAux (g : n → ℝ) :
+    C(spectrum ℝ (diagonal (fun i => (g i : ℂ))), ℝ) →⋆ₐ[ℝ] Matrix n n ℂ where
+  toFun p := diagonal fun i => ((p ⟨g i, mem_spectrum_real_ofReal_diagonal g i⟩ : ℝ) : ℂ)
+  map_zero' := by simp only [ContinuousMap.coe_zero, Pi.zero_apply, Complex.ofReal_zero,
+    diagonal_zero]
+  map_one' := by
+    simp only [ContinuousMap.coe_one, Pi.one_apply, Complex.ofReal_one, diagonal_one]
+  map_mul' p q := by
+    simp only [ContinuousMap.coe_mul, Pi.mul_apply, Complex.ofReal_mul, diagonal_mul_diagonal]
+  map_add' p q := by
+    simp only [ContinuousMap.coe_add, Pi.add_apply, Complex.ofReal_add, diagonal_add]
+  commutes' r := by
+    change diagonal (fun _ => ((r : ℝ) : ℂ)) = algebraMap ℝ (Matrix n n ℂ) r
+    rw [Matrix.algebraMap_eq_diagonal]
+    rfl
+  map_star' p := by
+    show diagonal (fun i => (((star p) ⟨g i, _⟩ : ℝ) : ℂ))
+      = star (diagonal (fun i => ((p ⟨g i, _⟩ : ℝ) : ℂ)))
+    rw [star_eq_conjTranspose, diagonal_conjTranspose]
+    congr 1; ext i
+    simp only [Pi.star_apply, RCLike.star_def, star_trivial, Complex.conj_ofReal]
+
+/-- **Continuous functional calculus of a real-valued diagonal matrix.** For a
+real-valued diagonal `diagonal (fun i => (g i : ℂ))` and a function `f` continuous on the
+range of the entries, the calculus acts entrywise:
+`cfc f (diagonal (g·)) = diagonal (fun i => (f (g i) : ℂ))`. -/
+theorem cfc_diagonal (g : n → ℝ) (f : ℝ → ℝ)
+    (hf : ContinuousOn f (Set.range g) := by cfc_cont_tac) :
+    cfc f (diagonal (fun i => (g i : ℂ)))
+      = diagonal (fun i => (f (g i) : ℂ)) := by
+  set D : Matrix n n ℂ := diagonal (fun i => (g i : ℂ)) with hD
+  have hsa : IsSelfAdjoint D := by
+    rw [isSelfAdjoint_iff, hD, star_eq_conjTranspose, diagonal_conjTranspose]
+    congr 1; ext i; simp [Complex.conj_ofReal]
+  have hfspec : ContinuousOn f (spectrum ℝ D) := by
+    rw [hD, spectrum_real_ofReal_diagonal]; exact hf
+  -- The hand-built map agrees with `cfcHom` by uniqueness.
+  have hfindim : FiniteDimensional ℝ C(spectrum ℝ D, ℝ) :=
+    FiniteDimensional.of_injective (ContinuousMap.coeFnLinearMap ℝ (M := ℝ))
+      DFunLike.coe_injective
+  have hcont : Continuous (diagonalCfcAux g) := by
+    have : Continuous ((diagonalCfcAux g).toLinearMap) :=
+      LinearMap.continuous_of_finiteDimensional _
+    exact this
+  have hid : diagonalCfcAux g ((ContinuousMap.id ℝ).restrict (spectrum ℝ D)) = D := by
+    ext i j
+    rcases eq_or_ne i j with rfl | hij
+    · simp only [diagonalCfcAux, ContinuousMap.restrict_apply, ContinuousMap.id_apply,
+        StarAlgHom.coe_mk', AlgHom.coe_mk, RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk,
+        diagonal_apply_eq, hD]
+    · simp only [diagonalCfcAux, StarAlgHom.coe_mk', AlgHom.coe_mk, RingHom.coe_mk,
+        MonoidHom.coe_mk, OneHom.coe_mk, diagonal_apply_ne _ hij, hD]
+  have hHom := cfcHom_eq_of_continuous_of_map_id (a := D) hsa (diagonalCfcAux g) hcont hid
+  rw [cfc_apply f D hsa hfspec, hHom]
+  ext i j
+  rcases eq_or_ne i j with rfl | hij
+  · simp [diagonalCfcAux, diagonal_apply_eq]
+  · simp [diagonalCfcAux, diagonal_apply_ne _ hij]
+
+end Diagonal
 
 end Matrix

--- a/TNLean/Analysis/CfcKronecker.lean
+++ b/TNLean/Analysis/CfcKronecker.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
+import TNLean.Analysis.CfcConjugation
+import TNLean.Analysis.TraceCFC
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.Analysis.Matrix.Order
 
@@ -29,9 +31,11 @@ either depending on the other.
   unital left tensor embedding: $f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1$.
 * `Matrix.cfc_one_kronecker` — the right embedding version:
   $f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$.
+* `Matrix.cfc_kronecker_of_mul_posSemidef` — multiplicative functional calculus
+  on Kronecker products of positive-semidefinite matrices.
 -/
 
-open scoped Kronecker
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
 
 namespace Matrix
 
@@ -112,5 +116,78 @@ theorem cfc_one_kronecker {B : Matrix n n ℂ} (hB : B.IsHermitian) (f : ℝ →
   simpa [rightKroneckerEmbed_apply] using
     (StarAlgHomClass.map_cfc (rightKroneckerEmbed (m := m) (n := n)) f B
       hcont hcontφ hsa hsa').symm
+
+/-- **Multiplicative functional calculus on positive Kronecker products.** If
+`f` is multiplicative on nonnegative real numbers, then
+\[
+  f(A \otimes B) = f(A) \otimes f(B)
+\]
+for positive-semidefinite matrices $A$ and $B$.
+
+The proof simultaneously diagonalizes the two factors. This form is useful for
+functions that need not be globally continuous, since a matrix has finite
+spectrum. -/
+theorem cfc_kronecker_of_mul_posSemidef
+    {A : Matrix m m ℂ} {B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (f : ℝ → ℝ)
+    (hf : ∀ x y : ℝ, 0 ≤ x → 0 ≤ y → f (x * y) = f x * f y) :
+    cfc f (A ⊗ₖ B) = cfc f A ⊗ₖ cfc f B := by
+  set evA := hA.isHermitian.eigenvalues with hevA
+  set evB := hB.isHermitian.eigenvalues with hevB
+  set UA : Matrix m m ℂ := (hA.isHermitian.eigenvectorUnitary : Matrix m m ℂ) with hUA
+  set UB : Matrix n n ℂ := (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ) with hUB
+  set U : Matrix (m × n) (m × n) ℂ := UA ⊗ₖ UB with hU
+  set g : m × n → ℝ := fun p ↦ evA p.1 * evB p.2 with hg
+  set D : Matrix (m × n) (m × n) ℂ := diagonal (fun p ↦ (g p : ℂ)) with hD
+  have hUstar : star U = star UA ⊗ₖ star UB := by
+    rw [hU, Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.star_eq_conjTranspose, Matrix.star_eq_conjTranspose]
+  have hUmem : U ∈ Matrix.unitaryGroup (m × n) ℂ :=
+    Matrix.kronecker_mem_unitary
+      hA.isHermitian.eigenvectorUnitary.2 hB.isHermitian.eigenvectorUnitary.2
+  set Uu : unitary (Matrix (m × n) (m × n) ℂ) := ⟨U, hUmem⟩ with hUu
+  have hconj_eq : A ⊗ₖ B = U * D * star U := by
+    have hAeq := IsHermitian.spectral_form hA.isHermitian
+    have hBeq := IsHermitian.spectral_form hB.isHermitian
+    conv_lhs => rw [hAeq, hBeq]
+    rw [hU, hD, hg, hUstar, Matrix.mul_kronecker_mul, Matrix.mul_kronecker_mul,
+      Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp)]
+    congr 1
+    ext p
+    push_cast
+    ring
+  have hDherm : D.IsHermitian :=
+    isHermitian_diagonal_of_self_adjoint _ (by
+      rw [isSelfAdjoint_iff]
+      ext p
+      simp [Complex.conj_ofReal])
+  have hcfD : cfc f D = diagonal (fun p ↦ ((f (g p) : ℝ) : ℂ)) := by
+    rw [hD, Matrix.cfc_diagonal g f ((Set.finite_range g).continuousOn f)]
+  have hcfAB : cfc f (A ⊗ₖ B) =
+      U * diagonal (fun p ↦ ((f (g p) : ℝ) : ℂ)) * star U := by
+    rw [hconj_eq, Matrix.cfc_conj_unitary hDherm f Uu]
+    simp only [hUu]
+    rw [hcfD]
+  have hcfA : cfc f A =
+      UA * diagonal (fun i ↦ ((f (evA i) : ℝ) : ℂ)) * star UA := by
+    rw [hA.isHermitian.cfc_eq, hA.isHermitian.cfc_form]
+  have hcfB : cfc f B =
+      UB * diagonal (fun j ↦ ((f (evB j) : ℝ) : ℂ)) * star UB := by
+    rw [hB.isHermitian.cfc_eq, hB.isHermitian.cfc_form]
+  have hdiag : diagonal (fun p ↦ ((f (g p) : ℝ) : ℂ)) =
+      diagonal (fun i ↦ ((f (evA i) : ℝ) : ℂ)) ⊗ₖ
+        diagonal (fun j ↦ ((f (evB j) : ℝ) : ℂ)) := by
+    rw [Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp)]
+    ext p q
+    by_cases hpq : p = q
+    · subst q
+      simp only [Matrix.diagonal_apply_eq]
+      rw [hg, hf _ _ (hevA ▸ hA.eigenvalues_nonneg p.1)
+        (hevB ▸ hB.eigenvalues_nonneg p.2)]
+      push_cast
+      rfl
+    · simp [Matrix.diagonal_apply_ne _ hpq]
+  rw [hcfAB, hcfA, hcfB, hU, hUstar, Matrix.mul_kronecker_mul,
+    Matrix.mul_kronecker_mul, hdiag]
 
 end Matrix

--- a/TNLean/Analysis/LiebOperatorIntegral.lean
+++ b/TNLean/Analysis/LiebOperatorIntegral.lean
@@ -36,8 +36,6 @@ combined with the resolvent-integrand concavity, yields the joint concavity of
 
 ## Main results
 
-* `Matrix.cfc_diagonal`: the continuous functional calculus acts entrywise on a
-  real-valued diagonal matrix.
 * `Matrix.rpow_diagonal`: the real power of a positive real diagonal matrix is the
   diagonal of the entrywise real powers.
 * `Matrix.rpow_conj_unitary`: covariance of the real power under unitary conjugation.
@@ -66,77 +64,6 @@ variable {n : Type*} [Fintype n] [DecidableEq n]
 importers (see `Mathlib/Analysis/CStarAlgebra/Matrix.lean`). -/
 noncomputable local instance matrixCStarAlgebra : CStarAlgebra (Matrix n n ℂ) where
 
-/-- The real spectrum of a real-valued diagonal matrix is the range of its diagonal. -/
-private lemma spectrum_real_ofReal_diagonal (g : n → ℝ) :
-    spectrum ℝ (diagonal (fun i => (g i : ℂ))) = Set.range g := by
-  ext x
-  rw [← spectrum.algebraMap_mem_iff (S := ℂ), Complex.coe_algebraMap, spectrum_diagonal]
-  simp only [Set.mem_range, Complex.ofReal_inj]
-
-/-- Membership of a diagonal entry in the real spectrum of the diagonal matrix. -/
-private lemma mem_spectrum_real_ofReal_diagonal (g : n → ℝ) (i : n) :
-    g i ∈ spectrum ℝ (diagonal (fun i => (g i : ℂ))) :=
-  (spectrum_real_ofReal_diagonal g).symm ▸ ⟨i, rfl⟩
-
-/-- The star-algebra homomorphism `C(spectrum ℝ (diagonal (g·)), ℝ) →⋆ₐ[ℝ] Matrix n n ℂ`
-that evaluates a function along the diagonal entries. It coincides with `cfcHom` of the
-diagonal matrix by uniqueness, which is the content of `cfc_diagonal`. -/
-private noncomputable def diagonalCfcAux (g : n → ℝ) :
-    C(spectrum ℝ (diagonal (fun i => (g i : ℂ))), ℝ) →⋆ₐ[ℝ] Matrix n n ℂ where
-  toFun p := diagonal fun i => ((p ⟨g i, mem_spectrum_real_ofReal_diagonal g i⟩ : ℝ) : ℂ)
-  map_zero' := by simp only [ContinuousMap.coe_zero, Pi.zero_apply, Complex.ofReal_zero,
-    diagonal_zero]
-  map_one' := by simp only [ContinuousMap.coe_one, Pi.one_apply, Complex.ofReal_one, diagonal_one]
-  map_mul' p q := by
-    simp only [ContinuousMap.coe_mul, Pi.mul_apply, Complex.ofReal_mul, diagonal_mul_diagonal]
-  map_add' p q := by
-    simp only [ContinuousMap.coe_add, Pi.add_apply, Complex.ofReal_add, diagonal_add]
-  commutes' r := by
-    change diagonal (fun _ => ((r : ℝ) : ℂ)) = algebraMap ℝ (Matrix n n ℂ) r
-    rw [Matrix.algebraMap_eq_diagonal]
-    rfl
-  map_star' p := by
-    show diagonal (fun i => (((star p) ⟨g i, _⟩ : ℝ) : ℂ))
-      = star (diagonal (fun i => ((p ⟨g i, _⟩ : ℝ) : ℂ)))
-    rw [star_eq_conjTranspose, diagonal_conjTranspose]
-    congr 1; ext i
-    simp only [Pi.star_apply, RCLike.star_def, star_trivial, Complex.conj_ofReal]
-
-/-- **Continuous functional calculus of a real-valued diagonal matrix.** For a
-real-valued diagonal `diagonal (fun i => (g i : ℂ))` and a function `f` continuous on the
-range of the entries, the calculus acts entrywise:
-`cfc f (diagonal (g·)) = diagonal (fun i => (f (g i) : ℂ))`. -/
-lemma cfc_diagonal (g : n → ℝ) (f : ℝ → ℝ)
-    (hf : ContinuousOn f (Set.range g) := by cfc_cont_tac) :
-    cfc f (diagonal (fun i => (g i : ℂ)))
-      = diagonal (fun i => (f (g i) : ℂ)) := by
-  set D : Matrix n n ℂ := diagonal (fun i => (g i : ℂ)) with hD
-  have hsa : IsSelfAdjoint D := by
-    rw [isSelfAdjoint_iff, hD, star_eq_conjTranspose, diagonal_conjTranspose]
-    congr 1; ext i; simp [Complex.conj_ofReal]
-  have hfspec : ContinuousOn f (spectrum ℝ D) := by
-    rw [hD, spectrum_real_ofReal_diagonal]; exact hf
-  -- The hand-built map agrees with `cfcHom` by uniqueness.
-  have hfindim : FiniteDimensional ℝ C(spectrum ℝ D, ℝ) :=
-    FiniteDimensional.of_injective (ContinuousMap.coeFnLinearMap ℝ (M := ℝ)) DFunLike.coe_injective
-  have hcont : Continuous (diagonalCfcAux g) := by
-    have : Continuous ((diagonalCfcAux g).toLinearMap) :=
-      LinearMap.continuous_of_finiteDimensional _
-    exact this
-  have hid : diagonalCfcAux g ((ContinuousMap.id ℝ).restrict (spectrum ℝ D)) = D := by
-    ext i j
-    rcases eq_or_ne i j with rfl | hij
-    · simp only [diagonalCfcAux, ContinuousMap.restrict_apply, ContinuousMap.id_apply,
-        StarAlgHom.coe_mk', AlgHom.coe_mk, RingHom.coe_mk, MonoidHom.coe_mk, OneHom.coe_mk,
-        diagonal_apply_eq, hD]
-    · simp only [diagonalCfcAux, StarAlgHom.coe_mk', AlgHom.coe_mk, RingHom.coe_mk,
-        MonoidHom.coe_mk, OneHom.coe_mk, diagonal_apply_ne _ hij, hD]
-  have hHom := cfcHom_eq_of_continuous_of_map_id (a := D) hsa (diagonalCfcAux g) hcont hid
-  rw [cfc_apply f D hsa hfspec, hHom]
-  ext i j
-  rcases eq_or_ne i j with rfl | hij
-  · simp [diagonalCfcAux, diagonal_apply_eq]
-  · simp [diagonalCfcAux, diagonal_apply_ne _ hij]
 
 omit [Fintype n] in
 /-- A real-valued diagonal matrix with positive entries is positive definite. -/

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -233,6 +233,8 @@ theorem PosSemidef.supportInvSqrt_kronecker
   rw [if_pos (mul_ne_zero hx0 hy0), if_pos hx0, if_pos hy0, Real.sqrt_mul hx,
     mul_inv]
 
+-- Keep the two unital specializations below on the direct embedding lemmas: this avoids
+-- introducing a separate support-inverse-square-root computation for the identity matrix.
 /-- The support inverse square root commutes with the unital left tensor
 embedding. This is the tensor functional-calculus identity for the support
 inverse in Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -25,6 +25,8 @@ theory development.
   original matrix.
 * `Matrix.PosSemidef.sqrt_smul`: the positive square root commutes with
   nonnegative real scaling.
+* `Matrix.PosSemidef.sqrt_kronecker`: positive square roots factor across
+  Kronecker products.
 * `Matrix.PosSemidef.blockDiagonal'`: a finite dependent block diagonal of
   positive-semidefinite matrices is positive semidefinite.
 * `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
@@ -32,9 +34,10 @@ theory development.
 * `Matrix.PosDef.supportInvSqrt_eq_inv_sqrt`: agreement with the ordinary
   inverse square root for positive-definite matrices.
 * `Matrix.PosSemidef.supportInvSqrt_smul`: compatibility with positive scaling.
-* `Matrix.PosSemidef.supportInvSqrt_kronecker_one` and
-  `Matrix.PosSemidef.supportInvSqrt_one_kronecker`: compatibility with the
-  unital tensor embeddings.
+* `Matrix.PosSemidef.supportInvSqrt_kronecker`: support inverse square roots
+  factor across arbitrary positive-semidefinite Kronecker products.
+* `Matrix.PosSemidef.supportProj_kronecker`: support projections factor across
+  arbitrary positive-semidefinite Kronecker products.
 * `Matrix.PosSemidef.supportInvSqrt_sq_mul_self` and
   `Matrix.PosSemidef.self_mul_supportInvSqrt_sq`: generalized-inverse identities.
 * `Matrix.PosSemidef.star_dotProduct_supportInv_mulVec_eq_of_mulVec_eq`:
@@ -61,6 +64,22 @@ theorem PosSemidef.sqrt_smul
     hscaled.nonneg hcand.nonneg).2
   rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
     CFC.sqrt_mul_sqrt_self A hA.nonneg, Real.mul_self_sqrt hc]
+
+open scoped Classical in
+/-- The positive square root factors across Kronecker products of
+positive-semidefinite matrices:
+\[
+  \sqrt{A \otimes B} = \sqrt A \otimes \sqrt B.
+\] -/
+theorem PosSemidef.sqrt_kronecker
+    {n m : Type*} [Fintype n] [Fintype m]
+    {A : Matrix n n ℂ} {B : Matrix m m ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    CFC.sqrt (A ⊗ₖ B) = CFC.sqrt A ⊗ₖ CFC.sqrt B := by
+  rw [CFC.sqrt_eq_real_sqrt (A ⊗ₖ B) (hA.kronecker hB).nonneg,
+    CFC.sqrt_eq_real_sqrt A hA.nonneg, CFC.sqrt_eq_real_sqrt B hB.nonneg,
+    cfcₙ_eq_cfc, cfcₙ_eq_cfc, cfcₙ_eq_cfc]
+  exact Matrix.cfc_kronecker_of_mul_posSemidef hA hB Real.sqrt
+    (fun x y hx _hy ↦ Real.sqrt_mul hx y)
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
@@ -191,6 +210,29 @@ theorem PosSemidef.supportInvSqrt_smul {ρ : Matrix n n ℂ}
     (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ
     (hf := ρ.finite_real_spectrum.continuousOn _)]
 
+/-- The support inverse square root factors across Kronecker products
+of positive-semidefinite matrices:
+\[
+  (A \otimes B)^{-1/2}_{\mathrm{supp}}
+    = A^{-1/2}_{\mathrm{supp}} \otimes B^{-1/2}_{\mathrm{supp}}.
+\]
+The zero-eigenvalue convention is essential when either factor is singular. -/
+theorem PosSemidef.supportInvSqrt_kronecker
+    {m : Type*} [Fintype m] [DecidableEq m]
+    {A : Matrix n n ℂ} {B : Matrix m m ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    (hA.kronecker hB).supportInvSqrt = hA.supportInvSqrt ⊗ₖ hB.supportInvSqrt := by
+  unfold PosSemidef.supportInvSqrt
+  rw [← (hA.kronecker hB).isHermitian.cfc_eq, ← hA.isHermitian.cfc_eq,
+    ← hB.isHermitian.cfc_eq]
+  apply Matrix.cfc_kronecker_of_mul_posSemidef hA hB
+  intro x y hx _hy
+  by_cases hx0 : x = 0
+  · simp [hx0]
+  by_cases hy0 : y = 0
+  · simp [hy0]
+  rw [if_pos (mul_ne_zero hx0 hy0), if_pos hx0, if_pos hy0, Real.sqrt_mul hx,
+    mul_inv]
+
 /-- The support inverse square root commutes with the unital left tensor
 embedding. This is the tensor functional-calculus identity for the support
 inverse in Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
@@ -220,6 +262,41 @@ theorem PosSemidef.supportInvSqrt_one_kronecker
     ← hρ.isHermitian.cfc_eq]
   exact Matrix.cfc_one_kronecker hρ.isHermitian
     (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0)
+
+/-- Multiplying the positive square root by the support inverse square
+root gives the support projection. -/
+theorem PosSemidef.cfc_sqrt_mul_supportInvSqrt
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.isHermitian.cfc Real.sqrt * hρ.supportInvSqrt = hρ.supportProj := by
+  let f : ℝ → ℝ := fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
+  change hρ.isHermitian.cfc Real.sqrt * hρ.isHermitian.cfc f =
+    hρ.isHermitian.supportProj
+  rw [← hρ.isHermitian.cfc_mul]
+  unfold Matrix.IsHermitian.cfc Matrix.IsHermitian.supportProj
+  rw [Unitary.conjStarAlgAut_apply]
+  have hdiag :
+      Matrix.diagonal ((RCLike.ofReal : ℝ → ℂ) ∘
+          (fun x ↦ Real.sqrt x * f x) ∘ hρ.isHermitian.eigenvalues) =
+        Matrix.diagonal (fun i ↦
+          if hρ.isHermitian.eigenvalues i ≠ 0 then (1 : ℂ) else 0) := by
+    congr 1
+    funext i
+    simp only [Function.comp_apply]
+    by_cases hi : hρ.isHermitian.eigenvalues i = 0
+    · simp [f, hi]
+    · have hsqrt : Real.sqrt (hρ.isHermitian.eigenvalues i) ≠ 0 :=
+        Real.sqrt_ne_zero'.mpr (lt_of_le_of_ne (hρ.eigenvalues_nonneg i) (Ne.symm hi))
+      simp [f, hi, hsqrt]
+  rw [hdiag]
+
+/-- Multiplying the support inverse square root by the positive square root gives
+the support projection. -/
+theorem PosSemidef.supportInvSqrt_mul_cfc_sqrt
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.supportInvSqrt * hρ.isHermitian.cfc Real.sqrt = hρ.supportProj := by
+  simpa [Matrix.conjTranspose_mul, hρ.supportInvSqrt_isHermitian.eq,
+    hρ.cfc_sqrt_isHermitian.eq, hρ.supportProj_isHermitian.eq] using
+      congrArg Matrix.conjTranspose hρ.cfc_sqrt_mul_supportInvSqrt
 
 /-- Sandwiching a positive-semidefinite matrix by its support inverse square
 root gives its support projection.  This is the spectral support identity
@@ -265,6 +342,34 @@ theorem PosSemidef.supportInvSqrt_mul_self_mul_supportInvSqrt
           simpa [f, hi] using congrArg Complex.ofReal hreal
       unfold Matrix.IsHermitian.supportProj
       rw [Matrix.IsHermitian.cfc, Unitary.conjStarAlgAut_apply, hdiag]
+
+/-- The support projection factors across Kronecker products of
+positive-semidefinite matrices:
+\[
+  P_{A \otimes B} = P_A \otimes P_B.
+\] -/
+theorem PosSemidef.supportProj_kronecker
+    {m : Type*} [Fintype m] [DecidableEq m]
+    {A : Matrix n n ℂ} {B : Matrix m m ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    (hA.kronecker hB).supportProj = hA.supportProj ⊗ₖ hB.supportProj := by
+  change (hA.kronecker hB).isHermitian.supportProj =
+    hA.isHermitian.supportProj ⊗ₖ hB.isHermitian.supportProj
+  rw [← (hA.kronecker hB).supportInvSqrt_mul_self_mul_supportInvSqrt,
+    hA.supportInvSqrt_kronecker hB, ← Matrix.mul_kronecker_mul,
+    ← Matrix.mul_kronecker_mul, hA.supportInvSqrt_mul_self_mul_supportInvSqrt,
+    hB.supportInvSqrt_mul_self_mul_supportInvSqrt]
+
+/-- A positive-definite matrix has full support. -/
+theorem PosDef.supportProj_eq_one {ρ : Matrix n n ℂ} (hρ : ρ.PosDef) :
+    hρ.posSemidef.supportProj = 1 := by
+  rw [← hρ.posSemidef.cfc_sqrt_mul_supportInvSqrt,
+    hρ.supportInvSqrt_eq_inv_sqrt]
+  have hsqrt : CFC.sqrt ρ = hρ.isHermitian.cfc Real.sqrt := by
+    rw [CFC.sqrt_eq_real_sqrt ρ hρ.posSemidef.nonneg, cfcₙ_eq_cfc,
+      hρ.isHermitian.cfc_eq]
+  rw [← hsqrt]
+  exact Matrix.mul_nonsing_inv _ ((Matrix.isUnit_iff_isUnit_det _).mp
+    ((CFC.isUnit_sqrt_iff ρ hρ.posSemidef.nonneg).mpr hρ.isUnit))
 
 /-- The square of the support inverse square root is a generalized inverse:
 multiplying it by the original matrix gives the support projection.

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -114,8 +114,26 @@
     the identity with $\tau$ on the left.
 \end{proof}
 
-\begin{lemma}[Square roots and supports of tensor products]
-    \label{lem:support_inverse_square_root_tensor_product}
+\begin{theorem}[Multiplicative functional calculus on positive tensor products]
+    \label{thm:multiplicative_functional_calculus_tensor_product}
+    \lean{Matrix.cfc_kronecker_of_mul_posSemidef}
+    \leanok
+    Let $A$ and $B$ be positive semidefinite, and let $f\colon\R\to\R$ be
+    multiplicative on the non-negative reals. Then
+    \begin{align}
+        f(A\otimes B)&=f(A)\otimes f(B).
+        \label{eq:entropy_cfc_tensor_product}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Diagonalize $A$ and $B$. In the resulting product eigenbasis, the
+    eigenvalues of $A\otimes B$ are $a_i b_j$ with $a_i,b_j\geq 0$, and the
+    claim follows from $f(a_i b_j)=f(a_i)f(b_j)$.
+\end{proof}
+
+\begin{theorem}[Square roots and supports of tensor products]
+    \label{thm:support_inverse_square_root_tensor_product}
     \lean{Matrix.PosSemidef.sqrt_kronecker}
     \lean{Matrix.PosSemidef.supportInvSqrt_kronecker}
     \lean{Matrix.PosSemidef.cfc_sqrt_mul_supportInvSqrt}
@@ -123,7 +141,7 @@
     \lean{Matrix.PosSemidef.supportProj_kronecker}
     \lean{Matrix.PosDef.supportProj_eq_one}
     \leanok
-    \uses{def:support_inverse_square_root,lem:support_inverse_square_root_sandwich}
+    \uses{def:support_inverse_square_root}
     Let $A$ and $B$ be positive semidefinite. Their positive square roots,
     support inverse square roots, and support projections satisfy
     \begin{align}
@@ -145,9 +163,11 @@
         \label{eq:entropy_support_sqrt_cancellation}
     \end{align}
     If $A$ is positive definite, then $P_A=\mathbf 1$.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:multiplicative_functional_calculus_tensor_product,
+        lem:support_inverse_square_root_sandwich}
     Diagonalize both factors. The eigenvalues of $A\otimes B$ are the products
     $a_i b_j$. Both the square-root function and the function that equals
     $x^{-1/2}$ for $x>0$ and zero at $x=0$ are multiplicative on the

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -167,16 +167,17 @@
 
 \begin{proof}\leanok
     \uses{thm:multiplicative_functional_calculus_tensor_product,
-        lem:support_inverse_square_root_sandwich}
+        lem:support_inverse_square_root_sandwich,
+        lem:support_inverse_square_root_positive_definite}
     Diagonalize both factors. The eigenvalues of $A\otimes B$ are the products
     $a_i b_j$. Both the square-root function and the function that equals
     $x^{-1/2}$ for $x>0$ and zero at $x=0$ are multiplicative on the
     non-negative reals. For the support projectors, apply the sandwich identity
     to $A\otimes B$, factor the support inverse square root and matrix products,
     and apply the sandwich identity to each factor. The cancellation identities
-    follow entrywise. For a positive-definite
-    matrix every eigenvalue is nonzero, so its support projection is the
-    identity.
+    follow entrywise. If $A$ is positive definite, then
+    $A^{-1/2}_{\mathrm{supp}}=(\sqrt A)^{-1}$ and $\sqrt A$ is invertible.
+    Hence the cancellation identity gives $P_A=\sqrt A(\sqrt A)^{-1}=\mathbf 1$.
 \end{proof}
 
 \begin{lemma}[Support inverse square root under scaling and a maximally mixed factor]

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -114,6 +114,49 @@
     the identity with $\tau$ on the left.
 \end{proof}
 
+\begin{lemma}[Square roots and supports of tensor products]
+    \label{lem:support_inverse_square_root_tensor_product}
+    \lean{Matrix.PosSemidef.sqrt_kronecker}
+    \lean{Matrix.PosSemidef.supportInvSqrt_kronecker}
+    \lean{Matrix.PosSemidef.cfc_sqrt_mul_supportInvSqrt}
+    \lean{Matrix.PosSemidef.supportInvSqrt_mul_cfc_sqrt}
+    \lean{Matrix.PosSemidef.supportProj_kronecker}
+    \lean{Matrix.PosDef.supportProj_eq_one}
+    \leanok
+    \uses{def:support_inverse_square_root,lem:support_inverse_square_root_sandwich}
+    Let $A$ and $B$ be positive semidefinite. Their positive square roots,
+    support inverse square roots, and support projections satisfy
+    \begin{align}
+        \sqrt{A\otimes B}
+        &=\sqrt A\otimes\sqrt B,
+        \notag\\
+        (A\otimes B)^{-1/2}_{\mathrm{supp}}
+        &=A^{-1/2}_{\mathrm{supp}}\otimes B^{-1/2}_{\mathrm{supp}},
+        \notag\\
+        P_{A\otimes B}
+        &=P_A\otimes P_B.
+        \label{eq:entropy_support_tensor_product}
+    \end{align}
+    Moreover,
+    \begin{align}
+        \sqrt A\,A^{-1/2}_{\mathrm{supp}}
+        =A^{-1/2}_{\mathrm{supp}}\sqrt A
+        &=P_A.
+        \label{eq:entropy_support_sqrt_cancellation}
+    \end{align}
+    If $A$ is positive definite, then $P_A=\mathbf 1$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Diagonalize both factors. The eigenvalues of $A\otimes B$ are the products
+    $a_i b_j$. Both the square-root function and the function that equals
+    $x^{-1/2}$ for $x>0$ and zero at $x=0$ are multiplicative on the
+    non-negative reals. The support indicator is multiplicative there as well.
+    The cancellation identities follow entrywise. For a positive-definite
+    matrix every eigenvalue is nonzero, so its support projection is the
+    identity.
+\end{proof}
+
 \begin{lemma}[Support inverse square root under scaling and a maximally mixed factor]
     \label{lem:support_inverse_square_root_maximally_mixed}
     \lean{Matrix.PosSemidef.supportInvSqrt_smul}

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -171,8 +171,10 @@
     Diagonalize both factors. The eigenvalues of $A\otimes B$ are the products
     $a_i b_j$. Both the square-root function and the function that equals
     $x^{-1/2}$ for $x>0$ and zero at $x=0$ are multiplicative on the
-    non-negative reals. The support indicator is multiplicative there as well.
-    The cancellation identities follow entrywise. For a positive-definite
+    non-negative reals. For the support projectors, apply the sandwich identity
+    to $A\otimes B$, factor the support inverse square root and matrix products,
+    and apply the sandwich identity to each factor. The cancellation identities
+    follow entrywise. For a positive-definite
     matrix every eigenvalue is nonzero, so its support projection is the
     identity.
 \end{proof}


### PR DESCRIPTION
## What changed

- relocate the reusable diagonal continuous-functional-calculus theorem to the low-level conjugation module
- prove multiplicative positive-semidefinite functional calculus over Kronecker products
- derive square-root, support-inverse-square-root, and support-projector Kronecker factorizations
- prove both square-root/support-inverse cancellation identities and full support for positive-definite matrices
- synchronize the Chapter 19 dependency graph, including the support-sandwich dependency

## Support behavior and scope

For positive-semidefinite factors, the new identities retain the support projections exactly. If one factor is the zero matrix, its square root, support inverse square root, and support projector are all zero, so the tensor identities reduce correctly to zero rather than silently assuming invertibility. If the first factor is singular but nonzero, its support projector remains a genuine compression: the corresponding raw product-reference Petz formula should act as

\[
X_A\otimes X_B\longmapsto (P_A X_A P_A)\otimes \mathcal R^{\mathrm{raw}}_{\rho_{BC}}(X_B),
\]

not as an unrestricted identity on the first factor.

This is the corrected boundary of #4890: an identity-tensored raw formula is valid on inputs supported by $P_A$, or globally when $\rho_A$ is positive definite. For singular $\rho_A$, a tensor-compatible CPTP extension may be chosen, but TNLean's generic completed channel need not factor in that form. This PR supplies the support calculus needed for that later proof; it does **not** prove the Petz factorization itself or any stronger HJPW claim.

## Validation

- targeted builds: `TNLean.Analysis.CfcConjugation`, `TNLean.Analysis.CfcKronecker`, `TNLean.Analysis.LiebOperatorIntegral`, and `TNLean.Analysis.MatrixSqrt` (3019 jobs)
- full `lake build TNLean` (9754 jobs)
- generated import-aggregator completeness and Lean module-policy gates
- blueprint declaration regeneration, sync, and `checkdecls`
- double LuaLaTeX with `TEXINPUTS="../../tex/tenkz//:"`; 746 pages and zero undefined cross-references
- proof-integrity, changed-line length, prose, whitespace, diff, and clean-status checks
- independent deep Lean audit approved the implementation, including singular and scalar-zero cases

Advances #4890 and #4229.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> These lemmas underpin singular support and tensor Petz calculus in the entropy stack; mistakes would affect downstream channel formulas, though the changes are standard spectral/Kronecker algebra with explicit zero-eigenvalue handling.
> 
> **Overview**
> Adds **multiplicative continuous functional calculus** on Kronecker products of positive-semidefinite matrices (`Matrix.cfc_kronecker_of_mul_posSemidef`), proved by joint diagonalization and entrywise use of `f(xy)=f(x)f(y)` on nonnegative eigenvalues.
> 
> **`Matrix.cfc_diagonal`** and its helpers move from `LiebOperatorIntegral` into **`CfcConjugation`** so Kronecker and Lieb layers share one entrywise diagonal CFC lemma without duplicating the C⋆-algebra setup.
> 
> From that core, **`MatrixSqrt`** gains Kronecker factorizations for **√**, **support inverse square root**, and **support projection**, plus **√ × support⁻¹/² = P** (both orders) and **P = 1** when the matrix is positive definite. Existing identity-tensored support lemmas stay on the direct embedding route.
> 
> **Chapter 19** blueprint is updated with the new Lean labels and dependency edges for tensor CFC and support/tensor identities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09ea4c7d421057a471fd84eee08a1a7444acceee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

