### PR TITLE
feat(CanonicalForm): gauge literal CPSV form to CFII

### DIFF
--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -14,6 +14,7 @@ import TNLean.MPS.CanonicalForm.BNTTransport
 import TNLean.MPS.CanonicalForm.BNTUniqueness
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.CanonicalForm.CPSVAfterBlocking
+import TNLean.MPS.CanonicalForm.CPSVCanonicalFormII
 import TNLean.MPS.CanonicalForm.CommonPeriodCyclicSectors
 import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.MPS.CanonicalForm.CyclicSectors.Basic

--- a/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
@@ -23,7 +23,7 @@ This is the nonsingular gauge asserted in arXiv:1606.00608, Appendix A,
 lines 1058--1077 and eq. `II_XAX`.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 
 namespace MPSTensor
 
@@ -45,20 +45,52 @@ noncomputable def coisometryExtendGL {r n : ℕ}
   have hQU : Q * Uᴴ = 0 := by
     simp only [Q, P, Matrix.sub_mul, Matrix.one_mul, Matrix.mul_assoc, hU,
       Matrix.mul_one, sub_self]
-  have hQQ : Q * Q = Q := by
-    simp only [Q, P]
+  have hPP : P * P = P := by
+    simp only [P]
     calc
-      (1 - Uᴴ * U) * (1 - Uᴴ * U) =
-          1 - Uᴴ * U - Uᴴ * U + Uᴴ * (U * Uᴴ) * U := by noncomm_ring
-      _ = 1 - Uᴴ * U := by rw [hU]; simp
+      (Uᴴ * U) * (Uᴴ * U) = Uᴴ * (U * Uᴴ) * U := by
+        simp only [Matrix.mul_assoc]
+      _ = Uᴴ * U := by rw [hU]; simp
+  have hQQ : Q * Q = Q := by
+    calc
+      Q * Q = (1 - P) * (1 - P) := rfl
+      _ = 1 - P - P + P * P := by noncomm_ring
+      _ = 1 - P := by rw [hPP]; abel
+  have hGU : G * Uᴴ = Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) := by
+    simp only [G, Matrix.add_mul, hQU, add_zero]
+    calc
+      (Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) * U) * Uᴴ =
+          Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) * (U * Uᴴ) := by
+            simp only [Matrix.mul_assoc]
+      _ = Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) := by rw [hU, Matrix.mul_one]
+  have hHU : H * Uᴴ =
+      Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) := by
+    simp only [H, Matrix.add_mul, hQU, add_zero]
+    calc
+      (Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) * U) * Uᴴ =
+          Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) *
+            (U * Uᴴ) := by simp only [Matrix.mul_assoc]
+      _ = Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) := by
+        rw [hU, Matrix.mul_one]
+  have hGQ : G * Q = Q := by
+    simp only [G, Matrix.add_mul, hQQ, Matrix.mul_assoc, hUQ, Matrix.mul_zero]
+    exact zero_add Q
+  have hHQ : H * Q = Q := by
+    simp only [H, Matrix.add_mul, hQQ, Matrix.mul_assoc, hUQ, Matrix.mul_zero]
+    exact zero_add Q
   have hGH : G * H = 1 := by
-    simp only [G, H, Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
-    rw [hU, Matrix.one_mul, hUQ, Matrix.mul_zero, hQU, Matrix.zero_mul, hQQ]
-    simp
+    rw [show H = Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) * U + Q
+      from rfl, Matrix.mul_add, hGQ]
+    rw [← Matrix.mul_assoc G
+      (Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ))) U,
+      ← Matrix.mul_assoc G Uᴴ, hGU]
+    simp [Q, P, Matrix.mul_assoc]
   have hHG : H * G = 1 := by
-    simp only [G, H, Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
-    rw [hU, Matrix.one_mul, hUQ, Matrix.mul_zero, hQU, Matrix.zero_mul, hQQ]
-    simp
+    rw [show G = Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) * U + Q from rfl,
+      Matrix.mul_add, hHQ]
+    rw [← Matrix.mul_assoc H (Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ)) U,
+      ← Matrix.mul_assoc H Uᴴ, hHU]
+    simp [Q, P, Matrix.mul_assoc]
   exact ⟨G, H, hGH, hHG⟩
 
 @[simp] theorem coisometryExtendGL_val {r n : ℕ}
@@ -74,6 +106,33 @@ noncomputable def coisometryExtendGL {r n : ℕ}
         (1 - Uᴴ * U) := by
   rfl
 
+/-- The extended gauge acts on the retained coisometric inclusion as the
+original retained-space gauge. -/
+theorem coisometryExtendGL_mul_conjTranspose {r n : ℕ}
+    (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1) (X : GL (Fin r) ℂ) :
+    (coisometryExtendGL U hU X : Matrix (Fin n) (Fin n) ℂ) * Uᴴ =
+      Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) := by
+  rw [coisometryExtendGL_val, Matrix.add_mul]
+  have hComplement : (1 - Uᴴ * U) * Uᴴ = 0 := by
+    simp only [Matrix.sub_mul, Matrix.one_mul, Matrix.mul_assoc, hU, Matrix.mul_one,
+      sub_self]
+  rw [hComplement, add_zero]
+  simp only [Matrix.mul_assoc, hU, Matrix.mul_one]
+
+/-- The coisometry intertwines the inverse extended gauge with the inverse
+retained-space gauge. -/
+theorem mul_coisometryExtendGL_inv {r n : ℕ}
+    (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1) (X : GL (Fin r) ℂ) :
+    U * (((coisometryExtendGL U hU X)⁻¹ : GL (Fin n) ℂ) :
+      Matrix (Fin n) (Fin n) ℂ) =
+      (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) * U := by
+  rw [coisometryExtendGL_inv_val, Matrix.mul_add]
+  have hComplement : U * (1 - Uᴴ * U) = 0 := by
+    simp only [Matrix.mul_sub, Matrix.mul_one, ← Matrix.mul_assoc, hU, Matrix.one_mul,
+      sub_self]
+  rw [hComplement, add_zero]
+  simp only [← Matrix.mul_assoc, hU, Matrix.one_mul]
+
 private structure CFIIBlockGaugeData {m : ℕ} (A : MPSTensor d m) where
   block : MPSTensor d m
   gauge : GaugeEquiv A block
@@ -88,7 +147,7 @@ private theorem IsNormalTensor.exists_cfiiBlockGaugeData {m : ℕ} [NeZero m]
   obtain ⟨σ, _hσ, _hσfix, hTP, hGaugeTP, _hPrimitive, hIrreducible⟩ :=
     hA.exists_tpGauge
   let T : MPSTensor d m := tpGauge A σ
-  obtain ⟨V, Λ, hSame, hΛPos, hΛDiag, hLeft, hΛFix⟩ :=
+  obtain ⟨V, Λ, _hSame, hΛPos, hΛDiag, hLeft, hΛFix⟩ :=
     exists_CFII_data_of_TP_of_isIrreducibleTensor T hTP hIrreducible (NeZero.pos m)
   let B : MPSTensor d m := fun i =>
     (V : Matrix (Fin m) (Fin m) ℂ)ᴴ * T i * (V : Matrix (Fin m) (Fin m) ℂ)
@@ -109,13 +168,13 @@ nonsingular gauge.
 Source: arXiv:1606.00608, Appendix A, lines 1058--1077 and eq. `II_XAX`. -/
 theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
     {A : MPSTensor d D} (data : CPSVCanonicalFormData A) :
-    ∃ B : MPSTensor d D, GaugeEquiv A B ∧ CPSVCanonicalFormIIData B := by
+    ∃ B : MPSTensor d D, GaugeEquiv A B ∧ IsCPSVCanonicalFormII B := by
   classical
-  let blockData : (k : Fin data.r) → CFIIBlockGaugeData (data.blocks k) := fun k =>
-    @Classical.choice _
+  let blockData : (k : Fin data.r) → CFIIBlockGaugeData (data.blocks k) := fun k => by
+    letI : NeZero (data.dim k) := NeZero.of_pos (data.dim_pos k)
+    exact Classical.choice
       (IsNormalTensor.exists_cfiiBlockGaugeData (A := data.blocks k)
-        (m := data.dim k) (hA := data.blocks_normal k)
-        (NeZero.of_pos (data.dim_pos k)))
+        (m := data.dim k) (hA := data.blocks_normal k))
   let newBlocks : (k : Fin data.r) → MPSTensor d (data.dim k) :=
     fun k => (blockData k).block
   let blockGauge : (k : Fin data.r) → GL (Fin (data.dim k)) ℂ :=
@@ -143,20 +202,39 @@ theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
       data.weights data.blocks newBlocks blockGauge hBlockGauge
   have hGU : (G : Matrix (Fin D) (Fin D) ℂ) * Uᴴ =
       Uᴴ * (X : Matrix (Fin (∑ k : Fin data.r, data.dim k))
-        (Fin (∑ k : Fin data.r, data.dim k)) ℂ) := by
-    simp [G, U, Matrix.mul_assoc, data.coisometric]
+        (Fin (∑ k : Fin data.r, data.dim k)) ℂ) :=
+    coisometryExtendGL_mul_conjTranspose U data.coisometric X
   have hUGinv : U * (((G⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) =
       (((X⁻¹ : GL (Fin (∑ k : Fin data.r, data.dim k)) ℂ)) :
         Matrix (Fin (∑ k : Fin data.r, data.dim k))
-          (Fin (∑ k : Fin data.r, data.dim k)) ℂ) * U := by
-    simp [G, U, Matrix.mul_assoc, data.coisometric]
+          (Fin (∑ k : Fin data.r, data.dim k)) ℂ) * U :=
+    mul_coisometryExtendGL_inv U data.coisometric X
   have hGauge : GaugeEquiv A B := by
     refine ⟨G, fun i => ?_⟩
     rw [data.reconstruct i]
-    simp only [B, hDirect i, Matrix.mul_assoc, hGU, hUGinv]
+    let C := toTensorFromBlocks data.weights data.blocks i
+    let Xmat : Matrix (Fin (∑ k : Fin data.r, data.dim k))
+        (Fin (∑ k : Fin data.r, data.dim k)) ℂ := X
+    let Xinv : Matrix (Fin (∑ k : Fin data.r, data.dim k))
+        (Fin (∑ k : Fin data.r, data.dim k)) ℂ :=
+      ((X⁻¹ : GL (Fin (∑ k : Fin data.r, data.dim k)) ℂ) : Matrix _ _ ℂ)
+    let Gmat : Matrix (Fin D) (Fin D) ℂ := G
+    let Ginv : Matrix (Fin D) (Fin D) ℂ :=
+      ((G⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+    have hGU' : Gmat * Uᴴ = Uᴴ * Xmat := hGU
+    have hUGinv' : U * Ginv = Xinv * U := hUGinv
+    have hDirect' : toTensorFromBlocks data.weights newBlocks i = Xmat * C * Xinv :=
+      hDirect i
+    change Uᴴ * toTensorFromBlocks data.weights newBlocks i * U = _
+    calc
+      Uᴴ * toTensorFromBlocks data.weights newBlocks i * U =
+          Uᴴ * (Xmat * C * Xinv) * U := by rw [hDirect']
+      _ = (Uᴴ * Xmat) * C * (Xinv * U) := by simp only [Matrix.mul_assoc]
+      _ = (Gmat * Uᴴ) * C * (U * Ginv) := by rw [hGU', hUGinv']
+      _ = Gmat * (Uᴴ * C * U) * Ginv := by simp only [Matrix.mul_assoc]
   refine ⟨B, hGauge, ?_⟩
-  refine
-    { r := data.r
+  refine ⟨{
+      r := data.r
       dim := data.dim
       dim_pos := data.dim_pos
       weights := data.weights
@@ -167,7 +245,7 @@ theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
       coisometric := data.coisometric
       reconstruct := fun _ => rfl
       blocks_left_canonical := fun k => (blockData k).leftCanonical
-      blocks_fixed_point := fun k => (blockData k).fixedPoint }
+      blocks_fixed_point := fun k => (blockData k).fixedPoint }⟩
 
 /-- Every tensor in literal CPSV canonical form is gauge-equivalent, in the
 same ambient bond dimension, to a tensor in literal canonical form II.
@@ -177,6 +255,6 @@ theorem IsCPSVCanonicalForm.exists_gaugeEquiv_canonicalFormII
     {A : MPSTensor d D} (hA : IsCPSVCanonicalForm A) :
     ∃ B : MPSTensor d D, GaugeEquiv A B ∧ IsCPSVCanonicalFormII B := by
   obtain ⟨B, hGauge, dataB⟩ := hA.data.exists_gaugeEquiv_canonicalFormII
-  exact ⟨B, hGauge, dataB.isCPSVCanonicalFormII⟩
+  exact ⟨B, hGauge, dataB⟩
 
 end MPSTensor

--- a/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
@@ -93,12 +93,15 @@ noncomputable def coisometryExtendGL {r n : ℕ}
     simp [Q, P, Matrix.mul_assoc]
   exact ⟨G, H, hGH, hHG⟩
 
+/-- The matrix underlying the extended gauge is the retained gauge plus the
+identity on the orthogonal complement. -/
 @[simp] theorem coisometryExtendGL_val {r n : ℕ}
     (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1) (X : GL (Fin r) ℂ) :
     (coisometryExtendGL U hU X : Matrix (Fin n) (Fin n) ℂ) =
       Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) * U + (1 - Uᴴ * U) := by
   rfl
 
+/-- The inverse extended gauge is obtained by extending the inverse retained gauge. -/
 @[simp] theorem coisometryExtendGL_inv_val {r n : ℕ}
     (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1) (X : GL (Fin r) ℂ) :
     (((coisometryExtendGL U hU X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ) =

--- a/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.Existence
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.SharedInfra.BlockGauge
+
+/-!
+# Gauge normalization from CPSV canonical form to canonical form II
+
+A tensor in the literal canonical form of Cirac--Pérez-García--Schuch--Verstraete
+admits a canonical-form-II representative in the same ambient bond dimension.
+Each retained normal block is first put in its Perron trace-preserving gauge and
+then unitarily diagonalized.  The resulting block gauges are assembled on the
+retained direct sum.  If `U` is the ambient coisometry, the retained gauge `X`
+is extended across the omitted zero coordinates by
+
+`Uᴴ * X * U + (1 - Uᴴ * U)`.
+
+This is the nonsingular gauge asserted in arXiv:1606.00608, Appendix A,
+lines 1058--1077 and eq. `II_XAX`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Extend an invertible operator on the range of a coisometry by the identity
+on the orthogonal complement of its initial space. -/
+noncomputable def coisometryExtendGL {r n : ℕ}
+    (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1) (X : GL (Fin r) ℂ) :
+    GL (Fin n) ℂ := by
+  let P : Matrix (Fin n) (Fin n) ℂ := Uᴴ * U
+  let Q : Matrix (Fin n) (Fin n) ℂ := 1 - P
+  let G : Matrix (Fin n) (Fin n) ℂ := Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) * U + Q
+  let H : Matrix (Fin n) (Fin n) ℂ :=
+    Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) * U + Q
+  have hUQ : U * Q = 0 := by
+    simp only [Q, P, Matrix.mul_sub, Matrix.mul_one, ← Matrix.mul_assoc, hU,
+      Matrix.one_mul, sub_self]
+  have hQU : Q * Uᴴ = 0 := by
+    simp only [Q, P, Matrix.sub_mul, Matrix.one_mul, Matrix.mul_assoc, hU,
+      Matrix.mul_one, sub_self]
+  have hQQ : Q * Q = Q := by
+    simp only [Q, P]
+    calc
+      (1 - Uᴴ * U) * (1 - Uᴴ * U) =
+          1 - Uᴴ * U - Uᴴ * U + Uᴴ * (U * Uᴴ) * U := by noncomm_ring
+      _ = 1 - Uᴴ * U := by rw [hU]; simp
+  have hGH : G * H = 1 := by
+    simp only [G, H, Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
+    rw [hU, Matrix.one_mul, hUQ, Matrix.mul_zero, hQU, Matrix.zero_mul, hQQ]
+    simp
+  have hHG : H * G = 1 := by
+    simp only [G, H, Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
+    rw [hU, Matrix.one_mul, hUQ, Matrix.mul_zero, hQU, Matrix.zero_mul, hQQ]
+    simp
+  exact ⟨G, H, hGH, hHG⟩
+
+@[simp] theorem coisometryExtendGL_val {r n : ℕ}
+    (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1) (X : GL (Fin r) ℂ) :
+    (coisometryExtendGL U hU X : Matrix (Fin n) (Fin n) ℂ) =
+      Uᴴ * (X : Matrix (Fin r) (Fin r) ℂ) * U + (1 - Uᴴ * U) := by
+  rfl
+
+@[simp] theorem coisometryExtendGL_inv_val {r n : ℕ}
+    (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1) (X : GL (Fin r) ℂ) :
+    (((coisometryExtendGL U hU X)⁻¹ : GL (Fin n) ℂ) : Matrix (Fin n) (Fin n) ℂ) =
+      Uᴴ * (((X⁻¹ : GL (Fin r) ℂ) : Matrix (Fin r) (Fin r) ℂ)) * U +
+        (1 - Uᴴ * U) := by
+  rfl
+
+private structure CFIIBlockGaugeData {m : ℕ} (A : MPSTensor d m) where
+  block : MPSTensor d m
+  gauge : GaugeEquiv A block
+  normal : IsNormalTensor block
+  leftCanonical : IsLeftCanonical block
+  fixedPoint : ∃ Λ : Matrix (Fin m) (Fin m) ℂ,
+    Λ.PosDef ∧ Λ.IsDiag ∧ transferMap block Λ = Λ
+
+private theorem IsNormalTensor.exists_cfiiBlockGaugeData {m : ℕ} [NeZero m]
+    {A : MPSTensor d m} (hA : IsNormalTensor A) :
+    Nonempty (CFIIBlockGaugeData A) := by
+  obtain ⟨σ, _hσ, _hσfix, hTP, hGaugeTP, _hPrimitive, hIrreducible⟩ :=
+    hA.exists_tpGauge
+  let T : MPSTensor d m := tpGauge A σ
+  obtain ⟨V, Λ, hSame, hΛPos, hΛDiag, hLeft, hΛFix⟩ :=
+    exists_CFII_data_of_TP_of_isIrreducibleTensor T hTP hIrreducible (NeZero.pos m)
+  let B : MPSTensor d m := fun i =>
+    (V : Matrix (Fin m) (Fin m) ℂ)ᴴ * T i * (V : Matrix (Fin m) (Fin m) ℂ)
+  have hGaugeUnitary : GaugeEquiv T B := by
+    refine ⟨(unitaryGL V)⁻¹, fun i => ?_⟩
+    simp [B, unitaryGL]
+  have hGauge : GaugeEquiv A B := hGaugeTP.trans hGaugeUnitary
+  have hNormalAlg : IsNormal B :=
+    isNormal_of_gaugeEquiv hA.isNormal hGauge
+  have hNormal : IsNormalTensor B :=
+    isNormalTensor_of_isNormal_leftCanonical B hNormalAlg hLeft
+  exact ⟨⟨B, hGauge, hNormal, hLeft, Λ, hΛPos, hΛDiag, hΛFix⟩⟩
+
+/-- Literal CPSV canonical-form data admit a canonical-form-II representative
+in the same ambient bond dimension, related to the original tensor by a
+nonsingular gauge.
+
+Source: arXiv:1606.00608, Appendix A, lines 1058--1077 and eq. `II_XAX`. -/
+theorem CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII
+    {A : MPSTensor d D} (data : CPSVCanonicalFormData A) :
+    ∃ B : MPSTensor d D, GaugeEquiv A B ∧ CPSVCanonicalFormIIData B := by
+  classical
+  let blockData : (k : Fin data.r) → CFIIBlockGaugeData (data.blocks k) := fun k =>
+    @Classical.choice _
+      (IsNormalTensor.exists_cfiiBlockGaugeData (A := data.blocks k)
+        (m := data.dim k) (hA := data.blocks_normal k)
+        (NeZero.of_pos (data.dim_pos k)))
+  let newBlocks : (k : Fin data.r) → MPSTensor d (data.dim k) :=
+    fun k => (blockData k).block
+  let blockGauge : (k : Fin data.r) → GL (Fin (data.dim k)) ℂ :=
+    fun k => Classical.choose (blockData k).gauge
+  let X := globalGaugeOfBlocks blockGauge
+  let U := data.ambient_coisometry
+  let G := coisometryExtendGL U data.coisometric X
+  let B : MPSTensor d D := fun i =>
+    Uᴴ * toTensorFromBlocks data.weights newBlocks i * U
+  have hBlockGauge : ∀ k i, newBlocks k i =
+      (blockGauge k : Matrix (Fin (data.dim k)) (Fin (data.dim k)) ℂ) *
+        data.blocks k i *
+        (((blockGauge k)⁻¹ : GL (Fin (data.dim k)) ℂ) :
+          Matrix (Fin (data.dim k)) (Fin (data.dim k)) ℂ) := by
+    intro k
+    exact Classical.choose_spec (blockData k).gauge
+  have hDirect : ∀ i, toTensorFromBlocks data.weights newBlocks i =
+      (X : Matrix (Fin (∑ k : Fin data.r, data.dim k))
+        (Fin (∑ k : Fin data.r, data.dim k)) ℂ) *
+        toTensorFromBlocks data.weights data.blocks i *
+        (((X⁻¹ : GL (Fin (∑ k : Fin data.r, data.dim k)) ℂ)) :
+          Matrix (Fin (∑ k : Fin data.r, data.dim k))
+            (Fin (∑ k : Fin data.r, data.dim k)) ℂ) :=
+    toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
+      data.weights data.blocks newBlocks blockGauge hBlockGauge
+  have hGU : (G : Matrix (Fin D) (Fin D) ℂ) * Uᴴ =
+      Uᴴ * (X : Matrix (Fin (∑ k : Fin data.r, data.dim k))
+        (Fin (∑ k : Fin data.r, data.dim k)) ℂ) := by
+    simp [G, U, Matrix.mul_assoc, data.coisometric]
+  have hUGinv : U * (((G⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) =
+      (((X⁻¹ : GL (Fin (∑ k : Fin data.r, data.dim k)) ℂ)) :
+        Matrix (Fin (∑ k : Fin data.r, data.dim k))
+          (Fin (∑ k : Fin data.r, data.dim k)) ℂ) * U := by
+    simp [G, U, Matrix.mul_assoc, data.coisometric]
+  have hGauge : GaugeEquiv A B := by
+    refine ⟨G, fun i => ?_⟩
+    rw [data.reconstruct i]
+    simp only [B, hDirect i, Matrix.mul_assoc, hGU, hUGinv]
+  refine ⟨B, hGauge, ?_⟩
+  refine
+    { r := data.r
+      dim := data.dim
+      dim_pos := data.dim_pos
+      weights := data.weights
+      blocks := newBlocks
+      blocks_normal := fun k => (blockData k).normal
+      total_dim_le := data.total_dim_le
+      ambient_coisometry := U
+      coisometric := data.coisometric
+      reconstruct := fun _ => rfl
+      blocks_left_canonical := fun k => (blockData k).leftCanonical
+      blocks_fixed_point := fun k => (blockData k).fixedPoint }
+
+/-- Every tensor in literal CPSV canonical form is gauge-equivalent, in the
+same ambient bond dimension, to a tensor in literal canonical form II.
+
+Source: arXiv:1606.00608, Appendix A, lines 1058--1077 and eq. `II_XAX`. -/
+theorem IsCPSVCanonicalForm.exists_gaugeEquiv_canonicalFormII
+    {A : MPSTensor d D} (hA : IsCPSVCanonicalForm A) :
+    ∃ B : MPSTensor d D, GaugeEquiv A B ∧ IsCPSVCanonicalFormII B := by
+  obtain ⟨B, hGauge, dataB⟩ := hA.data.exists_gaugeEquiv_canonicalFormII
+  exact ⟨B, hGauge, dataB.isCPSVCanonicalFormII⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -87,6 +87,61 @@
     underlying canonical-form data.
 \end{definition}
 
+\begin{theorem}[Canonical form admits a canonical-form-II gauge]
+    \label{thm:cpsv_cf_to_cfii_gauge}
+    \lean{MPSTensor.CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII}
+    \lean{MPSTensor.IsCPSVCanonicalForm.exists_gaugeEquiv_canonicalFormII}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:cpsv_cfii}
+    Let $A$ be a tensor in CPSV canonical form, with ambient bond dimension
+    $D$. Then there is a tensor $B$ of the same bond dimension and an
+    $G\in\GL(D,\C)$ such that, for every physical index~$i$,
+    \begin{align}
+        B^i
+         & =G A^iG^{-1}.
+    \end{align}
+    Moreover, $B$ is in canonical form II. This is the nonsingular gauge
+    assertion of \cite[Appendix~A]{Cirac2016MPDO_arXiv}.
+    % Maintainer source anchor: arXiv:1606.00608, lines 1058--1077,
+    % especially eq:II_TPLambda and eq:II_XAX at lines 1062--1077.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_normal_tp_gauge, thm:CFII_data,
+        def:global_gauge_of_blocks}
+    Write the retained part of the canonical-form decomposition as
+    $C^i=\bigoplus_k\mu_kA_k^i$, and let
+    $U\in\C^{S\times D}$ satisfy $UU^\dagger=\Id_S$ and
+    $A^i=U^\dagger C^iU$. For each normal block, first choose its pure
+    trace-preserving Perron gauge and then diagonalize its positive definite
+    fixed point by a unitary. This gives $X_k\in\GL(D_k,\C)$ and blocks
+    $B_k$ satisfying the two canonical-form-II identities. Put
+    $X=\bigoplus_kX_k$ and extend it to the omitted zero coordinates by
+    \begin{align}
+        G
+         & =U^\dagger XU+(\Id_D-U^\dagger U),
+        \notag\\
+        G^{-1}
+         & =U^\dagger X^{-1}U+(\Id_D-U^\dagger U).
+    \end{align}
+    The identity $UU^\dagger=\Id_S$ gives $GG^{-1}=G^{-1}G=\Id_D$ and
+    \begin{align}
+        GU^\dagger
+         & =U^\dagger X,
+        \notag\\
+        UG^{-1}
+         & =X^{-1}U.
+    \end{align}
+    Therefore
+    \begin{align}
+        GA^iG^{-1}
+         & =U^\dagger X C^iX^{-1}U
+          =U^\dagger\!\left(\bigoplus_k\mu_kB_k^i\right)U,
+    \end{align}
+    which has the same ambient reconstruction and satisfies canonical form II.
+\end{proof}
+
 \begin{theorem}[Diagonal Perron normalization for an irreducible TP tensor]
     \label{thm:form_II}
     \lean{MPSTensor.exists_unitary_diag_posDef_fixedPoint_of_TP_of_isIrreducibleTensor}

--- a/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_normal_forms_and_support_auxiliary.tex
@@ -120,16 +120,20 @@
     $X=\bigoplus_kX_k$ and extend it to the omitted zero coordinates by
     \begin{align}
         G
-         & =U^\dagger XU+(\Id_D-U^\dagger U),
-        \notag\\
+         & =U^\dagger XU+(\Id_D-U^\dagger U).
+    \end{align}
+    Its inverse is
+    \begin{align}
         G^{-1}
          & =U^\dagger X^{-1}U+(\Id_D-U^\dagger U).
     \end{align}
-    The identity $UU^\dagger=\Id_S$ gives $GG^{-1}=G^{-1}G=\Id_D$ and
+    The identity $UU^\dagger=\Id_S$ gives $GG^{-1}=G^{-1}G=\Id_D$. It also gives
     \begin{align}
         GU^\dagger
          & =U^\dagger X,
-        \notag\\
+    \end{align}
+    and
+    \begin{align}
         UG^{-1}
          & =X^{-1}U.
     \end{align}

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -98,7 +98,8 @@ Listed for completeness; detailed MPDO coverage audit is out of scope.
 
 | Paper label | Lines | Paper description | Lean location | Status |
 |---|---|---|---|---|
-| Defn CFII (l.1058) | 1058–1060 | CFII: CF + trace-preserving CPM + full-rank diagonal fixed point | `TNLean/MPS/CanonicalForm/Existence.lean` (`CFII` data) | `leanok` |
+| Defn CFII (l.1058) | 1058–1071 | CFII: CF + trace-preserving CPM + full-rank diagonal fixed point | `TNLean/MPS/CanonicalForm/Definitions.lean` (`CPSVCanonicalFormIIData`) | `leanok` |
+| Eq. `II_XAX` | 1072–1077 | Every CF tensor has a nonsingular same-ambient gauge representative in CFII | `TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean` (`CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII`) | `leanok` |
 | **Lemma `equalMPS`** (l.1080) | 1080–1091 | Two NMPVs: overlap → 0 or 1; if 1, gauge-phase equivalent | `TNLean/MPS/Overlap/NormalTensorDichotomy.lean` (`IsNormalTensor.overlap_dichotomy`) | `leanok` |
 | **Corollary `eqV`** (l.1121) | 1121–1128 | NMPV overlap → 0 or equal up to phase factor e^{iφN} | `TNLean/MPS/Overlap/NormalTensorDichotomy.lean` (`IsNormalTensor.mpv_phase_alternative`) | `leanok` |
 | **Corollary `Lem1`** (l.1131) | 1131–1133 | Orthogonal NMPVs are eventually linearly independent | `TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean` (`exists_eventually_linearIndependent_of_tp_primitive_irr_blocks_of_blocksNotGaugePhaseEquiv`) | `leanok` |


### PR DESCRIPTION
## What changed

- add the source-facing theorem that every literal CPSV canonical-form tensor is gauge-equivalent, in the same ambient bond dimension, to a literal canonical-form-II tensor;
- normalize each retained normal block by its Perron trace-preserving gauge and diagonal positive fixed-point gauge, then assemble the block gauges;
- extend the retained gauge across omitted zero coordinates by
  \[
  G=U^\dagger XU+(I-U^\dagger U),
  \qquad
  G^{-1}=U^\dagger X^{-1}U+(I-U^\dagger U);
  \]
- add the reusable coisometric gauge-extension API and synchronize Chapter 9 plus the CPSV Appendix-A coverage table.

This is CPSV16 Appendix A, lines 1058–1077, especially `eq:II_TPLambda` and `eq:II_XAX`. It introduces no weight ordering, per-block unit-weight hypothesis, retired one-copy BNT adapter, or asymptotic projection argument.

## Validation

- `lake build TNLean.MPS.CanonicalForm.CPSVCanonicalFormII TNLean.MPS.CanonicalForm` — 8,904 jobs, passed
- `lake build` — 9,752 jobs, passed
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` — passed
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — 5,621/5,624 theorem-like entries complete; passed
- `cd blueprint && leanblueprint checkdecls` — passed
- double `lualatex` with `TEXINPUTS='../../tex/tenkz//:'` — passed; 0 undefined cross-references
- independent Lean/source review — no substantive findings; empty retained family and proper omitted-complement cases checked
- independent blueprint review — no substantive findings
- `git diff --check` — passed

Closes #4912

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics on canonical-form gauge normalization; no runtime, auth, or data-path changes. Risk is proof-maintenance and dependency on existing CFII/block-gauge lemmas.
> 
> **Overview**
> Formalizes **CPSV Appendix A eq. `II_XAX`**: every tensor in literal CPSV canonical form has a **same bond-dimension** nonsingular gauge representative in **canonical form II**.
> 
> Adds `TNLean/MPS/CanonicalForm/CPSVCanonicalFormII.lean` with **`coisometryExtendGL`** (extend a retained-space gauge by identity on the orthogonal complement of the ambient coisometry) and the main existence theorems `CPSVCanonicalFormData.exists_gaugeEquiv_canonicalFormII` / `IsCPSVCanonicalForm.exists_gaugeEquiv_canonicalFormII`. The construction normalizes each retained normal block via Perron TP gauge plus CFII diagonal fixed-point data, assembles **`globalGaugeOfBlocks`**, then lifts to ambient dimension with **`Uᴴ X U + (1 - Uᴴ U)`**.
> 
> Chapter 9 blueprint gains **`thm:cpsv_cf_to_cfii_gauge`** with a proof sketch; the MPS–FT coverage audit marks eq. `II_XAX` as **`leanok`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391144f4b817a42c2351a6a985a5ac24bc6c0f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->