### PR TITLE
refactor(MPS/Examples): factor projective multiplication

### DIFF
--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -358,13 +358,19 @@ private def clusterGaugeZ : GL (Fin 2) ℂ :=
     (clusterGaugeZ : Matrix (Fin 2) (Fin 2) ℂ) = !![1, 0; 0, -1] :=
   Matrix.GeneralLinearGroup.val_mkOfDetNeZero _ _
 
+private lemma clusterGaugeZ_sq :
+    (!![(1 : ℂ), 0; 0, -1] : Matrix (Fin 2) (Fin 2) ℂ) *
+        !![(1 : ℂ), 0; 0, -1] = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two]
+
 private lemma clusterGaugeZ_inv_val :
     ((clusterGaugeZ⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) = !![1, 0; 0, -1] := by
   have hsq : clusterGaugeZ * clusterGaugeZ = 1 := by
     apply Units.ext
     simp only [Units.val_mul, Units.val_one, clusterGaugeZ_val]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [Matrix.mul_apply, Fin.sum_univ_two]
+    exact clusterGaugeZ_sq
   rw [show clusterGaugeZ⁻¹ = clusterGaugeZ from inv_eq_of_mul_eq_one_right hsq,
     clusterGaugeZ_val]
 
@@ -412,6 +418,10 @@ lemma cluster_gauge_anticomm :
     (!![(1 : ℂ), 0; 0, -1]) * pauliX = -(pauliX * !![(1 : ℂ), 0; 0, -1]) := by
   ext i j; fin_cases i <;> fin_cases j <;>
     simp [pauliX, Matrix.mul_apply, Fin.sum_univ_two, Matrix.neg_apply, Matrix.of_apply]
+
+private lemma cluster_gauge_anticomm' :
+    pauliX * !![(1 : ℂ), 0; 0, -1] = -(!![(1 : ℂ), 0; 0, -1] * pauliX) := by
+  simpa using (congrArg Neg.neg cluster_gauge_anticomm).symm
 
 /-! #### Gauge equivalences for the three nontrivial group elements -/
 
@@ -505,22 +515,20 @@ open TNLean.Algebra in
 def clusterProjRep : ProjectiveRepresentation (D := 2) clusterOmega where
   X := clusterRepX
   map_mul' g h := by
-    have hX : pauliX = !![(0 : ℂ), 1; 1, 0] := by
-      ext a b; fin_cases a <;> fin_cases b <;> simp [pauliX, Matrix.of_apply]
-    rcases zmod2sq_cases g with rfl | rfl | rfl | rfl <;>
-      rcases zmod2sq_cases h with rfl | rfl | rfl | rfl <;>
-      rw [clusterOmega_apply_val] <;>
-      simp only [clusterRepX, ← ofAdd_add, Prod.mk_add_mk, toAdd_ofAdd, toAdd_one,
-        Units.val_mul, Units.val_one, clusterGaugeZ_val, clusterGaugeX_val, hX,
-        show (1 : ZMod 2) + 1 = 0 from by decide, show (0 : ZMod 2) + 1 = 1 from by decide,
-        show (1 : ZMod 2) + 0 = 1 from by decide, show (0 : ZMod 2) + 0 = 0 from by decide,
-        one_ne_zero, ↓reduceIte, and_self, and_true, true_and,
-        mul_one, one_mul] <;>
-      (ext a b; fin_cases a <;> fin_cases b <;>
-        simp only [Matrix.mul_apply, Fin.sum_univ_two, Matrix.smul_apply, Matrix.one_apply,
-          smul_eq_mul, Matrix.of_apply, Matrix.cons_val', Matrix.cons_val_zero,
-          Matrix.cons_val_one, Matrix.empty_val', Matrix.cons_val_fin_one,
-          Fin.mk_zero] <;> norm_num)
+    rw [clusterOmega_apply_val]
+    have hZ (p : Prop) [Decidable p] :
+        ((if p then 1 else clusterGaugeZ : GL (Fin 2) ℂ) :
+          Matrix (Fin 2) (Fin 2) ℂ) =
+          if p then 1 else !![(1 : ℂ), 0; 0, -1] := by
+      split <;> simp
+    have hX (p : Prop) [Decidable p] :
+        ((if p then 1 else clusterGaugeX : GL (Fin 2) ℂ) :
+          Matrix (Fin 2) (Fin 2) ℂ) =
+          if p then 1 else pauliX := by
+      split <;> simp
+    simp only [clusterRepX, Units.val_mul, hZ, hX]
+    exact mul_of_anticommuting_involutions _ _ clusterGaugeZ_sq pauliX_sq
+      cluster_gauge_anticomm' g h
 
 open TNLean.Algebra in
 /-- `clusterOmega` is a genuine `2`-cocycle: it is the factor system of the

--- a/TNLean/MPS/Examples/ZMod2.lean
+++ b/TNLean/MPS/Examples/ZMod2.lean
@@ -131,4 +131,43 @@ lemma ofCommutingInvolutions_mul_conjTranspose (P₁ P₂ : Matrix n n ℂ)
       mul_assoc P₁ P₂ ((P₂)ᴴ * (P₁)ᴴ), ← mul_assoc P₂ (P₂)ᴴ (P₁)ᴴ,
       h₂U, one_mul, h₁U]
 
+/-- Two anticommuting involutions obey the standard `Z₂ × Z₂` projective
+multiplication law with factor `(-1)^(g₂ h₁)`. -/
+lemma mul_of_anticommuting_involutions (P₁ P₂ : Matrix n n ℂ)
+    (h₁ : P₁ * P₁ = 1) (h₂ : P₂ * P₂ = 1) (hc : P₂ * P₁ = -(P₁ * P₂))
+    (g h : Multiplicative (ZMod 2 × ZMod 2)) :
+    ((if (Multiplicative.toAdd g).1 = 0 then 1 else P₁) *
+          (if (Multiplicative.toAdd g).2 = 0 then 1 else P₂)) *
+        ((if (Multiplicative.toAdd h).1 = 0 then 1 else P₁) *
+          (if (Multiplicative.toAdd h).2 = 0 then 1 else P₂)) =
+      (if (Multiplicative.toAdd g).2 = 1 ∧ (Multiplicative.toAdd h).1 = 1
+        then (-1 : ℂ) else 1) •
+        ((if (Multiplicative.toAdd (g * h)).1 = 0 then 1 else P₁) *
+          (if (Multiplicative.toAdd (g * h)).2 = 0 then 1 else P₂)) := by
+  rcases zmod2sq_cases g with rfl | rfl | rfl | rfl <;>
+    rcases zmod2sq_cases h with rfl | rfl | rfl | rfl <;>
+    simp only [← ofAdd_add, Prod.mk_add_mk, toAdd_ofAdd, toAdd_one,
+      Prod.fst_zero, Prod.snd_zero,
+      show (1 : ZMod 2) + 1 = 0 from by decide,
+      show (0 : ZMod 2) + 1 = 1 from by decide,
+      show (1 : ZMod 2) + 0 = 1 from by decide,
+      show (0 : ZMod 2) + 0 = 0 from by decide,
+      one_ne_zero, zero_ne_one, ↓reduceIte, and_self, and_true, true_and,
+      mul_one, one_mul, one_smul, neg_one_smul] <;>
+    first
+    | exact h₁
+    | exact h₂
+    | exact hc
+    | rw [← mul_assoc, h₁, one_mul]
+    | rw [mul_assoc, h₂, mul_one]
+    | rw [hc, ← mul_assoc, h₁, one_mul]
+    | rw [← mul_assoc, hc, neg_mul, mul_assoc, h₂, mul_one]
+    | rw [mul_assoc, hc, mul_neg, ← mul_assoc, h₁, one_mul]
+    | rw [mul_neg, h₁]
+    | rw [← mul_assoc, hc, neg_mul, mul_assoc, h₂, mul_one]
+    | rw [mul_assoc, hc, mul_neg, ← mul_assoc, h₁, one_mul]
+    | rw [mul_assoc, hc, mul_neg, ← mul_assoc, h₁, one_mul]
+    | rw [mul_assoc, ← mul_assoc P₂ P₁ P₂, hc, neg_mul, mul_assoc P₁ P₂ P₂,
+        h₂, mul_one, mul_neg, h₁]
+
 end MPSTensor

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -90,6 +90,16 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Anticommuting-involution projective multiplication
+- **Pattern:** split both `Z₂ × Z₂` inputs into sixteen cases, expand two concrete
+  `2 × 2` matrices entrywise, and normalize every resulting scalar expression.
+- **Reuse:** `mul_of_anticommuting_involutions` in `MPS/Examples/ZMod2.lean`
+  proves the multiplication table once from the two involution laws and their
+  anticommutation law. `clusterProjRep` now supplies only those three relations.
+- **Result:** the concrete sixteen-case proof in `MPS/Examples/Cluster.lean`
+  is replaced by one exact application; its previously profiled 31-second
+  declaration falls below the 200-millisecond profiler threshold.
+
 ### Support left-right and relative-modular intertwining
 - **Pattern:** `supportRelativeModular_sourceB_solution` and
   `supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular`


### PR DESCRIPTION
## What changed

- add a reusable multiplication-table theorem for a pair of anticommuting involutions carrying the standard `Z₂ × Z₂` factor system
- replace `clusterProjRep.map_mul'`'s sixteen entrywise `2 × 2` matrix checks with one exact application of that theorem
- reuse the cluster `σz² = 1` relation and document the completed proof-pattern refactor

## Why

The definitive main-branch census reported `TNLean.MPS.Examples.Cluster` at 33 seconds. Declaration profiling isolated `clusterProjRep` at about 31.1 seconds: it expanded both group elements into sixteen cases and normalized each concrete matrix entry separately.

The refactored declaration falls below the 200 ms profiler threshold. The local Lake target is proof-clean and green; its final wall time was distorted by severe concurrent CPU contention, so exact-head CI is the authoritative module timing gate.

## Validation

- `lake build TNLean.MPS.Examples.ZMod2`
- `lake env lean TNLean/MPS/Examples/Cluster.lean`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- proof-integrity scan for `sorry`, `admit`, `native_decide`, `unsafeCast`, and `axiom`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor only: same mathematical claims with a shared lemma and faster elaboration; no auth, API, or runtime behavior changes.
> 
> **Overview**
> Adds **`mul_of_anticommuting_involutions`** in `ZMod2.lean`, which proves the standard `Z₂ × Z₂` projective multiplication table (factor `(-1)^{g₂ h₁}`) once from involution and anticommutation laws.
> 
> **`clusterProjRep.map_mul'`** no longer case-splits both group elements and normalizes `2×2` entries; it unfolds the gauge matrices and applies that theorem via `clusterGaugeZ_sq`, `pauliX_sq`, and **`cluster_gauge_anticomm'`** (a symmetric variant of the existing anticommutation lemma). **`clusterGaugeZ_inv_val`** reuses the new **`clusterGaugeZ_sq`** instead of inlining the squaring proof.
> 
> `docs/tactic_patterns.md` records this as a completed proof-pattern refactor (previously ~31s declaration now below the profiler threshold).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1c0020af796ab9c3f5a642f7e12bfdd1753b38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->