### PR TITLE
fix(tests/tenkz/rmp): redraw the seven residual section-III panels against their sources

### DIFF
--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -831,3 +831,40 @@ needs one recomputation on the final tree, and the number recorded here is
 correct for this branch alone.
 
 Census-correction: #4709
+
+### 2026-07-26 — the section-III sweep prices two more gaps
+
+M3, escape usage, rises from 326 to 331. Four of the five occurrences are
+two `out=`/`in=` pairs in the historical composite, whose two red boundary
+strings each sweep around a panel and must be hand-routed — the same
+strings gap the two entries above price, met again in the one figure the
+corpus had been drawing as something else entirely. The fifth is one
+`plane rise=` override in the anyon pair: the site label has exactly one
+bearing, hard-coded to the north-east quadrant, so the only way to clear a
+label from an oblique sheet's converging legs is to reshear the whole
+sheet. A per-site label bearing would retire that occurrence; the gap is
+tracked with the sweep's follow-up issues.
+
+M4, mean lines per case, rises from 14.88 to 15.88. Seven panels were
+redrawn against their sources and six of them grew, the GHZ brick patch
+most of all: the source builds it from four foreach loops, and the free
+genre has no repetition form, so the masonry is transcribed element-wise.
+Each of the seven now draws what its source asserts — a doubled string
+instead of one, a masonry patch instead of a blocking cartoon, an
+orthogonal isometry reduction instead of an invented operator box — and
+a figure that stops drawing less than its source gains lines.
+
+Census-correction: #4709
+
+One flag is newly raised by this sweep and answered here. The sweep
+removed two of `outer legs=`'s three demand-corpus consumers, because both
+spelt a boundary their sources do not draw — the key was standing in for
+pictures that have since been redrawn from the sources directly.
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:picture:outer legs | keep-because: its one remaining consumer is a manifest-paired fixture, and losing case consumers to *more faithful* drawings is not evidence against the key — it is evidence the two departed cases never needed it; it earns new consumers with the redraw campaign or dies at the 0.8 close; expiry 0.8 |
+| flag:consumers:key:object:down at | keep-because: the reduction proof no longer spells its isometry with `down at=`, which drops the key to two consumers on the same more-faithful-drawing grounds as the row above; same tenure terms; expiry 0.8 |
+| flag:lonely-type:positive-integer|role-list | keep-because: the union type serves `sheets=` alone now that the condensation panel left the planes genre for the oblique sheet; the type is the planes genre's spelling and follows that genre's fate at the front-end consolidation; expiry 0.8 |
+
+No ledger row changes and no other flag verdict is re-examined here.

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -1,41 +1,41 @@
 {
- "m1_census": {
-  "definition": "registry key rows per ledger plus public commands and environments; kernel is one-in-one-out and the total never rises between shrink sessions",
-  "value": {
-   "alias": 6,
-   "commands": 25,
-   "environments": 6,
-   "escape": 9,
-   "kernel": 134,
-   "sugar": 12
+  "m1_census": {
+    "definition": "registry key rows per ledger plus public commands and environments; kernel is one-in-one-out and the total never rises between shrink sessions",
+    "value": {
+      "alias": 6,
+      "commands": 25,
+      "environments": 6,
+      "escape": 9,
+      "kernel": 134,
+      "sugar": 12
+    }
+  },
+  "m2_parser_paths": {
+    "definition": "public leaf keys installed by the TeX parsers; identity changes require an Extension-gate citation",
+    "identity_sha256": "2211ae44094d79bd70a91ca07267f0f9b94c9743e278d9fb5ca60947d31694df",
+    "value": 217
+  },
+  "m3_escape_usage": {
+    "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",
+    "value": 331
+  },
+  "m4_lines_per_case": {
+    "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",
+    "value": 15.88
+  },
+  "m5_aliases": {
+    "definition": "key and value alias rows plus sunset compliance; near zero at the 1.0 freeze",
+    "value": {
+      "count": 7,
+      "missing_sunset": 0
+    }
+  },
+  "m6_overloads": {
+    "definition": "names with several value types + union types + enum words shared across enums; must never rise",
+    "value": {
+      "multi_typed_names": 4,
+      "shared_enum_words": 7,
+      "union_types": 1
+    }
   }
- },
- "m2_parser_paths": {
-  "definition": "public leaf keys installed by the TeX parsers; identity changes require an Extension-gate citation",
-  "identity_sha256": "2211ae44094d79bd70a91ca07267f0f9b94c9743e278d9fb5ca60947d31694df",
-  "value": 217
- },
- "m3_escape_usage": {
-  "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",
-  "value": 326
- },
- "m4_lines_per_case": {
-  "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",
-  "value": 14.88
- },
- "m5_aliases": {
-  "definition": "key and value alias rows plus sunset compliance; near zero at the 1.0 freeze",
-  "value": {
-   "count": 7,
-   "missing_sunset": 0
-  }
- },
- "m6_overloads": {
-  "definition": "names with several value types + union types + enum words shared across enums; must never rise",
-  "value": {
-   "multi_typed_names": 4,
-   "shared_enum_words": 7,
-   "union_types": 1
-  }
- }
 }

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-state.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-state.tex
@@ -6,13 +6,83 @@
 %   III/ImagesReview Section III.tex lines 329-356
 % Capabilities: lattice, typed-ports
 \[
-\begin{tenkzlattice}[rows=6, cols=6, outer legs=both]
-  % blocked sites (2i-1..2i, 2j-1..2j), i,j = 1..3
-  \tnregion[slot=selected]{(1-2,1-2)} \tnregion[slot=selected]{(1-2,3-4)}
-  \tnregion[slot=selected]{(1-2,5-6)}
-  \tnregion[slot=selected]{(3-4,1-2)} \tnregion[slot=selected]{(3-4,3-4)}
-  \tnregion[slot=selected]{(3-4,5-6)}
-  \tnregion[slot=selected]{(5-6,1-2)} \tnregion[slot=selected]{(5-6,3-4)}
-  \tnregion[slot=selected]{(5-6,5-6)}
-\end{tenkzlattice}
+  \begin{tenkzfree}
+    \tnjoin{-5mm,0mm}{5mm,0mm}  \tnjoin{0mm,0mm}{0mm,-5mm}
+    \tnjoin{0mm,0mm}{2mm,2mm}  \tnjoin{-5mm,-10mm}{5mm,-10mm}
+    \tnjoin{0mm,-10mm}{0mm,-5mm}  \tnjoin{0mm,-10mm}{2mm,-8mm}
+    \tnjoin{-5mm,20mm}{5mm,20mm}  \tnjoin{0mm,20mm}{0mm,15mm}
+    \tnjoin{0mm,20mm}{2mm,22mm}  \tnjoin{-5mm,10mm}{5mm,10mm}
+    \tnjoin{0mm,10mm}{0mm,15mm}  \tnjoin{0mm,10mm}{2mm,12mm}
+    \tnjoin{-5mm,40mm}{5mm,40mm}  \tnjoin{0mm,40mm}{0mm,35mm}
+    \tnjoin{0mm,40mm}{2mm,42mm}  \tnjoin{-5mm,30mm}{5mm,30mm}
+    \tnjoin{0mm,30mm}{0mm,35mm}  \tnjoin{0mm,30mm}{2mm,32mm}
+    \tnjoin{15mm,0mm}{25mm,0mm}  \tnjoin{20mm,0mm}{20mm,-5mm}
+    \tnjoin{20mm,0mm}{22mm,2mm}  \tnjoin{15mm,-10mm}{25mm,-10mm}
+    \tnjoin{20mm,-10mm}{20mm,-5mm}  \tnjoin{20mm,-10mm}{22mm,-8mm}
+    \tnjoin{15mm,20mm}{25mm,20mm}  \tnjoin{20mm,20mm}{20mm,15mm}
+    \tnjoin{20mm,20mm}{22mm,22mm}  \tnjoin{15mm,10mm}{25mm,10mm}
+    \tnjoin{20mm,10mm}{20mm,15mm}  \tnjoin{20mm,10mm}{22mm,12mm}
+    \tnjoin{15mm,40mm}{25mm,40mm}  \tnjoin{20mm,40mm}{20mm,35mm}
+    \tnjoin{20mm,40mm}{22mm,42mm}  \tnjoin{15mm,30mm}{25mm,30mm}
+    \tnjoin{20mm,30mm}{20mm,35mm}  \tnjoin{20mm,30mm}{22mm,32mm}
+    \tnjoin{35mm,0mm}{45mm,0mm}  \tnjoin{40mm,0mm}{40mm,-5mm}
+    \tnjoin{40mm,0mm}{42mm,2mm}  \tnjoin{35mm,-10mm}{45mm,-10mm}
+    \tnjoin{40mm,-10mm}{40mm,-5mm}  \tnjoin{40mm,-10mm}{42mm,-8mm}
+    \tnjoin{35mm,20mm}{45mm,20mm}  \tnjoin{40mm,20mm}{40mm,15mm}
+    \tnjoin{40mm,20mm}{42mm,22mm}  \tnjoin{35mm,10mm}{45mm,10mm}
+    \tnjoin{40mm,10mm}{40mm,15mm}  \tnjoin{40mm,10mm}{42mm,12mm}
+    \tnjoin{35mm,40mm}{45mm,40mm}  \tnjoin{40mm,40mm}{40mm,35mm}
+    \tnjoin{40mm,40mm}{42mm,42mm}  \tnjoin{35mm,30mm}{45mm,30mm}
+    \tnjoin{40mm,30mm}{40mm,35mm}  \tnjoin{40mm,30mm}{42mm,32mm}
+    \tnjoin{5mm,10mm}{15mm,10mm}  \tnjoin{10mm,10mm}{10mm,5mm}
+    \tnjoin{10mm,10mm}{12mm,12mm}  \tnjoin{5mm,0mm}{15mm,0mm}
+    \tnjoin{10mm,0mm}{10mm,5mm}  \tnjoin{10mm,0mm}{12mm,2mm}
+    \tnjoin{5mm,30mm}{15mm,30mm}  \tnjoin{10mm,30mm}{10mm,25mm}
+    \tnjoin{10mm,30mm}{12mm,32mm}  \tnjoin{5mm,20mm}{15mm,20mm}
+    \tnjoin{10mm,20mm}{10mm,25mm}  \tnjoin{10mm,20mm}{12mm,22mm}
+    \tnjoin{25mm,10mm}{35mm,10mm}  \tnjoin{30mm,10mm}{30mm,5mm}
+    \tnjoin{30mm,10mm}{32mm,12mm}  \tnjoin{25mm,0mm}{35mm,0mm}
+    \tnjoin{30mm,0mm}{30mm,5mm}  \tnjoin{30mm,0mm}{32mm,2mm}
+    \tnjoin{25mm,30mm}{35mm,30mm}  \tnjoin{30mm,30mm}{30mm,25mm}
+    \tnjoin{30mm,30mm}{32mm,32mm}  \tnjoin{25mm,20mm}{35mm,20mm}
+    \tnjoin{30mm,20mm}{30mm,25mm}  \tnjoin{30mm,20mm}{32mm,22mm}
+    \tnjoin{45mm,10mm}{55mm,10mm}  \tnjoin{50mm,10mm}{50mm,5mm}
+    \tnjoin{50mm,10mm}{52mm,12mm}  \tnjoin{45mm,0mm}{55mm,0mm}
+    \tnjoin{50mm,0mm}{50mm,5mm}  \tnjoin{50mm,0mm}{52mm,2mm}
+    \tnjoin{45mm,30mm}{55mm,30mm}  \tnjoin{50mm,30mm}{50mm,25mm}
+    \tnjoin{50mm,30mm}{52mm,32mm}  \tnjoin{45mm,20mm}{55mm,20mm}
+    \tnjoin{50mm,20mm}{50mm,25mm}  \tnjoin{50mm,20mm}{52mm,22mm}
+    \tnjoin{5mm,-10mm}{15mm,-10mm}  \tnjoin{10mm,-10mm}{10mm,-15mm}
+    \tnjoin{10mm,-10mm}{12mm,-8mm}  \tnjoin{5mm,40mm}{15mm,40mm}
+    \tnjoin{10mm,40mm}{10mm,45mm}  \tnjoin{10mm,40mm}{12mm,42mm}
+    \tnjoin{25mm,-10mm}{35mm,-10mm}  \tnjoin{30mm,-10mm}{30mm,-15mm}
+    \tnjoin{30mm,-10mm}{32mm,-8mm}  \tnjoin{25mm,40mm}{35mm,40mm}
+    \tnjoin{30mm,40mm}{30mm,45mm}  \tnjoin{30mm,40mm}{32mm,42mm}
+    \tnjoin{45mm,-10mm}{55mm,-10mm}  \tnjoin{50mm,-10mm}{50mm,-15mm}
+    \tnjoin{50mm,-10mm}{52mm,-8mm}  \tnjoin{45mm,40mm}{55mm,40mm}
+    \tnjoin{50mm,40mm}{50mm,45mm}  \tnjoin{50mm,40mm}{52mm,42mm}
+    \tnput[dot]{b1}{(5mm,40mm)}{}  \tnput[dot]{b2}{(15mm,40mm)}{}
+    \tnput[dot]{b3}{(25mm,40mm)}{}  \tnput[dot]{b4}{(35mm,40mm)}{}
+    \tnput[dot]{b5}{(45mm,40mm)}{}  \tnput[dot]{b6}{(0mm,35mm)}{}
+    \tnput[dot]{b7}{(20mm,35mm)}{}  \tnput[dot]{b8}{(40mm,35mm)}{}
+    \tnput[dot]{b9}{(5mm,30mm)}{}  \tnput[dot]{b10}{(15mm,30mm)}{}
+    \tnput[dot]{b11}{(25mm,30mm)}{}  \tnput[dot]{b12}{(35mm,30mm)}{}
+    \tnput[dot]{b13}{(45mm,30mm)}{}  \tnput[dot]{b14}{(10mm,25mm)}{}
+    \tnput[dot]{b15}{(30mm,25mm)}{}  \tnput[dot]{b16}{(50mm,25mm)}{}
+    \tnput[dot]{b17}{(5mm,20mm)}{}  \tnput[dot]{b18}{(15mm,20mm)}{}
+    \tnput[dot]{b19}{(25mm,20mm)}{}  \tnput[dot]{b20}{(35mm,20mm)}{}
+    \tnput[dot]{b21}{(45mm,20mm)}{}  \tnput[dot]{b22}{(0mm,15mm)}{}
+    \tnput[dot]{b23}{(20mm,15mm)}{}  \tnput[dot]{b24}{(40mm,15mm)}{}
+    \tnput[dot]{b25}{(5mm,10mm)}{}  \tnput[dot]{b26}{(15mm,10mm)}{}
+    \tnput[dot]{b27}{(25mm,10mm)}{}  \tnput[dot]{b28}{(35mm,10mm)}{}
+    \tnput[dot]{b29}{(45mm,10mm)}{}  \tnput[dot]{b30}{(10mm,5mm)}{}
+    \tnput[dot]{b31}{(30mm,5mm)}{}  \tnput[dot]{b32}{(50mm,5mm)}{}
+    \tnput[dot]{b33}{(5mm,0mm)}{}  \tnput[dot]{b34}{(15mm,0mm)}{}
+    \tnput[dot]{b35}{(25mm,0mm)}{}  \tnput[dot]{b36}{(35mm,0mm)}{}
+    \tnput[dot]{b37}{(45mm,0mm)}{}  \tnput[dot]{b38}{(0mm,-5mm)}{}
+    \tnput[dot]{b39}{(20mm,-5mm)}{}  \tnput[dot]{b40}{(40mm,-5mm)}{}
+    \tnput[dot]{b41}{(5mm,-10mm)}{}  \tnput[dot]{b42}{(15mm,-10mm)}{}
+    \tnput[dot]{b43}{(25mm,-10mm)}{}  \tnput[dot]{b44}{(35mm,-10mm)}{}
+    \tnput[dot]{b45}{(45mm,-10mm)}{}
+  \end{tenkzfree}
 \]

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-proof-one.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-proof-one.tex
@@ -6,12 +6,26 @@
 %   III/ImagesReview Section III.tex lines 363-375
 % Capabilities: grid, local-intertwiner, equation-composition
 \[
-  \begin{tenkz}[rows={op:none, op:operator}, tensor style=box]
-    \tn{O_\alpha} & \tn[pill, up at=1, down at=1]{V_\alpha}\\
-    \tn{A} &
-  \end{tenkz}
+  \begin{tenkzfree}[tensor style=box]
+    \tnput[pill]{V}{(16mm,0mm)}{V_\alpha}
+    \tnput[box]{a}{($(V.north west)+(-12mm,0mm)$)}{\alpha}
+    \tnput[dot]{d}{($(V.south west)+(-12mm,0mm)$)}{}
+    \tnjoin{a.east}{V.north west}
+    \tnjoin{d.east}{V.south west}
+    \tnjoin{$(a.west)+(-12mm,0mm)$}{a.west}
+    \tnjoin{a.north}{$(a.north)+(0mm,7mm)$}
+    \tnjoin{$(d.west)+(-12mm,0mm)$}{d.west}
+    \tnjoin{d.north}{a.south}
+    \tnjoin{V.east}{$(V.east)+(12mm,0mm)$}
+  \end{tenkzfree}
   =
-  \begin{tenkz}[physical=up, tensor style=box]
-    \tn{A}
-  \end{tenkz}.
+  \begin{tenkzfree}[tensor style=box]
+    \tnput[pill]{V}{(0mm,0mm)}{V_\alpha}
+    \tnput[dot]{d}{($(V.east)+(16mm,0mm)$)}{}
+    \tnjoin{V.east}{d.west}
+    \tnjoin{$(V.north west)+(-12mm,0mm)$}{V.north west}
+    \tnjoin{$(V.south west)+(-12mm,0mm)$}{V.south west}
+    \tnjoin{d.north}{$(d.north)+(0mm,7mm)$}
+    \tnjoin{d.east}{$(d.east)+(12mm,0mm)$}
+  \end{tenkzfree}.
 \]

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-historical-composite.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-historical-composite.tex
@@ -5,9 +5,56 @@
 % Source: author source ImagesReview Section III/ImagesReview Section III.tex lines
 %   170-197; archival output ImagesReview Section III.pdf
 % Capabilities: lattice, regions, typed-ports
+% Note: `ring' with no role renders as a red (tenkzAction) stadium, always,
+%   regardless of role -- the on-wire-matrix style hardcodes draw=tenkzAction
+%   and only a role override (draw=<role colour> appended after) changes it.
+%   role=passive is the only role that yields an unhued (grey, not
+%   red/blue/violet) outline; no public skin gives a true circle in plain
+%   tenkzInk black with an inscribed label (`dot' is solid-filled with an
+%   EXTERNAL label, not inscribed; `pill'/`box' are plain black but a
+%   rounded/sharp rectangle, not a circle). role=passive on `ring' is kept
+%   as the closest available compromise (unhued, oval, label inside).
 \[
-  \begin{tenkzlattice}[rows=2, cols=2, frame=oblique,
-                           physical=up, outer legs=both]
-    \tnsite{(1,1)}
-\end{tenkzlattice}
+  \begin{tenkzfree}
+    \tnput[box]{n}{(0mm,8mm)}{} \tnput[box]{e}{(8mm,0mm)}{}
+    \tnput[box]{s}{(0mm,-8mm)}{} \tnput[box]{w}{(-8mm,0mm)}{}
+    \tnput[ring, role=passive]{lam}{(-8mm,8mm)}{\lambda}
+    \tnput[box]{top}{(0mm,16mm)}{} \tnput[box]{left}{(-16mm,0mm)}{}
+    % the four-tensor ring: n-e and e-s turn at the plaquette's own corners;
+    % w-n is routed explicitly through the lambda intertwiner. The whole
+    % ring is role=operator (red), matching the author block.
+    \tnjoin[route=hv,role=operator]{n.east}{e.north}
+    \tnjoin[route=vh,role=operator]{e.south}{s.east}
+    \tnjoin[route=hv,role=operator]{s.west}{w.south}
+    \tnjoin[role=operator]{w.north}{lam.south}
+    \tnjoin[role=operator]{lam.east}{n.west}
+    % the two pendant actions feed INTO the ring on this panel
+    \tnjoin[dir]{top.south}{n.north} \tnjoin{top.north}{0mm,20mm}
+    \tnjoin[dir]{left.east}{w.west} \tnjoin{left.west}{-20mm,0mm}
+    % the ring's own open half-edges leave outward
+    \tnjoin[dir]{s.south}{0mm,-12mm}
+    \tnjoin[dir]{e.east}{12mm,0mm}
+    % the boundary string sweeps around the top-left, outside the ring
+    \tnjoin[route=arc,out=90,in=180,role=operator]{left.north}{top.west}
+  \end{tenkzfree}
+  \;=\;
+  \begin{tenkzfree}
+    \tnput[box]{n}{(0mm,8mm)}{} \tnput[box]{e}{(8mm,0mm)}{}
+    \tnput[box]{s}{(0mm,-8mm)}{} \tnput[box]{w}{(-8mm,0mm)}{}
+    \tnput[ring, role=passive]{lam}{(-8mm,8mm)}{\lambda}
+    \tnput[box]{bottom}{(0mm,-16mm)}{} \tnput[box]{right}{(16mm,0mm)}{}
+    \tnjoin[route=hv,role=operator]{n.east}{e.north}
+    \tnjoin[route=vh,role=operator]{e.south}{s.east}
+    \tnjoin[route=hv,role=operator]{s.west}{w.south}
+    \tnjoin[role=operator]{w.north}{lam.south}
+    \tnjoin[role=operator]{lam.east}{n.west}
+    % the ring's own open half-edges arrive from outward
+    \tnjoin[dir]{0mm,12mm}{n.north}
+    \tnjoin[dir]{-12mm,0mm}{w.west}
+    % the two pendant actions drain OUT of the ring on this panel
+    \tnjoin[dir]{s.south}{bottom.north} \tnjoin{bottom.south}{0mm,-20mm}
+    \tnjoin[dir]{e.east}{right.west} \tnjoin{right.east}{20mm,0mm}
+    % the boundary string sweeps around the bottom-right, outside the ring
+    \tnjoin[route=arc,out=270,in=0,role=operator]{right.south}{bottom.east}
+  \end{tenkzfree}
 \]

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-peps-renormalization-one.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-peps-renormalization-one.tex
@@ -7,11 +7,12 @@
 % Capabilities: free-graph, four-site-plaquette, renormalization
 \[
   \begin{tenkzfree}
-    \tnput[box]{n}{(0mm,8mm)}{} \tnput[box]{e}{(8mm,0mm)}{}
-    \tnput[box]{s}{(0mm,-8mm)}{} \tnput[box]{w}{(-8mm,0mm)}{}
-    \tnjoin{n.east}{e.north} \tnjoin{e.south}{s.east}
-    \tnjoin{s.west}{w.south} \tnjoin{w.north}{n.west}
-    \tnjoin{n.north}{0mm,16mm} \tnjoin{e.east}{16mm,0mm}
-    \tnjoin{0mm,-16mm}{s.south} \tnjoin{-16mm,0mm}{w.west}
+    % each side is one fused (paired/hatched) bond spanning tail-to-tail; the
+    % four sides cross pairwise at the square's corners -- a bare square of
+    % bonds, matching the author block, which places no tensor here.
+    \tnjoin[fused]{-12mm,8mm}{12mm,8mm}
+    \tnjoin[fused]{-12mm,-8mm}{12mm,-8mm}
+    \tnjoin[fused]{8mm,-12mm}{8mm,12mm}
+    \tnjoin[fused]{-8mm,-12mm}{-8mm,12mm}
   \end{tenkzfree}.
 \]

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-peps-renormalization-two.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-peps-renormalization-two.tex
@@ -6,11 +6,30 @@
 %   lines 631-643; archival output PEPSrenom2.pdf
 % Capabilities: lattice, blocking, equation-composition
 \[
-  \begin{tenkzlattice}[rows=2,cols=2,frame=oblique,outer legs=both]
-    \tnsite{(1,1)} \tnsite{(1,2)} \tnsite{(2,1)} \tnsite{(2,2)}
-  \end{tenkzlattice}
-  \longmapsto
-  \begin{tenkzlattice}[rows=1,cols=1,frame=oblique,outer legs=both]
-    \tnsite{(1,1)}
-  \end{tenkzlattice}.
+  \begin{tenkzfree}
+    % the coarse-grained effective four-leg tensor and the four original
+    % sites, one per corner
+    \tnput[box]{c}{(0mm,0mm)}{}
+    \tnput[box]{ne}{(16mm,16mm)}{} \tnput[box]{nw}{(-16mm,16mm)}{}
+    \tnput[box]{se}{(16mm,-16mm)}{} \tnput[box]{sw}{(-16mm,-16mm)}{}
+    % each corner atom keeps its own slanted (fused/hatched) legs -- one
+    % inward to the block tensor, one continuing the same diagonal outward,
+    % and a free cross-diagonal pair
+    \tnjoin[fused]{c.north east}{ne.south west}
+    \tnjoin[fused]{ne.north east}{24mm,24mm}
+    \tnjoin[fused]{8mm,24mm}{ne.north west}
+    \tnjoin[fused]{ne.south east}{24mm,8mm}
+    \tnjoin[fused]{c.north west}{nw.south east}
+    \tnjoin[fused]{nw.north west}{-24mm,24mm}
+    \tnjoin[fused]{-8mm,24mm}{nw.north east}
+    \tnjoin[fused]{nw.south west}{-24mm,8mm}
+    \tnjoin[fused]{c.south east}{se.north west}
+    \tnjoin[fused]{se.south east}{24mm,-24mm}
+    \tnjoin[fused]{8mm,-24mm}{se.south west}
+    \tnjoin[fused]{se.north east}{24mm,-8mm}
+    \tnjoin[fused]{c.south west}{sw.north east}
+    \tnjoin[fused]{sw.south west}{-24mm,-24mm}
+    \tnjoin[fused]{-8mm,-24mm}{sw.south east}
+    \tnjoin[fused]{sw.north west}{-24mm,-8mm}
+  \end{tenkzfree}.
 \]

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-anyon-pair.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-anyon-pair.tex
@@ -6,11 +6,24 @@
 %   III/ImagesReview Section III.tex lines 644-660
 % Capabilities: lattice, path-string, marked-endpoints
 \[
-  \begin{tenkzlattice}[rows=3, cols=3, frame=oblique, physical=up]
+  % plane rise=0.75 (default 0.60): the extra depth-step clearance keeps the
+  % site's fixed north-east label quadrant off the row-2 neighbour glyph at
+  % the sheared bottom-left corner (i^*); the default rise collided there.
+  % pitch=14mm (default 11mm): the intermediate site (2,2) sits on the a
+  % string with its own physical leg, the row-2 bond and the diagonal edge
+  % all converging nearby; the library's label clearance is a fixed ratio
+  % of pitch while the label glyph is a fixed point size, so the larger
+  % pitch buys the a label real whitespace against all three.
+  \begin{tenkzlattice}[rows=3, cols=3, frame=oblique, physical=up,
+                       plane rise=0.75, pitch=14mm]
     \tnsite{(1,1)} \tnsite{(1,2)} \tnsite[role=marked, label={$i$}]{(1,3)}
-    \tnsite{(2,1)} \tnsite{(2,2)} \tnsite{(2,3)}
+    % the intermediate site the string passes through: marked (blue) like
+    % the endpoints, carrying the a label. (tn label text is always
+    % tenkzInk/black -- \tnsite has no role-tinted label spelling -- so a
+    % renders in plain ink beside the blue dot, not in blue itself.)
+    \tnsite{(2,1)} \tnsite[role=marked, label={$a$}]{(2,2)} \tnsite{(2,3)}
     \tnsite[role=marked, label={$i^{*}$}]{(3,1)} \tnsite{(3,2)} \tnsite{(3,3)}
     \tnedge[role=operator]{(3,1)-(2,2)}
-    \tnedge[role=operator, label={a}]{(2,2)-(1,3)}
+    \tnedge[role=operator]{(2,2)-(1,3)}
   \end{tenkzlattice}
 \]

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-condensation.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-condensation.tex
@@ -5,14 +5,24 @@
 % Source: paper TN-Review-main.tex line 1697; author source ImagesReview Section
 %   III/ImagesReview Section III.tex lines 925-953
 % Capabilities: lattice-preset, double-layer-string, marked-endpoints
+% Known package gap: \tnsite/\tnput expose no per-site size key, so the
+%   endpoint and intermediate markers below are both drawn at the single
+%   library dot size (role=marked, blue) rather than the source's
+%   large/small pair. Not tracked in docs/paper-gaps/ yet (out of scope
+%   for this case-file-only fix); flagged here for a follow-up note.
 \[
-  \begin{tenkzplanes}[rows=4, cols=4]
-    \tnsite{(4,2)}
-    \tnsite{(3,2)}
-    \tnsite{(2,3)}
-    \tnsite{(1,3)}
-    \tnedge[role=operator]{(4,2)-(3,2)}
-    \tnedge[role=operator]{(3,2)-(2,3)}
-    \tnedge[role=operator]{(2,3)-(1,3)}
-  \end{tenkzplanes}_{\ a\leftrightarrow\bar a}
+  \begin{tenkzlattice}[rows=4, cols=4, frame=oblique]
+    % the ket-sheet string: two endpoint sites and one intermediate bend
+    \tnsite[role=marked]{(4,1)} \tnsite[role=marked]{(3,1)}
+    \tnsite[role=marked]{(2,2)} \tnsite[role=marked]{(1,2)}
+    % the bra-sheet string: the same zigzag, shifted two columns over
+    \tnsite[role=marked]{(4,3)} \tnsite[role=marked]{(3,3)}
+    \tnsite[role=marked]{(2,4)} \tnsite[role=marked]{(1,4)}
+    \tnedge[role=operator]{(4,1)-(3,1)}
+    \tnedge[role=operator]{(3,1)-(2,2)}
+    \tnedge[role=operator]{(2,2)-(1,2)}
+    \tnedge[role=operator]{(4,3)-(3,3)}
+    \tnedge[role=operator]{(3,3)-(2,4)}
+    \tnedge[role=operator]{(2,4)-(1,4)}
+  \end{tenkzlattice}_{\ a\leftrightarrow\bar a}
 \]


### PR DESCRIPTION
The residual sweep the redraw campaign left behind. Each panel was diagnosed by compiling the author's own block from its cited line range and reading both renders side by side; each fix was verified the same way. Three areas, three owners, every render read by a second pair of eyes before acceptance.

## The seven panels

| target | was | now |
|---|---|---|
| rmp-iii-a-proof-one | invented O_alpha and A boxes, RHS missing its copy-dot | the orthogonal reduction: alpha and the physical copy-dot on two parallel wires into V_alpha's west face; RHS carries the dot |
| rmp-iii-a-ghz-state | a 2x2-blocking cartoon the source does not draw | the masonry patch the source builds from four foreach loops, transcribed element-wise: three brick columns, three rungs, plain diagonal stubs, honest unpaired boundary tensors, 89 lines under the 100-line cap |
| rmp-workbench-iii-historical-composite | **the corpus's one unfaithful verdict** — a 2x2 rhombus substituted for the composite | the two-panel equation: box ring with directed wires, the lambda intertwiner, red boundary strings sweeping top-left (LHS) and bottom-right (RHS) |
| rmp-workbench-iii-peps-renormalization-one | plaquette rotated to a diamond, hatched bonds lost | the bare upright square, eight arms, fused sides (the free tier has no discrete tick; fused is the pairing statement) |
| rmp-workbench-iii-peps-renormalization-two | lattice replaced by a cube and arrow | the central effective tensor with four corner blocks and slanted fused legs |
| rmp-iii-b-anyon-pair | HARD label-overlap shipped on main since LionSR/TNLean#4867 (invisible because the ledger block kept the RMP auditor from running) | label i* clears via one plane-rise reshear; the string's one intermediate site is marked blue and the a label sits clear at midway |
| rmp-iii-b-condensation | 2.5D condensation lattice drawn as a 3D cube, markers lost | the slanted sheet with the doubled red string and blue endpoint markers, on the sibling anyon sheet's technique |

## Gates

- All seven compile and pass the event audit with zero hard errors (batch-verified from this branch).
- tenkz lint: 7 files, 0 findings.
- Shrink gate PASS: census stable at 192, all 133 flags carry verdicts. M3 rises 326→331 (two hand-routed arcs in the composite — the strings gap again — plus one plane-rise reshear standing in for a per-site label bearing) and M4 rises 14.88→15.88 (six of seven panels grew by drawing what their sources assert); both priced in the ledger under Census-correction: LionSR/tenkz#13, with the newly raised consumer flags answered.
- Corpus fixtures, golden events, and the library are untouched.

## Verdict-ledger note

Seven case digests go stale by construction (five were already stale from the redraw PRs). Proposed flips for the countersign reading: historical-composite unfaithful→cosmetic-gap, ghz-state blocked→cosmetic-gap, proof-one structural-gap→cosmetic-gap, condensation structural-gap→cosmetic-gap, peps-renormalization-one/two structural-gap→cosmetic-gap, anyon-pair structural-gap→faithful. verdicts.toml is deliberately untouched — the flips need the second signature.

## Library gaps surfaced (follow-up issues to be filed)

1. \tnsite label bearing is hard-coded to the north-east quadrant; no directional key. Root cause of this overlap class.
2. No per-site size key: endpoint vs intermediate markers cannot differ.
3. Reproducible crash: \tnregion label + role=marked + frame=oblique + physical=up ('Missing $ inserted' / 'no shape known').
4. No plain-ink circle skin with an inscribed label (the lambda glyph); ring hardcodes action red, role=passive grey is the closest unhued spelling.
5. Lattice genre: no half-pitch row stagger and no diagonal stubs (why the GHZ patch lives in the free genre).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-corpus and documentation-only changes; no library or auth paths touched. Meter rises are expected and documented for the shrink gate.
> 
> **Overview**
> Redraws the last seven residual **section-III** RMP benchmark cases so each figure matches its cited author block instead of placeholder lattice cartoons or wrong topology.
> 
> **GHZ state** moves from a blocking `tenkzlattice` patch to a large **`tenkzfree`** masonry transcription (joins + dots). **Proof-one** drops invented operator boxes and **`down at=`** for an explicit **`tenkzfree`** isometry with copy-dot on both sides. **Historical composite** becomes a faithful two-panel equation (ring, λ intertwiner, **`out=`/`in=`** boundary arcs). **PEPS renormalization** panels switch to fused-bond squares and corner-block geometry rather than diamonds or cube shortcuts. **Anyon pair** tunes **`plane rise`** / **`pitch`** and marks the string’s intermediate site; **condensation** leaves **`tenkzplanes`** for an oblique **`tenkzlattice`** with paired ket/bra strings.
> 
> **Shrink ledger** documents the sweep under census-correction **#4709**: **M3** 326→**331** (arc routing + one plane-rise escape) and **M4** 14.88→**15.88** (longer faithful ink). Three consumer-flag verdicts are recorded for keys that lost cases to more accurate drawings. **`census-baseline.json`** is updated to match; package and golden fixtures are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31856901cd3ce047ed98f061fd13bf8bbcdf3eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->