### PR TITLE
refactor(Channel.Semigroup): factor Liouvillian sums directly

### DIFF
--- a/TNLean/Channel/Semigroup/LiouvillianKernel.lean
+++ b/TNLean/Channel/Semigroup/LiouvillianKernel.lean
@@ -321,15 +321,8 @@ private theorem toAdjointLinearMap_conjTranspose_mul_self_eq_sum_commutator
       (∑ j, (A * F.L j - F.L j * A)ᴴ * (A * F.L j - F.L j * A)) =
       φ (Aᴴ * A) - φ Aᴴ * A - Aᴴ * φ A + Aᴴ * S * A := by
     simp_rw [hRHS_expand]
-    simp only [Finset.sum_sub_distrib, Finset.sum_add_distrib]
-    congr 1
-    · congr 1
-      · congr 1
-        -- ∑ (F.L j)ᴴ * Aᴴ * F.L j * A = φ(A†) · A
-        exact (Finset.sum_mul _ _ _).symm
-      -- A† · ∑ (F.L j)ᴴ * A * F.L j = A† · φ(A)
-      exact (Finset.mul_sum _ _ _).symm
-    -- ∑ A† · ((F.L j)ᴴ * F.L j) * A = A† · S · A
+    simp only [Finset.sum_sub_distrib, Finset.sum_add_distrib, φ, Kraus.adjointMap]
+    rw [← Finset.sum_mul, ← Finset.mul_sum]
     rw [← Finset.sum_mul, ← Finset.mul_sum, hS_def]
   -- Part 3: Connect LHS to the same expression
   rw [toAdjointLinearMap_apply_raw, hRHS_sum]


### PR DESCRIPTION
## Summary

- expose the Kraus adjoint-map sum before factoring the Lindblad identity
- replace a nested `congr` search with direct finite-sum distributivity rewrites
- preserve the theorem statement and proof strategy while reducing elaboration work

## Performance

- previous direct check: 37.94s wall / 18.66s user CPU (host-contended)
- refactored direct checks: 10.07s and 11.14s wall / 5.53s and 6.52s user CPU
- focused Lake build: `LiouvillianKernel` built in 6.3s
- import-only probe: 16.08s wall / 2.43s user CPU, showing the original hotspot was primarily declaration elaboration

Exact-head CI timing is the authoritative gate because local wall time was affected by host contention.

## Validation

- `lake env lean TNLean/Channel/Semigroup/LiouvillianKernel.lean`
- `lake build TNLean.Channel.Semigroup.LiouvillianKernel`
- `git diff --check`
- proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/tactic_pattern_scan.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logic-only proof refactor in a private lemma; no runtime or public API changes, with risk limited to a possible proof regression if elaboration tactics differ subtly.
> 
> **Overview**
> **Proof-only refactor** in the Lindblad identity lemma `toAdjointLinearMap_conjTranspose_mul_self_eq_sum_commutator` (`LiouvillianKernel.lean`): the step that rewrites the summed commutator squares into `φ(AᴴA) - φ(Aᴴ)A - Aᴴφ(A) + AᴴSA` is unchanged in meaning.
> 
> The old proof used a deep `congr 1` chain with three `Finset.sum_mul` / `Finset.mul_sum` lemmas. It now **`simp_rw`s the per-index expansion**, then **`simp`s with `φ` and `Kraus.adjointMap` unfolded** so the Kraus adjoint sum is visible, and finishes with the same **`← Finset.sum_mul` / `← Finset.mul_sum`** pulls plus `hS_def`.
> 
> No API or theorem statement changes—this targets **Lean elaboration time** on that block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873d6a1fce0f464a97bbf9f98fda67501e5336fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->