### PR TITLE
refactor(MPS/MPDO): tighten triple fusion simplification

### DIFF
--- a/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
+++ b/TNLean/MPS/MPDO/BNTTripleFusionSeparation.lean
@@ -505,10 +505,14 @@ private theorem tripleFusionComparison_final_entry_intertwines_of_lengthIndepend
   have hEntry := congrArg
     (fun X => X (Fam.leftFinalRow α β γ ε ⟨δL, μL, νL, bL⟩)
       (Fam.rightFinalRow α β γ ε' ⟨δR, μR, νR, bR⟩)) hFull
-  simpa [Matrix.mul_apply, Matrix.blockDiagonal'_apply,
-    leftFinalRow, rightFinalRow, Fintype.sum_sigma,
-    Fintype.sum_prod_type, Matrix.one_apply, MPOTensor.toMPSTensor]
-    using hEntry
+  simpa only [MPOTensor.toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat, leftFinalRow, rightFinalRow,
+    Matrix.mul_apply, Matrix.blockDiagonal'_apply, Matrix.kroneckerMap_apply,
+    Matrix.one_apply, ite_mul, one_mul, zero_mul, mul_ite, mul_zero, dite_mul,
+    Fintype.sum_sigma, Finset.sum_dite_irrel, Fintype.sum_prod_type,
+    Finset.sum_const_zero, Finset.sum_dite_eq, Finset.mem_univ, ↓reduceIte,
+    cast_eq, Finset.sum_ite_irrel, Finset.sum_ite_eq, mul_dite,
+    Finset.sum_dite_eq', Finset.sum_ite_eq'] using hEntry
 
 private theorem rectangularIntertwiner_eq_zero_of_selectorWords
     {d D₁ D₂ S : ℕ} (A : MPSTensor d D₁) (B : MPSTensor d D₂)
@@ -647,9 +651,13 @@ theorem exists_tripleFusionComparison_finalSector_eq_kronecker_one_of_separation
             (Fam.tensor ε).toMPSTensor ij) := by
     intro ij
     ext ⟨⟨δL, μL, νL⟩, bL⟩ ⟨⟨δR, μR, νR⟩, bR⟩
-    simpa [C, Matrix.mul_apply,
-      leftFinalIndexEquiv_symm_apply, rightFinalIndexEquiv_symm_apply,
-      Fintype.sum_prod_type, Matrix.one_apply] using
+    simpa only [C, Matrix.submatrix_submatrix, Matrix.mul_apply,
+      Matrix.kroneckerMap_apply, Matrix.one_apply, ite_mul, one_mul, zero_mul,
+      Matrix.submatrix_apply, Function.comp_apply,
+      rightFinalIndexEquiv_symm_apply, Fintype.sum_prod_type,
+      Finset.sum_ite_irrel, Finset.sum_const_zero, Finset.sum_ite_eq,
+      Finset.mem_univ, ↓reduceIte, leftFinalIndexEquiv_symm_apply, mul_ite,
+      mul_zero, Finset.sum_ite_eq'] using
       Fam.tripleFusionComparison_final_entry_intertwines_of_lengthIndependent
         c hχ hLI α β γ ε ε δL δR μL νL μR νR bL bR ij
   obtain ⟨F, hF⟩ :=


### PR DESCRIPTION
## Motivation

`TNLean.MPS.MPDO.BNTTripleFusionSeparation` still took 31 seconds in the
exact-main compilation census after the earlier structural refactor. Profiling
showed that one broad simplification of dependent block-matrix entries consumed
most of the remaining elaboration time.

## Description

- replace the broad simplification of the fixed-final intertwining entry with
  the exact simp lemma set
- likewise restrict simplification when the entry lemma is applied to the
  reindexed diagonal block

This is proof-only: public declarations and theorem statements are unchanged.

Addresses #4866.

## Testing

- forced focused build: 12s (31s exact-main baseline)
- direct profiler: 15.0s user CPU, down from 38.97s
- `lake build TNLean.MPS.MPDO.BNTFixedFinalUnitarity TNLean.MPS.MPDO.TopologicalProjectors TNLean.MPS.MPDO.BlockedCompleteZipper TNLean.MPS.MPDO`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity grep and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only internal proof scripts in one Lean file; no runtime, API, or mathematical statement changes.
> 
> **Overview**
> **Proof-only performance tweak** in `BNTTripleFusionSeparation.lean`: two closing `simpa` steps now use `simpa only` with explicit lemma lists instead of broader default simplification.
> 
> The first change is in `tripleFusionComparison_final_entry_intertwines_of_lengthIndependent`, where unfolding the intertwining entry adds targeted rules for `MPOTensor.toMPSTensor`, `finProdFinEquiv` indexing, Kronecker/block-diagonal matrix entries, and finset `ite` sums. The second is in `exists_tripleFusionComparison_finalSector_eq_kronecker_one_of_separation`, where the reindexed diagonal Kronecker intertwining step gets the same style of restricted simp (submatrix, Kronecker, index equivalences).
> 
> **No theorem statements or public API change**—only elaboration cost (per PR notes, large compile-time reduction on this file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ba15c298746cf3bf3fb6c23e17a18178b01358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->