### PR TITLE
refactor(Algebra): simplify Newton-Girard matrix rewrite

### DIFF
--- a/TNLean/Algebra/NewtonGirard.lean
+++ b/TNLean/Algebra/NewtonGirard.lean
@@ -185,7 +185,6 @@ private lemma T_trace_recursion (M : Matrix n n R) (l : ℕ) :
       (M.map C) ^ l * Adj - (X : R[X]) • ((M.map C) ^ l * Adj * M.map C) := by
     have hFF : F = (1 : Matrix n n R[X]) - (X : R[X]) • M.map C := rfl
     rw [hFF, Matrix.mul_sub, Matrix.mul_one]
-    congr 1
     rw [mul_smul_comm]
   have h_lhs : Matrix.trace ((M.map C) ^ l * Adj * F) =
       Matrix.trace ((M.map C) ^ l * Adj) -


### PR DESCRIPTION
## Summary

- remove a redundant `congr` step from the `T_trace_recursion` matrix-distributivity proof
- let the targeted `mul_smul_comm` rewrite close the equality directly
- preserve all statements and the Newton-Girard proof structure

## Performance

- import-only probe: 17.49s wall / 2.02s user CPU
- previous full direct check: 22.23s wall / 15.88s user CPU
- refactored direct checks: 8.07s, then 4.85s wall
- focused Lake build: `NewtonGirard` built in 4.0s
- threshold profiling previously put about 15.9s in the redundant `congr`; after the change the largest declaration is about 1.29s

Exact-head CI timing is the authoritative landing gate.

## Validation

- `lake exe cache get` before any build in the fresh worktree
- `lake env lean TNLean/Algebra/NewtonGirard.lean`
- `lake build TNLean.Algebra.NewtonGirard`
- `git diff --check`
- proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/tactic_pattern_scan.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof refactor in `NewtonGirard.lean` with unchanged statements and no runtime or API impact.
> 
> **Overview**
> **Proof-only tweak** in `T_trace_recursion`: the `hf` step that rewrites `(M.map C) ^ l * Adj * F` no longer uses an extra `congr 1` before commuting scalar multiplication.
> 
> After `Matrix.mul_sub` / `Matrix.mul_one`, the goal is closed with **`mul_smul_comm`** alone, so the distributivity argument is shorter for the elaborator.
> 
> **No theorem statements or downstream Newton–Girard lemmas change**—only how that one matrix equality is proved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 470b7ffc1f0464b0e0ce6face205295d57697c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->