### PR TITLE
refactor(Channel/Irreducible): streamline spectral-radius similarity

### DIFF
--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -230,10 +230,10 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
   have hρ_ne : ρ ≠ 0 := (Matrix.PosDef.isUnit hρ_pd).ne_zero
   have hE_ne : E ≠ 0 := by
     intro hE0
-    have hsmul : (r : ℂ) • ρ = 0 := by
-      simpa [hE0] using hEig.symm
+    rw [hE0, LinearMap.zero_apply] at hEig
     exact hρ_ne
-      ((eq_zero_or_eq_zero_of_smul_eq_zero hsmul).resolve_left (by exact_mod_cast hr.ne'))
+      ((eq_zero_or_eq_zero_of_smul_eq_zero hEig.symm).resolve_left
+        (by exact_mod_cast hr.ne'))
   obtain ⟨σ, t, hσ_pd, ht_pos, hσ_eig⟩ :=
     hSetup.exists_posDef_adjoint_eigenvector hE_ne
   have htrace : ∀ X : Matrix (Fin D) (Fin D) ℂ,
@@ -283,6 +283,11 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
     exact Matrix.inv_inv_of_invertible S
   have hS_inv_herm : (S⁻¹)ᴴ = S⁻¹ := by
     simpa [hS_herm] using Matrix.conjTranspose_nonsing_inv S
+  have hsim_apply (X : Matrix (Fin D) (Fin D) ℂ) :
+      similarityMap (D := D) S⁻¹ E X =
+        S * E (S⁻¹ * X * S⁻¹) * S := by
+    simp only [similarityMap, hS_inv_inv, hS_inv_herm]
+    rfl
   set A' : MPSTensor n D := fun i => d • K i with hA'_def
   have hA'_fix : MPSTensor.transferMap (d := n) (D := D) (fun i => (A' i)ᴴ) σ = σ := by
     simp only [hA'_def, MPSTensor.transferMap_apply, Matrix.conjTranspose_smul,
@@ -331,7 +336,7 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
             rw [hE_eq]
             simp [MPSTensor.transferMap_apply]
       _ = ((↑r : ℂ)⁻¹ • similarityMap (D := D) S⁻¹ E) X := by
-            simp [similarityMap, hS_inv_inv, hS_inv_herm, Matrix.mul_assoc]
+            rw [LinearMap.smul_apply, hsim_apply]
   set E' : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
     (↑r : ℂ)⁻¹ • similarityMap (D := D) S⁻¹ E with hE'_def
   -- The TP-normalized map has spectral radius `≤ 1`. In the formal proof we
@@ -353,10 +358,16 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
   have hY_eig : E' (S * ρ * S) = S * ρ * S := by
     calc
       E' (S * ρ * S)
-          = (↑r : ℂ)⁻¹ • (S * E (((S⁻¹ * S) * ρ) * (S * S⁻¹)) * S) := by
-              simp [hE'_def, similarityMap, hS_inv_inv, hS_inv_herm, Matrix.mul_assoc]
+          = (↑r : ℂ)⁻¹ • (S * E (S⁻¹ * (S * ρ * S) * S⁻¹) * S) := by
+              rw [hE'_def, LinearMap.smul_apply, hsim_apply]
       _ = (↑r : ℂ)⁻¹ • (S * E ρ * S) := by
-            rw [hS_inv_mul, one_mul, hS_mul_inv, mul_one]
+            have hinner : S⁻¹ * (S * ρ * S) * S⁻¹ = ρ := by
+              calc
+                S⁻¹ * (S * ρ * S) * S⁻¹ =
+                    (S⁻¹ * S) * ρ * (S * S⁻¹) := by
+                      simp only [Matrix.mul_assoc]
+                _ = ρ := by rw [hS_inv_mul, one_mul, hS_mul_inv, mul_one]
+            rw [hinner]
       _ = (↑r : ℂ)⁻¹ • (S * ((↑r : ℂ) • ρ) * S) := by rw [hEig]
       _ = S * ρ * S := by
             rw [Matrix.mul_smul, Matrix.smul_mul, smul_smul, inv_mul_cancel₀]

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -90,6 +90,17 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Positive-congruence similarity evaluation
+- **Pattern:** the spectral-radius proof repeatedly unfolded `similarityMap`
+  and asked broad `simp` calls to rediscover the same inverse and Hermitian
+  square-root identities.
+- **Reuse:** the local `hsim_apply` equation records that evaluation once.
+  The transformed eigenvector proof then cancels the two inverse pairs through
+  an explicit matrix identity instead of normalizing the whole expression.
+- **Result:** the main Wolf 6.3 declaration falls from 6.21 to 5.60 seconds in
+  the declaration profiler, and the clean full-source check completes in
+  15.34 seconds.
+
 ### Inverse physical action from a twisted companion
 - **Pattern:** the virtual-unitary construction in `StringOrderAux.lean`
   combined scalar normalization, transfer-map scaling, and the full inverse


### PR DESCRIPTION
## Summary

- evaluate the positive-congruence similarity through one local equation instead of repeatedly unfolding it under broad simplification
- cancel the square-root inverse pairs with an explicit matrix identity in the transformed eigenvector proof
- record the completed compilation-time refactor in the tactic-pattern ledger

## Performance evidence

- definitive census baseline: `TNLean.Channel.Irreducible.SpectralRadius` 29s
- import-only control on the hot worktree: 8.70s real (2.76s user, 4.27s sys)
- baseline top declaration: `spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp` 6.21s
- refactored top declaration: 5.60s
- clean profiled full-source check: 15.34s real
- real Lake target rebuild: 23s

The split shows that the module has meaningful declaration cost rather than being dominated solely by its imports.

## Validation

- `lake env lean -Dtrace.profiler=true TNLean/Channel/Irreducible/SpectralRadius.lean`
- `lake build TNLean.Channel.Irreducible.SpectralRadius`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- proof-integrity scan for `sorry`, `admit`, `native_decide`, `unsafeCast`, and `axiom`

No Mathlib source was rebuilt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one channel file plus documentation; no API or mathematical statement changes, only local proof structure and compilation cost.
> 
> **Overview**
> This PR speeds up the Wolf 6.3(4) spectral-radius proof in `SpectralRadius.lean` without changing any theorem statements.
> 
> It introduces a local **`hsim_apply`** lemma that records how the positive-congruence **`similarityMap`** acts once, then reuses it where the proof previously unfolded **`similarityMap`** and ran broad **`simp`** on the Hermitian square-root / inverse identities. The **`hB_eq`** step and the transformed fixed-point calculation **`hY_eig`** now **`rw`** that equation instead.
> 
> The **`hY_eig`** chain also replaces implicit inverse cancellation with an explicit **`hinner`** matrix identity (`S⁻¹ * (S * ρ * S) * S⁻¹ = ρ`). The **`hE_ne`** argument is tightened by applying **`LinearMap.zero_apply`** at the eigenvector hypothesis before the smul-zero split.
> 
> **`docs/tactic_patterns.md`** adds a completed-refactor entry documenting the pattern and reported profiler timings (~6.21s → ~5.60s on the main declaration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8636fac4f85b0adb5d3ecc5be47520ab60a7e7a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->