### PR TITLE
refactor(MPS/Examples): factor AKLT projective multiplication

### DIFF
--- a/TNLean/MPS/Examples/AKLT.lean
+++ b/TNLean/MPS/Examples/AKLT.lean
@@ -269,6 +269,11 @@ private def akltGaugeGL : GL (Fin 2) ℂ :=
     (akltGaugeGL : Matrix (Fin 2) (Fin 2) ℂ) = akltGaugeMat :=
   Matrix.GeneralLinearGroup.val_mkOfDetNeZero _ _
 
+private lemma akltGaugeMat_sq : akltGaugeMat * akltGaugeMat = -1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [akltGaugeMat, Matrix.mul_apply, Fin.sum_univ_two]
+
 private lemma akltGaugeGL_inv_val :
     ((akltGaugeGL⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) = !![0, -1; 1, 0] := by
   have : akltGaugeGL * (Matrix.GeneralLinearGroup.mkOfDetNeZero
@@ -394,13 +399,19 @@ private def akltGaugeZ : GL (Fin 2) ℂ :=
     (akltGaugeZ : Matrix (Fin 2) (Fin 2) ℂ) = !![1, 0; 0, -1] :=
   Matrix.GeneralLinearGroup.val_mkOfDetNeZero _ _
 
+private lemma akltGaugeZ_sq :
+    (!![(1 : ℂ), 0; 0, -1] : Matrix (Fin 2) (Fin 2) ℂ) *
+        !![(1 : ℂ), 0; 0, -1] = 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.mul_apply, Fin.sum_univ_two]
+
 private lemma akltGaugeZ_inv_val :
     ((akltGaugeZ⁻¹ : GL (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) = !![1, 0; 0, -1] := by
   have hsq : akltGaugeZ * akltGaugeZ = 1 := by
     apply Units.ext
     simp only [Units.val_mul, Units.val_one, akltGaugeZ_val]
-    ext i j; fin_cases i <;> fin_cases j <;>
-      simp [Matrix.mul_apply, Fin.sum_univ_two]
+    exact akltGaugeZ_sq
   rw [show akltGaugeZ⁻¹ = akltGaugeZ from inv_eq_of_mul_eq_one_right hsq, akltGaugeZ_val]
 
 /-- The virtual gauge for the combined element, `iσy · σz = [[0, -1], [-1, 0]]`. -/
@@ -429,6 +440,14 @@ lemma aklt_gauge_anticomm :
       -(!![(1 : ℂ), 0; 0, -1] * !![(0 : ℂ), 1; -1, 0]) := by
   ext i j; fin_cases i <;> fin_cases j <;>
     simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.neg_apply]
+
+private lemma aklt_gauge_anticomm' :
+    (!![(1 : ℂ), 0; 0, -1]) * akltGaugeMat =
+      -(akltGaugeMat * !![(1 : ℂ), 0; 0, -1]) := by
+  rw [akltGaugeMat]
+  have h := congrArg Neg.neg aklt_gauge_anticomm
+  rw [neg_neg] at h
+  exact h.symm
 
 /-! #### Twists by the second and combined generators -/
 
@@ -552,17 +571,20 @@ the third nontrivial element acts by their product `iσy σz`. -/
 def akltProjRep : ProjectiveRepresentation (D := 2) akltOmega where
   X := akltRepX
   map_mul' g h := by
-    rcases zmod2sq_cases g with rfl | rfl | rfl | rfl <;>
-      rcases zmod2sq_cases h with rfl | rfl | rfl | rfl <;>
-      rw [akltOmega_apply_val] <;>
-      simp only [akltRepX, ← ofAdd_add, Prod.mk_add_mk, toAdd_ofAdd, toAdd_one,
-        Units.val_mul, Units.val_one, akltGaugeGL_val, akltGaugeZ_val, akltGaugeMat,
-        show (1 : ZMod 2) + 1 = 0 from by decide, show (0 : ZMod 2) + 1 = 1 from by decide,
-        show (1 : ZMod 2) + 0 = 1 from by decide, show (0 : ZMod 2) + 0 = 0 from by decide,
-        one_ne_zero, ↓reduceIte, and_self, and_true, true_and, mul_one, one_mul] <;>
-      (ext a b; fin_cases a <;> fin_cases b <;>
-        simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.smul_apply, Matrix.one_apply,
-          smul_eq_mul])
+    rw [akltOmega_apply_val]
+    have hY (p : Prop) [Decidable p] :
+        ((if p then 1 else akltGaugeGL : GL (Fin 2) ℂ) :
+          Matrix (Fin 2) (Fin 2) ℂ) =
+          if p then 1 else akltGaugeMat := by
+      split <;> simp
+    have hZ (p : Prop) [Decidable p] :
+        ((if p then 1 else akltGaugeZ : GL (Fin 2) ℂ) :
+          Matrix (Fin 2) (Fin 2) ℂ) =
+          if p then 1 else !![(1 : ℂ), 0; 0, -1] := by
+      split <;> simp
+    simp only [akltRepX, Units.val_mul, hY, hZ]
+    exact mul_of_anticommuting_neg_involution _ _
+      akltGaugeMat_sq akltGaugeZ_sq aklt_gauge_anticomm' g h
 
 open TNLean.Algebra in
 /-- `akltOmega` is a genuine `2`-cocycle: it is the factor system of the

--- a/TNLean/MPS/Examples/ZMod2.lean
+++ b/TNLean/MPS/Examples/ZMod2.lean
@@ -170,4 +170,48 @@ lemma mul_of_anticommuting_involutions (P₁ P₂ : Matrix n n ℂ)
     | rw [mul_assoc, ← mul_assoc P₂ P₁ P₂, hc, neg_mul, mul_assoc P₁ P₂ P₂,
         h₂, mul_one, mul_neg, h₁]
 
+/-- An anticommuting negative involution and involution obey the
+`Z₂ × Z₂` projective multiplication law with factor
+`(-1)^((g₁ + g₂) h₁)`. -/
+lemma mul_of_anticommuting_neg_involution (P₁ P₂ : Matrix n n ℂ)
+    (h₁ : P₁ * P₁ = -1) (h₂ : P₂ * P₂ = 1) (hc : P₂ * P₁ = -(P₁ * P₂))
+    (g h : Multiplicative (ZMod 2 × ZMod 2)) :
+    ((if (Multiplicative.toAdd g).1 = 0 then 1 else P₁) *
+          (if (Multiplicative.toAdd g).2 = 0 then 1 else P₂)) *
+        ((if (Multiplicative.toAdd h).1 = 0 then 1 else P₁) *
+          (if (Multiplicative.toAdd h).2 = 0 then 1 else P₂)) =
+      (if (Multiplicative.toAdd g).1 + (Multiplicative.toAdd g).2 = 1 ∧
+          (Multiplicative.toAdd h).1 = 1 then (-1 : ℂ) else 1) •
+        ((if (Multiplicative.toAdd (g * h)).1 = 0 then 1 else P₁) *
+          (if (Multiplicative.toAdd (g * h)).2 = 0 then 1 else P₂)) := by
+  rcases zmod2sq_cases g with rfl | rfl | rfl | rfl <;>
+    rcases zmod2sq_cases h with rfl | rfl | rfl | rfl <;>
+    simp only [← ofAdd_add, Prod.mk_add_mk, toAdd_ofAdd, toAdd_one,
+      Prod.fst_zero, Prod.snd_zero,
+      show (1 : ZMod 2) + 1 = 0 from by decide,
+      show (0 : ZMod 2) + 1 = 1 from by decide,
+      show (1 : ZMod 2) + 0 = 1 from by decide,
+      show (0 : ZMod 2) + 0 = 0 from by decide,
+      one_ne_zero, zero_ne_one, ↓reduceIte, and_self, and_true, true_and,
+      mul_one, one_mul, one_smul, neg_one_smul] <;>
+    first
+    | exact h₁
+    | exact h₂
+    | exact hc
+    | rw [← mul_assoc, h₁, one_mul]
+    | rw [mul_assoc, h₂, mul_one]
+    | rw [hc, ← mul_assoc, h₁, one_mul]
+    | rw [← mul_assoc, hc, neg_mul, mul_assoc, h₂, mul_one]
+    | rw [mul_assoc, hc, mul_neg, ← mul_assoc, h₁, one_mul]
+    | rw [mul_neg, h₁, neg_neg]
+    | rw [← mul_assoc, hc, neg_mul, mul_assoc, h₂, mul_one]
+    | rw [mul_assoc, hc, mul_neg, ← mul_assoc, h₁, one_mul]
+    | rw [mul_assoc, hc, mul_neg, ← mul_assoc, h₁, one_mul]
+    | rw [← mul_assoc, h₁, neg_mul, one_mul]
+    | rw [hc, mul_neg, ← mul_assoc, h₁, neg_mul, one_mul, neg_neg]
+    | rw [mul_assoc, hc, mul_neg, ← mul_assoc, h₁, neg_mul, one_mul, neg_neg]
+    | rw [mul_assoc, ← mul_assoc P₂ P₁ P₂, hc, neg_mul, mul_assoc P₁ P₂ P₂,
+        h₂, mul_one, mul_neg, h₁]
+  all_goals simp
+
 end MPSTensor


### PR DESCRIPTION
## Motivation

`TNLean.MPS.Examples.AKLT` took 29 seconds in the exact-main compilation
census. Profiling identified the exhaustive proof of the projective
representation multiplication law as the largest declaration-level cost: it
expanded all 16 pairs of `Z₂ × Z₂` elements and simplified every matrix entry.

## Description

- add a reusable multiplication lemma for an anticommuting negative involution
  and involution, with factor `(-1)^((g₁ + g₂) h₁)`
- use that algebraic lemma for the AKLT projective representation instead of
  repeating finite group and matrix-entry enumeration
- reuse explicit square and anticommutation identities for the two AKLT gauges

All existing public AKLT declarations and theorem statements are unchanged.

Addresses #4866.

## Testing

- forced exact-head build: `ZMod2` 3.3s, `AKLT` 9.9s (29s AKLT census baseline)
- direct AKLT profiler: 33.10s to 16.57s wall; the former 12.84s declaration
  hotspot is eliminated
- `lake build TNLean.MPS.Examples.GHZ TNLean.MPS.Examples.Cluster TNLean.MPS.Examples.AKLTCorrelation TNLean.MPS.Examples.AKLTStringOrder TNLean.MPS.Examples`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity grep and `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged public API; risk is limited to accidental proof regressions, mitigated by existing build and example targets in the PR description.
> 
> **Overview**
> **Speeds up AKLT compilation** by replacing a large finite case split in `akltProjRep.map_mul'` with a shared algebraic lemma.
> 
> `ZMod2.lean` gains **`mul_of_anticommuting_neg_involution`**, which encodes the `Z₂ × Z₂` projective product law when the first gauge squares to **`-1`** (not `1`), with phase `(-1)^((g₁+g₂)h₁)`—the AKLT-specific variant beside the existing anticommuting-involutions lemma.
> 
> **AKLT** adds small matrix identities (`akltGaugeMat_sq`, `akltGaugeZ_sq`, `aklt_gauge_anticomm'`) and wires `map_mul'` through the new lemma after unfolding `GL` values to plain matrices. **`akltGaugeZ_inv_val`** reuses `akltGaugeZ_sq` instead of inlining the square proof.
> 
> Public AKLT definitions and theorem statements are unchanged; this is a proof/performance refactor only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b40129082528594b161a3924c71928e8b93ec84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->