### PR TITLE
refactor(MPS/MPDO): streamline algebra coordinates

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -360,7 +360,13 @@ theorem coe_reconstructFromBlockedCoefficients_apply
     ((data.reconstructFromBlockedCoefficients n a : data.A n) : Mat) =
       ∑ i, a i • ((data.blockedBasis n i : data.A n) : Mat) := by
   rw [reconstructFromBlockedCoefficients_apply (data := data) (n := n) (a := a)]
-  simp
+  change (data.A n).subtype (∑ i, a i • data.blockedBasis n i) =
+    ∑ i, a i • ((data.blockedBasis n i : data.A n) : Mat)
+  rw [map_sum]
+  refine Finset.sum_congr rfl ?_
+  intro i _
+  rw [map_smul]
+  rfl
 
 /-- Coordinates of an ambient matrix already known to lie in `A n`. -/
 noncomputable def toBlockedCoefficientsOfMem
@@ -422,9 +428,17 @@ theorem coe_mul_eq_sum_blockedStructureCoefficients
     ((data.m n (data.blockedBasis n i) (data.blockedBasis n j) : data.A (2 * n)) : Mat) =
       ∑ k, data.blockedStructureCoefficients n i j k •
         ((data.blockedBasis (2 * n) k : data.A (2 * n)) : Mat) := by
-  simpa [reconstructFromBlockedStructureCoefficients] using
-    coe_reconstructFromBlockedCoefficients_apply
-      (data := data) (n := 2 * n) (a := data.blockedStructureCoefficients n i j)
+  calc
+    ((data.m n (data.blockedBasis n i) (data.blockedBasis n j) :
+        data.A (2 * n)) : Mat) =
+        ((data.reconstructFromBlockedCoefficients (2 * n)
+          (data.blockedStructureCoefficients n i j) : data.A (2 * n)) : Mat) :=
+      congrArg (fun x : data.A (2 * n) => (x : Mat))
+        (reconstructFromBlockedStructureCoefficients data n i j).symm
+    _ = ∑ k, data.blockedStructureCoefficients n i j k •
+          ((data.blockedBasis (2 * n) k : data.A (2 * n)) : Mat) :=
+      coe_reconstructFromBlockedCoefficients_apply
+        (data := data) (n := 2 * n) (a := data.blockedStructureCoefficients n i j)
 
 /-- The coefficient family of the inclusion image of a chosen basis element. -/
 noncomputable def blockedInclusionCoefficients

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -90,6 +90,18 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Blocked-basis coercion reconstruction
+- **Pattern:** blocked support-algebra coordinate proofs coerced finite sums
+  into ambient matrices with unrestricted `simp`, which launched an expensive
+  and irrelevant search for a `Nonempty` instance on the basis index.
+- **Reuse:** `coe_reconstructFromBlockedCoefficients_apply` now transports the
+  reconstruction equation through the subalgebra subtype map explicitly with
+  `map_sum` and `map_smul`; the product formula composes the two reconstruction
+  equations directly.
+- **Result:** the worst reconstruction declaration falls from 1.68 seconds to
+  below one second in the declaration profiler, and a clean full-source check
+  completes in 15.39 seconds.
+
 ### Positive-congruence similarity evaluation
 - **Pattern:** the spectral-radius proof repeatedly unfolded `similarityMap`
   and asked broad `simp` calls to rediscover the same inverse and Hermitian


### PR DESCRIPTION
## Summary

- transport blocked-basis reconstruction through the support-subalgebra subtype map with explicit `map_sum` and `map_smul`
- derive the ambient multiplication-coordinate formula by composing exact reconstruction equations
- record the eliminated coercion-search pattern in the tactic-pattern ledger

## Performance evidence

- definitive census baseline: `TNLean.MPS.MPDO.AlgebraStructure` 26s
- import-only control on the hot worktree: 8.40s real (2.80s user, 3.85s sys)
- baseline top declaration: `coe_reconstructFromBlockedCoefficients_apply` 1.68s
- the unrestricted `simp` spent 1.44s attempting an irrelevant `Nonempty` synthesis for the basis index
- refactored reconstruction declaration: below 1s in the declaration profiler
- clean full-source check: 15.39s real
- isolated artifact-clean Lake target rebuild: 19s

## Validation

- `lake env lean TNLean/MPS/MPDO/AlgebraStructure.lean`
- `lake build TNLean.MPS.MPDO.AlgebraStructure`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check`
- proof-integrity scan for `sorry`, `admit`, `native_decide`, `unsafeCast`, and `axiom`

The isolated target measurement removed and regenerated only AlgebraStructure generated artifacts. No Mathlib source was rebuilt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorem statements; no runtime or security impact.
> 
> **Overview**
> This PR **re-proves** two ambient-matrix lemmas in `AlgebraStructure.lean` without broad `simp`, so typeclass search no longer dominates compile time.
> 
> **`coe_reconstructFromBlockedCoefficients_apply`** now coerces the finite-sum reconstruction through the support subalgebra subtype with **`map_sum`** and **`map_smul`** instead of **`simp`**, avoiding an expensive irrelevant **`Nonempty`** search on the basis index (profiler: ~1.68s → under 1s).
> 
> **`coe_mul_eq_sum_blockedStructureCoefficients`** is derived by a short **`calc`** that equates the product matrix to the reconstructed coefficient sum via **`reconstructFromBlockedStructureCoefficients`**, then applies the updated coercion lemma—replacing a **`simpa`** chain through the same path.
> 
> The tactic-pattern ledger documents this as a completed **blocked-basis coercion reconstruction** refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165adb7e3cdc471dc413386ab15d845916ddb22d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->