### PR TITLE
refactor(Channel.Semigroup): compute HIC witnesses algebraically

### DIFF
--- a/TNLean/Channel/Semigroup/HamiltonianIndependentContractivity.lean
+++ b/TNLean/Channel/Semigroup/HamiltonianIndependentContractivity.lean
@@ -101,9 +101,7 @@ def A : Mat4 := e 1 0 + e 2 1 + e 0 3
 def B : Mat4 := e 3 2
 
 private lemma A_cube : A ^ 3 = e 2 3 := by
-  ext i j
-  fin_cases i <;> fin_cases j <;>
-    simp [A, e, pow_succ, Matrix.mul_apply, Fin.sum_univ_succ]
+  simp [A, e, pow_succ, Matrix.mul_add, Matrix.add_mul]
 
 /-- The two matrices generate all sixteen standard matrix units and hence the
 full unital algebra $M_4(ℂ)$. -/
@@ -170,10 +168,21 @@ arXiv:2602.16067v1 (source lines 615--635). -/
 theorem dissipator_sum_x :
     dissipator A x + dissipator B x =
       -e 0 0 + e 1 1 + e 2 2 - e 3 3 := by
-  ext i j
-  fin_cases i <;> fin_cases j <;>
-    simp [dissipator, A, B, x, e, Matrix.mul_apply, Fin.sum_univ_succ]
-    <;> norm_num
+  simp only [dissipator, A, e, Fin.isValue, x, Matrix.mul_sub, Matrix.add_mul,
+    Matrix.single_mul_single_same, mul_one, ne_eq, one_ne_zero, not_false_eq_true,
+    Matrix.single_mul_single_of_ne, add_zero, Fin.reduceEq, sub_zero,
+    Matrix.conjTranspose_add, Matrix.conjTranspose_single, star_one, Matrix.mul_add,
+    zero_ne_one, one_div, zero_add, Matrix.smul_single, smul_eq_mul, Matrix.sub_mul,
+    sub_self, B, zero_sub, neg_mul, smul_neg, sub_neg_eq_add]
+  have hhalf (i : Fin 4) :
+      Matrix.single i i (2 : ℂ)⁻¹ = (2 : ℂ)⁻¹ • e i i := by
+    simp [e]
+  rw [hhalf 0, hhalf 2]
+  norm_num
+  change e 1 1 - (1 / 2 : ℂ) • e 0 0 - (1 / 2 : ℂ) • e 0 0 +
+      (-e 3 3 + (1 / 2 : ℂ) • e 2 2 + (1 / 2 : ℂ) • e 2 2) =
+    -e 0 0 + e 1 1 + e 2 2 - e 3 3
+  module
 
 end HICFourDimensionalExample
 


### PR DESCRIPTION
## Summary

- prove `A³ = E₂₄` directly with matrix-unit multiplication instead of 16 entry cases
- compute the dissipator witness by distributing matrix-unit products and normalizing its four diagonal coefficients
- preserve all statements and the four-dimensional counterexample argument

## Performance

- import-only probe: 6.00s wall / 1.89s user CPU
- previous full direct check: 17.26s wall / 14.86s user CPU
- refactored direct checks: 8.30s wall / 3.29s user CPU; 23.89s / 4.52s after rebase under heavy host contention
- focused Lake target: 11–15s locally
- profiler before: `A_cube` 5.18s and `dissipator_sum_x` 12.91s
- profiler after: `dissipator_sum_x` 2.63s; the brute-force entry expansions are gone

Exact-head CI timing is the authoritative landing gate because local wall time was visibly host-contended.

## Validation

- `lake exe cache get` before project builds in the fresh worktree
- `lake env lean TNLean/Channel/Semigroup/HamiltonianIndependentContractivity.lean`
- `lake build TNLean.Channel.Semigroup.HamiltonianIndependentContractivity`
- `git diff --check`
- proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/tactic_pattern_scan.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only proof scripts change; theorem statements and the counterexample argument are unchanged, with no API or runtime impact.
> 
> **Overview**
> Proof-only refactor in `HamiltonianIndependentContractivity.lean` for the four-dimensional HIC counterexample: **`A_cube`** and **`dissipator_sum_x`** keep the same conclusions but drop brute-force 4×4 entry case splits.
> 
> **`A_cube`** now proves `A³ = e₂₃` by expanding `A` and using `Matrix.mul_add` / `Matrix.add_mul` instead of `ext` + `fin_cases` on every index.
> 
> **`dissipator_sum_x`** unfolds the dissipator and matrix units, normalizes the `(2 : ℂ)⁻¹` diagonal pieces via a small `hhalf` lemma, and closes with `module`—same witness diagonal `-e₀₀ + e₁₁ + e₂₂ - e₃₃`, faster to kernel-check.
> 
> No changes to `adjoin_A_B_eq_top`, definitions of `A`, `B`, or `x`, or the surrounding HIC theory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703e3937ccfacc18ac5ce665755cbcafcbd47376. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->