### PR TITLE
fix(blueprint): correct CPSV Proposition 4.13 boundary

### DIFF
--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -299,9 +299,13 @@ theorem hasIdempotentCoefficientForm_of_blockedRepresentations
 
 namespace HasBNTFusionTensorClause
 
-/-- **Theorem 4.14(i) implies (iii).** A horizontal-canonical MPDO satisfying
-the Definition 4.1 renormalization fixed-point condition has the
-source-faithful active-support BNT fusion clause.
+/-- **BNT-refined Theorem 4.14(i) implies (iii).** An MPDO in normalized
+BNT-refined horizontal form that satisfies the Definition 4.1 renormalization
+fixed-point condition has the active-support BNT fusion clause.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Theorem 4.14 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 The one-site vertical decomposition supplies the BNT tensors, multiplicities,
 and positive weights.

--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -12,16 +12,20 @@ import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
 /-!
 # The BNT fusion clause from the MPDO renormalization fixed-point condition
 
-This file completes the implication from statement (i) to statement (iii) of
-CPSV16, Theorem 4.14.  The transported one-site and two-site vertical forms
-give both representations of the blocked closed-chain operator.  Eventual
-linear independence of the BNT operators compares their coefficients, and
-the positive power-sum lemma gives the length-one trace-scalar identity.
+This file proves the implication from statement (i) to statement (iii) of
+CPSV16, Theorem 4.14, for an MPDO in normalized BNT-refined horizontal form.
+The transported one-site and two-site vertical forms give both representations
+of the blocked closed-chain operator.  Eventual linear independence of the BNT
+operators compares their coefficients, and the positive power-sum lemma gives
+the length-one trace-scalar identity.  The corresponding implication from the
+literal CPSV canonical form remains open; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 ## Main result
 
-* `HasBNTFusionTensorClause.of_isRFPViaTS` constructs the source-faithful
-  active-support fusion clause from the Definition 4.1 RFP maps.
+* `HasBNTFusionTensorClause.of_isRFPViaTS` constructs the active-support fusion
+  clause from the Definition 4.1 RFP maps under the normalized BNT-refined
+  horizontal-form hypothesis.
 
 ## References
 

--- a/TNLean/MPS/MPDO/HorizontalBNT.lean
+++ b/TNLean/MPS/MPDO/HorizontalBNT.lean
@@ -121,14 +121,18 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- Horizontal canonical form for an MPO tensor.
+/-- Normalized BNT-refined horizontal form for an MPO tensor.
 
 The doubled-index tensor is the representative-indexed BNT sector
-decomposition, with one invertible gauge on each repeated copy.  Thus the
+decomposition, with one invertible gauge on each repeated copy. Thus the
 global gauge is the block direct sum of the copy gauges, rather than an
-arbitrary similarity that could mix distinct sectors.  Repeated
+arbitrary similarity that could mix distinct sectors. Repeated
 gauge-equivalent copies are grouped over one representative and retain their
-individual nonzero weights.  There is no additional all-zero summand.
+individual nonzero weights. There is no additional all-zero summand.
+
+**Scope restriction (BNT-refined horizontal form):** this predicate is stronger
+than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, canonical form at lines 237--244 and the BNT
 decomposition `eq:II_ABasicTensors` at lines 281--301. -/
@@ -149,7 +153,7 @@ def IsHorizontalCF (M : MPOTensor d D) : Prop :=
                     GL (Fin S.totalDim) ℂ) :
                   Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ))
 
-/-- A literal horizontal canonical form gives its positive-length BNT MPV
+/-- Normalized BNT-refined horizontal form gives its positive-length BNT MPV
 representation.
 
 The block direct sum of the copy similarities leaves every closed
@@ -330,7 +334,7 @@ theorem representative_braRight_eq_ketLeftBraRight_of_invariant
 
 /-- **Lemma L on the original bond space.**
 
-Let `M` be in literal horizontal canonical form.  If two physical operators
+Let `M` be in normalized BNT-refined horizontal form. If two physical operators
 have the same first-site action on every matrix product vector of `M`, then
 their inserted tensors are equal on the original bond space:
 \[
@@ -369,8 +373,9 @@ theorem IsHorizontalCF.insertedTensor_eq_of_firstSiteActionAgree
     S.insertedTensor_toTensor_eq_of_basis Y Z hBasis
   exact MPSTensor.insertedTensor_eq_of_gauge X hX' Y Z hSector
 
-/-- A displaced idempotent for a tensor in horizontal canonical form fails to
-commute with the generated density operator at some positive chain length.
+/-- A displaced idempotent for a tensor in normalized BNT-refined horizontal
+form fails to commute with the generated density operator at some positive
+chain length.
 
 If commutation held at every positive length, idempotence would give the
 one-sided first-site identities for the two-sided compression.  The literal
@@ -429,7 +434,7 @@ theorem IsHorizontalCF.exists_not_commute_of_displaced
   have hij := congrFun hTensor (finProdFinEquiv (i, j))
   simpa [toMPSTensor] using hij
 
-/-- The public horizontal canonical-form predicate supplies the
+/-- The normalized BNT-refined horizontal-form predicate supplies the
 representative-indexed invariant-projection conclusion.
 
 The witness is the BNT sector decomposition occurring in `IsHorizontalCF`.

--- a/TNLean/MPS/MPDO/HorizontalBlocking.lean
+++ b/TNLean/MPS/MPDO/HorizontalBlocking.lean
@@ -8,9 +8,9 @@ import TNLean.MPS.MPDO.HorizontalBNT
 import TNLean.MPS.MPDO.PhysicalBlocking
 
 /-!
-# Horizontal canonical form under two-site blocking
+# Normalized BNT-refined horizontal form under two-site blocking
 
-Two-site physical blocking preserves horizontal canonical form. The sector
+Two-site physical blocking preserves normalized BNT-refined horizontal form. The sector
 representatives and copy weights are blocked, the physical alphabet is
 relabeled by the canonical ket--bra equivalence, and every copy retains its
 original virtual gauge.
@@ -26,11 +26,16 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- Two-site physical blocking preserves horizontal canonical form.
+/-- Two-site physical blocking preserves normalized BNT-refined horizontal
+form.
 
 The proof blocks the BNT sector decomposition, transports it through the
 canonical ket--bra physical-index equivalence, and uses the same block-diagonal
 virtual gauge on every blocked word.
+
+**Scope restriction (BNT-refined horizontal form):** This theorem starts from
+`IsHorizontalCF`, not from literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
 theorem IsHorizontalCF.blockTwo {M : MPOTensor d D}

--- a/TNLean/MPS/MPDO/HorizontalBlocking.lean
+++ b/TNLean/MPS/MPDO/HorizontalBlocking.lean
@@ -10,8 +10,8 @@ import TNLean.MPS.MPDO.PhysicalBlocking
 /-!
 # Normalized BNT-refined horizontal form under two-site blocking
 
-Two-site physical blocking preserves normalized BNT-refined horizontal form. The sector
-representatives and copy weights are blocked, the physical alphabet is
+Two-site physical blocking preserves normalized BNT-refined horizontal form.
+The sector representatives and copy weights are blocked, the physical alphabet is
 relabeled by the canonical ket--bra equivalence, and every copy retains its
 original virtual gauge.
 

--- a/TNLean/MPS/MPDO/LinearMarkedTensor.lean
+++ b/TNLean/MPS/MPDO/LinearMarkedTensor.lean
@@ -32,8 +32,8 @@ not detect arbitrary off-diagonal matrices between repeated sectors.
 * `linearMarkedTensor_gauge`: linear marking is covariant under a common
   virtual similarity.
 * `MPOTensor.IsHorizontalCF.linearMarkedTensor_eq_of_trace_agree`: closed
-  marked-chain equality separates physical-letter marks in literal
-  horizontal canonical form.
+  marked-chain equality separates physical-letter marks in normalized
+  BNT-refined horizontal form.
 
 ## References
 
@@ -172,7 +172,7 @@ namespace MPOTensor.IsHorizontalCF
 variable {d e D : ℕ}
 
 /-- Closed chains with one marked letter separate two physical-letter marks
-for a tensor in literal horizontal canonical form.
+for a tensor in normalized BNT-refined horizontal form.
 
 For coefficient families `f` and `g`, suppose that replacing the first
 physical letter by `sum_z f u z M^z` or by `sum_z g u z M^z` gives equal
@@ -184,8 +184,10 @@ bond-space marks would give a false statement because closed chains cannot
 detect off-diagonal matrices between repeated sectors.
 
 This is the physical-insertion scope of Lemma L in arXiv:1606.00608,
-Appendix C.3, lines 1835--1858, transported through the literal horizontal
-block gauge used in Proposition 4.13, lines 1909--1919. -/
+Appendix C.3, lines 1835--1858, under the stronger `IsHorizontalCF` hypothesis.
+It does not provide the retained-coordinate separation from literal CPSV
+canonical form needed by Proposition 4.13; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 theorem linearMarkedTensor_eq_of_trace_agree
     (M : MPOTensor d D) (hHorizontal : M.IsHorizontalCF)
     (f g : Fin e → Fin (d * d) → ℂ)

--- a/TNLean/MPS/MPDO/LinearMarkedTensor.lean
+++ b/TNLean/MPS/MPDO/LinearMarkedTensor.lean
@@ -14,10 +14,10 @@ letter by taking the corresponding linear combination of the local tensor
 matrices.  Such marked letters commute with weighted direct sums and are
 covariant under a common virtual similarity.
 
-For a tensor in literal horizontal canonical form, equality of every closed
-chain with one such marked letter implies equality of the marked tensors.
-The proof passes to the representative-indexed sector decomposition, applies
-representative-grouped marked separation, and returns through the literal
+For a tensor in normalized BNT-refined horizontal form, equality of every
+closed chain with one such marked letter implies equality of the marked
+tensors.  The proof passes to the representative-indexed sector decomposition,
+applies representative-grouped marked separation, and returns through the
 block-diagonal gauge.
 
 The restriction to the physical-letter span is essential: closed chains do

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -203,6 +203,12 @@ theorem cpsvVerticalDecomposition_of_grouped_orthogonal_sectors
 /-- Horizontal canonical form and MPDO positivity furnish a vertical
 decomposition which retains the literal CPSV16 basis predicate.
 
+**Scope restriction:** `IsHorizontalCF` is a normalized BNT-refined hypothesis,
+strictly stronger than the literal CPSV canonical form assumed by Proposition
+4.13.  The literal implication remains open at the Lemma L separation after
+active-block refinement and transport through the ambient coisometry; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem IsHorizontalCF.exists_cpsvVerticalDecomposition
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -19,8 +19,8 @@ positivity.
   the source basis-of-normal-tensors predicate.
 * `IsHorizontalCF.exists_cpsvVerticalDecomposition`: construction of this
   decomposition from normalized BNT-refined horizontal form and positivity.
-* `exists_positiveFusionDecomposition_of_isRFPViaTS`: the source-facing
-  positive fusion theorem of CPSV16, Appendix C.4, lines 2020--2029.
+* `exists_positiveFusionDecomposition_of_isRFPViaTS`: the BNT-refined positive
+  fusion theorem corresponding to CPSV16, Appendix C.4, lines 2020--2029.
 
 ## References
 
@@ -201,8 +201,8 @@ theorem cpsvVerticalDecomposition_of_grouped_orthogonal_sectors
     reconstruction := hReconstruction
   }⟩
 
-/-- Horizontal canonical form and MPDO positivity furnish a vertical
-decomposition which retains the literal CPSV16 basis predicate.
+/-- Normalized BNT-refined horizontal form and MPDO positivity furnish a
+vertical decomposition which retains the literal CPSV16 basis predicate.
 
 **Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
 stronger than the literal CPSV canonical form assumed by Proposition 4.13.  The

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -203,11 +203,11 @@ theorem cpsvVerticalDecomposition_of_grouped_orthogonal_sectors
 /-- Horizontal canonical form and MPDO positivity furnish a vertical
 decomposition which retains the literal CPSV16 basis predicate.
 
-**Scope restriction:** `IsHorizontalCF` is a normalized BNT-refined hypothesis,
-strictly stronger than the literal CPSV canonical form assumed by Proposition
-4.13.  The literal implication remains open at the Lemma L separation after
-active-block refinement and transport through the ambient coisometry; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form assumed by Proposition 4.13.  The
+literal implication remains open at the Lemma L separation after active-block
+refinement and transport through the ambient coisometry; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem IsHorizontalCF.exists_cpsvVerticalDecomposition

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -10,14 +10,15 @@ import TNLean.MPS.MPDO.VerticalProductFusionDecomposition
 
 This file derives the positive fusion decomposition of the one-site vertical
 basis of normal tensors directly from the renormalization fixed-point maps,
-horizontal canonical form, and matrix-product-density-operator positivity.
+normalized BNT-refined horizontal form, and matrix-product-density-operator
+positivity.
 
 ## Main results
 
 * `CPSVVerticalDecomposition`: a vertical canonical decomposition retaining
   the source basis-of-normal-tensors predicate.
 * `IsHorizontalCF.exists_cpsvVerticalDecomposition`: construction of this
-  decomposition from horizontal canonical form and positivity.
+  decomposition from normalized BNT-refined horizontal form and positivity.
 * `exists_positiveFusionDecomposition_of_isRFPViaTS`: the source-facing
   positive fusion theorem of CPSV16, Appendix C.4, lines 2020--2029.
 
@@ -258,13 +259,18 @@ theorem IsHorizontalCF.exists_cpsvVerticalDecomposition
     (fun j ↦ blocks (C.repr j)) hBNT W hWIso hWOrth hWInter
     hWReconstructFlat
 
-/-- A horizontally canonical matrix product density operator satisfying the
-renormalization fixed-point condition has a positive fusion decomposition of
-its vertical basis of normal tensors.
+/-- A matrix product density operator in normalized BNT-refined horizontal form
+that satisfies the renormalization fixed-point condition has a positive fusion
+decomposition of its vertical basis of normal tensors.
 
 For every pair of BNT labels, the fusion map is a coisometry onto the active
 direct sum.  Both forward conjugation and exact reconstruction are asserted,
 so zero product tensors and proper active supports are permitted.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13.  The literal implication remains open; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 **Scope restriction (active product BNT):** Only active product corners are
 retained.  A BNT label absent from a fixed product pair has zero fusion

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -207,7 +207,8 @@ decomposition which retains the literal CPSV16 basis predicate.
 stronger than the literal CPSV canonical form assumed by Proposition 4.13.  The
 literal implication remains open at the Lemma L separation after active-block
 refinement and transport through the ambient coisometry; see
-`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex` for this scope and
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex` for the missing step.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem IsHorizontalCF.exists_cpsvVerticalDecomposition

--- a/TNLean/MPS/MPDO/TwoSiteVerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/TwoSiteVerticalCanonicalForm.lean
@@ -9,8 +9,9 @@ import TNLean.MPS.MPDO.VerticalCanonicalForm
 /-!
 # Vertical canonical form before and after two-site blocking
 
-For a horizontally canonical matrix product density operator, Proposition 4.13
-applies both to the original tensor and to its two-site physical blocking.
+For a matrix product density operator in normalized BNT-refined horizontal
+form, the current Proposition 4.13 specialization applies both to the original
+tensor and to its two-site physical blocking.
 This is the first step of the two-site comparison in Appendix C.4 of
 arXiv:1606.00608.
 -/
@@ -19,8 +20,13 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- A horizontally canonical matrix product density operator and its two-site
-blocking are both in vertical canonical form.
+/-- A matrix product density operator in normalized BNT-refined horizontal form
+and its two-site blocking are both in vertical canonical form.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13.  The literal implication remains open; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
 theorem verticalCF_and_blockTwo_of_horizontalCF (M : MPOTensor d D)

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -676,7 +676,7 @@ theorem sameMPV₂Pos_toTensorFromBlocks_verticalAssembledTensor_of_equiv
   · exact Equiv.sum_comp e
       (fun p : (α : Fin g) × Fin (mult α) ↦ (ω p.1 p.2) ^ N • MPSTensor.mpv (A p.1) σ)
 
--- The implication `verticalCF_of_horizontalCF` from arXiv:1606.00608,
--- Proposition 4.13, is proved in `VerticalCanonicalForm.lean`.
+-- The BNT-refined implication `verticalCF_of_horizontalCF` is proved in
+-- `VerticalCanonicalForm.lean`; literal Proposition 4.13 remains open.
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -41,6 +41,12 @@ normal tensors and the normalized physical sector maps.  Their positive
 weights, orthogonal isometric ranges, intertwinings, and exact reconstruction
 then combine to give the vertical coisometry.
 
+**Scope restriction:** `IsHorizontalCF` is a normalized BNT-refined hypothesis,
+strictly stronger than the literal CPSV canonical form assumed by Proposition
+4.13.  The literal implication remains open at the Lemma L separation after
+active-block refinement and transport through the ambient coisometry; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem verticalCF_of_horizontalCF (M : MPOTensor d D)
     (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -41,11 +41,11 @@ normal tensors and the normalized physical sector maps.  Their positive
 weights, orthogonal isometric ranges, intertwinings, and exact reconstruction
 then combine to give the vertical coisometry.
 
-**Scope restriction:** `IsHorizontalCF` is a normalized BNT-refined hypothesis,
-strictly stronger than the literal CPSV canonical form assumed by Proposition
-4.13.  The literal implication remains open at the Lemma L separation after
-active-block refinement and transport through the ambient coisometry; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form assumed by Proposition 4.13.  The
+literal implication remains open at the Lemma L separation after active-block
+refinement and transport through the ambient coisometry; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem verticalCF_of_horizontalCF (M : MPOTensor d D)

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -45,7 +45,8 @@ then combine to give the vertical coisometry.
 stronger than the literal CPSV canonical form assumed by Proposition 4.13.  The
 literal implication remains open at the Lemma L separation after active-block
 refinement and transport through the ambient coisometry; see
-`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex` for this scope and
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex` for the missing step.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem verticalCF_of_horizontalCF (M : MPOTensor d D)

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -10,16 +10,16 @@ import TNLean.MPS.MPDO.VerticalCoisometry
 /-!
 # Vertical canonical form of matrix product density operators
 
-The grouped vertical decomposition of a horizontally canonical matrix product
-density operator supplies a basis of normal tensors and normalized physical
-sector maps.  The resulting positive weights and sector maps give the
+The grouped vertical decomposition of a matrix product density operator in
+normalized BNT-refined horizontal form supplies a basis of normal tensors and
+normalized physical sector maps.  The resulting positive weights and sector maps give the
 coisometry and the two exact block-diagonal identities of the vertical
 canonical form.
 
 ## Main result
 
-* `MPOTensor.verticalCF_of_horizontalCF`: every horizontally canonical matrix
-  product density operator is in vertical canonical form.
+* `MPOTensor.verticalCF_of_horizontalCF`: every matrix product density operator
+  in normalized BNT-refined horizontal form is in vertical canonical form.
 
 ## References
 
@@ -33,8 +33,8 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- A horizontally canonical matrix product density operator is also in
-vertical canonical form.
+/-- A matrix product density operator in normalized BNT-refined horizontal form
+is also in vertical canonical form.
 
 The same grouped vertical decomposition supplies both the algebraic basis of
 normal tensors and the normalized physical sector maps.  Their positive

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -12,9 +12,9 @@ import TNLean.MPS.MPDO.VerticalCoisometry
 
 The grouped vertical decomposition of a matrix product density operator in
 normalized BNT-refined horizontal form supplies a basis of normal tensors and
-normalized physical sector maps.  The resulting positive weights and sector maps give the
-coisometry and the two exact block-diagonal identities of the vertical
-canonical form.
+normalized physical sector maps. The resulting positive weights and sector
+maps give the coisometry and the two exact block-diagonal identities of the
+vertical canonical form.
 
 ## Main result
 

--- a/TNLean/MPS/MPDO/VerticalProductCornerPositivity.lean
+++ b/TNLean/MPS/MPDO/VerticalProductCornerPositivity.lean
@@ -33,6 +33,10 @@ variable {g D : ℕ} {dim mult : Fin g → ℕ}
 /-- The scalar multiplying the blocked BNT representative in every active
 product corner is positive.
 
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 Source: CPSV16, Appendix C.4, lines 2025--2029, using the sector-weight
 positivity argument from Proposition 4.13, lines 1898--1902. -/
 theorem FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos

--- a/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
@@ -216,10 +216,6 @@ private theorem groupedFusionCoisometry_reconstruction
 /-- The positive original-label corners determine the fusion coisometries of
 the BNT family.
 
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form used in Appendix C.4 through
-Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
-
 **Scope restriction (active product BNT):** Only active product corners are
 retained.  A BNT label absent from a fixed product pair has zero fusion
 multiplicity.  Documented in

--- a/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
@@ -216,6 +216,10 @@ private theorem groupedFusionCoisometry_reconstruction
 /-- The positive original-label corners determine the fusion coisometries of
 the BNT family.
 
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 **Scope restriction (active product BNT):** Only active product corners are
 retained.  A BNT label absent from a fixed product pair has zero fusion
 multiplicity.  Documented in
@@ -353,6 +357,10 @@ theorem exists_positiveFusionDecomposition_of_unitaryBlockEquiv
 positive diagonal multiplicity matrices and coisometries onto the active
 product sectors.  The adjoint coisometries reconstruct every product letter,
 including when a common zero corner is discarded by the forward map.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 **Scope restriction (active product BNT):** Only active product corners are
 retained.  A one-site BNT label absent from a fixed product pair has zero

--- a/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
@@ -506,9 +506,9 @@ theorem verticalTensor_blockTwo_squared_coisometry_reconstruction
 /-- The squared retained product inherits projector closure and absence of
 periodic vectors from the blocked vertical tensor.
 
-The one-site coisometric reconstruction is squared exactly. Horizontal
-canonical form and positivity pass to two-site blocking, so the blocked
-vertical tensor has the two canonical-form hypotheses. The preceding
+The one-site coisometric reconstruction is squared exactly. Normalized
+BNT-refined horizontal form and positivity pass to two-site blocking, so the
+blocked vertical tensor has the two canonical-form hypotheses. The preceding
 coisometric transfer theorem then passes both hypotheses to the retained
 product tensor, including when its active support is smaller than the full
 product bond space.

--- a/TNLean/MPS/MPDO/VerticalProductSpectralFamily.lean
+++ b/TNLean/MPS/MPDO/VerticalProductSpectralFamily.lean
@@ -90,7 +90,11 @@ structure RetainedProductSpectralFamily
     (∑ k, localDim p k) ≤ dim p.1.1 * dim p.2.1
 
 /-- The local spectral decompositions may be chosen simultaneously for every
-retained copy pair.  Empty active families are preserved. -/
+retained copy pair.  Empty active families are preserved.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 theorem exists_retainedProductSpectralFamily
     {g d D : ℕ} (dim mult : Fin g → ℕ)
     (weight : (α : Fin g) → Fin (mult α) → ℂ)

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_intro_finite_separation.tex
@@ -67,14 +67,14 @@
     \cite[Section~2.3, lines~298--301]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Horizontal canonical form gives the BNT MPV representation]
+\begin{theorem}[BNT-refined horizontal form gives the BNT MPV representation]
     \label{thm:horizontal_cf_gives_mpv_representation}
     \lean{MPOTensor.IsHorizontalCF.hasHorizontalCFMPVRepresentation}
     \leanok
     \uses{def:horizontal_cf_mpdo,
         def:horizontal_cf_mpv_representation}
-    Every MPO tensor in horizontal canonical form has the associated positive-length
-    BNT matrix-product-vector representation.
+    Every MPO tensor in normalized BNT-refined horizontal form has the
+    associated positive-length BNT matrix-product-vector representation.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_representative_marked.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_representative_marked.tex
@@ -404,7 +404,7 @@
     Theorem~\ref{thm:representative_grouped_marked_separation}.
 \end{proof}
 
-\begin{corollary}[Physical-letter marked separation in horizontal canonical form]
+\begin{corollary}[Physical-letter marked separation in BNT-refined horizontal form]
     \label{cor:horizontal_cf_linear_marked_separation}
     \lean{MPSTensor.linearMarkedTensor}
     \lean{MPSTensor.linearMarkedTensor_toTensorFromBlocks}
@@ -415,7 +415,7 @@
     \leanok
     \uses{def:horizontal_cf_mpdo,
         cor:bnt_marked_representative_separation}
-    Let $M$ be an MPO tensor in literal horizontal canonical form. For two
+    Let $M$ be an MPO tensor in normalized BNT-refined horizontal form. For two
     coefficient families $f_{u,z}$ and $g_{u,z}$, put
     $C^u=\sum_z f_{u,z}M^z$ and $E^u=\sum_z g_{u,z}M^z$.
     If $\tr(C^uM^w)=\tr(E^uM^w)$ for every marked index $u$ and every word
@@ -433,8 +433,8 @@
 \begin{proof}
     \leanok
     \uses{cor:bnt_marked_representative_separation}
-    Pass through the block-diagonal similarity in the literal horizontal
-    canonical form. Linear combinations of physical letters are covariant
+    Pass through the block-diagonal similarity in the normalized BNT-refined
+    horizontal form. Linear combinations of physical letters are covariant
     under this similarity, and cyclicity of the trace removes it from each
     closed marked chain. On the representative-indexed sector
     decomposition one has

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -668,7 +668,7 @@
     $T$.
 \end{proof}
 
-% Source anchor: CPSV16 Proposition 4.13, statement at lines 1863--1870.
+% Source anchor: CPSV16 Proposition 4.13, statement and proof at lines 1863--1922.
 \begin{theorem}[Vertical canonical form of a canonical MPDO]
     \label{thm:vertical_cf_of_cpsv_canonical_form}
     \notready
@@ -678,15 +678,116 @@
     then $M$ is in canonical form in the vertical direction. More precisely,
     there is a basis of normal tensors $\{M_\alpha\}_\alpha$ for the vertically
     viewed tensor $\widetilde M$, together with positive diagonal matrices
-    $\mu_\alpha$ and an isometry $U$ such that
+    $\mu_\alpha$ and a coisometry $U$ from the physical space onto the retained
+    nonzero sectors. Writing
+    $B=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$, one has
     \begin{align}
-        U\widetilde M U^\dagger
-         &=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha.
+        UU^\dagger&=\Id.
+        \label{eq:cpsv_prop_4_13_coisometry}
+    \end{align}
+    \begin{align}
+        U\widetilde M U^\dagger&=B.
         \label{eq:cpsv_prop_4_13_vertical_form}
     \end{align}
-    This is \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+    \begin{align}
+        \widetilde M&=U^\dagger BU.
+        \label{eq:cpsv_prop_4_13_reconstruction}
+    \end{align}
+    This is \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}. The paper calls $U$
+    an isometry. In the displayed rectangular orientation, however, $U$ maps
+    the physical space onto the retained sector space and satisfies
+    $UU^\dagger=\Id$; thus $U$ is a coisometry and $U^\dagger$ is the
+    isometric inclusion.
 \end{theorem}
 
+\begin{proof}
+    Write $A$ for the doubled-index MPS tensor of $M$. Begin with its literal
+    canonical-form decomposition. Discard the blocks with zero coefficient,
+    partition the remaining normal blocks by
+    gauge-phase equivalence, and choose one representative $M_\alpha$ in each
+    class. The resulting coefficients $\nu_{\alpha,k}$ are nonzero. On the
+    retained horizontal support one has
+    \begin{align}
+        A^i
+        &=\bigoplus_{\alpha,k}
+          \nu_{\alpha,k}X_{\alpha,k}M_\alpha^iX_{\alpha,k}^{-1}.
+        \label{eq:cpsv_prop_4_13_active_bnt}
+    \end{align}
+    The representatives form the active basis of normal tensors associated
+    with the literal canonical form; the ambient coisometry in the canonical
+    form reconstructs the omitted zero complement. This refinement is derived
+    from the literal hypothesis and is not an assumption of normalized
+    BNT-refined horizontal form.
+
+    Let $H^{(N)}$ be the positive operator generated horizontally by $M$. If
+    an orthogonal projector $P$ on the physical space satisfies
+    $P\widetilde M=P\widetilde MP$, and $P_1$ acts on the first site, then
+    self-adjointness gives
+    \begin{align}
+        P_1H^{(N)}
+        &=P_1H^{(N)}P_1
+          =(P_1H^{(N)}P_1)^\dagger
+          =H^{(N)}P_1.
+        \label{eq:cpsv_prop_4_13_first_site}
+    \end{align}
+    Lemma~L applied to the active decomposition
+    (\ref{eq:cpsv_prop_4_13_active_bnt}) separates the first-site insertions
+    block by block and yields
+    $\widetilde MP=P\widetilde MP$. Hence
+    $(\Id-P)\widetilde MP=0$, so every one-sided invariant subspace is
+    reducing.
+
+    There are no nontrivial periodic vertical sectors. Otherwise a cyclic
+    projector $Q$ and an integer $p>1$ would commute with
+    $[H^{(N)}]^p$ but not with $H^{(N)}$. Since $H^{(N)}$ is positive
+    semidefinite, it is the positive $p$-th root of $[H^{(N)}]^p$; therefore
+    every operator commuting with $[H^{(N)}]^p$ also commutes with
+    $H^{(N)}$, a contradiction. Invariant-projector closure and the absence
+    of periodic sectors give a direct sum of normal vertical sectors.
+
+    Group gauge-equivalent vertical sectors over the representatives
+    $M_\alpha$. For each active copy $(\alpha,k)$, let $P_{\alpha,k}$ be its
+    range projection. At some length its compression is nonzero and positive,
+    and its trace has the form
+    \begin{align}
+        \tr\!\left(P_{\alpha,k}H^{(N)}P_{\alpha,k}\right)
+        &=\mu_{\alpha,k}d_\alpha>0.
+        \label{eq:cpsv_prop_4_13_positive_weight}
+    \end{align}
+    Choose the reference copy with $\mu_{\alpha,1}>0$. Then $d_\alpha>0$,
+    and (\ref{eq:cpsv_prop_4_13_positive_weight}) implies
+    $\mu_{\alpha,k}>0$ for every copy.
+
+    Self-adjointness of the same sector compressions gives the marked-chain
+    identity used in the proof of Proposition~4.13. A second application
+    of Lemma~L transfers this equality to the local tensors. Normal-tensor
+    rigidity then makes the relative Gram matrix scalar: for every $k$ there
+    is $\omega_{\alpha,k}>0$ such that
+    \begin{align}
+        X_{\alpha,k}^\dagger X_{\alpha,k}
+        &=\omega_{\alpha,k}
+          X_{\alpha,1}^\dagger X_{\alpha,1}.
+        \label{eq:cpsv_prop_4_13_gram}
+    \end{align}
+    Choose $X_{\alpha,1}=\Id$ and replace each remaining gauge by
+    $\omega_{\alpha,k}^{-1/2}X_{\alpha,k}$. The gauges are then unitary, while
+    their conjugation actions are unchanged.
+
+    Compose these unitary bond gauges with the mutually orthogonal inclusions
+    of the retained vertical sectors, and take their adjoints as the block-row
+    map $U$. The orthogonality of the sector ranges gives
+    (\ref{eq:cpsv_prop_4_13_coisometry}), and the sector intertwinings give
+    (\ref{eq:cpsv_prop_4_13_vertical_form}). Invariant-projector closure makes
+    the retained support reducing, while the complement is the all-zero
+    sector. Summing the sector reconstructions therefore gives the exact
+    identity (\ref{eq:cpsv_prop_4_13_reconstruction}).
+
+    The preceding paragraphs describe the source proof. The present formal
+    theorem starts from the stronger normalized BNT-refined horizontal form.
+    For the literal canonical-form hypothesis, the unresolved step is Lemma~L
+    in the first-site separation used above; the active-block refinement alone
+    does not supply that separation. Thus the literal theorem remains open.
+\end{proof}
 \begin{theorem}[BNT-refined horizontal form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \lean{MPOTensor.verticalCF_of_horizontalCF}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -741,11 +741,22 @@
           =H^{(N)}P_1.
         \label{eq:cpsv_prop_4_13_first_site}
     \end{align}
-    The missing step is to prove that the representative-grouped Lemma~L
-    remains applicable after compression to
-    (\ref{eq:cpsv_prop_4_13_active_bnt}) and that its separated identity carries
-    back through the ambient coisometry $V$. Once this is established, it gives
-    $\widetilde MP=P\widetilde MP$, hence
+    Write $Y_R(P)$ and $Y_C(P)$ for the right and central first-site
+    contractions determined by $P$. The missing step is to prove that the
+    representative-grouped Lemma~L remains applicable after compression to
+    (\ref{eq:cpsv_prop_4_13_active_bnt}), so that
+    \begin{align}
+        Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i
+        \qquad\text{for every $\alpha$ and $i$},
+        \label{eq:cpsv_prop_4_13_missing_active_separation}
+    \end{align}
+    and then to carry this separated identity back through the ambient
+    coisometry $V$ to obtain
+    \begin{align}
+        \widetilde MP&=P\widetilde MP.
+        \label{eq:cpsv_prop_4_13_missing_coisometry_transport}
+    \end{align}
+    Once these two implications are established,
     $(\Id-P)\widetilde MP=0$. Thus every one-sided invariant subspace is
     reducing.
 
@@ -776,10 +787,17 @@
 
     Self-adjointness of the same sector compressions gives the marked-chain
     identity used in the proof of Proposition~4.13. A second instance of the
-    same retained-coordinate separation would transfer this equality to the
-    local tensors. Normal-tensor rigidity would then make the relative Gram
-    matrix scalar: for every $k$ there
-    is $\omega_{\alpha,k}>0$ such that
+    missing retained-coordinate separation must transfer it to the local
+    Gram-conjugation identity
+    \begin{align}
+        (X_{\alpha,k}^\dagger X_{\alpha,k})M_\alpha^v
+        (X_{\alpha,k}^\dagger X_{\alpha,k})^{-1}
+        &=(X_{\alpha,1}^\dagger X_{\alpha,1})M_\alpha^v
+        (X_{\alpha,1}^\dagger X_{\alpha,1})^{-1}.
+        \label{eq:cpsv_prop_4_13_missing_gram_conjugation}
+    \end{align}
+    Normal-tensor rigidity would then make the relative Gram matrix scalar:
+    for every $k$ there is $\omega_{\alpha,k}>0$ such that
     \begin{align}
         X_{\alpha,k}^\dagger X_{\alpha,k}
         &=\omega_{\alpha,k}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -235,8 +235,8 @@
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
         def:invariant_projector_closure,
         thm:representative_one_sub_mp_zero}
-    Let $M$ be in horizontal canonical form and generate matrix product
-    density operators. If an orthogonal projection $P$ satisfies
+    Let $M$ be in normalized BNT-refined horizontal form and generate matrix
+    product density operators. If an orthogonal projection $P$ satisfies
     $P\widetilde M_v=P\widetilde M_vP$ for every vertical letter $v$, then it
     also satisfies $\widetilde M_vP=P\widetilde M_vP$ for every vertical
     letter $v$. Thus the vertically viewed tensor has invariant-projector
@@ -247,7 +247,7 @@
     \leanok
     \uses{thm:representative_one_sub_mp_zero}
     Translate the left-invariance identity into the one-site ket and bra
-    actions of the original tensor. The horizontal canonical-form version of
+    actions of the original tensor. The normalized BNT-refined version of
     Lemma~L gives the opposite one-sided identity. Translating back to the
     vertically viewed tensor proves the claim.
 \end{proof}
@@ -580,8 +580,8 @@
 
 \begin{proof}
     \leanok
-    The unit-modulus weight witness in the horizontal canonical form, together
-    with left canonicity of its representative, makes the doubled-index tensor
+    The unit-modulus weight witness in the normalized BNT-refined horizontal
+    form, together with left canonicity of its representative, makes the doubled-index tensor
     nonzero. Hence its vertical reshaping $\widetilde M$ is nonzero. If the
     retained decomposition had no sector,
     (\ref{eq:mpdo_vertical_grouped_reconstruction}) would make every letter of
@@ -594,8 +594,8 @@
     \lean{MPOTensor.IsHorizontalCF.verticalTensor_ne_zero}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:vertical_tensor_mpdo}
-    If an MPO tensor $M$ is in horizontal canonical form, then its vertical
-    reshaping is nonzero: $\widetilde M\ne0$.
+    If an MPO tensor $M$ is in normalized BNT-refined horizontal form, then
+    its vertical reshaping is nonzero: $\widetilde M\ne0$.
     This is the nonvanishing observation used in
     \cite[Proposition~4.13, lines~1895--1902]{Cirac2016MPDO_arXiv}.
 \end{theorem}
@@ -604,8 +604,8 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:vertical_tensor_mpdo,
         lem:sector_bnt_weight_unit_exists_of_struct}
-    Write the doubled-index tensor in horizontal canonical form as
-    $\widehat M=GSG^{-1}$, where $S$ is the weighted direct sum of its basis
+    Write the doubled-index tensor in normalized BNT-refined horizontal form
+    as $\widehat M=GSG^{-1}$, where $S$ is the weighted direct sum of its basis
     tensors. Choose a copy whose weight has unit modulus. Its basis tensor
     cannot have every letter equal to zero, since left canonicity gives
     $\sum_i(A^i)^\dagger A^i=\Id$.
@@ -619,10 +619,10 @@
     \label{thm:mpdo_vertical_grouped_is_bnt}
     \lean{MPOTensor.isBNT_verticalTensor_of_grouping}
     \leanok
-    \uses{def:horizontal_cf_mpdo, def:vertical_tensor_mpdo, def:bnt,
+    \uses{def:vertical_tensor_mpdo, def:bnt,
         def:bnt_cpsv, def:mpv_phase_class_data}
-    Let $M$ be in horizontal canonical form and put $T=\widetilde M$. Let
-    $B_k$ have bond dimension $d_k$, let $\mu_k\in\C$, and let
+    Let $M$ be an MPO tensor and put $T=\widetilde M$. Let $B_k$ have bond
+    dimension $d_k$, let $\mu_k\in\C$, and let
     $V_k:\C^{d_k}\to\C^d$ be an isometry for $0\leq k<r$. Assume, for every
     vertical letter $v$, that
     \begin{align}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -669,11 +669,13 @@
 \end{proof}
 
 % Source anchor: CPSV16 Proposition 4.13, statement and proof at lines 1863--1922.
+% Local fix (rectangular coisometry and reconstruction): the source calls U an
+% isometry and prints only the compressed identity. See
+% docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex.
 \begin{theorem}[Vertical canonical form of a canonical MPDO]
     \label{thm:vertical_cf_of_cpsv_canonical_form}
     \notready
-    \uses{def:mpdo, def:cpsv_canonical_form, def:vertical_cf_mpdo,
-        thm:cpsv_canonical_form_bnt_existence}
+    \uses{def:mpdo, def:cpsv_canonical_form, def:vertical_cf_mpdo}
     Let $M$ be an MPO tensor whose doubled-index MPS tensor is in the literal
     CPSV canonical form. If $M$ generates matrix product density operators,
     then $M$ is in canonical form in the vertical direction. More precisely,
@@ -706,7 +708,9 @@
     including the permitted zero orthogonal complement.
 \end{theorem}
 
-\begin{proof}
+\begin{proof}[Proof outline]
+    \uses{thm:cpsv_canonical_form_bnt_existence,
+        thm:representative_grouped_insert_eq}
     Write $A$ for the doubled-index MPS tensor of $M$. If $A=0$, take no
     retained sectors; the unique map onto the zero-dimensional sector space
     gives the conclusion. Suppose henceforth that $A\ne0$. Begin with its
@@ -737,11 +741,12 @@
           =H^{(N)}P_1.
         \label{eq:cpsv_prop_4_13_first_site}
     \end{align}
-    After compression by $V$, Lemma~L applied to the active decomposition
-    (\ref{eq:cpsv_prop_4_13_active_bnt}) separates the first-site insertions
-    block by block. Reconstructing with $V$ yields
-    $\widetilde MP=P\widetilde MP$. Hence
-    $(\Id-P)\widetilde MP=0$, so every one-sided invariant subspace is
+    The missing step is to prove that the representative-grouped Lemma~L
+    remains applicable after compression to
+    (\ref{eq:cpsv_prop_4_13_active_bnt}) and that its separated identity carries
+    back through the ambient coisometry $V$. Once this is established, it gives
+    $\widetilde MP=P\widetilde MP$, hence
+    $(\Id-P)\widetilde MP=0$. Thus every one-sided invariant subspace is
     reducing.
 
     There are no nontrivial periodic vertical sectors. Otherwise a cyclic
@@ -770,9 +775,10 @@
     $\mu_{\alpha,k}>0$ for every copy.
 
     Self-adjointness of the same sector compressions gives the marked-chain
-    identity used in the proof of Proposition~4.13. A second application
-    of Lemma~L transfers this equality to the local tensors. Normal-tensor
-    rigidity then makes the relative Gram matrix scalar: for every $k$ there
+    identity used in the proof of Proposition~4.13. A second instance of the
+    same retained-coordinate separation would transfer this equality to the
+    local tensors. Normal-tensor rigidity would then make the relative Gram
+    matrix scalar: for every $k$ there
     is $\omega_{\alpha,k}>0$ such that
     \begin{align}
         X_{\alpha,k}^\dagger X_{\alpha,k}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -795,12 +795,12 @@
 
     The preceding paragraphs recast the source proof on the active retained
     coordinates required by the literal canonical-form definition.
-    Theorem~\ref{thm:vertical_cf_of_horizontal_cf} below establishes the same
-    conclusion from the stronger normalized BNT-refined horizontal form. For
-    the literal canonical-form hypothesis, the unresolved step is the Lemma~L
-    separation after passage to the active decomposition; the refinement alone
-    does not supply that separation. Thus the literal theorem remains open.
 \end{proof}
+
+% Formalization status: the theorem above remains \notready. The theorem below
+% proves the same conclusion from the stronger normalized BNT-refined horizontal
+% form. For literal canonical form, the missing step is Lemma L separation after
+% passage to the active decomposition and back through the ambient coisometry.
 
 \begin{theorem}[BNT-refined horizontal form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -710,7 +710,18 @@
 
 \begin{proof}[Proof outline]
     \uses{thm:cpsv_canonical_form_bnt_existence,
-        thm:representative_grouped_insert_eq}
+        thm:representative_grouped_insert_eq,
+        thm:projector_closure_irreducible_corners,
+        thm:mpdo_no_periodic_sector_projector,
+        thm:psd_commute_of_commute_pow,
+        lem:irreducible_transfer_perron_pair,
+        lem:irreducible_block_spectral_normalization,
+        thm:cpsv_normal_mpv_phase_gauge,
+        thm:cpsv_normal_separated_eventually_li,
+        thm:mpdo_sector_compression_trace_pos,
+        thm:mpdo_sector_weight_pos,
+        thm:normal_tensor_gram_rigidity,
+        thm:vertical_sector_coisometry}
     Write $A$ for the doubled-index MPS tensor of $M$. If $A=0$, take no
     retained sectors; the unique map onto the zero-dimensional sector space
     gives the conclusion. Suppose henceforth that $A\ne0$. Begin with its
@@ -730,7 +741,8 @@
     including omission of all zero-weight blocks, follows from the literal
     hypothesis; it does not assume normalized BNT-refined horizontal form.
 
-    Let $H^{(N)}$ be the positive operator generated horizontally by $M$. If
+    Let $H^{(N)}$ be the positive operator generated horizontally by
+    $\widetilde M$. If
     an orthogonal projector $P$ on the physical space satisfies
     $P\widetilde M=P\widetilde MP$, and $P_1$ acts on the first site, then
     self-adjointness gives
@@ -744,14 +756,13 @@
     Write $Y_R(P)$ and $Y_C(P)$ for the right and central first-site
     contractions determined by $P$. The missing step is to prove that the
     representative-grouped Lemma~L remains applicable after compression to
-    (\ref{eq:cpsv_prop_4_13_active_bnt}), so that
+    (\ref{eq:cpsv_prop_4_13_active_bnt}), so that, for every $\alpha$ and $i$,
     \begin{align}
-        Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i
-        \qquad\text{for every $\alpha$ and $i$},
+        Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i.
         \label{eq:cpsv_prop_4_13_missing_active_separation}
     \end{align}
-    and then to carry this separated identity back through the ambient
-    coisometry $V$ to obtain
+    This identity must then be carried back through the ambient coisometry $V$
+    to obtain
     \begin{align}
         \widetilde MP&=P\widetilde MP.
         \label{eq:cpsv_prop_4_13_missing_coisometry_transport}
@@ -760,6 +771,9 @@
     $(\Id-P)\widetilde MP=0$. Thus every one-sided invariant subspace is
     reducing.
 
+    % Local fix (periodic-sector quantifier): use one noncommuting chain length,
+    % not the all-length assertion printed in the source. See
+    % docs/paper-gaps/cpgsv17_periodic_sector_projector.tex.
     There are no nontrivial periodic vertical sectors. Otherwise a cyclic
     projector $Q$ and an integer $p>1$ would commute with
     $[H^{(N)}]^p$ but not with $H^{(N)}$. Since $H^{(N)}$ is positive

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -761,7 +761,7 @@
         &=\mu_{\alpha,k}d_\alpha^{(N)}>0.
         \label{eq:cpsv_prop_4_13_positive_weight}
     \end{align}
-    Absorb the phase of one nonzero coefficient into $C_\alpha$, so that the
+    Absorb the phase of one nonzero coefficient into $M_\alpha$, so that the
     reference coefficient satisfies $\mu_{\alpha,1}>0$. The identity for
     the original copy first gives $d_\alpha^{(N)}\ne0$. Hence the reference
     compression has nonzero trace $\mu_{\alpha,1}d_\alpha^{(N)}$ and is
@@ -793,7 +793,8 @@
     sector. Summing the sector reconstructions therefore gives the exact
     identity (\ref{eq:cpsv_prop_4_13_reconstruction}).
 
-    The preceding paragraphs describe the source proof.
+    The preceding paragraphs recast the source proof on the active retained
+    coordinates required by the literal canonical-form definition.
     Theorem~\ref{thm:vertical_cf_of_horizontal_cf} below establishes the same
     conclusion from the stronger normalized BNT-refined horizontal form. For
     the literal canonical-form hypothesis, the unresolved step is the Lemma~L

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -672,7 +672,8 @@
 \begin{theorem}[Vertical canonical form of a canonical MPDO]
     \label{thm:vertical_cf_of_cpsv_canonical_form}
     \notready
-    \uses{def:mpdo, def:cpsv_canonical_form, def:vertical_cf_mpdo}
+    \uses{def:mpdo, def:cpsv_canonical_form, def:vertical_cf_mpdo,
+        thm:cpsv_canonical_form_bnt_existence}
     Let $M$ be an MPO tensor whose doubled-index MPS tensor is in the literal
     CPSV canonical form. If $M$ generates matrix product density operators,
     then $M$ is in canonical form in the vertical direction. More precisely,
@@ -693,31 +694,37 @@
         \widetilde M&=U^\dagger BU.
         \label{eq:cpsv_prop_4_13_reconstruction}
     \end{align}
-    This is \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}. The paper calls $U$
-    an isometry. In the displayed rectangular orientation, however, $U$ maps
-    the physical space onto the retained sector space and satisfies
-    $UU^\dagger=\Id$; thus $U$ is a coisometry and $U^\dagger$ is the
-    isometric inclusion.
+    The source explicitly displays
+    (\ref{eq:cpsv_prop_4_13_vertical_form}) and calls $U$ an isometry
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}. In this rectangular
+    orientation, however, $U$ maps the physical space onto the retained sector
+    space and satisfies (\ref{eq:cpsv_prop_4_13_coisometry}); thus $U$ is a
+    coisometry and $U^\dagger$ is the isometric inclusion. The reverse identity
+    (\ref{eq:cpsv_prop_4_13_reconstruction}) is not displayed separately in
+    the proposition. It records the exact reconstruction implicit in the
+    preceding assertion that $\widetilde M$ is itself in canonical form,
+    including the permitted zero orthogonal complement.
 \end{theorem}
 
 \begin{proof}
-    Write $A$ for the doubled-index MPS tensor of $M$. Begin with its literal
-    canonical-form decomposition. Discard the blocks with zero coefficient,
-    partition the remaining normal blocks by
-    gauge-phase equivalence, and choose one representative $M_\alpha$ in each
-    class. The resulting coefficients $\nu_{\alpha,k}$ are nonzero. On the
-    retained horizontal support one has
+    Write $A$ for the doubled-index MPS tensor of $M$. If $A=0$, take no
+    retained sectors; the unique map onto the zero-dimensional sector space
+    gives the conclusion. Suppose henceforth that $A\ne0$. Begin with its
+    literal canonical-form decomposition and discard the blocks with zero
+    coefficient. Partition the remaining normal blocks by gauge-phase
+    equivalence, and choose one representative $C_\alpha$ in each class. The
+    resulting coefficients $\nu_{\alpha,k}$ are nonzero. Thus there are an
+    active tensor $C$ and a coisometry $V$ such that
     \begin{align}
-        A^i
+        C^i
         &=\bigoplus_{\alpha,k}
-          \nu_{\alpha,k}X_{\alpha,k}M_\alpha^iX_{\alpha,k}^{-1}.
+          \nu_{\alpha,k}X_{\alpha,k}C_\alpha^iX_{\alpha,k}^{-1},
         \label{eq:cpsv_prop_4_13_active_bnt}
     \end{align}
-    The representatives form the active basis of normal tensors associated
-    with the literal canonical form; the ambient coisometry in the canonical
-    form reconstructs the omitted zero complement. This refinement is derived
-    from the literal hypothesis and is not an assumption of normalized
-    BNT-refined horizontal form.
+    and $A^i=V^\dagger C^iV$. The tensors $C_\alpha$ form the basis of
+    normal tensors associated with the active canonical form. This refinement,
+    including omission of all zero-weight blocks, follows from the literal
+    hypothesis; it does not assume normalized BNT-refined horizontal form.
 
     Let $H^{(N)}$ be the positive operator generated horizontally by $M$. If
     an orthogonal projector $P$ on the physical space satisfies
@@ -730,9 +737,9 @@
           =H^{(N)}P_1.
         \label{eq:cpsv_prop_4_13_first_site}
     \end{align}
-    Lemma~L applied to the active decomposition
+    After compression by $V$, Lemma~L applied to the active decomposition
     (\ref{eq:cpsv_prop_4_13_active_bnt}) separates the first-site insertions
-    block by block and yields
+    block by block. Reconstructing with $V$ yields
     $\widetilde MP=P\widetilde MP$. Hence
     $(\Id-P)\widetilde MP=0$, so every one-sided invariant subspace is
     reducing.
@@ -747,15 +754,19 @@
 
     Group gauge-equivalent vertical sectors over the representatives
     $M_\alpha$. For each active copy $(\alpha,k)$, let $P_{\alpha,k}$ be its
-    range projection. At some length its compression is nonzero and positive,
-    and its trace has the form
+    range projection. At some length its compression is nonzero and positive
+    semidefinite, and its trace has the form
     \begin{align}
         \tr\!\left(P_{\alpha,k}H^{(N)}P_{\alpha,k}\right)
-        &=\mu_{\alpha,k}d_\alpha>0.
+        &=\mu_{\alpha,k}d_\alpha^{(N)}>0.
         \label{eq:cpsv_prop_4_13_positive_weight}
     \end{align}
-    Choose the reference copy with $\mu_{\alpha,1}>0$. Then $d_\alpha>0$,
-    and (\ref{eq:cpsv_prop_4_13_positive_weight}) implies
+    Absorb the phase of one nonzero coefficient into $C_\alpha$, so that the
+    reference coefficient satisfies $\mu_{\alpha,1}>0$. The identity for
+    the original copy first gives $d_\alpha^{(N)}\ne0$. Hence the reference
+    compression has nonzero trace $\mu_{\alpha,1}d_\alpha^{(N)}$ and is
+    nonzero. Its positivity then gives $d_\alpha^{(N)}>0$, and
+    (\ref{eq:cpsv_prop_4_13_positive_weight}) implies
     $\mu_{\alpha,k}>0$ for every copy.
 
     Self-adjointness of the same sector compressions gives the marked-chain
@@ -782,12 +793,14 @@
     sector. Summing the sector reconstructions therefore gives the exact
     identity (\ref{eq:cpsv_prop_4_13_reconstruction}).
 
-    The preceding paragraphs describe the source proof. The present formal
-    theorem starts from the stronger normalized BNT-refined horizontal form.
-    For the literal canonical-form hypothesis, the unresolved step is Lemma~L
-    in the first-site separation used above; the active-block refinement alone
+    The preceding paragraphs describe the source proof.
+    Theorem~\ref{thm:vertical_cf_of_horizontal_cf} below establishes the same
+    conclusion from the stronger normalized BNT-refined horizontal form. For
+    the literal canonical-form hypothesis, the unresolved step is the Lemma~L
+    separation after passage to the active decomposition; the refinement alone
     does not supply that separation. Thus the literal theorem remains open.
 \end{proof}
+
 \begin{theorem}[BNT-refined horizontal form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}
     \lean{MPOTensor.verticalCF_of_horizontalCF}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -770,9 +770,10 @@ toBNTFusionCoisometryFamily}
           U_{\alpha,\beta}.
       \notag
     \end{align}
-    Thus the original renormalization fixed-point, horizontal-canonical, and
-    matrix-product-density-operator assumptions suffice for the positive
-    fusion decomposition of CPSV16, Appendix C.4, lines 2020--2029.
+    Thus the renormalization fixed-point and matrix-product-density-operator
+    assumptions, together with normalized BNT-refined horizontal form, imply
+    the positive fusion decomposition of CPSV16, Appendix C.4, lines
+    2020--2029.
 
     \textbf{Scope restriction (active product BNT):} Only active product
     corners occur. A label absent from a fixed product pair has zero fusion
@@ -790,9 +791,10 @@ toBNTFusionCoisometryFamily}
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply Proposition~4.13 to $M$ and to its two-site blocking, retaining in
-    each case the literal basis-of-normal-tensors assertion, the positive
-    multiplicity matrices, and both coisometric decomposition identities.
+    Apply the proved normalized BNT-refined specialization of
+    Proposition~4.13 to $M$ and to its two-site blocking. In each case, retain
+    the CPSV basis-of-normal-tensors assertion, the positive multiplicity
+    matrices, and both coisometric decomposition identities.
     Unpack the two completely positive, trace-preserving maps in the
     renormalization fixed-point condition. The preceding transported-sector
     theorem then supplies the positive diagonal family, the row

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -179,8 +179,8 @@
     Suppose that the vertical reading of $M$ is reconstructed from a retained
     tensor $A$ by a coisometry $U$. The two-site blocking is then reconstructed
     from the product of two copies of $A$ by the Kronecker square of $U$.
-    Moreover, if $M$ is horizontally canonical and generates positive
-    operators, this retained product tensor has invariant-projector closure
+    Moreover, if $M$ is in normalized BNT-refined horizontal form and generates
+    positive operators, this retained product tensor has invariant-projector closure
     and has no nontrivial periodic vectors. No full-support assumption is
     imposed on the retained bond space.
 \end{theorem}
@@ -189,8 +189,8 @@
     The Kronecker square of a coisometry is again a coisometry. Expanding a
     blocked vertical letter gives the product of the two one-site
     reconstructions and hence the asserted exact compression formula.
-    Horizontal canonical form and positivity are preserved by two-site
-    blocking. Invariant-projector closure descends to an exact reducing
+    Normalized BNT-refined horizontal form and positivity are preserved by
+    two-site blocking. Invariant-projector closure descends to an exact reducing
     compression, while a periodic vector in the compression would embed
     isometrically as a periodic vector of the blocked vertical tensor.
 \end{proof}
@@ -291,8 +291,8 @@
       thm:mpdo_retained_vertical_product_canonical_hypotheses,
       lem:matrix_sigma_block_inclusion}
     Suppose that the one-site vertical tensor has the stated exact
-    coisometric reconstruction, that $M$ is horizontally canonical, and that
-    $M$ generates positive operators. Then simultaneous retained-product
+    coisometric reconstruction, that $M$ is in normalized BNT-refined horizontal form, and that $M$ generates
+    positive operators. Then simultaneous retained-product
     spectral data exist. In copy coordinates, the assembled vertical tensor
     is the direct sum of the weighted simple blocks. The canonical inclusion
     of each copy is an isometry, intertwines in both directions, and its
@@ -483,8 +483,8 @@ activeCoefficient_mul_phase_pos}
       thm:mpdo_retained_product_spectral_family_exists,
       thm:mpdo_grouped_sector_compression_nonzero,
       thm:mpdo_sector_weight_pos}
-    Suppose that $M$ is horizontally canonical and generates positive
-    operators. Assume exact coisometric reconstructions of its one-site and
+    Suppose that $M$ is in normalized BNT-refined horizontal form and generates
+    positive operators. Assume exact coisometric reconstructions of its one-site and
     blocked vertical tensors, positive multiplicities and weights for the
     blocked BNT, and normality of its BNT representatives. For every active
     product corner $j$, one has $0<\lambda_j\zeta_j$.
@@ -496,8 +496,8 @@ activeCoefficient_mul_phase_pos}
     weight by hypothesis. The active corner has weight
     $\lambda_j\zeta_j$ by its exact compression and gauge--phase identity.
     This scalar is nonzero because $\lambda_j>0$ and $|\zeta_j|=1$.
-    Normality gives a nonzero range-projection corner; horizontal canonicality
-    separates it at some finite chain length. The sector-weight comparison
+    Normality gives a nonzero range-projection corner; the BNT-refined horizontal
+    hypothesis separates it at some finite chain length. The sector-weight comparison
     with the distinguished reference corner then yields
     $\lambda_j\zeta_j>0$.
 \end{proof}
@@ -686,8 +686,8 @@ toBNTFusionCoisometryFamily}
     Under the one-site and two-site vertical basis-of-normal-tensors
     decompositions and the two completely positive, trace-preserving
     physical-closure transport identities, assume that the one-site tensor
-    is in horizontal canonical form and defines a matrix product density
-    operator. Then there are positive diagonal multiplicity matrices
+    is in normalized BNT-refined horizontal form and defines a matrix product
+    density operator. Then there are positive diagonal multiplicity matrices
     $\chi_{\alpha,\beta,\gamma}$ and matrices $U_{\alpha,\beta}$ such that
     every diagonal entry is positive and
     \begin{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -291,8 +291,8 @@
       thm:mpdo_retained_vertical_product_canonical_hypotheses,
       lem:matrix_sigma_block_inclusion}
     Suppose that the one-site vertical tensor has the stated exact
-    coisometric reconstruction, that $M$ is in normalized BNT-refined horizontal form, and that $M$ generates
-    positive operators. Then simultaneous retained-product
+    coisometric reconstruction, that $M$ is in normalized BNT-refined
+    horizontal form, and that $M$ generates positive operators. Then simultaneous retained-product
     spectral data exist. In copy coordinates, the assembled vertical tensor
     is the direct sum of the weighted simple blocks. The canonical inclusion
     of each copy is an isometry, intertwines in both directions, and its

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -747,8 +747,8 @@ toBNTFusionCoisometryFamily}
     \uses{def:is_rfp_via_ts,
       thm:vertical_cf_of_horizontal_cf,
       thm:mpdo_transported_vertical_product_positive_fusion_decomposition}
-    Let $M$ be in horizontal canonical form, generate matrix product density
-    operators, and satisfy the renormalization fixed-point condition of
+    Let $M$ be in normalized BNT-refined horizontal form, generate matrix
+    product density operators, and satisfy the renormalization fixed-point condition of
     Definition~\ref{def:is_rfp_via_ts}. Then one may choose a vertical basis
     of normal tensors $\{M_\alpha\}_\alpha$ for which there are positive
     diagonal matrices $\chi_{\alpha,\beta,\gamma}$ and matrices

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -175,14 +175,14 @@ physical indices, as in
     column reindexing preserves positive semidefiniteness.
 \end{proof}
 
-\begin{lemma}[Two-site blocking preserves horizontal canonical form]
+\begin{lemma}[Two-site blocking preserves normalized BNT-refined horizontal form]
     \label{lem:mpdo_horizontal_cf_block_two}
     \lean{MPOTensor.IsHorizontalCF.blockTwo}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo_two_site_blocking,
         thm:sector_bnt_cf_block_tensor}
-    If an MPO tensor $K$ is in horizontal canonical form, then its two-site
-    blocking $K^{[2]}$ is again in horizontal canonical form.
+    If an MPO tensor $K$ is in normalized BNT-refined horizontal form, then its
+    two-site blocking $K^{[2]}$ is again in that form.
 \end{lemma}
 
 \begin{proof}
@@ -201,7 +201,7 @@ physical indices, as in
     original block-diagonal virtual gauge and $S$ its sector tensor, word
     evaluation gives $((K^{[2]})^{\mathrm{MPS}})_i=X(\varphi^*(S^{[2]}))_iX^{-1}$.
     Therefore this blocked decomposition and the same copy gauges witness
-    horizontal canonical form for $K^{[2]}$.
+    normalized BNT-refined horizontal form for $K^{[2]}$.
 \end{proof}
 
 \begin{theorem}[One-site and two-site vertical canonical forms]
@@ -211,8 +211,9 @@ physical indices, as in
     \uses{thm:vertical_cf_of_horizontal_cf,
         thm:mpdo_block_two_as_positive_blocking,
         lem:mpdo_horizontal_cf_block_two}
-    Let $K$ be a horizontally canonical MPO tensor that generates matrix
-    product density operators. Then both $K$ and $K^{[2]}$ satisfy the
+    Let $K$ be an MPO tensor in normalized BNT-refined horizontal form that
+    generates matrix product density operators. Then both $K$ and $K^{[2]}$
+    satisfy the
     vertical canonical-form conditions of
     Definition~\ref{def:vertical_cf_mpdo}.
     This is the initial canonical-form step in
@@ -220,8 +221,8 @@ physical indices, as in
 \end{theorem}
 
 \begin{proof}\leanok
-    The preceding blocking results show that $K^{[2]}$ is horizontally
-    canonical and generates matrix product density operators. Apply
+    The preceding blocking results show that $K^{[2]}$ is in normalized
+    BNT-refined horizontal form and generates matrix product density operators. Apply
     Theorem~\ref{thm:vertical_cf_of_horizontal_cf} first to $K$ and then to
     $K^{[2]}$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -188,17 +188,17 @@
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Renormalization fixed points have active-sector fusion]%
+\begin{theorem}[BNT-refined renormalization fixed points have active-sector fusion]%
     \label{thm:mpdo_rfp_to_bnt_fusion_tensor}
     \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}
     \leanok
     \uses{def:is_rfp_via_ts,
         def:vertical_cf_mpdo,
         def:mpdo_bnt_fusion_tensor_clause}
-    Let $M$ be a matrix product density operator in horizontal canonical form.
-    If the one-site and two-site physical closures are related in both
-    directions by trace-preserving completely positive maps as in
-    Definition~4.1, then a vertical canonical decomposition of $M$ has the
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form. If the one-site and two-site physical closures are
+    related in both directions by trace-preserving completely positive maps
+    as in Definition~4.1, then a vertical canonical decomposition of $M$ has the
     active-sector fusion clause above. In particular, its positive diagonal
     fusion matrices satisfy the length-one idempotent trace-scalar identity.
 \end{theorem}

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -426,8 +426,10 @@ model different levels of data and different sources.
 ### MPDO canonical-form predicates
 
 - `MPOTensor.IsHorizontalCF` in `TNLean/MPS/MPDO/HorizontalBNT.lean` is the
-  representative-indexed horizontal BNT decomposition from arXiv:1606.00608,
-  lines 237--244 and 281--301.
+  normalized representative-indexed BNT-refined horizontal decomposition. It
+  is stronger than the literal CPSV canonical form from arXiv:1606.00608,
+  lines 237--244; see
+  `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 - `MPOTensor.IsPerCopyHorizontalCF` in
   `TNLean/MPS/MPDO/PerCopyHorizontalCF.lean` is an older, stronger flattened
   per-copy separation condition. Its gap from the source is recorded in
@@ -436,9 +438,10 @@ model different levels of data and different sources.
 - `MPOTensor.IsVerticalCF` in `TNLean/MPS/MPDO/VerticalCF.lean` is the vertical
   basis decomposition with positive multiplicities, positive diagonal weights,
   and a coisometry `U` satisfying `U * Uᴴ = 1` (equivalently, `Uᴴ` is an
-  isometry), sourced to arXiv:1606.00608 lines 1901 and 1956. The reverse
-  identity is deliberately absent so zero sectors may be discarded; this
-  caveat is recorded in
+  isometry), sourced to arXiv:1606.00608 lines 1901 and 1956. It requires both
+  the compressed block identity and exact reconstruction by `Uᴴ` and `U`.
+  Reconstruction still permits an omitted all-zero complement because `Uᴴ * U`
+  is the retained-support projection; see
   `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
 - `MPOTensor.IsSimpleCanonicalForm` in `TNLean/MPS/MPDO/SimpleTensor.lean` is
   horizontal canonical form plus the MPDO and nonnilpotent-sector conditions of

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -58,7 +58,7 @@ Proposition~4.13 implication.
 
 \section{Formal proof}
 
-The formal proof first establishes the literal horizontal canonical-form
+The formal proof first establishes the normalized BNT-refined horizontal-form
 reduction described below.\footnote{Formal declaration:
 \leanid{MPOTensor.IsHorizontalCF.exists\_not\_commute\_of\_displaced} in
 \doclink{TNLean/MPS/MPDO/HorizontalBNT}.}  Suppose, to the contrary, that
@@ -67,7 +67,7 @@ $Q_1$ commutes with $H^{(N+1)}$ for every $N$.  Idempotence of $Q$ gives
   Q_1H^{(N+1)}=Q_1H^{(N+1)}Q_1.
 \]
 After writing these as first-site contractions of the doubled-index tensor,
-the literal representative-grouped Lemma~L yields
+the normalized BNT-refined representative-grouped Lemma~L yields
 $Q\widetilde M=Q\widetilde MQ$, contradicting displacement.
 
 The cyclic decomposition and its letter shift are formalized in

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -51,9 +51,10 @@ line~1889.  That stronger assertion is unnecessary: the positivity argument
 at lines~1890--1893 is pointwise in $N$, so the same existential witness
 suffices.
 
-This is a local correction of the intermediate statement, not a restriction
-of Proposition~4.13.  The final no-periodic-vectors theorem has exactly the
-source hypotheses.
+This is a local correction of the intermediate statement.  Under the
+normalized BNT-refined horizontal hypothesis used by the formal theorem, it
+adds no further restriction.  It does not close the literal
+Proposition~4.13 implication.
 
 \section{Formal proof}
 
@@ -82,24 +83,28 @@ with $H^{(N+1)}$, a contradiction.\footnote{Formal conclusion:
 \leanid{MPOTensor.hasNoPeriodicVectors\_verticalTensor\_of\_horizontalCF}
 in \doclink{TNLean/MPS/MPDO/CyclicProjector}.}
 
-The proof introduces no additional mathematical assumption.
+Within the normalized BNT-refined horizontal form used here, the proof
+introduces no additional mathematical assumption.
 
 \section{Status}
 
-The periodic-sector step of Proposition~4.13 is complete for every
-horizontally canonical matrix product density operator.  The earlier
-all-length condition remains only as a stronger conditional auxiliary
-statement and is not used by the source-faithful theorem.\footnote{Formal
-predicate: \leanid{MPOTensor.NoninvariantProjectorNoncommuting}.}
+The periodic-sector step is complete under the normalized BNT-refined
+hypothesis \path{MPOTensor.IsHorizontalCF}.  The earlier all-length condition
+remains only as a stronger conditional auxiliary statement and is not used by
+this step.\footnote{Formal predicate:
+\leanid{MPOTensor.NoninvariantProjectorNoncommuting}.}
 
 The invariant-projector and no-periodic-vector criterion, the nonzero sector
 compressions, positivity of the vertical weights, the dressed-adjoint
-identities, and the physical-space coisometry are now combined in the proof of
+identities, and the physical-space coisometry are combined in the proof of
 \path{MPOTensor.verticalCF_of_horizontalCF} in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  Thus the
-horizontal-to-vertical implication of Proposition~4.13 is complete.
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  This proves the
+horizontal-to-vertical implication under \path{MPOTensor.IsHorizontalCF},
+which is strictly stronger than the literal CPSV canonical form assumed in
+Proposition~4.13.  The literal implication remains open.
 
-\paragraph{Verdict.} Local correction.
+\paragraph{Verdict.} Conditional periodic-sector step complete; literal
+Proposition~4.13 open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -268,6 +268,18 @@ Proposition~4.13, so the literal theorem remains open.  The proved restricted
 result follows the grouped vertical sectors used in the paper and does not use
 the unsupported diagonal-restriction statement from \ghissue{2537}.
 
+To eliminate the stronger hypothesis, first use
+\path{MPSTensor.CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors} to
+pass from the literal decomposition to its active BNT representatives and
+ambient coisometry.  The missing lemma must establish the Lemma~L first-site
+insertion separation on those retained coordinates and carry the separated
+identity back through the coisometry.  With that statement in place, the
+invariant-projector argument, periodic-sector exclusion, positivity of the
+vertical multiplicities, grouped Gram normalization, and final coisometric
+reconstruction can be replayed without assuming \path{MPOTensor.IsHorizontalCF}.
+This yields the literal Proposition~4.13 theorem rather than an adapter through
+the stronger predicate.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -270,15 +270,19 @@ the unsupported diagonal-restriction statement from \ghissue{2537}.
 
 To eliminate the stronger hypothesis, first use
 \path{MPSTensor.CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors} to
-pass from the literal decomposition to its active BNT representatives and
-ambient coisometry.  The missing lemma must establish the Lemma~L first-site
-insertion separation on those retained coordinates and carry the separated
-identity back through the coisometry.  With that statement in place, the
-invariant-projector argument, periodic-sector exclusion, positivity of the
-vertical multiplicities, grouped Gram normalization, and final coisometric
-reconstruction can be replayed without assuming \path{MPOTensor.IsHorizontalCF}.
-This yields the literal Proposition~4.13 theorem rather than an adapter through
-the stronger predicate.
+obtain the active BNT representatives.  That theorem does not retain the
+active-index equivalence, the copy weights and gauges, or the ambient
+coisometry.  One must therefore strengthen its conclusion to a structured
+active-refinement witness carrying those data and the exact reconstruction.
+The missing lemma must then establish the Lemma~L first-site insertion
+separation on the retained coordinates and carry the separated identity back
+through the coisometry.  With that statement in place, the invariant-projector
+argument, periodic-sector exclusion, positivity of the vertical
+multiplicities, grouped Gram normalization, and final coisometric
+reconstruction can be replayed without assuming
+\path{MPOTensor.IsHorizontalCF}.  This yields
+the literal Proposition~4.13 theorem rather than an adapter through the
+stronger predicate.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -99,6 +99,17 @@ used in the source declaration.
 
 \section{Boundary of the present result}
 
+The results described below assume the normalized BNT-refined horizontal form
+\path{MPOTensor.IsHorizontalCF}: the retained sectors fill the horizontal bond
+space, every repeated-copy weight is nonzero, all copy weights have modulus at
+most one, at least one has modulus one, and the normal blocks are already
+grouped over BNT representatives.  This is strictly stronger than the literal CPSV canonical
+form of Proposition~4.13, which allows an omitted zero complement and does not
+include this normalized representative grouping.  Thus the completed
+construction below proves the vertical conclusion under the stronger
+horizontal hypothesis; the implication from literal CPSV canonical form
+remains open.
+
 An earlier auxiliary route compared one scalar weight $\mu_\alpha$ with
 several weights $\omega_{\alpha,j}$ under the additional identities
 \begin{equation}
@@ -245,10 +256,12 @@ horizontal scalar weights and diagonal restrictions, remains a false route
 rather than a consequence of the proposition.
 
 \paragraph{Verdict.}
-The source-faithful horizontal-to-vertical implication of Proposition~4.13 is
-complete.  The proof follows the grouped vertical sectors used in the paper;
-it does not use the unsupported diagonal-restriction statement from
-\ghissue{2537}.
+The horizontal-to-vertical implication is complete under the normalized
+BNT-refined hypothesis \path{MPOTensor.IsHorizontalCF}.  That hypothesis is
+strictly stronger than the literal CPSV canonical form assumed in
+Proposition~4.13, so the literal theorem remains open.  The proved restricted
+result follows the grouped vertical sectors used in the paper and does not use
+the unsupported diagonal-restriction statement from \ghissue{2537}.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -19,7 +19,8 @@
 Proposition~4.13 (source label \path{Prop:IV.12}) of
 \cite{Cirac2016MPDO_arXiv} states that a canonical-form
 tensor generating matrix product density operators is also in canonical form
-in the vertical direction.  After a physical isometry, the tensor has the form
+in the vertical direction.  With the rectangular map called an isometry in
+that proposition, the tensor has the form
 \begin{equation}
   U\widetilde M U^\dagger
   =
@@ -103,8 +104,9 @@ The results described below assume the normalized BNT-refined horizontal form
 \path{MPOTensor.IsHorizontalCF}: the retained sectors fill the horizontal bond
 space, every repeated-copy weight is nonzero, all copy weights have modulus at
 most one, at least one has modulus one, and the normal blocks are already
-grouped over BNT representatives.  This is strictly stronger than the literal CPSV canonical
-form of Proposition~4.13, which allows an omitted zero complement and does not
+grouped over BNT representatives.  This is strictly stronger than the
+literal CPSV canonical form of Proposition~4.13, which allows an omitted zero
+complement and does not
 include this normalized representative grouping.  Thus the completed
 construction below proves the vertical conclusion under the stronger
 horizontal hypothesis; the implication from literal CPSV canonical form
@@ -249,8 +251,11 @@ tensors.
 Finally, \path{MPOTensor.verticalCF_of_horizontalCF} in
 \path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean} applies the orthogonal sector
 coisometry theorem and identifies the dependent sector pairs $(\alpha,q)$
-with the standard finite direct-sum coordinates.  This gives the literal
-vertical canonical-form identities of Proposition~4.13.  The original
+with the standard finite direct-sum coordinates.  This gives the displayed
+identity of Proposition~4.13 together with the exact reconstruction implicit
+in its preceding assertion that the vertical
+tensor is in canonical form.  The reverse reconstruction is not separately
+printed in the proposition.  The original
 formulation of \ghissue{2537}, interpreted as a direct conversion of the
 horizontal scalar weights and diagonal restrictions, remains a false route
 rather than a consequence of the proposition.

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -83,6 +83,15 @@ restrictions of the horizontal basis.
 
 \section{The corrected formal target}
 
+The theorem currently proved assumes the normalized BNT-refined horizontal
+form \path{MPOTensor.IsHorizontalCF}.  In particular, the retained sectors
+have full horizontal bond dimension, every copy weight is nonzero, all copy
+weights have modulus at most one, at least one has modulus one, and the normal
+blocks are grouped over BNT representatives.  This
+is strictly stronger than the literal CPSV canonical form in
+Proposition~4.13.  The constructions summarized below are complete on this
+stronger surface; the literal canonical-form implication remains open.
+
 A source-faithful proof of Proposition~4.13 should begin with both horizontal
 canonical form and the MPDO positivity hypothesis.  It should then formalize the
 three stages visible in the source:
@@ -203,13 +212,16 @@ basis-of-normal-tensors property is established in
 reconstruction at positive lengths and a retained positive-dimensional
 representative at length zero.  The resulting orthogonal sector maps are
 assembled into the final coisometry in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}, which proves the literal
-vertical canonical-form identity from the MPDO hypotheses.
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  Together with the MPDO
+positivity hypothesis, the normalized BNT-refined horizontal form therefore
+gives the vertical canonical-form identities.
 
 \paragraph{Verdict.}
-The source-faithful horizontal-to-vertical implication of Proposition~4.13 is
-complete.  The diagonal-restriction route remains a false strengthening and
-plays no part in the proof.
+The horizontal-to-vertical implication is complete under the normalized
+BNT-refined hypothesis \path{MPOTensor.IsHorizontalCF}, which is strictly
+stronger than the literal CPSV canonical form of Proposition~4.13.  The
+literal theorem remains open.  The diagonal-restriction route remains a false
+strengthening and plays no part in the proved restricted result.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -104,8 +104,10 @@ three stages visible in the source:
 \end{enumerate}
 The target statement is now in place: the vertical canonical form is stated
 on the vertically viewed tensor, whose letters are indexed by the horizontal
-bond pair and whose matrices act on the physical space, in the isometry form
-of the source; an earlier statement on the diagonal tensor $i\mapsto M^{ii}$
+bond pair and whose matrices act on the physical space, in the rectangular
+orientation of the source.  In that orientation the displayed map is a
+coisometry onto the retained sectors; an earlier statement on the diagonal
+tensor $i\mapsto M^{ii}$
 has been removed.  The definitional realignment is recorded in
 \path{cpgsv17_vertical_tensor_definition.tex}.
 
@@ -214,7 +216,9 @@ representative at length zero.  The resulting orthogonal sector maps are
 assembled into the final coisometry in
 \path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.  Together with the MPDO
 positivity hypothesis, the normalized BNT-refined horizontal form therefore
-gives the vertical canonical-form identities.
+gives the displayed vertical identity and exact reconstruction.  The source
+prints the former; the latter is implicit in its assertion that the vertical
+tensor is itself in canonical form and is not displayed as a separate formula.
 
 \paragraph{Verdict.}
 The horizontal-to-vertical implication is complete under the normalized

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -175,7 +175,7 @@ proposition, while reconstruction records its preceding canonical-form claim.
 The retained part is represented
 rectangularly, while the omitted part is required to be zero. No full-support
 assumption is added to that conclusion.  The theorem in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.\footnote{The corresponding
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}\footnote{The corresponding
 declaration is \leanid{MPOTensor.verticalCF_of_horizontalCF}.} uses this
 corrected coisometry condition under the normalized BNT-refined horizontal
 form.  Its retained sectors fill the horizontal bond space, every copy weight

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -35,10 +35,12 @@ where the matrices $\mu_\alpha$ are positive and diagonal and the tensors
 $M_\alpha$ form a basis of normal tensors (source lines~943--951 and
 1863--1870).
 
-Let $s$ be the dimension of the right-hand side of
-\eqref{eq:vertical-form}. In the displayed orientation,
-$U:\mathbb C^D\to\mathbb C^s$ maps the original physical space onto the
-retained nonzero sector space. Consequently
+Let $d$ be the original physical dimension and let $s$ be the dimension of
+the right-hand side of \eqref{eq:vertical-form}.  When the generic
+canonical-form dimension bound \eqref{eq:dimension-bound} is applied
+vertically, it reads $s\leq d$.  In the displayed orientation,
+$U:\mathbb C^d\to\mathbb C^s$ maps the physical space onto the retained
+nonzero sector space. Consequently
 \begin{equation}
   UU^\dagger=I_s,
   \qquad
@@ -46,9 +48,11 @@ retained nonzero sector space. Consequently
   \label{eq:coisometry}
 \end{equation}
 where $P$ is the support projection of the nonzero sectors. Equality
-$U^\dagger U=I_D$ holds only when there is no zero complement. It is not part
-of the hypotheses or conclusion of Proposition~4.13.  The assertion that the
-discarded complement is a zero sector is the reconstruction identity
+$U^\dagger U=I_d$ holds only when there is no zero complement. It is not part
+of the hypotheses or conclusion of Proposition~4.13.  The source does not
+print a reverse identity separately.  Its preceding assertion that
+$\widetilde M$ is in canonical form says that the discarded complement is a
+zero sector, which is recorded explicitly by the reconstruction identity
 \begin{equation}
   \widetilde M
   =U^\dagger\left(\bigoplus_\alpha
@@ -166,7 +170,9 @@ asserted.
 The vertical canonical-form predicate now requires $UU^\dagger=I_s$ in the
 orientation of \eqref{eq:vertical-form}, together with
 \eqref{eq:reconstruction}. This is the source-faithful conclusion compatible
-with \eqref{eq:dimension-bound}: the retained part is represented
+with \eqref{eq:dimension-bound}: the displayed compression is printed in the
+proposition, while reconstruction records its preceding canonical-form claim.
+The retained part is represented
 rectangularly, while the omitted part is required to be zero. No full-support
 assumption is added to that conclusion.  The theorem in
 \path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.\footnote{The corresponding

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -165,15 +165,19 @@ asserted.
 
 The vertical canonical-form predicate now requires $UU^\dagger=I_s$ in the
 orientation of \eqref{eq:vertical-form}, together with
-\eqref{eq:reconstruction}. This is the source-faithful statement compatible
+\eqref{eq:reconstruction}. This is the source-faithful conclusion compatible
 with \eqref{eq:dimension-bound}: the retained part is represented
 rectangularly, while the omitted part is required to be zero. No full-support
-assumption is added to Proposition~4.13.  The construction of the canonical
-form from horizontal canonical form is proved in
+assumption is added to that conclusion.  The theorem in
 \path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.\footnote{The corresponding
-declaration is \leanid{MPOTensor.verticalCF_of_horizontalCF}.}  It uses this
-corrected coisometry condition.  The correction itself is tracked in
-\ghissue{3869}.
+declaration is \leanid{MPOTensor.verticalCF_of_horizontalCF}.} uses this
+corrected coisometry condition under the normalized BNT-refined horizontal
+form.  Its retained sectors fill the horizontal bond space, every copy weight
+is nonzero, all copy weights have modulus at most one, at least one has modulus
+one, and the normal blocks are grouped over BNT representatives.  This is
+strictly stronger than the literal CPSV canonical form of Proposition~4.13,
+so the literal implication remains open.  The coisometry correction itself is
+tracked in \ghissue{3869}.
 
 The source-generated support identities and their trace consequences are
 proved in
@@ -186,12 +190,14 @@ trace consequences are
 \leanid{MPOTensor.transportedVerticalSectorS_trace_of_source_generated}.}
 
 \paragraph{Verdict.}
-The earlier two-sided-unitary condition was a stronger statement absent from
-the source and was false when the vertically viewed tensor had a zero sector.
-Replacing it by the coisometry identity $UU^\dagger=I$, while retaining exact
-reconstruction from the nonzero sectors, is a corrected definitional
-mismatch. The correction changes no hypothesis of Proposition~4.13 and
-introduces no new mathematical assumption.
+The earlier two-sided-unitary condition was absent from the source and was
+false when the vertically viewed tensor had a zero sector.  Replacing it by
+the coisometry identity $UU^\dagger=I$, while retaining exact reconstruction
+from the nonzero sectors, corrects the conclusion without adding a
+full-support hypothesis.  The current theorem proves this corrected conclusion
+only under the normalized BNT-refined horizontal form, which is strictly
+stronger than literal CPSV canonical form.  The literal Proposition~4.13
+implication remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -115,12 +115,15 @@ decomposition, not from flattening horizontal weights;
 restriction of horizontal blocks does not preserve normality.  Neither note
 documented the definitional mismatch addressed here: the former predicate
 placed the conclusion of Proposition~4.13 on the wrong tensor.  The
-source-faithful horizontal-to-vertical implication is proved by
+horizontal-to-vertical implication is proved by
 \path{MPOTensor.verticalCF_of_horizontalCF} in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}; the blueprint entry for
-Proposition~4.13 in
-\path{blueprint/src/chapter/ch20_mpdo_canonical_forms.tex} records the same
-result.
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean} under the normalized
+BNT-refined hypothesis \path{MPOTensor.IsHorizontalCF}.  This hypothesis has
+full horizontal bond dimension and BNT representative grouping; every copy
+weight is nonzero, all have modulus at most one, and at least one has modulus
+one.  It is strictly stronger than the literal CPSV
+canonical form assumed in Proposition~4.13, whose vertical conclusion remains
+open.  The blueprint records these as separate statements.
 
 \paragraph{Verdict.}
 This is a corrected definitional mismatch.  The former predicate placed the
@@ -131,11 +134,13 @@ carry the multiplicity coefficients $m_\alpha=\tr(\mu_\alpha)$ of
 \eqref{eq:umu}; a proof of the surrogate would therefore not have formalized
 the proposition.  The realignment restores the source-faithful vertical tensor
 definition.  The later correction in
-\path{cpgsv17_vertical_isometry_zero_sector.tex} restores the source's
-one-sided isometry condition in the presence of zero sectors.  The
-horizontal-to-vertical implication of Proposition~4.13 is proved in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean} using this corrected
-definition.
+\path{cpgsv17_vertical_isometry_zero_sector.tex} expresses the source's
+one-sided condition as a coisometry onto the retained nonzero sectors and
+retains exact reconstruction.  The horizontal-to-vertical implication is
+proved with this corrected definition under the normalized BNT-refined
+hypothesis \path{MPOTensor.IsHorizontalCF}.  Since that hypothesis is strictly
+stronger than literal CPSV canonical form, the literal Proposition~4.13
+implication remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -86,9 +86,11 @@ the isometric inclusion into the original physical space.  The source's
 general canonical-form construction allows $\sum_k D_k<D$ and hence permits
 a zero orthogonal complement (lines~214--225).  Thus $U^\dagger U$ is in
 general the support projection rather than the identity.  This correction is
-documented in \path{cpgsv17_vertical_isometry_zero_sector.tex}.  The reverse
-identity reconstructs the original tensor from the displayed direct sum and
-therefore requires the omitted complement to be a zero sector.  Since each
+documented in \path{cpgsv17_vertical_isometry_zero_sector.tex}.  The
+proposition does not display the reverse identity separately.  It
+follows from the preceding assertion that the vertical tensor is itself in
+canonical form: it reconstructs the original tensor from the displayed direct
+sum and requires the omitted complement to be a zero sector.  Since each
 $\mu_\alpha$ is diagonal,
 the summand $\mu_\alpha\otimes M_\alpha$ is the direct sum
 $\bigoplus_{k=0}^{r_\alpha-1}\omega_{\alpha,k}M_\alpha$, so the right-hand side of


### PR DESCRIPTION
## What changed

- correct the rectangular map in literal CPSV Proposition 4.13 from an isometry to a coisometry in the displayed orientation, and state the exact retained-support reconstruction separately from the equation printed in CPSV16;
- add a formula-driven proof outline covering active nonzero blocks, the all-zero tensor, periodic-sector exclusion, positivity of vertical multiplicities, unitary gauge normalization, and reconstruction, while marking the retained-coordinate Lemma L separation and coisometry transport as the precise missing step;
- distinguish the merged literal-CF-to-active-BNT existence theorem from the stronger normalized `MPOTensor.IsHorizontalCF` theorem currently used by `MPOTensor.verticalCF_of_horizontalCF`;
- add explicit scope-restriction markers to the two stronger-hypothesis Lean declarations that cite Proposition 4.13;
- identify the concrete elimination plan: first retain the active-index, copy-gauge, weight, and ambient-coisometry witnesses in a structured refinement; then prove first-site insertion separation on those coordinates and carry it through the coisometry, before replaying the existing vertical-sector argument without an adapter through `IsHorizontalCF`;
- correct all four Proposition 4.13 paper-gap notes so none claims that the literal theorem is already formalized.

The source calls the rectangular map an “isometry,” but in its orientation $U:\mathbb C^d\to\mathbb C^s$ with $UU^\dagger=I_s$ it is a coisometry; $U^\dagger$ is the isometric inclusion. The reverse reconstruction is implicit in the source assertion that the vertically viewed tensor is itself in canonical form, but is not separately printed in Proposition 4.13.

## Validation

- independent CPSV/source and blueprint reviews completed; all substantive findings applied
- `git diff --check origin/main...HEAD`
- `lake build TNLean.MPS.MPDO.VerticalCanonicalForm TNLean.MPS.MPDO.RFPPositiveFusionDecomposition`
- full `lake build` — 9,755 jobs
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- from `blueprint/src`, double `lualatex -interaction=nonstopmode -halt-on-error print.tex` with `TEXINPUTS='../../tex/tenkz//:'` — zero undefined cross-references
- each of the five modified paper-gap notes compiled twice with PDFLaTeX — zero undefined cross-references

Closes #4925.
Closes #4926.
Closes #4927.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation, comments, and blueprint scope alignment; no substantive proof logic changes in the Lean diff. Risk is mainly mislabeling formal status for reviewers.
> 
> **Overview**
> **Clarifies what is proved vs. what remains open for CPSV16 Proposition 4.13** and aligns Lean docstrings, blueprint, glossary, and paper-gap notes.
> 
> Documentation now consistently treats **`MPOTensor.IsHorizontalCF` as normalized BNT-refined horizontal form**, strictly stronger than literal CPSV canonical form. Theorems such as `verticalCF_of_horizontalCF`, RFP fusion, and blocking lemmas are labeled with **scope-restriction** notes and pointers to `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
> 
> The blueprint adds a **`\notready`** literal Proposition 4.13 theorem with a **proof outline** (active blocks, periodic sectors, positivity, gauge normalization) and explicitly marks **Lemma L separation on retained coordinates** and **transport through the ambient coisometry** as missing. The proved result is separated as **BNT-refined horizontal form implies vertical canonical form**.
> 
> **Rectangular-map wording** is corrected: the displayed map is a **coisometry** (`UU† = I`) with **exact reconstruction** stated separately from the compression identity printed in the source.
> 
> Paper-gap notes no longer claim the literal theorem is formalized; they record the **elimination plan** (structured active refinement + retained-coordinate separation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f94546e73ae7fc36d3c15da77af25e9ed68b47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

