### PR TITLE
refactor(CPSV): close late post-merge review findings

### DIFF
--- a/TNLean/Algebra/SpinCover.lean
+++ b/TNLean/Algebra/SpinCover.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import Mathlib.LinearAlgebra.UnitaryGroup
 import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Basic
 import Mathlib.Algebra.BigOperators.Field
@@ -425,10 +426,7 @@ lemma exists_cos_sin {c s : ℝ} (h : c ^ 2 + s ^ 2 = 1) :
     rw [Complex.norm_def, Complex.normSq_mk,
       show c * c + s * s = 1 by nlinarith only [h]]
     simp
-  have hz : (⟨c, s⟩ : ℂ) ≠ 0 := by
-    intro hc; rw [Complex.ext_iff] at hc
-    simp only [Complex.zero_re, Complex.zero_im] at hc
-    nlinarith only [h, hc.1, hc.2]
+  have hz : (⟨c, s⟩ : ℂ) ≠ 0 := Complex.ne_zero_of_norm_eq_one hn
   exact ⟨Complex.arg (⟨c, s⟩ : ℂ), by rw [Complex.cos_arg hz, hn]; simp,
     by rw [Complex.sin_arg, hn]; simp⟩
 

--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -550,9 +550,8 @@ theorem peripheral_eigenvalue_multiplicity_one
         _ = ((γ * γ⁻¹ : ℂ)) • (X * (U : MatrixAlg D)ᴴ) := by
               rw [smul_mul_assoc, mul_smul_comm, smul_smul]
         _ = X * (U : MatrixAlg D)ᴴ := by
-              have hγ_ne : γ ≠ 0 := by
-                intro hγ0
-                simpa [hγ0] using hγ.2
+              have hγ_ne : γ ≠ 0 :=
+                Complex.ne_zero_of_norm_eq_one hγ.2
               simp [hγ_ne]
     obtain ⟨c, hc⟩ := MPSTensor.fixed_eq_scalar_of_irreducible_unital
       (K := K) hUnital hIrr (X * (U : MatrixAlg D)ᴴ) hXU_fix

--- a/TNLean/Channel/Peripheral/Spectrum.lean
+++ b/TNLean/Channel/Peripheral/Spectrum.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Channel.Primitive
 import TNLean.Channel.Irreducible.Basic
 import Mathlib.LinearAlgebra.Eigenspace.Basic
@@ -106,9 +107,7 @@ theorem isRootOfUnity_of_finite_powers (μ : ℂ) (hμ : ‖μ‖ = 1)
     fun hinj => Set.infinite_range_of_injective hinj hrange_fin
   simp only [Function.Injective, not_forall] at hninj
   obtain ⟨n₁, n₂, heq, hne⟩ := hninj
-  have hμ_ne : μ ≠ 0 := by
-    rw [← norm_ne_zero_iff, hμ]
-    norm_num
+  have hμ_ne : μ ≠ 0 := Complex.ne_zero_of_norm_eq_one hμ
   rcases Nat.lt_or_gt_of_ne hne with h | h
   · exact ⟨n₂ - n₁, Nat.sub_pos_of_lt h,
       mul_left_cancel₀ (pow_ne_zero _ hμ_ne) (by

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.CopyWeightMatching
 import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
@@ -282,10 +283,8 @@ theorem ft_sector_bnt_proportional_global_gauge_of_copy_weight_matching
       (P := P) (Q := Q) hP hQ hProp
   refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
   intro W
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
-    intro k hzero
-    have hnorm := hζ_norm k
-    simp [hzero] at hnorm
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := fun k =>
+    Complex.ne_zero_of_norm_eq_one (hζ_norm k)
   exact sector_bnt_global_gauge_of_copy_weight_matching
     (P := P) (Q := Q) β hDim ζ Xblock hζ_ne hConj W
 
@@ -341,10 +340,8 @@ theorem ft_sector_bnt_proportional_global_gauge_of_coeff_identity
       (P := P) (Q := Q) hP hQ hProp
   refine ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ?_⟩
   intro hCoeff
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
-    intro k hzero
-    have hnorm := hζ_norm k
-    simp [hzero] at hnorm
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := fun k =>
+    Complex.ne_zero_of_norm_eq_one (hζ_norm k)
   let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
     SectorBNTCopyWeightMatching.of_coeff_identity
       (P := P) (Q := Q) β ζ hζ_ne hCoeff
@@ -419,10 +416,8 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnesses
     exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB
       (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
         (ζ := ζ k) (hMpv k))
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
-    intro k hzero
-    have hnorm := hζ_norm k
-    simp [hzero] at hnorm
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := fun k =>
+    Complex.ne_zero_of_norm_eq_one (hζ_norm k)
   have hCoeff := coeff_identity_via_matched_mpv_phase hP hEqual β ζ
     (fun k N _hN σ => hMpv k N σ)
   let W : SectorBNTCopyWeightMatching (P := P) (Q := Q) β ζ :=
@@ -525,10 +520,8 @@ theorem ft_sector_bnt_equal_global_gauge
   obtain ⟨β, hDim, ζ, Xblock, hζ_norm, hConj, ⟨W⟩⟩ :=
     ft_sector_bnt_equal_matched_copy_weight_witnesses
       (P := P) (Q := Q) hP hQ hEqual
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
-    intro k hzero
-    have hnorm := hζ_norm k
-    simp [hzero] at hnorm
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := fun k =>
+    Complex.ne_zero_of_norm_eq_one (hζ_norm k)
   let hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := by
     intro k
     have hcard := Fintype.card_congr (W.copy_equiv k)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental
 import TNLean.MPS.FundamentalTheorem.UnitaryGauge
 import TNLean.MPS.SharedInfra.BlockGauge
@@ -130,9 +131,8 @@ theorem ft_sector_bnt_equal_unitary_global_gauge_witnesses
   classical
   obtain ⟨β, hDim, ζ, Xblock, hζ, hConj, ⟨W⟩⟩ :=
     ft_sector_bnt_equal_matched_copy_weight_witnesses hP hQ hEqual
-  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
-    intro k hzero
-    simpa [hzero] using hζ k
+  have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := fun k =>
+    Complex.ne_zero_of_norm_eq_one (hζ k)
   have hUnitary : ∀ k : Fin Q.basisCount,
       ∃ U : Matrix.unitaryGroup (Fin (Q.basisDim k)) ℂ,
         ∀ i, Q.basis k i = ζ k •

--- a/TNLean/MPS/MPDO/VerticalProductCornerPositivity.lean
+++ b/TNLean/MPS/MPDO/VerticalProductCornerPositivity.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.MPDO.VerticalProductCornerComparison
 
 /-!
@@ -74,10 +75,8 @@ theorem FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos
     exact S.ambientInclusion_isometry U₁ hU₁ x
   have hVref : Vrefᴴ * Vref = 1 := by
     exact C.referenceInclusion_isometry mult₂ hMult₂ U₂ hU₂ j
-  have hphase : C.phase j ≠ 0 := by
-    apply norm_ne_zero_iff.mp
-    rw [C.phase_norm j]
-    exact one_ne_zero
+  have hphase : C.phase j ≠ 0 :=
+    Complex.ne_zero_of_norm_eq_one (C.phase_norm j)
   have hc : c ≠ 0 := mul_ne_zero (S.flatCoefficient_ne j) hphase
   have hActiveCorner : ∀ ab,
       c • ((C.gauge j : Matrix (Fin (S.flatDim j))

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.PeriodicBlocking
 import TNLean.MPS.Core.Blocking
@@ -212,8 +213,7 @@ theorem equivalentBlocks_iff_gaugeEquiv {A B : MPSTensor d D} :
 theorem RepeatedBlocks.symm {A B : MPSTensor d D}
     (h : RepeatedBlocks A B) : RepeatedBlocks B A := by
   rcases h with ⟨ξ, Y, hξ, hY⟩
-  have hξ_ne : ξ ≠ 0 := by
-    intro h0; simp [h0] at hξ
+  have hξ_ne : ξ ≠ 0 := Complex.ne_zero_of_norm_eq_one hξ
   refine ⟨ξ⁻¹, Y⁻¹, by simp [norm_inv, hξ], ?_⟩
   intro i
   have hYi := hY i

--- a/TNLean/MPS/Periodic/Overlap/GaugePhase.lean
+++ b/TNLean/MPS/Periodic/Overlap/GaugePhase.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.FundamentalTheorem.UnitaryGauge
 import TNLean.MPS.Periodic.Defs
 
@@ -35,8 +36,7 @@ theorem repeatedBlocks_of_gaugePhaseData_norm_one
           ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
             ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :
     RepeatedBlocks A B := by
-  have hζ_ne : ζ ≠ 0 := by
-    exact norm_ne_zero_iff.mp (by rw [hζ_norm]; norm_num)
+  have hζ_ne : ζ ≠ 0 := Complex.ne_zero_of_norm_eq_one hζ_norm
   refine ⟨ζ⁻¹, X⁻¹, by rw [norm_inv, hζ_norm, inv_one], ?_⟩
   intro i
   simp only [inv_inv]

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.Core.MultiBlock
 import TNLean.Spectral.TransferOperatorGapNT
@@ -370,9 +371,8 @@ theorem phases_eq_of_isTransferIdempotent_directSum_scaled_self
     (hRFP : IsTransferIdempotent
       (directSumTensor (fun q : Fin r ↦ (fun i ↦ μ q • A i : MPSTensor d D))))
     (q q' : Fin r) : μ q = μ q' := by
-  have hμ_ne : ∀ q, μ q ≠ 0 := by
-    intro q hq
-    simpa [hq] using hμ q
+  have hμ_ne : ∀ q, μ q ≠ 0 := fun q =>
+    Complex.ne_zero_of_norm_eq_one (hμ q)
   have hphase : μ q * starRingEnd ℂ (μ q') = 1 := by
     have hidem :=
       (isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem

--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.Periodic.Defs
 
@@ -95,10 +96,7 @@ theorem isPeriodic_smul_of_norm_one
     {m : ℕ} {c : ℂ} (hc : ‖c‖ = 1)
     (A : MPSTensor d D) (hA : IsPeriodic m A) :
     IsPeriodic m (fun i => c • A i) := by
-  have hc_ne : c ≠ 0 := by
-    intro hc0
-    have hc' := hc
-    simp [hc0] at hc'
+  have hc_ne : c ≠ 0 := Complex.ne_zero_of_norm_eq_one hc
   have hTransfer : transferMap (fun i => c • A i) = transferMap A := by
     ext X : 1
     rw [transferMap_smul]

--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.MPS.Symmetry.StringOrderDefs
 import TNLean.MPS.Core.CPPrimitive
 import TNLean.MPS.Core.TPGauge
@@ -696,8 +697,7 @@ theorem boundaryState_invariant_of_virtualUnitary
     simp at hΛtr
   haveI : NeZero D := ⟨hD⟩
   let B : MPSTensor d D := twistedMixedCompanion A u
-  have hμ_ne : μ ≠ 0 := by
-    intro h; simp [h] at hμ
+  have hμ_ne : μ ≠ 0 := Complex.ne_zero_of_norm_eq_one hμ
   have hμ_sq : star μ * μ = 1 := by
     rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
   have huc : uᴴ * u = 1 := mul_eq_one_comm.mp hu

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Spectral.MixedTransfer
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Channel.FixedPoint.CanonicalGauge
 import TNLean.Channel.Schwarz.Basic
 
@@ -543,11 +544,7 @@ theorem gaugePhaseEquiv_of_gauged_intertwining [NeZero D]
   let B' : MPSTensor d D := gaugeTensor SB B
   have hSA_u : IsUnit SA.det := Ne.isUnit hSA_det
   have hSB_u : IsUnit SB.det := Ne.isUnit hSB_det
-  have hμ_ne0 : μ ≠ 0 := by
-    intro h0
-    have : (‖μ‖ : ℝ) = 0 := by
-      simp only [h0, norm_zero]
-    linarith [hμ, this]
+  have hμ_ne0 : μ ≠ 0 := Complex.ne_zero_of_norm_eq_one hμ
   have hper : ∀ i : Fin d, B' i = μ⁻¹ • (X'⁻¹ * A' i * X') := by
     intro i
     have hAX : A' i * X' = μ • X' * B' i := by
@@ -594,7 +591,7 @@ theorem gaugePhaseEquiv_of_gauged_intertwining [NeZero D]
       _ = SA * SA⁻¹ := by rw [h2]
       _ = 1 := h3
   let Ygl : GL (Fin D) ℂ := ⟨Ymat, Yinv, hYmul, hYinv_mul⟩
-  refine ⟨Ygl, μ⁻¹, inv_ne_zero (norm_ne_zero_iff.mp (by rw [hμ]; norm_num)), ?_⟩
+  refine ⟨Ygl, μ⁻¹, inv_ne_zero (Complex.ne_zero_of_norm_eq_one hμ), ?_⟩
   intro i
   have : B i = μ⁻¹ • (Ymat * A i * Yinv) := by
     have hBi : B i = SB * B' i * SB⁻¹ := by

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -656,10 +656,15 @@
     Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse}, including its
     normalized nonzero subleading spectral pair for every non-idempotent
     block. If $A$ has positive-gap BNT zero correlation length, then for every
-    $N>2$ its translated two-site parent interactions commute and their common
-    kernel is
+    $N>2$ its translated two-site parent interactions satisfy all three
+    ground-space conditions:
     \begin{align}
-        \ker H_2^{(N)}&=\spn_{\C}\{\ket{V^{(N)}(A_j)}:j\}.
+        h_i h_j&=h_j h_i,
+        \notag\\
+        h_iV^{(N)}(A)&=0,
+        \notag\\
+        \ker H_2^{(N)}(A)
+        &=\spn\bigl\{V^{(N)}(A_j):j=1,\ldots,g\bigr\}.
         \notag
     \end{align}
     This is only the conditional corrected implication from (ii) to (iii) of
@@ -673,8 +678,8 @@
     Theorem~\ref{thm:positive_gap_bnt_zcl_conditional_converse} gives
     $\E_A^2=\E_A$. The multiplicity-one fixed-point theorem
     \ref{thm:rfp_multiplicity_one_bnt_has_nncph_ground_spaces} then gives the
-    commuting parent interactions and the stated common kernel for every
-    $N>2$.
+    commuting parent interactions, zero-energy direct-sum state, and stated
+    common kernel for every $N>2$.
 \end{proof}
 
 \begin{theorem}[Physical ZCL implies idempotence under the spectral assumption]%

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -139,9 +139,12 @@ abstracted — record why, so it is not re-proposed).
   `norm_ne_zero_iff.mp (by rw [h]; exact one_ne_zero)`.
 - **Reuse:** `Complex.ne_zero_of_norm_eq_one` in
   `TNLean/Algebra/ComplexPhasePositivity.lean` now states this scalar fact once.
-- **Result:** ten call sites across `BNTCharacterization.lean`,
-  `BNTUniqueness.lean`, `BNTExistence.lean`, `BeigiLoopBNTIdentification.lean`,
-  and `GroupStructure.lean` use the shared lemma. All theorem statements and
+- **Result:** a repository-wide semantic audit migrated 26 call sites across
+  16 files, including nested `inv_ne_zero` uses and tactic-form contradiction
+  proofs. No exact-hypothesis conversion from `h : ‖z‖ = 1` to `z ≠ 0`
+  remains outside the shared lemma itself. The related proof from
+  `star α * α = 1` in `PeripheralUnitary.lean` remains separate because its
+  premise is not the helper's norm equality. All theorem statements and
   mathematical scopes are unchanged.
 
 ### Support left-right and relative-modular intertwining


### PR DESCRIPTION
## What changed

- Closes the late documentation finding on merged PR #4921 by displaying all three clauses of `HasNNCPHGroundSpaces` in `thm:positive_gap_bnt_zcl_conditional_nncph`: local-term commutation, annihilation of the full direct-sum state, and the sector-MPV kernel formula. The conditional spectral-pair hypothesis and the CPSV16 line-1250 obstruction remain unchanged.
- Closes the late refactor finding on merged PR #4920 by migrating the three named residual unit-norm-to-nonzero idioms and every other straightforward exact-hypothesis occurrence found by a fresh semantic audit, including nested `inv_ne_zero` and tactic-form proofs.
- Updates `docs/tactic_patterns.md` to record the audited total: 32 migrated call sites across 18 files. The separate `star α * α = 1` proof is recorded honestly because it does not have the helper's norm-equality premise.

Late review threads:
- #4920: https://github.com/LionSR/TNLean/pull/4920#discussion_r3653061122
- #4921: https://github.com/LionSR/TNLean/pull/4921#discussion_r3653002658

This PR claims no new mathematics and changes no theorem statements or CPSV scope.

## Validation

- targeted builds for all 12 touched Lean modules: passed (9064 jobs)
- `lake build TNLean`: passed (9755 jobs; only pre-existing warnings)
- generated import aggregators and Lean module policies: passed
- `blueprint_lean_sync.py` regeneration and CI sync: passed (5622 declarations referenced; 5633/5636 entries complete)
- `lake exe checkdecls blueprint/lean_decls` and `leanblueprint checkdecls`: passed
- LuaLaTeX twice with `TEXINPUTS='../../tex/tenkz//:'`: passed, 746 pages, zero undefined cross-references (standalone citation warnings only)
- proof-integrity, reader-facing prose, added-line length, and `git diff --check`: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical proof refactors and documentation alignment only; no new mathematics or changed theorem statements.
> 
> **Overview**
> Closes late review on merged PRs **#4920** and **#4921** without changing theorem statements or CPSV scope.
> 
> **Lean refactor:** Many proofs that derived `z ≠ 0` from `‖z‖ = 1` (via `norm_ne_zero_iff`, contradiction on `simp`, or nested `inv_ne_zero`) now call **`Complex.ne_zero_of_norm_eq_one`** from `TNLean.Algebra.ComplexPhasePositivity`, with that module imported where needed (spin cover, peripheral spectrum/group structure, BNT sector theorems, periodic MPS, gauge construction, etc.). **`docs/tactic_patterns.md`** records a repo-wide audit: **26 call sites across 16 files**; proofs from `star α * α = 1` stay separate.
> 
> **Blueprint:** **`thm:positive_gap_bnt_zcl_conditional_nncph`** now states all three **`HasNNCPHGroundSpaces`** conditions—commuting parent Hamiltonians, annihilation of the full direct-sum state, and the sector-MPV kernel formula—not only the kernel line. Conditional spectral-pair hypotheses are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6074831667e95b5dcefbb9fca5249d9d4ca4a750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
