### PR TITLE
refactor(CPSV): finish unit-norm nonzero migration

### DIFF
--- a/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.ComplexPhasePositivity
 import TNLean.Channel.FixedPoint.CanonicalGauge
 import TNLean.Channel.Semigroup.Primitivity.Basic
 
@@ -208,17 +209,13 @@ theorem bounded_root_of_peripheral_closed_powers [NeZero D]
   rcases Nat.lt_or_gt_of_ne hab_ne with hlt | hgt
   · refine ⟨(b : ℕ) - (a : ℕ), Nat.sub_pos_of_lt hlt, ?_, ?_⟩
     · exact Nat.sub_le _ _ |>.trans (Nat.le_of_lt_succ b.2)
-    · have hμ_ne : μ ≠ 0 := by
-        rw [← norm_ne_zero_iff, hμ.2]
-        norm_num
+    · have hμ_ne : μ ≠ 0 := Complex.ne_zero_of_norm_eq_one hμ.2
       exact mul_left_cancel₀ (pow_ne_zero _ hμ_ne) (by
         rw [← pow_add, Nat.add_sub_cancel' hlt.le, mul_one]
         exact hab'.symm)
   · refine ⟨(a : ℕ) - (b : ℕ), Nat.sub_pos_of_lt hgt, ?_, ?_⟩
     · exact Nat.sub_le _ _ |>.trans (Nat.le_of_lt_succ a.2)
-    · have hμ_ne : μ ≠ 0 := by
-        rw [← norm_ne_zero_iff, hμ.2]
-        norm_num
+    · have hμ_ne : μ ≠ 0 := Complex.ne_zero_of_norm_eq_one hμ.2
       exact mul_left_cancel₀ (pow_ne_zero _ hμ_ne) (by
         rw [← pow_add, Nat.add_sub_cancel' hgt.le, mul_one]
         exact hab')

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -452,10 +452,8 @@ theorem ft_sector_bnt_equal_sector_data
   let hMatch : ∀ k : Fin Q.basisCount, ∃ h : P.basisDim (β k) = Q.basisDim k,
       GaugePhaseEquiv (cast (congr_arg (MPSTensor d) h) (P.basis (β k))) (Q.basis k) :=
     fun k => by
-      refine ⟨hDim k, Xblock k, ζ k, ?_, hConj k⟩
-      intro hzero
-      have hnorm := hζ_norm k
-      simp [hzero] at hnorm
+      exact ⟨hDim k, Xblock k, ζ k,
+        Complex.ne_zero_of_norm_eq_one (hζ_norm k), hConj k⟩
   have hCopies : ∀ k : Fin Q.basisCount, P.copies (β k) = Q.copies k := by
     intro k
     have hcard := Fintype.card_congr (W.copy_equiv k)

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Unitary.lean
@@ -58,9 +58,7 @@ theorem ft_sector_bnt_proportional_unitary_sector_match_witnesses
   have hGPE : ∀ k : Fin Q.basisCount,
       GaugePhaseEquiv
         (cast (congr_arg (MPSTensor d) (hDim k)) (P.basis (β k))) (Q.basis k) :=
-    fun k => ⟨X k, ζ₀ k, by
-      intro hzero
-      simpa [hzero] using hζ₀ k, hConj k⟩
+    fun k => ⟨X k, ζ₀ k, Complex.ne_zero_of_norm_eq_one (hζ₀ k), hConj k⟩
   have hUnitary : ∀ k : Fin Q.basisCount,
       ∃ (U : Matrix.unitaryGroup (Fin (Q.basisDim k)) ℂ) (ζ : ℂ), ‖ζ‖ = 1 ∧
         ∀ i, Q.basis k i = ζ •

--- a/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
+++ b/TNLean/MPS/Overlap/NormalTensorDichotomy.lean
@@ -167,9 +167,7 @@ theorem EventuallyNonzeroProportionalMPV₂.exists_unit_phase_power_of_isNormalT
   · refine ⟨ζ⁻¹, ?_, ?_⟩
     · rw [norm_inv, hζ, inv_one]
     · intro N _hN σ
-      have hζ0 : ζ ≠ 0 := by
-        intro h
-        simp [h] at hζ
+      have hζ0 : ζ ≠ 0 := Complex.ne_zero_of_norm_eq_one hζ
       have hComponent := congrArg (fun v : MPVSpace d N ↦ v σ) (hState N)
       simp only [mpvState_apply, PiLp.smul_apply, smul_eq_mul] at hComponent
       rw [hComponent, ← mul_assoc, ← mul_pow, inv_mul_cancel₀ hζ0, one_pow, one_mul]

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -106,10 +106,7 @@ theorem isNormalTensor_of_isNormal_isTransferIdempotent [NeZero D]
                 rw [hXeq, map_smul, hXeq, smul_smul]
           _ = 0 := sub_eq_zero.mpr hIdemX
       exact sub_eq_zero.mp ((smul_eq_zero.mp hzero).resolve_right hXne)
-    have hμne : μ ≠ 0 := by
-      intro hzero
-      subst μ
-      norm_num at hμnorm
+    have hμne : μ ≠ 0 := Complex.ne_zero_of_norm_eq_one hμnorm
     apply mul_left_cancel₀ hμne
     simpa only [mul_one] using hμIdem
   have hScaled : IsNormalTensor (fun i =>

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -139,8 +139,8 @@ abstracted — record why, so it is not re-proposed).
   `norm_ne_zero_iff.mp (by rw [h]; exact one_ne_zero)`.
 - **Reuse:** `Complex.ne_zero_of_norm_eq_one` in
   `TNLean/Algebra/ComplexPhasePositivity.lean` now states this scalar fact once.
-- **Result:** a repository-wide semantic audit migrated 26 call sites across
-  16 files, including nested `inv_ne_zero` uses and tactic-form contradiction
+- **Result:** a repository-wide semantic audit migrated 32 call sites across
+  18 files, including nested `inv_ne_zero` uses and tactic-form contradiction
   proofs. No exact-hypothesis conversion from `h : ‖z‖ = 1` to `z ≠ 0`
   remains outside the shared lemma itself. The related proof from
   `star α * α = 1` in `PeripheralUnitary.lean` remains separate because its


### PR DESCRIPTION
## What changed

PR #4947 merged its original head while independent review execution `00309aeb76bf` was identifying six remaining exact unit-norm-to-nonzero conversions. This focused follow-up applies those missed migrations:

- one `GaugePhaseEquiv` witness in `SectorBNT/Fundamental.lean`;
- one proportional unitary witness in `SectorBNT/Unitary.lean`;
- one idempotent peripheral-eigenvalue proof in `BeigiLoopBNTIdentification.lean`;
- one inverse-phase cancellation in `NormalTensorDichotomy.lean`;
- both order branches in `Channel/Semigroup/Primitivity/Helpers.lean`.

A fresh repository-wide semantic search now leaves only the implementation of `Complex.ne_zero_of_norm_eq_one` among direct, nested `inv_ne_zero`, tactic-form, and contradiction-form exact `‖z‖ = 1 → z ≠ 0` conversions. The ledger count is updated mechanically from 26 sites/16 files to 32 sites/18 files. The distinct `star α * α = 1` proof remains documented separately because it does not have the helper's norm-equality premise.

This changes no theorem statements, CPSV scope, or mathematics. It completes the late #4920 refactor finding and corrects the overclaim that survived into #4947.

## Validation

- targeted builds for all five corrected modules: passed (9120 jobs)
- `lake build TNLean`: passed (9755 jobs; only pre-existing warnings)
- generated import aggregators and Lean module policies: passed
- blueprint regeneration/sync plus both checkdecls commands: passed
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'`: passed, 746 pages, zero undefined cross-references
- proof-integrity, reader-facing prose, added-line length, semantic grep, and `git diff --check`: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors with no API or theorem-statement changes; behavior is unchanged aside from using a single shared lemma.
> 
> **Overview**
> Completes the follow-up to the `Complex.ne_zero_of_norm_eq_one` refactor by swapping the last hand-written **`‖z‖ = 1` → `z ≠ 0`** steps for the shared lemma.
> 
> **Channel primitivity:** `Helpers.lean` imports `ComplexPhasePositivity` and uses the lemma for peripheral eigenvalues in both branches of `bounded_root_of_peripheral_closed_powers`.
> 
> **MPS / BNT:** `SectorBNT/Fundamental.lean` and `Unitary.lean` build `GaugePhaseEquiv` witnesses from unit phase norms without contradiction tactics; `NormalTensorDichotomy.lean` and `BeigiLoopBNTIdentification.lean` use the same helper for inverse-phase and idempotent-eigenvalue cancellation.
> 
> **Docs:** `docs/tactic_patterns.md` updates the migration ledger to **32 sites / 18 files**. Theorem statements and mathematics are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a581898d78365797cb13eab10e59c919f4cd5e3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->