### PR TITLE
fix(tenkz): diagnose region role misuse

### DIFF
--- a/scripts/test_tenkz_enclosures.py
+++ b/scripts/test_tenkz_enclosures.py
@@ -431,6 +431,25 @@ DUPLICATE_RECOVERY = r"""
 \end{document}
 """
 
+REGION_ROLE_RECOVERY = r"""
+\documentclass{article}
+\usepackage{tenkz}
+\pagestyle{empty}
+\newcommand*{\tenkzTestRejectedRegionRoleLabel}{%
+  \typeout{TENKZ-REJECTED-REGION-ROLE-LABEL}$R$}
+\newcommand*{\tenkzTestValidRegionAfterRole}{%
+  \typeout{TENKZ-VALID-REGION-AFTER-ROLE}$S$}
+\begin{document}
+\begin{tenkzlattice}[
+    rows=2, cols=2, frame=oblique, physical=up,
+    boundary=none, outer legs=none]
+  \tnregion[label={\tenkzTestRejectedRegionRoleLabel}, role=marked]{(1,1)}
+  \tnregion[name=S, label={\tenkzTestValidRegionAfterRole}]{(2,2)}
+\end{tenkzlattice}
+\typeout{TENKZ-REGION-ROLE-RECOVERED}
+\end{document}
+"""
+
 
 SPAN_SYNTAX_RECOVERY = r"""
 \documentclass{article}
@@ -712,6 +731,50 @@ region|picture=1|lang=free|slot=selected|members=a|outline=0|name=a
         if sum("|name=good" in line for line in recovery_joins) != 1:
             raise AssertionError(
                 f"valid recovery control emitted {recovery_joins!r}"
+            )
+
+        # `role=` describes sites and edges, whereas a region is classified
+        # by `slot=`.  The exact option combination from #4930 must stop at
+        # that grammatical distinction, before label-anchor geometry runs.
+        role_recovered = compile_tex(
+            engine, work, "region-role-recovery", REGION_ROLE_RECOVERY,
+            env, halt_on_error=False,
+        )
+        if role_recovered.returncode == 0:
+            raise AssertionError("region-role recovery compilation succeeded")
+        if "A lattice region has no 'role' key" not in role_recovered.stdout:
+            print(role_recovered.stdout)
+            raise AssertionError("region-role recovery missed its diagnostic")
+        for opaque_error in (
+            "Missing $ inserted",
+            "No shape named",
+            "no shape known",
+        ):
+            if opaque_error in role_recovered.stdout:
+                print(role_recovered.stdout)
+                raise AssertionError(
+                    f"region-role recovery reached {opaque_error!r}"
+                )
+        for marker in (
+            "TENKZ-VALID-REGION-AFTER-ROLE",
+            "TENKZ-REGION-ROLE-RECOVERED",
+        ):
+            if marker not in role_recovered.stdout:
+                print(role_recovered.stdout)
+                raise AssertionError(
+                    f"region-role recovery missed {marker!r}"
+                )
+        if "TENKZ-REJECTED-REGION-ROLE-LABEL" in role_recovered.stdout:
+            raise AssertionError("rejected region-role label reached drawing")
+        role_events = (work / "region-role-recovery.tnlog").read_text(
+            encoding="utf-8"
+        ).splitlines()
+        role_regions = [
+            line for line in role_events if line.startswith("region|")
+        ]
+        if len(role_regions) != 1 or "|cells=2-2" not in role_regions[0]:
+            raise AssertionError(
+                f"invalid region role emitted events {role_regions!r}"
             )
 
         # A duplicate semantic name is a rejected transaction, not merely a

--- a/tex/tenkz/tenkz-lattice.code.tex
+++ b/tex/tenkz/tenkz-lattice.code.tex
@@ -1157,8 +1157,18 @@
 \pgfkeysdef{/tenkz/region/.unknown}
   {
     \bool_set_false:N \l__tenkzl_region_valid_bool
-    \PackageError{tenkz}{Unknown~lattice-region~key~'\pgfkeyscurrentname'}
-      {Check~the~\token_to_str:N \tnregion~option~spelling.}
+    \str_if_eq:eeTF {\pgfkeyscurrentname} {role}
+      {
+        \PackageError{tenkz}{A~lattice~region~has~no~'role'~key}
+          {Use~the~slot~key~with~value~selected,~secondary,~complement,~
+           collar~or~neutral~for~\token_to_str:N \tnregion.^^J
+           The~role~key~belongs~to~\token_to_str:N \tnsite~and~
+           \token_to_str:N \tnedge.}
+      }
+      {
+        \PackageError{tenkz}{Unknown~lattice-region~key~'\pgfkeyscurrentname'}
+          {Check~the~\token_to_str:N \tnregion~option~spelling.}
+      }
   }
 
 \cs_new_protected:Npn \tenkz_lattice_region:nn #1#2


### PR DESCRIPTION
## Summary

A lattice region is classified by `slot=selected|secondary|complement|collar|neutral`. The `role` key belongs to sites and edges; it has never been part of the `\tnregion` grammar.

The literal report in LionSR/tenkz#92 therefore should not be made to compile by assigning new, unspecified semantics to `role=marked`. This change instead gives the unsupported combination the documented-error outcome allowed by duplicate report LionSR/tenkz#96:

- `\tnregion[..., role=marked]` now reports that a region has no `role` key;
- the help text names the five region slots and directs site/edge markings to `\tnsite` and `\tnedge`;
- the error remains transactional, so the invalid label is neither drawn nor recorded;
- a following valid region still renders under `frame=oblique, physical=up`.

The regression uses the exact reported oblique frame, upward physical legs, region label, and `role=marked`. It also excludes the former opaque failures, `Missing $ inserted` and unknown TikZ shapes.

## Verification

- `python3 scripts/test_tenkz_enclosures.py`
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `bash scripts/tenkz_kernel_probes.sh`
- `TENKZ_CORPUS_JOBS=8 scripts/tenkz_corpus.sh`
- `TENKZ_CORPUS_JOBS=8 scripts/tenkz_golden.sh --check`
- `git diff --check`

All pass. The full corpus contains 264 files, and all 264 event streams remain byte-identical to their baselines.

Closes LionSR/tenkz#92

LionSR/tenkz#96 is an exact duplicate and will be closed as such after this PR merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to lattice region key validation and test-only regression; no auth, data, or broad API surface.
> 
> **Overview**
> **`\tnregion` no longer treats `role=` as an unknown key** — it now fails with a dedicated message that regions use **`slot=`** (selected, secondary, complement, collar, neutral) and that **`role`** belongs on **`\tnsite`** / **`\tnedge`**.
> 
> The invalid declaration stays **transactional**: the bad region’s label is not drawn, only the following valid region is logged (e.g. `cells=2-2`), and compilation should not degrade into opaque errors like “Missing $ inserted” or unknown TikZ shapes.
> 
> **Regression coverage** in `scripts/test_tenkz_enclosures.py` mirrors the LionSR/tenkz#92 oblique lattice setup and checks diagnostics, recovery markers, and `.tnlog` region events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bacb4a90085e449eec2dd1313b2381b43e175efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->