### PR TITLE
docs(MPDO): propagate BNT-refined scope

### DIFF
--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -15,9 +15,9 @@ This file compares the chosen one-site vertical basis in a tensor-attached
 BNT algebra clause with a vertical canonical decomposition of the two-site
 blocking.  The same-length product law identifies the sectorwise power sums,
 and positivity turns them into the multiplicity-spectrum comparison used in
-the algebra-to-RFP implication.  The source-facing constructions assume
-normalized BNT-refined horizontal form; they do not establish the corresponding
-claim from the literal CPSV canonical form.
+the algebra-to-RFP implication.  The constructions below assume normalized
+BNT-refined horizontal form, which is stronger than literal CPSV canonical
+form.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -15,7 +15,9 @@ This file compares the chosen one-site vertical basis in a tensor-attached
 BNT algebra clause with a vertical canonical decomposition of the two-site
 blocking.  The same-length product law identifies the sectorwise power sums,
 and positivity turns them into the multiplicity-spectrum comparison used in
-the algebra-to-RFP implication.
+the algebra-to-RFP implication.  The source-facing constructions assume
+normalized BNT-refined horizontal form; they do not establish the corresponding
+claim from the literal CPSV canonical form.
 
 ## Main results
 
@@ -148,6 +150,11 @@ in `H`.  No renormalization maps or pre-existing one-site/two-site sector
 correspondence are assumed: full support of the two positive vertical
 decompositions derives the sector relabelling, and eventual BNT linear
 independence derives the power-sum equality.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is the
+normalized BNT-refined horizontal form, stronger than the literal CPSV
+canonical form used in Appendix C.4 through Proposition 4.13; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 **Scope restriction (invertible gauge):** The result retains bond-dimension
 equality and phase-one invertible conjugacy, but does not prove the line-2057
@@ -704,7 +711,12 @@ noncomputable def toTwoSiteExactSectorGauge
       rw [hzetaOne γ, one_smul] at hExact
       exact hExact }
 
-/-- The exact sector gauges determine the source-derived two-site multiplicity spectrum.
+/-- The exact sector gauges determine the two-site multiplicity spectrum under
+normalized BNT-refined horizontal form.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -714,8 +726,12 @@ noncomputable def toTwoSiteMultiplicitySpectrum
     TwoSiteMultiplicitySpectrum H :=
   (H.toTwoSiteExactSectorGauge hHorizontal hM).toTwoSiteMultiplicitySpectrum
 
-/-- The source-derived two-site multiplicity spectrum entails the corresponding
-multiplicity-spectrum comparison.
+/-- The two-site multiplicity spectrum under normalized BNT-refined horizontal
+form entails the corresponding multiplicity-spectrum comparison.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -45,12 +45,13 @@ unconditionally:
 
 The source also states that $Q$ fails to commute with the density operator
 $H^{(N)}$ at every length (arXiv:1606.00608, line 1889).  The proof needs only
-one noncommuting length.  Horizontal canonical form supplies such a length:
-otherwise the representative-grouped Lemma L would turn simultaneous
+one noncommuting length.  Normalized BNT-refined horizontal form supplies such
+a length: otherwise the representative-grouped Lemma L would turn simultaneous
 commutation into the forbidden letter-level invariance.  At that same length,
 full-period word invariance gives commutation with $[H^{(N)}]^p$, and
-positivity removes the power.  Thus the periodic-sector step is proved with
-the source hypotheses, without the stronger all-length inequality.
+positivity removes the power.  This proves the periodic-sector step on the
+stronger BNT-refined surface, not from the literal source hypotheses; see
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`.
 
 ## Main results
 
@@ -69,9 +70,9 @@ the source hypotheses, without the stronger all-length inequality.
 * `MPOTensor.hasNoPeriodicVectors_verticalTensor_of_noncommutation`: granted
   the hypothesis, a matrix product density operator has no nontrivial
   periodic vectors in the vertical direction.
-* `MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF`: a
-  horizontally canonical matrix product density operator has no nontrivial
-  periodic vectors in the vertical direction.
+* `MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF`: an MPDO in
+  normalized BNT-refined horizontal form has no nontrivial periodic vectors in
+  the vertical direction.
 
 ## References
 
@@ -625,10 +626,10 @@ $Q\widetilde M\ne Q\widetilde MQ$ — fails to commute with the density
 operator $H^{(N)}$ at every length.
 
 This is the horizontal-canonical-form step of the periodic-sector argument.
-The source assumes the tensor is in canonical form in the horizontal
-direction; the argument of lines 1874--1887 (Lemma L of the appendix,
-formalized for the literal representative-indexed horizontal canonical form
-in `TNLean/MPS/MPDO/HorizontalBNT.lean`) turns the full positive-length family
+The source assumes the tensor is in literal canonical form in the horizontal
+direction.  The available formal Lemma L in
+`TNLean/MPS/MPDO/HorizontalBNT.lean` instead assumes normalized BNT-refined
+horizontal form and turns the full positive-length family
 of first-site identities into the letter-level invariance
 $Q\widetilde M=Q\widetilde MQ$.  The predicate below records the stronger
 all-length assertion printed by the source.  The proof of Proposition 4.13
@@ -648,7 +649,7 @@ displacement upgrades to the all-length non-commutation family through the
 hypothesis.  This reduces the periodic-sector step of the proof of
 Proposition 4.13 of arXiv:1606.00608, lines 1888--1893, to the explicit
 all-length non-commutation interface.  This is a stronger conditional
-formulation than the unconditional horizontal-canonical-form theorem below. -/
+formulation than the normalized BNT-refined theorem below. -/
 theorem periodicVectorYieldsCyclicProjector_of_noncommutation
     {d D : ℕ} (M : MPOTensor d D)
     (hNC : NoninvariantProjectorNoncommuting M) :
@@ -667,9 +668,10 @@ and its word invariance constructed from the cyclic decomposition of the
 peripheral spectrum (Wolf 2012, Theorem 6.6) rather than assumed.
 
 **Scope restriction (conditional on the non-commutation family):** the
-hypothesis requires noncommutation at every length.  The source-faithful
-theorem `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` instead uses
-the one noncommuting length supplied by horizontal canonical form. -/
+hypothesis requires noncommutation at every length.  The theorem
+`hasNoPeriodicVectors_verticalTensor_of_horizontalCF` instead uses one
+noncommuting length supplied by normalized BNT-refined horizontal form; it is
+not the literal source theorem. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_noncommutation
     {d D : ℕ} (M : MPOTensor d D) (hM : IsMPDO M)
     (hNC : NoninvariantProjectorNoncommuting M) :
@@ -703,7 +705,7 @@ Proposition 4.13 allows `M` to be reducible, decomposed horizontally into
 several gauge-inequivalent canonical-form blocks with weights; this theorem
 covers the sub-case where `M`'s own tensor is already (single-letter)
 injective.  The theorem `hasNoPeriodicVectors_verticalTensor_of_horizontalCF`
-below treats the general horizontal canonical form. -/
+below treats normalized BNT-refined horizontal form. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_isInjective
     {d D : ℕ} (M : MPOTensor d D) (hM : IsMPDO M)
     (hInj : MPSTensor.IsInjective M.toMPSTensor) :
@@ -721,26 +723,32 @@ theorem hasNoPeriodicVectors_verticalTensor_of_isInjective
   exact ketLeftMul_eq_braRightMul_of_commute_of_isInjective M hInj hQidem
     (mpo_commute_of_commute_pow M hM 2 (by omega) hp hCommPow)
 
-/-- **The periodic-sector step for a horizontally canonical matrix product
-density operator.**
+/-- **The periodic-sector step for an MPDO in normalized BNT-refined
+horizontal form.**
 
-The vertically viewed tensor of a horizontally canonical MPDO has no
-nontrivial periodic vector.  A periodic vector supplies an orthogonal
-projector displaced by one vertical layer and invariant under every word of
-one full period.  Horizontal canonical form shows that this displacement
-forces noncommutation with the density operator at some positive length.
+The vertically viewed tensor of an MPDO in normalized BNT-refined horizontal
+form has no nontrivial periodic vector.  A periodic vector supplies an
+orthogonal projector displaced by one vertical layer and invariant under every
+word of one full period.  The BNT-refined horizontal form shows that this
+displacement forces noncommutation with the density operator at some positive
+length.
 Full-period invariance gives commutation with the corresponding power of that
 density operator, while positivity removes the power and gives a
 contradiction.
 
 This proves the periodic-sector paragraph of arXiv:1606.00608,
-Proposition 4.13, lines 1888--1893.  Only one noncommuting length is needed;
-the source states the stronger all-length inequality, but the contradiction
-is pointwise in the length.
+Proposition 4.13, lines 1888--1893, only under the stronger BNT-refined
+horizontal hypothesis.  One noncommuting length is enough; the source states
+the stronger all-length inequality, but the contradiction is pointwise in the
+length.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form.  The literal periodic-sector
+step remains open; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 **Local fix (noncommuting length):** the all-length inequality printed at
-source line 1889 is replaced by the existential consequence of the literal
-Lemma L, which is sufficient at lines 1890--1893.  Documented in
+source line 1889 is replaced by the existential consequence of the available
+BNT-refined Lemma L, which is sufficient at lines 1890--1893.  Documented in
 `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_horizontalCF
     (M : MPOTensor d D) (hM : IsMPDO M) (hHorizontal : IsHorizontalCF M) :

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -49,8 +49,9 @@ one noncommuting length.  Normalized BNT-refined horizontal form supplies such
 a length: otherwise the representative-grouped Lemma L would turn simultaneous
 commutation into the forbidden letter-level invariance.  At that same length,
 full-period word invariance gives commutation with $[H^{(N)}]^p$, and
-positivity removes the power.  This proves the periodic-sector step on the
-stronger BNT-refined surface, not from the literal source hypotheses; see
+positivity removes the power.  This proves the periodic-sector step under
+normalized BNT-refined horizontal form, which is stronger than the literal
+CPSV canonical-form hypothesis; see
 `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`.
 
 ## Main results

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -740,13 +740,12 @@ the stronger all-length inequality, but the contradiction is pointwise in the
 length.
 
 **Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form.  The literal periodic-sector
-step remains open; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+stronger than the literal CPSV canonical form; no literal canonical-form
+conclusion is asserted.
 
 **Local fix (noncommuting length):** the all-length inequality printed at
-source line 1889 is replaced by the existential consequence of the available
-BNT-refined Lemma L, which is sufficient at lines 1890--1893.  Documented in
-`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+source line 1889 is replaced by the existential consequence of the BNT-refined
+Lemma L, which is sufficient at lines 1890--1893. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_horizontalCF
     (M : MPOTensor d D) (hM : IsMPDO M) (hHorizontal : IsHorizontalCF M) :
     MPSTensor.HasNoPeriodicVectors (verticalTensor M) := by

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -739,13 +739,14 @@ horizontal hypothesis.  One noncommuting length is enough; the source states
 the stronger all-length inequality, but the contradiction is pointwise in the
 length.
 
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form; no literal canonical-form
-conclusion is asserted.
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`.
 
 **Local fix (noncommuting length):** the all-length inequality printed at
 source line 1889 is replaced by the existential consequence of the BNT-refined
-Lemma L, which is sufficient at lines 1890--1893. -/
+Lemma L, which is sufficient at lines 1890--1893; see
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_horizontalCF
     (M : MPOTensor d D) (hM : IsMPDO M) (hHorizontal : IsHorizontalCF M) :
     MPSTensor.HasNoPeriodicVectors (verticalTensor M) := by

--- a/TNLean/MPS/MPDO/CyclicProjector.lean
+++ b/TNLean/MPS/MPDO/CyclicProjector.lean
@@ -627,16 +627,12 @@ $Q\widetilde M\ne Q\widetilde MQ$ — fails to commute with the density
 operator $H^{(N)}$ at every length.
 
 This is the horizontal-canonical-form step of the periodic-sector argument.
-The source assumes the tensor is in literal canonical form in the horizontal
-direction.  The available formal Lemma L in
-`TNLean/MPS/MPDO/HorizontalBNT.lean` instead assumes normalized BNT-refined
-horizontal form and turns the full positive-length family
-of first-site identities into the letter-level invariance
-$Q\widetilde M=Q\widetilde MQ$.  The predicate below records the stronger
-all-length assertion printed by the source.  The proof of Proposition 4.13
-does not require this assertion: the theorem
-`hasNoPeriodicVectors_verticalTensor_of_horizontalCF` uses the single
-noncommuting length supplied by the contrapositive of Lemma L. -/
+The source assumes literal canonical form in the horizontal direction.  Under
+normalized BNT-refined horizontal form, Lemma L turns the full positive-length
+family of first-site identities into the letter-level invariance
+$Q\widetilde M=Q\widetilde MQ$.  The all-length assertion below is stronger
+than needed: `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` uses the
+single noncommuting length supplied by the contrapositive of Lemma L. -/
 def NoninvariantProjectorNoncommuting {d D : ℕ} (M : MPOTensor d D) : Prop :=
   ∀ Q : Matrix (Fin d) (Fin d) ℂ, Q.IsHermitian → IsIdempotentElem Q →
     M.ketLeftMul Q ≠ (M.ketLeftMul Q).braRightMul Q →

--- a/TNLean/MPS/MPDO/FigureEightPairwise.lean
+++ b/TNLean/MPS/MPDO/FigureEightPairwise.lean
@@ -18,7 +18,8 @@ have equal marked chains after Gram dressing.
 
 The final separation uses only marks in the span of the physical letters of
 the horizontal tensor.  The corner equations give the required coefficient
-families explicitly, and horizontal canonical form separates them.
+families explicitly, and normalized BNT-refined horizontal form separates them.
+The corresponding literal canonical-form separation remains open.
 
 ## Main results
 
@@ -313,7 +314,8 @@ variable {d D n : ℕ}
 
 Suppose two vertical corners of the same representative tensor are positive
 scalar multiples of similarities by `X` and `Y`.  If the horizontal tensor
-is in canonical form and defines positive operators at every length, then
+is in normalized BNT-refined form and defines positive operators at every
+length, then
 conjugation of the representative by the two Gram matrices gives the same
 tensor:
 $X^\dagger X A^v (X^\dagger X)^{-1}
@@ -321,8 +323,12 @@ $X^\dagger X A^v (X^\dagger X)^{-1}
 
 Hermiticity first identifies both marked chains with the common reflected
 chain of the representative.  The corner equations express the two marks as
-linear combinations of physical letters, so horizontal canonical form
-separates them.
+linear combinations of physical letters, so normalized BNT-refined horizontal
+form separates them.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, proof of Proposition 4.13, Figures 7--8 and lines
 1909--1919. -/

--- a/TNLean/MPS/MPDO/FigureEightPairwise.lean
+++ b/TNLean/MPS/MPDO/FigureEightPairwise.lean
@@ -19,7 +19,7 @@ have equal marked chains after Gram dressing.
 The final separation uses only marks in the span of the physical letters of
 the horizontal tensor.  The corner equations give the required coefficient
 families explicitly, and normalized BNT-refined horizontal form separates them.
-The corresponding literal canonical-form separation remains open.
+No corresponding literal canonical-form separation is asserted.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/GroupedFigure8.lean
+++ b/TNLean/MPS/MPDO/GroupedFigure8.lean
@@ -10,7 +10,8 @@ import TNLean.MPS.MPDO.VerticalBNT
 # Figure 8 for grouped vertical sectors
 
 This file applies the pairwise reflected form of Lemma L to the actual
-vertical corners and gauges furnished by the grouped vertical decomposition.
+vertical corners and gauges furnished by the grouped vertical decomposition
+under normalized BNT-refined horizontal form.
 
 ## Main result
 
@@ -76,6 +77,10 @@ conjugation fixes the transported representative tensor.
 
 No identity between an individual dressed tensor and its raw reflected
 adjoint is used or asserted.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is the
+normalized BNT-refined horizontal form, stronger than the literal CPSV
+canonical form; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, proof of Proposition 4.13, Figures 7--8 and lines
 1909--1919. -/

--- a/TNLean/MPS/MPDO/GroupedGramNormalization.lean
+++ b/TNLean/MPS/MPDO/GroupedGramNormalization.lean
@@ -10,8 +10,8 @@ import TNLean.MPS.MPDO.GroupedFigure8
 # Gram and unitary normalization of grouped vertical sectors
 
 This file applies normal-tensor rigidity to the grouped Figure 8 comparison
-constructed from normalized BNT-refined horizontal form.  The literal CPSV
-canonical-form refinement remains open.
+constructed from normalized BNT-refined horizontal form, which is stronger
+than literal CPSV canonical form.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/GroupedGramNormalization.lean
+++ b/TNLean/MPS/MPDO/GroupedGramNormalization.lean
@@ -9,7 +9,9 @@ import TNLean.MPS.MPDO.GroupedFigure8
 /-!
 # Gram and unitary normalization of grouped vertical sectors
 
-This file applies normal-tensor rigidity to the grouped Figure 8 comparison.
+This file applies normal-tensor rigidity to the grouped Figure 8 comparison
+constructed from normalized BNT-refined horizontal form.  The literal CPSV
+canonical-form refinement remains open.
 
 ## Main results
 
@@ -42,6 +44,10 @@ real multiple of the identity.
 
 All hypotheses are clauses furnished by
 `IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is the
+normalized BNT-refined horizontal form, stronger than the literal CPSV
+canonical form; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1903--1921. -/
 theorem IsMPDO.grouped_sector_gram_eq_pos_smul_one
@@ -105,6 +111,10 @@ by the square root of its positive Gram scalar.
 
 All hypotheses are clauses furnished by
 `IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is the
+normalized BNT-refined horizontal form, stronger than the literal CPSV
+canonical form; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, proof of Proposition 4.13, lines 1903--1921. -/
 theorem IsMPDO.grouped_sector_exists_unitary_normalization

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -21,16 +21,15 @@ where $P_1=P\otimes\Id^{\otimes N}$.  Given an MPV-level BNT representation,
 Lemma L transfers these identities to every minimal representative, where they
 say $(\Id-P)MP=0$.  Transport to the original MPO letters is currently proved
 only for normalized BNT-refined horizontal form in
-`TNLean.MPS.MPDO.HorizontalBNT`; the literal active-refinement transport remains
-open.
+`TNLean.MPS.MPDO.HorizontalBNT`, under normalized BNT-refined horizontal form.
 
 The file also specializes the positive-semidefinite power-commutation theorem
 to matrix product density operators.  This is only the final operator
 implication in source lines 1888--1893.  The cyclic projector and its word
 invariance are constructed in `TNLean/MPS/MPDO/CyclicProjector.lean`; for a
 tensor in normalized BNT-refined horizontal form, one noncommuting length
-suffices for the periodic-sector contradiction.  The corresponding literal
-canonical-form transport remains open.
+suffices for the periodic-sector contradiction.  No corresponding literal
+canonical-form transport is asserted.
 
 ## Main results
 
@@ -317,7 +316,7 @@ construct the orthogonal projector $Q$ associated with a nontrivial vertical
 period or establish its commutation with $[H^{(N)}]^p$.  Those ingredients are
 combined in `TNLean/MPS/MPDO/CyclicProjector.lean`, where one noncommuting
 length gives the contradiction under normalized BNT-refined horizontal form.
-The corresponding literal CPSV canonical-form implication remains open. -/
+No corresponding literal CPSV canonical-form implication is asserted. -/
 theorem mpo_commute_of_commute_pow (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     (hN : 0 < N) {p : ℕ} (hp : p ≠ 0)
     {Q : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ}

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -19,17 +19,18 @@ $$
 $$
 where $P_1=P\otimes\Id^{\otimes N}$.  Given an MPV-level BNT representation,
 Lemma L transfers these identities to every minimal representative, where they
-say $(\Id-P)MP=0$. The further transport to the original MPO letters uses the
-literal horizontal canonical form and is carried out in
-`TNLean.MPS.MPDO.HorizontalBNT`.
+say $(\Id-P)MP=0$.  Transport to the original MPO letters is currently proved
+only for normalized BNT-refined horizontal form in
+`TNLean.MPS.MPDO.HorizontalBNT`; the literal active-refinement transport remains
+open.
 
 The file also specializes the positive-semidefinite power-commutation theorem
 to matrix product density operators.  This is only the final operator
 implication in source lines 1888--1893.  The cyclic projector and its word
 invariance are constructed in `TNLean/MPS/MPDO/CyclicProjector.lean`; for a
-tensor in literal horizontal canonical form, one noncommuting length suffices
-for the periodic-sector contradiction, so the stronger all-length condition is
-not required.
+tensor in normalized BNT-refined horizontal form, one noncommuting length
+suffices for the periodic-sector contradiction.  The corresponding literal
+canonical-form transport remains open.
 
 ## Main results
 

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -19,9 +19,9 @@ $$
 $$
 where $P_1=P\otimes\Id^{\otimes N}$.  Given an MPV-level BNT representation,
 Lemma L transfers these identities to every minimal representative, where they
-say $(\Id-P)MP=0$.  Transport to the original MPO letters is currently proved
-only for normalized BNT-refined horizontal form in
-`TNLean.MPS.MPDO.HorizontalBNT`, under normalized BNT-refined horizontal form.
+say $(\Id-P)MP=0$. For tensors in the normalized BNT-refined horizontal form
+of `TNLean.MPS.MPDO.HorizontalBNT`, these identities also hold for the original
+MPO letters.
 
 The file also specializes the positive-semidefinite power-commutation theorem
 to matrix product density operators.  This is only the final operator

--- a/TNLean/MPS/MPDO/InvariantProjection.lean
+++ b/TNLean/MPS/MPDO/InvariantProjection.lean
@@ -316,8 +316,8 @@ arXiv:1606.00608, lines 1888--1893 (equation eq2:proof.IV.12).  It does not
 construct the orthogonal projector $Q$ associated with a nontrivial vertical
 period or establish its commutation with $[H^{(N)}]^p$.  Those ingredients are
 combined in `TNLean/MPS/MPDO/CyclicProjector.lean`, where one noncommuting
-length gives the contradiction for a tensor in literal horizontal canonical
-form. -/
+length gives the contradiction under normalized BNT-refined horizontal form.
+The corresponding literal CPSV canonical-form implication remains open. -/
 theorem mpo_commute_of_commute_pow (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     (hN : 0 < N) {p : ℕ} (hp : p ≠ 0)
     {Q : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ}

--- a/TNLean/MPS/MPDO/PeriodicExclusion.lean
+++ b/TNLean/MPS/MPDO/PeriodicExclusion.lean
@@ -35,10 +35,10 @@ spectrum (Wolf 2012, Theorem 6.6) applied to the vertical transfer map
 supplies the projector with its word invariance and single-letter
 displacement (`TNLean/MPS/MPDO/CyclicProjector.lean`).  The all-length
 non-commutation family remains available as a stronger conditional
-formulation.  For a tensor in horizontal canonical form, the theorem
-`hasNoPeriodicVectors_verticalTensor_of_horizontalCF` instead uses the one
-noncommuting length supplied by the contrapositive of Lemma L and proves the
-source conclusion without this hypothesis.
+formulation.  For a tensor in normalized BNT-refined horizontal form, the
+theorem `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` instead uses the
+one noncommuting length supplied by the contrapositive of the available Lemma L.
+The literal canonical-form conclusion remains open.
 
 ## Main definitions
 
@@ -135,8 +135,8 @@ derivation are formalized in `TNLean/MPS/MPDO/StackedLayers.lean`, which
 reduces this hypothesis to `PeriodicVectorYieldsCyclicProjector`; the
 cyclic projections themselves, with their word invariance and single-letter
 displacement, are constructed in `TNLean/MPS/MPDO/CyclicProjector.lean`,
-which also proves the source conclusion directly from horizontal canonical
-form by using one noncommuting length.  The predicate below retains the
+which proves the source-shaped conclusion from normalized BNT-refined
+horizontal form by using one noncommuting length.  The predicate below retains
 stronger all-length formulation as an auxiliary interface. -/
 def PeriodicVectorYieldsProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
@@ -159,10 +159,10 @@ density operators rules such a projector out.
 
 **Scope restriction (conditional on the supplied projector):** the source
 draws the projector from the general theory of the peripheral spectrum; here
-that implication is the explicit all-length hypothesis.  The general theorem
-for a tensor in literal horizontal canonical form is proved in
-`TNLean/MPS/MPDO/CyclicProjector.lean` from one noncommuting length.  Recorded
-in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+that implication is the explicit all-length hypothesis.  The theorem in
+`TNLean/MPS/MPDO/CyclicProjector.lean` uses one noncommuting length but assumes
+normalized BNT-refined horizontal form, not the literal CPSV canonical form.
+Recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor (M : MPOTensor d D)
     (hM : IsMPDO M) (hYield : PeriodicVectorYieldsProjector M) :
     MPSTensor.HasNoPeriodicVectors (verticalTensor M) := by

--- a/TNLean/MPS/MPDO/PeriodicExclusion.lean
+++ b/TNLean/MPS/MPDO/PeriodicExclusion.lean
@@ -135,8 +135,8 @@ derivation are formalized in `TNLean/MPS/MPDO/StackedLayers.lean`, which
 reduces this hypothesis to `PeriodicVectorYieldsCyclicProjector`; the
 cyclic projections themselves, with their word invariance and single-letter
 displacement, are constructed in `TNLean/MPS/MPDO/CyclicProjector.lean`,
-which proves the source-shaped conclusion from normalized BNT-refined
-horizontal form by using one noncommuting length.  The predicate below retains
+which proves the conclusion from normalized BNT-refined horizontal form by
+using one noncommuting length.  The predicate below retains
 stronger all-length formulation as an auxiliary interface. -/
 def PeriodicVectorYieldsProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)

--- a/TNLean/MPS/MPDO/PeriodicExclusion.lean
+++ b/TNLean/MPS/MPDO/PeriodicExclusion.lean
@@ -157,11 +157,12 @@ $p$-periodic vector would supply an orthogonal projector with the
 commutation identities eq2:proof.IV.12, and positive semidefiniteness of the
 density operators rules such a projector out.
 
-**Scope restriction (conditional on the supplied projector):** the source
+**Scope restriction (conditional on the supplied projector):** The source
 draws the projector from the general theory of the peripheral spectrum; here
-that implication is the explicit all-length hypothesis.  The theorem in
+that implication is the explicit all-length hypothesis. The theorem in
 `TNLean/MPS/MPDO/CyclicProjector.lean` uses one noncommuting length but assumes
-normalized BNT-refined horizontal form, not the literal CPSV canonical form. -/
+normalized BNT-refined horizontal form, not the literal CPSV canonical form;
+see `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor (M : MPOTensor d D)
     (hM : IsMPDO M) (hYield : PeriodicVectorYieldsProjector M) :
     MPSTensor.HasNoPeriodicVectors (verticalTensor M) := by

--- a/TNLean/MPS/MPDO/PeriodicExclusion.lean
+++ b/TNLean/MPS/MPDO/PeriodicExclusion.lean
@@ -34,11 +34,11 @@ completely positive maps at lines 1889--1891 — is stated as the hypothesis
 spectrum (Wolf 2012, Theorem 6.6) applied to the vertical transfer map
 supplies the projector with its word invariance and single-letter
 displacement (`TNLean/MPS/MPDO/CyclicProjector.lean`).  The all-length
-non-commutation family remains available as a stronger conditional
-formulation.  For a tensor in normalized BNT-refined horizontal form, the
+non-commutation family is retained as a stronger conditional formulation.  For
+a tensor in normalized BNT-refined horizontal form, the
 theorem `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` instead uses the
-one noncommuting length supplied by the contrapositive of the available Lemma L.
-The literal canonical-form conclusion remains open.
+one noncommuting length supplied by the contrapositive of Lemma L.  No literal
+canonical-form conclusion is asserted.
 
 ## Main definitions
 
@@ -136,8 +136,8 @@ reduces this hypothesis to `PeriodicVectorYieldsCyclicProjector`; the
 cyclic projections themselves, with their word invariance and single-letter
 displacement, are constructed in `TNLean/MPS/MPDO/CyclicProjector.lean`,
 which proves the conclusion from normalized BNT-refined horizontal form by
-using one noncommuting length.  The predicate below retains
-stronger all-length formulation as an auxiliary interface. -/
+using one noncommuting length.  The definition below retains the stronger
+all-length formulation. -/
 def PeriodicVectorYieldsProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
     (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),
@@ -161,8 +161,7 @@ density operators rules such a projector out.
 draws the projector from the general theory of the peripheral spectrum; here
 that implication is the explicit all-length hypothesis.  The theorem in
 `TNLean/MPS/MPDO/CyclicProjector.lean` uses one noncommuting length but assumes
-normalized BNT-refined horizontal form, not the literal CPSV canonical form.
-Recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+normalized BNT-refined horizontal form, not the literal CPSV canonical form. -/
 theorem hasNoPeriodicVectors_verticalTensor (M : MPOTensor d D)
     (hM : IsMPDO M) (hYield : PeriodicVectorYieldsProjector M) :
     MPSTensor.HasNoPeriodicVectors (verticalTensor M) := by

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -247,7 +247,9 @@ theorem exists_global_renormalization_maps (M : MPOTensor d D)
 /-- An MPDO in normalized BNT-refined horizontal form satisfying Definition
 4.1 has nonzero trace at every positive chain length.
 
-This horizontal hypothesis is stronger than literal CPSV canonical form.
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 The BNT representation supplies one sufficiently long nonzero density
 operator. Positivity makes its trace nonzero. Definition 4.1 makes the

--- a/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSGlobal.lean
@@ -40,9 +40,9 @@ source argument are recorded in
   the localized maps respectively insert and remove one tensor in every periodic MPO.
 * `MPOTensor.exists_global_renormalization_maps`: a renormalization fixed point
   supplies localized channels with the global physical-closure identities.
-* `MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS`: a
-  horizontally canonical MPDO satisfying Definition 4.1 has nonzero trace at
-  every positive chain length.
+* `MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS`: an MPDO
+  in normalized BNT-refined horizontal form satisfying Definition 4.1 has
+  nonzero trace at every positive chain length.
 
 ## References
 
@@ -244,8 +244,10 @@ theorem exists_global_renormalization_maps (M : MPOTensor d D)
   exact ⟨S, T, hS, hT, coarsenFirstTwoSites_physCloseN M S hSclose,
     refineFirstSite_physCloseN M T hTclose⟩
 
-/-- A horizontally canonical MPDO satisfying Definition 4.1 has nonzero trace
-at every positive chain length.
+/-- An MPDO in normalized BNT-refined horizontal form satisfying Definition
+4.1 has nonzero trace at every positive chain length.
+
+This horizontal hypothesis is stronger than literal CPSV canonical form.
 
 The BNT representation supplies one sufficiently long nonzero density
 operator. Positivity makes its trace nonzero. Definition 4.1 makes the

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -343,8 +343,8 @@ This is the conditional entropic conclusion of Appendix C.  It still does not
 assert Proposition `propsimple`, because identifying this flattened bipartite
 quantity with `mutualInfoChain` and assembling the positive-chain SAL statement
 remain separate steps.  The required nonzero trace follows separately from
-horizontal canonical form, the MPDO condition, and the renormalization maps;
-source simplicity is not used in this implication.
+normalized BNT-refined horizontal form, the MPDO condition, and the
+renormalization maps; source simplicity is not used in this implication.
 
 Source: arXiv:1606.00608, Definition 4.1 and Appendix C,
 lines 1333--1341.
@@ -393,9 +393,9 @@ area law.
 The two local channels transfer one site across a consecutive bipartition.
 Data processing in both directions gives equality of the bipartite mutual
 informations, and `mutualInfoChain_eq_mutualInformation` identifies these with
-the chain quantities `I_L` and `I_{L+1}`.  Horizontal canonical form,
-positivity, and the fixed-point equations give the nonzero trace required to
-normalize every positive-length ring.  No empty-chain condition is used.
+the chain quantities `I_L` and `I_{L+1}`.  Normalized BNT-refined horizontal
+form, positivity, and the fixed-point equations give the nonzero trace required
+to normalize every positive-length ring.  No empty-chain condition is used.
 
 Source: arXiv:1606.00608, Proposition `propsimple`, Appendix C,
 lines 1333--1341, under the canonical-form and density-operator standing

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -10,14 +10,17 @@ import TNLean.MPS.MPDO.RFPViaTSGlobal
 /-!
 # Saturation of the area law for MPDO renormalization fixed points
 
-This file proves Proposition `propsimple`: a horizontally canonical matrix
-product density operator satisfying the local renormalization fixed-point
-equations has source zero correlation length and saturates the area law.  The
+This file proves the normalized BNT-refined specialization of Proposition
+`propsimple`: a matrix product density operator in normalized BNT-refined
+horizontal form satisfying the local renormalization fixed-point equations has
+source zero correlation length and saturates the area law.  The
 SAL proof first establishes the two exact finite-chain identities obtained by
 transferring one site across a bipartition, applies mutual-information data
 processing in both directions, and then identifies bipartite mutual information
-with the chain quantity `I_L`.  Horizontal canonical form, positivity, and the
-fixed-point equations supply nonzero trace at every positive length; simplicity
+with the chain quantity `I_L`.  Normalized BNT-refined horizontal form,
+positivity, and the fixed-point equations supply nonzero trace at every positive
+length; this horizontal hypothesis is stronger than literal CPSV canonical form,
+and simplicity
 is not used in this implication.
 
 Source: arXiv:1606.00608, Appendix C, lines 1333--1341.  See
@@ -379,8 +382,11 @@ private theorem mutualInformation_bipartition_eq_of_isRFPViaTS_of_right_eq
   exact mutualInformation_bipartition_eq_of_isRFPViaTS
     M hRFP N a b hIn hOut hM htr
 
-/-- A horizontally canonical matrix product density operator satisfying the
-local renormalization fixed-point equations saturates the area law.
+/-- A matrix product density operator in normalized BNT-refined horizontal
+form satisfying the local renormalization fixed-point equations saturates the
+area law.
+
+This horizontal hypothesis is stronger than literal CPSV canonical form.
 
 The two local channels transfer one site across a consecutive bipartition.
 Data processing in both directions gives equality of the bipartite mutual
@@ -440,9 +446,11 @@ theorem isSAL_of_isRFPViaTS (M : MPOTensor d D)
       (mutualInfoChain_eq_mutualInformation M N₀ (a + 2)
         (hHalf.trans_le (Nat.div_le_self N₀ 2)) (hM N₀ hNpos)).symm
 
-/-- A horizontally canonical matrix product density operator satisfying the
-local renormalization fixed-point equations has zero correlation length and
-saturates the area law.
+/-- A matrix product density operator in normalized BNT-refined horizontal
+form satisfying the local renormalization fixed-point equations has zero
+correlation length and saturates the area law.
+
+This horizontal hypothesis is stronger than literal CPSV canonical form.
 
 This is Proposition `propsimple` of arXiv:1606.00608.  The nonzero
 physical-trace transfer required by source ZCL is derived from the nonzero

--- a/TNLean/MPS/MPDO/RFPViaTSSAL.lean
+++ b/TNLean/MPS/MPDO/RFPViaTSSAL.lean
@@ -386,7 +386,9 @@ private theorem mutualInformation_bipartition_eq_of_isRFPViaTS_of_right_eq
 form satisfying the local renormalization fixed-point equations saturates the
 area law.
 
-This horizontal hypothesis is stronger than literal CPSV canonical form.
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 The two local channels transfer one site across a consecutive bipartition.
 Data processing in both directions gives equality of the bipartite mutual
@@ -450,10 +452,13 @@ theorem isSAL_of_isRFPViaTS (M : MPOTensor d D)
 form satisfying the local renormalization fixed-point equations has zero
 correlation length and saturates the area law.
 
-This horizontal hypothesis is stronger than literal CPSV canonical form.
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
-This is Proposition `propsimple` of arXiv:1606.00608.  The nonzero
-physical-trace transfer required by source ZCL is derived from the nonzero
+Under this normalized BNT-refined horizontal hypothesis, the theorem specializes
+Proposition `propsimple` of arXiv:1606.00608. The nonzero physical-trace transfer
+required by source ZCL is derived from the nonzero
 one-site ring; it is not an additional hypothesis.
 
 Source: arXiv:1606.00608, Proposition `propsimple`, Appendix C,

--- a/TNLean/MPS/MPDO/RetainedClass.lean
+++ b/TNLean/MPS/MPDO/RetainedClass.lean
@@ -8,19 +8,21 @@ import TNLean.MPS.MPDO.VerticalBNT
 /-!
 # Nonemptiness of the retained vertical phase classes
 
-This file proves that the vertical decomposition of a horizontally canonical
-matrix product density operator contains a nonzero sector.  The literal
-reconstruction of the vertical tensor then shows that the finite partition of
-the retained sectors into matrix-product-vector phase classes is nonempty.
+This file proves that the vertical decomposition of a matrix product density
+operator in normalized BNT-refined horizontal form contains a nonzero sector.
+This horizontal hypothesis is stronger than literal CPSV canonical form.  The
+literal reconstruction of the vertical tensor then shows that the finite
+partition of the retained sectors into matrix-product-vector phase classes is
+nonempty.
 
 This is the nonemptiness observation used in arXiv:1606.00608, Proposition
 `prop:vertical`, lines 1895--1902.
 
 ## Main result
 
-* `IsHorizontalCF.exists_nonempty_verticalBNTGrouping`: a horizontally
-  canonical matrix product density operator has a retained vertical
-  decomposition whose phase-class family is nonempty.
+* `IsHorizontalCF.exists_nonempty_verticalBNTGrouping`: a matrix product
+  density operator in normalized BNT-refined horizontal form has a retained
+  vertical decomposition whose phase-class family is nonempty.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -74,7 +76,10 @@ private theorem bntCanonicalForm_toTensor_ne_zero
       Matrix.reindex_apply, Matrix.blockDiagonal'_apply_eq] using hentry.symm
   exact (mul_eq_zero.mp this).resolve_left hweight
 
-/-- The vertical tensor of a horizontally canonical MPO tensor is nonzero.
+/-- The vertical tensor of an MPO tensor in normalized BNT-refined horizontal
+form is nonzero.
+
+This horizontal hypothesis is stronger than literal CPSV canonical form.
 
 Source: arXiv:1606.00608, canonical form at lines 237--246 and Proposition
 `prop:vertical`, lines 1895--1902. -/
@@ -108,10 +113,11 @@ theorem IsHorizontalCF.verticalTensor_ne_zero
         (G : Matrix (Fin S.totalDim) (Fin S.totalDim) ℂ)) hi
   simpa [Matrix.mul_assoc] using hcancel
 
-/-- A horizontally canonical matrix product density operator has a nonempty
-family of retained vertical phase classes.
+/-- A matrix product density operator in normalized BNT-refined horizontal form
+has a nonempty family of retained vertical phase classes.
 
-The retained normal sectors reconstruct every vertical letter.  Since the
+This horizontal hypothesis is stronger than literal CPSV canonical form.  The
+retained normal sectors reconstruct every vertical letter.  Since the
 vertical tensor is nonzero, the sector index set is nonempty.  Its partition
 into matrix-product-vector phase classes is therefore nonempty as well.
 

--- a/TNLean/MPS/MPDO/RetainedClass.lean
+++ b/TNLean/MPS/MPDO/RetainedClass.lean
@@ -79,7 +79,9 @@ private theorem bntCanonicalForm_toTensor_ne_zero
 /-- The vertical tensor of an MPO tensor in normalized BNT-refined horizontal
 form is nonzero.
 
-This horizontal hypothesis is stronger than literal CPSV canonical form.
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, canonical form at lines 237--246 and Proposition
 `prop:vertical`, lines 1895--1902. -/
@@ -116,8 +118,11 @@ theorem IsHorizontalCF.verticalTensor_ne_zero
 /-- A matrix product density operator in normalized BNT-refined horizontal form
 has a nonempty family of retained vertical phase classes.
 
-This horizontal hypothesis is stronger than literal CPSV canonical form.  The
-retained normal sectors reconstruct every vertical letter.  Since the
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
+The retained normal sectors reconstruct every vertical letter.  Since the
 vertical tensor is nonzero, the sector index set is nonempty.  Its partition
 into matrix-product-vector phase classes is therefore nonempty as well.
 

--- a/TNLean/MPS/MPDO/SectorTrace.lean
+++ b/TNLean/MPS/MPDO/SectorTrace.lean
@@ -81,11 +81,10 @@ each sector $(\alpha,k)$, the orthogonal projector $P_{\alpha,k}$ and its
 `SectorProjectorData`.  The representative loop is defined entrywise by
 $(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$.  It is independent of
 $k$ because cyclicity of trace removes the internal similarity
-$X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  The formal decomposition uses
+$X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  The decomposition assumes
 normalized BNT-refined horizontal form to find a nonzero sector compression,
-and hence deduces the positivity of every grouped coefficient.  The remaining
-argument of Proposition 4.13 begins with the reflected marked-chain comparison at line
-1909.
+and hence deduces the positivity of every grouped coefficient.  Proposition
+4.13 then applies the reflected marked-chain comparison at line 1909.
 
 ## References
 

--- a/TNLean/MPS/MPDO/SectorTrace.lean
+++ b/TNLean/MPS/MPDO/SectorTrace.lean
@@ -81,10 +81,10 @@ each sector $(\alpha,k)$, the orthogonal projector $P_{\alpha,k}$ and its
 `SectorProjectorData`.  The representative loop is defined entrywise by
 $(E_\alpha)_{ab}=\operatorname{tr}(M_\alpha^{(a,b)})$.  It is independent of
 $k$ because cyclicity of trace removes the internal similarity
-$X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  The same decomposition uses
-the horizontal canonical form to find a nonzero sector compression, and hence
-deduces the positivity of every grouped coefficient.  The remaining argument
-of Proposition 4.13 begins with the reflected marked-chain comparison at line
+$X_{\alpha,k}M_\alpha^{(a,b)}X_{\alpha,k}^{-1}$.  The formal decomposition uses
+normalized BNT-refined horizontal form to find a nonzero sector compression,
+and hence deduces the positivity of every grouped coefficient.  The remaining
+argument of Proposition 4.13 begins with the reflected marked-chain comparison at line
 1909.
 
 ## References

--- a/TNLean/MPS/MPDO/StackedLayers.lean
+++ b/TNLean/MPS/MPDO/StackedLayers.lean
@@ -399,8 +399,7 @@ derived from the stacked-layers identity rather than assumed.
 theorem retains the stronger all-length projector hypothesis.  Under normalized
 BNT-refined horizontal form, `hasNoPeriodicVectors_verticalTensor_of_horizontalCF`
 uses the same invariant projector at one noncommuting length.  This horizontal
-hypothesis is stronger than literal CPSV canonical form.  Recorded in
-`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+hypothesis is stronger than literal CPSV canonical form. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_cyclicProjector
     (M : MPOTensor d D) (hM : IsMPDO M)
     (hCyc : PeriodicVectorYieldsCyclicProjector M) :

--- a/TNLean/MPS/MPDO/StackedLayers.lean
+++ b/TNLean/MPS/MPDO/StackedLayers.lean
@@ -356,9 +356,10 @@ normalized BNT-refined horizontal form, the direct theorem
 `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` avoids this stronger
 all-length hypothesis by using one noncommuting length.
 
-**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
-`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
+**Scope restriction (conditional cyclic-projector interface):** This predicate
+requires the supplied projector to fail to commute with the density operator at
+every length. The direct BNT-refined theorem needs only one noncommuting length;
+see `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 def PeriodicVectorYieldsCyclicProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
     (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),

--- a/TNLean/MPS/MPDO/StackedLayers.lean
+++ b/TNLean/MPS/MPDO/StackedLayers.lean
@@ -354,9 +354,11 @@ non-commutation hypothesis `NoninvariantProjectorNoncommuting` through
 `periodicVectorYieldsCyclicProjector_of_noncommutation`.  For a tensor in
 normalized BNT-refined horizontal form, the direct theorem
 `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` avoids this stronger
-all-length hypothesis by using one noncommuting length.  This hypothesis is
-stronger than literal CPSV canonical form; the distinction is
-recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
+all-length hypothesis by using one noncommuting length.
+
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 def PeriodicVectorYieldsCyclicProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
     (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),
@@ -395,11 +397,11 @@ projectors.  This is the periodic-sector step in the proof of Proposition
 4.13 of arXiv:1606.00608, lines 1888--1893, with the commutation family
 derived from the stacked-layers identity rather than assumed.
 
-**Scope restriction (conditional on the supplied cyclic projector):** this
-theorem retains the stronger all-length projector hypothesis.  Under normalized
+**Scope restriction (conditional on the supplied cyclic projector):** This
+theorem retains the stronger all-length projector hypothesis. Under normalized
 BNT-refined horizontal form, `hasNoPeriodicVectors_verticalTensor_of_horizontalCF`
-uses the same invariant projector at one noncommuting length.  This horizontal
-hypothesis is stronger than literal CPSV canonical form. -/
+uses the same invariant projector at one noncommuting length; see
+`docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_cyclicProjector
     (M : MPOTensor d D) (hM : IsMPDO M)
     (hCyc : PeriodicVectorYieldsCyclicProjector M) :

--- a/TNLean/MPS/MPDO/StackedLayers.lean
+++ b/TNLean/MPS/MPDO/StackedLayers.lean
@@ -352,9 +352,10 @@ constructed unconditionally in
 (`TNLean/MPS/MPDO/CyclicProjector.lean`); this hypothesis follows from the
 non-commutation hypothesis `NoninvariantProjectorNoncommuting` through
 `periodicVectorYieldsCyclicProjector_of_noncommutation`.  For a tensor in
-literal horizontal canonical form, the direct theorem
+normalized BNT-refined horizontal form, the direct theorem
 `hasNoPeriodicVectors_verticalTensor_of_horizontalCF` avoids this stronger
-all-length hypothesis by using one noncommuting length.  The distinction is
+all-length hypothesis by using one noncommuting length.  This hypothesis is
+stronger than literal CPSV canonical form; the distinction is
 recorded in `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 def PeriodicVectorYieldsCyclicProjector (M : MPOTensor d D) : Prop :=
   ∀ ⦃n : ℕ⦄ (V : Matrix (Fin d) (Fin n) ℂ) (B : MPSTensor (D * D) n)
@@ -395,10 +396,10 @@ projectors.  This is the periodic-sector step in the proof of Proposition
 derived from the stacked-layers identity rather than assumed.
 
 **Scope restriction (conditional on the supplied cyclic projector):** this
-theorem retains the stronger all-length projector hypothesis.  For a
-tensor in literal horizontal canonical form, that hypothesis is unnecessary:
-`hasNoPeriodicVectors_verticalTensor_of_horizontalCF` uses the same invariant
-projector at one noncommuting length.  Recorded in
+theorem retains the stronger all-length projector hypothesis.  Under normalized
+BNT-refined horizontal form, `hasNoPeriodicVectors_verticalTensor_of_horizontalCF`
+uses the same invariant projector at one noncommuting length.  This horizontal
+hypothesis is stronger than literal CPSV canonical form.  Recorded in
 `docs/paper-gaps/cpgsv17_periodic_sector_projector.tex`. -/
 theorem hasNoPeriodicVectors_verticalTensor_of_cyclicProjector
     (M : MPOTensor d D) (hM : IsMPDO M)

--- a/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
+++ b/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
@@ -30,6 +30,11 @@ coordinates.  The two global direct-sum factors commute because the multiplicity
 scalar identity in every configuration.  Applying the adjoint vertical map reconstructs the
 original density exactly.
 
+The source-facing RFP wrappers obtain their fusion clause only from normalized
+BNT-refined horizontal form.  They do not establish the corresponding
+construction from the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
@@ -663,11 +668,16 @@ namespace MPOTensor
 
 /-- **Line-999 density decomposition for an RFP MPDO.**
 
-A horizontal-canonical MPDO satisfying the source renormalization fixed-point condition
-admits one BNT fusion clause whose same multiplicities, positive weights, rectangular vertical
+An MPDO in normalized BNT-refined horizontal form satisfying the source
+renormalization fixed-point condition admits one BNT fusion clause whose same
+multiplicities, positive weights, rectangular vertical
 coisometry, fusion histories, and terminal operators give the all-initial-label density
 decomposition at every positive chain length.  No caller-supplied compatibility hypothesis is
 required.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used by Proposition 4.13 and
+Theorem 4.14; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Theorem 4.14 and the density identity at line 999.  This theorem
 stops before the commutator at line 1001 and makes no spectral or Gibbs-state assertion.
@@ -685,11 +695,16 @@ theorem exists_topologicalDensityDecomposition_of_isRFPViaTS
 
 /-- **All-label density-factor commutator for an RFP MPDO.**
 
-A horizontal-canonical MPDO satisfying the source renormalization fixed-point condition
-admits one BNT fusion clause that gives both the exact all-label density decomposition and
+An MPDO in normalized BNT-refined horizontal form satisfying the source
+renormalization fixed-point condition admits one BNT fusion clause that gives
+both the exact all-label density decomposition and
 the commutator between its multiplicity-weight and reconstructed recursive factors at every
 positive chain length.  No caller-supplied fusion clause or compatibility hypothesis is
 required.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used by Proposition 4.13 and
+Theorem 4.14; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, density decomposition and commutator at lines 999--1002.
 This theorem makes no length-independence, terminal spectral, projector, or Gibbs-state

--- a/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
+++ b/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
@@ -30,8 +30,8 @@ coordinates.  The two global direct-sum factors commute because the multiplicity
 scalar identity in every configuration.  Applying the adjoint vertical map reconstructs the
 original density exactly.
 
-The source-facing RFP wrappers obtain their fusion clause only from normalized
-BNT-refined horizontal form.  They do not establish the corresponding
+The RFP-derived theorems obtain their fusion clause only from normalized
+BNT-refined horizontal form. They do not establish the corresponding
 construction from the literal CPSV canonical form; see
 `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 

--- a/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
+++ b/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
@@ -773,10 +773,9 @@ constructed internally.  The conclusion includes the preceding all-label
 density decomposition, factor commutator, terminal spectral refinement, and
 the retained commuting nearest-neighbor Gibbs formula.
 
-**Scope restriction (BNT-refined horizontal form):** This theorem assumes
-normalized BNT-refined horizontal form (`IsHorizontalCF`), which is stronger
-than the literal CPSV canonical form. The additional grouping hypothesis is detailed
-in `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, lines 999--1016.
 

--- a/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
+++ b/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
@@ -773,6 +773,11 @@ constructed internally.  The conclusion includes the preceding all-label
 density decomposition, factor commutator, terminal spectral refinement, and
 the retained commuting nearest-neighbor Gibbs formula.
 
+**Scope restriction (BNT-refined horizontal form):** The RFP-derived clause is
+available here only under normalized BNT-refined horizontal form
+(`IsHorizontalCF`), which is stronger than the literal CPSV canonical form. See
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 Source: arXiv:1606.00608, lines 999--1016.
 
 **Scope restriction (retained vertical coordinates):** The Gibbs

--- a/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
+++ b/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
@@ -775,7 +775,8 @@ the retained commuting nearest-neighbor Gibbs formula.
 
 **Scope restriction (BNT-refined horizontal form):** This theorem assumes
 normalized BNT-refined horizontal form (`IsHorizontalCF`), which is stronger
-than the literal CPSV canonical form.
+than the literal CPSV canonical form. The additional grouping hypothesis is detailed
+in `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, lines 999--1016.
 

--- a/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
+++ b/TNLean/MPS/MPDO/TopologicalGibbsHamiltonian.lean
@@ -773,10 +773,9 @@ constructed internally.  The conclusion includes the preceding all-label
 density decomposition, factor commutator, terminal spectral refinement, and
 the retained commuting nearest-neighbor Gibbs formula.
 
-**Scope restriction (BNT-refined horizontal form):** The RFP-derived clause is
-available here only under normalized BNT-refined horizontal form
-(`IsHorizontalCF`), which is stronger than the literal CPSV canonical form. See
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+**Scope restriction (BNT-refined horizontal form):** This theorem assumes
+normalized BNT-refined horizontal form (`IsHorizontalCF`), which is stronger
+than the literal CPSV canonical form.
 
 Source: arXiv:1606.00608, lines 999--1016.
 

--- a/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
@@ -657,6 +657,11 @@ constructed internally. For every chain of length `N + 2`, the local
 translates commute, the projectors are pairwise orthogonal and commute with
 the Gibbs factor, and their weighted Gibbs sum is the physical MPDO.
 
+**Scope restriction (BNT-refined horizontal form):** The RFP-derived clause is
+available here only under normalized BNT-refined horizontal form
+(`IsHorizontalCF`), which is stronger than the literal CPSV canonical form. See
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 Source: CPSV16, lines 1013–1016, with the local two-site convention of
 Definition 4.8, lines 831–847.
 

--- a/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
@@ -657,10 +657,9 @@ constructed internally. For every chain of length `N + 2`, the local
 translates commute, the projectors are pairwise orthogonal and commute with
 the Gibbs factor, and their weighted Gibbs sum is the physical MPDO.
 
-**Scope restriction (BNT-refined horizontal form):** This theorem assumes
-normalized BNT-refined horizontal form (`IsHorizontalCF`), which is stronger
-than the literal CPSV canonical form. The additional grouping hypothesis is detailed
-in `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: CPSV16, lines 1013–1016, with the local two-site convention of
 Definition 4.8, lines 831–847.

--- a/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
@@ -657,10 +657,9 @@ constructed internally. For every chain of length `N + 2`, the local
 translates commute, the projectors are pairwise orthogonal and commute with
 the Gibbs factor, and their weighted Gibbs sum is the physical MPDO.
 
-**Scope restriction (BNT-refined horizontal form):** The RFP-derived clause is
-available here only under normalized BNT-refined horizontal form
-(`IsHorizontalCF`), which is stronger than the literal CPSV canonical form. See
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+**Scope restriction (BNT-refined horizontal form):** This theorem assumes
+normalized BNT-refined horizontal form (`IsHorizontalCF`), which is stronger
+than the literal CPSV canonical form.
 
 Source: CPSV16, lines 1013–1016, with the local two-site convention of
 Definition 4.8, lines 831–847.

--- a/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean
@@ -659,7 +659,8 @@ the Gibbs factor, and their weighted Gibbs sum is the physical MPDO.
 
 **Scope restriction (BNT-refined horizontal form):** This theorem assumes
 normalized BNT-refined horizontal form (`IsHorizontalCF`), which is stronger
-than the literal CPSV canonical form.
+than the literal CPSV canonical form. The additional grouping hypothesis is detailed
+in `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: CPSV16, lines 1013–1016, with the local two-site convention of
 Definition 4.8, lines 831–847.

--- a/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
+++ b/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
@@ -25,9 +25,9 @@ by the one-site positivity theorem for the original MPDO.
 * `MPOTensor.BNTFusionTensorClause.hasTerminalSpectralProjectorRefinement`:
   a length-independent fusion clause has the all-label spectral refinement.
 * `MPOTensor.terminalSpectralProjectorRefinement_of_isRFPViaTS`: under
-  normalized BNT-refined horizontal form, the source-facing theorem makes all
-  spectral choices internally.  The literal canonical-form implication remains
-  open.
+  normalized BNT-refined horizontal form, the theorem makes all spectral
+  choices internally.  This hypothesis is stronger than literal CPSV
+  canonical form.
 
 ## References
 

--- a/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
+++ b/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
@@ -24,8 +24,10 @@ by the one-site positivity theorem for the original MPDO.
 
 * `MPOTensor.BNTFusionTensorClause.hasTerminalSpectralProjectorRefinement`:
   a length-independent fusion clause has the all-label spectral refinement.
-* `MPOTensor.terminalSpectralProjectorRefinement_of_isRFPViaTS`: the
-  source-facing theorem makes all spectral choices internally.
+* `MPOTensor.terminalSpectralProjectorRefinement_of_isRFPViaTS`: under
+  normalized BNT-refined horizontal form, the source-facing theorem makes all
+  spectral choices internally.  The literal canonical-form implication remains
+  open.
 
 ## References
 
@@ -599,8 +601,12 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- The BNT fusion clause selected from the source renormalization fixed-point
-construction.
+/-- The BNT fusion clause selected from the renormalization fixed-point
+construction under normalized BNT-refined horizontal form.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Theorem 4.14(i),(iii), lines 972--993. -/
 noncomputable def rfpBNTFusionTensorClause (M : MPOTensor d D)
@@ -612,7 +618,7 @@ noncomputable def rfpBNTFusionTensorClause (M : MPOTensor d D)
 /-- **Terminal spectral projector refinement for a length-independent RFP
 MPDO.**
 
-The fusion clause is fixed by
+The fusion clause is fixed under normalized BNT-refined horizontal form by
 `rfpBNTFusionTensorClause M hHorizontal hM hRFP`; no additional fusion clause,
 spectral family, or projector hypothesis is assumed.  Length independence is
 stated on the coefficient family of exactly that RFP-derived clause.  This is
@@ -622,6 +628,10 @@ assumption.
 The conclusion supplies the line-999 density decomposition, the line-1001
 factor commutator, and the nonnegative terminal eigenweights with compatible
 all-label orthogonal projectors and their weighted reconstruction.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used by Proposition 4.13 and
+Theorem 4.14; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, lines 999--1012.  This theorem does not assert the
 commuting nearest-neighbor Hamiltonian or Gibbs-state conclusion beginning at

--- a/TNLean/MPS/MPDO/VerticalBNT.lean
+++ b/TNLean/MPS/MPDO/VerticalBNT.lean
@@ -28,6 +28,11 @@ and deduces that the grouped coefficient is positive.  The positive-diagonal
 isometry asserted at lines 1895--1896 and the gauge normalization and final
 coisometry argument at lines 1903--1921 are not included.
 
+The formal grouping starts from normalized BNT-refined horizontal form, which
+is stronger than the literal CPSV canonical form.  The missing active-refinement
+and coisometry transport are recorded in
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 ## Main statement
 
 * `IsHorizontalCF.exists_verticalBNTGrouping_with_isometry`: the normalized
@@ -46,15 +51,19 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- A nonzero vertical corner of a horizontally canonical tensor has a
-nonzero first-site sector compression at some chain length.
+/-- A nonzero vertical corner of a tensor in normalized BNT-refined horizontal
+form has a nonzero first-site sector compression at some chain length.
 
 If every compression by `P` vanished, their matrix entries would say that the
 two-sided first-site insertion by `P` has the same matrix product vectors as
-zero.  Lemma L for the horizontal canonical form would then make the inserted
+zero.  Lemma L for the BNT-refined horizontal form would then make the inserted
 tensor itself zero, forcing every corner $P\widetilde M_vP$ to vanish.  This is
 the separation assertion used in the proof of Proposition 4.13 of
-arXiv:1606.00608, line 1898. -/
+arXiv:1606.00608, line 1898.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 theorem IsHorizontalCF.exists_sectorCompression_ne_zero_of_corner
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M)
     (P : Matrix (Fin d) (Fin d) ℂ)
@@ -136,8 +145,9 @@ theorem exists_rangeProjection_corner_ne_zero
       hV, Matrix.mul_one]] at hcancel
   simpa using hcancel
 
-/-- Group the normalized vertical corners of a horizontally canonical MPDO by
-their gauge-phase classes while retaining the physical reducing isometries.
+/-- Group the normalized vertical corners of an MPDO in normalized BNT-refined
+horizontal form by their gauge-phase classes while retaining the physical
+reducing isometries.
 
 For each class `j` and copy `q`, the original normalized corner is
 
@@ -156,7 +166,11 @@ arXiv:1606.00608, lines 1898--1902, using the BNT characterization at lines
 1135--1148 and the preceding isometry-preserving vertical sector theorem.  The
 positive-diagonal isometry asserted at lines 1895--1896 and the subsequent
 gauge normalization and coisometry argument at lines 1903--1921 are not
-included. -/
+included.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
 theorem IsHorizontalCF.exists_verticalBNTGrouping_with_isometry
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
     ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)

--- a/TNLean/MPS/MPDO/VerticalBNT.lean
+++ b/TNLean/MPS/MPDO/VerticalBNT.lean
@@ -28,10 +28,8 @@ and deduces that the grouped coefficient is positive.  The positive-diagonal
 isometry asserted at lines 1895--1896 and the gauge normalization and final
 coisometry argument at lines 1903--1921 are not included.
 
-The formal grouping starts from normalized BNT-refined horizontal form, which
-is stronger than the literal CPSV canonical form.  The missing active-refinement
-and coisometry transport are recorded in
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+The grouping assumes normalized BNT-refined horizontal form, which is stronger
+than the literal CPSV canonical form.
 
 ## Main statement
 

--- a/TNLean/MPS/MPDO/VerticalSpectral.lean
+++ b/TNLean/MPS/MPDO/VerticalSpectral.lean
@@ -36,8 +36,12 @@ isometries retained.
 Let `M` generate matrix product density operators and be in normalized
 BNT-refined horizontal form.  The nonzero irreducible reducing corners of its
 vertically viewed tensor can be written as positive scalar multiples of normal
-tensors.  This horizontal hypothesis is stronger than literal CPSV canonical
-form.
+tensors.
+
+**Scope restriction (BNT-refined horizontal form):** The horizontal hypothesis
+`IsHorizontalCF` is stronger than the literal CPSV canonical form; see
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
 Their physical isometries remain pairwise orthogonal, both intertwining
 identities and the exact compression formula are preserved, and the retained
 corners reconstruct every vertical letter literally.

--- a/TNLean/MPS/MPDO/VerticalSpectral.lean
+++ b/TNLean/MPS/MPDO/VerticalSpectral.lean
@@ -16,11 +16,12 @@ corner to spectral radius one.
 
 The construction is the isometry-preserving form of the canonical-form steps
 in arXiv:1606.00608, lines 214--225, applied after the invariant-projection and
-periodic-sector arguments of Proposition 4.13, lines 1873--1893.  It gives a
-literal reconstruction of every vertical letter on the retained support.  It
-does not yet group gauge-equivalent normal tensors into a basis of normal
-tensors or prove positivity of the grouped multiplicity weights at lines
-1895--1921.
+periodic-sector arguments of Proposition 4.13, lines 1873--1893.  It assumes
+normalized BNT-refined horizontal form, which is stronger than literal CPSV
+canonical form.  It gives a literal reconstruction of every vertical letter
+on the retained support.  It does not yet group gauge-equivalent normal tensors
+into a basis of normal tensors or prove positivity of the grouped multiplicity
+weights at lines 1895--1921.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -32,9 +33,11 @@ variable {d D : ℕ}
 /-- Spectrally normalized nonzero vertical corners, with their physical
 isometries retained.
 
-Let `M` be a horizontally canonical MPO tensor generating matrix product
-density operators.  The nonzero irreducible reducing corners of its vertically
-viewed tensor can be written as positive scalar multiples of normal tensors.
+Let `M` generate matrix product density operators and be in normalized
+BNT-refined horizontal form.  The nonzero irreducible reducing corners of its
+vertically viewed tensor can be written as positive scalar multiples of normal
+tensors.  This horizontal hypothesis is stronger than literal CPSV canonical
+form.
 Their physical isometries remain pairwise orthogonal, both intertwining
 identities and the exact compression formula are preserved, and the retained
 corners reconstruct every vertical letter literally.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
@@ -35,11 +35,11 @@
     $Q_1H^{(N)}=H^{(N)}Q_1$ at every positive length.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    Definition~\ref{def:horizontal_cf_mpdo} is stronger than the literal CPSV
-    canonical form. The corresponding first-site reduction on the literal
-    canonical-form surface remains part of the active-refinement and
-    coisometry-transport gap recorded in
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % The literal first-site reduction remains part of the active-refinement
+    % and coisometry-transport gap recorded in
+    % docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 
     This is the representative-indexed conclusion of the invariant-projection
     step in

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_first_site_contractions.tex
@@ -15,7 +15,8 @@
         thm:representative_grouped_insert_eq,
         thm:postblocked_representative_grouped_insert_eq,
         thm:mpdo_first_site_invariant_comm}
-    Let $M$ be in horizontal canonical form. For doubled-index matrices
+    Let $M$ be in normalized BNT-refined horizontal form. For doubled-index
+    matrices
     $Y,Z$, suppose that
     $Y_1V^{(N)}(M)=Z_1V^{(N)}(M)$ for every $N\geq1$.
     Then the corresponding inserted tensors agree on the original bond
@@ -32,6 +33,13 @@
     The specialized assertion follows from the two entrywise identities
     $Q_1H^{(N)}=Q_1H^{(N)}Q_1$ and
     $Q_1H^{(N)}=H^{(N)}Q_1$ at every positive length.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    Definition~\ref{def:horizontal_cf_mpdo} is stronger than the literal CPSV
+    canonical form. The corresponding first-site reduction on the literal
+    canonical-form surface remains part of the active-refinement and
+    coisometry-transport gap recorded in
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 
     This is the representative-indexed conclusion of the invariant-projection
     step in

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
@@ -322,7 +322,7 @@
     projections.
 \end{proof}
 
-\begin{theorem}[Horizontal canonical form excludes vertical periodic sectors]
+\begin{theorem}[BNT-refined horizontal form excludes vertical periodic sectors]
     \label{thm:mpdo_vertical_no_periodic_vectors_horizontal_cf}
     \lean{MPOTensor.IsHorizontalCF.exists_not_commute_of_displaced}
     \lean{MPOTensor.hasNoPeriodicVectors_verticalTensor_of_horizontalCF}
@@ -333,11 +333,18 @@
         thm:mpdo_displaced_invariant_projector,
         thm:mpo_stacked_layers_power, thm:mpdo_first_site_invariant_comm,
         thm:psd_commute_of_commute_pow}
-    Let $M$ be in horizontal canonical form. If an idempotent $Q$ satisfies
+    Let $M$ be in normalized BNT-refined horizontal form. If an idempotent
+    $Q$ satisfies
     $Q\widetilde M\ne Q\widetilde MQ$, then for some $N\ge 0$,
     $Q_1H^{(N+1)}\ne H^{(N+1)}Q_1$.
     Consequently, if $M$ generates matrix product density operators, then
     $\widetilde M$ has no nontrivial periodic vectors.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the proved theorem uses the stronger normalized BNT-refined predicate, not
+    the literal CPSV canonical form. The literal periodic-sector conclusion
+    remains blocked by the active-refinement and coisometry-transport step; see
+    \path{docs/paper-gaps/cpgsv17_periodic_sector_projector.tex}.
 \end{theorem}
 
 \begin{proof}
@@ -383,7 +390,8 @@
     canonical form in the horizontal direction, and the argument of
     lines~1874--1887 turns all-length commutation of $Q_1$ with $H^{(N)}$
     into the letter-level invariance $Q\widetilde M=Q\widetilde MQ$. The
-    literal transport through a horizontal canonical form is proved. This
+    transport through normalized BNT-refined horizontal form is proved. The
+    corresponding literal canonical-form transport remains open. This
     all-length condition is a stronger auxiliary assumption than is needed
     for Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors_horizontal_cf},
     which uses the single noncommuting length supplied by the contrapositive
@@ -468,5 +476,5 @@
     invariance that the displacement forbids.
 
     Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors_horizontal_cf}
-    gives the corresponding result for a general horizontal canonical form.
+    gives the corresponding result for normalized BNT-refined horizontal form.
 \end{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
@@ -343,7 +343,8 @@
     \textbf{Scope restriction (BNT-refined horizontal form):}
     the theorem assumes normalized BNT-refined horizontal form, which is
     stronger than the literal CPSV canonical form. The literal periodic-sector
-    conclusion remains blocked by the active-refinement and coisometry-transport step; see
+    conclusion remains blocked by the active-refinement and
+    coisometry-transport step; see
     \path{docs/paper-gaps/cpgsv17_periodic_sector_projector.tex}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
@@ -341,11 +341,11 @@
     $\widetilde M$ has no nontrivial periodic vectors.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the theorem assumes normalized BNT-refined horizontal form, which is
-    stronger than the literal CPSV canonical form. The literal periodic-sector
-    conclusion remains blocked by the active-refinement and
-    coisometry-transport step; see
-    \path{docs/paper-gaps/cpgsv17_periodic_sector_projector.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % The literal periodic-sector conclusion remains part of the
+    % active-refinement and coisometry-transport gap recorded in
+    % docs/paper-gaps/cpgsv17_periodic_sector_projector.tex.
 \end{theorem}
 
 \begin{proof}
@@ -390,10 +390,10 @@
     \cite[Proposition~4.13]{Cirac2016MPDO_arXiv} assumes the tensor is in
     canonical form in the horizontal direction, and the argument of
     lines~1874--1887 turns all-length commutation of $Q_1$ with $H^{(N)}$
-    into the letter-level invariance $Q\widetilde M=Q\widetilde MQ$. The
-    transport through normalized BNT-refined horizontal form is proved. The
-    corresponding literal canonical-form transport remains open. This
+    into the letter-level invariance $Q\widetilde M=Q\widetilde MQ$. This
+    argument uses the normalized BNT-refined horizontal hypothesis. The
     all-length condition is a stronger auxiliary assumption than is needed
+    % The corresponding literal canonical-form transport remains open.
     for Theorem~\ref{thm:mpdo_vertical_no_periodic_vectors_horizontal_cf},
     which uses the single noncommuting length supplied by the contrapositive
     of Lemma~L.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_periodic_sectors.tex
@@ -341,9 +341,9 @@
     $\widetilde M$ has no nontrivial periodic vectors.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the proved theorem uses the stronger normalized BNT-refined predicate, not
-    the literal CPSV canonical form. The literal periodic-sector conclusion
-    remains blocked by the active-refinement and coisometry-transport step; see
+    the theorem assumes normalized BNT-refined horizontal form, which is
+    stronger than the literal CPSV canonical form. The literal periodic-sector
+    conclusion remains blocked by the active-refinement and coisometry-transport step; see
     \path{docs/paper-gaps/cpgsv17_periodic_sector_projector.tex}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -188,11 +188,11 @@
     \cite[Proposition~4.13, line 1898]{Cirac2016MPDO_arXiv}.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    this separation theorem assumes normalized BNT-refined horizontal form,
-    which is stronger than the literal CPSV canonical form. The literal
-    canonical-form version remains part of the missing Lemma-L and
-    active-refinement step recorded in
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % The literal canonical-form version remains part of the missing Lemma-L
+    % and active-refinement step recorded in
+    % docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -390,9 +390,9 @@
     \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the marked-tensor separation used here is proved only for normalized
-    BNT-refined horizontal form; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{theorem}
 
 \begin{proof}
@@ -601,10 +601,10 @@
     \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv}.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    this normalization theorem assumes normalized BNT-refined horizontal form,
-    which is stronger than the literal CPSV canonical form and does not close
-    the literal canonical-form refinement gap; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % The literal canonical-form refinement gap is recorded in
+    % docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -473,8 +473,8 @@
     \end{align}
     Hence any two gauges satisfying this conditional identity with the same
     target have equal Gram conjugations, and the ratio of their Gram matrices
-    commutes with $B$. This is a useful algebraic route from an abstract common
-    target to the relative identity in
+    commutes with $B$. This gives the relative identity from an abstract common
+    target in
     \cite[Proposition~4.13, lines 1909--1919]{Cirac2016MPDO_arXiv}.
     The reflected marked-chain argument in the source does not identify the
     target separately for either sector.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -174,23 +174,31 @@
     \uses{def:horizontal_cf_mpdo, def:mpdo_vertical_loops,
         def:vertical_tensor_mpdo, thm:representative_one_sub_mp_zero,
         thm:cpsv_normal_mpv_phase_gauge}
-    Let $M$ be horizontally canonical and let $P$ be a matrix for which
+    Let $M$ be in normalized BNT-refined horizontal form and let $P$ be a
+    matrix for which
     $P\widetilde M_vP$ is nonzero for some vertical letter $v$. Then the
     first-site compression $P_1H^{(N+1)}P_1$ is nonzero for some $N$.
-    Under the same horizontal canonical-form hypothesis, suppose in addition
+    Under the same normalized BNT-refined horizontal-form hypothesis, suppose
+    in addition
     that $A$ is a normal tensor, $V$ is an isometry, and the compression by
     $V$ is a nonzero scalar multiple of an invertible conjugate of $A$. Then
     the range projector $VV^\dagger$ has a nonzero vertical corner and hence a
     nonzero first-site compression.
     This is the separation step used in
     \cite[Proposition~4.13, line 1898]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the formal separation invokes the stronger normalized BNT-refined
+    predicate. The literal canonical-form version remains part of the missing
+    Lemma-L and active-refinement step recorded in
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{theorem}
 
 \begin{proof}\leanok
     If every compression vanished, its matrix entries would say that the
     first-site insertion by $P$ has the same matrix product vectors as zero.
-    Lemma~L for the horizontal canonical form would then force the inserted
-    tensor itself to vanish, contrary to the assumed nonzero corner.
+    Lemma~L on the normalized BNT-refined horizontal form would then force the
+    inserted tensor itself to vanish, contrary to the assumed nonzero corner.
     For the range-projector specialization, normality supplies a nonzero
     letter of $A$. A nonzero scalar and an invertible conjugation preserve
     this letter. If every $VV^\dagger$ corner vanished, compressing by
@@ -353,7 +361,7 @@
     \uses{def:mpdo, def:horizontal_cf_mpdo,
         thm:mpdo_reflected_marked_chain,
         cor:horizontal_cf_linear_marked_separation}
-    Let $M$ be in horizontal canonical form and generate positive
+    Let $M$ be in normalized BNT-refined horizontal form and generate positive
     semidefinite operators on every nonempty chain. Suppose two vertical
     corners are positive scalar multiples of similarities of the same tensor
     $A$:
@@ -379,6 +387,11 @@
     the subsequent proportionality of the Gram matrices. This is the
     pairwise conclusion of Figures~7--8 in
     \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the marked-tensor separation used here is proved only for normalized
+    BNT-refined horizontal form; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{theorem}
 
 \begin{proof}
@@ -570,11 +583,11 @@
     \uses{thm:mpdo_grouped_sector_gram_conjugation,
         thm:eq3_of_dressed_adjoint,
         thm:mpdo_vertical_bnt_grouping_with_isometries}
-    In the grouped vertical decomposition of a horizontally canonical
-    matrix-product density operator, let $X_{\alpha,k}$ be the gauge of a
-    copy of the normal representative $M_\alpha$, with the distinguished
-    gauge fixed to $X_{\alpha,1}=\Id$. Then there is a positive real number
-    $\omega_{\alpha,k}$ such that
+    In the grouped vertical decomposition of a matrix-product density
+    operator in normalized BNT-refined horizontal form, let $X_{\alpha,k}$ be
+    the gauge of a copy of the normal representative $M_\alpha$. Fix the
+    distinguished gauge to $X_{\alpha,1}=\Id$. Then there is a positive real
+    number $\omega_{\alpha,k}$ such that
     \begin{align}
         X_{\alpha,k}^\dagger X_{\alpha,k}
         &=\omega_{\alpha,k}\Id,
@@ -585,6 +598,11 @@
     \end{align}
     and $U_{\alpha,k}$ is unitary. This is the normalization in
     \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    this completed normalization inherits the stronger formal horizontal
+    predicate and does not close the literal canonical-form refinement gap; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -188,9 +188,10 @@
     \cite[Proposition~4.13, line 1898]{Cirac2016MPDO_arXiv}.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the formal separation invokes the stronger normalized BNT-refined
-    predicate. The literal canonical-form version remains part of the missing
-    Lemma-L and active-refinement step recorded in
+    this separation theorem assumes normalized BNT-refined horizontal form,
+    which is stronger than the literal CPSV canonical form. The literal
+    canonical-form version remains part of the missing Lemma-L and
+    active-refinement step recorded in
     \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{theorem}
 
@@ -600,8 +601,9 @@
     \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv}.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    this completed normalization inherits the stronger formal horizontal
-    predicate and does not close the literal canonical-form refinement gap; see
+    this normalization theorem assumes normalized BNT-refined horizontal form,
+    which is stronger than the literal CPSV canonical form and does not close
+    the literal canonical-form refinement gap; see
     \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -462,9 +462,10 @@
     =I(\sigma^{(N)}_{a+2:b+1})$.
     This is the channel calculation in
     \cite[Appendix~C, lines~1333--1341]{Cirac2016MPDO_arXiv}. For the forward
-    implication of the source proposition, the required nonzero trace follows
-    from horizontal canonical form, the MPDO condition, and the renormalization
-    maps; simplicity is not used.
+    implication proved here, the required nonzero trace follows from normalized
+    BNT-refined horizontal form, the MPDO condition, and the renormalization
+    maps; simplicity is not used. This horizontal hypothesis is stronger than
+    literal CPSV canonical form.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -474,25 +475,27 @@
     mutual informations.
 \end{proof}
 
-\begin{lemma}[Nonvanishing of positive-length RFP rings]
+\begin{lemma}[Nonvanishing of positive-length BNT-refined RFP rings]
     \label{lem:mpdo_rfp_positive_length_trace_nonzero}
     \lean{MPOTensor.firstSiteMatrix_one,
       MPOTensor.trace_mpo_ne_zero_of_isHorizontalCF_isMPDO_isRFPViaTS}
     \leanok
     \uses{def:is_rfp_via_ts}
-    Let $M$ be horizontally canonical, generate positive semidefinite ring
-    operators, and satisfy the local renormalization fixed-point equations.
+    Let $M$ be in normalized BNT-refined horizontal form, generate positive
+    semidefinite ring operators, and satisfy the local renormalization
+    fixed-point equations. This horizontal hypothesis is stronger than literal
+    CPSV canonical form.
     Then $\tr\rho^{(N)}(M)\neq0$ for every $N\geq1$.
 \end{lemma}
 
 \begin{proof}\leanok
-    Horizontal canonical form gives a nonzero sector compression for one
-    positive length. Positivity makes its trace nonzero. The fixed-point
+    Normalized BNT-refined horizontal form gives a nonzero sector compression
+    for one positive length. Positivity makes its trace nonzero. The fixed-point
     equations make the physical-trace transfer idempotent, so the trace of its
     positive powers is independent of the positive exponent.
 \end{proof}
 
-\begin{theorem}[Renormalization fixed points saturate the area law]
+\begin{theorem}[BNT-refined renormalization fixed points saturate the area law]
     \label{thm:mpdo_rfp_implies_sal}
     \lean{MPOTensor.isSAL_of_isRFPViaTS}
     \leanok
@@ -500,9 +503,10 @@
       lem:mpdo_rfp_transfer_across_cut,
       thm:mpdo_rfp_split_mutual_information_eq,
       lem:mpdo_rfp_positive_length_trace_nonzero}
-    Let $M$ be a horizontally canonical matrix product density operator which
-    satisfies the local renormalization fixed-point equations of
-    Definition~4.1. Then $M$ saturates the area law:
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form which satisfies the local renormalization fixed-point
+    equations of Definition~4.1. This horizontal hypothesis is stronger than
+    literal CPSV canonical form. Then $M$ saturates the area law:
     $I_L(M)=I_{L+1}(M)$ whenever
     $1\leq L<\lfloor N/2\rfloor$.
     This is the forward implication of Proposition~\texttt{propsimple} in
@@ -518,17 +522,18 @@
     the normalization at every positive chain length.
 \end{proof}
 
-\begin{theorem}[Renormalization fixed points have ZCL and SAL]
+\begin{theorem}[BNT-refined renormalization fixed points have ZCL and SAL]
     \label{thm:mpdo_rfp_implies_zcl_and_sal}
     \lean{MPOTensor.isSourceZCL_and_isSAL_of_isRFPViaTS}
     \leanok
     \uses{thm:rfp_via_ts_source_zcl,
       lem:mpdo_rfp_positive_length_trace_nonzero,
       thm:mpdo_rfp_implies_sal}
-    Let $M$ be a horizontally canonical matrix product density operator which
-    satisfies the local renormalization fixed-point equations of
-    Definition~4.1. Then $M$ has source zero correlation length and saturates
-    the area law. This is Proposition~\texttt{propsimple} in Appendix~C of
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form which satisfies the local renormalization fixed-point
+    equations of Definition~4.1. This horizontal hypothesis is stronger than
+    literal CPSV canonical form. Then $M$ has source zero correlation length
+    and saturates the area law. This is Proposition~\texttt{propsimple} in Appendix~C of
     \cite{Cirac2016MPDO_arXiv}, lines~1333--1341.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -533,7 +533,8 @@
     horizontal form which satisfies the local renormalization fixed-point
     equations of Definition~4.1. This horizontal hypothesis is stronger than
     literal CPSV canonical form. Then $M$ has source zero correlation length
-    and saturates the area law. This is Proposition~\texttt{propsimple} in Appendix~C of
+    and saturates the area law. This is the normalized-BNT-refined
+    specialization of Proposition~\texttt{propsimple} in Appendix~C of
     \cite{Cirac2016MPDO_arXiv}, lines~1333--1341.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_mixed_state_bounds.tex
@@ -509,9 +509,10 @@
     literal CPSV canonical form. Then $M$ saturates the area law:
     $I_L(M)=I_{L+1}(M)$ whenever
     $1\leq L<\lfloor N/2\rfloor$.
-    This is the forward implication of Proposition~\texttt{propsimple} in
-    Appendix~C of \cite{Cirac2016MPDO_arXiv}. Simplicity is among the ambient
-    hypotheses of Theorem~4.9 but is not used in this implication.
+    This is the normalized BNT-refined specialization of the forward
+    implication of Proposition~\texttt{propsimple} in Appendix~C of
+    \cite{Cirac2016MPDO_arXiv}. Simplicity is among the ambient hypotheses of
+    Theorem~4.9 but is not used in this implication.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -154,8 +154,7 @@
         def:mpdo_bnt_two_site_multiplicity_spectrum,
         def:mpdo_bnt_two_site_exact_sector_gauge,
         def:mpdo_bnt_multiplicity_spectrum_comparison,
-        def:mpdo_bnt_eventual_power_sums_multiplicity_comparison,
-        thm:vertical_cf_of_horizontal_cf}
+        def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
     Let $M$ be an MPDO in normalized BNT-refined horizontal form, equipped
     with a tensor-attached BNT algebra clause
     $\widetilde M=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$.
@@ -198,6 +197,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:vertical_cf_of_horizontal_cf}
     Multiplying the two one-site decompositions and using the BNT algebra law
     expresses the two-site closed chain in the basis $M_\gamma$, with
     coefficient

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -136,7 +136,7 @@
     exact invertible conjugacy retained from
     \cite[Appendix~C.4, lines~2053--2057]{Cirac2016MPDO_arXiv}.
     It does not include the further conclusion on line~2057 that $Z_\gamma$
-    may be chosen unitary; that strengthening remains open.
+    may be chosen unitary.
     % The full line-2057 unitary source step is tracked in issue 4645 and
     % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{definition}
@@ -154,7 +154,8 @@
         def:mpdo_bnt_two_site_multiplicity_spectrum,
         def:mpdo_bnt_two_site_exact_sector_gauge,
         def:mpdo_bnt_multiplicity_spectrum_comparison,
-        def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
+        def:mpdo_bnt_eventual_power_sums_multiplicity_comparison,
+        thm:vertical_cf_of_horizontal_cf}
     Let $M$ be an MPDO in normalized BNT-refined horizontal form, equipped
     with a tensor-attached BNT algebra clause
     $\widetilde M=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$.
@@ -185,8 +186,8 @@
         \label{eq:rfp_sector_conjugacy}
     \end{align}
     exactly. This is only the invertible-gauge sub-result of
-    lines~2053--2057: the further conclusion that $Z_\gamma$ may be chosen
-    unitary is not part of this statement and remains open.
+    lines~2053--2057; no unitary choice of $Z_\gamma$ follows from this
+    statement.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
     the normalized BNT-refined horizontal hypothesis is stronger than the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -189,9 +189,9 @@
     unitary is not part of this statement and remains open.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the two-site decomposition is constructed from the stronger normalized
-    BNT-refined horizontal form, not the literal CPSV canonical form. See
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
     % The full line-2057 unitary source step is tracked in issue 4645 and
     % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -155,8 +155,8 @@
         def:mpdo_bnt_two_site_exact_sector_gauge,
         def:mpdo_bnt_multiplicity_spectrum_comparison,
         def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
-    Let $M$ be an MPDO in horizontal canonical form, equipped with a
-    tensor-attached BNT algebra clause
+    Let $M$ be an MPDO in normalized BNT-refined horizontal form, equipped
+    with a tensor-attached BNT algebra clause
     $\widetilde M=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$.
     There is a vertical canonical decomposition of the two-site blocking,
     \begin{align}
@@ -187,6 +187,11 @@
     exactly. This is only the invertible-gauge sub-result of
     lines~2053--2057: the further conclusion that $Z_\gamma$ may be chosen
     unitary is not part of this statement and remains open.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the two-site decomposition is constructed from the stronger normalized
+    BNT-refined horizontal form, not the literal CPSV canonical form. See
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
     % The full line-2057 unitary source step is tracked in issue 4645 and
     % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -194,7 +194,8 @@
     \leanok
     \uses{def:is_rfp_via_ts,
         def:vertical_cf_mpdo,
-        def:mpdo_bnt_fusion_tensor_clause}
+        def:mpdo_bnt_fusion_tensor_clause,
+        thm:vertical_cf_of_horizontal_cf}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form. If the one-site and two-site physical closures are
     related in both directions by trace-preserving completely positive maps

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -194,8 +194,7 @@
     \leanok
     \uses{def:is_rfp_via_ts,
         def:vertical_cf_mpdo,
-        def:mpdo_bnt_fusion_tensor_clause,
-        thm:vertical_cf_of_horizontal_cf}
+        def:mpdo_bnt_fusion_tensor_clause}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form. If the one-site and two-site physical closures are
     related in both directions by trace-preserving completely positive maps
@@ -204,6 +203,7 @@
     fusion matrices satisfy the length-one idempotent trace-scalar identity.
 \end{theorem}
 \begin{proof}\leanok
+    \uses{thm:vertical_cf_of_horizontal_cf}
     Choose vertical canonical decompositions of the one-site tensor and its
     two-site blocking. Transporting the two physical maps through these
     decompositions identifies their normal sectors and yields the positive

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -343,8 +343,9 @@
     decomposition.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the fusion clause is obtained from the stronger normalized BNT-refined
-    horizontal predicate. This is not the literal Proposition~4.13 route; see
+    the fusion clause requires normalized BNT-refined horizontal form, which is
+    stronger than the literal CPSV canonical form. This is not the literal
+    Proposition~4.13 route; see
     \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 
     \textbf{Local fix (rectangular vertical map):} The second equality uses
@@ -357,9 +358,10 @@
     \uses{thm:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_topological_projector_recursion,
         lem:mpdo_sitewise_physical_coordinate_congruence}
-    On the normalized BNT-refined horizontal surface, the formal analogue of
-    Proposition~4.13 gives a rectangular coisometry onto the retained nonzero
-    vertical sectors, together with exact reconstruction from those sectors.
+    Under the normalized BNT-refined horizontal hypothesis, the vertical
+    canonical-form theorem gives a rectangular coisometry onto the retained
+    nonzero vertical sectors, together with exact reconstruction from those
+    sectors.
     In the retained coordinates, one-site matrix entries are block diagonal in
     the label and multiplicity coordinate. Hence a closed chain vanishes
     between different sitewise configurations. Within one configuration, the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -343,10 +343,10 @@
     decomposition.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the fusion clause requires normalized BNT-refined horizontal form, which is
-    stronger than the literal CPSV canonical form. This is not the literal
-    Proposition~4.13 route; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % This is not the literal Proposition 4.13 route; see
+    % docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 
     \textbf{Local fix (rectangular vertical map):} The second equality uses
     exact reconstruction from the retained nonzero sectors of
@@ -404,9 +404,9 @@
     terminal spectral, projection, Hamiltonian, or Gibbs-state assertion.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the selected fusion clause inherits the stronger normalized BNT-refined
-    horizontal hypothesis; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{corollary}
 \begin{proof}\leanok
     \uses{thm:mpdo_rfp_to_bnt_fusion_tensor}
@@ -454,10 +454,9 @@
     chain length $N$ by $P_s^{(N)}$.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    this definition uses the fusion clause obtained under normalized
-    BNT-refined horizontal form, which is stronger than the literal CPSV
-    canonical form; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{definition}
 
 \begin{theorem}[Terminal spectral projectors for a length-independent RFP
@@ -524,9 +523,9 @@
     fusion clause.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the fixed clause comes from normalized BNT-refined horizontal form, not the
-    literal CPSV canonical form; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 
     This theorem stops at
     \cite[lines~1003--1012]{Cirac2016MPDO_arXiv}; it does not assert the
@@ -655,9 +654,10 @@
     (\ref{eq:rfp_retained_gibbs_sum}).
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the RFP-derived clause uses normalized BNT-refined horizontal form. The
-    literal canonical-form implication remains open; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % The literal implication remains open; see
+    % docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 
     \textbf{Scope restriction (retained vertical coordinates):}
     the formula is an equality for $R_L$ on the retained vertical space, not
@@ -722,9 +722,9 @@
     \end{align}
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    this theorem inherits the same stronger normalized BNT-refined horizontal
-    hypothesis; see
-    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 
     \textbf{Local fix (physical complement):}
     the retained one-site energy is compressed to physical coordinates and

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -323,8 +323,9 @@
         def:mpdo_topological_density_operator,
         def:mpdo_single_kraus_map,
         def:mpdo_sitewise_physical_matrix}
-    Let $M$ be a matrix product density operator in horizontal canonical form
-    and suppose that it satisfies the renormalization fixed-point condition.
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form and suppose that it satisfies the renormalization
+    fixed-point condition.
     There is one vertical canonical decomposition and one compatible family of
     fusion coisometries such that, for every $N>0$, the rectangular vertical
     coisometry $V$ satisfies the two exact equations
@@ -341,6 +342,11 @@
     line~1001, length independence, or the subsequent spectral and Gibbs
     decomposition.
 
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the fusion clause is obtained from the stronger normalized BNT-refined
+    horizontal predicate. This is not the literal Proposition~4.13 route; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+
     \textbf{Local fix (rectangular vertical map):} The second equality uses
     exact reconstruction from the retained nonzero sectors of
     Proposition~4.13 and Appendix~C.4, lines~2020--2029, not a square-unitary
@@ -351,6 +357,7 @@
     \uses{thm:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_topological_projector_recursion,
         lem:mpdo_sitewise_physical_coordinate_congruence}
+    On the normalized BNT-refined horizontal surface, the formal analogue of
     Proposition~4.13 gives a rectangular coisometry onto the retained nonzero
     vertical sectors, together with exact reconstruction from those sectors.
     In the retained coordinates, one-site matrix entries are block diagonal in
@@ -376,8 +383,9 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_topological_density_operator}
-    Let $M$ be a matrix product density operator in horizontal canonical form
-    and suppose that it satisfies the renormalization fixed-point condition.
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form and suppose that it satisfies the renormalization
+    fixed-point condition.
     One choice of the vertical canonical decomposition and fusion
     coisometries satisfies, for every $N>0$,
     \begin{align}
@@ -392,6 +400,11 @@
     \cite[lines~1000--1002]{Cirac2016MPDO_arXiv}. No additional compatibility
     hypothesis is imposed. This statement makes no length-independence,
     terminal spectral, projection, Hamiltonian, or Gibbs-state assertion.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the selected fusion clause inherits the stronger normalized BNT-refined
+    horizontal hypothesis; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{corollary}
 \begin{proof}\leanok
     \uses{thm:mpdo_rfp_to_bnt_fusion_tensor}
@@ -420,11 +433,13 @@
         HasTerminalSpectralProjectorRefinement}
     \lean{MPOTensor.rfpBNTFusionTensorClause}
     \leanok
-    \uses{def:mpdo_bnt_fusion_tensor_clause,
+    \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
+        def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_topological_density_operator,
         def:mpdo_topological_projector_recursion}
-    Fix the fusion clause selected by the renormalization fixed-point
-    construction. For every terminal label $\gamma$, close the horizontal
+    For an MPDO in normalized BNT-refined horizontal form satisfying the
+    renormalization fixed-point condition, fix the fusion clause selected by
+    that construction. For every terminal label $\gamma$, close the horizontal
     operator leg of $M_\gamma$ to obtain a matrix $K_\gamma$ on its bond
     space. Its spectral indices are pairs $s=(\gamma,k)$ with
     $0\leq k<D_\gamma$.
@@ -435,6 +450,11 @@
     coisometry, and assemble over all sitewise label and multiplicity
     configurations. Denote the resulting all-label operator at positive
     chain length $N$ by $P_s^{(N)}$.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the source-facing fusion clause in this entry is selected only under the
+    stronger normalized BNT-refined horizontal hypothesis; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{definition}
 
 \begin{theorem}[Terminal spectral projectors for a length-independent RFP
@@ -458,8 +478,9 @@
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_terminal_spectral_refinement,
         cor:mpdo_topological_density_factor_commutator}
-    Let $M$ be a matrix product density operator in horizontal canonical form
-    satisfying the renormalization fixed-point condition. Fix internally the
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form satisfying the renormalization fixed-point condition. Fix
+    internally the
     fusion clause supplied by that construction, and suppose that its positive
     trace-power coefficients are independent of the positive chain length.
     Then $K_\gamma$ is positive semidefinite for every terminal label, so
@@ -497,7 +518,14 @@
     The length-independence assumption here is clause-relative: it is stated
     on the coefficients of the fixed clause selected from the
     renormalization fixed-point construction, not on an arbitrary
-    fusion clause. This theorem stops at
+    fusion clause.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the fixed clause comes from normalized BNT-refined horizontal form, not the
+    literal CPSV canonical form; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+
+    This theorem stops at
     \cite[lines~1003--1012]{Cirac2016MPDO_arXiv}; it does not assert the
     commuting nearest-neighbor Hamiltonian or Gibbs-state conclusion beginning
     at line~1013.
@@ -593,8 +621,9 @@
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_topological_gibbs_data_at_least_two,
         thm:mpdo_terminal_spectral_projector_refinement}
-    Let $M$ be a matrix product density operator in horizontal canonical form
-    satisfying the renormalization fixed-point condition. Select the fusion
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form satisfying the renormalization fixed-point condition.
+    Select the fusion
     clause supplied by that condition and suppose that its positive
     trace-power coefficients are independent of the positive chain length.
     There are non-negative numbers $\lambda_1,\ldots,\lambda_d$, independent
@@ -621,6 +650,11 @@
     Applying the adjoint retained-row map at every site reconstructs
     $\rho^{(L)}(M)$ from the right-hand side of
     (\ref{eq:rfp_retained_gibbs_sum}).
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the RFP-derived clause uses normalized BNT-refined horizontal form. The
+    literal canonical-form implication remains open; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 
     \textbf{Scope restriction (retained vertical coordinates):}
     the formula is an equality for $R_L$ on the retained vertical space, not
@@ -661,8 +695,9 @@
     \uses{thm:mpdo_topological_gibbs_at_least_two}
     \lean{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
-    Let $M$ be as in
-    Theorem~\ref{thm:mpdo_topological_gibbs_at_least_two}. There are
+    Let $M$ be in normalized BNT-refined horizontal form and satisfy the
+    hypotheses of Theorem~\ref{thm:mpdo_topological_gibbs_at_least_two}. There
+    are
     non-negative numbers $\lambda_1,\ldots,\lambda_d$ and one fixed Hermitian
     two-site matrix $\widehat h$, all independent of the chain length. For
     every $L\geq2$, let
@@ -682,6 +717,11 @@
           e^{-\widehat H_L}.
         \label{eq:rfp_physical_gibbs_sum}
     \end{align}
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    this theorem inherits the same stronger normalized BNT-refined horizontal
+    hypothesis; see
+    \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 
     \textbf{Local fix (physical complement):}
     the retained one-site energy is compressed to physical coordinates and

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -438,7 +438,8 @@
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_topological_density_operator,
-        def:mpdo_topological_projector_recursion}
+        def:mpdo_topological_projector_recursion,
+        thm:mpdo_rfp_to_bnt_fusion_tensor}
     For an MPDO in normalized BNT-refined horizontal form satisfying the
     renormalization fixed-point condition, fix the fusion clause selected by
     that construction. For every terminal label $\gamma$, close the horizontal
@@ -767,9 +768,8 @@
     $L=1$ instance is therefore undefined without an author or erratum
     convention. The source construction is defined for $L\geq2$, and no
     length-one theorem is asserted. The physical-coordinate theorem above
-    proves the result on this domain; the undefined length-one convention
-    remains open. See
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}
-    and
-    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+    proves the result on this domain; no $L=1$ statement follows without an
+    additional convention.
+    % See docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex
+    % and docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -454,8 +454,9 @@
     chain length $N$ by $P_s^{(N)}$.
 
     \textbf{Scope restriction (BNT-refined horizontal form):}
-    the source-facing fusion clause in this entry is selected only under the
-    stronger normalized BNT-refined horizontal hypothesis; see
+    this definition uses the fusion clause obtained under normalized
+    BNT-refined horizontal form, which is stronger than the literal CPSV
+    canonical form; see
     \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
 \end{definition}
 


### PR DESCRIPTION
## What changed

PR #4945 was merged at `e7e85fd11f50a449422888c8b93d7774d742d168` before post-merge independent review `cf492fef67fc` completed. That review found remaining transitive descendants which still described the stronger `MPOTensor.IsHorizontalCF` surface as unqualified or literal horizontal canonical form.

This follow-up:

- updates the remaining Chapter 20 completed entries for first-site separation, periodic-sector exclusion, nonzero sector compression, Figure 8 Gram comparison, and grouped gauge normalization;
- updates the Chapter 21 completed entries for the two-site multiplicity spectrum, RFP density decomposition and commutator, RFP-selected terminal spectral data, retained-coordinate Gibbs decomposition, and the physical-coordinate Gibbs corollary;
- synchronizes the corresponding source-facing Lean module overviews and declaration docstrings, including the descendants of `IsHorizontalCF.exists_cpsvVerticalDecomposition`, `HasBNTFusionTensorClause.of_isRFPViaTS`, and `rfpBNTFusionTensorClause`;
- consistently says **normalized BNT-refined horizontal form** and adds a scope-restriction marker when a result is presented as a CPSV16 Proposition 4.13 or Theorem 4.14 consequence;
- leaves genuinely abstract theorems unchanged when they only assume an already-supplied fusion clause.

The literal CPSV16 Proposition 4.13 blueprint node remains `\notready`. Its retained-coordinate Lemma L separation and ambient-coisometry transport gaps remain explicit, and the rectangular map remains correctly stated as a coisometry. No theorem statement, proof term, or proof semantics changed.

## Validation

- bounded direct/transitive dependency audit from `IsHorizontalCF.exists_cpsvVerticalDecomposition` and `HasBNTFusionTensorClause.of_isRFPViaTS`
- comment-stripped comparison of all 13 touched Lean modules against `origin/main` — zero noncomment semantic differences
- `git diff --check origin/main...HEAD`
- targeted builds for all 13 touched Lean modules — 9,134 jobs, success
- full `lake build TNLean` — 9,755 jobs, success
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- reader-facing prose, forbidden-token, oversized-file, numbered-module, and generated-import checks — success
- from `blueprint/src`, double `lualatex -interaction=nonstopmode -halt-on-error print.tex` with `TEXINPUTS='../../tex/tenkz//:'` — 747 pages, zero undefined cross-references (standalone bibliography citations remain unresolved as expected)
- generated PDF/log/aux changes removed; worktree clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint-only changes with no semantic Lean diffs; risk is limited to documentation accuracy for reviewers tracing CPSV vs BNT-refined hypotheses.
> 
> **Overview**
> This PR finishes a documentation pass left incomplete after #4945: **no Lean theorem statements or proofs change**—only module overviews, declaration docstrings, and blueprint prose.
> 
> Across Chapter 20–21 and the touched `TNLean/MPS/MPDO/*` files, results that assume `MPOTensor.IsHorizontalCF` are now described as holding under **normalized BNT-refined horizontal form**, explicitly **stronger than literal CPSV canonical form**, with **scope-restriction** notes and links to `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex` and related periodic-sector / vertical-CF gap docs. Wording is aligned for periodic-sector exclusion, Figure 8 / grouped Gram normalization, two-site multiplicity spectrum, RFP trace and area law (`propsimple`), and topological density / Gibbs theorems derived from `HasBNTFusionTensorClause.of_isRFPViaTS`.
> 
> The blueprint renames or reframes several theorem titles (e.g. periodic sectors and RFP SAL) to match that specialization and drops or softens claims that the formalization proves the **literal** source theorems under CPSV canonical form alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c86bae731c027d7af41edfdd8077ae0c49982bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->