### PR TITLE
fix(tenkz): reconcile merged census

### DIFF
--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -918,3 +918,13 @@ two-window PEPS relation. The additional lines state mathematical content
 that was previously absent.
 
 Census-correction: #4910
+
+### 2026-07-27 — the MPO-word correction synchronizes the line census
+
+PR~#4954 replaces one shared long-bond label by the four adjacent bond labels
+shown in the source MPO word. Spelling those four labels wraps the option list
+across two non-comment lines and raises the 130-case mean from 16.23 to 16.24.
+The increase records that source correction; no package surface or parser
+changes here.
+
+Census-correction: #4954

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -21,7 +21,7 @@
   },
   "m4_lines_per_case": {
     "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",
-    "value": 16.23
+    "value": 16.24
   },
   "m5_aliases": {
     "definition": "key and value alias rows plus sunset compliance; near zero at the 1.0 freeze",


### PR DESCRIPTION
## What changed

- synchronize the frozen `m4_lines_per_case` census from `16.23` to `16.24`;
- add the policy-required dated census-correction note with the exact source of the one counted line.

PR LionSR/TNLean#4954 commit `14f5d0275` replaced one compact deprecated long-bond label in `rmp-workbench-iii-mpo-representation.tex` with four explicit source-faithful bond-label options. That spelling wraps to one additional non-comment, nonblank line. The LionSR/TNLean#4954 state therefore already measures `2111 / 130 = 16.23846`, rounded to `16.24`; LionSR/TNLean#4955 remains at `16.23`. The catalogue denominator, parser-path fingerprint, parser-path count, manual-layer count, and alias count are unchanged, so the correction does not conceal catalogue or parser growth.

This restores the current-main shrink gate and unblocks unrelated PR LionSR/TNLean#4953.

## Validation

- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `git diff --check origin/main...HEAD`

Closes LionSR/tenkz#99.