### PR TITLE
feat(canonical-form): retain grouped active BNT refinement data

### DIFF
--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -8,6 +8,7 @@ Authors: TNLean contributors
 -- Import architecture: docs/import_structure.md.
 -- Generated aggregator module: TNLean.MPS.CanonicalForm
 
+import TNLean.MPS.CanonicalForm.ActiveBNTRefinement
 import TNLean.MPS.CanonicalForm.BNTCharacterization
 import TNLean.MPS.CanonicalForm.BNTExistence
 import TNLean.MPS.CanonicalForm.BNTGrouping

--- a/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
+++ b/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
@@ -1,0 +1,327 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.BNTExistence
+import TNLean.MPS.SharedInfra.BlockGauge
+
+/-!
+# Structured active BNT refinements of CPSV canonical form
+
+This module retains the data discarded by the existential BNT construction.  Starting from
+literal `CPSVCanonicalFormData`, it enumerates the nonzero-weight blocks, quotients them by
+MPV phase equivalence, and records the dimension, phase, and invertible gauge of every copy
+relative to its chosen representative.
+
+Zero-weight displayed blocks are not deleted.  They remain as literal zero-weight summands in
+the exact direct sum.  Consequently the original ambient coisometry is retained unchanged,
+with orientation `U * Uᴴ = 1`.  The active summands are replaced letterwise by gauged phase
+copies of their representatives, while inactive summands are left untouched.  A block-diagonal
+gauge then gives an exact letterwise regrouping and an exact ambient reconstruction.
+
+This is the preparatory active-refinement step in the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1863--1921.  It does not assert the retained-coordinate Lemma L or the
+vertical canonical-form conclusion of that proposition.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ} {A : MPSTensor d D}
+
+namespace CPSVCanonicalFormData
+
+/-- Indices of the displayed CPSV canonical-form blocks whose weights are nonzero.
+
+Source: arXiv:1606.00608, eq. `II_CF1` and Proposition 4.13, lines 1863--1898. -/
+abbrev Active (data : CPSVCanonicalFormData A) :=
+  {k : Fin data.r // data.weights k ≠ 0}
+
+/-- A finite enumeration of the nonzero-weight displayed blocks. -/
+noncomputable def activeEquiv (data : CPSVCanonicalFormData A) :
+    Fin (Fintype.card data.Active) ≃ data.Active :=
+  (Fintype.equivFin data.Active).symm
+
+/-- Bond dimensions of the enumerated active blocks. -/
+noncomputable def activeDim (data : CPSVCanonicalFormData A) :
+    Fin (Fintype.card data.Active) → ℕ :=
+  fun k => data.dim (data.activeEquiv k)
+
+/-- Weights of the enumerated active blocks. -/
+noncomputable def activeWeight (data : CPSVCanonicalFormData A) :
+    Fin (Fintype.card data.Active) → ℂ :=
+  fun k => data.weights (data.activeEquiv k)
+
+/-- Normal tensors of the enumerated active blocks. -/
+noncomputable def activeBlocks (data : CPSVCanonicalFormData A) :
+    (k : Fin (Fintype.card data.Active)) → MPSTensor d (data.activeDim k) :=
+  fun k => data.blocks (data.activeEquiv k)
+
+/-- MPV phase classes of the active canonical-form blocks. -/
+noncomputable def activePhaseClasses (data : CPSVCanonicalFormData A) :
+    MPVPhaseClassData data.activeBlocks :=
+  mpvPhaseClassData data.activeBlocks
+
+/-- Equivalence between phase-class copies and the original nonzero-weight displayed blocks.
+
+This is the explicit retained-index identification used in the copy enumeration at
+arXiv:1606.00608, lines 1894--1901. -/
+noncomputable def activeClassCopyEquiv (data : CPSVCanonicalFormData A) :
+    (Σ j : Fin data.activePhaseClasses.g,
+      Fin (data.activePhaseClasses.copies j)) ≃ data.Active :=
+  data.activePhaseClasses.enumEquiv.trans data.activeEquiv
+
+@[simp]
+theorem activeClassCopyEquiv_apply (data : CPSVCanonicalFormData A)
+    (j : Fin data.activePhaseClasses.g)
+    (q : Fin (data.activePhaseClasses.copies j)) :
+    data.activeClassCopyEquiv ⟨j, q⟩ =
+      data.activeEquiv (data.activePhaseClasses.enum j q) :=
+  rfl
+
+/-- The original displayed index of the representative of an active phase class. -/
+noncomputable def activeRepresentativeIndex (data : CPSVCanonicalFormData A)
+    (j : Fin data.activePhaseClasses.g) : data.Active :=
+  data.activeEquiv (data.activePhaseClasses.repr j)
+
+/-- The phase-class copy coordinate of an original active displayed index. -/
+noncomputable def activeClassCopy (data : CPSVCanonicalFormData A) (k : data.Active) :
+    Σ j : Fin data.activePhaseClasses.g, Fin (data.activePhaseClasses.copies j) :=
+  data.activeClassCopyEquiv.symm k
+
+@[simp]
+theorem activeClassCopy_activeClassCopyEquiv (data : CPSVCanonicalFormData A)
+    (j : Fin data.activePhaseClasses.g)
+    (q : Fin (data.activePhaseClasses.copies j)) :
+    data.activeClassCopy (data.activeClassCopyEquiv ⟨j, q⟩) = ⟨j, q⟩ :=
+  data.activeClassCopyEquiv.symm_apply_apply ⟨j, q⟩
+
+/-- Structured active BNT-refinement data for a literal CPSV canonical form.
+
+For every active displayed index, `activeClassCopy` gives its phase class and copy label.  The
+record stores the original weight, the equality of bond dimensions, a unit phase, and an actual
+invertible gauge realizing that copy as a gauged phase multiple of the chosen representative.
+The representative family is a CPSV basis of normal tensors.
+
+The displayed zero-weight coordinates are retained as literal zero summands.  The fields
+`regroup_letterwise` and `reconstruct_regrouped` are therefore exact matrix identities at every
+letter, not merely positive-length MPV equalities.  The ambient rectangular map keeps the
+coisometry orientation `U * Uᴴ = 1`.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921, especially the copy enumeration
+and gauges at lines 1894--1905. -/
+structure ActiveBNTRefinement (data : CPSVCanonicalFormData A) where
+  /-- Equality between the chosen representative's bond dimension and this copy's dimension. -/
+  copy_dim_eq : ∀ k : data.Active,
+    data.dim (data.activeRepresentativeIndex (data.activeClassCopy k).1) = data.dim k
+  /-- The unit phase multiplying this active copy of its representative. -/
+  copy_phase : data.Active → ℂ
+  /-- The phase of every active copy has unit modulus. -/
+  copy_phase_norm : ∀ k : data.Active, ‖copy_phase k‖ = 1
+  /-- The invertible gauge from the representative coordinates to this copy's coordinates. -/
+  copy_gauge : ∀ k : data.Active, GL (Fin (data.dim k)) ℂ
+  /-- Exact letterwise gauge-phase relation for every active copy. -/
+  copy_relation : ∀ (k : data.Active) i,
+    data.blocks k i = copy_phase k •
+      ((copy_gauge k : Matrix _ _ ℂ) *
+        (cast (congr_arg (MPSTensor d) (copy_dim_eq k))
+          (data.blocks (data.activeRepresentativeIndex (data.activeClassCopy k).1))) i *
+        (↑((copy_gauge k)⁻¹) : Matrix _ _ ℂ))
+  /-- The original scalar weight of each active copy. -/
+  copy_weight : data.Active → ℂ
+  /-- The copy weight is exactly the weight at its original displayed index. -/
+  copy_weight_eq : ∀ k : data.Active, copy_weight k = data.weights k
+  /-- Every chosen representative is a normal tensor. -/
+  representative_normal : ∀ j,
+    IsNormalTensor (data.blocks (data.activeRepresentativeIndex j))
+  /-- Distinct chosen representatives are not gauge-phase equivalent. -/
+  representatives_not_equiv :
+    BlocksNotGaugePhaseEquiv (d := d)
+      (fun j => data.blocks (data.activeRepresentativeIndex j))
+  /-- The representative family is a basis of normal tensors for the original tensor. -/
+  representatives_bnt :
+    IsCPSVBasisOfNormalTensors A
+      (fun j => ⟨data.dim (data.activeRepresentativeIndex j),
+        data.blocks (data.activeRepresentativeIndex j)⟩)
+  /-- One same-dimensional representative copy at every displayed index.  Inactive indices are
+  left unchanged because their displayed scalar weight is zero. -/
+  regrouped_blocks : (k : Fin data.r) → MPSTensor d (data.dim k)
+  /-- The block gauge at every displayed index. -/
+  listed_gauge : (k : Fin data.r) → GL (Fin (data.dim k)) ℂ
+  /-- Active entries of `regrouped_blocks` are phase multiples of their class representatives. -/
+  regrouped_blocks_active : ∀ k : data.Active,
+    regrouped_blocks k = fun i => copy_phase k •
+      (cast (congr_arg (MPSTensor d) (copy_dim_eq k))
+        (data.blocks (data.activeRepresentativeIndex (data.activeClassCopy k).1))) i
+  /-- Inactive displayed entries remain the original blocks and continue to carry zero weight. -/
+  regrouped_blocks_inactive : ∀ k, data.weights k = 0 →
+    regrouped_blocks k = data.blocks k
+  /-- Every original displayed block is the conjugate of its regrouped block. -/
+  blocks_eq_listed_gauge_conj : ∀ k i,
+    data.blocks k i =
+      (listed_gauge k : Matrix _ _ ℂ) * regrouped_blocks k i *
+        (↑((listed_gauge k)⁻¹) : Matrix _ _ ℂ)
+  /-- Exact letterwise regrouping of the displayed direct sum. -/
+  regroup_letterwise : ∀ i,
+    toTensorFromBlocks (d := d) data.weights data.blocks i =
+      (globalGaugeOfBlocks listed_gauge : Matrix _ _ ℂ) *
+        toTensorFromBlocks (d := d) data.weights regrouped_blocks i *
+        (↑((globalGaugeOfBlocks listed_gauge)⁻¹) : Matrix _ _ ℂ)
+  /-- The original ambient coisometry from literal CPSV canonical form. -/
+  ambient_coisometry : Matrix (Fin (∑ k : Fin data.r, data.dim k)) (Fin D) ℂ
+  /-- The retained rectangular map is exactly the original ambient coisometry in the literal
+  canonical-form witness. -/
+  ambient_coisometry_eq : ambient_coisometry = data.ambient_coisometry
+  /-- The ambient rectangular map is a coisometry, in the orientation `U * Uᴴ = 1`. -/
+  ambient_coisometric : ambient_coisometry * ambient_coisometryᴴ = 1
+  /-- Exact ambient reconstruction through the regrouped direct sum and its block gauge. -/
+  reconstruct_regrouped : ∀ i,
+    A i = ambient_coisometryᴴ *
+      ((globalGaugeOfBlocks listed_gauge : Matrix _ _ ℂ) *
+        toTensorFromBlocks (d := d) data.weights regrouped_blocks i *
+        (↑((globalGaugeOfBlocks listed_gauge)⁻¹) : Matrix _ _ ℂ)) *
+      ambient_coisometry
+
+/-- Every literal CPSV canonical-form decomposition has a structured active BNT refinement.
+
+Zero-weight listed blocks remain as literal zero-weight summands; no false equality deleting
+their coordinates is asserted.  Active indices are equivalently enumerated by phase class and
+copy, and every copy carries its original weight and a unit-phase gauge witness.  The final two
+identities are exact at each physical letter.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+theorem exists_activeBNTRefinement (data : CPSVCanonicalFormData A) :
+    Nonempty data.ActiveBNTRefinement := by
+  classical
+  let classes := data.activePhaseClasses
+  let repIndex : Fin classes.g → data.Active := data.activeRepresentativeIndex
+  let classCopy : data.Active → (Σ j : Fin classes.g, Fin (classes.copies j)) :=
+    data.activeClassCopy
+  letI : ∀ k, NeZero (data.dim k) :=
+    fun k => ⟨Nat.ne_of_gt (data.dim_pos k)⟩
+  have hPhase : ∀ k : data.Active,
+      MPVBlockPhaseEquiv (data.blocks (repIndex (classCopy k).1)) (data.blocks k) := by
+    intro k
+    let jq := classCopy k
+    have henum : data.activeEquiv (classes.enum jq.1 jq.2) = k := by
+      exact data.activeClassCopyEquiv.apply_symm_apply k
+    have h := classes.enum_phase jq.1 jq.2
+    change MPVBlockPhaseEquiv
+      (data.blocks (data.activeEquiv (classes.repr jq.1)))
+      (data.blocks (data.activeEquiv (classes.enum jq.1 jq.2))) at h
+    rw [henum] at h
+    exact h
+  have hWitness : ∀ k : data.Active,
+      ∃ hdim : data.dim (repIndex (classCopy k).1) = data.dim k,
+      ∃ X : GL (Fin (data.dim k)) ℂ,
+      ∃ ζ : ℂ, ‖ζ‖ = 1 ∧
+        ∀ i, data.blocks k i = ζ •
+          ((X : Matrix _ _ ℂ) *
+            (cast (congr_arg (MPSTensor d) hdim)
+              (data.blocks (repIndex (classCopy k).1))) i *
+            (↑(X⁻¹) : Matrix _ _ ℂ)) := by
+    intro k
+    obtain ⟨hdim, X, ζ, _hζ, hrel⟩ :=
+      (hPhase k).dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (data.blocks_normal (repIndex (classCopy k).1)) (data.blocks_normal k)
+    refine ⟨hdim, X, ζ, ?_, hrel⟩
+    exact norm_eq_one_of_gaugePhase_cast_of_isNormalTensor
+      (data.blocks_normal (repIndex (classCopy k).1)) (data.blocks_normal k) hdim hrel
+  choose copyDimEq copyGauge copyPhase copyPhaseNorm copyRelation using hWitness
+  let copyWeight : data.Active → ℂ := fun k => data.weights k
+  have hRepresentativeNormal : ∀ j,
+      IsNormalTensor (data.blocks (repIndex j)) := by
+    intro j
+    exact data.blocks_normal (repIndex j)
+  have hRepresentativesNotEquiv :
+      BlocksNotGaugePhaseEquiv (d := d) (fun j => data.blocks (repIndex j)) := by
+    simpa [classes, repIndex, activeRepresentativeIndex, activePhaseClasses,
+      activeBlocks, activeDim] using classes.blocks_not_equiv
+  have hRepresentativesBNT :
+      IsCPSVBasisOfNormalTensors A
+        (fun j => ⟨data.dim (repIndex j), data.blocks (repIndex j)⟩) := by
+    apply (data.isCPSVBasisOfNormalTensors_iff_covered_and_minimal
+      (fun j => data.blocks (repIndex j))).2
+    refine ⟨hRepresentativeNormal, ?_, ?_⟩
+    · intro k hk
+      let ka : data.Active := ⟨k, hk⟩
+      refine ⟨(classCopy ka).1, copyDimEq ka, copyGauge ka,
+        copyPhase ka, copyPhaseNorm ka, copyRelation ka⟩
+    · intro j k hjk hdim hUnit
+      obtain ⟨X, ζ, hζnorm, hrel⟩ := hUnit
+      exact hRepresentativesNotEquiv j k hjk hdim
+        ⟨X, ζ, Complex.ne_zero_of_norm_eq_one hζnorm, hrel⟩
+  let regroupedBlocks : (k : Fin data.r) → MPSTensor d (data.dim k) := fun k =>
+    if hk : data.weights k ≠ 0 then
+      let ka : data.Active := ⟨k, hk⟩
+      fun i => copyPhase ka •
+        (cast (congr_arg (MPSTensor d) (copyDimEq ka))
+          (data.blocks (repIndex (classCopy ka).1))) i
+    else data.blocks k
+  let listedGauge : (k : Fin data.r) → GL (Fin (data.dim k)) ℂ := fun k =>
+    if hk : data.weights k ≠ 0 then
+      copyGauge ⟨k, hk⟩
+    else 1
+  have hRegroupedActive : ∀ k : data.Active,
+      regroupedBlocks k = fun i => copyPhase k •
+        (cast (congr_arg (MPSTensor d) (copyDimEq k))
+          (data.blocks (repIndex (classCopy k).1))) i := by
+    intro k
+    simp only [regroupedBlocks, dif_pos k.property]
+  have hRegroupedInactive : ∀ k, data.weights k = 0 →
+      regroupedBlocks k = data.blocks k := by
+    intro k hk
+    simp [regroupedBlocks, hk]
+  have hBlocksGauge : ∀ k i,
+      data.blocks k i =
+        (listedGauge k : Matrix _ _ ℂ) * regroupedBlocks k i *
+          (↑((listedGauge k)⁻¹) : Matrix _ _ ℂ) := by
+    intro k i
+    by_cases hk : data.weights k ≠ 0
+    · let ka : data.Active := ⟨k, hk⟩
+      have hrel := copyRelation ka i
+      simp only [listedGauge, regroupedBlocks, dif_pos hk]
+      simpa [Matrix.mul_smul, Matrix.smul_mul] using hrel
+    · simp only [listedGauge, regroupedBlocks, dif_neg hk]
+      simp
+  have hRegroup :=
+    toTensorFromBlocks_eq_globalGaugeOfBlocks_conj data.weights
+      regroupedBlocks data.blocks listedGauge hBlocksGauge
+  refine ⟨{
+    copy_dim_eq := copyDimEq
+    copy_phase := copyPhase
+    copy_phase_norm := copyPhaseNorm
+    copy_gauge := copyGauge
+    copy_relation := copyRelation
+    copy_weight := copyWeight
+    copy_weight_eq := fun _ => rfl
+    representative_normal := hRepresentativeNormal
+    representatives_not_equiv := hRepresentativesNotEquiv
+    representatives_bnt := hRepresentativesBNT
+    regrouped_blocks := regroupedBlocks
+    listed_gauge := listedGauge
+    regrouped_blocks_active := hRegroupedActive
+    regrouped_blocks_inactive := hRegroupedInactive
+    blocks_eq_listed_gauge_conj := hBlocksGauge
+    regroup_letterwise := hRegroup
+    ambient_coisometry := data.ambient_coisometry
+    ambient_coisometry_eq := rfl
+    ambient_coisometric := data.coisometric
+    reconstruct_regrouped := ?_
+  }⟩
+  intro i
+  rw [data.reconstruct i, hRegroup i]
+
+/-- Choose the structured active BNT refinement canonically supplied by
+`exists_activeBNTRefinement`.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+noncomputable def activeBNTRefinement (data : CPSVCanonicalFormData A) :
+    data.ActiveBNTRefinement :=
+  Classical.choice data.exists_activeBNTRefinement
+
+end CPSVCanonicalFormData
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
+++ b/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
@@ -14,6 +14,12 @@ MPV phase classes.  Each active copy retains its original weight, unit phase, di
 identity, and invertible gauge relative to a chosen normal representative.  The inactive
 listed blocks remain as zero-weight summands.
 
+**Local fix (zero-weight listed blocks):** Literal Lean `CPSVCanonicalFormData` permits
+syntactically listed zero-weight blocks, whereas the source canonical-form construction lists
+nonzero blocks.  Retaining them as zero-weight inactive coordinates preserves the exact ambient
+dimensions without treating them as physical BNT copies.  See
+`docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`.
+
 The grouped order is the sum of the phase-class copy coordinates and the inactive complement.
 An explicit equivalence identifies this order with the original listed blocks, and its induced
 flattened-coordinate permutation gives exact letterwise direct-sum and ambient-reconstruction
@@ -106,73 +112,129 @@ The displayed zero-weight coordinates are retained as literal zero summands.  Th
 letter, not merely positive-length MPV equalities.  The ambient rectangular map keeps the
 coisometry orientation `U * Uᴴ = 1`.
 
+**Local fix (zero-weight listed blocks):** Literal Lean `CPSVCanonicalFormData` permits
+syntactically listed zero-weight blocks, while the source construction lists nonzero blocks.
+The inactive coordinates retain zero weight to preserve exact ambient dimensions and are not
+asserted to be physical BNT copies.  See
+`docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`.
+
 Source: arXiv:1606.00608, lines 265--301, 1080--1117, and 1135--1146.
 Proposition 4.13, lines 1863--1921, uses this refinement downstream. -/
 structure ActiveBNTRefinement (data : CPSVCanonicalFormData A) where
-  /-- Equality between the chosen representative's bond dimension and this copy's dimension. -/
+  /-- Equality between the chosen representative's bond dimension and this copy's dimension.
+
+  Source: arXiv:1606.00608, lines 265--301 and the normal-tensor gauge theorem at
+  lines 1080--1117. -/
   copyDimEq : ∀ k : data.Active,
     data.dim (data.activeRepresentativeIndex (data.activeClassCopy k).1) = data.dim k
-  /-- The unit phase multiplying this active copy of its representative. -/
+  /-- The unit phase multiplying this active copy of its representative.
+
+  Source: arXiv:1606.00608, lines 265--301 and 1080--1117. -/
   copyPhase : data.Active → ℂ
-  /-- The phase of every active copy has unit modulus. -/
+  /-- The phase of every active copy has unit modulus.
+
+  Source: the normal-tensor gauge theorem in arXiv:1606.00608, lines 1080--1117. -/
   copyPhaseNorm : ∀ k : data.Active, ‖copyPhase k‖ = 1
-  /-- The invertible gauge from the representative coordinates to this copy's coordinates. -/
+  /-- The invertible gauge from the representative coordinates to this copy's coordinates.
+
+  Source: the normal-tensor gauge theorem in arXiv:1606.00608, lines 1080--1117. -/
   copyGauge : ∀ k : data.Active, GL (Fin (data.dim k)) ℂ
-  /-- Exact letterwise gauge-phase relation for every active copy. -/
+  /-- Exact letterwise gauge-phase relation for every active copy.
+
+  Source: the normal-tensor gauge theorem in arXiv:1606.00608, lines 1080--1117. -/
   copyRelation : ∀ (k : data.Active) i,
     data.blocks k i = copyPhase k •
       ((copyGauge k : Matrix _ _ ℂ) *
         (cast (congr_arg (MPSTensor d) (copyDimEq k))
           (data.blocks (data.activeRepresentativeIndex (data.activeClassCopy k).1))) i *
         (↑((copyGauge k)⁻¹) : Matrix _ _ ℂ))
-  /-- The original scalar weight of each active copy. -/
+  /-- The original scalar weight of each active copy.
+
+  Source: arXiv:1606.00608, lines 265--301. -/
   copyWeight : data.Active → ℂ
-  /-- The copy weight is exactly the weight at its original displayed index. -/
+  /-- The copy weight is exactly the weight at its original displayed index.
+
+  Source: the weighted normal-block expansion in arXiv:1606.00608, lines 265--301. -/
   copyWeightEq : ∀ k : data.Active, copyWeight k = data.weights k
-  /-- Every chosen representative is a normal tensor. -/
+  /-- Every chosen representative is a normal tensor.
+
+  Source: arXiv:1606.00608, lines 265--280 and 1135--1146. -/
   representativeNormal : ∀ j,
     IsNormalTensor (data.blocks (data.activeRepresentativeIndex j))
-  /-- Distinct chosen representatives are not gauge-phase equivalent. -/
+  /-- Distinct chosen representatives are not gauge-phase equivalent.
+
+  Source: the BNT minimality argument in arXiv:1606.00608, lines 1135--1146. -/
   representativesNotEquiv :
     BlocksNotGaugePhaseEquiv (d := d)
       (fun j => data.blocks (data.activeRepresentativeIndex j))
-  /-- The representative family is a basis of normal tensors for the original tensor. -/
+  /-- The representative family is a basis of normal tensors for the original tensor.
+
+  Source: arXiv:1606.00608, lines 265--280 and 1135--1146. -/
   representativesBNT :
     IsCPSVBasisOfNormalTensors A
       (fun j => ⟨data.dim (data.activeRepresentativeIndex j),
         data.blocks (data.activeRepresentativeIndex j)⟩)
   /-- One same-dimensional representative copy at every displayed index.  Inactive indices are
-  left unchanged because their displayed scalar weight is zero. -/
+  left unchanged because their displayed scalar weight is zero.
+
+  Source: active copies follow arXiv:1606.00608, lines 265--301 and 1080--1117; retaining the
+  inactive complement is the formal preparation used downstream in Proposition 4.13,
+  lines 1863--1921. -/
   regroupedBlocks : (k : Fin data.r) → MPSTensor d (data.dim k)
-  /-- The block gauge at every displayed index. -/
+  /-- The block gauge at every displayed index.
+
+  Source: active gauges follow arXiv:1606.00608, lines 1080--1117; identity gauges on inactive
+  zero-weight coordinates are the formal preparation used downstream in Proposition 4.13,
+  lines 1863--1921. -/
   listedGauge : (k : Fin data.r) → GL (Fin (data.dim k)) ℂ
-  /-- Active entries of `regroupedBlocks` are phase multiples of their class representatives. -/
+  /-- Active entries of `regroupedBlocks` are phase multiples of their class representatives.
+
+  Source: arXiv:1606.00608, lines 265--301 and the gauge theorem at lines 1080--1117. -/
   regroupedBlocksActive : ∀ k : data.Active,
     regroupedBlocks k = fun i => copyPhase k •
       (cast (congr_arg (MPSTensor d) (copyDimEq k))
         (data.blocks (data.activeRepresentativeIndex (data.activeClassCopy k).1))) i
-  /-- Inactive displayed entries remain the original blocks and continue to carry zero weight. -/
+  /-- Inactive displayed entries remain the original blocks and continue to carry zero weight.
+
+  Source: the literal listed direct sum is arXiv:1606.00608, Section II.A, lines 214--245 and
+  eq. `II_CF1`; retaining syntactic zero-weight entries is the local fix described above. -/
   regroupedBlocksInactive : ∀ k, data.weights k = 0 →
     regroupedBlocks k = data.blocks k
-  /-- Every original displayed block is the conjugate of its regrouped block. -/
+  /-- Every original displayed block is the conjugate of its regrouped block.
+
+  Source: arXiv:1606.00608, lines 1080--1117, applied to the Section II.A listed blocks. -/
   blocksEqListedGaugeConj : ∀ k i,
     data.blocks k i =
       (listedGauge k : Matrix _ _ ℂ) * regroupedBlocks k i *
         (↑((listedGauge k)⁻¹) : Matrix _ _ ℂ)
-  /-- Exact letterwise regrouping of the displayed direct sum. -/
+  /-- Exact letterwise regrouping of the displayed direct sum.
+
+  Source: the listed direct sum is arXiv:1606.00608, Section II.A, lines 214--245 and
+  eq. `II_CF1`; this exact coordinate identity is formal preparation used downstream in
+  Proposition 4.13, lines 1863--1921. -/
   regroupLetterwise : ∀ i,
     toTensorFromBlocks (d := d) data.weights data.blocks i =
       (globalGaugeOfBlocks listedGauge : Matrix _ _ ℂ) *
         toTensorFromBlocks (d := d) data.weights regroupedBlocks i *
         (↑((globalGaugeOfBlocks listedGauge)⁻¹) : Matrix _ _ ℂ)
-  /-- The original ambient coisometry from literal CPSV canonical form. -/
+  /-- The original ambient coisometry from literal CPSV canonical form.
+
+  Source: arXiv:1606.00608, Section II.A, lines 214--245 and eq. `II_CF1`. -/
   ambientCoisometry : Matrix (Fin (∑ k : Fin data.r, data.dim k)) (Fin D) ℂ
   /-- The retained rectangular map is exactly the original ambient coisometry in the literal
-  canonical-form witness. -/
+  canonical-form witness.
+
+  Source: arXiv:1606.00608, Section II.A, lines 214--245 and eq. `II_CF1`. -/
   ambientCoisometryEq : ambientCoisometry = data.ambient_coisometry
-  /-- The ambient rectangular map is a coisometry, in the orientation `U * Uᴴ = 1`. -/
+  /-- The ambient rectangular map is a coisometry, in the orientation `U * Uᴴ = 1`.
+
+  Source: arXiv:1606.00608, Section II.A, lines 214--245 and eq. `II_CF1`. -/
   ambientCoisometric : ambientCoisometry * ambientCoisometryᴴ = 1
-  /-- Exact ambient reconstruction through the regrouped direct sum and its block gauge. -/
+  /-- Exact ambient reconstruction through the regrouped direct sum and its block gauge.
+
+  Source: the ambient reconstruction is arXiv:1606.00608, Section II.A, lines 214--245 and
+  eq. `II_CF1`; the grouped-coordinate form is formal preparation used downstream in
+  Proposition 4.13, lines 1863--1921. -/
   reconstructRegrouped : ∀ i,
     A i = ambientCoisometryᴴ *
       ((globalGaugeOfBlocks listedGauge : Matrix _ _ ℂ) *

--- a/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
+++ b/TNLean/MPS/CanonicalForm/ActiveBNTRefinement.lean
@@ -3,28 +3,25 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.CanonicalForm.BNTExistence
+import TNLean.MPS.CanonicalForm.BNTCharacterization
 import TNLean.MPS.SharedInfra.BlockGauge
 
 /-!
-# Structured active BNT refinements of CPSV canonical form
+# Active BNT refinements of CPSV canonical form
 
-This module retains the data discarded by the existential BNT construction.  Starting from
-literal `CPSVCanonicalFormData`, it enumerates the nonzero-weight blocks, quotients them by
-MPV phase equivalence, and records the dimension, phase, and invertible gauge of every copy
-relative to its chosen representative.
+A literal CPSV canonical form is restricted to its nonzero-weight blocks and partitioned into
+MPV phase classes.  Each active copy retains its original weight, unit phase, dimension
+identity, and invertible gauge relative to a chosen normal representative.  The inactive
+listed blocks remain as zero-weight summands.
 
-Zero-weight displayed blocks are not deleted.  They remain as literal zero-weight summands in
-the exact direct sum.  Consequently the original ambient coisometry is retained unchanged,
-with orientation `U * Uᴴ = 1`.  The active summands are replaced letterwise by gauged phase
-copies of their representatives, while inactive summands are left untouched.  A block-diagonal
-gauge then gives an exact letterwise regrouping and an exact ambient reconstruction.
+The grouped order is the sum of the phase-class copy coordinates and the inactive complement.
+An explicit equivalence identifies this order with the original listed blocks, and its induced
+flattened-coordinate permutation gives exact letterwise direct-sum and ambient-reconstruction
+identities.
 
-This is the preparatory active-refinement step in the proof of Proposition 4.13 of
-arXiv:1606.00608, lines 1863--1921.  It does not assert the retained-coordinate Lemma L or the
-vertical canonical-form conclusion of that proposition.
+The phase classes follow arXiv:1606.00608, lines 265--301 and 1135--1146; the gauge witnesses
+follow lines 1080--1117.  Proposition 4.13, lines 1863--1921, uses these data downstream.
 -/
-
 open scoped Matrix BigOperators
 
 namespace MPSTensor
@@ -67,7 +64,7 @@ noncomputable def activePhaseClasses (data : CPSVCanonicalFormData A) :
 /-- Equivalence between phase-class copies and the original nonzero-weight displayed blocks.
 
 This is the explicit retained-index identification used in the copy enumeration at
-arXiv:1606.00608, lines 1894--1901. -/
+arXiv:1606.00608, lines 265--301 and 1135--1146. -/
 noncomputable def activeClassCopyEquiv (data : CPSVCanonicalFormData A) :
     (Σ j : Fin data.activePhaseClasses.g,
       Fin (data.activePhaseClasses.copies j)) ≃ data.Active :=
@@ -91,7 +88,6 @@ noncomputable def activeClassCopy (data : CPSVCanonicalFormData A) (k : data.Act
     Σ j : Fin data.activePhaseClasses.g, Fin (data.activePhaseClasses.copies j) :=
   data.activeClassCopyEquiv.symm k
 
-@[simp]
 theorem activeClassCopy_activeClassCopyEquiv (data : CPSVCanonicalFormData A)
     (j : Fin data.activePhaseClasses.g)
     (q : Fin (data.activePhaseClasses.copies j)) :
@@ -106,83 +102,255 @@ invertible gauge realizing that copy as a gauged phase multiple of the chosen re
 The representative family is a CPSV basis of normal tensors.
 
 The displayed zero-weight coordinates are retained as literal zero summands.  The fields
-`regroup_letterwise` and `reconstruct_regrouped` are therefore exact matrix identities at every
+`regroupLetterwise` and `reconstructRegrouped` are therefore exact matrix identities at every
 letter, not merely positive-length MPV equalities.  The ambient rectangular map keeps the
 coisometry orientation `U * Uᴴ = 1`.
 
-Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921, especially the copy enumeration
-and gauges at lines 1894--1905. -/
+Source: arXiv:1606.00608, lines 265--301, 1080--1117, and 1135--1146.
+Proposition 4.13, lines 1863--1921, uses this refinement downstream. -/
 structure ActiveBNTRefinement (data : CPSVCanonicalFormData A) where
   /-- Equality between the chosen representative's bond dimension and this copy's dimension. -/
-  copy_dim_eq : ∀ k : data.Active,
+  copyDimEq : ∀ k : data.Active,
     data.dim (data.activeRepresentativeIndex (data.activeClassCopy k).1) = data.dim k
   /-- The unit phase multiplying this active copy of its representative. -/
-  copy_phase : data.Active → ℂ
+  copyPhase : data.Active → ℂ
   /-- The phase of every active copy has unit modulus. -/
-  copy_phase_norm : ∀ k : data.Active, ‖copy_phase k‖ = 1
+  copyPhaseNorm : ∀ k : data.Active, ‖copyPhase k‖ = 1
   /-- The invertible gauge from the representative coordinates to this copy's coordinates. -/
-  copy_gauge : ∀ k : data.Active, GL (Fin (data.dim k)) ℂ
+  copyGauge : ∀ k : data.Active, GL (Fin (data.dim k)) ℂ
   /-- Exact letterwise gauge-phase relation for every active copy. -/
-  copy_relation : ∀ (k : data.Active) i,
-    data.blocks k i = copy_phase k •
-      ((copy_gauge k : Matrix _ _ ℂ) *
-        (cast (congr_arg (MPSTensor d) (copy_dim_eq k))
+  copyRelation : ∀ (k : data.Active) i,
+    data.blocks k i = copyPhase k •
+      ((copyGauge k : Matrix _ _ ℂ) *
+        (cast (congr_arg (MPSTensor d) (copyDimEq k))
           (data.blocks (data.activeRepresentativeIndex (data.activeClassCopy k).1))) i *
-        (↑((copy_gauge k)⁻¹) : Matrix _ _ ℂ))
+        (↑((copyGauge k)⁻¹) : Matrix _ _ ℂ))
   /-- The original scalar weight of each active copy. -/
-  copy_weight : data.Active → ℂ
+  copyWeight : data.Active → ℂ
   /-- The copy weight is exactly the weight at its original displayed index. -/
-  copy_weight_eq : ∀ k : data.Active, copy_weight k = data.weights k
+  copyWeightEq : ∀ k : data.Active, copyWeight k = data.weights k
   /-- Every chosen representative is a normal tensor. -/
-  representative_normal : ∀ j,
+  representativeNormal : ∀ j,
     IsNormalTensor (data.blocks (data.activeRepresentativeIndex j))
   /-- Distinct chosen representatives are not gauge-phase equivalent. -/
-  representatives_not_equiv :
+  representativesNotEquiv :
     BlocksNotGaugePhaseEquiv (d := d)
       (fun j => data.blocks (data.activeRepresentativeIndex j))
   /-- The representative family is a basis of normal tensors for the original tensor. -/
-  representatives_bnt :
+  representativesBNT :
     IsCPSVBasisOfNormalTensors A
       (fun j => ⟨data.dim (data.activeRepresentativeIndex j),
         data.blocks (data.activeRepresentativeIndex j)⟩)
   /-- One same-dimensional representative copy at every displayed index.  Inactive indices are
   left unchanged because their displayed scalar weight is zero. -/
-  regrouped_blocks : (k : Fin data.r) → MPSTensor d (data.dim k)
+  regroupedBlocks : (k : Fin data.r) → MPSTensor d (data.dim k)
   /-- The block gauge at every displayed index. -/
-  listed_gauge : (k : Fin data.r) → GL (Fin (data.dim k)) ℂ
-  /-- Active entries of `regrouped_blocks` are phase multiples of their class representatives. -/
-  regrouped_blocks_active : ∀ k : data.Active,
-    regrouped_blocks k = fun i => copy_phase k •
-      (cast (congr_arg (MPSTensor d) (copy_dim_eq k))
+  listedGauge : (k : Fin data.r) → GL (Fin (data.dim k)) ℂ
+  /-- Active entries of `regroupedBlocks` are phase multiples of their class representatives. -/
+  regroupedBlocksActive : ∀ k : data.Active,
+    regroupedBlocks k = fun i => copyPhase k •
+      (cast (congr_arg (MPSTensor d) (copyDimEq k))
         (data.blocks (data.activeRepresentativeIndex (data.activeClassCopy k).1))) i
   /-- Inactive displayed entries remain the original blocks and continue to carry zero weight. -/
-  regrouped_blocks_inactive : ∀ k, data.weights k = 0 →
-    regrouped_blocks k = data.blocks k
+  regroupedBlocksInactive : ∀ k, data.weights k = 0 →
+    regroupedBlocks k = data.blocks k
   /-- Every original displayed block is the conjugate of its regrouped block. -/
-  blocks_eq_listed_gauge_conj : ∀ k i,
+  blocksEqListedGaugeConj : ∀ k i,
     data.blocks k i =
-      (listed_gauge k : Matrix _ _ ℂ) * regrouped_blocks k i *
-        (↑((listed_gauge k)⁻¹) : Matrix _ _ ℂ)
+      (listedGauge k : Matrix _ _ ℂ) * regroupedBlocks k i *
+        (↑((listedGauge k)⁻¹) : Matrix _ _ ℂ)
   /-- Exact letterwise regrouping of the displayed direct sum. -/
-  regroup_letterwise : ∀ i,
+  regroupLetterwise : ∀ i,
     toTensorFromBlocks (d := d) data.weights data.blocks i =
-      (globalGaugeOfBlocks listed_gauge : Matrix _ _ ℂ) *
-        toTensorFromBlocks (d := d) data.weights regrouped_blocks i *
-        (↑((globalGaugeOfBlocks listed_gauge)⁻¹) : Matrix _ _ ℂ)
+      (globalGaugeOfBlocks listedGauge : Matrix _ _ ℂ) *
+        toTensorFromBlocks (d := d) data.weights regroupedBlocks i *
+        (↑((globalGaugeOfBlocks listedGauge)⁻¹) : Matrix _ _ ℂ)
   /-- The original ambient coisometry from literal CPSV canonical form. -/
-  ambient_coisometry : Matrix (Fin (∑ k : Fin data.r, data.dim k)) (Fin D) ℂ
+  ambientCoisometry : Matrix (Fin (∑ k : Fin data.r, data.dim k)) (Fin D) ℂ
   /-- The retained rectangular map is exactly the original ambient coisometry in the literal
   canonical-form witness. -/
-  ambient_coisometry_eq : ambient_coisometry = data.ambient_coisometry
+  ambientCoisometryEq : ambientCoisometry = data.ambient_coisometry
   /-- The ambient rectangular map is a coisometry, in the orientation `U * Uᴴ = 1`. -/
-  ambient_coisometric : ambient_coisometry * ambient_coisometryᴴ = 1
+  ambientCoisometric : ambientCoisometry * ambientCoisometryᴴ = 1
   /-- Exact ambient reconstruction through the regrouped direct sum and its block gauge. -/
-  reconstruct_regrouped : ∀ i,
-    A i = ambient_coisometryᴴ *
-      ((globalGaugeOfBlocks listed_gauge : Matrix _ _ ℂ) *
-        toTensorFromBlocks (d := d) data.weights regrouped_blocks i *
-        (↑((globalGaugeOfBlocks listed_gauge)⁻¹) : Matrix _ _ ℂ)) *
-      ambient_coisometry
+  reconstructRegrouped : ∀ i,
+    A i = ambientCoisometryᴴ *
+      ((globalGaugeOfBlocks listedGauge : Matrix _ _ ℂ) *
+        toTensorFromBlocks (d := d) data.weights regroupedBlocks i *
+        (↑((globalGaugeOfBlocks listedGauge)⁻¹) : Matrix _ _ ℂ)) *
+      ambientCoisometry
+
+/-- Inactive displayed blocks, retained as the complement of the nonzero-weight blocks. -/
+abbrev Inactive (data : CPSVCanonicalFormData A) :=
+  {k : Fin data.r // ¬ data.weights k ≠ 0}
+
+/-- The grouped block order: phase class and copy for every active block, followed by the
+inactive complement. -/
+abbrev GroupedIndex (data : CPSVCanonicalFormData A) :=
+  (Σ j : Fin data.activePhaseClasses.g, Fin (data.activePhaseClasses.copies j)) ⊕
+    data.Inactive
+
+/-- Equivalence from the grouped class/copy-plus-inactive order to the original listed blocks. -/
+noncomputable def groupedIndexEquiv (data : CPSVCanonicalFormData A) :
+    data.GroupedIndex ≃ Fin data.r :=
+  (Equiv.sumCongr data.activeClassCopyEquiv (Equiv.refl data.Inactive)).trans
+    (Equiv.sumCompl fun k : Fin data.r => data.weights k ≠ 0)
+
+/-- Number of blocks in the grouped order, including the inactive complement. -/
+noncomputable def groupedCount (data : CPSVCanonicalFormData A) : ℕ :=
+  Fintype.card data.GroupedIndex
+
+/-- Enumeration of the grouped class/copy-plus-inactive order. -/
+noncomputable def groupedEnum (data : CPSVCanonicalFormData A) :
+    Fin data.groupedCount ≃ data.GroupedIndex :=
+  (Fintype.equivFin data.GroupedIndex).symm
+
+/-- Equivalence from the finite grouped enumeration to the original listed block indices. -/
+noncomputable def groupedListedEquiv (data : CPSVCanonicalFormData A) :
+    Fin data.groupedCount ≃ Fin data.r :=
+  data.groupedEnum.trans data.groupedIndexEquiv
+
+/-- Position of a class/copy or inactive block in the finite grouped enumeration. -/
+noncomputable def groupedPosition (data : CPSVCanonicalFormData A)
+    (x : data.GroupedIndex) : Fin data.groupedCount :=
+  data.groupedEnum.symm x
+
+/-- Bond dimension at a grouped block position. -/
+noncomputable def groupedDim (data : CPSVCanonicalFormData A) :
+    Fin data.groupedCount → ℕ :=
+  fun l => data.dim (data.groupedListedEquiv l)
+
+/-- Original scalar weight at a grouped block position. -/
+noncomputable def ActiveBNTRefinement.groupedWeight
+    {data : CPSVCanonicalFormData A} (_ref : data.ActiveBNTRefinement) :
+    Fin data.groupedCount → ℂ :=
+  fun l => data.weights (data.groupedListedEquiv l)
+
+/-- Representative copy, or unchanged inactive block, at a grouped block position. -/
+noncomputable def ActiveBNTRefinement.groupedBlocks
+    {data : CPSVCanonicalFormData A} (ref : data.ActiveBNTRefinement) :
+    (l : Fin data.groupedCount) → MPSTensor d (data.groupedDim l) :=
+  fun l => ref.regroupedBlocks (data.groupedListedEquiv l)
+
+/-- The flattened coordinate permutation from grouped block coordinates to the original
+listed direct-sum coordinates. -/
+noncomputable def groupedCoordinateEquiv (data : CPSVCanonicalFormData A) :
+    (Σ l : Fin data.groupedCount, Fin (data.groupedDim l)) ≃
+      Fin (∑ k : Fin data.r, data.dim k) :=
+  blockIndexCoordinateEquiv data.dim data.groupedListedEquiv
+
+/-- The grouped class/copy-plus-inactive order has exactly the original retained dimension. -/
+theorem groupedTotalDim_eq (data : CPSVCanonicalFormData A) :
+    (∑ l : Fin data.groupedCount, data.groupedDim l) =
+      ∑ k : Fin data.r, data.dim k := by
+  simpa only [Fintype.card_fin, Fintype.card_sigma] using
+    Fintype.card_congr data.groupedCoordinateEquiv
+
+/-- Exact grouped tensor in the original flattened retained-coordinate space.
+
+The raw block diagonal is ordered by phase class and copy, followed by the inactive complement;
+`groupedCoordinateEquiv` is the explicit permutation into the original retained coordinates.
+
+Source: arXiv:1606.00608, lines 265--301 and 1135--1146; this coordinate form is used
+in Proposition 4.13, lines 1863--1921. -/
+noncomputable def ActiveBNTRefinement.groupedTensor
+    {data : CPSVCanonicalFormData A} (ref : data.ActiveBNTRefinement) :
+    MPSTensor d (∑ k : Fin data.r, data.dim k) := fun i =>
+  Matrix.reindex data.groupedCoordinateEquiv data.groupedCoordinateEquiv
+    (Matrix.blockDiagonal' fun l : Fin data.groupedCount =>
+      ref.groupedWeight l • ref.groupedBlocks l i)
+
+/-- A grouped class/copy coordinate maps to its original active displayed block. -/
+theorem groupedIndexEquiv_inl (data : CPSVCanonicalFormData A)
+    (jq : Σ j : Fin data.activePhaseClasses.g,
+      Fin (data.activePhaseClasses.copies j)) :
+    data.groupedIndexEquiv (Sum.inl jq) = data.activeClassCopyEquiv jq := by
+  rfl
+
+/-- A grouped inactive coordinate maps to its original displayed block. -/
+theorem groupedIndexEquiv_inr (data : CPSVCanonicalFormData A) (k : data.Inactive) :
+    data.groupedIndexEquiv (Sum.inr k) = k := by
+  rfl
+
+/-- The finite position of a grouped coordinate maps to the same original listed block. -/
+theorem groupedListedEquiv_groupedPosition (data : CPSVCanonicalFormData A)
+    (x : data.GroupedIndex) :
+    data.groupedListedEquiv (data.groupedPosition x) = data.groupedIndexEquiv x := by
+  simp [groupedListedEquiv, groupedPosition, groupedEnum]
+
+/-- Locate an active phase-class copy in the original listed block family. -/
+theorem groupedListedEquiv_activeCopy (data : CPSVCanonicalFormData A)
+    (jq : Σ j : Fin data.activePhaseClasses.g,
+      Fin (data.activePhaseClasses.copies j)) :
+    data.groupedListedEquiv (data.groupedPosition (Sum.inl jq)) =
+      data.activeClassCopyEquiv jq := by
+  rw [data.groupedListedEquiv_groupedPosition, data.groupedIndexEquiv_inl]
+
+/-- Locate an inactive complement block in the original listed block family. -/
+theorem groupedListedEquiv_inactive (data : CPSVCanonicalFormData A) (k : data.Inactive) :
+    data.groupedListedEquiv (data.groupedPosition (Sum.inr k)) = k := by
+  rw [data.groupedListedEquiv_groupedPosition, data.groupedIndexEquiv_inr]
+
+/-- The grouped weight at a phase-class copy is its original displayed weight. -/
+theorem ActiveBNTRefinement.groupedWeight_activeCopy
+    {data : CPSVCanonicalFormData A} (ref : data.ActiveBNTRefinement)
+    (jq : Σ j : Fin data.activePhaseClasses.g,
+      Fin (data.activePhaseClasses.copies j)) :
+    ref.groupedWeight (data.groupedPosition (Sum.inl jq)) =
+      data.weights (data.activeClassCopyEquiv jq) := by
+  simp only [ActiveBNTRefinement.groupedWeight]
+  rw [data.groupedListedEquiv_activeCopy]
+
+/-- Inactive grouped weights vanish exactly. -/
+theorem ActiveBNTRefinement.groupedWeight_inactive
+    {data : CPSVCanonicalFormData A} (ref : data.ActiveBNTRefinement) (k : data.Inactive) :
+    ref.groupedWeight (data.groupedPosition (Sum.inr k)) = 0 := by
+  simp only [ActiveBNTRefinement.groupedWeight]
+  rw [data.groupedListedEquiv_inactive]
+  exact not_ne_iff.mp k.property
+
+/-- Exact permutation identity between the in-place regrouped direct sum and the explicit
+class/copy-plus-inactive grouped tensor. -/
+theorem ActiveBNTRefinement.regroupedTensor_eq_groupedTensor
+    {data : CPSVCanonicalFormData A} (ref : data.ActiveBNTRefinement) (i : Fin d) :
+    toTensorFromBlocks (d := d) data.weights ref.regroupedBlocks i = ref.groupedTensor i := by
+  change toTensorFromBlocks (d := d) data.weights ref.regroupedBlocks i =
+    Matrix.reindex (blockIndexCoordinateEquiv data.dim data.groupedListedEquiv)
+      (blockIndexCoordinateEquiv data.dim data.groupedListedEquiv)
+      (Matrix.blockDiagonal' fun l : Fin data.groupedCount =>
+        data.weights (data.groupedListedEquiv l) •
+          ref.regroupedBlocks (data.groupedListedEquiv l) i)
+  exact toTensorFromBlocks_eq_reindex_blockDiagonal_equiv data.weights ref.regroupedBlocks
+    data.groupedListedEquiv i
+
+/-- Exact letterwise class/copy-plus-inactive regrouping. The equation displays both the
+flattened coordinate permutation and the block-diagonal copy gauges.
+
+Source: arXiv:1606.00608, lines 265--301, 1080--1117, and 1135--1146. This is
+the structured input used downstream in Proposition 4.13, lines 1863--1921. -/
+theorem ActiveBNTRefinement.groupedRegroupLetterwise
+    {data : CPSVCanonicalFormData A} (ref : data.ActiveBNTRefinement) (i : Fin d) :
+    toTensorFromBlocks (d := d) data.weights data.blocks i =
+      (globalGaugeOfBlocks ref.listedGauge : Matrix _ _ ℂ) *
+        Matrix.reindex data.groupedCoordinateEquiv data.groupedCoordinateEquiv
+          (Matrix.blockDiagonal' fun l : Fin data.groupedCount =>
+            ref.groupedWeight l • ref.groupedBlocks l i) *
+        (↑((globalGaugeOfBlocks ref.listedGauge)⁻¹) : Matrix _ _ ℂ) := by
+  rw [ref.regroupLetterwise i, ref.regroupedTensor_eq_groupedTensor i]
+  rfl
+
+/-- Exact ambient reconstruction from the explicitly grouped tensor. The rectangular map is
+the original CPSV coisometry, with orientation `U * Uᴴ = 1`.
+
+Source: arXiv:1606.00608, eq. `II_CF1`, lines 237--244; the grouped coordinates follow
+lines 265--301, 1080--1117, and 1135--1146 and are used in Proposition 4.13. -/
+theorem ActiveBNTRefinement.reconstructGrouped
+    {data : CPSVCanonicalFormData A} (ref : data.ActiveBNTRefinement) (i : Fin d) :
+    A i = ref.ambientCoisometryᴴ *
+      ((globalGaugeOfBlocks ref.listedGauge : Matrix _ _ ℂ) * ref.groupedTensor i *
+        (↑((globalGaugeOfBlocks ref.listedGauge)⁻¹) : Matrix _ _ ℂ)) *
+      ref.ambientCoisometry := by
+  rw [ref.reconstructRegrouped i, ref.regroupedTensor_eq_groupedTensor i]
 
 /-- Every literal CPSV canonical-form decomposition has a structured active BNT refinement.
 
@@ -191,7 +359,8 @@ their coordinates is asserted.  Active indices are equivalently enumerated by ph
 copy, and every copy carries its original weight and a unit-phase gauge witness.  The final two
 identities are exact at each physical letter.
 
-Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+Source: arXiv:1606.00608, lines 265--301, 1080--1117, and 1135--1146;
+Proposition 4.13, lines 1863--1921, is the downstream application. -/
 theorem exists_activeBNTRefinement (data : CPSVCanonicalFormData A) :
     Nonempty data.ActiveBNTRefinement := by
   classical
@@ -290,26 +459,26 @@ theorem exists_activeBNTRefinement (data : CPSVCanonicalFormData A) :
     toTensorFromBlocks_eq_globalGaugeOfBlocks_conj data.weights
       regroupedBlocks data.blocks listedGauge hBlocksGauge
   refine ⟨{
-    copy_dim_eq := copyDimEq
-    copy_phase := copyPhase
-    copy_phase_norm := copyPhaseNorm
-    copy_gauge := copyGauge
-    copy_relation := copyRelation
-    copy_weight := copyWeight
-    copy_weight_eq := fun _ => rfl
-    representative_normal := hRepresentativeNormal
-    representatives_not_equiv := hRepresentativesNotEquiv
-    representatives_bnt := hRepresentativesBNT
-    regrouped_blocks := regroupedBlocks
-    listed_gauge := listedGauge
-    regrouped_blocks_active := hRegroupedActive
-    regrouped_blocks_inactive := hRegroupedInactive
-    blocks_eq_listed_gauge_conj := hBlocksGauge
-    regroup_letterwise := hRegroup
-    ambient_coisometry := data.ambient_coisometry
-    ambient_coisometry_eq := rfl
-    ambient_coisometric := data.coisometric
-    reconstruct_regrouped := ?_
+    copyDimEq := copyDimEq
+    copyPhase := copyPhase
+    copyPhaseNorm := copyPhaseNorm
+    copyGauge := copyGauge
+    copyRelation := copyRelation
+    copyWeight := copyWeight
+    copyWeightEq := fun _ => rfl
+    representativeNormal := hRepresentativeNormal
+    representativesNotEquiv := hRepresentativesNotEquiv
+    representativesBNT := hRepresentativesBNT
+    regroupedBlocks := regroupedBlocks
+    listedGauge := listedGauge
+    regroupedBlocksActive := hRegroupedActive
+    regroupedBlocksInactive := hRegroupedInactive
+    blocksEqListedGaugeConj := hBlocksGauge
+    regroupLetterwise := hRegroup
+    ambientCoisometry := data.ambient_coisometry
+    ambientCoisometryEq := rfl
+    ambientCoisometric := data.coisometric
+    reconstructRegrouped := ?_
   }⟩
   intro i
   rw [data.reconstruct i, hRegroup i]
@@ -317,7 +486,8 @@ theorem exists_activeBNTRefinement (data : CPSVCanonicalFormData A) :
 /-- Choose the structured active BNT refinement canonically supplied by
 `exists_activeBNTRefinement`.
 
-Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+Source: arXiv:1606.00608, lines 265--301, 1080--1117, and 1135--1146;
+Proposition 4.13, lines 1863--1921, is the downstream application. -/
 noncomputable def activeBNTRefinement (data : CPSVCanonicalFormData A) :
     data.ActiveBNTRefinement :=
   Classical.choice data.exists_activeBNTRefinement

--- a/TNLean/MPS/SharedInfra/BlockAssembly.lean
+++ b/TNLean/MPS/SharedInfra/BlockAssembly.lean
@@ -31,6 +31,56 @@ noncomputable def toTensorFromBlocks {r : ℕ} {dim : Fin r → ℕ}
   (Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv)
     (Matrix.blockDiagonal' fun k => (μ k) • (A k i))
 
+/-- Flatten the dependent block coordinates after reindexing the block family by an
+equivalence. -/
+noncomputable def blockIndexCoordinateEquiv {r : ℕ} {ι : Type*}
+    (dim : Fin r → ℕ) (e : ι ≃ Fin r) :
+    (Σ k : ι, Fin (dim (e k))) ≃ Fin (∑ k : Fin r, dim k) :=
+  (Equiv.sigmaCongr e (fun _ => Equiv.refl _)).trans finSigmaFinEquiv
+
+/-- Exact letterwise reindexing of a heterogeneous block-diagonal tensor.
+
+The right side is assembled in the `ι` block order and then permuted into the flattened
+coordinates of the original `Fin r` family. Unlike `mpv_toTensorFromBlocks_reindex`, this is
+an equality of matrices at each letter. -/
+theorem toTensorFromBlocks_eq_reindex_blockDiagonal_equiv
+    {r : ℕ} {ι : Type*} [DecidableEq ι]
+    {dim : Fin r → ℕ} (μ : Fin r → ℂ)
+    (A : (k : Fin r) → MPSTensor d (dim k)) (e : ι ≃ Fin r) (i : Fin d) :
+    toTensorFromBlocks (d := d) μ A i =
+      Matrix.reindex (blockIndexCoordinateEquiv dim e) (blockIndexCoordinateEquiv dim e)
+        (Matrix.blockDiagonal' fun k : ι => μ (e k) • A (e k) i) := by
+  classical
+  let se : (Σ k : ι, Fin (dim (e k))) ≃ (Σ k : Fin r, Fin (dim k)) :=
+    Equiv.sigmaCongr e (fun _ => Equiv.refl _)
+  have hrawInv :
+      Matrix.reindex se.symm se.symm
+          (Matrix.blockDiagonal' (fun k : Fin r => μ k • A k i)) =
+        Matrix.blockDiagonal' (fun k : ι => μ (e k) • A (e k) i) := by
+    ext x y
+    rcases x with ⟨kx, x⟩
+    rcases y with ⟨ky, y⟩
+    simp only [Matrix.reindex_apply]
+    dsimp [se]
+    by_cases h : kx = ky
+    · subst ky
+      change Matrix.blockDiagonal' (fun k : Fin r => μ k • A k i)
+        ⟨e kx, x⟩ ⟨e kx, y⟩ = _
+      simp
+    · rw [Matrix.blockDiagonal'_apply_ne _ _ _ h]
+      rw [Matrix.blockDiagonal'_apply_ne]
+      exact fun he => h (e.injective he)
+  have hraw :
+      Matrix.blockDiagonal' (fun k : Fin r => μ k • A k i) =
+        Matrix.reindex se se
+          (Matrix.blockDiagonal' fun k : ι => μ (e k) • A (e k) i) :=
+    (Equiv.symm_apply_eq (Matrix.reindex se se)).mp hrawInv
+  change Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+      (Matrix.blockDiagonal' (fun k : Fin r => μ k • A k i)) = _
+  rw [hraw]
+  ext a b
+  rfl
+
 /-- Word evaluation of `toTensorFromBlocks` is the reindexed block diagonal of
 the component word evaluations, with the scalar weight `μ k` contributing the
 factor `(μ k) ^ w.length` on block `k`. -/

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -177,13 +177,27 @@ single family.
 % Source anchor: CPSV16 Proposition 4.13, lines 1863--1921.
 \begin{theorem}[Structured active BNT refinement of CPSV canonical form]
     \label{thm:cpsv_canonical_form_active_bnt_refinement}
-    \lean{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement}
-    \lean{MPSTensor.CPSVCanonicalFormData.activeClassCopyEquiv}
-    \lean{MPSTensor.CPSVCanonicalFormData.exists_activeBNTRefinement}
+    \lean{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement,
+        MPSTensor.CPSVCanonicalFormData.exists_activeBNTRefinement}
+    \lean{MPSTensor.CPSVCanonicalFormData.activeClassCopyEquiv,
+        MPSTensor.CPSVCanonicalFormData.Inactive,
+        MPSTensor.CPSVCanonicalFormData.GroupedIndex,
+        MPSTensor.CPSVCanonicalFormData.groupedIndexEquiv,
+        MPSTensor.CPSVCanonicalFormData.groupedCoordinateEquiv,
+        MPSTensor.CPSVCanonicalFormData.groupedTotalDim_eq}
+    \lean{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedWeight,
+        MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedBlocks,
+        MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedTensor,
+        MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.regroupedTensor_eq_groupedTensor,
+        MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedRegroupLetterwise,
+        MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.reconstructGrouped}
+    \lean{MPSTensor.blockIndexCoordinateEquiv,
+        MPSTensor.toTensorFromBlocks_eq_reindex_blockDiagonal_equiv}
     \leanok
     \uses{def:cpsv_canonical_form, def:mpv_phase_class_data,
         thm:cpsv_canonical_form_bnt_characterization,
-        thm:cpsv_normal_mpv_phase_gauge, def:global_gauge_of_blocks}
+        thm:cpsv_normal_mpv_phase_gauge, def:block_diagonal_tensor,
+        def:global_gauge_of_blocks}
     Let
     \begin{align}
         A^i&=U^\dagger\left(\bigoplus_{k=1}^{r}\mu_kA_k^i\right)U.
@@ -193,17 +207,21 @@ single family.
         UU^\dagger&=\Id.
         \label{eq:cpsv_active_refinement_coisometry}
     \end{align}
-    be literal CPSV canonical-form data, and put
-    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$. There are phase classes $j$, copy
-    multiplicities $r_j$, and an equivalence
+    be literal CPSV canonical-form data. Put
+    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$ and
+    $K_0=\{k:\mu_k=0\}$. There are phase classes $j$, copy multiplicities
+    $r_j$, and an equivalence
     \begin{align}
-        \{(j,q):1\leq q\leq r_j\}&\simeq K_{\mathrm{act}}.
-        \label{eq:cpsv_active_refinement_equiv}
+        \mathcal G
+        :=\{(j,q):1\leq q\leq r_j\}\sqcup K_0
+        &\simeq\{1,\ldots,r\}.
+        \label{eq:cpsv_active_refinement_grouped_equiv}
     \end{align}
-    Each class has a representative $C_j$. If the copy $(j,q)$ corresponds to
-    $k\in K_{\mathrm{act}}$, then its bond dimension equals that of $C_j$ and
-    there are $\zeta_k\in\C$, with $|\zeta_k|=1$, and
-    $X_k\in\GL_{D_k}(\C)$ such that
+    Its active restriction identifies the class-copy pairs with
+    $K_{\mathrm{act}}$. Each class has a representative $C_j$. If the copy
+    $(j,q)$ corresponds to $k\in K_{\mathrm{act}}$, then its bond dimension
+    equals that of $C_j$ and there are $\zeta_k\in\C$, with $|\zeta_k|=1$,
+    and $X_k\in\GL_{D_k}(\C)$ such that
     \begin{align}
         A_k^i&=\zeta_kX_kC_j^iX_k^{-1}.
         \label{eq:cpsv_active_refinement_copy}
@@ -211,40 +229,58 @@ single family.
     The copy retains the original coefficient $\mu_k$, and the representatives
     $(C_j)_j$ form a basis of normal tensors for $A$.
 
-    Define $B_k^i=\zeta_kC_j^i$ and $Y_k=X_k$ on active indices, while
-    $B_k=A_k$ and $Y_k=\Id$ when $\mu_k=0$. These blocks remain indexed by the
-    original listed coordinate $k$; the class-copy equivalence is recorded
-    separately and is not used to reindex the direct sum. After the dimension
-    identifications in~(\ref{eq:cpsv_active_refinement_copy}), the
-    block-diagonal gauge $G=\bigoplus_kY_k$ satisfies, letter by letter,
+    Enumerate $\mathcal G$. The induced equivalence $\Phi$ between the
+    dependent grouped block coordinates and the original flattened listed
+    coordinates gives
+    \begin{align}
+        \sum_{x\in\mathcal G}D_x&=\sum_{k=1}^{r}D_k.
+        \label{eq:cpsv_active_refinement_total_dim}
+    \end{align}
+    For $x=(j,q)$, let $\widehat\mu_x$ be the original weight of that copy and
+    let $\widehat B_x^i=\zeta_xC_j^i$, with the required dimension
+    identification. For $x\in K_0$, let $\widehat\mu_x=0$ and retain the
+    original block $\widehat B_x=A_x$. Define the grouped tensor by
+    \begin{align}
+        T_{\mathrm{grp}}^i
+        &=\operatorname{reindex}_{\Phi}
+          \left(\bigoplus_{x\in\mathcal G}
+          \widehat\mu_x\widehat B_x^i\right).
+        \label{eq:cpsv_active_refinement_grouped_tensor}
+    \end{align}
+    If $G=\bigoplus_kY_k$ is the block-diagonal gauge, with $Y_k=X_k$ on
+    active indices and $Y_k=\Id$ on $K_0$, then, letter by letter,
     \begin{align}
         \bigoplus_{k=1}^{r}\mu_kA_k^i
-        &=G\left(\bigoplus_{k=1}^{r}\mu_kB_k^i\right)G^{-1},
+        &=GT_{\mathrm{grp}}^iG^{-1},
         \label{eq:cpsv_active_refinement_regroup}
     \end{align}
-    and hence
+    and
     \begin{align}
-        A^i
-        &=U^\dagger G\left(\bigoplus_{k=1}^{r}\mu_kB_k^i\right)G^{-1}U.
+        A^i&=U^\dagger GT_{\mathrm{grp}}^iG^{-1}U.
         \label{eq:cpsv_active_refinement_reconstruction}
     \end{align}
-    Thus the direct sum is conjugated in place on its original listed
-    coordinates. The zero-weight coordinates remain literal zero-weight
-    summands. This result neither deletes them nor gives a class-copy-indexed
-    direct-sum identity or a coisometric selector onto the active coordinates.
+    Thus the class-copy coordinates and the inactive complement are explicit,
+    while every zero-weight listed block remains present. No deletion of the
+    inactive coordinates and no coisometric selector onto the active part is
+    asserted.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:mpv_phase_class_data,
         thm:cpsv_canonical_form_bnt_characterization,
-        thm:cpsv_normal_mpv_phase_gauge, def:global_gauge_of_blocks}
+        thm:cpsv_normal_mpv_phase_gauge, def:block_diagonal_tensor,
+        def:global_gauge_of_blocks}
     Enumerate the active indices by their phase classes and choose one normal
     representative in each class. The normal-tensor phase theorem gives the
     dimension equality, unit phase, and invertible gauge in
     (\ref{eq:cpsv_active_refinement_copy}). The BNT characterization proves
-    that the representatives form a basis of normal tensors. Extend the list
-    by leaving every zero-weight block unchanged and assigning it the identity
-    gauge. Block-diagonal conjugation on the original listed coordinates gives
+    that the representatives form a basis of normal tensors. Adjoin the
+    inactive complement to the class-copy order. Reindexing the dependent block
+    coordinates gives $\Phi$ and
+    (\ref{eq:cpsv_active_refinement_total_dim}). The exact heterogeneous
+    block-diagonal reindexing identity identifies the grouped tensor with the
+    representative copies in the original retained-coordinate space.
+    Block-diagonal conjugation then gives
     (\ref{eq:cpsv_active_refinement_regroup}); substitution into
     (\ref{eq:cpsv_active_refinement_original}) gives
     (\ref{eq:cpsv_active_refinement_reconstruction}) with the original

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -174,6 +174,83 @@ single family.
     basis-of-normal-tensors conditions.
 \end{proof}
 
+% Source anchor: CPSV16 Proposition 4.13, lines 1863--1921.
+\begin{theorem}[Structured active BNT refinement of CPSV canonical form]
+    \label{thm:cpsv_canonical_form_active_bnt_refinement}
+    \lean{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement}
+    \lean{MPSTensor.CPSVCanonicalFormData.activeClassCopyEquiv}
+    \lean{MPSTensor.CPSVCanonicalFormData.exists_activeBNTRefinement}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:mpv_phase_class_data,
+        thm:cpsv_canonical_form_bnt_characterization,
+        thm:cpsv_normal_mpv_phase_gauge, def:global_gauge_of_blocks}
+    Let
+    \begin{align}
+        A^i&=U^\dagger\left(\bigoplus_{k=1}^{r}\mu_kA_k^i\right)U.
+        \label{eq:cpsv_active_refinement_original}
+    \end{align}
+    \begin{align}
+        UU^\dagger&=\Id.
+        \label{eq:cpsv_active_refinement_coisometry}
+    \end{align}
+    be literal CPSV canonical-form data, and put
+    $K_{\mathrm{act}}=\{k:\mu_k\ne0\}$. There are phase classes $j$, copy
+    multiplicities $r_j$, and an equivalence
+    \begin{align}
+        \{(j,q):1\leq q\leq r_j\}&\simeq K_{\mathrm{act}}.
+        \label{eq:cpsv_active_refinement_equiv}
+    \end{align}
+    Each class has a representative $C_j$. If the copy $(j,q)$ corresponds to
+    $k\in K_{\mathrm{act}}$, then its bond dimension equals that of $C_j$ and
+    there are $\zeta_k\in\C$, with $|\zeta_k|=1$, and
+    $X_k\in\GL_{D_k}(\C)$ such that
+    \begin{align}
+        A_k^i&=\zeta_kX_kC_j^iX_k^{-1}.
+        \label{eq:cpsv_active_refinement_copy}
+    \end{align}
+    The copy retains the original coefficient $\mu_k$, and the representatives
+    $(C_j)_j$ form a basis of normal tensors for $A$.
+
+    Define $B_k^i=\zeta_kC_j^i$ and $Y_k=X_k$ on active indices, while
+    $B_k=A_k$ and $Y_k=\Id$ when $\mu_k=0$. These blocks remain indexed by the
+    original listed coordinate $k$; the class-copy equivalence is recorded
+    separately and is not used to reindex the direct sum. After the dimension
+    identifications in~(\ref{eq:cpsv_active_refinement_copy}), the
+    block-diagonal gauge $G=\bigoplus_kY_k$ satisfies, letter by letter,
+    \begin{align}
+        \bigoplus_{k=1}^{r}\mu_kA_k^i
+        &=G\left(\bigoplus_{k=1}^{r}\mu_kB_k^i\right)G^{-1},
+        \label{eq:cpsv_active_refinement_regroup}
+    \end{align}
+    and hence
+    \begin{align}
+        A^i
+        &=U^\dagger G\left(\bigoplus_{k=1}^{r}\mu_kB_k^i\right)G^{-1}U.
+        \label{eq:cpsv_active_refinement_reconstruction}
+    \end{align}
+    Thus the direct sum is conjugated in place on its original listed
+    coordinates. The zero-weight coordinates remain literal zero-weight
+    summands. This result neither deletes them nor gives a class-copy-indexed
+    direct-sum identity or a coisometric selector onto the active coordinates.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpv_phase_class_data,
+        thm:cpsv_canonical_form_bnt_characterization,
+        thm:cpsv_normal_mpv_phase_gauge, def:global_gauge_of_blocks}
+    Enumerate the active indices by their phase classes and choose one normal
+    representative in each class. The normal-tensor phase theorem gives the
+    dimension equality, unit phase, and invertible gauge in
+    (\ref{eq:cpsv_active_refinement_copy}). The BNT characterization proves
+    that the representatives form a basis of normal tensors. Extend the list
+    by leaving every zero-weight block unchanged and assigning it the identity
+    gauge. Block-diagonal conjugation on the original listed coordinates gives
+    (\ref{eq:cpsv_active_refinement_regroup}); substitution into
+    (\ref{eq:cpsv_active_refinement_original}) gives
+    (\ref{eq:cpsv_active_refinement_reconstruction}) with the original
+    coisometry $U$.
+\end{proof}
+
 \begin{definition}[BNT canonical form]%
     \label{def:sector_bnt_cf}
     \lean{MPSTensor.IsBNTCanonicalForm}

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -174,7 +174,8 @@ single family.
     basis-of-normal-tensors conditions.
 \end{proof}
 
-% Source anchor: CPSV16 Proposition 4.13, lines 1863--1921.
+% Source anchors: CPSV16 lines 265--301, 1080--1117, and 1135--1146.
+% Proposition 4.13, lines 1863--1921, is the downstream application.
 \begin{theorem}[Structured active BNT refinement of CPSV canonical form]
     \label{thm:cpsv_canonical_form_active_bnt_refinement}
     \lean{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement,

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -729,33 +729,33 @@
     canonical-form data. The active listed indices are identified with pairs
     $(\alpha,k)$ consisting of a phase class and a copy, and every active copy
     retains its original nonzero coefficient $\nu_{\alpha,k}$, its bond
-    dimension, a unit phase, and an invertible gauge
-    $X_{\alpha,k}$. The chosen tensors $C_\alpha$ form a basis of normal
-    tensors. On the original listed coordinate space, including every
-    zero-weight coordinate, there are blocks $B_\ell$, still indexed by the
-    original $\ell$. There are also a block-diagonal gauge $G$ and the
-    original coisometry $V$ such that
+    dimension, a unit phase, and an invertible gauge $X_{\alpha,k}$. The
+    chosen tensors $C_\alpha$ form a basis of normal tensors. Adjoin the
+    inactive zero-weight indices to these pairs and call the resulting grouped
+    index set $\mathcal G$. There is an explicit equivalence from the dependent
+    coordinates of $\mathcal G$ to the original flattened listed coordinates.
+    If $T_{\mathrm{grp}}$ is the grouped direct sum, reindexed along this
+    equivalence, then there are a block-diagonal gauge $G$ and the original
+    coisometry $V$ such that
     \begin{align}
         \bigoplus_\ell\mu_\ell A_\ell^i
-        &=G\left(\bigoplus_\ell\mu_\ell B_\ell^i\right)G^{-1},
+        &=GT_{\mathrm{grp}}^iG^{-1},
         \label{eq:cpsv_prop_4_13_active_bnt}
     \end{align}
     and
     \begin{align}
-        A^i
-        &=V^\dagger G\left(\bigoplus_\ell\mu_\ell B_\ell^i\right)G^{-1}V.
+        A^i&=V^\dagger GT_{\mathrm{grp}}^iG^{-1}V.
         \label{eq:cpsv_prop_4_13_active_reconstruction}
     \end{align}
     \begin{align}
         VV^\dagger&=\Id.
         \label{eq:cpsv_prop_4_13_original_coisometry}
     \end{align}
-    For the active index corresponding to $(\alpha,k)$,
-    $B_\ell^i=\zeta_{\alpha,k}C_\alpha^i$ with
-    $|\zeta_{\alpha,k}|=1$; for an inactive index, $\mu_\ell=0$ and
-    $B_\ell=A_\ell$. This is an in-place conjugation, not yet an exact
-    direct sum reindexed by the class-copy pairs. No active-coordinate deletion
-    or selecting coisometry is part of the proved refinement.
+    The active summands of $T_{\mathrm{grp}}$ are
+    $\nu_{\alpha,k}\zeta_{\alpha,k}C_\alpha^i$, with
+    $|\zeta_{\alpha,k}|=1$. Every inactive summand is the original listed block
+    with coefficient zero. Thus the grouped coordinates are exact without
+    deleting the inactive complement or introducing a selecting coisometry.
 
     Let $H^{(N)}$ be the positive operator generated horizontally by
     $\widetilde M$. If
@@ -770,11 +770,9 @@
         \label{eq:cpsv_prop_4_13_first_site}
     \end{align}
     Write $Y_R(P)$ and $Y_C(P)$ for the right and central first-site
-    contractions determined by $P$. The active class-copy equivalence and the
-    in-place conjugation above are now formalized. One must still turn them into
-    an exact class-copy-coordinate direct sum and then prove the
-    representative-grouped form of Lemma~L on the retained coordinates, giving,
-    for every $\alpha$ and $i$,
+    contractions determined by $P$. The exact grouped-coordinate direct sum is
+    now formalized. The next missing step is the representative-grouped form of
+    Lemma~L on these retained coordinates, giving, for every $\alpha$ and $i$,
     \begin{align}
         Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i.
         \label{eq:cpsv_prop_4_13_missing_active_separation}
@@ -858,10 +856,10 @@
 
 % Formalization status: the theorem above remains \notready. The theorem below
 % proves the same conclusion from the stronger normalized BNT-refined horizontal
-% form. For literal canonical form, the active class-copy equivalence and
-% in-place conjugation are complete. Explicit class-copy-coordinate regrouping,
-% retained-coordinate Lemma L separation, and passage through the listed gauge
-% and ambient coisometry into the vertical tensor remain open.
+% form. For literal canonical form, the exact class-copy-plus-inactive
+% coordinate regrouping is complete. Retained-coordinate Lemma L separation and
+% passage through the listed gauge and ambient coisometry into the vertical
+% tensor remain open.
 
 \begin{theorem}[BNT-refined horizontal form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -709,7 +709,7 @@
 \end{theorem}
 
 \begin{proof}[Proof outline]
-    \uses{thm:cpsv_canonical_form_bnt_existence,
+    \uses{thm:cpsv_canonical_form_active_bnt_refinement,
         thm:representative_grouped_insert_eq,
         thm:projector_closure_irreducible_corners,
         thm:mpdo_no_periodic_sector_projector,
@@ -724,22 +724,38 @@
         thm:vertical_sector_coisometry}
     Write $A$ for the doubled-index MPS tensor of $M$. If $A=0$, take no
     retained sectors; the unique map onto the zero-dimensional sector space
-    gives the conclusion. Suppose henceforth that $A\ne0$. Begin with its
-    literal canonical-form decomposition and discard the blocks with zero
-    coefficient. Partition the remaining normal blocks by gauge-phase
-    equivalence, and choose one representative $C_\alpha$ in each class. The
-    resulting coefficients $\nu_{\alpha,k}$ are nonzero. Thus there are an
-    active tensor $C$ and a coisometry $V$ such that
+    gives the conclusion. Suppose henceforth that $A\ne0$. Apply
+    Theorem~\ref{thm:cpsv_canonical_form_active_bnt_refinement} to its literal
+    canonical-form data. The active listed indices are identified with pairs
+    $(\alpha,k)$ consisting of a phase class and a copy, and every active copy
+    retains its original nonzero coefficient $\nu_{\alpha,k}$, its bond
+    dimension, a unit phase, and an invertible gauge
+    $X_{\alpha,k}$. The chosen tensors $C_\alpha$ form a basis of normal
+    tensors. On the original listed coordinate space, including every
+    zero-weight coordinate, there are blocks $B_\ell$, still indexed by the
+    original $\ell$. There are also a block-diagonal gauge $G$ and the
+    original coisometry $V$ such that
     \begin{align}
-        C^i
-        &=\bigoplus_{\alpha,k}
-          \nu_{\alpha,k}X_{\alpha,k}C_\alpha^iX_{\alpha,k}^{-1},
+        \bigoplus_\ell\mu_\ell A_\ell^i
+        &=G\left(\bigoplus_\ell\mu_\ell B_\ell^i\right)G^{-1},
         \label{eq:cpsv_prop_4_13_active_bnt}
     \end{align}
-    and $A^i=V^\dagger C^iV$. The tensors $C_\alpha$ form the basis of
-    normal tensors associated with the active canonical form. This refinement,
-    including omission of all zero-weight blocks, follows from the literal
-    hypothesis; it does not assume normalized BNT-refined horizontal form.
+    and
+    \begin{align}
+        A^i
+        &=V^\dagger G\left(\bigoplus_\ell\mu_\ell B_\ell^i\right)G^{-1}V.
+        \label{eq:cpsv_prop_4_13_active_reconstruction}
+    \end{align}
+    \begin{align}
+        VV^\dagger&=\Id.
+        \label{eq:cpsv_prop_4_13_original_coisometry}
+    \end{align}
+    For the active index corresponding to $(\alpha,k)$,
+    $B_\ell^i=\zeta_{\alpha,k}C_\alpha^i$ with
+    $|\zeta_{\alpha,k}|=1$; for an inactive index, $\mu_\ell=0$ and
+    $B_\ell=A_\ell$. This is an in-place conjugation, not yet an exact
+    direct sum reindexed by the class-copy pairs. No active-coordinate deletion
+    or selecting coisometry is part of the proved refinement.
 
     Let $H^{(N)}$ be the positive operator generated horizontally by
     $\widetilde M$. If
@@ -754,20 +770,25 @@
         \label{eq:cpsv_prop_4_13_first_site}
     \end{align}
     Write $Y_R(P)$ and $Y_C(P)$ for the right and central first-site
-    contractions determined by $P$. The missing step is to prove that the
-    representative-grouped Lemma~L remains applicable after compression to
-    (\ref{eq:cpsv_prop_4_13_active_bnt}), so that, for every $\alpha$ and $i$,
+    contractions determined by $P$. The active class-copy equivalence and the
+    in-place conjugation above are now formalized. One must still turn them into
+    an exact class-copy-coordinate direct sum and then prove the
+    representative-grouped form of Lemma~L on the retained coordinates, giving,
+    for every $\alpha$ and $i$,
     \begin{align}
         Y_R(P)C_\alpha^i&=Y_C(P)C_\alpha^i.
         \label{eq:cpsv_prop_4_13_missing_active_separation}
     \end{align}
-    This identity must then be carried back through the ambient coisometry $V$
-    to obtain
+    This identity must then be carried through the listed block gauge and the
+    ambient coisometry $V$ into the vertically viewed tensor, to obtain
     \begin{align}
         \widetilde MP&=P\widetilde MP.
         \label{eq:cpsv_prop_4_13_missing_coisometry_transport}
     \end{align}
-    Once these two implications are established,
+    If a later argument instead removes the zero-weight coordinates, it must
+    also construct an explicit coisometric selector and prove the corresponding
+    reconstruction identity. Once the retained-coordinate Lemma~L statement
+    and the passage to $\widetilde M$ are established,
     $(\Id-P)\widetilde MP=0$. Thus every one-sided invariant subspace is
     reducing.
 
@@ -837,8 +858,10 @@
 
 % Formalization status: the theorem above remains \notready. The theorem below
 % proves the same conclusion from the stronger normalized BNT-refined horizontal
-% form. For literal canonical form, the missing step is Lemma L separation after
-% passage to the active decomposition and back through the ambient coisometry.
+% form. For literal canonical form, the active class-copy equivalence and
+% in-place conjugation are complete. Explicit class-copy-coordinate regrouping,
+% retained-coordinate Lemma L separation, and passage through the listed gauge
+% and ambient coisometry into the vertical tensor remain open.
 
 \begin{theorem}[BNT-refined horizontal form implies vertical canonical form]
     \label{thm:vertical_cf_of_horizontal_cf}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -268,50 +268,74 @@ Proposition~4.13, so the literal theorem remains open.  The proved restricted
 result follows the grouped vertical sectors used in the paper and does not use
 the unsupported diagonal-restriction statement from \ghissue{2537}.
 
-A first part of the preparatory dependency for eliminating the stronger
-hypothesis is now formalized.  The structure
-\path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement} and its constructor
-\path{MPSTensor.CPSVCanonicalFormData.exists_activeBNTRefinement} retain an
-explicit equivalence between phase-class copies and the original nonzero-weight
-listed blocks.  Every active copy keeps its original coefficient and bond
-dimension, together with a unit phase, an invertible gauge, and the exact
-letterwise gauge-phase relation to its representative.  The representatives
-form a CPSV basis of normal tensors.
+The preparatory dependency tracked by \ghissue{4956} is now complete.  The
+structure \path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement} and its
+constructor \path{MPSTensor.CPSVCanonicalFormData.exists_activeBNTRefinement}
+retain an explicit equivalence between phase-class copies and the original
+nonzero-weight listed blocks.  Every active copy keeps its original coefficient
+and bond dimension, together with a unit phase, an invertible gauge, and the
+exact letterwise gauge-phase relation to its representative.  The
+representatives form a CPSV basis of normal tensors.
 
-The construction does not delete the zero-weight listed coordinates.  It leaves
-them as literal zero-weight summands and assigns them the identity block gauge.
-The replacement blocks remain indexed by the original listed coordinate $k$;
-the explicit class-copy equivalence is stored separately.  If $G$ is the
-resulting block-diagonal gauge, it proves, for every letter $i$,
+The final API adjoins the inactive complement
+\path{MPSTensor.CPSVCanonicalFormData.Inactive} to the active class-copy pairs
+in \path{MPSTensor.CPSVCanonicalFormData.GroupedIndex}.  The equivalence
+\path{MPSTensor.CPSVCanonicalFormData.groupedIndexEquiv} identifies this grouped
+order with the original listed blocks.  The flattened dependent coordinates are
+identified with the original retained coordinates by
+\path{MPSTensor.CPSVCanonicalFormData.groupedCoordinateEquiv}; the theorem
+\path{MPSTensor.CPSVCanonicalFormData.groupedTotalDim_eq} records the resulting
+total-dimension equality.  The underlying reusable statements are
+\path{MPSTensor.blockIndexCoordinateEquiv} and
+\path{MPSTensor.toTensorFromBlocks_eq_reindex_blockDiagonal_equiv}.
+
+For grouped index $x$, let $\widehat\mu_x$ and $\widehat B_x$ denote the weight
+and block supplied by
+\path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedWeight} and
+\path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedBlocks}.  An
+active $x=(\alpha,k)$ carries the original nonzero copy weight and the
+corresponding phase multiple of $C_\alpha$.  An inactive $x$ carries weight zero
+and the original listed block.  If $\Phi$ is the flattened coordinate
+equivalence, the grouped tensor is
 \begin{equation}
-  \bigoplus_k\mu_kA_k^i
-  =G\left(\bigoplus_k\mu_kB_k^i\right)G^{-1},
+  T_{\mathrm{grp}}^i
+  =\operatorname{reindex}_{\Phi}
+    \left(\bigoplus_x\widehat\mu_x\widehat B_x^i\right).
+  \label{eq:completed-grouped-tensor}
+\end{equation}
+This is \path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedTensor}.
+It retains every zero-weight listed coordinate; no active-coordinate deletion
+or selecting coisometry is asserted.
+
+If $G$ is the block-diagonal gauge on the original listed blocks, then
+\path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.groupedRegroupLetterwise}
+proves, for every letter $i$,
+\begin{equation}
+  \bigoplus_k\mu_kA_k^i=GT_{\mathrm{grp}}^iG^{-1}.
   \label{eq:completed-active-regrouping}
 \end{equation}
-and, using the original ambient coisometry $U$ with $UU^\dagger=I$,
+The intermediate identity
+\path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.regroupedTensor_eq_groupedTensor}
+identifies the earlier in-place representative tensor with the explicit grouped
+tensor.  Finally,
+\path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement.reconstructGrouped}
+uses the original ambient coisometry $U$, with $UU^\dagger=I$, to give
 \begin{equation}
-  A^i
-  =U^\dagger G\left(\bigoplus_k\mu_kB_k^i\right)G^{-1}U.
+  A^i=U^\dagger GT_{\mathrm{grp}}^iG^{-1}U.
   \label{eq:completed-active-reconstruction}
 \end{equation}
-Thus the in-place listed direct-sum conjugation and the ambient reconstruction
-are exact letterwise identities.  The present API does not yet state the direct
-sum on explicit class-copy coordinates, and it claims no selector onto the
-active coordinates.
+Thus the class-copy-plus-inactive coordinates, the dependent coordinate
+permutation, the letterwise block-gauge conjugation, and the ambient
+reconstruction are all explicit and exact.
 
-Issue~\ghissue{4956} and literal Proposition~4.13 remain open.  The next
-preparatory result must combine the stored equivalence with the in-place
-identity to produce an exact class-copy-coordinate direct sum.  The subsequent
-missing result is the representative-grouped form of Lemma~L on the retained
-coordinates, followed by the argument carrying that identity through the block
-gauge and the ambient coisometry into the vertically viewed tensor.  If a later
-proof removes the inactive coordinates, it must additionally construct an
-explicit coisometric selector and prove its reconstruction identity.  Once this
-boundary is crossed, the invariant-projector argument, periodic-sector
-exclusion, positivity of the vertical multiplicities, grouped Gram
-normalization, and final coisometric reconstruction can be replayed without
-assuming \path{MPOTensor.IsHorizontalCF}.
-
+Literal Proposition~4.13 remains open.  The next missing result is the
+representative-grouped form of Lemma~L on the retained coordinates, followed by
+the argument carrying that identity through the listed gauge and the ambient
+coisometry into the vertically viewed tensor.  Once this boundary is crossed,
+the invariant-projector argument, periodic-sector exclusion, positivity of the
+vertical multiplicities, grouped Gram normalization, and final coisometric
+reconstruction can be replayed without assuming
+\path{MPOTensor.IsHorizontalCF}.
 \bibliographystyle{alpha}
 \bibliography{references}
 

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -268,21 +268,49 @@ Proposition~4.13, so the literal theorem remains open.  The proved restricted
 result follows the grouped vertical sectors used in the paper and does not use
 the unsupported diagonal-restriction statement from \ghissue{2537}.
 
-To eliminate the stronger hypothesis, first use
-\path{MPSTensor.CPSVCanonicalFormData.exists_isCPSVBasisOfNormalTensors} to
-obtain the active BNT representatives.  That theorem does not retain the
-active-index equivalence, the copy weights and gauges, or the ambient
-coisometry.  One must therefore strengthen its conclusion to a structured
-active-refinement witness carrying those data and the exact reconstruction.
-The missing lemma must then establish the Lemma~L first-site insertion
-separation on the retained coordinates and carry the separated identity back
-through the coisometry.  With that statement in place, the invariant-projector
-argument, periodic-sector exclusion, positivity of the vertical
-multiplicities, grouped Gram normalization, and final coisometric
-reconstruction can be replayed without assuming
-\path{MPOTensor.IsHorizontalCF}.  This yields
-the literal Proposition~4.13 theorem rather than an adapter through the
-stronger predicate.
+A first part of the preparatory dependency for eliminating the stronger
+hypothesis is now formalized.  The structure
+\path{MPSTensor.CPSVCanonicalFormData.ActiveBNTRefinement} and its constructor
+\path{MPSTensor.CPSVCanonicalFormData.exists_activeBNTRefinement} retain an
+explicit equivalence between phase-class copies and the original nonzero-weight
+listed blocks.  Every active copy keeps its original coefficient and bond
+dimension, together with a unit phase, an invertible gauge, and the exact
+letterwise gauge-phase relation to its representative.  The representatives
+form a CPSV basis of normal tensors.
+
+The construction does not delete the zero-weight listed coordinates.  It leaves
+them as literal zero-weight summands and assigns them the identity block gauge.
+The replacement blocks remain indexed by the original listed coordinate $k$;
+the explicit class-copy equivalence is stored separately.  If $G$ is the
+resulting block-diagonal gauge, it proves, for every letter $i$,
+\begin{equation}
+  \bigoplus_k\mu_kA_k^i
+  =G\left(\bigoplus_k\mu_kB_k^i\right)G^{-1},
+  \label{eq:completed-active-regrouping}
+\end{equation}
+and, using the original ambient coisometry $U$ with $UU^\dagger=I$,
+\begin{equation}
+  A^i
+  =U^\dagger G\left(\bigoplus_k\mu_kB_k^i\right)G^{-1}U.
+  \label{eq:completed-active-reconstruction}
+\end{equation}
+Thus the in-place listed direct-sum conjugation and the ambient reconstruction
+are exact letterwise identities.  The present API does not yet state the direct
+sum on explicit class-copy coordinates, and it claims no selector onto the
+active coordinates.
+
+Issue~\ghissue{4956} and literal Proposition~4.13 remain open.  The next
+preparatory result must combine the stored equivalence with the in-place
+identity to produce an exact class-copy-coordinate direct sum.  The subsequent
+missing result is the representative-grouped form of Lemma~L on the retained
+coordinates, followed by the argument carrying that identity through the block
+gauge and the ambient coisometry into the vertically viewed tensor.  If a later
+proof removes the inactive coordinates, it must additionally construct an
+explicit coisometric selector and prove its reconstruction identity.  Once this
+boundary is crossed, the invariant-projector argument, periodic-sector
+exclusion, positivity of the vertical multiplicities, grouped Gram
+normalization, and final coisometric reconstruction can be replayed without
+assuming \path{MPOTensor.IsHorizontalCF}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What changed

- bundle a structured refinement of literal `CPSVCanonicalFormData` that retains the equivalence between nonzero-weight listed blocks and phase-class/copy indices;
- retain every active copy's original weight, dimension equality, unit phase, and invertible gauge with an exact letterwise gauge-phase identity to its normal representative;
- include the inactive zero-weight complement explicitly rather than deleting its coordinates;
- lift the block-index equivalence to flattened dependent coordinates and prove an exact letterwise reindexing theorem for heterogeneous block direct sums;
- prove the exact grouped-coordinate identity
  $$
  \bigoplus_k \mu_k A_k^i
  =
  G\,\operatorname{reindex}_{E}
  \left(\bigoplus_l \widetilde\mu_l\widetilde B_l^i\right)G^{-1},
  $$
  and reconstruct the original tensor through the original ambient coisometry $U$, with $UU^\dagger=I$;
- synchronize the BNT and Proposition 4.13 blueprint nodes and the vertical-grouping paper-gap note.

This closes the structured active-refinement dependency identified after PR #4945. It does **not** claim that the gauges are unitary, delete inactive coordinates, or prove literal Proposition 4.13. The next mathematical step is representative-grouped Lemma L on these retained coordinates, followed by transport through the listed gauge and ambient coisometry into the vertically viewed tensor.

## Validation

- `lake build TNLean.MPS.SharedInfra.BlockAssembly` — passed
- `lake build TNLean.MPS.CanonicalForm.ActiveBNTRefinement` — passed
- `lake build TNLean.MPS.CanonicalForm` — passed
- `lake build TNLean` — passed (9757 jobs)
- full-file lint for both changed Lean modules — 0 errors across all 14 enabled linters
- oversized-module policy and generated import-aggregator checks — passed (1052 production modules)
- fresh blueprint generation and CI-style synchronization — passed
- `leanblueprint checkdecls` — passed
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'` — passed (750 pages, zero undefined cross-references)
- `git diff --check`, proof-integrity, and line-length scans — passed
- independent mathematical/API review approved the explicit grouped coordinates, gauge/reindexing direction, inactive complement, and coisometry reconstruction after one correction round

Closes #4956. Advances #2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal API (~560 lines) in core MPS canonical-form theory; proofs are additive and documentation-aligned, but mistakes in gauge/coordinate conventions would affect downstream Proposition 4.13 work.
> 
> **Overview**
> Introduces formal **active BNT refinement** data for literal `CPSVCanonicalFormData`: nonzero blocks are tied to MPV phase-class copies with original weights, unit phases, and invertible gauges to normal representatives, while **zero-weight listed blocks stay as inactive summands** (no coordinate deletion or active-only coisometry).
> 
> A new module `ActiveBNTRefinement.lean` defines `ActiveBNTRefinement`, grouped indices (`GroupedIndex`, `groupedIndexEquiv`, `groupedCoordinateEquiv`), and proves **letterwise** identities: block-gauge regrouping, grouped tensor vs in-place regrouping, and reconstruction through the **original** ambient coisometry. `exists_activeBNTRefinement` constructs a witness from existing phase-class and BNT characterization inputs.
> 
> `BlockAssembly.lean` gains `blockIndexCoordinateEquiv` and `toTensorFromBlocks_eq_reindex_blockDiagonal_equiv` for exact heterogeneous block-diagonal reindexing at each physical letter.
> 
> Blueprint **Theorem (structured active BNT refinement)** and the Proposition 4.13 proof outline are updated to use this API; the vertical grouping paper-gap note marks issue #4956 complete and states the next open step is representative-grouped Lemma L on retained coordinates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7da3fe204855ddc362c5081cef773f781c4134e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->