### PR TITLE
doc(blueprint): split range-corner dependency

### DIFF
--- a/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
+++ b/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
@@ -86,12 +86,13 @@ matching between normal blocks.
     \label{thm:cpsv_normal_nonzero_letter}
     \lean{MPSTensor.IsNormalTensor.exists_apply_ne_zero}
     \leanok
-    \uses{def:nt_cpsv, def:transfer_map}
+    \uses{def:nt_cpsv}
     Let $A$ be a CPSV normal tensor of positive bond dimension. Then
     $A^i\ne 0$ for some physical letter $i$.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:transfer_map}
     If every letter vanished, then the transfer map would vanish and its
     spectral radius would be zero, contradicting the spectral-radius-one
     normalization of a CPSV normal tensor.

--- a/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
+++ b/blueprint/src/chapter/ch10_bnt_normal_blocks_and_overlap.tex
@@ -82,9 +82,23 @@ matching between normal blocks.
     assumed limit.
 \end{proof}
 
+\begin{theorem}[A normal tensor has a nonzero letter]
+    \label{thm:cpsv_normal_nonzero_letter}
+    \lean{MPSTensor.IsNormalTensor.exists_apply_ne_zero}
+    \leanok
+    \uses{def:nt_cpsv, def:transfer_map}
+    Let $A$ be a CPSV normal tensor of positive bond dimension. Then
+    $A^i\ne 0$ for some physical letter $i$.
+\end{theorem}
+
+\begin{proof}\leanok
+    If every letter vanished, then the transfer map would vanish and its
+    spectral radius would be zero, contradicting the spectral-radius-one
+    normalization of a CPSV normal tensor.
+\end{proof}
+
 \begin{theorem}[Phase-equivalent normal tensors are gauge-phase equivalent]
     \label{thm:cpsv_normal_mpv_phase_gauge}
-    \lean{MPSTensor.IsNormalTensor.exists_apply_ne_zero}
     \lean{MPSTensor.IsNormalTensor.selfOverlap_tendsto_one}
     \lean{MPSTensor.isNormalTensor_cast_iff}
     \lean{MPSTensor.norm_eq_one_of_gaugePhase_cast_of_isNormalTensor}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -208,10 +208,44 @@
     (\ref{eq:cpsv_literal_sector_compression_separation}).
 \end{proof}
 
+\begin{theorem}[A gauge corner gives a nonzero range-projector corner]
+    \label{thm:mpdo_range_projection_corner_nonzero}
+    \lean{MPOTensor.exists_rangeProjection_corner_ne_zero}
+    \leanok
+    \uses{def:nt_cpsv, def:vertical_tensor_mpdo}
+    Let $M$ be an MPO tensor of physical dimension $d$ and bond dimension
+    $D$. Let $A$ be a CPSV normal tensor of positive bond dimension $n$ and
+    physical dimension $D^2$, let $V\in\C^{d\times n}$ be an isometry, let
+    $X\in\C^{n\times n}$ be invertible, and let $\omega$ be nonzero. Suppose
+    that, for every vertical letter $v$,
+    \begin{align}
+        \omega X A_v X^{-1}
+        &=V^\dagger\widetilde M_vV.
+        \label{eq:mpdo_gauge_corner}
+    \end{align}
+    Then the range projector $VV^\dagger$ has a nonzero vertical corner:
+    \begin{align}
+        (VV^\dagger)\widetilde M_v(VV^\dagger)&\ne 0
+        \label{eq:mpdo_range_projector_corner}
+    \end{align}
+    for some $v$.
+    This is the algebraic nonvanishing step used in
+    \cite[Proposition~4.13, line 1898]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_normal_nonzero_letter}
+    Normality supplies a letter $v$ for which $A_v\ne 0$. Since $\omega$ is
+    nonzero and $X$ is invertible, the left-hand side of
+    (\ref{eq:mpdo_gauge_corner}) is nonzero. If
+    (\ref{eq:mpdo_range_projector_corner}) vanished, multiplying it by
+    $V^\dagger$ and $V$ and using $V^\dagger V=1$ would contradict
+    (\ref{eq:mpdo_gauge_corner}).
+\end{proof}
+
 \begin{theorem}[A nonzero vertical corner has a nonzero sector compression]
     \label{thm:mpdo_grouped_sector_compression_nonzero}
     \lean{MPOTensor.IsHorizontalCF.exists_sectorCompression_ne_zero_of_corner}
-    \lean{MPOTensor.exists_rangeProjection_corner_ne_zero}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo_vertical_loops,
         def:vertical_tensor_mpdo, thm:representative_one_sub_mp_zero,
@@ -220,12 +254,6 @@
     matrix for which
     $P\widetilde M_vP$ is nonzero for some vertical letter $v$. Then the
     first-site compression $P_1H^{(N+1)}P_1$ is nonzero for some $N$.
-    Under the same normalized BNT-refined horizontal-form hypothesis, suppose
-    in addition
-    that $A$ is a normal tensor, $V$ is an isometry, and the compression by
-    $V$ is a nonzero scalar multiple of an invertible conjugate of $A$. Then
-    the range projector $VV^\dagger$ has a nonzero vertical corner and hence a
-    nonzero first-site compression.
     This is the separation step used in
     \cite[Proposition~4.13, line 1898]{Cirac2016MPDO_arXiv}.
 
@@ -240,11 +268,6 @@
     first-site insertion by $P$ has the same matrix product vectors as zero.
     Lemma~L on the normalized BNT-refined horizontal form would then force the
     inserted tensor itself to vanish, contrary to the assumed nonzero corner.
-    For the range-projector specialization, normality supplies a nonzero
-    letter of $A$. A nonzero scalar and an invertible conjugation preserve
-    this letter. If every $VV^\dagger$ corner vanished, compressing by
-    $V^\dagger$ and $V$ and using $V^\dagger V=1$ would contradict the exact
-    gauge-corner identity.
 \end{proof}
 
 \begin{theorem}[The sector trace identity]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_vertical_direct_sums.tex
@@ -514,6 +514,7 @@
     \uses{thm:mpdo_literal_normal_vertical_corners,
         thm:cpsv_normal_mpv_phase_gauge,
         thm:cpsv_normal_separated_eventually_li,
+        thm:mpdo_range_projection_corner_nonzero,
         thm:cpsv_literal_sector_compression_nonzero,
         def:mpdo_sector_projector, thm:mpdo_sector_weight_pos}
     Take one representative from each phase class.


### PR DESCRIPTION
Closes #4982.

Follow-up to the exact-head Codex review on #4979.

- gives `MPOTensor.exists_rangeProjection_corner_ne_zero` its own faithful Blueprint theorem
- separates the unrelated normal-tensor nonzero-letter helper from the gauge-phase entry
- records both the generic range-corner and literal sector-separation edges in the vertical grouping proof
- narrows the stronger horizontal-CF separation entry to its actual Lean declaration

Validation:
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `cd blueprint && leanblueprint checkdecls`

No Lean source changed and no Lean rebuild was run. Local `leanblueprint web` is unavailable in this worktree because its Python package environment is incomplete; exact-head Blueprint CI will provide the render gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Blueprint–Lean sync only; no runtime or proof code changes.
> 
> **Overview**
> Blueprint-only refactor so Lean declarations and proof dependencies match the actual formalization (no Lean source changes).
> 
> **`exists_apply_ne_zero`** is no longer tagged on the gauge-phase theorem; it gets its own entry **“A normal tensor has a nonzero letter”** in ch10, with a short transfer-map proof.
> 
> **`MPOTensor.exists_rangeProjection_corner_ne_zero`** is promoted to a dedicated theorem **“A gauge corner gives a nonzero range-projector corner”** in ch20 (gauge-corner identity → nonzero `VV†` corner, citing the new nonzero-letter result). The **horizontal BNT-refined sector-compression** theorem is trimmed to only what `IsHorizontalCF.exists_sectorCompression_ne_zero_of_corner` states—nonzero corner ⇒ nonzero first-site compression—without the former bundled range-projector corollary.
> 
> The **vertical BNT grouping** proof now explicitly `\uses` both the new range-corner theorem and **literal** sector-compression separation, so the Proposition 4.13 dependency graph records generic range-corner and literal edges separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23024d8eecbadaedabdb260da204d5dbb63ff769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->