### PR TITLE
doc(MPDO): synchronize Proposition 4.13 status

### DIFF
--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -17,8 +17,9 @@ CPSV16, Theorem 4.14, for an MPDO in normalized BNT-refined horizontal form.
 The transported one-site and two-site vertical forms give both representations
 of the blocked closed-chain operator.  Eventual linear independence of the BNT
 operators compares their coefficients, and the positive power-sum lemma gives
-the length-one trace-scalar identity.  The corresponding implication from the
-literal CPSV canonical form remains open; see
+the length-one trace-scalar identity.  The corresponding Theorem 4.14
+implication from the literal CPSV canonical form is not established here.
+Literal Proposition 4.13 is complete; see
 `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 ## Main result

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -205,11 +205,11 @@ theorem cpsvVerticalDecomposition_of_grouped_orthogonal_sectors
 vertical decomposition which retains the literal CPSV16 basis predicate.
 
 **Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form assumed by Proposition 4.13.  The
-literal implication remains open at the Lemma L separation after active-block
-refinement and transport through the ambient coisometry; see
-`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex` for this scope and
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex` for the missing step.
+stronger than the literal CPSV canonical form assumed by Proposition 4.13.
+The literal proposition is proved independently by
+`verticalCF_of_cpsvCanonicalForm`; the auxiliary decomposition below retains
+the stronger horizontal hypothesis.  Documented in
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem IsHorizontalCF.exists_cpsvVerticalDecomposition
@@ -269,7 +269,9 @@ so zero product tensors and proper active supports are permitted.
 
 **Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
 stronger than the literal CPSV canonical form used in Appendix C.4 through
-Proposition 4.13.  The literal implication remains open; see
+Proposition 4.13.  The literal proposition is proved independently by
+`verticalCF_of_cpsvCanonicalForm`; the positive-fusion theorem below retains
+the stronger horizontal hypothesis.  Documented in
 `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 **Scope restriction (active product BNT):** Only active product corners are

--- a/TNLean/MPS/MPDO/TwoSiteVerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/TwoSiteVerticalCanonicalForm.lean
@@ -25,7 +25,9 @@ and its two-site blocking are both in vertical canonical form.
 
 **Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
 stronger than the literal CPSV canonical form used in Appendix C.4 through
-Proposition 4.13.  The literal implication remains open; see
+Proposition 4.13.  The literal proposition is proved independently by
+`verticalCF_of_cpsvCanonicalForm`; the paired theorem below retains the stronger
+horizontal hypothesis and its stability under `blockTwo`.  Documented in
 `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -44,8 +44,10 @@ then combine to give the vertical coisometry.
 **Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
 stronger than the literal CPSV canonical form assumed by Proposition 4.13.
 The source-faithful literal implication is proved independently by
-`verticalCF_of_cpsvCanonicalForm`; this theorem retains the stronger horizontal
-interface for its existing consumers.
+`verticalCF_of_cpsvCanonicalForm`; the theorem below retains the stronger
+horizontal hypothesis for arguments that already assume it. This scope
+restriction is documented in
+`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
 theorem verticalCF_of_horizontalCF (M : MPOTensor d D)

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -859,10 +859,30 @@
     \leanok
     \uses{thm:cpsv_literal_grouped_sector_unitary_normalization,
         thm:cpsv_literal_vertical_bnt_grouping_with_isometries}
-    For each copy, use its positive Gram scalar to absorb the normalized
-    unitary gauge into the physical isometry. Unitarity preserves the isometry
-    equation and pairwise orthogonality. The intertwining identity loses the
-    internal similarity, while the Gram identity converts each normalized
-    corner back to the original grouped corner. Summing these corner identities
-    gives (\ref{eq:cpsv_literal_normalized_reconstruction}).
+    For each copy, put
+    $Q_{\alpha,q}=\omega_{\alpha,q}^{-1/2}X_{\alpha,q}$ and
+    $W_{\alpha,q}=V_{\alpha,q}Q_{\alpha,q}$. Unitarity of
+    $Q_{\alpha,q}$ preserves the isometry equation and pairwise
+    orthogonality. Substituting $W_{\alpha,q}=V_{\alpha,q}Q_{\alpha,q}$
+    into the intertwining identity gives
+    \[
+        \widetilde M_vW_{\alpha,q}
+        =V_{\alpha,q}\bigl(
+          c_{\alpha,q}\omega_{\alpha,q}^{-1/2}
+          X_{\alpha,q}M_\alpha^v
+          X_{\alpha,q}^{-1}X_{\alpha,q}\bigr)
+        =W_{\alpha,q}(c_{\alpha,q}M_\alpha^v).
+    \]
+    Thus the adjacent factors
+    $X_{\alpha,q}^{-1}X_{\alpha,q}$ cancel and leave the undressed
+    representative $M_\alpha^v$. The Gram identity
+    $X_{\alpha,q}^\dagger X_{\alpha,q}
+    =\omega_{\alpha,q}\Id$ also gives
+    \[
+        Q_{\alpha,q}(c_{\alpha,q}M_\alpha^v)Q_{\alpha,q}^\dagger
+        =c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
+    \]
+    Hence conjugation by $W_{\alpha,q}$ reproduces the original grouped
+    corner. Summing these equalities gives
+    (\ref{eq:cpsv_literal_normalized_reconstruction}).
 \end{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -865,23 +865,26 @@
     $Q_{\alpha,q}$ preserves the isometry equation and pairwise
     orthogonality. Substituting $W_{\alpha,q}=V_{\alpha,q}Q_{\alpha,q}$
     into the intertwining identity gives
-    \[
+    \begin{align}
         \widetilde M_vW_{\alpha,q}
-        =V_{\alpha,q}\bigl(
+        &=V_{\alpha,q}\bigl(
           c_{\alpha,q}\omega_{\alpha,q}^{-1/2}
           X_{\alpha,q}M_\alpha^v
           X_{\alpha,q}^{-1}X_{\alpha,q}\bigr)
-        =W_{\alpha,q}(c_{\alpha,q}M_\alpha^v).
-    \]
+        \notag\\
+        &=W_{\alpha,q}(c_{\alpha,q}M_\alpha^v).
+        \notag
+    \end{align}
     Thus the adjacent factors
     $X_{\alpha,q}^{-1}X_{\alpha,q}$ cancel and leave the undressed
     representative $M_\alpha^v$. The Gram identity
     $X_{\alpha,q}^\dagger X_{\alpha,q}
     =\omega_{\alpha,q}\Id$ also gives
-    \[
+    \begin{align}
         Q_{\alpha,q}(c_{\alpha,q}M_\alpha^v)Q_{\alpha,q}^\dagger
-        =c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
-    \]
+        &=c_{\alpha,q}X_{\alpha,q}M_\alpha^vX_{\alpha,q}^{-1}.
+        \notag
+    \end{align}
     Hence conjugation by $W_{\alpha,q}$ reproduces the original grouped
     corner. Summing these equalities gives
     (\ref{eq:cpsv_literal_normalized_reconstruction}).

--- a/docs/audits/scouting_1606.00608.md
+++ b/docs/audits/scouting_1606.00608.md
@@ -1,5 +1,10 @@
 # Scouting Report: arXiv:1606.00608 — Sections 3, 4, Appendices B–D
 
+> [!IMPORTANT]
+> This report is a historical scouting snapshot dated 2026-03-25. For the
+> maintained paper-to-code coverage record, see
+> [`2026-05-08-mps-ft-paper-coverage.md`](2026-05-08-mps-ft-paper-coverage.md).
+
 **Paper**: "Matrix Product Density Operators: Renormalization Fixed Points and Boundary Theories"
 **Authors**: Cirac, Perez-Garcia, Schuch, Verstraete (2017, Ann. Phys. 378, 100–149)
 **Date of scouting**: 2026-03-25

--- a/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
+++ b/docs/paper-gaps/cpgsv17_periodic_sector_projector.tex
@@ -54,8 +54,9 @@ suffices.
 This is a local correction of the intermediate statement.  The corrected
 periodic-sector implication is now proved both from literal CPSV canonical
 form and from the stronger normalized BNT-refined horizontal form.  It closes
-the periodic-exclusion step of Proposition~4.13, not the remaining grouping,
-normalization, and coisometry steps.
+the periodic-exclusion step used in Proposition~4.13.  The later vertical
+phase-class grouping, gauge normalization, and coisometry construction are
+recorded in \path{cpgsv17_vertical_cf_grouping.tex}.
 
 \section{Formal proof}
 
@@ -105,12 +106,21 @@ Combining literal periodic exclusion with literal invariant-projector closure
 gives the normal vertical corners with positive weights and exact letterwise
 reconstruction in
 \leanid{MPSTensor.IsCPSVCanonicalForm.exists\_normal\_verticalBlockDecomp\_with\_isometry}.
-Proposition~4.13 remains open only at the subsequent vertical BNT grouping,
-normalization of the grouped representatives, and final coisometry.  These
-steps are distinct from the Appendix~C.4 positive-fusion question.
+The subsequent vertical phase-class grouping, normalization of the grouped
+representatives, and final coisometry are also complete.  Together they give
+the literal theorem
+\leanid{MPOTensor.verticalCF\_of\_cpsvCanonicalForm} in
+\doclink{TNLean/MPS/MPDO/CPSVVerticalCanonicalForm}.  The stronger theorem from
+the normalized BNT-refined horizontal form remains available separately.
 
-\paragraph{Verdict.} Literal periodic-sector step complete; Proposition~4.13
-remains open at grouping, normalization, and the final coisometry.
+This completion concerns Proposition~4.13 only.  It neither proves the
+positive-fusion statement in Appendix~C.4 nor the renormalization fixed-point
+characterization in Theorem~4.14.
+
+\paragraph{Verdict.} The printed all-length inequality is replaced by the
+existence of one noncommuting length.  This local correction suffices for the
+periodic-sector step, and literal Proposition~4.13 is now complete by the
+independent grouping, normalization, and coisometry results.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -81,20 +81,20 @@ More importantly, even with positivity available, the proposition constructs a
 new vertical basis of normal tensors rather than reusing the diagonal
 restrictions of the horizontal basis.
 
-\section{The corrected formal target}
+\section{The corrected formal theorem}
 
-The theorem currently proved assumes the normalized BNT-refined horizontal
-form \path{MPOTensor.IsHorizontalCF}.  In particular, the retained sectors
-have full horizontal bond dimension, every copy weight is nonzero, all copy
-weights have modulus at most one, at least one has modulus one, and the normal
-blocks are grouped over BNT representatives.  This
-is strictly stronger than the literal CPSV canonical form in
-Proposition~4.13.  The constructions summarized below are complete on this
-stronger surface; the literal canonical-form implication remains open.
+The literal theorem now proved assumes the CPSV canonical form of
+Proposition~4.13 together with the MPDO positivity hypothesis and concludes
+vertical canonical form.\footnote{Formal declaration:
+\leanid{MPOTensor.verticalCF\_of\_cpsvCanonicalForm} in
+\doclink{TNLean/MPS/MPDO/CPSVVerticalCanonicalForm}.}
+A separate theorem retains the normalized BNT-refined horizontal hypothesis
+\path{MPOTensor.IsHorizontalCF} for arguments that already use that stronger
+form.\footnote{Formal declaration:
+\leanid{MPOTensor.verticalCF\_of\_horizontalCF} in
+\doclink{TNLean/MPS/MPDO/VerticalCanonicalForm}.}
 
-A source-faithful proof of Proposition~4.13 should begin with both horizontal
-canonical form and the MPDO positivity hypothesis.  It should then formalize the
-three stages visible in the source:
+The proof follows the three stages visible in the source:
 \begin{enumerate}
     \item use positivity and the first-site insertion lemma to rule out one-sided
       invariant projections in the vertical direction;
@@ -116,6 +116,10 @@ restriction remains useful as an auxiliary identity.  It cannot supply the
 normal blocks of the vertical canonical form.  In particular, Newton--Girard
 identities for scalar weights address only the multiplicity coefficients; they
 cannot restore matrix directions discarded by the restriction $(i,j)\mapsto(i,i)$.
+The vertical phase-class grouping and the resulting positive diagonal
+coefficients are described in
+\path{cpgsv17_vertical_cf_grouping.tex}; they do not arise from diagonal
+restriction.
 
 The first operator identity at lines~1873--1887 is now formalized: if $H\geq0$,
 $P=P^*$, and $PH=PHP$, then
@@ -220,12 +224,18 @@ gives the displayed vertical identity and exact reconstruction.  The source
 prints the former; the latter is implicit in its assertion that the vertical
 tensor is itself in canonical form and is not displayed as a separate formula.
 
+The corresponding constructions under literal CPSV canonical form are
+summarized in \path{cpgsv17_vertical_cf_grouping.tex}.  They give
+\path{MPOTensor.verticalCF_of_cpsvCanonicalForm} without using diagonal
+restriction.
+
 \paragraph{Verdict.}
-The horizontal-to-vertical implication is complete under the normalized
-BNT-refined hypothesis \path{MPOTensor.IsHorizontalCF}, which is strictly
-stronger than the literal CPSV canonical form of Proposition~4.13.  The
-literal theorem remains open.  The diagonal-restriction route remains a false
-strengthening and plays no part in the proved restricted result.
+Literal Proposition~4.13 is complete, and the stronger theorem under
+\path{MPOTensor.IsHorizontalCF} remains available separately.  Neither proof
+uses diagonal restriction to obtain the normal vertical representatives; that
+route remains false.  Proposition~4.13 does not settle the positive-fusion
+problem of Appendix~C.4 or the renormalization fixed-point characterization of
+Theorem~4.14.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -167,22 +167,24 @@ asserted.
 
 \section{Formal correction}
 
-The vertical canonical-form predicate now requires $UU^\dagger=I_s$ in the
+The vertical canonical-form predicate requires $UU^\dagger=I_s$ in the
 orientation of \eqref{eq:vertical-form}, together with
 \eqref{eq:reconstruction}. This is the source-faithful conclusion compatible
 with \eqref{eq:dimension-bound}: the displayed compression is printed in the
 proposition, while reconstruction records its preceding canonical-form claim.
 The retained part is represented
 rectangularly, while the omitted part is required to be zero. No full-support
-assumption is added to that conclusion.  The theorem in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}\footnote{The corresponding
-declaration is \leanid{MPOTensor.verticalCF_of_horizontalCF}.} uses this
-corrected coisometry condition under the normalized BNT-refined horizontal
-form.  Its retained sectors fill the horizontal bond space, every copy weight
-is nonzero, all copy weights have modulus at most one, at least one has modulus
-one, and the normal blocks are grouped over BNT representatives.  This is
-strictly stronger than the literal CPSV canonical form of Proposition~4.13,
-so the literal implication remains open.  The coisometry correction itself is
+assumption is added to that conclusion.  Literal Proposition~4.13 now uses
+this corrected condition in
+\path{TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean}.\footnote{Formal
+declaration: \leanid{MPOTensor.verticalCF\_of\_cpsvCanonicalForm}.}
+The theorem under the normalized BNT-refined horizontal form remains available
+separately in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean}.\footnote{Formal declaration:
+\leanid{MPOTensor.verticalCF\_of\_horizontalCF}.}
+The vertical phase-class grouping and normalization that precede both
+coisometry constructions are recorded in
+\path{cpgsv17_vertical_cf_grouping.tex}.  The coisometry correction itself is
 tracked in \ghissue{3869}.
 
 The source-generated support identities and their trace consequences are
@@ -200,10 +202,13 @@ The earlier two-sided-unitary condition was absent from the source and was
 false when the vertically viewed tensor had a zero sector.  Replacing it by
 the coisometry identity $UU^\dagger=I$, while retaining exact reconstruction
 from the nonzero sectors, corrects the conclusion without adding a
-full-support hypothesis.  The current theorem proves this corrected conclusion
-only under the normalized BNT-refined horizontal form, which is strictly
-stronger than literal CPSV canonical form.  The literal Proposition~4.13
-implication remains open.
+full-support hypothesis.  Literal Proposition~4.13 and the separate stronger
+horizontal theorem now prove this corrected conclusion.  This completion does
+not supply a trace-preserving map on every element of the finite products in
+Appendix~C.4; the support conditions
+\eqref{eq:transported-image-preservation} remain necessary there.  It also
+does not prove the renormalization fixed-point characterization of
+Theorem~4.14.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_tensor_definition.tex
@@ -116,16 +116,15 @@ decomposition, not from flattening horizontal weights;
 \path{cpgsv17_vertical_diagonal_restriction.tex} records that diagonal
 restriction of horizontal blocks does not preserve normality.  Neither note
 documented the definitional mismatch addressed here: the former predicate
-placed the conclusion of Proposition~4.13 on the wrong tensor.  The
-horizontal-to-vertical implication is proved by
-\path{MPOTensor.verticalCF_of_horizontalCF} in
-\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean} under the normalized
-BNT-refined hypothesis \path{MPOTensor.IsHorizontalCF}.  This hypothesis has
-full horizontal bond dimension and BNT representative grouping; every copy
-weight is nonzero, all have modulus at most one, and at least one has modulus
-one.  It is strictly stronger than the literal CPSV
-canonical form assumed in Proposition~4.13, whose vertical conclusion remains
-open.  The blueprint records these as separate statements.
+placed the conclusion of Proposition~4.13 on the wrong tensor.  The literal
+horizontal-to-vertical implication is now proved by
+\path{MPOTensor.verticalCF_of_cpsvCanonicalForm} in
+\path{TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean}.  It assumes the literal
+CPSV canonical form and MPDO positivity of Proposition~4.13.  The earlier
+theorem \path{MPOTensor.verticalCF_of_horizontalCF} in
+\path{TNLean/MPS/MPDO/VerticalCanonicalForm.lean} remains as a separate result
+under the stronger normalized BNT-refined hypothesis
+\path{MPOTensor.IsHorizontalCF}.
 
 \paragraph{Verdict.}
 This is a corrected definitional mismatch.  The former predicate placed the
@@ -139,10 +138,13 @@ definition.  The later correction in
 \path{cpgsv17_vertical_isometry_zero_sector.tex} expresses the source's
 one-sided condition as a coisometry onto the retained nonzero sectors and
 retains exact reconstruction.  The horizontal-to-vertical implication is
-proved with this corrected definition under the normalized BNT-refined
-hypothesis \path{MPOTensor.IsHorizontalCF}.  Since that hypothesis is strictly
-stronger than literal CPSV canonical form, the literal Proposition~4.13
-implication remains open.
+proved with this corrected definition under the literal CPSV canonical-form
+and MPDO hypotheses, and the stronger normalized BNT-refined theorem remains
+available separately.  The phase-class grouping and positive diagonal
+coefficients used in the proof are detailed in
+\path{cpgsv17_vertical_cf_grouping.tex}.  This completes Proposition~4.13 but
+does not prove the positive-fusion statement in Appendix~C.4 or the
+renormalization fixed-point characterization in Theorem~4.14.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -362,10 +362,12 @@ Its two-site ground space is spanned by $|01\rangle$ and $|10\rangle$.  The
 corresponding one-dimensional sectors have only the edges $0\to1$ and
 $1\to0$, so the self-loop sum is zero, whereas the project-local one-site
 ground space has dimension $d=2$.  Thus the project-local result is recorded
-separately, while Beigi's
-ordered-cycle theorem remains stated for $N\geq2$.  The source-level one-site
-convention remains open in \ghissue{4400}; \ghissue{4655} records the current
-project-local boundary.
+separately, while Beigi's ordered-cycle theorem is proved for every
+source-defined length $N\geq2$, including the two opposite orientations at
+$N=2$.  The resolved source boundary is recorded in \ghissue{4400}: no cited
+source defines the two-site operator $H_1$ or a convention for the coincident
+periodic edge at $N=1$.  \ghissue{4655} records the separate project-local
+boundary.
 
 The remaining finite graph comparison in Beigi's Section~IV is now proved
 without an axiom.  For a finite directed graph with nonnegative integral edge weights,
@@ -461,9 +463,10 @@ parent Hamiltonian.  Its Euclidean-space form is recorded by
 \hspace{0pt}\leanid{loopProductState_mem_parentHamiltonianGroundSpaceES}.
 The proof uses Beigi's local edge-ground-space condition from source
 lines 487--500 and the positive-loop specialization at lines 602--606.  The
-restriction $N\geq2$ is the nondegenerate range of the two-site periodic
-parent Hamiltonian used here; the length-one convention remains part of
-\ghissue{4400}.  At every positive length the loop vectors are nonzero by
+restriction $N\geq2$ is the source-defined range of the two-site periodic
+parent Hamiltonian used here.  As recorded by the resolved clarification in
+\ghissue{4400}, no source-defined coincident-edge convention extends this
+statement to $N=1$.  At every positive length the loop vectors are nonzero by
 \leanid{MPSTensor.BeigiSectorGraphData.}
 \hspace{0pt}\leanid{loopProductStateES_ne_zero}, and distinct loop vectors are
 orthogonal by


### PR DESCRIPTION
## What changed

- restore the required paper-gap path in the stronger-horizontal scope marker and make the normalized-map Blueprint proof display the adjacent (X_{\alpha,q}^{-1}X_{\alpha,q}) cancellation;
- update the related Lean docstrings so they distinguish the completed literal Proposition 4.13 theorem from stronger-horizontal auxiliary results and the still-open Theorem 4.14 work;
- synchronize four Proposition 4.13 gap notes with `MPOTensor.verticalCF_of_cpsvCanonicalForm`, while preserving their local corrections and the Appendix C.4 boundary;
- mark the March scouting report as historical and point to the maintained coverage audit;
- record the resolved Beigi (N\ge 2) / undefined (N=1) coincident-edge boundary from #4400.

## Why

Two review threads were filed after PR #4986 merged. One found that a required paper-gap citation had been dropped from a `**Scope restriction:**` marker; the other requested an explicit mathematical cancellation in the Blueprint proof. A source-first audit then found older records that still described literal Proposition 4.13 as open.

This is documentation synchronization only. No theorem statement or proof body changes. Proposition 4.13 remains separate from Appendix C.4, #4648/#4645, and Theorem 4.14.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- all five changed paper-gap notes compile with `latexmk -pdf -interaction=nonstopmode -halt-on-error`
- two independent final reviews approved the source boundaries and prose

A local Lean build was intentionally not started because this isolated documentation worktree has no hot exact-main `.lake`; exact-head CI supplies the cached Lean and `checkdecls` gates.

Closes #4987.
Follow-up to #4986.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose, blueprint display, and gap-note edits only; no Lean proof or statement changes. Risk is limited to documentation drift or misleading status if citations are wrong.
> 
> **Overview**
> This PR **does not change theorem statements or proof bodies**; it aligns prose with the current formalization boundary after follow-up to #4986.
> 
> **Lean module docstrings** (BNT fusion, RFP positive fusion, two-site vertical CF, vertical CF) now say **literal Proposition 4.13 is proved** by `MPOTensor.verticalCF_of_cpsvCanonicalForm`, while theorems under `IsHorizontalCF` are **auxiliary / stronger-hypothesis** results still documented in `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. **Theorem 4.14** from literal CPSV form remains explicitly **not** established in the BNT-fusion-from-RFP file.
> 
> The **blueprint** proof of literal normalized grouped sector maps now spells out \(Q_{\alpha,q}=\omega_{\alpha,q}^{-1/2}X_{\alpha,q}\), \(W_{\alpha,q}=V_{\alpha,q}Q_{\alpha,q}\), and the **\(X_{\alpha,q}^{-1}X_{\alpha,q}\) cancellation** in the intertwining step.
> 
> **Four Proposition 4.13 gap notes** (`periodic_sector_projector`, `vertical_diagonal_restriction`, `vertical_isometry_zero_sector`, `vertical_tensor_definition`) are updated to record completion of literal 4.13 and to **preserve boundaries** (Appendix C.4 positive fusion, Theorem 4.14). The **March scouting report** is labeled a historical snapshot with a pointer to the maintained coverage audit. **Beigi \(N\ge 2\)** / undefined \(N=1\) edge convention is recorded as resolved per #4400 in `cpsv16_nncph_ground_state_scope.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b8d203ed5dbb1eb60d700b2bb7b7602a5a71ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->