### PR TITLE
feat(Channel/Schwarz): prove support entropy gap integral

### DIFF
--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -39,6 +39,7 @@ import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.SchwarzSubnormal
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import TNLean.Channel.Schwarz.SupportLeftRightRelativeModular
+import TNLean.Channel.Schwarz.SupportRelativeEntropyGap
 import TNLean.Channel.Schwarz.SupportRelativeModular
 import TNLean.Channel.Schwarz.SupportResolvent
 import TNLean.Channel.Schwarz.SupportSourceBDefect

--- a/TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.SupportSourceDefect
+
+/-!
+# Finite-family support relative-entropy gap
+
+This file identifies the relative-entropy convexity gap of a finite family of
+positive-semidefinite pairs with the integral of its two support-resolvent
+defects. It also proves continuity of the gap integrand on the positive
+half-line.
+
+## Main results
+
+* `Matrix.supportRelativeEntropyFamilyGapIntegrand`: the finite-family
+  support-resolvent gap integrand.
+* `Matrix.supportRelativeEntropyFamilyGapIntegrand_integrableOn_and_integral_eq`:
+  its integral is the relative-entropy convexity gap.
+* `Matrix.supportRelativeEntropyFamilyGapIntegrand_continuousOn`: the
+  integrand is continuous for positive resolvent parameter.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, arXiv:0903.2895v4, the logarithmic
+  representation `(intspec)` and its finite matrix form `(intAB)` at lines
+  406--431, the positive-definite equality argument at lines 652--674, and
+  the positive-semidefinite extension at lines 717--720 and 766--793.
+
+This file proves only the integral and continuity infrastructure. Pointwise
+vanishing, common projected resolvents, and Petz recovery are not asserted
+here.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+open MeasureTheory Set
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The support-resolvent integrand for the relative-entropy convexity gap of
+a finite family. For \(A_\Sigma=\sum_i A_i\) and
+\(B_\Sigma=\sum_i B_i\), it is
+\[
+  \frac{\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)}{1+t},
+\]
+where each defect is the sum of the corresponding support quadratic forms
+minus the quadratic form of the summed pair.
+
+The coefficient \(t\) and the two source terms are those in `(intspec)` and
+`(intAB)` of Jenčová--Ruskai, arXiv:0903.2895v4, lines 406--431. -/
+noncomputable def supportRelativeEntropyFamilyGapIntegrand
+    {ι : Type*} [Fintype ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    (t : ℝ) : ℝ :=
+  let Abar := ∑ i, A i
+  let Bbar := ∑ i, B i
+  let hAbar : Abar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+  let defA :=
+    (∑ i, rawSupportSourceAQuadratic (hA i) (hB i) t) -
+      rawSupportSourceAQuadratic hAbar hBbar t
+  let defB :=
+    (∑ i, supportSourceBQuadratic (hA i) (hB i) t) -
+      supportSourceBQuadratic hAbar hBbar t
+  (defA + t * defB) / (1 + t)
+
+private theorem supportRelativeEntropyFamilyGapIntegrand_eq
+    {ι : Type*} [Fintype ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    (hker : ∀ i (v : n → ℂ), B i *ᵥ v = 0 → A i *ᵥ v = 0)
+    {t : ℝ} (ht : 0 < t) :
+    let Abar := ∑ i, A i
+    let Bbar := ∑ i, B i
+    let hAbar : Abar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+    let hBbar : Bbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+    supportRelativeEntropyFamilyGapIntegrand A B hA hB t =
+      (∑ i, supportRelativeEntropySpectralIntegrand (hA i) (hB i) t) -
+        supportRelativeEntropySpectralIntegrand hAbar hBbar t := by
+  classical
+  dsimp only
+  let Abar : Matrix n n ℂ := ∑ i, A i
+  let Bbar : Matrix n n ℂ := ∑ i, B i
+  let hAbar : Abar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+  have hkerbar (v : n → ℂ) (hv : Bbar *ᵥ v = 0) :
+      Abar *ᵥ v = 0 := by
+    change (∑ i, A i) *ᵥ v = 0
+    rw [sum_mulVec]
+    apply Finset.sum_eq_zero
+    intro i _
+    apply hker i v
+    exact Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero hB
+      (by simpa only [Bbar] using hv) i
+  rw [← rawSupportSourceAQuadratic_sub_trace_add_sourceB_eq_spectral
+    hAbar hBbar hkerbar ht]
+  simp_rw [← rawSupportSourceAQuadratic_sub_trace_add_sourceB_eq_spectral
+    (hA _) (hB _) (hker _) ht]
+  unfold supportRelativeEntropyFamilyGapIntegrand
+  dsimp only
+  rw [← Finset.sum_div, Finset.sum_add_distrib, Finset.sum_sub_distrib,
+    ← Finset.mul_sum]
+  have htrace :
+      ∑ i, (Matrix.trace (B i)).re = (Matrix.trace Bbar).re := by
+    rw [← Complex.re_sum, ← Matrix.trace_sum]
+  rw [htrace]
+  ring
+
+/-- For a finite nonempty family of positive-semidefinite pairs satisfying
+\(\ker B_i\subseteq\ker A_i\), the support-resolvent gap integrand is
+integrable on \((0,\infty)\), and
+\[
+  \int_0^\infty
+    \frac{\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)}{1+t}\,dt
+  =
+  \sum_i D(A_i\Vert B_i)
+    -D\!\left(\sum_i A_i\middle\Vert\sum_i B_i\right).
+\]
+
+This is the support-domain finite-family form of `(intspec)` and `(intAB)` in
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 406--431. The kernel assumptions
+are exactly those in their positive-semidefinite extension at lines 717--720
+and Theorem `thm:eqJpI`, lines 766--785. -/
+theorem
+    supportRelativeEntropyFamilyGapIntegrand_integrableOn_and_integral_eq
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    (hker : ∀ i (v : n → ℂ), B i *ᵥ v = 0 → A i *ᵥ v = 0) :
+    let Abar := ∑ i, A i
+    let Bbar := ∑ i, B i
+    IntegrableOn
+        (supportRelativeEntropyFamilyGapIntegrand A B hA hB) (Ioi 0) ∧
+      ∫ t : ℝ in Ioi 0,
+          supportRelativeEntropyFamilyGapIntegrand A B hA hB t =
+        (∑ i, quantumRelativeEntropy (A i) (B i)) -
+          quantumRelativeEntropy Abar Bbar := by
+  classical
+  dsimp only
+  let Abar : Matrix n n ℂ := ∑ i, A i
+  let Bbar : Matrix n n ℂ := ∑ i, B i
+  let hAbar : Abar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+  have hkerbar (v : n → ℂ) (hv : Bbar *ᵥ v = 0) :
+      Abar *ᵥ v = 0 := by
+    change (∑ i, A i) *ᵥ v = 0
+    rw [sum_mulVec]
+    apply Finset.sum_eq_zero
+    intro i _
+    apply hker i v
+    exact Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero hB
+      (by simpa only [Bbar] using hv) i
+  have hpair (i : ι) :=
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy
+      (hA i) (hB i) (hker i)
+  have hbar :=
+    supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy
+      hAbar hBbar hkerbar
+  let g : ℝ → ℝ := fun t =>
+    (∑ i, supportRelativeEntropySpectralIntegrand (hA i) (hB i) t) -
+      supportRelativeEntropySpectralIntegrand hAbar hBbar t
+  have hg : IntegrableOn g (Ioi 0) :=
+    (integrable_finsetSum Finset.univ fun i _ ↦ (hpair i).1).sub hbar.1
+  have heq (t : ℝ) (ht : t ∈ Ioi (0 : ℝ)) :
+      supportRelativeEntropyFamilyGapIntegrand A B hA hB t = g t := by
+    simpa only [Abar, Bbar, hAbar, hBbar, g] using
+      supportRelativeEntropyFamilyGapIntegrand_eq A B hA hB hker ht
+  refine ⟨hg.congr_fun (fun t ht ↦ (heq t ht).symm) measurableSet_Ioi, ?_⟩
+  rw [setIntegral_congr_fun measurableSet_Ioi heq]
+  rw [integral_sub (integrable_finsetSum Finset.univ fun i _ ↦ (hpair i).1)
+    hbar.1]
+  rw [integral_finsetSum Finset.univ fun i _ ↦ (hpair i).1]
+  simp_rw [(hpair _).2]
+  rw [hbar.2]
+
+/-- The finite-family support relative-entropy gap integrand is continuous on
+\((0,\infty)\). This is the continuity input for the equality passage in
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 652--674 and 788--790. No
+pointwise-vanishing or resolvent-equality conclusion is asserted here. -/
+theorem supportRelativeEntropyFamilyGapIntegrand_continuousOn
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    (hker : ∀ i (v : n → ℂ), B i *ᵥ v = 0 → A i *ᵥ v = 0) :
+    ContinuousOn
+      (supportRelativeEntropyFamilyGapIntegrand A B hA hB) (Ioi 0) := by
+  classical
+  let Abar : Matrix n n ℂ := ∑ i, A i
+  let Bbar : Matrix n n ℂ := ∑ i, B i
+  let hAbar : Abar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+  have hbase : ContinuousOn (fun t : ℝ =>
+      (∑ i, supportRelativeEntropySpectralIntegrand (hA i) (hB i) t) -
+        supportRelativeEntropySpectralIntegrand hAbar hBbar t) (Ioi 0) :=
+    (continuousOn_finsetSum Finset.univ fun i _ ↦
+      supportRelativeEntropySpectralIntegrand_continuousOn
+        (hA i) (hB i)).sub
+      (supportRelativeEntropySpectralIntegrand_continuousOn hAbar hBbar)
+  refine hbase.congr fun t ht ↦ ?_
+  have heq :=
+    supportRelativeEntropyFamilyGapIntegrand_eq A B hA hB hker ht
+  simpa only [Abar, Bbar, hAbar, hBbar] using heq
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
@@ -855,10 +855,69 @@
     as a sum of nonnegative quadratic residuals.
 \end{proof}
 
-% Open in #4435: both fixed-parameter defect inequalities are established.
-% It remains to express the finite-family relative-entropy gap as their
-% integral, pass from a zero integral to pointwise vanishing by continuity,
-% and derive the common projected relative-modular resolvent.
+\begin{theorem}[Finite-family support relative-entropy gap integral]
+    \label{thm:support_relative_entropy_family_gap_integral}
+    \lean{Matrix.supportRelativeEntropyFamilyGapIntegrand}
+    \lean{Matrix.supportRelativeEntropyFamilyGapIntegrand_integrableOn_and_integral_eq}
+    \lean{Matrix.supportRelativeEntropyFamilyGapIntegrand_continuousOn}
+    \leanok
+    \uses{thm:relative_entropy_support_spectral_integral,
+        thm:relative_entropy_support_left_right_quadratic}
+    Let $I$ be a finite nonempty set. For each $i\in I$, let $A_i$ and $B_i$
+    be positive-semidefinite matrices of the same size satisfying
+    $\ker B_i\subseteq\ker A_i$. Put
+    \begin{align}
+        A_\Sigma&=\sum_{i\in I}A_i,&
+        B_\Sigma&=\sum_{i\in I}B_i,
+        \notag\\
+        \operatorname{Def}_A(t)
+        &=
+        \sum_{i\in I}Q^A_{A_i,B_i}(t)
+          -Q^A_{A_\Sigma,B_\Sigma}(t),&
+        \operatorname{Def}_B(t)
+        &=
+        \sum_{i\in I}Q^B_{A_i,B_i}(t)
+          -Q^B_{A_\Sigma,B_\Sigma}(t).
+        \notag
+    \end{align}
+    Then the function
+    \begin{align}
+        F(t)
+        &=
+        \frac{\operatorname{Def}_A(t)+
+          t\operatorname{Def}_B(t)}{1+t}
+        \notag
+    \end{align}
+    is continuous on $(0,\infty)$ and integrable there, and
+    \begin{align}
+        \int_0^\infty F(t)\,dt
+        &=
+        \sum_{i\in I}D(A_i\Vert B_i)
+          -D(A_\Sigma\Vert B_\Sigma).
+        \label{eq:support_relative_entropy_family_gap_integral}
+    \end{align}
+    This is the finite-family support-domain form of
+    $(\mathrm{intspec})$ and $(\mathrm{intAB})$ in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines~406--431, with the
+    positive-semidefinite convention and kernel hypotheses at
+    lines~717--720 and 766--785.
+\end{theorem}
+
+\begin{proof}\leanok
+    The kernel inclusions for the summands imply
+    $\ker B_\Sigma\subseteq\ker A_\Sigma$. Apply the one-pair
+    support-domain integral representation to every $(A_i,B_i)$ and to
+    $(A_\Sigma,B_\Sigma)$. The pointwise left--right identities identify the
+    difference of the spectral integrands with $F$; linearity of trace
+    cancels the terms involving $\operatorname{tr}(B_i)$. Finite summation
+    commutes with the integral. Continuity follows from the corresponding
+    one-pair continuity theorem and finite summation.
+\end{proof}
+
+% Open in #4435: the finite-family gap integral and both fixed-parameter
+% defect inequalities are established. It remains to pass from a zero
+% integral to pointwise vanishing and derive the common projected
+% relative-modular resolvent.
 
 \begin{theorem}[Spectral resolvent representation of relative entropy]
     \label{thm:relative_entropy_resolvent_integral}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -426,9 +426,26 @@ pair.
 \leanid{Matrix.supportSourceBQuadratic_sum_sub_nonneg} in
 \path{TNLean/Channel/Schwarz/SupportSourceDefect.lean}.}
 These are fixed-$t$ algebraic inequalities.  The remaining analytic passage
-must identify the finite-family relative-entropy gap with the integral of the
-two defects, use nonnegativity and continuity to deduce pointwise vanishing,
-and then derive the common projected shifted relative-modular resolvent.
+now identifies the finite-family relative-entropy gap with the integral of
+the two defects:
+\[
+  \sum_i D(A_i\Vert B_i)
+    -D\!\left(\sum_iA_i\middle\Vert\sum_iB_i\right)
+  =
+  \int_0^\infty
+    \frac{\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)}{1+t}\,dt .
+\]
+The gap integrand is continuous on the positive half-line and integrable
+there.
+\footnote{Formal declarations:
+\leanid{Matrix.supportRelativeEntropyFamilyGapIntegrand},
+\leanid{Matrix.supportRelativeEntropyFamilyGapIntegrand_integrableOn_and_integral_eq},
+and
+\leanid{Matrix.supportRelativeEntropyFamilyGapIntegrand_continuousOn} in
+\path{TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean}.}
+The remaining analytic passage must use nonnegativity and continuity to
+deduce pointwise vanishing from a zero integral and then derive the common
+projected shifted relative-modular resolvent.
 Following the latter step, consider two positive semidefinite pairs $(A,B)$ and
 $(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
 $B$, and write
@@ -480,11 +497,11 @@ also identifies this vector with the support-generalized-inverse solution of
 the left--right equation, and hence identifies the two source-$B$ quadratic
 forms.  Together with the two defect inequalities, it still does not show that
 equality of relative entropies makes either defect vanish.  The
-integral-and-continuity argument and the resulting finite-family common
-projected resolvent theorem remain unformalized.  The kernel inclusion is
-already used for the unprojected source-$A$ inequality and remains an exact hypothesis
-of that source-facing equality theorem.  Consequently the singular Petz
-recovery identity is also still unformalized.
+zero-integral-to-pointwise-vanishing passage and the resulting finite-family
+common projected resolvent theorem remain unformalized.  The kernel inclusion
+is already used for the unprojected source-$A$ inequality and remains an exact
+hypothesis of that source-facing equality theorem.  Consequently the singular
+Petz recovery identity is also still unformalized.
 
 In particular, the affine regularizations used to prove the inequality cannot
 by themselves prove its equality case.  Equality at the limiting pair implies


### PR DESCRIPTION
## Summary

- define the finite-family support relative-entropy gap integrand
- prove integrability and identify its integral with the relative-entropy convexity gap
- prove continuity on the positive half-line
- synchronize the Blueprint entry and the CPSV16/Hayashi paper-gap note

## Source boundary

The coefficient of the source-B defect, kernel assumptions, and support-domain integral follow Jenčová–Ruskai, arXiv:0903.2895v4, `(intspec)` and `(intAB)` at lines 406–431, with the positive-semidefinite extension at lines 717–720 and 766–793. The CPSV16 MPDO paper invokes Hayashi for the later Markov decomposition; this PR does not attribute this analytic passage to CPSV16.

## Scope

This advances LionSR/QICLean#245 without closing it. Pointwise vanishing from a zero integral, the common projected resolvent theorem, singular Petz recovery, and the MPDO/Hayashi structural step remain explicitly open.

## Validation

- `lake build TNLean.Channel.Schwarz.SupportRelativeEntropyGap`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --base-ref origin/main`
- `python3 scripts/generate_import_aggregators.py --check`
- `leanblueprint checkdecls`
- `leanblueprint pdf` (affected theorem visually inspected)
- standalone paper-gap PDF build and visual inspection
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity and line-length scans
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds self-contained measure-theoretic lemmas on top of existing support spectral infrastructure; no changes to auth, runtime APIs, or downstream proof assumptions beyond documentation sync.
> 
> **Overview**
> Formalizes the **finite-family** support relative-entropy convexity gap as a resolvent defect integrand and proves the analytic inputs needed for the singular equality pipeline (#4435).
> 
> **Lean:** New `SupportRelativeEntropyGap.lean` defines `supportRelativeEntropyFamilyGapIntegrand` (combined source-A/source-B defect over summed pairs), shows it matches the difference of per-pair spectral integrands for `t > 0`, and proves **integrability on `(0,∞)`** with integral **∑ᵢ D(Aᵢ‖Bᵢ) − D(∑Aᵢ‖∑Bᵢ)** under `ker Bᵢ ⊆ ker Aᵢ`, plus **continuity on `(0,∞)`**. The module is wired into the `Schwarz` import aggregator.
> 
> **Docs:** Blueprint ch19 gains theorem `thm:support_relative_entropy_family_gap_integral` with `\leanok` links; the CPSV16/Hayashi paper-gap note records this step as done and leaves zero-integral → pointwise vanishing, common projected resolvent, and Petz recovery as still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649655cd60df8d177b7752f3dccb6e27952e8af9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->