### PR TITLE
feat(Channel/Schwarz): prove source-B defect vanishing

### DIFF
--- a/TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.MeasureTheory.Measure.OpenPos
 import TNLean.Channel.Schwarz.SupportSourceDefect
 
 /-!
@@ -21,6 +22,11 @@ half-line.
   its integral is the relative-entropy convexity gap.
 * `Matrix.supportRelativeEntropyFamilyGapIntegrand_continuousOn`: the
   integrand is continuous for positive resolvent parameter.
+* `Matrix.supportRelativeEntropyFamilyGapIntegrand_nonneg`: both
+  finite-family support defects make the integrand nonnegative.
+* `Matrix.supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq`:
+  equality of relative entropies makes the source-\(B\) defect vanish at
+  every positive resolvent parameter.
 
 ## References
 
@@ -29,9 +35,9 @@ half-line.
   406--431, the positive-definite equality argument at lines 652--674, and
   the positive-semidefinite extension at lines 717--720 and 766--793.
 
-This file proves only the integral and continuity infrastructure. Pointwise
-vanishing, common projected resolvents, and Petz recovery are not asserted
-here.
+This file proves the integral and continuity infrastructure and the
+pointwise vanishing of the source-\(B\) defect. Common projected resolvents
+and Petz recovery are not asserted here.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -216,5 +222,102 @@ theorem supportRelativeEntropyFamilyGapIntegrand_continuousOn
   have heq :=
     supportRelativeEntropyFamilyGapIntegrand_eq A B hA hB hker ht
   simpa only [Abar, Bbar, hAbar, hBbar] using heq
+
+/-- The finite-family support relative-entropy gap integrand is nonnegative
+for every positive resolvent parameter.
+
+This combines the two source-defect inequalities corresponding to
+`(intAB)` in Jenčová--Ruskai, arXiv:0903.2895v4, lines 423--435. -/
+theorem supportRelativeEntropyFamilyGapIntegrand_nonneg
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    (hker : ∀ i (v : n → ℂ), B i *ᵥ v = 0 → A i *ᵥ v = 0)
+    {t : ℝ} (ht : 0 < t) :
+    0 ≤ supportRelativeEntropyFamilyGapIntegrand A B hA hB t := by
+  unfold supportRelativeEntropyFamilyGapIntegrand
+  dsimp only
+  have hdefA :=
+    rawSupportSourceAQuadratic_sum_sub_nonneg A B hA hB hker ht
+  have hdefB :=
+    supportSourceBQuadratic_sum_sub_nonneg A B hA hB ht
+  exact div_nonneg
+    (add_nonneg hdefA (mul_nonneg ht.le hdefB)) (by linarith)
+
+/-- For a finite nonempty family of positive-semidefinite pairs satisfying
+\(\ker B_i\subseteq\ker A_i\), equality between the relative entropy of the
+summed pair and the sum of the individual relative entropies makes the
+source-\(B\) support defect vanish at every \(t>0\).
+
+The proof follows the equality passage of Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 433--435, 652--674, and 788--790: the nonnegative
+gap integrand has zero integral, hence vanishes almost everywhere, and
+continuity upgrades this to pointwise vanishing. This theorem stops before
+the common projected resolvent conclusion at lines 788--793. -/
+theorem supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    (hker : ∀ i (v : n → ℂ), B i *ᵥ v = 0 → A i *ᵥ v = 0)
+    (hrel :
+      quantumRelativeEntropy (∑ i, A i) (∑ i, B i) =
+        ∑ i, quantumRelativeEntropy (A i) (B i)) :
+    ∀ {t : ℝ}, 0 < t →
+      let hAbar : (∑ i, A i).PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+      let hBbar : (∑ i, B i).PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+      (∑ i, supportSourceBQuadratic (hA i) (hB i) t) -
+        supportSourceBQuadratic hAbar hBbar t = 0 := by
+  classical
+  let f : ℝ → ℝ :=
+    supportRelativeEntropyFamilyGapIntegrand A B hA hB
+  have hgap :=
+    supportRelativeEntropyFamilyGapIntegrand_integrableOn_and_integral_eq
+      A B hA hB hker
+  have hfInt : IntegrableOn f (Ioi 0) := by
+    simpa only [f] using hgap.1
+  have hfCont : ContinuousOn f (Ioi 0) := by
+    simpa only [f] using
+      supportRelativeEntropyFamilyGapIntegrand_continuousOn A B hA hB hker
+  have hfNonneg : ∀ t ∈ Ioi (0 : ℝ), 0 ≤ f t := by
+    intro t ht
+    simpa only [f] using
+      supportRelativeEntropyFamilyGapIntegrand_nonneg A B hA hB hker ht
+  have hIntZero : ∫ t in Ioi (0 : ℝ), f t = 0 := by
+    rw [show (∫ t in Ioi (0 : ℝ), f t) =
+      (∑ i, quantumRelativeEntropy (A i) (B i)) -
+        quantumRelativeEntropy (∑ i, A i) (∑ i, B i) by
+          simpa only [f] using hgap.2]
+    exact sub_eq_zero.mpr hrel.symm
+  have haeNonneg : 0 ≤ᵐ[volume.restrict (Ioi (0 : ℝ))] f := by
+    filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+    exact hfNonneg t ht
+  have haeZero : f =ᵐ[volume.restrict (Ioi (0 : ℝ))] 0 :=
+    (integral_eq_zero_iff_of_nonneg_ae haeNonneg hfInt).mp hIntZero
+  have hpointZero : EqOn f 0 (Ioi (0 : ℝ)) :=
+    Measure.eqOn_open_of_ae_eq haeZero isOpen_Ioi hfCont continuousOn_const
+  intro t ht
+  dsimp only
+  have hfZero : f t = 0 := hpointZero ht
+  dsimp only [f, supportRelativeEntropyFamilyGapIntegrand] at hfZero
+  have hden : (1 + t : ℝ) ≠ 0 := by linarith
+  have hsum :
+      ((∑ i, rawSupportSourceAQuadratic (hA i) (hB i) t) -
+          rawSupportSourceAQuadratic
+            (Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i)
+            (Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i) t) +
+        t * ((∑ i, supportSourceBQuadratic (hA i) (hB i) t) -
+          supportSourceBQuadratic
+            (Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i)
+            (Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i) t) = 0 := by
+    rcases (div_eq_zero_iff.mp hfZero) with h | h
+    · exact h
+    · exact (hden h).elim
+  have hdefA :=
+    rawSupportSourceAQuadratic_sum_sub_nonneg A B hA hB hker ht
+  have hdefB :=
+    supportSourceBQuadratic_sum_sub_nonneg A B hA hB ht
+  nlinarith
 
 end Matrix

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
@@ -914,10 +914,76 @@
     one-pair continuity theorem and finite summation.
 \end{proof}
 
-% Open in #4435: the finite-family gap integral and both fixed-parameter
-% defect inequalities are established. It remains to pass from a zero
-% integral to pointwise vanishing and derive the common projected
-% relative-modular resolvent.
+\begin{theorem}[Nonnegativity of the finite-family support gap integrand]
+    \label{thm:support_relative_entropy_family_gap_integrand_nonnegative}
+    \lean{Matrix.supportRelativeEntropyFamilyGapIntegrand_nonneg}
+    \leanok
+    \uses{lem:support_sourceB_quadratic_sum_sub_nonnegative,
+        lem:unprojected_support_sourceA_quadratic_sum_sub_nonnegative}
+    Under the hypotheses and notation of
+    Theorem~\ref{thm:support_relative_entropy_family_gap_integral},
+    for every $t>0$ one has
+    \begin{align}
+        0
+        &\leq
+        \frac{\operatorname{Def}_A(t)+
+          t\operatorname{Def}_B(t)}{1+t}.
+        \notag
+    \end{align}
+    This is the coefficient-correct combination of the two source defects
+    in $(\mathrm{intAB})$ of Jen\v{c}ov\'a--Ruskai,
+    arXiv:0903.2895v4, lines~423--435.
+\end{theorem}
+
+\begin{proof}\leanok
+    Both defects are nonnegative. Since $t>0$ and $1+t>0$, multiplying the
+    source-$B$ defect by $t$, adding the source-$A$ defect, and dividing by
+    $1+t$ preserves nonnegativity.
+\end{proof}
+
+\begin{theorem}[Relative-entropy equality annihilates the source-$B$ defect]
+    \label{thm:support_sourceB_defect_zero_of_relative_entropy_sum_eq}
+    \lean{Matrix.supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq}
+    \leanok
+    \uses{thm:support_relative_entropy_family_gap_integral,
+        thm:support_relative_entropy_family_gap_integrand_nonnegative,
+        lem:unprojected_support_sourceA_quadratic_sum_sub_nonnegative,
+        lem:support_sourceB_quadratic_sum_sub_nonnegative}
+    Under the hypotheses of
+    Theorem~\ref{thm:support_relative_entropy_family_gap_integral}, suppose
+    \begin{align}
+        D(A_\Sigma\Vert B_\Sigma)
+        &=
+        \sum_{i\in I}D(A_i\Vert B_i).
+        \notag
+    \end{align}
+    Then, for every $t>0$,
+    \begin{align}
+        \operatorname{Def}_B(t)
+        &=
+        \sum_{i\in I}Q^B_{A_i,B_i}(t)
+          -Q^B_{A_\Sigma,B_\Sigma}(t)
+        =0.
+        \notag
+    \end{align}
+    This is the source-$B$ pointwise-vanishing passage in
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines~433--435, 652--674,
+    and 788--790. The common projected resolvent conclusion at
+    lines~788--793 is not asserted here.
+\end{theorem}
+
+\begin{proof}\leanok
+    The relative-entropy equality and
+    (\ref{eq:support_relative_entropy_family_gap_integral}) make the
+    integral of the nonnegative function $F$ vanish. Hence $F=0$ almost
+    everywhere. Its continuity on the open positive half-line upgrades
+    this to $F(t)=0$ for every $t>0$. Both defects are nonnegative, so
+    $\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)=0$, and $t>0$
+    forces $\operatorname{Def}_B(t)=0$.
+\end{proof}
+
+% Open in #4435: it remains to convert the pointwise source-B defect
+% equality into the common projected relative-modular resolvent.
 
 \begin{theorem}[Spectral resolvent representation of relative entropy]
     \label{thm:relative_entropy_resolvent_integral}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -443,9 +443,18 @@ there.
 and
 \leanid{Matrix.supportRelativeEntropyFamilyGapIntegrand_continuousOn} in
 \path{TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean}.}
-The remaining analytic passage must use nonnegativity and continuity to
-deduce pointwise vanishing from a zero integral and then derive the common
-projected shifted relative-modular resolvent.
+The two defect inequalities make this integrand nonnegative.  If the
+relative entropy of the summed pair equals the sum of the individual
+relative entropies, its integral is zero.  Almost-everywhere vanishing and
+continuity then give pointwise vanishing for every $t>0$; in particular, the
+source-$B$ defect vanishes there.
+\footnote{Formal declarations:
+\leanid{Matrix.supportRelativeEntropyFamilyGapIntegrand_nonneg} and
+\leanid{Matrix.supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq} in
+\path{TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean}.}
+The remaining passage must derive the common projected shifted
+relative-modular resolvent from this fixed-parameter source-$B$ defect
+equality.
 Following the latter step, consider two positive semidefinite pairs $(A,B)$ and
 $(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
 $B$, and write
@@ -495,13 +504,14 @@ $\operatorname{vec}(B^{\mathsf T})$.  This uses only the generalized-inverse
 identity $(B^{-1/2}_{\mathrm{supp}})^2B=P_B$.  The one-pair identity above
 also identifies this vector with the support-generalized-inverse solution of
 the left--right equation, and hence identifies the two source-$B$ quadratic
-forms.  Together with the two defect inequalities, it still does not show that
-equality of relative entropies makes either defect vanish.  The
-zero-integral-to-pointwise-vanishing passage and the resulting finite-family
-common projected resolvent theorem remain unformalized.  The kernel inclusion
-is already used for the unprojected source-$A$ inequality and remains an exact
-hypothesis of that source-facing equality theorem.  Consequently the singular
-Petz recovery identity is also still unformalized.
+forms.  Together with the integral and continuity argument above, equality
+of relative entropies now makes the real-valued source-$B$ defect vanish at
+every positive parameter.  What remains is to convert that equality into
+the complex quadratic-residual equality and derive the finite-family common
+projected resolvent theorem.  The kernel inclusion is already used for the
+unprojected source-$A$ inequality and remains an exact hypothesis of that
+source-facing equality theorem.  Consequently the singular Petz recovery
+identity is also still unformalized.
 
 In particular, the affine regularizations used to prove the inequality cannot
 by themselves prove its equality case.  Equality at the limiting pair implies

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -627,6 +627,23 @@ spectral split → block extraction → MPV calculation → strict bounds
   `NormalEdgeBlockingData.toThreeBlockGeometry` mirror-kill (see #4522), which would
   change the occurrence count before any promotion.
 
+### continuous nonnegative function with zero integral — candidate
+- **Pattern:** on the open positive half-line, turn pointwise nonnegativity into an
+  almost-everywhere inequality, use integrability and a zero integral to obtain
+  almost-everywhere vanishing, then use continuity and
+  `Measure.eqOn_open_of_ae_eq` to obtain pointwise vanishing.
+- **Seen:** 2 occurrences across 2 files:
+  `TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean` in
+  `weyl_sourceB_defect_eq_zero_of_gap_eq_zero`, and
+  `TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean` in
+  `supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq` (2026-07-27).
+- **Abstraction (proposed):** a measure-theoretic lemma taking `IntegrableOn f (Ioi 0)`,
+  `ContinuousOn f (Ioi 0)`, nonnegativity on `Ioi 0`, and zero restricted integral,
+  and returning `EqOn f 0 (Ioi 0)`.
+- **Notes:** Below the rule-of-three threshold. Keep the application-specific integrand
+  definitions and the subsequent arithmetic that isolates the source-\(B\) defect
+  outside the eventual helper.
+
 ---
 
 ## Rejected


### PR DESCRIPTION
## Summary

- prove nonnegativity of the finite-family support relative-entropy gap integrand
- prove that equality of summed and component relative entropies makes the source-B defect vanish for every positive resolvent parameter
- synchronize the Blueprint and the CPSV/Hayashi paper-gap record

## Source boundary

This follows Jenčová--Ruskai, arXiv:0903.2895v4, lines 423--435 for the two source defects and lines 652--674 and 788--790 for the zero-integral-to-pointwise passage. CPSV16 invokes the later Markov-structure result but does not supply this analytic equality argument.

The PR deliberately stops before the common projected relative-modular resolvent at lines 788--793 and before Petz recovery. It advances LionSR/QICLean#245 without closing it.

## Validation

- lake build TNLean.Channel.Schwarz.SupportRelativeEntropyGap
- lake build TNLean
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/check_reader_facing_prose.py --base-ref origin/main
- python3 scripts/generate_import_aggregators.py --check
- python3 scripts/tactic_pattern_scan.py
- git diff --check
- leanblueprint checkdecls
- leanblueprint pdf
- leanblueprint web
- visual inspection of Blueprint PDF pages 361--362 and paper-gap pages 9--10

Advances LionSR/QICLean#245.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds specialized measure-theoretic lemmas on existing Schwarz entropy infrastructure with no auth, data, or API surface changes; remaining work is clearly bounded.
> 
> **Overview**
> Formalizes the next Jenčová–Ruskai equality step for **finite families** of PSD matrix pairs: the support relative-entropy gap integrand is **nonnegative** on \(t>0\), and if summed relative entropy equals the sum of component entropies, the **source-\(B\)** support defect is **zero at every** positive resolvent parameter.
> 
> The main proof reuses existing integral, continuity, and defect-inequality lemmas: a zero integral of a nonnegative continuous integrand on \((0,\infty)\) yields pointwise vanishing, then `nlinarith` isolates the source-\(B\) term. **Common projected resolvents** and **Petz recovery** are explicitly still out of scope (#4435).
> 
> Blueprint ch19 and the CPSV/Hayashi paper-gap note are updated to mark this passage as done and to record what remains. A **tactic-pattern candidate** documents the shared “continuous nonnegative, zero integral ⇒ pointwise zero on `Ioi 0`” route (also used in the Weyl integral file).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f604bfb146a96ef6b44425e59b95d669c151c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->