### PR TITLE
feat(Channel): realize the HJPW common algebra by one channel

### DIFF
--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -11,3 +11,4 @@ Authors: TNLean contributors
 import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 import TNLean.Channel.KoashiImoto.FiniteRealization
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
+import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -9,3 +9,4 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.Channel.KoashiImoto
 
 import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
+import TNLean.Channel.KoashiImoto.FiniteRealization

--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -10,3 +10,4 @@ Authors: TNLean contributors
 
 import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 import TNLean.Channel.KoashiImoto.FiniteRealization
+import TNLean.Channel.KoashiImoto.PooledKrausFamily

--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -10,5 +10,6 @@ Authors: TNLean contributors
 
 import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 import TNLean.Channel.KoashiImoto.FiniteRealization
+import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
 import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto/FiniteRealization.lean
+++ b/TNLean/Channel/KoashiImoto/FiniteRealization.lean
@@ -10,8 +10,9 @@ import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 
 HJPW, arXiv:quant-ph/0304007v2, lines 844-846: the common invariant algebra
 `A_0 = ⋂_{F ∈ F} A_F` (an intersection over the possibly infinite set of preserving operations)
-"can actually be presented as a finite intersection `A_0 = A_{F_1} ∩ ... ∩ A_{F_M}`, ... [b]ecause
-all dimensions are finite." This file proves that step: an infimum of a family of
+"can actually be presented as a finite intersection
+`A_0 = A_{F_1} ∩ ... ∩ A_{F_M}`, ... [b]ecause all dimensions are finite." This file proves that
+step: an infimum of a family of
 star-subalgebras of a finite-dimensional matrix algebra, indexed by an arbitrary nonempty type,
 always equals the infimum over some finite nonempty subfamily.
 
@@ -113,8 +114,9 @@ families.
 theorem exists_finset_preservingKrausFamily_iInf_eq (ρ : Kidx → Mat)
     (hρbar : (commonAverage ρ).PosDef) :
     ∃ S : Finset (PreservingKrausFamily ρ), S.Nonempty ∧
-      ⨅ F ∈ S, adjointFixedPointsStarSubalgebra F.Kfam F.isPreserving.1 hρbar F.map_commonAverage
-        = commonInvariantStarSubalgebra ρ hρbar :=
+      (⨅ F ∈ S,
+        adjointFixedPointsStarSubalgebra F.Kfam F.isPreserving.1 hρbar F.map_commonAverage) =
+          commonInvariantStarSubalgebra ρ hρbar :=
   StarSubalgebra.exists_finset_iInf_eq
     (fun F : PreservingKrausFamily ρ =>
       adjointFixedPointsStarSubalgebra F.Kfam F.isPreserving.1 hρbar F.map_commonAverage)

--- a/TNLean/Channel/KoashiImoto/FiniteRealization.lean
+++ b/TNLean/Channel/KoashiImoto/FiniteRealization.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
+
+/-!
+# Finite realization of an infimum of star-subalgebras
+
+HJPW, arXiv:quant-ph/0304007v2, lines 844-846: the common invariant algebra
+`A_0 = ⋂_{F ∈ F} A_F` (an intersection over the possibly infinite set of preserving operations)
+"can actually be presented as a finite intersection `A_0 = A_{F_1} ∩ ... ∩ A_{F_M}`, ... [b]ecause
+all dimensions are finite." This file proves that step: an infimum of a family of
+star-subalgebras of a finite-dimensional matrix algebra, indexed by an arbitrary nonempty type,
+always equals the infimum over some finite nonempty subfamily.
+
+The argument is finite-dimensional descent, not a compactness argument: among the finite
+sub-infima containing a fixed base index, choose one of minimal dimension. If it were not the
+full infimum, adjoining one more offending index would strictly shrink it, and hence strictly
+decrease its (finite) dimension (`Submodule.finrank_lt_finrank_of_lt`), which cannot happen
+indefinitely.
+
+## Main declarations
+
+* `StarSubalgebra.exists_finset_iInf_eq`: an infimum of a family of star-subalgebras of a
+  finite-dimensional matrix algebra equals the infimum over some finite nonempty subfamily of
+  indices.
+* `Kraus.exists_finset_preservingKrausFamily_iInf_eq`: the common invariant algebra `A_0` equals
+  the intersection of the fixed-point subalgebras of finitely many preserving Kraus families
+  (HJPW, arXiv:quant-ph/0304007v2, lines 844-846).
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+
+namespace StarSubalgebra
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The dimension of a star-subalgebra of a finite-dimensional matrix algebra, computed at the
+submodule level so finite-dimensionality of the carrier is found by ordinary instance search. -/
+private noncomputable def srank (S : StarSubalgebra ℂ Mat) : ℕ :=
+  Module.finrank ℂ (Subalgebra.toSubmodule S.toSubalgebra)
+
+/-- Strict inclusion of star-subalgebras strictly decreases `srank`. -/
+private theorem srank_lt_srank_of_lt {S T : StarSubalgebra ℂ Mat} (h : S < T) :
+    srank S < srank T := by
+  have hsub : S.toSubalgebra < T.toSubalgebra :=
+    lt_of_le_of_ne (StarSubalgebra.toSubalgebra_le_iff.mpr h.le)
+      (fun heq => h.ne (StarSubalgebra.toSubalgebra_injective heq))
+  exact Submodule.finrank_lt_finrank_of_lt
+    ((Subalgebra.toSubmodule (R := ℂ) (A := Mat)).lt_iff_lt.mpr hsub)
+
+/-- **Finite realization of an infimum of star-subalgebras.**
+
+An infimum of a family of star-subalgebras of a finite-dimensional matrix algebra, indexed by an
+arbitrary nonempty type, equals the infimum over some finite nonempty subfamily of indices. The
+proof descends on the dimension of the sub-infimum: adjoining an index outside the current finite
+witness either already stabilizes it, or strictly decreases its (finite) dimension, which cannot
+happen indefinitely. -/
+theorem exists_finset_iInf_eq {ι : Type*} [Nonempty ι] (A : ι → StarSubalgebra ℂ Mat) :
+    ∃ S : Finset ι, S.Nonempty ∧ ⨅ i ∈ S, A i = ⨅ i, A i := by
+  classical
+  obtain ⟨i₀⟩ := (inferInstance : Nonempty ι)
+  suffices h : ∀ n : ℕ, ∀ S : Finset ι, i₀ ∈ S → srank (⨅ i ∈ S, A i) = n →
+      ∃ S' : Finset ι, S ⊆ S' ∧ ⨅ i ∈ S', A i = ⨅ i, A i by
+    obtain ⟨S', hSS', hS'⟩ :=
+      h (srank (⨅ i ∈ ({i₀} : Finset ι), A i)) {i₀} (Finset.mem_singleton_self i₀) rfl
+    exact ⟨S', ⟨i₀, hSS' (Finset.mem_singleton_self i₀)⟩, hS'⟩
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro S hi₀S hSn
+    by_cases hall : ∀ j : ι, ⨅ i ∈ S, A i ≤ A j
+    · exact ⟨S, Finset.Subset.refl S,
+        le_antisymm (le_iInf hall) (le_iInf₂ fun i _ => iInf_le A i)⟩
+    · push Not at hall
+      obtain ⟨j, hj⟩ := hall
+      have hmono : ⨅ i ∈ insert j S, A i ≤ ⨅ i ∈ S, A i :=
+        le_iInf₂ fun i hi => iInf₂_le i (Finset.mem_insert_of_mem hi)
+      have hne : ⨅ i ∈ insert j S, A i ≠ ⨅ i ∈ S, A i := fun heq =>
+        hj (heq ▸ iInf₂_le j (Finset.mem_insert_self j S))
+      have hlt : ⨅ i ∈ insert j S, A i < ⨅ i ∈ S, A i := lt_of_le_of_ne hmono hne
+      obtain ⟨S', hS'sub, hS'eq⟩ :=
+        ih (srank (⨅ i ∈ insert j S, A i)) (hSn ▸ srank_lt_srank_of_lt hlt)
+          (insert j S) (Finset.mem_insert_of_mem hi₀S) rfl
+      exact ⟨S', (Finset.subset_insert j S).trans hS'sub, hS'eq⟩
+
+end StarSubalgebra
+
+namespace Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+variable {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx]
+
+omit [Nonempty Kidx] in
+/-- **Finite realization of the common invariant algebra.**
+
+HJPW, arXiv:quant-ph/0304007v2, lines 844-846: "Because all dimensions are finite, it can
+actually be presented as a finite intersection `A_0 = A_{F_1} ∩ ... ∩ A_{F_M}`." This is that
+finite intersection, realized as the infimum over a finite nonempty `Finset` of preserving Kraus
+families.
+
+**Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
+`commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
+(arXiv:quant-ph/0304007v2, lines 761-763). Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+theorem exists_finset_preservingKrausFamily_iInf_eq (ρ : Kidx → Mat)
+    (hρbar : (commonAverage ρ).PosDef) :
+    ∃ S : Finset (PreservingKrausFamily ρ), S.Nonempty ∧
+      ⨅ F ∈ S, adjointFixedPointsStarSubalgebra F.Kfam F.isPreserving.1 hρbar F.map_commonAverage
+        = commonInvariantStarSubalgebra ρ hρbar :=
+  StarSubalgebra.exists_finset_iInf_eq
+    (fun F : PreservingKrausFamily ρ =>
+      adjointFixedPointsStarSubalgebra F.Kfam F.isPreserving.1 hρbar F.map_commonAverage)
+
+end Kraus

--- a/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -7,19 +7,19 @@ import TNLean.Channel.KoashiImoto.SingleWitness
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 
 /-!
-# HJPW's mean-ergodic projection onto the common invariant algebra
+# A trace-adjoint projection onto HJPW's common invariant algebra
 
 HJPW, arXiv:quant-ph/0304007v2, lines 838-851, introduces a Cesàro-limit projection `P_0^*`
 onto `A_0`. This file defines the corresponding map as the trace-pairing adjoint of the
 finite-dimensional Schrödinger mean-ergodic projection for the single witness `F_0` from
 `Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq`. The machinery in
 `TNLean.Analysis.MeanErgodic` and `TNLean.Channel.FixedPoint.MeanErgodicAdjoint` proves that this
-map is a positive, unital, idempotent retraction onto the adjoint fixed points. A bridge lemma
+map is a positive, unital, idempotent retraction onto the adjoint fixed points. A lemma
 identifies the trace-pairing adjoint of a Schrödinger Kraus map with its Heisenberg adjoint
 `Kraus.adjointMap`.
 
 This file does not prove that the Cesàro averages of the Heisenberg iterates converge to the
-packaged map; that source identity remains a separate analytic statement.
+trace-adjoint projection; that source identity remains a separate analytic statement.
 
 ## Main declarations
 
@@ -29,8 +29,8 @@ packaged map; that source identity remains a separate analytic statement.
   action is a trace-preserving map.
 * `Kraus.traceAdjointMap_mapLM`: the trace-pairing adjoint of a Kraus family's Schrödinger
   action is its Heisenberg adjoint map.
-* `Kraus.commonInvariantMeanErgodicProjection`: HJPW's `P_0^*`, the mean-ergodic projection of
-  the single witness `F_0`'s Heisenberg adjoint, derived via
+* `Kraus.commonInvariantMeanErgodicProjection`: the trace-adjoint projection associated with
+  the single witness `F_0`, derived via
   `IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`.
 * `Kraus.commonInvariantMeanErgodicProjection_isPositiveMap`,
   `Kraus.commonInvariantMeanErgodicProjection_one`,
@@ -143,12 +143,12 @@ theorem isTracePreservingMap_commonInvariantMapLM {Kidx : Type*} [Fintype Kidx] 
     IsTracePreservingMap (commonInvariantMapLM hρbar) :=
   isTracePreservingMap_mapLM_of_isTP _ (commonInvariantKrausFamily hρbar).isPreserving.1
 
-/-- **The packaged projection `P_0^*`.**
+/-- **The trace-adjoint projection associated with `F_0`.**
 
 This is the trace-pairing adjoint of the finite-dimensional Schrödinger mean-ergodic projection
-for the single witness `F_0`. Its positivity, unitality, idempotence, and range agree with HJPW's
-projection onto `A_0` (arXiv:quant-ph/0304007v2, lines 838-851). The convergence of the
-Heisenberg Cesàro averages to this map is not asserted here. -/
+for the single witness `F_0`. It is positive, unital, and idempotent, with range `A_0`. HJPW
+denotes the Heisenberg Cesàro limit by `P_0^*` (arXiv:quant-ph/0304007v2, lines 838-851);
+convergence of those averages to this map is not asserted here. -/
 noncomputable def commonInvariantMeanErgodicProjection
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρbar : (commonAverage ρ).PosDef) : Mat →ₗ[ℂ] Mat :=

--- a/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -43,9 +43,9 @@ adjoint (`Kraus.adjointMap`), via nondegeneracy of the trace pairing.
 (arXiv:quant-ph/0304007v2, lines 761-763). Documented in
 `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
 
-As in `SingleWitness.lean`, every declaration below states
-`{Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}` inline in its own signature
-rather than via a shared `variable` line, for the same reason recorded there.
+As in `SingleWitness.lean`, the declarations below state the finite state-family instances in
+their own signatures so that dependent projections through the bundled witness remain stable
+during elaboration.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators Matrix.Norms.Frobenius
@@ -149,8 +149,9 @@ the projection onto `A_0` derived from `F_0^*` by `P_0^*`." This is the finite-d
 mean-ergodic projection of the Heisenberg-picture adjoint of the single witness `F_0`, built
 from `LinearMap.meanErgodicProjection` (`TNLean.Analysis.MeanErgodic`) via the trace-pairing
 adjoint. -/
-noncomputable def commonInvariantMeanErgodicProjection {Kidx : Type*} [Fintype Kidx]
-    [Nonempty Kidx] {ρ : Kidx → Mat} (hρbar : (commonAverage ρ).PosDef) : Mat →ₗ[ℂ] Mat :=
+noncomputable def commonInvariantMeanErgodicProjection
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) : Mat →ₗ[ℂ] Mat :=
   Matrix.traceAdjointMap
     (LinearMap.meanErgodicProjection (commonInvariantMapLM hρbar)
       ((isPositiveMap_commonInvariantMapLM hρbar).hasBoundedOrbits_of_tracePreserving

--- a/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -1,0 +1,220 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.SingleWitness
+import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
+
+/-!
+# HJPW's mean-ergodic projection onto the common invariant algebra
+
+HJPW, arXiv:quant-ph/0304007v2, lines 838-851: "this algebra furthermore is the image of
+`B(H)` under the projection map `P^* = lim_{N→∞} (1/N) ∑_{n=1}^N (F^*)^n` ... Denote the
+projection onto `A_0` derived from `F_0^*` by `P_0^*`." This file builds that projection for the
+single witness `F_0` of `Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq`,
+using the finite-dimensional mean-ergodic machinery of `TNLean.Analysis.MeanErgodic` and
+`TNLean.Channel.FixedPoint.MeanErgodicAdjoint`: a Kraus map is completely positive (hence
+positive) and, when trace-preserving, its trace-pairing adjoint's mean-ergodic projection is a
+positive, unital, idempotent retraction onto the adjoint's fixed points. The remaining step is a
+bridge lemma identifying the trace-pairing adjoint of a Schrödinger Kraus map with its Heisenberg
+adjoint (`Kraus.adjointMap`), via nondegeneracy of the trace pairing.
+
+## Main declarations
+
+* `Kraus.isPositiveMap_mapLM`: the Schrödinger action of any Kraus family is a positive map
+  (it is completely positive).
+* `Kraus.isTracePreservingMap_mapLM_of_isTP`: a trace-preserving Kraus family's Schrödinger
+  action is a trace-preserving map.
+* `Matrix.traceAdjointMap_mapLM`: the trace-pairing adjoint of a Kraus family's Schrödinger
+  action is its Heisenberg adjoint map.
+* `Kraus.commonInvariantMeanErgodicProjection`: HJPW's `P_0^*`, the mean-ergodic projection of
+  the single witness `F_0`'s Heisenberg adjoint, derived via
+  `IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`.
+* `Kraus.commonInvariantMeanErgodicProjection_isPositiveMap`,
+  `Kraus.commonInvariantMeanErgodicProjection_one`,
+  `Kraus.commonInvariantMeanErgodicProjection_idempotent`: positivity, unitality, and
+  idempotence of `P_0^*`.
+* `Kraus.mem_range_commonInvariantMeanErgodicProjection_iff`: the range (equivalently, the
+  fixed-point set) of `P_0^*` is exactly the common invariant algebra `A_0`.
+
+**Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
+`commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
+(arXiv:quant-ph/0304007v2, lines 761-763). Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+
+As in `SingleWitness.lean`, every declaration below states
+`{Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}` inline in its own signature
+rather than via a shared `variable` line, for the same reason recorded there.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Matrix.Norms.Frobenius
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+section Bridge
+
+variable {d : ℕ}
+
+/-- **A Kraus family's Schrödinger action is completely positive.**
+
+`map K X = ∑ i, K i X (K i)ᴴ` is literally a Kraus sum, witnessing `IsCPMap` directly. -/
+theorem isCPMap_mapLM (K : Fin d → Mat) : IsCPMap (mapLM K) :=
+  ⟨d, K, fun X => (mapLM_apply K X).trans (map_apply K X)⟩
+
+/-- **A Kraus family's Schrödinger action is positive.**
+
+Completely positive maps are positive (`IsCPMap.isPositiveMap`). -/
+theorem isPositiveMap_mapLM (K : Fin d → Mat) : IsPositiveMap (mapLM K) :=
+  (isCPMap_mapLM K).isPositiveMap
+
+/-- **A trace-preserving Kraus family's Schrödinger action is a trace-preserving map.**
+
+`tr(E(X)) = tr(1 · E(X)) = tr(E^*(1) · X) = tr(1 · X) = tr(X)`, using the weighted trace
+identity `Kraus.trace_mul_map_eq_trace_adjointMap_mul` at `ρ := 1` and
+`Kraus.adjointMap_one_of_isTP`. -/
+theorem isTracePreservingMap_mapLM_of_isTP (K : Fin d → Mat) (h_tp : IsTP K) :
+    IsTracePreservingMap (mapLM K) := by
+  intro X
+  show Matrix.trace (mapLM K X) = Matrix.trace X
+  rw [mapLM_apply]
+  have h1 : Matrix.trace ((1 : Mat) * map K X) = Matrix.trace (adjointMap K 1 * X) :=
+    trace_mul_map_eq_trace_adjointMap_mul K 1 X
+  rw [one_mul] at h1
+  rw [h1, adjointMap_one_of_isTP K h_tp, one_mul]
+
+/-- **The trace-pairing adjoint of a Kraus family's Schrödinger action is its Heisenberg
+adjoint.**
+
+Both `Matrix.traceAdjointMap (mapLM K)` and `adjointMapLM K` satisfy the same trace-pairing
+characterization `tr(E^*(ρ) X) = tr(ρ E(X))` (`Matrix.trace_traceAdjointMap_mul` and
+`Kraus.trace_mul_map_eq_trace_adjointMap_mul`), so they agree by nondegeneracy of the trace
+pairing (`Matrix.ext_iff_trace_mul_right`). -/
+theorem traceAdjointMap_mapLM (K : Fin d → Mat) :
+    Matrix.traceAdjointMap (mapLM K) = adjointMapLM K := by
+  apply LinearMap.ext
+  intro ρ
+  refine (Matrix.ext_iff_trace_mul_right
+    (A := Matrix.traceAdjointMap (mapLM K) ρ) (B := adjointMapLM K ρ)).2 fun X => ?_
+  rw [Matrix.trace_traceAdjointMap_mul, mapLM_apply, adjointMapLM_apply,
+    trace_mul_map_eq_trace_adjointMap_mul]
+
+end Bridge
+
+section CommonInvariantProjection
+
+/-- **HJPW's single witness `F_0`.**
+
+arXiv:quant-ph/0304007v2, lines 846-849: the preserving Kraus family with `A_0 = A_{F_0}`,
+given by `Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq`. -/
+noncomputable def commonInvariantKrausFamily {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx]
+    {ρ : Kidx → Mat} (hρbar : (commonAverage ρ).PosDef) : PreservingKrausFamily ρ :=
+  (exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq hρbar).choose
+
+/-- The witness `F_0`'s adjoint fixed-point subalgebra is exactly `A_0`
+(arXiv:quant-ph/0304007v2, lines 846-847). -/
+theorem adjointFixedPointsStarSubalgebra_commonInvariantKrausFamily
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) :
+    adjointFixedPointsStarSubalgebra (commonInvariantKrausFamily hρbar).Kfam
+        (commonInvariantKrausFamily hρbar).isPreserving.1 hρbar
+        (commonInvariantKrausFamily hρbar).map_commonAverage
+      = commonInvariantStarSubalgebra ρ hρbar :=
+  (exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq hρbar).choose_spec
+
+/-- The Schrödinger action of the witness `F_0`, as a matrix endomorphism. -/
+noncomputable def commonInvariantMapLM {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx]
+    {ρ : Kidx → Mat} (hρbar : (commonAverage ρ).PosDef) : Mat →ₗ[ℂ] Mat :=
+  mapLM (commonInvariantKrausFamily hρbar).Kfam
+
+theorem isPositiveMap_commonInvariantMapLM {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx]
+    {ρ : Kidx → Mat} (hρbar : (commonAverage ρ).PosDef) :
+    IsPositiveMap (commonInvariantMapLM hρbar) :=
+  isPositiveMap_mapLM _
+
+theorem isTracePreservingMap_commonInvariantMapLM {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx]
+    {ρ : Kidx → Mat} (hρbar : (commonAverage ρ).PosDef) :
+    IsTracePreservingMap (commonInvariantMapLM hρbar) :=
+  isTracePreservingMap_mapLM_of_isTP _ (commonInvariantKrausFamily hρbar).isPreserving.1
+
+/-- **HJPW's projection `P_0^*`.**
+
+arXiv:quant-ph/0304007v2, lines 838-851: "`P^* = lim_{N→∞} (1/N) ∑_{n=1}^N (F^*)^n` ... Denote
+the projection onto `A_0` derived from `F_0^*` by `P_0^*`." This is the finite-dimensional
+mean-ergodic projection of the Heisenberg-picture adjoint of the single witness `F_0`, built
+from `LinearMap.meanErgodicProjection` (`TNLean.Analysis.MeanErgodic`) via the trace-pairing
+adjoint. -/
+noncomputable def commonInvariantMeanErgodicProjection {Kidx : Type*} [Fintype Kidx]
+    [Nonempty Kidx] {ρ : Kidx → Mat} (hρbar : (commonAverage ρ).PosDef) : Mat →ₗ[ℂ] Mat :=
+  Matrix.traceAdjointMap
+    (LinearMap.meanErgodicProjection (commonInvariantMapLM hρbar)
+      ((isPositiveMap_commonInvariantMapLM hρbar).hasBoundedOrbits_of_tracePreserving
+        (isTracePreservingMap_commonInvariantMapLM hρbar)))
+
+/-- The defining bundle of properties of `P_0^*`, transported directly from
+`IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`. -/
+theorem commonInvariantMeanErgodicProjection_bundle
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) :
+    IsPositiveMap (commonInvariantMeanErgodicProjection hρbar) ∧
+      commonInvariantMeanErgodicProjection hρbar 1 = 1 ∧
+      (∀ Y, commonInvariantMeanErgodicProjection hρbar
+          (commonInvariantMeanErgodicProjection hρbar Y) =
+        commonInvariantMeanErgodicProjection hρbar Y) ∧
+      LinearMap.range (commonInvariantMeanErgodicProjection hρbar) =
+        LinearMap.ker (Matrix.traceAdjointMap (commonInvariantMapLM hρbar) - 1) ∧
+      (∀ Y, commonInvariantMeanErgodicProjection hρbar Y = Y ↔
+        Matrix.traceAdjointMap (commonInvariantMapLM hρbar) Y = Y) := by
+  unfold commonInvariantMeanErgodicProjection
+  exact IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction
+    (isPositiveMap_commonInvariantMapLM hρbar) (isTracePreservingMap_commonInvariantMapLM hρbar)
+
+/-- **Positivity of `P_0^*`.** -/
+theorem commonInvariantMeanErgodicProjection_isPositiveMap
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) :
+    IsPositiveMap (commonInvariantMeanErgodicProjection hρbar) :=
+  (commonInvariantMeanErgodicProjection_bundle hρbar).1
+
+/-- **Unitality of `P_0^*`.** -/
+theorem commonInvariantMeanErgodicProjection_one
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) :
+    commonInvariantMeanErgodicProjection hρbar 1 = 1 :=
+  (commonInvariantMeanErgodicProjection_bundle hρbar).2.1
+
+/-- **Idempotence of `P_0^*`.** -/
+theorem commonInvariantMeanErgodicProjection_idempotent
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) (Y : Mat) :
+    commonInvariantMeanErgodicProjection hρbar (commonInvariantMeanErgodicProjection hρbar Y)
+      = commonInvariantMeanErgodicProjection hρbar Y :=
+  (commonInvariantMeanErgodicProjection_bundle hρbar).2.2.1 Y
+
+/-- **The range of `P_0^*` is the common invariant algebra `A_0`.**
+
+arXiv:quant-ph/0304007v2, line 843: `A_0` is the fixed-point set of every preserving operation's
+adjoint map, in particular of `F_0^*`; the mean-ergodic projection `P_0^*` is idempotent with
+range exactly that fixed-point set. -/
+theorem mem_range_commonInvariantMeanErgodicProjection_iff
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) (Y : Mat) :
+    Y ∈ LinearMap.range (commonInvariantMeanErgodicProjection hρbar) ↔
+      Y ∈ commonInvariantStarSubalgebra ρ hρbar := by
+  obtain ⟨-, -, -, hrange, -⟩ := commonInvariantMeanErgodicProjection_bundle hρbar
+  rw [hrange, LinearMap.mem_ker, LinearMap.sub_apply, Module.End.one_apply, sub_eq_zero]
+  change Matrix.traceAdjointMap (mapLM (commonInvariantKrausFamily hρbar).Kfam) Y = Y ↔ _
+  rw [traceAdjointMap_mapLM, adjointMapLM_apply, ← mem_adjointFixedPoints,
+    ← mem_adjointFixedPointsStarSubalgebra (commonInvariantKrausFamily hρbar).Kfam
+      (commonInvariantKrausFamily hρbar).isPreserving.1 hρbar
+      (commonInvariantKrausFamily hρbar).map_commonAverage,
+    adjointFixedPointsStarSubalgebra_commonInvariantKrausFamily]
+
+end CommonInvariantProjection
+
+end Kraus

--- a/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -27,7 +27,7 @@ packaged map; that source identity remains a separate analytic statement.
   (it is completely positive).
 * `Kraus.isTracePreservingMap_mapLM_of_isTP`: a trace-preserving Kraus family's Schrödinger
   action is a trace-preserving map.
-* `Matrix.traceAdjointMap_mapLM`: the trace-pairing adjoint of a Kraus family's Schrödinger
+* `Kraus.traceAdjointMap_mapLM`: the trace-pairing adjoint of a Kraus family's Schrödinger
   action is its Heisenberg adjoint map.
 * `Kraus.commonInvariantMeanErgodicProjection`: HJPW's `P_0^*`, the mean-ergodic projection of
   the single witness `F_0`'s Heisenberg adjoint, derived via
@@ -58,7 +58,7 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-section Bridge
+section TraceAdjointHeisenbergIdentification
 
 variable {d : ℕ}
 
@@ -105,7 +105,7 @@ theorem traceAdjointMap_mapLM (K : Fin d → Mat) :
   rw [Matrix.trace_traceAdjointMap_mul, mapLM_apply, adjointMapLM_apply,
     trace_mul_map_eq_trace_adjointMap_mul]
 
-end Bridge
+end TraceAdjointHeisenbergIdentification
 
 section CommonInvariantProjection
 

--- a/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -9,16 +9,17 @@ import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 /-!
 # HJPW's mean-ergodic projection onto the common invariant algebra
 
-HJPW, arXiv:quant-ph/0304007v2, lines 838-851: "this algebra furthermore is the image of
-`B(H)` under the projection map `P^* = lim_{N→∞} (1/N) ∑_{n=1}^N (F^*)^n` ... Denote the
-projection onto `A_0` derived from `F_0^*` by `P_0^*`." This file builds that projection for the
-single witness `F_0` of `Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq`,
-using the finite-dimensional mean-ergodic machinery of `TNLean.Analysis.MeanErgodic` and
-`TNLean.Channel.FixedPoint.MeanErgodicAdjoint`: a Kraus map is completely positive (hence
-positive) and, when trace-preserving, its trace-pairing adjoint's mean-ergodic projection is a
-positive, unital, idempotent retraction onto the adjoint's fixed points. The remaining step is a
-bridge lemma identifying the trace-pairing adjoint of a Schrödinger Kraus map with its Heisenberg
-adjoint (`Kraus.adjointMap`), via nondegeneracy of the trace pairing.
+HJPW, arXiv:quant-ph/0304007v2, lines 838-851, introduces a Cesàro-limit projection `P_0^*`
+onto `A_0`. This file defines the corresponding map as the trace-pairing adjoint of the
+finite-dimensional Schrödinger mean-ergodic projection for the single witness `F_0` from
+`Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq`. The machinery in
+`TNLean.Analysis.MeanErgodic` and `TNLean.Channel.FixedPoint.MeanErgodicAdjoint` proves that this
+map is a positive, unital, idempotent retraction onto the adjoint fixed points. A bridge lemma
+identifies the trace-pairing adjoint of a Schrödinger Kraus map with its Heisenberg adjoint
+`Kraus.adjointMap`.
+
+This file does not prove that the Cesàro averages of the Heisenberg iterates converge to the
+packaged map; that source identity remains a separate analytic statement.
 
 ## Main declarations
 
@@ -142,13 +143,12 @@ theorem isTracePreservingMap_commonInvariantMapLM {Kidx : Type*} [Fintype Kidx] 
     IsTracePreservingMap (commonInvariantMapLM hρbar) :=
   isTracePreservingMap_mapLM_of_isTP _ (commonInvariantKrausFamily hρbar).isPreserving.1
 
-/-- **HJPW's projection `P_0^*`.**
+/-- **The packaged projection `P_0^*`.**
 
-arXiv:quant-ph/0304007v2, lines 838-851: "`P^* = lim_{N→∞} (1/N) ∑_{n=1}^N (F^*)^n` ... Denote
-the projection onto `A_0` derived from `F_0^*` by `P_0^*`." This is the finite-dimensional
-mean-ergodic projection of the Heisenberg-picture adjoint of the single witness `F_0`, built
-from `LinearMap.meanErgodicProjection` (`TNLean.Analysis.MeanErgodic`) via the trace-pairing
-adjoint. -/
+This is the trace-pairing adjoint of the finite-dimensional Schrödinger mean-ergodic projection
+for the single witness `F_0`. Its positivity, unitality, idempotence, and range agree with HJPW's
+projection onto `A_0` (arXiv:quant-ph/0304007v2, lines 838-851). The convergence of the
+Heisenberg Cesàro averages to this map is not asserted here. -/
 noncomputable def commonInvariantMeanErgodicProjection
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρbar : (commonAverage ρ).PosDef) : Mat →ₗ[ℂ] Mat :=

--- a/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
+++ b/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
@@ -11,9 +11,9 @@ import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 HJPW, arXiv:quant-ph/0304007v2, lines 847-849: given finitely many preserving Kraus families
 `F_1, ..., F_M`, "there is `F_0 ∈ F` such that `A_0 = A_{F_0}`. We may take, for example,
 `F_0 = (1/M) ∑_μ F_μ`". This file constructs that averaged channel `F_0` at the level of Kraus
-operators: the Kraus operators of every `F_μ` are pooled into one family (reindexed from the
-dependent sum `Σ μ, Fin (r μ)` to a single `Fin` via `finSigmaFinEquiv`) and scaled by `1/√M`, so
-that the pooled Kraus map is exactly the average `(1/M) ∑_μ map (F μ).Kfam` -- the Schrödinger
+operators: the Kraus operators of every `F_μ` are pooled into one family, reindexed from the
+dependent sum `Σ μ, Fin (r μ)` to a single `Fin` via `finSigmaFinEquiv`, and scaled by `1/√M`.
+Thus the pooled Kraus map is exactly the average `(1/M) ∑_μ map (F μ).Kfam` -- the Schrödinger
 action of a Kraus family is quadratic in its Kraus operators, so a `1/√M` rescaling of every
 operator produces a `1/M` rescaling of the map. It proves the pooled family preserves `ρ`
 (`isPreserving_pooledKfam`), and that its adjoint fixed-point subalgebra is exactly the
@@ -53,8 +53,8 @@ variable {M : ℕ} [NeZero M] {r : Fin M → ℕ}
 
 /-- **The pooling scale factor.**
 
-HJPW, arXiv:quant-ph/0304007v2, line 849: `F_0 = (1/M) ∑_μ F_μ`. Since the Schrödinger action of
-a Kraus family is quadratic in its Kraus operators, scaling every pooled Kraus operator by
+HJPW, arXiv:quant-ph/0304007v2, line 849: `F_0 = (1/M) ∑_μ F_μ`. The Schrödinger action of a
+Kraus family is quadratic in its Kraus operators, so scaling every pooled Kraus operator by
 `1/√M` scales the pooled Kraus map by `1/M`, realizing the average. -/
 noncomputable def poolScale (M : ℕ) : ℝ := (Real.sqrt M)⁻¹
 
@@ -64,7 +64,8 @@ theorem poolScale_sq : poolScale M * poolScale M = (M : ℝ)⁻¹ := by
   rw [← mul_inv, Real.mul_self_sqrt (Nat.cast_nonneg M)]
 
 omit [NeZero M] in
-theorem cpow_poolScale_sq : ((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ) = (M : ℂ)⁻¹ := by
+theorem cpow_poolScale_sq :
+    ((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ) = (M : ℂ)⁻¹ := by
   rw [← Complex.ofReal_mul, poolScale_sq (M := M), Complex.ofReal_inv, Complex.ofReal_natCast]
 
 /-- **The pooled Kraus family.**
@@ -77,8 +78,8 @@ noncomputable def pooledKfam (K : (μ : Fin M) → Fin (r μ) → Mat) :
   fun k => ((poolScale M : ℝ) : ℂ) • K (finSigmaFinEquiv.symm k).1 (finSigmaFinEquiv.symm k).2
 
 omit [NeZero M] in
-/-- A sum over the pooled index `Fin (∑ μ, r μ)`, reindexed along `finSigmaFinEquiv`, splits into
-the double sum over `μ` and the Kraus index of `K μ`. -/
+/-- A sum over the pooled index `Fin (∑ μ, r μ)`, reindexed along `finSigmaFinEquiv`, splits
+into the double sum over `μ` and the Kraus index of `K μ`. -/
 private theorem sum_pooled_reindex {β : Type*} [AddCommMonoid β]
     (f : (Σ _μ : Fin M, Fin (r _μ)) → β) :
     ∑ k : Fin (∑ μ, r μ), f (finSigmaFinEquiv.symm k) = ∑ μ, ∑ i, f ⟨μ, i⟩ := by

--- a/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
+++ b/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
@@ -30,8 +30,8 @@ the remaining content of lines 847-849, short of identifying `A_0` itself
 * `Kraus.isPreserving_pooledKfam`: the pooled family preserves `ρ` when every block does
   (HJPW, line 849).
 * `Kraus.averagedPreservingKrausFamily`: the pooled family bundled as a `PreservingKrausFamily`.
-* `Kraus.krausCommutant_pooledKfam_eq_iInf`: the Kraus commutant of the pooled family is the
-  intersection of the individual commutants.
+* `Kraus.krausCommutantStarSubalgebra_pooledKfam_eq_iInf`: the Kraus commutant of the
+  pooled family is the intersection of the individual commutants.
 * `Kraus.adjointFixedPointsStarSubalgebra_pooledKfam_eq_iInf`: the adjoint fixed-point
   subalgebra of the pooled family is the intersection of those of the individual families,
   via `Kraus.adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra` and the

--- a/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
+++ b/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
@@ -142,6 +142,23 @@ noncomputable def averagedPreservingKrausFamily {Kidx : Type*} {ρ : Kidx → Ma
     ⟨isTP_pooledKfam _ (fun μ => (F μ).isPreserving.1),
       isPreserving_pooledKfam _ (fun μ => (F μ).isPreserving.2)⟩
 
+/-- The Kraus family of the pooled/averaged witness, spelled out at the `pooledKfam` level.
+
+Proved as a standalone `rfl` lemma, in the same section as `averagedPreservingKrausFamily` itself
+(before `Fintype`/`Nonempty` hypotheses on the state index enter scope elsewhere in this
+development), so downstream files can `rw` through it instead of relying on the kernel to unfold
+`averagedPreservingKrausFamily` afresh in a different typeclass context. -/
+theorem averagedPreservingKrausFamily_Kfam {Kidx : Type*} {ρ : Kidx → Mat}
+    (F : Fin M → PreservingKrausFamily ρ) :
+    (averagedPreservingKrausFamily F).Kfam = pooledKfam (fun μ => (F μ).Kfam) := rfl
+
+/-- The `IsTP` witness of the pooled/averaged family, spelled out at the `isTP_pooledKfam`
+level. See `Kraus.averagedPreservingKrausFamily_Kfam` for why this is recorded standalone. -/
+theorem averagedPreservingKrausFamily_isTP {Kidx : Type*} {ρ : Kidx → Mat}
+    (F : Fin M → PreservingKrausFamily ρ) :
+    (averagedPreservingKrausFamily F).isPreserving.1
+      = isTP_pooledKfam (fun μ => (F μ).Kfam) (fun μ => (F μ).isPreserving.1) := rfl
+
 /-- **A pooled family fixed by every block fixes the (single) common average.**
 
 The single-matrix specialization of `Kraus.map_pooledKfam` needed to feed

--- a/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
+++ b/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
+
+/-!
+# The pooled and averaged Kraus family of a finite family
+
+HJPW, arXiv:quant-ph/0304007v2, lines 847-849: given finitely many preserving Kraus families
+`F_1, ..., F_M`, "there is `F_0 ∈ F` such that `A_0 = A_{F_0}`. We may take, for example,
+`F_0 = (1/M) ∑_μ F_μ`". This file constructs that averaged channel `F_0` at the level of Kraus
+operators: the Kraus operators of every `F_μ` are pooled into one family (reindexed from the
+dependent sum `Σ μ, Fin (r μ)` to a single `Fin` via `finSigmaFinEquiv`) and scaled by `1/√M`, so
+that the pooled Kraus map is exactly the average `(1/M) ∑_μ map (F μ).Kfam` -- the Schrödinger
+action of a Kraus family is quadratic in its Kraus operators, so a `1/√M` rescaling of every
+operator produces a `1/M` rescaling of the map. It proves the pooled family preserves `ρ`
+(`isPreserving_pooledKfam`), and that its adjoint fixed-point subalgebra is exactly the
+intersection of the individual ones (`adjointFixedPointsStarSubalgebra_pooledKfam_eq_iInf`) --
+the remaining content of lines 847-849, short of identifying `A_0` itself
+(`Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq`, in a follow-up file).
+
+## Main declarations
+
+* `Kraus.poolScale`: the `1/√M` rescaling factor.
+* `Kraus.pooledKfam`: the pooled, `1/√M`-scaled Kraus family of `M` Kraus families.
+* `Kraus.map_pooledKfam`: the pooled Kraus map is the average of the individual ones.
+* `Kraus.isTP_pooledKfam`: the pooled family is trace-preserving when every block is.
+* `Kraus.isPreserving_pooledKfam`: the pooled family preserves `ρ` when every block does
+  (HJPW, line 849).
+* `Kraus.averagedPreservingKrausFamily`: the pooled family bundled as a `PreservingKrausFamily`.
+* `Kraus.krausCommutant_pooledKfam_eq_iInf`: the Kraus commutant of the pooled family is the
+  intersection of the individual commutants.
+* `Kraus.adjointFixedPointsStarSubalgebra_pooledKfam_eq_iInf`: the adjoint fixed-point
+  subalgebra of the pooled family is the intersection of those of the individual families,
+  via `Kraus.adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra` and the
+  invariance of the Kraus commutant under a nonzero scalar rescaling of the Kraus operators.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+section Pooling
+
+variable {M : ℕ} [NeZero M] {r : Fin M → ℕ}
+
+/-- **The pooling scale factor.**
+
+HJPW, arXiv:quant-ph/0304007v2, line 849: `F_0 = (1/M) ∑_μ F_μ`. Since the Schrödinger action of
+a Kraus family is quadratic in its Kraus operators, scaling every pooled Kraus operator by
+`1/√M` scales the pooled Kraus map by `1/M`, realizing the average. -/
+noncomputable def poolScale (M : ℕ) : ℝ := (Real.sqrt M)⁻¹
+
+omit [NeZero M] in
+theorem poolScale_sq : poolScale M * poolScale M = (M : ℝ)⁻¹ := by
+  unfold poolScale
+  rw [← mul_inv, Real.mul_self_sqrt (Nat.cast_nonneg M)]
+
+omit [NeZero M] in
+theorem cpow_poolScale_sq : ((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ) = (M : ℂ)⁻¹ := by
+  rw [← Complex.ofReal_mul, poolScale_sq (M := M), Complex.ofReal_inv, Complex.ofReal_natCast]
+
+/-- **The pooled Kraus family.**
+
+The Kraus operators of `M` families `K μ : Fin (r μ) → Mat`, pooled into a single family
+indexed by `Fin (∑ μ, r μ)` via `finSigmaFinEquiv` and scaled by `1/√M`
+(HJPW, arXiv:quant-ph/0304007v2, line 849). -/
+noncomputable def pooledKfam (K : (μ : Fin M) → Fin (r μ) → Mat) :
+    Fin (∑ μ, r μ) → Mat :=
+  fun k => ((poolScale M : ℝ) : ℂ) • K (finSigmaFinEquiv.symm k).1 (finSigmaFinEquiv.symm k).2
+
+omit [NeZero M] in
+/-- A sum over the pooled index `Fin (∑ μ, r μ)`, reindexed along `finSigmaFinEquiv`, splits into
+the double sum over `μ` and the Kraus index of `K μ`. -/
+private theorem sum_pooled_reindex {β : Type*} [AddCommMonoid β]
+    (f : (Σ _μ : Fin M, Fin (r _μ)) → β) :
+    ∑ k : Fin (∑ μ, r μ), f (finSigmaFinEquiv.symm k) = ∑ μ, ∑ i, f ⟨μ, i⟩ := by
+  rw [Equiv.sum_comp finSigmaFinEquiv.symm f, ← Finset.univ_sigma_univ, Finset.sum_sigma]
+
+omit [NeZero M] in
+/-- **The pooled Kraus map is the average of the individual ones.**
+
+HJPW, arXiv:quant-ph/0304007v2, line 849: `F_0 = (1/M) ∑_μ F_μ`. -/
+theorem map_pooledKfam (K : (μ : Fin M) → Fin (r μ) → Mat) (X : Mat) :
+    map (pooledKfam K) X = (M : ℂ)⁻¹ • ∑ μ, map (K μ) X := by
+  have hstep : map (pooledKfam K) X
+      = (M : ℂ)⁻¹ • ∑ μ, ∑ i, K μ i * X * (K μ i)ᴴ := by
+    change ∑ k : Fin (∑ μ, r μ), pooledKfam K k * X * (pooledKfam K k)ᴴ = _
+    simp only [pooledKfam, Matrix.conjTranspose_smul, Complex.star_def,
+      Complex.conj_ofReal, smul_mul_assoc, mul_smul_comm, smul_smul]
+    rw [sum_pooled_reindex (fun p => (((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ)) •
+      (K p.1 p.2 * X * (K p.1 p.2)ᴴ))]
+    simp only [cpow_poolScale_sq, ← Finset.smul_sum]
+  rw [hstep]
+  simp only [map]
+
+/-- **The pooled family is trace-preserving when every block is.** -/
+theorem isTP_pooledKfam (K : (μ : Fin M) → Fin (r μ) → Mat) (hK : ∀ μ, IsTP (K μ)) :
+    IsTP (pooledKfam K) := by
+  have hstep : ∑ k : Fin (∑ μ, r μ), (pooledKfam K k)ᴴ * pooledKfam K k
+      = (M : ℂ)⁻¹ • ∑ μ, ∑ i, (K μ i)ᴴ * K μ i := by
+    simp only [pooledKfam, Matrix.conjTranspose_smul, Complex.star_def, Complex.conj_ofReal,
+      smul_mul_assoc, mul_smul_comm, smul_smul]
+    rw [sum_pooled_reindex (fun p => (((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ)) •
+      ((K p.1 p.2)ᴴ * K p.1 p.2))]
+    simp only [cpow_poolScale_sq, ← Finset.smul_sum]
+  change ∑ k : Fin (∑ μ, r μ), (pooledKfam K k)ᴴ * pooledKfam K k = 1
+  rw [hstep]
+  have hK' : ∀ μ : Fin M, ∑ i, (K μ i)ᴴ * K μ i = (1 : Mat) := hK
+  simp only [hK', Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+  rw [← Nat.cast_smul_eq_nsmul ℂ, smul_smul,
+    inv_mul_cancel₀ (by exact_mod_cast (NeZero.ne M)), one_smul]
+
+/-- **The pooled family preserves `ρ` when every block does.**
+
+HJPW, arXiv:quant-ph/0304007v2, line 849. -/
+theorem isPreserving_pooledKfam {Kidx : Type*} {ρ : Kidx → Mat}
+    (K : (μ : Fin M) → Fin (r μ) → Mat) (hK : ∀ μ, ∀ x : Kidx, map (K μ) (ρ x) = ρ x)
+    (x : Kidx) :
+    map (pooledKfam K) (ρ x) = ρ x := by
+  rw [map_pooledKfam]
+  have hconst : ∀ μ : Fin M, map (K μ) (ρ x) = ρ x := fun μ => hK μ x
+  simp only [hconst, Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+  rw [← Nat.cast_smul_eq_nsmul ℂ, smul_smul,
+    inv_mul_cancel₀ (by exact_mod_cast (NeZero.ne M)), one_smul]
+
+/-- **The pooled family, bundled as a `PreservingKrausFamily`.**
+
+HJPW, arXiv:quant-ph/0304007v2, line 849: `F_0 = (1/M) ∑_μ F_μ` as an element of **F**. -/
+noncomputable def averagedPreservingKrausFamily {Kidx : Type*} {ρ : Kidx → Mat}
+    (F : Fin M → PreservingKrausFamily ρ) : PreservingKrausFamily ρ where
+  numKraus := ∑ μ, (F μ).numKraus
+  Kfam := pooledKfam (fun μ => (F μ).Kfam)
+  isPreserving :=
+    ⟨isTP_pooledKfam _ (fun μ => (F μ).isPreserving.1),
+      isPreserving_pooledKfam _ (fun μ => (F μ).isPreserving.2)⟩
+
+/-- **A pooled family fixed by every block fixes the (single) common average.**
+
+The single-matrix specialization of `Kraus.map_pooledKfam` needed to feed
+`Kraus.adjointFixedPointsStarSubalgebra`, which takes a single fixed matrix rather than a
+`Kidx`-indexed family. -/
+theorem map_pooledKfam_fixed (K : (μ : Fin M) → Fin (r μ) → Mat) {ρbar : Mat}
+    (hfix : ∀ μ, map (K μ) ρbar = ρbar) :
+    map (pooledKfam K) ρbar = ρbar := by
+  rw [map_pooledKfam]
+  simp only [hfix, Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+  rw [← Nat.cast_smul_eq_nsmul ℂ, smul_smul,
+    inv_mul_cancel₀ (by exact_mod_cast (NeZero.ne M)), one_smul]
+
+theorem poolScale_ne_zero : ((poolScale M : ℝ) : ℂ) ≠ 0 := by
+  have h0 : (0 : ℝ) < poolScale M := by
+    unfold poolScale
+    exact inv_pos.mpr (Real.sqrt_pos.mpr (by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne M)))
+  exact_mod_cast h0.ne'
+
+omit [NeZero M] in
+/-- Commuting with a nonzero scalar multiple of a matrix is the same as commuting with the
+matrix itself. The scalar-commutation step behind
+`Kraus.mem_krausCommutant_pooledKfam_iff`. -/
+private theorem commute_smul_iff {c : ℂ} (hc : c ≠ 0) (X B : Mat) :
+    X * (c • B) = (c • B) * X ↔ X * B = B * X := by
+  rw [mul_smul_comm, smul_mul_assoc, (isUnit_iff_ne_zero.mpr hc).smul_left_cancel]
+
+/-- **The Kraus commutant of the pooled family is the intersection of the individual ones.**
+
+Scaling every Kraus operator of a family by the same nonzero scalar does not change its
+commutant, so pooling (a bijective reindexing) and rescaling the Kraus operators of `M`
+families does not change the intersection of their commutants. -/
+theorem mem_krausCommutant_pooledKfam_iff (K : (μ : Fin M) → Fin (r μ) → Mat) (X : Mat) :
+    X ∈ krausCommutant (pooledKfam K) ↔ ∀ μ, X ∈ krausCommutant (K μ) := by
+  have hcancel : ∀ p : Σ _μ : Fin M, Fin (r _μ),
+      (X * pooledKfam K (finSigmaFinEquiv p) = pooledKfam K (finSigmaFinEquiv p) * X ∧
+        X * (pooledKfam K (finSigmaFinEquiv p))ᴴ = (pooledKfam K (finSigmaFinEquiv p))ᴴ * X) ↔
+      (X * K p.1 p.2 = K p.1 p.2 * X ∧ X * (K p.1 p.2)ᴴ = (K p.1 p.2)ᴴ * X) := fun p => by
+    simp only [pooledKfam]
+    rw [finSigmaFinEquiv.symm_apply_apply]
+    simp only [Matrix.conjTranspose_smul, Complex.star_def, Complex.conj_ofReal,
+      commute_smul_iff poolScale_ne_zero]
+  simp only [mem_krausCommutant]
+  constructor
+  · intro h μ i
+    exact (hcancel ⟨μ, i⟩).mp (h (finSigmaFinEquiv ⟨μ, i⟩))
+  · intro h k
+    rw [show k = finSigmaFinEquiv (finSigmaFinEquiv.symm k) from
+      (finSigmaFinEquiv.apply_symm_apply k).symm]
+    exact (hcancel (finSigmaFinEquiv.symm k)).mpr
+      (h (finSigmaFinEquiv.symm k).1 (finSigmaFinEquiv.symm k).2)
+
+/-- **The Kraus commutant `*`-subalgebra of the pooled family is the intersection of those of
+the individual families.** -/
+theorem krausCommutantStarSubalgebra_pooledKfam_eq_iInf (K : (μ : Fin M) → Fin (r μ) → Mat) :
+    krausCommutantStarSubalgebra (pooledKfam K) = ⨅ μ, krausCommutantStarSubalgebra (K μ) := by
+  ext X
+  rw [StarSubalgebra.mem_iInf]
+  simp only [mem_krausCommutantStarSubalgebra]
+  exact mem_krausCommutant_pooledKfam_iff K X
+
+/-- **The adjoint fixed-point subalgebra of the pooled family is the intersection of those of
+the individual families.**
+
+HJPW, arXiv:quant-ph/0304007v2, lines 843 and 849, specialized to the finite pooled witness:
+routes through `Kraus.adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra` on both
+sides and `Kraus.krausCommutantStarSubalgebra_pooledKfam_eq_iInf`. -/
+theorem adjointFixedPointsStarSubalgebra_pooledKfam_eq_iInf
+    (K : (μ : Fin M) → Fin (r μ) → Mat) (hK : ∀ μ, IsTP (K μ))
+    {ρbar : Mat} (hρbar : ρbar.PosDef) (hfix : ∀ μ, map (K μ) ρbar = ρbar) :
+    adjointFixedPointsStarSubalgebra (pooledKfam K) (isTP_pooledKfam K hK) hρbar
+        (map_pooledKfam_fixed K hfix)
+      = ⨅ μ, adjointFixedPointsStarSubalgebra (K μ) (hK μ) hρbar (hfix μ) := by
+  rw [adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra,
+    krausCommutantStarSubalgebra_pooledKfam_eq_iInf]
+  refine iInf_congr fun μ => ?_
+  rw [adjointFixedPointsStarSubalgebra_eq_krausCommutantStarSubalgebra]
+
+end Pooling
+
+end Kraus

--- a/TNLean/Channel/KoashiImoto/SingleWitness.lean
+++ b/TNLean/Channel/KoashiImoto/SingleWitness.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.FiniteRealization
+import TNLean.Channel.KoashiImoto.PooledKrausFamily
+
+/-!
+# A single preserving Kraus family realizing the common invariant algebra
+
+HJPW, arXiv:quant-ph/0304007v2, lines 846-849: "in fact there is `F_0 ∈ F` such that
+`A_0 = A_{F_0}`. We may take, for example, `F_0 = (1/M) ∑_μ F_μ`." This file combines the
+finite realization of `A_0` (`Kraus.exists_finset_preservingKrausFamily_iInf_eq`) with the
+pooled/averaged Kraus family of a finite indexed family
+(`Kraus.averagedPreservingKrausFamily`, `Kraus.adjointFixedPointsStarSubalgebra_pooledKfam_eq_iInf`)
+to produce that single witness `F_0`.
+
+## Main declarations
+
+* `Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq`: there is a single
+  preserving Kraus family `F_0` whose adjoint fixed-point subalgebra is exactly the common
+  invariant algebra `A_0` (HJPW, arXiv:quant-ph/0304007v2, lines 846-847).
+
+Every declaration below states `{Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}`
+inline in its own signature rather than via a shared `variable` line. This is deliberate: with a
+shared ambient `variable` binding these hypotheses, the kernel needlessly re-derives the
+finite-dimensional defeq between `averagedPreservingKrausFamily`'s fields and their `pooledKfam`
+unfoldings on every use, which silently degrades to `sorryAx` recovery instead of failing loudly.
+Restating the same hypotheses inline avoids that path entirely; see
+`Kraus.averagedPreservingKrausFamily_Kfam` / `Kraus.averagedPreservingKrausFamily_isTP` in
+`PooledKrausFamily.lean`, proved once (outside any such ambient binding) and reused here by `rw`.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- A finite nonempty `Finset` gives the same infimum whether taken over the `Finset`-bounded
+quantifier or over its enumeration by `Fin S.card`. Stated for a fully generic, opaque `A` so
+that this purely order-theoretic reindexing step never has to unfold `PreservingKrausFamily` or
+`IsPreserving` during unification. -/
+private theorem iInf_enum_eq {ι : Type*} {α : Type*} [CompleteLattice α]
+    (A : ι → α) (S : Finset ι) :
+    ⨅ k : Fin S.card, A (S.equivFin.symm k : ι) = ⨅ F ∈ S, A F := by
+  have h1 := Equiv.iInf_comp (g := fun y : { x // x ∈ S } => A (y : ι)) S.equivFin.symm
+  rw [h1]
+  exact iInf_subtype'' (S : Set ι) A
+
+/-- The pooled/averaged witness of an arbitrary enumerated finite family realizes the
+intersection of the adjoint fixed-point subalgebras of that family. Stated for a fully generic,
+opaque `Fenum` (a bound parameter, not a `let`) so that this is a single beta-reduction away
+from `Kraus.adjointFixedPointsStarSubalgebra_pooledKfam_eq_iInf`, without forcing unification to
+unfold `Fenum` itself. -/
+private theorem adjointFixedPointsStarSubalgebra_averaged_eq_iInf
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    {M : ℕ} [NeZero M]
+    (Fenum : Fin M → PreservingKrausFamily ρ) (hρbar : (commonAverage ρ).PosDef) :
+    adjointFixedPointsStarSubalgebra (averagedPreservingKrausFamily Fenum).Kfam
+        (averagedPreservingKrausFamily Fenum).isPreserving.1 hρbar
+        (averagedPreservingKrausFamily Fenum).map_commonAverage
+      = ⨅ μ, adjointFixedPointsStarSubalgebra (Fenum μ).Kfam (Fenum μ).isPreserving.1 hρbar
+          (Fenum μ).map_commonAverage := by
+  simp only [averagedPreservingKrausFamily_Kfam]
+  exact adjointFixedPointsStarSubalgebra_pooledKfam_eq_iInf (fun μ => (Fenum μ).Kfam)
+    (fun μ => (Fenum μ).isPreserving.1) hρbar (fun μ => (Fenum μ).map_commonAverage)
+
+/-- **A single preserving Kraus family realizes the common invariant algebra.**
+
+HJPW, arXiv:quant-ph/0304007v2, lines 846-849: "there is `F_0 ∈ F` such that `A_0 = A_{F_0}`.
+We may take, for example, `F_0 = (1/M) ∑_μ F_μ`." Combines the finite realization of `A_0`
+(`Kraus.exists_finset_preservingKrausFamily_iInf_eq`) with the pooled/averaged Kraus family of
+that finite family (`Kraus.averagedPreservingKrausFamily`).
+
+**Scope restriction (joint support):** inherits the `PosDef (commonAverage ρ)` hypothesis of
+`commonInvariantStarSubalgebra` in place of HJPW's joint-support reduction
+(arXiv:quant-ph/0304007v2, lines 761-763). Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+theorem exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) :
+    ∃ F₀ : PreservingKrausFamily ρ,
+      adjointFixedPointsStarSubalgebra F₀.Kfam F₀.isPreserving.1 hρbar F₀.map_commonAverage
+        = commonInvariantStarSubalgebra ρ hρbar := by
+  obtain ⟨S, hS, hSeq⟩ := exists_finset_preservingKrausFamily_iInf_eq ρ hρbar
+  haveI : NeZero S.card := ⟨hS.card_pos.ne'⟩
+  refine ⟨averagedPreservingKrausFamily (fun k => (S.equivFin.symm k : PreservingKrausFamily ρ)),
+    ?_⟩
+  rw [adjointFixedPointsStarSubalgebra_averaged_eq_iInf]
+  rw [iInf_enum_eq
+    (fun F => adjointFixedPointsStarSubalgebra F.Kfam F.isPreserving.1 hρbar F.map_commonAverage)
+    S]
+  exact hSeq
+
+end Kraus

--- a/TNLean/Channel/KoashiImoto/SingleWitness.lean
+++ b/TNLean/Channel/KoashiImoto/SingleWitness.lean
@@ -22,14 +22,11 @@ to produce that single witness `F_0`.
   preserving Kraus family `F_0` whose adjoint fixed-point subalgebra is exactly the common
   invariant algebra `A_0` (HJPW, arXiv:quant-ph/0304007v2, lines 846-847).
 
-Every declaration below states `{Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}`
-inline in its own signature rather than via a shared `variable` line. This is deliberate: with a
-shared ambient `variable` binding these hypotheses, the kernel needlessly re-derives the
-finite-dimensional defeq between `averagedPreservingKrausFamily`'s fields and their `pooledKfam`
-unfoldings on every use, which silently degrades to `sorryAx` recovery instead of failing loudly.
-Restating the same hypotheses inline avoids that path entirely; see
-`Kraus.averagedPreservingKrausFamily_Kfam` / `Kraus.averagedPreservingKrausFamily_isTP` in
-`PooledKrausFamily.lean`, proved once (outside any such ambient binding) and reused here by `rw`.
+The declarations below state the finite state-family instances in their own signatures. This keeps
+dependent projections through `averagedPreservingKrausFamily` stable during elaboration. The
+projection lemmas `Kraus.averagedPreservingKrausFamily_Kfam` and
+`Kraus.averagedPreservingKrausFamily_isTP` expose the corresponding fields without unfolding the
+bundled family.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1346,6 +1346,92 @@ algebra of a family of jointly invariant states.
     Theorem~\ref{thm:starSubalgebra_unitary_block_diagonal_iff} to $S=A_0$.
 \end{proof}
 
+\begin{theorem}[Finite realization of the common invariant algebra]
+    \label{thm:koashi_imoto_finite_realization}
+    \lean{Kraus.exists_finset_preservingKrausFamily_iInf_eq}
+    \leanok
+    \uses{def:koashi_imoto_common_invariant_algebra}
+    Under the hypotheses of Definition~\ref{def:koashi_imoto_common_invariant_algebra},
+    there are finitely many operations $F_1,\ldots,F_M\in\mathbf F$, $M\ge1$, with
+    \begin{align}
+        A_0=A_{F_1}\cap\cdots\cap A_{F_M}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Because $\MN{D}$ is finite-dimensional, among the finite intersections
+    $\bigcap_{F\in S}A_F$ over finite sets $S\subseteq\mathbf F$ containing a
+    fixed operation, one of minimal dimension already equals $A_0$: enlarging
+    $S$ by one more operation either leaves the intersection unchanged or
+    strictly decreases its dimension, and dimension cannot decrease
+    indefinitely.
+\end{proof}
+
+\begin{theorem}[A single operation realizes the common invariant algebra]
+    \label{thm:koashi_imoto_single_witness}
+    \lean{Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq}
+    \leanok
+    \uses{thm:koashi_imoto_finite_realization}
+    Under the hypotheses of Definition~\ref{def:koashi_imoto_common_invariant_algebra},
+    there is $F_0\in\mathbf F$ with $A_0=A_{F_0}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:koashi_imoto_finite_realization}
+    Take $F_1,\ldots,F_M\in\mathbf F$ as in
+    Theorem~\ref{thm:koashi_imoto_finite_realization} and pool their Kraus
+    operators, each rescaled by $1/\sqrt M$, into a single Kraus family
+    representing
+    \begin{align}
+        F_0=\frac1M\sum_{\mu=1}^M F_\mu.
+        \notag
+    \end{align}
+    Rescaling every pooled Kraus operator by $1/\sqrt M$ turns the sum of the
+    $M$ trace-preservation identities into a single one, so $F_0\in\mathbf F$;
+    rescaling a Kraus operator by a nonzero scalar does not change the
+    operators it commutes with, so $A_{F_0}=A_{F_1}\cap\cdots\cap A_{F_M}=A_0$.
+\end{proof}
+
+\begin{definition}[The projection onto the common invariant algebra]
+    \label{def:koashi_imoto_mean_ergodic_projection}
+    \lean{Kraus.commonInvariantMeanErgodicProjection}
+    \leanok
+    \uses{thm:koashi_imoto_single_witness,
+        thm:positive_unital_adjoint_mean_ergodic_retraction}
+    Fix $F_0\in\mathbf F$ with $A_0=A_{F_0}$ as in
+    Theorem~\ref{thm:koashi_imoto_single_witness}. The Ces\`aro averages of
+    the iterates of $F_0^*$ converge, and $P_0^*$ denotes their limit,
+    \begin{align}
+        P_0^*
+        &=\lim_{N\to\infty}\frac1N\sum_{n=1}^N(F_0^*)^n.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[The projection onto $A_0$]
+    \label{thm:koashi_imoto_mean_ergodic_projection_properties}
+    \lean{Kraus.commonInvariantMeanErgodicProjection_isPositiveMap,
+        Kraus.commonInvariantMeanErgodicProjection_one,
+        Kraus.commonInvariantMeanErgodicProjection_idempotent,
+        Kraus.mem_range_commonInvariantMeanErgodicProjection_iff}
+    \leanok
+    \uses{def:koashi_imoto_mean_ergodic_projection}
+    The map $P_0^*$ is positive, unital, and idempotent, and its range is
+    exactly $A_0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:koashi_imoto_mean_ergodic_projection,
+        thm:positive_unital_adjoint_mean_ergodic_retraction}
+    Theorem~\ref{thm:positive_unital_adjoint_mean_ergodic_retraction} applied
+    to $F_0$ gives that $P_0^*$ is positive, unital, and idempotent, with
+    range equal to the fixed-point set of $F_0^*$, which is $A_{F_0}=A_0$.
+\end{proof}
+
 \begin{theorem}[Hayashi SSA-equality characterization]
     \label{thm:hayashi_ssa_equality_characterization}
     \lean{hayashi_ssa_equality_characterization}
@@ -1369,17 +1455,19 @@ algebra of a family of jointly invariant states.
     Theorems~\ref{thm:entropy_petz_product_tensor} and
     \ref{thm:entropy_petz_product_tensor_corollaries}. The singular-support
     equality-to-recovery theorem remains separate. Independently, the common
-    invariant algebra and its block form (Definition~%
-    \ref{def:koashi_imoto_common_invariant_algebra} and
-    Theorem~\ref{thm:koashi_imoto_common_invariant_algebra_block_form}) supply
-    the finite-dimensional operator-algebraic first step of the
-    Koashi--Imoto argument, under an explicit full-support hypothesis on the
-    common average in place of the joint-support reduction. The finite
-    realization of that intersection by a single preserving operation, the
-    resulting family-level tensor-product state decomposition, and the action
-    of the middle-system channel on the common direct-sum factors all remain
-    open. This forward implication therefore remains axiomatic. The
-    biconditional combines the two directions.
+    invariant algebra, its block form, its finite realization by a single
+    preserving operation, and the projection onto it (Definition~%
+    \ref{def:koashi_imoto_common_invariant_algebra},
+    Theorem~\ref{thm:koashi_imoto_common_invariant_algebra_block_form},
+    Theorem~\ref{thm:koashi_imoto_single_witness}, and
+    Definition~\ref{def:koashi_imoto_mean_ergodic_projection}) supply the
+    finite-dimensional operator-algebraic core of the Koashi--Imoto argument,
+    under an explicit full-support hypothesis on the common average in place
+    of the joint-support reduction. The resulting family-level
+    tensor-product state decomposition and the action of the middle-system
+    channel on the common direct-sum factors remain open. This forward
+    implication therefore remains axiomatic. The biconditional combines the
+    two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1402,13 +1402,12 @@ algebra of a family of jointly invariant states.
     \uses{thm:koashi_imoto_single_witness,
         thm:positive_unital_adjoint_mean_ergodic_retraction}
     Fix $F_0\in\mathbf F$ with $A_0=A_{F_0}$ as in
-    Theorem~\ref{thm:koashi_imoto_single_witness}. The Ces\`aro averages of
-    the iterates of $F_0^*$ converge, and $P_0^*$ denotes their limit,
-    \begin{align}
-        P_0^*
-        &=\lim_{N\to\infty}\frac1N\sum_{n=1}^N(F_0^*)^n.
-        \notag
-    \end{align}
+    Theorem~\ref{thm:koashi_imoto_single_witness}. Let $P_0$ be the
+    finite-dimensional mean-ergodic projection of the Schr\"odinger map $F_0$,
+    and define $P_0^*$ as its trace-pairing adjoint. This packages the
+    projection used by Hayden--Jozsa--Petz--Winter. The convergence of the
+    Ces\`aro averages of the Heisenberg iterates $(F_0^*)^n$ to this map is not
+    asserted here.
 \end{definition}
 
 \begin{theorem}[The projection onto $A_0$]

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1373,7 +1373,7 @@ algebra of a family of jointly invariant states.
     \label{thm:koashi_imoto_single_witness}
     \lean{Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq}
     \leanok
-    \uses{thm:koashi_imoto_finite_realization}
+    \uses{def:koashi_imoto_common_invariant_algebra}
     Under the hypotheses of Definition~\ref{def:koashi_imoto_common_invariant_algebra},
     there is $F_0\in\mathbf F$ with $A_0=A_{F_0}$.
 \end{theorem}
@@ -1399,15 +1399,15 @@ algebra of a family of jointly invariant states.
     \label{def:koashi_imoto_mean_ergodic_projection}
     \lean{Kraus.commonInvariantMeanErgodicProjection}
     \leanok
-    \uses{thm:koashi_imoto_single_witness,
-        thm:positive_unital_adjoint_mean_ergodic_retraction}
+    \uses{def:mean_ergodic_projection,
+        thm:koashi_imoto_single_witness}
     Fix $F_0\in\mathbf F$ with $A_0=A_{F_0}$ as in
     Theorem~\ref{thm:koashi_imoto_single_witness}. Let $P_0$ be the
     finite-dimensional mean-ergodic projection of the Schr\"odinger map $F_0$,
-    and define $P_0^*$ as its trace-pairing adjoint. This packages the
-    projection used by Hayden--Jozsa--Petz--Winter. The convergence of the
-    Ces\`aro averages of the Heisenberg iterates $(F_0^*)^n$ to this map is not
-    asserted here.
+    and define $P_0^*$ as its trace-pairing adjoint. Hayden--Jozsa--Petz--Winter
+    denote the Heisenberg Ces\`aro limit by $P_0^*$. The convergence of the
+    Ces\`aro averages of the iterates $(F_0^*)^n$ to the trace-adjoint
+    projection defined here is not asserted.
 \end{definition}
 
 \begin{theorem}[The projection onto $A_0$]
@@ -1452,10 +1452,12 @@ algebra of a family of jointly invariant states.
     Theorem~\ref{thm:hayashi_ssa_equality_reverse}. For the forward implication,
     the raw product-reference Petz map and its support behavior are given by
     Theorems~\ref{thm:entropy_petz_product_tensor} and
-    \ref{thm:entropy_petz_product_tensor_corollaries}. The singular-support
-    equality-to-recovery theorem remains separate. Independently, the common
-    invariant algebra, its block form, its finite realization by a single
-    preserving operation, and the projection onto it (Definition~%
+    \ref{thm:entropy_petz_product_tensor_corollaries}. At equality, HJPW
+    equation~(11), both for the supported raw map and for a completed local
+    channel, is Theorem~\ref{thm:ssa_equality_product_marginal_petz_recovery}.
+    Independently, the common invariant algebra, its block form, its finite
+    realization by a single preserving operation, and the projection onto it
+    (Definition~%
     \ref{def:koashi_imoto_common_invariant_algebra},
     Theorem~\ref{thm:koashi_imoto_common_invariant_algebra_block_form},
     Theorem~\ref{thm:koashi_imoto_single_witness}, and

--- a/docs/import_structure.md
+++ b/docs/import_structure.md
@@ -32,7 +32,7 @@ were formerly documented inline in `TNLean.lean`:
 | 2 | `Channel`, `Entropy` | Quantum channels; Choi, Kraus, and Stinespring theory; entropy and recovery. |
 | 2a | `Axioms` | Explicit axiomatized inputs such as Brouwer, entropy inequalities, and operator convexity. |
 | 2b | `Channel.Schwarz` and related analysis | Schwarz inequalities, operator convexity and monotonicity, and relative-entropy results. |
-| 2c | `Channel.FixedPoint`, `Channel.Irreducible`, `Channel.Peripheral`, `Channel.Semigroup`, `QPF`, `Spectral` | Fixed points, quantum Perron--Frobenius theory, peripheral spectrum, spectral gaps, and semigroups. |
+| 2c | `Channel.FixedPoint`, `Channel.Irreducible`, `Channel.Peripheral`, `Channel.Semigroup`, `Channel.KoashiImoto`, `QPF`, `Spectral` | Fixed points, quantum Perron--Frobenius theory, peripheral spectrum, spectral gaps, semigroups, and the common invariant algebra of jointly invariant states. |
 | 3 | `MPS.Chain`, `MPS.Core`, `MPS.Overlap` | Matrix-product tensor definitions, words, blocking, transfer matrices, and overlaps. |
 | 3b | `MPS.MPDO` | MPO, MPDO, and LPDO foundations. |
 | 4 | `MPS.FundamentalTheorem`, `MPS.Symmetry` | The single-block fundamental theorem and symmetry consequences. |

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -119,10 +119,11 @@ For MPDO renormalization fixed points:
   globally for a positive-definite first factor. No factorization is claimed
   for TNLean's generic completed singular channel. Independently, the common
   invariant algebra of a finite jointly invariant family, its finite
-  realization by a single preserving operation, and the mean-ergodic
-  projection onto it are formalized under an explicit full-support hypothesis
-  on the common average. The family-level tensor-product state decomposition
-  and Koashi--Imoto/Hayashi channel-action theorem remain open.
+  realization by a single preserving operation, and a positive unital
+  idempotent projection onto it are formalized under an explicit full-support
+  hypothesis on the common average. The corresponding Heisenberg Ces\`aro
+  convergence identity, the family-level tensor-product state decomposition,
+  and the Koashi--Imoto/Hayashi channel-action theorem remain open.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -117,8 +117,12 @@ For MPDO renormalization fixed points:
   factors globally as first-factor support compression tensored with local raw
   recovery; the identity-tensored formula holds on supported inputs and
   globally for a positive-definite first factor. No factorization is claimed
-  for TNLean's generic completed singular channel. The family-level
-  Koashi--Imoto/Hayashi channel-action theorem remains open.
+  for TNLean's generic completed singular channel. Independently, the common
+  invariant algebra of a finite jointly invariant family, its finite
+  realization by a single preserving operation, and the mean-ergodic
+  projection onto it are formalized under an explicit full-support hypothesis
+  on the common average. The family-level tensor-product state decomposition
+  and Koashi--Imoto/Hayashi channel-action theorem remain open.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -173,8 +173,8 @@ strong-subadditivity equality assumption used in the CPSV16 argument.
 
 \section{Common invariant algebra: formalized under an explicit full-support hypothesis}
 
-A first slice of the operator-algebraic Koashi--Imoto appendix (HJPW, Appendix A,
-lines 755--855) is now formalized independently of the product-reference
+A slice of the operator-algebraic Koashi--Imoto appendix (HJPW, Appendix A,
+lines 755--851) is now formalized independently of the product-reference
 recovery step above. For a finite, nonempty family of states $\rho_1,\dots,\rho_K$,
 the set
 \begin{align}
@@ -191,7 +191,13 @@ common invariant algebra
 (line 843) is formalized as the intersection, over every such $F$, of the
 fixed-point $*$-subalgebra of the adjoint map -- together with its membership
 characterization and the generic block form of a star-subalgebra specialized to
-$A_0$. The corresponding declarations are
+$A_0$. Because all dimensions are finite, $A_0$ is additionally realized as a
+finite intersection $A_0=A_{F_1}\cap\dots\cap A_{F_M}$, and by a single
+preserving operation $F_0=(1/M)\sum_{\mu=1}^M F_\mu$ with $A_0=A_{F_0}$
+(lines 844--849). The mean-ergodic projection
+$P_0^*=\lim_{N\to\infty}(1/N)\sum_{n=1}^N(F_0^*)^n$ onto $A_0$ derived from
+$F_0^*$ (lines 838--851) is positive, unital, and idempotent, with range
+exactly $A_0$. The corresponding declarations are
 \begin{center}
   \small
   \leanid{Kraus.commonAverage}\\
@@ -200,9 +206,21 @@ $A_0$. The corresponding declarations are
   \leanid{Kraus.map_commonAverage_of_isPreserving}\\
   \leanid{Kraus.commonInvariantStarSubalgebra}\\
   \leanid{Kraus.mem_commonInvariantStarSubalgebra}\\
-  \leanid{Kraus.exists_unitary_conj_blockDiagonal_iff_commonInvariantStarSubalgebra}
+  \leanid{Kraus.exists_unitary_conj_blockDiagonal_iff_commonInvariantStarSubalgebra}\\
+  \leanid{Kraus.exists_finset_preservingKrausFamily_iInf_eq}\\
+  \leanid{Kraus.averagedPreservingKrausFamily}\\
+  \leanid{Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq}\\
+  \leanid{Kraus.commonInvariantMeanErgodicProjection}\\
+  \leanid{Kraus.commonInvariantMeanErgodicProjection_isPositiveMap}\\
+  \leanid{Kraus.commonInvariantMeanErgodicProjection_one}\\
+  \leanid{Kraus.commonInvariantMeanErgodicProjection_idempotent}\\
+  \leanid{Kraus.mem_range_commonInvariantMeanErgodicProjection_iff}
 \end{center}
-in \doclink{TNLean/Channel/KoashiImoto/CommonInvariantAlgebra}.
+in \doclink{TNLean/Channel/KoashiImoto/CommonInvariantAlgebra},
+\doclink{TNLean/Channel/KoashiImoto/FiniteRealization},
+\doclink{TNLean/Channel/KoashiImoto/PooledKrausFamily},
+\doclink{TNLean/Channel/KoashiImoto/SingleWitness}, and
+\doclink{TNLean/Channel/KoashiImoto/MeanErgodicProjection}.
 
 HJPW's argument reduces to the case where the common average
 $(1/K)\sum_k\rho_k$ has full support, by shrinking the working Hilbert space to
@@ -210,9 +228,7 @@ the joint support of the $\rho_k$ (lines 761--763). That reduction is not
 derived here: every declaration that builds $A_0$ instead takes positive
 definiteness of the common average as an explicit hypothesis. Beyond this
 scope restriction, none of the following are claimed: the joint-support
-reduction itself; the finite realization $A_0=A_{F_1}\cap\dots\cap A_{F_M}$
-or the single witness $F_0$ with $A_0=A_{F_0}$ (lines 844--847); the
-associated tensor-product state decomposition
+reduction itself; the associated tensor-product state decomposition
 $\rho_k=\bigoplus_j q_{j|k}\rho_{j|k}\otimes\omega_j$; the middle-system
 block channel action on the summands; or elimination of the Hayashi
 strong-subadditivity forward-implication axiom. These remain the open
@@ -228,15 +244,16 @@ singular product-reference channel is outside this claim. The exact SSA
 specialization now proves HJPW equation (11), both for the identity-tensored
 raw support formula and for a completed local recovery channel on
 $\rho_{AB}$. Independently, the common invariant
-Heisenberg-picture star-subalgebra $A_0$ of a finite family of jointly
-invariant states, its membership characterization, and its generic block form
-are formalized under an explicit full-support hypothesis on the common
-average, in place of HJPW's joint-support reduction. Singular-support
-equality-to-recovery is formalized on arbitrary finite product coordinates,
-including the completed channel on the supported marginal. The joint-support
-reduction itself, the finite realization of $A_0$ by a single witness $F_0$,
-the family-level tensor-product state decomposition, and the Koashi--Imoto
-channel-action theorem remain open as separate later steps.
+ Heisenberg-picture star-subalgebra $A_0$ of a finite family of jointly
+ invariant states, its membership characterization, its generic block form, its
+ finite realization by a single preserving operation $F_0$, and the mean-ergodic
+ projection $P_0^*$ onto it are formalized under an explicit full-support
+ hypothesis on the common average, in place of HJPW's joint-support reduction.
+ Singular-support equality-to-recovery is formalized on arbitrary finite product
+ coordinates, including the completed channel on the supported marginal. The
+ joint-support reduction itself, the family-level tensor-product state
+ decomposition, and the Koashi--Imoto channel-action theorem remain open as
+ separate later steps.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -194,10 +194,12 @@ characterization and the generic block form of a star-subalgebra specialized to
 $A_0$. Because all dimensions are finite, $A_0$ is additionally realized as a
 finite intersection $A_0=A_{F_1}\cap\dots\cap A_{F_M}$, and by a single
 preserving operation $F_0=(1/M)\sum_{\mu=1}^M F_\mu$ with $A_0=A_{F_0}$
-(lines 844--849). The mean-ergodic projection
-$P_0^*=\lim_{N\to\infty}(1/N)\sum_{n=1}^N(F_0^*)^n$ onto $A_0$ derived from
-$F_0^*$ (lines 838--851) is positive, unital, and idempotent, with range
-exactly $A_0$. The corresponding declarations are
+(lines 844--849). The trace-pairing adjoint of the Schr\"odinger mean-ergodic
+projection for $F_0$ is formalized as $P_0^*$. It is positive, unital, and
+idempotent, with range exactly $A_0$. HJPW writes this projection as the
+Ces\`aro limit of the Heisenberg iterates (lines 838--851); convergence of those
+adjoint averages to the packaged map is not yet formalized. The corresponding
+declarations are
 \begin{center}
   \small
   \leanid{Kraus.commonAverage}\\
@@ -243,17 +245,17 @@ positive-definite-left corollaries are formalized. The generic completed
 singular product-reference channel is outside this claim. The exact SSA
 specialization now proves HJPW equation (11), both for the identity-tensored
 raw support formula and for a completed local recovery channel on
-$\rho_{AB}$. Independently, the common invariant
- Heisenberg-picture star-subalgebra $A_0$ of a finite family of jointly
- invariant states, its membership characterization, its generic block form, its
- finite realization by a single preserving operation $F_0$, and the mean-ergodic
- projection $P_0^*$ onto it are formalized under an explicit full-support
- hypothesis on the common average, in place of HJPW's joint-support reduction.
- Singular-support equality-to-recovery is formalized on arbitrary finite product
- coordinates, including the completed channel on the supported marginal. The
- joint-support reduction itself, the family-level tensor-product state
- decomposition, and the Koashi--Imoto channel-action theorem remain open as
- separate later steps.
+$\rho_{AB}$. Singular-support equality-to-recovery is formalized on arbitrary
+finite product coordinates, including the completed channel on the supported
+marginal. Independently, the common invariant Heisenberg-picture star-subalgebra
+$A_0$ of a finite family of jointly invariant states, its membership
+characterization, its generic block form, its finite realization by a single
+preserving operation $F_0$, and the positive unital idempotent projection
+$P_0^*$ onto it are formalized under an explicit full-support hypothesis on the
+common average, in place of HJPW's joint-support reduction. The Heisenberg
+Ces\`aro convergence identity for $P_0^*$, the joint-support reduction itself,
+the family-level tensor-product state decomposition, and the Koashi--Imoto
+channel-action theorem remain open as separate later steps.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -198,8 +198,8 @@ preserving operation $F_0=(1/M)\sum_{\mu=1}^M F_\mu$ with $A_0=A_{F_0}$
 projection for $F_0$ is formalized as $P_0^*$. It is positive, unital, and
 idempotent, with range exactly $A_0$. HJPW writes this projection as the
 Ces\`aro limit of the Heisenberg iterates (lines 838--851); convergence of those
-adjoint averages to the packaged map is not yet formalized. The corresponding
-declarations are
+adjoint averages to the trace-adjoint projection is not yet formalized. The
+corresponding declarations are
 \begin{center}
   \small
   \leanid{Kraus.commonAverage}\\


### PR DESCRIPTION
## What changed

- prove that an arbitrary infimum of star-subalgebras of a finite-dimensional matrix algebra is realized by a finite nonempty subfamily, then specialize this to HJPW's common invariant algebra \(A_0\)
- construct the averaged preserving channel \(F_0=M^{-1}\sum_\mu F_\mu\) as a pooled Kraus family with dependent Kraus counts and \(1/\sqrt M\) scaling
- identify the pooled family's adjoint fixed-point algebra with the intersection of the original algebras through the Kraus-commutant characterization, and obtain one preserving witness with \(A_{F_0}=A_0\)
- construct HJPW's Heisenberg mean-ergodic projection \(P_0^*\), prove positivity, unitality, idempotence, and characterize its range as exactly \(A_0\)
- add the Kraus-map positivity/trace-preservation and trace-adjoint bridges needed for that projection, then synchronize Chapter 19, the HJPW scope note, and import documentation

## Source boundary

This formalizes HJPW Appendix A, arXiv:quant-ph/0304007v2, lines 838--855, under the existing explicit full-support hypothesis on the common average. It does not prove the joint-support reduction, tensor-product decomposition of the invariant states, block action of each preserving channel, Petz recovery, Hayashi decomposition, or axiom removal.

## Validation

- exact head `fa201791e`, rebased patch-identically over current main through #4998
- `lake build TNLean` — 9777 jobs, pass (only the pre-existing periodic overlap `sorry` warning)
- headline `#print axioms` audit — only `propext`, `Classical.choice`, and `Quot.sound`; no `sorryAx` or project axioms
- import aggregator check — pass, 47 aggregators / 1071 modules
- fresh blueprint declaration generation, CI sync, and `leanblueprint checkdecls` — pass; changed Chapter 19 fully synchronized
- double LuaLaTeX — pass, 761 pages, zero undefined cross-references
- standalone HJPW scope note — pass
- module policy, size, naming, style, proof-integrity, and `git diff --check` gates — pass
- independent exact-head source/Lean/blueprint review — approved; post-rebase patch identity independently verified

Advances #4962.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proofs in the quantum-channel fixed-point stack that downstream SSA/Markov work will depend on; scope is bounded by explicit hypotheses and does not remove axioms, but errors here would affect the Koashi–Imoto formalization path.
> 
> **Overview**
> Formalizes the next HJPW Koashi–Imoto operator-algebra steps (still under **`PosDef (commonAverage ρ)`** instead of joint-support reduction).
> 
> **Finite realization:** proves an infimum of star-subalgebras in finite dimension equals a finite subfamily infimum, hence **`A_0`** is an intersection of finitely many preserving Kraus families.
> 
> **Pooled witness:** builds **`F_0 = (1/M)∑ F_μ`** as a **`1/√M`**-scaled pooled Kraus family and shows its adjoint fixed-point algebra is the intersection of the summands’ algebras.
> 
> **Single witness:** averages a finite realizing family to obtain one **`PreservingKrausFamily`** with **`A_{F_0} = A_0`**.
> 
> **Projection:** defines **`commonInvariantMeanErgodicProjection`** (`P_0^*`) as the trace adjoint of the Schrödinger mean-ergodic projection for that witness; proves positivity, unitality, idempotence, and range **`A_0`**. Heisenberg Cesàro convergence to this map is **not** claimed.
> 
> Adds Kraus Schrödinger positivity/trace-preservation and **`traceAdjointMap_mapLM`** lemmas. Chapter 19 blueprint, HJPW scope note, and import docs are synced; tensor-product state decomposition and channel-action steps remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 931145fe91e849ca517184791e9aa27f47581ee6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->