### PR TITLE
fix(scripts): teach the event parser the kernel dialect

### DIFF
--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -117,7 +117,7 @@ ENVIRONMENT_LANGS = {
     "tenkzfree": "free",
 }
 
-KNOWN_LANGS = set(ENVIRONMENT_LANGS.values())
+KNOWN_LANGS = set(ENVIRONMENT_LANGS.values()) | {"kernel"}
 
 # Empty-picture hard check applies exactly to the spec's list (section 5.4).
 EMPTY_CHECK_LANGS = {"grid", "lattice", "free"}

--- a/scripts/tenkzlib/tnlog.py
+++ b/scripts/tenkzlib/tnlog.py
@@ -24,6 +24,13 @@ def _is_int(value: str) -> bool:
     return _parse_int(value) is not None
 
 
+def _is_picture_id(value: str) -> bool:
+    """Dialect pictures use integer ids; the kernel prefixes its own with k."""
+    if value.startswith("k"):
+        return _is_int(value[1:])
+    return _is_int(value)
+
+
 def _is_number(value: str) -> bool:
     return NUMBER_RE.fullmatch(value) is not None
 
@@ -78,9 +85,9 @@ def _any(value: str) -> bool:
 # Numeric slots are validated strictly: they are cell/row coordinates, and
 # a coordinate that is not an integer addresses nothing.
 FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
-    "picture": {"id": _is_int, "lang": _any},
+    "picture": {"id": _is_picture_id, "lang": _any},
     "frame": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "scope": _enum("picture", "group"),
         "map": _any,
         "a": _is_number,
@@ -88,43 +95,43 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "c": _is_number,
         "d": _is_number,
     },
-    "label-use": {"picture": _is_int},
+    "label-use": {"picture": _is_picture_id},
     "label-anchor-site": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "label": _is_positive_int,
         "x": _is_int,
         "y": _is_int,
     },
     "ink-use": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "class": _enum("glyph", "wire"),
         "id": _is_positive_int,
         "shape": _enum("rect", "circle", "roundrect", "triangle"),
     },
-    "atom": {"picture": _is_int, "cell": _is_cell, "name": _any, "kind": _any},
+    "atom": {"picture": _is_picture_id, "cell": _is_cell, "name": _any, "kind": _any},
     "faceports": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "cell": _is_cell,
         "face": _enum("up", "down", "west", "east"),
         "arity": _is_nonnegative_int,
         "at": _any,
     },
     "pairleg": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "upper": _is_cell,
         "lower": _is_cell,
         "upper-port": _is_pairleg_port,
         "column": _is_int,
     },
     "bond": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "row": _is_int,
         "from": _is_int,
         "to": _is_int,
         "dir": _enum("none", "left", "right", "forward", "reverse"),
     },
     "trace": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "row": _is_int,
         "side": _enum("above", "below"),
         "lang": _enum("lattice"),
@@ -135,19 +142,19 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "to": _is_cell,
     },
     "hooks": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "row": _is_int,
         "side": _enum("above", "below"),
     },
     "pairtrace": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "row": _is_int,
         "col": _is_int,
         "site": _is_cell,
     },
-    "phtrace": {"picture": _is_int, "row": _is_int, "col": _is_int},
+    "phtrace": {"picture": _is_picture_id, "row": _is_int, "col": _is_int},
     "cup": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "lang": _enum("lattice"),
         "side": _enum("west", "east", "north", "south"),
         "top": _is_int,
@@ -157,10 +164,10 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "sheet-b": _is_int,
         "matrix": _is_int,
     },
-    "hole": {"picture": _is_int, "row": _is_int, "col": _is_int},
-    "warning": {"picture": _is_int, "code": _any},
+    "hole": {"picture": _is_picture_id, "row": _is_int, "col": _is_int},
+    "warning": {"picture": _is_picture_id, "code": _any},
     "boundary": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "virtual-west": _is_int,
         "virtual-east": _is_int,
         "virtual-north": _is_int,
@@ -169,7 +176,7 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "physical-down": _is_int,
     },
     "bbox": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "class": _enum("label", "wire"),
         "id": _is_positive_int,
         "xmin": _is_int,
@@ -180,7 +187,7 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "radius": _is_nonnegative_int,
     },
     "glyph-geometry": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "owner": _is_positive_int,
         "shape": _enum("rect", "circle", "roundrect", "triangle"),
         "xmin": _is_int,
@@ -197,7 +204,7 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "y3": _is_int,
     },
     "wire-geometry": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "owner": _is_positive_int,
         "shape": _enum("rect-minus-label"),
         "xmin": _is_int,
@@ -214,15 +221,15 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "cut-id": _is_positive_int,
     },
     "lattice": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "rows": _is_positive_int,
         "cols": _is_positive_int,
         "sheets": _is_positive_int,
         "roles": _any,
     },
-    "site": {"picture": _is_int, "cell": _is_lattice_cell, "mode": _enum("removed")},
+    "site": {"picture": _is_picture_id, "cell": _is_lattice_cell, "mode": _enum("removed")},
     "region": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "lang": _enum("free", "lattice"),
         "slot": _enum(
             "selected", "secondary", "complement", "collar", "neutral", "group"
@@ -233,16 +240,16 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "name": _any,
     },
     "edge": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "from": _is_lattice_cell,
         "to": _is_lattice_cell,
         "role": _enum("none", "operator", "marked", "extra", "passive"),
     },
-    "cdcell": {"picture": _is_int, "index": _is_int},
-    "cdobject": {"picture": _is_int, "cell": _is_cell},
-    "cdarrow": {"picture": _is_int, "from": _any, "to": _any},
+    "cdcell": {"picture": _is_picture_id, "index": _is_int},
+    "cdobject": {"picture": _is_picture_id, "cell": _is_cell},
+    "cdarrow": {"picture": _is_picture_id, "from": _any, "to": _any},
     "cdmap": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "from": _is_cell,
         "to": _is_cell,
         "fused": _enum("0", "1"),
@@ -250,7 +257,7 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "species": _any,
     },
     "tree": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "id": _is_positive_int,
         "style": _enum("wire", "ribbon"),
         "leaves": _is_positive_int,
@@ -259,9 +266,9 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
         "role": _enum("none", "operator", "marked", "extra", "passive"),
         "species": _any,
     },
-    "join": {"picture": _is_int, "from": _any, "to": _any},
+    "join": {"picture": _is_picture_id, "from": _any, "to": _any},
     "span": {
-        "picture": _is_int,
+        "picture": _is_picture_id,
         "row": _is_positive_int,
         "col": _is_positive_int,
         "length": _is_positive_int,
@@ -280,7 +287,7 @@ class Event:
 
 @dataclass
 class Picture:
-    ident: int
+    ident: int | str
     lang: str
     line: int
     events: list[Event] = field(default_factory=list)
@@ -405,9 +412,12 @@ def parse_log(
                 )
                 valid = False
         if kind == "picture":
-            if not valid or "id" not in attrs or not _is_int(attrs["id"]):
+            if not valid or "id" not in attrs or not _is_picture_id(attrs["id"]):
                 continue
-            picture_id = int(attrs["id"])
+            # Dialect ids stay integers (every existing consumer indexes with
+            # them); kernel ids keep their k-prefixed spelling as strings.
+            raw_id = attrs["id"]
+            picture_id = raw_id if raw_id.startswith("k") else int(raw_id)
             lang = attrs.get("lang", "")
             if known_langs is not None and lang not in known_langs:
                 advisory(
@@ -430,9 +440,9 @@ def parse_log(
         if check_event is not None:
             check_event(event)
         reference = attrs.get("picture", "")
-        if not _is_int(reference):
+        if not _is_picture_id(reference):
             continue
-        picture_id = int(reference)
+        picture_id = reference if reference.startswith("k") else int(reference)
         if picture_id == 0 and kind == "tree":
             continue
         if picture_id not in by_id:


### PR DESCRIPTION
The bridge (#4994) made the kernel reachable from corpus cases, but the audit's parser predated it: picture ids had to be integers and `lang=kernel` was unknown, so every kernel picture failed with HARD malformed-event before any real check ran — surfaced by the first wave-B agent and confirmed against the repo's own k_* fixtures.

**The change is containment-first.** `_is_picture_id` admits the kernel's k-prefixed ids; dialect ids normalize back to integers, so every existing consumer (and every synthetic-tnlog test) sees exactly the values it always saw. `kernel` joins KNOWN_LANGS. Kernel-specific event kinds surface as advisory unknown-event notes — the audit stays honest about what it cannot yet judge instead of hard-failing on what it can't parse.

Regression evidence: full tenkz script battery green (test_tenkz_equation_web's failure pre-exists), kernel probe audits clean with advisories only, dialect streams unchanged byte-for-byte. Two intermediate regressions (face_ports, label_overlap) were caught by the battery during development and fixed by the int-normalization design before this commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contained parser/validation changes in tenkz tooling with backward-compatible integer id normalization for dialect logs; no auth, security, or runtime LaTeX behavior changes.
> 
> **Overview**
> Kernel `.tnlog` streams can be parsed and audited without **HARD** `malformed-event` failures on picture ids and `lang=kernel`.
> 
> **`tenkzlib/tnlog.py`** adds `_is_picture_id` (plain integers plus `k`-prefixed kernel ids) and uses it for `picture|id=` and every event’s `picture=` back-reference. Dialect ids are still stored as **integers**; kernel ids stay as **strings** (`Picture.ident` is now `int | str`). Unrecognized kernel event kinds continue to surface as advisory `unknown-event` notes instead of blocking the run.
> 
> **`tenkz_audit.py`** adds **`kernel`** to `KNOWN_LANGS` so `lang=kernel` is no longer flagged as unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1473abe23d320779f0408a24bed29a50507836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->