### PR TITLE
feat(Channel/Schwarz): prove common support resolvents

### DIFF
--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -39,6 +39,7 @@ import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.SchwarzSubnormal
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import TNLean.Channel.Schwarz.SupportLeftRightRelativeModular
+import TNLean.Channel.Schwarz.SupportRelativeEntropyEquality
 import TNLean.Channel.Schwarz.SupportRelativeEntropyGap
 import TNLean.Channel.Schwarz.SupportRelativeModular
 import TNLean.Channel.Schwarz.SupportResolvent

--- a/TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean
@@ -43,6 +43,92 @@ open scoped Matrix ComplexOrder MatrixOrder Kronecker
 
 namespace Matrix
 
+/-- The right-support projection absorbs the support projection of the
+left-right operator:
+\[
+  (1\otimes P_B^{\mathsf T})P_{A\otimes 1+t(1\otimes B^{\mathsf T})}
+  =1\otimes P_B^{\mathsf T}.
+\]
+
+The range witness is the support-domain algebra underlying the restriction to
+\((\ker B)^\perp\) in Jenčová--Ruskai, arXiv:0903.2895v4, lines 766--790. -/
+theorem supportRightProj_mul_supportLeftRightSupportProj_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    let P := (1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ
+    let hS := supportLeftRightSuperoperator_posSemidef hA hB ht.le
+    P * hS.isHermitian.supportProj = P := by
+  let Bplus := hB.supportInv
+  let res := t • (1 : Matrix (n × n) (n × n) ℂ) +
+    A ⊗ₖ Bplusᵀ
+  let P := (1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ
+  let S := supportLeftRightSuperoperator A B t
+  let C := (1 : Matrix n n ℂ) ⊗ₖ Bᵀ
+  let D := (1 : Matrix n n ℂ) ⊗ₖ Bplusᵀ
+  let hS : S.PosSemidef := by
+    simpa only [S] using
+      supportLeftRightSuperoperator_posSemidef hA hB ht.le
+  have hBplus_mul : Bplus * B = hB.isHermitian.supportProj := by
+    simpa only [Bplus] using hB.supportInv_mul_self
+  have hres : res.PosDef := by
+    simpa only [res, Bplus] using
+      supportRelativeModular_resolvent_posDef hA hB ht
+  letI : Invertible res := hres.isUnit.invertible
+  have hSP : S * P = C * res := by
+    simpa only [S, P, C, res, Bplus] using
+      supportLeftRightSuperoperator_mul_supportProj_eq (A := A) hB t
+  have hCD : C * D = P := by
+    dsimp only [C, D, P]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, hBplus_mul]
+  have hPidem : P * P = P := by
+    dsimp only [P]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, hB.isHermitian.supportProj_idem]
+  have hPS : hS.isHermitian.supportProj * P = P := by
+    rw [Matrix.ext_iff_mulVec]
+    intro v
+    let y : n × n → ℂ := P *ᵥ v
+    have hyP : P *ᵥ y = y := by
+      calc
+        P *ᵥ y = (P * P) *ᵥ v := by
+          exact Matrix.mulVec_mulVec v P P
+        _ = y := by rw [hPidem]
+    let w : n × n → ℂ := P *ᵥ (res⁻¹ *ᵥ (D *ᵥ y))
+    have hrange : S *ᵥ w = y := by
+      calc
+        S *ᵥ w = (S * P) *ᵥ (res⁻¹ *ᵥ (D *ᵥ y)) := by
+          exact Matrix.mulVec_mulVec (res⁻¹ *ᵥ (D *ᵥ y)) S P
+        _ = (C * res) *ᵥ (res⁻¹ *ᵥ (D *ᵥ y)) := by rw [hSP]
+        _ = C *ᵥ ((res * res⁻¹) *ᵥ (D *ᵥ y)) := by
+          simp only [Matrix.mulVec_mulVec, Matrix.mul_assoc]
+        _ = C *ᵥ (D *ᵥ y) := by
+          rw [Matrix.mul_inv_of_invertible]
+          simp
+        _ = (C * D) *ᵥ y := Matrix.mulVec_mulVec y C D
+        _ = P *ᵥ y := by rw [hCD]
+        _ = y := hyP
+    have hySupport : hS.isHermitian.supportProj *ᵥ y = y := by
+      rw [← hrange]
+      conv_lhs => rw [Matrix.mulVec_mulVec]
+      rw [hS.isHermitian.supportProj_mul_self]
+    calc
+      (hS.isHermitian.supportProj * P) *ᵥ v =
+          hS.isHermitian.supportProj *ᵥ y := by
+        rw [Matrix.mulVec_mulVec]
+      _ = y := hySupport
+      _ = P *ᵥ v := rfl
+  have hPherm : P.IsHermitian := by
+    change
+      ((1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ)ᴴ =
+        (1 : Matrix n n ℂ) ⊗ₖ hB.isHermitian.supportProjᵀ
+    rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one,
+      (hB.isHermitian.supportProj_isHermitian.transpose).eq]
+  have hstar := congrArg Matrix.conjTranspose hPS
+  simpa only [Matrix.conjTranspose_mul, hPherm.eq,
+    hS.isHermitian.supportProj_isHermitian.eq] using hstar
+
 /-- The support-generalized-inverse source-\(B\) solution of the left-right
 operator is the projected shifted relative-modular solution:
 \[

--- a/TNLean/Channel/Schwarz/SupportRelativeEntropyEquality.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeEntropyEquality.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.SupportLeftRightRelativeModular
+import TNLean.Channel.Schwarz.SupportRelativeEntropyGap
+
+/-!
+# Equality of support relative-modular resolvents
+
+This file completes the fixed-parameter equality passage for a finite family
+of positive-semidefinite pairs. Equality of the summed relative entropy with
+the sum of the individual relative entropies gives a common shifted
+relative-modular resolvent after restriction to each reference support.
+
+## Main result
+
+* `Matrix.supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq`:
+  relative-entropy equality gives the common projected shifted
+  relative-modular resolvent for every summand and every positive parameter.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, arXiv:0903.2895v4, Theorem `thm:eqJpI` and
+  the support-restricted resolvent conclusion at lines 766--793.
+
+This is the analytic support-resolvent step used toward the external
+Hayashi/Koashi--Imoto Markov-structure result invoked in CPSV16. It is not
+itself stated in CPSV16 and does not assert the later structural
+decomposition.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace Matrix
+
+/-- For a finite nonempty family of positive-semidefinite pairs satisfying
+\(\ker B_i\subseteq\ker A_i\), suppose
+\[
+  D\!\left(\sum_i A_i\middle\Vert\sum_i B_i\right)
+  =\sum_i D(A_i\Vert B_i).
+\]
+Then for every \(i\) and \(t>0\), the shifted relative-modular resolvents
+agree after restriction by the local right-support projection:
+\[
+\begin{aligned}
+ &(1\otimes P_{B_i}^{\mathsf T})
+   \bigl(t1+A_i\otimes(B_i^+)^{\mathsf T}\bigr)^{-1}
+   \operatorname{vec}(1^{\mathsf T})\\
+ ={}&(1\otimes P_{B_i}^{\mathsf T})
+   \bigl(t1+A_\Sigma\otimes(B_\Sigma^+)^{\mathsf T}\bigr)^{-1}
+   \operatorname{vec}(1^{\mathsf T}).
+\end{aligned}
+\]
+
+The local projection is essential: this is equality on
+\((\ker B_i)^\perp\), not ambient equality. This formalizes the common
+support-restricted resolvent conclusion in Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 766--793, using the generalized-inverse convention
+from lines 255--261. -/
+theorem supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    (hker : ∀ i (v : n → ℂ), B i *ᵥ v = 0 → A i *ᵥ v = 0)
+    (hrel :
+      quantumRelativeEntropy (∑ i, A i) (∑ i, B i) =
+        ∑ i, quantumRelativeEntropy (A i) (B i))
+    {t : ℝ} (ht : 0 < t) (i : ι) :
+    let Abar := ∑ j, A j
+    let Bbar := ∑ j, B j
+    let hBbar : Bbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun j _ ↦ hB j
+    let Q := (1 : Matrix n n ℂ) ⊗ₖ
+      (hB i).isHermitian.supportProjᵀ
+    Q *ᵥ
+        ((t • (1 : Matrix (n × n) (n × n) ℂ) +
+          A i ⊗ₖ (hB i).supportInvᵀ)⁻¹ *ᵥ
+            Matrix.vec (1 : Matrix n n ℂ)ᵀ) =
+      Q *ᵥ
+        ((t • (1 : Matrix (n × n) (n × n) ℂ) +
+          Abar ⊗ₖ hBbar.supportInvᵀ)⁻¹ *ᵥ
+            Matrix.vec (1 : Matrix n n ℂ)ᵀ) := by
+  classical
+  dsimp only
+  let Abar : Matrix n n ℂ := ∑ j, A j
+  let Bbar : Matrix n n ℂ := ∑ j, B j
+  let hAbar : Abar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun j _ ↦ hA j
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun j _ ↦ hB j
+  let Q : Matrix (n × n) (n × n) ℂ :=
+    (1 : Matrix n n ℂ) ⊗ₖ (hB i).isHermitian.supportProjᵀ
+  let Qbar : Matrix (n × n) (n × n) ℂ :=
+    (1 : Matrix n n ℂ) ⊗ₖ hBbar.isHermitian.supportProjᵀ
+  let hSi :=
+    supportLeftRightSuperoperator_posSemidef (hA i) (hB i) ht.le
+  let x : n × n → ℂ :=
+    (t • (1 : Matrix (n × n) (n × n) ℂ) +
+      A i ⊗ₖ (hB i).supportInvᵀ)⁻¹ *ᵥ
+        Matrix.vec (1 : Matrix n n ℂ)ᵀ
+  let xbar : n × n → ℂ :=
+    (t • (1 : Matrix (n × n) (n × n) ℂ) +
+      Abar ⊗ₖ hBbar.supportInvᵀ)⁻¹ *ᵥ
+        Matrix.vec (1 : Matrix n n ℂ)ᵀ
+  have hzero :=
+    supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq
+      A B hA hB hker hrel ht
+  have hcommon :=
+    supportLeftRightSupportInv_mulVec_sourceB_eq_of_defect_eq_zero
+      A B hA hB ht hzero i
+  have hlocal :
+      supportLeftRightSupportInv (hA i) (hB i) t *ᵥ
+          Matrix.vec (B i)ᵀ =
+        Q *ᵥ x := by
+    simpa only [Q, x] using
+      supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular
+        (hA i) (hB i) ht
+  have hsum :
+      supportLeftRightSupportInv hAbar hBbar t *ᵥ Matrix.vec Bbarᵀ =
+        Qbar *ᵥ xbar := by
+    simpa only [Qbar, xbar] using
+      supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular
+        hAbar hBbar ht
+  have hcommonProjected :
+      Q *ᵥ x =
+        hSi.isHermitian.supportProj *ᵥ (Qbar *ᵥ xbar) := by
+    rw [← hlocal, ← hsum]
+    simpa only [Abar, Bbar, hAbar, hBbar, hSi] using hcommon
+  have hQidem : Q * Q = Q := by
+    dsimp only [Q]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+      ← Matrix.transpose_mul, (hB i).isHermitian.supportProj_idem]
+  have hQSi : Q * hSi.isHermitian.supportProj = Q := by
+    simpa only [Q, hSi] using
+      supportRightProj_mul_supportLeftRightSupportProj_eq
+        (hA i) (hB i) ht
+  have hQQbar : Q * Qbar = Q := by
+    simpa only [Q, Qbar, Bbar, hBbar] using
+      supportRightProj_mul_sumSupportRightProj_eq B hB i
+  have happly :=
+    congrArg (fun y : n × n → ℂ ↦ Q *ᵥ y) hcommonProjected
+  calc
+    Q *ᵥ x = Q *ᵥ (Q *ᵥ x) := by
+      symm
+      calc
+        Q *ᵥ (Q *ᵥ x) = (Q * Q) *ᵥ x :=
+          Matrix.mulVec_mulVec x Q Q
+        _ = Q *ᵥ x := by rw [hQidem]
+    _ = Q *ᵥ
+        (hSi.isHermitian.supportProj *ᵥ (Qbar *ᵥ xbar)) := happly
+    _ = (Q * hSi.isHermitian.supportProj) *ᵥ
+        (Qbar *ᵥ xbar) := Matrix.mulVec_mulVec _ _ _
+    _ = Q *ᵥ (Qbar *ᵥ xbar) := by rw [hQSi]
+    _ = (Q * Qbar) *ᵥ xbar := Matrix.mulVec_mulVec _ _ _
+    _ = Q *ᵥ xbar := by rw [hQQbar]
+
+end Matrix

--- a/TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean
@@ -36,8 +36,10 @@ half-line.
   the positive-semidefinite extension at lines 717--720 and 766--793.
 
 This file proves the integral and continuity infrastructure and the
-pointwise vanishing of the source-\(B\) defect. Common projected resolvents
-and Petz recovery are not asserted here.
+pointwise vanishing of the source-\(B\) defect. The common projected
+resolvent is derived downstream in
+`TNLean.Channel.Schwarz.SupportRelativeEntropyEquality`; Petz recovery is not
+asserted here.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -252,8 +254,9 @@ source-\(B\) support defect vanish at every \(t>0\).
 The proof follows the equality passage of Jenčová--Ruskai,
 arXiv:0903.2895v4, lines 433--435, 652--674, and 788--790: the nonnegative
 gap integrand has zero integral, hence vanishes almost everywhere, and
-continuity upgrades this to pointwise vanishing. This theorem stops before
-the common projected resolvent conclusion at lines 788--793. -/
+continuity upgrades this to pointwise vanishing. The common projected
+resolvent conclusion at lines 788--793 is derived downstream in
+`supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq`. -/
 theorem supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq
     {ι : Type*} [Fintype ι] [Nonempty ι]
     (A B : ι → Matrix n n ℂ)

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -35,8 +35,10 @@ reference matrix is represented as the square of its support inverse square root
   Entropy and Related Trace Functions, with Conditions for Equality*,
   arXiv:0903.2895v4, §4.2, lines 766--793.
 
-The preceding singular equality-to-resolvent step at lines 717--720 is not
-formalized here; see `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.
+The preceding singular equality-to-resolvent step is formalized downstream in
+`TNLean.Channel.Schwarz.SupportRelativeEntropyEquality`. The later
+support functional-calculus and recovery steps are tracked in
+`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.
 -/
 
 open scoped Matrix ComplexOrder Kronecker MatrixOrder
@@ -190,9 +192,9 @@ This is the positive-square-root specialization of the singular-support
 functional-calculus step in Jenčová--Ruskai, arXiv:0903.2895v4, §4.2,
 lines 788--793. The restriction by the support projection is essential: the
 source asserts equality only on the complement of the kernel of the smaller
-reference matrix. This theorem does not supply that resolvent equality from
-equality in data processing; the missing preceding step is recorded in
-`docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`. -/
+reference matrix. The required finite-family resolvent equality from
+relative-entropy equality is supplied downstream by
+`supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq`. -/
 theorem supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq
     {n : Type*} [Fintype n] [DecidableEq n]
     {A B C D : Matrix n n ℂ}

--- a/TNLean/Channel/Schwarz/SupportResolvent.lean
+++ b/TNLean/Channel/Schwarz/SupportResolvent.lean
@@ -20,8 +20,8 @@ gives a common generalized-inverse solution after projection to each support.
 
 * `Matrix.support_resolvent_residual_identity`: the difference of the
   generalized-inverse quadratic forms is a sum of residual quadratic forms.
-* `Matrix.support_resolvent_eq_of_defect_eq_zero`: zero defect gives a common
-  solution after projection to each support.
+* `Matrix.support_resolvent_eq_of_defect_eq_zero`: vanishing real part of the
+  defect gives a common solution after projection to each support.
 
 ## References
 
@@ -207,15 +207,18 @@ lemma support_resolvent_quadratic_sum_sub_nonneg
   rw [hres] at hresidual_nonneg
   exact (Complex.nonneg_iff.mp hresidual_nonneg).1
 
-/-- **Zero support-resolvent defect gives a common solution on each
+/-- **Zero real support-resolvent defect gives a common solution on each
 support.** Under the hypotheses of `support_resolvent_residual_identity`, if
-the generalized-inverse quadratic defect vanishes, then the generalized
-solution for each summand is the restriction of the summed solution to that
-summand's support.
+the real part of the generalized-inverse quadratic defect vanishes, then the
+generalized solution for each summand is the restriction of the summed
+solution to that summand's support.
 
 This is the support-domain form of the common-resolvent conclusion
-`(basiceq)` in Jenčová--Ruskai, arXiv:0903.2895v4, §3.1. Its residual
-calculation is the one in the Appendix, equations `(Mj)` and `(eq:Schz1)`. -/
+`(basiceq)` in Jenčová--Ruskai, arXiv:0903.2895v4, §3.1 and lines
+652--660. Its residual calculation is the one in the Appendix, equations
+`(Mj)` and `(eq:Schz1)`. The residual identity makes the complex defect a
+sum of nonnegative quadratic forms, so its imaginary part vanishes
+automatically. -/
 theorem support_resolvent_eq_of_defect_eq_zero
     {ι : Type*} [Fintype ι] [Nonempty ι]
     (S : ι → Matrix n n ℂ) (b : ι → n → ℂ)
@@ -234,8 +237,8 @@ theorem support_resolvent_eq_of_defect_eq_zero
       let hSbar : Sbar.PosSemidef :=
         Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
       let Gbar := hSbar.supportInvSqrt * hSbar.supportInvSqrt
-      (∑ i, dotProduct (star (b i)) (G i *ᵥ b i)) -
-        dotProduct (star bbar) (Gbar *ᵥ bbar) = 0) :
+      ((∑ i, dotProduct (star (b i)) (G i *ᵥ b i)) -
+        dotProduct (star bbar) (Gbar *ᵥ bbar)).re = 0) :
     let Sbar := ∑ i, S i
     let bbar := ∑ i, b i
     let G := fun i ↦ (hS i).supportInvSqrt * (hS i).supportInvSqrt
@@ -255,11 +258,32 @@ theorem support_resolvent_eq_of_defect_eq_zero
   let Gbar : Matrix n n ℂ := hSbar.supportInvSqrt * hSbar.supportInvSqrt
   let x : n → ℂ := Gbar *ᵥ bbar
   have hresid := support_resolvent_residual_identity S b hS hb hbar
+  have hdefect_re :
+      ((∑ i, dotProduct (star (b i)) (G i *ᵥ b i)) -
+        dotProduct (star bbar) (Gbar *ᵥ bbar)).re = 0 := by
+    simpa only [Sbar, bbar, hSbar, G, Gbar] using hzero
+  have hdefect_nonneg :
+      (0 : ℂ) ≤
+        (∑ i, dotProduct (star (b i)) (G i *ᵥ b i)) -
+          dotProduct (star bbar) (Gbar *ᵥ bbar) := by
+    rw [← hresid]
+    apply Finset.sum_nonneg
+    intro i _
+    have hGi : (G i).PosSemidef := by
+      simpa only [G, (hS i).supportInvSqrt_isHermitian.eq] using
+        posSemidef_conjTranspose_mul_self (hS i).supportInvSqrt
+    exact hGi.dotProduct_mulVec_nonneg (b i - S i *ᵥ x)
+  have hdefect_zero :
+      (∑ i, dotProduct (star (b i)) (G i *ᵥ b i)) -
+          dotProduct (star bbar) (Gbar *ᵥ bbar) = 0 := by
+    apply Complex.ext
+    · simpa using hdefect_re
+    · simpa using (Complex.nonneg_iff.mp hdefect_nonneg).2.symm
   have hreszero :
       ∑ i, dotProduct (star (b i - S i *ᵥ x))
         (G i *ᵥ (b i - S i *ᵥ x)) = 0 := by
     rw [hresid]
-    exact hzero
+    exact hdefect_zero
   intro i
   let H : Matrix n n ℂ := (hS i).supportInvSqrt
   let P : Matrix n n ℂ := (hS i).isHermitian.supportProj

--- a/TNLean/Channel/Schwarz/SupportSourceDefect.lean
+++ b/TNLean/Channel/Schwarz/SupportSourceDefect.lean
@@ -20,6 +20,9 @@ inclusion.
 
 * `Matrix.supportSourceBQuadratic_sum_sub_nonneg`: the sum of the source-\(B\)
   support quadratic forms dominates the quadratic form of the summed pair.
+* `Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_of_defect_eq_zero`:
+  zero source-\(B\) defect gives the common support-generalized-inverse
+  solution for every summand.
 * `Matrix.rawSupportSourceAQuadratic_sum_sub_nonneg`: under the kernel
   inclusions, the analogous inequality holds for the unprojected
   source-\(A\) quadratic forms.
@@ -30,8 +33,10 @@ inclusion.
   notation at lines 254--262 and the positive-definite Appendix calculation
   `(Mj)`, `(eq:Schz1)`, and `(eq:Schwzt)` at lines 1313--1343.
 
-The subsequent singular entropy-equality argument is not asserted here. Its
-remaining steps are recorded in
+This file also proves the fixed-parameter common generalized-inverse solution
+from vanishing source-\(B\) defect. The entropy-equality and projected
+relative-modular conclusions are assembled downstream; the later recovery
+steps are recorded in
 `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.
 -/
 
@@ -102,6 +107,258 @@ private theorem supportLeftRight_sourceA_mem_support
     (supportLeftRightSuperoperator_posSemidef hA hB
       ht.le).isHermitian.supportProj_mul_self
 
+omit [Fintype n] in
+private theorem sum_supportLeftRightSuperoperator
+    {ι : Type*} [Fintype ι]
+    (A B : ι → Matrix n n ℂ) (t : ℝ) :
+    ∑ i, supportLeftRightSuperoperator (A i) (B i) t =
+      supportLeftRightSuperoperator (∑ i, A i) (∑ i, B i) t := by
+  ext ⟨p, q⟩ ⟨r, s⟩
+  simp [supportLeftRightSuperoperator, Matrix.sum_apply,
+    Complex.real_smul, Finset.sum_add_distrib, Finset.sum_mul,
+    Finset.mul_sum]
+
+omit [Fintype n] [DecidableEq n] in
+private theorem sum_vec_transpose
+    {ι : Type*} [Fintype ι] (B : ι → Matrix n n ℂ) :
+    ∑ i, vec (B i)ᵀ = vec (∑ i, B i)ᵀ := by
+  ext ⟨p, q⟩
+  simp [Matrix.vec, Matrix.sum_apply]
+
+private theorem supportLeftRight_sourceB_family_mem_support
+    {ι : Type*} [Fintype ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    let S : ι → Matrix (n × n) (n × n) ℂ :=
+      fun i ↦ supportLeftRightSuperoperator (A i) (B i) t
+    let b : ι → n × n → ℂ := fun i ↦ vec (B i)ᵀ
+    let hS : ∀ i, (S i).PosSemidef :=
+      fun i ↦ supportLeftRightSuperoperator_posSemidef
+        (hA i) (hB i) ht.le
+    (∀ i, (hS i).isHermitian.supportProj *ᵥ b i = b i) ∧
+      (let Sbar := ∑ i, S i
+       let bbar := ∑ i, b i
+       let hSbar : Sbar.PosSemidef :=
+         Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+       hSbar.isHermitian.supportProj *ᵥ bbar = bbar) := by
+  classical
+  dsimp only
+  constructor
+  · intro i
+    exact supportLeftRight_sourceB_mem_support (hA i) (hB i) ht
+  · let Abar : Matrix n n ℂ := ∑ i, A i
+    let Bbar : Matrix n n ℂ := ∑ i, B i
+    let hAbar : Abar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+    let hBbar : Bbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+    have htransport
+        (Sbar : Matrix (n × n) (n × n) ℂ) (bbar : n × n → ℂ)
+        (hSbar : Sbar.PosSemidef)
+        (hSbar_eq : Sbar = supportLeftRightSuperoperator Abar Bbar t)
+        (hbbar_eq : bbar = vec Bbarᵀ) :
+        hSbar.isHermitian.supportProj *ᵥ bbar = bbar := by
+      subst Sbar
+      subst bbar
+      exact supportLeftRight_sourceB_mem_support hAbar hBbar ht
+    exact htransport
+      (∑ i, supportLeftRightSuperoperator (A i) (B i) t)
+      (∑ i, vec (B i)ᵀ)
+      (Matrix.posSemidef_sum Finset.univ fun i _ ↦
+        supportLeftRightSuperoperator_posSemidef (hA i) (hB i) ht.le)
+      (by simpa only [Abar, Bbar] using
+        sum_supportLeftRightSuperoperator A B t)
+      (by simpa only [Bbar] using sum_vec_transpose B)
+
+private theorem supportSourceB_defect_eq_supportResolvent_defect_re
+    {ι : Type*} [Fintype ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    let Abar := ∑ i, A i
+    let Bbar := ∑ i, B i
+    let hAbar : Abar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+    let hBbar : Bbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+    let S : ι → Matrix (n × n) (n × n) ℂ :=
+      fun i ↦ supportLeftRightSuperoperator (A i) (B i) t
+    let b : ι → n × n → ℂ := fun i ↦ vec (B i)ᵀ
+    let hS : ∀ i, (S i).PosSemidef :=
+      fun i ↦ supportLeftRightSuperoperator_posSemidef
+        (hA i) (hB i) ht.le
+    let Sbar := ∑ i, S i
+    let bbar := ∑ i, b i
+    let hSbar : Sbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+    (∑ i, supportSourceBQuadratic (hA i) (hB i) t) -
+        supportSourceBQuadratic hAbar hBbar t =
+      ((∑ i, dotProduct (star (b i))
+          ((hS i).supportInv *ᵥ b i)) -
+        dotProduct (star bbar) (hSbar.supportInv *ᵥ bbar)).re := by
+  classical
+  dsimp only
+  let Abar : Matrix n n ℂ := ∑ i, A i
+  let Bbar : Matrix n n ℂ := ∑ i, B i
+  let hAbar : Abar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+  let S : ι → Matrix (n × n) (n × n) ℂ :=
+    fun i ↦ supportLeftRightSuperoperator (A i) (B i) t
+  let b : ι → n × n → ℂ := fun i ↦ vec (B i)ᵀ
+  let hS : ∀ i, (S i).PosSemidef :=
+    fun i ↦ supportLeftRightSuperoperator_posSemidef
+      (hA i) (hB i) ht.le
+  let Sbar : Matrix (n × n) (n × n) ℂ := ∑ i, S i
+  let bbar : n × n → ℂ := ∑ i, b i
+  let hSbar : Sbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+  have hQi (i : ι) :
+      supportSourceBQuadratic (hA i) (hB i) t =
+        (dotProduct (star (b i)) ((hS i).supportInv *ᵥ b i)).re := by
+    rw [supportSourceBQuadratic,
+      supportLeftRightSupportInv_eq (hA i) (hB i) ht.le]
+  have hQsum :
+      ∑ i, supportSourceBQuadratic (hA i) (hB i) t =
+        (∑ i, dotProduct (star (b i))
+          ((hS i).supportInv *ᵥ b i)).re := by
+    rw [Complex.re_sum]
+    exact Finset.sum_congr rfl fun i _ ↦ hQi i
+  have hQbar :
+      supportSourceBQuadratic hAbar hBbar t =
+        (dotProduct (star bbar) (hSbar.supportInv *ᵥ bbar)).re := by
+    rw [supportSourceBQuadratic,
+      supportLeftRightSupportInv_eq hAbar hBbar ht.le]
+    have htransport
+        (S' : Matrix (n × n) (n × n) ℂ) (b' : n × n → ℂ)
+        (hS' : S'.PosSemidef)
+        (hS'_eq : S' = supportLeftRightSuperoperator Abar Bbar t)
+        (hb'_eq : b' = vec Bbarᵀ) :
+        (dotProduct (star (vec Bbarᵀ))
+          ((supportLeftRightSuperoperator_posSemidef
+            hAbar hBbar ht.le).supportInv *ᵥ vec Bbarᵀ)).re =
+          (dotProduct (star b') (hS'.supportInv *ᵥ b')).re := by
+      subst S'
+      subst b'
+      rfl
+    exact htransport Sbar bbar hSbar
+      (by simpa only [S, Abar, Bbar] using
+        sum_supportLeftRightSuperoperator A B t)
+      (by simpa only [b, Bbar] using sum_vec_transpose B)
+  rw [hQsum, hQbar, Complex.sub_re]
+
+private theorem supportLeftRight_sourceB_common_supportInv
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    {t : ℝ} (ht : 0 < t)
+    (hzero :
+      let Abar := ∑ i, A i
+      let Bbar := ∑ i, B i
+      let hAbar : Abar.PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+      let hBbar : Bbar.PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+      (∑ i, supportSourceBQuadratic (hA i) (hB i) t) -
+        supportSourceBQuadratic hAbar hBbar t = 0) :
+    let S : ι → Matrix (n × n) (n × n) ℂ :=
+      fun i ↦ supportLeftRightSuperoperator (A i) (B i) t
+    let b : ι → n × n → ℂ := fun i ↦ vec (B i)ᵀ
+    let hS : ∀ i, (S i).PosSemidef :=
+      fun i ↦ supportLeftRightSuperoperator_posSemidef
+        (hA i) (hB i) ht.le
+    let Sbar := ∑ i, S i
+    let bbar := ∑ i, b i
+    let hSbar : Sbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+    ∀ i,
+      (hS i).supportInv *ᵥ b i =
+        (hS i).isHermitian.supportProj *ᵥ
+          (hSbar.supportInv *ᵥ bbar) := by
+  classical
+  dsimp only
+  let S : ι → Matrix (n × n) (n × n) ℂ :=
+    fun i ↦ supportLeftRightSuperoperator (A i) (B i) t
+  let b : ι → n × n → ℂ := fun i ↦ vec (B i)ᵀ
+  let hS : ∀ i, (S i).PosSemidef :=
+    fun i ↦ supportLeftRightSuperoperator_posSemidef
+      (hA i) (hB i) ht.le
+  have hb : ∀ i, (hS i).isHermitian.supportProj *ᵥ b i = b i := by
+    simpa only [S, b, hS] using
+      (supportLeftRight_sourceB_family_mem_support A B hA hB ht).1
+  have hbar :
+      let Sbar := ∑ i, S i
+      let bbar := ∑ i, b i
+      let hSbar : Sbar.PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+      hSbar.isHermitian.supportProj *ᵥ bbar = bbar := by
+    simpa only [S, b, hS] using
+      (supportLeftRight_sourceB_family_mem_support A B hA hB ht).2
+  have hdefect_re :
+      let Sbar := ∑ i, S i
+      let bbar := ∑ i, b i
+      let hSbar : Sbar.PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+      ((∑ i, dotProduct (star (b i))
+          ((hS i).supportInv *ᵥ b i)) -
+        dotProduct (star bbar) (hSbar.supportInv *ᵥ bbar)).re = 0 := by
+    simpa only [S, b, hS] using
+      (supportSourceB_defect_eq_supportResolvent_defect_re
+        A B hA hB ht).symm.trans hzero
+  simpa only [PosSemidef.supportInv] using
+    support_resolvent_eq_of_defect_eq_zero S b hS hb hbar
+      (by simpa only [PosSemidef.supportInv] using hdefect_re)
+
+private theorem sum_supportInv_mulVec_sourceB_eq
+    {ι : Type*} [Fintype ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    {t : ℝ} (ht : 0 < t) :
+    let Abar := ∑ i, A i
+    let Bbar := ∑ i, B i
+    let hAbar : Abar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+    let hBbar : Bbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+    let S : ι → Matrix (n × n) (n × n) ℂ :=
+      fun i ↦ supportLeftRightSuperoperator (A i) (B i) t
+    let b : ι → n × n → ℂ := fun i ↦ vec (B i)ᵀ
+    let hS : ∀ i, (S i).PosSemidef :=
+      fun i ↦ supportLeftRightSuperoperator_posSemidef
+        (hA i) (hB i) ht.le
+    let Sbar := ∑ i, S i
+    let bbar := ∑ i, b i
+    let hSbar : Sbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+    hSbar.supportInv *ᵥ bbar =
+      supportLeftRightSupportInv hAbar hBbar t *ᵥ vec Bbarᵀ := by
+  classical
+  dsimp only
+  rw [supportLeftRightSupportInv_eq _ _ ht.le]
+  have htransport
+      (Sbar : Matrix (n × n) (n × n) ℂ) (bbar : n × n → ℂ)
+      (hSbar : Sbar.PosSemidef)
+      (hSbar_eq :
+        Sbar = supportLeftRightSuperoperator (∑ i, A i) (∑ i, B i) t)
+      (hbbar_eq : bbar = vec (∑ i, B i)ᵀ) :
+      hSbar.supportInv *ᵥ bbar =
+        (supportLeftRightSuperoperator_posSemidef
+          (Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i)
+          (Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i)
+          ht.le).supportInv *ᵥ vec (∑ i, B i)ᵀ := by
+    subst Sbar
+    subst bbar
+    rfl
+  exact htransport
+    (∑ i, supportLeftRightSuperoperator (A i) (B i) t)
+    (∑ i, vec (B i)ᵀ)
+    (Matrix.posSemidef_sum Finset.univ fun i _ ↦
+      supportLeftRightSuperoperator_posSemidef (hA i) (hB i) ht.le)
+    (sum_supportLeftRightSuperoperator A B t)
+    (sum_vec_transpose B)
+
 /-- For a finite nonempty family of positive-semidefinite pairs and a fixed
 \(t>0\), the sum of the source-\(B\) support quadratic forms dominates the
 source-\(B\) quadratic form of the summed pair:
@@ -140,89 +397,139 @@ theorem supportSourceBQuadratic_sum_sub_nonneg
       supportSourceBQuadratic hAbar hBbar t := by
   classical
   dsimp only
-  let Abar : Matrix n n ℂ := ∑ i, A i
-  let Bbar : Matrix n n ℂ := ∑ i, B i
-  let hAbar : Abar.PosSemidef :=
-    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
-  let hBbar : Bbar.PosSemidef :=
-    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
   let S : ι → Matrix (n × n) (n × n) ℂ :=
     fun i ↦ supportLeftRightSuperoperator (A i) (B i) t
   let b : ι → n × n → ℂ := fun i ↦ vec (B i)ᵀ
   let hS : ∀ i, (S i).PosSemidef :=
     fun i ↦ supportLeftRightSuperoperator_posSemidef (hA i) (hB i) ht.le
   have hb : ∀ i, (hS i).isHermitian.supportProj *ᵥ b i = b i := by
-    intro i
     simpa only [S, b, hS] using
-      supportLeftRight_sourceB_mem_support (hA i) (hB i) ht
-  have hSsum :
-      ∑ i, S i = supportLeftRightSuperoperator Abar Bbar t := by
-    ext ⟨p, q⟩ ⟨r, s⟩
-    simp [S, Abar, Bbar, supportLeftRightSuperoperator,
-      Matrix.sum_apply, Complex.real_smul, Finset.sum_add_distrib,
-      Finset.sum_mul, Finset.mul_sum]
-  have hbsum : ∑ i, b i = vec Bbarᵀ := by
-    ext ⟨p, q⟩
-    simp [b, Bbar, Matrix.vec, Matrix.sum_apply]
+      (supportLeftRight_sourceB_family_mem_support A B hA hB ht).1
   have hbar :
       let Sbar := ∑ i, S i
       let bbar := ∑ i, b i
       let hSbar : Sbar.PosSemidef :=
         Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
       hSbar.isHermitian.supportProj *ᵥ bbar = bbar := by
-    dsimp only
-    have htransport
-        (Sbar : Matrix (n × n) (n × n) ℂ) (bbar : n × n → ℂ)
-        (hSbar : Sbar.PosSemidef)
-        (hSbar_eq : Sbar = supportLeftRightSuperoperator Abar Bbar t)
-        (hbbar_eq : bbar = vec Bbarᵀ) :
-        hSbar.isHermitian.supportProj *ᵥ bbar = bbar := by
-      subst Sbar
-      subst bbar
-      exact supportLeftRight_sourceB_mem_support hAbar hBbar ht
-    exact htransport (∑ i, S i) (∑ i, b i)
-      (Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i) hSsum hbsum
-  let Sbar : Matrix (n × n) (n × n) ℂ := ∑ i, S i
-  let bbar : n × n → ℂ := ∑ i, b i
-  let hSbar : Sbar.PosSemidef :=
-    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
-  let G : ι → Matrix (n × n) (n × n) ℂ := fun i ↦ (hS i).supportInv
-  let Gbar : Matrix (n × n) (n × n) ℂ := hSbar.supportInv
+    simpa only [S, b, hS] using
+      (supportLeftRight_sourceB_family_mem_support A B hA hB ht).2
   have hdefect_re :
-      0 ≤ ((∑ i, dotProduct (star (b i)) (G i *ᵥ b i)) -
-        dotProduct (star bbar) (Gbar *ᵥ bbar)).re := by
-    simpa only [Sbar, bbar, hSbar, G, Gbar] using
+      let Sbar := ∑ i, S i
+      let bbar := ∑ i, b i
+      let hSbar : Sbar.PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hS i
+      0 ≤ ((∑ i, dotProduct (star (b i))
+          ((hS i).supportInv *ᵥ b i)) -
+        dotProduct (star bbar) (hSbar.supportInv *ᵥ bbar)).re := by
+    simpa only [PosSemidef.supportInv] using
       support_resolvent_quadratic_sum_sub_nonneg S b hS hb hbar
-  have hQi (i : ι) :
-      supportSourceBQuadratic (hA i) (hB i) t =
-        (dotProduct (star (b i)) (G i *ᵥ b i)).re := by
-    rw [supportSourceBQuadratic,
-      supportLeftRightSupportInv_eq (hA i) (hB i) ht.le]
-  have hQsum :
-      ∑ i, supportSourceBQuadratic (hA i) (hB i) t =
-        (∑ i, dotProduct (star (b i)) (G i *ᵥ b i)).re := by
-    rw [Complex.re_sum]
-    exact Finset.sum_congr rfl fun i _ ↦ hQi i
-  have hQbar :
-      supportSourceBQuadratic hAbar hBbar t =
-        (dotProduct (star bbar) (Gbar *ᵥ bbar)).re := by
-    rw [supportSourceBQuadratic,
-      supportLeftRightSupportInv_eq hAbar hBbar ht.le]
-    have htransport
-        (S' : Matrix (n × n) (n × n) ℂ) (b' : n × n → ℂ)
-        (hS' : S'.PosSemidef)
-        (hS'_eq : S' = supportLeftRightSuperoperator Abar Bbar t)
-        (hb'_eq : b' = vec Bbarᵀ) :
-        (dotProduct (star (vec Bbarᵀ))
-          ((supportLeftRightSuperoperator_posSemidef
-            hAbar hBbar ht.le).supportInv *ᵥ vec Bbarᵀ)).re =
-          (dotProduct (star b') (hS'.supportInv *ᵥ b')).re := by
-      subst S'
-      subst b'
-      rfl
-    exact htransport Sbar bbar hSbar hSsum hbsum
-  rw [hQsum, hQbar]
-  simpa only [Complex.sub_re] using hdefect_re
+  rw [supportSourceB_defect_eq_supportResolvent_defect_re A B hA hB ht]
+  simpa only [S, b, hS] using hdefect_re
+
+/-- For a finite nonempty family of positive-semidefinite pairs and a fixed
+\(t>0\), vanishing of the real source-\(B\) defect makes every local
+support-generalized-inverse solution the restriction of the summed solution:
+\[
+  S_i^+\operatorname{vec}(B_i^{\mathsf T})
+  =
+  P_{S_i}S_\Sigma^+\operatorname{vec}(B_\Sigma^{\mathsf T}).
+\]
+
+This is the fixed-parameter residual step behind `(basiceq)` in
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 652--660 and 788--790. The theorem
+needs no kernel inclusion between \(B_i\) and \(A_i\); that hypothesis enters
+the preceding entropy-equality argument. This statement stops before
+identifying the restrictions with the common projected relative-modular
+resolvent. -/
+theorem supportLeftRightSupportInv_mulVec_sourceB_eq_of_defect_eq_zero
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    (A B : ι → Matrix n n ℂ)
+    (hA : ∀ i, (A i).PosSemidef) (hB : ∀ i, (B i).PosSemidef)
+    {t : ℝ} (ht : 0 < t)
+    (hzero :
+      let Abar := ∑ i, A i
+      let Bbar := ∑ i, B i
+      let hAbar : Abar.PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+      let hBbar : Bbar.PosSemidef :=
+        Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+      (∑ i, supportSourceBQuadratic (hA i) (hB i) t) -
+        supportSourceBQuadratic hAbar hBbar t = 0) :
+    let Abar := ∑ i, A i
+    let Bbar := ∑ i, B i
+    let hAbar : Abar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+    let hBbar : Bbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+    ∀ i,
+      supportLeftRightSupportInv (hA i) (hB i) t *ᵥ vec (B i)ᵀ =
+        (supportLeftRightSuperoperator_posSemidef
+          (hA i) (hB i) ht.le).isHermitian.supportProj *ᵥ
+          (supportLeftRightSupportInv hAbar hBbar t *ᵥ vec Bbarᵀ) := by
+  classical
+  dsimp only
+  let Abar : Matrix n n ℂ := ∑ i, A i
+  let Bbar : Matrix n n ℂ := ∑ i, B i
+  let hAbar : Abar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+  have hcommon :=
+    supportLeftRight_sourceB_common_supportInv A B hA hB ht hzero
+  have haggregate :=
+    sum_supportInv_mulVec_sourceB_eq A B hA hB ht
+  intro i
+  rw [supportLeftRightSupportInv_eq (hA i) (hB i) ht.le]
+  rw [← haggregate]
+  exact hcommon i
+
+/-- For a positive-semidefinite family, the right-support projection of each
+summand absorbs the right-support projection of the sum:
+\[
+  (1\otimes P_{B_i}^{\mathsf T})
+  (1\otimes P_{\sum_j B_j}^{\mathsf T})
+  =1\otimes P_{B_i}^{\mathsf T}.
+\]
+
+This records the support restriction used for each summand in the singular
+family argument of Jenčová--Ruskai, arXiv:0903.2895v4, lines 766--790. -/
+theorem supportRightProj_mul_sumSupportRightProj_eq
+    {ι : Type*} [Fintype ι]
+    (B : ι → Matrix n n ℂ) (hB : ∀ i, (B i).PosSemidef)
+    (i : ι) :
+    let Bbar := ∑ j, B j
+    let hBbar : Bbar.PosSemidef :=
+      Matrix.posSemidef_sum Finset.univ fun j _ ↦ hB j
+    ((1 : Matrix n n ℂ) ⊗ₖ (hB i).isHermitian.supportProjᵀ) *
+        ((1 : Matrix n n ℂ) ⊗ₖ hBbar.isHermitian.supportProjᵀ) =
+      (1 : Matrix n n ℂ) ⊗ₖ (hB i).isHermitian.supportProjᵀ := by
+  classical
+  dsimp only
+  let Bbar : Matrix n n ℂ := ∑ j, B j
+  let hBbar : Bbar.PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun j _ ↦ hB j
+  have hker :
+      ∀ v : n → ℂ, Bbar *ᵥ v = 0 →
+        (hB i).isHermitian.supportProj *ᵥ v = 0 := by
+    intro v hv
+    apply (hB i).supportProj_mulVec_eq_zero_of_mulVec_eq_zero
+    exact Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero hB
+      (by simpa only [Bbar] using hv) i
+  have hPiPbar :
+      (hB i).isHermitian.supportProj *
+          hBbar.isHermitian.supportProj =
+        (hB i).isHermitian.supportProj :=
+    hBbar.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
+  have hPbarPi :
+      hBbar.isHermitian.supportProj *
+          (hB i).isHermitian.supportProj =
+        (hB i).isHermitian.supportProj := by
+    have hstar := congrArg Matrix.conjTranspose hPiPbar
+    simpa only [Matrix.conjTranspose_mul,
+      hBbar.isHermitian.supportProj_isHermitian.eq,
+      (hB i).isHermitian.supportProj_isHermitian.eq] using hstar
+  rw [← Matrix.mul_kronecker_mul, Matrix.one_mul,
+    ← Matrix.transpose_mul, hPbarPi]
 
 /-- For a finite nonempty family of positive-semidefinite pairs satisfying
 \(\ker B_i\subseteq\ker A_i\), and for \(t>0\), the sum of the raw

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
@@ -800,6 +800,50 @@
     the displayed defect as a sum of nonnegative quadratic residuals.
 \end{proof}
 
+\begin{theorem}[Vanishing source-$B$ defect gives common left--right solutions]
+    \label{thm:support_sourceB_zero_defect_common_left_right_solution}
+    \lean{Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_of_defect_eq_zero}
+    \leanok
+    \uses{lem:support_sourceB_quadratic_sum_sub_nonnegative,
+      thm:support_resolvent_zero_defect}
+    Under the hypotheses and notation of
+    Lemma~\ref{lem:support_sourceB_quadratic_sum_sub_nonnegative}, suppose
+    that the source-$B$ defect vanishes:
+    \begin{align}
+        \sum_{i\in I}Q^B_{A_i,B_i}(t)
+          -Q^B_{A_\Sigma,B_\Sigma}(t)
+        &=0.
+        \notag
+    \end{align}
+    Put
+    \begin{align}
+        S_i&=A_i\otimes\mathbf 1+
+          t(\mathbf 1\otimes B_i^{\mathsf T}),&
+        S_\Sigma&=\sum_{i\in I}S_i,
+        \notag
+    \end{align}
+    and let $P_{S_i}$ be the support projection of $S_i$. Then
+    \begin{align}
+        S_i^+\opvec(B_i^{\mathsf T})
+        &=
+        P_{S_i}S_\Sigma^+\opvec(B_\Sigma^{\mathsf T})
+        \qquad(i\in I).
+        \notag
+    \end{align}
+    This is the fixed-parameter support-domain residual step behind
+    $(\mathrm{basiceq})$ in Jen\v{c}ov\'a--Ruskai,
+    arXiv:0903.2895v4, lines~652--660 and 788--790. No kernel inclusion is
+    needed for this algebraic implication.
+\end{theorem}
+
+\begin{proof}\leanok
+    The source vectors lie in the supports of their left--right operators,
+    and their sum lies in the support of $S_\Sigma$. The vanishing real
+    defect and the support-resolvent residual identity force every quadratic
+    residual to vanish. The common-solution conclusion follows after
+    projection to the support of each $S_i$.
+\end{proof}
+
 \begin{lemma}[Nonnegativity of the finite-family unprojected source-$A$ support defect]
     \label{lem:unprojected_support_sourceA_quadratic_sum_sub_nonnegative}
     \lean{Matrix.rawSupportSourceAQuadratic_sum_sub_nonneg}
@@ -968,8 +1012,9 @@
     \end{align}
     This is the source-$B$ pointwise-vanishing passage in
     Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines~433--435, 652--674,
-    and 788--790. The common projected resolvent conclusion at
-    lines~788--793 is not asserted here.
+    and 788--790. The common projected resolvent conclusion is stated
+    downstream in
+    Theorem~\ref{thm:support_relative_entropy_equality_common_projected_resolvent}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -981,9 +1026,6 @@
     $\operatorname{Def}_A(t)+t\operatorname{Def}_B(t)=0$, and $t>0$
     forces $\operatorname{Def}_B(t)=0$.
 \end{proof}
-
-% Open in #4435: it remains to convert the pointwise source-B defect
-% equality into the common projected relative-modular resolvent.
 
 \begin{theorem}[Spectral resolvent representation of relative entropy]
     \label{thm:relative_entropy_resolvent_integral}
@@ -1100,7 +1142,7 @@
     last three terms combine to $-\langle b,Gb\rangle$.
 \end{proof}
 
-\begin{theorem}[Zero support-resolvent defect gives a common solution]
+\begin{theorem}[Vanishing real support-resolvent defect gives a common solution]
     \label{thm:support_resolvent_zero_defect}
     \lean{Matrix.support_resolvent_eq_of_defect_eq_zero}
     \leanok
@@ -1108,7 +1150,9 @@
     Under the hypotheses and notation of
     Lemma~\ref{lem:support_resolvent_residual_identity}, suppose that
     \begin{align}
-        \sum_i\langle b_i,G_i b_i\rangle-\langle b,Gb\rangle
+        \re\left(
+          \sum_i\langle b_i,G_i b_i\rangle-\langle b,Gb\rangle
+        \right)
         &=0.
         \label{eq:entropy_zero_defect}
     \end{align}
@@ -1127,9 +1171,11 @@
 \begin{proof}\leanok
     \uses{lem:support_resolvent_residual_identity,
           lem:support_inverse_square_root_generalized_inverse}
-    Lemma~\ref{lem:support_resolvent_residual_identity} writes
-    (\ref{eq:entropy_zero_defect}) as a finite sum of non-negative quadratic
-    forms. Hence $G_i(b_i-S_ix)=0$ for every $i$.
+    Lemma~\ref{lem:support_resolvent_residual_identity} writes the complex
+    defect in (\ref{eq:entropy_zero_defect}) as a finite sum of non-negative
+    quadratic forms. Its imaginary part therefore vanishes automatically,
+    while the hypothesis makes its real part vanish. Hence
+    $G_i(b_i-S_ix)=0$ for every $i$.
     Multiplication by $S_i$ shows that $P_i(b_i-S_ix)=0$. Both $b_i$ and
     $S_ix$ lie in the support of $S_i$, so $b_i=S_ix$. Multiplication by
     $G_i$ now gives (\ref{eq:entropy_common_solution}).

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -359,6 +359,7 @@
 
 \begin{theorem}[Support left-right solution as a projected relative-modular resolvent]
     \label{thm:support_left_right_projected_relative_modular}
+    \lean{Matrix.supportRightProj_mul_supportLeftRightSupportProj_eq}
     \lean{Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular}
     \lean{Matrix.supportSourceBQuadratic_eq_projected_relativeModular}
     \leanok
@@ -424,6 +425,59 @@
     real parts gives the quadratic identity.
 \end{proof}
 
+\begin{theorem}[Relative-entropy equality gives common projected shifted relative-modular resolvents]
+    \label{thm:support_relative_entropy_equality_common_projected_resolvent}
+    \lean{Matrix.supportRightProj_mul_sumSupportRightProj_eq}
+    \lean{Matrix.supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq}
+    \leanok
+    \uses{thm:support_sourceB_defect_zero_of_relative_entropy_sum_eq,
+      thm:support_sourceB_zero_defect_common_left_right_solution,
+      thm:support_left_right_projected_relative_modular}
+    Let $I$ be a finite nonempty set. For each $i\in I$, let $A_i$ and $B_i$
+    be positive-semidefinite matrices satisfying
+    $\ker B_i\subseteq\ker A_i$. Put
+    \begin{align}
+        A_\Sigma&=\sum_{i\in I}A_i,&
+        B_\Sigma&=\sum_{i\in I}B_i,
+        \notag
+    \end{align}
+    and suppose that
+    \begin{align}
+        D(A_\Sigma\Vert B_\Sigma)
+        &=
+        \sum_{i\in I}D(A_i\Vert B_i).
+        \notag
+    \end{align}
+    Then, for every $i\in I$ and $t>0$,
+    \begin{align}
+      &(\mathbf 1\otimes P_{B_i}^{\mathsf T})
+        \bigl(t\mathbf 1+
+          A_i\otimes(B_i^+)^{\mathsf T}\bigr)^{-1}
+        \opvec(\mathbf 1^{\mathsf T})
+        \notag\\
+      &\qquad=
+        (\mathbf 1\otimes P_{B_i}^{\mathsf T})
+        \bigl(t\mathbf 1+
+          A_\Sigma\otimes(B_\Sigma^+)^{\mathsf T}\bigr)^{-1}
+        \opvec(\mathbf 1^{\mathsf T}).
+        \notag
+    \end{align}
+    Thus the shifted relative-modular resolvents agree on
+    $(\ker B_i)^\perp$. The local support projection is essential; no
+    ambient equality is asserted. This is the support-restricted conclusion
+    of Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines~766--793.
+\end{theorem}
+
+\begin{proof}\leanok
+    Relative-entropy equality makes the source-$B$ defect vanish for every
+    positive parameter. The common left--right solution theorem and the
+    one-pair projected relative-modular identity then compare the local
+    solution with the summed solution. The local right-support projection
+    absorbs both the support projection of the local left--right operator and
+    the right-support projection of the summed reference matrix. Applying it
+    to the common-solution identity gives the displayed equality.
+\end{proof}
+
 \begin{lemma}[Support relative-modular square-root evaluation]
     \label{lem:support_relative_modular_sqrt_evaluation}
     \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}
@@ -484,8 +538,8 @@
     projection $P_B$ is essential: the source gives the common generalized
     resolvents only after restriction to $(\ker B)^\perp$. Deriving this
     restricted equality requires the preceding singular equality argument and
-    its kernel hypotheses.
-    % Formalization status: the preceding equality-to-resolvent step remains open.
+    its kernel hypotheses; these are supplied for finite families by
+    Theorem~\ref{thm:support_relative_entropy_equality_common_projected_resolvent}.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -423,7 +423,10 @@ The kernel inclusions for the summands imply the same inclusion for the summed
 pair.
 \footnote{Formal declarations:
 \leanid{Matrix.rawSupportSourceAQuadratic_sum_sub_nonneg} and
-\leanid{Matrix.supportSourceBQuadratic_sum_sub_nonneg} in
+\leanid{Matrix.supportSourceBQuadratic_sum_sub_nonneg},
+\leanid{Matrix.supportLeftRightSupportInv_mulVec_sourceB_eq_of_defect_eq_zero},
+and
+\leanid{Matrix.supportRightProj_mul_sumSupportRightProj_eq} in
 \path{TNLean/Channel/Schwarz/SupportSourceDefect.lean}.}
 These are fixed-$t$ algebraic inequalities.  The remaining analytic passage
 now identifies the finite-family relative-entropy gap with the integral of
@@ -452,10 +455,20 @@ source-$B$ defect vanishes there.
 \leanid{Matrix.supportRelativeEntropyFamilyGapIntegrand_nonneg} and
 \leanid{Matrix.supportSourceBDefect_eq_zero_of_relativeEntropy_sum_eq} in
 \path{TNLean/Channel/Schwarz/SupportRelativeEntropyGap.lean}.}
-The remaining passage must derive the common projected shifted
-relative-modular resolvent from this fixed-parameter source-$B$ defect
-equality.
-Following the latter step, consider two positive semidefinite pairs $(A,B)$ and
+The residual identity now converts this real-valued defect equality into the
+common support-generalized-inverse solution.  The local right-support
+projection absorbs both the support projection of the local left--right
+operator and the right-support projection of the summed reference matrix.
+Consequently the local and summed shifted relative-modular resolvents agree
+after the local right-support projection, for every summand and every
+positive parameter.
+\footnote{Formal declarations:
+\leanid{Matrix.supportRightProj_mul_supportLeftRightSupportProj_eq} in
+\path{TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean}, and
+\leanid{Matrix.supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq}
+in
+\path{TNLean/Channel/Schwarz/SupportRelativeEntropyEquality.lean}.}
+Following this step, consider two positive semidefinite pairs $(A,B)$ and
 $(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
 $B$, and write
 $B^+=(B^{-1/2}_{\mathrm{supp}})^2$ and
@@ -506,12 +519,14 @@ also identifies this vector with the support-generalized-inverse solution of
 the left--right equation, and hence identifies the two source-$B$ quadratic
 forms.  Together with the integral and continuity argument above, equality
 of relative entropies now makes the real-valued source-$B$ defect vanish at
-every positive parameter.  What remains is to convert that equality into
-the complex quadratic-residual equality and derive the finite-family common
-projected resolvent theorem.  The kernel inclusion is already used for the
-unprojected source-$A$ inequality and remains an exact hypothesis of that
-source-facing equality theorem.  Consequently the singular Petz recovery
-identity is also still unformalized.
+every positive parameter.  Nonnegativity of the complex quadratic residuals
+makes their imaginary parts vanish, so the real equality yields the
+finite-family common projected resolvent theorem.  The kernel inclusion used
+for the unprojected source-$A$ inequality remains an exact hypothesis of this
+source-facing equality theorem.  What remains is to apply the resulting
+support functional-calculus identity through the singular Weyl
+inverse-square-root sandwich and Petz-recovery argument.  Thus the singular
+Petz recovery identity is still unformalized.
 
 In particular, the affine regularizations used to prove the inequality cannot
 by themselves prove its equality case.  Equality at the limiting pair implies

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -644,6 +644,25 @@ spectral split → block extraction → MPV calculation → strict bounds
   definitions and the subsequent arithmetic that isolates the source-\(B\) defect
   outside the eventual helper.
 
+### right-support range witness for a left--right operator — candidate
+- **Pattern:** factor the left--right operator through the right-support
+  projection and the shifted relative-modular resolvent, construct
+  `P R⁻¹ D y` for a `P`-fixed vector `y`, and use the witness to show that
+  the support projection of the left--right operator fixes `y`.
+- **Seen:** 2 occurrences in
+  `TNLean/Channel/Schwarz/SupportLeftRightRelativeModular.lean`, in
+  `supportRightProj_mul_supportLeftRightSupportProj_eq` and
+  `supportLeftRightSupportInv_mulVec_sourceB_eq_projected_relativeModular`
+  (2026-07-27).
+- **Abstraction (proposed):** a range-inclusion lemma stating that the range
+  of `1 ⊗ P_Bᵀ` is contained in the range of
+  `A ⊗ 1 + t(1 ⊗ Bᵀ)` for `t > 0`, with the projection-absorption identity
+  and the one-pair source solution as consumers.
+- **Notes:** Below the rule-of-three threshold. Keep the explicit witness in
+  both proofs until another independent consumer establishes the promotion
+  threshold; the surrounding conclusions and final generalized-inverse
+  calculation differ.
+
 ---
 
 ## Rejected


### PR DESCRIPTION
## Summary

- weaken the generic support-resolvent zero-defect bridge to the source-facing real-part hypothesis and recover exact complex vanishing from residual nonnegativity
- prove the fixed-parameter source-B common generalized-inverse solution and the two support-projection absorption identities
- derive the finite-family common shifted relative-modular resolvent under the exact positive-semidefinite kernel and relative-entropy equality hypotheses
- synchronize the Blueprint, the CPSV/Hayashi gap note, and the tactic-pattern ledger

## Source fidelity

The final theorem follows the support-restricted equality passage of Jenčová--Ruskai, arXiv:0903.2895v4, lines 652--660 and 766--793. It places the same local projector `1 ⊗ P_{B_i}ᵀ` on both the local and summed resolvents. It does not assert ambient resolvent equality, singular Petz recovery, or the later CPSV/Hayashi Markov decomposition.

Closes LionSR/QICLean#245.
Advances LionSR/QICLean#243 and LionSR/TNLean#4228. The finite-Weyl/partial-trace specialization remains the separate downstream leaf LionSR/QICLean#244.

## Verification

- `lake exe cache get` (no files downloaded; 8,639 artifacts already decompressed)
- `lake build` (9,774 jobs; only the pre-existing `sorry` warning in untouched `TNLean/MPS/Periodic/Overlap/SectorMatch.lean`)
- direct `lake exe checkdecls` for all five new or changed public declarations
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- changed-file proof-integrity scan and `git diff --check`
- `leanblueprint pdf` (767 pages) with visual inspection of PDF pages 360--369, including the new intermediate and final theorem entries

`leanblueprint checkdecls` could not use the fresh-worktree wrapper because `blueprint/lean_decls` is absent and the local pipx `leanblueprint web` installation cannot import its own package. The underlying declaration gate was run directly with `lake exe checkdecls` and passed for every declaration added or changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof surface in analytic quantum-information infrastructure; hypotheses (kernel inclusions, support projections) are easy to misuse, but changes are additive Lean proofs with no runtime or auth impact.
> 
> **Overview**
> This PR closes the **support-restricted resolvent step** (Jencová–Ruskai arXiv:0903.2895v4, ~766–793) in the SSA equality / Hayashi–Markov pipeline: when summed relative entropy equals the sum of individual entropies (with \(\ker B_i\subseteq\ker A_i\)), each summand’s shifted relative-modular resolvent agrees with the aggregated one after the local right-support projector \(1\otimes P_{B_i}^{\mathsf T}\)—not in full ambient space.
> 
> **Infrastructure changes:** `support_resolvent_eq_of_defect_eq_zero` now assumes only **vanishing real part** of the quadratic defect; full complex vanishing follows from residual nonnegativity. New lemmas cover common source-\(B\) generalized-inverse solutions from zero defect (`supportLeftRightSupportInv_mulVec_sourceB_eq_of_defect_eq_zero`), right-support absorption for left-right operators (`supportRightProj_mul_supportLeftRightSupportProj_eq`), and summand-vs-sum projector composition (`supportRightProj_mul_sumSupportRightProj_eq`).
> 
> **Capstone:** `SupportRelativeEntropyEquality.lean` proves `supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq` by chaining defect annihilation, common left-right solutions, one-pair projected modular identities, and the projection lemmas. Blueprint ch19, `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`, and tactic-pattern notes are updated; **Petz recovery and Markov structure remain downstream**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c4298c873ced7341809195b5db078f9bff28e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->