### PR TITLE
feat(Channel/Schwarz): specialize support resolvents to Weyl family

### DIFF
--- a/TNLean/Analysis/RelativeEntropySupportIntegral.lean
+++ b/TNLean/Analysis/RelativeEntropySupportIntegral.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.PosSemidefSupport
 import TNLean.Analysis.RelativeEntropyResolventIntegral
 
 /-!
@@ -15,6 +16,8 @@ so no nonintegrable unweighted zero-reference term is introduced.
 
 ## Main results
 
+* `quantumRelativeEntropy_smul_support` proves positive homogeneity on the
+  finite-relative-entropy support domain.
 * `supportRelativeEntropySpectralIntegrand` is the finite support-domain
   spectral integrand.
 * `supportRelativeEntropySpectralIntegrand_integrableOn_and_integral_eq_quantumRelativeEntropy`
@@ -108,6 +111,77 @@ theorem relativeEntropyScalar_mul_integrableOn_and_integral_of_nonneg
       rw [sub_zero, mul_right_comm a (Real.log a) w, haw, zero_mul]
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
+
+open scoped Matrix.Norms.L2Operator in
+private theorem log_smul_posSemidef {A : Matrix n n ℂ}
+    (hA : A.PosSemidef) {c : ℝ} (hc : 0 < c) :
+    CFC.log (c • A) =
+      (Real.log c) • hA.isHermitian.supportProj + CFC.log A := by
+  let p : ℝ → ℝ := fun x ↦ if x ≠ 0 then 1 else 0
+  have hp : ContinuousOn p (spectrum ℝ A) :=
+    A.finite_real_spectrum.continuousOn p
+  have hlog : ContinuousOn Real.log (spectrum ℝ A) :=
+    A.finite_real_spectrum.continuousOn Real.log
+  have hlogScaled :
+      ContinuousOn Real.log ((c • ·) '' spectrum ℝ A) :=
+    (A.finite_real_spectrum.image (c • ·)).continuousOn Real.log
+  have hsupport : cfc p A = hA.isHermitian.supportProj := by
+    rw [hA.isHermitian.cfc_eq, Matrix.IsHermitian.cfc,
+      Unitary.conjStarAlgAut_apply]
+    simp only [Matrix.IsHermitian.supportProj, p, Function.comp_def]
+    congr 2
+    ext i j
+    simp [Matrix.diagonal_apply]
+  rw [CFC.log, CFC.log, ← cfc_comp_smul (p := IsSelfAdjoint) c Real.log A
+    hlogScaled hA.isHermitian.isSelfAdjoint, ← hsupport,
+    ← cfc_smul (p := IsSelfAdjoint) (Real.log c) p A hp,
+    ← cfc_add (p := IsSelfAdjoint) (a := A)
+      (fun x ↦ (Real.log c) • p x) Real.log
+      (hf := A.finite_real_spectrum.continuousOn _)
+      (hg := hlog)]
+  apply cfc_congr
+  intro x _
+  simp only [p, smul_eq_mul]
+  by_cases hx : x = 0
+  · simp [hx]
+  · rw [if_pos hx, Real.log_mul hc.ne' hx]
+    ring
+
+open scoped Matrix.Norms.L2Operator in
+/-- Simultaneous multiplication of two positive-semidefinite arguments by a
+positive scalar multiplies their relative entropy by the same scalar, provided
+the kernel of the second argument is contained in the kernel of the first.
+
+This auxiliary scaling identity is used to pass from the uniformly weighted
+finite Weyl family to its unweighted form. It is a consequence of the
+positive-semidefinite support convention used by Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 717--720.
+
+The kernel condition is the finite-relative-entropy support condition. It makes
+the two support-projection terms in `log (cA) = (log c) P_A + log A` cancel. -/
+theorem quantumRelativeEntropy_smul_support {A B : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    {c : ℝ} (hc : 0 < c) :
+    quantumRelativeEntropy (c • A) (c • B) =
+      c * quantumRelativeEntropy A B := by
+  have hAPA : A * hA.isHermitian.supportProj = A :=
+    hA.isHermitian.mul_supportProj_self
+  have hAPB : A * hB.isHermitian.supportProj = A :=
+    hB.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
+  unfold quantumRelativeEntropy
+  rw [log_smul_posSemidef hA hc,
+    log_smul_posSemidef hB hc, smul_mul]
+  have hinside :
+      A * ((Real.log c) • hA.isHermitian.supportProj + CFC.log A -
+        ((Real.log c) • hB.isHermitian.supportProj + CFC.log B)) =
+        A * (CFC.log A - CFC.log B) := by
+    rw [Matrix.mul_sub, Matrix.mul_add, Matrix.mul_add,
+      Matrix.mul_smul, Matrix.mul_smul, hAPA, hAPB]
+    rw [Matrix.mul_sub]
+    abel
+  rw [hinside]
+  simp [Matrix.trace_smul]
 
 open scoped Matrix.Norms.L2Operator in
 /-- If the kernel of a positive-semidefinite reference matrix `B` is contained

--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -47,4 +47,5 @@ import TNLean.Channel.Schwarz.SupportSourceBDefect
 import TNLean.Channel.Schwarz.SupportSourceDefect
 import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.WeylRelativeEntropyIntegral
+import TNLean.Channel.Schwarz.WeylSupportRelativeEntropyEquality
 import TNLean.Channel.Schwarz.WeylTwirl

--- a/TNLean/Channel/Schwarz/WeylSupportRelativeEntropyEquality.lean
+++ b/TNLean/Channel/Schwarz/WeylSupportRelativeEntropyEquality.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.SupportRelativeEntropyEquality
+import TNLean.Channel.Schwarz.PetzEqualityPrerequisites
+
+/-!
+# Support-relative-modular equality for the finite Weyl family
+
+This file specializes the finite-family support-relative-entropy equality
+theorem to the Weyl family used in the proof of data processing under a partial
+trace.
+
+## Main result
+
+* `Matrix.weyl_supportRelativeModular_resolvent_mulVec_eq_of_partialTraceRight_eq`
+  turns saturation of partial-trace data processing on the finite-relative-
+  entropy support domain into the projected common relative-modular resolvent
+  for every Weyl summand and the full Weyl sum.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, arXiv:0903.2895v4, lines 717--720 and
+  766--793.
+* P. Hayden, R. Jozsa, D. Petz, and A. Winter,
+  arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).
+
+The finite-Weyl argument is the project's analytic route toward the recovery
+implication that precedes the separate structural characterization invoked in
+CPSV16, Lemma `Lsigma3`. CPSV16 does not present this Weyl/resolvent route, and
+the result below is not the direct-sum Markov decomposition asserted there.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+/-- An unweighted conjugate in the finite Weyl family. -/
+noncomputable def unweightedWeylConjugate
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)
+    (g : ZMod dC × ZMod dC) :
+    Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ :=
+  let U := (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2
+  U * M * Uᴴ
+
+/-- The sum of the unweighted finite Weyl conjugates. -/
+noncomputable def unweightedWeylSum
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+    Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ :=
+  ∑ g, unweightedWeylConjugate ζ M g
+
+/-- Positive semidefiniteness is preserved by an unweighted Weyl conjugation. -/
+theorem PosSemidef.unweightedWeylConjugate
+    {dS dC : ℕ} [NeZero dC]
+    {M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hM : M.PosSemidef) (ζ : ℂ) (g : ZMod dC × ZMod dC) :
+    (unweightedWeylConjugate ζ M g).PosSemidef :=
+  hM.mul_mul_conjTranspose_same
+    ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ g.1 g.2)
+
+/-- The unweighted finite Weyl sum of a positive-semidefinite matrix is
+positive semidefinite. -/
+theorem PosSemidef.unweightedWeylSum
+    {dS dC : ℕ} [NeZero dC]
+    {M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hM : M.PosSemidef) (ζ : ℂ) :
+    (unweightedWeylSum ζ M).PosSemidef := by
+  rw [Matrix.unweightedWeylSum]
+  exact Matrix.posSemidef_sum Finset.univ fun g _ ↦
+    hM.unweightedWeylConjugate ζ g
+
+/-- The zero-index unweighted Weyl conjugate is the original matrix. -/
+@[simp] theorem unweightedWeylConjugate_zero_zero
+    {dS dC : ℕ} [NeZero dC] (ζ : ℂ)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+    unweightedWeylConjugate ζ M (0, 0) = M := by
+  simp [unweightedWeylConjugate, weyl, weylShift, weylClock]
+
+/-- Saturation of relative entropy under the right partial trace gives the
+support-restricted common relative-modular resolvent for every Weyl summand
+and the full, unweighted Weyl sum.
+
+The scalar Jensen equality is converted to the relative-entropy equality for
+the unweighted family by support-domain homogeneity. The local projection is
+essential: the source proves equality on the support of the local reference
+matrix, not ambient resolvent equality.
+
+The positive-semidefinite support convention is that of Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 717--720; their common-resolvent equality argument is
+at lines 766--793. This finite-Weyl specialization is used toward
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8). -/
+theorem weyl_supportRelativeModular_resolvent_mulVec_eq_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))
+    {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    {t : ℝ} (ht : 0 < t) (g : ZMod dC × ZMod dC) :
+    let hBg := hσ.unweightedWeylConjugate ζ g
+    let hBsum := hσ.unweightedWeylSum ζ
+    let Q := (1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ
+      hBg.isHermitian.supportProjᵀ
+    Q *ᵥ
+        ((t • (1 : Matrix
+            ((Fin dS × ZMod dC) × (Fin dS × ZMod dC))
+            ((Fin dS × ZMod dC) × (Fin dS × ZMod dC)) ℂ) +
+          unweightedWeylConjugate ζ ρ g ⊗ₖ hBg.supportInvᵀ)⁻¹ *ᵥ
+            Matrix.vec
+              (1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)ᵀ) =
+      Q *ᵥ
+        ((t • (1 : Matrix
+            ((Fin dS × ZMod dC) × (Fin dS × ZMod dC))
+            ((Fin dS × ZMod dC) × (Fin dS × ZMod dC)) ℂ) +
+          unweightedWeylSum ζ ρ ⊗ₖ hBsum.supportInvᵀ)⁻¹ *ᵥ
+            Matrix.vec
+              (1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ)ᵀ) := by
+  classical
+  let A := unweightedWeylConjugate ζ ρ
+  let B := unweightedWeylConjugate ζ σ
+  have hA (i : ZMod dC × ZMod dC) : (A i).PosSemidef :=
+    hρ.unweightedWeylConjugate ζ i
+  have hB (i : ZMod dC × ZMod dC) : (B i).PosSemidef :=
+    hσ.unweightedWeylConjugate ζ i
+  have hU (i : ZMod dC × ZMod dC) :
+      ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ i.1 i.2) ∈
+        unitary (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :=
+    Matrix.kronecker_mem_unitary (Submonoid.one_mem _)
+      (weyl_mem_unitary hζ i.1 i.2)
+  have hker (i : ZMod dC × ZMod dC)
+      (v : Fin dS × ZMod dC → ℂ) (hv : B i *ᵥ v = 0) :
+      A i *ᵥ v = 0 := by
+    let U := (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ i.1 i.2
+    have hUunit : IsUnit U :=
+      Unitary.isUnit_coe (U := ⟨U, hU i⟩)
+    have hσv : σ *ᵥ (Uᴴ *ᵥ v) = 0 := by
+      apply Matrix.mulVec_injective_of_isUnit hUunit
+      simpa [B, unweightedWeylConjugate, U, Matrix.mulVec_mulVec,
+        Matrix.mul_assoc] using hv
+    have hρv := hsupp (Uᴴ *ᵥ v) hσv
+    simpa [A, unweightedWeylConjugate, U, Matrix.mulVec_mulVec,
+      Matrix.mul_assoc] using congrArg U.mulVec hρv
+  have hAbar : (∑ i, A i).PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hA i
+  have hBbar : (∑ i, B i).PosSemidef :=
+    Matrix.posSemidef_sum Finset.univ fun i _ ↦ hB i
+  have hsumker (v : Fin dS × ZMod dC → ℂ)
+      (hv : (∑ i, B i) *ᵥ v = 0) : (∑ i, A i) *ᵥ v = 0 := by
+    rw [Matrix.sum_mulVec]
+    apply Finset.sum_eq_zero
+    intro i _
+    exact hker i v
+      (Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero hB hv i)
+  let q : ℝ := ((dC : ℝ) ^ 2)⁻¹
+  have hq : 0 < q := by
+    have hdC : (0 : ℝ) < dC := by
+      exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+    dsimp [q]
+    positivity
+  have hsat := quantumRelativeEntropy_weyl_jensen_eq_of_partialTraceRight_eq
+    hρ hσ hsupp heq hζ
+  have hscaled :
+      quantumRelativeEntropy (q • ∑ i, A i) (q • ∑ i, B i) =
+        q * quantumRelativeEntropy (∑ i, A i) (∑ i, B i) :=
+    quantumRelativeEntropy_smul_support hAbar hBbar hsumker hq
+  have hqsmul (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+      q • M = (((dC : ℂ) ^ 2)⁻¹) • M := by
+    ext i j
+    norm_num [q]
+  have hsat' :
+      quantumRelativeEntropy (q • ∑ i, A i) (q • ∑ i, B i) =
+        q * ∑ i, quantumRelativeEntropy (A i) (B i) := by
+    rw [hqsmul, hqsmul]
+    simp_rw [Fintype.sum_prod_type]
+    simp_rw [Finset.mul_sum]
+    simpa only [A, B, unweightedWeylConjugate, q, smul_eq_mul] using hsat
+  have hrel :
+      quantumRelativeEntropy (∑ i, A i) (∑ i, B i) =
+        ∑ i, quantumRelativeEntropy (A i) (B i) := by
+    apply (mul_left_cancel₀ hq.ne')
+    rw [← hscaled]
+    exact hsat'
+  simpa only [A, B, unweightedWeylSum] using
+    supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq
+      A B hA hB hker hrel ht g
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
@@ -458,6 +458,34 @@
     $\log(cA)-\log(cB)$. Linearity of the trace then gives the result.
 \end{proof}
 
+\begin{lemma}[Support-domain positive homogeneity of relative entropy]
+    \label{lem:relative_entropy_support_positive_homogeneity}
+    \lean{Matrix.quantumRelativeEntropy_smul_support}
+    \leanok
+    \uses{def:quantum_relative_entropy,
+        def:hermitian_support_projection,
+        thm:support_projection_absorption_kernel_inclusion}
+    Let $A$ and $B$ be positive semidefinite and suppose that
+    $\ker B\subseteq\ker A$. If $c>0$, then
+    \begin{align}
+        D(cA\Vert cB)
+        &=cD(A\Vert B).
+        \label{eq:entropy_support_homogeneity}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    On the support of a positive semidefinite matrix,
+    \begin{align}
+        \log(cA)&=(\log c)P_A+\log A.
+        \notag
+    \end{align}
+    The support projection $P_A$ fixes $A$ on the right. The kernel
+    inclusion also makes $P_B$ fix $A$ on the right. Hence the two
+    terms containing $\log c$ cancel in the trace-log difference, and
+    linearity of the trace gives the result.
+\end{proof}
+
 \begin{theorem}[Partial-trace saturation gives zero weighted Weyl gap]
     \label{thm:partial_trace_saturation_weyl_gap_zero}
     \lean{Matrix.weylRelativeEntropyGap_eq_zero_of_partialTraceRight_eq}

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -478,6 +478,75 @@
     to the common-solution identity gives the displayed equality.
 \end{proof}
 
+\begin{theorem}[Partial-trace saturation gives common projected Weyl resolvents]
+    \label{thm:partial_trace_saturation_common_projected_weyl_resolvent}
+    \lean{Matrix.unweightedWeylConjugate}
+    \lean{Matrix.unweightedWeylSum}
+    \lean{Matrix.PosSemidef.unweightedWeylConjugate}
+    \lean{Matrix.PosSemidef.unweightedWeylSum}
+    \lean{Matrix.unweightedWeylConjugate_zero_zero}
+    \lean{Matrix.weyl_supportRelativeModular_resolvent_mulVec_eq_of_partialTraceRight_eq}
+    \leanok
+    \uses{thm:relative_entropy_weyl_jensen_eq,
+      lem:relative_entropy_support_positive_homogeneity,
+      thm:weyl_operator_unitary,
+      thm:support_relative_entropy_equality_common_projected_resolvent}
+    Let $\rho$ and $\sigma$ be positive semidefinite matrices satisfying
+    $\ker\sigma\subseteq\ker\rho$, and suppose that
+    \begin{align}
+        D(\rho\Vert\sigma)
+        &=D(\tr_C\rho\Vert\tr_C\sigma).
+        \notag
+    \end{align}
+    Fix a primitive $d_C$-th root of unity, put
+    $U_g=\mathbf 1\otimes W_g$, and define the unweighted Weyl family
+    \begin{align}
+        A_g&=U_g\rho U_g^\dagger,&
+        B_g&=U_g\sigma U_g^\dagger,&
+        A_\Sigma&=\sum_g A_g,&
+        B_\Sigma&=\sum_g B_g.
+        \notag
+    \end{align}
+    Then, for every Weyl index $g$ and every $t>0$,
+    \begin{align}
+      &(\mathbf 1\otimes P_{B_g}^{\mathsf T})
+        \bigl(t\mathbf 1+
+          A_g\otimes(B_g^+)^{\mathsf T}\bigr)^{-1}
+        \opvec(\mathbf 1^{\mathsf T})
+        \notag\\
+      &\qquad=
+        (\mathbf 1\otimes P_{B_g}^{\mathsf T})
+        \bigl(t\mathbf 1+
+          A_\Sigma\otimes(B_\Sigma^+)^{\mathsf T}\bigr)^{-1}
+        \opvec(\mathbf 1^{\mathsf T}).
+        \notag
+    \end{align}
+    In particular, the zero Weyl index gives the projected resolvent of
+    the original pair $(\rho,\sigma)$. No ambient resolvent equality is
+    asserted. The support convention is that of Jen\v{c}ov\'a--Ruskai,
+    arXiv:0903.2895v4, lines~717--720, and their common-resolvent equality
+    argument is at lines~766--793. This is one analytic step toward the
+    recovery implication of
+    Hayden--Jozsa--Petz--Winter, Theorem~3 and equation~(8); it is not the
+    direct-sum Markov decomposition invoked in CPSV16, Lemma
+    \texttt{Lsigma3}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Unitary conjugation preserves positive semidefiniteness and transports
+    the kernel inclusion to every pair $(A_g,B_g)$. The kernel of the sum
+    of the $B_g$ is contained in the kernel of the sum of the $A_g$.
+    The finite Weyl Jensen equality and
+    Lemma~\ref{lem:relative_entropy_support_positive_homogeneity} give
+    \begin{align}
+        D(A_\Sigma\Vert B_\Sigma)
+        &=\sum_g D(A_g\Vert B_g).
+        \notag
+    \end{align}
+    Theorem~\ref{thm:support_relative_entropy_equality_common_projected_resolvent}
+    applied to this finite family gives the displayed projected resolvent.
+\end{proof}
+
 \begin{lemma}[Support relative-modular square-root evaluation]
     \label{lem:support_relative_modular_sqrt_evaluation}
     \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -468,6 +468,27 @@ positive parameter.
 \leanid{Matrix.supportRelativeModular_resolvent_mulVec_eq_of_relativeEntropy_sum_eq}
 in
 \path{TNLean/Channel/Schwarz/SupportRelativeEntropyEquality.lean}.}
+This generic result is now specialized to the finite Weyl family produced by
+partial-trace saturation.  For the unweighted conjugates
+$A_g=U_g\rho U_g^\dagger$ and $B_g=U_g\sigma U_g^\dagger$, positive-scalar
+homogeneity on the support domain converts the weighted Jensen equality into
+\begin{align}
+  D\Bigl(\sum_gA_g\Bigm\Vert\sum_gB_g\Bigr)
+  =\sum_gD(A_g\Vert B_g).
+\end{align}
+Unitary conjugation transports the local kernel inclusions, while positivity
+of the summands transports them to the summed pair.  Hence the generic theorem
+gives the common projected relative-modular resolvent for every Weyl summand.
+At the zero Weyl index, the local pair is exactly $(\rho,\sigma)$.
+\footnote{Formal declarations:
+\leanid{Matrix.quantumRelativeEntropy_smul_support} in
+\path{TNLean/Analysis/RelativeEntropySupportIntegral.lean}, and
+\leanid{Matrix.weyl_supportRelativeModular_resolvent_mulVec_eq_of_partialTraceRight_eq}
+in
+\path{TNLean/Channel/Schwarz/WeylSupportRelativeEntropyEquality.lean}.}
+This is the analytic specialization required before the support
+square-root-ratio step.  It does not yet assert that ratio, the Petz sandwich,
+or recovery.
 Following this step, consider two positive semidefinite pairs $(A,B)$ and
 $(C,D)$.  Let $P_B$ be the support projection of the first reference matrix
 $B$, and write
@@ -523,8 +544,9 @@ every positive parameter.  Nonnegativity of the complex quadratic residuals
 makes their imaginary parts vanish, so the real equality yields the
 finite-family common projected resolvent theorem.  The kernel inclusion used
 for the unprojected source-$A$ inequality remains an exact hypothesis of this
-source-facing equality theorem.  What remains is to apply the resulting
-support functional-calculus identity through the singular Weyl
+source-facing equality theorem.  The finite-Weyl specialization now supplies
+the projected resolvent hypothesis for the support functional-calculus step.
+What remains is to carry its conclusion through the singular Weyl
 inverse-square-root sandwich and Petz-recovery argument.  Thus the singular
 Petz recovery identity is still unformalized.
 
@@ -583,10 +605,9 @@ of data processing:
 This is the forward implication of
 \cite[Theorem~3]{HaydenJozsaPetzWinter2004}.  The present proof of data
 processing establishes the inequality by regularization, unitary averaging,
-and joint convexity.  In the positive-definite case its equality analysis now
-reaches the common Weyl resolvent solution, the inverse-square-root sandwich,
-and raw Petz recovery.  What remains is to control the same passage on the
-supports of singular inputs.
+and joint convexity.  On singular supports its equality analysis now reaches
+the common projected Weyl resolvent.  What remains is the support
+inverse-square-root sandwich and raw Petz recovery.
 After this analytic implication, the proof of the block decomposition still
 requires the invariant-state decomposition used in
 \cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the


### PR DESCRIPTION
## Summary

- prove positive homogeneity of quantum relative entropy on the positive-semidefinite support domain
- specialize the generic finite-family support-resolvent equality to the unweighted finite Weyl family arising from partial-trace DPI saturation
- synchronize the Chapter 19 Blueprint and the CPSV16/HJPW paper-gap account

## Mathematical scope

For positive semidefinite `ρ` and `σ` with `ker σ ⊆ ker ρ`, partial-trace relative-entropy equality now yields the common shifted relative-modular resolvent between every unweighted Weyl summand and the full unweighted Weyl sum, after the essential local support projection.

At the zero Weyl index the local pair is exactly `(ρ, σ)`. The result does not assert ambient resolvent equality, a support square-root ratio, the Petz sandwich, Petz recovery, or the HJPW/Koashi--Imoto direct-sum structure. Those remain downstream in LionSR/QICLean#243, LionSR/TNLean#4228, and LionSR/TNLean#4961.

The support convention follows Jenčová--Ruskai, arXiv:0903.2895v4, lines 717--720; the common-resolvent equality argument is at lines 766--793. This is the project's analytic route toward the recovery implication used before the separate structural characterization invoked by CPSV16; CPSV16 itself does not present the Weyl/resolvent route.

Closes LionSR/QICLean#244.

## Verification

- `lake env lean TNLean/Analysis/RelativeEntropySupportIntegral.lean`
- `lake env lean TNLean/Channel/Schwarz/WeylSupportRelativeEntropyEquality.lean`
- `lake build` (9,775 jobs; only the known pre-existing `SectorMatch.lean` sorry warning)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base HEAD`
- `chktex -q -l blueprint/.chktexrc` on both changed Chapter 19 sources
- `leanblueprint web`
- `leanblueprint pdf` (768 pages), with visual inspection of the two affected rendered pages
- proof-integrity, line-length, diff, and tactic-pattern scans

Three independent read-only reviews approved the final stable diff for Lean/API correctness, mathematical source faithfulness, and Blueprint/paper-gap synchronization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are formal analytic lemmas in the SSA/Petz pipeline rather than auth or infra; incorrect kernel or CFC hypotheses could break downstream equality proofs, but scope is localized and documentation explicitly bounds claims.
> 
> **Overview**
> This PR advances the **singular-support equality analysis** for partial-trace data processing by linking weighted Weyl Jensen identities to the existing finite-family support-resolvent theorem.
> 
> **Lean:** `Matrix.quantumRelativeEntropy_smul_support` (and `log_smul_posSemidef`) shows \(D(cA\Vert cB)=c\,D(A\Vert B)\) for PSD pairs with \(\ker B\subseteq\ker A\), so \(d_C^{-2}\) weights can be removed from the Weyl family. New `WeylSupportRelativeEntropyEquality.lean` defines **unweighted** Weyl conjugates/sums and proves `weyl_supportRelativeModular_resolvent_mulVec_eq_of_partialTraceRight_eq`: from \(D(\rho\Vert\sigma)=D(\mathrm{tr}_C\rho\Vert\mathrm{tr}_C\sigma)\) one gets **projected** common shifted relative-modular resolvents for each summand vs. the full sum (not ambient equality). Wired via `TNLean/Channel/Schwarz.lean`.
> 
> **Docs:** Chapter 19 blueprint adds the support homogeneity lemma and the partial-trace saturation Weyl resolvent theorem; `cpsv16_ssa_equality_hayashi_markov.tex` records this as the finite-Weyl step before square-root ratio / Petz recovery (still downstream).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a6af47f6a5f05872468ad81a3f92d884c9c549d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->