### PR TITLE
chore(checks): preserve P7 SDP reproducibility artifacts

### DIFF
--- a/Notes/OpenProblemsTN/checks/round2_p7_sdp_search.md
+++ b/Notes/OpenProblemsTN/checks/round2_p7_sdp_search.md
@@ -1,0 +1,311 @@
+# Round 2, P7: channel SDP search and exact deformed-toric obstruction
+
+## Executive verdict
+
+The deformed toric family in the strategy note gives a counterexample to the static converse once it is put in the trace-normalized canonical gauge.  For every rational
+
+\[
+0<|q|<1,
+\qquad
+M_{00}=\frac{I}{2},\quad M_{11}=\frac{qZ}{2},\quad M_{01}=M_{10}=0,
+\]
+
+the generated states are
+
+\[
+\rho_N(q)=2^{-N}\bigl(I^{\otimes N}+q^N Z^{\otimes N}\bigr).
+\]
+
+They are positive, have zero correlation length (ZCL), and saturate the mutual-information area law (SAL), exactly as in the strategy note.  Nevertheless, there are no CPTP coarse-graining and fine-graining maps between one and two sites.  More strongly, there are no such maps between any two consecutive block sizes $k$ and $k+1$.  The obstruction has an exact rational strict dual certificate for rational $q$, so it is not a solver-tolerance effect.
+
+The obstruction sits in the non-simple part of the tensor.  The horizontal BNT element proportional to $Z$ is nilpotent in the relevant sense: tracing any one of its physical sites gives $\operatorname{tr}(Z)=0$, so the entire term is annihilated by a one-site partial trace.  Thus this does not conflict with the simple-tensor theorem.
+
+This supplies a negative answer to `prob:static-rfp(a)`, including its ``possibly after blocking'' version, provided the problem's stated definitions are used.  Before presenting it as a theorem, the recommended next step is a short source-level check with the authors that no extra convention excludes subleading nilpotent BNT coefficients $0<|q|<1$.
+
+The requested Fibonacci mutual-information numbers were **not** inferable from the supplied derivation note.  The note itself correctly states that the golden-ratio weights do not determine the finite-ring reduced density matrices.  I traced the primary sources, but they do not supply a directly machine-readable, gauge-fixed local boundary MPDO in the conventions needed here.  Consequently, no $I_1,I_2$ values are reported or claimed.  The exact weight-squaring and trace-preservation obstruction is confirmed below, but the unpublished entropy recollection remains unverified.
+
+## 1. Provenance and implementation
+
+### Sources inspected
+
+1. `Notes/OpenProblemsTN/strategies/p7_static_channel_derivations.tex`, read in full.
+2. `Notes/OpenProblemsTN/problems/p7_static_vs_channel_rfp.tex`, especially `prob:static-rfp` and `prob:ts-vs-algebra`.
+3. Primary arXiv source of Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608, including Definition 4.1 and the Fibonacci appendix example.
+4. Primary arXiv source of Bultinck--Mariën--Williamson--Şahinoğlu--Haegeman--Verstraete, arXiv:1511.08090, including the graphical string-net MPO formula and Fibonacci $F$-symbols.
+
+Items 3--4 were used only to check conventions and to search for the missing Fibonacci tensor.  The SDP and counterexample derivation below are original computations based on the strategy note.
+
+### Code and numerical environment
+
+The implementation is in:
+
+- `checks/round2_p7_sdp.py`;
+- `checks/round2_p7_sdp_results.json`;
+- the JSON output stores the complete machine-readable solver statuses and residuals.
+
+It uses CVXPY 1.9.2 and SCS 3.2.11 in an isolated Python environment, with requested SCS accuracy $2\times10^{-7}$ and at most $2\times10^5$ iterations.  The code implements the input-first Choi convention
+
+\[
+J_\Phi=\sum_{a,b}E_{ab}\otimes\Phi(E_{ab}),
+\qquad
+\Phi(Y)_{uv}=\sum_{a,b}Y_{ab}J_{(a,u),(b,v)}.
+\]
+
+For every channel it imposes:
+
+1. $J_\Phi\succeq0$;
+2. $\operatorname{tr}_{\rm out}J_\Phi=I_{\rm in}$;
+3. all $D^2$ closure equations, including equations with zero closure matrices.
+
+The two channel directions are solved independently.  This is legitimate because the definition imposes no nonlinear relation between their Choi matrices.
+
+### Important normalization correction
+
+As printed in the strategy note, $M_{00}=I$ and $M_{11}=qZ$.  This gauge cannot satisfy the channel identities even at $q=1$: trace preservation would require a channel to send $I_2$ to $I_4$, although their traces are $2$ and $4$.  SCS correctly declares both directions infeasible.
+
+The normalized canonical gauge is
+
+\[
+M_{00}=I/2,
+\qquad
+M_{11}=qZ/2.
+\]
+
+It generates the normalized state $2^{-N}(I^{\otimes N}+q^N Z^{\otimes N})$ and makes the known toric point $q=1$ feasible.  This correction changes no normalized static state, ZCL calculation, or SAL calculation, but it is essential because the tensor-level CPTP identities preserve trace.
+
+## 2. Positive controls
+
+### Product MPDO
+
+The product tensor has $D=1$ and $M_{00}=\operatorname{diag}(0.7,0.3)$.  Both directions were feasible:
+
+| map | SCS status | minimum Choi eigenvalue | TP residual | closure residual |
+|---|---:|---:|---:|---:|
+| $1\to2$ | optimal | $5.69\times10^{-2}$ | $9.55\times10^{-9}$ | $8.05\times10^{-9}$ |
+| $2\to1$ | optimal | $2.09\times10^{-1}$ | $1.67\times10^{-15}$ | $6.11\times10^{-16}$ |
+
+Exact channels also exist: discard and prepare the appropriate product state in either direction.
+
+### Toric boundary, $q=1$
+
+After the $1/2$ normalization, both arities are feasible:
+
+| arity pair | direction | status | minimum Choi eigenvalue | TP residual | closure residual |
+|---|---|---:|---:|---:|---:|
+| $1\leftrightarrow2$ | forward | optimal | $-9.24\times10^{-9}$ | $3.21\times10^{-9}$ | $8.43\times10^{-9}$ |
+| $1\leftrightarrow2$ | reverse | optimal | $-8.62\times10^{-17}$ | $5.55\times10^{-16}$ | $6.66\times10^{-16}$ |
+| $2\leftrightarrow3$ | forward | optimal | $-3.44\times10^{-9}$ | $9.73\times10^{-9}$ | $2.23\times10^{-9}$ |
+| $2\leftrightarrow3$ | reverse | optimal | $-5.14\times10^{-17}$ | $1.33\times10^{-15}$ | $6.38\times10^{-16}$ |
+
+The small negative eigenvalues in the forward solutions are at SCS feasibility tolerance.  Exact parity-measure/prepare channels verify feasibility independently.  Let
+
+\[
+P_\pm^{(k)}=\frac{I\pm Z^{\otimes k}}2,
+\qquad
+\tau_\pm^{(k)}=\frac{P_\pm^{(k)}}{2^{k-1}}.
+\]
+
+At $q=1$, measuring the input parity and preparing $\tau_\pm$ on the output gives exact channels in both directions.
+
+## 3. Parameter scan
+
+The complete scan used
+
+\[
+q\in\{-1,-0.9,-0.75,-0.5,-0.25,-0.1,0,0.1,0.25,0.5,0.75,0.9,1\}.
+\]
+
+Here `F` means SCS `optimal` and `I` means SCS `infeasible`.
+
+| $q$ | $1\to2$ | $2\to1$ | $2\to3$ | $3\to2$ |
+|---:|:---:|:---:|:---:|:---:|
+| $-1$ | F | F | F | F |
+| $-0.9$ | F | I | F | I |
+| $-0.75$ | F | I | F | I |
+| $-0.5$ | F | I | F | I |
+| $-0.25$ | F | I | F | I |
+| $-0.1$ | F | I | F | I |
+| $0$ | F | F | F | F |
+| $0.1$ | F | I | F | I |
+| $0.25$ | F | I | F | I |
+| $0.5$ | F | I | F | I |
+| $0.75$ | F | I | F | I |
+| $0.9$ | F | I | F | I |
+| $1$ | F | F | F | F |
+
+Thus the numerics expose a sharp, non-marginal phase diagram: the fine-graining direction is feasible throughout $[-1,1]$, while the reverse direction is feasible only at $q=0,\pm1$.
+
+The forward feasibility has a direct exact construction.  Measure $k$-site parity, pass the resulting classical bit through a binary symmetric channel with correlation $q$, and prepare the normalized $(k+1)$-site parity sector.  This sends
+
+\[
+\frac{I_{2^k}}{2^k}\longmapsto\frac{I_{2^{k+1}}}{2^{k+1}},
+\qquad
+\frac{q^k Z^{\otimes k}}{2^k}
+\longmapsto
+\frac{q^{k+1}Z^{\otimes(k+1)}}{2^{k+1}}.
+\]
+
+## 4. Exact dual certificate and all-blocking theorem
+
+For $k\ge2$, consider a hypothetical reverse channel
+
+\[
+\mathcal S_k:\mathcal M_{2^k}\to\mathcal M_{2^{k-1}}
+\]
+
+which maps the $k$-site closures to the $(k-1)$-site closures.  The two nonzero closure equations force
+
+\[
+\mathcal S_k(I)=2I,
+\qquad
+\mathcal S_k(Z^{\otimes k})=\frac{2}{q}Z^{\otimes(k-1)}.
+\]
+
+Let
+
+\[
+P_+^{(k)}=\frac{I+Z^{\otimes k}}2\succeq0
+\]
+
+and choose a computational basis vector $v$ whose $Z^{\otimes(k-1)}$ eigenvalue is $-\operatorname{sgn}(q)$.  Complete positivity would imply
+
+\[
+0\le \langle v|\mathcal S_k(P_+^{(k)})|v\rangle
+=1-\frac1{|q|},
+\]
+
+which is strictly negative when $0<|q|<1$.  This proves exact infeasibility for every consecutive pair of block sizes, not only $1\leftrightarrow2$ and $2\leftrightarrow3$.
+
+This is also an explicit strict Choi-dual separator.  Use the two interpolation constraints with input matrices
+
+\[
+Y_0=\frac{I}{2^k},
+\qquad
+Y_1=\frac{q^kZ^{\otimes k}}{2^k},
+\]
+
+and dual output matrices
+
+\[
+H_0=2^{k-1}|v\rangle\langle v|,
+\qquad
+H_1=\frac{2^{k-1}}{q^k}|v\rangle\langle v|.
+\]
+
+Their adjoint image is
+
+\[
+Y_0^{\mathsf T}\otimes H_0+Y_1^{\mathsf T}\otimes H_1
+=P_+^{(k)}\otimes|v\rangle\langle v|\succeq0,
+\]
+
+while pairing the same multipliers with the required outputs gives
+
+\[
+1-\frac1{|q|}<0.
+\]
+
+For rational $q$, every entry of this certificate is rational.  At the representative point $q=1/2$:
+
+- for $2\to1$, $(H_0,H_1)=(2,8)|v\rangle\langle v|$ and the dual pairing is $-1$;
+- for $3\to2$, $(H_0,H_1)=(4,32)|v\rangle\langle v|$ and the dual pairing is again $-1$.
+
+No trace-preserving dual multiplier is needed: positivity plus the two closure equations already contradict each other.  This is stronger and cleaner than rationalizing a noisy solver-returned dual vector.
+
+The $1\to2$ reverse case is the same formula with $k=2$.  More generally, if one first blocks $r$ original sites into one supersite, the requested one-to-two map is a reverse map from $2r$ original sites to $r$ original sites.  Its closure equations force an amplification by $q^{-r}$, and the same positive-parity test gives $1-|q|^{-r}<0$.  Therefore **no finite blocking restores the RFP channel property**.
+
+## 5. Static properties and non-simplicity
+
+For $|q|\le1$, the eigenvalues of $\rho_N(q)$ are
+
+\[
+2^{-N}(1\pm q^N),
+\]
+
+each with multiplicity $2^{N-1}$, hence positivity is exact.  Every proper reduction is maximally mixed because tracing one site annihilates $Z^{\otimes N}$.  Therefore separated correlations factorize (ZCL), and
+
+\[
+I_L=N\log2-S(\rho_N(q))
+\]
+
+is independent of every admissible region size $L$ (SAL).
+
+The same trace identity proves non-simplicity.  The horizontal BNT contains the $qZ$ component.  For $q\ne0$,
+
+\[
+\operatorname{tr}(qZ)=0,
+\]
+
+so a partial trace over one site annihilates every periodic operator generated by this BNT element.  This is precisely the nilpotent behavior excluded by the simple-tensor results.
+
+## 6. Fibonacci $\rho$ versus $\rho^2$
+
+### What is verified exactly
+
+With $\phi=(1+\sqrt5)/2$ and sector weights $(1,\phi)$, the normalized distributions are
+
+\[
+p=(\phi^{-2},\phi^{-1})
+=\left(\frac{3-\sqrt5}{2},\frac{\sqrt5-1}{2}\right),
+\]
+
+and
+
+\[
+p^{[2]}=\frac{(1,\phi^2)}{1+\phi^2}
+=\left(\frac{5-\sqrt5}{10},\frac{5+\sqrt5}{10}\right).
+\]
+
+A symbolic Wolfram Language check verified both normalizations and the unequal sector trace ratios
+
+\[
+\frac{p_1^{[2]}}{p_1}=\frac{5+\sqrt5}{10},
+\qquad
+\frac{p_\tau^{[2]}}{p_\tau}=\frac{5+3\sqrt5}{10},
+\qquad
+\frac{p_\tau^{[2]}/p_\tau}{p_1^{[2]}/p_1}=\phi.
+\]
+
+Thus the inherited sectorwise CP map cannot be trace preserving after squaring.  This confirms the weight obstruction in the strategy note.
+
+### Why the requested $I_1,I_2$ table is not present
+
+The supplied note explicitly proves that the weights do not determine the transfer operator or the finite-ring reductions.  It even gives channels with the same Fibonacci fixed density matrix and spectra $\{1,t,t,t\}$ for arbitrary $t\in[0,1]$.  Hence no valid computation of $I_1$ and $I_2$ can use the two golden-ratio weights alone.
+
+The primary source arXiv:1606.00608 gives, for one vacuum BNT element, only
+
+\[
+A^{ijk}_{\alpha\beta}=\delta_{i\alpha}\delta_{k\beta}N_{ijk},
+\]
+
+with a support rule for $N_{ijk}$, not the complete weighted boundary MPDO needed for the entropy calculation.  ArXiv:1511.08090 gives the string-net MPO graphically in terms of $G$-symbols and supplies the Fibonacci $F$-symbols, but not as a gauge-fixed numerical tensor in the index convention of the P7 note.  Translating that graph is a substantive reconstruction step; guessing it would destroy provenance.
+
+Accordingly, for $N=4,\ldots,8$ the honest status is:
+
+| $N$ | $I_1(\rho)$ | $I_2(\rho)$ | $I_1(\rho^2)$ | $I_2(\rho^2)$ |
+|---:|:---:|:---:|:---:|:---:|
+| 4 | not determined from supplied data | not determined | not determined | not determined |
+| 5 | not determined from supplied data | not determined | not determined | not determined |
+| 6 | not determined from supplied data | not determined | not determined | not determined |
+| 7 | not determined from supplied data | not determined | not determined | not determined |
+| 8 | not determined from supplied data | not determined | not determined | not determined |
+
+This is a failed deliverable item, not a negative numerical result.  The unpublished Cirac--Pérez-García entropy recollection remains to be verified from an explicit local tensor.
+
+## 7. Implications and next steps
+
+1. **Highest priority: validate the counterexample's scope with the source conventions.** The proof is elementary and exact.  Check only that the canonical-form definition permits the subleading nilpotent coefficient $q$ and that SAL is intended at each fixed ring size exactly as quoted.
+2. **If confirmed, write the result as a proposition.** The one-parameter family proves ZCL+SAL $\not\Rightarrow$ RFP even after arbitrary finite blocking.  The proof needs no SDP machinery once discovered.
+3. **Interpret the missing static condition.** The counterexample isolates a natural candidate strengthening: static data must control nilpotent BNT amplitudes that disappear under proper reductions.  ZCL and SAL cannot see them, while reversibility requires their trace-norm distinguishability not to shrink.  A promising $\Sigma$ is therefore an ``absence of hidden decaying nilpotent sectors'' or, more operationally, preservation of distinguishability for boundary-conditioned closures.
+4. **Relation to $\Sigma_2$ and $\Sigma_3$.** Every proper local reduction here is maximally mixed, so a purely local compatible-Markov condition of the stated $\Sigma_2$ type is also blind to the obstruction.  Thus $\Sigma_2$ as currently phrased is unlikely to suffice.  The obstruction is instead visible at the boundary-conditioned operator-system level used by the SDP.
+5. **Fibonacci follow-up.** Obtain a gauge-fixed numerical boundary MPO directly from one of the original authors or from the code used for arXiv:1511.08090.  Record the precise map from categorical labels to matrix indices, verify positivity and normalization for $N=4$, and only then compute the four entropy columns for $N=4,\ldots,8$ at high precision.
+
+## Reproduction
+
+From an environment containing CVXPY and SCS:
+
+```sh
+python checks/round2_p7_sdp.py
+```
+
+The script writes the complete machine-readable solver statuses and residuals to `checks/round2_p7_sdp_results.json`.

--- a/checks/round2_p7_sdp.py
+++ b/checks/round2_p7_sdp.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""SDP checks for P7 (static versus channel RFP).
+
+The Choi convention is input-first:
+    J(Phi) = sum_ab E_ab tensor Phi(E_ab).
+All tensor products use NumPy/CVXPY's row-major Kronecker ordering.
+
+Run with the isolated environment used in the accompanying report:
+    /tmp/p7_sdp_venv/bin/python checks/round2_p7_sdp.py
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import cvxpy as cp
+import numpy as np
+
+
+def partial_trace_output(J, n_in: int, n_out: int):
+    """Trace the output factor of an input-first Choi matrix."""
+    return cp.bmat([
+        [sum(J[a*n_out+u, b*n_out+u] for u in range(n_out))
+         for b in range(n_in)]
+        for a in range(n_in)
+    ])
+
+
+def choi_action(J, Y: np.ndarray, n_in: int, n_out: int):
+    """Phi(Y), using J[(a,u),(b,v)] = Phi(E_ab)[u,v]."""
+    return cp.bmat([
+        [sum(Y[a, b] * J[a*n_out+u, b*n_out+v]
+             for a in range(n_in) for b in range(n_in))
+         for v in range(n_out)]
+        for u in range(n_out)
+    ])
+
+
+def solve_channel(inputs, outputs, eps=2e-7, max_iters=200_000):
+    """Find a CPTP map taking each input to the corresponding output."""
+    n_in = inputs[0].shape[0]
+    n_out = outputs[0].shape[0]
+    J = cp.Variable((n_in*n_out, n_in*n_out), hermitian=True)
+    constraints = [J >> 0, partial_trace_output(J, n_in, n_out) == np.eye(n_in)]
+    closure_constraints = []
+    for Y, Z in zip(inputs, outputs):
+        c = choi_action(J, Y, n_in, n_out) == Z
+        constraints.append(c)
+        closure_constraints.append(c)
+    prob = cp.Problem(cp.Minimize(0), constraints)
+    value = prob.solve(solver="SCS", eps=eps, max_iters=max_iters,
+                       acceleration_lookback=20, verbose=False)
+    out = {"status": prob.status, "value": value, "n_in": n_in, "n_out": n_out}
+    if J.value is not None:
+        Jh = (J.value + J.value.conj().T) / 2
+        out["min_choi_eig"] = float(np.linalg.eigvalsh(Jh).min())
+        out["tp_residual"] = float(np.max(np.abs(
+            np.array(partial_trace_output(cp.Constant(Jh), n_in, n_out).value)
+            - np.eye(n_in))))
+        out["closure_residual"] = float(max(
+            np.max(np.abs(np.array(choi_action(cp.Constant(Jh), Y, n_in, n_out).value) - Z))
+            for Y, Z in zip(inputs, outputs)))
+        out["choi"] = Jh
+    out["closure_duals"] = [None if c.dual_value is None else np.asarray(c.dual_value)
+                            for c in closure_constraints]
+    return out
+
+
+def mk_closures(M: np.ndarray, k: int):
+    """Return [M_k(E_pq)] in p,q lexicographic order.
+
+    M has shape (D,D,d,d). For E_pq the virtual path starts at q and ends at p.
+    """
+    D, _, d, _ = M.shape
+    ans = []
+    for p in range(D):
+        for q in range(D):
+            cur = {(q,): np.array([[1.0 + 0j]])}
+            for _step in range(k):
+                nxt = {}
+                for path, op in cur.items():
+                    a = path[-1]
+                    for b in range(D):
+                        nxt[path + (b,)] = np.kron(op, M[a, b])
+                cur = nxt
+            total = np.zeros((d**k, d**k), dtype=complex)
+            for path, op in cur.items():
+                if path[-1] == p:
+                    total += op
+            ans.append(total)
+    return ans
+
+
+def test_pair(M: np.ndarray, k_small=1, k_large=2, **solver_kw):
+    small = mk_closures(M, k_small)
+    large = mk_closures(M, k_large)
+    forward = solve_channel(small, large, **solver_kw)
+    reverse = solve_channel(large, small, **solver_kw)
+    return {"forward": strip_arrays(forward), "reverse": strip_arrays(reverse)}
+
+
+def strip_arrays(x):
+    if isinstance(x, dict):
+        return {k: strip_arrays(v) for k, v in x.items() if k not in {"choi", "closure_duals"}}
+    if isinstance(x, np.ndarray):
+        return x.tolist()
+    return x
+
+
+def product_tensor(rho=None):
+    if rho is None:
+        rho = np.diag([0.7, 0.3])
+    M = np.zeros((1, 1, 2, 2), dtype=complex)
+    M[0, 0] = rho
+    return M
+
+
+def toric_tensor(q: float, normalized=True):
+    """Diagonal virtual tensor. normalized=True inserts the necessary 1/2."""
+    I = np.eye(2)
+    Z = np.diag([1.0, -1.0])
+    scale = 0.5 if normalized else 1.0
+    M = np.zeros((2, 2, 2, 2), dtype=complex)
+    M[0, 0] = scale * I
+    M[1, 1] = scale * q * Z
+    return M
+
+
+def verify_toric_closures():
+    """Regression tests for the virtual-index and normalization conventions."""
+    q = 0.5
+    M = toric_tensor(q)
+    Z = np.diag([1.0, -1.0])
+    for k in (1, 2, 3):
+        closures = mk_closures(M, k)
+        Zk = Z.copy()
+        for _ in range(k - 1):
+            Zk = np.kron(Zk, Z)
+        assert np.allclose(closures[0], np.eye(2**k) / 2**k)
+        assert np.allclose(closures[3], q**k * Zk / 2**k)
+        assert np.allclose(closures[1], 0) and np.allclose(closures[2], 0)
+
+
+def compact(result):
+    def one(r):
+        return {
+            "status": r["status"],
+            "min_eig": r.get("min_choi_eig"),
+            "tp_res": r.get("tp_residual"),
+            "closure_res": r.get("closure_residual"),
+        }
+    return {direction: one(result[direction]) for direction in ["forward", "reverse"]}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", default="checks/round2_p7_sdp_results.json")
+    parser.add_argument("--quick", action="store_true")
+    args = parser.parse_args()
+
+    verify_toric_closures()
+    results = {}
+    results["product_1to2"] = compact(test_pair(product_tensor(), 1, 2))
+    # The tensor printed in the derivation note lacks the normalization required
+    # by trace preservation. Keep this as a deliberate diagnostic.
+    results["toric_q1_as_printed_1to2"] = compact(test_pair(toric_tensor(1, False), 1, 2))
+    results["toric_q1_normalized_1to2"] = compact(test_pair(toric_tensor(1, True), 1, 2))
+    results["toric_q1_normalized_2to3"] = compact(test_pair(toric_tensor(1, True), 2, 3))
+
+    qs = [0.0, 0.25, 0.5, 0.75, 1.0] if args.quick else [
+        -1.0, -0.9, -0.75, -0.5, -0.25, -0.1, 0.0,
+        0.1, 0.25, 0.5, 0.75, 0.9, 1.0
+    ]
+    scan = {}
+    for q in qs:
+        entry = {"1to2": compact(test_pair(toric_tensor(q), 1, 2))}
+        entry["2to3"] = compact(test_pair(toric_tensor(q), 2, 3))
+        scan[str(q)] = entry
+        print(q, json.dumps(entry, sort_keys=True))
+    results["normalized_toric_scan"] = scan
+
+    path = Path(args.output)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(results, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/checks/round2_p7_sdp_results.json
+++ b/checks/round2_p7_sdp_results.json
@@ -1,0 +1,450 @@
+{
+  "normalized_toric_scan": {
+    "-0.1": {
+      "1to2": {
+        "forward": {
+          "closure_res": 3.659662572985667e-10,
+          "min_eig": 0.22499999974894072,
+          "status": "optimal",
+          "tp_res": 1.4638652512388717e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.30644339369735e-10,
+          "min_eig": 0.1124999988976321,
+          "status": "optimal",
+          "tp_res": 7.445154937002485e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "-0.25": {
+      "1to2": {
+        "forward": {
+          "closure_res": 3.8522802656149047e-10,
+          "min_eig": 0.1874999988220259,
+          "status": "optimal",
+          "tp_res": 1.4517520519063964e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.319471305779814e-10,
+          "min_eig": 0.09374999863979333,
+          "status": "optimal",
+          "tp_res": 7.455576822579246e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "-0.5": {
+      "1to2": {
+        "forward": {
+          "closure_res": 1.535032365107547e-09,
+          "min_eig": 0.12499999728209132,
+          "status": "optimal",
+          "tp_res": 1.4086243282918076e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.365783149029028e-10,
+          "min_eig": 0.062499998214358275,
+          "status": "optimal",
+          "tp_res": 7.49262685229013e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "-0.75": {
+      "1to2": {
+        "forward": {
+          "closure_res": 3.4319171948737903e-09,
+          "min_eig": 0.06249999575841122,
+          "status": "optimal",
+          "tp_res": 1.3372032370284614e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.442234077949863e-10,
+          "min_eig": 0.031249997800612748,
+          "status": "optimal",
+          "tp_res": 7.553787484404495e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "-0.9": {
+      "1to2": {
+        "forward": {
+          "closure_res": 4.917158930028975e-09,
+          "min_eig": 0.02499999485674987,
+          "status": "optimal",
+          "tp_res": 1.281039274658724e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 1.2060061005403355e-09,
+          "min_eig": 0.012499997560889785,
+          "status": "optimal",
+          "tp_res": 7.601710372284742e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "-1.0": {
+      "1to2": {
+        "forward": {
+          "closure_res": 8.434475173846323e-09,
+          "min_eig": -9.236316622041917e-09,
+          "status": "optimal",
+          "tp_res": 3.2073657063591554e-09
+        },
+        "reverse": {
+          "closure_res": 4.996003610813204e-16,
+          "min_eig": 1.918222716010251e-16,
+          "status": "optimal",
+          "tp_res": 3.3306690738754696e-16
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 2.226480444456058e-09,
+          "min_eig": -3.4433096153511946e-09,
+          "status": "optimal",
+          "tp_res": 9.73463332165636e-09
+        },
+        "reverse": {
+          "closure_res": 8.326672684688674e-16,
+          "min_eig": -1.579089822920977e-16,
+          "status": "optimal",
+          "tp_res": 2.1094237467877974e-15
+        }
+      }
+    },
+    "0.0": {
+      "1to2": {
+        "forward": {
+          "closure_res": 3.665336367753014e-10,
+          "min_eig": 0.25000000036653264,
+          "status": "optimal",
+          "tp_res": 1.4661345471012055e-09
+        },
+        "reverse": {
+          "closure_res": 5.551115123125783e-16,
+          "min_eig": 0.4999999999999973,
+          "status": "optimal",
+          "tp_res": 1.2212453270876722e-15
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.303998821375004e-10,
+          "min_eig": 0.12499999906959963,
+          "status": "optimal",
+          "tp_res": 7.443199279144608e-09
+        },
+        "reverse": {
+          "closure_res": 3.885780586188048e-16,
+          "min_eig": 0.24999999999999964,
+          "status": "optimal",
+          "tp_res": 1.3322676295501878e-15
+        }
+      }
+    },
+    "0.1": {
+      "1to2": {
+        "forward": {
+          "closure_res": 3.659662572985667e-10,
+          "min_eig": 0.22499999974894075,
+          "status": "optimal",
+          "tp_res": 1.4638650291942668e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.306443116141594e-10,
+          "min_eig": 0.11249999889763221,
+          "status": "optimal",
+          "tp_res": 7.445154492913275e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "0.25": {
+      "1to2": {
+        "forward": {
+          "closure_res": 3.852280230920435e-10,
+          "min_eig": 0.1874999988220259,
+          "status": "optimal",
+          "tp_res": 1.4517520519063964e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.319471028224058e-10,
+          "min_eig": 0.0937499986397936,
+          "status": "optimal",
+          "tp_res": 7.455577266668456e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "0.5": {
+      "1to2": {
+        "forward": {
+          "closure_res": 1.5350323789853348e-09,
+          "min_eig": 0.12499999728209135,
+          "status": "optimal",
+          "tp_res": 1.4086245503364125e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.365784259252052e-10,
+          "min_eig": 0.06249999821435818,
+          "status": "optimal",
+          "tp_res": 7.492627407401642e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "0.75": {
+      "1to2": {
+        "forward": {
+          "closure_res": 3.4319171948737903e-09,
+          "min_eig": 0.06249999575841116,
+          "status": "optimal",
+          "tp_res": 1.3372030149838565e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 9.44223421672774e-10,
+          "min_eig": 0.031249997800612783,
+          "status": "optimal",
+          "tp_res": 7.55378726235989e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "0.9": {
+      "1to2": {
+        "forward": {
+          "closure_res": 4.917158930028975e-09,
+          "min_eig": 0.02499999485674987,
+          "status": "optimal",
+          "tp_res": 1.281039274658724e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 1.206006058906972e-09,
+          "min_eig": 0.01249999756088973,
+          "status": "optimal",
+          "tp_res": 7.60171026126244e-09
+        },
+        "reverse": {
+          "closure_res": null,
+          "min_eig": null,
+          "status": "infeasible",
+          "tp_res": null
+        }
+      }
+    },
+    "1.0": {
+      "1to2": {
+        "forward": {
+          "closure_res": 8.434475118335172e-09,
+          "min_eig": -9.236316643345085e-09,
+          "status": "optimal",
+          "tp_res": 3.2073659284037603e-09
+        },
+        "reverse": {
+          "closure_res": 6.661338147750939e-16,
+          "min_eig": -8.621485038892221e-17,
+          "status": "optimal",
+          "tp_res": 5.551115123125783e-16
+        }
+      },
+      "2to3": {
+        "forward": {
+          "closure_res": 2.2264804999672094e-09,
+          "min_eig": -3.4433096965216436e-09,
+          "status": "optimal",
+          "tp_res": 9.734632988589453e-09
+        },
+        "reverse": {
+          "closure_res": 6.38378239159465e-16,
+          "min_eig": -5.1366975982327156e-17,
+          "status": "optimal",
+          "tp_res": 1.3322676295501878e-15
+        }
+      }
+    }
+  },
+  "product_1to2": {
+    "forward": {
+      "closure_res": 8.053914146710639e-09,
+      "min_eig": 0.05689659252401009,
+      "status": "optimal",
+      "tp_res": 9.551719193368058e-09
+    },
+    "reverse": {
+      "closure_res": 6.106226635438361e-16,
+      "min_eig": 0.20868027320151342,
+      "status": "optimal",
+      "tp_res": 1.6653345369377348e-15
+    }
+  },
+  "toric_q1_as_printed_1to2": {
+    "forward": {
+      "closure_res": null,
+      "min_eig": null,
+      "status": "infeasible",
+      "tp_res": null
+    },
+    "reverse": {
+      "closure_res": null,
+      "min_eig": null,
+      "status": "infeasible",
+      "tp_res": null
+    }
+  },
+  "toric_q1_normalized_1to2": {
+    "forward": {
+      "closure_res": 8.434475118335172e-09,
+      "min_eig": -9.236316643345085e-09,
+      "status": "optimal",
+      "tp_res": 3.2073659284037603e-09
+    },
+    "reverse": {
+      "closure_res": 6.661338147750939e-16,
+      "min_eig": -8.621485038892221e-17,
+      "status": "optimal",
+      "tp_res": 5.551115123125783e-16
+    }
+  },
+  "toric_q1_normalized_2to3": {
+    "forward": {
+      "closure_res": 2.2264804999672094e-09,
+      "min_eig": -3.4433096965216436e-09,
+      "status": "optimal",
+      "tp_res": 9.734632988589453e-09
+    },
+    "reverse": {
+      "closure_res": 6.38378239159465e-16,
+      "min_eig": -5.1366975982327156e-17,
+      "status": "optimal",
+      "tp_res": 1.3322676295501878e-15
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- preserve the Round-2 P7 static-versus-channel-RFP audit that was previously hidden by the global `notes/` ignore;
- add the CVXPY/SCS Choi-matrix feasibility checker used by the audit;
- add the complete machine-readable solver statuses and residuals for the deformed-toric scan;
- keep transient Python caches and console logs untracked.

## Validation

- `python3 checks/round2_p7_sdp.py --quick --output /tmp/round2_p7_sdp_quick.json`
- regression assertions for the product and normalized toric controls and the infeasible reverse maps at `q = 0.25, 0.5, 0.75`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds research notes, a standalone check script, and JSON artifacts only; no changes to library runtime or production paths.
> 
> **Overview**
> Adds **Round 2 P7** audit materials that were previously easy to lose under repo ignore rules: a long write-up (`Notes/OpenProblemsTN/checks/round2_p7_sdp_search.md`), a CVXPY/SCS checker (`checks/round2_p7_sdp.py`), and frozen solver output (`checks/round2_p7_sdp_results.json`).
> 
> The script encodes **input-first Choi** CPTP feasibility with closure constraints, builds MPDO closures from virtual tensors, and runs product/toric controls plus a **normalized deformed-toric** scan over `q`. It deliberately contrasts the strategy note’s unnormalized toric gauge (infeasible) with trace-normalized `M_{00}=I/2`, `M_{11}=qZ/2` (feasible at `q=1`). The report ties numerics to an **exact reverse-channel obstruction** for `0<|q|<1` and notes Fibonacci entropy tables were not computed from available data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6867609efba442d44a1aeb32b3e8e4f780101503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->