### PR TITLE
feat(Channel/Schwarz): prove support-domain Petz recovery

### DIFF
--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -98,6 +98,43 @@ theorem PosSemidef.cfc_sqrt_isHermitian {ρ : Matrix n n ℂ} (hρ : ρ.PosSemid
     · simp [Matrix.diagonal_apply_ne _ hij, Matrix.diagonal_apply_ne _ (Ne.symm hij)]
   exact Matrix.isHermitian_mul_mul_conjTranspose _ hD
 
+/-- The positive square root is absorbed on the right by the support
+projection of the original positive-semidefinite matrix. -/
+theorem PosSemidef.cfc_sqrt_mul_supportProj
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.isHermitian.cfc Real.sqrt * hρ.isHermitian.supportProj =
+      hρ.isHermitian.cfc Real.sqrt := by
+  rw [hρ.isHermitian.cfc_form Real.sqrt]
+  unfold Matrix.IsHermitian.supportProj
+  let U := (hρ.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let D := Matrix.diagonal
+    (fun i => ((Real.sqrt (hρ.isHermitian.eigenvalues i) : ℝ) : ℂ))
+  let P := Matrix.diagonal
+    (fun i => if hρ.isHermitian.eigenvalues i ≠ 0 then (1 : ℂ) else 0)
+  have hU : star U * U = 1 := by
+    exact Unitary.coe_star_mul_self hρ.isHermitian.eigenvectorUnitary
+  change (U * D * star U) * (U * P * star U) = U * D * star U
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (star U) U (P * star U), hU, Matrix.one_mul,
+    ← Matrix.mul_assoc D P (star U)]
+  congr 2
+  simp only [D, P, Matrix.diagonal_mul_diagonal]
+  congr 1
+  funext i
+  by_cases hi : hρ.isHermitian.eigenvalues i = 0
+  · simp [hi]
+  · simp [hi]
+
+/-- The positive square root is absorbed on the left by the support projection
+of the original positive-semidefinite matrix. -/
+theorem PosSemidef.supportProj_mul_cfc_sqrt
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
+    hρ.isHermitian.supportProj * hρ.isHermitian.cfc Real.sqrt =
+      hρ.isHermitian.cfc Real.sqrt := by
+  simpa only [Matrix.conjTranspose_mul, hρ.cfc_sqrt_isHermitian.eq,
+    hρ.isHermitian.supportProj_isHermitian.eq] using
+      congrArg Matrix.conjTranspose hρ.cfc_sqrt_mul_supportProj
+
 /-- The square of the Hermitian functional-calculus square root recovers the
 positive-semidefinite matrix. -/
 theorem PosSemidef.cfc_sqrt_mul_self {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :

--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -47,5 +47,6 @@ import TNLean.Channel.Schwarz.SupportSourceBDefect
 import TNLean.Channel.Schwarz.SupportSourceDefect
 import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.WeylRelativeEntropyIntegral
+import TNLean.Channel.Schwarz.WeylSupportPetzRecovery
 import TNLean.Channel.Schwarz.WeylSupportRelativeEntropyEquality
 import TNLean.Channel.Schwarz.WeylTwirl

--- a/TNLean/Channel/Schwarz/SupportRelativeModular.lean
+++ b/TNLean/Channel/Schwarz/SupportRelativeModular.lean
@@ -226,4 +226,108 @@ theorem supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq
     one_kronecker_transpose_mulVec_vec_transpose] at hsqrt
   exact Matrix.transpose_injective (Matrix.vec_inj.mp hsqrt)
 
+/-- Equality of support-projected square-root ratios gives the support Petz
+sandwich when the kernel of the reference matrix is contained in the kernel
+of the first matrix.
+
+This is the algebraic Gram-matrix step after the support functional-calculus
+conclusion of Jenčová--Ruskai, arXiv:0903.2895v4, lines 788--793. It supplies
+the sandwich entering the singular Petz formula of
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8). -/
+theorem supportRelativeModular_sandwich_eq_of_sqrt_ratio_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B C D : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (hC : C.PosSemidef) (hD : D.PosSemidef)
+    (hker : ∀ v : n → ℂ, B *ᵥ v = 0 → A *ᵥ v = 0)
+    (hratio :
+      (CFC.sqrt A * hB.supportInvSqrt) * hB.isHermitian.supportProj =
+        (CFC.sqrt C * hD.supportInvSqrt) * hB.isHermitian.supportProj) :
+    hB.isHermitian.cfc Real.sqrt *
+        (hD.supportInvSqrt * C * hD.supportInvSqrt) *
+        hB.isHermitian.cfc Real.sqrt = A := by
+  have hsqrtA : (CFC.sqrt A)ᴴ = CFC.sqrt A :=
+    (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg A)).isHermitian.eq
+  have hsqrtC : (CFC.sqrt C)ᴴ = CFC.sqrt C :=
+    (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg C)).isHermitian.eq
+  have hPstar :
+      (hB.isHermitian.supportProj)ᴴ = hB.isHermitian.supportProj :=
+    hB.isHermitian.supportProj_isHermitian.eq
+  have hgram := congrArg (fun X => Xᴴ * X) hratio
+  have hleftGram :
+      ((CFC.sqrt A * hB.supportInvSqrt) * hB.isHermitian.supportProj)ᴴ *
+          ((CFC.sqrt A * hB.supportInvSqrt) * hB.isHermitian.supportProj) =
+        hB.isHermitian.supportProj *
+          (hB.supportInvSqrt * A * hB.supportInvSqrt) *
+          hB.isHermitian.supportProj := by
+    simp only [Matrix.conjTranspose_mul, hPstar,
+      hB.supportInvSqrt_isHermitian.eq, hsqrtA, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (CFC.sqrt A) (CFC.sqrt A)
+      (hB.supportInvSqrt * hB.isHermitian.supportProj),
+      CFC.sqrt_mul_sqrt_self A hA.nonneg]
+  have hrightGram :
+      ((CFC.sqrt C * hD.supportInvSqrt) * hB.isHermitian.supportProj)ᴴ *
+          ((CFC.sqrt C * hD.supportInvSqrt) * hB.isHermitian.supportProj) =
+        hB.isHermitian.supportProj *
+          (hD.supportInvSqrt * C * hD.supportInvSqrt) *
+          hB.isHermitian.supportProj := by
+    simp only [Matrix.conjTranspose_mul, hPstar,
+      hD.supportInvSqrt_isHermitian.eq, hsqrtC, Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (CFC.sqrt C) (CFC.sqrt C)
+      (hD.supportInvSqrt * hB.isHermitian.supportProj),
+      CFC.sqrt_mul_sqrt_self C hC.nonneg]
+  have hcore :
+      hB.isHermitian.supportProj *
+          (hB.supportInvSqrt * A * hB.supportInvSqrt) *
+          hB.isHermitian.supportProj =
+        hB.isHermitian.supportProj *
+          (hD.supportInvSqrt * C * hD.supportInvSqrt) *
+          hB.isHermitian.supportProj :=
+    hleftGram.symm.trans (hgram.trans hrightGram)
+  have hAright :
+      A * hB.isHermitian.supportProj = A :=
+    hB.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
+  have hAleft :
+      hB.isHermitian.supportProj * A = A := by
+    simpa only [Matrix.conjTranspose_mul, hPstar, hA.isHermitian.eq] using
+      congrArg Matrix.conjTranspose hAright
+  have hAPA :
+      hB.isHermitian.supportProj * A * hB.isHermitian.supportProj = A := by
+    rw [hAleft, hAright]
+  calc
+    hB.isHermitian.cfc Real.sqrt *
+          (hD.supportInvSqrt * C * hD.supportInvSqrt) *
+          hB.isHermitian.cfc Real.sqrt =
+        (hB.isHermitian.cfc Real.sqrt * hB.isHermitian.supportProj) *
+          (hD.supportInvSqrt * C * hD.supportInvSqrt) *
+          (hB.isHermitian.supportProj * hB.isHermitian.cfc Real.sqrt) := by
+      rw [hB.cfc_sqrt_mul_supportProj, hB.supportProj_mul_cfc_sqrt]
+    _ = hB.isHermitian.cfc Real.sqrt *
+        (hB.isHermitian.supportProj *
+          (hD.supportInvSqrt * C * hD.supportInvSqrt) *
+          hB.isHermitian.supportProj) *
+        hB.isHermitian.cfc Real.sqrt := by
+      simp only [Matrix.mul_assoc]
+    _ = hB.isHermitian.cfc Real.sqrt *
+        (hB.isHermitian.supportProj *
+          (hB.supportInvSqrt * A * hB.supportInvSqrt) *
+          hB.isHermitian.supportProj) *
+        hB.isHermitian.cfc Real.sqrt := by
+      rw [hcore]
+    _ = (hB.isHermitian.cfc Real.sqrt *
+          hB.isHermitian.supportProj * hB.supportInvSqrt) *
+        A *
+        (hB.supportInvSqrt * hB.isHermitian.supportProj *
+          hB.isHermitian.cfc Real.sqrt) := by
+      simp only [Matrix.mul_assoc]
+    _ = hB.isHermitian.supportProj * A * hB.isHermitian.supportProj := by
+      rw [Matrix.mul_assoc hB.supportInvSqrt hB.isHermitian.supportProj
+          (hB.isHermitian.cfc Real.sqrt),
+        hB.supportProj_mul_cfc_sqrt, hB.cfc_sqrt_mul_supportProj,
+        hB.cfc_sqrt_mul_supportInvSqrt,
+        hB.supportInvSqrt_mul_cfc_sqrt]
+      congr
+    _ = A := hAPA
+
 end Matrix

--- a/TNLean/Channel/Schwarz/WeylSupportPetzRecovery.lean
+++ b/TNLean/Channel/Schwarz/WeylSupportPetzRecovery.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Schwarz.SupportRelativeModular
+import TNLean.Channel.Schwarz.WeylSupportRelativeEntropyEquality
+
+/-!
+# Petz recovery from support-relative Weyl equality
+
+This file derives the support-domain square-root ratio, support sandwich, and
+raw Petz recovery identity from saturation of relative entropy under a right
+partial trace.
+
+## Main results
+
+* `Matrix.weyl_support_sqrt_ratio_eq_of_partialTraceRight_eq` identifies the
+  square-root ratios on the support of the reference matrix.
+* `Matrix.weyl_support_identity_sandwich_of_partialTraceRight_eq` proves the
+  support Petz sandwich.
+* `Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq` proves raw
+  recovery by the partial-trace Petz map.
+
+## References
+
+* A. Jenčová and M. B. Ruskai, arXiv:0903.2895v4, lines 788--793.
+* P. Hayden, R. Jozsa, D. Petz, and A. Winter,
+  arXiv:quant-ph/0304007v2, Theorem 3 and equation (8).
+
+This analytic recovery step precedes the separate direct-sum structure invoked
+in CPSV16, Lemma `Lsigma3`; CPSV16 does not present the Weyl/resolvent argument.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+/-- Saturation under the right partial trace identifies the square-root ratio
+of the original pair with that of its maximally mixed extension on the support
+of the reference matrix.
+
+The support projection is essential: Jenčová--Ruskai,
+arXiv:0903.2895v4, lines 788--793, pass from the common relative-modular
+resolvent to the square root only on the complement of the kernel. This is the
+analytic square-root step toward the Petz identity in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8). -/
+theorem weyl_support_sqrt_ratio_eq_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
+    let barρ := partialTraceRight ρ ⊗ₖ
+      ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+    let barσ := partialTraceRight σ ⊗ₖ
+      ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+    let hbarσ : barσ.PosSemidef := hσ.partialTraceRight.kronecker
+      maximallyMixed_posDef.posSemidef
+    (CFC.sqrt ρ * hσ.supportInvSqrt) * hσ.isHermitian.supportProj =
+      (CFC.sqrt barρ * hbarσ.supportInvSqrt) *
+        hσ.isHermitian.supportProj := by
+  classical
+  let barρ := partialTraceRight ρ ⊗ₖ
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+  let barσ := partialTraceRight σ ⊗ₖ
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+  have hbarρ : barρ.PosSemidef :=
+    hρ.partialTraceRight.kronecker maximallyMixed_posDef.posSemidef
+  have hbarσ : barσ.PosSemidef :=
+    hσ.partialTraceRight.kronecker maximallyMixed_posDef.posSemidef
+  change (CFC.sqrt ρ * hσ.supportInvSqrt) * hσ.isHermitian.supportProj =
+    (CFC.sqrt barρ * hbarσ.supportInvSqrt) * hσ.isHermitian.supportProj
+  obtain ⟨ζ, hζ⟩ : ∃ ζ : ℂ, IsPrimitiveRoot ζ dC :=
+    ⟨_, Complex.isPrimitiveRoot_exp dC (NeZero.ne dC)⟩
+  have hres : ∀ {t : ℝ}, 0 < t →
+      ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ
+          hσ.isHermitian.supportProjᵀ) *ᵥ
+          ((t • (1 : Matrix
+              ((Fin dS × ZMod dC) × (Fin dS × ZMod dC))
+              ((Fin dS × ZMod dC) × (Fin dS × ZMod dC)) ℂ) +
+            ρ ⊗ₖ (hσ.supportInvSqrt * hσ.supportInvSqrt)ᵀ)⁻¹ *ᵥ
+              Matrix.vec
+                (1 : Matrix (Fin dS × ZMod dC)
+                  (Fin dS × ZMod dC) ℂ)ᵀ) =
+        ((1 : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) ⊗ₖ
+          hσ.isHermitian.supportProjᵀ) *ᵥ
+          ((t • (1 : Matrix
+              ((Fin dS × ZMod dC) × (Fin dS × ZMod dC))
+              ((Fin dS × ZMod dC) × (Fin dS × ZMod dC)) ℂ) +
+            unweightedWeylSum ζ ρ ⊗ₖ
+              ((hσ.unweightedWeylSum ζ).supportInvSqrt *
+                (hσ.unweightedWeylSum ζ).supportInvSqrt)ᵀ)⁻¹ *ᵥ
+              Matrix.vec
+                (1 : Matrix (Fin dS × ZMod dC)
+                  (Fin dS × ZMod dC) ℂ)ᵀ) := by
+    intro t ht
+    have hraw :=
+      weyl_supportRelativeModular_resolvent_mulVec_eq_of_partialTraceRight_eq
+        hρ hσ hsupp heq hζ ht (0, 0)
+    convert hraw using 1 <;>
+      simp only [unweightedWeylConjugate_zero_zero, PosSemidef.supportInv] <;>
+      congr
+    all_goals exact (unweightedWeylConjugate_zero_zero ζ σ).symm
+  have hratio :=
+    supportRelativeModular_sqrt_ratio_eq_of_resolvent_mulVec_eq
+      hρ hσ (hρ.unweightedWeylSum ζ) (hσ.unweightedWeylSum ζ) hres
+  have hc : 0 < ((dC : ℝ) ^ 2) := by
+    have hdC : (0 : ℝ) < dC := by
+      exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+    positivity
+  have hratioScaled :
+      (CFC.sqrt ρ * hσ.supportInvSqrt) * hσ.isHermitian.supportProj =
+        (CFC.sqrt (((dC : ℝ) ^ 2) • barρ) *
+            (hbarσ.smul hc.le).supportInvSqrt) *
+          hσ.isHermitian.supportProj := by
+    convert hratio using 1
+    all_goals rw [unweightedWeylSum_eq_smul_partialTraceRight_kronecker hζ]
+    all_goals congr
+    exact (unweightedWeylSum_eq_smul_partialTraceRight_kronecker hζ σ).symm
+  rw [hbarρ.sqrt_smul hc.le, hbarσ.supportInvSqrt_smul hc] at hratioScaled
+  have hsqrtc : Real.sqrt ((dC : ℝ) ^ 2) ≠ 0 :=
+    Real.sqrt_ne_zero'.mpr hc
+  simpa only [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+    inv_mul_cancel₀ hsqrtc, one_smul] using hratioScaled
+
+/-- Saturation under the right partial trace gives the identity-Weyl support
+Petz sandwich.
+
+The projected square-root ratio is converted to a Gram-matrix identity on the
+support of `σ`, then the kernel inclusion absorbs `ρ` on both sides. This is
+the algebraic Gram step after the support functional-calculus conclusion of
+Jenčová--Ruskai, arXiv:0903.2895v4, lines 788--793. It supplies the sandwich
+entering Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
+equation (8). -/
+theorem weyl_support_identity_sandwich_of_partialTraceRight_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
+    let hbarσ := hσ.partialTraceRight.kronecker
+      maximallyMixed_posDef.posSemidef
+    hσ.isHermitian.cfc Real.sqrt *
+        (hbarσ.supportInvSqrt *
+          (partialTraceRight ρ ⊗ₖ
+            ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) *
+          hbarσ.supportInvSqrt) *
+        hσ.isHermitian.cfc Real.sqrt = ρ := by
+  let barρ := partialTraceRight ρ ⊗ₖ
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+  let barσ := partialTraceRight σ ⊗ₖ
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))
+  have hbarρ : barρ.PosSemidef :=
+    hρ.partialTraceRight.kronecker maximallyMixed_posDef.posSemidef
+  have hbarσ : barσ.PosSemidef :=
+    hσ.partialTraceRight.kronecker maximallyMixed_posDef.posSemidef
+  change hσ.isHermitian.cfc Real.sqrt *
+      (hbarσ.supportInvSqrt * barρ * hbarσ.supportInvSqrt) *
+      hσ.isHermitian.cfc Real.sqrt = ρ
+  apply supportRelativeModular_sandwich_eq_of_sqrt_ratio_eq
+    hρ hσ hbarρ hbarσ hsupp
+  exact weyl_support_sqrt_ratio_eq_of_partialTraceRight_eq hρ hσ hsupp heq
+
+/-- Equality in right-partial-trace data processing on the finite-relative-
+entropy support domain implies recovery by the raw partial-trace Petz map.
+
+This is the raw support-map identity entering the Weyl-coordinate
+support-domain recovery implication of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3, equation (8). It is an analytic input
+preceding, not the direct-sum decomposition of, CPSV16, Lemma `Lsigma3`. -/
+theorem partialTraceRightPetzMap_eq_of_relativeEntropy_eq
+    {dS dC : ℕ} [NeZero dC]
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
+    partialTraceRightPetzMap σ hσ (partialTraceRight ρ) = ρ := by
+  apply partialTraceRightPetzMap_eq_of_weyl_identity_sandwich hσ
+  exact weyl_support_identity_sandwich_of_partialTraceRight_eq
+    hρ hσ hsupp heq
+
+end Matrix

--- a/TNLean/Channel/Schwarz/WeylSupportPetzRecovery.lean
+++ b/TNLean/Channel/Schwarz/WeylSupportPetzRecovery.lean
@@ -42,9 +42,10 @@ of the original pair with that of its maximally mixed extension on the support
 of the reference matrix.
 
 The support projection is essential: Jenčová--Ruskai,
-arXiv:0903.2895v4, lines 788--793, pass from the common relative-modular
-resolvent to the square root only on the complement of the kernel. This is the
-analytic square-root step toward the Petz identity in
+arXiv:0903.2895v4, lines 788--793, obtain the common relative-modular
+resolvent only on the complement of the kernel and pass through functional
+calculus; here this is specialized to the square root. This is the analytic
+square-root step toward the Petz identity in
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3,
 equation (8). -/
 theorem weyl_support_sqrt_ratio_eq_of_partialTraceRight_eq

--- a/TNLean/Channel/Schwarz/WeylSupportRelativeEntropyEquality.lean
+++ b/TNLean/Channel/Schwarz/WeylSupportRelativeEntropyEquality.lean
@@ -54,6 +54,47 @@ noncomputable def unweightedWeylSum
     Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ :=
   ∑ g, unweightedWeylConjugate ζ M g
 
+/-- The unweighted finite Weyl sum is `dC ^ 2` times the partial trace tensored
+with the maximally mixed ancilla. -/
+theorem unweightedWeylSum_eq_smul_partialTraceRight_kronecker
+    {dS dC : ℕ} [NeZero dC] {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    (M : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :
+    unweightedWeylSum ζ M =
+      ((dC : ℝ) ^ 2) •
+        (partialTraceRight M ⊗ₖ
+          ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) := by
+  classical
+  have hsum :
+      unweightedWeylSum ζ M =
+        ∑ a : ZMod dC, ∑ b : ZMod dC,
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * M *
+            ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ := by
+    simp only [unweightedWeylSum, unweightedWeylConjugate,
+      ← Finset.univ_product_univ, Finset.sum_product]
+  rw [hsum]
+  have htwirl := sum_kronecker_one_weyl_conj (S := Fin dS) hζ M
+  have hdC : ((dC : ℂ) ^ 2) ≠ 0 := by
+    exact pow_ne_zero 2 (by exact_mod_cast NeZero.ne dC)
+  calc
+    (∑ a : ZMod dC, ∑ b : ZMod dC,
+        ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * M *
+          ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ) =
+        ((dC : ℂ) ^ 2) •
+          (((dC : ℂ) ^ 2)⁻¹ •
+            ∑ a : ZMod dC, ∑ b : ZMod dC,
+              ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * M *
+                ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ) := by
+      rw [smul_smul, mul_inv_cancel₀ hdC, one_smul]
+    _ = ((dC : ℂ) ^ 2) •
+        (partialTraceRight M ⊗ₖ
+          ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) := by
+      rw [htwirl]
+    _ = ((dC : ℝ) ^ 2) •
+        (partialTraceRight M ⊗ₖ
+          ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ))) := by
+      ext i j
+      norm_num
+
 /-- Positive semidefiniteness is preserved by an unweighted Weyl conjugation. -/
 theorem PosSemidef.unweightedWeylConjugate
     {dS dC : ℕ} [NeZero dC]

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -547,6 +547,28 @@
     applied to this finite family gives the displayed projected resolvent.
 \end{proof}
 
+\begin{lemma}[Unweighted finite-Weyl sum normalization]
+    \label{lem:unweighted_weyl_sum_normalization}
+    \lean{Matrix.unweightedWeylSum_eq_smul_partialTraceRight_kronecker}
+    \leanok
+    \uses{lem:twirl_partial_trace}
+    Let $X$ be a matrix on
+    $\mathcal H_S\otimes\mathbb C^{d_C}$ and let
+    $U_g=\mathbf 1\otimes W_g$ for the $d_C^2$ Weyl indices. Then
+    \begin{align}
+        \sum_g U_g XU_g^\dagger
+        &=
+        d_C^2\bigl((\tr_CX)\otimes d_C^{-1}\mathbf 1_C\bigr).
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    The uniform Weyl twirl is
+    $(\tr_CX)\otimes d_C^{-1}\mathbf 1_C$. Multiplying its defining identity
+    by $d_C^2$ gives the unweighted sum.
+\end{proof}
+
 \begin{lemma}[Support relative-modular square-root evaluation]
     \label{lem:support_relative_modular_sqrt_evaluation}
     \lean{Matrix.supportRelativeModular_sqrt_mulVec_vec_one}
@@ -773,6 +795,90 @@
     \end{align}
     The support Petz formula therefore identifies the left-hand side of the
     assumed sandwich identity with $\mathcal R_\sigma(\tr_C\rho)$.
+\end{proof}
+
+\begin{theorem}[Support-domain Petz recovery]
+    \label{thm:partial_trace_saturation_support_petz_recovery}
+    \lean{Matrix.supportRelativeModular_sandwich_eq_of_sqrt_ratio_eq}
+    \lean{Matrix.weyl_support_sqrt_ratio_eq_of_partialTraceRight_eq}
+    \lean{Matrix.weyl_support_identity_sandwich_of_partialTraceRight_eq}
+    \lean{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq}
+    \leanok
+    In the finite Weyl coordinates
+    $\mathbb C^{d_S}\otimes\mathbb C^{\mathbb Z/d_C\mathbb Z}$, let
+    $\rho$ and $\sigma$ be positive semidefinite matrices satisfying
+    $\ker\sigma\subseteq\ker\rho$, and suppose that
+    \begin{align}
+        D(\rho\Vert\sigma)
+        &=D(\tr_C\rho\Vert\tr_C\sigma).
+        \notag
+    \end{align}
+    Put
+    \begin{align}
+        \overline\rho
+        &=(\tr_C\rho)\otimes d_C^{-1}\mathbf 1_C,
+        &
+        \overline\sigma
+        &=(\tr_C\sigma)\otimes d_C^{-1}\mathbf 1_C.
+        \notag
+    \end{align}
+    If $P_\sigma$ is the orthogonal projection onto
+    $(\ker\sigma)^\perp$, then
+    \begin{align}
+        \bigl(\sqrt\rho\,\sigma^{-1/2}_{\mathrm{supp}}\bigr)P_\sigma
+        &=
+        \bigl(\sqrt{\overline\rho}\,
+          \overline\sigma^{-1/2}_{\mathrm{supp}}\bigr)P_\sigma,
+        \notag\\
+        \sqrt\sigma\,\overline\sigma^{-1/2}_{\mathrm{supp}}
+          \overline\rho\,\overline\sigma^{-1/2}_{\mathrm{supp}}
+          \sqrt\sigma
+        &=\rho.
+        \notag
+    \end{align}
+    Consequently,
+    $\mathcal R_\sigma(\tr_C\rho)=\rho$ for the raw support Petz map.
+    The projected relative-modular argument follows
+    Jen\v{c}ov\'a--Ruskai, arXiv:0903.2895v4, lines~766--793, and the
+    recovery formula is
+    \cite[Theorem~3, equation~(8)]{Hayden2004Structure}.
+    This result does not assert the middle-space direct-sum decomposition in
+    \cite[Lemma~\textup{Lsigma3}, lines~1351--1363]
+      {Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:partial_trace_saturation_common_projected_weyl_resolvent,
+        lem:unweighted_weyl_sum_normalization,
+        lem:support_relative_modular_sqrt_ratio,
+        thm:support_inverse_square_root_tensor_product,
+        thm:support_projection_absorption_kernel_inclusion,
+        thm:weyl_identity_sandwich_petz_recovery}
+    Use the zero Weyl index in
+    Theorem~\ref{thm:partial_trace_saturation_common_projected_weyl_resolvent}.
+    Lemma~\ref{lem:support_relative_modular_sqrt_ratio} gives the projected
+    square-root ratio for $(\rho,\sigma)$ and the unweighted Weyl sums.
+    Lemma~\ref{lem:unweighted_weyl_sum_normalization} identifies those sums
+    with $d_C^2\overline\rho$ and $d_C^2\overline\sigma$. The factors
+    $\sqrt{d_C^2}$ and $(\sqrt{d_C^2})^{-1}$ cancel, giving the first displayed
+    equality.
+
+    Taking the adjoint product of that equality gives
+    \begin{align}
+        P_\sigma\sigma^{-1/2}_{\mathrm{supp}}\rho
+          \sigma^{-1/2}_{\mathrm{supp}}P_\sigma
+        &=
+        P_\sigma\overline\sigma^{-1/2}_{\mathrm{supp}}
+          \overline\rho\,
+          \overline\sigma^{-1/2}_{\mathrm{supp}}P_\sigma.
+        \notag
+    \end{align}
+    The support projection absorbs $\sqrt\sigma$ on both sides, while
+    $\ker\sigma\subseteq\ker\rho$ gives
+    $P_\sigma\rho P_\sigma=\rho$. Multiplying the last equality by
+    $\sqrt\sigma$ on the left and right therefore yields the support sandwich.
+    Theorem~\ref{thm:weyl_identity_sandwich_petz_recovery} gives the raw Petz
+    recovery identity.
 \end{proof}
 
 \begin{theorem}[Relative entropy against the product of the marginals]

--- a/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_von_neumann_and_relative_ii.tex
@@ -138,6 +138,8 @@
     \lean{Matrix.PosSemidef.supportInvSqrt_kronecker}
     \lean{Matrix.PosSemidef.cfc_sqrt_mul_supportInvSqrt}
     \lean{Matrix.PosSemidef.supportInvSqrt_mul_cfc_sqrt}
+    \lean{Matrix.PosSemidef.cfc_sqrt_mul_supportProj}
+    \lean{Matrix.PosSemidef.supportProj_mul_cfc_sqrt}
     \lean{Matrix.PosSemidef.supportProj_kronecker}
     \lean{Matrix.PosDef.supportProj_eq_one}
     \leanok
@@ -161,6 +163,11 @@
         =A^{-1/2}_{\mathrm{supp}}\sqrt A
         &=P_A.
         \label{eq:entropy_support_sqrt_cancellation}
+    \end{align}
+    The same support projection absorbs the square root:
+    \begin{align}
+        \sqrt A\,P_A=P_A\sqrt A&=\sqrt A.
+        \notag
     \end{align}
     If $A$ is positive definite, then $P_A=\mathbf 1$.
 \end{theorem}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -62,10 +62,11 @@ density operators, and the block-diagonal equality.} The forward direction is an
 external stand-in: that implication is a theorem of Ruskai, of
 Hayden--Jozsa--Petz--Winter, and of Hayashi, but its proof rests on the full
 singular-support saturation-to-recovery theorem and the structural analysis of
-recovered states.  Positive-definite saturation-to-recovery and the
-trace-preserving extension of the support Petz map are now available; the
-singular-support extension and structural step are not.  The reverse direction
-is proved from the entropy-additivity sub-lemmas listed below.
+recovered states.  The singular-support saturation-to-raw-recovery implication,
+its positive-definite specialization, and the trace-preserving extension of the
+support Petz map are now available.  The family-level structural step remains
+open.  The reverse direction is proved from the entropy-additivity sub-lemmas
+listed below.
 
 \section{The point at issue: only the forward direction is consumed}
 
@@ -79,12 +80,12 @@ downstream. Its proof is the deep part of the characterization: it requires
 recovery-map theory and the Petz transpose channel, that is, the analysis of
 when the data-processing inequality for relative entropy is saturated and the
 reconstruction of the discarded subsystem from a recovery map. This recovery-map
-argument still lacks the singular-support extension of saturation-to-recovery
-and the subsequent structural analysis, which is why the forward direction is
-treated as an external assumption rather than proved.  The positive-definite
-recovery implication and
-the complementary trace-preserving extension of the support Petz map have now
-been supplied and are no longer part of this gap.
+argument now includes the singular-support saturation-to-raw-recovery
+implication.  The subsequent family-level invariant-state and direct-sum
+analysis is still missing, which is why the forward direction is treated as an
+external assumption rather than proved.  The recovery implication and the
+complementary trace-preserving extension of the support Petz map are no longer
+part of this gap.
 
 \paragraph{Reverse direction (tractable, currently unused).}
 The implication \eqref{eq:qmc} $\Rightarrow$~\eqref{eq:ssa-eq} --- a state of the
@@ -153,8 +154,8 @@ The reverse half uses the following entropy-additivity sub-lemmas, all proved in
 
 With these five facts the reverse implication is a finite computation, now
 carried out in \path{TNLean/Analysis/EntropyMarkovReverse.lean}; the
-forward implication remains an external assumption until the singular-support
-recovery extension and the structural analysis are available.
+forward implication remains an external assumption until the family-level
+structural analysis is available.
 
 \section{Trace-preserving Petz channel now available}
 
@@ -368,10 +369,10 @@ L\"owner integral representation of the power $p=1/2$.
 \leanid{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq_posDef} in
 \path{TNLean/Channel/Schwarz/WeylRelativeEntropyIntegral.lean}.}
 Thus equality under the partial trace implies raw Petz recovery for positive
-definite inputs.  The remaining analytic work is the extension of this passage
-to singular supports.
+definite inputs.  The support-domain argument below extends this passage to
+singular supports.
 
-One part of that extension is now available.  Jen\v{c}ov\'a--Ruskai extend the
+Jen\v{c}ov\'a--Ruskai extend the
 definition and convexity argument directly to positive semidefinite pairs with
 $\ker B\subseteq\ker A$; see arXiv:0903.2895v4, lines 717--720.  Their singular
 equality argument then obtains the common relative-modular resolvent on the
@@ -546,9 +547,16 @@ finite-family common projected resolvent theorem.  The kernel inclusion used
 for the unprojected source-$A$ inequality remains an exact hypothesis of this
 source-facing equality theorem.  The finite-Weyl specialization now supplies
 the projected resolvent hypothesis for the support functional-calculus step.
-What remains is to carry its conclusion through the singular Weyl
-inverse-square-root sandwich and Petz-recovery argument.  Thus the singular
-Petz recovery identity is still unformalized.
+The zero Weyl summand, the unweighted-sum normalization, and the projected
+square-root-ratio theorem now carry this conclusion through the singular
+inverse-square-root sandwich and raw Petz-recovery argument.
+\footnote{Formal declarations:
+\leanid{Matrix.unweightedWeylSum_eq_smul_partialTraceRight_kronecker} in
+\path{TNLean/Channel/Schwarz/WeylSupportRelativeEntropyEquality.lean};
+\leanid{Matrix.weyl_support_sqrt_ratio_eq_of_partialTraceRight_eq},
+\leanid{Matrix.weyl_support_identity_sandwich_of_partialTraceRight_eq}, and
+\leanid{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq} in
+\path{TNLean/Channel/Schwarz/WeylSupportPetzRecovery.lean}.}
 
 In particular, the affine regularizations used to prove the inequality cannot
 by themselves prove its equality case.  Equality at the limiting pair implies
@@ -590,43 +598,46 @@ of \cite[Theorem~3, equation~(8)]{HaydenJozsaPetzWinter2004}.
 \leanid{Matrix.partialTraceRightPetzMap_eq_of_weyl_identity_sandwich} in
 \path{TNLean/Channel/Schwarz/PetzEqualityPrerequisites.lean}.}
 The algebraic implication itself is conditional on the displayed operator
-identity.  The positive-definite finite-Weyl argument above now supplies that
-identity from equality of relative entropy under the partial trace.  No claim
-is made here for an arbitrary convex ensemble or for singular inputs.
+identity.  The finite-Weyl argument now supplies that identity from equality
+of relative entropy under the partial trace for positive-semidefinite inputs
+satisfying $\ker\sigma\subseteq\ker\rho$.  No claim is made here for an
+arbitrary convex ensemble.
 
-The exact remaining analytic implication is the singular-support equality case
-of data processing:
+The singular-support equality case of data processing is now formalized in
+finite Weyl coordinates:
 \begin{align}
   D(\rho\Vert\sigma)
     =D(\operatorname{tr}_R\rho\Vert\operatorname{tr}_R\sigma)
   \quad\Longrightarrow\quad
   \mathcal R_\sigma(\operatorname{tr}_R\rho)=\rho.
 \end{align}
-This is the forward implication of
-\cite[Theorem~3]{HaydenJozsaPetzWinter2004}.  The present proof of data
-processing establishes the inequality by regularization, unitary averaging,
-and joint convexity.  On singular supports its equality analysis now reaches
-the common projected Weyl resolvent.  What remains is the support
-inverse-square-root sandwich and raw Petz recovery.
-After this analytic implication, the proof of the block decomposition still
-requires the invariant-state decomposition used in
+This is the raw support-map identity entering the forward implication of
+\cite[Theorem~3]{HaydenJozsaPetzWinter2004}.  The proof does not infer
+equality for positive affine regularizations.  Instead, the
+support-restricted finite-family equality theorem gives the common projected
+Weyl resolvent; the support functional calculus gives the projected
+square-root ratio; and the kernel inclusion reduces its Gram identity to the
+displayed Petz sandwich.
+
+The proof of the block decomposition still requires the invariant-state
+decomposition used in
 \cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the
-Koashi--Imoto structural step.  Both steps remain necessary before the forward
-external assumption can be removed.
+Koashi--Imoto structural step.  This structural step remains necessary before
+the forward external assumption can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-singular-support recovery theorem and the structural analysis of recovered
-states; positive-definite recovery and the trace-preserving Petz channel are
-now available.  The forward direction alone is postulated. The reverse
-direction, a block-diagonal product state attains equality, is proved from
-entropy additivity over weighted direct sums and tensor factors together with
-unitary and reindexing invariance.
-Until those remaining steps are formalized, the forward direction remains the
-irreducible unproved content of this characterization.
+family-level structural analysis of recovered states.  Singular-support raw
+recovery, positive-definite recovery, and the trace-preserving Petz channel are
+available.  The forward direction alone is postulated. The reverse direction,
+a block-diagonal product state attains equality, is proved from entropy
+additivity over weighted direct sums and tensor factors together with unitary
+and reindexing invariance.  Until the structural step is formalized, the
+forward direction remains the irreducible unproved content of this
+characterization.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -125,8 +125,8 @@ sum
 \end{align}
 and describe the action of the middle-system channel on every summand so that
 the full family has the quantum-Markov form. The singular-support
-equality-to-recovery theorem remains a separate analytic obligation. Beyond
-it, this family-level invariant-state and channel-action
+equality-to-raw-recovery implication is now formalized by the projected
+finite-Weyl argument. The family-level invariant-state and channel-action
 theorem is the remaining structural obstruction to replacing the forward
 Hayashi strong-subadditivity equality assumption used in the CPSV16 argument.
 
@@ -173,9 +173,8 @@ reduction itself; the finite realization $A_0=A_{F_1}\cap\dots\cap A_{F_M}$
 or the single witness $F_0$ with $A_0=A_{F_0}$ (lines 844--847); the
 associated tensor-product state decomposition
 $\rho_k=\bigoplus_j q_{j|k}\rho_{j|k}\otimes\omega_j$; the middle-system
-block channel action on the summands; the singular-support
-equality-to-recovery theorem of the section above; or elimination of the
-Hayashi strong-subadditivity forward-implication axiom. These remain the open
+block channel action on the summands; or elimination of the Hayashi
+strong-subadditivity forward-implication axiom. These remain the open
 structural obstructions identified in the previous section.
 
 \section{Classification}
@@ -189,10 +188,10 @@ Heisenberg-picture star-subalgebra $A_0$ of a finite family of jointly
 invariant states, its membership characterization, and its generic block form
 are formalized under an explicit full-support hypothesis on the common
 average, in place of HJPW's joint-support reduction. Singular-support
-equality-to-recovery, the joint-support reduction itself, the finite
-realization of $A_0$ by a single witness $F_0$, the family-level tensor-product
-state decomposition, and the Koashi--Imoto channel-action theorem all remain
-open as separate later steps.
+equality-to-raw-recovery is formalized by the finite-Weyl support argument. The
+joint-support reduction itself, the finite realization of $A_0$ by a single
+witness $F_0$, the family-level tensor-product state decomposition, and the
+Koashi--Imoto channel-action theorem remain open as separate later steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Closes LionSR/QICLean#243.

## What changed

- prove that the positive square root is absorbed by its support projection;
- turn equality of support-projected square-root ratios into the singular-support Petz sandwich;
- normalize the unweighted finite Weyl sum against the right partial trace and maximally mixed ancillary factor;
- derive raw right-partial-trace Petz recovery from equality in relative-entropy data processing on the finite-Weyl support domain;
- synchronize the Blueprint and the two paper-gap documents with the newly completed analytic step.

## Source and scope

The projected functional-calculus passage follows Jenčová--Ruskai, arXiv:0903.2895v4, lines 766--793. The resulting raw support-map identity is the Petz formula entering Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3, equation (8).

This PR deliberately stops at the analytic endpoint used before CPSV16 Lemma `Lsigma3` (lines 1351--1363). It does **not** claim the family-level invariant-state/direct-sum decomposition. It also does not add the arbitrary-`Fintype` coordinate wrapper or a completed trace-preserving recovery channel; those remain follow-up work in LionSR/TNLean#4228. The later structural work remains tracked separately by LionSR/TNLean#4961 and LionSR/TNLean#4962.

Gap records updated here:

- `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`
- `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`

## Validation

- `lake build TNLean.Channel.Schwarz.WeylSupportPetzRecovery`
- full `lake build` (9,776 jobs; only the pre-existing `SectorMatch.lean:600` warning)
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- rendered PDF visual inspection of the new support identities, Weyl normalization, and recovery theorem pages
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check origin/main`
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in the changed Lean files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, correctness-sensitive formal proofs in relative-entropy and Petz-recovery theory; impact is confined to the Lean library and gap documentation, not runtime services.
> 
> **Overview**
> Closes the **singular-support analytic gap** before Koashi–Imoto structural work: equality \(D(\rho\Vert\sigma)=D(\mathrm{tr}_C\rho\Vert\mathrm{tr}_C\sigma)\) with \(\ker\sigma\subseteq\ker\rho\) now yields **raw** `partialTraceRightPetzMap` recovery in finite Weyl coordinates.
> 
> **New Lean infrastructure:** support projections absorb functional-calculus square roots (`PosSemidef.cfc_sqrt_mul_supportProj` / `supportProj_mul_cfc_sqrt`); projected square-root ratio equality implies the support Petz sandwich (`supportRelativeModular_sandwich_eq_of_sqrt_ratio_eq`); unweighted Weyl sums match \(d_C^2\) times partial trace ⊗ maximally mixed ancilla (`unweightedWeylSum_eq_smul_partialTraceRight_kronecker`); `WeylSupportPetzRecovery.lean` chains projected resolvents → square-root ratio → sandwich → `partialTraceRightPetzMap_eq_of_relativeEntropy_eq`.
> 
> **Docs:** blueprint gains the normalization lemma and **Support-domain Petz recovery** theorem; `cpsv16_ssa_equality_hayashi_markov.tex` and `hjpw04_petz_factorization_maximally_mixed_scope.tex` mark singular raw recovery as done and leave **family-level** direct-sum / channel structure as the remaining forward-implication obstruction (not CPSV16 Lemma `Lsigma3`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42cdc63c30bccd31f9eabe541cbdb34f4d6a095c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->