### PR TITLE
feat(Channel/Schwarz): recover Petz channel from DPI equality

### DIFF
--- a/TNLean/Analysis/CfcKronecker.lean
+++ b/TNLean/Analysis/CfcKronecker.lean
@@ -60,6 +60,20 @@ noncomputable def leftKroneckerEmbed :
 @[simp] theorem leftKroneckerEmbed_apply (A : Matrix m m ℂ) :
     leftKroneckerEmbed (n := n) A = A ⊗ₖ (1 : Matrix n n ℂ) := rfl
 
+/-- The left tensor embedding commutes with equivalence reindexing of both
+tensor factors. -/
+theorem leftKroneckerEmbed_submatrix_prod_equiv
+    {m' n' : Type*} [Fintype m'] [DecidableEq m']
+    [Fintype n'] [DecidableEq n']
+    (em : m ≃ m') (en : n ≃ n') (A : Matrix m m ℂ) :
+    leftKroneckerEmbed (n := n') (A.submatrix em.symm em.symm) =
+      (leftKroneckerEmbed (n := n) A).submatrix
+        (em.prodCongr en).symm (em.prodCongr en).symm := by
+  simpa only [leftKroneckerEmbed_apply, Matrix.submatrix_one_equiv,
+    Equiv.prodCongr_symm, Equiv.prodCongr_apply] using
+    Matrix.kroneckerMap_submatrix_submatrix (fun x y : ℂ ↦ x * y)
+      A (1 : Matrix n n ℂ) em.symm em.symm en.symm en.symm
+
 /-- The unital right tensor embedding $B \mapsto \mathbf 1 \otimes B$ as a star
 algebra homomorphism of complex matrix algebras. -/
 noncomputable def rightKroneckerEmbed :

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -160,6 +160,18 @@ noncomputable def PosSemidef.supportInvSqrt {ρ : Matrix n n ℂ}
     (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
   hρ.isHermitian.cfc fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
 
+/-- The support inverse square root commutes with reindexing by an
+equivalence. -/
+theorem PosSemidef.supportInvSqrt_submatrix_equiv
+    {m : Type*} [Fintype m] [DecidableEq m]
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (e : n ≃ m) :
+    (hρ.submatrix e.symm).supportInvSqrt =
+      hρ.supportInvSqrt.submatrix e.symm e.symm := by
+  rw [PosSemidef.supportInvSqrt, PosSemidef.supportInvSqrt,
+    ← (hρ.submatrix e.symm).isHermitian.cfc_eq, ← hρ.isHermitian.cfc_eq]
+  exact cfc_submatrix_equiv hρ.isHermitian
+    (fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) e
+
 /-- The generalized inverse of a positive-semidefinite matrix on its support:
 the zero eigenspace is sent to zero and every positive eigenvalue \(x\) is sent
 to \(x^{-1}\).

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -427,6 +427,21 @@ theorem partialTraceRight_submatrix_right {α β β' : Type*} [Fintype β] [Fint
   simp only [partialTraceRight_apply, Matrix.submatrix_apply, Prod.map_apply, id_eq]
   exact (g.sum_comp (fun k => Z (i, k) (j, k))).symm
 
+/-- The right partial trace commutes with simultaneous equivalence reindexing
+of both factors. -/
+theorem partialTraceRight_submatrix_prod_equiv
+    {α α' β β' : Type*} [Fintype β] [Fintype β']
+    (eα : α ≃ α') (eβ : β ≃ β')
+    (Z : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight
+        (Z.submatrix (eα.prodCongr eβ).symm (eα.prodCongr eβ).symm) =
+      (partialTraceRight Z).submatrix eα.symm eα.symm := by
+  rw [partialTraceRight_submatrix_left eα.symm Z,
+    partialTraceRight_submatrix_right eβ.symm
+      (Z.submatrix (Prod.map eα.symm id) (Prod.map eα.symm id)),
+    Matrix.submatrix_submatrix]
+  congr 1
+
 /-- **Partial trace over the first (left) tensor factor** (`tr_A`).
 
 For a matrix `X : M_{d·d'}(ℂ)` indexed by `(Fin d × Fin d')`, the partial

--- a/TNLean/Channel/PetzRecovery.lean
+++ b/TNLean/Channel/PetzRecovery.lean
@@ -95,6 +95,54 @@ theorem partialTraceRightPetzMap_apply
     (PosSemidef.partialTraceRight hσ).supportInvSqrt_isHermitian.eq,
     Matrix.mul_assoc]
 
+/-- The raw partial-trace Petz map commutes with equivalence reindexing of
+both tensor factors. -/
+theorem partialTraceRightPetzMap_submatrix_prod_equiv
+    {L' R' : Type*} [Fintype L'] [DecidableEq L']
+    [Fintype R'] [DecidableEq R']
+    (eL : L ≃ L') (eR : R ≃ R')
+    (σ : Matrix (L × R) (L × R) ℂ) (hσ : σ.PosSemidef)
+    (X : Matrix L L ℂ) :
+    partialTraceRightPetzMap
+        (σ.submatrix (eL.prodCongr eR).symm (eL.prodCongr eR).symm)
+        (hσ.submatrix (eL.prodCongr eR).symm)
+        (X.submatrix eL.symm eL.symm) =
+      (partialTraceRightPetzMap σ hσ X).submatrix
+        (eL.prodCongr eR).symm (eL.prodCongr eR).symm := by
+  let e := eL.prodCongr eR
+  have hptr :
+      partialTraceRight (σ.submatrix e.symm e.symm) =
+        (partialTraceRight σ).submatrix eL.symm eL.symm :=
+    partialTraceRight_submatrix_prod_equiv eL eR σ
+  have hsqrt :
+      (hσ.submatrix e.symm).isHermitian.cfc Real.sqrt =
+        (hσ.isHermitian.cfc Real.sqrt).submatrix e.symm e.symm := by
+    rw [← (hσ.submatrix e.symm).isHermitian.cfc_eq,
+      ← hσ.isHermitian.cfc_eq]
+    exact cfc_submatrix_equiv hσ.isHermitian Real.sqrt e
+  have hinv :
+      (PosSemidef.partialTraceRight (hσ.submatrix e.symm)).supportInvSqrt =
+        (PosSemidef.partialTraceRight hσ).supportInvSqrt.submatrix
+          eL.symm eL.symm := by
+    have htransport :
+        (PosSemidef.partialTraceRight
+            (hσ.submatrix e.symm)).supportInvSqrt =
+          ((PosSemidef.partialTraceRight hσ).submatrix
+            eL.symm).supportInvSqrt := by
+      rw [PosSemidef.supportInvSqrt, PosSemidef.supportInvSqrt,
+        ← (PosSemidef.partialTraceRight
+          (hσ.submatrix e.symm)).isHermitian.cfc_eq,
+        ← ((PosSemidef.partialTraceRight hσ).submatrix
+          eL.symm).isHermitian.cfc_eq, hptr]
+    exact htransport.trans
+      ((PosSemidef.partialTraceRight hσ).supportInvSqrt_submatrix_equiv eL)
+  rw [partialTraceRightPetzMap_apply, partialTraceRightPetzMap_apply,
+    hsqrt, hinv]
+  simp only [Matrix.submatrix_mul_equiv]
+  rw [leftKroneckerEmbed_submatrix_prod_equiv eL eR]
+  dsimp only [e]
+  rw [Matrix.submatrix_mul_equiv, Matrix.submatrix_mul_equiv]
+
 /-- The raw partial-trace Petz map is completely positive in rectangular Kraus
 form.  This is the complete-positivity part of the support formula in
 Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,

--- a/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
@@ -750,11 +750,8 @@ theorem quantumRelativeEntropy_partialTraceRight_le_general_support
       partialTraceRight (X.submatrix e.symm e.symm)
         = (partialTraceRight X).submatrix eS.symm eS.symm := by
     intro X
-    rw [partialTraceRight_submatrix_left eS.symm X,
-      partialTraceRight_submatrix_right eT.symm
-        (X.submatrix (Prod.map eS.symm id) (Prod.map eS.symm id)),
-      Matrix.submatrix_submatrix]
-    congr 1
+    simpa only [hedef] using
+      partialTraceRight_submatrix_prod_equiv eS eT X
   rw [hptr ρ, hptr σ,
     quantumRelativeEntropy_submatrix_equiv
       (partialTraceRight_isHermitian hρ.isHermitian)

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -435,11 +435,8 @@ theorem quantumRelativeEntropy_partialTraceRight_le_general
       partialTraceRight (X.submatrix e.symm e.symm)
         = (partialTraceRight X).submatrix eS.symm eS.symm := by
     intro X
-    rw [partialTraceRight_submatrix_left eS.symm X,
-      partialTraceRight_submatrix_right eT.symm
-        (X.submatrix (Prod.map eS.symm id) (Prod.map eS.symm id)),
-      Matrix.submatrix_submatrix]
-    congr 1
+    simpa only [hedef] using
+      partialTraceRight_submatrix_prod_equiv eS eT X
   rw [hptr ρ, hptr σ,
     quantumRelativeEntropy_submatrix_equiv
       (partialTraceRight_isHermitian hρ.isHermitian)

--- a/TNLean/Channel/Schwarz/WeylSupportPetzRecovery.lean
+++ b/TNLean/Channel/Schwarz/WeylSupportPetzRecovery.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Schwarz.SupportRelativeModular
+import TNLean.Channel.Schwarz.PetzRecoverySupport
 import TNLean.Channel.Schwarz.WeylSupportRelativeEntropyEquality
 
 /-!
@@ -21,6 +22,8 @@ partial trace.
   support Petz sandwich.
 * `Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq` proves raw
   recovery by the partial-trace Petz map.
+* `Matrix.partialTraceRightPetzChannel_recovery_of_dpi_equality` gives the
+  arbitrary-index density-state result for the completed Petz channel.
 
 ## References
 
@@ -184,6 +187,140 @@ theorem partialTraceRightPetzMap_eq_of_relativeEntropy_eq
     partialTraceRightPetzMap σ hσ (partialTraceRight ρ) = ρ := by
   apply partialTraceRightPetzMap_eq_of_weyl_identity_sandwich hσ
   exact weyl_support_identity_sandwich_of_partialTraceRight_eq
+    hρ hσ hsupp heq
+
+/-- Equality in right-partial-trace data processing is invariant under
+equivalence reindexing of both tensor factors. -/
+private theorem quantumRelativeEntropy_partialTraceRight_eq_submatrix_prod_equiv
+    {L R L' R' : Type*}
+    [Fintype L] [DecidableEq L] [Fintype R] [DecidableEq R]
+    [Fintype L'] [DecidableEq L'] [Fintype R'] [DecidableEq R']
+    {ρ σ : Matrix (L × R) (L × R) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (eL : L ≃ L') (eR : R ≃ R')
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
+    quantumRelativeEntropy
+        (ρ.submatrix (eL.prodCongr eR).symm (eL.prodCongr eR).symm)
+        (σ.submatrix (eL.prodCongr eR).symm (eL.prodCongr eR).symm) =
+      quantumRelativeEntropy
+        (partialTraceRight
+          (ρ.submatrix (eL.prodCongr eR).symm (eL.prodCongr eR).symm))
+        (partialTraceRight
+          (σ.submatrix (eL.prodCongr eR).symm
+            (eL.prodCongr eR).symm)) := by
+  rw [quantumRelativeEntropy_submatrix_equiv
+      hρ.isHermitian hσ.isHermitian (eL.prodCongr eR),
+    partialTraceRight_submatrix_prod_equiv eL eR ρ,
+    partialTraceRight_submatrix_prod_equiv eL eR σ,
+    quantumRelativeEntropy_submatrix_equiv
+      (partialTraceRight_isHermitian hρ.isHermitian)
+      (partialTraceRight_isHermitian hσ.isHermitian) eL]
+  exact heq
+
+/-- Reindexing a square matrix along an equivalence is injective. -/
+private theorem eq_of_submatrix_equiv_eq
+    {m n : Type*} (e : m ≃ n) {A B : Matrix m m ℂ}
+    (h : A.submatrix e.symm e.symm = B.submatrix e.symm e.symm) :
+    A = B := by
+  ext i j
+  have hij := congrArg (fun M => M (e i) (e j)) h
+  simpa only [Matrix.submatrix_apply, Equiv.symm_apply_apply] using hij
+
+/-- Transport raw Petz recovery from a finite Weyl coordinate model along
+specified equivalences of the two tensor factors. -/
+private theorem partialTraceRightPetzMap_eq_of_relativeEntropy_eq_of_equiv
+    {L R : Type*} [Fintype L] [DecidableEq L]
+    [Fintype R] [DecidableEq R]
+    {dL dR : ℕ} [NeZero dR]
+    (eL : L ≃ Fin dL) (eR : R ≃ ZMod dR)
+    {ρ σ : Matrix (L × R) (L × R) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : L × R → ℂ, σ *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
+    partialTraceRightPetzMap σ hσ (partialTraceRight ρ) = ρ := by
+  let e := eL.prodCongr eR
+  have hρ' : (ρ.submatrix e.symm e.symm).PosSemidef :=
+    hρ.submatrix e.symm
+  have hσ' : (σ.submatrix e.symm e.symm).PosSemidef :=
+    hσ.submatrix e.symm
+  have hsupp' := mulVec_submatrix_support e hsupp
+  have hptrρ :
+      partialTraceRight (ρ.submatrix e.symm e.symm) =
+        (partialTraceRight ρ).submatrix eL.symm eL.symm :=
+    partialTraceRight_submatrix_prod_equiv eL eR ρ
+  have heq' :
+      quantumRelativeEntropy
+          (ρ.submatrix e.symm e.symm)
+          (σ.submatrix e.symm e.symm) =
+        quantumRelativeEntropy
+          (partialTraceRight (ρ.submatrix e.symm e.symm))
+          (partialTraceRight (σ.submatrix e.symm e.symm)) :=
+    quantumRelativeEntropy_partialTraceRight_eq_submatrix_prod_equiv
+      hρ hσ eL eR heq
+  have hbase :=
+    partialTraceRightPetzMap_eq_of_relativeEntropy_eq
+      hρ' hσ' hsupp' heq'
+  rw [hptrρ,
+    partialTraceRightPetzMap_submatrix_prod_equiv eL eR σ hσ
+      (partialTraceRight ρ)] at hbase
+  exact eq_of_submatrix_equiv_eq e hbase
+
+/-- Equality in right-partial-trace data processing on an arbitrary finite
+product index implies recovery by the raw partial-trace Petz map.
+
+The coordinate-free statement is obtained by transporting the finite Weyl
+model above along equivalences of both tensor factors. It is the
+right-partial-trace forward implication of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 3 and equation (8), on the explicit
+finite-relative-entropy support domain. -/
+theorem partialTraceRightPetzMap_eq_of_relativeEntropy_eq_general_support
+    {L R : Type*} [Fintype L] [DecidableEq L]
+    [Fintype R] [DecidableEq R] [Nonempty R]
+    {ρ σ : Matrix (L × R) (L × R) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : L × R → ℂ, σ *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
+    partialTraceRightPetzMap σ hσ (partialTraceRight ρ) = ρ := by
+  classical
+  set dL := Fintype.card L
+  set dR := Fintype.card R
+  letI : NeZero dR := ⟨by simp [dR, Fintype.card_ne_zero (α := R)]⟩
+  set eL : L ≃ Fin dL := Fintype.equivFin L
+  set eR : R ≃ ZMod dR :=
+    (Fintype.equivFin R).trans (ZMod.finEquiv dR).toEquiv
+  exact partialTraceRightPetzMap_eq_of_relativeEntropy_eq_of_equiv
+    eL eR hρ hσ hsupp heq
+
+/-- Equality in right-partial-trace data processing for density matrices
+implies recovery by the completed partial-trace Petz channel.
+
+This is the right-partial-trace forward implication of
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3 and
+equation (8), on the explicit finite-relative-entropy support domain. The raw
+support formula gives the recovery identity; the channel's off-support
+preparation term is the separately chosen trace-preserving completion and
+vanishes on the recovered marginal. -/
+theorem partialTraceRightPetzChannel_recovery_of_dpi_equality
+    {L R : Type*} [Fintype L] [DecidableEq L]
+    [Fintype R] [DecidableEq R]
+    {ρ σ : Matrix (L × R) (L × R) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hρtrace : ρ.trace = 1) (hσtrace : σ.trace = 1)
+    (hsupp : ∀ v : L × R → ℂ, σ *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (heq : quantumRelativeEntropy ρ σ =
+      quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)) :
+    partialTraceRightPetzChannel σ hσ (partialTraceRight ρ) = ρ := by
+  classical
+  let ρIndex := Classical.choice (nonempty_of_trace_eq_one ρ hρtrace)
+  let σIndex := Classical.choice (nonempty_of_trace_eq_one σ hσtrace)
+  letI : Nonempty L := ⟨ρIndex.1⟩
+  letI : Nonempty R := ⟨σIndex.2⟩
+  rw [partialTraceRightPetzChannel_apply_partialTraceRight_of_support
+    hρ hσ hsupp]
+  exact partialTraceRightPetzMap_eq_of_relativeEntropy_eq_general_support
     hρ hσ hsupp heq
 
 end Matrix

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -881,6 +881,81 @@
     recovery identity.
 \end{proof}
 
+\begin{lemma}[Product-coordinate covariance of the partial trace and Petz map]
+    \label{lem:partial_trace_petz_product_reindexing}
+    \lean{Matrix.partialTraceRight_submatrix_prod_equiv}
+    \lean{Matrix.partialTraceRightPetzMap_submatrix_prod_equiv}
+    \leanok
+    Let $e_L:H_L\to H_L'$ and $e_R:H_R\to H_R'$ be bijections, and write
+    $Z^{e_L\otimes e_R}$ for the corresponding simultaneous relabelling of
+    the rows and columns of $Z$. Then
+    \begin{align}
+        \tr_{R'}\bigl(Z^{e_L\otimes e_R}\bigr)
+        &=(\tr_R Z)^{e_L},
+        \label{eq:petz_product_reindexing_trace}\\
+        \mathcal R_{\sigma^{e_L\otimes e_R}}
+          \bigl(X^{e_L}\bigr)
+        &=\bigl(\mathcal R_\sigma(X)\bigr)^{e_L\otimes e_R}.
+        \label{eq:petz_product_reindexing_map}
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    The first identity follows by changing the summation index in the partial
+    trace. Functional calculus commutes with a relabelling by a bijection, so
+    both $\sqrt{\sigma}$ and the support inverse square root of $\tr_R\sigma$
+    have the same covariance. The embedding
+    $X\mapsto X\otimes\mathbf 1_R$ and matrix multiplication also commute with
+    the product relabelling, which gives
+    (\ref{eq:petz_product_reindexing_map}).
+\end{proof}
+
+\begin{theorem}[Petz recovery under equality in data processing]
+    \label{thm:petz_recovery_of_dpi_equality}
+    \lean{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq_general_support}
+    \lean{Matrix.partialTraceRightPetzChannel_recovery_of_dpi_equality}
+    \leanok
+    \uses{def:quantum_relative_entropy, def:partial_trace,
+        def:partial_trace_petz_channel}
+    Let $\rho$ and $\sigma$ be density operators on the finite-dimensional
+    product $H_L\otimes H_R$ such that
+    $\ker\sigma\subseteq\ker\rho$. If
+    \begin{align}
+        D(\rho\Vert\sigma)
+        &=D(\tr_R\rho\Vert\tr_R\sigma),
+        \label{eq:petz_dpi_equality}
+    \end{align}
+    then the completed partial-trace Petz channel associated with $\sigma$
+    recovers $\rho$:
+    \begin{align}
+        \widehat{\mathcal R}_\sigma(\tr_R\rho)
+        &=\rho.
+        \label{eq:petz_dpi_recovery}
+    \end{align}
+    This is the right-partial-trace forward implication of
+    \cite[Theorem~3, equation~(8)]{Hayden2004Structure}. The additional
+    off-support term belongs to the trace-preserving completion and vanishes
+    on $\tr_R\rho$; it is not part of the formula in the cited equation.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:partial_trace_saturation_support_petz_recovery,
+        lem:partial_trace_petz_product_reindexing,
+        lem:relative_entropy_submatrix_equiv,
+        thm:partial_trace_petz_channel_first_marginal_agreement}
+    Choose bijections from $H_L$ to a finite standard basis and from $H_R$ to
+    a finite cyclic basis. Relative entropy, the support inclusion, and the
+    equality (\ref{eq:petz_dpi_equality}) are unchanged under this product
+    relabelling. Theorem~
+    \ref{thm:partial_trace_saturation_support_petz_recovery} gives raw Petz
+    recovery in the cyclic coordinates, and Lemma~
+    \ref{lem:partial_trace_petz_product_reindexing} transports the identity
+    back to $H_L\otimes H_R$. Finally, Theorem~
+    \ref{thm:partial_trace_petz_channel_first_marginal_agreement} identifies
+    the completed channel with the raw support formula at $\tr_R\rho$, giving
+    (\ref{eq:petz_dpi_recovery}).
+\end{proof}
+
 \begin{theorem}[Relative entropy against the product of the marginals]
     \label{thm:relative_entropy_product_marginals}
     \lean{quantumRelativeEntropy_product_marginals}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -603,7 +603,7 @@ of relative entropy under the partial trace for positive-semidefinite inputs
 satisfying $\ker\sigma\subseteq\ker\rho$.  No claim is made here for an
 arbitrary convex ensemble.
 
-The singular-support equality case of data processing is now formalized in
+The singular-support equality case of data processing is first formalized in
 finite Weyl coordinates:
 \begin{align}
   D(\rho\Vert\sigma)
@@ -619,6 +619,25 @@ Weyl resolvent; the support functional calculus gives the projected
 square-root ratio; and the kernel inclusion reduces its Gram identity to the
 displayed Petz sandwich.
 
+Product-coordinate covariance transports this identity to arbitrary finite
+tensor factors. For density operators, the support condition also makes the
+chosen trace-preserving completion agree with the raw support formula on
+$\operatorname{tr}_R\rho$. Consequently the source-facing conclusion is
+\begin{align}
+  D(\rho\Vert\sigma)
+    =D(\operatorname{tr}_R\rho\Vert\operatorname{tr}_R\sigma)
+  \quad\Longrightarrow\quad
+  \widehat{\mathcal R}_\sigma(\operatorname{tr}_R\rho)=\rho.
+\end{align}
+The complementary preparation term in
+$\widehat{\mathcal R}_\sigma$ is the chosen trace-preserving extension and is
+not part of \cite[Equation~(8)]{HaydenJozsaPetzWinter2004}.
+\footnote{Formal declarations:
+\leanid{Matrix.partialTraceRightPetzMap_submatrix_prod_equiv},
+\leanid{Matrix.partialTraceRightPetzMap_eq_of_relativeEntropy_eq_general_support},
+and
+\leanid{Matrix.partialTraceRightPetzChannel_recovery_of_dpi_equality}.}
+
 The proof of the block decomposition still requires the invariant-state
 decomposition used in
 \cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the
@@ -630,9 +649,11 @@ the forward external assumption can be removed.
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-family-level structural analysis of recovered states.  Singular-support raw
-recovery, positive-definite recovery, and the trace-preserving Petz channel are
-available.  The forward direction alone is postulated. The reverse direction,
+family-level structural analysis of recovered states. Source-facing
+completed-channel recovery from equality in data processing is available on
+arbitrary finite tensor factors, together with positive-definite recovery and
+the trace-preserving Petz channel. The forward structural direction alone is
+postulated. The reverse direction,
 a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
 and reindexing invariance.  Until the structural step is formalized, the

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -126,9 +126,13 @@ sum
 and describe the action of the middle-system channel on every summand so that
 the full family has the quantum-Markov form. The singular-support
 equality-to-raw-recovery implication is now formalized by the projected
-finite-Weyl argument. The family-level invariant-state and channel-action
-theorem is the remaining structural obstruction to replacing the forward
-Hayashi strong-subadditivity equality assumption used in the CPSV16 argument.
+finite-Weyl argument and transported to arbitrary finite product coordinates.
+For density operators, support agreement upgrades this equality to the chosen
+completed partial-trace Petz channel on the recovered marginal. This does not
+give a tensor-product factorization of the generic completed singular channel.
+The family-level invariant-state and channel-action theorem is the remaining
+structural obstruction to replacing the forward Hayashi
+strong-subadditivity equality assumption used in the CPSV16 argument.
 
 \section{Common invariant algebra: formalized under an explicit full-support hypothesis}
 
@@ -188,10 +192,11 @@ Heisenberg-picture star-subalgebra $A_0$ of a finite family of jointly
 invariant states, its membership characterization, and its generic block form
 are formalized under an explicit full-support hypothesis on the common
 average, in place of HJPW's joint-support reduction. Singular-support
-equality-to-raw-recovery is formalized by the finite-Weyl support argument. The
-joint-support reduction itself, the finite realization of $A_0$ by a single
-witness $F_0$, the family-level tensor-product state decomposition, and the
-Koashi--Imoto channel-action theorem remain open as separate later steps.
+equality-to-recovery is formalized on arbitrary finite product coordinates,
+including the completed channel on the supported marginal. The joint-support
+reduction itself, the finite realization of $A_0$ by a single witness $F_0$,
+the family-level tensor-product state decomposition, and the Koashi--Imoto
+channel-action theorem remain open as separate later steps.
 
 \begin{thebibliography}{9}
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -36,6 +36,19 @@ abstracted — record why, so it is not re-proposed).
 - **Abstraction:** `@[mps_transfer]` simp set + `transfer_simp` macro
   (`TNLean/MPS/Tactic/Basic.lean`).
 
+### partial trace under product reindexing — promoted
+- **Pattern:** split a simultaneous relabelling of both tensor factors into
+  left- and right-factor submatrices, change the summation index in the traced
+  factor, and compose the resulting submatrices.
+- **Seen:** three occurrences across `PartialTrace.lean`,
+  `RelativeEntropyDataProcessing.lean`, and `StrongSubadditivityPosDef.lean`
+  before promotion.
+- **Abstraction:** `Matrix.partialTraceRight_submatrix_prod_equiv` in
+  `TNLean/Channel/PartialTrace.lean`.
+- **Notes:** the two data-processing proofs now call the shared covariance
+  theorem; the same theorem is also used to transport partial-trace Petz
+  recovery from finite cyclic coordinates to arbitrary finite products.
+
 ### eventual word-tuple span from selectors — promoted
 - **Pattern:** propagate block injectivity from a positive length to the prefix remaining after
   a fixed selector suffix, concatenate the prefix and suffix, and simplify their total length.


### PR DESCRIPTION
Closes #4228.

## Summary

- prove covariance of the partial trace, support inverse square root, tensor embedding, and raw partial-trace Petz map under equivalence reindexing
- transport the finite-Weyl support recovery theorem to arbitrary finite product indices
- add `Matrix.partialTraceRightPetzChannel_recovery_of_dpi_equality`, retaining positive-semidefinite inputs, both trace-one hypotheses, explicit kernel inclusion, and equality in relative-entropy data processing
- promote and reuse the shared partial-trace reindexing lemma at the two existing data-processing call sites
- synchronize the Blueprint and the CPSV16/HJPW paper-gap records

## Source boundary

This is the right-partial-trace forward implication of HJPW Theorem 3, equation (8). The completed channel's off-support preparation term is TNLean's trace-preserving extension and vanishes on the supported marginal; it is not attributed to HJPW equation (8).

CPSV16 Lemma `Lsigma3` and the HJPW Theorem 6 / Koashi--Imoto direct-sum structural step remain open. This PR does not claim that structure or use the forward SSA characterization axiom.

## Validation

- `lake build TNLean.Analysis.CfcKronecker TNLean.Analysis.MatrixSqrt TNLean.Channel.PartialTrace TNLean.Channel.PetzRecovery TNLean.Channel.Schwarz.RelativeEntropyDataProcessing TNLean.Channel.Schwarz.StrongSubadditivityPosDef TNLean.Channel.Schwarz.WeylSupportPetzRecovery` (3,200 jobs)
- `lake build` (9,776 jobs; only the existing unrelated `sorry` warning in `MPS/Periodic/Overlap/SectorMatch.lean`)
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `leanblueprint web`
- `leanblueprint pdf` (769 pages), with visual inspection of the new entries and proof continuation

Three independent read-only reviews approved the frozen diff for Lean/API correctness, source/Blueprint faithfulness, and scope/proof integrity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new Lean proofs in quantum relative entropy and Petz recovery; incorrect transport or covariance lemmas would undermine formal claims tied to published theorems, but changes are additive with no runtime or auth surface.
> 
> **Overview**
> Adds **reindexing covariance** for the left Kronecker embed, support inverse square root, right partial trace, and raw partial-trace Petz map, then **lifts** the existing finite-Weyl support recovery theorem to arbitrary finite product indices.
> 
> New end results: **`partialTraceRightPetzMap_eq_of_relativeEntropy_eq_general_support`** (raw Petz map) and **`partialTraceRightPetzChannel_recovery_of_dpi_equality`** (completed trace-preserving channel on density states with kernel support and equality in relative-entropy data processing). The shared lemma **`partialTraceRight_submatrix_prod_equiv`** replaces duplicated proof blocks in relative-entropy data processing and strong subadditivity.
> 
> Blueprint ch19 and the CPSV16/HJPW paper-gap notes are updated to record completed-channel recovery; Koashi–Imoto / forward SSA structure remains explicitly out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8478fb4be53a9b6423f99347057f4d99c3110610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->