### PR TITLE
feat(Channel/Schwarz): specialize HJPW Petz recovery

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -496,6 +496,32 @@ noncomputable def traceAC_ABC
     Matrix (Fin dB) (Fin dB) ℂ :=
   fun b₁ b₂ => ∑ a : Fin dA, ∑ c : Fin dC, ρ (a, b₁, c) (a, b₂, c)
 
+/-- Reassociating a tripartite matrix from \(A \times (B \times C)\) to
+\((A \times B) \times C\) and taking the right partial trace gives
+\(\operatorname{tr}_C \rho_{ABC}\). -/
+theorem partialTraceRight_submatrix_prodAssoc
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    partialTraceRight
+        (ρ.submatrix (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))
+          (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))) =
+      traceC_ABC ρ := by
+  ext q₁ q₂
+  simp only [partialTraceRight_apply, Matrix.submatrix_apply, traceC_ABC,
+    Equiv.prodAssoc_apply]
+
+/-- Tracing out \(A\) after tracing out \(C\) gives the same \(B\)-marginal
+as tracing out \(C\) after tracing out \(A\). -/
+theorem partialTraceLeft_traceC_ABC_eq_partialTraceRight_traceA_ABC
+    (ρ : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    partialTraceLeft (traceC_ABC ρ) =
+      partialTraceRight (traceA_ABC ρ) := by
+  ext b₁ b₂
+  simp only [partialTraceLeft_apply, partialTraceRight_apply, traceC_ABC,
+    traceA_ABC]
+  rw [Finset.sum_comm]
+
 /-! ### Hermiticity preservation for partial traces -/
 
 /-- Partial trace over A preserves Hermiticity. -/

--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -34,6 +34,7 @@ import TNLean.Channel.Schwarz.RelativeEntropyConvexity
 import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
 import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
 import TNLean.Channel.Schwarz.SSAEqualityDPI
+import TNLean.Channel.Schwarz.SSAEqualityPetzRecovery
 import TNLean.Channel.Schwarz.SchwarzNormal
 import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.SchwarzSubnormal

--- a/TNLean/Channel/Schwarz/SSAEqualityPetzRecovery.lean
+++ b/TNLean/Channel/Schwarz/SSAEqualityPetzRecovery.lean
@@ -1,0 +1,345 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.PetzProductReference
+import TNLean.Channel.Schwarz.SSAEqualityDPI
+import TNLean.Channel.Schwarz.WeylSupportPetzRecovery
+
+/-!
+# Petz recovery from equality in strong subadditivity
+
+For a tripartite density matrix satisfying equality in strong subadditivity,
+this file specializes equality in relative-entropy data processing to the
+reference matrix \(\rho_A\otimes\rho_{BC}\). The resulting Petz map recovers
+\(\rho_{ABC}\), and its product-reference formula is
+\(\operatorname{id}_A\otimes\mathcal R^{\mathrm{raw}}_{\rho_{BC}}\) on the
+supported input \(\rho_{AB}\).
+
+## Main results
+
+* `Matrix.product_marginal_support` places a bipartite positive semidefinite
+  matrix in the support of the product of its marginals.
+* `Matrix.partialTraceRightPetzMap_product_marginal_recovery_of_isSSAEquality`
+  gives the recovery identity for the product reference.
+* `Matrix.idTensor_partialTraceRightPetzMap_traceC_ABC_eq_of_isSSAEquality`
+  gives the identity-tensored form of the recovery formula.
+* `Matrix.idTensor_partialTraceRightPetzChannel_traceC_ABC_eq_of_isSSAEquality`
+  supplies the identity-tensored quantum-operation form used by HJPW.
+
+## References
+
+* P. Hayden, R. Jozsa, D. Petz, and A. Winter,
+  arXiv:quant-ph/0304007v2, Theorem 3 and equations (8), (10), and (11);
+  source labels `eq:transpose:channel`, `eq:form:of:hat-T`, and
+  `eq:markov:quantum`.
+-/
+
+open scoped Matrix ComplexOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+private theorem PosSemidef.supportProj_eq_of_eq
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A B : Matrix n n ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef)
+    (h : A = B) :
+    hA.supportProj = hB.supportProj := by
+  subst B
+  rfl
+
+private theorem bipartiteBlock_support_of_right_sandwich
+    {A B : Type*} [Fintype A] [DecidableEq A]
+    [Fintype B]
+    {X : Matrix (A × B) (A × B) ℂ} {P : Matrix B B ℂ}
+    (hX : ((1 : Matrix A A ℂ) ⊗ₖ P) * X *
+      ((1 : Matrix A A ℂ) ⊗ₖ P) = X)
+    (a a' : A) :
+    P * bipartiteBlock X a a' * P = bipartiteBlock X a a' := by
+  ext b b'
+  have hentry := congrArg (fun M => M (a, b) (a', b')) hX
+  simp only [Matrix.mul_apply, Matrix.kroneckerMap_apply, Matrix.one_apply] at hentry
+  simp_rw [Fintype.sum_prod_type] at hentry
+  simp at hentry
+  simpa only [Matrix.mul_apply, bipartiteBlock_apply] using hentry
+
+section ProductMarginalSupport
+
+variable {L R : Type*} [Fintype L] [Fintype R]
+
+/-- A positive semidefinite matrix \(\rho_{LR}\) is supported on
+\(\operatorname{supp}\rho_L\otimes\operatorname{supp}\rho_R\). Equivalently,
+\[
+  \ker(\rho_L\otimes\rho_R)\subseteq\ker\rho_{LR}.
+\]
+This is the support condition for the product reference used in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2,
+`eq:transpose:channel`. -/
+theorem product_marginal_support
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef) :
+    ∀ v : L × R → ℂ,
+      (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) *ᵥ v = 0 → ρ *ᵥ v = 0 := by
+  classical
+  intro v hv
+  let hL := hρ.partialTraceRight
+  let hR := hρ.partialTraceLeft
+  have hPzero :
+      (hL.supportProj ⊗ₖ hR.supportProj) *ᵥ v = 0 := by
+    simpa only [hL.supportProj_kronecker hR] using
+      (hL.kronecker hR).supportProj_mulVec_eq_zero_of_mulVec_eq_zero v hv
+  have hPL :
+      ρ * (hL.supportProj ⊗ₖ (1 : Matrix R R ℂ)) = ρ := by
+    simpa only [hL, PosSemidef.supportProj, leftKroneckerEmbed_apply] using
+      hρ.mul_leftKroneckerEmbed_supportProj_self
+  have hPR :
+      ρ * ((1 : Matrix L L ℂ) ⊗ₖ hR.supportProj) = ρ := by
+    simpa only [hR, PosSemidef.supportProj, rightKroneckerEmbed_apply] using
+      hρ.mul_rightKroneckerEmbed_supportProj_self
+  have hP :
+      ρ * (hL.supportProj ⊗ₖ hR.supportProj) = ρ := by
+    rw [show hL.supportProj ⊗ₖ hR.supportProj =
+        (hL.supportProj ⊗ₖ (1 : Matrix R R ℂ)) *
+          ((1 : Matrix L L ℂ) ⊗ₖ hR.supportProj) by
+        rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul],
+      ← Matrix.mul_assoc, hPL, hPR]
+  rw [← hP, ← Matrix.mulVec_mulVec, hPzero, Matrix.mulVec_zero]
+
+end ProductMarginalSupport
+
+section SSAEqualityRecovery
+
+variable {dA dB dC : ℕ}
+
+open SSAPosDef
+
+/-- **Product-reference Petz recovery at SSA equality.** If a tripartite
+density matrix saturates strong subadditivity, then the raw Petz map for the
+reference \(\rho_A\otimes\rho_{BC}\), canonically reassociated so that it
+traces out \(C\), recovers \(\rho_{ABC}\) from \(\rho_{AB}\).
+
+This is Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, Theorem 3 and
+equation (8), specialized to the product reference used in equations
+(10)--(11). No marginal is assumed invertible. -/
+theorem partialTraceRightPetzMap_product_marginal_recovery_of_isSSAEquality
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    partialTraceRightPetzMap
+        (productTensorReference (partialTraceRight ρ_ABC) (traceA_ABC ρ_ABC))
+        (productTensorReference_posSemidef hρ_dm.1.partialTraceRight
+          (traceLeftA_posSemidef hρ_dm.1))
+        (traceC_ABC ρ_ABC) =
+      ρ_ABC.submatrix (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))
+        (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC)) := by
+  classical
+  let r := Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC)
+  let ρr := ρ_ABC.submatrix r r
+  let ρA := partialTraceRight ρ_ABC
+  let ρBC := traceA_ABC ρ_ABC
+  let σ0 := ρA ⊗ₖ ρBC
+  let σr := productTensorReference ρA ρBC
+  have hρ := hρ_dm.1
+  have hA : ρA.PosSemidef := by
+    exact hρ.partialTraceRight
+  have hBC : ρBC.PosSemidef := by
+    exact traceLeftA_posSemidef hρ
+  have hρr : ρr.PosSemidef := hρ.submatrix r
+  have hσr : σr.PosSemidef := productTensorReference_posSemidef hA hBC
+  have hsupp0 :
+      ∀ v, σ0 *ᵥ v = 0 → ρ_ABC *ᵥ v = 0 := by
+    exact product_marginal_support hρ
+  have hsupp :
+      ∀ v, σr *ᵥ v = 0 → ρr *ᵥ v = 0 := by
+    simpa only [σ0, σr, ρr, productTensorReference, r, Equiv.symm_symm] using
+      mulVec_submatrix_support r.symm hsupp0
+  have hDPI :=
+    (isSSAEquality_iff_product_marginal_data_processing_eq ρ_ABC hρ_dm).mp hSSA
+  rw [← traceC_ABC_product_marginals ρ_ABC] at hDPI
+  have heq :
+      quantumRelativeEntropy ρr σr =
+        quantumRelativeEntropy (partialTraceRight ρr) (partialTraceRight σr) := by
+    calc
+      quantumRelativeEntropy ρr σr =
+          quantumRelativeEntropy ρ_ABC σ0 := by
+            simpa only [ρr, σr, σ0, productTensorReference, r,
+              Equiv.symm_symm] using
+              quantumRelativeEntropy_submatrix_equiv hρ.isHermitian
+                (hA.kronecker hBC).isHermitian r.symm
+      _ = quantumRelativeEntropy (traceC_ABC ρ_ABC) (traceC_ABC σ0) := hDPI
+      _ = quantumRelativeEntropy (partialTraceRight ρr)
+          (partialTraceRight σr) := by
+            rw [show partialTraceRight ρr = traceC_ABC ρ_ABC by
+                simpa only [ρr, r] using
+                  partialTraceRight_submatrix_prodAssoc ρ_ABC,
+              show partialTraceRight σr = traceC_ABC σ0 by
+                simpa only [σr, σ0, productTensorReference, r] using
+                  partialTraceRight_submatrix_prodAssoc σ0]
+  let ρIndex := Classical.choice (nonempty_of_trace_eq_one ρ_ABC hρ_dm.2)
+  letI : Nonempty (Fin dC) := ⟨ρIndex.2.2⟩
+  have hrec :=
+    partialTraceRightPetzMap_eq_of_relativeEntropy_eq_general_support
+      hρr hσr hsupp heq
+  simpa only [ρr, σr, ρA, ρBC, r,
+    partialTraceRight_submatrix_prodAssoc] using hrec
+
+/-- **Identity-tensored form of HJPW equation (11).** At equality in strong
+subadditivity, the raw Petz map for \(\rho_{BC}\), tensored with the identity
+on \(A\), recovers \(\rho_{ABC}\) from \(\rho_{AB}\).
+
+This is the supported-input consequence of Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, equations (10)--(11). For singular \(\rho_A\), this
+does not assert a global identity-tensored factorization of the raw map or of
+TNLean's chosen completed channel on unsupported inputs. -/
+theorem idTensor_partialTraceRightPetzMap_traceC_ABC_eq_of_isSSAEquality
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    idTensorMapLM (δ := Fin dA)
+        (partialTraceRightPetzMap (traceA_ABC ρ_ABC)
+          (traceLeftA_posSemidef hρ_dm.1))
+        (traceC_ABC ρ_ABC) =
+      ρ_ABC := by
+  classical
+  have hρ := hρ_dm.1
+  have hAB := traceC_ABC_posSemidef hρ
+  have hA := hρ.partialTraceRight
+  have hBC := traceLeftA_posSemidef hρ
+  let hAAB := PosSemidef.partialTraceRight hAB
+  let P := hAAB.supportProj
+  have hProj : P = hA.supportProj :=
+    hAAB.supportProj_eq_of_eq hA
+      (partialTraceRight_traceC_ABC ρ_ABC)
+  have hL :
+      (P ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) *
+          traceC_ABC ρ_ABC =
+        traceC_ABC ρ_ABC := by
+    change leftKroneckerEmbed (n := Fin dB)
+        (PosSemidef.partialTraceRight hAB).isHermitian.supportProj *
+          traceC_ABC ρ_ABC =
+        traceC_ABC ρ_ABC
+    exact hAB.leftKroneckerEmbed_supportProj_mul_self
+  have hR :
+      traceC_ABC ρ_ABC *
+          (P ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) =
+        traceC_ABC ρ_ABC := by
+    change traceC_ABC ρ_ABC * leftKroneckerEmbed (n := Fin dB)
+        (PosSemidef.partialTraceRight hAB).isHermitian.supportProj =
+      traceC_ABC ρ_ABC
+    exact hAB.mul_leftKroneckerEmbed_supportProj_self
+  have hX :
+      (hA.supportProj ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) * traceC_ABC ρ_ABC *
+          (hA.supportProj ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) =
+        traceC_ABC ρ_ABC := by
+    rw [← hProj]
+    rw [hL, hR]
+  have hfactor :=
+    partialTraceRightPetzMap_productTensor_apply_of_left_supported
+      (partialTraceRight ρ_ABC) (traceA_ABC ρ_ABC) hA hBC
+      (traceC_ABC ρ_ABC) hX
+  have hraw :=
+    partialTraceRightPetzMap_product_marginal_recovery_of_isSSAEquality
+      ρ_ABC hρ_dm hSSA
+  rw [hraw] at hfactor
+  have hcancel :
+      equivReindexMap (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))
+          (ρ_ABC.submatrix (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))
+            (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))) =
+        ρ_ABC := by
+    ext i j
+    change Matrix.reindex (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))
+        (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))
+          (ρ_ABC.submatrix (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))
+            (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC))) i j =
+      ρ_ABC i j
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply, Equiv.apply_symm_apply]
+  exact hfactor.symm.trans hcancel
+
+/-- The local completed Petz map for \(\rho_{BC}\) is a quantum channel.
+
+This supplies the quantum operation \(\widehat{\mathcal R}\) in
+Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, equations (10)--(11),
+without requiring invertibility of \(\rho_{BC}\). -/
+theorem partialTraceRightPetzChannel_traceA_ABC_isKrausCPTP
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
+    IsKrausCPTP
+      (partialTraceRightPetzChannel (traceA_ABC ρ_ABC)
+        (traceLeftA_posSemidef hρ_dm.1)) := by
+  apply partialTraceRightPetzChannel_isKrausCPTP
+  change (partialTraceLeft ρ_ABC).trace = 1
+  rw [trace_partialTraceLeft, hρ_dm.2]
+
+/-- **Quantum-operation form of HJPW equation (11).** At equality in strong
+subadditivity, the completed local Petz channel for \(\rho_{BC}\), tensored
+with the identity on \(A\), recovers \(\rho_{ABC}\) from \(\rho_{AB}\).
+
+The completed channel agrees with the raw support formula on every
+\(B\)-block of \(\rho_{AB}\). This is the source-facing quantum operation
+\(\widehat{\mathcal R}\) from Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, equations (10)--(11); no global factorization of
+TNLean's completed product-reference channel is asserted. -/
+theorem idTensor_partialTraceRightPetzChannel_traceC_ABC_eq_of_isSSAEquality
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    idTensorMapLM (δ := Fin dA)
+        (partialTraceRightPetzChannel (traceA_ABC ρ_ABC)
+          (traceLeftA_posSemidef hρ_dm.1))
+        (traceC_ABC ρ_ABC) =
+      ρ_ABC := by
+  classical
+  have hρ := hρ_dm.1
+  have hAB := traceC_ABC_posSemidef hρ
+  have hBC := traceLeftA_posSemidef hρ
+  have hBAB := hAB.partialTraceLeft
+  have hB := hBC.partialTraceRight
+  let P := hBAB.supportProj
+  have hProj : P = hB.supportProj :=
+    hBAB.supportProj_eq_of_eq hB
+      (partialTraceLeft_traceC_ABC_eq_partialTraceRight_traceA_ABC ρ_ABC)
+  have hL :
+      ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ P) * traceC_ABC ρ_ABC =
+        traceC_ABC ρ_ABC := by
+    change rightKroneckerEmbed (m := Fin dA)
+        (PosSemidef.partialTraceLeft hAB).isHermitian.supportProj *
+          traceC_ABC ρ_ABC =
+        traceC_ABC ρ_ABC
+    exact hAB.rightKroneckerEmbed_supportProj_mul_self
+  have hR :
+      traceC_ABC ρ_ABC * ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ P) =
+        traceC_ABC ρ_ABC := by
+    change traceC_ABC ρ_ABC * rightKroneckerEmbed (m := Fin dA)
+        (PosSemidef.partialTraceLeft hAB).isHermitian.supportProj =
+      traceC_ABC ρ_ABC
+    exact hAB.mul_rightKroneckerEmbed_supportProj_self
+  have hX :
+      ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ hB.supportProj) *
+          traceC_ABC ρ_ABC *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ hB.supportProj) =
+        traceC_ABC ρ_ABC := by
+    rw [← hProj, hL, hR]
+  have hraw :=
+    idTensor_partialTraceRightPetzMap_traceC_ABC_eq_of_isSSAEquality
+      ρ_ABC hρ_dm hSSA
+  ext ⟨a, bc⟩ ⟨a', bc'⟩
+  have hblock :=
+    bipartiteBlock_support_of_right_sandwich hX a a'
+  have hlocal :=
+    partialTraceRightPetzChannel_apply_of_supported
+      (traceA_ABC ρ_ABC) hBC
+      (bipartiteBlock (traceC_ABC ρ_ABC) a a') hblock
+  change
+    (partialTraceRightPetzChannel (traceA_ABC ρ_ABC) hBC
+      (bipartiteBlock (traceC_ABC ρ_ABC) a a')) bc bc' =
+      ρ_ABC (a, bc) (a', bc')
+  rw [hlocal]
+  exact congrArg (fun M => M (a, bc) (a', bc')) hraw
+
+end SSAEqualityRecovery
+
+end Matrix

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -464,13 +464,10 @@ theorem quantumRelativeEntropy_traceC_le [NeZero dC]
     (S := Fin dA × Fin dB) (T := Fin dC)
     (ρ := ρ.submatrix r.symm r.symm) (σ := σ.submatrix r.symm r.symm) hρr hσr
   rw [quantumRelativeEntropy_submatrix_equiv hρ.isHermitian hσ.isHermitian r] at hbase
-  have hImage : ∀ X : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ,
-      partialTraceRight (X.submatrix r.symm r.symm) = traceC_ABC X := by
-    intro X
-    ext q₁ q₂
-    simp only [partialTraceRight_apply, Matrix.submatrix_apply, traceC_ABC, hr,
-      Equiv.symm_symm, Equiv.prodAssoc_apply]
-  rw [hImage ρ, hImage σ] at hbase
+  rw [show partialTraceRight (ρ.submatrix r.symm r.symm) = traceC_ABC ρ by
+      simpa only [hr, Equiv.symm_symm] using partialTraceRight_submatrix_prodAssoc ρ,
+    show partialTraceRight (σ.submatrix r.symm r.symm) = traceC_ABC σ by
+      simpa only [hr, Equiv.symm_symm] using partialTraceRight_submatrix_prodAssoc σ] at hbase
   exact hbase
 
 /-- The partial trace over the third factor of a positive definite tripartite
@@ -547,13 +544,10 @@ theorem quantumRelativeEntropy_traceC_le_support [NeZero dC]
     (S := Fin dA × Fin dB) (T := Fin dC)
     (ρ := ρ.submatrix r.symm r.symm) (σ := σ.submatrix r.symm r.symm) hρr hσr hsuppr
   rw [quantumRelativeEntropy_submatrix_equiv hρ.isHermitian hσ.isHermitian r] at hbase
-  have hImage : ∀ X : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ,
-      partialTraceRight (X.submatrix r.symm r.symm) = traceC_ABC X := by
-    intro X
-    ext q₁ q₂
-    simp only [partialTraceRight_apply, Matrix.submatrix_apply, traceC_ABC, hr,
-      Equiv.symm_symm, Equiv.prodAssoc_apply]
-  rw [hImage ρ, hImage σ] at hbase
+  rw [show partialTraceRight (ρ.submatrix r.symm r.symm) = traceC_ABC ρ by
+      simpa only [hr, Equiv.symm_symm] using partialTraceRight_submatrix_prodAssoc ρ,
+    show partialTraceRight (σ.submatrix r.symm r.symm) = traceC_ABC σ by
+      simpa only [hr, Equiv.symm_symm] using partialTraceRight_submatrix_prodAssoc σ] at hbase
   exact hbase
 
 end DataProcessingGeneral

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -992,6 +992,34 @@
     $D(\rho\,\| \sigma)=-S(\rho)-\re\tr(\rho\log\sigma)$.
 \end{proof}
 
+\begin{lemma}[Support of a bipartite state in the product of its marginals]
+    \label{lem:product_marginal_support}
+    \lean{Matrix.product_marginal_support}
+    \leanok
+    \uses{def:partial_trace, def:partial_trace_left,
+        thm:marginal_support_left_absorption,
+        thm:marginal_support_right_absorption,
+        thm:right_marginal_support_left_absorption,
+        thm:right_marginal_support_right_absorption}
+    Let $\omega_{XY}$ be positive semidefinite. Then
+    \begin{align}
+        \ker(\omega_X\otimes\omega_Y)
+        &\subseteq \ker\omega_{XY}.
+        \notag
+    \end{align}
+    Equivalently, $\omega_{XY}$ is supported on
+    $\operatorname{supp}\omega_X\otimes\operatorname{supp}\omega_Y$.
+\end{lemma}
+
+\begin{proof}\leanok
+    The support projection of $\omega_X\otimes\omega_Y$ is
+    $P_X\otimes P_Y$. The lifted projections
+    $P_X\otimes\mathbf 1_Y$ and $\mathbf 1_X\otimes P_Y$ both fix
+    $\omega_{XY}$, so their product $P_X\otimes P_Y$ fixes it as well.
+    Every vector annihilated by the product of the marginals is therefore
+    annihilated by $\omega_{XY}$.
+\end{proof}
+
 \begin{theorem}[SSA equality as saturation for the product marginals]
     \label{thm:ssa_equality_product_marginal_dpi}
     \lean{isSSAEquality_iff_product_marginal_data_processing_eq}
@@ -1044,6 +1072,61 @@
         [\rho_A\otimes\rho_B]_{(a,b),(a',b')}.
         \notag
     \end{align}
+\end{proof}
+
+\begin{theorem}[Product-reference Petz recovery at SSA equality]
+    \label{thm:ssa_equality_product_marginal_petz_recovery}
+    \lean{Matrix.partialTraceRightPetzMap_product_marginal_recovery_of_isSSAEquality}
+    \lean{Matrix.idTensor_partialTraceRightPetzMap_traceC_ABC_eq_of_isSSAEquality}
+    \lean{Matrix.partialTraceRightPetzChannel_traceA_ABC_isKrausCPTP}
+    \lean{Matrix.idTensor_partialTraceRightPetzChannel_traceC_ABC_eq_of_isSSAEquality}
+    \leanok
+    \uses{thm:ssa_equality_product_marginal_dpi,
+        lem:product_marginal_support,
+        thm:petz_recovery_of_dpi_equality,
+        thm:entropy_petz_product_tensor_corollaries,
+        thm:partial_trace_petz_channel_cptp,
+        thm:partial_trace_petz_channel_supported_agreement}
+    Let $\rho_{ABC}$ be a tripartite density matrix attaining equality in
+    strong subadditivity. The raw Petz support map for the reference
+    $\rho_A\otimes\rho_{BC}$ recovers $\rho_{ABC}$ from $\rho_{AB}$.
+    Moreover,
+    \begin{align}
+        \rho_{ABC}
+        &=
+        (\operatorname{id}_A\otimes
+          \mathcal R^{\mathrm{raw}}_{\rho_{BC}})(\rho_{AB})
+        =
+        (\operatorname{id}_A\otimes
+          \widehat{\mathcal R}_{\rho_{BC}})(\rho_{AB}),
+        \notag
+    \end{align}
+    where $\widehat{\mathcal R}_{\rho_{BC}}$ is a trace-preserving completely
+    positive extension of the support formula. This is equation~(11) of
+    \cite{Hayden2004Structure}, obtained from Theorem~3 and equation~(8)
+    together with the supported form of equation~(10).
+
+    No marginal is required to be invertible. If $\rho_A$ is singular, the
+    displayed factorization is asserted on the supported input
+    $\rho_{AB}$ only; it is not a global factorization of an ambient
+    product-reference completion.
+\end{theorem}
+
+\begin{proof}\leanok
+    Equality in strong subadditivity gives equality in relative-entropy data
+    processing for $\rho_{ABC}$ and
+    $\rho_A\otimes\rho_{BC}$. Lemma~
+    \ref{lem:product_marginal_support} supplies the required support
+    inclusion, and Theorem~\ref{thm:petz_recovery_of_dpi_equality} gives raw
+    recovery after the canonical reassociation of the tensor factors.
+
+    The state $\rho_{AB}$ is fixed on both sides by
+    $P_A\otimes\mathbf 1_B$, so the supported product-reference
+    factorization removes the first-factor support compression. It is also
+    fixed by $\mathbf 1_A\otimes P_B$; hence every $B$-block lies in the
+    support of $\rho_B$. The completed local channel therefore agrees with
+    its raw support formula on every block, proving both displayed
+    identities.
 \end{proof}
 
 \begin{theorem}[SSA equality as saturation for a maximally mixed reference]

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -638,6 +638,26 @@ not part of \cite[Equation~(8)]{HaydenJozsaPetzWinter2004}.
 and
 \leanid{Matrix.partialTraceRightPetzChannel_recovery_of_dpi_equality}.}
 
+For the exact strong-subadditivity pair
+$\rho=\rho_{ABC}$ and $\sigma=\rho_A\otimes\rho_{BC}$, the product-marginal
+support inclusion is automatic. The specialized declarations
+\begin{center}
+  \small
+  \leanid{Matrix.product_marginal_support}\\
+  \leanid{Matrix.partialTraceRightPetzMap_product_marginal_recovery_of_isSSAEquality}\\
+  \leanid{Matrix.partialTraceRightPetzChannel_traceA_ABC_isKrausCPTP}\\
+  \leanid{Matrix.idTensor_partialTraceRightPetzChannel_traceC_ABC_eq_of_isSSAEquality}
+\end{center}
+therefore give HJPW equation (11):
+\begin{align}
+  \rho_{ABC}
+  &=(\operatorname{id}_A\otimes
+    \widehat{\mathcal R}_{\rho_{BC}})(\rho_{AB}).
+\end{align}
+The local completed Petz map is trace-preserving and completely positive.
+For singular $\rho_A$, this is a supported-input identity, not a global
+factorization of TNLean's generic completed product-reference channel.
+
 The proof of the block decomposition still requires the invariant-state
 decomposition used in
 \cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the
@@ -651,9 +671,10 @@ reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
 family-level structural analysis of recovered states. Source-facing
 completed-channel recovery from equality in data processing is available on
-arbitrary finite tensor factors, together with positive-definite recovery and
-the trace-preserving Petz channel. The forward structural direction alone is
-postulated. The reverse direction,
+arbitrary finite tensor factors. Its exact HJPW product-reference
+specialization and identity-tensored local recovery channel are also
+formalized without invertibility assumptions. The forward structural
+direction alone is postulated. The reverse direction,
 a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
 and reindexing invariance.  Until the structural step is formalized, the

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -113,6 +113,43 @@ identity on $A$ tensored with a projection on $B$. No factorization of that
 generic completed channel is claimed. The existing maximally mixed completed
 factorization is valid because the first-factor support is full.
 
+\section{SSA product-reference specialization}
+
+For every positive semidefinite bipartite operator $\omega_{XY}$,
+\begin{align}
+  \ker(\omega_X\otimes\omega_Y)\subseteq\ker\omega_{XY}.
+\end{align}
+Thus the product-marginal reference automatically satisfies the support
+condition in HJPW Theorem~3. If a tripartite density matrix attains equality
+in strong subadditivity, the raw product-reference Petz map recovers it:
+\begin{align}
+  \mathcal R^{\mathrm{raw}}_{\rho_A\otimes\rho_{BC}}(\rho_{AB})
+  &=\rho_{ABC}.
+\end{align}
+Since $\rho_{AB}$ is supported by both $P_A\otimes\mathbf 1_B$ and
+$\mathbf 1_A\otimes P_B$, the supported factorization and the local
+trace-preserving completion give
+\begin{align}
+  (\operatorname{id}_A\otimes
+    \mathcal R^{\mathrm{raw}}_{\rho_{BC}})(\rho_{AB})
+  &=
+  (\operatorname{id}_A\otimes
+    \widehat{\mathcal R}_{\rho_{BC}})(\rho_{AB})
+  =\rho_{ABC}.
+\end{align}
+These are HJPW equations (10)--(11) on the supported input. They are
+formalized in \doclink{TNLean/Channel/Schwarz/SSAEqualityPetzRecovery} by
+\begin{center}
+  \small
+  \leanid{Matrix.product_marginal_support}\\
+  \leanid{Matrix.partialTraceRightPetzMap_product_marginal_recovery_of_isSSAEquality}\\
+  \leanid{Matrix.idTensor_partialTraceRightPetzMap_traceC_ABC_eq_of_isSSAEquality}\\
+  \leanid{Matrix.partialTraceRightPetzChannel_traceA_ABC_isKrausCPTP}\\
+  \leanid{Matrix.idTensor_partialTraceRightPetzChannel_traceC_ABC_eq_of_isSSAEquality}.
+\end{center}
+No global identity-tensored factorization of TNLean's generic completed
+singular product-reference channel is claimed.
+
 \section{Remaining structural theorem}
 
 Equation~\eqref{eq:hjpw-global-support-factorization} supplies the
@@ -183,11 +220,14 @@ structural obstructions identified in the previous section.
 
 \section{Classification}
 
-\emph{Raw factorization complete; structural implication open.} The general
+\emph{Product-reference recovery complete; structural implication open.} The general
 positive-semidefinite product reference, its marginal and support calculus, the
 global support-compressed raw formula, and the supported-input and
 positive-definite-left corollaries are formalized. The generic completed
-singular channel is outside this claim. Independently, the common invariant
+singular product-reference channel is outside this claim. The exact SSA
+specialization now proves HJPW equation (11), both for the identity-tensored
+raw support formula and for a completed local recovery channel on
+$\rho_{AB}$. Independently, the common invariant
 Heisenberg-picture star-subalgebra $A_0$ of a finite family of jointly
 invariant states, its membership characterization, and its generic block form
 are formalized under an explicit full-support hypothesis on the common

--- a/docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex
+++ b/docs/paper-gaps/hjpw04_ssa_product_marginal_reference.tex
@@ -131,6 +131,31 @@ processing.  This is formalized by the declaration
 \end{center}
 No recovery map or Petz equality theorem is needed for this step.
 
+\section{Downstream recovery corollary}
+
+The equality criterion above now feeds the singular-support Petz theorem.
+The automatic inclusion
+\begin{align}
+  \ker(\rho_A\otimes\rho_{BC})\subseteq\ker\rho_{ABC}
+\end{align}
+is formalized by \leanid{Matrix.product_marginal_support}. Consequently,
+strong-subadditivity equality implies
+\begin{align}
+  \mathcal R^{\mathrm{raw}}_{\rho_A\otimes\rho_{BC}}(\rho_{AB})
+  &=\rho_{ABC},\\
+  (\operatorname{id}_A\otimes
+    \widehat{\mathcal R}_{\rho_{BC}})(\rho_{AB})
+  &=\rho_{ABC}.
+\end{align}
+The declarations
+\leanid{Matrix.partialTraceRightPetzMap_product_marginal_recovery_of_isSSAEquality}
+and
+\leanid{Matrix.idTensor_partialTraceRightPetzChannel_traceC_ABC_eq_of_isSSAEquality}
+formalize HJPW Theorem~3 and equations (8), (10), and (11) at this exact
+product reference. The identity-tensored statement is supported-input only;
+it does not assert a global factorization of the generic completed singular
+product-reference channel.
+
 \section{Verdict}
 
 The gap is closed.  Equality in strong subadditivity is identified with

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -49,6 +49,18 @@ abstracted — record why, so it is not re-proposed).
   theorem; the same theorem is also used to transport partial-trace Petz
   recovery from finite cyclic coordinates to arbitrary finite products.
 
+### tripartite right partial trace after reassociation — promoted
+- **Pattern:** reassociate a matrix indexed by
+  \(A\times(B\times C)\) to \((A\times B)\times C\), expand the right
+  partial trace, and identify the result with the direct tripartite trace over
+  \(C\).
+- **Seen:** three occurrences across `StrongSubadditivityPosDef.lean` and
+  `SSAEqualityPetzRecovery.lean` before promotion.
+- **Abstraction:** `Matrix.partialTraceRight_submatrix_prodAssoc` in
+  `TNLean/Analysis/Entropy.lean`.
+- **Notes:** the two strong-subadditivity data-processing proofs and the HJPW
+  product-reference recovery proof now use the shared reassociation identity.
+
 ### eventual word-tuple span from selectors — promoted
 - **Pattern:** propagate block injectivity from a positive length to the prefix remaining after
   a fixed selector suffix, concatenate the prefix and suffix, and simplify their total length.


### PR DESCRIPTION
Closes #4961.

## What changed

- prove that a positive semidefinite bipartite operator is supported on the tensor product of its marginals;
- specialize singular partial-trace equality-to-recovery to the HJPW reference `rho_A tensor rho_BC`;
- derive the supported `id_A tensor R_raw_rhoBC` recovery identity;
- provide the completed local Petz channel, prove it is CPTP, and prove the source-facing `id_A tensor Rhat_rhoBC` recovery identity needed by #4962;
- extract the shared tripartite reassociation/partial-trace lemma and refactor its existing duplicate call sites;
- synchronize the Chapter 19 Blueprint, paper-gap records, tactic-pattern ledger, and generated Schwarz import.

## Source and boundary

This follows Hayden–Jozsa–Petz–Winter, arXiv:quant-ph/0304007v2, Theorem 3 and equations (8), (10), and (11). No marginal is assumed positive definite or invertible. For singular `rho_A`, the identity-tensored formula is claimed only on the supported input `rho_AB`; this PR does not claim a global factorization of TNLean's generic completed product-reference channel.

## Validation

- `lake env lean TNLean/Channel/Schwarz/SSAEqualityPetzRecovery.lean`
- `lake build TNLean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `leanblueprint checkdecls`
- full Blueprint PDF build (770 pages), with the new theorem pages visually inspected
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal proofs in relative-entropy/Petz recovery on singular supports; errors would misstate recovery identities used downstream (#4962), but scope is math formalization rather than runtime security.
> 
> **Overview**
> Adds **Petz recovery** when a tripartite state **saturates strong subadditivity**, specializing the existing DPI equality-to-recovery pipeline to the HJPW reference **ρ_A ⊗ ρ_BC** (no invertible marginals).
> 
> A new module proves **`product_marginal_support`** (bipartite states live in the support of marginal tensor products), then chains product-marginal DPI saturation to raw and **id_A ⊗** local Petz recovery on **ρ_AB**, including a **CPTP completed** local channel form aligned with HJPW eq. (11). Singular **ρ_A** is explicitly **supported-input only**, not a global completion factorization.
> 
> **`partialTraceRight_submatrix_prodAssoc`** and a commute identity for tracing A then C vs C then A are promoted to **`Entropy.lean`**; **`StrongSubadditivityPosDef`** drops duplicate reassociation proofs in favor of the shared lemma. Blueprint ch.19, paper-gap notes, tactic-pattern ledger, and the generated Schwarz import are synced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86199cd5c15b23165b2d87a1a4d8fa20c8c34a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->