### PR TITLE
feat(Channel/KoashiImoto): add invariant family fixed-point block form

### DIFF
--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -9,6 +9,7 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.Channel.KoashiImoto
 
 import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
+import TNLean.Channel.KoashiImoto.FamilyFixedPointBlockForm
 import TNLean.Channel.KoashiImoto.FiniteRealization
 import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.PooledKrausFamily

--- a/TNLean/Channel/KoashiImoto/FamilyFixedPointBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/FamilyFixedPointBlockForm.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.TraceAdjointDensityBlocks
+import TNLean.Channel.KoashiImoto.MeanErgodicProjection
+
+/-!
+# A simultaneous fixed-point block form for a preserved family of states
+
+The single preserving channel `F₀` constructed from a finite family of states fixes every
+member of that family.  The full-support density-block classification of its Schrödinger
+fixed points therefore gives one simultaneous direct-sum tensor form for all family members.
+The density matrix on the multiplicity factor is independent of the family member.
+
+This is the algebraic fixed-point statement underlying the projection classification in HJPW,
+arXiv:quant-ph/0304007v2, Appendix A, lines 853--856.  It stops before deriving positivity
+and normalizing the member-dependent matrix blocks into the probabilities and density
+matrices of Property 1 (lines 785--789); those steps begin at lines 857--858.
+
+## Main declaration
+
+* `Kraus.exists_commonInvariant_fixedPointBlockForm`: every state preserved by the common
+  witness `F₀` has the same density factors in one direct-sum tensor decomposition.
+
+**Scope restriction (full support):** The common average is assumed positive definite on the
+ambient space, in place of HJPW's reduction to the joint support (lines 761--763).  This is
+documented in `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+open Matrix
+
+namespace Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Simultaneous density-block form of a full-support invariant family.**
+
+For the single channel `F₀` preserving every `ρ x`, its Schrödinger fixed-point space has
+the form
+\[
+  U\left(\bigoplus_j \sigma_j\otimes M_{d_j}(\mathbb C)\right)U^*.
+\]
+Consequently every family member has one such block form, with the density matrices
+`σ j` independent of `x`.  This is the fixed-point step used in HJPW,
+arXiv:quant-ph/0304007v2, Appendix A, lines 853--856.
+
+No positivity or trace normalization is asserted for the matrices `X j`.  Thus the theorem
+does not claim the probability-density decomposition of HJPW Property 1 (lines 785--789);
+that normalization begins at lines 857--858.
+
+**Scope restriction (full support):** `hρbar` replaces HJPW's joint-support reduction
+(lines 761--763).  Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+theorem exists_commonInvariant_fixedPointBlockForm
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+      (U : Mat) (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ j, 0 < d j) ∧ (∀ j, 0 < m j) ∧
+        (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
+        ∀ x, ∃ X : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+          star U * ρ x * U =
+            Matrix.reindex e e (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ X j) := by
+  have hSchwarz :
+      IsSchwarzMap (Matrix.traceAdjointMap (commonInvariantMapLM hρbar)) := by
+    exact isSchwarzMap_traceAdjointMap_mapLM_of_isTP _
+      (commonInvariantKrausFamily hρbar).isPreserving.1
+  have hρbarFix : commonInvariantMapLM hρbar (commonAverage ρ) = commonAverage ρ := by
+    exact (commonInvariantKrausFamily hρbar).map_commonAverage
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, -, hfixed⟩ :=
+    (isPositiveMap_commonInvariantMapLM hρbar).exists_block_densities_of_meanErgodicProjection
+      (isTracePreservingMap_commonInvariantMapLM hρbar) hSchwarz hρbar hρbarFix
+  refine ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, ?_⟩
+  intro x
+  apply (hfixed (ρ x)).1
+  simpa only [commonInvariantMapLM, mapLM_apply] using
+    (commonInvariantKrausFamily hρbar).isPreserving.2 x
+
+end Kraus

--- a/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.KoashiImoto.SingleWitness
 import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
+import TNLean.Channel.Schwarz.KadisonSchwarz
 
 /-!
 # A trace-adjoint projection onto HJPW's common invariant algebra
@@ -29,6 +30,8 @@ trace-adjoint projection; that source identity remains a separate analytic state
   action is a trace-preserving map.
 * `Kraus.traceAdjointMap_mapLM`: the trace-pairing adjoint of a Kraus family's Schrödinger
   action is its Heisenberg adjoint map.
+* `Kraus.isSchwarzMap_traceAdjointMap_mapLM_of_isTP`: the trace adjoint of a
+  trace-preserving Kraus map satisfies the Schwarz inequality.
 * `Kraus.commonInvariantMeanErgodicProjection`: the trace-adjoint projection associated with
   the single witness `F_0`, derived via
   `IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`.
@@ -104,6 +107,17 @@ theorem traceAdjointMap_mapLM (K : Fin d → Mat) :
     (A := Matrix.traceAdjointMap (mapLM K) ρ) (B := adjointMapLM K ρ)).2 fun X => ?_
   rw [Matrix.trace_traceAdjointMap_mul, mapLM_apply, adjointMapLM_apply,
     trace_mul_map_eq_trace_adjointMap_mul]
+
+/-- **The trace adjoint of a trace-preserving Kraus map satisfies the Schwarz inequality.**
+
+After `Kraus.traceAdjointMap_mapLM` identifies the trace adjoint with the
+Heisenberg Kraus map, this is `KadisonSchwarz.kadison_schwarz_adjoint`. -/
+theorem isSchwarzMap_traceAdjointMap_mapLM_of_isTP (K : Fin d → Mat) (h_tp : IsTP K) :
+    IsSchwarzMap (Matrix.traceAdjointMap (mapLM K)) := by
+  intro A
+  have hKS := KadisonSchwarz.kadison_schwarz_adjoint K h_tp A
+  change (adjointMap K (Aᴴ * A) - (adjointMap K A)ᴴ * adjointMap K A).PosSemidef at hKS
+  simpa only [traceAdjointMap_mapLM, adjointMapLM_apply, adjointMap_conjTranspose] using hKS
 
 end TraceAdjointHeisenbergIdentification
 

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1431,6 +1431,48 @@ algebra of a family of jointly invariant states.
     range equal to the fixed-point set of $F_0^*$, which is $A_{F_0}=A_0$.
 \end{proof}
 
+\begin{theorem}[Simultaneous algebraic block form of the invariant family]
+    \label{thm:koashi_imoto_family_fixed_point_block_form}
+    \lean{Kraus.exists_commonInvariant_fixedPointBlockForm}
+    \leanok
+    \uses{def:koashi_imoto_preserving_average,
+        thm:koashi_imoto_single_witness,
+        thm:mean_ergodic_projection_density_block_form}
+    Under the hypotheses of
+    Definition~\ref{def:koashi_imoto_common_invariant_algebra}, there are
+    $L\in\N$, positive dimensions $d_\ell,m_\ell$, a unitary $U$, and density
+    matrices $\sigma_\ell\in\MN{m_\ell}$ such that, for every member $\rho_k$
+    of the invariant family, there are matrices
+    $X_{\ell,k}\in\MN{d_\ell}$ satisfying
+    \begin{align}
+        U^\dagger\rho_kU
+        &=
+        \bigoplus_{\ell=0}^{L-1}\sigma_\ell\otimes X_{\ell,k}.
+        \label{eq:koashi_imoto_family_fixed_point_block_form}
+    \end{align}
+    The density matrices $\sigma_\ell$ and the decomposition are common to
+    the whole family.
+
+    No positivity or trace normalization is asserted for the matrices
+    $X_{\ell,k}$. Thus this is the full-support fixed-point block form
+    underlying HJPW Appendix~A, lines 853--856, not the normalized
+    decomposition of Property~1.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:koashi_imoto_single_witness,
+        thm:mean_ergodic_projection_density_block_form}
+    Apply
+    Theorem~\ref{thm:mean_ergodic_projection_density_block_form} to the
+    Schr\"odinger map of the single operation $F_0$ from
+    Theorem~\ref{thm:koashi_imoto_single_witness}. Its adjoint satisfies the
+    Schwarz inequality by the Kraus form and trace preservation, and it fixes
+    the positive-definite common average. Since $F_0\rho_k=\rho_k$ for every
+    $k$, each family member belongs to the one fixed-point space
+    $U(\bigoplus_\ell\sigma_\ell\otimes\MN{d_\ell})U^\dagger$.
+\end{proof}
+
 \begin{theorem}[Hayashi SSA-equality characterization]
     \label{thm:hayashi_ssa_equality_characterization}
     \lean{hayashi_ssa_equality_characterization}
@@ -1462,13 +1504,15 @@ algebra of a family of jointly invariant states.
     Theorem~\ref{thm:koashi_imoto_common_invariant_algebra_block_form},
     Theorem~\ref{thm:koashi_imoto_single_witness}, and
     Definition~\ref{def:koashi_imoto_mean_ergodic_projection}) supply the
-    finite-dimensional operator-algebraic core of the Koashi--Imoto argument,
-    under an explicit full-support hypothesis on the common average in place
-    of the joint-support reduction. The resulting family-level
-    tensor-product state decomposition and the action of the middle-system
-    channel on the common direct-sum factors remain open. This forward
-    implication therefore remains axiomatic. The biconditional combines the
-    two directions.
+    finite-dimensional operator-algebraic core of the Koashi--Imoto argument.
+    Theorem~\ref{thm:koashi_imoto_family_fixed_point_block_form} also gives a
+    simultaneous algebraic tensor-block form for the invariant family, under
+    the same explicit full-support hypothesis on the common average in place
+    of the joint-support reduction. Normalizing the member-dependent blocks
+    into probabilities and density matrices, and proving the action of the
+    middle-system channel on the common direct-sum factors, remain open. This
+    forward implication therefore remains axiomatic. The biconditional
+    combines the two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -81,8 +81,12 @@ recovery-map theory and the Petz transpose channel, that is, the analysis of
 when the data-processing inequality for relative entropy is saturated and the
 reconstruction of the discarded subsystem from a recovery map. This recovery-map
 argument now includes the singular-support saturation-to-raw-recovery
-implication.  The subsequent family-level invariant-state and direct-sum
-analysis is still missing, which is why the forward direction is treated as an
+implication.  A simultaneous fixed-point block form for the preserved family
+is also available under a positive-definite common-average hypothesis. Its
+member-dependent blocks have not yet been proved positive and normalized into
+probabilities and density matrices, and the preserving-channel action on the
+common summands is still missing. Thus the family-level structural implication
+needed here remains open, which is why the forward direction is treated as an
 external assumption rather than proved.  The recovery implication and the
 complementary trace-preserving extension of the support Petz map are no longer
 part of this gap.

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -216,13 +216,25 @@ corresponding declarations are
   \leanid{Kraus.commonInvariantMeanErgodicProjection_isPositiveMap}\\
   \leanid{Kraus.commonInvariantMeanErgodicProjection_one}\\
   \leanid{Kraus.commonInvariantMeanErgodicProjection_idempotent}\\
-  \leanid{Kraus.mem_range_commonInvariantMeanErgodicProjection_iff}
+  \leanid{Kraus.mem_range_commonInvariantMeanErgodicProjection_iff}\\
+  \leanid{Kraus.exists_commonInvariant_fixedPointBlockForm}
 \end{center}
 in \doclink{TNLean/Channel/KoashiImoto/CommonInvariantAlgebra},
 \doclink{TNLean/Channel/KoashiImoto/FiniteRealization},
 \doclink{TNLean/Channel/KoashiImoto/PooledKrausFamily},
 \doclink{TNLean/Channel/KoashiImoto/SingleWitness}, and
-\doclink{TNLean/Channel/KoashiImoto/MeanErgodicProjection}.
+\doclink{TNLean/Channel/KoashiImoto/MeanErgodicProjection}.  The final
+declaration, in
+\doclink{TNLean/Channel/KoashiImoto/FamilyFixedPointBlockForm}, specializes
+the full-support density-block classification to $F_0$: one unitary
+direct-sum tensor decomposition and one family of density factors
+$\sigma_j$ work simultaneously for all $\rho_k$,
+\begin{align}
+  U^\dagger\rho_kU=\bigoplus_j\sigma_j\otimes X_{j,k}.
+\end{align}
+No positivity or trace normalization is yet asserted for the matrices
+$X_{j,k}$. This is the unnormalized fixed-point step underlying HJPW
+Appendix~A, lines 853--856, not Property~1.
 
 HJPW's argument reduces to the case where the common average
 $(1/K)\sum_k\rho_k$ has full support, by shrinking the working Hilbert space to
@@ -230,9 +242,10 @@ the joint support of the $\rho_k$ (lines 761--763). That reduction is not
 derived here: every declaration that builds $A_0$ instead takes positive
 definiteness of the common average as an explicit hypothesis. Beyond this
 scope restriction, none of the following are claimed: the joint-support
-reduction itself; the associated tensor-product state decomposition
-$\rho_k=\bigoplus_j q_{j|k}\rho_{j|k}\otimes\omega_j$; the middle-system
-block channel action on the summands; or elimination of the Hayashi
+reduction itself; positivity and normalization of the member-dependent
+matrices $X_{j,k}$ into the state decomposition
+$\rho_k=\bigoplus_j q_{j|k}\rho_{j|k}\otimes\omega_j$; the middle-system block
+channel action on the summands; or elimination of the Hayashi
 strong-subadditivity forward-implication axiom. These remain the open
 structural obstructions identified in the previous section.
 
@@ -252,10 +265,14 @@ $A_0$ of a finite family of jointly invariant states, its membership
 characterization, its generic block form, its finite realization by a single
 preserving operation $F_0$, and the positive unital idempotent projection
 $P_0^*$ onto it are formalized under an explicit full-support hypothesis on the
-common average, in place of HJPW's joint-support reduction. The Heisenberg
-Ces\`aro convergence identity for $P_0^*$, the joint-support reduction itself,
-the family-level tensor-product state decomposition, and the Koashi--Imoto
-channel-action theorem remain open as separate later steps.
+common average, in place of HJPW's joint-support reduction. A simultaneous
+algebraic block form
+$U^\dagger\rho_kU=\bigoplus_j\sigma_j\otimes X_{j,k}$ for the whole invariant
+family is also formalized. The Heisenberg Ces\`aro convergence identity for
+$P_0^*$, the joint-support reduction itself, normalization of the
+member-dependent matrices into the probability-density form of the
+Koashi--Imoto state decomposition, and the Koashi--Imoto channel-action
+theorem remain open as separate later steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
## Summary

Addresses part of #4962 by specializing the existing full-support density-block classification to the single preserving operation for a finite invariant family.

- add `Kraus.exists_commonInvariant_fixedPointBlockForm`, giving one unitary direct-sum tensor decomposition and common density factors for every family member
- add a reusable Schwarz-map bridge for the trace adjoint of a trace-preserving Kraus map
- document the precise HJPW Appendix A source boundary and update the Blueprint and paper-gap status

## Mathematical scope

This formalizes the algebraic fixed-point step at HJPW Appendix A, lines 853–856:

`U† ρₖ U = ⨁ⱼ σⱼ ⊗ Xⱼ,ₖ`.

It deliberately does **not** claim normalized HJPW Property 1. Positivity and trace normalization of the member-dependent blocks `Xⱼ,ₖ`, the joint-support reduction, and the preserving-channel action on the common factors remain open. The existing explicit `PosDef (commonAverage ρ)` hypothesis replaces HJPW's joint-support reduction, as recorded in `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.

The exact Koashi–Imoto source is HJPW arXiv:quant-ph/0304007v2 Appendix A; CPSV Appendix C.2 is a later consumer of this decomposition.

A later channel-action slice will likely need the decomposition coordinates tied explicitly to `commonInvariantStarSubalgebra`; that architectural strengthening is intentionally outside this PR.

## Validation

- `lake exe cache get` — reused 8,639 prebuilt Mathlib artifacts; Mathlib was not rebuilt from source
- `lake build TNLean` — 9,782 jobs passed; only the pre-existing `SectorMatch.lean` sorry warning remains
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`
- rendered PDF page containing the theorem inspected visually
- changed-file proof-integrity, line-length, and `git diff --check` scans

## Remaining work for #4962

The next source-faithful slice is to prove positivity of the member-dependent blocks and normalize nonzero-weight blocks into probabilities and density matrices. Joint-support reduction and channel action remain separate later steps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Lean theorems compose sensitive fixed-point and channel machinery; risk is moderate because changes are additive and scoped under an explicit PosDef common-average hypothesis, with no runtime or security surface.
> 
> **Overview**
> Adds **`Kraus.exists_commonInvariant_fixedPointBlockForm`**, showing that when the common average is positive definite, every state in a jointly preserved finite family shares one unitary direct-sum decomposition with common density factors σⱼ and member-dependent blocks Xⱼ,ₖ — the HJPW Appendix A fixed-point step (lines 853–856), **not** the normalized Property 1 decomposition.
> 
> A reusable lemma **`isSchwarzMap_traceAdjointMap_mapLM_of_isTP`** bridges trace-preserving Kraus maps to the Schwarz hypothesis needed by the existing mean-ergodic density-block classification. The proof instantiates that classification on the single witness channel F₀ and applies preservation ρₖ ↦ ρₖ.
> 
> Blueprint and paper-gap notes are updated to record this progress while **positivity/normalization of Xⱼ,ₖ**, joint-support reduction, and channel action on summands remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d7d862440200279ae6114ee2beb016d51ab3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->