### PR TITLE
feat(Channel/KoashiImoto): normalize invariant family block form

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -45,6 +45,7 @@ import TNLean.Algebra.PerronFrobenius
 import TNLean.Algebra.PiSigmaEquiv
 import TNLean.Algebra.PiTensorProductPhase
 import TNLean.Algebra.PosSemidefSupport
+import TNLean.Algebra.PositiveSemidefiniteNormalization
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.ScalarCommutant

--- a/TNLean/Algebra/PositiveSemidefiniteNormalization.lean
+++ b/TNLean/Algebra/PositiveSemidefiniteNormalization.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+
+/-!
+# Trace normalization of positive semidefinite matrices
+
+This file gives a total trace normalization for a positive semidefinite matrix on a
+nonempty finite-dimensional space.  When the trace vanishes, the normalized matrix is
+chosen to be the maximally mixed state; the original matrix then vanishes.
+
+## Main declarations
+
+* `Matrix.normalizePosSemidef`: total trace normalization.
+* `Matrix.normalizePosSemidef_posSemidef`: the normalized matrix is positive semidefinite.
+* `Matrix.normalizePosSemidef_trace`: the normalized matrix has trace one.
+* `Matrix.trace_re_smul_normalizePosSemidef`: multiplying by the original trace recovers
+  the matrix.
+* `Matrix.kronecker_eq_trace_re_mul_normalized`: normalization of two Kronecker factors.
+
+This total normalization makes explicit the normalization implicit in HJPW,
+arXiv:quant-ph/0304007v2, Appendix A, lines 857--858; the zero-trace branch is a local
+total choice.  The same normalization is used in CPSV, arXiv:1606.00608,
+Appendix C.2, lines 1614--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace Matrix
+
+/-- Normalize a positive semidefinite matrix by its trace, using the maximally mixed
+state when the trace vanishes. -/
+noncomputable def normalizePosSemidef
+    {n : Type*} [Fintype n] (_x₀ : n) (M : Matrix n n ℂ) :
+    Matrix n n ℂ := by
+  classical
+  exact if M.trace.re = 0 then
+      ((Fintype.card n : ℂ)⁻¹) • (1 : Matrix n n ℂ)
+    else
+      (((M.trace.re)⁻¹ : ℝ) : ℂ) • M
+
+/-- Trace normalization preserves positive semidefiniteness. -/
+theorem normalizePosSemidef_posSemidef
+    {n : Type*} [Fintype n] (x₀ : n)
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    (normalizePosSemidef x₀ M).PosSemidef := by
+  classical
+  letI : Nonempty n := ⟨x₀⟩
+  rw [normalizePosSemidef]
+  split_ifs with htr
+  · apply Matrix.PosSemidef.one.smul
+      (a := ((Fintype.card n : ℂ)⁻¹))
+    exact inv_nonneg_of_nonneg (by positivity : (0 : ℂ) ≤ Fintype.card n)
+  · apply hM.smul
+    exact_mod_cast inv_nonneg.mpr (Complex.nonneg_iff.mp hM.trace_nonneg).1
+
+/-- The total normalization has trace one. -/
+theorem normalizePosSemidef_trace
+    {n : Type*} [Fintype n] (x₀ : n)
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    (normalizePosSemidef x₀ M).trace = 1 := by
+  classical
+  letI : Nonempty n := ⟨x₀⟩
+  have htrace : M.trace = (M.trace.re : ℂ) := by
+    apply Complex.ext
+    · simp
+    · simpa using (Complex.nonneg_iff.mp hM.trace_nonneg).2.symm
+  rw [normalizePosSemidef]
+  split_ifs with htr
+  · rw [Matrix.trace_smul, Matrix.trace_one]
+    exact inv_mul_cancel₀ (by exact_mod_cast Fintype.card_ne_zero)
+  · rw [Matrix.trace_smul, htrace]
+    change ((M.trace.re⁻¹ : ℝ) : ℂ) * (M.trace.re : ℂ) = 1
+    exact_mod_cast inv_mul_cancel₀ htr
+
+/-- Multiplying the normalized matrix by the real part of the original trace recovers
+the positive semidefinite matrix. -/
+theorem trace_re_smul_normalizePosSemidef
+    {n : Type*} [Fintype n] (x₀ : n)
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    (M.trace.re : ℂ) • normalizePosSemidef x₀ M = M := by
+  classical
+  letI : Nonempty n := ⟨x₀⟩
+  have htrace : M.trace = (M.trace.re : ℂ) := by
+    apply Complex.ext
+    · simp
+    · simpa using (Complex.nonneg_iff.mp hM.trace_nonneg).2.symm
+  rw [normalizePosSemidef]
+  split_ifs with htr
+  · have htrace0 : M.trace = 0 := by
+      rw [htrace, htr]
+      exact Complex.ofReal_zero
+    have hM0 : M = 0 := hM.trace_eq_zero_iff.mp htrace0
+    rw [hM0]
+    simp
+  · rw [smul_smul]
+    rw [← Complex.ofReal_mul]
+    rw [mul_inv_cancel₀ htr]
+    simp
+
+/-- A Kronecker product of positive semidefinite matrices separates into the product
+of their traces and their normalized factors. -/
+theorem kronecker_eq_trace_re_mul_normalized
+    {m n : Type*} [Fintype m] [Fintype n] (x₀ : m) (y₀ : n)
+    {L : Matrix m m ℂ} {R : Matrix n n ℂ}
+    (hL : L.PosSemidef) (hR : R.PosSemidef) :
+    L ⊗ₖ R =
+      ((L.trace.re * R.trace.re : ℝ) : ℂ) •
+        (normalizePosSemidef x₀ L ⊗ₖ normalizePosSemidef y₀ R) := by
+  ext ⟨xL, xR⟩ ⟨yL, yR⟩
+  have hLe := congrFun (congrFun
+    (trace_re_smul_normalizePosSemidef x₀ hL) xL) yL
+  have hRe := congrFun (congrFun
+    (trace_re_smul_normalizePosSemidef y₀ hR) xR) yR
+  simp only [smul_apply] at hLe hRe
+  simp only [Matrix.kroneckerMap_apply, smul_apply]
+  rw [← hLe, ← hRe]
+  push_cast
+  ring
+
+end Matrix

--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -12,5 +12,6 @@ import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 import TNLean.Channel.KoashiImoto.FamilyFixedPointBlockForm
 import TNLean.Channel.KoashiImoto.FiniteRealization
 import TNLean.Channel.KoashiImoto.MeanErgodicProjection
+import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
 import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto/NormalizedFamilyBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/NormalizedFamilyBlockForm.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.PositiveSemidefiniteNormalization
+import TNLean.Algebra.TraceReindex
+import TNLean.Channel.KoashiImoto.FamilyFixedPointBlockForm
+
+/-!
+# A normalized block form for a preserved family of states
+
+For a finite family of density matrices with positive-definite common average, the common
+fixed-point decomposition can be normalized into member-dependent probabilities and density
+matrices.  The density matrix on the multiplicity factor remains common to the whole family.
+
+This is the full-support specialization of HJPW, arXiv:quant-ph/0304007v2, Property 1
+(lines 785--789).  The proof continues the fixed-point formula at lines 853--856 through
+the normalized state decomposition at lines 857--858.  The action of preserving operations
+on the common factors, beginning at line 860, is not included.
+
+## Main declaration
+
+* `Kraus.exists_commonInvariant_normalizedStateBlockForm`: a common direct-sum tensor
+  decomposition with member-dependent probability weights and density matrices.
+
+**Scope restriction (full support):** The common average is assumed positive definite on the
+ambient space, in place of HJPW's reduction to the joint support (lines 761--763).  This is
+documented in `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+open Matrix
+
+namespace Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Normalized state-block form of a full-support invariant family.**
+
+There is one direct-sum tensor decomposition in which every family member has the form
+\[
+  U^*\rho_xU=\bigoplus_j q_{j|x}\,\sigma_j\otimes\tau_{j|x}.
+\]
+The weights are nonnegative and sum to one, while both `σ j` and `τ x j` are density
+matrices.  The factors are ordered oppositely from HJPW Property 1: `σ j` is the common
+factor, corresponding to HJPW's `ω_j`.
+
+This is the full-support specialization of HJPW, arXiv:quant-ph/0304007v2, Property 1
+(lines 785--789), with its proof formula at lines 857--858.  At zero weight, `τ x j` is
+chosen to be maximally mixed; HJPW does not specify this irrelevant choice.
+
+**Scope restriction (full support):** `hρbar` replaces HJPW's joint-support reduction
+(lines 761--763).  Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+theorem exists_commonInvariant_normalizedStateBlockForm
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρpos : ∀ x, (ρ x).PosSemidef) (hρtrace : ∀ x, (ρ x).trace = 1)
+    (hρbar : (commonAverage ρ).PosDef) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+      (U : Mat) (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+      (q : Kidx → Fin K → ℝ)
+      (τ : Kidx → ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ j, 0 < d j) ∧ (∀ j, 0 < m j) ∧
+        (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
+        (∀ x j, 0 ≤ q x j) ∧ (∀ x, ∑ j, q x j = 1) ∧
+        (∀ x j, (τ x j).PosSemidef) ∧ (∀ x j, (τ x j).trace = 1) ∧
+        ∀ x, star U * ρ x * U =
+          Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦
+              (q x j : ℂ) • (σ j ⊗ₖ τ x j)) := by
+  classical
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hfamily⟩ :=
+    exists_commonInvariant_fixedPointBlockForm hρbar
+  choose X hXform using hfamily
+  have hXpos : ∀ x j, (X x j).PosSemidef := by
+    intro x j
+    have hreindexed :
+        (Matrix.reindex e e
+          (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X x k)).PosSemidef := by
+      rw [← hXform x]
+      simpa only [star_eq_conjTranspose] using
+        (hρpos x).conjTranspose_mul_mul_same U
+    have hblockDiagonal :
+        (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X x k).PosSemidef := by
+      have hprincipal := hreindexed.submatrix e
+      simpa only [Matrix.reindex_apply, Matrix.submatrix_submatrix,
+        Equiv.symm_comp_self, Matrix.submatrix_id_id] using hprincipal
+    have hblock : (σ j ⊗ₖ X x j).PosSemidef := by
+      have hprincipal := hblockDiagonal.submatrix (fun i ↦ ⟨j, i⟩)
+      have heq :
+          (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X x k).submatrix
+              (fun i ↦ ⟨j, i⟩) (fun i ↦ ⟨j, i⟩) =
+            σ j ⊗ₖ X x j := by
+        ext i k
+        exact Matrix.blockDiagonal'_apply_eq
+          (fun r : Fin K ↦ σ r ⊗ₖ X x r) j i k
+      rw [heq] at hprincipal
+      exact hprincipal
+    have hpartial := hblock.partialTraceLeft
+    simpa only [Matrix.partialTraceLeft_kronecker, hσtrace, one_smul] using hpartial
+  let q : Kidx → Fin K → ℝ := fun x j ↦ (X x j).trace.re
+  let τ : ∀ x j, Matrix (Fin (d j)) (Fin (d j)) ℂ :=
+    fun x j ↦ Matrix.normalizePosSemidef ⟨0, hd j⟩ (X x j)
+  have hqnonneg : ∀ x j, 0 ≤ q x j := by
+    intro x j
+    exact (Complex.nonneg_iff.mp (hXpos x j).trace_nonneg).1
+  have hqsum : ∀ x, ∑ j, q x j = 1 := by
+    intro x
+    have hUright : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hU
+    have htraceX : ∑ j, (X x j).trace = 1 := by
+      have htrace := congrArg Matrix.trace (hXform x)
+      rw [Matrix.trace_mul_cycle (star U) (ρ x) U, hUright, Matrix.one_mul,
+        hρtrace x, Matrix.trace_reindex, Matrix.trace_blockDiagonal'] at htrace
+      simpa only [Matrix.trace_kronecker, hσtrace, one_mul] using htrace.symm
+    change ∑ j, (X x j).trace.re = 1
+    calc
+      ∑ j, (X x j).trace.re =
+          Complex.reAddGroupHom (∑ j, (X x j).trace) :=
+        (map_sum Complex.reAddGroupHom (fun j ↦ (X x j).trace) Finset.univ).symm
+      _ = 1 := by rw [htraceX]; rfl
+  have hτpos : ∀ x j, (τ x j).PosSemidef := by
+    intro x j
+    exact Matrix.normalizePosSemidef_posSemidef ⟨0, hd j⟩ (hXpos x j)
+  have hτtrace : ∀ x j, (τ x j).trace = 1 := by
+    intro x j
+    exact Matrix.normalizePosSemidef_trace ⟨0, hd j⟩ (hXpos x j)
+  refine ⟨K, d, m, e, U, σ, q, τ, hU, hd, hm, hσpos, hσtrace,
+    hqnonneg, hqsum, hτpos, hτtrace, ?_⟩
+  intro x
+  rw [hXform x]
+  apply congrArg (Matrix.reindex e e)
+  congr 1
+  funext j
+  calc
+    σ j ⊗ₖ X x j =
+        σ j ⊗ₖ ((q x j : ℂ) • τ x j) := by
+      rw [Matrix.trace_re_smul_normalizePosSemidef ⟨0, hd j⟩ (hXpos x j)]
+    _ = (q x j : ℂ) • (σ j ⊗ₖ τ x j) := Matrix.kronecker_smul _ _ _
+
+end Kraus

--- a/TNLean/MPS/MPDO/CyclicActiveMarkovNormalization.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkovNormalization.lean
@@ -3,146 +3,16 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.PositiveSemidefiniteNormalization
 import TNLean.MPS.MPDO.CyclicActiveFourthRegion
 
 /-!
 # Positive normalization for cyclic-active Markov blocks
 
-This file collects the finite Kronecker-positivity and trace-normalization
+This compatibility module imports the common positive-semidefinite normalization
 lemmas used to turn the left and right cut factors into density matrices.
 
 ## Reference
 
 * arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
 -/
-
-open scoped Matrix BigOperators ComplexOrder Kronecker
-
-namespace Matrix
-
-/-- Normalize a positive semidefinite matrix by its trace, using the maximally
-mixed state when the trace vanishes.
-
-Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
-1614--1617.
-
-**Local fix (cyclic-active restriction):** This total normalization is applied
-to the positive path factors of the restricted two-step coefficient. See
-`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-noncomputable def normalizePosSemidef
-    {n : Type*} [Fintype n] (_x₀ : n) (M : Matrix n n ℂ) :
-    Matrix n n ℂ := by
-  classical
-  exact if M.trace.re = 0 then
-      ((Fintype.card n : ℂ)⁻¹) • (1 : Matrix n n ℂ)
-    else
-      (((M.trace.re)⁻¹ : ℝ) : ℂ) • M
-
-/-- Trace normalization preserves positive semidefiniteness.
-
-Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
-1614--1617.
-
-**Local fix (cyclic-active restriction):** This positivity statement is used
-for the normalized path factors of the restricted decomposition. See
-`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-theorem normalizePosSemidef_posSemidef
-    {n : Type*} [Fintype n] (x₀ : n)
-    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
-    (normalizePosSemidef x₀ M).PosSemidef := by
-  classical
-  letI : Nonempty n := ⟨x₀⟩
-  rw [normalizePosSemidef]
-  split_ifs with htr
-  · apply Matrix.PosSemidef.one.smul
-      (a := ((Fintype.card n : ℂ)⁻¹))
-    exact inv_nonneg_of_nonneg (by positivity : (0 : ℂ) ≤ Fintype.card n)
-  · apply hM.smul
-    exact_mod_cast inv_nonneg.mpr (Complex.nonneg_iff.mp hM.trace_nonneg).1
-
-/-- The total normalization has trace one.
-
-Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
-1614--1617.
-
-**Local fix (cyclic-active restriction):** This trace identity is used for the
-normalized path factors of the restricted decomposition. See
-`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-theorem normalizePosSemidef_trace
-    {n : Type*} [Fintype n] (x₀ : n)
-    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
-    (normalizePosSemidef x₀ M).trace = 1 := by
-  classical
-  letI : Nonempty n := ⟨x₀⟩
-  have htrace : M.trace = (M.trace.re : ℂ) := by
-    apply Complex.ext
-    · simp
-    · simpa using (Complex.nonneg_iff.mp hM.trace_nonneg).2.symm
-  rw [normalizePosSemidef]
-  split_ifs with htr
-  · rw [Matrix.trace_smul, Matrix.trace_one]
-    exact inv_mul_cancel₀ (by exact_mod_cast Fintype.card_ne_zero)
-  · rw [Matrix.trace_smul, htrace]
-    change ((M.trace.re⁻¹ : ℝ) : ℂ) * (M.trace.re : ℂ) = 1
-    exact_mod_cast inv_mul_cancel₀ htr
-
-/-- Multiplying the normalized matrix by the real part of the original trace
-recovers a positive semidefinite matrix.
-
-Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
-1614--1617.
-
-**Local fix (cyclic-active restriction):** This identity recovers the
-unnormalized path factors of the restricted decomposition. See
-`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-theorem trace_re_smul_normalizePosSemidef
-    {n : Type*} [Fintype n] (x₀ : n)
-    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
-    (M.trace.re : ℂ) • normalizePosSemidef x₀ M = M := by
-  classical
-  letI : Nonempty n := ⟨x₀⟩
-  have htrace : M.trace = (M.trace.re : ℂ) := by
-    apply Complex.ext
-    · simp
-    · simpa using (Complex.nonneg_iff.mp hM.trace_nonneg).2.symm
-  rw [normalizePosSemidef]
-  split_ifs with htr
-  · have htrace0 : M.trace = 0 := by
-      rw [htrace, htr]
-      exact Complex.ofReal_zero
-    have hM0 : M = 0 := hM.trace_eq_zero_iff.mp htrace0
-    rw [hM0]
-    simp
-  · rw [smul_smul]
-    rw [← Complex.ofReal_mul]
-    rw [mul_inv_cancel₀ htr]
-    simp
-
-/-- A Kronecker product of positive semidefinite matrices separates into the
-product of their traces and their normalized factors.
-
-Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
-1614--1617.
-
-**Local fix (cyclic-active restriction):** This identity normalizes the two
-positive path factors obtained from the restricted coefficient. See
-`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-theorem kronecker_eq_trace_re_mul_normalized
-    {m n : Type*} [Fintype m] [Fintype n] (x₀ : m) (y₀ : n)
-    {L : Matrix m m ℂ} {R : Matrix n n ℂ}
-    (hL : L.PosSemidef) (hR : R.PosSemidef) :
-    L ⊗ₖ R =
-      ((L.trace.re * R.trace.re : ℝ) : ℂ) •
-        (normalizePosSemidef x₀ L ⊗ₖ normalizePosSemidef y₀ R) := by
-  ext ⟨xL, xR⟩ ⟨yL, yR⟩
-  have hLe := congrFun (congrFun
-    (trace_re_smul_normalizePosSemidef x₀ hL) xL) yL
-  have hRe := congrFun (congrFun
-    (trace_re_smul_normalizePosSemidef y₀ hR) xR) yR
-  simp only [smul_apply] at hLe hRe
-  simp only [Matrix.kroneckerMap_apply, smul_apply]
-  rw [← hLe, ← hRe]
-  push_cast
-  ring
-
-end Matrix

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1473,6 +1473,50 @@ algebra of a family of jointly invariant states.
     $U(\bigoplus_\ell\sigma_\ell\otimes\MN{d_\ell})U^\dagger$.
 \end{proof}
 
+\begin{theorem}[Normalized state decomposition of a full-support invariant family]
+    \label{thm:koashi_imoto_normalized_family_block_form}
+    \lean{Kraus.exists_commonInvariant_normalizedStateBlockForm}
+    \leanok
+    \uses{thm:koashi_imoto_family_fixed_point_block_form}
+    Suppose in addition that every $\rho_k$ is positive semidefinite with
+    trace one. Under the explicit positive-definite common-average hypothesis
+    of Definition~\ref{def:koashi_imoto_common_invariant_algebra}, the common
+    decomposition of
+    Theorem~\ref{thm:koashi_imoto_family_fixed_point_block_form} admits
+    numbers $q_{\ell|k}\geq 0$ and density matrices
+    $\tau_{\ell|k}\in\MN{d_\ell}$ such that, for every $k$,
+    \begin{align}
+        \sum_{\ell=0}^{L-1}q_{\ell|k}&=1,
+        \label{eq:koashi_imoto_family_weights}\\
+        U^\dagger\rho_kU
+        &=
+        \bigoplus_{\ell=0}^{L-1}
+        q_{\ell|k}\,\sigma_\ell\otimes\tau_{\ell|k}.
+        \label{eq:koashi_imoto_normalized_family_block_form}
+    \end{align}
+    The density matrix $\sigma_\ell$ is independent of $k$. The tensor factors
+    are written in the reverse order from HJPW Property~1. This is the
+    full-support specialization of that state decomposition; no action of a
+    preserving operation on the summands is asserted.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:koashi_imoto_family_fixed_point_block_form}
+    Write the $\ell$-th block as
+    $\sigma_\ell\otimes X_{\ell,k}$. Positivity of $\rho_k$, compression to
+    this block, and the partial trace over the first factor show that
+    $X_{\ell,k}$ is positive semidefinite. Put
+    $q_{\ell|k}=\tr(X_{\ell,k})$. The trace-one identities for $\rho_k$ and
+    $\sigma_\ell$ give
+    $q_{\ell|k}\geq 0$ and
+    $\sum_\ell q_{\ell|k}=1$. For positive weight, divide
+    $X_{\ell,k}$ by its trace. At zero weight, positivity forces
+    $X_{\ell,k}=0$, so the maximally mixed density matrix may be chosen.
+    In both cases
+    $X_{\ell,k}=q_{\ell|k}\tau_{\ell|k}$.
+\end{proof}
+
 \begin{theorem}[Hayashi SSA-equality characterization]
     \label{thm:hayashi_ssa_equality_characterization}
     \lean{hayashi_ssa_equality_characterization}
@@ -1505,14 +1549,14 @@ algebra of a family of jointly invariant states.
     Theorem~\ref{thm:koashi_imoto_single_witness}, and
     Definition~\ref{def:koashi_imoto_mean_ergodic_projection}) supply the
     finite-dimensional operator-algebraic core of the Koashi--Imoto argument.
-    Theorem~\ref{thm:koashi_imoto_family_fixed_point_block_form} also gives a
-    simultaneous algebraic tensor-block form for the invariant family, under
-    the same explicit full-support hypothesis on the common average in place
-    of the joint-support reduction. Normalizing the member-dependent blocks
-    into probabilities and density matrices, and proving the action of the
-    middle-system channel on the common direct-sum factors, remain open. This
-    forward implication therefore remains axiomatic. The biconditional
-    combines the two directions.
+    Theorems~\ref{thm:koashi_imoto_family_fixed_point_block_form} and
+    \ref{thm:koashi_imoto_normalized_family_block_form} give the simultaneous
+    algebraic tensor-block form and its probability-density normalization,
+    under the same explicit full-support hypothesis on the common average in
+    place of the joint-support reduction. The joint-support reduction and the
+    action of the middle-system channel on the common direct-sum factors remain
+    open. This forward implication therefore remains axiomatic. The
+    biconditional combines the two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -81,13 +81,12 @@ recovery-map theory and the Petz transpose channel, that is, the analysis of
 when the data-processing inequality for relative entropy is saturated and the
 reconstruction of the discarded subsystem from a recovery map. This recovery-map
 argument now includes the singular-support saturation-to-raw-recovery
-implication.  A simultaneous fixed-point block form for the preserved family
-is also available under a positive-definite common-average hypothesis. Its
-member-dependent blocks have not yet been proved positive and normalized into
-probabilities and density matrices, and the preserving-channel action on the
-common summands is still missing. Thus the family-level structural implication
-needed here remains open, which is why the forward direction is treated as an
-external assumption rather than proved.  The recovery implication and the
+implication.  A simultaneous probability-density block form for the preserved
+family is also available under a positive-definite common-average hypothesis.
+The joint-support reduction and the preserving-channel action on the common
+summands are still missing. Thus the family-level structural implication needed
+here remains open, which is why the forward direction is treated as an external
+assumption rather than proved.  The recovery implication and the
 complementary trace-preserving extension of the support Petz map are no longer
 part of this gap.
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -173,9 +173,10 @@ strong-subadditivity equality assumption used in the CPSV16 argument.
 
 \section{Common invariant algebra: formalized under an explicit full-support hypothesis}
 
-A slice of the operator-algebraic Koashi--Imoto appendix (HJPW, Appendix A,
-lines 755--851) is now formalized independently of the product-reference
-recovery step above. For a finite, nonempty family of states $\rho_1,\dots,\rho_K$,
+A full-support specialization of a slice of the operator-algebraic
+Koashi--Imoto appendix (HJPW, Appendix A, lines 755--858) is now formalized
+independently of the product-reference recovery step above. For a finite,
+nonempty family of states $\rho_1,\dots,\rho_K$,
 the set
 \begin{align}
   {\bf F}=\bigl\{F:\forall k\ F\rho_k=\rho_k\bigr\}
@@ -217,13 +218,14 @@ corresponding declarations are
   \leanid{Kraus.commonInvariantMeanErgodicProjection_one}\\
   \leanid{Kraus.commonInvariantMeanErgodicProjection_idempotent}\\
   \leanid{Kraus.mem_range_commonInvariantMeanErgodicProjection_iff}\\
-  \leanid{Kraus.exists_commonInvariant_fixedPointBlockForm}
+  \leanid{Kraus.exists_commonInvariant_fixedPointBlockForm}\\
+  \leanid{Kraus.exists_commonInvariant_normalizedStateBlockForm}
 \end{center}
 in \doclink{TNLean/Channel/KoashiImoto/CommonInvariantAlgebra},
 \doclink{TNLean/Channel/KoashiImoto/FiniteRealization},
 \doclink{TNLean/Channel/KoashiImoto/PooledKrausFamily},
 \doclink{TNLean/Channel/KoashiImoto/SingleWitness}, and
-\doclink{TNLean/Channel/KoashiImoto/MeanErgodicProjection}.  The final
+\doclink{TNLean/Channel/KoashiImoto/MeanErgodicProjection}.  The penultimate
 declaration, in
 \doclink{TNLean/Channel/KoashiImoto/FamilyFixedPointBlockForm}, specializes
 the full-support density-block classification to $F_0$: one unitary
@@ -232,9 +234,21 @@ $\sigma_j$ work simultaneously for all $\rho_k$,
 \begin{align}
   U^\dagger\rho_kU=\bigoplus_j\sigma_j\otimes X_{j,k}.
 \end{align}
-No positivity or trace normalization is yet asserted for the matrices
-$X_{j,k}$. This is the unnormalized fixed-point step underlying HJPW
-Appendix~A, lines 853--856, not Property~1.
+The declaration in
+\doclink{TNLean/Channel/KoashiImoto/NormalizedFamilyBlockForm} assumes that
+the family members are density matrices, proves that the $X_{j,k}$ are
+positive semidefinite, and normalizes them as
+\begin{align}
+  X_{j,k}=q_{j|k}\tau_{j|k},
+  \qquad
+  q_{j|k}\geq 0,
+  \qquad
+  \sum_jq_{j|k}=1,
+\end{align}
+where each $\tau_{j|k}$ is a density matrix. Thus the full-support
+specialization of HJPW Property~1, lines 785--789 and 857--858, is formalized,
+with the two tensor factors written in the reverse order. The unrestricted
+property remains open pending the joint-support reduction.
 
 HJPW's argument reduces to the case where the common average
 $(1/K)\sum_k\rho_k$ has full support, by shrinking the working Hilbert space to
@@ -242,10 +256,8 @@ the joint support of the $\rho_k$ (lines 761--763). That reduction is not
 derived here: every declaration that builds $A_0$ instead takes positive
 definiteness of the common average as an explicit hypothesis. Beyond this
 scope restriction, none of the following are claimed: the joint-support
-reduction itself; positivity and normalization of the member-dependent
-matrices $X_{j,k}$ into the state decomposition
-$\rho_k=\bigoplus_j q_{j|k}\rho_{j|k}\otimes\omega_j$; the middle-system block
-channel action on the summands; or elimination of the Hayashi
+reduction itself; the middle-system block channel action on the summands; or
+elimination of the Hayashi
 strong-subadditivity forward-implication axiom. These remain the open
 structural obstructions identified in the previous section.
 
@@ -265,14 +277,13 @@ $A_0$ of a finite family of jointly invariant states, its membership
 characterization, its generic block form, its finite realization by a single
 preserving operation $F_0$, and the positive unital idempotent projection
 $P_0^*$ onto it are formalized under an explicit full-support hypothesis on the
-common average, in place of HJPW's joint-support reduction. A simultaneous
-algebraic block form
-$U^\dagger\rho_kU=\bigoplus_j\sigma_j\otimes X_{j,k}$ for the whole invariant
-family is also formalized. The Heisenberg Ces\`aro convergence identity for
-$P_0^*$, the joint-support reduction itself, normalization of the
-member-dependent matrices into the probability-density form of the
-Koashi--Imoto state decomposition, and the Koashi--Imoto channel-action
-theorem remain open as separate later steps.
+common average, in place of HJPW's joint-support reduction. The simultaneous
+state decomposition
+$U^\dagger\rho_kU=\bigoplus_jq_{j|k}\sigma_j\otimes\tau_{j|k}$ for the whole
+invariant family is also formalized, with nonnegative weights summing to one
+and density matrices on both tensor factors. The Heisenberg Ces\`aro
+convergence identity for $P_0^*$, the joint-support reduction itself, and the
+Koashi--Imoto channel-action theorem remain open as separate later steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Addresses part of #4962.

## Summary

- prove the normalized simultaneous block form for a finite invariant family of density matrices when the common average is positive definite
- construct nonnegative member-dependent weights summing to one and density blocks, including a total maximally mixed choice for zero-weight blocks
- promote the generic positive-semidefinite trace-normalization API from the MPS layer to `TNLean/Algebra`, while preserving the five existing declaration names and retaining the old MPS module as a compatibility re-export
- update the Blueprint and paper-gap documents to record this as the full-support specialization of HJPW Property 1

The tensor factors are written in the reverse order from HJPW: the common `σ_j` factor corresponds to HJPW's `ω_j`. The zero-weight convention is a local total choice; HJPW does not specify it.

## Scope

This PR deliberately stops before:

- the joint-support reduction that removes the positive-definite common-average hypothesis
- the action of a preserving channel on the direct-sum factors

Accordingly, #4962 remains open.

## Validation

- `lake exe cache get` (8,639 cached artifacts; no Mathlib source rebuild)
- `lake build TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm`
- `lake build TNLean` (9,784 jobs)
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf` (771 pages)
- visual inspection of the rendered theorem page
- `git diff --check`
- changed-Lean proof-integrity and 100-character line checks

Two read-only subagent reviews were serialized after the diff froze: Lean/API/layering reported no findings; source/Blueprint review identified two wording issues, which were fixed and re-reviewed with no residual findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean library additions and doc/blueprint sync with no runtime, auth, or data-path changes; main risk is proof/API layering mistakes, mitigated by full `TNLean` build and unchanged declaration names on the MPS re-export path.
> 
> **Overview**
> This PR **formalizes the normalized simultaneous block decomposition** for a finite family of density matrices preserved under a positive-definite common average: member weights `q_{j|x} ≥ 0` summing to 1 and trace-one blocks `τ_{j|x}`, via `Kraus.exists_commonInvariant_normalizedStateBlockForm`, building on the existing fixed-point block form and `Matrix.normalizePosSemidef` (maximally mixed when trace is zero).
> 
> **`Matrix.normalizePosSemidef` and its lemmas** move from `TNLean/MPS/MPDO/CyclicActiveMarkovNormalization.lean` into new `TNLean/Algebra/PositiveSemidefiniteNormalization.lean`; the MPS file becomes a thin compatibility import. Aggregators and Blueprint/paper-gap docs are updated to record this as the full-support HJPW Property 1 specialization (joint-support reduction and preserving-channel action on summands remain out of scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6f598e1b2de9624b63e849a91ab523d2355226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->