### PR TITLE
feat(Channel/KoashiImoto): formalize preserving-family block action

### DIFF
--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -286,6 +286,85 @@ theorem isBlockDiagonal'_of_commutes_blockProjection
 
 end Semiring
 
+section CommSemiring
+
+variable {R : Type*} [CommSemiring R]
+
+/-- The commutant of a dependent direct sum of full right matrix factors
+consists exactly of block-diagonal left-factor matrices. -/
+theorem commutes_blockDiagonal'_one_kronecker_iff
+    {m d : ι → Type*}
+    [Fintype ι] [(j : ι) → Fintype (m j)] [(j : ι) → DecidableEq (m j)]
+    [(j : ι) → Fintype (d j)] [(j : ι) → DecidableEq (d j)]
+    (X : Matrix ((j : ι) × (m j × d j)) ((j : ι) × (m j × d j)) R) :
+    (∀ B : (j : ι) → Matrix (d j) (d j) R,
+      X * Matrix.blockDiagonal' (fun j =>
+          (1 : Matrix (m j) (m j) R) ⊗ₖ B j) =
+        Matrix.blockDiagonal' (fun j =>
+          (1 : Matrix (m j) (m j) R) ⊗ₖ B j) * X) ↔
+    ∃ C : (j : ι) → Matrix (m j) (m j) R,
+      X = Matrix.blockDiagonal' (fun j =>
+        C j ⊗ₖ (1 : Matrix (d j) (d j) R)) := by
+  classical
+  constructor
+  · intro hComm
+    have hProjection (k : ι) :
+        Matrix.blockDiagonal' (fun j =>
+            (1 : Matrix (m j) (m j) R) ⊗ₖ
+              (Pi.single k (1 : Matrix (d k) (d k) R) :
+                (i : ι) → Matrix (d i) (d i) R) j) =
+          Matrix.blockProjection (n := fun j => m j × d j) (R := R) k := by
+      change Matrix.blockDiagonal' _ =
+        Matrix.blockDiagonal' (fun j =>
+          if j = k then (1 : Matrix (m j × d j) (m j × d j) R) else 0)
+      congr 1
+      funext j
+      by_cases hjk : j = k
+      · subst j
+        simp
+      · simp [hjk]
+    have hProjComm (k : ι) :
+        X * Matrix.blockProjection (n := fun j => m j × d j) (R := R) k =
+          Matrix.blockProjection (n := fun j => m j × d j) (R := R) k * X := by
+      rw [← hProjection k]
+      exact hComm (Pi.single k (1 : Matrix (d k) (d k) R))
+    obtain ⟨Xb, hX⟩ :=
+      Matrix.isBlockDiagonal'_of_commutes_blockProjection hProjComm
+    have hLocalComm (k : ι) (B : Matrix (d k) (d k) R) :
+        Xb k * ((1 : Matrix (m k) (m k) R) ⊗ₖ B) =
+          ((1 : Matrix (m k) (m k) R) ⊗ₖ B) * Xb k := by
+      have h := hComm
+        (Pi.single k B : (j : ι) → Matrix (d j) (d j) R)
+      rw [hX, ← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul] at h
+      have hFamilies := Matrix.blockDiagonal'_injective h
+      have hk := congrFun hFamilies k
+      simpa using hk
+    have hLocal (k : ι) :
+        ∃ Ck : Matrix (m k) (m k) R,
+          Xb k = Ck ⊗ₖ (1 : Matrix (d k) (d k) R) := by
+      apply Matrix.exists_eq_kronecker_one_of_intertwines_span_eq_top
+        (A := fun B : Matrix (d k) (d k) R => B)
+        (C := Xb k)
+      · rw [show Set.range (fun B : Matrix (d k) (d k) R => B) = Set.univ by
+              ext B
+              simp,
+          Submodule.span_univ]
+      · intro B
+        exact (hLocalComm k B).symm
+    choose C hC using hLocal
+    refine ⟨C, ?_⟩
+    rw [hX]
+    congr 1
+    funext k
+    exact hC k
+  · rintro ⟨C, rfl⟩ B
+    rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext k
+    simp only [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]
+
+end CommSemiring
+
 end BlockDiagonal
 
 end Matrix

--- a/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
+++ b/TNLean/Channel/FixedPoint/TraceAdjointDensityBlocks.lean
@@ -22,11 +22,13 @@ matrix-factor index.  Thus the left partial trace is over the multiplicity
 factor, and the Schrödinger-picture summand has the form
 $\sigma_k\otimes M_{d_k}(\mathbb C)$.
 
-## Main result
+## Main results
 
+* `IsPositiveMap.exists_block_densities_of_meanErgodicProjection_with_adjoint`:
+  the full-support density-block form in the same coordinates as the
+  trace-adjoint fixed-point algebra.
 * `IsPositiveMap.exists_block_densities_of_meanErgodicProjection`: the
-  full-support density-block form of the Cesàro projection and of the fixed
-  points.
+  corresponding Schrödinger-picture statement.
 
 ## References
 
@@ -106,7 +108,7 @@ complementary zero summand are completed in
 the opposite order.  Each summand is indexed by
 `Fin (m k) × Fin (d k)`, so `Matrix.partialTraceLeft` traces the multiplicity
 factor and the density block is $\sigma_k\otimes M_{d_k}(\mathbb C)$. -/
-theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection
+theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection_with_adjoint
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
     (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
@@ -120,6 +122,12 @@ theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection
       (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
       U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
         (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ A : Matrix (Fin D) (Fin D) ℂ,
+          Matrix.traceAdjointMap T A = A ↔
+            ∃ Y : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+              star U * A * U = Matrix.reindex e e
+                (Matrix.blockDiagonal' fun k ↦
+                  (1 : Matrix (Fin (m k)) (Fin (m k)) ℂ) ⊗ₖ Y k)) ∧
         (∀ k, (σ k).PosSemidef) ∧ (∀ k, (σ k).trace = 1) ∧
         (∀ B, P B = U * Matrix.reindex e e
           (Matrix.blockDiagonal' fun k ↦
@@ -134,7 +142,7 @@ theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection
   let P := LinearMap.meanErgodicProjection (𝕜 := ℂ)
     (E := Matrix (Fin D) (Fin D) ℂ) T
     (hT.hasBoundedOrbits_of_tracePreserving hTP)
-  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, _, hσpos, hσtrace, hFormula⟩ :=
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hBlock, hσpos, hσtrace, hFormula⟩ :=
     hT.exists_block_densities_of_adjoint_meanErgodicProjection hTP hSchwarz hρ hρfix
   have hPFormula : ∀ B, P B = U * Matrix.reindex e e
       (Matrix.blockDiagonal' fun k ↦
@@ -194,7 +202,7 @@ theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection
         exact (Matrix.trace_density_blockMap_mul_eq σ (Φ A) (Φ B)).symm
       _ = Matrix.trace (Φ.symm (G (Φ B)) * A) :=
         (Matrix.trace_unitaryReindexLinearEquiv_symm_mul e U hU _ _).symm
-  refine ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hPFormula, ?_⟩
+  refine ⟨K, d, m, e, U, σ, hU, hd, hm, hBlock, hσpos, hσtrace, hPFormula, ?_⟩
   intro B
   let Φ := Matrix.unitaryReindexLinearEquiv e U hU
   let G : Matrix ((k : Fin K) × (Fin (m k) × Fin (d k)))
@@ -244,3 +252,39 @@ theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection
           Matrix.unitaryReindexLinearEquiv_symm_apply] using hPFormula B
       _ = Φ.symm (Φ B) := by rw [hG]
       _ = B := Φ.symm_apply_apply B
+
+/-- **Schrödinger fixed-point blocks in the coordinates of the adjoint algebra.**
+
+This is the Schrödinger-picture projection of
+`IsPositiveMap.exists_block_densities_of_meanErgodicProjection_with_adjoint`.
+It retains the established API for clients that do not need the simultaneous
+trace-adjoint fixed-point characterization. -/
+theorem IsPositiveMap.exists_block_densities_of_meanErgodicProjection
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTP : IsTracePreservingMap T)
+    (hSchwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosDef) (hρfix : T ρ = ρ) :
+    let P := LinearMap.meanErgodicProjection (𝕜 := ℂ)
+      (E := Matrix (Fin D) (Fin D) ℂ) T
+      (hT.hasBoundedOrbits_of_tracePreserving hTP)
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((k : Fin K) × (Fin (m k) × Fin (d k))) ≃ Fin D)
+      (U : Matrix (Fin D) (Fin D) ℂ)
+      (σ : ∀ k, Matrix (Fin (m k)) (Fin (m k)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ k, 0 < d k) ∧ (∀ k, 0 < m k) ∧
+        (∀ k, (σ k).PosSemidef) ∧ (∀ k, (σ k).trace = 1) ∧
+        (∀ B, P B = U * Matrix.reindex e e
+          (Matrix.blockDiagonal' fun k ↦
+            σ k ⊗ₖ Matrix.partialTraceLeft
+              (Matrix.directSumBlockCompression (m := m) (d := d) k
+                (Matrix.reindex e.symm e.symm (star U * B * U)))) * star U) ∧
+        ∀ B, T B = B ↔
+          ∃ X : ∀ k, Matrix (Fin (d k)) (Fin (d k)) ℂ,
+            star U * B * U = Matrix.reindex e e
+              (Matrix.blockDiagonal' fun k ↦ σ k ⊗ₖ X k) := by
+  dsimp only
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, -, hσpos, hσtrace, hFormula, hFixed⟩ :=
+    hT.exists_block_densities_of_meanErgodicProjection_with_adjoint
+      hTP hSchwarz hρ hρfix
+  exact ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hFormula, hFixed⟩

--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -14,4 +14,5 @@ import TNLean.Channel.KoashiImoto.FiniteRealization
 import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
+import TNLean.Channel.KoashiImoto.PreservingBlockAction
 import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto/FamilyFixedPointBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/FamilyFixedPointBlockForm.lean
@@ -19,10 +19,11 @@ arXiv:quant-ph/0304007v2, Appendix A, lines 853--856.  It stops before deriving 
 and normalizing the member-dependent matrix blocks into the probabilities and density
 matrices of Property 1 (lines 785--789); those steps begin at lines 857--858.
 
-## Main declaration
+## Main declarations
 
-* `Kraus.exists_commonInvariant_fixedPointBlockForm`: every state preserved by the common
-  witness `F₀` has the same density factors in one direct-sum tensor decomposition.
+* `Kraus.exists_commonInvariant_fixedPointBlockForm_with_algebra`: the common invariant
+  algebra and every preserved state in the same coordinates.
+* `Kraus.exists_commonInvariant_fixedPointBlockForm`: the corresponding state-only result.
 
 **Scope restriction (full support):** The common average is assumed positive definite on the
 ambient space, in place of HJPW's reduction to the joint support (lines 761--763).  This is
@@ -56,6 +57,49 @@ that normalization begins at lines 857--858.
 **Scope restriction (full support):** `hρbar` replaces HJPW's joint-support reduction
 (lines 761--763).  Documented in
 `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+theorem exists_commonInvariant_fixedPointBlockForm_with_algebra
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+      (U : Mat) (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ j, 0 < d j) ∧ (∀ j, 0 < m j) ∧
+        (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
+        (∀ A : Mat, A ∈ commonInvariantStarSubalgebra ρ hρbar ↔
+          ∃ Y : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+            star U * A * U =
+              Matrix.reindex e e
+                (Matrix.blockDiagonal' fun j ↦
+                  (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ Y j)) ∧
+        ∀ x, ∃ X : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+          star U * ρ x * U =
+            Matrix.reindex e e (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ X j) := by
+  have hSchwarz :
+      IsSchwarzMap (Matrix.traceAdjointMap (commonInvariantMapLM hρbar)) := by
+    exact isSchwarzMap_traceAdjointMap_mapLM_of_isTP _
+      (commonInvariantKrausFamily hρbar).isPreserving.1
+  have hρbarFix : commonInvariantMapLM hρbar (commonAverage ρ) = commonAverage ρ := by
+    exact (commonInvariantKrausFamily hρbar).map_commonAverage
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hAdjoint, hσpos, hσtrace, -, hfixed⟩ :=
+    IsPositiveMap.exists_block_densities_of_meanErgodicProjection_with_adjoint
+      (isPositiveMap_commonInvariantMapLM hρbar)
+      (isTracePreservingMap_commonInvariantMapLM hρbar) hSchwarz hρbar hρbarFix
+  refine ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, ?_, ?_⟩
+  · intro A
+    rw [← adjointFixedPointsStarSubalgebra_commonInvariantKrausFamily hρbar,
+      mem_adjointFixedPointsStarSubalgebra]
+    change adjointMap (commonInvariantKrausFamily hρbar).Kfam A = A ↔ _
+    simpa only [commonInvariantMapLM, traceAdjointMap_mapLM, adjointMapLM_apply] using hAdjoint A
+  · intro x
+    apply (hfixed (ρ x)).1
+    simpa only [commonInvariantMapLM, mapLM_apply] using
+      (commonInvariantKrausFamily hρbar).isPreserving.2 x
+
+/-- **Simultaneous density-block form of a full-support invariant family.**
+
+This is the state-only projection of
+`exists_commonInvariant_fixedPointBlockForm_with_algebra`. -/
 theorem exists_commonInvariant_fixedPointBlockForm
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρbar : (commonAverage ρ).PosDef) :
@@ -68,19 +112,8 @@ theorem exists_commonInvariant_fixedPointBlockForm
         ∀ x, ∃ X : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
           star U * ρ x * U =
             Matrix.reindex e e (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ X j) := by
-  have hSchwarz :
-      IsSchwarzMap (Matrix.traceAdjointMap (commonInvariantMapLM hρbar)) := by
-    exact isSchwarzMap_traceAdjointMap_mapLM_of_isTP _
-      (commonInvariantKrausFamily hρbar).isPreserving.1
-  have hρbarFix : commonInvariantMapLM hρbar (commonAverage ρ) = commonAverage ρ := by
-    exact (commonInvariantKrausFamily hρbar).map_commonAverage
-  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, -, hfixed⟩ :=
-    (isPositiveMap_commonInvariantMapLM hρbar).exists_block_densities_of_meanErgodicProjection
-      (isTracePreservingMap_commonInvariantMapLM hρbar) hSchwarz hρbar hρbarFix
-  refine ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, ?_⟩
-  intro x
-  apply (hfixed (ρ x)).1
-  simpa only [commonInvariantMapLM, mapLM_apply] using
-    (commonInvariantKrausFamily hρbar).isPreserving.2 x
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, -, hfamily⟩ :=
+    exists_commonInvariant_fixedPointBlockForm_with_algebra hρbar
+  exact ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hfamily⟩
 
 end Kraus

--- a/TNLean/Channel/KoashiImoto/NormalizedFamilyBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/NormalizedFamilyBlockForm.lean
@@ -19,10 +19,12 @@ This is the full-support specialization of HJPW, arXiv:quant-ph/0304007v2, Prope
 the normalized state decomposition at lines 857--858.  The action of preserving operations
 on the common factors, beginning at line 860, is not included.
 
-## Main declaration
+## Main declarations
 
-* `Kraus.exists_commonInvariant_normalizedStateBlockForm`: a common direct-sum tensor
-  decomposition with member-dependent probability weights and density matrices.
+* `Kraus.exists_commonInvariant_normalizedStateBlockForm_with_algebra`: the common
+  invariant algebra and normalized family in the same coordinates.
+* `Kraus.exists_commonInvariant_normalizedStateBlockForm`: the corresponding state-only
+  result.
 
 **Scope restriction (full support):** The common average is assumed positive definite on the
 ambient space, in place of HJPW's reduction to the joint support (lines 761--763).  This is
@@ -55,7 +57,7 @@ chosen to be maximally mixed; HJPW does not specify this irrelevant choice.
 **Scope restriction (full support):** `hρbar` replaces HJPW's joint-support reduction
 (lines 761--763).  Documented in
 `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
-theorem exists_commonInvariant_normalizedStateBlockForm
+theorem exists_commonInvariant_normalizedStateBlockForm_with_algebra
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρpos : ∀ x, (ρ x).PosSemidef) (hρtrace : ∀ x, (ρ x).trace = 1)
     (hρbar : (commonAverage ρ).PosDef) :
@@ -69,13 +71,19 @@ theorem exists_commonInvariant_normalizedStateBlockForm
         (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
         (∀ x j, 0 ≤ q x j) ∧ (∀ x, ∑ j, q x j = 1) ∧
         (∀ x j, (τ x j).PosSemidef) ∧ (∀ x j, (τ x j).trace = 1) ∧
+        (∀ A : Mat, A ∈ commonInvariantStarSubalgebra ρ hρbar ↔
+          ∃ Y : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+            star U * A * U =
+              Matrix.reindex e e
+                (Matrix.blockDiagonal' fun j ↦
+                  (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ Y j)) ∧
         ∀ x, star U * ρ x * U =
           Matrix.reindex e e
             (Matrix.blockDiagonal' fun j ↦
               (q x j : ℂ) • (σ j ⊗ₖ τ x j)) := by
   classical
-  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hfamily⟩ :=
-    exists_commonInvariant_fixedPointBlockForm hρbar
+  obtain ⟨K, d, m, e, U, σ, hU, hd, hm, hσpos, hσtrace, hAlgebra, hfamily⟩ :=
+    exists_commonInvariant_fixedPointBlockForm_with_algebra hρbar
   choose X hXform using hfamily
   have hXpos : ∀ x j, (X x j).PosSemidef := by
     intro x j
@@ -130,7 +138,7 @@ theorem exists_commonInvariant_normalizedStateBlockForm
     intro x j
     exact Matrix.normalizePosSemidef_trace ⟨0, hd j⟩ (hXpos x j)
   refine ⟨K, d, m, e, U, σ, q, τ, hU, hd, hm, hσpos, hσtrace,
-    hqnonneg, hqsum, hτpos, hτtrace, ?_⟩
+    hqnonneg, hqsum, hτpos, hτtrace, hAlgebra, ?_⟩
   intro x
   rw [hXform x]
   apply congrArg (Matrix.reindex e e)
@@ -141,5 +149,33 @@ theorem exists_commonInvariant_normalizedStateBlockForm
         σ j ⊗ₖ ((q x j : ℂ) • τ x j) := by
       rw [Matrix.trace_re_smul_normalizePosSemidef ⟨0, hd j⟩ (hXpos x j)]
     _ = (q x j : ℂ) • (σ j ⊗ₖ τ x j) := Matrix.kronecker_smul _ _ _
+
+/-- **Normalized state-block form of a full-support invariant family.**
+
+This is the state-only projection of
+`exists_commonInvariant_normalizedStateBlockForm_with_algebra`. -/
+theorem exists_commonInvariant_normalizedStateBlockForm
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρpos : ∀ x, (ρ x).PosSemidef) (hρtrace : ∀ x, (ρ x).trace = 1)
+    (hρbar : (commonAverage ρ).PosDef) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+      (U : Mat) (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+      (q : Kidx → Fin K → ℝ)
+      (τ : Kidx → ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ j, 0 < d j) ∧ (∀ j, 0 < m j) ∧
+        (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
+        (∀ x j, 0 ≤ q x j) ∧ (∀ x, ∑ j, q x j = 1) ∧
+        (∀ x j, (τ x j).PosSemidef) ∧ (∀ x j, (τ x j).trace = 1) ∧
+        ∀ x, star U * ρ x * U =
+          Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦
+              (q x j : ℂ) • (σ j ⊗ₖ τ x j)) := by
+  obtain ⟨K, d, m, e, U, σ, q, τ, hU, hd, hm, hσpos, hσtrace,
+      hqnonneg, hqsum, hτpos, hτtrace, -, hfamily⟩ :=
+    exists_commonInvariant_normalizedStateBlockForm_with_algebra hρpos hρtrace hρbar
+  exact ⟨K, d, m, e, U, σ, q, τ, hU, hd, hm, hσpos, hσtrace,
+    hqnonneg, hqsum, hτpos, hτtrace, hfamily⟩
 
 end Kraus

--- a/TNLean/Channel/KoashiImoto/PreservingBlockAction.lean
+++ b/TNLean/Channel/KoashiImoto/PreservingBlockAction.lean
@@ -1,0 +1,507 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
+
+/-!
+# Block action of operations preserving a state family
+
+This file proves the operation-level part of the full-support
+Koashi--Imoto decomposition.  In the coordinates that put the common
+invariant algebra in the form
+`⊕ j, 1 ⊗ M (d j)`, every Kraus operator of every channel preserving the
+family lies in the commutant and hence has the form `⊕ j, C j ⊗ 1`.
+
+This is HJPW, arXiv:quant-ph/0304007v2, Property `2'`, lines 808--816,
+with the commutant argument from lines 860--882.
+
+## Main results
+
+* `Kraus.exists_adaptedKrausBlocks_of_isPreserving`: the Kraus operators of
+  an arbitrary preserving operation have the left-factor block form in the
+  fixed coordinates of the common invariant algebra.
+* `Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction`:
+  one decomposition simultaneously normalizes the invariant family and
+  describes the action of every preserving operation on each diagonal block.
+
+**Scope restriction (full support):** The positive-definite common-average
+hypothesis replaces HJPW's reduction to the joint support, lines 761--763.
+Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+
+**Convention (factor order):** TNLean orders each summand as the common
+density factor followed by the member-dependent factor, opposite to HJPW.
+Thus the preserving operation acts on the first factor and leaves the second
+factor unchanged.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+open Matrix
+
+namespace Kraus
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- **Adapted Kraus blocks for every preserving operation.**
+
+Fix coordinates realizing the common invariant algebra as
+`⊕ j, 1 ⊗ M (d j)`.  Every Kraus operator of an arbitrary CPTP operation
+preserving the family then belongs to its commutant, so in the same
+coordinates it is `⊕ j, C j ⊗ 1`.
+
+This is the Kraus-operator form of HJPW, arXiv:quant-ph/0304007v2,
+Property `2'`, lines 808--816, proved at lines 860--882.
+
+**Scope restriction (full support):** `hρbar` replaces HJPW's joint-support
+reduction, lines 761--763.  Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. -/
+theorem exists_adaptedKrausBlocks_of_isPreserving
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef)
+    {K : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+    (U : Mat) (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (hAlgebra : ∀ A : Mat, A ∈ commonInvariantStarSubalgebra ρ hρbar ↔
+      ∃ Y : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+        star U * A * U =
+          Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦
+              (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ Y j))
+    (F : PreservingKrausFamily ρ) :
+    ∃ C : (i : Fin F.numKraus) → ∀ j,
+        Matrix (Fin (m j)) (Fin (m j)) ℂ,
+      ∀ i,
+        Matrix.unitaryReindexLinearEquiv e U hU (F.Kfam i) =
+          Matrix.blockDiagonal' fun j ↦
+            C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ) := by
+  classical
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  have hA₀_le :
+      commonInvariantStarSubalgebra ρ hρbar ≤
+        krausCommutantStarSubalgebra (K := F.Kfam) := by
+    apply le_krausCommutantStarSubalgebra_of_le_adjointFixedPoints
+      (K := F.Kfam) F.isPreserving.1
+    intro A hA
+    exact (mem_commonInvariantStarSubalgebra ρ hρbar A).1 hA F
+  have hComm (i : Fin F.numKraus)
+      (B : (j : Fin K) → Matrix (Fin (d j)) (Fin (d j)) ℂ) :
+      Φ (F.Kfam i) *
+          Matrix.blockDiagonal' (fun j ↦
+            (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j) =
+        Matrix.blockDiagonal' (fun j ↦
+            (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j) *
+          Φ (F.Kfam i) := by
+    let R := Matrix.blockDiagonal' fun j ↦
+      (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ B j
+    let A := Φ.symm R
+    have hΦA : Φ A = R := Φ.apply_symm_apply R
+    have hA : A ∈ commonInvariantStarSubalgebra ρ hρbar := by
+      apply (hAlgebra A).2
+      refine ⟨B, ?_⟩
+      have hUleft : star U * U = 1 := Matrix.mem_unitaryGroup_iff'.mp hU
+      simp only [A, Φ, Matrix.unitaryReindexLinearEquiv_symm_apply,
+        Matrix.mul_assoc, hUleft, Matrix.mul_one]
+      rw [← Matrix.mul_assoc, hUleft, Matrix.one_mul]
+    have hAK : A * F.Kfam i = F.Kfam i * A := (hA₀_le hA i).1
+    change Φ (F.Kfam i) * R = R * Φ (F.Kfam i)
+    calc
+      Φ (F.Kfam i) * R = Φ (F.Kfam i) * Φ A := by rw [hΦA]
+      _ = Φ (F.Kfam i * A) :=
+        (Matrix.unitaryReindexLinearEquiv_mul e U hU _ _).symm
+      _ = Φ (A * F.Kfam i) := congrArg Φ hAK.symm
+      _ = Φ A * Φ (F.Kfam i) :=
+        Matrix.unitaryReindexLinearEquiv_mul e U hU _ _
+      _ = R * Φ (F.Kfam i) := by rw [hΦA]
+  have hBlocks (i : Fin F.numKraus) :
+      ∃ Ci : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ,
+        Φ (F.Kfam i) =
+          Matrix.blockDiagonal' fun j ↦
+            Ci j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ) :=
+    (Matrix.commutes_blockDiagonal'_one_kronecker_iff (Φ (F.Kfam i))).1
+      (hComm i)
+  choose C hC using hBlocks
+  exact ⟨C, hC⟩
+
+/-- Trace preservation descends from an adapted global Kraus family to each
+left-factor Kraus family. -/
+theorem isTP_adaptedKrausBlocks
+    {r K : ℕ} {d m : Fin K → ℕ}
+    {D : ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (L : Fin r → Matrix (Fin D) (Fin D) ℂ) (hL : IsTP L)
+    (C : (i : Fin r) → ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (hC : ∀ i,
+      Matrix.unitaryReindexLinearEquiv e U hU (L i) =
+        Matrix.blockDiagonal' fun j ↦
+          C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ))
+    (hd : ∀ j, 0 < d j) :
+    ∀ j, IsTP (fun i ↦ C i j) := by
+  classical
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  have hΦTP : IsTP (fun i ↦ Φ (L i)) := by
+    unfold IsTP
+    calc
+      ∑ i, star (Φ (L i)) * Φ (L i) =
+          ∑ i, Φ (star (L i) * L i) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [Matrix.unitaryReindexLinearEquiv_mul,
+          Matrix.unitaryReindexLinearEquiv_star]
+      _ = Φ (∑ i, star (L i) * L i) :=
+        (map_sum Φ (fun i ↦ star (L i) * L i) Finset.univ).symm
+      _ = Φ 1 := congrArg Φ hL
+      _ = 1 := Matrix.unitaryReindexLinearEquiv_one e U hU
+  intro j
+  unfold IsTP at hΦTP ⊢
+  dsimp only [Φ] at hΦTP
+  have hBlock := congrArg
+    (Matrix.directSumBlockCompression (m := m) (d := d) j) hΦTP
+  simp_rw [hC] at hBlock
+  simp only [map_sum, Matrix.blockDiagonal'_conjTranspose,
+    ← Matrix.blockDiagonal'_mul,
+    Matrix.directSumBlockCompression_blockDiagonal',
+    Matrix.directSumBlockCompression_one,
+    Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one,
+    ← Matrix.mul_kronecker_mul] at hBlock
+  let z : Fin (d j) := ⟨0, hd j⟩
+  ext a b
+  have hEntry := congrFun (congrFun hBlock (a, z)) (b, z)
+  simpa only [Matrix.star_eq_conjTranspose, Matrix.sum_apply,
+    Matrix.kroneckerMap_apply, Matrix.one_apply, Matrix.one_mul, z, if_true,
+    mul_one, Prod.mk.injEq, and_true] using hEntry
+
+/-- In adapted coordinates, a preserving Kraus map acts on a simple tensor
+in one diagonal summand through the left-factor Kraus family and leaves the
+right factor unchanged. -/
+theorem map_adapted_singleBlock_kronecker
+    {r K D : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (L : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (C : (i : Fin r) → ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (hC : ∀ i,
+      Matrix.unitaryReindexLinearEquiv e U hU (L i) =
+        Matrix.blockDiagonal' fun j ↦
+          C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ))
+    (j : Fin K) (A : Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (B : Matrix (Fin (d j)) (Fin (d j)) ℂ) :
+    Matrix.unitaryReindexLinearEquiv e U hU
+        (map L ((Matrix.unitaryReindexLinearEquiv e U hU).symm
+          (Matrix.directSumBlockEmbedding (m := m) (d := d) j (A ⊗ₖ B)))) =
+      Matrix.directSumBlockEmbedding (m := m) (d := d) j
+        (map (fun i ↦ C i j) A ⊗ₖ B) := by
+  classical
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  change Φ (∑ i, L i * Φ.symm
+      (Matrix.directSumBlockEmbedding (m := m) (d := d) j (A ⊗ₖ B)) *
+        star (L i)) = _
+  rw [map_sum]
+  dsimp only [Φ]
+  simp_rw [Matrix.unitaryReindexLinearEquiv_mul,
+    Matrix.unitaryReindexLinearEquiv_star, LinearEquiv.apply_symm_apply, hC]
+  simp only [Matrix.star_eq_conjTranspose]
+  simp_rw [Matrix.blockDiagonal'_conjTranspose]
+  simp_rw [Matrix.blockDiagonal'_mul_directSumBlockEmbedding_mul_blockDiagonal']
+  simp only [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one]
+  unfold map
+  rw [← map_sum (Matrix.directSumBlockEmbedding (m := m) (d := d) j)]
+  apply congrArg (Matrix.directSumBlockEmbedding (m := m) (d := d) j)
+  calc
+    ∑ i, (C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) *
+          (A ⊗ₖ B) *
+          ((C i j)ᴴ ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) =
+        ∑ i, (C i j * A * (C i j)ᴴ) ⊗ₖ B := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+        Matrix.one_mul, Matrix.mul_one]
+    _ = (∑ i, C i j * A * (C i j)ᴴ) ⊗ₖ B := by
+      exact (map_sum ((Matrix.kroneckerBilinear (R := ℂ)).flip B)
+        (fun i ↦ C i j * A * (C i j)ᴴ) Finset.univ).symm
+
+/-- The simple-tensor block action assembles over all diagonal summands. -/
+theorem map_adapted_blockDiagonal_kronecker
+    {r K D : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+    (U : Matrix (Fin D) (Fin D) ℂ)
+    (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (L : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (C : (i : Fin r) → ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (hC : ∀ i,
+      Matrix.unitaryReindexLinearEquiv e U hU (L i) =
+        Matrix.blockDiagonal' fun j ↦
+          C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ))
+    (A : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (B : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ) :
+    Matrix.unitaryReindexLinearEquiv e U hU
+        (map L ((Matrix.unitaryReindexLinearEquiv e U hU).symm
+          (Matrix.blockDiagonal' fun j ↦ A j ⊗ₖ B j))) =
+      Matrix.blockDiagonal' fun j ↦ map (fun i ↦ C i j) (A j) ⊗ₖ B j := by
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  have hInput := Matrix.sum_directSumBlockEmbedding_eq_blockDiagonal'
+    (m := m) (d := d) (fun j ↦ A j ⊗ₖ B j)
+  have hOutput := Matrix.sum_directSumBlockEmbedding_eq_blockDiagonal'
+    (m := m) (d := d) (fun j ↦ map (fun i ↦ C i j) (A j) ⊗ₖ B j)
+  calc
+    Φ (map L (Φ.symm (Matrix.blockDiagonal' fun j ↦ A j ⊗ₖ B j))) =
+        Φ (map L (Φ.symm (∑ j,
+          Matrix.directSumBlockEmbedding (m := m) (d := d) j (A j ⊗ₖ B j)))) := by
+      rw [hInput]
+    _ = Φ (map L (∑ j, Φ.symm
+          (Matrix.directSumBlockEmbedding (m := m) (d := d) j (A j ⊗ₖ B j)))) := by
+      rw [map_sum]
+    _ = Φ (∑ j, map L (Φ.symm
+          (Matrix.directSumBlockEmbedding (m := m) (d := d) j (A j ⊗ₖ B j)))) := by
+      change Φ (mapLM L (∑ j, Φ.symm
+        (Matrix.directSumBlockEmbedding (m := m) (d := d) j (A j ⊗ₖ B j)))) = _
+      rw [map_sum]
+      rfl
+    _ = ∑ j, Φ (map L (Φ.symm
+          (Matrix.directSumBlockEmbedding (m := m) (d := d) j (A j ⊗ₖ B j)))) := by
+      rw [map_sum]
+    _ = ∑ j, Matrix.directSumBlockEmbedding (m := m) (d := d) j
+          (map (fun i ↦ C i j) (A j) ⊗ₖ B j) := by
+      apply Finset.sum_congr rfl
+      intro j _
+      exact map_adapted_singleBlock_kronecker e U hU L C hC j (A j) (B j)
+    _ = Matrix.blockDiagonal' (fun j ↦
+          map (fun i ↦ C i j) (A j) ⊗ₖ B j) := hOutput
+
+/-- Positive definiteness of the common average forces every block of a
+normalized invariant-family decomposition to occur with positive weight in
+at least one family member. -/
+theorem exists_pos_normalizedBlockWeight
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef)
+    {K : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+    (U : Mat) (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (hd : ∀ j, 0 < d j) (hm : ∀ j, 0 < m j)
+    (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (q : Kidx → Fin K → ℝ)
+    (τ : Kidx → ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ)
+    (hqnonneg : ∀ x j, 0 ≤ q x j)
+    (hfamily : ∀ x, star U * ρ x * U =
+      Matrix.reindex e e
+        (Matrix.blockDiagonal' fun j ↦
+          (q x j : ℂ) • (σ j ⊗ₖ τ x j))) :
+    ∀ j, ∃ x, 0 < q x j := by
+  classical
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  have hΦρ (x : Kidx) :
+      Φ (ρ x) = Matrix.blockDiagonal' (fun j ↦
+        (q x j : ℂ) • (σ j ⊗ₖ τ x j)) := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply, hfamily x]
+    ext i j
+    simp
+  have hΦbar :
+      Φ (commonAverage ρ) =
+        (Fintype.card Kidx : ℂ)⁻¹ • ∑ x,
+          Matrix.blockDiagonal' (fun j ↦
+            (q x j : ℂ) • (σ j ⊗ₖ τ x j)) := by
+    unfold commonAverage
+    rw [Φ.map_smul, map_sum Φ]
+    congr 1
+    exact Finset.sum_congr rfl fun x _ ↦ hΦρ x
+  let Uunitary : unitary Mat := ⟨U, hU⟩
+  have hUunit : IsUnit U := ⟨Unitary.toUnits Uunitary, rfl⟩
+  have hΦbarPD : (Φ (commonAverage ρ)).PosDef := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply]
+    have hconj : (star U * commonAverage ρ * U).PosDef := by
+      simpa only [Matrix.star_eq_conjTranspose] using
+        hρbar.conjTranspose_mul_mul_same
+          (Matrix.mulVec_injective_iff_isUnit.mpr hUunit)
+    exact hconj.submatrix e.injective
+  intro j
+  by_contra hpos
+  push Not at hpos
+  have hzero (x : Kidx) : q x j = 0 :=
+    le_antisymm (hpos x) (hqnonneg x j)
+  have hblockPD :
+      (Matrix.directSumBlockCompression (m := m) (d := d) j
+        (Φ (commonAverage ρ))).PosDef := by
+    change ((Φ (commonAverage ρ)).submatrix
+      (fun i ↦ ⟨j, i⟩) (fun i ↦ ⟨j, i⟩)).PosDef
+    exact hΦbarPD.submatrix
+      (fun _ _ hij ↦ eq_of_heq (Sigma.mk.inj_iff.mp hij).2)
+  have hz : Matrix.directSumBlockCompression (m := m) (d := d) j
+      (Φ (commonAverage ρ)) = 0 := by
+    rw [hΦbar]
+    simp [hzero, Matrix.directSumBlockCompression_blockDiagonal']
+  letI : Nonempty (Fin (m j)) := Fin.pos_iff_nonempty.mp (hm j)
+  letI : Nonempty (Fin (d j)) := Fin.pos_iff_nonempty.mp (hd j)
+  exact hblockPD.isUnit.ne_zero hz
+
+/-- Every local left-factor channel fixes the common density matrix of its
+block. -/
+theorem map_adaptedKrausBlock_sigma
+    {Kidx : Type*} [Nonempty Kidx] {ρ : Kidx → Mat}
+    {K : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+    (U : Mat) (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (q : Kidx → Fin K → ℝ)
+    (τ : Kidx → ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ)
+    (hτtrace : ∀ x j, (τ x j).trace = 1)
+    (hfamily : ∀ x, star U * ρ x * U =
+      Matrix.reindex e e
+        (Matrix.blockDiagonal' fun j ↦
+          (q x j : ℂ) • (σ j ⊗ₖ τ x j)))
+    (hqpos : ∀ j, ∃ x, 0 < q x j)
+    (F : PreservingKrausFamily ρ)
+    (C : (i : Fin F.numKraus) → ∀ j,
+      Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (hC : ∀ i,
+      Matrix.unitaryReindexLinearEquiv e U hU (F.Kfam i) =
+        Matrix.blockDiagonal' fun j ↦
+          C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) :
+    ∀ j, map (fun i ↦ C i j) (σ j) = σ j := by
+  classical
+  let Φ := Matrix.unitaryReindexLinearEquiv e U hU
+  have hΦρ (x : Kidx) :
+      Φ (ρ x) = Matrix.blockDiagonal' (fun j ↦
+        ((q x j : ℂ) • σ j) ⊗ₖ τ x j) := by
+    rw [Matrix.unitaryReindexLinearEquiv_apply, hfamily x]
+    ext i j
+    simp [Matrix.smul_kronecker]
+  intro j
+  obtain ⟨x, hqx⟩ := hqpos j
+  have hAction := map_adapted_blockDiagonal_kronecker e U hU F.Kfam C hC
+    (fun k ↦ (q x k : ℂ) • σ k) (τ x)
+  rw [← hΦρ x, Φ.symm_apply_apply] at hAction
+  have hFixCoord := congrArg Φ (F.isPreserving.2 x)
+  have hBlocks :
+      Matrix.blockDiagonal' (fun k ↦
+          map (fun i ↦ C i k) ((q x k : ℂ) • σ k) ⊗ₖ τ x k) =
+        Matrix.blockDiagonal' (fun k ↦
+          ((q x k : ℂ) • σ k) ⊗ₖ τ x k) := by
+    exact hAction.symm.trans (hFixCoord.trans (hΦρ x))
+  have hBlock := congrArg
+    (Matrix.directSumBlockCompression (m := m) (d := d) j) hBlocks
+  simp only [Matrix.directSumBlockCompression_blockDiagonal'] at hBlock
+  have hPartial := congrArg Matrix.partialTraceRight hBlock
+  simp only [Matrix.partialTraceRight_kronecker, hτtrace x j, one_smul,
+    map_smul] at hPartial
+  have hqC : (q x j : ℂ) ≠ 0 := by
+    exact_mod_cast ne_of_gt hqx
+  exact smul_right_injective _ hqC hPartial
+
+/-- The adapted Kraus blocks of an arbitrary preserving operation form local
+trace-preserving Kraus families and give the one-block action on simple
+tensors. -/
+theorem exists_adaptedKrausBlocks_isTP_and_map
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef)
+    {K : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+    (U : Mat) (hU : U ∈ Matrix.unitaryGroup (Fin D) ℂ)
+    (hd : ∀ j, 0 < d j)
+    (hAlgebra : ∀ A : Mat, A ∈ commonInvariantStarSubalgebra ρ hρbar ↔
+      ∃ Y : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+        star U * A * U =
+          Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦
+              (1 : Matrix (Fin (m j)) (Fin (m j)) ℂ) ⊗ₖ Y j))
+    (F : PreservingKrausFamily ρ) :
+    ∃ C : (i : Fin F.numKraus) → ∀ j,
+        Matrix (Fin (m j)) (Fin (m j)) ℂ,
+      (∀ i,
+        Matrix.unitaryReindexLinearEquiv e U hU (F.Kfam i) =
+          Matrix.blockDiagonal' fun j ↦
+            C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) ∧
+      (∀ j, IsTP (fun i ↦ C i j)) ∧
+      ∀ j (A : Matrix (Fin (m j)) (Fin (m j)) ℂ)
+          (B : Matrix (Fin (d j)) (Fin (d j)) ℂ),
+        Matrix.unitaryReindexLinearEquiv e U hU
+            (map F.Kfam ((Matrix.unitaryReindexLinearEquiv e U hU).symm
+              (Matrix.directSumBlockEmbedding (m := m) (d := d) j (A ⊗ₖ B)))) =
+          Matrix.directSumBlockEmbedding (m := m) (d := d) j
+            (map (fun i ↦ C i j) A ⊗ₖ B) := by
+  obtain ⟨C, hC⟩ :=
+    exists_adaptedKrausBlocks_of_isPreserving hρbar e U hU hAlgebra F
+  refine ⟨C, hC, isTP_adaptedKrausBlocks e U hU F.Kfam
+    F.isPreserving.1 C hC hd, ?_⟩
+  intro j A B
+  exact map_adapted_singleBlock_kronecker e U hU F.Kfam C hC j A B
+
+/-- **Normalized invariant-family blocks and the action of every preserving
+operation.**
+
+There is one direct-sum tensor decomposition in which every family member is
+`⊕ j, q_{j|x} σ_j ⊗ τ_{j|x}` and every preserving CPTP operation has, on the
+`j`-th diagonal summand, a local CPTP Kraus family `C_j` acting on `σ_j` and
+the identity action on the member-dependent factor.  Moreover
+`map C_j σ_j = σ_j`.
+
+This is the full-support specialization of HJPW,
+arXiv:quant-ph/0304007v2, Properties 1 and `2'`, lines 785--816, with the
+operation-level proof at lines 860--882.
+
+**Scope restriction (full support):** `hρbar` replaces HJPW's reduction to
+the joint support, lines 761--763.  Documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+
+**Convention (factor order):** TNLean writes `σ_j ⊗ τ_{j|x}`, opposite to
+HJPW's order.  Thus the local channel acts on the first factor. -/
+theorem exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρpos : ∀ x, (ρ x).PosSemidef) (hρtrace : ∀ x, (ρ x).trace = 1)
+    (hρbar : (commonAverage ρ).PosDef) :
+    ∃ (K : ℕ) (d m : Fin K → ℕ)
+      (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin D)
+      (U : Mat) (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+      (q : Kidx → Fin K → ℝ)
+      (τ : Kidx → ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ),
+      U ∈ Matrix.unitaryGroup (Fin D) ℂ ∧
+        (∀ j, 0 < d j) ∧ (∀ j, 0 < m j) ∧
+        (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
+        (∀ x j, 0 ≤ q x j) ∧ (∀ x, ∑ j, q x j = 1) ∧
+        (∀ x j, (τ x j).PosSemidef) ∧ (∀ x j, (τ x j).trace = 1) ∧
+        (∀ x, star U * ρ x * U =
+          Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦
+              (q x j : ℂ) • (σ j ⊗ₖ τ x j))) ∧
+        ∀ F : PreservingKrausFamily ρ,
+          ∃ C : (i : Fin F.numKraus) → ∀ j,
+              Matrix (Fin (m j)) (Fin (m j)) ℂ,
+            (∀ i,
+              Matrix.reindex e.symm e.symm (star U * F.Kfam i * U) =
+                Matrix.blockDiagonal' fun j ↦
+                  C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) ∧
+            (∀ j, IsTP (fun i ↦ C i j)) ∧
+            (∀ j, map (fun i ↦ C i j) (σ j) = σ j) ∧
+            ∀ j (A : Matrix (Fin (m j)) (Fin (m j)) ℂ)
+                (B : Matrix (Fin (d j)) (Fin (d j)) ℂ),
+              Matrix.reindex e.symm e.symm
+                  (star U * map F.Kfam
+                    (U * Matrix.reindex e e
+                      (Matrix.directSumBlockEmbedding (m := m) (d := d) j
+                        (A ⊗ₖ B)) * star U) * U) =
+                Matrix.directSumBlockEmbedding (m := m) (d := d) j
+                  (map (fun i ↦ C i j) A ⊗ₖ B) := by
+  obtain ⟨K, d, m, e, U, σ, q, τ, hU, hd, hm, hσpos, hσtrace,
+      hqnonneg, hqsum, hτpos, hτtrace, hAlgebra, hfamily⟩ :=
+    exists_commonInvariant_normalizedStateBlockForm_with_algebra
+      hρpos hρtrace hρbar
+  have hqpos : ∀ j, ∃ x, 0 < q x j :=
+    exists_pos_normalizedBlockWeight hρbar e U hU hd hm σ q τ hqnonneg hfamily
+  refine ⟨K, d, m, e, U, σ, q, τ, hU, hd, hm, hσpos, hσtrace,
+    hqnonneg, hqsum, hτpos, hτtrace, hfamily, ?_⟩
+  intro F
+  obtain ⟨C, hC, hCtp, hAction⟩ :=
+    exists_adaptedKrausBlocks_isTP_and_map hρbar e U hU hd hAlgebra F
+  refine ⟨C, ?_, hCtp, ?_, ?_⟩
+  · simpa only [Matrix.unitaryReindexLinearEquiv_apply] using hC
+  · exact map_adaptedKrausBlock_sigma e U hU σ q τ hτtrace hfamily hqpos F C hC
+  · intro j A B
+    simpa only [Matrix.unitaryReindexLinearEquiv_apply,
+      Matrix.unitaryReindexLinearEquiv_symm_apply] using hAction j A B
+
+end Kraus

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -109,6 +109,17 @@ theorem unitaryReindexLinearEquiv_mul
         Matrix.reindex e.symm e.symm (star U * B * U) :=
       (Matrix.reindexLinearEquiv_mul ℂ ℂ e.symm e.symm e.symm _ _).symm
 
+@[simp]
+theorem unitaryReindexLinearEquiv_star
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (A : Matrix n n ℂ) :
+    unitaryReindexLinearEquiv e U hU (star A) =
+      star (unitaryReindexLinearEquiv e U hU A) := by
+  rw [unitaryReindexLinearEquiv_apply, unitaryReindexLinearEquiv_apply]
+  simp only [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_reindex,
+    Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+
 /-- The inverse unitary block-coordinate change is adjoint to the forward
 change under the bilinear trace pairing:
 $\operatorname{tr}(\Phi^{-1}(X)A)=\operatorname{tr}(X\Phi(A))$. -/
@@ -209,6 +220,25 @@ theorem directSumBlockCompression_apply (k : Fin K)
     directSumBlockCompression (m := m) (d := d) k A i j = A ⟨k, i⟩ ⟨k, j⟩ :=
   rfl
 
+@[simp]
+theorem directSumBlockCompression_blockDiagonal'
+    (B : ∀ j, Matrix (Fin (m j) × Fin (d j))
+      (Fin (m j) × Fin (d j)) ℂ) (k : Fin K) :
+    directSumBlockCompression (m := m) (d := d) k
+        (Matrix.blockDiagonal' B) = B k := by
+  classical
+  ext i j
+  exact Matrix.blockDiagonal'_apply_eq B k i j
+
+@[simp]
+theorem directSumBlockCompression_one (k : Fin K) :
+    directSumBlockCompression (m := m) (d := d) k 1 = 1 := by
+  classical
+  ext i j
+  rcases i with ⟨a, b⟩
+  rcases j with ⟨c, f⟩
+  simp [directSumBlockCompression, Matrix.one_apply]
+
 /-- Embed a matrix as one diagonal block of a finite dependent direct sum.
 
 This is the inclusion of a single summand in Wolf, Proposition 1.5 and
@@ -232,6 +262,58 @@ theorem directSumBlockCompression_embedding (k : Fin K)
   ext i j
   simp [directSumBlockCompression, directSumBlockEmbedding,
     Matrix.blockDiagonal'_apply_eq]
+
+/-- Multiplication by block-diagonal matrices restricts on an embedded
+summand to multiplication by the corresponding diagonal blocks. -/
+theorem blockDiagonal'_mul_directSumBlockEmbedding_mul_blockDiagonal'
+    (P Q : ∀ j, Matrix (Fin (m j) × Fin (d j))
+      (Fin (m j) × Fin (d j)) ℂ)
+    (k : Fin K)
+    (A : Matrix (Fin (m k) × Fin (d k))
+      (Fin (m k) × Fin (d k)) ℂ) :
+    Matrix.blockDiagonal' P *
+        directSumBlockEmbedding (m := m) (d := d) k A *
+        Matrix.blockDiagonal' Q =
+      directSumBlockEmbedding (m := m) (d := d) k (P k * A * Q k) := by
+  classical
+  change Matrix.blockDiagonal' P * Matrix.blockDiagonal' (Pi.single k A) *
+      Matrix.blockDiagonal' Q =
+    Matrix.blockDiagonal' (Pi.single k (P k * A * Q k))
+  rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+  congr 1
+  funext j
+  by_cases hjk : j = k
+  · subst j
+    simp
+  · simp [hjk]
+
+/-- A dependent block-diagonal matrix is the sum of its embedded diagonal
+blocks. -/
+theorem sum_directSumBlockEmbedding_eq_blockDiagonal'
+    (B : ∀ j, Matrix (Fin (m j) × Fin (d j))
+      (Fin (m j) × Fin (d j)) ℂ) :
+    ∑ j, directSumBlockEmbedding (m := m) (d := d) j (B j) =
+      Matrix.blockDiagonal' B := by
+  classical
+  ext ⟨k, a⟩ ⟨l, b⟩
+  change (∑ j, Matrix.blockDiagonal' (Pi.single j (B j))) ⟨k, a⟩ ⟨l, b⟩ =
+    Matrix.blockDiagonal' B ⟨k, a⟩ ⟨l, b⟩
+  by_cases hkl : k = l
+  · subst l
+    rw [Matrix.sum_apply]
+    simp only [Matrix.blockDiagonal'_apply_eq]
+    rw [Finset.sum_eq_single k]
+    · simp
+    · intro i _ hik
+      rw [Pi.single_eq_of_ne (Ne.symm hik)]
+      rfl
+    · simp
+  · rw [Matrix.blockDiagonal'_apply_ne B a b hkl, Matrix.sum_apply]
+    apply Finset.sum_eq_zero
+    intro j _
+    exact Matrix.blockDiagonal'_apply_ne
+      (Pi.single j (B j) : ∀ i, Matrix (Fin (m i) × Fin (d i))
+        (Fin (m i) × Fin (d i)) ℂ) a b hkl
 
 /-- Compression to a diagonal summand preserves positive semidefiniteness. -/
 theorem directSumBlockCompression_isPositiveMap (k : Fin K) :

--- a/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
+++ b/TNLean/Channel/PositiveConditionalExpectationDirectSum.lean
@@ -74,6 +74,41 @@ theorem unitaryReindexLinearEquiv_symm_apply
   simp [unitaryReindexLinearEquiv, Unitary.toUnits,
     Matrix.symm_reindexLinearEquiv, Matrix.coe_reindexLinearEquiv, Matrix.mul_assoc]
 
+@[simp]
+theorem unitaryReindexLinearEquiv_one
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ) :
+    unitaryReindexLinearEquiv e U hU 1 = 1 := by
+  rw [unitaryReindexLinearEquiv_apply, Matrix.mul_one,
+    Matrix.mem_unitaryGroup_iff'.mp hU]
+  exact Matrix.reindexLinearEquiv_one ℂ ℂ e.symm
+
+theorem unitaryReindexLinearEquiv_mul
+    {n H : Type*} [Fintype n] [DecidableEq n] [Fintype H] [DecidableEq H]
+    (e : H ≃ n) (U : Matrix n n ℂ) (hU : U ∈ Matrix.unitaryGroup n ℂ)
+    (A B : Matrix n n ℂ) :
+    unitaryReindexLinearEquiv e U hU (A * B) =
+      unitaryReindexLinearEquiv e U hU A *
+        unitaryReindexLinearEquiv e U hU B := by
+  rw [unitaryReindexLinearEquiv_apply, unitaryReindexLinearEquiv_apply,
+    unitaryReindexLinearEquiv_apply]
+  have hUright : U * star U = 1 := Matrix.mem_unitaryGroup_iff.mp hU
+  have hconj : star U * (A * B) * U =
+      (star U * A * U) * (star U * B * U) := by
+    calc
+      star U * (A * B) * U = star U * A * (U * star U) * B * U := by
+        rw [hUright]
+        simp only [Matrix.mul_one, Matrix.mul_assoc]
+      _ = (star U * A * U) * (star U * B * U) := by
+        simp only [Matrix.mul_assoc]
+  calc
+    Matrix.reindex e.symm e.symm (star U * (A * B) * U) =
+        Matrix.reindex e.symm e.symm
+          ((star U * A * U) * (star U * B * U)) := congrArg _ hconj
+    _ = Matrix.reindex e.symm e.symm (star U * A * U) *
+        Matrix.reindex e.symm e.symm (star U * B * U) :=
+      (Matrix.reindexLinearEquiv_mul ℂ ℂ e.symm e.symm e.symm _ _).symm
+
 /-- The inverse unitary block-coordinate change is adjoint to the forward
 change under the bilinear trace pairing:
 $\operatorname{tr}(\Phi^{-1}(X)A)=\operatorname{tr}(X\Phi(A))$. -/

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1496,8 +1496,9 @@ algebra of a family of jointly invariant states.
     \end{align}
     The density matrix $\sigma_\ell$ is independent of $k$. The tensor factors
     are written in the reverse order from HJPW Property~1. This is the
-    full-support specialization of that state decomposition; no action of a
-    preserving operation on the summands is asserted.
+    full-support specialization of that state decomposition. No action of a
+    preserving operation on the summands is asserted in this theorem; the next
+    theorem supplies it under the same full-support hypothesis.
 \end{theorem}
 
 \begin{proof}
@@ -1515,6 +1516,50 @@ algebra of a family of jointly invariant states.
     $X_{\ell,k}=0$, so the maximally mixed density matrix may be chosen.
     In both cases
     $X_{\ell,k}=q_{\ell|k}\tau_{\ell|k}$.
+\end{proof}
+
+\begin{theorem}[Action of preserving operations on full-support invariant-family blocks]
+    \label{thm:koashi_imoto_preserving_block_action}
+    \lean{Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction}
+    \leanok
+    \uses{def:koashi_imoto_common_invariant_algebra,
+        thm:koashi_imoto_normalized_family_block_form}
+    Use the decomposition of
+    Theorem~\ref{thm:koashi_imoto_normalized_family_block_form}. For every
+    trace-preserving completely positive operation $F$ satisfying
+    $F(\rho_k)=\rho_k$ for all $k$, and every summand $\ell$, there is a
+    trace-preserving completely positive operation $F_\ell$ on
+    $\MN{m_\ell}$ such that $F_\ell(\sigma_\ell)=\sigma_\ell$. If
+    $\iota_\ell$ denotes inclusion of the $\ell$-th diagonal summand and
+    \begin{align}
+        \widetilde F(X)=U^\dagger F(UXU^\dagger)U,
+    \end{align}
+    then, for all $A\in\MN{m_\ell}$ and $B\in\MN{d_\ell}$,
+    \begin{align}
+        \widetilde F\bigl(\iota_\ell(A\otimes B)\bigr)
+        =
+        \iota_\ell\bigl(F_\ell(A)\otimes B\bigr).
+    \end{align}
+    This is the full-support specialization of HJPW Property~$2'$
+    (Appendix~A, lines 808--816 and 860--882), with the tensor factors
+    reversed. It does not include the joint-support reduction or the
+    Stinespring form of Property~2.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:koashi_imoto_common_invariant_algebra,
+        thm:koashi_imoto_normalized_family_block_form}
+    For a preserving operation $F$, every Kraus operator commutes with the
+    common invariant algebra. In the common direct-sum coordinates it
+    therefore has the form
+    $\bigoplus_\ell C_{i,\ell}\otimes\mathbf 1$. Compressing
+    $\sum_iC_{i,\ell}^\dagger C_{i,\ell}=\mathbf 1$ to a summand gives trace
+    preservation of $F_\ell$. The displayed action follows by multiplication.
+    Positive definiteness of the common average implies that every summand has
+    positive weight for some $\rho_k$. Compressing $F(\rho_k)=\rho_k$ and
+    tracing over the second factor then gives
+    $F_\ell(\sigma_\ell)=\sigma_\ell$.
 \end{proof}
 
 \begin{theorem}[Hayashi SSA-equality characterization]
@@ -1551,12 +1596,15 @@ algebra of a family of jointly invariant states.
     finite-dimensional operator-algebraic core of the Koashi--Imoto argument.
     Theorems~\ref{thm:koashi_imoto_family_fixed_point_block_form} and
     \ref{thm:koashi_imoto_normalized_family_block_form} give the simultaneous
-    algebraic tensor-block form and its probability-density normalization,
-    under the same explicit full-support hypothesis on the common average in
-    place of the joint-support reduction. The joint-support reduction and the
-    action of the middle-system channel on the common direct-sum factors remain
-    open. This forward implication therefore remains axiomatic. The
-    biconditional combines the two directions.
+    algebraic tensor-block form and its probability-density normalization.
+    Theorem~\ref{thm:koashi_imoto_preserving_block_action} gives the action of
+    every preserving operation on those blocks. Together these give
+    Property~1 and the full-support specialization of Property~$2'$ under the
+    same explicit full-support hypothesis on the common average. The reduction
+    to the joint support, transport of this result to the recovered family,
+    and assembly of the quantum-Markov decomposition remain open. This forward
+    implication therefore remains axiomatic. The biconditional combines the
+    two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -122,8 +122,10 @@ For MPDO renormalization fixed points:
   realization by a single preserving operation, and a positive unital
   idempotent projection onto it are formalized under an explicit full-support
   hypothesis on the common average. The corresponding Heisenberg Ces\`aro
-  convergence identity, the family-level tensor-product state decomposition,
-  and the Koashi--Imoto/Hayashi channel-action theorem remain open.
+  convergence identity remains open. The full-support family-level
+  tensor-product state decomposition and HJPW Property~`2'` channel action are
+  formalized; the joint-support reduction and transport, together with the
+  generic Hayashi forward implication, remain open.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -65,8 +65,11 @@ singular-support saturation-to-recovery theorem and the structural analysis of
 recovered states.  The singular-support saturation-to-raw-recovery implication,
 its positive-definite specialization, and the trace-preserving extension of the
 support Petz map are now available.  The family-level structural step remains
-open.  The reverse direction is proved from the entropy-additivity sub-lemmas
-listed below.
+open only beyond the full-support case: the invariant-family decomposition and
+the action of every preserving operation on its diagonal blocks are available
+when the common average is positive definite, while the joint-support passage
+and quantum-Markov assembly remain. The reverse direction is proved from the
+entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
 
@@ -83,10 +86,13 @@ reconstruction of the discarded subsystem from a recovery map. This recovery-map
 argument now includes the singular-support saturation-to-raw-recovery
 implication.  A simultaneous probability-density block form for the preserved
 family is also available under a positive-definite common-average hypothesis.
-The joint-support reduction and the preserving-channel action on the common
-summands are still missing. Thus the family-level structural implication needed
-here remains open, which is why the forward direction is treated as an external
-assumption rather than proved.  The recovery implication and the
+In the same full-support setting, every preserving channel acts locally on the
+common summands and fixes their common density factors. The joint-support
+reduction, transport of this result to the recovered family, and assembly of
+the quantum-Markov decomposition are still missing. Thus the family-level
+structural implication needed here remains open, which is why the forward
+direction is treated as an external assumption rather than proved. The recovery
+implication and the
 complementary trace-preserving extension of the support Petz map are no longer
 part of this gap.
 
@@ -661,28 +667,30 @@ The local completed Petz map is trace-preserving and completely positive.
 For singular $\rho_A$, this is a supported-input identity, not a global
 factorization of TNLean's generic completed product-reference channel.
 
-The proof of the block decomposition still requires the invariant-state
-decomposition used in
-\cite[Theorem~6]{HaydenJozsaPetzWinter2004}; that is the
-Koashi--Imoto structural step.  This structural step remains necessary before
-the forward external assumption can be removed.
+The full-support invariant-state decomposition and preserving-operation block
+action used in \cite[Theorem~6]{HaydenJozsaPetzWinter2004} are now available.
+Applying them after restriction to the joint support, transporting the result
+back to the recovered family, and assembling the quantum-Markov decomposition
+remain necessary before the forward external assumption can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-family-level structural analysis of recovered states. Source-facing
+joint-support transport and quantum-Markov assembly for the recovered family.
+The full-support invariant-family state decomposition and preserving-operation
+block action are formalized. Source-facing
 completed-channel recovery from equality in data processing is available on
 arbitrary finite tensor factors. Its exact HJPW product-reference
 specialization and identity-tensored local recovery channel are also
-formalized without invertibility assumptions. The forward structural
+formalized without invertibility assumptions. The remaining forward structural
 direction alone is postulated. The reverse direction,
 a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
-and reindexing invariance.  Until the structural step is formalized, the
-forward direction remains the irreducible unproved content of this
-characterization.
+and reindexing invariance. Until the joint-support transport and
+quantum-Markov assembly are formalized, the forward direction remains the
+irreducible unproved content of this characterization.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -150,31 +150,33 @@ formalized in \doclink{TNLean/Channel/Schwarz/SSAEqualityPetzRecovery} by
 No global identity-tensored factorization of TNLean's generic completed
 singular product-reference channel is claimed.
 
-\section{Remaining structural theorem}
+\section{Remaining structural bridge}
 
 Equation~\eqref{eq:hjpw-global-support-factorization} supplies the
 product-reference recovery factorization required before the structural part
-of the HJPW argument. It does not prove the Koashi--Imoto decomposition for a
-family of recovered states. The remaining step must identify one common direct
-sum
+of the HJPW argument. Under a positive-definite common-average hypothesis, the
+Koashi--Imoto state decomposition and the action of every preserving operation
+on its diagonal summands are now formalized below. To apply this result to an
+arbitrary recovered family, the remaining bridge must pass to the joint
+support, transport the full-support decomposition back to the original
+coordinates, and assemble one common direct sum
 \begin{align}
   H_B\cong\bigoplus_j H_{B_j^L}\otimes H_{B_j^R}
 \end{align}
-and describe the action of the middle-system channel on every summand so that
-the full family has the quantum-Markov form. The singular-support
+with the quantum-Markov form. The singular-support
 equality-to-raw-recovery implication is now formalized by the projected
 finite-Weyl argument and transported to arbitrary finite product coordinates.
 For density operators, support agreement upgrades this equality to the chosen
 completed partial-trace Petz channel on the recovered marginal. This does not
 give a tensor-product factorization of the generic completed singular channel.
-The family-level invariant-state and channel-action theorem is the remaining
-structural obstruction to replacing the forward Hayashi
+The joint-support transport and quantum-Markov assembly are the remaining
+structural obstructions to replacing the forward Hayashi
 strong-subadditivity equality assumption used in the CPSV16 argument.
 
 \section{Common invariant algebra: formalized under an explicit full-support hypothesis}
 
 A full-support specialization of a slice of the operator-algebraic
-Koashi--Imoto appendix (HJPW, Appendix A, lines 755--858) is now formalized
+Koashi--Imoto appendix (HJPW, Appendix A, lines 755--882) is now formalized
 independently of the product-reference recovery step above. For a finite,
 nonempty family of states $\rho_1,\dots,\rho_K$,
 the set
@@ -219,14 +221,16 @@ corresponding declarations are
   \leanid{Kraus.commonInvariantMeanErgodicProjection_idempotent}\\
   \leanid{Kraus.mem_range_commonInvariantMeanErgodicProjection_iff}\\
   \leanid{Kraus.exists_commonInvariant_fixedPointBlockForm}\\
-  \leanid{Kraus.exists_commonInvariant_normalizedStateBlockForm}
+  \leanid{Kraus.exists_commonInvariant_normalizedStateBlockForm}\\
+  \leanid{Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction}
 \end{center}
 in \doclink{TNLean/Channel/KoashiImoto/CommonInvariantAlgebra},
 \doclink{TNLean/Channel/KoashiImoto/FiniteRealization},
 \doclink{TNLean/Channel/KoashiImoto/PooledKrausFamily},
-\doclink{TNLean/Channel/KoashiImoto/SingleWitness}, and
-\doclink{TNLean/Channel/KoashiImoto/MeanErgodicProjection}.  The penultimate
-declaration, in
+\doclink{TNLean/Channel/KoashiImoto/SingleWitness},
+\doclink{TNLean/Channel/KoashiImoto/MeanErgodicProjection}, and
+\doclink{TNLean/Channel/KoashiImoto/PreservingBlockAction}. The fixed-point
+block-form declaration, in
 \doclink{TNLean/Channel/KoashiImoto/FamilyFixedPointBlockForm}, specializes
 the full-support density-block classification to $F_0$: one unitary
 direct-sum tensor decomposition and one family of density factors
@@ -250,16 +254,30 @@ specialization of HJPW Property~1, lines 785--789 and 857--858, is formalized,
 with the two tensor factors written in the reverse order. The unrestricted
 property remains open pending the joint-support reduction.
 
+The preserving-block-action declaration proves the full-support specialization
+of HJPW Property~$2'$, lines 808--816 and 860--882, in the same coordinates.
+For every preserving operation $F$ and every block $j$, it produces a local
+trace-preserving completely positive operation $F_j$ such that
+\begin{align}
+  F_j(\sigma_j)&=\sigma_j,\\
+  \widetilde F\bigl(\iota_j(A\otimes B)\bigr)
+    &=\iota_j\bigl(F_j(A)\otimes B\bigr).
+\end{align}
+Here the factor order is reversed from HJPW, so the local operation acts on
+the first factor. This statement concerns diagonal summands; it does not claim
+the Stinespring form of Property~2 or an action on off-diagonal coherences.
+
 HJPW's argument reduces to the case where the common average
 $(1/K)\sum_k\rho_k$ has full support, by shrinking the working Hilbert space to
 the joint support of the $\rho_k$ (lines 761--763). That reduction is not
 derived here: every declaration that builds $A_0$ instead takes positive
 definiteness of the common average as an explicit hypothesis. Beyond this
 scope restriction, none of the following are claimed: the joint-support
-reduction itself; the middle-system block channel action on the summands; or
-elimination of the Hayashi
-strong-subadditivity forward-implication axiom. These remain the open
-structural obstructions identified in the previous section.
+reduction and transport to the unrestricted family; assembly of the recovered
+family into the generic quantum-Markov decomposition; or elimination of the
+external assumption for the forward Hayashi strong-subadditivity implication.
+These remain the open structural obstructions identified in the previous
+section.
 
 \section{Classification}
 
@@ -281,9 +299,13 @@ common average, in place of HJPW's joint-support reduction. The simultaneous
 state decomposition
 $U^\dagger\rho_kU=\bigoplus_jq_{j|k}\sigma_j\otimes\tau_{j|k}$ for the whole
 invariant family is also formalized, with nonnegative weights summing to one
-and density matrices on both tensor factors. The Heisenberg Ces\`aro
-convergence identity for $P_0^*$, the joint-support reduction itself, and the
-Koashi--Imoto channel-action theorem remain open as separate later steps.
+and density matrices on both tensor factors. In the same coordinates, every
+preserving operation acts as a local trace-preserving completely positive
+operation fixing $\sigma_j$, tensored with the identity, on each diagonal
+summand. Thus full-support HJPW Property~$2'$ is also formalized. The
+Heisenberg Ces\`aro convergence identity for $P_0^*$, the joint-support
+reduction and transport, and the generic Hayashi forward implication remain
+open as separate later steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
## Summary

- preserve one common set of direct-sum coordinates for the invariant algebra and normalized state family
- prove that every preserving CPTP operation has adapted Kraus blocks of the form `C_{i,j} ⊗ 1`, with each local family trace preserving and fixing the common density `σ_j`
- prove the induced action `F_j ⊗ id` on every diagonal simple tensor and synchronize the Blueprint and paper-gap status

## Source and scope

This formalizes the full-support specialization of HJPW Property `2'` (arXiv:quant-ph/0304007v2, Appendix A, lines 808–816 and 860–882), using the same decomposition as Property 1. TNLean uses the reversed tensor-factor order, so the local channel acts on the first factor.

The positive-definite common-average hypothesis replaces HJPW's joint-support reduction, as documented in `docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`. This PR does not claim the joint-support transport, off-diagonal coherence action, Stinespring Property 2, or the generic Hayashi forward implication.

Closes #4962.

## Validation

- `lake build TNLean.Channel.KoashiImoto.PreservingBlockAction`
- `lake build` (9,785 jobs; one pre-existing `sorry` warning in `TNLean/MPS/Periodic/Overlap/SectorMatch.lean:600`)
- `python3 scripts/generate_import_aggregators.py` with no post-generation diff
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`; visually inspected the affected entropy pages 376–377

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in quantum channel / Koashi–Imoto theory with API splits on several theorems; scope is full-support only and does not change runtime code, but correctness matters for downstream SSA/HJPW formalization.
> 
> **Overview**
> Formalizes the **full-support** Koashi–Imoto step where every CPTP map preserving a state family acts locally on diagonal blocks: Kraus operators become `⊕_j C_{i,j} ⊗ 1`, each block channel is trace-preserving, fixes the common density `σ_j`, and acts as `F_j ⊗ id` on simple tensors (`PreservingBlockAction.lean`, main theorem `exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction`).
> 
> **Supporting algebra:** `commutes_blockDiagonal'_one_kronecker_iff` classifies the commutant of `1 ⊗ M(d)` factors; direct-sum helpers (`unitaryReindexLinearEquiv` mul/star/one, block embedding/compression lemmas) support the adapted-coordinate proofs.
> 
> **API layering:** Mean-ergodic and Koashi–Imoto existence theorems gain `_with_algebra` variants that also characterize `commonInvariantStarSubalgebra` as `⊕ 1 ⊗ Y_j`; the previous statements remain as state-only wrappers.
> 
> Blueprint ch.19 and paper-gap docs record Property `2'` as proved under positive-definite common average; joint-support transport and the generic Hayashi SSA forward implication stay open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b83e25bc0046def6cfaa57c66e6127bd65f4a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->