### PR TITLE
fix(tenkz): render kernel species semantics

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -83,7 +83,7 @@ Every frame contracts adjacent compatible cells by default: `bonds=grid`
 holds in chain and lattice frames alike, and `bonds=none` suppresses the
 frame-generated bonds.
 
-### 2.3 Atom keys (11)
+### 2.3 Atom keys (12)
 
 | Key | Type | Values | Default | Diagnostic family |
 |---|---|---|---|---|
@@ -95,6 +95,7 @@ frame-generated bonds.
 | `ports=` | typed-port-list | — | from skin | `TKZ-PORT-*` |
 | `frame=` | small-enum | `flat` `plane` `circle` | `flat` | `TKZ-FRAME-*` |
 | `species=` | identifier | — | empty | `TKZ-SPECIES-*` |
+| `size=` | small-enum | `s` `m` `l` | `m` | `TKZ-SIZE-*` |
 | `label pos=` | angle | a bearing in the record's own axes, or `auto` | `auto` | `TKZ-LABEL-*` |
 | `conjugate` | flag | — | false | `TKZ-ATOM-*` |
 | `void=` | small-enum | `open` `sealed` | unset | `TKZ-ATOM-*` |

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1083,3 +1083,30 @@ a kernel attempt drew one loop on a bare grid where the source draws a
 torus and two lattice panels, and was refused at review.
 
 No ledger row changes and no flag verdict is re-examined here.
+
+### 2026-07-28 — recorded kernel semantics reach the ink
+
+Species hue and wire direction were already kernel record fields, but the
+renderer discarded both. They now resolve at the shared ink boundary:
+declared `source:` hues reproduce the cited palette, undeclared named species
+use the house cycle, and `dir=` selects the corresponding mid-wire barb.
+Unnamed records retain the ordinary theme ink.
+
+The canonical atom gains the existing `size=s|m|l` property and marks gain
+the already-specified `species=` property under the extension gate requested
+by the source-corpus audit. This raises M1 kernel rows from 136 to 138 and M2
+parser leaves from 221 to 223. It does not change M3. M4 rises from 18.08 to
+18.20 because eleven source cases now state their cited palettes explicitly
+instead of relying on encounter order. The focused regression records all
+three size classes, document-stable species hues, mark species, and wire
+direction while the ten kernel event streams remain byte-identical.
+
+Extension-gate: #5013
+
+Census-correction: #5013
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:kernel-atom:size | keep-because: #4931 records the condensation source's large endpoints and small intermediate beads, while #5013 makes the existing size-class answer reachable from canonical atoms; expiry 1.0 |
+| flag:consumers:key:kernel-mark:species | keep-because: #5013 implements the LANGUAGE-1.0 semantic-ink contract at mark scope and pins it in the focused kernel regression; the cited dyon, boundary-lasso, and injectivity-ring consumers migrate in the queued redraw waves; expiry 1.0 |
+| flag:sugar-shaped:command:tndeclare | keep-because: a species declaration binds one semantic identity to a cited palette across atoms, wires, and marks; it changes the document-scope descriptor table and cannot expand into picture records; expiry 1.0 |

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -205,6 +205,7 @@ kernel-\allowbreak{}atom & \texttt{ports} & typed-\allowbreak{}port-\allowbreak{
 kernel-\allowbreak{}atom & \texttt{up} & math-\allowbreak{}list & empty & Outward \allowbreak{}physical \allowbreak{}labels,\allowbreak{} \allowbreak{}page-\allowbreak{}up. \\
 kernel-\allowbreak{}atom & \texttt{down} & math-\allowbreak{}list & empty & Outward \allowbreak{}physical \allowbreak{}labels,\allowbreak{} \allowbreak{}page-\allowbreak{}down. \\
 kernel-\allowbreak{}atom & \texttt{species} & declared-\allowbreak{}name & empty & Semantic \allowbreak{}species. \\
+kernel-\allowbreak{}atom & \texttt{size} & size-\allowbreak{}class & m & Per-\allowbreak{}atom \allowbreak{}metric \allowbreak{}size \allowbreak{}class. \\
 kernel-\allowbreak{}atom & \texttt{label~pos} & angle & auto & Label \allowbreak{}quadrant. \\
 kernel-\allowbreak{}atom & \texttt{nudge} & pair & zero & Quarter-\allowbreak{}pitch \allowbreak{}displacement. \\
 kernel-\allowbreak{}atom & \texttt{void} & void-\allowbreak{}policy & unset & Hole \allowbreak{}or \allowbreak{}removed \allowbreak{}site. \\
@@ -226,6 +227,7 @@ kernel-\allowbreak{}wire & \texttt{name} & identifier & generated & Addressable 
 kernel-\allowbreak{}wire & \texttt{closed} & flag & false & A \allowbreak{}smooth \allowbreak{}closed \allowbreak{}cycle; \allowbreak{}takes \allowbreak{}no \allowbreak{}ends. \\
 kernel-\allowbreak{}mark & \texttt{form} & enum(\allowbreak{}brace-\allowbreak{}above\textbar{}\allowbreak{}brace-\allowbreak{}below\textbar{}\allowbreak{}enclosure\textbar{}\allowbreak{}cut\textbar{}\allowbreak{}band\textbar{}\allowbreak{}label\textbar{}\allowbreak{}prose) & label & Mark \allowbreak{}form. \\
 kernel-\allowbreak{}mark & \texttt{slot} & semantic-\allowbreak{}slot & selected & Semantic \allowbreak{}tint. \\
+kernel-\allowbreak{}mark & \texttt{species} & declared-\allowbreak{}name & empty & Semantic \allowbreak{}species. \\
 kernel-\allowbreak{}mark & \texttt{inset} & number & 0 & Nested-\allowbreak{}contour \allowbreak{}step. \\
 kernel-\allowbreak{}mark & \texttt{label~pos} & angle & auto & Label \allowbreak{}quadrant. \\
 kernel-\allowbreak{}mark & \texttt{nudge} & pair & zero & Quarter-\allowbreak{}pitch \allowbreak{}displacement. \\

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -229,16 +229,49 @@ grep -Fq 'TENKZ-HULL-BOX-POOL=1' "$WORK/r_hull_live.tex.transcript" || {
   exit 1
 }
 command -v pdftoppm >/dev/null 2>&1 || {
-  echo "FAIL: live-hull pixel gate requires pdftoppm" >&2
+  echo "FAIL: kernel pixel gate requires pdftoppm" >&2
   exit 1
 }
-if ! pdftoppm -singlefile -png -r 300 \
-    "$WORK/r_hull_live.pdf" "$WORK/r_hull_live" >/dev/null 2>&1; then
-  echo "FAIL: live-hull fixture could not be rasterized" >&2
+for pixel_fixture in r_hull_live r_ink_semantics; do
+  if ! pdftoppm -singlefile -png -r 300 \
+      "$WORK/$pixel_fixture.pdf" "$WORK/$pixel_fixture" >/dev/null 2>&1; then
+    echo "FAIL: $pixel_fixture fixture could not be rasterized" >&2
+    exit 1
+  fi
+  [ -f "$WORK/$pixel_fixture.png" ] || {
+    echo "FAIL: $pixel_fixture rasterizer produced no PNG" >&2
+    exit 1
+  }
+done
+grep -Eq '^atom.*\|size=s\|.*\|species=warm($|\|)' \
+  "$WORK/r_ink_semantics.tnlog" || {
+  echo "FAIL: small warm atom semantics were not recorded" >&2
   exit 1
-fi
-[ -f "$WORK/r_hull_live.png" ] || {
-  echo "FAIL: live-hull rasterizer produced no PNG" >&2
+}
+grep -Fq '|dir=to|' "$WORK/r_ink_semantics.tnlog" || {
+  echo "FAIL: forward direction semantics were not recorded" >&2
+  exit 1
+}
+grep -Fq '|dir=from|' "$WORK/r_ink_semantics.tnlog" || {
+  echo "FAIL: reverse direction semantics were not recorded" >&2
+  exit 1
+}
+grep -Eq '^mark.*\|form=enclosure\|.*\|species=warm($|\|)' \
+  "$WORK/r_ink_semantics.tnlog" || {
+  echo "FAIL: mark species semantics were not recorded" >&2
+  exit 1
+}
+grep -Eq '^atom.*\|skin=dots\|species=gamma($|\|)' \
+  "$WORK/r_ink_semantics.tnlog" || {
+  echo "FAIL: ellipsis species semantics were not recorded" >&2
+  exit 1
+}
+cluster_species_count=$(
+  grep -Ec '^atom.*\|cluster-of=quad\|.*\|species=leaf($|\|)' \
+    "$WORK/r_ink_semantics.tnlog" || true
+)
+[ "$cluster_species_count" -eq 4 ] || {
+  echo "FAIL: cluster species semantics did not reach all four child dots" >&2
   exit 1
 }
 PIXEL_CURRENT="$WORK/current-pixels.sha256"
@@ -247,9 +280,10 @@ PIXEL_CURRENT="$WORK/current-pixels.sha256"
 # this script with --snapshot to accept the new raster.
 python3 -c \
   'import hashlib,sys
-data = open(sys.argv[1], "rb").read()
-print(hashlib.sha256(data).hexdigest(), "", "r_hull_live.png")' \
-  "$WORK/r_hull_live.png" >"$PIXEL_CURRENT"
+for path in sys.argv[1:]:
+    data = open(path, "rb").read()
+    print(hashlib.sha256(data).hexdigest(), "", path.rsplit("/", 1)[-1])' \
+  "$WORK/r_hull_live.png" "$WORK/r_ink_semantics.png" >"$PIXEL_CURRENT"
 
 negative="$KERNEL/negative/n_diagonal_port.tex"
 if ( cd "$WORK" &&
@@ -626,7 +660,7 @@ if [ "$MODE" = "--snapshot" ]; then
   cp "$CURRENT" "$GOLDEN"
   cp "$PIXEL_CURRENT" "$PIXEL_GOLDEN"
   echo "PASS: froze $(wc -l <"$GOLDEN" | tr -d ' ') kernel record streams"
-  echo "PASS: froze live-hull pixel baseline"
+  echo "PASS: froze kernel pixel baselines"
   exit "$fail"
 fi
 if ! diff -u "$GOLDEN" "$CURRENT"; then
@@ -635,8 +669,8 @@ if ! diff -u "$GOLDEN" "$CURRENT"; then
 fi
 echo "PASS: $(wc -l <"$GOLDEN" | tr -d ' ') kernel record streams byte-identical"
 if ! diff -u "$PIXEL_GOLDEN" "$PIXEL_CURRENT"; then
-  echo "FAIL: live-hull pixels diverged from their pin" >&2
+  echo "FAIL: kernel pixels diverged from their pins" >&2
   exit 1
 fi
-echo "PASS: live-hull pixels byte-identical"
+echo "PASS: kernel pixels byte-identical"
 exit "$fail"

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -6,14 +6,14 @@
       "commands": 25,
       "environments": 6,
       "escape": 9,
-      "kernel": 136,
+      "kernel": 138,
       "sugar": 12
     }
   },
   "m2_parser_paths": {
     "definition": "public leaf keys installed by the TeX parsers; identity changes require an Extension-gate citation",
-    "identity_sha256": "cad712955418a3d87a7bf47efb724f2dada18d4302809f373cf02f884a39d054",
-    "value": 221
+    "identity_sha256": "d865d1cc455129c006137ccb71fdc88d7d04395b72ebcb52dfa8f725266e9b6a",
+    "value": 223
   },
   "m3_escape_usage": {
     "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",
@@ -21,7 +21,7 @@
   },
   "m4_lines_per_case": {
     "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",
-    "value": 18.08
+    "value": 18.2
   },
   "m5_aliases": {
     "definition": "key and value alias rows plus sunset compliance; near zero at the 1.0 freeze",

--- a/tests/tenkz/kernel/golden-pixels.sha256
+++ b/tests/tenkz/kernel/golden-pixels.sha256
@@ -1,1 +1,2 @@
 26bf5b6aa7d3fc4c08c70bb87fc69bfeb2b4898c1e4e7bbe4899365b291291f4  r_hull_live.png
+180bbb192f6693435dba8a896703c2fedba69b958dfb850efae563db2b3b1152  r_ink_semantics.png

--- a/tests/tenkz/kernel/regression/r_ink_semantics.tex
+++ b/tests/tenkz/kernel/regression/r_ink_semantics.tex
@@ -1,0 +1,42 @@
+%% Regression: recorded species, direction, and atom size reach kernel ink.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\tndeclare{species}{warm}{hue={source:red}}
+\tndeclare{species}{cool}{hue=source:blue}
+\tndeclare{species}{leaf}{hue=source:green}
+\tndeclare{species}{alpha}{}
+\tndeclare{species}{beta}{}
+\begin{tenkz}[rows={wire,wire,wire}, cols=5, bonds=none]
+  \tn[at=(1,1), name=small, skin=dot, size=s, species=warm]{}
+  \tn[at=(1,3), name=medium, skin=dot, size=m, species=cool]{}
+  \tn[at=(1,5), name=large, skin=dot, size=l, species=leaf]{}
+  \tn[at=(2,1), name=left, skin=box, size=s, species=warm]{L}
+  \tn[at=(2,3), name=middle, skin=box, size=m, species=cool]{M}
+  \tn[at=(2,5), name=right, skin=box, size=l, species=leaf]{R}
+  \tn[at=(3,1), name=intrinsic, skin=ring]{U}
+  \tn[at=(3,3), name=prelude, skin=box, role=operator]{O}
+  \tn[at=(3,5), name=cycle, skin=dot, species=alpha]{}
+  \tnwire[species=warm, dir=to]{small.0}{medium.180}
+  \tnwire[species=cool, dir=from]{medium.0}{large.180}
+  \tnwire[kind=string, species=leaf, dir=to]{(1,1)}{(2,1)}
+  \tnwire[species=beta]{intrinsic.0}{prelude.180}
+  % The live hull must follow the large non-dot silhouette.
+  \tnmark[form=enclosure, species=warm]{right}{}
+\end{tenkz}
+\quad
+% Reversing first use in a later picture must not exchange declared hues.
+\begin{tenkz}[rows={wire,wire}, cols=5, bonds=none]
+  \tn[at=(1,1), skin=box, species=beta]{B}
+  \tn[at=(1,3), skin=box, species=alpha]{A}
+  \tn[at=(1,5), skin=dots, species=gamma]{}
+  \tn[at=(2,1), skin=dot, species=warm]{D}
+  \tn[at=(2,3), name=quad, cluster=2x2, species=leaf]{}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-two-shift.tex
+++ b/tests/tenkz/rmp/section-ii/cases/rmp-ii-mpu-two-shift.tex
@@ -8,6 +8,8 @@
 % Capabilities: grid, typed-ports
 \[
   \tenkzkernel
+  \tndeclare{species}{right}{hue=source:blue}
+  \tndeclare{species}{left}{hue=source:red}
   \begin{tenkz}[rows={wire,wire}, cols=4, bonds=none, west=trace, east=trace]
     \tnwire[kind=string, species=right, name=r1]{(1,1)}{(2,2)}
     \tnwire[kind=string, species=right, name=r2]{(1,3)}{(2,4)}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-f-symbol.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-f-symbol.tex
@@ -8,6 +8,8 @@
 % Capabilities: coherence, grid
 \[
   \tenkzkernel
+  \tndeclare{species}{sector}{hue=source:black}
+  \tndeclare{species}{mpo}{hue=source:red}
   \begin{tenkz}[rows={wire,wire,wire,wire,wire,wire,wire}, cols=7, bonds=none]
     \tnwire[kind=string, species=sector, name=c, dir=to]{(7,4)}{(1,4)}
     \tnwire[kind=string, species=mpo, name=a, dir=to,

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-g-injective-projector.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-g-injective-projector.tex
@@ -12,6 +12,7 @@
   % crosses the east and south legs instead.  The action boxes stand on the
   % string at its measured leg crossings.
   \tenkzkernel
+  \tndeclare{species}{g}{hue=source:red}
   \begin{tenkzeq}[size=m]
     \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5, bonds=none]
       \tn[at=(3,3), name=A]{}

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-spt-mpo.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-spt-mpo.tex
@@ -7,6 +7,8 @@
 % Capabilities: grid, pulling-through, crossing-order, rotated-action
 \[
   \tenkzkernel
+  \tndeclare{species}{lattice}{hue=source:black}
+  \tndeclare{species}{g}{hue=source:red}
   \begin{tenkzeq}[size=m]
     \begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none]
       % the PEPS star: two lattice lines through A, physical leg up

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.tex
@@ -12,6 +12,7 @@
   % crosses the east and south legs instead and the unitary U_g appears
   % on the physical leg, drawn at the 45-degree face of the flat redraw.
   \tenkzkernel
+  \tndeclare{species}{g}{hue=source:red}
   \begin{tenkzeq}[size=m]
     \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5, bonds=none]
       \tn[at=(3,3), name=A, ports={0:virtual, 90:virtual, 180:virtual,

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-mpo-injective-white.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-mpo-injective-white.tex
@@ -11,6 +11,8 @@
   % tensor at each crossing; pulled through, it crosses the east and front
   % legs instead, and the tensor A is unchanged.
   \tenkzkernel
+  \tndeclare{species}{lattice}{hue=source:black}
+  \tndeclare{species}{g}{hue=source:blue}
   \begin{tenkzeq}[size=m]
     \begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none]
       % the PEPS star: two lattice lines through A, physical leg up

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-four.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-four.tex
@@ -7,6 +7,7 @@
 % Capabilities: grid, braid-resolver, crossing-order
 \[
   \tenkzkernel
+  \tndeclare{species}{operator}{hue=source:red}
   \begin{tenkz}[rows={wire,wire,wire,wire}, cols=4, bonds=none]
     % anyons j and i sit where the transversal lattice line meets the rails
     \tn[at=(1,2), name=j, role=extra, label pos=nw]{j}

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-one.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-one.tex
@@ -7,6 +7,7 @@
 % Capabilities: grid, multi-strand-braid, crossing-order
 \[
   \tenkzkernel
+  \tndeclare{species}{operator}{hue=source:red}
   \begin{tenkz}[rows={wire,wire}, cols=2, physical=updown]
     % the two-by-two lattice patch: anyons j and i on the upper rail
     \tn[at=(1,1), name=j, label pos=se]{j}

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-three.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-three.tex
@@ -7,6 +7,7 @@
 % Capabilities: grid, braid-resolver, crossing-order
 \[
   \tenkzkernel
+  \tndeclare{species}{operator}{hue=source:red}
   \begin{tenkz}[rows={wire,wire}, cols=2, physical=updown]
     % the two-by-two lattice patch: the anyons stand on the right column
     \tn[at=(1,1), name=p]{}

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-two.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-braid-two.tex
@@ -11,6 +11,7 @@
   % leg, and each string-lattice crossing carries its dot.  The kernel routes
   % below say exactly that; every dot stands at the address of its crossing.
   \tenkzkernel
+  \tndeclare{species}{operator}{hue=source:red}
   \begin{tenkz}[rows={wire,wire}, cols=2, bonds=none]
     \tn[at=(1,1), name=b, role=extra, label pos=nw]{b}
     \tn[at=(1,2), name=a, role=marked, label pos=ne]{a}

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-r-tensor-left.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-r-tensor-left.tex
@@ -7,6 +7,7 @@
 % Capabilities: grid, multi-strand-braid, crossing-order
 \[
   \tenkzkernel
+  \tndeclare{species}{operator}{hue=source:red}
   \begin{tenkz}[rows={wire,wire,wire}, cols=4, bonds=none, physical=up]
     % the anyon i and the plain lattice site below it; each site carries its
     % physical leg

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -147,10 +147,10 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "7210d80b33c212cf43812d1a89d581ba1571ca8bcd21937dff7e63973aa64a71"
-reviewed = "2026-07-27"
-renderer = "fable-wave-b-acceptance-2026-07-27-200dpi"
-note = "the kernel form LANGUAGE-1.0 section 12.4 fixes for this target: two traced rows, four inter-row shift strings, both crossings declared and rendered under; the author box-turn ink is the mpu-wrap-second skin-pairings property"
+case_sha256 = "f3ea5680b53f1787a563c81ac99ec951f718e9d6ea95fc3df83c0fcf3a5e2cec"
+reviewed = "2026-07-28"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
+note = "the kernel form LANGUAGE-1.0 section 12.4 fixes for this target: two traced rows, four source-blue/source-red inter-row shift strings, both crossings declared and rendered under; the author box-turn ink is the mpu-wrap-second skin-pairings property"
 
 [[verdict]]
 id = "rmp-ii-mpu-normal-form"
@@ -418,10 +418,10 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "codex-pairing-sweep-2026-07-24"
 defects = []
-case_sha256 = "95222124e362a3cd5cabdb41c708bede81c90a547f6264409773ad29c1559203"
-reviewed = "2026-07-27"
-renderer = "fable-wave-b-acceptance-2026-07-27-200dpi"
-note = "the author string realization: c over a at the declared crossing, four quadrant sectors, six labels at their stations; c blue in the sector species where the source paints black, arrowheads recorded as dir but not yet inked"
+case_sha256 = "f39fe6acc9f54a55c5a377f58426c1d5db73ff61532d0e3e8bc62466f5a80a74"
+reviewed = "2026-07-28"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
+note = "the author string realization: black c over red a at the declared crossing, both source-directed arrowheads, four quadrant sectors, and six labels at their stations"
 
 [[verdict]]
 id = "rmp-iii-a-boundary-algebra-n"
@@ -615,10 +615,10 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "f1e08b4c9dceddd32e2c2dab02db6b3a2706e9fac933cf7a0a8d1bcd341e42b2"
-reviewed = "2026-07-27"
-renderer = "fable-wave-b-acceptance-2026-07-27-200dpi"
-note = "the g string pulls through with its action boxes riding the string over the measured legs on both sides; hue conventions differ"
+case_sha256 = "7759bccc35322e75af52c778724e5bbff93131297b4c65c5e6245b44aa604bf6"
+reviewed = "2026-07-28"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
+note = "the source-red g string pulls through the black lattice with its action boxes riding the string over the measured legs on both sides"
 
 [[verdict]]
 id = "rmp-iii-a-spt-intertwiner"
@@ -635,9 +635,9 @@ id = "rmp-iii-a-g-injective-projector"
 status = "cosmetic-gap"
 pairing = "wrong-source"
 defects = []
-case_sha256 = "1e7f27cdde08b7f232b7cb497f1da84d31e0abf23450a5eeb061c46dd930aaa0"
-reviewed = "2026-07-27"
-renderer = "fable-wave-b-acceptance-2026-07-27-200dpi"
+case_sha256 = "20c7fa066c431da92e147a549e674fabfc5276e86e305b8c22ffe52f8ce34525"
+reviewed = "2026-07-28"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
 note = "the pulling-through equality with the g string crossing west/north then east/south and action boxes on the string; g and A labelled per panel at review"
 
 [[verdict]]
@@ -745,10 +745,10 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "43a1b039b03c2da88117f65bd366a77409df88b580ec1d6be39d3ab99d8e0524"
-reviewed = "2026-07-27"
-renderer = "fable-wave-b-acceptance-2026-07-27-200dpi"
-note = "the three strings wind from i down through the b, a, b stations with the under-i detour; hue and pitch differ"
+case_sha256 = "2f2af2e4ff27be82858156cb028510e6b40ba5c18bf11050ef8b90c47d9acc2c"
+reviewed = "2026-07-28"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
+note = "the three source-red strings wind from i down through the b, a, b stations with the under-i detour; pitch differs"
 
 [[verdict]]
 id = "rmp-iii-b-r-tensor-right"
@@ -767,9 +767,9 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "616c219d5c451894b19126188662978e398b279ae332b40d9ea6347a63f0a036"
-reviewed = "2026-07-27"
-renderer = "fable-wave-b-acceptance-2026-07-27-200dpi"
+case_sha256 = "d11ef6c19d6b1a9b292d2b445f6d0854b887e18dfe65b34c17dd6af8926cdf10"
+reviewed = "2026-07-28"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
 note = "winding strings restored to the lattice patch with j, b, i, a at their stations; the strands do not cross each other, as the source draws"
 
 [[verdict]]
@@ -778,9 +778,9 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "codex-pairing-sweep-2026-07-24"
 defects = []
-case_sha256 = "2f762e187d7fa340dcb72a43f286c157d400874248886c5f2dc3adacd9d9016f"
-reviewed = "2026-07-27"
-renderer = "fable-wave-b-acceptance-2026-07-27-200dpi"
+case_sha256 = "54937a3e9120c8f44d36626ed058ec13731196c311450ae84be2334ac32717f5"
+reviewed = "2026-07-28"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
 note = "the two strands nest through their bead stations without crossing each other -- the side-by-side against the flattened source shows every meeting occluded by a bead; the old crossing was the previous body's invention"
 
 [[verdict]]
@@ -789,10 +789,10 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "1b6b18c1485c32cb3f160b320601eabd25777912654278b6eeed809adffd711a"
+case_sha256 = "700f88a4f679ef5b9fa633ec57e527945704ea4631aa0b6c4d3a64800fdddbc2"
 reviewed = "2026-07-28"
-renderer = "fable-wave-b-acceptance-2026-07-28-200dpi"
-note = "the strings wind through their bead stations into R_{j,a} with j and i at their corners; hue and the source lattice slant differ"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
+note = "the source-red strings wind through their bead stations into R_{j,a} with j and i at their corners; the source lattice slant differs"
 
 [[verdict]]
 id = "rmp-iii-b-braid-four"
@@ -800,9 +800,9 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "d7a901828b21cfea11cc56becafee13d38fdacf4ed1de9d2b92e4c1731fba82c"
+case_sha256 = "f3d6d702e5be8e11ba6bae00c3d970172220c7c02eabf878e42860060b882930"
 reviewed = "2026-07-28"
-renderer = "fable-wave-b-acceptance-2026-07-28-200dpi"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
 note = "both R boxes stacked on the strings with i and j at the rails; the source slants its boxes as parallelograms"
 
 [[verdict]]
@@ -1292,9 +1292,9 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "codex-pairing-sweep-2026-07-24"
 defects = []
-case_sha256 = "5d063fdf7744179e73c015568338f3b20f6a92f2c4f52ea864c0588c37036c45"
+case_sha256 = "4ec5a8c617814008b9d70960e1be6f947d6e09263fbdf9ddc1c47b98cf78993a"
 reviewed = "2026-07-28"
-renderer = "fable-wave-b-acceptance-2026-07-28-200dpi"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
 note = "the g string pulls through and U_g appears on the diagonal, with the action boxes riding the string on both sides"
 
 [[verdict]]
@@ -1313,9 +1313,9 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "codex-pairing-sweep-2026-07-24"
 defects = []
-case_sha256 = "2eed9f1865380c16bc26b7979cd4560c188bbea8ba353d9e899a12fe1bed6899"
+case_sha256 = "76d95a3b9f032b696b9d406da4e669278da4e3a236baff6e2cc4f5c05588582d"
 reviewed = "2026-07-28"
-renderer = "fable-wave-b-acceptance-2026-07-28-200dpi"
+renderer = "codex-kernel-ink-2026-07-28-200dpi"
 note = "the g string crosses the site and pulls to the far side, drawn as strings rather than the substituted boxes"
 
 [[verdict]]

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -305,6 +305,21 @@
   tenkz inscribed size l/.style={
       minimum width=\dimexpr
         \tenkz@r@glyphref\tenkz@pitch * 5 / 4\relax},
+  % Canonical atoms use the class reference on both axes.  Compatibility
+  % renderers retain the width-only styles above until their own migration.
+  tenkz canonical size s/.style={
+      minimum width=\dimexpr
+        \tenkz@r@glyphref\tenkz@pitch * 3 / 4\relax,
+      minimum height=\dimexpr
+        \tenkz@r@glyphref\tenkz@pitch * 3 / 4\relax},
+  tenkz canonical size m/.style={
+      minimum width=\tenkz@dim{\tenkz@r@glyphref},
+      minimum height=\tenkz@dim{\tenkz@r@glyphref}},
+  tenkz canonical size l/.style={
+      minimum width=\dimexpr
+        \tenkz@r@glyphref\tenkz@pitch * 5 / 4\relax,
+      minimum height=\dimexpr
+        \tenkz@r@glyphref\tenkz@pitch * 5 / 4\relax},
   tenkz dot size s/.style={
       minimum size=\tenkz@dim{\tenkz@r@clusterdot}},
   tenkz dot size m/.style={

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -701,6 +701,8 @@
 \__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { up } { up }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { down } { down }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { species } { species }
+\__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { size }
+  { s, m, l } { size }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { label~pos } { label-pos }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-atom } { nudge } { nudge }
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-atom } { void }
@@ -745,6 +747,7 @@
   { brace-above, brace-below, enclosure, cut, band, label, prose } { form }
 \__tenkz_kernel_choice:nnnn { tenkz-kernel-mark } { slot }
   { selected, secondary, complement, collar, neutral } { slot }
+\__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { species } { species }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { inset } { inset }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { label~pos } { label-pos }
 \__tenkz_kernel_value:nnn   { tenkz-kernel-mark } { nudge } { nudge }
@@ -919,6 +922,15 @@
       { \A \s* ([1-9]\d*) \s* x \s* ([1-9]\d*) \s* \Z } {#2}
       \l__tenkz_kernel_match_seq
       {
+        \prop_get:NnN \l__tenkz_kernel_named_prop {#1} \l_tmpa_tl
+        \__tenkz_model_get:nnN
+          { \tl_use:N \l_tmpa_tl } {species} \l_tmpb_tl
+        \tl_clear:N \l__tenkz_kernel_scratch_tl
+        \quark_if_no_value:NF \l_tmpb_tl
+          {
+            \tl_set:Ne \l__tenkz_kernel_scratch_tl
+              { , species = \tl_use:N \l_tmpb_tl }
+          }
         \int_gincr:N \g__tenkz_kernel_group_int
         \__tenkz_model_record_frame:e
           {
@@ -934,6 +946,7 @@
                     kind = tn , skin = dot , name = #1 - ##1 - ####1 ,
                     cluster-of = #1 ,
                     group = g \int_use:N \g__tenkz_kernel_group_int
+                    \tl_use:N \l__tenkz_kernel_scratch_tl
                   }
                 \prop_put:Nee \l__tenkz_kernel_named_prop
                   { #1 - ##1 - ####1 } { \tl_use:N \l__tenkz_model_last_tl }
@@ -1429,6 +1442,7 @@
 % mints a one-label command; skins and species are descriptor tables the
 % style stage consumes.
 \prop_new:N \g__tenkz_kernel_species_prop
+\prop_new:N \g__tenkz_kernel_species_hue_prop
 \prop_new:N \g__tenkz_kernel_skin_prop
 \cs_new_protected:Npn \__tenkz_kernel_tndeclare:nnn #1#2#3
   {
@@ -1437,10 +1451,39 @@
         {atom}    { \__tenkz_kernel_declare_atom:nn {#2} {#3} }
         {skin}    { \__tenkz_kernel_declare_table:Nnn
                       \g__tenkz_kernel_skin_prop {#2} {#3} }
-        {species} { \__tenkz_kernel_declare_table:Nnn
-                      \g__tenkz_kernel_species_prop {#2} {#3} }
+        {species} { \__tenkz_kernel_declare_species:nn {#2} {#3} }
       }
       { \msg_error:nnn {tenkz}{kernel-declare-class} {#1} }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_declare_species:nn #1#2
+  {
+    \__tenkz_kernel_declare_table:Nnn
+      \g__tenkz_kernel_species_prop {#1} {#2}
+    % Hue-less declarations receive a document-scope cycle slot now, in
+    % declaration order.  Reordering first uses in later pictures therefore
+    % cannot change the identity's ink.
+    \regex_extract_once:nnNF
+      { (?: \A | , ) \s* hue \s* = }
+      {#2}
+      \l__tenkz_kernel_r_hue_match_seq
+      {
+        \prop_if_in:NnF \g__tenkz_kernel_species_hue_prop {#1}
+          {
+            \int_set:Nn \l_tmpa_int
+              {
+                \int_mod:nn
+                  { \prop_count:N \g__tenkz_kernel_species_hue_prop }
+                  { \clist_count:N \c__tenkz_speccycle_clist }
+                + 1
+              }
+            \tl_set:Nx \l_tmpa_tl
+              {
+                \clist_item:Nn \c__tenkz_speccycle_clist
+                  { \l_tmpa_int }
+              }
+            \prop_gput:NnV \g__tenkz_kernel_species_hue_prop {#1} \l_tmpa_tl
+          }
+      }
   }
 \cs_new_protected:Npn \__tenkz_kernel_declare_table:Nnn #1#2#3
   {
@@ -2030,7 +2073,6 @@
 \prop_new:N \l__tenkz_kernel_r_species_prop   % species word -> hue
 \seq_new:N  \l__tenkz_kernel_r_strings_seq    % string wire record ids
 \seq_new:N  \l__tenkz_kernel_r_after_atom_seq % physical traces need glyph borders
-\seq_new:N  \l__tenkz_kernel_r_palette_seq
 \int_new:N  \l__tenkz_kernel_r_rows_int
 \int_new:N  \l__tenkz_kernel_r_cols_int
 \tl_new:N   \l__tenkz_kernel_r_tl
@@ -2041,6 +2083,13 @@
 \tl_new:N   \l__tenkz_kernel_r_pts_tl
 \tl_new:N   \l__tenkz_kernel_r_sid_tl
 \tl_new:N   \l__tenkz_kernel_r_hue_tl
+\tl_new:N   \l__tenkz_kernel_r_species_tl
+\tl_new:N   \l__tenkz_kernel_r_species_descriptor_tl
+\tl_new:N   \l__tenkz_kernel_r_mark_ink_tl
+\tl_new:N   \l__tenkz_kernel_r_wire_ink_tl
+\tl_new:N   \l__tenkz_kernel_r_wire_style_tl
+\tl_new:N   \l__tenkz_kernel_r_atom_style_tl
+\seq_new:N  \l__tenkz_kernel_r_hue_match_seq
 \tl_new:N   \l__tenkz_kernel_r_x_tl
 \tl_new:N   \l__tenkz_kernel_r_y_tl
 \tl_new:N   \l__tenkz_kernel_r_xb_tl
@@ -2790,6 +2839,8 @@
 \tl_new:N \l__tenkz_kernel_hull_a_tl
 \tl_new:N \l__tenkz_kernel_hull_b_tl
 \tl_new:N \l__tenkz_kernel_hull_skin_tl
+\tl_new:N \l__tenkz_kernel_hull_size_tl
+\tl_new:N \l__tenkz_kernel_hull_radius_tl
 \tl_new:N \l__tenkz_kernel_hull_turn_tl
 \tl_new:N \l__tenkz_kernel_hull_measure_name_tl
 \tl_new:N \l__tenkz_kernel_hull_shape_tl
@@ -3406,6 +3457,8 @@
             % a contour that clears the dot but cuts the label clears nothing
             \__tenkz_model_get:nnN {#1} {label} \l_tmpa_tl
             \__tenkz_model_get:nnN {#1} {cluster-of} \l_tmpb_tl
+            \__tenkz_kernel_hull_dot_radius:nN {#1}
+              \l__tenkz_kernel_hull_radius_tl
             \tl_set:Ne #2
               {
                 {circle}
@@ -3414,8 +3467,10 @@
                     {
                       \quark_if_no_value_p:N \l_tmpb_tl
                         ? ( \quark_if_no_value_p:N \l_tmpa_tl
-                              ? \__tenkz_metric_ratio:n {dotdia} / 2
-                              : \__tenkz_metric_ratio:n {dotlabelband} )
+                              ? \l__tenkz_kernel_hull_radius_tl
+                              : max(
+                                  \l__tenkz_kernel_hull_radius_tl ,
+                                  \__tenkz_metric_ratio:n {dotlabelband} ) )
                         : \__tenkz_metric_ratio:n {clusterdot} / 2
                     }
                 }
@@ -3448,6 +3503,34 @@
             { \tl_use:N \l__tenkz_kernel_hull_b_tl }
             {0}
             { \tl_use:N \l__tenkz_kernel_hull_turn_tl }
+          }
+      }
+  }
+% Radius of an ordinary dot's declared size class, in pitch units.  Cluster
+% children keep their sub-frame radius in the caller above.
+\cs_new_protected:Npn \__tenkz_kernel_hull_dot_radius:nN #1#2
+  {
+    \__tenkz_model_get:nnN {#1} {size} \l__tenkz_kernel_hull_size_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_hull_size_tl
+      { \tl_set:Ne #2 { \__tenkz_metric_ratio:n {dotdia} / 2 } }
+      {
+        \str_case:Vn \l__tenkz_kernel_hull_size_tl
+          {
+            {s}
+              {
+                \tl_set:Ne #2
+                  { \__tenkz_metric_ratio:n {clusterdot} / 2 }
+              }
+            {m}
+              {
+                \tl_set:Ne #2
+                  { \__tenkz_metric_ratio:n {dotdia} / 2 }
+              }
+            {l}
+              {
+                \tl_set:Ne #2
+                  { \__tenkz_metric_ratio:n {glyphbox} / 2 }
+              }
           }
       }
   }
@@ -4172,6 +4255,13 @@
   }
 
 % ---------- index-wire ink ---------------------------------------------------------------------
+\cs_new_protected:Npn \__tenkz_kernel_r_wire_stroke:nn #1#2
+  {
+    \tl_set:Ne \l__tenkz_kernel_r_wire_style_tl
+      { #1 , \tl_use:N \l__tenkz_kernel_r_wire_ink_tl }
+    \exp_args:NV \__tenkz_render_stroke:nn
+      \l__tenkz_kernel_r_wire_style_tl {#2}
+  }
 \cs_new_protected:Npn \__tenkz_kernel_r_wire_queue:n #1
   {
     \__tenkz_model_get:nnN {#1} {kind} \l__tenkz_kernel_r_tl
@@ -4188,6 +4278,8 @@
         % ink.  This predeclares any curve named by an `on w t` end while
         % leaving unrelated string event order unchanged.
         \__tenkz_kernel_settle:n {#1}
+        \__tenkz_kernel_r_wire_ink:nN {#1}
+          \l__tenkz_kernel_r_wire_ink_tl
         \__tenkz_model_get:nnN {#1} {origin} \l__tenkz_kernel_r_tl
         \quark_if_no_value:NTF \l__tenkz_kernel_r_tl
           { \__tenkz_kernel_r_wire_ends:n {#1} }
@@ -4226,7 +4318,7 @@
             \__tenkz_kernel_r_frame_xy:nnNN
               { \l__tenkz_kernel_r_col_tl } {1}
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_render_stroke:nn { bond }
+            \__tenkz_kernel_r_wire_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
                   { \l__tenkz_kernel_r_x_fp }
@@ -4265,7 +4357,7 @@
               { \l__tenkz_kernel_r_col_tl }
               { \l__tenkz_kernel_r_cols_int }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_render_stroke:nn { bond }
+            \__tenkz_kernel_r_wire_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
                   { \l__tenkz_kernel_r_x_fp }
@@ -4302,7 +4394,7 @@
             \__tenkz_kernel_r_frame_xy:nnNN
               {1} { \l__tenkz_kernel_r_col_tl }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_render_stroke:nn { bond }
+            \__tenkz_kernel_r_wire_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
                   { \l__tenkz_kernel_r_x_fp }
@@ -4341,7 +4433,7 @@
               { \l__tenkz_kernel_r_rows_int }
               { \l__tenkz_kernel_r_col_tl }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_render_stroke:nn { bond }
+            \__tenkz_kernel_r_wire_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
                   { \l__tenkz_kernel_r_x_fp }
@@ -4462,7 +4554,7 @@
         % an ellipsis endpoint keeps daylight: the wire stops short of the dots
         \clist_map_inline:nn {from, to}
           { \__tenkz_kernel_r_dots_trim:nn {#1} {##1} }
-        \__tenkz_render_stroke:nn { bond }
+        \__tenkz_kernel_r_wire_stroke:nn { bond }
           {
             \__tenkz_kernel_r_pair:nn
               { \l__tenkz_kernel_r_x_fp } { \l__tenkz_kernel_r_y_fp }
@@ -4561,7 +4653,7 @@
                 + \__tenkz_metric_ratio:n {wrapreach}
               }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_render_stroke:nn { bond }
+            \__tenkz_kernel_r_wire_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
                   { \l__tenkz_kernel_r_x_fp }
@@ -4586,7 +4678,7 @@
               }
               { \l__tenkz_kernel_r_col_tl }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_render_stroke:nn { bond }
+            \__tenkz_kernel_r_wire_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
                   { \l__tenkz_kernel_r_x_fp }
@@ -4611,7 +4703,7 @@
               { \l__tenkz_kernel_r_row_tl + 1 }
               { \l__tenkz_kernel_r_col_tl }
               \l__tenkz_kernel_r_xb_fp \l__tenkz_kernel_r_yb_fp
-            \__tenkz_render_stroke:nn { bond }
+            \__tenkz_kernel_r_wire_stroke:nn { bond }
               {
                 \__tenkz_kernel_r_pair:nn
                   { \l__tenkz_kernel_r_x_fp }
@@ -4656,7 +4748,7 @@
       { \__tenkz_metric_ratio:n {pairtracereach} }
     \fp_set:Nn \l__tenkz_kernel_r_xc_fp
       { \l__tenkz_kernel_r_x_fp + \l__tenkz_kernel_r_reach_fp }
-    \__tenkz_render_stroke:nn { trace }
+    \__tenkz_kernel_r_wire_stroke:nn { trace }
       {
         \__tenkz_kernel_r_pair:nn
           { \l__tenkz_kernel_r_x_fp } { \l__tenkz_kernel_r_y_fp }
@@ -5073,31 +5165,89 @@
     \quark_if_no_value:NT #2 { \tl_set:Nn #2 {#1} }
   }
 
-% species -> hue, first species takes the first palette entry
+% Cache one undeclared or hue-less species in the house cycle.
+\cs_new_protected:Npn \__tenkz_kernel_r_cycle_hue:nN #1#2
+  {
+    \prop_get:NnNF \l__tenkz_kernel_r_species_prop {#1} #2
+      {
+        \tl_set:Ne #2
+          {
+            \clist_item:Nn \c__tenkz_speccycle_clist
+              {
+                \int_mod:nn
+                  { \prop_count:N \l__tenkz_kernel_r_species_prop }
+                  { \clist_count:N \c__tenkz_speccycle_clist }
+                + 1
+              }
+          }
+        \prop_put:NnV \l__tenkz_kernel_r_species_prop {#1} #2
+      }
+  }
+
+% Species -> hue.  An explicit hue is authoritative.  Hue-less declarations
+% and other named species take the house cycle in model-record order; the
+% undeclared prelude roles retain their fixed semantic hues.
 \cs_new_protected:Npn \__tenkz_kernel_r_hue:nN #1#2
   {
-    \__tenkz_model_get:nnN {#1} {species} \l__tenkz_kernel_r_c_tl
-    \quark_if_no_value:NTF \l__tenkz_kernel_r_c_tl
-      { \tl_set:Nn #2 { tenkzMarked } }
+    \__tenkz_model_get:nnN {#1} {species} \l__tenkz_kernel_r_species_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_r_species_tl
+      { \tl_set:Nn #2 { tenkzInk } }
       {
-        \prop_get:NVNF \l__tenkz_kernel_r_species_prop
-          \l__tenkz_kernel_r_c_tl #2
+        \prop_get:NVNTF \g__tenkz_kernel_species_prop
+          \l__tenkz_kernel_r_species_tl
+          \l__tenkz_kernel_r_species_descriptor_tl
           {
-            \int_compare:nNnTF
-              { \prop_count:N \l__tenkz_kernel_r_species_prop }
-              < { \seq_count:N \l__tenkz_kernel_r_palette_seq }
+            \exp_args:NnV \regex_extract_once:nnNTF
+              {
+                (?: \A | , ) \s* hue \s* = \s*
+                (?: \{ \s* )? (?: source: )?
+                ([^,{}\s]+) (?: \s* \} )?
+              }
+              \l__tenkz_kernel_r_species_descriptor_tl
+              \l__tenkz_kernel_r_hue_match_seq
               {
                 \tl_set:Ne #2
+                  { \seq_item:Nn \l__tenkz_kernel_r_hue_match_seq {2} }
+              }
+              {
+                \prop_get:NVNTF \g__tenkz_kernel_species_hue_prop
+                  \l__tenkz_kernel_r_species_tl #2
+                  { }
                   {
-                    \seq_item:Nn \l__tenkz_kernel_r_palette_seq
-                      {
-                        \prop_count:N \l__tenkz_kernel_r_species_prop + 1
-                      }
+                    \exp_args:NV \__tenkz_kernel_r_cycle_hue:nN
+                      \l__tenkz_kernel_r_species_tl #2
                   }
               }
-              { \tl_set:Nn #2 { tenkzMarked } }
-            \prop_put:NVV \l__tenkz_kernel_r_species_prop
-              \l__tenkz_kernel_r_c_tl #2
+          }
+          {
+            \str_case:VnF \l__tenkz_kernel_r_species_tl
+              {
+                {operator} { \tl_set:Nn #2 {tenkzOperator} }
+                {marked}   { \tl_set:Nn #2 {tenkzMarked} }
+                {extra}    { \tl_set:Nn #2 {tenkzExtra} }
+                {passive}  { \tl_set:Nn #2 {tenkzPassive} }
+              }
+              {
+                \exp_args:NV \__tenkz_kernel_r_cycle_hue:nN
+                  \l__tenkz_kernel_r_species_tl #2
+              }
+          }
+      }
+  }
+
+% Ink semantics shared by index wires and strings.
+\cs_new_protected:Npn \__tenkz_kernel_r_wire_ink:nN #1#2
+  {
+    \__tenkz_kernel_r_hue:nN {#1} \l__tenkz_kernel_r_hue_tl
+    \tl_set:Ne #2 { draw = \tl_use:N \l__tenkz_kernel_r_hue_tl }
+    \__tenkz_model_get:nnN {#1} {dir} \l__tenkz_kernel_r_c_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_r_c_tl
+      {
+        \str_case:Vn \l__tenkz_kernel_r_c_tl
+          {
+            {to}   { \tl_put_right:Nn #2 { , dir~marks } }
+            {from} { \tl_put_right:Nn #2 { , dir~marks~reversed } }
+            {none} { }
           }
       }
   }
@@ -5676,10 +5826,11 @@
     \seq_map_inline:Nn \l__tenkz_kernel_r_strings_seq
       {
         \__tenkz_kernel_r_sid:nN {##1} \l__tenkz_kernel_r_sid_tl
-        \__tenkz_kernel_r_hue:nN {##1} \l__tenkz_kernel_r_hue_tl
-        \__tenkz_render_string:nn
-          { \tl_use:N \l__tenkz_kernel_r_sid_tl }
-          { draw = \tl_use:N \l__tenkz_kernel_r_hue_tl }
+        \__tenkz_kernel_r_wire_ink:nN {##1}
+          \l__tenkz_kernel_r_wire_ink_tl
+        \exp_args:NVV \__tenkz_render_string:nn
+          \l__tenkz_kernel_r_sid_tl
+          \l__tenkz_kernel_r_wire_ink_tl
       }
   }
 
@@ -5773,15 +5924,25 @@
         {none} { }
         {dots}
           {
-            \__tenkz_kernel_r_xy:nNN {#1}
-              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
-            \__tenkz_render_labelnode:nnn
+            \tl_set:Nn \l__tenkz_kernel_r_atom_style_tl
               {
                 tenkz~audited~label ,
                 alias = #1 ,
                 inner~sep = \__tenkz_dim:n {labelclear} ,
                 fill = tenkzPaper
               }
+            \__tenkz_model_get:nnN {#1} {species}
+              \l__tenkz_kernel_r_species_tl
+            \quark_if_no_value:NF \l__tenkz_kernel_r_species_tl
+              {
+                \__tenkz_kernel_r_hue:nN {#1} \l__tenkz_kernel_r_hue_tl
+                \tl_put_right:Ne \l__tenkz_kernel_r_atom_style_tl
+                  { , text = \tl_use:N \l__tenkz_kernel_r_hue_tl }
+              }
+            \__tenkz_kernel_r_xy:nNN {#1}
+              \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+            \exp_args:NV \__tenkz_render_labelnode:nnn
+              \l__tenkz_kernel_r_atom_style_tl
               {
                 (
                   \__tenkz_kernel_r_pt:n { \l__tenkz_kernel_r_x_fp } ,
@@ -5792,21 +5953,56 @@
           }
         {dot}
           {
+            \__tenkz_model_get:nnN {#1} {species}
+              \l__tenkz_kernel_r_species_tl
+            \__tenkz_model_get:nnN {#1} {size} \l__tenkz_kernel_r_row_tl
             % a spin on a cluster's sub-frame is drawn at the sub-frame's
             % scale: four of them read as one site, and at the site dot's
             % size they would read as one blot
             \__tenkz_model_get:nnN {#1} {cluster-of} \l__tenkz_kernel_r_c_tl
             \quark_if_no_value:NTF \l__tenkz_kernel_r_c_tl
               {
-                \__tenkz_render_atom_scaled:nnnn
-                  { dot } {#1} { } { , alias = #1 }
+                \tl_set:Ne \l__tenkz_kernel_r_atom_style_tl
+                  { , alias = #1 }
+                \quark_if_no_value:NF \l__tenkz_kernel_r_species_tl
+                  {
+                    \__tenkz_kernel_r_hue:nN {#1}
+                      \l__tenkz_kernel_r_hue_tl
+                    \tl_put_right:Ne \l__tenkz_kernel_r_atom_style_tl
+                      {
+                        , draw = \tl_use:N \l__tenkz_kernel_r_hue_tl
+                        , fill = \tl_use:N \l__tenkz_kernel_r_hue_tl
+                      }
+                  }
+                \quark_if_no_value:NF \l__tenkz_kernel_r_row_tl
+                  {
+                    \tl_put_right:Ne \l__tenkz_kernel_r_atom_style_tl
+                      {
+                        , tenkz~dot~size~
+                            \tl_use:N \l__tenkz_kernel_r_row_tl
+                      }
+                  }
+                \exp_args:NnnnV \__tenkz_render_atom_scaled:nnnn
+                  { dot } {#1} { } \l__tenkz_kernel_r_atom_style_tl
               }
               {
-                \__tenkz_render_atom_scaled:nnnn { dot } {#1} { }
+                \tl_set:Ne \l__tenkz_kernel_r_atom_style_tl
                   {
                     , alias = #1
                     , minimum~size = \__tenkz_dim:n {clusterdot}
                   }
+                \quark_if_no_value:NF \l__tenkz_kernel_r_species_tl
+                  {
+                    \__tenkz_kernel_r_hue:nN {#1}
+                      \l__tenkz_kernel_r_hue_tl
+                    \tl_put_right:Ne \l__tenkz_kernel_r_atom_style_tl
+                      {
+                        , draw = \tl_use:N \l__tenkz_kernel_r_hue_tl
+                        , fill = \tl_use:N \l__tenkz_kernel_r_hue_tl
+                      }
+                  }
+                \exp_args:NnnnV \__tenkz_render_atom_scaled:nnnn
+                  { dot } {#1} { } \l__tenkz_kernel_r_atom_style_tl
               }
             % a dot cannot inscribe text: its label sits in the label band,
             % on the side label pos names, default south
@@ -5839,12 +6035,19 @@
                     \exp_args:NV \__tenkz_render_label_anchor:n
                       \l__tenkz_kernel_r_c_tl
                   }
-                \__tenkz_render_labelnode:nnn
+                \tl_set:Ne \l__tenkz_kernel_r_atom_style_tl
                   {
                     tenkz~audited~label ,
                     anchor = \tl_use:N \l__tenkz_kernel_r_c_tl ,
                     inner~sep = \__tenkz_dim:n {labelclear}
                   }
+                \quark_if_no_value:NF \l__tenkz_kernel_r_species_tl
+                  {
+                    \tl_put_right:Ne \l__tenkz_kernel_r_atom_style_tl
+                      { , text = \tl_use:N \l__tenkz_kernel_r_hue_tl }
+                  }
+                \exp_args:NV \__tenkz_render_labelnode:nnn
+                  \l__tenkz_kernel_r_atom_style_tl
                   {
                     (
                       \__tenkz_kernel_r_pt:n { \l__tenkz_kernel_r_x_fp } ,
@@ -5878,6 +6081,17 @@
           { skin = #2 } {#1}
         \tl_set:Nn #3 { box~tensor }
       }
+    \__tenkz_model_get:nnN {#1} {size} \l__tenkz_kernel_r_x_tl
+    % An absent size keeps the established per-skin geometry.  Once a class
+    % is requested, all canonical skins use its reference on both axes.
+    \quark_if_no_value:NF \l__tenkz_kernel_r_x_tl
+      {
+        \tl_put_right:Ne #3
+          {
+            , tenkz~canonical~size~
+                \tl_use:N \l__tenkz_kernel_r_x_tl
+          }
+      }
     \int_compare:nNnT { \l__tenkz_kernel_r_row_tl } > {1}
       {
         \tl_put_right:Ne #3
@@ -5910,6 +6124,17 @@
     \exp_args:NnV \__tenkz_kernel_r_atom_glyph_style:nnN
       {#1} \l__tenkz_kernel_r_tl \l__tenkz_kernel_r_c_tl
     \tl_put_right:Nn \l__tenkz_kernel_r_c_tl { , alias = #1 }
+    \__tenkz_model_get:nnN {#1} {species}
+      \l__tenkz_kernel_r_species_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_r_species_tl
+      {
+        \__tenkz_kernel_r_hue:nN {#1} \l__tenkz_kernel_r_hue_tl
+        \tl_put_right:Ne \l__tenkz_kernel_r_c_tl
+          {
+            , draw = \tl_use:N \l__tenkz_kernel_r_hue_tl
+            , text = \tl_use:N \l__tenkz_kernel_r_hue_tl
+          }
+      }
     % Ink the frame measures lies in the frame; ink the frame only places
     % stays upright.  A skin is measured, so it turns with its carrier; the
     % name inside it is placed, so it is turned back by the same angle and
@@ -6011,9 +6236,12 @@
     \__tenkz_model_get:nnN {#1} {label} \l__tenkz_kernel_r_b_tl
     \quark_if_no_value:NF \l__tenkz_kernel_r_b_tl
       {
+        \__tenkz_kernel_r_mark_text_ink:nN {#1}
+          \l__tenkz_kernel_r_mark_ink_tl
         \__tenkz_render_labelnode:nnn
           {
             tenkz~audited~label ,
+            \tl_use:N \l__tenkz_kernel_r_mark_ink_tl
             anchor = \exp_args:NV \__tenkz_render_label_anchor:n
               \l__tenkz_kernel_r_c_tl ,
             inner~sep = \__tenkz_dim:n {labelclear}
@@ -6035,6 +6263,16 @@
             )
           }
           { \tl_use:N \l__tenkz_kernel_r_b_tl }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_mark_text_ink:nN #1#2
+  {
+    \tl_clear:N #2
+    \__tenkz_model_get:nnN {#1} {species} \l__tenkz_kernel_r_species_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_r_species_tl
+      {
+        \__tenkz_kernel_r_hue:nN {#1} \l__tenkz_kernel_r_hue_tl
+        \tl_set:Ne #2 { text = \tl_use:N \l__tenkz_kernel_r_hue_tl , }
       }
   }
 
@@ -6110,22 +6348,28 @@
                 { \l__tenkz_kernel_r_xc_fp } { \l__tenkz_kernel_r_yc_fp } }
           }
       }
-    \__tenkz_model_get:nnN {#1} {slot} \l__tenkz_kernel_r_hue_tl
-    \quark_if_no_value:NTF \l__tenkz_kernel_r_hue_tl
-      { \tl_set:Nn \l__tenkz_kernel_r_hue_tl { tenkzPassive } }
+    \__tenkz_model_get:nnN {#1} {species} \l__tenkz_kernel_r_species_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_r_species_tl
       {
-        \tl_set:Ne \l__tenkz_kernel_r_hue_tl
+        % `slot` remains a compatibility spelling until the S4 surface swap.
+        \__tenkz_model_get:nnN {#1} {slot} \l__tenkz_kernel_r_hue_tl
+        \quark_if_no_value:NTF \l__tenkz_kernel_r_hue_tl
+          { \tl_set:Nn \l__tenkz_kernel_r_hue_tl { tenkzPassive } }
           {
-            \str_case:Vn \l__tenkz_kernel_r_hue_tl
+            \tl_set:Ne \l__tenkz_kernel_r_hue_tl
               {
-                {selected}   { tenkzMarked }
-                {secondary}  { tenkzAction }
-                {complement} { tenkzExtra }
-                {collar}     { tenkzPassive }
-                {neutral}    { tenkzPassive }
+                \str_case:Vn \l__tenkz_kernel_r_hue_tl
+                  {
+                    {selected}   { tenkzMarked }
+                    {secondary}  { tenkzAction }
+                    {complement} { tenkzExtra }
+                    {collar}     { tenkzPassive }
+                    {neutral}    { tenkzPassive }
+                  }
               }
           }
       }
+      { \__tenkz_kernel_r_hue:nN {#1} \l__tenkz_kernel_r_hue_tl }
     \__tenkz_render_stroke:en
       {
         draw = \tl_use:N \l__tenkz_kernel_r_hue_tl ,
@@ -6188,9 +6432,12 @@
     \__tenkz_model_get:nnN {#1} {label} \l__tenkz_kernel_r_b_tl
     \quark_if_no_value:NF \l__tenkz_kernel_r_b_tl
       {
+        \__tenkz_kernel_r_mark_text_ink:nN {#1}
+          \l__tenkz_kernel_r_mark_ink_tl
         \__tenkz_render_labelnode:nnn
           {
             tenkz~audited~label ,
+            \tl_use:N \l__tenkz_kernel_r_mark_ink_tl
             inner~sep = \__tenkz_dim:n {labelclear}
           }
           {
@@ -6227,8 +6474,16 @@
     \seq_clear:N \l__tenkz_kernel_r_strings_seq
     \seq_clear:N \l__tenkz_kernel_r_after_atom_seq
     \seq_clear:N \l__tenkz_kernel_ow_run_stack_seq
-    \seq_set_from_clist:Nn \l__tenkz_kernel_r_palette_seq
-      { tenkzMarked , tenkzAction , tenkzExtra , tenkzOperator }
+    % Document-scope hue-less declarations reserve their cycle slots before
+    % any picture-local undeclared name is assigned.  An unused declaration
+    % therefore cannot collide with an undeclared identity used earlier in
+    % this picture.
+    \prop_map_inline:Nn \g__tenkz_kernel_species_hue_prop
+      { \prop_put:Nnn \l__tenkz_kernel_r_species_prop {##1} {##2} }
+    % Resolve cycle assignment once in declaration order, before renderer
+    % staging separates wires from atoms.
+    \seq_map_inline:Nn \l__tenkz_model_record_seq
+      { \__tenkz_kernel_r_hue:nN {##1} \l__tenkz_kernel_r_hue_tl }
     \__tenkz_kernel_r_axis_read:
     \int_set:Nn \l__tenkz_kernel_r_rows_int { \__tenkz_kernel_rows: }
     \int_set:Nn \l__tenkz_kernel_r_cols_int { \__tenkz_kernel_cols: }

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -287,6 +287,7 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{up}{math-list}{empty}{kernel}{Outward physical labels, page-up.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{down}{math-list}{empty}{kernel}{Outward physical labels, page-down.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{species}{declared-name}{empty}{kernel}{Semantic species.}
+\__tenkz_language_registry_key:nnnnnn {kernel-atom}{size}{size-class}{m}{kernel}{Per-atom metric size class.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{label~pos}{angle}{auto}{kernel}{Label quadrant.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{nudge}{pair}{zero}{kernel}{Quarter-pitch displacement.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{void}{void-policy}{unset}{kernel}{Hole or removed site.}
@@ -314,6 +315,7 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-wire}{closed}{flag}{false}{kernel}{A smooth closed cycle; takes no ends.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{form}{enum(brace-above|brace-below|enclosure|cut|band|label|prose)}{label}{kernel}{Mark form.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{slot}{semantic-slot}{selected}{kernel}{Semantic tint.}
+\__tenkz_language_registry_key:nnnnnn {kernel-mark}{species}{declared-name}{empty}{kernel}{Semantic species.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{inset}{number}{0}{kernel}{Nested-contour step.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{label~pos}{angle}{auto}{kernel}{Label quadrant.}
 \__tenkz_language_registry_key:nnnnnn {kernel-mark}{nudge}{pair}{zero}{kernel}{Quarter-pitch displacement.}


### PR DESCRIPTION
## Summary

- resolve recorded atom and wire species into declared source hues or the house cycle at the shared kernel ink boundary
- render `dir=to|from` on strings and ordinary index wires, and expose `size=s|m|l` on canonical kernel atoms
- pin an inspected hue/direction/size fixture while keeping all ten golden kernel event streams byte-identical
- declare cited source palettes in the affected RMP cases and update their reviewed hashes/notes

Closes LionSR/tenkz#106.

## Validation

- `scripts/tenkz_kernel_probes.sh --check`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/tenkz_manual_doctest.py --list`
- `scripts/tenkz_corpus.sh` (264 standalone files)
- `python3 scripts/tenkz_rmp.py check --all` (130 targets)
- full-resolution visual inspection of the focused species/direction/size raster and source comparison for the F-symbol palette/directions
- `git diff --check`

## Contract

The ten pinned kernel record streams do not move. Unnamed records retain ordinary theme ink; declared `source:` palettes are authoritative; undeclared named species use the deterministic house cycle. The extension/census movement is recorded under `Extension-gate: LionSR/tenkz#106` and `Census-correction: LionSR/tenkz#106`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core kernel rendering (species hue resolution, strokes, atom/mark ink, hull sizing) across many RMP figures; behavior is heavily pinned by pixel and tnlog baselines but visual output changes are intentional.
> 
> **Overview**
> Kernel records already carried **species**, **dir**, and per-atom **size**, but rendering largely ignored them. This PR wires those fields through the shared ink path so output matches the LANGUAGE-1.0 semantic contract.
> 
> **Species ink** now resolves at render time: `\tndeclare{species}{…}{hue=source:…}` reproduces cited palettes, hue-less declarations get stable document-scope cycle slots, and undeclared names use the house cycle without reordering bugs across pictures. Hues apply to index wires, travelling strings, dots/boxes/rings, ellipsis **dots**, mark enclosures/labels, and **cluster** children inherit parent **species**.
> 
> **Direction** (`dir=to|from`) adds mid-wire barbs on both strings and ordinary index wires. **Atom `size=s|m|l`** is parsed on canonical atoms, drives dot/glyph metrics and live-hull measurement, and uses new `tenkz canonical size` styles on both axes.
> 
> Contract/docs/registry/census move with the change (+2 kernel keys: atom **size**, mark **species**). A new **`r_ink_semantics`** regression plus expanded kernel pixel pins exercise hue, direction, size, and cluster propagation while the ten golden **tnlog** streams stay byte-identical. Several RMP cases gain explicit `\tndeclare{species}{…}{hue=source:…}` and updated verdict hashes/notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5696357fdba4922c8ee7c5786ac240bb4b1e90a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->