### PR TITLE
feat(Channel/KoashiImoto): transport block form through joint support

### DIFF
--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 import TNLean.Channel.KoashiImoto.FamilyFixedPointBlockForm
 import TNLean.Channel.KoashiImoto.FiniteRealization
+import TNLean.Channel.KoashiImoto.JointSupport
 import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
 import TNLean.Channel.KoashiImoto.PooledKrausFamily

--- a/TNLean/Channel/KoashiImoto/JointSupport.lean
+++ b/TNLean/Channel/KoashiImoto/JointSupport.lean
@@ -1,0 +1,350 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.SupportInvariance
+import TNLean.Channel.KoashiImoto.PreservingBlockAction
+import TNLean.Channel.Spectral.Support
+
+/-!
+# Joint-support compression for invariant state families
+
+This file formalizes the support reduction at the start of the operator-algebraic
+Koashi--Imoto argument in Hayden, Jozsa, Petz and Winter,
+arXiv:quant-ph/0304007v2, Appendix A, lines 761--763.
+
+For a finite nonempty family of density matrices, the support of their common
+average is their minimum joint supporting subspace.  Compression to that
+subspace makes the common average positive definite, preserves the density
+normalization of every family member, and restricts every channel preserving
+the family to a trace-preserving channel on the support.
+
+## Main declarations
+
+* `Kraus.commonAverage_posSemidef`: the common average of a positive family is
+  positive semidefinite.
+* `Kraus.commonAverage_trace`: the common average of a trace-one family has
+  trace one.
+* `Kraus.supportCompressedFamily`: compression of a state family along an
+  isometry.
+* `Kraus.supportCompressedKraus`: compression of a Kraus family along the same
+  isometry.
+* `Kraus.map_supportCompressedKraus_intertwines`: the compressed Kraus map
+  intertwines with the ambient map on the joint support.
+* `Kraus.exists_commonAverageSupportCompression`: the source-faithful
+  joint-support reduction for an arbitrary finite density family.
+* `Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction_jointSupport`:
+  the unrestricted invariant-family block form and support-space channel
+  action.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+open Matrix Finset Complex
+
+namespace Kraus
+
+variable {D : ℕ}
+variable {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx]
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+/-- The common average of a positive-semidefinite family is positive
+semidefinite.
+
+This is the positive-matrix part of HJPW, arXiv:quant-ph/0304007v2,
+lines 761--763. -/
+theorem commonAverage_posSemidef (ρ : Kidx → Mat)
+    (hρpos : ∀ x, (ρ x).PosSemidef) :
+    (commonAverage ρ).PosSemidef := by
+  unfold commonAverage
+  exact (Matrix.posSemidef_sum Finset.univ fun x _ ↦ hρpos x).smul (by positivity)
+
+/-- The common average of a trace-one family has trace one. -/
+theorem commonAverage_trace (ρ : Kidx → Mat)
+    (hρtrace : ∀ x, (ρ x).trace = 1) :
+    (commonAverage ρ).trace = 1 := by
+  unfold commonAverage
+  rw [Matrix.trace_smul, Matrix.trace_sum]
+  simp [hρtrace, Fintype.card_ne_zero]
+
+/-- Compress every member of a matrix family along an isometry `V`. -/
+noncomputable def supportCompressedFamily {n : ℕ}
+    (V : Matrix (Fin D) (Fin n) ℂ) (ρ : Kidx → Mat) :
+    Kidx → Matrix (Fin n) (Fin n) ℂ :=
+  fun x ↦ Vᴴ * ρ x * V
+
+/-- Compress every Kraus operator along an isometry `V`. -/
+noncomputable def supportCompressedKraus {n r : ℕ}
+    (V : Matrix (Fin D) (Fin n) ℂ) (Kfam : Fin r → Mat) :
+    Fin r → Matrix (Fin n) (Fin n) ℂ :=
+  fun i ↦ Vᴴ * Kfam i * V
+
+/-- Compression intertwines a support-preserving Kraus map with its ambient
+action.
+
+This is the operation-transport step in HJPW,
+arXiv:quant-ph/0304007v2, Appendix A, lines 761--763. -/
+theorem map_supportCompressedKraus_intertwines {n r : ℕ}
+    (V : Matrix (Fin D) (Fin n) ℂ) (Kfam : Fin r → Mat) (Q : Mat)
+    (hV : Vᴴ * V = 1) (hVrange : V * Vᴴ = Q)
+    (hQproj : IsOrthogonalProjection Q)
+    (hLower : ∀ i, (1 - Q) * Kfam i * Q = 0) :
+    ∀ X, map Kfam (V * X * Vᴴ) =
+      V * map (supportCompressedKraus V Kfam) X * Vᴴ := by
+  intro X
+  have hsupported : Q * (V * X * Vᴴ) * Q = V * X * Vᴴ := by
+    calc
+      Q * (V * X * Vᴴ) * Q =
+          (V * Vᴴ) * (V * X * Vᴴ) * (V * Vᴴ) := by rw [hVrange]
+      _ = V * (Vᴴ * V) * X * (Vᴴ * V) * Vᴴ := by
+        simp only [Matrix.mul_assoc]
+      _ = V * X * Vᴴ := by rw [hV]; simp
+  have hinvariant :=
+    lowerZero_implies_invariance Kfam Q hQproj hLower (V * X * Vᴴ)
+  rw [hsupported] at hinvariant
+  rw [← hinvariant]
+  unfold map supportCompressedKraus
+  rw [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_sum, Matrix.sum_mul]
+  refine Finset.sum_congr rfl fun i _ ↦ ?_
+  rw [← hVrange]
+  simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+/-- Every member of a positive family is supported on the support of its
+common average.
+
+This identifies the support of the common average with the minimum joint
+support used by HJPW, arXiv:quant-ph/0304007v2, lines 761--763. -/
+theorem commonAverage_supports_family (ρ : Kidx → Mat)
+    (hρpos : ∀ x, (ρ x).PosSemidef) :
+    let hρbar := commonAverage_posSemidef ρ hρpos
+    ∀ x, hρbar.supportProj * ρ x * hρbar.supportProj = ρ x := by
+  classical
+  dsimp only
+  let hρbar := commonAverage_posSemidef ρ hρpos
+  intro x
+  have hker : ∀ v : Fin D → ℂ,
+      commonAverage ρ *ᵥ v = 0 → ρ x *ᵥ v = 0 := by
+    intro v hv
+    have hsum : (∑ y, ρ y) *ᵥ v = 0 := by
+      have hcard : ((Fintype.card Kidx : ℂ)⁻¹) ≠ 0 :=
+        inv_ne_zero (by exact_mod_cast Fintype.card_ne_zero)
+      change (((Fintype.card Kidx : ℂ)⁻¹) • (∑ y, ρ y)) *ᵥ v = 0 at hv
+      rw [Matrix.smul_mulVec] at hv
+      exact (smul_eq_zero.mp hv).resolve_left hcard
+    exact Matrix.PosSemidef.mulVec_eq_zero_of_sum_mulVec_eq_zero hρpos hsum x
+  have hright : ρ x * hρbar.supportProj = ρ x :=
+    hρbar.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le hker
+  have hleft : hρbar.supportProj * ρ x = ρ x := by
+    have h := congrArg Matrix.conjTranspose hright
+    simpa [Matrix.conjTranspose_mul, hρbar.supportProj_isHermitian.eq,
+      (hρpos x).isHermitian.eq] using h
+  rw [hleft, hright]
+
+/-- **Joint-support reduction for a finite invariant-state family.**
+
+For positive-semidefinite trace-one states `ρ x`, there are support coordinates
+`V : Fin n → Fin D` in which the common average is positive definite.  Every
+state reconstructs exactly from its compression, and every ambient CPTP Kraus
+family preserving `ρ` compresses to a CPTP Kraus family preserving the
+compressed states.
+
+This is HJPW, arXiv:quant-ph/0304007v2, Appendix A, lines 761--763.  It is the
+support-transport prerequisite for applying
+`exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction`
+without a full-support hypothesis on the original ambient space. -/
+theorem exists_commonAverageSupportCompression
+    (ρ : Kidx → Mat)
+    (hρpos : ∀ x, (ρ x).PosSemidef)
+    (hρtrace : ∀ x, (ρ x).trace = 1) :
+    ∃ (n : ℕ) (V : Matrix (Fin D) (Fin n) ℂ),
+      Vᴴ * V = 1 ∧
+      V * Vᴴ = (commonAverage_posSemidef ρ hρpos).supportProj ∧
+      (∀ x, (supportCompressedFamily V ρ x).PosSemidef) ∧
+      (∀ x, (supportCompressedFamily V ρ x).trace = 1) ∧
+      (commonAverage (supportCompressedFamily V ρ)).PosDef ∧
+      (∀ x, V * supportCompressedFamily V ρ x * Vᴴ = ρ x) ∧
+      ∀ F : PreservingKrausFamily ρ,
+        IsPreserving (supportCompressedFamily V ρ)
+            (supportCompressedKraus V F.Kfam) ∧
+          ∀ X, map F.Kfam (V * X * Vᴴ) =
+            V * map (supportCompressedKraus V F.Kfam) X * Vᴴ := by
+  classical
+  let hρbar := commonAverage_posSemidef ρ hρpos
+  obtain ⟨n, V, hV, hVrange⟩ :=
+    hρbar.isOrthogonalProjection_supportProj.exists_range_isometry
+  refine ⟨n, V, hV, hVrange, ?_, ?_, ?_, ?_, ?_⟩
+  · intro x
+    simpa only [supportCompressedFamily, Matrix.conjTranspose_conjTranspose] using
+      (hρpos x).mul_mul_conjTranspose_same Vᴴ
+  · intro x
+    rw [supportCompressedFamily, Matrix.trace_mul_cycle, hVrange]
+    have hsupp := commonAverage_supports_family ρ hρpos x
+    have hQρ : hρbar.supportProj * ρ x = ρ x := by
+      calc
+        hρbar.supportProj * ρ x =
+            hρbar.supportProj * (hρbar.supportProj * ρ x * hρbar.supportProj) := by
+              rw [hsupp]
+        _ = (hρbar.supportProj * hρbar.supportProj) *
+              ρ x * hρbar.supportProj := by simp [Matrix.mul_assoc]
+        _ = ρ x := by rw [hρbar.supportProj_idem, hsupp]
+    rw [hQρ]
+    exact hρtrace x
+  · have hcompression :=
+      hρbar.compression_on_support_posDef (V := Vᴴ)
+        (by simpa [Matrix.conjTranspose_conjTranspose] using hV)
+        (by simpa [Matrix.conjTranspose_conjTranspose] using hVrange)
+    have havg :
+        commonAverage (supportCompressedFamily V ρ) =
+          Vᴴ * commonAverage ρ * V := by
+      unfold commonAverage supportCompressedFamily
+      simp only [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_sum, Matrix.sum_mul]
+    rw [havg]
+    simpa only [Matrix.conjTranspose_conjTranspose] using hcompression
+  · intro x
+    change V * (Vᴴ * ρ x * V) * Vᴴ = ρ x
+    calc
+      V * (Vᴴ * ρ x * V) * Vᴴ =
+          (V * Vᴴ) * ρ x * (V * Vᴴ) := by simp [Matrix.mul_assoc]
+      _ = ρ x := by
+        rw [hVrange]
+        exact commonAverage_supports_family ρ hρpos x
+  · intro F
+    have hQproj := hρbar.isOrthogonalProjection_supportProj
+    have hInv : ∀ i : Fin F.numKraus,
+        (1 - hρbar.supportProj) * F.Kfam i * hρbar.supportProj = 0 := by
+      simpa only [stationaryProj] using
+        (lowerZero_of_posSemidef_fixedPoint F.Kfam (commonAverage ρ)
+          hρbar F.map_commonAverage).2
+    constructor
+    · constructor
+      · have hQV : hρbar.supportProj * V = V := by
+          rw [← hVrange]
+          simp [Matrix.mul_assoc, hV]
+        have hKV : ∀ i : Fin F.numKraus,
+            hρbar.supportProj * F.Kfam i * V = F.Kfam i * V := by
+          intro i
+          have h := hInv i
+          rw [Matrix.sub_mul, Matrix.sub_mul, Matrix.one_mul, sub_eq_zero] at h
+          calc
+            hρbar.supportProj * F.Kfam i * V =
+                hρbar.supportProj * F.Kfam i * (hρbar.supportProj * V) := by
+                  rw [hQV]
+            _ = (hρbar.supportProj * F.Kfam i * hρbar.supportProj) * V := by
+              simp [Matrix.mul_assoc]
+            _ = (F.Kfam i * hρbar.supportProj) * V := by rw [← h]
+            _ = F.Kfam i * V := by rw [Matrix.mul_assoc, hQV]
+        calc
+          ∑ i : Fin F.numKraus,
+              (supportCompressedKraus V F.Kfam i)ᴴ *
+                supportCompressedKraus V F.Kfam i
+              = Vᴴ * (∑ i : Fin F.numKraus, (F.Kfam i)ᴴ * F.Kfam i) * V := by
+                  rw [Matrix.mul_sum, Matrix.sum_mul]
+                  refine Finset.sum_congr rfl fun i _ ↦ ?_
+                  simp only [supportCompressedKraus, Matrix.conjTranspose_mul,
+                    Matrix.conjTranspose_conjTranspose]
+                  calc
+                    Vᴴ * ((F.Kfam i)ᴴ * V) * (Vᴴ * F.Kfam i * V) =
+                        Vᴴ * (F.Kfam i)ᴴ *
+                          ((V * Vᴴ) * F.Kfam i * V) := by
+                            simp [Matrix.mul_assoc]
+                    _ = Vᴴ * ((F.Kfam i)ᴴ * F.Kfam i) * V := by
+                      rw [hVrange, hKV]
+                      simp [Matrix.mul_assoc]
+          _ = 1 := by rw [F.isPreserving.1, Matrix.mul_one, hV]
+      · intro x
+        have hsupp := commonAverage_supports_family ρ hρpos x
+        have hmap :
+            map (supportCompressedKraus V F.Kfam)
+                (supportCompressedFamily V ρ x) =
+              Vᴴ * map F.Kfam (ρ x) * V := by
+          unfold map supportCompressedKraus supportCompressedFamily
+          rw [Matrix.mul_sum, Matrix.sum_mul]
+          refine Finset.sum_congr rfl fun i _ ↦ ?_
+          simp only [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+          calc
+            Vᴴ * F.Kfam i * V * (Vᴴ * ρ x * V) *
+                  (Vᴴ * ((F.Kfam i)ᴴ * V)) =
+                Vᴴ * (F.Kfam i * ((V * Vᴴ) * ρ x * (V * Vᴴ)) *
+                  (F.Kfam i)ᴴ) * V := by
+                    simp [Matrix.mul_assoc]
+            _ = Vᴴ * (F.Kfam i * ρ x * (F.Kfam i)ᴴ) * V := by
+              rw [hVrange, hsupp]
+        rw [hmap, F.isPreserving.2 x]
+        rfl
+    · exact map_supportCompressedKraus_intertwines V F.Kfam hρbar.supportProj
+        hV hVrange hQproj hInv
+
+/-- **Unrestricted Koashi--Imoto state and preserving-operation block form.**
+
+Every finite density family admits support coordinates in which the normalized
+state decomposition and the action of every preserving operation on the
+compressed family have the full-support form proved in
+`exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction`.
+
+The isometry `V` reconstructs the original family from the support coordinates.
+Every ambient preserving operation restricts to this family, and its ambient
+action intertwines with the compressed action.  The block equation itself is
+stated on the minimum joint support, so no artificial zero-weight density
+block is added on its orthogonal complement.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Appendix A, lines 761--816 and
+853--882.  TNLean uses the reverse tensor-factor order from HJPW. -/
+theorem exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction_jointSupport
+    (ρ : Kidx → Mat)
+    (hρpos : ∀ x, (ρ x).PosSemidef)
+    (hρtrace : ∀ x, (ρ x).trace = 1) :
+    ∃ (n : ℕ) (V : Matrix (Fin D) (Fin n) ℂ),
+      Vᴴ * V = 1 ∧
+      V * Vᴴ = (commonAverage_posSemidef ρ hρpos).supportProj ∧
+      (∀ x, V * supportCompressedFamily V ρ x * Vᴴ = ρ x) ∧
+      ∃ (K : ℕ) (d m : Fin K → ℕ)
+        (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+        (U : Matrix (Fin n) (Fin n) ℂ)
+        (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+        (q : Kidx → Fin K → ℝ)
+        (τ : Kidx → ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ),
+        U ∈ Matrix.unitaryGroup (Fin n) ℂ ∧
+          (∀ j, 0 < d j) ∧ (∀ j, 0 < m j) ∧
+          (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
+          (∀ x j, 0 ≤ q x j) ∧ (∀ x, ∑ j, q x j = 1) ∧
+          (∀ x j, (τ x j).PosSemidef) ∧ (∀ x j, (τ x j).trace = 1) ∧
+          (∀ x, star U * supportCompressedFamily V ρ x * U =
+            Matrix.reindex e e
+              (Matrix.blockDiagonal' fun j ↦
+                (q x j : ℂ) • (σ j ⊗ₖ τ x j))) ∧
+          (∀ F : PreservingKrausFamily ρ,
+            IsPreserving (supportCompressedFamily V ρ)
+                (supportCompressedKraus V F.Kfam) ∧
+              ∀ X, map F.Kfam (V * X * Vᴴ) =
+                V * map (supportCompressedKraus V F.Kfam) X * Vᴴ) ∧
+          ∀ G : PreservingKrausFamily (supportCompressedFamily V ρ),
+            ∃ C : (i : Fin G.numKraus) → ∀ j,
+                Matrix (Fin (m j)) (Fin (m j)) ℂ,
+              (∀ i,
+                Matrix.reindex e.symm e.symm
+                    (star U * G.Kfam i * U) =
+                  Matrix.blockDiagonal' fun j ↦
+                    C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) ∧
+              (∀ j, IsTP (fun i ↦ C i j)) ∧
+              (∀ j, map (fun i ↦ C i j) (σ j) = σ j) ∧
+              ∀ j (A : Matrix (Fin (m j)) (Fin (m j)) ℂ)
+                  (B : Matrix (Fin (d j)) (Fin (d j)) ℂ),
+                Matrix.reindex e.symm e.symm
+                    (star U * map G.Kfam
+                      (U * Matrix.reindex e e
+                        (Matrix.directSumBlockEmbedding (m := m) (d := d) j
+                          (A ⊗ₖ B)) * star U) * U) =
+                  Matrix.directSumBlockEmbedding (m := m) (d := d) j
+                    (map (fun i ↦ C i j) A ⊗ₖ B) := by
+  classical
+  obtain ⟨n, V, hV, hVrange, hρspos, hρstrace, hρsbar, hrec, hpres⟩ :=
+    exists_commonAverageSupportCompression ρ hρpos hρtrace
+  obtain ⟨K, d, m, e, U, σ, q, τ, hU, hd, hm, hσpos, hσtrace,
+      hqnonneg, hqsum, hτpos, hτtrace, hfamily, haction⟩ :=
+    exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction
+      hρspos hρstrace hρsbar
+  refine ⟨n, V, hV, hVrange, hrec, K, d, m, e, U, σ, q, τ, hU, hd, hm,
+    hσpos, hσtrace, hqnonneg, hqsum, hτpos, hτtrace, hfamily, hpres, haction⟩
+
+end Kraus

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1562,6 +1562,88 @@ algebra of a family of jointly invariant states.
     $F_\ell(\sigma_\ell)=\sigma_\ell$.
 \end{proof}
 
+\begin{theorem}[Joint-support compression of an invariant state family]
+    \label{thm:koashi_imoto_joint_support_compression}
+    \lean{Kraus.exists_commonAverageSupportCompression}
+    \leanok
+    Let $\rho_1,\ldots,\rho_K$ be density operators and let $Q$ be the
+    support projection of their average. There are an integer $r$ and an
+    isometry $V:\mathbb C^r\to\mathcal H$ with
+    $VV^\dagger=Q$ such that the compressed states
+    $\widehat\rho_k=V^\dagger\rho_kV$ are density operators, their average is
+    positive definite, and
+    \begin{align}
+        \rho_k=V\widehat\rho_kV^\dagger.
+    \end{align}
+    Every trace-preserving completely positive operation preserving all
+    $\rho_k$ compresses along the same isometry to a trace-preserving
+    completely positive operation $\widehat F$ preserving all
+    $\widehat\rho_k$. Its ambient and compressed actions intertwine:
+    \begin{align}
+        F(VXV^\dagger)=V\widehat F(X)V^\dagger.
+    \end{align}
+
+    This is the reduction to the minimum joint supporting subspace in HJPW,
+    Appendix~A, lines 761--763.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The kernel of the average is the intersection of the kernels of the
+    positive summands. Hence $Q\rho_kQ=\rho_k$ for every $k$. Choose an
+    isometry onto the range of $Q$. Compression then preserves positivity and
+    trace, reconstructs each state, and makes the compressed average positive
+    definite. Invariance of the average implies that every Kraus operator
+    preserves its support. Compressing the Kraus operators therefore preserves
+    both trace and every compressed state. Expanding the two Kraus sums and
+    using support invariance gives the displayed intertwining identity.
+\end{proof}
+
+\begin{theorem}[Invariant-family blocks on the joint support]
+    \label{thm:koashi_imoto_joint_support_block_action}
+    \lean{Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction_jointSupport}
+    \leanok
+    \uses{thm:koashi_imoto_joint_support_compression,
+        thm:koashi_imoto_preserving_block_action}
+    Let $\rho_1,\ldots,\rho_K$ be density operators, without a faithfulness
+    assumption on their average. On their minimum joint supporting subspace
+    there is one direct-sum tensor decomposition in which
+    \begin{align}
+        \widehat\rho_k
+        =
+        \bigoplus_j q_{j|k}\sigma_j\otimes\tau_{j|k},
+    \end{align}
+    where the weights form probability distributions and all displayed
+    factors are density operators. Every trace-preserving completely positive
+    operation preserving the compressed family acts on each diagonal summand
+    as
+    \begin{align}
+        F_j\otimes\operatorname{id},
+        \qquad F_j(\sigma_j)=\sigma_j.
+    \end{align}
+    In particular, every operation preserving the original family restricts
+    to such an operation, and its action transports back through the support
+    isometry by the intertwining identity above.
+    The support isometry reconstructs every original $\rho_k$ from
+    $\widehat\rho_k$.
+
+    This is HJPW Properties~1 and~$2'$ after the joint-support reduction in
+    Appendix~A, lines 761--816 and 853--882. The tensor factors are written in
+    the reverse order from HJPW.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Apply Theorem~\ref{thm:koashi_imoto_joint_support_compression}. The common
+    average is positive definite in the resulting support coordinates, so
+    Theorem~\ref{thm:koashi_imoto_preserving_block_action} applies there.
+    Apply the full-support block-action theorem to every preserving operation
+    of the compressed family. Operations preserving the original family
+    restrict along the same support isometry, and the intertwining identity
+    transports their action back to the ambient space. Use the reconstruction
+    identity for the family members.
+\end{proof}
+
 \begin{theorem}[Hayashi SSA-equality characterization]
     \label{thm:hayashi_ssa_equality_characterization}
     \lean{hayashi_ssa_equality_characterization}
@@ -1600,11 +1682,15 @@ algebra of a family of jointly invariant states.
     Theorem~\ref{thm:koashi_imoto_preserving_block_action} gives the action of
     every preserving operation on those blocks. Together these give
     Property~1 and the full-support specialization of Property~$2'$ under the
-    same explicit full-support hypothesis on the common average. The reduction
-    to the joint support, transport of this result to the recovered family,
-    and assembly of the quantum-Markov decomposition remain open. This forward
-    implication therefore remains axiomatic. The biconditional combines the
-    two directions.
+    same explicit full-support hypothesis on the common average.
+    Theorem~\ref{thm:koashi_imoto_joint_support_compression} constructs the
+    faithful support coordinates for an arbitrary finite family and restricts
+    every preserving operation to them.
+    Theorem~\ref{thm:koashi_imoto_joint_support_block_action} packages the
+    state blocks and operation action on that minimum joint support. Transport
+    to the recovered conditional family and assembly of the quantum-Markov
+    decomposition remain open. This forward implication therefore remains
+    axiomatic. The biconditional combines the two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -124,8 +124,11 @@ For MPDO renormalization fixed points:
   hypothesis on the common average. The corresponding Heisenberg Ces\`aro
   convergence identity remains open. The full-support family-level
   tensor-product state decomposition and HJPW Property~`2'` channel action are
-  formalized; the joint-support reduction and transport, together with the
-  generic Hayashi forward implication, remain open.
+  formalized. The joint-support coordinate reduction, state reconstruction,
+  and restriction of preserving operations are also formalized, together with
+  the combined block form on the minimum joint support. The recovered
+  conditional-family transport and the generic Hayashi forward implication
+  remain open.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -669,16 +669,21 @@ factorization of TNLean's generic completed product-reference channel.
 
 The full-support invariant-state decomposition and preserving-operation block
 action used in \cite[Theorem~6]{HaydenJozsaPetzWinter2004} are now available.
-Applying them after restriction to the joint support, transporting the result
-back to the recovered family, and assembling the quantum-Markov decomposition
-remain necessary before the forward external assumption can be removed.
+The joint-support reduction now constructs faithful support coordinates,
+reconstructs every family member, and restricts each preserving operation to
+those coordinates. The normalized family blocks and preserving-operation
+action are packaged on the minimum joint support. Transporting this theorem to
+the recovered conditional family and assembling the quantum-Markov
+decomposition remain necessary before the forward external assumption can be
+removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-joint-support transport and quantum-Markov assembly for the recovered family.
+conditional-family transport and quantum-Markov assembly for the recovered
+family.
 The full-support invariant-family state decomposition and preserving-operation
 block action are formalized. Source-facing
 completed-channel recovery from equality in data processing is available on
@@ -688,9 +693,10 @@ formalized without invertibility assumptions. The remaining forward structural
 direction alone is postulated. The reverse direction,
 a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
-and reindexing invariance. Until the joint-support transport and
-quantum-Markov assembly are formalized, the forward direction remains the
-irreducible unproved content of this characterization.
+and reindexing invariance. Until the joint-support block form is connected to
+the recovered conditional family and the quantum-Markov assembly is
+formalized, the forward direction remains the irreducible unproved content of
+this characterization.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -156,10 +156,12 @@ Equation~\eqref{eq:hjpw-global-support-factorization} supplies the
 product-reference recovery factorization required before the structural part
 of the HJPW argument. Under a positive-definite common-average hypothesis, the
 Koashi--Imoto state decomposition and the action of every preserving operation
-on its diagonal summands are now formalized below. To apply this result to an
-arbitrary recovered family, the remaining bridge must pass to the joint
-support, transport the full-support decomposition back to the original
-coordinates, and assemble one common direct sum
+on its diagonal summands are now formalized below. The joint-support
+compression, state reconstruction, restriction of ambient preserving
+operations, and intertwining of their compressed and ambient actions are also
+formalized. To apply this result to an arbitrary recovered family, the
+remaining bridge must construct and transport the recovered conditional
+family and assemble one common direct sum
 \begin{align}
   H_B\cong\bigoplus_j H_{B_j^L}\otimes H_{B_j^R}
 \end{align}
@@ -169,8 +171,8 @@ finite-Weyl argument and transported to arbitrary finite product coordinates.
 For density operators, support agreement upgrades this equality to the chosen
 completed partial-trace Petz channel on the recovered marginal. This does not
 give a tensor-product factorization of the generic completed singular channel.
-The joint-support transport and quantum-Markov assembly are the remaining
-structural obstructions to replacing the forward Hayashi
+The recovered conditional-family transport and quantum-Markov assembly are the
+remaining structural obstructions to replacing the forward Hayashi
 strong-subadditivity equality assumption used in the CPSV16 argument.
 
 \section{Common invariant algebra: formalized under an explicit full-support hypothesis}
@@ -251,8 +253,8 @@ positive semidefinite, and normalizes them as
 \end{align}
 where each $\tau_{j|k}$ is a density matrix. Thus the full-support
 specialization of HJPW Property~1, lines 785--789 and 857--858, is formalized,
-with the two tensor factors written in the reverse order. The unrestricted
-property remains open pending the joint-support reduction.
+with the two tensor factors written in the reverse order. Its unrestricted
+joint-support form is supplied by the joint-support declaration below.
 
 The preserving-block-action declaration proves the full-support specialization
 of HJPW Property~$2'$, lines 808--816 and 860--882, in the same coordinates.
@@ -269,15 +271,21 @@ the Stinespring form of Property~2 or an action on off-diagonal coherences.
 
 HJPW's argument reduces to the case where the common average
 $(1/K)\sum_k\rho_k$ has full support, by shrinking the working Hilbert space to
-the joint support of the $\rho_k$ (lines 761--763). That reduction is not
-derived here: every declaration that builds $A_0$ instead takes positive
-definiteness of the common average as an explicit hypothesis. Beyond this
-scope restriction, none of the following are claimed: the joint-support
-reduction and transport to the unrestricted family; assembly of the recovered
-family into the generic quantum-Markov decomposition; or elimination of the
-external assumption for the forward Hayashi strong-subadditivity implication.
-These remain the open structural obstructions identified in the previous
-section.
+the joint support of the $\rho_k$ (lines 761--763). The declaration
+\leanid{Kraus.exists_commonAverageSupportCompression} now constructs this
+support coordinate space, proves that the compressed average is positive
+definite, reconstructs every family member, and restricts every preserving
+operation to a trace-preserving operation on the support. It also proves the
+intertwining identity that transports the compressed channel action back
+through the support isometry. The declaration
+\leanid{Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction_jointSupport}
+then packages the normalized state blocks and the action of every preserving
+operation on that minimum joint support; ambient preserving operations inherit
+this action by restriction and intertwining. Construction and transport of the
+recovered conditional family, assembly of the generic quantum-Markov
+decomposition, and elimination of the
+external assumption for the forward Hayashi strong-subadditivity implication
+remain open.
 
 \section{Classification}
 
@@ -303,9 +311,12 @@ and density matrices on both tensor factors. In the same coordinates, every
 preserving operation acts as a local trace-preserving completely positive
 operation fixing $\sigma_j$, tensored with the identity, on each diagonal
 summand. Thus full-support HJPW Property~$2'$ is also formalized. The
-Heisenberg Ces\`aro convergence identity for $P_0^*$, the joint-support
-reduction and transport, and the generic Hayashi forward implication remain
-open as separate later steps.
+Heisenberg Ces\`aro convergence identity for $P_0^*$ remains open. The
+joint-support coordinate reduction, density-family reconstruction, and
+restriction of preserving operations are formalized, as is the combined block
+form on the minimum joint support. The recovered conditional-family transport
+and the generic Hayashi forward implication remain open as separate later
+steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Fixes #5022.

## Summary

- construct the minimum joint-support coordinates of an arbitrary finite density family
- prove positivity, normalization, positive-definite common average, and exact state reconstruction after compression
- compress every ambient preserving Kraus family to a preserving CPTP family and prove the ambient/support intertwining identity
- apply the full-support Koashi--Imoto theorem to every preserving operation on the compressed family
- synchronize the Blueprint and paper-gap ledger with the completed joint-support boundary

## Source boundary

This formalizes the support reduction at HJPW Appendix A, lines 761--763 and transports Properties 1 and 2' through that reduction (lines 785--816 and 853--882). TNLean keeps its existing reverse tensor-factor convention.

The result does not add a zero block on the orthogonal complement. It states the block form on the minimum joint support and reconstructs the ambient states and ambient preserving-operation action through the support isometry.

## Out of scope

- construction and transport of the recovered conditional family
- rectangular recovery/dilation lift needed by the HJPW Markov argument
- final quantum-Markov direct-sum assembly
- removal of the forward Hayashi SSA-equality assumption

## Validation

- `lake exe cache get` before any Lean build in the fresh worktree
- `lake env lean TNLean/Channel/KoashiImoto/JointSupport.lean`
- `lake build TNLean.Channel.KoashiImoto.JointSupport`
- `lake build`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/test_lean_file_policies.py`
- `python3 scripts/test_generate_import_aggregators.py`
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- visual inspection of the rendered joint-support theorem pages

The full build retains the pre-existing `sorry` warning in `TNLean/MPS/Periodic/Overlap/SectorMatch.lean:600`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New operator-algebra and channel-compression proofs in a critical entropy/Markov path; scope is additive and downstream assembly is still open, but errors here would affect later SSA-equality work.
> 
> **Overview**
> Adds **`TNLean/Channel/KoashiImoto/JointSupport.lean`**, formalizing HJPW’s minimum joint-support step (Appendix A, ~761–763) and composing it with the existing full-support Koashi–Imoto block theorems.
> 
> For a finite family of density matrices, the new results build support coordinates where the common average is **positive definite**, each state **reconstructs** from its compression, and every ambient preserving Kraus family **compresses** to a CPTP family with an **intertwining** identity between ambient and compressed channel action. A second theorem packages the normalized tensor-block state decomposition and preserving-operation action on that joint support (without assuming a full-support common average).
> 
> Blueprint chapter 19 and the paper-gap notes are updated to record this boundary; **recovered conditional-family transport**, quantum-Markov assembly, and removal of the forward Hayashi SSA assumption remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b457ca9282e1a7a9d584087b57f4dbb8cb41d535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->