### PR TITLE
feat(Channel/KoashiImoto): construct recovered conditional family

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -604,17 +604,18 @@ end BipartiteHermiticity
 /-! ## SSA equality condition
 
 The Hayashi characterization of equality in strong subadditivity is defined as
-a predicate. The theorem (equality ↔ recovery map condition) is the sanctioned
-axiom `hayashi_ssa_equality_characterization` in
-`TNLean/Axioms/Entropy.lean`.
+a predicate. The forward implication from equality to a quantum-Markov
+decomposition is the sanctioned axiom
+`hayashi_ssa_equality_characterization_forward` in
+`TNLean/Axioms/Entropy.lean`; the reverse implication is proved.
 
 Source: Hayashi, *Quantum Information: An Introduction*, Springer 2006,
 Theorem 5.24; Hayden--Jozsa--Petz--Winter, Commun. Math. Phys. 246,
 359--374 (2004);
 blueprint `def:ssa_equality`.
 
-TODO: Replace with a proof following Hayashi, "Quantum Information: An
-Introduction", Springer 2006, Theorem 5.24. -/
+TODO: Apply the joint-support block theorem to the recovered conditional
+family and assemble the resulting quantum-Markov decomposition. -/
 
 section SSAEquality
 

--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -35,12 +35,9 @@ clear to downstream files and to CI.
 ## TODO
 
 Remove the remaining axiom `hayashi_ssa_equality_characterization_forward` by
-proving the forward implication of the equality case. A faithful formalization
-is expected to require:
-1. Conditional mutual information and recovery maps (the Petz transpose channel)
-2. The saturation analysis of the data-processing inequality for relative
-   entropy
-3. The reconstruction of the discarded subsystem from a recovery map
+applying the formalized joint-support Koashi--Imoto block theorem to the
+finite recovered conditional family and assembling those blocks into the
+quantum-Markov decomposition of the tripartite state.
 
 ## References
 
@@ -80,8 +77,10 @@ direct sum `⊕_j (B_jᴸ ⊗ B_jᴿ)` and the state takes block-diagonal form
 This implication is the deep half of the characterization: its proof needs
 recovery-map and Petz-transpose theory, that is, the analysis of when the
 data-processing inequality for relative entropy is saturated and the
-reconstruction of the discarded subsystem from a recovery map. This machinery is
-not yet formalized in Mathlib or in this repository, so the forward direction is
+reconstruction of the discarded subsystem from a recovery map. The recovery
+channel, finite recovered conditional family, and joint-support
+Koashi--Imoto theorem are formalized; their blockwise application and the
+final quantum-Markov assembly remain open. The forward direction is therefore
 introduced here as a **sanctioned axiom**. The reverse direction is proved in
 `TNLean.Analysis.EntropyMarkovReverse` and the biconditional below combines the
 two; see `docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex`.

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -22,6 +22,7 @@ import TNLean.Channel.Determinant.HilbertSchmidt
 import TNLean.Channel.Determinant.UnitaryCharacterization
 import TNLean.Channel.EntanglementWitness
 import TNLean.Channel.FixedPoint
+import TNLean.Channel.InformationallyCompleteEffects
 import TNLean.Channel.Irreducible
 import TNLean.Channel.KoashiImoto
 import TNLean.Channel.KrausCPTP

--- a/TNLean/Channel/InformationallyCompleteEffects.lean
+++ b/TNLean/Channel/InformationallyCompleteEffects.lean
@@ -1,0 +1,359 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.HermitianHelpers
+import TNLean.Analysis.MatrixSqrt
+import TNLean.Channel.PartialTrace
+import TNLean.Channel.TensorMap
+import TNLean.Channel.WolfProps
+
+/-!
+# A finite informationally complete family of effects
+
+This file constructs a finite family of positive effects whose complex span is
+the full matrix algebra.  The construction uses the four rank-one projectors in
+the polarization identity.
+
+This is the finite separation device for the conditional states in Hayden,
+Jozsa, Petz and Winter, arXiv:quant-ph/0304007v2, Theorem 6, lines 499--505.
+
+## Main declarations
+
+* `Matrix.ICEffectIndex`: indices for the finite effect family.
+* `Matrix.informationallyCompleteEffect`: the effects.
+* `Matrix.informationallyCompleteEffect_posSemidef`: every family member is
+  positive semidefinite.
+* `Matrix.informationallyCompleteEffect_le_one`: every family member is at most
+  the identity.
+* `Matrix.linearMap_eq_zero_of_apply_informationallyCompleteEffect_eq_zero`:
+  vanishing on the family forces a linear map to vanish.
+* `Matrix.eq_of_conditionalSlice_informationallyCompleteEffect_eq`: the
+  conditional slices against the finite family separate bipartite matrices.
+-/
+
+open scoped ComplexOrder MatrixOrder Kronecker
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- Indices for a distinguished identity effect and the four polarization
+effects for every ordered pair of coordinate vectors. -/
+abbrev ICEffectIndex (D : ℕ) :=
+  Unit ⊕ (Fin D × Fin D × Fin 4)
+
+/-- The coordinate vector scaled by one half. -/
+noncomputable def halfCoordinateVector (i : Fin D) : Fin D → ℂ :=
+  (2 : ℂ)⁻¹ • Pi.single i 1
+
+/-- The four scaled vectors used by the polarization identity. -/
+noncomputable def informationallyCompleteVector
+    (i j : Fin D) (t : Fin 4) : Fin D → ℂ :=
+  halfCoordinateVector i +
+    ![(1 : ℂ), -1, Complex.I, -Complex.I] t • halfCoordinateVector j
+
+/-- A finite informationally complete family of positive effects.
+
+The distinguished member is the identity.  Every other member is the
+rank-one projector onto one of the four scaled polarization vectors. -/
+noncomputable def informationallyCompleteEffect
+    (s : ICEffectIndex D) : Matrix (Fin D) (Fin D) ℂ :=
+  match s with
+  | Sum.inl _ => 1
+  | Sum.inr ⟨i, j, t⟩ =>
+      vecMulVec (informationallyCompleteVector i j t)
+        (star (informationallyCompleteVector i j t))
+
+/-- Every informationally complete effect is positive semidefinite. -/
+theorem informationallyCompleteEffect_posSemidef
+    (s : ICEffectIndex D) :
+    (informationallyCompleteEffect s).PosSemidef := by
+  rcases s with _ | ⟨i, j, t⟩
+  · exact Matrix.PosSemidef.one
+  · exact Matrix.posSemidef_vecMulVec_self_star _
+
+/-- Every polarization vector has squared norm at most one. -/
+theorem informationallyCompleteVector_sum_norm_sq_le_one
+    (i j : Fin D) (t : Fin 4) :
+    ∑ k, ‖informationallyCompleteVector i j t k‖ ^ 2 ≤ 1 := by
+  let u : EuclideanSpace ℂ (Fin D) :=
+    WithLp.toLp 2 (halfCoordinateVector i)
+  let v : EuclideanSpace ℂ (Fin D) :=
+    WithLp.toLp 2 (halfCoordinateVector j)
+  let c : ℂ := ![(1 : ℂ), -1, Complex.I, -Complex.I] t
+  rw [← EuclideanSpace.norm_sq_eq
+    (WithLp.toLp 2 (informationallyCompleteVector i j t))]
+  change ‖u + c • v‖ ^ 2 ≤ 1
+  have hu : ‖u‖ = 1 / 2 := by
+    change ‖(2 : ℂ)⁻¹ • PiLp.single 2 i 1‖ = 1 / 2
+    rw [norm_smul, PiLp.norm_single]
+    norm_num
+  have hv : ‖v‖ = 1 / 2 := by
+    change ‖(2 : ℂ)⁻¹ • PiLp.single 2 j 1‖ = 1 / 2
+    rw [norm_smul, PiLp.norm_single]
+    norm_num
+  have hc : ‖c‖ = 1 := by
+    fin_cases t <;> norm_num [c, Complex.normSq_apply]
+  have hnorm : ‖u + c • v‖ ≤ 1 := by
+    calc
+      ‖u + c • v‖ ≤ ‖u‖ + ‖c • v‖ := norm_add_le _ _
+      _ = 1 := by rw [norm_smul, hu, hv, hc]; norm_num
+  nlinarith [norm_nonneg (u + c • v)]
+
+/-- Every informationally complete effect is bounded above by the identity. -/
+theorem informationallyCompleteEffect_le_one
+    (s : ICEffectIndex D) :
+    informationallyCompleteEffect s ≤ 1 := by
+  rcases s with _ | ⟨i, j, t⟩
+  · rfl
+  · exact one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one _
+      (informationallyCompleteVector_sum_norm_sq_le_one i j t)
+
+/-- A complex-linear map that vanishes on the informationally complete effects
+vanishes everywhere. -/
+theorem linearMap_eq_zero_of_apply_informationallyCompleteEffect_eq_zero
+    {N : Type*} [AddCommGroup N] [Module ℂ N]
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] N)
+    (hT : ∀ s, T (informationallyCompleteEffect s) = 0) :
+    T = 0 := by
+  classical
+  have hsingle (i j : Fin D) : T (Matrix.single i j 1) = 0 := by
+    have hpolarization :=
+      (WolfProps.vecMulVec_star_eq_polarization
+        (halfCoordinateVector i) (halfCoordinateVector j))
+    have h0 (t : Fin 4) :
+        T (vecMulVec (informationallyCompleteVector i j t)
+          (star (informationallyCompleteVector i j t))) = 0 := by
+      simpa only [informationallyCompleteEffect] using
+        hT (Sum.inr ⟨i, j, t⟩)
+    have hleft :
+        (4 : ℂ) •
+            vecMulVec (halfCoordinateVector i) (star (halfCoordinateVector j)) =
+          Matrix.single i j 1 := by
+      ext a b
+      by_cases hai : i = a
+      · subst a
+        by_cases hbj : j = b
+        · subst b
+          norm_num [halfCoordinateVector, Matrix.vecMulVec_apply, Matrix.single]
+        · simp [halfCoordinateVector, Matrix.vecMulVec_apply,
+            Matrix.single, hbj]
+      · simp [halfCoordinateVector, Matrix.vecMulVec_apply,
+          Matrix.single, hai]
+    rw [hleft] at hpolarization
+    have h0₀ : T (vecMulVec (halfCoordinateVector i + halfCoordinateVector j)
+        (star (halfCoordinateVector i + halfCoordinateVector j))) = 0 := by
+      simpa [informationallyCompleteVector] using h0 0
+    have h0₁ : T (vecMulVec (halfCoordinateVector i - halfCoordinateVector j)
+        (star (halfCoordinateVector i - halfCoordinateVector j))) = 0 := by
+      simpa [informationallyCompleteVector, sub_eq_add_neg] using h0 1
+    have h0₂ : T (vecMulVec
+        (halfCoordinateVector i + Complex.I • halfCoordinateVector j)
+        (star (halfCoordinateVector i + Complex.I • halfCoordinateVector j))) = 0 := by
+      simpa [informationallyCompleteVector] using h0 2
+    have h0₃ : T (vecMulVec
+        (halfCoordinateVector i - Complex.I • halfCoordinateVector j)
+        (star (halfCoordinateVector i - Complex.I • halfCoordinateVector j))) = 0 := by
+      simpa [informationallyCompleteVector, sub_eq_add_neg] using h0 3
+    rw [hpolarization, map_sub, map_add, map_sub, map_smul, map_smul,
+      h0₀, h0₁, h0₂, h0₃]
+    simp
+  exact LinearMap.ext_on_range (Matrix.stdBasis ℂ (Fin D) (Fin D)).span_eq
+    fun ⟨i, j⟩ ↦ by
+      rw [Matrix.stdBasis_eq_single, hsingle]
+      rfl
+
+/-! ## Conditional-slice separation -/
+
+variable {A B : ℕ}
+
+/-- The subnormalized conditional slice obtained by testing the first factor
+against `M`.
+
+This is HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 499--502:
+`Tr_A(ρ_AB (M ⊗ 1))`. -/
+noncomputable def conditionalSlice
+    (ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (M : Matrix (Fin A) (Fin A) ℂ) :
+    Matrix (Fin B) (Fin B) ℂ :=
+  fun k l ↦ ∑ i, ∑ j, ρ (i, k) (j, l) * M j i
+
+/-- The entrywise conditional slice agrees with the partial-trace formula in
+HJPW. -/
+theorem conditionalSlice_eq_partialTraceLeft
+    (ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (M : Matrix (Fin A) (Fin A) ℂ) :
+    conditionalSlice ρ M =
+      partialTraceLeft (ρ * (M ⊗ₖ (1 : Matrix (Fin B) (Fin B) ℂ))) := by
+  classical
+  ext k l
+  simp only [conditionalSlice, partialTraceLeft_apply, Matrix.mul_apply,
+    Matrix.kroneckerMap_apply, Matrix.one_apply]
+  simp_rw [Fintype.sum_prod_type]
+  simp
+
+/-- The left partial trace is cyclic with respect to an operator acting only
+on the traced factor. -/
+theorem partialTraceLeft_mul_kronecker_one_comm
+    (X : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (M : Matrix (Fin A) (Fin A) ℂ) :
+    partialTraceLeft (X * (M ⊗ₖ (1 : Matrix (Fin B) (Fin B) ℂ))) =
+      partialTraceLeft ((M ⊗ₖ (1 : Matrix (Fin B) (Fin B) ℂ)) * X) := by
+  classical
+  ext k l
+  simp only [partialTraceLeft_apply, Matrix.mul_apply,
+    Matrix.kroneckerMap_apply, Matrix.one_apply]
+  simp_rw [Fintype.sum_prod_type]
+  simp only [mul_ite, mul_one, mul_zero, ite_mul, zero_mul,
+    Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
+  simp_rw [show ∀ x : Fin B, k = x ↔ x = k from fun x ↦ eq_comm]
+  simp only [Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
+  calc
+    (∑ x, ∑ y, X (x, k) (y, l) * M y x) =
+        ∑ x, ∑ y, M y x * X (x, k) (y, l) := by
+      apply Finset.sum_congr rfl
+      intro x _
+      exact Finset.sum_congr rfl fun y _ ↦ mul_comm _ _
+    _ = ∑ y, ∑ x, M y x * X (x, k) (y, l) := Finset.sum_comm
+
+/-- A positive bipartite matrix has positive conditional slices against
+positive effects. -/
+theorem PosSemidef.conditionalSlice
+    {ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ}
+    {M : Matrix (Fin A) (Fin A) ℂ}
+    (hρ : ρ.PosSemidef) (hM : M.PosSemidef) :
+    (conditionalSlice ρ M).PosSemidef := by
+  let S := hM.isHermitian.cfc Real.sqrt
+  let K := S ⊗ₖ (1 : Matrix (Fin B) (Fin B) ℂ)
+  have hS : Sᴴ = S := hM.cfc_sqrt_isHermitian.eq
+  have hSS : S * S = M := hM.cfc_sqrt_mul_self
+  have hK : Kᴴ = K := by
+    simp only [K, Matrix.conjTranspose_kronecker, hS, Matrix.conjTranspose_one]
+  rw [conditionalSlice_eq_partialTraceLeft,
+    partialTraceLeft_mul_kronecker_one_comm]
+  have hMM :
+      M ⊗ₖ (1 : Matrix (Fin B) (Fin B) ℂ) = K * K := by
+    simp only [K, ← Matrix.mul_kronecker_mul, hSS, Matrix.one_mul]
+  rw [hMM, Matrix.mul_assoc]
+  rw [← partialTraceLeft_mul_kronecker_one_comm
+    (X := K * ρ) (M := S)]
+  simpa only [hK] using
+    (hρ.mul_mul_conjTranspose_same K).partialTraceLeft
+
+/-- The trace of a conditional slice is the probability of the tested
+effect. -/
+theorem trace_conditionalSlice
+    (ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (M : Matrix (Fin A) (Fin A) ℂ) :
+    (conditionalSlice ρ M).trace =
+      (ρ * (M ⊗ₖ (1 : Matrix (Fin B) (Fin B) ℂ))).trace := by
+  rw [conditionalSlice_eq_partialTraceLeft, trace_partialTraceLeft]
+
+/-- Conditional slicing is a finite linear combination of bipartite blocks. -/
+theorem conditionalSlice_eq_sum_smul_bipartiteBlock
+    (ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (M : Matrix (Fin A) (Fin A) ℂ) :
+    conditionalSlice ρ M =
+      ∑ i, ∑ j, M j i • bipartiteBlock ρ i j := by
+  classical
+  ext k l
+  simp only [conditionalSlice, Matrix.sum_apply, Matrix.smul_apply,
+    bipartiteBlock_apply, smul_eq_mul]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  ring
+
+/-- A linear map on the retained factor commutes with conditional slicing. -/
+theorem map_conditionalSlice
+    {C : ℕ}
+    (T : Matrix (Fin B) (Fin B) ℂ →ₗ[ℂ] Matrix (Fin C) (Fin C) ℂ)
+    (ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (M : Matrix (Fin A) (Fin A) ℂ) :
+    T (conditionalSlice ρ M) =
+      conditionalSlice (idTensorMapLM (δ := Fin A) T ρ) M := by
+  classical
+  rw [conditionalSlice_eq_sum_smul_bipartiteBlock, map_sum]
+  simp_rw [map_sum, map_smul]
+  rw [conditionalSlice_eq_sum_smul_bipartiteBlock]
+  congr 1
+
+/-- Conditional slicing as a complex-linear map in the tested effect. -/
+noncomputable def conditionalSliceLM
+    (ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ) :
+    Matrix (Fin A) (Fin A) ℂ →ₗ[ℂ] Matrix (Fin B) (Fin B) ℂ where
+  toFun := conditionalSlice ρ
+  map_add' := by
+    intro M N
+    ext k l
+    simp [conditionalSlice, mul_add, Finset.sum_add_distrib]
+  map_smul' := by
+    intro c M
+    ext k l
+    simp only [conditionalSlice, Matrix.smul_apply, smul_eq_mul]
+    change (∑ i, ∑ j, ρ (i, k) (j, l) * (c * M j i)) =
+      (RingHom.id ℂ) c * (∑ i, ∑ j, ρ (i, k) (j, l) * M j i)
+    have hterm (i j : Fin A) :
+        ρ (i, k) (j, l) * (c * M j i) =
+          c * (ρ (i, k) (j, l) * M j i) := by ring
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl fun j _ ↦ hterm i j
+
+@[simp]
+theorem conditionalSliceLM_apply
+    (ρ : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (M : Matrix (Fin A) (Fin A) ℂ) :
+    conditionalSliceLM ρ M = conditionalSlice ρ M := rfl
+
+/-- The finite informationally complete effects separate bipartite matrices by
+their conditional slices.
+
+This supplies the finite replacement for “varying `M`” in HJPW,
+arXiv:quant-ph/0304007v2, Theorem 6, lines 499--505. -/
+theorem eq_of_conditionalSlice_informationallyCompleteEffect_eq
+    (X Y : Matrix (Fin A × Fin B) (Fin A × Fin B) ℂ)
+    (h : ∀ s, conditionalSlice X (informationallyCompleteEffect s) =
+      conditionalSlice Y (informationallyCompleteEffect s)) :
+    X = Y := by
+  classical
+  let T := conditionalSliceLM (X - Y)
+  have hT : ∀ s, T (informationallyCompleteEffect s) = 0 := by
+    intro s
+    change conditionalSlice (X - Y) (informationallyCompleteEffect s) = 0
+    ext k l
+    have hs := congrFun (congrFun (h s) k) l
+    simpa [conditionalSlice, sub_mul, Finset.sum_sub_distrib] using sub_eq_zero.mpr hs
+  have hTzero :=
+    linearMap_eq_zero_of_apply_informationallyCompleteEffect_eq_zero T hT
+  ext ⟨i, k⟩ ⟨j, l⟩
+  have hentry := congrFun (congrFun
+    (LinearMap.congr_fun hTzero (Matrix.single j i 1)) k) l
+  change conditionalSlice (X - Y) (Matrix.single j i 1) k l = 0 at hentry
+  simp only [conditionalSlice, Matrix.sub_apply, Matrix.single] at hentry
+  change (∑ x, ∑ y, (X (x, k) (y, l) - Y (x, k) (y, l)) *
+    (if j = y ∧ i = x then 1 else 0)) = 0 at hentry
+  simp only [mul_ite, mul_one, mul_zero] at hentry
+  have hsum :
+      X (i, k) (j, l) - Y (i, k) (j, l) =
+        ∑ x, ∑ y, if j = y ∧ i = x then
+          X (x, k) (y, l) - Y (x, k) (y, l) else 0 := by
+    have hinner (x : Fin A) :
+        (∑ y, if j = y ∧ i = x then
+          X (x, k) (y, l) - Y (x, k) (y, l) else 0) =
+          if i = x then X (x, k) (j, l) - Y (x, k) (j, l) else 0 := by
+      by_cases hix : i = x
+      · subst x
+        simp
+      · simp [hix]
+    simp_rw [hinner]
+    simp
+  rw [← hsum] at hentry
+  exact sub_eq_zero.mp hentry
+
+end Matrix

--- a/TNLean/Channel/InformationallyCompleteEffects.lean
+++ b/TNLean/Channel/InformationallyCompleteEffects.lean
@@ -13,7 +13,7 @@ import TNLean.Channel.WolfProps
 # A finite informationally complete family of effects
 
 This file constructs a finite family of positive effects whose complex span is
-the full matrix algebra.  The construction uses the four rank-one projectors in
+the full matrix algebra.  The construction uses the four rank-one effects in
 the polarization identity.
 
 This is the finite separation device for the conditional states in Hayden,
@@ -57,7 +57,7 @@ noncomputable def informationallyCompleteVector
 /-- A finite informationally complete family of positive effects.
 
 The distinguished member is the identity.  Every other member is the
-rank-one projector onto one of the four scaled polarization vectors. -/
+rank-one effect formed from one of the four scaled polarization vectors. -/
 noncomputable def informationallyCompleteEffect
     (s : ICEffectIndex D) : Matrix (Fin D) (Fin D) ℂ :=
   match s with
@@ -279,7 +279,13 @@ theorem map_conditionalSlice
   rw [conditionalSlice_eq_sum_smul_bipartiteBlock, map_sum]
   simp_rw [map_sum, map_smul]
   rw [conditionalSlice_eq_sum_smul_bipartiteBlock]
-  congr 1
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  apply congrArg (M j i • ·)
+  ext k l
+  simp [idTensorMapLM_apply, idTensorMap_apply]
 
 /-- Conditional slicing as a complex-linear map in the tested effect. -/
 noncomputable def conditionalSliceLM

--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -16,4 +16,5 @@ import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
 import TNLean.Channel.KoashiImoto.PreservingBlockAction
+import TNLean.Channel.KoashiImoto.RecoveredConditionalFamily
 import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalFamily.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalFamily.lean
@@ -1,0 +1,242 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.InformationallyCompleteEffects
+import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
+import TNLean.Channel.Schwarz.SSAEqualityPetzRecovery
+
+/-!
+# The finite recovered conditional family at SSA equality
+
+At equality in strong subadditivity, compose the HJPW recovery channel with
+the partial trace over the recovered system.  The resulting channel on the
+middle system fixes the bipartite marginal and therefore fixes every
+conditional slice obtained by testing the first system.
+
+This file selects the finite informationally complete effects from
+`TNLean.Channel.InformationallyCompleteEffects`, discards exactly the
+zero-probability slices, and normalizes the remaining slices.  The result is a
+finite nonempty density family fixed by one CPTP map.
+
+Source: Hayden, Jozsa, Petz and Winter,
+arXiv:quant-ph/0304007v2, Theorem 6, lines 493--505.
+
+## Main declarations
+
+* `Matrix.recoveredMiddleChannel`: the channel
+  `φ = Tr_C ∘ Rhat`.
+* `Matrix.idTensor_recoveredMiddleChannel_traceC_ABC_eq`: `id_A ⊗ φ`
+  fixes `ρ_AB`.
+* `Matrix.RecoveredEffectIndex`: the nonzero-probability finite effects.
+* `Matrix.recoveredConditionalState`: the normalized conditional states.
+* `Matrix.exists_recoveredConditionalPreservingKrausFamily`: the finite
+  nonempty invariant density family and one preserving Kraus realization.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+
+namespace Matrix
+
+variable {dA dB dC : ℕ}
+
+/-- The HJPW middle-system channel
+`φ = Tr_C ∘ Rhat`.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 493--498. -/
+noncomputable def recoveredMiddleChannel
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ : ρ_ABC.PosSemidef) :
+    Matrix (Fin dB) (Fin dB) ℂ →ₗ[ℂ]
+      Matrix (Fin dB) (Fin dB) ℂ :=
+  partialTraceRightLM (α := Fin dB) (β := Fin dC) ∘ₗ
+    partialTraceRightPetzChannel (traceA_ABC ρ_ABC)
+      (traceLeftA_posSemidef hρ)
+
+/-- The recovered middle-system map is a quantum channel.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 493--498. -/
+theorem recoveredMiddleChannel_isKrausCPTP
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1) :
+    IsKrausCPTP (recoveredMiddleChannel ρ_ABC hρ_dm.1) := by
+  exact isKrausCPTP_comp
+    (partialTraceRightPetzChannel_traceA_ABC_isKrausCPTP ρ_ABC hρ_dm)
+    partialTraceRightLM_isKrausCPTP
+
+/-- Applying the partial trace over `C` on the second tensor factor is the
+tripartite `C`-marginal. -/
+theorem idTensor_partialTraceRightLM_eq_traceC_ABC
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ) :
+    idTensorMapLM (δ := Fin dA)
+        (partialTraceRightLM (α := Fin dB) (β := Fin dC)) ρ_ABC =
+      traceC_ABC ρ_ABC := by
+  classical
+  ext ⟨a, b⟩ ⟨a', b'⟩
+  simp [idTensorMapLM_apply, idTensorMap_apply, partialTraceRightLM,
+    partialTraceRight_apply, bipartiteBlock_apply, traceC_ABC]
+
+/-- At SSA equality, `id_A ⊗ φ` fixes the bipartite marginal `ρ_AB`.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equations (12)--(13),
+lines 493--498. -/
+theorem idTensor_recoveredMiddleChannel_traceC_ABC_eq
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    idTensorMapLM (δ := Fin dA)
+        (recoveredMiddleChannel ρ_ABC hρ_dm.1)
+        (traceC_ABC ρ_ABC) =
+      traceC_ABC ρ_ABC := by
+  rw [recoveredMiddleChannel, idTensorMapLM_comp,
+    LinearMap.comp_apply,
+    idTensor_partialTraceRightPetzChannel_traceC_ABC_eq_of_isSSAEquality
+      ρ_ABC hρ_dm hSSA,
+    idTensor_partialTraceRightLM_eq_traceC_ABC]
+
+/-! ## The active finite conditional family -/
+
+/-- Indices of the informationally complete effects whose conditional slices
+have nonzero probability.
+
+The subtype removes exactly the zero-probability effects before
+normalization, as in HJPW, arXiv:quant-ph/0304007v2, Theorem 6,
+lines 499--505. -/
+abbrev RecoveredEffectIndex
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ) :=
+  {s : ICEffectIndex dA //
+    (conditionalSlice ρ_AB (informationallyCompleteEffect s)).trace.re ≠ 0}
+
+/-- The active effect family is nonempty for a trace-one bipartite state:
+the distinguished identity effect has probability one. -/
+theorem recoveredEffectIndex_nonempty
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρtrace : ρ_AB.trace = 1) :
+    Nonempty (RecoveredEffectIndex ρ_AB) := by
+  refine ⟨⟨Sum.inl (), ?_⟩⟩
+  rw [trace_conditionalSlice]
+  simp [informationallyCompleteEffect, hρtrace]
+
+/-- The normalized conditional state associated to a nonzero-probability
+effect.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equations (14)--(15),
+lines 499--505. -/
+noncomputable def recoveredConditionalState
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (s : RecoveredEffectIndex ρ_AB) :
+    Matrix (Fin dB) (Fin dB) ℂ :=
+  ((((conditionalSlice ρ_AB
+    (informationallyCompleteEffect s)).trace.re)⁻¹ : ℝ) : ℂ) •
+      conditionalSlice ρ_AB (informationallyCompleteEffect s)
+
+/-- Every recovered conditional state is positive semidefinite. -/
+theorem recoveredConditionalState_posSemidef
+    {ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (hρ : ρ_AB.PosSemidef) (s : RecoveredEffectIndex ρ_AB) :
+    (recoveredConditionalState ρ_AB s).PosSemidef := by
+  have hslice :=
+    hρ.conditionalSlice
+      (informationallyCompleteEffect_posSemidef (s : ICEffectIndex dA))
+  apply hslice.smul
+  exact_mod_cast inv_nonneg.mpr (Complex.nonneg_iff.mp hslice.trace_nonneg).1
+
+/-- Every recovered conditional state has trace one. -/
+theorem recoveredConditionalState_trace
+    {ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (hρ : ρ_AB.PosSemidef) (s : RecoveredEffectIndex ρ_AB) :
+    (recoveredConditionalState ρ_AB s).trace = 1 := by
+  let ξ := conditionalSlice ρ_AB (informationallyCompleteEffect s)
+  have hξ : ξ.PosSemidef :=
+    hρ.conditionalSlice
+      (informationallyCompleteEffect_posSemidef (s : ICEffectIndex dA))
+  have htrace : ξ.trace = (ξ.trace.re : ℂ) := by
+    apply Complex.ext
+    · simp
+    · simpa using (Complex.nonneg_iff.mp hξ.trace_nonneg).2.symm
+  rw [recoveredConditionalState, Matrix.trace_smul, htrace]
+  change ((ξ.trace.re⁻¹ : ℝ) : ℂ) * (ξ.trace.re : ℂ) = 1
+  exact_mod_cast inv_mul_cancel₀ s.property
+
+/-- If `id_A ⊗ φ` fixes a bipartite state, then `φ` fixes every conditional
+slice of that state. -/
+theorem map_conditionalSlice_eq_self_of_idTensorMap_eq_self
+    (φ : Matrix (Fin dB) (Fin dB) ℂ →ₗ[ℂ]
+      Matrix (Fin dB) (Fin dB) ℂ)
+    (ρ_AB : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hfix : idTensorMapLM (δ := Fin dA) φ ρ_AB = ρ_AB)
+    (M : Matrix (Fin dA) (Fin dA) ℂ) :
+    φ (conditionalSlice ρ_AB M) = conditionalSlice ρ_AB M := by
+  rw [map_conditionalSlice, hfix]
+
+/-- At SSA equality, the recovered middle-system channel fixes every
+normalized active conditional state.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (15),
+lines 499--505. -/
+theorem recoveredMiddleChannel_recoveredConditionalState
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian)
+    (s : RecoveredEffectIndex (traceC_ABC ρ_ABC)) :
+    recoveredMiddleChannel ρ_ABC hρ_dm.1
+        (recoveredConditionalState (traceC_ABC ρ_ABC) s) =
+      recoveredConditionalState (traceC_ABC ρ_ABC) s := by
+  rw [recoveredConditionalState, map_smul]
+  congr 1
+  exact map_conditionalSlice_eq_self_of_idTensorMap_eq_self
+    (recoveredMiddleChannel ρ_ABC hρ_dm.1) (traceC_ABC ρ_ABC)
+    (idTensor_recoveredMiddleChannel_traceC_ABC_eq ρ_ABC hρ_dm hSSA)
+    (informationallyCompleteEffect s)
+
+/-- **Finite recovered conditional family at SSA equality.**
+
+The active informationally complete effects form a finite nonempty index
+type.  Their normalized conditional slices are density matrices, and one
+Kraus representation of the recovered middle-system channel preserves every
+member.  The returned map identity ties the bundled Kraus family to
+`φ = Tr_C ∘ Rhat`, making the family directly suitable for the
+Koashi--Imoto joint-support reduction.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 493--505. -/
+theorem exists_recoveredConditionalPreservingKrausFamily
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    let ρ_AB := traceC_ABC ρ_ABC
+    let μ := recoveredConditionalState ρ_AB
+    Nonempty (RecoveredEffectIndex ρ_AB) ∧
+      (∀ s, (μ s).PosSemidef) ∧
+      (∀ s, (μ s).trace = 1) ∧
+      ∃ F : Kraus.PreservingKrausFamily μ,
+        ∀ X, Kraus.map F.Kfam X =
+          recoveredMiddleChannel ρ_ABC hρ_dm.1 X := by
+  dsimp only
+  have hABpos := SSAPosDef.traceC_ABC_posSemidef hρ_dm.1
+  have hABtrace : (traceC_ABC ρ_ABC).trace = 1 := by
+    rw [← trace_eq_trace_traceC_ABC]
+    exact hρ_dm.2
+  refine ⟨recoveredEffectIndex_nonempty (traceC_ABC ρ_ABC) hABtrace,
+    recoveredConditionalState_posSemidef hABpos,
+    recoveredConditionalState_trace hABpos, ?_⟩
+  obtain ⟨r, K, hKform, hKtp⟩ :=
+    recoveredMiddleChannel_isKrausCPTP ρ_ABC hρ_dm
+  let F : Kraus.PreservingKrausFamily
+      (recoveredConditionalState (traceC_ABC ρ_ABC)) :=
+    { numKraus := r
+      Kfam := K
+      isPreserving := ⟨hKtp, fun s ↦ by
+        rw [Kraus.map, ← hKform]
+        exact recoveredMiddleChannel_recoveredConditionalState
+          ρ_ABC hρ_dm hSSA s⟩ }
+  refine ⟨F, fun X ↦ ?_⟩
+  simpa only [F, Kraus.map] using (hKform X).symm
+
+end Matrix

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalFamily.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalFamily.lean
@@ -200,11 +200,12 @@ theorem recoveredMiddleChannel_recoveredConditionalState
 The active informationally complete effects form a finite nonempty index
 type.  Their normalized conditional slices are density matrices, and one
 Kraus representation of the recovered middle-system channel preserves every
-member.  The returned map identity ties the bundled Kraus family to
-`φ = Tr_C ∘ Rhat`, making the family directly suitable for the
-Koashi--Imoto joint-support reduction.
+member.  This is the finite invariant family used in the Koashi--Imoto
+joint-support reduction.
 
 Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 493--505. -/
+-- Maintainer note: the conclusion bundles the common Kraus representation and
+-- identifies its map with the recovered middle-system channel.
 theorem exists_recoveredConditionalPreservingKrausFamily
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1129,6 +1129,117 @@
     identities.
 \end{proof}
 
+\begin{definition}[Finite separating family of effects]
+    \label{def:hjpw_finite_separating_effects}
+    \lean{Matrix.ICEffectIndex,
+        Matrix.informationallyCompleteEffect,
+        Matrix.informationallyCompleteEffect_posSemidef,
+        Matrix.informationallyCompleteEffect_le_one,
+        Matrix.conditionalSlice,
+        Matrix.conditionalSlice_eq_partialTraceLeft}
+    \leanok
+    For a finite-dimensional system $A$, there is a finite family of effects
+    $(M_s)_s$, with $0\leq M_s\leq\mathbf 1_A$, whose complex linear span is
+    the full matrix algebra on $A$. One member is the identity. For an
+    operator $X$ on $A\otimes B$, define its conditional slice by
+    \begin{align}
+        \xi_s(X)
+        &=
+        \tr_A\!\left(X(M_s\otimes\mathbf 1_B)\right).
+        \notag
+    \end{align}
+    The family may be chosen from the four rank-one effects occurring in the
+    polarization identity, scaled so that every member is bounded by the
+    identity.
+\end{definition}
+
+\begin{theorem}[Finite separation by conditional slices]
+    \label{thm:hjpw_finite_conditional_slice_separation}
+    \lean{Matrix.linearMap_eq_zero_of_apply_informationallyCompleteEffect_eq_zero,
+        Matrix.eq_of_conditionalSlice_informationallyCompleteEffect_eq}
+    \leanok
+    \uses{def:hjpw_finite_separating_effects}
+    If two operators $X,Y$ on $A\otimes B$ have
+    \begin{align}
+        \xi_s(X)=\xi_s(Y)
+    \end{align}
+    for every member of the finite effect family, then $X=Y$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The polarization identity expresses every matrix unit as a complex linear
+    combination of the selected rank-one effects. Hence any linear map
+    vanishing on all selected effects vanishes on the full matrix algebra.
+    Apply this to each matrix entry of the difference of the two conditional
+    slice maps.
+\end{proof}
+
+\begin{theorem}[Finite recovered conditional family at SSA equality]
+    \label{thm:hjpw_recovered_conditional_family}
+    \lean{Matrix.recoveredMiddleChannel,
+        Matrix.recoveredMiddleChannel_isKrausCPTP,
+        Matrix.idTensor_recoveredMiddleChannel_traceC_ABC_eq,
+        Matrix.RecoveredEffectIndex,
+        Matrix.recoveredEffectIndex_nonempty,
+        Matrix.recoveredConditionalState,
+        Matrix.recoveredConditionalState_posSemidef,
+        Matrix.recoveredConditionalState_trace,
+        Matrix.map_conditionalSlice_eq_self_of_idTensorMap_eq_self,
+        Matrix.recoveredMiddleChannel_recoveredConditionalState,
+        Matrix.exists_recoveredConditionalPreservingKrausFamily}
+    \leanok
+    \uses{thm:ssa_equality_product_marginal_petz_recovery,
+        def:hjpw_finite_separating_effects}
+    Let $\rho_{ABC}$ be a tripartite density matrix attaining equality in
+    strong subadditivity, and put $\rho_{AB}=\tr_C\rho_{ABC}$. If
+    $\widehat{\mathcal R}:B\to B\otimes C$ is the completed recovery channel,
+    define
+    \begin{align}
+        \varphi
+        &=
+        \tr_C\circ\widehat{\mathcal R}.
+    \end{align}
+    Then $\varphi$ is trace-preserving and completely positive and
+    \begin{align}
+        (\operatorname{id}_A\otimes\varphi)(\rho_{AB})
+        &=
+        \rho_{AB}.
+    \end{align}
+    For each selected effect, let
+    \begin{align}
+        \xi_s
+        &=
+        \tr_A\!\left(\rho_{AB}(M_s\otimes\mathbf 1_B)\right),
+        &
+        p_s
+        &=
+        \tr(\xi_s).
+    \end{align}
+    The indices with $p_s\neq0$ form a finite nonempty set. For each such
+    index, positivity of $\xi_s$ makes $p_s$ real and positive, and
+    \begin{align}
+        \mu_s=p_s^{-1}\xi_s
+    \end{align}
+    is a density operator and $\varphi(\mu_s)=\mu_s$. Consequently a Kraus
+    representation of $\varphi$ gives a single preserving operation for this
+    finite nonempty density family.
+
+    This is the conditional-family construction in
+    \cite[Theorem~6, lines~493--505]{Hayden2004Structure}. Effects with
+    $p_s=0$ are omitted before normalization; no artificial conditional state
+    is introduced for them.
+\end{theorem}
+
+\begin{proof}\leanok
+    Compose equation~(11) with the partial trace over $C$ to obtain the fixed
+    point identity for $\rho_{AB}$. Conditional slicing commutes with every
+    linear map on $B$, so $\varphi(\xi_s)=\xi_s$. Positivity of $\rho_{AB}$
+    and $M_s$ gives positivity of $\xi_s$. On the nonzero-trace subtype,
+    scaling by $p_s^{-1}$ preserves positivity and makes the trace one; the
+    fixed-point equation is preserved by the same scaling. The identity
+    effect has probability $\tr(\rho_{AB})=1$, proving nonemptiness.
+\end{proof}
+
 \begin{theorem}[SSA equality as saturation for a maximally mixed reference]
     \label{thm:ssa_equality_maximally_mixed_reference_dpi}
     \lean{isSSAEquality_iff_maximally_mixed_reference_data_processing_eq}
@@ -1687,10 +1798,15 @@ algebra of a family of jointly invariant states.
     faithful support coordinates for an arbitrary finite family and restricts
     every preserving operation to them.
     Theorem~\ref{thm:koashi_imoto_joint_support_block_action} packages the
-    state blocks and operation action on that minimum joint support. Transport
-    to the recovered conditional family and assembly of the quantum-Markov
-    decomposition remain open. This forward implication therefore remains
-    axiomatic. The biconditional combines the two directions.
+    state blocks and operation action on that minimum joint support.
+    Theorem~\ref{thm:hjpw_recovered_conditional_family} now constructs the
+    finite nonempty invariant density family from the SSA recovery channel,
+    while Theorem~\ref{thm:hjpw_finite_conditional_slice_separation} supplies
+    the finite replacement for varying all effects. Applying the joint-support
+    block form to this family and assembling the resulting blocks into the
+    quantum-Markov decomposition remain open. This forward implication
+    therefore remains axiomatic. The biconditional combines the two
+    directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -126,9 +126,11 @@ For MPDO renormalization fixed points:
   tensor-product state decomposition and HJPW Property~`2'` channel action are
   formalized. The joint-support coordinate reduction, state reconstruction,
   and restriction of preserving operations are also formalized, together with
-  the combined block form on the minimum joint support. The recovered
-  conditional-family transport and the generic Hayashi forward implication
-  remain open.
+  the combined block form on the minimum joint support. The finite
+  informationally complete effect family, conditional-slice separation, and
+  the nonzero normalized family fixed by the recovered middle-system channel
+  are formalized. Applying the joint-support block form to this recovered
+  family and completing the generic Hayashi forward implication remain open.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -64,11 +64,11 @@ Hayden--Jozsa--Petz--Winter, and of Hayashi, but its proof rests on the full
 singular-support saturation-to-recovery theorem and the structural analysis of
 recovered states.  The singular-support saturation-to-raw-recovery implication,
 its positive-definite specialization, and the trace-preserving extension of the
-support Petz map are now available.  The family-level structural step remains
-open only beyond the full-support case: the invariant-family decomposition and
-the action of every preserving operation on its diagonal blocks are available
-when the common average is positive definite, while the joint-support passage
-and quantum-Markov assembly remain. The reverse direction is proved from the
+support Petz map are now available. The finite recovered conditional density
+family, its separating effects, and its common preserving channel are also
+formalized. The family-level structural step remains open at the application
+of the joint-support block theorem to that family and the subsequent
+quantum-Markov assembly. The reverse direction is proved from the
 entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
@@ -88,11 +88,12 @@ implication.  A simultaneous probability-density block form for the preserved
 family is also available under a positive-definite common-average hypothesis.
 In the same full-support setting, every preserving channel acts locally on the
 common summands and fixes their common density factors. The joint-support
-reduction, transport of this result to the recovered family, and assembly of
-the quantum-Markov decomposition are still missing. Thus the family-level
-structural implication needed here remains open, which is why the forward
-direction is treated as an external assumption rather than proved. The recovery
-implication and the
+reduction is available, and the finite nonzero normalized conditional family
+fixed by the recovered middle-system channel is constructed. Applying the
+joint-support block theorem to this family and assembling the quantum-Markov
+decomposition are still missing. Thus the family-level structural implication
+needed here remains open, which is why the forward direction is treated as an
+external assumption rather than proved. The recovery implication and the
 complementary trace-preserving extension of the support Petz map are no longer
 part of this gap.
 
@@ -673,30 +674,43 @@ The joint-support reduction now constructs faithful support coordinates,
 reconstructs every family member, and restricts each preserving operation to
 those coordinates. The normalized family blocks and preserving-operation
 action are packaged on the minimum joint support. Transporting this theorem to
-the recovered conditional family and assembling the quantum-Markov
-decomposition remain necessary before the forward external assumption can be
-removed.
+the recovered conditional family begins with the finite informationally
+complete effect family and conditional slices
+\begin{center}
+  \small
+  \leanid{Matrix.eq_of_conditionalSlice_informationallyCompleteEffect_eq}\\
+  \leanid{Matrix.idTensor_recoveredMiddleChannel_traceC_ABC_eq}\\
+  \leanid{Matrix.exists_recoveredConditionalPreservingKrausFamily}.
+\end{center}
+These declarations construct a finite nonempty family of nonzero normalized
+conditional states fixed by
+$\varphi=\operatorname{Tr}_C\circ\widehat{\mathcal R}$ and prove that the
+finite slices separate bipartite operators. Applying the joint-support block
+form to this family and assembling the quantum-Markov decomposition remain
+necessary before the forward external assumption can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-conditional-family transport and quantum-Markov assembly for the recovered
-family.
+joint-support block theorem applied to the recovered family and the subsequent
+quantum-Markov assembly.
 The full-support invariant-family state decomposition and preserving-operation
 block action are formalized. Source-facing
 completed-channel recovery from equality in data processing is available on
 arbitrary finite tensor factors. Its exact HJPW product-reference
 specialization and identity-tensored local recovery channel are also
-formalized without invertibility assumptions. The remaining forward structural
-direction alone is postulated. The reverse direction,
+formalized without invertibility assumptions. The finite recovered
+conditional density family and its common preserving channel are also
+formalized, with zero-probability effects omitted before normalization. The
+remaining forward structural direction alone is postulated. The reverse direction,
 a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
-and reindexing invariance. Until the joint-support block form is connected to
-the recovered conditional family and the quantum-Markov assembly is
-formalized, the forward direction remains the irreducible unproved content of
-this characterization.
+and reindexing invariance. Until the joint-support block form is applied to the
+recovered conditional family and the quantum-Markov assembly is formalized,
+the forward direction remains the irreducible unproved content of this
+characterization.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -159,9 +159,14 @@ Koashi--Imoto state decomposition and the action of every preserving operation
 on its diagonal summands are now formalized below. The joint-support
 compression, state reconstruction, restriction of ambient preserving
 operations, and intertwining of their compressed and ambient actions are also
-formalized. To apply this result to an arbitrary recovered family, the
-remaining bridge must construct and transport the recovered conditional
-family and assemble one common direct sum
+formalized. The finite informationally complete effect family, conditional
+slices, nonzero normalization, and their common preserving channel are now
+constructed by
+\leanid{Matrix.exists_recoveredConditionalPreservingKrausFamily}; the slices
+separate bipartite operators by
+\leanid{Matrix.eq_of_conditionalSlice_informationallyCompleteEffect_eq}.
+The remaining bridge must apply the joint-support block theorem to this family
+and assemble one common direct sum
 \begin{align}
   H_B\cong\bigoplus_j H_{B_j^L}\otimes H_{B_j^R}
 \end{align}
@@ -171,7 +176,7 @@ finite-Weyl argument and transported to arbitrary finite product coordinates.
 For density operators, support agreement upgrades this equality to the chosen
 completed partial-trace Petz channel on the recovered marginal. This does not
 give a tensor-product factorization of the generic completed singular channel.
-The recovered conditional-family transport and quantum-Markov assembly are the
+The joint-support block application and quantum-Markov assembly are the
 remaining structural obstructions to replacing the forward Hayashi
 strong-subadditivity equality assumption used in the CPSV16 argument.
 
@@ -281,9 +286,10 @@ through the support isometry. The declaration
 \leanid{Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction_jointSupport}
 then packages the normalized state blocks and the action of every preserving
 operation on that minimum joint support; ambient preserving operations inherit
-this action by restriction and intertwining. Construction and transport of the
-recovered conditional family, assembly of the generic quantum-Markov
-decomposition, and elimination of the
+this action by restriction and intertwining. The finite recovered conditional
+family and one preserving Kraus realization are now constructed from SSA
+equality. Applying this block theorem to that family, assembling the generic
+quantum-Markov decomposition, and eliminating the
 external assumption for the forward Hayashi strong-subadditivity implication
 remain open.
 
@@ -314,9 +320,10 @@ summand. Thus full-support HJPW Property~$2'$ is also formalized. The
 Heisenberg Ces\`aro convergence identity for $P_0^*$ remains open. The
 joint-support coordinate reduction, density-family reconstruction, and
 restriction of preserving operations are formalized, as is the combined block
-form on the minimum joint support. The recovered conditional-family transport
-and the generic Hayashi forward implication remain open as separate later
-steps.
+form on the minimum joint support. The finite recovered conditional family,
+its separating effects, and its preserving middle-system channel are
+formalized. Applying the block form to this family and the generic Hayashi
+forward implication remain open as separate later steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Closes LionSR/QICLean#254.

## Summary

- construct an explicit finite informationally complete family of positive effects from the polarization identity, prove each is bounded by the identity, and prove that its conditional slices separate bipartite operators;
- construct the recovered middle CPTP channel at SSA equality and the active finite family of normalized conditional states obtained from nonzero-probability effects;
- prove every active state is positive, trace one, and fixed by the recovered channel, and package one Kraus family preserving the whole finite family;
- align the Blueprint, entropy boundary comments, and HJPW/CPSV paper-gap notes with the newly formalized HJPW04 lines 493–505 step.

Effects of zero probability are omitted before normalization, so no artificial conditional state is introduced.

## Scope boundary

This PR does not apply the joint-support Koashi–Imoto block theorem or assemble the final `HayashiMarkovDecomposition`. The forward SSA-equality characterization axiom remains, and the gap notes identify those two remaining steps.

## Validation

- fetched prebuilt Mathlib artifacts with `lake exe cache get` before any Lean build in the fresh worktree;
- `lake build` (9,788 jobs; only the pre-existing `SectorMatch.lean:600` sorry warning);
- focused `lake build` and `lake env lean` checks for both new modules;
- `lake build lint_style` and `lake exe lint_style --github`;
- module-policy, oversized-file, numbered-file, reader-facing-prose, and tactic-pattern checks;
- import-aggregator and Blueprint declaration-sync checks;
- `lake exe checkdecls blueprint/lean_decls`;
- `leanblueprint web` and `leanblueprint pdf`;
- visual inspection of the affected rendered PDF pages;
- `git diff --check` and proof-integrity scans for the new files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new quantum-channel formalization with many lemmas, but behavior is additive proof work on an isolated SSA/HJPW path—not production runtime or security-sensitive code.
> 
> **Overview**
> Formalizes the HJPW finite effect family and the **recovered conditional density family** at strong-subadditivity equality, as a step toward the forward Hayashi characterization.
> 
> **`InformationallyCompleteEffects`** builds a finite polarization-based effect family (PSD, bounded by identity) and proves **conditional slices** `Tr_A(ρ(M⊗1))` separate bipartite operators. **`RecoveredConditionalFamily`** defines the middle channel **φ = Tr_C ∘ R̂**, shows **`id_A ⊗ φ` fixes ρ_AB** at SSA equality, keeps only **nonzero-probability** effects, normalizes slices to trace-one states, and packages **`exists_recoveredConditionalPreservingKrausFamily`** (one Kraus map preserving the whole finite family).
> 
> Imports are wired through **`TNLean.Channel`** and **`KoashiImoto`**. Blueprint ch19 and paper-gap notes are updated; **`hayashi_ssa_equality_characterization_forward`** stays an axiom—the remaining work is applying joint-support Koashi–Imoto blocks to this family and assembling **`HayashiMarkovDecomposition`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ce3aa4a46b31f2a8ba4eee39f9724a5c5f7873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->