### PR TITLE
feat(Channel/KoashiImoto): specialize recovered joint-support blocks

### DIFF
--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -16,5 +16,6 @@ import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
 import TNLean.Channel.KoashiImoto.PreservingBlockAction
+import TNLean.Channel.KoashiImoto.RecoveredConditionalBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalFamily
 import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalBlockForm.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.JointSupport
+import TNLean.Channel.KoashiImoto.RecoveredConditionalFamily
+
+/-!
+# Joint-support block form of the recovered conditional family
+
+At equality in strong subadditivity, the recovered middle-system channel fixes
+the finite family of normalized conditional states selected by the
+informationally complete effects.  This file applies the unrestricted
+Koashi--Imoto joint-support theorem to that family.
+
+The resulting coordinates decompose the minimum joint support into a direct
+sum of tensor products.  They simultaneously put every recovered conditional
+state in normalized block form and describe the action of every preserving
+operation, including the recovered middle-system channel.
+
+Source: Hayden, Jozsa, Petz and Winter,
+arXiv:quant-ph/0304007v2, Theorem 6, lines 493--505, and Appendix A,
+lines 761--816 and 853--882.
+
+## Main declaration
+
+* `Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport`:
+  the joint-support block form and preserving-channel action specialized to
+  the recovered conditional family at SSA equality.
+
+**Convention (factor order):** TNLean orders each summand as the common
+density factor followed by the conditional-state-dependent factor, opposite
+to HJPW.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+
+namespace Matrix
+
+variable {dA dB dC : ℕ}
+
+/-- **Joint-support block form of the recovered conditional family.**
+
+For a tripartite density matrix attaining equality in strong subadditivity,
+the normalized conditional states on the middle system admit one
+Koashi--Imoto decomposition on their minimum joint support.  The bundled
+preserving Kraus family realizes
+`φ = Tr_C ∘ Rhat`, and the final two clauses retain the support-intertwining
+and diagonal-block action of every preserving operation.
+
+This is the specialization used in HJPW's proof of the quantum-Markov
+decomposition.  It does not yet reconstruct the bipartite marginal or lift
+the square middle-system action to the rectangular recovery channel.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 493--505, and
+Appendix A, lines 761--816 and 853--882.  TNLean uses the reverse
+tensor-factor order from HJPW. -/
+theorem exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    let ρ_AB := traceC_ABC ρ_ABC
+    let μ := recoveredConditionalState ρ_AB
+    letI : Nonempty (RecoveredEffectIndex ρ_AB) :=
+      recoveredEffectIndex_nonempty ρ_AB (by
+        rw [← trace_eq_trace_traceC_ABC]
+        exact hρ_dm.2)
+    ∃ (F : Kraus.PreservingKrausFamily μ)
+        (n : ℕ) (V : Matrix (Fin dB) (Fin n) ℂ),
+      (∀ X, Kraus.map F.Kfam X =
+        recoveredMiddleChannel ρ_ABC hρ_dm.1 X) ∧
+      Vᴴ * V = 1 ∧
+      V * Vᴴ = (Kraus.commonAverage_posSemidef μ
+        (recoveredConditionalState_posSemidef
+          (SSAPosDef.traceC_ABC_posSemidef hρ_dm.1))).supportProj ∧
+      (∀ x, V * Kraus.supportCompressedFamily V μ x * Vᴴ = μ x) ∧
+      ∃ (K : ℕ) (d m : Fin K → ℕ)
+        (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+        (U : Matrix (Fin n) (Fin n) ℂ)
+        (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+        (q : RecoveredEffectIndex ρ_AB → Fin K → ℝ)
+        (τ : RecoveredEffectIndex ρ_AB → ∀ j,
+          Matrix (Fin (d j)) (Fin (d j)) ℂ),
+        U ∈ Matrix.unitaryGroup (Fin n) ℂ ∧
+          (∀ j, 0 < d j) ∧ (∀ j, 0 < m j) ∧
+          (∀ j, (σ j).PosSemidef) ∧ (∀ j, (σ j).trace = 1) ∧
+          (∀ x j, 0 ≤ q x j) ∧ (∀ x, ∑ j, q x j = 1) ∧
+          (∀ x j, (τ x j).PosSemidef) ∧
+          (∀ x j, (τ x j).trace = 1) ∧
+          (∀ x, star U * Kraus.supportCompressedFamily V μ x * U =
+            Matrix.reindex e e
+              (Matrix.blockDiagonal' fun j ↦
+                (q x j : ℂ) • (σ j ⊗ₖ τ x j))) ∧
+          (∀ G : Kraus.PreservingKrausFamily μ,
+            Kraus.IsPreserving (Kraus.supportCompressedFamily V μ)
+                (Kraus.supportCompressedKraus V G.Kfam) ∧
+              ∀ X, Kraus.map G.Kfam (V * X * Vᴴ) =
+                V * Kraus.map (Kraus.supportCompressedKraus V G.Kfam) X * Vᴴ) ∧
+          ∀ G : Kraus.PreservingKrausFamily
+              (Kraus.supportCompressedFamily V μ),
+            ∃ C : (i : Fin G.numKraus) → ∀ j,
+                Matrix (Fin (m j)) (Fin (m j)) ℂ,
+              (∀ i,
+                Matrix.reindex e.symm e.symm
+                    (star U * G.Kfam i * U) =
+                  Matrix.blockDiagonal' fun j ↦
+                    C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) ∧
+              (∀ j, Kraus.IsTP (fun i ↦ C i j)) ∧
+              (∀ j, Kraus.map (fun i ↦ C i j) (σ j) = σ j) ∧
+              ∀ j (A : Matrix (Fin (m j)) (Fin (m j)) ℂ)
+                  (B : Matrix (Fin (d j)) (Fin (d j)) ℂ),
+                Matrix.reindex e.symm e.symm
+                    (star U * Kraus.map G.Kfam
+                      (U * Matrix.reindex e e
+                        (Matrix.directSumBlockEmbedding (m := m) (d := d) j
+                          (A ⊗ₖ B)) * star U) * U) =
+                  Matrix.directSumBlockEmbedding (m := m) (d := d) j
+                    (Kraus.map (fun i ↦ C i j) A ⊗ₖ B) := by
+  classical
+  dsimp only
+  obtain ⟨hμnonempty, hμpos, hμtrace, F, hFmap⟩ :=
+    exists_recoveredConditionalPreservingKrausFamily ρ_ABC hρ_dm hSSA
+  letI : Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC)) := hμnonempty
+  obtain ⟨n, V, hV, hVrange, hrec, K, d, m, e, U, σ, q, τ, hU, hd, hm,
+      hσpos, hσtrace, hqnonneg, hqsum, hτpos, hτtrace, hfamily, hpres,
+      haction⟩ :=
+    Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction_jointSupport
+      (recoveredConditionalState (traceC_ABC ρ_ABC)) hμpos hμtrace
+  exact ⟨F, n, V, hFmap, hV, hVrange, hrec, K, d, m, e, U, σ, q, τ, hU,
+    hd, hm, hσpos, hσtrace, hqnonneg, hqsum, hτpos, hτtrace, hfamily,
+    hpres, haction⟩
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1755,6 +1755,54 @@ algebra of a family of jointly invariant states.
     identity for the family members.
 \end{proof}
 
+\begin{theorem}[Recovered conditional blocks on the joint support]
+    \label{thm:hjpw_recovered_conditional_joint_support_blocks}
+    \lean{Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport}
+    \leanok
+    \uses{thm:hjpw_recovered_conditional_family,
+        thm:koashi_imoto_joint_support_block_action}
+    Let $\rho_{ABC}$ be a tripartite density matrix attaining equality in
+    strong subadditivity, and let $\mu_s$ be the finite nonempty family of
+    normalized conditional states obtained from the active separating
+    effects. On the minimum joint supporting subspace of this family there
+    are tensor-product direct-sum coordinates such that
+    \begin{align}
+        \widehat\mu_s
+        =
+        \bigoplus_j q_{j|s}\sigma_j\otimes\tau_{j|s},
+    \end{align}
+    where the weights form probability distributions and all factors are
+    density operators. The support isometry reconstructs every $\mu_s$.
+
+    The channel
+    \begin{align}
+        \varphi
+        =
+        \tr_C\circ\widehat{\mathcal R}
+    \end{align}
+    restricts to the same support and intertwines with its ambient action.
+    In these coordinates its action on each diagonal summand is
+    \begin{align}
+        \varphi_j\otimes\operatorname{id},
+        \qquad
+        \varphi_j(\sigma_j)=\sigma_j.
+    \end{align}
+    The tensor factors are written in the reverse order from HJPW.
+
+    This is the application of HJPW Theorem~6, lines 493--505, to
+    Properties~1 and~$2'$ from Appendix~A, lines 761--816 and 853--882.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:hjpw_recovered_conditional_family} supplies a finite
+    nonempty density family together with a trace-preserving completely
+    positive operation fixing every member. Apply
+    Theorem~\ref{thm:koashi_imoto_joint_support_block_action} to this family.
+    Retain the support reconstruction, the normalized block equations, and
+    the restriction and block-action clauses for the preserving operation.
+\end{proof}
+
 \begin{theorem}[Hayashi SSA-equality characterization]
     \label{thm:hayashi_ssa_equality_characterization}
     \lean{hayashi_ssa_equality_characterization}
@@ -1802,8 +1850,11 @@ algebra of a family of jointly invariant states.
     Theorem~\ref{thm:hjpw_recovered_conditional_family} now constructs the
     finite nonempty invariant density family from the SSA recovery channel,
     while Theorem~\ref{thm:hjpw_finite_conditional_slice_separation} supplies
-    the finite replacement for varying all effects. Applying the joint-support
-    block form to this family and assembling the resulting blocks into the
+    the finite replacement for varying all effects.
+    Theorem~\ref{thm:hjpw_recovered_conditional_joint_support_blocks} applies
+    the joint-support block form and preserving-operation action to this
+    recovered family. Extending these block equations to the bipartite
+    marginal and lifting them through the recovery channel to assemble the
     quantum-Markov decomposition remain open. This forward implication
     therefore remains axiomatic. The biconditional combines the two
     directions.

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -680,21 +680,25 @@ complete effect family and conditional slices
   \small
   \leanid{Matrix.eq_of_conditionalSlice_informationallyCompleteEffect_eq}\\
   \leanid{Matrix.idTensor_recoveredMiddleChannel_traceC_ABC_eq}\\
-  \leanid{Matrix.exists_recoveredConditionalPreservingKrausFamily}.
+  \leanid{Matrix.exists_recoveredConditionalPreservingKrausFamily}\\
+  \leanid{Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport}.
 \end{center}
 These declarations construct a finite nonempty family of nonzero normalized
 conditional states fixed by
 $\varphi=\operatorname{Tr}_C\circ\widehat{\mathcal R}$ and prove that the
-finite slices separate bipartite operators. Applying the joint-support block
-form to this family and assembling the quantum-Markov decomposition remain
-necessary before the forward external assumption can be removed.
+finite slices separate bipartite operators. They also apply the joint-support
+block form to this family and retain the support-intertwining and
+preserving-operation action of $\varphi$. Extending the finite block equations
+to the bipartite marginal, lifting them through the recovery channel, and
+assembling the quantum-Markov decomposition remain necessary before the
+forward external assumption can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-joint-support block theorem applied to the recovered family and the subsequent
+bipartite reconstruction, recovery-channel lifting, and subsequent
 quantum-Markov assembly.
 The full-support invariant-family state decomposition and preserving-operation
 block action are formalized. Source-facing
@@ -707,10 +711,10 @@ formalized, with zero-probability effects omitted before normalization. The
 remaining forward structural direction alone is postulated. The reverse direction,
 a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
-and reindexing invariance. Until the joint-support block form is applied to the
-recovered conditional family and the quantum-Markov assembly is formalized,
-the forward direction remains the irreducible unproved content of this
-characterization.
+and reindexing invariance. The joint-support block form is now applied to the
+recovered conditional family. Until the bipartite and recovered tripartite
+blocks are assembled into the quantum-Markov decomposition, the forward
+direction remains the irreducible unproved content of this characterization.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -288,10 +288,14 @@ then packages the normalized state blocks and the action of every preserving
 operation on that minimum joint support; ambient preserving operations inherit
 this action by restriction and intertwining. The finite recovered conditional
 family and one preserving Kraus realization are now constructed from SSA
-equality. Applying this block theorem to that family, assembling the generic
-quantum-Markov decomposition, and eliminating the
-external assumption for the forward Hayashi strong-subadditivity implication
-remain open.
+equality. The declaration
+\leanid{Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport}
+applies the block theorem to this family and retains the recovered
+middle-system channel together with the support intertwining and diagonal
+block action. Extending these block equations to the bipartite marginal,
+lifting them through the recovery channel, assembling the generic
+quantum-Markov decomposition, and eliminating the external assumption for the
+forward Hayashi strong-subadditivity implication remain open.
 
 \section{Classification}
 
@@ -322,8 +326,10 @@ joint-support coordinate reduction, density-family reconstruction, and
 restriction of preserving operations are formalized, as is the combined block
 form on the minimum joint support. The finite recovered conditional family,
 its separating effects, and its preserving middle-system channel are
-formalized. Applying the block form to this family and the generic Hayashi
-forward implication remain open as separate later steps.
+formalized. The joint-support block form and preserving-operation action have
+also been applied to this family. Bipartite reconstruction, recovery-channel
+lifting, and the generic Hayashi forward implication remain open as separate
+later steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
## Summary

- specialize the unrestricted Koashi–Imoto joint-support block/action theorem to the finite recovered conditional family at SSA equality
- retain the recovered middle-system Kraus realization, support reconstruction, normalized state blocks, support intertwining, and preserving-operation block action
- synchronize the generated import surface, chapter 19 Blueprint, and both HJPW/Hayashi paper-gap notes

## Mathematical scope

This implements only the first executable step after LionSR/TNLean#5026: HJPW Theorem 6, lines 493–505, using Appendix A, lines 761–816 and 853–882. It does not yet reconstruct `ρ_AB`, lift the square middle-system action through the rectangular recovery channel, assemble `HayashiMarkovDecomposition`, or remove the forward entropy axiom.

TNLean’s Koashi–Imoto tensor-factor order remains explicitly reversed from HJPW.

## Validation

- `lake exe cache get`
- `lake build TNLean.Channel.KoashiImoto.RecoveredConditionalBlockForm`
- `lake build TNLean.Channel.KoashiImoto`
- `lake build TNLean`
- `lake exe lint_style`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint pdf`
- `leanblueprint web`
- visual inspection of the rendered theorem and adjacent Hayashi status page
- no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in the new module

The full root build reports the repository’s pre-existing `sorry` warning in `TNLean/MPS/Periodic/Overlap/SectorMatch.lean`; this PR does not touch that file.

Closes LionSR/QICLean#256
Parent: LionSR/QICLean#255

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalization composed from existing theorems with documentation-only updates; no runtime, security, or broad API surface changes.
> 
> **Overview**
> Adds **`Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport`**, which instantiates the generic Koashi–Imoto joint-support block/action theorem on the **finite recovered conditional state family** at strong-subadditivity equality. The proof chains the existing preserving Kraus family for `φ = Tr_C ∘ R̂` with `Kraus.exists_commonInvariant_normalizedStateBlockForm_preservingBlockAction_jointSupport`, bundling support isometry, normalized block decomposition, and preserving-operation action—including the recovered middle-system channel.
> 
> Registers the module on the **`TNLean.Channel.KoashiImoto`** aggregator, adds the matching Blueprint theorem in chapter 19, and updates Hayashi/HJPW paper-gap notes so the joint-support step on the recovered family is **done** while bipartite marginal reconstruction, recovery-channel lifting, and quantum-Markov assembly stay **open**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51dd4d7fc430a6899a367045591db4e86155d4df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->