### PR TITLE
feat(Channel/KoashiImoto): prove Heisenberg Cesaro convergence

### DIFF
--- a/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
+++ b/TNLean/Channel/KoashiImoto/MeanErgodicProjection.lean
@@ -19,8 +19,9 @@ map is a positive, unital, idempotent retraction onto the adjoint fixed points. 
 identifies the trace-pairing adjoint of a Schrödinger Kraus map with its Heisenberg adjoint
 `Kraus.adjointMap`.
 
-This file does not prove that the Cesàro averages of the Heisenberg iterates converge to the
-trace-adjoint projection; that source identity remains a separate analytic statement.
+The Cesàro averages of the Heisenberg iterates converge to this trace-adjoint projection.
+The proof transports the finite sums and iterates through the trace pairing and applies the
+finite-dimensional Schrödinger mean-ergodic theorem entrywise.
 
 ## Main declarations
 
@@ -35,6 +36,8 @@ trace-adjoint projection; that source identity remains a separate analytic state
 * `Kraus.commonInvariantMeanErgodicProjection`: the trace-adjoint projection associated with
   the single witness `F_0`, derived via
   `IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`.
+* `Kraus.tendsto_birkhoffAverage_commonInvariantMeanErgodicProjection`: the Heisenberg
+  Cesàro averages of `F_0^*` converge to `P_0^*`.
 * `Kraus.commonInvariantMeanErgodicProjection_isPositiveMap`,
   `Kraus.commonInvariantMeanErgodicProjection_one`,
   `Kraus.commonInvariantMeanErgodicProjection_idempotent`: positivity, unitality, and
@@ -123,6 +126,24 @@ end TraceAdjointHeisenbergIdentification
 
 section CommonInvariantProjection
 
+private theorem trace_traceAdjointMap_iterate_mul
+    (T : Mat →ₗ[ℂ] Mat) (n : ℕ) (Y X : Mat) :
+    Matrix.trace ((Matrix.traceAdjointMap T)^[n] Y * X) =
+      Matrix.trace (Y * T^[n] X) := by
+  induction n generalizing X with
+  | zero => rfl
+  | succ n ih =>
+      rw [Function.iterate_succ_apply', Matrix.trace_traceAdjointMap_mul, ih,
+        Function.iterate_succ_apply]
+
+private theorem trace_birkhoffAverage_traceAdjointMap_mul
+    (T : Mat →ₗ[ℂ] Mat) (n : ℕ) (Y X : Mat) :
+    Matrix.trace (birkhoffAverage ℂ (Matrix.traceAdjointMap T) _root_.id n Y * X) =
+      Matrix.trace (Y * birkhoffAverage ℂ T _root_.id n X) := by
+  simp only [birkhoffAverage, birkhoffSum, id_eq, Matrix.smul_mul, Matrix.mul_smul,
+    Matrix.sum_mul, Matrix.mul_sum, Matrix.trace_smul, Matrix.trace_sum,
+    trace_traceAdjointMap_iterate_mul]
+
 /-- **HJPW's single witness `F_0`.**
 
 arXiv:quant-ph/0304007v2, lines 846-849: the preserving Kraus family with `A_0 = A_{F_0}`,
@@ -162,7 +183,7 @@ theorem isTracePreservingMap_commonInvariantMapLM {Kidx : Type*} [Fintype Kidx] 
 This is the trace-pairing adjoint of the finite-dimensional Schrödinger mean-ergodic projection
 for the single witness `F_0`. It is positive, unital, and idempotent, with range `A_0`. HJPW
 denotes the Heisenberg Cesàro limit by `P_0^*` (arXiv:quant-ph/0304007v2, lines 838-851);
-convergence of those averages to this map is not asserted here. -/
+the convergence theorem appears below. -/
 noncomputable def commonInvariantMeanErgodicProjection
     {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
     (hρbar : (commonAverage ρ).PosDef) : Mat →ₗ[ℂ] Mat :=
@@ -170,6 +191,77 @@ noncomputable def commonInvariantMeanErgodicProjection
     (LinearMap.meanErgodicProjection (commonInvariantMapLM hρbar)
       ((isPositiveMap_commonInvariantMapLM hρbar).hasBoundedOrbits_of_tracePreserving
         (isTracePreservingMap_commonInvariantMapLM hρbar)))
+
+/-- **The Heisenberg Cesàro averages for `F_0^*` converge to `P_0^*`.**
+
+HJPW, arXiv:quant-ph/0304007v2, lines 838-851, defines `P_0^*` as the Cesàro limit
+of the Heisenberg iterates of the single preserving operation `F_0`. This is that
+convergence identity under the explicit joint-support hypothesis used throughout
+this file. -/
+theorem tendsto_birkhoffAverage_commonInvariantMeanErgodicProjection
+    {Kidx : Type*} [Fintype Kidx] [Nonempty Kidx] {ρ : Kidx → Mat}
+    (hρbar : (commonAverage ρ).PosDef) (Y : Mat) :
+    Filter.Tendsto
+      (birkhoffAverage ℂ (Matrix.traceAdjointMap (commonInvariantMapLM hρbar))
+        _root_.id · Y)
+      Filter.atTop (nhds (commonInvariantMeanErgodicProjection hρbar Y)) := by
+  let T := commonInvariantMapLM hρbar
+  let hbounded :=
+    (isPositiveMap_commonInvariantMapLM hρbar).hasBoundedOrbits_of_tracePreserving
+      (isTracePreservingMap_commonInvariantMapLM hρbar)
+  let P := LinearMap.meanErgodicProjection T hbounded
+  change Filter.Tendsto
+    (birkhoffAverage ℂ (Matrix.traceAdjointMap T) _root_.id · Y)
+    Filter.atTop (nhds (Matrix.traceAdjointMap P Y))
+  change Filter.Tendsto
+    (fun n : ℕ => fun i j =>
+      birkhoffAverage ℂ (Matrix.traceAdjointMap T) _root_.id n Y i j)
+    Filter.atTop (nhds (fun i j => Matrix.traceAdjointMap P Y i j))
+  rw [tendsto_pi_nhds]
+  intro i
+  rw [tendsto_pi_nhds]
+  intro j
+  let traceMulY :=
+    (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ Y)
+  have hlimit :=
+    (traceMulY.continuous_of_finiteDimensional.tendsto
+      (P (Matrix.single j i 1))).comp
+      (hbounded.tendsto_birkhoffAverage_meanErgodicProjection
+        (Matrix.single j i 1))
+  have hseq :
+      (fun n : ℕ =>
+        birkhoffAverage ℂ (Matrix.traceAdjointMap T) _root_.id n Y i j) =
+        fun n : ℕ => traceMulY
+          (birkhoffAverage ℂ T _root_.id n (Matrix.single j i 1)) := by
+    funext n
+    calc
+      birkhoffAverage ℂ (Matrix.traceAdjointMap T) _root_.id n Y i j =
+          Matrix.trace
+            (birkhoffAverage ℂ (Matrix.traceAdjointMap T) _root_.id n Y *
+              Matrix.single j i 1) := by
+            rw [Matrix.trace_mul_single, MulOpposite.op_one, one_smul]
+      _ = Matrix.trace
+          (Y * birkhoffAverage ℂ T _root_.id n (Matrix.single j i 1)) :=
+        trace_birkhoffAverage_traceAdjointMap_mul T n Y (Matrix.single j i 1)
+      _ = traceMulY
+          (birkhoffAverage ℂ T _root_.id n (Matrix.single j i 1)) := by
+        simp only [traceMulY, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+          Matrix.traceLinearMap_apply]
+  have htarget :
+      traceMulY (P (Matrix.single j i 1)) = Matrix.traceAdjointMap P Y i j := by
+    calc
+      traceMulY (P (Matrix.single j i 1)) =
+          Matrix.trace (Y * P (Matrix.single j i 1)) := by
+        simp only [traceMulY, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+          Matrix.traceLinearMap_apply]
+      _ = Matrix.trace
+          (Matrix.traceAdjointMap P Y * Matrix.single j i 1) :=
+        (Matrix.trace_traceAdjointMap_mul P Y (Matrix.single j i 1)).symm
+      _ = Matrix.traceAdjointMap P Y i j := by
+        rw [Matrix.trace_mul_single, MulOpposite.op_one, one_smul]
+  rw [hseq]
+  rw [htarget] at hlimit
+  simpa only [T, Function.comp_def] using hlimit
 
 /-- The defining bundle of properties of `P_0^*`, transported directly from
 `IsPositiveMap.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction`. -/

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1515,11 +1515,33 @@ algebra of a family of jointly invariant states.
     Fix $F_0\in\mathbf F$ with $A_0=A_{F_0}$ as in
     Theorem~\ref{thm:koashi_imoto_single_witness}. Let $P_0$ be the
     finite-dimensional mean-ergodic projection of the Schr\"odinger map $F_0$,
-    and define $P_0^*$ as its trace-pairing adjoint. Hayden--Jozsa--Petz--Winter
-    denote the Heisenberg Ces\`aro limit by $P_0^*$. The convergence of the
-    Ces\`aro averages of the iterates $(F_0^*)^n$ to the trace-adjoint
-    projection defined here is not asserted.
+    and define $P_0^*$ as its trace-pairing adjoint.
 \end{definition}
+
+\begin{theorem}[Heisenberg Ces\`aro convergence to $P_0^*$]
+    \label{thm:koashi_imoto_heisenberg_cesaro_convergence}
+    \lean{Kraus.tendsto_birkhoffAverage_commonInvariantMeanErgodicProjection}
+    \leanok
+    \uses{def:koashi_imoto_mean_ergodic_projection,
+        thm:mean_ergodic_bounded_orbits}
+    For every $X\in\MN{D}$,
+    \begin{align}
+        \lim_{N\to\infty}\frac1N
+        \sum_{n=0}^{N-1}(F_0^*)^n(X)
+        =P_0^*(X).
+        \label{eq:koashi_imoto_heisenberg_cesaro_convergence}
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:koashi_imoto_mean_ergodic_projection,
+        thm:mean_ergodic_bounded_orbits}
+    The trace pairing transports every iterate of $F_0^*$ to the corresponding
+    iterate of $F_0$, and hence transports each finite Ces\`aro average.
+    Apply Theorem~\ref{thm:mean_ergodic_bounded_orbits} to $F_0$ and use
+    nondegeneracy of the trace pairing.
+\end{proof}
 
 \begin{theorem}[The projection onto $A_0$]
     \label{thm:koashi_imoto_mean_ergodic_projection_properties}

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -207,9 +207,9 @@ preserving operation $F_0=(1/M)\sum_{\mu=1}^M F_\mu$ with $A_0=A_{F_0}$
 (lines 844--849). The trace-pairing adjoint of the Schr\"odinger mean-ergodic
 projection for $F_0$ is formalized as $P_0^*$. It is positive, unital, and
 idempotent, with range exactly $A_0$. HJPW writes this projection as the
-Ces\`aro limit of the Heisenberg iterates (lines 838--851); convergence of those
-adjoint averages to the trace-adjoint projection is not yet formalized. The
-corresponding declarations are
+Ces\`aro limit of the Heisenberg iterates (lines 838--851), and those adjoint
+averages converge to the trace-adjoint projection. The corresponding
+declarations are
 \begin{center}
   \small
   \leanid{Kraus.commonAverage}\\
@@ -223,6 +223,7 @@ corresponding declarations are
   \leanid{Kraus.averagedPreservingKrausFamily}\\
   \leanid{Kraus.exists_preservingKrausFamily_adjointFixedPointsStarSubalgebra_eq}\\
   \leanid{Kraus.commonInvariantMeanErgodicProjection}\\
+  \leanid{Kraus.tendsto_birkhoffAverage_commonInvariantMeanErgodicProjection}\\
   \leanid{Kraus.commonInvariantMeanErgodicProjection_isPositiveMap}\\
   \leanid{Kraus.commonInvariantMeanErgodicProjection_one}\\
   \leanid{Kraus.commonInvariantMeanErgodicProjection_idempotent}\\
@@ -320,9 +321,9 @@ invariant family is also formalized, with nonnegative weights summing to one
 and density matrices on both tensor factors. In the same coordinates, every
 preserving operation acts as a local trace-preserving completely positive
 operation fixing $\sigma_j$, tensored with the identity, on each diagonal
-summand. Thus full-support HJPW Property~$2'$ is also formalized. The
-Heisenberg Ces\`aro convergence identity for $P_0^*$ remains open. The
-joint-support coordinate reduction, density-family reconstruction, and
+summand. Thus full-support HJPW Property~$2'$ and the Heisenberg Ces\`aro
+convergence identity for $P_0^*$ are formalized. The joint-support coordinate
+reduction, density-family reconstruction, and
 restriction of preserving operations are formalized, as is the combined block
 form on the minimum joint support. The finite recovered conditional family,
 its separating effects, and its preserving middle-system channel are


### PR DESCRIPTION
## Summary

- prove pointwise convergence of the Heisenberg Cesàro averages of the single preserving operation `F₀*` to the trace-adjoint mean-ergodic projection `P₀*`
- transport finite averages and iterates through the trace pairing, then apply the finite-dimensional Schrödinger mean-ergodic theorem entrywise
- synchronize the HJPW Blueprint statement and paper-gap status

Source: HJPW, arXiv:quant-ph/0304007v2, lines 838–851.

Closes LionSR/QICLean#257.

## Validation

- `lake exe cache get` before any build in the fresh isolated worktree
- `lake build TNLean.Channel.KoashiImoto.MeanErgodicProjection`
- `lake build TNLean.Channel.KoashiImoto`
- `lake build TNLean` (9,788 jobs; only the pre-existing unrelated `SectorMatch.lean:600` sorry warning)
- `lake exe lint_style`
- Blueprint/Lean sync and `checkdecls`
- generated import aggregator check
- tactic pattern scan and proof-integrity scan of the changed Lean module
- `leanblueprint pdf` and `leanblueprint web`
- visual inspection of the rendered theorem and proof on printed pages 375–376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal analysis in the Koashi–Imoto mean-ergodic module with doc sync only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Closes a previously open HJPW analytic gap: **Heisenberg Cesàro averages** of the single preserving witness `F₀^*` are now proved to converge to the trace-adjoint mean-ergodic projection **`P₀^*`** (`Kraus.tendsto_birkhoffAverage_commonInvariantMeanErgodicProjection`).
> 
> The Lean proof adds trace-pairing lemmas that relate iterates and finite Cesàro sums of `traceAdjointMap T` to those of the Schrödinger map `T`, then reduces matrix-entry convergence to the existing finite-dimensional Schrödinger mean-ergodic theorem entrywise (via standard basis singles and continuity of trace).
> 
> Blueprint **ch19** gains a theorem for equation (eq:koashi_imoto_heisenberg_cesaro_convergence); the HJPW paper-gap doc no longer lists this convergence as missing and records the new `leanid`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9a538dd60fe0451aa45939c9e2499945954ad47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->