### PR TITLE
feat(Channel/KoashiImoto): reconstruct recovered bipartite blocks

### DIFF
--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -16,6 +16,7 @@ import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
 import TNLean.Channel.KoashiImoto.PreservingBlockAction
+import TNLean.Channel.KoashiImoto.RecoveredConditionalBipartiteBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalFamily
 import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
@@ -1,0 +1,613 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.RecoveredConditionalBlockForm
+
+/-!
+# Bipartite block form from recovered conditional states
+
+This file reconstructs the bipartite marginal from the block form of its
+recovered conditional states.  The reconstruction uses the finite
+informationally complete effects on the first subsystem.
+
+Source: Hayden, Jozsa, Petz and Winter,
+arXiv:quant-ph/0304007v2, Theorem 6, equation (14), lines 499--502.
+
+**Convention (factor order):** TNLean orders each middle-system summand as
+the common density factor followed by the conditional-state-dependent factor,
+opposite to HJPW.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+
+namespace Matrix
+
+variable {dA dB dC n : ℕ}
+
+/-- Conditional slicing commutes with compression of the retained factor.
+
+This is the coordinate identity underlying HJPW,
+arXiv:quant-ph/0304007v2, Theorem 6, equation (14), lines 499--502. -/
+private theorem conditionalSlice_one_kronecker_compression
+    (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (M : Matrix (Fin dA) (Fin dA) ℂ)
+    (V : Matrix (Fin dB) (Fin n) ℂ) :
+    conditionalSlice
+        ((1 ⊗ₖ V)ᴴ * ρ * (1 ⊗ₖ V)) M =
+      Vᴴ * conditionalSlice ρ M * V := by
+  classical
+  let T : Matrix (Fin dB) (Fin dB) ℂ →ₗ[ℂ]
+      Matrix (Fin n) (Fin n) ℂ :=
+    { toFun := fun X ↦ Vᴴ * X * V
+      map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := by intro c X; simp [Matrix.mul_smul, Matrix.smul_mul] }
+  have hmap :
+      idTensorMapLM (δ := Fin dA) T ρ =
+        (1 ⊗ₖ V)ᴴ * ρ * (1 ⊗ₖ V) := by
+    ext ⟨a, k⟩ ⟨b, l⟩
+    simp only [idTensorMapLM_apply, idTensorMap_apply, T,
+      Matrix.mul_apply, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, Matrix.kroneckerMap_apply,
+      Matrix.one_apply]
+    simp_rw [Fintype.sum_prod_type]
+    simp
+    rfl
+  rw [← hmap, ← map_conditionalSlice]
+  rfl
+
+/-- Conditional slicing commutes with extension of the retained factor.
+
+This is the coordinate identity used to reconstruct the ambient bipartite
+state in HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (14),
+lines 499--502. -/
+private theorem conditionalSlice_one_kronecker_extension
+    (ρ : Matrix (Fin dA × Fin n) (Fin dA × Fin n) ℂ)
+    (M : Matrix (Fin dA) (Fin dA) ℂ)
+    (V : Matrix (Fin dB) (Fin n) ℂ) :
+    conditionalSlice
+        ((1 ⊗ₖ V) * ρ * (1 ⊗ₖ V)ᴴ) M =
+      V * conditionalSlice ρ M * Vᴴ := by
+  classical
+  let T : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ]
+      Matrix (Fin dB) (Fin dB) ℂ :=
+    { toFun := fun X ↦ V * X * Vᴴ
+      map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := by intro c X; simp [Matrix.mul_smul, Matrix.smul_mul] }
+  have hmap :
+      idTensorMapLM (δ := Fin dA) T ρ =
+        (1 ⊗ₖ V) * ρ * (1 ⊗ₖ V)ᴴ := by
+    ext ⟨a, k⟩ ⟨b, l⟩
+    simp only [idTensorMapLM_apply, idTensorMap_apply, T,
+      Matrix.mul_apply, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, Matrix.kroneckerMap_apply,
+      Matrix.one_apply]
+    simp_rw [Fintype.sum_prod_type]
+    simp
+    rfl
+  rw [← hmap, ← map_conditionalSlice]
+  rfl
+
+/-- A positive conditional slice with zero real trace vanishes. -/
+private theorem conditionalSlice_eq_zero_of_trace_re_eq_zero
+    {ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (hρ : ρ.PosSemidef) (s : ICEffectIndex dA)
+    (htrace : (conditionalSlice ρ
+      (informationallyCompleteEffect s)).trace.re = 0) :
+    conditionalSlice ρ (informationallyCompleteEffect s) = 0 := by
+  let ξ := conditionalSlice ρ (informationallyCompleteEffect s)
+  have hξ : ξ.PosSemidef :=
+    hρ.conditionalSlice (informationallyCompleteEffect_posSemidef s)
+  apply (hξ.trace_eq_zero_iff).mp
+  apply Complex.ext
+  · exact htrace
+  · simpa using (Complex.nonneg_iff.mp hξ.trace_nonneg).2.symm
+
+/-- Rescaling an active normalized conditional state recovers its
+unnormalized conditional slice. -/
+private theorem trace_re_smul_recoveredConditionalState
+    (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (s : RecoveredEffectIndex ρ) :
+    ((conditionalSlice ρ
+        (informationallyCompleteEffect (s : ICEffectIndex dA))).trace.re : ℂ) •
+      recoveredConditionalState ρ s =
+    conditionalSlice ρ
+      (informationallyCompleteEffect (s : ICEffectIndex dA)) := by
+  rw [recoveredConditionalState, smul_smul]
+  rw [show
+    ((conditionalSlice ρ
+        (informationallyCompleteEffect (s : ICEffectIndex dA))).trace.re : ℂ) *
+      (((conditionalSlice ρ
+        (informationallyCompleteEffect (s : ICEffectIndex dA))).trace.re)⁻¹ : ℝ) =
+        1 by exact_mod_cast mul_inv_cancel₀ s.property]
+  simp
+
+/-- Reconstruction from normalized active conditional states and vanishing
+inactive conditional slices. -/
+private theorem one_kronecker_reconstructs_of_recoveredConditionalState
+    (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ : ρ.PosSemidef) (V : Matrix (Fin dB) (Fin n) ℂ)
+    (hrec : ∀ s : RecoveredEffectIndex ρ,
+      V * (Vᴴ * recoveredConditionalState ρ s * V) * Vᴴ =
+        recoveredConditionalState ρ s) :
+    ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ V) *
+          (((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ V)ᴴ * ρ *
+            ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ V)) *
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ V)ᴴ = ρ := by
+  apply eq_of_conditionalSlice_informationallyCompleteEffect_eq
+  intro s
+  rw [conditionalSlice_one_kronecker_extension,
+    conditionalSlice_one_kronecker_compression]
+  by_cases hs :
+      (conditionalSlice ρ (informationallyCompleteEffect s)).trace.re = 0
+  · rw [conditionalSlice_eq_zero_of_trace_re_eq_zero hρ s hs]
+    simp
+  · let x : RecoveredEffectIndex ρ := ⟨s, hs⟩
+    let p : ℂ :=
+      (conditionalSlice ρ (informationallyCompleteEffect s)).trace.re
+    have hscale :
+        p • recoveredConditionalState ρ x =
+          conditionalSlice ρ (informationallyCompleteEffect s) :=
+      trace_re_smul_recoveredConditionalState ρ x
+    calc
+      V * (Vᴴ * conditionalSlice ρ (informationallyCompleteEffect s) * V) * Vᴴ =
+          p • (V * (Vᴴ * recoveredConditionalState ρ x * V) * Vᴴ) := by
+            rw [← hscale]
+            simp [Matrix.mul_smul, Matrix.smul_mul]
+      _ = p • recoveredConditionalState ρ x := by rw [hrec x]
+      _ = conditionalSlice ρ (informationallyCompleteEffect s) := hscale
+
+/-- Reassociate subsystem A with the joint-support direct-sum coordinates.
+
+The target order is the one used by TNLean in HJPW Theorem 6, equation (14):
+the common factor precedes the joint A--conditional factor. -/
+def recoveredBipartiteBlockEquiv
+    {K : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n) :
+    ((j : Fin K) × (Fin (m j) × (Fin dA × Fin (d j)))) ≃
+      Fin dA × Fin n :=
+  (Equiv.sigmaCongrRight fun j ↦
+      (Equiv.refl (Fin (m j))).prodCongr
+        (Equiv.prodComm (Fin dA) (Fin (d j)))
+      |>.trans (Equiv.prodAssoc (Fin (m j)) (Fin (d j)) (Fin dA)).symm)
+    |>.trans (Equiv.sigmaProdDistrib
+      (fun j : Fin K ↦ Fin (m j) × Fin (d j)) (Fin dA)).symm
+    |>.trans (e.prodCongr (Equiv.refl (Fin dA)))
+    |>.trans (Equiv.prodComm (Fin n) (Fin dA))
+
+@[simp]
+private theorem recoveredBipartiteBlockEquiv_symm_apply
+    {K : ℕ} {d m : Fin K → ℕ}
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (a : Fin dA)
+    (z : (j : Fin K) × (Fin (m j) × Fin (d j))) :
+    (recoveredBipartiteBlockEquiv (dA := dA) e).symm (a, e z) =
+      ⟨z.1, (z.2.1, (a, z.2.2))⟩ := by
+  simp [recoveredBipartiteBlockEquiv]
+  rfl
+
+/-- Conditional-slice block equations reconstruct a positive bipartite
+direct-sum tensor form. -/
+private theorem exists_bipartiteBlockForm_of_conditionalSlice_blockForm
+    {K : ℕ} {d m : Fin K → ℕ}
+    (R : Matrix (Fin dA × Fin n) (Fin dA × Fin n) ℂ)
+    (hR : R.PosSemidef)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (hσtrace : ∀ j, (σ j).trace = 1)
+    (hslice : ∀ s : ICEffectIndex dA,
+      ∃ X : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+        conditionalSlice R (informationallyCompleteEffect s) =
+          Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ X j)) :
+    ∃ ω : ∀ j,
+        Matrix (Fin dA × Fin (d j)) (Fin dA × Fin (d j)) ℂ,
+      (∀ j, (ω j).PosSemidef) ∧
+      R = Matrix.reindex (recoveredBipartiteBlockEquiv e)
+        (recoveredBipartiteBlockEquiv e)
+        (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ ω j) ∧
+      ∑ j, (ω j).trace = R.trace := by
+  classical
+  let g := recoveredBipartiteBlockEquiv (dA := dA) e
+  let S := Matrix.reindex g.symm g.symm R
+  let ω : ∀ j,
+      Matrix (Fin dA × Fin (d j)) (Fin dA × Fin (d j)) ℂ :=
+    fun j ↦ Matrix.partialTraceLeft
+      (S.submatrix (fun z ↦ ⟨j, z⟩) (fun z ↦ ⟨j, z⟩))
+  have hS : S.PosSemidef := by
+    exact hR.submatrix g
+  have hωpos : ∀ j, (ω j).PosSemidef := by
+    intro j
+    exact (hS.submatrix (fun z ↦ ⟨j, z⟩)).partialTraceLeft
+  have hform : R = Matrix.reindex (recoveredBipartiteBlockEquiv e)
+      (recoveredBipartiteBlockEquiv e)
+      (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ ω j) := by
+    apply eq_of_conditionalSlice_informationallyCompleteEffect_eq
+    intro s
+    obtain ⟨X, hX⟩ := hslice s
+    ext k l
+    let zk := e.symm k
+    let zl := e.symm l
+    have hk : k = e zk := by simp [zk]
+    have hl : l = e zl := by simp [zl]
+    conv_lhs =>
+      rw [hk, hl]
+    conv_rhs =>
+      rw [hk, hl]
+    obtain ⟨j, zk⟩ := zk
+    obtain ⟨j', zl⟩ := zl
+    by_cases hj : j = j'
+    · subst j'
+      have hωslice :
+          conditionalSlice (ω j) (informationallyCompleteEffect s) =
+            X j := by
+        ext c d'
+        change
+          (∑ a, ∑ b, (∑ x,
+            R (a, e ⟨j, (x, c)⟩)
+              (b, e ⟨j, (x, d')⟩)) *
+            informationallyCompleteEffect s b a) =
+          X j c d'
+        simp_rw [Finset.sum_mul]
+        calc
+          (∑ a, ∑ b, ∑ x,
+              R (a, e ⟨j, (x, c)⟩)
+                  (b, e ⟨j, (x, d')⟩) *
+                informationallyCompleteEffect s b a) =
+              ∑ a, ∑ x, ∑ b,
+                R (a, e ⟨j, (x, c)⟩)
+                    (b, e ⟨j, (x, d')⟩) *
+                  informationallyCompleteEffect s b a := by
+                    apply Finset.sum_congr rfl
+                    intro a _
+                    rw [Finset.sum_comm]
+          _ =
+              ∑ x, ∑ a, ∑ b,
+                R (a, e ⟨j, (x, c)⟩)
+                    (b, e ⟨j, (x, d')⟩) *
+                  informationallyCompleteEffect s b a := by
+                    rw [Finset.sum_comm]
+          _ = ∑ x, σ j x x * X j c d' := by
+            apply Finset.sum_congr rfl
+            intro x _
+            have hentry := congrFun (congrFun hX
+              (e ⟨j, (x, c)⟩))
+              (e ⟨j, (x, d')⟩)
+            simpa only [conditionalSlice, Matrix.reindex_apply,
+              Matrix.submatrix_apply, Equiv.symm_apply_apply,
+              Matrix.blockDiagonal'_apply_eq,
+              Matrix.kroneckerMap_apply] using hentry
+          _ = (σ j).trace * X j c d' := by
+            rw [← Finset.sum_mul]
+            rfl
+          _ = X j c d' := by rw [hσtrace, one_mul]
+      calc
+        conditionalSlice R (informationallyCompleteEffect s)
+            (e ⟨j, zk⟩) (e ⟨j, zl⟩) =
+            σ j zk.1 zl.1 * X j zk.2 zl.2 := by
+              have hentry := congrFun (congrFun hX
+                (e ⟨j, zk⟩)) (e ⟨j, zl⟩)
+              simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+                Equiv.symm_apply_apply, Matrix.blockDiagonal'_apply_eq,
+                Matrix.kroneckerMap_apply] using hentry
+        _ = σ j zk.1 zl.1 *
+            conditionalSlice (ω j) (informationallyCompleteEffect s)
+              zk.2 zl.2 := by rw [hωslice]
+        _ = conditionalSlice
+            (Matrix.reindex (recoveredBipartiteBlockEquiv e)
+              (recoveredBipartiteBlockEquiv e)
+              (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ ω j))
+            (informationallyCompleteEffect s)
+            (e ⟨j, zk⟩) (e ⟨j, zl⟩) := by
+              simp only [conditionalSlice, Matrix.reindex_apply,
+                Matrix.submatrix_apply, Matrix.blockDiagonal'_apply_eq,
+                Matrix.kroneckerMap_apply,
+                recoveredBipartiteBlockEquiv_symm_apply]
+              rw [Finset.mul_sum]
+              apply Finset.sum_congr rfl
+              intro a _
+              rw [Finset.mul_sum]
+              apply Finset.sum_congr rfl
+              intro b _
+              ring
+    · calc
+        conditionalSlice R (informationallyCompleteEffect s)
+            (e ⟨j, zk⟩) (e ⟨j', zl⟩) = 0 := by
+          have hentry := congrFun (congrFun hX (e ⟨j, zk⟩)) (e ⟨j', zl⟩)
+          simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+            Equiv.symm_apply_apply,
+            Matrix.blockDiagonal'_apply_ne _ _ _ hj] using hentry
+        _ = conditionalSlice
+            (Matrix.reindex (recoveredBipartiteBlockEquiv e)
+              (recoveredBipartiteBlockEquiv e)
+              (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ ω j))
+            (informationallyCompleteEffect s)
+            (e ⟨j, zk⟩) (e ⟨j', zl⟩) := by
+              simp only [conditionalSlice, Matrix.reindex_apply,
+                Matrix.submatrix_apply,
+                Matrix.blockDiagonal'_apply_ne _ _ _ hj,
+                zero_mul, Finset.sum_const_zero,
+                recoveredBipartiteBlockEquiv_symm_apply]
+  refine ⟨ω, hωpos, hform, ?_⟩
+  have htrace := congrArg Matrix.trace hform
+  rw [Matrix.trace_reindex, Matrix.trace_blockDiagonal'] at htrace
+  simpa only [Matrix.trace_kronecker, hσtrace, one_mul] using htrace.symm
+
+/-- The recovered conditional-family witnesses together with the bipartite
+block form on their minimum joint support.
+
+This bundle retains the full preserving-family, density, and block-action
+package used to obtain the coordinates.  Its final fields add precisely the
+bipartite reconstruction in HJPW Theorem 6, equation (14), lines 499--502.
+The recovery-dilation action of equation (15) is not included. -/
+structure RecoveredConditionalBipartiteBlockForm
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))] where
+  F : Kraus.PreservingKrausFamily
+    (recoveredConditionalState (traceC_ABC ρ_ABC))
+  n : ℕ
+  V : Matrix (Fin dB) (Fin n) ℂ
+  recoveredMiddleChannel_eq : ∀ X, Kraus.map F.Kfam X =
+    recoveredMiddleChannel ρ_ABC hρ_dm.1 X
+  V_isometry : Vᴴ * V = 1
+  V_range : V * Vᴴ = (Kraus.commonAverage_posSemidef
+      (recoveredConditionalState (traceC_ABC ρ_ABC))
+        (recoveredConditionalState_posSemidef
+          (SSAPosDef.traceC_ABC_posSemidef hρ_dm.1))).supportProj
+  V_recovers : ∀ x,
+    V * Kraus.supportCompressedFamily V
+      (recoveredConditionalState (traceC_ABC ρ_ABC)) x * Vᴴ =
+      recoveredConditionalState (traceC_ABC ρ_ABC) x
+  K : ℕ
+  d : Fin K → ℕ
+  m : Fin K → ℕ
+  e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n
+  U : Matrix (Fin n) (Fin n) ℂ
+  σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ
+  q : RecoveredEffectIndex (traceC_ABC ρ_ABC) → Fin K → ℝ
+  τ : RecoveredEffectIndex (traceC_ABC ρ_ABC) → ∀ j,
+    Matrix (Fin (d j)) (Fin (d j)) ℂ
+  U_unitary : U ∈ Matrix.unitaryGroup (Fin n) ℂ
+  d_pos : ∀ j, 0 < d j
+  m_pos : ∀ j, 0 < m j
+  σ_pos : ∀ j, (σ j).PosSemidef
+  σ_trace : ∀ j, (σ j).trace = 1
+  q_nonneg : ∀ x j, 0 ≤ q x j
+  q_sum : ∀ x, ∑ j, q x j = 1
+  τ_pos : ∀ x j, (τ x j).PosSemidef
+  τ_trace : ∀ x j, (τ x j).trace = 1
+  recoveredConditionalState_eq : ∀ x,
+    star U * Kraus.supportCompressedFamily V
+        (recoveredConditionalState (traceC_ABC ρ_ABC)) x * U =
+      Matrix.reindex e e
+        (Matrix.blockDiagonal' fun j ↦
+          (q x j : ℂ) • (σ j ⊗ₖ τ x j))
+  preserving_support_action :
+    ∀ G : Kraus.PreservingKrausFamily
+        (recoveredConditionalState (traceC_ABC ρ_ABC)),
+      Kraus.IsPreserving
+          (Kraus.supportCompressedFamily V
+            (recoveredConditionalState (traceC_ABC ρ_ABC)))
+          (Kraus.supportCompressedKraus V G.Kfam) ∧
+        ∀ X, Kraus.map G.Kfam (V * X * Vᴴ) =
+          V * Kraus.map (Kraus.supportCompressedKraus V G.Kfam) X * Vᴴ
+  preserving_block_action :
+    ∀ G : Kraus.PreservingKrausFamily
+        (Kraus.supportCompressedFamily V
+          (recoveredConditionalState (traceC_ABC ρ_ABC))),
+      ∃ C : (i : Fin G.numKraus) → ∀ j,
+          Matrix (Fin (m j)) (Fin (m j)) ℂ,
+        (∀ i,
+          Matrix.reindex e.symm e.symm (star U * G.Kfam i * U) =
+            Matrix.blockDiagonal' fun j ↦
+              C i j ⊗ₖ (1 : Matrix (Fin (d j)) (Fin (d j)) ℂ)) ∧
+        (∀ j, Kraus.IsTP (fun i ↦ C i j)) ∧
+        (∀ j, Kraus.map (fun i ↦ C i j) (σ j) = σ j) ∧
+        ∀ j (A : Matrix (Fin (m j)) (Fin (m j)) ℂ)
+            (B : Matrix (Fin (d j)) (Fin (d j)) ℂ),
+          Matrix.reindex e.symm e.symm
+              (star U * Kraus.map G.Kfam
+                (U * Matrix.reindex e e
+                  (Matrix.directSumBlockEmbedding (m := m) (d := d) j
+                    (A ⊗ₖ B)) * star U) * U) =
+            Matrix.directSumBlockEmbedding (m := m) (d := d) j
+              (Kraus.map (fun i ↦ C i j) A ⊗ₖ B)
+  ambient_reconstruction :
+    let W := (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ V
+    W * (Wᴴ * traceC_ABC ρ_ABC * W) * Wᴴ = traceC_ABC ρ_ABC
+  ω : ∀ j, Matrix (Fin dA × Fin (d j)) (Fin dA × Fin (d j)) ℂ
+  ω_pos : ∀ j, (ω j).PosSemidef
+  bipartite_block_form :
+    let W := (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ V
+    let R := ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U)ᴴ *
+      (Wᴴ * traceC_ABC ρ_ABC * W) *
+      ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U)
+    R = Matrix.reindex (recoveredBipartiteBlockEquiv e)
+      (recoveredBipartiteBlockEquiv e)
+      (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ ω j)
+  ω_trace_sum : ∑ j, (ω j).trace = 1
+
+/-- **Recovered bipartite block form on the minimum joint support.**
+
+At equality in strong subadditivity, the exact joint-support witnesses of
+`exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport`
+also reconstruct the bipartite marginal.  The result retains the complete
+preserving-family, density, and block-action package for the next recovery
+step.  With `W = 1_A ⊗ V`, the ambient state is recovered from its support
+compression.  After the same unitary `U`, that compression is
+`\bigoplus_j σ_j ⊗ ω_j`, where each unnormalized `ω j` is positive and their
+traces sum to one.
+
+TNLean uses the reverse tensor-factor order from HJPW.  The tensor equation is
+only on the minimum joint-support coordinates; no ambient equivalence on
+subsystem B or rectangular recovery action is claimed.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (14),
+lines 499--502. -/
+theorem exists_recoveredConditionalBipartiteBlockForm_jointSupport
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    letI : Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC)) :=
+      recoveredEffectIndex_nonempty (traceC_ABC ρ_ABC) (by
+        rw [← trace_eq_trace_traceC_ABC]
+        exact hρ_dm.2)
+    Nonempty (RecoveredConditionalBipartiteBlockForm ρ_ABC hρ_dm) := by
+  classical
+  letI : Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC)) :=
+    recoveredEffectIndex_nonempty (traceC_ABC ρ_ABC) (by
+      rw [← trace_eq_trace_traceC_ABC]
+      exact hρ_dm.2)
+  obtain ⟨F, n, V, hFmap, hV, hVrange, hrec, K, d, m, e, U, σ, q, τ,
+      hU, hd, hm, hσpos, hσtrace, hqnonneg, hqsum, hτpos, hτtrace,
+      hfamily, hpres, haction⟩ :=
+    exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport
+      ρ_ABC hρ_dm hSSA
+  let ρ_AB := traceC_ABC ρ_ABC
+  let μ := recoveredConditionalState ρ_AB
+  let W := (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ V
+  have hABpos : ρ_AB.PosSemidef :=
+    SSAPosDef.traceC_ABC_posSemidef hρ_dm.1
+  have hambient : W * (Wᴴ * ρ_AB * W) * Wᴴ = ρ_AB :=
+    one_kronecker_reconstructs_of_recoveredConditionalState
+      ρ_AB hABpos V (by
+        intro x
+        simpa only [Kraus.supportCompressedFamily] using hrec x)
+  let R := ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U)ᴴ *
+    (Wᴴ * ρ_AB * W) *
+    ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U)
+  have hR : R.PosSemidef := by
+    have hcompressed : (Wᴴ * ρ_AB * W).PosSemidef :=
+      by simpa only [Matrix.conjTranspose_conjTranspose] using
+        hABpos.mul_mul_conjTranspose_same Wᴴ
+    simpa only [Matrix.conjTranspose_conjTranspose] using
+      hcompressed.mul_mul_conjTranspose_same
+        (((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U)ᴴ)
+  have hslice : ∀ s : ICEffectIndex dA,
+      ∃ X : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ,
+        conditionalSlice R (informationallyCompleteEffect s) =
+          Matrix.reindex e e
+            (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ X j) := by
+    intro s
+    by_cases hs :
+        (conditionalSlice ρ_AB (informationallyCompleteEffect s)).trace.re = 0
+    · refine ⟨fun _ ↦ 0, ?_⟩
+      dsimp only [R, W]
+      rw [conditionalSlice_one_kronecker_compression,
+        conditionalSlice_one_kronecker_compression,
+        conditionalSlice_eq_zero_of_trace_re_eq_zero hABpos s hs]
+      ext z w
+      simp [Matrix.blockDiagonal'_apply]
+    · let x : RecoveredEffectIndex ρ_AB := ⟨s, hs⟩
+      let p : ℂ :=
+        (conditionalSlice ρ_AB (informationallyCompleteEffect s)).trace.re
+      refine ⟨fun j ↦ (p * q x j) • τ x j, ?_⟩
+      dsimp only [R, W]
+      rw [conditionalSlice_one_kronecker_compression,
+        conditionalSlice_one_kronecker_compression]
+      have hscale :
+          p • recoveredConditionalState ρ_AB x =
+            conditionalSlice ρ_AB (informationallyCompleteEffect s) :=
+        trace_re_smul_recoveredConditionalState ρ_AB x
+      rw [← hscale]
+      simp only [Matrix.mul_smul, Matrix.smul_mul]
+      rw [show Vᴴ * recoveredConditionalState ρ_AB x * V =
+        Kraus.supportCompressedFamily V μ x by rfl]
+      change p • (star U * Kraus.supportCompressedFamily V μ x * U) = _
+      rw [hfamily x]
+      ext z w
+      simp only [Matrix.smul_apply, Matrix.reindex_apply,
+        Matrix.submatrix_apply]
+      let z' := e.symm z
+      let w' := e.symm w
+      have hz : e.symm z = z' := rfl
+      have hw : e.symm w = w' := rfl
+      rw [hz, hw]
+      by_cases hzw : z'.1 = w'.1
+      · obtain ⟨j, z'⟩ := z'
+        obtain ⟨j', w'⟩ := w'
+        dsimp only at hzw
+        subst j'
+        change p •
+              Matrix.blockDiagonal'
+                (fun j ↦ (q x j : ℂ) • (σ j ⊗ₖ τ x j))
+                ⟨j, z'⟩ ⟨j, w'⟩ =
+            Matrix.blockDiagonal'
+              (fun j ↦ σ j ⊗ₖ ((p * q x j) • τ x j))
+              ⟨j, z'⟩ ⟨j, w'⟩
+        rw [Matrix.blockDiagonal'_apply_eq,
+          Matrix.blockDiagonal'_apply_eq]
+        simp only [Matrix.kroneckerMap_apply, Matrix.smul_apply]
+        ring
+      · change p •
+            Matrix.blockDiagonal'
+              (fun j ↦ (q x j : ℂ) • (σ j ⊗ₖ τ x j)) z' w' =
+          Matrix.blockDiagonal'
+            (fun j ↦ σ j ⊗ₖ ((p * q x j) • τ x j)) z' w'
+        rw [Matrix.blockDiagonal'_apply_ne _ _ _ hzw,
+          Matrix.blockDiagonal'_apply_ne _ _ _ hzw]
+        simp
+  obtain ⟨ω, hωpos, hRform, hωtraceR⟩ :=
+    exists_bipartiteBlockForm_of_conditionalSlice_blockForm
+      R hR e σ hσtrace hslice
+  have hRtrace : R.trace = 1 := by
+    have hW : Wᴴ * W = 1 := by
+      dsimp only [W]
+      rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one,
+        ← Matrix.mul_kronecker_mul, hV, Matrix.one_mul]
+      exact Matrix.one_kronecker_one
+    have hUright : U * Uᴴ = 1 := Matrix.mem_unitaryGroup_iff.mp hU
+    have hT :
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U) *
+            ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U)ᴴ = 1 := by
+      rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one,
+        ← Matrix.mul_kronecker_mul, hUright, Matrix.one_mul]
+      exact Matrix.one_kronecker_one
+    have hcompressedTrace : (Wᴴ * ρ_AB * W).trace = 1 := by
+      have ht := congrArg Matrix.trace hambient
+      rw [Matrix.trace_mul_cycle, hW, Matrix.one_mul] at ht
+      rw [ht]
+      rw [← trace_eq_trace_traceC_ABC]
+      exact hρ_dm.2
+    dsimp only [R]
+    rw [Matrix.trace_mul_cycle, hT, Matrix.one_mul]
+    exact hcompressedTrace
+  exact ⟨{
+    F := F
+    n := n
+    V := V
+    recoveredMiddleChannel_eq := hFmap
+    V_isometry := hV
+    V_range := hVrange
+    V_recovers := hrec
+    K := K
+    d := d
+    m := m
+    e := e
+    U := U
+    σ := σ
+    q := q
+    τ := τ
+    U_unitary := hU
+    d_pos := hd
+    m_pos := hm
+    σ_pos := hσpos
+    σ_trace := hσtrace
+    q_nonneg := hqnonneg
+    q_sum := hqsum
+    τ_pos := hτpos
+    τ_trace := hτtrace
+    recoveredConditionalState_eq := hfamily
+    preserving_support_action := hpres
+    preserving_block_action := haction
+    ambient_reconstruction := hambient
+    ω := ω
+    ω_pos := hωpos
+    bipartite_block_form := hRform
+    ω_trace_sum := hωtraceR.trans hRtrace }⟩
+
+end Matrix

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
@@ -8,12 +8,13 @@ import TNLean.Channel.KoashiImoto.RecoveredConditionalBlockForm
 /-!
 # Bipartite block form from recovered conditional states
 
-This file reconstructs the bipartite marginal from the block form of its
-recovered conditional states.  The reconstruction uses the finite
-informationally complete effects on the first subsystem.
+This file reconstructs the bipartite marginal in the minimum joint-support
+coordinates of its recovered conditional states.  The reconstruction uses the
+finite informationally complete effects on the first subsystem.
 
-Source: Hayden, Jozsa, Petz and Winter,
-arXiv:quant-ph/0304007v2, Theorem 6, equation (14), lines 499--502.
+This is a scope-restricted step toward Hayden, Jozsa, Petz and Winter,
+arXiv:quant-ph/0304007v2, Theorem 6, equation (14), lines 499--502; extending
+the coordinates to the ambient middle subsystem remains open.
 
 **Convention (factor order):** TNLean orders each middle-system summand as
 the common density factor followed by the conditional-state-dependent factor,
@@ -338,9 +339,16 @@ private theorem exists_bipartiteBlockForm_of_conditionalSlice_blockForm
 block form on their minimum joint support.
 
 This bundle retains the full preserving-family, density, and block-action
-package used to obtain the coordinates.  Its final fields add precisely the
-bipartite reconstruction in HJPW Theorem 6, equation (14), lines 499--502.
-The recovery-dilation action of equation (15) is not included. -/
+package used to obtain the coordinates.  Its final fields add the
+joint-support bipartite reconstruction toward HJPW Theorem 6, equation (14),
+lines 499--502.
+
+**Scope restriction (HJPW Theorem 6, equation (14)):** the direct-sum
+coordinates cover only the minimum joint support, not the ambient middle
+subsystem.  This is documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+Elimination: extend the coordinates to the ambient middle subsystem before
+proving the recovery-dilation action of equation (15). -/
 structure RecoveredConditionalBipartiteBlockForm
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)
@@ -445,8 +453,13 @@ TNLean uses the reverse tensor-factor order from HJPW.  The tensor equation is
 only on the minimum joint-support coordinates; no ambient equivalence on
 subsystem B or rectangular recovery action is claimed.
 
-Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (14),
-lines 499--502. -/
+**Scope restriction (HJPW Theorem 6, equation (14)):** the source states an
+ambient direct-sum equivalence on subsystem B, whereas this theorem supplies
+the block equation only after compression to the minimum joint support.  This
+is documented in
+`docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex`.
+Elimination: extend the support coordinates to ambient B before proving the
+recovery-dilation action of equation (15). -/
 theorem exists_recoveredConditionalBipartiteBlockForm_jointSupport
     (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
       (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
@@ -338,10 +338,10 @@ private theorem exists_bipartiteBlockForm_of_conditionalSlice_blockForm
 /-- The recovered conditional-family witnesses together with the bipartite
 block form on their minimum joint support.
 
-This bundle retains the full preserving-family, density, and block-action
-package used to obtain the coordinates.  Its final fields add the
-joint-support bipartite reconstruction toward HJPW Theorem 6, equation (14),
-lines 499--502.
+This structure retains the preserving family, density operators, support
+isometry, and block-action identities used to obtain the coordinates.  Its
+final fields add the joint-support bipartite reconstruction toward HJPW
+Theorem 6, equation (14), lines 499--502.
 
 **Scope restriction (HJPW Theorem 6, equation (14)):** the direct-sum
 coordinates cover only the minimum joint support, not the ambient middle
@@ -443,9 +443,9 @@ structure RecoveredConditionalBipartiteBlockForm
 At equality in strong subadditivity, the exact joint-support witnesses of
 `exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport`
 also reconstruct the bipartite marginal.  The result retains the complete
-preserving-family, density, and block-action package for the next recovery
-step.  With `W = 1_A ⊗ V`, the ambient state is recovered from its support
-compression.  After the same unitary `U`, that compression is
+preserving family, density operators, support isometry, and block-action
+identities.  With `W = 1_A ⊗ V`, the ambient state is recovered from its
+support compression.  After the same unitary `U`, that compression is
 `\bigoplus_j σ_j ⊗ ω_j`, where each unnormalized `ω j` is positive and their
 traces sum to one.
 

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1829,8 +1829,7 @@ algebra of a family of jointly invariant states.
     \label{thm:hjpw_recovered_bipartite_joint_support_blocks}
     \lean{Matrix.exists_recoveredConditionalBipartiteBlockForm_jointSupport}
     \leanok
-    \uses{thm:hjpw_recovered_conditional_joint_support_blocks,
-        thm:hjpw_finite_conditional_slice_separation}
+    \uses{thm:hjpw_recovered_conditional_joint_support_blocks}
     Let $\rho_{ABC}$ be a tripartite density matrix attaining equality in
     strong subadditivity, and let $V$ be the support isometry and
     $(e,U,\sigma_j)$ the direct-sum coordinates of
@@ -1860,6 +1859,7 @@ algebra of a family of jointly invariant states.
 
 \begin{proof}
     \leanok
+    \uses{thm:hjpw_finite_conditional_slice_separation}
     Rescale the normalized equations for the active separating effects to
     their unnormalized conditional slices. A positive slice associated with
     an inactive effect has trace zero and therefore vanishes. The finite

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1846,7 +1846,7 @@ algebra of a family of jointly invariant states.
         W^\dagger\rho_{AB}W
         (\mathbf 1_A\otimes U)
         &={}\bigoplus_j\sigma_j\otimes\omega_j,
-        &
+        \\
         \sum_j\tr\omega_j&=1.
     \end{align}
     The tensor factors are written in the reverse order from HJPW. The block
@@ -1854,17 +1854,18 @@ algebra of a family of jointly invariant states.
     an ambient direct-sum equivalence on subsystem $B$.
 
     \textbf{Scope restriction (HJPW Theorem~6, equation~(14)):}
-    equation~(14), lines 499--502, states an ambient direct-sum equivalence on
-    subsystem $B$, whereas the displayed equation is only its joint-support
-    variant. This restriction is documented in
+    the displayed direct sum is restricted to the minimum joint supporting
+    subspace, whereas equation~(14), lines 499--502, decomposes the ambient
+    subsystem $B$. This restriction is documented in
     \path{docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex}.
-    The next step is to extend these coordinates to ambient $B$; only after
-    that can one address the recovery-dilation block action of equation~(15).
+    % Roadmap: extend these coordinates to ambient B before addressing the
+    % recovery-dilation block action of equation (15).
 \end{theorem}
 
 \begin{proof}
     \leanok
-    \uses{thm:hjpw_finite_conditional_slice_separation}
+    \uses{thm:hjpw_recovered_conditional_joint_support_blocks,
+        thm:hjpw_finite_conditional_slice_separation}
     Rescale the normalized equations for the active separating effects to
     their unnormalized conditional slices. A positive slice associated with
     an inactive effect has trace zero and therefore vanishes. The finite

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1853,8 +1853,13 @@ algebra of a family of jointly invariant states.
     equation is on the minimum joint supporting subspace; it does not assert
     an ambient direct-sum equivalence on subsystem $B$.
 
-    This is HJPW Theorem~6, equation~(14), lines 499--502. Equation~(15),
-    which concerns the recovery-dilation block action, remains a later step.
+    \textbf{Scope restriction (HJPW Theorem~6, equation~(14)):}
+    equation~(14), lines 499--502, states an ambient direct-sum equivalence on
+    subsystem $B$, whereas the displayed equation is only its joint-support
+    variant. This restriction is documented in
+    \path{docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex}.
+    The next step is to extend these coordinates to ambient $B$; only after
+    that can one address the recovery-dilation block action of equation~(15).
 \end{theorem}
 
 \begin{proof}
@@ -1923,10 +1928,12 @@ algebra of a family of jointly invariant states.
     the joint-support block form and preserving-operation action to this
     recovered family.
     Theorem~\ref{thm:hjpw_recovered_bipartite_joint_support_blocks}
-    reconstructs the bipartite marginal in the same support coordinates.
-    Lifting these blocks through the recovery channel and assembling the
-    quantum-Markov decomposition remain open. This forward implication
-    therefore remains axiomatic. The biconditional combines the two directions.
+    reconstructs the bipartite marginal only in the same minimum-support
+    coordinates. Extending those coordinates to ambient $B$ to complete
+    equation~(14), proving the recovery-dilation block action of
+    equation~(15), and assembling the quantum-Markov decomposition remain
+    open. This forward implication therefore remains axiomatic. The
+    biconditional combines the two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1825,6 +1825,52 @@ algebra of a family of jointly invariant states.
     the restriction and block-action clauses for the preserving operation.
 \end{proof}
 
+\begin{theorem}[Recovered bipartite blocks on the joint support]
+    \label{thm:hjpw_recovered_bipartite_joint_support_blocks}
+    \lean{Matrix.exists_recoveredConditionalBipartiteBlockForm_jointSupport}
+    \leanok
+    \uses{thm:hjpw_recovered_conditional_joint_support_blocks,
+        thm:hjpw_finite_conditional_slice_separation}
+    Let $\rho_{ABC}$ be a tripartite density matrix attaining equality in
+    strong subadditivity, and let $V$ be the support isometry and
+    $(e,U,\sigma_j)$ the direct-sum coordinates of
+    Theorem~\ref{thm:hjpw_recovered_conditional_joint_support_blocks}. Put
+    $W=\mathbf 1_A\otimes V$. Then
+    \begin{align}
+        W\bigl(W^\dagger\rho_{AB}W\bigr)W^\dagger
+        &={}\rho_{AB}.
+    \end{align}
+    In the same support coordinates there are positive, not necessarily
+    normalized operators $\omega_j$ such that
+    \begin{align}
+        (\mathbf 1_A\otimes U)^\dagger
+        W^\dagger\rho_{AB}W
+        (\mathbf 1_A\otimes U)
+        &={}\bigoplus_j\sigma_j\otimes\omega_j,
+        &
+        \sum_j\tr\omega_j&=1.
+    \end{align}
+    The tensor factors are written in the reverse order from HJPW. The block
+    equation is on the minimum joint supporting subspace; it does not assert
+    an ambient direct-sum equivalence on subsystem $B$.
+
+    This is HJPW Theorem~6, equation~(14), lines 499--502. Equation~(15),
+    which concerns the recovery-dilation block action, remains a later step.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Rescale the normalized equations for the active separating effects to
+    their unnormalized conditional slices. A positive slice associated with
+    an inactive effect has trace zero and therefore vanishes. The finite
+    separating family then reconstructs $\rho_{AB}$ through
+    $\mathbf 1_A\otimes V$. In the transformed support coordinates, take
+    $\omega_j$ to be the partial trace over the common factor of the
+    $j$-th principal block. Positivity follows from positivity of principal
+    blocks and of partial trace. Applying separation once more gives the
+    displayed direct-sum equation, and taking traces gives the normalization.
+\end{proof}
+
 \begin{theorem}[Hayashi SSA-equality characterization]
     \label{thm:hayashi_ssa_equality_characterization}
     \lean{hayashi_ssa_equality_characterization}
@@ -1875,11 +1921,12 @@ algebra of a family of jointly invariant states.
     the finite replacement for varying all effects.
     Theorem~\ref{thm:hjpw_recovered_conditional_joint_support_blocks} applies
     the joint-support block form and preserving-operation action to this
-    recovered family. Extending these block equations to the bipartite
-    marginal and lifting them through the recovery channel to assemble the
+    recovered family.
+    Theorem~\ref{thm:hjpw_recovered_bipartite_joint_support_blocks}
+    reconstructs the bipartite marginal in the same support coordinates.
+    Lifting these blocks through the recovery channel and assembling the
     quantum-Markov decomposition remain open. This forward implication
-    therefore remains axiomatic. The biconditional combines the two
-    directions.
+    therefore remains axiomatic. The biconditional combines the two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -66,10 +66,11 @@ recovered states.  The singular-support saturation-to-raw-recovery implication,
 its positive-definite specialization, and the trace-preserving extension of the
 support Petz map are now available. The finite recovered conditional density
 family, its separating effects, and its common preserving channel are also
-formalized. The family-level structural step remains open at the application
-of the joint-support block theorem to that family and the subsequent
-quantum-Markov assembly. The reverse direction is proved from the
-entropy-additivity sub-lemmas listed below.
+formalized. The joint-support block theorem has now been applied and the
+bipartite marginal reconstructed in the same support coordinates; lifting
+these blocks through the recovery channel as in HJPW equation~(15) and the
+subsequent quantum-Markov assembly remain open. The reverse direction is
+proved from the entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
 
@@ -89,13 +90,15 @@ family is also available under a positive-definite common-average hypothesis.
 In the same full-support setting, every preserving channel acts locally on the
 common summands and fixes their common density factors. The joint-support
 reduction is available, and the finite nonzero normalized conditional family
-fixed by the recovered middle-system channel is constructed. Applying the
-joint-support block theorem to this family and assembling the quantum-Markov
-decomposition are still missing. Thus the family-level structural implication
-needed here remains open, which is why the forward direction is treated as an
-external assumption rather than proved. The recovery implication and the
-complementary trace-preserving extension of the support Petz map are no longer
-part of this gap.
+fixed by the recovered middle-system channel is constructed. The joint-support
+block theorem has been applied to this family, and the bipartite marginal has
+been reconstructed in the same coordinates. Lifting the resulting blocks
+through the recovery channel as in HJPW equation~(15) and assembling the
+quantum-Markov decomposition are still missing. Thus the family-level
+structural implication needed here remains open, which is why the forward
+direction is treated as an external assumption rather than proved. The
+recovery implication and the complementary trace-preserving extension of the
+support Petz map are no longer part of this gap.
 
 \paragraph{Reverse direction (tractable, currently unused).}
 The implication \eqref{eq:qmc} $\Rightarrow$~\eqref{eq:ssa-eq} --- a state of the
@@ -681,16 +684,19 @@ complete effect family and conditional slices
   \leanid{Matrix.eq_of_conditionalSlice_informationallyCompleteEffect_eq}\\
   \leanid{Matrix.idTensor_recoveredMiddleChannel_traceC_ABC_eq}\\
   \leanid{Matrix.exists_recoveredConditionalPreservingKrausFamily}\\
-  \leanid{Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport}.
+  \leanid{Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport}\\
+  \leanid{Matrix.exists_recoveredConditionalBipartiteBlockForm_jointSupport}.
 \end{center}
 These declarations construct a finite nonempty family of nonzero normalized
 conditional states fixed by
 $\varphi=\operatorname{Tr}_C\circ\widehat{\mathcal R}$ and prove that the
 finite slices separate bipartite operators. They also apply the joint-support
 block form to this family and retain the support-intertwining and
-preserving-operation action of $\varphi$. Extending the finite block equations
-to the bipartite marginal, lifting them through the recovery channel, and
-assembling the quantum-Markov decomposition remain necessary before the
+preserving-operation action of $\varphi$. The last declaration rescales active
+slices, proves inactive positive slices vanish, and reconstructs
+$\rho_{AB}$ as $\bigoplus_j\sigma_j\otimes\omega_j$ on the same minimum joint
+support, which is HJPW equation~(14). The recovery-dilation block action of
+equation~(15) and the quantum-Markov assembly remain necessary before the
 forward external assumption can be removed.
 
 \section{Verdict}
@@ -698,8 +704,7 @@ forward external assumption can be removed.
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-bipartite reconstruction, recovery-channel lifting, and subsequent
-quantum-Markov assembly.
+recovery-channel lifting and subsequent quantum-Markov assembly.
 The full-support invariant-family state decomposition and preserving-operation
 block action are formalized. Source-facing
 completed-channel recovery from equality in data processing is available on
@@ -712,8 +717,9 @@ remaining forward structural direction alone is postulated. The reverse directio
 a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
 and reindexing invariance. The joint-support block form is now applied to the
-recovered conditional family. Until the bipartite and recovered tripartite
-blocks are assembled into the quantum-Markov decomposition, the forward
+recovered conditional family, and the bipartite marginal is reconstructed in
+the same support coordinates. Until the recovered tripartite blocks are
+assembled into the quantum-Markov decomposition, the forward
 direction remains the irreducible unproved content of this characterization.
 
 \begin{thebibliography}{9}

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -68,9 +68,10 @@ support Petz map are now available. The finite recovered conditional density
 family, its separating effects, and its common preserving channel are also
 formalized. The joint-support block theorem has now been applied and the
 bipartite marginal reconstructed in the same support coordinates; lifting
-these blocks through the recovery channel as in HJPW equation~(15) and the
-subsequent quantum-Markov assembly remain open. The reverse direction is
-proved from the entropy-additivity sub-lemmas listed below.
+those coordinates to ambient $B$ to complete HJPW equation~(14), proving the
+recovery-dilation block action of equation~(15), and the subsequent
+quantum-Markov assembly remain open. The reverse direction is proved from the
+entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
 
@@ -93,12 +94,13 @@ reduction is available, and the finite nonzero normalized conditional family
 fixed by the recovered middle-system channel is constructed. The joint-support
 block theorem has been applied to this family, and the bipartite marginal has
 been reconstructed in the same coordinates. Lifting the resulting blocks
-through the recovery channel as in HJPW equation~(15) and assembling the
-quantum-Markov decomposition are still missing. Thus the family-level
-structural implication needed here remains open, which is why the forward
-direction is treated as an external assumption rather than proved. The
-recovery implication and the complementary trace-preserving extension of the
-support Petz map are no longer part of this gap.
+to ambient $B$ to complete HJPW equation~(14), proving the recovery-dilation
+block action of equation~(15), and assembling the quantum-Markov decomposition
+are still missing. Thus the family-level structural implication needed here
+remains open, which is why the forward direction is treated as an external
+assumption rather than proved. The recovery implication and the complementary
+trace-preserving extension of the support Petz map are no longer part of this
+gap.
 
 \paragraph{Reverse direction (tractable, currently unused).}
 The implication \eqref{eq:qmc} $\Rightarrow$~\eqref{eq:ssa-eq} --- a state of the
@@ -695,16 +697,19 @@ block form to this family and retain the support-intertwining and
 preserving-operation action of $\varphi$. The last declaration rescales active
 slices, proves inactive positive slices vanish, and reconstructs
 $\rho_{AB}$ as $\bigoplus_j\sigma_j\otimes\omega_j$ on the same minimum joint
-support, which is HJPW equation~(14). The recovery-dilation block action of
-equation~(15) and the quantum-Markov assembly remain necessary before the
-forward external assumption can be removed.
+support. This is a scope-restricted joint-support variant toward HJPW
+equation~(14), not its ambient-$B$ statement. Extending the coordinates to
+ambient $B$ to complete equation~(14), proving the recovery-dilation block
+action of equation~(15), and the quantum-Markov assembly remain necessary
+before the forward external assumption can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-recovery-channel lifting and subsequent quantum-Markov assembly.
+ambient-$B$ coordinate extension, recovery-dilation block action, and
+subsequent quantum-Markov assembly.
 The full-support invariant-family state decomposition and preserving-operation
 block action are formalized. Source-facing
 completed-channel recovery from equality in data processing is available on
@@ -718,9 +723,10 @@ a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
 and reindexing invariance. The joint-support block form is now applied to the
 recovered conditional family, and the bipartite marginal is reconstructed in
-the same support coordinates. Until the recovered tripartite blocks are
-assembled into the quantum-Markov decomposition, the forward
-direction remains the irreducible unproved content of this characterization.
+the same support coordinates. Extending those coordinates to ambient $B$
+before constructing the recovered tripartite blocks and assembling the
+quantum-Markov decomposition remains part of the irreducible unproved forward
+direction.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -165,20 +165,22 @@ constructed by
 \leanid{Matrix.exists_recoveredConditionalPreservingKrausFamily}; the slices
 separate bipartite operators by
 \leanid{Matrix.eq_of_conditionalSlice_informationallyCompleteEffect_eq}.
-The remaining bridge must apply the joint-support block theorem to this family
-and assemble one common direct sum
+The joint-support block theorem is now applied to this family. The remaining
+bridge must extend its coordinates to one ambient direct sum
 \begin{align}
   H_B\cong\bigoplus_j H_{B_j^L}\otimes H_{B_j^R}
 \end{align}
-with the quantum-Markov form. The singular-support
+before proving the recovery-dilation block action and assembling the
+quantum-Markov form. The singular-support
 equality-to-raw-recovery implication is now formalized by the projected
 finite-Weyl argument and transported to arbitrary finite product coordinates.
 For density operators, support agreement upgrades this equality to the chosen
 completed partial-trace Petz channel on the recovered marginal. This does not
 give a tensor-product factorization of the generic completed singular channel.
-The joint-support block application and quantum-Markov assembly are the
-remaining structural obstructions to replacing the forward Hayashi
-strong-subadditivity equality assumption used in the CPSV16 argument.
+The ambient coordinate extension, recovery-dilation block action, and
+quantum-Markov assembly are the remaining structural obstructions to
+replacing the forward Hayashi strong-subadditivity equality assumption used in
+the CPSV16 argument.
 
 \section{Common invariant algebra: formalized under an explicit full-support hypothesis}
 
@@ -299,10 +301,12 @@ uses the same support isometry and block coordinates to reconstruct the
 bipartite marginal. It produces positive unnormalized factors $\omega_j$,
 proves that their traces sum to one, and establishes
 $\bigoplus_j\sigma_j\otimes\omega_j$ on the minimum joint support, with the
-tensor order reversed from HJPW. This is the bipartite statement in HJPW
-equation~(14). The recovery-dilation block action in equation~(15), the
-assembly of the generic quantum-Markov decomposition, and eliminating the
-external assumption for the
+tensor order reversed from HJPW. This is a scope-restricted joint-support
+variant toward HJPW equation~(14), not its ambient equivalence on $H_B$.
+Extending these coordinates to ambient $H_B$ to complete equation~(14),
+proving the recovery-dilation block action in equation~(15), assembling the
+generic quantum-Markov decomposition, and eliminating the external assumption
+for the
 forward Hayashi strong-subadditivity implication remain open.
 
 \section{Classification}
@@ -336,9 +340,11 @@ form on the minimum joint support. The finite recovered conditional family,
 its separating effects, and its preserving middle-system channel are
 formalized. The joint-support block form and preserving-operation action have
 also been applied to this family, and the bipartite marginal is reconstructed
-in those same support coordinates, completing HJPW equation~(14).
-The recovery-dilation block action of equation~(15) and the generic Hayashi
-forward implication remain open as separate later steps.
+in those same support coordinates. This is a scope-restricted joint-support
+variant toward HJPW equation~(14), not the ambient statement. Extending the
+coordinates to ambient $H_B$, the recovery-dilation block action of
+equation~(15), and the generic Hayashi forward implication remain open as
+separate sequential steps.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -293,9 +293,16 @@ equality. The declaration
 \leanid{Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport}
 applies the block theorem to this family and retains the recovered
 middle-system channel together with the support intertwining and diagonal
-block action. Extending these block equations to the bipartite marginal,
-lifting them through the recovery channel, assembling the generic
-quantum-Markov decomposition, and eliminating the external assumption for the
+block action. The declaration
+\leanid{Matrix.exists_recoveredConditionalBipartiteBlockForm_jointSupport}
+uses the same support isometry and block coordinates to reconstruct the
+bipartite marginal. It produces positive unnormalized factors $\omega_j$,
+proves that their traces sum to one, and establishes
+$\bigoplus_j\sigma_j\otimes\omega_j$ on the minimum joint support, with the
+tensor order reversed from HJPW. This is the bipartite statement in HJPW
+equation~(14). The recovery-dilation block action in equation~(15), the
+assembly of the generic quantum-Markov decomposition, and eliminating the
+external assumption for the
 forward Hayashi strong-subadditivity implication remain open.
 
 \section{Classification}
@@ -328,9 +335,10 @@ restriction of preserving operations are formalized, as is the combined block
 form on the minimum joint support. The finite recovered conditional family,
 its separating effects, and its preserving middle-system channel are
 formalized. The joint-support block form and preserving-operation action have
-also been applied to this family. Bipartite reconstruction, recovery-channel
-lifting, and the generic Hayashi forward implication remain open as separate
-later steps.
+also been applied to this family, and the bipartite marginal is reconstructed
+in those same support coordinates, completing HJPW equation~(14).
+The recovery-dilation block action of equation~(15) and the generic Hayashi
+forward implication remain open as separate later steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Closes LionSR/QICLean#258.

## Summary

- package the complete recovered conditional-family and preserving-channel witnesses from LionSR/TNLean#5031 in one dependent public structure
- reconstruct `ρ_AB` in the same minimum-joint-support coordinates and prove the positive unnormalized block form `⊕_j σ_j ⊗ ω_j`
- prove `∑_j tr ω_j = 1`, including the zero-probability blocks by positivity plus trace zero
- synchronize the Blueprint and paper-gap notes with the exact source boundary

This is a scope-restricted minimum-joint-support step toward HJPW Theorem 6, equation (14), lines 499–502. It deliberately does not claim the ambient direct-sum equivalence on all of subsystem `B`. The next sequential leaf is to extend these coordinates to ambient `B` and thereby complete equation (14); only then does equation (15), the recovery-dilation block action, follow.

## Validation

- `lake exe cache get` before any build in the fresh worktree (8,451 cached artifacts; no Mathlib source rebuild)
- `lake build TNLean.Channel.KoashiImoto.RecoveredConditionalBipartiteBlockForm TNLean.Channel.KoashiImoto`
- `lake build TNLean` (9,790 jobs)
- `lake exe lint_style`
- import aggregator check (47 files; 1,084 production modules)
- `python3 scripts/tactic_pattern_scan.py` (baseline-only findings)
- Blueprint declaration sync and `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint pdf`
- `leanblueprint web`
- visual inspection of the rendered theorem and adjacent pages
- reader-facing prose and stale-completion-claim scans
- proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`, or `maxHeartbeats` in the changed files

After rebasing onto current `main` at `cf779863f21b053fe9eb8367e02c16ce09ad1850`, the focused Koashi–Imoto build and Blueprint sync passed again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation with no runtime or security surface; main risk is proof/maintenance burden from a large new Lean module and scope boundaries vs. HJPW.
> 
> **Overview**
> Adds **`RecoveredConditionalBipartiteBlockForm.lean`** and wires it into the Koashi–Imoto aggregator. At SSA equality, it extends the joint-support recovered conditional block package by proving **bipartite marginal reconstruction** in the same minimum-support coordinates (HJPW Thm. 6, eq. (14), joint-support variant).
> 
> The main result **`exists_recoveredConditionalBipartiteBlockForm_jointSupport`** bundles the prior preserving-channel witnesses with **`ambient_reconstruction`** via `W = 1_A ⊗ V`, a block form `⊕_j σ_j ⊗ ω_j` after `1_A ⊗ U`, positive **`ω_j`**, and **`∑_j tr ω_j = 1`**. Supporting lemmas handle Kronecker–conditional-slice identities, rescaling active recovered states, vanishing inactive slices, and building **`ω_j`** from conditional-slice block data.
> 
> The **Blueprint** gains **`thm:hjpw_recovered_bipartite_joint_support_blocks`**; **Hayashi SSA** and **paper-gap** notes now record bipartite reconstruction as done while **ambient B**, eq. (15) recovery-dilation, and quantum-Markov assembly stay open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2468b2d63c4f11114c874c3cc6773f3ecce70c05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->