### PR TITLE
fix(tenkz): keep kernel bindings behind opt-in

### DIFF
--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -114,6 +114,10 @@ changes topology.  Public names come from the executable registry; private
 names follow `\__tenkz_<owner>_...:`.  Unsupported requested ink is a coded
 error, never a warning followed by omission.
 
+Until the S4 surface swap, kernel package loading is inert with respect to the
+0.7 surface. `KERNEL-LOAD-SWEEP.md` records the binding and key-tree audit and
+the regression that protects this boundary.
+
 ## expl3 and PGF traps
 
 These mistakes have shipped bugs here.

--- a/docs/tenkz/KERNEL-LOAD-SWEEP.md
+++ b/docs/tenkz/KERNEL-LOAD-SWEEP.md
@@ -1,0 +1,57 @@
+# Kernel load-time binding sweep
+
+This is the 2026-07-28 audit requested by #5014. The 1.0 kernel remains a
+group-local opt-in until the S4 surface swap, so loading `tenkz.sty` must not
+change the 0.7 command surface.
+
+## Method
+
+The sweep used two views of `tenkz-kernel.code.tex`.
+
+1. A source inventory covered every file-scope `\cs_new...`,
+   `\NewDocumentCommand`, `\cs_generate_variant`, `\keys_define`, and shared
+   assignment.
+2. A LuaTeX hash-table snapshot loaded all 0.7 stages without the kernel,
+   recorded every control-sequence meaning, then input the kernel and compared
+   the complete table. The same pass inspected generated l3keys control
+   sequences; a source search confirmed that the kernel creates no pgfkeys
+   paths.
+
+Undefined names interned while the kernel source was tokenized were not counted
+as bindings. LaTeX3 command/key-definition scratch registers changed transient
+values during input; they are framework-owned scratch, and no tenkz dialect
+reads them.
+
+## Result
+
+| Name or class | Binding time | Owner | Verdict |
+|---|---|---|---|
+| `\tenkzkernel` | package load | kernel public entry point | Keep. This is the sole public kernel command defined by loading the stage. |
+| `\tnwire`, `\tnmark`, `\tndeclare`, `\tnbond`, `\tnprose` | formerly package load; now `\tenkzkernel` | kernel body grammar | Load-time leak fixed. Their implementations are private and the switch binds the public names for its group. |
+| `tenkzeq`, `\endtenkzeq` | formerly no-op placeholders at package load; now `\tenkzkernel` | kernel equation grammar | Load-time leak fixed. The silent placeholders were removed. |
+| `tenkz`, `\endtenkz`, `\tnset`, `\tngroup` | `\tenkzkernel` | shared 0.7 names | Safe. The switch changes them locally and group exit restores the exact prior meanings. |
+| `\tn` and row `\\` | kernel picture begin | shared dialect names | Safe. The environment group owns and restores them. |
+| `\__tenkz_kernel_...` plus `\l__tenkz_kernel_...`, `\g__tenkz_kernel_...`, and `\c__tenkz_kernel_...` | package load | kernel private implementation and state | Safe. The hash-table additions are name-mangled and do not replace a prior meaning. |
+| l3keys trees `tenkz-kernel-picture`, `tenkz-kernel-atom`, `tenkz-kernel-wire`, and `tenkz-kernel-setup` | package load | kernel parser | Safe. Every generated handler remains in a kernel-owned tree; the kernel defines no pgfkeys path. |
+| geometry/render variants used by the kernel | owning stage load | shared geometry/render services | Boundary fixed. Variant declarations moved from the kernel file to the stage that owns each base function. |
+| commands created by `\tndeclare{atom}` | explicit declaration | author-requested kernel extension | Safe. They are runtime output of the documented extension door, not package-load state. |
+
+The post-fix hash comparison found no changed 0.7 command or environment
+meaning and no kernel-created control sequence in another tenkz stage's
+namespace. `tests/tenkz/kernel/regression/r_load_inert.tex` makes the public
+part of that result permanent: the kernel body/equation names are absent
+before opt-in, present inside the switch group, absent again afterward, and
+the saved 0.7 `tenkz`, `tnset`, and `tngroup` meanings are restored exactly.
+
+## Gates
+
+Run:
+
+```sh
+scripts/tenkz_kernel_probes.sh
+scripts/tenkz_corpus.sh
+```
+
+The first command includes the load-inertness regression and the kernel event
+and pixel goldens. The second keeps the bridge byte-identical for the complete
+0.7 fixture corpus.

--- a/scripts/tenkz_language.py
+++ b/scripts/tenkz_language.py
@@ -239,6 +239,15 @@ def _declared_api() -> tuple[set[str], set[str]]:
     for path in (ROOT / "tex/tenkz").glob("*.code.tex"):
         text = path.read_text(encoding="utf-8")
         commands.update(re.findall(r"\\NewDocumentCommand\s+\\([A-Za-z]+)", text))
+        commands.update(
+            public
+            for public, implementation in re.findall(
+                r"\\cs_set_eq:NN\s+\\([A-Za-z]+)"
+                r"\s+\\(__tenkz_kernel_[A-Za-z_]+_cmd)",
+                text,
+            )
+            if "_env_" not in implementation
+        )
         environments.update(
             re.findall(r"\\NewDocumentEnvironment\s*\{\s*([A-Za-z]+)", text)
         )

--- a/tests/tenkz/kernel/regression/r_load_inert.tex
+++ b/tests/tenkz/kernel/regression/r_load_inert.tex
@@ -1,0 +1,56 @@
+\documentclass[tikz,border=2pt]{standalone}
+\usepackage{tenkz}
+
+\ExplSyntaxOn
+\cs_new_eq:NN \tenkz_test_grid_begin: \tenkz
+\cs_new_eq:NN \tenkz_test_grid_end: \endtenkz
+\cs_new_eq:NN \tenkz_test_tnset: \tnset
+\cs_new_eq:NN \tenkz_test_tngroup: \tngroup
+
+\clist_map_inline:nn
+  {tnwire,tnmark,tndeclare,tnbond,tnprose,tenkzeq,endtenkzeq}
+  {
+    \cs_if_exist:cT {#1}
+      { \tex_errmessage:D { kernel~public~name~#1~leaked~at~package~load } }
+  }
+\ExplSyntaxOff
+
+\begin{document}
+\begingroup
+  \tenkzkernel
+  \ExplSyntaxOn
+  \clist_map_inline:nn
+    {tnwire,tnmark,tndeclare,tnbond,tnprose,tenkzeq,endtenkzeq}
+    {
+      \cs_if_exist:cF {#1}
+        { \tex_errmessage:D { kernel~switch~did~not~bind~#1 } }
+    }
+  \cs_if_eq:NNT \tenkz \tenkz_test_grid_begin:
+    { \tex_errmessage:D { kernel~switch~did~not~replace~tenkz } }
+  \ExplSyntaxOff
+  \begin{tenkz}[rows=1, cols=1]
+    \tn{A}
+  \end{tenkz}
+\endgroup
+
+\ExplSyntaxOn
+\cs_if_eq:NNF \tenkz \tenkz_test_grid_begin:
+  { \tex_errmessage:D { kernel~switch~leaked~the~tenkz~binding } }
+\cs_if_eq:NNF \endtenkz \tenkz_test_grid_end:
+  { \tex_errmessage:D { kernel~switch~leaked~the~endtenkz~binding } }
+\cs_if_eq:NNF \tnset \tenkz_test_tnset:
+  { \tex_errmessage:D { kernel~switch~leaked~the~tnset~binding } }
+\cs_if_eq:NNF \tngroup \tenkz_test_tngroup:
+  { \tex_errmessage:D { kernel~switch~leaked~the~tngroup~binding } }
+\clist_map_inline:nn
+  {tnwire,tnmark,tndeclare,tnbond,tnprose,tenkzeq,endtenkzeq}
+  {
+    \cs_if_exist:cT {#1}
+      { \tex_errmessage:D { kernel~public~name~#1~escaped~its~group } }
+  }
+\ExplSyntaxOff
+
+\begin{tenkz}
+  \tn{B}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -275,8 +275,10 @@
 \cs_generate_variant:Nn \__tenkz_geom_place_cell:nnnn { nnee }
 \cs_new_protected:Npn \__tenkz_geom_place_rel:nnnn #1#2#3#4
   { \prop_put:Nnn \l__tenkz_geom_req_prop {#1} { {rel}{#2}{#3}{#4} } }
+\cs_generate_variant:Nn \__tenkz_geom_place_rel:nnnn { nnee, nVee, neee }
 \cs_new_protected:Npn \__tenkz_geom_place_mid:nnn #1#2#3
   { \prop_put:Nnn \l__tenkz_geom_req_prop {#1} { {mid}{#2}{#3}{} } }
+\cs_generate_variant:Nn \__tenkz_geom_place_mid:nnn { nVV, nee }
 \cs_new_protected:Npn \__tenkz_geom_place_onseg:nnnn #1#2#3#4
   { \prop_put:Nnn \l__tenkz_geom_req_prop {#1} { {onseg}{#2}{#3}{#4} } }
 

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2239,11 +2239,6 @@
     \fp_set:Nn #4 { \l__tenkz_kernel_r_y_tl + 0 }
   }
 
-\cs_generate_variant:Nn \__tenkz_render_stroke:nn { en }
-\cs_generate_variant:Nn \__tenkz_geom_place_rel:nnnn { nnee, nVee, neee }
-\cs_generate_variant:Nn \__tenkz_geom_place_mid:nnn { nVV, nee }
-\cs_generate_variant:Nn \__tenkz_render_atom_labelled:nnn { nen }
-
 % The turn of one atom, read after it is placed: the frame's own turn at the
 % cell it occupies, or -- for a spin that stands on a cluster's sub-frame --
 % the turn of the carrier it stands on.  Only a turned atom is recorded, so
@@ -6789,9 +6784,9 @@
   }
 
 % ---------- the public surface -----------------------------------------------------------------
-% \tnwire, \tnmark, \tngroup, and \tndeclare are new spellings and bind
-% globally; \tn and both environment command pairs rebind locally through
-% \tenkzkernel until the S4 swap deletes the switch and the 0.7 bindings.
+% Every body command is kernel-private at load.  \tenkzkernel installs the
+% public surface for the current group; until then the bridge changes no 0.7
+% command or environment binding.
 
 % A closed wire takes no positional ends, so both ends are peeked before the
 % command commits.  This preserves the dedicated arity diagnostic for a
@@ -6805,7 +6800,7 @@
           { \__tenkz_kernel_tnwire:nnnn {#1} {#2} { } {1} }
       }
   }
-\NewDocumentCommand \tnwire { O{} }
+\NewDocumentCommand \__tenkz_kernel_tnwire_cmd { O{} }
   {
     \peek_remove_spaces:n
       {
@@ -6814,7 +6809,7 @@
           { \__tenkz_kernel_tnwire:nnnn {#1} { } { } {0} }
       }
   }
-\NewDocumentCommand \tnmark { O{} m m }
+\NewDocumentCommand \__tenkz_kernel_tnmark_cmd { O{} m m }
   { \__tenkz_kernel_tnmark:nnn {#1} {#2} {#3} }
 % The dialect composition layer installs \tngroup first; the kernel switch
 % (\tenkzkernel, below) replaces that renderer-backed binding with the
@@ -6822,16 +6817,16 @@
 % group untouched for every document that does not ask for the kernel.
 \NewDocumentCommand \__tenkz_kernel_tngroup_cmd { O{} m }
   { \__tenkz_kernel_tngroup:nn {#1} {#2} }
-\NewDocumentCommand \tndeclare { m m m }
+\NewDocumentCommand \__tenkz_kernel_tndeclare_cmd { m m m }
   { \__tenkz_kernel_tndeclare:nnn {#1} {#2} {#3} }
 
 % sugar commands: one-line reassemblies of kernel calls
-\NewDocumentCommand \tnbond { O{} m m }
+\NewDocumentCommand \__tenkz_kernel_tnbond_cmd { O{} m m }
   {
     \__tenkz_kernel_sugar:n {tnbond}
     \__tenkz_kernel_tnwire:nnn { kind = index , #1 } {#2} {#3}
   }
-\NewDocumentCommand \tnprose { m }
+\NewDocumentCommand \__tenkz_kernel_tnprose_cmd { m }
   {
     \__tenkz_kernel_sugar:n {tnprose}
     \__tenkz_kernel_tnmark:nnn { form = prose } { panel } {#1}
@@ -6841,7 +6836,6 @@
   { \__tenkz_kernel_begin:n {#1} }
 \NewDocumentCommand \__tenkz_kernel_eq_env_begin_cmd { O{} }
   { \__tenkz_kernel_eq_begin:n {#1} }
-\ProvideDocumentEnvironment { tenkzeq } { O{} } { } { }
 \NewDocumentCommand \tenkzkernel { }
   {
     \cs_set_eq:NN \tenkz \__tenkz_kernel_env_begin_cmd
@@ -6850,6 +6844,11 @@
     \cs_set_eq:NN \endtenkzeq \__tenkz_kernel_eq_end:
     \cs_set_eq:NN \tnset \__tenkz_kernel_tnset:n
     \cs_set_eq:NN \tngroup \__tenkz_kernel_tngroup_cmd
+    \cs_set_eq:NN \tnwire \__tenkz_kernel_tnwire_cmd
+    \cs_set_eq:NN \tnmark \__tenkz_kernel_tnmark_cmd
+    \cs_set_eq:NN \tndeclare \__tenkz_kernel_tndeclare_cmd
+    \cs_set_eq:NN \tnbond \__tenkz_kernel_tnbond_cmd
+    \cs_set_eq:NN \tnprose \__tenkz_kernel_tnprose_cmd
   }
 
 \ExplSyntaxOff

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -51,6 +51,7 @@
 % emitted verbatim.
 \cs_new_protected:Npn \__tenkz_render_stroke:nn #1#2
   { \__tenkz_ink_path:nn {#1} {#2} }
+\cs_generate_variant:Nn \__tenkz_render_stroke:nn { en }
 % A coordinator-decided label node: #1 option tokens, #2 position tokens,
 % #3 content tokens.  The named form threads the positional node name --
 % pgf registers positional names before option processing, and name=
@@ -156,6 +157,7 @@
       { \fp_to_decimal:n { \l__tenkz_render_y_tl * \dim_to_fp:n { \tenkz@pitch } } pt }
       {#3}
   }
+\cs_generate_variant:Nn \__tenkz_render_atom_labelled:nnn { nen }
 
 % Measure the exact live node selected by #1 without contributing ink or a
 % bounding box.  The caller disables geometry events around this probe.


### PR DESCRIPTION
Closes LionSR/tenkz#107

## Summary
- keep every kernel body and equation command private until the group-local `\tenkzkernel` switch installs the public surface
- move shared geometry/render variants to the stages that own their base functions
- record the full load-time command/key-tree sweep and add a regression proving exact 0.7 binding restoration

## Verification
- `scripts/tenkz_kernel_probes.sh`
- `scripts/tenkz_corpus.sh` (264 files)
- `python3 scripts/tenkz_rmp.py check --all` (130 targets)
- `python3 scripts/tenkz_shrink.py gate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the package-load contract for kernel vs 0.7 command bindings—a boundary many documents rely on—but behavior is scoped to group-local opt-in and is covered by load-inert regression and corpus gates.
> 
> **Overview**
> **Kernel load is inert for the 0.7 surface** until authors call `\tenkzkernel` in a group. Body/equation commands (`\tnwire`, `\tnmark`, `\tndeclare`, `\tnbond`, `\tnprose`, `tenkzeq`) are now private `\__tenkz_kernel_*_cmd` implementations; the switch assigns the public names together with the existing rebinding of `tenkz`, `\tnset`, and `\tngroup`. Load-time `tenkzeq` no-op placeholders are removed.
> 
> **Shared geometry/render variants** (`\__tenkz_geom_place_*`, `\__tenkz_render_stroke`, `\__tenkz_render_atom_labelled`) are declared in `tenkz-geometry.code.tex` and `tenkz-render.code.tex` instead of the kernel file.
> 
> **Documentation and gates:** `KERNEL-LOAD-SWEEP.md` records the binding/key-tree audit; `HACKING.md` points to it. `r_load_inert.tex` locks in no leak at load, bindings inside the switch group, and exact restoration of 0.7 meanings after `\endgroup`. `tenkz_language.py` treats `\cs_set_eq:NN` kernel switch targets as declared public API for registry checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b10e3f13f67fdfedda3a9cd46b7dff5e06d3b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->