### PR TITLE
feat(Channel/KoashiImoto): extend recovered blocks to ambient B

### DIFF
--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -16,6 +16,7 @@ import TNLean.Channel.KoashiImoto.MeanErgodicProjection
 import TNLean.Channel.KoashiImoto.NormalizedFamilyBlockForm
 import TNLean.Channel.KoashiImoto.PooledKrausFamily
 import TNLean.Channel.KoashiImoto.PreservingBlockAction
+import TNLean.Channel.KoashiImoto.RecoveredConditionalAmbientBipartiteBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalBipartiteBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalFamily

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalAmbientBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalAmbientBipartiteBlockForm.lean
@@ -1,0 +1,677 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixGramUnitary
+import TNLean.Channel.KoashiImoto.RecoveredConditionalBipartiteBlockForm
+
+/-!
+# Ambient recovered bipartite block coordinates
+
+This file extends the recovered bipartite block form from the minimum joint
+support to the whole middle subsystem.  Each basis direction in the orthogonal
+complement is represented by a one-dimensional tensor sector with zero
+unnormalized conditional factor.
+
+This is the ambient decomposition and bipartite marginal identity in HJPW,
+arXiv:quant-ph/0304007v2, Theorem 6, equations (13)--(14), lines 493--502.
+
+**Convention (factor order):** TNLean orders each middle-system summand as
+the common density factor followed by the conditional-state-dependent factor,
+opposite to HJPW.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+
+namespace Matrix
+
+variable {dA dB dC n K : ℕ}
+
+/-- The ambient sector index consists of one sector for each complementary
+basis direction, followed by the joint-support sectors.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (13),
+lines 493--496. -/
+abbrev AmbientRecoveredBlockIndex (z K : ℕ) := Fin z ⊕ Fin K
+
+/-- The common-factor dimension of an ambient recovered block. -/
+def ambientRecoveredCommonDim {z K : ℕ} (m : Fin K → ℕ) :
+    AmbientRecoveredBlockIndex z K → ℕ
+  | Sum.inl _ => 1
+  | Sum.inr j => m j
+
+/-- The conditional-factor dimension of an ambient recovered block. -/
+def ambientRecoveredConditionalDim {z K : ℕ} (d : Fin K → ℕ) :
+    AmbientRecoveredBlockIndex z K → ℕ
+  | Sum.inl _ => 1
+  | Sum.inr j => d j
+
+/-- The common density factor on an ambient recovered block.
+
+Complementary one-dimensional sectors carry the unique density matrix.
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equations (13)--(14),
+lines 493--502. -/
+def ambientRecoveredCommonState {z K : ℕ} {m : Fin K → ℕ}
+    (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ) :
+    (j : AmbientRecoveredBlockIndex z K) →
+      Matrix (Fin (ambientRecoveredCommonDim m j))
+        (Fin (ambientRecoveredCommonDim m j)) ℂ
+  | Sum.inl _ => 1
+  | Sum.inr j => σ j
+
+/-- The unnormalized conditional factor on an ambient recovered block.
+
+Complementary one-dimensional sectors have zero weight.  This is a zero
+unnormalized factor, not an additional normalized physical state.
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (14),
+lines 499--502. -/
+def ambientRecoveredConditionalState {z K dA : ℕ} {d : Fin K → ℕ}
+    (ω : ∀ j, Matrix (Fin dA × Fin (d j)) (Fin dA × Fin (d j)) ℂ) :
+    (_j : AmbientRecoveredBlockIndex z K) →
+      Matrix (Fin dA × Fin (ambientRecoveredConditionalDim d _j))
+        (Fin dA × Fin (ambientRecoveredConditionalDim d _j)) ℂ
+  | Sum.inl _ => 0
+  | Sum.inr j => ω j
+
+/-- Collapse the dependent sum of one-dimensional complementary sectors to
+its complement index. -/
+def ambientRecoveredComplementEquiv (z : ℕ) :
+    ((_ : Fin z) × (Fin 1 × Fin 1)) ≃ Fin z where
+  toFun x := x.1
+  invFun j := ⟨j, (0, 0)⟩
+  left_inv x := by
+    rcases x with ⟨j, a, b⟩
+    have ha : a = 0 := Subsingleton.elim _ _
+    have hb : b = 0 := Subsingleton.elim _ _
+    subst a
+    subst b
+    rfl
+  right_inv _ := rfl
+
+/-- Extend the joint-support tensor coordinates by one-dimensional
+zero-weight sectors on the ambient complement.
+
+This is the direct-sum tensor equivalence for the ambient middle subsystem in
+HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (13), lines 493--496. -/
+def recoveredAmbientMiddleBlockEquiv
+    {dB n K : ℕ} {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n) :
+    ((j : AmbientRecoveredBlockIndex (dB - n) K) ×
+      (Fin (ambientRecoveredCommonDim m j) ×
+        Fin (ambientRecoveredConditionalDim d j))) ≃ Fin dB :=
+  (Equiv.sumSigmaDistrib fun j : AmbientRecoveredBlockIndex (dB - n) K ↦
+      Fin (ambientRecoveredCommonDim m j) ×
+        Fin (ambientRecoveredConditionalDim d j))
+    |>.trans (Equiv.sumCongr (ambientRecoveredComplementEquiv (dB - n)) e)
+    |>.trans e₀
+
+@[simp]
+private theorem recoveredAmbientMiddleBlockEquiv_apply_complement
+    {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (j : Fin (dB - n))
+    (u : Fin (ambientRecoveredCommonDim m (Sum.inl j)))
+    (v : Fin (ambientRecoveredConditionalDim d (Sum.inl j))) :
+    recoveredAmbientMiddleBlockEquiv e₀ e ⟨Sum.inl j, (u, v)⟩ =
+      e₀ (Sum.inl j) := by
+  change Fin 1 at u v
+  fin_cases u
+  fin_cases v
+  rfl
+
+@[simp]
+private theorem recoveredAmbientMiddleBlockEquiv_apply_support
+    {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (j : Fin K) (u : Fin (m j)) (v : Fin (d j)) :
+    recoveredAmbientMiddleBlockEquiv e₀ e ⟨Sum.inr j, (u, v)⟩ =
+      e₀ (Sum.inr (e ⟨j, (u, v)⟩)) := rfl
+
+/-- Reassociate subsystem `A` with the complement/support split of subsystem
+`B`. -/
+private def recoveredBipartiteComplementEquiv
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB) :
+    ((Fin dA × Fin (dB - n)) ⊕ (Fin dA × Fin n)) ≃
+      Fin dA × Fin dB :=
+  (Equiv.prodSumDistrib (Fin dA) (Fin (dB - n)) (Fin n)).symm
+    |>.trans ((Equiv.refl (Fin dA)).prodCongr e₀)
+
+@[simp]
+private theorem recoveredBipartiteComplementEquiv_symm_apply_complement
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (a : Fin dA) (j : Fin (dB - n)) :
+    (recoveredBipartiteComplementEquiv (dA := dA) e₀).symm
+        (a, e₀ (Sum.inl j)) =
+      Sum.inl (a, j) := by
+  simp [recoveredBipartiteComplementEquiv]
+
+@[simp]
+private theorem recoveredBipartiteComplementEquiv_symm_apply_support
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (a : Fin dA) (j : Fin n) :
+    (recoveredBipartiteComplementEquiv (dA := dA) e₀).symm
+        (a, e₀ (Sum.inr j)) =
+      Sum.inr (a, j) := by
+  simp [recoveredBipartiteComplementEquiv]
+
+@[simp]
+private theorem recoveredAmbientBipartiteBlockEquiv_apply_complement
+    {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (j : Fin (dB - n))
+    (u : Fin (ambientRecoveredCommonDim m (Sum.inl j)))
+    (a : Fin dA)
+    (v : Fin (ambientRecoveredConditionalDim d (Sum.inl j))) :
+    recoveredBipartiteBlockEquiv
+        (recoveredAmbientMiddleBlockEquiv e₀ e)
+        ⟨Sum.inl j, (u, (a, v))⟩ =
+      (a, e₀ (Sum.inl j)) := by
+  change
+    (a, recoveredAmbientMiddleBlockEquiv e₀ e ⟨Sum.inl j, (u, v)⟩) =
+      (a, e₀ (Sum.inl j))
+  rw [recoveredAmbientMiddleBlockEquiv_apply_complement]
+
+@[simp]
+private theorem recoveredAmbientBipartiteBlockEquiv_apply_support
+    {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (j : Fin K) (u : Fin (m j)) (a : Fin dA) (v : Fin (d j)) :
+    recoveredBipartiteBlockEquiv
+        (recoveredAmbientMiddleBlockEquiv e₀ e)
+        ⟨Sum.inr j, (u, (a, v))⟩ =
+      (a, e₀ (Sum.inr (e ⟨j, (u, v)⟩))) := by
+  change
+    (a, recoveredAmbientMiddleBlockEquiv e₀ e ⟨Sum.inr j, (u, v)⟩) =
+      (a, e₀ (Sum.inr (e ⟨j, (u, v)⟩)))
+  rw [recoveredAmbientMiddleBlockEquiv_apply_support]
+
+@[simp]
+private theorem recoveredAmbientBipartiteBlockEquiv_symm_apply_complement
+    {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (a : Fin dA) (j : Fin (dB - n)) :
+    (recoveredBipartiteBlockEquiv
+        (recoveredAmbientMiddleBlockEquiv e₀ e)).symm
+        (a, e₀ (Sum.inl j)) =
+      ⟨Sum.inl j, ((0 : Fin 1), (a, (0 : Fin 1)))⟩ := by
+  exact recoveredBipartiteBlockEquiv_symm_apply
+    (recoveredAmbientMiddleBlockEquiv e₀ e) a
+      ⟨Sum.inl j, ((0 : Fin 1), (0 : Fin 1))⟩
+
+@[simp]
+private theorem recoveredAmbientBipartiteBlockEquiv_symm_apply_support
+    {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (a : Fin dA) (j : Fin K) (u : Fin (m j)) (v : Fin (d j)) :
+    (recoveredBipartiteBlockEquiv
+        (recoveredAmbientMiddleBlockEquiv e₀ e)).symm
+        (a, e₀ (Sum.inr (e ⟨j, (u, v)⟩))) =
+      ⟨Sum.inr j, (u, (a, v))⟩ := by
+  exact recoveredBipartiteBlockEquiv_symm_apply
+    (recoveredAmbientMiddleBlockEquiv e₀ e) a
+      ⟨Sum.inr j, (u, v)⟩
+
+/-- Applying a conjugation to the second matrix factor is conjugation by the
+identity-tensored rectangular matrix. -/
+private theorem idTensorMap_conjugation
+    {δ : Type*} [Fintype δ] [DecidableEq δ]
+    {α β : Type*} [Fintype α]
+    (Z : Matrix β α ℂ)
+    (R : Matrix (δ × α) (δ × α) ℂ) :
+    let T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
+      { toFun := fun X ↦ Z * X * Zᴴ
+        map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+        map_smul' := by intro c X; simp [Matrix.mul_smul, Matrix.smul_mul] }
+    idTensorMapLM T R =
+      ((1 : Matrix δ δ ℂ) ⊗ₖ Z) * R *
+        ((1 : Matrix δ δ ℂ) ⊗ₖ Z)ᴴ := by
+  dsimp only
+  ext ⟨a, k⟩ ⟨b, l⟩
+  simp only [idTensorMapLM_apply, idTensorMap_apply,
+    Matrix.mul_apply, Matrix.conjTranspose_kronecker,
+    Matrix.conjTranspose_one, Matrix.kroneckerMap_apply,
+    Matrix.one_apply]
+  simp_rw [Fintype.sum_prod_type]
+  simp
+  rfl
+
+/-- Applying the complementary zero embedding on the second factor produces
+the corresponding complementary zero block on the bipartite space. -/
+private theorem idTensorMap_zero_extension
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (R : Matrix (Fin dA × Fin n) (Fin dA × Fin n) ℂ) :
+    let E : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ]
+        Matrix (Fin dB) (Fin dB) ℂ :=
+      { toFun := fun X ↦
+          Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 X)
+        map_add' := by
+          intro X Y
+          ext i j
+          rw [← e₀.apply_symm_apply i, ← e₀.apply_symm_apply j]
+          generalize e₀.symm i = i'
+          generalize e₀.symm j = j'
+          rcases i' with i' | i' <;> rcases j' with j' | j' <;> simp
+        map_smul' := by
+          intro c X
+          ext i j
+          rw [← e₀.apply_symm_apply i, ← e₀.apply_symm_apply j]
+          generalize e₀.symm i = i'
+          generalize e₀.symm j = j'
+          rcases i' with i' | i' <;> rcases j' with j' | j' <;> simp }
+    idTensorMapLM E R =
+      Matrix.reindex (recoveredBipartiteComplementEquiv e₀)
+        (recoveredBipartiteComplementEquiv e₀)
+        (Matrix.fromBlocks 0 0 0 R) := by
+  dsimp only
+  ext ⟨a, b⟩ ⟨a', b'⟩
+  rw [← e₀.apply_symm_apply b, ← e₀.apply_symm_apply b']
+  generalize e₀.symm b = i
+  generalize e₀.symm b' = i'
+  rcases i with i | i <;> rcases i' with i' | i' <;>
+    simp [idTensorMapLM_apply, idTensorMap_apply,
+      recoveredBipartiteComplementEquiv]
+
+/-- Unitary zero extension on subsystem `B` lifts through a spectator
+subsystem `A`. -/
+private theorem one_kronecker_zero_extension_eq
+    (Z : Matrix (Fin dB) (Fin n) ℂ)
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (U_B : Matrix (Fin dB) (Fin dB) ℂ)
+    (hU_B : U_B ∈ Matrix.unitaryGroup (Fin dB) ℂ)
+    (hzero : ∀ A : Matrix (Fin n) (Fin n) ℂ,
+      Z * A * Zᴴ =
+        U_B * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U_B)
+    (R : Matrix (Fin dA × Fin n) (Fin dA × Fin n) ℂ) :
+    star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+        (((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z) * R *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z)ᴴ) *
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) =
+      Matrix.reindex (recoveredBipartiteComplementEquiv e₀)
+        (recoveredBipartiteComplementEquiv e₀)
+        (Matrix.fromBlocks 0 0 0 R) := by
+  let E : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ]
+      Matrix (Fin dB) (Fin dB) ℂ :=
+    { toFun := fun X ↦
+        Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 X)
+      map_add' := by
+        intro X Y
+        ext i j
+        rw [← e₀.apply_symm_apply i, ← e₀.apply_symm_apply j]
+        generalize e₀.symm i = i'
+        generalize e₀.symm j = j'
+        rcases i' with i' | i' <;> rcases j' with j' | j' <;> simp
+      map_smul' := by
+        intro c X
+        ext i j
+        rw [← e₀.apply_symm_apply i, ← e₀.apply_symm_apply j]
+        generalize e₀.symm i = i'
+        generalize e₀.symm j = j'
+        rcases i' with i' | i' <;> rcases j' with j' | j' <;> simp }
+  let T_Z : Matrix (Fin n) (Fin n) ℂ →ₗ[ℂ]
+      Matrix (Fin dB) (Fin dB) ℂ :=
+    { toFun := fun X ↦ Z * X * Zᴴ
+      map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := by intro c X; simp [Matrix.mul_smul, Matrix.smul_mul] }
+  let T_U : Matrix (Fin dB) (Fin dB) ℂ →ₗ[ℂ]
+      Matrix (Fin dB) (Fin dB) ℂ :=
+    { toFun := fun X ↦ U_B * X * U_Bᴴ
+      map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := by intro c X; simp }
+  have hmaps : T_Z = T_U.comp E := by
+    ext A i j
+    exact congrFun (congrFun (hzero A) i) j
+  have hconjZ :
+      idTensorMapLM T_Z R =
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z) * R *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z)ᴴ := by
+    simpa only [T_Z] using idTensorMap_conjugation Z R
+  have hconjU :
+      idTensorMapLM T_U (idTensorMapLM E R) =
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+          idTensorMapLM E R *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)ᴴ := by
+    simpa only [T_U] using idTensorMap_conjugation U_B (idTensorMapLM E R)
+  have htensorComp :
+      idTensorMapLM (T_U.comp E) R =
+        idTensorMapLM T_U (idTensorMapLM E R) := by
+    ext ⟨a, i⟩ ⟨b, j⟩
+    rfl
+  have hlift :
+      ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z) * R *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z)ᴴ =
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+          idTensorMapLM E R *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)ᴴ := by
+    rw [← hconjZ, hmaps, htensorComp, hconjU]
+  have hUleft : star U_B * U_B = 1 :=
+    Matrix.mem_unitaryGroup_iff'.mp hU_B
+  have hUleft' : U_Bᴴ * U_B = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using hUleft
+  have hUliftLeft :
+      star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) = 1 := by
+    rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.conjTranspose_one, ← Matrix.mul_kronecker_mul, hUleft',
+      Matrix.one_mul]
+    exact Matrix.one_kronecker_one
+  rw [hlift]
+  have hUliftLeft' :
+      ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)ᴴ *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) = 1 := by
+    simpa only [Matrix.star_eq_conjTranspose] using hUliftLeft
+  calc
+    star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+          (((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+            idTensorMapLM E R *
+            ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)ᴴ) *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) =
+        (star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+            ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)) *
+          idTensorMapLM E R *
+          (((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)ᴴ *
+            ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)) := by
+          simp only [Matrix.mul_assoc]
+    _ = idTensorMapLM E R := by rw [hUliftLeft, hUliftLeft']; simp
+    _ = _ := idTensorMap_zero_extension e₀ R
+
+/-- The complementary zero block and the supported tensor blocks form one
+ambient direct sum of tensor sectors. -/
+private theorem reindex_fromBlocks_support_eq_ambientBlockForm
+    {d m : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (ω : ∀ j,
+      Matrix (Fin dA × Fin (d j)) (Fin dA × Fin (d j)) ℂ) :
+    Matrix.reindex (recoveredBipartiteComplementEquiv e₀)
+        (recoveredBipartiteComplementEquiv e₀)
+        (Matrix.fromBlocks 0 0 0
+          (Matrix.reindex (recoveredBipartiteBlockEquiv e)
+            (recoveredBipartiteBlockEquiv e)
+            (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ ω j))) =
+      Matrix.reindex
+        (recoveredBipartiteBlockEquiv
+          (recoveredAmbientMiddleBlockEquiv e₀ e))
+        (recoveredBipartiteBlockEquiv
+          (recoveredAmbientMiddleBlockEquiv e₀ e))
+        (Matrix.blockDiagonal' fun j ↦
+          ambientRecoveredCommonState σ j ⊗ₖ
+            ambientRecoveredConditionalState ω j) := by
+  classical
+  let g := recoveredBipartiteBlockEquiv (dA := dA)
+    (recoveredAmbientMiddleBlockEquiv e₀ e)
+  ext x y
+  rw [← g.apply_symm_apply x, ← g.apply_symm_apply y]
+  generalize g.symm x = x'
+  generalize g.symm y = y'
+  rcases x' with ⟨j, u, a, v⟩
+  rcases y' with ⟨j', u', a', v'⟩
+  rcases j with j | j <;> rcases j' with j' | j'
+  · change Fin 1 at u v u' v'
+    fin_cases u
+    fin_cases v
+    fin_cases u'
+    fin_cases v'
+    simp [g, ambientRecoveredCommonState,
+      ambientRecoveredConditionalState, Matrix.blockDiagonal'_apply]
+  · change Fin 1 at u v
+    change Fin (m j') at u'
+    change Fin (d j') at v'
+    fin_cases u
+    fin_cases v
+    simp [g, ambientRecoveredCommonState,
+      ambientRecoveredConditionalState, Matrix.blockDiagonal'_apply]
+  · change Fin (m j) at u
+    change Fin (d j) at v
+    change Fin 1 at u' v'
+    fin_cases u'
+    fin_cases v'
+    simp [g, ambientRecoveredCommonState,
+      ambientRecoveredConditionalState, Matrix.blockDiagonal'_apply]
+  · change Fin (m j) at u
+    change Fin (d j) at v
+    change Fin (m j') at u'
+    change Fin (d j') at v'
+    simp [g, ambientRecoveredCommonState,
+      ambientRecoveredConditionalState, Matrix.blockDiagonal'_apply]
+    rfl
+
+/-- The exact recovered conditional-family witnesses together with ambient
+direct-sum tensor coordinates for the middle subsystem.
+
+Every complementary basis direction is a one-dimensional tensor sector.  Its
+common factor is the unique density matrix and its unnormalized conditional
+factor is zero.  Thus all sectors have positive factor dimensions, while the
+supported factors and their positivity and trace data are retained exactly.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equations (13)--(14),
+lines 493--502.  TNLean writes the tensor factors in the reverse order from
+HJPW. -/
+structure RecoveredConditionalAmbientBipartiteBlockForm
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))] where
+  jointSupport : RecoveredConditionalBipartiteBlockForm ρ_ABC hρ_dm
+  e₀ : (Fin (dB - jointSupport.n) ⊕ Fin jointSupport.n) ≃ Fin dB
+  U_B : Matrix (Fin dB) (Fin dB) ℂ
+  U_B_unitary : U_B ∈ Matrix.unitaryGroup (Fin dB) ℂ
+  /-- The ambient unitary extends the support coordinates: every matrix on the
+  minimum joint support becomes its complementary zero extension.
+
+  Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equation (13),
+  lines 493--496. -/
+  ambient_support_extension :
+    ∀ A : Matrix (Fin jointSupport.n) (Fin jointSupport.n) ℂ,
+      (jointSupport.V * jointSupport.U) * A *
+          (jointSupport.V * jointSupport.U)ᴴ =
+        U_B * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U_B
+  ambient_d_pos :
+    ∀ j : AmbientRecoveredBlockIndex (dB - jointSupport.n) jointSupport.K,
+      0 < ambientRecoveredConditionalDim jointSupport.d j
+  ambient_m_pos :
+    ∀ j : AmbientRecoveredBlockIndex (dB - jointSupport.n) jointSupport.K,
+      0 < ambientRecoveredCommonDim jointSupport.m j
+  ambient_σ_pos :
+    ∀ j : AmbientRecoveredBlockIndex (dB - jointSupport.n) jointSupport.K,
+      (ambientRecoveredCommonState jointSupport.σ j).PosSemidef
+  ambient_σ_trace :
+    ∀ j : AmbientRecoveredBlockIndex (dB - jointSupport.n) jointSupport.K,
+      (ambientRecoveredCommonState jointSupport.σ j).trace = 1
+  ambient_ω_pos :
+    ∀ j : AmbientRecoveredBlockIndex (dB - jointSupport.n) jointSupport.K,
+      (ambientRecoveredConditionalState jointSupport.ω j).PosSemidef
+  ambient_ω_trace_sum :
+    ∑ j : AmbientRecoveredBlockIndex (dB - jointSupport.n) jointSupport.K,
+      (ambientRecoveredConditionalState jointSupport.ω j).trace = 1
+  ambient_bipartite_block_form :
+    let eB := recoveredAmbientMiddleBlockEquiv e₀ jointSupport.e
+    star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+        traceC_ABC ρ_ABC *
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) =
+      Matrix.reindex (recoveredBipartiteBlockEquiv eB)
+        (recoveredBipartiteBlockEquiv eB)
+        (Matrix.blockDiagonal' fun j ↦
+          ambientRecoveredCommonState jointSupport.σ j ⊗ₖ
+            ambientRecoveredConditionalState jointSupport.ω j)
+
+/-- **Ambient recovered bipartite block form.**
+
+At equality in strong subadditivity, subsystem `B` admits an ambient
+direct-sum tensor decomposition.  In the corresponding unitary coordinates,
+the bipartite marginal is a direct sum
+`\bigoplus_j σ_j \otimes ω_j`, with positive common density factors,
+positive unnormalized conditional factors, and total conditional trace one.
+Complementary directions outside the minimum joint support occur as
+one-dimensional zero-weight sectors.
+
+This is the ambient middle-system decomposition and equation (14) in HJPW,
+arXiv:quant-ph/0304007v2, Theorem 6, equations (13)--(14), lines 493--502.
+TNLean writes the tensor factors in the reverse order from HJPW.  No statement
+about the recovery-dilation action in equation (15) is made here. -/
+theorem exists_recoveredConditionalAmbientBipartiteBlockForm
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    letI : Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC)) :=
+      recoveredEffectIndex_nonempty (traceC_ABC ρ_ABC) (by
+        rw [← trace_eq_trace_traceC_ABC]
+        exact hρ_dm.2)
+    Nonempty
+      (RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm) := by
+  classical
+  letI : Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC)) :=
+    recoveredEffectIndex_nonempty (traceC_ABC ρ_ABC) (by
+      rw [← trace_eq_trace_traceC_ABC]
+      exact hρ_dm.2)
+  obtain ⟨support⟩ :=
+    exists_recoveredConditionalBipartiteBlockForm_jointSupport
+      ρ_ABC hρ_dm hSSA
+  let Z : Matrix (Fin dB) (Fin support.n) ℂ := support.V * support.U
+  have hUleft : star support.U * support.U = 1 :=
+    Matrix.mem_unitaryGroup_iff'.mp support.U_unitary
+  have hZstar : Zᴴ = star support.U * support.Vᴴ := by
+    simp only [Z, Matrix.conjTranspose_mul, Matrix.star_eq_conjTranspose]
+  have hZ : Zᴴ * Z = 1 := by
+    rw [hZstar]
+    dsimp only [Z]
+    calc
+      star support.U * support.Vᴴ * (support.V * support.U) =
+          star support.U * (support.Vᴴ * support.V) * support.U := by
+            simp only [Matrix.mul_assoc]
+      _ = star support.U * support.U := by
+        rw [support.V_isometry]
+        simp
+      _ = 1 := hUleft
+  obtain ⟨e₀, U_B_group, hzero⟩ :=
+    Matrix.exists_unitary_zero_extension_eq Z hZ
+  let U_B : Matrix (Fin dB) (Fin dB) ℂ := U_B_group
+  have hambientSupportExtension :
+      ∀ A : Matrix (Fin support.n) (Fin support.n) ℂ,
+        (support.V * support.U) * A * (support.V * support.U)ᴴ =
+          U_B * Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 A) * star U_B := by
+    simpa only [Z, U_B] using hzero
+  let W := (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ support.V
+  let L := (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ support.U
+  let R := Lᴴ * (Wᴴ * traceC_ABC ρ_ABC * W) * L
+  have hUright : support.U * star support.U = 1 :=
+    Matrix.mem_unitaryGroup_iff.mp support.U_unitary
+  have hLright : L * Lᴴ = 1 := by
+    dsimp only [L]
+    rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one,
+      ← Matrix.mul_kronecker_mul]
+    change (1 * 1) ⊗ₖ (support.U * star support.U) = 1
+    rw [Matrix.one_mul, hUright]
+    exact Matrix.one_kronecker_one
+  have hcompress : L * R * Lᴴ = Wᴴ * traceC_ABC ρ_ABC * W := by
+    dsimp only [R]
+    calc
+      L * (Lᴴ * (Wᴴ * traceC_ABC ρ_ABC * W) * L) * Lᴴ =
+          (L * Lᴴ) * (Wᴴ * traceC_ABC ρ_ABC * W) * (L * Lᴴ) := by
+            simp only [Matrix.mul_assoc]
+      _ = Wᴴ * traceC_ABC ρ_ABC * W := by rw [hLright]; simp
+  have hWL :
+      W * L = (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z := by
+    dsimp only [W, L, Z]
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul]
+  have hρZ :
+      traceC_ABC ρ_ABC =
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z) * R *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z)ᴴ := by
+    calc
+      traceC_ABC ρ_ABC = W * (Wᴴ * traceC_ABC ρ_ABC * W) * Wᴴ :=
+        support.ambient_reconstruction.symm
+      _ = W * (L * R * Lᴴ) * Wᴴ := by rw [hcompress]
+      _ = (W * L) * R * (W * L)ᴴ := by
+        simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+      _ = ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z) * R *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ Z)ᴴ := by
+        rw [hWL]
+  have hnested :
+      star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+          traceC_ABC ρ_ABC *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) =
+        Matrix.reindex (recoveredBipartiteComplementEquiv e₀)
+          (recoveredBipartiteComplementEquiv e₀)
+          (Matrix.fromBlocks 0 0 0 R) := by
+    exact (congrArg (fun X ↦
+      star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) * X *
+        ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B)) hρZ).trans
+          (one_kronecker_zero_extension_eq Z e₀ U_B
+            U_B_group.property (by
+              simpa only [Z] using hambientSupportExtension) R)
+  have hR :
+      R = Matrix.reindex (recoveredBipartiteBlockEquiv support.e)
+          (recoveredBipartiteBlockEquiv support.e)
+          (Matrix.blockDiagonal' fun j ↦ support.σ j ⊗ₖ support.ω j) :=
+    support.bipartite_block_form
+  have hambient :
+      star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) *
+          traceC_ABC ρ_ABC *
+          ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ U_B) =
+        Matrix.reindex
+          (recoveredBipartiteBlockEquiv
+            (recoveredAmbientMiddleBlockEquiv e₀ support.e))
+          (recoveredBipartiteBlockEquiv
+            (recoveredAmbientMiddleBlockEquiv e₀ support.e))
+          (Matrix.blockDiagonal' fun j ↦
+            ambientRecoveredCommonState support.σ j ⊗ₖ
+              ambientRecoveredConditionalState support.ω j) := by
+    rw [hnested, hR]
+    exact reindex_fromBlocks_support_eq_ambientBlockForm
+      e₀ support.e support.σ support.ω
+  refine ⟨{
+    jointSupport := support
+    e₀ := e₀
+    U_B := U_B
+    U_B_unitary := U_B_group.property
+    ambient_support_extension := hambientSupportExtension
+    ambient_d_pos := ?_
+    ambient_m_pos := ?_
+    ambient_σ_pos := ?_
+    ambient_σ_trace := ?_
+    ambient_ω_pos := ?_
+    ambient_ω_trace_sum := ?_
+    ambient_bipartite_block_form := hambient }⟩
+  · intro j
+    rcases j with j | j
+    · exact Nat.zero_lt_one
+    · exact support.d_pos j
+  · intro j
+    rcases j with j | j
+    · exact Nat.zero_lt_one
+    · exact support.m_pos j
+  · intro j
+    rcases j with j | j
+    · exact Matrix.PosSemidef.one
+    · exact support.σ_pos j
+  · intro j
+    rcases j with j | j
+    · change (1 : Matrix (Fin 1) (Fin 1) ℂ).trace = 1
+      simp
+    · exact support.σ_trace j
+  · intro j
+    rcases j with j | j
+    · exact Matrix.PosSemidef.zero
+    · exact support.ω_pos j
+  · rw [Fintype.sum_sum_type]
+    change
+      (∑ _ : Fin (dB - support.n),
+          (0 : Matrix (Fin dA × Fin 1) (Fin dA × Fin 1) ℂ).trace) +
+        ∑ j, (support.ω j).trace = 1
+    rw [show
+      (∑ _ : Fin (dB - support.n),
+        (0 : Matrix (Fin dA × Fin 1) (Fin dA × Fin 1) ℂ).trace) = 0 by
+          simp, zero_add]
+    exact support.ω_trace_sum
+
+end Matrix

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalAmbientBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalAmbientBipartiteBlockForm.lean
@@ -450,7 +450,8 @@ direct-sum tensor coordinates for the middle subsystem.
 Every complementary basis direction is a one-dimensional tensor sector.  Its
 common factor is the unique density matrix and its unnormalized conditional
 factor is zero.  Thus all sectors have positive factor dimensions, while the
-supported factors and their positivity and trace data are retained exactly.
+supported factors, positivity assertions, and trace identities are retained
+exactly.
 
 Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equations (13)--(14),
 lines 493--502.  TNLean writes the tensor factors in the reverse order from

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalBipartiteBlockForm.lean
@@ -164,25 +164,36 @@ private theorem one_kronecker_reconstructs_of_recoveredConditionalState
 The target order is the one used by TNLean in HJPW Theorem 6, equation (14):
 the common factor precedes the joint A--conditional factor. -/
 def recoveredBipartiteBlockEquiv
-    {K : ℕ} {d m : Fin K → ℕ}
-    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n) :
-    ((j : Fin K) × (Fin (m j) × (Fin dA × Fin (d j)))) ≃
+    {ι : Type*} {d m : ι → ℕ}
+    (e : ((j : ι) × (Fin (m j) × Fin (d j))) ≃ Fin n) :
+    ((j : ι) × (Fin (m j) × (Fin dA × Fin (d j)))) ≃
       Fin dA × Fin n :=
   (Equiv.sigmaCongrRight fun j ↦
       (Equiv.refl (Fin (m j))).prodCongr
         (Equiv.prodComm (Fin dA) (Fin (d j)))
       |>.trans (Equiv.prodAssoc (Fin (m j)) (Fin (d j)) (Fin dA)).symm)
     |>.trans (Equiv.sigmaProdDistrib
-      (fun j : Fin K ↦ Fin (m j) × Fin (d j)) (Fin dA)).symm
+      (fun j : ι ↦ Fin (m j) × Fin (d j)) (Fin dA)).symm
     |>.trans (e.prodCongr (Equiv.refl (Fin dA)))
     |>.trans (Equiv.prodComm (Fin n) (Fin dA))
 
 @[simp]
-private theorem recoveredBipartiteBlockEquiv_symm_apply
-    {K : ℕ} {d m : Fin K → ℕ}
-    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+theorem recoveredBipartiteBlockEquiv_apply
+    {ι : Type*} {d m : ι → ℕ}
+    (e : ((j : ι) × (Fin (m j) × Fin (d j))) ≃ Fin n)
     (a : Fin dA)
-    (z : (j : Fin K) × (Fin (m j) × Fin (d j))) :
+    (z : (j : ι) × (Fin (m j) × Fin (d j))) :
+    recoveredBipartiteBlockEquiv (dA := dA) e
+        ⟨z.1, (z.2.1, (a, z.2.2))⟩ =
+      (a, e z) := by
+  simp [recoveredBipartiteBlockEquiv]
+
+@[simp]
+theorem recoveredBipartiteBlockEquiv_symm_apply
+    {ι : Type*} {d m : ι → ℕ}
+    (e : ((j : ι) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (a : Fin dA)
+    (z : (j : ι) × (Fin (m j) × Fin (d j))) :
     (recoveredBipartiteBlockEquiv (dA := dA) e).symm (a, e z) =
       ⟨z.1, (z.2.1, (a, z.2.2))⟩ := by
   simp [recoveredBipartiteBlockEquiv]

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1858,8 +1858,8 @@ algebra of a family of jointly invariant states.
     subspace, whereas equation~(14), lines 499--502, decomposes the ambient
     subsystem $B$. This restriction is documented in
     \path{docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex}.
-    % Roadmap: extend these coordinates to ambient B before addressing the
-    % recovery-dilation block action of equation (15).
+    % The next theorem performs the ambient extension; equation (15) remains
+    % the following sequential step.
 \end{theorem}
 
 \begin{proof}
@@ -1875,6 +1875,53 @@ algebra of a family of jointly invariant states.
     $j$-th principal block. Positivity follows from positivity of principal
     blocks and of partial trace. Applying separation once more gives the
     displayed direct-sum equation, and taking traces gives the normalization.
+\end{proof}
+
+\begin{theorem}[Ambient recovered bipartite blocks]
+    \label{thm:hjpw_recovered_bipartite_ambient_blocks}
+    \lean{Matrix.exists_recoveredConditionalAmbientBipartiteBlockForm}
+    \leanok
+    \uses{thm:hjpw_recovered_bipartite_joint_support_blocks}
+    Let $\rho_{ABC}$ be a tripartite density matrix attaining equality in
+    strong subadditivity. Then the ambient middle subsystem has a direct-sum
+    tensor decomposition
+    \begin{align}
+        \mathcal H_B
+        =
+        \bigoplus_j \mathcal H_{b_j^L}\otimes
+            \mathcal H_{b_j^R}.
+    \end{align}
+    In unitary coordinates adapted to this decomposition there are density
+    matrices $\sigma_j$ and positive, not necessarily normalized operators
+    $\omega_j$ such that
+    \begin{align}
+        \rho_{AB}
+        &={}\bigoplus_j \sigma_j\otimes\omega_j,
+        \\
+        \sum_j\tr\omega_j
+        &=1.
+    \end{align}
+    The tensor factors are written in the reverse order from HJPW.
+    Directions complementary to the minimum joint support form
+    one-dimensional tensor sectors with zero $\omega_j$.
+
+    This is
+    \cite[Theorem~6, equations~(13)--(14)]{Hayden2004Structure},
+    lines~493--502.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:hjpw_recovered_bipartite_joint_support_blocks}
+    Extend the support isometry, after composing it with the support block
+    unitary, to a unitary on the ambient middle subsystem. Split the
+    orthogonal complement into one-dimensional tensor sectors. Give each
+    such sector its unique density matrix and the zero unnormalized
+    conditional factor. The supported sectors retain the factors from
+    Theorem~\ref{thm:hjpw_recovered_bipartite_joint_support_blocks}.
+    Lifting the unitary extension through subsystem $A$ and combining the
+    complementary zero block with the supported direct sum gives the
+    displayed ambient equation.
 \end{proof}
 
 \begin{theorem}[Hayashi SSA-equality characterization]
@@ -1930,11 +1977,13 @@ algebra of a family of jointly invariant states.
     recovered family.
     Theorem~\ref{thm:hjpw_recovered_bipartite_joint_support_blocks}
     reconstructs the bipartite marginal only in the same minimum-support
-    coordinates. Extending those coordinates to ambient $B$ to complete
-    equation~(14), proving the recovery-dilation block action of
-    equation~(15), and assembling the quantum-Markov decomposition remain
-    open. This forward implication therefore remains axiomatic. The
-    biconditional combines the two directions.
+    coordinates.
+    Theorem~\ref{thm:hjpw_recovered_bipartite_ambient_blocks} extends them to
+    all of $B$ and completes equations~(13)--(14). Proving the
+    recovery-dilation block action of equation~(15) and assembling the
+    quantum-Markov decomposition remain open. This forward implication
+    therefore remains axiomatic. The biconditional combines the two
+    directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -67,9 +67,10 @@ its positive-definite specialization, and the trace-preserving extension of the
 support Petz map are now available. The finite recovered conditional density
 family, its separating effects, and its common preserving channel are also
 formalized. The joint-support block theorem has now been applied and the
-bipartite marginal reconstructed in the same support coordinates; lifting
-those coordinates to ambient $B$ to complete HJPW equation~(14), proving the
-recovery-dilation block action of equation~(15), and the subsequent
+bipartite marginal reconstructed in the same support coordinates. Those
+coordinates have now been extended to ambient $B$ by one-dimensional
+zero-weight complement sectors, completing HJPW equations~(13)--(14).
+Proving the recovery-dilation block action of equation~(15) and the subsequent
 quantum-Markov assembly remain open. The reverse direction is proved from the
 entropy-additivity sub-lemmas listed below.
 
@@ -93,10 +94,11 @@ common summands and fixes their common density factors. The joint-support
 reduction is available, and the finite nonzero normalized conditional family
 fixed by the recovered middle-system channel is constructed. The joint-support
 block theorem has been applied to this family, and the bipartite marginal has
-been reconstructed in the same coordinates. Lifting the resulting blocks
-to ambient $B$ to complete HJPW equation~(14), proving the recovery-dilation
-block action of equation~(15), and assembling the quantum-Markov decomposition
-are still missing. Thus the family-level structural implication needed here
+been reconstructed in the same coordinates. The resulting blocks now extend
+to ambient $B$ and prove HJPW equations~(13)--(14), with one-dimensional
+zero-weight sectors on the complement. The recovery-dilation block action of
+equation~(15) and assembly of the quantum-Markov decomposition are still
+missing. Thus the family-level structural implication needed here
 remains open, which is why the forward direction is treated as an external
 assumption rather than proved. The recovery implication and the complementary
 trace-preserving extension of the support Petz map are no longer part of this
@@ -687,7 +689,8 @@ complete effect family and conditional slices
   \leanid{Matrix.idTensor_recoveredMiddleChannel_traceC_ABC_eq}\\
   \leanid{Matrix.exists_recoveredConditionalPreservingKrausFamily}\\
   \leanid{Matrix.exists_recoveredConditionalStateBlockForm_preservingBlockAction_jointSupport}\\
-  \leanid{Matrix.exists_recoveredConditionalBipartiteBlockForm_jointSupport}.
+  \leanid{Matrix.exists_recoveredConditionalBipartiteBlockForm_jointSupport}\\
+  \leanid{Matrix.exists_recoveredConditionalAmbientBipartiteBlockForm}.
 \end{center}
 These declarations construct a finite nonempty family of nonzero normalized
 conditional states fixed by
@@ -698,18 +701,19 @@ preserving-operation action of $\varphi$. The last declaration rescales active
 slices, proves inactive positive slices vanish, and reconstructs
 $\rho_{AB}$ as $\bigoplus_j\sigma_j\otimes\omega_j$ on the same minimum joint
 support. This is a scope-restricted joint-support variant toward HJPW
-equation~(14), not its ambient-$B$ statement. Extending the coordinates to
-ambient $B$ to complete equation~(14), proving the recovery-dilation block
-action of equation~(15), and the quantum-Markov assembly remain necessary
-before the forward external assumption can be removed.
+equation~(14). The ambient declaration completes the support coordinates to
+all of $B$, adds one-dimensional zero-weight tensor sectors on the complement,
+and proves the ambient equation~(14) with positive factors whose conditional
+traces sum to one. The recovery-dilation block action of equation~(15) and the
+quantum-Markov assembly remain necessary before the forward external
+assumption can be removed.
 
 \section{Verdict}
 
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-ambient-$B$ coordinate extension, recovery-dilation block action, and
-subsequent quantum-Markov assembly.
+recovery-dilation block action and subsequent quantum-Markov assembly.
 The full-support invariant-family state decomposition and preserving-operation
 block action are formalized. Source-facing
 completed-channel recovery from equality in data processing is available on
@@ -723,10 +727,10 @@ a block-diagonal product state attains equality, is proved from entropy
 additivity over weighted direct sums and tensor factors together with unitary
 and reindexing invariance. The joint-support block form is now applied to the
 recovered conditional family, and the bipartite marginal is reconstructed in
-the same support coordinates. Extending those coordinates to ambient $B$
-before constructing the recovered tripartite blocks and assembling the
-quantum-Markov decomposition remains part of the irreducible unproved forward
-direction.
+the same support coordinates. Those coordinates now extend to all of $B$ and
+prove the ambient HJPW equation~(14). Constructing the recovered tripartite
+blocks from equation~(15) and assembling the quantum-Markov decomposition
+remain part of the irreducible unproved forward direction.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -303,11 +303,17 @@ proves that their traces sum to one, and establishes
 $\bigoplus_j\sigma_j\otimes\omega_j$ on the minimum joint support, with the
 tensor order reversed from HJPW. This is a scope-restricted joint-support
 variant toward HJPW equation~(14), not its ambient equivalence on $H_B$.
-Extending these coordinates to ambient $H_B$ to complete equation~(14),
-proving the recovery-dilation block action in equation~(15), assembling the
-generic quantum-Markov decomposition, and eliminating the external assumption
-for the
-forward Hayashi strong-subadditivity implication remain open.
+The declaration
+\leanid{Matrix.exists_recoveredConditionalAmbientBipartiteBlockForm}
+completes the support isometry to an ambient middle-system unitary and splits
+its orthogonal complement into one-dimensional zero-weight tensor sectors.
+It retains the supported positive factors, proves positivity on every ambient
+sector, and proves the total conditional trace is one. Thus HJPW
+equations~(13)--(14), lines 493--502, now hold on the ambient $H_B$ without an
+extra source hypothesis. Proving the recovery-dilation block action in
+equation~(15), assembling the generic quantum-Markov decomposition, and
+eliminating the external assumption for the forward Hayashi
+strong-subadditivity implication remain open.
 
 \section{Classification}
 
@@ -341,10 +347,12 @@ its separating effects, and its preserving middle-system channel are
 formalized. The joint-support block form and preserving-operation action have
 also been applied to this family, and the bipartite marginal is reconstructed
 in those same support coordinates. This is a scope-restricted joint-support
-variant toward HJPW equation~(14), not the ambient statement. Extending the
-coordinates to ambient $H_B$, the recovery-dilation block action of
-equation~(15), and the generic Hayashi forward implication remain open as
-separate sequential steps.
+variant toward HJPW equation~(14). The subsequent ambient extension now gives
+a direct sum of tensor factors on all of $H_B$, using one-dimensional
+zero-weight sectors on the orthogonal complement, and proves the full
+bipartite equation~(14). The recovery-dilation block action of equation~(15)
+and the generic Hayashi forward implication remain open as separate
+sequential steps.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Closes #5037.

## Summary

- extend the minimum-joint-support recovered block coordinates to a direct-sum tensor decomposition of the full middle subsystem `B`
- complete `V * U` to an ambient unitary and represent complement directions as canonical one-dimensional zero-weight tensor sectors
- prove the literal ambient HJPW equation-(14) block identity with positive factors and total conditional trace one
- retain the universal support-extension identity publicly so the sequential equation-(15) proof can transport the preserving block action without reopening this existential construction
- synchronize the Blueprint and HJPW/CPSV paper-gap notes while leaving equation (15) and quantum-Markov assembly open

Source: HJPW Theorem 6, equations (13)–(14), lines 493–502. TNLean uses the reverse tensor-factor order from HJPW.

## Validation

- cache safeguard: an initial focused build was stopped immediately after process inspection showed it compiling Mathlib; `lake exe cache get` was then rerun against the physically present pinned checkout (`81a5d257...`), restoring 7,082 cached artifacts plus 1,557 already decompressed, with zero downloads; all subsequent builds were verified to compile TNLean/Gametheory project sources only
- focused new-module and Koashi–Imoto aggregate builds
- full `lake build TNLean` (9,791 jobs; only the known unrelated `SectorMatch.lean:600` sorry warning)
- `lake exe lint_style`
- import aggregator check (47 generated files; 1,085 production modules)
- tactic-pattern scan
- Blueprint sync (chapter 19: 108/108; total 5,774/5,777)
- `lake exe checkdecls blueprint/lean_decls`
- changed-file proof-integrity and reader-facing prose scans
- `leanblueprint pdf` and `leanblueprint web`
- visual inspection of the new theorem on PDF page 380 / printed page 379 and verification of web theorem .219

After rebasing onto current `main` at `5f5188cbb6e570f3a3e3ee959ef95070466a5608`, the focused module/aggregate build, Blueprint sync, checkdecls, and diff checks passed again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof (~678 lines) in a critical SSA/HJPW chain; mistakes could affect downstream equation-(15) work, but scope is additive Lean math with no runtime or auth impact.
> 
> **Overview**
> Extends minimum joint-support recovered bipartite block coordinates to the **full middle subsystem** `B`, formalizing HJPW Theorem 6 equations (13)–(14) at SSA equality.
> 
> A new module introduces `AmbientRecoveredBlockIndex`, one-dimensional complement sectors with zero unnormalized conditional weight, `recoveredAmbientMiddleBlockEquiv`, and `exists_recoveredConditionalAmbientBipartiteBlockForm`: complete `V*U` to ambient unitary `U_B` via `exists_unitary_zero_extension_eq`, then show `ρ_{AB}` is a direct sum `⊕_j σ_j ⊗ ω_j` on all of `B` with positive factors and conditional traces summing to one. **`recoveredBipartiteBlockEquiv`** is generalized to arbitrary index type `ι` with public `@[simp]` forward/backward lemmas for reuse.
> 
> Blueprint chapter 19 adds **Ambient recovered bipartite blocks**; HJPW/CPSV gap notes mark ambient `B` as done and leave equation (15) recovery-dilation and quantum-Markov assembly open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926b04b68f10a9cd0def5a6144224cc98f807919. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->