### PR TITLE
refactor(algebra): move sum fiber smul lemma to FinSum

### DIFF
--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -6,7 +6,6 @@ Authors: TNLean contributors
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.Fin.Tuple
 
 /-!
@@ -68,13 +67,14 @@ lemma sum_fiber_smul
     (∑ i : ι, a i • v (φ i)) =
         ∑ k : κ, ∑ i with φ i = k, a i • v (φ i) := by
       symm
-      simpa using Finset.sum_fiberwise_eq_sum_filter
-        (Finset.univ : Finset ι) (Finset.univ : Finset κ) φ
-        (fun i => a i • v (φ i))
+      simpa only [Finset.mem_univ, Finset.filter_true] using
+        Finset.sum_fiberwise_eq_sum_filter
+          (Finset.univ : Finset ι) (Finset.univ : Finset κ) φ
+          (fun i => a i • v (φ i))
     _ = ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
       refine Finset.sum_congr rfl fun k _ => ?_
       rw [Finset.sum_smul, Finset.sum_filter]
       refine Finset.sum_congr rfl fun i _ => ?_
-      by_cases h : φ i = k <;> simp [h]
+      by_cases h : φ i = k <;> simp only [h, ↓reduceIte, zero_smul]
 
 end MPSTensor

--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -4,13 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Algebra.Module.BigOperators
+import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Order.Fin.Tuple
 
 /-!
 # Finite initial-segment sums
 
-This file collects small finite-sum identities for `Fin` index types.
+This file collects small finite-sum identities.
 -/
 
 open scoped BigOperators
@@ -50,3 +52,29 @@ theorem sum_castLE_extend_zero {r s : ℕ} {β : Type*} [AddCommMonoid β]
           by_cases hlt : α.val < r <;> simp [hlt]
 
 end Fin
+
+namespace MPSTensor
+
+/-- Re-index a sum over a finite family by collecting coefficients in the fibres
+of a finite map. -/
+lemma sum_fiber_smul
+    {ι κ V : Type*} [Fintype ι] [Fintype κ] [DecidableEq κ]
+    [AddCommMonoid V] [Module ℂ V]
+    (φ : ι → κ) (a : ι → ℂ) (v : κ → V) :
+    (∑ i : ι, a i • v (φ i)) =
+      ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
+  classical
+  calc
+    (∑ i : ι, a i • v (φ i)) =
+        ∑ k : κ, ∑ i with φ i = k, a i • v (φ i) := by
+      symm
+      simpa using Finset.sum_fiberwise_eq_sum_filter
+        (Finset.univ : Finset ι) (Finset.univ : Finset κ) φ
+        (fun i => a i • v (φ i))
+    _ = ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
+      refine Finset.sum_congr rfl fun k _ => ?_
+      rw [Finset.sum_smul, Finset.sum_filter]
+      refine Finset.sum_congr rfl fun i _ => ?_
+      by_cases h : φ i = k <;> simp [h]
+
+end MPSTensor

--- a/TNLean/MPS/BNT/Basic.lean
+++ b/TNLean/MPS/BNT/Basic.lean
@@ -88,32 +88,6 @@ structure IsBNT {d Dtot : ℕ} (A_total : MPSTensor d Dtot)
   eventually_li : ∃ N0 : ℕ, ∀ N > N0,
       LinearIndependent ℂ (fun j : Fin g => mpvState (d := d) (A_bnt j) N)
 
-/-- Re-index a sum over a finite family by collecting coefficients in the fibres
-of a finite map. -/
-lemma sum_fiber_smul
-    {ι κ V : Type*} [Fintype ι] [Fintype κ] [DecidableEq κ]
-    [AddCommMonoid V] [Module ℂ V]
-    (φ : ι → κ) (a : ι → ℂ) (v : κ → V) :
-    (∑ i : ι, a i • v (φ i)) =
-      ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
-  classical
-  calc
-    (∑ i : ι, a i • v (φ i))
-        = ∑ i : ι, ∑ k : κ, (if φ i = k then a i else 0) • v k := by
-          refine Finset.sum_congr rfl ?_
-          intro i _
-          have hinner :
-              (∑ k : κ, (if φ i = k then a i else 0) • v k)
-                = a i • v (φ i) := by
-            simp [ite_smul, eq_comm]
-          exact hinner.symm
-    _ = ∑ k : κ, ∑ i : ι, (if φ i = k then a i else 0) • v k := by
-          rw [Finset.sum_comm]
-    _ = ∑ k : κ, (∑ i : ι, if φ i = k then a i else 0) • v k := by
-          refine Finset.sum_congr rfl ?_
-          intro k _
-          rw [Finset.sum_smul]
-
 /--
 If the MPV overlaps of a finite index family `A j` converge to an orthonormal
 Gram matrix, then the MPV states `mpvState (A j) N` are eventually linearly

--- a/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
+++ b/TNLean/MPS/CanonicalForm/BNTCharacterization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.CanonicalForm.PhaseClassSectorData
 import TNLean.MPS.FundamentalTheorem.SectorWeightComparison

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/ProportionalMatch/Core.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.FundamentalTheorem.SectorBNT.MatchAux
 
 /-!


### PR DESCRIPTION
## What changed

- move the generic `MPSTensor.sum_fiber_smul` declaration unchanged from `MPS/BNT/Basic.lean` to the layer-0 finite-sum module `TNLean/Algebra/FinSum.lean`
- replace the hand-written double-sum rearrangement with Mathlib's `Finset.sum_fiberwise_eq_sum_filter`, `Finset.sum_smul`, and the stated filter-to-`if` conversion
- add direct `TNLean.Algebra.FinSum` imports at all three current consumers: two in `BNTCharacterization.lean` and one in `SectorBNT/ProportionalMatch/Core.lean`
- tighten the proof to explicit `simp only` sets and remove a redundant Mathlib import

## Validation

- `lake build TNLean.Algebra.FinSum` — passed
- targeted builds of `TNLean.MPS.BNT.Basic`, `TNLean.MPS.CanonicalForm.BNTCharacterization`, and `TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch.Core` — passed
- `lake build TNLean` — passed (9,791 jobs)
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v` — passed
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check` — passed (47 aggregators; 1,085 production modules)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — passed
- public theorem statement comparison — byte-identical before and after relocation
- occurrence inventory — one declaration and exactly three intended call sites
- independent Mathlib-style simplification review — approved with no caveats
- `git diff --check` — passed

Closes #4210

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure relocation and proof simplification with no statement or API changes beyond import paths; validated builds and byte-identical theorem statements.
> 
> **Overview**
> **`MPSTensor.sum_fiber_smul`** is moved out of `MPS/BNT/Basic.lean` into the layer-0 module **`TNLean/Algebra/FinSum.lean`**. The lemma’s statement is unchanged; the proof now goes through **`Finset.sum_fiberwise_eq_sum_filter`**, **`Finset.sum_smul`**, and filter/`if` bookkeeping instead of a hand-written double-sum swap.
> 
> **`FinSum`** drops `Mathlib.Data.Fintype.Basic` and adds imports for module big operators and `ℂ`. **`BNTCharacterization.lean`** and **`SectorBNT/ProportionalMatch/Core.lean`** import **`TNLean.Algebra.FinSum`** directly so fiber grouping still resolves after the lemma leaves BNT basic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8da1b0bf6122e1f67df14721bcd2e1deded65fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->