### PR TITLE
feat(Channel/KoashiImoto): transport recovered tripartite blocks

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -25,6 +25,7 @@ import TNLean.Channel.FixedPoint
 import TNLean.Channel.InformationallyCompleteEffects
 import TNLean.Channel.Irreducible
 import TNLean.Channel.KoashiImoto
+import TNLean.Channel.KrausBlockTransport
 import TNLean.Channel.KrausCPTP
 import TNLean.Channel.KrausFreedom
 import TNLean.Channel.KrausRank

--- a/TNLean/Channel/KoashiImoto.lean
+++ b/TNLean/Channel/KoashiImoto.lean
@@ -22,4 +22,5 @@ import TNLean.Channel.KoashiImoto.RecoveredConditionalBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalDilation
 import TNLean.Channel.KoashiImoto.RecoveredConditionalDilationBlockForm
 import TNLean.Channel.KoashiImoto.RecoveredConditionalFamily
+import TNLean.Channel.KoashiImoto.RecoveredConditionalTripartiteBlockForm
 import TNLean.Channel.KoashiImoto.SingleWitness

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalAmbientBipartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalAmbientBipartiteBlockForm.lean
@@ -230,30 +230,6 @@ private theorem recoveredAmbientBipartiteBlockEquiv_symm_apply_support
     (recoveredAmbientMiddleBlockEquiv e₀ e) a
       ⟨Sum.inr j, (u, v)⟩
 
-/-- Applying a conjugation to the second matrix factor is conjugation by the
-identity-tensored rectangular matrix. -/
-private theorem idTensorMap_conjugation
-    {δ : Type*} [Fintype δ] [DecidableEq δ]
-    {α β : Type*} [Fintype α]
-    (Z : Matrix β α ℂ)
-    (R : Matrix (δ × α) (δ × α) ℂ) :
-    let T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
-      { toFun := fun X ↦ Z * X * Zᴴ
-        map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
-        map_smul' := by intro c X; simp [Matrix.mul_smul, Matrix.smul_mul] }
-    idTensorMapLM T R =
-      ((1 : Matrix δ δ ℂ) ⊗ₖ Z) * R *
-        ((1 : Matrix δ δ ℂ) ⊗ₖ Z)ᴴ := by
-  dsimp only
-  ext ⟨a, k⟩ ⟨b, l⟩
-  simp only [idTensorMapLM_apply, idTensorMap_apply,
-    Matrix.mul_apply, Matrix.conjTranspose_kronecker,
-    Matrix.conjTranspose_one, Matrix.kroneckerMap_apply,
-    Matrix.one_apply]
-  simp_rw [Fintype.sum_prod_type]
-  simp
-  rfl
-
 /-- Applying the complementary zero embedding on the second factor produces
 the corresponding complementary zero block on the bipartite space. -/
 private theorem idTensorMap_zero_extension

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalDilation.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalDilation.lean
@@ -9,4 +9,5 @@ Authors: TNLean contributors
 -- Generated aggregator module: TNLean.Channel.KoashiImoto.RecoveredConditionalDilation
 
 import TNLean.Channel.KoashiImoto.RecoveredConditionalDilation.Basic
+import TNLean.Channel.KoashiImoto.RecoveredConditionalDilation.Covariance
 import TNLean.Channel.KoashiImoto.RecoveredConditionalDilation.SectorAction

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalDilation/Basic.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalDilation/Basic.lean
@@ -43,8 +43,10 @@ private theorem ambientSupportEmbedding_apply
       if b = e₀ (Sum.inr s) then 1 else 0 := by
   simp [ambientSupportEmbedding, Matrix.one_apply]
 
+/-- Multiplication by the ambient support inclusion selects the corresponding
+supported column. -/
 @[simp]
-private theorem mul_ambientSupportEmbedding_apply
+theorem RecoveredConditionalDilationInternal.mul_ambientSupportEmbedding_apply
     {A : Type*} {dB n : ℕ}
     (W : Matrix A (Fin dB) ℂ)
     (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB) (a : A) (s : Fin n) :
@@ -56,8 +58,10 @@ private theorem mul_ambientSupportEmbedding_apply
     simp [ambientSupportEmbedding_apply, hne]
   · simp
 
+/-- On a supported ambient row, the support inclusion preserves matrix
+entries. -/
 @[simp]
-private theorem ambientSupportEmbedding_mul_apply_support
+theorem RecoveredConditionalDilationInternal.ambientSupportEmbedding_mul_apply_support
     {dB n : ℕ} (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
     (A : Matrix (Fin n) (Fin n) ℂ) (s t : Fin n) :
     (ambientSupportEmbedding e₀ * A) (e₀ (Sum.inr s)) t = A s t := by
@@ -71,8 +75,10 @@ private theorem ambientSupportEmbedding_mul_apply_support
     simp [ambientSupportEmbedding_apply, hne]
   · simp
 
+/-- On a complementary ambient row, the support inclusion has zero matrix
+entries. -/
 @[simp]
-private theorem ambientSupportEmbedding_mul_apply_complement
+theorem RecoveredConditionalDilationInternal.ambientSupportEmbedding_mul_apply_complement
     {dB n : ℕ} (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
     (A : Matrix (Fin n) (Fin n) ℂ) (z : Fin (dB - n)) (t : Fin n) :
     (ambientSupportEmbedding e₀ * A) (e₀ (Sum.inl z)) t = 0 := by

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalDilation/Covariance.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalDilation/Covariance.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KoashiImoto.RecoveredConditionalDilation.Basic
+
+/-!
+# Coordinate covariance of pure-ancilla recovery
+
+This file proves that pure-ancilla recovery commutes with a unitary change of
+system coordinates.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+
+namespace Matrix
+
+open RecoveredConditionalDilationInternal
+
+/-- A pure-ancilla recovery transported to unitary system coordinates is the
+recovery of the inverse-coordinate dilation, followed by the corresponding
+output coordinate change. -/
+theorem RecoveredConditionalDilationInternal.pureAncillaRecovery_inverse_coordinate
+    {B C R : Type*} [Fintype B] [DecidableEq B]
+    [Fintype C] [DecidableEq C] [Fintype R] [DecidableEq R]
+    (c₀ : C) (r₀ : R)
+    (V : Matrix B B ℂ) (hV : V ∈ Matrix.unitaryGroup B ℂ)
+    (Uphysical Ucoordinate :
+      Matrix (B × (C × R)) (B × (C × R)) ℂ)
+    (hcoordinate :
+      star (V ⊗ₖ (1 : Matrix (C × R) (C × R) ℂ)) *
+          Uphysical *
+          (V ⊗ₖ (1 : Matrix (C × R) (C × R) ℂ)) =
+        Ucoordinate)
+    (X : Matrix B B ℂ) :
+    pureAncillaRecovery c₀ r₀ Ucoordinate (star V * X * V) =
+      star (V ⊗ₖ (1 : Matrix C C ℂ)) *
+        pureAncillaRecovery c₀ r₀ Uphysical X *
+          (V ⊗ₖ (1 : Matrix C C ℂ)) := by
+  let liftR := V ⊗ₖ (1 : Matrix (C × R) (C × R) ℂ)
+  let liftC := V ⊗ₖ (1 : Matrix C C ℂ)
+  have hliftR : liftR ∈ Matrix.unitaryGroup (B × (C × R)) ℂ :=
+    Matrix.kronecker_mem_unitary hV (Submonoid.one_mem _)
+  have hliftR_left : star liftR * liftR = 1 :=
+    Matrix.mem_unitaryGroup_iff'.mp hliftR
+  have hliftR_right : liftR * star liftR = 1 :=
+    Matrix.mem_unitaryGroup_iff.mp hliftR
+  have hliftC : liftC ∈ Matrix.unitaryGroup (B × C) ℂ :=
+    Matrix.kronecker_mem_unitary hV (Submonoid.one_mem _)
+  have hliftC_left : star liftC * liftC = 1 :=
+    Matrix.mem_unitaryGroup_iff'.mp hliftC
+  change star liftR * Uphysical * liftR = Ucoordinate at hcoordinate
+  have hphysical : Uphysical = liftR * Ucoordinate * star liftR := by
+    calc
+      Uphysical = 1 * Uphysical * 1 := by simp
+      _ = (liftR * star liftR) * Uphysical *
+          (liftR * star liftR) := by
+        rw [hliftR_right]
+      _ = liftR * (star liftR * Uphysical * liftR) *
+          star liftR := by simp only [Matrix.mul_assoc]
+      _ = liftR * Ucoordinate * star liftR := by rw [hcoordinate]
+  have hisometry :=
+    physicalDilation_mul_fixedEnvEmbedding_mul_support
+      (c₀, r₀) V hV Ucoordinate
+      (1 : Matrix B B ℂ)
+  dsimp only at hisometry
+  change
+    (liftR * Ucoordinate * star liftR) *
+          fixedEnvEmbedding (S := B) (c₀, r₀) * (V * 1) =
+      liftR *
+        (Ucoordinate * fixedEnvEmbedding (S := B) (c₀, r₀) * 1)
+    at hisometry
+  rw [← hphysical] at hisometry
+  have hslices : ∀ r : R,
+      rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Uphysical) r * V =
+        liftC *
+          rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r := by
+    intro r
+    ext bc b
+    rcases bc with ⟨b', c⟩
+    have hraw := congrArg
+      (fun W ↦ rightOutputSlice W (c, r)) hisometry
+    simp only [Matrix.mul_one] at hraw
+    have hraw' :
+        rightOutputSlice
+            (Uphysical * fixedEnvEmbedding (S := B) (c₀, r₀) * V)
+            (c, r) =
+          V * rightOutputSlice
+            (Ucoordinate * fixedEnvEmbedding (S := B) (c₀, r₀))
+            (c, r) := by
+      simpa only [liftR] using hraw.trans
+        (rightOutputSlice_kronecker_one_mul V
+          (Ucoordinate * fixedEnvEmbedding (S := B) (c₀, r₀))
+          (c, r))
+    have hentry := congrFun (congrFun hraw' b') b
+    simpa [pureAncillaDilationIsometry, rightOutputSlice,
+      Matrix.reindex_apply, Matrix.submatrix_apply, Equiv.prodAssoc,
+      Matrix.mul_apply, liftC, Matrix.kroneckerMap_apply,
+      Matrix.one_apply, Fintype.sum_prod_type] using hentry
+  rw [pureAncillaRecovery, pureAncillaRecovery,
+    LinearMap.comp_apply, LinearMap.comp_apply, singleKrausMap_apply,
+    singleKrausMap_apply]
+  change
+    partialTraceRight
+        (pureAncillaDilationIsometry c₀ r₀ Ucoordinate *
+          (star V * X * V) *
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate)ᴴ) =
+      star liftC *
+        partialTraceRight
+          (pureAncillaDilationIsometry c₀ r₀ Uphysical * X *
+            (pureAncillaDilationIsometry c₀ r₀ Uphysical)ᴴ) *
+        liftC
+  have hpure (U : Matrix (B × (C × R)) (B × (C × R)) ℂ)
+      (Y : Matrix B B ℂ) :
+      partialTraceRight
+          (pureAncillaDilationIsometry c₀ r₀ U * Y *
+            (pureAncillaDilationIsometry c₀ r₀ U)ᴴ) =
+        rectangularKrausMap
+          (fun r ↦ rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ U) r) Y := by
+    ext bc bc'
+    simp only [partialTraceRight_apply, rectangularKrausMap,
+      LinearMap.coe_mk, AddHom.coe_mk, Matrix.sum_apply]
+    rfl
+  rw [hpure, hpure]
+  change
+    (∑ r, rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r *
+        (star V * X * V) *
+        (rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r)ᴴ) =
+      star liftC *
+        (∑ r, rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ Uphysical) r * X *
+            (rightOutputSlice
+              (pureAncillaDilationIsometry c₀ r₀ Uphysical) r)ᴴ) *
+        liftC
+  rw [Finset.mul_sum, Finset.sum_mul]
+  apply Finset.sum_congr rfl
+  intro r _
+  have hs := hslices r
+  have hs' :
+      rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r * star V =
+        star liftC *
+          rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ Uphysical) r := by
+    calc
+      rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r * star V =
+        (star liftC * liftC) *
+            rightOutputSlice
+              (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r *
+            star V := by rw [hliftC_left]; simp
+      _ = star liftC *
+            (liftC *
+              rightOutputSlice
+                (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r) *
+            star V := by simp only [Matrix.mul_assoc]
+      _ = star liftC *
+          rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ Uphysical) r := by
+          rw [← hs]
+          simp only [Matrix.mul_assoc]
+          rw [Matrix.mem_unitaryGroup_iff.mp hV, Matrix.mul_one]
+  calc
+    rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r *
+        (star V * X * V) *
+        (rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r)ᴴ =
+      (rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r * star V) *
+        X *
+        (rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Ucoordinate) r * star V)ᴴ := by
+            simp only [star_eq_conjTranspose, Matrix.conjTranspose_mul,
+              Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+    _ = (star liftC *
+          rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ Uphysical) r) *
+        X *
+        (star liftC *
+          rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ Uphysical) r)ᴴ := by
+          rw [hs']
+    _ = star liftC *
+        (rightOutputSlice
+          (pureAncillaDilationIsometry c₀ r₀ Uphysical) r * X *
+          (rightOutputSlice
+            (pureAncillaDilationIsometry c₀ r₀ Uphysical) r)ᴴ) *
+        liftC := by
+          simp only [star_eq_conjTranspose, Matrix.conjTranspose_mul,
+            Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
+
+end Matrix

--- a/TNLean/Channel/KoashiImoto/RecoveredConditionalTripartiteBlockForm.lean
+++ b/TNLean/Channel/KoashiImoto/RecoveredConditionalTripartiteBlockForm.lean
@@ -1,0 +1,1000 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.HayashiMarkovStructure
+import TNLean.Channel.KrausBlockTransport
+import TNLean.Channel.KoashiImoto.RecoveredConditionalDilation.Covariance
+import TNLean.Channel.KoashiImoto.RecoveredConditionalDilationBlockForm
+
+/-!
+# Recovered conditional tripartite block form
+
+This file transports the recovered bipartite factors and the sector recovery
+states into the tripartite direct sum at equality in strong subadditivity.
+The middle-system fibres are written in HJPW order, with the conditional
+factor before the common factor. Complementary sectors remain zero.
+
+Source: Hayden--Jozsa--Petz--Winter,
+arXiv:quant-ph/0304007v2, Theorem 6, lines 562--570;
+arXiv:1606.00608, Appendix C.2, Lemma `Lsigma3`, equation `eq:sigma3`.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder BigOperators Kronecker
+namespace Matrix
+open RecoveredConditionalDilationInternal
+variable {dA dB dC : ℕ}
+/-- Canonical finite enumeration of the ambient recovered sectors. -/
+def recoveredAmbientHayashiSector
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm)
+    (j : Fin ((dB - F.jointSupport.n) + F.jointSupport.K)) :
+    AmbientRecoveredBlockIndex
+      (dB - F.jointSupport.n) F.jointSupport.K :=
+  finSumFinEquiv.symm j
+/-- The HJPW left-factor dimension in the canonical ambient enumeration. -/
+def recoveredAmbientHayashiLeftDim
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm)
+    (j : Fin ((dB - F.jointSupport.n) + F.jointSupport.K)) : ℕ :=
+  ambientRecoveredConditionalDim F.jointSupport.d
+    (recoveredAmbientHayashiSector F j)
+/-- The HJPW right-factor dimension in the canonical ambient enumeration. -/
+def recoveredAmbientHayashiRightDim
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm)
+    (j : Fin ((dB - F.jointSupport.n) + F.jointSupport.K)) : ℕ :=
+  ambientRecoveredCommonDim F.jointSupport.m
+    (recoveredAmbientHayashiSector F j)
+/-- The ambient middle-system decomposition in HJPW order before enumerating
+its sectors by a single finite type. -/
+def recoveredAmbientHJPWMiddleEquiv
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm) :
+    Fin dB ≃
+      ((s : AmbientRecoveredBlockIndex
+        (dB - F.jointSupport.n) F.jointSupport.K) ×
+        (Fin (ambientRecoveredConditionalDim F.jointSupport.d s) ×
+          Fin (ambientRecoveredCommonDim F.jointSupport.m s))) :=
+  let eSwap :=
+    Equiv.sigmaCongrRight fun s :
+        AmbientRecoveredBlockIndex
+          (dB - F.jointSupport.n) F.jointSupport.K ↦
+      Equiv.prodComm
+        (Fin (ambientRecoveredCommonDim F.jointSupport.m s))
+        (Fin (ambientRecoveredConditionalDim F.jointSupport.d s))
+  (recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e).symm
+    |>.trans eSwap
+/-- The recovered `b_j^R ⊗ b_j^L` coordinates become
+`b_j^L ⊗ b_j^R` coordinates by swapping the two fibre entries. -/
+@[simp]
+theorem recoveredAmbientHJPWMiddleEquiv_apply_coordinate
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm)
+    (s : AmbientRecoveredBlockIndex
+      (dB - F.jointSupport.n) F.jointSupport.K)
+    (r : Fin (ambientRecoveredCommonDim F.jointSupport.m s))
+    (l : Fin (ambientRecoveredConditionalDim F.jointSupport.d s)) :
+    recoveredAmbientHJPWMiddleEquiv F
+        (recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+          ⟨s, (r, l)⟩) =
+      ⟨s, (l, r)⟩ := by
+  simp [recoveredAmbientHJPWMiddleEquiv]
+/-- The ambient middle-system decomposition in HJPW order
+`b_j^L ⊗ b_j^R`, with the sectors canonically enumerated by `Fin`.
+The recovered bipartite witness stores each fibre in the reverse order
+`b_j^R ⊗ b_j^L`; `recoveredAmbientHJPWMiddleEquiv` performs the explicit
+factor swap before this equivalence enumerates the sectors.
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equations (13)--(15),
+lines 493--502 and 547--570. -/
+def recoveredAmbientHayashiMiddleEquiv
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm) :
+    Fin dB ≃
+      ((j : Fin ((dB - F.jointSupport.n) + F.jointSupport.K)) ×
+        (Fin (recoveredAmbientHayashiLeftDim F j) ×
+          Fin (recoveredAmbientHayashiRightDim F j))) :=
+  (recoveredAmbientHJPWMiddleEquiv F).trans
+    (Equiv.sigmaCongrLeft' finSumFinEquiv)
+/-- The enumerated HJPW equivalence sends a recovered coordinate to its swapped fibre. -/
+@[simp]
+theorem recoveredAmbientHayashiMiddleEquiv_apply_coordinate
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm)
+    (q : Fin ((dB - F.jointSupport.n) + F.jointSupport.K))
+    (r : Fin (recoveredAmbientHayashiRightDim F q))
+    (l : Fin (recoveredAmbientHayashiLeftDim F q)) :
+    recoveredAmbientHayashiMiddleEquiv F
+      (recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+        ⟨recoveredAmbientHayashiSector F q, (r, l)⟩) =
+      ⟨q, (l, r)⟩ := by
+  rw [recoveredAmbientHayashiMiddleEquiv, Equiv.trans_apply]
+  rw [recoveredAmbientHJPWMiddleEquiv_apply_coordinate]
+  let eSector :
+      ((s : AmbientRecoveredBlockIndex
+          (dB - F.jointSupport.n) F.jointSupport.K) ×
+        (Fin (ambientRecoveredConditionalDim F.jointSupport.d s) ×
+          Fin (ambientRecoveredCommonDim F.jointSupport.m s))) ≃
+      ((j : Fin ((dB - F.jointSupport.n) + F.jointSupport.K)) ×
+        (Fin (recoveredAmbientHayashiLeftDim F j) ×
+          Fin (recoveredAmbientHayashiRightDim F j))) :=
+    Equiv.sigmaCongrLeft' finSumFinEquiv
+  exact eSector.apply_symm_apply ⟨q, (l, r)⟩
+/-- The middle-system unitary with the orientation used by the Hayashi
+coordinate equation.
+The ambient recovered witness records the coordinate-to-physical unitary
+`U_B`. Therefore the physical-to-coordinate unitary in
+`U ρ Uᴴ` is `U_Bᴴ`.
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, equations (13)--(15),
+lines 493--502 and 547--570. -/
+def recoveredAmbientHayashiUnitary
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm) :
+    Matrix.unitaryGroup (Fin dB) ℂ :=
+  ⟨star F.U_B, by
+    rw [Matrix.mem_unitaryGroup_iff]
+    simpa only [star_star] using
+      Matrix.mem_unitaryGroup_iff'.mp F.U_B_unitary⟩
+private def
+    RecoveredConditionalDilationBlockForm.ambientRecoveredKraus
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    {F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm}
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F)
+    (i : Fin D.r)
+    (s : AmbientRecoveredBlockIndex
+      (dB - F.jointSupport.n) F.jointSupport.K) :
+    Matrix
+      (Fin (ambientRecoveredCommonDim F.jointSupport.m s) × Fin dC)
+      (Fin (ambientRecoveredCommonDim F.jointSupport.m s)) ℂ :=
+  match s with
+  | Sum.inl _ => 0
+  | Sum.inr j => D.L i j
+private noncomputable def
+    RecoveredConditionalDilationBlockForm.ambientRecoveredBlockKraus
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    {F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm}
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F)
+    (i : Fin D.r) :
+    Matrix (Fin dB × Fin dC) (Fin dB) ℂ :=
+  let eB := recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+  Matrix.reindex (dilationBlockEquiv (E := Fin dC) eB) eB
+    (Matrix.blockDiagonal' fun s ↦
+      D.ambientRecoveredKraus i s ⊗ₖ
+        (1 : Matrix
+          (Fin (ambientRecoveredConditionalDim F.jointSupport.d s))
+          (Fin (ambientRecoveredConditionalDim F.jointSupport.d s)) ℂ))
+private theorem
+    RecoveredConditionalDilationBlockForm.blockCoordinateDilation_isometry
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    {F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm}
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F) :
+    pureAncillaDilationIsometry D.c₀ D.k₀ D.U_BCE_blocks *
+        ambientSupportEmbedding F.e₀ =
+      stinespringV D.ambientRecoveredBlockKraus *
+        ambientSupportEmbedding F.e₀ := by
+  classical
+  let C : Fin (dC * D.r) → ∀ j : Fin F.jointSupport.K,
+      Matrix (Fin (F.jointSupport.m j))
+        (Fin (F.jointSupport.m j)) ℂ :=
+    fun k j ↦ rightOutputSlice
+      (D.L (finProdFinEquiv.symm k).2 j)
+      (finProdFinEquiv.symm k).1
+  have hL : ∀ i j u c u', D.L i j (u, c) u' =
+      C (finProdFinEquiv (c, i)) j u u' := by
+    intro i j u c u'
+    change D.L i j (u, c) u' =
+      rightOutputSlice
+        (D.L (finProdFinEquiv.symm (finProdFinEquiv (c, i))).2 j)
+        (finProdFinEquiv.symm (finProdFinEquiv (c, i))).1 u u'
+    rw [Equiv.symm_apply_apply]
+    rfl
+  have hslices :=
+    blockDilation_slice_support F.e₀ F.jointSupport.e
+      D.c₀ D.k₀ C D.L hL D.Ulocal D.sector_pure_ancilla_extension
+  have hK : ∀ c i,
+      rightOutputSlice (D.ambientRecoveredBlockKraus i) c *
+          ambientSupportEmbedding F.e₀ =
+        ambientSupportEmbedding F.e₀ *
+          Matrix.reindex F.jointSupport.e F.jointSupport.e
+            (Matrix.blockDiagonal' fun j ↦
+              C (finProdFinEquiv (c, i)) j ⊗ₖ
+                (1 : Matrix (Fin (F.jointSupport.d j))
+                  (Fin (F.jointSupport.d j)) ℂ)) := by
+    intro c i
+    ext b x
+    rw [← (recoveredAmbientMiddleBlockEquiv
+      F.e₀ F.jointSupport.e).apply_symm_apply b,
+      ← F.jointSupport.e.apply_symm_apply x]
+    generalize (recoveredAmbientMiddleBlockEquiv
+      F.e₀ F.jointSupport.e).symm b = sb
+    generalize F.jointSupport.e.symm x = sx
+    rcases sb with ⟨s, u, v⟩
+    rcases sx with ⟨j, u', v'⟩
+    rcases s with z | j'
+    · change Fin 1 at u v
+      have hu : u = (0 : Fin 1) := Subsingleton.elim _ _
+      have hv : v = (0 : Fin 1) := Subsingleton.elim _ _
+      subst u
+      subst v
+      have hrow :
+          recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+              ⟨Sum.inl z, ((0 : Fin 1), (0 : Fin 1))⟩ =
+            F.e₀ (Sum.inl z) := by rfl
+      rw [hrow]
+      rw [mul_ambientSupportEmbedding_apply,
+        ambientSupportEmbedding_mul_apply_complement]
+      have hcol :
+          (recoveredAmbientMiddleBlockEquiv
+            F.e₀ F.jointSupport.e).symm
+              (F.e₀ (Sum.inr
+                (F.jointSupport.e ⟨j, (u', v')⟩))) =
+            ⟨Sum.inr j, (u', v')⟩ := by
+        rw [← show recoveredAmbientMiddleBlockEquiv
+          F.e₀ F.jointSupport.e ⟨Sum.inr j, (u', v')⟩ =
+            F.e₀ (Sum.inr
+              (F.jointSupport.e ⟨j, (u', v')⟩)) by rfl]
+        exact Equiv.symm_apply_apply _ _
+      have hout :
+          (dilationBlockEquiv
+            (recoveredAmbientMiddleBlockEquiv
+              F.e₀ F.jointSupport.e)).symm
+              (F.e₀ (Sum.inl z), c) =
+            ⟨Sum.inl z, (((0 : Fin 1), c), (0 : Fin 1))⟩ := by
+        rw [← show dilationBlockEquiv
+          (recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e)
+            ⟨Sum.inl z, (((0 : Fin 1), c), (0 : Fin 1))⟩ =
+              (F.e₀ (Sum.inl z), c) by rfl]
+        exact Equiv.symm_apply_apply _ _
+      simp [ambientRecoveredBlockKraus, ambientRecoveredKraus,
+        rightOutputSlice,
+        Matrix.reindex_apply, Matrix.submatrix_apply,
+        Matrix.blockDiagonal'_apply, hcol, hout]
+    · by_cases hj : j' = j
+      · subst j'
+        have hrow :
+            recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+                ⟨Sum.inr j, (u, v)⟩ =
+              F.e₀ (Sum.inr (F.jointSupport.e ⟨j, (u, v)⟩)) := by
+          rfl
+        rw [hrow]
+        rw [mul_ambientSupportEmbedding_apply,
+          ambientSupportEmbedding_mul_apply_support]
+        have hcol :
+            (recoveredAmbientMiddleBlockEquiv
+              F.e₀ F.jointSupport.e).symm
+                (F.e₀ (Sum.inr
+                  (F.jointSupport.e ⟨j, (u', v')⟩))) =
+              ⟨Sum.inr j, (u', v')⟩ := by
+          rw [← show recoveredAmbientMiddleBlockEquiv
+            F.e₀ F.jointSupport.e ⟨Sum.inr j, (u', v')⟩ =
+              F.e₀ (Sum.inr
+                (F.jointSupport.e ⟨j, (u', v')⟩)) by rfl]
+          exact Equiv.symm_apply_apply _ _
+        have hout :
+            (dilationBlockEquiv
+              (recoveredAmbientMiddleBlockEquiv
+                F.e₀ F.jointSupport.e)).symm
+                (F.e₀ (Sum.inr
+                  (F.jointSupport.e ⟨j, (u, v)⟩)), c) =
+              ⟨Sum.inr j, ((u, c), v)⟩ := by
+          rw [← show dilationBlockEquiv
+            (recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e)
+              ⟨Sum.inr j, ((u, c), v)⟩ =
+                (F.e₀ (Sum.inr
+                  (F.jointSupport.e ⟨j, (u, v)⟩)), c) by rfl]
+          exact Equiv.symm_apply_apply _ _
+        simp [ambientRecoveredBlockKraus, ambientRecoveredKraus,
+          rightOutputSlice, Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply, C, hcol, hout]
+        have hp :
+            finProdFinEquiv.symm (finProdFinEquiv (c, i)) = (c, i) :=
+          Equiv.symm_apply_apply _ _
+        have hc :
+            (finProdFinEquiv (c, i)).divNat = c :=
+          congrArg Prod.fst hp
+        have hi :
+            (finProdFinEquiv (c, i)).modNat = i :=
+          congrArg Prod.snd hp
+        rw [hc, hi]
+        rfl
+      · have hrow :
+            recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+                ⟨Sum.inr j', (u, v)⟩ =
+              F.e₀ (Sum.inr (F.jointSupport.e ⟨j', (u, v)⟩)) := by
+          rfl
+        rw [hrow]
+        rw [mul_ambientSupportEmbedding_apply,
+          ambientSupportEmbedding_mul_apply_support]
+        have hcol :
+            (recoveredAmbientMiddleBlockEquiv
+              F.e₀ F.jointSupport.e).symm
+                (F.e₀ (Sum.inr
+                  (F.jointSupport.e ⟨j, (u', v')⟩))) =
+              ⟨Sum.inr j, (u', v')⟩ := by
+          rw [← show recoveredAmbientMiddleBlockEquiv
+            F.e₀ F.jointSupport.e ⟨Sum.inr j, (u', v')⟩ =
+              F.e₀ (Sum.inr
+                (F.jointSupport.e ⟨j, (u', v')⟩)) by rfl]
+          exact Equiv.symm_apply_apply _ _
+        have hout :
+            (dilationBlockEquiv
+              (recoveredAmbientMiddleBlockEquiv
+                F.e₀ F.jointSupport.e)).symm
+                (F.e₀ (Sum.inr
+                  (F.jointSupport.e ⟨j', (u, v)⟩)), c) =
+              ⟨Sum.inr j', ((u, c), v)⟩ := by
+          rw [← show dilationBlockEquiv
+            (recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e)
+              ⟨Sum.inr j', ((u, c), v)⟩ =
+                (F.e₀ (Sum.inr
+                  (F.jointSupport.e ⟨j', (u, v)⟩)), c) by rfl]
+          exact Equiv.symm_apply_apply _ _
+        simp [ambientRecoveredBlockKraus, ambientRecoveredKraus,
+          rightOutputSlice,
+          Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply, hj, hcol, hout]
+  rw [D.block_coordinate_unitary_eq]
+  ext ⟨⟨b, c⟩, i⟩ x
+  change
+    rightOutputSlice
+        ((Matrix.reindex
+              (dilationBlockEquiv
+                (recoveredAmbientMiddleBlockEquiv
+                  F.e₀ F.jointSupport.e))
+              (dilationBlockEquiv
+                (recoveredAmbientMiddleBlockEquiv
+                  F.e₀ F.jointSupport.e))
+              (Matrix.blockDiagonal' fun s ↦
+                D.Ulocal s ⊗ₖ
+                  (1 : Matrix
+                    (Fin (ambientRecoveredConditionalDim
+                      F.jointSupport.d s))
+                    (Fin (ambientRecoveredConditionalDim
+                      F.jointSupport.d s)) ℂ)) *
+            fixedEnvEmbedding (S := Fin dB) (D.c₀, D.k₀)) *
+          ambientSupportEmbedding F.e₀)
+        (c, i) b x =
+      (rightOutputSlice (D.ambientRecoveredBlockKraus i) c *
+        ambientSupportEmbedding F.e₀) b x
+  have hentry := congrFun (congrFun (hslices c i) b) x
+  have hKentry := congrFun (congrFun (hK c i) b) x
+  exact hentry.trans hKentry.symm
+private def ambientRecoveredConditionalBlock
+    {n K : ℕ} (d : Fin K → ℕ)
+    (B : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ)
+    (s : AmbientRecoveredBlockIndex n K) :
+    Matrix (Fin (ambientRecoveredConditionalDim d s))
+      (Fin (ambientRecoveredConditionalDim d s)) ℂ :=
+  match s with
+  | Sum.inl _ => 0
+  | Sum.inr j => B j
+private theorem ambientRecoveredConditionalBlock_bipartiteBlock_apply
+    {n K dA : ℕ} {d : Fin K → ℕ}
+    (ω : ∀ j, Matrix (Fin dA × Fin (d j))
+      (Fin dA × Fin (d j)) ℂ)
+    (a a' : Fin dA)
+    (s : AmbientRecoveredBlockIndex n K)
+    (l l' : Fin (ambientRecoveredConditionalDim d s)) :
+    ambientRecoveredConditionalBlock d
+        (fun j ↦ bipartiteBlock (ω j) a a') s l l' =
+      ambientRecoveredConditionalState ω s (a, l) (a', l') := by
+  cases s <;> rfl
+private theorem ambientRecoveredBlockState_eq_supportSandwich
+    {n K : ℕ} {m d : Fin K → ℕ}
+    (e₀ : (Fin (dB - n) ⊕ Fin n) ≃ Fin dB)
+    (e : ((j : Fin K) × (Fin (m j) × Fin (d j))) ≃ Fin n)
+    (σ : ∀ j, Matrix (Fin (m j)) (Fin (m j)) ℂ)
+    (B : ∀ j, Matrix (Fin (d j)) (Fin (d j)) ℂ) :
+    let eB := recoveredAmbientMiddleBlockEquiv e₀ e
+    Matrix.reindex eB eB
+        (Matrix.blockDiagonal' fun s ↦
+          ambientRecoveredCommonState σ s ⊗ₖ
+            ambientRecoveredConditionalBlock d B s) =
+      ambientSupportEmbedding e₀ *
+        Matrix.reindex e e
+          (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ B j) *
+        (ambientSupportEmbedding e₀)ᴴ := by
+  classical
+  dsimp only
+  let eB := recoveredAmbientMiddleBlockEquiv e₀ e
+  let X := Matrix.reindex e e
+    (Matrix.blockDiagonal' fun j ↦ σ j ⊗ₖ B j)
+  have hJ :
+      ambientSupportEmbedding e₀ * X * (ambientSupportEmbedding e₀)ᴴ =
+        Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 X) := by
+    ext b b'
+    rw [← e₀.apply_symm_apply b, ← e₀.apply_symm_apply b']
+    generalize e₀.symm b = sb
+    generalize e₀.symm b' = tb
+    rcases sb with z | s <;> rcases tb with z' | t <;>
+      simp [X, ambientSupportEmbedding, Matrix.mul_apply,
+        Matrix.one_apply]
+  have heBcomp (z : Fin (dB - n)) :
+      eB.symm (e₀ (Sum.inl z)) =
+        ⟨Sum.inl z, ((0 : Fin 1), (0 : Fin 1))⟩ := by
+    rw [← show eB ⟨Sum.inl z, ((0 : Fin 1), (0 : Fin 1))⟩ =
+      e₀ (Sum.inl z) by rfl]
+    exact Equiv.symm_apply_apply _ _
+  have heBsupp (j : Fin K) (u : Fin (m j)) (v : Fin (d j)) :
+      eB.symm (e₀ (Sum.inr (e ⟨j, (u, v)⟩))) =
+        ⟨Sum.inr j, (u, v)⟩ := by
+    rw [← show eB ⟨Sum.inr j, (u, v)⟩ =
+      e₀ (Sum.inr (e ⟨j, (u, v)⟩)) by rfl]
+    exact Equiv.symm_apply_apply _ _
+  have hambient :
+      Matrix.reindex eB eB
+          (Matrix.blockDiagonal' fun s ↦
+            ambientRecoveredCommonState σ s ⊗ₖ
+              ambientRecoveredConditionalBlock d B s) =
+        Matrix.reindex e₀ e₀ (Matrix.fromBlocks 0 0 0 X) := by
+    ext x y
+    rw [← eB.apply_symm_apply x, ← eB.apply_symm_apply y]
+    generalize eB.symm x = sx
+    generalize eB.symm y = sy
+    rcases sx with ⟨s, u, v⟩
+    rcases sy with ⟨t, u', v'⟩
+    rcases s with z | j <;> rcases t with z' | j'
+    · change Fin 1 at u v u' v'
+      fin_cases u
+      fin_cases v
+      fin_cases u'
+      fin_cases v'
+      simp [eB, X, ambientRecoveredCommonState,
+        ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+        heBcomp]
+    · change Fin 1 at u v
+      fin_cases u
+      fin_cases v
+      simp [eB, X, ambientRecoveredCommonState,
+        ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+        heBcomp, heBsupp]
+    · change Fin 1 at u' v'
+      fin_cases u'
+      fin_cases v'
+      simp [eB, X, ambientRecoveredCommonState,
+        ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+        heBcomp, heBsupp]
+    · by_cases hj : j = j'
+      · subst j'
+        simp [eB, X, ambientRecoveredCommonState,
+          ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+          heBsupp]
+      · simp [eB, X, ambientRecoveredCommonState,
+          ambientRecoveredConditionalBlock,
+          Matrix.blockDiagonal'_apply, hj, heBsupp]
+  exact hambient.trans hJ.symm
+/-- The recovered output factor on an ambient sector.
+
+Supported sectors carry the recovered `b_j^R C` state. Complementary sectors
+carry the zero operator; no normalized filler is chosen here.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 562--570. -/
+noncomputable def
+    RecoveredConditionalDilationBlockForm.ambientRecoveredOutputFactor
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    {F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm}
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F) :
+    (s : AmbientRecoveredBlockIndex
+      (dB - F.jointSupport.n) F.jointSupport.K) →
+      Matrix
+        (Fin (ambientRecoveredCommonDim F.jointSupport.m s) × Fin dC)
+        (Fin (ambientRecoveredCommonDim F.jointSupport.m s) × Fin dC) ℂ
+  | Sum.inl _ => 0
+  | Sum.inr j => D.recoveredSectorState j
+
+private theorem
+    RecoveredConditionalDilationBlockForm.blockCoordinateRecovery
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    {F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm}
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F)
+    (B : ∀ j, Matrix (Fin (F.jointSupport.d j))
+      (Fin (F.jointSupport.d j)) ℂ) :
+    let eB := recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+    let eOut := dilationBlockEquiv (E := Fin dC) eB
+    pureAncillaRecovery D.c₀ D.k₀ D.U_BCE_blocks
+        (Matrix.reindex eB eB
+          (Matrix.blockDiagonal' fun s ↦
+            ambientRecoveredCommonState F.jointSupport.σ s ⊗ₖ
+              ambientRecoveredConditionalBlock F.jointSupport.d B s)) =
+      Matrix.reindex eOut eOut
+        (Matrix.blockDiagonal' fun s ↦
+          D.ambientRecoveredOutputFactor s ⊗ₖ
+            ambientRecoveredConditionalBlock F.jointSupport.d B s) := by
+  classical
+  dsimp only
+  let eB := recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+  let eOut := dilationBlockEquiv (E := Fin dC) eB
+  let J := ambientSupportEmbedding F.e₀
+  let X := Matrix.reindex F.jointSupport.e F.jointSupport.e
+    (Matrix.blockDiagonal' fun j ↦ F.jointSupport.σ j ⊗ₖ B j)
+  let K₀ := fun i : Fin D.r ↦ Matrix.blockDiagonal' fun s ↦
+    D.ambientRecoveredKraus i s ⊗ₖ
+      (1 : Matrix
+        (Fin (ambientRecoveredConditionalDim F.jointSupport.d s))
+        (Fin (ambientRecoveredConditionalDim F.jointSupport.d s)) ℂ)
+  have hsupport :=
+    ambientRecoveredBlockState_eq_supportSandwich
+      F.e₀ F.jointSupport.e F.jointSupport.σ B
+  have hmap :=
+    pureAncillaRecovery_eq_rectangularKrausMap_on_support
+      D.c₀ D.k₀ D.U_BCE_blocks D.ambientRecoveredBlockKraus J
+      D.blockCoordinateDilation_isometry X
+  change
+    pureAncillaRecovery D.c₀ D.k₀ D.U_BCE_blocks
+        (Matrix.reindex eB eB
+          (Matrix.blockDiagonal' fun s ↦
+            ambientRecoveredCommonState F.jointSupport.σ s ⊗ₖ
+              ambientRecoveredConditionalBlock F.jointSupport.d B s)) =
+      Matrix.reindex eOut eOut
+        (Matrix.blockDiagonal' fun s ↦
+          D.ambientRecoveredOutputFactor s ⊗ₖ
+            ambientRecoveredConditionalBlock F.jointSupport.d B s)
+  have hrec :
+      pureAncillaRecovery D.c₀ D.k₀ D.U_BCE_blocks
+          (Matrix.reindex eB eB
+            (Matrix.blockDiagonal' fun s ↦
+              ambientRecoveredCommonState F.jointSupport.σ s ⊗ₖ
+                ambientRecoveredConditionalBlock F.jointSupport.d B s)) =
+        rectangularKrausMap D.ambientRecoveredBlockKraus
+          (Matrix.reindex eB eB
+            (Matrix.blockDiagonal' fun s ↦
+              ambientRecoveredCommonState F.jointSupport.σ s ⊗ₖ
+                ambientRecoveredConditionalBlock F.jointSupport.d B s)) := by
+    simpa only [eB, J, X, hsupport] using hmap
+  rw [hrec]
+  change
+    rectangularKrausMap
+        (fun i ↦ Matrix.reindex eOut eB (K₀ i))
+        (Matrix.reindex eB eB
+          (Matrix.blockDiagonal' fun s ↦
+            ambientRecoveredCommonState F.jointSupport.σ s ⊗ₖ
+              ambientRecoveredConditionalBlock F.jointSupport.d B s)) =
+      _
+  rw [rectangularKrausMap_reindex]
+  rw [rectangularKrausMap_blockDiagonal_kronecker_one]
+  congr 2
+  funext s
+  rcases s with z | j
+  · simp [ambientRecoveredKraus, ambientRecoveredOutputFactor,
+      ambientRecoveredConditionalBlock, ambientRecoveredCommonState,
+      rectangularKrausMap]
+  · simp [ambientRecoveredKraus, ambientRecoveredOutputFactor,
+      ambientRecoveredConditionalBlock, ambientRecoveredCommonState,
+      RecoveredConditionalDilationBlockForm.recoveredSectorState]
+    rfl
+/-- The unnormalized tripartite direct sum in HJPW factor order.
+
+On a supported sector the block is
+`ω_j ⊗ D.recoveredSectorState j`, where `ω_j` is the unnormalized
+`A b_j^L` factor. Complementary blocks are zero.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 562--570;
+arXiv:1606.00608, Appendix C.2, Lemma `Lsigma3`, equation `eq:sigma3`. -/
+noncomputable def
+    RecoveredConditionalDilationBlockForm.ambientTripartiteBlockState
+    {ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ}
+    {hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1}
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    {F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm}
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F) :
+    Matrix
+      (Fin dA ×
+        (((j : Fin ((dB - F.jointSupport.n) + F.jointSupport.K)) ×
+            (Fin (recoveredAmbientHayashiLeftDim F j) ×
+              Fin (recoveredAmbientHayashiRightDim F j))) ×
+          Fin dC))
+      (Fin dA ×
+        (((j : Fin ((dB - F.jointSupport.n) + F.jointSupport.K)) ×
+            (Fin (recoveredAmbientHayashiLeftDim F j) ×
+              Fin (recoveredAmbientHayashiRightDim F j))) ×
+          Fin dC)) ℂ :=
+  Matrix.reindex
+    (HayashiMarkov.sigmaAssoc
+      (dA := dA) (dC := dC)
+      (recoveredAmbientHayashiLeftDim F)
+      (recoveredAmbientHayashiRightDim F))
+    (HayashiMarkov.sigmaAssoc
+      (dA := dA) (dC := dC)
+      (recoveredAmbientHayashiLeftDim F)
+      (recoveredAmbientHayashiRightDim F))
+    (Matrix.blockDiagonal' fun j ↦
+      ambientRecoveredConditionalState F.jointSupport.ω
+          (recoveredAmbientHayashiSector F j) ⊗ₖ
+        D.ambientRecoveredOutputFactor
+          (recoveredAmbientHayashiSector F j))
+
+/-- The final HJPW substitution for fixed ambient and dilation witnesses.
+
+After conjugating by `U_Bᴴ` and explicitly swapping each middle-system fibre
+from the recovered `b_j^R ⊗ b_j^L` order to HJPW's
+`b_j^L ⊗ b_j^R` order, the tripartite state is the direct sum
+`⊕_j ω_j ⊗ η_j`. Complementary blocks are zero.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 562--570;
+arXiv:1606.00608, Appendix C.2, Lemma `Lsigma3`, equation `eq:sigma3`. -/
+structure RecoveredConditionalTripartiteBlockForm
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm)
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F) : Type where
+  /-- The transformed state equals the raw HJPW direct sum in ambient coordinates. -/
+  tripartite_block_form :
+    Matrix.reindex
+        (HayashiMarkov.abcEquiv
+          (dA := dA) (dB := dB) (dC := dC)
+          (recoveredAmbientHayashiMiddleEquiv F))
+        (HayashiMarkov.abcEquiv
+          (dA := dA) (dB := dB) (dC := dC)
+          (recoveredAmbientHayashiMiddleEquiv F))
+        (HayashiMarkov.liftB
+            (dA := dA) (dB := dB) (dC := dC)
+            (recoveredAmbientHayashiUnitary F : Matrix (Fin dB) (Fin dB) ℂ) *
+          ρ_ABC *
+          (HayashiMarkov.liftB
+            (dA := dA) (dB := dB) (dC := dC)
+            (recoveredAmbientHayashiUnitary F :
+              Matrix (Fin dB) (Fin dB) ℂ))ᴴ) =
+      D.ambientTripartiteBlockState
+/-- Fixed ambient and dilation witnesses determine the exact tripartite
+direct-sum transport in HJPW coordinates.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 562--570. -/
+theorem exists_recoveredConditionalTripartiteBlockForm_of_dilationBlockForm
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    [Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC))]
+    (F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm)
+    (D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F) :
+    Nonempty (RecoveredConditionalTripartiteBlockForm ρ_ABC hρ_dm F D) := by
+  classical
+  let T_B : Matrix (Fin dB) (Fin dB) ℂ →ₗ[ℂ]
+      Matrix (Fin dB) (Fin dB) ℂ :=
+    { toFun := fun X ↦ star F.U_B * X * F.U_B
+      map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := by intro c X; simp }
+  let T_BC : Matrix (Fin dB × Fin dC) (Fin dB × Fin dC) ℂ →ₗ[ℂ]
+      Matrix (Fin dB × Fin dC) (Fin dB × Fin dC) ℂ :=
+    { toFun := fun X ↦
+        star (F.U_B ⊗ₖ (1 : Matrix (Fin dC) (Fin dC) ℂ)) * X *
+          (F.U_B ⊗ₖ (1 : Matrix (Fin dC) (Fin dC) ℂ))
+      map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+      map_smul' := by intro c X; simp }
+  let Rblocks :=
+    pureAncillaRecovery D.c₀ D.k₀ D.U_BCE_blocks
+  let Rphysical :=
+    pureAncillaRecovery D.c₀ D.k₀ D.U_BCE_physical
+  have hcov : Rblocks.comp T_B = T_BC.comp Rphysical := by
+    apply LinearMap.ext
+    intro X
+    change
+      pureAncillaRecovery D.c₀ D.k₀ D.U_BCE_blocks
+          (star F.U_B * X * F.U_B) =
+        star (F.U_B ⊗ₖ
+            (1 : Matrix (Fin dC) (Fin dC) ℂ)) *
+          pureAncillaRecovery D.c₀ D.k₀ D.U_BCE_physical X *
+          (F.U_B ⊗ₖ (1 : Matrix (Fin dC) (Fin dC) ℂ))
+    exact
+      pureAncillaRecovery_inverse_coordinate D.c₀ D.k₀
+        F.U_B F.U_B_unitary D.U_BCE_physical D.U_BCE_blocks
+        D.inverse_coordinate_eq X
+  let ρ_AB := traceC_ABC ρ_ABC
+  let eB := recoveredAmbientMiddleBlockEquiv F.e₀ F.jointSupport.e
+  let ρ_AB_blocks :=
+    Matrix.reindex (recoveredBipartiteBlockEquiv eB)
+      (recoveredBipartiteBlockEquiv eB)
+      (Matrix.blockDiagonal' fun s ↦
+        ambientRecoveredCommonState F.jointSupport.σ s ⊗ₖ
+          ambientRecoveredConditionalState F.jointSupport.ω s)
+  have hAB :
+      idTensorMapLM (δ := Fin dA) T_B ρ_AB = ρ_AB_blocks := by
+    have hconj := idTensorMap_conjugation (star F.U_B) ρ_AB
+    have hUB :
+        (star F.U_B)ᴴ = F.U_B := by
+      simp only [star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose]
+    rw [hUB] at hconj
+    calc
+      idTensorMapLM (δ := Fin dA) T_B ρ_AB =
+          star ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ F.U_B) *
+            ρ_AB *
+            ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ F.U_B) := by
+              simpa only [T_B, Matrix.conjTranspose_kronecker,
+                Matrix.conjTranspose_one, star_eq_conjTranspose,
+                Matrix.conjTranspose_conjTranspose] using hconj
+      _ = ρ_AB_blocks := by
+        simpa only [ρ_AB, ρ_AB_blocks, eB,
+          Matrix.star_eq_conjTranspose] using F.ambient_bipartite_block_form
+  have hcoordinate :
+      HayashiMarkov.liftB
+            (dA := dA) (dB := dB) (dC := dC) (star F.U_B) *
+          ρ_ABC *
+          (HayashiMarkov.liftB
+            (dA := dA) (dB := dB) (dC := dC) (star F.U_B))ᴴ =
+        idTensorMapLM (δ := Fin dA) Rblocks ρ_AB_blocks := by
+    have hconj := idTensorMap_conjugation
+      (star (F.U_B ⊗ₖ (1 : Matrix (Fin dC) (Fin dC) ℂ))) ρ_ABC
+    have hUBC :
+        (star (F.U_B ⊗ₖ
+          (1 : Matrix (Fin dC) (Fin dC) ℂ)))ᴴ =
+            F.U_B ⊗ₖ (1 : Matrix (Fin dC) (Fin dC) ℂ) := by
+      simp only [star_eq_conjTranspose,
+        Matrix.conjTranspose_conjTranspose]
+    rw [hUBC] at hconj
+    calc
+      HayashiMarkov.liftB (star F.U_B) * ρ_ABC *
+          (HayashiMarkov.liftB (star F.U_B))ᴴ =
+        idTensorMapLM (δ := Fin dA) T_BC ρ_ABC := by
+          simpa only [T_BC, HayashiMarkov.liftB,
+            Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one,
+            star_eq_conjTranspose] using hconj.symm
+      _ = idTensorMapLM (δ := Fin dA) T_BC
+          (idTensorMapLM (δ := Fin dA) Rphysical ρ_AB) := by
+            rw [D.recovery_eq11]
+      _ = idTensorMapLM (δ := Fin dA) (T_BC.comp Rphysical) ρ_AB := by
+            rw [idTensorMapLM_comp, LinearMap.comp_apply]
+      _ = idTensorMapLM (δ := Fin dA) (Rblocks.comp T_B) ρ_AB := by
+            rw [hcov]
+      _ = idTensorMapLM (δ := Fin dA) Rblocks
+          (idTensorMapLM (δ := Fin dA) T_B ρ_AB) := by
+            rw [idTensorMapLM_comp, LinearMap.comp_apply]
+      _ = idTensorMapLM (δ := Fin dA) Rblocks ρ_AB_blocks := by
+            rw [hAB]
+  refine ⟨{ tripartite_block_form := ?_ }⟩
+  rw [show recoveredAmbientHayashiUnitary F =
+      (⟨star F.U_B, by
+        rw [Matrix.mem_unitaryGroup_iff]
+        simpa only [star_star] using
+          Matrix.mem_unitaryGroup_iff'.mp F.U_B_unitary⟩ :
+        Matrix.unitaryGroup (Fin dB) ℂ) by rfl]
+  change Matrix.reindex _ _
+      (HayashiMarkov.liftB (star F.U_B) * ρ_ABC *
+        (HayashiMarkov.liftB (star F.U_B))ᴴ) =
+    D.ambientTripartiteBlockState
+  rw [hcoordinate]
+  let Bblock (a a' : Fin dA) (j : Fin F.jointSupport.K) :=
+    bipartiteBlock (F.jointSupport.ω j) a a'
+  have heBcomp (z : Fin (dB - F.jointSupport.n)) :
+      eB.symm (F.e₀ (Sum.inl z)) =
+        ⟨Sum.inl z, ((0 : Fin 1), (0 : Fin 1))⟩ := by
+    rw [← show eB ⟨Sum.inl z, ((0 : Fin 1), (0 : Fin 1))⟩ =
+      F.e₀ (Sum.inl z) by rfl]
+    exact Equiv.symm_apply_apply _ _
+  have heBsupp (j : Fin F.jointSupport.K)
+      (u : Fin (F.jointSupport.m j))
+      (v : Fin (F.jointSupport.d j)) :
+      eB.symm (F.e₀ (Sum.inr
+        (F.jointSupport.e ⟨j, (u, v)⟩))) =
+        ⟨Sum.inr j, (u, v)⟩ := by
+    rw [← show eB ⟨Sum.inr j, (u, v)⟩ =
+      F.e₀ (Sum.inr
+        (F.jointSupport.e ⟨j, (u, v)⟩)) by rfl]
+    exact Equiv.symm_apply_apply _ _
+  have hbipartite (a a' : Fin dA) :
+      bipartiteBlock ρ_AB_blocks a a' =
+        Matrix.reindex eB eB
+          (Matrix.blockDiagonal' fun s ↦
+            ambientRecoveredCommonState F.jointSupport.σ s ⊗ₖ
+              ambientRecoveredConditionalBlock F.jointSupport.d
+                (Bblock a a') s) := by
+    ext b b'
+    rw [← eB.apply_symm_apply b, ← eB.apply_symm_apply b']
+    generalize eB.symm b = sb
+    generalize eB.symm b' = tb
+    rcases sb with ⟨s, u, v⟩
+    rcases tb with ⟨t, u', v'⟩
+    rcases s with z | j <;> rcases t with z' | j'
+    · change Fin 1 at u v u' v'
+      fin_cases u
+      fin_cases v
+      fin_cases u'
+      fin_cases v'
+      simp [ρ_AB_blocks, eB, Bblock, bipartiteBlock_apply,
+        ambientRecoveredCommonState, ambientRecoveredConditionalState,
+        ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+        heBcomp]
+    · change Fin 1 at u v
+      fin_cases u
+      fin_cases v
+      simp [ρ_AB_blocks, eB, Bblock, bipartiteBlock_apply,
+        ambientRecoveredCommonState, ambientRecoveredConditionalState,
+        ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+        heBcomp, heBsupp]
+    · change Fin 1 at u' v'
+      fin_cases u'
+      fin_cases v'
+      simp [ρ_AB_blocks, eB, Bblock, bipartiteBlock_apply,
+        ambientRecoveredCommonState, ambientRecoveredConditionalState,
+        ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+        heBcomp, heBsupp]
+    · by_cases hj : j = j'
+      · subst j'
+        simp [ρ_AB_blocks, eB, Bblock, bipartiteBlock_apply,
+          ambientRecoveredCommonState, ambientRecoveredConditionalState,
+          ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+          heBsupp]
+        exact Or.inl rfl
+      · simp [ρ_AB_blocks, eB, Bblock, bipartiteBlock_apply,
+          ambientRecoveredCommonState, ambientRecoveredConditionalState,
+          ambientRecoveredConditionalBlock, Matrix.blockDiagonal'_apply,
+          hj, heBsupp]
+  ext ⟨a, ⟨⟨q, ⟨l, r⟩⟩, c⟩⟩
+      ⟨a', ⟨⟨q', ⟨l', r'⟩⟩, c'⟩⟩
+  let s := recoveredAmbientHayashiSector F q
+  let s' := recoveredAmbientHayashiSector F q'
+  have hmid :
+      recoveredAmbientHayashiMiddleEquiv F (eB ⟨s, (r, l)⟩) =
+        ⟨q, (l, r)⟩ := by
+    dsimp only [s, eB]
+    exact recoveredAmbientHayashiMiddleEquiv_apply_coordinate F q r l
+  have hmid' :
+      recoveredAmbientHayashiMiddleEquiv F (eB ⟨s', (r', l')⟩) =
+        ⟨q', (l', r')⟩ := by
+    dsimp only [s', eB]
+    exact recoveredAmbientHayashiMiddleEquiv_apply_coordinate F q' r' l'
+  have habc :
+      (HayashiMarkov.abcEquiv
+        (recoveredAmbientHayashiMiddleEquiv F)).symm
+          (a, ⟨q, (l, r)⟩, c) =
+        (a, eB ⟨s, (r, l)⟩, c) := by
+    rw [← show HayashiMarkov.abcEquiv
+      (recoveredAmbientHayashiMiddleEquiv F)
+        (a, eB ⟨s, (r, l)⟩, c) =
+          (a, ⟨q, (l, r)⟩, c) by
+            simp [HayashiMarkov.abcEquiv, hmid]]
+    exact Equiv.symm_apply_apply _ _
+  have habc' :
+      (HayashiMarkov.abcEquiv
+        (recoveredAmbientHayashiMiddleEquiv F)).symm
+          (a', ⟨q', (l', r')⟩, c') =
+        (a', eB ⟨s', (r', l')⟩, c') := by
+    rw [← show HayashiMarkov.abcEquiv
+      (recoveredAmbientHayashiMiddleEquiv F)
+        (a', eB ⟨s', (r', l')⟩, c') =
+          (a', ⟨q', (l', r')⟩, c') by
+            simp [HayashiMarkov.abcEquiv, hmid']]
+    exact Equiv.symm_apply_apply _ _
+  have hsigma :
+      (HayashiMarkov.sigmaAssoc
+        (dA := dA) (dC := dC)
+        (recoveredAmbientHayashiLeftDim F)
+        (recoveredAmbientHayashiRightDim F)).symm
+          (a, ⟨q, (l, r)⟩, c) =
+        ⟨q, ((a, l), (r, c))⟩ := by
+    rw [← show HayashiMarkov.sigmaAssoc
+      (dA := dA) (dC := dC)
+      (recoveredAmbientHayashiLeftDim F)
+      (recoveredAmbientHayashiRightDim F)
+        ⟨q, ((a, l), (r, c))⟩ =
+          (a, ⟨q, (l, r)⟩, c) by rfl]
+    exact Equiv.symm_apply_apply _ _
+  have hsigma' :
+      (HayashiMarkov.sigmaAssoc
+        (dA := dA) (dC := dC)
+        (recoveredAmbientHayashiLeftDim F)
+        (recoveredAmbientHayashiRightDim F)).symm
+          (a', ⟨q', (l', r')⟩, c') =
+        ⟨q', ((a', l'), (r', c'))⟩ := by
+    rw [← show HayashiMarkov.sigmaAssoc
+      (dA := dA) (dC := dC)
+      (recoveredAmbientHayashiLeftDim F)
+      (recoveredAmbientHayashiRightDim F)
+        ⟨q', ((a', l'), (r', c'))⟩ =
+          (a', ⟨q', (l', r')⟩, c') by rfl]
+    exact Equiv.symm_apply_apply _ _
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    idTensorMapLM_apply, idTensorMap_apply, habc, habc',
+    RecoveredConditionalDilationBlockForm.ambientTripartiteBlockState,
+    hsigma, hsigma']
+  change
+    Rblocks (bipartiteBlock ρ_AB_blocks a a')
+        (eB ⟨s, (r, l)⟩, c)
+        (eB ⟨s', (r', l')⟩, c') =
+      Matrix.blockDiagonal' (fun q ↦
+        ambientRecoveredConditionalState F.jointSupport.ω
+            (recoveredAmbientHayashiSector F q) ⊗ₖ
+          D.ambientRecoveredOutputFactor
+            (recoveredAmbientHayashiSector F q))
+        ⟨q, ((a, l), (r, c))⟩
+        ⟨q', ((a', l'), (r', c'))⟩
+  rw [hbipartite]
+  have hrec := D.blockCoordinateRecovery (Bblock a a')
+  have hentry := congrFun (congrFun hrec
+    (dilationBlockEquiv eB ⟨s, ((r, c), l)⟩))
+    (dilationBlockEquiv eB ⟨s', ((r', c'), l')⟩)
+  dsimp only [eB, Rblocks] at hentry ⊢
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply] at hentry
+  simp only [Equiv.symm_apply_apply] at hentry
+  by_cases hq : q = q'
+  · subst q'
+    dsimp only [s, s'] at hentry ⊢
+    convert hentry using 1 <;>
+      simp [Matrix.reindex_apply, recoveredAmbientHayashiSector,
+        Matrix.blockDiagonal'_apply, Matrix.kroneckerMap_apply]
+    rw [ambientRecoveredConditionalBlock_bipartiteBlock_apply]
+    exact mul_comm _ _
+  · have hs : s ≠ s' := by
+      intro hss
+      apply hq
+      exact finSumFinEquiv.symm.injective hss
+    simpa [Matrix.reindex_apply, Matrix.submatrix_apply,
+      recoveredAmbientHayashiSector, s, s',
+      Matrix.blockDiagonal'_apply, Matrix.kroneckerMap_apply,
+      Bblock, bipartiteBlock_apply, hq, hs] using hentry
+
+/-- At equality in strong subadditivity, the tripartite state has the raw
+HJPW direct-sum form `⊕_j ω_j ⊗ η_j` in ambient middle-system coordinates.
+
+This theorem introduces no probability normalization or density fillers.
+
+Source: HJPW, arXiv:quant-ph/0304007v2, Theorem 6, lines 562--570;
+arXiv:1606.00608, Appendix C.2, Lemma `Lsigma3`, equation `eq:sigma3`. -/
+theorem exists_recoveredConditionalTripartiteBlockForm
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC)
+      (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ_dm : ρ_ABC.PosSemidef ∧ ρ_ABC.trace = 1)
+    (hSSA : IsSSAEquality ρ_ABC hρ_dm.1.isHermitian) :
+    letI : Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC)) :=
+      recoveredEffectIndex_nonempty (traceC_ABC ρ_ABC) (by
+        rw [← trace_eq_trace_traceC_ABC]
+        exact hρ_dm.2)
+    Nonempty
+      (Σ F : RecoveredConditionalAmbientBipartiteBlockForm ρ_ABC hρ_dm,
+        Σ D : RecoveredConditionalDilationBlockForm ρ_ABC hρ_dm F,
+          RecoveredConditionalTripartiteBlockForm ρ_ABC hρ_dm F D) := by
+  classical
+  letI : Nonempty (RecoveredEffectIndex (traceC_ABC ρ_ABC)) :=
+    recoveredEffectIndex_nonempty (traceC_ABC ρ_ABC) (by
+      rw [← trace_eq_trace_traceC_ABC]
+      exact hρ_dm.2)
+  obtain ⟨⟨F, D⟩⟩ :=
+    exists_recoveredDilationBlockUnitary ρ_ABC hρ_dm hSSA
+  obtain ⟨T⟩ :=
+    exists_recoveredConditionalTripartiteBlockForm_of_dilationBlockForm
+      ρ_ABC hρ_dm F D
+  exact ⟨⟨F, D, T⟩⟩
+
+end Matrix

--- a/TNLean/Channel/KrausBlockTransport.lean
+++ b/TNLean/Channel/KrausBlockTransport.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KrausCPTP
+
+/-!
+# Block and coordinate transport for rectangular Kraus maps
+
+This file records how rectangular Kraus maps act on dependent tensor blocks
+and commute with simultaneous changes of input and output coordinates.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace Matrix
+
+/-- A dependent block-diagonal rectangular Kraus family acts independently
+on every common factor and leaves each spectator factor unchanged. -/
+theorem rectangularKrausMap_blockDiagonal_kronecker_one
+    {κ ι : Type*} [Fintype κ] [Fintype ι] [DecidableEq ι]
+    {α β δ : ι → Type*}
+    [∀ i, Fintype (α i)] [∀ i, Fintype (δ i)]
+    [∀ i, DecidableEq (δ i)]
+    (L : κ → ∀ i, Matrix (β i) (α i) ℂ)
+    (A : ∀ i, Matrix (α i) (α i) ℂ)
+    (B : ∀ i, Matrix (δ i) (δ i) ℂ) :
+    rectangularKrausMap
+        (fun k ↦ Matrix.blockDiagonal' (fun i ↦
+          L k i ⊗ₖ (1 : Matrix (δ i) (δ i) ℂ)))
+        (Matrix.blockDiagonal' fun i ↦ A i ⊗ₖ B i) =
+      Matrix.blockDiagonal' fun i ↦
+        rectangularKrausMap (fun k ↦ L k i) (A i) ⊗ₖ B i := by
+  classical
+  change
+    (∑ k, Matrix.blockDiagonal' (fun i ↦
+          L k i ⊗ₖ (1 : Matrix (δ i) (δ i) ℂ)) *
+        (Matrix.blockDiagonal' fun i ↦ A i ⊗ₖ B i) *
+        (Matrix.blockDiagonal' (fun i ↦
+          L k i ⊗ₖ (1 : Matrix (δ i) (δ i) ℂ)))ᴴ) =
+      Matrix.blockDiagonal' fun i ↦
+        (∑ k, L k i * A i * (L k i)ᴴ) ⊗ₖ B i
+  have hterm (k : κ) :
+      Matrix.blockDiagonal' (fun i ↦
+          L k i ⊗ₖ (1 : Matrix (δ i) (δ i) ℂ)) *
+          (Matrix.blockDiagonal' fun i ↦ A i ⊗ₖ B i) *
+          (Matrix.blockDiagonal' (fun i ↦
+            L k i ⊗ₖ (1 : Matrix (δ i) (δ i) ℂ)))ᴴ =
+        Matrix.blockDiagonal' fun i ↦
+          (L k i * A i * (L k i)ᴴ) ⊗ₖ B i := by
+    rw [Matrix.blockDiagonal'_conjTranspose]
+    rw [← Matrix.blockDiagonal'_mul, ← Matrix.blockDiagonal'_mul]
+    congr 1
+    funext i
+    rw [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one]
+    rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+    simp
+  simp_rw [hterm]
+  ext ⟨i, x⟩ ⟨j, y⟩
+  by_cases hij : i = j
+  · subst j
+    simp only [Matrix.sum_apply, Matrix.blockDiagonal'_apply_eq]
+    rcases x with ⟨xα, xδ⟩
+    rcases y with ⟨yα, yδ⟩
+    simp only [Matrix.kroneckerMap_apply, Matrix.sum_apply]
+    rw [Finset.sum_mul]
+  · simp only [Matrix.sum_apply]
+    calc
+      (∑ k, Matrix.blockDiagonal' (fun i ↦
+          (L k i * A i * (L k i)ᴴ) ⊗ₖ B i) ⟨i, x⟩ ⟨j, y⟩) = 0 := by
+        apply Finset.sum_eq_zero
+        intro k _
+        exact Matrix.blockDiagonal'_apply_ne _ _ _ hij
+      _ = Matrix.blockDiagonal' (fun i ↦
+          (∑ k, L k i * A i * (L k i)ᴴ) ⊗ₖ B i)
+            ⟨i, x⟩ ⟨j, y⟩ :=
+        (Matrix.blockDiagonal'_apply_ne _ _ _ hij).symm
+
+/-- Simultaneously relabeling the input and output coordinates commutes with
+a rectangular Kraus map. -/
+theorem rectangularKrausMap_reindex
+    {κ α α' β β' : Type*} [Fintype κ] [Fintype α]
+    [Fintype α']
+    (eα : α ≃ α') (eβ : β ≃ β')
+    (K : κ → Matrix β α ℂ) (X : Matrix α α ℂ) :
+    rectangularKrausMap
+        (fun k ↦ Matrix.reindex eβ eα (K k))
+        (Matrix.reindex eα eα X) =
+      Matrix.reindex eβ eβ (rectangularKrausMap K X) := by
+  change
+    (∑ k, Matrix.reindex eβ eα (K k) *
+        Matrix.reindex eα eα X *
+        (Matrix.reindex eβ eα (K k))ᴴ) =
+      Matrix.reindex eβ eβ (∑ k, K k * X * (K k)ᴴ)
+  have hreindexSum :
+      Matrix.reindex eβ eβ (∑ k, K k * X * (K k)ᴴ) =
+        ∑ k, Matrix.reindex eβ eβ (K k * X * (K k)ᴴ) := by
+    ext b b'
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.sum_apply]
+  rw [hreindexSum]
+  apply Finset.sum_congr rfl
+  intro k _
+  rw [Matrix.conjTranspose_reindex]
+  calc
+    Matrix.reindex eβ eα (K k) *
+          Matrix.reindex eα eα X *
+          Matrix.reindex eα eβ (K k)ᴴ =
+      Matrix.reindex eβ eα (K k * X) *
+          Matrix.reindex eα eβ (K k)ᴴ := by
+        rw [show Matrix.reindex eβ eα (K k) *
+              Matrix.reindex eα eα X =
+            Matrix.reindex eβ eα (K k * X) by
+          exact Matrix.reindexLinearEquiv_mul ℂ ℂ eβ eα eα _ _]
+    _ = Matrix.reindex eβ eβ (K k * X * (K k)ᴴ) := by
+      exact Matrix.reindexLinearEquiv_mul ℂ ℂ eβ eα eβ _ _
+
+end Matrix

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -76,7 +76,7 @@ dimensions.
   preparation.
 -/
 
-open scoped Matrix BigOperators ComplexOrder
+open scoped Matrix BigOperators ComplexOrder Kronecker
 
 /-- A **completely positive map** in rectangular Kraus form
 `S(X) = ∑ᵢ Aᵢ X Aᵢ†`.  Rectangular Kraus operators

--- a/TNLean/Channel/TensorMap.lean
+++ b/TNLean/Channel/TensorMap.lean
@@ -43,7 +43,7 @@ act trivially on an ancillary factor.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 2][Wolf2012QChannels]
 -/
 
-open scoped Matrix
+open scoped Matrix Kronecker
 open Matrix Finset BigOperators
 
 namespace Matrix
@@ -218,6 +218,30 @@ theorem idTensorMap_kronecker
       kroneckerMap (· * ·) A (T B) := by
   rw [idTensorMap, swapFactorsLinearEquiv_kronecker,
     tensorMapId_kronecker, swapFactorsLinearEquiv_kronecker]
+
+/-- Applying a rectangular conjugation to the second matrix factor is
+conjugation by the identity-tensored rectangular matrix. -/
+theorem idTensorMap_conjugation
+    {δ : Type*} [Fintype δ] [DecidableEq δ]
+    {α β : Type*} [Fintype α]
+    (Z : Matrix β α ℂ)
+    (R : Matrix (δ × α) (δ × α) ℂ) :
+    let T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
+      { toFun := fun X ↦ Z * X * Zᴴ
+        map_add' := by intro X Y; simp [Matrix.mul_add, Matrix.add_mul]
+        map_smul' := by intro c X; simp [Matrix.mul_smul, Matrix.smul_mul] }
+    idTensorMapLM T R =
+      ((1 : Matrix δ δ ℂ) ⊗ₖ Z) * R *
+        ((1 : Matrix δ δ ℂ) ⊗ₖ Z)ᴴ := by
+  dsimp only
+  ext ⟨a, k⟩ ⟨b, l⟩
+  simp only [idTensorMapLM_apply, idTensorMap_apply,
+    Matrix.mul_apply, Matrix.conjTranspose_kronecker,
+    Matrix.conjTranspose_one, Matrix.kroneckerMap_apply,
+    Matrix.one_apply]
+  simp_rw [Fintype.sum_prod_type]
+  simp
+  rfl
 
 /-- Tensoring the identity map on the first factor with the identity map on the
 second gives the identity map on the product matrix algebra. -/

--- a/TNLean/Channel/TensorMap.lean
+++ b/TNLean/Channel/TensorMap.lean
@@ -239,9 +239,7 @@ theorem idTensorMap_conjugation
     Matrix.mul_apply, Matrix.conjTranspose_kronecker,
     Matrix.conjTranspose_one, Matrix.kroneckerMap_apply,
     Matrix.one_apply]
-  simp_rw [Fintype.sum_prod_type]
-  simp
-  rfl
+  simp [Fintype.sum_prod_type, Matrix.mul_apply, bipartiteBlock_apply]
 
 /-- Tensoring the identity map on the first factor with the identity map on the
 second gives the identity map on the product matrix algebra. -/

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -1996,6 +1996,59 @@ algebra of a family of jointly invariant states.
     unitary recovery.
 \end{proof}
 
+\begin{theorem}[Recovered tripartite blocks in ambient coordinates]
+    \label{thm:hjpw_recovered_tripartite_ambient_blocks}
+    \lean{Matrix.exists_recoveredConditionalTripartiteBlockForm}
+    \leanok
+    \uses{thm:hjpw_recovered_bipartite_ambient_blocks,
+        thm:hjpw_recovered_dilation_ambient_blocks}
+    Let $\rho_{ABC}$ be a tripartite density matrix attaining equality in
+    strong subadditivity. In the ambient decomposition
+    \begin{align}
+        \mathcal H_B
+        =
+        \bigoplus_j \mathcal H_{b_j^L}\otimes
+            \mathcal H_{b_j^R},
+    \end{align}
+    obtained by exchanging the two factors in
+    Theorem~\ref{thm:hjpw_recovered_bipartite_ambient_blocks}, the transformed
+    tripartite state has the direct-sum form
+    \begin{align}
+        \rho_{ABC}
+        =
+        \bigoplus_j
+            \omega_j^{A b_j^L}\otimes\eta_j^{b_j^R C}.
+    \end{align}
+    Here $\omega_j$ is the positive, not necessarily normalized conditional
+    factor from the bipartite marginal, and $\eta_j$ is the recovered
+    common-factor state. On the one-dimensional sectors complementary to the
+    minimum joint support, both sides vanish. No normalization or density
+    operator is chosen for these zero-weight sectors.
+
+    This is the final substitution in
+    \cite[Theorem~6, equations~(13)--(15)]{Hayden2004Structure},
+    lines~562--570, and the direct-sum identity in
+    \cite[Lemma~\textup{Lsigma3}, equation~\textup{eq:sigma3}]
+      {Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:hjpw_recovered_bipartite_ambient_blocks,
+        thm:hjpw_recovered_dilation_ambient_blocks}
+    Express each $A$-matrix entry of the recovered bipartite state in the
+    ambient direct sum. The block-coordinate recovery acts independently on
+    every common factor and as the identity on its conditional factor, so
+    the $j$-th block becomes
+    $\eta_j^{b_j^R C}\otimes\omega_j^{A b_j^L}$ in the
+    $b_j^R\otimes b_j^L$ factor order.
+    Exchange the two middle-system factors and commute the scalar matrix
+    entries to obtain
+    $\omega_j^{A b_j^L}\otimes\eta_j^{b_j^R C}$.
+    Distinct sectors give zero matrix entries, including every complementary
+    sector.
+\end{proof}
+
 \begin{theorem}[Hayashi SSA-equality characterization]
     \label{thm:hayashi_ssa_equality_characterization}
     \lean{hayashi_ssa_equality_characterization}
@@ -2054,10 +2107,11 @@ algebra of a family of jointly invariant states.
     all of $B$ and completes equations~(13)--(14).
     Theorem~\ref{thm:hjpw_recovered_dilation_ambient_blocks} supplies
     equation~(15), agreement with the Petz operation on the joint support,
-    and the recovered supported-sector states. Only transporting those
-    sector states into the tripartite direct sum and assembling the
-    quantum-Markov decomposition remain open, so this forward implication
-    remains axiomatic. The biconditional combines the two directions.
+    and the recovered supported-sector states.
+    Theorem~\ref{thm:hjpw_recovered_tripartite_ambient_blocks} transports
+    these states into the raw tripartite direct sum. Only its normalized
+    quantum-Markov assembly and removal of the forward axiom remain open.
+    The biconditional combines the two directions.
 
     This equality criterion is cited here as an input for the later MPDO arguments.
     It is the equality criterion needed by Appendix~C of arXiv:1606.00608.

--- a/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
+++ b/docs/paper-gaps/cpsv16_ssa_equality_hayashi_markov.tex
@@ -73,8 +73,10 @@ zero-weight complement sectors, completing HJPW equations~(13)--(14).
 The recovery-dilation block action of equation~(15) is now formalized by one
 chosen pure-ancilla unitary, including supported agreement with the Petz
 operation and normalized recovered states on the supported common-factor
-sectors. Transporting those sector states into the tripartite direct sum and
-assembling the quantum-Markov decomposition remain open. The reverse direction
+sectors. Those sector states are now transported into the raw tripartite
+direct sum of HJPW equations~(13)--(15), with zero complementary sectors and
+without normalized fillers. Assembling this raw form into the normalized
+quantum-Markov decomposition remains open. The reverse direction
 is proved from the entropy-additivity sub-lemmas listed below.
 
 \section{The point at issue: only the forward direction is consumed}
@@ -102,9 +104,10 @@ to ambient $B$ and prove HJPW equations~(13)--(14), with one-dimensional
 zero-weight sectors on the complement. Equation~(15) is also formalized:
 one chosen pure-ancilla unitary is block diagonal in those coordinates,
 agrees with the Petz operation on the joint support, and produces normalized
-supported-sector states with the prescribed common-factor marginals. The transport of
-those states into a tripartite direct sum and assembly of the quantum-Markov
-decomposition are still missing. Thus the family-level structural implication
+supported-sector states with the prescribed common-factor marginals. These
+states are now transported into the raw tripartite direct sum, including the
+zero complementary sectors. Assembly of its normalized quantum-Markov
+decomposition is still missing. Thus the family-level structural implication
 needed here remains open, which is why the forward direction is treated as an
 external assumption rather than proved. The recovery implication and the
 complementary trace-preserving extension of the support Petz map are no longer
@@ -715,8 +718,9 @@ traces sum to one. The final declaration proves the block-coordinate recovery
 dilation of equation~(15), supported agreement with the Petz operation, and
 the exact recovery identity. It also constructs positive trace-one recovered
 states on the supported common-factor sectors with the prescribed
-common-factor marginals. Transporting these states into the tripartite direct sum and
-assembling the quantum-Markov decomposition remain necessary before the
+common-factor marginals. Their transport into the raw tripartite direct sum is
+now formalized. Assembling the normalized quantum-Markov decomposition remains
+necessary before the
 forward external assumption can be removed.
 
 \section{Verdict}
@@ -724,7 +728,7 @@ forward external assumption can be removed.
 The strong-subadditivity equality characterization is now split into a proved
 reverse direction and a postulated forward direction. Only the forward
 direction, equality implies quantum-Markov-chain structure, still needs the
-tripartite sector-state transport and subsequent quantum-Markov assembly.
+normalized quantum-Markov assembly from the transported raw tripartite blocks.
 The full-support invariant-family state decomposition and preserving-operation
 block action are formalized. Source-facing
 completed-channel recovery from equality in data processing is available on
@@ -742,8 +746,9 @@ the same support coordinates. Those coordinates now extend to all of $B$ and
 prove the ambient HJPW equation~(14). The chosen block-coordinate dilation of
 equation~(15), its supported Petz agreement, and its normalized recovered
 supported-sector states are now formalized. Transporting those states to the
-tripartite sector blocks and assembling the quantum-Markov decomposition
-remain part of the irreducible unproved forward direction.
+tripartite sector blocks is now formalized; assembling the normalized
+quantum-Markov decomposition remains part of the irreducible unproved forward
+direction.
 
 \begin{thebibliography}{9}
 

--- a/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
+++ b/docs/paper-gaps/hjpw04_petz_factorization_maximally_mixed_scope.tex
@@ -174,15 +174,16 @@ with one-dimensional zero-weight complement sectors. One chosen
 pure-ancilla unitary now realizes the recovery-dilation block action of
 equation~(15), agrees with the Petz operation on the joint support, and
 produces normalized supported-sector states with the prescribed common-factor
-marginals. Transporting those states into the tripartite direct sum and
-assembling the quantum-Markov form remain open. The singular-support
+marginals. Those states are now transported into the raw tripartite direct
+sum, with zero complementary sectors and without normalized fillers.
+Assembling the normalized quantum-Markov form remains open. The singular-support
 equality-to-raw-recovery implication is now formalized by the projected
 finite-Weyl argument and transported to arbitrary finite product coordinates.
 For density operators, support agreement upgrades this equality to the chosen
 completed partial-trace Petz channel on the recovered marginal. This does not
 give a tensor-product factorization of the generic completed singular channel.
-Tripartite sector-state transport and quantum-Markov assembly are the
-remaining structural obstructions to replacing the forward Hayashi
+Normalized quantum-Markov assembly from the transported tripartite blocks is
+the remaining structural obstruction to replacing the forward Hayashi
 strong-subadditivity equality assumption used in the CPSV16 argument.
 
 \section{Common invariant algebra: formalized under an explicit full-support hypothesis}
@@ -318,7 +319,8 @@ extra source hypothesis. The declaration
 for one chosen pure-ancilla unitary, together with supported Petz agreement,
 the exact recovery identity, and normalized recovered states on the supported
 common-factor sectors. Transporting these states into the tripartite direct
-sum, assembling the generic quantum-Markov decomposition, and eliminating the
+sum is now formalized, including the zero complementary sectors. Assembling
+the generic normalized quantum-Markov decomposition and eliminating the
 external assumption for the forward Hayashi strong-subadditivity implication
 remain open.
 
@@ -360,7 +362,8 @@ zero-weight sectors on the orthogonal complement, and proves the full
 bipartite equation~(14). The chosen recovery-dilation block action of
 equation~(15), its supported Petz agreement, and normalized recovered
 supported-sector states are also formalized. Tripartite sector-state transport,
-quantum-Markov assembly, and the generic Hayashi forward implication remain
+including the zero complementary sectors, is now formalized. Normalized
+quantum-Markov assembly and the generic Hayashi forward implication remain
 open as sequential steps.
 
 \begin{thebibliography}{9}


### PR DESCRIPTION
## Summary

- transport the recovered ambient bipartite factors and dilation sector states into the exact HJPW tripartite direct-sum identity;
- expose the explicit `b_j^R ⊗ b_j^L` to `b_j^L ⊗ b_j^R` coordinate conversion and the correctly oriented Hayashi-facing unitary;
- keep complementary ambient sectors identically zero, without introducing normalized fillers or claiming final quantum-Markov assembly;
- add reusable rectangular-Kraus block/reindex and pure-ancilla coordinate-covariance lemmas at their shared ownership boundaries;
- synchronize Chapter 19 and the two HJPW/CPSV paper-gap notes.

## Source boundary

This PR formalizes the final substitution in HJPW Theorem 6, arXiv:quant-ph/0304007v2, lines 562–570:

`ρ_ABC = ⊕_j ω_j^{A b_j^L} ⊗ η_j^{b_j^R C}`.

It also matches CPSV16 Appendix C.2, Lemma `Lsigma3` / equation `eq:sigma3`. The source-facing theorem assumes only a tripartite density matrix and equality in strong subadditivity; the recovered-effect, ambient-block, and dilation witnesses are derived internally.

TNLean’s recovered coordinates use `b_j^R ⊗ b_j^L`; the public transport theorem proves the explicit swap to HJPW/Hayashi order `b_j^L ⊗ b_j^R`. Complement sectors remain zero. Probability normalization, zero-weight density fillers, construction of `HayashiMarkovDecomposition`, and removal of the forward axiom remain exclusively in successor LionSR/TNLean#5047.

## Architecture

- `KrausBlockTransport.lean`: dependent block-diagonal/spectator preservation and reindex covariance for rectangular Kraus maps;
- `RecoveredConditionalDilation/Covariance.lean`: inverse-coordinate covariance of pure-ancilla recovery;
- `RecoveredConditionalTripartiteBlockForm.lean`: HJPW-order ambient equivalences, zero/support output factors, exact block state, fixed-witness theorem, and source-facing existence wrapper;
- `TensorMap.lean`: promotes the pre-existing generic identity-tensor conjugation theorem and removes its private duplicate from the ambient block-form module.

Every production module is at or below the 1,000-line policy limit.

## Validation

Exact head: `4677d3afc0b7d293abd7df75d6686903d1e7c882` on base `864cbb4b0c4aac2c7d180c32b710d41c7733613f`.

- direct compiles for all new/shared modules and old callers: pass;
- generated Channel, dilation, and Koashi–Imoto aggregators: pass;
- full cache-backed `lake build`: pass, 9,798 jobs; no Mathlib source rebuild;
- changed-file integrity scan: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`;
- module policy/oversized guard: pass, zero files above 1,000 lines;
- tactic-pattern, reader-facing prose, Blueprint coverage, and `git diff --check`: pass;
- `leanblueprint web`: exit 0; visual success is not claimed because repo-wide renderer issue LionSR/TNLean#5045 remains open;
- `leanblueprint checkdecls`: pass;
- `leanblueprint pdf`: pass, 776 pages; physical pages 380–381 visually inspected and clean.

The full build reports one unrelated pre-existing `sorry` warning in `TNLean/MPS/Periodic/Overlap/SectorMatch.lean:600`. Four unsuppressed flexible-tactic linter suggestions remain in the new proof; they are style-only and replacing them with `simp only` did not close the dependent goals.

Closes LionSR/QICLean#259.
Depends on LionSR/TNLean#5046.
Precedes LionSR/TNLean#5047.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new dependent-type proofs in the Koashi–Imoto/HJPW chain; mistakes would be mathematical incorrectness rather than runtime/security issues, but the surface area and proof complexity are substantial.
> 
> **Overview**
> Formalizes the **raw HJPW tripartite direct-sum identity** at strong-subadditivity equality: after conjugating by the Hayashi-oriented middle unitary and swapping each fibre from recovered `b_j^R ⊗ b_j^L` order to **`b_j^L ⊗ b_j^R`**, the state is **`⊕_j ω_j ⊗ η_j`**, with **zero complementary sectors** and no normalized fillers.
> 
> **New Lean modules:** `KrausBlockTransport` (block-diagonal rectangular Kraus maps and reindex covariance), `RecoveredConditionalDilation/Covariance` (pure-ancilla recovery under unitary coordinate change), and **`RecoveredConditionalTripartiteBlockForm`** (HJPW equivalences, block recovery, `exists_recoveredConditionalTripartiteBlockForm` from SSA equality). **`idTensorMap_conjugation`** is promoted to `TensorMap.lean`; several ambient support lemmas are exported from dilation `Basic` for reuse.
> 
> Blueprint Chapter 19 and the HJPW/CPSV paper-gap notes are updated to record that tripartite transport is proved; **normalized quantum-Markov assembly** remains open (successor work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4677d3afc0b7d293abd7df75d6686903d1e7c882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
