### PR TITLE
fix(tenkz): synchronize GHZ ink metadata

### DIFF
--- a/tests/tenkz/rmp/manifest.toml
+++ b/tests/tenkz/rmp/manifest.toml
@@ -901,7 +901,7 @@ section = "section-iii-a"
 order = 54
 case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-state.tex"
 formula = "|CZX> = blocking of (x)_{i,j} |GHZ_ij> ,"
-ink = "Canonical public tenkzlattice environment; no raw TikZ."
+ink = "Canonical public tenkzfree masonry checkerboard with staggered GHZ dot nodes."
 boundary = "Resolved by the public environment; open indices remain explicit."
 source = "paper TN-Review-main.tex line 1446; author source ImagesReview Section III/ImagesReview Section III.tex lines 329-356"
 capabilities = ["free-graph", "typed-ports"]
@@ -1984,7 +1984,7 @@ section = "section-iii-a"
 order = 27
 case = "tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-ghz-state-workbench.tex"
 formula = "The cluster-state workbench alternates up and down GHZ copy tensors."
-ink = "Canonical public tenkzlattice 3x4 staggered GHZ pattern."
+ink = "Canonical public tenkzfree masonry checkerboard with staggered GHZ dot nodes."
 boundary = "Horizontal copy bonds are open at the left and right boundaries."
 source = "author source ImagesReview Section III/ImagesReview Section III.tex lines 329-356; archival output ghzstate.pdf"
 capabilities = ["free-graph", "staggered-sites", "copy-tensor"]

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-state.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-ghz-state.tex
@@ -1,6 +1,6 @@
 % Target: rmp-iii-a-ghz-state
 % Formula: |CZX> = blocking of (x)_{i,j} |GHZ_ij> ,
-% Ink: Canonical public tenkzlattice environment; no raw TikZ.
+% Ink: Canonical public tenkzfree masonry checkerboard with staggered GHZ dot nodes.
 % Boundary: Resolved by the public environment; open indices remain explicit.
 % Source: paper TN-Review-main.tex line 1446; author source ImagesReview Section
 %   III/ImagesReview Section III.tex lines 329-356

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-ghz-state-workbench.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-ghz-state-workbench.tex
@@ -1,6 +1,6 @@
 % Target: rmp-workbench-iii-ghz-state-workbench
 % Formula: The cluster-state workbench alternates up and down GHZ copy tensors.
-% Ink: Canonical public tenkzlattice 3x4 staggered GHZ pattern.
+% Ink: Canonical public tenkzfree masonry checkerboard with staggered GHZ dot nodes.
 % Boundary: Horizontal copy bonds are open at the left and right boundaries.
 % Source: author source ImagesReview Section III/ImagesReview Section III.tex
 %   lines 329-356; archival output ghzstate.pdf

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -2,7 +2,7 @@
 # Schema: scripts/tenkz_rmp.py (load_verdicts).  Any status may be
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
-campaign_sha256 = "ec9466395efd0a9e42db78f30a6fc1a47001f8ee69dd09aa0d571d7037011735"
+campaign_sha256 = "75ee5bbae378431847f00ff1ec53f04fd42163cdb03c93952560ff7c33b01949"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"
@@ -585,7 +585,7 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = []
-case_sha256 = "e2b5df2b4ed6e773e2988e8fcd7ab4f300db7ebaaef8a7d6ecf5e1a0df485702"
+case_sha256 = "6d28f37dc9c4709d8f513c76e253a713d60c0fac566fba7d4c79669cd4468846"
 reviewed = "2026-07-26"
 renderer = "fable-countersign-reading-2026-07-26-200dpi"
 note = "masonry patch with diagonal stubs; truncated to the line cap (#4931 for the lattice-genre gaps)"
@@ -1269,7 +1269,7 @@ status = "cosmetic-gap"
 pairing = "verified"
 pairing_by = "codex-pairing-sweep-2026-07-24"
 defects = []
-case_sha256 = "79a14233161fe53d54bce99a1f6a77ba6f3da19a5c16bffb101bf4e8739e2901"
+case_sha256 = "9f1941da3694c489e3559f67f1b3bf01f54b79057e1ec10cfc53c4444b9876b0"
 reviewed = "2026-07-27"
 renderer = "fable-wave-a-acceptance-2026-07-27-200dpi"
 note = "the dense masonry checkerboard, transcribed as the equivalence twin of rmp-iii-a-ghz-state -- both targets cite author lines 329-356 -- with the twin declared in the manifest"


### PR DESCRIPTION
Closes LionSR/tenkz#102.

## What changed

- replace the stale `tenkzlattice` Ink descriptions with the actual
  `tenkzfree` masonry checkerboard description
- apply the same correction to the paired published and author-workbench GHZ
  targets, keeping their headers and manifest entries identical
- regenerate both affected `case_sha256` values and the campaign digest

## Root cause

The GHZ drawings were redrawn with the free-graph surface, but their
human-readable provenance retained the former lattice-environment wording.
Because header and manifest strings agreed with each other, consistency
validation could not detect that both copies were stale.

## Verification

- `git diff --check`
- `python3 scripts/tenkz_rmp.py check --id rmp-iii-a-ghz-state`
- `python3 scripts/tenkz_rmp.py check --id rmp-workbench-iii-ghz-state-workbench`
- `python3 scripts/tenkz_rmp.py book --all` (all 130 targets passed; 286-page
  benchmark book generated)
- rendered and visually inspected the corrected evidence pages 116 and 250

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and benchmark ledger updates only; no rendering or diagram body changes.
> 
> **Overview**
> **Ink provenance** for the published `rmp-iii-a-ghz-state` and twin workbench `rmp-workbench-iii-ghz-state-workbench` targets now describes a **`tenkzfree` masonry checkerboard with staggered GHZ dot nodes**, replacing stale **`tenkzlattice`** wording that no longer matched the redrawn cases.
> 
> The same **Ink** string is applied in **manifest** entries, **case** header comments, and kept aligned so `tenkz_rmp.py` header checks stay consistent. **`verdicts.toml`** picks up new **`case_sha256`** values for both targets (header-only change) and an updated **`campaign_sha256`** digest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cdb3f0dba4c9d5425114732a066552885fae4bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->