### PR TITLE
doc(tenkz): document the rebuild toolchain

### DIFF
--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -107,8 +107,11 @@ and TeX epoch.  The exact-toolchain pins in
 after an approved XeTeX, Poppler, font, or intentional render change, inspect
 the full-resolution fixtures.  Before re-pinning, run
 `scripts/tenkz_kernel_probes.sh --check`: an expected pixel mismatch is
-acceptable, but its event-stream comparison must remain clean unless a separate
-event-contract change was also reviewed.  Then re-pin with
+acceptable, but every non-pixel probe must pass, including structural
+assertions, sugar-expansion parity, and the event-stream comparison.  If a
+separate reviewed contract change intentionally affects a non-pixel pin, review
+and update that contract first, then rerun until every non-pixel probe passes.
+Do not snapshot after any non-pixel failure.  Then re-pin with
 `scripts/tenkz_kernel_probes.sh --snapshot`, which updates both the pixel and
 event ledgers.
 
@@ -132,6 +135,21 @@ python3 scripts/tenkz_shrink.py flags
 python3 scripts/tenkz_shrink.py gate --base-ref origin/main
 ```
 
+When an intentional registry or demand-corpus change alters a meter, compute
+and review the new baseline before the gate:
+
+```sh
+python3 scripts/tenkz_shrink.py meters > /tmp/tenkz-census-baseline.json
+diff -u tests/tenkz/census-baseline.json /tmp/tenkz-census-baseline.json
+cp /tmp/tenkz-census-baseline.json tests/tenkz/census-baseline.json
+python3 scripts/tenkz_shrink.py gate --base-ref origin/main
+```
+
+At the start of a new 0.9 or 1.0 shrink session, advance
+`CURRENT_MILESTONE` in `scripts/tenkz_shrink.py` in the same change.  The
+`flags` and `gate` actions use that constant to decide which alias sunsets are
+due.
+
 The registry's implementation ledgers are `kernel` and `sugar(...)`: kernel
 rows are one-in-one-out vocabulary, while sugar rows must expand into kernel
 spellings and earn continued use.  The other status words record lifecycle
@@ -139,17 +157,20 @@ debt: `alias(...; sunset=...)` reads old sources until its stated rewrite, and
 `escape` names raw geometry whose uses count in meter M3.
 
 The gate first compares the pinned meters with the base revision.  M1 total or
-kernel growth requires an extension, or a census correction while parser
-identities are unchanged; command or environment growth requires an extension.
-M2 path-count growth and every parser-leaf identity change, including
-replacement or removal, require an `Extension-gate: #NNNN` citation.  M3 or M4
-growth requires a census correction.  M5 alias-count growth is rejected
-unconditionally, and every alias must have a valid sunset.  M6 component growth
-requires a census correction while parser identities are unchanged.
+kernel growth requires an `Extension-gate: #NNNN` citation, or a
+`Census-correction: #NNNN` citation while parser identities are unchanged;
+command or environment growth permits only the extension citation.  M2
+path-count growth and every parser-leaf identity change, including replacement
+or removal, require the extension citation.  M3 or M4 growth requires the
+census-correction citation.  M6 component growth also requires a census
+correction while parser identities are unchanged.  M5 alias-count growth is
+rejected unconditionally, and every alias must have a valid sunset.
 
 After that ratchet passes, a public-census decrease is accepted.  Otherwise,
 every raised low-consumer, co-occurrence, lonely-type, sugar-shaped, and due
 alias-sunset flag needs a verdict in the latest `docs/tenkz/SHRINK.md` session.
+The ledger is append-only: retain the entire pre-change file byte-for-byte as a
+prefix and add corrections and verdicts in a new final session section.
 
 ## Shared parsers
 
@@ -174,7 +195,7 @@ library.  Never add another parser for syntax already parsed by
 
 ## Stage ownership
 
-Each stage file begins with its complete input, output, owned-state, invariant,
+Each stage file begins with its declared input, output, owned-state, invariant,
 and next-stage contract.
 
 These are normative ownership rules for new code and migration destinations,

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -105,8 +105,12 @@ not cross-revision redraw evidence because raster bytes depend on the machine
 and TeX epoch.  The exact-toolchain pins in
 `tests/tenkz/kernel/golden-pixels.sha256` are a narrower regression gate:
 after an approved XeTeX, Poppler, font, or intentional render change, inspect
-the full-resolution fixtures and re-pin them with
-`scripts/tenkz_kernel_probes.sh --snapshot`.
+the full-resolution fixtures.  Before re-pinning, run
+`scripts/tenkz_kernel_probes.sh --check`: an expected pixel mismatch is
+acceptable, but its event-stream comparison must remain clean unless a separate
+event-contract change was also reviewed.  Then re-pin with
+`scripts/tenkz_kernel_probes.sh --snapshot`, which updates both the pixel and
+event ledgers.
 
 This command exists for the redraw campaign and expires at its close, no later
 than 1.0.  Do not turn it into a permanent raster manifest.
@@ -143,7 +147,10 @@ extension or census-correction procedure.
 
 ## Shared parsers
 
-`scripts/tenkzlib/tnlog.py` is the single parser for `.tnlog` event streams.
+`scripts/tenkzlib/tnlog.py` is the canonical schema-validating parser for
+`.tnlog` event streams.  Use it whenever a checker needs structured event
+fields.  `scripts/test_tenkz_cd_map_labels.py` still has two direct field-parser
+exceptions; keep them aligned until they are migrated to `tnlog.py`.
 `scripts/tenkzlib/texcase.py` provides shared TeX comment stripping,
 balanced-group matching, and picture-construct scanning.  Import these modules
 when adding or modifying a checker that needs those answers.
@@ -182,8 +189,9 @@ scripts/tenkz_golden.sh --check
 scripts/tenkz_pixelpair.sh origin/main
 ```
 
-The golden gate proves event-stream parity.  The same-session pixel pair proves
-render parity only for the fixtures listed in
+The golden gate proves event-stream parity for the top-level corpus fixtures.
+Run the applicable suite-specific semantic gates for affected nested fixtures.
+The same-session pixel pair proves render parity only for the fixtures listed in
 `tests/tenkz/pixelpair-sources.txt`.  If a change can affect a fixture outside
 that manifest, add the affected fixture to the comparison or attach reviewed
 replacement render evidence.  If a reviewed contract or drawing intentionally

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -40,6 +40,8 @@ python3 scripts/tenkz_rmp.py check --section <section>
 python3 scripts/tenkz_rmp.py check --all
 python3 scripts/tenkz_rmp.py book --all
 python3 scripts/tenkz_rmp.py render --all
+python3 scripts/tenkz_rmp.py compare --all \
+  --source-root /absolute/path/to/author-source-tree
 ```
 
 The comparison command requires a separate author-source tree supplied through
@@ -170,10 +172,13 @@ scripts/tenkz_golden.sh --check
 scripts/tenkz_pixelpair.sh origin/main
 ```
 
-The golden gate proves event-stream parity; the same-session pixel pair proves
-render parity.  If a reviewed contract or drawing intentionally changes, state
-the affected fixtures and attach the reviewed replacement evidence instead of
-claiming parity.
+The golden gate proves event-stream parity.  The same-session pixel pair proves
+render parity only for the fixtures listed in
+`tests/tenkz/pixelpair-sources.txt`.  If a change can affect a fixture outside
+that manifest, add the affected fixture to the comparison or attach reviewed
+replacement render evidence.  If a reviewed contract or drawing intentionally
+changes, state the affected fixtures and attach the reviewed replacement
+evidence instead of claiming parity.
 
 The demolition checker remains a temporary guard against restoring retired
 catalogue paths and expires at the 0.8 close, after branches predating the

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -138,14 +138,18 @@ spellings and earn continued use.  The other status words record lifecycle
 debt: `alias(...; sunset=...)` reads old sources until its stated rewrite, and
 `escape` names raw geometry whose uses count in meter M3.
 
-The gate compares the pinned meters with the base revision.  It passes when
-the public census decreases, or when the census is stable and every raised
-low-consumer, co-occurrence, lonely-type, or sugar-shaped flag has a verdict in
-the latest `docs/tenkz/SHRINK.md` session.  Alias-sunset flags require verdicts
-there as soon as their milestone is due.  Meter growth requires the recorded
-extension or census-correction procedure.  Any parser-leaf identity change,
-including a one-for-one replacement or removal, requires an
-`Extension-gate: #NNNN` citation even when the M2 count is stable or decreases.
+The gate first compares the pinned meters with the base revision.  M1 total or
+kernel growth requires an extension, or a census correction while parser
+identities are unchanged; command or environment growth requires an extension.
+M2 path-count growth and every parser-leaf identity change, including
+replacement or removal, require an `Extension-gate: #NNNN` citation.  M3 or M4
+growth requires a census correction.  M5 alias-count growth is rejected
+unconditionally, and every alias must have a valid sunset.  M6 component growth
+requires a census correction while parser identities are unchanged.
+
+After that ratchet passes, a public-census decrease is accepted.  Otherwise,
+every raised low-consumer, co-occurrence, lonely-type, sugar-shaped, and due
+alias-sunset flag needs a verdict in the latest `docs/tenkz/SHRINK.md` session.
 
 ## Shared parsers
 
@@ -177,10 +181,14 @@ and next-stage contract.
   dimension accessor.
 - `tenkz-geometry.code.tex` owns frames, placement resolution, directions, and
   silhouette support distances; it emits no ink.
-- `tenkz-render.code.tex` owns mark emission from frozen records and resolved
-  geometry; it parses nothing and stores no topology.
+- `tenkz-render.code.tex` owns final mark and string emission from frozen
+  records and resolved geometry; it parses nothing and stores no topology.
 - `tenkz-string.code.tex` owns saved string paths and the crossing, join, and
   gap ledgers consumed by rendering.
+
+Until string/render integration is complete, string fixtures use the temporary
+`\__tenkz_string_dev_draw:nn` primitive in `tenkz-string.code.tex`, which issues
+the development `\draw` directly.
 
 Read the header before changing a stage, and keep new state in the stage that
 owns its answer.

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -135,8 +135,9 @@ python3 scripts/tenkz_shrink.py flags
 python3 scripts/tenkz_shrink.py gate --base-ref origin/main
 ```
 
-When an intentional registry or demand-corpus change alters a meter, compute
-and review the new baseline before the gate:
+When any intentional change alters a computed meter—including a registry,
+demand-corpus, or parser-source identity change—compute and review the new
+baseline before the gate:
 
 ```sh
 python3 scripts/tenkz_shrink.py meters > /tmp/tenkz-census-baseline.json

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -40,8 +40,12 @@ python3 scripts/tenkz_rmp.py check --section <section>
 python3 scripts/tenkz_rmp.py check --all
 python3 scripts/tenkz_rmp.py book --all
 python3 scripts/tenkz_rmp.py render --all
-python3 scripts/tenkz_rmp.py compare --all --source-root tex/RMP_TIKZ_SOURCE_CODE
 ```
+
+The comparison command requires a separate author-source tree supplied through
+`--source-root`.  That tree is not part of this repository, so comparison is not
+a clean-checkout build command.  Run it only in a source-pairing session with an
+explicit external tree.
 
 Per-target verdicts are stored in `tests/tenkz/rmp/verdicts.toml`, one
 stanza per target.  Any status may be recorded, including failure; the check
@@ -60,6 +64,118 @@ scripts/tenkz_corpus.sh --render
 
 Both suites may share lower-level helpers; neither frontend changes the
 other's defaults.
+
+## Golden event streams
+
+The event ledger is `tests/tenkz/golden-events.sha256`.
+
+```sh
+scripts/tenkz_golden.sh --check
+```
+
+The check recompiles every standalone fixture and requires each `.tnlog` event
+stream to be byte-identical to the stored SHA-256 baseline.  Run the command
+without an argument to take a new snapshot:
+
+```sh
+scripts/tenkz_golden.sh
+```
+
+Re-pin only when fixture source changes and the new event stream has been
+reviewed as the intended contract.  Package-only changes must pass `--check`;
+they do not authorize a new baseline.
+
+## Same-session pixel pairs
+
+Pixel evidence compares two package revisions in one session:
+
+```sh
+scripts/tenkz_pixelpair.sh origin/main
+```
+
+The command creates a detached worktree at the base revision, renders the
+renderer-only source manifest against that true legacy package and the current
+package, rasterizes both at 300 dpi, and compares the paired pages byte for
+byte.  A copied package tree is not a legacy control.  Stored raster hashes are
+not evidence because raster bytes depend on the machine and TeX epoch.
+
+This command exists for the redraw campaign and expires at its close, no later
+than 1.0.  Do not turn it into a permanent raster manifest.
+
+## Shrink sessions
+
+The shrink checker reports six meters:
+
+1. public vocabulary census;
+2. parser-leaf paths;
+3. escape-spelling use in the demand corpus;
+4. mean non-comment lines across the 130 RMP cases;
+5. aliases and their sunsets;
+6. overloaded names, union types, and shared enum words.
+
+```sh
+python3 scripts/tenkz_shrink.py meters
+python3 scripts/tenkz_shrink.py flags
+python3 scripts/tenkz_shrink.py gate --base-ref origin/main
+```
+
+The registry's implementation ledgers are `kernel` and `sugar(...)`: kernel
+rows are one-in-one-out vocabulary, while sugar rows must expand into kernel
+spellings and earn continued use.  The other status words record lifecycle
+debt: `alias(...; sunset=...)` reads old sources until its stated rewrite, and
+`escape` names raw geometry whose uses count in meter M3.
+
+The gate compares the pinned meters with the base revision.  It passes when
+the public census decreases, or when the census is stable and every raised
+low-consumer, co-occurrence, lonely-type, or sugar-shaped flag has a verdict in
+the latest `docs/tenkz/SHRINK.md` session.  Meter growth requires the recorded
+extension or census-correction procedure.
+
+## Shared parsers
+
+`scripts/tenkzlib/tnlog.py` is the single parser for `.tnlog` event streams.
+`scripts/tenkzlib/texcase.py` owns TeX comment stripping and case-header
+extraction.  Import these modules whenever a checker needs those answers.
+Never re-parse syntax already parsed by `scripts/tenkzlib/`.
+
+## Stage ownership
+
+Each stage file begins with its complete input, output, owned-state, invariant,
+and next-stage contract.
+
+- `tenkz-model.code.tex` owns normalized semantic records and freezes topology
+  after validation.
+- `tenkz-metric.code.tex` owns the motivated metric registry and its sole
+  dimension accessor.
+- `tenkz-geometry.code.tex` owns frames, placement resolution, directions, and
+  silhouette support distances; it emits no ink.
+- `tenkz-render.code.tex` owns mark emission from frozen records and resolved
+  geometry; it parses nothing and stores no topology.
+- `tenkz-string.code.tex` owns saved string paths and the crossing, join, and
+  gap ledgers consumed by rendering.
+
+Read the header before changing a stage, and keep new state in the stage that
+owns its answer.
+
+## Pull-request evidence
+
+Every change under `tex/tenkz/` records both semantic and visual evidence in
+the pull-request body:
+
+```sh
+scripts/tenkz_golden.sh --check
+scripts/tenkz_pixelpair.sh origin/main
+```
+
+The golden gate proves event-stream parity; the same-session pixel pair proves
+render parity.  If a reviewed contract or drawing intentionally changes, state
+the affected fixtures and attach the reviewed replacement evidence instead of
+claiming parity.
+
+The demolition checker remains a temporary guard against restoring retired
+catalogue paths and expires at the 0.8 close, after branches predating the
+demolition have landed or died.  The pixel-pair command expires with the redraw
+campaign at 1.0.
 
 ## Audit and visual review
 

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -173,6 +173,14 @@ alias-sunset flag needs a verdict in the latest `docs/tenkz/SHRINK.md` session.
 The ledger is append-only: retain the entire pre-change file byte-for-byte as a
 prefix and add corrections and verdicts in a new final session section.
 
+A verdict is a table row whose first cell is the exact `flag:*` ID printed by
+`flags` (escape an internal table pipe as `\|`).  Its second cell must begin
+with one of `keep-because`, `keep`, `dies`, `demoted`, `folds`, `respelled`,
+`becomes`, `moves`, `confirmed`, `confirmed merge`, `tombstoned`,
+`sugar preset`, or `executes`, and must include an unexpired
+`expiry <milestone>`, `permanent`, or `executes at the <milestone> freeze`
+lifetime.  Prose outside such a row is not a machine-readable verdict.
+
 ## Shared parsers
 
 `scripts/tenkzlib/tnlog.py` is the canonical schema-validating parser for

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -75,17 +75,19 @@ The event ledger is `tests/tenkz/golden-events.sha256`.
 scripts/tenkz_golden.sh --check
 ```
 
-The check recompiles every standalone fixture and requires each `.tnlog` event
-stream to be byte-identical to the stored SHA-256 baseline.  Run the command
-without an argument to take a new snapshot:
+The check recompiles every top-level `tests/tenkz/*.tex` standalone fixture and
+requires each `.tnlog` event stream to be byte-identical to the stored SHA-256
+baseline.  Nested suites such as `tests/tenkz/kernel/` have their own gates.
+Run the command without an argument to take a new snapshot:
 
 ```sh
 scripts/tenkz_golden.sh
 ```
 
-Re-pin only when fixture source changes and the new event stream has been
-reviewed as the intended contract.  Package-only changes must pass `--check`;
-they do not authorize a new baseline.
+Re-pin only when fixture source changes or a reviewed package contract change
+intentionally changes the emitted events, and the new streams have been
+reviewed as the intended contract.  Behavior-preserving package changes must
+pass `--check`; they do not authorize a new baseline.
 
 ## Same-session pixel pairs
 
@@ -99,7 +101,12 @@ The command creates a detached worktree at the base revision, renders the
 renderer-only source manifest against that true legacy package and the current
 package, rasterizes both at 300 dpi, and compares the paired pages byte for
 byte.  A copied package tree is not a legacy control.  Stored raster hashes are
-not evidence because raster bytes depend on the machine and TeX epoch.
+not cross-revision redraw evidence because raster bytes depend on the machine
+and TeX epoch.  The exact-toolchain pins in
+`tests/tenkz/kernel/golden-pixels.sha256` are a narrower regression gate:
+after an approved XeTeX, Poppler, font, or intentional render change, inspect
+the full-resolution fixtures and re-pin them with
+`scripts/tenkz_kernel_probes.sh --snapshot`.
 
 This command exists for the redraw campaign and expires at its close, no later
 than 1.0.  Do not turn it into a permanent raster manifest.
@@ -137,11 +144,14 @@ extension or census-correction procedure.
 ## Shared parsers
 
 `scripts/tenkzlib/tnlog.py` is the single parser for `.tnlog` event streams.
-`scripts/tenkzlib/texcase.py` owns TeX comment stripping, balanced-group
-matching, and picture-construct scanning.  Import these modules whenever a
-checker needs those answers.  RMP case-header extraction remains local to
-`scripts/tenkz_rmp.py`; do not claim it as shared until it moves into the
-library.  Never re-parse syntax already parsed by `scripts/tenkzlib/`.
+`scripts/tenkzlib/texcase.py` provides shared TeX comment stripping,
+balanced-group matching, and picture-construct scanning.  Import these modules
+when adding or modifying a checker that needs those answers.
+`scripts/tenkz_shrink.py` still carries the local `_group_payload` exception;
+keep its behavior aligned until it is migrated to `texcase.py`.  RMP case-header
+extraction remains local to `scripts/tenkz_rmp.py`; do not claim it as shared
+until it moves into the library.  Never add another parser for syntax already
+parsed by `scripts/tenkzlib/`.
 
 ## Stage ownership
 

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -143,9 +143,9 @@ the public census decreases, or when the census is stable and every raised
 low-consumer, co-occurrence, lonely-type, or sugar-shaped flag has a verdict in
 the latest `docs/tenkz/SHRINK.md` session.  Alias-sunset flags require verdicts
 there as soon as their milestone is due.  Meter growth requires the recorded
-extension or census-correction procedure.  A one-for-one parser-leaf change can
-leave the M2 count stable while changing its identity fingerprint; it still
-requires an `Extension-gate: #NNNN` citation.
+extension or census-correction procedure.  Any parser-leaf identity change,
+including a one-for-one replacement or removal, requires an
+`Extension-gate: #NNNN` citation even when the M2 count is stable or decreases.
 
 ## Shared parsers
 

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -177,9 +177,10 @@ A verdict is a table row whose first cell is the exact `flag:*` ID printed by
 `flags` (escape an internal table pipe as `\|`).  Its second cell must begin
 with one of `keep-because`, `keep`, `dies`, `demoted`, `folds`, `respelled`,
 `becomes`, `moves`, `confirmed`, `confirmed merge`, `tombstoned`,
-`sugar preset`, or `executes`, and must include an unexpired
-`expiry <milestone>`, `permanent`, or `executes at the <milestone> freeze`
-lifetime.  Prose outside such a row is not a machine-readable verdict.
+or `sugar preset` and include an unexpired `expiry <milestone>` or `permanent`
+lifetime.  The alternative execution form must begin exactly
+`executes at the <milestone> freeze`.  Prose outside such a row is not a
+machine-readable verdict.
 
 ## Shared parsers
 

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -143,14 +143,20 @@ the public census decreases, or when the census is stable and every raised
 low-consumer, co-occurrence, lonely-type, or sugar-shaped flag has a verdict in
 the latest `docs/tenkz/SHRINK.md` session.  Alias-sunset flags require verdicts
 there as soon as their milestone is due.  Meter growth requires the recorded
-extension or census-correction procedure.
+extension or census-correction procedure.  A one-for-one parser-leaf change can
+leave the M2 count stable while changing its identity fingerprint; it still
+requires an `Extension-gate: #NNNN` citation.
 
 ## Shared parsers
 
 `scripts/tenkzlib/tnlog.py` is the canonical schema-validating parser for
 `.tnlog` event streams.  Use it whenever a checker needs structured event
-fields.  `scripts/test_tenkz_cd_map_labels.py` still has two direct field-parser
-exceptions; keep them aligned until they are migrated to `tnlog.py`.
+fields.  Some narrow regression tests still inspect raw lines directly,
+including `scripts/test_tenkz_cd_map_labels.py`,
+`scripts/test_tenkz_enclosures.py`, and `scripts/test_tenkz_peps_torus.py`.
+Before changing event syntax, field order, or validation, search every `.tnlog`
+consumer and update or migrate these exceptions; do not assume the canonical
+parser is their only dependency.
 `scripts/tenkzlib/texcase.py` provides shared TeX comment stripping,
 balanced-group matching, and picture-construct scanning.  Import these modules
 when adding or modifying a checker that needs those answers.

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -164,16 +164,24 @@ parser is their only dependency.
 `scripts/tenkzlib/texcase.py` provides shared TeX comment stripping,
 balanced-group matching, and picture-construct scanning.  Import these modules
 when adding or modifying a checker that needs those answers.
-`scripts/tenkz_shrink.py` still carries the local `_group_payload` exception;
-keep its behavior aligned until it is migrated to `texcase.py`.  RMP case-header
-extraction remains local to `scripts/tenkz_rmp.py`; do not claim it as shared
-until it moves into the library.  Never add another parser for syntax already
-parsed by `scripts/tenkzlib/`.
+Known local balanced-group parsers remain in
+`scripts/tenkz_shrink.py::_group_payload` and
+`scripts/tenkz_language.py::_group`; keep both aligned until they migrate to
+`texcase.py`.  RMP case-header extraction remains local to
+`scripts/tenkz_rmp.py`; do not claim it as shared until it moves into the
+library.  Never add another parser for syntax already parsed by
+`scripts/tenkzlib/`.
 
 ## Stage ownership
 
 Each stage file begins with its complete input, output, owned-state, invariant,
 and next-stage contract.
+
+These are normative ownership rules for new code and migration destinations,
+not a claim that every historical path has moved.  The live `tenkz-core`,
+`tenkz-grid`, `tenkz-cd`, `tenkz-lattice`, and `tenkz-free` files still combine
+some parsing, geometry, rendering, and event work; direct `\draw` or `\node`
+emission in those files remains migration debt.
 
 - `tenkz-model.code.tex` owns normalized semantic records and freezes topology
   after validation.
@@ -186,7 +194,8 @@ and next-stage contract.
 - `tenkz-string.code.tex` owns saved string paths and the crossing, join, and
   gap ledgers consumed by rendering.
 
-Until string/render integration is complete, string fixtures use the temporary
+The string stage has one further explicit exception: until string/render
+integration is complete, string fixtures use the temporary
 `\__tenkz_string_dev_draw:nn` primitive in `tenkz-string.code.tex`, which issues
 the development `\draw` directly.
 

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -128,15 +128,18 @@ debt: `alias(...; sunset=...)` reads old sources until its stated rewrite, and
 The gate compares the pinned meters with the base revision.  It passes when
 the public census decreases, or when the census is stable and every raised
 low-consumer, co-occurrence, lonely-type, or sugar-shaped flag has a verdict in
-the latest `docs/tenkz/SHRINK.md` session.  Meter growth requires the recorded
+the latest `docs/tenkz/SHRINK.md` session.  Alias-sunset flags require verdicts
+there as soon as their milestone is due.  Meter growth requires the recorded
 extension or census-correction procedure.
 
 ## Shared parsers
 
 `scripts/tenkzlib/tnlog.py` is the single parser for `.tnlog` event streams.
-`scripts/tenkzlib/texcase.py` owns TeX comment stripping and case-header
-extraction.  Import these modules whenever a checker needs those answers.
-Never re-parse syntax already parsed by `scripts/tenkzlib/`.
+`scripts/tenkzlib/texcase.py` owns TeX comment stripping, balanced-group
+matching, and picture-construct scanning.  Import these modules whenever a
+checker needs those answers.  RMP case-header extraction remains local to
+`scripts/tenkz_rmp.py`; do not claim it as shared until it moves into the
+library.  Never re-parse syntax already parsed by `scripts/tenkzlib/`.
 
 ## Stage ownership
 

--- a/docs/tenkz/chapters2/ch-rmp.tex
+++ b/docs/tenkz/chapters2/ch-rmp.tex
@@ -27,11 +27,12 @@ python3 scripts/tenkz_rmp.py check --section <section>
 python3 scripts/tenkz_rmp.py check --all
 python3 scripts/tenkz_rmp.py book --all
 python3 scripts/tenkz_rmp.py render --all
-python3 scripts/tenkz_rmp.py compare --all --source-root tex/RMP_TIKZ_SOURCE_CODE
+python3 scripts/tenkz_rmp.py compare --all --source-root /absolute/path/to/author-source-tree
 \end{Verbatim}
 
 The benchmark style controls typography only.  It does not extend tenkz.
-Reference comparisons are compiled temporarily from mapped author-source
-blocks; prebuilt PDFs are not design evidence.  Targets without author
-drawing source do not pretend that a reference implementation exists.  They
-carry the status \texttt{paper-context-}\allowbreak\texttt{only}.
+The separate author-source tree is not part of this repository.  Reference
+comparisons are compiled temporarily from its mapped source blocks; prebuilt
+PDFs are not design evidence.  Targets without author drawing source do not
+pretend that a reference implementation exists.  They carry the status
+\texttt{paper-context-}\allowbreak\texttt{only}.

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -280,8 +280,9 @@ _INK_TOKEN = re.compile(
 # Saving geometry for later string surgery creates no visible ink.  Keep this
 # state-owner operation out of the raw-rendering debt meter.
 _SAVED_PATH_CAPTURE = re.compile(r"\\path\s*\[([^]]*\bspath/save\s*=[^]]*)\]")
-_VISIBLE_PATH_OPTION = re.compile(
-    r"(?:^|,)\s*(?:draw|fill|shade|pattern|preaction|postaction)\b"
+_CAPTURE_ONLY_OPTIONS = re.compile(
+    r"^\s*spath/save\s*=\s*(?:\{[^{}]*\}|[^,\]]+)\s*"
+    r"(?:,\s*use~Hobby~shortcut\s*)?$"
 )
 _DECIMAL = re.compile(r"(?<![\w@.])\d*\.\d+")
 # Only metric-table DEFINITIONS are exempt; a stray literal multiplying a
@@ -292,7 +293,7 @@ _RENDER_PRIMITIVE_REF = re.compile(r"\\__tenkz_ink_[A-Za-z@:_]+")
 
 def ink_token_count(line: str) -> int:
     captures = sum(
-        _VISIBLE_PATH_OPTION.search(match.group(1)) is None
+        _CAPTURE_ONLY_OPTIONS.fullmatch(match.group(1)) is not None
         for match in _SAVED_PATH_CAPTURE.finditer(line)
     )
     return len(_INK_TOKEN.findall(line)) - captures

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -279,7 +279,10 @@ _INK_TOKEN = re.compile(
 )
 # Saving geometry for later string surgery creates no visible ink.  Keep this
 # state-owner operation out of the raw-rendering debt meter.
-_SAVED_PATH_CAPTURE = re.compile(r"\\path\s*\[[^]]*\bspath/save\s*=")
+_SAVED_PATH_CAPTURE = re.compile(r"\\path\s*\[([^]]*\bspath/save\s*=[^]]*)\]")
+_VISIBLE_PATH_OPTION = re.compile(
+    r"(?:^|,)\s*(?:draw|fill|shade|pattern|preaction|postaction)\b"
+)
 _DECIMAL = re.compile(r"(?<![\w@.])\d*\.\d+")
 # Only metric-table DEFINITIONS are exempt; a stray literal multiplying a
 # metric macro in drawing code is exactly the debt this meter measures.
@@ -288,7 +291,11 @@ _RENDER_PRIMITIVE_REF = re.compile(r"\\__tenkz_ink_[A-Za-z@:_]+")
 
 
 def ink_token_count(line: str) -> int:
-    return len(_INK_TOKEN.findall(line)) - len(_SAVED_PATH_CAPTURE.findall(line))
+    captures = sum(
+        _VISIBLE_PATH_OPTION.search(match.group(1)) is None
+        for match in _SAVED_PATH_CAPTURE.finditer(line)
+    )
+    return len(_INK_TOKEN.findall(line)) - captures
 
 
 def census(repo: Path) -> int:

--- a/scripts/tenkz_lint.py
+++ b/scripts/tenkz_lint.py
@@ -277,11 +277,18 @@ _INK_TOKEN = re.compile(
     r"|pgf(?:path|usepath|text|node|setlinewidth|setstrokecolor"
     r"|setfillcolor|stroke|fill|transform)[a-z@]*)\b"
 )
+# Saving geometry for later string surgery creates no visible ink.  Keep this
+# state-owner operation out of the raw-rendering debt meter.
+_SAVED_PATH_CAPTURE = re.compile(r"\\path\s*\[[^]]*\bspath/save\s*=")
 _DECIMAL = re.compile(r"(?<![\w@.])\d*\.\d+")
 # Only metric-table DEFINITIONS are exempt; a stray literal multiplying a
 # metric macro in drawing code is exactly the debt this meter measures.
 _METRIC_LINE = re.compile(r"\\def\\tenkz@(?:r@[a-z]+|basepitch|pitch)\b|\\tenkz@pitch=")
 _RENDER_PRIMITIVE_REF = re.compile(r"\\__tenkz_ink_[A-Za-z@:_]+")
+
+
+def ink_token_count(line: str) -> int:
+    return len(_INK_TOKEN.findall(line)) - len(_SAVED_PATH_CAPTURE.findall(line))
 
 
 def census(repo: Path) -> int:
@@ -303,7 +310,7 @@ def census(repo: Path) -> int:
         ):
             if not is_renderer:
                 if is_census_source:
-                    ink += len(_INK_TOKEN.findall(line))
+                    ink += ink_token_count(line)
                 primitive_violations.extend(
                     (path, lineno, match.group())
                     for match in _RENDER_PRIMITIVE_REF.finditer(line)

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -26,6 +26,15 @@ import tenkz_shrink  # noqa: E402
 
 def test_saved_path_capture_is_not_rendering_debt() -> None:
     assert ink_token_count(r"\path [ spath/save = {route} ] (0,0) -- (1,0) ;") == 0
+    assert ink_token_count(
+        r"\path [ spath/save = {route} , use~Hobby~shortcut ] (0,0) -- (1,0) ;"
+    ) == 0
+    assert ink_token_count(
+        r"\path [ spath/save = {route} , draw ] (0,0) -- (1,0) ;"
+    ) == 1
+    assert ink_token_count(
+        r"\path [ fill , spath/save = {route} ] (0,0) rectangle (1,1) ;"
+    ) == 1
     assert ink_token_count(r"\draw (0,0) -- (1,0) ;") == 1
 
 

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -20,8 +20,13 @@ from tenkz_language import (  # noqa: E402
     parse_alias_payload,
     parse_status,
 )
-from tenkz_lint import registry_alias_patterns  # noqa: E402
+from tenkz_lint import ink_token_count, registry_alias_patterns  # noqa: E402
 import tenkz_shrink  # noqa: E402
+
+
+def test_saved_path_capture_is_not_rendering_debt() -> None:
+    assert ink_token_count(r"\path [ spath/save = {route} ] (0,0) -- (1,0) ;") == 0
+    assert ink_token_count(r"\draw (0,0) -- (1,0) ;") == 1
 
 
 def test_parse_status_ledgers() -> None:

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -35,6 +35,9 @@ def test_saved_path_capture_is_not_rendering_debt() -> None:
     assert ink_token_count(
         r"\path [ fill , spath/save = {route} ] (0,0) rectangle (1,1) ;"
     ) == 1
+    assert ink_token_count(
+        r"\path [ spath/save = {route} , bond ] (0,0) -- (1,0) ;"
+    ) == 1
     assert ink_token_count(r"\draw (0,0) -- (1,0) ;") == 1
 
 

--- a/tests/tenkz/render-census-baseline.json
+++ b/tests/tenkz/render-census-baseline.json
@@ -7,15 +7,15 @@
       "tenkz-free.code.tex": 0,
       "tenkz-geometry.code.tex": 0,
       "tenkz-grid.code.tex": 7,
-      "tenkz-kernel.code.tex": 1,
+      "tenkz-kernel.code.tex": 0,
       "tenkz-language.code.tex": 0,
       "tenkz-lattice.code.tex": 0,
       "tenkz-metric.code.tex": 0,
       "tenkz-model.code.tex": 0,
       "tenkz-render.code.tex": 0,
-      "tenkz-string.code.tex": 7
+      "tenkz-string.code.tex": 2
     },
-    "total": 44
+    "total": 38
   },
   "decimal_literals": {
     "by_file": {

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -1,4 +1,4 @@
-% Input:       frozen model records and resolved geometry.
+% Input:       frozen model records, resolved geometry, metric access, and saved string paths.
 % Output:      ink -- nodes and paths on the current tikzpicture.
 % Owned state: none; rendering reads records and draws, remembering nothing.
 % Invariants:  no parsing, no topology, no recovery; label text never rotates.

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -1,6 +1,6 @@
-% Input:       frozen model records, resolved geometry, metric access, and saved string paths.
-% Output:      ink -- nodes and paths on the current tikzpicture.
-% Owned state: none; rendering reads records and draws, remembering nothing.
+% Input:       frozen records, resolved geometry, metrics, route geometry, and saved paths.
+% Output:      ink and saved routes on the current tikzpicture.
+% Owned state: saved route paths; no semantic or topological state.
 % Invariants:  no parsing, no topology, no recovery; label text never rotates.
 % Next stage:  events serialize the same records this stage consumed.
 %

--- a/tex/tenkz/tenkz-render.code.tex
+++ b/tex/tenkz/tenkz-render.code.tex
@@ -1,6 +1,6 @@
-% Input:       frozen records, resolved geometry, metrics, route geometry, and saved paths.
-% Output:      ink and saved routes on the current tikzpicture.
-% Owned state: saved route paths; no semantic or topological state.
+% Input:       frozen model records, resolved geometry, metric access, and saved string paths.
+% Output:      ink -- nodes and paths on the current tikzpicture.
+% Owned state: none; rendering reads records and draws, remembering nothing.
 % Invariants:  no parsing, no topology, no recovery; label text never rotates.
 % Next stage:  events serialize the same records this stage consumed.
 %
@@ -225,11 +225,6 @@
   }
 
 % ---------- strings -----------------------------------------------------------
-% Save route geometry at the sole TikZ path boundary.  The string/model owner
-% registers identity and semantics; this helper contributes no visible ink.
-\cs_new_protected:Npn \__tenkz_render_save_route:nn #1#2
-  { \path [ spath/save = {#1} ] #2 ; }
-
 % A string draws its saved spath3 route: after crossing surgery the saved
 % path already carries its gaps, so one stroke is the whole story.  #1 the
 % saved path id, #2 extra style tokens (species hue, emphasis).

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -179,7 +179,7 @@
   {
     \__tenkz_string_register:nn {#1} {route}
     \prop_put:Nnn \l__tenkz_string_source_prop {#1} {generated}
-    \__tenkz_render_save_route:nn {#1} {#2}
+    \path [ spath/save = {#1} ] #2 ;
   }
 \cs_generate_variant:Nn \__tenkz_string_save_route:nn { nV }
 


### PR DESCRIPTION
Closes #4747.

## What changed

- document golden event snapshots and the byte-identical check
- document same-session pixel pairs and their detached legacy control
- document the six shrink meters, registry statuses, flags, and session gate
- identify the shared `tnlog` and `texcase` parsers as the only parsing owners
- summarize ownership for the model, metric, geometry, render, and string stages
- require golden and paired-pixel evidence for `tex/tenkz` pull requests
- record the 0.8 demolition-checker and 1.0 pixel-pair expiry terms
- remove the stale clean-checkout comparison command; comparison requires an
  explicit external author-source tree

## Verification

- `scripts/tenkz_golden.sh` (264 streams; baseline unchanged)
- `scripts/tenkz_golden.sh --check` (264 streams byte-identical)
- `scripts/tenkz_pixelpair.sh origin/main` (6 pages byte-identical at 300 dpi)
- `python3 scripts/tenkz_shrink.py meters`
- `python3 scripts/tenkz_shrink.py flags` (131 flags)
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_manual_doctest.py` (9 displayed and 25 reference
  examples)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation plus a small stage-ownership refactor and census accounting; no auth, data, or runtime behavior changes beyond where route geometry is saved.
> 
> **Overview**
> **Documents** the tenkz rebuild workflow in `HACKING.md`: golden `.tnlog` checks, same-session pixel pairs, shrink meters/flags/gate, shared parser ownership, stage boundaries, and required PR evidence. **Clarifies** that RMP `compare` needs an external author-source tree (not a clean-checkout path) in both `HACKING.md` and `ch-rmp.tex`.
> 
> **Moves** `spath/save` route capture from `tenkz-render` into `__tenkz_string_save_route` in `tenkz-string`, and **updates** `tenkz_lint.py` so capture-only `\path [spath/save=…]` lines are excluded from the raw-ink debt meter, with a refreshed `render-census-baseline.json` and unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2da100ef3e881b5a731ad2cab821ec30af07ee40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->