### PR TITLE
doc(MPDO): correct CPSV16 coverage classifications

### DIFF
--- a/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_cases.tex
@@ -41,7 +41,10 @@ Definition~\ref{def:sector_bnt_cf}. The source canonical form is brought to
 this surface by the reductions and normalizations of Chapters~\ref{ch:canonical}
 and~\ref{ch:bnt}. Our hypothesis only requires eventual nonzero projective
 proportionality, so the source assumption at every positive length
-is a special case. The reduction of an \emph{arbitrary} proportional-MPV pair
+is a special case. The conclusion compares the chosen BNT representatives,
+exactly as in the source theorem; conjugacy of the full ambient block matrices
+is the stronger equal-MPV corollary. The reduction of an
+\emph{arbitrary} proportional-MPV pair
 to a common primitive block decomposition is
 Theorem~\ref{thm:ft_after_blocking_common_length_common_sector_theorem} of
 Chapter~\ref{ch:canonical}.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -386,6 +386,10 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     \end{align}
     Then $M$ has the explicit GSNNCH sector form with outer sectors $x$ and
     natural multiplicities $n_x$.
+    This is the conclusion of
+    \cite[Proposition \texttt{prop3to4}, lines~1783--1792]
+    {Cirac2016MPDO_arXiv}; the rank-one trace identities used earlier in the
+    source argument are not needed for this implication.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -48,23 +48,24 @@ theorem. This is tracked by issue #873 under the proposition-level tracker #81.
 
 ## 2. Coverage crosswalk: CPSV16 (arXiv:1606.00608)
 
-At Lean revision `33f69af68`, after the normal-tensor RFP characterization and the trace-normalized RFP-to-ZCL-and-SAL result, the paper has 45 theorem-like occurrences and 40 distinct results. The occurrence-level count is 18 complete, 15 partial, and 12 not-ready; the distinct-result count is 17 complete, 12 partial, and 11 not-ready. Here **not-ready** means that the printed statement is false, ambiguous, or depends essentially on a formally refuted source lemma. It does not mean that every printed result has been formalized.
+At Lean revision `dc475473a`, after the normal-tensor RFP characterization and the trace-normalized RFP-to-ZCL-and-SAL result, the paper has 45 theorem-like occurrences and 40 distinct results. The occurrence-level count is 22 complete, 11 partial, and 12 not-ready; the distinct-result count is 20 complete, 9 partial, and 11 not-ready. Here **not-ready** means that the printed statement is false, ambiguous, or depends essentially on a formally refuted source lemma. It does not mean that every printed result has been formalized.
 
 The distinct count is the 40 source `thm`, `prop`, `cor`, and `lem`
 environments. The occurrence count adds five Appendix A/D restatements.
 The following ledger makes the count reproducible from source line numbers:
 
-- **Complete (17 distinct):** 249, 253, 606, 945, 1080, 1121, 1130,
-  1274, 1333, 1351, 1406, 1510, 1569, 1647, 1680, 1835, and 2221.
-- **Partial (12 distinct):** 278, 342, 349, 398, 583, 801, 851, 972,
-  1013, 1597, 1786, and 1801.
+- **Complete (20 distinct):** 249, 253, 342, 349, 606, 945, 1080, 1121,
+  1130, 1274, 1333, 1351, 1406, 1510, 1569, 1647, 1680, 1786, 1835, and
+  2221.
+- **Partial (9 distinct):** 278, 398, 583, 801, 851, 972, 1013, 1597,
+  and 1801.
 - **Not-ready (11 distinct):** 354, 500, 534, 543, 777, 1155, 1197,
   1484, 1503, 1740, and 1810.
 - **Additional occurrences:** the Appendix A restatements at 1137, 1167,
-  and 1172 inherit partial, partial, and not-ready status, respectively; the
+  and 1172 inherit partial, complete, and not-ready status, respectively; the
   Appendix D restatements at 1863 and 1929 inherit complete and partial status.
-  Thus the five restatements add one complete, three partial, and one not-ready
-  occurrence, giving the displayed totals 18/15/12.
+  Thus the five restatements add two complete, two partial, and one not-ready
+  occurrence, giving the displayed totals 22/11/12.
 
 Definitions, equations, and explanatory proof-segment rows are not counted.
 In particular, Eq. `II_XAX` at 1072--1077 is excluded, while the purification
@@ -81,8 +82,8 @@ segments of Theorems 3.1 and 3.10, not additional theorem occurrences.
 | Prop (l.253) | 253–255 | Projector criterion for canonical form | `TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean` (`MPSTensor.exists_normalTensor_blockDecomp_with_isometry_of_hasInvariantProjectorClosure`) | **complete**; #2634 closed |
 | Prop 2.7 (l.278, `prop:char-BNT`) | 278–280 | BNT characterization: every active canonical-form normal tensor is gauge-phase-equivalent to a basis element | `TNLean/MPS/CanonicalForm/BNTCharacterization.lean` (`MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal`) | **partial** — the active-block characterization is complete, but positive-length MPVs cannot determine listed zero-weight blocks; see `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` |
 | Defn "injective" (l.317, `defnbi`) | 317–322 | A normal tensor is injective when its matrices span the full matrix algebra; biCF is block-injective canonical form | `TNLean/MPS/Defs.lean` (`MPSTensor.IsInjective`) and the biCF development under `TNLean/MPS/MPDO/BiCFDerivation/` | `leanok` |
-| Prop (l.342, `propblockinj`) | 342–345 | After blocking at most $3D^5$ spins, any canonical-form tensor becomes biCF | `TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean` (`IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five`) with `MPSTensor.hasBiCF_of_propBlockInjective` | **partial** — the bound is proved for the stronger packaged `IsBNTCanonicalForm` surface, but the printed proposition starts from literal canonical form; the zero-weight ambiguity in Proposition 2.7 prevents the missing unconditional conversion |
-| **Theorem II.1** (l.349, `thm1`) | 349–352 | Fundamental theorem of MPVs, proportional case | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_proportional_canonicalForm`); `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` | **partial** — the theorem covers the active, nonzero BNT sector under the packaged BNT hypothesis, while the printed statement starts from literal canonical form, which may list inactive zero-weight blocks |
+| Prop (l.342, `propblockinj`) | 342–345 | After blocking at most $3D^5$ spins, any canonical-form tensor becomes biCF | `TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean` (`IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five`) with `MPSTensor.hasBiCF_of_wordTupleSpanTop` | **complete** — the theorem gives the simultaneous span, hence biCF, for the chosen BNT representatives at a positive length bounded by $3D^5$; inactive listed coordinates are not additional BNT representatives |
+| **Theorem II.1** (l.349, `thm1`) | 349–352 | Fundamental theorem of MPVs, proportional case | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_proportional_canonicalForm`) | **complete** — from proportional MPV families, the theorem gives exactly the source conclusion for the chosen BNTs: a sector bijection, matched bond dimensions, unit phases, and invertible block gauges |
 | **Corollary II.2** (l.354, `II_cor2`) | 354–361 | Equal MPVs imply conjugacy by an invertible matrix | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_equal_canonicalForm`); `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` | **not-ready** — literal canonical form permits inactive zero-weight blocks, which positive-length MPVs cannot detect; tensors with equal MPVs may therefore have different ambient dimensions, contradicting the printed dimension and global-conjugacy conclusion |
 
 ### 2.2 Section III — Pure States: Renormalization of MPS (RFP / ZCL / NNCPH)
@@ -128,7 +129,7 @@ segments of Theorems 3.1 and 3.10, not additional theorem occurrences.
 | **Corollary `Lem1`** (l.1130) | 1130–1133 | Orthogonal normal MPVs are eventually linearly independent | `TNLean/MPS/CanonicalForm/PhaseClassSectorData.lean`; `TNLean/MPS/BNT/Basic.lean` | **complete** |
 | Restatement of `prop:char-BNT` | 1137–1142 | BNT characterization | `TNLean/MPS/CanonicalForm/BNTCharacterization.lean` | **partial restatement** — inherits the zero-weight ambiguity at lines 278–280 |
 | **Lemma `Lem:app_simple`** (l.1155) | 1155–1163 | Equality of finite power sums implies equality of multisets | `TNLean/Algebra/ScalarPowerSumIdentity.lean`; `docs/paper-gaps/power_sum_alternative_route.tex` | **not-ready** — the positive-power sums of \([1]\) and \([1,0]\) agree although the multisets differ; the formal alternatives either assume nonzero entries or conclude equality only after filtering out zeros |
-| Restatement of `thm1` | 1167–1170 | Proportional fundamental theorem | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_proportional_canonicalForm`); `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` | **partial restatement** — mirrors the active, nonzero BNT scope gap of Theorem II.1 |
+| Restatement of `thm1` | 1167–1170 | Proportional fundamental theorem | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_proportional_canonicalForm`) | **complete restatement** — the Lean theorem gives the BNT bijection, dimensions, phases, and gauges asserted here |
 | Restatement of `II_cor2` | 1172–1179 | Equal-MPV fundamental theorem | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_equal_canonicalForm`); `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` | **not-ready restatement** — mirrors the inactive zero-weight block obstruction to Corollary II.2 |
 | **Corollary `thm:Fundamental-CFII`** (l.1197) | 1197–1199 | CFII refinement with unitary global and block gauges | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_equal_canonicalForm_unitary`) and `SectorBNT/Unitary.lean`; `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`; `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` | **not-ready** — literal CFII still permits zero weights and therefore inherits Corollary II.2's false dimension and global-unitary conclusion; the Lean unitary theorem covers the active, nonzero BNT surface |
 
@@ -156,7 +157,7 @@ segments of Theorems 3.1 and 3.10, not additional theorem occurrences.
 | Lemma `lemmus` | 1647–1650 | ZCL makes repeated-copy weights independent of the copy index | `TNLean/MPS/MPDO/SimpleTensor.lean` (`MPOTensor.weight_copy_independent_of_isSourceZCL`) | **complete** |
 | Lemma | 1680–1691 | SAL gives separating orthogonal projectors | `TNLean/MPS/MPDO/BNTSeparatingProjectors.lean`; `BNTSourceSectorProjectors.lean` | **complete** |
 | Prop `prop2to3` | 1740–1743 | SAL and ZCL imply the blockwise structural form | `TNLean/MPS/MPDO/BNTSeparatingProjectors.lean`; `BNTSourceSectorProjectors.lean`; `docs/paper-gaps/cpgsv17_pf_rank_one.tex` | **not-ready** — the printed proof requires the false rank-one conclusion of Lemma C.5 |
-| Prop `prop3to4` | 1786–1789 | Blockwise structure gives the GSNNCH form | `TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean` (`hasGSNNCHForm_of_bntSectorSAL`); `GSNNCHOrthogonalSectors.lean` | **partial** — the current assembly assumes sectorwise SAL together with inverse, closure, nonzero-closing, and word-span data; no theorem derives those inputs from the printed blockwise structural condition alone |
+| Prop `prop3to4` | 1786–1789 | Blockwise structure gives the GSNNCH form | `TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean` (`hasGSNNCHForm_of_bntSectorSAL`); `GSNNCHOrthogonalSectors.lean` | **complete** — the source-context assembly constructs the orthogonally supported positive commuting sector products and combines them with the natural BNT multiplicities to give the exact GSNNCH form for every periodic chain of length at least two |
 | Prop `prop4to2` | 1801–1804 | GSNNCH gives SAL | `TNLean/MPS/MPDO/OrthogonalSectorAreaLaw.lean`; `LocalOrthogonalSumAreaLaw.lean`; `PhysicalSectorFactorization.lean`; `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex` | **partial** — the statement omits the ZCL hypothesis used in its proof; the corrected sectorwise-ZCL result still depends on #4175/#4459 |
 | Prop `prop2to5` | 1810–1813 | SAL and ZCL give the two trace-preserving maps | `TNLean/MPS/MPDO/PhysicalSectorCoarseGrainingIdentity.lean`; `PhysicalSectorRefinementIdentity.lean`; `PhysicalSectorBlockedRFP.lean` | **not-ready** — the conditional maps are constructed, but deriving their neighboring trace factorization from the printed hypotheses uses false Lemma C.5 |
 
@@ -273,12 +274,13 @@ under #2633.
 
 ## 5. Note on Theorem 4.4 (CPSV21) naming
 
-The sector-BNT theorems cover the active, nonzero BNT form of CPSV16
-Theorem II.1 and its equal-MPV specialization. They do not discharge the
-inactive zero-weight block ambiguity in the literal canonical-form statements
-of Theorem II.1 and Corollary II.2. CPSV21 Theorem 4.4 is the corresponding
-proportional fundamental theorem; it should not be confused with the older
-single-block or conditional sector-matching reductions.
+The sector-BNT proportional theorem is the source-faithful formalization of
+CPSV16 Theorem II.1: the source states its conclusion for the chosen BNT
+representatives. It does not discharge the inactive zero-weight ambiguity in
+the stronger ambient-dimension and global-conjugacy conclusion of Corollary
+II.2. CPSV21 Theorem 4.4 is the corresponding proportional fundamental
+theorem; it should not be confused with the older single-block or conditional
+sector-matching reductions.
 
 | Lean declaration | Paper | CPSV16 relation |
 |---|---|---|
@@ -303,7 +305,7 @@ These are known oversized (documented in #1512/#1522) and do not block unrelated
 
 ## 7. Key remaining coverage gaps
 
-The 23 non-complete distinct CPSV16 results comprise 12 partial and 11
+The 20 non-complete distinct CPSV16 results comprise 9 partial and 11
 not-ready results. They are source-ambiguous, formally refuted, research-level,
 owner-held, or scope-restricted by the current formal interface. Lemma
 `Lsigma3`, the Hayashi strong-subadditivity equality characterization, and the
@@ -313,8 +315,6 @@ axiom-free.
 | Status | Paper | Result | Current certificate | Ownership |
 |---|---|---|---|---|
 | Partial | CPSV16 | Prop. 2.7, BNT characterization | Active blocks are characterized; listed zero-weight blocks are invisible to positive-length MPVs | Source clarification required |
-| Partial | CPSV16 | Proposition `propblockinj` | The $3D^5$ bound is proved for packaged BNT data, not for every literal canonical-form tensor | Blocked by the same zero-weight ambiguity as Proposition 2.7 |
-| Partial | CPSV16 | Theorem II.1 | The sector-BNT theorem covers active, nonzero BNT data, not every literal canonical-form block list | `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` |
 | Not-ready | CPSV16 | Corollary II.2 | Inactive zero-weight blocks can change the ambient dimension without changing any positive-length MPV | `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` |
 | Not-ready | CPSV16 | Appendix A Lemma `Lem:app_simple` | \([1]\) and \([1,0]\) have identical positive-power sums but different multisets; the formal corrections require nonzero entries or filter zeros | `TNLean/Algebra/ScalarPowerSumIdentity.lean`; `docs/paper-gaps/power_sum_alternative_route.tex` |
 | Not-ready | CPSV16 | Appendix A CFII refinement | Literal CFII permits zero weights and inherits the false dimension/global-unitary conclusion; the Lean theorem covers active, nonzero BNT data | `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex`; `docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex` |
@@ -331,7 +331,6 @@ axiom-free.
 | Not-ready | CPSV16 | Lemma C.5 (`SALZCL`) | A formal injective four-sector counterexample has SAL and source ZCL but no rank-one active trace factorization | #4270 closed by counterexample |
 | Not-ready | CPSV16 | Structural corollary, lines 1503–1506 | Its printed proof depends on false Lemma C.5 | No source-faithful replacement known |
 | Partial | CPSV16 | Proposition `4to2`, lines 1597–1601 | The selected tensor satisfies all-cut SAL; comparison with the original tensor is missing | #4175/#4459, assigned to `LionSR` |
-| Partial | CPSV16 | Proposition `prop3to4` | The current GSNNCH assembly assumes sectorwise SAL and auxiliary inverse/closure/span data not yet derived from the printed blockwise structure | No source-hypothesis capstone is currently present |
 | Not-ready | CPSV16 | Proposition `prop2to3` | Its printed SAL+ZCL proof depends on false Lemma C.5 | No source-faithful replacement known |
 | Partial | CPSV16 | Proposition `prop4to2` | The statement omits the ZCL hypothesis used in the proof and shares the original-to-selected-tensor gap | #4175/#4459, assigned to `LionSR` |
 | Not-ready | CPSV16 | Proposition `prop2to5` | Conditional maps exist, but the printed derivation of their factorization uses false Lemma C.5 | No unconditional source theorem available |

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -64,8 +64,9 @@ For MPDO renormalization fixed points:
 - `cpsv16_gsnnch_sector_decomposition.tex` records that
   `MPOTensor.GSNNCHData` now retains the source orthogonal sectors and natural
   multiplicities. The separate single-bond presentation gives its one-sector
-  case. Constructing the outer sectors from the BNT decomposition, and any
-  reverse comparison needed later, remain open.
+  case, while the orthogonal BNT-sector construction and source-context
+  assembly prove Proposition `prop3to4`. Reverse implications used elsewhere
+  remain separate.
 - `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records the missing
   coherent positive choice for the inverse-map neighboring operators in
   Appendix C.2. The comparison with the conjugated Hayashi decomposition,

--- a/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
+++ b/docs/paper-gaps/canonical_bnt_ft_theorem_surface.tex
@@ -200,15 +200,17 @@ identified with one another.
     \path{MPSTensor.fundamentalTheorem_singleBlock} is the injective-block
     gauge theorem. It is a source-level theorem only for one injective block,
     not for the multi-block BNT comparison.
+  \item The proportional theorem
+    \path{MPSTensor.fundamentalTheorem_proportional_canonicalForm}
+    is the source-level BNT comparison: it derives the sector bijection,
+    matched dimensions, unit phases, and block gauges directly from eventual
+    nonzero proportionality of the total MPV families.
   \item The SectorBNT equal-MPV declarations
     \path{MPSTensor.ft_sector_bnt_equal_sector_data} and
-    \path{MPSTensor.ft_sector_bnt_equal_global_gauge} are the current formal
-    statements closest to the BNT part of the source proof. They work with raw
-    sector weights and derive the sector matching, copy-count equalities, and
-    matched copy-weight identities on the SectorBNT surface. The source-level
-    equal-MPV corollary is obtained after the canonical-form supplier has put
-    the input tensors on this surface with the required unit-modulus-copy
-    normalization.
+    \path{MPSTensor.ft_sector_bnt_equal_global_gauge} treat the additional
+    copy-weight comparison needed for a global equal-MPV gauge. They work with
+    raw sector weights and should not be identified with the proportional
+    theorem's per-BNT conclusion.
   \item The sector-decomposition theorem
     \path{MPSTensor.fundamentalTheorem_equalMPV_sectorDecomposition_hetero_of_sectorMatching}
     is now an auxiliary rectangular comparison statement: from a supplied
@@ -219,30 +221,31 @@ identified with one another.
 \end{enumerate}
 
 The former strict canonical-form BNT equal-MPV declaration was only a strict
-representative form and is no longer part of the active Lean tree. The former
-one-shot proportional wrappers have also been removed because their hypotheses
-did not supply the full BNT matching conclusion. The current proportional
-surface is instead split into conditional SectorBNT statements. The
-sector-matching theorem\footnote{Formal declaration:
+representative form and is no longer part of the active Lean tree. Earlier
+one-shot proportional wrappers were also removed because their hypotheses did
+not supply the full BNT matching conclusion. The current sector-matching
+theorem\footnote{Formal declaration:
   \path{MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses}.}
-supplies the matched sectors, phases, and block gauges under the present
-full-basis unit-copy hypotheses; the conditional global-gauge
+derives the matched sectors, dimensions, phases, and block gauges from the
+BNT canonical-form hypotheses and eventual nonzero proportionality. The
+paper-level declaration
+\path{MPSTensor.fundamentalTheorem_proportional_canonicalForm} exposes exactly
+this conclusion and is the formalization of CPSV16 Theorem~II.1. The
+conditional global-gauge
 theorem\footnote{Formal declaration:
   \path{MPSTensor.ft_sector_bnt_proportional_global_gauge_of_coeff_identity}.}
 then assumes the eventual matched-sector coefficient identities for those same
-phases and derives the copy-weight matching and global gauge. This is a
-conditional interface, not the unrestricted source theorem.
+phases and derives copy-weight matching and a global gauge. That stronger
+copy-level conclusion belongs to the equal-MPV/global-gauge route; it is not a
+hypothesis or conclusion of Theorem~II.1.
 
-Thus the proof gap is not that the paper has many hidden Fundamental Theorems.
-Rather, the paper suppresses the formal separation between deriving the BNT
-comparison data from the source hypotheses and applying the existing comparison
-theorems to that data. The remaining theorem-level work is to derive, from the
-source proportional MPV hypothesis, the eventual matched-sector coefficient
-identities used in the conditional global-gauge theorem,
-and to discharge any full-basis unit-copy hypotheses from the source
-normalization rather than assuming them separately. Once those inputs are
-available, the SectorBNT statements combine to give the paper-level theorem;
-they are not additional paper theorems.
+Thus there is no remaining theorem-level gap in the proportional BNT
+comparison. The unresolved boundary is the stronger equal-MPV corollary for
+literal ambient canonical-form tensors: positive-length MPVs do not detect
+inactive zero-weight coordinates, whereas the printed corollary asserts equal
+ambient dimensions and one global conjugating matrix. The conditional
+copy-weight declarations remain useful for faithful restricted versions of
+that stronger conclusion, but they are not additional paper theorems.
 
 \paragraph{Paper-level targets.}
 The proportional canonical-form theorem and the equal-MPV corollary are the
@@ -252,21 +255,18 @@ $\mu_{j,q}$ in the sums
 \[
   \sum_q \mu_{j,q}^N.
 \]
-The current SectorBNT equal-MPV declarations
+The declaration
+\path{fundamentalTheorem_proportional_canonicalForm} proves the proportional
+source target on the BNT surface directly from eventual nonzero proportional
+MPV families. The SectorBNT equal-MPV declarations
 \path{ft_sector_bnt_equal_sector_data} and
-\path{ft_sector_bnt_equal_global_gauge} are therefore the relevant formal
-statements on the BNT surface, not the older one-copy \texttt{CFBNT} surface.
-The proportional theorem on the same surface is currently conditional: it
-assumes the matched-sector coefficient identities for the phases produced by
-the sector matching theorem. It should not be cited as the general
-arXiv:1606.00608
-theorem until those coefficient identities are derived from the proportional
-MPV hypothesis. The equal-MPV common-block comparison likewise assumes the
+\path{ft_sector_bnt_equal_global_gauge} address the repeated-copy data needed
+for global equal-MPV comparisons; they are not prerequisites for the
+proportional theorem. The equal-MPV common-block comparison assumes the
 repeated-copy structure has already been matched into common weights and
-dimensions. Rectangular variants that state the permutation, phases, gauges,
-and weight matching for sector decompositions with different bases are
-legitimate theorem statements only when their hypotheses are obtained from the
-same BNT comparison.
+dimensions. Rectangular variants that state weight matching or a global gauge
+for sector decompositions with different bases are legitimate theorem
+statements only when their hypotheses account for that repeated-copy data.
 
 \paragraph{Conditional after-blocking statements.}
 The after-blocking comparison theorems are useful only after the source


### PR DESCRIPTION
## Motivation

The CPSV16 coverage audit still classified propblockinj, Theorem II.1, and prop3to4 as partial after source-faithful capstones had landed.

## Description

- classify all three results as complete with exact declaration-level certificates
- update the reproducible distinct and occurrence counts
- clarify the proportional BNT theorem versus the stronger ambient equal-MPV corollary
- synchronize the paper-gap index and Blueprint source notes

An independent read-only source/signature review confirmed all three classifications before publication.

## Testing

- lake build TNLean (9,799 jobs)
- python3 scripts/blueprint_lean_sync.py --ci
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- lake exe checkdecls blueprint/lean_decls
- LuaLaTeX PDF build to convergence; zero undefined references or citations
- visual inspection of the changed Chapter 11 and Chapter 21 pages
- python3 scripts/check_reader_facing_prose.py --base-ref origin/main
- git diff --check

Closes #5062

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and audit metadata only; no Lean or runtime behavior changes.
> 
> **Overview**
> **CPSV16 coverage audit** (`docs/audits/2026-05-08-mps-ft-paper-coverage.md`) now marks **propblockinj** (l.342), **Theorem II.1** (l.349), and **prop3to4** (l.1786) as **complete**, with Lean certificates (`hasBiCF_of_wordTupleSpanTop`, `fundamentalTheorem_proportional_canonicalForm`, `hasGSNNCHForm_of_bntSectorSAL`). Reproducible tallies move to **20 complete / 9 partial / 11 not-ready** distinct results (22/11/12 occurrences at revision `dc475473a`). §5 and §7 drop the old “partial FT / prop3to4 assembly” gap rows for these items.
> 
> **Blueprint** Chapter 11 states that the proportional theorem compares **chosen BNT representatives** (source Theorem II.1); global ambient conjugacy remains the **equal-MPV** corollary. Chapter 21 ties the orthogonal commuting-sector GSNNCH theorem to **prop3to4** and notes rank-one trace steps are not needed for that implication.
> 
> **Paper-gap index** (`docs/paper-gaps/README.md`) and **`canonical_bnt_ft_theorem_surface.tex`** describe `fundamentalTheorem_proportional_canonicalForm` as the closed CPSV16 II.1 surface, GSNNCH **prop3to4** as proved via the BNT-sector assembly, and the remaining boundary as **Corollary II.2** (inactive zero-weight blocks vs positive-length MPVs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77636221d71b760e8286706d47996ebd18fa3cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->