### PR TITLE
feat(MPS/MPDO): transport physical-sector factorizations through gauges

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -166,6 +166,7 @@ import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 import TNLean.MPS.MPDO.PhysicalSectorDirectedCut
 import TNLean.MPS.MPDO.PhysicalSectorEtaLocalStructure
 import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorGaugeTransport
 import TNLean.MPS.MPDO.PhysicalSectorNormalProductRepresentative
 import TNLean.MPS.MPDO.PhysicalSectorOmegaPreparation
 import TNLean.MPS.MPDO.PhysicalSectorPhysicalMaps

--- a/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
@@ -1,0 +1,192 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+
+/-!
+# Virtual-gauge transport of physical-sector factorizations
+
+A virtual similarity mixes the left and right virtual indices by inverse
+matrices.  These changes can be absorbed separately into the two tensor
+factors of a physical-sector factorization.  Their contraction cancels the
+gauge, so the neighboring operators are unchanged.
+-/
+
+open scoped ComplexOrder Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K L : MPOTensor d D}
+
+/-- Transport a physical-sector factorization through an invertible virtual
+gauge.
+
+The physical-sector decomposition and physical isometry are unchanged.  The
+gauge and its inverse are absorbed into the left and right virtual tensor
+families, respectively.
+
+Source context: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388. -/
+noncomputable def ofGaugeEquiv (F : PhysicalSectorFactorization K)
+    (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
+    PhysicalSectorFactorization L := by
+  classical
+  let X : GL (Fin D) ℂ := Classical.choose hGauge
+  have hX : ∀ i : Fin (d * d),
+      L.toMPSTensor i = X * K.toMPSTensor i * X⁻¹ :=
+    Classical.choose_spec hGauge
+  let x : Matrix (Fin D) (Fin D) ℂ := X
+  let y : Matrix (Fin D) (Fin D) ℂ :=
+    ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+  refine
+    { sectorCount := F.sectorCount
+      leftDim := F.leftDim
+      rightDim := F.rightDim
+      leftDim_pos := F.leftDim_pos
+      rightDim_pos := F.rightDim_pos
+      sectorEquiv := F.sectorEquiv
+      physicalIsometry := F.physicalIsometry
+      physicalIsometry_isometry := F.physicalIsometry_isometry
+      leftTensor := fun k beta ↦
+        ∑ gamma, x beta gamma • F.leftTensor k gamma
+      rightTensor := fun k alpha ↦
+        ∑ delta, y delta alpha • F.rightTensor k delta
+      factorization := ?_ }
+  intro beta alpha
+  ext ⟨k, a⟩ ⟨h, b⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
+  have hLetter (i j : Fin d) :
+      L i j = x * K i j * y := by
+    simpa only [MPOTensor.toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+      MPSTensor.finProdFinEquiv_modNat, x, y] using
+      hX (finProdFinEquiv (i, j))
+  have hSlice :
+      physicalSlice L beta alpha =
+        ∑ gamma, ∑ delta,
+          (x beta gamma * y delta alpha) • physicalSlice K gamma delta := by
+    ext i j
+    simp only [physicalSlice, hLetter, Matrix.mul_apply, Matrix.sum_apply,
+      Matrix.smul_apply, smul_eq_mul]
+    simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro gamma _
+    apply Finset.sum_congr rfl
+    intro delta _
+    ring
+  have hConj :
+      F.physicalIsometry * physicalSlice L beta alpha *
+          F.physicalIsometryᴴ =
+        ∑ gamma, ∑ delta, (x beta gamma * y delta alpha) •
+          (F.physicalIsometry * physicalSlice K gamma delta *
+            F.physicalIsometryᴴ) := by
+    rw [hSlice]
+    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul,
+      Matrix.smul_mul]
+  rw [hConj]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.kroneckerMap_apply, Matrix.sum_apply,
+      Matrix.smul_apply, smul_eq_mul]
+    have hF (gamma delta : Fin D) :=
+      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨k, b⟩
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] at hF
+    simp_rw [hF]
+    rw [Finset.sum_mul]
+    simp_rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro gamma _
+    apply Finset.sum_congr rfl
+    intro delta _
+    ring
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+    have hF (gamma delta : Fin D) :=
+      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨h, b⟩
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hkh] at hF
+    simp_rw [hF]
+    simp
+
+/-- Virtual-gauge transport leaves every neighboring operator unchanged. -/
+@[simp] theorem ofGaugeEquiv_neighboringOperator
+    (F : PhysicalSectorFactorization K)
+    (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor)
+    (k h : Fin F.sectorCount) :
+    (F.ofGaugeEquiv hGauge).neighboringOperator k h =
+      F.neighboringOperator k h := by
+  classical
+  let X : GL (Fin D) ℂ := Classical.choose hGauge
+  let x : Matrix (Fin D) (Fin D) ℂ := X
+  let y : Matrix (Fin D) (Fin D) ℂ :=
+    ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+  have hyx : y * x = 1 := by
+    change
+      (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+        (X : Matrix (Fin D) (Fin D) ℂ)) = 1
+    rw [← Units.val_mul]
+    simp
+  ext a b
+  simp only [neighboringOperator_apply, ofGaugeEquiv, Matrix.sum_apply,
+    Matrix.smul_apply, smul_eq_mul]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro delta _
+  rw [Finset.sum_comm]
+  calc
+    (∑ gamma, ∑ beta,
+        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) delta beta *
+            F.rightTensor k delta a.1 b.1 *
+          ((X : Matrix (Fin D) (Fin D) ℂ) beta gamma *
+            F.leftTensor h gamma a.2 b.2)) =
+        ∑ gamma, if delta = gamma then
+          F.rightTensor k delta a.1 b.1 *
+            F.leftTensor h gamma a.2 b.2
+        else 0 := by
+      apply Finset.sum_congr rfl
+      intro gamma _
+      calc
+        (∑ beta,
+            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) delta beta *
+                F.rightTensor k delta a.1 b.1 *
+              ((X : Matrix (Fin D) (Fin D) ℂ) beta gamma *
+                F.leftTensor h gamma a.2 b.2)) =
+            (y * x) delta gamma *
+              F.rightTensor k delta a.1 b.1 *
+              F.leftTensor h gamma a.2 b.2 := by
+          rw [Matrix.mul_apply]
+          simp only [y, x]
+          rw [Finset.sum_mul, Finset.sum_mul]
+          apply Finset.sum_congr rfl
+          intro beta _
+          ring
+        _ = if delta = gamma then
+              F.rightTensor k delta a.1 b.1 *
+                F.leftTensor h gamma a.2 b.2
+            else 0 := by
+          rw [hyx, Matrix.one_apply]
+          split
+          · simp_all
+          · simp_all
+    _ = F.rightTensor k delta a.1 b.1 *
+        F.leftTensor h delta a.2 b.2 := by
+      simp [Finset.sum_ite_eq, Finset.mem_univ]
+
+/-- Positivity of the neighboring operators is preserved by virtual-gauge
+transport. -/
+theorem ofGaugeEquiv_neighboringOperator_posSemidef
+    (F : PhysicalSectorFactorization K)
+    (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    ∀ k h,
+      ((F.ofGaugeEquiv hGauge).neighboringOperator k h).PosSemidef := by
+  intro k h
+  rw [F.ofGaugeEquiv_neighboringOperator hGauge k h]
+  exact hpos k h
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -116,6 +116,29 @@
     this definition; it is a separate hypothesis in Proposition~C.7.
 \end{definition}
 
+\begin{theorem}[Virtual-gauge invariance of physical-sector factorizations]
+    \label{thm:mpdo_physical_sector_factorization_gauge}
+    \lean{MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv,
+      MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator,
+      MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator_posSemidef}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator}
+    Suppose that two MPO tensors of the same virtual dimension differ by an
+    invertible virtual gauge.  Every physical-sector factorization of the
+    first tensor induces one of the second tensor with the same physical
+    decomposition and the same neighboring operators.  In particular,
+    positive semidefiniteness of all neighboring operators is invariant under
+    the gauge.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Absorb the gauge into each left sector tensor and its inverse into each
+    right sector tensor.  The two matrices cancel when the common virtual
+    index is contracted, so every neighboring operator is unchanged.
+\end{proof}
+
 \begin{definition}[One-site matrix spaces of sector sets]%
     \label{def:mpdo_one_site_sector_matrix_space}
     \lean{MPOTensor.PhysicalSectorFactorization.oneSiteSectorMatrix,

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -489,7 +489,14 @@ constructed from the fixed commuting bond in equation \emph{sigmaNK2} at
 source lines~1581--1605.  The remaining work is structural: supply the
 normality and blocking comparison from the original normal MPDO block and
 proportional bond-product hypotheses of Proposition~\emph{4to2}, at source
-lines~1597--1605, to that selected fixed representative.  The explicit
+lines~1597--1605, to that selected fixed representative.  Once such a
+comparison gives an invertible virtual gauge,
+\leanid{MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv} transports the
+factorization to the original tensor, and
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+ofGaugeEquiv_neighboringOperator} shows that its positive neighboring
+operators are unchanged.  This gauge invariance does not construct the
+required comparison from closed-chain proportionality.  The explicit
 factorization and positivity assumptions of the proved corollary are marked
 scope restrictions, not additional hypotheses on the source proposition.
 
@@ -553,7 +560,8 @@ constructed non-circularly from the source-side commuting bond, as recorded by
 the fixed-tensor theorem identified above.
 \item Prove the normality and blocking comparison from the original normal
 MPDO block and the printed proportional commuting-bond hypotheses to the
-selected fixed representative.
+selected fixed representative.  The resulting virtual gauge then transports
+the fixed tensor's factorization without changing its neighboring operators.
 Only then may the source proposition receive a formal declaration and a
 \texttt{\string\leanok} marker.
 \end{enumerate}


### PR DESCRIPTION
## Summary

- transport a `PhysicalSectorFactorization` through an invertible virtual gauge
- prove that every neighboring operator is exactly unchanged, hence positive semidefiniteness is preserved
- add the corresponding Blueprint theorem and record the precise remaining structural gap toward CPSV16 Proposition `4to2`

The public names describe the mathematics (`ofGaugeEquiv` and neighboring-operator invariance); they do not encode proof history or a recovery process.

This is a prerequisite for #4459, not a proof of the source-faithful SAL implication. Closed-chain proportionality still has to produce the required invertible gauge or an equivalent minimal-realization comparison.

## Source

CPSV16, arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines 1381--1388. The gap boundary is documented in `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.

## Validation

- `lake exe cache get` before all Lean builds
- `lake env lean TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean`
- `lake build TNLean.MPS.MPDO.PhysicalSectorGaugeTransport`
- `lake build` (9,800 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web` (completed; local Python package hooks were unavailable, so authoritative rendering remains the CI web job)
- `python3 scripts/check_reader_facing_prose.py --base-ref origin/main`
- `python3 scripts/tactic_pattern_scan.py`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`
- no new `sorry`, `axiom`, kernel bypass, or source-absent hypothesis

Closes #5067
Addresses #4459

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization on existing MPDO definitions with no runtime, auth, or data-path changes; main project risk is proof maintenance in a specialized Lean module.
> 
> **Overview**
> Adds **virtual-gauge transport** for `PhysicalSectorFactorization`: given `MPSTensor.GaugeEquiv` between two MPO tensors, `ofGaugeEquiv` rebuilds a factorization on the gauged tensor by absorbing the gauge into left sector tensors and its inverse into right ones, while keeping the physical decomposition and isometry fixed.
> 
> Proves **`ofGaugeEquiv_neighboringOperator`** (neighboring operators are unchanged) and a corollary that **positive semidefiniteness** of those operators is preserved. Registers the result in the Blueprint (`thm:mpdo_physical_sector_factorization_gauge`) and updates the CPSV16 gap note to say that, once a normality/blocking comparison yields an invertible gauge, this transport moves the fixed-tensor factorization to the original tensor **without** proving that comparison from closed-chain proportionality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb13fd5b1f8b58a0103e5e9d9db6ba40f2b55cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->