### PR TITLE
feat(MPS/Core): preserve eventual proportionality under blocking

### DIFF
--- a/TNLean/MPS/Core/BlockingInfrastructure.lean
+++ b/TNLean/MPS/Core/BlockingInfrastructure.lean
@@ -23,6 +23,8 @@ primitive simultaneously.
 * `sameMPV₂_blockTensor_of_sameMPV₂_toTensorFromBlocks` — Blocking distributes over
   `toTensorFromBlocks`: if `SameMPV₂ A (toTensorFromBlocks μ blocks)`, then
   `SameMPV₂ (blockTensor A p) (toTensorFromBlocks (μ^p) (blockTensor blocks p))`.
+* `EventuallyNonzeroProportionalMPV₂.blockTensor` — Eventual nonzero proportionality
+  is preserved by positive physical blocking.
 
 ### Part B: Primitivity under multiples
 * `isPrimitive_pow_of_isPrimitive` — primitive channels remain primitive under positive powers.
@@ -175,6 +177,28 @@ theorem sameMPV₂Pos_blockTensor
     _ = mpv B σflat := hSame (N * p) (Nat.mul_pos hN hp) σflat
     _ = mpv (blockTensor (d := d) (D := D₂) B p) σ :=
           (mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) B p σ).symm
+
+/-- Eventual nonzero MPV proportionality is preserved by positive physical blocking. -/
+theorem EventuallyNonzeroProportionalMPV₂.blockTensor
+    {D₁ D₂ : ℕ} {A : MPSTensor d D₁} {B : MPSTensor d D₂}
+    (h : EventuallyNonzeroProportionalMPV₂ A B) (p : ℕ) (hp : 0 < p) :
+    EventuallyNonzeroProportionalMPV₂
+      (blockTensor (d := d) (D := D₁) A p)
+      (blockTensor (d := d) (D := D₂) B p) := by
+  unfold EventuallyNonzeroProportionalMPV₂ at h ⊢
+  rw [Filter.eventually_atTop] at h ⊢
+  rcases h with ⟨N₀, hN₀⟩
+  refine ⟨N₀, fun N hN => ?_⟩
+  have hNle : N ≤ N * p := le_mul_of_one_le_right (Nat.zero_le N) hp
+  rcases hN₀ (N * p) (hN.trans hNle) with ⟨c, hc, hEq⟩
+  refine ⟨c, hc, fun σ => ?_⟩
+  calc
+    mpv (MPSTensor.blockTensor (d := d) (D := D₁) A p) σ =
+        mpv A (blockedFlatConfig (d := d) p σ) :=
+      mpv_blockTensor_eq_mpv_blockedFlatConfig (d := d) A p σ
+    _ = c * mpv B (blockedFlatConfig (d := d) p σ) := hEq _
+    _ = c * mpv (MPSTensor.blockTensor (d := d) (D := D₂) B p) σ := by
+      rw [mpv_blockTensor_eq_mpv_blockedFlatConfig]
 
 /-- Positive-length equality with a weighted nonzero-block tensor is preserved by
 positive physical blocking, with each weight transported to the corresponding power. -/

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
@@ -226,13 +226,13 @@ through its own period agrees with the directly $p$-blocked block.
     so do their blocked tensors after any positive blocking length.
 \end{lemma}
 
-\begin{lemma}[Eventual nonzero proportionality survives blocking]%
-    \label{lem:eventual_nonzero_proportional_mpv_blocking}
+\begin{theorem}[Eventual nonzero proportionality survives blocking]%
+    \label{thm:eventual_nonzero_proportional_mpv_blocking}
     \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.blockTensor}\leanok
     \uses{def:blocked_tensor, def:eventually_nonzero_proportional_mpv}
     If two tensors have eventually nonzero proportional MPV coefficients, then
     so do their blocked tensors after any positive blocking length.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     If proportionality holds from length $N_0$ onward, a blocked chain of length

--- a/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
+++ b/blueprint/src/appendix/ft_mps/ch09_canonical_blocking_and_sectors.tex
@@ -226,6 +226,20 @@ through its own period agrees with the directly $p$-blocked block.
     so do their blocked tensors after any positive blocking length.
 \end{lemma}
 
+\begin{lemma}[Eventual nonzero proportionality survives blocking]%
+    \label{lem:eventual_nonzero_proportional_mpv_blocking}
+    \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.blockTensor}\leanok
+    \uses{def:blocked_tensor, def:eventually_nonzero_proportional_mpv}
+    If two tensors have eventually nonzero proportional MPV coefficients, then
+    so do their blocked tensors after any positive blocking length.
+\end{lemma}
+
+\begin{proof}\leanok
+    If proportionality holds from length $N_0$ onward, a blocked chain of length
+    $N\ge N_0$ expands to an original chain of length $Np\ge N_0$. Use the
+    original proportionality scalar at length $Np$.
+\end{proof}
+
 \begin{lemma}[Positive-length blocking of a weighted block sum]%
     \label{thm:same_mpv2_pos_block_tensor_to_tensor_from_blocks}
     \lean{MPSTensor.sameMPV₂Pos_blockTensor_toTensorFromBlocks}\leanok

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -374,23 +374,6 @@ boundary conditions (PBC).
     is the case $c_N = 1$.
 \end{proof}
 
-\begin{lemma}[Positive blocking preserves eventual nonzero proportionality]%
-    \label{lem:eventual_nonzero_proportional_mpv_blocking}
-    \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.blockTensor}
-    \leanok
-    \uses{def:eventually_nonzero_proportional_mpv, def:blocked_tensor}
-    Let $A$ and $B$ have eventually nonzero proportional MPV families, and let
-    $p>0$. Then the tensors obtained by blocking $p$ consecutive sites also have
-    eventually nonzero proportional MPV families.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    If proportionality holds from length $N_0$ onward, then a blocked chain of
-    length $N\ge N_0$ expands to an original chain of length $Np\ge N_0$. Use the
-    original proportionality scalar at length $Np$.
-\end{proof}
-
 \begin{lemma}[Scaling of word evaluation]\label{lem:eval_word_smul}
     \lean{MPSTensor.evalWord_smul}
     \leanok

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -374,6 +374,23 @@ boundary conditions (PBC).
     is the case $c_N = 1$.
 \end{proof}
 
+\begin{lemma}[Positive blocking preserves eventual nonzero proportionality]%
+    \label{lem:eventual_nonzero_proportional_mpv_blocking}
+    \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.blockTensor}
+    \leanok
+    \uses{def:eventually_nonzero_proportional_mpv, def:blocked_tensor}
+    Let $A$ and $B$ have eventually nonzero proportional MPV families, and let
+    $p>0$. Then the tensors obtained by blocking $p$ consecutive sites also have
+    eventually nonzero proportional MPV families.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If proportionality holds from length $N_0$ onward, then a blocked chain of
+    length $N\ge N_0$ expands to an original chain of length $Np\ge N_0$. Use the
+    original proportionality scalar at length $Np$.
+\end{proof}
+
 \begin{lemma}[Scaling of word evaluation]\label{lem:eval_word_smul}
     \lean{MPSTensor.evalWord_smul}
     \leanok


### PR DESCRIPTION
## Summary

- add `EventuallyNonzeroProportionalMPV₂.blockTensor`
- prove eventual nonzero proportionality is preserved by every positive physical blocking
- document the theorem in the blocking-infrastructure module overview

## Why

The fixed-bond-to-SAL route in #4459 must compare the original injective normal tensor and a canonicalized fixed-product representative at a common positive blocking. Existing infrastructure preserved exact positive-length equality under blocking, but not eventual nonzero proportionality.

The proof pulls the eventual tail back along `N ↦ N * p` and uses the existing blocked MPV evaluation identity. It does not assert a global gauge or identify an arbitrary representative with a minimal sector.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.Core.BlockingInfrastructure` (3,096 jobs)
- `lake build` (9,800 jobs)
- `lake exe lint_style --github`
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base 6ed7c7333fb8c702d204c7901a7acd7af0875d14 --ci`
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`

Closes #5069
Contributes to #4459

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a localized Mathlib proof and blueprint prose in existing blocking infrastructure; no auth, data, or API surface changes.
> 
> **Overview**
> Extends blocking infrastructure so **eventual nonzero MPV proportionality** (`EventuallyNonzeroProportionalMPV₂`) is preserved when both tensors are blocked by any positive length `p`, complementing the existing **exact** positive-length equality result (`sameMPV₂Pos_blockTensor`).
> 
> The new `EventuallyNonzeroProportionalMPV₂.blockTensor` proof reuses the same tail as exact blocking: for blocked length `N ≥ N₀`, original length `N·p` inherits proportionality from the hypothesis, then `mpv_blockTensor_eq_mpv_blockedFlatConfig` relates blocked MPVs to flattened originals. The module overview and appendix (`ch09_canonical_blocking_and_sectors.tex`) document the theorem for the fixed-bond-to-SAL route that compares tensors at a common blocking period.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab16c2f0848f95bcab7f522d01583257a40e8e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->