### PR TITLE
feat(MPS/FundamentalTheorem/SectorBNT): add single-sector form

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT.lean
@@ -21,6 +21,7 @@ import TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord
 import TNLean.MPS.FundamentalTheorem.SectorBNT.MatchAux
 import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch
 import TNLean.MPS.FundamentalTheorem.SectorBNT.ProportionalMatch.Core
+import TNLean.MPS.FundamentalTheorem.SectorBNT.SingleSector
 import TNLean.MPS.FundamentalTheorem.SectorBNT.StrongMatch
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier
 import TNLean.MPS.FundamentalTheorem.SectorBNT.SupplierNormalized

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -3,16 +3,15 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
 import TNLean.MPS.FundamentalTheorem.SectorBNT.EqualModulus
+import TNLean.MPS.FundamentalTheorem.SectorBNT.SingleSector
 
 /-!
 # Concrete BNT canonical forms
 
 These examples present one-sector BNT canonical forms built from a normal block
-`C`.  The assumptions on `C` are the standard mathematical ones for such a
-block: positive bond dimension, irreducibility, left canonicity, normalized
-self-overlap, and eventual non-vanishing of the associated vector state.
+`C`. The single-copy construction is provided by `singleSectorDecomposition`;
+the remaining examples illustrate nontrivial copy weights.
 
 * A single normal block `C`, with coefficient `1`.
 * The sign-flip GHZ pair `C ⊕ (-C)`, with length-`N` coefficient
@@ -35,47 +34,14 @@ variable {d D : ℕ}
 
 /-! ## Example 1 — single sector, single copy -/
 
-/-- The trivial single-sector single-copy decomposition of `C`. -/
-@[reducible] noncomputable def singletonDecomp (C : MPSTensor d D) :
-    SectorDecomposition d where
-  basisCount := 1
-  basisDim := fun _ => D
-  basis := fun _ => C
-  sectors :=
-    { copies := fun _ => 1
-      copies_pos := fun _ => Nat.one_pos
-      weight := fun _ _ => 1
-      weight_ne_zero := fun _ _ => one_ne_zero }
-
 /-- **Example 1**: a single BNT sector with a single copy and weight `1`. -/
 noncomputable example
-    (C : MPSTensor d D) (hDpos : 0 < D)
+    (C : MPSTensor d D) [NeZero D]
     (hCIrr : IsIrreducibleTensor C)
     (hCLeft : IsLeftCanonical C)
-    (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1))
-    (hCNonzero : ∃ N0 : ℕ, ∀ N > N0, mpvState C N ≠ 0) :
-    IsBNTCanonicalForm (singletonDecomp C) where
-  basis_dim_pos := fun _ => hDpos
-  basis_irreducible := fun _ => hCIrr
-  basis_left_canonical := fun _ => hCLeft
-  basis_normalized_self_overlap := fun _ => hCSelf
-  bnt_data := by
-    classical
-    obtain ⟨N0, hN0⟩ := hCNonzero
-    refine ⟨N0, fun N hN => ?_⟩
-    exact LinearIndependent.of_subsingleton (i := (0 : Fin 1)) (hN0 N hN)
-  basis_distinct := fun j k hjk _ =>
-    absurd (Subsingleton.elim j k) hjk
-  -- CPSV16 line 246: the unique weight `μ = 1` has `‖μ‖ = 1 ≤ 1`.
-  weight_norm_le_one := by
-    intro _ _
-    change ‖(1 : ℂ)‖ ≤ 1
-    simp
-  -- CPSV16 line 246: the unique weight is the global unit-modulus witness.
-  weight_unit_exists := by
-    refine ⟨0, 0, ?_⟩
-    change ‖(1 : ℂ)‖ = 1
-    simp
+    (hCSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) C C N) atTop (𝓝 1)) :
+    IsBNTCanonicalForm (singleSectorDecomposition C) :=
+  isBNTCanonicalForm_singleSectorDecomposition hCIrr hCLeft hCSelf
 
 /-! ## Example 2 — `C ⊕ (-C)` -/
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -34,7 +34,7 @@ variable {d D : ℕ}
 
 /-! ## Compatibility alias -/
 
-/-- Deprecated alias for `singleSectorDecomposition`. -/
+/-- Compatibility alias for `singleSectorDecomposition`. -/
 @[deprecated singleSectorDecomposition (since := "2026-07-29")]
 noncomputable abbrev singletonDecomp (C : MPSTensor d D) :
     SectorDecomposition d :=

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Examples.lean
@@ -32,6 +32,14 @@ namespace SectorBNT.Examples
 
 variable {d D : ℕ}
 
+/-! ## Compatibility alias -/
+
+/-- Deprecated alias for `singleSectorDecomposition`. -/
+@[deprecated singleSectorDecomposition (since := "2026-07-29")]
+noncomputable abbrev singletonDecomp (C : MPSTensor d D) :
+    SectorDecomposition d :=
+  singleSectorDecomposition C
+
 /-! ## Example 1 — single sector, single copy -/
 
 /-- **Example 1**: a single BNT sector with a single copy and weight `1`. -/

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SingleSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SingleSector.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+import TNLean.MPS.Tactic.Basic
 
 /-!
 # Single-sector BNT canonical forms
@@ -103,10 +104,10 @@ theorem IsNormalTensor.exists_gaugeEquiv_singleSectorDecomposition
   have hBNT : IsBNTCanonicalForm (singleSectorDecomposition B) :=
     isBNTCanonicalForm_singleSectorDecomposition hIrr hLeft hSelf
   refine ⟨B, hGauge, hBNT, ?_⟩
-  intro N _hN τ
+  mpv_ext
   calc
-    mpv A τ = mpv B τ := GaugeEquiv.sameMPV hGauge N τ
-    _ = mpv (singleSectorDecomposition B).toTensor τ := by
+    mpv A σ = mpv B σ := GaugeEquiv.sameMPV hGauge N σ
+    _ = mpv (singleSectorDecomposition B).toTensor σ := by
       rw [(singleSectorDecomposition B).mpv_toTensor_eq_sum_coeff]
       simp [singleSectorDecomposition, SectorDecomposition.coeff, SectorWeightData.coeff]
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/SingleSector.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/SingleSector.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.FundamentalTheorem.SectorBNT.Basic
+
+/-!
+# Single-sector BNT canonical forms
+
+This file presents a tensor as a sector decomposition with one basis block, one copy, and
+unit weight. It proves that the presentation is a BNT canonical form under the standard
+irreducibility, left-canonicality, and self-overlap hypotheses. A normal tensor admits such
+a presentation after its pure trace-preserving Perron gauge.
+
+## Main results
+
+* `singleSectorDecomposition`: the one-sector, one-copy decomposition of a tensor.
+* `isBNTCanonicalForm_singleSectorDecomposition`: the corresponding BNT canonical form.
+* `IsNormalTensor.exists_gaugeEquiv_singleSectorDecomposition`: a normal tensor has a
+  gauge-equivalent single-sector BNT presentation.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete, arXiv:1606.00608, Section 2.3,
+  lines 217--301.
+-/
+
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The sector decomposition with one basis block, one copy, and unit weight. -/
+@[reducible]
+noncomputable def singleSectorDecomposition (A : MPSTensor d D) :
+    SectorDecomposition d where
+  basisCount := 1
+  basisDim := fun _ => D
+  basis := fun _ => A
+  sectors :=
+    { copies := fun _ => 1
+      copies_pos := fun _ => Nat.one_pos
+      weight := fun _ _ => 1
+      weight_ne_zero := fun _ _ => one_ne_zero }
+
+/-- An irreducible left-canonical tensor with normalized self-overlap gives a
+single-sector BNT canonical form.
+
+This is the one-block specialization of the BNT canonical form in
+arXiv:1606.00608, Section 2.3, lines 217--301. -/
+theorem isBNTCanonicalForm_singleSectorDecomposition [NeZero D]
+    {A : MPSTensor d D}
+    (hIrr : IsIrreducibleTensor A)
+    (hLeft : IsLeftCanonical A)
+    (hSelf : Tendsto (fun N : ℕ => mpvOverlap (d := d) A A N) atTop (𝓝 1)) :
+    IsBNTCanonicalForm (singleSectorDecomposition A) where
+  basis_dim_pos := fun _ => NeZero.pos D
+  basis_irreducible := fun _ => hIrr
+  basis_left_canonical := fun _ => hLeft
+  basis_normalized_self_overlap := fun _ => hSelf
+  bnt_data := by
+    classical
+    obtain ⟨N₀, hN₀⟩ := (eventually_atTop.1 (hSelf.eventually_ne one_ne_zero))
+    refine ⟨N₀, fun N hN => ?_⟩
+    apply LinearIndependent.of_subsingleton (i := (0 : Fin 1))
+    intro hState
+    apply hN₀ N (Nat.le_of_lt hN)
+    have hCoeff : ∀ σ : Fin N → Fin d, mpv A σ = 0 := by
+      intro σ
+      have hApply := congrArg (fun x => x σ) hState
+      simpa using hApply
+    simp only [mpvOverlap, hCoeff, zero_mul, Finset.sum_const_zero]
+  basis_distinct := fun j k hjk _ =>
+    absurd (Subsingleton.elim j k) hjk
+  weight_norm_le_one := by
+    intro _ _
+    change ‖(1 : ℂ)‖ ≤ 1
+    simp
+  weight_unit_exists := by
+    refine ⟨0, 0, ?_⟩
+    change ‖(1 : ℂ)‖ = 1
+    simp
+
+/-- A normal tensor is gauge equivalent to a single-sector BNT canonical form.
+
+The gauge is the pure trace-preserving Perron gauge from arXiv:1606.00608,
+Appendix A, lines 1093--1117. -/
+theorem IsNormalTensor.exists_gaugeEquiv_singleSectorDecomposition
+    {A : MPSTensor d D} (hA : IsNormalTensor A) :
+    ∃ B : MPSTensor d D,
+      GaugeEquiv A B ∧
+      IsBNTCanonicalForm (singleSectorDecomposition B) ∧
+      SameMPV₂Pos A (singleSectorDecomposition B).toTensor := by
+  letI : NeZero D := ⟨hA.bondDim_ne_zero⟩
+  obtain ⟨σ, _hσ, _hσfix, hLeft, hGauge, hPrim, hIrr⟩ := hA.exists_tpGauge
+  let B := tpGauge (d := d) (D := D) A σ
+  have hSelf :
+      Tendsto (fun N : ℕ => mpvOverlap (d := d) B B N) atTop (𝓝 1) :=
+    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible B hIrr hLeft hPrim
+  have hBNT : IsBNTCanonicalForm (singleSectorDecomposition B) :=
+    isBNTCanonicalForm_singleSectorDecomposition hIrr hLeft hSelf
+  refine ⟨B, hGauge, hBNT, ?_⟩
+  intro N _hN τ
+  calc
+    mpv A τ = mpv B τ := GaugeEquiv.sameMPV hGauge N τ
+    _ = mpv (singleSectorDecomposition B).toTensor τ := by
+      rw [(singleSectorDecomposition B).mpv_toTensor_eq_sum_coeff]
+      simp [singleSectorDecomposition, SectorDecomposition.coeff, SectorWeightData.coeff]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -425,7 +425,10 @@ single family.
 
 \begin{proof}\leanok
     \uses{thm:single_sector_decomposition_bnt,
-        thm:cpsv_normal_tp_gauge}
+        thm:cpsv_normal_tp_gauge,
+        thm:peripheral_primitive_irreducible_overlap_one,
+        thm:gauge_invariance,
+        lem:paper_decomp_formula}
     Choose the pure trace-preserving Perron gauge. Its tensor is irreducible
     and left-canonical, and primitivity gives self-overlap converging to one.
     The preceding theorem supplies the BNT canonical form. Gauge invariance

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -405,10 +405,16 @@ single family.
 \end{theorem}
 
 \begin{proof}\leanok
-    Since the self-overlap is eventually nonzero, the matrix product vector
-    of $A$ is eventually nonzero. A family consisting of one nonzero vector
-    is linearly independent. All remaining conditions are immediate from the
-    hypotheses and the unit weight.
+    The identity
+    \[
+        O_{AA}(N)
+        =\left\lVert V^{(N)}(A)\right\rVert^2
+        \longrightarrow 1\ne0
+    \]
+    shows that $V^{(N)}(A)$ is nonzero for all sufficiently large $N$.
+    A family consisting of one nonzero vector is linearly independent. All
+    remaining conditions are immediate from the hypotheses and the unit
+    weight.
 \end{proof}
 
 \begin{theorem}[Normal tensors have single-sector BNT presentations]
@@ -431,8 +437,16 @@ single family.
         lem:paper_decomp_formula}
     Choose the pure trace-preserving Perron gauge. Its tensor is irreducible
     and left-canonical, and primitivity gives self-overlap converging to one.
-    The preceding theorem supplies the BNT canonical form. Gauge invariance
-    and the unit weight identify the positive-length matrix product vectors.
+    The preceding theorem supplies the BNT canonical form. If $P$ denotes
+    the total tensor of its single-sector decomposition, then gauge invariance
+    and the sector-decomposition formula give, for every $N>0$ and word
+    $\sigma$,
+    \[
+        V^{(N)}(A)_\sigma
+        =V^{(N)}(B)_\sigma
+        =1^N V^{(N)}(B)_\sigma
+        =V^{(N)}(P)_\sigma.
+    \]
 \end{proof}
 
 \begin{lemma}[Unit-modulus weight witness from the canonical-form normalization]%

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -385,6 +385,52 @@ single family.
     not derivable from the per-block normality hypotheses alone.
 \end{definition}
 
+\begin{definition}[Single-sector decomposition]
+    \label{def:single_sector_decomposition}
+    \lean{MPSTensor.singleSectorDecomposition}
+    \leanok
+    \uses{def:sector_weight_data}
+    For a tensor $A$, its single-sector decomposition has $A$ as its only
+    basis tensor, with one copy of weight $1$.
+\end{definition}
+
+\begin{theorem}[Single-sector BNT canonical form]
+    \label{thm:single_sector_decomposition_bnt}
+    \lean{MPSTensor.isBNTCanonicalForm_singleSectorDecomposition}
+    \leanok
+    \uses{def:sector_bnt_cf, def:single_sector_decomposition}
+    Let $A$ have positive bond dimension, be irreducible and left-canonical,
+    and satisfy $O_{AA}(N)\longrightarrow1$. Then its single-sector
+    decomposition is a BNT canonical form.
+\end{theorem}
+
+\begin{proof}\leanok
+    Since the self-overlap is eventually nonzero, the matrix product vector
+    of $A$ is eventually nonzero. A family consisting of one nonzero vector
+    is linearly independent. All remaining conditions are immediate from the
+    hypotheses and the unit weight.
+\end{proof}
+
+\begin{corollary}[Normal tensors have single-sector BNT presentations]
+    \label{cor:normal_single_sector_bnt_gauge}
+    \lean{MPSTensor.IsNormalTensor.exists_gaugeEquiv_singleSectorDecomposition}
+    \leanok
+    \uses{def:single_sector_decomposition,
+        thm:single_sector_decomposition_bnt,
+        thm:cpsv_normal_tp_gauge}
+    Every normal tensor is gauge equivalent to a tensor whose single-sector
+    decomposition is a BNT canonical form. The original tensor and the total
+    tensor of this decomposition generate the same matrix product vectors at
+    every positive length.
+\end{corollary}
+
+\begin{proof}\leanok
+    Choose the pure trace-preserving Perron gauge. Its tensor is irreducible
+    and left-canonical, and primitivity gives self-overlap converging to one.
+    The preceding theorem supplies the BNT canonical form. Gauge invariance
+    and the unit weight identify the positive-length matrix product vectors.
+\end{proof}
+
 \begin{lemma}[Unit-modulus weight witness from the canonical-form normalization]%
     \label{lem:sector_bnt_weight_unit_exists_of_struct}
     \lean{MPSTensor.IsBNTCanonicalForm.weight_unit_exists_of_struct}

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -406,11 +406,11 @@ single family.
 
 \begin{proof}\leanok
     The identity
-    \[
+    \begin{align}
         O_{AA}(N)
-        =\left\lVert V^{(N)}(A)\right\rVert^2
-        \longrightarrow 1\ne0
-    \]
+        &=\left\lVert V^{(N)}(A)\right\rVert^2
+        \longrightarrow 1\ne0.
+    \end{align}
     shows that $V^{(N)}(A)$ is nonzero for all sufficiently large $N$.
     A family consisting of one nonzero vector is linearly independent. All
     remaining conditions are immediate from the hypotheses and the unit
@@ -441,12 +441,12 @@ single family.
     the total tensor of its single-sector decomposition, then gauge invariance
     and the sector-decomposition formula give, for every $N>0$ and word
     $\sigma$,
-    \[
+    \begin{align}
         V^{(N)}(A)_\sigma
-        =V^{(N)}(B)_\sigma
+        &=V^{(N)}(B)_\sigma
         =1^N V^{(N)}(B)_\sigma
         =V^{(N)}(P)_\sigma.
-    \]
+    \end{align}
 \end{proof}
 
 \begin{lemma}[Unit-modulus weight witness from the canonical-form normalization]%

--- a/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_sector_canonical_form.tex
@@ -411,20 +411,21 @@ single family.
     hypotheses and the unit weight.
 \end{proof}
 
-\begin{corollary}[Normal tensors have single-sector BNT presentations]
-    \label{cor:normal_single_sector_bnt_gauge}
+\begin{theorem}[Normal tensors have single-sector BNT presentations]
+    \label{thm:normal_single_sector_bnt_gauge}
     \lean{MPSTensor.IsNormalTensor.exists_gaugeEquiv_singleSectorDecomposition}
     \leanok
-    \uses{def:single_sector_decomposition,
-        thm:single_sector_decomposition_bnt,
-        thm:cpsv_normal_tp_gauge}
+    \uses{def:nt_cpsv, def:gauge_equiv, def:sector_bnt_cf,
+        def:single_sector_decomposition, def:same_mpv2_pos}
     Every normal tensor is gauge equivalent to a tensor whose single-sector
     decomposition is a BNT canonical form. The original tensor and the total
     tensor of this decomposition generate the same matrix product vectors at
     every positive length.
-\end{corollary}
+\end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:single_sector_decomposition_bnt,
+        thm:cpsv_normal_tp_gauge}
     Choose the pure trace-preserving Perron gauge. Its tensor is irreducible
     and left-canonical, and primitivity gives self-overlap converging to one.
     The preceding theorem supplies the BNT canonical form. Gauge invariance


### PR DESCRIPTION
## Summary

- move the one-sector, one-copy decomposition from the examples namespace into production API as `singleSectorDecomposition`
- derive its BNT canonical form directly from irreducibility, left canonicity, and normalized self-overlap, eliminating the redundant eventual-nonvanishing hypothesis
- give every normal tensor a gauge-equivalent single-sector BNT presentation via its pure trace-preserving Perron gauge
- update the example, generated import aggregator, and blueprint

## Scope boundary

This is a reusable child of #4459, but it does not transport a physical-sector factorization through BNT compression. The current supplier does not retain the virtual compression maps or an unblocked tensor root, and neighboring-operator positivity is not implied by the existing factorization field under arbitrary rectangular compression.

Closes #5073.

## Verification

- `lake exe cache get`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.SingleSector TNLean.MPS.FundamentalTheorem.SectorBNT.Examples`
- `lake build`
- `lake build lint_style`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `PYTHONPATH=scripts python3 scripts/test_generate_import_aggregators.py -v`
- `PYTHONPATH=scripts python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/tactic_pattern_scan.py`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean API and documentation with localized refactors in examples; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Introduces **`SingleSector.lean`** as the production API for the one-block, one-copy, unit-weight sector decomposition (`singleSectorDecomposition`), with **`isBNTCanonicalForm_singleSectorDecomposition`** proving BNT canonical form from irreducibility, left canonicity, and self-overlap → 1—**dropping** the separate eventual-nonvanishing hypothesis by deriving linear independence from overlap limits.
> 
> Adds **`IsNormalTensor.exists_gaugeEquiv_singleSectorDecomposition`**: every normal tensor is gauge-equivalent to a tensor whose single-sector decomposition is BNT, with **same positive-length MPVs**, via the pure trace-preserving Perron gauge.
> 
> **`Examples.lean`** delegates to the new module: `singletonDecomp` becomes a deprecated alias; Example 1 is a one-liner calling the shared theorem; bond dimension uses `[NeZero D]` instead of `0 < D`.
> 
> Wires the module into the SectorBNT aggregator import and extends **blueprint ch10** with definitions/theorems for single-sector decomposition, the BNT proof, and the normal-tensor gauge presentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4539b331565c23cc883f3e71763884d1f2187b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->