### PR TITLE
feat(MPDO): derive absorbed BNT supports from prop3to4 layers

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -27,6 +27,7 @@ import TNLean.MPS.MPDO.BNTFusionCoisometries
 import TNLean.MPS.MPDO.BNTFusionIsometries
 import TNLean.MPS.MPDO.BNTFusionTensorClause
 import TNLean.MPS.MPDO.BNTFusionTensorClauseFromRFP
+import TNLean.MPS.MPDO.BNTLayerOrthogonality
 import TNLean.MPS.MPDO.BNTLeftTripleFusion
 import TNLean.MPS.MPDO.BNTMarkovKeyFormula
 import TNLean.MPS.MPDO.BNTMarkovSectorProjectors

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -73,6 +73,7 @@ import TNLean.MPS.MPDO.CPSVPeriodicExclusion
 import TNLean.MPS.MPDO.CPSVRepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.CPSVVerticalBNT
 import TNLean.MPS.MPDO.CPSVVerticalCanonicalForm
+import TNLean.MPS.MPDO.CommonWeightAbsorbedBNTSupport
 import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.CommutingBondEtaBoundaryTrace
 import TNLean.MPS.MPDO.CommutingBondEtaCyclicCore

--- a/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
+++ b/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
@@ -1,0 +1,457 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.OrthogonalProjection
+import TNLean.Algebra.PosSemidefSupport
+import TNLean.MPS.FundamentalTheorem.Basic
+import TNLean.MPS.MPDO.HayashiSectorComparison
+import TNLean.MPS.MPDO.PhysicalSectorProductRealization
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+import TNLean.MPS.MPDO.StackedLayers
+
+/-!
+# Orthogonality of vertically composed BNT layers
+
+Distinct elements of a basis of normal tensors in the simple matrix-product-density-operator
+setting have disjoint physical sectors.  The corresponding local identity is ordinary vertical
+composition: the layer labelled by $y$ is placed above the layer labelled by $x$, with no
+adjoint, and the resulting MPO tensor vanishes when $x \ne y$.
+
+This file records that identity for families whose bond dimensions may depend on the label,
+characterizes it by products of physical slices and their entries, and derives it from pairwise
+orthogonal two-sided physical supports.  A two-label square-zero example shows that the raw
+local identity alone does not provide such support projections for arbitrary MPO tensors.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.9(iv), equation `KxKy=0`, lines 863--868, and Appendix C.2,
+  equations `AppKxKy=0` and `PjKiPj`, lines 1634--1639 and 1680--1691
+-/
+
+open scoped Matrix ComplexOrder BigOperators Kronecker
+
+namespace MPOTensor
+
+variable {d g : ℕ} {bondDim : Fin g → ℕ}
+
+/-- Positivity of every neighbouring sector operator makes the original tensor an MPDO.  The
+sector-coordinate operators are positive by their cyclic product decomposition, and the
+physical isometry transports positivity back to the original physical space.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `Appetakhetc`,
+lines 1383--1450. -/
+theorem PhysicalSectorFactorization.isMPDO_of_neighboringOperator_pos
+    {K : MPOTensor d D} (F : PhysicalSectorFactorization K)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef) : IsMPDO K := by
+  apply isMPDO_of_changePhysicalBasis_isMPDO_of_isometry
+    F.physicalCoordinateMatrix F.physicalCoordinateMatrix_isometry K
+  rw [← F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  intro N hN
+  letI : NeZero N := ⟨Nat.ne_of_gt hN⟩
+  exact F.mpo_sectorCoordinateTensor_posSemidef hpos
+
+/-! ### Physical adjoint -/
+
+/-- The physical adjoint of an MPO tensor swaps its ket and bra indices and conjugates each
+virtual matrix entry, without transposing the virtual indices:
+$$(K^\sharp)^{ij}_{\beta\alpha} = \overline{K^{ji}_{\beta\alpha}}.$$
+
+This local adjoint relates layer annihilation to the two-sided support condition in equation
+`PjKiPj`; unlike `adjointTensor`, it does not reverse virtual multiplication.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppKxKy=0`--`PjKiPj`,
+lines 1634--1689. -/
+def physicalAdjointTensor (K : MPOTensor d D) : MPOTensor d D :=
+  fun i j β α ↦ star (K j i β α)
+
+@[simp] theorem physicalAdjointTensor_apply (K : MPOTensor d D)
+    (i j : Fin d) (β α : Fin D) :
+    physicalAdjointTensor K i j β α = star (K j i β α) := rfl
+
+/-- Physical slices of the physical adjoint are the conjugate transposes of the original
+physical slices.  Only physical indices are transposed.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1634--1689. -/
+theorem physicalSlice_physicalAdjointTensor (K : MPOTensor d D) (β α : Fin D) :
+    physicalSlice (physicalAdjointTensor K) β α = (physicalSlice K β α)ᴴ := by
+  ext i j
+  rfl
+
+/-- Closed words of the physical adjoint are entrywise conjugates of the words with ket and
+bra configurations exchanged. -/
+theorem evalWord_physicalAdjointTensor (K : MPOTensor d D)
+    (is js : List (Fin d)) (hlen : is.length = js.length) :
+    evalWord (physicalAdjointTensor K) is js =
+      (evalWord K js is).map (starRingEnd ℂ) := by
+  induction is generalizing js with
+  | nil =>
+      simp only [List.length_nil, eq_comm, List.length_eq_zero_iff] at hlen
+      subst js
+      exact (starRingEnd ℂ).mapMatrix.map_one.symm
+  | cons i is ih =>
+      cases js with
+      | nil => simp at hlen
+      | cons j js =>
+          simp only [List.length_cons, Nat.succ.injEq] at hlen
+          simp only [evalWord_cons, ih js hlen]
+          exact ((starRingEnd ℂ).mapMatrix.map_mul (K j i) (evalWord K js is)).symm
+
+/-- The physical adjoint generates the conjugate-transposed periodic operator family without
+spatial reflection.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1634--1689. -/
+theorem mpo_physicalAdjointTensor (K : MPOTensor d D) (N : ℕ)
+    (σ τ : Fin N → Fin d) :
+    mpo (physicalAdjointTensor K) N σ τ = star (mpo K N τ σ) := by
+  rw [mpo_apply, mpoMatrixEntry, evalWord_physicalAdjointTensor K _ _ (by simp),
+    ← AddMonoidHom.map_trace (starRingEnd ℂ)]
+  rfl
+
+/-- Positivity of every nonempty periodic operator makes an MPO tensor and its physical adjoint
+produce the same positive-length MPV family.  The positive-length convention is the weakest
+one supplied directly by `IsMPDO`; no assertion at length zero is used.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1634--1689. -/
+theorem IsMPDO.sameMPV₂Pos_physicalAdjointTensor {K : MPOTensor d D} (hK : IsMPDO K) :
+    MPSTensor.SameMPV₂Pos K.toMPSTensor (physicalAdjointTensor K).toMPSTensor := by
+  intro N hN ρ
+  let σ : Fin N → Fin d := fun n ↦ (ρ n).divNat
+  let τ : Fin N → Fin d := fun n ↦ (ρ n).modNat
+  have hρ : ρ = fun n ↦ finProdFinEquiv (σ n, τ n) := by
+    funext n
+    exact (finProdFinEquiv.apply_symm_apply (ρ n)).symm
+  calc
+    MPSTensor.mpv K.toMPSTensor ρ = mpo K N σ τ := by
+      rw [hρ, MPSTensor.mpv_toMPSTensor_pairConfig]
+    _ = star (mpo K N τ σ) := ((hK N hN).isHermitian.apply σ τ).symm
+    _ = mpo (physicalAdjointTensor K) N σ τ :=
+      (mpo_physicalAdjointTensor K N σ τ).symm
+    _ = MPSTensor.mpv (physicalAdjointTensor K).toMPSTensor ρ := by
+      rw [hρ, MPSTensor.mpv_toMPSTensor_pairConfig]
+
+/-- Since the two tensors have the same bond dimension, the positive-length equality extends
+at length zero by the universal zero-length MPV formula. -/
+theorem IsMPDO.sameMPV_physicalAdjointTensor {K : MPOTensor d D} (hK : IsMPDO K) :
+    MPSTensor.SameMPV K.toMPSTensor (physicalAdjointTensor K).toMPSTensor := by
+  intro N ρ
+  by_cases hN : 0 < N
+  · exact hK.sameMPV₂Pos_physicalAdjointTensor N hN ρ
+  · have hzero : N = 0 := Nat.eq_zero_of_not_pos hN
+    subst N
+    simp
+
+/-- For an injective MPDO tensor, every conjugate-transposed physical slice has an explicit
+finite expansion in the original physical slices.  The coefficients are matrix entries of the
+inner gauge comparing the tensor with its physical adjoint.
+
+This is the adjoint-closure step that connects equations `AppKxKy=0` and `PjKiPj`.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1634--1639 and 1680--1691. -/
+theorem exists_physicalSlice_conjTranspose_eq_sum_of_isInjective_isMPDO
+    (K : MPOTensor d D) (hInj : MPSTensor.IsInjective K.toMPSTensor) (hK : IsMPDO K) :
+    ∃ X : GL (Fin D) ℂ, ∀ β α : Fin D,
+      (physicalSlice K β α)ᴴ =
+        ∑ ν : Fin D, ∑ μ : Fin D,
+          (X β μ * (X⁻¹ : Matrix (Fin D) (Fin D) ℂ) ν α) • physicalSlice K μ ν := by
+  obtain ⟨X, hX⟩ :=
+    MPSTensor.fundamentalTheorem_singleBlock hInj hK.sameMPV_physicalAdjointTensor
+  refine ⟨X, fun β α ↦ ?_⟩
+  ext i j
+  have hEntry := congrArg
+    (fun A : Matrix (Fin D) (Fin D) ℂ ↦ A β α)
+    (hX (finProdFinEquiv (i, j)))
+  simpa [toMPSTensor, physicalAdjointTensor, physicalSlice, Matrix.mul_apply,
+    Matrix.sum_apply, Pi.smul_apply, smul_eq_mul, Finset.mul_sum, Finset.sum_mul,
+    mul_assoc, mul_left_comm, mul_comm] using hEntry
+
+/-! ### Finite physical supports -/
+
+/-- Stack all columns of all physical slices into one finite matrix.  A column is indexed by a
+virtual-index pair followed by a physical column index. -/
+noncomputable def physicalSliceColumns (K : MPOTensor d D) :
+    Matrix (Fin d) (Fin (D * D * d)) ℂ :=
+  fun i q ↦ K i q.modNat q.divNat.divNat q.divNat.modNat
+
+/-- The orthogonal projection onto the span of all columns of all physical slices. -/
+noncomputable def physicalSupportProj (K : MPOTensor d D) : Matrix (Fin d) (Fin d) ℂ :=
+  MPSTensor.supportProj
+    (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
+    (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))
+
+@[simp] theorem physicalSliceColumns_apply_finProdFinEquiv (K : MPOTensor d D)
+    (i j : Fin d) (β α : Fin D) :
+    physicalSliceColumns K i (finProdFinEquiv (finProdFinEquiv (β, α), j)) = K i j β α := by
+  simp [physicalSliceColumns]
+
+/-- Orthogonal column spaces give orthogonal support projections. -/
+theorem supportProj_mul_supportProj_eq_zero_of_conjTranspose_mul_eq_zero
+    {k l : ℕ} (Y : Matrix (Fin d) (Fin k) ℂ) (Z : Matrix (Fin d) (Fin l) ℂ)
+    (hYZ : Yᴴ * Z = 0) :
+    MPSTensor.supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) *
+      MPSTensor.supportProj (Z * Zᴴ) (Matrix.posSemidef_self_mul_conjTranspose Z) = 0 := by
+  let πY := MPSTensor.supportProj (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y)
+  let πZ := MPSTensor.supportProj (Z * Zᴴ) (Matrix.posSemidef_self_mul_conjTranspose Z)
+  have hπYZ : πY * Z = 0 := by
+    ext i j
+    have hmat : (Y * Yᴴ) * Z = 0 :=
+      (Matrix.self_mul_conjTranspose_mul_eq_zero Y Z).2 hYZ
+    have hker : (Y * Yᴴ) *ᵥ (fun a ↦ Z a j) = 0 := by
+      funext a
+      have hEntry := congrArg (fun A : Matrix (Fin d) (Fin l) ℂ ↦ A a j) hmat
+      simpa [Matrix.mulVec, dotProduct, Matrix.mul_apply] using hEntry
+    have hsupport := MPSTensor.supportProj_mulVec_eq_zero_of_mulVec_eq_zero
+      (Y * Yᴴ) (Matrix.posSemidef_self_mul_conjTranspose Y) (fun a ↦ Z a j) hker
+    simpa [πY, Matrix.mul_apply, Matrix.mulVec, dotProduct] using congrFun hsupport i
+  obtain ⟨W, hW⟩ := MPSTensor.exists_supportProj_eq_mul
+    (Z * Zᴴ) (Matrix.posSemidef_self_mul_conjTranspose Z)
+  have hπZ : πZ = Z * Zᴴ * W := by simpa [πZ] using hW
+  calc
+    πY * πZ = πY * (Z * Zᴴ * W) := by rw [hπZ]
+    _ = (πY * Z) * (Zᴴ * W) := by simp only [Matrix.mul_assoc]
+    _ = 0 := by rw [hπYZ, Matrix.zero_mul]
+
+/-- The support projection of the stacked physical columns fixes every physical slice on the
+left. -/
+theorem physicalSupportProj_mul_physicalSlice (K : MPOTensor d D) (β α : Fin D) :
+    physicalSupportProj K * physicalSlice K β α = physicalSlice K β α := by
+  have hColumns := MPSTensor.supportProj_mul_left_eq_self (physicalSliceColumns K)
+  ext i j
+  have hEntry := congrArg
+    (fun A : Matrix (Fin d) (Fin (D * D * d)) ℂ ↦
+      A i (finProdFinEquiv (finProdFinEquiv (β, α), j))) hColumns
+  simpa [physicalSupportProj, Matrix.mul_apply, physicalSlice] using hEntry
+
+/-- Adjoint closure makes the same physical support projection fix every slice on the right. -/
+theorem physicalSlice_mul_physicalSupportProj_of_isInjective_isMPDO
+    (K : MPOTensor d D) (hInj : MPSTensor.IsInjective K.toMPSTensor) (hK : IsMPDO K)
+    (β α : Fin D) :
+    physicalSlice K β α * physicalSupportProj K = physicalSlice K β α := by
+  obtain ⟨_, hAdj⟩ :=
+    exists_physicalSlice_conjTranspose_eq_sum_of_isInjective_isMPDO K hInj hK
+  have hleftAdj : physicalSupportProj K * (physicalSlice K β α)ᴴ =
+      (physicalSlice K β α)ᴴ := by
+    rw [hAdj β α, Matrix.mul_sum]
+    simp_rw [Matrix.mul_sum, Matrix.mul_smul, physicalSupportProj_mul_physicalSlice]
+  have hHerm : (physicalSupportProj K).IsHermitian :=
+    (MPSTensor.isOrthogonalProjection_supportProj
+      (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
+      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))).1
+  have hstar := congrArg Matrix.conjTranspose hleftAdj
+  simpa [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose, hHerm.eq] using hstar
+
+/-- Distinct BNT layers vanish under ordinary vertical composition, with the $y$ layer above
+ the $x$ layer.
+
+The dependent bond dimension permits different BNT elements to have different virtual spaces.
+There is no adjoint in this identity.
+
+Source: arXiv:1606.00608, Theorem 4.9(iv), equation `KxKy=0`, lines 863--868,
+and Appendix C.2, equation `AppKxKy=0`, lines 1634--1639. -/
+def IsBNTLayerOrthogonal (K : (x : Fin g) → MPOTensor d (bondDim x)) : Prop :=
+  ∀ x y, x ≠ y → layerMul (K y) (K x) = 0
+
+/-- Layer orthogonality is equivalent to vanishing of every ordered product of physical slices.
+The first factor is a slice of the $y$ layer and the second a slice of the $x$ layer, matching
+the vertical order in equation `AppKxKy=0`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppKxKy=0`, lines 1634--1639. -/
+theorem isBNTLayerOrthogonal_iff_physicalSlice_mul_eq_zero
+    (K : (x : Fin g) → MPOTensor d (bondDim x)) :
+    IsBNTLayerOrthogonal K ↔
+      ∀ x y, x ≠ y → ∀ (βy αy : Fin (bondDim y)) (βx αx : Fin (bondDim x)),
+        physicalSlice (K y) βy αy * physicalSlice (K x) βx αx = 0 := by
+  constructor
+  · intro h x y hxy βy αy βx αx
+    ext i j
+    have hEntry := congrArg
+      (fun T : MPOTensor d (bondDim y * bondDim x) ↦
+        T i j (finProdFinEquiv (βy, βx)) (finProdFinEquiv (αy, αx)))
+      (h x y hxy)
+    simpa [layerMul_apply, physicalSlice, Matrix.mul_apply] using hEntry
+  · intro h x y hxy
+    funext i j
+    ext a b
+    obtain ⟨⟨βy, βx⟩, rfl⟩ := finProdFinEquiv.surjective a
+    obtain ⟨⟨αy, αx⟩, rfl⟩ := finProdFinEquiv.surjective b
+    have hEntry := congrArg (fun A : Matrix (Fin d) (Fin d) ℂ ↦ A i j)
+      (h x y hxy βy αy βx αx)
+    simpa [layerMul_apply, physicalSlice, Matrix.mul_apply] using hEntry
+
+/-- Entrywise form of BNT layer orthogonality.  It keeps both heterogeneous bond-index pairs
+explicit and preserves the exact order $K_y K_x$.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppKxKy=0`, lines 1634--1639. -/
+theorem isBNTLayerOrthogonal_iff_physicalSlice_mul_apply_eq_zero
+    (K : (x : Fin g) → MPOTensor d (bondDim x)) :
+    IsBNTLayerOrthogonal K ↔
+      ∀ x y, x ≠ y → ∀ (βy αy : Fin (bondDim y)) (βx αx : Fin (bondDim x))
+        (i j : Fin d),
+        ∑ k : Fin d, K y i k βy αy * K x k j βx αx = 0 := by
+  rw [isBNTLayerOrthogonal_iff_physicalSlice_mul_eq_zero]
+  constructor
+  · intro h x y hxy βy αy βx αx i j
+    have hEntry := congrArg (fun A : Matrix (Fin d) (Fin d) ℂ ↦ A i j)
+      (h x y hxy βy αy βx αx)
+    simpa [physicalSlice, Matrix.mul_apply] using hEntry
+  · intro h x y hxy βy αy βx αx
+    ext i j
+    simpa [physicalSlice, Matrix.mul_apply] using h x y hxy βy αy βx αx i j
+
+/-- For distinct injective MPDO layers, ordinary layer annihilation makes the stacked physical
+column spaces orthogonal. -/
+theorem physicalSliceColumns_conjTranspose_mul_eq_zero
+    (K : (x : Fin g) → MPOTensor d (bondDim x))
+    (hInj : ∀ x, MPSTensor.IsInjective (K x).toMPSTensor)
+    (hMPDO : ∀ x, IsMPDO (K x)) (hOrth : IsBNTLayerOrthogonal K)
+    {x y : Fin g} (hxy : x ≠ y) :
+    (physicalSliceColumns (K x))ᴴ * physicalSliceColumns (K y) = 0 := by
+  have hMul := (isBNTLayerOrthogonal_iff_physicalSlice_mul_eq_zero K).mp hOrth
+  obtain ⟨_, hAdj⟩ :=
+    exists_physicalSlice_conjTranspose_eq_sum_of_isInjective_isMPDO
+      (K x) (hInj x) (hMPDO x)
+  have hSlice (βx αx : Fin (bondDim x)) (βy αy : Fin (bondDim y)) :
+      (physicalSlice (K x) βx αx)ᴴ * physicalSlice (K y) βy αy = 0 := by
+    rw [hAdj βx αx, Finset.sum_mul]
+    apply Finset.sum_eq_zero
+    intro ν _
+    rw [Finset.sum_mul]
+    apply Finset.sum_eq_zero
+    intro μ _
+    rw [Matrix.smul_mul, hMul y x hxy.symm μ ν βy αy, smul_zero]
+  ext qx qy
+  have hEntry := congrArg (fun A : Matrix (Fin d) (Fin d) ℂ ↦
+    A qx.modNat qy.modNat)
+    (hSlice qx.divNat.divNat qx.divNat.modNat qy.divNat.divNat qy.divNat.modNat)
+  simpa [physicalSliceColumns, physicalSlice, Matrix.mul_apply,
+    Matrix.conjTranspose_apply] using hEntry
+
+/-- An injective MPDO family satisfying ordinary BNT layer orthogonality has pairwise
+orthogonal physical support projections, and each projection fixes every physical slice on
+both sides.  Positivity supplies adjoint closure; no adjoint orthogonality is assumed.  This
+constructs the pairwise supports, but not the completeness identity `Pis` from the paper.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppKxKy=0` and `PjKiPj`,
+lines 1634--1639 and 1680--1691. -/
+theorem exists_pairwise_orthogonal_twoSided_physicalSupport
+    (K : (x : Fin g) → MPOTensor d (bondDim x))
+    (hInj : ∀ x, MPSTensor.IsInjective (K x).toMPSTensor)
+    (hMPDO : ∀ x, IsMPDO (K x)) (hOrth : IsBNTLayerOrthogonal K) :
+    ∃ P : Fin g → Matrix (Fin d) (Fin d) ℂ,
+      (∀ x, IsOrthogonalProjection (P x)) ∧
+      (∀ {x y}, x ≠ y → P x * P y = 0) ∧
+      (∀ x (β α : Fin (bondDim x)),
+        P x * physicalSlice (K x) β α = physicalSlice (K x) β α ∧
+          physicalSlice (K x) β α * P x = physicalSlice (K x) β α) := by
+  let P : Fin g → Matrix (Fin d) (Fin d) ℂ := fun x ↦ physicalSupportProj (K x)
+  refine ⟨P, ?_, ?_, ?_⟩
+  · intro x
+    exact MPSTensor.isOrthogonalProjection_supportProj
+      (physicalSliceColumns (K x) * (physicalSliceColumns (K x))ᴴ)
+      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns (K x)))
+  · intro x y hxy
+    exact supportProj_mul_supportProj_eq_zero_of_conjTranspose_mul_eq_zero
+      (physicalSliceColumns (K x)) (physicalSliceColumns (K y))
+      (physicalSliceColumns_conjTranspose_mul_eq_zero K hInj hMPDO hOrth hxy)
+  · intro x β α
+    exact ⟨physicalSupportProj_mul_physicalSlice (K x) β α,
+      physicalSlice_mul_physicalSupportProj_of_isInjective_isMPDO
+        (K x) (hInj x) (hMPDO x) β α⟩
+
+/-- Pairwise-annihilating one-site matrices that support every physical slice on both sides
+imply BNT layer orthogonality.  No idempotence or self-adjointness of these matrices is required.
+
+Source: arXiv:1606.00608, Theorem 4.9(iv), equation `KxKy=0`, lines 863--868,
+and Appendix C.2, equations `AppKxKy=0` and `PjKiPj`, lines 1634--1639 and
+1688--1689. -/
+theorem isBNTLayerOrthogonal_of_pairwise_orthogonal_twoSided_support
+    (K : (x : Fin g) → MPOTensor d (bondDim x))
+    (P : Fin g → Matrix (Fin d) (Fin d) ℂ)
+    (hPorth : ∀ {x y}, x ≠ y → P x * P y = 0)
+    (hSupport : ∀ x (β α : Fin (bondDim x)),
+      P x * physicalSlice (K x) β α = physicalSlice (K x) β α ∧
+        physicalSlice (K x) β α * P x = physicalSlice (K x) β α) :
+    IsBNTLayerOrthogonal K := by
+  rw [isBNTLayerOrthogonal_iff_physicalSlice_mul_eq_zero]
+  intro x y hxy βy αy βx αx
+  calc
+    physicalSlice (K y) βy αy * physicalSlice (K x) βx αx =
+        (physicalSlice (K y) βy αy * P y) *
+          (P x * physicalSlice (K x) βx αx) := by rw [(hSupport y βy αy).2,
+            (hSupport x βx αx).1]
+    _ = physicalSlice (K y) βy αy * (P y * P x) *
+          physicalSlice (K x) βx αx := by simp only [Matrix.mul_assoc]
+    _ = 0 := by rw [hPorth hxy.symm, Matrix.mul_zero, Matrix.zero_mul]
+
+/-! ### A square-zero obstruction to a generic support converse -/
+
+namespace BNTLayerOrthogonalityCounterexample
+
+/-- The nonzero square-zero matrix $|0\rangle\langle 1|$ on a two-dimensional physical space. -/
+def squareZeroPhysicalMatrix : Matrix (Fin 2) (Fin 2) ℂ :=
+  fun i j ↦ if i = 0 ∧ j = 1 then 1 else 0
+
+/-- The chosen physical matrix is nonzero. -/
+theorem squareZeroPhysicalMatrix_ne_zero : squareZeroPhysicalMatrix ≠ 0 := by
+  intro h
+  have hEntry := congrArg (fun A : Matrix (Fin 2) (Fin 2) ℂ ↦ A 0 1) h
+  simp [squareZeroPhysicalMatrix] at hEntry
+
+/-- The chosen physical matrix squares to zero. -/
+theorem squareZeroPhysicalMatrix_mul_self :
+    squareZeroPhysicalMatrix * squareZeroPhysicalMatrix = 0 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [squareZeroPhysicalMatrix, Matrix.mul_apply]
+
+/-- The bond-dimension-one MPO tensor whose sole physical slice is the square-zero matrix. -/
+def tensor : MPOTensor 2 1 :=
+  fun i j _ _ ↦ squareZeroPhysicalMatrix i j
+
+/-- Two labelled copies of the same square-zero tensor. -/
+def family (_x : Fin 2) : MPOTensor 2 1 := tensor
+
+/-- Every physical slice of either labelled copy is the same square-zero matrix. -/
+@[simp] theorem physicalSlice_family (x : Fin 2) (β α : Fin 1) :
+    physicalSlice (family x) β α = squareZeroPhysicalMatrix := by
+  ext i j
+  simp [physicalSlice, family, tensor]
+
+/-- The two labelled copies satisfy the raw BNT layer-orthogonality identity. -/
+theorem family_isBNTLayerOrthogonal : IsBNTLayerOrthogonal family := by
+  rw [isBNTLayerOrthogonal_iff_physicalSlice_mul_eq_zero]
+  intro x y _ βy αy βx αx
+  rw [physicalSlice_family, physicalSlice_family, squareZeroPhysicalMatrix_mul_self]
+
+/-- The raw layer-orthogonality identity does not, for arbitrary MPO tensors, imply the
+existence of pairwise orthogonal one-site projections that fix every sector slice on both
+sides.  This statement concerns only that generic converse; it does not address the injectivity
+and MPDO hypotheses under which the support construction above applies.
+
+Source comparison: arXiv:1606.00608, Appendix C.2, equations `AppKxKy=0` and
+`PjKiPj`, lines 1634--1639 and 1688--1689, and Proposition `prop3to4`, lines
+1786--1796. -/
+theorem no_pairwise_orthogonal_twoSided_support :
+    ¬ ∃ P : Fin 2 → Matrix (Fin 2) (Fin 2) ℂ,
+      (∀ x, IsOrthogonalProjection (P x)) ∧
+      (∀ {x y}, x ≠ y → P x * P y = 0) ∧
+      (∀ x (β α : Fin 1),
+        P x * physicalSlice (family x) β α = physicalSlice (family x) β α ∧
+          physicalSlice (family x) β α * P x = physicalSlice (family x) β α) := by
+  rintro ⟨P, _hP, hPorth, hSupport⟩
+  have hSupportZero := (hSupport 0 0 0).1
+  have hSupportOne := (hSupport 1 0 0).1
+  rw [physicalSlice_family] at hSupportZero hSupportOne
+  have hzero : squareZeroPhysicalMatrix = 0 := by
+    calc
+      squareZeroPhysicalMatrix = P 0 * squareZeroPhysicalMatrix := hSupportZero.symm
+      _ = P 0 * (P 1 * squareZeroPhysicalMatrix) := by rw [hSupportOne]
+      _ = (P 0 * P 1) * squareZeroPhysicalMatrix := by rw [Matrix.mul_assoc]
+      _ = 0 := by rw [hPorth (by decide), Matrix.zero_mul]
+  exact squareZeroPhysicalMatrix_ne_zero hzero
+
+end BNTLayerOrthogonalityCounterexample
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
+++ b/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
@@ -3,10 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.OrthogonalProjection
-import TNLean.Algebra.PosSemidefSupport
-import TNLean.MPS.FundamentalTheorem.Basic
-import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.PhysicalSectorProductRealization
 import TNLean.MPS.MPDO.PhysicalSupportSALTransport
 import TNLean.MPS.MPDO.StackedLayers
@@ -67,6 +63,7 @@ lines 1634--1689. -/
 def physicalAdjointTensor (K : MPOTensor d D) : MPOTensor d D :=
   fun i j β α ↦ star (K j i β α)
 
+/-- Evaluating the physical adjoint swaps the physical indices and conjugates the entry. -/
 @[simp] theorem physicalAdjointTensor_apply (K : MPOTensor d D)
     (i j : Fin d) (β α : Fin D) :
     physicalAdjointTensor K i j β α = star (K j i β α) := rfl
@@ -181,6 +178,7 @@ noncomputable def physicalSupportProj (K : MPOTensor d D) : Matrix (Fin d) (Fin 
     (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
     (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))
 
+/-- The product index selects the corresponding virtual pair and physical column. -/
 @[simp] theorem physicalSliceColumns_apply_finProdFinEquiv (K : MPOTensor d D)
     (i j : Fin d) (β α : Fin D) :
     physicalSliceColumns K i (finProdFinEquiv (finProdFinEquiv (β, α), j)) = K i j β α := by

--- a/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
+++ b/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
@@ -27,7 +27,7 @@ local identity alone does not provide such support projections for arbitrary MPO
   equations `AppKxKy=0` and `PjKiPj`, lines 1634--1639 and 1680--1691
 -/
 
-open scoped Matrix ComplexOrder BigOperators Kronecker
+open scoped Matrix ComplexOrder BigOperators
 
 namespace MPOTensor
 

--- a/TNLean/MPS/MPDO/CommonWeightAbsorbedBNTSupport.lean
+++ b/TNLean/MPS/MPDO/CommonWeightAbsorbedBNTSupport.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTLayerOrthogonality
-import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
 
 /-!
@@ -22,7 +21,7 @@ the given physical-sector factorizations.
   lines 1383--1450 and 1634--1691
 -/
 
-open scoped Matrix
+open scoped Matrix ComplexOrder
 
 namespace MPOTensor
 
@@ -32,8 +31,8 @@ variable {d : ℕ}
 orthogonal vertical layers have pairwise orthogonal two-sided physical support projections.
 
 This combines the standing one-site spanning condition with the local physical-sector
-factorization and positivity data.  It constructs the sector supports but does not assert that
-their sum is the identity.
+factorization and pointwise positivity of its neighboring operators; no trace factorization is
+required.  It constructs the sector supports but does not assert that their sum is the identity.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `CFK`, `AppUkU=rl`, `Appetakhetc`,
 `AppKxKy=0`, and `PjKiPj`, lines 1383--1450 and 1634--1691. -/
@@ -44,7 +43,7 @@ theorem exists_pairwise_orthogonal_twoSided_physicalSupport_commonWeightAbsorbed
     (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
     (F : (s : Fin S.basisCount) → PhysicalSectorFactorization
       (commonWeightAbsorbedBasisMPOTensor S hWeight s))
-    (hNeighbor : ∀ s, PhysicalSectorFactorization.NeighboringTraceFactorization (F s))
+    (hNeighbor : ∀ s q h, ((F s).neighboringOperator q h).PosSemidef)
     (hLayer : IsBNTLayerOrthogonal
       (fun s ↦ commonWeightAbsorbedBasisMPOTensor S hWeight s)) :
     ∃ P : Fin S.basisCount → Matrix (Fin d) (Fin d) ℂ,
@@ -57,8 +56,7 @@ theorem exists_pairwise_orthogonal_twoSided_physicalSupport_commonWeightAbsorbed
             physicalSlice (commonWeightAbsorbedBasisMPOTensor S hWeight s) β α) := by
   apply exists_pairwise_orthogonal_twoSided_physicalSupport
   · exact fun s ↦ commonWeightAbsorbedBasisMPOTensor_isInjective S hWeight hSpan s
-  · exact fun s ↦ (F s).isMPDO_of_neighboringOperator_pos
-      (hNeighbor s).neighboringOperator_pos
+  · exact fun s ↦ (F s).isMPDO_of_neighboringOperator_pos (hNeighbor s)
   · exact hLayer
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/CommonWeightAbsorbedBNTSupport.lean
+++ b/TNLean/MPS/MPDO/CommonWeightAbsorbedBNTSupport.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTLayerOrthogonality
+import TNLean.MPS.MPDO.NeighboringPreparation
+import TNLean.MPS.MPDO.PhysicalSupportRestriction
+
+/-!
+# Physical supports for common-weight-absorbed BNT representatives
+
+This file specializes the generic support theorem for orthogonal BNT layers to the
+common-weight-absorbed representatives of a sector decomposition.  One-site spanning supplies
+injectivity, while positivity of the neighboring operators supplies the MPDO condition through
+the given physical-sector factorizations.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `CFK`, `AppUkU=rl`, `Appetakhetc`, `AppKxKy=0`, and `PjKiPj`,
+  lines 1383--1450 and 1634--1691
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d : ℕ}
+
+/-- Common-weight-absorbed BNT representatives with positive neighboring operators and
+orthogonal vertical layers have pairwise orthogonal two-sided physical support projections.
+
+This combines the standing one-site spanning condition with the local physical-sector
+factorization and positivity data.  It constructs the sector supports but does not assert that
+their sum is the identity.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `CFK`, `AppUkU=rl`, `Appetakhetc`,
+`AppKxKy=0`, and `PjKiPj`, lines 1383--1450 and 1634--1691. -/
+theorem exists_pairwise_orthogonal_twoSided_physicalSupport_commonWeightAbsorbedBasis
+    (S : MPSTensor.SectorDecomposition (d * d))
+    (hWeight : ∀ (j : Fin S.basisCount) (q q' : Fin (S.copies j)),
+      S.weight j q = S.weight j q')
+    (hSpan : MPSTensor.WordTupleSpanTop S.basis 1)
+    (F : (s : Fin S.basisCount) → PhysicalSectorFactorization
+      (commonWeightAbsorbedBasisMPOTensor S hWeight s))
+    (hNeighbor : ∀ s, PhysicalSectorFactorization.NeighboringTraceFactorization (F s))
+    (hLayer : IsBNTLayerOrthogonal
+      (fun s ↦ commonWeightAbsorbedBasisMPOTensor S hWeight s)) :
+    ∃ P : Fin S.basisCount → Matrix (Fin d) (Fin d) ℂ,
+      (∀ s, IsOrthogonalProjection (P s)) ∧
+      (∀ {s t}, s ≠ t → P s * P t = 0) ∧
+      (∀ s (β α : Fin (S.basisDim s)),
+        P s * physicalSlice (commonWeightAbsorbedBasisMPOTensor S hWeight s) β α =
+            physicalSlice (commonWeightAbsorbedBasisMPOTensor S hWeight s) β α ∧
+          physicalSlice (commonWeightAbsorbedBasisMPOTensor S hWeight s) β α * P s =
+            physicalSlice (commonWeightAbsorbedBasisMPOTensor S hWeight s) β α) := by
+  apply exists_pairwise_orthogonal_twoSided_physicalSupport
+  · exact fun s ↦ commonWeightAbsorbedBasisMPOTensor_isInjective S hWeight hSpan s
+  · exact fun s ↦ (F s).isMPDO_of_neighboringOperator_pos
+      (hNeighbor s).neighboringOperator_pos
+  · exact hLayer
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -361,6 +361,34 @@
     orthogonal, hence $P_xP_y=0$.
 \end{proof}
 
+\begin{corollary}[Supports of common-weight BNT representatives]
+    \label{cor:mpdo_common_weight_bnt_layer_supports}
+    \lean{MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport_commonWeightAbsorbedBasis}
+    \leanok
+    \uses{thm:mpdo_neighboring_sector_positivity,
+        thm:mpdo_bnt_layer_orthogonal_supports}
+    Let a BNT decomposition have a common nonzero weight within each sector,
+    and suppose that its one-site words span the product of the virtual matrix
+    algebras. For every sector $s$, assume a physical-sector factorization with
+    positive neighboring operators. If distinct absorbed representatives obey
+    the unstarred layer identities, then there are pairwise orthogonal
+    projections $P_s$ such that
+    \begin{align}
+        P_s\mathcal K_s[\beta,\alpha]
+        &=\mathcal K_s[\beta,\alpha]
+         =\mathcal K_s[\beta,\alpha]P_s
+        \notag
+    \end{align}
+    for every $s,\beta,\alpha$.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    One-site spanning makes every absorbed representative injective. The
+    positive neighboring operators make every representative an MPDO. Apply
+    Theorem~\ref{thm:mpdo_bnt_layer_orthogonal_supports}.
+\end{proof}
+
 \begin{theorem}[Square-zero obstruction for arbitrary MPO tensors]
     \label{thm:mpdo_bnt_layer_square_zero_obstruction}
     \lean{MPOTensor.BNTLayerOrthogonalityCounterexample.squareZeroPhysicalMatrix_ne_zero,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -217,10 +217,11 @@
 
 \begin{proof}
     \leanok
-    In sector coordinates, the periodic operator is a sum of cyclic products
-    of the positive neighboring operators. It is therefore positive
-    semidefinite. Conjugation by $U^{\otimes N}$ preserves positivity and
-    returns $\rho^{(N)}(K)$.
+    In sector coordinates, the periodic operator is block diagonal, and each
+    block is a tensor product of positive neighboring operators. Hence every
+    block, and therefore the full operator, is positive semidefinite.
+    Conjugation by $U^{\otimes N}$ preserves positivity and returns
+    $\rho^{(N)}(K)$.
 \end{proof}
 
 \begin{definition}[Unstarred orthogonality of BNT layers]
@@ -310,6 +311,11 @@
     entries yields the displayed expansion.
 \end{proof}
 
+% **Partial coverage of CPSV16 Proposition `prop3to4`:** this theorem derives
+% pairwise two-sided supports from `AppKxKy=0` under the standing biCF
+% injectivity and the sectorwise positivity supplied by `AppUkU=rl` and
+% `Appetakhetc`.  It does not derive the common-copy-weight identity, a
+% supported commuting bond for each outer sector, or the final GSNNCH form.
 \begin{theorem}[Orthogonal two-sided supports from unstarred layer orthogonality]
     \label{thm:mpdo_bnt_layer_orthogonal_supports}
     \lean{MPOTensor.physicalSliceColumns,
@@ -437,18 +443,11 @@ This is the calculation in
 % independence is given by
 % thm:simple_mpdo_local_structure_data_of_sal_zcl. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-% **Partial coverage:** the support implication is covered by
-% thm:mpdo_bnt_layer_orthogonal_supports under the standing biCF
-% injectivity and sectorwise MPDO positivity.  The exact five-identity
-% package AppKxKy=0, AppUkU=rl, Appetakhetc, Apptralktrrk, AppPsiPhi
-% The completeness identity sum_j P_j = Id is not a conclusion of the
-% pairwise-support theorem.  It and the final GSNNCH assembly remain pending.
 \begin{theorem}[BNT sector structure from SAL and ZCL]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}
     \notready
     \uses{def:is_sal, def:mpo_source_zcl,
-        thm:mpdo_neighboring_sector_positivity,
-        thm:mpdo_bnt_layer_orthogonal_supports}
+        cor:mpdo_sal_zcl_local_sector_structure}
     Let $K$ be a simple tensor in block-injective canonical form (biCF),
     equipped with a basis-of-normal-tensors decomposition. If $K$ satisfies
     the strong area law and zero correlation length, then its basis tensors
@@ -460,9 +459,9 @@ This is the calculation in
         \sum_k a_kb_k&=1. \notag
     \end{align}
     This is implication (ii)$\Rightarrow$(iv) of
-    \cite[Theorem~4.9 and Appendix~C.2, lines~1740--1788]
+    \cite[Theorem~4.9 and Appendix~C.2, lines~1740--1782]
       {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
-    imposed at lines~849--850 and restated at line~1628 of the same source.
+    imposed at line~849 and restated at line~1628 of the same source.
     The orthogonal-support conclusion uses the injectivity supplied by biCF,
     the positive neighboring operators in each sector factorization, and the
     unstarred layer identities. The remaining identities specify the local

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -200,31 +200,195 @@
     assumption.
 \end{theorem}
 
-For $x\ne y$, the two vertical MPO layers annihilate:
+\begin{theorem}[Positive neighboring sectors generate positive periodic operators]
+    \label{thm:mpdo_neighboring_sector_positivity}
+    \lean{MPOTensor.PhysicalSectorFactorization.isMPDO_of_neighboringOperator_pos}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    Suppose that an MPO tensor $K$ admits a physical-sector factorization
+    through an isometry $U$, with neighboring operators
+    $\eta_{q,h}$. If $\eta_{q,h}\geq0$ for every pair $(q,h)$, then
+    \begin{align}
+        \rho^{(N)}(K)&\geq0
+        \qquad (N\geq1).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    In sector coordinates, the periodic operator is a sum of cyclic products
+    of the positive neighboring operators. It is therefore positive
+    semidefinite. Conjugation by $U^{\otimes N}$ preserves positivity and
+    returns $\rho^{(N)}(K)$.
+\end{proof}
+
+\begin{definition}[Unstarred orthogonality of BNT layers]
+    \label{def:mpdo_bnt_layer_orthogonality}
+    \lean{MPOTensor.IsBNTLayerOrthogonal,
+        MPOTensor.isBNTLayerOrthogonal_iff_physicalSlice_mul_eq_zero,
+        MPOTensor.isBNTLayerOrthogonal_iff_physicalSlice_mul_apply_eq_zero}
+    \leanok
+    For a family $\{\mathcal K_x\}_{x=0}^{g-1}$, write
+    $\mathcal K_x[\beta,\alpha]\in M_d(\C)$ for the physical matrix obtained
+    by fixing the two virtual indices. The layers are orthogonal when, for
+    $x\ne y$,
+    \begin{align}
+        \mathcal K_y[\beta_y,\alpha_y]\,
+        \mathcal K_x[\beta_x,\alpha_x]&=0
+        \label{eq:mpdo_bnt_layer_unstarred}
+    \end{align}
+    for every choice of virtual indices. Equivalently, for all physical
+    indices $i,j$,
+    \begin{align}
+        \sum_{k=0}^{d-1}
+        (\mathcal K_y)^{ik}_{\beta_y\alpha_y}
+        (\mathcal K_x)^{kj}_{\beta_x\alpha_x}&=0.
+        \notag
+    \end{align}
+    The factor order is exactly $\mathcal K_y\mathcal K_x$; no adjoint occurs.
+    This is equation \texttt{AppKxKy=0} in
+    \cite[Appendix~C.2, lines~1634--1639]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{center}
-    % Formula: (\mathcal K_y\mathcal K_x)^{ij}_{a_y a_x;b_y b_x}
-    % = \sum_q (\mathcal K_y)^{iq}_{a_y b_y}
-    % (\mathcal K_x)^{qj}_{a_x b_x}=0 for x\ne y.
-    % Source: Papers/1606.00608/MPDO_KxKy.png and source TeX lines 863--868.
-    % The upper source glyph is plain \mathcal K_y: the vertical contraction is
-    % ordinary MPO-layer multiplication, with no adjoint or conjugation.
-    % Ink-to-index: q is the sole contracted physical index; the free indices
-    % are west (a_y,a_x), east (b_y,b_x), up i, and down j.
-    % LHS paired signature: boundary|virtual-west=2|virtual-east=2|
-    % physical-up=1|physical-down=1. The typed-zero RHS has that same boundary
-    % type, although the plain 0 carries no tensor-network ink.
+    % Exact source orientation: the upper layer is plain K_y and the lower
+    % layer is plain K_x.  There is no conjugation or adjoint in AppKxKy=0.
+    % Source: Papers/1606.00608/MPDO_KxKy.png and source TeX lines 1634--1639.
     \begin{tenkz}[rows={op,op}]
         \tn[mpo]{\mathcal K_y} \\
         \tn[mpo]{\mathcal K_x}
     \end{tenkz}
-    $ = 0$
+    $ = 0 \qquad (x\ne y)$
 \end{center}
-In contraction notation, the cross-sector layer identity is
-$\mathcal K_y\mathcal K_x=0$ whenever $x\ne y$.
-This is \cite[Theorem~4.9(iv), lines~863--868]{Cirac2016MPDO_arXiv}.
 
-Expanding $\sum_jP_j=\Id$ on both physical indices and using the sector
-projector relations leaves only the diagonal term:
+\begin{definition}[Physical adjoint]
+    \label{def:mpdo_physical_adjoint}
+    \lean{MPOTensor.physicalAdjointTensor,
+        MPOTensor.physicalSlice_physicalAdjointTensor,
+        MPOTensor.mpo_physicalAdjointTensor}
+    \leanok
+    For an MPO tensor $K$, define $K^\sharp$ by
+    \begin{align}
+        (K^\sharp)^{ij}_{\beta\alpha}
+        &=\overline{K^{ji}_{\beta\alpha}}.
+        \notag
+    \end{align}
+    Thus $K^\sharp[\beta,\alpha]=K[\beta,\alpha]^*$, while the virtual
+    indices retain their order. For every periodic chain,
+    \begin{align}
+        \rho^{(N)}(K^\sharp)_{\sigma,\tau}
+        &=\overline{\rho^{(N)}(K)_{\tau,\sigma}}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Adjoint closure of the physical slices]
+    \label{thm:mpdo_injective_mpdo_adjoint_closure}
+    \lean{MPOTensor.IsMPDO.sameMPV₂Pos_physicalAdjointTensor,
+        MPOTensor.IsMPDO.sameMPV_physicalAdjointTensor,
+        MPOTensor.exists_physicalSlice_conjTranspose_eq_sum_of_isInjective_isMPDO}
+    \leanok
+    \uses{def:mpdo_physical_adjoint, thm:ft_single}
+    Let $K$ be injective and suppose that $\rho^{(N)}(K)\geq0$ for every
+    $N\geq1$. Then the linear span of its physical slices is closed under
+    conjugate transpose. More precisely, there is $X\in\GL_D(\C)$ such that
+    \begin{align}
+        K[\beta,\alpha]^*
+        &=\sum_{\nu,\mu=0}^{D-1}
+          X_{\beta\mu}(X^{-1})_{\nu\alpha}K[\mu,\nu]
+        \notag
+    \end{align}
+    for all virtual indices $\beta,\alpha$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Positivity makes every periodic operator Hermitian, so $K$ and
+    $K^\sharp$ generate the same matrix-product vectors. The single-block
+    fundamental theorem gives the inner gauge $X$. Taking its virtual matrix
+    entries yields the displayed expansion.
+\end{proof}
+
+\begin{theorem}[Orthogonal two-sided supports from unstarred layer orthogonality]
+    \label{thm:mpdo_bnt_layer_orthogonal_supports}
+    \lean{MPOTensor.physicalSliceColumns,
+        MPOTensor.physicalSupportProj,
+        MPOTensor.physicalSupportProj_mul_physicalSlice,
+        MPOTensor.physicalSlice_mul_physicalSupportProj_of_isInjective_isMPDO,
+        MPOTensor.physicalSliceColumns_conjTranspose_mul_eq_zero,
+        MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport,
+        MPOTensor.isBNTLayerOrthogonal_of_pairwise_orthogonal_twoSided_support}
+    \leanok
+    \uses{def:mpdo_bnt_layer_orthogonality,
+        thm:mpdo_injective_mpdo_adjoint_closure}
+    Let $\{\mathcal K_x\}_{x=0}^{g-1}$ be injective MPO tensors, each of which
+    generates positive semidefinite periodic operators at every positive
+    length. If the unstarred identities
+    \begin{align}
+        \mathcal K_y[\beta_y,\alpha_y]\,
+        \mathcal K_x[\beta_x,\alpha_x]&=0
+        \qquad (x\ne y)
+        \notag
+    \end{align}
+    hold for all virtual indices, then there are pairwise orthogonal
+    projections $P_x\in M_d(\C)$ such that
+    \begin{align}
+        P_x\mathcal K_x[\beta,\alpha]
+        &=\mathcal K_x[\beta,\alpha]
+         =\mathcal K_x[\beta,\alpha]P_x
+        \notag
+    \end{align}
+    for every $x,\beta,\alpha$. Conversely, any pairwise annihilating family
+    with these two-sided support identities satisfies the unstarred layer
+    identities.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Stack the columns of all slices of $\mathcal K_x$ and let $P_x$ be the
+    orthogonal projection onto their span. The left support identity is
+    immediate. By Theorem~\ref{thm:mpdo_injective_mpdo_adjoint_closure}, the
+    slice span is closed under conjugate transpose, which gives the right
+    support identity. For $x\ne y$, equation~\eqref{eq:mpdo_bnt_layer_unstarred}
+    and adjoint closure imply that the two stacked column spaces are
+    orthogonal, hence $P_xP_y=0$.
+\end{proof}
+
+\begin{theorem}[Square-zero obstruction for arbitrary MPO tensors]
+    \label{thm:mpdo_bnt_layer_square_zero_obstruction}
+    \lean{MPOTensor.BNTLayerOrthogonalityCounterexample.squareZeroPhysicalMatrix_ne_zero,
+        MPOTensor.BNTLayerOrthogonalityCounterexample.squareZeroPhysicalMatrix_mul_self,
+        MPOTensor.BNTLayerOrthogonalityCounterexample.family_isBNTLayerOrthogonal,
+        MPOTensor.BNTLayerOrthogonalityCounterexample.no_pairwise_orthogonal_twoSided_support}
+    \leanok
+    \uses{def:mpdo_bnt_layer_orthogonality}
+    There is a two-label family of bond-dimension-one MPO tensors for which
+    the unstarred layer identities hold, but no pairwise orthogonal one-site
+    projections support both tensors on both sides. One may take both labels
+    to have the single physical slice
+    \begin{align}
+        A&=|0\rangle\langle1|,
+        &A\ne0,
+        &A^2=0.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The equation $A^2=0$ gives both ordered layer products. If $P_0P_1=0$
+    and $P_xA=A$ for both labels, then
+    \begin{align}
+        A=P_0A=P_0P_1A=0,
+        \notag
+    \end{align}
+    contradicting $A\ne0$.
+\end{proof}
+
+If the projections also satisfy $\sum_jP_j=\Id$, then expanding this
+identity on both physical indices and using the sector projector relations
+leaves only the diagonal term:
 \begin{align}
     \mathcal K_i
     &=\sum_{j,j'}P_j\,\mathcal K_i\,P_{j'}
@@ -273,10 +437,18 @@ This is the calculation in
 % independence is given by
 % thm:simple_mpdo_local_structure_data_of_sal_zcl. Documented in
 % docs/paper-gaps/cpgsv17_pf_rank_one.tex.
-\begin{theorem}[BNT sector structure from SAL and ZCL (open)]
+% **Partial coverage:** the support implication is covered by
+% thm:mpdo_bnt_layer_orthogonal_supports under the standing biCF
+% injectivity and sectorwise MPDO positivity.  The exact five-identity
+% package AppKxKy=0, AppUkU=rl, Appetakhetc, Apptralktrrk, AppPsiPhi
+% The completeness identity sum_j P_j = Id is not a conclusion of the
+% pairwise-support theorem.  It and the final GSNNCH assembly remain pending.
+\begin{theorem}[BNT sector structure from SAL and ZCL]
     \label{thm:mpdo_sal_zcl_bnt_sector_structure}
     \notready
-    \uses{def:is_sal, def:mpo_source_zcl}
+    \uses{def:is_sal, def:mpo_source_zcl,
+        thm:mpdo_neighboring_sector_positivity,
+        thm:mpdo_bnt_layer_orthogonal_supports}
     Let $K$ be a simple tensor in block-injective canonical form (biCF),
     equipped with a basis-of-normal-tensors decomposition. If $K$ satisfies
     the strong area law and zero correlation length, then its basis tensors
@@ -291,7 +463,8 @@ This is the calculation in
     \cite[Theorem~4.9 and Appendix~C.2, lines~1740--1788]
       {Cirac2016MPDO_arXiv}. The separate standing biCF and BNT hypotheses are
     imposed at lines~849--850 and restated at line~1628 of the same source.
-    The proof at lines~1745--1785 applies the structural corollary after
-    establishing SAL and ZCL for each basis tensor. Since that corollary uses
-    the refuted Lemma~C.5, the printed proof does not establish this proposition.
+    The orthogonal-support conclusion uses the injectivity supplied by biCF,
+    the positive neighboring operators in each sector factorization, and the
+    unstarred layer identities. The remaining identities specify the local
+    factorization and its rank-one normalization.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -207,10 +207,10 @@
     \uses{def:mpdo_physical_sector_factorization}
     Suppose that an MPO tensor $K$ admits a physical-sector factorization
     through an isometry $U$, with neighboring operators
-    $\eta_{q,h}$. If $\eta_{q,h}\geq0$ for every pair $(q,h)$, then
+    $\eta_{q,h}$. If $\eta_{q,h}\geq0$ for every pair $(q,h)$, then for every
+    $N\geq1$,
     \begin{align}
-        \rho^{(N)}(K)&\geq0
-        \qquad (N\geq1).
+        \rho^{(N)}(K)&\geq0.
         \notag
     \end{align}
 \end{theorem}
@@ -260,7 +260,7 @@
         \tn[mpo]{\mathcal K_y} \\
         \tn[mpo]{\mathcal K_x}
     \end{tenkz}
-    $ = 0 \qquad (x\ne y)$
+    $ = 0$
 \end{center}
 
 \begin{definition}[Physical adjoint]
@@ -330,11 +330,10 @@
         thm:mpdo_injective_mpdo_adjoint_closure}
     Let $\{\mathcal K_x\}_{x=0}^{g-1}$ be injective MPO tensors, each of which
     generates positive semidefinite periodic operators at every positive
-    length. If the unstarred identities
+    length. If, for every pair $x\ne y$, the unstarred identities
     \begin{align}
         \mathcal K_y[\beta_y,\alpha_y]\,
         \mathcal K_x[\beta_x,\alpha_x]&=0
-        \qquad (x\ne y)
         \notag
     \end{align}
     hold for all virtual indices, then there are pairwise orthogonal
@@ -352,13 +351,17 @@
 
 \begin{proof}
     \leanok
-    Stack the columns of all slices of $\mathcal K_x$ and let $P_x$ be the
-    orthogonal projection onto their span. The left support identity is
-    immediate. By Theorem~\ref{thm:mpdo_injective_mpdo_adjoint_closure}, the
-    slice span is closed under conjugate transpose, which gives the right
-    support identity. For $x\ne y$, equation~\eqref{eq:mpdo_bnt_layer_unstarred}
-    and adjoint closure imply that the two stacked column spaces are
-    orthogonal, hence $P_xP_y=0$.
+    Let $C_x$ be the matrix obtained by stacking the columns of all slices of
+    $\mathcal K_x$, and let $P_x$ be the orthogonal projection onto its column
+    space. The left support identity is immediate.
+    Theorem~\ref{thm:mpdo_injective_mpdo_adjoint_closure} gives the right
+    support identity. For $x\ne y$, (\ref{eq:mpdo_bnt_layer_unstarred}) and
+    adjoint closure give
+    \begin{align}
+        C_x^*C_y&=0,
+        &P_xP_y&=0.
+        \notag
+    \end{align}
 \end{proof}
 
 \begin{corollary}[Supports of common-weight BNT representatives]

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -122,9 +122,10 @@ and
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported}}.}
 Choosing supported products over all absorbed BNT representatives gives
 an orthogonal commuting sector family once the required one-site supports are
-available.  The previously missing support implication is now proved in the
-source setting relevant to Proposition~\texttt{prop3to4}.  The local identity
-is the unstarred ordered product
+available.  A source-context corollary now derives pairwise two-sided supports
+from common copy weights, one-site spanning, the positive neighboring-operator
+factorizations, and the unstarred layer identity.  The local identity is the
+ordered product
 \[
   {\cal K}_y[\beta_y,\alpha_y]\,
   {\cal K}_x[\beta_x,\alpha_x]=0
@@ -142,13 +143,16 @@ and their support projections fix every sector slice on both sides.
 {\scriptsize\leanid{MPOTensor.IsBNTLayerOrthogonal}},
 {\scriptsize\leanid{MPOTensor.PhysicalSectorFactorization.isMPDO_of_neighboringOperator_pos}},
 {\scriptsize\leanid{MPOTensor.exists_physicalSlice_conjTranspose_eq_sum_of_isInjective_isMPDO}},
+{\scriptsize\leanid{MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport}},
 and
-{\scriptsize\leanid{MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport}}.}
+{\scriptsize\leanid{MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport_commonWeightAbsorbedBasis}}.}
 
-This closes the pairwise two-sided support implication used in the source
-argument.  It does not prove the completeness identity $\sum_xP_x=\Id$, and
-it does not complete Proposition~\texttt{prop3to4}.  The source hypothesis is the joint
-five-identity package
+This formalizes the pairwise support consequence of the earlier Case~II data.
+The final printed proof of Proposition~\texttt{prop3to4} uses projector
+relations obtained earlier rather than deriving them in its last step.  The
+support corollary does not prove the completeness identity $\sum_xP_x=\Id$,
+and it does not complete Proposition~\texttt{prop3to4}.  The printed hypothesis
+is the joint five-identity package
 \[
   \texttt{AppKxKy=0},\quad
   \texttt{AppUkU=rl},\quad

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -83,52 +83,6 @@ through a one-sector witness.\footnote{\raggedright Formal declarations:
 one-sector form is the commuting product form in which Proposition~C.8 states
 its conclusion for an injective tensor.
 
-\section{The printed blockwise implication}
-
-Appendix C Proposition \texttt{prop3to4}, lines~1786--1796, assumes five
-blockwise identities.  Four are the physical-sector factorization
-\texttt{AppUkU=rl}, positivity of the neighboring operators
-\texttt{Appetakhetc}, their rank-one trace formula
-\texttt{Apptralktrrk}, and the scalar normalization
-\texttt{AppPsiPhi}.  These are represented by the physical-sector
-factorization and neighboring trace-factorization data.
-
-The fifth identity, \texttt{AppKxKy=0}, is the unstarred vertical product
-\[
-  \mathcal K_y\mathcal K_x=0 \qquad (x\ne y).
-\]
-Equivalently, if \texttt{layerMul} denotes vertical MPO composition, then
-\[
-  \operatorname{layerMul}(\mathcal K_y,\mathcal K_x)=0.
-\]
-The source diagram contains no adjoint or conjugation.  This identity is not
-the mixed-transfer condition used for pure-state BNTs.
-
-The current general GSNNCH theorem starts after pairwise orthogonal one-site
-sector projections and supported positive commuting bonds have been supplied.
-The available BNT construction obtains those projections from left-inverse,
-three-site closure, Markov-sector, nonzero-closing, one-site spanning, and
-sectorwise-SAL hypotheses.  No theorem presently derives the supported
-orthogonal sector family from exactly the five identities above.  In
-particular, ordinary products of non-Hermitian physical slices do not by
-themselves provide the cross-adjoint products needed to identify orthogonal
-two-sided supports.  Closing the literal proposition therefore requires either
-a derivation of that adjoint closure from the complete BNT and positivity
-context, or a corrected statement exposing the missing support hypothesis.
-
-There is a second independent interface condition.  The available BNT sum with
-natural multiplicities uses a common absorbed weight in each BNT sector,
-\[
-  \mu_{s,q}=\mu_{s,q'}\qquad\text{for all copies }q,q'.
-\]
-The five identities displayed in \texttt{prop3to4} do not imply this equality.
-Appendix~C.2 invokes \texttt{lemmus} earlier in the Case~II argument to obtain
-it from zero correlation length.  Consequently, a standalone formulation of
-\texttt{prop3to4} must either retain common copy weights as part of the standing
-BNT data or state that hypothesis explicitly.  Proving orthogonal supports
-alone does not supply the multiplicity-weighted BNT sum used by the current
-GSNNCH theorem.
-
 \section{Elimination plan}
 
 The first part of the original plan---positivity and translation invariance
@@ -166,19 +120,57 @@ restricted product.
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.restricted_isSAL}},
 and
 {\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported}}.}
-Choosing these supported products over all absorbed BNT representatives gives
-an orthogonal commuting sector family, and the BNT sum with its natural copy
-numbers therefore has the source GSNNCH form.
+Choosing supported products over all absorbed BNT representatives gives
+an orthogonal commuting sector family once the required one-site supports are
+available.  The previously missing support implication is now proved in the
+source setting relevant to Proposition~\texttt{prop3to4}.  The local identity
+is the unstarred ordered product
+\[
+  {\cal K}_y[\beta_y,\alpha_y]\,
+  {\cal K}_x[\beta_x,\alpha_x]=0
+  \qquad (x\ne y),
+\]
+not an adjoint product.  Under the standing biCF hypothesis, each BNT tensor
+is injective.  Equations~\texttt{AppUkU=rl} and
+\texttt{Appetakhetc} supply positive neighboring operators and hence an MPDO
+in every sector.  Hermiticity then identifies each sector tensor with its
+physical adjoint through the injective fundamental theorem, so the span of its
+physical slices is closed under conjugate transpose.  The unstarred ordered
+annihilation identities consequently make the slice-column spaces orthogonal,
+and their support projections fix every sector slice on both sides.
 \footnote{\raggedright Formal declarations:
-{\scriptsize\leanid{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL}}
+{\scriptsize\leanid{MPOTensor.IsBNTLayerOrthogonal}},
+{\scriptsize\leanid{MPOTensor.PhysicalSectorFactorization.isMPDO_of_neighboringOperator_pos}},
+{\scriptsize\leanid{MPOTensor.exists_physicalSlice_conjTranspose_eq_sum_of_isInjective_isMPDO}},
 and
-{\scriptsize\leanid{MPOTensor.hasGSNNCHForm_of_bntSectorSAL}}.}
-No reverse comparison with a single-bond predicate is needed for this
-implication.  The construction chooses one supported bond for each absorbed
-BNT representative, assembles these bonds into the orthogonal outer sectors,
-and concludes the source GSNNCH form directly from the positive-length BNT
-sum.  Thus a theorem extracting one bond from arbitrary GSNNCH sector data
-would not enter the proof of the simple-MPDO implication.
+{\scriptsize\leanid{MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport}}.}
+
+This closes the pairwise two-sided support implication used in the source
+argument.  It does not prove the completeness identity $\sum_xP_x=\Id$, and
+it does not complete Proposition~\texttt{prop3to4}.  The source hypothesis is the joint
+five-identity package
+\[
+  \texttt{AppKxKy=0},\quad
+  \texttt{AppUkU=rl},\quad
+  \texttt{Appetakhetc},\quad
+  \texttt{Apptralktrrk},\quad
+  \texttt{AppPsiPhi}.
+\]
+The final theorem assembling exactly this package, with the BNT
+multiplicities, into the GSNNCH sector decomposition remains to be supplied.
+There is also an independent common-copy-weight interface:
+\[
+  \mu_{s,q}=\mu_{s,q'}\qquad\text{for all copies }q,q'.
+\]
+The five displayed identities do not imply this equality.  Appendix~C.2 invokes
+\texttt{lemmus} earlier in the Case~II argument to obtain it from zero
+correlation length.  A standalone formulation must therefore retain common
+copy weights as standing BNT data or state the equality explicitly.
+
+The existing abstract theorem for an already constructed orthogonal commuting
+sector family is a later conditional step; it does not by itself perform this
+source-context construction.  No reverse comparison with a single-bond
+predicate is needed.
 
 The local Markov labels in Appendix C.2 belong inside one injective BNT
 component.  They are not the outer labels $x$ of Definition~4.8 and must not
@@ -188,22 +180,23 @@ be substituted for those outer sectors.
 
 Verdict: the source GSNNCH data and predicate are formalized, the represented
 sector sum is proved positive semidefinite and translation invariant with
-pairwise commuting translates, and the single-bond presentation is proved to
-give the one-sector case; every injective tensor satisfying the saturated
-area law is proved GSNNCH through a one-sector witness.  For a general simple
-tensor, the BNT projectors, their positive-length compression formula, and the
-sectorwise MPDO, SAL, and ZCL conclusions are formalized.  The abstract
-construction of the outer sector sum with its natural multiplicities is
-formalized, as is the injective restriction of every representative to its
-projector range.  SAL is invariant under the support isometry, and the
-resulting positive bond has a positive ambient lift supported on the matching
-two-site sector, and all cyclic translates of that lift commute pairwise on
-every periodic chain of length at least two.  Their product realizes the
-ambient finite-chain operator exactly, with normalization scalar one.  The
-supported products are assembled into the BNT outer sectors with their
-natural multiplicities.  This proves the GSNNCH implication under the
-projector-selection and sectorwise-SAL hypotheses.  The literal
-\texttt{prop3to4} implication from its five displayed identities remains the
-separate support question described above.
+pairwise commuting translates, and the single-bond presentation gives the
+one-sector case.  The exact unstarred BNT layer identity is formalized.  Under
+the standing biCF injectivity and the per-sector MPDO positivity supplied by
+the positive neighboring-operator factorization, it yields pairwise
+orthogonal one-site projections supporting every BNT tensor on both sides.
+This theorem does not assert that the projections sum to the identity.
+A square-zero family shows that this conclusion would be false for arbitrary
+MPO tensors without those hypotheses.
+
+The construction from an already supplied orthogonal commuting sector family
+to the GSNNCH form is available, together with the natural BNT multiplicities
+and the support-preserving positive bond construction.  The remaining
+source-faithful obligation is to derive that bond family from the exact five
+identities \texttt{AppKxKy=0}, \texttt{AppUkU=rl},
+\texttt{Appetakhetc}, \texttt{Apptralktrrk}, and
+\texttt{AppPsiPhi}, with common copy weights retained from the preceding
+Case~II argument.  Proposition~\texttt{prop3to4} should therefore not yet be
+classified as complete.
 
 \end{document}


### PR DESCRIPTION
## What changed

- formalize the support-theoretic consequence of the five ordered blockwise identities in CPSV16 Appendix C.2 (`prop3to4`, lines 1786–1796)
- derive pairwise orthogonal sector supports and two-sided slice absorption from the BNT layer products
- expose the common-copy-weight corollary under pointwise positive neighboring operators, keeping that independent hypothesis explicit
- synchronize the Chapter 21 Blueprint and the CPSV16 paper-gap record without claiming support completeness or the full GSNNCH conclusion

## Validation

- `lake exe cache get` before Lean builds in the fresh review worktree
- `lake build TNLean.MPS.MPDO.CommonWeightAbsorbedBNTSupport -q --log-level=info` — passed
- `lake build TNLean -q --log-level=info` — 9,805 jobs passed on hot main `2517200b3`
- reader-facing prose check — passed
- Blueprint/Lean sync — affected chapter 42/42; total 5,824/5,827
- `lake exe checkdecls blueprint/lean_decls` — passed
- `leanblueprint web` and `leanblueprint pdf` — passed; affected PDF pages 650–652 visually inspected
- generated import aggregators current
- `git diff --check` — passed
- no `sorry`, `axiom`, `unsafe`, conflict markers, or proof-history names in the added modules

Closes #5065

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and documentation only; no runtime, auth, or data-path changes. Scope is additive formalization with explicit non-claims about completeness.
> 
> **Overview**
> Adds Lean formalization for **unstarred** BNT vertical layer orthogonality (`AppKxKy=0`) and the support-theoretic bridge to pairwise orthogonal one-site projections, plus blueprint and paper-gap sync that records partial `prop3to4` progress without claiming GSNNCH completion.
> 
> **`BNTLayerOrthogonality.lean`** introduces `physicalAdjointTensor`, MPDO positivity from positive neighboring operators, `IsBNTLayerOrthogonal` with slice-level equivalences, and **`exists_pairwise_orthogonal_twoSided_physicalSupport`** under injectivity + MPDO + layer orthogonality (not \(\sum P_x = I\)). A square-zero counterexample shows the converse needs those hypotheses.
> 
> **`CommonWeightAbsorbedBNTSupport.lean`** instantiates that theorem for common-weight-absorbed BNT representatives (spanning, per-sector factorizations, positive \(\eta\), layer identity).
> 
> Chapter 21 blueprint gains matching definitions/theorems; the CPSV16 gap doc reframes elimination around the new support corollary and states that full **`prop3to4`** and support completeness remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d1e71eb3f86116ffd96817081a64b608e9a5d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->