### PR TITLE
fix(tenkz): correct RMP source pairings

### DIFF
--- a/docs/tenkz/wave2-targets.md
+++ b/docs/tenkz/wave2-targets.md
@@ -76,17 +76,17 @@ Otherwise it is **unowned**. The scan finds 107 labelled blocks: 90 owned and
 | `Diagram4` | 198–210 | owned: `rmp-workbench-iii-diagram-four` |
 | `Eq new52` | 211–219 | owned: `rmp-workbench-iii-eq50-reduced` |
 | `Eq intertwiner` | 220–304 | owned: `rmp-iii-a-commuting-hamiltonian`, `rmp-iii-a-f-symbol`, `rmp-workbench-iii-dual-reduced`, `rmp-workbench-iii-f-symbol-simplified-a`, `rmp-workbench-iii-f-tensor`, `rmp-workbench-iii-mpo-representation` |
-| `Eq 59now56` | 305–328 | owned: `rmp-workbench-iii-eq59-now` |
+| `Eq 59now56` | 305–328 | owned: `rmp-iii-a-g-injective-projector`, `rmp-workbench-iii-eq59-now` |
 | `diagram of clusterstate` | 329–356 | owned: `rmp-iii-a-ghz-state`, `rmp-workbench-iii-ghz-state-workbench` |
 | `ghzupdownmatrix` | 357–362 | owned: `rmp-iii-a-ghz-tensor`, `rmp-iii-a-hadamard`, `rmp-workbench-iii-ghz-up` |
 | `Frank's proof of MPS invariant under MPO` | 363–363 | owned: `rmp-iii-a-proof-one` |
 | `proof1` | 364–375 | owned: `rmp-iii-a-proof-one` |
 | `proof2` | 376–385 | owned: `rmp-iii-a-proof-two` |
 | `proof3` | 386–413 | owned: `rmp-iii-a-proof-three` |
-| `eq55now (Fig8previously draw)` | 414–447 | owned: `rmp-iii-a-pulling-through`, `rmp-iii-a-spt-mpo`, `rmp-workbench-iii-g-injective-pull` |
+| `eq55now (Fig8previously draw)` | 414–447 | owned: `rmp-iii-a-pulling-through`, `rmp-iii-a-spt-mpo` |
 | `Dia. intertwiner for SPT` | 448–467 | owned: `rmp-iii-a-spt-intertwiner`, `rmp-workbench-iii-intertwining-mpo` |
-| `pullingthroughtforGinjective (Fig8previously draw)` | 468–500 | owned: `rmp-iii-a-g-injective-projector` |
-| `veryold` | 501–520 | owned: `rmp-iii-a-g-injective-projector`, `rmp-workbench-iii-mpo-injective-white` |
+| `pullingthroughtforGinjective (Fig8previously draw)` | 468–500 | owned: `rmp-workbench-iii-g-injective-pull` |
+| `veryold` | 501–520 | owned: `rmp-workbench-iii-mpo-injective-white` |
 | `Explaining the MPO-injective PEPS` | 521–537 | owned: `rmp-iii-a-mpo-injective`, `rmp-workbench-iii-mpo-on-peps-definition` |
 | `Eq.60now57` | 538–552 | owned: `rmp-iii-a-mpo-action`, `rmp-workbench-iii-eq60-now` |
 | `Eq63now59` | 553–562 | owned: `rmp-iii-a-torus-two`, `rmp-workbench-iii-enlarged-mpo-black` |

--- a/tests/tenkz/rmp/manifest.toml
+++ b/tests/tenkz/rmp/manifest.toml
@@ -986,14 +986,14 @@ section = "section-iii-a"
 order = 59
 case = "tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-g-injective-projector.tex"
 formula = "P_G = |G|^-1 sum_g L_g on the four virtual legs."
-ink = "Canonical public tenkzfree environment; no raw TikZ."
-boundary = "Resolved by the public environment; open indices remain explicit."
-source = "paper TN-Review-main.tex line 1483; author source ImagesReview Section III/ImagesReview Section III.tex lines 468-520"
-capabilities = ["kernel", "typed-ports"]
+ink = "Canonical public kernel group-action cross and projector ring."
+boundary = "Four virtual lines pass through each side; only group actions are directed."
+source = "paper TN-Review-main.tex line 1483; author source ImagesReview Section III/ImagesReview Section III.tex lines 305-328"
+capabilities = ["kernel", "group-average", "ring-closure", "typed-ports"]
 paper_context_only = false
 fixture = "tests/tenkz/t2_eq54_ginj.tex"
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "468-520"
+author_lines = "305-328"
 placements = [{ order = 59, line = 1483, asset = "fig3_fig3-pepe_Eq54Ginjred.pdf" }]
 
 [[target]]
@@ -2020,11 +2020,11 @@ case = "tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.t
 formula = "A virtual g-string pulls through a G-injective PEPS tensor."
 ink = "Canonical public tenkzfree PEPS star with opposite g-string corners."
 boundary = "Five PEPS legs and two g-string ends remain open on each side."
-source = "author source ImagesReview Section III/ImagesReview Section III.tex lines 414-444; archival output Ginjpullt.pdf"
+source = "author source ImagesReview Section III/ImagesReview Section III.tex lines 468-497; archival output Ginjpullt.pdf"
 capabilities = ["kernel", "pulling-through", "open-string"]
 paper_context_only = false
 author_source = "ImagesReview Section III/ImagesReview Section III.tex"
-author_lines = "414-444"
+author_lines = "468-497"
 placements = []
 fixture = "tests/tenkz/t2_eq50_pull.tex"
 

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-g-injective-projector.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-iii-a-g-injective-projector.tex
@@ -1,43 +1,38 @@
 % Target: rmp-iii-a-g-injective-projector
 % Formula: P_G = |G|^-1 sum_g L_g on the four virtual legs.
-% Ink: Canonical public tenkzfree environment; no raw TikZ.
-% Boundary: Resolved by the public environment; open indices remain explicit.
+% Ink: Canonical public kernel group-action cross and projector ring.
+% Boundary: Four virtual lines pass through each side; only group actions are directed.
 % Source: paper TN-Review-main.tex line 1483; author source ImagesReview Section
-%   III/ImagesReview Section III.tex lines 468-520
-% Capabilities: kernel, typed-ports
-\[
-  % Author panel (lines 468-497): the pulling-through equality for the
-  % G-injective tensor.  A virtual g-string crosses the west and north legs,
-  % with a group-action box at each crossing; pulled through the tensor it
-  % crosses the east and south legs instead.  The action boxes stand on the
-  % string at its measured leg crossings.
-  \tenkzkernel
-  \tndeclare{species}{g}{hue=source:red}
-  \begin{tenkzeq}[size=m]
-    \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5, bonds=none]
-      \tn[at=(3,3), name=A]{}
-      \tnwire[kind=index]{A.w}{(3,1)}
-      \tnwire[kind=index]{A.e}{(3,5)}
-      \tnwire[kind=index]{A.s}{(5,3)}
-      \tnwire[kind=index]{A.n}{(1,3)}
-      \tnwire[kind=string, species=g, name=g, via={(3,2), (2,3)}]{(4,2)}{(2,4)}
-      \tn[skin=box, at=on g 0.28]{}
-      \tn[skin=box, at=on g 0.72]{}
-      \tnmark[form=label]{(2,2)}{$g$}
-      \tnmark[form=label]{(4,4)}{$A$}
-    \end{tenkz}
-    =
-    \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5, bonds=none]
-      \tn[at=(3,3), name=A]{}
-      \tnwire[kind=index]{A.w}{(3,1)}
-      \tnwire[kind=index]{A.e}{(3,5)}
-      \tnwire[kind=index]{A.s}{(5,3)}
-      \tnwire[kind=index]{A.n}{(1,3)}
-      \tnwire[kind=string, species=g, name=g, via={(3,4), (4,3)}]{(2,4)}{(4,2)}
-      \tn[skin=box, at=on g 0.30]{}
-      \tn[skin=box, at=on g 0.70]{}
-      \tnmark[form=label]{(4,4)}{$g$}
-      \tnmark[form=label]{(2,2)}{$A$}
-    \end{tenkz}
-  \end{tenkzeq}
-\]
+%   III/ImagesReview Section III.tex lines 305-328
+% Capabilities: kernel, group-average, ring-closure, typed-ports
+\tenkzkernel
+\tndeclare{species}{projector}{hue=source:red}
+\[ \frac1{|G|}\sum_{g\in G}
+  \begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none, size=s]
+    \tn[skin=ring, at=(1,2), name=n]{L_g}
+    \tn[skin=ring, at=(2,3), name=e]{L_g}
+    \tn[skin=ring, at=(3,2), name=s]{L_g}
+    \tn[skin=ring, at=(2,1), name=w]{L_g}
+    \tnwire[dir=from]{n.90}{0.7 n of n} \tnwire[dir=to]{n.270}{0.7 s of n}
+    \tnwire[dir=from]{e.0}{0.7 e of e} \tnwire[dir=to]{e.180}{0.7 w of e}
+    \tnwire[dir=from]{s.270}{0.7 s of s} \tnwire[dir=to]{s.90}{0.7 n of s}
+    \tnwire[dir=from]{w.180}{0.7 w of w} \tnwire[dir=to]{w.0}{0.7 e of w}
+  \end{tenkz} =
+  \begin{tenkz}[rows={wire,wire,wire}, cols=3, bonds=none, size=s]
+    \tn[skin=dot, at=(1,1), name=d]{}
+    \tn[skin=box, at=(1,2), name=n]{}
+    \tn[skin=box, at=(2,3), name=e]{}
+    \tn[skin=box, at=(3,2), name=s]{}
+    \tn[skin=box, at=(2,1), name=w]{}
+    \tnwire[kind=string, species=projector, name=ring, closed,
+      via={
+        d, n,
+        (1,3), e,
+        (3,3), s,
+        (3,1), w
+      }]
+    \tnwire{n.90}{0.7 n of n} \tnwire{e.0}{0.7 e of e}
+    \tnwire{s.270}{0.7 s of s} \tnwire{w.180}{0.7 w of w}
+    \tnwire{n.270}{0.7 s of n} \tnwire{e.180}{0.7 w of e}
+    \tnwire{s.90}{0.7 n of s} \tnwire{w.0}{0.7 e of w}
+  \end{tenkz}. \]

--- a/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.tex
+++ b/tests/tenkz/rmp/section-iii-a/cases/rmp-workbench-iii-g-injective-pull.tex
@@ -3,14 +3,13 @@
 % Ink: Canonical public tenkzfree PEPS star with opposite g-string corners.
 % Boundary: Five PEPS legs and two g-string ends remain open on each side.
 % Source: author source ImagesReview Section III/ImagesReview Section III.tex
-%   lines 414-444; archival output Ginjpullt.pdf
+%   lines 468-497; archival output Ginjpullt.pdf
 % Capabilities: kernel, pulling-through, open-string
 \[
-  % Author panels (lines 414-444): the pulling-through equality for the
+  % Author panels (lines 468-497): the pulling-through equality for the
   % G-injective PEPS tensor A.  A virtual g-string crosses the west and
   % north legs, a group-action box at each crossing; pulled through, it
-  % crosses the east and south legs instead and the unitary U_g appears
-  % on the physical leg, drawn at the 45-degree face of the flat redraw.
+  % crosses the east and south legs instead.  Both physical legs stay short.
   \tenkzkernel
   \tndeclare{species}{g}{hue=source:red}
   \begin{tenkzeq}[size=m]
@@ -21,12 +20,13 @@
       \tnwire[kind=index]{A.0}{(3,5)}
       \tnwire[kind=index]{A.270}{(5,3)}
       \tnwire[kind=index]{A.90}{(1,3)}
-      \tnwire[kind=index]{A.45}{midway A and (2,4)}
-      \tnwire[kind=string, species=g, name=g, via={(3,2), (2,3)}]{(4,2)}{(2,5)}
+      \tnwire[kind=index]
+        {A.45}{midway A and (2,4)}
+      \tnwire[kind=string, species=g, name=g, via={(3,2), (2,3)}]
+        {(4,2)}{(2,5)}
       \tn[skin=box, at=on g 0.24]{}
       \tn[skin=box, at=on g 0.56]{}
       \tnmark[form=label]{(2,2)}{$g$}
-      \tnmark[form=label]{(4,4)}{$A$}
     \end{tenkz}
     =
     \begin{tenkz}[rows={wire,wire,wire,wire,wire}, cols=5, bonds=none]
@@ -36,12 +36,11 @@
       \tnwire[kind=index]{A.0}{(3,5)}
       \tnwire[kind=index]{A.270}{(5,3)}
       \tnwire[kind=index]{A.90}{(1,3)}
-      \tnwire[kind=index, name=p]{A.45}{(1,5)}
-      \tn[at=on p 0.5, name=U]{}
+      \tnwire[kind=index]
+        {A.45}{midway A and (2,4)}
       \tnwire[kind=string, species=g, name=g, via={(3,4), (4,3)}]{(2,5)}{(4,2)}
       \tn[skin=box, at=on g 0.37]{}
       \tn[skin=box, at=on g 0.74]{}
-      \tnmark[form=label, label pos=w]{U}{$U_g$}
       \tnmark[form=label]{(4,4)}{$g$}
     \end{tenkz}
   \end{tenkzeq}

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -2,7 +2,7 @@
 # Schema: scripts/tenkz_rmp.py (load_verdicts).  Any status may be
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
-campaign_sha256 = "75ee5bbae378431847f00ff1ec53f04fd42163cdb03c93952560ff7c33b01949"
+campaign_sha256 = "76ad8f2d3caa8bb647fd43ae0f3bad0c9f7232fee878ec50f44de86b4bbb9cbe"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"
@@ -633,12 +633,13 @@ note = "mirrored operator order; small glyphs"
 [[verdict]]
 id = "rmp-iii-a-g-injective-projector"
 status = "cosmetic-gap"
-pairing = "wrong-source"
+pairing = "verified"
+pairing_by = "codex-source-repair-2026-07-29"
 defects = []
-case_sha256 = "372b2c06604fb1467675b37cc4c818286f4dd912aa3cb35fb01c0626f2986f5d"
-reviewed = "2026-07-28"
-renderer = "codex-kernel-ink-2026-07-28-200dpi"
-note = "the pulling-through equality with the g string crossing west/north then east/south and action boxes on the string; g and A labelled per panel at review"
+case_sha256 = "733c5ac2790a0fd4b6f78839efda9b673c1a540223e03edad5ac4cf8da6de201"
+reviewed = "2026-07-29"
+renderer = "codex-source-repair-2026-07-29-300dpi"
+note = "the paper projector: a normalized average of four cardinal L_g actions equals the four-tensor red ring with the northwest black junction"
 
 [[verdict]]
 id = "rmp-iii-a-mpo-action"
@@ -1288,12 +1289,12 @@ note = "glyph and leg geometry"
 id = "rmp-workbench-iii-g-injective-pull"
 status = "cosmetic-gap"
 pairing = "verified"
-pairing_by = "codex-pairing-sweep-2026-07-24"
+pairing_by = "codex-source-repair-2026-07-29"
 defects = []
-case_sha256 = "46fcd1f6040013f2d2056126a009b867f3225e3c08930278539297ae0074e0a0"
-reviewed = "2026-07-28"
-renderer = "codex-kernel-ink-2026-07-28-200dpi"
-note = "the g string pulls through and U_g appears on the diagonal, with the action boxes riding the string on both sides"
+case_sha256 = "a986ed5baceb52d3b0bfcba69645a24652944d7d8b20d7a663d885ed20a75c9e"
+reviewed = "2026-07-29"
+renderer = "codex-source-repair-2026-07-29-300dpi"
+note = "the author-source G-injective pull at lines 468-497: the g string moves across the tensor while the short physical leg remains undecorated"
 
 [[verdict]]
 id = "rmp-workbench-iii-intertwining-mpo"


### PR DESCRIPTION
## Summary
- redraw the published G-injective projector target from the actual paper asset
- move the archival pulling-through target to its correct author-source lines
- refresh the reviewed verdict and campaign hashes

## Validation
- 130 RMP targets compiled, linted, and audited
- 264 standalone corpus fixtures compiled and audited
- 264 golden event streams byte-identical
- kernel structural, sugar, event, and pixel probes passed
- 30 string event and pixel artifacts byte-identical

Closes LionSR/tenkz#81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to tenkz RMP benchmark cases, metadata, and docs; no runtime application or security-sensitive code paths.
> 
> **Overview**
> Repairs **wrong author-line pairings** for two Section III-a RMP targets that had been conflated with each other or with neighboring TikZ blocks.
> 
> The published target **`rmp-iii-a-g-injective-projector`** is re-anchored to author lines **305–328** (`Eq 59now56`) and its case is redrawn as the paper identity **P_G = |G|⁻¹ Σ_g L_g** (four cardinal **L_g** actions versus the closed projector ring), instead of the G-injective **pulling-through** diagram that had been checked in under the same id. The workbench target **`rmp-workbench-iii-g-injective-pull`** moves to lines **468–497**, with the case adjusted so the **g-string** reroutes across the tensor while the **short physical leg stays undecorated** (no **U_g** on the RHS).
> 
> **`docs/tenkz/wave2-targets.md`**, **`manifest.toml`**, and **`verdicts.toml`** are updated to match the split ownership (including **`rmp-iii-a-g-injective-projector`** pairing **verified** and a refreshed **campaign_sha256**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f545940aa4599fecede8122971d2bbb2a1a9773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->