### PR TITLE
feat(MPS/MPDO): transport sector factorizations through compression

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -184,6 +184,7 @@ import TNLean.MPS.MPDO.PhysicalSectorSubspinMaps
 import TNLean.MPS.MPDO.PhysicalSectorSupportRecurrence
 import TNLean.MPS.MPDO.PhysicalSectorTraceActions
 import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
+import TNLean.MPS.MPDO.PhysicalSectorVirtualCompression
 import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
 import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSupportBondTransport

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -186,6 +186,7 @@ import TNLean.MPS.MPDO.PhysicalSectorTraceActions
 import TNLean.MPS.MPDO.PhysicalSectorTraceMatrix
 import TNLean.MPS.MPDO.PhysicalSectorVirtualCompression
 import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
+import TNLean.MPS.MPDO.PhysicalSectorVirtualTransport
 import TNLean.MPS.MPDO.PhysicalSupportBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSupportBondTransport
 import TNLean.MPS.MPDO.PhysicalSupportProductTransport

--- a/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
@@ -31,16 +31,27 @@ Source context: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
 1381--1388. -/
 noncomputable def ofGaugeEquiv (F : PhysicalSectorFactorization K)
     (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
-    PhysicalSectorFactorization L := by
-  classical
-  let X : GL (Fin D) ℂ := Classical.choose hGauge
-  have hX : ∀ i : Fin (d * d),
-      L.toMPSTensor i = X * K.toMPSTensor i * X⁻¹ :=
-    Classical.choose_spec hGauge
-  exact F.ofVirtualMatrices
-    (X : Matrix (Fin D) (Fin D) ℂ)
-    ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-    hX
+    PhysicalSectorFactorization L :=
+  F.ofVirtualMatrices
+    ((Classical.choose hGauge : GL (Fin D) ℂ) :
+      Matrix (Fin D) (Fin D) ℂ)
+    (((Classical.choose hGauge : GL (Fin D) ℂ)⁻¹ : GL (Fin D) ℂ) :
+      Matrix (Fin D) (Fin D) ℂ)
+    (Classical.choose_spec hGauge)
+
+/-- Virtual-gauge transport is virtual-matrix transport by a gauge and its
+inverse. -/
+theorem ofGaugeEquiv_eq_ofVirtualMatrices
+    (F : PhysicalSectorFactorization K)
+    (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
+    F.ofGaugeEquiv hGauge =
+      F.ofVirtualMatrices
+        ((Classical.choose hGauge : GL (Fin D) ℂ) :
+          Matrix (Fin D) (Fin D) ℂ)
+        (((Classical.choose hGauge : GL (Fin D) ℂ)⁻¹ : GL (Fin D) ℂ) :
+          Matrix (Fin D) (Fin D) ℂ)
+        (Classical.choose_spec hGauge) :=
+  rfl
 
 /-- Virtual-gauge transport leaves every neighboring operator unchanged. -/
 @[simp] theorem ofGaugeEquiv_neighboringOperator
@@ -63,10 +74,14 @@ noncomputable def ofGaugeEquiv (F : PhysicalSectorFactorization K)
         (X : Matrix (Fin D) (Fin D) ℂ)) = 1
     rw [← Units.val_mul]
     simp
-  change (F.ofVirtualMatrices x y hX).neighboringOperator k h =
-    F.neighboringOperator k h
-  rw [F.ofVirtualMatrices_neighboringOperator x y hX k h, hyx]
-  exact F.neighboringOperatorWithMatrix_one k h
+  calc
+    (F.ofGaugeEquiv hGauge).neighboringOperator k h =
+        F.neighboringOperatorWithMatrix k h (y * x) := by
+      simpa only [ofGaugeEquiv_eq_ofVirtualMatrices, X, x, y] using
+        F.ofVirtualMatrices_neighboringOperator x y hX k h
+    _ = F.neighboringOperator k h := by
+      rw [hyx]
+      exact F.neighboringOperatorWithMatrix_one k h
 
 /-- Positivity of the neighboring operators is preserved by virtual-gauge
 transport. -/

--- a/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorVirtualTransport
 
 /-!
 # Virtual-gauge transport of physical-sector factorizations
@@ -37,80 +37,10 @@ noncomputable def ofGaugeEquiv (F : PhysicalSectorFactorization K)
   have hX : ∀ i : Fin (d * d),
       L.toMPSTensor i = X * K.toMPSTensor i * X⁻¹ :=
     Classical.choose_spec hGauge
-  let x : Matrix (Fin D) (Fin D) ℂ := X
-  let y : Matrix (Fin D) (Fin D) ℂ :=
+  exact F.ofVirtualMatrices
+    (X : Matrix (Fin D) (Fin D) ℂ)
     ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
-  refine
-    { sectorCount := F.sectorCount
-      leftDim := F.leftDim
-      rightDim := F.rightDim
-      leftDim_pos := F.leftDim_pos
-      rightDim_pos := F.rightDim_pos
-      sectorEquiv := F.sectorEquiv
-      physicalIsometry := F.physicalIsometry
-      physicalIsometry_isometry := F.physicalIsometry_isometry
-      leftTensor := fun k beta ↦
-        ∑ gamma, x beta gamma • F.leftTensor k gamma
-      rightTensor := fun k alpha ↦
-        ∑ delta, y delta alpha • F.rightTensor k delta
-      factorization := ?_ }
-  intro beta alpha
-  ext ⟨k, a⟩ ⟨h, b⟩
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
-  have hLetter (i j : Fin d) :
-      L i j = x * K i j * y := by
-    simpa only [MPOTensor.toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
-      MPSTensor.finProdFinEquiv_modNat, x, y] using
-      hX (finProdFinEquiv (i, j))
-  have hSlice :
-      physicalSlice L beta alpha =
-        ∑ gamma, ∑ delta,
-          (x beta gamma * y delta alpha) • physicalSlice K gamma delta := by
-    ext i j
-    simp only [physicalSlice, hLetter, Matrix.mul_apply, Matrix.sum_apply,
-      Matrix.smul_apply, smul_eq_mul]
-    simp_rw [Finset.sum_mul]
-    rw [Finset.sum_comm]
-    apply Finset.sum_congr rfl
-    intro gamma _
-    apply Finset.sum_congr rfl
-    intro delta _
-    ring
-  have hConj :
-      F.physicalIsometry * physicalSlice L beta alpha *
-          F.physicalIsometryᴴ =
-        ∑ gamma, ∑ delta, (x beta gamma * y delta alpha) •
-          (F.physicalIsometry * physicalSlice K gamma delta *
-            F.physicalIsometryᴴ) := by
-    rw [hSlice]
-    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul,
-      Matrix.smul_mul]
-  rw [hConj]
-  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
-  by_cases hkh : k = h
-  · subst h
-    rw [Matrix.blockDiagonal'_apply_eq]
-    simp only [Matrix.kroneckerMap_apply, Matrix.sum_apply,
-      Matrix.smul_apply, smul_eq_mul]
-    have hF (gamma delta : Fin D) :=
-      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨k, b⟩
-    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] at hF
-    simp_rw [hF]
-    rw [Finset.sum_mul]
-    simp_rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro gamma _
-    apply Finset.sum_congr rfl
-    intro delta _
-    ring
-  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
-    have hF (gamma delta : Fin D) :=
-      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨h, b⟩
-    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-      Matrix.blockDiagonal'_apply_ne _ _ _ hkh] at hF
-    simp_rw [hF]
-    simp
+    hX
 
 /-- Virtual-gauge transport leaves every neighboring operator unchanged. -/
 @[simp] theorem ofGaugeEquiv_neighboringOperator
@@ -124,58 +54,19 @@ noncomputable def ofGaugeEquiv (F : PhysicalSectorFactorization K)
   let x : Matrix (Fin D) (Fin D) ℂ := X
   let y : Matrix (Fin D) (Fin D) ℂ :=
     ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+  have hX : ∀ i : Fin (d * d),
+      L.toMPSTensor i = X * K.toMPSTensor i * X⁻¹ :=
+    Classical.choose_spec hGauge
   have hyx : y * x = 1 := by
     change
       (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
         (X : Matrix (Fin D) (Fin D) ℂ)) = 1
     rw [← Units.val_mul]
     simp
-  ext a b
-  simp only [neighboringOperator_apply, ofGaugeEquiv, Matrix.sum_apply,
-    Matrix.smul_apply, smul_eq_mul]
-  simp_rw [Finset.sum_mul, Finset.mul_sum]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl
-  intro delta _
-  rw [Finset.sum_comm]
-  calc
-    (∑ gamma, ∑ beta,
-        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) delta beta *
-            F.rightTensor k delta a.1 b.1 *
-          ((X : Matrix (Fin D) (Fin D) ℂ) beta gamma *
-            F.leftTensor h gamma a.2 b.2)) =
-        ∑ gamma, if delta = gamma then
-          F.rightTensor k delta a.1 b.1 *
-            F.leftTensor h gamma a.2 b.2
-        else 0 := by
-      apply Finset.sum_congr rfl
-      intro gamma _
-      calc
-        (∑ beta,
-            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) delta beta *
-                F.rightTensor k delta a.1 b.1 *
-              ((X : Matrix (Fin D) (Fin D) ℂ) beta gamma *
-                F.leftTensor h gamma a.2 b.2)) =
-            (y * x) delta gamma *
-              F.rightTensor k delta a.1 b.1 *
-              F.leftTensor h gamma a.2 b.2 := by
-          rw [Matrix.mul_apply]
-          simp only [y, x]
-          rw [Finset.sum_mul, Finset.sum_mul]
-          apply Finset.sum_congr rfl
-          intro beta _
-          ring
-        _ = if delta = gamma then
-              F.rightTensor k delta a.1 b.1 *
-                F.leftTensor h gamma a.2 b.2
-            else 0 := by
-          rw [hyx, Matrix.one_apply]
-          split
-          · simp_all
-          · simp_all
-    _ = F.rightTensor k delta a.1 b.1 *
-        F.leftTensor h delta a.2 b.2 := by
-      simp [Finset.sum_ite_eq, Finset.mem_univ]
+  change (F.ofVirtualMatrices x y hX).neighboringOperator k h =
+    F.neighboringOperator k h
+  rw [F.ofVirtualMatrices_neighboringOperator x y hX k h, hyx]
+  exact F.neighboringOperatorWithMatrix_one k h
 
 /-- Positivity of the neighboring operators is preserved by virtual-gauge
 transport. -/

--- a/TNLean/MPS/MPDO/PhysicalSectorVirtualCompression.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorVirtualCompression.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+
+/-!
+# Virtual compression of physical-sector factorizations
+
+A rectangular change of virtual coordinates can be absorbed separately into
+the left and right tensors of a physical-sector factorization.  Their
+contraction inserts the range matrix of the coordinate map between the
+original right and left tensors.
+
+## Main definitions
+
+* `MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix`
+  contracts neighboring sector tensors through a prescribed virtual matrix.
+* `MPOTensor.PhysicalSectorFactorization.ofVirtualCompression` transports a
+  physical-sector factorization through a rectangular virtual compression.
+
+## References
+
+* arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219
+* arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+  lines 1381--1450
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D E : ℕ} {K : MPOTensor d D} {L : MPOTensor d E}
+
+/-- The neighboring-sector contraction through a virtual matrix `P`.
+
+For `P = 1`, this is the ordinary neighboring operator.  A rectangular
+virtual compression by `V` produces this contraction with `P = V * Vᴴ`.
+
+Source context: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines
+1441--1445. -/
+noncomputable def neighboringOperatorWithMatrix
+    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
+    (k h : Fin F.sectorCount) :
+    Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
+  Matrix.of fun x y ↦
+    ∑ delta, ∑ gamma,
+      P delta gamma * F.rightTensor k delta x.1 y.1 *
+        F.leftTensor h gamma x.2 y.2
+
+/-- Entries of the matrix-weighted neighboring operator are the corresponding
+weighted contractions of the right and left sector tensors. -/
+@[simp] theorem neighboringOperatorWithMatrix_apply
+    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
+    (k h : Fin F.sectorCount) (x y : NeighborIndex F k h) :
+    F.neighboringOperatorWithMatrix P k h x y =
+      ∑ delta, ∑ gamma,
+        P delta gamma * F.rightTensor k delta x.1 y.1 *
+          F.leftTensor h gamma x.2 y.2 :=
+  rfl
+
+/-- Contraction through the identity matrix is the ordinary neighboring
+operator. -/
+@[simp] theorem neighboringOperatorWithMatrix_one
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    F.neighboringOperatorWithMatrix 1 k h = F.neighboringOperator k h := by
+  ext x y
+  rw [neighboringOperatorWithMatrix_apply, neighboringOperator_apply]
+  apply Finset.sum_congr rfl
+  intro delta _
+  simp [Matrix.one_apply, Finset.sum_ite_eq, Finset.mem_univ]
+
+/-- Transport a physical-sector factorization through a rectangular virtual
+compression.
+
+The physical-sector decomposition and physical isometry are unchanged.  The
+coordinate map and its adjoint are absorbed into the right and left virtual
+tensor families, respectively.
+
+Source context: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines
+195--219, and Appendix C.2, equation `AppUkU=rl`, lines 1381--1388. -/
+noncomputable def ofVirtualCompression (F : PhysicalSectorFactorization K)
+    (V : Matrix (Fin D) (Fin E) ℂ)
+    (hCompression : ∀ i : Fin (d * d),
+      L.toMPSTensor i = Vᴴ * K.toMPSTensor i * V) :
+    PhysicalSectorFactorization L := by
+  classical
+  refine
+    { sectorCount := F.sectorCount
+      leftDim := F.leftDim
+      rightDim := F.rightDim
+      leftDim_pos := F.leftDim_pos
+      rightDim_pos := F.rightDim_pos
+      sectorEquiv := F.sectorEquiv
+      physicalIsometry := F.physicalIsometry
+      physicalIsometry_isometry := F.physicalIsometry_isometry
+      leftTensor := fun k beta ↦
+        ∑ gamma, star (V gamma beta) • F.leftTensor k gamma
+      rightTensor := fun k alpha ↦
+        ∑ delta, V delta alpha • F.rightTensor k delta
+      factorization := ?_ }
+  intro beta alpha
+  ext ⟨k, a⟩ ⟨h, b⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
+  have hLetter (i j : Fin d) :
+      L i j = Vᴴ * K i j * V := by
+    simpa only [MPOTensor.toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+      MPSTensor.finProdFinEquiv_modNat] using
+      hCompression (finProdFinEquiv (i, j))
+  have hSlice :
+      physicalSlice L beta alpha =
+        ∑ gamma, ∑ delta,
+          (star (V gamma beta) * V delta alpha) •
+            physicalSlice K gamma delta := by
+    ext i j
+    simp only [physicalSlice, hLetter, Matrix.mul_apply, Matrix.sum_apply,
+      Matrix.smul_apply, smul_eq_mul, Matrix.conjTranspose_apply]
+    simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro gamma _
+    apply Finset.sum_congr rfl
+    intro delta _
+    ring
+  have hConj :
+      F.physicalIsometry * physicalSlice L beta alpha *
+          F.physicalIsometryᴴ =
+        ∑ gamma, ∑ delta, (star (V gamma beta) * V delta alpha) •
+          (F.physicalIsometry * physicalSlice K gamma delta *
+            F.physicalIsometryᴴ) := by
+    rw [hSlice]
+    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul,
+      Matrix.smul_mul]
+  rw [hConj]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.kroneckerMap_apply, Matrix.sum_apply,
+      Matrix.smul_apply, smul_eq_mul]
+    have hF (gamma delta : Fin D) :=
+      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨k, b⟩
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] at hF
+    simp_rw [hF]
+    rw [Finset.sum_mul]
+    simp_rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro gamma _
+    apply Finset.sum_congr rfl
+    intro delta _
+    ring
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+    have hF (gamma delta : Fin D) :=
+      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨h, b⟩
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hkh] at hF
+    simp_rw [hF]
+    simp
+
+/-- Virtual compression replaces the ordinary neighboring contraction by the
+matrix-weighted contraction through `V * Vᴴ`.
+
+No positivity is asserted: positivity of the ordinary neighboring contraction
+does not by itself establish positivity after inserting the range matrix.
+
+Source context: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines
+195--219, and Appendix C.2, equation `etarl`, lines 1441--1445. -/
+@[simp] theorem ofVirtualCompression_neighboringOperator
+    (F : PhysicalSectorFactorization K) (V : Matrix (Fin D) (Fin E) ℂ)
+    (hCompression : ∀ i : Fin (d * d),
+      L.toMPSTensor i = Vᴴ * K.toMPSTensor i * V)
+    (k h : Fin F.sectorCount) :
+    (F.ofVirtualCompression V hCompression).neighboringOperator k h =
+      F.neighboringOperatorWithMatrix (V * Vᴴ) k h := by
+  classical
+  ext x y
+  simp only [neighboringOperator_apply, ofVirtualCompression,
+    neighboringOperatorWithMatrix_apply, Matrix.sum_apply, Matrix.smul_apply,
+    smul_eq_mul, Matrix.mul_apply, Matrix.conjTranspose_apply]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro delta _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro gamma _
+  apply Finset.sum_congr rfl
+  intro beta _
+  ring
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorVirtualCompression.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorVirtualCompression.lean
@@ -3,22 +3,14 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.PhysicalSectorFactorization
+import TNLean.MPS.MPDO.PhysicalSectorVirtualTransport
 
 /-!
 # Virtual compression of physical-sector factorizations
 
-A rectangular change of virtual coordinates can be absorbed separately into
-the left and right tensors of a physical-sector factorization.  Their
-contraction inserts the range matrix of the coordinate map between the
-original right and left tensors.
-
-## Main definitions
-
-* `MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix`
-  contracts neighboring sector tensors through a prescribed virtual matrix.
-* `MPOTensor.PhysicalSectorFactorization.ofVirtualCompression` transports a
-  physical-sector factorization through a rectangular virtual compression.
+A rectangular change of virtual coordinates is a virtual-matrix transport
+whose left matrix is the adjoint of its right matrix.  The neighboring
+contraction therefore inserts the range matrix of the coordinate map.
 
 ## References
 
@@ -33,44 +25,6 @@ namespace MPOTensor.PhysicalSectorFactorization
 
 variable {d D E : ℕ} {K : MPOTensor d D} {L : MPOTensor d E}
 
-/-- The neighboring-sector contraction through a virtual matrix `P`.
-
-For `P = 1`, this is the ordinary neighboring operator.  A rectangular
-virtual compression by `V` produces this contraction with `P = V * Vᴴ`.
-
-Source context: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines
-1441--1445. -/
-noncomputable def neighboringOperatorWithMatrix
-    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
-    (k h : Fin F.sectorCount) :
-    Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
-  Matrix.of fun x y ↦
-    ∑ delta, ∑ gamma,
-      P delta gamma * F.rightTensor k delta x.1 y.1 *
-        F.leftTensor h gamma x.2 y.2
-
-/-- Entries of the matrix-weighted neighboring operator are the corresponding
-weighted contractions of the right and left sector tensors. -/
-@[simp] theorem neighboringOperatorWithMatrix_apply
-    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
-    (k h : Fin F.sectorCount) (x y : NeighborIndex F k h) :
-    F.neighboringOperatorWithMatrix P k h x y =
-      ∑ delta, ∑ gamma,
-        P delta gamma * F.rightTensor k delta x.1 y.1 *
-          F.leftTensor h gamma x.2 y.2 :=
-  rfl
-
-/-- Contraction through the identity matrix is the ordinary neighboring
-operator. -/
-@[simp] theorem neighboringOperatorWithMatrix_one
-    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
-    F.neighboringOperatorWithMatrix 1 k h = F.neighboringOperator k h := by
-  ext x y
-  rw [neighboringOperatorWithMatrix_apply, neighboringOperator_apply]
-  apply Finset.sum_congr rfl
-  intro delta _
-  simp [Matrix.one_apply, Finset.sum_ite_eq, Finset.mem_univ]
-
 /-- Transport a physical-sector factorization through a rectangular virtual
 compression.
 
@@ -84,80 +38,8 @@ noncomputable def ofVirtualCompression (F : PhysicalSectorFactorization K)
     (V : Matrix (Fin D) (Fin E) ℂ)
     (hCompression : ∀ i : Fin (d * d),
       L.toMPSTensor i = Vᴴ * K.toMPSTensor i * V) :
-    PhysicalSectorFactorization L := by
-  classical
-  refine
-    { sectorCount := F.sectorCount
-      leftDim := F.leftDim
-      rightDim := F.rightDim
-      leftDim_pos := F.leftDim_pos
-      rightDim_pos := F.rightDim_pos
-      sectorEquiv := F.sectorEquiv
-      physicalIsometry := F.physicalIsometry
-      physicalIsometry_isometry := F.physicalIsometry_isometry
-      leftTensor := fun k beta ↦
-        ∑ gamma, star (V gamma beta) • F.leftTensor k gamma
-      rightTensor := fun k alpha ↦
-        ∑ delta, V delta alpha • F.rightTensor k delta
-      factorization := ?_ }
-  intro beta alpha
-  ext ⟨k, a⟩ ⟨h, b⟩
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
-  have hLetter (i j : Fin d) :
-      L i j = Vᴴ * K i j * V := by
-    simpa only [MPOTensor.toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
-      MPSTensor.finProdFinEquiv_modNat] using
-      hCompression (finProdFinEquiv (i, j))
-  have hSlice :
-      physicalSlice L beta alpha =
-        ∑ gamma, ∑ delta,
-          (star (V gamma beta) * V delta alpha) •
-            physicalSlice K gamma delta := by
-    ext i j
-    simp only [physicalSlice, hLetter, Matrix.mul_apply, Matrix.sum_apply,
-      Matrix.smul_apply, smul_eq_mul, Matrix.conjTranspose_apply]
-    simp_rw [Finset.sum_mul]
-    rw [Finset.sum_comm]
-    apply Finset.sum_congr rfl
-    intro gamma _
-    apply Finset.sum_congr rfl
-    intro delta _
-    ring
-  have hConj :
-      F.physicalIsometry * physicalSlice L beta alpha *
-          F.physicalIsometryᴴ =
-        ∑ gamma, ∑ delta, (star (V gamma beta) * V delta alpha) •
-          (F.physicalIsometry * physicalSlice K gamma delta *
-            F.physicalIsometryᴴ) := by
-    rw [hSlice]
-    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul,
-      Matrix.smul_mul]
-  rw [hConj]
-  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
-  by_cases hkh : k = h
-  · subst h
-    rw [Matrix.blockDiagonal'_apply_eq]
-    simp only [Matrix.kroneckerMap_apply, Matrix.sum_apply,
-      Matrix.smul_apply, smul_eq_mul]
-    have hF (gamma delta : Fin D) :=
-      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨k, b⟩
-    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] at hF
-    simp_rw [hF]
-    rw [Finset.sum_mul]
-    simp_rw [Finset.mul_sum]
-    apply Finset.sum_congr rfl
-    intro gamma _
-    apply Finset.sum_congr rfl
-    intro delta _
-    ring
-  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
-    have hF (gamma delta : Fin D) :=
-      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨h, b⟩
-    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-      Matrix.blockDiagonal'_apply_ne _ _ _ hkh] at hF
-    simp_rw [hF]
-    simp
+    PhysicalSectorFactorization L :=
+  F.ofVirtualMatrices Vᴴ V hCompression
 
 /-- Virtual compression replaces the ordinary neighboring contraction by the
 matrix-weighted contraction through `V * Vᴴ`.
@@ -173,21 +55,7 @@ Source context: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines
       L.toMPSTensor i = Vᴴ * K.toMPSTensor i * V)
     (k h : Fin F.sectorCount) :
     (F.ofVirtualCompression V hCompression).neighboringOperator k h =
-      F.neighboringOperatorWithMatrix (V * Vᴴ) k h := by
-  classical
-  ext x y
-  simp only [neighboringOperator_apply, ofVirtualCompression,
-    neighboringOperatorWithMatrix_apply, Matrix.sum_apply, Matrix.smul_apply,
-    smul_eq_mul, Matrix.mul_apply, Matrix.conjTranspose_apply]
-  simp_rw [Finset.sum_mul, Finset.mul_sum]
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl
-  intro delta _
-  rw [Finset.sum_comm]
-  apply Finset.sum_congr rfl
-  intro gamma _
-  apply Finset.sum_congr rfl
-  intro beta _
-  ring
+      F.neighboringOperatorWithMatrix (V * Vᴴ) k h :=
+  F.ofVirtualMatrices_neighboringOperator Vᴴ V hCompression k h
 
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorVirtualCompression.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorVirtualCompression.lean
@@ -55,7 +55,7 @@ Source context: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines
       L.toMPSTensor i = Vᴴ * K.toMPSTensor i * V)
     (k h : Fin F.sectorCount) :
     (F.ofVirtualCompression V hCompression).neighboringOperator k h =
-      F.neighboringOperatorWithMatrix (V * Vᴴ) k h :=
+      F.neighboringOperatorWithMatrix k h (V * Vᴴ) :=
   F.ofVirtualMatrices_neighboringOperator Vᴴ V hCompression k h
 
 end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorVirtualTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorVirtualTransport.lean
@@ -39,8 +39,8 @@ For `P = 1`, this is the ordinary neighboring operator.
 Source context: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines
 1441--1445. -/
 noncomputable def neighboringOperatorWithMatrix
-    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
-    (k h : Fin F.sectorCount) :
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (P : Matrix (Fin D) (Fin D) ℂ) :
     Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
   Matrix.of fun x y ↦
     ∑ delta, ∑ gamma,
@@ -50,9 +50,9 @@ noncomputable def neighboringOperatorWithMatrix
 /-- Entries of the matrix-weighted neighboring operator are the corresponding
 weighted contractions of the right and left sector tensors. -/
 @[simp] theorem neighboringOperatorWithMatrix_apply
-    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
-    (k h : Fin F.sectorCount) (x y : NeighborIndex F k h) :
-    F.neighboringOperatorWithMatrix P k h x y =
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount)
+    (P : Matrix (Fin D) (Fin D) ℂ) (x y : NeighborIndex F k h) :
+    F.neighboringOperatorWithMatrix k h P x y =
       ∑ delta, ∑ gamma,
         P delta gamma * F.rightTensor k delta x.1 y.1 *
           F.leftTensor h gamma x.2 y.2 :=
@@ -62,7 +62,7 @@ weighted contractions of the right and left sector tensors. -/
 operator. -/
 @[simp] theorem neighboringOperatorWithMatrix_one
     (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
-    F.neighboringOperatorWithMatrix 1 k h = F.neighboringOperator k h := by
+    F.neighboringOperatorWithMatrix k h 1 = F.neighboringOperator k h := by
   ext x y
   rw [neighboringOperatorWithMatrix_apply, neighboringOperator_apply]
   apply Finset.sum_congr rfl
@@ -169,7 +169,7 @@ Source context: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines
       L.toMPSTensor i = X * K.toMPSTensor i * Y)
     (k h : Fin F.sectorCount) :
     (F.ofVirtualMatrices X Y hTransport).neighboringOperator k h =
-      F.neighboringOperatorWithMatrix (Y * X) k h := by
+      F.neighboringOperatorWithMatrix k h (Y * X) := by
   classical
   ext x y
   simp only [neighboringOperator_apply, ofVirtualMatrices,

--- a/TNLean/MPS/MPDO/PhysicalSectorVirtualTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorVirtualTransport.lean
@@ -1,0 +1,189 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorFactorization
+
+/-!
+# Virtual transport of physical-sector factorizations
+
+Two rectangular virtual matrices can be absorbed separately into the left and
+right tensors of a physical-sector factorization.  Their neighboring
+contraction inserts the product of the right and left virtual matrices.
+
+## Main definitions
+
+* `MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix`
+  contracts neighboring sector tensors through a prescribed virtual matrix.
+* `MPOTensor.PhysicalSectorFactorization.ofVirtualMatrices` transports a
+  physical-sector factorization through two virtual matrices.
+
+## References
+
+* arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219
+* arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `etarl`,
+  lines 1381--1450
+-/
+
+open scoped Matrix
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D E : ℕ} {K : MPOTensor d D} {L : MPOTensor d E}
+
+/-- The neighboring-sector contraction through a virtual matrix `P`.
+
+For `P = 1`, this is the ordinary neighboring operator.
+
+Source context: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines
+1441--1445. -/
+noncomputable def neighboringOperatorWithMatrix
+    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
+    (k h : Fin F.sectorCount) :
+    Matrix (NeighborIndex F k h) (NeighborIndex F k h) ℂ :=
+  Matrix.of fun x y ↦
+    ∑ delta, ∑ gamma,
+      P delta gamma * F.rightTensor k delta x.1 y.1 *
+        F.leftTensor h gamma x.2 y.2
+
+/-- Entries of the matrix-weighted neighboring operator are the corresponding
+weighted contractions of the right and left sector tensors. -/
+@[simp] theorem neighboringOperatorWithMatrix_apply
+    (F : PhysicalSectorFactorization K) (P : Matrix (Fin D) (Fin D) ℂ)
+    (k h : Fin F.sectorCount) (x y : NeighborIndex F k h) :
+    F.neighboringOperatorWithMatrix P k h x y =
+      ∑ delta, ∑ gamma,
+        P delta gamma * F.rightTensor k delta x.1 y.1 *
+          F.leftTensor h gamma x.2 y.2 :=
+  rfl
+
+/-- Contraction through the identity matrix is the ordinary neighboring
+operator. -/
+@[simp] theorem neighboringOperatorWithMatrix_one
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    F.neighboringOperatorWithMatrix 1 k h = F.neighboringOperator k h := by
+  ext x y
+  rw [neighboringOperatorWithMatrix_apply, neighboringOperator_apply]
+  apply Finset.sum_congr rfl
+  intro delta _
+  simp [Matrix.one_apply, Finset.sum_ite_eq, Finset.mem_univ]
+
+/-- Transport a physical-sector factorization through a pair of rectangular
+virtual matrices.
+
+The physical-sector decomposition and physical isometry are unchanged.  The
+left and right matrices are absorbed into the corresponding virtual tensor
+families.
+
+Source context: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines
+195--219, and Appendix C.2, equation `AppUkU=rl`, lines 1381--1388. -/
+noncomputable def ofVirtualMatrices (F : PhysicalSectorFactorization K)
+    (X : Matrix (Fin E) (Fin D) ℂ) (Y : Matrix (Fin D) (Fin E) ℂ)
+    (hTransport : ∀ i : Fin (d * d),
+      L.toMPSTensor i = X * K.toMPSTensor i * Y) :
+    PhysicalSectorFactorization L := by
+  classical
+  refine
+    { sectorCount := F.sectorCount
+      leftDim := F.leftDim
+      rightDim := F.rightDim
+      leftDim_pos := F.leftDim_pos
+      rightDim_pos := F.rightDim_pos
+      sectorEquiv := F.sectorEquiv
+      physicalIsometry := F.physicalIsometry
+      physicalIsometry_isometry := F.physicalIsometry_isometry
+      leftTensor := fun k beta ↦
+        ∑ gamma, X beta gamma • F.leftTensor k gamma
+      rightTensor := fun k alpha ↦
+        ∑ delta, Y delta alpha • F.rightTensor k delta
+      factorization := ?_ }
+  intro beta alpha
+  ext ⟨k, a⟩ ⟨h, b⟩
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply]
+  have hLetter (i j : Fin d) :
+      L i j = X * K i j * Y := by
+    simpa only [MPOTensor.toMPSTensor, MPSTensor.finProdFinEquiv_divNat,
+      MPSTensor.finProdFinEquiv_modNat] using
+      hTransport (finProdFinEquiv (i, j))
+  have hSlice :
+      physicalSlice L beta alpha =
+        ∑ gamma, ∑ delta,
+          (X beta gamma * Y delta alpha) •
+            physicalSlice K gamma delta := by
+    ext i j
+    simp only [physicalSlice, hLetter, Matrix.mul_apply, Matrix.sum_apply,
+      Matrix.smul_apply, smul_eq_mul]
+    simp_rw [Finset.sum_mul]
+    rw [Finset.sum_comm]
+    apply Finset.sum_congr rfl
+    intro gamma _
+    apply Finset.sum_congr rfl
+    intro delta _
+    ring
+  have hConj :
+      F.physicalIsometry * physicalSlice L beta alpha *
+          F.physicalIsometryᴴ =
+        ∑ gamma, ∑ delta, (X beta gamma * Y delta alpha) •
+          (F.physicalIsometry * physicalSlice K gamma delta *
+            F.physicalIsometryᴴ) := by
+    rw [hSlice]
+    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.mul_smul,
+      Matrix.smul_mul]
+  rw [hConj]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
+  by_cases hkh : k = h
+  · subst h
+    rw [Matrix.blockDiagonal'_apply_eq]
+    simp only [Matrix.kroneckerMap_apply, Matrix.sum_apply,
+      Matrix.smul_apply, smul_eq_mul]
+    have hF (gamma delta : Fin D) :=
+      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨k, b⟩
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.blockDiagonal'_apply_eq, Matrix.kroneckerMap_apply] at hF
+    simp_rw [hF]
+    rw [Finset.sum_mul]
+    simp_rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro gamma _
+    apply Finset.sum_congr rfl
+    intro delta _
+    ring
+  · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+    have hF (gamma delta : Fin D) :=
+      congrFun (congrFun (F.factorization gamma delta) ⟨k, a⟩) ⟨h, b⟩
+    simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+      Matrix.blockDiagonal'_apply_ne _ _ _ hkh] at hF
+    simp_rw [hF]
+    simp
+
+/-- Transport through virtual matrices `X` and `Y` inserts `Y * X` in the
+neighboring contraction.
+
+Source context: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines
+195--219, and Appendix C.2, equation `etarl`, lines 1441--1445. -/
+@[simp] theorem ofVirtualMatrices_neighboringOperator
+    (F : PhysicalSectorFactorization K)
+    (X : Matrix (Fin E) (Fin D) ℂ) (Y : Matrix (Fin D) (Fin E) ℂ)
+    (hTransport : ∀ i : Fin (d * d),
+      L.toMPSTensor i = X * K.toMPSTensor i * Y)
+    (k h : Fin F.sectorCount) :
+    (F.ofVirtualMatrices X Y hTransport).neighboringOperator k h =
+      F.neighboringOperatorWithMatrix (Y * X) k h := by
+  classical
+  ext x y
+  simp only [neighboringOperator_apply, ofVirtualMatrices,
+    neighboringOperatorWithMatrix_apply, Matrix.sum_apply, Matrix.smul_apply,
+    smul_eq_mul, Matrix.mul_apply]
+  simp_rw [Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro delta _
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro gamma _
+  apply Finset.sum_congr rfl
+  intro beta _
+  ring
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -186,8 +186,8 @@
     \leanok
     Replace each left factor by
     $\sum_\gamma X_{\beta,\gamma}(l_k)_\gamma$ and each right factor by
-    $\sum_\delta Y_{\delta,\alpha}(r_k)_\delta$.  Expanding a physical slice
-    gives the stated transport.  Contracting the common virtual index gives
+    $\sum_\delta Y_{\delta,\alpha}(r_k)_\delta$.  Contracting the common
+    virtual index gives
     \begin{align}
         \sum_\beta Y_{\delta,\beta}X_{\beta,\gamma}
         &=(YX)_{\delta,\gamma},
@@ -220,7 +220,8 @@
     \label{thm:mpdo_physical_sector_factorization_virtual_compression_neighbor}
     \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression_neighboringOperator}
     \leanok
-    \uses{thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor,
+    \uses{def:mpdo_minimal_neighboring_operator,
+      def:mpdo_matrix_weighted_neighboring_operator,
       def:mpdo_physical_sector_factorization_virtual_compression}
     The neighboring operators of the factorization obtained by virtual
     compression satisfy
@@ -238,6 +239,7 @@
 
 \begin{proof}
     \leanok
+    \uses{thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor}
     Apply the virtual-matrix transport identity with $X=V^\dagger$ and $Y=V$.
 \end{proof}
 
@@ -248,22 +250,25 @@
       MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator,
       MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator_posSemidef}
     \leanok
-    \uses{def:mpdo_matrix_weighted_neighboring_operator,
-      def:mpdo_physical_sector_factorization_virtual_matrices,
-      thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor}
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator,
+      def:mpdo_physical_sector_factorization_virtual_matrices}
     Suppose that two MPO tensors of the same virtual dimension differ by an
-    invertible virtual gauge.  Every physical-sector factorization of the
-    first tensor induces one of the second tensor with the same physical
-    decomposition and the same neighboring operators.  In particular,
-    positive semidefiniteness of all neighboring operators is invariant under
-    the gauge.
+    invertible virtual gauge $X$.  The induced factorization is precisely the
+    virtual-matrix transport by $X$ and $X^{-1}$.  Thus every physical-sector
+    factorization of the first tensor induces one of the second tensor with
+    the same physical decomposition and the same neighboring operators.  In
+    particular, positive semidefiniteness of all neighboring operators is
+    invariant under the gauge.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Absorb the gauge into each left sector tensor and its inverse into each
-    right sector tensor.  The two matrices cancel when the common virtual
-    index is contracted, so every neighboring operator is unchanged.
+    \uses{def:mpdo_matrix_weighted_neighboring_operator,
+      thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor}
+    Specialize the virtual-matrix neighboring identity to a gauge and its
+    inverse.  Their product is the identity matrix, and contraction through
+    the identity matrix is the ordinary neighboring operator.
 \end{proof}
 
 \begin{definition}[One-site matrix spaces of sector sets]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -122,7 +122,8 @@
       MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix_apply,
       MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix_one}
     \leanok
-    \uses{def:mpdo_physical_sector_factorization}
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator}
     For a virtual matrix $P$, define
     \begin{align}
         \eta_{k,h}(P)
@@ -158,7 +159,8 @@
     \label{thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor}
     \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualMatrices_neighboringOperator}
     \leanok
-    \uses{def:mpdo_matrix_weighted_neighboring_operator,
+    \uses{def:mpdo_minimal_neighboring_operator,
+      def:mpdo_matrix_weighted_neighboring_operator,
       def:mpdo_physical_sector_factorization_virtual_matrices}
     The neighboring operators of the transported factorization satisfy
     \begin{align}
@@ -237,8 +239,9 @@
       MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator,
       MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator_posSemidef}
     \leanok
-    \uses{def:mpdo_physical_sector_factorization,
-      def:mpdo_minimal_neighboring_operator}
+    \uses{def:mpdo_matrix_weighted_neighboring_operator,
+      def:mpdo_physical_sector_factorization_virtual_matrices,
+      thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor}
     Suppose that two MPO tensors of the same virtual dimension differ by an
     invertible virtual gauge.  Every physical-sector factorization of the
     first tensor induces one of the second tensor with the same physical

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -116,6 +116,67 @@
     this definition; it is a separate hypothesis in Proposition~C.7.
 \end{definition}
 
+\begin{definition}[Matrix-weighted neighboring contraction]
+    \label{def:mpdo_matrix_weighted_neighboring_operator}
+    \lean{MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix,
+      MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix_apply,
+      MPOTensor.PhysicalSectorFactorization.neighboringOperatorWithMatrix_one}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    For a virtual matrix $P$, define
+    \begin{align}
+        \eta_{k,h}(P)
+        &=\sum_{\delta,\gamma}P_{\delta,\gamma}
+          (r_k)_\delta\otimes(l_h)_\gamma.
+        \notag
+    \end{align}
+    The ordinary neighboring contraction is the case $P=I$.
+\end{definition}
+
+\begin{theorem}[Virtual compression of a physical-sector factorization]
+    \label{thm:mpdo_physical_sector_factorization_virtual_compression}
+    \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression,
+      MPOTensor.PhysicalSectorFactorization.ofVirtualCompression_neighboringOperator}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_minimal_neighboring_operator,
+      def:mpdo_matrix_weighted_neighboring_operator}
+    Let $K$ and $L$ have virtual dimensions $D$ and $E$, respectively, and
+    suppose that a rectangular matrix $V\in M_{D\times E}(\C)$ satisfies the
+    following identity for every physical index $i$:
+    \begin{align}
+        L^i&=V^\dagger K^iV.
+        \notag
+    \end{align}
+    Every physical-sector factorization of $K$ induces one of $L$ with the
+    same physical decomposition.  Its neighboring operators satisfy
+    \begin{align}
+        \eta^L_{k,h}
+        &=\eta^K_{k,h}(VV^\dagger).
+        \notag
+    \end{align}
+    No positivity of the right-hand side is asserted.
+    The construction combines the virtual corner in
+    \cite[Section~2.3, lines~195--219]{Cirac2016MPDO_arXiv} with the
+    physical-sector factorization and neighboring contraction in
+    \cite[Appendix~C.2, lines~1381--1450]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Replace each left factor by
+    $\sum_\gamma\overline{V_{\gamma,\beta}}(l_k)_\gamma$ and each right
+    factor by $\sum_\delta V_{\delta,\alpha}(r_k)_\delta$.  Expanding a
+    physical slice gives the stated compression.  Contracting the common
+    virtual index gives
+    \begin{align}
+        \sum_\beta V_{\delta,\beta}\overline{V_{\gamma,\beta}}
+        &=(VV^\dagger)_{\delta,\gamma},
+        \notag
+    \end{align}
+    which proves the neighboring-operator identity.
+\end{proof}
+
 \begin{theorem}[Virtual-gauge invariance of physical-sector factorizations]
     \label{thm:mpdo_physical_sector_factorization_gauge}
     \lean{MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -148,7 +148,15 @@
         \notag
     \end{align}
     Every physical-sector factorization of $K$ induces one of $L$ with the
-    same physical decomposition.
+    same physical decomposition.  Its virtual tensor families are
+    \begin{align}
+        (l_k^L)_\beta
+        &=\sum_\gamma X_{\beta,\gamma}(l_k^K)_\gamma,
+        &
+        (r_k^L)_\alpha
+        &=\sum_\delta Y_{\delta,\alpha}(r_k^K)_\delta.
+        \notag
+    \end{align}
     This construction abstracts the virtual corner in
     \cite[Section~2.3, lines~195--219]{Cirac2016MPDO_arXiv} and the
     physical-sector factorization in
@@ -236,6 +244,7 @@
 \begin{theorem}[Virtual-gauge invariance of physical-sector factorizations]
     \label{thm:mpdo_physical_sector_factorization_gauge}
     \lean{MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv,
+      MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_eq_ofVirtualMatrices,
       MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator,
       MPOTensor.PhysicalSectorFactorization.ofGaugeEquiv_neighboringOperator_posSemidef}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -133,14 +133,11 @@
     The ordinary neighboring contraction is the case $P=I$.
 \end{definition}
 
-\begin{theorem}[Virtual compression of a physical-sector factorization]
-    \label{thm:mpdo_physical_sector_factorization_virtual_compression}
-    \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression,
-      MPOTensor.PhysicalSectorFactorization.ofVirtualCompression_neighboringOperator}
+\begin{definition}[Virtual compression of a physical-sector factorization]
+    \label{def:mpdo_physical_sector_factorization_virtual_compression}
+    \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression}
     \leanok
-    \uses{def:mpdo_physical_sector_factorization,
-      def:mpdo_minimal_neighboring_operator,
-      def:mpdo_matrix_weighted_neighboring_operator}
+    \uses{def:mpdo_physical_sector_factorization}
     Let $K$ and $L$ have virtual dimensions $D$ and $E$, respectively, and
     suppose that a rectangular matrix $V\in M_{D\times E}(\C)$ satisfies the
     following identity for every physical index $i$:
@@ -149,17 +146,32 @@
         \notag
     \end{align}
     Every physical-sector factorization of $K$ induces one of $L$ with the
-    same physical decomposition.  Its neighboring operators satisfy
+    same physical decomposition.
+    This construction combines the virtual corner in
+    \cite[Section~2.3, lines~195--219]{Cirac2016MPDO_arXiv} with the
+    physical-sector factorization in
+    \cite[Appendix~C.2, lines~1381--1439]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Neighboring operators under virtual compression]
+    \label{thm:mpdo_physical_sector_factorization_virtual_compression_neighbor}
+    \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression_neighboringOperator}
+    \leanok
+    \uses{def:mpdo_minimal_neighboring_operator,
+      def:mpdo_matrix_weighted_neighboring_operator,
+      def:mpdo_physical_sector_factorization_virtual_compression}
+    The neighboring operators of the factorization obtained by virtual
+    compression satisfy
     \begin{align}
         \eta^L_{k,h}
         &=\eta^K_{k,h}(VV^\dagger).
         \notag
     \end{align}
     No positivity of the right-hand side is asserted.
-    The construction combines the virtual corner in
+    This identity combines the virtual corner in
     \cite[Section~2.3, lines~195--219]{Cirac2016MPDO_arXiv} with the
-    physical-sector factorization and neighboring contraction in
-    \cite[Appendix~C.2, lines~1381--1450]{Cirac2016MPDO_arXiv}.
+    neighboring contraction in
+    \cite[Appendix~C.2, lines~1441--1450]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -133,11 +133,64 @@
     The ordinary neighboring contraction is the case $P=I$.
 \end{definition}
 
+\begin{definition}[Virtual-matrix transport of a physical-sector factorization]
+    \label{def:mpdo_physical_sector_factorization_virtual_matrices}
+    \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualMatrices}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization}
+    Let $K$ and $L$ have virtual dimensions $D$ and $E$, respectively.
+    Suppose that matrices $X\in M_{E\times D}(\C)$ and
+    $Y\in M_{D\times E}(\C)$ satisfy the following identity for every
+    physical index $i$:
+    \begin{align}
+        L^i&=XK^iY.
+        \notag
+    \end{align}
+    Every physical-sector factorization of $K$ induces one of $L$ with the
+    same physical decomposition.
+    This construction abstracts the virtual corner in
+    \cite[Section~2.3, lines~195--219]{Cirac2016MPDO_arXiv} and the
+    physical-sector factorization in
+    \cite[Appendix~C.2, lines~1381--1439]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Neighboring operators under virtual-matrix transport]
+    \label{thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor}
+    \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualMatrices_neighboringOperator}
+    \leanok
+    \uses{def:mpdo_matrix_weighted_neighboring_operator,
+      def:mpdo_physical_sector_factorization_virtual_matrices}
+    The neighboring operators of the transported factorization satisfy
+    \begin{align}
+        \eta^L_{k,h}
+        &=\eta^K_{k,h}(YX).
+        \notag
+    \end{align}
+    This identity combines the virtual corner in
+    \cite[Section~2.3, lines~195--219]{Cirac2016MPDO_arXiv} with the
+    neighboring contraction in
+    \cite[Appendix~C.2, lines~1441--1450]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Replace each left factor by
+    $\sum_\gamma X_{\beta,\gamma}(l_k)_\gamma$ and each right factor by
+    $\sum_\delta Y_{\delta,\alpha}(r_k)_\delta$.  Expanding a physical slice
+    gives the stated transport.  Contracting the common virtual index gives
+    \begin{align}
+        \sum_\beta Y_{\delta,\beta}X_{\beta,\gamma}
+        &=(YX)_{\delta,\gamma},
+        \notag
+    \end{align}
+    which proves the neighboring-operator identity.
+\end{proof}
+
 \begin{definition}[Virtual compression of a physical-sector factorization]
     \label{def:mpdo_physical_sector_factorization_virtual_compression}
     \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression}
     \leanok
-    \uses{def:mpdo_physical_sector_factorization}
+    \uses{def:mpdo_physical_sector_factorization_virtual_matrices}
     Let $K$ and $L$ have virtual dimensions $D$ and $E$, respectively, and
     suppose that a rectangular matrix $V\in M_{D\times E}(\C)$ satisfies the
     following identity for every physical index $i$:
@@ -157,8 +210,7 @@
     \label{thm:mpdo_physical_sector_factorization_virtual_compression_neighbor}
     \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression_neighboringOperator}
     \leanok
-    \uses{def:mpdo_minimal_neighboring_operator,
-      def:mpdo_matrix_weighted_neighboring_operator,
+    \uses{thm:mpdo_physical_sector_factorization_virtual_matrices_neighbor,
       def:mpdo_physical_sector_factorization_virtual_compression}
     The neighboring operators of the factorization obtained by virtual
     compression satisfy
@@ -176,17 +228,7 @@
 
 \begin{proof}
     \leanok
-    Replace each left factor by
-    $\sum_\gamma\overline{V_{\gamma,\beta}}(l_k)_\gamma$ and each right
-    factor by $\sum_\delta V_{\delta,\alpha}(r_k)_\delta$.  Expanding a
-    physical slice gives the stated compression.  Contracting the common
-    virtual index gives
-    \begin{align}
-        \sum_\beta V_{\delta,\beta}\overline{V_{\gamma,\beta}}
-        &=(VV^\dagger)_{\delta,\gamma},
-        \notag
-    \end{align}
-    which proves the neighboring-operator identity.
+    Apply the virtual-matrix transport identity with $X=V^\dagger$ and $Y=V$.
 \end{proof}
 
 \begin{theorem}[Virtual-gauge invariance of physical-sector factorizations]

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -500,6 +500,21 @@ required comparison from closed-chain proportionality.  The explicit
 factorization and positivity assumptions of the proved corollary are marked
 scope restrictions, not additional hypotheses on the source proposition.
 
+\leanid{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression} records
+the corresponding algebraic construction for a rectangular virtual
+compression $L^i=V^*K^iV$.  The physical decomposition is unchanged, but the
+neighboring operator is no longer the original contraction.  By
+\leanid{MPOTensor.PhysicalSectorFactorization.%
+ofVirtualCompression_neighboringOperator}, it is the contraction with
+$VV^*$ inserted between the right and left virtual factors.  Thus positivity
+of the original contraction, which concerns the identity matrix, does not by
+itself establish positivity after compression.  The canonical-form projection
+at source lines~195--219 supplies the virtual corner but does not assert this
+projected positivity.  Moreover, the present proportional canonical-form
+comparison does not retain a compression map from the selected fixed tensor
+to its matched trace-visible sector.  Both the map and positivity of the
+projected contraction remain necessary.
+
 \paragraph{Local fix (the later orthogonal-sector statement).}
 The proposition labelled \emph{prop4to2} at source lines~1801--1808 states
 that the GSNNCH form alone implies SAL.  Its proof applies Proposition
@@ -543,8 +558,12 @@ the all-cut entropy argument, and transport to the original physical basis are
 complete under an explicit positive physical-sector factorization.  The exact
 fixed tensor selected from the source-side commuting bond now has such a
 factorization, with positive neighboring operators and the original physical
-bond.  The remaining gap is the normality and blocking comparison between the
-original source tensor and that selected fixed tensor.  The later
+bond.  Rectangular virtual compression now transports the algebraic
+factorization and identifies its neighboring contraction exactly.  The
+remaining gap is to retain the selected trace-visible sector as an exact
+virtual corner, prove positivity after inserting its range projection, and
+relate the resulting blocked sector back to the original source tensor.
+The later
 orthogonal direct-sum implication is likewise formalized only as a
 scope-restricted theorem assuming sectorwise SAL.  It neither supplies that
 sectorwise premise nor proves the printed assertion that the GSNNCH form alone
@@ -558,12 +577,15 @@ The gap can be removed in the following stages.
 \item The selected fixed tensor has a positive physical-sector factorization
 constructed non-circularly from the source-side commuting bond, as recorded by
 the fixed-tensor theorem identified above.
-\item Prove the normality and blocking comparison from the original normal
-MPDO block and the printed proportional commuting-bond hypotheses to the
-selected fixed representative.  The resulting virtual gauge then transports
-the fixed tensor's factorization without changing its neighboring operators.
-Only then may the source proposition receive a formal declaration and a
-\texttt{\string\leanok} marker.
+\item Retain an exact virtual compression map when selecting the
+trace-visible canonical sector of the fixed tensor.  Prove that the
+neighboring contraction remains positive after inserting the range
+projection of this map.
+\item Use the proportional canonical-form theorem and its virtual gauge to
+transport the positive compressed factorization to the matching normal
+sector, then remove any blocking without adding a hypothesis absent from
+Proposition~\emph{4to2}.  Only then may the source proposition receive a
+formal declaration and a \texttt{\string\leanok} marker.
 \end{enumerate}
 
 \bibliographystyle{alpha}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -114,6 +114,22 @@ abstracted — record why, so it is not re-proposed).
   are 30 and 44 declaration/proof lines. Including the dependency-neutral module split,
   the refactor removes 364 source lines overall (865 additions, 1229 deletions).
 
+### physical-sector virtual-matrix transport — promoted
+- **Pattern:** absorb two virtual matrices into the left and right tensor
+  families of a physical-sector factorization, expand the transported physical
+  slice, and discharge the equal- and unequal-sector blocks separately.
+- **Seen:** two implementations exceeding 70 proof lines each in
+  `PhysicalSectorGaugeTransport.lean` and
+  `PhysicalSectorVirtualCompression.lean`; both also expanded the same
+  neighboring contraction.
+- **Abstraction:** `MPOTensor.PhysicalSectorFactorization.ofVirtualMatrices`
+  and `ofVirtualMatrices_neighboringOperator` in
+  `TNLean/MPS/MPDO/PhysicalSectorVirtualTransport.lean`.
+- **Notes:** gauge transport specializes the two matrices to an invertible
+  gauge and its inverse; virtual compression specializes them to an adjoint
+  and its coordinate map.  The source-facing definitions and theorem
+  statements remain unchanged.
+
 ### list_ofFn_products — promoted
 - **Pattern:** induction on the length to distribute an ordered `List.ofFn` product over
   finite sums, or to extract scalar coefficients from such a product.


### PR DESCRIPTION
Closes #5079. This is a scoped child of #4459; the parent tracker remains open.

## What changed

- add the shared mathematical transport `PhysicalSectorFactorization.ofVirtualMatrices` for a pair of rectangular virtual matrices `X` and `Y`
- prove that its neighboring contraction inserts the product `Y * X`
- refactor existing virtual-gauge transport to specialize that shared construction
- define virtual compression as the specialization `X = Vᴴ`, `Y = V`
- prove that the compressed neighboring operator is weighted by `V * Vᴴ`
- record the promoted repeated proof pattern and document the exact statements in the Blueprint and CPSV16 paper-gap note

## Mathematical scope

For a transport satisfying `Lᵢ = X Kᵢ Y`, the left and right sector tensors absorb `X` and `Y` separately. Their neighboring contraction therefore inserts `Y * X`. An invertible gauge gives the identity insertion; a rectangular compression gives `V * Vᴴ`.

This PR intentionally makes no projected-positivity, SAL, global-gauge, or unblocked-root claim. Positivity of the inserted-range contraction requires a separate source-faithful argument, so #4459 remains open.

Source anchors: CPSV16 / arXiv:1606.00608, Section 2.3 lines 195–219 and Appendix C.2 lines 1381–1450.

## Validation

- `lake exe cache get` before all Lean work in the fresh worktree
- focused builds of virtual transport, gauge transport, and virtual compression — passed
- `lake build` — 9,803 jobs passed on hot main `886b4591d`
- Blueprint/Lean sync — affected chapter 76/76
- `lake exe checkdecls blueprint/lean_decls` — passed
- `leanblueprint web` — passed
- `leanblueprint pdf` — passed; final pages 603–604 visually inspected for clipping and layout
- import-aggregator generation/check — passed
- reader-facing prose policy — passed
- tactic-pattern scan and promoted ledger entry — completed
- Lean file-policy tests — 16 passed
- import-aggregator tests — 9 passed
- Lake hotspot tests — 7 passed
- `git diff --check` — passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean formalization and documentation only—no runtime or security surface. Main risk is proof-maintenance surface area in MPDO physical-sector theory, mitigated by shared abstraction and existing build/sync checks.
> 
> **Overview**
> Introduces **`PhysicalSectorVirtualTransport`**: matrix-weighted neighboring contraction (`neighboringOperatorWithMatrix`), transport through rectangular virtual matrices (`ofVirtualMatrices`), and the identity that the transported neighboring operator is weighted by **`Y * X`**.
> 
> **Gauge transport** is refactored to call that construction with an invertible gauge and its inverse; long duplicate proofs are removed in favor of `ofVirtualMatrices_neighboringOperator` and `neighboringOperatorWithMatrix_one`.
> 
> Adds **`ofVirtualCompression`** as the `Vᴴ` / `V` specialization, with neighboring operators weighted by **`V * Vᴴ`** (no projected-positivity claim). Blueprint chapter 21 and the CPSV16 gap note are updated to match; the tactic ledger records the promoted pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d535a7a0dc3b29ef78150251457faa938cfe95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->