### PR TITLE
refactor(MPS/MPDO): lower sector positivity dependencies

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -63,6 +63,7 @@ import TNLean.Channel.SchmidtRank
 import TNLean.Channel.Schwarz
 import TNLean.Channel.Semigroup
 import TNLean.Channel.Separable
+import TNLean.Channel.SingleKrausPositivity
 import TNLean.Channel.Spectral
 import TNLean.Channel.Stinespring
 import TNLean.Channel.SupportedMarginalChannel

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -43,6 +43,8 @@ dimensions.
   completely positive.
 * `singleKrausMap`: the linear map `X ↦ V X V†` associated with one rectangular
   matrix `V`.
+* `Matrix.posSemidef_of_singleKraus_isometry`: positivity can be read back
+  through an isometric single-Kraus conjugation.
 * `singleKrausMap_isKrausCP`: a single-Kraus map is completely positive.
 * `singleKrausMap_isKrausCPTP`: an isometric single-Kraus map is trace-preserving
   completely positive.
@@ -295,6 +297,25 @@ noncomputable alias sandwichMap := singleKrausMap
     (V : Matrix β α ℂ) (X : Matrix α α ℂ) :
     singleKrausMap V X = V * X * Vᴴ :=
   rfl
+
+/-- Positivity can be read back through an isometric single-Kraus
+conjugation. -/
+theorem Matrix.posSemidef_of_singleKraus_isometry
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β]
+    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) {X : Matrix α α ℂ}
+    (hX : (singleKrausMap V X).PosSemidef) : X.PosSemidef := by
+  classical
+  have hback := hX.mul_mul_conjTranspose_same Vᴴ
+  simp only [singleKrausMap_apply,
+    Matrix.conjTranspose_conjTranspose] at hback
+  have heq : Vᴴ * (V * X * Vᴴ) * V = X := by
+    calc
+      _ = (Vᴴ * V) * X * (Vᴴ * V) := by
+        simp only [← Matrix.mul_assoc]
+      _ = X := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+  rw [heq] at hback
+  exact hback
 
 /-- Conjugation by one rectangular matrix is completely positive. -/
 theorem singleKrausMap_isKrausCP {α β : Type*}

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -43,8 +43,6 @@ dimensions.
   completely positive.
 * `singleKrausMap`: the linear map `X ↦ V X V†` associated with one rectangular
   matrix `V`.
-* `Matrix.posSemidef_of_singleKraus_isometry`: positivity can be read back
-  through an isometric single-Kraus conjugation.
 * `singleKrausMap_isKrausCP`: a single-Kraus map is completely positive.
 * `singleKrausMap_isKrausCPTP`: an isometric single-Kraus map is trace-preserving
   completely positive.
@@ -297,25 +295,6 @@ noncomputable alias sandwichMap := singleKrausMap
     (V : Matrix β α ℂ) (X : Matrix α α ℂ) :
     singleKrausMap V X = V * X * Vᴴ :=
   rfl
-
-/-- Positivity can be read back through an isometric single-Kraus
-conjugation. -/
-theorem Matrix.posSemidef_of_singleKraus_isometry
-    {α β : Type*} [Fintype α] [DecidableEq α]
-    [Fintype β]
-    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) {X : Matrix α α ℂ}
-    (hX : (singleKrausMap V X).PosSemidef) : X.PosSemidef := by
-  classical
-  have hback := hX.mul_mul_conjTranspose_same Vᴴ
-  simp only [singleKrausMap_apply,
-    Matrix.conjTranspose_conjTranspose] at hback
-  have heq : Vᴴ * (V * X * Vᴴ) * V = X := by
-    calc
-      _ = (Vᴴ * V) * X * (Vᴴ * V) := by
-        simp only [← Matrix.mul_assoc]
-      _ = X := by rw [hV, Matrix.one_mul, Matrix.mul_one]
-  rw [heq] at hback
-  exact hback
 
 /-- Conjugation by one rectangular matrix is completely positive. -/
 theorem singleKrausMap_isKrausCP {α β : Type*}

--- a/TNLean/Channel/SingleKrausPositivity.lean
+++ b/TNLean/Channel/SingleKrausPositivity.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KrausCPTP
+
+/-!
+# Positivity under single-Kraus isometries
+
+This file records the order-reflection property of conjugation by a rectangular
+isometry.
+
+## Main declarations
+
+* `Matrix.posSemidef_of_singleKraus_isometry`: positivity can be read back
+  through an isometric single-Kraus conjugation.
+-/
+
+open scoped Matrix ComplexOrder
+
+/-- Positivity can be read back through an isometric single-Kraus
+conjugation. -/
+theorem Matrix.posSemidef_of_singleKraus_isometry
+    {α β : Type*} [Fintype α] [DecidableEq α]
+    [Fintype β]
+    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) {X : Matrix α α ℂ}
+    (hX : (singleKrausMap V X).PosSemidef) : X.PosSemidef := by
+  classical
+  have hback := hX.mul_mul_conjTranspose_same Vᴴ
+  simp only [singleKrausMap_apply,
+    Matrix.conjTranspose_conjTranspose] at hback
+  have heq : Vᴴ * (V * X * Vᴴ) * V = X := by
+    calc
+      _ = (Vᴴ * V) * X * (Vᴴ * V) := by
+        simp only [← Matrix.mul_assoc]
+      _ = X := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+  rw [heq] at hback
+  exact hback

--- a/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
+++ b/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.HayashiSectorComparison
+import TNLean.Algebra.PosSemidefSupport
+import TNLean.MPS.FundamentalTheorem.Basic
+import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.StackedLayers
 
 /-!

--- a/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
+++ b/TNLean/MPS/MPDO/BNTLayerOrthogonality.lean
@@ -3,8 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.PhysicalSectorProductRealization
-import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+import TNLean.MPS.MPDO.HayashiSectorComparison
 import TNLean.MPS.MPDO.StackedLayers
 
 /-!
@@ -32,22 +31,6 @@ open scoped Matrix ComplexOrder BigOperators
 namespace MPOTensor
 
 variable {d g : ℕ} {bondDim : Fin g → ℕ}
-
-/-- Positivity of every neighbouring sector operator makes the original tensor an MPDO.  The
-sector-coordinate operators are positive by their cyclic product decomposition, and the
-physical isometry transports positivity back to the original physical space.
-
-Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `Appetakhetc`,
-lines 1383--1450. -/
-theorem PhysicalSectorFactorization.isMPDO_of_neighboringOperator_pos
-    {K : MPOTensor d D} (F : PhysicalSectorFactorization K)
-    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef) : IsMPDO K := by
-  apply isMPDO_of_changePhysicalBasis_isMPDO_of_isometry
-    F.physicalCoordinateMatrix F.physicalCoordinateMatrix_isometry K
-  rw [← F.sectorCoordinateTensor_eq_changePhysicalBasis]
-  intro N hN
-  letI : NeZero N := ⟨Nat.ne_of_gt hN⟩
-  exact F.mpo_sectorCoordinateTensor_posSemidef hpos
 
 /-! ### Physical adjoint -/
 

--- a/TNLean/MPS/MPDO/CommonWeightAbsorbedBNTSupport.lean
+++ b/TNLean/MPS/MPDO/CommonWeightAbsorbedBNTSupport.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BNTLayerOrthogonality
+import TNLean.MPS.MPDO.PhysicalSectorProductRealization
 import TNLean.MPS.MPDO.PhysicalSupportRestriction
 
 /-!

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -42,6 +42,7 @@ Verstraete):
 * `MPOTensor.IsRFP`: renormalization fixed-point predicate.
 * `MPOTensor.toMPSTensor`: view an MPO tensor as an MPS tensor with doubled
   physical index `Fin (d * d)`.
+* `MPOTensor.physicalSlice`: the physical matrix at fixed virtual indices.
 
 ## References
 
@@ -87,6 +88,14 @@ identifying `Fin d × Fin d` with `Fin (d * d)` via the standard product encodin
 (`Fin.divNat` = ket, `Fin.modNat` = bra). -/
 def toMPSTensor (M : MPOTensor d D) : MPSTensor (d * d) D :=
   fun ij => M (ij.divNat) (ij.modNat)
+
+/-- The physical matrix obtained from a fixed pair of virtual indices of an
+MPO tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, lines 1424--1438 and equation `formK`. -/
+def physicalSlice (K : MPOTensor d D) (β α : Fin D) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  fun i j ↦ K i j β α
 
 /-! ### Word evaluation -/
 

--- a/TNLean/MPS/MPDO/HayashiSectorComparison.lean
+++ b/TNLean/MPS/MPDO/HayashiSectorComparison.lean
@@ -18,7 +18,6 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 
 - `MPOTensor.IsThreeSiteClosure`: closure of three local tensors against a
   virtual tail.
-- `MPOTensor.physicalSlice`: the physical matrix at fixed virtual indices.
 - `MPOTensor.hayashiInverseLeft` and `MPOTensor.hayashiInverseRight`: the two
   outer inverse-map factors in a fixed Hayashi sector.
 - `MPOTensor.inverseMap_threeSite_closure_collapse`: the outer inverse-map
@@ -54,14 +53,6 @@ def IsThreeSiteClosure {d D : ℕ} (K : MPOTensor d D)
   ∀ i₁ i₂ i₃ j₁ j₂ j₃,
     ρ (i₁, i₂, i₃) (j₁, j₂, j₃) =
       Matrix.trace (K i₁ j₁ * K i₂ j₂ * K i₃ j₃ * R)
-
-/-- The physical matrix obtained from a fixed pair of virtual indices of an
-MPO tensor.
-
-Source: arXiv:1606.00608, Appendix C.2, lines 1424--1438 and equation `formK`. -/
-def physicalSlice {d D : ℕ} (K : MPOTensor d D) (β α : Fin D) :
-    Matrix (Fin d) (Fin d) ℂ :=
-  fun i j ↦ K i j β α
 
 /-- The left outer factor obtained by applying the inverse tensor to the left
 density matrix in a Hayashi sector.

--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingBondEtaCyclicCore
-import TNLean.MPS.MPDO.PhysicalSupportSALTransport
+import TNLean.MPS.MPDO.SitewisePhysicalMatrix
 
 open scoped ComplexOrder Matrix
 

--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -8,6 +8,7 @@ import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
 import TNLean.MPS.MPDO.PhysicalSectorPositiveBond
 import TNLean.MPS.MPDO.CommutingForm
 import TNLean.MPS.MPDO.CommutingBondEtaCyclicCore
+import TNLean.MPS.MPDO.PhysicalSupportSALTransport
 
 open scoped ComplexOrder Matrix
 
@@ -275,6 +276,22 @@ theorem mpo_sectorCoordinateTensor_posSemidef
     simp [Matrix.finKronecker_apply]
   rw [heq]
   exact Matrix.finKronecker_posSemidef _ fun n ↦ hpos _ _
+
+/-- Positivity of every neighbouring sector operator makes the original tensor an MPDO.  The
+sector-coordinate operators are positive by their cyclic product decomposition, and the
+physical isometry transports positivity back to the original physical space.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `Appetakhetc`,
+lines 1383--1450. -/
+theorem isMPDO_of_neighboringOperator_pos
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef) : IsMPDO K := by
+  apply isMPDO_of_changePhysicalBasis_isMPDO_of_isometry
+    F.physicalCoordinateMatrix F.physicalCoordinateMatrix_isometry K
+  rw [← F.sectorCoordinateTensor_eq_changePhysicalBasis]
+  intro N hN
+  letI : NeZero N := ⟨Nat.ne_of_gt hN⟩
+  exact F.mpo_sectorCoordinateTensor_posSemidef hpos
 
 /-- The sector-coordinate bond indexed by two-site configurations. -/
 noncomputable def sectorBond (F : PhysicalSectorFactorization K) :

--- a/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
@@ -116,58 +116,11 @@ theorem vonNeumannEntropy_singleKraus_isometry
     _ = vonNeumannEntropy ρ hρ :=
       vonNeumannEntropy_congr hBAeq hBA hρ
 
-namespace Matrix
-
-/-- Positivity can be read back through an isometric single-Kraus
-conjugation. -/
-theorem posSemidef_of_singleKraus_isometry
-    {α β : Type*} [Fintype α] [DecidableEq α]
-    [Fintype β]
-    (V : Matrix β α ℂ) (hV : Vᴴ * V = 1) {X : Matrix α α ℂ}
-    (hX : (singleKrausMap V X).PosSemidef) : X.PosSemidef := by
-  classical
-  have hback := hX.mul_mul_conjTranspose_same Vᴴ
-  simp only [singleKrausMap_apply,
-    Matrix.conjTranspose_conjTranspose] at hback
-  have heq : Vᴴ * (V * X * Vᴴ) * V = X := by
-    calc
-      _ = (Vᴴ * V) * X * (Vᴴ * V) := by
-        simp only [← Matrix.mul_assoc]
-      _ = X := by rw [hV, Matrix.one_mul, Matrix.mul_one]
-  rw [heq] at hback
-  exact hback
-
-end Matrix
-
 namespace MPOTensor
 
 variable {d e D : ℕ}
 
 open PhysicalSectorFactorization
-
-/-- The sitewise tensor power of a one-site isometry is an isometry. -/
-theorem sitewisePhysicalMatrix_isometry
-    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1) (N : ℕ) :
-    (sitewisePhysicalMatrix V N)ᴴ * sitewisePhysicalMatrix V N = 1 := by
-  classical
-  ext x y
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-    sitewisePhysicalMatrix]
-  simp_rw [star_prod, ← Finset.prod_mul_distrib]
-  rw [← Fintype.piFinset_univ]
-  rw [← Finset.prod_univ_sum
-    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin e)))
-    (fun n a ↦ star (V a (x n)) * V a (y n))]
-  have hentry : ∀ n : Fin N,
-      (∑ a : Fin e, star (V a (x n)) * V a (y n)) =
-        if x n = y n then 1 else 0 := by
-    intro n
-    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-      Matrix.one_apply] using congrFun (congrFun hV (x n)) (y n)
-  simp_rw [hentry]
-  rw [Fintype.prod_boole]
-  congr 1
-  exact propext funext_iff.symm
 
 /-- An isometric physical inclusion preserves the trace of every periodic
 MPO, including every positive-length chain used by SAL. -/
@@ -266,18 +219,6 @@ theorem reducedBlockState_changePhysicalBasis_of_isometry
   exact blockReducedState_singleKraus_sitewise V hV L (N - L)
     (Matrix.reindex (blockReindexEquiv d N L hL)
       (blockReindexEquiv d N L hL) (normalizedMPO M N))
-
-/-- If an MPO is positive after an isometric physical inclusion, then it was
-already positive before inclusion. -/
-theorem isMPDO_of_changePhysicalBasis_isMPDO_of_isometry
-    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
-    (M : MPOTensor d D) (hM : IsMPDO (changePhysicalBasis V M)) :
-    IsMPDO M := by
-  intro N hN
-  apply Matrix.posSemidef_of_singleKraus_isometry
-    (sitewisePhysicalMatrix V N) (sitewisePhysicalMatrix_isometry V hV N)
-  rw [singleKrausMap_sitewisePhysicalMatrix_mpo]
-  exact hM N hN
 
 /-- An isometric physical inclusion does not change a contiguous block
 entropy. -/

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.ListProduct
+import TNLean.Channel.SingleKrausPositivity
 import TNLean.MPS.MPDO.PhysicalSectorCoordinateTransport
 
 /-!

--- a/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
+++ b/TNLean/MPS/MPDO/SitewisePhysicalMatrix.lean
@@ -74,6 +74,30 @@ theorem sitewisePhysicalMatrix_conjTranspose
   ext s t
   simp [Matrix.conjTranspose_apply, sitewisePhysicalMatrix, star_prod]
 
+/-- The sitewise tensor power of a one-site isometry is an isometry. -/
+theorem sitewisePhysicalMatrix_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1) (N : ℕ) :
+    (sitewisePhysicalMatrix V N)ᴴ * sitewisePhysicalMatrix V N = 1 := by
+  classical
+  ext x y
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    sitewisePhysicalMatrix]
+  simp_rw [star_prod, ← Finset.prod_mul_distrib]
+  rw [← Fintype.piFinset_univ]
+  rw [← Finset.prod_univ_sum
+    (fun _ : Fin N ↦ (Finset.univ : Finset (Fin e)))
+    (fun n a ↦ star (V a (x n)) * V a (y n))]
+  have hentry : ∀ n : Fin N,
+      (∑ a : Fin e, star (V a (x n)) * V a (y n)) =
+        if x n = y n then 1 else 0 := by
+    intro n
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply] using congrFun (congrFun hV (x n)) (y n)
+  simp_rw [hentry]
+  rw [Fintype.prod_boole]
+  congr 1
+  exact propext funext_iff.symm
+
 /-- The product of a sitewise tensor power with its conjugate transpose is the
 sitewise tensor power of the corresponding one-site product. -/
 theorem sitewisePhysicalMatrix_mul_conjTranspose
@@ -196,6 +220,18 @@ theorem singleKrausMap_sitewisePhysicalMatrix_mpo
       ring)
   rw [Fintype.sum_prod_type] at h
   exact h
+
+/-- If an MPO is positive after an isometric physical inclusion, then it was
+already positive before inclusion. -/
+theorem isMPDO_of_changePhysicalBasis_isMPDO_of_isometry
+    (V : Matrix (Fin e) (Fin d) ℂ) (hV : Vᴴ * V = 1)
+    (M : MPOTensor d D) (hM : IsMPDO (changePhysicalBasis V M)) :
+    IsMPDO M := by
+  intro N hN
+  apply Matrix.posSemidef_of_singleKraus_isometry
+    (sitewisePhysicalMatrix V N) (sitewisePhysicalMatrix_isometry V hV N)
+  rw [singleKrausMap_sitewisePhysicalMatrix_mpo]
+  exact hM N hN
 
 /-- The sitewise tensor power of a Hermitian one-site matrix is Hermitian. -/
 theorem sitewisePhysicalMatrix_isHermitian


### PR DESCRIPTION
## Summary

- place `PhysicalSectorFactorization.isMPDO_of_neighboringOperator_pos` beside the sector-coordinate product-positivity theorem it specializes
- isolate the generic order-reflection theorem in the focused `Channel.SingleKrausPositivity` module
- lower sitewise isometry and MPDO physical-inclusion transport into `SitewisePhysicalMatrix`
- move the elementary `physicalSlice` MPO view into MPDO `Defs`
- make `BNTLayerOrthogonality` and the sector product-realization module import their actual lower-level dependencies

This is the source-boundary follow-up to the exact-head location review on #5076. All moved declarations keep their fully qualified names, statements, proofs, and source citations. The product-realization import closure is 244 modules and no longer contains `PhysicalSupportSALTransport` (the initial placement-only version expanded it to 445).

## Validation

- `lake exe cache get` (8,451 cached artifacts; no Mathlib source rebuild)
- focused build of `TNLean.Channel.SingleKrausPositivity`, `TNLean.MPS.MPDO.Defs`, `SitewisePhysicalMatrix`, `PhysicalSupportSALTransport`, `PhysicalSectorProductRealization`, `BNTLayerOrthogonality`, and `CommonWeightAbsorbedBNTSupport`
- `lake build TNLean.MPS.MPDO TNLean -q --log-level=info`
- `PYTHONPATH=scripts python3 scripts/test_lean_file_policies.py -v`
- `PYTHONPATH=scripts python3 scripts/check_oversized_lean_files.py --root . --import-only-aggregator TNLean.lean` (1,152 files, zero nonexempt files over 1,000 lines)
- `python3 scripts/generate_import_aggregators.py --root . --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- proof-integrity scan on all moved/touched Lean files (no `sorry` or `axiom`)
- `git diff --check`
- import-graph measurement with `lake exe graph --to TNLean.MPS.MPDO.PhysicalSectorProductRealization`: 244 nodes; `PhysicalSupportSALTransport` absent

The full build reports only the existing unrelated `SectorMatch` sorry and unused-variable warnings in the two grouped-Gram normalization modules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-preserving moves and import rewiring only; no new axioms or changed theorem statements.
> 
> **Overview**
> This PR **relocates** several Lean declarations so MPDO modules depend on smaller, more appropriate layers—no statement or proof changes.
> 
> **Channel:** Adds `TNLean.Channel.SingleKrausPositivity` with `Matrix.posSemidef_of_singleKraus_isometry` (pulled out of MPDO SAL transport).
> 
> **MPDO core:** Defines `MPOTensor.physicalSlice` in `Defs` (was in `HayashiSectorComparison`).
> 
> **Sitewise transport:** Moves `sitewisePhysicalMatrix_isometry`, `isMPDO_of_changePhysicalBasis_isMPDO_of_isometry`, and related logic into `SitewisePhysicalMatrix`, which now imports the channel positivity lemma.
> 
> **Sector positivity:** Moves `isMPDO_of_neighboringOperator_pos` next to `mpo_sectorCoordinateTensor_posSemidef` in `PhysicalSectorProductRealization` and drops it from `BNTLayerOrthogonality`.
> 
> **Import cleanup:** `BNTLayerOrthogonality` switches to lighter imports (`Defs`, `StackedLayers`, etc.); `CommonWeightAbsorbedBNTSupport` gains `PhysicalSectorProductRealization` so callers still get neighboring-operator MPDO positivity. The product-realization closure shrinks (e.g. no longer drags `PhysicalSupportSALTransport` through that path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab0ae7bc432f6c305342b24dfe0d5ed92cc6538. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->