### PR TITLE
feat(MPS/SharedInfra): realize flattened sector compression

### DIFF
--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.DependentBlockDiagonal
 import Mathlib.Data.Complex.Basic
 import Mathlib.Data.Matrix.Basis
 import Mathlib.Data.Matrix.Block
@@ -109,6 +110,36 @@ block decomposition. -/
 def blockProjection {R : Type*} [Zero R] [One R] [(i : ι) → DecidableEq (n i)]
     (k : ι) : Matrix ((i : ι) × n i) ((i : ι) × n i) R :=
   Matrix.blockDiagonal' fun i => if i = k then (1 : Matrix (n i) (n i) R) else 0
+
+/-- The range projection of a canonical summand inclusion is the block
+projection onto that summand. -/
+theorem sigmaBlockInclusion_mul_conjTranspose_eq_blockProjection
+    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
+    (k : ι) :
+    sigmaBlockInclusion n k * (sigmaBlockInclusion n k)ᴴ =
+      blockProjection (n := n) (R := ℂ) k := by
+  ext x y
+  rcases x with ⟨i, a⟩
+  rcases y with ⟨j, b⟩
+  unfold blockProjection
+  by_cases hi : i = k
+  · subst i
+    by_cases hj : j = k
+    · subst j
+      simp [sigmaBlockInclusion, Matrix.mul_apply,
+        Matrix.blockDiagonal'_apply_eq, Matrix.one_apply]
+    · rw [Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hj)]
+      simp [sigmaBlockInclusion, Matrix.mul_apply, hj]
+  · by_cases hj : j = k
+    · subst j
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hi]
+      simp [sigmaBlockInclusion, Matrix.mul_apply, hi]
+    · by_cases hij : i = j
+      · subst j
+        simp [sigmaBlockInclusion, Matrix.mul_apply,
+          Matrix.blockDiagonal'_apply_eq, hi]
+      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hij]
+        simp [sigmaBlockInclusion, Matrix.mul_apply, hi, hj]
 
 /-- A matrix on a dependent direct sum is block diagonal when it is a dependent
 `Matrix.blockDiagonal'` of its diagonal blocks. -/

--- a/TNLean/MPS/SharedInfra.lean
+++ b/TNLean/MPS/SharedInfra.lean
@@ -13,4 +13,5 @@ import TNLean.MPS.SharedInfra.BlockGauge
 import TNLean.MPS.SharedInfra.GaugePhase
 import TNLean.MPS.SharedInfra.KrausAdjointSetup
 import TNLean.MPS.SharedInfra.Scaling
+import TNLean.MPS.SharedInfra.SectorCompression
 import TNLean.MPS.SharedInfra.SectorDecomposition

--- a/TNLean/MPS/SharedInfra/SectorCompression.lean
+++ b/TNLean/MPS/SharedInfra/SectorCompression.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.DependentBlockDiagonal
+import TNLean.Algebra.ScalarCommutant
+import TNLean.MPS.SharedInfra.SectorDecomposition
+
+/-!
+# Virtual compression to a flattened sector block
+
+This file identifies each weighted flattened block of a sector decomposition
+as an isometric virtual compression of its block-diagonal tensor.
+
+## Main results
+
+- `MPSTensor.SectorDecomposition.flatBlockInclusion`: the canonical inclusion
+  of one flattened block.
+- `MPSTensor.SectorDecomposition.flatWeight_smul_flatBasis_eq_compression`:
+  compression of the ambient tensor recovers the weighted block.
+
+The construction is the blockwise virtual corner from arXiv:1606.00608,
+Section 2.3, equation `II_Aiplusk1`, lines 195--219. Appendix C.2, Case I,
+lines 1374--1450 and 1571--1619 is a downstream application context.
+-/
+
+open scoped Matrix
+
+noncomputable section
+
+namespace MPSTensor.SectorDecomposition
+
+variable {d : ℕ}
+
+/-- The canonical isometric inclusion of a flattened sector block into the
+full virtual space.
+
+Source: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219. -/
+def flatBlockInclusion
+    (P : SectorDecomposition d) (s : Fin P.totalCopies) :
+    Matrix (Fin P.totalDim) (Fin (P.flatDim s)) ℂ :=
+  Matrix.reindex finSigmaFinEquiv (Equiv.refl _)
+    (Matrix.sigmaBlockInclusion
+      (fun t : Fin P.totalCopies ↦ Fin (P.flatDim t)) s)
+
+/-- The canonical inclusion of a flattened sector block is an isometry.
+
+Source: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219. -/
+@[simp]
+theorem flatBlockInclusion_isometry
+    (P : SectorDecomposition d) (s : Fin P.totalCopies) :
+    (P.flatBlockInclusion s)ᴴ * P.flatBlockInclusion s = 1 := by
+  let dim := fun t : Fin P.totalCopies ↦ Fin (P.flatDim t)
+  let e : ((t : Fin P.totalCopies) × dim t) ≃ Fin P.totalDim :=
+    finSigmaFinEquiv
+  let E := Matrix.sigmaBlockInclusion dim s
+  change (Matrix.reindex e (Equiv.refl _) E)ᴴ *
+      Matrix.reindex e (Equiv.refl _) E = 1
+  rw [Matrix.conjTranspose_reindex]
+  change Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e Eᴴ *
+      Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) E = 1
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) e (Equiv.refl _),
+    Matrix.sigmaBlockInclusion_isometry,
+    Matrix.reindexLinearEquiv_one]
+
+/-- The range projection of a flattened block inclusion is the reindexed
+projection onto that block.
+
+Source: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219. -/
+theorem flatBlockInclusion_mul_conjTranspose
+    (P : SectorDecomposition d) (s : Fin P.totalCopies) :
+    P.flatBlockInclusion s * (P.flatBlockInclusion s)ᴴ =
+      Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv
+        (Matrix.blockProjection
+          (n := fun t : Fin P.totalCopies ↦ Fin (P.flatDim t))
+          (R := ℂ) s) := by
+  let dim := fun t : Fin P.totalCopies ↦ Fin (P.flatDim t)
+  let e : ((t : Fin P.totalCopies) × dim t) ≃ Fin P.totalDim :=
+    finSigmaFinEquiv
+  let E := Matrix.sigmaBlockInclusion dim s
+  change Matrix.reindex e (Equiv.refl _) E *
+      (Matrix.reindex e (Equiv.refl _) E)ᴴ =
+        Matrix.reindex e e (Matrix.blockProjection (n := dim) (R := ℂ) s)
+  rw [Matrix.conjTranspose_reindex]
+  change Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) E *
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e Eᴴ =
+        Matrix.reindexLinearEquiv ℂ ℂ e e
+          (Matrix.blockProjection (n := dim) (R := ℂ) s)
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ e (Equiv.refl _) e]
+  rw [Matrix.sigmaBlockInclusion_mul_conjTranspose_eq_blockProjection
+    (n := dim) s]
+
+/-- The flattened block inclusion intertwines the ambient tensor with the
+weighted selected block on the right.
+
+Source: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219. -/
+theorem toTensor_mul_flatBlockInclusion
+    (P : SectorDecomposition d) (s : Fin P.totalCopies) (i : Fin d) :
+    P.toTensor i * P.flatBlockInclusion s =
+      P.flatBlockInclusion s * (P.flatWeight s • P.flatBasis s i) := by
+  let dim := fun t : Fin P.totalCopies ↦ Fin (P.flatDim t)
+  let e : ((t : Fin P.totalCopies) × dim t) ≃ Fin P.totalDim :=
+    finSigmaFinEquiv
+  let E := Matrix.sigmaBlockInclusion dim s
+  let B := fun t : Fin P.totalCopies ↦ P.flatWeight t • P.flatBasis t i
+  change Matrix.reindex e e (Matrix.blockDiagonal' B) *
+      Matrix.reindex e (Equiv.refl _) E =
+        Matrix.reindex e (Equiv.refl _) E * B s
+  change Matrix.reindexLinearEquiv ℂ ℂ e e (Matrix.blockDiagonal' B) *
+      Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) E =
+        Matrix.reindexLinearEquiv ℂ ℂ e (Equiv.refl _) E *
+          Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) (Equiv.refl _) (B s)
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ e e (Equiv.refl _),
+    Matrix.reindexLinearEquiv_mul ℂ ℂ e (Equiv.refl _) (Equiv.refl _),
+    Matrix.blockDiagonal'_mul_sigmaBlockInclusion]
+
+/-- The adjoint flattened block inclusion intertwines the ambient tensor with
+the weighted selected block on the left.
+
+Source: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219. -/
+theorem flatBlockInclusion_conjTranspose_mul_toTensor
+    (P : SectorDecomposition d) (s : Fin P.totalCopies) (i : Fin d) :
+    (P.flatBlockInclusion s)ᴴ * P.toTensor i =
+      (P.flatWeight s • P.flatBasis s i) *
+        (P.flatBlockInclusion s)ᴴ := by
+  let dim := fun t : Fin P.totalCopies ↦ Fin (P.flatDim t)
+  let e : ((t : Fin P.totalCopies) × dim t) ≃ Fin P.totalDim :=
+    finSigmaFinEquiv
+  let E := Matrix.sigmaBlockInclusion dim s
+  let B := fun t : Fin P.totalCopies ↦ P.flatWeight t • P.flatBasis t i
+  change (Matrix.reindex e (Equiv.refl _) E)ᴴ *
+      Matrix.reindex e e (Matrix.blockDiagonal' B) =
+        B s * (Matrix.reindex e (Equiv.refl _) E)ᴴ
+  rw [Matrix.conjTranspose_reindex]
+  change Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e Eᴴ *
+      Matrix.reindexLinearEquiv ℂ ℂ e e (Matrix.blockDiagonal' B) =
+        Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) (Equiv.refl _) (B s) *
+          Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) e Eᴴ
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) e e,
+    Matrix.reindexLinearEquiv_mul ℂ ℂ (Equiv.refl _) (Equiv.refl _) e,
+    Matrix.sigmaBlockInclusion_conjTranspose_mul_blockDiagonal']
+
+/-- Compressing the ambient tensor to a flattened sector recovers its exact
+weighted block.
+
+Source: arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195--219.
+Application context: Appendix C.2, Case I, lines 1571--1619. -/
+theorem flatWeight_smul_flatBasis_eq_compression
+    (P : SectorDecomposition d) (s : Fin P.totalCopies) (i : Fin d) :
+    P.flatWeight s • P.flatBasis s i =
+      (P.flatBlockInclusion s)ᴴ * P.toTensor i *
+        P.flatBlockInclusion s := by
+  symm
+  rw [Matrix.mul_assoc, P.toTensor_mul_flatBlockInclusion s i,
+    ← Matrix.mul_assoc, P.flatBlockInclusion_isometry s, Matrix.one_mul]
+
+end MPSTensor.SectorDecomposition

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -218,7 +218,8 @@
 
 \begin{theorem}[Flattened sector as an isometric virtual corner]
     \label{thm:mpdo_flattened_sector_virtual_compression}
-    \lean{MPSTensor.SectorDecomposition.flatBlockInclusion,
+    \lean{Matrix.sigmaBlockInclusion_mul_conjTranspose_eq_blockProjection,
+      MPSTensor.SectorDecomposition.flatBlockInclusion,
       MPSTensor.SectorDecomposition.flatBlockInclusion_isometry,
       MPSTensor.SectorDecomposition.flatBlockInclusion_mul_conjTranspose,
       MPSTensor.SectorDecomposition.toTensor_mul_flatBlockInclusion,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -250,12 +250,13 @@
 \begin{proof}
     \leanok
     Let $E_s$ be the canonical inclusion of the $s$-th summand in the
-    dependent direct sum, and let $e$ flatten the direct-sum coordinates.
-    Thus $V_s$ is the reindexing of $E_s$.  Multiplicativity of reindexing
-    transports
+    dependent direct sum, let $Q_s$ be the corresponding unflattened block
+    projection, and let $e$ flatten the direct-sum coordinates.  Thus $V_s$
+    is the reindexing of $E_s$, while $P_s$ is the reindexing of $Q_s$.
+    Multiplicativity of reindexing transports
     \begin{align}
         E_s^\dagger E_s&=1, \notag\\
-        E_sE_s^\dagger&=P_s
+        E_sE_s^\dagger&=Q_s
         \notag
     \end{align}
     to the two corresponding identities for $V_s$.  If

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -226,23 +226,20 @@
       MPSTensor.SectorDecomposition.flatWeight_smul_flatBasis_eq_compression}
     \leanok
     \uses{def:sector_weight_data}
-    Let
-    \[
-        A=\bigoplus_t \mu_t A_t
-    \]
-    be a weighted block-diagonal tensor in flattened virtual coordinates.
+    Let $A=\bigoplus_t \mu_t A_t$ be a weighted block-diagonal tensor in
+    flattened virtual coordinates.
     For every block $s$, the canonical inclusion $V_s$ of that block satisfies
-    \[
-        V_s^\dagger V_s=1,\qquad
-        V_sV_s^\dagger=P_s,\qquad
-        V_s^\dagger A^iV_s=\mu_s A_s^i.
-    \]
+    \begin{align}
+        V_s^\dagger V_s&=1, \notag\\
+        V_sV_s^\dagger&=P_s, \notag\\
+        V_s^\dagger A^iV_s&=\mu_s A_s^i. \notag
+    \end{align}
     Here $P_s$ is the corresponding block projection, transported to the
     flattened coordinates.  Moreover,
-    \[
-        A^iV_s=V_s(\mu_sA_s^i),\qquad
-        V_s^\dagger A^i=(\mu_sA_s^i)V_s^\dagger.
-    \]
+    \begin{align}
+        A^iV_s&=V_s(\mu_sA_s^i), \notag\\
+        V_s^\dagger A^i&=(\mu_sA_s^i)V_s^\dagger. \notag
+    \end{align}
     This is the exact blockwise virtual-corner identity from
     \cite[Section~2.3, equation \emph{II\_Aiplusk1},
       lines~195--219]{Cirac2016MPDO_arXiv}.  Appendix~C.2, Case~I,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -249,10 +249,30 @@
 
 \begin{proof}
     \leanok
-    Reindex the canonical inclusion of a summand in the dependent direct sum.
-    Its isometry and range identities give the first two equations.
-    The two intertwining identities follow from block diagonality, and their
-    composition with the isometry gives the compression formula.
+    Let $E_s$ be the canonical inclusion of the $s$-th summand in the
+    dependent direct sum, and let $e$ flatten the direct-sum coordinates.
+    Thus $V_s$ is the reindexing of $E_s$.  Multiplicativity of reindexing
+    transports
+    \begin{align}
+        E_s^\dagger E_s&=1, \notag\\
+        E_sE_s^\dagger&=P_s
+        \notag
+    \end{align}
+    to the two corresponding identities for $V_s$.  If
+    $B_t^i=\mu_tA_t^i$, block diagonality gives
+    \begin{align}
+        A^iV_s&=V_sB_s^i, \notag\\
+        V_s^\dagger A^i&=B_s^iV_s^\dagger.
+        \notag
+    \end{align}
+    Therefore
+    \begin{align}
+        V_s^\dagger A^iV_s
+        &=V_s^\dagger V_sB_s^i
+         =B_s^i
+         =\mu_sA_s^i.
+        \notag
+    \end{align}
 \end{proof}
 
 \begin{theorem}[Neighboring operators under virtual compression]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex
@@ -216,6 +216,48 @@
     \cite[Appendix~C.2, lines~1381--1439]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Flattened sector as an isometric virtual corner]
+    \label{thm:mpdo_flattened_sector_virtual_compression}
+    \lean{MPSTensor.SectorDecomposition.flatBlockInclusion,
+      MPSTensor.SectorDecomposition.flatBlockInclusion_isometry,
+      MPSTensor.SectorDecomposition.flatBlockInclusion_mul_conjTranspose,
+      MPSTensor.SectorDecomposition.toTensor_mul_flatBlockInclusion,
+      MPSTensor.SectorDecomposition.flatBlockInclusion_conjTranspose_mul_toTensor,
+      MPSTensor.SectorDecomposition.flatWeight_smul_flatBasis_eq_compression}
+    \leanok
+    \uses{def:sector_weight_data}
+    Let
+    \[
+        A=\bigoplus_t \mu_t A_t
+    \]
+    be a weighted block-diagonal tensor in flattened virtual coordinates.
+    For every block $s$, the canonical inclusion $V_s$ of that block satisfies
+    \[
+        V_s^\dagger V_s=1,\qquad
+        V_sV_s^\dagger=P_s,\qquad
+        V_s^\dagger A^iV_s=\mu_s A_s^i.
+    \]
+    Here $P_s$ is the corresponding block projection, transported to the
+    flattened coordinates.  Moreover,
+    \[
+        A^iV_s=V_s(\mu_sA_s^i),\qquad
+        V_s^\dagger A^i=(\mu_sA_s^i)V_s^\dagger.
+    \]
+    This is the exact blockwise virtual-corner identity from
+    \cite[Section~2.3, equation \emph{II\_Aiplusk1},
+      lines~195--219]{Cirac2016MPDO_arXiv}.  Appendix~C.2, Case~I,
+    lines~1374--1450 and 1571--1619 is the downstream application context;
+    no positivity after insertion of $P_s$ is asserted here.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Reindex the canonical inclusion of a summand in the dependent direct sum.
+    Its isometry and range identities give the first two equations.
+    The two intertwining identities follow from block diagonality, and their
+    composition with the isometry gives the compression formula.
+\end{proof}
+
 \begin{theorem}[Neighboring operators under virtual compression]
     \label{thm:mpdo_physical_sector_factorization_virtual_compression_neighbor}
     \lean{MPOTensor.PhysicalSectorFactorization.ofVirtualCompression_neighboringOperator}

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -512,8 +512,16 @@ itself establish positivity after compression.  The canonical-form projection
 at source lines~195--219 supplies the virtual corner but does not assert this
 projected positivity.  Moreover, the present proportional canonical-form
 comparison does not retain a compression map from the selected fixed tensor
-to its matched trace-visible sector.  Both the map and positivity of the
-projected contraction remain necessary.
+to its matched trace-visible sector.  For a supplied flattened sector
+decomposition,
+\leanid{MPSTensor.SectorDecomposition.flatBlockInclusion} now gives the
+canonical isometry, while
+\leanid{MPSTensor.SectorDecomposition.%
+flatWeight_smul_flatBasis_eq_compression} identifies its exact weighted
+virtual corner.  The accompanying range-projection and intertwining identities
+are also formalized.  This algebraic certificate does not select the
+trace-visible sector of the fixed tensor and does not prove positivity of the
+projected contraction.  Those two source-specific steps remain necessary.
 
 \paragraph{Local fix (the later orthogonal-sector statement).}
 The proposition labelled \emph{prop4to2} at source lines~1801--1808 states
@@ -577,10 +585,11 @@ The gap can be removed in the following stages.
 \item The selected fixed tensor has a positive physical-sector factorization
 constructed non-circularly from the source-side commuting bond, as recorded by
 the fixed-tensor theorem identified above.
-\item Retain an exact virtual compression map when selecting the
-trace-visible canonical sector of the fixed tensor.  Prove that the
-neighboring contraction remains positive after inserting the range
-projection of this map.
+\item The canonical inclusion and exact compression identity for every
+flattened sector are formalized.  Use this certificate when selecting the
+trace-visible canonical sector of the fixed tensor, and prove that the
+neighboring contraction remains positive after inserting its range
+projection.
 \item Use the proportional canonical-form theorem and its virtual gauge to
 transport the positive compressed factorization to the matching normal
 sector, then remove any blocking without adding a hypothesis absent from


### PR DESCRIPTION
## Summary

- add the canonical flattened-sector inclusion by reindexing `Matrix.sigmaBlockInclusion`
- prove its isometry, range projection, left/right intertwining, and exact weighted-block compression identities
- add the generic `sigmaBlockInclusion_mul_conjTranspose_eq_blockProjection` lemma beside `Matrix.blockProjection`
- update the Blueprint and commuting-form-to-SAL paper-gap note with the exact completed boundary

## Source and scope

Direct source: CPSV16 / arXiv:1606.00608, Section 2.3, equation `II_Aiplusk1`, lines 195–219. Appendix C.2, Case I is the downstream application context.

This PR proves only the algebraic virtual-corner certificate. It does not select the trace-visible sector of the fixed tensor and does not prove positivity after inserting the range projection. Those source-specific steps remain open under #5065 and #4459.

Closes #5081.

## Validation

- `lake exe cache get` (8,451 cached artifacts; no Mathlib source rebuild)
- `lake build TNLean.Algebra.ScalarCommutant TNLean.MPS.SharedInfra.SectorCompression`
- `lake build TNLean` (9,807 jobs)
- `lake build lint_style`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf` (784 pages)
- visual inspection of the rendered theorem on PDF page 604
- generated-import tests and `--check`
- oversized-file guard
- proof-integrity and proof-history-name scan

The full build retains only the three pre-existing unrelated warnings in `SectorMatch.lean`, `GroupedGramNormalization.lean`, and `CPSVGroupedGramNormalization.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely additive formalization and documentation with no changes to runtime behavior or security-sensitive paths.
> 
> **Overview**
> Formalizes the **blockwise virtual corner** from CPSV16 Section 2.3 (`II_Aiplusk1`): each flattened sector block is an isometric compression of the ambient weighted block-diagonal tensor.
> 
> **Algebra:** New `Matrix.sigmaBlockInclusion_mul_conjTranspose_eq_blockProjection` links summand inclusion `E_s E_s†` to `blockProjection`. New `TNLean.MPS.SharedInfra.SectorCompression` defines `flatBlockInclusion` (reindexed `sigmaBlockInclusion`) and proves isometry, range projection, left/right intertwining with `toTensor`, and `flatWeight_smul_flatBasis_eq_compression`.
> 
> **Docs:** Blueprint theorem `thm:mpdo_flattened_sector_virtual_compression` and the commuting-form-to-SAL gap note record this as completed algebraic boundary; **trace-visible sector choice** and **positivity after range projection** are explicitly still out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadbcc0dc60220cc9d1886732a8c185081d21b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->