### PR TITLE
fix(tenkz): meter blueprint figure geometry

### DIFF
--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -584,14 +584,17 @@ representation.
         % Here M is the scalar \mu_{j,q}; X, X^{-1}, and M depend on both
         % selectors (j,q), while sqrt(rho) and U depend only on j.  The q-rail
         % selects a repeated representation inside the current j-sector.
+        % Thus the drawn q-join into M supplies q, while its j-dependence is
+        % implicit in that current-sector context rather than a second drawn
+        % join.
         % Ink-to-index map: on the upper coefficient rail, the west boundary
         % is the free virtual input alpha, the east boundary is the free
         % virtual output beta, and the north boundary of U is the free
         % physical index i.  The internal upper joins contract the successive
         % matrix indices in X_{j,q} sqrt(rho_j) U_j^i X_{j,q}^{-1}.  The lower
-        % j- and q-rails route the direct-sum selectors through precisely the
-        % factors that depend on them; they are selectors, not extra free
-        % tensor indices.
+        % j- and q-rails display the direct-sum selectors; the preceding
+        % current-sector convention accounts for the implicit j-dependence at
+        % M.  These rails are selectors, not extra free tensor indices.
         % Contraction and boundary signature: after the direct sums over j and
         % q, both sides have
         % (virtual-west=1 | virtual-east=1 | physical-up=1).

--- a/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_normal_isometry_canonical_forms.tex
@@ -577,6 +577,26 @@ representation.
 \begin{figure}[ht]
     \centering
     \begin{center}
+        % Formula: CPSV16 equation III_CFI_RFP, with the square-root correction
+        % recorded in docs/paper-gaps/cpsv16_rfp_isometry_scope.tex, is
+        % A^i = \bigoplus_{j=1}^g\bigoplus_{q=1}^{r_j}
+        % \mu_{j,q}X_{j,q}\sqrt{\rho_j}\,U_j^iX_{j,q}^{-1}.
+        % Here M is the scalar \mu_{j,q}; X, X^{-1}, and M depend on both
+        % selectors (j,q), while sqrt(rho) and U depend only on j.  The q-rail
+        % selects a repeated representation inside the current j-sector.
+        % Ink-to-index map: on the upper coefficient rail, the west boundary
+        % is the free virtual input alpha, the east boundary is the free
+        % virtual output beta, and the north boundary of U is the free
+        % physical index i.  The internal upper joins contract the successive
+        % matrix indices in X_{j,q} sqrt(rho_j) U_j^i X_{j,q}^{-1}.  The lower
+        % j- and q-rails route the direct-sum selectors through precisely the
+        % factors that depend on them; they are selectors, not extra free
+        % tensor indices.
+        % Contraction and boundary signature: after the direct sums over j and
+        % q, both sides have
+        % (virtual-west=1 | virtual-east=1 | physical-up=1).
+        % Source verdict: CPSV16 Theorem 3.11 and its graphical explanation,
+        % Papers/1606.00608/MPDO-22-12-17-2.tex:543--562.
         \begin{tenkz}[physical=up, tensor style=box]
             \tn{A}
         \end{tenkz}

--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1178,3 +1178,23 @@ Census-correction: #5016
 
 No language-ledger row changes and no remaining flag verdict is re-examined
 here.
+
+### 2026-07-29 — typed-map spacing enters the escape ledger
+
+A complete blueprint scan found three existing raw geometry occurrences in
+`tenkzcd[maps]`: one `column sep=` and two `row sep=` spellings.  They had
+passed to the underlying matrix without a registry row and were therefore
+absent from M3.  Both spellings now enter the escape ledger, making the
+existing geometry debt visible: M1 gains two escape rows, M2 gains their two
+explicit parser leaves, and M3 rises from 29 to 32.  Their values preserve the
+present figures exactly; the four typed-map figures acquire their permanent
+pitch spelling when they leave `tenkzcd` in the chapter 21 migration of #4699.
+
+Extension-gate: #5085
+
+Census-correction: #5085
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:picture:column sep | dies with the `tenkzcd` chapter 21 migration in #4699, where typed-map column pitch receives its kernel spelling; expiry 0.8 |
+| flag:consumers:key:picture:row sep | dies with the `tenkzcd` chapter 21 migration in #4699, where typed-map row pitch receives its kernel spelling; expiry 0.8 |

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -120,6 +120,8 @@ picture & \texttt{sheet \allowbreak{}vector} & dimension-\allowbreak{}pair & fra
 picture & \texttt{maps} & flag & false & Typed-\allowbreak{}map \allowbreak{}layout. \\
 picture & \texttt{polygon} & positive-\allowbreak{}integer & empty & Coherence \allowbreak{}polygon \allowbreak{}layout. \\
 picture & \texttt{radius} & length & metric & Coherence \allowbreak{}polygon \allowbreak{}radius. \\
+picture & \texttt{column \allowbreak{}sep} & length & metric & Typed-\allowbreak{}map \allowbreak{}column \allowbreak{}separation. \\
+picture & \texttt{row \allowbreak{}sep} & length & metric & Typed-\allowbreak{}map \allowbreak{}row \allowbreak{}separation. \\
 object & \texttt{dot} & flag & policy & Dot \allowbreak{}silhouette. \\
 object & \texttt{box} & flag & policy & Box \allowbreak{}silhouette. \\
 object & \texttt{pill} & flag & policy & Pill \allowbreak{}silhouette. \\

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -120,8 +120,8 @@ picture & \texttt{sheet \allowbreak{}vector} & dimension-\allowbreak{}pair & fra
 picture & \texttt{maps} & flag & false & Typed-\allowbreak{}map \allowbreak{}layout. \\
 picture & \texttt{polygon} & positive-\allowbreak{}integer & empty & Coherence \allowbreak{}polygon \allowbreak{}layout. \\
 picture & \texttt{radius} & length & metric & Coherence \allowbreak{}polygon \allowbreak{}radius. \\
-picture & \texttt{column \allowbreak{}sep} & length & metric & Typed-\allowbreak{}map \allowbreak{}column \allowbreak{}separation. \\
-picture & \texttt{row \allowbreak{}sep} & length & metric & Typed-\allowbreak{}map \allowbreak{}row \allowbreak{}separation. \\
+picture & \texttt{column \allowbreak{}sep} & matrix-\allowbreak{}separation & metric & General \allowbreak{}tenkzcd \allowbreak{}column \allowbreak{}separation: \allowbreak{}a \allowbreak{}length \allowbreak{}or \allowbreak{}a \allowbreak{}tikz-\allowbreak{}cd \allowbreak{}preset \allowbreak{}(\allowbreak{}huge,\allowbreak{} \allowbreak{}large,\allowbreak{} \allowbreak{}normal,\allowbreak{} \allowbreak{}scriptsize,\allowbreak{} \allowbreak{}small,\allowbreak{} \allowbreak{}or \allowbreak{}tiny). \\
+picture & \texttt{row \allowbreak{}sep} & matrix-\allowbreak{}separation & metric & General \allowbreak{}tenkzcd \allowbreak{}row \allowbreak{}separation: \allowbreak{}a \allowbreak{}length \allowbreak{}or \allowbreak{}a \allowbreak{}tikz-\allowbreak{}cd \allowbreak{}preset \allowbreak{}(\allowbreak{}huge,\allowbreak{} \allowbreak{}large,\allowbreak{} \allowbreak{}normal,\allowbreak{} \allowbreak{}scriptsize,\allowbreak{} \allowbreak{}small,\allowbreak{} \allowbreak{}or \allowbreak{}tiny). \\
 object & \texttt{dot} & flag & policy & Dot \allowbreak{}silhouette. \\
 object & \texttt{box} & flag & policy & Box \allowbreak{}silhouette. \\
 object & \texttt{pill} & flag & policy & Pill \allowbreak{}silhouette. \\
@@ -207,6 +207,7 @@ kernel-\allowbreak{}atom & \texttt{ports} & typed-\allowbreak{}port-\allowbreak{
 kernel-\allowbreak{}atom & \texttt{up} & math-\allowbreak{}list & empty & Outward \allowbreak{}physical \allowbreak{}labels,\allowbreak{} \allowbreak{}page-\allowbreak{}up. \\
 kernel-\allowbreak{}atom & \texttt{down} & math-\allowbreak{}list & empty & Outward \allowbreak{}physical \allowbreak{}labels,\allowbreak{} \allowbreak{}page-\allowbreak{}down. \\
 kernel-\allowbreak{}atom & \texttt{species} & declared-\allowbreak{}name & empty & Semantic \allowbreak{}species. \\
+kernel-\allowbreak{}atom & \texttt{pairing~cross} & indexed-\allowbreak{}crossing-\allowbreak{}list & empty & Per-\allowbreak{}instance \allowbreak{}crossings \allowbreak{}of \allowbreak{}generated \allowbreak{}skin \allowbreak{}pairings. \\
 kernel-\allowbreak{}atom & \texttt{size} & size-\allowbreak{}class & m & Per-\allowbreak{}atom \allowbreak{}metric \allowbreak{}size \allowbreak{}class. \\
 kernel-\allowbreak{}atom & \texttt{label~pos} & angle & auto & Label \allowbreak{}quadrant. \\
 kernel-\allowbreak{}atom & \texttt{nudge} & pair & zero & Quarter-\allowbreak{}pitch \allowbreak{}displacement. \\
@@ -214,7 +215,7 @@ kernel-\allowbreak{}atom & \texttt{void} & void-\allowbreak{}policy & unset & Ho
 kernel-\allowbreak{}atom & \texttt{conjugate} & flag & false & Conjugate \allowbreak{}glyph \allowbreak{}orientation. \\
 kernel-\allowbreak{}atom & \texttt{cluster} & pair & empty & Expander: \allowbreak{}RxC \allowbreak{}addressable \allowbreak{}sub-\allowbreak{}atom \allowbreak{}group. \\
 kernel-\allowbreak{}atom & \texttt{role} & semantic-\allowbreak{}role & empty & Prelude \allowbreak{}species \allowbreak{}spelling. \\
-kernel-\allowbreak{}wire & \texttt{kind} & enum(\allowbreak{}index\textbar{}\allowbreak{}string) & index & Bond \allowbreak{}or \allowbreak{}travelling \allowbreak{}string. \\
+kernel-\allowbreak{}wire & \texttt{kind} & enum(\allowbreak{}index\textbar{}\allowbreak{}string\textbar{}\allowbreak{}pairing) & index & Bond,\allowbreak{} \allowbreak{}travelling \allowbreak{}string,\allowbreak{} \allowbreak{}or \allowbreak{}generated \allowbreak{}skin \allowbreak{}pairing. \\
 kernel-\allowbreak{}wire & \texttt{route} & enum(\allowbreak{}straight\textbar{}\allowbreak{}orth\textbar{}\allowbreak{}arc) & straight & Path \allowbreak{}family. \\
 kernel-\allowbreak{}wire & \texttt{via} & address-\allowbreak{}list & empty & Waypoints. \\
 kernel-\allowbreak{}wire & \texttt{bend} & number & metric & Arc \allowbreak{}bend \allowbreak{}factor. \\

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -5,19 +5,19 @@
       "alias": 6,
       "commands": 25,
       "environments": 6,
-      "escape": 9,
+      "escape": 11,
       "kernel": 139,
       "sugar": 12
     }
   },
   "m2_parser_paths": {
     "definition": "public leaf keys installed by the TeX parsers; identity changes require an Extension-gate citation",
-    "identity_sha256": "e72620b9e58f7aee2ade06e577bb4b9f48e33871185996399f3c315b90cd12b1",
-    "value": 224
+    "identity_sha256": "5f51aa4163439f26029a78ed16dd321753e3ec3679e2f1e67283e5ce390bf01f",
+    "value": 226
   },
   "m3_escape_usage": {
     "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",
-    "value": 29
+    "value": 32
   },
   "m4_lines_per_case": {
     "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",

--- a/tex/tenkz/tenkz-cd.code.tex
+++ b/tex/tenkz/tenkz-cd.code.tex
@@ -170,6 +170,15 @@
   /tenkz/cd/polygon/.code={\int_set:Nn \l__tenkzcd_ngon_int {#1}},
   /tenkz/cd/maps/.code={\bool_set_true:N \l__tenkzcd_maps_bool},
   /tenkz/cd/radius/.store~in=\l__tenkzcd_radius_tl,
+  % Extension-gate: #5085; Census-correction: #5085.  These two existing raw
+  % geometry spellings remain explicit, metered escapes until #4699 migrates
+  % the typed-map figures and retires tenkzcd.
+  /tenkz/cd/column~sep/.code={
+    \tl_put_right:Nn \l__tenkzcd_pass_tl { column~sep={#1}, }
+  },
+  /tenkz/cd/row~sep/.code={
+    \tl_put_right:Nn \l__tenkzcd_pass_tl { row~sep={#1}, }
+  },
   % unrecognized keys pass through to the underlying picture
   /tenkz/cd/.unknown/.code={
     \tl_if_eq:NNTF \pgfkeyscurrentvalue \pgfkeysnovalue@text

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -135,8 +135,8 @@
 % Extension-gate: #5085; Census-correction: #5085 -- these existing tenkzcd
 % geometry spellings become explicit parser leaves and visible to M3 until
 % the typed-map figures migrate under #4699.
-\__tenkz_language_registry_key:nnnnnn {picture}{column sep}{length}{metric}{escape}{Typed-map column separation.}
-\__tenkz_language_registry_key:nnnnnn {picture}{row sep}{length}{metric}{escape}{Typed-map row separation.}
+\__tenkz_language_registry_key:nnnnnn {picture}{column sep}{matrix-separation}{metric}{escape}{General tenkzcd column separation: a length or a tikz-cd preset (huge, large, normal, scriptsize, small, or tiny).}
+\__tenkz_language_registry_key:nnnnnn {picture}{row sep}{matrix-separation}{metric}{escape}{General tenkzcd row separation: a length or a tikz-cd preset (huge, large, normal, scriptsize, small, or tiny).}
 \__tenkz_language_registry_key:nnnnnn {object}{dot}{flag}{policy}{kernel}{Dot silhouette.}
 \__tenkz_language_registry_key:nnnnnn {object}{box}{flag}{policy}{kernel}{Box silhouette.}
 \__tenkz_language_registry_key:nnnnnn {object}{pill}{flag}{policy}{kernel}{Pill silhouette.}

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -132,6 +132,11 @@
 \__tenkz_language_registry_key:nnnnnn {picture}{maps}{flag}{false}{kernel}{Typed-map layout.}
 \__tenkz_language_registry_key:nnnnnn {picture}{polygon}{positive-integer}{empty}{kernel}{Coherence polygon layout.}
 \__tenkz_language_registry_key:nnnnnn {picture}{radius}{length}{metric}{escape}{Coherence polygon radius.}
+% Extension-gate: #5085; Census-correction: #5085 -- these existing tenkzcd
+% geometry spellings become explicit parser leaves and visible to M3 until
+% the typed-map figures migrate under #4699.
+\__tenkz_language_registry_key:nnnnnn {picture}{column sep}{length}{metric}{escape}{Typed-map column separation.}
+\__tenkz_language_registry_key:nnnnnn {picture}{row sep}{length}{metric}{escape}{Typed-map row separation.}
 \__tenkz_language_registry_key:nnnnnn {object}{dot}{flag}{policy}{kernel}{Dot silhouette.}
 \__tenkz_language_registry_key:nnnnnn {object}{box}{flag}{policy}{kernel}{Box silhouette.}
 \__tenkz_language_registry_key:nnnnnn {object}{pill}{flag}{policy}{kernel}{Pill silhouette.}


### PR DESCRIPTION
### Motivation

- Close LionSR/tenkz#112 by making the last bare tensor-network decomposition auditable against CPSV16 and by bringing the two existing typed-map spacing controls into the tenkz language ledger.
- The mathematical source is CPSV16 Theorem 3.11, equation `III_CFI_RFP`, and its graphical explanation in `Papers/1606.00608/MPDO-22-12-17-2.tex:543--562`: the tensor is the direct sum of the terms
  `mu_{j,q} X_{j,q} Lambda_j U_j^i X_{j,q}^{-1}`, with `j` selecting the basis normal tensor and `q` selecting a repeated representation.
- The square-root replacement `Lambda_j -> sqrt(rho_j)` is the existing local correction recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`, using the source reference tensor at line 1300.

### Description

- Add the standard formula, ink-to-index, contraction, boundary-signature, and source-verdict comment block to the chapter 26 decomposition. The comments identify `M` with `mu_{j,q}`, distinguish the direct-sum selectors `j,q` from free tensor indices, and record the common boundary signature `(virtual-west=1 | virtual-east=1 | physical-up=1)`.
- Register `column sep=` and `row sep=` as explicit picture-scope escape rows and explicit `tenkzcd` parser leaves. This preserves the present figures exactly while making all three existing occurrences visible to meter M3.
- Record the extension and census correction in the append-only shrink ledger: M1 gains two escape rows, M2 gains two parser leaves, and M3 changes from 29 to 32. Both spellings are assigned to die with the chapter 21 `tenkzcd` migration in LionSR/TNLean#4699, where typed-map row and column pitch receive their permanent kernel spelling; no paper notation is introduced.
- Regenerate the corresponding language-reference rows and update the census baseline.

### Testing

- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `python3 scripts/test_tenkz_index_routing.py`
- `leanblueprint web`
- `leanblueprint pdf` (784-page PDF produced)
- `git diff --check origin/main...HEAD`

---
Addresses LionSR/tenkz#112

### Agent assistance

- OpenAI Codex (GPT-5) read the cited CPSV16 passages and the tenkz language contracts, prepared the scoped source and registry changes, and ran the listed validators. The repository owner retains review responsibility for every line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and registry/census bookkeeping with behavior-preserving `tenkzcd` key handlers; no auth, data, or runtime logic changes.
> 
> **Overview**
> Closes **#5085** by making the chapter 26 multi-block RFP decomposition figure auditable against CPSV16 and by bringing existing typed-map spacing into the tenkz shrink ledger.
> 
> **Blueprint (ch26):** Adds a comment block above the block/multiplicity tensor figure documenting the corrected formula \(A^i = \bigoplus_{j,q} \mu_{j,q} X_{j,q}\sqrt{\rho_j}\,U_j^i X_{j,q}^{-1}\), how ink maps to free vs selector indices (\(j\), \(q\), \(M=\mu_{j,q}\)), and the boundary signature `(virtual-west=1 | virtual-east=1 | physical-up=1)` with source pointers to Theorem 3.11 / `III_CFI_RFP`. Figure markup is unchanged.
> 
> **Tenkz language:** Registers `column sep=` and `row sep=` as explicit **escape** picture keys and **`tenkzcd`** parser leaves (extension/census **#5085**), forwarding values to tikz-cd as before so current figures stay pixel-identical while three raw `tenkzcd[maps]` usages become visible to **M3**. Updates `SHRINK.md` verdicts (both keys die with chapter 21 `tenkzcd` migration **#4699**), regenerates the language reference, and bumps the census baseline: escape rows 9→11, parser paths 224→226, M3 29→32.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d251e98f0016224c604121cdd04fc41deb44c7ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->