### PR TITLE
feat(MPS/MPDO): lift positive bonds from physical restrictions

### DIFF
--- a/TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean
+++ b/TNLean/MPS/MPDO/BNTSectorCommutingFamily.lean
@@ -24,7 +24,84 @@ periodic chain of length at least two.
 
 namespace MPOTensor
 
+open scoped ComplexOrder
+
 variable {d D : ℕ}
+
+/-- Pairwise orthogonal physical restrictions carrying positive physical-sector
+factorizations determine an orthogonal family of positive commuting bonds. Each
+sector MPO is the exact periodic product of its bond.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl`, `Appetakhetc`,
+`PjKiPj`, and `generateMPDO`, lines 1383--1450 and 1680--1770. -/
+theorem nonempty_orthogonalCommutingSectorFamily_of_restrictedPhysicalSectorFactorization
+    {g : ℕ} {dim : Fin g → ℕ}
+    (K : (s : Fin g) → MPOTensor d (dim s))
+    (P : Fin g → Matrix (Fin d) (Fin d) ℂ)
+    (hP : ∀ s, IsOrthogonalProjection (P s))
+    (hPorth : ∀ {s t}, s ≠ t → P s * P t = 0)
+    (restriction : (s : Fin g) → PhysicalSupportRestrictionData (P s) (K s))
+    (G : (s : Fin g) → PhysicalSectorFactorization
+      (PhysicalSectorFactorization.changePhysicalBasis
+        (Matrix.conjTranspose ((restriction s).inclusion)) (K s)))
+    (hη : ∀ s k h, ((G s).neighboringOperator k h).PosSemidef) :
+    Nonempty (OrthogonalCommutingSectorFamily K) := by
+  classical
+  let data : (s : Fin g) → EtaLocalStructureData (K s) :=
+    fun s ↦ Classical.choose
+      ((restriction s).exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization
+        (G s) (hη s))
+  have hdata : ∀ s : Fin g,
+      twoSiteSectorProjection (P s) * (data s).bondData.bond *
+          twoSiteSectorProjection (P s) = (data s).bondData.bond ∧
+        ∀ N (hN : 2 ≤ N),
+          mpo (K s) N = ((data s).bondData.toCommutingFormData hN).product :=
+    fun s ↦ Classical.choose_spec
+      ((restriction s).exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization
+        (G s) (hη s))
+  exact ⟨{
+    projection := P
+    projection_isOrthogonal := hP
+    projection_orthogonal := fun hst ↦ hPorth hst
+    bondData := fun s ↦ (data s).bondData
+    bond_supported := fun s ↦ (hdata s).1
+    realizes_mpo := fun s N hN ↦ (hdata s).2 N hN }⟩
+
+/-- Pairwise orthogonal projections that absorb each injective sector tensor on
+both sides give an orthogonal commuting sector family once the restricted
+tensors have positive physical-sector factorizations.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl`, `Appetakhetc`,
+`PjKiPj`, and `generateMPDO`, lines 1383--1450 and 1680--1770.
+
+**Scope restriction (factorization after restriction):** The positive
+physical-sector factorization is assumed on the range of each projection. The
+remaining source-facing theorem must derive it from the ambient factorization
+in `AppUkU=rl`; see
+`docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex`. -/
+theorem nonempty_orthogonalCommutingSectorFamily_of_twoSidedPhysicalSlice
+    {g : ℕ} {dim : Fin g → ℕ}
+    (K : (s : Fin g) → MPOTensor d (dim s))
+    (P : Fin g → Matrix (Fin d) (Fin d) ℂ)
+    (hP : ∀ s, IsOrthogonalProjection (P s))
+    (hPorth : ∀ {s t}, s ≠ t → P s * P t = 0)
+    (hInjective : ∀ s, (K s).IsInjective)
+    (hSupport : ∀ s β α,
+      P s * physicalSlice (K s) β α = physicalSlice (K s) β α ∧
+        physicalSlice (K s) β α * P s = physicalSlice (K s) β α)
+    (G : (s : Fin g) → PhysicalSectorFactorization
+      (PhysicalSectorFactorization.changePhysicalBasis
+        (Matrix.conjTranspose
+          ((physicalSupportRestrictionDataOfTwoSidedPhysicalSlice
+            (P s) (K s) (hP s) (hInjective s) (hSupport s)).inclusion))
+        (K s)))
+    (hη : ∀ s k h, ((G s).neighboringOperator k h).PosSemidef) :
+    Nonempty (OrthogonalCommutingSectorFamily K) := by
+  let restriction : (s : Fin g) → PhysicalSupportRestrictionData (P s) (K s) :=
+    fun s ↦ physicalSupportRestrictionDataOfTwoSidedPhysicalSlice
+      (P s) (K s) (hP s) (hInjective s) (hSupport s)
+  exact nonempty_orthogonalCommutingSectorFamily_of_restrictedPhysicalSectorFactorization
+    K P hP hPorth restriction G hη
 
 /-- Saturation of the area law for every absorbed BNT representative gives a
 family of positive commuting bond products supported on the corresponding

--- a/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportProductTransport.lean
@@ -679,23 +679,24 @@ bond as its local bond. -/
     (F.liftedEtaLocalStructureData data).bondData.bond =
       F.liftedBond data.bondData.bond := rfl
 
-/-- Proposition C.8 on the injective physical support gives an eta-local
-commuting-product realization of the ambient tensor whose bond remains in the
-prescribed two-site sector.
+/-- A positive physical-sector factorization on the restricted physical space
+gives a positive commuting bond for the ambient tensor supported on the tensor
+square of the prescribed one-site projection. Its periodic product is exactly
+the ambient MPO at every length at least two.
 
-Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`) and
-equations `PjKiPj` and `generateMPDO`, lines 1571--1593 and 1733--1770. -/
-theorem exists_etaLocalStructureData_lifted_supported
-    (F : PhysicalSupportRestrictionData P K) (hSAL : IsSAL K) :
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl`, `Appetakhetc`,
+`PjKiPj`, and `generateMPDO`, lines 1383--1450 and 1680--1770. -/
+theorem exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization
+    (F : PhysicalSupportRestrictionData P K)
+    (G : PhysicalSectorFactorization
+      (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K))
+    (hη : ∀ k h, (G.neighboringOperator k h).PosSemidef) :
     ∃ data : EtaLocalStructureData K,
       twoSiteSectorProjection P * data.bondData.bond *
           twoSiteSectorProjection P = data.bondData.bond ∧
       ∀ N (hN : 2 ≤ N),
         mpo K N = (data.bondData.toCommutingFormData hN).product := by
-  obtain ⟨G, hG⟩ := exists_positive_physicalSectorFactorization_of_isSAL
-    (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K)
-    F.restricted_injective (F.restricted_isSAL hSAL)
-  let restrictedData := G.etaLocalStructureData hG
+  let restrictedData := G.etaLocalStructureData hη
   let data := F.liftedEtaLocalStructureData restrictedData
   refine ⟨data, F.liftedBond_supported restrictedData.bondData.bond, ?_⟩
   intro N hN
@@ -722,6 +723,25 @@ theorem exists_etaLocalStructureData_lifted_supported
     exact G.mpo_eq_product_physicalBond hN]
   exact F.singleKrausMap_bondProduct_eq_liftedBondProduct
     restrictedData.bondData hN
+
+/-- Proposition C.8 on the injective physical support gives an eta-local
+commuting-product realization of the ambient tensor whose bond remains in the
+prescribed two-site sector.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`) and
+equations `PjKiPj` and `generateMPDO`, lines 1571--1593 and 1733--1770. -/
+theorem exists_etaLocalStructureData_lifted_supported
+    (F : PhysicalSupportRestrictionData P K) (hSAL : IsSAL K) :
+    ∃ data : EtaLocalStructureData K,
+      twoSiteSectorProjection P * data.bondData.bond *
+          twoSiteSectorProjection P = data.bondData.bond ∧
+      ∀ N (hN : 2 ≤ N),
+        mpo K N = (data.bondData.toCommutingFormData hN).product := by
+  obtain ⟨G, hG⟩ := exists_positive_physicalSectorFactorization_of_isSAL
+    (PhysicalSectorFactorization.changePhysicalBasis F.inclusionᴴ K)
+    F.restricted_injective (F.restricted_isSAL hSAL)
+  exact F.exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization
+    G hG
 
 end PhysicalSupportRestrictionData
 

--- a/TNLean/MPS/MPDO/PhysicalSupportRestriction.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportRestriction.lean
@@ -98,6 +98,50 @@ theorem exists_physicalSupportRestrictionData
         (changePhysicalBasis Vᴴ K) K hreembed.symm hInjective
     reembed := hreembed }⟩
 
+/-- Two-sided absorption of every physical slice by an orthogonal projection
+implies invariance under compression by that projection.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `PjKiPj`, lines 1680--1691. -/
+theorem changePhysicalBasis_eq_self_of_twoSided_physicalSlice
+    (P : Matrix (Fin d) (Fin d) ℂ) (K : MPOTensor d D)
+    (hP : IsOrthogonalProjection P)
+    (hSupport : ∀ β α, P * physicalSlice K β α = physicalSlice K β α ∧
+      physicalSlice K β α * P = physicalSlice K β α) :
+    changePhysicalBasis P K = K := by
+  ext i j β α
+  change (P * physicalSlice K β α * Pᴴ) i j = physicalSlice K β α i j
+  rw [hP.1.eq, (hSupport β α).1, (hSupport β α).2]
+
+/-- An injective tensor whose physical slices are absorbed on both sides by an
+orthogonal projection has an injective realization on the range of that projection.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and `generateMPDO`,
+lines 1680--1691 and 1733--1770. -/
+theorem nonempty_physicalSupportRestrictionData_of_twoSided_physicalSlice
+    (P : Matrix (Fin d) (Fin d) ℂ) (K : MPOTensor d D)
+    (hP : IsOrthogonalProjection P) (hInjective : K.IsInjective)
+    (hSupport : ∀ β α, P * physicalSlice K β α = physicalSlice K β α ∧
+      physicalSlice K β α * P = physicalSlice K β α) :
+    Nonempty (PhysicalSupportRestrictionData P K) :=
+  exists_physicalSupportRestrictionData P K hP
+    (changePhysicalBasis_eq_self_of_twoSided_physicalSlice P K hP hSupport)
+    hInjective
+
+/-- The restriction of an injective tensor to an orthogonal projection that
+absorbs every physical slice on both sides.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `PjKiPj` and `generateMPDO`,
+lines 1680--1691 and 1733--1770. -/
+noncomputable def physicalSupportRestrictionDataOfTwoSidedPhysicalSlice
+    (P : Matrix (Fin d) (Fin d) ℂ) (K : MPOTensor d D)
+    (hP : IsOrthogonalProjection P) (hInjective : K.IsInjective)
+    (hSupport : ∀ β α, P * physicalSlice K β α = physicalSlice K β α ∧
+      physicalSlice K β α * P = physicalSlice K β α) :
+    PhysicalSupportRestrictionData P K :=
+  Classical.choice
+    (nonempty_physicalSupportRestrictionData_of_twoSided_physicalSlice
+      P K hP hInjective hSupport)
+
 /-- The common-weight-absorbed BNT representative is injective after the
 source's common blocking.
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_gsnnch_definitions.tex
@@ -329,6 +329,53 @@ Definition~\ref{def:mpdo_source_gsnnch}; the converse comparison is not used.
     Definition~\ref{def:mpdo_source_gsnnch}.
 \end{definition}
 
+\begin{theorem}[Positive factorizations on orthogonal physical restrictions]
+    \label{thm:mpdo_restricted_positive_factorizations_commuting_family}
+    \lean{MPOTensor.nonempty_physicalSupportRestrictionData_of_twoSided_physicalSlice,
+        MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization,
+        MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_twoSidedPhysicalSlice}
+    \leanok
+    \uses{def:mpdo_physical_support_restriction,
+        def:mpdo_physical_sector_factorization,
+        def:mpdo_orthogonal_commuting_sector_family}
+    Let $\{\mathcal K_x\}_{x=0}^{g-1}$ be injective MPO tensors and let
+    $\{P_x\}_{x=0}^{g-1}$ be pairwise orthogonal projections. Suppose that
+    every physical slice is absorbed on both sides:
+    \begin{align}
+        P_x\mathcal K_x[\beta,\alpha]
+        &=\mathcal K_x[\beta,\alpha]
+        =\mathcal K_x[\beta,\alpha]P_x.
+        \notag
+    \end{align}
+    Write $\mathcal K_x=V_x\mathcal K_{x,P_x}V_x^*$ for the restriction to
+    the range of $P_x$. If every $\mathcal K_{x,P_x}$ admits a physical-sector
+    factorization whose neighboring operators are positive semidefinite, then
+    there are positive bonds $B^{(x)}$ such that
+    \begin{align}
+        (P_x\otimes P_x)B^{(x)}(P_x\otimes P_x)
+        &=B^{(x)}
+        \notag
+    \end{align}
+    and all translates of each $B^{(x)}$ commute pairwise. For every
+    $N\geq2$,
+    \begin{align}
+        \rho^{(N)}(\mathcal K_x)
+        &=\prod_{i=0}^{N-1}\tau_i(B^{(x)}).
+        \notag
+    \end{align}
+    Thus these bonds form an orthogonally supported family of commuting
+    sector products.
+\end{theorem}
+
+\begin{proof}\leanok
+    The two-sided equations identify each tensor with its compression to
+    $\operatorname{ran}(P_x)$ and give an injective restricted tensor.
+    The positive neighboring operators determine the positive commuting bond
+    on this restricted space. Conjugating by $V_x^{\otimes2}$ preserves
+    positivity and commutativity, gives the displayed support equation, and
+    transports every nonempty periodic product exactly.
+\end{proof}
+
 \begin{theorem}[SAL supplies orthogonally supported BNT sector products]
     \label{thm:mpdo_bnt_sector_sal_commuting_family}
     \lean{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_bntSectorSAL}

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -148,6 +148,33 @@ and
 {\scriptsize\leanid{MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport_commonWeightAbsorbedBasis}}.}
 
 This formalizes the pairwise support consequence of the earlier Case~II data.
+The two-sided slice equations now also give the injective restriction of each
+representative to the range of its projection.  If this restricted tensor is
+equipped with a physical-sector factorization whose neighboring operators are
+positive semidefinite, its positive commuting bond lifts to a bond $B_x$ on
+the original one-site space satisfying
+\[
+  (P_x\otimes P_x)B_x(P_x\otimes P_x)=B_x.
+\]
+All periodic translates of $B_x$ commute, and their product equals
+$\rho^{(N)}(\mathcal K_x)$ exactly for every $N\geq2$.  Applying this
+construction to pairwise orthogonal projections gives the orthogonal commuting
+sector family required for the outer GSNNCH sum.
+\footnote{\raggedright Formal declarations:
+{\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_of_twoSided_physicalSlice}},
+{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization}},
+and
+{\scriptsize\leanid{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_twoSidedPhysicalSlice}}.}
+
+The remaining local obligation is therefore precise.  The displayed ambient
+factorization \texttt{AppUkU=rl} must be transported to the range of $P_x$,
+with positivity of the neighboring operators retained.  One cannot simply use
+the uncompressed ambient bond: a nonminimal physical-sector factorization may
+retain identity factors in directions on which every physical slice vanishes,
+so its raw bond need not be supported on $P_x\otimes P_x$.  The required
+construction must remove these inactive factor directions, or prove an
+equivalent positive factorization directly on the restricted space.
+
 The final printed proof of Proposition~\texttt{prop3to4} uses projector
 relations obtained earlier rather than deriving them in its last step.  The
 support corollary does not prove the completeness identity $\sum_xP_x=\Id$,
@@ -194,13 +221,17 @@ A square-zero family shows that this conclusion would be false for arbitrary
 MPO tensors without those hypotheses.
 
 The construction from an already supplied orthogonal commuting sector family
-to the GSNNCH form is available, together with the natural BNT multiplicities
-and the support-preserving positive bond construction.  The remaining
-source-faithful obligation is to derive that bond family from the exact five
-identities \texttt{AppKxKy=0}, \texttt{AppUkU=rl},
-\texttt{Appetakhetc}, \texttt{Apptralktrrk}, and
-\texttt{AppPsiPhi}, with common copy weights retained from the preceding
-Case~II argument.  Proposition~\texttt{prop3to4} should therefore not yet be
-classified as complete.
+to the GSNNCH form is available, together with the natural BNT multiplicities.
+Two-sided physical-slice absorption now supplies the physical restrictions,
+and a positive physical-sector factorization on each restricted space supplies
+supported positive commuting bonds with exact periodic products.  The
+remaining source-faithful local obligation is to derive these restricted
+factorizations from the ambient identities \texttt{AppUkU=rl} and
+\texttt{Appetakhetc}, removing inactive factor directions without adding a
+minimality hypothesis.  This must then be combined with
+\texttt{AppKxKy=0}, \texttt{Apptralktrrk}, and \texttt{AppPsiPhi}, with
+common copy weights retained from the preceding Case~II argument.
+Proposition~\texttt{prop3to4} should therefore not yet be classified as
+complete.
 
 \end{document}


### PR DESCRIPTION
### Motivation

- CPSV16 Appendix C.2 requires positive commuting sector bonds supported on the one-site projections obtained from the ordered layer orthogonality relation.
- The raw ambient physical-sector bond need not have this support: inactive outer-factor directions may remain even when every tensor slice is supported on the projection.
- This PR isolates the valid conditional step recorded in child issue #5093, while parent #5091 remains open for transport of the ambient factorization to the restricted physical space.

Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, equations `AppUkU=rl`, `Appetakhetc`, `PjKiPj`, and `generateMPDO`, lines 1383--1450 and 1680--1770.

### Description

- prove that two-sided absorption of all physical slices gives an injective restriction to the range of an orthogonal projection
- lift a positive physical-sector factorization on that restriction to an ambient positive bond supported on the tensor square of the projection
- prove exact periodic product realization and assemble pairwise orthogonal restrictions into `OrthogonalCommutingSectorFamily`
- update the Blueprint and the CPSV16 sector-decomposition gap note, explicitly retaining the ambient `AppUkU=rl`/`Appetakhetc` transport as the remaining source-facing obligation

Closes #5093.
Addresses #5091.

### Testing

- `lake build TNLean.MPS.MPDO.BNTSectorCommutingFamily`
- `lake build TNLean` (9,807 jobs)
- `leanblueprint checkdecls`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity search over the three changed Lean modules
- `git diff --check origin/main...HEAD`
- independent exact-head mathematical and source-faithfulness review

The full build retains only the three pre-existing unrelated warnings in `SectorMatch.lean`, `GroupedGramNormalization.lean`, and `CPSVGroupedGramNormalization.lean`.

---

### Agent assistance

- Codex (GPT-5) assisted with the scoped Lean implementation, source comparison, proof repair, documentation, and verification. The final exact head was independently reviewed for mathematical truth, source faithfulness, proof integrity, Blueprint dependencies, and axioms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only changes in MPDO Lean modules and documentation; no runtime, auth, or data-path impact.
> 
> **Overview**
> This PR formalizes the **conditional** CPSV16 step: once each sector tensor is supported on a pairwise orthogonal projector and the **restricted** tensor has a positive physical-sector factorization, you get an `OrthogonalCommutingSectorFamily` with bonds on \(P_x \otimes P_x\) and exact MPO products.
> 
> **Lean:** Two-sided physical-slice absorption yields injective `PhysicalSupportRestrictionData` (`changePhysicalBasis_eq_self_of_twoSided_physicalSlice`, `physicalSupportRestrictionDataOfTwoSidedPhysicalSlice`). The SAL-based lift is split so **`exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization`** takes an explicit factorization and PSD neighboring operators; the old SAL theorem delegates to it. Sector assembly is in **`nonempty_orthogonalCommutingSectorFamily_of_restrictedPhysicalSectorFactorization`** and **`..._of_twoSidedPhysicalSlice`**.
> 
> **Docs:** Blueprint adds Theorem “Positive factorizations on orthogonal physical restrictions”; the CPSV16 gap note records that deriving restricted factorizations from ambient **`AppUkU=rl`** / **`Appetakhetc`** (dropping inactive factor directions) remains open (#5091).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c677df4850d81dfb87b378d1a646b1c648360f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->