### PR TITLE
feat(MPS/MPDO): transport two-site bond support

### DIFF
--- a/TNLean/MPS/MPDO/PhysicalSupportBondTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportBondTransport.lean
@@ -67,6 +67,68 @@ theorem sitewisePhysicalMatrix_two_mul_conjTranspose
   rw [sitewisePhysicalMatrix_mul_conjTranspose,
     sitewisePhysicalMatrix_two_eq_twoSiteSectorProjection]
 
+/-- A product identity between one-site matrices is preserved on the
+corresponding two-site spaces.
+
+This is an elementary support consequence used between equation `PjKiPj` and
+the construction `generateMPDO` in arXiv:1606.00608, Appendix C.2, lines
+1688--1750. -/
+theorem twoSiteSectorProjection_mul_eq_of_mul_eq
+    (P Q R : Matrix (Fin d) (Fin d) ℂ) (hPQR : P * Q = R) :
+    twoSiteSectorProjection P * twoSiteSectorProjection Q =
+      twoSiteSectorProjection R := by
+  change
+    (Matrix.reindexAlgEquiv ℂ ℂ (finTwoArrowEquiv (Fin d)).symm)
+          (Matrix.kroneckerMap (· * ·) P P) *
+        (Matrix.reindexAlgEquiv ℂ ℂ (finTwoArrowEquiv (Fin d)).symm)
+          (Matrix.kroneckerMap (· * ·) Q Q) =
+      (Matrix.reindexAlgEquiv ℂ ℂ (finTwoArrowEquiv (Fin d)).symm)
+        (Matrix.kroneckerMap (· * ·) R R)
+  rw [← map_mul, ← Matrix.mul_kronecker_mul, hPQR]
+
+/-- If two one-site matrices absorb in both orders, then their two-site
+matrices satisfy the same two absorption identities.
+
+This is an elementary support consequence used between equation `PjKiPj` and
+the construction `generateMPDO` in arXiv:1606.00608, Appendix C.2, lines
+1688--1750. -/
+theorem twoSiteSectorProjection_absorbs_of_absorbs
+    (P Q : Matrix (Fin d) (Fin d) ℂ)
+    (hPQ : P * Q = Q) (hQP : Q * P = Q) :
+    twoSiteSectorProjection P * twoSiteSectorProjection Q =
+        twoSiteSectorProjection Q ∧
+      twoSiteSectorProjection Q * twoSiteSectorProjection P =
+        twoSiteSectorProjection Q := by
+  constructor
+  · exact twoSiteSectorProjection_mul_eq_of_mul_eq P Q Q hPQ
+  · exact twoSiteSectorProjection_mul_eq_of_mul_eq Q P Q hQP
+
+/-- A two-site matrix supported on an absorbed one-site subspace is also
+supported on the larger one-site subspace.
+
+This is an elementary support consequence used between equation `PjKiPj` and
+the construction `generateMPDO` in arXiv:1606.00608, Appendix C.2, lines
+1688--1750. -/
+theorem twoSiteSectorProjection_supported_of_supported_of_absorbs
+    (P Q : Matrix (Fin d) (Fin d) ℂ)
+    (hPQ : P * Q = Q) (hQP : Q * P = Q)
+    (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ)
+    (hB : twoSiteSectorProjection Q * B * twoSiteSectorProjection Q = B) :
+    twoSiteSectorProjection P * B * twoSiteSectorProjection P = B := by
+  obtain ⟨hPQ₂, hQP₂⟩ :=
+    twoSiteSectorProjection_absorbs_of_absorbs P Q hPQ hQP
+  calc
+    twoSiteSectorProjection P * B * twoSiteSectorProjection P =
+        twoSiteSectorProjection P *
+          (twoSiteSectorProjection Q * B * twoSiteSectorProjection Q) *
+            twoSiteSectorProjection P := by rw [hB]
+    _ = (twoSiteSectorProjection P * twoSiteSectorProjection Q) * B *
+          (twoSiteSectorProjection Q * twoSiteSectorProjection P) := by
+        simp only [Matrix.mul_assoc]
+    _ = twoSiteSectorProjection Q * B * twoSiteSectorProjection Q := by
+        rw [hPQ₂, hQP₂]
+    _ = B := hB
+
 namespace PhysicalSupportRestrictionData
 
 variable {P : Matrix (Fin d) (Fin d) ℂ} {K : MPOTensor d D}


### PR DESCRIPTION
## Summary

- prove that multiplication identities of one-site matrices pass to their two-site sector matrices
- derive two-sided absorption under `P * Q = Q` and `Q * P = Q`
- transport a bond supported on the active sector `Q` to the containing sector `P`

This is the elementary support-monotonicity step used between `PjKiPj` and `generateMPDO` in CPSV16 Appendix C.2.

Closes #5095
Addresses #5091

## Verification

- focused Lean source check
- proof-integrity search
- `git diff --check`
- line-length check
- `python3 scripts/tactic_pattern_scan.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive formal proofs in one MPS/MPDO file; no API, auth, or runtime behavior changes.
> 
> **Overview**
> Adds three **support transport** lemmas for `twoSiteSectorProjection` in `PhysicalSupportBondTransport.lean`, aimed at the CPSV16 Appendix C.2 step between `PjKiPj` and `generateMPDO`.
> 
> **`twoSiteSectorProjection_mul_eq_of_mul_eq`** lifts a one-site product `P * Q = R` to the matching two-site product via Kronecker/reindex algebra. **`twoSiteSectorProjection_absorbs_of_absorbs`** derives the two-sided absorption identities on two sites when `P * Q = Q` and `Q * P = Q`. **`twoSiteSectorProjection_supported_of_supported_of_absorbs`** shows that if a bond `B` is sector-supported for the smaller projector `Q`, the same support holds for the larger absorbed sector `P`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c1e9fc852b9ca31197d0c1844aa9c35fc185727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->