### PR TITLE
feat(algebra): add finite-family support compression

### DIFF
--- a/TNLean/Algebra.lean
+++ b/TNLean/Algebra.lean
@@ -31,6 +31,7 @@ import TNLean.Algebra.KroneckerFactorPositivity
 import TNLean.Algebra.ListProduct
 import TNLean.Algebra.MatrixAlgEquiv
 import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.MatrixFamilySupport
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.MatrixOperatorSpace
 import TNLean.Algebra.MatrixRankBaseChange

--- a/TNLean/Algebra/MatrixFamilySupport.lean
+++ b/TNLean/Algebra/MatrixFamilySupport.lean
@@ -1,0 +1,163 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.PosSemidefSupport
+
+/-!
+# Joint column supports of finite matrix families
+
+A finite family of rectangular complex matrices has a canonical joint column
+support: the orthogonal projection onto the span of all columns in the family.
+It is realized as the support projection of the Gram matrix obtained by
+stacking those columns.
+
+The projection absorbs every member of the family on the left. If the linear
+span of the family is closed under conjugate transpose, it also absorbs every
+member on the right. A nonzero family on a finite coordinate space has a
+positive-dimensional isometric parametrization of its joint column support.
+
+## Main definitions
+
+* `Matrix.familyColumns`: all columns of a finite matrix family in one matrix.
+* `Matrix.familyColumnGram`: the positive-semidefinite joint column Gram matrix.
+* `Matrix.familySupportProj`: the orthogonal projection onto the joint column span.
+
+## Main results
+
+* `Matrix.familySupportProj_mul`: left absorption of every family member.
+* `Matrix.mul_familySupportProj_of_conjTranspose_mem_span`: right absorption
+  under closure of the family span under conjugate transpose.
+* `Matrix.familySupportProj_mul_eq_self_of_forall_mul_eq`: minimality of the
+  joint column support.
+* `Matrix.exists_familySupport_isometry_of_exists_ne_zero`: a
+  positive-dimensional isometric parametrization for a nonzero `Fin`-indexed
+  family.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace Matrix
+
+variable {ι m n : Type*} [Fintype ι] [DecidableEq ι]
+  [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+
+/-- Stack all columns of a finite rectangular matrix family into one matrix. -/
+noncomputable def familyColumns (A : ι → Matrix m n ℂ) :
+    Matrix m (ι × n) ℂ :=
+  fun i q ↦ A q.1 i q.2
+
+/-- The positive-semidefinite Gram matrix of all columns in a finite matrix family. -/
+noncomputable def familyColumnGram (A : ι → Matrix m n ℂ) : Matrix m m ℂ :=
+  familyColumns A * (familyColumns A)ᴴ
+
+omit [DecidableEq ι] [Fintype m] [DecidableEq m] [DecidableEq n] in
+/-- The family column Gram matrix is the sum of the individual column Gram matrices. -/
+theorem familyColumnGram_eq_sum (A : ι → Matrix m n ℂ) :
+    familyColumnGram A = ∑ a, A a * (A a)ᴴ := by
+  ext i j
+  simp [familyColumnGram, familyColumns, Matrix.mul_apply, Matrix.sum_apply,
+    Fintype.sum_prod_type]
+
+omit [DecidableEq ι] [Fintype m] [DecidableEq m] [DecidableEq n] in
+/-- The joint column Gram matrix of a finite family is positive semidefinite. -/
+theorem familyColumnGram_posSemidef [Finite m] (A : ι → Matrix m n ℂ) :
+    (familyColumnGram A).PosSemidef :=
+  posSemidef_self_mul_conjTranspose (familyColumns A)
+
+/-- The orthogonal projection onto the joint column span of a finite matrix family. -/
+noncomputable def familySupportProj (A : ι → Matrix m n ℂ) : Matrix m m ℂ :=
+  (familyColumnGram_posSemidef A).supportProj
+
+omit [DecidableEq ι] [DecidableEq n] in
+/-- The joint column support of a finite matrix family is an orthogonal projection. -/
+theorem isOrthogonalProjection_familySupportProj
+    {p : ℕ} (A : ι → Matrix (Fin p) n ℂ) :
+    IsOrthogonalProjection (familySupportProj A) :=
+  (familyColumnGram_posSemidef A).isOrthogonalProjection_supportProj
+
+omit [DecidableEq ι] [DecidableEq n] in
+/-- The joint column support absorbs every member of the family on the left. -/
+theorem familySupportProj_mul (A : ι → Matrix m n ℂ) (a : ι) :
+    familySupportProj A * A a = A a := by
+  have hColumns :
+      familySupportProj A * familyColumns A = familyColumns A := by
+    change (familyColumnGram_posSemidef A).supportProj * familyColumns A =
+      familyColumns A
+    have hProof :
+        familyColumnGram_posSemidef A =
+          posSemidef_self_mul_conjTranspose (familyColumns A) :=
+      Subsingleton.elim _ _
+    rw [hProof]
+    exact Matrix.supportProj_mul_conjTranspose_mul_self (familyColumns A)
+  ext i j
+  simpa [familyColumns, Matrix.mul_apply] using
+    congrFun (congrFun hColumns i) (a, j)
+
+omit [DecidableEq ι] in
+/-- If the family span is closed under conjugate transpose, its joint column
+support absorbs every member on the right. -/
+theorem mul_familySupportProj_of_conjTranspose_mem_span
+    (A : ι → Matrix m m ℂ)
+    (hstar : ∀ a, ∃ c : ι → ℂ, (A a)ᴴ = ∑ b, c b • A b) (a : ι) :
+    A a * familySupportProj A = A a := by
+  obtain ⟨c, hc⟩ := hstar a
+  have hleft : familySupportProj A * (A a)ᴴ = (A a)ᴴ := by
+    rw [hc, Matrix.mul_sum]
+    simp_rw [Matrix.mul_smul, familySupportProj_mul]
+  have hAdjoint := congrArg Matrix.conjTranspose hleft
+  have hHermitian :
+      (familySupportProj A)ᴴ = familySupportProj A :=
+    (familyColumnGram_posSemidef A).supportProj_isHermitian.eq
+  simpa [Matrix.conjTranspose_mul, hHermitian] using hAdjoint
+
+omit [DecidableEq ι] [DecidableEq n] in
+/-- Every matrix that fixes all family members on the left also fixes their
+joint column support on the left. -/
+theorem familySupportProj_mul_eq_self_of_forall_mul_eq
+    (A : ι → Matrix m n ℂ) (P : Matrix m m ℂ)
+    (hP : ∀ a, P * A a = A a) :
+    P * familySupportProj A = familySupportProj A := by
+  have hGram : P * familyColumnGram A = familyColumnGram A := by
+    rw [familyColumnGram_eq_sum, Matrix.mul_sum]
+    apply Finset.sum_congr rfl
+    intro a _
+    rw [← Matrix.mul_assoc, hP]
+  obtain ⟨W, hW⟩ :=
+    (familyColumnGram_posSemidef A).exists_supportProj_eq_mul
+  change P * (familyColumnGram_posSemidef A).supportProj =
+    (familyColumnGram_posSemidef A).supportProj
+  rw [hW, ← Matrix.mul_assoc, hGram]
+
+omit [DecidableEq ι] [DecidableEq n] in
+/-- A finite matrix family with a nonzero member has nonzero joint column support. -/
+theorem familySupportProj_ne_zero_of_exists_ne_zero
+    (A : ι → Matrix m n ℂ) (hA : ∃ a, A a ≠ 0) :
+    familySupportProj A ≠ 0 := by
+  obtain ⟨a, ha⟩ := hA
+  intro hzero
+  apply ha
+  have hAbsorb := familySupportProj_mul A a
+  rw [hzero, Matrix.zero_mul] at hAbsorb
+  exact hAbsorb.symm
+
+/-- A nonzero `Fin`-indexed matrix family has a positive-dimensional isometric
+parametrization of its joint column support. -/
+theorem exists_familySupport_isometry_of_exists_ne_zero
+    {r p q : ℕ} (A : Fin r → Matrix (Fin p) (Fin q) ℂ)
+    (hA : ∃ a, A a ≠ 0) :
+    ∃ (s : ℕ) (V : Matrix (Fin p) (Fin s) ℂ),
+      0 < s ∧ Vᴴ * V = 1 ∧ V * Vᴴ = familySupportProj A := by
+  obtain ⟨s, V, hIsometry, hRange⟩ :=
+    (isOrthogonalProjection_familySupportProj A).exists_range_isometry
+  have hs : 0 < s := by
+    apply Nat.pos_of_ne_zero
+    intro hs
+    subst s
+    have hVzero : V = 0 := Subsingleton.elim _ _
+    apply familySupportProj_ne_zero_of_exists_ne_zero A hA
+    rw [← hRange, hVzero, Matrix.zero_mul]
+  exact ⟨s, V, hs, hIsometry, hRange⟩
+
+end Matrix

--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -25,6 +25,7 @@ import TNLean.Analysis.LiebOperatorConcave
 import TNLean.Analysis.LiebOperatorIntegral
 import TNLean.Analysis.LiebScalarIntegral
 import TNLean.Analysis.MarginalSupport
+import TNLean.Analysis.MatrixFamilySupport
 import TNLean.Analysis.MatrixOrderTopology
 import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.MatrixTraceInequalities

--- a/TNLean/Analysis/MatrixFamilySupport.lean
+++ b/TNLean/Analysis/MatrixFamilySupport.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.MatrixFamilySupport
+import TNLean.Analysis.MatrixSqrt
+
+/-!
+# Joint column supports of Kronecker-product families
+
+The joint column Gram matrix of the full product family
+\(\{A_a\otimes B_b\}_{a,b}\) is the Kronecker product of the two individual
+joint column Gram matrices. Consequently its joint column support is the
+Kronecker product of the two individual support projections.
+
+## Main results
+
+* `Matrix.familyColumnGram_kronecker`: factorization of the product-family Gram.
+* `Matrix.familySupportProj_kronecker`: factorization of the product-family support.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace Matrix
+
+variable {ι κ m n p q : Type*}
+  [Fintype ι] [DecidableEq ι] [Fintype κ] [DecidableEq κ]
+  [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+  [Fintype p] [DecidableEq p] [Fintype q] [DecidableEq q]
+
+/-- The family consisting of all Kronecker products of one member from each
+of two finite matrix families. -/
+noncomputable def familyKronecker
+    (A : ι → Matrix m n ℂ) (B : κ → Matrix p q ℂ) :
+    ι × κ → Matrix (m × p) (n × q) ℂ :=
+  fun ab ↦ A ab.1 ⊗ₖ B ab.2
+
+omit [DecidableEq ι] [DecidableEq κ] [Fintype m] [DecidableEq m]
+  [DecidableEq n] [Fintype p] [DecidableEq p] [DecidableEq q] in
+/-- The joint column Gram of a full Kronecker-product family is the Kronecker
+product of the two joint column Gram matrices. -/
+theorem familyColumnGram_kronecker
+    (A : ι → Matrix m n ℂ) (B : κ → Matrix p q ℂ) :
+    familyColumnGram (familyKronecker A B) =
+      familyColumnGram A ⊗ₖ familyColumnGram B := by
+  rw [familyColumnGram_eq_sum, familyColumnGram_eq_sum,
+    familyColumnGram_eq_sum]
+  simp_rw [familyKronecker, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul]
+  ext ⟨i, u⟩ ⟨j, v⟩
+  simp only [Matrix.kroneckerMap_apply]
+  simp only [Matrix.sum_apply, Matrix.kroneckerMap_apply,
+    Fintype.sum_prod_type, Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm]
+
+omit [DecidableEq ι] [DecidableEq κ] [DecidableEq n] [DecidableEq q] in
+/-- The joint column support of a full Kronecker-product family is the
+Kronecker product of the two joint column supports. -/
+theorem familySupportProj_kronecker
+    (A : ι → Matrix m n ℂ) (B : κ → Matrix p q ℂ) :
+    familySupportProj (familyKronecker A B) =
+      familySupportProj A ⊗ₖ familySupportProj B := by
+  have supportProj_congr :
+      ∀ {X Y : Matrix (m × p) (m × p) ℂ}
+        (hX : X.PosSemidef) (hY : Y.PosSemidef),
+        X = Y → hX.supportProj = hY.supportProj := by
+    intro X Y hX hY hXY
+    subst Y
+    have hProof : hX = hY := Subsingleton.elim _ _
+    subst hY
+    rfl
+  let hA := familyColumnGram_posSemidef A
+  let hB := familyColumnGram_posSemidef B
+  let hProduct := familyColumnGram_posSemidef (familyKronecker A B)
+  calc
+    familySupportProj (familyKronecker A B) =
+        (hA.kronecker hB).supportProj := by
+      rw [familySupportProj]
+      exact supportProj_congr hProduct (hA.kronecker hB)
+        (familyColumnGram_kronecker A B)
+    _ = hA.supportProj ⊗ₖ hB.supportProj :=
+      hA.supportProj_kronecker hB
+    _ = familySupportProj A ⊗ₖ familySupportProj B := by
+      rfl
+
+end Matrix


### PR DESCRIPTION
## Summary

- define the canonical joint column support of a finite rectangular matrix family
- prove minimality, left absorption, and right absorption under conjugate-transpose closure
- construct a positive-dimensional range isometry for every nonzero `Fin`-indexed family
- prove that the support of a full Kronecker-product family is the Kronecker product of the two family supports

This is the finite-dimensional support theorem needed to remove partial kernels from the active factors in CPSV16 Appendix C.2. It is stated independently of MPO terminology.

Closes #5099
Addresses #5096

## Verification

- focused Lean checks for both new modules
- generated import aggregation check
- proof-integrity search and axiom audit
- `git diff --check` and line-length check
- tactic-pattern scan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-style proofs only; no runtime, auth, or data-path changes—intended as library infrastructure for downstream formalization (e.g. CPSV16 support compression).
> 
> **Overview**
> Adds formal support for **joint column spans** of finite matrix families: stacked columns, a joint Gram matrix, and `familySupportProj` as the PSD support projection of that Gram matrix.
> 
> The algebra module proves **left absorption** for every family member, **minimality** (any left fixer fixes the support), **right absorption** when the span is closed under conjugate transpose, and an **isometric range parametrization** for nonzero `Fin`-indexed families. The analysis module introduces `familyKronecker` and shows joint Gram/support **factor as Kronecker products** for full product families, using existing `PosSemidef.supportProj_kronecker`. Aggregator imports wire both modules into `TNLean.Algebra` and `TNLean.Analysis`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f0c135d4e04e8659a7167caefe354bc72a88c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->