### PR TITLE
feat(mpdo): compress active sector factors

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -150,6 +150,7 @@ import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
+import TNLean.MPS.MPDO.PhysicalSectorActiveFactorSupport
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity
 import TNLean.MPS.MPDO.PhysicalSectorBondPairwise

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveFactorSupport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveFactorSupport.lean
@@ -162,7 +162,8 @@ theorem sectorCoordinateTensor_isMPDO_of_neighboringOperator_pos
 conjugate transpose.
 
 Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and
-`Appetakhetc`, lines 1381--1450 and 1680--1691. -/
+`Appetakhetc`, lines 1381--1450. This closure is a finite-dimensional
+consequence of the injective MPDO factorization stated there. -/
 theorem sectorProductFamily_conjTranspose_mem_span
     (F : PhysicalSectorFactorization K)
     (hK : MPSTensor.IsInjective K.toMPSTensor)
@@ -192,8 +193,9 @@ theorem sectorProductFamily_conjTranspose_mem_span
 /-- In an active sector, the left factor family is closed under conjugate
 transpose.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `PjKiPj`,
-lines 1381--1388 and 1680--1691. -/
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and
+`Appetakhetc`, lines 1381--1450. This is the left-factor consequence of the
+product-family closure. -/
 theorem leftTensor_conjTranspose_mem_span_of_isActiveSector
     (F : PhysicalSectorFactorization K)
     (hK : MPSTensor.IsInjective K.toMPSTensor)
@@ -245,8 +247,9 @@ theorem leftTensor_conjTranspose_mem_span_of_isActiveSector
 /-- In an active sector, the right factor family is closed under conjugate
 transpose.
 
-Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `PjKiPj`,
-lines 1381--1388 and 1680--1691. -/
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and
+`Appetakhetc`, lines 1381--1450. This is the right-factor consequence of the
+product-family closure. -/
 theorem rightTensor_conjTranspose_mem_span_of_isActiveSector
     (F : PhysicalSectorFactorization K)
     (hK : MPSTensor.IsInjective K.toMPSTensor)
@@ -309,8 +312,9 @@ noncomputable abbrev rightFactorSupportProj
 /-- In an active sector, the factor support projections absorb every factor
 on both sides.
 
-Source: arXiv:1606.00608, Appendix C.2, equation `PjKiPj`, lines
-1680--1691. -/
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and
+`Appetakhetc`, lines 1381--1450. The support projections give a
+finite-dimensional normalization of the factors appearing there. -/
 theorem activeSector_factorSupport_twoSided
     (F : PhysicalSectorFactorization K)
     (hK : MPSTensor.IsInjective K.toMPSTensor)
@@ -349,8 +353,8 @@ theorem sectorProductFamily_supportProj
 /-- An active sector has positive-dimensional isometric parametrizations of
 both factor supports.
 
-These isometries realize the factor supports occurring in `PjKiPj`,
-arXiv:1606.00608, Appendix C.2, lines 1680--1691. -/
+These isometries give a finite-dimensional normalization of the factors in
+`AppUkU=rl`, arXiv:1606.00608, Appendix C.2, lines 1381--1450. -/
 theorem exists_activeSector_factorSupportIsometries
     (F : PhysicalSectorFactorization K)
     {k : Fin F.sectorCount} (hk : F.IsActiveSector k) :

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveFactorSupport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveFactorSupport.lean
@@ -1,0 +1,372 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.MatrixFamilySupport
+import TNLean.MPS.MPDO.BNTLayerOrthogonality
+import TNLean.MPS.MPDO.PhysicalSectorProductRealization
+import TNLean.MPS.MPDO.PhysicalSectorVirtualSpanning
+
+/-!
+# Supports of active physical-sector factors
+
+For an injective matrix product density operator, positivity of the
+neighboring operators makes the sector-coordinate tensor an injective matrix
+product density operator. Its physical adjoint therefore lies in the span of
+its physical slices. Restriction to one sector gives adjoint closure of the
+product family
+\[
+  \{l_{k,\beta}\otimes r_{k,\alpha}\}_{\beta,\alpha}.
+\]
+For a sector in which this family is nonzero, matrix-entry functionals descend
+the closure relation to the left and right factor families separately. Their
+joint column supports consequently absorb the factors on both sides and have
+positive-dimensional isometric parametrizations.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `AppUkU=rl` and `Appetakhetc`, lines 1381--1450.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The family of all left-right Kronecker products in one physical sector.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388. -/
+noncomputable abbrev sectorProductFamily
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :=
+  Matrix.familyKronecker (F.leftTensor k) (F.rightTensor k)
+
+/-- A physical sector is active when both of its factor families have a
+nonzero member.
+
+Equivalently, the sector contributes a nonzero block to the direct-sum
+factorization in `AppUkU=rl`.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388. -/
+def IsActiveSector (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) : Prop :=
+  (∃ β, F.leftTensor k β ≠ 0) ∧
+    ∃ α, F.rightTensor k α ≠ 0
+
+/-- A sector is active if and only if its left-right product family has a
+nonzero member. -/
+theorem isActiveSector_iff_exists_sectorProductFamily_ne_zero
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :
+    F.IsActiveSector k ↔ ∃ q, F.sectorProductFamily k q ≠ 0 := by
+  constructor
+  · rintro ⟨⟨β, hβ⟩, ⟨α, hα⟩⟩
+    refine ⟨(β, α), ?_⟩
+    intro hzero
+    have hαentry : ∃ i j, F.rightTensor k α i j ≠ 0 := by
+      by_contra h
+      apply hα
+      ext i j
+      simpa using not_exists.mp (not_exists.mp h i) j
+    obtain ⟨i, j, hij⟩ := hαentry
+    apply hβ
+    ext u v
+    have hEntry := congrFun (congrFun hzero (u, i)) (v, j)
+    simpa [sectorProductFamily, Matrix.familyKronecker,
+      Matrix.kroneckerMap_apply, hij] using hEntry
+  · rintro ⟨⟨β, α⟩, hβα⟩
+    refine ⟨⟨β, ?_⟩, ⟨α, ?_⟩⟩
+    · intro hβ
+      apply hβα
+      simp [sectorProductFamily, Matrix.familyKronecker, hβ]
+    · intro hα
+      apply hβα
+      simp [sectorProductFamily, Matrix.familyKronecker, hα]
+
+/-- Inactivity means that every left-right product in the sector vanishes. -/
+theorem not_isActiveSector_iff (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) :
+    ¬ F.IsActiveSector k ↔ ∀ q, F.sectorProductFamily k q = 0 := by
+  constructor
+  · intro hk q
+    by_contra hq
+    exact hk ((F.isActiveSector_iff_exists_sectorProductFamily_ne_zero k).2
+      ⟨q, hq⟩)
+  · intro hzero hk
+    obtain ⟨q, hq⟩ :=
+      (F.isActiveSector_iff_exists_sectorProductFamily_ne_zero k).1 hk
+    exact hq (hzero q)
+
+/-- A sector is inactive precisely when one of its two factor families is
+identically zero. -/
+theorem not_isActiveSector_iff_left_or_right_eq_zero
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :
+    ¬ F.IsActiveSector k ↔
+      (∀ β, F.leftTensor k β = 0) ∨
+        ∀ α, F.rightTensor k α = 0 := by
+  simp only [IsActiveSector, not_and_or]
+  constructor
+  · intro h
+    rcases h with hleft | hright
+    · exact Or.inl fun β ↦ not_ne_iff.mp (not_exists.mp hleft β)
+    · exact Or.inr fun α ↦ not_ne_iff.mp (not_exists.mp hright α)
+  · rintro (hleft | hright)
+    · exact Or.inl (not_exists.mpr fun β ↦ not_ne_iff.mpr (hleft β))
+    · exact Or.inr (not_exists.mpr fun α ↦ not_ne_iff.mpr (hright α))
+
+/-- At bond dimension zero every physical sector is inactive. -/
+theorem not_isActiveSector_bondDim_zero
+    {K : MPOTensor d 0} (F : PhysicalSectorFactorization K)
+    (k : Fin F.sectorCount) :
+    ¬ F.IsActiveSector k := by
+  rintro ⟨⟨β, _⟩, _⟩
+  exact Fin.elim0 β
+
+/-- Injectivity is preserved when the physical indices are expressed in
+sector coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
+1381--1388. -/
+theorem sectorCoordinateTensor_isInjective
+    (F : PhysicalSectorFactorization K)
+    (hK : MPSTensor.IsInjective K.toMPSTensor) :
+    MPSTensor.IsInjective F.sectorCoordinateTensor.toMPSTensor := by
+  change Submodule.span ℂ (Set.range F.sectorCoordinateTensor.toMPSTensor) = ⊤
+  rw [← F.sectorCoordinateMatrixFamily_span_eq_top hK]
+  congr 1
+  ext A
+  constructor
+  · rintro ⟨q, rfl⟩
+    exact ⟨(q.divNat, q.modNat), rfl⟩
+  · rintro ⟨⟨i, j⟩, rfl⟩
+    refine ⟨finProdFinEquiv (i, j), ?_⟩
+    simp [MPOTensor.toMPSTensor, sectorCoordinateMatrixFamily]
+
+/-- Positive neighboring operators make the sector-coordinate tensor a
+matrix product density operator.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Appetakhetc`, lines
+1389--1450. -/
+theorem sectorCoordinateTensor_isMPDO_of_neighboringOperator_pos
+    (F : PhysicalSectorFactorization K)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    IsMPDO F.sectorCoordinateTensor := by
+  intro N hN
+  letI : NeZero N := ⟨Nat.ne_of_gt hN⟩
+  exact F.mpo_sectorCoordinateTensor_posSemidef hpos
+
+/-- The full left-right product family in every sector is closed under
+conjugate transpose.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and
+`Appetakhetc`, lines 1381--1450 and 1680--1691. -/
+theorem sectorProductFamily_conjTranspose_mem_span
+    (F : PhysicalSectorFactorization K)
+    (hK : MPSTensor.IsInjective K.toMPSTensor)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (k : Fin F.sectorCount) :
+    ∀ q, ∃ c : Fin D × Fin D → ℂ,
+      (F.sectorProductFamily k q)ᴴ =
+        ∑ r, c r • F.sectorProductFamily k r := by
+  obtain ⟨X, hAdjoint⟩ :=
+    exists_physicalSlice_conjTranspose_eq_sum_of_isInjective_isMPDO
+      F.sectorCoordinateTensor
+      (F.sectorCoordinateTensor_isInjective hK)
+      (F.sectorCoordinateTensor_isMPDO_of_neighboringOperator_pos hpos)
+  rintro ⟨β, α⟩
+  refine ⟨fun r ↦
+    X β r.1 * (X⁻¹ : Matrix (Fin D) (Fin D) ℂ) r.2 α, ?_⟩
+  ext x y
+  have hEntry := congrFun (congrFun (hAdjoint β α)
+    (F.sectorFinEquiv.symm ⟨k, x⟩))
+    (F.sectorFinEquiv.symm ⟨k, y⟩)
+  rw [Finset.sum_comm] at hEntry
+  simpa only [sectorProductFamily, Matrix.familyKronecker,
+    Matrix.conjTranspose_apply, Matrix.kroneckerMap_apply, physicalSlice,
+    sectorCoordinateTensor_apply_same, Matrix.sum_apply, Matrix.smul_apply,
+    smul_eq_mul, Fintype.sum_prod_type] using hEntry
+
+/-- In an active sector, the left factor family is closed under conjugate
+transpose.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `PjKiPj`,
+lines 1381--1388 and 1680--1691. -/
+theorem leftTensor_conjTranspose_mem_span_of_isActiveSector
+    (F : PhysicalSectorFactorization K)
+    (hK : MPSTensor.IsInjective K.toMPSTensor)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    {k : Fin F.sectorCount} (hk : F.IsActiveSector k) :
+    ∀ β, ∃ c : Fin D → ℂ,
+      (F.leftTensor k β)ᴴ = ∑ μ, c μ • F.leftTensor k μ := by
+  obtain ⟨α, hα⟩ := hk.2
+  have hαentry : ∃ u v, F.rightTensor k α u v ≠ 0 := by
+    by_contra h
+    apply hα
+    ext u v
+    simpa using not_exists.mp (not_exists.mp h u) v
+  obtain ⟨u, v, huv⟩ := hαentry
+  let z : ℂ := star (F.rightTensor k α u v)
+  have hz : z ≠ 0 := (map_ne_zero (starRingEnd ℂ)).2 huv
+  intro β
+  obtain ⟨c, hc⟩ :=
+    F.sectorProductFamily_conjTranspose_mem_span hK hpos k (β, α)
+  refine ⟨fun μ ↦ z⁻¹ * ∑ ν, c (μ, ν) * F.rightTensor k ν v u, ?_⟩
+  ext x y
+  have hEntry := congrFun (congrFun hc (x, v)) (y, u)
+  simp only [sectorProductFamily, Matrix.familyKronecker,
+    Matrix.conjTranspose_apply, Matrix.kroneckerMap_apply, Matrix.sum_apply,
+    Matrix.smul_apply, smul_eq_mul, Fintype.sum_prod_type] at hEntry ⊢
+  have hEntry' :
+      star (F.leftTensor k β y x) * z =
+        ∑ μ, ∑ ν,
+          c (μ, ν) * (F.leftTensor k μ x y * F.rightTensor k ν v u) := by
+    rw [star_mul'] at hEntry
+    simpa only [z] using hEntry
+  calc
+    star (F.leftTensor k β y x) =
+        z⁻¹ * (star (F.leftTensor k β y x) * z) := by
+      field_simp
+    _ = z⁻¹ * ∑ μ, ∑ ν,
+        c (μ, ν) * (F.leftTensor k μ x y * F.rightTensor k ν v u) := by
+      rw [hEntry']
+    _ = ∑ μ,
+        (z⁻¹ * ∑ ν, c (μ, ν) * F.rightTensor k ν v u) *
+          F.leftTensor k μ x y := by
+      simp_rw [Finset.mul_sum, Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro μ _
+      apply Finset.sum_congr rfl
+      intro ν _
+      ring
+
+/-- In an active sector, the right factor family is closed under conjugate
+transpose.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl` and `PjKiPj`,
+lines 1381--1388 and 1680--1691. -/
+theorem rightTensor_conjTranspose_mem_span_of_isActiveSector
+    (F : PhysicalSectorFactorization K)
+    (hK : MPSTensor.IsInjective K.toMPSTensor)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    {k : Fin F.sectorCount} (hk : F.IsActiveSector k) :
+    ∀ α, ∃ c : Fin D → ℂ,
+      (F.rightTensor k α)ᴴ = ∑ ν, c ν • F.rightTensor k ν := by
+  obtain ⟨β, hβ⟩ := hk.1
+  have hβentry : ∃ u v, F.leftTensor k β u v ≠ 0 := by
+    by_contra h
+    apply hβ
+    ext u v
+    simpa using not_exists.mp (not_exists.mp h u) v
+  obtain ⟨u, v, huv⟩ := hβentry
+  let z : ℂ := star (F.leftTensor k β u v)
+  have hz : z ≠ 0 := (map_ne_zero (starRingEnd ℂ)).2 huv
+  intro α
+  obtain ⟨c, hc⟩ :=
+    F.sectorProductFamily_conjTranspose_mem_span hK hpos k (β, α)
+  refine ⟨fun ν ↦ z⁻¹ * ∑ μ, c (μ, ν) * F.leftTensor k μ v u, ?_⟩
+  ext x y
+  have hEntry := congrFun (congrFun hc (v, x)) (u, y)
+  simp only [sectorProductFamily, Matrix.familyKronecker,
+    Matrix.conjTranspose_apply, Matrix.kroneckerMap_apply, Matrix.sum_apply,
+    Matrix.smul_apply, smul_eq_mul, Fintype.sum_prod_type] at hEntry ⊢
+  rw [Finset.sum_comm] at hEntry
+  have hEntry' :
+      z * star (F.rightTensor k α y x) =
+        ∑ ν, ∑ μ,
+          c (μ, ν) * (F.leftTensor k μ v u * F.rightTensor k ν x y) := by
+    rw [star_mul'] at hEntry
+    simpa only [z] using hEntry
+  calc
+    star (F.rightTensor k α y x) =
+        z⁻¹ * (z * star (F.rightTensor k α y x)) := by
+      field_simp
+    _ = z⁻¹ * ∑ ν, ∑ μ,
+        c (μ, ν) * (F.leftTensor k μ v u * F.rightTensor k ν x y) := by
+      rw [hEntry']
+    _ = ∑ ν,
+        (z⁻¹ * ∑ μ, c (μ, ν) * F.leftTensor k μ v u) *
+          F.rightTensor k ν x y := by
+      simp_rw [Finset.mul_sum, Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro ν _
+      apply Finset.sum_congr rfl
+      intro μ _
+      ring
+
+/-- The joint column support of the left factor family in a sector. -/
+noncomputable abbrev leftFactorSupportProj
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :=
+  Matrix.familySupportProj (F.leftTensor k)
+
+/-- The joint column support of the right factor family in a sector. -/
+noncomputable abbrev rightFactorSupportProj
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :=
+  Matrix.familySupportProj (F.rightTensor k)
+
+/-- In an active sector, the factor support projections absorb every factor
+on both sides.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `PjKiPj`, lines
+1680--1691. -/
+theorem activeSector_factorSupport_twoSided
+    (F : PhysicalSectorFactorization K)
+    (hK : MPSTensor.IsInjective K.toMPSTensor)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    {k : Fin F.sectorCount} (hk : F.IsActiveSector k) :
+    (∀ β,
+      F.leftFactorSupportProj k * F.leftTensor k β = F.leftTensor k β ∧
+        F.leftTensor k β * F.leftFactorSupportProj k = F.leftTensor k β) ∧
+      ∀ α,
+        F.rightFactorSupportProj k * F.rightTensor k α = F.rightTensor k α ∧
+          F.rightTensor k α * F.rightFactorSupportProj k =
+            F.rightTensor k α := by
+  constructor
+  · intro β
+    exact ⟨Matrix.familySupportProj_mul (F.leftTensor k) β,
+      Matrix.mul_familySupportProj_of_conjTranspose_mem_span
+        (F.leftTensor k)
+        (F.leftTensor_conjTranspose_mem_span_of_isActiveSector hK hpos hk) β⟩
+  · intro α
+    exact ⟨Matrix.familySupportProj_mul (F.rightTensor k) α,
+      Matrix.mul_familySupportProj_of_conjTranspose_mem_span
+        (F.rightTensor k)
+        (F.rightTensor_conjTranspose_mem_span_of_isActiveSector hK hpos hk) α⟩
+
+/-- The support of a sector product family is the Kronecker product of the
+two factor supports.
+
+This is the finite-dimensional support identity for the product in
+`AppUkU=rl`, arXiv:1606.00608, Appendix C.2, lines 1381--1388. -/
+theorem sectorProductFamily_supportProj
+    (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :
+    Matrix.familySupportProj (F.sectorProductFamily k) =
+      F.leftFactorSupportProj k ⊗ₖ F.rightFactorSupportProj k :=
+  Matrix.familySupportProj_kronecker (F.leftTensor k) (F.rightTensor k)
+
+/-- An active sector has positive-dimensional isometric parametrizations of
+both factor supports.
+
+These isometries realize the factor supports occurring in `PjKiPj`,
+arXiv:1606.00608, Appendix C.2, lines 1680--1691. -/
+theorem exists_activeSector_factorSupportIsometries
+    (F : PhysicalSectorFactorization K)
+    {k : Fin F.sectorCount} (hk : F.IsActiveSector k) :
+    ∃ (l r : ℕ)
+      (VL : Matrix (Fin (F.leftDim k)) (Fin l) ℂ)
+      (VR : Matrix (Fin (F.rightDim k)) (Fin r) ℂ),
+      0 < l ∧ VLᴴ * VL = 1 ∧
+        VL * VLᴴ = F.leftFactorSupportProj k ∧
+      0 < r ∧ VRᴴ * VR = 1 ∧
+        VR * VRᴴ = F.rightFactorSupportProj k := by
+  obtain ⟨l, VL, hl, hVL, hRangeL⟩ :=
+    Matrix.exists_familySupport_isometry_of_exists_ne_zero
+      (F.leftTensor k) hk.1
+  obtain ⟨r, VR, hr, hVR, hRangeR⟩ :=
+    Matrix.exists_familySupport_isometry_of_exists_ne_zero
+      (F.rightTensor k) hk.2
+  exact ⟨l, r, VL, VR, hl, hVL, hRangeL, hr, hVR, hRangeR⟩
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveFactorSupport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveFactorSupport.lean
@@ -230,7 +230,7 @@ theorem leftTensor_conjTranspose_mem_span_of_isActiveSector
   calc
     star (F.leftTensor k β y x) =
         z⁻¹ * (star (F.leftTensor k β y x) * z) := by
-      field_simp
+      field_simp [hz]
     _ = z⁻¹ * ∑ μ, ∑ ν,
         c (μ, ν) * (F.leftTensor k μ x y * F.rightTensor k ν v u) := by
       rw [hEntry']
@@ -285,7 +285,7 @@ theorem rightTensor_conjTranspose_mem_span_of_isActiveSector
   calc
     star (F.rightTensor k α y x) =
         z⁻¹ * (z * star (F.rightTensor k α y x)) := by
-      field_simp
+      field_simp [hz]
     _ = z⁻¹ * ∑ ν, ∑ μ,
         c (μ, ν) * (F.leftTensor k μ v u * F.rightTensor k ν x y) := by
       rw [hEntry']

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -386,7 +386,7 @@
     Since $k$ is active, choose $\alpha,u,v$ for which
     $r_{k,\alpha}(u,v)\ne0$, and put
     $z=\overline{r_{k,\alpha}(u,v)}$. Evaluating
-    \eqref{eq:mpdo_active_sector_product_adjoint_closure} at the corresponding
+    (\ref{eq:mpdo_active_sector_product_adjoint_closure}) at the corresponding
     matrix entry and dividing by $z$ yields
     \begin{align}
         l_{k,\beta}^*
@@ -396,7 +396,6 @@
             z^{-1}\sum_\nu
             c_{k,\beta,\alpha}(\mu,\nu)r_{k,\nu}(v,u)
         \right)l_{k,\mu}.
-        \label{eq:mpdo_active_sector_left_adjoint_closure}
     \end{align}
     Interchanging the two factors gives the corresponding identity for
     $r_{k,\alpha}^*$. Thus both factor spans are closed under conjugate

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -311,6 +311,77 @@
     entries yields the displayed expansion.
 \end{proof}
 
+\begin{theorem}[Canonical supports of the active physical-sector factors]
+    \label{thm:mpdo_active_physical_sector_factor_supports}
+    \lean{MPOTensor.PhysicalSectorFactorization.sectorProductFamily,
+        MPOTensor.PhysicalSectorFactorization.IsActiveSector,
+        MPOTensor.PhysicalSectorFactorization.isActiveSector_iff_exists_sectorProductFamily_ne_zero,
+        MPOTensor.PhysicalSectorFactorization.not_isActiveSector_iff,
+        MPOTensor.PhysicalSectorFactorization.not_isActiveSector_iff_left_or_right_eq_zero,
+        MPOTensor.PhysicalSectorFactorization.not_isActiveSector_bondDim_zero,
+        MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_isInjective,
+        MPOTensor.PhysicalSectorFactorization.sectorCoordinateTensor_isMPDO_of_neighboringOperator_pos,
+        MPOTensor.PhysicalSectorFactorization.sectorProductFamily_conjTranspose_mem_span,
+        MPOTensor.PhysicalSectorFactorization.leftTensor_conjTranspose_mem_span_of_isActiveSector,
+        MPOTensor.PhysicalSectorFactorization.rightTensor_conjTranspose_mem_span_of_isActiveSector,
+        MPOTensor.PhysicalSectorFactorization.leftFactorSupportProj,
+        MPOTensor.PhysicalSectorFactorization.rightFactorSupportProj,
+        MPOTensor.PhysicalSectorFactorization.activeSector_factorSupport_twoSided,
+        MPOTensor.PhysicalSectorFactorization.sectorProductFamily_supportProj,
+        MPOTensor.PhysicalSectorFactorization.exists_activeSector_factorSupportIsometries}
+    \leanok
+    \uses{thm:mpdo_injective_mpdo_adjoint_closure}
+    Let $K$ be injective and let
+    \[
+        UK[\beta,\alpha]U^*
+        =\bigoplus_k l_{k,\beta}\otimes r_{k,\alpha}
+    \]
+    be a physical-sector factorization whose neighboring operators are
+    positive semidefinite. Call $k$ active when both families
+    $\{l_{k,\beta}\}_\beta$ and $\{r_{k,\alpha}\}_\alpha$ contain a nonzero
+    member. For every active $k$, the two factor spans are closed under
+    conjugate transpose. If $P_k^L$ and $P_k^R$ are their respective joint
+    column-support projections, then
+    \begin{align}
+        P_k^L l_{k,\beta}
+        &=l_{k,\beta}
+         =l_{k,\beta}P_k^L,
+        &
+        P_k^R r_{k,\alpha}
+        &=r_{k,\alpha}
+         =r_{k,\alpha}P_k^R,
+        \notag\\
+        \operatorname{supp}
+        \{l_{k,\beta}\otimes r_{k,\alpha}\}_{\beta,\alpha}
+        &=P_k^L\otimes P_k^R.
+        \notag
+    \end{align}
+    Moreover, there are positive integers $p_k,q_k$ and isometries
+    \[
+        V_k^L:\C^{p_k}\longrightarrow\C^{d_k^L},
+        \qquad
+        V_k^R:\C^{q_k}\longrightarrow\C^{d_k^R}
+    \]
+    whose range projections are $P_k^L$ and $P_k^R$. If $k$ is inactive,
+    every product $l_{k,\beta}\otimes r_{k,\alpha}$ vanishes; in particular,
+    there is no active sector when the virtual dimension is zero.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The sector-coordinate tensor remains injective. Positivity of the
+    neighboring operators makes it a matrix product density operator, so
+    Theorem~\ref{thm:mpdo_injective_mpdo_adjoint_closure} closes its physical
+    slices under conjugate transpose. Restriction to one diagonal sector
+    closes the span of the products
+    $l_{k,\beta}\otimes r_{k,\alpha}$. Evaluating a nonzero matrix entry in
+    the opposite factor gives conjugate-transpose closure of each factor
+    span. The joint column-support projections then absorb the factors on
+    both sides. Their tensor product is the support projection of the
+    product family, and finite-dimensional range decompositions give the two
+    isometries.
+\end{proof}
+
 % **Partial coverage of CPSV16 Proposition `prop3to4`:** this theorem derives
 % pairwise two-sided supports from `AppKxKy=0` under the standing biCF
 % injectivity and the sectorwise positivity supplied by `AppUkU=rl` and

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -332,10 +332,11 @@
     \leanok
     \uses{thm:mpdo_injective_mpdo_adjoint_closure}
     Let $K$ be injective and let
-    \[
+    \begin{align}
         UK[\beta,\alpha]U^*
         =\bigoplus_k l_{k,\beta}\otimes r_{k,\alpha}
-    \]
+        \notag
+    \end{align}
     be a physical-sector factorization whose neighboring operators are
     positive semidefinite. Call $k$ active when both families
     $\{l_{k,\beta}\}_\beta$ and $\{r_{k,\alpha}\}_\alpha$ contain a nonzero
@@ -357,11 +358,12 @@
         \notag
     \end{align}
     Moreover, there are positive integers $p_k,q_k$ and isometries
-    \[
+    \begin{align}
         V_k^L:\C^{p_k}\longrightarrow\C^{d_k^L},
-        \qquad
+        \qquad&
         V_k^R:\C^{q_k}\longrightarrow\C^{d_k^R}
-    \]
+        \notag
+    \end{align}
     whose range projections are $P_k^L$ and $P_k^R$. If $k$ is inactive,
     every product $l_{k,\beta}\otimes r_{k,\alpha}$ vanishes; in particular,
     there is no active sector when the virtual dimension is zero.
@@ -372,12 +374,34 @@
     The sector-coordinate tensor remains injective. Positivity of the
     neighboring operators makes it a matrix product density operator, so
     Theorem~\ref{thm:mpdo_injective_mpdo_adjoint_closure} closes its physical
-    slices under conjugate transpose. Restriction to one diagonal sector
-    closes the span of the products
-    $l_{k,\beta}\otimes r_{k,\alpha}$. Evaluating a nonzero matrix entry in
-    the opposite factor gives conjugate-transpose closure of each factor
-    span. The joint column-support projections then absorb the factors on
-    both sides. Their tensor product is the support projection of the
+    slices under conjugate transpose. Restriction to the $k$-th diagonal
+    sector gives coefficients $c_{k,\beta,\alpha}(\mu,\nu)$ such that
+    \begin{align}
+        (l_{k,\beta}\otimes r_{k,\alpha})^*
+        &=
+        \sum_{\mu,\nu}c_{k,\beta,\alpha}(\mu,\nu)\,
+        l_{k,\mu}\otimes r_{k,\nu}.
+        \label{eq:mpdo_active_sector_product_adjoint_closure}
+    \end{align}
+    Since $k$ is active, choose $\alpha,u,v$ for which
+    $r_{k,\alpha}(u,v)\ne0$, and put
+    $z=\overline{r_{k,\alpha}(u,v)}$. Evaluating
+    \eqref{eq:mpdo_active_sector_product_adjoint_closure} at the corresponding
+    matrix entry and dividing by $z$ yields
+    \begin{align}
+        l_{k,\beta}^*
+        &=
+        \sum_\mu
+        \left(
+            z^{-1}\sum_\nu
+            c_{k,\beta,\alpha}(\mu,\nu)r_{k,\nu}(v,u)
+        \right)l_{k,\mu}.
+        \label{eq:mpdo_active_sector_left_adjoint_closure}
+    \end{align}
+    Interchanging the two factors gives the corresponding identity for
+    $r_{k,\alpha}^*$. Thus both factor spans are closed under conjugate
+    transpose. The joint column-support projections then absorb the factors
+    on both sides. Their tensor product is the support projection of the
     product family, and finite-dimensional range decompositions give the two
     isometries.
 \end{proof}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -84,7 +84,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | — | L188 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L443 `tenkz` → `C-policy+C-record` | L447, 453, 458 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L514 `tenkz` → `C-policy+C-record` | L518, 524, 529 `tenkz` → `C-record+R-record` |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -84,7 +84,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | — | L188 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L514 `tenkz` → `C-policy+C-record` | L518, 524, 529 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L538 `tenkz` → `C-policy+C-record` | L542, 548, 553 `tenkz` → `C-record+R-record` |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -84,7 +84,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | — | L188 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L538 `tenkz` → `C-policy+C-record` | L542, 548, 553 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L537 `tenkz` → `C-policy+C-record` | L541, 547, 552 `tenkz` → `C-record+R-record` |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |


### PR DESCRIPTION
## Summary

For a CPSV16 physical-sector factorization, this change defines an active sector by nonvanishing of both factor families and proves the finite-dimensional support statements needed for the canonical restriction.

The main argument first transfers injectivity and matrix-product-density-operator positivity to the sector-coordinate tensor. Its physical slices are closed under conjugate transpose. Restricting this relation to a fixed sector gives closure of the left-right product family; a nonzero matrix entry in the opposite factor then descends the relation separately to the left and right families.

The resulting canonical family-support projections absorb every active factor on both sides. Each active factor support admits a positive-dimensional isometric parametrization, and the support of the product family is the Kronecker product of the two factor supports. Inactive sectors, including all sectors at bond dimension zero, are treated explicitly.

Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl`, `Appetakhetc`.

## Verification

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorActiveFactorSupport.lean`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- word-boundary proof-integrity scan
- `git diff --check` and 100-column check
- kernel axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Closes #5100.
Addresses #5096.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and blueprint documentation only; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds **`PhysicalSectorActiveFactorSupport.lean`** and wires it into the MPDO aggregator, formalizing CPSV16 Appendix C.2 support/compression for physical-sector factorizations.
> 
> **Active sectors** are defined when both left and right factor families are nonzero; lemmas characterize inactive sectors (vanishing products, one-sided zero families, bond dimension zero). Under **injectivity** and **positive neighboring operators**, the sector-coordinate tensor stays injective and is an MPDO, so physical-slice adjoint closure yields **conjugate-transpose closure** of each sector’s left⊗right product family; in active sectors, matrix-entry arguments **split** that closure to the left and right families separately.
> 
> For active sectors, **joint column-support projections** act two-sided on factors, the product-family support is the **Kronecker product** of the factor supports, and **positive-dimensional isometries** parametrize each support. The blueprint capstone chapter gains a matching **theorem and proof** (`thm:mpdo_active_physical_sector_factor_supports`); `DISPOSITIONS.md` line refs for that chapter are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c75ff33a4d6735bbbb40bd702ad19f620c9b81aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->