### PR TITLE
feat(MPS/MPDO): preserve neighboring positivity

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -151,6 +151,7 @@ import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
 import TNLean.MPS.MPDO.PhysicalSectorActiveFactorSupport
+import TNLean.MPS.MPDO.PhysicalSectorActiveNeighboring
 import TNLean.MPS.MPDO.PhysicalSectorActiveRestriction
 import TNLean.MPS.MPDO.PhysicalSectorBlockedRFP
 import TNLean.MPS.MPDO.PhysicalSectorBondCommutativity

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveNeighboring.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveNeighboring.lean
@@ -1,0 +1,404 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorActiveRestriction
+
+/-!
+# Neighboring operators after active physical restriction
+
+The canonical active restriction compresses the right factor of a source
+sector and the left factor of a target sector.  Consequently its neighboring
+operator is the congruence of the ambient neighboring operator by the
+Kronecker product of those two support isometries.  Positive
+semidefiniteness then follows directly from preservation under matrix
+congruence.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `Appetakhetc` and `etarl`, lines 1435--1450.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The retained neighboring index between a source sector `k` and a target
+sector `h`. -/
+abbrev SupportedNeighborIndex (F : PhysicalSectorFactorization K)
+    (A : ActiveFactorSupportData F) (k h : Fin F.sectorCount) :=
+  Fin (A.sector k).rightDim × Fin (A.sector h).leftDim
+
+/-- The inclusion of the retained neighboring space into the ambient
+neighboring space.  It uses the source right support and target left support.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `etarl`, lines
+1441--1445. -/
+noncomputable def neighboringSupportInclusion
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (k h : Fin F.sectorCount) :
+    Matrix (NeighborIndex F k h) (SupportedNeighborIndex F A k h) ℂ :=
+  (A.sector k).rightInclusion ⊗ₖ (A.sector h).leftInclusion
+
+/-- The neighboring inclusion is an isometry. -/
+theorem neighboringSupportInclusion_isometry
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (k h : Fin F.sectorCount) :
+    (F.neighboringSupportInclusion A k h)ᴴ *
+        F.neighboringSupportInclusion A k h = 1 := by
+  rw [neighboringSupportInclusion, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul,
+    (A.sector k).rightInclusion_isometry,
+    (A.sector h).leftInclusion_isometry]
+  exact Matrix.one_kronecker_one
+
+/-- The neighboring operator formed from the compressed source-right and
+target-left factors.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and
+`etarl`, lines 1435--1450. -/
+noncomputable def compressedNeighboringOperator
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (k h : Fin F.sectorCount) :
+    Matrix (SupportedNeighborIndex F A k h)
+      (SupportedNeighborIndex F A k h) ℂ :=
+  ∑ a : Fin D,
+    F.compressedRightTensor A k a ⊗ₖ F.compressedLeftTensor A h a
+
+/-- The ambient neighboring operator is the sum of the corresponding
+right-left Kronecker products. -/
+theorem neighboringOperator_eq_sum_kronecker
+    (F : PhysicalSectorFactorization K) (k h : Fin F.sectorCount) :
+    F.neighboringOperator k h =
+      ∑ a : Fin D, F.rightTensor k a ⊗ₖ F.leftTensor h a := by
+  ext x y
+  simp [neighboringOperator, Matrix.sum_apply]
+
+/-- The restricted neighboring operator is the explicit congruence of the
+ambient neighboring operator by the source-right and target-left support
+isometries.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and
+`etarl`, lines 1435--1450. -/
+theorem compressedNeighboringOperator_eq_congruence
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (k h : Fin F.sectorCount) :
+    F.compressedNeighboringOperator A k h =
+      (F.neighboringSupportInclusion A k h)ᴴ *
+          F.neighboringOperator k h *
+        F.neighboringSupportInclusion A k h := by
+  rw [compressedNeighboringOperator, F.neighboringOperator_eq_sum_kronecker,
+    Matrix.mul_sum, Matrix.sum_mul]
+  apply Finset.sum_congr rfl
+  intro a _
+  rw [neighboringSupportInclusion, Matrix.conjTranspose_kronecker,
+    ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+  rfl
+
+/-- Positive semidefiniteness of an ambient neighboring operator passes to
+the compressed neighboring operator by its explicit congruence.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Appetakhetc`, lines
+1435--1450. -/
+theorem compressedNeighboringOperator_posSemidef
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (k h : Fin F.sectorCount) :
+    (F.compressedNeighboringOperator A k h).PosSemidef := by
+  rw [F.compressedNeighboringOperator_eq_congruence]
+  exact (hpos k h).conjTranspose_mul_mul_same
+    (F.neighboringSupportInclusion A k h)
+
+/-- The finite type of active sectors. -/
+abbrev FactorActiveSector (F : PhysicalSectorFactorization K) :=
+  {k : Fin F.sectorCount // F.IsActiveSector k}
+
+/-- The active sectors form a finite type. -/
+noncomputable instance activeSectorFintype
+    (F : PhysicalSectorFactorization K) : Fintype (FactorActiveSector F) :=
+  Fintype.ofFinite _
+
+/-- The number of active sectors. -/
+noncomputable def activeSectorCount (F : PhysicalSectorFactorization K) :=
+  Fintype.card (FactorActiveSector F)
+
+/-- A chosen finite enumeration of the active sectors. -/
+noncomputable def activeSectorFinEquiv (F : PhysicalSectorFactorization K) :
+    Fin F.activeSectorCount ≃ FactorActiveSector F :=
+  (Fintype.equivFin _).symm
+
+/-- A retained sector fiber is inhabited precisely when its ambient sector is
+active. -/
+theorem nonempty_supportedSectorIndex_iff_isActiveSector
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (k : Fin F.sectorCount) :
+    Nonempty (SupportedSectorIndex F A k) ↔ F.IsActiveSector k := by
+  constructor
+  · rintro ⟨x⟩
+    by_contra hk
+    have hzero := (A.sector k).leftDim_eq_zero_of_not_isActiveSector hk
+    have hx := x.1.isLt
+    omega
+  · intro hk
+    exact ⟨(⟨0, (A.sector k).leftDim_pos_of_isActiveSector hk⟩,
+      ⟨0, (A.sector k).rightDim_pos_of_isActiveSector hk⟩)⟩
+
+/-- Removing the empty inactive fibers identifies the active-sector
+dependent sum with the retained physical index space. -/
+noncomputable def activeSubtypeSigmaEquiv
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F) :
+    (Σ s : FactorActiveSector F, SupportedSectorIndex F A s.1) ≃
+      SupportedPhysicalIndex F A :=
+  Equiv.sigmaSubtypeEquivOfSubset
+    (fun k ↦ SupportedSectorIndex F A k) F.IsActiveSector
+    (fun k x ↦
+      (F.nonempty_supportedSectorIndex_iff_isActiveSector A k).mp ⟨x⟩)
+
+/-- The active-subtype equivalence forgets only the proof of activity. -/
+@[simp] theorem activeSubtypeSigmaEquiv_apply
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (s : FactorActiveSector F) (x : SupportedSectorIndex F A s.1) :
+    F.activeSubtypeSigmaEquiv A ⟨s, x⟩ = ⟨s.1, x⟩ :=
+  rfl
+
+/-- The active-sector dependent sum with active sectors enumerated by a
+finite ordinal. -/
+noncomputable def activeSectorSigmaEquiv
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F) :
+    (Σ j : Fin F.activeSectorCount,
+      SupportedSectorIndex F A (F.activeSectorFinEquiv j).1) ≃
+        SupportedPhysicalIndex F A :=
+  (Equiv.sigmaCongrLeft (β := fun s : FactorActiveSector F ↦
+    SupportedSectorIndex F A s.1) F.activeSectorFinEquiv).trans
+      (F.activeSubtypeSigmaEquiv A)
+
+/-- The enumerated active-sector equivalence preserves the fiber
+coordinates. -/
+@[simp] theorem activeSectorSigmaEquiv_apply
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (j : Fin F.activeSectorCount)
+    (x : SupportedSectorIndex F A (F.activeSectorFinEquiv j).1) :
+    F.activeSectorSigmaEquiv A ⟨j, x⟩ =
+      ⟨(F.activeSectorFinEquiv j).1, x⟩ := by
+  rfl
+
+/-- The physical coordinates of the active restriction, decomposed as the
+direct sum over active sectors. -/
+noncomputable def activeRestrictionSectorEquiv
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F) :
+    Fin (F.supportedPhysicalDim A) ≃
+      Σ j : Fin F.activeSectorCount,
+        SupportedSectorIndex F A (F.activeSectorFinEquiv j).1 :=
+  (F.supportedPhysicalFinEquiv A).trans (F.activeSectorSigmaEquiv A).symm
+
+/-- In active-sector coordinates, the restricted physical slice is the direct
+sum of the compressed left-right factors.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and
+`etarl`, lines 1435--1450. -/
+theorem reindex_physicalSlice_activeRestriction_activeSectors
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (β α : Fin D) :
+    Matrix.reindex (F.activeRestrictionSectorEquiv A)
+        (F.activeRestrictionSectorEquiv A)
+        (physicalSlice (F.activePhysicalSupportRestriction A) β α) =
+      Matrix.blockDiagonal' fun j : Fin F.activeSectorCount ↦
+        F.compressedLeftTensor A (F.activeSectorFinEquiv j).1 β ⊗ₖ
+          F.compressedRightTensor A (F.activeSectorFinEquiv j).1 α := by
+  have hfull :=
+    F.reindex_physicalSlice_activePhysicalSupportRestriction A β α
+  ext ⟨j, x⟩ ⟨l, y⟩
+  have hEntry := congrFun (congrFun hfull
+    (F.activeSectorSigmaEquiv A ⟨j, x⟩))
+    (F.activeSectorSigmaEquiv A ⟨l, y⟩)
+  have hjl :
+      (F.activeSectorFinEquiv j).1 =
+          (F.activeSectorFinEquiv l).1 ↔ j = l := by
+    constructor
+    · intro h
+      apply F.activeSectorFinEquiv.injective
+      exact Subtype.ext h
+    · exact fun h ↦ h ▸ rfl
+  simpa [activeRestrictionSectorEquiv, Matrix.reindex_apply,
+    Matrix.blockDiagonal'_apply, hjl] using hEntry
+
+/-- The physical-sector factorization of the active physical restriction.
+
+Its sectors are precisely the active ambient sectors, and its left and right
+factors are the corresponding support compressions.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and
+`etarl`, lines 1435--1450. -/
+noncomputable abbrev activeRestrictedPhysicalSectorFactorization
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F) :
+    PhysicalSectorFactorization (F.activePhysicalSupportRestriction A) where
+  sectorCount := F.activeSectorCount
+  leftDim := fun j ↦ (A.sector (F.activeSectorFinEquiv j).1).leftDim
+  rightDim := fun j ↦ (A.sector (F.activeSectorFinEquiv j).1).rightDim
+  leftDim_pos := fun j ↦
+    (A.sector (F.activeSectorFinEquiv j).1).leftDim_pos_of_isActiveSector
+      (F.activeSectorFinEquiv j).2
+  rightDim_pos := fun j ↦
+    (A.sector (F.activeSectorFinEquiv j).1).rightDim_pos_of_isActiveSector
+      (F.activeSectorFinEquiv j).2
+  sectorEquiv := F.activeRestrictionSectorEquiv A
+  physicalIsometry := 1
+  physicalIsometry_isometry := by simp
+  leftTensor := fun j β ↦
+    F.compressedLeftTensor A (F.activeSectorFinEquiv j).1 β
+  rightTensor := fun j α ↦
+    F.compressedRightTensor A (F.activeSectorFinEquiv j).1 α
+  factorization := by
+    intro β α
+    rw [Matrix.one_mul, Matrix.conjTranspose_one, Matrix.mul_one]
+    exact F.reindex_physicalSlice_activeRestriction_activeSectors A β α
+
+/-- The active restricted factorization retains exactly the enumerated
+ambient active sector. -/
+@[simp] theorem activeRestrictedPhysicalSectorFactorization_sector
+    (F : PhysicalSectorFactorization K) (_A : ActiveFactorSupportData F)
+    (j : Fin F.activeSectorCount) :
+    F.IsActiveSector (F.activeSectorFinEquiv j).1 :=
+  (F.activeSectorFinEquiv j).2
+
+/-- The neighboring operator of the restricted factorization is the
+compressed neighboring operator of the corresponding ambient active
+sectors. -/
+theorem activeRestrictedPhysicalSectorFactorization_neighboringOperator
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (j l : Fin F.activeSectorCount) :
+    (F.activeRestrictedPhysicalSectorFactorization A).neighboringOperator j l =
+      F.compressedNeighboringOperator A
+        (F.activeSectorFinEquiv j).1 (F.activeSectorFinEquiv l).1 := by
+  ext x y
+  simp [neighboringOperator, compressedNeighboringOperator,
+    compressedLeftTensor, compressedRightTensor, Matrix.sum_apply]
+
+/-- Every neighboring operator of the active restricted factorization is
+the explicit congruence of its ambient neighboring operator.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and
+`etarl`, lines 1435--1450. -/
+theorem activeRestrictedPhysicalSectorFactorization_neighboringOperator_eq_congruence
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (j l : Fin F.activeSectorCount) :
+    (F.activeRestrictedPhysicalSectorFactorization A).neighboringOperator j l =
+      (F.neighboringSupportInclusion A
+          (F.activeSectorFinEquiv j).1 (F.activeSectorFinEquiv l).1)ᴴ *
+        F.neighboringOperator
+          (F.activeSectorFinEquiv j).1 (F.activeSectorFinEquiv l).1 *
+        F.neighboringSupportInclusion A
+          (F.activeSectorFinEquiv j).1 (F.activeSectorFinEquiv l).1 := by
+  rw [F.activeRestrictedPhysicalSectorFactorization_neighboringOperator,
+    F.compressedNeighboringOperator_eq_congruence]
+
+/-- Neighboring positivity passes to every pair of sectors of the active
+restricted factorization by the explicit congruence.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Appetakhetc`, lines
+1435--1450. -/
+theorem activeRestrictedPhysicalSectorFactorization_neighboringOperator_posSemidef
+    (F : PhysicalSectorFactorization K) (A : ActiveFactorSupportData F)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (j l : Fin F.activeSectorCount) :
+    ((F.activeRestrictedPhysicalSectorFactorization A).neighboringOperator
+      j l).PosSemidef := by
+  rw [F.activeRestrictedPhysicalSectorFactorization_neighboringOperator]
+  exact F.compressedNeighboringOperator_posSemidef A hpos _ _
+
+/-- The complete canonical active compression associated with a
+physical-sector factorization.
+
+The stored datum is only the simultaneous choice of factor-support
+coordinates.  Its canonical projection, exact physical restriction,
+active-sector factorization, sector correspondence, neighboring congruences,
+and neighboring positivity are exposed below.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and
+`etarl`, lines 1435--1450. -/
+structure ActivePhysicalCompressionWitness
+    (F : PhysicalSectorFactorization K) where
+  /-- The support coordinates chosen in every ambient sector. -/
+  factorSupport : ActiveFactorSupportData F
+
+namespace ActivePhysicalCompressionWitness
+
+variable {F : PhysicalSectorFactorization K}
+
+/-- The canonical active compression witness. -/
+noncomputable def canonical
+    (F : PhysicalSectorFactorization K) :
+    ActivePhysicalCompressionWitness F where
+  factorSupport := F.activeFactorSupportData
+
+/-- The canonical physical-support restriction carried by the witness. -/
+noncomputable def restrictionData
+    (W : ActivePhysicalCompressionWitness F)
+    (hK : MPSTensor.IsInjective K.toMPSTensor)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    PhysicalSupportRestrictionData (physicalSupportProj K) K :=
+  F.activePhysicalSupportRestrictionData W.factorSupport hK hpos
+
+/-- The restricted factorization carried by the witness. -/
+noncomputable abbrev factorization
+    (W : ActivePhysicalCompressionWitness F) :
+    PhysicalSectorFactorization
+      (F.activePhysicalSupportRestriction W.factorSupport) :=
+  F.activeRestrictedPhysicalSectorFactorization W.factorSupport
+
+/-- The restricted factorization has exactly the tensor obtained from the
+canonical restriction datum. -/
+noncomputable abbrev factorizationForRestrictionData
+    (W : ActivePhysicalCompressionWitness F)
+    (hK : MPSTensor.IsInjective K.toMPSTensor)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    PhysicalSectorFactorization
+      (changePhysicalBasis (W.restrictionData hK hpos).inclusionᴴ K) :=
+  W.factorization
+
+/-- Sectors of the restricted factorization correspond bijectively to the
+active ambient sectors. -/
+noncomputable def sectorCorrespondence
+    (W : ActivePhysicalCompressionWitness F) :
+    Fin W.factorization.sectorCount ≃ FactorActiveSector F :=
+  F.activeSectorFinEquiv
+
+/-- The witness exposes the exact neighboring congruence for every pair of
+its active sectors.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and
+`etarl`, lines 1435--1450. -/
+theorem neighboringOperator_eq_congruence
+    (W : ActivePhysicalCompressionWitness F)
+    (j l : Fin W.factorization.sectorCount) :
+    W.factorization.neighboringOperator j l =
+      (F.neighboringSupportInclusion W.factorSupport
+          (W.sectorCorrespondence j).1 (W.sectorCorrespondence l).1)ᴴ *
+        F.neighboringOperator
+          (W.sectorCorrespondence j).1 (W.sectorCorrespondence l).1 *
+        F.neighboringSupportInclusion W.factorSupport
+          (W.sectorCorrespondence j).1
+          (W.sectorCorrespondence l).1 :=
+  F.activeRestrictedPhysicalSectorFactorization_neighboringOperator_eq_congruence
+    W.factorSupport j l
+
+/-- The witness exposes positive semidefiniteness of every restricted
+neighboring operator, obtained by the explicit congruence.
+
+Source: arXiv:1606.00608, Appendix C.2, equation `Appetakhetc`, lines
+1435--1450. -/
+theorem neighboringOperator_posSemidef
+    (W : ActivePhysicalCompressionWitness F)
+    (hpos : ∀ k h, (F.neighboringOperator k h).PosSemidef)
+    (j l : Fin W.factorization.sectorCount) :
+    (W.factorization.neighboringOperator j l).PosSemidef :=
+  F.activeRestrictedPhysicalSectorFactorization_neighboringOperator_posSemidef
+    W.factorSupport hpos j l
+
+end ActivePhysicalCompressionWitness
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -469,6 +469,55 @@
     descends through the physical isometry.
 \end{proof}
 
+\begin{theorem}[Neighboring positivity on the canonical active restriction]
+    \label{thm:mpdo_active_physical_sector_neighboring_positivity}
+    \lean{MPOTensor.PhysicalSectorFactorization.FactorActiveSector,
+        MPOTensor.PhysicalSectorFactorization.%
+          activeRestrictedPhysicalSectorFactorization,
+        MPOTensor.PhysicalSectorFactorization.%
+          activeRestrictedPhysicalSectorFactorization_neighboringOperator_eq_congruence,
+        MPOTensor.PhysicalSectorFactorization.%
+          activeRestrictedPhysicalSectorFactorization_neighboringOperator_posSemidef,
+        MPOTensor.PhysicalSectorFactorization.ActivePhysicalCompressionWitness,
+        MPOTensor.PhysicalSectorFactorization.%
+          ActivePhysicalCompressionWitness.factorizationForRestrictionData}
+    \leanok
+    \uses{thm:mpdo_active_physical_sector_restriction}
+    In the setting of
+    Theorem~\ref{thm:mpdo_active_physical_sector_restriction}, the restricted
+    tensor $K_{\mathrm{act}}$ has a physical-sector factorization indexed
+    precisely by the active ambient sectors.  For active sectors $k,h$, put
+    \begin{align}
+        W_{k,h}=V_k^R\otimes V_h^L.
+        \notag
+    \end{align}
+    Its neighboring operator is
+    \begin{align}
+        \eta^{\mathrm{act}}_{k,h}
+        =W_{k,h}^*\eta_{k,h}W_{k,h}.
+        \notag
+    \end{align}
+    In particular, every $\eta^{\mathrm{act}}_{k,h}$ is positive
+    semidefinite.  If the active family is empty, the restricted
+    factorization has no sectors and the assertion is vacuous.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Remove the empty inactive fibers from the dependent direct sum and
+    enumerate the remaining sector subtype by a finite ordinal.  The
+    compressed right factor of $k$ and compressed left factor of $h$ give
+    \begin{align}
+        \sum_\alpha
+        \bigl((V_k^R)^*r_{k,\alpha}V_k^R\bigr)
+        \otimes
+        \bigl((V_h^L)^*l_{h,\alpha}V_h^L\bigr)
+        =W_{k,h}^*\eta_{k,h}W_{k,h}.
+        \notag
+    \end{align}
+    Positive semidefiniteness is preserved by this matrix congruence.
+\end{proof}
+
 % **Partial coverage of CPSV16 Proposition `prop3to4`:** this theorem derives
 % pairwise two-sided supports from `AppKxKy=0` under the standing biCF
 % injectivity and the sectorwise positivity supplied by `AppUkU=rl` and

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -67,10 +67,10 @@ For MPDO renormalization fixed points:
   can be assembled into the outer direct sum, and the BNT SAL construction
   supplies one such family under its projector, closure, inverse, word-span,
   and sectorwise-SAL hypotheses. The active factor supports now give the
-  canonical physical restriction without unused complementary directions.
-  Proposition `prop3to4` remains partial because positivity of the compressed
-  neighboring operators and the final assembly from exactly its five printed
-  blockwise identities have not yet been proved.
+  canonical physical restriction without unused complementary directions,
+  and the compressed neighboring operators remain positive by explicit
+  congruence. Proposition `prop3to4` remains partial because the final assembly
+  from exactly its five printed blockwise identities has not yet been proved.
 - `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records the missing
   coherent positive choice for the inverse-map neighboring operators in
   Appendix C.2. The comparison with the conjugated Hayashi decomposition,

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -176,12 +176,12 @@ factorization, and re-embedding recovers $\mathcal K_x$ exactly.  Thus no
 identity factor in an unused direction and no complementary zero summand is
 introduced.  This includes the case in which the active family is empty.
 
-The remaining local obligation is to identify every neighboring operator of
-this compressed factorization with the explicit congruence of the ambient
-operator from \texttt{Appetakhetc}.  Its positive semidefiniteness must then be
-deduced from congruence.  Until that step is supplied, the supported positive
-commuting bond required below is not yet available from the compressed
-factorization.
+Every neighboring operator of this compressed factorization is now identified
+with the explicit congruence of the corresponding ambient operator from
+\texttt{Appetakhetc}.  Positive semidefiniteness follows from congruence.
+Consequently the canonical restriction has a positive physical-sector
+factorization indexed precisely by the active ambient sectors, including the
+vacuous empty-family case.
 
 The final printed proof of Proposition~\texttt{prop3to4} uses projector
 relations obtained earlier rather than deriving them in its last step.  The
@@ -235,10 +235,9 @@ and a positive physical-sector factorization on each restricted space supplies
 supported positive commuting bonds with exact periodic products.  The
 canonical restriction and its exact sectorwise factorization have now been
 derived from \texttt{AppUkU=rl}, with inactive factor directions removed
-without a minimality hypothesis.  The remaining source-faithful local
-obligation is the explicit congruence formula transporting
-\texttt{Appetakhetc} to this restriction, together with the resulting
-positivity.  This must then be combined with
+without a minimality hypothesis.  The neighboring operators are the explicit
+congruences prescribed by \texttt{Appetakhetc}, and hence remain positive
+semidefinite.  This active compression must now be combined with
 \texttt{AppKxKy=0}, \texttt{Apptralktrrk}, and \texttt{AppPsiPhi}, with
 common copy weights retained from the preceding Case~II argument.
 Proposition~\texttt{prop3to4} should therefore not yet be classified as

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -84,7 +84,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | — | L188 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L601 `tenkz` → `C-policy+C-record` | L605, 611, 616 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L650 `tenkz` → `C-policy+C-record` | L654, 660, 665 `tenkz` → `C-record+R-record` |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |


### PR DESCRIPTION
## Mathematical content

For a physical-sector factorization, this change restricts every sector to its active left and right factor supports. For ambient sectors `k,h`, the resulting neighboring operator is proved to be the exact congruence

`(V_k^R ⊗ V_h^L)ᴴ η_{k,h} (V_k^R ⊗ V_h^L)`.

Consequently positive semidefiniteness passes to every pair of restricted sectors. The construction removes all inactive empty fibers, including the case in which the active family itself is empty; it introduces no complementary summand or identity factor.

The packaged `ActivePhysicalCompressionWitness` exposes the canonical physical-support projection and restriction datum, the factorization indexed precisely by active ambient sectors, the sector correspondence, the exact congruence, and neighboring positivity. Its `factorizationForRestrictionData` has the precise tensor type required by the subsequent physical-support product-transport theorem.

## Source

CPSV16, arXiv:1606.00608, Appendix C.2, equations `Appetakhetc` and `etarl`, lines 1435–1450. Positivity is transported only by the explicit matrix congruence; the proof does not invoke SAL, source ZCL, inverse maps, or an ambient bond theorem.

The Blueprint and the existing paper-gap account are updated. The remaining gap is the final assembly of Proposition `prop3to4` from its five printed blockwise identities.

## Verification

- `lake env lean TNLean/MPS/MPDO/PhysicalSectorActiveNeighboring.lean`
- `lake build TNLean.MPS.MPDO.PhysicalSectorActiveNeighboring`
- `lake build TNLean`
- `lake env lean scripts/LintStyle.lean`
- `cd blueprint && leanblueprint checkdecls`
- import-aggregator, reader-facing prose, oversized-file, and TenKZ disposition checks
- proof-integrity scan and kernel axiom inspection
- independent mathematical review: no blockers

Closes #5102.

Parent: #5096.
Depends on merged #5101 / #5105.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and documentation; no runtime, auth, or data-path changes. Mathematical claims are localized to MPDO physical-sector theory with explicit hypotheses.
> 
> **Overview**
> Adds **`PhysicalSectorActiveNeighboring.lean`** (~400 lines) and wires it into the MPDO aggregator. After canonical active physical restriction, neighboring operators on retained supports are proved to equal **W\* η W** with **W = V_k^R ⊗ V_h^L**, and **PosSemidef** is transported by congruence only (no SAL/ZCL).
> 
> The module builds **`activeRestrictedPhysicalSectorFactorization`** (sectors = active ambient sectors only), equivalences that drop inactive fibers, and **`ActivePhysicalCompressionWitness`** packaging restriction data, factorization, sector correspondence, congruence identities, and neighboring PSD.
> 
> **Blueprint** gains Theorem `mpdo_active_physical_sector_neighboring_positivity` (CPSV16 App C.2). **Paper-gap** notes (`cpsv16_gsnnch_sector_decomposition.tex`, README) mark the compressed-neighboring congruence/positivity step **closed**; Proposition `prop3to4` assembly from the five block identities remains open. Minor **TenKZ** disposition line shift in the capstone chapter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e72e478926feeb37fbabf6320d4faf4ac231d0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->