### PR TITLE
feat(Channel/POVM): sharp rank-one Naimark extension

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -41,6 +41,7 @@ import TNLean.Channel.NormalForm
 import TNLean.Channel.OpenSystem
 import TNLean.Channel.OrderedCP
 import TNLean.Channel.POVM
+import TNLean.Channel.POVM.RankOneNeumark
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.PartialTrace
 import TNLean.Channel.PartialTranspose

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -41,7 +41,7 @@ import TNLean.Channel.NormalForm
 import TNLean.Channel.OpenSystem
 import TNLean.Channel.OrderedCP
 import TNLean.Channel.POVM
-import TNLean.Channel.POVM.RankOneNeumark
+import TNLean.Channel.POVM.RankOneNaimark
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.PartialTrace
 import TNLean.Channel.PartialTranspose

--- a/TNLean/Channel/POVM/RankOneNaimark.lean
+++ b/TNLean/Channel/POVM/RankOneNaimark.lean
@@ -8,9 +8,9 @@ import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Channel.POVM
 
 /-!
-# Sharp rank-one Neumark extension (Wolf lines 480--499)
+# Sharp rank-one Naimark extension (Wolf lines 480--499)
 
-This file proves the sharp form of Neumark's theorem for rank-one POVM
+This file proves the sharp rank-one form of Naimark's theorem for POVM
 effects, following Wolf, *Quantum Channels & Operations*, lines 480--499
 of `Notes/WolfNoteTexSource/ch02_representations.tex`.
 
@@ -41,14 +41,14 @@ extension directly, without the tensor-product factor.
   Theorem "Neumark's theorem", lines 480--499][Wolf2012QChannels]
 -/
 
-open scoped Matrix
+open scoped Matrix ComplexOrder
 open Matrix Finset
 
 namespace POVM
 
 variable {d n : ℕ}
 
-section rankOneNeumarkSharp
+section rankOneNaimarkSharp
 
 /-- Given a family `ψᵢ : Fin d → ℂ` of `n` vectors satisfying the
 resolution of identity `∑_i |ψᵢ⟩⟨ψᵢ| = 1_d`, the `n×d` matrix
@@ -72,38 +72,7 @@ private lemma gram_eq_one_of_vecMulVec_sum_eq_one (ψ : Fin n → (Fin d → ℂ
     _ = star (if j = k then (1 : ℂ) else 0) := by rw [h_entry]
     _ = if j = k then (1 : ℂ) else 0 := by split <;> simp
 
-/-- The `n×d` inclusion matrix `J` with `J i j = 1` when `i` is the
-natural embedding of `j` into `Fin n` via `Fin.castLE hd` and `0`
-otherwise.  For `d ≤ n`, `J` is an isometry: `Jᴴ * J = 1_d`. -/
-private lemma inclusion_conjTranspose_mul_self (hd : d ≤ n) :
-    ((Matrix.of fun (i : Fin n) (j : Fin d) =>
-        if i = Fin.castLE hd j then (1 : ℂ) else 0)ᴴ *
-      (Matrix.of fun (i : Fin n) (j : Fin d) =>
-        if i = Fin.castLE hd j then (1 : ℂ) else 0)) = 1 := by
-  ext j k
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
-  by_cases hjk : j = k
-  · subst hjk
-    rw [Finset.sum_eq_single (Fin.castLE hd j)]
-    · simp
-    · intro i _ hi
-      have hterm : (if i = Fin.castLE hd j then (1 : ℂ) else 0) = 0 := by
-        simp [hi]
-      simp [hterm]
-    · intro h; exact absurd (Finset.mem_univ _) h
-  · have hcast_ne : Fin.castLE hd j ≠ Fin.castLE hd k :=
-      fun h ↦ hjk ((Fin.castLE_injective hd) h)
-    rw [if_neg hjk]
-    apply Finset.sum_eq_zero
-    intro i _
-    simp only [Matrix.of_apply]
-    by_cases hij : i = Fin.castLE hd j
-    · subst hij; rw [if_neg hcast_ne]; simp
-    · by_cases hik : i = Fin.castLE hd k
-      · subst hik; rw [if_neg (Ne.symm hcast_ne)]; simp
-      · simp [hij, hik]
-
-/-- **Sharp rank-one Neumark extension** (Wolf, *Quantum Channels & Operations*,
+/-- **Sharp rank-one Naimark extension** (Wolf, *Quantum Channels & Operations*,
 Theorem "Neumark's theorem", lines 480--499).
 
 Given `n` vectors `ψᵢ : Fin d → ℂ` (`i = 1,…,n`) forming a rank-one resolution
@@ -128,39 +97,37 @@ theorem exists_orthonormal_basis_restriction (ψ : Fin n → (Fin d → ℂ))
     dsimp [Ψ]
     exact gram_eq_one_of_vecMulVec_sum_eq_one ψ h_sum
   have hinj : Function.Injective (Matrix.mulVecLin Ψ) := by
-    intro x y hxy
-    have hxy' : Ψ.mulVec x = Ψ.mulVec y := hxy
-    have h1 : (Ψᴴ * Ψ).mulVec x = (Ψᴴ * Ψ).mulVec y := by
-      rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
-      exact congrArg _ hxy'
-    simpa [hΨGram] using h1
+    rw [← LinearMap.ker_eq_bot,
+      ← Matrix.ker_mulVecLin_conjTranspose_mul_self Ψ, hΨGram]
+    simp
   have hd : d ≤ n := by
     simpa using LinearMap.finrank_le_finrank_of_injective hinj
   let J : Matrix (Fin n) (Fin d) ℂ :=
-    Matrix.of fun i j => if i = Fin.castLE hd j then (1 : ℂ) else 0
-  have hJGram : Jᴴ * J = 1 := inclusion_conjTranspose_mul_self hd
+    (1 : Matrix (Fin n) (Fin n) ℂ).submatrix id (Fin.castLE hd)
+  have hJGram : Jᴴ * J = 1 := by
+    rw [show Jᴴ = (1 : Matrix (Fin n) (Fin n) ℂ).submatrix (Fin.castLE hd) id by
+      simp [J]]
+    change
+      (1 : Matrix (Fin n) (Fin n) ℂ).submatrix (Fin.castLE hd) (Equiv.refl (Fin n)) *
+          (1 : Matrix (Fin n) (Fin n) ℂ).submatrix (Equiv.refl (Fin n)) (Fin.castLE hd) = 1
+    rw [Matrix.submatrix_mul_equiv]
+    simpa only [Matrix.one_mul] using
+      Matrix.submatrix_one (α := ℂ) (Fin.castLE hd) (Fin.castLE_injective hd)
   obtain ⟨U, hU⟩ :=
     Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq Ψ J (hΨGram.trans hJGram.symm)
-  -- hU: Ψ = (U : Matrix (Fin n) (Fin n) ℂ) * J
+  have hUJ :
+      (U : Matrix (Fin n) (Fin n) ℂ) * J =
+        (U : Matrix (Fin n) (Fin n) ℂ).submatrix id (Fin.castLE hd) := by
+    simpa [J] using
+      Matrix.mul_submatrix_one (Equiv.refl (Fin n)) (Fin.castLE hd)
+        (U : Matrix (Fin n) (Fin n) ℂ)
   have h_restrict (i : Fin n) (j : Fin d) :
       (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j := by
-    calc
-      (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j)
-          = (∑ k : Fin n, (U : Matrix (Fin n) (Fin n) ℂ) i k * J k j) := by
-        rw [Finset.sum_eq_single (Fin.castLE hd j)]
-        · simp [J]
-        · intro k _ hk
-          have hJzero : J k j = 0 := by
-            dsimp [J]
-            simp [hk]
-          simp [hJzero]
-        · intro h; exact absurd (Finset.mem_univ _) h
-      _ = ((U : Matrix (Fin n) (Fin n) ℂ) * J) i j := rfl
-      _ = Ψ i j := by rw [hU]
-      _ = ψ i j := rfl
+    simpa [Ψ] using
+      (congrArg (fun M ↦ M i j) (hU.trans hUJ)).symm
   exact ⟨hd, U, h_restrict⟩
 
-end rankOneNeumarkSharp
+end rankOneNaimarkSharp
 
 /-! ### The rank-one POVM corollary -/
 

--- a/TNLean/Channel/POVM/RankOneNaimark.lean
+++ b/TNLean/Channel/POVM/RankOneNaimark.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Data.Fin.SuccPred
 import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Channel.POVM
 
@@ -32,8 +31,9 @@ extension directly, without the tensor-product factor.
 * `exists_orthonormal_basis_restriction` — the sharp rank-one extension:
   from `ψᵢ` on `ℂᵈ` with `∑ |ψᵢ⟩⟨ψᵢ| = 1`, derive `d ≤ n` and obtain a
   unitary `U ∈ U(n)` whose rows restrict to `ψᵢ`.
-* `of_rank_one_povm` — the rank-one POVM corollary: given a `POVM d n` with
-  an explicit decomposition `E_i = |ψᵢ⟩⟨ψᵢ|`, apply the sharp extension.
+* `exists_orthonormal_basis_restriction_of_rank_one` — the rank-one POVM
+  corollary: given a `POVM d n` with an explicit decomposition
+  `E_i = |ψᵢ⟩⟨ψᵢ|`, apply the sharp extension.
 
 ## References
 
@@ -142,7 +142,8 @@ hypotheses of the sharp theorem.  Unlike `exists_naimark_dilation`,
 whose ambient Hilbert space is `ℂ^D ⊗ ℂ^n` (dimension `D·n`), this
 corollary gives the source's assertion of an `n`-dimensional ambient
 space under the rank-one hypothesis. -/
-theorem of_rank_one_povm (E : POVM d n) (ψ : Fin n → (Fin d → ℂ))
+theorem exists_orthonormal_basis_restriction_of_rank_one
+    (E : POVM d n) (ψ : Fin n → (Fin d → ℂ))
     (h_ops : ∀ i, E.ops i = Matrix.vecMulVec (ψ i) (star (ψ i))) :
     ∃ (hd : d ≤ n) (U : Matrix.unitaryGroup (Fin n) ℂ),
       (∀ i j, (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j) := by

--- a/TNLean/Channel/POVM/RankOneNeumark.lean
+++ b/TNLean/Channel/POVM/RankOneNeumark.lean
@@ -68,7 +68,9 @@ private lemma gram_eq_one_of_vecMulVec_sum_eq_one (ψ : Fin n → (Fin d → ℂ
         = (∑ i : Fin n, star (ψ i j * star (ψ i k))) := by
       refine Finset.sum_congr rfl fun i _ => ?_
       rw [star_mul, star_star, mul_comm]
-    _ = star (∑ i : Fin n, ψ i j * star (ψ i k)) := by rw [map_sum]
+    _ = star (∑ i : Fin n, ψ i j * star (ψ i k)) := by
+      simpa using ((starRingEnd ℂ).map_sum (Finset.univ : Finset (Fin n))
+        (fun i ↦ ψ i j * star (ψ i k))).symm
     _ = star (if j = k then (1 : ℂ) else 0) := by rw [h_entry]
     _ = if j = k then (1 : ℂ) else 0 := by split <;> simp
 
@@ -92,7 +94,7 @@ private lemma inclusion_conjTranspose_mul_self (hd : d ≤ n) :
       simp [hterm]
     · intro h; exact absurd (Finset.mem_univ _) h
   · have hcast_ne : Fin.castLE hd j ≠ Fin.castLE hd k :=
-      mt (Fin.castLE_injective hd) hjk
+      fun h ↦ hjk ((Fin.castLE_injective hd) h)
     refine Finset.sum_eq_zero fun i _ => ?_
     by_cases hij : i = Fin.castLE hd j
     · subst hij; rw [if_neg hcast_ne]; simp

--- a/TNLean/Channel/POVM/RankOneNeumark.lean
+++ b/TNLean/Channel/POVM/RankOneNeumark.lean
@@ -33,8 +33,8 @@ extension directly, without the tensor-product factor.
 * `exists_orthonormal_basis_restriction` — the sharp rank-one extension:
   from `ψᵢ` on `ℂᵈ` with `d ≤ n` and `∑ |ψᵢ⟩⟨ψᵢ| = 1`, obtain a unitary
   `U ∈ U(n)` whose rows restrict to `ψᵢ`.
-* `of_rank_one_povm` — bridge lemma: given a `POVM d n` with an explicit
-  rank-one decomposition `E_i = |ψᵢ⟩⟨ψᵢ|`, apply the sharp extension.
+* `of_rank_one_povm` — the rank-one POVM corollary: given a `POVM d n` with
+  an explicit decomposition `E_i = |ψᵢ⟩⟨ψᵢ|`, apply the sharp extension.
 
 ## References
 
@@ -56,8 +56,8 @@ resolution of identity `∑_i |ψᵢ⟩⟨ψᵢ| = 1_d`, the `n×d` matrix
 `Ψ i j := ψ i j` satisfies `Ψᴴ * Ψ = 1_d`. -/
 private lemma gram_eq_one_of_vecMulVec_sum_eq_one (ψ : Fin n → (Fin d → ℂ))
     (h_sum : ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i)) = 1) :
-    ((fun (i : Fin n) (j : Fin d) => ψ i j)ᴴ *
-      (fun (i : Fin n) (j : Fin d) => ψ i j)) = 1 := by
+    ((Matrix.of fun (i : Fin n) (j : Fin d) => ψ i j)ᴴ *
+      (Matrix.of fun (i : Fin n) (j : Fin d) => ψ i j)) = 1 := by
   ext j k
   simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
   have h_entry := congrArg (fun M : Matrix (Fin d) (Fin d) ℂ => M j k) h_sum
@@ -76,8 +76,10 @@ private lemma gram_eq_one_of_vecMulVec_sum_eq_one (ψ : Fin n → (Fin d → ℂ
 natural embedding of `j` into `Fin n` via `Fin.castLE hd` and `0`
 otherwise.  For `d ≤ n`, `J` is an isometry: `Jᴴ * J = 1_d`. -/
 private lemma inclusion_conjTranspose_mul_self (hd : d ≤ n) :
-    ((fun (i : Fin n) (j : Fin d) => if i = Fin.castLE hd j then (1 : ℂ) else 0)ᴴ *
-      (fun (i : Fin n) (j : Fin d) => if i = Fin.castLE hd j then (1 : ℂ) else 0)) = 1 := by
+    ((Matrix.of fun (i : Fin n) (j : Fin d) =>
+        if i = Fin.castLE hd j then (1 : ℂ) else 0)ᴴ *
+      (Matrix.of fun (i : Fin n) (j : Fin d) =>
+        if i = Fin.castLE hd j then (1 : ℂ) else 0)) = 1 := by
   ext j k
   simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
   by_cases hjk : j = k
@@ -120,12 +122,12 @@ theorem exists_orthonormal_basis_restriction (ψ : Fin n → (Fin d → ℂ))
     (h_sum : ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i)) = 1) :
     ∃ (U : Matrix.unitaryGroup (Fin n) ℂ),
       (∀ i j, (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j) := by
-  let Ψ : Matrix (Fin n) (Fin d) ℂ := fun i j => ψ i j
+  let Ψ : Matrix (Fin n) (Fin d) ℂ := Matrix.of fun i j => ψ i j
   have hΨGram : Ψᴴ * Ψ = 1 := by
     dsimp [Ψ]
     exact gram_eq_one_of_vecMulVec_sum_eq_one ψ h_sum
   let J : Matrix (Fin n) (Fin d) ℂ :=
-    fun i j => if i = Fin.castLE hd j then (1 : ℂ) else 0
+    Matrix.of fun i j => if i = Fin.castLE hd j then (1 : ℂ) else 0
   have hJGram : Jᴴ * J = 1 := inclusion_conjTranspose_mul_self hd
   obtain ⟨U, hU⟩ :=
     Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq Ψ J (hΨGram.trans hJGram.symm)
@@ -150,16 +152,16 @@ theorem exists_orthonormal_basis_restriction (ψ : Fin n → (Fin d → ℂ))
 
 end rankOneNeumarkSharp
 
-/-! ### Bridge lemma: rank-one POVM to sharp extension -/
+/-! ### The rank-one POVM corollary -/
 
-/-- **Bridge lemma**: start from a `POVM d n` whose effects are explicitly
-given as rank-one `|ψᵢ⟩⟨ψᵢ|`.  The POVM axioms guarantee the resolution
+/-- **Rank-one POVM corollary**: start from a `POVM d n` whose effects are
+explicitly given as rank-one `|ψᵢ⟩⟨ψᵢ|`.  The POVM axioms guarantee the resolution
 `∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1`, so `exists_orthonormal_basis_restriction` applies and
 yields the sharp `n`-dimensional orthonormal-basis extension recorded in
 Wolf lines 480--499.
 
-This translates from the general POVM structure to the vector-level
-hypotheses required by the sharp theorem.  Unlike `exists_naimark_dilation`,
+This specializes the general POVM structure to the vector-level
+hypotheses of the sharp theorem.  Unlike `exists_naimark_dilation`,
 whose ambient Hilbert space is `ℂ^D ⊗ ℂ^n` (dimension `D·n`), this
 corollary gives the source's assertion of an `n`-dimensional ambient
 space under the rank-one hypothesis. -/

--- a/TNLean/Channel/POVM/RankOneNeumark.lean
+++ b/TNLean/Channel/POVM/RankOneNeumark.lean
@@ -1,0 +1,180 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Fin.SuccPred
+import TNLean.Algebra.MatrixGramUnitary
+import TNLean.Channel.POVM
+
+/-!
+# Sharp rank-one Neumark extension (Wolf lines 480--499)
+
+This file proves the sharp form of Neumark's theorem for rank-one POVM
+effects, following Wolf, *Quantum Channels & Operations*, lines 480--499
+of `Notes/WolfNoteTexSource/ch02_representations.tex`.
+
+Given `n` vectors `ψᵢ ∈ ℂᵈ` with the rank-one resolution of the identity
+`∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1_d` and the dimension condition `d ≤ n` (so that `ℂᵈ`
+is a subspace of `ℂⁿ`), there exists an orthonormal basis `{φᵢ}ᵢ₌₁ⁿ`
+of `ℂⁿ` such that each `ψᵢ` is the restriction of `φᵢ` to the first `d`
+coordinates.
+
+## Ambient dimension
+
+`POVM.exists_naimark_dilation` dilates a general POVM onto
+`ℂ^D ⊗ ℂ^n` (dimension `D·n`).  The source asserts the sharper
+`n`-dimensional ambient space for rank-one effects.  The present theorem
+(`exists_orthonormal_basis_restriction`) provides the `n × n` unitary
+extension directly, without the tensor-product factor.
+
+## Main results
+
+* `exists_orthonormal_basis_restriction` — the sharp rank-one extension:
+  from `ψᵢ` on `ℂᵈ` with `d ≤ n` and `∑ |ψᵢ⟩⟨ψᵢ| = 1`, obtain a unitary
+  `U ∈ U(n)` whose rows restrict to `ψᵢ`.
+* `of_rank_one_povm` — bridge lemma: given a `POVM d n` with an explicit
+  rank-one decomposition `E_i = |ψᵢ⟩⟨ψᵢ|`, apply the sharp extension.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*,
+  Theorem "Neumark's theorem", lines 480--499][Wolf2012QChannels]
+-/
+
+open scoped Matrix
+open Matrix Finset
+
+namespace POVM
+
+variable {d n : ℕ}
+
+section rankOneNeumarkSharp
+
+/-- Given a family `ψᵢ : Fin d → ℂ` of `n` vectors satisfying the
+resolution of identity `∑_i |ψᵢ⟩⟨ψᵢ| = 1_d`, the `n×d` matrix
+`Ψ i j := ψ i j` satisfies `Ψᴴ * Ψ = 1_d`. -/
+private lemma gram_eq_one_of_vecMulVec_sum_eq_one (ψ : Fin n → (Fin d → ℂ))
+    (h_sum : ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i)) = 1) :
+    ((fun (i : Fin n) (j : Fin d) => ψ i j)ᴴ *
+      (fun (i : Fin n) (j : Fin d) => ψ i j)) = 1 := by
+  ext j k
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
+  have h_entry := congrArg (fun M : Matrix (Fin d) (Fin d) ℂ => M j k) h_sum
+  simp only [Matrix.sum_apply, Matrix.vecMulVec_apply, Matrix.one_apply,
+    Pi.star_apply] at h_entry
+  calc
+    (∑ i : Fin n, star (ψ i j) * ψ i k)
+        = (∑ i : Fin n, star (ψ i j * star (ψ i k))) := by
+      refine Finset.sum_congr rfl fun i _ => ?_
+      rw [star_mul, star_star, mul_comm]
+    _ = star (∑ i : Fin n, ψ i j * star (ψ i k)) := by rw [map_sum]
+    _ = star (if j = k then (1 : ℂ) else 0) := by rw [h_entry]
+    _ = if j = k then (1 : ℂ) else 0 := by split <;> simp
+
+/-- The `n×d` inclusion matrix `J` with `J i j = 1` when `i` is the
+natural embedding of `j` into `Fin n` via `Fin.castLE hd` and `0`
+otherwise.  For `d ≤ n`, `J` is an isometry: `Jᴴ * J = 1_d`. -/
+private lemma inclusion_conjTranspose_mul_self (hd : d ≤ n) :
+    ((fun (i : Fin n) (j : Fin d) => if i = Fin.castLE hd j then (1 : ℂ) else 0)ᴴ *
+      (fun (i : Fin n) (j : Fin d) => if i = Fin.castLE hd j then (1 : ℂ) else 0)) = 1 := by
+  ext j k
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
+  by_cases hjk : j = k
+  · subst hjk
+    rw [Finset.sum_eq_single (Fin.castLE hd j)]
+    · simp
+    · intro i _ hi
+      have hterm : (if i = Fin.castLE hd j then (1 : ℂ) else 0) = 0 := by
+        simp [hi]
+      simp [hterm]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  · have hcast_ne : Fin.castLE hd j ≠ Fin.castLE hd k :=
+      mt (Fin.castLE_injective hd) hjk
+    refine Finset.sum_eq_zero fun i _ => ?_
+    by_cases hij : i = Fin.castLE hd j
+    · subst hij; rw [if_neg hcast_ne]; simp
+    · by_cases hik : i = Fin.castLE hd k
+      · subst hik; rw [if_neg (Ne.symm hcast_ne)]; simp
+      · simp [hij, hik]
+
+/-- **Sharp rank-one Neumark extension** (Wolf, *Quantum Channels & Operations*,
+Theorem "Neumark's theorem", lines 480--499).
+
+Given `n` vectors `ψᵢ : Fin d → ℂ` (`i = 1,…,n`) forming a rank-one resolution
+of the identity `∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1_d` on `ℂᵈ` and the dimension condition
+`d ≤ n` (so that `ℂᵈ` is a subspace of `ℂⁿ`), there exists a unitary
+`U ∈ U(n)` such that each `ψᵢ` is the restriction of the `i`-th row of `U`
+to the first `d` coordinates.
+
+In coordinates: `ψ i j = (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j)`.
+The rows `φᵢ j := U i j` form an orthonormal basis of `ℂⁿ` (because `U`
+is unitary) and each `ψᵢ` is the restriction of `φᵢ` to the embedded
+subspace `ℂᵈ ⊂ ℂⁿ`.
+
+The ambient dimension of this extension is `n` (the number of outcomes),
+in contrast to `POVM.exists_naimark_dilation` which constructs an isometry
+onto `ℂ^D ⊗ ℂ^n` of dimension `D·n`. -/
+theorem exists_orthonormal_basis_restriction (ψ : Fin n → (Fin d → ℂ))
+    (hd : d ≤ n)
+    (h_sum : ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i)) = 1) :
+    ∃ (U : Matrix.unitaryGroup (Fin n) ℂ),
+      (∀ i j, (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j) := by
+  let Ψ : Matrix (Fin n) (Fin d) ℂ := fun i j => ψ i j
+  have hΨGram : Ψᴴ * Ψ = 1 := by
+    dsimp [Ψ]
+    exact gram_eq_one_of_vecMulVec_sum_eq_one ψ h_sum
+  let J : Matrix (Fin n) (Fin d) ℂ :=
+    fun i j => if i = Fin.castLE hd j then (1 : ℂ) else 0
+  have hJGram : Jᴴ * J = 1 := inclusion_conjTranspose_mul_self hd
+  obtain ⟨U, hU⟩ :=
+    Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq Ψ J (hΨGram.trans hJGram.symm)
+  -- hU: Ψ = (U : Matrix (Fin n) (Fin n) ℂ) * J
+  have h_restrict (i : Fin n) (j : Fin d) :
+      (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j := by
+    calc
+      (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j)
+          = (∑ k : Fin n, (U : Matrix (Fin n) (Fin n) ℂ) i k * J k j) := by
+        rw [Finset.sum_eq_single (Fin.castLE hd j)]
+        · simp [J]
+        · intro k _ hk
+          have hJzero : J k j = 0 := by
+            dsimp [J]
+            simp [hk]
+          simp [hJzero]
+        · intro h; exact absurd (Finset.mem_univ _) h
+      _ = ((U : Matrix (Fin n) (Fin n) ℂ) * J) i j := rfl
+      _ = Ψ i j := by rw [hU]
+      _ = ψ i j := rfl
+  exact ⟨U, h_restrict⟩
+
+end rankOneNeumarkSharp
+
+/-! ### Bridge lemma: rank-one POVM to sharp extension -/
+
+/-- **Bridge lemma**: start from a `POVM d n` whose effects are explicitly
+given as rank-one `|ψᵢ⟩⟨ψᵢ|`.  The POVM axioms guarantee the resolution
+`∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1`, so `exists_orthonormal_basis_restriction` applies and
+yields the sharp `n`-dimensional orthonormal-basis extension recorded in
+Wolf lines 480--499.
+
+This translates from the general POVM structure to the vector-level
+hypotheses required by the sharp theorem.  Unlike `exists_naimark_dilation`,
+whose ambient Hilbert space is `ℂ^D ⊗ ℂ^n` (dimension `D·n`), this
+corollary gives the source's assertion of an `n`-dimensional ambient
+space under the rank-one hypothesis. -/
+theorem of_rank_one_povm (E : POVM d n) (ψ : Fin n → (Fin d → ℂ))
+    (hd : d ≤ n)
+    (h_ops : ∀ i, E.ops i = Matrix.vecMulVec (ψ i) (star (ψ i))) :
+    ∃ (U : Matrix.unitaryGroup (Fin n) ℂ),
+      (∀ i j, (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j) := by
+  have h_sum : ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i)) = 1 := by
+    calc
+      ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i))
+          = ∑ i : Fin n, E.ops i := by
+        refine Finset.sum_congr rfl fun i _ => ?_
+        rw [h_ops i]
+      _ = 1 := E.sum_eq_one
+  exact exists_orthonormal_basis_restriction ψ hd h_sum
+
+end POVM

--- a/TNLean/Channel/POVM/RankOneNeumark.lean
+++ b/TNLean/Channel/POVM/RankOneNeumark.lean
@@ -15,10 +15,9 @@ effects, following Wolf, *Quantum Channels & Operations*, lines 480--499
 of `Notes/WolfNoteTexSource/ch02_representations.tex`.
 
 Given `n` vectors `ψᵢ ∈ ℂᵈ` with the rank-one resolution of the identity
-`∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1_d` and the dimension condition `d ≤ n` (so that `ℂᵈ`
-is a subspace of `ℂⁿ`), there exists an orthonormal basis `{φᵢ}ᵢ₌₁ⁿ`
-of `ℂⁿ` such that each `ψᵢ` is the restriction of `φᵢ` to the first `d`
-coordinates.
+`∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1_d`, the resolution forces `d ≤ n`, and there exists an
+orthonormal basis `{φᵢ}ᵢ₌₁ⁿ` of `ℂⁿ` such that each `ψᵢ` is the restriction
+of `φᵢ` to the first `d` coordinates.
 
 ## Ambient dimension
 
@@ -31,8 +30,8 @@ extension directly, without the tensor-product factor.
 ## Main results
 
 * `exists_orthonormal_basis_restriction` — the sharp rank-one extension:
-  from `ψᵢ` on `ℂᵈ` with `d ≤ n` and `∑ |ψᵢ⟩⟨ψᵢ| = 1`, obtain a unitary
-  `U ∈ U(n)` whose rows restrict to `ψᵢ`.
+  from `ψᵢ` on `ℂᵈ` with `∑ |ψᵢ⟩⟨ψᵢ| = 1`, derive `d ≤ n` and obtain a
+  unitary `U ∈ U(n)` whose rows restrict to `ψᵢ`.
 * `of_rank_one_povm` — the rank-one POVM corollary: given a `POVM d n` with
   an explicit decomposition `E_i = |ψᵢ⟩⟨ψᵢ|`, apply the sharp extension.
 
@@ -69,8 +68,7 @@ private lemma gram_eq_one_of_vecMulVec_sum_eq_one (ψ : Fin n → (Fin d → ℂ
       refine Finset.sum_congr rfl fun i _ => ?_
       rw [star_mul, star_star, mul_comm]
     _ = star (∑ i : Fin n, ψ i j * star (ψ i k)) := by
-      simpa using ((starRingEnd ℂ).map_sum (Finset.univ : Finset (Fin n))
-        (fun i ↦ ψ i j * star (ψ i k))).symm
+      simp
     _ = star (if j = k then (1 : ℂ) else 0) := by rw [h_entry]
     _ = if j = k then (1 : ℂ) else 0 := by split <;> simp
 
@@ -95,7 +93,10 @@ private lemma inclusion_conjTranspose_mul_self (hd : d ≤ n) :
     · intro h; exact absurd (Finset.mem_univ _) h
   · have hcast_ne : Fin.castLE hd j ≠ Fin.castLE hd k :=
       fun h ↦ hjk ((Fin.castLE_injective hd) h)
-    refine Finset.sum_eq_zero fun i _ => ?_
+    rw [if_neg hjk]
+    apply Finset.sum_eq_zero
+    intro i _
+    simp only [Matrix.of_apply]
     by_cases hij : i = Fin.castLE hd j
     · subst hij; rw [if_neg hcast_ne]; simp
     · by_cases hik : i = Fin.castLE hd k
@@ -106,10 +107,9 @@ private lemma inclusion_conjTranspose_mul_self (hd : d ≤ n) :
 Theorem "Neumark's theorem", lines 480--499).
 
 Given `n` vectors `ψᵢ : Fin d → ℂ` (`i = 1,…,n`) forming a rank-one resolution
-of the identity `∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1_d` on `ℂᵈ` and the dimension condition
-`d ≤ n` (so that `ℂᵈ` is a subspace of `ℂⁿ`), there exists a unitary
-`U ∈ U(n)` such that each `ψᵢ` is the restriction of the `i`-th row of `U`
-to the first `d` coordinates.
+of the identity `∑ᵢ |ψᵢ⟩⟨ψᵢ| = 1_d` on `ℂᵈ`, one has `d ≤ n`, and there
+exists a unitary `U ∈ U(n)` such that each `ψᵢ` is the restriction of the
+`i`-th row of `U` to the first `d` coordinates.
 
 In coordinates: `ψ i j = (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j)`.
 The rows `φᵢ j := U i j` form an orthonormal basis of `ℂⁿ` (because `U`
@@ -120,14 +120,22 @@ The ambient dimension of this extension is `n` (the number of outcomes),
 in contrast to `POVM.exists_naimark_dilation` which constructs an isometry
 onto `ℂ^D ⊗ ℂ^n` of dimension `D·n`. -/
 theorem exists_orthonormal_basis_restriction (ψ : Fin n → (Fin d → ℂ))
-    (hd : d ≤ n)
     (h_sum : ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i)) = 1) :
-    ∃ (U : Matrix.unitaryGroup (Fin n) ℂ),
+    ∃ (hd : d ≤ n) (U : Matrix.unitaryGroup (Fin n) ℂ),
       (∀ i j, (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j) := by
   let Ψ : Matrix (Fin n) (Fin d) ℂ := Matrix.of fun i j => ψ i j
   have hΨGram : Ψᴴ * Ψ = 1 := by
     dsimp [Ψ]
     exact gram_eq_one_of_vecMulVec_sum_eq_one ψ h_sum
+  have hinj : Function.Injective (Matrix.mulVecLin Ψ) := by
+    intro x y hxy
+    have hxy' : Ψ.mulVec x = Ψ.mulVec y := hxy
+    have h1 : (Ψᴴ * Ψ).mulVec x = (Ψᴴ * Ψ).mulVec y := by
+      rw [← Matrix.mulVec_mulVec, ← Matrix.mulVec_mulVec]
+      exact congrArg _ hxy'
+    simpa [hΨGram] using h1
+  have hd : d ≤ n := by
+    simpa using LinearMap.finrank_le_finrank_of_injective hinj
   let J : Matrix (Fin n) (Fin d) ℂ :=
     Matrix.of fun i j => if i = Fin.castLE hd j then (1 : ℂ) else 0
   have hJGram : Jᴴ * J = 1 := inclusion_conjTranspose_mul_self hd
@@ -150,7 +158,7 @@ theorem exists_orthonormal_basis_restriction (ψ : Fin n → (Fin d → ℂ))
       _ = ((U : Matrix (Fin n) (Fin n) ℂ) * J) i j := rfl
       _ = Ψ i j := by rw [hU]
       _ = ψ i j := rfl
-  exact ⟨U, h_restrict⟩
+  exact ⟨hd, U, h_restrict⟩
 
 end rankOneNeumarkSharp
 
@@ -168,9 +176,8 @@ whose ambient Hilbert space is `ℂ^D ⊗ ℂ^n` (dimension `D·n`), this
 corollary gives the source's assertion of an `n`-dimensional ambient
 space under the rank-one hypothesis. -/
 theorem of_rank_one_povm (E : POVM d n) (ψ : Fin n → (Fin d → ℂ))
-    (hd : d ≤ n)
     (h_ops : ∀ i, E.ops i = Matrix.vecMulVec (ψ i) (star (ψ i))) :
-    ∃ (U : Matrix.unitaryGroup (Fin n) ℂ),
+    ∃ (hd : d ≤ n) (U : Matrix.unitaryGroup (Fin n) ℂ),
       (∀ i j, (U : Matrix (Fin n) (Fin n) ℂ) i (Fin.castLE hd j) = ψ i j) := by
   have h_sum : ∑ i : Fin n, Matrix.vecMulVec (ψ i) (star (ψ i)) = 1 := by
     calc
@@ -179,6 +186,6 @@ theorem of_rank_one_povm (E : POVM d n) (ψ : Fin n → (Fin d → ℂ))
         refine Finset.sum_congr rfl fun i _ => ?_
         rw [h_ops i]
       _ = 1 := E.sum_eq_one
-  exact exists_orthonormal_basis_restriction ψ hd h_sum
+  exact exists_orthonormal_basis_restriction ψ h_sum
 
 end POVM

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -15,7 +15,7 @@ import TNLean.Channel.OrderedCP
 import TNLean.Channel.RadonNikodym
 import TNLean.Channel.OpenSystem
 import TNLean.Channel.POVM
-import TNLean.Channel.POVM.RankOneNeumark
+import TNLean.Channel.POVM.RankOneNaimark
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WolfProps
@@ -230,7 +230,7 @@ project import.
 | POVM | `POVM.lean` | `POVM` |
 | Naimark isometry | `POVM.lean` | `POVM.naimarkIsometry` |
 | Naimark projector | `POVM.lean` | `POVM.naimarkProjection` |
-| Rank-one Neumark | `POVM/RankOneNeumark.lean` | `POVM.exists_orthonormal_basis_restriction` |
+| Rank-one Naimark | `POVM/RankOneNaimark.lean` | `POVM.exists_orthonormal_basis_restriction` |
 | Quantum instrument | `POVM.lean` | `Instrument` |
 | Transfer matrix | `TransferMatrix.lean` | `transferMatrix` |
 | Unitary conjugation | `TransferMatrix.lean` | `unitaryConjLM` |

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -124,7 +124,8 @@ project import.
       through the canonical Naimark isometry via a dilation isometry ✓
   - `POVM.exists_orthonormal_basis_restriction` — a rank-one resolution
     forces `d ≤ n` and extends to an orthonormal basis of `ℂⁿ` ✓
-  - `POVM.of_rank_one_povm` — sharp rank-one specialization for a POVM ✓
+  - `POVM.exists_orthonormal_basis_restriction_of_rank_one` — sharp
+    rank-one specialization for a POVM ✓
   - `POVM.ofPSDResolutionOfIdentity` — converse construction: PSD resolution
     of identity on a dilation pulls back to a POVM ✓
   - `Instrument` — quantum-instrument structure + `total_isChannel`,

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -15,6 +15,7 @@ import TNLean.Channel.OrderedCP
 import TNLean.Channel.RadonNikodym
 import TNLean.Channel.OpenSystem
 import TNLean.Channel.POVM
+import TNLean.Channel.POVM.RankOneNeumark
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WolfProps
@@ -121,6 +122,9 @@ project import.
   - `POVM.exists_isometry_mul_naimarkIsometry_of_recovery`
     — concrete uniqueness: any dilation using the canonical projectors factors
       through the canonical Naimark isometry via a dilation isometry ✓
+  - `POVM.exists_orthonormal_basis_restriction` — a rank-one resolution
+    forces `d ≤ n` and extends to an orthonormal basis of `ℂⁿ` ✓
+  - `POVM.of_rank_one_povm` — sharp rank-one specialization for a POVM ✓
   - `POVM.ofPSDResolutionOfIdentity` — converse construction: PSD resolution
     of identity on a dilation pulls back to a POVM ✓
   - `Instrument` — quantum-instrument structure + `total_isChannel`,
@@ -226,6 +230,7 @@ project import.
 | POVM | `POVM.lean` | `POVM` |
 | Naimark isometry | `POVM.lean` | `POVM.naimarkIsometry` |
 | Naimark projector | `POVM.lean` | `POVM.naimarkProjection` |
+| Rank-one Neumark | `POVM/RankOneNeumark.lean` | `POVM.exists_orthonormal_basis_restriction` |
 | Quantum instrument | `POVM.lean` | `Instrument` |
 | Transfer matrix | `TransferMatrix.lean` | `transferMatrix` |
 | Unitary conjugation | `TransferMatrix.lean` | `unitaryConjLM` |

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -746,7 +746,7 @@ a common dilation space.
 \begin{theorem}[Sharp rank-one Naimark extension]
     \label{thm:sharp_rank_one_naimark}
     \lean{POVM.exists_orthonormal_basis_restriction,
-        POVM.of_rank_one_povm}
+        POVM.exists_orthonormal_basis_restriction_of_rank_one}
     \leanok
     \uses{def:povm}
     Let $\{\ketbra{\psi_i}{\psi_i}\}_{i=0}^{n-1}$ be a rank-one POVM on

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -770,7 +770,7 @@ a common dilation space.
 
 \begin{proof}
     \leanok
-    \uses{lem:exists_unitary_mul_eq_of_gram_eq}
+    \uses{def:povm, lem:exists_unitary_mul_eq_of_gram_eq}
     Assemble the $n\times d$ matrix $\Psi_{i,j}:=\psi_i(j)$.  From the
     resolution of identity one obtains $\Psi^\dagger\Psi=\Id_d$.
     Thus $\Psi$ is an isometry, which implies $d\le n$.

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -743,6 +743,45 @@ a common dilation space.
     $V=W\sum_iM_i\otimes\ket{i}=WV_0$.
 \end{proof}
 
+\begin{theorem}[Sharp rank-one Neumark extension]
+    \label{thm:sharp_rank_one_neumark}
+    \lean{POVM.exists_orthonormal_basis_restriction,
+        POVM.of_rank_one_povm}
+    \uses{def:povm, thm:exists_naimark_dilation}
+    Let $\{\ketbra{\psi_i}{\psi_i}\}_{i=0}^{n-1}$ be a rank-one POVM on
+    $\C^d$ with outcomes $n$ and $d\le n$, i.e.\
+    $\sum_i\ketbra{\psi_i}{\psi_i}=\Id_d$.  Then there exists an
+    orthonormal basis $\{\phi_i\}_{i=0}^{n-1}$ of $\C^n$ such that each
+    $\psi_i$ is the restriction of $\phi_i$ to the first $d$ coordinates.
+    Concretely, the rows of a unitary $U\in U(n)$ give the $\phi_i$, and
+    $\psi_i$ is recovered as $\psi_i(j)=U_{i,\,j}$ for
+    $j=0,\dots,d-1$.
+
+    Unlike \ref{thm:exists_naimark_dilation}, whose ambient Hilbert space
+    is $\C^D\otimes\C^n$ of dimension $D\cdot n$, this theorem yields the
+    sharp $n$-dimensional ambient space asserted by the source (Wolf,
+    Theorem ``Neumark's theorem'').
+
+    The bridge lemma \lean{POVM.of_rank_one_povm} starts from a
+    \lean{POVM} with an explicit rank-one decomposition and applies the
+    sharp extension.
+\end{theorem}
+
+\begin{proof}
+    Assemble the $n\times d$ matrix $\Psi_{i,j}:=\psi_i(j)$.  From the
+    resolution of identity one obtains $\Psi^\dagger\Psi=\Id_d$.
+    Let $J$ be the $n\times d$ inclusion matrix
+    $J_{i,j}=1$ if $i$ equals the embedding of $j$ into $\Fin_n$ and $0$
+    otherwise; for $d\le n$, $J^\dagger J=\Id_d$.
+    By \ref{thm:exists_unitary_zero_extension} via
+    \lean{Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq}
+    there exists a unitary $U\in U(n)$ with $\Psi=UJ$, hence
+    $\psi_i(j)=U_{i,\iota(j)}$ where $\iota:\Fin_d\to\Fin_n$ is the
+    natural inclusion.  The rows of $U$ are the required orthonormal
+    basis.  The bridge lemma extracts the vectors from a POVM whose
+    effects are given in rank-one form and applies the main theorem.
+\end{proof}
+
 \begin{definition}[POVM from a PSD resolution of identity on a dilation]
     \label{def:povm_of_psd_resolution_of_identity}
     \lean{POVM.ofPSDResolutionOfIdentity}

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -762,7 +762,7 @@ a common dilation space.
     sharp $n$-dimensional ambient space asserted by the source (Wolf,
     Theorem ``Neumark's theorem'').
 
-    The bridge lemma \lean{POVM.of_rank_one_povm} starts from a
+    The corollary \lean{POVM.of_rank_one_povm} starts from a
     \lean{POVM} with an explicit rank-one decomposition and applies the
     sharp extension.
 \end{theorem}
@@ -778,7 +778,7 @@ a common dilation space.
     there exists a unitary $U\in U(n)$ with $\Psi=UJ$, hence
     $\psi_i(j)=U_{i,\iota(j)}$ where $\iota:\Fin_d\to\Fin_n$ is the
     natural inclusion.  The rows of $U$ are the required orthonormal
-    basis.  The bridge lemma extracts the vectors from a POVM whose
+    basis.  The corollary extracts the vectors from a POVM whose
     effects are given in rank-one form and applies the main theorem.
 \end{proof}
 

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -747,12 +747,14 @@ a common dilation space.
     \label{thm:sharp_rank_one_neumark}
     \lean{POVM.exists_orthonormal_basis_restriction,
         POVM.of_rank_one_povm}
-    \uses{def:povm, thm:exists_naimark_dilation}
+    \leanok
+    \uses{def:povm}
     Let $\{\ketbra{\psi_i}{\psi_i}\}_{i=0}^{n-1}$ be a rank-one POVM on
-    $\C^d$ with outcomes $n$ and $d\le n$, i.e.\
-    $\sum_i\ketbra{\psi_i}{\psi_i}=\Id_d$.  Then there exists an
-    orthonormal basis $\{\phi_i\}_{i=0}^{n-1}$ of $\C^n$ such that each
-    $\psi_i$ is the restriction of $\phi_i$ to the first $d$ coordinates.
+    $\C^d$ with $n$ outcomes, i.e.\
+    $\sum_i\ketbra{\psi_i}{\psi_i}=\Id_d$.  Then necessarily $d\le n$,
+    and there exists an orthonormal basis
+    $\{\phi_i\}_{i=0}^{n-1}$ of $\C^n$ such that each $\psi_i$ is the
+    restriction of $\phi_i$ to the first $d$ coordinates.
     Concretely, the rows of a unitary $U\in U(n)$ give the $\phi_i$, and
     $\psi_i$ is recovered as $\psi_i(j)=U_{i,\,j}$ for
     $j=0,\dots,d-1$.
@@ -762,21 +764,22 @@ a common dilation space.
     sharp $n$-dimensional ambient space asserted by the source (Wolf,
     Theorem ``Neumark's theorem'').
 
-    The corollary \lean{POVM.of_rank_one_povm} starts from a
-    \lean{POVM} with an explicit rank-one decomposition and applies the
-    sharp extension.
+    The corresponding corollary starts from a positive operator-valued
+    measure with an explicit rank-one decomposition.
 \end{theorem}
 
 \begin{proof}
+    \leanok
+    \uses{lem:exists_unitary_mul_eq_of_gram_eq}
     Assemble the $n\times d$ matrix $\Psi_{i,j}:=\psi_i(j)$.  From the
     resolution of identity one obtains $\Psi^\dagger\Psi=\Id_d$.
+    Thus $\Psi$ is an isometry, which implies $d\le n$.
     Let $J$ be the $n\times d$ inclusion matrix
-    $J_{i,j}=1$ if $i$ equals the embedding of $j$ into $\Fin_n$ and $0$
+    $J_{i,j}=1$ if $i$ equals the embedding of $j$ into $\Fin{n}$ and $0$
     otherwise; for $d\le n$, $J^\dagger J=\Id_d$.
-    By \ref{thm:exists_unitary_zero_extension} via
-    \lean{Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq}
-    there exists a unitary $U\in U(n)$ with $\Psi=UJ$, hence
-    $\psi_i(j)=U_{i,\iota(j)}$ where $\iota:\Fin_d\to\Fin_n$ is the
+    By Lemma~\ref{lem:exists_unitary_mul_eq_of_gram_eq}, there exists a
+    unitary $U\in U(n)$ with $\Psi=UJ$, hence
+    $\psi_i(j)=U_{i,\iota(j)}$ where $\iota:\Fin{d}\to\Fin{n}$ is the
     natural inclusion.  The rows of $U$ are the required orthonormal
     basis.  The corollary extracts the vectors from a POVM whose
     effects are given in rank-one form and applies the main theorem.

--- a/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_dilations_and_ordered_cp.tex
@@ -743,8 +743,8 @@ a common dilation space.
     $V=W\sum_iM_i\otimes\ket{i}=WV_0$.
 \end{proof}
 
-\begin{theorem}[Sharp rank-one Neumark extension]
-    \label{thm:sharp_rank_one_neumark}
+\begin{theorem}[Sharp rank-one Naimark extension]
+    \label{thm:sharp_rank_one_naimark}
     \lean{POVM.exists_orthonormal_basis_restriction,
         POVM.of_rank_one_povm}
     \leanok
@@ -761,8 +761,8 @@ a common dilation space.
 
     Unlike \ref{thm:exists_naimark_dilation}, whose ambient Hilbert space
     is $\C^D\otimes\C^n$ of dimension $D\cdot n$, this theorem yields the
-    sharp $n$-dimensional ambient space asserted by the source (Wolf,
-    Theorem ``Neumark's theorem'').
+    sharp $n$-dimensional ambient space asserted by
+    \cite[Theorem ``Neumark's theorem'']{Wolf2012Quantum}.
 
     The corresponding corollary starts from a positive operator-valued
     measure with an explicit rank-one decomposition.


### PR DESCRIPTION
### Motivation

Wolf's theorem headed “Neumark's theorem” in the local source
(`Notes/WolfNoteTexSource/ch02_representations.tex`, lines 480--499) gives the
sharp rank-one dilation in `ℂⁿ`. The existing general Naimark construction has
ambient dimension `D·n`, so it does not by itself state this sharper result.

### Description

- Add `TNLean/Channel/POVM/RankOneNaimark.lean`, following the repository's
  established `Naimark` API spelling.
- `POVM.exists_orthonormal_basis_restriction` derives `d ≤ n` from the
  rank-one resolution of the identity and produces a unitary on `ℂⁿ` whose
  rows restrict to the original vectors.
- `POVM.of_rank_one_povm` specializes the result to a POVM with an explicit
  rank-one decomposition.
- Reuse `Matrix.ker_mulVecLin_conjTranspose_mul_self`,
  `Matrix.submatrix_one`, and `Matrix.mul_submatrix_one` for the isometry,
  coordinate inclusion, and restriction arguments.
- Update the Chapter 2 index, generated channel aggregator, and Blueprint
  statement/citation.

The dimension inequality is a conclusion, not an extra hypothesis, so the
Lean statement matches the source hypothesis set.

### Validation

- `lake env lean TNLean/Channel/POVM/RankOneNaimark.lean`
- `lake build TNLean.Channel.WolfChapter2Index`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Full 785-page Blueprint build and visual inspection of the changed theorem
  and proof pages
- Proof-integrity, stale-name, tactic-pattern, and whitespace scans

---

Addresses LionSR/QICLean#131

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and documentation only; no changes to auth, runtime, or existing Naimark APIs beyond new imports and theorems.
> 
> **Overview**
> Adds formalization of Wolf’s **sharp rank-one Neumark/Naimark** result: from vectors with \(\sum_i |\psi_i\rangle\langle\psi_i| = \mathbb{1}_d\), the PR proves **`d ≤ n`** and builds a **unitary on \(\mathbb{C}^n\)** whose rows restrict to the \(\psi_i\)—ambient dimension **\(n\)**, not the **`D·n`** tensor dilation from general `exists_naimark_dilation`.
> 
> New module `TNLean/Channel/POVM/RankOneNaimark.lean` introduces `POVM.exists_orthonormal_basis_restriction` (Gram matrix \(\Psi^\dagger\Psi = \mathbb{1}\), inclusion matrix \(J\), `Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq`) and `POVM.exists_orthonormal_basis_restriction_of_rank_one` for POVMs with explicit rank-one effects. **Channel aggregator**, **Wolf Chapter 2 index**, and **Blueprint** ch16 gain imports, index entries, and `thm:sharp_rank_one_naimark` with a `\leanok` proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d9886af14b86976fc89f7638145bcc40c76675a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->