### PR TITLE
fix(Channel/FixedPoint): correct conditional-expectation source attribution

### DIFF
--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -373,15 +373,16 @@ theorem meanErgodicAdjoint_isConditionalExpectation
     (T : Mat →ₗ[ℂ] Mat) (hT_pos : IsPositiveMap T) (hT_tp : IsTracePreservingMap T)
     (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
-    let Pstar : Mat →ₗ[ℂ] Mat :=
-      (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp).traceAdjointMeanErgodicProjection
-    IsConditionalExpectation Pstar
+    IsConditionalExpectation
+      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
+        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
       (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
         hT_pos.traceAdjointMap
         (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)
         hTstar_schwarz hρ (by
           simpa [Matrix.traceAdjointMap_traceAdjointMap] using hρ_fix)) := by
-  intro Pstar
+  set Pstar := Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
+    (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp))
   have hlemma := hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp
   have hPstar_idemp : ∀ Y, Pstar (Pstar Y) = Pstar Y := hlemma.2.2.1
   have hPstar_one : Pstar 1 = 1 := hlemma.2.1

--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -387,12 +387,10 @@ theorem meanErgodicAdjoint_isConditionalExpectation
     (LinearMap.meanErgodicProjection T
       (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)
       (𝕜 := ℂ) (E := Mat))
-  have hlemma := hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp
-  have hPstar_idemp : ∀ Y, Pstar (Pstar Y) = Pstar Y := hlemma.2.2.1
-  have hPstar_one : Pstar 1 = 1 := hlemma.2.1
-  have hPstar_fixed : ∀ Y, Pstar Y = Y ↔ Matrix.traceAdjointMap T Y = Y := hlemma.2.2.2.2
+  obtain ⟨hPstar_pos, hPstar_one, hPstar_idemp, _, hPstar_fixed⟩ :=
+    hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp
   exact
-  { positive := hlemma.1
+  { positive := hPstar_pos
     idempotent := hPstar_idemp
     unital := hPstar_one
     range_subset := fun Y ↦ by

--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -373,22 +373,19 @@ theorem meanErgodicAdjoint_isConditionalExpectation
     (T : Mat →ₗ[ℂ] Mat) (hT_pos : IsPositiveMap T) (hT_tp : IsTracePreservingMap T)
     (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
-    IsConditionalExpectation
-      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
-        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
+    let Pstar : Mat →ₗ[ℂ] Mat :=
+      (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp).traceAdjointMeanErgodicProjection
+    IsConditionalExpectation Pstar
       (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
         hT_pos.traceAdjointMap
         (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)
         hTstar_schwarz hρ (by
           simpa [Matrix.traceAdjointMap_traceAdjointMap] using hρ_fix)) := by
-  set Pstar := Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
-    (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp))
-  have hPstar_idemp : ∀ Y, Pstar (Pstar Y) = Pstar Y :=
-    (hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp).2.2.1
-  have hPstar_one : Pstar 1 = 1 :=
-    (hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp).2.1
-  have hPstar_fixed : ∀ Y, Pstar Y = Y ↔ Matrix.traceAdjointMap T Y = Y :=
-    (hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp).2.2.2.2
+  intro Pstar
+  have hlemma := hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp
+  have hPstar_idemp : ∀ Y, Pstar (Pstar Y) = Pstar Y := hlemma.2.2.1
+  have hPstar_one : Pstar 1 = 1 := hlemma.2.1
+  have hPstar_fixed : ∀ Y, Pstar Y = Y ↔ Matrix.traceAdjointMap T Y = Y := hlemma.2.2.2.2
   exact
   { idempotent := hPstar_idemp
     unital := hPstar_one

--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -20,8 +20,9 @@ the conditional-expectation step in the proof of Theorem 6.14.
 When the fixed-point *-subalgebra is the scalar algebra `ℂ · 1` (as for
 primitive channels), the conditional expectation takes the explicit form
 `E_σ(X) = (tr(σ X) / tr(σ)) • 1`, where `σ` is the unique positive-definite
-stationary state. The general irreducible case (period > 1) requires the
-Wedderburn block decomposition from Wolf Theorem 6.14.
+stationary state. The explicit density-block formula for the general
+irreducible case requires the Wedderburn block decomposition from Wolf
+Theorem 6.14.
 
 ## Main results
 

--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -39,6 +39,8 @@ Theorem 6.14.
   `E_σ(X)` is always a fixed point of `T*`.
 * `scalarConditionalExpectation_isConditionalExpectation`:
   the scalar fixed-point algebra case.
+* `meanErgodicAdjoint_isConditionalExpectation`:
+  the mean-ergodic adjoint projection onto the full fixed-point algebra.
 
 ## Cross-references
 

--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -11,23 +11,22 @@ import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 import Mathlib.Analysis.Matrix.Order
 
 /-!
-# Conditional expectation onto fixed-point algebra (Wolf Theorem 6.15)
+# Conditional expectations onto fixed-point algebras
 
-This file formalizes the conditional expectation projecting onto the
-fixed-point *-subalgebra of a quantum channel's Heisenberg-picture map,
-following Wolf Theorem 6.15.
+This file formalizes positive projections onto fixed-point *-subalgebras of
+Heisenberg-picture maps, following Wolf Proposition 1.5, Equation (1.40), and
+the conditional-expectation step in the proof of Theorem 6.14.
 
 When the fixed-point *-subalgebra is the scalar algebra `ℂ · 1` (as for
 primitive channels), the conditional expectation takes the explicit form
 `E_σ(X) = (tr(σ X) / tr(σ)) • 1`, where `σ` is the unique positive-definite
 stationary state. The general irreducible case (period > 1) requires the
-Wedderburn block decomposition from Wolf Theorem 6.14 (issue #27).
+Wedderburn block decomposition from Wolf Theorem 6.14.
 
 ## Main results
 
-* `IsConditionalExpectation`: predicate stating that a linear map is
+* `IsConditionalExpectation`: predicate stating that a matrix map is positive,
   idempotent, unital, maps into a `StarSubalgebra`, and fixes it pointwise.
-  Defined generically over any `StarAlgebra` for upstream compatibility.
 * `scalarConditionalExpectation`: the linear map `X ↦ (tr(σX)/tr(σ)) • 1`.
 * `scalarConditionalExpectation_idempotent`: `E_σ² = E_σ`.
 * `scalarConditionalExpectation_unital`: `E_σ(1) = 1`.
@@ -38,7 +37,7 @@ Wedderburn block decomposition from Wolf Theorem 6.14 (issue #27).
 * `scalarConditionalExpectation_mem_adjointFixedPoints`:
   `E_σ(X)` is always a fixed point of `T*`.
 * `scalarConditionalExpectation_isConditionalExpectation`:
-  **Wolf Theorem 6.15** for the scalar fixed-point algebra case.
+  the scalar fixed-point algebra case.
 
 ## Cross-references
 
@@ -52,10 +51,11 @@ Wedderburn block decomposition from Wolf Theorem 6.14 (issue #27).
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 6.15, Section 6.4]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Proposition 1.5,
+  Equation (1.40), and the proof of Theorem 6.14]
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder BigOperators
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius BigOperators
 open Matrix Finset Complex
 
 namespace Kraus
@@ -66,23 +66,25 @@ local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 /-! ## Abstract conditional expectation -/
 
-/-- A **conditional expectation** onto a `StarSubalgebra` `S ⊆ A` is a
-ℂ-linear map that is idempotent, unital, maps into `S`, and fixes every
-element of `S`. This is the abstract property from Wolf Theorem 6.15.
+/-- A **conditional expectation** onto a matrix `StarSubalgebra` `S` is a
+positive complex-linear map that is idempotent, unital, maps into `S`, and
+fixes every element of `S`.
 
-The definition is generic over any `StarAlgebra` so that it can be reused
-for non-matrix algebras (e.g., Wedderburn blocks) in future work. -/
-structure IsConditionalExpectation {A : Type*}
-    [Semiring A] [StarRing A] [Algebra ℂ A] [StarModule ℂ A]
-    (E : A →ₗ[ℂ] A) (S : StarSubalgebra ℂ A) : Prop where
+Source: Wolf, Proposition 1.5 and Equation (1.40), local source
+`Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, lines 545--570. -/
+structure IsConditionalExpectation {n : Type*} [Fintype n] [DecidableEq n]
+    (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
+    (S : StarSubalgebra ℂ (Matrix n n ℂ)) : Prop where
+  /-- Positivity: positive semidefinite matrices have positive semidefinite images. -/
+  positive : IsPositiveMap E
   /-- Idempotent: `E(E(X)) = E(X)`. -/
-  idempotent : ∀ X : A, E (E X) = E X
+  idempotent : ∀ X, E (E X) = E X
   /-- Unital: `E(1) = 1`. -/
   unital : E 1 = 1
   /-- Range contained in `S`. -/
-  range_subset : ∀ X : A, E X ∈ S
+  range_subset : ∀ X, E X ∈ S
   /-- Fixes `S` pointwise. -/
-  fixes : ∀ X : A, X ∈ S → E X = X
+  fixes : ∀ X, X ∈ S → E X = X
 
 /-! ## Scalar conditional expectation -/
 
@@ -90,9 +92,8 @@ structure IsConditionalExpectation {A : Type*}
 
 `E_σ(X) = (tr(σ X) / tr(σ)) • 1`.
 
-This is the conditional expectation from Wolf Theorem 6.15 in the case where
-the fixed-point *-subalgebra of the adjoint map is the scalar algebra `ℂ · 1`
-(i.e., the channel is primitive).
+This is the scalar-algebra specialization of Wolf Equation (1.40), where the
+fixed-point *-subalgebra of the adjoint map is `ℂ · 1`.
 
 The definition does not require `trace σ ≠ 0`; when `trace σ = 0` the map
 sends everything to zero. The nonzero-trace hypothesis is instead required
@@ -305,26 +306,24 @@ theorem scalarConditionalExpectation_preserves_weighted_trace
 
 /-! ## Conditional expectation onto the adjoint fixed-point *-subalgebra -/
 
-/-- **Wolf Theorem 6.15** (scalar fixed-point algebra case):
+/-- Scalar fixed-point algebra conditional expectation.
 
 When a TP Kraus family has `ρ` as a positive-definite fixed point of the
 Schrödinger map, and the adjoint fixed-point set consists only of scalar
 matrices, the scalar conditional expectation `E_ρ` is a conditional
 expectation onto the adjoint fixed-point `StarSubalgebra`.
 
-This covers the primitive channel case. In the general irreducible case
-with period `h > 1`, the fixed-point algebra is `h`-dimensional and the
-conditional expectation requires the Wedderburn block decomposition
-(Wolf Theorem 6.14, issue #27). -/
+Source: Wolf, Equation (1.40), specialized to the scalar algebra. -/
 theorem scalarConditionalExpectation_isConditionalExpectation
     [NeZero D]
     (K : Fin d → Mat) (h_tp : IsTP K)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ)
     (h_scalar : ∀ X : Mat, X ∈ adjointFixedPoints K →
       ∃ c : ℂ, X = c • (1 : Mat)) :
-    IsConditionalExpectation
+    IsConditionalExpectation (n := Fin D)
       (scalarConditionalExpectation ρ)
       (adjointFixedPointsStarSubalgebra K h_tp hρ hρ_fix) where
+  positive := (scalarConditionalExpectation_isCPMap ρ hρ.posSemidef).isPositiveMap
   idempotent := scalarConditionalExpectation_idempotent ρ
     (ne_of_gt hρ.trace_pos)
   unital := scalarConditionalExpectation_unital ρ
@@ -345,7 +344,7 @@ When the Heisenberg-picture map (the trace adjoint) is unital and Schwarz, and
 the Schrödinger-picture map has a positive definite fixed point, the trace
 adjoint of the mean-ergodic projection is a conditional expectation onto the
 fixed-point star-subalgebra of the Heisenberg map.  This is the general case
-of **Wolf Theorem 6.15**, uniform in the period `h`.
+used in the proof of Wolf Theorem 6.14.
 
 The formula follows from the finite-dimensional mean-ergodic theorem: the
 projection `P*` is idempotent, unital, and fixes exactly the fixed points of
@@ -353,7 +352,7 @@ projection `P*` is idempotent, unital, and fixes exactly the fixed points of
 abstract Schwarz-map algebra theorem (Wolf Theorem 6.12), so the target is a
 bona fide `StarSubalgebra`. -/
 
-/-- **Wolf Theorem 6.15** (general case, via the mean-ergodic projection).
+/-- Conditional expectation from the adjoint mean-ergodic projection.
 
 Let `T : M_D(ℂ) → M_D(ℂ)` be a positive trace-preserving linear map whose
 trace adjoint `T*` satisfies the Schwarz inequality.  If `T` has a positive
@@ -364,8 +363,8 @@ definite fixed point `ρ`, then the adjoint of the mean-ergodic projection of
 This generalizes `Kraus.scalarConditionalExpectation` from the scalar (h = 1)
 case to arbitrary dimension of the fixed-point algebra.
 
-Reference: Wolf, *Quantum Channels & Operations*, Theorem 6.15 and
-Equation (6.14); local source
+Reference: Wolf, *Quantum Channels & Operations*, Equation (6.14) and the
+proof of Theorem 6.14; local source
 `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
 lines 226–269 and 1488–1492. -/
 theorem meanErgodicAdjoint_isConditionalExpectation
@@ -373,22 +372,27 @@ theorem meanErgodicAdjoint_isConditionalExpectation
     (T : Mat →ₗ[ℂ] Mat) (hT_pos : IsPositiveMap T) (hT_tp : IsTracePreservingMap T)
     (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
-    IsConditionalExpectation
-      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
-        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
+    IsConditionalExpectation (n := Fin D)
+      (Matrix.traceAdjointMap
+        (LinearMap.meanErgodicProjection T
+          (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)
+          (𝕜 := ℂ) (E := Mat)))
       (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
         hT_pos.traceAdjointMap
         (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)
         hTstar_schwarz hρ (by
           simpa [Matrix.traceAdjointMap_traceAdjointMap] using hρ_fix)) := by
-  set Pstar := Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
-    (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp))
+  set Pstar := Matrix.traceAdjointMap
+    (LinearMap.meanErgodicProjection T
+      (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)
+      (𝕜 := ℂ) (E := Mat))
   have hlemma := hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp
   have hPstar_idemp : ∀ Y, Pstar (Pstar Y) = Pstar Y := hlemma.2.2.1
   have hPstar_one : Pstar 1 = 1 := hlemma.2.1
   have hPstar_fixed : ∀ Y, Pstar Y = Y ↔ Matrix.traceAdjointMap T Y = Y := hlemma.2.2.2.2
   exact
-  { idempotent := hPstar_idemp
+  { positive := hlemma.1
+    idempotent := hPstar_idemp
     unital := hPstar_one
     range_subset := fun Y ↦ by
       have hfix : Matrix.traceAdjointMap T (Pstar Y) = Pstar Y :=

--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -3,7 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Channel.FixedPoint.AbstractAlgebra
 import TNLean.Channel.FixedPoint.Algebra
+import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.Semigroup.CPClosure
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Basic
 import Mathlib.Analysis.Matrix.Order
@@ -336,5 +338,67 @@ theorem scalarConditionalExpectation_isConditionalExpectation
     rw [hc]
     exact scalarConditionalExpectation_fixes_scalar ρ
       (ne_of_gt hρ.trace_pos) c
+
+/-! ## General conditional expectation via the mean-ergodic projection
+
+When the Heisenberg-picture map (the trace adjoint) is unital and Schwarz, and
+the Schrödinger-picture map has a positive definite fixed point, the trace
+adjoint of the mean-ergodic projection is a conditional expectation onto the
+fixed-point star-subalgebra of the Heisenberg map.  This is the general case
+of **Wolf Theorem 6.15**, uniform in the period `h`.
+
+The formula follows from the finite-dimensional mean-ergodic theorem: the
+projection `P*` is idempotent, unital, and fixes exactly the fixed points of
+`T*`.  The star-algebra structure of those fixed points is supplied by the
+abstract Schwarz-map algebra theorem (Wolf Theorem 6.12), so the target is a
+bona fide `StarSubalgebra`. -/
+
+/-- **Wolf Theorem 6.15** (general case, via the mean-ergodic projection).
+
+Let `T : M_D(ℂ) → M_D(ℂ)` be a positive trace-preserving linear map whose
+trace adjoint `T*` satisfies the Schwarz inequality.  If `T` has a positive
+definite fixed point `ρ`, then the adjoint of the mean-ergodic projection of
+`T` is a conditional expectation onto the fixed-point star-subalgebra of
+`T*`.  The construction is uniform in the period `h` of `T`.
+
+This generalizes `Kraus.scalarConditionalExpectation` from the scalar (h = 1)
+case to arbitrary dimension of the fixed-point algebra.
+
+Reference: Wolf, *Quantum Channels & Operations*, Theorem 6.15 and
+Equation (6.14); local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`,
+lines 226–269 and 1488–1492. -/
+theorem meanErgodicAdjoint_isConditionalExpectation
+    [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT_pos : IsPositiveMap T) (hT_tp : IsTracePreservingMap T)
+    (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
+    IsConditionalExpectation
+      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
+        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
+      (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
+        hT_pos.traceAdjointMap
+        (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)
+        hTstar_schwarz hρ (by
+          simpa [Matrix.traceAdjointMap_traceAdjointMap] using hρ_fix)) := by
+  set Pstar := Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
+    (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp))
+  have hPstar_idemp : ∀ Y, Pstar (Pstar Y) = Pstar Y :=
+    (hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp).2.2.1
+  have hPstar_one : Pstar 1 = 1 :=
+    (hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp).2.1
+  have hPstar_fixed : ∀ Y, Pstar Y = Y ↔ Matrix.traceAdjointMap T Y = Y :=
+    (hT_pos.traceAdjoint_meanErgodicProjection_isPositiveUnitalRetraction hT_tp).2.2.2.2
+  exact
+  { idempotent := hPstar_idemp
+    unital := hPstar_one
+    range_subset := fun Y ↦ by
+      have hfix : Matrix.traceAdjointMap T (Pstar Y) = Pstar Y :=
+        ((hPstar_fixed (Pstar Y)).mp (hPstar_idemp Y))
+      rw [SchwarzMap.mem_fixedPointsStarSubalgebra]
+      exact hfix
+    fixes := fun Y hY ↦ by
+      rw [SchwarzMap.mem_fixedPointsStarSubalgebra] at hY
+      exact (hPstar_fixed Y).mpr hY }
 
 end Kraus

--- a/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
@@ -27,6 +27,21 @@ open scoped Matrix Matrix.Norms.Frobenius
 
 variable {D : ℕ}
 
+/-- The trace-pairing adjoint of the mean-ergodic projection of `T`.
+
+This is the projection `P*` used in the proof of Wolf Theorem 6.14
+(see Equation 6.14 and lines 1488-1492 of the local source)
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`.
+
+The explicit definition as a named function avoids typeclass instance diamonds
+in downstream modules that import additional matrix instances
+(e.g., `Mathlib.Analysis.Matrix.Order`). -/
+noncomputable def LinearMap.HasBoundedOrbits.traceAdjointMeanErgodicProjection
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hb : T.HasBoundedOrbits) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+  Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hb)
+
 /-- A matrix endomorphism is trace-preserving if and only if its trace-pairing
 adjoint fixes the identity.
 

--- a/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
+++ b/TNLean/Channel/FixedPoint/MeanErgodicAdjoint.lean
@@ -27,21 +27,6 @@ open scoped Matrix Matrix.Norms.Frobenius
 
 variable {D : ℕ}
 
-/-- The trace-pairing adjoint of the mean-ergodic projection of `T`.
-
-This is the projection `P*` used in the proof of Wolf Theorem 6.14
-(see Equation 6.14 and lines 1488-1492 of the local source)
-`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`.
-
-The explicit definition as a named function avoids typeclass instance diamonds
-in downstream modules that import additional matrix instances
-(e.g., `Mathlib.Analysis.Matrix.Order`). -/
-noncomputable def LinearMap.HasBoundedOrbits.traceAdjointMeanErgodicProjection
-    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
-    (hb : T.HasBoundedOrbits) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
-  Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T hb)
-
 /-- A matrix endomorphism is trace-preserving if and only if its trace-pairing
 adjoint fixes the identity.
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -482,7 +482,7 @@ maximum-rank fixed-point density matrix satisfies the rank hypothesis, with
 unit trace of $\rho$ itself not needed for the conclusion
 (see `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`).
 
-### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — PARTIALLY FORMALIZED
+### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — FORMALIZED
 
 In `TNLean.Channel.FixedPoint.ConditionalExpectation`:
 
@@ -498,12 +498,19 @@ In `TNLean.Channel.FixedPoint.ConditionalExpectation`:
   `T*(E_σ(X)) = E_σ(X)` when `T` is TP.
 * `Kraus.scalarConditionalExpectation_isConditionalExpectation` —
   bundles everything into `IsConditionalExpectation` for the scalar case.
-* Numbered theorem: `Kraus.wolf_theorem_6_15_scalar` —
+* Numbered theorems:
+  `Kraus.wolf_theorem_6_15` (general case via mean-ergodic projection),
+  `Kraus.wolf_theorem_6_15_scalar` (scalar specialization) —
   `TNLean.Channel.WolfChapter6Wrappers`.
 
-The density-block decomposition required for the general irreducible case with
-period `h > 1` is now supplied by Wolf Theorem 6.14.  The corresponding
-conditional-expectation construction remains to be assembled.
+The general conditional expectation is the trace adjoint of the mean-ergodic
+projection, which is idempotent, unital, and fixes exactly the fixed points of
+`T*`; the star-algebra structure follows from Theorem 6.12.  This covers both
+the primitive (h = 1) and the irreducible period-h > 1 cases uniformly, since
+the period never enters the hypotheses.  The density-block decomposition of
+Theorem 6.14 is not required for the abstract statement; it supplies the
+explicit block formula for the retraction (see
+`TNLean.Channel.FixedPoint.FullSupportBlockRetraction`).
 
 ---
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -482,12 +482,13 @@ maximum-rank fixed-point density matrix satisfies the rank hypothesis, with
 unit trace of $\rho$ itself not needed for the conclusion
 (see `docs/paper-gaps/wolf_cor67_maximal_support_restriction.tex`).
 
-### Wolf Theorem 6.15 (Conditional expectation onto fixed-point algebra) — FORMALIZED
+### Conditional expectation used in Wolf Theorem 6.14 — FORMALIZED
 
 In `TNLean.Channel.FixedPoint.ConditionalExpectation`:
 
-* `Kraus.IsConditionalExpectation` — abstract predicate (generic over any
-  `StarAlgebra`): idempotent, unital, range ⊆ `S`, fixes `S` pointwise.
+* `Kraus.IsConditionalExpectation` — a positive, idempotent, unital matrix
+  map whose range is contained in a star-subalgebra and which fixes that
+  subalgebra pointwise, following Wolf Proposition 1.5 and Equation (1.40).
 * `Kraus.scalarConditionalExpectation` — the linear map
   `E_σ(X) = (tr(σ X) / tr(σ)) • 1` for the scalar fixed-point algebra case.
 * `Kraus.scalarConditionalExpectation_idempotent` — `E_σ² = E_σ`.
@@ -498,19 +499,23 @@ In `TNLean.Channel.FixedPoint.ConditionalExpectation`:
   `T*(E_σ(X)) = E_σ(X)` when `T` is TP.
 * `Kraus.scalarConditionalExpectation_isConditionalExpectation` —
   bundles everything into `IsConditionalExpectation` for the scalar case.
-* Numbered theorems:
-  `Kraus.wolf_theorem_6_15` (general case via mean-ergodic projection),
-  `Kraus.wolf_theorem_6_15_scalar` (scalar specialization) —
-  `TNLean.Channel.WolfChapter6Wrappers`.
+* `Kraus.meanErgodicAdjoint_isConditionalExpectation` — the trace adjoint of
+  the mean-ergodic projection is a conditional expectation onto the adjoint
+  fixed-point star-subalgebra.
 
 The general conditional expectation is the trace adjoint of the mean-ergodic
-projection, which is idempotent, unital, and fixes exactly the fixed points of
-`T*`; the star-algebra structure follows from Theorem 6.12.  This covers both
-the primitive (h = 1) and the irreducible period-h > 1 cases uniformly, since
-the period never enters the hypotheses.  The density-block decomposition of
-Theorem 6.14 is not required for the abstract statement; it supplies the
-explicit block formula for the retraction (see
-`TNLean.Channel.FixedPoint.FullSupportBlockRetraction`).
+projection, which is positive, idempotent, unital, and fixes exactly the fixed
+points of `T*`; the star-algebra structure follows from Theorem 6.12. This is
+the conditional-expectation step in the proof of Theorem 6.14. The theorem's
+explicit density-block formula is developed in
+`TNLean.Channel.FixedPoint.FullSupportBlockRetraction`.
+
+### Wolf Theorem 6.15 (Unique fixed point from full Kraus-word span) — NOT FORMALIZED
+
+The source assumes that the homogeneous words of some fixed length in the
+Kraus operators span the full matrix algebra. It concludes that the channel
+has a unique fixed density matrix and that this density matrix is positive
+definite. No Lean theorem currently has this hypothesis and conclusion.
 
 ---
 

--- a/TNLean/Channel/WolfChapter6Wrappers.lean
+++ b/TNLean/Channel/WolfChapter6Wrappers.lean
@@ -50,8 +50,7 @@ theorem wolf_theorem_6_15
     (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
     IsConditionalExpectation
-      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
-        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
+      ((hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp).traceAdjointMeanErgodicProjection)
       (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
         hT_pos.traceAdjointMap
         (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)

--- a/TNLean/Channel/WolfChapter6Wrappers.lean
+++ b/TNLean/Channel/WolfChapter6Wrappers.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.ConditionalExpectation
+import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.Irreducible.Similarity
 
 /-!
@@ -15,7 +16,7 @@ results already formalized elsewhere:
 
 * Proposition 6.6 (`isIrreducibleMap_full_similarity`)
 * Proposition 6.8 (`IsChannel.posSemidef_parts_of_hermitian_fixedPoint`)
-* Theorem 6.15 (`scalarConditionalExpectation_isConditionalExpectation`)
+* Theorem 6.15 (`wolf_theorem_6_15`, `wolf_theorem_6_15_scalar`)
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
@@ -36,7 +37,34 @@ theorem wolf_prop_6_6
     IsIrreducibleMap ((c : ℂ) • similarityMap (D := D) C E) :=
   isIrreducibleMap_full_similarity (D := D) hc hC hIrr
 
-/-- Wolf Theorem 6.15: scalar fixed-point conditional expectation. -/
+/-- A positive trace-preserving map whose adjoint is Schwarz and which has a
+positive-definite fixed point admits a conditional expectation onto the adjoint
+fixed-point star-subalgebra via the adjoint of the mean-ergodic projection.
+
+This is the general formulation of **Wolf Theorem 6.15**; it does not require
+irreducibility or a Kraus representation.  The period `h` never enters the
+hypotheses, so the argument is uniform in `h`. -/
+theorem wolf_theorem_6_15
+    [NeZero D]
+    (T : Mat →ₗ[ℂ] Mat) (hT_pos : IsPositiveMap T) (hT_tp : IsTracePreservingMap T)
+    (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
+    IsConditionalExpectation
+      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
+        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
+      (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
+        hT_pos.traceAdjointMap
+        (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)
+        hTstar_schwarz hρ (by
+          simpa [Matrix.traceAdjointMap_traceAdjointMap] using hρ_fix)) :=
+  meanErgodicAdjoint_isConditionalExpectation T hT_pos hT_tp hTstar_schwarz hρ hρ_fix
+
+/-- Wolf Theorem 6.15 (scalar case).
+
+When the adjoint fixed-point set consists only of scalar matrices, the
+general mean-ergodic construction specialises to a scalar conditional
+expectation.  This is a corollary of `wolf_theorem_6_15`; the present
+wrapper is retained as a convenience for the primitive (h = 1) case. -/
 theorem wolf_theorem_6_15_scalar
     [NeZero D]
     (K : Fin d → Mat) (h_tp : IsTP K)

--- a/TNLean/Channel/WolfChapter6Wrappers.lean
+++ b/TNLean/Channel/WolfChapter6Wrappers.lean
@@ -50,7 +50,8 @@ theorem wolf_theorem_6_15
     (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
     IsConditionalExpectation
-      ((hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp).traceAdjointMeanErgodicProjection)
+      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
+        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
       (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
         hT_pos.traceAdjointMap
         (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)

--- a/TNLean/Channel/WolfChapter6Wrappers.lean
+++ b/TNLean/Channel/WolfChapter6Wrappers.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.FixedPoint.Cesaro
-import TNLean.Channel.FixedPoint.ConditionalExpectation
-import TNLean.Channel.FixedPoint.MeanErgodicAdjoint
 import TNLean.Channel.Irreducible.Similarity
 
 /-!
@@ -16,7 +14,6 @@ results already formalized elsewhere:
 
 * Proposition 6.6 (`isIrreducibleMap_full_similarity`)
 * Proposition 6.8 (`IsChannel.posSemidef_parts_of_hermitian_fixedPoint`)
-* Theorem 6.15 (`wolf_theorem_6_15`, `wolf_theorem_6_15_scalar`)
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
@@ -24,7 +21,7 @@ open Matrix Finset Complex
 
 namespace Kraus
 
-variable {d D : ℕ}
+variable {D : ℕ}
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 /-- Wolf Proposition 6.6: full similarity preserves irreducibility. -/
@@ -36,45 +33,6 @@ theorem wolf_prop_6_6
     (hIrr : IsIrreducibleMap E) :
     IsIrreducibleMap ((c : ℂ) • similarityMap (D := D) C E) :=
   isIrreducibleMap_full_similarity (D := D) hc hC hIrr
-
-/-- A positive trace-preserving map whose adjoint is Schwarz and which has a
-positive-definite fixed point admits a conditional expectation onto the adjoint
-fixed-point star-subalgebra via the adjoint of the mean-ergodic projection.
-
-This is the general formulation of **Wolf Theorem 6.15**; it does not require
-irreducibility or a Kraus representation.  The period `h` never enters the
-hypotheses, so the argument is uniform in `h`. -/
-theorem wolf_theorem_6_15
-    [NeZero D]
-    (T : Mat →ₗ[ℂ] Mat) (hT_pos : IsPositiveMap T) (hT_tp : IsTracePreservingMap T)
-    (hTstar_schwarz : IsSchwarzMap (Matrix.traceAdjointMap T))
-    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : T ρ = ρ) :
-    IsConditionalExpectation
-      (Matrix.traceAdjointMap (LinearMap.meanErgodicProjection T
-        (hT_pos.hasBoundedOrbits_of_tracePreserving hT_tp)))
-      (SchwarzMap.fixedPointsStarSubalgebra (Matrix.traceAdjointMap T)
-        hT_pos.traceAdjointMap
-        (isTracePreservingMap_iff_traceAdjointMap_one.mp hT_tp)
-        hTstar_schwarz hρ (by
-          simpa [Matrix.traceAdjointMap_traceAdjointMap] using hρ_fix)) :=
-  meanErgodicAdjoint_isConditionalExpectation T hT_pos hT_tp hTstar_schwarz hρ hρ_fix
-
-/-- Wolf Theorem 6.15 (scalar case).
-
-When the adjoint fixed-point set consists only of scalar matrices, the
-general mean-ergodic construction specialises to a scalar conditional
-expectation.  This is a corollary of `wolf_theorem_6_15`; the present
-wrapper is retained as a convenience for the primitive (h = 1) case. -/
-theorem wolf_theorem_6_15_scalar
-    [NeZero D]
-    (K : Fin d → Mat) (h_tp : IsTP K)
-    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ)
-    (h_scalar : ∀ X : Mat, X ∈ adjointFixedPoints K →
-      ∃ c : ℂ, X = c • (1 : Mat)) :
-    IsConditionalExpectation
-      (scalarConditionalExpectation ρ)
-      (adjointFixedPointsStarSubalgebra K h_tp hρ hρ_fix) :=
-  scalarConditionalExpectation_isConditionalExpectation K h_tp hρ hρ_fix h_scalar
 
 end Kraus
 

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -403,7 +403,8 @@ Theorem~6.2 appears in Theorem~\ref{thm:wolf_6_2_item_3}.
     \label{thm:scalar_fixed_point_conditional_expectation}
     \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
     \leanok
-    \uses{def:channel}
+    \uses{def:channel,
+        thm:scalar_conditional_expectation_isConditionalExpectation}
     In the scalar fixed-point algebra setting, the weighted map
     $X\mapsto\tr(\rho X)\tr(\rho)^{-1}\Id$ is a conditional expectation
     onto the adjoint fixed-point $*$-subalgebra.

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -400,7 +400,7 @@ Theorem~6.2 appears in Theorem~\ref{thm:wolf_6_2_item_3}.
 \end{remark}
 
 \begin{theorem}[Scalar fixed-point algebra case]
-    \label{thm:wolf_6_15_scalar_conditional_expectation}
+    \label{thm:scalar_fixed_point_conditional_expectation}
     \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
     \leanok
     \uses{def:channel}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_point_structure_and_cycles.tex
@@ -399,17 +399,6 @@ Theorem~6.2 appears in Theorem~\ref{thm:wolf_6_2_item_3}.
     Theorem~\ref{thm:wielandt_proposition_three}.
 \end{remark}
 
-\begin{theorem}[Scalar fixed-point algebra case]
-    \label{thm:scalar_fixed_point_conditional_expectation}
-    \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
-    \leanok
-    \uses{def:channel,
-        thm:scalar_conditional_expectation_isConditionalExpectation}
-    In the scalar fixed-point algebra setting, the weighted map
-    $X\mapsto\tr(\rho X)\tr(\rho)^{-1}\Id$ is a conditional expectation
-    onto the adjoint fixed-point $*$-subalgebra.
-\end{theorem}
-
 \section{Multi-cycle block-permutation structure}
 
 This section develops the block-permutation structure underlying the

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -6,11 +6,10 @@ of~\cite[Theorem~6.14]{Wolf2012Quantum}
 via~\cite[(1.40)]{Wolf2012Quantum}.
 The scalar conditional expectation $E_\sigma$ is the special case where
 the fixed-point $*$-subalgebra is the scalar algebra $\C\cdot\Id$
-(the primitive-channel case). The general irreducible case with
-nontrivial period requires the Wedderburn block decomposition
-of~\cite[Theorem~6.14]{Wolf2012Quantum}.
-% The nontrivial-period conditional expectation is outside the present
-% formal scope of this section.
+(the primitive-channel case). The general case, including the irreducible
+case with nontrivial period, is covered by the adjoint of the mean-ergodic
+projection; the period never enters the hypotheses, so the argument is
+uniform in $h$.
 
 \begin{definition}[Conditional expectation]\label{def:is_conditional_expectation}
     \lean{Kraus.IsConditionalExpectation}
@@ -104,6 +103,30 @@ of~\cite[Theorem~6.14]{Wolf2012Quantum}.
     $T(\rho)=\sum_iK_i\rho K_i^\dagger$, and assume every adjoint fixed point
     of $T^*$ is a scalar multiple of $\Id$. Then $E_\rho$ is a conditional
     expectation onto the adjoint fixed-point $*$-subalgebra.
+\end{theorem}
+
+\begin{theorem}[Conditional expectation onto the fixed-point algebra]
+    \label{thm:meanErgodicAdjoint_isConditionalExpectation}
+    \lean{Kraus.meanErgodicAdjoint_isConditionalExpectation}
+    \leanok
+    \uses{def:is_conditional_expectation, thm:traceAdjoint_meanErgodicProjection}
+    Let $T:\MN{D}\to\MN{D}$ be a positive trace-preserving linear map
+    whose trace adjoint $T^*$ satisfies the Schwarz inequality.  If $T$ has a
+    positive definite fixed point $\rho>0$, then the trace adjoint of the
+    mean-ergodic projection of $T$ is a conditional expectation onto the
+    fixed-point star-subalgebra of $T^*$.
+    This is the main formulation of Wolf Theorem~6.15;
+    the construction does not use irreducibility or a Kraus representation,
+    and the period $h$ never enters the hypotheses.
+\end{theorem}
+
+\begin{theorem}[Wolf Theorem~6.15, numbered wrapper]
+    \label{thm:wolf_theorem_6_15}
+    \lean{Kraus.wolf_theorem_6_15}
+    \leanok
+    \uses{thm:meanErgodicAdjoint_isConditionalExpectation}
+    The numbered wrapper for Wolf Theorem~6.15:
+    same statement as Theorem~\ref{thm:meanErgodicAdjoint_isConditionalExpectation}.
 \end{theorem}
 
 \begin{lemma}[Complete positivity of the scalar conditional expectation]

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -88,47 +88,6 @@ uniform in $h$.
     For every $X$, the matrix $E_\sigma(X)$ is fixed by $T^*$.
 \end{lemma}
 
-\begin{theorem}[Scalar map is a conditional expectation]
-    \label{thm:scalar_conditional_expectation_isConditionalExpectation}
-    \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
-    \leanok
-    \uses{def:is_conditional_expectation, def:scalar_conditional_expectation,
-        def:tp_kraus,
-        thm:scalar_conditional_expectation_unital,
-        thm:scalar_conditional_expectation_idempotent,
-        lem:scalar_conditional_expectation_mem_adjointFixedPoints,
-        lem:scalar_conditional_expectation_fixes_scalar}
-    Let $K$ be a trace-preserving Kraus family, let $\rho>0$ satisfy
-    $T(\rho)=\rho$ for the associated channel
-    $T(\rho)=\sum_iK_i\rho K_i^\dagger$, and assume every adjoint fixed point
-    of $T^*$ is a scalar multiple of $\Id$. Then $E_\rho$ is a conditional
-    expectation onto the adjoint fixed-point $*$-subalgebra.
-\end{theorem}
-
-\begin{theorem}[Conditional expectation onto the fixed-point algebra]
-    \label{thm:meanErgodicAdjoint_isConditionalExpectation}
-    \lean{Kraus.meanErgodicAdjoint_isConditionalExpectation}
-    \leanok
-    \uses{def:is_conditional_expectation}
-    Let $T:\MN{D}\to\MN{D}$ be a positive trace-preserving linear map
-    whose trace adjoint $T^*$ satisfies the Schwarz inequality.  If $T$ has a
-    positive definite fixed point $\rho>0$, then the trace adjoint of the
-    mean-ergodic projection of $T$ is a conditional expectation onto the
-    fixed-point star-subalgebra of $T^*$.
-    This is the conditional-expectation step used in the proof of
-    Wolf Theorem~6.14.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:positive_unital_adjoint_mean_ergodic_retraction,
-        thm:fixedPointsStarSubalgebra}
-    The trace adjoint of the mean-ergodic projection is positive, unital, and
-    idempotent, and its fixed points are exactly the fixed points of $T^*$.
-    The Schwarz inequality and the faithful fixed point make this fixed-point
-    space a $*$-subalgebra. Hence the projection is a conditional expectation
-    onto that algebra.
-\end{proof}
-
 \begin{lemma}[Complete positivity of the scalar conditional expectation]
     \label{thm:scalar_conditional_expectation_isCPMap}
     \lean{Kraus.scalarConditionalExpectation_isCPMap}
@@ -154,6 +113,55 @@ uniform in $h$.
     $E_\sigma$ is the Kraus map in
     (\ref{eq:spectral_scalar_ce_kraus}) scaled by the non-negative real
     number $\tr(\sigma)^{-1}$, and is therefore completely positive.
+\end{proof}
+
+\begin{theorem}[Scalar map is a conditional expectation]
+    \label{thm:scalar_conditional_expectation_isConditionalExpectation}
+    \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
+    \leanok
+    \uses{def:is_conditional_expectation, def:scalar_conditional_expectation,
+        def:tp_kraus}
+    Let $K$ be a trace-preserving Kraus family, let $\rho>0$ satisfy
+    $T(\rho)=\rho$ for the associated channel
+    $T(\rho)=\sum_iK_i\rho K_i^\dagger$, and assume every adjoint fixed point
+    of $T^*$ is a scalar multiple of $\Id$. Then $E_\rho$ is a conditional
+    expectation onto the adjoint fixed-point $*$-subalgebra.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:scalar_conditional_expectation_isCPMap,
+        thm:scalar_conditional_expectation_unital,
+        thm:scalar_conditional_expectation_idempotent,
+        lem:scalar_conditional_expectation_mem_adjointFixedPoints,
+        lem:scalar_conditional_expectation_fixes_scalar}
+    Complete positivity implies positivity. The evaluation formula gives
+    unitality and idempotence, while trace preservation places the range in
+    the adjoint fixed-point algebra. Every element of that algebra is scalar
+    by hypothesis, and $E_\rho$ fixes every scalar matrix.
+\end{proof}
+
+\begin{theorem}[Conditional expectation onto the fixed-point algebra]
+    \label{thm:meanErgodicAdjoint_isConditionalExpectation}
+    \lean{Kraus.meanErgodicAdjoint_isConditionalExpectation}
+    \leanok
+    \uses{def:is_conditional_expectation}
+    Let $T:\MN{D}\to\MN{D}$ be a positive trace-preserving linear map
+    whose trace adjoint $T^*$ satisfies the Schwarz inequality.  If $T$ has a
+    positive definite fixed point $\rho>0$, then the trace adjoint of the
+    mean-ergodic projection of $T$ is a conditional expectation onto the
+    fixed-point star-subalgebra of $T^*$.
+    This is the conditional-expectation step used in the proof of
+    Wolf Theorem~6.14.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:positive_unital_adjoint_mean_ergodic_retraction,
+        thm:fixedPointsStarSubalgebra}
+    The trace adjoint of the mean-ergodic projection is positive, unital, and
+    idempotent, and its fixed points are exactly the fixed points of $T^*$.
+    The Schwarz inequality and the faithful fixed point make this fixed-point
+    space a $*$-subalgebra. Hence the projection is a conditional expectation
+    onto that algebra.
 \end{proof}
 
 \begin{lemma}[$\sigma$-trace preservation of the scalar conditional expectation]

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -109,7 +109,7 @@ uniform in $h$.
     \label{thm:meanErgodicAdjoint_isConditionalExpectation}
     \lean{Kraus.meanErgodicAdjoint_isConditionalExpectation}
     \leanok
-    \uses{def:is_conditional_expectation, thm:traceAdjoint_meanErgodicProjection}
+    \uses{def:is_conditional_expectation, thm:positive_unital_adjoint_mean_ergodic_retraction}
     Let $T:\MN{D}\to\MN{D}$ be a positive trace-preserving linear map
     whose trace adjoint $T^*$ satisfies the Schwarz inequality.  If $T$ has a
     positive definite fixed point $\rho>0$, then the trace adjoint of the

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -120,7 +120,7 @@ uniform in $h$.
     \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
     \leanok
     \uses{def:is_conditional_expectation, def:scalar_conditional_expectation,
-        def:tp_kraus}
+        def:tp_kraus, thm:scalar_conditional_expectation_isCPMap}
     Let $K$ be a trace-preserving Kraus family, let $\rho>0$ satisfy
     $T(\rho)=\rho$ for the associated channel
     $T(\rho)=\sum_iK_i\rho K_i^\dagger$, and assume every adjoint fixed point

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -120,7 +120,7 @@ uniform in $h$.
     \lean{Kraus.scalarConditionalExpectation_isConditionalExpectation}
     \leanok
     \uses{def:is_conditional_expectation, def:scalar_conditional_expectation,
-        def:tp_kraus, thm:scalar_conditional_expectation_isCPMap}
+        def:tp_kraus}
     Let $K$ be a trace-preserving Kraus family, let $\rho>0$ satisfy
     $T(\rho)=\rho$ for the associated channel
     $T(\rho)=\sum_iK_i\rho K_i^\dagger$, and assume every adjoint fixed point

--- a/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_fixed_points_and_wedderburn_i.tex
@@ -16,8 +16,8 @@ uniform in $h$.
     \leanok
     Given a $*$-subalgebra $S\subseteq\MN{D}$, a linear map
     $P:\MN{D}\to\MN{D}$ is a conditional expectation onto $S$ if it is
-    idempotent and unital, has range contained in $S$, and satisfies
-    $P(X)=X$ for every $X\in S$.
+    positive, idempotent, and unital, has range contained in $S$, and
+    satisfies $P(X)=X$ for every $X\in S$.
 \end{definition}
 
 \begin{definition}[Scalar conditional expectation]\label{def:scalar_conditional_expectation}
@@ -109,25 +109,25 @@ uniform in $h$.
     \label{thm:meanErgodicAdjoint_isConditionalExpectation}
     \lean{Kraus.meanErgodicAdjoint_isConditionalExpectation}
     \leanok
-    \uses{def:is_conditional_expectation, thm:positive_unital_adjoint_mean_ergodic_retraction}
+    \uses{def:is_conditional_expectation}
     Let $T:\MN{D}\to\MN{D}$ be a positive trace-preserving linear map
     whose trace adjoint $T^*$ satisfies the Schwarz inequality.  If $T$ has a
     positive definite fixed point $\rho>0$, then the trace adjoint of the
     mean-ergodic projection of $T$ is a conditional expectation onto the
     fixed-point star-subalgebra of $T^*$.
-    This is the main formulation of Wolf Theorem~6.15;
-    the construction does not use irreducibility or a Kraus representation,
-    and the period $h$ never enters the hypotheses.
+    This is the conditional-expectation step used in the proof of
+    Wolf Theorem~6.14.
 \end{theorem}
 
-\begin{theorem}[Wolf Theorem~6.15, numbered wrapper]
-    \label{thm:wolf_theorem_6_15}
-    \lean{Kraus.wolf_theorem_6_15}
-    \leanok
-    \uses{thm:meanErgodicAdjoint_isConditionalExpectation}
-    The numbered wrapper for Wolf Theorem~6.15:
-    same statement as Theorem~\ref{thm:meanErgodicAdjoint_isConditionalExpectation}.
-\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:positive_unital_adjoint_mean_ergodic_retraction,
+        thm:fixedPointsStarSubalgebra}
+    The trace adjoint of the mean-ergodic projection is positive, unital, and
+    idempotent, and its fixed points are exactly the fixed points of $T^*$.
+    The Schwarz inequality and the faithful fixed point make this fixed-point
+    space a $*$-subalgebra. Hence the projection is a conditional expectation
+    onto that algebra.
+\end{proof}
 
 \begin{lemma}[Complete positivity of the scalar conditional expectation]
     \label{thm:scalar_conditional_expectation_isCPMap}


### PR DESCRIPTION
### Motivation

The previous draft attributed the mean-ergodic conditional-expectation
construction to Wolf Theorem 6.15. The source's actual Theorem 6.15 is the
unique faithful fixed-state theorem under a full fixed-length Kraus-word span,
so that attribution was not source-faithful.

### Description

- Make `Kraus.IsConditionalExpectation` a matrix-algebra predicate that includes
  positivity, as required by Wolf Proposition 1.5 and Equation (1.40).
- Prove positivity for both the scalar and mean-ergodic constructions using
  their existing complete-positivity/positive-retraction results.
- Attribute `meanErgodicAdjoint_isConditionalExpectation` to the
  conditional-expectation step in the proof of Wolf Theorem 6.14.
- Remove the misleading `wolf_theorem_6_15` and
  `wolf_theorem_6_15_scalar` wrappers. This is a mathematical-language
  correction, so deprecated aliases would preserve the false attribution.
- Mark the actual Wolf Theorem 6.15 as not formalized in the Chapter 6 index.
- Replace the duplicate numbered Blueprint wrapper with a mathematical proof
  and correct the scalar-result label.

### Validation

- `lake env lean TNLean/Channel/FixedPoint/ConditionalExpectation.lean`
- `lake build TNLean.Channel.FixedPoint.ConditionalExpectation TNLean.Channel.WolfChapter6Wrappers TNLean.Channel.WolfChapter6Index`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Full 786-page Blueprint PDF build and visual inspection of the changed pages
- Proof-integrity and whitespace scans

`leanblueprint checkdecls` is currently blocked before reaching these
declarations by the repository-wide duplicate generated declaration
`MPSTensor.sum_fiber_smul._simp_1_1` from `TNLean.Algebra.FinSum`.

---

Addresses LionSR/QICLean#240

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and predicate tightening on formal math; no runtime or security impact. Call sites must satisfy the new positivity field on `IsConditionalExpectation`.
> 
> **Overview**
> Corrects how conditional expectations are tied to Wolf’s text: the mean-ergodic construction is attributed to the **Theorem 6.14** proof step (Prop. 1.5 / Eq. (1.40)), not to **Theorem 6.15** (unique faithful fixed state under full Kraus-word span).
> 
> **`Kraus.IsConditionalExpectation`** is now a matrix-algebra predicate that **requires positivity** (`IsPositiveMap`), matching Wolf Prop. 1.5. The scalar case supplies positivity via existing CP; **`meanErgodicAdjoint_isConditionalExpectation`** is added, showing the trace adjoint of the mean-ergodic projection is a conditional expectation onto the adjoint fixed-point star-subalgebra (general case beyond scalar `E_ρ`).
> 
> Removes **`wolf_theorem_6_15_scalar`** and the **`ConditionalExpectation`** import from **`WolfChapter6Wrappers`**. Updates **`WolfChapter6Index`**: conditional-expectation material is “used in 6.14 — FORMALIZED”; real **6.15** is **NOT FORMALIZED**. Blueprint drops the duplicate scalar-only wrapper in one chapter, adds the general theorem and proof in the Wedderburn section, and extends the definition with positivity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831be3229c612412744ead77bfbf58fc6f2e8267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->