### PR TITLE
refactor(PEPS): remove zero-reference auxiliaries (wave 6)

### DIFF
--- a/TNLean/PEPS/CoherentFrameInstance.lean
+++ b/TNLean/PEPS/CoherentFrameInstance.lean
@@ -166,6 +166,100 @@ noncomputable def legPair2 {cbd : Edge coarseGraph → ℕ} :
     (legs : (ie : IncidentEdge coarseGraph 2) → Fin (cbd ie.1)) :
     (legPair2 legs).2 = legs incidentBC2 := rfl
 
+/-! ### Crossing exclusivity at a super-site
+
+Under the partition the two crossing classes at a super-site are exclusive: a
+boundary edge crossing to one partner region does not cross to the other, because
+the two partner regions are disjoint. These lemmas make the boundary-edge
+partition of a region a genuine dichotomy. -/
+
+namespace CoarseBlockingFrame
+
+variable (F : CoarseBlockingFrame (G := G) (d := d) A)
+
+/-- A red boundary edge crossing to blue does not cross to the complement. -/
+@[deprecated "Use the pairwise-disjoint fields of `IsPartition` directly."
+  (since := "2026-07-30")]
+theorem not_crossing_rb_and_rc (hP : F.IsPartition) {g : Edge G}
+    (hrb : IsCrossingEdge (G := G) A F.red F.blue g) :
+    ¬ IsCrossingEdge (G := G) A F.red F.complement g := by
+  intro hrc
+  rcases hrb.1 with ⟨h1r, _⟩ | ⟨_, h2r⟩
+  · have hb2 : g.1.2 ∈ F.blue := by
+      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_blue h1r)
+      · exact hb
+    have hc2 : g.1.2 ∈ F.complement := by
+      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_complement h1r)
+      · exact hb
+    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb2 hc2
+  · have hb1 : g.1.1 ∈ F.blue := by
+      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact ha
+      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_blue h2r)
+    have hc1 : g.1.1 ∈ F.complement := by
+      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact ha
+      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_complement h2r)
+    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb1 hc1
+
+/-- A blue boundary edge crossing to red does not cross to the complement. -/
+@[deprecated "Use the pairwise-disjoint fields of `IsPartition` directly."
+  (since := "2026-07-30")]
+theorem not_crossing_rb_and_bc (hP : F.IsPartition) {g : Edge G}
+    (hrb : IsCrossingEdge (G := G) A F.red F.blue g) :
+    ¬ IsCrossingEdge (G := G) A F.blue F.complement g := by
+  intro hbc
+  rcases hrb.1 with ⟨h1r, _⟩ | ⟨_, h2r⟩
+  · have hb2 : g.1.2 ∈ F.blue := by
+      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_blue h1r)
+      · exact hb
+    have hc2 : g.1.2 ∈ F.complement := by
+      rcases hbc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_complement h1r)
+      · exact hb
+    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb2 hc2
+  · have hb1 : g.1.1 ∈ F.blue := by
+      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact ha
+      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_blue h2r)
+    have hc1 : g.1.1 ∈ F.complement := by
+      rcases hbc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact ha
+      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_complement h2r)
+    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb1 hc1
+
+/-- A complement boundary edge crossing to red does not cross to blue. -/
+@[deprecated "Use the pairwise-disjoint fields of `IsPartition` directly."
+  (since := "2026-07-30")]
+theorem not_crossing_rc_and_bc (hP : F.IsPartition) {g : Edge G}
+    (hrc : IsCrossingEdge (G := G) A F.red F.complement g) :
+    ¬ IsCrossingEdge (G := G) A F.blue F.complement g := by
+  intro hbc
+  rcases hrc.1 with ⟨h1r, _⟩ | ⟨_, h2r⟩
+  · have hc2 : g.1.2 ∈ F.complement := by
+      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_complement h1r)
+      · exact hb
+    have hb2 : g.1.2 ∈ F.blue := by
+      rcases hbc.1 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_blue h1r)
+      · exact hb
+    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb2 hc2
+  · have hc1 : g.1.1 ∈ F.complement := by
+      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact ha
+      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_complement h2r)
+    have hb1 : g.1.1 ∈ F.blue := by
+      rcases hbc.1 with ⟨ha, _⟩ | ⟨_, hb⟩
+      · exact ha
+      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_blue h2r)
+    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb1 hc1
+
+end CoarseBlockingFrame
+
 /-! ### Region-level crossing classification
 
 The crossing classification of a region boundary edge depends only on the three
@@ -849,6 +943,19 @@ noncomputable def coherentFrameOfRegions
     (hcover : red ∪ blue ∪ complement = Finset.univ) :
     (coherentFrameOfRegions hRed hBlue hCompl hd hpos hrb hrc hbc hcover).frame.complement =
       complement := rfl
+
+/-- The coherent frame of three partitioned regions is partitioned. -/
+@[deprecated "Construct `CoarseBlockingFrame.IsPartition` directly from the supplied
+disjointness and covering hypotheses." (since := "2026-07-30")]
+theorem coherentFrameOfRegions_isPartition
+    (hRed : RegionBlockedTensorInjective (G := G) A red)
+    (hBlue : RegionBlockedTensorInjective (G := G) A blue)
+    (hCompl : RegionBlockedTensorInjective (G := G) A complement)
+    (hd : 0 < d) (hpos : ∀ e : Edge G, 0 < A.bondDim e)
+    (hrb : Disjoint red blue) (hrc : Disjoint red complement) (hbc : Disjoint blue complement)
+    (hcover : red ∪ blue ∪ complement = Finset.univ) :
+    (coherentFrameOfRegions hRed hBlue hCompl hd hpos hrb hrc hbc hcover).frame.IsPartition :=
+  ⟨hrb, hrc, hbc, hcover⟩
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/CoherentFrameInstance.lean
+++ b/TNLean/PEPS/CoherentFrameInstance.lean
@@ -166,100 +166,6 @@ noncomputable def legPair2 {cbd : Edge coarseGraph → ℕ} :
     (legs : (ie : IncidentEdge coarseGraph 2) → Fin (cbd ie.1)) :
     (legPair2 legs).2 = legs incidentBC2 := rfl
 
-/-! ### Crossing exclusivity at a super-site
-
-Under the partition the two crossing classes at a super-site are exclusive: a
-boundary edge crossing to one partner region does not cross to the other, because
-the two partner regions are disjoint.  These lemmas make the boundary-edge
-partition of a region a genuine dichotomy. -/
-
-namespace CoarseBlockingFrame
-
-variable (F : CoarseBlockingFrame (G := G) (d := d) A)
-
-/-- A red boundary edge crossing to blue does not cross to the complement. -/
-theorem not_crossing_rb_and_rc (hP : F.IsPartition) {g : Edge G}
-    (hrb : IsCrossingEdge (G := G) A F.red F.blue g) :
-    ¬ IsCrossingEdge (G := G) A F.red F.complement g := by
-  intro hrc
-  rcases hrb.1 with ⟨h1r, _⟩ | ⟨_, h2r⟩
-  · have hb2 : g.1.2 ∈ F.blue := by
-      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_blue h1r)
-      · exact hb
-    have hc2 : g.1.2 ∈ F.complement := by
-      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_complement h1r)
-      · exact hb
-    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb2 hc2
-  · have hb1 : g.1.1 ∈ F.blue := by
-      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact ha
-      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_blue h2r)
-    have hc1 : g.1.1 ∈ F.complement := by
-      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact ha
-      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_complement h2r)
-    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb1 hc1
-
-/-- A blue boundary edge crossing to red does not cross to the complement. -/
-theorem not_crossing_rb_and_bc (hP : F.IsPartition) {g : Edge G}
-    (hrb : IsCrossingEdge (G := G) A F.red F.blue g) :
-    ¬ IsCrossingEdge (G := G) A F.blue F.complement g := by
-  intro hbc
-  rcases hrb.1 with ⟨h1r, _⟩ | ⟨_, h2r⟩
-  · have hb2 : g.1.2 ∈ F.blue := by
-      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_blue h1r)
-      · exact hb
-    have hc2 : g.1.2 ∈ F.complement := by
-      rcases hbc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_complement h1r)
-      · exact hb
-    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb2 hc2
-  · have hb1 : g.1.1 ∈ F.blue := by
-      rcases hrb.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact ha
-      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_blue h2r)
-    have hc1 : g.1.1 ∈ F.complement := by
-      rcases hbc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact ha
-      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_complement h2r)
-    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb1 hc1
-
-/-- A complement boundary edge crossing to red does not cross to blue. -/
-theorem not_crossing_rc_and_bc (hP : F.IsPartition) {g : Edge G}
-    (hrc : IsCrossingEdge (G := G) A F.red F.complement g) :
-    ¬ IsCrossingEdge (G := G) A F.blue F.complement g := by
-  intro hbc
-  rcases hrc.1 with ⟨h1r, _⟩ | ⟨_, h2r⟩
-  · have hc2 : g.1.2 ∈ F.complement := by
-      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_complement h1r)
-      · exact hb
-    have hb2 : g.1.2 ∈ F.blue := by
-      rcases hbc.1 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact absurd ha (Finset.disjoint_left.mp hP.red_disjoint_blue h1r)
-      · exact hb
-    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb2 hc2
-  · have hc1 : g.1.1 ∈ F.complement := by
-      rcases hrc.2 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact ha
-      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_complement h2r)
-    have hb1 : g.1.1 ∈ F.blue := by
-      rcases hbc.1 with ⟨ha, _⟩ | ⟨_, hb⟩
-      · exact ha
-      · exact absurd hb (Finset.disjoint_left.mp hP.red_disjoint_blue h2r)
-    exact Finset.disjoint_left.mp hP.blue_disjoint_complement hb1 hc1
-
-/-! ### Boundary-edge split of a region
-
-Every boundary edge of a region crosses to exactly one partner region
-(`isCrossingEdge_red_blue_or_red_complement` and its siblings), so a region
-boundary configuration splits into its two crossing configurations. -/
-
-end CoarseBlockingFrame
-
 /-! ### Region-level crossing classification
 
 The crossing classification of a region boundary edge depends only on the three
@@ -943,17 +849,6 @@ noncomputable def coherentFrameOfRegions
     (hcover : red ∪ blue ∪ complement = Finset.univ) :
     (coherentFrameOfRegions hRed hBlue hCompl hd hpos hrb hrc hbc hcover).frame.complement =
       complement := rfl
-
-/-- The coherent frame of three partitioned regions is partitioned. -/
-theorem coherentFrameOfRegions_isPartition
-    (hRed : RegionBlockedTensorInjective (G := G) A red)
-    (hBlue : RegionBlockedTensorInjective (G := G) A blue)
-    (hCompl : RegionBlockedTensorInjective (G := G) A complement)
-    (hd : 0 < d) (hpos : ∀ e : Edge G, 0 < A.bondDim e)
-    (hrb : Disjoint red blue) (hrc : Disjoint red complement) (hbc : Disjoint blue complement)
-    (hcover : red ∪ blue ∪ complement = Finset.univ) :
-    (coherentFrameOfRegions hRed hBlue hCompl hd hpos hrb hrc hbc hcover).frame.IsPartition :=
-  ⟨hrb, hrc, hbc, hcover⟩
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -79,16 +79,6 @@ omit [Fintype V] in
   rw [Edge.ofAdj_of_lt e.2.2 e.2.1]
 
 omit [Fintype V] in
-/-- The image edge `Edge.ofAdj h` is independent of the incidence direction of the
-adjacency `h`: orienting the pair `(u, v)` and the pair `(v, u)` gives the same
-edge, since `Edge.ofAdj` places the smaller endpoint first either way. -/
-theorem Edge.ofAdj_symm {G : SimpleGraph V} {u v : V} (h : G.Adj u v) :
-    Edge.ofAdj h = Edge.ofAdj h.symm := by
-  rcases lt_or_gt_of_ne (G.ne_of_adj h) with huv | hvu
-  · rw [Edge.ofAdj_of_lt h huv, Edge.ofAdj_of_gt h.symm huv]
-  · rw [Edge.ofAdj_of_gt h hvu, Edge.ofAdj_of_lt h.symm hvu]
-
-omit [Fintype V] in
 /-- An edge is determined by its unordered endpoint pair: if `(u, v)` is, in some
 order, the ordered endpoint pair of `e`, then orienting `(u, v)` with `Edge.ofAdj`
 recovers `e`. This is the bookkeeping that makes edge constructions independent

--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -79,6 +79,18 @@ omit [Fintype V] in
   rw [Edge.ofAdj_of_lt e.2.2 e.2.1]
 
 omit [Fintype V] in
+/-- The image edge `Edge.ofAdj h` is independent of the incidence direction of the
+adjacency `h`: orienting the pair `(u, v)` and the pair `(v, u)` gives the same
+edge, since `Edge.ofAdj` places the smaller endpoint first either way. -/
+@[deprecated "Use `Edge.ofAdj_of_lt` and `Edge.ofAdj_of_gt` for the required orientation."
+  (since := "2026-07-30")]
+theorem Edge.ofAdj_symm {G : SimpleGraph V} {u v : V} (h : G.Adj u v) :
+    Edge.ofAdj h = Edge.ofAdj h.symm := by
+  rcases lt_or_gt_of_ne (G.ne_of_adj h) with huv | hvu
+  · rw [Edge.ofAdj_of_lt h huv, Edge.ofAdj_of_gt h.symm huv]
+  · rw [Edge.ofAdj_of_gt h hvu, Edge.ofAdj_of_lt h.symm hvu]
+
+omit [Fintype V] in
 /-- An edge is determined by its unordered endpoint pair: if `(u, v)` is, in some
 order, the ordered endpoint pair of `e`, then orienting `(u, v)` with `Edge.ofAdj`
 recovers `e`. This is the bookkeeping that makes edge constructions independent

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite3.lean
@@ -465,26 +465,6 @@ theorem legEquivRed_eq_legEquivBlue_on_rb_single
   F.legEquivRed_eq_legEquivBlue_on_rb (fun ie => η ie.1) (fun ie => η ie.1)
     incidentRB0 rfl incidentRB1 rfl rfl g hf
 
-/-- For a single `η`, the red and complement boundary configurations agree on
-every red-to-complement crossing edge. -/
-theorem legEquivRed_eq_legEquivComplement_on_rc_single
-    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
-    (hf : IsCrossingEdge (G := G) A F.frame.red F.frame.complement g) :
-    (F.frame.legEquivRed (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
-      (F.frame.legEquivComplement (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) :=
-  F.legEquivRed_eq_legEquivComplement_on_rc (fun ie => η ie.1) (fun ie => η ie.1)
-    incidentRC0 rfl incidentRC2 rfl rfl g hf
-
-/-- For a single `η`, the blue and complement boundary configurations agree on
-every blue-to-complement crossing edge. -/
-theorem legEquivBlue_eq_legEquivComplement_on_bc_single
-    (η : VirtualConfig (F.frame.coarseTensor)) (g : Edge G)
-    (hf : IsCrossingEdge (G := G) A F.frame.blue F.frame.complement g) :
-    (F.frame.legEquivBlue (fun ie => η ie.1) ⟨g, hf.1⟩ : Fin (A.bondDim g)) =
-      (F.frame.legEquivComplement (fun ie => η ie.1) ⟨g, hf.2⟩ : Fin (A.bondDim g)) :=
-  F.legEquivBlue_eq_legEquivComplement_on_bc (fun ie => η ie.1) (fun ie => η ie.1)
-    incidentBC1 rfl incidentBC2 rfl rfl g hf
-
 end CoherentCoarseBlockingFrame
 
 end PEPS

--- a/TNLean/PEPS/TorusCoordinateSwap.lean
+++ b/TNLean/PEPS/TorusCoordinateSwap.lean
@@ -58,7 +58,7 @@ def torusCoordinateSwapRegion {width height : ℕ}
   simp [torusCoordinateSwapRegion]
 
 /-- Coordinate swap preserves unions of finite regions. -/
-@[deprecated "Expand `torusCoordinateSwapRegion` and use `Finset.image_union`."
+@[deprecated "Expand `torusCoordinateSwapRegion` and use `Finset.map_union`."
   (since := "2026-07-30")]
 theorem torusCoordinateSwapRegion_union {width height : ℕ}
     (R S : Finset (TorusVertex width height)) :

--- a/TNLean/PEPS/TorusCoordinateSwap.lean
+++ b/TNLean/PEPS/TorusCoordinateSwap.lean
@@ -57,6 +57,16 @@ def torusCoordinateSwapRegion {width height : ℕ}
     v ∈ torusCoordinateSwapRegion R ↔ (v.2, v.1) ∈ R := by
   simp [torusCoordinateSwapRegion]
 
+/-- Coordinate swap preserves unions of finite regions. -/
+@[deprecated "Expand `torusCoordinateSwapRegion` and use `Finset.image_union`."
+  (since := "2026-07-30")]
+theorem torusCoordinateSwapRegion_union {width height : ℕ}
+    (R S : Finset (TorusVertex width height)) :
+    torusCoordinateSwapRegion (R ∪ S) =
+      torusCoordinateSwapRegion R ∪ torusCoordinateSwapRegion S := by
+  ext v
+  simp only [mem_torusCoordinateSwapRegion, Finset.mem_union]
+
 /-- Coordinate swap commutes with finite indexed unions. -/
 theorem torusCoordinateSwapRegion_biUnion {width height : ℕ} {ι : Type*}
     (s : Finset ι) (R : ι → Finset (TorusVertex width height)) :
@@ -111,6 +121,40 @@ def torusCoordinateSwap :
     (torusCoordinateSwap (width := width) (height := height)).symm =
       torusCoordinateSwap (width := height) (height := width) :=
   rfl
+
+/-- Coordinate swap sends horizontal edges to vertical edges. -/
+@[deprecated "Use `torusHorizontalNeighbor_coordinateSwap` together with
+`Edge.map_endpoints`." (since := "2026-07-30")]
+theorem torusCoordinateSwap_isVertical {e : Edge (torusGraph width height)}
+    (he : IsHorizontalTorusEdge e) :
+    IsVerticalTorusEdge (Edge.map torusCoordinateSwap e) := by
+  have h := (torusHorizontalNeighbor_coordinateSwap (v := e.1.1) (w := e.1.2)).mpr he
+  rcases Edge.map_endpoints torusCoordinateSwap e with hends | hends
+  · unfold IsVerticalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.1 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.2 from hends.2]
+    exact h
+  · unfold IsVerticalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.2 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.1 from hends.2]
+    exact torusVerticalNeighbor_symm h
+
+/-- Coordinate swap sends vertical edges to horizontal edges. -/
+@[deprecated "Use `torusVerticalNeighbor_coordinateSwap` together with
+`Edge.map_endpoints`." (since := "2026-07-30")]
+theorem torusCoordinateSwap_isHorizontal {e : Edge (torusGraph width height)}
+    (he : IsVerticalTorusEdge e) :
+    IsHorizontalTorusEdge (Edge.map torusCoordinateSwap e) := by
+  have h := (torusVerticalNeighbor_coordinateSwap (v := e.1.1) (w := e.1.2)).mpr he
+  rcases Edge.map_endpoints torusCoordinateSwap e with hends | hends
+  · unfold IsHorizontalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.1 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.2 from hends.2]
+    exact h
+  · unfold IsHorizontalTorusEdge
+    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.2 from hends.1,
+      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.1 from hends.2]
+    exact torusHorizontalNeighbor_symm h
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusCoordinateSwap.lean
+++ b/TNLean/PEPS/TorusCoordinateSwap.lean
@@ -57,14 +57,6 @@ def torusCoordinateSwapRegion {width height : ℕ}
     v ∈ torusCoordinateSwapRegion R ↔ (v.2, v.1) ∈ R := by
   simp [torusCoordinateSwapRegion]
 
-/-- Coordinate swap preserves unions of finite regions. -/
-theorem torusCoordinateSwapRegion_union {width height : ℕ}
-    (R S : Finset (TorusVertex width height)) :
-    torusCoordinateSwapRegion (R ∪ S) =
-      torusCoordinateSwapRegion R ∪ torusCoordinateSwapRegion S := by
-  ext v
-  simp only [mem_torusCoordinateSwapRegion, Finset.mem_union]
-
 /-- Coordinate swap commutes with finite indexed unions. -/
 theorem torusCoordinateSwapRegion_biUnion {width height : ℕ} {ι : Type*}
     (s : Finset ι) (R : ι → Finset (TorusVertex width height)) :
@@ -119,44 +111,6 @@ def torusCoordinateSwap :
     (torusCoordinateSwap (width := width) (height := height)).symm =
       torusCoordinateSwap (width := height) (height := width) :=
   rfl
-
-/-- Coordinate swap sends horizontal edges to vertical edges. -/
-theorem torusCoordinateSwap_isVertical {e : Edge (torusGraph width height)}
-    (he : IsHorizontalTorusEdge e) :
-    IsVerticalTorusEdge (Edge.map torusCoordinateSwap e) := by
-  have h := (torusHorizontalNeighbor_coordinateSwap (v := e.1.1) (w := e.1.2)).mpr he
-  rcases Edge.map_endpoints torusCoordinateSwap e with hends | hends
-  · unfold IsVerticalTorusEdge
-    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.1 from hends.1,
-      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.2 from hends.2]
-    exact h
-  · unfold IsVerticalTorusEdge
-    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.2 from hends.1,
-      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.1 from hends.2]
-    exact torusVerticalNeighbor_symm h
-
-/-- Coordinate swap sends vertical edges to horizontal edges. -/
-theorem torusCoordinateSwap_isHorizontal {e : Edge (torusGraph width height)}
-    (he : IsVerticalTorusEdge e) :
-    IsHorizontalTorusEdge (Edge.map torusCoordinateSwap e) := by
-  have h := (torusVerticalNeighbor_coordinateSwap (v := e.1.1) (w := e.1.2)).mpr he
-  rcases Edge.map_endpoints torusCoordinateSwap e with hends | hends
-  · unfold IsHorizontalTorusEdge
-    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.1 from hends.1,
-      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.2 from hends.2]
-    exact h
-  · unfold IsHorizontalTorusEdge
-    rw [show (Edge.map torusCoordinateSwap e).1.1 = torusCoordinateSwap e.1.2 from hends.1,
-      show (Edge.map torusCoordinateSwap e).1.2 = torusCoordinateSwap e.1.1 from hends.2]
-    exact torusHorizontalNeighbor_symm h
-
-/-- Coordinate swap transposes a cyclic rectangle and exchanges its side lengths. -/
-theorem Region_map_torusCoordinateSwap_torusArcRectangle
-    (s : TorusVertex width height) (xLen yLen : ℕ) :
-    Region.map torusCoordinateSwap (torusArcRectangle s xLen yLen) =
-      torusArcRectangle (s.2, s.1) yLen xLen := by
-  change torusCoordinateSwapRegion (torusArcRectangle s xLen yLen) = _
-  exact torusCoordinateSwapRegion_torusArcRectangle s xLen yLen
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -64,65 +64,6 @@ def verticalStaircaseWindow (s : TorusVertex width height) (L K j : ℕ) :
     Finset (TorusVertex width height) :=
   torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j)
 
-/-! ### Coordinate-swap covariance -/
-
-/-- The first vertical end window is the coordinate transpose of the first
-horizontal end window with exchanged side lengths. -/
-theorem torusCoordinateSwapRegion_horizontalStaircaseRightWindow
-    (s : TorusVertex width height) (L K : ℕ) :
-    torusCoordinateSwapRegion
-        (horizontalStaircaseRightWindow (s.2, s.1) K L) =
-      verticalStaircaseRightWindow s L K :=
-  rfl
-
-/-- The last vertical end window is the coordinate transpose of the last
-horizontal end window with exchanged side lengths. -/
-theorem torusCoordinateSwapRegion_horizontalStaircaseLeftWindow
-    (s : TorusVertex width height) (L K : ℕ) :
-    torusCoordinateSwapRegion
-        (horizontalStaircaseLeftWindow (s.2, s.1) K L) =
-      verticalStaircaseLeftWindow s L K :=
-  rfl
-
-/-- The vertical staircase patch is the coordinate transpose of the horizontal
-staircase patch with exchanged side lengths. -/
-theorem torusCoordinateSwapRegion_horizontalStaircasePatch
-    (s : TorusVertex width height) (L K : ℕ) :
-    torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L) =
-      verticalStaircasePatch s L K :=
-  rfl
-
-/-- Each vertical staircase window is the coordinate transpose of the
-corresponding horizontal window with exchanged side lengths. -/
-theorem torusCoordinateSwapRegion_staircaseWindow
-    (s : TorusVertex width height) (L K j : ℕ) :
-    torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j) =
-      verticalStaircaseWindow s L K j :=
-  rfl
-
-/-- The first window of the vertical family is its first end window. -/
-theorem verticalStaircaseWindow_zero (s : TorusVertex width height) (L K : ℕ) :
-    verticalStaircaseWindow s L K 0 = verticalStaircaseRightWindow s L K := by
-  simp only [verticalStaircaseWindow, verticalStaircaseRightWindow, staircaseWindow_zero]
-
-/-- The last window of the vertical family is its last end window. -/
-theorem verticalStaircaseWindow_last (s : TorusVertex width height) {L K : ℕ}
-    (hL : 0 < L) (hK : 0 < K) :
-    verticalStaircaseWindow s L K (L + K - 1) = verticalStaircaseLeftWindow s L K := by
-  rw [verticalStaircaseWindow, verticalStaircaseLeftWindow, Nat.add_comm,
-    staircaseWindow_last (s.2, s.1) hK hL]
-
-/-- Every vertical staircase window is an `L × K` cyclic window, hence is
-injective under the window hypotheses. -/
-theorem NormalTorusArcWindowInjectivityHypotheses.verticalStaircaseWindow_injective
-    {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
-    (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
-    (s : TorusVertex width height) (j : ℕ) :
-    κ.IsInjective (verticalStaircaseWindow s L K j) := by
-  rw [verticalStaircaseWindow, staircaseWindow,
-    torusCoordinateSwapRegion_torusArcRectangle]
-  exact h.arcWindow_injective _
-
 /-! ### Transported consecutive-window unions -/
 
 /-- The union of two consecutive vertical staircase windows, defined as the
@@ -130,41 +71,6 @@ coordinate transpose of the corresponding horizontal union. -/
 def verticalStaircaseUnion (s : TorusVertex width height) (L K j : ℕ) :
     Finset (TorusVertex width height) :=
   torusCoordinateSwapRegion (staircaseUnion (s.2, s.1) K L j)
-
-/-- Each vertical consecutive-window union is the coordinate transpose of the
-corresponding horizontal union with exchanged side lengths. -/
-theorem torusCoordinateSwapRegion_staircaseUnion
-    (s : TorusVertex width height) (L K j : ℕ) :
-    torusCoordinateSwapRegion (staircaseUnion (s.2, s.1) K L j) =
-      verticalStaircaseUnion s L K j :=
-  rfl
-
-section GraphCovariance
-
-variable [Fact (1 < width)] [Fact (1 < height)]
-
-/-- Graph-isomorphism form of coordinate-swap covariance for staircase windows. -/
-theorem Region_map_torusCoordinateSwap_staircaseWindow
-    (s : TorusVertex width height) (L K j : ℕ) :
-    Region.map (torusCoordinateSwap (width := height) (height := width))
-        (staircaseWindow (s.2, s.1) K L j) = verticalStaircaseWindow s L K j :=
-  rfl
-
-/-- Graph-isomorphism form of coordinate-swap covariance for consecutive unions. -/
-theorem Region_map_torusCoordinateSwap_staircaseUnion
-    (s : TorusVertex width height) (L K j : ℕ) :
-    Region.map (torusCoordinateSwap (width := height) (height := width))
-        (staircaseUnion (s.2, s.1) K L j) = verticalStaircaseUnion s L K j :=
-  rfl
-
-/-- Graph-isomorphism form of coordinate-swap covariance for staircase patches. -/
-theorem Region_map_torusCoordinateSwap_horizontalStaircasePatch
-    (s : TorusVertex width height) (L K : ℕ) :
-    Region.map (torusCoordinateSwap (width := height) (height := width))
-        (horizontalStaircasePatch (s.2, s.1) K L) = verticalStaircasePatch s L K :=
-  rfl
-
-end GraphCovariance
 
 /-- A descending-arm consecutive union is an `L × (K + 1)` cyclic rectangle. -/
 theorem verticalStaircaseUnion_eq_verticalRectangle {L K : ℕ} (hh : 1 < height)
@@ -190,80 +96,6 @@ theorem verticalStaircaseUnion_eq_horizontalRectangle {L K : ℕ} (hw : 1 < widt
       (L := K) (K := L) hw (s.2, s.1) hj (by simpa [Nat.add_comm] using hjK))
   simpa only [verticalStaircaseUnion,
     torusCoordinateSwapRegion_torusArcRectangle] using h
-
-/-- Each vertical consecutive union is injective under the window and union
-closure hypotheses. -/
-theorem NormalTorusArcWindowInjectivityHypotheses.verticalStaircaseUnion_injective
-    {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
-    (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
-    (hUnion : RegionInjectivityUnionClosure κ) (hL : 2 ≤ L) (hK : 2 ≤ K)
-    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height) (s : TorusVertex width height)
-    {j : ℕ} (hjK : j + 1 < L + K) :
-    κ.IsInjective (verticalStaircaseUnion s L K j) := by
-  by_cases hj : j < K
-  · rw [verticalStaircaseUnion_eq_verticalRectangle (by omega) s hj]
-    exact h.verticalUnion_injective hUnion hL hK hxw hyh _
-  · rw [verticalStaircaseUnion_eq_horizontalRectangle (by omega) s (by omega) hjK]
-    exact h.horizontalUnion_injective hUnion hL hK hxw hyh _
-
-/-! ### Membership and transported nesting -/
-
-/-- Membership in a vertical staircase window, expressed by cyclic distances
-from the staircase corner. -/
-theorem mem_verticalStaircaseWindow {L K j : ℕ} (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height)
-    (s : TorusVertex width height) (v : TorusVertex width height) :
-    v ∈ verticalStaircaseWindow s L K j ↔
-      ((L - 1 - (j - K) : ℕ) ≤ (v.1 - s.1).val ∧
-          (v.1 - s.1).val < (L - 1 - (j - K)) + L) ∧
-        ((K - j : ℕ) ≤ (v.2 - s.2).val ∧ (v.2 - s.2).val < (K - j) + K) := by
-  rw [verticalStaircaseWindow, mem_torusCoordinateSwapRegion,
-    mem_staircaseWindow hyh hxw]
-  exact and_comm
-
-/-- The first window of a consecutive vertical union sits in that union. -/
-theorem verticalStaircaseWindow_subset_verticalStaircaseUnion
-    (s : TorusVertex width height) (L K j : ℕ) :
-    verticalStaircaseWindow s L K j ⊆ verticalStaircaseUnion s L K j :=
-  torusCoordinateSwapRegion_mono (staircaseWindow_subset_staircaseUnion (s.2, s.1) K L j)
-
-/-- The second window of a consecutive vertical union sits in that union. -/
-theorem verticalStaircaseWindow_succ_subset_verticalStaircaseUnion
-    (s : TorusVertex width height) (L K j : ℕ) :
-    verticalStaircaseWindow s L K (j + 1) ⊆ verticalStaircaseUnion s L K j :=
-  torusCoordinateSwapRegion_mono
-    (staircaseWindow_succ_subset_staircaseUnion (s.2, s.1) K L j)
-
-/-- Each vertical staircase window sits in the transported staircase patch. -/
-theorem verticalStaircaseWindow_subset_patch {L K j : ℕ} (hL : 0 < L)
-    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
-    verticalStaircaseWindow s L K j ⊆ verticalStaircasePatch s L K :=
-  torusCoordinateSwapRegion_mono
-    (staircaseWindow_subset_patch hL hyh hxw (s.2, s.1))
-
-/-- Each vertical consecutive union sits in the transported staircase patch. -/
-theorem verticalStaircaseUnion_subset_patch {L K j : ℕ} (hL : 0 < L)
-    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
-    verticalStaircaseUnion s L K j ⊆ verticalStaircasePatch s L K :=
-  torusCoordinateSwapRegion_mono
-    (staircaseUnion_subset_patch hL hyh hxw (s.2, s.1))
-
-/-- The transported patch is exactly the union of the vertical staircase family. -/
-theorem biUnion_verticalStaircaseWindow_eq_patch {L K : ℕ} (hL : 0 < L) (hK : 0 < K)
-    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
-    (Finset.range (L + K)).biUnion (verticalStaircaseWindow s L K) =
-      verticalStaircasePatch s L K := by
-  calc
-    (Finset.range (L + K)).biUnion (verticalStaircaseWindow s L K) =
-        (Finset.range (K + L)).biUnion
-          (fun j => torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j)) := by
-      rw [Nat.add_comm]
-      rfl
-    _ = torusCoordinateSwapRegion
-        ((Finset.range (K + L)).biUnion (staircaseWindow (s.2, s.1) K L)) :=
-      (torusCoordinateSwapRegion_biUnion _ _).symm
-    _ = torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L) := by
-      rw [biUnion_staircaseWindow_eq_patch hK hL hyh hxw]
-    _ = verticalStaircasePatch s L K := rfl
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -20,9 +20,10 @@ In staircase coordinates `s = (a, b)`, the resulting windows are the cyclic
 * `W_j = [a + L - 1, a + 2L - 1) × [b + K - j, b + 2K - j)` for `j ≤ K`;
 * `W_{K+i} = [a + L - 1 - i, a + 2L - 1 - i) × [b, b + K)`.
 
-The first arm descends and the second shifts horizontally.  All endpoint,
-consecutive-union, membership, nesting, and covering statements below are
-transported counterparts of the horizontal declarations.
+The first arm descends and the second shifts horizontally.  What is recorded
+below is the vertical family itself together with the two rectangle identities
+for its union: the union of the first `K` windows is the cyclic vertical
+rectangle, and the union of the remaining windows is the cyclic horizontal one.
 
 ## References
 

--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -21,9 +21,10 @@ In staircase coordinates `s = (a, b)`, the resulting windows are the cyclic
 * `W_{K+i} = [a + L - 1 - i, a + 2L - 1 - i) × [b, b + K)`.
 
 The first arm descends and the second shifts horizontally.  What is recorded
-below is the vertical family itself together with the two rectangle identities
-for its union: the union of the first `K` windows is the cyclic vertical
-rectangle, and the union of the remaining windows is the cyclic horizontal one.
+below is the vertical family itself, together with the union of two consecutive
+windows and the two rectangle identities it satisfies: on the descending arm,
+where `j < K`, that union is a cyclic `L × (K + 1)` rectangle, and on the
+shifting arm, where `K ≤ j`, it is a cyclic `(L + 1) × K` rectangle.
 
 ## References
 

--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -65,6 +65,35 @@ def verticalStaircaseWindow (s : TorusVertex width height) (L K j : ℕ) :
     Finset (TorusVertex width height) :=
   torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j)
 
+/-- The first window of the vertical family is its first end window. -/
+@[deprecated "Expand `verticalStaircaseWindow` and use `staircaseWindow_zero`."
+  (since := "2026-07-30")]
+theorem verticalStaircaseWindow_zero (s : TorusVertex width height) (L K : ℕ) :
+    verticalStaircaseWindow s L K 0 = verticalStaircaseRightWindow s L K := by
+  simp only [verticalStaircaseWindow, verticalStaircaseRightWindow, staircaseWindow_zero]
+
+/-- The last window of the vertical family is its last end window. -/
+@[deprecated "Expand the vertical-window definitions and use `staircaseWindow_last`."
+  (since := "2026-07-30")]
+theorem verticalStaircaseWindow_last (s : TorusVertex width height) {L K : ℕ}
+    (hL : 0 < L) (hK : 0 < K) :
+    verticalStaircaseWindow s L K (L + K - 1) = verticalStaircaseLeftWindow s L K := by
+  rw [verticalStaircaseWindow, verticalStaircaseLeftWindow, Nat.add_comm,
+    staircaseWindow_last (s.2, s.1) hK hL]
+
+/-- Every vertical staircase window is an `L × K` cyclic window, hence is
+injective under the window hypotheses. -/
+@[deprecated "Expand `verticalStaircaseWindow` and apply `arcWindow_injective`."
+  (since := "2026-07-30")]
+theorem NormalTorusArcWindowInjectivityHypotheses.verticalStaircaseWindow_injective
+    {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
+    (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
+    (s : TorusVertex width height) (j : ℕ) :
+    κ.IsInjective (verticalStaircaseWindow s L K j) := by
+  rw [verticalStaircaseWindow, staircaseWindow,
+    torusCoordinateSwapRegion_torusArcRectangle]
+  exact h.arcWindow_injective _
+
 /-! ### Transported consecutive-window unions -/
 
 /-- The union of two consecutive vertical staircase windows, defined as the
@@ -97,6 +126,95 @@ theorem verticalStaircaseUnion_eq_horizontalRectangle {L K : ℕ} (hw : 1 < widt
       (L := K) (K := L) hw (s.2, s.1) hj (by simpa [Nat.add_comm] using hjK))
   simpa only [verticalStaircaseUnion,
     torusCoordinateSwapRegion_torusArcRectangle] using h
+
+/-- Each vertical consecutive union is injective under the window and union
+closure hypotheses. -/
+@[deprecated "Rewrite with `verticalStaircaseUnion_eq_verticalRectangle` or
+`verticalStaircaseUnion_eq_horizontalRectangle`, then use the corresponding union
+injectivity theorem." (since := "2026-07-30")]
+theorem NormalTorusArcWindowInjectivityHypotheses.verticalStaircaseUnion_injective
+    {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
+    (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hL : 2 ≤ L) (hK : 2 ≤ K)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height) (s : TorusVertex width height)
+    {j : ℕ} (hjK : j + 1 < L + K) :
+    κ.IsInjective (verticalStaircaseUnion s L K j) := by
+  by_cases hj : j < K
+  · rw [verticalStaircaseUnion_eq_verticalRectangle (by omega) s hj]
+    exact h.verticalUnion_injective hUnion hL hK hxw hyh _
+  · rw [verticalStaircaseUnion_eq_horizontalRectangle (by omega) s (by omega) hjK]
+    exact h.horizontalUnion_injective hUnion hL hK hxw hyh _
+
+/-! ### Membership and transported nesting -/
+
+/-- Membership in a vertical staircase window, expressed by cyclic distances
+from the staircase corner. -/
+@[deprecated "Expand `verticalStaircaseWindow` and use `mem_staircaseWindow`."
+  (since := "2026-07-30")]
+theorem mem_verticalStaircaseWindow {L K j : ℕ} (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (s : TorusVertex width height) (v : TorusVertex width height) :
+    v ∈ verticalStaircaseWindow s L K j ↔
+      ((L - 1 - (j - K) : ℕ) ≤ (v.1 - s.1).val ∧
+          (v.1 - s.1).val < (L - 1 - (j - K)) + L) ∧
+        ((K - j : ℕ) ≤ (v.2 - s.2).val ∧ (v.2 - s.2).val < (K - j) + K) := by
+  rw [verticalStaircaseWindow, mem_torusCoordinateSwapRegion,
+    mem_staircaseWindow hyh hxw]
+  exact and_comm
+
+/-- The first window of a consecutive vertical union sits in that union. -/
+@[deprecated "Expand the vertical definitions and use
+`staircaseWindow_subset_staircaseUnion`." (since := "2026-07-30")]
+theorem verticalStaircaseWindow_subset_verticalStaircaseUnion
+    (s : TorusVertex width height) (L K j : ℕ) :
+    verticalStaircaseWindow s L K j ⊆ verticalStaircaseUnion s L K j :=
+  torusCoordinateSwapRegion_mono (staircaseWindow_subset_staircaseUnion (s.2, s.1) K L j)
+
+/-- The second window of a consecutive vertical union sits in that union. -/
+@[deprecated "Expand the vertical definitions and use
+`staircaseWindow_succ_subset_staircaseUnion`." (since := "2026-07-30")]
+theorem verticalStaircaseWindow_succ_subset_verticalStaircaseUnion
+    (s : TorusVertex width height) (L K j : ℕ) :
+    verticalStaircaseWindow s L K (j + 1) ⊆ verticalStaircaseUnion s L K j :=
+  torusCoordinateSwapRegion_mono
+    (staircaseWindow_succ_subset_staircaseUnion (s.2, s.1) K L j)
+
+/-- Each vertical staircase window sits in the transported staircase patch. -/
+@[deprecated "Expand the vertical definitions and use `staircaseWindow_subset_patch`."
+  (since := "2026-07-30")]
+theorem verticalStaircaseWindow_subset_patch {L K j : ℕ} (hL : 0 < L)
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
+    verticalStaircaseWindow s L K j ⊆ verticalStaircasePatch s L K :=
+  torusCoordinateSwapRegion_mono
+    (staircaseWindow_subset_patch hL hyh hxw (s.2, s.1))
+
+/-- Each vertical consecutive union sits in the transported staircase patch. -/
+@[deprecated "Expand the vertical definitions and use `staircaseUnion_subset_patch`."
+  (since := "2026-07-30")]
+theorem verticalStaircaseUnion_subset_patch {L K j : ℕ} (hL : 0 < L)
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
+    verticalStaircaseUnion s L K j ⊆ verticalStaircasePatch s L K :=
+  torusCoordinateSwapRegion_mono
+    (staircaseUnion_subset_patch hL hyh hxw (s.2, s.1))
+
+/-- The transported patch is exactly the union of the vertical staircase family. -/
+@[deprecated "Expand the vertical definitions and use `biUnion_staircaseWindow_eq_patch`."
+  (since := "2026-07-30")]
+theorem biUnion_verticalStaircaseWindow_eq_patch {L K : ℕ} (hL : 0 < L) (hK : 0 < K)
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
+    (Finset.range (L + K)).biUnion (verticalStaircaseWindow s L K) =
+      verticalStaircasePatch s L K := by
+  calc
+    (Finset.range (L + K)).biUnion (verticalStaircaseWindow s L K) =
+        (Finset.range (K + L)).biUnion
+          (fun j => torusCoordinateSwapRegion (staircaseWindow (s.2, s.1) K L j)) := by
+      rw [Nat.add_comm]
+      rfl
+    _ = torusCoordinateSwapRegion
+        ((Finset.range (K + L)).biUnion (staircaseWindow (s.2, s.1) K L)) :=
+      (torusCoordinateSwapRegion_biUnion _ _).symm
+    _ = torusCoordinateSwapRegion (horizontalStaircasePatch (s.2, s.1) K L) := by
+      rw [biUnion_staircaseWindow_eq_patch hK hL hyh hxw]
+    _ = verticalStaircasePatch s L K := rfl
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowFamilyVertical.lean
+++ b/TNLean/PEPS/TorusWindowFamilyVertical.lean
@@ -20,11 +20,10 @@ In staircase coordinates `s = (a, b)`, the resulting windows are the cyclic
 * `W_j = [a + L - 1, a + 2L - 1) × [b + K - j, b + 2K - j)` for `j ≤ K`;
 * `W_{K+i} = [a + L - 1 - i, a + 2L - 1 - i) × [b, b + K)`.
 
-The first arm descends and the second shifts horizontally.  What is recorded
-below is the vertical family itself, together with the union of two consecutive
-windows and the two rectangle identities it satisfies: on the descending arm,
-where `j < K`, that union is a cyclic `L × (K + 1)` rectangle, and on the
-shifting arm, where `K ≤ j`, it is a cyclic `(L + 1) × K` rectangle.
+The first arm descends and the second shifts horizontally.  A union of two
+consecutive windows is again a cyclic rectangle: on the descending arm, where
+`j < K`, it is `L × (K + 1)`, and on the shifting arm, where `K ≤ j` and
+`j + 1 < L + K`, it is `(L + 1) × K`.
 
 ## References
 

--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -139,18 +139,6 @@ theorem localTensorMap_ker_eq_bot_of_linearIndependent {A : Tensor G d} {v : V}
     LinearMap.ker (localTensorMap A v) = ⊥ :=
   LinearMap.ker_eq_bot.mpr <| localTensorMap_injective_of_linearIndependent hv
 
-/-- Vertex injectivity makes the local tensor map injective. -/
-theorem IsVertexInjective.localTensorMap_injective {A : Tensor G d}
-    (hA : IsVertexInjective A) (v : V) :
-    Function.Injective (localTensorMap A v) :=
-  localTensorMap_injective_of_linearIndependent (hA v)
-
-/-- Kernel form of `IsVertexInjective.localTensorMap_injective`. -/
-theorem IsVertexInjective.localTensorMap_ker_eq_bot {A : Tensor G d}
-    (hA : IsVertexInjective A) (v : V) :
-    LinearMap.ker (localTensorMap A v) = ⊥ :=
-  localTensorMap_ker_eq_bot_of_linearIndependent (hA v)
-
 /-- A chosen left inverse of the local tensor map under per-vertex linear
 independence of the tensor family at `v`. -/
 noncomputable def localLeftInverseAt (A : Tensor G d) {v : V}
@@ -543,13 +531,6 @@ theorem physRealizeLocalOpAt_smul (A : Tensor G d) {v : V}
   ext x
   simp [physRealizeLocalOpAt]
 
-/-- Realization is compatible with composition of virtual operators. -/
-theorem physRealizeLocalOp_comp (A : Tensor G d) (hA : IsVertexInjective A)
-    (v : V) (S T : LocalVirtualOp A v) :
-    physRealizeLocalOp A hA v (S.comp T) =
-      (physRealizeLocalOp A hA v S).comp (physRealizeLocalOp A hA v T) :=
-  physRealizeLocalOpAt_comp A (hA v) S T
-
 /-- Virtual operators are determined by their physical realizations. -/
 theorem physRealizeLocalOpAt_injective (A : Tensor G d) {v : V}
     (hv : LinearIndependent ℂ (A.component v)) :
@@ -641,12 +622,6 @@ theorem localProjectorAt_idempotent (A : Tensor G d) {v : V}
   simpa [localProjectorAt] using
     (physRealizeLocalOpAt_comp A hv LinearMap.id LinearMap.id).symm
 
-theorem localProjector_idempotent (A : Tensor G d) (hA : IsVertexInjective A)
-    (v : V) :
-    (localProjector A hA v).comp (localProjector A hA v) =
-      localProjector A hA v :=
-  localProjectorAt_idempotent A (hA v)
-
 /-- The virtual pullback realizes the projected physical action on the image of
 the local tensor map. -/
 theorem localVirtualOpOfPhysicalOpAt_spec (A : Tensor G d) {v : V}
@@ -732,18 +707,6 @@ theorem localVirtualOpOfPhysicalOpAt_eq_of_projected_action_eq (A : Tensor G d)
   intro c
   apply localTensorMap_injective_of_linearIndependent hv
   rw [localVirtualOpOfPhysicalOpAt_spec, localVirtualOpOfPhysicalOpAt_spec, hOO']
-
-/-- Two physical endpoint operations have the same virtual pullback if their
-projected actions agree on the image of the local tensor map. -/
-theorem localVirtualOpOfPhysicalOp_eq_of_projected_action_eq (A : Tensor G d)
-    (hA : IsVertexInjective A) (v : V)
-    (O O' : (Fin d → ℂ) →ₗ[ℂ] (Fin d → ℂ))
-    (hOO' : ∀ c : LocalVirtualConfig A v → ℂ,
-      localProjector A hA v (O (localTensorMap A v c)) =
-        localProjector A hA v (O' (localTensorMap A v c))) :
-    localVirtualOpOfPhysicalOp A hA v O =
-      localVirtualOpOfPhysicalOp A hA v O' :=
-  localVirtualOpOfPhysicalOpAt_eq_of_projected_action_eq A (hA v) O O' hOO'
 
 /-- Equality of virtual pullbacks is equivalent to equality of the projected
 physical actions on the image of the local tensor map. -/

--- a/TNLean/PEPS/VirtualInsertion.lean
+++ b/TNLean/PEPS/VirtualInsertion.lean
@@ -139,6 +139,12 @@ theorem localTensorMap_ker_eq_bot_of_linearIndependent {A : Tensor G d} {v : V}
     LinearMap.ker (localTensorMap A v) = ⊥ :=
   LinearMap.ker_eq_bot.mpr <| localTensorMap_injective_of_linearIndependent hv
 
+/-- Vertex injectivity makes the local tensor map injective. -/
+theorem IsVertexInjective.localTensorMap_injective {A : Tensor G d}
+    (hA : IsVertexInjective A) (v : V) :
+    Function.Injective (localTensorMap A v) :=
+  localTensorMap_injective_of_linearIndependent (hA v)
+
 /-- A chosen left inverse of the local tensor map under per-vertex linear
 independence of the tensor family at `v`. -/
 noncomputable def localLeftInverseAt (A : Tensor G d) {v : V}

--- a/docs/audits/2026-07-30_peps_zero_reference_pass_through_audit.md
+++ b/docs/audits/2026-07-30_peps_zero_reference_pass_through_audit.md
@@ -1,0 +1,28 @@
+# PEPS zero-reference pass-through audit
+
+This audit records the repository-local deprecation exception used by PR #5112.
+Each declaration below was an exact pass-through with no independent
+mathematical content. At the audited head, it had no non-`Archive` consumer and
+no Blueprint `\lean{...}` tag.
+
+| Removed declaration | Existing replacement |
+|---|---|
+| `legEquivRed_eq_legEquivComplement_on_rc_single` | `legEquivRed_eq_legEquivComplement_on_rc` with the same configuration in both arguments |
+| `legEquivBlue_eq_legEquivComplement_on_bc_single` | `legEquivBlue_eq_legEquivComplement_on_bc` with the same configuration in both arguments |
+| `Region_map_torusCoordinateSwap_torusArcRectangle` | unfold `Region.map`, then use `torusCoordinateSwapRegion_torusArcRectangle` |
+| `torusCoordinateSwapRegion_horizontalStaircaseRightWindow` | unfold `verticalStaircaseRightWindow`; the equality is definitional |
+| `torusCoordinateSwapRegion_horizontalStaircaseLeftWindow` | unfold `verticalStaircaseLeftWindow`; the equality is definitional |
+| `torusCoordinateSwapRegion_horizontalStaircasePatch` | unfold `verticalStaircasePatch`; the equality is definitional |
+| `torusCoordinateSwapRegion_staircaseWindow` | unfold `verticalStaircaseWindow`; the equality is definitional |
+| `torusCoordinateSwapRegion_staircaseUnion` | unfold `verticalStaircaseUnion`; the equality is definitional |
+| `Region_map_torusCoordinateSwap_staircaseWindow` | unfold `Region.map` and `verticalStaircaseWindow`; the equality is definitional |
+| `Region_map_torusCoordinateSwap_staircaseUnion` | unfold `Region.map` and `verticalStaircaseUnion`; the equality is definitional |
+| `Region_map_torusCoordinateSwap_horizontalStaircasePatch` | unfold `Region.map` and `verticalStaircasePatch`; the equality is definitional |
+| `IsVertexInjective.localTensorMap_ker_eq_bot` | `localTensorMap_ker_eq_bot_of_linearIndependent (hA v)` |
+| `physRealizeLocalOp_comp` | `physRealizeLocalOpAt_comp A (hA v)` |
+| `localProjector_idempotent` | `localProjectorAt_idempotent A (hA v)` |
+| `localVirtualOpOfPhysicalOp_eq_of_projected_action_eq` | `localVirtualOpOfPhysicalOpAt_eq_of_projected_action_eq A (hA v)` |
+
+All other public declarations considered by this wave contain independent
+mathematical statements or proofs. They remain available with dated
+deprecations rather than using this exception.


### PR DESCRIPTION
### Motivation

- Wave 5 left PEPS as the only large block of declarations whose name token occurs exactly once in the repository, at their own definition site.
- These are staged helpers from abandoned proof attempts: no proof, no blueprint `\lean{}` tag, and no documentation cites them, so removing them changes no provable statement on the blueprint route.

### Description

The wave has two halves, and the deprecation policy in `docs/MATHLIB_style.md` decides which declaration falls in which.

**Half one — dated deprecations (18 declarations).** Every removed public declaration that carries independent mathematical content keeps a `@[deprecated]` transition rather than disappearing. Downstream code continues to compile and is told what to move to.

**Half two — immediate removal under the repository-local pass-through exception (15 declarations).** These were exact pass-throughs with no independent mathematical content, no non-`Archive` consumer, and no blueprint `\lean{}` tag at the audited head. **This pull request uses that exception**, and `docs/audits/2026-07-30_peps_zero_reference_pass_through_audit.md` records the audit the exception requires. The declarations and their replacements:

| Removed declaration | Existing replacement |
|---|---|
| `legEquivRed_eq_legEquivComplement_on_rc_single` | `legEquivRed_eq_legEquivComplement_on_rc`, same configuration in both arguments |
| `legEquivBlue_eq_legEquivComplement_on_bc_single` | `legEquivBlue_eq_legEquivComplement_on_bc`, same configuration in both arguments |
| `Region_map_torusCoordinateSwap_torusArcRectangle` | unfold `Region.map`, then `torusCoordinateSwapRegion_torusArcRectangle` |
| `torusCoordinateSwapRegion_horizontalStaircaseRightWindow` | unfold `verticalStaircaseRightWindow`; definitional |
| `torusCoordinateSwapRegion_horizontalStaircaseLeftWindow` | unfold `verticalStaircaseLeftWindow`; definitional |
| `torusCoordinateSwapRegion_horizontalStaircasePatch` | unfold `verticalStaircasePatch`; definitional |
| `torusCoordinateSwapRegion_staircaseWindow` | unfold `verticalStaircaseWindow`; definitional |
| `torusCoordinateSwapRegion_staircaseUnion` | unfold `verticalStaircaseUnion`; definitional |
| `Region_map_torusCoordinateSwap_staircaseWindow` | unfold `Region.map` and `verticalStaircaseWindow`; definitional |
| `Region_map_torusCoordinateSwap_staircaseUnion` | unfold `Region.map` and `verticalStaircaseUnion`; definitional |
| `Region_map_torusCoordinateSwap_horizontalStaircasePatch` | unfold `Region.map` and `verticalStaircasePatch`; definitional |
| `IsVertexInjective.localTensorMap_ker_eq_bot` | `localTensorMap_ker_eq_bot_of_linearIndependent (hA v)` |
| `physRealizeLocalOp_comp` | `physRealizeLocalOpAt_comp A (hA v)` |
| `localProjector_idempotent` | `localProjectorAt_idempotent A (hA v)` |
| `localVirtualOpOfPhysicalOp_eq_of_projected_action_eq` | `localVirtualOpOfPhysicalOpAt_eq_of_projected_action_eq A (hA v)` |

Files touched: `TNLean/PEPS/TorusWindowFamilyVertical.lean`, `CoherentFrameInstance.lean`, `TorusCoordinateSwap.lean`, `VirtualInsertion.lean`, `RegionBlock/CoarseThreeSite3.lean`, `Defs.lean`, plus the audit note. Net +70/−140.

`IsVertexInjective.localTensorMap_injective` was restored after the first revision: it has four dot-notation call sites that the fully-qualified-name scan could not see. The module summary of `TorusWindowFamilyVertical.lean` was also rewritten, since the sections it advertised are gone.

No renames, no statement changes, no proof rewrites, and no import edits beyond those the deletions make dead — the import work stays with #4847.

### Testing

CI on this pull request is the verification of record, and the blueprint declaration check is the load-bearing gate for a deletion wave — a lost `\lean{}` target surfaces there. An independent dot-notation-aware rescan over every declaration removed by this wave found no surviving references.

---
Addresses #4564

### Agent assistance

Written by the repository's `@claude` mention workflow (Claude Code in GitHub Actions, using the provider configured in `CLAUDE_OPUS_MODEL`), from a scoping comment on the issue, with follow-up commits from the auto-fix loop. The pull request was opened separately because the workflow's auto-create-PR step failed with `HTTP 401: Bad credentials`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion and deprecation of unused PEPS helpers with no logic changes; blueprint-relevant math is unchanged aside from migration paths for deprecated names.
> 
> **Overview**
> **Wave 6** trims unused PEPS lemmas: **15 pass-through declarations** are deleted outright (documented in `docs/audits/2026-07-30_peps_zero_reference_pass_through_audit.md`), and **18 others** stay in the library with `@[deprecated … (since := "2026-07-30")]` pointing callers at `…At` lemmas, `IsPartition` fields, or definitional unfolds.
> 
> The bulk of the line count drop is **vertical torus window geometry**: definitional `torusCoordinateSwapRegion_*` / `Region_map_torusCoordinateSwap_*` bridges and a `GraphCovariance` section go away; `TorusWindowFamilyVertical` module docs now describe consecutive unions as cyclic rectangles instead of listing transported lemmas. **Virtual insertion** loses thin `IsVertexInjective` wrappers (`localTensorMap_ker_eq_bot`, `physRealizeLocalOp_comp`, etc.) in favor of existing `…At` APIs. **Coarse three-site** drops two single-`η` leg-equivalence corollaries; **CoherentFrameInstance** drops a redundant doc section and deprecates partition/crossing helpers rather than removing them.
> 
> No theorem statements or proofs are rewritten—only API surface and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2731ef98dd32a11243134098426739bb637d61a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->