### PR TITLE
feat(MPS/MPDO): support active sector bonds

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -150,6 +150,7 @@ import TNLean.MPS.MPDO.PerCopyHorizontalCF
 import TNLean.MPS.MPDO.PeriodicExclusion
 import TNLean.MPS.MPDO.PhysicalBlocking
 import TNLean.MPS.MPDO.PhysicalGibbsEmbedding
+import TNLean.MPS.MPDO.PhysicalSectorActiveBond
 import TNLean.MPS.MPDO.PhysicalSectorActiveFactorSupport
 import TNLean.MPS.MPDO.PhysicalSectorActiveNeighboring
 import TNLean.MPS.MPDO.PhysicalSectorActiveRestriction

--- a/TNLean/MPS/MPDO/PhysicalSectorActiveBond.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorActiveBond.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTSectorCommutingFamily
+import TNLean.MPS.MPDO.PhysicalSectorActiveNeighboring
+import TNLean.MPS.MPDO.PhysicalSupportBondTransport
+
+/-!
+# Positive bonds from the active physical compression
+
+An ambient physical-sector factorization with positive neighboring operators
+has a canonical restriction to the joint physical support of its slices.  The
+positive commuting bond constructed on that restriction is supported on every
+orthogonal one-site projection which absorbs all physical slices.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.2, equations `AppUkU=rl`, `Appetakhetc`, `PjKiPj`, and
+  `generateMPDO`, lines 1383--1450 and 1680--1770.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+namespace PhysicalSectorFactorization
+
+/-- An ambient physical-sector factorization with positive neighboring
+operators gives a positive commuting bond supported on every orthogonal
+projection which absorbs all physical slices.  Its periodic product is the
+original MPO at every length at least two.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppUkU=rl`,
+`Appetakhetc`, `PjKiPj`, and `generateMPDO`, lines 1383--1450 and
+1680--1770. -/
+theorem exists_etaLocalStructureData_supported_of_twoSidedPhysicalSlice
+    {K : MPOTensor d D} (F : PhysicalSectorFactorization K)
+    (P : Matrix (Fin d) (Fin d) ℂ)
+    (hP : IsOrthogonalProjection P)
+    (hK : K.IsInjective)
+    (hSupport : ∀ β α,
+      P * physicalSlice K β α = physicalSlice K β α ∧
+        physicalSlice K β α * P = physicalSlice K β α)
+    (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef) :
+    ∃ data : EtaLocalStructureData K,
+      twoSiteSectorProjection P * data.bondData.bond *
+          twoSiteSectorProjection P = data.bondData.bond ∧
+      ∀ N (hN : 2 ≤ N),
+        mpo K N = (data.bondData.toCommutingFormData hN).product := by
+  let W :=
+    PhysicalSectorFactorization.ActivePhysicalCompressionWitness.canonical F
+  let restriction := W.restrictionData hK hη
+  let G := W.factorizationForRestrictionData hK hη
+  obtain ⟨data, hdata, hrealizes⟩ :=
+    restriction.exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization
+      G (fun k h ↦ W.neighboringOperator_posSemidef hη k h)
+  refine ⟨data, ?_, hrealizes⟩
+  let Q := physicalSupportProj K
+  have hPQ : P * Q = Q :=
+    mul_physicalSupportProj_eq_self_of_forall_mul_physicalSlice_eq
+      K P (fun β α ↦ (hSupport β α).1)
+  have hQ : IsOrthogonalProjection Q :=
+    MPSTensor.isOrthogonalProjection_supportProj
+      (physicalSliceColumns K * (physicalSliceColumns K)ᴴ)
+      (Matrix.posSemidef_self_mul_conjTranspose (physicalSliceColumns K))
+  have hQP : Q * P = Q := by
+    have h := congrArg Matrix.conjTranspose hPQ
+    rwa [Matrix.conjTranspose_mul, hQ.1.eq, hP.1.eq] at h
+  exact twoSiteSectorProjection_supported_of_supported_of_absorbs
+    P Q hPQ hQP data.bondData.bond hdata
+
+end PhysicalSectorFactorization
+
+/-- Pairwise orthogonal projections which absorb injective sector tensors
+support an orthogonal family of positive commuting bonds whenever the ambient
+sector tensors have positive physical-sector factorizations.
+
+Source: arXiv:1606.00608, Appendix C.2, equations `AppKxKy=0`,
+`AppUkU=rl`, `Appetakhetc`, `PjKiPj`, and `generateMPDO`, lines
+1383--1450 and 1628--1770, and Proposition `prop3to4`, lines
+1786--1796. -/
+theorem nonempty_orthogonalCommutingSectorFamily_of_ambientPhysicalSectorFactorization
+    {g : ℕ} {dim : Fin g → ℕ}
+    (K : (s : Fin g) → MPOTensor d (dim s))
+    (P : Fin g → Matrix (Fin d) (Fin d) ℂ)
+    (hP : ∀ s, IsOrthogonalProjection (P s))
+    (hPorth : ∀ {s t}, s ≠ t → P s * P t = 0)
+    (hInjective : ∀ s, (K s).IsInjective)
+    (hSupport : ∀ s β α,
+      P s * physicalSlice (K s) β α = physicalSlice (K s) β α ∧
+        physicalSlice (K s) β α * P s = physicalSlice (K s) β α)
+    (F : (s : Fin g) → PhysicalSectorFactorization (K s))
+    (hη : ∀ s k h, ((F s).neighboringOperator k h).PosSemidef) :
+    Nonempty (OrthogonalCommutingSectorFamily K) := by
+  classical
+  let data : (s : Fin g) → EtaLocalStructureData (K s) :=
+    fun s ↦ Classical.choose
+      ((F s).exists_etaLocalStructureData_supported_of_twoSidedPhysicalSlice
+        (P s) (hP s) (hInjective s) (hSupport s) (hη s))
+  have hdata : ∀ s : Fin g,
+      twoSiteSectorProjection (P s) * (data s).bondData.bond *
+          twoSiteSectorProjection (P s) = (data s).bondData.bond ∧
+        ∀ N (hN : 2 ≤ N),
+          mpo (K s) N = ((data s).bondData.toCommutingFormData hN).product :=
+    fun s ↦ Classical.choose_spec
+      ((F s).exists_etaLocalStructureData_supported_of_twoSidedPhysicalSlice
+        (P s) (hP s) (hInjective s) (hSupport s) (hη s))
+  exact ⟨{
+    projection := P
+    projection_isOrthogonal := hP
+    projection_orthogonal := fun hst ↦ hPorth hst
+    bondData := fun s ↦ (data s).bondData
+    bond_supported := fun s ↦ (hdata s).1
+    realizes_mpo := fun s N hN ↦ (hdata s).2 N hN }⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure_capstone.tex
@@ -599,6 +599,56 @@
     Theorem~\ref{thm:mpdo_bnt_layer_orthogonal_supports}.
 \end{proof}
 
+\begin{theorem}[Positive sector bonds on the printed physical supports]
+    \label{thm:mpdo_ambient_sector_factorization_supported_bond}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+        exists_etaLocalStructureData_supported_of_twoSidedPhysicalSlice,
+        MPOTensor.%
+          nonempty_orthogonalCommutingSectorFamily_of_ambientPhysicalSectorFactorization}
+    \leanok
+    \uses{thm:mpdo_active_physical_sector_neighboring_positivity}
+    Let $K$ be injective and admit a physical-sector factorization with
+    positive semidefinite neighboring operators.  If an orthogonal projection
+    $P$ satisfies
+    \begin{align}
+        PK[\beta,\alpha]
+        &=K[\beta,\alpha]
+         =K[\beta,\alpha]P
+        \notag
+    \end{align}
+    for every $\beta,\alpha$, then there is a positive two-site operator $B$
+    whose periodic translates commute and such that
+    \begin{align}
+        (P\otimes P)B(P\otimes P)&=B,
+        \notag\\
+        \operatorname{mpo}(K,N)
+        &=\prod_{j=0}^{N-1}\tau_j(B)
+        \qquad (N\geq2).
+        \notag
+    \end{align}
+    Applied to pairwise orthogonal projections $P_s$, this construction gives
+    an orthogonal family of positive commuting sector bonds for the tensors
+    $K_s$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Restrict $K$ to its canonical joint physical support $Q$ by
+    Theorems~\ref{thm:mpdo_active_physical_sector_restriction}
+    and~\ref{thm:mpdo_active_physical_sector_neighboring_positivity}.
+    The positive neighboring operators on the restriction give a positive
+    commuting bond supported on $Q\otimes Q$, with the displayed periodic
+    product.  Minimality of the joint column support and the two-sided
+    absorption by $P$ give
+    \begin{align}
+        PQ=Q=QP.
+        \notag
+    \end{align}
+    Hence support of the bond on $Q\otimes Q$ implies support on
+    $P\otimes P$.  Performing this construction in every orthogonal sector
+    gives the final assertion.
+\end{proof}
+
 \begin{theorem}[Square-zero obstruction for arbitrary MPO tensors]
     \label{thm:mpdo_bnt_layer_square_zero_obstruction}
     \lean{MPOTensor.BNTLayerOrthogonalityCounterexample.squareZeroPhysicalMatrix_ne_zero,

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -68,9 +68,11 @@ For MPDO renormalization fixed points:
   supplies one such family under its projector, closure, inverse, word-span,
   and sectorwise-SAL hypotheses. The active factor supports now give the
   canonical physical restriction without unused complementary directions,
-  and the compressed neighboring operators remain positive by explicit
-  congruence. Proposition `prop3to4` remains partial because the final assembly
-  from exactly its five printed blockwise identities has not yet been proved.
+  the compressed neighboring operators remain positive by explicit
+  congruence, and the resulting positive commuting bonds are supported on the
+  printed absorbing projections. Proposition `prop3to4` remains partial
+  because the trace-factor, normalization, and common-copy-weight data have
+  not yet been assembled with these sector bonds.
 - `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records the missing
   coherent positive choice for the inverse-map neighboring operators in
   Appendix C.2. The comparison with the conjugated Hayashi decomposition,

--- a/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
+++ b/docs/paper-gaps/cpsv16_gsnnch_sector_decomposition.tex
@@ -148,11 +148,10 @@ and
 {\scriptsize\leanid{MPOTensor.exists_pairwise_orthogonal_twoSided_physicalSupport_commonWeightAbsorbedBasis}}.}
 
 This formalizes the pairwise support consequence of the earlier Case~II data.
-The two-sided slice equations now also give the injective restriction of each
-representative to the range of its projection.  If this restricted tensor is
-equipped with a physical-sector factorization whose neighboring operators are
-positive semidefinite, its positive commuting bond lifts to a bond $B_x$ on
-the original one-site space satisfying
+The ambient factorization \texttt{AppUkU=rl}, together with
+\texttt{Appetakhetc}, now supplies the canonical injective active restriction
+and its positive physical-sector factorization.  Its positive commuting bond
+lifts to a bond $B_x$ on the original one-site space satisfying
 \[
   (P_x\otimes P_x)B_x(P_x\otimes P_x)=B_x.
 \]
@@ -161,10 +160,9 @@ $\rho^{(N)}(\mathcal K_x)$ exactly for every $N\geq2$.  Applying this
 construction to pairwise orthogonal projections gives the orthogonal commuting
 sector family required for the outer GSNNCH sum.
 \footnote{\raggedright Formal declarations:
-{\scriptsize\leanid{MPOTensor.nonempty_physicalSupportRestrictionData_of_twoSided_physicalSlice}},
-{\scriptsize\leanid{MPOTensor.PhysicalSupportRestrictionData.exists_etaLocalStructureData_lifted_supported_of_physicalSectorFactorization}},
+{\scriptsize\leanid{MPOTensor.PhysicalSectorFactorization.exists_etaLocalStructureData_supported_of_twoSidedPhysicalSlice}},
 and
-{\scriptsize\leanid{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_twoSidedPhysicalSlice}}.}
+{\scriptsize\leanid{MPOTensor.nonempty_orthogonalCommutingSectorFamily_of_ambientPhysicalSectorFactorization}}.}
 
 The active factor supports in the displayed ambient factorization
 \texttt{AppUkU=rl} have now been assembled into the canonical physical
@@ -182,6 +180,14 @@ with the explicit congruence of the corresponding ambient operator from
 Consequently the canonical restriction has a positive physical-sector
 factorization indexed precisely by the active ambient sectors, including the
 vacuous empty-family case.
+
+The canonical joint physical support is contained in every orthogonal
+projection satisfying the two-sided equations \texttt{PjKiPj}.  Two-site
+support monotonicity therefore transports the positive commuting bond from
+the canonical support to the printed projection $P_x$.  Thus the local
+compatibility obligation between \texttt{AppUkU=rl},
+\texttt{Appetakhetc}, and \texttt{PjKiPj} is complete, both for one sector
+and for a pairwise orthogonal family of sectors.
 
 The final printed proof of Proposition~\texttt{prop3to4} uses projector
 relations obtained earlier rather than deriving them in its last step.  The
@@ -230,16 +236,15 @@ MPO tensors without those hypotheses.
 
 The construction from an already supplied orthogonal commuting sector family
 to the GSNNCH form is available, together with the natural BNT multiplicities.
-Two-sided physical-slice absorption now supplies the physical restrictions,
-and a positive physical-sector factorization on each restricted space supplies
-supported positive commuting bonds with exact periodic products.  The
-canonical restriction and its exact sectorwise factorization have now been
-derived from \texttt{AppUkU=rl}, with inactive factor directions removed
-without a minimality hypothesis.  The neighboring operators are the explicit
-congruences prescribed by \texttt{Appetakhetc}, and hence remain positive
-semidefinite.  This active compression must now be combined with
-\texttt{AppKxKy=0}, \texttt{Apptralktrrk}, and \texttt{AppPsiPhi}, with
-common copy weights retained from the preceding Case~II argument.
+The canonical restriction, its exact sectorwise factorization, and its
+positive neighboring operators have now been derived from
+\texttt{AppUkU=rl} and \texttt{Appetakhetc}, with inactive factor
+directions removed without a minimality hypothesis.  Together with the
+two-sided supports obtained from \texttt{AppKxKy=0}, this gives supported
+positive commuting bonds with exact periodic products on the printed
+projections.  The remaining capstone must combine these sector bonds with
+\texttt{Apptralktrrk} and \texttt{AppPsiPhi}, with common copy weights
+retained from the preceding Case~II argument.
 Proposition~\texttt{prop3to4} should therefore not yet be classified as
 complete.
 

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -84,7 +84,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_simple_local_primitivity_active_trace_matrix.tex` | — | — | L188 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_physical_coordinates.tex` | — | — | L324, 329, 334, 344, 352, 357 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_refinement_channels_sector_coordinates.tex` | — | — | L160, 175 `tenkzcd` → `R-cd+R-record` |
-| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L650 `tenkz` → `C-policy+C-record` | L654, 660, 665 `tenkz` → `C-record+R-record` |
+| `ch21_mpdo_rfp_simple_local_structure_capstone.tex` | — | L259 `tenkz` → `C-record`<br>L700 `tenkz` → `C-policy+C-record` | L704, 710, 715 `tenkz` → `C-record+R-record` |
 | `ch23_algebraic_ft_foundations.tex` | — | — | L47, 51, 167, 371, 375, 387, 391, 433, 437, 441, 450, 454 `tenkz` → `C-policy+C-record+R-record`<br>L171 `tenkz` → `C-record+R-record` |
 | `ch24_peps_ft.tex` | — | — | L25 `tenkzlattice` → `C-policy+R-lattice+R-record`<br>L53, 96 `tenkzfree` → `R-free+R-record` |
 | `ch24_peps_ft_balanced_edge_scalars.tex` | — | — | L18 `tenkzfree` → `C-species+R-free+R-record` |


### PR DESCRIPTION
## Mathematical content

This proves the final compatibility step for the sector-bond part of Proposition 3. From an ambient physical-sector factorization, injectivity, and positivity of the neighboring operators, it constructs the canonical active restriction and its positive commuting nearest-neighbor bond.

For the canonical active support projection `Q`, the restriction theorem gives a bond supported on `Q ⊗ Q`. If `P` is any printed orthogonal sector projection satisfying the two-sided slice identities, minimality of the physical support gives `P Q = Q`; taking adjoints gives `Q P = Q`. The two-site support lemma then transports the bond support from `Q ⊗ Q` to `P ⊗ P`.

The accompanying family theorem chooses these data sectorwise and produces `Nonempty (OrthogonalCommutingSectorFamily K)`. The bond data retain positivity, commutativity of all translates, and the exact periodic product identity for every chain length at least two. The empty active-sector family remains vacuous and no complementary sector is introduced.

The proof uses no source SAL or ZCL assumptions, inverse maps, word-span reconstruction, preassembled restriction datum, or factorization-after-restriction hypothesis. Source references and the paper-gap account are synchronized with the Blueprint.

This does not claim the complete five-identity assembly of `prop3to4`. Issue #5065 still owns the trace factors `Apptralktrrk`, normalization `AppPsiPhi`, common-copy weights, and final GSNNCH assembly.

Closes #5107. Parent: #5091.

## Dependencies

The result builds on the already merged sector orthogonality, support-minimality, and active-compression results from #5093, #5095, and #5096.

## Verification

- `lake build`
- `lake env lean TNLean/MPS/MPDO/PhysicalSectorActiveBond.lean`
- `lake build TNLean.MPS.MPDO.PhysicalSectorActiveBond`
- `lake build TNLean`
- `lake env lean scripts/LintStyle.lean`
- import-aggregator, reader-facing prose, oversized-file, TenKZ disposition, and proof-integrity checks
- CI-style Blueprint declaration generation and synchronization
- `leanblueprint checkdecls`
- kernel axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

An independent mathematical review found no correctness or faithfulness blocker; its sole Blueprint dependency observation was corrected before this pull request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and documentation only; no runtime, auth, or data-path changes. Mathematical risk is localized to MPDO sector-bond assembly already built on merged prior lemmas.
> 
> **Overview**
> Adds **`PhysicalSectorActiveBond.lean`** with the sector-bond compatibility step for Appendix C.2: from injectivity, a **physical-sector factorization** with PSD neighboring operators, and two-sided absorption of physical slices by an orthogonal projection `P`, it builds **`EtaLocalStructureData`** whose bond is supported on **`P ⊗ P`** and whose periodic product realizes **`mpo K N`** for **`N ≥ 2`**. The proof goes through the **canonical active compression** and lifts bond support from the joint physical support **`Q`** via **`PQ = Q = QP`** and **`twoSiteSectorProjection_supported_of_supported_of_absorbs`**.
> 
> A second theorem packages the same construction **sectorwise** over pairwise orthogonal absorbing projections into **`Nonempty (OrthogonalCommutingSectorFamily K)`**, using ambient factorizations rather than preassembled restriction data.
> 
> **Blueprint** gains **`thm:mpdo_ambient_sector_factorization_supported_bond`**; **`MPDO.lean`** imports the new module. **Paper-gap** notes (`README`, `cpsv16_gsnnch_sector_decomposition.tex`) now treat **`AppUkU=rl` / `Appetakhetc` / `PjKiPj`** as complete for supported bonds, while **`prop3to4`** stays open on trace factors, normalization, and common copy weights. **`DISPOSITIONS.md`** line refs for the capstone chapter are nudged for the new theorem block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a822c804fcc8e98e55524341cf63419ebcf139f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->