### PR TITLE
feat(MPS/MPDO): transport normalized MPO proportionality

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -146,6 +146,7 @@ import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.MPDO.NeighboringPreparation
 import TNLean.MPS.MPDO.NormalizedGroupedSectorMaps
 import TNLean.MPS.MPDO.NormalizedGroupedSectors
+import TNLean.MPS.MPDO.NormalizedMPOProportionality
 import TNLean.MPS.MPDO.OperatorProduct
 import TNLean.MPS.MPDO.OrthogonalSectorAreaLaw
 import TNLean.MPS.MPDO.PRFP

--- a/TNLean/MPS/MPDO/NormalizedMPOProportionality.lean
+++ b/TNLean/MPS/MPDO/NormalizedMPOProportionality.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.AreaLaw
+import TNLean.MPS.MPDO.VerticalCF
+
+/-!
+# Normalized MPOs under finite-chain proportionality
+
+This file proves that a nonzero scalar relating two doubled-index matrix-product
+vectors at a fixed chain length cancels upon trace normalization. Consequently
+all reduced block states at that chain length agree. The same conclusion holds
+eventually when the matrix-product vectors are eventually nonzero proportional.
+
+## Main statements
+
+* `MPOTensor.normalizedMPO_eq_of_nonzeroProportionalMPV₂_at`
+* `MPOTensor.reducedBlockState_eq_of_nonzeroProportionalMPV₂_at`
+* `MPSTensor.EventuallyNonzeroProportionalMPV₂.eventually_normalizedMPO_eq`
+* `MPSTensor.EventuallyNonzeroProportionalMPV₂.eventually_reducedBlockState_eq`
+
+## References
+
+* arXiv:1606.00608, Theorem `thm1`, lines 1167--1182.
+-/
+
+open scoped Matrix
+
+namespace MPOTensor
+
+variable {d D₁ D₂ N L : ℕ}
+
+/-- Two finite-chain MPOs have the same normalized MPO matrix when their doubled-index
+matrix-product vectors differ by a nonzero scalar at that chain length.
+
+No nonzero-trace hypothesis is needed: the traces are proportional, so if either
+vanishes, both normalized MPO matrices are zero by definition.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1167--1182; this
+transport is used in Appendix C.2, Proposition `4to2`, lines 1571--1619. -/
+theorem normalizedMPO_eq_of_nonzeroProportionalMPV₂_at
+    (M : MPOTensor d D₁) (K : MPOTensor d D₂)
+    (h : ∃ c : ℂ, c ≠ 0 ∧ ∀ ρ : Fin N → Fin (d * d),
+      MPSTensor.mpv M.toMPSTensor ρ = c * MPSTensor.mpv K.toMPSTensor ρ) :
+    normalizedMPO M N = normalizedMPO K N := by
+  obtain ⟨c, hc, hmpv⟩ := h
+  have hmpo : mpo M N = c • mpo K N := by
+    ext σ τ
+    rw [← MPSTensor.mpv_toMPSTensor_pairConfig, hmpv,
+      MPSTensor.mpv_toMPSTensor_pairConfig, Matrix.smul_apply, smul_eq_mul]
+  rw [normalizedMPO, normalizedMPO, hmpo, Matrix.trace_smul, smul_smul, smul_eq_mul]
+  congr 1
+  field_simp
+
+/-- Nonzero proportionality at one chain length identifies every reduced block
+state obtained from that finite chain.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1167--1182; this
+transport is used in Appendix C.2, Proposition `4to2`, lines 1571--1619. -/
+theorem reducedBlockState_eq_of_nonzeroProportionalMPV₂_at
+    (M : MPOTensor d D₁) (K : MPOTensor d D₂) (hL : L ≤ N)
+    (h : ∃ c : ℂ, c ≠ 0 ∧ ∀ ρ : Fin N → Fin (d * d),
+      MPSTensor.mpv M.toMPSTensor ρ = c * MPSTensor.mpv K.toMPSTensor ρ) :
+    reducedBlockState M N L hL = reducedBlockState K N L hL := by
+  unfold reducedBlockState
+  rw [normalizedMPO_eq_of_nonzeroProportionalMPV₂_at M K h]
+
+end MPOTensor
+
+namespace MPSTensor
+
+/-- Eventual nonzero proportionality of doubled-index matrix-product vectors
+identifies the normalized MPO matrices at every sufficiently large length.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1167--1182; this
+transport is used in Appendix C.2, Proposition `4to2`, lines 1571--1619. -/
+theorem EventuallyNonzeroProportionalMPV₂.eventually_normalizedMPO_eq
+    {d D₁ D₂ : ℕ} {M : MPOTensor d D₁} {K : MPOTensor d D₂}
+    (h : EventuallyNonzeroProportionalMPV₂ M.toMPSTensor K.toMPSTensor) :
+    ∀ᶠ N in Filter.atTop, MPOTensor.normalizedMPO M N = MPOTensor.normalizedMPO K N :=
+  h.mono fun _ hN ↦ MPOTensor.normalizedMPO_eq_of_nonzeroProportionalMPV₂_at M K hN
+
+/-- Eventual nonzero proportionality identifies every fixed-size reduced block
+state once the total chain length is sufficiently large.
+
+Source context: arXiv:1606.00608, Theorem `thm1`, lines 1167--1182; this
+transport is used in Appendix C.2, Proposition `4to2`, lines 1571--1619. -/
+theorem EventuallyNonzeroProportionalMPV₂.eventually_reducedBlockState_eq
+    {d D₁ D₂ : ℕ} {M : MPOTensor d D₁} {K : MPOTensor d D₂}
+    (h : EventuallyNonzeroProportionalMPV₂ M.toMPSTensor K.toMPSTensor)
+    (L : ℕ) :
+    ∀ᶠ N in Filter.atTop, ∀ hL : L ≤ N,
+      MPOTensor.reducedBlockState M N L hL =
+        MPOTensor.reducedBlockState K N L hL := by
+  filter_upwards [h] with N hN
+  exact fun hL ↦ MPOTensor.reducedBlockState_eq_of_nonzeroProportionalMPV₂_at
+    M K hL hN
+
+end MPSTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
@@ -1,3 +1,119 @@
+\begin{theorem}[Finite-chain normalization under nonzero proportionality]
+    \label{thm:mpdo_finite_chain_normalized_proportionality}
+    \lean{MPOTensor.normalizedMPO_eq_of_nonzeroProportionalMPV₂_at}
+    \leanok
+    \uses{def:mpo_tensor, def:mpv}
+    Let $M$ and $C$ be MPO tensors, possibly of different bond dimensions,
+    and fix a chain length $N$. Write
+    \begin{align}
+        \widehat\rho^{(N)}(M)
+        &=
+        \tr\!\left[\rho^{(N)}(M)\right]^{-1}\rho^{(N)}(M),
+        \notag
+    \end{align}
+    with the inverse of zero understood to be zero. Suppose that, for some
+    $c\in\C\setminus\{0\}$, the doubled-index matrix-product vectors satisfy
+    $\ket{V^{(N)}(M)}=c\ket{V^{(N)}(C)}$. Then
+    \begin{align}
+        \widehat\rho^{(N)}(M)
+        &=
+        \widehat\rho^{(N)}(C).
+        \notag
+    \end{align}
+
+    The proportionality hypothesis is the finite-length form of the
+    hypothesis in \cite[Theorem~2.10]{Cirac2016MPDO_arXiv}. The conclusion is
+    an auxiliary cancellation used in the comparison preceding
+    \cite[Appendix~C.2, lines~1597--1619]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Reading a doubled physical index as a ket--bra pair gives
+    $\rho^{(N)}(M)=c\rho^{(N)}(C)$, and hence
+    $\tr[\rho^{(N)}(M)]=c\tr[\rho^{(N)}(C)]$. Since $c\ne0$,
+    \begin{align}
+        \bigl(c\tr[\rho^{(N)}(C)]\bigr)^{-1}
+        c\rho^{(N)}(C)
+        &=
+        \tr[\rho^{(N)}(C)]^{-1}\rho^{(N)}(C).
+        \notag
+    \end{align}
+    This identity also holds when the two proportional traces vanish.
+\end{proof}
+
+\begin{theorem}[Finite-chain reduced marginals under nonzero proportionality]
+    \label{thm:mpdo_finite_chain_reduced_proportionality}
+    \lean{MPOTensor.reducedBlockState_eq_of_nonzeroProportionalMPV₂_at}
+    \leanok
+    \uses{def:block_entropy, def:mpv}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_finite_chain_normalized_proportionality}, for every
+    $L\leq N$ the reduced operators on the first $L$ sites agree:
+    \begin{align}
+        \tr_{N-L}\!\left[\widehat\rho^{(N)}(M)\right]
+        &=
+        \tr_{N-L}\!\left[\widehat\rho^{(N)}(C)\right].
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_finite_chain_normalized_proportionality}
+    Apply the same finite-index identification and partial trace to both
+    sides of
+    Theorem~\ref{thm:mpdo_finite_chain_normalized_proportionality}.
+\end{proof}
+
+\begin{theorem}[Eventual equality of normalized finite-chain operators]
+    \label{thm:mpdo_eventual_normalized_proportionality}
+    \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.%
+      eventually_normalizedMPO_eq}
+    \leanok
+    \uses{def:eventually_nonzero_proportional_mpv, def:mpo_tensor}
+    If the doubled-index tensors of $M$ and $C$ are eventually nonzero
+    proportional, then, for every sufficiently large $N$,
+    \begin{align}
+        \widehat\rho^{(N)}(M)
+        &=
+        \widehat\rho^{(N)}(C).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_finite_chain_normalized_proportionality}
+    At each sufficiently large length, apply
+    Theorem~\ref{thm:mpdo_finite_chain_normalized_proportionality} to the
+    nonzero proportionality scalar at that length.
+\end{proof}
+
+\begin{theorem}[Eventual equality of fixed-size reduced marginals]
+    \label{thm:mpdo_eventual_reduced_proportionality}
+    \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.%
+      eventually_reducedBlockState_eq}
+    \leanok
+    \uses{def:eventually_nonzero_proportional_mpv, def:block_entropy}
+    If the doubled-index tensors of $M$ and $C$ are eventually nonzero
+    proportional, then for each fixed $L$ and every sufficiently large
+    $N\geq L$,
+    \begin{align}
+        \tr_{N-L}\!\left[\widehat\rho^{(N)}(M)\right]
+        &=
+        \tr_{N-L}\!\left[\widehat\rho^{(N)}(C)\right].
+        \notag
+    \end{align}
+    This equality alone does not identify the virtual sector families of
+    $M$ and $C$, and therefore does not prove the rank-one separation or the
+    Markov decomposition asserted in
+    \cite[Appendix~C.2, lines~1597--1619]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_finite_chain_reduced_proportionality}
+    At each sufficiently large length, apply
+    Theorem~\ref{thm:mpdo_finite_chain_reduced_proportionality}.
+\end{proof}
+
 \begin{lemma}[Marginal stability under source zero correlation length]
     \label{lem:mpdo_source_zcl_marginal_stability}
     \lean{MPOTensor.%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
@@ -2,7 +2,7 @@
     \label{thm:mpdo_finite_chain_normalized_proportionality}
     \lean{MPOTensor.normalizedMPO_eq_of_nonzeroProportionalMPV₂_at}
     \leanok
-    \uses{def:mpo_tensor, def:mpv}
+    \uses{def:mpo_tensor, def:mpo_to_mps, def:mpv}
     Let $M$ and $C$ be MPO tensors, possibly of different bond dimensions,
     and fix a chain length $N$. Write
     \begin{align}
@@ -45,7 +45,8 @@
     \label{thm:mpdo_finite_chain_reduced_proportionality}
     \lean{MPOTensor.reducedBlockState_eq_of_nonzeroProportionalMPV₂_at}
     \leanok
-    \uses{def:block_entropy, def:mpv}
+    \uses{thm:mpdo_finite_chain_normalized_proportionality,
+      def:mpo_to_mps}
     Under the hypotheses of
     Theorem~\ref{thm:mpdo_finite_chain_normalized_proportionality}, for every
     $L\leq N$ the reduced operators on the first $L$ sites agree:
@@ -69,7 +70,8 @@
     \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.%
       eventually_normalizedMPO_eq}
     \leanok
-    \uses{def:eventually_nonzero_proportional_mpv, def:mpo_tensor}
+    \uses{def:eventually_nonzero_proportional_mpv, def:mpo_tensor,
+      def:mpo_to_mps}
     If the doubled-index tensors of $M$ and $C$ are eventually nonzero
     proportional, then, for every sufficiently large $N$,
     \begin{align}
@@ -92,7 +94,7 @@
     \lean{MPSTensor.EventuallyNonzeroProportionalMPV₂.%
       eventually_reducedBlockState_eq}
     \leanok
-    \uses{def:eventually_nonzero_proportional_mpv, def:block_entropy}
+    \uses{def:eventually_nonzero_proportional_mpv, def:mpo_to_mps}
     If the doubled-index tensors of $M$ and $C$ are eventually nonzero
     proportional, then for each fixed $L$ and every sufficiently large
     $N\geq L$,


### PR DESCRIPTION
### Motivation

- Isolate the finite-chain transport required by #5123 before the unresolved cyclic-active visibility argument.
- The source is `Papers/1606.00608/MPDO-22-12-17-2.tex`, Theorem `thm1`, lines 1167–1182: “If for all N, A and B generate MPV that are proportional to each other”; the application is Proposition `4to2`, lines 1597–1619, where normalized reduced states are compared across the fixed commuting-bond presentation.
- This PR proves only the normalization and marginal transport. It does not assert the cyclic-active rank-one separation; that remaining theorem is tracked in #5124.

### Description

- Add `MPOTensor.normalizedMPO_eq_of_nonzeroProportionalMPV₂_at`: a nonzero finite-length MPV scalar cancels under trace normalization. No trace-nonzero hypothesis is required; proportional traces vanish simultaneously.
- Add the corresponding fixed-length equality of every reduced block state.
- Add eventual normalized-MPO and reduced-block equalities from `MPSTensor.EventuallyNonzeroProportionalMPV₂`.
- Import the new module from `TNLean/MPS/MPDO.lean`.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.MPDO.NormalizedMPOProportionality`
- `lake env lean TNLean/MPS/MPDO/NormalizedMPOProportionality.lean`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/MPDO/NormalizedMPOProportionality.lean || true`
- An aggregate `lake build TNLean.MPS.MPDO` built the new module successfully; the remaining unrelated aggregate compilation was stopped in the fresh worktree.

---
Closes #5125
Addresses #5123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style MPO/MPV transport lemmas and documentation; no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds formal Lean proofs and blueprint theorems that **nonzero proportionality of doubled-index MPVs identifies trace-normalized finite-chain MPOs and their reduced marginals**, isolating the transport step used before the commuting-form comparison in Cirac et al. (Appendix C.2).
> 
> **`TNLean/MPS/MPDO/NormalizedMPOProportionality.lean`** shows a nonzero scalar at fixed length `N` scales `mpo` and cancels in `normalizedMPO` (including when traces vanish), hence `reducedBlockState` agrees; **`EventuallyNonzeroProportionalMPV₂`** yields the same equalities for all large `N`. The module is wired into **`TNLean/MPS/MPDO.lean`**.
> 
> **Blueprint** (`ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex`) adds four `\leanok` theorems with proofs and notes that eventual reduced-marginal equality alone does **not** prove rank-one separation or Markov decomposition (#5124).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 525308e372d58e5c355f74e204386ce13aac7c93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->