### PR TITLE
feat(mps/mpdo): expand adjacent suffix marginals

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -104,6 +104,7 @@ import TNLean.MPS.MPDO.CyclicActiveMarkovDecomposition
 import TNLean.MPS.MPDO.CyclicActiveMarkovNormalization
 import TNLean.MPS.MPDO.CyclicActiveRetainedCoordinates
 import TNLean.MPS.MPDO.CyclicActiveSectorRestriction
+import TNLean.MPS.MPDO.CyclicActiveSuffixMarginal
 import TNLean.MPS.MPDO.CyclicActiveThreeBoundaryTrace
 import TNLean.MPS.MPDO.CyclicEdgeWeightTensor
 import TNLean.MPS.MPDO.CyclicProjector

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
@@ -383,6 +383,26 @@ private theorem fourthRegion_suffix_two_neighboring_entry
         fourthRegion_suffix_two_succ).trans ?_
       exact heq_of_eq (F.retainedOpenEdgeEquiv_symm_first_left k y)
 
+/-- Trace a suffix of fixed length from a retained sector block of the cyclic
+neighboring product, summing over all discarded sector labels and fibers.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (adjacent marginal comparison):** The source argument uses
+adjacent suffix lengths; the length-three specialization is later restricted
+to cyclic-active sector labels. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def suffixSectorContraction
+    (F : PhysicalSectorFactorization K) (R : ℕ) [NeZero R] {L : ℕ}
+    (k : Fin L → Fin F.sectorCount) :
+    Matrix (F.SectorChainFiber k) (F.SectorChainFiber k) ℂ :=
+  fun x y ↦
+    ∑ t : Fin R → Fin F.sectorCount,
+      ∑ z : F.SectorChainFiber t,
+        F.cyclicNeighboringProduct (Fin.append k t)
+          (F.appendSectorFiber x z) (F.appendSectorFiber y z)
+
 /-- Trace the last three site fibers of a fixed retained sector block of the
 cyclic neighboring product, summing over all three discarded sector labels.
 
@@ -392,15 +412,11 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 **Local fix (cyclic-active restriction):** The suffix sum is later restricted
 to cyclic-active sector labels, producing the restricted two-step
 coefficient. See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-noncomputable def threeSuffixSectorContraction
+noncomputable abbrev threeSuffixSectorContraction
     (F : PhysicalSectorFactorization K) {L : ℕ}
     (k : Fin L → Fin F.sectorCount) :
     Matrix (F.SectorChainFiber k) (F.SectorChainFiber k) ℂ :=
-  fun x y ↦
-    ∑ t : Fin 3 → Fin F.sectorCount,
-      ∑ z : F.SectorChainFiber t,
-        F.cyclicNeighboringProduct (Fin.append k t)
-          (F.appendSectorFiber x z) (F.appendSectorFiber y z)
+  F.suffixSectorContraction 3 k
 
 private theorem sum_threeSuffixFiber_cyclicNeighboringProduct
     (F : PhysicalSectorFactorization K) {n : ℕ}
@@ -542,6 +558,112 @@ def cyclicActiveRetainedWord
 
 
 /-- In complete physical-sector coordinates, the marginal obtained by
+discarding a suffix of arbitrary length is the direct sum of the corresponding
+suffix contractions of the cyclic neighboring products.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (adjacent marginal comparison):** The arbitrary suffix length
+simultaneously covers the adjacent source marginals and the later
+three-suffix cyclic-active restriction. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_reducedBlockState_add_eq_suffixSectorContraction
+    (F : PhysicalSectorFactorization K) (L R : ℕ) [NeZero R] :
+    Matrix.reindex (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateTensor.reducedBlockState (L + R) L (by omega)) =
+      ((Matrix.trace (mpo F.sectorCoordinateTensor (L + R)))⁻¹ : ℂ) •
+        Matrix.blockDiagonal' (fun k ↦ F.suffixSectorContraction R k) := by
+  classical
+  have hblock :
+      F.sectorCoordinateTensor.reducedBlockState (L + R) L (by omega) =
+        blockReducedState (Fintype.card (SectorSiteIndex F)) L R
+          (F.sectorCoordinateTensor.normalizedMPO (L + R)) := by
+    rw [MPOTensor.reducedBlockState]
+    simpa only [blockReindexEquiv] using
+      blockReducedState_submatrix_finCongr
+        (show L + R = L + (L + R - L) by omega)
+        (F.sectorCoordinateTensor.normalizedMPO (L + R))
+  rw [hblock]
+  ext s t
+  obtain ⟨k, x⟩ := s
+  obtain ⟨h, y⟩ := t
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    blockReducedState, Matrix.partialTraceRight_apply,
+    normalizedMPO, Matrix.smul_apply, smul_eq_mul]
+  rw [← Finset.mul_sum]
+  congr 1
+  simp only [blockSplitEquiv_symm_apply]
+  change (∑ i : Fin R → Fin (Fintype.card (SectorSiteIndex F)),
+      mpo F.sectorCoordinateTensor (L + R)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩) i)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩) i)) = _
+  have hconfig
+      (p : Fin L → Fin F.sectorCount) (u : F.SectorChainFiber p)
+      (q : Fin R → Fin F.sectorCount) (z : F.SectorChainFiber q) :
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv R).symm ⟨q, z⟩) =
+        (F.sectorCoordinateChainEquiv (L + R)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ := by
+    funext i
+    refine Fin.addCases (motive := fun i' : Fin (L + R) ↦
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv R).symm ⟨q, z⟩) i' =
+        (F.sectorCoordinateChainEquiv (L + R)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ i')
+      (fun j ↦ ?_) (fun j ↦ ?_) i
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+  calc
+    _ = ∑ s : F.SectorChainIndex R,
+        mpo F.sectorCoordinateTensor (L + R)
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩)
+            ((F.sectorCoordinateChainEquiv R).symm s))
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩)
+            ((F.sectorCoordinateChainEquiv R).symm s)) := by
+      apply Fintype.sum_equiv (F.sectorCoordinateChainEquiv R)
+      intro i
+      rw [Equiv.symm_apply_apply]
+    _ = _ := by
+      rw [Fintype.sum_sigma]
+      by_cases hkh : k = h
+      · subst h
+        rw [Matrix.blockDiagonal'_apply_eq]
+        simp only [suffixSectorContraction]
+        apply Finset.sum_congr rfl
+        intro q _
+        apply Finset.sum_congr rfl
+        intro z _
+        rw [hconfig k x q z, hconfig k y q z]
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + R))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append k q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_eq] using hentry
+      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+        apply Finset.sum_eq_zero
+        intro q _
+        apply Finset.sum_eq_zero
+        intro z _
+        rw [hconfig k x q z, hconfig h y q z]
+        have happend_ne : Fin.append k q ≠ Fin.append h q := by
+          intro heq
+          apply hkh
+          funext i
+          have hi := congrFun heq (Fin.castAdd R i)
+          simpa using hi
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + R))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append h q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_ne _ _ _ happend_ne] using hentry
+
+/-- In complete physical-sector coordinates, the marginal obtained by
 discarding three suffix sites is the direct sum of the corresponding
 three-suffix contractions of the cyclic neighboring products.
 
@@ -557,95 +679,8 @@ theorem reindex_reducedBlockState_add_three_eq_threeSuffixSectorContraction
         (F.sectorCoordinateChainEquiv L)
         (F.sectorCoordinateTensor.reducedBlockState (L + 3) L (by omega)) =
       ((Matrix.trace (mpo F.sectorCoordinateTensor (L + 3)))⁻¹ : ℂ) •
-        Matrix.blockDiagonal' (fun k ↦ F.threeSuffixSectorContraction k) := by
-  classical
-  letI : NeZero (L + 3) := ⟨by omega⟩
-  have hblock :
-      F.sectorCoordinateTensor.reducedBlockState (L + 3) L (by omega) =
-        blockReducedState (Fintype.card (SectorSiteIndex F)) L 3
-          (F.sectorCoordinateTensor.normalizedMPO (L + 3)) := by
-    rw [MPOTensor.reducedBlockState]
-    simpa only [blockReindexEquiv] using
-      blockReducedState_submatrix_finCongr
-        (show L + 3 = L + (L + 3 - L) by omega)
-        (F.sectorCoordinateTensor.normalizedMPO (L + 3))
-  rw [hblock]
-  ext s t
-  obtain ⟨k, x⟩ := s
-  obtain ⟨h, y⟩ := t
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    blockReducedState, Matrix.partialTraceRight_apply,
-    normalizedMPO, Matrix.smul_apply, smul_eq_mul]
-  rw [← Finset.mul_sum]
-  congr 1
-  simp only [blockSplitEquiv_symm_apply]
-  change (∑ i : Fin 3 → Fin (Fintype.card (SectorSiteIndex F)),
-      mpo F.sectorCoordinateTensor (L + 3)
-        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩) i)
-        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩) i)) = _
-  have hconfig
-      (p : Fin L → Fin F.sectorCount) (u : F.SectorChainFiber p)
-      (q : Fin 3 → Fin F.sectorCount) (z : F.SectorChainFiber q) :
-      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
-          ((F.sectorCoordinateChainEquiv 3).symm ⟨q, z⟩) =
-        (F.sectorCoordinateChainEquiv (L + 3)).symm
-          ⟨Fin.append p q, F.appendSectorFiber u z⟩ := by
-    funext i
-    refine Fin.addCases (motive := fun i' : Fin (L + 3) ↦
-      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
-          ((F.sectorCoordinateChainEquiv 3).symm ⟨q, z⟩) i' =
-        (F.sectorCoordinateChainEquiv (L + 3)).symm
-          ⟨Fin.append p q, F.appendSectorFiber u z⟩ i')
-      (fun j ↦ ?_) (fun j ↦ ?_) i
-    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
-    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
-  calc
-    _ = ∑ s : F.SectorChainIndex 3,
-        mpo F.sectorCoordinateTensor (L + 3)
-          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩)
-            ((F.sectorCoordinateChainEquiv 3).symm s))
-          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩)
-            ((F.sectorCoordinateChainEquiv 3).symm s)) := by
-      apply Fintype.sum_equiv (F.sectorCoordinateChainEquiv 3)
-      intro i
-      rw [Equiv.symm_apply_apply]
-    _ = _ := by
-      rw [Fintype.sum_sigma]
-      by_cases hkh : k = h
-      · subst h
-        rw [Matrix.blockDiagonal'_apply_eq]
-        simp only [threeSuffixSectorContraction]
-        apply Finset.sum_congr rfl
-        intro q _
-        apply Finset.sum_congr rfl
-        intro z _
-        rw [hconfig k x q z, hconfig k y q z]
-        have hentry := congrFun (congrFun
-          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
-            (N := L + 3))
-          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
-          ⟨Fin.append k q, F.appendSectorFiber y z⟩
-        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
-          Matrix.blockDiagonal'_apply_eq] using hentry
-      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
-        apply Finset.sum_eq_zero
-        intro q _
-        apply Finset.sum_eq_zero
-        intro z _
-        rw [hconfig k x q z, hconfig h y q z]
-        have happend_ne : Fin.append k q ≠ Fin.append h q := by
-          intro heq
-          apply hkh
-          funext i
-          have hi := congrFun heq (Fin.castAdd 3 i)
-          simpa using hi
-        have hentry := congrFun (congrFun
-          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
-            (N := L + 3))
-          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
-          ⟨Fin.append h q, F.appendSectorFiber y z⟩
-        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
-          Matrix.blockDiagonal'_apply_ne _ _ _ happend_ne] using hentry
+        Matrix.blockDiagonal' (fun k ↦ F.threeSuffixSectorContraction k) :=
+  F.reindex_reducedBlockState_add_eq_suffixSectorContraction L 3
 
 /-- Source ZCL marginal replacement is preserved by the physical coordinate
 isometry defining the sector-coordinate tensor.

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
@@ -93,7 +93,7 @@ theorem threeSuffixSectorContraction_eq_zero_of_not_isCyclicActiveRetainedWord
     F.threeSuffixSectorContraction k = 0 := by
   classical
   ext x y
-  simp only [threeSuffixSectorContraction, Matrix.zero_apply]
+  simp only [threeSuffixSectorContraction, suffixSectorContraction, Matrix.zero_apply]
   apply Finset.sum_eq_zero
   intro t _
   apply Finset.sum_eq_zero
@@ -132,7 +132,7 @@ theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveUnnormalized
   classical
   ext x y
   simp only [Matrix.reindex_apply, Matrix.submatrix_apply, threeSuffixSectorContraction,
-    Matrix.kroneckerMap_apply]
+    suffixSectorContraction, Matrix.kroneckerMap_apply]
   have hrestrict :
       (∑ t : Fin 3 → Fin F.sectorCount,
           ∑ z : F.SectorChainFiber t,

--- a/TNLean/MPS/MPDO/CyclicActiveSuffixMarginal.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSuffixMarginal.lean
@@ -1,0 +1,277 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CyclicActiveFourthRegionContraction
+
+/-!
+# Adjacent cyclic-active suffix marginals
+
+This file gives the physical-sector block expansions of the marginals
+obtained by tracing one or two suffix sites.  After tracing the two surviving
+outer boundary factors, these adjacent contractions have coefficients given
+by the square and cube of the cyclic-active trace matrix.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1606--1617.
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- Trace the last site fiber of a fixed retained sector block of the cyclic
+neighboring product, summing over its discarded sector label.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (adjacent marginal comparison):** This is the one-suffix side of
+the source-adjacent comparison. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def oneSuffixSectorContraction
+    (F : PhysicalSectorFactorization K) {L : ℕ}
+    (k : Fin L → Fin F.sectorCount) :
+    Matrix (F.SectorChainFiber k) (F.SectorChainFiber k) ℂ :=
+  fun x y ↦
+    ∑ t : Fin 1 → Fin F.sectorCount,
+      ∑ z : F.SectorChainFiber t,
+        F.cyclicNeighboringProduct (Fin.append k t)
+          (F.appendSectorFiber x z) (F.appendSectorFiber y z)
+
+/-- Trace the last two site fibers of a fixed retained sector block of the
+cyclic neighboring product, summing over both discarded sector labels.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (adjacent marginal comparison):** Two suffix sites, rather than
+one, give the coefficient adjacent to the existing three-suffix coefficient.
+See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+noncomputable def twoSuffixSectorContraction
+    (F : PhysicalSectorFactorization K) {L : ℕ}
+    (k : Fin L → Fin F.sectorCount) :
+    Matrix (F.SectorChainFiber k) (F.SectorChainFiber k) ℂ :=
+  fun x y ↦
+    ∑ t : Fin 2 → Fin F.sectorCount,
+      ∑ z : F.SectorChainFiber t,
+        F.cyclicNeighboringProduct (Fin.append k t)
+          (F.appendSectorFiber x z) (F.appendSectorFiber y z)
+
+/-- In complete physical-sector coordinates, the marginal obtained by
+discarding one suffix site is the direct sum of the corresponding one-suffix
+contractions of the cyclic neighboring products.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (adjacent marginal comparison):** This is the one-suffix side of
+the comparison with the two-suffix expansion. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_reducedBlockState_add_one_eq_oneSuffixSectorContraction
+    (F : PhysicalSectorFactorization K) (L : ℕ) :
+    Matrix.reindex (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega)) =
+      ((Matrix.trace (mpo F.sectorCoordinateTensor (L + 1)))⁻¹ : ℂ) •
+        Matrix.blockDiagonal' (fun k ↦ F.oneSuffixSectorContraction k) := by
+  classical
+  letI : NeZero (L + 1) := ⟨by omega⟩
+  have hblock :
+      F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) =
+        blockReducedState (Fintype.card (SectorSiteIndex F)) L 1
+          (F.sectorCoordinateTensor.normalizedMPO (L + 1)) := by
+    rw [MPOTensor.reducedBlockState]
+    simpa only [blockReindexEquiv] using
+      blockReducedState_submatrix_finCongr
+        (show L + 1 = L + (L + 1 - L) by omega)
+        (F.sectorCoordinateTensor.normalizedMPO (L + 1))
+  rw [hblock]
+  ext s t
+  obtain ⟨k, x⟩ := s
+  obtain ⟨h, y⟩ := t
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    blockReducedState, Matrix.partialTraceRight_apply,
+    normalizedMPO, Matrix.smul_apply, smul_eq_mul]
+  rw [← Finset.mul_sum]
+  congr 1
+  simp only [blockSplitEquiv_symm_apply]
+  change (∑ i : Fin 1 → Fin (Fintype.card (SectorSiteIndex F)),
+      mpo F.sectorCoordinateTensor (L + 1)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩) i)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩) i)) = _
+  have hconfig
+      (p : Fin L → Fin F.sectorCount) (u : F.SectorChainFiber p)
+      (q : Fin 1 → Fin F.sectorCount) (z : F.SectorChainFiber q) :
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv 1).symm ⟨q, z⟩) =
+        (F.sectorCoordinateChainEquiv (L + 1)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ := by
+    funext i
+    refine Fin.addCases (motive := fun i' : Fin (L + 1) ↦
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv 1).symm ⟨q, z⟩) i' =
+        (F.sectorCoordinateChainEquiv (L + 1)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ i')
+      (fun j ↦ ?_) (fun j ↦ ?_) i
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+  calc
+    _ = ∑ s : F.SectorChainIndex 1,
+        mpo F.sectorCoordinateTensor (L + 1)
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩)
+            ((F.sectorCoordinateChainEquiv 1).symm s))
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩)
+            ((F.sectorCoordinateChainEquiv 1).symm s)) := by
+      apply Fintype.sum_equiv (F.sectorCoordinateChainEquiv 1)
+      intro i
+      rw [Equiv.symm_apply_apply]
+    _ = _ := by
+      rw [Fintype.sum_sigma]
+      by_cases hkh : k = h
+      · subst h
+        rw [Matrix.blockDiagonal'_apply_eq]
+        simp only [oneSuffixSectorContraction]
+        apply Finset.sum_congr rfl
+        intro q _
+        apply Finset.sum_congr rfl
+        intro z _
+        rw [hconfig k x q z, hconfig k y q z]
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + 1))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append k q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_eq] using hentry
+      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+        apply Finset.sum_eq_zero
+        intro q _
+        apply Finset.sum_eq_zero
+        intro z _
+        rw [hconfig k x q z, hconfig h y q z]
+        have happend_ne : Fin.append k q ≠ Fin.append h q := by
+          intro heq
+          apply hkh
+          funext i
+          have hi := congrFun heq (Fin.castAdd 1 i)
+          simpa using hi
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + 1))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append h q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_ne _ _ _ happend_ne] using hentry
+
+/-- In complete physical-sector coordinates, the marginal obtained by
+discarding two suffix sites is the direct sum of the corresponding two-suffix
+contractions of the cyclic neighboring products.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (adjacent marginal comparison):** This is the two-suffix side of
+the comparison with the three-suffix expansion. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem reindex_reducedBlockState_add_two_eq_twoSuffixSectorContraction
+    (F : PhysicalSectorFactorization K) (L : ℕ) :
+    Matrix.reindex (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateChainEquiv L)
+        (F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega)) =
+      ((Matrix.trace (mpo F.sectorCoordinateTensor (L + 2)))⁻¹ : ℂ) •
+        Matrix.blockDiagonal' (fun k ↦ F.twoSuffixSectorContraction k) := by
+  classical
+  letI : NeZero (L + 2) := ⟨by omega⟩
+  have hblock :
+      F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega) =
+        blockReducedState (Fintype.card (SectorSiteIndex F)) L 2
+          (F.sectorCoordinateTensor.normalizedMPO (L + 2)) := by
+    rw [MPOTensor.reducedBlockState]
+    simpa only [blockReindexEquiv] using
+      blockReducedState_submatrix_finCongr
+        (show L + 2 = L + (L + 2 - L) by omega)
+        (F.sectorCoordinateTensor.normalizedMPO (L + 2))
+  rw [hblock]
+  ext s t
+  obtain ⟨k, x⟩ := s
+  obtain ⟨h, y⟩ := t
+  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
+    blockReducedState, Matrix.partialTraceRight_apply,
+    normalizedMPO, Matrix.smul_apply, smul_eq_mul]
+  rw [← Finset.mul_sum]
+  congr 1
+  simp only [blockSplitEquiv_symm_apply]
+  change (∑ i : Fin 2 → Fin (Fintype.card (SectorSiteIndex F)),
+      mpo F.sectorCoordinateTensor (L + 2)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩) i)
+        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩) i)) = _
+  have hconfig
+      (p : Fin L → Fin F.sectorCount) (u : F.SectorChainFiber p)
+      (q : Fin 2 → Fin F.sectorCount) (z : F.SectorChainFiber q) :
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv 2).symm ⟨q, z⟩) =
+        (F.sectorCoordinateChainEquiv (L + 2)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ := by
+    funext i
+    refine Fin.addCases (motive := fun i' : Fin (L + 2) ↦
+      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
+          ((F.sectorCoordinateChainEquiv 2).symm ⟨q, z⟩) i' =
+        (F.sectorCoordinateChainEquiv (L + 2)).symm
+          ⟨Fin.append p q, F.appendSectorFiber u z⟩ i')
+      (fun j ↦ ?_) (fun j ↦ ?_) i
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
+  calc
+    _ = ∑ s : F.SectorChainIndex 2,
+        mpo F.sectorCoordinateTensor (L + 2)
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩)
+            ((F.sectorCoordinateChainEquiv 2).symm s))
+          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩)
+            ((F.sectorCoordinateChainEquiv 2).symm s)) := by
+      apply Fintype.sum_equiv (F.sectorCoordinateChainEquiv 2)
+      intro i
+      rw [Equiv.symm_apply_apply]
+    _ = _ := by
+      rw [Fintype.sum_sigma]
+      by_cases hkh : k = h
+      · subst h
+        rw [Matrix.blockDiagonal'_apply_eq]
+        simp only [twoSuffixSectorContraction]
+        apply Finset.sum_congr rfl
+        intro q _
+        apply Finset.sum_congr rfl
+        intro z _
+        rw [hconfig k x q z, hconfig k y q z]
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + 2))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append k q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_eq] using hentry
+      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
+        apply Finset.sum_eq_zero
+        intro q _
+        apply Finset.sum_eq_zero
+        intro z _
+        rw [hconfig k x q z, hconfig h y q z]
+        have happend_ne : Fin.append k q ≠ Fin.append h q := by
+          intro heq
+          apply hkh
+          funext i
+          have hi := congrFun heq (Fin.castAdd 2 i)
+          simpa using hi
+        have hentry := congrFun (congrFun
+          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
+            (N := L + 2))
+          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
+          ⟨Fin.append h q, F.appendSectorFiber y z⟩
+        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
+          Matrix.blockDiagonal'_apply_ne _ _ _ happend_ne] using hentry
+
+end MPOTensor.PhysicalSectorFactorization

--- a/TNLean/MPS/MPDO/CyclicActiveSuffixMarginal.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSuffixMarginal.lean
@@ -45,9 +45,10 @@ cyclic neighboring product, summing over both discarded sector labels.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (adjacent marginal comparison):** Two suffix sites, rather than
-one, give the coefficient adjacent to the existing three-suffix coefficient.
-See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+**Local fix (adjacent marginal comparison):** The two-suffix contraction is
+paired with the one-suffix contraction. After tracing the two surviving outer
+boundary factors, their coefficients are respectively \(T_C^3\) and
+\(T_C^2\). See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable abbrev twoSuffixSectorContraction
     (F : PhysicalSectorFactorization K) {L : ℕ}
     (k : Fin L → Fin F.sectorCount) :

--- a/TNLean/MPS/MPDO/CyclicActiveSuffixMarginal.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSuffixMarginal.lean
@@ -8,10 +8,10 @@ import TNLean.MPS.MPDO.CyclicActiveFourthRegionContraction
 /-!
 # Adjacent cyclic-active suffix marginals
 
-This file gives the physical-sector block expansions of the marginals
-obtained by tracing one or two suffix sites.  After tracing the two surviving
-outer boundary factors, these adjacent contractions have coefficients given
-by the square and cube of the cyclic-active trace matrix.
+This file specializes the arbitrary-suffix physical-sector block expansion to
+the marginals obtained by tracing one or two suffix sites. After tracing the
+two surviving outer boundary factors, these adjacent contractions have
+coefficients given by the square and cube of the cyclic-active trace matrix.
 
 ## Reference
 
@@ -33,15 +33,11 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 **Local fix (adjacent marginal comparison):** This is the one-suffix side of
 the source-adjacent comparison. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-noncomputable def oneSuffixSectorContraction
+noncomputable abbrev oneSuffixSectorContraction
     (F : PhysicalSectorFactorization K) {L : ℕ}
     (k : Fin L → Fin F.sectorCount) :
     Matrix (F.SectorChainFiber k) (F.SectorChainFiber k) ℂ :=
-  fun x y ↦
-    ∑ t : Fin 1 → Fin F.sectorCount,
-      ∑ z : F.SectorChainFiber t,
-        F.cyclicNeighboringProduct (Fin.append k t)
-          (F.appendSectorFiber x z) (F.appendSectorFiber y z)
+  F.suffixSectorContraction 1 k
 
 /-- Trace the last two site fibers of a fixed retained sector block of the
 cyclic neighboring product, summing over both discarded sector labels.
@@ -52,15 +48,11 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 **Local fix (adjacent marginal comparison):** Two suffix sites, rather than
 one, give the coefficient adjacent to the existing three-suffix coefficient.
 See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
-noncomputable def twoSuffixSectorContraction
+noncomputable abbrev twoSuffixSectorContraction
     (F : PhysicalSectorFactorization K) {L : ℕ}
     (k : Fin L → Fin F.sectorCount) :
     Matrix (F.SectorChainFiber k) (F.SectorChainFiber k) ℂ :=
-  fun x y ↦
-    ∑ t : Fin 2 → Fin F.sectorCount,
-      ∑ z : F.SectorChainFiber t,
-        F.cyclicNeighboringProduct (Fin.append k t)
-          (F.appendSectorFiber x z) (F.appendSectorFiber y z)
+  F.suffixSectorContraction 2 k
 
 /-- In complete physical-sector coordinates, the marginal obtained by
 discarding one suffix site is the direct sum of the corresponding one-suffix
@@ -78,95 +70,8 @@ theorem reindex_reducedBlockState_add_one_eq_oneSuffixSectorContraction
         (F.sectorCoordinateChainEquiv L)
         (F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega)) =
       ((Matrix.trace (mpo F.sectorCoordinateTensor (L + 1)))⁻¹ : ℂ) •
-        Matrix.blockDiagonal' (fun k ↦ F.oneSuffixSectorContraction k) := by
-  classical
-  letI : NeZero (L + 1) := ⟨by omega⟩
-  have hblock :
-      F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) =
-        blockReducedState (Fintype.card (SectorSiteIndex F)) L 1
-          (F.sectorCoordinateTensor.normalizedMPO (L + 1)) := by
-    rw [MPOTensor.reducedBlockState]
-    simpa only [blockReindexEquiv] using
-      blockReducedState_submatrix_finCongr
-        (show L + 1 = L + (L + 1 - L) by omega)
-        (F.sectorCoordinateTensor.normalizedMPO (L + 1))
-  rw [hblock]
-  ext s t
-  obtain ⟨k, x⟩ := s
-  obtain ⟨h, y⟩ := t
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    blockReducedState, Matrix.partialTraceRight_apply,
-    normalizedMPO, Matrix.smul_apply, smul_eq_mul]
-  rw [← Finset.mul_sum]
-  congr 1
-  simp only [blockSplitEquiv_symm_apply]
-  change (∑ i : Fin 1 → Fin (Fintype.card (SectorSiteIndex F)),
-      mpo F.sectorCoordinateTensor (L + 1)
-        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩) i)
-        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩) i)) = _
-  have hconfig
-      (p : Fin L → Fin F.sectorCount) (u : F.SectorChainFiber p)
-      (q : Fin 1 → Fin F.sectorCount) (z : F.SectorChainFiber q) :
-      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
-          ((F.sectorCoordinateChainEquiv 1).symm ⟨q, z⟩) =
-        (F.sectorCoordinateChainEquiv (L + 1)).symm
-          ⟨Fin.append p q, F.appendSectorFiber u z⟩ := by
-    funext i
-    refine Fin.addCases (motive := fun i' : Fin (L + 1) ↦
-      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
-          ((F.sectorCoordinateChainEquiv 1).symm ⟨q, z⟩) i' =
-        (F.sectorCoordinateChainEquiv (L + 1)).symm
-          ⟨Fin.append p q, F.appendSectorFiber u z⟩ i')
-      (fun j ↦ ?_) (fun j ↦ ?_) i
-    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
-    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
-  calc
-    _ = ∑ s : F.SectorChainIndex 1,
-        mpo F.sectorCoordinateTensor (L + 1)
-          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩)
-            ((F.sectorCoordinateChainEquiv 1).symm s))
-          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩)
-            ((F.sectorCoordinateChainEquiv 1).symm s)) := by
-      apply Fintype.sum_equiv (F.sectorCoordinateChainEquiv 1)
-      intro i
-      rw [Equiv.symm_apply_apply]
-    _ = _ := by
-      rw [Fintype.sum_sigma]
-      by_cases hkh : k = h
-      · subst h
-        rw [Matrix.blockDiagonal'_apply_eq]
-        simp only [oneSuffixSectorContraction]
-        apply Finset.sum_congr rfl
-        intro q _
-        apply Finset.sum_congr rfl
-        intro z _
-        rw [hconfig k x q z, hconfig k y q z]
-        have hentry := congrFun (congrFun
-          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
-            (N := L + 1))
-          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
-          ⟨Fin.append k q, F.appendSectorFiber y z⟩
-        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
-          Matrix.blockDiagonal'_apply_eq] using hentry
-      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
-        apply Finset.sum_eq_zero
-        intro q _
-        apply Finset.sum_eq_zero
-        intro z _
-        rw [hconfig k x q z, hconfig h y q z]
-        have happend_ne : Fin.append k q ≠ Fin.append h q := by
-          intro heq
-          apply hkh
-          funext i
-          have hi := congrFun heq (Fin.castAdd 1 i)
-          simpa using hi
-        have hentry := congrFun (congrFun
-          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
-            (N := L + 1))
-          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
-          ⟨Fin.append h q, F.appendSectorFiber y z⟩
-        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
-          Matrix.blockDiagonal'_apply_ne _ _ _ happend_ne] using hentry
+        Matrix.blockDiagonal' (fun k ↦ F.oneSuffixSectorContraction k) :=
+  F.reindex_reducedBlockState_add_eq_suffixSectorContraction L 1
 
 /-- In complete physical-sector coordinates, the marginal obtained by
 discarding two suffix sites is the direct sum of the corresponding two-suffix
@@ -176,7 +81,7 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
 **Local fix (adjacent marginal comparison):** This is the two-suffix side of
-the comparison with the three-suffix expansion. See
+the comparison with the one-suffix expansion. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reindex_reducedBlockState_add_two_eq_twoSuffixSectorContraction
     (F : PhysicalSectorFactorization K) (L : ℕ) :
@@ -184,94 +89,7 @@ theorem reindex_reducedBlockState_add_two_eq_twoSuffixSectorContraction
         (F.sectorCoordinateChainEquiv L)
         (F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega)) =
       ((Matrix.trace (mpo F.sectorCoordinateTensor (L + 2)))⁻¹ : ℂ) •
-        Matrix.blockDiagonal' (fun k ↦ F.twoSuffixSectorContraction k) := by
-  classical
-  letI : NeZero (L + 2) := ⟨by omega⟩
-  have hblock :
-      F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega) =
-        blockReducedState (Fintype.card (SectorSiteIndex F)) L 2
-          (F.sectorCoordinateTensor.normalizedMPO (L + 2)) := by
-    rw [MPOTensor.reducedBlockState]
-    simpa only [blockReindexEquiv] using
-      blockReducedState_submatrix_finCongr
-        (show L + 2 = L + (L + 2 - L) by omega)
-        (F.sectorCoordinateTensor.normalizedMPO (L + 2))
-  rw [hblock]
-  ext s t
-  obtain ⟨k, x⟩ := s
-  obtain ⟨h, y⟩ := t
-  simp only [Matrix.reindex_apply, Matrix.submatrix_apply,
-    blockReducedState, Matrix.partialTraceRight_apply,
-    normalizedMPO, Matrix.smul_apply, smul_eq_mul]
-  rw [← Finset.mul_sum]
-  congr 1
-  simp only [blockSplitEquiv_symm_apply]
-  change (∑ i : Fin 2 → Fin (Fintype.card (SectorSiteIndex F)),
-      mpo F.sectorCoordinateTensor (L + 2)
-        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩) i)
-        (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩) i)) = _
-  have hconfig
-      (p : Fin L → Fin F.sectorCount) (u : F.SectorChainFiber p)
-      (q : Fin 2 → Fin F.sectorCount) (z : F.SectorChainFiber q) :
-      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
-          ((F.sectorCoordinateChainEquiv 2).symm ⟨q, z⟩) =
-        (F.sectorCoordinateChainEquiv (L + 2)).symm
-          ⟨Fin.append p q, F.appendSectorFiber u z⟩ := by
-    funext i
-    refine Fin.addCases (motive := fun i' : Fin (L + 2) ↦
-      Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨p, u⟩)
-          ((F.sectorCoordinateChainEquiv 2).symm ⟨q, z⟩) i' =
-        (F.sectorCoordinateChainEquiv (L + 2)).symm
-          ⟨Fin.append p q, F.appendSectorFiber u z⟩ i')
-      (fun j ↦ ?_) (fun j ↦ ?_) i
-    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
-    · simp [F.sectorCoordinateChainEquiv_symm_apply, appendSectorFiber]
-  calc
-    _ = ∑ s : F.SectorChainIndex 2,
-        mpo F.sectorCoordinateTensor (L + 2)
-          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨k, x⟩)
-            ((F.sectorCoordinateChainEquiv 2).symm s))
-          (Fin.append ((F.sectorCoordinateChainEquiv L).symm ⟨h, y⟩)
-            ((F.sectorCoordinateChainEquiv 2).symm s)) := by
-      apply Fintype.sum_equiv (F.sectorCoordinateChainEquiv 2)
-      intro i
-      rw [Equiv.symm_apply_apply]
-    _ = _ := by
-      rw [Fintype.sum_sigma]
-      by_cases hkh : k = h
-      · subst h
-        rw [Matrix.blockDiagonal'_apply_eq]
-        simp only [twoSuffixSectorContraction]
-        apply Finset.sum_congr rfl
-        intro q _
-        apply Finset.sum_congr rfl
-        intro z _
-        rw [hconfig k x q z, hconfig k y q z]
-        have hentry := congrFun (congrFun
-          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
-            (N := L + 2))
-          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
-          ⟨Fin.append k q, F.appendSectorFiber y z⟩
-        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
-          Matrix.blockDiagonal'_apply_eq] using hentry
-      · rw [Matrix.blockDiagonal'_apply_ne _ _ _ hkh]
-        apply Finset.sum_eq_zero
-        intro q _
-        apply Finset.sum_eq_zero
-        intro z _
-        rw [hconfig k x q z, hconfig h y q z]
-        have happend_ne : Fin.append k q ≠ Fin.append h q := by
-          intro heq
-          apply hkh
-          funext i
-          have hi := congrFun heq (Fin.castAdd 2 i)
-          simpa using hi
-        have hentry := congrFun (congrFun
-          (F.reindex_mpo_sectorCoordinateTensor_eq_blockDiagonal
-            (N := L + 2))
-          ⟨Fin.append k q, F.appendSectorFiber x z⟩)
-          ⟨Fin.append h q, F.appendSectorFiber y z⟩
-        simpa only [Matrix.reindex_apply, Matrix.submatrix_apply,
-          Matrix.blockDiagonal'_apply_ne _ _ _ happend_ne] using hentry
+        Matrix.blockDiagonal' (fun k ↦ F.twoSuffixSectorContraction k) :=
+  F.reindex_reducedBlockState_add_eq_suffixSectorContraction L 2
 
 end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
@@ -166,6 +166,91 @@
     sites.
 \end{proof}
 
+% Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+% 1606--1617.
+% **Local fix (adjacent marginal comparison):** the arbitrary positive suffix
+% length includes the one-, two-, and three-site contractions used below. See
+% docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\begin{definition}[Fixed-sector suffix contraction]
+    \label{def:mpdo_suffix_sector_contraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.suffixSectorContraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      oneSuffixSectorContraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      twoSuffixSectorContraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      threeSuffixSectorContraction}
+    \leanok
+    \uses{def:mpdo_physical_sector_chain_coordinates}
+    Let $S$ be the finite set of physical sectors and let
+    $k=(k_0,\ldots,k_{L-1})\in S^L$ be a retained sector word. For
+    $R\geq1$ and $x,y\in I_k$, define
+    \begin{align}
+        \Gamma_k^{(R)}(x,y)
+        &=
+        \sum_{t\in S^R}\ \sum_{z\in I_t}
+        \Omega_{kt}(xz,yz),
+        \notag
+    \end{align}
+    where $kt$ and $xz$ denote concatenation of sector words and their
+    corresponding fiber coordinates. The cases $R=1,2,3$ are denoted by
+    $\Gamma_k^{(1)}$, $\Gamma_k^{(2)}$, and $\Gamma_k^{(3)}$.
+\end{definition}
+
+% Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+% 1606--1617.
+% **Local fix (adjacent marginal comparison):** the cases R=1 and R=2 give
+% the adjacent marginals whose boundary traces have coefficients T_C^2 and
+% T_C^3. See docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.
+\begin{theorem}[Sector decomposition of a suffix marginal]
+    \label{thm:mpdo_suffix_marginal_block_expansion}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      reindex_reducedBlockState_add_eq_suffixSectorContraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      reindex_reducedBlockState_add_one_eq_oneSuffixSectorContraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      reindex_reducedBlockState_add_two_eq_twoSuffixSectorContraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      reindex_reducedBlockState_add_three_eq_threeSuffixSectorContraction}
+    \leanok
+    \uses{def:mpdo_suffix_sector_contraction,
+      def:mpdo_physical_sector_chain_coordinates}
+    Let $\widetilde{\mathcal K}$ be the tensor in physical-sector
+    coordinates. For $L\geq0$ and $R\geq1$, the normalized $L$-site
+    marginal obtained from a chain of length $L+R$ satisfies
+    \begin{align}
+        \reindex_{\Phi_L}\!
+        \left(
+          \tr_R\!\left[\widehat\rho^{(L+R)}
+          (\widetilde{\mathcal K})\right]
+        \right)
+        &=
+        \tr\!\left[\rho^{(L+R)}
+          (\widetilde{\mathcal K})\right]^{-1}
+        \bigoplus_{k\in S^L}\Gamma_k^{(R)}.
+        \notag
+    \end{align}
+    In particular, this identity holds for $R=1$, $R=2$, and $R=3$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_physical_sector_chain_decomposition}
+    Decompose each discarded physical configuration uniquely as a suffix
+    sector word $t\in S^R$ and a fiber coordinate $z\in I_t$. By
+    Theorem~\ref{thm:mpdo_physical_sector_chain_decomposition}, matrix
+    elements with distinct retained sector words vanish. For a fixed
+    retained word $k$, summing the diagonal entries of the discarded fiber
+    gives
+    \begin{align}
+        \sum_{t\in S^R}\ \sum_{z\in I_t}
+        \Omega_{kt}(xz,yz)
+        &=\Gamma_k^{(R)}(x,y).
+        \notag
+    \end{align}
+    Multiplication by the inverse trace of the length-$L+R$ operator gives
+    the stated normalization.
+\end{proof}
+
 \begin{definition}[Rank-one trace factorization for neighboring operators]
     \label{def:mpdo_generic_eta_rank_one_trace_factorization}
     \lean{Matrix.EtaRankOneTraceFactorization}

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -36,6 +36,19 @@ abstracted — record why, so it is not re-proposed).
 - **Abstraction:** `@[mps_transfer]` simp set + `transfer_simp` macro
   (`TNLean/MPS/Tactic/Basic.lean`).
 
+### suffix marginal sector-block expansion — promoted
+- **Pattern:** reindex a normalized reduced state into physical-sector
+  coordinates, change the discarded-site sum to dependent sector fibers, and
+  identify equal retained-sector words with a dependent block-diagonal entry.
+- **Seen:** three suffix lengths in
+  `CyclicActiveFourthRegionContraction.lean` and
+  `CyclicActiveSuffixMarginal.lean` before promotion.
+- **Abstraction:**
+  `PhysicalSectorFactorization.reindex_reducedBlockState_add_eq_suffixSectorContraction`
+  in `TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean`.
+- **Notes:** the arbitrary suffix length is the mathematical parameter; the
+  source-facing one-, two-, and three-suffix theorems are specializations.
+
 ### partial trace under product reindexing — promoted
 - **Pattern:** split a simultaneous relabelling of both tensor factors into
   left- and right-factor submatrices, change the summation index in the traced


### PR DESCRIPTION
## Summary

- define the one-site and two-site suffix contractions of fixed physical-sector blocks
- expand the corresponding normalized reduced states as dependent block diagonals in complete physical-sector coordinates
- expose the new focused module through `TNLean.MPS.MPDO`

## Mathematical scope

This is a checked leaf toward #5129. The source-adjacent comparison is the one-suffix marginal against the two-suffix marginal. After tracing the two surviving outer boundary factors, their coefficients are respectively the square and cube of the cyclic-active sector trace matrix. The previously proposed one-versus-three comparison is not used: it would only compare even powers and does not imply the required square--cube relation.

The remaining coefficient cancellation requires a nonzero retained cyclic path for each cyclic-active ordered pair. That visibility statement is the subject of #5128, so this pull request does not claim the final converse theorem.

Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1606--1617; see `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.

## Verification

- `lake exe cache get`
- `lake build TNLean.MPS.MPDO.CyclicActiveSuffixMarginal` (9122/9122 jobs, successful)
- proof-integrity scan of the new module: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`
- `git diff --check`

Related: #5129
Depends on: #5128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean proofs and blueprint documentation only; no runtime, auth, or data-path changes. Refactors preserve the three-site API via abbreviations and thin wrapper theorems.
> 
> **Overview**
> Introduces **`suffixSectorContraction`** for arbitrary suffix length **R** and **`reindex_reducedBlockState_add_eq_suffixSectorContraction`**, which expresses a normalized **L**-site marginal (after tracing **R** sites) as a trace-normalized block diagonal of those contractions in physical-sector coordinates. The former three-site-only proof is refactored so **`threeSuffixSectorContraction`** is **`suffixSectorContraction 3`**, and the old three-site marginal theorem is a one-line specialization.
> 
> Adds **`CyclicActiveSuffixMarginal.lean`** with **`oneSuffixSectorContraction`** / **`twoSuffixSectorContraction`** and the corresponding **`reindex_reducedBlockState_add_one_eq_*`** and **`add_two_eq_*`** theorems (instantiating **R = 1, 2**), wired through **`TNLean.MPS.MPDO`**. Downstream proofs in **`CyclicActiveFourthRegionFormula.lean`** only adjust **`simp`** after the definitional change.
> 
> The blueprint chapter gains a suffix-contraction definition and a unified suffix-marginal block-expansion theorem (with **R = 1, 2, 3** cases); **`docs/tactic_patterns.md`** records the promoted sector-block expansion pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2bb5f73741bcab5a28e33c2009b0732e6ffbbe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->