### PR TITLE
feat(Spectral): prove rectangular mixed-transfer decay

### DIFF
--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -261,41 +261,13 @@ theorem mixedTransfer_pow_tendsto_zero_of_irreducible_TP
     (X : Matrix (Fin D) (Fin D) ℂ) :
     Filter.Tendsto (fun n => ((mixedTransferMap A B) ^ n) X)
       Filter.atTop (nhds 0) := by
-  let V := Matrix (Fin D) (Fin D) ℂ
-  let Φ : (V →ₗ[ℂ] V) ≃ₐ[ℂ] (V →L[ℂ] V) := Module.End.toContinuousLinearMap V
-  let F' : V →L[ℂ] V := Φ (mixedTransferMap A B)
-  letI : NormedAddCommGroup (V →L[ℂ] V) := ContinuousLinearMap.toNormedAddCommGroup
-  letI : SeminormedRing (V →L[ℂ] V) := ContinuousLinearMap.toSeminormedRing
-  letI : NormedRing (V →L[ℂ] V) := ContinuousLinearMap.toNormedRing
-  letI : NormedSpace ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedSpace
-  letI : NormedAlgebra ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedAlgebra
-  haveI : FiniteDimensional ℂ (V →L[ℂ] V) := Φ.toLinearEquiv.finiteDimensional
-  have hComplete : CompleteSpace (V →L[ℂ] V) := FiniteDimensional.complete ℂ (V →L[ℂ] V)
-  letI : CompleteSpace (V →L[ℂ] V) := hComplete
-  have hSpectF : spectralRadius ℂ F' < 1 := by
-    -- `mixedTransferSpectralRadius A B` unfolds to `spectralRadius ℂ F'`
-    -- after expanding `mixedTransferSpectralRadius` and `F'`, `Φ`, `V`
-    have h := spectralRadius_mixedTransfer_lt_one_of_irreducible_TP
-      A B hA_irr hB_irr hA_left hB_left hAB
-    unfold mixedTransferSpectralRadius at h
-    dsimp [V, F', Φ] at h ⊢
-    exact h
-  have hF : Filter.Tendsto (fun n => F' ^ n) Filter.atTop (nhds 0) :=
-    @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
-      (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
-      (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V)) F' hSpectF
-  have hEval : Filter.Tendsto (fun n => (F' ^ n) X) Filter.atTop (nhds 0) := by
-    apply squeeze_zero_norm' (a := fun n => ‖F' ^ n‖ * ‖X‖)
-    · exact Filter.Eventually.of_forall fun n => (F' ^ n).le_opNorm X
-    · simpa using (tendsto_norm_zero.comp hF).mul_const ‖X‖
-  have h_eq_app : ∀ n, (F' ^ n) X = ((mixedTransferMap A B) ^ n) X := by
-    intro n
-    have h_pow : (F' ^ n : V →L[ℂ] V) = (Φ ((mixedTransferMap A B) ^ n) : V →L[ℂ] V) := by
-      simp [V, F', Φ, map_pow]
-    rw [h_pow]
-    dsimp [V, Φ]
-    rfl
-  exact hEval.congr h_eq_app
+  simpa only [mixedTransferMap₂_pow_same_dim] using
+    mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one A B
+      (by
+        rw [mixedTransferSpectralRadius₂_same_dim]
+        exact spectralRadius_mixedTransfer_lt_one_of_irreducible_TP
+          A B hA_irr hB_irr hA_left hB_left hAB)
+      X
 
 end SameDimension
 

--- a/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
+++ b/TNLean/Spectral/TransferOperatorGapRectNormalized.lean
@@ -11,13 +11,25 @@ import Mathlib.LinearAlgebra.Eigenspace.Basic
 # Normalized rectangular transfer-operator bounds
 
 This module proves the normalized bound $ρ(F_{AB}) ≤ 1$ for the rectangular mixed
-transfer operator. The strict dimension-mismatch and overlap-decay theorems are
-proved separately from this normalized estimate.
+transfer operator and pointwise decay of its powers when the spectral radius is
+strictly below one. The strict dimension-mismatch and overlap-decay theorems are
+proved separately from the normalized estimate.
+
+## Main results
+
+* `spectralRadius_mixedTransfer₂_le_one`: the rectangular mixed transfer
+  operator of normalized tensors has spectral radius at most one.
+* `mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one`: a rectangular
+  mixed transfer operator with spectral radius below one has pointwise-vanishing
+  powers.
 
 ## References
 
 * [PerezGarcia2007String] Pérez-García, Verstraete, Wolf, Cirac,
   *Matrix Product State Representations*, 2007, Lemma 5.
+* CPSV16: Cirac, Pérez-García, Schuch, Verstraete,
+  *Matrix Product Density Operators: Renormalization Fixed Points and Boundary
+  Theories*, arXiv:1606.00608, Appendix B, equations `EasEkk`--`Ekk`.
 -/
 
 open scoped Matrix MatrixOrder ComplexOrder BigOperators NNReal ENNReal Matrix.Norms.Operator
@@ -164,10 +176,61 @@ theorem spectralRadius_mixedTransfer₂_le_one
 
 end EigenvalueBound
 
+/-! ## Power decay -/
+
+/--
+If the rectangular mixed transfer operator has spectral radius strictly below one, then its
+powers converge pointwise to zero.
+
+This is the decay step for the off-diagonal operators in CPSV16, Appendix B,
+equations `EasEkk`--`Ekk` and line 1243.
+-/
+theorem mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (h : mixedTransferSpectralRadius₂ A B < 1)
+    (X : Matrix (Fin D₁) (Fin D₂) ℂ) :
+    Filter.Tendsto (fun n => ((mixedTransferMap₂ A B) ^ n) X)
+      Filter.atTop (nhds 0) := by
+  let V := Matrix (Fin D₁) (Fin D₂) ℂ
+  let Φ : (V →ₗ[ℂ] V) ≃ₐ[ℂ] (V →L[ℂ] V) := Module.End.toContinuousLinearMap V
+  let F : V →L[ℂ] V := Φ (mixedTransferMap₂ A B)
+  letI : NormedAddCommGroup (V →L[ℂ] V) := ContinuousLinearMap.toNormedAddCommGroup
+  letI : SeminormedRing (V →L[ℂ] V) := ContinuousLinearMap.toSeminormedRing
+  letI : NormedRing (V →L[ℂ] V) := ContinuousLinearMap.toNormedRing
+  letI : NormedSpace ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedSpace
+  letI : NormedAlgebra ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedAlgebra
+  haveI : FiniteDimensional ℂ (V →L[ℂ] V) := Φ.toLinearEquiv.finiteDimensional
+  have hComplete : CompleteSpace (V →L[ℂ] V) :=
+    FiniteDimensional.complete ℂ (V →L[ℂ] V)
+  letI : CompleteSpace (V →L[ℂ] V) := hComplete
+  have hSpectralRadius : spectralRadius ℂ F < 1 := by
+    change spectralRadius ℂ
+      (((Module.End.toContinuousLinearMap (Matrix (Fin D₁) (Fin D₂) ℂ))
+        (mixedTransferMap₂ A B)) :
+          Matrix (Fin D₁) (Fin D₂) ℂ →L[ℂ] Matrix (Fin D₁) (Fin D₂) ℂ) < 1
+    simpa only [mixedTransferSpectralRadius₂] using h
+  have hF : Filter.Tendsto (fun n => F ^ n) Filter.atTop (nhds 0) :=
+    @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+      (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
+      (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V))
+      F hSpectralRadius
+  have hEval : Filter.Tendsto (fun n => (F ^ n) X) Filter.atTop (nhds 0) := by
+    apply squeeze_zero_norm' (a := fun n => ‖F ^ n‖ * ‖X‖)
+    · exact Filter.Eventually.of_forall fun n => (F ^ n).le_opNorm X
+    · simpa using (tendsto_norm_zero.comp hF).mul_const ‖X‖
+  have hApply : ∀ n, (F ^ n) X = ((mixedTransferMap₂ A B) ^ n) X := by
+    intro n
+    have hPow :
+        (F ^ n : V →L[ℂ] V) = Φ ((mixedTransferMap₂ A B) ^ n) := by
+      simp [V, Φ, F, map_pow]
+    rw [hPow]
+    rfl
+  exact hEval.congr hApply
+
 /-!
 Strict dimension-mismatch consequences are intentionally downstream in
 `TransferOperatorGapNT` and `TransferOperatorGapInjective`.  This module contains
-only the shared rectangular spectral-radius bound.
+only the shared rectangular spectral-radius bound and its analytic decay consequence.
 -/
 
 end MPSTensor

--- a/blueprint/src/appendix/ft_mps/ch07_spectral.tex
+++ b/blueprint/src/appendix/ft_mps/ch07_spectral.tex
@@ -370,10 +370,12 @@ the block-separation consequences of the transfer-operator gap.
     sufficiently large $n$, and $r^n\to0$.
 \end{proof}
 
+Theorem~\ref{thm:rectangular_transfer_pow_zero} applies
+Lemma~\ref{lem:spectral_radius_pow_zero} to the rectangular mixed transfer
+operator and then evaluates its powers at a fixed matrix.
 Theorem~\ref{thm:transfer_pow_zero} combines the gap
-$\rho_{\spec}(F_{AB})<1$ of Theorem~\ref{thm:transfer_operator_gap} with
-Lemma~\ref{lem:spectral_radius_pow_zero} to give
-$\|F_{AB}^n\|_{\mathrm{op}}\to0$, hence $F_{AB}^n(X)\to0$ for every $X$.
+$\rho_{\spec}(F_{AB})<1$ of Theorem~\ref{thm:transfer_operator_gap} with the
+equal-bond-dimension specialization of this rectangular decay theorem.
 Since $\Tr$ is continuous on the finite-dimensional matrix-endomorphism
 algebra, this gives $\Tr(F_{AB}^N)\to0$ term by term over the finitely many
 matrix-unit entries of (\ref{eq:spectral_trace_expansion}); combined with

--- a/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
+++ b/blueprint/src/chapter/ch07_spectral_mixed_transfer_and_overlap.tex
@@ -335,6 +335,31 @@ a block embedding of a mixed-transfer eigenvector.
     $D_1=D_2$, contradicting the hypothesis.
 \end{proof}
 
+\begin{theorem}[Rectangular transfer powers below unit spectral radius]%
+    \label{thm:rectangular_transfer_pow_zero}
+    \lean{MPSTensor.mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    Let $A$ and $B$ have bond dimensions $D_1$ and $D_2$, respectively. If
+    $\rho_{\spec}(F_{AB}^{\mathrm{rect}})<1$, then, for every
+    $X\in M_{D_1\times D_2}(\C)$,
+    \begin{align}
+        (F_{AB}^{\mathrm{rect}})^n(X)\longrightarrow0.
+        \notag
+    \end{align}
+    This is the decay mechanism for the off-diagonal transfer operators in
+    \cite[Appendix~B, equations~(B.3)--(B.4) and the paragraph following
+    equation~(B.6)]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:spectral_radius_pow_zero}
+    The Gelfand formula implies convergence of
+    $(F_{AB}^{\mathrm{rect}})^n$ to zero in operator norm. Evaluation at a
+    fixed rectangular matrix is continuous, and therefore preserves this
+    limit.
+\end{proof}
+
 \begin{theorem}[Rectangular overlap decay]\label{thm:overlap_decay_rect}
     \lean{MPSTensor.mpvOverlap_tendsto_zero_of_dim_ne}
     \leanok
@@ -344,9 +369,11 @@ a block embedding of a mixed-transfer eigenvector.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:transfer_operator_gap_rect, thm:overlap_trace_rect}
+    \uses{thm:transfer_operator_gap_rect, lem:spectral_radius_pow_zero,
+        thm:overlap_trace_rect}
     The gap $\rho_{\spec}(F_{AB}^{\mathrm{rect}})<1$ from
-    Theorem~\ref{thm:transfer_operator_gap_rect} implies
+    Theorem~\ref{thm:transfer_operator_gap_rect} and
+    Lemma~\ref{lem:spectral_radius_pow_zero} imply operator-norm convergence
     $(F_{AB}^{\mathrm{rect}})^N\to0$, so its operator trace tends to zero.
     The identity (\ref{eq:spectral_overlap_trace_rect}) therefore gives
     $O_{AB}(N)\to0$.
@@ -383,12 +410,11 @@ proved in Section~\ref{sec:app_spectral_decay}.
 
 \begin{proof}
     \leanok
-    \uses{thm:transfer_operator_gap, lem:spectral_radius_pow_zero}
+    \uses{thm:transfer_operator_gap, thm:rectangular_transfer_pow_zero}
     The gap $\rho_{\spec}(F_{AB})<1$ from
-    Theorem~\ref{thm:transfer_operator_gap} and the Gelfand-formula
-    convergence of Lemma~\ref{lem:spectral_radius_pow_zero} give
-    $\|F_{AB}^n\|_{\mathrm{op}}\to0$. Hence $F_{AB}^n(X)\to0$ for every
-    $X$.
+    Theorem~\ref{thm:transfer_operator_gap} and the equal-bond-dimension case
+    of Theorem~\ref{thm:rectangular_transfer_pow_zero} give
+    $F_{AB}^n(X)\to0$ for every $X$.
 \end{proof}
 
 \begin{theorem}[Overlap decay]\label{thm:overlap_decay}


### PR DESCRIPTION
## Summary

- prove that powers of a rectangular mixed transfer operator converge pointwise to zero when its spectral radius is strictly below one
- refactor the equal-bond-dimension decay theorem to specialize the rectangular result
- add the corresponding blueprint theorem and use it in the rectangular-overlap and equal-dimension decay arguments

## Mathematical source

This isolates the analytic decay step used for the off-diagonal transfer operators in CPSV16, Appendix B, equations `EasEkk`--`Ekk` and line 1243 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

The statement is conditional on the exact hypothesis `ρ(F) < 1`; it does not claim the paper's false unrestricted convergence assertion for the full canonical-form renormalization flow.

## Validation

- `lake build TNLean.Spectral.TransferOperatorGapRectNormalized TNLean.Spectral.TransferOperatorGapNT`
- full `lake build`
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`
- `python3 scripts/blueprint_lean_sync.py --ci ...`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity scan and `git diff --check`

The full build, web, and PDF gates ran on the frozen source diff before the clean rebase; the affected Lean modules and declaration/sync checks were rerun on the rebased head.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor and documentation only; behavior is unchanged for equal dimensions via specialization lemmas, with no auth, I/O, or runtime surface area.
> 
> **Overview**
> This PR **centralizes the analytic decay step** for mixed transfer operators: when the rectangular operator has spectral radius strictly below 1, its powers converge pointwise to zero on every fixed matrix (`mixedTransferMap₂_pow_tendsto_zero_of_spectralRadius_lt_one` in `TransferOperatorGapRectNormalized.lean`). The proof lifts the map to a finite-dimensional continuous linear endomorphism and applies the existing Banach-algebra lemma `pow_tendsto_zero_of_spectralRadius_lt_one`.
> 
> The **equal-bond-dimension** theorem `mixedTransfer_pow_tendsto_zero_of_irreducible_TP` no longer duplicates that argument; it `simpa`s through `mixedTransferMap₂_pow_same_dim` and `mixedTransferSpectralRadius₂_same_dim`, supplying ρ &lt; 1 from the existing irreducible-TP gap.
> 
> **Blueprint** adds Theorem `rectangular_transfer_pow_zero` (CPSV16 off-diagonal decay), updates the appendix decay section, and routes `transfer_pow_zero` and rectangular overlap decay proofs through the rectangular result instead of repeating Gelfand-formula details inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ca2f5ac02a647f9edf9049a4475b11bfda306e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->