### PR TITLE
fix(tenkz): verify the RMP author-source authority

### DIFF
--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -41,13 +41,25 @@ python3 scripts/tenkz_rmp.py check --all
 python3 scripts/tenkz_rmp.py book --all
 python3 scripts/tenkz_rmp.py render --all
 python3 scripts/tenkz_rmp.py compare --all \
-  --source-root /absolute/path/to/author-source-tree
+  --source-root References/RMP_TIKZ_SOURCE_CODE
 ```
 
 The comparison command requires a separate author-source tree supplied through
-`--source-root`.  That tree is not part of this repository, so comparison is not
-a clean-checkout build command.  Run it only in a source-pairing session with an
-explicit external tree.
+`--source-root`.  The canonical local home is the gitignored
+`References/RMP_TIKZ_SOURCE_CODE/` directory.  It contains the authors'
+standalone `ImagesReview Section II` through `ImagesReview Section V` source
+drop used to establish the `author_source` and `author_lines` pairings in
+`tests/tenkz/rmp/manifest.toml`; the source drop is not redistributed by this
+repository.
+
+The four cited section files are identified by
+`tests/tenkz/rmp/author-source.sha256`.  `compare` verifies that manifest before
+compiling any corpus target, so a missing, edited, or different source drop
+fails quickly instead of producing a comparison book against unreviewed
+evidence.  Generated PDFs, auxiliary files, logs, and filesystem metadata are
+not provenance: only the section sources cited by the pairing manifest define
+the external authority.  A source tree in another local directory is acceptable
+only when it matches the committed hashes.
 
 Per-target verdicts are stored in `tests/tenkz/rmp/verdicts.toml`, one
 stanza per target.  Any status may be recorded, including failure; the check

--- a/docs/tenkz/HACKING.md
+++ b/docs/tenkz/HACKING.md
@@ -53,12 +53,14 @@ drop used to establish the `author_source` and `author_lines` pairings in
 repository.
 
 The four cited section files are identified by
-`tests/tenkz/rmp/author-source.sha256`.  `compare` verifies that manifest before
-compiling any corpus target, so a missing, edited, or different source drop
-fails quickly instead of producing a comparison book against unreviewed
-evidence.  Generated PDFs, auxiliary files, logs, and filesystem metadata are
-not provenance: only the section sources cited by the pairing manifest define
-the external authority.  A source tree in another local directory is acceptable
+`tests/tenkz/rmp/author-source.sha256`.  `compare` verifies and snapshots those
+files before compiling any corpus target, so a missing, edited, or different
+source drop fails quickly and later filesystem changes cannot alter the
+comparison.  Pairing verdicts are also bound to the source identities and
+extraction ranges by `pairing_sha256` in `tests/tenkz/rmp/verdicts.toml`.
+Generated PDFs, auxiliary files, logs, and filesystem metadata are not
+provenance: only the section sources cited by the pairing manifest define the
+external authority.  A source tree in another local directory is acceptable
 only when it matches the committed hashes.
 
 Per-target verdicts are stored in `tests/tenkz/rmp/verdicts.toml`, one

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -987,8 +987,9 @@ def verify_author_source_tree(
     source_root: Path,
     *,
     hashes_path: Path = AUTHOR_SOURCE_HASHES,
+    snapshot_root: Path | None = None,
 ) -> int:
-    """Prove that comparison reads the authority reviewed by the verdicts."""
+    """Verify the external authority and optionally snapshot the exact bytes."""
     if not source_root.is_dir():
         fail(f"source root does not exist: {source_root}")
     hashes = load_author_source_hashes(hashes_path)
@@ -1014,17 +1015,40 @@ def verify_author_source_tree(
     for source in sorted(cited, key=lambda item: item.as_posix()):
         candidate = source_root / source
         try:
-            actual = sha256(candidate)
+            payload = candidate.read_bytes()
         except FileNotFoundError:
             fail(f"author source does not exist: {candidate}")
         except OSError as exc:
-            fail(f"cannot hash author source {candidate}: {exc}")
+            fail(f"cannot read author source {candidate}: {exc}")
+        actual = hashlib.sha256(payload).hexdigest()
         if actual != hashes[source]:
             fail(
                 f"author source hash mismatch: {source} "
                 f"(expected {hashes[source]}, got {actual})"
             )
+        if snapshot_root is not None:
+            snapshot = snapshot_root / source
+            snapshot.parent.mkdir(parents=True, exist_ok=True)
+            snapshot.write_bytes(payload)
     return len(cited)
+
+
+def pairing_digest(targets: Sequence[Target]) -> str:
+    """Bind pairing judgments to source identities and extraction boundaries."""
+    digest = hashlib.sha256()
+    digest.update(sha256(AUTHOR_SOURCE_HASHES).encode("ascii"))
+    digest.update(b"\n")
+    for target in sorted(targets, key=lambda item: item.id):
+        fields = (
+            target.id,
+            target.author_source.as_posix() if target.author_source else "",
+            target.author_lines or "",
+            target.extraction_override or "",
+            "context-only" if target.paper_context_only else "paired",
+        )
+        digest.update("\0".join(fields).encode("utf-8"))
+        digest.update(b"\n")
+    return digest.hexdigest()
 
 
 def campaign_digest(targets: Sequence[Target]) -> str:
@@ -1099,7 +1123,12 @@ def load_verdicts(targets: Sequence[Target]) -> dict[str, TargetVerdict]:
         raw = tomllib.loads(DEFAULT_VERDICT.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, tomllib.TOMLDecodeError) as exc:
         fail(f"cannot read verdict ledger {DEFAULT_VERDICT}: {exc}")
-    allowed_top = {"schema_version", "campaign_sha256", "verdict"}
+    allowed_top = {
+        "schema_version",
+        "pairing_sha256",
+        "campaign_sha256",
+        "verdict",
+    }
     if not set(raw) <= allowed_top:
         fail(f"verdict ledger top-level keys must be within {sorted(allowed_top)}")
     if raw.get("schema_version") != 1:
@@ -1185,6 +1214,16 @@ def load_verdicts(targets: Sequence[Target]) -> dict[str, TargetVerdict]:
     missing_ids = sorted(set(by_target) - set(verdicts))
     if missing_ids:
         fail("targets without a verdict stanza: " + ", ".join(missing_ids))
+    recorded_pairing = raw.get("pairing_sha256")
+    if not isinstance(recorded_pairing, str):
+        fail("verdict ledger pairing_sha256 must be a string")
+    current_pairing = pairing_digest(targets)
+    if recorded_pairing != current_pairing:
+        fail(
+            "stale pairing verdicts; author-source identities or extraction "
+            "boundaries changed since review "
+            f"(recorded {recorded_pairing[:12]}, current {current_pairing[:12]})"
+        )
     recorded_campaign = raw.get("campaign_sha256")
     if isinstance(recorded_campaign, str):
         current_campaign = campaign_digest(targets)
@@ -1850,14 +1889,20 @@ def main() -> int:
         validate_verdict_consistency(targets, verdicts)
         if args.command == "compare":
             source_root = args.source_root.resolve()
-            verified = verify_author_source_tree(targets, source_root)
-            print(
-                "PASS: verified "
-                f"{verified} author-source authority file(s) against "
-                f"{AUTHOR_SOURCE_HASHES.relative_to(REPO)}"
-            )
         with tempfile.TemporaryDirectory(prefix="tenkz-rmp-") as temporary:
             work = Path(temporary)
+            if args.command == "compare":
+                source_snapshot = work / "author-source"
+                verified = verify_author_source_tree(
+                    targets,
+                    source_root,
+                    snapshot_root=source_snapshot,
+                )
+                print(
+                    "PASS: snapshotted "
+                    f"{verified} verified author-source authority file(s) against "
+                    f"{AUTHOR_SOURCE_HASHES.relative_to(REPO)}"
+                )
             results = compile_targets(selected, work, jobs)
             if args.command == "check":
                 counts = verdict_histogram(verdicts)
@@ -1888,7 +1933,7 @@ def main() -> int:
                 print(f"PASS: rendered {png_count} target/book page(s) to {destination}")
                 print(f"Checksums: {destination / 'SHA256SUMS'}")
                 return 0
-            comparison = compile_comparison(results, source_root, work, jobs)
+            comparison = compile_comparison(results, source_snapshot, work, jobs)
             install_pdf(comparison, COMPARE_OUTPUT)
             print(f"PASS: wrote source-only comparison book to {COMPARE_OUTPUT}")
             return 0

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -31,6 +31,9 @@ from tenkzlib.tnlog import ParsedLog, parse_log
 REPO = Path(__file__).resolve().parent.parent
 DEFAULT_MANIFEST = REPO / "tests" / "tenkz" / "rmp" / "manifest.toml"
 DEFAULT_VERDICT = REPO / "tests" / "tenkz" / "rmp" / "verdicts.toml"
+AUTHOR_SOURCE_HASHES = (
+    REPO / "tests" / "tenkz" / "rmp" / "author-source.sha256"
+)
 PAPER_SOURCE = REPO / "Papers" / "2011.12127" / "TN-Review-main.tex"
 FROZEN_TARGET_COUNT = 130
 BOOK_SOURCE = REPO / "docs" / "tenkz" / "rmp-benchmark.tex"
@@ -944,10 +947,91 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def load_author_source_hashes(path: Path) -> dict[Path, str]:
+    """Read the committed identity of the external author-source authority."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        fail(f"author-source hash manifest does not exist: {path}")
+    except (OSError, UnicodeError) as exc:
+        fail(f"cannot read author-source hash manifest {path}: {exc}")
+
+    hashes: dict[Path, str] = {}
+    order: list[str] = []
+    for line_number, line in enumerate(lines, 1):
+        if not line or line.startswith("#"):
+            continue
+        match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
+        if match is None:
+            fail(
+                f"{path}:{line_number}: expected '<sha256>  <relative .tex path>'"
+            )
+        source = relative_repo_path(
+            match.group(2),
+            field=f"{path}:{line_number}",
+            suffix=".tex",
+        )
+        if source in hashes:
+            fail(f"{path}:{line_number}: duplicate author source {source}")
+        hashes[source] = match.group(1)
+        order.append(source.as_posix())
+    if order != sorted(order):
+        fail(f"author-source hash manifest is not path-sorted: {path}")
+    if not hashes:
+        fail(f"author-source hash manifest is empty: {path}")
+    return hashes
+
+
+def verify_author_source_tree(
+    targets: Sequence[Target],
+    source_root: Path,
+    *,
+    hashes_path: Path = AUTHOR_SOURCE_HASHES,
+) -> int:
+    """Prove that comparison reads the authority reviewed by the verdicts."""
+    if not source_root.is_dir():
+        fail(f"source root does not exist: {source_root}")
+    hashes = load_author_source_hashes(hashes_path)
+    cited = {
+        target.author_source
+        for target in targets
+        if target.author_source is not None
+    }
+    recorded = set(hashes)
+    if recorded != cited:
+        missing = sorted(path.as_posix() for path in cited - recorded)
+        extra = sorted(path.as_posix() for path in recorded - cited)
+        details: list[str] = []
+        if missing:
+            details.append("missing: " + ", ".join(missing))
+        if extra:
+            details.append("uncited: " + ", ".join(extra))
+        fail(
+            "author-source hash manifest disagrees with manifest.toml ("
+            + "; ".join(details)
+            + ")"
+        )
+    for source in sorted(cited, key=lambda item: item.as_posix()):
+        candidate = source_root / source
+        try:
+            actual = sha256(candidate)
+        except FileNotFoundError:
+            fail(f"author source does not exist: {candidate}")
+        except OSError as exc:
+            fail(f"cannot hash author source {candidate}: {exc}")
+        if actual != hashes[source]:
+            fail(
+                f"author source hash mismatch: {source} "
+                f"(expected {hashes[source]}, got {actual})"
+            )
+    return len(cited)
+
+
 def campaign_digest(targets: Sequence[Target]) -> str:
     """Hash every committed input whose change invalidates visual verdicts."""
     paths = {
         DEFAULT_MANIFEST,
+        AUTHOR_SOURCE_HASHES,
         PAPER_SOURCE,
         BOOK_SOURCE,
         REPO / "docs" / "tenkz" / "tenkzrmpbenchmark.sty",
@@ -1764,8 +1848,14 @@ def main() -> int:
         # fail in seconds, not after 130 builds.
         verdicts = load_verdicts(targets)
         validate_verdict_consistency(targets, verdicts)
-        if args.command == "compare" and not args.source_root.is_dir():
-            fail(f"source root does not exist: {args.source_root}")
+        if args.command == "compare":
+            source_root = args.source_root.resolve()
+            verified = verify_author_source_tree(targets, source_root)
+            print(
+                "PASS: verified "
+                f"{verified} author-source authority file(s) against "
+                f"{AUTHOR_SOURCE_HASHES.relative_to(REPO)}"
+            )
         with tempfile.TemporaryDirectory(prefix="tenkz-rmp-") as temporary:
             work = Path(temporary)
             results = compile_targets(selected, work, jobs)
@@ -1798,7 +1888,7 @@ def main() -> int:
                 print(f"PASS: rendered {png_count} target/book page(s) to {destination}")
                 print(f"Checksums: {destination / 'SHA256SUMS'}")
                 return 0
-            comparison = compile_comparison(results, args.source_root.resolve(), work, jobs)
+            comparison = compile_comparison(results, source_root, work, jobs)
             install_pdf(comparison, COMPARE_OUTPUT)
             print(f"PASS: wrote source-only comparison book to {COMPARE_OUTPUT}")
             return 0

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -11,9 +11,14 @@ from pathlib import Path
 
 from tenkz_audit import Audit
 from tenkz_rmp import (
+    DEFAULT_MANIFEST,
+    RMPError,
     ink_environment_problems,
+    load_manifest,
     rendered_ink_environment_families,
+    sha256,
     structural_capability_problems,
+    verify_author_source_tree,
 )
 from tenkzlib.tnlog import parse_log
 
@@ -155,9 +160,71 @@ def test_ink_environment_owner() -> None:
         raise AssertionError("compiled kernel owner was omitted")
 
 
+def test_rmp_author_source_identity() -> None:
+    targets = load_manifest(DEFAULT_MANIFEST)
+    cited = sorted(
+        {
+            target.author_source
+            for target in targets
+            if target.author_source is not None
+        },
+        key=lambda path: path.as_posix(),
+    )
+    with tempfile.TemporaryDirectory(prefix="tenkz-rmp-author-source-") as tmp:
+        work = Path(tmp)
+        source_root = work / "RMP_TIKZ_SOURCE_CODE"
+        for index, source in enumerate(cited, 1):
+            candidate = source_root / source
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            candidate.write_text(f"author source {index}\n", encoding="utf-8")
+        hashes = work / "author-source.sha256"
+        hashes.write_text(
+            "".join(
+                f"{sha256(source_root / source)}  {source.as_posix()}\n"
+                for source in cited
+            ),
+            encoding="utf-8",
+        )
+        verified = verify_author_source_tree(
+            targets, source_root, hashes_path=hashes
+        )
+        if verified != len(cited):
+            raise AssertionError("author-source verifier lost a cited source")
+
+        changed = source_root / cited[0]
+        original = changed.read_text(encoding="utf-8")
+        changed.write_text("different authority\n", encoding="utf-8")
+        try:
+            verify_author_source_tree(targets, source_root, hashes_path=hashes)
+        except RMPError as exc:
+            if "author source hash mismatch" not in str(exc):
+                raise AssertionError(
+                    f"changed author source produced the wrong failure: {exc}"
+                ) from exc
+        else:
+            raise AssertionError("changed author source passed identity verification")
+
+        changed.write_text(original, encoding="utf-8")
+        hashes.write_text(
+            hashes.read_text(encoding="utf-8")
+            + f"{'0' * 64}  uncited.tex\n",
+            encoding="utf-8",
+        )
+        try:
+            verify_author_source_tree(targets, source_root, hashes_path=hashes)
+        except RMPError as exc:
+            if "uncited: uncited.tex" not in str(exc):
+                raise AssertionError(
+                    f"uncited hash entry produced the wrong failure: {exc}"
+                ) from exc
+        else:
+            raise AssertionError("uncited author-source hash entry was accepted")
+
+
 def main() -> int:
     test_kernel_capability_owner()
     test_ink_environment_owner()
+    test_rmp_author_source_identity()
     with PROVENANCE.open(encoding="utf-8", newline="") as stream:
         rows = list(csv.reader(stream, dialect="excel-tab"))
 

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 
 import csv
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
 
+import tenkz_rmp
 from tenkz_audit import Audit
 from tenkz_rmp import (
     AUTHOR_SOURCE_HASHES,
     DEFAULT_MANIFEST,
+    DEFAULT_VERDICT,
     RMPError,
     ink_environment_problems,
     load_author_source_hashes,
@@ -195,15 +198,24 @@ def test_rmp_author_source_identity() -> None:
             ),
             encoding="utf-8",
         )
+        snapshot_root = work / "verified-snapshot"
         verified = verify_author_source_tree(
-            targets, source_root, hashes_path=hashes
+            targets,
+            source_root,
+            hashes_path=hashes,
+            snapshot_root=snapshot_root,
         )
         if verified != len(cited):
             raise AssertionError("author-source verifier lost a cited source")
 
         changed = source_root / cited[0]
         original = changed.read_text(encoding="utf-8")
+        snapshotted = snapshot_root / cited[0]
+        if snapshotted.read_text(encoding="utf-8") != original:
+            raise AssertionError("author-source snapshot changed the verified bytes")
         changed.write_text("different authority\n", encoding="utf-8")
+        if snapshotted.read_text(encoding="utf-8") != original:
+            raise AssertionError("author-source snapshot followed the live tree")
         try:
             verify_author_source_tree(targets, source_root, hashes_path=hashes)
         except RMPError as exc:
@@ -231,10 +243,40 @@ def test_rmp_author_source_identity() -> None:
             raise AssertionError("uncited author-source hash entry was accepted")
 
 
+def test_rmp_pairing_identity() -> None:
+    targets = load_manifest(DEFAULT_MANIFEST)
+    with tempfile.TemporaryDirectory(prefix="tenkz-rmp-pairing-") as tmp:
+        stale = Path(tmp) / "verdicts.toml"
+        text = DEFAULT_VERDICT.read_text(encoding="utf-8")
+        stale.write_text(
+            re.sub(
+                r'(?m)^pairing_sha256 = "[0-9a-f]{64}"$',
+                f'pairing_sha256 = "{"0" * 64}"',
+                text,
+                count=1,
+            ),
+            encoding="utf-8",
+        )
+        original = tenkz_rmp.DEFAULT_VERDICT
+        tenkz_rmp.DEFAULT_VERDICT = stale
+        try:
+            tenkz_rmp.load_verdicts(targets)
+        except RMPError as exc:
+            if "stale pairing verdicts" not in str(exc):
+                raise AssertionError(
+                    f"stale pairing digest produced the wrong failure: {exc}"
+                ) from exc
+        else:
+            raise AssertionError("stale pairing digest was accepted")
+        finally:
+            tenkz_rmp.DEFAULT_VERDICT = original
+
+
 def main() -> int:
     test_kernel_capability_owner()
     test_ink_environment_owner()
     test_rmp_author_source_identity()
+    test_rmp_pairing_identity()
     with PROVENANCE.open(encoding="utf-8", newline="") as stream:
         rows = list(csv.reader(stream, dialect="excel-tab"))
 

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -11,9 +11,11 @@ from pathlib import Path
 
 from tenkz_audit import Audit
 from tenkz_rmp import (
+    AUTHOR_SOURCE_HASHES,
     DEFAULT_MANIFEST,
     RMPError,
     ink_environment_problems,
+    load_author_source_hashes,
     load_manifest,
     rendered_ink_environment_families,
     sha256,
@@ -170,6 +172,14 @@ def test_rmp_author_source_identity() -> None:
         },
         key=lambda path: path.as_posix(),
     )
+    committed = sorted(
+        load_author_source_hashes(AUTHOR_SOURCE_HASHES),
+        key=lambda path: path.as_posix(),
+    )
+    if committed != cited:
+        raise AssertionError(
+            "committed author-source hashes disagree with manifest.toml"
+        )
     with tempfile.TemporaryDirectory(prefix="tenkz-rmp-author-source-") as tmp:
         work = Path(tmp)
         source_root = work / "RMP_TIKZ_SOURCE_CODE"

--- a/tests/tenkz/rmp/author-source.sha256
+++ b/tests/tenkz/rmp/author-source.sha256
@@ -1,0 +1,4 @@
+e63cf71601824d8323c8ac190b51741c86c20efbd55e2d8d8ce38486480867a3  ImagesReview Section II/ImagesReview Section II.tex
+406b2cf943e461c56aee8bb8282de3bad3f302df4d9c31f008109cc96e85ba44  ImagesReview Section III/ImagesReview Section III.tex
+78c1d7d461ca5a24a4f91bbdce321d3a18edd8023277028dd0f8dc67130d1b47  ImagesReview Section IV/ImagesReview Section IV.tex
+2051f6e2a4626c64b97c29f0ebe4d15ba23aaa07d93fb2fd12ad3edebc415274  ImagesReview Section V/ImagesReview Section V.tex

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -2,7 +2,8 @@
 # Schema: scripts/tenkz_rmp.py (load_verdicts).  Any status may be
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
-campaign_sha256 = "6ec0e999700749b8b3ff7bd0ff383553683f858a9a896bd3ee53359ca7f12107"
+pairing_sha256 = "b3375317e8dddb4402eda08b0d74e1aaa4789467cf5a84fe4d4bd722ef470e89"
+campaign_sha256 = "8e42628a7e0ff3617541ad85decde74ec5a399f5638682c47c8b19d98d8a808d"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -2,7 +2,7 @@
 # Schema: scripts/tenkz_rmp.py (load_verdicts).  Any status may be
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
-campaign_sha256 = "703bc27eb0c861768ea717df028838dbb9c1a1ade27bfc64be2330cc3c3cbce0"
+campaign_sha256 = "6ec0e999700749b8b3ff7bd0ff383553683f858a9a896bd3ee53359ca7f12107"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"


### PR DESCRIPTION
Closes LionSR/tenkz#116.

## Summary

- document the gitignored `References/RMP_TIKZ_SOURCE_CODE` canonical local home and source provenance
- pin the four `.tex` files cited by the RMP pairing manifest with committed SHA-256 identities
- make `compare --all` reject missing, changed, or uncited author-source authority files before corpus compilation
- include the authority manifest in the campaign digest and cover success/mismatch/uncited-entry behavior

Generated PDFs, logs, auxiliary files, and filesystem metadata are deliberately excluded because comparison extracts evidence directly from the four cited section sources.

## Validation

- `git diff --check`
- `python3 scripts/test_tenkz_corpus_provenance.py`
- `python3 -m py_compile scripts/tenkz_rmp.py scripts/test_tenkz_corpus_provenance.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/tenkz_rmp.py check --id rmp-ii-triangle-network`
- `python3 scripts/tenkz_rmp.py compare --all --source-root /Users/siruilu/Local/agentFormalization/TNLean/References/RMP_TIKZ_SOURCE_CODE` (all 130 targets passed; fresh comparison PDF written)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RMP benchmark provenance and compare behavior: wrong or missing local sources now fail fast, and pairing/campaign digests must be kept in sync when manifest or author-source metadata changes.
> 
> **Overview**
> Pins the four external RMP section `.tex` files with committed SHA-256 identities in `tests/tenkz/rmp/author-source.sha256` and documents the gitignored canonical tree at `References/RMP_TIKZ_SOURCE_CODE/`.
> 
> **`compare --all`** now verifies that tree against the manifest (missing, wrong hash, or uncited/extra hash entries fail) and snapshots the verified bytes before any corpus build, so later edits to the live tree cannot change what gets compiled. The comparison book is built from that snapshot, not the mutable `--source-root`.
> 
> **Verdict ledger** gains `pairing_sha256`, computed from author-source hashes plus per-target pairing fields; `load_verdicts` rejects a stale digest when identities or extraction boundaries drift. The author-source manifest is included in `campaign_sha256`, and provenance tests cover verify/snapshot, hash mismatch, uncited entries, and stale pairing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d3e774c80513748e7fb1abf96dc57a6d5a52b5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->