### PR TITLE
feat(MPS/MPDO): prove sector-chain fiber contraction

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -222,6 +222,7 @@ import TNLean.MPS.MPDO.RepresentativeGroupedMarkedLemmaL
 import TNLean.MPS.MPDO.RetainedClass
 import TNLean.MPS.MPDO.SALArbitraryCut
 import TNLean.MPS.MPDO.SALPhysicalSectorCyclicPositivity
+import TNLean.MPS.MPDO.SectorChainFiberContraction
 import TNLean.MPS.MPDO.SectorCompressionSeparation
 import TNLean.MPS.MPDO.SectorEtaContraction
 import TNLean.MPS.MPDO.SectorEtaOperator

--- a/TNLean/MPS/MPDO/SectorChainFiberContraction.lean
+++ b/TNLean/MPS/MPDO/SectorChainFiberContraction.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.PhysicalSectorChainDecomposition
+
+/-!
+# Contraction of a finite chain fiber
+
+This file records the finite Fubini identity underlying contractions over the
+left--right fibers of a nonempty sector word.
+
+## Reference
+
+* arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1606--1617.
+-/
+
+open scoped BigOperators
+
+namespace MPOTensor.PhysicalSectorFactorization
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+private def piProdEquiv {ι : Type*} (α β : ι → Type*) :
+    ((i : ι) → α i × β i) ≃
+      ((i : ι) → α i) × ((i : ι) → β i) where
+  toFun z := (fun i ↦ (z i).1, fun i ↦ (z i).2)
+  invFun z i := (z.1 i, z.2 i)
+  left_inv z := by
+    funext i
+    rfl
+  right_inv z := rfl
+
+/-- Summing a nearest-neighbor product over all left--right coordinates of a
+nonempty finite chain factors into its left boundary sum, its internal edge
+sums, and its right boundary sum.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617. -/
+theorem sum_pi_prod_eq_mul_prod_mul
+    {m : ℕ}
+    (α β : Fin (m + 1) → Type*)
+    [∀ i, Fintype (α i)] [∀ i, Fintype (β i)]
+    (left : α 0 → ℂ) (right : β (Fin.last m) → ℂ)
+    (edge : (i : Fin m) → β i.castSucc → α i.succ → ℂ) :
+    (∑ z : (i : Fin (m + 1)) → α i × β i,
+        left (z 0).1 *
+          (∏ i : Fin m, edge i (z i.castSucc).2 (z i.succ).1) *
+          right (z (Fin.last m)).2) =
+      (∑ a, left a) *
+        (∏ i : Fin m, ∑ b, ∑ a, edge i b a) *
+        ∑ b, right b := by
+  classical
+  calc
+    _ = ∑ z : ((i : Fin (m + 1)) → α i) ×
+          ((i : Fin (m + 1)) → β i),
+        left (z.1 0) *
+          (∏ i : Fin m, edge i (z.2 i.castSucc) (z.1 i.succ)) *
+          right (z.2 (Fin.last m)) := by
+      apply Fintype.sum_equiv (piProdEquiv α β)
+      intro z
+      rfl
+    _ = _ := by
+      rw [Fintype.sum_prod_type, Finset.sum_comm]
+      have hleft (r : (i : Fin (m + 1)) → β i) :
+          (∑ l : (i : Fin (m + 1)) → α i,
+              left (l 0) *
+                ∏ i : Fin m, edge i (r i.castSucc) (l i.succ)) =
+            (∑ a, left a) *
+              ∏ i : Fin m, ∑ a, edge i (r i.castSucc) a := by
+        let f : (i : Fin (m + 1)) → α i → ℂ :=
+          Fin.cases left fun i a ↦ edge i (r i.castSucc) a
+        calc
+          _ = ∑ l : (i : Fin (m + 1)) → α i, ∏ i, f i (l i) := by
+            apply Finset.sum_congr rfl
+            intro l hl
+            rw [Fin.prod_univ_succ]
+            rfl
+          _ = ∏ i, ∑ a, f i a := by
+            symm
+            simpa only [Fintype.piFinset_univ] using
+              (Finset.prod_univ_sum
+                (fun i : Fin (m + 1) ↦ (Finset.univ : Finset (α i))) f)
+          _ = _ := by
+            rw [Fin.prod_univ_succ]
+            rfl
+      have hright :
+          (∑ r : (i : Fin (m + 1)) → β i,
+              (∏ i : Fin m, ∑ a, edge i (r i.castSucc) a) *
+                right (r (Fin.last m))) =
+            (∏ i : Fin m, ∑ b, ∑ a, edge i b a) *
+              ∑ b, right b := by
+        let f : (i : Fin (m + 1)) → β i → ℂ :=
+          Fin.lastCases right fun i b ↦ ∑ a, edge i b a
+        calc
+          _ = ∑ r : (i : Fin (m + 1)) → β i, ∏ i, f i (r i) := by
+            apply Finset.sum_congr rfl
+            intro r hr
+            rw [Fin.prod_univ_castSucc]
+            simp [f]
+          _ = ∏ i, ∑ b, f i b := by
+            symm
+            simpa only [Fintype.piFinset_univ] using
+              (Finset.prod_univ_sum
+                (fun i : Fin (m + 1) ↦ (Finset.univ : Finset (β i))) f)
+          _ = _ := by
+            rw [Fin.prod_univ_castSucc]
+            simp [f]
+      simp_rw [← Finset.sum_mul, hleft, mul_assoc]
+      rw [← Finset.mul_sum, hright]
+
+/-- Contracting the diagonal neighboring-operator entries along a nonempty
+sector-chain fiber leaves the two boundary sums and the product of the
+internal neighboring-operator traces.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617. -/
+theorem sum_sectorChainFiber_neighboringOperator_diag
+    (F : PhysicalSectorFactorization K)
+    {m : ℕ} (t : Fin (m + 1) → Fin F.sectorCount)
+    (left : Fin (F.leftDim (t 0)) → ℂ)
+    (right : Fin (F.rightDim (t (Fin.last m))) → ℂ) :
+    (∑ z : F.SectorChainFiber t,
+        left (z 0).1 *
+          (∏ i : Fin m,
+            F.neighboringOperator (t i.castSucc) (t i.succ)
+              ((z i.castSucc).2, (z i.succ).1)
+              ((z i.castSucc).2, (z i.succ).1)) *
+          right (z (Fin.last m)).2) =
+      (∑ a, left a) *
+        (∏ i : Fin m,
+          (F.neighboringOperator (t i.castSucc) (t i.succ)).trace) *
+        ∑ b, right b := by
+  simpa only [SectorChainFiber, Matrix.trace, Matrix.diag_apply,
+    Fintype.sum_prod_type] using
+    (sum_pi_prod_eq_mul_prod_mul
+      (fun i ↦ Fin (F.leftDim (t i)))
+      (fun i ↦ Fin (F.rightDim (t i)))
+      left right
+      (fun i b a ↦
+        F.neighboringOperator (t i.castSucc) (t i.succ) (b, a) (b, a)))
+
+end MPOTensor.PhysicalSectorFactorization

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
@@ -197,6 +197,55 @@
     $\Gamma_k^{(1)}$, $\Gamma_k^{(2)}$, and $\Gamma_k^{(3)}$.
 \end{definition}
 
+\begin{theorem}[Contraction of a sector-chain fiber]
+    \label{thm:mpdo_sector_chain_fiber_contraction}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      sum_sectorChainFiber_neighboringOperator_diag}
+    \leanok
+    \uses{def:mpdo_physical_sector_chain_coordinates}
+    Let $t=(t_0,\ldots,t_m)$ be a nonempty sector word. For functions
+    $a$ on the left coordinate of $t_0$ and $b$ on the right coordinate of
+    $t_m$,
+    \begin{align}
+      &\sum_{z\in I_t}
+        a(z_0^{\mathrm L})
+        \prod_{i=0}^{m-1}
+          \eta_{t_i,t_{i+1}}
+          \bigl((z_i^{\mathrm R},z_{i+1}^{\mathrm L}),
+                (z_i^{\mathrm R},z_{i+1}^{\mathrm L})\bigr)
+        b(z_m^{\mathrm R})
+        \notag\\
+      &\qquad=
+        \left(\sum_u a(u)\right)
+        \left(\prod_{i=0}^{m-1}\tr(\eta_{t_i,t_{i+1}})\right)
+        \left(\sum_v b(v)\right).
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Write $z_i=(\ell_i,r_i)$. Finite distributivity separates the left and
+    right coordinates:
+    \begin{align}
+      &\sum_{\ell,r}
+        a(\ell_0)
+        \prod_{i=0}^{m-1}
+          \eta_{t_i,t_{i+1}}
+          \bigl((r_i,\ell_{i+1}),(r_i,\ell_{i+1})\bigr)
+        b(r_m)
+        \notag\\
+      &\qquad=
+        \left(\sum_{\ell_0}a(\ell_0)\right)
+        \prod_{i=0}^{m-1}
+          \left(\sum_{r_i,\ell_{i+1}}
+            \eta_{t_i,t_{i+1}}
+            \bigl((r_i,\ell_{i+1}),(r_i,\ell_{i+1})\bigr)\right)
+        \left(\sum_{r_m}b(r_m)\right).
+    \end{align}
+    The internal double sum is
+    $\tr(\eta_{t_i,t_{i+1}})$ for each $i$, which gives the asserted
+    factorization.
+\end{proof}
+
 % Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 % 1606--1617.
 % **Local fix (adjacent marginal comparison):** the cases R=1 and R=2 give


### PR DESCRIPTION
## Summary

- prove a finite Fubini identity for nearest-neighbor products over dependent left-right coordinate families
- specialize it to arbitrary nonempty `SectorChainFiber` words, factoring the contraction into two boundary sums and the product of internal neighboring-operator traces
- add the generated MPDO import and a source-facing blueprint lemma

## Mathematical source

This isolates the common contraction step behind CPSV16 Appendix C.2, Proposition `4to2`, lines 1606–1617 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

It is a prerequisite for #5129: the one-suffix and two-suffix coefficient formulas can now be short specializations of one arbitrary-length theorem instead of separate dependent-index proofs.

## Validation

- `lake exe cache get` before Lean in the fresh worktree
- `lake build TNLean` — 9,826 jobs
- rebased-head `lake build TNLean.MPS.MPDO.SectorChainFiberContraction TNLean.MPS.MPDO`
- `lake exe checkdecls blueprint/lean_decls`
- blueprint/Lean sync and reader-facing prose checks
- generated import aggregator check
- tactic-pattern and proof-integrity scans
- `git diff --check`

The only full-build warnings were pre-existing: two unused-variable warnings and the known `SectorMatch.lean` `sorry`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style combinatorics on existing `PhysicalSectorFactorization` definitions; no auth, runtime, or API surface beyond a new formal theorem and blueprint sync.
> 
> **Overview**
> Adds a **general finite Fubini identity** (`sum_pi_prod_eq_mul_prod_mul`) for nearest-neighbor products over dependent left/right coordinate families on a chain, then specializes it to **`sum_sectorChainFiber_neighboringOperator_diag`**: summing diagonal neighboring-operator entries over an arbitrary nonempty `SectorChainFiber` factors into boundary sums on the first left and last right coordinates times the product of internal **traces** of `neighboringOperator`.
> 
> The new module `SectorChainFiberContraction.lean` is wired into the generated `TNLean.MPS.MPDO` import list. The blueprint chapter gains **Theorem** `thm:mpdo_sector_chain_fiber_contraction` (`\leanok`) with a short distributivity proof, aligned with CPSV16 Appendix C.2 Proposition `4to2` (lines 1606–1617).
> 
> This is positioned as a reusable contraction step so one- and two-suffix coefficient arguments can later be special cases rather than separate dependent-index proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed68df8ce89d6ffa45244eb73f7c59b11f4c525e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->