### PR TITLE
feat(MPS/MPDO): prove selected Markov cuts

### DIFF
--- a/TNLean/MPS/MPDO/CyclicActiveAdjacentCoefficientExtraction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveAdjacentCoefficientExtraction.lean
@@ -784,6 +784,146 @@ namespace MPOTensor.EtaLocalStructureData
 
 variable {d D : ℕ} {K : MPOTensor d D}
 
+/-- At every realized chain length, the selected fixed-product tensor and
+the source tensor in the selected physical coordinates have the same
+normalized reduced states.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1597--1613. -/
+theorem selectedFixedProduct_reducedBlockState_eq_changePhysicalBasis
+    (data : EtaLocalStructureData K)
+    (N L : ℕ) (hN : 2 ≤ N) (hL : L ≤ N) :
+    let F :=
+      data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+    F.sectorCoordinateTensor.reducedBlockState N L hL =
+      (PhysicalSectorFactorization.changePhysicalBasis
+        F.physicalCoordinateMatrix K).reducedBlockState N L hL := by
+  let F :=
+    data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+  let M :=
+    PhysicalSectorFactorization.changePhysicalBasis
+      F.physicalCoordinateMatrix K
+  obtain ⟨c, hc, hclosed⟩ :=
+    data.exists_positive_scalar_mpo_changePhysicalBasis_eq_smul_selected N hN
+  exact (PhysicalSectorFactorization.reducedBlockState_eq_of_mpo_eq_smul
+    M F.sectorCoordinateTensor N L hL (c : ℂ)
+    (Complex.ofReal_ne_zero.mpr (ne_of_gt hc)) hclosed).symm
+
+private theorem selectedFixedProduct_reducedBlockState_eq_of_source_eq
+    (data : EtaLocalStructureData K)
+    (N₁ N₂ L : ℕ) (hN₁ : 2 ≤ N₁) (hN₂ : 2 ≤ N₂)
+    (hL₁ : L ≤ N₁) (hL₂ : L ≤ N₂)
+    (hsource :
+      K.reducedBlockState N₁ L hL₁ =
+        K.reducedBlockState N₂ L hL₂) :
+    let F :=
+      data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+    F.sectorCoordinateTensor.reducedBlockState N₁ L hL₁ =
+      F.sectorCoordinateTensor.reducedBlockState N₂ L hL₂ := by
+  let F :=
+    data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+  let U := F.physicalCoordinateMatrix
+  let M := PhysicalSectorFactorization.changePhysicalBasis U K
+  calc
+    F.sectorCoordinateTensor.reducedBlockState N₁ L hL₁ =
+        M.reducedBlockState N₁ L hL₁ :=
+      data.selectedFixedProduct_reducedBlockState_eq_changePhysicalBasis
+        N₁ L hN₁ hL₁
+    _ = singleKrausMap (sitewisePhysicalMatrix U L)
+        (K.reducedBlockState N₁ L hL₁) :=
+      reducedBlockState_changePhysicalBasis_of_isometry
+        U F.physicalCoordinateMatrix_isometry K N₁ L hL₁
+    _ = singleKrausMap (sitewisePhysicalMatrix U L)
+        (K.reducedBlockState N₂ L hL₂) := by rw [hsource]
+    _ = M.reducedBlockState N₂ L hL₂ := by
+      symm
+      exact reducedBlockState_changePhysicalBasis_of_isometry
+        U F.physicalCoordinateMatrix_isometry K N₂ L hL₂
+    _ = F.sectorCoordinateTensor.reducedBlockState N₂ L hL₂ :=
+      (data.selectedFixedProduct_reducedBlockState_eq_changePhysicalBasis
+        N₂ L hN₂ hL₂).symm
+
+/-- Source zero correlation length transports adjacent normalized marginal
+stability to the selected fixed-product tensor in its physical-sector
+coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1603--1613. -/
+theorem selectedFixedProduct_reducedBlockState_succ_succ_eq_succ_of_isSourceZCL
+    (data : EtaLocalStructureData K) (hZCL : K.IsSourceZCL)
+    (L : ℕ) (hL : 0 < L) :
+    let F :=
+      data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+    F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega) =
+      F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) := by
+  apply data.selectedFixedProduct_reducedBlockState_eq_of_source_eq
+      (hN₁ := by omega) (hN₂ := by omega)
+  exact K.reducedBlockState_succ_succ_eq_succ_of_isSourceZCL hZCL L
+
+/-- Source zero correlation length transports the three-suffix/one-suffix
+normalized marginal identity to the selected fixed-product tensor.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1613.
+
+**Local fix (cyclic-active restriction):** This is the additional marginal
+replacement used to expose the two-step cyclic-active coefficient. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem selectedFixedProduct_reducedBlockState_add_three_eq_succ_of_isSourceZCL
+    (data : EtaLocalStructureData K) (hZCL : K.IsSourceZCL)
+    (L : ℕ) (hL : 0 < L) :
+    let F :=
+      data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+    F.sectorCoordinateTensor.reducedBlockState (L + 3) L (by omega) =
+      F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) := by
+  apply data.selectedFixedProduct_reducedBlockState_eq_of_source_eq
+      (hN₁ := by omega) (hN₂ := by omega)
+  exact K.reducedBlockState_add_three_eq_succ_of_isSourceZCL hZCL L
+
+/-- Every selected fixed-product periodic operator of length at least two has
+a strictly positive real trace under source zero correlation length.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1597--1613. -/
+theorem exists_pos_trace_mpo_selectedFixedProduct_of_isSourceZCL
+    (data : EtaLocalStructureData K) (hZCL : K.IsSourceZCL)
+    (N : ℕ) (hN : 2 ≤ N) :
+    let F :=
+      data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+    ∃ z : ℝ, 0 < z ∧
+      Matrix.trace (mpo F.sectorCoordinateTensor N) = (z : ℂ) := by
+  let F :=
+    data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+  let U := F.physicalCoordinateMatrix
+  let M := PhysicalSectorFactorization.changePhysicalBasis U K
+  letI : NeZero N := ⟨by omega⟩
+  have hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef :=
+    data.bondData.fixedProductTensorDataPhysicalSectorFactorization_neighboring_pos
+  obtain ⟨c, _, hclosed⟩ :=
+    data.exists_positive_scalar_mpo_changePhysicalBasis_eq_smul_selected N hN
+  have hsourceTraceNe : Matrix.trace (mpo K N) ≠ 0 :=
+    trace_mpo_ne_zero_of_isSourceZCL K hZCL (by omega)
+  have hchangeTraceNe : Matrix.trace (mpo M N) ≠ 0 := by
+    rw [trace_mpo_changePhysicalBasis_of_isometry
+      U F.physicalCoordinateMatrix_isometry K N]
+    exact hsourceTraceNe
+  have hclosedTrace := congrArg Matrix.trace hclosed
+  rw [Matrix.trace_smul] at hclosedTrace
+  have hselectedTraceNe :
+      Matrix.trace (mpo F.sectorCoordinateTensor N) ≠ 0 := by
+    intro hzero
+    apply hchangeTraceNe
+    rw [hclosedTrace, hzero, smul_eq_mul, mul_zero]
+  have hselectedPos :
+      0 < Matrix.trace (mpo F.sectorCoordinateTensor N) :=
+    (F.mpo_sectorCoordinateTensor_posSemidef hpos).trace_pos_of_ne_zero
+      (fun hzero ↦ hselectedTraceNe (by rw [hzero, Matrix.trace_zero]))
+  obtain ⟨hre, him⟩ := Complex.pos_iff.mp hselectedPos
+  refine ⟨(Matrix.trace (mpo F.sectorCoordinateTensor N)).re, hre, ?_⟩
+  apply Complex.ext
+  · rfl
+  · simpa using him.symm
+
 /-- For the selected fixed-product realization of an eta-local source-ZCL
 tensor, the cyclic-active trace matrix admits a positive normalization whose
 square equals its cube.
@@ -808,8 +948,6 @@ theorem exists_normalized_selectedFixedProduct_cyclicActiveSectorTraceMatrix_pow
   classical
   let F :=
     data.bondData.fixedProductTensorDataPhysicalSectorFactorization
-  let U := F.physicalCoordinateMatrix
-  let M := PhysicalSectorFactorization.changePhysicalBasis U K
   have hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef :=
     data.bondData.fixedProductTensorDataPhysicalSectorFactorization_neighboring_pos
   have hreach : ∀ q h : F.CyclicActiveSector,
@@ -822,63 +960,12 @@ theorem exists_normalized_selectedFixedProduct_cyclicActiveSectorTraceMatrix_pow
       F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega) =
         F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) := by
     intro L hL
-    obtain ⟨c₂, hc₂, hclosed₂⟩ :=
-      data.exists_positive_scalar_mpo_changePhysicalBasis_eq_smul_selected
-        (L + 2) (by omega)
-    obtain ⟨c₁, hc₁, hclosed₁⟩ :=
-      data.exists_positive_scalar_mpo_changePhysicalBasis_eq_smul_selected
-        (L + 1) (by omega)
-    calc
-      F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega) =
-          M.reducedBlockState (L + 2) L (by omega) :=
-        (PhysicalSectorFactorization.reducedBlockState_eq_of_mpo_eq_smul
-          M F.sectorCoordinateTensor
-          (L + 2) L (by omega) (c₂ : ℂ)
-          (Complex.ofReal_ne_zero.mpr (ne_of_gt hc₂)) hclosed₂).symm
-      _ = singleKrausMap (sitewisePhysicalMatrix U L)
-          (K.reducedBlockState (L + 2) L (by omega)) := by
-        exact reducedBlockState_changePhysicalBasis_of_isometry
-          U F.physicalCoordinateMatrix_isometry K (L + 2) L (by omega)
-      _ = singleKrausMap (sitewisePhysicalMatrix U L)
-          (K.reducedBlockState (L + 1) L (by omega)) := by
-        rw [K.reducedBlockState_succ_succ_eq_succ_of_isSourceZCL hZCL L]
-      _ = M.reducedBlockState (L + 1) L (by omega) := by
-        symm
-        exact reducedBlockState_changePhysicalBasis_of_isometry
-          U F.physicalCoordinateMatrix_isometry K (L + 1) L (by omega)
-      _ = F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) :=
-        PhysicalSectorFactorization.reducedBlockState_eq_of_mpo_eq_smul
-          M F.sectorCoordinateTensor
-          (L + 1) L (by omega) (c₁ : ℂ)
-          (Complex.ofReal_ne_zero.mpr (ne_of_gt hc₁)) hclosed₁
+    exact data.selectedFixedProduct_reducedBlockState_succ_succ_eq_succ_of_isSourceZCL
+      hZCL L hL
   have htrace : ∀ N, 2 ≤ N → ∃ z : ℝ, 0 < z ∧
       Matrix.trace (mpo F.sectorCoordinateTensor N) = (z : ℂ) := by
     intro N hN
-    letI : NeZero N := ⟨by omega⟩
-    obtain ⟨c, hc, hclosed⟩ :=
-      data.exists_positive_scalar_mpo_changePhysicalBasis_eq_smul_selected N hN
-    have hsourceTraceNe : Matrix.trace (mpo K N) ≠ 0 :=
-      trace_mpo_ne_zero_of_isSourceZCL K hZCL (by omega)
-    have hchangeTraceNe : Matrix.trace (mpo M N) ≠ 0 := by
-      rw [trace_mpo_changePhysicalBasis_of_isometry
-        U F.physicalCoordinateMatrix_isometry K N]
-      exact hsourceTraceNe
-    have hclosedTrace := congrArg Matrix.trace hclosed
-    rw [Matrix.trace_smul] at hclosedTrace
-    have hselectedTraceNe :
-        Matrix.trace (mpo F.sectorCoordinateTensor N) ≠ 0 := by
-      intro hzero
-      apply hchangeTraceNe
-      rw [hclosedTrace, hzero, smul_eq_mul, mul_zero]
-    have hselectedPos :
-        0 < Matrix.trace (mpo F.sectorCoordinateTensor N) :=
-      (F.mpo_sectorCoordinateTensor_posSemidef hpos).trace_pos_of_ne_zero
-        (fun hzero ↦ hselectedTraceNe (by rw [hzero, Matrix.trace_zero]))
-    obtain ⟨hre, him⟩ := Complex.pos_iff.mp hselectedPos
-    refine ⟨(Matrix.trace (mpo F.sectorCoordinateTensor N)).re, hre, ?_⟩
-    apply Complex.ext
-    · simp
-    · simpa using him.symm
+    exact data.exists_pos_trace_mpo_selectedFixedProduct_of_isSourceZCL hZCL N hN
   exact F.exists_normalized_cyclicActiveSectorTraceMatrix_pow_two_eq_pow_three_of_adjacent_marginals
     hpos hreach hmarg htrace
 

--- a/TNLean/MPS/MPDO/CyclicActiveMarkovDecomposition.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkovDecomposition.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.CyclicActiveCutRegrouping
+import TNLean.MPS.MPDO.CyclicActiveAdjacentCoefficientExtraction
 
 /-!
 # Hayashi decomposition in cyclic-active coordinates
@@ -102,9 +103,11 @@ See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 private theorem reindex_reducedBlockState_eq_cyclicActiveCut
     (F : PhysicalSectorFactorization K) [NeZero D]
     (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
-    (hZCL : K.IsSourceZCL) (A C : ℕ) (lam : ℝ)
+    (A C : ℕ) (lam : ℝ)
     (a b : F.CyclicActiveSector → ℝ)
     (ha : ∀ q, 0 < a q) (hb : ∀ h, 0 < b h)
+    (htC : 0 < Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)))
     (hfour :
       Matrix.reindex (F.retainedOpenEdgeChainEquiv (A + C))
           (F.retainedOpenEdgeChainEquiv (A + C))
@@ -134,9 +137,6 @@ private theorem reindex_reducedBlockState_eq_cyclicActiveCut
   let ρL := F.cyclicActiveLeftCutState A lam b
   let ρR := F.cyclicActiveRightCutState C a
   let t := F.cyclicActiveCutNormalization A C
-  have htC : 0 < Matrix.trace
-      (mpo F.sectorCoordinateTensor (A + C + 4)) :=
-    F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL hpos hZCL (by omega)
   have htEq : Matrix.trace (mpo F.sectorCoordinateTensor (A + C + 4)) =
       (t : ℂ) := by
     apply Complex.ext
@@ -282,14 +282,13 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 private theorem cyclicActiveCutProbability_nonneg
     (F : PhysicalSectorFactorization K) [NeZero D]
     (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
-    (hZCL : K.IsSourceZCL) (A C : ℕ) (lam : ℝ)
+    (A C : ℕ) (lam : ℝ)
     (a b : F.CyclicActiveSector → ℝ)
     (ha : ∀ q, 0 < a q) (hb : ∀ h, 0 < b h)
+    (htC : 0 < Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)))
     (j : Fin F.sectorCount) :
     0 ≤ F.cyclicActiveCutProbability A C lam a b j := by
-  have htC : 0 < Matrix.trace
-      (mpo F.sectorCoordinateTensor (A + C + 4)) :=
-    F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL hpos hZCL (by omega)
   have ht : 0 < F.cyclicActiveCutNormalization A C := by
     simpa [cyclicActiveCutNormalization] using (Complex.lt_def.mp htC).1
   have hL := F.cyclicActiveLeftCutRaw_posSemidef
@@ -312,9 +311,11 @@ the fourth-region marginal before the final restriction.  See
 private theorem sum_cyclicActiveCutProbability_eq_one
     (F : PhysicalSectorFactorization K) [NeZero D]
     (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
-    (hZCL : K.IsSourceZCL) (A C : ℕ) (lam : ℝ)
+    (A C : ℕ) (lam : ℝ)
     (a b : F.CyclicActiveSector → ℝ)
     (ha : ∀ q, 0 < a q) (hb : ∀ h, 0 < b h)
+    (htraceShort : Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 2)) ≠ 0)
     (hnormalized :
       Matrix.reindex (F.cyclicActiveHayashiCutEquiv A C)
           (F.cyclicActiveHayashiCutEquiv A C)
@@ -326,11 +327,6 @@ private theorem sum_cyclicActiveCutProbability_eq_one
               F.cyclicActiveRightCutState C a j))) :
     ∑ j : Fin F.sectorCount,
       F.cyclicActiveCutProbability A C lam a b j = 1 := by
-  have htraceShort : Matrix.trace
-      (mpo F.sectorCoordinateTensor (A + C + 2)) ≠ 0 := by
-    have hposShort := F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL
-      hpos hZCL (N := A + C + 2) (by omega)
-    exact ne_of_gt hposShort
   have hstateTrace : Matrix.trace
       (F.sectorCoordinateTensor.reducedBlockState
         (A + C + 2) (A + 1 + C) (by omega)) = 1 :=
@@ -412,6 +408,70 @@ private theorem cyclicActiveCut_transported_state_eq
   rw [hx, hy] at hxy
   simpa [HayashiMarkov.blockState, HayashiMarkov.abcEquiv] using hxy
 
+/-- Assemble a Hayashi decomposition from an explicit positive factorization
+of the normalized two-step cyclic-active coefficient and the corresponding
+fourth-region formula.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1606--1617.
+
+**Local fix (cyclic-active restriction):** The separating coefficient is the
+square of the trace matrix restricted to positive-length cyclic sectors,
+after one additional marginal replacement. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem exists_hayashiMarkovDecomposition_cyclicActiveCut_of_fourthRegion
+    (F : PhysicalSectorFactorization K) [NeZero D]
+    (hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef)
+    (A C : ℕ) (lam : ℝ)
+    (a b : F.CyclicActiveSector → ℝ)
+    (ha : ∀ q, 0 < a q) (hb : ∀ h, 0 < b h)
+    (htC : 0 < Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)))
+    (htraceShort : Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 2)) ≠ 0)
+    (hfour :
+      Matrix.reindex (F.retainedOpenEdgeChainEquiv (A + C))
+          (F.retainedOpenEdgeChainEquiv (A + C))
+          (F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + C + 1) (by omega)) =
+        ((Matrix.trace
+          (mpo F.sectorCoordinateTensor (A + C + 4)))⁻¹ : ℂ) •
+          Matrix.blockDiagonal' (fun k ↦
+            F.cyclicActiveFourthRegionBlock lam a b k)) :
+    let ρ_ABC :=
+      (F.sectorCoordinateTensor.reducedBlockState
+        (A + C + 2) (A + 1 + C) (by omega)).submatrix
+          (tripartiteSplitEquiv
+            (Fintype.card F.SectorSiteIndex) A 1 C).symm
+          (tripartiteSplitEquiv
+            (Fintype.card F.SectorSiteIndex) A 1 C).symm
+    Nonempty (HayashiMarkovDecomposition ρ_ABC) := by
+  classical
+  dsimp only
+  have hnormalized :=
+    F.reindex_reducedBlockState_eq_cyclicActiveCut
+      hpos A C lam a b ha hb htC hfour
+  have hp_sum :=
+    F.sum_cyclicActiveCutProbability_eq_one
+      hpos A C lam a b ha hb htraceShort hnormalized
+  refine ⟨{
+    m := F.sectorCount
+    dL := F.leftDim
+    dR := F.rightDim
+    decompB := F.sectorCoordinateMiddleEquiv
+    U_B := 1
+    p := F.cyclicActiveCutProbability A C lam a b
+    hp_nonneg := F.cyclicActiveCutProbability_nonneg
+      hpos A C lam a b ha hb htC
+    hp_sum := hp_sum
+    ρ_left := F.cyclicActiveLeftCutState A lam b
+    ρ_right := F.cyclicActiveRightCutState C a
+    hρ_left_dm := F.cyclicActiveLeftCutState_isDensity hpos A lam b hb
+    hρ_right_dm := F.cyclicActiveRightCutState_isDensity hpos C a ha
+    h_state := ?_ }⟩
+  simpa [HayashiMarkov.liftB] using
+    F.cyclicActiveCut_transported_state_eq A C lam a b hnormalized
+
 /-- Source zero correlation length gives an explicit quantum-Markov
 decomposition at every one-site cut of the fourth-region marginal.
 
@@ -440,28 +500,157 @@ theorem exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL
   obtain ⟨lam, _, a, b, ha, hb, _, hfour⟩ :=
     F.exists_cyclicActiveFourthRegion_formula_of_isSourceZCL
       hK hpos hZCL (A + C)
-  have hnormalized :=
-    F.reindex_reducedBlockState_eq_cyclicActiveCut
-      hpos hZCL A C lam a b ha hb hfour
-  have hp_sum :=
-    F.sum_cyclicActiveCutProbability_eq_one
-      hpos hZCL A C lam a b ha hb hnormalized
-  refine ⟨{
-    m := F.sectorCount
-    dL := F.leftDim
-    dR := F.rightDim
-    decompB := F.sectorCoordinateMiddleEquiv
-    U_B := 1
-    p := F.cyclicActiveCutProbability A C lam a b
-    hp_nonneg := F.cyclicActiveCutProbability_nonneg
-      hpos hZCL A C lam a b ha hb
-    hp_sum := hp_sum
-    ρ_left := F.cyclicActiveLeftCutState A lam b
-    ρ_right := F.cyclicActiveRightCutState C a
-    hρ_left_dm := F.cyclicActiveLeftCutState_isDensity hpos A lam b hb
-    hρ_right_dm := F.cyclicActiveRightCutState_isDensity hpos C a ha
-    h_state := ?_ }⟩
-  simpa [HayashiMarkov.liftB] using
-    F.cyclicActiveCut_transported_state_eq A C lam a b hnormalized
+  have htC : 0 < Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)) :=
+    F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL hpos hZCL (by omega)
+  have htraceShort : Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 2)) ≠ 0 :=
+    ne_of_gt (F.trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL
+      hpos hZCL (by omega))
+  exact F.exists_hayashiMarkovDecomposition_cyclicActiveCut_of_fourthRegion
+    hpos A C lam a b ha hb htC htraceShort hfour
 
 end MPOTensor.PhysicalSectorFactorization
+
+namespace MPOTensor.EtaLocalStructureData
+
+variable {d D : ℕ} {K : MPOTensor d D}
+
+/-- The fixed positive-bond representative selected from an injective normal
+source with zero correlation length yields a Hayashi decomposition at every
+one-site cut of the source tensor in the selected physical coordinates.
+
+Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
+1597--1619.
+
+**Local fix (cyclic-active restriction):** The proof factors the normalized
+square of the trace matrix on positive-length cyclic sectors after one
+additional marginal replacement. It assumes no injectivity, normality, or
+zero-correlation-length property of the selected fixed-product tensor. See
+`docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
+theorem exists_hayashiMarkovDecomposition_selectedPhysicalCut_of_isSourceZCL
+    (hMPDO : IsMPDO K) (hK : K.IsInjective)
+    (hNormal : MPSTensor.IsNormalTensor K.toMPSTensor)
+    (data : EtaLocalStructureData K) (hZCL : K.IsSourceZCL)
+    (A C : ℕ) :
+    let F :=
+      data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+    let M :=
+      PhysicalSectorFactorization.changePhysicalBasis
+        F.physicalCoordinateMatrix K
+    let ρ_ABC :=
+      (M.reducedBlockState
+        (A + C + 2) (A + 1 + C) (by omega)).submatrix
+          (tripartiteSplitEquiv
+            (Fintype.card F.SectorSiteIndex) A 1 C).symm
+          (tripartiteSplitEquiv
+            (Fintype.card F.SectorSiteIndex) A 1 C).symm
+    Nonempty (HayashiMarkovDecomposition ρ_ABC) := by
+  classical
+  let F :=
+    data.bondData.fixedProductTensorDataPhysicalSectorFactorization
+  let U := F.physicalCoordinateMatrix
+  let M := PhysicalSectorFactorization.changePhysicalBasis U K
+  have hpos : ∀ q h, (F.neighboringOperator q h).PosSemidef :=
+    data.bondData.fixedProductTensorDataPhysicalSectorFactorization_neighboring_pos
+  have hreach : ∀ q h : F.CyclicActiveSector,
+      Relation.ReflTransGen
+        (fun a b : F.CyclicActiveSector ↦ F.neighboringOperator a b ≠ 0) q h := by
+    intro q h
+    exact data.selectedFixedProduct_cyclicActive_reflTransGen_neighboringOperator_ne_zero
+      hMPDO hK hNormal hZCL q h
+  have hmarg : ∀ L, 0 < L →
+      F.sectorCoordinateTensor.reducedBlockState (L + 2) L (by omega) =
+        F.sectorCoordinateTensor.reducedBlockState (L + 1) L (by omega) := by
+    intro L hL
+    exact data.selectedFixedProduct_reducedBlockState_succ_succ_eq_succ_of_isSourceZCL
+      hZCL L hL
+  have htrace : ∀ N, 2 ≤ N → ∃ z : ℝ, 0 < z ∧
+      Matrix.trace (mpo F.sectorCoordinateTensor N) = (z : ℂ) := by
+    intro N hN
+    exact data.exists_pos_trace_mpo_selectedFixedProduct_of_isSourceZCL hZCL N hN
+  obtain ⟨lam, hlam, hpow⟩ :=
+    data.exists_normalized_selectedFixedProduct_cyclicActiveSectorTraceMatrix_pow_two_eq_pow_three
+      hMPDO hK hNormal hZCL
+  have hTtwo : ∀ q h, 0 < (F.cyclicActiveSectorTraceMatrix ^ 2) q h :=
+    F.cyclicActiveSectorTraceMatrix_pow_two_pos_of_adjacent_marginals
+      hpos hreach hmarg htrace
+  letI : NeZero D := ⟨hNormal.bondDim_ne_zero⟩
+  letI : Nonempty F.CyclicActiveSector := by
+    obtain ⟨c₂, _, h₂⟩ :=
+      data.exists_positive_scalar_mpo_changePhysicalBasis_eq_smul_selected 2 (by omega)
+    have hspan :=
+      F.cyclicActiveOriginalOneSiteMatrixFamily_span_eq_top hK (c₂ : ℂ) h₂
+    cases isEmpty_or_nonempty F.CyclicActiveSector with
+    | inr hnonempty => exact hnonempty
+    | inl hempty =>
+        letI : IsEmpty F.CyclicActiveSector := hempty
+        have hbot :
+            Submodule.span ℂ
+                (Set.range (F.cyclicActiveOriginalOneSiteMatrixFamily K)) =
+              (⊥ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
+          rw [Set.range_eq_empty, Submodule.span_empty]
+        have htopbot :
+            (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) = ⊥ := by
+          rw [← hspan, hbot]
+        have hone :
+            (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+              (⊥ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
+          rw [← htopbot]
+          exact Submodule.mem_top
+        simp at hone
+  have hprimitive :
+      Matrix.IsPrimitive (lam⁻¹ • F.cyclicActiveSectorTraceMatrix) := by
+    refine ⟨?_, 2, by omega, ?_⟩
+    · intro q h
+      rw [Matrix.smul_apply]
+      exact mul_nonneg (inv_nonneg.mpr hlam.le)
+        (F.activeSectorTraceMatrix_nonneg F.cyclicActiveWeight hpos q h)
+    · intro q h
+      rw [smul_pow, Matrix.smul_apply]
+      exact mul_pos (pow_pos (inv_pos.mpr hlam) 2) (hTtwo q h)
+  obtain ⟨a, b, ha, hb, hab, _⟩ :=
+    hprimitive.exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three hpow
+  have hthree :=
+    F.reindex_reducedBlockState_add_three_eq_cyclicActiveFourthRegionBlock
+      (A + C) hpos lam hlam a b hab
+  have hmargThree :=
+    data.selectedFixedProduct_reducedBlockState_add_three_eq_succ_of_isSourceZCL
+      hZCL (A + C + 1) (by omega)
+  have hfour :
+      Matrix.reindex (F.retainedOpenEdgeChainEquiv (A + C))
+          (F.retainedOpenEdgeChainEquiv (A + C))
+          (F.sectorCoordinateTensor.reducedBlockState
+            (A + C + 2) (A + C + 1) (by omega)) =
+        ((Matrix.trace
+          (mpo F.sectorCoordinateTensor (A + C + 4)))⁻¹ : ℂ) •
+          Matrix.blockDiagonal' (fun k ↦
+            F.cyclicActiveFourthRegionBlock lam a b k) := by
+    rw [← hmargThree]
+    exact hthree
+  obtain ⟨zLong, hzLong, htraceLong⟩ := htrace (A + C + 4) (by omega)
+  obtain ⟨zShort, hzShort, htraceShort⟩ := htrace (A + C + 2) (by omega)
+  have htC : 0 < Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 4)) := by
+    rw [htraceLong]
+    exact_mod_cast hzLong
+  have htShort : Matrix.trace
+      (mpo F.sectorCoordinateTensor (A + C + 2)) ≠ 0 := by
+    rw [htraceShort]
+    exact Complex.ofReal_ne_zero.mpr (ne_of_gt hzShort)
+  have hselectedMarkov :=
+    letI : NeZero data.bondData.fixedProductTensorData.bondDim :=
+      ⟨Nat.ne_of_gt data.bondData.fixedProductTensorData.bondDim_pos⟩
+    F.exists_hayashiMarkovDecomposition_cyclicActiveCut_of_fourthRegion
+      hpos A C lam a b ha hb htC htShort hfour
+  have hstate :
+      M.reducedBlockState (A + C + 2) (A + 1 + C) (by omega) =
+        F.sectorCoordinateTensor.reducedBlockState
+          (A + C + 2) (A + 1 + C) (by omega) :=
+    (data.selectedFixedProduct_reducedBlockState_eq_changePhysicalBasis
+      (A + C + 2) (A + 1 + C) (by omega) (by omega)).symm
+  dsimp only
+  rw [hstate]
+  exact hselectedMarkov
+
+end MPOTensor.EtaLocalStructureData

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_cyclic_active_markov.tex
@@ -600,6 +600,91 @@
     vanish. This contradicts the one-sided matrix-space obstruction.
 \end{proof}
 
+\begin{theorem}[Selected fixed-product reduced states]
+    \label{thm:mpdo_selected_fixed_product_reduced_states}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      selectedFixedProduct_reducedBlockState_eq_changePhysicalBasis}
+    \leanok
+    \uses{def:mpdo_eta_local_structure_data,
+      thm:mpdo_fixed_bond_positive_physical_sector_representative}
+    Let $K$ have an eta-local structure, let $F$ be the positive
+    physical-sector factorization of its selected fixed-product tensor, and
+    express $K$ in the physical coordinates of $F$. For every $N\geq2$ and
+    $L\leq N$, the selected sector-coordinate tensor and the transformed
+    source tensor have the same normalized $L$-site reduced state.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_finite_chain_normalized_proportionality}
+    At length $N$, the unnormalized periodic operators satisfy
+    \[
+      \rho^{(N)}(K_F)=c_N\,\rho^{(N)}(C_F),
+      \qquad c_N>0.
+    \]
+    The scalar cancels under trace normalization, and taking the prescribed
+    partial trace preserves the equality.
+\end{proof}
+
+\begin{theorem}[Adjacent selected fixed-product marginals]
+    \label{thm:mpdo_selected_fixed_product_adjacent_marginals}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      selectedFixedProduct_reducedBlockState_succ_succ_eq_succ_of_isSourceZCL}
+    \leanok
+    \uses{def:mpo_source_zcl, def:mpdo_eta_local_structure_data,
+      thm:mpdo_selected_fixed_product_reduced_states}
+    Let $K$ have an eta-local structure and source zero correlation length,
+    and let $C$ be the selected fixed-product tensor in its physical-sector
+    coordinates. For every $L>0$, the normalized $L$-site reduced states of
+    $C$ obtained from chain lengths $L+2$ and $L+1$ are equal.
+\end{theorem}
+
+\begin{proof}\leanok
+    In the selected physical coordinates, the periodic operators of $K$ at
+    both lengths are positive nonzero scalar multiples of those of $C$.
+    Cancel these scalars by
+    Theorem~\ref{thm:mpdo_selected_fixed_product_reduced_states}, transport
+    through the physical isometry, and apply source marginal stability.
+\end{proof}
+
+\begin{theorem}[Iterated selected fixed-product marginals]
+    \label{thm:mpdo_selected_fixed_product_iterated_marginals}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      selectedFixedProduct_reducedBlockState_add_three_eq_succ_of_isSourceZCL}
+    \leanok
+    \uses{def:mpo_source_zcl, def:mpdo_eta_local_structure_data,
+      thm:mpdo_selected_fixed_product_reduced_states,
+      thm:mpdo_source_zcl_iterated_marginal_stability}
+    Under the preceding hypotheses, for every $L>0$, the normalized
+    $L$-site reduced states of the selected fixed-product tensor obtained
+    from chain lengths $L+3$ and $L+1$ are equal.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the two-step source marginal identity to $K$, transport both sides
+    through the selected physical isometry, and cancel the two positive
+    realization scalars.
+\end{proof}
+
+\begin{theorem}[Positive traces of the selected fixed product]
+    \label{thm:mpdo_selected_fixed_product_positive_traces}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      exists_pos_trace_mpo_selectedFixedProduct_of_isSourceZCL}
+    \leanok
+    \uses{def:mpo_source_zcl, def:mpdo_eta_local_structure_data,
+      thm:mpdo_fixed_bond_positive_physical_sector_representative}
+    Let $K$ have an eta-local structure and source zero correlation length.
+    For every $N\geq2$, the trace of the selected fixed-product periodic
+    operator is a strictly positive real number.
+\end{theorem}
+
+\begin{proof}\leanok
+    The selected neighboring operators are positive semidefinite, so their
+    cyclic product is positive semidefinite. Its trace cannot vanish:
+    positive proportionality would then force the trace of the source
+    periodic operator to vanish, contrary to source zero correlation length.
+    A nonzero positive semidefinite matrix has strictly positive real trace.
+\end{proof}
+
 \begin{theorem}[Stabilization of the support of an irreducible square]
     \label{thm:matrix_irreducible_square_support_stabilization}
     \lean{Matrix.IsIrreducible.%
@@ -739,6 +824,8 @@
       thm:mpdo_eta_fixed_bond_product_tensor,
       thm:mpdo_fixed_bond_positive_physical_sector_representative,
       thm:mpdo_selected_fixed_product_cyclic_recurrence,
+      thm:mpdo_selected_fixed_product_adjacent_marginals,
+      thm:mpdo_selected_fixed_product_positive_traces,
       thm:mpdo_cyclic_active_square_cube_adjacent_marginals}
     Express the original tensor in the physical coordinates of $F$. At every
     length $N\geq2$, its closed operator is a positive scalar multiple of the
@@ -749,6 +836,53 @@
     recurrence.
     Theorem~\ref{thm:mpdo_cyclic_active_square_cube_adjacent_marginals} now
     gives the required normalization.
+\end{proof}
+
+\begin{theorem}[Markov cuts from the selected fixed product]
+    \label{thm:mpdo_selected_fixed_product_markov_cuts}
+    \lean{MPOTensor.EtaLocalStructureData.%
+      exists_hayashiMarkovDecomposition_selectedPhysicalCut_of_isSourceZCL}
+    \leanok
+    \uses{def:mpdo, def:injective, def:normal, def:mpo_source_zcl,
+      def:mpdo_eta_local_structure_data,
+      thm:mpdo_fixed_bond_positive_physical_sector_representative,
+      def:hayashi_markov_decomposition}
+    Let $K$ be an injective normal tensor generating matrix-product density
+    operators, with an eta-local structure and source zero correlation
+    length. Express $K$ in the one-site physical coordinates of the positive
+    fixed-product factorization selected by the eta-local structure. For
+    arbitrary $A,C\geq0$, the normalized marginal on consecutive regions of
+    lengths $A$, $1$, and $C$, obtained from the periodic chain of length
+    $A+C+2$, admits a Hayashi Markov decomposition.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_selected_fixed_product_cyclic_recurrence,
+      thm:mpdo_selected_fixed_product_adjacent_marginals,
+      thm:mpdo_selected_fixed_product_iterated_marginals,
+      thm:mpdo_selected_fixed_product_positive_traces,
+      thm:mpdo_selected_fixed_product_reduced_states,
+      thm:mpdo_selected_fixed_product_square_cube,
+      thm:mpdo_cyclic_active_square_positive_adjacent_marginals,
+      thm:mpdo_cyclic_active_explicit_fourth_region_blocks,
+      thm:mpdo_cyclic_active_markov_of_fourth_region,
+      thm:matrix_primitive_pow_two_rank_one}
+    The selected trace matrix is recurrent, and its square is strictly
+    positive. After the positive normalization of
+    Theorem~\ref{thm:mpdo_selected_fixed_product_square_cube}, its square and
+    cube agree. Thus the normalized matrix is primitive, with its second
+    power as a positive power, and the latter factors as
+    $a b^{\mathsf T}$ for strictly positive vectors $a,b$.
+
+    Transport the three-suffix/one-suffix marginal identity from the source
+    tensor to the selected fixed product. In cyclic-active coordinates, its
+    retained blocks are the unchanged interior neighboring products tensored
+    with the boundary factors determined by $a$ and $b$. Regrouping at the
+    distinguished middle site gives the direct sum of normalized positive
+    left and right path states. Their trace products are nonnegative and sum
+    to one. Finally, positive proportionality identifies this selected
+    normalized marginal with the marginal of $K$ in the same physical
+    coordinates.
 \end{proof}
 
 % **Local fix (cyclic-active restriction):** this is a restricted replacement for
@@ -918,12 +1052,46 @@
     two trace factors by $\lambda^{-1}$ gives the normalized identity.
 \end{proof}
 
+\begin{theorem}[Fourth-region blocks from an explicit factorization]
+    \label{thm:mpdo_cyclic_active_explicit_fourth_region_blocks}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      reindex_reducedBlockState_add_three_eq_cyclicActiveFourthRegionBlock}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_cyclic_active_sector}
+    Let $F$ be a physical-sector factorization with positive semidefinite
+    neighboring operators. Suppose that $\lambda>0$ and that functions
+    $a,b$ on the cyclic-active sectors satisfy
+    \[
+        (\lambda^{-1}T_C)^2=a b^{\mathsf T}.
+    \]
+    For every $n\geq0$, reindex the $(n+1)$-site reduced state obtained from
+    the periodic chain of length $n+4$ by its retained open-edge coordinates.
+    The result is the inverse trace of the length-$(n+4)$ periodic operator
+    times the direct sum over retained sector words. A word outside cyclic
+    support contributes zero; every cyclic-active word contributes its
+    unchanged interior neighboring product tensored with the separated
+    boundary factors determined by $\lambda,a,b$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_cyclic_active_three_boundary_trace,
+      thm:mpdo_cyclic_active_deletion}
+    Expand the reduced state as a direct sum of three-suffix contractions.
+    Terms outside positive-length cyclic support vanish. For a retained
+    cyclic-active word, the three traced suffix sites leave the interior
+    product and the two-step boundary contraction. Substitute
+    $(\lambda^{-1}T_C)^2=a b^{\mathsf T}$ to separate its two boundary
+    factors, retaining the normalization by the length-$(n+4)$ trace.
+\end{proof}
+
 \begin{theorem}[Cyclic-active fourth-region factorization]
     \label{thm:mpdo_cyclic_active_fourth_region_factorization}
     \lean{MPOTensor.PhysicalSectorFactorization.%
       exists_cyclicActiveFourthRegion_formula_of_isSourceZCL}
     \leanok
     \uses{thm:mpdo_source_zcl_iterated_marginal_stability,
+      thm:mpdo_cyclic_active_explicit_fourth_region_blocks,
       thm:mpdo_cyclic_active_three_boundary_trace,
       thm:mpdo_cyclic_active_deletion}
     Let $\mathcal K$ be injective and have source zero correlation length,
@@ -949,12 +1117,42 @@
     before the two outer partial traces are evaluated.
 \end{proof}
 
+\begin{theorem}[Markov decomposition from an explicit fourth-region formula]
+    \label{thm:mpdo_cyclic_active_markov_of_fourth_region}
+    \lean{MPOTensor.PhysicalSectorFactorization.%
+      exists_hayashiMarkovDecomposition_cyclicActiveCut_of_fourthRegion}
+    \leanok
+    \uses{def:mpdo_physical_sector_factorization,
+      def:mpdo_cyclic_active_sector,
+      def:hayashi_markov_decomposition}
+    Let $F$ be a positive-dimensional physical-sector factorization whose
+    neighboring operators are positive semidefinite. Fix $A,C\geq0$,
+    $\lambda\in\mathbb R$, and strictly positive functions $a,b$ on the
+    cyclic-active sectors. Suppose that the length-$(A+C+4)$ periodic
+    operator has positive trace, the length-$(A+C+2)$ periodic operator has
+    nonzero trace, and the normalized $(A+C+1)$-site reduced state at length
+    $A+C+2$ has the explicit fourth-region block formula determined by
+    $\lambda,a,b$. Then its tripartite form on regions of lengths
+    $A$, $1$, and $C$ admits a Hayashi Markov decomposition.
+\end{theorem}
+
+\begin{proof}\leanok
+    Regroup every retained fourth-region block at the distinguished middle
+    sector. Its positive left and right path factors are normalized by their
+    traces, with fixed density matrices used only when a factor vanishes.
+    The positive long-chain trace makes all block weights nonnegative. The
+    nonzero short-chain trace makes the reduced state trace one, so these
+    weights sum to one. The resulting direct sum is exactly the Hayashi
+    decomposition in the sector-coordinate middle-site splitting.
+\end{proof}
+
 \begin{theorem}[Cyclic-active Markov decomposition at every cut]
     \label{thm:mpdo_cyclic_active_markov_all_cuts}
     \lean{MPOTensor.PhysicalSectorFactorization.%
       exists_hayashiMarkovDecomposition_cyclicActiveCut_of_isSourceZCL}
     \leanok
     \uses{thm:mpdo_cyclic_active_fourth_region_factorization,
+      thm:mpdo_cyclic_active_markov_of_fourth_region,
       def:hayashi_markov_decomposition}
     Under the hypotheses of
     Theorem~\ref{thm:mpdo_cyclic_active_fourth_region_factorization}, for

--- a/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
+++ b/docs/paper-gaps/cpsv16_commuting_form_to_sal.tex
@@ -526,13 +526,43 @@ It uses only source ZCL and injectivity of the original tensor, not of the
 selected fixed-product tensor.  This closes the adjacent coefficient-extraction
 step tracked in issue~\#5129.
 
-The remaining step is to combine this square--cube identity with the
-strictly positive two-step coefficient in the Markov reconstruction and
-thereby obtain the source's rank-one conclusion for the selected
-factorization.  Until that assembly is proved, the commuting-form-to-SAL
-implication remains open.  The explicit factorization and positivity
-assumptions of the proved SAL corollary remain scope restrictions, not
-additional hypotheses on Proposition~\emph{4to2}.
+This square--cube identity has now been assembled with the strictly positive
+two-step coefficient.  Nonemptiness of the cyclic-active sector set follows
+from the spanning family of original one-site matrices: if the sector set
+were empty, that family would have zero span rather than the full auxiliary
+matrix algebra.  The normalized trace matrix is therefore primitive, with
+its second power as a strictly positive power, and
+\leanid{Matrix.IsPrimitive.%
+exists_pos_pow_two_eq_vecMulVec_of_pow_two_eq_pow_three}
+gives strictly positive vectors $a,b$ satisfying
+\[
+  (\lambda^{-1}T_C)^2=a b^{\mathsf T}.
+\]
+
+The one-step and iterated marginal identities, and the positive selected
+traces, are transported separately by
+\leanid{MPOTensor.EtaLocalStructureData.%
+selectedFixedProduct_reducedBlockState_succ_succ_eq_succ_of_isSourceZCL},
+\leanid{MPOTensor.EtaLocalStructureData.%
+selectedFixedProduct_reducedBlockState_add_three_eq_succ_of_isSourceZCL},
+and
+\leanid{MPOTensor.EtaLocalStructureData.%
+exists_pos_trace_mpo_selectedFixedProduct_of_isSourceZCL}.
+Substituting the positive factorization into the three-suffix formula and
+regrouping at an arbitrary distinguished site produces the Hayashi direct
+sum.  Positive proportionality then identifies the selected normalized
+marginal with that of the original source tensor in the same one-site
+physical coordinates.  This is
+\leanid{MPOTensor.EtaLocalStructureData.%
+exists_hayashiMarkovDecomposition_selectedPhysicalCut_of_isSourceZCL}.
+It assumes exactly the hypotheses of Proposition~\emph{4to2} together with
+the standing MPDO and normal-block hypotheses; it assumes no injectivity,
+normality, or zero correlation length for the selected fixed-product tensor.
+
+Thus the source-facing Markov-cut construction is complete.  The remaining
+step in the commuting-form-to-SAL implication is the entropy-theoretic
+assembly: apply the all-cut Markov criterion to these physical-coordinate
+marginals and transport saturation through the one-site isometry.
 
 \paragraph{Local fix (the later orthogonal-sector statement).}
 The proposition labelled \emph{prop4to2} at source lines~1801--1808 states
@@ -572,16 +602,15 @@ uses ZCL.
 
 \paragraph{Verdict.}
 Proposition~\emph{4to2} is classified as a structural-bridge gap.  The
-fourth-region factorization, the Markov decomposition at every admissible cut,
-the all-cut entropy argument, and transport to the original physical basis are
-complete under an explicit positive physical-sector factorization.  The exact
-fixed tensor selected from the source-side commuting bond now has such a
-factorization, with positive neighboring operators and the original physical
-bond.  Rectangular virtual compression now transports the algebraic
-factorization and identifies its neighboring contraction exactly.  The
-remaining gap is to retain the selected trace-visible sector as an exact
-virtual corner, prove positivity after inserting its range projection, and
-relate the resulting blocked sector back to the original source tensor.
+positive fixed-product representative, its cyclic-active recurrent component,
+the normalized square--cube identity, and the positive rank-one factorization
+of the two-step coefficient are now obtained from the source tensor without a
+virtual comparison between the two tensors.  The resulting Hayashi
+decomposition holds at every one-site cut of the original source tensor in the
+selected physical coordinates.  The remaining gap is only to pass from these
+all-cut decompositions to SAL and then transport SAL through the one-site
+physical isometry.
+
 The later
 orthogonal direct-sum implication is likewise formalized only as a
 scope-restricted theorem assuming sectorwise SAL.  It neither supplies that
@@ -590,22 +619,18 @@ implies SAL.
 
 \section{Elimination plan}
 
-The gap can be removed in the following stages.
+The remaining gap can be removed in the following stages.
 
 \begin{enumerate}
-\item The selected fixed tensor has a positive physical-sector factorization
-constructed non-circularly from the source-side commuting bond, as recorded by
-the fixed-tensor theorem identified above.
-\item The canonical inclusion and exact compression identity for every
-flattened sector are formalized.  Use this certificate when selecting the
-trace-visible canonical sector of the fixed tensor, and prove that the
-neighboring contraction remains positive after inserting its range
-projection.
-\item Use the proportional canonical-form theorem and its virtual gauge to
-transport the positive compressed factorization to the matching normal
-sector, then remove any blocking without adding a hypothesis absent from
-Proposition~\emph{4to2}.  Only then may the source proposition receive a
-formal declaration and a \texttt{\string\leanok} marker.
+\item Apply the all-cut Markov criterion to the decompositions supplied by
+\leanid{MPOTensor.EtaLocalStructureData.%
+exists_hayashiMarkovDecomposition_selectedPhysicalCut_of_isSourceZCL}.
+Positivity and nonvanishing of the physical-coordinate periodic operators
+follow from the MPDO and source-ZCL hypotheses.
+\item Transport SAL back through the selected one-site physical isometry.
+Only after this conclusion is stated under exactly the source hypotheses may
+Proposition~\emph{4to2} receive a formal declaration and a
+\texttt{\string\leanok} marker.
 \end{enumerate}
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
## Summary

This proves the source-facing arbitrary-cut Hayashi Markov decomposition needed in CPSV16 Appendix C.2, Proposition 4to2.

The selected fixed-product representative is used only to calculate the marginal. The final theorem concerns the original tensor after the selected one-site physical-coordinate isometry and assumes exactly:

- MPDO positivity of the source tensor;
- injectivity and normality of the source tensor;
- eta-local fixed-bond structure;
- source zero correlation length.

It does not assume injectivity, normality, or source zero correlation length for the selected representative.

The proof transports adjacent and iterated normalized marginal identities and positive finite-chain traces from the source. Recurrence and strict positivity of the two-step cyclic-active coefficient make the normalized trace matrix primitive. The square-cube identity then gives a positive rank-one factorization, which supplies the fourth-region boundary separation and hence the Hayashi direct sum at every one-site cut. Positive proportionality finally identifies the selected marginal with the source marginal in the same physical coordinates.

The Blueprint contains separate exact entries for every new public declaration. The paper-gap note records that only the final all-cut entropy/SAL assembly remains.

Source: arXiv:1606.00608, Appendix C.2, Proposition 4to2, lines 1597--1619.

Paper-gap note: docs/paper-gaps/cpsv16_commuting_form_to_sal.tex.

## Validation

- focused builds for both changed Lean modules;
- full lake build;
- leanblueprint checkdecls;
- independent mathematical and proof-integrity review;
- changed-file proof-integrity, whitespace, line-length, and tactic-pattern checks.

Closes #5123.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proofs in core MPDO/CPSV16 Proposition 4to2 chain; mathematical risk is moderate (proof complexity and dependency on cyclic-active restrictions), not auth or runtime security.
> 
> **Overview**
> Completes the **source-facing Hayashi Markov decomposition** at every one-site cut for the original tensor in the eta-local **selected physical coordinates**, under MPDO/injectivity/normality/source-ZCL only (not on the fixed-product representative).
> 
> **`CyclicActiveAdjacentCoefficientExtraction`:** Adds reusable lemmas that transport source ZCL to the selected fixed product—equal reduced states under physical-basis proportionality, adjacent and three-suffix marginal identities, and positive periodic traces—and refactors the square–cube theorem to call them instead of inlined proofs.
> 
> **`CyclicActiveMarkovDecomposition`:** Splits Markov assembly into **`exists_hayashiMarkovDecomposition_cyclicActiveCut_of_fourthRegion`** (hypotheses: explicit fourth-region blocks and trace positivity) with the ZCL theorem as a thin wrapper; adds **`exists_hayashiMarkovDecomposition_selectedPhysicalCut_of_isSourceZCL`**, which builds rank-one \((\lambda^{-1}T_C)^2 = ab^{\mathsf T}\), fourth-region blocks, and identifies marginals via positive proportionality.
> 
> Blueprint and **`cpsv16_commuting_form_to_sal.tex`** record the new theorems and state that only **all-cut entropy → SAL** plus isometry transport remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec4c5b75a2668d01baa4acbc8db4a86ae8ea7f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->