### PR TITLE
fix(tenkz): preserve affine hull bases

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -809,6 +809,21 @@ grep -Fq '(record picture)' "$WORK/n_malformed_physical.transcript" || {
   exit 1
 }
 
+singular_basis_negative="$KERNEL/negative/n_geom_singular_basis.tex"
+if ( cd "$WORK" &&
+     TEXINPUTS="$REPO/tex/tenkz//:" \
+       timeout 120 xelatex -interaction=nonstopmode -halt-on-error \
+       "$singular_basis_negative" \
+       >"$WORK/n_geom_singular_basis.transcript" 2>&1 ); then
+  echo "FAIL: a singular carrier basis was accepted" >&2
+  exit 1
+fi
+grep -Fq '[TKZ-GEOM-SINGULAR-BASIS]' \
+    "$WORK/n_geom_singular_basis.transcript" || {
+  echo "FAIL: singular basis rejection lacked TKZ-GEOM-SINGULAR-BASIS" >&2
+  exit 1
+}
+
 for strict_negative in \
   n_strict_sandwich \
   n_strict_role \

--- a/tests/tenkz/kernel/negative/n_geom_singular_basis.tex
+++ b/tests/tenkz/kernel/negative/n_geom_singular_basis.tex
@@ -1,0 +1,10 @@
+%% Negative regression: inverse carrier coordinates require two independent
+%% basis vectors.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\ExplSyntaxOn
+\__tenkz_geom_basis_unapply:nnnnnnNN
+  {1}{2}{2}{4}{3}{6} \l_tmpa_tl \l_tmpb_tl
+\ExplSyntaxOff
+\end{document}

--- a/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
+++ b/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
@@ -1,0 +1,115 @@
+%% Regression: hull enclosures and side routes retain both vectors of a
+%% sheared plane carrier, rather than reducing the carrier to one turn angle.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\fp_new:N \l__tenkz_test_route_x_fp
+\fp_new:N \l__tenkz_test_route_y_fp
+\tl_new:N \l__tenkz_test_route_name_tl
+\cs_new_eq:NN
+  \__tenkz_test_route_measure:n
+  \__tenkz_kernel_r_route_measure:n
+\cs_set_protected:Npn \__tenkz_kernel_r_route_measure:n #1
+  {
+    \__tenkz_test_route_measure:n {#1}
+    \__tenkz_model_get:nnN {#1} {name} \l__tenkz_test_route_name_tl
+    \tl_if_in:VnT \l__tenkz_test_route_name_tl {affine-}
+      {
+        \fp_compare:nNnF { abs(\l__tenkz_kernel_ro_ex_tl - 1) }
+          < {0.000001}
+          { \errmessage{an~affine~route~lost~its~east~basis~vector} }
+        \fp_compare:nNnF { abs(\l__tenkz_kernel_ro_ey_tl) }
+          < {0.000001}
+          { \errmessage{an~affine~route~tilted~its~east~basis~vector} }
+        \fp_compare:nNnF { abs(\l__tenkz_kernel_ro_nx_tl - 0.45) }
+          < {0.000001}
+          { \errmessage{an~affine~route~lost~the~plane~shear} }
+        \fp_compare:nNnF { abs(\l__tenkz_kernel_ro_ny_tl - 0.60) }
+          < {0.000001}
+          { \errmessage{an~affine~route~lost~the~plane~rise} }
+      }
+  }
+\cs_new_eq:NN
+  \__tenkz_test_route_point:nn
+  \__tenkz_kernel_r_route_pt:nn
+\cs_set_protected:Npn \__tenkz_kernel_r_route_pt:nn #1#2
+  {
+    \fp_set:Nn \l__tenkz_test_route_x_fp
+      {
+        \l__tenkz_kernel_ro_ex_tl * (#1)
+        + \l__tenkz_kernel_ro_nx_tl * (#2)
+      }
+    \fp_set:Nn \l__tenkz_test_route_y_fp
+      {
+        \l__tenkz_kernel_ro_ey_tl * (#1)
+        + \l__tenkz_kernel_ro_ny_tl * (#2)
+      }
+    \__tenkz_test_route_point:nn {#1}{#2}
+    \fp_compare:nNnF
+      { abs(\l__tenkz_kernel_ro_u_fp - \l__tenkz_test_route_x_fp) }
+      < {0.000001}
+      { \errmessage{a~route~point~lost~its~affine~x~projection} }
+    \fp_compare:nNnF
+      { abs(\l__tenkz_kernel_ro_v_fp - \l__tenkz_test_route_y_fp) }
+      < {0.000001}
+      { \errmessage{a~route~point~lost~its~affine~y~projection} }
+  }
+\cs_new_protected:Npn \__tenkz_test_basis_round_trip:
+  {
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      {1}{0}{0.45}{0.60}{2.25}{-1.5} \l_tmpa_tl \l_tmpb_tl
+    \__tenkz_geom_basis_unapply:nnnnnnNN
+      {1}{0}{0.45}{0.60}{\l_tmpa_tl}{\l_tmpb_tl}
+      \l_tmpc_tl \l_tmpd_tl
+    \fp_compare:nNnF { abs(\l_tmpc_tl - 2.25) } < {0.000001}
+      { \errmessage{the~affine~basis~lost~the~east~coordinate} }
+    \fp_compare:nNnF { abs(\l_tmpd_tl + 1.5) } < {0.000001}
+      { \errmessage{the~affine~basis~lost~the~north~coordinate} }
+    \__tenkz_geom_basis_dual:nnnnNNNN
+      {1}{0}{0.45}{0.60} \l_tmpa_tl \l_tmpb_tl \l_tmpc_tl \l_tmpd_tl
+    \fp_compare:nNnF { abs(\l_tmpa_tl - 1) } < {0.000001}
+      { \errmessage{the~east~dual~does~not~read~the~east~basis} }
+    \fp_compare:nNnF { abs(\l_tmpb_tl + 0.75) } < {0.000001}
+      { \errmessage{the~east~dual~lost~the~plane~shear} }
+    \fp_compare:nNnF { abs(\l_tmpc_tl) } < {0.000001}
+      { \errmessage{the~north~dual~does~not~annihilate~east} }
+    \fp_compare:nNnF { abs(\l_tmpd_tl - 1.6666666666667) } < {0.000001}
+      { \errmessage{the~north~dual~does~not~read~the~north~basis} }
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\ExplSyntaxOn
+\__tenkz_test_basis_round_trip:
+\ExplSyntaxOff
+\begin{tenkz}[rows={wire,wire}, cols=2, frame=plane, bonds=none]
+  \tn[at=(1,1), skin=box]{A}
+  \tn[at=(1,2), skin=box]{B}
+  \tn[at=(2,1), skin=box]{C}
+  \tn[at=(2,2), skin=box]{D}
+  \tnmark[form=enclosure]{(1,1)..(2,2)}{$H$}
+  \tnwire[name=affine-north, closed,
+          route={n of (1,1) .. (2,2)}]
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire,wire}, cols=2, frame=plane, bonds=none]
+  \tn[at=(1,1), skin=box]{A}
+  \tn[at=(1,2), skin=box]{B}
+  \tn[at=(2,1), skin=box]{C}
+  \tn[at=(2,2), skin=box]{D}
+  \tnwire[name=affine-east, closed,
+          route={e of (1,1) .. (2,2)}]
+\end{tenkz}
+\quad
+\begin{tenkz}[rows={wire,wire}, cols=2, frame=plane, bonds=none]
+  \tn[at=(1,1), skin=box]{A}
+  \tn[at=(1,2), skin=box]{B}
+  \tn[at=(2,1), skin=box]{C}
+  \tn[at=(2,2), skin=box]{D}
+  \tnwire[name=affine-all, closed,
+          route={all of (1,1) .. (2,2)}]
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
+++ b/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
@@ -8,6 +8,7 @@
 \fp_new:N \l__tenkz_test_route_x_fp
 \fp_new:N \l__tenkz_test_route_y_fp
 \tl_new:N \l__tenkz_test_route_name_tl
+\seq_new:N \l__tenkz_test_support_seq
 \cs_new_eq:NN
   \__tenkz_test_route_measure:n
   \__tenkz_kernel_r_route_measure:n
@@ -86,6 +87,13 @@
     \__tenkz_geom_rect_ray_reach:nnnN {30}{2}{1} \l_tmpa_tl
     \fp_compare:nNnF { abs(\l_tmpa_tl - 2) } < {0.000001}
       { \errmessage{a~numeric~label~ray~did~not~meet~the~rectangle~edge} }
+    \seq_clear:N \l__tenkz_test_support_seq
+    \seq_put_right:Nn \l__tenkz_test_support_seq
+      { {circle}{0}{0}{0}{0}{0}{0} }
+    \__tenkz_kernel_hull_reach_linear:NnnnN
+      \l__tenkz_test_support_seq {0}{1.6666666666667}{0.3} \l_tmpa_tl
+    \fp_compare:nNnF { abs(\l_tmpa_tl - 0.5) } < {0.000001}
+      { \errmessage{page~daylight~was~not~lifted~into~dual~units} }
   }
 \cs_new_protected:Npn \__tenkz_test_leg_lane:
   {
@@ -121,7 +129,8 @@
 \__tenkz_test_basis_round_trip:
 \__tenkz_test_leg_lane:
 \ExplSyntaxOff
-\begin{tenkz}[rows={wire,wire}, cols=2, frame=plane, bonds=none]
+\begin{tenkz}[
+    rows={wire,wire}, cols=2, frame=plane, bonds=none, physical=up]
   \tn[at=(1,1), skin=box]{A}
   \tn[at=(1,2), skin=box]{B}
   \tn[at=(2,1), skin=box]{C}

--- a/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
+++ b/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
@@ -29,6 +29,12 @@
         \fp_compare:nNnF { abs(\l__tenkz_kernel_ro_ny_tl - 0.60) }
           < {0.000001}
           { \errmessage{an~affine~route~lost~the~plane~rise} }
+        \fp_compare:nNnF
+          { \l__tenkz_kernel_ro_x_fp } < { \l__tenkz_kernel_ro_xb_fp }
+          { \errmessage{an~affine~route~lost~its~ordered~east~bounds} }
+        \fp_compare:nNnF
+          { \l__tenkz_kernel_ro_y_fp } < { \l__tenkz_kernel_ro_yb_fp }
+          { \errmessage{an~affine~route~lost~its~ordered~north~bounds} }
       }
   }
 \cs_new_eq:NN
@@ -77,6 +83,35 @@
       { \errmessage{the~north~dual~does~not~annihilate~east} }
     \fp_compare:nNnF { abs(\l_tmpd_tl - 1.6666666666667) } < {0.000001}
       { \errmessage{the~north~dual~does~not~read~the~north~basis} }
+    \__tenkz_geom_rect_ray_reach:nnnN {30}{2}{1} \l_tmpa_tl
+    \fp_compare:nNnF { abs(\l_tmpa_tl - 2) } < {0.000001}
+      { \errmessage{a~numeric~label~ray~did~not~meet~the~rectangle~edge} }
+  }
+\cs_new_protected:Npn \__tenkz_test_leg_lane:
+  {
+    \fp_zero:N \l__tenkz_kernel_r_x_fp
+    \fp_zero:N \l__tenkz_kernel_r_y_fp
+    \fp_zero:N \l__tenkz_kernel_r_reach_fp
+    \tl_set:Nn \l__tenkz_kernel_leg_dir_tl {90}
+    \__tenkz_kernel_r_leg_lane:nnn {2}{0}{1.6666666666667}
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_reach_fp
+          - 1.2 - \__tenkz_metric_ratio:n {legcrossclear} )
+      }
+      < {0.000001}
+      { \errmessage{a~sheared~leg~did~not~reach~its~route~lane} }
+    \tl_set:Nn \l__tenkz_kernel_leg_dir_tl {0}
+    \__tenkz_kernel_r_leg_lane:nnn {20}{0}{1.6666666666667}
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_reach_fp
+          - 1.2 - \__tenkz_metric_ratio:n {legcrossclear} )
+      }
+      < {0.000001}
+      { \errmessage{a~parallel~leg~was~extended~toward~an~unreachable~lane} }
   }
 \ExplSyntaxOff
 \makeatother
@@ -84,13 +119,14 @@
 \tenkzkernel
 \ExplSyntaxOn
 \__tenkz_test_basis_round_trip:
+\__tenkz_test_leg_lane:
 \ExplSyntaxOff
 \begin{tenkz}[rows={wire,wire}, cols=2, frame=plane, bonds=none]
   \tn[at=(1,1), skin=box]{A}
   \tn[at=(1,2), skin=box]{B}
   \tn[at=(2,1), skin=box]{C}
   \tn[at=(2,2), skin=box]{D}
-  \tnmark[form=enclosure]{(1,1)..(2,2)}{$H$}
+  \tnmark[form=enclosure, label pos=30]{(1,1)..(2,2)}{$H$}
   \tnwire[name=affine-north, closed,
           route={n of (1,1) .. (2,2)}]
 \end{tenkz}

--- a/tests/tenkz/kernel/regression/r_route_all_faces.tex
+++ b/tests/tenkz/kernel/regression/r_route_all_faces.tex
@@ -14,16 +14,19 @@
 \fp_set:Nn \l__tenkz_kernel_ro_y_fp {-1}
 \fp_set:Nn \l__tenkz_kernel_ro_yb_fp {4}
 \tl_set:Nn \l__tenkz_kernel_ro_lane_tl {4}
-\tl_set:Nn \l__tenkz_kernel_ro_tau_tl {0}
+\tl_set:Nn \l__tenkz_kernel_ro_ux_tl {1}
+\tl_set:Nn \l__tenkz_kernel_ro_uy_tl {0}
+\tl_set:Nn \l__tenkz_kernel_ro_vx_tl {0}
+\tl_set:Nn \l__tenkz_kernel_ro_vy_tl {1}
 \__tenkz_kernel_r_route_leg:nn {{n}{1}{1}} {wire-1}
 \__tenkz_kernel_r_route_leg:nn {{s}{2}{1}} {wire-1}
 \prop_get:NnN \l__tenkz_kernel_ro_legs_prop
   {leg-n-1-1} \l_tmpa_tl
-\tl_if_eq:NnF \l_tmpa_tl {{{4}{0}}}
+\tl_if_eq:NnF \l_tmpa_tl {{{4}{0}{1}}}
   { \errmessage{the north leg did not receive the north lane} }
 \prop_get:NnN \l__tenkz_kernel_ro_legs_prop
   {leg-s-2-1} \l_tmpa_tl
-\tl_if_eq:NnF \l_tmpa_tl {{{-1}{0}}}
+\tl_if_eq:NnF \l_tmpa_tl {{{-1}{0}{1}}}
   { \errmessage{the south leg received the north lane} }
 \ExplSyntaxOff
 \mbox{parsed}

--- a/tests/tenkz/kernel/regression/r_route_mixed_axes.tex
+++ b/tests/tenkz/kernel/regression/r_route_mixed_axes.tex
@@ -12,10 +12,12 @@
 \ExplSyntaxOn
 \prop_clear:N \l__tenkz_kernel_ro_legs_prop
 \tl_set:Nn \l__tenkz_kernel_ro_lane_tl {2}
-\tl_set:Nn \l__tenkz_kernel_ro_tau_tl {0}
+\tl_set:Nn \l__tenkz_kernel_ro_vx_tl {0}
+\tl_set:Nn \l__tenkz_kernel_ro_vy_tl {1}
 \__tenkz_kernel_r_route_leg:nn {{n}{1}{1}} {wire-1}
 \tl_set:Nn \l__tenkz_kernel_ro_lane_tl {-1}
-\tl_set:Nn \l__tenkz_kernel_ro_tau_tl {90}
+\tl_set:Nn \l__tenkz_kernel_ro_vx_tl {-1}
+\tl_set:Nn \l__tenkz_kernel_ro_vy_tl {0}
 \__tenkz_kernel_r_route_leg:nn {{n}{1}{1}} {wire-2}
 \prop_map_inline:Nn \l__tenkz_kernel_ro_legs_prop
   {

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -324,6 +324,30 @@
       }
   }
 
+% Distance from the centre of an axis-aligned rectangle to its boundary along
+% a ray.  The half-extents #2,#3 and result #4 share one coordinate system;
+% #1 is the ray angle in that system.
+\cs_new_protected:Npn \__tenkz_geom_rect_ray_reach:nnnN #1#2#3#4
+  {
+    \fp_compare:nNnTF { cosd(#1) } = {0}
+      { \tl_set:Ne #4 { \fp_eval:n { (#3) / abs(sind(#1)) } } }
+      {
+        \fp_compare:nNnTF { sind(#1) } = {0}
+          { \tl_set:Ne #4 { \fp_eval:n { (#2) / abs(cosd(#1)) } } }
+          {
+            \tl_set:Ne #4
+              {
+                \fp_eval:n
+                  {
+                    min(
+                      (#2) / abs(cosd(#1)) ,
+                      (#3) / abs(sind(#1)) )
+                  }
+              }
+          }
+      }
+  }
+
 % The local east/north basis supplied by one frame address.  Affine frames
 % use E=(b,d), N=(-a,-c); circle frames retain their orthonormal tangent and
 % outward-normal basis at the named station.

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -32,6 +32,8 @@
   { [TKZ-GEOM-FAMILY]~no~silhouette~family~named~'#1' }
 \msg_new:nnn {tenkz}{geom-compass}
   { [TKZ-GEOM-COMPASS]~no~compass~face~named~'#1';~expected~n,~e,~s,~or~w }
+\msg_new:nnn {tenkz}{geom-singular-basis}
+  { [TKZ-GEOM-SINGULAR-BASIS]~a~carrier~basis~must~have~nonzero~determinant }
 
 % ---------- frames ----------------------------------------------------------
 % A frame record is six fp fields (row-major matrix a b / c d, offset dx dy)
@@ -260,6 +262,99 @@
 % leaking into each port, leg, and open-end consumer.
 \cs_new_protected:Npn \__tenkz_geom_local_dir:nnN #1#2#3
   { \__tenkz_geom_dir:nnN {#1} { 90 + (#2) } #3 }
+
+% A carrier basis is the complete local east/north pair on the page.  Keeping
+% both vectors, rather than one turn angle, preserves shear and unequal scale.
+% The generic apply/unapply pair below is shared by every consumer which
+% stores geometry in carrier-local coordinates.
+\cs_new_protected:Npn \__tenkz_geom_basis_apply:nnnnnnNN
+    #1#2#3#4#5#6#7#8
+  {
+    \tl_set:Ne #7 { \fp_eval:n { (#1) * (#5) + (#3) * (#6) } }
+    \tl_set:Ne #8 { \fp_eval:n { (#2) * (#5) + (#4) * (#6) } }
+  }
+\cs_new_protected:Npn \__tenkz_geom_basis_unapply:nnnnnnNN
+    #1#2#3#4#5#6#7#8
+  {
+    \fp_compare:nNnTF { (#1) * (#4) - (#2) * (#3) } = {0}
+      {
+        \tl_clear:N #7
+        \tl_clear:N #8
+        \msg_error:nn {tenkz}{geom-singular-basis}
+      }
+      {
+        \tl_set:Ne #7
+          {
+            \fp_eval:n
+              { ( (#4) * (#5) - (#3) * (#6) )
+                  / ( (#1) * (#4) - (#2) * (#3) ) }
+          }
+        \tl_set:Ne #8
+          {
+            \fp_eval:n
+              { ( -(#2) * (#5) + (#1) * (#6) )
+                  / ( (#1) * (#4) - (#2) * (#3) ) }
+          }
+      }
+  }
+
+% The dual basis reads page vectors as local coordinates.  These covectors
+% also let support folds measure a rendered silhouette directly in local
+% coordinates without first replacing it by an axis-aligned page box.
+\cs_new_protected:Npn \__tenkz_geom_basis_dual:nnnnNNNN
+    #1#2#3#4#5#6#7#8
+  {
+    \fp_compare:nNnTF { (#1) * (#4) - (#2) * (#3) } = {0}
+      {
+        \tl_clear:N #5
+        \tl_clear:N #6
+        \tl_clear:N #7
+        \tl_clear:N #8
+        \msg_error:nn {tenkz}{geom-singular-basis}
+      }
+      {
+        \tl_set:Ne #5
+          { \fp_eval:n { (#4) / ( (#1) * (#4) - (#2) * (#3) ) } }
+        \tl_set:Ne #6
+          { \fp_eval:n { -(#3) / ( (#1) * (#4) - (#2) * (#3) ) } }
+        \tl_set:Ne #7
+          { \fp_eval:n { -(#2) / ( (#1) * (#4) - (#2) * (#3) ) } }
+        \tl_set:Ne #8
+          { \fp_eval:n { (#1) / ( (#1) * (#4) - (#2) * (#3) ) } }
+      }
+  }
+
+% The local east/north basis supplied by one frame address.  Affine frames
+% use E=(b,d), N=(-a,-c); circle frames retain their orthonormal tangent and
+% outward-normal basis at the named station.
+\cs_new_protected:Npn \__tenkz_geom_local_basis:nnnNNNN #1#2#3#4#5#6#7
+  {
+    \prop_get:NnN \l__tenkz_geom_framekind_prop {#1} \l__tenkz_geom_kind_tl
+    \quark_if_no_value:NTF \l__tenkz_geom_kind_tl
+      {
+        \msg_error:nnn {tenkz}{geom-unknown-frame} {#1}
+        \tl_set:Nn #4 {1}
+        \tl_set:Nn #5 {0}
+        \tl_set:Nn #6 {0}
+        \tl_set:Nn #7 {1}
+      }
+      {
+        \str_if_eq:VnTF \l__tenkz_geom_kind_tl {circle}
+          {
+            \__tenkz_geom_turn:nnnN {#1}{#2}{#3} \l__tenkz_geom_tmp_tl
+            \tl_set:Ne #4 { \fp_eval:n { cosd(\l__tenkz_geom_tmp_tl) } }
+            \tl_set:Ne #5 { \fp_eval:n { sind(\l__tenkz_geom_tmp_tl) } }
+            \tl_set:Ne #6 { \fp_eval:n { -sind(\l__tenkz_geom_tmp_tl) } }
+            \tl_set:Ne #7 { \fp_eval:n { cosd(\l__tenkz_geom_tmp_tl) } }
+          }
+          {
+            \tl_set:Ne #4 { \__tenkz_geom_field:nn{#1}{b} }
+            \tl_set:Ne #5 { \__tenkz_geom_field:nn{#1}{d} }
+            \tl_set:Ne #6 { \fp_eval:n { -\__tenkz_geom_field:nn{#1}{a} } }
+            \tl_set:Ne #7 { \fp_eval:n { -\__tenkz_geom_field:nn{#1}{c} } }
+          }
+      }
+  }
 
 % The axes a frame gives a record.  An address on a carrier is read in the
 % carrier's axes, and the ink the frame measures is measured in them, so
@@ -532,6 +627,47 @@
                  (#6) * cosd(#8) + (#7) * sind(#8)
                  + \__tenkz_geom_support:nnnnnn
                      {#1}{#2}{#3}{#4}{#5}{#8} ) } }
+  }
+
+% Fold support against an arbitrary page covector (gx,gy).  The result is in
+% the covector's coordinate units, so a dual-basis row returns an exact local
+% coordinate even when the carrier is sheared or scaled.
+\tl_new:N \l__tenkz_geom_support_gx_tl
+\tl_new:N \l__tenkz_geom_support_gy_tl
+\cs_new_protected:Npn \__tenkz_geom_support_max_linear:nnnN #1#2#3#4
+  {
+    \tl_set:Nn \l__tenkz_geom_support_gx_tl {#2}
+    \tl_set:Nn \l__tenkz_geom_support_gy_tl {#3}
+    \tl_set:Nn #4 { -10000 }
+    \seq_map_inline:cn {#1}
+      {
+        \__tenkz_geom_support_max_linear_one:nnnnnnnN ##1 #4
+      }
+  }
+\cs_new_protected:Npn \__tenkz_geom_support_max_linear_one:nnnnnnnN
+    #1#2#3#4#5#6#7#8
+  {
+    \tl_set:Ne #8
+      {
+        \fp_eval:n
+          {
+            max(
+              #8 ,
+              (#6) * \l__tenkz_geom_support_gx_tl
+                + (#7) * \l__tenkz_geom_support_gy_tl
+              + sqrt(
+                  ( \l__tenkz_geom_support_gx_tl ) ^ 2
+                  + ( \l__tenkz_geom_support_gy_tl ) ^ 2 )
+                * \__tenkz_geom_support:nnnnnn
+                    {#1}{#2}{#3}{#4}{#5}
+                    {
+                      atand(
+                        \l__tenkz_geom_support_gy_tl ,
+                        \l__tenkz_geom_support_gx_tl )
+                    }
+            )
+          }
+      }
   }
 
 % ---------- corridors --------------------------------------------------------

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -4518,6 +4518,20 @@
 % is what keeps a page-axis contour a page-axis contour.
 \fp_new:N \l__tenkz_kernel_hull_cos_fp
 \fp_new:N \l__tenkz_kernel_hull_sin_fp
+\tl_new:N \l__tenkz_kernel_hull_ex_tl
+\tl_new:N \l__tenkz_kernel_hull_ey_tl
+\tl_new:N \l__tenkz_kernel_hull_nx_tl
+\tl_new:N \l__tenkz_kernel_hull_ny_tl
+\tl_new:N \l__tenkz_kernel_hull_ux_tl
+\tl_new:N \l__tenkz_kernel_hull_uy_tl
+\tl_new:N \l__tenkz_kernel_hull_vx_tl
+\tl_new:N \l__tenkz_kernel_hull_vy_tl
+\tl_new:N \l__tenkz_kernel_hull_basis_row_tl
+\tl_new:N \l__tenkz_kernel_hull_basis_col_tl
+\tl_new:N \l__tenkz_kernel_hull_basis_parent_tl
+\tl_new:N \l__tenkz_kernel_hull_basis_record_tl
+\bool_new:N \l__tenkz_kernel_hull_chart_bool
+\bool_new:N \l__tenkz_kernel_hull_basis_at_bool
 \cs_new_protected:Npn \__tenkz_kernel_hull_turn:NN #1#2
   {
     \fp_zero:N \l__tenkz_kernel_hull_cos_fp
@@ -4536,6 +4550,87 @@
           { atand( \l__tenkz_kernel_hull_sin_fp ,
                    \l__tenkz_kernel_hull_cos_fp ) }
       }
+  }
+
+% The complete east/north basis of a selection.  Affine pictures have one
+% global linear part.  Circle selections retain the established mean tangent,
+% represented here as an orthonormal pair so all downstream consumers use the
+% same state shape.
+\cs_new_protected:Npn \__tenkz_kernel_hull_basis:NNNNN #1#2#3#4#5
+  {
+    \bool_set_true:N \l__tenkz_kernel_hull_chart_bool
+    \seq_map_inline:Nn #1
+      {
+        \__tenkz_kernel_r_atom_rc:nNNN {##1}
+          \l__tenkz_kernel_hull_basis_row_tl
+          \l__tenkz_kernel_hull_basis_col_tl
+          \l__tenkz_kernel_hull_basis_at_bool
+        \bool_if:NF \l__tenkz_kernel_hull_basis_at_bool
+          {
+            \__tenkz_model_get:nnN {##1} {cluster-of}
+              \l__tenkz_kernel_hull_basis_parent_tl
+            \quark_if_no_value:NTF \l__tenkz_kernel_hull_basis_parent_tl
+              { \bool_set_false:N \l__tenkz_kernel_hull_chart_bool }
+              {
+                \prop_get:NVN \l__tenkz_kernel_named_prop
+                  \l__tenkz_kernel_hull_basis_parent_tl
+                  \l__tenkz_kernel_hull_basis_record_tl
+                \quark_if_no_value:NTF \l__tenkz_kernel_hull_basis_record_tl
+                  { \bool_set_false:N \l__tenkz_kernel_hull_chart_bool }
+                  {
+                    \exp_args:NV \__tenkz_kernel_r_atom_rc:nNNN
+                      \l__tenkz_kernel_hull_basis_record_tl
+                      \l__tenkz_kernel_hull_basis_row_tl
+                      \l__tenkz_kernel_hull_basis_col_tl
+                      \l__tenkz_kernel_hull_basis_at_bool
+                    \bool_if:NF \l__tenkz_kernel_hull_basis_at_bool
+                      { \bool_set_false:N \l__tenkz_kernel_hull_chart_bool }
+                  }
+              }
+          }
+      }
+    \__tenkz_geom_frame_if_affine:nTF {kpic}
+      {
+        \bool_if:NTF \l__tenkz_kernel_hull_chart_bool
+          { \__tenkz_geom_local_basis:nnnNNNN {kpic}{1}{1} #2#3#4#5 }
+          { \__tenkz_kernel_hull_basis_orthogonal:NNNNN #1#2#3#4#5 }
+      }
+      { \__tenkz_kernel_hull_basis_orthogonal:NNNNN #1#2#3#4#5 }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_hull_basis_orthogonal:NNNNN
+    #1#2#3#4#5
+  {
+    \__tenkz_kernel_hull_turn:NN #1 \l__tenkz_kernel_hull_turn_tl
+    \tl_set:Ne #2
+      { \fp_eval:n { cosd(\l__tenkz_kernel_hull_turn_tl) } }
+    \tl_set:Ne #3
+      { \fp_eval:n { sind(\l__tenkz_kernel_hull_turn_tl) } }
+    \tl_set:Ne #4
+      { \fp_eval:n { -sind(\l__tenkz_kernel_hull_turn_tl) } }
+    \tl_set:Ne #5
+      { \fp_eval:n { cosd(\l__tenkz_kernel_hull_turn_tl) } }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_hull_basis_dual:
+  {
+    \__tenkz_geom_basis_dual:nnnnNNNN
+      { \l__tenkz_kernel_hull_ex_tl }
+      { \l__tenkz_kernel_hull_ey_tl }
+      { \l__tenkz_kernel_hull_nx_tl }
+      { \l__tenkz_kernel_hull_ny_tl }
+      \l__tenkz_kernel_hull_ux_tl
+      \l__tenkz_kernel_hull_uy_tl
+      \l__tenkz_kernel_hull_vx_tl
+      \l__tenkz_kernel_hull_vy_tl
+  }
+
+% Maximum local coordinate against one row of the dual basis, padded in the
+% same carrier-local units.
+\cs_new_protected:Npn \__tenkz_kernel_hull_reach_linear:NnnnN #1#2#3#4#5
+  {
+    \__tenkz_geom_support_max_linear:nnnN
+      { \cs_to_str:N #1 } {#2} {#3} #5
+    \tl_set:Ne #5 { \fp_eval:n { #5 + (#4) } }
   }
 \tl_new:N \l__tenkz_kernel_r_tau_tl
 \tl_new:N \l__tenkz_kernel_r_turnopt_tl
@@ -4608,31 +4703,48 @@
 \fp_new:N \l__tenkz_kernel_ro_yb_fp
 \fp_new:N \l__tenkz_kernel_ro_u_fp
 \fp_new:N \l__tenkz_kernel_ro_v_fp
-\tl_new:N \l__tenkz_kernel_ro_tau_tl
+\tl_new:N \l__tenkz_kernel_ro_gx_tl
+\tl_new:N \l__tenkz_kernel_ro_gy_tl
+\tl_new:N \l__tenkz_kernel_ro_ex_tl
+\tl_new:N \l__tenkz_kernel_ro_ey_tl
+\tl_new:N \l__tenkz_kernel_ro_nx_tl
+\tl_new:N \l__tenkz_kernel_ro_ny_tl
+\tl_new:N \l__tenkz_kernel_ro_ux_tl
+\tl_new:N \l__tenkz_kernel_ro_uy_tl
+\tl_new:N \l__tenkz_kernel_ro_vx_tl
+\tl_new:N \l__tenkz_kernel_ro_vy_tl
+\tl_new:N \l__tenkz_kernel_ro_apply_x_tl
+\tl_new:N \l__tenkz_kernel_ro_apply_y_tl
 \prop_new:N \l__tenkz_kernel_ro_lane_prop    % wire id -> lane coordinate
-\prop_new:N \l__tenkz_kernel_ro_box_prop     % wire id -> {x}{xb}{y}{yb}{tau}
-\prop_new:N \l__tenkz_kernel_ro_legs_prop    % leg path id -> {{lane}{tau}},...
+\prop_new:N \l__tenkz_kernel_ro_box_prop     % id -> {u}{ub}{v}{vb}{E}{N}
+\prop_new:N \l__tenkz_kernel_ro_legs_prop    % leg id -> {{lane}{gx}{gy}},...
 \prop_new:N \l__tenkz_kernel_ro_taken_prop   % side | selector -> next lane
 \prop_new:N \l__tenkz_kernel_ro_family_prop  % side | selector -> string ids
 
-% A route stands in the axes of the selection it travels, which is the rule a
-% contour over that same selection already obeys: a quantity measured against
-% a record is measured in that record's axes.  Its box, its lane and the ends
-% it compares against them are therefore held in those axes and carried to the
-% page at the last moment, through the one carry the axes rule owns -- taken
-% forward here and backward below.  At zero turn either is the identity, token
-% for token, which is why a flat picture does not know this section exists.
-\cs_new_protected:Npn \__tenkz_kernel_ro_unturn:NN #1#2
+% A route stands in the complete E,N basis of the selection it travels.  Its
+% box, lane, and endpoint comparisons stay in those coordinates until the
+% final carry to the page.  This state boundary preserves shear; a scalar turn
+% cannot.
+\cs_new_protected:Npn \__tenkz_kernel_ro_basis_apply:NN #1#2
   {
-    \tl_set_eq:NN \l__tenkz_kernel_r_tau_tl \l__tenkz_kernel_ro_tau_tl
-    \__tenkz_kernel_r_unturn:NN #1#2
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      { \l__tenkz_kernel_ro_ex_tl } { \l__tenkz_kernel_ro_ey_tl }
+      { \l__tenkz_kernel_ro_nx_tl } { \l__tenkz_kernel_ro_ny_tl }
+      {#1}{#2}
+      \l__tenkz_kernel_ro_apply_x_tl \l__tenkz_kernel_ro_apply_y_tl
+    \fp_set:Nn #1 { \l__tenkz_kernel_ro_apply_x_tl }
+    \fp_set:Nn #2 { \l__tenkz_kernel_ro_apply_y_tl }
   }
 % a pair already on the page, read in the route's axes
-\cs_new_protected:Npn \__tenkz_kernel_ro_turn:NN #1#2
+\cs_new_protected:Npn \__tenkz_kernel_ro_basis_unapply:NN #1#2
   {
-    \tl_set:Ne \l__tenkz_kernel_r_tau_tl
-      { \fp_eval:n { - \l__tenkz_kernel_ro_tau_tl } }
-    \__tenkz_kernel_r_unturn:NN #1#2
+    \__tenkz_geom_basis_unapply:nnnnnnNN
+      { \l__tenkz_kernel_ro_ex_tl } { \l__tenkz_kernel_ro_ey_tl }
+      { \l__tenkz_kernel_ro_nx_tl } { \l__tenkz_kernel_ro_ny_tl }
+      {#1}{#2}
+      \l__tenkz_kernel_ro_apply_x_tl \l__tenkz_kernel_ro_apply_y_tl
+    \fp_set:Nn #1 { \l__tenkz_kernel_ro_apply_x_tl }
+    \fp_set:Nn #2 { \l__tenkz_kernel_ro_apply_y_tl }
   }
 
 \msg_new:nnn {tenkz}{kernel-route-noroute}
@@ -4974,8 +5086,15 @@
           \l__tenkz_kernel_ro_mem_seq \l__tenkz_kernel_ro_obst_seq
         \__tenkz_kernel_hull_scale:NN
           \l__tenkz_kernel_ro_mem_seq \l__tenkz_kernel_ro_scale_tl
-        \__tenkz_kernel_hull_turn:NN
-          \l__tenkz_kernel_ro_mem_seq \l__tenkz_kernel_ro_tau_tl
+        \__tenkz_kernel_hull_basis:NNNNN
+          \l__tenkz_kernel_ro_mem_seq
+          \l__tenkz_kernel_ro_ex_tl \l__tenkz_kernel_ro_ey_tl
+          \l__tenkz_kernel_ro_nx_tl \l__tenkz_kernel_ro_ny_tl
+        \__tenkz_geom_basis_dual:nnnnNNNN
+          { \l__tenkz_kernel_ro_ex_tl } { \l__tenkz_kernel_ro_ey_tl }
+          { \l__tenkz_kernel_ro_nx_tl } { \l__tenkz_kernel_ro_ny_tl }
+          \l__tenkz_kernel_ro_ux_tl \l__tenkz_kernel_ro_uy_tl
+          \l__tenkz_kernel_ro_vx_tl \l__tenkz_kernel_ro_vy_tl
         % Only the complete generated lane is model-proven disjoint from its
         % siblings.  An address-bearing route adds arbitrary segments between
         % its endpoints and the hull, and those segments still need geometric
@@ -5017,21 +5136,28 @@
               }
           }
         \__tenkz_kernel_r_route_lane_take:
-        \__tenkz_kernel_r_route_edge:nnN
-          { \l__tenkz_kernel_ro_tau_tl       } { } \l__tenkz_kernel_ro_xb_fp
-        \__tenkz_kernel_r_route_edge:nnN
-          { \l__tenkz_kernel_ro_tau_tl + 90  } { } \l__tenkz_kernel_ro_yb_fp
-        \__tenkz_kernel_r_route_edge:nnN
-          { \l__tenkz_kernel_ro_tau_tl + 180 } {-} \l__tenkz_kernel_ro_x_fp
-        \__tenkz_kernel_r_route_edge:nnN
-          { \l__tenkz_kernel_ro_tau_tl + 270 } {-} \l__tenkz_kernel_ro_y_fp
+        \__tenkz_kernel_r_route_edge:nnnN
+          { \l__tenkz_kernel_ro_ux_tl }
+          { \l__tenkz_kernel_ro_uy_tl } { } \l__tenkz_kernel_ro_xb_fp
+        \__tenkz_kernel_r_route_edge:nnnN
+          { \l__tenkz_kernel_ro_vx_tl }
+          { \l__tenkz_kernel_ro_vy_tl } { } \l__tenkz_kernel_ro_yb_fp
+        \__tenkz_kernel_r_route_edge:nnnN
+          { -\l__tenkz_kernel_ro_ux_tl }
+          { -\l__tenkz_kernel_ro_uy_tl } {-} \l__tenkz_kernel_ro_x_fp
+        \__tenkz_kernel_r_route_edge:nnnN
+          { -\l__tenkz_kernel_ro_vx_tl }
+          { -\l__tenkz_kernel_ro_vy_tl } {-} \l__tenkz_kernel_ro_y_fp
         \prop_put:Nne \l__tenkz_kernel_ro_box_prop {#1}
           {
             { \fp_eval:n { \l__tenkz_kernel_ro_x_fp  } }
             { \fp_eval:n { \l__tenkz_kernel_ro_xb_fp } }
             { \fp_eval:n { \l__tenkz_kernel_ro_y_fp  } }
             { \fp_eval:n { \l__tenkz_kernel_ro_yb_fp } }
-            { \tl_use:N  \l__tenkz_kernel_ro_tau_tl  }
+            { \tl_use:N  \l__tenkz_kernel_ro_ex_tl  }
+            { \tl_use:N  \l__tenkz_kernel_ro_ey_tl  }
+            { \tl_use:N  \l__tenkz_kernel_ro_nx_tl  }
+            { \tl_use:N  \l__tenkz_kernel_ro_ny_tl  }
           }
         \prop_put:Nne \l__tenkz_kernel_ro_lane_prop {#1}
           {
@@ -5050,17 +5176,18 @@
       }
   }
 % one edge of the offset hull, pushed out by the lanes already standing there
-\cs_new_protected:Npn \__tenkz_kernel_r_route_edge:nnN #1#2#3
+\cs_new_protected:Npn \__tenkz_kernel_r_route_edge:nnnN #1#2#3#4
   {
     % one clearance is the hull's own, the next is this route's, and one more
     % for every route already standing over the same selection
-    \__tenkz_kernel_hull_reach:NnnN \l__tenkz_kernel_ro_obst_seq {#1}
+    \__tenkz_kernel_hull_reach_linear:NnnnN
+      \l__tenkz_kernel_ro_obst_seq {#1}{#2}
       {
         ( \l__tenkz_kernel_ro_lane_tl + 2 )
         * \__tenkz_metric_ratio:n {daylight} * \l__tenkz_kernel_ro_scale_tl
       }
       \l__tenkz_kernel_ro_reach_tl
-    \fp_set:Nn #3 { #2 \l__tenkz_kernel_ro_reach_tl }
+    \fp_set:Nn #4 { #3 \l__tenkz_kernel_ro_reach_tl }
   }
 
 % `crossing of a and b` is where the two strings actually meet, so the
@@ -6088,7 +6215,7 @@
             \clist_map_inline:Vn \l__tenkz_kernel_leg_reach_tl
               {
                 \tl_set:Nn \l__tenkz_kernel_ro_row_tl {##1}
-                \exp_last_unbraced:NV \__tenkz_kernel_r_leg_lane:nn
+                \exp_last_unbraced:NV \__tenkz_kernel_r_leg_lane:nnn
                   \l__tenkz_kernel_ro_row_tl
               }
           }
@@ -6137,18 +6264,18 @@
           }
       }
   }
-% How far along its own direction a leg must run to meet a route's lane: #1
-% the lane, #2 the axes it was measured in.  The lane is a coordinate along
-% the route's north, so the gap between this atom and it is measured across
-% that same north, and the leg spends only as much of its length crossing that
-% gap as its direction lies along it.  Down the page, over a flat selection,
-% both readings are the old vertical delta.  A leg lying in the lane's own
-% line never meets it however far it runs, and is left at its natural length
-% for the crossing police to refuse.
-\cs_new_protected:Npn \__tenkz_kernel_r_leg_lane:nn #1#2
+% How far along its own page direction a leg must run to meet a route lane.
+% #1 is the lane coordinate and (#2,#3) is the dual-basis covector which reads
+% that coordinate.  This line/covector intersection is valid for rotation,
+% shear, and unequal scale alike.
+\cs_new_protected:Npn \__tenkz_kernel_r_leg_lane:nnn #1#2#3
   {
     \fp_compare:nNnF
-      { cosd( \l__tenkz_kernel_leg_dir_tl - (#2) - 90 ) } = {0}
+      {
+        (#2) * cosd( \l__tenkz_kernel_leg_dir_tl )
+        + (#3) * sind( \l__tenkz_kernel_leg_dir_tl )
+      }
+      = {0}
       {
         \fp_set:Nn \l__tenkz_kernel_r_reach_fp
           {
@@ -6156,9 +6283,13 @@
                  abs
                    (
                      ( (#1)
-                       - \l__tenkz_kernel_r_x_fp * cosd( (#2) + 90 )
-                       - \l__tenkz_kernel_r_y_fp * sind( (#2) + 90 ) )
-                     / cosd( \l__tenkz_kernel_leg_dir_tl - (#2) - 90 )
+                       - (#2) * \l__tenkz_kernel_r_x_fp
+                       - (#3) * \l__tenkz_kernel_r_y_fp )
+                     /
+                     (
+                       (#2) * cosd( \l__tenkz_kernel_leg_dir_tl )
+                       + (#3) * sind( \l__tenkz_kernel_leg_dir_tl )
+                     )
                    )
                  + \__tenkz_metric_ratio:n {legcrossclear} )
           }
@@ -6299,7 +6430,7 @@
             % a south leg chase its north edge.
             \prop_get:NnN \l__tenkz_kernel_ro_box_prop {##1}
               \l__tenkz_kernel_ro_b_tl
-            \exp_last_unbraced:NV \__tenkz_kernel_r_route_box:nnnnn
+            \exp_last_unbraced:NV \__tenkz_kernel_r_route_box:nnnnnnnn
               \l__tenkz_kernel_ro_b_tl
             \seq_map_inline:Nn \l__tenkz_kernel_ro_leg_seq
               { \__tenkz_kernel_r_route_leg:nn {####1} {##1} }
@@ -6336,12 +6467,40 @@
             \tl_set:Ne \l__tenkz_kernel_ro_lane_tl
               { \fp_eval:n { \l__tenkz_kernel_ro_y_fp } }
           }
+        {e}
+          {
+            \tl_set:Ne \l__tenkz_kernel_ro_lane_tl
+              { \fp_eval:n { \l__tenkz_kernel_ro_xb_fp } }
+          }
+        {w}
+          {
+            \tl_set:Ne \l__tenkz_kernel_ro_lane_tl
+              { \fp_eval:n { \l__tenkz_kernel_ro_x_fp } }
+          }
+      }
+    \str_case:VnTF \l__tenkz_kernel_ro_side_tl
+      {
+        {n}{}
+        {s}{}
+      }
+      {
+        \tl_set_eq:NN \l__tenkz_kernel_ro_gx_tl
+          \l__tenkz_kernel_ro_vx_tl
+        \tl_set_eq:NN \l__tenkz_kernel_ro_gy_tl
+          \l__tenkz_kernel_ro_vy_tl
+      }
+      {
+        \tl_set_eq:NN \l__tenkz_kernel_ro_gx_tl
+          \l__tenkz_kernel_ro_ux_tl
+        \tl_set_eq:NN \l__tenkz_kernel_ro_gy_tl
+          \l__tenkz_kernel_ro_uy_tl
       }
     \tl_set:Ne \l__tenkz_kernel_ro_row_tl
       {
         {
           { \tl_use:N \l__tenkz_kernel_ro_lane_tl }
-          { \tl_use:N \l__tenkz_kernel_ro_tau_tl  }
+          { \tl_use:N \l__tenkz_kernel_ro_gx_tl }
+          { \tl_use:N \l__tenkz_kernel_ro_gy_tl }
         }
       }
     \prop_get:NVN \l__tenkz_kernel_ro_legs_prop
@@ -6677,7 +6836,7 @@
     \prop_get:NnN \l__tenkz_kernel_ro_lane_prop {#1}
       \l__tenkz_kernel_ro_lane_tl
     \prop_get:NnN \l__tenkz_kernel_ro_box_prop {#1} \l__tenkz_kernel_ro_b_tl
-    \exp_last_unbraced:NV \__tenkz_kernel_r_route_box:nnnnn
+    \exp_last_unbraced:NV \__tenkz_kernel_r_route_box:nnnnnnnn
       \l__tenkz_kernel_ro_b_tl
     \tl_clear:N \l__tenkz_kernel_r_from_tl
     \tl_clear:N \l__tenkz_kernel_r_to_tl
@@ -6711,20 +6870,28 @@
   }
 % the measured hull box, and the axes it was measured in, back into the route
 % registers
-\cs_new_protected:Npn \__tenkz_kernel_r_route_box:nnnnn #1#2#3#4#5
+\cs_new_protected:Npn \__tenkz_kernel_r_route_box:nnnnnnnn
+    #1#2#3#4#5#6#7#8
   {
     \fp_set:Nn \l__tenkz_kernel_ro_x_fp  {#1}
     \fp_set:Nn \l__tenkz_kernel_ro_xb_fp {#2}
     \fp_set:Nn \l__tenkz_kernel_ro_y_fp  {#3}
     \fp_set:Nn \l__tenkz_kernel_ro_yb_fp {#4}
-    \tl_set:Nn \l__tenkz_kernel_ro_tau_tl {#5}
+    \tl_set:Nn \l__tenkz_kernel_ro_ex_tl {#5}
+    \tl_set:Nn \l__tenkz_kernel_ro_ey_tl {#6}
+    \tl_set:Nn \l__tenkz_kernel_ro_nx_tl {#7}
+    \tl_set:Nn \l__tenkz_kernel_ro_ny_tl {#8}
+    \__tenkz_geom_basis_dual:nnnnNNNN
+      {#5}{#6}{#7}{#8}
+      \l__tenkz_kernel_ro_ux_tl \l__tenkz_kernel_ro_uy_tl
+      \l__tenkz_kernel_ro_vx_tl \l__tenkz_kernel_ro_vy_tl
   }
 % one point of the arc, named in the route's axes and carried to the page
 \cs_new_protected:Npn \__tenkz_kernel_r_route_pt:nn #1#2
   {
     \fp_set:Nn \l__tenkz_kernel_ro_u_fp {#1}
     \fp_set:Nn \l__tenkz_kernel_ro_v_fp {#2}
-    \__tenkz_kernel_ro_unturn:NN
+    \__tenkz_kernel_ro_basis_apply:NN
       \l__tenkz_kernel_ro_u_fp \l__tenkz_kernel_ro_v_fp
     \tl_put_right:Ne \l__tenkz_kernel_r_pts_tl
       {
@@ -6821,7 +6988,7 @@
       { \tl_set:Nn #2 {0} }
       {
         \exp_args:Ne \__tenkz_kernel_r_point_fp:n { \tl_item:Nn #1 {1} }
-        \__tenkz_kernel_ro_turn:NN
+        \__tenkz_kernel_ro_basis_unapply:NN
           \l__tenkz_kernel_r_xc_fp \l__tenkz_kernel_r_yc_fp
         \tl_set:Ne #2
           {
@@ -8516,6 +8683,25 @@
       }
   }
 
+\cs_new_protected:Npn \__tenkz_kernel_r_hull_point_add:nn #1#2
+  {
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      { \l__tenkz_kernel_hull_ex_tl }
+      { \l__tenkz_kernel_hull_ey_tl }
+      { \l__tenkz_kernel_hull_nx_tl }
+      { \l__tenkz_kernel_hull_ny_tl }
+      {#1}{#2}
+      \l__tenkz_kernel_ro_apply_x_tl \l__tenkz_kernel_ro_apply_y_tl
+    \tl_if_empty:NF \l__tenkz_kernel_r_pts_tl
+      { \tl_put_right:Nn \l__tenkz_kernel_r_pts_tl { -- } }
+    \tl_put_right:Ne \l__tenkz_kernel_r_pts_tl
+      {
+        \__tenkz_kernel_r_pair:nn
+          { \l__tenkz_kernel_ro_apply_x_tl }
+          { \l__tenkz_kernel_ro_apply_y_tl }
+      }
+  }
+
 % An enclosure strokes the offset hull of what it selects, in the axes its
 % selection stands in.  The four supports are taken along those axes and the
 % contour is stroked in them, so a mark over turned records is turned with
@@ -8526,8 +8712,11 @@
     \__tenkz_kernel_mark_members:nN {#1} \l__tenkz_kernel_sel_seq
     \__tenkz_kernel_hull_obstacles:NN
       \l__tenkz_kernel_sel_seq \l__tenkz_kernel_sel_obst_seq
-    \__tenkz_kernel_hull_turn:NN \l__tenkz_kernel_sel_seq
-      \l__tenkz_kernel_r_tau_tl
+    \__tenkz_kernel_hull_basis:NNNNN
+      \l__tenkz_kernel_sel_seq
+      \l__tenkz_kernel_hull_ex_tl \l__tenkz_kernel_hull_ey_tl
+      \l__tenkz_kernel_hull_nx_tl \l__tenkz_kernel_hull_ny_tl
+    \__tenkz_kernel_hull_basis_dual:
     % A contour clears its members by one clearance.  It is one clearance for
     % every selection: what differs between a row of labelled sites and four
     % bare spins is the members' own silhouettes, which already carry their
@@ -8535,59 +8724,56 @@
     \__tenkz_kernel_hull_scale:NN \l__tenkz_kernel_sel_seq \l__tenkz_kernel_sel_tl
     \fp_set:Nn \l__tenkz_kernel_r_reach_fp
       { \__tenkz_metric_ratio:n {daylight} * \l__tenkz_kernel_sel_tl }
-    \__tenkz_kernel_hull_reach:NnnN \l__tenkz_kernel_sel_obst_seq
-      { \l__tenkz_kernel_r_tau_tl }
+    \__tenkz_kernel_hull_reach_linear:NnnnN
+      \l__tenkz_kernel_sel_obst_seq
+      { \l__tenkz_kernel_hull_ux_tl }
+      { \l__tenkz_kernel_hull_uy_tl }
       { \l__tenkz_kernel_r_reach_fp } \l__tenkz_kernel_r_xb_tl
-    \__tenkz_kernel_hull_reach:NnnN \l__tenkz_kernel_sel_obst_seq
-      { \l__tenkz_kernel_r_tau_tl + 180 }
+    \__tenkz_kernel_hull_reach_linear:NnnnN
+      \l__tenkz_kernel_sel_obst_seq
+      { -\l__tenkz_kernel_hull_ux_tl }
+      { -\l__tenkz_kernel_hull_uy_tl }
       { \l__tenkz_kernel_r_reach_fp } \l__tenkz_kernel_r_x_tl
-    \__tenkz_kernel_hull_reach:NnnN \l__tenkz_kernel_sel_obst_seq
-      { \l__tenkz_kernel_r_tau_tl + 90 }
+    \tl_set:Ne \l__tenkz_kernel_r_x_tl
+      { \fp_eval:n { -\l__tenkz_kernel_r_x_tl } }
+    \__tenkz_kernel_hull_reach_linear:NnnnN
+      \l__tenkz_kernel_sel_obst_seq
+      { \l__tenkz_kernel_hull_vx_tl }
+      { \l__tenkz_kernel_hull_vy_tl }
       { \l__tenkz_kernel_r_reach_fp } \l__tenkz_kernel_r_yb_tl
-    \__tenkz_kernel_hull_reach:NnnN \l__tenkz_kernel_sel_obst_seq
-      { \l__tenkz_kernel_r_tau_tl + 270 }
+    \__tenkz_kernel_hull_reach_linear:NnnnN
+      \l__tenkz_kernel_sel_obst_seq
+      { -\l__tenkz_kernel_hull_vx_tl }
+      { -\l__tenkz_kernel_hull_vy_tl }
       { \l__tenkz_kernel_r_reach_fp } \l__tenkz_kernel_r_y_tl
-    % the contour's own centre, carried back to the page through its axes
+    \tl_set:Ne \l__tenkz_kernel_r_y_tl
+      { \fp_eval:n { -\l__tenkz_kernel_r_y_tl } }
+    % The centre is formed in local coordinates and carried through both
+    % basis vectors.
     \fp_set:Nn \l__tenkz_kernel_r_xc_fp
-      { ( \l__tenkz_kernel_r_xb_tl - \l__tenkz_kernel_r_x_tl ) / 2 }
+      { ( \l__tenkz_kernel_r_xb_tl + \l__tenkz_kernel_r_x_tl ) / 2 }
     \fp_set:Nn \l__tenkz_kernel_r_yc_fp
-      { ( \l__tenkz_kernel_r_yb_tl - \l__tenkz_kernel_r_y_tl ) / 2 }
-    \__tenkz_kernel_r_unturn:NN
-      \l__tenkz_kernel_r_xc_fp \l__tenkz_kernel_r_yc_fp
+      { ( \l__tenkz_kernel_r_yb_tl + \l__tenkz_kernel_r_y_tl ) / 2 }
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      { \l__tenkz_kernel_hull_ex_tl }
+      { \l__tenkz_kernel_hull_ey_tl }
+      { \l__tenkz_kernel_hull_nx_tl }
+      { \l__tenkz_kernel_hull_ny_tl }
+      { \l__tenkz_kernel_r_xc_fp } { \l__tenkz_kernel_r_yc_fp }
+      \l__tenkz_kernel_ro_apply_x_tl \l__tenkz_kernel_ro_apply_y_tl
     \fp_set:Nn \l__tenkz_kernel_r_x_fp
-      {
-        \l__tenkz_kernel_r_xc_fp
-        - ( \l__tenkz_kernel_r_xb_tl + \l__tenkz_kernel_r_x_tl ) / 2
-      }
-    \fp_set:Nn \l__tenkz_kernel_r_xb_fp
-      {
-        \l__tenkz_kernel_r_xc_fp
-        + ( \l__tenkz_kernel_r_xb_tl + \l__tenkz_kernel_r_x_tl ) / 2
-      }
+      { \l__tenkz_kernel_ro_apply_x_tl }
     \fp_set:Nn \l__tenkz_kernel_r_y_fp
-      {
-        \l__tenkz_kernel_r_yc_fp
-        - ( \l__tenkz_kernel_r_yb_tl + \l__tenkz_kernel_r_y_tl ) / 2
-      }
-    \fp_set:Nn \l__tenkz_kernel_r_yb_fp
-      {
-        \l__tenkz_kernel_r_yc_fp
-        + ( \l__tenkz_kernel_r_yb_tl + \l__tenkz_kernel_r_y_tl ) / 2
-      }
-    % the turn is an option on the stroke, not a second path spelling
-    \tl_clear:N \l__tenkz_kernel_r_turnopt_tl
-    \fp_compare:nNnF { \l__tenkz_kernel_r_tau_tl } = {0}
-      {
-        \tl_set:Ne \l__tenkz_kernel_r_turnopt_tl
-          {
-            % the engine's own separator is a catcode-12 colon, which this
-            % syntax spells only through the string constant
-            , rotate~around = {
-              \fp_eval:n { \l__tenkz_kernel_r_tau_tl } \c_colon_str
-              \__tenkz_kernel_r_pair:nn
-                { \l__tenkz_kernel_r_xc_fp } { \l__tenkz_kernel_r_yc_fp } }
-          }
-      }
+      { \l__tenkz_kernel_ro_apply_y_tl }
+    \tl_clear:N \l__tenkz_kernel_r_pts_tl
+    \__tenkz_kernel_r_hull_point_add:nn
+      { \l__tenkz_kernel_r_x_tl } { \l__tenkz_kernel_r_y_tl }
+    \__tenkz_kernel_r_hull_point_add:nn
+      { \l__tenkz_kernel_r_xb_tl } { \l__tenkz_kernel_r_y_tl }
+    \__tenkz_kernel_r_hull_point_add:nn
+      { \l__tenkz_kernel_r_xb_tl } { \l__tenkz_kernel_r_yb_tl }
+    \__tenkz_kernel_r_hull_point_add:nn
+      { \l__tenkz_kernel_r_x_tl } { \l__tenkz_kernel_r_yb_tl }
     \__tenkz_model_get:nnN {#1} {species} \l__tenkz_kernel_r_species_tl
     \quark_if_no_value:NTF \l__tenkz_kernel_r_species_tl
       {
@@ -8610,6 +8796,104 @@
           }
       }
       { \__tenkz_kernel_r_hue:nN {#1} \l__tenkz_kernel_r_hue_tl }
+    \__tenkz_geom_frame_if_affine:nTF {kpic}
+      {
+        \bool_if:NTF \l__tenkz_kernel_hull_chart_bool
+          {
+            \__tenkz_render_stroke:en
+              {
+                draw = \tl_use:N \l__tenkz_kernel_r_hue_tl ,
+                line~width = \__tenkz_dim:n {annwidth} ,
+                rounded~corners = \__tenkz_dim:n {corner}
+              }
+              { \tl_use:N \l__tenkz_kernel_r_pts_tl -- cycle }
+          }
+          { \__tenkz_kernel_r_mark_enclosure_orthogonal: }
+      }
+      { \__tenkz_kernel_r_mark_enclosure_orthogonal: }
+    % A label that names no side stands in the middle of what it encloses --
+    % which is where an operator acting on a region belongs.  A label that
+    % names one stands on the contour there.
+    \__tenkz_model_get:nnN {#1} {label-pos} \l__tenkz_kernel_r_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_r_tl
+      { \__tenkz_kernel_r_mark_label_centre:n {#1} }
+      {
+    \tl_set:Ne \l__tenkz_kernel_r_tl
+      { \__tenkz_kernel_r_compass:n { \tl_use:N \l__tenkz_kernel_r_tl } }
+    % the side a label speaks from is a side OF THE CONTOUR, so the step out
+    % to it is taken in the contour's axes and then carried to the page
+    \fp_set:Nn \l__tenkz_kernel_r_xc_fp
+      {
+        cosd( \l__tenkz_kernel_r_tl )
+        * ( \l__tenkz_kernel_r_xb_tl - \l__tenkz_kernel_r_x_tl ) / 2
+      }
+    \fp_set:Nn \l__tenkz_kernel_r_yc_fp
+      {
+        sind( \l__tenkz_kernel_r_tl )
+        * ( \l__tenkz_kernel_r_yb_tl - \l__tenkz_kernel_r_y_tl ) / 2
+      }
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      { \l__tenkz_kernel_hull_ex_tl }
+      { \l__tenkz_kernel_hull_ey_tl }
+      { \l__tenkz_kernel_hull_nx_tl }
+      { \l__tenkz_kernel_hull_ny_tl }
+      { \l__tenkz_kernel_r_xc_fp } { \l__tenkz_kernel_r_yc_fp }
+      \l__tenkz_kernel_ro_apply_x_tl \l__tenkz_kernel_ro_apply_y_tl
+    \fp_set:Nn \l__tenkz_kernel_r_x_fp
+      {
+        \l__tenkz_kernel_r_x_fp + \l__tenkz_kernel_ro_apply_x_tl
+      }
+    \fp_set:Nn \l__tenkz_kernel_r_y_fp
+      {
+        \l__tenkz_kernel_r_y_fp + \l__tenkz_kernel_ro_apply_y_tl
+      }
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      { \l__tenkz_kernel_hull_ex_tl }
+      { \l__tenkz_kernel_hull_ey_tl }
+      { \l__tenkz_kernel_hull_nx_tl }
+      { \l__tenkz_kernel_hull_ny_tl }
+      { cosd(\l__tenkz_kernel_r_tl) }
+      { sind(\l__tenkz_kernel_r_tl) }
+      \l__tenkz_kernel_ro_apply_x_tl \l__tenkz_kernel_ro_apply_y_tl
+    \tl_set:Ne \l__tenkz_kernel_r_tau_tl
+      {
+        \fp_eval:n
+          {
+            atand(
+              \l__tenkz_kernel_ro_apply_y_tl ,
+              \l__tenkz_kernel_ro_apply_x_tl )
+            - \l__tenkz_kernel_r_tl
+          }
+      }
+    \__tenkz_kernel_r_mark_label_ink:n {#1}
+      }
+  }
+% The non-affine fallback deliberately retains the established rotated
+% rectangle spelling.  Circle hulls have an orthonormal mean tangent rather
+% than one affine chart, and preserving their path spelling also keeps their
+% antialiasing stable under the affine refactor.
+\cs_new_protected:Npn \__tenkz_kernel_r_mark_enclosure_orthogonal:
+  {
+    \tl_set:Ne \l__tenkz_kernel_r_tau_tl
+      {
+        \fp_eval:n
+          {
+            atand(
+              \l__tenkz_kernel_hull_ey_tl ,
+              \l__tenkz_kernel_hull_ex_tl )
+          }
+      }
+    \tl_clear:N \l__tenkz_kernel_r_turnopt_tl
+    \fp_compare:nNnF { \l__tenkz_kernel_r_tau_tl } = {0}
+      {
+        \tl_set:Ne \l__tenkz_kernel_r_turnopt_tl
+          {
+            , rotate~around = {
+              \fp_eval:n { \l__tenkz_kernel_r_tau_tl } \c_colon_str
+              \__tenkz_kernel_r_pair:nn
+                { \l__tenkz_kernel_r_x_fp } { \l__tenkz_kernel_r_y_fp } }
+          }
+      }
     \__tenkz_render_stroke:en
       {
         draw = \tl_use:N \l__tenkz_kernel_r_hue_tl ,
@@ -8619,51 +8903,24 @@
       }
       {
         \__tenkz_kernel_r_pair:nn
-          { \l__tenkz_kernel_r_x_fp } { \l__tenkz_kernel_r_y_fp }
+          {
+            \l__tenkz_kernel_r_x_fp
+            - ( \l__tenkz_kernel_r_xb_tl - \l__tenkz_kernel_r_x_tl ) / 2
+          }
+          {
+            \l__tenkz_kernel_r_y_fp
+            - ( \l__tenkz_kernel_r_yb_tl - \l__tenkz_kernel_r_y_tl ) / 2
+          }
         rectangle
         \__tenkz_kernel_r_pair:nn
-          { \l__tenkz_kernel_r_xb_fp } { \l__tenkz_kernel_r_yb_fp }
-      }
-    % A label that names no side stands in the middle of what it encloses --
-    % which is where an operator acting on a region belongs.  A label that
-    % names one stands on the contour there.
-    \__tenkz_model_get:nnN {#1} {label-pos} \l__tenkz_kernel_r_tl
-    \quark_if_no_value:NTF \l__tenkz_kernel_r_tl
-      {
-        \fp_set:Nn \l__tenkz_kernel_r_x_fp
-          { ( \l__tenkz_kernel_r_x_fp + \l__tenkz_kernel_r_xb_fp ) / 2 }
-        \fp_set:Nn \l__tenkz_kernel_r_y_fp
-          { ( \l__tenkz_kernel_r_y_fp + \l__tenkz_kernel_r_yb_fp ) / 2 }
-        \__tenkz_kernel_r_mark_label_centre:n {#1}
-      }
-      {
-    \tl_set:Ne \l__tenkz_kernel_r_tl
-      { \__tenkz_kernel_r_compass:n { \tl_use:N \l__tenkz_kernel_r_tl } }
-    % the side a label speaks from is a side OF THE CONTOUR, so the step out
-    % to it is taken in the contour's axes and then carried to the page
-    \fp_set:Nn \l__tenkz_kernel_r_xc_fp
-      {
-        cosd( \l__tenkz_kernel_r_tl )
-        * ( \l__tenkz_kernel_r_xb_fp - \l__tenkz_kernel_r_x_fp ) / 2
-      }
-    \fp_set:Nn \l__tenkz_kernel_r_yc_fp
-      {
-        sind( \l__tenkz_kernel_r_tl )
-        * ( \l__tenkz_kernel_r_yb_fp - \l__tenkz_kernel_r_y_fp ) / 2
-      }
-    \__tenkz_kernel_r_unturn:NN
-      \l__tenkz_kernel_r_xc_fp \l__tenkz_kernel_r_yc_fp
-    \fp_set:Nn \l__tenkz_kernel_r_x_fp
-      {
-        ( \l__tenkz_kernel_r_x_fp + \l__tenkz_kernel_r_xb_fp ) / 2
-        + \l__tenkz_kernel_r_xc_fp
-      }
-    \fp_set:Nn \l__tenkz_kernel_r_y_fp
-      {
-        ( \l__tenkz_kernel_r_y_fp + \l__tenkz_kernel_r_yb_fp ) / 2
-        + \l__tenkz_kernel_r_yc_fp
-      }
-    \__tenkz_kernel_r_mark_label_ink:n {#1}
+          {
+            \l__tenkz_kernel_r_x_fp
+            + ( \l__tenkz_kernel_r_xb_tl - \l__tenkz_kernel_r_x_tl ) / 2
+          }
+          {
+            \l__tenkz_kernel_r_y_fp
+            + ( \l__tenkz_kernel_r_yb_tl - \l__tenkz_kernel_r_y_tl ) / 2
+          }
       }
   }
 % a centred mark label sits on the paper, not against an edge

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2752,8 +2752,9 @@
 \cs_new:Npn \__tenkz_kernel_r_compass:n #1
   {
     % the argument may arrive as an unexpanded register: compare its string
-    \str_case:en {#1}
+    \str_case:enF {#1}
       { {n}{90} {ne}{45} {e}{0} {se}{315} {s}{270} {sw}{225} {w}{180} {nw}{135} }
+      {#1}
   }
 
 \cs_new_protected:Npn \__tenkz_kernel_r_xy:nNN #1#2#3
@@ -8820,17 +8821,22 @@
       {
     \tl_set:Ne \l__tenkz_kernel_r_tl
       { \__tenkz_kernel_r_compass:n { \tl_use:N \l__tenkz_kernel_r_tl } }
-    % the side a label speaks from is a side OF THE CONTOUR, so the step out
-    % to it is taken in the contour's axes and then carried to the page
+    % A label bearing is a ray from the contour centre.  Meet the local
+    % rectangle boundary first, then carry that boundary point to the page.
+    \__tenkz_geom_rect_ray_reach:nnnN
+      { \l__tenkz_kernel_r_tl }
+      { ( \l__tenkz_kernel_r_xb_tl - \l__tenkz_kernel_r_x_tl ) / 2 }
+      { ( \l__tenkz_kernel_r_yb_tl - \l__tenkz_kernel_r_y_tl ) / 2 }
+      \l__tenkz_kernel_r_reach_tl
     \fp_set:Nn \l__tenkz_kernel_r_xc_fp
       {
         cosd( \l__tenkz_kernel_r_tl )
-        * ( \l__tenkz_kernel_r_xb_tl - \l__tenkz_kernel_r_x_tl ) / 2
+        * \l__tenkz_kernel_r_reach_tl
       }
     \fp_set:Nn \l__tenkz_kernel_r_yc_fp
       {
         sind( \l__tenkz_kernel_r_tl )
-        * ( \l__tenkz_kernel_r_yb_tl - \l__tenkz_kernel_r_y_tl ) / 2
+        * \l__tenkz_kernel_r_reach_tl
       }
     \__tenkz_geom_basis_apply:nnnnnnNN
       { \l__tenkz_kernel_hull_ex_tl }

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -3696,6 +3696,8 @@
 \tl_new:N \l__tenkz_kernel_leg_tl
 \tl_new:N \l__tenkz_kernel_leg_reach_tl
 \tl_new:N \l__tenkz_kernel_leg_dir_tl
+\tl_new:N \l__tenkz_kernel_leg_gx_tl
+\tl_new:N \l__tenkz_kernel_leg_gy_tl
 % A leg asks every contour whether it holds the site the leg grew from, and
 % that question resolves a range through the shared cell registers.  The leg
 % therefore keeps its own cell in registers of its own: read from the shared
@@ -4625,13 +4627,17 @@
       \l__tenkz_kernel_hull_vy_tl
   }
 
-% Maximum local coordinate against one row of the dual basis, padded in the
-% same carrier-local units.
+% Maximum coordinate against one row of the dual basis.  The pad is a page
+% distance, so lift it into covector units by the dual row's Euclidean norm.
 \cs_new_protected:Npn \__tenkz_kernel_hull_reach_linear:NnnnN #1#2#3#4#5
   {
     \__tenkz_geom_support_max_linear:nnnN
       { \cs_to_str:N #1 } {#2} {#3} #5
-    \tl_set:Ne #5 { \fp_eval:n { #5 + (#4) } }
+    \tl_set:Ne #5
+      {
+        \fp_eval:n
+          { #5 + (#4) * sqrt( (#2) ^ 2 + (#3) ^ 2 ) }
+      }
   }
 \tl_new:N \l__tenkz_kernel_r_tau_tl
 \tl_new:N \l__tenkz_kernel_r_turnopt_tl
@@ -6176,27 +6182,65 @@
                         \__tenkz_kernel_hull_scale:NN
                           \l__tenkz_kernel_leg_sel_seq
                           \l__tenkz_kernel_leg_tl
-                        \__tenkz_kernel_hull_reach:NnnN
-                          \l__tenkz_kernel_leg_obst_seq
-                          { \l__tenkz_kernel_leg_dir_tl }
+                        \__tenkz_kernel_hull_basis:NNNNN
+                          \l__tenkz_kernel_leg_sel_seq
+                          \l__tenkz_kernel_hull_ex_tl
+                          \l__tenkz_kernel_hull_ey_tl
+                          \l__tenkz_kernel_hull_nx_tl
+                          \l__tenkz_kernel_hull_ny_tl
+                        \__tenkz_geom_frame_if_affine:nTF {kpic}
                           {
-                            2 * \__tenkz_metric_ratio:n {daylight}
-                            * \l__tenkz_kernel_leg_tl
+                            \bool_if:NTF \l__tenkz_kernel_hull_chart_bool
+                              {
+                                \__tenkz_kernel_hull_basis_dual:
+                                \str_if_eq:nnTF {#2} {n}
+                                  {
+                                    \tl_set_eq:NN
+                                      \l__tenkz_kernel_leg_gx_tl
+                                      \l__tenkz_kernel_hull_vx_tl
+                                    \tl_set_eq:NN
+                                      \l__tenkz_kernel_leg_gy_tl
+                                      \l__tenkz_kernel_hull_vy_tl
+                                  }
+                                  {
+                                    \tl_set:Ne \l__tenkz_kernel_leg_gx_tl
+                                      { -\l__tenkz_kernel_hull_vx_tl }
+                                    \tl_set:Ne \l__tenkz_kernel_leg_gy_tl
+                                      { -\l__tenkz_kernel_hull_vy_tl }
+                                  }
+                                \__tenkz_kernel_hull_reach_linear:NnnnN
+                                  \l__tenkz_kernel_leg_obst_seq
+                                  { \l__tenkz_kernel_leg_gx_tl }
+                                  { \l__tenkz_kernel_leg_gy_tl }
+                                  {
+                                    2 * \__tenkz_metric_ratio:n {daylight}
+                                    * \l__tenkz_kernel_leg_tl
+                                  }
+                                  \l__tenkz_kernel_leg_reach_tl
+                                \fp_set:Nn \l__tenkz_kernel_r_reach_fp
+                                  {
+                                    max(
+                                      \l__tenkz_kernel_r_reach_fp ,
+                                      (
+                                        \l__tenkz_kernel_leg_reach_tl
+                                        - \l__tenkz_kernel_leg_gx_tl
+                                          * \l__tenkz_kernel_r_x_fp
+                                        - \l__tenkz_kernel_leg_gy_tl
+                                          * \l__tenkz_kernel_r_y_fp )
+                                      /
+                                      (
+                                        \l__tenkz_kernel_leg_gx_tl
+                                          * cosd(
+                                              \l__tenkz_kernel_leg_dir_tl )
+                                        + \l__tenkz_kernel_leg_gy_tl
+                                          * sind(
+                                              \l__tenkz_kernel_leg_dir_tl )
+                                      ) )
+                                  }
+                              }
+                              { \__tenkz_kernel_r_leg_enclosure_orthogonal: }
                           }
-                          \l__tenkz_kernel_leg_reach_tl
-                        % how far the contour stands from this atom ALONG THE
-                        % LEG: the hull's reach that way less the atom's own
-                        % reach that way, which is the projection of where it
-                        % stands onto the direction it leaves in
-                        \fp_set:Nn \l__tenkz_kernel_r_reach_fp
-                          {
-                            max( \l__tenkz_kernel_r_reach_fp ,
-                                 \l__tenkz_kernel_leg_reach_tl
-                                 - ( \l__tenkz_kernel_r_x_fp
-                                       * cosd( \l__tenkz_kernel_leg_dir_tl )
-                                     + \l__tenkz_kernel_r_y_fp
-                                       * sind( \l__tenkz_kernel_leg_dir_tl ) ) )
-                          }
+                          { \__tenkz_kernel_r_leg_enclosure_orthogonal: }
                       }
                   }
               }
@@ -6263,6 +6307,29 @@
               }
               { \tl_use:N \l__tenkz_kernel_r_b_tl }
           }
+      }
+  }
+% Circle and mixed-carrier contours retain their established orthogonal
+% support reach; they do not claim one common affine chart.
+\cs_new_protected:Npn \__tenkz_kernel_r_leg_enclosure_orthogonal:
+  {
+    \__tenkz_kernel_hull_reach:NnnN
+      \l__tenkz_kernel_leg_obst_seq
+      { \l__tenkz_kernel_leg_dir_tl }
+      {
+        2 * \__tenkz_metric_ratio:n {daylight}
+        * \l__tenkz_kernel_leg_tl
+      }
+      \l__tenkz_kernel_leg_reach_tl
+    \fp_set:Nn \l__tenkz_kernel_r_reach_fp
+      {
+        max(
+          \l__tenkz_kernel_r_reach_fp ,
+          \l__tenkz_kernel_leg_reach_tl
+          - \l__tenkz_kernel_r_x_fp
+            * cosd( \l__tenkz_kernel_leg_dir_tl )
+          - \l__tenkz_kernel_r_y_fp
+            * sind( \l__tenkz_kernel_leg_dir_tl ) )
       }
   }
 % How far along its own page direction a leg must run to meet a route lane.

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -4641,23 +4641,6 @@
   }
 \tl_new:N \l__tenkz_kernel_r_tau_tl
 \tl_new:N \l__tenkz_kernel_r_turnopt_tl
-\fp_new:N \l__tenkz_kernel_r_unturn_fp
-% A pair held in the axes of \l__tenkz_kernel_r_tau_tl, carried back to the
-% page in place.  At zero turn it is the identity, token for token.
-\cs_new_protected:Npn \__tenkz_kernel_r_unturn:NN #1#2
-  {
-    \fp_set:Nn \l__tenkz_kernel_r_unturn_fp
-      {
-        #1 * cosd( \l__tenkz_kernel_r_tau_tl )
-        - #2 * sind( \l__tenkz_kernel_r_tau_tl )
-      }
-    \fp_set:Nn #2
-      {
-        #1 * sind( \l__tenkz_kernel_r_tau_tl )
-        + #2 * cosd( \l__tenkz_kernel_r_tau_tl )
-      }
-    \fp_set_eq:NN #1 \l__tenkz_kernel_r_unturn_fp
-  }
 
 % the hull's support along #2 degrees, padded by #3, over the obstacle seq #1
 \cs_new_protected:Npn \__tenkz_kernel_hull_reach:NnnN #1#2#3#4


### PR DESCRIPTION
## What changed

- add shared carrier-basis apply, inverse, dual-covector, and linear-support geometry primitives
- keep hull and enclosure bounds in complete east/north coordinates, then project their corners through both basis vectors
- store side-route boxes as local bounds plus the complete basis instead of a scalar turn
- carry route/physical-leg intersections by the lane's dual covector
- retain the established orthogonal circle fallback and byte-identical flat/circle pixels
- add sheared plane regressions, route-state regressions, and singular-basis rejection

## Root cause

Hull and side-route consumers reduced a carrier to one turn angle. That representation can encode rotation but necessarily discards shear and unequal scale, so plane-frame projections could place atoms correctly while their enclosures and routes remained only partially projected.

This moves the shared hull/route boundary to full affine basis state. It deliberately does not claim that glyph skins, boundary signatures, cluster offsets, or every address-label carrier are complete; those remain separate consumers under LionSR/tenkz#113.

Advances LionSR/tenkz#113.

## Validation

- `scripts/tenkz_kernel_probes.sh --check` — 48 regressions, 8 sugar equivalences, 12 record streams, byte-identical pixel pins
- `python3 scripts/tenkz_language.py check` — 226 records
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — census 200, all 132 flags carry verdicts
- `scripts/tenkz_corpus.sh` — 264 standalone files compiled and audited
- `python3 scripts/tenkz_rmp.py check --all` — 130 targets; 32 faithful, 98 cosmetic-gap, 0 structural/unfaithful/blocked
- `python3 scripts/tenkz_lint.py ...` — changed regression sources clean
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large refactor of hull/route/enclosure math in the rendering kernel; behavior is heavily regression-tested (including pixel pins) but wrong basis math would misplace wires and marks on sheared plane frames.
> 
> **Overview**
> Hull enclosures, side routes, and leg–lane intersections no longer collapse a carrier to a single **turn angle**; they keep a full **east/north basis** (including shear from `frame=plane`) and use **dual covectors** for support reach and lane matching.
> 
> **Geometry** adds shared `__tenkz_geom_basis_*` apply/inverse/dual helpers, linear support folding, rectangle ray reach, and `[TKZ-GEOM-SINGULAR-BASIS]` when the basis determinant is zero.
> 
> **Kernel** stores route boxes as local bounds plus **E/N basis vectors** (not `tau`), projects route points through the basis, strokes affine enclosures as **four page corners** instead of a rotated axis-aligned rectangle, and keeps an **orthogonal fallback** for circle/mixed carriers. Leg metadata becomes `{lane}{gx}{gy}` instead of `{lane}{tau}`; east/west route legs are enrolled like north/south.
> 
> **Tests** add sheared-plane regression `r_affine_hull_routes`, singular-basis negative `n_geom_singular_basis`, and update route leg regressions; the kernel probe script gates the new negative.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fbdde224e1786b1c631cd01b92d53fd8816af19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->