### PR TITLE
fix(tenkz): project affine offsets and open rays

### DIFF
--- a/tests/tenkz/kernel/regression/r_affine_cluster.tex
+++ b/tests/tenkz/kernel/regression/r_affine_cluster.tex
@@ -1,0 +1,66 @@
+% Regression: cluster-member offsets pass through both vectors of an affine
+% carrier basis.  A scalar parent turn cannot reproduce the plane shear.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\bool_new:N \l__tenkz_test_cluster_checked_bool
+\tl_new:N \l__tenkz_test_cluster_name_tl
+\tl_new:N \l__tenkz_test_cluster_parent_tl
+\fp_new:N \l__tenkz_test_cluster_x_fp
+\fp_new:N \l__tenkz_test_cluster_y_fp
+\fp_new:N \l__tenkz_test_cluster_parent_x_fp
+\fp_new:N \l__tenkz_test_cluster_parent_y_fp
+\cs_new_eq:NN
+  \__tenkz_test_cluster_atom_ink:n
+  \__tenkz_kernel_r_atom_ink:n
+\cs_set_protected:Npn \__tenkz_kernel_r_atom_ink:n #1
+  {
+    \__tenkz_model_get:nnN {#1} {cluster-of} \l__tenkz_test_cluster_name_tl
+    \bool_lazy_and:nnT
+      { ! \quark_if_no_value_p:N \l__tenkz_test_cluster_name_tl }
+      { ! \bool_if_p:N \l__tenkz_test_cluster_checked_bool }
+      {
+        \prop_get:NnN \l__tenkz_kernel_named_prop {g}
+          \l__tenkz_test_cluster_parent_tl
+        \__tenkz_kernel_r_xy:nNN {#1}
+          \l__tenkz_test_cluster_x_fp \l__tenkz_test_cluster_y_fp
+        \__tenkz_kernel_r_xy:nNN
+          { \l__tenkz_test_cluster_parent_tl }
+          \l__tenkz_test_cluster_parent_x_fp
+          \l__tenkz_test_cluster_parent_y_fp
+        \fp_compare:nNnF
+          {
+            abs(
+              \l__tenkz_test_cluster_x_fp
+              - \l__tenkz_test_cluster_parent_x_fp
+              + 0.275 * \__tenkz_metric_ratio:n {clusterstep} )
+          }
+          < {0.000001}
+          { \errmessage{cluster~member~lost~the~plane~shear} }
+        \fp_compare:nNnF
+          {
+            abs(
+              \l__tenkz_test_cluster_y_fp
+              - \l__tenkz_test_cluster_parent_y_fp
+              - 0.3 * \__tenkz_metric_ratio:n {clusterstep} )
+          }
+          < {0.000001}
+          { \errmessage{cluster~member~lost~the~plane~rise} }
+        \bool_gset_true:N \l__tenkz_test_cluster_checked_bool
+      }
+    \__tenkz_test_cluster_atom_ink:n {#1}
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=1, frame=plane, bonds=none]
+  \tn[name=g, cluster=2x2]{}
+\end{tenkz}
+\ExplSyntaxOn
+\bool_if:NF \l__tenkz_test_cluster_checked_bool
+  { \errmessage{affine~cluster~fixture~did~not~inspect~its~member} }
+\ExplSyntaxOff
+\end{document}

--- a/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
+++ b/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
@@ -87,6 +87,12 @@
     \__tenkz_geom_rect_ray_reach:nnnN {30}{2}{1} \l_tmpa_tl
     \fp_compare:nNnF { abs(\l_tmpa_tl - 2) } < {0.000001}
       { \errmessage{a~numeric~label~ray~did~not~meet~the~rectangle~edge} }
+    \__tenkz_geom_rect_ray_intersect:nnnnnnnNN
+      {1}{1}{45}{0}{4}{0}{3} \l_tmpa_tl \l_tmpb_tl
+    \fp_compare:nNnF { abs(\l_tmpa_tl - 3) } < {0.000001}
+      { \errmessage{a~diagonal~ray~snapped~to~a~rectangle~corner} }
+    \fp_compare:nNnF { abs(\l_tmpb_tl - 3) } < {0.000001}
+      { \errmessage{a~diagonal~ray~missed~the~first~rectangle~margin} }
     \seq_clear:N \l__tenkz_test_support_seq
     \seq_put_right:Nn \l__tenkz_test_support_seq
       { {circle}{0}{0}{0}{0}{0}{0} }

--- a/tests/tenkz/kernel/regression/r_affine_open_rays.tex
+++ b/tests/tenkz/kernel/regression/r_affine_open_rays.tex
@@ -1,0 +1,91 @@
+%% Regression: diagonal affine open ends follow their logical ray to the
+%% first picture margin instead of snapping to a projected corner.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\tl_new:N \l__tenkz_test_ray_end_row_tl
+\tl_new:N \l__tenkz_test_ray_end_col_tl
+\cs_new_protected:Npn \__tenkz_test_affine_open_ray:nnn #1#2#3
+  {
+    \__tenkz_kernel_r_frame_xy:nnNN {#2}{#3}
+      \l__tenkz_kernel_r_xc_fp \l__tenkz_kernel_r_yc_fp
+    \__tenkz_kernel_r_open_tip_affine_xy:nNN {#1}
+      \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+    \__tenkz_geom_unapply:nnnNN {kpic}
+      { \l__tenkz_kernel_r_x_fp } { \l__tenkz_kernel_r_y_fp }
+      \l__tenkz_test_ray_end_row_tl \l__tenkz_test_ray_end_col_tl
+    \str_case:nn {#1}
+      {
+        {ne}
+          {
+            \fp_compare:nNnF
+              {
+                abs(
+                  \l__tenkz_test_ray_end_row_tl
+                  - (1 - \__tenkz_metric_ratio:n {stub}) )
+              }
+              < {0.000001}
+              { \errmessage{the~northeast~ray~missed~the~north~margin} }
+            \fp_compare:nNnF
+              {
+                abs(
+                  \l__tenkz_test_ray_end_col_tl - (#3)
+                  - (#2) + \l__tenkz_test_ray_end_row_tl )
+              }
+              < {0.000001}
+              { \errmessage{the~northeast~open~end~left~its~logical~ray} }
+            \fp_compare:nNnF
+              { \l__tenkz_test_ray_end_col_tl }
+              < { \l__tenkz_kernel_r_cols_int
+                  + \__tenkz_metric_ratio:n {stub} }
+              { \errmessage{the~northeast~open~end~snapped~to~a~corner} }
+          }
+        {sw}
+          {
+            \fp_compare:nNnF
+              {
+                abs(
+                  \l__tenkz_test_ray_end_row_tl
+                  - \l__tenkz_kernel_r_rows_int
+                  - \__tenkz_metric_ratio:n {stub} )
+              }
+              < {0.000001}
+              { \errmessage{the~southwest~ray~missed~the~south~margin} }
+            \fp_compare:nNnF
+              {
+                abs(
+                  (#3) - \l__tenkz_test_ray_end_col_tl
+                  - \l__tenkz_test_ray_end_row_tl + (#2) )
+              }
+              < {0.000001}
+              { \errmessage{the~southwest~open~end~left~its~logical~ray} }
+            \fp_compare:nNnF
+              { \l__tenkz_test_ray_end_col_tl }
+              > { 1 - \__tenkz_metric_ratio:n {stub} }
+              { \errmessage{the~southwest~open~end~snapped~to~a~corner} }
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_test_affine_open_rays:
+  {
+    \int_set:Nn \l__tenkz_kernel_r_rows_int {3}
+    \int_set:Nn \l__tenkz_kernel_r_cols_int {5}
+    \__tenkz_geom_frame_declare_plane:n {kpic}
+    \__tenkz_test_affine_open_ray:nnn {ne}{2}{2}
+    \__tenkz_test_affine_open_ray:nnn {sw}{2}{4}
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\ExplSyntaxOn
+\__tenkz_test_affine_open_rays:
+\ExplSyntaxOff
+\begin{tenkz}[rows={wire,wire,wire}, cols=5, frame=plane, bonds=none]
+  \tn[at=(2,2), skin=box]{A}
+  \tn[at=(2,4), skin=box]{B}
+  \tnwire[kind=string, route=orth, via={(2,2),(2,4)}]{open ne}{open sw}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -34,6 +34,8 @@
   { [TKZ-GEOM-COMPASS]~no~compass~face~named~'#1';~expected~n,~e,~s,~or~w }
 \msg_new:nnn {tenkz}{geom-singular-basis}
   { [TKZ-GEOM-SINGULAR-BASIS]~a~carrier~basis~must~have~nonzero~determinant }
+\msg_new:nnn {tenkz}{geom-zero-ray}
+  { [TKZ-GEOM-ZERO-RAY]~a~boundary~ray~must~have~a~nonzero~direction }
 
 % ---------- frames ----------------------------------------------------------
 % A frame record is six fp fields (row-major matrix a b / c d, offset dx dy)
@@ -345,6 +347,76 @@
                   }
               }
           }
+      }
+  }
+
+% The first intersection of a ray from an interior point with an
+% axis-aligned rectangle.  Positions and bounds are expressed in one local
+% coordinate system; #3 is the ray angle in that system.
+\tl_new:N \l__tenkz_geom_ray_tx_tl
+\tl_new:N \l__tenkz_geom_ray_ty_tl
+\tl_new:N \l__tenkz_geom_ray_t_tl
+\cs_new_protected:Npn \__tenkz_geom_rect_ray_intersect:nnnnnnnNN
+    #1#2#3#4#5#6#7#8#9
+  {
+    \tl_clear:N \l__tenkz_geom_ray_tx_tl
+    \tl_clear:N \l__tenkz_geom_ray_ty_tl
+    \tl_clear:N \l__tenkz_geom_ray_t_tl
+    \fp_compare:nNnTF { cosd(#3) } > {0}
+      {
+        \tl_set:Ne \l__tenkz_geom_ray_tx_tl
+          { \fp_eval:n { ((#5) - (#1)) / cosd(#3) } }
+      }
+      {
+        \fp_compare:nNnT { cosd(#3) } < {0}
+          {
+            \tl_set:Ne \l__tenkz_geom_ray_tx_tl
+              { \fp_eval:n { ((#4) - (#1)) / cosd(#3) } }
+          }
+      }
+    \fp_compare:nNnTF { sind(#3) } > {0}
+      {
+        \tl_set:Ne \l__tenkz_geom_ray_ty_tl
+          { \fp_eval:n { ((#7) - (#2)) / sind(#3) } }
+      }
+      {
+        \fp_compare:nNnT { sind(#3) } < {0}
+          {
+            \tl_set:Ne \l__tenkz_geom_ray_ty_tl
+              { \fp_eval:n { ((#6) - (#2)) / sind(#3) } }
+          }
+      }
+    \tl_if_empty:NTF \l__tenkz_geom_ray_tx_tl
+      {
+        \tl_if_empty:NTF \l__tenkz_geom_ray_ty_tl
+          {
+            \tl_clear:N #8
+            \tl_clear:N #9
+            \msg_error:nn {tenkz}{geom-zero-ray}
+          }
+          { \tl_set_eq:NN \l__tenkz_geom_ray_t_tl \l__tenkz_geom_ray_ty_tl }
+      }
+      {
+        \tl_if_empty:NTF \l__tenkz_geom_ray_ty_tl
+          { \tl_set_eq:NN \l__tenkz_geom_ray_t_tl \l__tenkz_geom_ray_tx_tl }
+          {
+            \tl_set:Ne \l__tenkz_geom_ray_t_tl
+              {
+                \fp_eval:n
+                  {
+                    min(
+                      \l__tenkz_geom_ray_tx_tl ,
+                      \l__tenkz_geom_ray_ty_tl )
+                  }
+              }
+          }
+      }
+    \tl_if_empty:NF \l__tenkz_geom_ray_t_tl
+      {
+        \tl_set:Ne #8
+          { \fp_eval:n { (#1) + \l__tenkz_geom_ray_t_tl * cosd(#3) } }
+        \tl_set:Ne #9
+          { \fp_eval:n { (#2) + \l__tenkz_geom_ray_t_tl * sind(#3) } }
       }
   }
 

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -549,6 +549,9 @@
 \cs_new_protected:Npn \__tenkz_geom_place_rel:nnnn #1#2#3#4
   { \prop_put:Nnn \l__tenkz_geom_req_prop {#1} { {rel}{#2}{#3}{#4} } }
 \cs_generate_variant:Nn \__tenkz_geom_place_rel:nnnn { nnee, nVee, neee }
+\cs_new_protected:Npn \__tenkz_geom_place_offset:nnnn #1#2#3#4
+  { \prop_put:Nnn \l__tenkz_geom_req_prop {#1} { {offset}{#2}{#3}{#4} } }
+\cs_generate_variant:Nn \__tenkz_geom_place_offset:nnnn { nVee }
 \cs_new_protected:Npn \__tenkz_geom_place_mid:nnn #1#2#3
   { \prop_put:Nnn \l__tenkz_geom_req_prop {#1} { {mid}{#2}{#3}{} } }
 \cs_generate_variant:Nn \__tenkz_geom_place_mid:nnn { nVV, nee }
@@ -614,6 +617,16 @@
                 \__tenkz_geom_store:nnn {#5}
                   { \prop_item:Nn \l__tenkz_geom_x_prop {#2} + (#4) * cosd(#3) }
                   { \prop_item:Nn \l__tenkz_geom_y_prop {#2} + (#4) * sind(#3) }
+              }
+          }
+        {offset}
+          {
+            \__tenkz_geom_need:nN {#2} #6
+            \bool_if:NT #6
+              {
+                \__tenkz_geom_store:nnn {#5}
+                  { \prop_item:Nn \l__tenkz_geom_x_prop {#2} + (#3) }
+                  { \prop_item:Nn \l__tenkz_geom_y_prop {#2} + (#4) }
               }
           }
         {mid}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -3161,7 +3161,14 @@
 % own name carries its (r, c) inside the cluster by construction.  The
 % sub-frame is the parent's, so the step from the parent to the member is
 % taken in the parent's axes: four spins on a turned carrier turn with it
-% rather than staying square to the page.
+% rather than staying square to the page.  The complete basis carries that
+% step: a scalar turn would discard shear and unequal axis scale.
+\tl_new:N \l__tenkz_kernel_cluster_ex_tl
+\tl_new:N \l__tenkz_kernel_cluster_ey_tl
+\tl_new:N \l__tenkz_kernel_cluster_nx_tl
+\tl_new:N \l__tenkz_kernel_cluster_ny_tl
+\tl_new:N \l__tenkz_kernel_cluster_dx_tl
+\tl_new:N \l__tenkz_kernel_cluster_dy_tl
 \cs_new_protected:Npn \__tenkz_kernel_r_cluster_place:n #1
   {
     % parent record id
@@ -3189,20 +3196,39 @@
             - ( \l__tenkz_kernel_r_row_tl + 1 ) / 2 )
         * \__tenkz_metric_ratio:n {clusterstep}
       }
-    \__tenkz_geom_place_rel:nVee {#1} \l__tenkz_kernel_r_b_tl
+    \exp_args:NV \__tenkz_kernel_r_atom_rc:nNNN
+      \l__tenkz_kernel_r_b_tl
+      \l__tenkz_kernel_r_row_tl \l__tenkz_kernel_r_col_tl
+      \l__tenkz_kernel_turn_bool
+    \bool_if:NTF \l__tenkz_kernel_turn_bool
       {
-        \fp_eval:n
-          {
-            atand( \l__tenkz_kernel_r_y_fp , \l__tenkz_kernel_r_x_fp )
-            + \l__tenkz_kernel_turn_tl
-          }
+        \__tenkz_geom_local_basis:nnnNNNN {kpic}
+          { \l__tenkz_kernel_r_row_tl } { \l__tenkz_kernel_r_col_tl }
+          \l__tenkz_kernel_cluster_ex_tl
+          \l__tenkz_kernel_cluster_ey_tl
+          \l__tenkz_kernel_cluster_nx_tl
+          \l__tenkz_kernel_cluster_ny_tl
       }
       {
-        \fp_eval:n
-          {
-            sqrt( \l__tenkz_kernel_r_x_fp ^ 2 + \l__tenkz_kernel_r_y_fp ^ 2 )
-          }
+        \tl_set:Ne \l__tenkz_kernel_cluster_ex_tl
+          { \fp_eval:n { cosd(\l__tenkz_kernel_turn_tl) } }
+        \tl_set:Ne \l__tenkz_kernel_cluster_ey_tl
+          { \fp_eval:n { sind(\l__tenkz_kernel_turn_tl) } }
+        \tl_set:Ne \l__tenkz_kernel_cluster_nx_tl
+          { \fp_eval:n { -sind(\l__tenkz_kernel_turn_tl) } }
+        \tl_set:Ne \l__tenkz_kernel_cluster_ny_tl
+          { \fp_eval:n { cosd(\l__tenkz_kernel_turn_tl) } }
       }
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      { \l__tenkz_kernel_cluster_ex_tl }
+      { \l__tenkz_kernel_cluster_ey_tl }
+      { \l__tenkz_kernel_cluster_nx_tl }
+      { \l__tenkz_kernel_cluster_ny_tl }
+      { \l__tenkz_kernel_r_x_fp } { \l__tenkz_kernel_r_y_fp }
+      \l__tenkz_kernel_cluster_dx_tl \l__tenkz_kernel_cluster_dy_tl
+    \__tenkz_geom_place_offset:nVee {#1} \l__tenkz_kernel_r_b_tl
+      { \l__tenkz_kernel_cluster_dx_tl }
+      { \l__tenkz_kernel_cluster_dy_tl }
   }
 
 % ---------- the address dependency graph --------------------------------------

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -6708,93 +6708,29 @@
     \__tenkz_geom_unapply:nnnNN {kpic}
       { \l__tenkz_kernel_r_xc_fp } { \l__tenkz_kernel_r_yc_fp }
       \l__tenkz_kernel_r_row_tl \l__tenkz_kernel_r_col_tl
+    % A compass word is a logical ray, not a request for a picture corner.
+    % Intersect that ray with the first expanded row/column margin, then
+    % carry the resulting logical point through the complete affine frame.
     \str_case:nn {#1}
       {
-        {n}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_row_tl
-              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
-          }
-        {s}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_row_tl
-              {
-                \fp_eval:n
-                  {
-                    \l__tenkz_kernel_r_rows_int
-                    + \__tenkz_metric_ratio:n {stub}
-                  }
-              }
-          }
-        {w}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_col_tl
-              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
-          }
-        {e}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_col_tl
-              {
-                \fp_eval:n
-                  {
-                    \l__tenkz_kernel_r_cols_int
-                    + \__tenkz_metric_ratio:n {stub}
-                  }
-              }
-          }
-        {nw}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_row_tl
-              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
-            \tl_set:Ne \l__tenkz_kernel_r_col_tl
-              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
-          }
-        {ne}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_row_tl
-              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
-            \tl_set:Ne \l__tenkz_kernel_r_col_tl
-              {
-                \fp_eval:n
-                  {
-                    \l__tenkz_kernel_r_cols_int
-                    + \__tenkz_metric_ratio:n {stub}
-                  }
-              }
-          }
-        {sw}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_row_tl
-              {
-                \fp_eval:n
-                  {
-                    \l__tenkz_kernel_r_rows_int
-                    + \__tenkz_metric_ratio:n {stub}
-                  }
-              }
-            \tl_set:Ne \l__tenkz_kernel_r_col_tl
-              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
-          }
-        {se}
-          {
-            \tl_set:Ne \l__tenkz_kernel_r_row_tl
-              {
-                \fp_eval:n
-                  {
-                    \l__tenkz_kernel_r_rows_int
-                    + \__tenkz_metric_ratio:n {stub}
-                  }
-              }
-            \tl_set:Ne \l__tenkz_kernel_r_col_tl
-              {
-                \fp_eval:n
-                  {
-                    \l__tenkz_kernel_r_cols_int
-                    + \__tenkz_metric_ratio:n {stub}
-                  }
-              }
-          }
+        {n}  { \tl_set:Nn \l__tenkz_kernel_r_b_tl {-90} }
+        {s}  { \tl_set:Nn \l__tenkz_kernel_r_b_tl { 90} }
+        {w}  { \tl_set:Nn \l__tenkz_kernel_r_b_tl {180} }
+        {e}  { \tl_set:Nn \l__tenkz_kernel_r_b_tl {  0} }
+        {nw} { \tl_set:Nn \l__tenkz_kernel_r_b_tl {-135} }
+        {ne} { \tl_set:Nn \l__tenkz_kernel_r_b_tl { -45} }
+        {sw} { \tl_set:Nn \l__tenkz_kernel_r_b_tl { 135} }
+        {se} { \tl_set:Nn \l__tenkz_kernel_r_b_tl {  45} }
       }
+    \__tenkz_geom_rect_ray_intersect:nnnnnnnNN
+      { \l__tenkz_kernel_r_col_tl }
+      { \l__tenkz_kernel_r_row_tl }
+      { \l__tenkz_kernel_r_b_tl }
+      { 1 - \__tenkz_metric_ratio:n {stub} }
+      { \l__tenkz_kernel_r_cols_int + \__tenkz_metric_ratio:n {stub} }
+      { 1 - \__tenkz_metric_ratio:n {stub} }
+      { \l__tenkz_kernel_r_rows_int + \__tenkz_metric_ratio:n {stub} }
+      \l__tenkz_kernel_r_col_tl \l__tenkz_kernel_r_row_tl
     \__tenkz_kernel_r_frame_xy:nnNN
       { \l__tenkz_kernel_r_row_tl } { \l__tenkz_kernel_r_col_tl }
       #2 #3


### PR DESCRIPTION
## Summary

- intersect diagonal open ends with the first logical picture margin before affine projection
- carry cluster-member offsets through the complete carrier east/north basis
- add focused sheared-plane regressions for both shared geometry consumers

This continues LionSR/tenkz#113 without introducing page-unit constants or figure-specific formulas.

## Validation

- `scripts/tenkz_kernel_probes.sh --check` (50 regressions; 8 sugar pairs; 12 record streams; existing pixels byte-identical)
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `scripts/tenkz_corpus.sh` (264 fixtures)
- `python3 scripts/tenkz_rmp.py check --all` (130 targets)
- changed-fixture lint and `git diff --check`

Refs LionSR/tenkz#113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core kernel address resolution and wire open-end geometry on sheared carriers; behavior change is localized to affine frames but affects routing and cluster layout correctness.
> 
> **Overview**
> Fixes **affine plane** behavior where compass open ends and cluster sub-atoms were treated like axis-aligned corners or a single parent rotation, which dropped shear and unequal scale on `frame=plane`.
> 
> **Open wire tips** on affine pictures now map the anchor to logical coordinates, shoot a **logical ray** at the compass angle through the stub-expanded picture bounds via new `__tenkz_geom_rect_ray_intersect`, then map the hit back through the full frame—so diagonals meet the **first margin** on the ray, not a forced corner pair.
> 
> **Cluster member placement** replaces polar `place_rel` from a scalar turn with the parent’s **east/north carrier basis** (`local_basis` or turn-derived basis, then `basis_apply`) and a new **`offset` placement** that adds page deltas from the parent.
> 
> Adds **`geom-zero-ray`** for degenerate rays and regressions for open rays, cluster shear, plus a diagonal intersect check in the hull fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b6a9741848bb8de7365b7709b4345f5ddb2080. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->