### PR TITLE
doc(blueprint): repair stale parent-Hamiltonian cross-references

### DIFF
--- a/blueprint/src/appendix/full_only/ch27_channel_asymptotics.tex
+++ b/blueprint/src/appendix/full_only/ch27_channel_asymptotics.tex
@@ -6,7 +6,8 @@ positivity, trace-preservation, unitality, and trace-adjoint properties of the
 mean-ergodic projections used there, together with the weighted-trace and
 idempotent-retraction results used for fixed-point algebras and Choi--Effros
 absorption. It also records the Gram-matrix unitary-extension criterion used
-in the Chapter 16 Stinespring construction and its zero-extension consequence
+in the Stinespring construction of
+Chapter~\ref{ch:channel_representations} and its zero-extension consequence
 for the fixed-point decomposition.
 
 \section{Preservation under the mean-ergodic projection}


### PR DESCRIPTION
## What changed

- replace the hard-coded "Chapter 16" in the opening paragraph of `blueprint/src/appendix/full_only/ch27_channel_asymptotics.tex` with `Chapter~\ref{ch:channel_representations}`, so the reference tracks chapter renumbering

## Context

Issue #4858 identified two stale cross-references left by the parent-Hamiltonian chapter split of PR #4855:

1. The Hamiltonian-spectral-gap reference in `rem:spectral_hypothesis` (`ch14_correlations.tex`). This was already retargeted to `ch:parent_hamiltonian_commuting_and_gap` by merged PR #4857, which also renamed the intermediate `ch:parent_hamiltonian_gap_and_blocks` chapter out of existence; no further change is needed.
2. The hard-coded "Chapter 16" in `ch27_channel_asymptotics.tex`, fixed here.

A repository-wide search confirms no other internal hard-coded chapter numbers remain under `blueprint/src/` (the remaining `Chapter~N` occurrences are all `\cite` locators into Wolf's lecture notes).

Closes #4858.

https://claude.ai/code/session_01FKPeDfZmey6TpraTXpyqQ8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX cross-reference fix with no runtime or proof logic changes.
> 
> **Overview**
> Fixes a **stale chapter pointer** in `ch27_channel_asymptotics.tex` after the parent-Hamiltonian chapter split: the opening paragraph no longer says “Chapter 16” for the Stinespring construction and instead uses `Chapter~\ref{ch:channel_representations}`, matching the labeled channel-representations chapter elsewhere in the blueprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a7416efe21bb76e5e41fd051e51ef930dd1094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->