### PR TITLE
fix(tenkz): promote three content-level residues out of the cosmetic-gap bar

### DIFF
--- a/docs/tenkz/COSMETIC-GAP-BAR.md
+++ b/docs/tenkz/COSMETIC-GAP-BAR.md
@@ -69,7 +69,7 @@ hash-pinned visual check required before changing a verdict.
 | `rmp-iii-a-proof-three` | K2 | The full fusion stack is present; red operator rails are the house semantic hue. |
 | `rmp-iii-a-ghz-state` | X | The free-form case records no lattice genre or truncation property; migrate it to the carrier-axis/lattice model first. |
 | `rmp-iii-a-ghz-tensor` | K2 | Copy dot versus labelled box and diagonal angle are equivalent house forms. |
-| `rmp-iii-a-hadamard` | X | Its ledger pairing is `wrong-source`; repair and verify the source mapping before judging the explicit label. |
+| `rmp-iii-a-hadamard` | X | Promoted to `structural-gap`: its pairing is `wrong-source`; repair and verify the source mapping before judging the explicit label. |
 | `rmp-iii-a-spt-mpo` | K2 | The string, action boxes, and measured-leg crossings are complete. |
 | `rmp-iii-a-spt-intertwiner` | X | The open fusion map has no trace cyclicity; restore the source factor order before reviewing glyph scale. |
 | `rmp-iii-a-g-injective-projector` | X | Its ledger pairing is `wrong-source`; repair the projector source mapping before any verdict promotion. |
@@ -100,11 +100,11 @@ hash-pinned visual check required before changing a verdict.
 | `rmp-iv-intersection-rhs-four` | K2 | The five open ends match and the spurious crossing is absent. |
 | `rmp-iv-intersection-lhs-five` | K2 | Sideways stubs preserve the restored three-leg boundary. |
 | `rmp-iv-intersection-rhs-five` | X | Re-audit the mirrored open C--X contraction before accepting it as equivalent routing. |
-| `rmp-iv-intersection-lhs-six` | X | The ledger records `wrong-contraction`; move it out of `cosmetic-gap` before fixing the invented lattice. |
-| `rmp-iv-intersection-rhs-six` | X | The ledger records `wrong-contraction`; move it out of `cosmetic-gap` before fixing the invented lattice. |
+| `rmp-iv-intersection-lhs-six` | X | Promoted to `blocked`: the missing `nested-regions` capability leaves an invented lattice and the wrong contraction. |
+| `rmp-iv-intersection-rhs-six` | X | Promoted to `blocked`: the missing `nested-regions` capability leaves an invented lattice and the wrong contraction. |
 | `rmp-app-czx-state` | K2 | Lighter enclosure fill is a public-theme choice. |
 | `rmp-workbench-ii-newfig7` | K2 | Crossing-gadget styling is a house-form difference. |
-| `rmp-workbench-ii-projector-on-pta` | K4 | Restore the two missing source triangles. |
+| `rmp-workbench-ii-projector-on-pta` | X | Promoted to `structural-gap`: omitting two of four source triangles changes the multiplicity of the sandwich sum. |
 | `rmp-workbench-ii-peps-rg-workbench` | X | Its ledger pairing is `wrong-source`; repair and verify the source mapping before judging the U-application idiom. |
 | `rmp-workbench-ii-positive-mpo-old` | K2 | The ledger already records equal X sizes; re-review the hash-pinned render as faithful. |
 | `rmp-workbench-ii-peps-gauge-old` | K3 | Preserve diagonal leg flow and smooth the marked detour tangents. |

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -603,12 +603,12 @@ note = "box-G vs copy-dot; diagonal leg angle"
 
 [[verdict]]
 id = "rmp-iii-a-hadamard"
-status = "cosmetic-gap"
+status = "structural-gap"
 pairing = "wrong-source"
 case_sha256 = "ae3e69b02f579b42925b116697b02e2c5d0988578db1b0e41bb334576171b106"
-reviewed = "2026-07-24"
+reviewed = "2026-07-30"
 renderer = "source-split-page-review-2026-07-24"
-note = "Author panel shows an unlabeled black bond node, not the declared Hadamard matrix."
+note = "paired author panel is an unlabeled black bond node, not the declared Hadamard matrix"
 
 [[verdict]]
 id = "rmp-iii-a-spt-mpo"
@@ -939,25 +939,27 @@ note = "Boundary types match; the equivalent C--X contraction is mirrored."
 
 [[verdict]]
 id = "rmp-iv-intersection-lhs-six"
-status = "cosmetic-gap"
+status = "blocked"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = ["extra-element", "wrong-contraction"]
+missing = ["nested-regions"]
 case_sha256 = "90b54689d81f976c919bcea414d0754342133c7f521e7c8e013fa5e80d1e4114"
-reviewed = "2026-07-26"
+reviewed = "2026-07-30"
 renderer = "codex-region-label-math-review-2026-07-26"
-note = "nesting drawn as overlap plus an invented lattice"
+note = "nested source regions are drawn as overlap plus an invented lattice"
 
 [[verdict]]
 id = "rmp-iv-intersection-rhs-six"
-status = "cosmetic-gap"
+status = "blocked"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = ["extra-element", "wrong-contraction"]
+missing = ["nested-regions"]
 case_sha256 = "597e03c401223fbad66083892235c28c7a7fe6f12e204367adcf55806a062210"
-reviewed = "2026-07-26"
+reviewed = "2026-07-30"
 renderer = "codex-region-label-math-review-2026-07-26"
-note = "same"
+note = "nested source regions are drawn as overlap plus an invented lattice"
 
 [[verdict]]
 id = "rmp-app-toric-primal"
@@ -1002,14 +1004,14 @@ note = "crossing-gadget styling"
 
 [[verdict]]
 id = "rmp-workbench-ii-projector-on-pta"
-status = "cosmetic-gap"
+status = "structural-gap"
 pairing = "verified"
 pairing_by = "pairing-sweep-two-viewers-2026-07-23"
 defects = ["missing-element"]
 case_sha256 = "3afa8ab06f286b75e13326b974d6a6dde1fd3454a689a405bc2c07fc6986acdc"
-reviewed = "2026-07-26"
+reviewed = "2026-07-30"
 renderer = "fable-countersign-reading-2026-07-26-200dpi"
-note = "east cup draws; two triangles where the source has four"
+note = "east cup draws; the second sandwich sum has two triangles where the source has four"
 
 [[verdict]]
 id = "rmp-workbench-ii-peps-rg-workbench"


### PR DESCRIPTION
This PR promotes the content-level residues identified by the cosmetic-gap audit
to conceding RMP verdicts.

- `rmp-iv-intersection-lhs-six` and `rmp-iv-intersection-rhs-six`:
  `cosmetic-gap` → `blocked`. Their recorded `extra-element` and
  `wrong-contraction` defects cross the bar's topological and contraction
  criteria. Both now name `missing = ["nested-regions"]`; no manifest capability
  is declared because tenkz cannot presently represent the source nesting.
- `rmp-workbench-ii-projector-on-pta`: `cosmetic-gap` → `structural-gap`, and
  K4 → X in the bar table. Omitting two of the four source triangles removes
  half of the repeated factors in the sandwich sum, so this is not a small
  isolated mark omission: the mathematical multiplicity changes.
- `rmp-iii-a-hadamard`: `cosmetic-gap` → `structural-gap`. Its `wrong-source`
  pairing compares the declared Hadamard matrix with an unlabeled black bond
  node, so the source mapping must be repaired before the label can be judged.

The doctrine table now records the same dispositions as the verdict ledger.

Closes LionSR/tenkz#115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to the RMP verdict ledger and cosmetic-gap doctrine doc; no renderer or case bodies change.
> 
> **Overview**
> This PR **reclassifies five RMP benchmark targets** that were incorrectly listed under the cosmetic-gap audit. Their ledger `status` values and the doctrine table in `docs/tenkz/COSMETIC-GAP-BAR.md` now agree.
> 
> **`rmp-iv-intersection-lhs-six` and `rmp-iv-intersection-rhs-six`** move from `cosmetic-gap` to **`blocked`**, with `missing = ["nested-regions"]` added. The notes state that nested source regions are drawn as overlap plus an invented lattice, with `extra-element` and `wrong-contraction` defects—content that crosses the cosmetic bar, not K3/K4 styling.
> 
> **`rmp-workbench-ii-projector-on-pta`** moves to **`structural-gap`** (`missing-element`). The bar table shifts from K4 to X: only two triangles in the second sandwich sum where the source has four, which changes the multiplicity of the sum rather than a small label omission.
> 
> **`rmp-iii-a-hadamard`** moves to **`structural-gap`** with pairing unchanged as `wrong-source`. The paired author panel is an unlabeled bond node, not the declared Hadamard matrix, so source mapping must be fixed before the label can be judged.
> 
> Review dates for the promoted entries are bumped to **2026-07-30** and notes are tightened to match the new dispositions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329971a4e04b8826aa3b52f5616b4eb6de875074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->