### PR TITLE
doc(blueprint): separate the Schmidt-number hierarchy from Schwarz-map material

### DIFF
--- a/blueprint/src/appendix/full_only/ch25_positive_not_cp.tex
+++ b/blueprint/src/appendix/full_only/ch25_positive_not_cp.tex
@@ -6,7 +6,9 @@ positive-filter identities used in trace normalization, the Schmidt-rank
 linear algebra behind the maximal-overlap theorem, the extremal projection
 bounds in Ky Fan's maximum principle, the right-tensor identities behind the
 Choi-compression criteria, and the elementary closure properties of
-$k$-positive maps.
+$k$-positive maps. The final sections give the convex geometry of
+Schmidt-number sets and the Choi trace pairing used for entanglement
+detection.
 
 \section{Positive filters and trace normalization}
 
@@ -787,3 +789,5 @@ used with the positivity hierarchy in Chapter~\ref{ch:positive_not_cp}.
     $E^{(k)}(X)\succeq0$. Since this holds for every positive semidefinite
     $X$, the limit map $E$ is $k$-positive.
 \end{proof}
+
+\input{appendix/full_only/ch25_schmidt_number_and_witnesses}

--- a/blueprint/src/appendix/full_only/ch25_schmidt_number_and_witnesses.tex
+++ b/blueprint/src/appendix/full_only/ch25_schmidt_number_and_witnesses.tex
@@ -1,0 +1,207 @@
+\section{Schmidt-number geometry and entanglement witnesses}
+\label{sec:app_positive_not_cp_schmidt_number_geometry}
+
+This section supplies the convexity, compactness, and separation results used
+in the witness criterion of Theorem~\ref{thm:not_has_schmidt_number_le_iff_exists_witness}.
+
+\begin{theorem}[Basic properties of bounded Schmidt number]
+    \label{thm:has_schmidt_number_le_basic}
+    \lean{Matrix.HasSchmidtNumberLE.posSemidef, Matrix.HasSchmidtNumberLE.add,
+        Matrix.HasSchmidtNumberLE.mono, Matrix.HasSchmidtNumberLE.smul}
+    \leanok
+    \uses{def:has_schmidt_number_le}
+    A matrix of Schmidt number at most $n$ is positive semidefinite. States of
+    Schmidt number at most $n$ are closed under addition and under multiplication by a
+    non-negative real scalar, and a bound on the Schmidt number relaxes to any larger
+    bound.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Each summand $\ket{\psi_i}\bra{\psi_i}$ is a rank-one positive semidefinite
+    matrix, and a finite sum of positive semidefinite matrices is positive
+    semidefinite. Concatenating two pure-state families realizes a sum as a single
+    finite sum of pure-state projectors of Schmidt rank at most $n$, and a pure
+    summand of Schmidt rank at most $n$ also has Schmidt rank at most any larger
+    bound. Multiplication by a non-negative real $a$ rescales each pure summand
+    $\psi_i$ to $\sqrt a\,\psi_i$, which leaves its Schmidt rank unchanged and
+    reproduces $a$ times the original state.
+\end{proof}
+
+\begin{theorem}[Convexity of the Schmidt-number set]
+    \label{thm:convex_setOf_has_schmidt_number_le}
+    \lean{Matrix.convex_setOf_hasSchmidtNumberLE}
+    \leanok
+    \uses{def:has_schmidt_number_le}
+    For each $n$ the set $S_n$ of bipartite states of Schmidt number at most $n$ is
+    convex.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    A convex combination $a x + b y$ with $a,b\ge 0$ is a sum of two non-negatively
+    scaled states of Schmidt number at most $n$, and that bound is preserved under
+    non-negative scaling and under addition; rescaling a vector by a non-negative
+    scalar scales its coefficient matrix and so does not increase the Schmidt rank.
+\end{proof}
+
+\begin{theorem}[Compactness of the Schmidt-number state set]
+    \label{thm:compact_setOf_has_schmidt_number_le_trace_one}
+    \lean{Matrix.isCompact_setOf_hasSchmidtNumberLE_trace_one}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:schmidt_rank,
+        thm:convex_setOf_has_schmidt_number_le}
+    For each $n$ the set $S_n$ of trace-one bipartite states of Schmidt number at most
+    $n$ is compact.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    A trace-one state of Schmidt number at most $n$ is a convex combination of pure
+    states $\ket{\psi}\bra{\psi}$ whose vector $\psi$ has unit norm and Schmidt rank
+    at most $n$, so $S_n$ is the convex hull of the set $P_n$ of those pure states.
+    The set $P_n$ is the image, under the continuous projector map
+    $\psi\mapsto\ket{\psi}\bra{\psi}$, of the unit vectors of Schmidt rank at most
+    $n$. In the Euclidean norm those unit vectors form the unit sphere, which is
+    compact in finite dimension, intersected with the closed set on which the Schmidt
+    rank is at most $n$ (the coefficient matrix depends continuously on the vector and
+    the matrices of rank at most $n$ form a closed set); hence $P_n$ is compact. The
+    trace of $\ket{\psi}\bra{\psi}$ is the squared Euclidean norm of $\psi$, so the
+    trace-one constraint is exactly the unit-norm constraint and the weights of the
+    convex decomposition are the squared norms, summing to the trace. The convex hull
+    of a compact set is compact in a finite-dimensional real normed space.
+\end{proof}
+
+\begin{theorem}[Trace-form representation of a real-linear functional]
+    \label{thm:exists_isHermitian_trace_form_re}
+    \lean{Matrix.exists_isHermitian_trace_form_re}
+    \leanok
+    Every real-linear functional $g$ on the space of square complex matrices is the
+    trace form of a Hermitian matrix: there is a Hermitian $H_0$ with
+    $g(X)=\re\tr(X H_0)$ for every Hermitian $X$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The real bilinear pairing $(X,H)\mapsto\re\tr(X H)$ is nondegenerate,
+    because on the diagonal pair $(H,H^{\dagger})$ it equals the squared Frobenius norm
+    $\re\tr(H H^{\dagger})=\sum_{i,j}\lvert H_{ij}\rvert^2$, which is positive
+    unless $H=0$. Hence the map sending $H$ to the functional
+    $X\mapsto\re\tr(X H)$ is an injective real-linear map from the matrix
+    space to its real dual. These two spaces have the same finite real dimension, so the
+    map is also surjective, and every $g$ is represented by some $H$. Replacing $H$ by
+    its Hermitian part $\tfrac12(H+H^{\dagger})$ keeps the value on Hermitian inputs,
+    since $\tr(X H^{\dagger})=\overline{\tr(X H)}$ when $X$ is Hermitian, and produces a
+    Hermitian representing matrix.
+\end{proof}
+
+\begin{theorem}[Entanglement witness from a separating hyperplane]
+    \label{thm:exists_entanglement_witness}
+    \lean{Matrix.exists_isHermitian_witness}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:schmidt_rank,
+        thm:convex_setOf_has_schmidt_number_le,
+        thm:compact_setOf_has_schmidt_number_le_trace_one,
+        thm:exists_isHermitian_trace_form_re}
+    Let $\rho$ be a trace-one Hermitian bipartite state whose Schmidt number exceeds $n$.
+    Then there is a Hermitian operator $W$ such that, for every $\psi$ of Schmidt rank
+    at most $n$,
+    \begin{align}
+        \re\tr(W\rho)            & <0,
+        \notag                            \\
+        \re\bra{\psi}W\ket{\psi} & \ge 0.
+        \notag
+    \end{align}
+    This is the only-if direction of Wolf's Proposition~3.3
+    \cite[Chapter~3, Proposition~3.3]{Wolf2012Quantum}: a state of Schmidt number larger
+    than $n$ is detected by an entanglement witness for $S_n$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The set $S_n$ of trace-one states of Schmidt number at most $n$ is convex and
+    compact, and $\rho\notin S_n$. The geometric Hahn--Banach theorem separates the
+    closed convex set $\{\rho\}$ from the compact convex set $S_n$ by a continuous
+    real-linear functional $f$ and a constant $c$ with $f(\rho)<c<f(\sigma)$ for every
+    $\sigma\in S_n$. Representing $f$ as the trace form of a Hermitian $H_0$ and setting
+    $W=H_0-c\,\Id$ gives $\re\tr(W\rho)=f(\rho)-c<0$. For a vector $\psi$
+    of Schmidt rank at most $n$ the projector $\ket{\psi}\bra{\psi}$, after
+    normalization by $\lVert\psi\rVert^2$, is a trace-one state of $S_n$, so its value
+    under $f$ is at least $c$; multiplying back by the squared norm gives
+    $\re\bra{\psi}W\ket{\psi}\ge 0$, with the zero vector giving the value
+    $0$ directly.
+\end{proof}
+
+\section{Entanglement witnesses and Choi trace pairing}
+\label{sec:app_positive_not_cp_witness_choi}
+
+The following results identify witnesses with Choi matrices of $n$-positive
+maps and supply the trace identity used in
+Theorem~\ref{thm:exists_isNPositiveMap_detects}.
+
+\begin{theorem}[Surjectivity of the Choi correspondence]
+    \label{thm:exists_choiMatrix_eq}
+    \lean{ChoiJamiolkowski.exists_choiMatrix_eq}
+    \leanok
+    \uses{thm:cp_iff_choi_posSemidef}
+    Assume $D>0$. Every bipartite matrix $W$ on $\C^D\otimes\C^D$ is the Choi matrix
+    $\tau_T=(T\otimes\Id)(\ket{\Omega}\bra{\Omega})$ of some linear map
+    $T\colon\MN{D}\to\MN{D}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The Choi correspondence $T\mapsto\tau_T$ is complex-linear and injective. Its domain,
+    the space of linear maps on $\MN{D}$, and its codomain, the bipartite matrix space on
+    $\C^D\otimes\C^D$, both have complex dimension $D^4$, so the injective map is also
+    surjective. Hence every $W$ is a Choi matrix.
+\end{proof}
+
+\begin{theorem}[A witness is the Choi matrix of an $n$-positive map]
+    \label{thm:exists_isNPositiveMap_choiMatrix_eq}
+    \lean{ChoiJamiolkowski.exists_isNPositiveMap_choiMatrix_eq_of_witness}
+    \leanok
+    \uses{def:k_positive_map, def:schmidt_rank, thm:exists_choiMatrix_eq,
+        thm:schmidt_rank_choi_test_iff, thm:exists_entanglement_witness}
+    Assume $D>0$. Let $W$ be a Hermitian operator on $\C^D\otimes\C^D$ with
+    $\re\bra{\psi}W\ket{\psi}\ge 0$ for every $\psi$ of Schmidt rank at most $n$.
+    Then $W$ is the Choi matrix of an $n$-positive map $T$. This is the
+    Choi--Jamio\l kowski translation of the entanglement witness of Wolf's Proposition~3.3
+    into the $n$-positive map of Wolf's Proposition~3.4
+    \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By the surjectivity of the Choi correspondence (\ref{thm:exists_choiMatrix_eq}) there
+    is a linear map $T$ with $\tau_T=W$. Because $W$ is Hermitian, the Choi quadratic form
+    $\bra{\psi}W\ket{\psi}$ is real, and it equals the witness expectation
+    $\tr(W\ket{\psi}\bra{\psi})$; the witness condition makes it non-negative on every
+    vector of Schmidt rank at most $n$. This is exactly the Schmidt-rank Choi criterion
+    (\ref{thm:schmidt_rank_choi_test_iff}) for $n$-positivity of $T$.
+\end{proof}
+
+\begin{theorem}[Choi trace pairing through the trace-pairing adjoint]
+    \label{thm:trace_choiMatrix_omega_quadratic_adjoint}
+    \lean{ChoiJamiolkowski.trace_choiMatrix_mul_eq_omegaVec_quadraticForm_traceAdjointMap}
+    \leanok
+    \uses{def:trace_pairing_adjoint, thm:trace_pairing_adjoint_ampliation}
+    For a linear map $T\colon\MN{D}\to\MN{D}$ with Choi matrix $\tau_T$ and any bipartite
+    matrix $\rho$ on $\C^D\otimes\C^D$,
+    \begin{align}
+        \tr(\tau_T\,\rho)
+         & =\bra{\Omega}(T^{*}\otimes\Id)(\rho)\ket{\Omega},
+        \notag
+    \end{align}
+    where $T^{*}$ is the trace-pairing adjoint of $T$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $\tau_T=(T\otimes\Id)(\ket{\Omega}\bra{\Omega})$, cyclicity of the trace gives
+    $\tr(\tau_T\rho)=\tr(\rho\,(T\otimes\Id)(\ket{\Omega}\bra{\Omega}))$. The
+    $\Id$-ampliation of the trace-pairing adjoint is the trace-pairing adjoint of the
+    ampliation, so moving $T$ across the trace pairing replaces
+    $(T\otimes\Id)$ by $(T^{*}\otimes\Id)$ acting on $\rho$ and turns the pairing against
+    $\ket{\Omega}\bra{\Omega}$ into the quadratic form $\bra{\Omega} \cdot\,\ket{\Omega}$.
+\end{proof}

--- a/blueprint/src/appendix/full_only/ch27_channel_asymptotics.tex
+++ b/blueprint/src/appendix/full_only/ch27_channel_asymptotics.tex
@@ -6,7 +6,8 @@ positivity, trace-preservation, unitality, and trace-adjoint properties of the
 mean-ergodic projections used there, together with the weighted-trace and
 idempotent-retraction results used for fixed-point algebras and Choi--Effros
 absorption. It also records the Gram-matrix unitary-extension criterion used
-in the Chapter 16 Stinespring construction and its zero-extension consequence
+in the Stinespring construction of
+Chapter~\ref{ch:channel_representations} and its zero-extension consequence
 for the fixed-point decomposition.
 
 \section{Preservation under the mean-ergodic projection}

--- a/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
+++ b/blueprint/src/chapter/ch05_schwarz_abstract_domains_and_order_auxiliary.tex
@@ -321,3 +321,68 @@ Section~\ref{sec:app_schwarz_trace_order}.
     Apply Theorem~\ref{thm:positive_map_image_bounded} and translate
     (\ref{eq:schwarz_order_interval}) back into spectral bounds.
 \end{proof}
+
+\section{Positive Schwarz maps outside complete positivity}
+
+The following example shows that the Schwarz inequality does not force complete
+positivity.
+
+\subsection{A positive Schwarz map that is not completely positive}
+
+\begin{example}[Transpose-trace map on $\MN{2}$]\label{def:wolf_example53}
+    \lean{wolfExample53}
+    \leanok
+    Consider the linear map $T : \MN{2} \to \MN{2}$ defined by
+    \begin{align}
+        T(A) & =\frac{1}{2} A^T+\frac{1}{4}\tr(A)\Id.
+        \notag
+    \end{align}
+    This is the map from \cite[Example~5.3]{Wolf2012Quantum}.
+\end{example}
+
+\begin{theorem}[The transpose-trace map is positive]\label{thm:wolf_example53_positive}
+    \lean{wolfExample53_isPositive}
+    \leanok
+    \uses{def:wolf_example53, def:positive_map}
+    The map from Example~\ref{def:wolf_example53} is positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    It is a non-negative linear combination of the transpose map and the map
+    $A \mapsto \tr(A) \Id$, and both of these maps send positive
+    semidefinite matrices to positive semidefinite matrices.
+\end{proof}
+
+\begin{theorem}[The transpose-trace map satisfies the Schwarz inequality]\label{thm:wolf_example53_schwarz}
+    \lean{wolfExample53_satisfies_schwarz}
+    \leanok
+    \uses{def:wolf_example53}
+    For every $A \in \MN{2}$,
+    $T(A^\dagger A)-T(A^\dagger)T(A)\ge 0$, where $T$ is the map from
+    Example~\ref{def:wolf_example53}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write the Schwarz gap as $F(A)$.
+    One checks that $F(A + \lambda \Id) = F(A)$ for every scalar $\lambda$,
+    so it is enough to treat the case $\tr(A) = 0$.
+    In that case a direct $2 \times 2$ computation shows that
+    $F(A)$ dominates $\frac{1}{2} (A^\dagger A)^T$, hence is positive semidefinite.
+\end{proof}
+
+\begin{theorem}[The transpose-trace map is not completely positive]\label{thm:wolf_example53_not_cp}
+    \lean{wolfExample53_not_cp}
+    \leanok
+    \uses{def:wolf_example53, def:cp_map}
+    The map from Example~\ref{def:wolf_example53} is not completely positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Compute the Choi matrix of $T$ and test it on the antisymmetric vector
+    $\ket{01} - \ket{10}$.
+    The resulting expectation value is negative, so the Choi matrix is not
+    positive semidefinite.
+\end{proof}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -15,4 +15,4 @@ the full reduction criterion.
 \input{chapter/ch25_positive_not_cp_positivity_reduction_and_breuer_hall}
 \input{chapter/ch25_positive_not_cp_choi_and_decomposable_maps}
 \input{chapter/ch25_positive_not_cp_ppt_and_separable_states}
-\input{chapter/ch25_positive_not_cp_schmidt_number_and_schwarz_maps}
+\input{chapter/ch25_positive_not_cp_schmidt_number_and_entanglement}

--- a/blueprint/src/chapter/ch25_positive_not_cp_schmidt_number_and_entanglement.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp_schmidt_number_and_entanglement.tex
@@ -30,29 +30,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \end{align}
 \end{definition}
 
-\begin{theorem}[Basic properties of bounded Schmidt number]
-    \label{thm:has_schmidt_number_le_basic}
-    \lean{Matrix.HasSchmidtNumberLE.posSemidef, Matrix.HasSchmidtNumberLE.add,
-        Matrix.HasSchmidtNumberLE.mono, Matrix.HasSchmidtNumberLE.smul}
-    \leanok
-    \uses{def:has_schmidt_number_le}
-    A matrix of Schmidt number at most $n$ is positive semidefinite. States of
-    Schmidt number at most $n$ are closed under addition and under multiplication by a
-    non-negative real scalar, and a bound on the Schmidt number relaxes to any larger
-    bound.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Each summand $\ket{\psi_i}\bra{\psi_i}$ is a rank-one positive semidefinite
-    matrix, and a finite sum of positive semidefinite matrices is positive
-    semidefinite. Concatenating two pure-state families realizes a sum as a single
-    finite sum of pure-state projectors of Schmidt rank at most $n$, and a pure
-    summand of Schmidt rank at most $n$ also has Schmidt rank at most any larger
-    bound. Multiplication by a non-negative real $a$ rescales each pure summand
-    $\psi_i$ to $\sqrt a\,\psi_i$, which leaves its Schmidt rank unchanged and
-    reproduces $a$ times the original state.
-\end{proof}
+The closure and compactness properties of the Schmidt-number sets are proved
+in Section~\ref{sec:app_positive_not_cp_schmidt_number_geometry}.
 
 \begin{theorem}[Schmidt number one is separability]
     \label{thm:has_schmidt_number_le_one_iff_separable}
@@ -74,50 +53,6 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     after expanding each factor into rank-one projectors, is a double sum of
     product-vector projectors, each of Schmidt rank at most one, so it has Schmidt
     number at most one; a separable matrix is a finite sum of such products.
-\end{proof}
-
-\begin{theorem}[Convexity of the Schmidt-number set]
-    \label{thm:convex_setOf_has_schmidt_number_le}
-    \lean{Matrix.convex_setOf_hasSchmidtNumberLE}
-    \leanok
-    \uses{def:has_schmidt_number_le}
-    For each $n$ the set $S_n$ of bipartite states of Schmidt number at most $n$ is
-    convex.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    A convex combination $a x + b y$ with $a,b\ge 0$ is a sum of two non-negatively
-    scaled states of Schmidt number at most $n$, and that bound is preserved under
-    non-negative scaling and under addition; rescaling a vector by a non-negative
-    scalar scales its coefficient matrix and so does not increase the Schmidt rank.
-\end{proof}
-
-\begin{theorem}[Compactness of the Schmidt-number state set]
-    \label{thm:compact_setOf_has_schmidt_number_le_trace_one}
-    \lean{Matrix.isCompact_setOf_hasSchmidtNumberLE_trace_one}
-    \leanok
-    \uses{def:has_schmidt_number_le, def:schmidt_rank,
-        thm:convex_setOf_has_schmidt_number_le}
-    For each $n$ the set $S_n$ of trace-one bipartite states of Schmidt number at most
-    $n$ is compact.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    A trace-one state of Schmidt number at most $n$ is a convex combination of pure
-    states $\ket{\psi}\bra{\psi}$ whose vector $\psi$ has unit norm and Schmidt rank
-    at most $n$, so $S_n$ is the convex hull of the set $P_n$ of those pure states.
-    The set $P_n$ is the image, under the continuous projector map
-    $\psi\mapsto\ket{\psi}\bra{\psi}$, of the unit vectors of Schmidt rank at most
-    $n$. In the Euclidean norm those unit vectors form the unit sphere, which is
-    compact in finite dimension, intersected with the closed set on which the Schmidt
-    rank is at most $n$ (the coefficient matrix depends continuously on the vector and
-    the matrices of rank at most $n$ form a closed set); hence $P_n$ is compact. The
-    trace of $\ket{\psi}\bra{\psi}$ is the squared Euclidean norm of $\psi$, so the
-    trace-one constraint is exactly the unit-norm constraint and the weights of the
-    convex decomposition are the squared norms, summing to the trace. The convex hull
-    of a compact set is compact in a finite-dimensional real normed space.
 \end{proof}
 
 \begin{theorem}[Pure-state step of the reduction criterion]
@@ -273,65 +208,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
 \end{proof}
 
 
-\begin{theorem}[Trace-form representation of a real-linear functional]
-    \label{thm:exists_isHermitian_trace_form_re}
-    \lean{Matrix.exists_isHermitian_trace_form_re}
-    \leanok
-    Every real-linear functional $g$ on the space of square complex matrices is the
-    trace form of a Hermitian matrix: there is a Hermitian $H_0$ with
-    $g(X)=\re\tr(X H_0)$ for every Hermitian $X$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    The real bilinear pairing $(X,H)\mapsto\re\tr(X H)$ is nondegenerate,
-    because on the diagonal pair $(H,H^{\dagger})$ it equals the squared Frobenius norm
-    $\re\tr(H H^{\dagger})=\sum_{i,j}\lvert H_{ij}\rvert^2$, which is positive
-    unless $H=0$. Hence the map sending $H$ to the functional
-    $X\mapsto\re\tr(X H)$ is an injective real-linear map from the matrix
-    space to its real dual. These two spaces have the same finite real dimension, so the
-    map is also surjective, and every $g$ is represented by some $H$. Replacing $H$ by
-    its Hermitian part $\tfrac12(H+H^{\dagger})$ keeps the value on Hermitian inputs,
-    since $\tr(X H^{\dagger})=\overline{\tr(X H)}$ when $X$ is Hermitian, and produces a
-    Hermitian representing matrix.
-\end{proof}
-
-\begin{theorem}[Entanglement witness from a separating hyperplane]
-    \label{thm:exists_entanglement_witness}
-    \lean{Matrix.exists_isHermitian_witness}
-    \leanok
-    \uses{def:has_schmidt_number_le, def:schmidt_rank,
-        thm:convex_setOf_has_schmidt_number_le,
-        thm:compact_setOf_has_schmidt_number_le_trace_one,
-        thm:exists_isHermitian_trace_form_re}
-    Let $\rho$ be a trace-one Hermitian bipartite state whose Schmidt number exceeds $n$.
-    Then there is a Hermitian operator $W$ such that, for every $\psi$ of Schmidt rank
-    at most $n$,
-    \begin{align}
-        \re\tr(W\rho)            & <0,
-        \notag                            \\
-        \re\bra{\psi}W\ket{\psi} & \ge 0.
-        \notag
-    \end{align}
-    This is the only-if direction of Wolf's Proposition~3.3
-    \cite[Chapter~3, Proposition~3.3]{Wolf2012Quantum}: a state of Schmidt number larger
-    than $n$ is detected by an entanglement witness for $S_n$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    The set $S_n$ of trace-one states of Schmidt number at most $n$ is convex and
-    compact, and $\rho\notin S_n$. The geometric Hahn--Banach theorem separates the
-    closed convex set $\{\rho\}$ from the compact convex set $S_n$ by a continuous
-    real-linear functional $f$ and a constant $c$ with $f(\rho)<c<f(\sigma)$ for every
-    $\sigma\in S_n$. Representing $f$ as the trace form of a Hermitian $H_0$ and setting
-    $W=H_0-c\,\Id$ gives $\re\tr(W\rho)=f(\rho)-c<0$. For a vector $\psi$
-    of Schmidt rank at most $n$ the projector $\ket{\psi}\bra{\psi}$, after
-    normalization by $\lVert\psi\rVert^2$, is a trace-one state of $S_n$, so its value
-    under $f$ is at least $c$; multiplying back by the squared norm gives
-    $\re\bra{\psi}W\ket{\psi}\ge 0$, with the zero vector giving the value
-    $0$ directly.
-\end{proof}
+The separating-hyperplane construction and its trace-form representation are
+proved in Section~\ref{sec:app_positive_not_cp_schmidt_number_geometry}.
 
 \begin{theorem}[Witness criterion for Schmidt number]
     \label{thm:not_has_schmidt_number_le_iff_exists_witness}
@@ -364,72 +242,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     converse uses no density-matrix hypotheses on $\rho$.
 \end{proof}
 
-\begin{theorem}[Surjectivity of the Choi correspondence]
-    \label{thm:exists_choiMatrix_eq}
-    \lean{ChoiJamiolkowski.exists_choiMatrix_eq}
-    \leanok
-    \uses{thm:cp_iff_choi_posSemidef}
-    Assume $D>0$. Every bipartite matrix $W$ on $\C^D\otimes\C^D$ is the Choi matrix
-    $\tau_T=(T\otimes\Id)(\ket{\Omega}\bra{\Omega})$ of some linear map
-    $T\colon\MN{D}\to\MN{D}$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    The Choi correspondence $T\mapsto\tau_T$ is complex-linear and injective. Its domain,
-    the space of linear maps on $\MN{D}$, and its codomain, the bipartite matrix space on
-    $\C^D\otimes\C^D$, both have complex dimension $D^4$, so the injective map is also
-    surjective. Hence every $W$ is a Choi matrix.
-\end{proof}
-
-\begin{theorem}[A witness is the Choi matrix of an $n$-positive map]
-    \label{thm:exists_isNPositiveMap_choiMatrix_eq}
-    \lean{ChoiJamiolkowski.exists_isNPositiveMap_choiMatrix_eq_of_witness}
-    \leanok
-    \uses{def:k_positive_map, def:schmidt_rank, thm:exists_choiMatrix_eq,
-        thm:schmidt_rank_choi_test_iff, thm:exists_entanglement_witness}
-    Assume $D>0$. Let $W$ be a Hermitian operator on $\C^D\otimes\C^D$ with
-    $\re\bra{\psi}W\ket{\psi}\ge 0$ for every $\psi$ of Schmidt rank at most $n$.
-    Then $W$ is the Choi matrix of an $n$-positive map $T$. This is the
-    Choi--Jamio\l kowski translation of the entanglement witness of Wolf's Proposition~3.3
-    into the $n$-positive map of Wolf's Proposition~3.4
-    \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    By the surjectivity of the Choi correspondence (\ref{thm:exists_choiMatrix_eq}) there
-    is a linear map $T$ with $\tau_T=W$. Because $W$ is Hermitian, the Choi quadratic form
-    $\bra{\psi}W\ket{\psi}$ is real, and it equals the witness expectation
-    $\tr(W\ket{\psi}\bra{\psi})$; the witness condition makes it non-negative on every
-    vector of Schmidt rank at most $n$. This is exactly the Schmidt-rank Choi criterion
-    (\ref{thm:schmidt_rank_choi_test_iff}) for $n$-positivity of $T$.
-\end{proof}
-
-\begin{theorem}[Choi trace pairing through the trace-pairing adjoint]
-    \label{thm:trace_choiMatrix_omega_quadratic_adjoint}
-    \lean{ChoiJamiolkowski.trace_choiMatrix_mul_eq_omegaVec_quadraticForm_traceAdjointMap}
-    \leanok
-    \uses{def:trace_pairing_adjoint, thm:trace_pairing_adjoint_ampliation}
-    For a linear map $T\colon\MN{D}\to\MN{D}$ with Choi matrix $\tau_T$ and any bipartite
-    matrix $\rho$ on $\C^D\otimes\C^D$,
-    \begin{align}
-        \tr(\tau_T\,\rho)
-         & =\bra{\Omega}(T^{*}\otimes\Id)(\rho)\ket{\Omega},
-        \notag
-    \end{align}
-    where $T^{*}$ is the trace-pairing adjoint of $T$.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Since $\tau_T=(T\otimes\Id)(\ket{\Omega}\bra{\Omega})$, cyclicity of the trace gives
-    $\tr(\tau_T\rho)=\tr(\rho\,(T\otimes\Id)(\ket{\Omega}\bra{\Omega}))$. The
-    $\Id$-ampliation of the trace-pairing adjoint is the trace-pairing adjoint of the
-    ampliation, so moving $T$ across the trace pairing replaces
-    $(T\otimes\Id)$ by $(T^{*}\otimes\Id)$ acting on $\rho$ and turns the pairing against
-    $\ket{\Omega}\bra{\Omega}$ into the quadratic form $\bra{\Omega} \cdot\,\ket{\Omega}$.
-\end{proof}
+The Choi correspondence and trace-pairing identities used below are proved in
+Section~\ref{sec:app_positive_not_cp_witness_choi}.
 
 \begin{theorem}[Positive maps detect high Schmidt number]
     \label{thm:exists_isNPositiveMap_detects}
@@ -454,69 +268,4 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     $\bra{\Omega}(T\otimes\Id)(\rho)\ket{\Omega}=\tr(W\rho)$, whose real part is
     negative. A positive semidefinite matrix has non-negative quadratic forms, so
     $(T\otimes\Id)(\rho)$ is not positive semidefinite.
-\end{proof}
-
-\section{Positive Schwarz maps outside complete positivity}
-
-The following example shows that the Schwarz inequality does not force complete
-positivity.
-
-\subsection{A positive Schwarz map that is not completely positive}
-
-\begin{example}[Transpose-trace map on $\MN{2}$]\label{def:wolf_example53}
-    \lean{wolfExample53}
-    \leanok
-    Consider the linear map $T : \MN{2} \to \MN{2}$ defined by
-    \begin{align}
-        T(A) & =\frac{1}{2} A^T+\frac{1}{4}\tr(A)\Id.
-        \notag
-    \end{align}
-    This is the map from \cite[Example~5.3]{Wolf2012Quantum}.
-\end{example}
-
-\begin{theorem}[The transpose-trace map is positive]\label{thm:wolf_example53_positive}
-    \lean{wolfExample53_isPositive}
-    \leanok
-    \uses{def:wolf_example53, def:positive_map}
-    The map from Example~\ref{def:wolf_example53} is positive.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    It is a non-negative linear combination of the transpose map and the map
-    $A \mapsto \tr(A) \Id$, and both of these maps send positive
-    semidefinite matrices to positive semidefinite matrices.
-\end{proof}
-
-\begin{theorem}[The transpose-trace map satisfies the Schwarz inequality]\label{thm:wolf_example53_schwarz}
-    \lean{wolfExample53_satisfies_schwarz}
-    \leanok
-    \uses{def:wolf_example53}
-    For every $A \in \MN{2}$,
-    $T(A^\dagger A)-T(A^\dagger)T(A)\ge 0$, where $T$ is the map from
-    Example~\ref{def:wolf_example53}.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Write the Schwarz gap as $F(A)$.
-    One checks that $F(A + \lambda \Id) = F(A)$ for every scalar $\lambda$,
-    so it is enough to treat the case $\tr(A) = 0$.
-    In that case a direct $2 \times 2$ computation shows that
-    $F(A)$ dominates $\frac{1}{2} (A^\dagger A)^T$, hence is positive semidefinite.
-\end{proof}
-
-\begin{theorem}[The transpose-trace map is not completely positive]\label{thm:wolf_example53_not_cp}
-    \lean{wolfExample53_not_cp}
-    \leanok
-    \uses{def:wolf_example53, def:cp_map}
-    The map from Example~\ref{def:wolf_example53} is not completely positive.
-\end{theorem}
-
-\begin{proof}
-    \leanok
-    Compute the Choi matrix of $T$ and test it on the antisymmetric vector
-    $\ket{01} - \ket{10}$.
-    The resulting expectation value is negative, so the Choi matrix is not
-    positive semidefinite.
 \end{proof}


### PR DESCRIPTION
## Summary

- retain the Schmidt-number definition, reduction criterion, witness equivalence, and detecting-map theorem in the dedicated Wolf Chapter 3 chapter
- collect the convex geometry of Schmidt-number sets and the Choi trace-pairing ingredients in two new sections of the Chapter 3 supporting appendix
- move the transpose--trace example of Wolf Example 5.3 to the abstract Schwarz material associated with Wolf Chapter 5
- rename the final Chapter 3 source file to describe its Schmidt-number and entanglement content

## Placement decision

The Schmidt-number/entanglement-witness equivalence and the n-positivity characterization remain in the existing chapter “Positive but Not Completely Positive Maps.” That chapter already follows Wolf Chapter 3 and contains the n-positivity hierarchy, Choi-compression criteria, reduction maps, transposition, PPT states, and decomposable maps. Keeping the two principal equivalences there follows the Wolf Chapter 3 decomposition recorded in LionSR/QICLean#25 and avoids introducing a second chapter for the same source chapter.

The supporting appendix now ends with:

- “Schmidt-number geometry and entanglement witnesses,” containing closure, convexity, compactness, trace-form representation, and separating-hyperplane results;
- “Entanglement witnesses and Choi trace pairing,” containing Choi surjectivity, the witness-to-n-positive-map statement, and the adjoint trace identity.

The principal witness criterion, positive-map detection theorem, and full reduction criterion remain in the chapter body and refer to these supporting sections.

## References and metadata

- all 22 labeled statements from the former mixed file, together with their proofs, match their original text exactly after relocation
- every moved `\label`, `\lean`, `\leanok`, and `\uses` entry is unchanged
- the internal phrase “Chapter 16 Stinespring construction” now uses `Chapter~\ref{ch:channel_representations}`; all remaining numerical chapter occurrences are bibliographic locators into cited sources
- the chapter input now names `ch25_positive_not_cp_schmidt_number_and_entanglement.tex`, and the supporting chapter inputs `ch25_schmidt_number_and_witnesses.tex`

## Structural validation

- 265 TeX files examined
- 279 input declarations; every target exists
- 4,499 distinct labels; no duplicate labels
- 3,285 reference targets and 8,817 dependency targets; no missing targets after excluding the two macro parameters `##1` in `macros/print.tex`
- `\lean{}` tags: 5,421 before and 5,421 after
- reader-facing prose check passed
- whitespace check passed

`leanblueprint checkdecls` was not run because this worktree has no seeded `.lake`; running it would risk rebuilding Mathlib from source. No Lean files or proofs change.

Closes LionSR/QICLean#253

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only TeX moves with unchanged labels and lean tags; no proof or application code changes.
> 
> **Overview**
> This PR **restructures blueprint documentation only** (no Lean changes): Schmidt-number and entanglement content stays in Chapter 25, but supporting proofs move out and Wolf’s Schwarz example moves to the right Wolf chapter.
> 
> **Chapter 25** keeps the Schmidt-number definition, reduction criterion, witness equivalence, and detecting-map theorem in `ch25_positive_not_cp_schmidt_number_and_entanglement.tex` (renamed from the mixed Schwarz/Schmidt file). Long proofs for convexity, compactness, Hahn–Banach witnesses, Choi surjectivity, witness→$n$-positive maps, and the Choi trace-pairing identity are **removed from the chapter** and replaced with pointers to new appendix sections; labels and `\lean` tags stay the same.
> 
> A new **`ch25_schmidt_number_and_witnesses.tex`** is `\input` at the end of the Chapter 25 supporting appendix, with two sections: Schmidt-number geometry/entanglement witnesses, and entanglement witnesses with Choi trace pairing.
> 
> **Wolf Example 5.3** (transpose–trace map: positive, Schwarz, not CP) moves from Chapter 25 to **`ch05_schwarz_abstract_domains_and_order_auxiliary.tex`** under “Positive Schwarz maps outside complete positivity.”
> 
> The channel-asymptotics appendix now cites Stinespring via `Chapter~\ref{ch:channel_representations}` instead of a hard-coded “Chapter 16.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b6a7d468cd6bb4aaba761a5751a478b85c0a062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->