### PR TITLE
doc(Channel): qualify Wolf Corollary 6.6 as the completely positive case

### DIFF
--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -275,7 +275,13 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 * `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` — the channel specialization.
 * Numbered theorem: `IsChannel.wolf_prop_6_8` — `TNLean.Channel.WolfChapter6Wrappers`
 
-### Wolf Corollary 6.6 (projected support corner) — FORMALIZED
+### Wolf Corollary 6.6 (projected support corner) — FORMALIZED (Kraus case)
+
+Wolf states the corollary for a positive trace-preserving map whose trace
+adjoint is unital and satisfies the Schwarz inequality; complete positivity is
+an example there, not a hypothesis. The declarations below assume a
+trace-preserving Kraus family, so they establish the completely positive case
+only.
 
 In `TNLean.Channel.FixedPoint.CornerFixedPoints`:
 

--- a/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
+++ b/docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex
@@ -1,0 +1,66 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Complete Positivity in the Projected Support Corner Star-Algebra}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\section{The assertion}
+
+Corollary 6.6 of \emph{Quantum Channels \& Operations} (Wolf 2012), stated at
+lines 1380--1510 of \texttt{Notes/WolfNoteTexSource/ch06\_spectral\_properties.tex},
+concerns a positive trace-preserving linear map $T$ on $M_D(\mathbb{C})$ whose trace
+adjoint $T^{*}$ is unital and satisfies the Schwarz inequality. For a positive
+semidefinite fixed point $\rho$ of $T$ with support projection $Q$, the corner-restricted
+fixed-point set
+\[
+    \{\, Y \in Q\,M_D(\mathbb{C})\,Q \;\mid\; Q\,T^{*}(Y)\,Q = Y \,\}
+\]
+is a $*$-subalgebra of the corner algebra $Q\,M_D(\mathbb{C})\,Q$.
+
+Wolf offers complete positivity as an \emph{example} of a map meeting the hypothesis,
+not as part of the hypothesis. The Schwarz inequality for the adjoint is strictly weaker:
+every completely positive unital map satisfies it, but positive maps that are not
+completely positive can satisfy it as well.
+
+\section{The restriction in the formalization}
+
+The available Lean statement is \leanid{Kraus.cornerFixedPointsStarSubalgebra}, with the
+membership characterization \leanid{Kraus.mem\_cornerFixedPointsStarSubalgebra}, both in
+\texttt{TNLean/Channel/FixedPoint/CornerFixedPoints.lean}. Its hypotheses are a family
+$K$ of Kraus operators with \leanid{IsTP} $K$ and a positive semidefinite fixed point of
+the induced map. Presenting the map by a Kraus family assumes complete positivity, so the
+Lean hypothesis set is strictly stronger than the source's. Under the repository
+faithfulness rule this declaration establishes the completely positive case of
+Corollary 6.6 and is not a formalization of the corollary itself.
+
+The corresponding Blueprint entry states the Kraus form explicitly in its hypotheses, so
+its \leanid{\textbackslash leanok} is honest for the restricted statement; it must not be
+read as the unrestricted corollary. The analogous restriction for Corollary 6.7 is
+recorded separately in \texttt{wolf\_cor67\_maximal\_support\_restriction.tex}.
+
+\section{Elimination plan}
+
+No further material is needed from the source: the corollary is stated in full at the
+lines cited above, and the machinery to express its hypothesis without Kraus data already
+exists. The multiplicative domain of a bare linear map
+$E : M_D(\mathbb{C}) \to M_D(\mathbb{C})$ is available as \leanid{multiplicativeDomain} in
+\texttt{TNLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean}, together with its
+membership characterization, so the Schwarz hypothesis can be carried directly.
+
+The elimination is therefore to restate the corollary for a positive trace-preserving map
+whose trace adjoint is unital and Schwarz, discharging it through the general support
+compression and the now-available Theorem 6.14, and then to recover the present Kraus
+declarations as specializations rather than maintaining a parallel development. The
+source-general statement is the one that may carry a source-facing Blueprint entry for
+Corollary 6.6.
+
+\end{document}


### PR DESCRIPTION
`TNLean/Channel/WolfChapter6Index.lean` recorded Wolf Corollary 6.6 as `FORMALIZED` without qualification. The declarations backing it, `Kraus.cornerFixedPointsStarSubalgebra` and `Kraus.mem_cornerFixedPointsStarSubalgebra`, take a Kraus family with `IsTP`, which assumes complete positivity. Wolf states the corollary for a positive trace-preserving map whose trace adjoint is unital and satisfies the Schwarz inequality, and presents complete positivity as an example rather than a hypothesis, so the Lean hypothesis set is strictly stronger than the source's.

Two changes, both documentation:

- the index heading becomes `FORMALIZED (Kraus case)`, matching the qualification already carried by Corollary 6.7, with a short paragraph naming the source hypothesis and what the declarations actually establish;
- a new paper-gap note `docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex` records the restriction, as the faithfulness rule requires whenever a stricter-hypothesis version is the only available formalization. Corollary 6.7's analogous restriction was already documented in `wolf_cor67_maximal_support_restriction.tex`; Corollary 6.6 had no note.

The elimination plan needs nothing further from the source: the abstract multiplicative domain of a bare linear map is already available in `TNLean/Channel/Schwarz/AbstractMultiplicativeDomain.lean`, so the Schwarz hypothesis can be carried without Kraus data, and the restatement can be discharged through the general support compression together with Theorem 6.14.

No Lean proof, statement, or `\leanok` tag changes. The Blueprint entry for this theorem already states the Kraus form explicitly in its hypotheses, so its existing tag remains honest for the restricted statement.

Progresses LionSR/QICLean#39.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on proofs, APIs, or runtime behavior.
> 
> **Overview**
> **Wolf Corollary 6.6** is no longer described as unconditionally formalized in `WolfChapter6Index.lean`. The section title is **FORMALIZED (Kraus case)** and a short note explains that Wolf assumes a positive TP map with unital Schwarz trace adjoint, while `Kraus.cornerFixedPointsStarSubalgebra` and related lemmas require a trace-preserving Kraus family—i.e. the completely positive case only.
> 
> A new paper-gap document, `docs/paper-gaps/wolf_cor66_kraus_hypothesis_restriction.tex`, records this faithfulness boundary (parallel to the existing Corollary 6.7 note). It states that existing Blueprint `\leanok` tags remain honest for the Kraus-stated version and outlines restating the corollary via `multiplicativeDomain` / Theorem 6.14 without Kraus data.
> 
> **No Lean proofs, theorem statements, or `\leanok` changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53dff29bf0de20f2c3905de290d9300ec8e3c923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->