### PR TITLE
feat(Analysis): two-projection norm-compression from a subspace-angle bound

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -45,3 +45,4 @@ import TNLean.Analysis.TraceCFC
 import TNLean.Analysis.TraceNormAbs
 import TNLean.Analysis.TraceNormContractivity
 import TNLean.Analysis.TraceNormVariational
+import TNLean.Analysis.TwoProjectionCompression

--- a/TNLean/Analysis/TwoProjectionCompression.lean
+++ b/TNLean/Analysis/TwoProjectionCompression.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
+
+/-!
+# Norm compression for two orthogonal projections
+
+This file proves the elementary Hilbert-space passage from a Friedrichs overlap
+bound for two subspaces to a norm estimate for the product of their orthogonal
+projections. The common intersection is removed before the overlap bound is
+applied.
+-/
+
+open scoped InnerProductSpace
+
+namespace Submodule
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+  [FiniteDimensional ℂ E]
+
+/-- The Friedrichs overlap of \(U\) and \(V\), after removing their common
+intersection, is at most \(\eta\).
+
+This is the two-subspace overlap quantity used in the principal-angle argument
+of arXiv:2011.12127 §IV.C, eq:4:martingale-2, and in the Kastoryano–Lucia 2018
+principal-angle estimate. Its application to MPS ground spaces is discussed in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+def IsFriedrichsBound (U V : Submodule ℂ E) (η : ℝ) : Prop :=
+  ∀ x : E, x ∈ U → x ∈ (U ⊓ V)ᗮ →
+    ∀ y : E, y ∈ V → y ∈ (U ⊓ V)ᗮ →
+      ‖⟪x, y⟫_ℂ‖ ≤ η * ‖x‖ * ‖y‖
+
+/-- A Friedrichs overlap bound controls the orthogonal projection of a vector
+in one reduced subspace onto the other reduced subspace.
+
+Here the reduced parts of \(U\) and \(V\) are their intersections with
+\((U \cap V)^\perp\). This is the two-subspace geometric estimate underlying
+the principal-angle argument in arXiv:2011.12127 §IV.C,
+eq:4:martingale-2. The later MPS-specific input is the Kastoryano–Lucia 2018
+principal-angle estimate. The precise comparison is recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem norm_starProjection_le_of_friedrichs_bound
+    (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
+    (hAngle : IsFriedrichsBound U V η)
+    {v : E} (hvV : v ∈ V) (hvInter : v ∈ (U ⊓ V)ᗮ) :
+    ‖U.starProjection v‖ ≤ η * ‖v‖ := by
+  let x := U.starProjection v
+  change ‖x‖ ≤ η * ‖v‖
+  have hxU : x ∈ U := U.starProjection_apply_mem v
+  have hxInter : x ∈ (U ⊓ V)ᗮ := by
+    rw [Submodule.mem_orthogonal'] at hvInter ⊢
+    intro z hz
+    calc
+      ⟪x, z⟫_ℂ = ⟪v, U.starProjection z⟫_ℂ :=
+        U.inner_starProjection_left_eq_right v z
+      _ = ⟪v, z⟫_ℂ := by rw [U.starProjection_eq_self_iff.mpr hz.1]
+      _ = 0 := hvInter z hz
+  have hInner := hAngle x hxU hxInter v hvV hvInter
+  have hInnerEq : ⟪x, v⟫_ℂ = ⟪x, x⟫_ℂ := by
+    calc
+      ⟪x, v⟫_ℂ = ⟪U.starProjection x, v⟫_ℂ := by
+        rw [U.starProjection_eq_self_iff.mpr hxU]
+      _ = ⟪x, U.starProjection v⟫_ℂ :=
+        U.inner_starProjection_left_eq_right x v
+      _ = ⟪x, x⟫_ℂ := rfl
+  rw [hInnerEq, inner_self_eq_norm_sq_to_K, norm_pow, RCLike.norm_ofReal,
+    abs_of_nonneg (norm_nonneg x)] at hInner
+  by_cases hx : x = 0
+  · rw [hx, norm_zero]
+    exact mul_nonneg hη (norm_nonneg v)
+  · have hxpos : 0 < ‖x‖ := norm_pos_iff.mpr hx
+    nlinarith [hInner]
+
+/-- A Friedrichs overlap bound controls the product of the two orthogonal
+projections on the orthogonal complement of their common range.
+
+This is the generic two-projection norm-compression lemma associated with
+arXiv:2011.12127 §IV.C, eq:4:martingale-2. The MPS-specific input needed later
+is the Kastoryano–Lucia 2018 principal-angle estimate; its source boundary is
+recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem norm_starProjection_starProjection_le_of_friedrichs_bound
+    (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
+    (hAngle : IsFriedrichsBound U V η)
+    {v : E} (hvInter : v ∈ (U ⊓ V)ᗮ) :
+    ‖U.starProjection (V.starProjection v)‖ ≤
+      η * ‖V.starProjection v‖ := by
+  apply norm_starProjection_le_of_friedrichs_bound U V hη hAngle
+  · exact V.starProjection_apply_mem v
+  · rw [Submodule.mem_orthogonal'] at hvInter ⊢
+    intro z hz
+    calc
+      ⟪V.starProjection v, z⟫_ℂ = ⟪v, V.starProjection z⟫_ℂ :=
+        V.inner_starProjection_left_eq_right v z
+      _ = ⟪v, z⟫_ℂ := by rw [V.starProjection_eq_self_iff.mpr hz.2]
+      _ = 0 := hvInter z hz
+
+/-- On the reduced range of the first projection, a Friedrichs overlap bound
+gives the directional compression estimate
+\(\|P_U(P_Vv)\|\leq\eta\|P_Uv\|\).
+
+The restriction to the range of \(P_U\) is essential: without it, this
+directional inequality would force \(P_V\) to preserve \(\ker P_U\), which does
+not follow from a subspace-angle bound. This is the restricted geometric form
+relevant to arXiv:2011.12127 §IV.C, eq:4:martingale-2; the remaining
+Kastoryano–Lucia 2018 principal-angle estimate for MPS ground spaces is
+described in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem norm_starProjection_starProjection_le_of_friedrichs_bound_of_mem
+    (U V : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
+    (hAngle : IsFriedrichsBound U V η)
+    {v : E} (hvU : v ∈ U) (hvInter : v ∈ (U ⊓ V)ᗮ) :
+    ‖U.starProjection (V.starProjection v)‖ ≤
+      η * ‖U.starProjection v‖ := by
+  calc
+    ‖U.starProjection (V.starProjection v)‖ ≤
+        η * ‖V.starProjection v‖ :=
+      norm_starProjection_starProjection_le_of_friedrichs_bound
+        U V hη hAngle hvInter
+    _ ≤ η * ‖v‖ :=
+      mul_le_mul_of_nonneg_left (V.norm_starProjection_apply_le v) hη
+    _ = η * ‖U.starProjection v‖ := by
+      rw [U.norm_starProjection_apply hvU]
+
+/-- For projections onto \(K^\perp\) and \(L^\perp\), a Friedrichs bound on
+these kernel complements gives directional compression on the reduced range of
+the first projection.
+
+This is the form in which the generic geometry can be applied to local
+excitation projections. The source is arXiv:2011.12127 §IV.C,
+eq:4:martingale-2; the MPS-specific input is the Kastoryano–Lucia 2018
+principal-angle estimate, whose comparison is recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem norm_starProjection_orthogonal_comp_le_of_friedrichs_bound
+    (K L : Submodule ℂ E) {η : ℝ} (hη : 0 ≤ η)
+    (hAngle : IsFriedrichsBound Kᗮ Lᗮ η)
+    {v : E} (hvK : v ∈ Kᗮ) (hvInter : v ∈ (Kᗮ ⊓ Lᗮ)ᗮ) :
+    ‖Kᗮ.starProjection (Lᗮ.starProjection v)‖ ≤
+      η * ‖Kᗮ.starProjection v‖ :=
+  norm_starProjection_starProjection_le_of_friedrichs_bound_of_mem
+    Kᗮ Lᗮ hη hAngle hvK hvInter
+
+end Submodule

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex
@@ -414,6 +414,110 @@
     explicit constant is positive because $L>1$ implies $4L>0$.
 \end{proof}
 
+\begin{definition}[Friedrichs overlap bound]
+    \label{def:friedrichs_overlap_bound}
+    \lean{Submodule.IsFriedrichsBound}
+    \leanok
+    Let $U$ and $V$ be subspaces of a finite-dimensional complex Hilbert space.
+    Their Friedrichs overlap is at most $\eta$ when
+    \begin{align}
+        |\langle x,y\rangle|
+        &\le \eta\|x\|\|y\| \notag
+    \end{align}
+    for every
+    $x\in U\cap(U\cap V)^\perp$ and
+    $y\in V\cap(U\cap V)^\perp$.
+\end{definition}
+
+\begin{lemma}[Projection compression from a Friedrichs overlap bound]
+    \label{lem:two_projection_friedrichs_compression}
+    \lean{Submodule.norm_starProjection_le_of_friedrichs_bound}
+    \leanok
+    \uses{def:friedrichs_overlap_bound}
+    Let $P_U$ be the orthogonal projection onto $U$. If the Friedrichs overlap
+    of $U$ and $V$ is at most $\eta$, where $\eta\ge0$, then
+    \begin{align}
+        \|P_Uv\|
+        &\le \eta\|v\| \notag
+    \end{align}
+    for every $v\in V\cap(U\cap V)^\perp$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Put $x=P_Uv$. Since the common intersection is contained in $U$, the
+    projection preserves orthogonality to $U\cap V$. Thus
+    $x\in U\cap(U\cap V)^\perp$. Moreover,
+    $\langle x,v\rangle=\langle x,x\rangle=\|x\|^2$. The Friedrichs bound gives
+    $\|x\|^2\le\eta\|x\|\|v\|$, and cancellation proves the result when
+    $x\ne0$; the case $x=0$ is immediate.
+\end{proof}
+
+\begin{lemma}[Two-projection compression on the reduced space]
+    \label{lem:two_projection_friedrichs_product}
+    \lean{Submodule.norm_starProjection_starProjection_le_of_friedrichs_bound}
+    \leanok
+    \uses{def:friedrichs_overlap_bound,
+        lem:two_projection_friedrichs_compression}
+    Let $P_U$ and $P_V$ be the orthogonal projections onto $U$ and $V$. If the
+    Friedrichs overlap of $U$ and $V$ is at most $\eta$, where $\eta\ge0$, then
+    every $v\in(U\cap V)^\perp$ satisfies
+    \begin{align}
+        \|P_UP_Vv\|
+        &\le\eta\|P_Vv\|. \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The vector $P_Vv$ belongs to $V$ and remains orthogonal to $U\cap V$.
+    Apply Lemma~\ref{lem:two_projection_friedrichs_compression}.
+\end{proof}
+
+\begin{lemma}[Directional compression on a reduced projection range]
+    \label{lem:two_projection_friedrichs_directional}
+    \lean{Submodule.norm_starProjection_starProjection_le_of_friedrichs_bound_of_mem}
+    \leanok
+    \uses{def:friedrichs_overlap_bound,
+        lem:two_projection_friedrichs_product}
+    Under the hypotheses of
+    Lemma~\ref{lem:two_projection_friedrichs_product}, every
+    $v\in U\cap(U\cap V)^\perp$ satisfies
+    \begin{align}
+        \|P_UP_Vv\|
+        &\le\eta\|P_Uv\|. \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Orthogonal projection onto $V$ does not increase the norm, while
+    $P_Uv=v$. Hence
+    $\|P_UP_Vv\|\le\eta\|P_Vv\|\le\eta\|v\|=\eta\|P_Uv\|$.
+\end{proof}
+
+\begin{lemma}[Directional compression for kernel-complement projections]
+    \label{lem:two_projection_kernel_complement_compression}
+    \lean{Submodule.norm_starProjection_orthogonal_comp_le_of_friedrichs_bound}
+    \leanok
+    \uses{def:friedrichs_overlap_bound,
+        lem:two_projection_friedrichs_directional}
+    Let $P$ and $Q$ be the orthogonal projections onto $K^\perp$ and
+    $L^\perp$. If the Friedrichs overlap of these two ranges is at most
+    $\eta\ge0$, then every
+    $v\in K^\perp\cap(K^\perp\cap L^\perp)^\perp$ satisfies
+    \begin{align}
+        \|PQv\|
+        &\le\eta\|Pv\|. \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply Lemma~\ref{lem:two_projection_friedrichs_directional} to the two
+    subspaces $K^\perp$ and $L^\perp$.
+\end{proof}
+
 \begin{remark}[Projection-geometry identities for row-sum arguments]
     \label{rem:projection_geometry_rowsum_identities}
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_self}


### PR DESCRIPTION
This PR proves the generic finite-dimensional Hilbert-space step converting a Friedrichs overlap bound into norm compression for two orthogonal projections. For subspaces U and V, the common intersection is removed, and the estimate is proved first for a vector in the reduced second subspace, then for the product of the two projections on (U ∩ V)⊥, and finally in the directional form ‖P_U P_V v‖ ≤ η ‖P_U v‖ on the reduced range of P_U. A corollary states the result for projections onto K⊥ and L⊥.

The reduced-range hypothesis in the directional statement is essential: an unrestricted estimate with right-hand side ‖P_U v‖ would force P_V to preserve ker P_U, which does not follow from a Friedrichs-angle bound. The MPS-specific Kastoryano–Lucia angle-decay estimate is not addressed here.

Sources: arXiv:2011.12127 §IV.C, eq:4:martingale-2; the Kastoryano–Lucia 2018 principal-angle estimate; and `docs/paper-gaps/cpgsv21_martingale_overlap.tex`.

New declarations:
- `Submodule.IsFriedrichsBound`
- `Submodule.norm_starProjection_le_of_friedrichs_bound`
- `Submodule.norm_starProjection_starProjection_le_of_friedrichs_bound`
- `Submodule.norm_starProjection_starProjection_le_of_friedrichs_bound_of_mem`
- `Submodule.norm_starProjection_orthogonal_comp_le_of_friedrichs_bound`

The corresponding Chapter 13 blueprint statements and proofs are marked `\leanok`.

Progresses #952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New pure analysis lemmas and blueprint documentation only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds formal Lean support for turning a **Friedrichs overlap bound** between two subspaces (after removing \(U \cap V\)) into **norm compression** for orthogonal projections, as used in the parent-Hamiltonian row-sum / martingale line (arXiv:2011.12127 §IV.C).
> 
> New module `TNLean/Analysis/TwoProjectionCompression.lean` introduces `Submodule.IsFriedrichsBound` and proves, in order: \(\|P_U v\| \le \eta \|v\|\) on the reduced part of \(V\); \(\|P_U P_V v\| \le \eta \|P_V v\|\) on \((U \cap V)^\perp\); the **directional** estimate \(\|P_U P_V v\| \le \eta \|P_U v\|\) when \(v \in U\) (with an explicit note that the \(U\)-range hypothesis is necessary); and the \(K^\perp / L^\perp\) corollary for local excitation projections. The analysis aggregator imports the new file.
> 
> Chapter 13 blueprint (`ch13_parent_hamiltonian_spectral_gap_hilbert_space_rowsum.tex`) gains matching definitions and lemmas, each wired to the Lean names and marked `\leanok`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb892ca9665afd56d3633427623f853c2ec6784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->