### PR TITLE
doc(audits): record the sector-match contraction obstruction

### DIFF
--- a/docs/audits/2026-07-30_issue4916_sector_match_contraction_obstruction.md
+++ b/docs/audits/2026-07-30_issue4916_sector_match_contraction_obstruction.md
@@ -1,0 +1,96 @@
+# Sector-match contraction obstruction
+
+## Scope
+
+This note records the obstruction encountered while attempting to prove
+`periodicOverlap_gaugeEquiv_of_sector_match` in
+`TNLean/MPS/Periodic/Overlap/SectorMatch.lean`.
+
+The intended argument is arXiv:1708.00029, Appendix A, lines 1023–1117.
+No alternative argument was substituted.
+
+## Source argument
+
+Before the contraction begins, lines 985–1002 have produced, for every matched
+pair of sectors, a phase and an ambient corner partial unitary
+\[
+  U_v=P_uU_vQ_v
+\]
+such that the blocked corner tensors satisfy `eq:BCmprop`. In particular,
+\[
+  U_v^\dagger U_v=Q_v,\qquad U_vU_v^\dagger=P_u.
+\]
+
+The concatenation at lines 1041–1056 uses these support identities when
+successive blocked factors are multiplied. The application of the inverses
+\(\Omega_{u+1},\ldots,\Omega_u\) at lines 1057–1062 then leaves the uniform
+product-tensor identity `eq:resultprop`.
+
+## Lean-side mismatch
+
+The current input to `sectorTensor_proportional_of_blockedMatch` is
+`hBlockMatch`. For each sector it supplies only a `GaugePhaseEquiv` between the
+abstract compressed tensors
+`blocksA u` and `blocksB (u + q)`. The cyclic decomposition also supplies
+multiplicative, adjoint-preserving linear equivalences
+\[
+  \varphi^A_u:M_{\dim A_u}(\mathbb C)\longrightarrow P_uM_D(\mathbb C)P_u,
+  \qquad
+  \varphi^B_v:M_{\dim B_v}(\mathbb C)\longrightarrow Q_vM_D(\mathbb C)Q_v.
+\]
+However, the available API contains no theorem spatially implementing the
+induced isomorphism between these two ambient corners. The missing theorem must
+produce a matrix \(U_v\) satisfying
+\[
+  U_v=P_uU_vQ_v,\qquad
+  U_v^\dagger U_v=Q_v,\qquad
+  U_vU_v^\dagger=P_u,
+\]
+and transport the compressed gauge-phase equation to `eq:BCmprop` in the
+ambient matrix algebra.
+
+This is not supplied by `GaugePhaseEquiv`: its gauge matrix acts on the
+compressed bond space, whereas `cornerLetter`, `cornerProd`, and
+`repeatedBlocks_of_globalGauge` require matrices on the ambient bond space.
+The dimension equality in `GaugePhaseEquiv` is necessary but does not itself
+construct the spatial corner implementer.
+
+## Consequence for the existing contraction lemmas
+
+The two available contraction results begin strictly after this missing step:
+
+- `cornerProd_blockMatch_pow` assumes a direct scalar equality of ambient
+  corner products. It has no corner implementers and therefore cannot express
+  `eq:BCmprop`.
+- `exists_cornerProd_contraction_of_sectorRightInverse` contracts one ambient
+  corner family after its right inverse has been lifted. It does not transport
+  the same coefficients through the matched \(B\)-family and cancel adjacent
+  corner implementers.
+
+Thus source lines 1041–1062 do not currently transfer: the term whose adjacent
+partial unitaries the paper cancels cannot be stated from `hBlockMatch`.
+Proceeding directly from the compressed gauge matrices would require a new
+argument not present in the cited contraction.
+
+## Required continuation
+
+The source-faithful continuation requires the following result before the
+\(\Omega\)-contraction.
+
+1. Prove spatiality for two full complex matrix corners represented by the
+   supplied multiplicative, adjoint-preserving corner equivalences.
+2. Apply it to each compressed unitary gauge to obtain the ambient partial
+   unitaries \(U_v\) and the ambient blocked identity `eq:BCmprop`.
+3. Add the gauge-aware cyclic concatenation lemma in which adjacent identities
+   \(U_{v+1}^\dagger U_{v+1}=Q_{v+1}\) telescope.
+4. Combine that lemma with
+   `exists_cornerProd_contraction_of_sectorRightInverse` to obtain the uniform
+   product-tensor identity.
+5. Only then apply
+   `exists_kappa_product_one_of_piTensorProduct_eq_root_smul`, the
+   left-canonical unit-modulus normalization,
+   `exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`, and
+   `repeatedBlocks_of_globalGauge`.
+
+The first item is the missing formal ingredient corresponding to the ambient
+unitaries already present at arXiv:1708.00029, Appendix A, lines 985–1002.


### PR DESCRIPTION
Records, under `docs/audits/`, the obstruction met when attempting the cyclic
contraction of `periodicOverlap_gaugeEquiv_of_sector_match` along
arXiv:1708.00029, Appendix A, lines 1023-1117.

The source argument enters the contraction already holding, for every matched
pair of sectors, an ambient corner partial unitary $U_v = P_u U_v Q_v$ with
$U_v^\dagger U_v = Q_v$ and $U_v U_v^\dagger = P_u$ (lines 985-1002). The
concatenation at lines 1041-1056 cancels these adjacent identities, and the
inverses applied at lines 1057-1062 leave the uniform product-tensor identity.

The available hypothesis supplies only a gauge-phase equivalence between the
compressed sector tensors, whose gauge matrix acts on the compressed bond
space. Nothing in the present API spatially implements the induced isomorphism
of the two ambient corners, so the ambient blocked identity the paper cancels
cannot be stated, and both existing contraction lemmas begin strictly after
that missing step. The note lists the source-faithful continuation, whose first
item is exactly the spatial implementation result.

Documentation only: no Lean file is touched, and no `sorry` is added or moved.

Related: #4916 (the contraction the note analyses) and #5157 (the prerequisite
spatial implementation of a corner star-isomorphism by a partial isometry).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under `docs/audits/` with no runtime or formal proof impact.
> 
> **Overview**
> Adds **`docs/audits/2026-07-30_issue4916_sector_match_contraction_obstruction.md`**, documenting why the arXiv:1708.00029 Appendix A cyclic contraction for **`periodicOverlap_gaugeEquiv_of_sector_match`** cannot yet be completed in Lean.
> 
> The note contrasts the paper’s **ambient corner partial unitaries** \(U_v\) (with \(P_u/Q_v\) support identities) with today’s **`hBlockMatch`** input, which only gives **`GaugePhaseEquiv`** on compressed sector tensors. It explains that existing lemmas **`cornerProd_blockMatch_pow`** and **`exists_cornerProd_contraction_of_sectorRightInverse`** start after the missing **spatial corner implementer**, and lists a five-step source-faithful continuation (spatiality first, then \(\Omega\)-contraction and downstream phase lemmas).
> 
> **Documentation only** — no Lean files, sorries, or proof changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 864941c4fdab7a1280607e51766b58c4d117833b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->