### PR TITLE
feat(MPS): prove sharp literal CPSV block injectivity

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -73,6 +73,7 @@ import TNLean.MPS.MPDO.CPSVNormalizedGroupedSectors
 import TNLean.MPS.MPDO.CPSVOriginalSpaceLemmaL
 import TNLean.MPS.MPDO.CPSVPeriodicExclusion
 import TNLean.MPS.MPDO.CPSVRepresentativeGroupedLemmaL
+import TNLean.MPS.MPDO.CPSVSharpBlocking
 import TNLean.MPS.MPDO.CPSVVerticalBNT
 import TNLean.MPS.MPDO.CPSVVerticalCanonicalForm
 import TNLean.MPS.MPDO.CommonWeightAbsorbedBNTSupport

--- a/TNLean/MPS/MPDO/CPSVSharpBlocking.lean
+++ b/TNLean/MPS/MPDO/CPSVSharpBlocking.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.ActiveBNTRefinement
+import TNLean.MPS.MPDO.BiCFDerivation.BNTDirectSum
+import TNLean.MPS.MPDO.SourceBNTBlocking
+
+/-!
+# Sharp blocking bound for literal CPSV canonical form
+
+A CPSV basis of normal tensors whose total representative bond dimension is at most `K`
+has simultaneous product-algebra span at a positive length no greater than `3 * K ^ 5`.
+Applying this estimate to the active representatives of literal CPSV canonical-form data
+proves Proposition `propblockinj` of arXiv:1606.00608.
+
+## Main results
+
+* `IsCPSVBasisOfNormalTensors.exists_positive_wordTupleSpanTop_le_three_cap_pow_five`:
+  the quantitative simultaneous spanning theorem for a source BNT.
+* `IsCPSVCanonicalForm.exists_bnt_biCF_after_blocking_le_three_bondDim_pow_five`:
+  literal CPSV canonical form becomes block-injective canonical form after blocking at most
+  `3 * D ^ 5` sites.
+
+## References
+
+* arXiv:1606.00608, lines 317--345.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+private theorem wordTupleSpanTop_of_family_gaugeEquiv
+    {g L : ℕ} {dim : Fin g → ℕ}
+    {A B : (j : Fin g) → MPSTensor d (dim j)}
+    (hSpan : WordTupleSpanTop A L)
+    (hGauge : ∀ j, GaugeEquiv (A j) (B j)) :
+    WordTupleSpanTop B L := by
+  classical
+  choose X hX using hGauge
+  unfold WordTupleSpanTop at hSpan ⊢
+  apply top_unique
+  intro M _
+  let M' : (j : Fin g) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ := fun j =>
+    (↑((X j)⁻¹) : Matrix _ _ ℂ) * M j * (X j : Matrix _ _ ℂ)
+  have hM' : M' ∈ Submodule.span ℂ (Set.range (wordTuple A L)) := by
+    rw [hSpan]
+    exact Submodule.mem_top
+  obtain ⟨c, hc⟩ := (Submodule.mem_span_range_iff_exists_fun ℂ).mp hM'
+  apply (Submodule.mem_span_range_iff_exists_fun ℂ).2
+  refine ⟨c, ?_⟩
+  funext j
+  have hcj : (∑ w, c w • evalWord (A j) (List.ofFn w)) = M' j := by
+    simpa [wordTuple, Fintype.linearCombination_apply] using congrFun hc j
+  have hGoal : (∑ w, c w • evalWord (B j) (List.ofFn w)) = M j := by
+    calc
+      (∑ w, c w • evalWord (B j) (List.ofFn w)) =
+          ∑ w, c w • ((X j : Matrix _ _ ℂ) *
+            evalWord (A j) (List.ofFn w) *
+            (↑((X j)⁻¹) : Matrix _ _ ℂ)) := by
+        apply Finset.sum_congr rfl
+        intro w _
+        rw [evalWord_gauge (X j) (hX j)]
+      _ = (X j : Matrix _ _ ℂ) *
+          (∑ w, c w • evalWord (A j) (List.ofFn w)) *
+          (↑((X j)⁻¹) : Matrix _ _ ℂ) := by
+        rw [Matrix.mul_sum, Finset.sum_mul]
+        apply Finset.sum_congr rfl
+        intro w _
+        simp
+      _ = (X j : Matrix _ _ ℂ) * M' j *
+          (↑((X j)⁻¹) : Matrix _ _ ℂ) := by rw [hcj]
+      _ = M j := by simp [M', Matrix.mul_assoc]
+  simpa [wordTuple] using hGoal
+
+/-- A CPSV basis of normal tensors with total representative bond dimension at most `K`
+has simultaneous product-algebra span at a positive length at most `3 * K ^ 5`.
+
+The empty family is immediate. For one representative, the quantum Wielandt bound gives
+length `K ^ 4`. For at least two representatives, the three-block separation argument gives
+length `3 * (g - 1) * (K ^ 4 + 1)`, and positivity of every representative dimension implies
+`g ≤ K`.
+
+Source: arXiv:1606.00608, lines 317--345. -/
+theorem IsCPSVBasisOfNormalTensors.exists_positive_wordTupleSpanTop_le_three_cap_pow_five
+    {g K : ℕ} {dim : Fin g → ℕ}
+    {A : MPSTensor d D} {B : (j : Fin g) → MPSTensor d (dim j)}
+    (hK : 0 < K) (hDim : ∑ j, dim j ≤ K)
+    (hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩)) :
+    ∃ L : ℕ, 0 < L ∧ L ≤ 3 * K ^ 5 ∧ WordTupleSpanTop B L := by
+  classical
+  have hdimPos := hBNT.blocks_dim_pos
+  have hdimLe : ∀ j, dim j ≤ K := by
+    intro j
+    exact (Finset.single_le_sum (fun k _ => Nat.zero_le (dim k))
+      (Finset.mem_univ j)).trans hDim
+  have hK4pos : 0 < K ^ 4 := Nat.pow_pos hK
+  letI : ∀ j : Fin g, NeZero (dim j) := fun j => ⟨(hdimPos j).ne'⟩
+  choose σ _hσ _hσfix hTP hGauge hPrim hIrr using
+    fun j => (hBNT.blocks_normal j).exists_tpGauge
+  let prepared : (j : Fin g) → MPSTensor d (dim j) :=
+    fun j => tpGauge (B j) (σ j)
+  have hPreparedDistinct : BlocksNotGaugePhaseEquiv (d := d) prepared := by
+    intro j k hjk hdim hGPE
+    apply hBNT.blocks_not_gaugePhaseEquiv j k hjk hdim
+    exact gaugePhaseEquiv_of_gaugeEquiv_left_right_cast hdim
+      (hGauge j) (by simpa [prepared] using hGPE) (hGauge k)
+  have hPreparedNormal : ∀ j, IsNormal (prepared j) := by
+    intro j
+    exact isNormal_of_tp_primitive_irreducible
+      (prepared j) (hTP j) (hPrim j) (hIrr j)
+  have hBlk0 : ∀ j, IsNBlkInjective (prepared j) (K ^ 4) := by
+    intro j
+    have hOwn : IsNBlkInjective (prepared j) ((dim j) ^ 4) :=
+      isNBlkInjective_pow_four_of_isNormal_leftCanonical
+        (prepared j) (hTP j) (hPreparedNormal j)
+    exact isNBlkInjective_of_le (Nat.pow_pos (hdimPos j)) hOwn
+      (Nat.pow_le_pow_left (hdimLe j) 4)
+  by_cases hCountZero : g = 0
+  · subst g
+    refine ⟨1, by omega, ?_, ?_⟩
+    · have hK5pos : 0 < K ^ 5 := Nat.pow_pos hK
+      omega
+    · unfold WordTupleSpanTop
+      apply top_unique
+      intro X _
+      have hX : X = 0 := by
+        funext j
+        exact Fin.elim0 j
+      rw [hX]
+      exact Submodule.zero_mem _
+  by_cases hCountOne : g = 1
+  · refine ⟨K ^ 4, hK4pos, ?_, ?_⟩
+    · calc
+        K ^ 4 = K ^ 4 * 1 := by simp
+        _ ≤ K ^ 4 * (3 * K) := Nat.mul_le_mul_left _ (by omega)
+        _ = 3 * K ^ 5 := by ring
+    · have hPreparedSpan :=
+        wordTupleSpanTop_of_card_eq_one_of_isNBlkInjective
+          prepared hCountOne hBlk0
+      exact wordTupleSpanTop_of_family_gaugeEquiv hPreparedSpan
+        (fun j => (hGauge j).symm)
+  · have hCountTwo : 2 ≤ g := by omega
+    have hBlk1 : ∀ j, IsNBlkInjective (prepared j) (K ^ 4 + 1) := by
+      intro j
+      exact isNBlkInjective_of_le hK4pos (hBlk0 j) (by omega)
+    have hBlk3 : ∀ j, IsNBlkInjective (prepared j)
+        ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1))) := by
+      intro j
+      exact isNBlkInjective_of_le hK4pos (hBlk0 j) (by omega)
+    have hIrrBlocks : HasIrreducibleBlocks (d := d) prepared :=
+      HasIrreducibleBlocks.ofForall hIrr
+    have hLeft : IsLeftCanonicalBlockFamily (d := d) prepared :=
+      IsLeftCanonicalBlockFamily.ofForall hTP
+    have hOverlap : HasNormalizedSelfOverlap (d := d) prepared :=
+      HasNormalizedSelfOverlap.ofForall fun j =>
+        overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+          (prepared j) (hIrr j) (hTP j) (hPrim j)
+    have hPreparedSpan : WordTupleSpanTop prepared
+        ((g - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1)))) :=
+      wordTupleSpanTop_threeBlock_mul_pred_of_blocksNotGaugePhaseEquiv_c1
+        prepared hIrrBlocks hLeft hOverlap hPreparedDistinct
+        hBlk0 hBlk1 hBlk3 hK4pos hCountTwo
+    have hSpan : WordTupleSpanTop B
+        ((g - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1)))) :=
+      wordTupleSpanTop_of_family_gaugeEquiv hPreparedSpan
+        (fun j => (hGauge j).symm)
+    refine ⟨(g - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1))),
+      Nat.mul_pos (by omega) (by omega), ?_, hSpan⟩
+    have hCountLeSum : g ≤ ∑ j, dim j := by
+      calc
+        g = ∑ _j : Fin g, 1 := by simp
+        _ ≤ ∑ j : Fin g, dim j :=
+          Finset.sum_le_sum fun j _ => hdimPos j
+    have hCountLe : g ≤ K := hCountLeSum.trans hDim
+    have hPredLe : g - 1 ≤ K - 1 := Nat.sub_le_sub_right hCountLe 1
+    have hFirst :
+        (g - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1))) ≤
+          (K - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1))) :=
+      Nat.mul_le_mul_right _ hPredLe
+    refine hFirst.trans ?_
+    calc
+      (K - 1) * ((K ^ 4 + 1) + ((K ^ 4 + 1) + (K ^ 4 + 1))) =
+          3 * ((K - 1) * (K ^ 4 + 1)) := by ring
+      _ ≤ 3 * K ^ 5 :=
+        three_mul_pred_mul_pow_four_add_one_le_three_mul_pow_five hK
+
+/-- The active representative dimensions in literal CPSV canonical-form data sum to at most
+the ambient bond dimension. -/
+theorem CPSVCanonicalFormData.sum_activeRepresentative_dim_le
+    {A : MPSTensor d D} (data : CPSVCanonicalFormData A) :
+    ∑ j : Fin data.activePhaseClasses.g,
+      data.dim (data.activeRepresentativeIndex j) ≤ D := by
+  classical
+  let firstCopyIndex : Fin data.activePhaseClasses.g → Fin data.r := fun j =>
+    (data.activeClassCopyEquiv
+      ⟨j, ⟨0, data.activePhaseClasses.copies_pos j⟩⟩ : data.Active).1
+  have hFirstCopyIndex : ∀ j, firstCopyIndex j = data.activeRepresentativeIndex j := by
+    intro j
+    have hEnum : data.activePhaseClasses.enum j
+        ⟨0, data.activePhaseClasses.copies_pos j⟩ =
+        data.activePhaseClasses.repr j := by
+      simp [CPSVCanonicalFormData.activePhaseClasses]
+    change ((data.activeEquiv
+      (data.activePhaseClasses.enum j
+        ⟨0, data.activePhaseClasses.copies_pos j⟩) : data.Active) : Fin data.r) =
+      ((data.activeEquiv (data.activePhaseClasses.repr j) : data.Active) : Fin data.r)
+    rw [hEnum]
+  have hInjective : Function.Injective firstCopyIndex := by
+    intro j k hjk
+    have hSubtype :
+        data.activeClassCopyEquiv
+            ⟨j, ⟨0, data.activePhaseClasses.copies_pos j⟩⟩ =
+          data.activeClassCopyEquiv
+            ⟨k, ⟨0, data.activePhaseClasses.copies_pos k⟩⟩ := by
+      apply Subtype.ext
+      exact hjk
+    have hSigma := data.activeClassCopyEquiv.injective hSubtype
+    exact congrArg Sigma.fst hSigma
+  calc
+    (∑ j : Fin data.activePhaseClasses.g,
+        data.dim (data.activeRepresentativeIndex j)) =
+        ∑ j : Fin data.activePhaseClasses.g, data.dim (firstCopyIndex j) := by
+          apply Finset.sum_congr rfl
+          intro j _
+          rw [hFirstCopyIndex j]
+    _ = ∑ k ∈ Finset.image firstCopyIndex Finset.univ, data.dim k :=
+      (Finset.sum_image hInjective.injOn).symm
+    _ ≤ ∑ k ∈ Finset.univ, data.dim k :=
+      Finset.sum_le_sum_of_subset (Finset.subset_univ _)
+    _ = ∑ k : Fin data.r, data.dim k := rfl
+    _ ≤ D := data.total_dim_le
+
+/-- **CPSV16 Proposition `propblockinj`.** A tensor in literal CPSV canonical form has an
+active basis of normal tensors that becomes simultaneously block-injective after blocking a
+positive number `L ≤ 3 * D ^ 5` of sites.
+
+The conclusion is the one-letter span of the full product algebra of the chosen BNT. Inactive
+zero-weight coordinates are not included among the representatives.
+
+Source: arXiv:1606.00608, lines 317--345. -/
+theorem IsCPSVCanonicalForm.exists_bnt_biCF_after_blocking_le_three_bondDim_pow_five
+    {A : MPSTensor d D} [NeZero D] (hA : IsCPSVCanonicalForm A) :
+    ∃ g : ℕ, ∃ dim : Fin g → ℕ,
+      ∃ B : (j : Fin g) → MPSTensor d (dim j),
+        IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩) ∧
+        ∃ L : ℕ, 0 < L ∧ L ≤ 3 * D ^ 5 ∧
+          WordTupleSpanTop (fun j => blockTensor (B j) L) 1 := by
+  let data := Classical.choice hA
+  let ref := data.activeBNTRefinement
+  let dim : Fin data.activePhaseClasses.g → ℕ := fun j =>
+    data.dim (data.activeRepresentativeIndex j)
+  let B : (j : Fin data.activePhaseClasses.g) → MPSTensor d (dim j) := fun j =>
+    data.blocks (data.activeRepresentativeIndex j)
+  have hBNT : IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, B j⟩) := by
+    simpa [dim, B] using ref.representativesBNT
+  obtain ⟨L, hL, hLbound, hSpan⟩ :=
+    hBNT.exists_positive_wordTupleSpanTop_le_three_cap_pow_five
+      (NeZero.pos D) (by simpa [dim] using data.sum_activeRepresentative_dim_le)
+  exact ⟨data.activePhaseClasses.g, dim, B, hBNT, L, hL, hLbound,
+    wordTupleSpanTop_blockTensor_one B hSpan⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
+++ b/blueprint/src/chapter/ch10_bnt_block_injective_form.tex
@@ -140,6 +140,112 @@ apply it to coefficient-form and sector BNTs.
     statement.
 \end{proof}
 
+% Source anchors: CPSV16 lines 317--345.
+\begin{theorem}[Sharp simultaneous span under a total-dimension bound]
+    \label{thm:cpsv_bnt_sharp_span_ambient_cap}
+    \lean{MPSTensor.IsCPSVBasisOfNormalTensors.%
+        exists_positive_wordTupleSpanTop_le_three_cap_pow_five}
+    \leanok
+    \uses{def:bnt_cpsv, def:blockwise_product_word_span}
+    Let $(A_j)_{j=1}^{g}$ be a basis of normal tensors with bond dimensions
+    $D_j$. If $K>0$ and $\sum_jD_j\leq K$, then there is a positive integer
+    $L\leq3K^5$ such that
+    \begin{align}
+        \spn_{\C}\{(A_1^\omega,\ldots,A_g^\omega):|\omega|=L\}
+         & =\prod_{j=1}^{g}\MN{D_j}.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:cpsv_bnt_block_dimensions_positive,
+        thm:cpsv_bnt_blocks_not_gaugePhaseEquiv,
+        thm:cpsv_normal_tp_gauge,
+        thm:normal_tp_primitive_irred,
+        thm:exact_pow_four_block_injectivity_normal_left_canonical,
+        thm:wordspan_blk_inj_succ,
+        lem:bnt_direct_sum_block_separation_word_span,
+        lem:gauge_invariance_block_injective}
+    Put every representative in its trace-preserving Perron gauge. Since
+    $D_j\leq\sum_kD_k\leq K$, quantum Wielandt and homogeneous-span
+    propagation make every representative block-injective at $K^4$,
+    $K^4+1$, and $3(K^4+1)$. Conjugation preserves the simultaneous word
+    span.
+
+    For $g=0$, take $L=1$; the product algebra has only its zero element. For
+    $g=1$, take $L=K^4$. If $g\geq2$, the three-block separation theorem gives
+    \begin{align}
+        L&=3(g-1)(K^4+1).
+        \notag
+    \end{align}
+    Positivity of the $D_j$ gives
+    $g=\sum_j1\leq\sum_jD_j\leq K$, and hence
+    $L\leq3(K-1)(K^4+1)\leq3K^5$.
+\end{proof}
+
+% Source anchors: CPSV16 lines 219--225 and 265--301.
+\begin{theorem}[Total dimension of the active BNT representatives]
+    \label{thm:cpsv_active_bnt_dimension_bound}
+    \lean{MPSTensor.CPSVCanonicalFormData.sum_activeRepresentative_dim_le}
+    \leanok
+    \uses{def:cpsv_canonical_form,
+        thm:cpsv_canonical_form_active_bnt_refinement}
+    Let literal canonical-form data of ambient bond dimension $D$ have active
+    phase classes $j$ and chosen representatives of dimensions $D_j$. Then
+    \begin{align}
+        \sum_jD_j&\leq D.
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_canonical_form_active_bnt_refinement}
+    In every active phase class, choose its first copy. The class-copy
+    equivalence sends these choices to distinct displayed block indices, and
+    the first copy is the chosen representative. Thus the sum of the
+    representative dimensions is bounded by the sum over all displayed
+    blocks, which is at most $D$ by the canonical-form dimension bound.
+\end{proof}
+
+% Source anchor: CPSV16 Proposition propblockinj, lines 342--345.
+\begin{theorem}[Sharp block-injective form for literal CPSV canonical form]
+    \label{thm:cpsv_literal_propblockinj}
+    \lean{MPSTensor.IsCPSVCanonicalForm.%
+        exists_bnt_biCF_after_blocking_le_three_bondDim_pow_five}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:bnt_cpsv,
+        def:blocked_tensor, def:blockwise_product_word_span}
+    Let $A$ be in literal CPSV canonical form with positive ambient bond
+    dimension $D$. There is a basis of normal tensors
+    $(A_j)_{j=1}^{g}$ and a positive integer $L\leq3D^5$ such that
+    \begin{align}
+        \spn_{\C}\left\{((A_1^{[L]})^i,\ldots,(A_g^{[L]})^i):
+        0\leq i<d^L\right\}
+         & =\prod_{j=1}^{g}\MN{D_j}.
+        \notag
+    \end{align}
+    Hence $A$ is in block-injective canonical form after blocking at most
+    $3D^5$ sites. This is the proposition at
+    \cite[lines~342--345]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:cpsv_canonical_form_active_bnt_refinement,
+        thm:cpsv_active_bnt_dimension_bound,
+        thm:cpsv_bnt_sharp_span_ambient_cap,
+        thm:cpsv_bnt_blocked_simultaneous_span}
+    Choose one representative from every active matrix-product-vector phase
+    class. These representatives form a basis of normal tensors, and their
+    total bond dimension is at most $D$ by
+    Theorem~\ref{thm:cpsv_active_bnt_dimension_bound}. Apply
+    Theorem~\ref{thm:cpsv_bnt_sharp_span_ambient_cap} with $K=D$. A word of
+    length $L$ in $A_j$ is a one-letter evaluation of $A_j^{[L]}$, so the
+    resulting length-$L$ span is exactly the asserted one-letter span.
+\end{proof}
+
 Let $A$ be a tensor in canonical form, and let $A_1,\ldots,A_g$ be a basis of
 normal tensors of $A$. For suitable coefficients $\mu_{j,q}$ and invertible
 matrices $X_{j,q}$, write

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -48,23 +48,22 @@ theorem. This is tracked by issue #873 under the proposition-level tracker #81.
 
 ## 2. Coverage crosswalk: CPSV16 (arXiv:1606.00608)
 
-At this revision, after the normal-tensor RFP characterization, the trace-normalized RFP-to-ZCL-and-SAL result, and the unrestricted Proposition `prop3to4`, the paper has 45 theorem-like occurrences and 40 distinct results. The occurrence-level count is 20 complete, 11 partial, and 14 not-ready; the distinct-result count is 19 complete, 9 partial, and 12 not-ready. Here **not-ready** means that the printed statement is false, ambiguous, or depends essentially on a formally refuted source lemma. It does not mean that every printed result has been formalized.
+At this revision, after the normal-tensor RFP characterization, the trace-normalized RFP-to-ZCL-and-SAL result, the unrestricted Proposition `prop3to4`, the normal-sector blocking result for Theorem 4.9, and the literal sharp `propblockinj` theorem, the paper has 45 theorem-like occurrences and 40 distinct results. The occurrence-level count is 22 complete, 9 partial, and 14 not-ready; the distinct-result count is 21 complete, 7 partial, and 12 not-ready. Here **not-ready** means that the printed statement is false, ambiguous, or depends essentially on a formally refuted source lemma. It does not mean that every printed result has been formalized.
 
 The distinct count is the 40 source `thm`, `prop`, `cor`, and `lem`
 environments. The occurrence count adds five Appendix A/D restatements.
 The following ledger makes the count reproducible from source line numbers:
 
-- **Complete (19 distinct):** 249, 253, 398, 606, 945, 1080, 1121, 1130,
-  1274, 1333, 1351, 1406, 1510, 1569, 1647, 1680, 1786, 1835, and 2221.
-- **Partial (9 distinct):** 278, 342, 583, 801, 851, 972, 1013, 1597,
-  and 1801.
+- **Complete (21 distinct):** 249, 253, 342, 398, 606, 945, 1080, 1121, 1130,
+  1274, 1333, 1351, 1406, 1510, 1569, 1597, 1647, 1680, 1786, 1835, and 2221.
+- **Partial (7 distinct):** 278, 583, 801, 851, 972, 1013, and 1801.
 - **Not-ready (12 distinct):** 349, 354, 500, 534, 543, 777, 1155, 1197,
   1484, 1503, 1740, and 1810.
 - **Additional occurrences:** the Appendix A restatements at 1137, 1167,
   and 1172 inherit partial, not-ready, and not-ready status, respectively; the
   Appendix D restatements at 1863 and 1929 inherit complete and partial status.
   Thus the five restatements add one complete, two partial, and two not-ready
-  occurrences, giving the displayed totals 20/11/14.
+  occurrences, giving the displayed totals 22/9/14.
 
 Definitions, equations, and explanatory proof-segment rows are not counted.
 In particular, Eq. `II_XAX` at 1072--1077 is excluded, while the purification
@@ -81,7 +80,7 @@ segments of Theorems 3.1 and 3.10, not additional theorem occurrences.
 | Prop (l.253) | 253–255 | Projector criterion for canonical form | `TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean` (`MPSTensor.exists_normalTensor_blockDecomp_with_isometry_of_hasInvariantProjectorClosure`) | **complete**; #2634 closed |
 | Prop 2.7 (l.278, `prop:char-BNT`) | 278–280 | BNT characterization: every active canonical-form normal tensor is gauge-phase-equivalent to a basis element | `TNLean/MPS/CanonicalForm/BNTCharacterization.lean` (`MPSTensor.isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal`) | **partial** — the active-block characterization is complete, but positive-length MPVs cannot determine listed zero-weight blocks; see `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` |
 | Defn "injective" (l.317, `defnbi`) | 317–322 | A normal tensor is injective when its matrices span the full matrix algebra; biCF is block-injective canonical form | `TNLean/MPS/Defs.lean` (`MPSTensor.IsInjective`) and the biCF development under `TNLean/MPS/MPDO/BiCFDerivation/` | `leanok` |
-| Prop (l.342, `propblockinj`) | 342–345 | After blocking at most $3D^5$ spins, any canonical-form tensor becomes biCF | `TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean` (`IsBNTCanonicalForm.exists_basis_wordTupleSpanTop_le_three_totalDim_pow_five`) with `MPSTensor.hasBiCF_of_wordTupleSpanTop` | **partial** — the bound is proved for the stronger packaged `IsBNTCanonicalForm` surface, but the printed proposition starts from literal canonical form; the zero-weight ambiguity in Proposition 2.7 prevents the missing unconditional conversion |
+| Prop (l.342, `propblockinj`) | 342–345 | After blocking at most $3D^5$ spins, any canonical-form tensor becomes biCF | `TNLean/MPS/MPDO/CPSVSharpBlocking.lean` (`MPSTensor.IsCPSVCanonicalForm.exists_bnt_biCF_after_blocking_le_three_bondDim_pow_five`) | **complete** — literal canonical-form data supply an active BNT whose representative dimensions sum to at most the ambient bond dimension $D$; for $D>0$, blocking at a positive length $L\leq3D^5$ gives the simultaneous one-letter span of the full product matrix algebra |
 | **Theorem II.1** (l.349, `thm1`) | 349–352 | Fundamental theorem of MPVs, proportional case | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_proportional_canonicalForm`); `TNLean/MPS/CanonicalForm/BNTUniqueness.lean`; `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex` | **not-ready** — the printed BNT definition permits adjoining an unrelated normal tensor with coefficient zero at every length. The formal one-versus-two-element BNT example for the same tensor refutes the asserted equality of BNT cardinalities. The Lean fundamental theorem proves the corrected active, nonzero, converse-covered BNT statement |
 | **Corollary II.2** (l.354, `II_cor2`) | 354–361 | Equal MPVs imply conjugacy by an invertible matrix | `TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean` (`MPSTensor.fundamentalTheorem_equal_canonicalForm`); `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` | **not-ready** — literal canonical form permits inactive zero-weight blocks, which positive-length MPVs cannot detect; tensors with equal MPVs may therefore have different ambient dimensions, contradicting the printed dimension and global-conjugacy conclusion |
 
@@ -314,7 +313,7 @@ These are known oversized (documented in #1512/#1522) and do not block unrelated
 
 ## 7. Key remaining coverage gaps
 
-The 21 non-complete distinct CPSV16 results comprise 9 partial and 12
+The 19 non-complete distinct CPSV16 results comprise 7 partial and 12
 not-ready results. They are source-ambiguous, formally refuted, research-level,
 owner-held, or scope-restricted by the current formal interface. Lemma
 `Lsigma3`, the Hayashi strong-subadditivity equality characterization, and the
@@ -324,7 +323,6 @@ axiom-free.
 | Status | Paper | Result | Current certificate | Ownership |
 |---|---|---|---|---|
 | Partial | CPSV16 | Prop. 2.7, BNT characterization | Active blocks are characterized; listed zero-weight blocks are invisible to positive-length MPVs | Source clarification required |
-| Partial | CPSV16 | Proposition `propblockinj` | The $3D^5$ bound is proved for packaged BNT data, not for every literal canonical-form tensor | Blocked by the same zero-weight ambiguity as Proposition 2.7 |
 | Not-ready | CPSV16 | Theorem II.1 | The printed BNT definition admits an unrelated normal representative with identically zero coefficient; the formal one-versus-two-element example refutes the claimed equality of BNT cardinalities | `TNLean/MPS/CanonicalForm/BNTUniqueness.lean`; `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex` |
 | Not-ready | CPSV16 | Corollary II.2 | Inactive zero-weight blocks can change the ambient dimension without changing any positive-length MPV | `docs/paper-gaps/cpsv16_bnt_characterization_active_blocks.tex` |
 | Not-ready | CPSV16 | Appendix A Lemma `Lem:app_simple` | \([1]\) and \([1,0]\) have identical positive-power sums but different multisets; the formal corrections require nonzero entries or filter zeros | `TNLean/Algebra/ScalarPowerSumIdentity.lean`; `docs/paper-gaps/power_sum_alternative_route.tex` |

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -48,7 +48,7 @@ theorem. This is tracked by issue #873 under the proposition-level tracker #81.
 
 ## 2. Coverage crosswalk: CPSV16 (arXiv:1606.00608)
 
-At this revision, after the normal-tensor RFP characterization, the trace-normalized RFP-to-ZCL-and-SAL result, the unrestricted Proposition `prop3to4`, the normal-sector blocking result for Theorem 4.9, and the literal sharp `propblockinj` theorem, the paper has 45 theorem-like occurrences and 40 distinct results. The occurrence-level count is 22 complete, 9 partial, and 14 not-ready; the distinct-result count is 21 complete, 7 partial, and 12 not-ready. Here **not-ready** means that the printed statement is false, ambiguous, or depends essentially on a formally refuted source lemma. It does not mean that every printed result has been formalized.
+At this revision, after the normal-tensor RFP characterization, the trace-normalized RFP-to-ZCL-and-SAL result, the unrestricted Proposition `prop3to4`, the fixed-bond/source-ZCL SAL theorem, and the literal sharp `propblockinj` theorem, the paper has 45 theorem-like occurrences and 40 distinct results. The occurrence-level count is 22 complete, 9 partial, and 14 not-ready; the distinct-result count is 21 complete, 7 partial, and 12 not-ready. Here **not-ready** means that the printed statement is false, ambiguous, or depends essentially on a formally refuted source lemma. It does not mean that every printed result has been formalized.
 
 The distinct count is the 40 source `thm`, `prop`, `cor`, and `lem`
 environments. The occurrence count adds five Appendix A/D restatements.


### PR DESCRIPTION
## What changed
- prove the sharp simultaneous BNT word-span bound $L \le 3K^5$ under a total representative-dimension cap
- bound the active representative dimensions selected from literal CPSV canonical-form data by the ambient bond dimension
- conclude literal CPSV canonical form becomes block-injective canonical form after at most $3D^5$ sites, using the active BNT rather than false ambient injectivity
- add standalone Blueprint entries and promote CPSV16 `propblockinj` to complete in the maintained coverage audit

## Validation
- `lake build TNLean.MPS.MPDO.CPSVSharpBlocking` — passed (8952 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --ci` — passed
- `TEXINPUTS='../../tex/tenkz//:' lualatex -interaction=nonstopmode -halt-on-error print.tex` twice — passed; no undefined references (only pre-existing standalone citation warnings)
- `git diff --check origin/main...HEAD` — passed
- independent Lean review found no blocker or nit; checked the exact $3D^5$ argument and kernel axioms
- full `lake build` — passed (9830 jobs)

Closes #5160

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and documentation only; no runtime or security-sensitive paths. Main review surface is correctness of the quantitative blocking bound chain in Lean.
> 
> **Overview**
> Adds **`TNLean/MPS/MPDO/CPSVSharpBlocking.lean`** and wires it into the MPDO aggregator. The module proves that a CPSV basis of normal tensors with total representative bond dimension ≤ `K` has simultaneous product-algebra word span at some positive length **≤ `3K^5`**, that active BNT representatives from literal CPSV canonical-form data sum to at most ambient bond dimension **`D`**, and that **`IsCPSVCanonicalForm`** yields an active BNT with blocked one-letter span after blocking at **`L ≤ 3D^5`** sites—closing the gap where the old route needed packaged BNT data or false ambient injectivity.
> 
> **Blueprint** chapter 10 gains three linked theorems (`cpsv_bnt_sharp_span_ambient_cap`, active dimension bound, literal `propblockinj`). The **coverage audit** promotes CPSV16 Proposition at lines 342–345 from partial to **complete** and refreshes complete/partial counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b730e65a7bd54298c07be74fb90072b4e247685. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->