### PR TITLE
refactor(Wielandt): remove zero-reference auxiliaries (wave 7)

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/Basic.lean
@@ -15,8 +15,8 @@ import Mathlib.Data.Fin.Tuple.Basic
 
 This module contains the foundational rectangular-span theory used in the Wielandt
 bound: blocking preserves normality, blocked eigenvector transfer, the basic
-one-sided and cumulative rectangular spans, and the conditional and blocked
-fixed-length matrix spanning theorems for Lemma 2(b).
+one-sided rectangular span, and the conditional and blocked fixed-length matrix
+spanning theorems for Lemma 2(b).
 
 The later growth, stabilization, universality, and sharp quantitative theorems
 live in `TNLean.Wielandt.RectangularSpan.Growth` and
@@ -27,7 +27,7 @@ live in `TNLean.Wielandt.RectangularSpan.Growth` and
 - `isNormal_blockTensor`
 - `blockTensor_single_eigenvector`
 - `encodeBlock`, `blockTensor_apply_encodeBlock`
-- `rectSpan`, `cumulativeRectSpan`
+- `rectSpan`
 - `wielandt_lemma2b_conditional`
 - `wielandt_blocked_assembly`
 -/
@@ -197,43 +197,6 @@ theorem rectSpan_le_wordSpan (A : MPSTensor d D) {m n : ℕ}
   obtain ⟨Q, hQ, rfl⟩ := Submodule.mem_map.mp hM
   simp only [LinearMap.mulLeft_apply]
   exact (wordSpan_mul_le A m n) (Submodule.mul_mem_mul hP hQ)
-
-/-! ## Section 4: Cumulative rectangular span -/
-
-/-- The **cumulative rectangular span**: image of `cumulativeSpan` under left-mult by P. -/
-noncomputable def cumulativeRectSpan (P : Matrix (Fin D) (Fin D) ℂ)
-    (A : MPSTensor d D) (n : ℕ) :
-    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
-  Submodule.map (LinearMap.mulLeft ℂ P) (cumulativeSpan A n)
-
-/-- Monotonicity of cumulative rectangular span. -/
-theorem cumulativeRectSpan_mono
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) (n : ℕ) :
-    cumulativeRectSpan P A n ≤ cumulativeRectSpan P A (n + 1) :=
-  Submodule.map_mono (cumulativeSpan_mono A n)
-
-/-- Dimension bound for cumulative rectangular span. -/
-theorem cumulativeRectSpan_finrank_le
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) (n : ℕ) :
-    Module.finrank ℂ (cumulativeRectSpan P A n) ≤ D ^ 2 := by
-  calc Module.finrank ℂ (cumulativeRectSpan P A n)
-      ≤ Module.finrank ℂ (Matrix (Fin D) (Fin D) ℂ) := Submodule.finrank_le _
-    _ = D ^ 2 := by
-          rw [Module.finrank_matrix, Fintype.card_fin, Module.finrank_self, mul_one]; ring
-
-/-- When `cumulativeSpan A n = ⊤`, the cumulative rectangular span equals `range(mulLeft P)`. -/
-theorem cumulativeRectSpan_eq_range_of_cumulativeSpan_eq_top
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) {n : ℕ}
-    (htop : cumulativeSpan A n = ⊤) :
-    cumulativeRectSpan P A n = LinearMap.range (LinearMap.mulLeft ℂ P) := by
-  simp [cumulativeRectSpan, htop, Submodule.map_top]
-
-/-- Under `IsNormal`, cumulative rectangular span = range at level D². -/
-theorem cumulativeRectSpan_eq_range_of_isNormal [NeZero D]
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) (hN : IsNormal A) :
-    cumulativeRectSpan P A (D ^ 2) = LinearMap.range (LinearMap.mulLeft ℂ P) :=
-  cumulativeRectSpan_eq_range_of_cumulativeSpan_eq_top P A
-    (cumulativeSpan_eq_top A hN)
 
 /-! ## Section 5: Conditional fixed-length matrix spanning (Lemma 2(b)) -/
 

--- a/TNLean/Wielandt/RectangularSpan/Growth.lean
+++ b/TNLean/Wielandt/RectangularSpan/Growth.lean
@@ -12,8 +12,8 @@ import TNLean.Wielandt.RankOne.SpanGrowth
 This module develops the one-sided rectangular-span growth argument used in
 Wielandt Lemma 2(b). It proves that left-multiplication by `A i₀`
 induces an injective step map on `rectSpan ((A i₀)^D) A n`, deduces monotonicity
-of the associated finrank sequence, and proves the stabilization criteria that
-identify `rectSpan` and `cumulativeRectSpan` with `range (mulLeft P)`.
+of the associated finrank sequence, and proves criteria that identify `rectSpan`
+with `range (mulLeft P)`.
 
 `TNLean.Wielandt.RectangularSpan.Universality` builds on this file to turn stabilized
 rectangular spans into rank-one universality and the later sharp D²-D+1 theorems.
@@ -32,30 +32,6 @@ given `P = (A i₀)^D` (which kills the nilpotent block of `A i₀`), the subspa
 `rectSpan P A n` grow in dimension with each step, because left-multiplication by
 `A i₀` is injective on the range of `mulLeft P`.
 -/
-
-/-- Generic pigeonhole: a monotone function `ℕ → ℕ` bounded by `B` has a consecutive
-equality within the first `B` values (i.e., `∃ n ≤ B, a n = a (n + 1)`). -/
-theorem exists_consecutive_eq_of_monotone_bounded'
-    {B : ℕ} {a : ℕ → ℕ}
-    (ha_mono : ∀ n, a n ≤ a (n + 1))
-    (ha_bound : ∀ n, a n ≤ B) :
-    ∃ n ≤ B, a n = a (n + 1) := by
-  by_contra h
-  push Not at h
-  have hstrict : ∀ n ≤ B, a n < a (n + 1) := by
-    intro n hn
-    exact lt_of_le_of_ne (ha_mono n) (h n hn)
-  have hgrow : ∀ k, k ≤ B + 1 → a k ≥ a 0 + k := by
-    intro k hk
-    induction k with
-    | zero => omega
-    | succ k ih =>
-      have hih : a k ≥ a 0 + k := ih (by omega)
-      have hstep : a k < a (k + 1) := hstrict k (by omega)
-      omega
-  have : a (B + 1) ≥ a 0 + (B + 1) := hgrow (B + 1) le_rfl
-  have : a (B + 1) ≤ B := ha_bound (B + 1)
-  omega
 
 namespace RectSpanGrowth
 
@@ -167,24 +143,13 @@ end RectSpanGrowth
 
 /-! ## Section 8b: Stabilization — rectSpan meets full range
 
-This section provides the connection between `rectSpan`/`cumulativeRectSpan` and
+This section provides the connection between `rectSpan` and
 `LinearMap.range (mulLeft ℂ P)`:
 
-- `rectSpan_le_range` / `cumulativeRectSpan_le_range` : basic containment
+- `rectSpan_le_range`: basic containment
 - `rectSpan_eq_range_of_wordSpan_eq_top` : rectSpan = range when wordSpan = ⊤
 - `exists_rectSpan_eq_range_of_isNormal` : under `IsNormal`, some level reaches range
 - `rectSpan_eq_range_of_finrank_eq_range` : finrank criterion for rectSpan = range
-- `cumulativeRectSpan_eq_of_finrank_eq` : consecutive finrank eq → subspace equality
-- `cumulativeRectSpan_eq_range_of_finrank_eq_range_finrank` : finrank criterion (cumulative)
-- `cumulativeRectSpan_finrank_mono` : finrank is non-decreasing
-- `exists_cumulativeRectSpan_finrank_eq_succ` : pigeonhole stabilization within D² steps
-
-The cumulative-stabilization cluster (the five `cumulativeRectSpan_*` results
-above together with the pigeonhole helper
-`exists_consecutive_eq_of_monotone_bounded'` and the `cumulativeRectSpan_mono` /
-`cumulativeRectSpan_finrank_le` bounds in `RectangularSpan/Basic.lean`)
-currently has no callers outside the cluster; it is retained as advertised
-stabilization API while the keep/delete question is tracked separately.
 -/
 
 section RectSpanStabilization
@@ -228,55 +193,6 @@ theorem rectSpan_eq_range_of_finrank_eq_range
   haveI : FiniteDimensional ℂ (LinearMap.range (LinearMap.mulLeft ℂ P)) :=
     FiniteDimensional.finiteDimensional_submodule _
   exact Submodule.eq_of_le_of_finrank_eq (rectSpan_le_range P A n) hfin
-
-/-! ### Cumulative rectangular span: stabilization and full range -/
-
-/-- `cumulativeRectSpan P A n` is always contained in the range of `mulLeft P`. -/
-theorem cumulativeRectSpan_le_range (P : Matrix (Fin D) (Fin D) ℂ)
-    (A : MPSTensor d D) (n : ℕ) :
-    cumulativeRectSpan P A n ≤ LinearMap.range (LinearMap.mulLeft ℂ P) := by
-  rw [cumulativeRectSpan, ← Submodule.map_top (f := LinearMap.mulLeft ℂ P)]
-  exact Submodule.map_mono le_top
-
-/-- If finrank of consecutive cumulative rectangular spans are equal, they coincide
-as submodules. This uses monotonicity + `Submodule.eq_of_le_of_finrank_eq`. -/
-theorem cumulativeRectSpan_eq_of_finrank_eq
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) {n : ℕ}
-    (hfin : finrank ℂ (cumulativeRectSpan P A n) =
-            finrank ℂ (cumulativeRectSpan P A (n + 1))) :
-    cumulativeRectSpan P A n = cumulativeRectSpan P A (n + 1) := by
-  haveI : FiniteDimensional ℂ (cumulativeRectSpan P A (n + 1)) :=
-    FiniteDimensional.finiteDimensional_submodule _
-  exact Submodule.eq_of_le_of_finrank_eq (cumulativeRectSpan_mono P A n) hfin
-
-/-- If `finrank (cumulativeRectSpan P A n)` equals `finrank (range (mulLeft P))`, then
-`cumulativeRectSpan P A n = range (mulLeft P)`. -/
-theorem cumulativeRectSpan_eq_range_of_finrank_eq_range_finrank
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) {n : ℕ}
-    (hfin : finrank ℂ (cumulativeRectSpan P A n) =
-            finrank ℂ (LinearMap.range (LinearMap.mulLeft ℂ P))) :
-    cumulativeRectSpan P A n = LinearMap.range (LinearMap.mulLeft ℂ P) := by
-  haveI : FiniteDimensional ℂ (LinearMap.range (LinearMap.mulLeft ℂ P)) :=
-    FiniteDimensional.finiteDimensional_submodule _
-  exact Submodule.eq_of_le_of_finrank_eq (cumulativeRectSpan_le_range P A n) hfin
-
-/-- Finrank of the cumulative rectangular span is non-decreasing. -/
-theorem cumulativeRectSpan_finrank_mono
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) (n : ℕ) :
-    finrank ℂ (cumulativeRectSpan P A n) ≤
-      finrank ℂ (cumulativeRectSpan P A (n + 1)) :=
-  Submodule.finrank_mono (cumulativeRectSpan_mono P A n)
-
-/-- Pigeonhole: the non-decreasing bounded sequence
-`n ↦ finrank(cumulativeRectSpan P A n)` has a consecutive equality within `D²` steps. -/
-theorem exists_cumulativeRectSpan_finrank_eq_succ
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) :
-    ∃ n ≤ D ^ 2,
-      finrank ℂ (cumulativeRectSpan P A n) =
-      finrank ℂ (cumulativeRectSpan P A (n + 1)) :=
-  exists_consecutive_eq_of_monotone_bounded'
-    (fun n => cumulativeRectSpan_finrank_mono P A n)
-    (fun n => cumulativeRectSpan_finrank_le P A n)
 
 end RectSpanStabilization
 

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
@@ -6,11 +6,10 @@ Authors: TNLean contributors
 import TNLean.Wielandt.RectangularSpan.UniversalityAux.Basic
 
 /-!
-# Rectangular span universality auxiliary lemmas: quantitative ceiling
+# Rectangular span quantitative ceiling
 
-This module contains the Section 8e dimension-counting results for rectangular
-spans, including the quantitative cumulative-span range equality and the
-parametric Wielandt-length bounds derived from a stabilization witness.
+This module bounds the dimension of a rectangular span in terms of the rank
+of the fixed left factor.
 -/
 
 open scoped Matrix
@@ -19,23 +18,9 @@ namespace MPSTensor
 
 /-! ## Section 8e: Quantitative ceiling for one-sided rectangular span
 
-This section provides the quantitative dimension-counting lemmas for the
-exact Lemma 2(b) bound. The key results are:
-
-1. **Level zero**: `rectSpan P A 0 = span{P}` (`rectSpan_zero_eq_span`).
-2. **Tight ceiling**: `finrank(rectSpan P A n) ≤ D · rank(P)`, matching the exact formula
-   `finrank(range(mulLeft P)) = D · rank(P)` from `RectangularSpan/Ranges.lean`.
-3. **Quantitative range equality**: `cumulativeRectSpan_eq_range_quantitative`.
-4. **Parametric Wielandt-length bound**: `wielandt_parametric_span`, combining a `rectSpan`
-   stabilization witness with the conditional Lemma 2(b) rank-one step.
-
-These results are designed to combine with the already proved `vecMulVec_eigenvector_mem_wordSpan`
-to give the quantitative stage bound on the Wolf/paper path toward `D²-D+1`.
-
-Items 1, 3 and 4 currently have no in-repo callers: the consumers that
-motivated them were removed by dead-code sweeps, and they are retained as the
-module's advertised quantitative API while that keep/delete question is
-tracked separately. Item 2 stays live via `RectangularSpan/Universality.lean`.
+The tight ceiling
+`finrank(rectSpan P A n) ≤ D · rank(P)` matches the exact formula
+`finrank(range(mulLeft P)) = D · rank(P)` from `RectangularSpan/Ranges.lean`.
 
 ### References
 - arXiv:0909.5347, Lemma 2(b)
@@ -48,23 +33,6 @@ open Matrix Module
 
 variable {d D : ℕ}
 
-/-! ### Part 1: Initial dimension of rectSpan -/
-
-/-- `rectSpan P A 0 = span{P}`: the level-0 rectangular span is just the 1-D subspace
-spanned by `P` (since `wordSpan A 0 = span{1}`). -/
-theorem rectSpan_zero_eq_span (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) :
-    rectSpan P A 0 = Submodule.span ℂ {P} := by
-  simp only [rectSpan, wordSpan_zero]
-  rw [Submodule.map_span]
-  congr 1
-  ext M
-  simp only [Set.mem_image, Set.mem_singleton_iff, LinearMap.mulLeft_apply]
-  constructor
-  · rintro ⟨N, rfl, rfl⟩; simp
-  · intro hM; exact ⟨1, rfl, by simp [hM]⟩
-
-/-! ### Part 2: Tight ceiling for rectSpan finrank -/
-
 /-- **Tight ceiling**: `finrank(rectSpan P A n) ≤ D * rank(P)`.
 
 This improves the generic bound `≤ D²` when `rank(P) < D`, which is the case
@@ -76,81 +44,6 @@ theorem rectSpan_finrank_le_rank_mul_D (P : Matrix (Fin D) (Fin D) ℂ)
       ≤ finrank ℂ (LinearMap.range (LinearMap.mulLeft ℂ P)) :=
         Submodule.finrank_mono (rectSpan_le_range P A n)
     _ = D * P.rank := finrank_range_mulLeft P
-
-/-! ### Part 3: Quantitative cumulative rectangular span = range -/
-
-/-- **Quantitative cumulativeRectSpan = range under IsNormal.**
-
-Under `[NeZero D]` and `IsNormal A`, the cumulative rectangular span at level `D²` equals
-the full range of left-multiplication by `P`.
-
-This follows from `cumulativeSpan A (D²) = ⊤` (which is
-`cumulativeSpan_eq_top_of_isNormal_bound`). -/
-theorem cumulativeRectSpan_eq_range_quantitative [NeZero D]
-    (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D)
-    (hN : IsNormal A) :
-    cumulativeRectSpan P A (D ^ 2) = LinearMap.range (LinearMap.mulLeft ℂ P) := by
-  exact cumulativeRectSpan_eq_range_of_isNormal P A hN
-
-/-! ### Part 4: Parametric rectangular span — toward exact Lemma 2(b)
-
-The parametric rectangular span theorem combines:
-1. Power membership: `(A i₀)^D ∈ wordSpan A D`
-2. Eigenvector in range: `φ ∈ range(toLin' ((A i₀)^D))`
-3. Stabilization: `rectSpan ((A i₀)^D) A n₀ = range(mulLeft ((A i₀)^D))`
-4. Transfer: `vecMulVec φ ψ ∈ wordSpan A (D + n₀)`
-5. Conditional fixed-length matrix spanning: `wordSpan A (D + n₀ + 2(D-1)) = ⊤`
-
-into a single theorem parameterized by the stabilization witness `n₀`.
-
-When the Wielandt inductive bound is available (giving `n₀ ≤ D² - 3D + 3`),
-this yields `wordSpan A (D² - D + 1) = ⊤`.
--/
-
-/-- **Parametric Lemma 2(b) (rectangular span).**
-
-Given the full eigenvector/row-eigenvector setup AND a stabilization witness `n₀`
-such that `rectSpan ((A i₀)^D) A n₀ = range(mulLeft ((A i₀)^D))`, we get:
-
-  `wordSpan A (D + n₀ + 2*(D-1)) = ⊤`
-
-i.e., the word span at length `D + n₀ + 2D - 2` is the full matrix algebra.
-
-### Proof strategy
-1. Eigenvector `φ` lies in `range(toLin' ((A i₀)^D))`, so for all `ψ`,
-   `vecMulVec φ ψ ∈ rectSpan`.
-2. `rectSpan` stabilized at `n₀` → `vecMulVec φ ψ ∈ wordSpan A (D + n₀)`
-3. Apply conditional fixed-length matrix spanning (eigenvector spreading + row spreading)
-4. Output: `wordSpan A ((D-1) + ((D + n₀) + (D-1))) = ⊤`
-
-This simplifies to `wordSpan A (3D + n₀ - 2) = ⊤`.
-
-The hypothesis `n₀` is the key degree of freedom. Different bounds on `n₀`
-give different final bounds:
-- `n₀ = D² - 2D + 2` (normality witness): gives `D² + D = ⊤` (coarse)
-- `n₀ = D² - 4D + 3` (from induction on D): gives `D² - D + 1 = ⊤` (sharp) -/
-theorem wielandt_parametric_span [NeZero D]
-    (A : MPSTensor d D)
-    (hNormal : IsNormal (d := d) (D := D) A)
-    -- Column eigenvector
-    (i₀ : Fin d) (μ : ℂ) (hμ : μ ≠ 0)
-    (φ : Fin D → ℂ) (hφ : φ ≠ 0)
-    (heigφ : A i₀ *ᵥ φ = μ • φ)
-    -- Row eigenvector (for the conditional fixed-length matrix spanning)
-    (i₁ : Fin d) (ν : ℂ) (hν : ν ≠ 0)
-    (ψ₀ : Fin D → ℂ) (hψ₀ : ψ₀ ≠ 0)
-    (heigψ : (A i₁)ᵀ *ᵥ ψ₀ = ν • ψ₀)
-    -- Stabilization witness
-    {n₀ : ℕ}
-    (hstab : rectSpan ((A i₀) ^ D) A n₀ =
-             LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D))) :
-    wordSpan A ((D - 1) + ((D + n₀) + (D - 1))) = ⊤ := by
-  -- Step 1: vecMulVec φ ψ₀ ∈ wordSpan A (D + n₀)
-  have hRankOne : vecMulVec φ ψ₀ ∈ wordSpan A (D + n₀) :=
-    vecMulVec_eigenvector_mem_wordSpan A i₀ hμ heigφ hstab ψ₀
-  -- Step 2: Apply conditional fixed-length matrix spanning
-  exact wielandt_lemma2b_conditional A hNormal i₀ μ hμ φ hφ heigφ
-    i₁ ν hν ψ₀ hψ₀ heigψ hRankOne
 
 end QuantitativeCeiling
 

--- a/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -50,9 +50,6 @@ supplied by strong irreducibility, i.e. peripheral spectrum `{1}`.
 * `isNormal_of_algSpan_eq_top_of_aperiodic`:
   If `algSpan A = ⊤` and `1 ∈ wordSpan A 1`, then `IsNormal A`.
 
-* `isNormal_of_isIrreducibleAction_of_aperiodic`:
-  If `IsIrreducibleAction A`, `1 ∈ wordSpan A 1`, and `NeZero D`, then `IsNormal A`.
-
 ## References
 
 * arXiv:0909.5347, Proposition 3
@@ -260,23 +257,6 @@ theorem isNormal_of_algSpan_eq_top_of_aperiodic
     IsNormal A := by
   obtain ⟨N, hN⟩ := exists_cumulativeSpan_eq_top_of_algSpan_eq_top A halg
   exact isNormal_of_cumulativeSpan_eq_top_of_aperiodic A hN hone
-
-/-- If `IsIrreducibleAction A`, `1 ∈ wordSpan A 1`, and `NeZero D`, then `IsNormal A`.
-
-The full chain:
-```
-IsIrreducibleAction A
-  →  algSpan A = ⊤           (Burnside's theorem)
-  →  ∃ N, cumulativeSpan = ⊤  (Noetherian chain stabilization)
-  →  wordSpan A N = ⊤         (aperiodicity: 1 ∈ wordSpan A 1)
-  =  IsNormal A
-``` -/
-theorem isNormal_of_isIrreducibleAction_of_aperiodic [NeZero D]
-    (A : MPSTensor d D)
-    (hIrr : IsIrreducibleAction A)
-    (hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1) :
-    IsNormal A := by
-  exact isNormal_of_algSpan_eq_top_of_aperiodic A (burnside_matrix A hIrr) hone
 
 /-! ## Part 5: Eigenvector extraction from a nonzero-trace word -/
 


### PR DESCRIPTION
## Summary

Remove 15 unreferenced Wielandt auxiliaries in one deletion wave. The main
deletion is the closed cumulative rectangular-span cluster documented in
`RectangularSpan/Growth.lean`; three additional advertised leaves had no code
callers and did not state results from the cited sources.

The paper-appearing zero-reference statements remain in place.

## Scan methodology

A fresh scratch Python scan parsed top-level `theorem`, `lemma`, `def`,
`abbrev`, and `opaque` commands under `TNLean/Wielandt/**`, including commands
with prefixes such as `private` and `noncomputable`. For each declaration it
counted the final name component as an exact Lean identifier token across every
decodable tracked or untracked repository file, excluding only Git metadata and
build artifacts. The corpus therefore included all Lean sources, blueprint
files, `docs/`, `scripts/`, `Notes/`, and `Papers/`.

Instances and declarations with automatic-use attributes were excluded.
Exact-name searches also checked blueprint tags, documentation, scripts,
aliases, deprecated aliases, and exports.

The initial count-one inventory was:

| File | Candidates |
|---|---:|
| `RankOne/Element.lean` | 1 |
| `RectangularSpan/Growth.lean` | 1 |
| `SpanGrowth/CumulativeToWordSpan.lean` | 1 |
| **Total** | **3** |

All three are explicit arXiv:0909.5347 proof steps and were retained under the
paper-appearing rule.

To detect islands missed by count-one scanning, a second pass formed the
declaration dependency graph after removing comments from Wielandt source.
References from outside the scope, non-theorem commands, and automatic
attributes were live roots; liveness was propagated through proof
dependencies. This found the 12-declaration cumulative rectangular-span
cluster, together with three non-source advertised leaves. After deletion the
same passes were rerun. The only newly exposed count-one declaration was
`vecMulVec_eigenvector_mem_wordSpan`, the rank-one step in Lemma 2(b), which was
retained.

No scan false positives were found. No deleted declaration was a sibling of a
blueprint-cited theorem.

## Declarations and line counts

| File | Declarations | Diff | Net |
|---|---:|---:|---:|
| `RectangularSpan/Basic.lean` | 5 | +3 / -40 | -37 |
| `RectangularSpan/Growth.lean` | 6 | +4 / -88 | -84 |
| `RectangularSpan/UniversalityAux/Quantitative.lean` | 3 | +6 / -113 | -107 |
| `SpanGrowth/CumulativeToWordSpan.lean` | 1 | +0 / -20 | -20 |
| **Total** | **15** | **+13 / -261** | **-248** |

Removed declarations:

- `Basic.lean`: `cumulativeRectSpan`, `cumulativeRectSpan_mono`,
  `cumulativeRectSpan_finrank_le`,
  `cumulativeRectSpan_eq_range_of_cumulativeSpan_eq_top`,
  `cumulativeRectSpan_eq_range_of_isNormal`.
- `Growth.lean`: `exists_consecutive_eq_of_monotone_bounded'`,
  `cumulativeRectSpan_le_range`, `cumulativeRectSpan_eq_of_finrank_eq`,
  `cumulativeRectSpan_eq_range_of_finrank_eq_range_finrank`,
  `cumulativeRectSpan_finrank_mono`,
  `exists_cumulativeRectSpan_finrank_eq_succ`.
- `Quantitative.lean`: `rectSpan_zero_eq_span`,
  `cumulativeRectSpan_eq_range_quantitative`,
  `wielandt_parametric_span`.
- `CumulativeToWordSpan.lean`:
  `isNormal_of_isIrreducibleAction_of_aperiodic`.

## Wave structure

There were fewer than thirty deletable declarations, so the cleanup was one
15-declaration wave. A full build followed the wave, and both scanners were
rerun to the paper-protected fixed point.

## Verification

- `lake build -q --log-level=info`: passed, 9828 targets.
- `rg -n "sorry|axiom" TNLean/Wielandt/`: 0 before, 0 after.
- Regenerated `blueprint/lean_decls` with
  `scripts/blueprint_lean_sync.py --update-lean-decls`.
- `scripts/blueprint_lean_sync.py --ci`: passed; 5933 blueprint declaration
  targets found and all present.
- `cd blueprint && leanblueprint checkdecls`: passed.
- Exact final search: every deleted name is absent from Lean, blueprint,
  documentation, scripts, Notes, and Papers.

Progresses #4564

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of unused proofs and doc edits; no changes to cited paper-facing theorems or the remaining Lemma 2(b) `rectSpan` pipeline.
> 
> **Overview**
> **Wave 7 dead-code cleanup** removes fifteen Lean declarations that had no in-repo callers after identifier and dependency-graph scans. The largest cut is the **cumulative rectangular-span API** (`cumulativeRectSpan` and its monotonicity, finrank, range-equality, and pigeonhole stabilization lemmas in `RectangularSpan/Basic.lean` and `RectangularSpan/Growth.lean`), plus the generic helper `exists_consecutive_eq_of_monotone_bounded'`.
> 
> **Quantitative auxiliaries** in `RectangularSpan/UniversalityAux/Quantitative.lean` drop `rectSpan_zero_eq_span`, `cumulativeRectSpan_eq_range_quantitative`, and `wielandt_parametric_span`; the file now documents and keeps only the live ceiling `rectSpan_finrank_le_rank_mul_D`.
> 
> **Span growth** removes the convenience theorem `isNormal_of_isIrreducibleAction_of_aperiodic` from `SpanGrowth/CumulativeToWordSpan.lean` (Burnside → algSpan → normality chain), while the underlying `isNormal_of_algSpan_eq_top_of_aperiodic` path remains.
> 
> Module headers and main-result lists are updated to describe **one-sided `rectSpan`** only, without advertising the deleted cumulative or parametric APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a331190cacae945903f0bbb42274f44ee74de8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->