### PR TITLE
refactor(MPS/MPDO): distinguish transfer retracts from fusion isometries

### DIFF
--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -190,7 +190,7 @@ private theorem phaseFlipMPO_not_isRFP_MPDO_via_transferRetract :
     phaseFlipTensor_transferMap_apply] at hEntry
   norm_num [X] at hEntry
 
-/-- The support-algebra predicate does not imply the fusion predicate, even
+/-- The support-algebra predicate does not imply the transfer-retract predicate, even
 under trace preservation and the existence of a positive-definite fixed point.
 
 The witness is the qubit phase-flip channel with Kraus operators

--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.MPDO.FusionIsometries
 
 This file gives an explicit trace-preserving MPO tensor with a positive-definite
 fixed point which satisfies `MPOTensor.IsRFP_MPDO_via_algebra` but not
-`MPOTensor.IsRFP_MPDO_via_fusion`.
+`MPOTensor.IsRFP_MPDO_via_transferRetract`.
 
 ## References
 
@@ -176,10 +176,10 @@ private theorem phaseFlipMPO_isRFP_MPDO_via_algebra :
     phaseFlipMPO_isTP (Matrix.PosDef.one (n := Fin 2) (R := ℂ))
       phaseFlipMPO_one_fixed phaseFlipMPO_adjointFixedPoints_eq
 
-private theorem phaseFlipMPO_not_isRFP_MPDO_via_fusion :
-    ¬IsRFP_MPDO_via_fusion phaseFlipTensor.toMPOTensor := by
+private theorem phaseFlipMPO_not_isRFP_MPDO_via_transferRetract :
+    ¬IsRFP_MPDO_via_transferRetract phaseFlipTensor.toMPOTensor := by
   intro hFusion
-  have hRFP := isRFP_of_isRFP_MPDO_via_fusion hFusion
+  have hRFP := isRFP_of_isRFP_MPDO_via_transferRetract hFusion
   change MPOTensor.transferMap phaseFlipTensor.toMPOTensor ∘ₗ
       MPOTensor.transferMap phaseFlipTensor.toMPOTensor =
         MPOTensor.transferMap phaseFlipTensor.toMPOTensor at hRFP
@@ -202,12 +202,12 @@ This does not contradict arXiv:1606.00608, Theorem 4.14(ii). The converse in
 Appendix C.4, lines 2046--2085, assumes the positive BNT-label coefficient
 formula and the length-one idempotent trace identity, neither of which is part
 of `IsRFP_MPDO_via_algebra`. -/
-theorem exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion :
+theorem exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_transferRetract :
     ∃ (M : MPOTensor 2 2) (ρ : Matrix (Fin 2) (Fin 2) ℂ),
       Kraus.IsTP M.toMPSTensor ∧ ρ.PosDef ∧ MPOTensor.transferMap M ρ = ρ ∧
-        IsRFP_MPDO_via_algebra M ∧ ¬IsRFP_MPDO_via_fusion M :=
+        IsRFP_MPDO_via_algebra M ∧ ¬IsRFP_MPDO_via_transferRetract M :=
   ⟨phaseFlipTensor.toMPOTensor, 1, phaseFlipMPO_isTP,
     Matrix.PosDef.one (n := Fin 2) (R := ℂ), phaseFlipMPO_one_fixed,
-    phaseFlipMPO_isRFP_MPDO_via_algebra, phaseFlipMPO_not_isRFP_MPDO_via_fusion⟩
+    phaseFlipMPO_isRFP_MPDO_via_algebra, phaseFlipMPO_not_isRFP_MPDO_via_transferRetract⟩
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -178,8 +178,8 @@ private theorem phaseFlipMPO_isRFP_MPDO_via_algebra :
 
 private theorem phaseFlipMPO_not_isRFP_MPDO_via_transferRetract :
     ¬IsRFP_MPDO_via_transferRetract phaseFlipTensor.toMPOTensor := by
-  intro hFusion
-  have hRFP := isRFP_of_isRFP_MPDO_via_transferRetract hFusion
+  intro hRetract
+  have hRFP := isRFP_of_isRFP_MPDO_via_transferRetract hRetract
   change MPOTensor.transferMap phaseFlipTensor.toMPOTensor ∘ₗ
       MPOTensor.transferMap phaseFlipTensor.toMPOTensor =
         MPOTensor.transferMap phaseFlipTensor.toMPOTensor at hRFP

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -39,7 +39,7 @@ with the transfer-map fusion criterion from `FusionIsometries.lean`, this gives 
 one-way implication
 
 * `isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed`
-* `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed`
+* `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_transferRetract_of_isTP_of_posDef_fixed`
 
 from the current fusion formulation to the algebra formulation, under the same
 side hypotheses. The `IsRFP` assumption is essential here: without idempotence,
@@ -288,13 +288,13 @@ this algebra formulation.
 preservation and a positive-definite fixed point, used to invoke Wolf Theorem
 6.12) are absent from Theorem IV.13, which assumes only that `M` is in canonical
 form generating an MPDO; see `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
-theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed
-    {M : MPOTensor d D} (hFusion : IsRFP_MPDO_via_fusion M)
+theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_transferRetract_of_isTP_of_posDef_fixed
+    {M : MPOTensor d D} (hFusion : IsRFP_MPDO_via_transferRetract M)
     (h_tp : Kraus.IsTP M.toMPSTensor) {ρ : Mat} (hρ : ρ.PosDef)
     (hρ_fix : transferMap M ρ = ρ) :
     IsRFP_MPDO_via_algebra M :=
   isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
-    (M := M) (isRFP_of_isRFP_MPDO_via_fusion hFusion) h_tp hρ hρ_fix
+    (M := M) (isRFP_of_isRFP_MPDO_via_transferRetract hFusion) h_tp hρ hρ_fix
 
 /-- The current algebra-side predicate also holds whenever the blocked adjoint
 fixed-point spaces stabilize across all positive powers. This extracts exactly

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -35,13 +35,13 @@ coincides with the fixed-point algebra of the adjoint blocked transfer map
 
 Under a trace-preserving normalization and a positive-definite fixed point of the
 MPO transfer map, an RFP tensor yields a **stationary** algebra tower. Combined
-with the transfer-map fusion criterion from `FusionIsometries.lean`, this gives a
+with the transfer-retract criterion from `FusionIsometries.lean`, this gives a
 one-way implication
 
 * `isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed`
 * `isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_transferRetract_of_isTP_of_posDef_fixed`
 
-from the current fusion formulation to the algebra formulation, under the same
+from the current transfer-retract formulation to the algebra formulation, under the same
 side hypotheses. The `IsRFP` assumption is essential here: without idempotence,
 the adjoint fixed-point algebras of the blocked transfer maps need not stabilize
 with the blocking length.
@@ -281,7 +281,7 @@ theorem isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
    AlgebraStructureData.stationaryOfFaithfulFixedPoint_compatible
      (M := M) (h_tp := h_tp) hρ hρ_fix hRFP⟩
 
-/-- Under the same side hypotheses, the transfer-map fusion formulation implies
+/-- Under the same side hypotheses, the transfer-retract formulation implies
 this algebra formulation.
 
 **Scope restriction:** the side hypotheses `h_tp`/`hρ`/`hρ_fix` (trace
@@ -289,17 +289,17 @@ preservation and a positive-definite fixed point, used to invoke Wolf Theorem
 6.12) are absent from Theorem IV.13, which assumes only that `M` is in canonical
 form generating an MPDO; see `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 theorem isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_transferRetract_of_isTP_of_posDef_fixed
-    {M : MPOTensor d D} (hFusion : IsRFP_MPDO_via_transferRetract M)
+    {M : MPOTensor d D} (hRetract : IsRFP_MPDO_via_transferRetract M)
     (h_tp : Kraus.IsTP M.toMPSTensor) {ρ : Mat} (hρ : ρ.PosDef)
     (hρ_fix : transferMap M ρ = ρ) :
     IsRFP_MPDO_via_algebra M :=
   isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
-    (M := M) (isRFP_of_isRFP_MPDO_via_transferRetract hFusion) h_tp hρ hρ_fix
+    (M := M) (isRFP_of_isRFP_MPDO_via_transferRetract hRetract) h_tp hρ hρ_fix
 
 /-- The current algebra-side predicate also holds whenever the blocked adjoint
 fixed-point spaces stabilize across all positive powers. This extracts exactly
-what the present compatibility relation can see, without asserting the fusion /
-idempotence conclusion. -/
+what the present compatibility relation can see, without asserting the
+transfer-retract, equivalently idempotence, conclusion. -/
 theorem isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed
     {M : MPOTensor d D} (h_tp : Kraus.IsTP M.toMPSTensor)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ)
@@ -536,7 +536,7 @@ with eigenvalue `λ^n`.
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
 lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. This is the
 spectral fixed-point calculation underlying the obstruction to deriving the
-fusion formulation from the present support-algebra predicate alone. -/
+transfer-retract formulation from the present support-algebra predicate alone. -/
 theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector
     {M : MPOTensor d D} (n : ℕ) {lam : ℂ} {X : Mat}
     (hX : (transferMap M).adjoint X = lam • X) :
@@ -555,7 +555,7 @@ More explicitly, let `E` be the one-site transfer map. If
 `E† X = λ X`, and `λ^n = 1` for some `n > 0`, then `λ = 1`. This is exactly the
 finite-order consequence of the fixed-point equality
 $\operatorname{Fix}((E^n)^\dagger)=\operatorname{Fix}(E^\dagger)$. It is not
-the fusion-side idempotence statement $E^2=E$; the latter is the paper's
+the transfer-retract idempotence statement $E^2=E$; the latter is the paper's
 coefficient-comparison argument in Appendix C.4.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
@@ -583,9 +583,9 @@ the unblocked transfer map.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
 lines 2015--2067. This equality is only the fixed-point consequence of the
-present algebra-tower predicate. It is not the converse
-from the algebra formulation to the fusion formulation; the latter requires
-the positive trace-power coefficient comparison used in Appendix C.4. -/
+present algebra-tower predicate. It is not the converse from the algebra
+formulation to the paper's physical fusion-isometry formulation; the latter
+requires the positive trace-power coefficient comparison used in Appendix C.4. -/
 theorem adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {X : Mat} :

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -456,9 +456,9 @@ noncomputable def blockedInclusionCoefficients
 
 end AlgebraStructureData
 
-/-- One-site peeling of the blocked transfer map, $\mathbb{E}^{n+1} = \mathbb{E}^n \circ
-\mathbb{E}$, used in the spectral fixed-point calculation of arXiv:1606.00608,
-Appendix C.4, lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+/-- One-site peeling of the blocked transfer map,
+$\mathbb{E}^{n+1} = \mathbb{E}^n \circ \mathbb{E}$, used in the local spectral
+argument below. -/
 private theorem blockedTransferMap_succ (M : MPOTensor d D) (n : ℕ) :
     blockedTransferMap M (n + 1) = blockedTransferMap M n ∘ₗ transferMap M := by
   simp only [blockedTransferMap_eq_pow, pow_succ, Module.End.mul_eq_comp]

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -554,12 +554,13 @@ More explicitly, let `E` be the one-site transfer map. If
 `IsRFP_MPDO_via_algebra M` holds, `X ≠ 0`,
 `E† X = λ X`, and `λ^n = 1` for some `n > 0`, then `λ = 1`. This is exactly the
 finite-order consequence of the fixed-point equality
-$\operatorname{Fix}((E^n)^\dagger)=\operatorname{Fix}(E^\dagger)$. It is not
-the transfer-retract idempotence statement $E^2=E$; the latter is the paper's
-coefficient-comparison argument in Appendix C.4.
+$\operatorname{Fix}((E^n)^\dagger)=\operatorname{Fix}(E^\dagger)$. It does not
+imply the transfer-retract idempotence statement $E^2=E$. Appendix C.4 instead
+constructs physical trace-preserving completely positive maps between blocked
+tensors.
 
 Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+lines 2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {lam : ℂ} {X : Mat} (hX_ne : X ≠ 0)

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -533,10 +533,11 @@ If `X` is an eigenvector of the unblocked adjoint transfer map with eigenvalue
 `λ`, then it is an eigenvector of the adjoint blocked transfer map at size `n`
 with eigenvalue `λ^n`.
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. This is the
-spectral fixed-point calculation underlying the obstruction to deriving the
-transfer-retract formulation from the present support-algebra predicate alone. -/
+Comparison: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix
+C.4, lines 2046--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. The cited
+passages do not state this elementary power calculation; it records the
+spectral obstruction to deriving the transfer-retract formulation from the
+present support-algebra predicate alone. -/
 theorem adjoint_blockedTransferMap_apply_of_adjoint_transferMap_eigenvector
     {M : MPOTensor d D} (n : ℕ) {lam : ℂ} {X : Mat}
     (hX : (transferMap M).adjoint X = lam • X) :
@@ -559,8 +560,9 @@ imply the transfer-retract idempotence statement $E^2=E$. Appendix C.4 instead
 constructs physical trace-preserving completely positive maps between blocked
 tensors.
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+Comparison: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix
+C.4, lines 2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. The cited
+passages do not state this spectral consequence. -/
 theorem adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {lam : ℂ} {X : Mat} (hX_ne : X ≠ 0)
@@ -582,11 +584,12 @@ theorem adjoint_transferMap_eigenvalue_eq_one_of_isRFP_MPDO_via_algebra
 every positive blocked transfer map coincide with the adjoint fixed points of
 the unblocked transfer map.
 
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2015--2067. This equality is only the fixed-point consequence of the
-present algebra-tower predicate. It is not the converse from the algebra
-formulation to the paper's physical fusion-isometry formulation; the latter
-requires the positive trace-power coefficient comparison used in Appendix C.4. -/
+Comparison: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix
+C.4, lines 2015--2067. The cited passages do not state this equality. It is
+only the fixed-point consequence of the present algebra-tower predicate, not
+the converse from the algebra formulation to the paper's physical
+active-support fusion-coisometry formulation; the latter requires the positive
+trace-power coefficient comparison used in Appendix C.4. -/
 theorem adjoint_blockedTransferMap_apply_iff_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     {n : ℕ} (hn : 0 < n) {X : Mat} :
@@ -602,9 +605,12 @@ with the MPO tensor.
 Applying the fixed-point equality above to the stationary tower constructed
 from the faithful fixed point yields compatibility with the MPO tensor.  It is
 still only a consequence of the present algebra-tower predicate, not the source
-converse from Theorem IV.13(ii) to the fusion-isometry formulation.
-Source: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix C.4,
-lines 2015--2067 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+converse from Theorem IV.13(ii) to the active-support fusion-coisometry
+formulation.
+
+Comparison: arXiv:1606.00608, Theorem IV.13(ii), lines 972--985, and Appendix
+C.4, lines 2015--2067 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. The cited
+passages do not state this stationary-tower consequence. -/
 theorem stationaryOfFaithfulFixedPoint_compatible_of_isRFP_MPDO_via_algebra
     {M : MPOTensor d D} (hAlg : IsRFP_MPDO_via_algebra M)
     (h_tp : Kraus.IsTP M.toMPSTensor)

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -20,7 +20,7 @@ blocked size `n ≥ 1`, the doubled-index blocked tensor of an MPO has a blocked
 transfer map `Eₙ` acting on bond-space matrices, and the support algebra is
 modeled by a subspace through which `Eₙ` factors as a retract.
 
-Concretely, `FusionIsometryData M n` specifies a support subspace `𝒜ₙ`, a
+Concretely, `TransferRetractData M n` specifies a support subspace `𝒜ₙ`, a
 forward map `Tₙ : phys → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ → phys` with
 `Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`. The retract identity forces
 `Eₙ² = Eₙ`; conversely any idempotent blocked transfer map factors through its
@@ -35,12 +35,12 @@ The physical fusion isometries of Theorem 4.14(iii) are the object
 
 * `blockedTransferMap`: the transfer map of the `n`-site blocked doubled-index
   MPS tensor.
-* `FusionIsometryData`: retract structure whose characteristic identity is the
+* `TransferRetractData`: retract structure whose characteristic identity is the
   blocked transfer map.
-* `IsRFP_MPDO_via_fusion`: existence of such structures for every positive blocked
+* `IsRFP_MPDO_via_transferRetract`: existence of such structures for every positive blocked
   size.
-* `isRFP_MPDO_via_fusion_iff_isRFP`: equivalence with the MPDO RFP predicate.
-* `MPSTensor.toMPOTensor_isRFP_MPDO_via_fusion_iff_isTransferIdempotent`: pure-state recovery
+* `isRFP_MPDO_via_transferRetract_iff_isRFP`: equivalence with the MPDO RFP predicate.
+* `MPSTensor.toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent`: pure-state recovery
   for the diagonal MPO embedding.
 
 ## References
@@ -90,7 +90,7 @@ A support subspace of bond-space matrices together with a retract whose
 characteristic map is the blocked transfer map.  This is the
 transfer-map-level content of the idempotence criterion, not the paper's
 physical fusion isometry (see `BNTFusionIsometryFamily` for those). -/
-structure FusionIsometryData (M : MPOTensor d D) (n : ℕ) where
+structure TransferRetractData (M : MPOTensor d D) (n : ℕ) where
   /-- The support subspace through which the blocked transfer map factors. -/
   supportAlgebra : Submodule ℂ (FusionBondSpace D)
   /-- Forward map `T_n : phys → 𝒜_n`. -/
@@ -103,13 +103,13 @@ structure FusionIsometryData (M : MPOTensor d D) (n : ℕ) where
   map `E_n`. -/
   hST : S ∘ₗ T = blockedTransferMap M n
 
-namespace FusionIsometryData
+namespace TransferRetractData
 
 variable {M : MPOTensor d D} {n : ℕ}
 
 /-- Any transfer-retract witness forces the blocked transfer map at the same
 size to be idempotent. -/
-theorem blockedTransferMap_idempotent (F : FusionIsometryData M n) :
+theorem blockedTransferMap_idempotent (F : TransferRetractData M n) :
     blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n := by
   calc
     blockedTransferMap M n ∘ₗ blockedTransferMap M n
@@ -124,7 +124,7 @@ theorem blockedTransferMap_idempotent (F : FusionIsometryData M n) :
 witness by factoring through its range. -/
 noncomputable def ofBlockedTransferMapIdempotent
     (hE : blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n) :
-    FusionIsometryData M n where
+    TransferRetractData M n where
   supportAlgebra := (blockedTransferMap M n).range
   T := LinearMap.codRestrict (blockedTransferMap M n).range (blockedTransferMap M n)
     (fun x => ⟨x, rfl⟩)
@@ -144,10 +144,10 @@ noncomputable def ofBlockedTransferMapIdempotent
       (fun x => ⟨x, rfl⟩)
 
 /-- A level-`1` transfer-retract witness implies the MPDO RFP condition. -/
-theorem isRFP (F : FusionIsometryData M 1) : IsRFP M := by
+theorem isRFP (F : TransferRetractData M 1) : IsRFP M := by
   simpa only [IsRFP, blockedTransferMap_one] using F.blockedTransferMap_idempotent
 
-end FusionIsometryData
+end TransferRetractData
 
 /-- A one-site transfer-retract datum is equivalent to the MPDO RFP condition.
 
@@ -156,13 +156,13 @@ The forward direction is the retract calculation
 idempotent transfer map through its range.  This is a definitional unfolding:
 the source's Appendix C.4 constructs physical trace-preserving CP maps on the
 physical indices, not this bond-space retract. -/
-theorem fusionIsometryData_one_iff_isRFP (M : MPOTensor d D) :
-    Nonempty (FusionIsometryData M 1) ↔ IsRFP M := by
+theorem transferRetractData_one_iff_isRFP (M : MPOTensor d D) :
+    Nonempty (TransferRetractData M 1) ↔ IsRFP M := by
   constructor
   · rintro ⟨F⟩
     exact F.isRFP
   · intro hM
-    exact ⟨FusionIsometryData.ofBlockedTransferMapIdempotent
+    exact ⟨TransferRetractData.ofBlockedTransferMapIdempotent
       (M := M) (n := 1) (by simpa only [IsRFP, blockedTransferMap_one] using hM)⟩
 
 /-- If `M` is already an MPDO renormalization fixed point, then every positive
@@ -185,40 +185,40 @@ theorem blockedTransferMap_idempotent_of_isRFP {M : MPOTensor d D}
 
 For every positive blocked size `n`, the blocked transfer map of `M` factors as
 `S_n ∘ T_n` through some support subspace `𝒜_n`, with `T_n ∘ S_n = id_{𝒜_n}`. -/
-def IsRFP_MPDO_via_fusion (M : MPOTensor d D) : Prop :=
-  ∀ n : ℕ, 0 < n → Nonempty (FusionIsometryData M n)
+def IsRFP_MPDO_via_transferRetract (M : MPOTensor d D) : Prop :=
+  ∀ n : ℕ, 0 < n → Nonempty (TransferRetractData M n)
 
 /-- The transfer-retract formulation implies the MPDO RFP condition. -/
-theorem isRFP_of_isRFP_MPDO_via_fusion {M : MPOTensor d D}
-    (hM : IsRFP_MPDO_via_fusion M) : IsRFP M := by
+theorem isRFP_of_isRFP_MPDO_via_transferRetract {M : MPOTensor d D}
+    (hM : IsRFP_MPDO_via_transferRetract M) : IsRFP M := by
   obtain ⟨F⟩ := hM 1 Nat.one_pos
   exact F.isRFP
 
 /-- An MPDO renormalization fixed point admits transfer-retract structures at
 every positive blocking size. -/
-theorem isRFP_MPDO_via_fusion_of_isRFP {M : MPOTensor d D}
-    (hM : IsRFP M) : IsRFP_MPDO_via_fusion M := by
+theorem isRFP_MPDO_via_transferRetract_of_isRFP {M : MPOTensor d D}
+    (hM : IsRFP M) : IsRFP_MPDO_via_transferRetract M := by
   intro n hn
-  exact ⟨FusionIsometryData.ofBlockedTransferMapIdempotent
+  exact ⟨TransferRetractData.ofBlockedTransferMapIdempotent
     (M := M)
     (n := n)
     (blockedTransferMap_idempotent_of_isRFP hM hn)⟩
 
 /-- The transfer-retract formulation is equivalent to the current mixed-state
 RFP predicate. -/
-theorem isRFP_MPDO_via_fusion_iff_isRFP (M : MPOTensor d D) :
-    IsRFP_MPDO_via_fusion M ↔ IsRFP M := by
+theorem isRFP_MPDO_via_transferRetract_iff_isRFP (M : MPOTensor d D) :
+    IsRFP_MPDO_via_transferRetract M ↔ IsRFP M := by
   constructor
-  · exact isRFP_of_isRFP_MPDO_via_fusion
-  · exact isRFP_MPDO_via_fusion_of_isRFP
+  · exact isRFP_of_isRFP_MPDO_via_transferRetract
+  · exact isRFP_MPDO_via_transferRetract_of_isRFP
 
 /-- The all-blocked transfer-retract formulation is equivalent to a one-site
 transfer-retract datum.
 
 Follows from the equivalence with `IsRFP` and the one-site criterion. -/
-theorem isRFP_MPDO_via_fusion_iff_fusionIsometryData_one (M : MPOTensor d D) :
-    IsRFP_MPDO_via_fusion M ↔ Nonempty (FusionIsometryData M 1) := by
-  rw [isRFP_MPDO_via_fusion_iff_isRFP, fusionIsometryData_one_iff_isRFP]
+theorem isRFP_MPDO_via_transferRetract_iff_transferRetractData_one (M : MPOTensor d D) :
+    IsRFP_MPDO_via_transferRetract M ↔ Nonempty (TransferRetractData M 1) := by
+  rw [isRFP_MPDO_via_transferRetract_iff_isRFP, transferRetractData_one_iff_isRFP]
 
 end MPOTensor
 
@@ -230,8 +230,8 @@ variable {d D : ℕ}
 
 /-- For a pure MPS embedded diagonally as an MPO, the transfer-retract
 formulation recovers the original pure-state RFP condition. -/
-theorem toMPOTensor_isRFP_MPDO_via_fusion_iff_isTransferIdempotent (A : MPSTensor d D) :
-    MPOTensor.IsRFP_MPDO_via_fusion A.toMPOTensor ↔ IsTransferIdempotent A := by
-  rw [MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP, toMPOTensor_isRFP_iff_isTransferIdempotent]
+theorem toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent (A : MPSTensor d D) :
+    MPOTensor.IsRFP_MPDO_via_transferRetract A.toMPOTensor ↔ IsTransferIdempotent A := by
+  rw [MPOTensor.isRFP_MPDO_via_transferRetract_iff_isRFP, toMPOTensor_isRFP_iff_isTransferIdempotent]
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -59,7 +59,7 @@ variable {d D : ℕ}
 
 In the present transfer-map formulation this is the bond-space matrix algebra on
 which the blocked transfer map acts. -/
-abbrev FusionPhysicalSpace (D : ℕ) : Type :=
+abbrev FusionBondSpace (D : ℕ) : Type :=
   Matrix (Fin D) (Fin D) ℂ
 
 /-! ## Transfer-map-level retract data -/
@@ -67,7 +67,7 @@ abbrev FusionPhysicalSpace (D : ℕ) : Type :=
 /-- The blocked transfer map of an MPO tensor, obtained by viewing `M` as a
 Doubled-index MPS tensor and blocking `n` physical sites. -/
 noncomputable def blockedTransferMap (M : MPOTensor d D) (n : ℕ) :
-    FusionPhysicalSpace D →ₗ[ℂ] FusionPhysicalSpace D :=
+    FusionBondSpace D →ₗ[ℂ] FusionBondSpace D :=
   MPSTensor.transferMap
     (d := MPSTensor.blockPhysDim (d * d) n) (D := D)
     (MPSTensor.blockTensor (d := d * d) (D := D) M.toMPSTensor n)
@@ -92,11 +92,11 @@ transfer-map-level content of the idempotence criterion, not the paper's
 physical fusion isometry (see `BNTFusionIsometryFamily` for those). -/
 structure FusionIsometryData (M : MPOTensor d D) (n : ℕ) where
   /-- The support subspace through which the blocked transfer map factors. -/
-  supportAlgebra : Submodule ℂ (FusionPhysicalSpace D)
+  supportAlgebra : Submodule ℂ (FusionBondSpace D)
   /-- Forward map `T_n : phys → 𝒜_n`. -/
-  T : FusionPhysicalSpace D →ₗ[ℂ] supportAlgebra
+  T : FusionBondSpace D →ₗ[ℂ] supportAlgebra
   /-- Backward map `S_n : 𝒜_n → phys`. -/
-  S : supportAlgebra →ₗ[ℂ] FusionPhysicalSpace D
+  S : supportAlgebra →ₗ[ℂ] FusionBondSpace D
   /-- The retract identity `T_n ∘ S_n = id_{𝒜_n}`. -/
   hTS : T ∘ₗ S = LinearMap.id
   /-- The characteristic identity `S_n ∘ T_n = E_n` for the blocked transfer

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -27,9 +27,9 @@ forward map `Tₙ : M_D(ℂ) → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ �
 range. This yields an equivalence between `MPOTensor.IsRFP` and the
 transfer-retract formulation.
 
-The physical fusion isometries of Theorem 4.14(iii) are the object
-`BNTFusionIsometryFamily`, recorded in
-`TNLean/MPS/MPDO/BNTFusionIsometries.lean`.
+The source-faithful active-support fusion maps of Theorem 4.14(iii) are recorded
+by `BNTFusionCoisometryFamily`. Their stronger full-support specialization is
+recorded by `BNTFusionIsometryFamily`.
 
 ## Main declarations
 
@@ -86,7 +86,8 @@ map to the corresponding power. -/
 A support subspace of bond-space matrices together with a retract whose
 characteristic map is the blocked transfer map.  This is the
 transfer-map-level content of the idempotence criterion, not the paper's
-physical fusion isometry (see `BNTFusionIsometryFamily` for those). -/
+physical fusion map (see `BNTFusionCoisometryFamily` for the active-support
+family and `BNTFusionIsometryFamily` for its full-support specialization). -/
 structure TransferRetractData (M : MPOTensor d D) (n : ℕ) where
   /-- The support subspace through which the blocked transfer map factors. -/
   supportAlgebra : Submodule ℂ (FusionBondSpace D)

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -9,26 +9,27 @@ import TNLean.MPS.MPDO.PureRecovery
 import TNLean.MPS.MPDO.RFP
 
 /-!
-# Fusion-isometry formulations of the MPDO renormalization fixed point
+# Transfer-retract formulations of the MPDO renormalization fixed point
 
-This file gives the **fusion-isometry** side of the equivalence stated in
-arXiv:1606.00608 Section 4.5 (Cirac–Pérez-García–Schuch–Verstraete). In the notation
-of the paper, a fusion isometry at blocked size `n` is a pair of linear maps
-`T`, `S` between the physical space of `n` blocked sites and the corresponding
-support algebra of the tensor, with `T ∘ S = id` on the support algebra and
-`S ∘ T` the orthogonal projection onto its image in the physical space.
-Iterated applications of `T` and `S` reproduce the doubled-tensor transfer-map
-dynamics described by `MPOTensor.IsRFP` in `TNLean/MPS/MPDO/RFP.lean`. This file
-develops the transfer-map side of the fusion-isometry picture: a
-fusion-isometry witness at blocked size `n` is a retract factorization of the
-blocked transfer map through a support subspace of bond-space matrices.
-Concretely, if `Eₙ` denotes the blocked transfer map of `M`, then
-`FusionIsometryData M n` specifies a support subspace `𝒜ₙ`, a forward map
-`Tₙ : phys → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ → phys` with
+These definitions isolate the transfer-map content underlying the
+fusion-isometry picture of arXiv:1606.00608 Section 4.5
+(Cirac–Pérez-García–Schuch–Verstraete): they record when the blocked transfer
+map factors through its support algebra as a retract, which is the idempotence
+criterion, not the physical fusion isometry of two tensors into one. For each
+blocked size `n ≥ 1`, the doubled-index blocked tensor of an MPO has a blocked
+transfer map `Eₙ` acting on bond-space matrices, and the support algebra is
+modeled by a subspace through which `Eₙ` factors as a retract.
+
+Concretely, `FusionIsometryData M n` specifies a support subspace `𝒜ₙ`, a
+forward map `Tₙ : phys → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ → phys` with
 `Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`. The retract identity forces
-`Eₙ^2 = Eₙ`; conversely any idempotent blocked transfer map factors through its
+`Eₙ² = Eₙ`; conversely any idempotent blocked transfer map factors through its
 range. This yields an equivalence between `MPOTensor.IsRFP` and the
-transfer-map-level fusion formulation.
+transfer-retract formulation.
+
+The physical fusion isometries of Theorem 4.14(iii) are the object
+`BNTFusionIsometryFamily`, recorded in
+`TNLean/MPS/MPDO/BNTFusionIsometries.lean`.
 
 ## Main declarations
 
@@ -44,7 +45,7 @@ transfer-map-level fusion formulation.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.5 and Appendix C.4
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.5
   (Cirac–Pérez-García–Schuch–Verstraete, Ann. Phys. 378, 100–149).
 -/
 

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -62,7 +62,7 @@ which the blocked transfer map acts. -/
 abbrev FusionPhysicalSpace (D : ℕ) : Type :=
   Matrix (Fin D) (Fin D) ℂ
 
-/-! ## Transfer-map-level fusion data -/
+/-! ## Transfer-map-level retract data -/
 
 /-- The blocked transfer map of an MPO tensor, obtained by viewing `M` as a
 Doubled-index MPS tensor and blocking `n` physical sites. -/
@@ -84,12 +84,12 @@ map to the corresponding power. -/
     blockedTransferMap M 1 = transferMap M := by
   rw [blockedTransferMap_eq_pow (M := M), pow_one]
 
-/-- Transfer-map-level fusion-isometry structure at blocked size `n`.
+/-- Transfer-retract datum at blocked size `n`.
 
-This records the transfer-map part of the paper's fusion-isometry picture: a
-support subspace of bond-space matrices together with a retract whose
-characteristic map is the blocked transfer map. It is separate from the
-Hilbert-space isometry statement for the support algebra. -/
+A support subspace of bond-space matrices together with a retract whose
+characteristic map is the blocked transfer map.  This is the
+transfer-map-level content of the idempotence criterion, not the paper's
+physical fusion isometry (see `BNTFusionIsometryFamily` for those). -/
 structure FusionIsometryData (M : MPOTensor d D) (n : ℕ) where
   /-- The support subspace through which the blocked transfer map factors. -/
   supportAlgebra : Submodule ℂ (FusionPhysicalSpace D)
@@ -107,8 +107,8 @@ namespace FusionIsometryData
 
 variable {M : MPOTensor d D} {n : ℕ}
 
-/-- Any transfer-map-level fusion-isometry witness forces the blocked transfer map
-at the same size to be idempotent. -/
+/-- Any transfer-retract witness forces the blocked transfer map at the same
+size to be idempotent. -/
 theorem blockedTransferMap_idempotent (F : FusionIsometryData M n) :
     blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n := by
   calc
@@ -120,8 +120,8 @@ theorem blockedTransferMap_idempotent (F : FusionIsometryData M n) :
       simp only [LinearMap.id_comp]
     _ = blockedTransferMap M n := F.hST
 
-/-- An idempotent blocked transfer map yields a canonical fusion-isometry witness
-by factoring through its range. -/
+/-- An idempotent blocked transfer map yields a canonical transfer-retract
+witness by factoring through its range. -/
 noncomputable def ofBlockedTransferMapIdempotent
     (hE : blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n) :
     FusionIsometryData M n where
@@ -143,22 +143,19 @@ noncomputable def ofBlockedTransferMapIdempotent
       (blockedTransferMap M n).range
       (fun x => ⟨x, rfl⟩)
 
-/-- A level-`1` fusion-isometry witness implies the MPDO RFP condition. -/
+/-- A level-`1` transfer-retract witness implies the MPDO RFP condition. -/
 theorem isRFP (F : FusionIsometryData M 1) : IsRFP M := by
   simpa only [IsRFP, blockedTransferMap_one] using F.blockedTransferMap_idempotent
 
 end FusionIsometryData
 
-/-- A one-site transfer-map fusion retract is equivalent to the MPDO RFP
-condition.
+/-- A one-site transfer-retract datum is equivalent to the MPDO RFP condition.
 
 The forward direction is the retract calculation
 \(E_1^2 = S_1T_1S_1T_1 = S_1T_1\).  The reverse direction factors the
-idempotent transfer map through its range.
-
-Source: arXiv:1606.00608, Theorem IV.13(i), and Appendix C.4, lines
-2065--2085 of `Papers/1606.00608/MPDO-22-12-17-2.tex`, where the converse
-algebra-to-fusion proof constructs the one-step maps \(T\) and \(S\). -/
+idempotent transfer map through its range.  This is a definitional unfolding:
+the source's Appendix C.4 constructs physical trace-preserving CP maps on the
+physical indices, not this bond-space retract. -/
 theorem fusionIsometryData_one_iff_isRFP (M : MPOTensor d D) :
     Nonempty (FusionIsometryData M 1) ↔ IsRFP M := by
   constructor
@@ -184,21 +181,21 @@ theorem blockedTransferMap_idempotent_of_isRFP {M : MPOTensor d D}
   rw [blockedTransferMap_eq_transferMap_of_isRFP hM hn]
   exact hM
 
-/-- Transfer-map-level fusion-isometry formulation of the MPDO RFP condition.
+/-- Transfer-retract formulation of the MPDO RFP condition.
 
 For every positive blocked size `n`, the blocked transfer map of `M` factors as
 `S_n ∘ T_n` through some support subspace `𝒜_n`, with `T_n ∘ S_n = id_{𝒜_n}`. -/
 def IsRFP_MPDO_via_fusion (M : MPOTensor d D) : Prop :=
   ∀ n : ℕ, 0 < n → Nonempty (FusionIsometryData M n)
 
-/-- The transfer-map-level fusion formulation implies the MPDO RFP condition. -/
+/-- The transfer-retract formulation implies the MPDO RFP condition. -/
 theorem isRFP_of_isRFP_MPDO_via_fusion {M : MPOTensor d D}
     (hM : IsRFP_MPDO_via_fusion M) : IsRFP M := by
   obtain ⟨F⟩ := hM 1 Nat.one_pos
   exact F.isRFP
 
-/-- An MPDO renormalization fixed point admits transfer-map-level fusion structures
-at every positive blocking size. -/
+/-- An MPDO renormalization fixed point admits transfer-retract structures at
+every positive blocking size. -/
 theorem isRFP_MPDO_via_fusion_of_isRFP {M : MPOTensor d D}
     (hM : IsRFP M) : IsRFP_MPDO_via_fusion M := by
   intro n hn
@@ -207,20 +204,18 @@ theorem isRFP_MPDO_via_fusion_of_isRFP {M : MPOTensor d D}
     (n := n)
     (blockedTransferMap_idempotent_of_isRFP hM hn)⟩
 
-/-- The transfer-map-level fusion formulation is equivalent to the current
-mixed-state RFP predicate. -/
+/-- The transfer-retract formulation is equivalent to the current mixed-state
+RFP predicate. -/
 theorem isRFP_MPDO_via_fusion_iff_isRFP (M : MPOTensor d D) :
     IsRFP_MPDO_via_fusion M ↔ IsRFP M := by
   constructor
   · exact isRFP_of_isRFP_MPDO_via_fusion
   · exact isRFP_MPDO_via_fusion_of_isRFP
 
-/-- The all-blocked transfer-map fusion formulation is equivalent to a
-one-site fusion retract.
+/-- The all-blocked transfer-retract formulation is equivalent to a one-site
+transfer-retract datum.
 
-Thus, in the present transfer-map formulation, an algebra-to-fusion proof may
-be reduced to constructing the one-step retract appearing in Appendix C.4 of
-arXiv:1606.00608. -/
+Follows from the equivalence with `IsRFP` and the one-site criterion. -/
 theorem isRFP_MPDO_via_fusion_iff_fusionIsometryData_one (M : MPOTensor d D) :
     IsRFP_MPDO_via_fusion M ↔ Nonempty (FusionIsometryData M 1) := by
   rw [isRFP_MPDO_via_fusion_iff_isRFP, fusionIsometryData_one_iff_isRFP]
@@ -233,8 +228,8 @@ open MPOTensor
 
 variable {d D : ℕ}
 
-/-- For a pure MPS embedded diagonally as an MPO, the transfer-map-level
-fusion formulation recovers the original pure-state RFP condition. -/
+/-- For a pure MPS embedded diagonally as an MPO, the transfer-retract
+formulation recovers the original pure-state RFP condition. -/
 theorem toMPOTensor_isRFP_MPDO_via_fusion_iff_isTransferIdempotent (A : MPSTensor d D) :
     MPOTensor.IsRFP_MPDO_via_fusion A.toMPOTensor ↔ IsTransferIdempotent A := by
   rw [MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP, toMPOTensor_isRFP_iff_isTransferIdempotent]

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -21,7 +21,7 @@ transfer map `Eₙ` acting on bond-space matrices, and the support algebra is
 modeled by a subspace through which `Eₙ` factors as a retract.
 
 Concretely, `TransferRetractData M n` specifies a support subspace `𝒜ₙ`, a
-forward map `Tₙ : phys → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ → phys` with
+forward map `Tₙ : M_D(ℂ) → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ → M_D(ℂ)` with
 `Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`. The retract identity forces
 `Eₙ² = Eₙ`; conversely any idempotent blocked transfer map factors through its
 range. This yields an equivalence between `MPOTensor.IsRFP` and the
@@ -40,8 +40,8 @@ The physical fusion isometries of Theorem 4.14(iii) are the object
 * `IsRFP_MPDO_via_transferRetract`: existence of such structures for every positive blocked
   size.
 * `isRFP_MPDO_via_transferRetract_iff_isRFP`: equivalence with the MPDO RFP predicate.
-* `MPSTensor.toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent`: pure-state recovery
-  for the diagonal MPO embedding.
+* `MPSTensor.toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent`:
+  pure-state recovery for the diagonal MPO embedding.
 
 ## References
 
@@ -55,10 +55,7 @@ namespace MPOTensor
 
 variable {d D : ℕ}
 
-/-- The *physical space at blocked size `n`*.
-
-In the present transfer-map formulation this is the bond-space matrix algebra on
-which the blocked transfer map acts. -/
+/-- The bond-space matrix algebra on which the blocked transfer map acts. -/
 abbrev FusionBondSpace (D : ℕ) : Type :=
   Matrix (Fin D) (Fin D) ℂ
 
@@ -93,9 +90,9 @@ physical fusion isometry (see `BNTFusionIsometryFamily` for those). -/
 structure TransferRetractData (M : MPOTensor d D) (n : ℕ) where
   /-- The support subspace through which the blocked transfer map factors. -/
   supportAlgebra : Submodule ℂ (FusionBondSpace D)
-  /-- Forward map `T_n : phys → 𝒜_n`. -/
+  /-- Forward map `T_n : M_D(ℂ) → 𝒜_n`. -/
   T : FusionBondSpace D →ₗ[ℂ] supportAlgebra
-  /-- Backward map `S_n : 𝒜_n → phys`. -/
+  /-- Backward map `S_n : 𝒜_n → M_D(ℂ)`. -/
   S : supportAlgebra →ₗ[ℂ] FusionBondSpace D
   /-- The retract identity `T_n ∘ S_n = id_{𝒜_n}`. -/
   hTS : T ∘ₗ S = LinearMap.id
@@ -232,6 +229,7 @@ variable {d D : ℕ}
 formulation recovers the original pure-state RFP condition. -/
 theorem toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent (A : MPSTensor d D) :
     MPOTensor.IsRFP_MPDO_via_transferRetract A.toMPOTensor ↔ IsTransferIdempotent A := by
-  rw [MPOTensor.isRFP_MPDO_via_transferRetract_iff_isRFP, toMPOTensor_isRFP_iff_isTransferIdempotent]
+  rw [MPOTensor.isRFP_MPDO_via_transferRetract_iff_isRFP,
+    toMPOTensor_isRFP_iff_isTransferIdempotent]
 
 end MPSTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -101,7 +101,7 @@ fixed-point algebras compared in
 
 \begin{theorem}[Fusion yields a stationary algebra tower under a faithful fixed point]%
     \label{thm:mpdo_rfp_via_algebra_from_fusion}
-    \lean{MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_fusion_of_isTP_of_posDef_fixed}
+    \lean{MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_transferRetract_of_isTP_of_posDef_fixed}
     \leanok
     \uses{thm:mpdo_rfp_of_fusion, thm:mpdo_rfp_via_algebra_from_rfp}
     Assume the doubled tensor is trace-preserving and the transfer map admits a
@@ -346,7 +346,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
 
 \begin{theorem}[The support-algebra condition does not imply fusion]%
     \label{thm:mpdo_algebra_not_imply_fusion}
-    \lean{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion}
+    \lean{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_transferRetract}
     \leanok
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion,
         thm:mpdo_rfp_of_fusion,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -99,13 +99,13 @@ closed by $\tr$; the physical legs remain open. Their spans are the
 fixed-point algebras compared in
 \cite[Appendix~C.4, lines~1974--1980]{Cirac2016MPDO_arXiv}.
 
-\begin{theorem}[Fusion yields a stationary algebra tower under a faithful fixed point]%
+\begin{theorem}[A transfer retract yields a stationary algebra tower under a faithful fixed point]%
     \label{thm:mpdo_rfp_via_algebra_from_fusion}
     \lean{MPOTensor.isRFP_MPDO_via_algebra_of_isRFP_MPDO_via_transferRetract_of_isTP_of_posDef_fixed}
     \leanok
     \uses{thm:mpdo_rfp_of_fusion, thm:mpdo_rfp_via_algebra_from_rfp}
     Assume the doubled tensor is trace-preserving and the transfer map admits a
-    positive-definite fixed point. If the transfer-map fusion criterion holds,
+    positive-definite fixed point. If the transfer-retract criterion holds,
     then the MPO satisfies the algebra-structure formulation of the
     renormalization fixed-point condition.
 \end{theorem}
@@ -344,7 +344,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     $\Fix(E_1^\dagger)=\Fix(E_n^\dagger)$.
 \end{theorem}
 
-\begin{theorem}[The support-algebra condition does not imply fusion]%
+\begin{theorem}[The support-algebra condition does not imply a transfer retract]%
     \label{thm:mpdo_algebra_not_imply_fusion}
     \lean{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_transferRetract}
     \leanok
@@ -354,7 +354,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     There exists an MPO tensor of physical and bond dimension two such that the
     doubled tensor is trace-preserving, the transfer map has a
     positive-definite fixed point, and the support-algebra condition holds, but
-    the fusion condition does not hold.
+    the transfer-retract condition does not hold.
 \end{theorem}
 \begin{proof}\leanok
     Take the phase-flip channel with Kraus operators

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -374,10 +374,10 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     $\Fix((E^n)^\dagger)=\Fix(E^\dagger)$. Thus the support-algebra condition
     holds. On the other hand,
     $E^2(X)_{01}=\frac{49}{625}X_{01}\neq-\frac7{25}X_{01}=E(X)_{01}$.
-    Therefore $E^2\neq E$, so the fusion condition fails.
+    Therefore $E^2\neq E$, so the transfer-retract condition fails.
 \end{proof}
 
-\begin{remark}[Why algebra data do not imply fusion data]%
+\begin{remark}[Why algebra data do not imply transfer-retract data]%
     \label{rem:mpdo_algebra_to_fusion_gap}
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion,
         thm:mpdo_algebra_not_imply_fusion, thm:newton_girard}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -12,12 +12,12 @@ a retract. The physical fusion isometries of
 section, together with the derivation of the same-length product law from
 them.
 
-\begin{definition}[Transfer-map fusion-isometry datum]%
+\begin{definition}[Transfer-retract datum]%
     \label{def:mpdo_fusion_isometry}
     \lean{MPOTensor.TransferRetractData}
     \leanok
     \uses{def:mpo_tensor}
-    A \emph{transfer-map fusion-isometry datum} at blocked size $n$ for an
+    A \emph{transfer-retract datum} at blocked size $n$ for an
     MPO tensor consists of a subspace $\mathcal{A}_n \subseteq \MN{D}$
     together with linear maps
     \begin{align}
@@ -33,24 +33,24 @@ them.
     where $E_n$ denotes the blocked transfer map.
 \end{definition}
 
-\begin{definition}[Fusion-isometry RFP predicate]%
+\begin{definition}[Transfer-retract RFP predicate]%
     \label{def:mpdo_rfp_via_fusion}
     \lean{MPOTensor.IsRFP_MPDO_via_transferRetract}
     \leanok
     \uses{def:mpdo_fusion_isometry, def:mpo_tensor}
-    An MPO tensor $M$ satisfies the \emph{fusion-isometry formulation} of the
+    An MPO tensor $M$ satisfies the \emph{transfer-retract formulation} of the
     renormalization fixed-point condition when for every blocked size $n \ge 1$
-    there exists transfer-map fusion-isometry data for the blocked transfer
+    there exists transfer-retract data for the blocked transfer
     map $E_n$.
 \end{definition}
 
-\begin{theorem}[Fusion-isometry data imply transfer-map idempotence]%
+\begin{theorem}[Transfer-retract data imply transfer-map idempotence]%
     \label{thm:mpdo_rfp_of_fusion}
     \lean{MPOTensor.TransferRetractData.isRFP, MPOTensor.isRFP_of_isRFP_MPDO_via_transferRetract}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    A one-site fusion-isometry datum implies transfer-map idempotence. Hence the
-    fusion-isometry formulation, which supplies such data at every positive
+    A one-site transfer-retract datum implies transfer-map idempotence. Hence the
+    transfer-retract formulation, which supplies such data at every positive
     blocked size, implies the same condition.
 \end{theorem}
 \begin{proof}\leanok
@@ -73,7 +73,7 @@ them.
     \lean{MPOTensor.transferRetractData_one_iff_isRFP}
     \leanok
     \uses{def:mpdo_fusion_isometry}
-    A one-site transfer-map fusion-isometry datum exists if and only if the MPO
+    A one-site transfer-retract datum exists if and only if the MPO
     transfer map is idempotent.
 \end{theorem}
 \begin{proof}\leanok
@@ -82,18 +82,18 @@ them.
     it factors through its range, giving the required one-site datum.
 \end{proof}
 
-\begin{theorem}[Transfer-map fusion criterion for idempotence]%
+\begin{theorem}[Transfer-retract criterion for idempotence]%
     \label{thm:mpdo_rfp_via_fusion_iff}
     \lean{MPOTensor.isRFP_MPDO_via_transferRetract_iff_isRFP}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
-    The fusion-isometry formulation is equivalent to transfer-map idempotence.
+    The transfer-retract formulation is equivalent to transfer-map idempotence.
 \end{theorem}
 \begin{proof}\leanok\uses{thm:mpdo_rfp_of_fusion}
     The forward implication is Theorem~\ref{thm:mpdo_rfp_of_fusion}.
     Conversely, if the transfer map $E$ is idempotent, then every positive blocked
     transfer map equals $E$ and therefore factors through its range.
-    This range-factorization gives the required fusion-isometry data.
+    This range-factorization gives the required transfer-retract data.
 \end{proof}
 
 \begin{corollary}[Pure-state recovery]%
@@ -101,7 +101,7 @@ them.
     \lean{MPSTensor.toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent}
     \leanok
     \uses{thm:mpdo_rfp_via_fusion_iff}
-    For the diagonal MPO associated to a pure MPS tensor, the fusion-isometry
+    For the diagonal MPO associated to a pure MPS tensor, the transfer-retract
     formulation reduces to the usual pure-state RFP condition.
 \end{corollary}
 \begin{proof}\leanok
@@ -109,19 +109,19 @@ them.
     recovery theorem for the MPO predicate.
 \end{proof}
 
-\begin{theorem}[All-blocked fusion reduces to one-site fusion]%
+\begin{theorem}[All-blocked transfer retracts reduce to one site]%
     \label{thm:mpdo_fusion_iff_one_site_fusion}
     \lean{MPOTensor.isRFP_MPDO_via_transferRetract_iff_transferRetractData_one}
     \leanok
     \uses{def:mpdo_rfp_via_fusion, thm:mpdo_one_site_fusion_iff_rfp,
         thm:mpdo_rfp_via_fusion_iff}
-    The fusion-isometry formulation for all positive blocked sizes is
-    equivalent to the existence of a one-site transfer-map fusion-isometry
+    The transfer-retract formulation for all positive blocked sizes is
+    equivalent to the existence of a one-site transfer-retract
     datum.
 \end{theorem}
 \begin{proof}\leanok
     Combine the one-site criterion with the equivalence between the all-blocked
-    fusion formulation and transfer-map idempotence.
+    transfer-retract formulation and transfer-map idempotence.
 \end{proof}
 
 \begin{definition}[Operator product of MPO tensors]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -14,7 +14,7 @@ them.
 
 \begin{definition}[Transfer-map fusion-isometry datum]%
     \label{def:mpdo_fusion_isometry}
-    \lean{MPOTensor.FusionIsometryData}
+    \lean{MPOTensor.TransferRetractData}
     \leanok
     \uses{def:mpo_tensor}
     A \emph{transfer-map fusion-isometry datum} at blocked size $n$ for an
@@ -35,7 +35,7 @@ them.
 
 \begin{definition}[Fusion-isometry RFP predicate]%
     \label{def:mpdo_rfp_via_fusion}
-    \lean{MPOTensor.IsRFP_MPDO_via_fusion}
+    \lean{MPOTensor.IsRFP_MPDO_via_transferRetract}
     \leanok
     \uses{def:mpdo_fusion_isometry, def:mpo_tensor}
     An MPO tensor $M$ satisfies the \emph{fusion-isometry formulation} of the
@@ -46,7 +46,7 @@ them.
 
 \begin{theorem}[Fusion-isometry data imply transfer-map idempotence]%
     \label{thm:mpdo_rfp_of_fusion}
-    \lean{MPOTensor.FusionIsometryData.isRFP, MPOTensor.isRFP_of_isRFP_MPDO_via_fusion}
+    \lean{MPOTensor.TransferRetractData.isRFP, MPOTensor.isRFP_of_isRFP_MPDO_via_transferRetract}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
     A one-site fusion-isometry datum implies transfer-map idempotence. Hence the
@@ -70,7 +70,7 @@ them.
 
 \begin{theorem}[One-site fusion retract criterion]%
     \label{thm:mpdo_one_site_fusion_iff_rfp}
-    \lean{MPOTensor.fusionIsometryData_one_iff_isRFP}
+    \lean{MPOTensor.transferRetractData_one_iff_isRFP}
     \leanok
     \uses{def:mpdo_fusion_isometry}
     A one-site transfer-map fusion-isometry datum exists if and only if the MPO
@@ -84,7 +84,7 @@ them.
 
 \begin{theorem}[Transfer-map fusion criterion for idempotence]%
     \label{thm:mpdo_rfp_via_fusion_iff}
-    \lean{MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP}
+    \lean{MPOTensor.isRFP_MPDO_via_transferRetract_iff_isRFP}
     \leanok
     \uses{def:mpdo_rfp_via_fusion}
     The fusion-isometry formulation is equivalent to transfer-map idempotence.
@@ -98,7 +98,7 @@ them.
 
 \begin{corollary}[Pure-state recovery]%
     \label{cor:mpdo_fusion_pure_recovery}
-    \lean{MPSTensor.toMPOTensor_isRFP_MPDO_via_fusion_iff_isTransferIdempotent}
+    \lean{MPSTensor.toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent}
     \leanok
     \uses{thm:mpdo_rfp_via_fusion_iff}
     For the diagonal MPO associated to a pure MPS tensor, the fusion-isometry
@@ -111,7 +111,7 @@ them.
 
 \begin{theorem}[All-blocked fusion reduces to one-site fusion]%
     \label{thm:mpdo_fusion_iff_one_site_fusion}
-    \lean{MPOTensor.isRFP_MPDO_via_fusion_iff_fusionIsometryData_one}
+    \lean{MPOTensor.isRFP_MPDO_via_transferRetract_iff_transferRetractData_one}
     \leanok
     \uses{def:mpdo_rfp_via_fusion, thm:mpdo_one_site_fusion_iff_rfp,
         thm:mpdo_rfp_via_fusion_iff}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -68,7 +68,7 @@ them.
     idempotence.
 \end{proof}
 
-\begin{theorem}[One-site fusion retract criterion]%
+\begin{theorem}[One-site transfer-retract criterion]%
     \label{thm:mpdo_one_site_fusion_iff_rfp}
     \lean{MPOTensor.transferRetractData_one_iff_isRFP}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -312,9 +312,9 @@ derivation of the same-length product law from them.
             \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}.
         \label{eq:rfp_fusion_identity}
     \end{align}
-    This is the isometry statement of
+    This is the full-support specialization of the fusion statement in
     \cite[Theorem~4.14(iii)]{Cirac2016MPDO_arXiv}; the tensors are the
-    vertically read basis of normal tensors of
+    vertically read basis of normal tensors from
     \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}, so the physical dimension
     is the bond dimension of the original tensor. Statement (iii) of the
     source theorem additionally asserts the idempotent identity for the trace

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -7,10 +7,10 @@ which is the idempotence criterion, not the physical fusion isometry of two
 tensors into one. For each blocked size $n \ge 1$, the doubled-index blocked
 tensor of an MPO has a blocked transfer map $E_n$ acting on bond-space matrices,
 and the support algebra is modeled by a subspace through which $E_n$ factors as
-a retract. The physical fusion isometries of
-\cite[Theorem~4.14(iii)]{Cirac2016MPDO_arXiv} are recorded at the end of this
-section, together with the derivation of the same-length product law from
-them.
+a retract. The active-support fusion coisometries of
+\cite[Theorem~4.14(iii)]{Cirac2016MPDO_arXiv}, and their stronger full-support
+specialization, are recorded at the end of this section, together with the
+derivation of the same-length product law from them.
 
 \begin{definition}[Transfer-retract datum]%
     \label{def:mpdo_fusion_isometry}

--- a/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
+++ b/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
@@ -29,7 +29,7 @@ that the compatibility relation is trivial.
 
 ## The merged #611 API that one would naturally transfer from
 
-PR #665 (#611) added the transfer-map-level fusion formulation in
+PR #665 (#611) added the transfer-retract formulation in
 `TNLean/MPS/MPDO/FusionIsometries.lean`. For each blocked size `n`, it provides
 `MPOTensor.TransferRetractData M n` consisting of:
 

--- a/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
+++ b/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
@@ -31,7 +31,7 @@ that the compatibility relation is trivial.
 
 PR #665 (#611) added the transfer-map-level fusion formulation in
 `TNLean/MPS/MPDO/FusionIsometries.lean`. For each blocked size `n`, it provides
-`MPOTensor.FusionIsometryData M n` consisting of:
+`MPOTensor.TransferRetractData M n` consisting of:
 
 - a support subspace
   `supportAlgebra : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)`;
@@ -45,7 +45,7 @@ PR #665 (#611) added the transfer-map-level fusion formulation in
   `S ∘ₗ T = blockedTransferMap M n`.
 
 This is strong enough to prove
-`MPOTensor.isRFP_MPDO_via_fusion_iff_isRFP`, because an idempotent blocked
+`MPOTensor.isRFP_MPDO_via_transferRetract_iff_isRFP`, because an idempotent blocked
 transfer map factors through its range and conversely any such retract makes the
 blocked transfer map idempotent.
 
@@ -60,7 +60,7 @@ on the range of `blockedTransferMap M n` by
 
 `a ⋆ b := T (S a * S b)`.
 
-However, the current `supportAlgebra` in `FusionIsometryData` is only a
+However, the current `supportAlgebra` in `TransferRetractData` is only a
 `Submodule`, not a `Subalgebra` / `StarSubalgebra`, and the existing API does not
 prove that this projected product is associative or unital.
 
@@ -102,7 +102,7 @@ support-algebra structure carrying:
 - associativity and unit laws;
 - the relation to `E_n` as the corresponding projection / conditional expectation.
 
-At present, `FusionIsometryData.supportAlgebra` is only a `Submodule`, so the
+At present, `TransferRetractData.supportAlgebra` is only a `Submodule`, so the
 necessary algebraic laws cannot even be stated in the right form.
 
 ### 3. Basis-coordinate extraction for the coefficients
@@ -137,6 +137,6 @@ Suggested scope:
    identities needed on `range(E_n)`.
 2. Package `range(E_n)` as a `StarSubalgebra`-like support algebra with projected
    multiplication.
-3. Expose the bridge from `FusionIsometryData` to that support algebra.
+3. Expose the bridge from `TransferRetractData` to that support algebra.
 4. Only after this, return to issue #612 and define the algebra-structure
    coefficients and compatibility predicate in a non-vacuous way.

--- a/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
+++ b/docs/audits/2026-04-21_issue612_algebra_structure_blocker.md
@@ -55,7 +55,7 @@ The paper's algebra-structure formulation is not just a retract through a subspa
 It needs a genuine algebra object at each blocked size, together with multiplication
 coefficients `c_{αβγ}^{(L)}` and compatibility across blocking levels.
 
-The natural route from the merged fusion API would be to define a projected product
+The natural route from the merged transfer-retract API would be to define a projected product
 on the range of `blockedTransferMap M n` by
 
 `a ⋆ b := T (S a * S b)`.
@@ -87,7 +87,7 @@ Equivalently, one wants the standard form
 `E_n (E_n x * E_n y) = E_n (x * y)`.
 
 Without these identities there is no sound route to an associative multiplication
-on the support object extracted from the fusion datum.
+on the support object extracted from the transfer-retract datum.
 
 ### 2. Packaging the range as an algebra / support-algebra object
 
@@ -121,7 +121,7 @@ actually reflects the paper.
 ## Conclusion
 
 Issue #612 is blocked not by a local proof gap in `AlgebraStructure.lean`, but by a
-missing layer between the current fusion retracts and the paper's support-algebra
+missing layer between the current transfer retracts and the paper's support-algebra
 formulation. The correct next step is to build that missing layer first, and only
 then return to the algebra-structure coefficients themselves.
 

--- a/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
+++ b/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
@@ -1,4 +1,4 @@
-# Issue #826 scouting report — algebra ⇒ fusion converse
+# Issue #826 scouting report — algebra ⇒ transfer-retract converse
 
 Date: 2026-04-23; rebased on current `main` on 2026-04-25
 Branch: `feat/826-algebra-to-fusion-v2`

--- a/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
+++ b/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
@@ -8,7 +8,7 @@ Target issue: #826
 
 Issue #826 asks for the converse direction of the MPDO §4.5 equivalence:
 
-given the algebra-structure formulation, derive the transfer-map fusion
+given the algebra-structure formulation, derive the transfer-retract
 formulation under the same trace-preserving and positive-definite fixed-point
 side hypotheses used by the forward implication.
 

--- a/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
+++ b/docs/audits/2026-04-23_issue826_algebra_to_fusion_scout.md
@@ -78,6 +78,6 @@ of the blocked transfer maps.
 
 So the branch now gives an honest forward theorem and updated blueprint text,
 but it does **not** prove the requested converse
-`IsRFP_MPDO_via_algebra → IsRFP_MPDO_via_fusion`.
+`IsRFP_MPDO_via_algebra → IsRFP_MPDO_via_transferRetract`.
 The remaining gap is still the stronger coefficient/BNT layer from
 Appendix C.3–C.4.

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -209,8 +209,10 @@ coefficients, the positive $\chi_{\alpha,\beta,\gamma}$, or the length-one
 idempotent trace identity.  It proves the fixed-point-space equation above, not
 the displayed BNT coefficient comparison.  Thus a source-faithful construction
 must first obtain the BNT-label theorem witness from the MPDO tensor and then use
-the one-site retract criterion
-\leanid{MPOTensor.transferRetractData_one_iff_isRFP}.
+the trace identity to construct the physical trace-preserving completely
+positive maps of Appendix~C.4.  The one-site transfer-retract criterion
+\leanid{MPOTensor.transferRetractData_one_iff_isRFP} concerns the separate
+transfer-map idempotence predicate and cannot supply these physical maps.
 
 The scalar normalization step is now isolated independently of the still
 missing channel construction.  The structure

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -207,9 +207,9 @@ The present algebra predicate
 \leanid{MPOTensor.IsRFP_MPDO_via_algebra} does not include these BNT-label
 coefficients, the positive $\chi_{\alpha,\beta,\gamma}$, or the length-one
 idempotent trace identity.  It proves the fixed-point-space equation above, not
-the displayed BNT coefficient comparison.  Thus the source-faithful route to the
-fusion formulation must construct the BNT-label theorem witness from the MPDO
-tensor and then use the one-site retract criterion
+the displayed BNT coefficient comparison.  Thus a source-faithful construction
+must first obtain the BNT-label theorem witness from the MPDO tensor and then use
+the one-site retract criterion
 \leanid{MPOTensor.transferRetractData_one_iff_isRFP}.
 
 The scalar normalization step is now isolated independently of the still
@@ -826,7 +826,7 @@ To eliminate the source-theorem gap, the formalization should instead:
         $S=\widetilde R_1\widetilde S R_2$ exactly as in lines~2065--2085;
     \item conclude the paper's renormalization fixed-point predicate, namely
         the existence of the two trace-preserving completely positive maps in
-        Definition~4.1.  Any comparison with the transfer-map fusion predicate
+        Definition~4.1.  Any comparison with the transfer-retract predicate
         must then be stated separately, because the latter is presently
         equivalent to transfer-map idempotence rather than Definition~4.1.
 \end{enumerate}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -135,7 +135,7 @@ the fixed-point-space identity
     \qquad n>0.
 \]
 This rules out root-of-unity peripheral eigenvalues of $E^\dagger$, but it does
-not imply the fusion-side idempotence equation $E^2=E$.
+not imply the transfer-retract idempotence equation $E^2=E$.
 
 This failure is formalized by
 \leanid{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_transferRetract}.

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -138,7 +138,7 @@ This rules out root-of-unity peripheral eigenvalues of $E^\dagger$, but it does
 not imply the fusion-side idempotence equation $E^2=E$.
 
 This failure is formalized by
-\leanid{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion}.
+\leanid{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_transferRetract}.
 The counterexample is the phase-flip channel with Kraus operators
 $K_0=\frac35 I$ and $K_1=\frac45 Z$.  It is trace-preserving, fixes the
 positive-definite matrix $I$, and has off-diagonal eigenvalue $-\frac7{25}$.
@@ -210,7 +210,7 @@ idempotent trace identity.  It proves the fixed-point-space equation above, not
 the displayed BNT coefficient comparison.  Thus the source-faithful route to the
 fusion formulation must construct the BNT-label theorem witness from the MPDO
 tensor and then use the one-site retract criterion
-\leanid{MPOTensor.fusionIsometryData_one_iff_isRFP}.
+\leanid{MPOTensor.transferRetractData_one_iff_isRFP}.
 
 The scalar normalization step is now isolated independently of the still
 missing channel construction.  The structure


### PR DESCRIPTION
## Motivation

`MPOTensor.FusionIsometryData` was a retract factorization of the blocked transfer map on bond-space matrices. It was not the physical fusion isometry (U_{\alpha,\beta}) of CPSV16, Theorem 4.14(iii), which is represented by `BNTFusionIsometryFamily`. Its one-site equivalence also cited Appendix C.4, lines 2065–2085, although the maps constructed there are trace-preserving completely positive maps on physical indices rather than this bond-space retract.

## Changes

- rename `FusionPhysicalSpace` to `FusionBondSpace`;
- rename `FusionIsometryData` and its namespace to `TransferRetractData`;
- rename `IsRFP_MPDO_via_fusion` and all associated theorems to transfer-retract terminology;
- update every downstream Lean, Blueprint, audit, and paper-gap reference;
- describe the maps as acting on (M_D(\mathbb C)), and distinguish them from both the CPSV16 fusion isometries and the physical completely positive maps of Appendix C.4;
- align reader-facing Blueprint prose with the corrected terminology.

No deprecated aliases are introduced: the retired names encode a mathematically misleading identification between a bond-space retract and a physical fusion isometry. Declaration types, definition bodies, theorem statements, and proofs are unchanged modulo identifier and local-binder renaming.

## Verification

- `lake exe cache get`
- `lake build` — 9,832 jobs, successful
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main --diff-head HEAD`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- independent source-faithfulness and exact-diff reviews

Closes #5171.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identifier and documentation renames only; theorem statements and proofs are unchanged aside from names, with no deprecated aliases.
> 
> **Overview**
> This PR **renames** the MPDO API that records when a blocked transfer map factors through bond-space support as a retract (`S ∘ T = E`, `T ∘ S = id`). That notion was previously labeled fusion-isometry; it is **not** the physical fusion maps \(U_{\alpha,\beta}\) from CPSV Theorem 4.14(iii), which stay as `BNTFusionCoisometryFamily` / `BNTFusionIsometryFamily`.
> 
> **Lean (`FusionIsometries.lean` and dependents):** `FusionPhysicalSpace` → `FusionBondSpace`; `FusionIsometryData` → `TransferRetractData`; `IsRFP_MPDO_via_fusion` → `IsRFP_MPDO_via_transferRetract`, with matching theorem and namespace renames. Module docs now stress bond-space idempotence vs. Appendix C.4 physical CP maps, and drop the misleading citation that Appendix C.4 proves the one-site retract equivalence.
> 
> **`AlgebraStructure.lean` / counterexample:** Forward implication and the phase-flip counterexample use the new names; docstrings distinguish transfer-retract idempotence from active-support fusion coisometries and clarify which CPSV passages are comparisons vs. stated results.
> 
> **Blueprint and paper-gap docs:** Reader-facing prose, `\lean{}` links, and audits align with the new identifiers and the fusion vs. retract distinction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62851b01b2dd1b435c770bb281f13cfa7c7b427d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->