### PR TITLE
fix(tenkz): handle exterior open rays

### DIFF
--- a/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
+++ b/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
@@ -93,6 +93,16 @@
       { \errmessage{a~diagonal~ray~snapped~to~a~rectangle~corner} }
     \fp_compare:nNnF { abs(\l_tmpb_tl - 3) } < {0.000001}
       { \errmessage{a~diagonal~ray~missed~the~first~rectangle~margin} }
+    \__tenkz_geom_rect_ray_intersect:nnnnnnnNN
+      {5}{1}{180}{0}{4}{0}{3} \l_tmpa_tl \l_tmpb_tl
+    \fp_compare:nNnF { abs(\l_tmpa_tl - 4) } < {0.000001}
+      { \errmessage{an~outside~ray~missed~its~first~rectangle~entry} }
+    \fp_compare:nNnF { abs(\l_tmpb_tl - 1) } < {0.000001}
+      { \errmessage{an~outside~ray~changed~its~transverse~coordinate} }
+    \__tenkz_geom_rect_ray_intersect:nnnnnnnNN
+      {5}{1}{0}{0}{4}{0}{3} \l_tmpa_tl \l_tmpb_tl
+    \tl_if_empty:NF \l_tmpa_tl
+      { \errmessage{an~outward~outside~ray~invented~a~backward~intersection} }
     \seq_clear:N \l__tenkz_test_support_seq
     \seq_put_right:Nn \l__tenkz_test_support_seq
       { {circle}{0}{0}{0}{0}{0}{0} }

--- a/tests/tenkz/kernel/regression/r_affine_open_rays.tex
+++ b/tests/tenkz/kernel/regression/r_affine_open_rays.tex
@@ -75,6 +75,24 @@
     \__tenkz_geom_frame_declare_plane:n {kpic}
     \__tenkz_test_affine_open_ray:nnn {ne}{2}{2}
     \__tenkz_test_affine_open_ray:nnn {sw}{2}{4}
+    \__tenkz_kernel_r_frame_xy:nnNN {2}{6}
+      \l__tenkz_kernel_r_xc_fp \l__tenkz_kernel_r_yc_fp
+    \__tenkz_kernel_r_open_tip_affine_xy:nNN {e}
+      \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
+    \__tenkz_geom_unapply:nnnNN {kpic}
+      { \l__tenkz_kernel_r_x_fp } { \l__tenkz_kernel_r_y_fp }
+      \l__tenkz_test_ray_end_row_tl \l__tenkz_test_ray_end_col_tl
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_test_ray_end_col_tl
+          - \l__tenkz_kernel_r_cols_int
+          - \__tenkz_metric_ratio:n {stub} )
+      }
+      < {0.000001}
+      { \errmessage{an~outward~outside~ray~lost~its~named~margin~fallback} }
+    \fp_compare:nNnF { abs(\l__tenkz_test_ray_end_row_tl - 2) } < {0.000001}
+      { \errmessage{an~outward~outside~ray~changed~its~transverse~coordinate} }
   }
 \ExplSyntaxOff
 \makeatother

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -34,8 +34,6 @@
   { [TKZ-GEOM-COMPASS]~no~compass~face~named~'#1';~expected~n,~e,~s,~or~w }
 \msg_new:nnn {tenkz}{geom-singular-basis}
   { [TKZ-GEOM-SINGULAR-BASIS]~a~carrier~basis~must~have~nonzero~determinant }
-\msg_new:nnn {tenkz}{geom-zero-ray}
-  { [TKZ-GEOM-ZERO-RAY]~a~boundary~ray~must~have~a~nonzero~direction }
 
 % ---------- frames ----------------------------------------------------------
 % A frame record is six fp fields (row-major matrix a b / c d, offset dx dy)
@@ -350,74 +348,112 @@
       }
   }
 
-% The first intersection of a ray from an interior point with an
-% axis-aligned rectangle.  Positions and bounds are expressed in one local
-% coordinate system; #3 is the ray angle in that system.
-\tl_new:N \l__tenkz_geom_ray_tx_tl
-\tl_new:N \l__tenkz_geom_ray_ty_tl
+% Update the entry/exit parameters of a ray against one axis-aligned slab.
+% A zero direction component either leaves that axis unconstrained or proves
+% that the ray misses the slab.
+\tl_new:N \l__tenkz_geom_ray_near_tl
+\tl_new:N \l__tenkz_geom_ray_far_tl
+\tl_new:N \l__tenkz_geom_ray_enter_tl
+\tl_new:N \l__tenkz_geom_ray_exit_tl
 \tl_new:N \l__tenkz_geom_ray_t_tl
-\cs_new_protected:Npn \__tenkz_geom_rect_ray_intersect:nnnnnnnNN
-    #1#2#3#4#5#6#7#8#9
+\bool_new:N \l__tenkz_geom_ray_hit_bool
+\cs_new_protected:Npn \__tenkz_geom_ray_slab:nnnn #1#2#3#4
   {
-    \tl_clear:N \l__tenkz_geom_ray_tx_tl
-    \tl_clear:N \l__tenkz_geom_ray_ty_tl
-    \tl_clear:N \l__tenkz_geom_ray_t_tl
-    \fp_compare:nNnTF { cosd(#3) } > {0}
+    \fp_compare:nNnTF {#2} = {0}
       {
-        \tl_set:Ne \l__tenkz_geom_ray_tx_tl
-          { \fp_eval:n { ((#5) - (#1)) / cosd(#3) } }
+        \bool_lazy_or:nnT
+          { \fp_compare_p:nNn {#1} < {#3} }
+          { \fp_compare_p:nNn {#1} > {#4} }
+          { \bool_set_false:N \l__tenkz_geom_ray_hit_bool }
       }
       {
-        \fp_compare:nNnT { cosd(#3) } < {0}
+        \tl_set:Ne \l__tenkz_geom_ray_near_tl
           {
-            \tl_set:Ne \l__tenkz_geom_ray_tx_tl
-              { \fp_eval:n { ((#4) - (#1)) / cosd(#3) } }
+            \fp_eval:n
+              { min(((#3) - (#1)) / (#2), ((#4) - (#1)) / (#2)) }
           }
-      }
-    \fp_compare:nNnTF { sind(#3) } > {0}
-      {
-        \tl_set:Ne \l__tenkz_geom_ray_ty_tl
-          { \fp_eval:n { ((#7) - (#2)) / sind(#3) } }
-      }
-      {
-        \fp_compare:nNnT { sind(#3) } < {0}
+        \tl_set:Ne \l__tenkz_geom_ray_far_tl
           {
-            \tl_set:Ne \l__tenkz_geom_ray_ty_tl
-              { \fp_eval:n { ((#6) - (#2)) / sind(#3) } }
+            \fp_eval:n
+              { max(((#3) - (#1)) / (#2), ((#4) - (#1)) / (#2)) }
           }
-      }
-    \tl_if_empty:NTF \l__tenkz_geom_ray_tx_tl
-      {
-        \tl_if_empty:NTF \l__tenkz_geom_ray_ty_tl
+        \tl_if_empty:NTF \l__tenkz_geom_ray_enter_tl
           {
-            \tl_clear:N #8
-            \tl_clear:N #9
-            \msg_error:nn {tenkz}{geom-zero-ray}
+            \tl_set_eq:NN
+              \l__tenkz_geom_ray_enter_tl \l__tenkz_geom_ray_near_tl
           }
-          { \tl_set_eq:NN \l__tenkz_geom_ray_t_tl \l__tenkz_geom_ray_ty_tl }
-      }
-      {
-        \tl_if_empty:NTF \l__tenkz_geom_ray_ty_tl
-          { \tl_set_eq:NN \l__tenkz_geom_ray_t_tl \l__tenkz_geom_ray_tx_tl }
           {
-            \tl_set:Ne \l__tenkz_geom_ray_t_tl
+            \tl_set:Ne \l__tenkz_geom_ray_enter_tl
+              {
+                \fp_eval:n
+                  {
+                    max(
+                      \l__tenkz_geom_ray_enter_tl ,
+                      \l__tenkz_geom_ray_near_tl )
+                  }
+              }
+          }
+        \tl_if_empty:NTF \l__tenkz_geom_ray_exit_tl
+          {
+            \tl_set_eq:NN
+              \l__tenkz_geom_ray_exit_tl \l__tenkz_geom_ray_far_tl
+          }
+          {
+            \tl_set:Ne \l__tenkz_geom_ray_exit_tl
               {
                 \fp_eval:n
                   {
                     min(
-                      \l__tenkz_geom_ray_tx_tl ,
-                      \l__tenkz_geom_ray_ty_tl )
+                      \l__tenkz_geom_ray_exit_tl ,
+                      \l__tenkz_geom_ray_far_tl )
                   }
               }
           }
       }
-    \tl_if_empty:NF \l__tenkz_geom_ray_t_tl
+  }
+
+% The first forward intersection of a ray with an axis-aligned rectangle.
+% Positions and bounds are expressed in one local coordinate system; #3 is
+% the ray angle in that system.  An interior origin returns its first exit;
+% an exterior origin returns its first entry.  Both outputs are empty when
+% the forward ray misses the rectangle.
+\cs_new_protected:Npn \__tenkz_geom_rect_ray_intersect:nnnnnnnNN
+    #1#2#3#4#5#6#7#8#9
+  {
+    \bool_set_true:N \l__tenkz_geom_ray_hit_bool
+    \tl_clear:N \l__tenkz_geom_ray_enter_tl
+    \tl_clear:N \l__tenkz_geom_ray_exit_tl
+    \tl_clear:N \l__tenkz_geom_ray_t_tl
+    \__tenkz_geom_ray_slab:nnnn {#1}{cosd(#3)}{#4}{#5}
+    \__tenkz_geom_ray_slab:nnnn {#2}{sind(#3)}{#6}{#7}
+    \bool_if:NT \l__tenkz_geom_ray_hit_bool
       {
+        \bool_lazy_or:nnT
+          {
+            \fp_compare_p:nNn
+              { \l__tenkz_geom_ray_enter_tl }
+              > { \l__tenkz_geom_ray_exit_tl }
+          }
+          { \fp_compare_p:nNn { \l__tenkz_geom_ray_exit_tl } < {0} }
+          { \bool_set_false:N \l__tenkz_geom_ray_hit_bool }
+      }
+    \bool_if:NTF \l__tenkz_geom_ray_hit_bool
+      {
+        \tl_set:Ne \l__tenkz_geom_ray_t_tl
+          {
+            \fp_eval:n
+              {
+                \l__tenkz_geom_ray_enter_tl >= 0
+                  ? \l__tenkz_geom_ray_enter_tl
+                  : \l__tenkz_geom_ray_exit_tl
+              }
+          }
         \tl_set:Ne #8
           { \fp_eval:n { (#1) + \l__tenkz_geom_ray_t_tl * cosd(#3) } }
         \tl_set:Ne #9
           { \fp_eval:n { (#2) + \l__tenkz_geom_ray_t_tl * sind(#3) } }
       }
+      { \tl_clear:N #8 \tl_clear:N #9 }
   }
 
 % The local east/north basis supplied by one frame address.  Affine frames

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -6756,7 +6756,50 @@
       { \l__tenkz_kernel_r_cols_int + \__tenkz_metric_ratio:n {stub} }
       { 1 - \__tenkz_metric_ratio:n {stub} }
       { \l__tenkz_kernel_r_rows_int + \__tenkz_metric_ratio:n {stub} }
-      \l__tenkz_kernel_r_col_tl \l__tenkz_kernel_r_row_tl
+      \l__tenkz_kernel_r_x_tl \l__tenkz_kernel_r_y_tl
+    \tl_if_empty:NTF \l__tenkz_kernel_r_x_tl
+      {
+        % A point already outside the picture can face farther outward, so
+        % its forward ray need not meet the rectangle.  Preserve the
+        % established named-margin fallback in that case; this matters for
+        % off-cell relative waypoints in flat pictures.
+        \fp_compare:nNnT { cosd(\l__tenkz_kernel_r_b_tl) } < {0}
+          {
+            \tl_set:Ne \l__tenkz_kernel_r_col_tl
+              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
+          }
+        \fp_compare:nNnT { cosd(\l__tenkz_kernel_r_b_tl) } > {0}
+          {
+            \tl_set:Ne \l__tenkz_kernel_r_col_tl
+              {
+                \fp_eval:n
+                  {
+                    \l__tenkz_kernel_r_cols_int
+                    + \__tenkz_metric_ratio:n {stub}
+                  }
+              }
+          }
+        \fp_compare:nNnT { sind(\l__tenkz_kernel_r_b_tl) } < {0}
+          {
+            \tl_set:Ne \l__tenkz_kernel_r_row_tl
+              { \fp_eval:n { 1 - \__tenkz_metric_ratio:n {stub} } }
+          }
+        \fp_compare:nNnT { sind(\l__tenkz_kernel_r_b_tl) } > {0}
+          {
+            \tl_set:Ne \l__tenkz_kernel_r_row_tl
+              {
+                \fp_eval:n
+                  {
+                    \l__tenkz_kernel_r_rows_int
+                    + \__tenkz_metric_ratio:n {stub}
+                  }
+              }
+          }
+      }
+      {
+        \tl_set_eq:NN \l__tenkz_kernel_r_col_tl \l__tenkz_kernel_r_x_tl
+        \tl_set_eq:NN \l__tenkz_kernel_r_row_tl \l__tenkz_kernel_r_y_tl
+      }
     \__tenkz_kernel_r_frame_xy:nnNN
       { \l__tenkz_kernel_r_row_tl } { \l__tenkz_kernel_r_col_tl }
       #2 #3


### PR DESCRIPTION
## Summary

- make the shared ray/rectangle helper handle interior and exterior origins with slab entry/exit parameters
- preserve the established named-margin fallback when an exterior ray has no forward rectangle hit
- cover exterior entry, exterior miss, and off-centre diagonal exit regressions

This is the narrow follow-up to the exterior-origin review finding on LionSR/TNLean#5149, which auto-merged before the remediation push.

## Validation

- `scripts/tenkz_kernel_probes.sh --check` (50 regressions; 8 sugar pairs; 12 record streams; pixels byte-identical)
- focused exterior-entry/miss renderer probes
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- full corpus: `PASS: compiled and audited 264 standalone tenkz corpus files`
- exact-head RMP: 130 targets passed; 32 faithful, 94 cosmetic-gap, 2 structural-gap, 0 unfaithful, 2 blocked; pairing 118 verified, 2 wrong-source, 10 context-only

Refs LionSR/tenkz#113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared geometry and open-end routing used for wire tips; behavior change is scoped and covered by new kernel regressions.
> 
> **Overview**
> Fixes **open-wire tip placement** when the anchor sits **outside** the picture grid by reworking rectangle–ray intersection and keeping the old margin fallback when a forward ray never hits the bounds.
> 
> **Geometry:** `__tenkz_geom_rect_ray_intersect` now uses **slab entry/exit clipping** instead of taking the minimum of separate axis hits. Interior origins still get the first **forward exit**; exterior origins get the first **forward entry**; a miss returns empty outputs (no invented backward hit). The **`geom-zero-ray`** error is removed in favor of slab miss logic.
> 
> **Kernel:** Affine open tips read intersection into separate **x/y** temporaries. When there is no hit (e.g. ray points farther outward), the code restores the **named stub margins** by compass direction so off-grid relative waypoints behave as before; on a hit it uses the intersected logical row/column.
> 
> **Tests:** Regressions cover exterior entry, outward miss with stable transverse coordinate, and no spurious intersection for outward rays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c7c67a4656964e6d372891002c3c2472a5f0ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
