### PR TITLE
doc(MPS/MPDO): correct deviation-marker hygiene

### DIFF
--- a/TNLean/Algebra/CommutingOverlappingDecomp.lean
+++ b/TNLean/Algebra/CommutingOverlappingDecomp.lean
@@ -31,7 +31,7 @@ indices.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting Hamiltonians*,
-  arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`) and its proof on pages 2--3.
+  J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`) and its proof on pages 2--3.
 -/
 
 open scoped InnerProductSpace Kronecker
@@ -107,7 +107,7 @@ variable [DecidableEq a] [DecidableEq b] [DecidableEq c]
 /-- The natural embedding of an operator on the first two factors into the three-factor
 space.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`). -/
 def leftOverlappingLift (X : Matrix (a × b) (a × b) ℂ) :
     Matrix ((a × b) × c) ((a × b) × c) ℂ :=
   fun p q ↦ X p.1 q.1 * (1 : Matrix c c ℂ) p.2 q.2
@@ -115,7 +115,7 @@ def leftOverlappingLift (X : Matrix (a × b) (a × b) ℂ) :
 /-- The natural embedding of an operator on the last two factors into the three-factor
 space.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`). -/
 def rightOverlappingLift (Y : Matrix (b × c) (b × c) ℂ) :
     Matrix ((a × b) × c) ((a × b) × c) ℂ :=
   fun p q ↦ (1 : Matrix a a ℂ) p.1.1 q.1.1 * Y (p.1.2, p.2) (q.1.2, q.2)
@@ -124,14 +124,14 @@ def rightOverlappingLift (Y : Matrix (b × c) (b × c) ℂ) :
 the two first-factor indices fixed. It is the complex specialization of
 `operatorBlock`.
 
-Source: Beigi, arXiv:1105.1019v2, proof of Lemma 2.1 (`lem:comm`). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, proof of Lemma 2.1 (`lem:comm`). -/
 abbrev leftMiddleSlice (X : Matrix (a × b) (a × b) ℂ) (i i' : a) : Matrix b b ℂ :=
   operatorBlock X i i'
 
 /-- The middle-factor coefficient matrix of an operator on the last two factors, with
 the two last-factor indices fixed.
 
-Source: Beigi, arXiv:1105.1019v2, proof of Lemma 2.1 (`lem:comm`). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, proof of Lemma 2.1 (`lem:comm`). -/
 def rightMiddleSlice (Y : Matrix (b × c) (b × c) ℂ) (k k' : c) : Matrix b b ℂ :=
   fun j j' ↦ Y (j, k) (j', k')
 
@@ -139,7 +139,7 @@ def rightMiddleSlice (Y : Matrix (b × c) (b × c) ℂ) (k k' : c) : Matrix b b 
 right factor when adjoining the first outer space. It sends
 `(q, ((i, s), r))` to `(i, e (q, (r, s)))`.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), decomposition and first block
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), decomposition and first block
 identity on pages 2--3. -/
 def leftSpatialBlockEquiv {K : ℕ} {d m : Fin K → ℕ}
     (e : ((q : Fin K) × (Fin (m q) × Fin (d q))) ≃ b) :
@@ -161,7 +161,7 @@ def leftSpatialBlockEquiv {K : ℕ} {d m : Fin K → ℕ}
 right factor when adjoining the last outer space. It sends
 `(q, (s, (r, k)))` to `(e (q, (r, s)), k)`.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), decomposition and second block
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), decomposition and second block
 identity on pages 2--3. -/
 def rightSpatialBlockEquiv {K : ℕ} {d m : Fin K → ℕ}
     (e : ((q : Fin K) × (Fin (m q) × Fin (d q))) ≃ b) :
@@ -204,7 +204,7 @@ private theorem conj_right_tensor_apply (Y : Matrix (b × c) (b × c) ℂ)
 omit [Fintype b] [Fintype c] [DecidableEq b] [DecidableEq c] in
 /-- Hermiticity exchanges the two outer indices of a middle-factor coefficient matrix.
 
-Source: Beigi, arXiv:1105.1019v2, proof of Lemma 2.1 (`lem:comm`). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, proof of Lemma 2.1 (`lem:comm`). -/
 theorem star_rightMiddleSlice (Y : Matrix (b × c) (b × c) ℂ) (hY : Y.IsHermitian)
     (k k' : c) : star (rightMiddleSlice Y k k') = rightMiddleSlice Y k' k := by
   ext i j
@@ -218,7 +218,7 @@ operator commutes with every middle-factor coefficient matrix of the second oper
 
 This is the coefficientwise consequence of
 `[X_{AB} \otimes \mathbf 1_C, \mathbf 1_A \otimes Y_{BC}] = 0` used before the
-finite-dimensional star-algebra decomposition in S. Beigi, arXiv:1105.1019v2,
+finite-dimensional star-algebra decomposition in S. Beigi, J. Phys. A 45 (2012) 025306,
 proof of Lemma 2.1 (`lem:comm`), pages 2--3. Hermiticity is not needed for this
 coefficientwise implication. -/
 theorem middleSlices_commute_of_overlappingLifts_commute
@@ -248,7 +248,7 @@ two tensor factors, the basis realizes
 operator families.
 
 This is the middle-space conclusion of the Bravyi--Vyalyi decomposition in S. Beigi,
-arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`). The source assumes both `X` and `Y` Hermitian;
+J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`). The source assumes both `X` and `Y` Hermitian;
 the proof below uses Hermiticity only for `Y`, because it applies the star-subalgebra
 decomposition to the commutant of the coefficient matrices of `Y`. -/
 theorem exists_middle_spatial_decomposition_of_overlappingLifts_commute
@@ -362,7 +362,7 @@ $A\otimes(H_{q,l}\otimes H_{q,r})$ and
 $(H_{q,l}\otimes H_{q,r})\otimes C$, respectively.
 
 This is the explicit coordinate form of the two block-action identities in S. Beigi,
-arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. Its hypotheses agree with the
+J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. Its hypotheses agree with the
 source: both overlapping operators are Hermitian and their natural lifts commute. -/
 theorem exists_unitary_blockActions_of_overlappingLifts_commute
     (X : Matrix (a × b) (a × b) ℂ) (Y : Matrix (b × c) (b × c) ℂ)
@@ -483,8 +483,8 @@ The reindexings in the formal statement express the two dependent direct sums in
 original product coordinates. The block operators are Hermitian; no unitarity assertion
 is made about them.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), TeX lines 398--422,
-especially the two displayed equalities on page 3. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`),
+especially the two displayed equalities in the lemma. -/
 theorem exists_unitary_blockSum_equalities_of_overlappingLifts_commute
     (X : Matrix (a × b) (a × b) ℂ) (Y : Matrix (b × c) (b × c) ℂ)
     (hX : X.IsHermitian) (hY : Y.IsHermitian)

--- a/TNLean/Algebra/EventuallyConstantCycleWeights.lean
+++ b/TNLean/Algebra/EventuallyConstantCycleWeights.lean
@@ -26,8 +26,7 @@ periods `N` and `N+1`, hence period one, so every cycle is constant.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Section IV, equations (7)--(13), source
-  lines 561--606.
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Section IV, equations (7)--(13).
 -/
 
 open scoped BigOperators
@@ -38,14 +37,13 @@ variable {V : Type*} [Fintype V]
 
 /-- The successor of an index on a nonempty finite cycle.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 def next {N : ℕ} (hN : 0 < N) (i : Fin N) : Fin N :=
   ⟨(i.val + 1) % N, Nat.mod_lt _ hN⟩
 
 /-- The product of the directed-edge weights around an ordered cycle.
 
-Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
-561--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (4) and Section IV. -/
 def cycleWeight (w : V → V → ℕ) {N : ℕ} (hN : 0 < N)
     (x : Fin N → V) : ℕ :=
   ∏ i, w (x i) (x (next hN i))
@@ -55,15 +53,14 @@ def cycleWeight (w : V → V → ℕ) {N : ℕ} (hN : 0 < N)
 Cycles are ordered: cyclic rotations are counted separately, exactly as in
 Beigi's dimension formula.
 
-Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
-561--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (4) and Section IV. -/
 def cycleWeightSum (w : V → V → ℕ) {N : ℕ} (hN : 0 < N) : ℕ :=
   ∑ x : Fin N → V, cycleWeight w hN x
 
 /-- The numerical cycle sum is constant at all sufficiently large positive
 lengths.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--568. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 def HasEventuallyConstantCycleWeightSum (w : V → V → ℕ) : Prop :=
   ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N → ∀ hN : 0 < N, cycleWeightSum w hN = c
 
@@ -71,7 +68,7 @@ omit [Fintype V] in
 /-- Repeating a finite word a positive number of times is injective as a
 function of the original word.
 
-Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equations (7)--(10). -/
 theorem repeat_injective {N m : ℕ} (hm : 0 < m) :
     Function.Injective (Fin.repeat m : (Fin N → V) → Fin (m * N) → V) := by
   intro x y hxy
@@ -102,7 +99,7 @@ omit [Fintype V] in
 This is the product identity underlying Beigi's comparisons at lengths `N`,
 `N+1`, and `N(N+1)`.
 
-Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equations (7)--(10). -/
 theorem cycleWeight_repeat (w : V → V → ℕ) {N m : ℕ}
     (hN : 0 < N) (hm : 0 < m) (x : Fin N → V) :
     cycleWeight w (Nat.mul_pos hm hN) (Fin.repeat m x) = cycleWeight w hN x ^ m := by
@@ -116,7 +113,7 @@ theorem cycleWeight_repeat (w : V → V → ℕ) {N m : ℕ}
 /-- The total weight of repeated cycles is bounded by the total weight of all
 cycles at the repeated length.
 
-Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equations (7)--(10). -/
 theorem sum_cycleWeight_pow_le (w : V → V → ℕ) {N m : ℕ}
     (hN : 0 < N) (hm : 0 < m) :
     (∑ x : Fin N → V, cycleWeight w hN x ^ m) ≤
@@ -157,7 +154,7 @@ weight sum is eventually constant.
 
 In particular, every edge that occurs in a directed cycle has weight one.
 
-Source: Beigi, arXiv:1105.1019v2, equations (7)--(11), source lines 570--593. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equations (7)--(11). -/
 theorem cycleWeight_eq_one {w : V → V → ℕ}
     (hconst : HasEventuallyConstantCycleWeightSum w) {K : ℕ}
     (hK : 0 < K) (x : Fin K → V) (hx : cycleWeight w hK x ≠ 0) :
@@ -192,7 +189,7 @@ theorem cycleWeight_eq_one {w : V → V → ℕ}
 
 /-- Every edge belonging to a positive-weight directed cycle has weight one.
 
-Source: Beigi, arXiv:1105.1019v2, equation (11), source lines 587--593. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (11). -/
 theorem cyclicEdgeWeight_eq_one {w : V → V → ℕ}
     (hconst : HasEventuallyConstantCycleWeightSum w) {N : ℕ}
     (hN : 0 < N) (x : Fin N → V) (hx : cycleWeight w hN x ≠ 0)
@@ -204,7 +201,7 @@ theorem cyclicEdgeWeight_eq_one {w : V → V → ℕ}
 
 /-- Positive-weight ordered cycles at a fixed positive length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 private def PositiveCycle (w : V → V → ℕ) {N : ℕ} (hN : 0 < N) :=
   {x : Fin N → V // cycleWeight w hN x ≠ 0}
 
@@ -230,7 +227,7 @@ private theorem positiveCycle_card_eq_cycleWeightSum {w : V → V → ℕ}
 /-- Repetition sends a positive-weight ordered cycle to a positive-weight
 ordered cycle.
 
-Source: Beigi, arXiv:1105.1019v2, equations (7)--(10), source lines 570--586. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equations (7)--(10). -/
 private noncomputable def repeatPositiveCycle (w : V → V → ℕ) {N m : ℕ}
     (hN : 0 < N) (hm : 0 < m) :
     PositiveCycle w hN → PositiveCycle w (Nat.mul_pos hm hN) :=
@@ -313,7 +310,7 @@ cycle to a sufficiently large length `N`, compares the exhaustive repetition
 maps from lengths `N` and `N+1` into their common multiple, and uses the two
 consecutive periods.
 
-Source: Beigi, arXiv:1105.1019v2, equations (12)--(13), source lines 594--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equations (12)--(13). -/
 theorem cycle_eq_constant {w : V → V → ℕ}
     (hconst : HasEventuallyConstantCycleWeightSum w) {K : ℕ}
     (hK : 0 < K) (x : Fin K → V) (hx : cycleWeight w hK x ≠ 0) :
@@ -363,7 +360,7 @@ theorem cycle_eq_constant {w : V → V → ℕ}
 
 /-- Vertices carrying a positive-weight loop.
 
-Source: Beigi, arXiv:1105.1019v2, equation (13), source lines 600--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (13). -/
 def Loop (w : V → V → ℕ) := {v : V // w v v ≠ 0}
 
 noncomputable instance (w : V → V → ℕ) : Fintype (Loop w) := by
@@ -391,7 +388,7 @@ private noncomputable def positiveCycleEquivLoop {w : V → V → ℕ}
 /-- At every positive length, the ordered-cycle weight sum is the number of
 positive-weight loops.
 
-Source: Beigi, arXiv:1105.1019v2, equation (13), source lines 600--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (13). -/
 theorem cycleWeightSum_eq_card_loop {w : V → V → ℕ}
     (hconst : HasEventuallyConstantCycleWeightSum w) {N : ℕ} (hN : 0 < N) :
     cycleWeightSum w hN = Fintype.card (Loop w) := by

--- a/TNLean/Algebra/StarSubalgebraBlockForm.lean
+++ b/TNLean/Algebra/StarSubalgebraBlockForm.lean
@@ -278,7 +278,7 @@ Thus the same orthonormal identification realizes the complementary block algebr
 `\bigoplus_k (M_{m_k} \otimes \mathbf 1_{d_k})`.
 
 This is the finite-dimensional star-algebra step in the proof of the Bravyi--Vyalyi
-spatial decomposition; see S. Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), proof on
+spatial decomposition; see S. Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), proof on
 pages 2--3. -/
 theorem exists_complementary_action_orthonormalBasis :
     ∃ (K : ℕ) (d m : Fin K → ℕ)

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -298,12 +298,14 @@ def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
 /-- A trace-preserving MPO with a positive-definite fixed point admits a
 stationary algebra tower as soon as it is an RFP.
 
-**Scope restriction (trace preservation and faithful fixed point):** The
-hypotheses `h_tp`, `hρ`, and `hρ_fix`, used to invoke Wolf Theorem 6.12, are
-absent from arXiv:1606.00608, Theorem `thm:IV.13` (Theorem 4.14), which assumes
-only that $M$ is in canonical form and generates an MPDO. Moreover, the
-conclusion is the blocked fixed-point-algebra predicate above, not the full
-coefficient statement in part (ii). See
+**Scope restriction (RFP premise, trace preservation, and faithful fixed
+point):** The local premise `hRFP : IsRFP M` is doubled-index transfer-map
+idempotence, not the source MPDO RFP condition of arXiv:1606.00608,
+Definition 4.1 (`IsRFPViaTS`). The hypotheses `h_tp`, `hρ`, and `hρ_fix`, used
+to invoke Wolf Theorem 6.12, are also absent from Theorem `thm:IV.13`
+(Theorem 4.14), which assumes only that $M$ is in canonical form and generates
+an MPDO. Moreover, the conclusion is the blocked fixed-point-algebra predicate
+above, not the full coefficient statement in part (ii). See
 `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 theorem isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
     {M : MPOTensor d D} (hRFP : IsRFP M) (h_tp : Kraus.IsTP M.toMPSTensor)

--- a/TNLean/MPS/MPDO/AlgebraStructure.lean
+++ b/TNLean/MPS/MPDO/AlgebraStructure.lean
@@ -148,7 +148,17 @@ support algebra. The fields `m_apply` and `iota_apply` require that these maps
 are realized by the ambient matrix product and ambient inclusion.
 
 This structure contains only this realization data. It does **not** yet include
-the full Section 4.5 coherence / coefficient / BNT layer from the paper. -/
+the full Section 4.5 coherence / coefficient / BNT layer from the paper.
+
+**Scope restriction (blocked support-algebra tower):** arXiv:1606.00608,
+Theorem `thm:IV.13` (Theorem 4.14(ii), lines 972--985), is stated using one
+fixed BNT-label coefficient family
+$c_{\alpha,\beta,\gamma}^{(L)}
+  = \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^L)$
+and its idempotent law. The present structure instead records blocked support
+algebras and their ambient multiplication and inclusion maps; it does not
+contain the source coefficient family. See
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 structure AlgebraStructureData (d D : ℕ) where
   /-- Support algebra at blocked size `n`. -/
   A : ℕ → StarSubalgebra ℂ (Matrix (Fin D) (Fin D) ℂ)
@@ -174,7 +184,14 @@ variable {d D : ℕ}
 The current compatibility condition says that, for every positive blocked size
 `n`, the support algebra `A n` is exactly the fixed-point algebra of the
 adjoint blocked transfer map. This is a non-vacuous algebra-side condition, but
-it is still weaker than the full coefficient statement of Theorem IV.13(ii). -/
+it is still weaker than the full coefficient statement of Theorem IV.13(ii).
+
+**Scope restriction (blocked adjoint fixed points):** arXiv:1606.00608,
+Theorem `thm:IV.13` (Theorem 4.14(ii), lines 972--985), does not formulate
+compatibility by the equalities
+$\mathcal A_n = \operatorname{Fix}(E_n^\dagger)$. This local condition omits
+the uniform BNT-label coefficient family and the idempotent coefficient law in
+the source. See `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 def CompatibleWith (data : AlgebraStructureData d D) (M : MPOTensor d D) : Prop :=
   ∀ n : ℕ, 0 < n → ∀ X : Matrix (Fin D) (Fin D) ℂ,
     X ∈ data.A n ↔ (blockedTransferMap M n).adjoint X = X
@@ -267,12 +284,27 @@ end AlgebraStructureData
 /-- The algebra-structure formulation of MPDO RFP used in this file.
 
 An MPO tensor satisfies `IsRFP_MPDO_via_algebra` when it admits algebra-structure
-support data compatible with its blocked adjoint transfer maps. -/
+support data compatible with its blocked adjoint transfer maps.
+
+**Scope restriction (blocked fixed-point-algebra predicate):** This predicate
+packages the preceding blocked support-algebra tower and adjoint-fixed-point
+compatibility. It is weaker than, and is not the formalization of,
+arXiv:1606.00608, Theorem `thm:IV.13` (Theorem 4.14(ii), lines 972--985), which
+also requires the uniform BNT-label coefficient family and its idempotent law.
+See `docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 def IsRFP_MPDO_via_algebra (M : MPOTensor d D) : Prop :=
   ∃ data : AlgebraStructureData d D, data.CompatibleWith M
 
 /-- A trace-preserving MPO with a positive-definite fixed point admits a
-stationary algebra tower as soon as it is an RFP. -/
+stationary algebra tower as soon as it is an RFP.
+
+**Scope restriction (trace preservation and faithful fixed point):** The
+hypotheses `h_tp`, `hρ`, and `hρ_fix`, used to invoke Wolf Theorem 6.12, are
+absent from arXiv:1606.00608, Theorem `thm:IV.13` (Theorem 4.14), which assumes
+only that $M$ is in canonical form and generates an MPDO. Moreover, the
+conclusion is the blocked fixed-point-algebra predicate above, not the full
+coefficient statement in part (ii). See
+`docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex`. -/
 theorem isRFP_MPDO_via_algebra_of_isRFP_of_isTP_of_posDef_fixed
     {M : MPOTensor d D} (hRFP : IsRFP M) (h_tp : Kraus.IsTP M.toMPSTensor)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : transferMap M ρ = ρ) :

--- a/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaCyclicCore.lean
@@ -538,7 +538,7 @@ neighboring-operator decomposition.  This is the local-to-global commutation
 consequence of the same cyclic edge coordinates used in Beigi's finite-chain
 decomposition.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(3), pages 3--4. -/
 theorem embedLocalOperator_commute_of_etaPair_decomposition
     {K N : ℕ} [NeZero N] (hN : 2 ≤ N) (dl dr : Fin K → ℕ)
     (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)

--- a/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
+++ b/TNLean/MPS/MPDO/CommutingBondEtaDecomposition.lean
@@ -22,7 +22,7 @@ finite chain.
 
 ## References
 
-* S. Beigi, arXiv:1105.1019v2, Lemma 2.1.
+* S. Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1.
 * arXiv:1606.00608, Appendix C.2, equation sigmaNK2, lines 1581--1605.
 -/
 
@@ -76,7 +76,7 @@ No zero-correlation-length or area-law hypothesis is used.  In particular, this 
 does not assert the rank-one trace factorization invoked later in Proposition 4to2.
 
 Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
-lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III,
+lines 1581--1605; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III,
 equation (2). -/
 theorem exists_positive_etaPair_decomposition_of_overlappingLifts_commute
     (B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (hB : B.PosSemidef)
@@ -289,7 +289,7 @@ variable {d : ℕ}
 eta-pair decomposition.
 
 Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
-lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+lines 1581--1605; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1. -/
 theorem exists_positive_eta_pairBond_decomposition
     (data : TranslationInvariantBondData d) :
     ∃ (K : ℕ) (dl dr : Fin K → ℕ)
@@ -324,7 +324,7 @@ variable {d D : ℕ} {M : MPOTensor d D}
 sector decomposition with positive neighboring operators.
 
 Source: arXiv:1606.00608, Appendix C.2, equation sigmaNK2 and Proposition 4to2,
-lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+lines 1581--1605; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1. -/
 theorem exists_positive_eta_pairBond_decomposition
     (data : EtaLocalStructureData M) :
     ∃ (K : ℕ) (dl dr : Fin K → ℕ)

--- a/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
+++ b/TNLean/MPS/MPDO/CommutingBondTraceMatrixObstruction.lean
@@ -34,7 +34,7 @@ factorization merely from the displayed commuting product.
 ## References
 
 * arXiv:1606.00608, Appendix C.2, converse implication, lines 1597--1619.
-* Beigi, arXiv:1105.1019v2, Lemma 2.1.
+* Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1.
 -/
 
 open scoped BigOperators ComplexOrder Matrix
@@ -50,7 +50,7 @@ noncomputable def tensor : MPOTensor 2 1 :=
   fun i j => if i = j then Matrix.of fun _ _ => sectorWeight i else 0
 
 /-- The two-dimensional physical space as two one-dimensional sectors in the
-decomposition of Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+decomposition of Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1. -/
 noncomputable def sectorEquiv :
     Fin 2 ≃ Sigma fun _k : Fin 2 => Fin 1 × Fin 1 where
   toFun k := ⟨k, (0, 0)⟩
@@ -107,7 +107,7 @@ noncomputable def factorization : PhysicalSectorFactorization tensor where
 /-- The two physical basis vectors as one sector with a two-dimensional left
 factor and a one-dimensional right factor.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1; arXiv:1606.00608,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1; arXiv:1606.00608,
 Appendix C.2, lines 1603--1605. -/
 noncomputable def oneSectorEquiv :
     Fin 2 ≃ Sigma fun _k : Fin 1 => Fin 2 × Fin 1 where
@@ -125,7 +125,7 @@ noncomputable def oneSectorEquiv :
 /-- A one-sector factorization of the product tensor, with the sector weight
 placed entirely in its two-dimensional left factor.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1; arXiv:1606.00608,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1; arXiv:1606.00608,
 Appendix C.2, lines 1603--1605. -/
 noncomputable def oneSectorFactorization : PhysicalSectorFactorization tensor where
   sectorCount := 1

--- a/TNLean/MPS/MPDO/CommutingFormSpatialBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormSpatialBridge.lean
@@ -18,7 +18,7 @@ of a positive translation-invariant commuting family.
 
 ## References
 
-* S. Beigi, arXiv:1105.1019v2, Lemma 2.1.
+* S. Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1.
 * arXiv:1606.00608, Appendix C.2, lines 1597--1610.
 -/
 
@@ -35,7 +35,7 @@ Under the common three-site identification, the two abstract overlapping lifts a
 precisely the first two adjacent translates of the original bond.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1597--1610; Beigi,
-arXiv:1105.1019v2, Lemma 2.1. -/
+J. Phys. A 45 (2012) 025306, Lemma 2.1. -/
 theorem exists_unitary_blockActions_of_pairBond
     (data : TranslationInvariantBondData d) :
     ∃ (K : ℕ) (dl dr : Fin K → ℕ)
@@ -73,7 +73,7 @@ variable {d D : ℕ} {M : MPOTensor d D}
 decomposition of Beigi's lemma.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1597--1610; Beigi,
-arXiv:1105.1019v2, Lemma 2.1. -/
+J. Phys. A 45 (2012) 025306, Lemma 2.1. -/
 theorem exists_unitary_blockActions_of_pairBond
     (data : EtaLocalStructureData M) :
     ∃ (K : ℕ) (dl dr : Fin K → ℕ)

--- a/TNLean/MPS/MPDO/CommutingOverlappingCoordinates.lean
+++ b/TNLean/MPS/MPDO/CommutingOverlappingCoordinates.lean
@@ -36,7 +36,7 @@ commutation through the common equivalence gives the remaining hypothesis of
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
   Appendix C.2, Proposition `4to2`, lines 1599--1605
-* [Beigi 2012] arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3
+* [Beigi 2012] J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3
 -/
 
 open scoped Matrix ComplexOrder
@@ -52,7 +52,7 @@ equivalence sends a configuration `x` to `((x 0, x 1), x 2)`, which is the index
 used simultaneously by `Matrix.leftOverlappingLift` and `Matrix.rightOverlappingLift`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 def threeSiteOverlappingEquiv (n : Type*) :
     (Fin 3 → n) ≃ ((n × n) × n) :=
   (_root_.finThreeArrowEquiv n).trans (Equiv.prodAssoc n n n).symm
@@ -69,7 +69,7 @@ def pairBondMatrix (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
 at site zero is its left overlapping lift.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem reindex_embedLocalOperator_zero_eq_leftOverlappingLift
     (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
     Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
@@ -129,7 +129,7 @@ theorem reindex_embedLocalOperator_zero_eq_leftOverlappingLift
 embedded at site one is its right overlapping lift.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem reindex_embedLocalOperator_one_eq_rightOverlappingLift
     (B : Matrix (Fin 2 → Fin d) (Fin 2 → Fin d) ℂ) :
     Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
@@ -208,7 +208,7 @@ theorem pairBond_isHermitian (data : TranslationInvariantBondData d) :
 equivalence.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem reindex_bondAt_zero_eq_leftOverlappingLift
     (data : TranslationInvariantBondData d) :
     Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
@@ -221,7 +221,7 @@ theorem reindex_bondAt_zero_eq_leftOverlappingLift
 equivalence.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem reindex_bondAt_one_eq_rightOverlappingLift
     (data : TranslationInvariantBondData d) :
     Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
@@ -234,7 +234,7 @@ theorem reindex_bondAt_one_eq_rightOverlappingLift
 with Hermiticity, they satisfy the hypotheses of Beigi's spatial decomposition.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem overlappingLifts_pairBond_comm (data : TranslationInvariantBondData d) :
     Matrix.leftOverlappingLift data.pairBond *
         Matrix.rightOverlappingLift data.pairBond =
@@ -288,7 +288,7 @@ theorem pairBond_isHermitian (data : EtaLocalStructureData M) :
 the common three-site equivalence.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem reindex_bondAt_zero_eq_leftOverlappingLift
     (data : EtaLocalStructureData M) :
     Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
@@ -301,7 +301,7 @@ theorem reindex_bondAt_zero_eq_leftOverlappingLift
 under the same three-site equivalence.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem reindex_bondAt_one_eq_rightOverlappingLift
     (data : EtaLocalStructureData M) :
     Matrix.reindex (threeSiteOverlappingEquiv (Fin d))
@@ -315,7 +315,7 @@ together with `pairBond_isHermitian`, they satisfy exactly the hypotheses of
 `Matrix.exists_unitary_blockActions_of_overlappingLifts_commute`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines 1599--1605;
-Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem overlappingLifts_pairBond_comm (data : EtaLocalStructureData M) :
     Matrix.leftOverlappingLift data.pairBond *
         Matrix.rightOverlappingLift data.pairBond =

--- a/TNLean/MPS/MPDO/CyclicActiveAdjacentCoefficientExtraction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveAdjacentCoefficientExtraction.lean
@@ -866,7 +866,7 @@ normalized marginal identity to the selected fixed-product tensor.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1613.
 
-**Local fix (cyclic-active restriction):** This is the additional marginal
+**Scope restriction (cyclic-active restriction):** This is the additional marginal
 replacement used to expose the two-step cyclic-active coefficient. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem selectedFixedProduct_reducedBlockState_add_three_eq_succ_of_isSourceZCL

--- a/TNLean/MPS/MPDO/CyclicActiveCutCoordinates.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutCoordinates.lean
@@ -31,7 +31,7 @@ coefficient.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The sum is restricted to
+**Scope restriction (cyclic-active restriction):** The sum is restricted to
 cyclic-active sectors. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveLeftBoundary
@@ -47,7 +47,7 @@ coefficient.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The sum is restricted to
+**Scope restriction (cyclic-active restriction):** The sum is restricted to
 cyclic-active sectors. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveRightBoundary
@@ -63,7 +63,7 @@ positive semidefinite.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** Positivity is proved after
+**Scope restriction (cyclic-active restriction):** Positivity is proved after
 restricting the boundary sum to cyclic-active sectors. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveLeftBoundary_posSemidef
@@ -84,7 +84,7 @@ positive semidefinite.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** Positivity is proved after
+**Scope restriction (cyclic-active restriction):** Positivity is proved after
 restricting the boundary sum to cyclic-active sectors. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveRightBoundary_posSemidef
@@ -105,7 +105,7 @@ right and left factors.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** Both factors come from the
+**Scope restriction (cyclic-active restriction):** Both factors come from the
 restricted two-step coefficient. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSeparatedBoundary_eq_right_kronecker_left
@@ -122,7 +122,7 @@ theorem cyclicActiveSeparatedBoundary_eq_right_kronecker_left
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** These coordinates describe the
+**Scope restriction (cyclic-active restriction):** These coordinates describe the
 retained left path in the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 abbrev LeftOpenEdgeIndex (F : PhysicalSectorFactorization K) {A : ℕ}
@@ -136,7 +136,7 @@ left boundary coordinate and the intervening neighboring edges.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identification is used for
+**Scope restriction (cyclic-active restriction):** This identification is used for
 the retained left path in the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def leftFiberOpenEdgeEquiv (F : PhysicalSectorFactorization K) {A : ℕ}
@@ -192,7 +192,7 @@ def leftFiberOpenEdgeEquiv (F : PhysicalSectorFactorization K) {A : ℕ}
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** These coordinates describe the
+**Scope restriction (cyclic-active restriction):** These coordinates describe the
 retained right path in the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 abbrev RightOpenEdgeIndex (F : PhysicalSectorFactorization K) {C : ℕ}
@@ -206,7 +206,7 @@ intervening neighboring edges and its right boundary coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identification is used for
+**Scope restriction (cyclic-active restriction):** This identification is used for
 the retained right path in the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def rightFiberOpenEdgeEquiv (F : PhysicalSectorFactorization K) {C : ℕ}
@@ -263,7 +263,7 @@ basis.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The middle-site coordinates are
+**Scope restriction (cyclic-active restriction):** The middle-site coordinates are
 those of the retained sector decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def sectorCoordinateMiddleEquiv
@@ -279,7 +279,7 @@ the corresponding physical coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identity supplies the sector
+**Scope restriction (cyclic-active restriction):** This identity supplies the sector
 coordinates for the retained decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem sectorCoordinateChainEquiv_apply_fst
@@ -299,7 +299,7 @@ of the corresponding physical coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identity supplies the
+**Scope restriction (cyclic-active restriction):** This identity supplies the
 dependent fiber coordinates for the retained decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem sectorCoordinateChainEquiv_apply_snd_heq
@@ -322,7 +322,7 @@ theorem sectorCoordinateChainEquiv_apply_snd_heq
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The resulting word indexes a
+**Scope restriction (cyclic-active restriction):** The resulting word indexes a
 retained left path in the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def leftSectorWord (F : PhysicalSectorFactorization K) {A : ℕ}
@@ -335,7 +335,7 @@ def leftSectorWord (F : PhysicalSectorFactorization K) {A : ℕ}
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The resulting word indexes a
+**Scope restriction (cyclic-active restriction):** The resulting word indexes a
 retained right path in the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def rightSectorWord (F : PhysicalSectorFactorization K) {C : ℕ}
@@ -349,7 +349,7 @@ into left open-edge coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the left fiber
+**Scope restriction (cyclic-active restriction):** This is the left fiber
 identification for the retained decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def leftFixedFiberOpenEdgeEquiv
@@ -369,7 +369,7 @@ fiber into right open-edge coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the right fiber
+**Scope restriction (cyclic-active restriction):** This is the right fiber
 identification for the retained decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def rightFixedFiberOpenEdgeEquiv
@@ -387,7 +387,7 @@ as a direct sum of left open-edge configurations.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The direct sum is the left side of
+**Scope restriction (cyclic-active restriction):** The direct sum is the left side of
 the retained cut decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def leftSectorOpenEdgeEquiv
@@ -408,7 +408,7 @@ a direct sum of right open-edge configurations.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The direct sum is the right side
+**Scope restriction (cyclic-active restriction):** The direct sum is the right side
 of the retained cut decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def rightSectorOpenEdgeEquiv
@@ -432,7 +432,7 @@ of the left physical chain.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 left retained-sector word. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem leftSectorOpenEdgeEquiv_apply_fst
@@ -448,7 +448,7 @@ of the right physical chain.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 right retained-sector word. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem rightSectorOpenEdgeEquiv_apply_fst
@@ -464,7 +464,7 @@ and the middle-left boundary coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+**Scope restriction (cyclic-active restriction):** This dependent-coordinate identity
 is used in the retained cut decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem leftSectorOpenEdgeEquiv_symm_fiber_heq
@@ -495,7 +495,7 @@ boundary coordinate and the right chain fiber.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+**Scope restriction (cyclic-active restriction):** This dependent-coordinate identity
 is used in the retained cut decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem rightSectorOpenEdgeEquiv_symm_fiber_heq
@@ -527,7 +527,7 @@ middle-left boundary coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity belongs to
+**Scope restriction (cyclic-active restriction):** This endpoint identity belongs to
 the retained cut decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem leftSectorOpenEdgeEquiv_symm_last_eq
@@ -560,7 +560,7 @@ middle-right boundary coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity belongs to
+**Scope restriction (cyclic-active restriction):** This endpoint identity belongs to
 the retained cut decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem rightSectorOpenEdgeEquiv_symm_first_eq
@@ -594,7 +594,7 @@ coordinate recovered in the fixed-sector fiber.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+**Scope restriction (cyclic-active restriction):** This dependent-coordinate identity
 is used for retained left paths. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem leftFiberOpenEdgeEquiv_symm_fst_heq
@@ -613,7 +613,7 @@ the boundary coordinate in the fixed-sector fiber.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+**Scope restriction (cyclic-active restriction):** This dependent-coordinate identity
 is used for retained left paths. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem leftFiberOpenEdgeEquiv_symm_snd_heq
@@ -632,7 +632,7 @@ with the boundary coordinate in the fixed-sector fiber.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+**Scope restriction (cyclic-active restriction):** This dependent-coordinate identity
 is used for retained right paths. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem rightFiberOpenEdgeEquiv_symm_fst_heq
@@ -651,7 +651,7 @@ coordinate recovered in the fixed-sector fiber.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This dependent-coordinate identity
+**Scope restriction (cyclic-active restriction):** This dependent-coordinate identity
 is used for retained right paths. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem rightFiberOpenEdgeEquiv_symm_snd_heq
@@ -670,7 +670,7 @@ coordinate at the same position.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This projection describes retained
+**Scope restriction (cyclic-active restriction):** This projection describes retained
 left-path coordinates. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem leftFiberOpenEdgeEquiv_symm_edge_fst
@@ -688,7 +688,7 @@ coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity covers the
+**Scope restriction (cyclic-active restriction):** This endpoint identity covers the
 empty retained left path. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem leftFiberOpenEdgeEquiv_symm_boundary_zero
@@ -703,7 +703,7 @@ coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity describes a
+**Scope restriction (cyclic-active restriction):** This endpoint identity describes a
 retained left path. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem leftFiberOpenEdgeEquiv_symm_boundary_succ
@@ -718,7 +718,7 @@ next left site coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This projection describes retained
+**Scope restriction (cyclic-active restriction):** This projection describes retained
 left-path coordinates. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem leftFiberOpenEdgeEquiv_symm_edge_snd_castSucc
@@ -735,7 +735,7 @@ the middle-left boundary coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity describes a
+**Scope restriction (cyclic-active restriction):** This endpoint identity describes a
 retained left path. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem leftFiberOpenEdgeEquiv_symm_edge_snd_last
@@ -752,7 +752,7 @@ the middle-right boundary coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity describes a
+**Scope restriction (cyclic-active restriction):** This endpoint identity describes a
 retained right path. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem rightFiberOpenEdgeEquiv_symm_edge_fst_zero
@@ -768,7 +768,7 @@ coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity covers the
+**Scope restriction (cyclic-active restriction):** This endpoint identity covers the
 empty retained right path. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem rightFiberOpenEdgeEquiv_symm_boundary_zero
@@ -783,7 +783,7 @@ coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity describes a
+**Scope restriction (cyclic-active restriction):** This endpoint identity describes a
 retained right path. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem rightFiberOpenEdgeEquiv_symm_boundary_succ
@@ -798,7 +798,7 @@ preceding right site coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This projection describes retained
+**Scope restriction (cyclic-active restriction):** This projection describes retained
 right-path coordinates. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem rightFiberOpenEdgeEquiv_symm_edge_fst_succ
@@ -815,7 +815,7 @@ coordinate at the same position.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This projection describes retained
+**Scope restriction (cyclic-active restriction):** This projection describes retained
 right-path coordinates. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem rightFiberOpenEdgeEquiv_symm_edge_snd

--- a/TNLean/MPS/MPDO/CyclicActiveCutRegrouping.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutRegrouping.lean
@@ -383,7 +383,7 @@ fourth-region block into a direct sum of left and right path factors.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The blocks are those of the
+**Scope restriction (cyclic-active restriction):** The blocks are those of the
 restricted two-step cyclic-active coefficient. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reindex_cyclicActiveFourthRegionBlock_eq_cutRaw

--- a/TNLean/MPS/MPDO/CyclicActiveCutStates.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveCutStates.lean
@@ -30,7 +30,7 @@ coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This factor uses the left boundary
+**Scope restriction (cyclic-active restriction):** This factor uses the left boundary
 of the restricted two-step coefficient. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveLeftOpenBlock
@@ -53,7 +53,7 @@ coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This factor uses the right
+**Scope restriction (cyclic-active restriction):** This factor uses the right
 boundary of the restricted two-step coefficient. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveRightOpenBlock
@@ -75,7 +75,7 @@ operators and left boundary weights are nonnegative.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the left positive factor
+**Scope restriction (cyclic-active restriction):** This is the left positive factor
 for the restricted two-step coefficient. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveLeftOpenBlock_posSemidef
@@ -101,7 +101,7 @@ operators and right boundary weights are nonnegative.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the right positive factor
+**Scope restriction (cyclic-active restriction):** This is the right positive factor
 for the restricted two-step coefficient. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveRightOpenBlock_posSemidef
@@ -123,7 +123,7 @@ theorem cyclicActiveRightOpenBlock_posSemidef
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The direct sum ranges over left
+**Scope restriction (cyclic-active restriction):** The direct sum ranges over left
 paths retained by the cyclic-active restriction. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveLeftCutRaw
@@ -143,7 +143,7 @@ noncomputable def cyclicActiveLeftCutRaw
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The direct sum ranges over right
+**Scope restriction (cyclic-active restriction):** The direct sum ranges over right
 paths retained by the cyclic-active restriction. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveRightCutRaw
@@ -164,7 +164,7 @@ the standard left-cut coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The sum ranges over the retained
+**Scope restriction (cyclic-active restriction):** The sum ranges over the retained
 cyclic-active sectors. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveLeftCutRaw_posSemidef
@@ -183,7 +183,7 @@ the standard right-cut coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The sum ranges over the retained
+**Scope restriction (cyclic-active restriction):** The sum ranges over the retained
 cyclic-active sectors. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveRightCutRaw_posSemidef
@@ -202,7 +202,7 @@ every positive length under source zero correlation length.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This positivity normalizes the
+**Scope restriction (cyclic-active restriction):** This positivity normalizes the
 restricted cut probabilities after the additional marginal replacement. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem trace_mpo_sectorCoordinateTensor_pos_of_isSourceZCL
@@ -225,7 +225,7 @@ left cut block.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** Positive block traces make the
+**Scope restriction (cyclic-active restriction):** Positive block traces make the
 fallback mathematically inactive; it makes normalization total.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveLeftCutFallback
@@ -243,7 +243,7 @@ right cut block.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** Positive block traces make the
+**Scope restriction (cyclic-active restriction):** Positive block traces make the
 fallback mathematically inactive; it makes normalization total.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveRightCutFallback
@@ -260,7 +260,7 @@ noncomputable def cyclicActiveRightCutFallback
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The state normalizes the positive
+**Scope restriction (cyclic-active restriction):** The state normalizes the positive
 left factor of the restricted two-step coefficient.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveLeftCutState
@@ -274,7 +274,7 @@ noncomputable def cyclicActiveLeftCutState
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The state normalizes the positive
+**Scope restriction (cyclic-active restriction):** The state normalizes the positive
 right factor of the restricted two-step coefficient.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveRightCutState
@@ -288,7 +288,7 @@ noncomputable def cyclicActiveRightCutState
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** Its length includes the additional
+**Scope restriction (cyclic-active restriction):** Its length includes the additional
 marginal replacement.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveCutNormalization
@@ -301,7 +301,7 @@ decomposition.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The weight uses the normalized
+**Scope restriction (cyclic-active restriction):** The weight uses the normalized
 restricted two-step coefficient.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveCutProbability
@@ -317,7 +317,7 @@ the dependent blocks of the Hayashi decomposition.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identification separates the
+**Scope restriction (cyclic-active restriction):** This identification separates the
 retained cyclic-active chain at its distinguished middle site. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def retainedCutEquiv
@@ -346,7 +346,7 @@ site is the prescribed cut sector.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identity describes the
+**Scope restriction (cyclic-active restriction):** This identity describes the
 sector coordinates of the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem retainedCutEquiv_symm_middle_sector
@@ -368,7 +368,7 @@ cut is the corresponding sector in the left chain.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identity describes the
+**Scope restriction (cyclic-active restriction):** This identity describes the
 sector coordinates of the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem retainedCutEquiv_symm_left_sector
@@ -392,7 +392,7 @@ cut is the corresponding sector in the right chain.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identity describes the
+**Scope restriction (cyclic-active restriction):** This identity describes the
 sector coordinates of the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem retainedCutEquiv_symm_right_sector
@@ -417,7 +417,7 @@ agrees with the corresponding coordinate of the left open chain.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the dependent-coordinate
+**Scope restriction (cyclic-active restriction):** This is the dependent-coordinate
 identity for the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem retainedCutEquiv_symm_left_fiber_heq
@@ -504,7 +504,7 @@ agrees with the corresponding coordinate of the right open chain.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the dependent-coordinate
+**Scope restriction (cyclic-active restriction):** This is the dependent-coordinate
 identity for the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem retainedCutEquiv_symm_right_fiber_heq
@@ -593,7 +593,7 @@ left and right boundary indices.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the middle
+**Scope restriction (cyclic-active restriction):** This is the middle
 dependent-coordinate identity for the restricted decomposition. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem retainedCutEquiv_symm_middle_fiber_heq

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionContraction.lean
@@ -426,7 +426,7 @@ cyclic neighboring product, summing over all three discarded sector labels.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The suffix sum is later restricted
+**Scope restriction (cyclic-active restriction):** The suffix sum is later restricted
 to cyclic-active sector labels, producing the restricted two-step
 coefficient. See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable abbrev threeSuffixSectorContraction
@@ -536,7 +536,7 @@ lies on a positive-length directed cycle.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The source sum is represented on
+**Scope restriction (cyclic-active restriction):** The source sum is represented on
 the sectors occurring in nonzero cyclic products. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def IsCyclicActiveRetainedWord
@@ -550,7 +550,7 @@ subtype.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This word belongs to the restricted
+**Scope restriction (cyclic-active restriction):** This word belongs to the restricted
 sector set used in the fourth-region formula. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def cyclicActiveRetainedWord
@@ -675,7 +675,7 @@ three-suffix contractions of the cyclic neighboring products.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The direct sum is subsequently
+**Scope restriction (cyclic-active restriction):** The direct sum is subsequently
 reduced to retained cyclic-active sector words. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reindex_reducedBlockState_add_three_eq_threeSuffixSectorContraction
@@ -693,7 +693,7 @@ isometry defining the sector-coordinate tensor.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This replacement supplies the
+**Scope restriction (cyclic-active restriction):** This replacement supplies the
 extra marginal step used before restricting the sector sum. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem sectorCoordinateTensor_reducedBlockState_add_three_eq_succ_of_isSourceZCL
@@ -712,7 +712,7 @@ theorem sectorCoordinateTensor_reducedBlockState_add_three_eq_succ_of_isSourceZC
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The word ranges over the restricted
+**Scope restriction (cyclic-active restriction):** The word ranges over the restricted
 cyclic-active sector set. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def activeThreeSectorWord
@@ -725,7 +725,7 @@ def activeThreeSectorWord
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 first sector of the restricted suffix. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem activeThreeSectorWord_zero
@@ -738,7 +738,7 @@ first sector of the restricted suffix. See
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 middle sector of the restricted suffix. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem activeThreeSectorWord_one
@@ -751,7 +751,7 @@ middle sector of the restricted suffix. See
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 last sector of the restricted suffix. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem activeThreeSectorWord_two
@@ -764,7 +764,7 @@ last sector of the restricted suffix. See
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The contraction is evaluated only
+**Scope restriction (cyclic-active restriction):** The contraction is evaluated only
 on the sectors surviving cyclic-active deletion. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem sum_threeSuffixFiber_cyclicNeighboringProduct_active

--- a/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveFourthRegionFormula.lean
@@ -59,7 +59,7 @@ vanishes unless every retained sector is cyclic-active.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The boundary factors come from
+**Scope restriction (cyclic-active restriction):** The boundary factors come from
 $(\lambda^{-1}T_C)^2$ on the cyclic-active support.  Sectors outside that
 support contribute zero rather than being identified with cyclic-active
 sectors.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -83,7 +83,7 @@ contraction.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The vanishing follows from
+**Scope restriction (cyclic-active restriction):** The vanishing follows from
 deleting sector words outside positive-length cyclic support.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem threeSuffixSectorContraction_eq_zero_of_not_isCyclicActiveRetainedWord
@@ -115,7 +115,7 @@ contraction.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The coefficient is the square of
+**Scope restriction (cyclic-active restriction):** The coefficient is the square of
 the restricted cyclic-active trace matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveUnnormalized
@@ -247,7 +247,7 @@ to zero.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The two boundary factors arise
+**Scope restriction (cyclic-active restriction):** The two boundary factors arise
 from the normalized square of the restricted trace matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reindex_threeSuffixSectorContraction_eq_cyclicActiveFourthRegionBlock
@@ -284,7 +284,7 @@ left and right boundary factors.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The block formula uses the
+**Scope restriction (cyclic-active restriction):** The block formula uses the
 normalized square of the restricted cyclic-active trace matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem reindex_reducedBlockState_add_three_eq_cyclicActiveFourthRegionBlock
@@ -328,7 +328,7 @@ the three-site representative of the same marginal.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** One additional source-ZCL
+**Scope restriction (cyclic-active restriction):** One additional source-ZCL
 marginal replacement is used, so the separated coefficient is the normalized
 square of the restricted cyclic-active trace matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/

--- a/TNLean/MPS/MPDO/CyclicActiveMarkovDecomposition.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveMarkovDecomposition.lean
@@ -31,7 +31,7 @@ variable {d D : ℕ} {K : MPOTensor d D}
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This reassociation is used for the
+**Scope restriction (cyclic-active restriction):** This reassociation is used for the
 retained cyclic-active chain after the additional marginal replacement. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveCutLengthEquiv
@@ -48,7 +48,7 @@ and split at the middle sector.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The retained coordinates use only
+**Scope restriction (cyclic-active restriction):** The retained coordinates use only
 positive-length cyclic sectors.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveHayashiCutEquiv
@@ -97,7 +97,7 @@ one-site cut, with its blocks expressed as normalized left and right states.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The coefficient is restricted to
+**Scope restriction (cyclic-active restriction):** The coefficient is restricted to
 positive-length cyclic sectors and uses one additional marginal replacement.
 See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 private theorem reindex_reducedBlockState_eq_cyclicActiveCut
@@ -305,7 +305,7 @@ private theorem cyclicActiveCutProbability_nonneg
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** The normalization is the trace of
+**Scope restriction (cyclic-active restriction):** The normalization is the trace of
 the fourth-region marginal before the final restriction.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 private theorem sum_cyclicActiveCutProbability_eq_one
@@ -347,7 +347,7 @@ block matrix is the Hayashi block state.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the sector-coordinate
+**Scope restriction (cyclic-active restriction):** This is the sector-coordinate
 statement; transport to the original physical basis lies outside this
 sector-coordinate result.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -415,7 +415,7 @@ fourth-region formula.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The separating coefficient is the
+**Scope restriction (cyclic-active restriction):** The separating coefficient is the
 square of the trace matrix restricted to positive-length cyclic sectors,
 after one additional marginal replacement. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -478,7 +478,7 @@ decomposition at every one-site cut of the fourth-region marginal.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The separating coefficient is the
+**Scope restriction (cyclic-active restriction):** The separating coefficient is the
 normalized square of the trace matrix restricted to positive-length cyclic
 sectors, and it is obtained after one additional marginal replacement.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -523,7 +523,7 @@ one-site cut of the source tensor in the selected physical coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1597--1619.
 
-**Local fix (cyclic-active restriction):** The proof factors the normalized
+**Scope restriction (cyclic-active restriction):** The proof factors the normalized
 square of the trace matrix on positive-length cyclic sectors after one
 additional marginal replacement. It assumes no injectivity, normality, or
 zero-correlation-length property of the selected fixed-product tensor. See

--- a/TNLean/MPS/MPDO/CyclicActiveRetainedCoordinates.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveRetainedCoordinates.lean
@@ -33,7 +33,7 @@ edge from the last retained site back to the first.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** These coordinates retain only the
+**Scope restriction (cyclic-active restriction):** These coordinates retain only the
 sector words used in the cyclic-active fourth-region formula. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 abbrev RetainedOpenEdgeIndex (F : PhysicalSectorFactorization K) {n : ℕ}
@@ -50,7 +50,7 @@ the remaining boundary edge.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identification is applied to
+**Scope restriction (cyclic-active restriction):** This identification is applied to
 the retained cyclic-active sector words. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def retainedOpenEdgeEquiv (F : PhysicalSectorFactorization K) {n : ℕ}
@@ -67,7 +67,7 @@ corresponding open-edge coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identity is used after
+**Scope restriction (cyclic-active restriction):** This identity is used after
 restricting to retained cyclic-active words. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem cyclicEdgeEquiv_retainedOpenEdgeEquiv_symm_internal
@@ -84,7 +84,7 @@ that open-edge coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This identity is used after
+**Scope restriction (cyclic-active restriction):** This identity is used after
 restricting to retained cyclic-active words. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem retainedOpenEdgeEquiv_symm_internal_edge
@@ -104,7 +104,7 @@ boundary coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity is used for
+**Scope restriction (cyclic-active restriction):** This endpoint identity is used for
 retained cyclic-active words. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem cyclicEdgeEquiv_retainedOpenEdgeEquiv_symm_last
@@ -121,7 +121,7 @@ the remaining boundary edge.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity is used for
+**Scope restriction (cyclic-active restriction):** This endpoint identity is used for
 retained cyclic-active words. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem retainedOpenEdgeEquiv_symm_last_right
@@ -138,7 +138,7 @@ the remaining boundary edge.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This endpoint identity is used for
+**Scope restriction (cyclic-active restriction):** This endpoint identity is used for
 retained cyclic-active words. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem retainedOpenEdgeEquiv_symm_first_left
@@ -156,7 +156,7 @@ neighboring edges.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The change of coordinates is used
+**Scope restriction (cyclic-active restriction):** The change of coordinates is used
 on the sector words surviving the cyclic-active restriction. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def retainedOpenEdgeChainEquiv
@@ -172,7 +172,7 @@ coordinates.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1614--1617.
 
-**Local fix (cyclic-active restriction):** This is the unchanged interior
+**Scope restriction (cyclic-active restriction):** This is the unchanged interior
 product on a retained cyclic-active sector word. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def retainedBulkProduct
@@ -402,7 +402,7 @@ sector word.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This identification separates the
+**Scope restriction (cyclic-active restriction):** This identification separates the
 retained word from the three traced boundary sites. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def appendSectorFiber (F : PhysicalSectorFactorization K)
@@ -419,7 +419,7 @@ def appendSectorFiber (F : PhysicalSectorFactorization K)
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** These are the three boundary sites
+**Scope restriction (cyclic-active restriction):** These are the three boundary sites
 traced after the cyclic-active restriction. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 def threeSectorFiberEquiv (F : PhysicalSectorFactorization K)
@@ -441,7 +441,7 @@ first sector coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 first traced boundary site. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem threeSectorFiberEquiv_symm_apply_zero
@@ -458,7 +458,7 @@ second sector coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 second traced boundary site. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem threeSectorFiberEquiv_symm_apply_one
@@ -475,7 +475,7 @@ third sector coordinate.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This projection identifies the
+**Scope restriction (cyclic-active restriction):** This projection identifies the
 third traced boundary site. See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 @[simp] theorem threeSectorFiberEquiv_symm_apply_two

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -56,7 +56,7 @@ edge excludes the empty reflexive walk.
 Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
 
-**Local fix (cyclic-active restriction):** This definition isolates the
+**Scope restriction (cyclic-active restriction):** This definition isolates the
 nonzero cyclic support missing from the SAL-dependent primitive-matrix step
 of CPSV16 Lemma `propSN`.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -73,7 +73,7 @@ directed walk.
 Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
 
-**Local fix (cyclic-active restriction):** This indicator vanishes outside
+**Scope restriction (cyclic-active restriction):** This indicator vanishes outside
 the positive-length cyclic support, rather than ranging over every source
 sector.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveWeight (F : PhysicalSectorFactorization K)
@@ -98,7 +98,7 @@ Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 449--514.
 
-**Local fix (cyclic-active restriction):** This subtype contains only the
+**Scope restriction (cyclic-active restriction):** This subtype contains only the
 positive-length cyclic support, rather than every source sector.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
@@ -108,7 +108,7 @@ abbrev CyclicActiveSector (F : PhysicalSectorFactorization K) :=
 
 Source: arXiv:1606.00608, Appendix C.2, equation `Tkn`, lines 1480--1482.
 
-**Local fix (cyclic-active restriction):** Unlike the source matrix, this
+**Scope restriction (cyclic-active restriction):** Unlike the source matrix, this
 matrix is indexed only by sectors on positive-length directed cycles.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable abbrev cyclicActiveSectorTraceMatrix
@@ -184,7 +184,7 @@ containing a nonzero virtual matrix lies on a directed two-cycle.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** This is a restricted trace-pairing
+**Scope restriction (cyclic-active restriction):** This is a restricted trace-pairing
 consequence used in place of the SAL-dependent primitive-matrix step of
 `propSN`.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem isCyclicActiveSector_of_sectorVirtualMatrix_ne_zero
@@ -241,7 +241,7 @@ support vanishes.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** This removes only sectors outside
+**Scope restriction (cyclic-active restriction):** This removes only sectors outside
 nonzero cyclic support; it does not assert primitivity of the unreduced trace
 matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem sectorVirtualMatrix_eq_zero_of_not_isCyclicActiveSector
@@ -263,7 +263,7 @@ trace matrix; it does not identify that matrix with the unreduced one.
 Source: arXiv:1606.00608, Appendix C.2, equations `formK`, `etarl`, and
 `Tkn`, lines 1434--1493.
 
-**Local fix (cyclic-active restriction):** This auxiliary representative
+**Scope restriction (cyclic-active restriction):** This auxiliary representative
 implements the restricted repair; it is not the SAL decomposition in
 `propSN`.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveLeftRestriction
@@ -393,7 +393,7 @@ concerns the restricted trace matrix only, not the unreduced Beigi matrix.
 Source: arXiv:1606.00608, Appendix C.2, equations `Tkn` and `SALZCL`, lines
 1473--1497, used at Proposition `4to2`, lines 1606--1616.
 
-**Local fix (cyclic-active restriction):** The conclusion is transported to
+**Scope restriction (cyclic-active restriction):** The conclusion is transported to
 the restricted matrix.  It neither invokes SAL nor identifies this matrix
 with the full matrix of `propSN`.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -460,7 +460,7 @@ theorem cyclicActiveSectorTraceMatrix_normalized_relations_of_isSourceZCL
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** This restricted spanning statement
+**Scope restriction (cyclic-active restriction):** This restricted spanning statement
 replaces the SAL-dependent sector selection in `propSN`.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorOneSiteMatrixFamily_span_eq_top
@@ -479,7 +479,7 @@ sector.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** Nonemptiness is proved for the
+**Scope restriction (cyclic-active restriction):** Nonemptiness is proved for the
 restricted support, without the SAL hypothesis of `propSN`.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem nonempty_cyclicActiveSector
@@ -510,7 +510,7 @@ indicator-weight indexing used by the restricted trace matrix.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** This is an indexed form of the
+**Scope restriction (cyclic-active restriction):** This is an indexed form of the
 restricted support statement, not the SAL-dependent sector selection in
 `propSN`.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSector_exists_sectorVirtualMatrix_ne_zero
@@ -524,7 +524,7 @@ cyclic-active sector when the tensor is injective.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** The length-three return is proved
+**Scope restriction (cyclic-active restriction):** The length-three return is proved
 on the restricted support and replaces the paper's blocking assertion.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem exists_cyclicActive_two_edge_return
@@ -548,7 +548,7 @@ tensor is injective and the neighboring operators are positive semidefinite.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** Irreducibility is asserted only
+**Scope restriction (cyclic-active restriction):** Irreducibility is asserted only
 for the restricted trace matrix, without the SAL hypothesis of `propSN`.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_isIrreducible
@@ -563,7 +563,7 @@ theorem cyclicActiveSectorTraceMatrix_isIrreducible
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** This return weight belongs to the
+**Scope restriction (cyclic-active restriction):** This return weight belongs to the
 restricted trace matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_pow_two_diag_pos
@@ -579,7 +579,7 @@ theorem cyclicActiveSectorTraceMatrix_pow_two_diag_pos
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471.
 
-**Local fix (cyclic-active restriction):** This return weight belongs to the
+**Scope restriction (cyclic-active restriction):** This return weight belongs to the
 restricted trace matrix and replaces the paper's blocking assertion.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_pow_three_diag_pos
@@ -603,7 +603,7 @@ aperiodicity.
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471;
 Beigi, arXiv:1105.1019v2, lines 449--514.
 
-**Local fix (cyclic-active restriction):** This proves primitivity only after
+**Scope restriction (cyclic-active restriction):** This proves primitivity only after
 deleting sectors absent from nonzero cyclic products.  It is not the
 SAL-dependent full-matrix assertion of `propSN`.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -622,7 +622,7 @@ square--cube relation, then its square has rank one.
 Source: arXiv:1606.00608, Appendix C.2, equations `SALZCL`, lines
 1490--1497.
 
-**Local fix (cyclic-active restriction):** The rank-one conclusion concerns
+**Scope restriction (cyclic-active restriction):** The rank-one conclusion concerns
 the square of the restricted trace matrix, not the one-step full matrix in
 the printed proof.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
@@ -642,7 +642,7 @@ rank-one square whenever it satisfies the source-ZCL square--cube relation.
 Source: arXiv:1606.00608, Appendix C.2, equations `SALZCL`, lines
 1490--1497.
 
-**Local fix (cyclic-active restriction):** The rank-one conclusion concerns
+**Scope restriction (cyclic-active restriction):** The rank-one conclusion concerns
 the square of the restricted trace matrix, not the one-step full matrix in
 the printed proof.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem normalized_cyclicActiveSectorTraceMatrix_rank_pow_two_eq_one
@@ -668,7 +668,7 @@ normalized two-step trace coefficient on cyclic-active sectors:
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The factors belong to the square
+**Scope restriction (cyclic-active restriction):** The factors belong to the square
 of the restricted trace matrix.  This does not identify that square with the
 one-step matrix printed at source line 1613 or with the unreduced Beigi
 matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -708,7 +708,7 @@ assertion about the unreduced Beigi trace matrix.
 Source: arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1490--1497,
 and Proposition `4to2`, lines 1606--1616.
 
-**Local fix (cyclic-active restriction):** CPSV16 line 1613 uses the one-step
+**Scope restriction (cyclic-active restriction):** CPSV16 line 1613 uses the one-step
 coefficient, whereas this theorem proves rank one for the square of the
 restricted coefficient.  The additional marginal replacement remains open.
 See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -809,7 +809,7 @@ bond product unchanged: precisely the deleted blocks vanish.
 Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450; Beigi,
 arXiv:1105.1019v2, directed-cycle discussion at lines 449--514.
 
-**Local fix (cyclic-active restriction):** This deletion concerns the
+**Scope restriction (cyclic-active restriction):** This deletion concerns the
 restricted cyclic support and makes no primitivity claim about the full trace
 matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicNeighboringProduct_eq_zero_of_not_isCyclicActiveSector
@@ -844,7 +844,7 @@ nonzero contribution.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617, together with the cyclic sector decomposition at lines 1441--1450.
 
-**Local fix (cyclic-active restriction):** This assertion concerns deletion
+**Scope restriction (cyclic-active restriction):** This assertion concerns deletion
 outside the positive-length cyclic support; it does not identify the
 restricted trace matrix with the unreduced Beigi matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/

--- a/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveSectorRestriction.lean
@@ -33,7 +33,7 @@ the two matrices are not identified here.
 
 ## References
 
-* Beigi, arXiv:1105.1019v2, Lemma 2.1 and lines 449--514.
+* Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III.
 * arXiv:1606.00608, Appendix C.2, equations `formK` and `etarl`, lines
   1434--1450.
 -/
@@ -53,8 +53,8 @@ Equivalently, it has an outgoing nonzero neighboring operator whose target
 can return through a possibly empty directed path.  The explicit outgoing
 edge excludes the empty reflexive walk.
 
-Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
-449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
+Source: Beigi, J. Phys. A 45 (2012) 025306, directed-cycle discussion in
+Section III; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
 
 **Scope restriction (cyclic-active restriction):** This definition isolates the
 nonzero cyclic support missing from the SAL-dependent primitive-matrix step
@@ -70,8 +70,8 @@ def IsCyclicActiveSector (F : PhysicalSectorFactorization K)
 /-- The indicator weight of the sectors lying on a positive-length closed
 directed walk.
 
-Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
-449--514; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
+Source: Beigi, J. Phys. A 45 (2012) 025306, directed-cycle discussion in
+Section III; arXiv:1606.00608, Appendix C.2, lines 1441--1450.
 
 **Scope restriction (cyclic-active restriction):** This indicator vanishes outside
 the positive-length cyclic support, rather than ranging over every source
@@ -85,8 +85,7 @@ noncomputable def cyclicActiveWeight (F : PhysicalSectorFactorization K)
 /-- The cyclic-active indicator is nonzero precisely on sectors which lie on
 a positive-length closed walk.
 
-Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
-449--514. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, directed-cycle discussion in Section III. -/
 @[simp] theorem cyclicActiveWeight_ne_zero_iff
     (F : PhysicalSectorFactorization K) (k : Fin F.sectorCount) :
     F.cyclicActiveWeight k ≠ 0 ↔ F.IsCyclicActiveSector k := by
@@ -95,8 +94,7 @@ Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
 
 /-- The subtype of sectors lying on a positive-length closed directed walk.
 
-Source: Beigi, arXiv:1105.1019v2, directed-cycle discussion at lines
-449--514.
+Source: Beigi, J. Phys. A 45 (2012) 025306, directed-cycle discussion in Section III.
 
 **Scope restriction (cyclic-active restriction):** This subtype contains only the
 positive-length cyclic support, rather than every source sector.  See
@@ -162,7 +160,7 @@ private theorem exists_leftTensor_entry_ne_zero_of_neighboringOperator_ne_zero
 
 /-- Every cyclic-active sector contains a nonzero virtual matrix.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and lines 449--514. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 theorem exists_sectorVirtualMatrix_ne_zero_of_isCyclicActiveSector
     (F : PhysicalSectorFactorization K) {k : Fin F.sectorCount}
     (hk : F.IsCyclicActiveSector k) :
@@ -601,7 +599,7 @@ trace pairing supplies closed walks of lengths two and three, hence
 aperiodicity.
 
 Source: arXiv:1606.00608, Appendix C.2, Lemma `propSN`, lines 1451--1471;
-Beigi, arXiv:1105.1019v2, lines 449--514.
+Beigi, J. Phys. A 45 (2012) 025306, Section III.
 
 **Scope restriction (cyclic-active restriction):** This proves primitivity only after
 deleting sectors absent from nonzero cyclic products.  It is not the
@@ -807,7 +805,7 @@ Thus deleting all non-cyclic-active sector blocks leaves every finite cyclic
 bond product unchanged: precisely the deleted blocks vanish.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1441--1450; Beigi,
-arXiv:1105.1019v2, directed-cycle discussion at lines 449--514.
+J. Phys. A 45 (2012) 025306, directed-cycle discussion in Section III.
 
 **Scope restriction (cyclic-active restriction):** This deletion concerns the
 restricted cyclic support and makes no primitivity claim about the full trace

--- a/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
+++ b/TNLean/MPS/MPDO/CyclicActiveThreeBoundaryTrace.lean
@@ -48,7 +48,7 @@ the corresponding cyclic-active trace-matrix entry.
 
 Source: arXiv:1606.00608, Appendix C.2, lines 1441--1455.
 
-**Local fix (cyclic-active restriction):** This equality is recorded on the
+**Scope restriction (cyclic-active restriction):** This equality is recorded on the
 positive-length cyclic support used in the three-boundary coefficient.  It
 does not identify the restricted trace matrix with the unreduced Beigi
 matrix.  See `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -75,7 +75,7 @@ complexification of its real part.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The sum is restricted to sectors
+**Scope restriction (cyclic-active restriction):** The sum is restricted to sectors
 on positive-length directed cycles and yields the square of the restricted
 trace matrix.  It does not replace this square by the one-step trace matrix
 printed at source line 1613.  See
@@ -105,7 +105,7 @@ trace matrix:
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This is the normalized two-step
+**Scope restriction (cyclic-active restriction):** This is the normalized two-step
 coefficient on the positive-length cyclic support.  It does not identify the
 one-step matrix with its square or with the unreduced Beigi matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -130,7 +130,7 @@ coefficient $(T_C^2)_{q,h}$.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This is the three-boundary
+**Scope restriction (cyclic-active restriction):** This is the three-boundary
 coordinate identity for the positive-length cyclic support.  It proves only
 the appearance of the two-step coefficient; the identification with the
 source-ZCL reduced state and the Markov decomposition remain separate.  See
@@ -154,7 +154,7 @@ $T_C^2$.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The coefficient is the square of
+**Scope restriction (cyclic-active restriction):** The coefficient is the square of
 the restricted trace matrix.  It is not replaced by the one-step matrix
 printed at source line 1613.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -175,7 +175,7 @@ retain one partial trace each.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The coefficient is the square of
+**Scope restriction (cyclic-active restriction):** The coefficient is the square of
 the restricted normalized trace matrix, not the one-step coefficient printed
 at source line 1613.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
@@ -195,7 +195,7 @@ corresponding square from the unnormalized fourth-region boundary.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This identity relates $T_C^2$ to
+**Scope restriction (cyclic-active restriction):** This identity relates $T_C^2$ to
 $(\lambda^{-1}T_C)^2$ and does not identify either square with $T_C$.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 theorem cyclicActiveUnnormalizedTwoStepBoundaryContraction_eq_smul
@@ -241,7 +241,7 @@ normalized two-step cyclic-active coefficient.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** The factors belong to
+**Scope restriction (cyclic-active restriction):** The factors belong to
 $(\lambda^{-1}T_C)^2$ and do not factor the one-step matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/
 noncomputable def cyclicActiveSeparatedBoundary
@@ -261,7 +261,7 @@ the two surviving fourth-region boundaries.
 Source: arXiv:1606.00608, Appendix C.2, Proposition `4to2`, lines
 1606--1617.
 
-**Local fix (cyclic-active restriction):** This theorem uses a factorization
+**Scope restriction (cyclic-active restriction):** This theorem uses a factorization
 of $(\lambda^{-1}T_C)^2$.  It neither identifies $T_C$ with its square nor
 uses the unreduced sector matrix.  See
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`. -/

--- a/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorConstructor.lean
+++ b/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorConstructor.lean
@@ -27,7 +27,7 @@ matrices in the commuting-bond decomposition.
 ## References
 
 * arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1605.
-* S. Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III.
+* S. Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III.
 -/
 
 open scoped BigOperators ComplexOrder Kronecker Matrix
@@ -208,7 +208,7 @@ private theorem positiveEtaPhysicalSectorFactorization_neighboringOperator
 /-- The two-site physical coordinate matrix is the reindexed tensor square
 of the Beigi unitary.
 
-Source: Beigi, arXiv:1105.1019v2, Section III. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III. -/
 private theorem positiveEtaPhysicalSectorFactorization_coordinateTwo
     {K : ℕ} (dl dr : Fin K → ℕ)
     (e : Matrix.EtaSiteIndex K dl dr ≃ Fin d)
@@ -231,7 +231,7 @@ private theorem positiveEtaPhysicalSectorFactorization_coordinateTwo
 /-- Conjugating the input pair bond by the retained physical coordinates is
 the reindexed Beigi-conjugated bond.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, and arXiv:1606.00608,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III; arXiv:1606.00608,
 equation `sigmaNK2`, lines 1581--1589. -/
 private theorem positiveEtaPhysicalSectorFactorization_conjugate_pairBond
     (data : TranslationInvariantBondData d)
@@ -311,7 +311,7 @@ private theorem positiveEtaPhysicalSectorFactorization_etaPairEquiv
 the physical-sector coordinates.
 
 Source: arXiv:1606.00608, equation `sigmaNK2`, lines 1581--1589; Beigi,
-arXiv:1105.1019v2, Section III. -/
+J. Phys. A 45 (2012) 025306, Section III. -/
 private theorem positiveEtaPhysicalSectorFactorization_sectorBond_eq
     (data : TranslationInvariantBondData d)
     {K : ℕ} (dl dr : Fin K → ℕ)
@@ -465,7 +465,7 @@ The factorization belongs to the exact tensor stored in `repr`; it is not
 transported from a second tensor with the same closed MPOs.
 
 Source: arXiv:1606.00608, equation `sigmaNK2`, lines 1581--1589; Beigi,
-arXiv:1105.1019v2, Lemma 2.1 and Section III. -/
+J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 structure PositivePhysicalSectorFixedProductTensorData
     (data : TranslationInvariantBondData d) where
   /-- The exact fixed-product representative. -/
@@ -515,7 +515,7 @@ No nonempty-physical-space hypothesis is needed.  When `d = 0`, a separate
 one-dimensional virtual tensor carries the zero-sector factorization.
 
 Source: arXiv:1606.00608, equation `sigmaNK2`, lines 1581--1605; Beigi,
-arXiv:1105.1019v2, Lemma 2.1 and Section III. -/
+J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 theorem nonempty_positivePhysicalSectorFixedProductTensorData
     (data : TranslationInvariantBondData d) :
     Nonempty (PositivePhysicalSectorFixedProductTensorData data) := by
@@ -556,7 +556,7 @@ theorem nonempty_positivePhysicalSectorFixedProductTensorData
 physical-sector witness.
 
 Source: arXiv:1606.00608, equation `sigmaNK2`, lines 1581--1605; Beigi,
-arXiv:1105.1019v2, Lemma 2.1 and Section III. -/
+J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 noncomputable def positivePhysicalSectorFixedProductTensorData
     (data : TranslationInvariantBondData d) :
     PositivePhysicalSectorFixedProductTensorData data :=

--- a/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorRepresentative.lean
+++ b/TNLean/MPS/MPDO/FixedBondPositivePhysicalSectorRepresentative.lean
@@ -24,8 +24,7 @@ statement is asserted.
 ## References
 
 * arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines 1581--1605.
-* S. Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, lines 395--415 and
-  456--476.
+* S. Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III.
 -/
 
 open scoped ComplexOrder
@@ -48,8 +47,7 @@ comparison is recorded in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
-1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, lines
-395--415 and 456--476. -/
+1581--1605; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 theorem exists_positive_physicalSectorFactorization_fixedProductTensorData
     (data : TranslationInvariantBondData d) :
     ∃ F : PhysicalSectorFactorization data.fixedProductTensorData.tensor,

--- a/TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean
+++ b/TNLean/MPS/MPDO/FixedBondProductEtaTensor.lean
@@ -127,7 +127,7 @@ product.  This is the representative whose positive physical sectors are
 exposed by `fixedProductTensorDataPhysicalSectorFactorization`.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition
-`4to2`, lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+`4to2`, lines 1581--1605; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1. -/
 noncomputable def fixedProductTensorData (data : TranslationInvariantBondData d) :
     FixedProductTensorData data :=
   data.positivePhysicalSectorFixedProductTensorData.repr
@@ -146,7 +146,7 @@ that the representing tensor is normal and does not constrain the positive
 realization scalar of the source MPO.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2` and Proposition
-`4to2`, lines 1581--1605; Beigi, arXiv:1105.1019v2, Lemma 2.1. -/
+`4to2`, lines 1581--1605; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1. -/
 theorem nonempty_fixedProductTensorData (data : TranslationInvariantBondData d) :
     Nonempty (FixedProductTensorData data) :=
   ⟨data.fixedProductTensorData⟩
@@ -155,7 +155,7 @@ theorem nonempty_fixedProductTensorData (data : TranslationInvariantBondData d) 
 fixed-product tensor.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
-1581--1589; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III. -/
+1581--1589; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 noncomputable def fixedProductTensorDataPhysicalSectorFactorization
     (data : TranslationInvariantBondData d) :
     PhysicalSectorFactorization data.fixedProductTensorData.tensor :=
@@ -165,7 +165,7 @@ noncomputable def fixedProductTensorDataPhysicalSectorFactorization
 factorization is the input commuting bond.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
-1581--1589; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III. -/
+1581--1589; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 theorem fixedProductTensorDataPhysicalSectorFactorization_physicalBond_eq
     (data : TranslationInvariantBondData d) :
     data.fixedProductTensorDataPhysicalSectorFactorization.physicalBond =
@@ -176,7 +176,7 @@ theorem fixedProductTensorDataPhysicalSectorFactorization_physicalBond_eq
 factorization are positive semidefinite.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
-1581--1589; Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III. -/
+1581--1589; Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III. -/
 theorem fixedProductTensorDataPhysicalSectorFactorization_neighboring_pos
     (data : TranslationInvariantBondData d) :
     ∀ q h,

--- a/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorEtaLocalStructure.lean
@@ -37,8 +37,14 @@ The normalization scalar at every chain length is one.
 Source: arXiv:1606.00608, Appendix C.2, Proposition C.8 (`3to4`), lines
 1571--1593.
 
-The source-faithful existence theorem from SAL is
-`MPOTensor.nonempty_etaLocalStructureData_of_isSAL`. -/
+**Scope restriction (given physical-sector factorization):** Proposition
+`3to4` assumes SAL (arXiv:1606.00608, Appendix C.2, Proposition C.8, lines
+1571--1593); positivity of the neighboring operators is obtained in the
+preceding Lemma `propSN`, lines 1441--1450. The present declaration instead
+takes both the physical-sector factorization and this positivity as
+hypotheses. The source-faithful implication is
+`MPOTensor.nonempty_etaLocalStructureData_of_isSAL`; see
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
 noncomputable def etaLocalStructureData
     (F : PhysicalSectorFactorization K)
     (hη : ∀ k h, (F.neighboringOperator k h).PosSemidef) :

--- a/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
@@ -12,6 +12,11 @@ A virtual similarity mixes the left and right virtual indices by inverse
 matrices.  These changes can be absorbed separately into the two tensor
 factors of a physical-sector factorization.  Their contraction cancels the
 gauge, so the neighboring operators are unchanged.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Appendix C.2,
+  equation `AppUkU=rl`, lines 1381--1388.
 -/
 
 open scoped ComplexOrder Matrix

--- a/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorGaugeTransport.lean
@@ -13,10 +13,11 @@ matrices.  These changes can be absorbed separately into the two tensor
 factors of a physical-sector factorization.  Their contraction cancels the
 gauge, so the neighboring operators are unchanged.
 
-## References
+## Background
 
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Appendix C.2,
-  equation `AppUkU=rl`, lines 1381--1388.
+  equation `AppUkU=rl`, lines 1381--1388, for the physical-sector
+  factorization transported here.
 -/
 
 open scoped ComplexOrder Matrix
@@ -32,8 +33,10 @@ The physical-sector decomposition and physical isometry are unchanged.  The
 gauge and its inverse are absorbed into the left and right virtual tensor
 families, respectively.
 
-Source context: arXiv:1606.00608, Appendix C.2, equation `AppUkU=rl`, lines
-1381--1388. -/
+Background for the factorization: arXiv:1606.00608, Appendix C.2, equation
+`AppUkU=rl`, lines 1381--1388. That passage does not state the virtual-gauge
+transport; the present construction is the direct algebraic transport of its
+two virtual factors. -/
 noncomputable def ofGaugeEquiv (F : PhysicalSectorFactorization K)
     (hGauge : MPSTensor.GaugeEquiv K.toMPSTensor L.toMPSTensor) :
     PhysicalSectorFactorization L :=

--- a/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorProductRealization.lean
@@ -316,7 +316,7 @@ noncomputable def sectorBond (F : PhysicalSectorFactorization K) :
 operator decomposition required by cyclic eta transport.
 
 Source: arXiv:1606.00608, Appendix C.2, equation `sigmaNK2`, lines
-1581--1589; Beigi, arXiv:1105.1019v2, Section III. -/
+1581--1589; Beigi, J. Phys. A 45 (2012) 025306, Section III. -/
 theorem sectorCoordinateBond_etaPair_decomposition
     (F : PhysicalSectorFactorization K) :
     Matrix.reindex (Matrix.etaPairSpatialBlockEquiv F.etaSectorFinEquiv).symm

--- a/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
@@ -234,7 +234,7 @@ theorem exists_active_neighboringOperator_ne_zero
 /-- The real trace matrix of the neighboring operators, restricted to the
 nonzero-weight sector subtype.
 
-**Local fix (inactive sectors):** the full physical sector decomposition is
+**Scope restriction (inactive sectors):** the full physical sector decomposition is
 unchanged. Only this auxiliary matrix is restricted, because every row and
 column incident to a zero-weight sector vanishes after the source-faithful
 reparameterization. See
@@ -284,7 +284,7 @@ operators from `k` to `h` and from `h` to `k` are nonzero.
 This is the length-two closed-walk input in the primitivity argument of
 arXiv:1606.00608, Appendix C.2, Lemma C.4 (`propSN`), lines 1452--1470.
 
-**Local fix (periodicity):** the source removes periodic components by
+**Scope restriction (periodicity):** the source removes periodic components by
 blocking. Here the trace pairing instead supplies a closed walk of length two;
 it is an auxiliary replacement to be paired with the length-three walk from
 triangle closure. See

--- a/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
+++ b/TNLean/MPS/MPDO/PhysicalSectorTraceMatrix.lean
@@ -355,9 +355,9 @@ The positive summand is supplied by the directed two-cycle through the given
 sector. This is one of two coprime-period inputs; it does not assert that the
 diagonal entry of the trace matrix itself is positive.
 
-**Local fix (periodicity):** this length-two return is an auxiliary substitute
-for the source's blocking of periodic components and must be combined with
-the length-three return from triangle closure. See
+**Scope restriction (periodicity):** this length-two return is an auxiliary
+substitute for the source's blocking of periodic components and must be
+combined with the length-three return from triangle closure. See
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`. -/
 theorem activeSectorTraceMatrix_pow_two_diag_pos
     (F : PhysicalSectorFactorization K) (p : Fin F.sectorCount → ℝ)
@@ -416,7 +416,7 @@ theorem activeSectorTraceMatrix_isIrreducible
 /-- If every active nonzero edge closes through a third active sector, then
 every diagonal entry of the cube of the active trace matrix is positive.
 
-**Local fix (periodicity):** this length-three return is an auxiliary
+**Scope restriction (periodicity):** this length-three return is an auxiliary
 substitute for the source's blocking of periodic components and is combined
 with the length-two return above. See
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
@@ -461,8 +461,9 @@ theorem activeSectorTraceMatrix_pow_three_diag_pos
 /-- Active-sector spanning, sector nonvanishing, positive neighboring
 operators, and triangle closure imply primitivity of the active trace matrix.
 
-**Local fix (periodicity):** the common positive power is obtained from
-closed walks of lengths two and three in place of the source's blocking
+**Scope restriction (periodicity and triangle closure):** the common positive
+power is obtained from closed walks of lengths two and three, under the
+source-absent triangle-closure hypothesis, in place of the source's blocking
 argument. See
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 

--- a/TNLean/MPS/MPDO/SALArbitraryCut.lean
+++ b/TNLean/MPS/MPDO/SALArbitraryCut.lean
@@ -170,7 +170,7 @@ give SAL.
 **Scope restriction (Markov decomposition assumed):** Proposition 4to2 of
 arXiv:1606.00608 assumes instead a single translation-invariant commuting bond
 and ZCL. Deriving the decompositions below from those hypotheses requires the
-Bravyi--Vyalyi spatial decomposition (Beigi, arXiv:1105.1019v2, Lemma 2.1),
+Bravyi--Vyalyi spatial decomposition (Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1),
 and the subsequent ZCL trace factorization. This missing implication is documented in
 `docs/paper-gaps/cpsv16_commuting_form_to_sal.tex`.
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -794,9 +794,10 @@ paper's construction of `T`, but the PSD rank-one criterion is stronger and does
 not use primitivity once `trace T = 1` and constant trace powers are known.
 
 **Scope restriction (positive-semidefinite trace matrix):** Positive
-semidefiniteness is absent from Lemma C.5. The primitivity hypothesis is
-retained for comparison with the source but is unused by this corrected
-argument. Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+semidefiniteness is absent from arXiv:1606.00608, Appendix C.2, Lemma
+`SALZCL` (Lemma C.5), lines 1484--1499. The primitivity hypothesis is retained
+for comparison with the source but is unused by this corrected argument.
+Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
 theorem sal_zcl_implies_rank_one_T_of_posSemidef
     (T : Matrix (Fin n) (Fin n) ℝ)
     (_hPrimitive : Matrix.IsPrimitive T)

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -791,7 +791,12 @@ factorization directly.
 
 The primitivity hypothesis is kept in the statement because it is part of the
 paper's construction of `T`, but the PSD rank-one criterion is stronger and does
-not use primitivity once `trace T = 1` and constant trace powers are known. -/
+not use primitivity once `trace T = 1` and constant trace powers are known.
+
+**Scope restriction (positive-semidefinite trace matrix):** Positive
+semidefiniteness is absent from Lemma C.5. The primitivity hypothesis is
+retained for comparison with the source but is unused by this corrected
+argument. Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
 theorem sal_zcl_implies_rank_one_T_of_posSemidef
     (T : Matrix (Fin n) (Fin n) ℝ)
     (_hPrimitive : Matrix.IsPrimitive T)

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -633,7 +633,13 @@ imply
   \psi\in \bigvee_j G_{n+2}(A^j).
 \]
 This is the local membership step in
-Theorem 12 of arXiv:quant-ph/0608197, proof lines 1446--1452. -/
+Theorem 12 of arXiv:quant-ph/0608197, proof lines 1446--1452.
+
+**Local fix (missing adjoint):** The printed definition
+\(E^j=\sum_a C_a^jA_a^j\) at line 1449 omits the adjoint required by the
+right-canonical identity used in the calculation. Here
+\(E^j=\sum_a C_a^jA_a^{j\dagger}\). See
+`docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -210,8 +210,8 @@ noncomputable def parentHamiltonian (A : MPSTensor d D) (L N : ℕ) :
 /-- The two-site parent Hamiltonian on a one-site periodic chain is zero under
 the project's convention for a local interaction larger than the chain.
 
-**Scope restriction (one-site chain):** Beigi, arXiv:1105.1019v2, Section III,
-source lines 451--514, defines each interaction on two neighboring sites but
+**Scope restriction (one-site chain):** Beigi, J. Phys. A 45 (2012) 025306,
+Section III, defines each interaction on two neighboring sites but
 does not specify its action when those sites coincide. The zero value here is
 the convention in `localTerm`, not a one-site case of Beigi's ordered-cycle
 formula. CPSV16, arXiv:1606.00608, Theorem 3.10(iii), source lines 534--540,

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -151,8 +151,8 @@ noncomputable def parentHamiltonianGroundSpaceES (A : MPSTensor d D)
 one-site Hilbert space under the project's zero convention.
 
 **Scope restriction (one-site chain):** This is a consequence of
-`parentHamiltonian_two_one_eq_zero`. Beigi, arXiv:1105.1019v2, Section III,
-source lines 451--514, does not specify a one-site action for its two-site
+`parentHamiltonian_two_one_eq_zero`. Beigi, J. Phys. A 45 (2012) 025306,
+Section III, does not specify a one-site action for its two-site
 interaction, while CPSV16, arXiv:1606.00608, Theorem 3.10(iii), source lines
 534--540, only uses chain lengths greater than two. This restriction is documented
 in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/

--- a/TNLean/MPS/RFP/BeigiEventuallyConstantSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiEventuallyConstantSectorGraph.lean
@@ -20,8 +20,7 @@ the parent formula equals the number of loops.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Section IV, equations (7)--(13), source
-  lines 561--606.
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Section IV, equations (7)--(13).
 -/
 
 open scoped BigOperators
@@ -34,8 +33,7 @@ variable {d D : ℕ} {A : MPSTensor d D}
 
 /-- The dimension of the ground space carried by a directed sector edge.
 
-Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
-561--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (4) and Section IV. -/
 noncomputable def edgeWeight (F : BeigiSectorGraphData A)
     (a b : Fin F.sectorCount) : ℕ :=
   Module.finrank ℂ (F.edgeGroundSpace a b)
@@ -43,8 +41,7 @@ noncomputable def edgeWeight (F : BeigiSectorGraphData A)
 /-- A sector edge is present exactly when its edge-ground-space dimension is
 nonzero.
 
-Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
-561--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (4) and Section IV. -/
 theorem isEdge_iff_edgeWeight_ne_zero (F : BeigiSectorGraphData A)
     (a b : Fin F.sectorCount) :
     F.IsEdge a b ↔ F.edgeWeight a b ≠ 0 := by
@@ -62,8 +59,7 @@ private theorem next_eq_add_one {N : ℕ} [NeZero N] (hN : 0 < N) (i : Fin N) :
 /-- The abstract weighted-cycle sum agrees with Beigi's sum over ordered
 sector cycles.
 
-Source: Beigi, arXiv:1105.1019v2, equation (4) and Section IV, source lines
-561--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (4) and Section IV. -/
 theorem cycleWeightSum_edgeWeight_eq (F : BeigiSectorGraphData A)
     {N : ℕ} (hN : 0 < N) :
     letI : NeZero N := ⟨Nat.ne_of_gt hN⟩
@@ -98,7 +94,7 @@ theorem cycleWeightSum_edgeWeight_eq (F : BeigiSectorGraphData A)
 /-- Eventual constancy of the actual parent-ground-space dimension implies
 eventual constancy of the numerical weighted-cycle sum.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 561--568. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem hasEventuallyConstantCycleWeightSum_of_parentGroundSpace
     (F : BeigiSectorGraphData A)
     (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
@@ -117,7 +113,7 @@ theorem hasEventuallyConstantCycleWeightSum_of_parentGroundSpace
 /-- If the parent-ground-space dimension is eventually constant, then at
 every length greater than two it equals the number of positive sector loops.
 
-Source: Beigi, arXiv:1105.1019v2, equation (13), source lines 600--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, equation (13). -/
 theorem parentHamiltonianGroundSpaceES_finrank_eq_card_loop
     (F : BeigiSectorGraphData A)
     (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
@@ -154,7 +150,7 @@ dimension covered by Beigi's cycle formula equals the number of positive
 sector loops.
 
 Source: CPSV16, Definition 3.9 and Theorem 3.10, lines 517--540; Beigi,
-arXiv:1105.1019v2, Section IV, source lines 561--606. -/
+J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem parentHamiltonianGroundSpaceES_finrank_eq_card_loop_of_hasBNTSectorData
     {P : SectorDecomposition d} (F : BeigiSectorGraphData P.toTensor)
     (hBNT : HasBNTSectorData P)

--- a/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
+++ b/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
@@ -39,8 +39,8 @@ that ground space is eventually the number of distinct basis sectors.
 Comparison: arXiv:1606.00608, Definition 3.9 and Theorem 3.10, lines 517--540.
 Those passages do not state this dimension count. It is a local consequence of
 the all-chain spanning equality and eventual linear independence, and supplies
-the eventual ground-state degeneracy used in Beigi, arXiv:1105.1019,
-Section IV. Documented in
+the eventual ground-state degeneracy used in Beigi, J. Phys. A 45 (2012)
+025306, Section IV. Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq
     {d : ℕ} {P : SectorDecomposition d}

--- a/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
+++ b/TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean
@@ -36,9 +36,12 @@ namespace MPSTensor
 span every sufficiently long nearest-neighbor parent ground space, then the dimension of
 that ground space is eventually the number of distinct basis sectors.
 
-Source: arXiv:1606.00608, Definition 3.9 and Theorem 3.10, lines 517--540.
-This supplies the eventual ground-state degeneracy used in Beigi,
-arXiv:1105.1019, Section IV. -/
+Comparison: arXiv:1606.00608, Definition 3.9 and Theorem 3.10, lines 517--540.
+Those passages do not state this dimension count. It is a local consequence of
+the all-chain spanning equality and eventual linear independence, and supplies
+the eventual ground-state degeneracy used in Beigi, arXiv:1105.1019,
+Section IV. Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem HasBNTSectorData.eventually_parentHamiltonian_groundSpace_finrank_eq
     {d : ℕ} {P : SectorDecomposition d}
     (hBNT : HasBNTSectorData P)

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -410,8 +410,10 @@ Proposition 3 (arXiv:0909.5347) and Wolf, Theorem 6.3.
 **Scope restriction (normal representative):** CPSV16, Theorem 3.10 is stated for a tensor in
 canonical form. This theorem proves its reverse implication for one explicitly normal and
 left-canonical representative, together with an explicit BNT relation and the all-chain
-ground-space condition. It does not assert the unrestricted canonical-form theorem. This
-restriction is documented in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+ground-space condition. In the source canonical decomposition, normality selects the
+one-sector case \(g=1\), where Beigi's finite-degeneracy classification is unnecessary.
+The multi-sector case \(g>1\), which motivates that classification, remains unproved.
+This restriction is documented in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 theorem nncph_implies_rfp
     (B : MPSTensor d D) [NeZero D]

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -411,8 +411,10 @@ Proposition 3 (arXiv:0909.5347) and Wolf, Theorem 6.3.
 canonical form. This theorem proves its reverse implication for one explicitly normal and
 left-canonical representative, together with an explicit BNT relation and the all-chain
 ground-space condition. In the source canonical decomposition, normality selects the
-one-sector case \(g=1\), where Beigi's finite-degeneracy classification is unnecessary.
-The multi-sector case \(g>1\), which motivates that classification, remains unproved.
+one-sector case \(g=1\), for which a source-level proof need not use Beigi's
+finite-degeneracy classification. The present formal proof nevertheless uses the finite
+sector graph and its loop-span theorem as an intermediate route to the gauge-phase match.
+The multi-sector case \(g>1\), which motivates the classification, remains unproved.
 This restriction is documented in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 theorem nncph_implies_rfp

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -404,7 +404,7 @@ normal-family span argument therefore matches the original tensor to one loop te
 phase and an invertible virtual gauge, which transports transfer idempotence.
 
 Source: CPSV16, proof of Theorem 3.10 at line 1307; Beigi,
-arXiv:1105.1019v2, Sections III--IV; algebraic-to-spectral normality uses quantum Wielandt
+J. Phys. A 45 (2012) 025306, Sections III--IV; algebraic-to-spectral normality uses quantum Wielandt
 Proposition 3 (arXiv:0909.5347) and Wolf, Theorem 6.3.
 
 **Scope restriction (normal representative):** CPSV16, Theorem 3.10 is stated for a tensor in

--- a/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
+++ b/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
@@ -23,7 +23,7 @@ length `N`, it multiplies Beigi's product-of-pairs vector by `‖φ‖₂⁻ᴺ`
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Section IV, source lines 602--606.
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Section IV.
 * J. I. Cirac, D. Pérez-García, N. Schuch, and F. Verstraete, *Matrix product
   density operators: Renormalization fixed points and boundary theories*,
   arXiv:1606.00608, equations `III_CFI_RFP` and `eq:III_isometry`, source
@@ -96,7 +96,7 @@ Euclidean space is essential here.
 vector.  The normalized RFP representative divides by its Euclidean norm; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
 the fixed-point normal-form derivation, source lines 1293--1300. -/
 noncomputable def loopBondNorm (F : BeigiSectorGraphData A)
@@ -106,7 +106,7 @@ noncomputable def loopBondNorm (F : BeigiSectorGraphData A)
 
 /-- The Euclidean norm of a positive-loop bond vector is positive.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16, fixed-point
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16, fixed-point
 normal-form derivation, source lines 1293--1300.  The normalization correction
 is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -117,7 +117,7 @@ theorem loopBondNorm_pos (F : BeigiSectorGraphData A)
 
 /-- The Euclidean norm of a positive-loop bond vector is nonzero.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16, fixed-point
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16, fixed-point
 normal-form derivation, source lines 1293--1300.  The normalization correction
 is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -128,7 +128,7 @@ theorem loopBondNorm_ne_zero (F : BeigiSectorGraphData A)
 /-- The Euclidean norm of the loop bond vector is the Frobenius norm of its
 coefficient matrix.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16, fixed-point
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16, fixed-point
 normal-form derivation, source lines 1293--1300.  The normalization correction
 is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -147,7 +147,7 @@ support removes unused virtual directions, while division by the Euclidean
 norm gives the normalized fixed-point representative; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555,
 `eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
 the fixed-point normal-form derivation, source lines 1293--1300. -/
@@ -163,7 +163,7 @@ bond vector.
 representative of Beigi's product-of-pairs tensor on its Schmidt support; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555,
 `eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
 the fixed-point normal-form derivation, source lines 1293--1300. -/
@@ -188,7 +188,7 @@ rank-one map on the virtual matrix algebra.
 rank factorization through the Schmidt support; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source context: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source context: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
 fixed-point normal-form derivation, source lines 1293--1300.  The rank-one
 formula itself is the local rank-factorization calculation recorded in
@@ -269,7 +269,7 @@ is nonzero but need not have unit norm.  Thus the raw transfer map is a scalar
 multiple of an idempotent rather than necessarily idempotent itself; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source context: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source context: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
 fixed-point normal-form derivation, source lines 1293--1300.  The scalar
 identity itself is the local rank-factorization calculation recorded in
@@ -307,7 +307,7 @@ inverse squared bond norm.
 norm of the bond vector, equivalently the Frobenius norm of its coefficient
 matrix; see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
 fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem transferMap_normalizedMinimalLoopCoordinateTensor
@@ -337,7 +337,7 @@ idempotent transfer map.
 removes the factor `‖φ‖₂²` from the square of the raw rank-one transfer map;
 see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
 fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopCoordinateTensor_isTransferIdempotent
@@ -377,7 +377,7 @@ the transfer map invariant, so the coordinate result passes to Beigi's
 physical coordinates; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
 fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopTensor_isTransferIdempotent
@@ -400,7 +400,7 @@ theorem normalizedMinimalLoopTensor_isTransferIdempotent
 nonzero inverse bond norm preserves one-site injectivity; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
 fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopTensor_isInjective
@@ -415,7 +415,7 @@ theorem normalizedMinimalLoopTensor_isInjective
 one-site injectivity of the normalized representative; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555, and the
 fixed-point normal-form derivation, source lines 1293--1300. -/
 theorem normalizedMinimalLoopTensor_isNormal
@@ -430,7 +430,7 @@ is Beigi's product-of-pairs vector multiplied by `‖φ‖₂⁻ᴺ`.
 Euclidean bond norm at each site; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, source lines 602--606; CPSV16,
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13); CPSV16,
 `III_CFI_RFP` and `eq:III_isometry`, source lines 543--555,
 `eq:basic-vectors-RFP-pure` and `eq:III_varphi`, source lines 570--578, and
 the fixed-point normal-form derivation, source lines 1293--1300. -/

--- a/TNLean/MPS/RFP/BeigiLoopInjectivity.lean
+++ b/TNLean/MPS/RFP/BeigiLoopInjectivity.lean
@@ -21,7 +21,7 @@ tensor.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
   Section IV, equation (10) and the paragraph following it.
 -/
 
@@ -152,7 +152,7 @@ The rank factors have maximal possible rank on their common Schmidt index.
 Their columns and rows therefore span that index space, so their outer
 products span the full matrix algebra.
 
-Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+Source context: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation),
 and Section IV, equation (10) and the paragraph following it.  The
 Schmidt-support consequence is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -196,7 +196,7 @@ theorem minimalLoopCoordinateTensor_isInjective
 
 /-- The physical loop tensor is injective on its Schmidt support.
 
-Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+Source context: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation),
 and Section IV, equation (10) and the paragraph following it.  The physical
 unitary preserves the one-site spanning property. -/
 theorem minimalLoopTensor_isInjective
@@ -210,7 +210,7 @@ theorem minimalLoopTensor_isInjective
 
 /-- The physical loop tensor is normal on its Schmidt support.
 
-Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+Source context: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation),
 and Section IV, equation (10) and the paragraph following it.  This is the
 one-site-injective consequence only; no normalization or transfer identity is
 asserted. -/

--- a/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
+++ b/TNLean/MPS/RFP/BeigiLoopSchmidtSupport.lean
@@ -19,7 +19,7 @@ realization at every positive length.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
   Section IV, equation (10) and the paragraph following it.
 -/
 
@@ -39,7 +39,7 @@ ambient left and right factors.  The minimal virtual space is therefore its
 Schmidt support.  This point is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 noncomputable def loopSchmidtRank (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : ℕ :=
@@ -53,25 +53,25 @@ rank rather than either ambient tensor-factor dimension.  This removes
 unused virtual directions when the chosen loop vector has deficient Schmidt
 rank; see `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 structure LoopSchmidtFactorization (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) where
   /-- The right/Schmidt-indexed factor of the loop bond coefficient matrix.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
   Section IV, equation (10) and the paragraph following it. -/
   rightFactor :
     Matrix (Fin (F.rightDim l.1)) (Fin (F.loopSchmidtRank l)) ℂ
   /-- The Schmidt/left-indexed factor of the loop bond coefficient matrix.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
   Section IV, equation (10) and the paragraph following it. -/
   leftFactor :
     Matrix (Fin (F.loopSchmidtRank l)) (Fin (F.leftDim l.1)) ℂ
   /-- The two factors multiply to the loop bond coefficient matrix.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
   Section IV, equation (10) and the paragraph following it. -/
   mul_eq : rightFactor * leftFactor =
     Matrix.schmidtCoeffMatrix (F.loopBondVector l)
@@ -83,7 +83,7 @@ Schmidt support.
 rank rather than an ambient tensor-factor dimension; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 noncomputable def loopSchmidtFactorization (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : LoopSchmidtFactorization F l := by
@@ -104,7 +104,7 @@ dimension.
 bond vector after restricting to its Schmidt support; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 theorem loopSchmidtRank_pos (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : 0 < F.loopSchmidtRank l := by
@@ -127,7 +127,7 @@ theorem loopSchmidtRank_pos (F : BeigiSectorGraphData A)
 /-- The rectangular letter whose product with the left Schmidt factor gives
 the ambient loop tensor letter.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it, with the
 Schmidt-support refinement recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -155,7 +155,7 @@ the chosen bond vector, not the full left-factor dimension.  This is the
 minimal realization compatible with Beigi's product-of-pairs state; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 noncomputable def minimalLoopCoordinateTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : MPSTensor d (F.loopSchmidtRank l) :=
@@ -169,7 +169,7 @@ tensor on the minimal Schmidt support.
 Schmidt support as documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 noncomputable def minimalLoopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : MPSTensor d (F.loopSchmidtRank l) :=
@@ -179,7 +179,7 @@ noncomputable def minimalLoopTensor (F : BeigiSectorGraphData A)
 outer product of a column of the left rank factor and a row of the right rank
 factor.
 
-Source context: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation),
+Source context: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation),
 and Section IV, equation (10) and the paragraph following it.  The
 Schmidt-support refinement is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -216,7 +216,7 @@ theorem minimalLoopCoordinateTensor_sector_apply
 /-- Outside the chosen loop sector, every letter of the minimal coordinate
 tensor vanishes.
 
-Source context: Beigi, arXiv:1105.1019v2, Section IV, equation (10) and the
+Source context: Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (10) and the
 paragraph following it.  The Schmidt-support refinement is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem minimalLoopCoordinateTensor_sector_ne
@@ -231,7 +231,7 @@ theorem minimalLoopCoordinateTensor_sector_ne
 /-- Each ambient loop letter is the rectangular Schmidt-support letter
 followed by the left factor of the bond coefficient matrix.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it, with the
 Schmidt-support refinement recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -279,7 +279,7 @@ private theorem exists_schmidtWordCore {r L : ℕ}
 /-- The ambient and Schmidt-support loop tensors have equal traces on every
 nonempty word.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it, with the
 Schmidt-support refinement recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
@@ -308,7 +308,7 @@ support leaves every positive-length periodic vector unchanged.  The role of
 this restriction is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 theorem mpv_minimalLoopCoordinateTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
@@ -328,7 +328,7 @@ product-of-pairs state as its periodic vector at every positive chain length.
 virtual directions does not alter the physical loop state; see
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, p. 4 (MPS observation), and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, p. 4 (MPS observation), and
 Section IV, equation (10) and the paragraph following it. -/
 theorem mpv_minimalLoopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :

--- a/TNLean/MPS/RFP/BeigiLoopTensor.lean
+++ b/TNLean/MPS/RFP/BeigiLoopTensor.lean
@@ -27,7 +27,7 @@ from a product over disjoint pairs of physical sites.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Section IV, source lines 602--606.
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Section IV.
 -/
 
 open scoped BigOperators Kronecker Matrix
@@ -40,7 +40,7 @@ variable {d D : ℕ} {A : MPSTensor d D}
 
 /-- A nonzero vector in the edge ground space carried by a positive loop.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 noncomputable def loopBondVector (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) :
     Matrix.EtaEdgeIndex F.leftDim F.rightDim l.1 l.1 → ℂ :=
@@ -68,7 +68,7 @@ left factor and the column index is contracted with the next site's left
 factor.  The matrix entry is the corresponding component of the loop bond
 vector.  Coordinates in every other sector give the zero matrix.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 noncomputable def loopCoordinateTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : MPSTensor d (F.leftDim l.1) :=
   fun i a b ↦
@@ -82,7 +82,7 @@ noncomputable def loopCoordinateTensor (F : BeigiSectorGraphData A)
 /-- The physical loop tensor obtained by applying the spatial-decomposition
 unitary to the sector-coordinate tensor.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 noncomputable def loopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) : MPSTensor d (F.leftDim l.1) :=
   rotatePhysical F.unitary (F.loopCoordinateTensor l)
@@ -110,7 +110,7 @@ private def loopRightIndex (F : BeigiSectorGraphData A)
 The right factor at site `n` is paired with the left factor at site `n + 1`.
 The value is zero unless every site belongs to the chosen loop sector.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 noncomputable def loopCyclicProduct (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N]
     (s : Fin N → Fin d) : ℂ :=
@@ -124,7 +124,7 @@ noncomputable def loopCyclicProduct (F : BeigiSectorGraphData A)
 It is the sitewise unitary image of the cyclic product whose bonds join the
 right factor at site `n` to the left factor at site `n + 1`.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 noncomputable def loopProductState (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] : NSiteSpace d N :=
   fun s ↦ ∑ t : Fin N → Fin d,
@@ -132,7 +132,7 @@ noncomputable def loopProductState (F : BeigiSectorGraphData A)
 
 /-- The Euclidean-space realization of a positive-loop product state.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 noncomputable def loopProductStateES (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
     EuclideanSpace ℂ (Fin N → Fin d) :=
@@ -214,7 +214,7 @@ private theorem loopCyclicProduct_etaCyclicEdgeEquiv_symm_of_ne
 /-- The cyclic product belonging to a positive loop is nonzero at every
 positive chain length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem loopCyclicProduct_ne_zero (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
     F.loopCyclicProduct l ≠ (0 : NSiteSpace d N) := by
@@ -240,7 +240,7 @@ theorem loopCyclicProduct_ne_zero (F : BeigiSectorGraphData A)
 /-- Cyclic products belonging to distinct positive loops have disjoint sector
 support and hence zero inner product.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem loopCyclicProduct_inner_eq_zero_of_ne
     (F : BeigiSectorGraphData A) {l m : Loop F.edgeWeight}
     {N : ℕ} [NeZero N] (hlm : l ≠ m) :
@@ -364,7 +364,7 @@ private theorem loopProductState_eq_sitewisePhysicalMatrix_mulVec
 
 /-- A positive-loop product state is nonzero at every positive chain length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem loopProductState_ne_zero (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
     F.loopProductState (N := N) l ≠ 0 := by
@@ -386,7 +386,7 @@ theorem loopProductState_ne_zero (F : BeigiSectorGraphData A)
 /-- The Euclidean realization of a positive-loop product state is nonzero at
 every positive chain length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem loopProductStateES_ne_zero (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] :
     F.loopProductStateES (N := N) l ≠ 0 := by
@@ -396,7 +396,7 @@ theorem loopProductStateES_ne_zero (F : BeigiSectorGraphData A)
 /-- Euclidean positive-loop product states belonging to distinct loops are
 orthogonal at every positive chain length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem loopProductStateES_inner_eq_zero_of_ne
     (F : BeigiSectorGraphData A) {l m : Loop F.edgeWeight}
     {N : ℕ} [NeZero N] (hlm : l ≠ m) :
@@ -423,7 +423,7 @@ theorem loopProductStateES_inner_eq_zero_of_ne
 /-- The Euclidean positive-loop product states are linearly independent at
 every positive chain length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem loopProductStateES_linearIndependent
     (F : BeigiSectorGraphData A) {N : ℕ} [NeZero N] :
     LinearIndependent ℂ
@@ -491,8 +491,7 @@ nondegenerate range of the two-site periodic parent Hamiltonian used here.
 The length-one convention is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and
-Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Sections III--IV. -/
 theorem loopProductState_mem_ker_parentHamiltonian
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
     {N : ℕ} (hN : 2 ≤ N) :
@@ -513,8 +512,7 @@ nondegenerate range of the two-site periodic parent Hamiltonian used here.
 The length-one convention is recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and
-Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Sections III--IV. -/
 theorem loopProductState_mem_parentHamiltonianGroundSpaceES
     (F : BeigiSectorGraphData A) (l : Loop F.edgeWeight)
     {N : ℕ} (hN : 2 ≤ N) :
@@ -554,8 +552,7 @@ covered by the ordered-cycle ground-space dimension formula used here.  The
 short-chain conventions are recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and
-Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Sections III--IV. -/
 theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES
     (F : BeigiSectorGraphData A)
     (hparent : ∃ c N₀ : ℕ, ∀ M : ℕ, N₀ < M →
@@ -577,8 +574,7 @@ short-chain conventions are recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Source: CPSV16, Definition 3.9 and Theorem 3.10, source lines 517--540;
-Beigi, arXiv:1105.1019v2, Section III, source lines 487--500, and Section IV,
-source lines 602--606. -/
+Beigi, J. Phys. A 45 (2012) 025306, Sections III--IV. -/
 theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_hasBNTSectorData
     {P : SectorDecomposition d} (F : BeigiSectorGraphData P.toTensor)
     (hBNT : HasBNTSectorData P)
@@ -595,7 +591,7 @@ theorem span_loopProductStateES_eq_parentHamiltonianGroundSpaceES_of_hasBNTSecto
 /-- The sector-coordinate loop tensor closes to the cyclic product of loop
 bond vectors at every positive length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem mpv_loopCoordinateTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
     mpv (F.loopCoordinateTensor l) s = F.loopCyclicProduct l s := by
@@ -633,7 +629,7 @@ theorem mpv_loopCoordinateTensor (F : BeigiSectorGraphData A)
 /-- The periodic matrix product vector of `loopTensor` is exactly Beigi's
 physical product-of-pairs state at every positive chain length.
 
-Source: Beigi, arXiv:1105.1019v2, Section IV, source lines 602--606. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section IV. -/
 theorem mpv_loopTensor (F : BeigiSectorGraphData A)
     (l : Loop F.edgeWeight) {N : ℕ} [NeZero N] (s : Fin N → Fin d) :
     mpv (F.loopTensor l) s = F.loopProductState l s := by

--- a/TNLean/MPS/RFP/BeigiSectorGraph.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraph.lean
@@ -39,7 +39,7 @@ Hamiltonian, its trace gives Beigi's ordered-cycle formula.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Section III, equations (2)--(4), pages
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(4), pages
   3--4.
 -/
 
@@ -52,7 +52,7 @@ variable {d D : ℕ}
 /-- The two-site projector onto the canonical parent ground space, in ordered
 pair coordinates.  It is the complement of the canonical parent interaction.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
 noncomputable def twoSiteParentGroundProjectorMatrix (A : MPSTensor d D) :
     Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
   1 - twoSiteParentInteractionMatrix A
@@ -65,50 +65,50 @@ notation.  The only compatibility field is the local coordinate identity for
 the complementary bond `1 - h`; no finite-chain ground-space statement or
 scale-invariance hypothesis is part of the data.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(3), pages 3--4. -/
 structure BeigiSectorGraphData (A : MPSTensor d D) where
   /-- The number of sectors in the one-site spatial decomposition.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
   sectorCount : ℕ
   /-- The dimension of the left factor in each sector.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
   leftDim : Fin sectorCount → ℕ
   /-- The dimension of the right factor in each sector.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
   rightDim : Fin sectorCount → ℕ
   /-- Identification of one physical site with its finite sum of right--left
   sector factors.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
   sectorEquiv : Matrix.EtaSiteIndex sectorCount leftDim rightDim ≃ Fin d
   /-- The one-site unitary implementing the spatial coordinates.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
   unitary : Matrix (Fin d) (Fin d) ℂ
   /-- The spatial coordinate change is unitary.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
   unitary_mem : unitary ∈ Matrix.unitaryGroup (Fin d) ℂ
   /-- The projector onto the ground space carried by the directed edge
   `a ⟶ b`.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(3), pages 3--4. -/
   edgeProjector : (a b : Fin sectorCount) →
     Matrix (Matrix.EtaEdgeIndex leftDim rightDim a b)
       (Matrix.EtaEdgeIndex leftDim rightDim a b) ℂ
   /-- Every edge ground-space operator is an orthogonal projector.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(3), pages 3--4. -/
   edgeProjector_isOrthogonal : ∀ a b,
     (edgeProjector a b).IsHermitian ∧ IsIdempotentElem (edgeProjector a b)
   /-- In spatial coordinates, the complementary parent interaction is the
   direct sum of the edge ground-space projectors, with identities on the two
   boundary factors.
 
-  Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+  Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
   groundProjector_block :
     Matrix.reindex (Matrix.etaPairSpatialBlockEquiv sectorEquiv).symm
         (Matrix.etaPairSpatialBlockEquiv sectorEquiv).symm
@@ -128,7 +128,7 @@ variable {A : MPSTensor d D}
 This is `ker Q_{a,b}` in Beigi's notation, represented as the range of its
 orthogonal projector `P_{a,b}`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equation (3), page 4. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (3), page 4. -/
 noncomputable def edgeGroundSpace (F : BeigiSectorGraphData A)
     (a b : Fin F.sectorCount) :
     Submodule ℂ (Matrix.EtaEdgeIndex F.leftDim F.rightDim a b → ℂ) :=
@@ -136,7 +136,7 @@ noncomputable def edgeGroundSpace (F : BeigiSectorGraphData A)
 
 /-- The edge projector is a projection onto its edge ground space.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(3), pages 3--4. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(3), pages 3--4. -/
 theorem edgeProjector_isProj (F : BeigiSectorGraphData A)
     (a b : Fin F.sectorCount) :
     LinearMap.IsProj (F.edgeGroundSpace a b)
@@ -149,7 +149,7 @@ theorem edgeProjector_isProj (F : BeigiSectorGraphData A)
 
 /-- The spatial coordinate matrix is right-unitary.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
 theorem unitary_mul_conjTranspose (F : BeigiSectorGraphData A) :
     F.unitary * F.unitaryᴴ = 1 := by
   simpa only [Matrix.star_eq_conjTranspose] using
@@ -157,7 +157,7 @@ theorem unitary_mul_conjTranspose (F : BeigiSectorGraphData A) :
 
 /-- A directed edge is present exactly when its edge ground space is nonzero.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, graph definition immediately
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, graph definition immediately
 after equation (2), page 3. -/
 def IsEdge (F : BeigiSectorGraphData A) (a b : Fin F.sectorCount) : Prop :=
   F.edgeGroundSpace a b ≠ ⊥
@@ -166,7 +166,7 @@ def IsEdge (F : BeigiSectorGraphData A) (a b : Fin F.sectorCount) : Prop :=
 are nonzero.  Cyclic rotation is not quotiented out: the source sum is over
 ordered cycles.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equations (3)--(4), page 4. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (3)--(4), page 4. -/
 def OrderedCycle (F : BeigiSectorGraphData A) (N : ℕ) [NeZero N] :=
   {k : Fin N → Fin F.sectorCount // ∀ n : Fin N, F.IsEdge (k n) (k (n + 1))}
 
@@ -283,7 +283,7 @@ private theorem singleKrausMap_groundBond_eq_transformedGroundBond
 the sitewise spatial unitary gives the corresponding product in sector
 coordinates.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equation (2), page 3. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2), page 3. -/
 theorem singleKrausMap_groundBondProduct (F : BeigiSectorGraphData A)
     {N : ℕ} [NeZero N] (hN : 2 ≤ N) :
     singleKrausMap (MPOTensor.sitewisePhysicalMatrix F.unitaryᴴ N)
@@ -608,7 +608,7 @@ parent interactions.  This restricted auxiliary form, and its possible
 generalization to an explicit commutativity hypothesis, are recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, source lines 487--500. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III. -/
 theorem mem_ker_parentHamiltonian_of_groundBondProduct_mulVec_eq_self
     (F : BeigiSectorGraphData A) {N : ℕ} [NeZero N] (hN : 2 ≤ N)
     (v : NSiteSpace d N)
@@ -651,8 +651,7 @@ periodic lengths, whereas this theorem treats `2 ≤ N`; the one-site periodic
 interaction convention remains open. Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(4), source
-lines 451--512. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(4). -/
 theorem parentHamiltonianGroundSpaceES_finrank_eq
     (F : BeigiSectorGraphData A) {N : ℕ} (hN : 2 ≤ N) :
     letI : NeZero N := ⟨by omega⟩
@@ -691,9 +690,8 @@ theorem parentHamiltonianGroundSpaceES_finrank_eq
 two cyclic windows traverse the same pair of sites in opposite orders, so
 `(a, b)` and `(b, a)` remain distinct ordered cycles when `a ≠ b`.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equations (2)--(4), source
-lines 451--512; the period-two ordered-cycle convention is explicit at source
-lines 509--512. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equations (2)--(4),
+including the period-two ordered-cycle convention. -/
 theorem parentHamiltonianGroundSpaceES_finrank_eq_two
     (F : BeigiSectorGraphData A) :
     Module.finrank ℂ (parentHamiltonianGroundSpaceES A 2 2) =

--- a/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
+++ b/TNLean/MPS/RFP/BeigiSectorGraphConstruction.lean
@@ -21,7 +21,7 @@ commuting parent interaction and packages them as `BeigiSectorGraphData`.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2).
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III, equation (2).
 -/
 
 open scoped ComplexOrder Kronecker Matrix MatrixOrder
@@ -32,7 +32,7 @@ variable {d D : ℕ}
 
 /-- The canonical two-site parent interaction is an orthogonal projection.
 
-Source: Beigi, arXiv:1105.1019v2, Section II, paragraph before Lemma 2.1, and
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section II, paragraph before Lemma 2.1, and
 Section III, equation (2). -/
 theorem twoSiteParentInteractionMatrix_isStarProjection (A : MPSTensor d D) :
     IsStarProjection (twoSiteParentInteractionMatrix A) := by
@@ -56,14 +56,14 @@ theorem twoSiteParentInteractionMatrix_isStarProjection (A : MPSTensor d D) :
 
 /-- The complementary two-site parent interaction is an orthogonal projection.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equation (2). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2). -/
 theorem twoSiteParentGroundProjectorMatrix_isStarProjection (A : MPSTensor d D) :
     IsStarProjection (twoSiteParentGroundProjectorMatrix A) := by
   exact (twoSiteParentInteractionMatrix_isStarProjection A).one_sub
 
 /-- The complementary two-site parent interaction is positive semidefinite.
 
-Source: Beigi, arXiv:1105.1019v2, Section III, equation (2). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Section III, equation (2). -/
 theorem twoSiteParentGroundProjectorMatrix_posSemidef (A : MPSTensor d D) :
     (twoSiteParentGroundProjectorMatrix A).PosSemidef := by
   rw [← Matrix.nonneg_iff_posSemidef]
@@ -74,7 +74,7 @@ theorem twoSiteParentGroundProjectorMatrix_posSemidef (A : MPSTensor d D) :
 This is the complement form of the local commutator used in Beigi's spatial
 decomposition.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III, equation (2). -/
 theorem IsNNCPH.twoSiteParentGroundProjectorMatrix_overlappingLifts_commute
     {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
     Matrix.leftOverlappingLift (twoSiteParentGroundProjectorMatrix A) *
@@ -150,7 +150,7 @@ private theorem eta_isIdempotent_of_blockDiagonal_isIdempotent
 /-- A nearest-neighbor commuting parent interaction determines Beigi's finite sector graph
 data in the symmetric two-sided coordinates.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III, equation (2). -/
 theorem IsNNCPH.nonempty_beigiSectorGraphData
     {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
     Nonempty (BeigiSectorGraphData A) := by
@@ -199,7 +199,7 @@ theorem IsNNCPH.nonempty_beigiSectorGraphData
 
 /-- A chosen Beigi sector graph datum for a nearest-neighbor commuting parent interaction.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 and Section III, equation (2). -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Section III, equation (2). -/
 noncomputable def IsNNCPH.beigiSectorGraphData
     {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) : BeigiSectorGraphData A :=
   Classical.choice hNNCPH.nonempty_beigiSectorGraphData

--- a/TNLean/MPS/RFP/BeigiSpatialDecomposition.lean
+++ b/TNLean/MPS/RFP/BeigiSpatialDecomposition.lean
@@ -28,7 +28,7 @@ commute.  Beigi's spatial decomposition therefore applies directly.
 ## References
 
 * S. Beigi, *Classification of the phases of 1D spin chains with commuting
-  Hamiltonians*, arXiv:1105.1019v2, Lemma 2.1 and Sections II--IV.
+  Hamiltonians*, J. Phys. A 45 (2012) 025306, Lemma 2.1 and Sections II--IV.
 * Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
   Theorem 3.10, lines 534--540.
 -/
@@ -44,7 +44,7 @@ variable {d D : ℕ}
 /-- The common left-associated coordinates for three consecutive physical sites.
 The equivalence sends a configuration `x` to `((x 0, x 1), x 2)`.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 def threeSiteParentInteractionEquiv (n : Type*) :
     (Fin 3 → n) ≃ ((n × n) × n) :=
   (finThreeArrowEquiv n).trans (Equiv.prodAssoc n n n).symm
@@ -52,7 +52,7 @@ def threeSiteParentInteractionEquiv (n : Type*) :
 /-- In common left-associated three-site coordinates, the first-pair lift of a
 two-site operator is its left overlapping matrix lift.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem leftPairLift_toMatrix_reindex_leftAssociated
     (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
     Matrix.reindex (threeSiteParentInteractionEquiv (Fin d))
@@ -76,7 +76,7 @@ theorem leftPairLift_toMatrix_reindex_leftAssociated
 /-- In common left-associated three-site coordinates, the final-pair lift of a
 two-site operator is its right overlapping matrix lift.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem rightPairLift_toMatrix_reindex_leftAssociated
     (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
     Matrix.reindex (threeSiteParentInteractionEquiv (Fin d))
@@ -136,7 +136,7 @@ theorem twoSiteParentInteractionMatrix_isHermitian (A : MPSTensor d D) :
 the two natural overlapping lifts of the canonical two-site interaction.
 
 Source: arXiv:1606.00608, Theorem 3.10, lines 534--540; Beigi,
-arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem IsNNCPH.twoSiteParentInteractionMatrix_overlappingLifts_commute
     {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
     Matrix.leftOverlappingLift (twoSiteParentInteractionMatrix A) *
@@ -168,7 +168,7 @@ theorem IsNNCPH.twoSiteParentInteractionMatrix_overlappingLifts_commute
 lifts commute on three sites.
 
 This is exactly the local input to the spatial decomposition of Beigi,
-arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3. -/
+J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3. -/
 theorem IsNNCPH.twoSiteParentInteractionMatrix_isHermitian_and_overlappingLifts_commute
     {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :
     (twoSiteParentInteractionMatrix A).IsHermitian ∧
@@ -184,7 +184,7 @@ theorem IsNNCPH.twoSiteParentInteractionMatrix_isHermitian_and_overlappingLifts_
 /-- The canonical two-site parent interaction admits Beigi's explicit unitary
 block-action decomposition on the middle physical site.
 
-Source: Beigi, arXiv:1105.1019v2, Lemma 2.1 (`lem:comm`), pages 2--3;
+Source: Beigi, J. Phys. A 45 (2012) 025306, Lemma 2.1 (`lem:comm`), pages 2--3;
 arXiv:1606.00608, Theorem 3.10, lines 534--540. -/
 theorem IsNNCPH.exists_unitary_blockActions_of_twoSiteParentInteractionMatrix
     {A : MPSTensor d D} (hNNCPH : IsNNCPH A 3) :

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -52,7 +52,13 @@ theorem WordTupleSpanTop.exists_one_letter_identity_coefficients
 
 /-- A common one-letter expression for the block identities replaces the
 right-canonical normalization in the restriction argument of
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. -/
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452.
+
+**Local fix (common identity coefficients):** The source uses
+\(\sum_i A_i A_i^\dagger=1\) and the adjoint-corrected boundary matrix
+\(E=\sum_i C_i A_i^\dagger\). This theorem instead assumes common coefficients
+\(c_i\) with \(\sum_i c_i A_i=1\) and sets \(E=\sum_i c_i C_i\).
+Documented in `docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition_of_identity_coefficients
     (A : (j : Fin r) → MPSTensor d (dim j))
     {n : ℕ} (hSpan : WordTupleSpanTop A n)
@@ -94,7 +100,9 @@ theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition_of_identity_coeffici
 
 /-- The two one-boundary restrictions imply membership in the next block
 ground-space sum when the identity tuple has a common one-letter expansion.
-This is arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. -/
+This is the common-identity-coefficient variant of the local step in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. The substitution is
+documented in `docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions_of_identity_coefficients
     (A : (j : Fin r) → MPSTensor d (dim j))
     {n : ℕ} (hSpan : WordTupleSpanTop A n)
@@ -113,8 +121,9 @@ theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions_of_identity_coefficien
 
 /-- The PGVWC one-step restriction intersection needs only a common
 one-letter expansion of the block identities, rather than right-canonical
-normalization. This is the local intersection step in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. -/
+normalization. This is a local variant of the intersection step in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452, documented in
+`docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection_of_identity_coefficients
     (A : (j : Fin r) → MPSTensor d (dim j))
     {n : ℕ} (hSpan : WordTupleSpanTop A n)

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -184,7 +184,13 @@ theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection_of_identity_coeffic
 /-- A simultaneous one-site span propagates nearest-neighbor periodic
 constraints into the sum of the open-boundary block spaces. This is the
 restriction-intersection propagation in arXiv:quant-ph/0608197, Theorem 12,
-proof lines 1430--1452. -/
+proof lines 1430--1452.
+
+**Scope restriction (simultaneous one-site span):** The source uses
+right-canonical normalization. This theorem instead assumes that the
+simultaneous one-site word tuples span the product algebra and derives common
+identity coefficients from that hypothesis. Documented in
+`docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_wordTupleSpanTop_one
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     (hμ : ∀ j : Fin r, μ j ≠ 0)
@@ -211,7 +217,13 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_wordTupleSpan
 /-- A nearest-neighbor chain vector has block-diagonal open-boundary matrices
 when the simultaneous one-site word tuples span the product algebra. This is
 the block-boundary decomposition in arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1430--1452. -/
+lines 1430--1452.
+
+**Scope restriction (simultaneous one-site span):** The source uses
+right-canonical normalization. This theorem instead obtains the open-boundary
+membership step through common identity coefficients derived from the
+simultaneous one-site span. Documented in
+`docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem exists_blockDiagonal_boundary_of_chainGroundSpace_of_wordTupleSpanTop_one
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     (hμ : ∀ j : Fin r, μ j ≠ 0)
@@ -250,7 +262,13 @@ theorem exists_blockDiagonal_boundary_of_chainGroundSpace_of_wordTupleSpanTop_on
 
 /-- A global one-site change of cut closes the block-diagonal boundary
 matrices of a nearest-neighbor chain vector. This is the boundary-closing step
-in arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456. -/
+in arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456.
+
+**Scope restriction (simultaneous one-site span):** The source uses
+right-canonical normalization. The block-diagonal boundary supplied here
+depends on the common identity coefficients derived from the simultaneous
+one-site span. Documented in
+`docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_wordTupleSpanTop_one
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     (hμ : ∀ j : Fin r, μ j ≠ 0)
@@ -341,7 +359,13 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_wordTupleSpanTop_one
 /-- A simultaneous one-site product span splits the nearest-neighbor periodic
 chain space into the periodic chain spaces of the blocks. This is the
 multiplicity-one distinct-block specialization of arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1430--1456. -/
+Theorem 12, proof lines 1430--1456.
+
+**Scope restriction (simultaneous one-site span):** The source uses
+right-canonical normalization. This equality instead follows through the
+common identity coefficients derived from the simultaneous one-site product
+span. Documented in
+`docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_wordTupleSpanTop_one
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     (hμ : ∀ j : Fin r, μ j ≠ 0)

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -54,7 +54,7 @@ theorem WordTupleSpanTop.exists_one_letter_identity_coefficients
 right-canonical normalization in the restriction argument of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452.
 
-**Local fix (common identity coefficients):** The source uses
+**Scope restriction (common identity coefficients):** The source uses
 \(\sum_i A_i A_i^\dagger=1\) and the adjoint-corrected boundary matrix
 \(E=\sum_i C_i A_i^\dagger\). This theorem instead assumes common coefficients
 \(c_i\) with \(\sum_i c_i A_i=1\) and sets \(E=\sum_i c_i C_i\).

--- a/TNLean/MPS/RFP/NNCPHMultiSector.lean
+++ b/TNLean/MPS/RFP/NNCPHMultiSector.lean
@@ -101,8 +101,13 @@ theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition_of_identity_coeffici
 /-- The two one-boundary restrictions imply membership in the next block
 ground-space sum when the identity tuple has a common one-letter expansion.
 This is the common-identity-coefficient variant of the local step in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452. The substitution is
-documented in `docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452.
+
+**Scope restriction (common identity coefficients):** The source uses
+right-canonical normalization. This theorem instead assumes one coefficient
+family \(c_i\), common to every block, with \(\sum_i c_iA_i^j=1\), and invokes
+the restricted boundary-matrix construction above. Documented in
+`docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions_of_identity_coefficients
     (A : (j : Fin r) → MPSTensor d (dim j))
     {n : ℕ} (hSpan : WordTupleSpanTop A n)
@@ -122,7 +127,12 @@ theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions_of_identity_coefficien
 /-- The PGVWC one-step restriction intersection needs only a common
 one-letter expansion of the block identities, rather than right-canonical
 normalization. This is a local variant of the intersection step in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452, documented in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1442--1452.
+
+**Scope restriction (common identity coefficients):** The source uses
+right-canonical normalization. This theorem instead assumes one coefficient
+family \(c_i\), common to every block, with \(\sum_i c_iA_i^j=1\), through the
+restricted membership theorem above. Documented in
 `docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. -/
 theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection_of_identity_coefficients
     (A : (j : Fin r) → MPSTensor d (dim j))

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -10,7 +10,7 @@
         \ker H_2^{(1)} & = \C^d. \notag
     \end{align}
     This convention is local to the present development. The two-site terms
-    in \cite[Section~III]{Beigi2012Classification}, source lines 451--514, are
+    in \cite[Section~III]{Beigi2012Classification} are
     not assigned an action when both site labels denote the same site. The
     nearest-neighbor condition in
     \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}, source lines 534--540, only

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -189,6 +189,9 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
   PGVWC07 \(C^j,D^j\) comparison is now formalized under a crossing-tail
   word-span hypothesis; the remaining boundary is the replacement of that
   span-dependent short-tail statement by the source \(C^j,D^j,E^j\) comparison.
+- `pgvwc07_common_identity_coefficients.tex` distinguishes the right-canonical
+  normalization used in the proof of PGVWC07 Theorem 12 from the local variant
+  that assumes a common one-letter expansion of every block identity.
 - `cpgsv21_martingale_overlap.tex` records the spectral-gap martingale
   comparison: the finite-row cyclic-window reduction is formalized, while the
   remaining source comparison is the overlapping-window anticommutator estimate;

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -506,7 +506,10 @@ lines 534--541 and its proof at line 1307: the formal theorem assumes explicitly
 that the chosen representative is normal and left-canonical, as well as an
 explicit BNT relation and the all-chain ground-space condition.  It does not
 state the unrestricted three-way equivalence for an arbitrary tensor in
-canonical form.
+canonical form.  In the source canonical decomposition, the normality
+hypothesis selects the one-sector case \(g=1\).  Thus this theorem does not
+establish the multi-sector case \(g>1\), for which Beigi's finite-degeneracy
+classification is the essential input.
 
 The auxiliary declaration
 \leanid{MPSTensor.BeigiSectorGraphData.}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -325,16 +325,16 @@ Its period-two specialization
 \leanid{MPSTensor.BeigiSectorGraphData.}
 \hspace{0pt}\leanid{parentHamiltonianGroundSpaceES_finrank_eq_two}
 retains the two orientations: if $a\ne b$, then $(a,b)$ and $(b,a)$ are
-distinct ordered cycles, exactly as stated in Beigi, arXiv:1105.1019v2,
-Section~III, equations~(2)--(4), source lines 509--512.  No chain-level
+distinct ordered cycles, exactly as stated in Beigi, J. Phys. A 45 (2012) 025306,
+Section~III, equations~(2)--(4).  No chain-level
 ground-space equation, eventual degeneracy, or canonical-form datum is assumed
 in these sector-graph theorems.
 
 At $N=1$, Beigi's two-site interaction has no specified action.  The source
 defines $P_{j,j+1}$ on sites $j,j+1$ and then separates the actions of
 $P_{j-1,j}$ and $P_{j,j+1}$ on the middle site; see
-arXiv:1105.1019v2, Section~III, source lines 451--476.  When $N=1$, these site
-labels all coincide, and lines 477--514 do not add a rule for turning the
+J. Phys. A 45 (2012) 025306, Section~III.  When $N=1$, these site
+labels all coincide, and the remainder of that section does not add a rule for turning the
 two-site operator into a one-site operator.  CPSV16 does not impose such a
 rule: Theorem~3.10(iii), local source lines 534--540, only concerns $N>2$.
 
@@ -405,7 +405,7 @@ product
 \]
 For a positive loop $a\to a$, denote the resulting physical state on a chain
 of length $N$ by $\Psi_a^{(N)}$.
-This is the construction in Beigi, arXiv:1105.1019v2, source lines 602--606.
+This is the construction in Beigi, J. Phys. A 45 (2012) 025306, Section IV, equation (13).
 The ambient left factor need not be the minimal virtual space: Beigi assumes
 only that the selected bond vector is nonzero, not that its coefficient matrix
 has full rank.  Writing that matrix as
@@ -461,8 +461,8 @@ now proves that this vector belongs to the kernel of the length-two periodic
 parent Hamiltonian.  Its Euclidean-space form is recorded by
 \leanid{MPSTensor.BeigiSectorGraphData.}
 \hspace{0pt}\leanid{loopProductState_mem_parentHamiltonianGroundSpaceES}.
-The proof uses Beigi's local edge-ground-space condition from source
-lines 487--500 and the positive-loop specialization at lines 602--606.  The
+The proof uses Beigi's local edge-ground-space condition in Section~III
+and the positive-loop specialization in Section~IV.  The
 restriction $N\geq2$ is the source-defined range of the two-site periodic
 parent Hamiltonian used here.  As recorded by the resolved clarification in
 \ghissue{4400}, no source-defined coincident-edge convention extends this

--- a/docs/paper-gaps/pgvwc07_common_identity_coefficients.tex
+++ b/docs/paper-gaps/pgvwc07_common_identity_coefficients.tex
@@ -1,0 +1,89 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+
+\title{Common Identity Coefficients in the Block Ground-Space Intersection}
+\author{}
+\date{2026-07-30}
+
+\begin{document}
+\maketitle
+
+\section{The source argument}
+
+The proof of Theorem~12 in
+\cite[lines~1424--1456]{PerezGarcia2007MPSReps} compares two boundary
+representations of a vector in the intersection
+\[
+  \mathbb C^d\otimes\left(\bigoplus_j\mathcal G_m^{A^j}\right)
+  \cap
+  \left(\bigoplus_j\mathcal G_m^{A^j}\right)\otimes\mathbb C^d.
+\]
+The common word-span condition gives, for every block \(j\) and physical
+indices \(a,b\),
+\[
+  A_b^j C_a^j=D_b^j A_a^j.
+\]
+The source then uses the right-canonical normalization
+\[
+  \sum_a A_a^j A_a^{j\dagger}=I.
+\]
+Its displayed definition \(E^j=\sum_a C_a^jA_a^j\) omits the adjoint required
+by the following calculation.  With the adjoint-corrected definition
+\[
+  E^j=\sum_a C_a^jA_a^{j\dagger},
+\]
+one obtains
+\[
+  D_b^j=A_b^jE^j,\qquad
+  A_b^jC_a^j=A_b^jE^jA_a^j.
+\]
+This source-aligned argument is formalized by
+\path{MPSTensor.pgvwc07_mem_iSup_groundSpace_of_trace_decomposition}.
+
+\section{The common-coefficient variant}
+
+The local variant
+\path{MPSTensor.%
+pgvwc07_mem_iSup_groundSpace_of_trace_decomposition_of_identity_coefficients}
+does not assume right-canonical normalization.  Instead, it assumes common
+coefficients \(c_a\), independent of the block \(j\), such that
+\[
+  \sum_a c_a A_a^j=I
+\]
+for every block, and defines
+\[
+  E^j=\sum_a c_a C_a^j.
+\]
+Summing \(A_b^jC_a^j=D_b^jA_a^j\) against \(c_a\) gives
+\[
+  A_b^jE^j=D_b^j,
+\]
+and hence the same boundary identity
+\[
+  A_b^jC_a^j=A_b^jE^jA_a^j.
+\]
+Thus the conclusion agrees with the local step of the source proof, but the
+hypothesis and construction of \(E^j\) are different.
+
+\section{Formal boundary}
+
+The common-coefficient theorem is a conditional local variant, not the
+formalization of the right-canonical step printed in Theorem~12.  Results that
+derive the common coefficients from a simultaneous one-letter word-span
+condition may use this variant.  A source-faithful proof should instead use
+\path{MPSTensor.%
+pgvwc07_mem_iSup_groundSpace_of_trace_decomposition}, which retains the
+right-canonical hypothesis and the adjoint-corrected boundary matrix.  No
+mathematical hypothesis should be transferred between these two statements
+without a separate implication.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/pgvwc07_common_identity_coefficients.tex
+++ b/docs/paper-gaps/pgvwc07_common_identity_coefficients.tex
@@ -73,10 +73,11 @@ hypothesis and construction of \(E^j\) are different.
 
 \section{Formal boundary}
 
-The common-coefficient theorem is a conditional local variant, not the
-formalization of the right-canonical step printed in Theorem~12.  Results that
-derive the common coefficients from a simultaneous one-letter word-span
-condition may use this variant.  A source-faithful proof should instead use
+The common-coefficient theorem is a scope restriction: it is a conditional
+local variant, not the formalization of the right-canonical step printed in
+Theorem~12.  Results that derive the common coefficients from a simultaneous
+one-letter word-span condition may use this variant.  A source-faithful proof
+should instead use
 \path{MPSTensor.%
 pgvwc07_mem_iSup_groundSpace_of_trace_decomposition}, which retains the
 right-canonical hypothesis and the adjoint-corrected boundary matrix.  No


### PR DESCRIPTION
### Motivation

- Issue #5172 identified declarations that narrow or replace the cited source argument without the repository's standard declaration-level marker.
- CPSV16 Theorem 4.14(ii), `Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 972--985, begins: “Given a tensor M in CF that generates MPDO, the following statements are equivalent.” Its algebra clause uses one BNT-label coefficient family and an idempotent law; the local blocked fixed-point-algebra predicate does not contain that data.
- CPSV16 Appendix C.2, Lemma `propSN` and Proposition `3to4`, lines 1441--1450 and 1571--1593, derive the positive physical-sector factorization from SAL. The local eta constructor instead takes that factorization and positivity as hypotheses.

### Description

- Add `Scope restriction` markers to `AlgebraStructureData`, its compatibility predicate, `IsRFP_MPDO_via_algebra`, the trace-preserving fixed-point implication, and `etaLocalStructureData`.
- Reclassify 131 cyclic-active markers, the active-sector trace matrix, and `exists_active_two_cycle` from `Local fix` to `Scope restriction`. These declarations change the source index set or substitute a closed-walk argument; they are not typographical corrections.
- Replace repository-local Beigi arXiv line anchors by the published reference S. Beigi, J. Phys. A 45 (2012) 025306, retaining Lemma 2.1, Sections III--IV, and equation numbers. The source was not vendored because `Papers/NOTICE.md` requires author permission.
- Clarify that the normal representative proves only the one-sector case of the NNCPH-to-RFP direction, and that the multi-sector case remains open.
- Correct the eventual ground-space dimension attribution, add the missing gauge-transport reference section, and mark the extra positive-semidefinite hypothesis in the trace-matrix rank-one theorem.
- Add `docs/paper-gaps/pgvwc07_common_identity_coefficients.tex`. It separates the right-canonical argument in PGVWC07 Theorem 12 from the local common-identity-coefficient scope restriction and records the adjoint correction in the source-aligned construction.
- No theorem signature, proof term, or Blueprint mathematical statement changes.

### Testing

- `lake exe cache get`
- `lake build` — 9,832 jobs completed successfully.
- `lake env lean TNLean/MPS/RFP/NNCPHMultiSector.lean`
- `lake env lean TNLean/MPS/RFP/BeigiGroundSpaceDimension.lean`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `leanblueprint pdf` — 804-page PDF generated.
- The new PGVWC07 paper-gap note compiles independently to PDF.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check origin/main...HEAD`
- Three read-only exact-head reviews approved the final marker taxonomy and source citations.

---
Closes #5172
Related: #2380, #232

### Agent assistance

- OpenAI Codex (GPT-5) assisted with the source audit, documentation edits, paper-gap note, validation, and review coordination. The maintainer opening this pull request is accountable for the mathematical classification and every changed line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and citation edits only; no executable Lean or proof logic changes. Risk is limited to documentation accuracy for reviewers tracing formalizations to papers.
> 
> **Overview**
> Aligns declaration docstrings with the repo’s paper-gap conventions so narrowed or substituted arguments are labeled consistently, and updates bibliographic anchors for Beigi (2012).
> 
> **Scope restriction taxonomy:** Adds **Scope restriction** blocks to blocked algebra-structure data (`AlgebraStructureData`, `CompatibleWith`, `IsRFP_MPDO_via_algebra`, and related RFP implications), `etaLocalStructureData`, and many cyclic-active MPDO declarations. Reclassifies a large set of former **Local fix (cyclic-active restriction)** notes (and similar active-sector / periodicity markers) to **Scope restriction**, on the grounds that they change index sets or proof routes rather than fix typos. Each block points at the relevant `docs/paper-gaps/*.tex` note.
> 
> **Citations and attribution:** Replaces Beigi `arXiv:1105.1019v2` line-range anchors with **J. Phys. A 45 (2012) 025306** (Lemma 2.1, Sections III–IV, equation numbers) across algebra, parent Hamiltonian, and MPDO files. Tightens other docstrings (e.g. eventual ground-space dimension vs CPSV16 Theorem 3.10, NNCPH→RFP one-sector vs multi-sector scope, extra PSD hypothesis in `sal_zcl_implies_rank_one_T_of_posSemidef`, PGVWC07 Theorem 12 adjoint in `pgvwc07_mem_iSup_groundSpace_of_trace_decomposition`, gauge-transport background in `PhysicalSectorGaugeTransport`).
> 
> **New paper-gap note:** `docs/paper-gaps/pgvwc07_common_identity_coefficients.tex` for the PGVWC07 common-identity coefficient scope.
> 
> No theorem signatures, proof terms, or blueprint math change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e56df095cf8b6a6c6107ef320d3237d5fbdf20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->