### PR TITLE
refactor(tenkz): own core style metrics

### DIFF
--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import copy
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -22,6 +23,30 @@ from tenkz_language import (  # noqa: E402
 )
 from tenkz_lint import ink_token_count, registry_alias_patterns  # noqa: E402
 import tenkz_shrink  # noqa: E402
+
+
+def test_core_style_lengths_are_metric_owned() -> None:
+    source = (ROOT / "tex/tenkz/tenkz-core.code.tex").read_text(encoding="utf-8")
+    style_table = source.split(
+        "% ---------- style table", maxsplit=1
+    )[1].split(
+        "% ---------- event stream", maxsplit=1
+    )[0]
+    uncommented = "\n".join(
+        line.split("%", maxsplit=1)[0] for line in style_table.splitlines()
+    )
+    absolute_literals = re.findall(
+        r"(?<![\w@.])(?:\d+(?:\.\d*)?|\.\d+)(?:pt|mm)\b",
+        uncommented,
+    )
+    nonzero_literals = [
+        literal for literal in absolute_literals
+        if float(literal.removesuffix("pt").removesuffix("mm")) != 0
+    ]
+    assert not nonzero_literals, (
+        "nonzero core style lengths belong in tenkz-metric.code.tex: "
+        f"{nonzero_literals}"
+    )
 
 
 def test_saved_path_capture_is_not_rendering_debt() -> None:

--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -25,6 +25,22 @@ from tenkz_lint import ink_token_count, registry_alias_patterns  # noqa: E402
 import tenkz_shrink  # noqa: E402
 
 
+_TEX_DIMENSION_LITERAL = re.compile(
+    r"(?<![\w@.])"
+    r"(?P<value>\d+(?:\.\d*)?|\.\d+)"
+    r"[ \t]*(?P<unit>pt|pc|in|bp|cm|mm|dd|cc|sp|em|ex)\b",
+    re.IGNORECASE,
+)
+
+
+def nonzero_dimension_literals(source: str) -> list[str]:
+    return [
+        match.group()
+        for match in _TEX_DIMENSION_LITERAL.finditer(source)
+        if float(match.group("value")) != 0
+    ]
+
+
 def test_core_style_lengths_are_metric_owned() -> None:
     source = (ROOT / "tex/tenkz/tenkz-core.code.tex").read_text(encoding="utf-8")
     style_table = source.split(
@@ -35,18 +51,33 @@ def test_core_style_lengths_are_metric_owned() -> None:
     uncommented = "\n".join(
         line.split("%", maxsplit=1)[0] for line in style_table.splitlines()
     )
-    absolute_literals = re.findall(
-        r"(?<![\w@.])(?:\d+(?:\.\d*)?|\.\d+)(?:pt|mm)\b",
-        uncommented,
-    )
-    nonzero_literals = [
-        literal for literal in absolute_literals
-        if float(literal.removesuffix("pt").removesuffix("mm")) != 0
-    ]
+    nonzero_literals = nonzero_dimension_literals(uncommented)
     assert not nonzero_literals, (
-        "nonzero core style lengths belong in tenkz-metric.code.tex: "
+        "nonzero core style dimensions belong in tenkz-metric.code.tex: "
         f"{nonzero_literals}"
     )
+
+
+def test_core_style_length_ratchet_covers_tex_units() -> None:
+    source = (
+        "1pt 2pc 3in 4bp 5cm 6mm 7dd 8cc 9sp "
+        "10em .5ex 11 CM 12\tBP 0pt 0.0em word1mm 1ptx"
+    )
+    assert nonzero_dimension_literals(source) == [
+        "1pt",
+        "2pc",
+        "3in",
+        "4bp",
+        "5cm",
+        "6mm",
+        "7dd",
+        "8cc",
+        "9sp",
+        "10em",
+        ".5ex",
+        "11 CM",
+        "12\tBP",
+    ]
 
 
 def test_saved_path_capture_is_not_rendering_debt() -> None:

--- a/tests/tenkz/render-census-baseline.json
+++ b/tests/tenkz/render-census-baseline.json
@@ -20,7 +20,7 @@
   "decimal_literals": {
     "by_file": {
       "tenkz-cd.code.tex": 1,
-      "tenkz-core.code.tex": 18,
+      "tenkz-core.code.tex": 5,
       "tenkz-frame.code.tex": 0,
       "tenkz-free.code.tex": 4,
       "tenkz-geometry.code.tex": 0,
@@ -33,6 +33,6 @@
       "tenkz-render.code.tex": 0,
       "tenkz-string.code.tex": 0
     },
-    "total": 42
+    "total": 29
   }
 }

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -163,7 +163,8 @@
   box tensor/.style={tenkz audited glyph={rect}{0pt},
       draw=tenkzInk, fill=tenkzPaper,
       rectangle,
-      inner sep=1.6pt, minimum size=\tenkz@dim{\tenkz@r@glyphbox},
+      inner sep=\tenkz@boxinset,
+      minimum size=\tenkz@dim{\tenkz@r@glyphbox},
       minimum width=\tenkz@dim{\tenkz@r@glyphref},
       line width=\tenkz@wirewidth, text=tenkzInk},
   % A labelled circle is distinct from the filled dot and the on-wire
@@ -173,10 +174,11 @@
   circle tensor/.style={box tensor,
       tenkz audited glyph={circle}{0pt}, circle},
   mpo tensor/.style={box tensor},
-  pill tensor/.style={tenkz audited glyph={roundrect}{2.2pt},
+  pill tensor/.style={tenkz audited glyph={roundrect}{\tenkz@pillcap},
       draw=tenkzInk, fill=tenkzPaper,
       rectangle,
-      rounded corners=2.2pt, inner xsep=3.2pt, inner ysep=2.2pt,
+      rounded corners=\tenkz@pillcap,
+      inner xsep=\tenkz@pillxinset, inner ysep=\tenkz@pillcap,
       minimum height=\tenkz@dim{\tenkz@r@glyphbox},
       minimum width=\tenkz@dim{\tenkz@r@glyphref},
       line width=\tenkz@wirewidth, text=tenkzInk},
@@ -191,7 +193,8 @@
       draw=tenkzAction,
       fill=tenkzPaper, rectangle,
       rounded corners=\tenkz@dim{\tenkz@r@wireglyphcap},
-      inner xsep=1.8pt, inner ysep=1.4pt,
+      inner xsep=\tenkz@wireglyphxinset,
+      inner ysep=\tenkz@wireglyphyinset,
       minimum size=\tenkz@dim{\tenkz@r@wireglyph},
       minimum width=\tenkz@dim{\tenkz@r@glyphref},
       line width=\tenkz@wirewidth, text=tenkzInk},
@@ -201,7 +204,7 @@
   % side receives the isometry's domain and whose APEX emits its codomain --
   % the A_L / A_R glyphs of canonical-form MPS (sum_s A_L^s{}^dagger A_L^s = 1).
   % Wires meet the flat side's midpoint and the apex, both on the wire axis.
-  % inner sep is tight (0.6pt): a triangle must CIRCUMSCRIBE its text box,
+  % triangleinset is tight: a triangle must CIRCUMSCRIBE its text box,
   % so every point of padding costs ~triple in glyph height; the inscribed
   % label also drops the glyph strut (see \tenkz_tri_node:nnn) or two
   % triangle rows would collide across the default layer gap
@@ -212,8 +215,8 @@
       draw=tenkzInk,
       fill=tenkzPaper,
       isosceles triangle, isosceles triangle apex angle=55,
-      isosceles triangle stretches, inner sep=0.6pt,
-      minimum width=\tenkz@dim{0.34},
+      isosceles triangle stretches, inner sep=\tenkz@triangleinset,
+      minimum width=\tenkz@dim{\tenkz@r@canonicalwidth},
       minimum height=\tenkz@dim{\tenkz@r@wireglyph},
       line width=\tenkz@wirewidth, text=tenkzInk},
   left canonical tensor/.style={canonical tensor, shape border rotate=0},
@@ -239,7 +242,8 @@
   % without touching the grid renderer itself; see
   % scripts/test_tenkz_face_ports.py.
   tenkz combined stub/.style={},
-  fused bond/.style={bond, double=tenkzPaper, double distance=1.1pt},
+  fused bond/.style={bond, double=tenkzPaper,
+      double distance=\tenkz@fusedwiregap},
   physical leg/.style={bond},
   operator bond/.style={bond, draw=tenkzOperator},
   trace/.style={bond, rounded corners=\tenkz@dim{\tenkz@r@corner}},
@@ -352,16 +356,16 @@
   % and K7 free regions consume this same style and the same measured-box
   % renderer below.
   group region/.style={draw=tenkzPassive, fill=none, densely dashed,
-      rounded corners=2pt, line width=\tenkz@annwidth},
+      rounded corners=\tenkz@groupcorner, line width=\tenkz@annwidth},
   % the package's label skin.  Named `tn label`, NOT `label`: a bare
   % `label/.style` would clobber TikZ's built-in /tikz/label key
   % document-wide, silently swallowing `label=above:$x$` on every node of
   % every picture that merely loads tenkz.
   tn label/.style={tenkz audited label, shape=rectangle, rounded corners=0pt,
-      text=tenkzInk, inner sep=1pt, font=\scriptsize},
+      text=tenkzInk, inner sep=\tenkz@labelinset, font=\scriptsize},
   cd arrow/.style={draw=tenkzInk, line width=\tenkz@annwidth,
-      -{Straight Barb[length=3.4pt]},
-      shorten <=3.5pt, shorten >=3.5pt},
+      -{Straight Barb[length=\tenkz@cdbarblen]},
+      shorten <=\tenkz@cdarrowshorten, shorten >=\tenkz@cdarrowshorten},
   % regions
   region selected/.style={draw=tenkzAction, fill=tenkzAction!12!tenkzPaper,
       line width=\tenkz@emphwidth},

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -178,7 +178,7 @@
       draw=tenkzInk, fill=tenkzPaper,
       rectangle,
       rounded corners=\tenkz@pillcap,
-      inner xsep=\tenkz@pillxinset, inner ysep=\tenkz@pillcap,
+      inner xsep=\tenkz@pillxinset, inner ysep=\tenkz@pillyinset,
       minimum height=\tenkz@dim{\tenkz@r@glyphbox},
       minimum width=\tenkz@dim{\tenkz@r@glyphref},
       line width=\tenkz@wirewidth, text=tenkzInk},
@@ -365,7 +365,7 @@
       text=tenkzInk, inner sep=\tenkz@labelinset, font=\scriptsize},
   cd arrow/.style={draw=tenkzInk, line width=\tenkz@annwidth,
       -{Straight Barb[length=\tenkz@cdbarblen]},
-      shorten <=\tenkz@cdarrowshorten, shorten >=\tenkz@cdarrowshorten},
+      shorten <=\tenkz@cdsourceshorten, shorten >=\tenkz@cdtargetshorten},
   % regions
   region selected/.style={draw=tenkzAction, fill=tenkzAction!12!tenkzPaper,
       line width=\tenkz@emphwidth},

--- a/tex/tenkz/tenkz-metric.code.tex
+++ b/tex/tenkz/tenkz-metric.code.tex
@@ -206,9 +206,11 @@
 \__tenkz_metric_declare_length:nnn {boxinset} {1.6pt}
   { inscribed-label~padding~that~keeps~a~box~compact~at~the~glyph~floor }
 \__tenkz_metric_declare_length:nnn {pillcap} {2.2pt}
-  { a~pill's~vertical~inset~and~corner~radius~share~one~cap~scale }
+  { the~corner~radius~rounds~a~pill's~ends~without~making~it~a~circle }
 \__tenkz_metric_declare_length:nnn {pillxinset} {3.2pt}
   { a~pill~leaves~more~horizontal~than~vertical~room~around~its~label }
+\__tenkz_metric_declare_length:nnn {pillyinset} {2.2pt}
+  { a~pill's~vertical~label~padding~keeps~the~skin~flatter~than~a~box }
 \__tenkz_metric_declare_length:nnn {wireglyphxinset} {1.8pt}
   { an~on-wire~capsule~keeps~its~label~off~the~rounded~end~caps }
 \__tenkz_metric_declare_length:nnn {wireglyphyinset} {1.4pt}
@@ -223,8 +225,10 @@
   { the~house~label~skin~keeps~script~text~clear~of~its~anchor~ink }
 \__tenkz_metric_declare_length:nnn {cdbarblen} {3.4pt}
   { a~commutative-diagram~arrowhead~remains~legible~on~annotation-weight~shafts }
-\__tenkz_metric_declare_length:nnn {cdarrowshorten} {3.5pt}
-  { a~commutative-diagram~shaft~stops~just~behind~its~arrowhead~at~both~ends }
+\__tenkz_metric_declare_length:nnn {cdsourceshorten} {3.5pt}
+  { source-side~shortening~keeps~the~path~start~clear~of~its~source~node }
+\__tenkz_metric_declare_length:nnn {cdtargetshorten} {3.5pt}
+  { target-side~shortening~seats~the~arrowhead~before~the~target~node }
 
 % ---------- one truth, two spellings: assert agreement with the legacy ----
 \cs_new_protected:Npn \__tenkz_metric_assert:nn #1#2

--- a/tex/tenkz/tenkz-metric.code.tex
+++ b/tex/tenkz/tenkz-metric.code.tex
@@ -185,6 +185,9 @@
 \__tenkz_metric_declare:nnn {clusterdot} {0.11}
   { a~spin~on~a~cluster~sub-frame:~small~enough~that~the~gap~between~two~
     spins~exceeds~their~radius,~so~four~of~them~read~as~four }
+\__tenkz_metric_declare:nnn {canonicalwidth} {0.34}
+  { canonical-form~triangles~clear~their~inscribed~labels~without~widening~
+    enough~to~crowd~the~neighbouring~bond }
 
 \__tenkz_metric_declare_length:nnn {wirewidth} {0.55pt}
   { the~wire~stroke~of~the~ink~hierarchy }
@@ -200,6 +203,28 @@
   { barb~spanning~a~doubled~wire }
 \__tenkz_metric_declare_length:nnn {braceamp} {2.6pt}
   { brace~amplitude:~numerically~the~barb~floor,~semantically~independent }
+\__tenkz_metric_declare_length:nnn {boxinset} {1.6pt}
+  { inscribed-label~padding~that~keeps~a~box~compact~at~the~glyph~floor }
+\__tenkz_metric_declare_length:nnn {pillcap} {2.2pt}
+  { a~pill's~vertical~inset~and~corner~radius~share~one~cap~scale }
+\__tenkz_metric_declare_length:nnn {pillxinset} {3.2pt}
+  { a~pill~leaves~more~horizontal~than~vertical~room~around~its~label }
+\__tenkz_metric_declare_length:nnn {wireglyphxinset} {1.8pt}
+  { an~on-wire~capsule~keeps~its~label~off~the~rounded~end~caps }
+\__tenkz_metric_declare_length:nnn {wireglyphyinset} {1.4pt}
+  { an~on-wire~capsule~stays~flatter~than~an~ordinary~labelled~glyph }
+\__tenkz_metric_declare_length:nnn {triangleinset} {0.6pt}
+  { a~triangle~circumscribes~its~label,~so~a~small~inset~protects~row~clearance }
+\__tenkz_metric_declare_length:nnn {fusedwiregap} {1.1pt}
+  { the~paper~channel~between~a~fused~bond's~two~wire-weight~strokes }
+\__tenkz_metric_declare_length:nnn {groupcorner} {2pt}
+  { grouped-object~outlines~turn~gently~without~reading~as~pill~glyphs }
+\__tenkz_metric_declare_length:nnn {labelinset} {1pt}
+  { the~house~label~skin~keeps~script~text~clear~of~its~anchor~ink }
+\__tenkz_metric_declare_length:nnn {cdbarblen} {3.4pt}
+  { a~commutative-diagram~arrowhead~remains~legible~on~annotation-weight~shafts }
+\__tenkz_metric_declare_length:nnn {cdarrowshorten} {3.5pt}
+  { a~commutative-diagram~shaft~stops~just~behind~its~arrowhead~at~both~ends }
 
 % ---------- one truth, two spellings: assert agreement with the legacy ----
 \cs_new_protected:Npn \__tenkz_metric_assert:nn #1#2


### PR DESCRIPTION
## Summary

- move anonymous nonzero style dimensions from the core style table into the motivated metric registry
- keep curvature, padding, source clearance, and target clearance as distinct semantic measurements even where their current values coincide
- add a ratchet rejecting future hardcoded TeX dimension literals in the core style table
- update the render census from 42 to 29 stray decimal literals package-wide, with core reduced from 18 to 5

## Why

The core renderer still embedded print-size decisions such as `1.6pt`, `2.2pt`, and `3.5pt` directly in TikZ styles. That shadowed the metric registry and made later tuning or auditing depend on scattered literals. This change gives each measurement one named owner and motivation without tuning any individual page or changing any numerical value.

The new ratchet covers TeX/TikZ units `pt`, `pc`, `in`, `bp`, `cm`, `mm`, `dd`, `cc`, `sp`, `em`, and `ex`, with adversarial coverage for bypass cases.

## Validation

- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — census 200; all 132 flags covered
- language registry — 226 records
- kernel suite — 50 regressions, 8 sugar equivalences, 12 event streams, byte-identical pixels
- full corpus — 264 standalone files compiled and audited
- full golden comparison before the final exact-main rebase — all 264 event streams byte-identical
- independent paired render review — 6 pages byte-identical at 300 dpi against base `43a4456c8`

Refs #4158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with byte-identical render validation; no auth or runtime logic—only where dimensions are defined and enforced by tests.
> 
> **Overview**
> Moves **hardcoded TeX dimensions** out of the `tenkz-core` style table into **`tenkz-metric.code.tex`**, with each value registered as a named length (or ratio) and a documented motivation. Core TikZ styles now reference macros such as `\tenkz@boxinset`, `\tenkz@pillcap`, and `\tenkz@cdsourceshorten` instead of inline `pt` literals; canonical triangles use the new ratio **`canonicalwidth`** (`0.34`) via `\tenkz@r@canonicalwidth`.
> 
> Adds **contract tests** in `scripts/test_tenkz_shrink.py` that scan the core style table for nonzero dimension literals (TeX units `pt`–`ex`) and fail if any appear outside the metric file, plus unit coverage for the detector regex.
> 
> Updates **`render-census-baseline.json`**: package-wide decimal literal count **42 → 29**, with **`tenkz-core.code.tex` 18 → 5**. Numerical rendering is unchanged; this is ownership and auditability only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b8dd46a7fab938dbf65d4d48379542af41db3d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->