### PR TITLE
refactor(tenkz): own direction mark station

### DIFF
--- a/scripts/test_tenkz_shrink.py
+++ b/scripts/test_tenkz_shrink.py
@@ -80,6 +80,17 @@ def test_core_style_length_ratchet_covers_tex_units() -> None:
     ]
 
 
+def test_direction_marks_share_one_named_station() -> None:
+    source = (ROOT / "tex/tenkz/tenkz-core.code.tex").read_text(encoding="utf-8")
+    direction_styles = source.split(
+        "% directionality marks", maxsplit=1
+    )[1].split(
+        "% annotation ink", maxsplit=1
+    )[0]
+    assert direction_styles.count(r"position \tenkz@r@dirmarkstation") == 4
+    assert "position 0.55" not in direction_styles
+
+
 def test_saved_path_capture_is_not_rendering_debt() -> None:
     assert ink_token_count(r"\path [ spath/save = {route} ] (0,0) -- (1,0) ;") == 0
     assert ink_token_count(

--- a/tests/tenkz/render-census-baseline.json
+++ b/tests/tenkz/render-census-baseline.json
@@ -20,7 +20,7 @@
   "decimal_literals": {
     "by_file": {
       "tenkz-cd.code.tex": 1,
-      "tenkz-core.code.tex": 5,
+      "tenkz-core.code.tex": 1,
       "tenkz-frame.code.tex": 0,
       "tenkz-free.code.tex": 4,
       "tenkz-geometry.code.tex": 0,
@@ -33,6 +33,6 @@
       "tenkz-render.code.tex": 0,
       "tenkz-string.code.tex": 0
     },
-    "total": 29
+    "total": 25
   }
 }

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -335,16 +335,19 @@
   % a barb is the dual/inverse representation -- so `reversed` variants flip
   % the barb, never the wire.  The barb rides mid-wire and inherits the wire's
   % colour; the `fused` variants size the barb to span the doubled wire.
-  dir marks/.style={decoration={markings, mark=at position 0.55 with
+  dir marks/.style={decoration={markings,
+      mark=at position \tenkz@r@dirmarkstation with
       {\arrow{Straight Barb[length=\tenkz@barblen]}}}, postaction=decorate},
-  dir marks reversed/.style={decoration={markings, mark=at position 0.55 with
+  dir marks reversed/.style={decoration={markings,
+      mark=at position \tenkz@r@dirmarkstation with
       {\arrow{Straight Barb[length=\tenkz@barblen, reversed]}}},
       postaction=decorate},
-  fused dir marks/.style={decoration={markings, mark=at position 0.55 with
+  fused dir marks/.style={decoration={markings,
+      mark=at position \tenkz@r@dirmarkstation with
       {\arrow{Straight Barb[length=\tenkz@fusedbarblen]}}},
       postaction=decorate},
   fused dir marks reversed/.style={decoration={markings,
-      mark=at position 0.55 with
+      mark=at position \tenkz@r@dirmarkstation with
       {\arrow{Straight Barb[length=\tenkz@fusedbarblen, reversed]}}},
       postaction=decorate},
   % annotation ink (never confusable with 0.55pt wires)

--- a/tex/tenkz/tenkz-metric.code.tex
+++ b/tex/tenkz/tenkz-metric.code.tex
@@ -188,6 +188,9 @@
 \__tenkz_metric_declare:nnn {canonicalwidth} {0.34}
   { canonical-form~triangles~clear~their~inscribed~labels~without~widening~
     enough~to~crowd~the~neighbouring~bond }
+\__tenkz_metric_declare:nnn {dirmarkstation} {0.55}
+  { direction~barbs~sit~just~past~mid-wire,~clear~of~central~glyphs~while~
+    remaining~visually~attached~to~the~bond~they~orient }
 
 \__tenkz_metric_declare_length:nnn {wirewidth} {0.55pt}
   { the~wire~stroke~of~the~ink~hierarchy }


### PR DESCRIPTION
## Summary

- give the shared direction-barb station one motivated metric-registry owner
- use that owner in normal, reversed, fused, and fused-reversed direction styles
- add a focused ratchet that keeps all four styles on the shared station
- reduce the stray-decimal census from 29 to 25, with core reduced from 5 to 1

## Why

A read-only semantic audit of every remaining decimal after #5177 found that these four `0.55` occurrences were the only active shared rendering measurement still anonymously repeated. The styles are consumed across the free, grid, and kernel renderers, so this is a shared policy rather than page-specific tuning.

Other remaining decimals are exact coordinate arithmetic, historical guard evidence, values already owned by named thresholds, or implementation debt in surfaces scheduled for retirement. This PR intentionally does not turn those into misleading metrics.

## Validation

- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — census 200; all 132 flags covered
- `python3 scripts/tenkz_language.py check` — 226 records
- `scripts/tenkz_kernel_probes.sh --check` — 50 regressions, 8 sugar equivalences, 12 byte-identical event streams, byte-identical pixels

Refs #4158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Same numeric placement as before, scoped to shared TikZ direction-mark styles plus tests and census baselines—no auth, data, or API surface changes.
> 
> **Overview**
> **Direction-barb placement** is no longer four copies of `0.55` in core styles. A new ratio metric `dirmarkstation` (0.55) lives in `tenkz-metric.code.tex` with a documented motivation, and `dir marks`, reversed, fused, and fused-reversed all use `mark=at position \tenkz@r@dirmarkstation`.
> 
> A contract test in `test_tenkz_shrink.py` asserts exactly four uses of that macro in the directionality block and forbids bare `position 0.55`. The render **decimal literal census** baseline drops from 29 to 25 total (core from 5 to 1); behavior at 0.55 along the bond is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba99c4f2b1afa884f2fa3f1090dd32e5ba0b16dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->