### PR TITLE
refactor(tenkz): own carrier bearing projection

### DIFF
--- a/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
+++ b/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
@@ -8,6 +8,8 @@
 \fp_new:N \l__tenkz_test_route_x_fp
 \fp_new:N \l__tenkz_test_route_y_fp
 \tl_new:N \l__tenkz_test_route_name_tl
+\tl_new:N \l__tenkz_test_enclosure_bearing_tl
+\int_new:N \l__tenkz_test_enclosure_label_int
 \seq_new:N \l__tenkz_test_support_seq
 \cs_new_eq:NN
   \__tenkz_test_route_measure:n
@@ -137,6 +139,35 @@
       < {0.000001}
       { \errmessage{a~parallel~leg~was~extended~toward~an~unreachable~lane} }
   }
+\cs_new_eq:NN
+  \__tenkz_test_enclosure_label_ink:n
+  \__tenkz_kernel_r_mark_label_ink:n
+\cs_set_protected:Npn \__tenkz_kernel_r_mark_label_ink:n #1
+  {
+    \int_gincr:N \l__tenkz_test_enclosure_label_int
+    \__tenkz_model_get:nnN {#1} {label-pos}
+      \l__tenkz_test_enclosure_bearing_tl
+    \tl_set:Ne \l__tenkz_test_enclosure_bearing_tl
+      {
+        \fp_eval:n
+          {
+            \l__tenkz_test_enclosure_bearing_tl
+            + \l__tenkz_kernel_r_tau_tl
+          }
+      }
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_test_enclosure_bearing_tl
+          - atand(
+              0.5 * \__tenkz_metric_ratio:n {planerise},
+              cosd(30) + 0.5 * \__tenkz_metric_ratio:n {planeslant} )
+        )
+      }
+      < {0.000001}
+      { \errmessage{the~enclosure~label~lost~its~projected~bearing} }
+    \__tenkz_test_enclosure_label_ink:n {#1}
+  }
 \ExplSyntaxOff
 \makeatother
 \begin{document}
@@ -173,4 +204,8 @@
   \tnwire[name=affine-all, closed,
           route={all of (1,1) .. (2,2)}]
 \end{tenkz}
+\ExplSyntaxOn
+\int_compare:nNnF { \l__tenkz_test_enclosure_label_int } = {1}
+  { \errmessage{the~enclosure~fixture~did~not~render~its~label} }
+\ExplSyntaxOff
 \end{document}

--- a/tests/tenkz/zz_geomframe.tex
+++ b/tests/tenkz/zz_geomframe.tex
@@ -5,6 +5,12 @@
 \begin{document}
 \ExplSyntaxOn
 \tl_new:N \l_probe_xa_tl \tl_new:N \l_probe_ya_tl \tl_new:N \l_probe_ta_tl
+\cs_new_protected:Npn \__tenkz_test_bearing:nnnnn #1#2#3#4#5
+  {
+    \__tenkz_geom_local_bearing:nnnnN {#1}{1}{1}{#2} \l_probe_ta_tl
+    \fp_compare:nNnF { abs(\l_probe_ta_tl - (#3)) } < {0.000001}
+      { \tex_errmessage:D { local~bearing~#4~on~#5~did~not~reach~the~page } }
+  }
 % a pure rotation moves the east unit vector onto the 30-degree ray
 \__tenkz_geom_frame_declare_rotation:nnnn {rotA} {30} {0} {0}
 \__tenkz_geom_apply:nnnNN {rotA} {1} {0} \l_probe_xa_tl \l_probe_ya_tl
@@ -23,15 +29,30 @@
 \__tenkz_geom_port_angle:nnN {rotA} {n} \l_probe_ta_tl
 \__tenkz_geom_probe:nn {rot-port-n}
   { angle = \__tenkz_geom_round:n { \l_probe_ta_tl } }
-% kernel-local plane directions use east=column and north=negative row
+% The carrier-bearing service is an identity on the kernel flat frame.
+\__tenkz_geom_frame_declare_affine:nnnnnnn {flatK} {0}{1}{-1}{0}{0}{0}
+\__tenkz_test_bearing:nnnnn {flatK}{0}{0}{east}{flat}
+\__tenkz_test_bearing:nnnnn {flatK}{45}{45}{diagonal}{flat}
+\__tenkz_test_bearing:nnnnn {flatK}{90}{90}{north}{flat}
+% Kernel-local plane directions use east=column and north=negative row.  The
+% independent expected bearings retain both vectors of the sheared basis.
 \__tenkz_geom_frame_declare_plane:n {planeC}
-\__tenkz_geom_local_dir:nnN {planeC} {0} \l_probe_ta_tl
+\__tenkz_test_bearing:nnnnn {planeC}{0}{0}{east}{plane}
+\__tenkz_test_bearing:nnnnn
+  {planeC}{45}
+  { atand(\__tenkz_metric_ratio:n {planerise},1+\__tenkz_metric_ratio:n {planeslant}) }
+  {diagonal}{plane}
+\__tenkz_test_bearing:nnnnn
+  {planeC}{90}
+  { atand(\__tenkz_metric_ratio:n {planerise},\__tenkz_metric_ratio:n {planeslant}) }
+  {north}{plane}
+\__tenkz_geom_local_bearing:nnnnN {planeC}{1}{1}{0} \l_probe_ta_tl
 \__tenkz_geom_probe:nn {plane-local-east}
   { angle = \__tenkz_geom_round:n { \l_probe_ta_tl } }
-\__tenkz_geom_local_dir:nnN {planeC} {45} \l_probe_ta_tl
+\__tenkz_geom_local_bearing:nnnnN {planeC}{1}{1}{45} \l_probe_ta_tl
 \__tenkz_geom_probe:nn {plane-local-ne}
   { angle = \__tenkz_geom_round:n { \l_probe_ta_tl } }
-\__tenkz_geom_local_dir:nnN {planeC} {90} \l_probe_ta_tl
+\__tenkz_geom_local_bearing:nnnnN {planeC}{1}{1}{90} \l_probe_ta_tl
 \__tenkz_geom_probe:nn {plane-local-north}
   { angle = \__tenkz_geom_round:n { \l_probe_ta_tl } }
 % four stations on a unit circle starting north: east-going tangents

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -261,7 +261,7 @@
 % 90 + theta.  Keeping that convention here prevents row/column details from
 % leaking into each port, leg, and open-end consumer.
 \cs_new_protected:Npn \__tenkz_geom_local_dir:nnN #1#2#3
-  { \__tenkz_geom_dir:nnN {#1} { 90 + (#2) } #3 }
+  { \__tenkz_geom_local_bearing:nnnnN {#1}{1}{1}{#2} #3 }
 
 % A carrier basis is the complete local east/north pair on the page.  Keeping
 % both vectors, rather than one turn angle, preserves shear and unequal scale.
@@ -272,6 +272,28 @@
   {
     \tl_set:Ne #7 { \fp_eval:n { (#1) * (#5) + (#3) * (#6) } }
     \tl_set:Ne #8 { \fp_eval:n { (#2) * (#5) + (#4) * (#6) } }
+  }
+% Carry a local direction through a complete carrier basis and read its page
+% bearing.  A scalar turn cannot answer this question under shear or unequal
+% axis scale; the two basis vectors are the one source of direction geometry.
+\tl_new:N \l__tenkz_geom_bearing_x_tl
+\tl_new:N \l__tenkz_geom_bearing_y_tl
+\cs_new_protected:Npn \__tenkz_geom_basis_bearing:nnnnnN
+    #1#2#3#4#5#6
+  {
+    \__tenkz_geom_basis_apply:nnnnnnNN
+      {#1}{#2}{#3}{#4}
+      { cosd(#5) } { sind(#5) }
+      \l__tenkz_geom_bearing_x_tl \l__tenkz_geom_bearing_y_tl
+    \tl_set:Ne #6
+      {
+        \fp_eval:n
+          {
+            atand(
+              \l__tenkz_geom_bearing_y_tl ,
+              \l__tenkz_geom_bearing_x_tl )
+          }
+      }
   }
 \cs_new_protected:Npn \__tenkz_geom_basis_unapply:nnnnnnNN
     #1#2#3#4#5#6#7#8
@@ -486,6 +508,26 @@
             \tl_set:Ne #7 { \fp_eval:n { -\__tenkz_geom_field:nn{#1}{c} } }
           }
       }
+  }
+
+% The page bearing of one direction in the local east/north axes of a frame
+% address.  Both affine and circular carriers answer through the same complete
+% basis; consumers do not inspect frame kinds or reproduce projection formulae.
+\tl_new:N \l__tenkz_geom_bearing_ex_tl
+\tl_new:N \l__tenkz_geom_bearing_ey_tl
+\tl_new:N \l__tenkz_geom_bearing_nx_tl
+\tl_new:N \l__tenkz_geom_bearing_ny_tl
+\cs_new_protected:Npn \__tenkz_geom_local_bearing:nnnnN #1#2#3#4#5
+  {
+    \__tenkz_geom_local_basis:nnnNNNN {#1}{#2}{#3}
+      \l__tenkz_geom_bearing_ex_tl \l__tenkz_geom_bearing_ey_tl
+      \l__tenkz_geom_bearing_nx_tl \l__tenkz_geom_bearing_ny_tl
+    \__tenkz_geom_basis_bearing:nnnnnN
+      { \l__tenkz_geom_bearing_ex_tl }
+      { \l__tenkz_geom_bearing_ey_tl }
+      { \l__tenkz_geom_bearing_nx_tl }
+      { \l__tenkz_geom_bearing_ny_tl }
+      {#4} #5
   }
 
 % The axes a frame gives a record.  An address on a carrier is read in the

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -2998,11 +2998,9 @@
 \prop_new:N \l__tenkz_kernel_r_turn_prop
 
 % Carry one of an atom's logical face directions to the page.  Kernel cell
-% coordinates are (row, column), whereas geometry direction angles are
-% measured from the first affine input.  Thus a face angle theta enters the
-% matrix as 90 + theta: east follows the column vector and north follows the
-% negative row vector.  A circle or a carrier-local atom retains the turn
-% model because its axes vary by station rather than by one affine matrix.
+% coordinates are (row, column), whereas the face is measured from local east.
+% Geometry owns the complete east/north basis at that address and carries the
+% direction through it.  A non-cell atom retains its carrier-local turn model.
 \cs_new_protected:Npn \__tenkz_kernel_r_page_face:nnN #1#2#3
   {
     \__tenkz_kernel_r_atom_rc:nNNN {#1}
@@ -3010,13 +3008,10 @@
       \l__tenkz_kernel_turn_bool
     \bool_if:NTF \l__tenkz_kernel_turn_bool
       {
-        \__tenkz_geom_frame_if_affine:nTF {kpic}
-          { \__tenkz_geom_local_dir:nnN {kpic} {#2} #3 }
-          {
-            \__tenkz_kernel_r_turn:nN {#1} \l__tenkz_kernel_turn_tl
-            \tl_set:Ne #3
-              { \fp_eval:n { (#2) + \l__tenkz_kernel_turn_tl } }
-          }
+        \__tenkz_geom_local_bearing:nnnnN {kpic}
+          { \l__tenkz_kernel_turn_a_tl }
+          { \l__tenkz_kernel_turn_b_tl }
+          {#2} #3
       }
       {
         \__tenkz_kernel_r_turn:nN {#1} \l__tenkz_kernel_turn_tl
@@ -8908,21 +8903,18 @@
       {
         \l__tenkz_kernel_r_y_fp + \l__tenkz_kernel_ro_apply_y_tl
       }
-    \__tenkz_geom_basis_apply:nnnnnnNN
+    \__tenkz_geom_basis_bearing:nnnnnN
       { \l__tenkz_kernel_hull_ex_tl }
       { \l__tenkz_kernel_hull_ey_tl }
       { \l__tenkz_kernel_hull_nx_tl }
       { \l__tenkz_kernel_hull_ny_tl }
-      { cosd(\l__tenkz_kernel_r_tl) }
-      { sind(\l__tenkz_kernel_r_tl) }
-      \l__tenkz_kernel_ro_apply_x_tl \l__tenkz_kernel_ro_apply_y_tl
+      { \l__tenkz_kernel_r_tl }
+      \l__tenkz_kernel_r_tau_tl
     \tl_set:Ne \l__tenkz_kernel_r_tau_tl
       {
         \fp_eval:n
           {
-            atand(
-              \l__tenkz_kernel_ro_apply_y_tl ,
-              \l__tenkz_kernel_ro_apply_x_tl )
+            \l__tenkz_kernel_r_tau_tl
             - \l__tenkz_kernel_r_tl
           }
       }


### PR DESCRIPTION
## Summary

- add one geometry-owned operation that carries a local bearing through the complete east/north carrier basis and reads its page angle
- refactor record/port face projection and affine enclosure-label bearings to use that shared operation
- add independent flat and sheared-plane probes at east, north, and a diagonal bearing
- add a focused enclosure-label regression derived directly from the plane basis

## Why

The kernel already preserved complete affine bases for support, routes, and enclosures, but bearing consumers still performed their own projection steps. A scalar turn is insufficient under shear or unequal axis scale. This change makes the full basis the single owner of local-to-page bearing projection and removes duplicated projection arithmetic without changing the public grammar or current rendering behavior.

This is the behavior-preserving first slice of the remaining LionSR/tenkz#113 carrier work. Bare cell/member/cluster label targets are intentionally deferred to the next slice, where their corrected placement will have an explicit pixel surface. Boundary signatures remain logical-frame semantics and are intentionally not projected.

## Validation

- focused XeLaTeX: `zz_geomframe.tex`, `r_plane_projection.tex`, `r_affine_hull_routes.tex`
- `scripts/tenkz_kernel_probes.sh --check` — 50 regressions, 8 sugar equivalences, 12 byte-identical record streams, byte-identical pixels
- `python3 scripts/tenkz_language.py check` — 226 records
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — census 200; all 132 flags covered
- `scripts/tenkz_golden.sh --check` — all 264 event streams byte-identical
- independent review found no actionable findings

Refs LionSR/tenkz#113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors direction geometry used by ports, legs, and enclosure labels on sheared carriers; intended behavior-preserving with broad regression gates but still core rendering math.
> 
> **Overview**
> Geometry now owns **local-to-page bearing** through the full east/north carrier basis instead of scattered `90 + theta` / manual `atand` steps in the kernel.
> 
> New helpers **`__tenkz_geom_basis_bearing`** and **`__tenkz_geom_local_bearing`** apply a local direction via the complete basis and return the page angle; **`__tenkz_geom_local_dir`** delegates to the latter. Cell **port/face** projection (`__tenkz_kernel_r_page_face`) and **affine enclosure-label** placement call these shared APIs rather than duplicating projection math.
> 
> **Regression coverage** adds independent east/north/diagonal probes on flat and sheared plane frames in `zz_geomframe.tex`, and a hook on enclosure label ink in `r_affine_hull_routes.tex` that asserts the projected bearing matches the plane basis formula.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6c0fa8871b9c7e453b10b3304fe3fbc696e2cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->