### PR TITLE
feat(MPS): preserve literal CPSV form under blocking

### DIFF
--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -85,7 +85,9 @@ private noncomputable def sandwichLinearEquiv
   simp [sandwichUnit, Matrix.star_eq_conjTranspose, Matrix.conjTranspose_nonsing_inv,
     Matrix.mul_assoc]
 
-private lemma spectralRadius_similarity_eq
+/-- Spectral radius is invariant under the congruence similarity
+`X ↦ C⁻¹ * E (C * X * Cᴴ) * (Cᴴ)⁻¹`. -/
+theorem spectralRadius_similarityMap_eq
     (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0)
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
     spectralRadius ℂ
@@ -408,7 +410,7 @@ theorem spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
         (similarityMap (D := D) S⁻¹ E)) =
       spectralRadius ℂ
         ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) E) :=
-    spectralRadius_similarity_eq (D := D) S⁻¹ hSinv_det E
+    spectralRadius_similarityMap_eq (D := D) S⁻¹ hSinv_det E
   have hscale : spectralRadius ℂ
       ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) E') =
       (‖((↑r : ℂ)⁻¹)‖₊ : ℝ≥0∞) *

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -86,7 +86,14 @@ private noncomputable def sandwichLinearEquiv
     Matrix.mul_assoc]
 
 /-- Spectral radius is invariant under the congruence similarity
-`X ↦ C⁻¹ * E (C * X * Cᴴ) * (Cᴴ)⁻¹`. -/
+`X ↦ C⁻¹ * E (C * X * Cᴴ) * (Cᴴ)⁻¹`.
+
+Source context: arXiv:1606.00608, lines 214--235, fixes the transfer-map
+spectral radius when passing to normal blocks.  The equality here is the
+finite-dimensional similarity identity used to transport that normalization
+through a bond-space gauge.  See also M. Wolf, *Quantum Channels & Operations:
+Guided Tour*, Section 6.2, the similarity step in the proof of Theorem 6.3
+[Wolf2012QChannels]. -/
 theorem spectralRadius_similarityMap_eq
     (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0)
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :

--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.CanonicalForm.BNTTransport
 import TNLean.MPS.CanonicalForm.BNTUniqueness
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.CanonicalForm.CPSVAfterBlocking
+import TNLean.MPS.CanonicalForm.CPSVBlocking
 import TNLean.MPS.CanonicalForm.CPSVCanonicalFormII
 import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
 import TNLean.MPS.CanonicalForm.CommonPeriodCyclicSectors

--- a/TNLean/MPS/CanonicalForm.lean
+++ b/TNLean/MPS/CanonicalForm.lean
@@ -17,6 +17,7 @@ import TNLean.MPS.CanonicalForm.BNTUniqueness
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.MPS.CanonicalForm.CPSVAfterBlocking
 import TNLean.MPS.CanonicalForm.CPSVCanonicalFormII
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
 import TNLean.MPS.CanonicalForm.CommonPeriodCyclicSectors
 import TNLean.MPS.CanonicalForm.CyclicSectors
 import TNLean.MPS.CanonicalForm.CyclicSectors.Basic

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -255,7 +255,10 @@ end CPSVCanonicalFormData
 
 namespace IsCPSVCanonicalForm
 
-/-- Positive physical blocking preserves literal CPSV canonical form. -/
+/-- Positive physical blocking preserves literal CPSV canonical form.
+
+Source: arXiv:1606.00608, lines 227--244 define blocking, normal tensors, and
+canonical form; lines 259--301 give the weight-power expansion under products. -/
 theorem blockTensor {A : MPSTensor d D} (hA : IsCPSVCanonicalForm A)
     (p : ℕ) (hp : 0 < p) :
     IsCPSVCanonicalForm (MPSTensor.blockTensor (d := d) (D := D) A p) := by

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Irreducible.SpectralRadius
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
+import TNLean.MPS.CanonicalForm.NormalTensorGauge
+import TNLean.MPS.CanonicalForm.SectorComparison.PrimitiveBlocks
+
+/-!
+# Literal CPSV canonical forms under positive physical blocking
+
+This module proves that CPSV normal tensors and literal CPSV canonical-form
+data are preserved by blocking a positive number of physical sites.
+
+The retained block dimensions and the ambient coisometry are unchanged.  Each
+normal block is replaced by its physical block tensor and each CPSV weight is
+raised to the blocking length.  The reconstruction is the exact blocked
+letterwise reconstruction, not only equality of closed-chain coefficients.
+
+## Main results
+
+* `MPSTensor.IsNormalTensor.blockTensor`: positive blocking preserves normal
+  tensors.
+* `MPSTensor.CPSVCanonicalFormData.blockTensor`: literal canonical-form data
+  block exactly.
+* `MPSTensor.IsCPSVCanonicalForm.blockTensor`: positive blocking preserves
+  literal CPSV canonical form.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Section 2.3,
+  lines 214--245 and eq. `II_CF1`.
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+namespace GaugeEquiv
+
+/-- Gauge equivalence is preserved by blocking the physical alphabet. -/
+theorem blockTensor {A B : MPSTensor d D} (h : GaugeEquiv A B) (p : ℕ) :
+    GaugeEquiv (blockTensor (d := d) (D := D) A p)
+      (blockTensor (d := d) (D := D) B p) := by
+  obtain ⟨X, hX⟩ := h
+  refine ⟨X, fun i ↦ ?_⟩
+  simpa [MPSTensor.blockTensor, Matrix.GeneralLinearGroup.coe_inv] using
+    evalWord_gauge (A := A) (B := B) X hX (wordOfBlock d p i)
+
+/-- The transfer maps of gauge-equivalent tensors are related by the standard
+congruence similarity of completely positive maps. -/
+theorem transferMap_eq_similarityMap {A B : MPSTensor d D} (h : GaugeEquiv A B) :
+    ∃ C : Matrix (Fin D) (Fin D) ℂ, C.det ≠ 0 ∧
+      transferMap (d := d) (D := D) B =
+        similarityMap (D := D) C (transferMap (d := d) (D := D) A) := by
+  obtain ⟨X, hX⟩ := h
+  refine ⟨((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ), ?_, ?_⟩
+  · exact Matrix.GeneralLinearGroup.det_ne_zero (X⁻¹ : GL (Fin D) ℂ)
+  · apply LinearMap.ext
+    intro Y
+    have hXdet : IsUnit ((X : Matrix (Fin D) (Fin D) ℂ).det) :=
+      Ne.isUnit (Matrix.GeneralLinearGroup.det_ne_zero X)
+    have hX_inv_inv :
+        ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹)⁻¹ =
+          (X : Matrix (Fin D) (Fin D) ℂ) :=
+      Matrix.nonsing_inv_nonsing_inv (X : Matrix (Fin D) (Fin D) ℂ) hXdet
+    have hXstar_det : IsUnit (((X : Matrix (Fin D) (Fin D) ℂ)ᴴ).det) := by
+      simpa [Matrix.det_conjTranspose] using IsUnit.star hXdet
+    have hXstar_inv_inv :
+        (((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹)⁻¹ =
+          (X : Matrix (Fin D) (Fin D) ℂ)ᴴ :=
+      Matrix.nonsing_inv_nonsing_inv
+        ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ) hXstar_det
+    calc
+      transferMap (d := d) (D := D) B Y =
+          ∑ x : Fin d,
+            ((X : Matrix (Fin D) (Fin D) ℂ) * A x *
+              (X : Matrix (Fin D) (Fin D) ℂ)⁻¹) * Y *
+              (((X : Matrix (Fin D) (Fin D) ℂ) * A x *
+                (X : Matrix (Fin D) (Fin D) ℂ)⁻¹)ᴴ) := by
+            simp [transferMap_apply, hX]
+      _ = ∑ x : Fin d,
+            (X : Matrix (Fin D) (Fin D) ℂ) *
+              (A x * ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹ * Y *
+                ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹) * (A x)ᴴ) *
+              (X : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
+            refine Finset.sum_congr rfl ?_
+            intro x _
+            simp [Matrix.conjTranspose_mul, Matrix.conjTranspose_nonsing_inv,
+              Matrix.mul_assoc]
+      _ = (X : Matrix (Fin D) (Fin D) ℂ) *
+            (∑ x : Fin d,
+              A x * ((X : Matrix (Fin D) (Fin D) ℂ)⁻¹ * Y *
+                ((X : Matrix (Fin D) (Fin D) ℂ)ᴴ)⁻¹) * (A x)ᴴ) *
+            (X : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
+            simp [Finset.mul_sum, Finset.sum_mul, Matrix.mul_assoc]
+      _ = similarityMap (D := D)
+            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+            (transferMap (d := d) (D := D) A) Y := by
+            simp [similarityMap, transferMap_apply, Matrix.conjTranspose_nonsing_inv,
+              hX_inv_inv, hXstar_inv_inv, Matrix.mul_assoc]
+
+end GaugeEquiv
+
+namespace IsNormalTensor
+
+/-- Transport normal-tensor status backward along a gauge equivalence.
+
+The transfer maps are similar, hence have the same spectral radius and
+peripheral spectrum; irreducibility is transported through the corresponding
+irreducible-map similarity. -/
+theorem of_gaugeEquiv {A B : MPSTensor d D} (hB : IsNormalTensor B)
+    (hGauge : GaugeEquiv A B) :
+    IsNormalTensor A := by
+  obtain ⟨C, hC, hMap⟩ := hGauge.transferMap_eq_similarityMap
+  refine ⟨?_, ?_, ?_⟩
+  · have hIrrB : IsIrreducibleMap (transferMap (d := d) (D := D) B) :=
+      isIrreducibleCP_transferMap_of_isIrreducibleTensor B hB.no_invariant_proj
+    have hIrrA : IsIrreducibleMap (transferMap (d := d) (D := D) A) := by
+      have hIrrSim : IsIrreducibleMap
+          (similarityMap (D := D) C (transferMap (d := d) (D := D) A)) := by
+        simpa [hMap] using hIrrB
+      exact (isIrreducibleMap_similarity_iff (D := D) hC).1 hIrrSim
+    exact isIrreducibleTensor_of_isIrreducibleMap A hIrrA
+  · have hsr := hB.spectral_radius_one
+    rw [hMap] at hsr
+    rw [spectralRadius_similarityMap_eq (D := D) C hC
+      (transferMap (d := d) (D := D) A)] at hsr
+    exact hsr
+  · have hPrim := hB.primitive_transfer
+    rw [hMap] at hPrim
+    exact (IsPrimitive.similarityMap_iff (D := D) C hC
+      (transferMap (d := d) (D := D) A)).1 hPrim
+
+/-- Positive physical blocking preserves CPSV normal tensors.
+
+The proof puts the tensor into its trace-preserving Perron gauge.  Positive
+blocking preserves trace preservation, transfer-map primitivity, and tensor
+irreducibility for that gauge; hence the blocked gauge is a normal tensor.  A
+blocked gauge equivalence then transports the result back to the original
+blocked tensor. -/
+theorem blockTensor {A : MPSTensor d D} (hA : IsNormalTensor A) (p : ℕ) (hp : 0 < p) :
+    IsNormalTensor (MPSTensor.blockTensor (d := d) (D := D) A p) := by
+  letI : NeZero D := ⟨hA.bondDim_ne_zero⟩
+  obtain ⟨σ, _hσpos, _hσfix, hTP, hGauge, hPrim, hIrr⟩ := hA.exists_tpGauge
+  let B : MPSTensor d D := tpGauge (d := d) (D := D) A σ
+  have hExtra := tp_primitive_irreducible_extra_blocking
+    (d := d) (D := D) B hTP hPrim hIrr hp
+  have hNormalAlg : IsNormal (MPSTensor.blockTensor (d := d) (D := D) B p) :=
+    isNormal_of_tp_primitive_irreducible
+      (d := blockPhysDim d p) (D := D)
+      (MPSTensor.blockTensor (d := d) (D := D) B p) hExtra.1 hExtra.2.1 hExtra.2.2
+  have hBlockedGaugeNormal :
+      IsNormalTensor (MPSTensor.blockTensor (d := d) (D := D) B p) :=
+    isNormalTensor_of_isNormal_leftCanonical
+      (d := blockPhysDim d p) (D := D)
+      (MPSTensor.blockTensor (d := d) (D := D) B p) hNormalAlg hExtra.1
+  exact hBlockedGaugeNormal.of_gaugeEquiv (hGauge.blockTensor p)
+
+end IsNormalTensor
+
+/-- Exact word-level transport through a coisometric reconstruction, for
+nonempty words. -/
+theorem evalWord_eq_coisometry_reconstruction_of_ne_nil
+    {s d n : ℕ} {A : MPSTensor s d} {B : MPSTensor s n}
+    (U : Matrix (Fin n) (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ v, A v = Uᴴ * B v * U) :
+    ∀ w : List (Fin s), w ≠ [] →
+      evalWord A w = Uᴴ * evalWord B w * U
+  | [], hnil => False.elim (hnil rfl)
+  | v :: w, _ => by
+      induction w generalizing v with
+      | nil =>
+          simpa [evalWord] using hReconstruct v
+      | cons v' w ih =>
+          change A v * evalWord A (v' :: w) =
+            Uᴴ * (B v * evalWord B (v' :: w)) * U
+          rw [hReconstruct v, ih v' (by simp)]
+          simp only [Matrix.mul_assoc]
+          rw [← Matrix.mul_assoc U Uᴴ, hU, Matrix.one_mul]
+
+/-- Blocking a weighted direct sum is exactly the weighted direct sum of the
+blocked summands, with every weight raised to the blocking length. -/
+theorem blockTensor_toTensorFromBlocks_apply {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (p : ℕ) (i : Fin (blockPhysDim d p)) :
+    blockTensor (d := d) (D := ∑ k : Fin r, dim k)
+        (toTensorFromBlocks (d := d) (μ := μ) blocks) p i =
+      toTensorFromBlocks (d := blockPhysDim d p)
+        (fun k ↦ μ k ^ p)
+        (fun k ↦ blockTensor (d := d) (D := dim k) (blocks k) p) i := by
+  simp [MPSTensor.blockTensor, toTensorFromBlocks,
+    evalWord_toTensorFromBlocks_eq_reindex_blockDiagonal,
+    length_wordOfBlock]
+
+namespace CPSVCanonicalFormData
+
+/-- Literal CPSV canonical-form data are preserved by positive physical
+blocking.
+
+The retained dimensions and ambient coisometry are unchanged.  The retained
+weights are raised to the blocking length and each retained normal tensor is
+blocked by that length.
+
+Source: arXiv:1606.00608, Section 2.3, lines 214--245 and eq. `II_CF1`. -/
+noncomputable def blockTensor {A : MPSTensor d D}
+    (data : CPSVCanonicalFormData A) (p : ℕ) (hp : 0 < p) :
+    CPSVCanonicalFormData (MPSTensor.blockTensor (d := d) (D := D) A p) where
+  r := data.r
+  dim := data.dim
+  dim_pos := data.dim_pos
+  weights := fun k ↦ data.weights k ^ p
+  blocks := fun k ↦ MPSTensor.blockTensor (d := d) (D := data.dim k) (data.blocks k) p
+  blocks_normal := fun k ↦ (data.blocks_normal k).blockTensor p hp
+  total_dim_le := data.total_dim_le
+  ambient_coisometry := data.ambient_coisometry
+  coisometric := data.coisometric
+  reconstruct := by
+    intro i
+    have hword_ne : wordOfBlock d p i ≠ [] := by
+      intro hnil
+      have hlen := congrArg List.length hnil
+      simp [length_wordOfBlock, hp.ne'] at hlen
+    calc
+      MPSTensor.blockTensor (d := d) (D := D) A p i =
+          data.ambient_coisometryᴴ *
+            evalWord (toTensorFromBlocks (d := d) data.weights data.blocks)
+              (wordOfBlock d p i) *
+            data.ambient_coisometry := by
+            simpa [MPSTensor.blockTensor] using
+              evalWord_eq_coisometry_reconstruction_of_ne_nil
+                data.ambient_coisometry data.coisometric data.reconstruct
+                (wordOfBlock d p i) hword_ne
+      _ = data.ambient_coisometryᴴ *
+            toTensorFromBlocks (d := blockPhysDim d p)
+              (fun k ↦ data.weights k ^ p)
+              (fun k ↦ MPSTensor.blockTensor (d := d) (D := data.dim k)
+                (data.blocks k) p) i *
+            data.ambient_coisometry := by
+            have hblock := blockTensor_toTensorFromBlocks_apply
+              (d := d) (dim := data.dim) data.weights data.blocks p i
+            rw [← hblock]
+            rfl
+
+end CPSVCanonicalFormData
+
+namespace IsCPSVCanonicalForm
+
+/-- Positive physical blocking preserves literal CPSV canonical form. -/
+theorem blockTensor {A : MPSTensor d D} (hA : IsCPSVCanonicalForm A)
+    (p : ℕ) (hp : 0 < p) :
+    IsCPSVCanonicalForm (MPSTensor.blockTensor (d := d) (D := D) A p) := by
+  obtain ⟨data⟩ := hA
+  exact ⟨data.blockTensor p hp⟩
+
+end IsCPSVCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -112,7 +112,10 @@ namespace IsNormalTensor
 
 The transfer maps are similar, hence have the same spectral radius and
 peripheral spectrum; irreducibility is transported through the corresponding
-irreducible-map similarity. -/
+irreducible-map similarity.
+
+Source: arXiv:1606.00608, lines 233--235 define normal tensors and lines
+264--268 give the invertible gauge relation between normal representatives. -/
 theorem of_gaugeEquiv {A B : MPSTensor d D} (hB : IsNormalTensor B)
     (hGauge : GaugeEquiv A B) :
     IsNormalTensor A := by

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -142,7 +142,11 @@ The proof puts the tensor into its trace-preserving Perron gauge.  Positive
 blocking preserves trace preservation, transfer-map primitivity, and tensor
 irreducibility for that gauge; hence the blocked gauge is a normal tensor.  A
 blocked gauge equivalence then transports the result back to the original
-blocked tensor. -/
+blocked tensor.
+
+Source: arXiv:1606.00608, lines 227--235 define physical blocking and normal
+tensors; the closure under reblocking is used in the normal-block arguments at
+lines 332--345. -/
 theorem blockTensor {A : MPSTensor d D} (hA : IsNormalTensor A) (p : ℕ) (hp : 0 < p) :
     IsNormalTensor (MPSTensor.blockTensor (d := d) (D := D) A p) := by
   letI : NeZero D := ⟨hA.bondDim_ne_zero⟩

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -177,7 +177,13 @@ theorem blockTensor {A : MPSTensor d D} (hA : IsNormalTensor A) (p : ℕ) (hp : 
 end IsNormalTensor
 
 /-- Exact word-level transport through a coisometric reconstruction, for
-nonempty words. -/
+nonempty words.
+
+Source: arXiv:1606.00608, equation `II_CF1` at lines 237--244 gives the
+one-site canonical-form reconstruction, and Proposition 4.13 at lines
+1917--1921 uses the corresponding coisometric reconstruction.  This theorem is
+its nonempty-word iteration, with intermediate coisometries cancelled by
+\(UU^*=1\). -/
 theorem evalWord_eq_coisometry_reconstruction_of_ne_nil
     {s d n : ℕ} {A : MPSTensor s d} {B : MPSTensor s n}
     (U : Matrix (Fin n) (Fin d) ℂ)

--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -42,7 +42,10 @@ variable {d D : ℕ}
 
 namespace GaugeEquiv
 
-/-- Gauge equivalence is preserved by blocking the physical alphabet. -/
+/-- Gauge equivalence is preserved by blocking the physical alphabet.
+
+Source: arXiv:1606.00608, line 227 defines blocking by matrix products and
+lines 264--268 give the invertible gauge relation. -/
 theorem blockTensor {A B : MPSTensor d D} (h : GaugeEquiv A B) (p : ℕ) :
     GaugeEquiv (blockTensor (d := d) (D := D) A p)
       (blockTensor (d := d) (D := D) B p) := by
@@ -52,7 +55,10 @@ theorem blockTensor {A B : MPSTensor d D} (h : GaugeEquiv A B) (p : ℕ) :
     evalWord_gauge (A := A) (B := B) X hX (wordOfBlock d p i)
 
 /-- The transfer maps of gauge-equivalent tensors are related by the standard
-congruence similarity of completely positive maps. -/
+congruence similarity of completely positive maps.
+
+Source: arXiv:1606.00608, lines 219--223 define the transfer map and lines
+264--268 give the invertible gauge relation. -/
 theorem transferMap_eq_similarityMap {A B : MPSTensor d D} (h : GaugeEquiv A B) :
     ∃ C : Matrix (Fin D) (Fin D) ℂ, C.det ≠ 0 ∧
       transferMap (d := d) (D := D) B =
@@ -192,7 +198,10 @@ theorem evalWord_eq_coisometry_reconstruction_of_ne_nil
           rw [← Matrix.mul_assoc U Uᴴ, hU, Matrix.one_mul]
 
 /-- Blocking a weighted direct sum is exactly the weighted direct sum of the
-blocked summands, with every weight raised to the blocking length. -/
+blocked summands, with every weight raised to the blocking length.
+
+Source: arXiv:1606.00608, lines 259--301, especially equations `II_Psi_k`,
+`II_ABasicTensors`, and `decBSV`. -/
 theorem blockTensor_toTensorFromBlocks_apply {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k))
     (p : ℕ) (i : Fin (blockPhysDim d p)) :

--- a/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVPhysicalReindex.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.Core.PhysicalReindexTransport
+
+/-!
+# Literal CPSV canonical form under physical relabeling
+
+A bijective relabeling of the physical alphabet leaves the transfer map unchanged.  It therefore
+preserves normal tensors and the retained-block reconstruction of literal CPSV canonical form.
+
+## Main results
+
+* `MPSTensor.IsNormalTensor.reindexPhysical`: physical relabeling preserves normal tensors.
+* `MPSTensor.CPSVCanonicalFormData.reindexPhysical`: relabel literal canonical-form data.
+* `MPSTensor.IsCPSVCanonicalForm.reindexPhysical`: physical relabeling preserves literal
+  canonical form.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Section 2.3.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d₁ d₂ D : ℕ}
+
+namespace IsNormalTensor
+
+/-- A bijective relabeling of the physical alphabet preserves a normal tensor.
+
+The transfer map is unchanged, so its spectral radius and peripheral spectrum are unchanged.  The
+invariant-projection condition is likewise invariant under the relabeling.
+
+Source: arXiv:1606.00608, normal-tensor definition at lines 233--235. -/
+theorem reindexPhysical {A : MPSTensor d₂ D} (hA : IsNormalTensor A)
+    (e : Fin d₁ ≃ Fin d₂) :
+    IsNormalTensor (MPSTensor.reindexPhysical e A) := by
+  refine ⟨(isIrreducibleTensor_reindexPhysical_equiv e A).2 hA.no_invariant_proj, ?_, ?_⟩
+  · rw [transferMap_reindexPhysical_equiv e A]
+    exact hA.spectral_radius_one
+  · exact (isPrimitive_transferMap_reindexPhysical_equiv e A).2 hA.primitive_transfer
+
+end IsNormalTensor
+
+namespace CPSVCanonicalFormData
+
+/-- Relabel the physical alphabet in literal CPSV canonical-form data.
+
+The retained dimensions, weights, and ambient coisometry are unchanged; only each retained normal
+block is relabeled.
+
+Source: arXiv:1606.00608, eq. `II_CF1`, lines 237--245. -/
+noncomputable def reindexPhysical {A : MPSTensor d₂ D}
+    (data : CPSVCanonicalFormData A) (e : Fin d₁ ≃ Fin d₂) :
+    CPSVCanonicalFormData (MPSTensor.reindexPhysical e A) where
+  r := data.r
+  dim := data.dim
+  dim_pos := data.dim_pos
+  weights := data.weights
+  blocks := fun k ↦ MPSTensor.reindexPhysical e (data.blocks k)
+  blocks_normal := fun k ↦ (data.blocks_normal k).reindexPhysical e
+  total_dim_le := data.total_dim_le
+  ambient_coisometry := data.ambient_coisometry
+  coisometric := data.coisometric
+  reconstruct := by
+    intro i
+    simpa [MPSTensor.reindexPhysical, toTensorFromBlocks] using data.reconstruct (e i)
+
+end CPSVCanonicalFormData
+
+namespace IsCPSVCanonicalForm
+
+/-- A bijective relabeling of the physical alphabet preserves literal CPSV canonical form.
+
+Source: arXiv:1606.00608, eq. `II_CF1`, lines 237--245. -/
+theorem reindexPhysical {A : MPSTensor d₂ D} (hA : IsCPSVCanonicalForm A)
+    (e : Fin d₁ ≃ Fin d₂) :
+    IsCPSVCanonicalForm (MPSTensor.reindexPhysical e A) := by
+  obtain ⟨data⟩ := hA
+  exact ⟨data.reindexPhysical e⟩
+
+end IsCPSVCanonicalForm
+
+end MPSTensor

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -66,6 +66,7 @@ import TNLean.MPS.MPDO.BiCFDerivation.Selectors
 import TNLean.MPS.MPDO.BlockedBNTFusionIsometries
 import TNLean.MPS.MPDO.BlockedCompleteZipper
 import TNLean.MPS.MPDO.BlockedRFPConstruction
+import TNLean.MPS.MPDO.CPSVBlocking
 import TNLean.MPS.MPDO.CPSVFigureEight
 import TNLean.MPS.MPDO.CPSVGroupedFigureEight
 import TNLean.MPS.MPDO.CPSVGroupedGramNormalization

--- a/TNLean/MPS/MPDO/CPSVBlocking.lean
+++ b/TNLean/MPS/MPDO/CPSVBlocking.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.CanonicalForm.CPSVBlocking
+import TNLean.MPS.MPDO.PhysicalBlocking
+
+/-!
+# Literal CPSV canonical form and MPO physical blocking
+
+This module specializes the MPS-level literal CPSV blocking theorem to MPO
+tensors through the doubled-index MPS tensor.
+
+## Main results
+
+* `MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTensor`
+* `MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTwo`
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Section 2.3 and
+  Appendix C.4, lines 1951--1956.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- Literal CPSV canonical form is preserved by arbitrary positive MPO physical
+blocking after passing to the doubled-index MPS tensor. -/
+theorem IsCPSVCanonicalForm_toMPSTensor_blockTensor {M : MPOTensor d D}
+    (hM : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor) (p : ℕ) (hp : 0 < p) :
+    MPSTensor.IsCPSVCanonicalForm (blockTensor M p).toMPSTensor := by
+  rw [toMPSTensor_blockTensor]
+  exact (hM.blockTensor p hp).reindexPhysical (blockedDoubledIndexEquiv d p)
+
+/-- Literal CPSV canonical form is preserved by concrete two-site MPO
+blocking after passing to the doubled-index MPS tensor. -/
+theorem IsCPSVCanonicalForm_toMPSTensor_blockTwo {M : MPOTensor d D}
+    (hM : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor) :
+    MPSTensor.IsCPSVCanonicalForm (blockTwo M).toMPSTensor := by
+  rw [toMPSTensor_blockTwo]
+  exact (hM.blockTensor 2 (by norm_num)).reindexPhysical (twoSiteDoubledIndexEquiv d)
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CPSVBlocking.lean
+++ b/TNLean/MPS/MPDO/CPSVBlocking.lean
@@ -30,7 +30,11 @@ namespace MPOTensor
 variable {d D : ℕ}
 
 /-- Literal CPSV canonical form is preserved by arbitrary positive MPO physical
-blocking after passing to the doubled-index MPS tensor. -/
+blocking after passing to the doubled-index MPS tensor.
+
+Source: arXiv:1606.00608, lines 636--659 define MPDO coarse graining by
+physical blocking and its two-site tensor maps; arbitrary positive blocking is
+the iterated form of the same operation. -/
 theorem IsCPSVCanonicalForm_toMPSTensor_blockTensor {M : MPOTensor d D}
     (hM : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor) (p : ℕ) (hp : 0 < p) :
     MPSTensor.IsCPSVCanonicalForm (blockTensor M p).toMPSTensor := by
@@ -38,7 +42,10 @@ theorem IsCPSVCanonicalForm_toMPSTensor_blockTensor {M : MPOTensor d D}
   exact (hM.blockTensor p hp).reindexPhysical (blockedDoubledIndexEquiv d p)
 
 /-- Literal CPSV canonical form is preserved by concrete two-site MPO
-blocking after passing to the doubled-index MPS tensor. -/
+blocking after passing to the doubled-index MPS tensor.
+
+Source: arXiv:1606.00608, lines 636--659, especially the two-site maps
+`M_2(X)` and equations `eq:Smap`--`eq:Tmap`. -/
 theorem IsCPSVCanonicalForm_toMPSTensor_blockTwo {M : MPOTensor d D}
     (hM : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor) :
     MPSTensor.IsCPSVCanonicalForm (blockTwo M).toMPSTensor := by

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -467,6 +467,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \lean{MPSTensor.IsNormalTensor.blockTensor}
     \leanok
     \uses{def:nt_cpsv, def:blocked_tensor,
+        thm:cpsv_normal_tp_gauge,
+        thm:tp_primitive_irreducible_extra_blocking,
         thm:cpsv_normal_tensor_gauge_transport,
         thm:is_normal_tensor_of_is_normal_left_canonical}
     Let $A$ be a CPSV normal tensor and let $L\geq1$. Then the blocked tensor
@@ -474,7 +476,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:nt_cpsv, def:blocked_tensor,
+    \uses{thm:cpsv_normal_tp_gauge,
+        thm:tp_primitive_irreducible_extra_blocking,
         thm:cpsv_normal_tensor_gauge_transport,
         thm:is_normal_tensor_of_is_normal_left_canonical}
     Choose a trace-preserving gauge $B^i=XA^iX^{-1}$. Positive blocking gives

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -450,10 +450,15 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
         \label{eq:cpsv_transfer_similarity}
     \end{align}
     Similarity preserves the spectral radius and the peripheral spectrum.
-    The same conjugation carries invariant orthogonal projections for one
-    tensor to invariant orthogonal projections for the other. Thus the two
-    conditions in Definition~\ref{def:nt_cpsv} are transported across the
-    gauge.
+    For irreducibility, start with an invariant orthogonal projection $Q$ for
+    one transfer map and form the support projection of the corresponding
+    positive congruence $XQX^\dagger$ (using $X^{-1}$ in the reverse
+    direction).  The intertwining in
+    Formula~(\ref{eq:cpsv_transfer_similarity}) makes this support projection
+    invariant for the other transfer map.  Irreducibility forces its support
+    to be zero or full, and invertibility of $X$ then forces $Q=0$ or
+    $Q=\Id$.  Thus both conditions in Definition~\ref{def:nt_cpsv} are
+    transported across the gauge.
 \end{proof}
 
 \begin{theorem}[Positive blocking preserves CPSV normal tensors]

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -385,6 +385,156 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     Definition~\ref{def:bnt}; it is not part of canonical form itself.
 \end{definition}
 
+\begin{theorem}[Physical relabeling preserves CPSV normal and canonical form]
+    \label{thm:cpsv_physical_reindexing}
+    \lean{MPSTensor.IsNormalTensor.reindexPhysical}
+    \lean{MPSTensor.CPSVCanonicalFormData.reindexPhysical}
+    \lean{MPSTensor.IsCPSVCanonicalForm.reindexPhysical}
+    \leanok
+    \uses{def:nt_cpsv, def:cpsv_canonical_form}
+    Let $e:\{0,\ldots,d'-1\}\to\{0,\ldots,d-1\}$ be a bijection and set
+    \begin{align}
+        (e^*A)^j
+        &= A^{e(j)}.
+        \label{eq:cpsv_physical_reindexing_tensor}
+    \end{align}
+    If $A$ is a CPSV normal tensor, then $e^*A$ is a CPSV normal tensor. If
+    $A$ has canonical-form data
+    \begin{align}
+        A^i
+        &=U^\dagger\!\left(\bigoplus_{k=1}^r\mu_kA_k^i\right)U,
+        \notag
+    \end{align}
+    then $e^*A$ has the same weights and coisometry and the relabeled normal
+    blocks:
+    \begin{align}
+        (e^*A)^j
+        &=U^\dagger\!\left(\bigoplus_{k=1}^r
+            \mu_k(e^*A_k)^j\right)U.
+        \label{eq:cpsv_physical_reindexing_cf}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:nt_cpsv, def:cpsv_canonical_form}
+    A bijection of the physical alphabet only permutes the summands in
+    $\E_A(X)=\sum_iA^iX(A^i)^\dagger$. Hence the transfer map, its spectral
+    radius, its peripheral spectrum, and its invariant orthogonal projections
+    are unchanged. Formula~(\ref{eq:cpsv_physical_reindexing_cf}) is obtained
+    from Formula~(\ref{eq:cpsv_canonical_form}) by replacing $i$ with $e(j)$.
+\end{proof}
+
+\begin{theorem}[Gauge transport of CPSV normality]
+    \label{thm:cpsv_normal_tensor_gauge_transport}
+    \lean{spectralRadius_similarityMap_eq}
+    \lean{MPSTensor.GaugeEquiv.transferMap_eq_similarityMap}
+    \lean{MPSTensor.IsNormalTensor.of_gaugeEquiv}
+    \leanok
+    \uses{def:nt_cpsv}
+    Let $X$ be invertible and suppose
+    \begin{align}
+        B^i
+        &=XA^iX^{-1}
+        \notag
+    \end{align}
+    for every physical index $i$. If $B$ is a CPSV normal tensor, then $A$ is
+    a CPSV normal tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:nt_cpsv}
+    With $S_X(Y)=XYX^\dagger$, the transfer maps satisfy
+    \begin{align}
+        \E_B
+        &= S_X\circ\E_A\circ S_X^{-1}.
+        \label{eq:cpsv_transfer_similarity}
+    \end{align}
+    Similarity preserves the spectral radius and the peripheral spectrum.
+    The same conjugation carries invariant orthogonal projections for one
+    tensor to invariant orthogonal projections for the other. Thus the two
+    conditions in Definition~\ref{def:nt_cpsv} are transported across the
+    gauge.
+\end{proof}
+
+\begin{theorem}[Positive blocking preserves CPSV normal tensors]
+    \label{thm:cpsv_normal_tensor_positive_blocking}
+    \lean{MPSTensor.GaugeEquiv.blockTensor}
+    \lean{MPSTensor.IsNormalTensor.blockTensor}
+    \leanok
+    \uses{def:nt_cpsv, def:blocked_tensor,
+        thm:cpsv_normal_tensor_gauge_transport,
+        thm:is_normal_tensor_of_is_normal_left_canonical}
+    Let $A$ be a CPSV normal tensor and let $L\geq1$. Then the blocked tensor
+    $A^{[L]}$ is a CPSV normal tensor.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:nt_cpsv, def:blocked_tensor,
+        thm:cpsv_normal_tensor_gauge_transport,
+        thm:is_normal_tensor_of_is_normal_left_canonical}
+    Choose a trace-preserving gauge $B^i=XA^iX^{-1}$. Positive blocking gives
+    \begin{align}
+        (B^{[L]})^I
+        &=X(A^{[L]})^IX^{-1}.
+        \label{eq:cpsv_blocking_gauge}
+    \end{align}
+    The trace-preserving primitive and irreducible structure of $B$ is
+    preserved by positive blocking, so Theorem~\ref{thm:is_normal_tensor_of_is_normal_left_canonical}
+    makes $B^{[L]}$ CPSV normal. Gauge transport
+    (Theorem~\ref{thm:cpsv_normal_tensor_gauge_transport}) then gives CPSV
+    normality of $A^{[L]}$.
+\end{proof}
+
+\begin{theorem}[Literal CPSV canonical form is preserved by positive blocking]
+    \label{thm:cpsv_literal_canonical_form_positive_blocking}
+    \lean{MPSTensor.evalWord_eq_coisometry_reconstruction_of_ne_nil}
+    \lean{MPSTensor.blockTensor_toTensorFromBlocks_apply}
+    \lean{MPSTensor.CPSVCanonicalFormData.blockTensor}
+    \lean{MPSTensor.IsCPSVCanonicalForm.blockTensor}
+    \leanok
+    \uses{def:cpsv_canonical_form, def:blocked_tensor,
+        thm:cpsv_normal_tensor_positive_blocking}
+    Let $A$ have canonical-form data
+    \begin{align}
+        A^i
+        &=U^\dagger\!\left(\bigoplus_{k=1}^r\mu_kA_k^i\right)U,
+        \qquad
+        UU^\dagger=\Id.
+        \notag
+    \end{align}
+    For every $L\geq1$, $A^{[L]}$ has canonical-form data with the same
+    coisometry $U$, the blocked normal tensors $A_k^{[L]}$, and the weights
+    $\mu_k^L$:
+    \begin{align}
+        (A^{[L]})^I
+        &=U^\dagger\!\left(\bigoplus_{k=1}^r
+            \mu_k^L(A_k^{[L]})^I\right)U.
+        \label{eq:cpsv_literal_blocking_cf}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:cpsv_canonical_form, def:blocked_tensor,
+        thm:cpsv_normal_tensor_positive_blocking}
+    Write $I=(i_1,\ldots,i_L)$. Since $L\geq1$, the word $I$ is nonempty.
+    Repeatedly inserting $UU^\dagger=\Id$ into
+    $A^{i_1}\cdots A^{i_L}$ gives
+    \begin{align}
+        A^{i_1}\cdots A^{i_L}
+        &=
+        U^\dagger\!\left(\bigoplus_{k=1}^r
+            \mu_k^L A_k^{i_1}\cdots A_k^{i_L}\right)U
+        \notag\\
+        &=
+        U^\dagger\!\left(\bigoplus_{k=1}^r
+            \mu_k^L(A_k^{[L]})^I\right)U.
+        \notag
+    \end{align}
+    The preceding theorem gives CPSV normality of every blocked block
+    $A_k^{[L]}$, and the displayed identity is exactly the retained direct-sum
+    reconstruction.
+\end{proof}
+
 \begin{theorem}[CPSV canonical-form representative after blocking]
     \label{thm:cpsv_canonical_form_representative_after_blocking}
     \lean{MPSTensor.exists_cpsvCanonicalForm_representative_after_blocking}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -175,6 +175,43 @@ physical indices, as in
     column reindexing preserves positive semidefiniteness.
 \end{proof}
 
+\begin{theorem}[MPO blocking preserves literal CPSV doubled-index form]
+    \label{thm:mpdo_literal_cpsv_positive_blocking}
+    \lean{MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTensor}
+    \lean{MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTwo}
+    \leanok
+    \uses{def:mpdo_positive_physical_blocking, def:mpdo_two_site_blocking,
+        thm:mpdo_positive_blocking_doubled_index,
+        thm:mpdo_block_two_as_positive_blocking,
+        thm:cpsv_physical_reindexing,
+        thm:cpsv_literal_canonical_form_positive_blocking}
+    Let $A_M$ be the doubled-index MPS tensor associated to an MPO tensor
+    $M$. If $A_M$ is in literal CPSV canonical form and $L\geq1$, then the
+    doubled-index MPS tensor associated to $M^{[L]}$ is again in literal CPSV
+    canonical form. The same conclusion holds for the concrete two-site
+    blocking $M^{[2]}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:mpdo_positive_physical_blocking, def:mpdo_two_site_blocking,
+        thm:mpdo_positive_blocking_doubled_index,
+        thm:mpdo_block_two_as_positive_blocking,
+        thm:cpsv_physical_reindexing,
+        thm:cpsv_literal_canonical_form_positive_blocking}
+    The doubled-index tensor of $M^{[L]}$ is, under the canonical pairing of
+    ket and bra words, a physical relabeling of $A_M^{[L]}$:
+    \begin{align}
+        A_{M^{[L]}}
+        &=\psi_L^*(A_M^{[L]}).
+        \label{eq:mpdo_cpsv_block_tensor_reindex}
+    \end{align}
+    Theorem~\ref{thm:cpsv_literal_canonical_form_positive_blocking} gives
+    literal CPSV canonical form for $A_M^{[L]}$, and
+    Theorem~\ref{thm:cpsv_physical_reindexing} carries it across
+    $\psi_L$. For two-site blocking one takes $L=2$ and uses the concrete
+    identification of Theorem~\ref{thm:mpdo_block_two_as_positive_blocking}.
+\end{proof}
+
 \begin{lemma}[Two-site blocking preserves normalized BNT-refined horizontal form]
     \label{lem:mpdo_horizontal_cf_block_two}
     \lean{MPOTensor.IsHorizontalCF.blockTwo}


### PR DESCRIPTION
## What changed
- prove CPSV normal tensors and literal canonical-form data are preserved by bijective physical relabeling
- expose spectral-radius invariance under the channel similarity used by Perron gauges, and prove normal-tensor gauge transport
- prove positive physical blocking preserves CPSV normal tensors and exact literal canonical form, with blocked weights $\mu_k^L$ and the original ambient coisometry
- derive exact MPO positive-blocking and concrete two-site doubled-index canonical-form specializations
- add standalone Blueprint statements for the MPS and MPO preservation theorems without promoting the still-partial topological Gibbs result

## Source boundary
This completes Goal 1 of #5159. It preserves the actual blocked tensor letterwise, rather than replacing it by a merely MPV-equivalent canonical representative. The final literal-CPSV RFP-to-fusion and Gibbs theorem remains follow-up work.

## Validation
- `lake build` — passed (9835 jobs)
- `lake build TNLean.MPS.CanonicalForm.CPSVBlocking TNLean.MPS.MPDO.CPSVBlocking` — passed (8888 jobs)
- import aggregators — current (48 aggregators, 1128 production modules)
- fresh Blueprint declaration generation, `leanblueprint checkdecls`, and CI sync — passed
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'` — passed; no undefined cross-references (only pre-existing standalone citation warnings)
- `git diff --check origin/main...HEAD` — passed
- forbidden-token and kernel-axiom audits — no proof bypass; only `propext`, `Classical.choice`, and `Quot.sound`
- independent Lean review found no blockers or substantive nits

Advances #5159

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib proofs and documentation in MPS canonical-form and spectral-radius areas; no changes to runtime services, auth, or data paths.
> 
> **Overview**
> Adds Lean proofs and Blueprint statements that **literal CPSV canonical form** (same ambient coisometry, blocked normal blocks, weights \(\mu_k^L\)) is preserved under bijective physical relabeling and under positive physical blocking—not only MPV-equivalent representatives.
> 
> **Channel / gauge infrastructure:** `spectralRadius_similarityMap_eq` is promoted from a private lemma with documentation; gauge-equivalent MPS tensors are shown to have transfer maps related by `similarityMap`, and CPSV normality transports backward along gauge equivalence (`of_gaugeEquiv`).
> 
> **MPS:** New modules prove relabeling invariance (`CPSVPhysicalReindex`) and blocking closure (`CPSVBlocking`): gauge blocking, normal-tensor blocking via trace-preserving Perron gauge, coisometric word reconstruction, and `CPSVCanonicalFormData.blockTensor`.
> 
> **MPO:** `MPDO/CPSVBlocking` lifts the MPS blocking theorem to doubled-index `toMPSTensor` for general `blockTensor` and `blockTwo`, using physical reindexing equivalences.
> 
> **Docs:** Chapter 9 and chapter 21 gain linked theorems for physical reindexing, gauge transport, normal-tensor blocking, literal canonical-form blocking, and MPO doubled-index preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9086d6b95e02acc933326a21f8bca333268e4ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->