### PR TITLE
fix(tenkz): project label carrier bearings

### DIFF
--- a/tests/tenkz/kernel/regression/r_label_carriers_affine.tex
+++ b/tests/tenkz/kernel/regression/r_label_carriers_affine.tex
@@ -1,0 +1,207 @@
+% Regression: label marks read the complete affine basis of every confirmed
+% carrier spelling.  Bare cells and members, named member atoms, and named
+% cluster children and ports all project local north through the plane basis.
+% A relative point remains page-space, a flat carrier remains unchanged, and
+% neither picture changes its empty boundary signature.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\int_new:N \l__tenkz_test_carrier_label_count_int
+\int_new:N \l__tenkz_test_carrier_boundary_count_int
+\bool_new:N \l__tenkz_test_carrier_label_bool
+\tl_new:N \l__tenkz_test_carrier_label_tl
+\tl_new:N \l__tenkz_test_carrier_anchor_tl
+\tl_new:N \l__tenkz_test_carrier_style_tl
+\tl_new:N \l__tenkz_test_carrier_event_tl
+\fp_new:N \l__tenkz_test_carrier_centre_x_fp
+\fp_new:N \l__tenkz_test_carrier_centre_y_fp
+\fp_new:N \l__tenkz_test_carrier_bearing_fp
+\fp_new:N \l__tenkz_test_carrier_expected_x_fp
+\fp_new:N \l__tenkz_test_carrier_expected_y_fp
+\fp_new:N \l__tenkz_test_carrier_actual_x_fp
+\fp_new:N \l__tenkz_test_carrier_actual_y_fp
+\fp_new:N \l__tenkz_test_carrier_norm_fp
+
+\cs_new_eq:NN
+  \__tenkz_test_carrier_event:n
+  \__tenkz_kernel_event:n
+\cs_set_protected:Npn \__tenkz_kernel_event:n #1
+  {
+    \tl_set:Ne \l__tenkz_test_carrier_event_tl {#1}
+    \exp_args:NnV \regex_match:nnT
+      { \A \s* kernel-boundary } \l__tenkz_test_carrier_event_tl
+      {
+        \int_gincr:N \l__tenkz_test_carrier_boundary_count_int
+        \exp_args:NnV \regex_match:nnF
+          {
+            \A \s* kernel-boundary \s* \| \s* signature \s* = \s* \Z
+          }
+          \l__tenkz_test_carrier_event_tl
+          { \errmessage{label~carrier~fixture~changed~the~boundary~signature} }
+      }
+    \__tenkz_test_carrier_event:n {#1}
+  }
+
+\cs_new_eq:NN
+  \__tenkz_test_carrier_label_ink:n
+  \__tenkz_kernel_r_mark_label_ink:n
+\cs_set_protected:Npn \__tenkz_kernel_r_mark_label_ink:n #1
+  {
+    \int_gincr:N \l__tenkz_test_carrier_label_count_int
+    \__tenkz_model_get:nnN {#1} {label}
+      \l__tenkz_test_carrier_label_tl
+    \fp_set_eq:NN
+      \l__tenkz_test_carrier_centre_x_fp \l__tenkz_kernel_r_x_fp
+    \fp_set_eq:NN
+      \l__tenkz_test_carrier_centre_y_fp \l__tenkz_kernel_r_y_fp
+    \str_case:VnF \l__tenkz_test_carrier_label_tl
+      {
+        {C}{ \__tenkz_test_carrier_expect_plane: }
+        {B}{ \__tenkz_test_carrier_expect_plane: }
+        {M}{ \__tenkz_test_carrier_expect_plane: }
+        {H}{ \__tenkz_test_carrier_expect_plane: }
+        {P}{ \__tenkz_test_carrier_expect_plane: }
+        {R}{ \__tenkz_test_carrier_expect_page: }
+        {F}{ \__tenkz_test_carrier_expect_page: }
+      }
+      { \errmessage{unexpected~label~in~carrier~fixture} }
+    \fp_compare:nNnF
+      {
+        abs
+          (
+            90 + \l__tenkz_kernel_r_tau_tl
+            - \l__tenkz_test_carrier_bearing_fp
+          )
+      }
+      < {0.000001}
+      { \errmessage{label~target~lost~its~effective~bearing} }
+    \bool_set_true:N \l__tenkz_test_carrier_label_bool
+    \__tenkz_test_carrier_label_ink:n {#1}
+    \bool_set_false:N \l__tenkz_test_carrier_label_bool
+  }
+
+\cs_new_protected:Npn \__tenkz_test_carrier_expect_plane:
+  {
+    \fp_set:Nn \l__tenkz_test_carrier_bearing_fp
+      {
+        atand
+          (
+            \__tenkz_metric_ratio:n {planerise},
+            \__tenkz_metric_ratio:n {planeslant}
+          )
+      }
+    \fp_set:Nn \l__tenkz_test_carrier_norm_fp
+      {
+        sqrt
+          (
+            \__tenkz_metric_ratio:n {planeslant} ^ 2
+            + \__tenkz_metric_ratio:n {planerise} ^ 2
+          )
+      }
+    \fp_set:Nn \l__tenkz_test_carrier_expected_x_fp
+      {
+        \l__tenkz_test_carrier_centre_x_fp
+        + \__tenkz_metric_ratio:n {dotlabelband}
+          * \__tenkz_metric_ratio:n {planeslant}
+          / \l__tenkz_test_carrier_norm_fp
+      }
+    \fp_set:Nn \l__tenkz_test_carrier_expected_y_fp
+      {
+        \l__tenkz_test_carrier_centre_y_fp
+        + \__tenkz_metric_ratio:n {dotlabelband}
+          * \__tenkz_metric_ratio:n {planerise}
+          / \l__tenkz_test_carrier_norm_fp
+      }
+    \tl_set:Nn \l__tenkz_test_carrier_anchor_tl {south~west}
+  }
+
+\cs_new_protected:Npn \__tenkz_test_carrier_expect_page:
+  {
+    \fp_set:Nn \l__tenkz_test_carrier_bearing_fp {90}
+    \fp_set_eq:NN
+      \l__tenkz_test_carrier_expected_x_fp
+      \l__tenkz_test_carrier_centre_x_fp
+    \fp_set:Nn \l__tenkz_test_carrier_expected_y_fp
+      {
+        \l__tenkz_test_carrier_centre_y_fp
+        + \__tenkz_metric_ratio:n {dotlabelband}
+      }
+    \tl_set:Nn \l__tenkz_test_carrier_anchor_tl {south}
+  }
+
+\cs_new_eq:NN
+  \__tenkz_test_carrier_labelnode:nnn
+  \__tenkz_render_labelnode:nnn
+\cs_set_protected:Npn \__tenkz_render_labelnode:nnn #1#2#3
+  {
+    \bool_if:NT \l__tenkz_test_carrier_label_bool
+      {
+        \tl_set:Ne \l__tenkz_test_carrier_style_tl {#1}
+        \tl_if_in:NVF
+          \l__tenkz_test_carrier_style_tl
+          \l__tenkz_test_carrier_anchor_tl
+          { \errmessage{label~target~chose~the~wrong~anchor~sector} }
+        \path coordinate (tenkz-test-carrier-label) at #2;
+        \pgfpointanchor {tenkz-test-carrier-label} {center}
+        \fp_set:Nn \l__tenkz_test_carrier_actual_x_fp
+          {
+            \dim_to_fp:n { \use:c {pgf@x} }
+            / \dim_to_fp:n { \use:c {tenkz@pitch} }
+          }
+        \fp_set:Nn \l__tenkz_test_carrier_actual_y_fp
+          {
+            \dim_to_fp:n { \use:c {pgf@y} }
+            / \dim_to_fp:n { \use:c {tenkz@pitch} }
+          }
+        \fp_compare:nNnF
+          {
+            abs
+              (
+                \l__tenkz_test_carrier_actual_x_fp
+                - \l__tenkz_test_carrier_expected_x_fp
+              )
+          }
+          < {0.00001}
+          { \errmessage{label~target~lost~its~projected~x~displacement} }
+        \fp_compare:nNnF
+          {
+            abs
+              (
+                \l__tenkz_test_carrier_actual_y_fp
+                - \l__tenkz_test_carrier_expected_y_fp
+              )
+          }
+          < {0.00001}
+          { \errmessage{label~target~lost~its~projected~y~displacement} }
+      }
+    \__tenkz_test_carrier_labelnode:nnn {#1}{#2}{#3}
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[
+    lattice={1x5}, bonds=none,
+    frame={plane,basis={
+      wire at (0,0), wire at (4,0), wire at (0,4)}}]
+  \tn[at=(1,3,2), skin=box, name=M]{M}
+  \tn[at=(1,4,2), skin=box, name=G, cluster=2x2]{}
+  \tnmark[form=label, label pos=n]{(1,1)}{C}
+  \tnmark[form=label, label pos=n]{(1,2,2)}{B}
+  \tnmark[form=label, label pos=n]{M}{M}
+  \tnmark[form=label, label pos=n]{G-1-1}{H}
+  \tnmark[form=label, label pos=n]{G-1-2.90}{P}
+  \tnmark[form=label, label pos=n]{1 n of (1,5)}{R}
+\end{tenkz}
+\begin{tenkz}[lattice={1x1}, bonds=none, frame=flat]
+  \tnmark[form=label, label pos=n]{(1,1)}{F}
+\end{tenkz}
+\ExplSyntaxOn
+\int_compare:nNnF { \l__tenkz_test_carrier_label_count_int } = {7}
+  { \errmessage{label~carrier~fixture~did~not~render~seven~labels} }
+\int_compare:nNnF { \l__tenkz_test_carrier_boundary_count_int } = {2}
+  { \errmessage{label~carrier~fixture~did~not~inspect~both~boundaries} }
+\ExplSyntaxOff
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -5288,6 +5288,76 @@
       }
   }
 
+% The affine carrier of a label target, when it has one.  A cell and one of
+% its basis members share the frame chart at (row, column).  Named records
+% answer through the atom they name; a cluster child inherits the chart of
+% its named parent, and a port inherits the chart of its host.  Composite and
+% curve addresses deliberately answer false: relative, midway, crossing, and
+% on-wire nodes are page-space points rather than local-frame carriers.
+\tl_new:N \l__tenkz_kernel_carrier_parent_tl
+\tl_new:N \l__tenkz_kernel_carrier_record_tl
+\cs_new_protected:Npn \__tenkz_kernel_r_record_carrier:nNNN #1#2#3#4
+  {
+    \__tenkz_kernel_r_atom_rc:nNNN {#1} #2#3#4
+    \bool_if:NF #4
+      {
+        \__tenkz_model_get:nnN {#1} {cluster-of}
+          \l__tenkz_kernel_carrier_parent_tl
+        \quark_if_no_value:NF \l__tenkz_kernel_carrier_parent_tl
+          {
+            \prop_get:NVN \l__tenkz_kernel_named_prop
+              \l__tenkz_kernel_carrier_parent_tl
+              \l__tenkz_kernel_carrier_record_tl
+            \quark_if_no_value:NF \l__tenkz_kernel_carrier_record_tl
+              {
+                \exp_args:NV \__tenkz_kernel_r_record_carrier:nNNN
+                  \l__tenkz_kernel_carrier_record_tl #2#3#4
+              }
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_kernel_r_node_carrier:nNNN #1#2#3#4
+  {
+    \bool_set_false:N #4
+    \str_case:en
+      { \__tenkz_kernel_r_item:nn {#1} {kind} }
+      {
+        {cell}
+          {
+            \tl_set:Ne #2 { \__tenkz_kernel_r_item:nn {#1} {row} }
+            \tl_set:Ne #3 { \__tenkz_kernel_r_item:nn {#1} {col} }
+            \bool_set_true:N #4
+          }
+        {member}
+          {
+            \tl_set:Ne #2 { \__tenkz_kernel_r_item:nn {#1} {row} }
+            \tl_set:Ne #3 { \__tenkz_kernel_r_item:nn {#1} {col} }
+            \bool_set_true:N #4
+          }
+        {record}
+          {
+            \prop_get:NeN \l__tenkz_kernel_named_prop
+              { \__tenkz_kernel_r_item:nn {#1} {name} }
+              \l__tenkz_kernel_carrier_record_tl
+            \quark_if_no_value:NF \l__tenkz_kernel_carrier_record_tl
+              {
+                \exp_args:NV \__tenkz_kernel_r_record_carrier:nNNN
+                  \l__tenkz_kernel_carrier_record_tl #2#3#4
+              }
+          }
+        {port}
+          {
+            \__tenkz_kernel_r_port_record:nN {#1}
+              \l__tenkz_kernel_carrier_record_tl
+            \quark_if_no_value:NF \l__tenkz_kernel_carrier_record_tl
+              {
+                \exp_args:NV \__tenkz_kernel_r_record_carrier:nNNN
+                  \l__tenkz_kernel_carrier_record_tl #2#3#4
+              }
+          }
+      }
+  }
+
 % Resolve a live glyph anchor in the host's local axes and carry it to the
 % page.  Non-cell pairing ink and ordinary wires share this face boundary;
 % the placed address node remains only dependency geometry.
@@ -8626,26 +8696,11 @@
     \__tenkz_kernel_r_node:V \l__tenkz_kernel_r_node_tl
     \__tenkz_kernel_r_xy:nNN { \tl_use:N \l__tenkz_kernel_r_node_tl }
       \l__tenkz_kernel_r_x_fp \l__tenkz_kernel_r_y_fp
-    \tl_set:Nn \l__tenkz_kernel_r_tl { \q_no_value }
-    \str_case:en
-      { \__tenkz_kernel_node_item:Nn \l__tenkz_kernel_r_node_tl {kind} }
-      {
-        {record}
-          {
-            \prop_get:NeN \l__tenkz_kernel_named_prop
-              {
-                \__tenkz_kernel_node_item:Nn
-                  \l__tenkz_kernel_r_node_tl {name}
-              }
-              \l__tenkz_kernel_r_tl
-          }
-        {port}
-          {
-            \exp_args:NV \__tenkz_kernel_r_port_record:nN
-              \l__tenkz_kernel_r_node_tl \l__tenkz_kernel_r_tl
-          }
-      }
-    \quark_if_no_value:NF \l__tenkz_kernel_r_tl
+    \exp_args:NV \__tenkz_kernel_r_node_carrier:nNNN
+      \l__tenkz_kernel_r_node_tl
+      \l__tenkz_kernel_r_row_tl \l__tenkz_kernel_r_col_tl
+      \l__tenkz_kernel_turn_bool
+    \bool_if:NT \l__tenkz_kernel_turn_bool
       {
         \__tenkz_model_get:nnN {#1} {label-pos} \l__tenkz_kernel_r_c_tl
         \quark_if_no_value:NT \l__tenkz_kernel_r_c_tl
@@ -8658,8 +8713,10 @@
         % A label bearing is a carrier-local direction, just like a port
         % face.  Subtract its local angle again because the shared ink helper
         % below adds that angle to the carrier contribution.
-        \exp_args:NVV \__tenkz_kernel_r_page_face:nnN
-          \l__tenkz_kernel_r_tl \l__tenkz_kernel_r_c_tl
+        \__tenkz_geom_local_bearing:nnnnN {kpic}
+          { \l__tenkz_kernel_r_row_tl }
+          { \l__tenkz_kernel_r_col_tl }
+          { \l__tenkz_kernel_r_c_tl }
           \l__tenkz_kernel_r_tau_tl
         \tl_set:Ne \l__tenkz_kernel_r_tau_tl
           {


### PR DESCRIPTION
## Summary

- resolve the affine carrier of label targets through cells, basis members, named records, ports, and cluster-parent links
- carry authored local label bearings through the shared complete-basis geometry service
- preserve page-space behavior for relative, midpoint, crossing, on-wire, outside, and other carrierless targets
- add one analytic sheared-plane regression covering every confirmed carrier spelling, page-space fallback, flat fallback, displacement, anchor sector, and unchanged boundary signatures

## Root cause

Label targets were normalized before model freeze, but the renderer only recovered a carrier for record and port node kinds. Bare `(r,c)` and `(r,c,k)` targets therefore reset to page-square bearings, and cluster children inherited only a scalar turn. Under the default plane basis, local north should be `53.130102°` with displacement `(0.18, 0.24)` pitch units and a southwest anchor; the affected targets instead used page north `90°`, `(0, 0.30)`, and a south anchor.

The fix resolves only node kinds with a defined carrier and delegates projection to the complete-basis service from LionSR/TNLean#5179. It introduces no frame-specific formulas. Boundary signatures remain frozen logical-frame semantics and are unchanged.

Atom-owned dot labels and affine skin contours remain separate projection work.

## Validation

- focused XeLaTeX: new carrier fixture, `r_plane_projection.tex`, `r_label_turn.tex`
- `scripts/tenkz_kernel_probes.sh --check` — 51 regressions, 8 sugar equivalences, 12 byte-identical record streams, byte-identical existing pixels
- `python3 scripts/tenkz_language.py check` — 226 records
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main` — census 200; all 132 flags covered
- `scripts/tenkz_golden.sh --check` — all 264 existing event streams byte-identical
- independent resolver review found no actionable findings

Refs LionSR/tenkz#113

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches kernel label rendering and geometry projection for many target spellings, but behavior is narrowly scoped to carrier resolution and existing golden streams reportedly stay byte-identical.
> 
> **Overview**
> **Label marks** on affine carriers (bare cells/members, named atoms, cluster children, ports) now resolve a full frame chart and project authored local directions via `__tenkz_geom_local_bearing` instead of only handling record/port kinds with a partial turn model. Targets without a carrier (relative points, composites, etc.) still skip projection and keep page-space bearings.
> 
> New kernel helpers **`__tenkz_kernel_r_node_carrier`** / **`__tenkz_kernel_r_record_carrier`** walk node kind, named records, cluster parents, and port hosts to obtain row/column; **`__tenkz_kernel_r_mark_label`** wires that into the existing label ink path.
> 
> Adds **`r_label_carriers_affine.tex`** to assert plane vs page displacement, anchor sector, effective bearing, and unchanged boundary signatures across seven label spellings plus a flat frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee38601574e1d04d36bee110c62eed94bef84802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->