### PR TITLE
doc(MPS/MPDO): distinguish transfer retracts from physical RFP

### DIFF
--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -21,7 +21,7 @@ range. Thus such data exist at a fixed size precisely when `Eₙ` is idempotent;
 existence at every positive size is equivalent to idempotence of `E₁`.
 
 This range-subspace factorization is not the physical renormalization
-fixed-point condition of arXiv:1606.00608, Definition `RFPMixedTS`, lines
+fixed-point condition of arXiv:1606.00608, Definition RFPMixedTS, lines
 638--660. That definition requires trace-preserving completely positive maps
 on the physical indices; its Appendix C.4 construction appears at lines
 1974--2085. The predicate `IsRFPViaTS` records this physical-map condition.
@@ -46,7 +46,7 @@ recorded by `BNTFusionIsometryFamily`.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Definition
-  `RFPMixedTS`, lines 638--660, and Appendix C.4, lines 1974--2085, for the
+  RFPMixedTS, lines 638--660, and Appendix C.4, lines 1974--2085, for the
   distinct physical-map RFP condition.
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Theorem
   4.14(ii)--(iii), lines 972--991, for the BNT fusion maps.
@@ -156,7 +156,7 @@ transfer-map idempotence.
 The forward direction is the retract calculation
 \(E_1^2 = S_1T_1S_1T_1 = S_1T_1\).  The reverse direction factors the
 idempotent transfer map through its range.  This is a definitional unfolding:
-arXiv:1606.00608, Definition `RFPMixedTS`, lines 638--660, and Appendix C.4,
+arXiv:1606.00608, Definition RFPMixedTS, lines 638--660, and Appendix C.4,
 lines 1974--2085 construct physical trace-preserving CP maps, not this
 bond-space retract. -/
 theorem transferRetractData_one_iff_isRFP (M : MPOTensor d D) :

--- a/TNLean/MPS/MPDO/FusionIsometries.lean
+++ b/TNLean/MPS/MPDO/FusionIsometries.lean
@@ -9,23 +9,22 @@ import TNLean.MPS.MPDO.PureRecovery
 import TNLean.MPS.MPDO.RFP
 
 /-!
-# Transfer-retract formulations of the MPDO renormalization fixed point
+# Transfer retracts and fusion coisometries
 
-These definitions isolate the transfer-map content underlying the
-fusion-isometry picture of arXiv:1606.00608 Section 4.5
-(Cirac–Pérez-García–Schuch–Verstraete): they record when the blocked transfer
-map factors through its support algebra as a retract, which is the idempotence
-criterion, not the physical fusion isometry of two tensors into one. For each
-blocked size `n ≥ 1`, the doubled-index blocked tensor of an MPO has a blocked
-transfer map `Eₙ` acting on bond-space matrices, and the support algebra is
-modeled by a subspace through which `Eₙ` factors as a retract.
+The first definitions record a linear-algebraic factorization of a
+doubled-index blocked transfer map. At a fixed blocked size `n ≥ 1`,
+`TransferRetractData M n` specifies a subspace `𝒜ₙ`, a forward map
+`Tₙ : M_D(ℂ) → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ → M_D(ℂ)` with
+`Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`. These identities force `Eₙ² = Eₙ`;
+conversely any idempotent blocked transfer map factors canonically through its
+range. Thus such data exist at a fixed size precisely when `Eₙ` is idempotent;
+existence at every positive size is equivalent to idempotence of `E₁`.
 
-Concretely, `TransferRetractData M n` specifies a support subspace `𝒜ₙ`, a
-forward map `Tₙ : M_D(ℂ) → 𝒜ₙ`, and a backward map `Sₙ : 𝒜ₙ → M_D(ℂ)` with
-`Tₙ ∘ Sₙ = id_{𝒜ₙ}` and `Sₙ ∘ Tₙ = Eₙ`. The retract identity forces
-`Eₙ² = Eₙ`; conversely any idempotent blocked transfer map factors through its
-range. This yields an equivalence between `MPOTensor.IsRFP` and the
-transfer-retract formulation.
+This range-subspace factorization is not the physical renormalization
+fixed-point condition of arXiv:1606.00608, Definition `RFPMixedTS`, lines
+638--660. That definition requires trace-preserving completely positive maps
+on the physical indices; its Appendix C.4 construction appears at lines
+1974--2085. The predicate `IsRFPViaTS` records this physical-map condition.
 
 The source-faithful active-support fusion maps of Theorem 4.14(iii) are recorded
 by `BNTFusionCoisometryFamily`. Their stronger full-support specialization is
@@ -37,16 +36,20 @@ recorded by `BNTFusionIsometryFamily`.
   MPS tensor.
 * `TransferRetractData`: retract structure whose characteristic identity is the
   blocked transfer map.
-* `IsRFP_MPDO_via_transferRetract`: existence of such structures for every positive blocked
-  size.
-* `isRFP_MPDO_via_transferRetract_iff_isRFP`: equivalence with the MPDO RFP predicate.
+* `IsRFP_MPDO_via_transferRetract`: existence of such structures for every
+  positive blocked size.
+* `isRFP_MPDO_via_transferRetract_iff_isRFP`: equivalence with doubled-index
+  transfer-map idempotence.
 * `MPSTensor.toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent`:
   pure-state recovery for the diagonal MPO embedding.
 
 ## References
 
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Section 4.5
-  (Cirac–Pérez-García–Schuch–Verstraete, Ann. Phys. 378, 100–149).
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Definition
+  `RFPMixedTS`, lines 638--660, and Appendix C.4, lines 1974--2085, for the
+  distinct physical-map RFP condition.
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608, Theorem
+  4.14(ii)--(iii), lines 972--991, for the BNT fusion maps.
 -/
 
 open scoped Matrix BigOperators
@@ -83,13 +86,13 @@ map to the corresponding power. -/
 
 /-- Transfer-retract datum at blocked size `n`.
 
-A support subspace of bond-space matrices together with a retract whose
-characteristic map is the blocked transfer map.  This is the
-transfer-map-level content of the idempotence criterion, not the paper's
-physical fusion map (see `BNTFusionCoisometryFamily` for the active-support
-family and `BNTFusionIsometryFamily` for its full-support specialization). -/
+A subspace of bond-space matrices together with a retract whose characteristic
+map is the blocked transfer map. This is a range-subspace factorization of the
+doubled-index idempotence criterion, not the paper's physical RFP map (see
+`IsRFPViaTS`) or its BNT fusion coisometries (see
+`BNTFusionCoisometryFamily`). -/
 structure TransferRetractData (M : MPOTensor d D) (n : ℕ) where
-  /-- The support subspace through which the blocked transfer map factors. -/
+  /-- The subspace through which the blocked transfer map factors. -/
   supportAlgebra : Submodule ℂ (FusionBondSpace D)
   /-- Forward map `T_n : M_D(ℂ) → 𝒜_n`. -/
   T : FusionBondSpace D →ₗ[ℂ] supportAlgebra
@@ -141,19 +144,21 @@ noncomputable def ofBlockedTransferMapIdempotent
       (blockedTransferMap M n).range
       (fun x => ⟨x, rfl⟩)
 
-/-- A level-`1` transfer-retract witness implies the MPDO RFP condition. -/
+/-- A level-`1` transfer retract implies doubled-index transfer-map idempotence. -/
 theorem isRFP (F : TransferRetractData M 1) : IsRFP M := by
   simpa only [IsRFP, blockedTransferMap_one] using F.blockedTransferMap_idempotent
 
 end TransferRetractData
 
-/-- A one-site transfer-retract datum is equivalent to the MPDO RFP condition.
+/-- A one-site transfer-retract datum is equivalent to doubled-index
+transfer-map idempotence.
 
 The forward direction is the retract calculation
 \(E_1^2 = S_1T_1S_1T_1 = S_1T_1\).  The reverse direction factors the
 idempotent transfer map through its range.  This is a definitional unfolding:
-the source's Appendix C.4 constructs physical trace-preserving CP maps on the
-physical indices, not this bond-space retract. -/
+arXiv:1606.00608, Definition `RFPMixedTS`, lines 638--660, and Appendix C.4,
+lines 1974--2085 construct physical trace-preserving CP maps, not this
+bond-space retract. -/
 theorem transferRetractData_one_iff_isRFP (M : MPOTensor d D) :
     Nonempty (TransferRetractData M 1) ↔ IsRFP M := by
   constructor
@@ -163,37 +168,37 @@ theorem transferRetractData_one_iff_isRFP (M : MPOTensor d D) :
     exact ⟨TransferRetractData.ofBlockedTransferMapIdempotent
       (M := M) (n := 1) (by simpa only [IsRFP, blockedTransferMap_one] using hM)⟩
 
-/-- If `M` is already an MPDO renormalization fixed point, then every positive
-blocked transfer map coincides with the original transfer map. -/
+/-- Under doubled-index transfer-map idempotence, every positive blocked
+transfer map coincides with the original transfer map. -/
 theorem blockedTransferMap_eq_transferMap_of_isRFP {M : MPOTensor d D}
     (hM : IsRFP M) {n : ℕ} (hn : 0 < n) :
     blockedTransferMap M n = transferMap M := by
   have hIdem : IsIdempotentElem (transferMap M) := hM
   simpa only [blockedTransferMap_eq_pow] using hIdem.pow_eq (Nat.ne_of_gt hn)
 
-/-- Under the MPDO RFP condition, every positive blocked transfer map is
-idempotent. -/
+/-- Under doubled-index transfer-map idempotence, every positive blocked
+transfer map is idempotent. -/
 theorem blockedTransferMap_idempotent_of_isRFP {M : MPOTensor d D}
     (hM : IsRFP M) {n : ℕ} (hn : 0 < n) :
     blockedTransferMap M n ∘ₗ blockedTransferMap M n = blockedTransferMap M n := by
   rw [blockedTransferMap_eq_transferMap_of_isRFP hM hn]
   exact hM
 
-/-- Transfer-retract formulation of the MPDO RFP condition.
+/-- All-positive-blocking transfer-retract predicate.
 
 For every positive blocked size `n`, the blocked transfer map of `M` factors as
-`S_n ∘ T_n` through some support subspace `𝒜_n`, with `T_n ∘ S_n = id_{𝒜_n}`. -/
+`S_n ∘ T_n` through a subspace `𝒜_n`, with `T_n ∘ S_n = id_{𝒜_n}`. -/
 def IsRFP_MPDO_via_transferRetract (M : MPOTensor d D) : Prop :=
   ∀ n : ℕ, 0 < n → Nonempty (TransferRetractData M n)
 
-/-- The transfer-retract formulation implies the MPDO RFP condition. -/
+/-- The transfer-retract predicate implies doubled-index transfer-map idempotence. -/
 theorem isRFP_of_isRFP_MPDO_via_transferRetract {M : MPOTensor d D}
     (hM : IsRFP_MPDO_via_transferRetract M) : IsRFP M := by
   obtain ⟨F⟩ := hM 1 Nat.one_pos
   exact F.isRFP
 
-/-- An MPDO renormalization fixed point admits transfer-retract structures at
-every positive blocking size. -/
+/-- Doubled-index transfer-map idempotence gives transfer retracts at every
+positive blocking size. -/
 theorem isRFP_MPDO_via_transferRetract_of_isRFP {M : MPOTensor d D}
     (hM : IsRFP M) : IsRFP_MPDO_via_transferRetract M := by
   intro n hn
@@ -202,8 +207,8 @@ theorem isRFP_MPDO_via_transferRetract_of_isRFP {M : MPOTensor d D}
     (n := n)
     (blockedTransferMap_idempotent_of_isRFP hM hn)⟩
 
-/-- The transfer-retract formulation is equivalent to the current mixed-state
-RFP predicate. -/
+/-- The transfer-retract predicate is equivalent to doubled-index transfer-map
+idempotence. -/
 theorem isRFP_MPDO_via_transferRetract_iff_isRFP (M : MPOTensor d D) :
     IsRFP_MPDO_via_transferRetract M ↔ IsRFP M := by
   constructor
@@ -226,8 +231,8 @@ open MPOTensor
 
 variable {d D : ℕ}
 
-/-- For a pure MPS embedded diagonally as an MPO, the transfer-retract
-formulation recovers the original pure-state RFP condition. -/
+/-- For a pure MPS embedded diagonally as an MPO, transfer retracts are
+equivalent to transfer-map idempotence. -/
 theorem toMPOTensor_isRFP_MPDO_via_transferRetract_iff_isTransferIdempotent (A : MPSTensor d D) :
     MPOTensor.IsRFP_MPDO_via_transferRetract A.toMPOTensor ↔ IsTransferIdempotent A := by
   rw [MPOTensor.isRFP_MPDO_via_transferRetract_iff_isRFP,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_foundations.tex
@@ -1,16 +1,19 @@
-\section{Fusion isometries}
+\section{Transfer retracts and fusion coisometries}
 
-The next definitions isolate the transfer-map content underlying the
-fusion-isometry picture of \cite[Section~4.5]{Cirac2016MPDO_arXiv}: they record
-when the blocked transfer map factors through its support algebra as a retract,
-which is the idempotence criterion, not the physical fusion isometry of two
-tensors into one. For each blocked size $n \ge 1$, the doubled-index blocked
-tensor of an MPO has a blocked transfer map $E_n$ acting on bond-space matrices,
-and the support algebra is modeled by a subspace through which $E_n$ factors as
-a retract. The active-support fusion coisometries of
-\cite[Theorem~4.14(iii)]{Cirac2016MPDO_arXiv}, and their stronger full-support
-specialization, are recorded at the end of this section, together with the
-derivation of the same-length product law from them.
+The first definitions concern a linear-algebraic factorization of a
+doubled-index blocked transfer map. At a fixed blocked size $n \ge 1$, such a
+factorization exists precisely when $E_n$ is idempotent. Requiring it at every
+positive blocked size is equivalent to idempotence of $E_1$. This is distinct
+from the physical renormalization fixed-point condition in
+Definition~\ref{def:is_rfp_via_ts} and
+\cite[Definition~4.1, lines 638--660]{Cirac2016MPDO_arXiv}, which requires
+trace-preserving completely positive maps on the physical indices. The
+physical maps constructed in Appendix~C.4 likewise act on physical indices
+\cite[lines 1974--2085]{Cirac2016MPDO_arXiv}. The active-support fusion
+coisometries of
+\cite[Theorem~4.14(ii)--(iii), lines 972--991]{Cirac2016MPDO_arXiv}, and their
+stronger full-support specialization, are recorded at the end of this section,
+together with the derivation of the same-length product law from them.
 
 \begin{definition}[Transfer-retract datum]%
     \label{def:mpdo_fusion_isometry}
@@ -33,15 +36,14 @@ derivation of the same-length product law from them.
     where $E_n$ denotes the blocked transfer map.
 \end{definition}
 
-\begin{definition}[Transfer-retract RFP predicate]%
+\begin{definition}[All-positive-blocking transfer-retract predicate]%
     \label{def:mpdo_rfp_via_fusion}
     \lean{MPOTensor.IsRFP_MPDO_via_transferRetract}
     \leanok
     \uses{def:mpdo_fusion_isometry, def:mpo_tensor}
-    An MPO tensor $M$ satisfies the \emph{transfer-retract formulation} of the
-    renormalization fixed-point condition when for every blocked size $n \ge 1$
-    there exists transfer-retract data for the blocked transfer
-    map $E_n$.
+    An MPO tensor $M$ satisfies the \emph{all-positive-blocking
+    transfer-retract predicate} when for every blocked size $n \ge 1$ there
+    exists transfer-retract data for the blocked transfer map $E_n$.
 \end{definition}
 
 \begin{theorem}[Transfer-retract data imply transfer-map idempotence]%
@@ -102,7 +104,7 @@ derivation of the same-length product law from them.
     \leanok
     \uses{thm:mpdo_rfp_via_fusion_iff}
     For the diagonal MPO associated to a pure MPS tensor, the transfer-retract
-    formulation reduces to the usual pure-state RFP condition.
+    predicate is equivalent to transfer-map idempotence.
 \end{corollary}
 \begin{proof}\leanok
     Combine Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} with the diagonal pure-state

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -74,7 +74,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_foundations.tex` | — | L63, 67 `tenkz` → `C-policy+C-record` | — |
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
-| `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L400, 641, 647, 654, 661, 669, 674 `tnpic` → `C-picture+C-record+R-record`<br>L407 `tnpic` → `C-picture+C-policy+C-record+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L420, 422 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L283 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L734 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L736, 739, 742, 745 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |


### PR DESCRIPTION
### Motivation

- The transfer-retract documentation still identified a bond-space range
  factorization with the physical renormalization maps of CPSV16.
- In `Papers/1606.00608/MPDO-22-12-17-2.tex`, Definition `RFPMixedTS`
  (lines 638–660) requires two trace-preserving completely positive maps acting
  on physical indices. Appendix C.4 (lines 1974–2085) likewise studies physical
  maps and their restrictions.
- Theorem 4.14(ii)–(iii) (lines 972–991) separately gives the BNT coefficient
  and fusion-map structure.

### Description

- Describe `TransferRetractData` as a range-subspace factorization of the
  doubled-index blocked transfer map.
- State the fixed-size and all-positive-size idempotence equivalences precisely.
- Distinguish this linear factorization from the physical-map predicate
  `IsRFPViaTS`.
- Synchronize the Chapter 21 Blueprint introduction and retain the separate
  Theorem 4.14(ii)–(iii) citation for BNT fusion coisometries.
- Refresh the tenkz Blueprint inventory line anchors shifted by the prose edit.
- Keep every public declaration unchanged; this PR introduces no API rename.

### Testing

- `lake build TNLean.MPS.MPDO.FusionIsometries -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/test_check_tenkz_demolition.py`
- `python3 scripts/check_tenkz_demolition.py`
- `python3 scripts/test_check_tenkz_dispositions.py`
- `python3 scripts/check_tenkz_dispositions.py`
- `rg -n "sorry|axiom" TNLean/MPS/MPDO/FusionIsometries.lean || true`
- `git diff origin/main...HEAD --check`

Closes #5181

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and Blueprint prose only; no Lean API or proof changes.
> 
> **Overview**
> **Documentation-only** — public Lean names and proofs are unchanged.
> 
> The module doc and docstrings in `FusionIsometries.lean` are reframed around **transfer retracts and fusion coisometries**: `TransferRetractData` is described as a **range-subspace factorization** of the doubled-index blocked transfer map, with explicit idempotence equivalences at one site and at all positive block sizes. Wording that suggested this retract was the paper’s physical renormalization picture is removed; instead the text contrasts the construction with **Definition RFPMixedTS** (physical trace-preserving CP maps, Appendix C.4) and points readers to **`IsRFPViaTS`** for that condition and to **`BNTFusionCoisometryFamily`** / **`BNTFusionIsometryFamily`** for Theorem 4.14(ii)–(iii). Theorem and predicate docstrings now say **doubled-index transfer-map idempotence** rather than “MPDO RFP” where that was ambiguous.
> 
> The Blueprint section **`ch21_mpdo_rfp_fusion_isometries_foundations.tex`** is retitled to match, with the same conceptual separation from `def:is_rfp_via_ts` and CPSV16 line citations; the global predicate is renamed in prose to the **all-positive-blocking transfer-retract predicate**, and the pure-state corollary states equivalence with transfer-map idempotence.
> 
> **`docs/tenkz/DISPOSITIONS.md`** only updates `\tnpic` line anchors for that chapter after the prose edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aea02652f39b0f0ae482619a6e76163ae0dc927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->