### PR TITLE
chore: remove stale linter suppressions in four modules

### DIFF
--- a/TNLean/MPS/Structure/BlockPermutation.lean
+++ b/TNLean/MPS/Structure/BlockPermutation.lean
@@ -36,7 +36,6 @@ Technical note on the two-level algebraic structure:
 * `algEquiv_pi_matrix_decomposition` — the main decomposition theorem
 -/
 
-set_option linter.unusedSectionVars false
 set_option linter.unusedFintypeInType false
 set_option linter.style.show false
 

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
@@ -481,7 +481,6 @@ term is the host label itself: any configuration realizing `b₂` with `P₀`-ou
 same union host label as `q₀` by the partition determinacy, so the fiber coefficient at the host
 label is forced to vanish. -/
 
-set_option linter.unusedSectionVars false in
 omit [DecidableEq V] in
 open scoped Classical in
 /-- Transport of host annihilation along a region-set equality: if a coefficient family `c`
@@ -503,7 +502,6 @@ theorem hc_transport {S R : Finset V} (h : S = R)
   simp only []
   rw [hb]
 
-set_option linter.unusedSectionVars false in
 omit [Fintype V] in
 open scoped Classical in
 /-- **Union host-boundary surjectivity.** With positive bond dimensions, every union `R₁ ∪ R₂`

--- a/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
@@ -486,9 +486,9 @@ theorem fullContraction_eq
 /-! ### Operator-Schmidt uniqueness: the bond gauge -/
 
 -- The shared-bond `Fintype` instances are used in the proof (to sum over
--- `SharedBondConfig bondDim`) but not reflected in the statement, so the
--- `unusedFintypeInType` linter cannot see them.
-set_option linter.unusedFintypeInType false in
+-- `SharedBondConfig bondDim`) but not reflected in the statement, so they are
+-- omitted from the type and supplied by `classical` in the body.
+omit [Fintype Bond] [(b : Bond) → Fintype (bondDim b)] in
 open scoped Classical in
 /-- Config-indexed linear independence from joint injectivity.
 

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -33,11 +33,6 @@ the non-strict, ties-allowed order used in the reduction to canonical form.
 - Canonical-form conditions: `IsCanonicalForm` and `IsNormalCanonicalForm`.
 -/
 
-set_option linter.unusedSectionVars false
-set_option linter.unusedVariables false
-set_option linter.style.longLine false
-set_option linter.unusedSimpArgs false
-
 open scoped Matrix BigOperators
 
 namespace MPSTensor


### PR DESCRIPTION
Removes linter suppressions that the v4.32 upgrade left behind, fixing the underlying warning rather than renaming the suppression.

- `TNLean/PiAlgebra/CanonicalFormSepAux.lean` — four file-level suppressions removed (`unusedSectionVars`, `unusedVariables`, `style.longLine`, `unusedSimpArgs`). This is the most valuable of the four, since a file-level `style.longLine` suppression silently exempted the whole file from the hundred-character rule.
- `TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean` — two stale `unusedSectionVars` suppressions removed.
- `TNLean/PEPS/TwoInjectiveComparison/Basic.lean` — `unusedFintypeInType` suppression replaced by `omit`, which states the same fact declaratively instead of muting the linter.
- `TNLean/MPS/Structure/BlockPermutation.lean` — stale `unusedSectionVars` suppression removed.

No theorem statement or proof changes; no new suppressions introduced.

Not addressed here, so this does not close the issue: the four suppressions in `TNLean/Algebra/MatrixRankClosed.lean` (lines 71--72 and 118--119) remain, as do occurrences in `Analysis/LiebOperatorIntegral.lean`, `MPS/Examples/MajumdarGhosh.lean`, and the `Archive/` tree, which is excluded from the root imports. The `matrixAbs` wrapper half of the issue appears already complete: no `matrixAbs` occurrences remain anywhere under `TNLean/`.

Progresses #4037

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Linter and comment-only edits with no mathematical or API changes; the `omit` in `TwoInjectiveComparison/Basic.lean` is the same pattern already used elsewhere in that file.
> 
> **Overview**
> Removes **file- and local-level linter suppressions** that were no longer needed after the v4.32 upgrade, so warnings are addressed instead of hidden.
> 
> In **`CanonicalFormSepAux.lean`**, four file-level options are dropped (`unusedSectionVars`, `unusedVariables`, `style.longLine`, `unusedSimpArgs`), including a **`style.longLine`** mute that had exempted the whole file from the line-length rule.
> 
> **`UnionInjectivityOverlap6.lean`** and **`BlockPermutation.lean`** lose obsolete **`unusedSectionVars`** `set_option`s before specific theorems.
> 
> In **`TwoInjectiveComparison/Basic.lean`**, **`unusedFintypeInType false`** before `IsTwoBlockInjective.config_linearIndependent` is replaced by **`omit [Fintype Bond] …`**, matching how other lemmas in that file declare that `Fintype` data is only needed in proofs (via `classical`), not in the theorem statement. Comments are adjusted accordingly.
> 
> **No theorem statements or proofs change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61e027077bf89dbaaf541fe7f385f658fccfa4d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->