### PR TITLE
feat(MPS/RFP): derive basis-direct-sum RFP from NNCPH

### DIFF
--- a/TNLean/MPS/Periodic/Applications.lean
+++ b/TNLean/MPS/Periodic/Applications.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.FundamentalTheorem.Basic
 import TNLean.MPS.Periodic.Defs
 import TNLean.Channel.KrausRepresentation
+import TNLean.Spectral.MixedTransfer
 
 /-!
 Copyright (c) 2026 TNLean contributors. All rights reserved.
@@ -166,6 +167,52 @@ theorem transferMap_rotatePhysical (A : MPSTensor d D) (u : Matrix (Fin d) (Fin 
   ext X : 1
   simp only [transferMap_apply, rotatePhysical_apply]
   exact kraus_same_map_of_unitary_combination _ A u (mul_eq_one_comm.mp hu) (fun _ => rfl) X
+
+/-- A common unitary rotation of the physical index leaves the rectangular
+mixed transfer map unchanged. -/
+theorem mixedTransferMap₂_rotatePhysical {D₁ D₂ : ℕ}
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (u : Matrix (Fin d) (Fin d) ℂ) (hu : u * uᴴ = 1) :
+    mixedTransferMap₂ (rotatePhysical u A) (rotatePhysical u B) =
+      mixedTransferMap₂ A B := by
+  ext X : 1
+  simp only [mixedTransferMap₂_apply, rotatePhysical_apply]
+  have hu' : uᴴ * u = 1 := mul_eq_one_comm.mp hu
+  have hU : ∀ j k : Fin d,
+      ∑ i : Fin d, starRingEnd ℂ (u i j) * u i k = if j = k then 1 else 0 := by
+    intro j k
+    have h := congrArg (fun M : Matrix (Fin d) (Fin d) ℂ => M j k) hu'
+    simpa [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply] using h
+  have star_eq : ∀ (c : ℂ), star c = starRingEnd ℂ c := fun _ => rfl
+  simp_rw [Matrix.conjTranspose_sum, Matrix.conjTranspose_smul, star_eq,
+    Matrix.sum_mul, Matrix.mul_sum]
+  rw [Finset.sum_comm]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [Finset.sum_comm]
+  have factor : ∀ k : Fin d,
+      ∑ i : Fin d, (u i j * starRingEnd ℂ (u i k)) •
+          (A j * X * (B k)ᴴ) =
+        (if k = j then (1 : ℂ) else 0) • (A j * X * (B k)ᴴ) := by
+    intro k
+    rw [← Finset.sum_smul]
+    convert congrArg (fun c : ℂ => c • (A j * X * (B k)ᴴ)) (hU k j) using 1
+    simp [mul_comm]
+  have hExpand :
+      (∑ k : Fin d, ∑ i : Fin d,
+        u i j • A j * X * starRingEnd ℂ (u i k) • (B k)ᴴ) =
+      ∑ k : Fin d, ∑ i : Fin d,
+        (u i j * starRingEnd ℂ (u i k)) • (A j * X * (B k)ᴴ) := by
+    apply Finset.sum_congr rfl
+    intro k _
+    apply Finset.sum_congr rfl
+    intro i _
+    ext a b
+    simp only [Matrix.smul_mul, Matrix.mul_smul, Matrix.smul_apply, smul_eq_mul]
+    ring
+  rw [hExpand]
+  simp only [factor, ite_smul, one_smul, zero_smul]
+  simp [Finset.mem_univ]
 
 /-! ### Left-canonical preservation under rotation -/
 

--- a/TNLean/MPS/Periodic/Applications.lean
+++ b/TNLean/MPS/Periodic/Applications.lean
@@ -24,8 +24,9 @@ corollary belongs to Section 4.2. It contains:
 2. A **periodic-form theorem** that isolates the periodic equal-case FT input
    for the symmetry corollary of arXiv:1708.00029, Section 4.2.
 3. **Preservation lemmas** showing that unitary rotation of the physical index
-   preserves the transfer map, left-canonical normalization, irreducibility,
-   periodicity, and irreducible form II structure.
+   preserves transfer maps, rectangular mixed transfer maps, left-canonical
+   normalization, irreducibility, periodicity, and irreducible form II
+   structure.
 
 ## Status for Section 4 (as of merged periodic FT theory)
 

--- a/TNLean/MPS/RFP/BNTDirectSumBasis.lean
+++ b/TNLean/MPS/RFP/BNTDirectSumBasis.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.MPS.BNT.Bridge
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.Periodic.NormalizedSelfOverlap
 import TNLean.MPS.RFP.BNTOrthogonality
@@ -92,12 +93,9 @@ multiplicity-one, unit-weight direct sum. -/
 theorem isBNT_basisDirectSum
     (hCF : IsBNTCanonicalForm P) :
     IsBNT (directSumTensor P.basis) P.basisCount P.basisDim P.basis := by
-  refine ⟨hCF.basis_isNormal, ?_, hCF.bnt_data⟩
-  intro N _hN
-  refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
-  rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis,
-    mpv_toTensorFromBlocks_eq_sum]
-  simp
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  exact hCF.isCPSVBasisOfNormalTensors_basisDirectSum.isBNT
 
 end IsBNTCanonicalForm
 

--- a/TNLean/MPS/RFP/BNTDirectSumBasis.lean
+++ b/TNLean/MPS/RFP/BNTDirectSumBasis.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.RFP.BNTOrthogonality
 
 This file proves that the multiplicity-one unit-weight direct-sum representative
 of a BNT canonical form is in literal CPSV canonical form and that its distinct
-blocks form a CPSV basis of normal tensors.
+blocks form both a CPSV basis of normal tensors and an algebraic BNT.
 -/
 
 open scoped Matrix BigOperators
@@ -81,6 +81,18 @@ theorem isCPSVBasisOfNormalTensors_basisDirectSum
         (hCF.basis_isNormal j) (hCF.basis_left_canonical j)
     spans_mpv := ?_
     eventually_li := by exact hCF.bnt_data }
+  intro N _hN
+  refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
+  rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis,
+    mpv_toTensorFromBlocks_eq_sum]
+  simp
+
+/-- The distinct basis tensors form an algebraic BNT for their
+multiplicity-one, unit-weight direct sum. -/
+theorem isBNT_basisDirectSum
+    (hCF : IsBNTCanonicalForm P) :
+    IsBNT (directSumTensor P.basis) P.basisCount P.basisDim P.basis := by
+  refine ⟨hCF.basis_isNormal, ?_, hCF.bnt_data⟩
   intro N _hN
   refine ⟨fun _ ↦ 1, fun σ ↦ ?_⟩
   rw [← toTensorFromBlocks_one_eq_directSumTensor P.basis,

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -417,7 +417,8 @@ private theorem BeigiSectorGraphData.eventually_mpvState_mem_span_normalizedMini
 
 /-- Each BNT component in an all-chain NNCPH ground-space family eventually
 belongs to the span of the normalized minimal-loop MPV states. -/
-private theorem BeigiSectorGraphData.eventually_component_mpvState_mem_loopSpan
+private theorem
+    BeigiSectorGraphData.eventually_component_mpvState_mem_span_normalizedMinimalLoopTensor
     {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
     {B : MPSTensor d D} (F : BeigiSectorGraphData B)
     (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
@@ -564,7 +565,9 @@ theorem isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces
       (hBasisNormal j) F.normalizedMinimalLoopTensor hLoopNormal
     · intro l m hlm
       exact F.normalizedMinimalLoopTensor_overlap_tendsto_zero hlm
-    · exact F.eventually_component_mpvState_mem_loopSpan hparent hNNCPH j
+    · exact
+        F.eventually_component_mpvState_mem_span_normalizedMinimalLoopTensor
+          hparent hNNCPH j
   let loopOf (j : Fin P.basisCount) : Loop F.edgeWeight :=
     (hPhaseExists j).choose
   have hPhase (j : Fin P.basisCount) :

--- a/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
+++ b/TNLean/MPS/RFP/BeigiLoopBNTIdentification.lean
@@ -8,6 +8,8 @@ import TNLean.MPS.BNT.Basic
 import TNLean.MPS.Overlap.NormalTensorDichotomy
 import TNLean.MPS.RFP.BeigiLoopFixedPoint
 import TNLean.MPS.RFP.BeigiSectorGraphConstruction
+import TNLean.MPS.RFP.BNTDirectSumBasis
+import TNLean.MPS.RFP.ResidualIsometry
 import TNLean.MPS.RFP.StructuralForm
 import TNLean.Wielandt.Primitivity.Equivalence
 
@@ -25,6 +27,10 @@ arXiv:0909.5347, Proposition 3, together with the Perron--Frobenius theorem for 
 completely positive maps (Wolf, Theorem 6.3). The companion conversion from an algebraically
 normal left-canonical tensor is `isNormalTensor_of_isNormal_leftCanonical` in
 `TNLean/MPS/CanonicalForm/NormalTensorGauge.lean`.
+
+The final theorem applies the comparison familywise to the distinct BNT basis
+sectors and derives transfer idempotence of their multiplicity-one, unit-weight
+direct sum from the all-chain NNCPH ground-space condition.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -344,32 +350,21 @@ private theorem BeigiSectorGraphData.normalizedMinimalLoopTensor_overlap_tendsto
     F.mpvState_normalizedMinimalLoopTensor m]
   simp [F.loopProductStateES_inner_eq_zero_of_ne hlm]
 
-/-- The periodic MPV state of the NNCPH tensor eventually belongs to the span of the normalized
-minimal loop MPV states. -/
-private theorem BeigiSectorGraphData.eventually_mpvState_mem_span_normalizedMinimalLoopTensor
-    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
-    {B : MPSTensor d D} (F : BeigiSectorGraphData B)
+/-- A periodic MPV state in the parent ground space belongs to the span of the
+normalized minimal-loop MPV states. -/
+private theorem BeigiSectorGraphData.mpvState_mem_span_normalizedMinimalLoopTensor
+    {D' : ℕ} {B : MPSTensor d D} (F : BeigiSectorGraphData B)
     (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
       Module.finrank ℂ (parentHamiltonianGroundSpaceES B 2 N) = c)
-    (hNNCPH : HasNNCPHGroundSpaces B A) :
-    ∀ᶠ N in Filter.atTop,
-      mpvState (d := d) B N ∈
-        Submodule.span ℂ (Set.range fun l : Loop F.edgeWeight =>
-          mpvState (d := d) (F.normalizedMinimalLoopTensor l) N) := by
-  refine Filter.eventually_atTop.mpr ⟨3, ?_⟩
-  intro N hN
-  have hTwo : 2 < N := by omega
+    {C : MPSTensor d D'} {N : ℕ} (hN : 2 < N)
+    (hGround :
+      mpvState (d := d) C N ∈ parentHamiltonianGroundSpaceES B 2 N) :
+    mpvState (d := d) C N ∈
+      Submodule.span ℂ (Set.range fun l : Loop F.edgeWeight =>
+        mpvState (d := d) (F.normalizedMinimalLoopTensor l) N) := by
   letI : NeZero N := ⟨by omega⟩
-  have hGround : mpvState (d := d) B N ∈ parentHamiltonianGroundSpaceES B 2 N := by
-    rw [parentHamiltonianGroundSpaceES, Submodule.mem_map]
-    refine ⟨(mpv B : NSiteSpace d N), ?_, rfl⟩
-    rw [LinearMap.mem_ker, parentHamiltonian]
-    rw [LinearMap.sum_apply]
-    apply Finset.sum_eq_zero
-    intro i _hi
-    exact (hNNCPH N hTwo).isFrustrationFree i
-  have hLoopSpan := F.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES hparent hTwo
-  have hInLoopSpan : mpvState (d := d) B N ∈
+  have hLoopSpan := F.span_loopProductStateES_eq_parentHamiltonianGroundSpaceES hparent hN
+  have hInLoopSpan : mpvState (d := d) C N ∈
       Submodule.span ℂ
         (Set.range fun l : Loop F.edgeWeight => F.loopProductStateES l) := by
     rw [hLoopSpan]
@@ -395,6 +390,54 @@ private theorem BeigiSectorGraphData.eventually_mpvState_mem_span_normalizedMini
   rw [hEq]
   exact hScaled
 
+/-- The periodic MPV state of the NNCPH tensor eventually belongs to the span of the normalized
+minimal loop MPV states. -/
+private theorem BeigiSectorGraphData.eventually_mpvState_mem_span_normalizedMinimalLoopTensor
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    {B : MPSTensor d D} (F : BeigiSectorGraphData B)
+    (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
+      Module.finrank ℂ (parentHamiltonianGroundSpaceES B 2 N) = c)
+    (hNNCPH : HasNNCPHGroundSpaces B A) :
+    ∀ᶠ N in Filter.atTop,
+      mpvState (d := d) B N ∈
+        Submodule.span ℂ (Set.range fun l : Loop F.edgeWeight =>
+          mpvState (d := d) (F.normalizedMinimalLoopTensor l) N) := by
+  refine Filter.eventually_atTop.mpr ⟨3, ?_⟩
+  intro N hN
+  have hTwo : 2 < N := by omega
+  have hGround : mpvState (d := d) B N ∈ parentHamiltonianGroundSpaceES B 2 N := by
+    rw [parentHamiltonianGroundSpaceES, Submodule.mem_map]
+    refine ⟨(mpv B : NSiteSpace d N), ?_, rfl⟩
+    rw [LinearMap.mem_ker, parentHamiltonian]
+    rw [LinearMap.sum_apply]
+    apply Finset.sum_eq_zero
+    intro i _hi
+    exact (hNNCPH N hTwo).isFrustrationFree i
+  exact F.mpvState_mem_span_normalizedMinimalLoopTensor hparent hTwo hGround
+
+/-- Each BNT component in an all-chain NNCPH ground-space family eventually
+belongs to the span of the normalized minimal-loop MPV states. -/
+private theorem BeigiSectorGraphData.eventually_component_mpvState_mem_loopSpan
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    {B : MPSTensor d D} (F : BeigiSectorGraphData B)
+    (hparent : ∃ c N₀ : ℕ, ∀ N : ℕ, N₀ < N →
+      Module.finrank ℂ (parentHamiltonianGroundSpaceES B 2 N) = c)
+    (hNNCPH : HasNNCPHGroundSpaces B A) (j : Fin r) :
+    ∀ᶠ N in Filter.atTop,
+      mpvState (d := d) (A j) N ∈
+        Submodule.span ℂ (Set.range fun l : Loop F.edgeWeight =>
+          mpvState (d := d) (F.normalizedMinimalLoopTensor l) N) := by
+  refine Filter.eventually_atTop.mpr ⟨3, ?_⟩
+  intro N hN
+  have hTwo : 2 < N := by omega
+  have hGround :
+      mpvState (d := d) (A j) N ∈ parentHamiltonianGroundSpaceES B 2 N := by
+    rw [parentHamiltonianGroundSpaceES, Submodule.mem_map]
+    refine ⟨(mpv (A j) : NSiteSpace d N), ?_, rfl⟩
+    rw [(hNNCPH N hTwo).groundSpaceSpanning, bntMPSVectorSpan]
+    exact Submodule.subset_span ⟨j, rfl⟩
+  exact F.mpvState_mem_span_normalizedMinimalLoopTensor hparent hTwo hGround
+
 /-- All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply transfer
 idempotence for a normal left-canonical representative.
 
@@ -414,7 +457,9 @@ ground-space condition. In the source canonical decomposition, normality selects
 one-sector case \(g=1\), for which a source-level proof need not use Beigi's
 finite-degeneracy classification. The present formal proof nevertheless uses the finite
 sector graph and its loop-span theorem as an intermediate route to the gauge-phase match.
-The multi-sector case \(g>1\), which motivates the classification, remains unproved.
+The familywise theorem below proves the multi-sector case for the
+multiplicity-one, unit-weight basis direct sum. The unrestricted repeated-copy
+and raw-weight canonical-form case remains unproved.
 This restriction is documented in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 theorem nncph_implies_rfp
@@ -462,5 +507,127 @@ theorem nncph_implies_rfp
       (hLoopNormal l) hBCastNormal
       (F.normalizedMinimalLoopTensor_isTransferIdempotent l)
   exact (isTransferIdempotent_cast_iff hdim B).1 hBCastRFP
+
+namespace IsBNTCanonicalForm
+
+variable {P : SectorDecomposition d}
+
+/-- The all-chain NNCPH ground-space condition for the distinct BNT basis
+sectors implies transfer idempotence of their unit-weight direct sum.
+
+The proof follows CPSV16, proof of Theorem 3.10 at line 1307: Beigi's
+positive-loop product states span the parent ground spaces, each normal BNT
+basis tensor is gauge-phase equivalent to one normalized minimal loop tensor,
+distinct basis tensors select distinct locally orthogonal loops, and the
+blockwise fixed-point and mixed-transfer equations assemble on the direct sum.
+
+Source: CPSV16, Theorem `thm:main-MPS`, lines 534--541, and its reverse proof
+at line 1307; Beigi, J. Phys. A 45 (2012) 025306, Sections III--IV.
+
+**Scope restriction (multiplicity-one unit-weight representative):** This
+proves the reverse implication for `directSumTensor P.basis`, containing one
+unit-weight copy of each distinct BNT basis sector. It does not prove the
+printed theorem for arbitrary raw weights or repeated copies. Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces
+    (hCF : IsBNTCanonicalForm P)
+    (hNNCPH : HasNNCPHGroundSpaces (directSumTensor P.basis) P.basis) :
+    IsTransferIdempotent (directSumTensor P.basis) := by
+  classical
+  letI : ∀ j : Fin P.basisCount, NeZero (P.basisDim j) :=
+    fun j ↦ ⟨(hCF.basis_dim_pos j).ne'⟩
+  have hNNCPH3 : IsNNCPH (directSumTensor P.basis) 3 :=
+    (hNNCPH 3 (by omega)).isNNCPH
+  let F : BeigiSectorGraphData (directSumTensor P.basis) :=
+    hNNCPH3.beigiSectorGraphData
+  letI : ∀ l : Loop F.edgeWeight, NeZero (F.loopSchmidtRank l) :=
+    fun l => ⟨(F.loopSchmidtRank_pos l).ne'⟩
+  have hBasisNormal : ∀ j, IsNormalTensor (P.basis j) := by
+    intro j
+    exact isNormalTensor_of_isNormal_leftCanonical
+      (P.basis j) (hCF.basis_isNormal j) (hCF.basis_left_canonical j)
+  have hLoopNormal : ∀ l : Loop F.edgeWeight,
+      IsNormalTensor (F.normalizedMinimalLoopTensor l) := by
+    intro l
+    exact isNormalTensor_of_isNormal_isTransferIdempotent
+      (F.normalizedMinimalLoopTensor l)
+      (F.normalizedMinimalLoopTensor_isNormal l)
+      (F.normalizedMinimalLoopTensor_isTransferIdempotent l)
+  have hparent :=
+    eventually_parentHamiltonianGroundSpaceES_finrank_eq_of_isBNT
+      hCF.isBNT_basisDirectSum hNNCPH
+  have hPhaseExists : ∀ j : Fin P.basisCount,
+      ∃ l : Loop F.edgeWeight,
+        MPVBlockPhaseEquiv (P.basis j) (F.normalizedMinimalLoopTensor l) := by
+    intro j
+    apply exists_mpvBlockPhaseEquiv_of_mem_span_eventually
+      (hBasisNormal j) F.normalizedMinimalLoopTensor hLoopNormal
+    · intro l m hlm
+      exact F.normalizedMinimalLoopTensor_overlap_tendsto_zero hlm
+    · exact F.eventually_component_mpvState_mem_loopSpan hparent hNNCPH j
+  let loopOf (j : Fin P.basisCount) : Loop F.edgeWeight :=
+    (hPhaseExists j).choose
+  have hPhase (j : Fin P.basisCount) :
+      MPVBlockPhaseEquiv (P.basis j) (F.normalizedMinimalLoopTensor (loopOf j)) :=
+    (hPhaseExists j).choose_spec
+  have hLoopOf_ne {j k : Fin P.basisCount} (hjk : j ≠ k) :
+      loopOf j ≠ loopOf k := by
+    intro hEq
+    have hPhaseBack :
+        MPVBlockPhaseEquiv (F.normalizedMinimalLoopTensor (loopOf j)) (P.basis k) := by
+      rw [hEq]
+      exact (hPhase k).symm
+    have hPhaseJK : MPVBlockPhaseEquiv (P.basis j) (P.basis k) :=
+      (hPhase j).trans hPhaseBack
+    obtain ⟨hdim, hGauge⟩ :=
+      hPhaseJK.dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (hBasisNormal j) (hBasisNormal k)
+    exact hCF.basis_distinct j k hjk hdim hGauge
+  have hBlockRFP : ∀ j : Fin P.basisCount, IsTransferIdempotent (P.basis j) := by
+    intro j
+    obtain ⟨hdim, hGauge⟩ :=
+      (hPhase j).dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (hBasisNormal j) (hLoopNormal (loopOf j))
+    have hCastNormal :
+        IsNormalTensor (cast (congr_arg (MPSTensor d) hdim) (P.basis j)) :=
+      (isNormalTensor_cast_iff hdim (P.basis j)).2 (hBasisNormal j)
+    have hCastRFP :
+        IsTransferIdempotent (cast (congr_arg (MPSTensor d) hdim) (P.basis j)) :=
+      (gaugePhaseEquiv_symm_same_dim hGauge).isTransferIdempotent
+        (hLoopNormal (loopOf j)) hCastNormal
+        (F.normalizedMinimalLoopTensor_isTransferIdempotent (loopOf j))
+    exact (isTransferIdempotent_cast_iff hdim (P.basis j)).1 hCastRFP
+  apply
+    (isTransferIdempotent_directSumTensor_iff_pairwise_mixedTransferMap₂_isIdempotentElem
+      P.basis).2
+  intro j k
+  by_cases hjk : j = k
+  · subst k
+    rw [mixedTransferMap₂_self]
+    change IsTransferIdempotent (P.basis j)
+    exact hBlockRFP j
+  · obtain ⟨hdimJ, hGaugeJ⟩ :=
+      (hPhase j).dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (hBasisNormal j) (hLoopNormal (loopOf j))
+    obtain ⟨hdimK, hGaugeK⟩ :=
+      (hPhase k).dim_eq_and_gaugePhaseEquiv_of_isNormalTensor
+        (hBasisNormal k) (hLoopNormal (loopOf k))
+    have hLoopZero :
+        mixedTransferMap₂
+            (F.normalizedMinimalLoopTensor (loopOf j))
+            (F.normalizedMinimalLoopTensor (loopOf k)) = 0 :=
+      F.normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne (hLoopOf_ne hjk)
+    have hCastZero :
+        mixedTransferMap₂
+            (cast (congr_arg (MPSTensor d) hdimJ) (P.basis j))
+            (cast (congr_arg (MPSTensor d) hdimK) (P.basis k)) = 0 :=
+      mixedTransferMap₂_eq_zero_of_gaugePhaseEquiv hGaugeJ hGaugeK hLoopZero
+    have hZero : mixedTransferMap₂ (P.basis j) (P.basis k) = 0 :=
+      (mixedTransferMap₂_cast_eq_zero_iff
+        hdimJ hdimK (P.basis j) (P.basis k)).1 hCastZero
+    rw [hZero]
+    exact IsIdempotentElem.zero
+
+end IsBNTCanonicalForm
 
 end MPSTensor

--- a/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
+++ b/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
@@ -181,6 +181,72 @@ private theorem normalizedMinimalLoopTensor_eq_rotatePhysical
     minimalLoopTensor, rotatePhysical_apply, Finset.smul_sum, smul_smul]
   simp [mul_comm]
 
+/-- Distinct normalized minimal loop tensors have zero mixed transfer map in
+sector coordinates. -/
+private theorem normalizedMinimalLoopCoordinateTensor_mixedTransferMap₂_eq_zero_of_ne
+    (F : BeigiSectorGraphData A) {l m : Loop F.edgeWeight} (hlm : l ≠ m) :
+    mixedTransferMap₂ (F.normalizedMinimalLoopCoordinateTensor l)
+      (F.normalizedMinimalLoopCoordinateTensor m) = 0 := by
+  classical
+  apply LinearMap.ext
+  intro Z
+  simp only [mixedTransferMap₂_apply, LinearMap.zero_apply]
+  calc
+    (∑ i : Fin d, F.normalizedMinimalLoopCoordinateTensor l i * Z *
+        (F.normalizedMinimalLoopCoordinateTensor m i)ᴴ) =
+        ∑ z : Σ k, Fin (F.rightDim k) × Fin (F.leftDim k),
+          F.normalizedMinimalLoopCoordinateTensor l (F.sectorEquiv z) * Z *
+            (F.normalizedMinimalLoopCoordinateTensor m (F.sectorEquiv z))ᴴ := by
+      exact Fintype.sum_equiv F.sectorEquiv.symm
+        (fun i : Fin d ↦ F.normalizedMinimalLoopCoordinateTensor l i * Z *
+          (F.normalizedMinimalLoopCoordinateTensor m i)ᴴ)
+        (fun z ↦ F.normalizedMinimalLoopCoordinateTensor l (F.sectorEquiv z) * Z *
+          (F.normalizedMinimalLoopCoordinateTensor m (F.sectorEquiv z))ᴴ)
+        (fun i ↦ by rw [Equiv.apply_symm_apply])
+    _ = ∑ k : Fin F.sectorCount,
+        ∑ qa : Fin (F.rightDim k) × Fin (F.leftDim k),
+          F.normalizedMinimalLoopCoordinateTensor l (F.sectorEquiv ⟨k, qa⟩) * Z *
+            (F.normalizedMinimalLoopCoordinateTensor m (F.sectorEquiv ⟨k, qa⟩))ᴴ := by
+      rw [Fintype.sum_sigma]
+    _ = 0 := by
+      apply Finset.sum_eq_zero
+      intro k _
+      apply Finset.sum_eq_zero
+      rintro ⟨q, a⟩ _
+      by_cases hkl : k = l.1
+      · subst k
+        have hlmSector : l.1 ≠ m.1 := by
+          intro h
+          exact hlm (Subtype.ext h)
+        simp only [normalizedMinimalLoopCoordinateTensor]
+        rw [F.minimalLoopCoordinateTensor_sector_ne m l.1 hlmSector q a]
+        simp
+      · simp only [normalizedMinimalLoopCoordinateTensor]
+        rw [F.minimalLoopCoordinateTensor_sector_ne l k hkl q a]
+        simp
+
+/-- Distinct normalized minimal Beigi loop tensors are locally orthogonal:
+their rectangular mixed transfer map vanishes.
+
+Source: CPSV16, proof of Theorem 3.10 at line 1307; Beigi,
+J. Phys. A 45 (2012) 025306, Sections III--IV.
+
+**Local fix (Schmidt support and normalization):** The formal loop tensors use
+their Schmidt supports and the fixed-point normalization documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. The common physical
+unitary preserves the mixed transfer map, so disjoint loop-sector support gives
+the stated local orthogonality. -/
+theorem normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne
+    (F : BeigiSectorGraphData A) {l m : Loop F.edgeWeight} (hlm : l ≠ m) :
+    mixedTransferMap₂ (F.normalizedMinimalLoopTensor l)
+      (F.normalizedMinimalLoopTensor m) = 0 := by
+  have hunitary : F.unitary * F.unitaryᴴ = 1 :=
+    Unitary.mul_star_self_of_mem F.unitary_mem
+  rw [F.normalizedMinimalLoopTensor_eq_rotatePhysical l,
+    F.normalizedMinimalLoopTensor_eq_rotatePhysical m,
+    mixedTransferMap₂_rotatePhysical _ _ F.unitary hunitary]
+  exact F.normalizedMinimalLoopCoordinateTensor_mixedTransferMap₂_eq_zero_of_ne hlm
+
 /-- The transfer map of the minimal loop tensor in sector coordinates is a
 rank-one map on the virtual matrix algebra.
 

--- a/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
+++ b/TNLean/MPS/RFP/BeigiLoopFixedPoint.lean
@@ -19,6 +19,8 @@ of `φ` gives an injective normal tensor whose transfer map is idempotent.
 
 The normalization does not alter the associated ray of periodic vectors: at
 length `N`, it multiplies Beigi's product-of-pairs vector by `‖φ‖₂⁻ᴺ`.
+Normalized tensors belonging to distinct positive loops have zero rectangular
+mixed transfer map because their sector-coordinate supports are disjoint.
 
 ## References
 

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -28,6 +28,8 @@ the full isometry condition of Corollary III.cor3 (arXiv:1606.00608, line 584).
 * `mixedTransferMap₂_eq_zero_of_conj` — cancelling the invertible outer factors
   turns the vanishing of `mixedTransferMap₂ A B` into that of
   `mixedTransferMap₂ U V`.
+* `mixedTransferMap₂_eq_zero_of_gaugePhaseEquiv` — the corresponding
+  gauge-phase transport API for two tensor legs.
 * `residual_isometry_entry_of_mixedTransferMap₂_eq_zero` — reading off a matrix
   entry turns the vanishing operator into the entrywise residual-isometry sum.
 * `IsResidualIsometryFamily` — the full isometry condition eq:III_isometry as a
@@ -139,6 +141,45 @@ lemma mixedTransferMap₂_eq_zero_of_conj
   · rw [Matrix.det_mul]; exact mul_ne_zero hXa hDa
   · rw [Matrix.det_conjTranspose, Matrix.det_mul]
     exact star_ne_zero.mpr (mul_ne_zero hXb hDb)
+
+/-- Vanishing of a rectangular mixed transfer map descends through independent
+gauge-phase equivalences on its two tensor legs. -/
+theorem mixedTransferMap₂_eq_zero_of_gaugePhaseEquiv
+    {A U : MPSTensor d D₁} {B V : MPSTensor d D₂}
+    (hA : GaugePhaseEquiv U A) (hB : GaugePhaseEquiv V B)
+    (hAB : mixedTransferMap₂ A B = 0) :
+    mixedTransferMap₂ U V = 0 := by
+  obtain ⟨Xa, ζa, hζa, hrelA⟩ := hA
+  obtain ⟨Xb, ζb, hζb, hrelB⟩ := hB
+  let Da : Matrix (Fin D₁) (Fin D₁) ℂ := ζa • 1
+  let Db : Matrix (Fin D₂) (Fin D₂) ℂ := ζb • 1
+  apply mixedTransferMap₂_eq_zero_of_conj A U B V
+    (Xa : Matrix (Fin D₁) (Fin D₁) ℂ) Da
+    (Xb : Matrix (Fin D₂) (Fin D₂) ℂ) Db
+  · intro i
+    rw [hrelA i]
+    simp [Da, Matrix.mul_assoc]
+  · intro i
+    rw [hrelB i]
+    simp [Db, Matrix.mul_assoc]
+  · exact Matrix.GeneralLinearGroup.det_ne_zero Xa
+  · simp [Da, hζa]
+  · exact Matrix.GeneralLinearGroup.det_ne_zero Xb
+  · simp [Db, hζb]
+  · exact hAB
+
+/-- Transport across equalities of the two bond dimensions preserves
+vanishing of the rectangular mixed transfer map. -/
+theorem mixedTransferMap₂_cast_eq_zero_iff
+    {D₁ D₁' D₂ D₂' : ℕ} (h₁ : D₁ = D₁') (h₂ : D₂ = D₂')
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂) :
+    mixedTransferMap₂
+        (cast (congr_arg (MPSTensor d) h₁) A)
+        (cast (congr_arg (MPSTensor d) h₂) B) = 0 ↔
+      mixedTransferMap₂ A B = 0 := by
+  subst D₁'
+  subst D₂'
+  rfl
 
 /-- **Entrywise form of the vanishing residual operator.** If
 `mixedTransferMap₂ U V` vanishes, then for all virtual indices

--- a/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Complex.Basic
+import Mathlib.Data.Fintype.Pi
 import Mathlib.Data.Matrix.Basis
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Basis.VectorSpace

--- a/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Fintype.Pi
 import Mathlib.Data.Matrix.Basis
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Basis.VectorSpace

--- a/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Complex.Basic
-import Mathlib.Data.Fintype.Pi
 import Mathlib.Data.Matrix.Basis
 import Mathlib.LinearAlgebra.LinearIndependent.Basic
 import Mathlib.LinearAlgebra.Basis.VectorSpace
@@ -30,7 +29,7 @@ open scoped BigOperators Matrix
 namespace TNLean
 namespace PEPS
 
-variable {Bond : Type*} [Fintype Bond]
+variable {Bond : Type*} [DecidableEq Bond] [Fintype Bond]
 variable {bondDim : Bond → Type*} [∀ b, Fintype (bondDim b)]
 
 /-! ### Abstract two-block tensors -/

--- a/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
@@ -29,7 +29,7 @@ open scoped BigOperators Matrix
 namespace TNLean
 namespace PEPS
 
-variable {Bond : Type*} [DecidableEq Bond] [Fintype Bond]
+variable {Bond : Type*} [Fintype Bond]
 variable {bondDim : Bond → Type*} [∀ b, Fintype (bondDim b)]
 
 /-! ### Abstract two-block tensors -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -566,7 +566,9 @@
     \uses{def:mps_transfer_idempotence, def:has_nncph_ground_spaces,
         thm:beigi_loop_product_states_span_ground_space,
         thm:beigi_normalized_minimal_loop_tensor_rfp,
-        lem:beigi_normalized_minimal_loop_mixed_transfer_zero}
+        lem:beigi_normalized_minimal_loop_mixed_transfer_zero,
+        thm:cpsv_normal_mpv_phase_gauge,
+        thm:direct_sum_transfer_idempotent_iff_pairwise_mixed}
     Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
     form, and set
     \[
@@ -590,8 +592,8 @@
 \begin{proof}
     \leanok
     Beigi's positive-loop product states span each parent ground space.
-    Consequently every normal basis tensor $A_j$ agrees, up to a nonzero
-    phase and an invertible virtual change of basis, with a normalized
+    Consequently every normal basis tensor $A_j$ agrees, up to a unit-modulus
+    scalar and an invertible virtual change of basis, with a normalized
     minimal loop tensor $L_{\ell(j)}$. Distinctness of the BNT basis makes
     $j\mapsto\ell(j)$ injective.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -510,6 +510,25 @@
     Transfer idempotence is preserved by these transformations.
 \end{proof}
 
+\begin{lemma}[The unit-weight basis direct sum is a BNT]
+    \label{lem:bnt_basis_direct_sum}
+    \lean{MPSTensor.IsBNTCanonicalForm.isBNT_basisDirectSum}
+    \leanok
+    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
+    form. Then their multiplicity-one, unit-weight direct sum
+    \[
+        B=\bigoplus_{j=1}^g A_j
+    \]
+    has the same family $A_1,\ldots,A_g$ as an algebraic BNT.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Each $A_j$ is normal and left-canonical. The direct-sum state is the sum
+    of the states of the $A_j$ with coefficient one, and the eventual linear
+    independence is part of the given BNT canonical form.
+\end{proof}
+
 \begin{lemma}[Common physical unitaries preserve mixed transfer maps]
     \label{lem:mixed_transfer_common_physical_unitary}
     \lean{MPSTensor.mixedTransferMap₂_rotatePhysical}
@@ -572,6 +591,20 @@
     $\mathcal E_{U,V}(Z)=0$ for every $Z$.
 \end{proof}
 
+\begin{lemma}[Equal bond-dimension identifications preserve mixed-transfer vanishing]
+    \label{lem:mixed_transfer_dimension_identification_zero}
+    \lean{MPSTensor.mixedTransferMap₂_cast_eq_zero_iff}
+    \leanok
+    Identifying either bond dimension with an equal natural number does not
+    change whether the rectangular mixed transfer map vanishes.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    After the two dimension identifications, both tensors and their mixed
+    transfer map are unchanged.
+\end{proof}
+
 \begin{lemma}[Distinct normalized Beigi loops are locally orthogonal]
     \label{lem:beigi_normalized_minimal_loop_mixed_transfer_zero}
     \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne}
@@ -603,10 +636,12 @@
     \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces}
     \leanok
     \uses{def:mps_transfer_idempotence, def:has_nncph_ground_spaces,
+        lem:bnt_basis_direct_sum,
         thm:beigi_loop_product_states_span_ground_space,
         thm:beigi_normalized_minimal_loop_tensor_rfp,
         lem:beigi_normalized_minimal_loop_mixed_transfer_zero,
         lem:mixed_transfer_gauge_phase_zero,
+        lem:mixed_transfer_dimension_identification_zero,
         thm:cpsv_normal_mpv_phase_gauge,
         thm:direct_sum_transfer_idempotent_iff_pairwise_mixed}
     Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -509,3 +509,97 @@
     $L_j^i = \zeta X B^i X^{-1}$.
     Transfer idempotence is preserved by these transformations.
 \end{proof}
+
+\begin{lemma}[Common physical unitaries preserve mixed transfer maps]
+    \label{lem:mixed_transfer_common_physical_unitary}
+    \lean{MPSTensor.mixedTransferMap₂_rotatePhysical}
+    \leanok
+    Let $A=(A_i)_i$ and $B=(B_i)_i$ be two tensors, possibly with
+    different bond dimensions, and let $u$ be unitary on the physical index.
+    If
+    \[
+        \widetilde A_i=\sum_j u_{ij}A_j,
+        \qquad
+        \widetilde B_i=\sum_j u_{ij}B_j,
+    \]
+    then
+    \[
+        \mathcal E_{\widetilde A,\widetilde B}
+        =
+        \mathcal E_{A,B}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand both physical sums. The coefficient of
+    $A_jX B_k^\dagger$ is
+    $\sum_i u_{ij}\overline{u_{ik}}=\delta_{jk}$, so only the diagonal
+    terms remain.
+\end{proof}
+
+\begin{lemma}[Distinct normalized Beigi loops are locally orthogonal]
+    \label{lem:beigi_normalized_minimal_loop_mixed_transfer_zero}
+    \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne}
+    \leanok
+    \uses{lem:mixed_transfer_common_physical_unitary}
+    If $a$ and $b$ are distinct positive loops in the sector graph, then the
+    mixed transfer map of their normalized minimal loop tensors vanishes:
+    \[
+        \mathcal E_{L_a,L_b}=0.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    In sector coordinates, every physical letter of $L_a$ is supported in
+    sector $a$, while every physical letter of $L_b$ is supported in sector
+    $b$. Thus each summand in the mixed transfer map is zero. The common
+    one-site physical unitary preserves the mixed transfer map by
+    Lemma~\ref{lem:mixed_transfer_common_physical_unitary}.
+\end{proof}
+
+\begin{theorem}[Multi-sector NNCPH ground spaces imply a fixed point for the basis direct sum]
+    \label{thm:nncph_implies_rfp_basis_direct_sum}
+    \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces}
+    \leanok
+    \uses{def:mps_transfer_idempotence, def:has_nncph_ground_spaces,
+        thm:beigi_loop_product_states_span_ground_space,
+        thm:beigi_normalized_minimal_loop_tensor_rfp,
+        lem:beigi_normalized_minimal_loop_mixed_transfer_zero}
+    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
+    form, and set
+    \[
+        B=\bigoplus_{j=1}^g A_j .
+    \]
+    Suppose that, for every $N>2$, the translated length-two parent
+    interactions of $B$ commute, every $V^{(N)}(A_j)$ has zero energy, and
+    \[
+        \ker H_2^{(N)}(B)
+        =
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
+    \]
+    Then $B$ is a renormalization fixed point.
+
+    This is the multiplicity-one, unit-weight representative case of the
+    reverse implication in Theorem~3.10 of
+    \cite{Cirac2016MPDO_arXiv}. It does not assert the printed theorem for
+    repeated copies or arbitrary raw weights.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Beigi's positive-loop product states span each parent ground space.
+    Consequently every normal basis tensor $A_j$ agrees, up to a nonzero
+    phase and an invertible virtual change of basis, with a normalized
+    minimal loop tensor $L_{\ell(j)}$. Distinctness of the BNT basis makes
+    $j\mapsto\ell(j)$ injective.
+
+    Each $L_{\ell(j)}$ has an idempotent transfer map. If $j\ne k$, then
+    $L_{\ell(j)}$ and $L_{\ell(k)}$ have disjoint sector support, so their
+    mixed transfer map vanishes. The common physical unitary and the two
+    virtual changes of basis preserve this vanishing. Thus the diagonal
+    mixed transfer maps of the family $A_j$ are idempotent and the
+    off-diagonal ones vanish. The blockwise criterion for the direct-sum
+    transfer map now proves the claim.
+\end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -510,25 +510,6 @@
     Transfer idempotence is preserved by these transformations.
 \end{proof}
 
-\begin{lemma}[The unit-weight basis direct sum is a BNT]
-    \label{lem:bnt_basis_direct_sum}
-    \lean{MPSTensor.IsBNTCanonicalForm.isBNT_basisDirectSum}
-    \leanok
-    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
-    form. Then their multiplicity-one, unit-weight direct sum
-    \[
-        B=\bigoplus_{j=1}^g A_j
-    \]
-    has the same family $A_1,\ldots,A_g$ as an algebraic BNT.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    Each $A_j$ is normal and left-canonical. The direct-sum state is the sum
-    of the states of the $A_j$ with coefficient one, and the eventual linear
-    independence is part of the given BNT canonical form.
-\end{proof}
-
 \begin{lemma}[Common physical unitaries preserve mixed transfer maps]
     \label{lem:mixed_transfer_common_physical_unitary}
     \lean{MPSTensor.mixedTransferMap₂_rotatePhysical}
@@ -594,20 +575,6 @@
     $\mathcal E_{U,V}(Z)=0$ for every $Z$.
 \end{proof}
 
-\begin{lemma}[Equal bond-dimension identifications preserve mixed-transfer vanishing]
-    \label{lem:mixed_transfer_dimension_identification_zero}
-    \lean{MPSTensor.mixedTransferMap₂_cast_eq_zero_iff}
-    \leanok
-    Identifying either bond dimension with an equal natural number does not
-    change whether the rectangular mixed transfer map vanishes.
-\end{lemma}
-
-\begin{proof}
-    \leanok
-    After the two dimension identifications, both tensors and their mixed
-    transfer map are unchanged.
-\end{proof}
-
 \begin{lemma}[Distinct normalized Beigi loops are locally orthogonal]
     \label{lem:beigi_normalized_minimal_loop_mixed_transfer_zero}
     \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne}
@@ -639,12 +606,11 @@
     \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces}
     \leanok
     \uses{def:mps_transfer_idempotence, def:has_nncph_ground_spaces,
-        lem:bnt_basis_direct_sum,
+        thm:bnt_cf_basis_is_bnt_for_direct_sum,
         thm:beigi_loop_product_states_span_ground_space,
         thm:beigi_normalized_minimal_loop_tensor_rfp,
         lem:beigi_normalized_minimal_loop_mixed_transfer_zero,
         lem:mixed_transfer_gauge_phase_zero,
-        lem:mixed_transfer_dimension_identification_zero,
         thm:cpsv_normal_mpv_phase_gauge,
         thm:direct_sum_transfer_idempotent_iff_pairwise_mixed}
     Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -538,6 +538,40 @@
     terms remain.
 \end{proof}
 
+\begin{lemma}[Gauge-phase transport of mixed-transfer vanishing]
+    \label{lem:mixed_transfer_gauge_phase_zero}
+    \lean{MPSTensor.mixedTransferMap₂_eq_zero_of_gaugePhaseEquiv}
+    \leanok
+    \uses{def:gauge_phase_equiv}
+    Let $U,A$ and $V,B$ be pairs of tensors with respective common bond
+    dimensions. Suppose that $\zeta_A,\zeta_B\ne 0$ and that $X_A,X_B$ are
+    invertible matrices such that, for every physical index $i$,
+    \begin{align}
+        A^i &= \zeta_A X_A U^i X_A^{-1}, \\
+        B^i &= \zeta_B X_B V^i X_B^{-1}.
+    \end{align}
+    Then
+    \begin{align}
+        \mathcal E_{A,B}=0
+        \quad\Longrightarrow\quad
+        \mathcal E_{U,V}=0.
+    \end{align}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Set $D_A=\zeta_A I$ and $D_B=\zeta_B I$. For every rectangular matrix
+    $Z$, covariance of the mixed transfer map gives
+    \begin{align}
+        \mathcal E_{A,B}(X_A Z X_B^\dagger)
+        &=
+        X_A D_A\,\mathcal E_{U,V}(Z)\,(X_B D_B)^\dagger .
+    \end{align}
+    If $\mathcal E_{A,B}=0$, the left-hand side vanishes. The two outer
+    factors are invertible, so cancellation gives
+    $\mathcal E_{U,V}(Z)=0$ for every $Z$.
+\end{proof}
+
 \begin{lemma}[Distinct normalized Beigi loops are locally orthogonal]
     \label{lem:beigi_normalized_minimal_loop_mixed_transfer_zero}
     \lean{MPSTensor.BeigiSectorGraphData.normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne}
@@ -554,8 +588,13 @@
     \leanok
     In sector coordinates, every physical letter of $L_a$ is supported in
     sector $a$, while every physical letter of $L_b$ is supported in sector
-    $b$. Thus each summand in the mixed transfer map is zero. The common
-    one-site physical unitary preserves the mixed transfer map by
+    $b$. Hence, for every rectangular matrix $Z$ and every physical index $i$,
+    \begin{align}
+        L_a^i Z (L_b^i)^\dagger &= 0, \\
+        \mathcal E_{L_a,L_b}(Z)
+        &= \sum_i L_a^i Z (L_b^i)^\dagger = 0.
+    \end{align}
+    The common one-site physical unitary preserves the mixed transfer map by
     Lemma~\ref{lem:mixed_transfer_common_physical_unitary}.
 \end{proof}
 
@@ -567,6 +606,7 @@
         thm:beigi_loop_product_states_span_ground_space,
         thm:beigi_normalized_minimal_loop_tensor_rfp,
         lem:beigi_normalized_minimal_loop_mixed_transfer_zero,
+        lem:mixed_transfer_gauge_phase_zero,
         thm:cpsv_normal_mpv_phase_gauge,
         thm:direct_sum_transfer_idempotent_iff_pairwise_mixed}
     Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
@@ -595,13 +635,28 @@
     Consequently every normal basis tensor $A_j$ agrees, up to a unit-modulus
     scalar and an invertible virtual change of basis, with a normalized
     minimal loop tensor $L_{\ell(j)}$. Distinctness of the BNT basis makes
-    $j\mapsto\ell(j)$ injective.
+    $j\mapsto\ell(j)$ injective. Thus there are $\zeta_j\ne 0$ and invertible
+    $X_j$ such that
+    \begin{align}
+        L_{\ell(j)}^i &= \zeta_j X_j A_j^i X_j^{-1}.
+    \end{align}
 
     Each $L_{\ell(j)}$ has an idempotent transfer map. If $j\ne k$, then
     $L_{\ell(j)}$ and $L_{\ell(k)}$ have disjoint sector support, so their
-    mixed transfer map vanishes. The common physical unitary and the two
-    virtual changes of basis preserve this vanishing. Thus the diagonal
-    mixed transfer maps of the family $A_j$ are idempotent and the
-    off-diagonal ones vanish. The blockwise criterion for the direct-sum
-    transfer map now proves the claim.
+    mixed transfer map vanishes. Lemma~\ref{lem:mixed_transfer_gauge_phase_zero}
+    transports this vanishing through the two virtual changes of basis:
+    \begin{align}
+        \mathcal E_{L_{\ell(j)},L_{\ell(k)}}=0
+        \quad\Longrightarrow\quad
+        \mathcal E_{A_j,A_k}=0.
+    \end{align}
+    Thus the diagonal mixed transfer maps of the family $A_j$ are idempotent
+    and the off-diagonal ones vanish. The blockwise criterion is
+    \begin{align}
+        \mathcal E_B\circ\mathcal E_B=\mathcal E_B
+        \quad\Longleftrightarrow\quad
+        \mathcal E_{A_j,A_k}\circ\mathcal E_{A_j,A_k}
+        =\mathcal E_{A_j,A_k}
+    \end{align}
+    for every pair $j,k$, and proves the claim.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -541,6 +541,7 @@
 \begin{lemma}[Gauge-phase transport of mixed-transfer vanishing]
     \label{lem:mixed_transfer_gauge_phase_zero}
     \lean{MPSTensor.mixedTransferMap₂_eq_zero_of_gaugePhaseEquiv}
+    \lean{MPSTensor.mixedTransferMap₂_cast_eq_zero_iff}
     \leanok
     \uses{def:gauge_phase_equiv}
     Let $U,A$ and $V,B$ be pairs of tensors with respective common bond
@@ -556,6 +557,8 @@
         \quad\Longrightarrow\quad
         \mathcal E_{U,V}=0.
     \end{align}
+    Identifying equal bond dimensions on either tensor leg preserves this
+    vanishing condition in both directions.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -381,6 +381,7 @@
 \begin{theorem}[Auxiliary BNT basis gives a basis for its direct sum]%
     \label{thm:bnt_cf_basis_is_bnt_for_direct_sum}
     \lean{MPSTensor.IsBNTCanonicalForm.isCPSVBasisOfNormalTensors_basisDirectSum}
+    \lean{MPSTensor.IsBNTCanonicalForm.isBNT_basisDirectSum}
     \leanok
     \uses{def:bnt_cpsv, def:sector_bnt_cf}
     Let $P$ be an auxiliary BNT sector decomposition with distinct basis

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -272,6 +272,18 @@ axiom.  These hypotheses select a normal representative and fix its
 normalization.  They are not the full canonical-form hypothesis of
 Theorem~3.10.
 
+For the multiplicity-one, unit-weight direct sum of all distinct BNT basis
+sectors, the reverse implication is now proved without the single-sector
+normality restriction.  The theorem
+\leanid{MPSTensor.IsBNTCanonicalForm.}
+\hspace{0pt}\leanid{isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces}
+matches every BNT basis tensor with a distinct normalized Beigi loop tensor.
+The disjoint loop sectors have zero mixed transfer maps, and this local
+orthogonality transports through the independent virtual gauge-phase
+relations.  The direct-sum transfer criterion then gives transfer
+idempotence.  This statement still excludes repeated copies and arbitrary raw
+weights.
+
 The eventual scale-invariance input to Beigi's classification is now proved
 without this axiom.  Let $P$ be a sector decomposition with representatives
 $A_1,\ldots,A_g$ and total tensor $B$. If the representative matrix product
@@ -501,15 +513,18 @@ invertible virtual change of basis.  Transfer idempotence is invariant under
 these transformations.  This is the proof of
 \leanid{MPSTensor.nncph_implies_rfp}.
 
-This result is a scope restriction relative to CPSV16, Theorem~3.10, source
+The single-normal result is a scope restriction relative to CPSV16,
+Theorem~3.10, source
 lines 534--541 and its proof at line 1307: the formal theorem assumes explicitly
 that the chosen representative is normal and left-canonical, as well as an
 explicit BNT relation and the all-chain ground-space condition.  It does not
 state the unrestricted three-way equivalence for an arbitrary tensor in
 canonical form.  In the source canonical decomposition, the normality
-hypothesis selects the one-sector case \(g=1\).  Thus this theorem does not
-establish the multi-sector case \(g>1\), for which Beigi's finite-degeneracy
-classification is the essential input.
+hypothesis selects the one-sector case \(g=1\).  The companion basis-direct-sum
+theorem now establishes the \(g>1\) reverse implication at the
+multiplicity-one, unit-weight representative, using Beigi's
+finite-degeneracy classification.  Neither statement establishes the
+unrestricted repeated-copy, raw-weight canonical-form theorem.
 
 The auxiliary declaration
 \leanid{MPSTensor.BeigiSectorGraphData.}
@@ -534,17 +549,19 @@ parent-Hamiltonian ground-space clause:
   \forall N>2,\; |V^{(N)}(A)\rangle
   \text{ is a ground state of a NNCPH}.
 \end{align}
-The reverse implication for a normal left-canonical representative, including
-the comparison of Beigi's locally orthogonal product-of-pairs loop states with
-the given normal tensor, is now proved and requires no axiom.  The remaining
-task is to derive this representative-level statement from the source's full
-canonical-form hypotheses and combine it with the unrestricted forward and ZCL
-directions.\footnote{Tracked by \ghissue{2633}.}
+The reverse implication is now proved both for a normal left-canonical
+representative and for the multiplicity-one, unit-weight direct sum of all
+distinct BNT basis sectors.  In the latter statement the comparison with
+Beigi's locally orthogonal product-of-pairs loop states is performed
+familywise and requires no axiom.  The remaining task is to reconcile this
+corrected representative theorem with the source's repeated-copy and raw-weight
+canonical form and with the unrestricted forward and ZCL directions, subject
+to the known obstruction.\footnote{Tracked by \ghissue{2633}.}
 
 The current proof boundary is therefore: the reverse implication is proved for
-an explicitly normal left-canonical representative satisfying the source
-all-chain ground-space hypothesis and an explicit BNT relation; the
-unrestricted canonical-form reduction remains open.  The forward commutation
+the corrected basis-direct-sum representative satisfying the source all-chain
+ground-space condition; the unrestricted repeated-copy and raw-weight
+canonical-form reduction remains open.  The forward commutation
 implication has the source-unit Appendix~B structural datum, its
 physical isometric embedding and all tensor powers with explicit left
 inverses, the two-site bond insertion, the equality of its physical image with
@@ -567,11 +584,12 @@ sector graph to one-dimensional loops, and the exact matrix product realization
 and parent-ground-space membership of every positive loop state are proved.
 The loop vectors are also proved to span the parent ground space for every
 $N>2$ under the eventual-dimension hypothesis supplied by BNT eventual linear
-independence together with the source all-chain ground-space condition.  For a
-normal left-canonical representative, their comparison with the original
-tensor and the transport of transfer idempotence are proved.  What remains is
-the passage from the source's general canonical-form statement to this normal
-representative theorem.
+independence together with the source all-chain ground-space condition.  Their
+comparison with the original tensor is proved for one normal left-canonical
+representative and familywise for the multiplicity-one, unit-weight BNT basis
+direct sum; the corresponding transfer-idempotence statements are proved.
+What remains is the repeated-copy and arbitrary-raw-weight passage in the
+source's general canonical-form statement.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -577,8 +577,8 @@ commutator. Extending from one normal tensor to the full repeated-sector
 canonical form is subject to the source obstruction recorded in
 \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}. The single-normal-sector
 ground-space spanning clause and the multiplicity-one distinct-sector
-extension are proved. The repeated-copy and arbitrary-raw-weight extension
-remains open.  In the reverse direction, eventual ground-space dimension
+extension are proved. Repeated copies and arbitrary raw weights lie outside
+the corrected theorem.  In the reverse direction, eventual ground-space dimension
 stability, the symmetric sector-graph construction from three-site commuting
 parent terms, the ordered-cycle dimension formula, the reduction of the
 sector graph to one-dimensional loops, and the exact matrix product realization
@@ -589,8 +589,8 @@ independence together with the source all-chain ground-space condition.  Their
 comparison with the original tensor is proved for one normal left-canonical
 representative and familywise for the multiplicity-one, unit-weight BNT basis
 direct sum; the corresponding transfer-idempotence statements are proved.
-What remains is the repeated-copy and arbitrary-raw-weight passage in the
-source's general canonical-form statement.
+What remains is to assemble these representative-level implications into the
+corrected three-way theorem stated above.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -538,30 +538,31 @@ commutativity of the translated interactions.
 
 \section{Remaining extension plan}
 
-A source-faithful completion should state the three-way equivalence for
-canonical-form tensors, including the spanning condition in the
-parent-Hamiltonian ground-space clause:
+The immediate remaining theorem should assemble the corrected three-way
+equivalence for the multiplicity-one, unit-weight direct sum of the distinct
+BNT basis tensors:
 \begin{align}
-  \mathrm{RFP}(A)
+  \mathrm{RFP}(A_{\mathrm{basis}})
   \Longleftrightarrow
-  \mathrm{ZCL}(A)
+  \text{positive-gap BNT ZCL}(A_{\mathrm{basis}})
   \Longleftrightarrow
-  \forall N>2,\; |V^{(N)}(A)\rangle
-  \text{ is a ground state of a NNCPH}.
+  \mathrm{HasNNCPHGroundSpaces}(A_{\mathrm{basis}}).
 \end{align}
 The reverse implication is now proved both for a normal left-canonical
 representative and for the multiplicity-one, unit-weight direct sum of all
 distinct BNT basis sectors.  In the latter statement the comparison with
 Beigi's locally orthogonal product-of-pairs loop states is performed
-familywise and requires no axiom.  The remaining task is to reconcile this
-corrected representative theorem with the source's repeated-copy and raw-weight
-canonical form and with the unrestricted forward and ZCL directions, subject
-to the known obstruction.\footnote{Tracked by \ghissue{2633}.}
+familywise and requires no axiom.  The remaining task is therefore only to
+combine this reverse implication with the already proved representative-level
+RFP--positive-gap-ZCL equivalence and RFP-to-NNCPH direction in one theorem
+with precise hypotheses.\footnote{Tracked by \ghissue{2633}.}
 
 The current proof boundary is therefore: the reverse implication is proved for
 the corrected basis-direct-sum representative satisfying the source all-chain
-ground-space condition; the unrestricted repeated-copy and raw-weight
-canonical-form reduction remains open.  The forward commutation
+ground-space condition.  Repeated copies and arbitrary raw weights remain
+excluded by the known counterexample; they are not a pending extension of this
+representative theorem.  The printed unrestricted equivalence remains
+unformalized.  The forward commutation
 implication has the source-unit Appendix~B structural datum, its
 physical isometric embedding and all tensor powers with explicit left
 inverses, the two-site bond insertion, the equality of its physical image with


### PR DESCRIPTION
## Summary

- prove that the all-chain NNCPH ground-space condition implies transfer
  idempotence for the multiplicity-one, unit-weight direct sum of the distinct
  BNT basis sectors
- follow CPSV16 line 1307 through Beigi's positive-loop ground states:
  match each BNT sector to a distinct normalized loop, prove distinct loops
  have zero mixed transfer map, and apply the pairwise direct-sum criterion
- add reusable common-physical-unitary and gauge-phase transport lemmas for
  rectangular mixed transfer maps
- update the scope-restricted Blueprint statement and
  `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`

## Source boundary

Source: arXiv:1606.00608, Theorem `thm:main-MPS`, lines 534--541, and
the reverse proof at line 1307; Beigi, J. Phys. A 45 (2012) 025306,
Sections III--IV.

The proved theorem concerns `directSumTensor P.basis`, with one unit-weight
copy of every distinct BNT basis tensor. It does not claim the printed theorem
for repeated copies or arbitrary raw weights. No diagonalizability,
spectral-pair, comparison, crossing, or raw-weight hypothesis is added.

## Validation

- `lake build TNLean.MPS.RFP.BeigiLoopBNTIdentification -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity search on all changed Lean files
- oversized-module and numbered-module policy checks
- `git diff --check`

Closes #5185.
Parent tracker: #2633.
Coverage tracker: #2380.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MPS/RFP and spectral transfer-map theory with a long familywise identification proof; scope is explicitly restricted to the basis direct sum, not arbitrary canonical form.
> 
> **Overview**
> Extends the CPSV16 reverse implication from a single normal tensor to the **multiplicity-one, unit-weight direct sum** of distinct BNT basis sectors: `isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces` matches each basis block to a normalized Beigi loop, shows distinct loops have vanishing rectangular mixed transfer, and closes with the existing pairwise direct-sum RFP criterion.
> 
> **New infrastructure:** `mixedTransferMap₂_rotatePhysical` (common physical unitary invariance), gauge-phase transport and cast lemmas in `ResidualIsometry.lean`, `isBNT_basisDirectSum`, disjoint-sector proof `normalizedMinimalLoopTensor_mixedTransferMap₂_eq_zero_of_ne`, and refactored span lemmas so each BNT component’s MPV state is eventually in the loop span.
> 
> Blueprint ch13 and gap doc `cpsv16_nncph_ground_state_scope.tex` are updated to record the proved multi-sector representative and remaining scope (repeated copies / raw weights).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0933f94447fff43b8a3919a9ca69aa40a8d7a82b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->