### PR TITLE
doc(MPS/CanonicalForm): expose gauge-transport dependencies

### DIFF
--- a/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
+++ b/TNLean/MPS/CanonicalForm/CPSVBlocking.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Irreducible.SpectralRadius
-import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
 import TNLean.MPS.CanonicalForm.NormalTensorGauge
 import TNLean.MPS.CanonicalForm.SectorComparison.PrimitiveBlocks
 

--- a/TNLean/MPS/MPDO/CPSVBlocking.lean
+++ b/TNLean/MPS/MPDO/CPSVBlocking.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.CPSVBlocking
+import TNLean.MPS.CanonicalForm.CPSVPhysicalReindex
 import TNLean.MPS.MPDO.PhysicalBlocking
 
 /-!

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -424,8 +424,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     from Formula~(\ref{eq:cpsv_canonical_form}) by replacing $i$ with $e(j)$.
 \end{proof}
 
-\begin{lemma}[Transfer maps under a bond-space gauge]
-    \label{lem:cpsv_gauge_transfer_similarity}
+\begin{theorem}[Transfer maps under a bond-space gauge]
+    \label{thm:cpsv_gauge_transfer_similarity}
     \lean{MPSTensor.GaugeEquiv.transferMap_eq_similarityMap}
     \leanok
     \uses{def:gauge_equiv, def:transfer_map}
@@ -436,14 +436,14 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
         &=C^{-1}\E_A(CYC^\dagger)(C^\dagger)^{-1}.
         \notag
     \end{align}
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Expand both transfer maps and take $C=X^{-1}$.
 \end{proof}
 
-\begin{lemma}[Spectral radius under congruence similarity]
-    \label{lem:cpsv_spectral_radius_similarity}
+\begin{theorem}[Spectral radius under congruence similarity]
+    \label{thm:cpsv_spectral_radius_similarity}
     \lean{spectralRadius_similarityMap_eq}
     \leanok
     For an invertible matrix $C$, the linear maps
@@ -454,15 +454,15 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
         \notag
     \end{align}
     have the same spectral radius.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     The two maps are conjugate by the invertible linear transformation
     $Y\mapsto CYC^\dagger$, and therefore have the same spectrum.
 \end{proof}
 
-\begin{lemma}[Primitivity under congruence similarity]
-    \label{lem:cpsv_primitivity_similarity}
+\begin{theorem}[Primitivity under congruence similarity]
+    \label{thm:cpsv_primitivity_similarity}
     \lean{IsPrimitive.similarityMap_iff}
     \leanok
     \uses{def:primitive_channel}
@@ -473,7 +473,7 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
         \notag
     \end{align}
     is primitive.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Congruence similarity is an algebra isomorphism on the endomorphism
@@ -497,10 +497,10 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 
 \begin{proof}\leanok
     \uses{def:nt_cpsv,
-        lem:cpsv_gauge_transfer_similarity,
-        lem:cpsv_spectral_radius_similarity,
+        thm:cpsv_gauge_transfer_similarity,
+        thm:cpsv_spectral_radius_similarity,
         lem:similarity_irred_iff,
-        lem:cpsv_primitivity_similarity}
+        thm:cpsv_primitivity_similarity}
     With $S_X(Y)=XYX^\dagger$, the transfer maps satisfy
     \begin{align}
         \E_B

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -428,9 +428,9 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \label{lem:cpsv_gauge_transfer_similarity}
     \lean{MPSTensor.GaugeEquiv.transferMap_eq_similarityMap}
     \leanok
-    \uses{def:gauge_equiv}
-    If \(B^i=XA^iX^{-1}\) for every physical index \(i\), then there is an
-    invertible matrix \(C\) such that
+    \uses{def:gauge_equiv, def:transfer_map}
+    If $B^i=XA^iX^{-1}$ for every physical index $i$, then there is an
+    invertible matrix $C$ such that
     \begin{align}
         \E_B(Y)
         &=C^{-1}\E_A(CYC^\dagger)(C^\dagger)^{-1}.
@@ -439,36 +439,39 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \end{lemma}
 
 \begin{proof}\leanok
-    Expand both transfer maps and take \(C=X^{-1}\).
+    Expand both transfer maps and take $C=X^{-1}$.
 \end{proof}
 
 \begin{lemma}[Spectral radius under congruence similarity]
     \label{lem:cpsv_spectral_radius_similarity}
     \lean{spectralRadius_similarityMap_eq}
     \leanok
-    For an invertible matrix \(C\), the linear maps
-    \[
+    For an invertible matrix $C$, the linear maps
+    \begin{align}
         E
         \quad\hbox{and}\quad
         Y\longmapsto C^{-1}E(CYC^\dagger)(C^\dagger)^{-1}
-    \]
+        \notag
+    \end{align}
     have the same spectral radius.
 \end{lemma}
 
 \begin{proof}\leanok
     The two maps are conjugate by the invertible linear transformation
-    \(Y\mapsto CYC^\dagger\), and therefore have the same spectrum.
+    $Y\mapsto CYC^\dagger$, and therefore have the same spectrum.
 \end{proof}
 
 \begin{lemma}[Primitivity under congruence similarity]
     \label{lem:cpsv_primitivity_similarity}
     \lean{IsPrimitive.similarityMap_iff}
     \leanok
-    For an invertible matrix \(C\), a linear map \(E\) is primitive if and
+    \uses{def:primitive_channel}
+    For an invertible matrix $C$, a linear map $E$ is primitive if and
     only if
-    \[
+    \begin{align}
         Y\longmapsto C^{-1}E(CYC^\dagger)(C^\dagger)^{-1}
-    \]
+        \notag
+    \end{align}
     is primitive.
 \end{lemma}
 
@@ -493,7 +496,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:cpsv_gauge_transfer_similarity,
+    \uses{def:nt_cpsv,
+        lem:cpsv_gauge_transfer_similarity,
         lem:cpsv_spectral_radius_similarity,
         lem:similarity_irred_iff,
         lem:cpsv_primitivity_similarity}

--- a/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
+++ b/blueprint/src/chapter/ch09_canonical_forms_and_projectors_auxiliary.tex
@@ -424,10 +424,61 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     from Formula~(\ref{eq:cpsv_canonical_form}) by replacing $i$ with $e(j)$.
 \end{proof}
 
+\begin{lemma}[Transfer maps under a bond-space gauge]
+    \label{lem:cpsv_gauge_transfer_similarity}
+    \lean{MPSTensor.GaugeEquiv.transferMap_eq_similarityMap}
+    \leanok
+    \uses{def:gauge_equiv}
+    If \(B^i=XA^iX^{-1}\) for every physical index \(i\), then there is an
+    invertible matrix \(C\) such that
+    \begin{align}
+        \E_B(Y)
+        &=C^{-1}\E_A(CYC^\dagger)(C^\dagger)^{-1}.
+        \notag
+    \end{align}
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand both transfer maps and take \(C=X^{-1}\).
+\end{proof}
+
+\begin{lemma}[Spectral radius under congruence similarity]
+    \label{lem:cpsv_spectral_radius_similarity}
+    \lean{spectralRadius_similarityMap_eq}
+    \leanok
+    For an invertible matrix \(C\), the linear maps
+    \[
+        E
+        \quad\hbox{and}\quad
+        Y\longmapsto C^{-1}E(CYC^\dagger)(C^\dagger)^{-1}
+    \]
+    have the same spectral radius.
+\end{lemma}
+
+\begin{proof}\leanok
+    The two maps are conjugate by the invertible linear transformation
+    \(Y\mapsto CYC^\dagger\), and therefore have the same spectrum.
+\end{proof}
+
+\begin{lemma}[Primitivity under congruence similarity]
+    \label{lem:cpsv_primitivity_similarity}
+    \lean{IsPrimitive.similarityMap_iff}
+    \leanok
+    For an invertible matrix \(C\), a linear map \(E\) is primitive if and
+    only if
+    \[
+        Y\longmapsto C^{-1}E(CYC^\dagger)(C^\dagger)^{-1}
+    \]
+    is primitive.
+\end{lemma}
+
+\begin{proof}\leanok
+    Congruence similarity is an algebra isomorphism on the endomorphism
+    algebra and hence preserves the peripheral spectrum.
+\end{proof}
+
 \begin{theorem}[Gauge transport of CPSV normality]
     \label{thm:cpsv_normal_tensor_gauge_transport}
-    \lean{spectralRadius_similarityMap_eq}
-    \lean{MPSTensor.GaugeEquiv.transferMap_eq_similarityMap}
     \lean{MPSTensor.IsNormalTensor.of_gaugeEquiv}
     \leanok
     \uses{def:nt_cpsv}
@@ -442,7 +493,10 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:nt_cpsv}
+    \uses{lem:cpsv_gauge_transfer_similarity,
+        lem:cpsv_spectral_radius_similarity,
+        lem:similarity_irred_iff,
+        lem:cpsv_primitivity_similarity}
     With $S_X(Y)=XYX^\dagger$, the transfer maps satisfy
     \begin{align}
         \E_B


### PR DESCRIPTION
Follow-up to #5180. Two review findings arrived immediately after that pull request merged.

This change:

- gives the transfer-map gauge identity, spectral-radius invariance, and primitivity invariance separate checked Blueprint entries;
- records those entries, together with irreducibility under similarity, as the actual dependencies of gauge transport for CPSV normal tensors; and
- moves the physical-reindexing import to the MPO blocking module that uses it.

No declaration, theorem statement, or proof term changes.

Validation performed locally:

- `lake env lean TNLean/MPS/CanonicalForm/CPSVBlocking.lean`
- `lake env lean TNLean/MPS/MPDO/CPSVBlocking.lean`
- `leanblueprint checkdecls`

Advances #5159.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and import hygiene only; no changes to Lean proofs or API surface beyond module dependencies.
> 
> **Overview**
> **Blueprint documentation** now lists three standalone checked theorems—transfer-map gauge identity (`thm:cpsv_gauge_transfer_similarity`), spectral-radius invariance under congruence (`thm:cpsv_spectral_radius_similarity`), and primitivity invariance (`thm:cpsv_primitivity_similarity`)—instead of folding their Lean names only into gauge transport of CPSV normality. The proof of **`thm:cpsv_normal_tensor_gauge_transport`** explicitly `\uses` those entries plus irreducibility under similarity.
> 
> **Lean imports only:** `CPSVPhysicalReindex` is dropped from `TNLean/MPS/CanonicalForm/CPSVBlocking.lean` and added to `TNLean/MPS/MPDO/CPSVBlocking.lean`, where MPO blocking actually needs physical reindexing. No theorem statements or proof terms change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f2ab998e15c27cd7469a2ed164613473f901b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->