### PR TITLE
fix(PEPS/TwoInjectiveComparison): restore shared-bond finiteness

### DIFF
--- a/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
@@ -486,9 +486,9 @@ theorem fullContraction_eq
 /-! ### Operator-Schmidt uniqueness: the bond gauge -/
 
 -- The shared-bond `Fintype` instances are used in the proof (to sum over
--- `SharedBondConfig bondDim`) but not reflected in the statement, so they are
--- omitted from the type and supplied by `classical` in the body.
-omit [Fintype Bond] [(b : Bond) → Fintype (bondDim b)] in
+-- `SharedBondConfig bondDim`) but not reflected in the statement, so the
+-- `unusedFintypeInType` linter cannot see them.
+set_option linter.unusedFintypeInType false in
 open scoped Classical in
 /-- Config-indexed linear independence from joint injectivity.
 


### PR DESCRIPTION
Fixes #5192.

PR #5187 replaced a load-bearing `unusedFintypeInType` suppression with an `omit` wrapper. The proof of config-indexed linear independence still sums over `SharedBondConfig bondDim`, so omitting the shared-bond `Fintype` instances makes synthetic-merge CI fail across open pull requests. A `classical` block supplies decidable instances, not finiteness.

This restores the local suppression and its accurate explanation, leaving the theorem statement and proof unchanged.

Validation:

- `lake build TNLean.PEPS.TwoInjectiveComparison.Basic -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`
- no proof-integrity blockers in the affected module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and linter-only change around an existing theorem; no logic or API changes.
> 
> **Overview**
> **Restores local `unusedFintypeInType` handling** for `IsTwoBlockInjective.config_linearIndependent` after an `omit` of the shared-bond `Fintype` hypotheses broke CI.
> 
> The change **drops the `omit [Fintype Bond] …` wrapper** and **re-enables** `set_option linter.unusedFintypeInType false` with an updated comment: the proof still **sums over `SharedBondConfig bondDim`**, so those finiteness instances are load-bearing even though they do not appear in the theorem statement. The **statement and proof body are unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8c6a0bd9d32f746c2f666926d13d8647a43a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->