### PR TITLE
doc(MPS/MPDO): isolate exact Gram-dressing obstruction

### DIFF
--- a/TNLean/MPS/MPDO/PositiveMinimalRealizationCounterexample.lean
+++ b/TNLean/MPS/MPDO/PositiveMinimalRealizationCounterexample.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.NormalCommutant
+import TNLean.MPS.MPDO.FigureEightPairwise
 import TNLean.MPS.Tactic.Basic
 
 /-!
@@ -27,8 +28,10 @@ information.
 This is the obstruction recorded in the discussion of arXiv:1606.00608,
 Appendix C.4, lines 2048--2057, and Proposition 4.13, lines 1898--1921.
 
-## Main result
+## Main results
 
+* `gramDressing_gauge_ne_one`: the exact invertible gauge does not preserve
+  the identity Gram dressing.
 * `sameMPV₂Pos_does_not_force_positive_isometric_realization`: the explicit
   nonunitary-similarity counterexample.
 -/
@@ -139,6 +142,31 @@ vectors. -/
 lemma tensor_sameMPV₂Pos_gaugedTensor : SameMPV₂Pos tensor gaugedTensor := by
   mpv_ext
   exact GaugeEquiv.sameMPV tensor_gaugeEquiv_gaugedTensor N σ
+
+/-- The nonunitary similarity has a nontrivial Gram dressing on the source
+tensor.
+
+Thus equality of all positive-length closed chains and an exact invertible
+gauge do not permit transport of the identity Gram dressing through a general
+invertible gauge.  A common physical target or equivalent marked-chain
+identity is still necessary.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2057, and Proposition
+4.13, lines 1898--1921. -/
+lemma gramDressing_gauge_ne_one :
+    MPOTensor.gramDressing (D := 2) gauge tensor ≠
+      MPOTensor.gramDressing (D := 2) (1 : GL (Fin 2) ℂ) tensor := by
+  intro h
+  have h2 := congrFun h 2
+  simp only [MPOTensor.gramDressing] at h2
+  rw [Matrix.mul_inv_rev, ← Matrix.conjTranspose_nonsing_inv] at h2
+  rw [← Matrix.coe_units_inv gauge] at h2
+  rw [gauge_inv_val] at h2
+  have h201 := congrArg (fun M ↦ M 0 1) h2
+  norm_num [gauge_val, gaugeMatrix, tensor,
+    Matrix.mul_apply, Matrix.vecMul, dotProduct, Fin.sum_univ_two,
+    Matrix.conjTranspose_apply, map_ofNat] at h201
+  simp at h201
 
 @[simp]
 private lemma tensor_zero : tensor 0 = 1 := by

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -278,6 +278,66 @@ explicitly.  The explicit obstruction is formalized in the declaration
 \mbox{\leanid{isometric_realization}}.
 \end{center}
 
+\section{The exact Gram-dressing obstruction}
+
+The same example also rules out transporting the identity Gram dressing
+through an arbitrary exact invertible gauge.  With the notation above,
+\[
+  \operatorname{gramDressing}(X,A)^v
+  =(X^\dagger X)A^v(X^\dagger X)^{-1}.
+\]
+For the letter $A^v=E_{01}$ and
+$X^\dagger X=\operatorname{diag}(4,1)$, this gives
+\[
+  \operatorname{gramDressing}(X,A)^v=4E_{01},
+  \qquad
+  \operatorname{gramDressing}(\mathbf 1,A)^v=E_{01}.
+\]
+Consequently the exact gauge and equality of every positive-length closed
+chain do not imply the marked Figure~8 identity.  This assertion is
+formalized as
+\begin{center}
+\scriptsize
+\mbox{\leanid{MPSTensor.PositiveMinimalRealizationCounterexample.}}\\
+\mbox{\leanid{gramDressing_gauge_ne_one}.}
+\end{center}
+
+This is a sharp obstruction to any proof using only the fields
+\path{TwoSiteExactSectorGauge.tensor_eq} and
+\path{TwoSiteExactSectorGauge.sector_sameMPV}.  It is not a counterexample to
+the complete tensor-attached hypotheses of Theorem~4.14(ii): the displayed
+two-by-two tensor has not been made into a tensor-attached algebra clause
+satisfying horizontal canonical form and positivity of every matrix product
+operator.
+
+\section{Non-circular product corners}
+
+The one-site coisometric reconstruction does give genuine local information
+beyond closed chains.  Squaring it produces isometric inclusions for the
+retained product sectors of the two-site blocking.  Decomposing those product
+tensors into normal summands, comparing them with the actual two-site
+vertical canonical form, and applying Proposition~4.13 legitimately
+normalizes every active product gauge.  This part uses the common physical
+tensor and does not assume a renormalization map.
+
+The first unresolved step is the identification of such an active product
+corner with the prescribed original representative $M_\gamma$.  The present
+transport theorem requires a unitary matrix and the letterwise identity
+\[
+  A_{\sigma(\gamma)}^v
+  =
+  \frac{\operatorname{tr}(\mu_\gamma)}
+       {\operatorname{tr}(\nu_{\sigma(\gamma)})}
+  U_\gamma M_\gamma^v U_\gamma^\dagger.
+\]
+The only current construction of these data uses the mutually inverse
+completely positive trace-preserving maps whose existence is downstream of
+the implication under study.  The algebra clause supplies instead only the
+closed cyclic product law.  Hence the active-corner construction stops at the
+same metric boundary exhibited by the preceding example: it gives coverage
+up to phase and invertible similarity, but not the star-preserving local
+comparison needed to identify the two Gram dressings.
+
 \section{Faithful target and remaining boundary}
 
 For a matched label $\gamma$, let $A_\gamma$ be the algebra-side


### PR DESCRIPTION
## Motivation

CPSV16 Appendix C.4, lines 2048–2057, passes from algebra-side representatives to physical vertical canonical-form tensors “up to unitaries.” Issue #4648 asks for the tensor-attached marked/common-target identity needed to justify this passage. The existing exact GL similarity and closed-chain data do not determine the Hilbert-space metric, so they cannot by themselves yield identity Gram dressing.

This pull request records that precise obstruction and the first missing non-circular transport step. It advances #4648 without claiming to complete it.

## Description

- Add MPSTensor.PositiveMinimalRealizationCounterexample.gramDressing_gauge_ne_one. For the diagonal gauge diag(2,1) and the matrix unit E₀₁, the nontrivial Gram dressing is 4E₀₁, whereas identity dressing is E₀₁. Thus exact GL similarity and equality of all closed chains do not permit one to replace the Gram matrix by the identity.
- Extend docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex with this exact obstruction and the strongest presently available non-circular product-corner route. The note identifies the first missing statement: a unitary transport back to the original physical tensor, with a local letter identity, followed by a second marked realization in a common ambient space.
- State explicitly that this is not a counterexample to the full H/S/hHorizontal/hM contract and does not complete #4648 or #4645. The Blueprint status is unchanged.

## Testing

- lake exe cache get: succeeded; no files to download, 8639 files already decompressed.
- lake env lean TNLean/MPS/MPDO/PositiveMinimalRealizationCounterexample.lean: passed on the merged current-main head.
- python3 scripts/check_reader_facing_prose.py --diff-base origin/main: passed.
- python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main: passed.
- git diff --check origin/main...HEAD: passed.
- Standalone latexmk build of the paper-gap note: passed, 6 pages, with no overfull or underfull box warnings; the two changed pages were visually inspected.
- lake build on the preceding base compiled the changed module successfully at step 9740 and then exited 1 solely because TNLean/PEPS/TwoInjectiveComparison/Basic.lean:510–529 on that base lacked a Fintype (SharedBondConfig bondDim) instance. That unrelated main-branch failure was subsequently fixed by the merged current main.

## Agent disclosure

This pull request was prepared with OpenAI Codex. Codex audited the cited source and current APIs, developed the Lean proof, revised the paper-gap note, and ran the validations listed above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a localized Lean proof and documentation on an existing counterexample module; no changes to core gauge or authentication paths.
> 
> **Overview**
> Adds **`gramDressing_gauge_ne_one`** on the existing `diag(2,1)` vs identity counterexample: for letter index `2` (`E₀₁`), the nontrivial gauge yields **`4E₀₁`** Gram dressing while the identity gauge yields **`E₀₁`**, so exact **`GL`** similarity plus matching closed chains do **not** force identity Gram dressing (marked Figure~8).
> 
> The CPSV16 two-site gauge-gap note gains sections on this **exact Gram-dressing obstruction** (scoped to `TwoSiteExactSectorGauge.tensor_eq` / `sector_sameMPV`, not full tensor-attached hypotheses) and on **non-circular product corners**—what one-site coisometry can normalize vs the still-missing unitary transport back to the original representative `M_γ`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f090f2df7df00143d712a0507d69105790029fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->