### PR TITLE
feat(MPS/RFP): assemble corrected CPSV equivalence

### DIFF
--- a/TNLean/MPS/RFP/MainMPSConditional.lean
+++ b/TNLean/MPS/RFP/MainMPSConditional.lean
@@ -4,14 +4,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.RFP.NNCPHGroundSpacesMultiSector
+import TNLean.MPS.RFP.BeigiLoopBNTIdentification
 import TNLean.MPS.RFP.ZCLReverse
 
 /-!
-# Zero-correlation-length implications for commuting parent ground spaces
+# Fixed-point, zero-correlation-length, and commuting-ground-space equivalences
 
-This file proves the corrected positive-gap implication from zero correlation
-length to nearest-neighbor commuting parent-Hamiltonian ground spaces for the
-multiplicity-one unit-weight representative.
+This file proves the corrected equivalences among transfer idempotence,
+positive-gap BNT zero correlation length, and nearest-neighbor commuting
+parent-Hamiltonian ground spaces for the multiplicity-one unit-weight
+representative. It also retains the conditional spectral-pair implication.
 
 ## References
 
@@ -74,6 +76,48 @@ theorem isPositiveGapBNTZCL_implies_hasNNCPHGroundSpaces_basisDirectSum
     HasNNCPHGroundSpaces (directSumTensor P.basis) P.basis :=
   hCF.rfp_implies_hasNNCPHGroundSpaces_basisDirectSum
     (hCF.isTransferIdempotent_basisDirectSum_of_isPositiveGapBNTZCL hZCL)
+
+/-- Transfer idempotence is equivalent to the all-chain nearest-neighbor
+commuting parent-Hamiltonian ground-space condition for the direct sum of the
+distinct BNT basis tensors.
+
+This is the corrected representative-level equivalence between conditions
+(i) and (iii) of CPSV16, Theorem `thm:main-MPS`, lines 534--541; the reverse
+argument is at lines 1305--1307.
+
+**Scope restriction (multiplicity-one unit weights):** the tensor is
+`directSumTensor P.basis`, with one unit-weight copy of each distinct BNT
+basis tensor. The statement does not cover repeated copies or arbitrary raw
+weights. See `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem isTransferIdempotent_basisDirectSum_iff_hasNNCPHGroundSpaces
+    (hCF : IsBNTCanonicalForm P) :
+    IsTransferIdempotent (directSumTensor P.basis) ↔
+      HasNNCPHGroundSpaces (directSumTensor P.basis) P.basis :=
+  ⟨hCF.rfp_implies_hasNNCPHGroundSpaces_basisDirectSum,
+    hCF.isTransferIdempotent_basisDirectSum_of_hasNNCPHGroundSpaces⟩
+
+/-- Positive-gap BNT zero correlation length is equivalent to the all-chain
+nearest-neighbor commuting parent-Hamiltonian ground-space condition for the
+direct sum of the distinct BNT basis tensors.
+
+This is the corrected representative-level equivalence between conditions
+(ii) and (iii) of CPSV16, Theorem `thm:main-MPS`, lines 534--541; the
+positive-gap repair concerns lines 1248--1268, and the reverse NNCPH argument
+is at lines 1305--1307.
+
+**Scope restriction (multiplicity-one unit weights and positive gaps):** the
+tensor is `directSumTensor P.basis`, with one unit-weight copy of each distinct
+BNT basis tensor, and the correlation condition excludes adjacent
+complementary regions. The statement does not cover repeated copies or
+arbitrary raw weights. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex` and
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
+theorem isPositiveGapBNTZCL_basisDirectSum_iff_hasNNCPHGroundSpaces
+    (hCF : IsBNTCanonicalForm P) :
+    IsPositiveGapBNTZCL (directSumTensor P.basis) P.basis ↔
+      HasNNCPHGroundSpaces (directSumTensor P.basis) P.basis :=
+  hCF.isPositiveGapBNTZCL_basisDirectSum_iff_isTransferIdempotent.trans
+    hCF.isTransferIdempotent_basisDirectSum_iff_hasNNCPHGroundSpaces
 
 end IsBNTCanonicalForm
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap_beigi_loops.tex
@@ -664,3 +664,28 @@
     \end{align}
     for every pair $j,k$, and proves the claim.
 \end{proof}
+
+\begin{theorem}[Fixed points and commuting parent ground spaces for the basis direct sum]
+    \label{thm:rfp_multiplicity_one_bnt_iff_nncph_ground_spaces}
+    \lean{MPSTensor.IsBNTCanonicalForm.isTransferIdempotent_basisDirectSum_iff_hasNNCPHGroundSpaces}
+    \leanok
+    \uses{thm:rfp_multiplicity_one_bnt_has_nncph_ground_spaces,
+        thm:nncph_implies_rfp_basis_direct_sum}
+    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
+    form, and set $A=\bigoplus_{j=1}^g A_j$. Then
+    \begin{align}
+        \mathcal E_A^2=\mathcal E_A
+        \quad\Longleftrightarrow\quad
+        A\text{ has all-chain commuting parent ground spaces spanned by }(A_j)_j.
+    \end{align}
+    This statement concerns the multiplicity-one, unit-weight direct sum; it
+    does not include repeated copies or arbitrary raw weights.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The forward implication is
+    Theorem~\ref{thm:rfp_multiplicity_one_bnt_has_nncph_ground_spaces}, and the
+    reverse implication is
+    Theorem~\ref{thm:nncph_implies_rfp_basis_direct_sum}.
+\end{proof}

--- a/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
+++ b/blueprint/src/chapter/ch26_mps_rfp_zero_correlation_length.tex
@@ -860,6 +860,35 @@
     stated interactions and ground spaces.
 \end{proof}
 
+\begin{theorem}[Positive-gap zero correlation length and commuting parent
+    ground spaces for the basis direct sum]
+    \label{thm:positive_gap_bnt_zcl_multiplicity_one_iff_nncph_ground_spaces}
+    \lean{MPSTensor.IsBNTCanonicalForm.isPositiveGapBNTZCL_basisDirectSum_iff_hasNNCPHGroundSpaces}
+    \leanok
+    \uses{thm:positive_gap_bnt_zcl_multiplicity_one_iff_rfp,
+        thm:rfp_multiplicity_one_bnt_iff_nncph_ground_spaces}
+    Let $A_1,\ldots,A_g$ be the distinct basis tensors of a BNT canonical
+    form, and set $A=\bigoplus_{j=1}^g A_j$. Then
+    \begin{align}
+        A\text{ has positive-gap BNT zero correlation length}
+        \quad\Longleftrightarrow\quad
+        A\text{ has all-chain commuting parent ground spaces spanned by }(A_j)_j.
+    \end{align}
+    This statement concerns one unit-weight copy of each distinct sector and
+    positive complementary gaps. It does not include repeated copies,
+    arbitrary raw weights, or adjacent complementary regions.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By
+    Theorem~\ref{thm:positive_gap_bnt_zcl_multiplicity_one_iff_rfp},
+    positive-gap BNT zero correlation length is equivalent to transfer
+    idempotence. The latter is equivalent to the all-chain commuting parent
+    ground-space condition by
+    Theorem~\ref{thm:rfp_multiplicity_one_bnt_iff_nncph_ground_spaces}.
+\end{proof}
+
 \begin{remark}[Remaining obstructions in the printed converse]
     For the multiplicity-one unit-weight representative, the sector-supported
     observables require no additional hypothesis. The full literal CPSV

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -134,10 +134,12 @@ This implication uses only BNT canonical form and transfer idempotence of the
 whole multiplicity-one direct sum. It uses no comparison, crossing,
 repeated-copy, raw-weight, or externally supplied commutation hypothesis.
 
-This scope-restricted implication does not prove the full source theorem.  The
-ground-space spanning condition for repeated copies and arbitrary raw sector
-weights, the three-way equivalence with ZCL, the complete canonical-form
-hypotheses from the source statement remain open.
+This scope-restricted implication does not prove the full source theorem.
+Together with the reverse implication and the corrected positive-gap
+zero-correlation-length equivalence, it does prove the three-way equivalence
+for the multiplicity-one, unit-weight basis direct sum.  Repeated copies,
+arbitrary raw sector weights, adjacent complementary gaps, and the complete
+unrestricted canonical-form statement remain excluded.
 For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 Appendix~B supplies the basic-vector form.  The local projectors in
@@ -536,11 +538,10 @@ parent interactions.  If the criterion is needed independently of Beigi's
 decomposition, its hypothesis should be replaced by explicit pairwise
 commutativity of the translated interactions.
 
-\section{Remaining extension plan}
+\section{Completed representative equivalence and residual scope}
 
-The immediate remaining theorem should assemble the corrected three-way
-equivalence for the multiplicity-one, unit-weight direct sum of the distinct
-BNT basis tensors:
+The corrected three-way equivalence is now assembled for the
+multiplicity-one, unit-weight direct sum of the distinct BNT basis tensors:
 \begin{align}
   \mathrm{RFP}(A_{\mathrm{basis}})
   \Longleftrightarrow
@@ -548,14 +549,17 @@ BNT basis tensors:
   \Longleftrightarrow
   \mathrm{HasNNCPHGroundSpaces}(A_{\mathrm{basis}}).
 \end{align}
-The reverse implication is now proved both for a normal left-canonical
+The reverse implication is proved both for a normal left-canonical
 representative and for the multiplicity-one, unit-weight direct sum of all
 distinct BNT basis sectors.  In the latter statement the comparison with
 Beigi's locally orthogonal product-of-pairs loop states is performed
-familywise and requires no axiom.  The remaining task is therefore only to
-combine this reverse implication with the already proved representative-level
-RFP--positive-gap-ZCL equivalence and RFP-to-NNCPH direction in one theorem
-with precise hypotheses.\footnote{Tracked by \ghissue{2633}.}
+familywise and requires no axiom.  The pairwise equivalences are formalized by
+\leanid{MPSTensor.IsBNTCanonicalForm.%
+isTransferIdempotent_basisDirectSum_iff_hasNNCPHGroundSpaces}
+and
+\leanid{MPSTensor.IsBNTCanonicalForm.%
+isPositiveGapBNTZCL_basisDirectSum_iff_hasNNCPHGroundSpaces}.
+\footnote{Tracked by \ghissue{2633}.}
 
 The current proof boundary is therefore: the reverse implication is proved for
 the corrected basis-direct-sum representative satisfying the source all-chain
@@ -589,8 +593,10 @@ independence together with the source all-chain ground-space condition.  Their
 comparison with the original tensor is proved for one normal left-canonical
 representative and familywise for the multiplicity-one, unit-weight BNT basis
 direct sum; the corresponding transfer-idempotence statements are proved.
-What remains is to assemble these representative-level implications into the
-corrected three-way theorem stated above.
+These representative-level implications are assembled by the two
+biconditionals above.  The residual gap is only the printed unrestricted
+statement, whose repeated-copy, raw-weight, and adjacent-gap boundaries are
+excluded from the corrected theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -257,6 +257,15 @@ correction to line 1250 rather than a formalization of the printed spectral
 argument.  It does not alter the raw-weight counterexample or the adjacent-gap
 scope restriction.
 
+Combining this repair with the fixed-point characterization of the all-chain
+commuting parent ground spaces gives the corrected representative-level
+equivalence, formalized by
+\leanid{MPSTensor.IsBNTCanonicalForm.%
+isPositiveGapBNTZCL_basisDirectSum_iff_hasNNCPHGroundSpaces}.
+The statement concerns the multiplicity-one, unit-weight basis direct sum and
+positive complementary gaps.  Repeated copies, arbitrary raw weights, and
+zero complementary gaps remain excluded.
+
 Since the older predicate universally quantifies over positive definite fixed
 points, it is also vacuous for a tensor without such a fixed point.  The
 periodic-chain predicate avoids this boundary-state issue.  For the


### PR DESCRIPTION
Closes #5194.

## Summary

- add the natural basis-direct-sum biconditional between transfer idempotence and all-chain NNCPH ground spaces
- compose it with the existing positive-gap BNT ZCL equivalence
- link the two pairwise results in the Blueprint and close the representative-level assembly in both paper-gap notes

## Source and scope

This packages the corrected multiplicity-one, unit-weight representative case of CPSV16 Theorem `thm:main-MPS` (lines 534–541; reverse discussion at lines 1305–1307). The ZCL statement uses positive complementary gaps. Repeated copies, arbitrary raw weights, and adjacent complementary regions remain excluded; the printed unrestricted theorem stays `\notready`.

No aggregate `A ↔ B ∧ C` declaration and no `Recovered...` name is introduced.

## Validation

- `lake build TNLean.MPS.RFP.MainMPSConditional -q`
- `lake build TNLean -q` (incremental hot-main aggregate refresh; no Mathlib rebuild)
- proof-integrity search on the changed Lean file
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main...HEAD`

## Documentation

The unrestricted CPSV16 theorem remains unformalized for the documented raw-weight and adjacent-gap obstructions. This PR only closes the corrected representative-level assembly tracked by #2633.