### PR TITLE
feat(MPS/MPDO): construct literal CPSV vertical decompositions

### DIFF
--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Algebra.Module.BigOperators
 import Mathlib.Data.Complex.Basic
@@ -15,6 +16,18 @@ This file collects small finite-sum identities.
 -/
 
 open scoped BigOperators
+
+namespace Fintype
+
+/-- Reindex a sum over a finite dependent pair by `finSigmaFinEquiv`. -/
+theorem sum_finSigmaFinEquiv {g : ℕ} {mult : Fin g → ℕ} {β : Type*}
+    [AddCommMonoid β] (f : ((j : Fin g) × Fin (mult j)) → β) :
+    ∑ q : Fin (∑ j, mult j), f (finSigmaFinEquiv.symm q) =
+      ∑ j, ∑ q, f ⟨j, q⟩ := by
+  rw [Equiv.sum_comp finSigmaFinEquiv.symm f, ← Finset.univ_sigma_univ,
+    Finset.sum_sigma]
+
+end Fintype
 
 namespace Fin
 

--- a/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
+++ b/TNLean/Channel/KoashiImoto/PooledKrausFamily.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.Channel.KoashiImoto.CommonInvariantAlgebra
 
 /-!
@@ -78,14 +79,6 @@ noncomputable def pooledKfam (K : (μ : Fin M) → Fin (r μ) → Mat) :
   fun k => ((poolScale M : ℝ) : ℂ) • K (finSigmaFinEquiv.symm k).1 (finSigmaFinEquiv.symm k).2
 
 omit [NeZero M] in
-/-- A sum over the pooled index `Fin (∑ μ, r μ)`, reindexed along `finSigmaFinEquiv`, splits
-into the double sum over `μ` and the Kraus index of `K μ`. -/
-private theorem sum_pooled_reindex {β : Type*} [AddCommMonoid β]
-    (f : (Σ _μ : Fin M, Fin (r _μ)) → β) :
-    ∑ k : Fin (∑ μ, r μ), f (finSigmaFinEquiv.symm k) = ∑ μ, ∑ i, f ⟨μ, i⟩ := by
-  rw [Equiv.sum_comp finSigmaFinEquiv.symm f, ← Finset.univ_sigma_univ, Finset.sum_sigma]
-
-omit [NeZero M] in
 /-- **The pooled Kraus map is the average of the individual ones.**
 
 HJPW, arXiv:quant-ph/0304007v2, line 849: `F_0 = (1/M) ∑_μ F_μ`. -/
@@ -96,8 +89,9 @@ theorem map_pooledKfam (K : (μ : Fin M) → Fin (r μ) → Mat) (X : Mat) :
     change ∑ k : Fin (∑ μ, r μ), pooledKfam K k * X * (pooledKfam K k)ᴴ = _
     simp only [pooledKfam, Matrix.conjTranspose_smul, Complex.star_def,
       Complex.conj_ofReal, smul_mul_assoc, mul_smul_comm, smul_smul]
-    rw [sum_pooled_reindex (fun p => (((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ)) •
-      (K p.1 p.2 * X * (K p.1 p.2)ᴴ))]
+    rw [Fintype.sum_finSigmaFinEquiv
+      (fun p => (((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ)) •
+        (K p.1 p.2 * X * (K p.1 p.2)ᴴ))]
     simp only [cpow_poolScale_sq, ← Finset.smul_sum]
   rw [hstep]
   simp only [map]
@@ -109,8 +103,9 @@ theorem isTP_pooledKfam (K : (μ : Fin M) → Fin (r μ) → Mat) (hK : ∀ μ, 
       = (M : ℂ)⁻¹ • ∑ μ, ∑ i, (K μ i)ᴴ * K μ i := by
     simp only [pooledKfam, Matrix.conjTranspose_smul, Complex.star_def, Complex.conj_ofReal,
       smul_mul_assoc, mul_smul_comm, smul_smul]
-    rw [sum_pooled_reindex (fun p => (((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ)) •
-      ((K p.1 p.2)ᴴ * K p.1 p.2))]
+    rw [Fintype.sum_finSigmaFinEquiv
+      (fun p => (((poolScale M : ℝ) : ℂ) * ((poolScale M : ℝ) : ℂ)) •
+        ((K p.1 p.2)ᴴ * K p.1 p.2))]
     simp only [cpow_poolScale_sq, ← Finset.smul_sum]
   change ∑ k : Fin (∑ μ, r μ), (pooledKfam K k)ᴴ * pooledKfam K k = 1
   rw [hstep]

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -77,6 +77,7 @@ import TNLean.MPS.MPDO.CPSVRepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.CPSVSharpBlocking
 import TNLean.MPS.MPDO.CPSVVerticalBNT
 import TNLean.MPS.MPDO.CPSVVerticalCanonicalForm
+import TNLean.MPS.MPDO.CPSVVerticalDecomposition
 import TNLean.MPS.MPDO.CommonWeightAbsorbedBNTSupport
 import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.CommutingBondEtaBoundaryTrace

--- a/TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean
@@ -73,8 +73,6 @@ theorem verticalCF_of_cpsvCanonicalForm (M : MPOTensor d D)
       ((mu (C.enum p.1 p.2) * zeta p.1 p.2) • blocks (C.repr p.1) v) *
       (W p)ᴴ
   change (∑ j, ∑ q, f ⟨j, q⟩) = ∑ q, f (finSigmaFinEquiv.symm q)
-  calc
-    _ = ∑ p, f p := (Fintype.sum_sigma f).symm
-    _ = _ := (Equiv.sum_comp finSigmaFinEquiv.symm f).symm
+  exact (Fintype.sum_finSigmaFinEquiv f).symm
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/CPSVVerticalDecomposition.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalDecomposition.lean
@@ -79,9 +79,7 @@ theorem exists_cpsvVerticalDecomposition
         blocks (C.repr p.1) ab) * (W p)ᴴ
     change (∑ j, ∑ q, f ⟨j, q⟩) =
       ∑ q, f (finSigmaFinEquiv.symm q)
-    calc
-      _ = ∑ p, f p := (Fintype.sum_sigma f).symm
-      _ = _ := (Equiv.sum_comp finSigmaFinEquiv.symm f).symm
+    exact (Fintype.sum_finSigmaFinEquiv f).symm
   exact MPOTensor.cpsvVerticalDecomposition_of_grouped_orthogonal_sectors M
     (fun j ↦ dim (C.repr j)) C.copies C.copies_pos
     (fun j q ↦ mu (C.enum j q) * zeta j q) hCoeffPos

--- a/TNLean/MPS/MPDO/CPSVVerticalDecomposition.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalDecomposition.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CPSVBlocking
+import TNLean.MPS.MPDO.CPSVNormalizedGroupedSectors
+import TNLean.MPS.MPDO.CPSVVerticalBNT
+import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
+
+/-!
+# Vertical decomposition from literal CPSV canonical form
+
+Literal CPSV canonical form and matrix-product-density-operator positivity give
+one-site and two-site vertical decompositions retaining the source basis of
+normal tensors.
+
+## Main results
+
+* `MPSTensor.IsCPSVCanonicalForm.exists_cpsvVerticalDecomposition`
+* `MPSTensor.IsCPSVCanonicalForm.exists_cpsvVerticalDecomposition_blockTwo`
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13 and Appendix C.4, lines 1951--1956.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPSTensor.IsCPSVCanonicalForm
+
+variable {d D : ℕ}
+
+/-- Literal CPSV canonical form and MPDO positivity furnish a vertical
+canonical decomposition retaining the CPSV basis-of-normal-tensors predicate.
+
+The decomposition has positive diagonal weights, mutually orthogonal physical
+sector maps, and exact forward and reverse identities.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1863--1921. -/
+theorem exists_cpsvVerticalDecomposition
+    (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : MPOTensor.IsMPDO M) :
+    Nonempty (MPOTensor.CPSVVerticalDecomposition M) := by
+  classical
+  obtain ⟨r, dim, mu, blocks, V, hDimPos, _, hNormal, hIso, _, _, hInterStar,
+    _, hReconstruct, hdim, X, zeta, _, _, hXDist, _, _, hSpectralBNT, _, _, _, _,
+    hCoeffPos, hGroupedIso, hGroupedOrth, hGroupedInter, _, hGroupedCorner,
+    hGroupedReconstruct⟩ :=
+      hCanonical.exists_verticalBNTGrouping_with_isometry M hM
+  let C := MPSTensor.mpvPhaseClassData blocks
+  have hSame : MPSTensor.SameMPV₂Pos (MPOTensor.verticalTensor M)
+      (MPSTensor.toTensorFromBlocks (d := D * D) (μ := mu) blocks) :=
+    MPSTensor.sameMPV₂Pos_toTensorFromBlocks_of_reconstruction
+      (MPOTensor.verticalTensor M) mu blocks V hIso hInterStar hReconstruct
+  have hBNT : MPSTensor.IsCPSVBasisOfNormalTensors (MPOTensor.verticalTensor M)
+      (fun j ↦ ⟨dim (C.repr j), blocks (C.repr j)⟩) :=
+    hSpectralBNT.of_sameMPV₂Pos hSame.symm
+  obtain ⟨_, W, _, hWIso, hWOrth, hWInter, hWReconstruct⟩ :=
+    hCanonical.exists_normalized_grouped_sector_maps blocks hM mu V hDimPos
+      hNormal hdim X zeta hXDist hCoeffPos hGroupedIso hGroupedOrth
+      hGroupedInter hGroupedCorner hGroupedReconstruct
+  have hWReconstructFlat : ∀ ab, MPOTensor.verticalTensor M ab =
+      ∑ q : Fin (∑ j, C.copies j),
+        MPOTensor.flattenGroupedSectorMap (fun j ↦ dim (C.repr j)) C.copies W q *
+          ((MPOTensor.verticalCopyWeights C.copies
+              (fun j q ↦ mu (C.enum j q) * zeta j q) q) •
+            MPOTensor.verticalCopyBlocks (fun j ↦ dim (C.repr j)) C.copies
+              (fun j ↦ blocks (C.repr j)) q ab) *
+          (MPOTensor.flattenGroupedSectorMap
+            (fun j ↦ dim (C.repr j)) C.copies W q)ᴴ := by
+    intro ab
+    rw [hWReconstruct ab]
+    let f : ((j : Fin C.g) × Fin (C.copies j)) →
+        Matrix (Fin d) (Fin d) ℂ := fun p ↦
+      W p * ((mu (C.enum p.1 p.2) * zeta p.1 p.2) •
+        blocks (C.repr p.1) ab) * (W p)ᴴ
+    change (∑ j, ∑ q, f ⟨j, q⟩) =
+      ∑ q, f (finSigmaFinEquiv.symm q)
+    calc
+      _ = ∑ p, f p := (Fintype.sum_sigma f).symm
+      _ = _ := (Equiv.sum_comp finSigmaFinEquiv.symm f).symm
+  exact MPOTensor.cpsvVerticalDecomposition_of_grouped_orthogonal_sectors M
+    (fun j ↦ dim (C.repr j)) C.copies C.copies_pos
+    (fun j q ↦ mu (C.enum j q) * zeta j q) hCoeffPos
+    (fun j ↦ blocks (C.repr j)) hBNT W hWIso hWOrth hWInter
+    hWReconstructFlat
+
+/-- The concrete two-site block of a literal CPSV canonical MPDO has a
+vertical canonical decomposition retaining the CPSV basis predicate.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 1951--1956. -/
+theorem exists_cpsvVerticalDecomposition_blockTwo
+    (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : MPOTensor.IsMPDO M) :
+    Nonempty (MPOTensor.CPSVVerticalDecomposition (MPOTensor.blockTwo M)) := by
+  have hBlocked :=
+    MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTwo hCanonical
+  exact hBlocked.exists_cpsvVerticalDecomposition (MPOTensor.blockTwo M) hM.blockTwo
+
+end MPSTensor.IsCPSVCanonicalForm

--- a/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/RFPPositiveFusionDecomposition.lean
@@ -250,9 +250,7 @@ theorem IsHorizontalCF.exists_cpsvVerticalDecomposition
         blocks (C.repr p.1) ab) * (W p)ᴴ
     change (∑ j, ∑ q, f ⟨j, q⟩) =
       ∑ q, f (finSigmaFinEquiv.symm q)
-    calc
-      _ = ∑ p, f p := (Fintype.sum_sigma f).symm
-      _ = _ := (Equiv.sum_comp finSigmaFinEquiv.symm f).symm
+    exact (Fintype.sum_finSigmaFinEquiv f).symm
   exact cpsvVerticalDecomposition_of_grouped_orthogonal_sectors M
     (fun j ↦ dim (C.repr j)) C.copies C.copies_pos
     (fun j q ↦ mu (C.enum j q) * zeta j q) hCoeffPos

--- a/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
+++ b/TNLean/MPS/MPDO/VerticalCanonicalForm.lean
@@ -79,8 +79,6 @@ theorem verticalCF_of_horizontalCF (M : MPOTensor d D)
       ((mu (C.enum p.1 p.2) * zeta p.1 p.2) • blocks (C.repr p.1) v) *
       (W p)ᴴ
   change (∑ j, ∑ q, f ⟨j, q⟩) = ∑ q, f (finSigmaFinEquiv.symm q)
-  calc
-    _ = ∑ p, f p := (Fintype.sum_sigma f).symm
-    _ = _ := (Equiv.sum_comp finSigmaFinEquiv.symm f).symm
+  exact (Fintype.sum_finSigmaFinEquiv f).symm
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalCoisometry.lean
+++ b/TNLean/MPS/MPDO/VerticalCoisometry.lean
@@ -45,6 +45,18 @@ conditional consequence of an assumed literal sum over the sector corners.
 
 open scoped Matrix BigOperators ComplexOrder
 
+namespace Fintype
+
+/-- Reindex a sum over a finite dependent pair by `finSigmaFinEquiv`. -/
+theorem sum_finSigmaFinEquiv {g : ℕ} {mult : Fin g → ℕ} {β : Type*}
+    [AddCommMonoid β] (f : ((j : Fin g) × Fin (mult j)) → β) :
+    ∑ q : Fin (∑ j, mult j), f (finSigmaFinEquiv.symm q) =
+      ∑ j, ∑ q, f ⟨j, q⟩ := by
+  rw [Equiv.sum_comp finSigmaFinEquiv.symm f, ← Finset.univ_sigma_univ,
+    Finset.sum_sigma]
+
+end Fintype
+
 namespace Matrix
 
 variable {r d s : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/MPDO/VerticalCoisometry.lean
+++ b/TNLean/MPS/MPDO/VerticalCoisometry.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FinSum
 import TNLean.MPS.MPDO.VerticalCF
 
 /-!
@@ -44,18 +45,6 @@ conditional consequence of an assumed literal sum over the sector corners.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
-
-namespace Fintype
-
-/-- Reindex a sum over a finite dependent pair by `finSigmaFinEquiv`. -/
-theorem sum_finSigmaFinEquiv {g : ℕ} {mult : Fin g → ℕ} {β : Type*}
-    [AddCommMonoid β] (f : ((j : Fin g) × Fin (mult j)) → β) :
-    ∑ q : Fin (∑ j, mult j), f (finSigmaFinEquiv.symm q) =
-      ∑ j, ∑ q, f ⟨j, q⟩ := by
-  rw [Equiv.sum_comp finSigmaFinEquiv.symm f, ← Finset.univ_sigma_univ,
-    Finset.sum_sigma]
-
-end Fintype
 
 namespace Matrix
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -212,6 +212,90 @@ physical indices, as in
     identification of Theorem~\ref{thm:mpdo_block_two_as_positive_blocking}.
 \end{proof}
 
+% This is the vertical-decomposition input to Appendix C.4, not the later
+% positive-fusion or Gibbs conclusion.
+\begin{theorem}[Literal one-site vertical decomposition]
+    \label{thm:mpdo_literal_cpsv_vertical_decomposition}
+    \lean{MPSTensor.IsCPSVCanonicalForm.exists_cpsvVerticalDecomposition}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form, def:vertical_tensor_mpdo,
+        def:bnt_cpsv}
+    Let $M$ generate matrix product density operators, and suppose that its
+    doubled-index MPS tensor is in literal CPSV canonical form. Then there are
+    normal tensors $A_\alpha$, positive multiplicities $r_\alpha$, positive
+    numbers $c_{\alpha,q}$, and a coisometry $U$ such that the
+    $A_\alpha$ form a CPSV basis of normal tensors for $\widetilde M$ and,
+    writing
+    \begin{align}
+        B_v
+        &=\bigoplus_\alpha\bigoplus_{q=0}^{r_\alpha-1}
+          c_{\alpha,q}A_\alpha^v,
+        \label{eq:mpdo_literal_cpsv_vertical_decomposition_block}
+    \end{align}
+    one has
+    \begin{align}
+        UU^\dagger&=\Id,
+        \notag\\
+        U\widetilde M_vU^\dagger&=B_v,
+        \notag\\
+        \widetilde M_v&=U^\dagger B_vU.
+        \label{eq:mpdo_literal_cpsv_vertical_decomposition}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:cpsv_literal_vertical_bnt_grouping_with_isometries,
+        thm:cpsv_literal_normalized_grouped_sector_maps,
+        lem:same_mpv_exact_isometric_decomposition}
+    Group the normal vertical corners into phase classes and normalize their
+    physical sector maps. The exact original-sector reconstruction gives
+    positive-length matrix-product-vector equality with the corresponding
+    weighted direct sum. Hence the spectral representatives retain the CPSV
+    basis-of-normal-tensors property for $\widetilde M$. Flatten the pair
+    $(\alpha,q)$ into one finite index. Orthogonality of the normalized sector
+    maps gives $UU^\dagger=\Id$; their intertwining identities give the middle
+    equality in~(\ref{eq:mpdo_literal_cpsv_vertical_decomposition}), and their
+    exact reconstruction gives the last equality.
+\end{proof}
+
+\begin{theorem}[Literal two-site vertical decomposition]
+    \label{thm:mpdo_literal_cpsv_vertical_decomposition_block_two}
+    \lean{MPSTensor.IsCPSVCanonicalForm.%
+        exists_cpsvVerticalDecomposition_blockTwo}
+    \leanok
+    \uses{def:mpdo_two_site_blocking, def:vertical_tensor_mpdo,
+        def:bnt_cpsv}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_literal_cpsv_vertical_decomposition}, the concrete
+    two-site block $M^{[2]}$ has a decomposition of the same form:
+    there are $A^{[2]}_\alpha$, $r^{[2]}_\alpha>0$,
+    $c^{[2]}_{\alpha,q}>0$, and a coisometry $U^{[2]}$ such that
+    \begin{align}
+        U^{[2]}(U^{[2]})^\dagger&=\Id,
+        \notag\\
+        U^{[2]}\widetilde{M^{[2]}}_v(U^{[2]})^\dagger
+        &=\bigoplus_{\alpha,q}c^{[2]}_{\alpha,q}
+          (A^{[2]}_\alpha)^v,
+        \notag\\
+        \widetilde{M^{[2]}}_v
+        &=(U^{[2]})^\dagger
+          \left(\bigoplus_{\alpha,q}c^{[2]}_{\alpha,q}
+          (A^{[2]}_\alpha)^v\right)U^{[2]}.
+        \label{eq:mpdo_literal_cpsv_vertical_decomposition_block_two}
+    \end{align}
+    The tensors $A^{[2]}_\alpha$ form a CPSV basis of normal tensors for
+    $\widetilde{M^{[2]}}$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_literal_cpsv_positive_blocking,
+        thm:mpdo_block_two_as_positive_blocking,
+        thm:mpdo_literal_cpsv_vertical_decomposition}
+    Two-site blocking preserves both literal CPSV canonical form and
+    matrix-product-density-operator positivity. Apply
+    Theorem~\ref{thm:mpdo_literal_cpsv_vertical_decomposition} to $M^{[2]}$.
+\end{proof}
+
 \begin{lemma}[Two-site blocking preserves normalized BNT-refined horizontal form]
     \label{lem:mpdo_horizontal_cf_block_two}
     \lean{MPOTensor.IsHorizontalCF.blockTwo}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -268,22 +268,22 @@ physical indices, as in
     Under the hypotheses of
     Theorem~\ref{thm:mpdo_literal_cpsv_vertical_decomposition}, the concrete
     two-site block $M^{[2]}$ has a decomposition of the same form:
-    there are $A^{[2]}_\alpha$, $r^{[2]}_\alpha>0$,
+    there are normal tensors $\widehat A_\alpha$, $r^{[2]}_\alpha>0$,
     $c^{[2]}_{\alpha,q}>0$, and a coisometry $U^{[2]}$ such that
     \begin{align}
         U^{[2]}(U^{[2]})^\dagger&=\Id,
         \notag\\
         U^{[2]}\widetilde{M^{[2]}}_v(U^{[2]})^\dagger
         &=\bigoplus_{\alpha,q}c^{[2]}_{\alpha,q}
-          (A^{[2]}_\alpha)^v,
+          \widehat A_\alpha^v,
         \notag\\
         \widetilde{M^{[2]}}_v
         &=(U^{[2]})^\dagger
           \left(\bigoplus_{\alpha,q}c^{[2]}_{\alpha,q}
-          (A^{[2]}_\alpha)^v\right)U^{[2]}.
+          \widehat A_\alpha^v\right)U^{[2]}.
         \label{eq:mpdo_literal_cpsv_vertical_decomposition_block_two}
     \end{align}
-    The tensors $A^{[2]}_\alpha$ form a CPSV basis of normal tensors for
+    The tensors $\widehat A_\alpha$ form a CPSV basis of normal tensors for
     $\widetilde{M^{[2]}}$.
 \end{theorem}
 

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -36,6 +36,17 @@ abstracted — record why, so it is not re-proposed).
 - **Abstraction:** `@[mps_transfer]` simp set + `transfer_simp` macro
   (`TNLean/MPS/Tactic/Basic.lean`).
 
+### dependent finite-sum flattening — promoted
+- **Pattern:** pass between the double sum over `j` and `q : Fin (mult j)` and the
+  single sum over `Fin (∑ j, mult j)` reindexed by `finSigmaFinEquiv.symm`.
+- **Seen:** four reconstruction proofs across `VerticalCanonicalForm.lean`,
+  `CPSVVerticalCanonicalForm.lean`, `RFPPositiveFusionDecomposition.lean`, and
+  `CPSVVerticalDecomposition.lean` before promotion.
+- **Abstraction:** `Fintype.sum_finSigmaFinEquiv` in
+  `TNLean/MPS/MPDO/VerticalCoisometry.lean`.
+- **Notes:** the shared lemma is polymorphic over the additive commutative monoid,
+  so reconstruction proofs retain only the MPDO-specific summand.
+
 ### suffix marginal sector-block expansion — promoted
 - **Pattern:** reindex a normalized reduced state into physical-sector
   coordinates, change the discarded-site sum to dependent sector fibers, and

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -39,13 +39,13 @@ abstracted — record why, so it is not re-proposed).
 ### dependent finite-sum flattening — promoted
 - **Pattern:** pass between the double sum over `j` and `q : Fin (mult j)` and the
   single sum over `Fin (∑ j, mult j)` reindexed by `finSigmaFinEquiv.symm`.
-- **Seen:** four reconstruction proofs across `VerticalCanonicalForm.lean`,
-  `CPSVVerticalCanonicalForm.lean`, `RFPPositiveFusionDecomposition.lean`, and
-  `CPSVVerticalDecomposition.lean` before promotion.
+- **Seen:** five proofs across `VerticalCanonicalForm.lean`,
+  `CPSVVerticalCanonicalForm.lean`, `RFPPositiveFusionDecomposition.lean`,
+  `CPSVVerticalDecomposition.lean`, and `PooledKrausFamily.lean` before promotion.
 - **Abstraction:** `Fintype.sum_finSigmaFinEquiv` in
-  `TNLean/MPS/MPDO/VerticalCoisometry.lean`.
+  `TNLean/Algebra/FinSum.lean`.
 - **Notes:** the shared lemma is polymorphic over the additive commutative monoid,
-  so reconstruction proofs retain only the MPDO-specific summand.
+  so callers retain only their application-specific summand.
 
 ### suffix marginal sector-block expansion — promoted
 - **Pattern:** reindex a normalized reduced state into physical-sector


### PR DESCRIPTION
## Summary

- package the literal CPSV Proposition 4.13 data as a `CPSVVerticalDecomposition` without an `IsHorizontalCF` adapter
- expose the concrete two-site blocked specialization used by the Appendix C.4 RFP argument
- add standalone Blueprint statements and import the new module from the MPDO aggregate

This is the source-faithful vertical-decomposition slice of #5159. It does not yet claim the RFP-to-fusion or topological Gibbs theorem.

## Source boundary

The hypotheses are exactly literal `MPSTensor.IsCPSVCanonicalForm M.toMPSTensor` and `MPOTensor.IsMPDO M`. The two-site result derives its hypotheses through the merged literal blocking theorem from #5180. No hidden normalization premise or `IsHorizontalCF` adapter is introduced.

Source: CPSV16 Proposition 4.13 and Appendix C.4, arXiv:1606.00608 lines 1863–1921 and 1951–1956.

## Validation

- `lake build TNLean.MPS.MPDO.CPSVVerticalDecomposition -q`
- `lake build TNLean.MPS.MPDO -q`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `(cd blueprint && leanblueprint checkdecls)`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity search and `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New CPSV vertical-decomposition theorems sit on the formal path to Appendix C.4 RFP arguments; changes are localized refactoring plus new proofs, not runtime or security-sensitive code.
> 
> **Overview**
> Introduces **`CPSVVerticalDecomposition.lean`** with one-site and two-site **`CPSVVerticalDecomposition`** witnesses under literal **`IsCPSVCanonicalForm`** and **`IsMPDO`**, without an **`IsHorizontalCF`** adapter. The two-site result is obtained by blocking preservation plus the one-site theorem.
> 
> **`Fintype.sum_finSigmaFinEquiv`** in **`TNLean/Algebra/FinSum.lean`** centralizes reindexing between a double sum over dependent pairs and a single sum over **`Fin (∑ j, mult j)`** via **`finSigmaFinEquiv`**. Call sites in vertical canonical form, pooled Kraus families, and related MPDO proofs drop local **`calc`** blocks (and the private **`sum_pooled_reindex`** lemma).
> 
> Blueprint chapter 21 gains the matching literal one-site and two-site vertical decomposition theorems with Lean sync tags; **`docs/tactic_patterns.md`** records the promoted pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12461322ea7e76ad55951de18df2e4aaca30ee9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->