### PR TITLE
feat(MPS/MPDO): derive literal CPSV fusion clause

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -66,6 +66,7 @@ import TNLean.MPS.MPDO.BiCFDerivation.Selectors
 import TNLean.MPS.MPDO.BlockedBNTFusionIsometries
 import TNLean.MPS.MPDO.BlockedCompleteZipper
 import TNLean.MPS.MPDO.BlockedRFPConstruction
+import TNLean.MPS.MPDO.CPSVBNTFusionTensorClauseFromRFP
 import TNLean.MPS.MPDO.CPSVBlocking
 import TNLean.MPS.MPDO.CPSVFigureEight
 import TNLean.MPS.MPDO.CPSVGroupedFigureEight
@@ -78,6 +79,9 @@ import TNLean.MPS.MPDO.CPSVSharpBlocking
 import TNLean.MPS.MPDO.CPSVVerticalBNT
 import TNLean.MPS.MPDO.CPSVVerticalCanonicalForm
 import TNLean.MPS.MPDO.CPSVVerticalDecomposition
+import TNLean.MPS.MPDO.CPSVVerticalProductCornerPositivity
+import TNLean.MPS.MPDO.CPSVVerticalProductFusionDecomposition
+import TNLean.MPS.MPDO.CPSVVerticalProductSpectralFamily
 import TNLean.MPS.MPDO.CommonWeightAbsorbedBNTSupport
 import TNLean.MPS.MPDO.CommonWeightAbsorption
 import TNLean.MPS.MPDO.CommutingBondEtaBoundaryTrace

--- a/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTFusionTensorClauseFromRFP
+import TNLean.MPS.MPDO.CPSVVerticalDecomposition
+import TNLean.MPS.MPDO.CPSVVerticalProductFusionDecomposition
+
+/-!
+# Literal CPSV RFP tensors satisfy the BNT fusion clause
+
+This file proves the source-faithful implication from the literal CPSV
+canonical-form and renormalization fixed-point hypotheses to the active-sector
+BNT fusion tensor clause.
+
+## Main result
+
+* `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorem 4.14 and Appendix C.4
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace HasBNTFusionTensorClause
+
+/-- **Theorem 4.14(i) implies (iii).** An MPDO in literal CPSV canonical form
+that satisfies the Definition 4.1 renormalization fixed-point condition has
+the active-support BNT fusion clause.
+
+Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
+lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
+    HasBNTFusionTensorClause M := by
+  classical
+  obtain ⟨D₁⟩ := hCanonical.exists_cpsvVerticalDecomposition M hM
+  obtain ⟨D₂⟩ := hCanonical.exists_cpsvVerticalDecomposition_blockTwo M hM
+  obtain ⟨Smap, T, hSCPTP, hTCPTP, hSphys, hTphys⟩ := hRFP
+  obtain ⟨sigma, hDim, V, _hContract, hLetter⟩ :=
+    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
+      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
+      hTphys hSphys
+  have hRepresentations : ∀ (L : ℕ), 0 < L →
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+          ∑ γ,
+            (((verticalMultiplicityTrace D₁.weight γ /
+                verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
+              (∑ r, D₂.weight (sigma γ) r ^ L)) •
+              mpo (verticalBNTMPO (D₁.tensor γ)) L ∧
+      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
+        ∑ α, ∑ β,
+          ((∑ q, D₁.weight α q ^ L) * (∑ r, D₁.weight β r ^ L)) •
+            (mpo (verticalBNTMPO (D₁.tensor α)) L *
+              mpo (verticalBNTMPO (D₁.tensor β)) L) := by
+    intro L hL
+    exact blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      M D₁.tensor D₂.tensor
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry
+      D₁.reconstruction D₂.reconstruction
+      sigma hDim V hLetter hL
+  obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
+    exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
+      sigma hDim V hLetter hCanonical hM
+  have hIdempotent := hasIdempotentCoefficientForm_of_blockedRepresentations
+    D₁ D₂ sigma chi U hChiPos hU hFusion hFusionReconstruction
+    hRepresentations
+  exact ⟨{
+    labelCount := D₁.labelCount
+    bondDim := D₁.bondDim
+    multiplicity := D₁.multiplicity
+    weight := D₁.weight
+    tensor := D₁.tensor
+    verticalCoisometry := D₁.verticalCoisometry
+    multiplicity_pos := D₁.multiplicity_pos
+    weight_pos := D₁.weight_pos
+    coisometry := D₁.coisometry
+    isCPSVBNT := D₁.isCPSVBNT
+    forward := D₁.forward
+    reconstruction := D₁.reconstruction
+    chi := chi
+    chi_pos := hChiPos
+    fusionCoisometry := U
+    fusionCoisometry_mul_conjTranspose := hU
+    fusion := hFusion
+    fusionReconstruction := hFusionReconstruction
+    idempotent := hIdempotent
+  }⟩
+
+end HasBNTFusionTensorClause
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CPSVVerticalProductCornerPositivity.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalProductCornerPositivity.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CPSVBlocking
+import TNLean.MPS.MPDO.CPSVFigureEight
+import TNLean.MPS.MPDO.CPSVVerticalBNT
+import TNLean.MPS.MPDO.VerticalProductCornerPositivity
+
+/-!
+# Literal CPSV positivity and normalization of active product gauges
+
+The literal CPSV canonical form supplies the sector-compression separation
+and Figure 8 Gram comparison needed to normalize the active product corners
+in the RFP-to-fusion construction.
+
+## Main results
+
+* `FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos_of_cpsvCanonicalForm`:
+  every active product coefficient is positive.
+* `FlatBlockedBNTComparison.exists_unitaryNormalization_of_cpsvCanonicalForm`:
+  every active product gauge has positive scalar Gram matrix and can be
+  normalized to a unitary.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, lines 1898--1921, and Appendix C.4, lines 2020--2029
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace RetainedProductSpectralFamily
+
+variable {g D : ℕ} {dim mult : Fin g → ℕ}
+  {weight : (α : Fin g) → Fin (mult α) → ℂ}
+  {B : (α : Fin g) → MPSTensor (D * D) (dim α)}
+
+/-- The scalar multiplying every active product corner is positive under
+literal CPSV canonical form.
+
+Source: CPSV16, Proposition 4.13, lines 1898--1902, and Appendix C.4,
+lines 2025--2029. -/
+theorem FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos_of_cpsvCanonicalForm
+    {g₂ d : ℕ} {dim₂ : Fin g₂ → ℕ}
+    {A₂ : (γ : Fin g₂) → MPSTensor (D * D) (dim₂ γ)}
+    {S : RetainedProductSpectralFamily dim mult weight B}
+    (C : FlatBlockedBNTComparison S dim₂ A₂)
+    (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M)
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim mult weight B ab * U₁)
+    (mult₂ : Fin g₂ → ℕ) (hMult₂ : ∀ γ, 0 < mult₂ γ)
+    (weight₂ : (γ : Fin g₂) → Fin (mult₂ γ) → ℂ)
+    (hWeight₂ : ∀ γ q, (0 : ℂ) < weight₂ γ q)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ γ : Fin g₂, mult₂ γ),
+        verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hNormal₂ : ∀ γ, MPSTensor.IsNormalTensor (A₂ γ))
+    (j : Fin (Fintype.card S.ActiveLabel)) :
+    (0 : ℂ) < S.flatCoefficient j * C.phase j := by
+  let hBlocked := IsCPSVCanonicalForm_toMPSTensor_blockTwo hCanonical
+  refine C.activeCoefficient_mul_phase_pos_of_sectorCompression_separation M hM
+    ?_ (U₁ := U₁) hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂
+      U₂ hU₂ hReconstruct₂ hNormal₂ j
+  intro P hP
+  exact hBlocked.exists_sectorCompression_ne_zero_of_corner
+    (blockTwo M) P hP
+
+/-- Every active product gauge has positive scalar Gram matrix and becomes
+unitary after division by the square root of that scalar under literal CPSV
+canonical form.
+
+Source: CPSV16, Proposition 4.13, lines 1903--1921, and Appendix C.4,
+lines 2025--2029. -/
+theorem FlatBlockedBNTComparison.exists_unitaryNormalization_of_cpsvCanonicalForm
+    {g₂ d : ℕ} {dim₂ : Fin g₂ → ℕ}
+    {A₂ : (γ : Fin g₂) → MPSTensor (D * D) (dim₂ γ)}
+    {S : RetainedProductSpectralFamily dim mult weight B}
+    (C : FlatBlockedBNTComparison S dim₂ A₂)
+    (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M)
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim mult weight B ab * U₁)
+    (mult₂ : Fin g₂ → ℕ) (hMult₂ : ∀ γ, 0 < mult₂ γ)
+    (weight₂ : (γ : Fin g₂) → Fin (mult₂ γ) → ℂ)
+    (hWeight₂ : ∀ γ q, (0 : ℂ) < weight₂ γ q)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ γ : Fin g₂, mult₂ γ),
+        verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hNormal₂ : ∀ γ, MPSTensor.IsNormalTensor (A₂ γ))
+    (j : Fin (Fintype.card S.ActiveLabel)) :
+    ∃ ω : ℝ, 0 < ω ∧
+      (C.gauge j : Matrix (Fin (S.flatDim j)) (Fin (S.flatDim j)) ℂ)ᴴ *
+          C.gauge j = (ω : ℂ) • 1 ∧
+      ((Real.sqrt ω : ℂ))⁻¹ •
+          (C.gauge j : Matrix (Fin (S.flatDim j))
+            (Fin (S.flatDim j)) ℂ) ∈
+        Matrix.unitaryGroup (Fin (S.flatDim j)) ℂ := by
+  let hBlocked := IsCPSVCanonicalForm_toMPSTensor_blockTwo hCanonical
+  let x := S.activeLabelEquiv j
+  let A := cast (congrArg (MPSTensor (D * D)) (C.dim_eq j))
+    (A₂ (C.label j))
+  let Vact := S.ambientInclusion U₁ x
+  let Vref := C.referenceInclusion mult₂ hMult₂ U₂ j
+  let c := S.flatCoefficient j * C.phase j
+  let c₀ := weight₂ (C.label j) ⟨0, hMult₂ (C.label j)⟩
+  letI : NeZero (S.flatDim j) := ⟨(S.flatDim_pos j).ne'⟩
+  have hA : MPSTensor.IsNormalTensor A :=
+    (MPSTensor.isNormalTensor_cast_iff (C.dim_eq j) (A₂ (C.label j))).2
+      (hNormal₂ (C.label j))
+  have hc : (0 : ℂ) < c :=
+    C.activeCoefficient_mul_phase_pos_of_cpsvCanonicalForm M hCanonical hM
+      U₁ hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂ U₂ hU₂
+      hReconstruct₂ hNormal₂ j
+  have hc₀ : (0 : ℂ) < c₀ :=
+    hWeight₂ (C.label j) ⟨0, hMult₂ (C.label j)⟩
+  have hActiveCorner : ∀ ab,
+      Vactᴴ * verticalTensor (blockTwo M) ab * Vact =
+        c • ((C.gauge j : Matrix (Fin (S.flatDim j))
+            (Fin (S.flatDim j)) ℂ) * A ab *
+          (↑((C.gauge j)⁻¹) : Matrix (Fin (S.flatDim j))
+            (Fin (S.flatDim j)) ℂ)) := by
+    intro ab
+    symm
+    calc
+      c • ((C.gauge j : Matrix (Fin (S.flatDim j))
+            (Fin (S.flatDim j)) ℂ) * A ab *
+          (↑((C.gauge j)⁻¹) : Matrix (Fin (S.flatDim j))
+            (Fin (S.flatDim j)) ℂ)) =
+        S.flatCoefficient j • S.flatBlock j ab := by
+          rw [C.block_eq j ab]
+          simp only [c, A, smul_smul]
+      _ = Vactᴴ * verticalTensor (blockTwo M) ab * Vact := by
+        change S.coefficient x.1 x.2 • S.block x.1 x.2 ab = _
+        exact S.ambient_compression M U₁ hU₁ hReconstruct₁ x ab
+  have hReferenceCorner : ∀ ab,
+      Vrefᴴ * verticalTensor (blockTwo M) ab * Vref = c₀ • A ab := by
+    intro ab
+    exact (C.reference_compression M mult₂ hMult₂ weight₂ U₂ hU₂
+      hReconstruct₂ j ab).symm
+  obtain ⟨ω, hω, hGram⟩ :=
+    hBlocked.gram_eq_pos_smul_gram_of_two_grouped_corners
+      (blockTwo M) hM.blockTwo A hA.isNormal Vact Vref (C.gauge j) 1
+      c c₀ hc hc₀ hActiveCorner (by
+        intro ab
+        simpa using hReferenceCorner ab)
+  have hGramOne :
+      (C.gauge j : Matrix (Fin (S.flatDim j))
+          (Fin (S.flatDim j)) ℂ)ᴴ * C.gauge j = (ω : ℂ) • 1 := by
+    simpa using hGram
+  exact ⟨ω, hω, hGramOne,
+    Matrix.smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one
+      hω hGramOne⟩
+
+end RetainedProductSpectralFamily
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CPSVVerticalProductFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalProductFusionDecomposition.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CPSVVerticalProductCornerPositivity
+import TNLean.MPS.MPDO.CPSVVerticalProductSpectralFamily
+import TNLean.MPS.MPDO.VerticalProductFusionDecomposition
+
+/-!
+# Fusion decomposition from literal CPSV canonical form
+
+Literal CPSV canonical form supplies the retained product spectra, positive
+active coefficients, and unitary normalizations needed by the form-neutral
+fusion-coisometry construction.
+
+## Main result
+
+* `MPOTensor.exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13 and Appendix C.4, lines 2020--2029
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+/-- A one-site/two-site sector comparison under literal CPSV canonical form
+determines positive diagonal fusion data and coisometries onto the active
+product sectors.
+
+Source: CPSV16, Proposition 4.13, lines 1863--1921, and Appendix C.4,
+lines 2001--2029. -/
+theorem exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm
+    {g₁ g₂ d D : ℕ}
+    (dim₁ mult₁ : Fin g₁ → ℕ)
+    (weight₁ : (α : Fin g₁) → Fin (mult₁ α) → ℂ)
+    (dim₂ mult₂ : Fin g₂ → ℕ)
+    (weight₂ : (β : Fin g₂) → Fin (mult₂ β) → ℂ)
+    (hMult₁ : ∀ α, 0 < mult₁ α)
+    (hWeight₁ : ∀ α q, (0 : ℂ) < weight₁ α q)
+    (hMult₂ : ∀ β, 0 < mult₂ β)
+    (hWeight₂ : ∀ β q, (0 : ℂ) < weight₂ β q)
+    (M : MPOTensor d D)
+    (A₁ : (α : Fin g₁) → MPSTensor (D * D) (dim₁ α))
+    (A₂ : (β : Fin g₂) → MPSTensor (D * D) (dim₂ β))
+    (hBNT₂ : MPSTensor.IsCPSVBasisOfNormalTensors (verticalTensor (blockTwo M))
+      (fun β ↦ ⟨dim₂ β, A₂ β⟩))
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g₁, mult₁ α), verticalCopyDim dim₁ mult₁ q))
+      (Fin d) ℂ)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ β : Fin g₂, mult₂ β), verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim₁ mult₁ weight₁ A₁ ab * U₁)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (sigma : Fin g₁ ≃ Fin g₂)
+    (hDim : ∀ i, dim₁ i = dim₂ (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ)
+    (hLetter : ∀ (i : Fin g₁) (ab : Fin (D * D)),
+      A₂ (sigma i) ab =
+        (verticalMultiplicityTrace weight₁ i /
+          verticalMultiplicityTrace weight₂ (sigma i)) •
+        ((V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (A₁ i ab) *
+          (V i : Matrix (Fin (dim₂ (sigma i))) (Fin (dim₂ (sigma i))) ℂ)ᴴ))
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) :
+    ∃ (chi : DiagonalChiFamily (Fin g₁))
+      (U : ∀ α β : Fin g₁,
+        Matrix
+          ((γ : Fin g₁) × (Fin (chi.dim α β γ) × Fin (dim₁ γ)))
+          (Fin (dim₁ α * dim₁ β)) ℂ),
+      chi.PosEntries ∧
+      (∀ α β, U α β * (U α β)ᴴ = 1) ∧
+      (∀ (α β : Fin g₁) (i j : Fin D),
+        U α β *
+            (mulTensor (verticalBNTMPO (A₁ α))
+              (verticalBNTMPO (A₁ β))) i j *
+            (U α β)ᴴ =
+          Matrix.blockDiagonal' fun γ =>
+            chi.matrix α β γ ⊗ₖ verticalBNTMPO (A₁ γ) i j) ∧
+      ∀ (α β : Fin g₁) (i j : Fin D),
+        (mulTensor (verticalBNTMPO (A₁ α))
+          (verticalBNTMPO (A₁ β))) i j =
+          (U α β)ᴴ *
+            (Matrix.blockDiagonal' fun γ =>
+              chi.matrix α β γ ⊗ₖ verticalBNTMPO (A₁ γ) i j) *
+            U α β := by
+  classical
+  obtain ⟨R⟩ := hCanonical.exists_retainedProductSpectralFamily
+    dim₁ mult₁ weight₁ A₁ U₁ hU₁ hReconstruct₁ hM
+  letI : ∀ γ, NeZero (dim₂ γ) := fun γ ↦
+    ⟨(hBNT₂.blocks_dim_pos γ).ne'⟩
+  obtain ⟨C⟩ := R.exists_flatBlockedBNTComparison
+    M U₁ hU₁ hReconstruct₁ dim₂ A₂ hBNT₂
+  have hNormal₂ : ∀ γ, MPSTensor.IsNormalTensor (A₂ γ) := fun γ ↦
+    hBNT₂.blocks_normal γ
+  have hActivePos : ∀ j, (0 : ℂ) < R.flatCoefficient j * C.phase j := fun j ↦
+    C.activeCoefficient_mul_phase_pos_of_cpsvCanonicalForm
+      M hCanonical hM U₁ hU₁ hReconstruct₁
+      mult₂ hMult₂ weight₂ hWeight₂ U₂ hU₂ hReconstruct₂ hNormal₂ j
+  choose omega homega hGram _hQ using fun j ↦
+    C.exists_unitaryNormalization_of_cpsvCanonicalForm
+      M hCanonical hM U₁ hU₁ hReconstruct₁
+      mult₂ hMult₂ weight₂ hWeight₂ U₂ hU₂ hReconstruct₂ hNormal₂ j
+  exact R.exists_bntFusionCoisometryFamily C hMult₁ hWeight₁
+    mult₂ hMult₂ weight₂ hWeight₂ sigma hDim V hLetter
+    hActivePos omega homega hGram
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CPSVVerticalProductSpectralFamily.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalProductSpectralFamily.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CPSVBlocking
+import TNLean.MPS.MPDO.CPSVPeriodicExclusion
+import TNLean.MPS.MPDO.VerticalProductSpectralFamily
+
+/-!
+# Retained vertical product sectors from literal CPSV canonical form
+
+Literal CPSV canonical form passes to two-site physical blocking. Proposition
+4.13 supplies invariant-projector closure and excludes periodic vectors for
+the blocked vertical tensor. The form-neutral retained-product construction
+then gives simultaneous normal decompositions of all retained copy pairs.
+
+## Main result
+
+* `MPSTensor.IsCPSVCanonicalForm.exists_retainedProductSpectralFamily`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, lines 1873--1893, and Appendix C.4, lines 2020--2029
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPSTensor.IsCPSVCanonicalForm
+
+open MPOTensor
+
+/-- Literal CPSV canonical form and MPDO positivity give simultaneous normal
+decompositions of all retained vertical copy-pair tensors. Empty active
+families are preserved.
+
+The one-site coisometric reconstruction is squared exactly. Literal canonical
+form and positivity supply projector closure and absence of periodic vectors
+for the blocked vertical tensor, and these properties descend to every
+retained copy pair.
+
+Source: CPSV16, Proposition 4.13, lines 1873--1893, and Appendix C.4,
+lines 2020--2029. -/
+theorem exists_retainedProductSpectralFamily
+    {g d D : ℕ} {M : MPOTensor d D}
+    (hCanonical : IsCPSVCanonicalForm M.toMPSTensor)
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (B : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ ab, verticalTensor M ab =
+      Uᴴ * verticalAssembledTensor dim mult weight B ab * U)
+    (hM : IsMPDO M) :
+    Nonempty (RetainedProductSpectralFamily dim mult weight B) := by
+  have hCanonicalTwo :=
+    MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTwo hCanonical
+  have hMTwo := hM.blockTwo
+  exact MPOTensor.exists_retainedProductSpectralFamily_of_blockTwo
+    dim mult weight B M U hU hReconstruct
+    (hCanonicalTwo.hasInvariantProjectorClosure_verticalTensor (blockTwo M) hMTwo)
+    (MPOTensor.hasNoPeriodicVectors_verticalTensor_of_cpsvCanonicalForm
+      (blockTwo M) hMTwo hCanonicalTwo)
+
+end MPSTensor.IsCPSVCanonicalForm

--- a/TNLean/MPS/MPDO/VerticalProductCornerPositivity.lean
+++ b/TNLean/MPS/MPDO/VerticalProductCornerPositivity.lean
@@ -31,20 +31,20 @@ variable {g D : ℕ} {dim mult : Fin g → ℕ}
   {B : (α : Fin g) → MPSTensor (D * D) (dim α)}
 
 /-- The scalar multiplying the blocked BNT representative in every active
-product corner is positive.
-
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form used in Appendix C.4 through
-Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+product corner is positive whenever nonzero blocked corners can be separated
+by a finite sector compression.
 
 Source: CPSV16, Appendix C.4, lines 2025--2029, using the sector-weight
 positivity argument from Proposition 4.13, lines 1898--1902. -/
-theorem FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos
+theorem FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos_of_sectorCompression_separation
     {g₂ d : ℕ} {dim₂ : Fin g₂ → ℕ}
     {A₂ : (γ : Fin g₂) → MPSTensor (D * D) (dim₂ γ)}
     {S : RetainedProductSpectralFamily dim mult weight B}
     (C : FlatBlockedBNTComparison S dim₂ A₂)
-    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (M : MPOTensor d D) (hM : IsMPDO M)
+    (hSeparate : ∀ P : Matrix (Fin (d * d)) (Fin (d * d)) ℂ,
+      (∃ v, P * verticalTensor (blockTwo M) v * P ≠ 0) →
+        ∃ N, sectorCompression (blockTwo M) P N ≠ 0)
     (U₁ : Matrix
       (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
       (Fin d) ℂ)
@@ -113,12 +113,52 @@ theorem FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos
       simpa using hReferenceCorner ab)
   have hRange := exists_rangeProjection_corner_ne_zero
     (blockTwo M) A hA Vact hVact (C.gauge j) c hc hActiveCorner
-  obtain ⟨N, hne⟩ :=
-    (hHorizontal.blockTwo).exists_sectorCompression_ne_zero_of_corner
-      (blockTwo M) (Vact * Vactᴴ) hRange
+  obtain ⟨N, hne⟩ := hSeparate (Vact * Vactᴴ) hRange
   exact sector_weight_pos hM.blockTwo hSectorRef
     (hWeight₂ (C.label j) ⟨0, hMult₂ (C.label j)⟩)
     hSectorAct N hne
+
+/-- The scalar multiplying the blocked BNT representative in every active
+product corner is positive for an MPDO in normalized BNT-refined horizontal
+form.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
+Source: CPSV16, Appendix C.4, lines 2025--2029, using the sector-weight
+positivity argument from Proposition 4.13, lines 1898--1902. -/
+theorem FlatBlockedBNTComparison.activeCoefficient_mul_phase_pos
+    {g₂ d : ℕ} {dim₂ : Fin g₂ → ℕ}
+    {A₂ : (γ : Fin g₂) → MPSTensor (D * D) (dim₂ γ)}
+    {S : RetainedProductSpectralFamily dim mult weight B}
+    (C : FlatBlockedBNTComparison S dim₂ A₂)
+    (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (U₁ : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU₁ : U₁ * U₁ᴴ = 1)
+    (hReconstruct₁ : ∀ ab, verticalTensor M ab =
+      U₁ᴴ * verticalAssembledTensor dim mult weight B ab * U₁)
+    (mult₂ : Fin g₂ → ℕ) (hMult₂ : ∀ γ, 0 < mult₂ γ)
+    (weight₂ : (γ : Fin g₂) → Fin (mult₂ γ) → ℂ)
+    (hWeight₂ : ∀ γ q, (0 : ℂ) < weight₂ γ q)
+    (U₂ : Matrix
+      (Fin (∑ q : Fin (∑ γ : Fin g₂, mult₂ γ),
+        verticalCopyDim dim₂ mult₂ q))
+      (Fin (d * d)) ℂ)
+    (hU₂ : U₂ * U₂ᴴ = 1)
+    (hReconstruct₂ : ∀ ab, verticalTensor (blockTwo M) ab =
+      U₂ᴴ * verticalAssembledTensor dim₂ mult₂ weight₂ A₂ ab * U₂)
+    (hNormal₂ : ∀ γ, MPSTensor.IsNormalTensor (A₂ γ))
+    (j : Fin (Fintype.card S.ActiveLabel)) :
+    (0 : ℂ) < S.flatCoefficient j * C.phase j := by
+  refine C.activeCoefficient_mul_phase_pos_of_sectorCompression_separation M hM
+    ?_ (U₁ := U₁) hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂
+      U₂ hU₂ hReconstruct₂ hNormal₂ j
+  intro P hP
+  exact (hHorizontal.blockTwo).exists_sectorCompression_ne_zero_of_corner
+    (blockTwo M) P hP
 
 /-- Every active product gauge has scalar positive Gram matrix and becomes
 unitary after division by the square root of that scalar.

--- a/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
@@ -256,6 +256,65 @@ noncomputable def toBNTFusionCoisometryFamily
 
 end OriginalCornerFamily
 
+/-- Positive normalized product corners determine a family of fusion
+coisometries for the original one-site BNT labels.
+
+Source: CPSV16, Appendix C.4, lines 2020--2029. -/
+theorem exists_bntFusionCoisometryFamily
+    {g₂ : ℕ} {dim₂ : Fin g₂ → ℕ}
+    {A₂ : (γ : Fin g₂) → MPSTensor (D * D) (dim₂ γ)}
+    (S : RetainedProductSpectralFamily dim mult weight B)
+    (C : FlatBlockedBNTComparison S dim₂ A₂)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q)
+    (mult₂ : Fin g₂ → ℕ) (hMult₂ : ∀ γ, 0 < mult₂ γ)
+    (weight₂ : (γ : Fin g₂) → Fin (mult₂ γ) → ℂ)
+    (hWeight₂ : ∀ γ q, (0 : ℂ) < weight₂ γ q)
+    (sigma : Fin g ≃ Fin g₂) (hDim : ∀ i, dim i = dim₂ (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (dim₂ (sigma i))) ℂ)
+    (hLetter : ∀ (i : Fin g) (ab : Fin (D * D)),
+      A₂ (sigma i) ab =
+        (verticalMultiplicityTrace weight i /
+          verticalMultiplicityTrace weight₂ (sigma i)) •
+        ((V i : Matrix (Fin (dim₂ (sigma i)))
+            (Fin (dim₂ (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (B i ab) *
+          (V i : Matrix (Fin (dim₂ (sigma i)))
+            (Fin (dim₂ (sigma i))) ℂ)ᴴ))
+    (hActivePos : ∀ j, (0 : ℂ) < S.flatCoefficient j * C.phase j)
+    (omega : Fin (Fintype.card S.ActiveLabel) → ℝ)
+    (homega : ∀ j, 0 < omega j)
+    (hGram : ∀ j,
+      (C.gauge j : Matrix (Fin (S.flatDim j)) (Fin (S.flatDim j)) ℂ)ᴴ *
+        C.gauge j = (omega j : ℂ) • 1) :
+    ∃ (chi : DiagonalChiFamily (Fin g))
+      (U : ∀ α β : Fin g,
+        Matrix
+          ((γ : Fin g) × (Fin (chi.dim α β γ) × Fin (dim γ)))
+          (Fin (dim α * dim β)) ℂ),
+      chi.PosEntries ∧
+      (∀ α β, U α β * (U α β)ᴴ = 1) ∧
+      (∀ (α β : Fin g) (i j : Fin D),
+        U α β *
+            (mulTensor (verticalBNTMPO (B α))
+              (verticalBNTMPO (B β))) i j *
+            (U α β)ᴴ =
+          Matrix.blockDiagonal' fun γ =>
+            chi.matrix α β γ ⊗ₖ verticalBNTMPO (B γ) i j) ∧
+      ∀ (α β : Fin g) (i j : Fin D),
+        (mulTensor (verticalBNTMPO (B α))
+          (verticalBNTMPO (B β))) i j =
+          (U α β)ᴴ *
+            (Matrix.blockDiagonal' fun γ =>
+              chi.matrix α β γ ⊗ₖ verticalBNTMPO (B γ) i j) *
+            U α β := by
+  obtain ⟨O⟩ := S.exists_originalCornerFamily C hMult hWeight
+    mult₂ hMult₂ weight₂ hWeight₂ sigma hDim V hLetter
+    hActivePos omega homega hGram
+  let Fam := O.toBNTFusionCoisometryFamily hMult
+  exact ⟨Fam.chi, Fam.fusionCoisometry, Fam.posEntries,
+    Fam.coisometry, Fam.fusion, Fam.reconstruction⟩
+
 end RetainedProductSpectralFamily
 
 /-- A fixed one-site/two-site sector transport witness determines positive
@@ -342,12 +401,9 @@ theorem exists_positiveFusionDecomposition_of_unitaryBlockEquiv
     C.exists_unitaryNormalization M hHorizontal hM
       U₁ hU₁ hReconstruct₁ mult₂ hMult₂ weight₂ hWeight₂
       U₂ hU₂ hReconstruct₂ hNormal₂ j
-  obtain ⟨O⟩ := R.exists_originalCornerFamily C hMult₁ hWeight₁
+  exact R.exists_bntFusionCoisometryFamily C hMult₁ hWeight₁
     mult₂ hMult₂ weight₂ hWeight₂ sigma hDim V hLetter
     hActivePos omega homega hGram
-  let Fam := O.toBNTFusionCoisometryFamily hMult₁
-  exact ⟨Fam.chi, Fam.fusionCoisometry, Fam.posEntries,
-    Fam.coisometry, Fam.fusion, Fam.reconstruction⟩
 
 /-- The one-site vertical BNT is closed under pairwise products through
 positive diagonal multiplicity matrices and coisometries onto the active

--- a/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
+++ b/TNLean/MPS/MPDO/VerticalProductPairBlocks.lean
@@ -506,14 +506,37 @@ theorem verticalTensor_blockTwo_squared_coisometry_reconstruction
 /-- The squared retained product inherits projector closure and absence of
 periodic vectors from the blocked vertical tensor.
 
-The one-site coisometric reconstruction is squared exactly. Normalized
-BNT-refined horizontal form and positivity pass to two-site blocking, so the
-blocked vertical tensor has the two canonical-form hypotheses. The preceding
+The one-site coisometric reconstruction is squared exactly. The preceding
 coisometric transfer theorem then passes both hypotheses to the retained
 product tensor, including when its active support is smaller than the full
 product bond space.
 
-Source: CPSV16, Appendix C.4, lines 2015--2025. -/
+Source: CPSV16, Proposition 4.13, lines 1873--1893, and Appendix C.4,
+lines 2015--2025. -/
+theorem retainedVerticalProduct_projectorClosure_and_noPeriodicVectors_of_blockTwo
+    {d D n : ℕ} (M : MPOTensor d D) (A : MPSTensor (D * D) n)
+    (U : Matrix (Fin n) (Fin d) ℂ) (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ ab, verticalTensor M ab = Uᴴ * A ab * U)
+    (hClosure : MPSTensor.HasInvariantProjectorClosure (verticalTensor (blockTwo M)))
+    (hPer : MPSTensor.HasNoPeriodicVectors (verticalTensor (blockTwo M))) :
+    let C :=
+      (mulTensor (verticalBNTMPO A) (verticalBNTMPO A)).toMPSTensor
+    MPSTensor.HasInvariantProjectorClosure C ∧
+      MPSTensor.HasNoPeriodicVectors C := by
+  dsimp only
+  have hsquare := verticalTensor_blockTwo_squared_coisometry_reconstruction
+    M A U hU hReconstruct
+  exact MPSTensor.projectorClosure_and_noPeriodicVectors_of_coisometry_reconstruction
+    (verticalTensor (blockTwo M))
+    (mulTensor (verticalBNTMPO A) (verticalBNTMPO A)).toMPSTensor
+    (verticalCoisometrySquare U) hsquare.1 hsquare.2
+    hClosure hPer
+
+/-- The squared retained product of a tensor in normalized BNT-refined
+horizontal form has projector closure and no periodic vectors.
+
+Source: CPSV16, Proposition 4.13, lines 1873--1893, and Appendix C.4,
+lines 2015--2025. -/
 theorem retainedVerticalProduct_projectorClosure_and_noPeriodicVectors
     {d D n : ℕ} (M : MPOTensor d D) (A : MPSTensor (D * D) n)
     (U : Matrix (Fin n) (Fin d) ℂ) (hU : U * Uᴴ = 1)
@@ -523,15 +546,10 @@ theorem retainedVerticalProduct_projectorClosure_and_noPeriodicVectors
       (mulTensor (verticalBNTMPO A) (verticalBNTMPO A)).toMPSTensor
     MPSTensor.HasInvariantProjectorClosure C ∧
       MPSTensor.HasNoPeriodicVectors C := by
-  dsimp only
-  have hsquare := verticalTensor_blockTwo_squared_coisometry_reconstruction
-    M A U hU hReconstruct
   have hHorizontalTwo := hHorizontal.blockTwo
   have hMTwo := hM.blockTwo
-  exact MPSTensor.projectorClosure_and_noPeriodicVectors_of_coisometry_reconstruction
-    (verticalTensor (blockTwo M))
-    (mulTensor (verticalBNTMPO A) (verticalBNTMPO A)).toMPSTensor
-    (verticalCoisometrySquare U) hsquare.1 hsquare.2
+  exact retainedVerticalProduct_projectorClosure_and_noPeriodicVectors_of_blockTwo
+    M A U hU hReconstruct
     (hHorizontalTwo.hasInvariantProjectorClosure_verticalTensor (blockTwo M) hMTwo)
     (hasNoPeriodicVectors_verticalTensor_of_horizontalCF
       (blockTwo M) hMTwo hHorizontalTwo)
@@ -794,6 +812,51 @@ summands.  Unused blocked labels are represented later by empty fibers.
 Documented in `docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`.
 
 Source: CPSV16, Appendix C.4, lines 2020--2029. -/
+theorem weightedVerticalProductBlock_projectorClosure_and_noPeriodicVectors_of_blockTwo
+    {g d D : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (B : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (M : MPOTensor d D)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ ab, verticalTensor M ab =
+      Uᴴ * verticalAssembledTensor dim mult weight B ab * U)
+    (hClosure : MPSTensor.HasInvariantProjectorClosure (verticalTensor (blockTwo M)))
+    (hPer : MPSTensor.HasNoPeriodicVectors (verticalTensor (blockTwo M)))
+    (p : ((α : Fin g) × Fin (mult α)) ×
+      ((α : Fin g) × Fin (mult α))) :
+    MPSTensor.HasInvariantProjectorClosure
+        (weightedVerticalProductBlock dim mult weight B p) ∧
+      MPSTensor.HasNoPeriodicVectors
+        (weightedVerticalProductBlock dim mult weight B p) := by
+  let C := (mulTensor
+    (verticalBNTMPO (verticalAssembledTensor dim mult weight B))
+    (verticalBNTMPO (verticalAssembledTensor dim mult weight B))).toMPSTensor
+  have hCanonical : MPSTensor.HasInvariantProjectorClosure C ∧
+      MPSTensor.HasNoPeriodicVectors C := by
+    simpa only [C] using
+      retainedVerticalProduct_projectorClosure_and_noPeriodicVectors_of_blockTwo M
+        (verticalAssembledTensor dim mult weight B) U hU hReconstruct
+        hClosure hPer
+  exact MPSTensor.projectorClosure_and_noPeriodicVectors_block_of_reindex_eq_blockDiagonal
+    (fun p : ((α : Fin g) × Fin (mult α)) ×
+      ((α : Fin g) × Fin (mult α)) ↦ dim p.1.1 * dim p.2.1)
+    (fun p : ((α : Fin g) × Fin (mult α)) ×
+      ((α : Fin g) × Fin (mult α)) ↦
+        Fin (dim p.1.1) × Fin (dim p.2.1))
+    (fun _ ↦ finProdFinEquiv.symm) C
+    (weightedVerticalProductBlock dim mult weight B)
+    (productRetainedEquiv dim mult)
+    (mulTensor_verticalAssembledTensor_reindex dim mult weight B)
+    hCanonical.1 hCanonical.2 p
+
+/-- Every ordered pair of retained vertical BNT copies of a tensor in
+normalized BNT-refined horizontal form has projector closure and no periodic
+vectors.
+
+Source: CPSV16, Appendix C.4, lines 2020--2029. -/
 theorem weightedVerticalProductBlock_projectorClosure_and_noPeriodicVectors
     {g d D : ℕ} (dim mult : Fin g → ℕ)
     (weight : (α : Fin g) → Fin (mult α) → ℂ)
@@ -812,26 +875,13 @@ theorem weightedVerticalProductBlock_projectorClosure_and_noPeriodicVectors
         (weightedVerticalProductBlock dim mult weight B p) ∧
       MPSTensor.HasNoPeriodicVectors
         (weightedVerticalProductBlock dim mult weight B p) := by
-  let C := (mulTensor
-    (verticalBNTMPO (verticalAssembledTensor dim mult weight B))
-    (verticalBNTMPO (verticalAssembledTensor dim mult weight B))).toMPSTensor
-  have hCanonical : MPSTensor.HasInvariantProjectorClosure C ∧
-      MPSTensor.HasNoPeriodicVectors C := by
-    simpa only [C] using
-      retainedVerticalProduct_projectorClosure_and_noPeriodicVectors M
-        (verticalAssembledTensor dim mult weight B) U hU hReconstruct
-        hHorizontal hM
-  exact MPSTensor.projectorClosure_and_noPeriodicVectors_block_of_reindex_eq_blockDiagonal
-    (fun p : ((α : Fin g) × Fin (mult α)) ×
-      ((α : Fin g) × Fin (mult α)) ↦ dim p.1.1 * dim p.2.1)
-    (fun p : ((α : Fin g) × Fin (mult α)) ×
-      ((α : Fin g) × Fin (mult α)) ↦
-        Fin (dim p.1.1) × Fin (dim p.2.1))
-    (fun _ ↦ finProdFinEquiv.symm) C
-    (weightedVerticalProductBlock dim mult weight B)
-    (productRetainedEquiv dim mult)
-    (mulTensor_verticalAssembledTensor_reindex dim mult weight B)
-    hCanonical.1 hCanonical.2 p
+  have hHorizontalTwo := hHorizontal.blockTwo
+  have hMTwo := hM.blockTwo
+  exact weightedVerticalProductBlock_projectorClosure_and_noPeriodicVectors_of_blockTwo
+    dim mult weight B M U hU hReconstruct
+    (hHorizontalTwo.hasInvariantProjectorClosure_verticalTensor (blockTwo M) hMTwo)
+    (hasNoPeriodicVectors_verticalTensor_of_horizontalCF
+      (blockTwo M) hMTwo hHorizontalTwo) p
 
 /-- Every retained copy-pair tensor has an exact decomposition into its
 nonzero normal corners, with the corner isometries retained.
@@ -839,6 +889,59 @@ nonzero normal corners, with the corner isometries retained.
 The active family may be empty.  Thus a zero-dimensional copy pair, or a
 copy-pair tensor whose every letter vanishes, contributes no artificial
 normal sector.  No division by the outer copy weight occurs in this theorem.
+
+Source: CPSV16, Appendix C.4, lines 2020--2029. -/
+theorem exists_weightedVerticalProductBlock_normalDecomposition_of_blockTwo
+    {g d D : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (B : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (M : MPOTensor d D)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ ab, verticalTensor M ab =
+      Uᴴ * verticalAssembledTensor dim mult weight B ab * U)
+    (hClosure : MPSTensor.HasInvariantProjectorClosure (verticalTensor (blockTwo M)))
+    (hPer : MPSTensor.HasNoPeriodicVectors (verticalTensor (blockTwo M)))
+    (p : ((α : Fin g) × Fin (mult α)) ×
+      ((α : Fin g) × Fin (mult α))) :
+    ∃ (r : ℕ) (localDim : Fin r → ℕ) (coefficient : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor (D * D) (localDim k))
+      (V : (k : Fin r) →
+        Matrix (Fin (dim p.1.1 * dim p.2.1)) (Fin (localDim k)) ℂ),
+      (∀ k, 0 < localDim k) ∧
+      (∀ k, (0 : ℂ) < coefficient k) ∧
+      (∀ k, MPSTensor.IsNormalTensor (blocks k)) ∧
+      (∀ k, (V k)ᴴ * V k = 1) ∧
+      (∀ k l, k ≠ l → (V k)ᴴ * V l = 0) ∧
+      (∀ (k : Fin r) (ab : Fin (D * D)),
+        weightedVerticalProductBlock dim mult weight B p ab * V k =
+          V k * (coefficient k • blocks k ab)) ∧
+      (∀ (k : Fin r) (ab : Fin (D * D)),
+        (V k)ᴴ * weightedVerticalProductBlock dim mult weight B p ab =
+          (coefficient k • blocks k ab) * (V k)ᴴ) ∧
+      (∀ (k : Fin r) (ab : Fin (D * D)),
+        coefficient k • blocks k ab =
+          (V k)ᴴ * weightedVerticalProductBlock dim mult weight B p ab * V k) ∧
+      (∀ ab : Fin (D * D),
+        weightedVerticalProductBlock dim mult weight B p ab =
+          ∑ k, V k * (coefficient k • blocks k ab) * (V k)ᴴ) ∧
+      MPSTensor.SameMPV₂Pos
+        (weightedVerticalProductBlock dim mult weight B p)
+        (MPSTensor.toTensorFromBlocks (d := D * D)
+          (μ := coefficient) blocks) ∧
+      (∑ k, localDim k) ≤ dim p.1.1 * dim p.2.1 := by
+  have hCanonical :=
+    weightedVerticalProductBlock_projectorClosure_and_noPeriodicVectors_of_blockTwo
+      dim mult weight B M U hU hReconstruct hClosure hPer p
+  exact MPSTensor.exists_normalTensor_blockDecomp_with_isometry_of_hasInvariantProjectorClosure
+    (weightedVerticalProductBlock dim mult weight B p)
+    hCanonical.1 hCanonical.2
+
+/-- Every retained copy-pair tensor of a tensor in normalized BNT-refined
+horizontal form has an exact decomposition into its nonzero normal corners,
+with the corner isometries retained.
 
 Source: CPSV16, Appendix C.4, lines 2020--2029. -/
 theorem exists_weightedVerticalProductBlock_normalDecomposition
@@ -881,11 +984,12 @@ theorem exists_weightedVerticalProductBlock_normalDecomposition
         (MPSTensor.toTensorFromBlocks (d := D * D)
           (μ := coefficient) blocks) ∧
       (∑ k, localDim k) ≤ dim p.1.1 * dim p.2.1 := by
-  have hCanonical :=
-    weightedVerticalProductBlock_projectorClosure_and_noPeriodicVectors
-      dim mult weight B M U hU hReconstruct hHorizontal hM p
-  exact MPSTensor.exists_normalTensor_blockDecomp_with_isometry_of_hasInvariantProjectorClosure
-    (weightedVerticalProductBlock dim mult weight B p)
-    hCanonical.1 hCanonical.2
+  have hHorizontalTwo := hHorizontal.blockTwo
+  have hMTwo := hM.blockTwo
+  exact exists_weightedVerticalProductBlock_normalDecomposition_of_blockTwo
+    dim mult weight B M U hU hReconstruct
+    (hHorizontalTwo.hasInvariantProjectorClosure_verticalTensor (blockTwo M) hMTwo)
+    (hasNoPeriodicVectors_verticalTensor_of_horizontalCF
+      (blockTwo M) hMTwo hHorizontalTwo) p
 
 end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalProductSpectralFamily.lean
+++ b/TNLean/MPS/MPDO/VerticalProductSpectralFamily.lean
@@ -90,12 +90,12 @@ structure RetainedProductSpectralFamily
     (∑ k, localDim p k) ≤ dim p.1.1 * dim p.2.1
 
 /-- The local spectral decompositions may be chosen simultaneously for every
-retained copy pair.  Empty active families are preserved.
+retained copy pair when the blocked vertical tensor has projector closure and
+no periodic vectors. Empty active families are preserved.
 
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form used in Appendix C.4 through
-Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`. -/
-theorem exists_retainedProductSpectralFamily
+Source: CPSV16, Proposition 4.13, lines 1873--1893, and Appendix C.4,
+lines 2020--2029. -/
+theorem exists_retainedProductSpectralFamily_of_blockTwo
     {g d D : ℕ} (dim mult : Fin g → ℕ)
     (weight : (α : Fin g) → Fin (mult α) → ℂ)
     (B : (α : Fin g) → MPSTensor (D * D) (dim α))
@@ -106,12 +106,13 @@ theorem exists_retainedProductSpectralFamily
     (hU : U * Uᴴ = 1)
     (hReconstruct : ∀ ab, verticalTensor M ab =
       Uᴴ * verticalAssembledTensor dim mult weight B ab * U)
-    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    (hClosure : MPSTensor.HasInvariantProjectorClosure (verticalTensor (blockTwo M)))
+    (hPer : MPSTensor.HasNoPeriodicVectors (verticalTensor (blockTwo M))) :
     Nonempty (RetainedProductSpectralFamily dim mult weight B) := by
   classical
   have hExists := fun p ↦
-    exists_weightedVerticalProductBlock_normalDecomposition
-      dim mult weight B M U hU hReconstruct hHorizontal hM p
+    exists_weightedVerticalProductBlock_normalDecomposition_of_blockTwo
+      dim mult weight B M U hU hReconstruct hClosure hPer p
   choose count localDim coefficient block localInclusion
     localDim_pos coefficient_pos block_normal localInclusion_isometry
     localInclusion_orthogonal local_intertwine local_intertwine_adjoint
@@ -134,6 +135,37 @@ theorem exists_retainedProductSpectralFamily
     local_reconstruction := local_reconstruction
     local_sameMPV₂Pos := local_sameMPV₂Pos
     local_dimension_bound := local_dimension_bound }⟩
+
+/-- The local spectral decompositions may be chosen simultaneously for every
+retained copy pair of a tensor in normalized BNT-refined horizontal form.
+Empty active families are preserved.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Appendix C.4 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
+Source: CPSV16, Proposition 4.13, lines 1873--1893, and Appendix C.4,
+lines 2020--2029. -/
+theorem exists_retainedProductSpectralFamily
+    {g d D : ℕ} (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (B : (α : Fin g) → MPSTensor (D * D) (dim α))
+    (M : MPOTensor d D)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1)
+    (hReconstruct : ∀ ab, verticalTensor M ab =
+      Uᴴ * verticalAssembledTensor dim mult weight B ab * U)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    Nonempty (RetainedProductSpectralFamily dim mult weight B) := by
+  have hHorizontalTwo := hHorizontal.blockTwo
+  have hMTwo := hM.blockTwo
+  exact exists_retainedProductSpectralFamily_of_blockTwo
+    dim mult weight B M U hU hReconstruct
+    (hHorizontalTwo.hasInvariantProjectorClosure_verticalTensor (blockTwo M) hMTwo)
+    (hasNoPeriodicVectors_verticalTensor_of_horizontalCF
+      (blockTwo M) hMTwo hHorizontalTwo)
 
 namespace RetainedProductSpectralFamily
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -503,14 +503,15 @@ referenceInclusion_isometry}
     \lean{MPOTensor.RetainedProductSpectralFamily.FlatBlockedBNTComparison.%
 activeCoefficient_mul_phase_pos_of_sectorCompression_separation}
     \leanok
-    \uses{thm:mpdo_active_product_corner_blocked_bnt_coverage,
+    \uses{def:mpdo, thm:mpdo_active_product_corner_blocked_bnt_coverage,
       thm:mpdo_blocked_reference_corners,
       thm:mpdo_retained_product_spectral_family_exists,
       thm:mpdo_sector_weight_pos}
-    Assume exact coisometric reconstructions of the one-site and blocked
-    vertical tensors, positive multiplicities and weights for the blocked
-    BNT, and normality of its representatives. Suppose moreover that every
-    projection with a nonzero two-sided corner of the blocked vertical tensor
+    Assume that $M$ generates matrix product density operators and that the
+    one-site and blocked vertical tensors admit exact coisometric
+    reconstructions. Assume positive multiplicities and weights for the
+    blocked BNT and normality of its representatives. Suppose moreover that
+    every projection with a nonzero two-sided corner of the blocked vertical tensor
     has a nonzero finite-chain sector compression. Then every active product
     corner $j$ satisfies $0<\lambda_j\zeta_j$.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -331,6 +331,31 @@
     compression formula.
 \end{proof}
 
+\begin{theorem}[Retained-product spectra from literal CPSV canonical form]
+    \label{thm:mpdo_literal_cpsv_retained_product_spectral_family}
+    \lean{MPSTensor.IsCPSVCanonicalForm.exists_retainedProductSpectralFamily}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form,
+      def:mpdo_retained_product_spectral_family,
+      thm:mpdo_literal_cpsv_positive_blocking,
+      thm:mpdo_vertical_projector_closure_literal_cpsv,
+      thm:mpdo_vertical_no_periodic_vectors_literal_cpsv}
+    Let $M$ generate matrix product density operators, and suppose that its
+    doubled-index MPS tensor is in literal CPSV canonical form. Given an exact
+    coisometric reconstruction of the one-site vertical tensor by a retained
+    direct sum of weighted normal tensors, simultaneous retained-product
+    spectral families exist for all ordered pairs of retained copies. Empty
+    active families are preserved. This is the retained-product decomposition
+    used in \cite[Appendix~C.4, lines~2020--2029]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Literal CPSV canonical form passes to the two-site blocking. Proposition
+    4.13 gives invariant-projector closure and excludes nontrivial periodic
+    vectors for its vertical tensor. Apply the retained-product construction
+    to these two properties and the squared coisometric reconstruction.
+\end{proof}
+
 \begin{theorem}[Flattened reconstruction of the retained product]
     \label{thm:mpdo_retained_product_flat_reconstruction}
     \lean{MPOTensor.retainedVerticalProductTensor_eq_sum_pairBlocks}
@@ -473,6 +498,31 @@ referenceInclusion_isometry}
     Transport along equality of bond dimensions preserves these equations.
 \end{proof}
 
+\begin{theorem}[Active product positivity from sector separation]
+    \label{thm:mpdo_active_product_coefficient_phase_pos_of_sector_separation}
+    \lean{MPOTensor.RetainedProductSpectralFamily.FlatBlockedBNTComparison.%
+activeCoefficient_mul_phase_pos_of_sectorCompression_separation}
+    \leanok
+    \uses{thm:mpdo_active_product_corner_blocked_bnt_coverage,
+      thm:mpdo_blocked_reference_corners,
+      thm:mpdo_retained_product_spectral_family_exists,
+      thm:mpdo_sector_weight_pos}
+    Assume exact coisometric reconstructions of the one-site and blocked
+    vertical tensors, positive multiplicities and weights for the blocked
+    BNT, and normality of its representatives. Suppose moreover that every
+    projection with a nonzero two-sided corner of the blocked vertical tensor
+    has a nonzero finite-chain sector compression. Then every active product
+    corner $j$ satisfies $0<\lambda_j\zeta_j$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Compare the active corner with the distinguished positive-weight copy of
+    its blocked BNT representative. The active coefficient is nonzero because
+    $\lambda_j>0$ and $|\zeta_j|=1$. The assumed separation property supplies
+    a nonzero finite-chain compression, so the sector-weight comparison gives
+    $\lambda_j\zeta_j>0$.
+\end{proof}
+
 \begin{theorem}[Positivity of active product coefficients]
     \label{thm:mpdo_active_product_coefficient_phase_pos}
     \lean{MPOTensor.RetainedProductSpectralFamily.FlatBlockedBNTComparison.%
@@ -482,7 +532,8 @@ activeCoefficient_mul_phase_pos}
       thm:mpdo_blocked_reference_corners,
       thm:mpdo_retained_product_spectral_family_exists,
       thm:mpdo_grouped_sector_compression_nonzero,
-      thm:mpdo_sector_weight_pos}
+      thm:mpdo_sector_weight_pos,
+      thm:mpdo_active_product_coefficient_phase_pos_of_sector_separation}
     Suppose that $M$ is in normalized BNT-refined horizontal form and generates
     positive operators. Assume exact coisometric reconstructions of its one-site and
     blocked vertical tensors, positive multiplicities and weights for the
@@ -491,15 +542,35 @@ activeCoefficient_mul_phase_pos}
 \end{theorem}
 
 \begin{proof}\leanok
-    Compare two isometric corners of the blocked vertical tensor carrying the
-    same normal representative. The distinguished blocked copy has positive
-    weight by hypothesis. The active corner has weight
-    $\lambda_j\zeta_j$ by its exact compression and gauge--phase identity.
-    This scalar is nonzero because $\lambda_j>0$ and $|\zeta_j|=1$.
-    Normality gives a nonzero range-projection corner; the BNT-refined horizontal
-    hypothesis separates it at some finite chain length. The sector-weight comparison
-    with the distinguished reference corner then yields
-    $\lambda_j\zeta_j>0$.
+    Normalized BNT-refined horizontal form separates every nonzero
+    range-projection corner at some finite chain length. Apply the preceding
+    theorem with this separation property.
+\end{proof}
+
+\begin{theorem}[Literal positivity of active product coefficients]
+    \label{thm:mpdo_literal_cpsv_active_product_coefficient_phase_pos}
+    \lean{MPOTensor.RetainedProductSpectralFamily.FlatBlockedBNTComparison.%
+activeCoefficient_mul_phase_pos_of_cpsvCanonicalForm}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form,
+      thm:mpdo_active_product_corner_blocked_bnt_coverage,
+      thm:mpdo_blocked_reference_corners,
+      thm:cpsv_literal_sector_compression_nonzero,
+      thm:mpdo_sector_weight_pos,
+      thm:mpdo_active_product_coefficient_phase_pos_of_sector_separation}
+    Suppose that the doubled-index MPS tensor of $M$ is in literal CPSV
+    canonical form and that $M$ generates matrix product density operators.
+    Assume exact coisometric reconstructions of the one-site and blocked
+    vertical tensors, positive multiplicities and weights for the blocked
+    BNT, and normality of its representatives. For every active product
+    corner $j$, one has $0<\lambda_j\zeta_j$. This is the positivity step of
+    \cite[Appendix~C.4, lines~2025--2029]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The literal sector-compression separation theorem supplies the finite
+    chain on which the active corner is nonzero. Apply
+    Theorem~\ref{thm:mpdo_active_product_coefficient_phase_pos_of_sector_separation}.
 \end{proof}
 
 \begin{theorem}[Unitary normalization of active product gauges]
@@ -525,6 +596,8 @@ exists_unitaryNormalization}
       &\in\mathrm{U}(D_j).
       \notag
     \end{align}
+    This is the gauge normalization used in
+    \cite[Appendix~C.4, lines~2025--2029]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -534,6 +607,38 @@ exists_unitaryNormalization}
     Normal-tensor rigidity then makes $X_j^\dagger X_j$ a positive real
     multiple of the identity. Division by the positive square root gives a
     unitary matrix.
+\end{proof}
+
+\begin{theorem}[Literal unitary normalization of active product gauges]
+    \label{thm:mpdo_literal_cpsv_active_product_gauge_unitary_normalization}
+    \lean{MPOTensor.RetainedProductSpectralFamily.FlatBlockedBNTComparison.%
+exists_unitaryNormalization_of_cpsvCanonicalForm}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form,
+      thm:mpdo_active_product_corner_blocked_bnt_coverage,
+      thm:mpdo_blocked_reference_corners,
+      thm:mpdo_literal_cpsv_active_product_coefficient_phase_pos,
+      thm:cpsv_literal_positive_relative_gram_scalar}
+    Under the hypotheses of the preceding literal positivity theorem, for
+    every active product corner $j$ there is a real number $\omega_j>0$ such
+    that
+    \begin{align}
+      X_j^\dagger X_j
+      &=\omega_j\Id,
+      \notag\\
+      \omega_j^{-1/2}X_j
+      &\in\mathrm{U}(D_j).
+      \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    Compress the blocked vertical tensor to the active corner and to the
+    distinguished blocked reference corner. Their coefficients are positive
+    by the preceding theorem and by positivity of the blocked multiplicity
+    weight. The literal Figure~8 comparison gives
+    $X_j^\dagger X_j=\omega_j\Id$ with $\omega_j>0$; division by
+    $\sqrt{\omega_j}$ gives a unitary matrix.
 \end{proof}
 
 \begin{definition}[Original-label corner family]
@@ -671,6 +776,30 @@ toBNTFusionCoisometryFamily}
     without separate cases when a fiber or the whole active family is empty.
 \end{proof}
 
+\begin{theorem}[Fusion coisometries from normalized product corners]
+    \label{thm:mpdo_normalized_product_corners_to_fusion_coisometry}
+    \lean{MPOTensor.RetainedProductSpectralFamily.%
+exists_bntFusionCoisometryFamily}
+    \leanok
+    \uses{thm:mpdo_original_corner_family_exists,
+      thm:mpdo_original_corner_family_to_fusion_coisometry}
+    Suppose that every active product corner has positive gauge--phase
+    coefficient and that its gauge Gram matrix is a positive scalar multiple
+    of the identity. Given the trace-ratio unitary correspondence between the
+    one-site and two-site vertical sectors, there are positive diagonal
+    matrices $\chi_{\alpha,\beta,\gamma}$ and coisometries
+    $U_{\alpha,\beta}$ satisfying the forward fusion identity and exact
+    reconstruction for every product tensor $M_\alpha M_\beta$. This is the
+    active-corner construction in
+    \cite[Appendix~C.4, lines~2020--2029]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    The positive coefficients and normalized gauges give an original-label
+    corner family. Apply the preceding block-row construction to its
+    orthogonal isometric inclusions.
+\end{proof}
+
 \begin{theorem}[Positive fusion from transported vertical sectors]
     \label{thm:mpdo_transported_vertical_product_positive_fusion_decomposition}
     \lean{MPOTensor.transportedVerticalSector_exists_positiveFusionDecomposition}
@@ -682,7 +811,8 @@ toBNTFusionCoisometryFamily}
       thm:mpdo_active_product_coefficient_phase_pos,
       thm:mpdo_active_product_gauge_unitary_normalization,
       thm:mpdo_original_corner_family_exists,
-      thm:mpdo_original_corner_family_to_fusion_coisometry}
+      thm:mpdo_original_corner_family_to_fusion_coisometry,
+      thm:mpdo_normalized_product_corners_to_fusion_coisometry}
     Under the one-site and two-site vertical basis-of-normal-tensors
     decompositions and the two completely positive, trace-preserving
     physical-closure transport identities, assume that the one-site tensor
@@ -738,6 +868,102 @@ toBNTFusionCoisometryFamily}
     label gives the positive diagonal matrices $\chi_{\alpha,\beta,\gamma}$;
     corner intertwining and corner reconstruction give the two displayed
     identities.
+\end{proof}
+
+\begin{theorem}[Positive fusion from literal CPSV canonical form]
+    \label{thm:mpdo_literal_cpsv_vertical_product_positive_fusion_decomposition}
+    \lean{MPOTensor.%
+exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form,
+      thm:mpdo_transported_vertical_sector_coefficient_comparison,
+      thm:mpdo_literal_cpsv_retained_product_spectral_family,
+      thm:mpdo_active_product_corner_blocked_bnt_coverage,
+      thm:mpdo_literal_cpsv_active_product_coefficient_phase_pos,
+      thm:mpdo_literal_cpsv_active_product_gauge_unitary_normalization,
+      thm:mpdo_original_corner_family_exists,
+      thm:mpdo_original_corner_family_to_fusion_coisometry,
+      thm:mpdo_normalized_product_corners_to_fusion_coisometry}
+    Let $M$ generate matrix product density operators, and suppose that its
+    doubled-index MPS tensor is in literal CPSV canonical form. Given one-site
+    and two-site vertical canonical decompositions and their trace-ratio
+    unitary sector correspondence, there are positive diagonal matrices
+    $\chi_{\alpha,\beta,\gamma}$ and matrices $U_{\alpha,\beta}$ such that
+    \begin{align}
+      U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}
+      &=1,
+      \notag\\
+      U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
+        U_{\alpha,\beta}^{\dagger}
+      &=\bigoplus_\gamma
+        \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij},
+      \notag\\
+      (M_\alpha M_\beta)^{ij}
+      &=U_{\alpha,\beta}^{\dagger}
+        \left(\bigoplus_\gamma
+          \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}\right)
+        U_{\alpha,\beta}.
+      \notag
+    \end{align}
+    Every diagonal entry of $\chi_{\alpha,\beta,\gamma}$ is positive.
+    This is the positive fusion decomposition in
+    \cite[Appendix~C.4, lines~2020--2029]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Literal canonical form gives simultaneous spectra for all retained product
+    corners. Compare each active corner with the blocked vertical BNT. Literal
+    sector separation makes its coefficient positive, and the literal
+    Figure~8 comparison normalizes its gauge to a unitary. Transporting these
+    corners through the one-site--two-site sector correspondence gives
+    positive original-label corners; their adjoints form the rows of the
+    coisometries $U_{\alpha,\beta}$ and yield both displayed identities.
+\end{proof}
+
+\begin{theorem}[Idempotent trace scalars from blocked representations]
+    \label{thm:mpdo_blocked_representations_idempotent_trace_scalars}
+    \lean{MPOTensor.hasIdempotentCoefficientForm_of_blockedRepresentations}
+    \leanok
+    \uses{def:mpdo_bnt_label_idempotent_coefficient_form,
+      def:mpdo_bnt_fusion_coisometry_family,
+      def:mpdo_bnt_eventual_power_sums_multiplicity_comparison,
+      thm:mpdo_blocked_vertical_operator_representations}
+    Fix one-site and two-site vertical canonical decompositions whose sectors
+    are identified by the transported unitary relabelling. Suppose that the
+    product tensors have positive diagonal fusion matrices
+    $\chi_{\alpha,\beta,\gamma}$ and exact forward and reverse coisometric
+    fusion identities. If the blocked operator has the two simultaneous
+    representations of
+    Theorem~\ref{thm:mpdo_blocked_vertical_operator_representations}, then
+    \begin{align}
+      m_\gamma
+      &=\sum_{\alpha,\beta}
+        \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta.
+      \notag
+    \end{align}
+    This is the idempotent coefficient identity in
+    \cite[Appendix~C.4, lines~2030--2042]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    For every sufficiently large $L$, expand the product of one-site sector
+    operators with the fusion identity. Eventual linear independence of the
+    BNT operators and the two blocked representations then identify, for
+    every $\gamma$, the two positive power sums
+    \begin{align}
+      \tr\!\left[
+        \left(\frac{m_\gamma}{n_{\sigma(\gamma)}}
+          \nu_{\sigma(\gamma)}\right)^L\right]
+      &=
+      \sum_{\alpha,\beta}
+        \tr\!\left[
+          \left(\mu_\alpha\otimes\mu_\beta\otimes
+            \chi_{\alpha,\beta,\gamma}\right)^L\right].
+      \notag
+    \end{align}
+    The eventual power-sum comparison identifies the two multisets of positive
+    entries. Summing this multiset equality and cancelling
+    $n_{\sigma(\gamma)}$ gives the displayed length-one identity.
 \end{proof}
 
 \begin{theorem}[Positive fusion decomposition of vertical products]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -223,7 +223,7 @@
     \label{thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor}
     \lean{MPOTensor.HasBNTFusionTensorClause.%
 of_isRFPViaTS_of_cpsvCanonicalForm}
-    \notready
+    \leanok
     \uses{def:mpdo, def:cpsv_canonical_form, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause}
     Let $M$ generate matrix product density operators, and suppose that its
@@ -242,7 +242,7 @@ of_isRFPViaTS_of_cpsvCanonicalForm}
     \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
-\begin{proof}\notready
+\begin{proof}\leanok
     \uses{thm:mpdo_literal_cpsv_vertical_decomposition,
       thm:mpdo_literal_cpsv_vertical_decomposition_block_two,
       thm:mpdo_transported_vertical_sector_coefficient_comparison,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -219,6 +219,45 @@
     which completes the fusion clause.
 \end{proof}
 
+\begin{theorem}[Literal CPSV renormalization fixed points have active-sector fusion]%
+    \label{thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor}
+    \lean{MPOTensor.HasBNTFusionTensorClause.%
+of_isRFPViaTS_of_cpsvCanonicalForm}
+    \notready
+    \uses{def:mpdo, def:cpsv_canonical_form, def:is_rfp_via_ts,
+        def:mpdo_bnt_fusion_tensor_clause}
+    Let $M$ generate matrix product density operators, and suppose that its
+    doubled-index MPS tensor is in literal CPSV canonical form. If the
+    one-site and two-site physical closures are related in both directions by
+    trace-preserving completely positive maps as in Definition~4.1, then a
+    vertical canonical decomposition of $M$ has the active-sector fusion
+    clause. In particular, its positive diagonal fusion matrices satisfy
+    \begin{align}
+      m_\gamma
+      &=\sum_{\alpha,\beta}
+        \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta.
+      \notag
+    \end{align}
+    This is implication (i)$\Rightarrow$(iii) of
+    \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\notready
+    \uses{thm:mpdo_literal_cpsv_vertical_decomposition,
+      thm:mpdo_literal_cpsv_vertical_decomposition_block_two,
+      thm:mpdo_transported_vertical_sector_coefficient_comparison,
+      thm:mpdo_blocked_vertical_operator_representations,
+      thm:mpdo_literal_cpsv_vertical_product_positive_fusion_decomposition,
+      thm:mpdo_blocked_representations_idempotent_trace_scalars}
+    Choose the literal one-site and two-site vertical decompositions.
+    Transporting the two physical maps through them identifies their normal
+    sectors by trace-ratio unitary conjugacies. The literal positive-fusion
+    theorem gives the positive diagonal matrices, coisometries, and exact
+    reconstruction on every active product sector. The two simultaneous
+    blocked-operator representations and eventual linear independence of the
+    BNT operators then give the length-one idempotent trace-scalar identity.
+\end{proof}
+
 \begin{theorem}[Active-sector fusion implies the tensor-attached algebra clause]%
     \label{thm:mpdo_bnt_fusion_tensor_to_algebra_tensor}
     \lean{MPOTensor.BNTFusionTensorClause.toBNTAlgebraTensorClause}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L420, 422 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L283 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L459, 461 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L322 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L734 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L736, 739, 742, 745 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |


### PR DESCRIPTION
Closes #5199.

## Summary

- factor retained-product spectra through the blocked invariant-projector-closure and no-periodic-vectors capabilities
- factor active-corner positivity through finite sector-compression separation
- add literal CPSV specializations for retained spectra, coefficient positivity, gauge normalization, and positive fusion data
- prove `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm`
- preserve the existing `IsHorizontalCF` APIs as wrappers and sync the Chapter 21 Blueprint

The final theorem has exactly the source hypotheses `IsCPSVCanonicalForm M.toMPSTensor`, `IsMPDO M`, and `IsRFPViaTS M`; it does not pass through `IsHorizontalCF` or add a metric, channel, raw-fusion, or unitary-comparison assumption.

This proves the repository's active-support fusion clause, not the final topological Gibbs theorem or the reverse algebra-to-RFP implication. The active-support/Figure-11 conventions remain documented in:

- `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`
- `docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`
- `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`

## Validation

- `lake build TNLean.MPS.MPDO.CPSVVerticalProductCornerPositivity -q --log-level=info`
- `lake build TNLean.MPS.MPDO.VerticalProductFusionDecomposition -q --log-level=info`
- `lake build TNLean.MPS.MPDO.CPSVVerticalProductFusionDecomposition -q --log-level=info`
- `lake build TNLean.MPS.MPDO.CPSVBNTFusionTensorClauseFromRFP -q --log-level=info`
- `lake build TNLean.MPS.MPDO -q --log-level=info`
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --update-lean-decls --ci`
- changed-declaration Blueprint coverage check
- `lake exe checkdecls` on all PR-added Blueprint declaration references
- proof-integrity, line-length, and `git diff --check` audits

The repository-wide `lake exe checkdecls blueprint/lean_decls` still reports eight unrelated pre-existing missing declarations in periodic/BNT modules; every declaration added or newly tagged by this PR resolves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof surface in core MPDO vertical-product and fusion infrastructure; incorrect lemma factoring could break downstream RFP/fusion theorems without obvious runtime impact.
> 
> **Overview**
> This PR completes the **source-faithful CPSV path** from literal canonical form plus `IsRFPViaTS` to the active-support **`HasBNTFusionTensorClause`**, via `of_isRFPViaTS_of_cpsvCanonicalForm` (CPSV Theorem 4.14 (i)⇒(iii)).
> 
> The vertical product pipeline is **refactored** so shared lemmas take weaker hypotheses: retained-product spectral families need only **blocked** invariant-projector closure and no periodic vectors (`*_of_blockTwo`), and active-corner positivity is factored through **sector-compression separation** before `IsHorizontalCF` and literal CPSV wrappers plug in the missing separation.
> 
> **New CPSV modules** wire literal form into retained spectra, coefficient positivity, gauge unitary normalization, positive fusion data, and the fusion tensor clause. **`exists_bntFusionCoisometryFamily`** centralizes the corner-to-coisometry step used by both horizontal-CF and CPSV entry points. Chapter 21 **Blueprint** gains matching theorems (retained spectra, literal positivity/normalization, fusion, idempotent trace scalars, literal RFP⇒fusion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225472b9ace9af3284ecf1bab4b7c32c6e38c5f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->