### PR TITLE
feat(MPS/MPDO): pair literal CPSV vertical decompositions

### DIFF
--- a/TNLean/MPS/MPDO/CPSVVerticalDecomposition.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalDecomposition.lean
@@ -19,6 +19,7 @@ normal tensors.
 
 * `MPSTensor.IsCPSVCanonicalForm.exists_cpsvVerticalDecomposition`
 * `MPSTensor.IsCPSVCanonicalForm.exists_cpsvVerticalDecomposition_blockTwo`
+* `MPSTensor.IsCPSVCanonicalForm.exists_cpsvVerticalDecomposition_pair`
 
 ## References
 
@@ -98,5 +99,20 @@ theorem exists_cpsvVerticalDecomposition_blockTwo
   have hBlocked :=
     MPOTensor.IsCPSVCanonicalForm_toMPSTensor_blockTwo hCanonical
   exact hBlocked.exists_cpsvVerticalDecomposition (MPOTensor.blockTwo M) hM.blockTwo
+
+/-- Literal CPSV canonical form gives the one-site and concrete two-site
+vertical decompositions as a single pair for their comparison in Appendix C.4.
+
+Source: arXiv:1606.00608, Proposition 4.13 and Appendix C.4,
+lines 1863--1956. -/
+theorem exists_cpsvVerticalDecomposition_pair
+    (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : MPOTensor.IsMPDO M) :
+    Nonempty (MPOTensor.CPSVVerticalDecomposition M ×
+      MPOTensor.CPSVVerticalDecomposition (MPOTensor.blockTwo M)) := by
+  obtain ⟨D₁⟩ := hCanonical.exists_cpsvVerticalDecomposition M hM
+  obtain ⟨D₂⟩ := hCanonical.exists_cpsvVerticalDecomposition_blockTwo M hM
+  exact ⟨D₁, D₂⟩
 
 end MPSTensor.IsCPSVCanonicalForm

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex
@@ -296,6 +296,28 @@ physical indices, as in
     Theorem~\ref{thm:mpdo_literal_cpsv_vertical_decomposition} to $M^{[2]}$.
 \end{proof}
 
+\begin{corollary}[Paired literal vertical decompositions]
+    \label{cor:mpdo_literal_cpsv_vertical_decomposition_pair}
+    \lean{MPSTensor.IsCPSVCanonicalForm.%
+        exists_cpsvVerticalDecomposition_pair}
+    \leanok
+    \uses{thm:mpdo_literal_cpsv_vertical_decomposition,
+        thm:mpdo_literal_cpsv_vertical_decomposition_block_two}
+    Under the hypotheses of
+    Theorem~\ref{thm:mpdo_literal_cpsv_vertical_decomposition}, there exist
+    simultaneously a one-site vertical decomposition of $M$ and a two-site
+    vertical decomposition of $M^{[2]}$ of the respective forms stated in
+    Theorems~\ref{thm:mpdo_literal_cpsv_vertical_decomposition}
+    and~\ref{thm:mpdo_literal_cpsv_vertical_decomposition_block_two}.
+\end{corollary}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_literal_cpsv_vertical_decomposition,
+        thm:mpdo_literal_cpsv_vertical_decomposition_block_two}
+    Choose the one-site and two-site decompositions independently and take
+    their ordered pair.
+\end{proof}
+
 \begin{lemma}[Two-site blocking preserves normalized BNT-refined horizontal form]
     \label{lem:mpdo_horizontal_cf_block_two}
     \lean{MPOTensor.IsHorizontalCF.blockTwo}


### PR DESCRIPTION
## Summary

- package the literal one-site and concrete two-site CPSV vertical decompositions as a single existence statement
- provide the exact paired datum used by the Appendix C.4 comparison
- retain the separate constructors and Blueprint statements merged in #5198

This is the final completion criterion of #5197. The pair asserts no additional compatibility between the two decompositions; it records their simultaneous existence under the common literal CPSV and MPDO hypotheses.

## Source

CPSV16, Proposition 4.13 and Appendix C.4, arXiv:1606.00608, lines 1863–1956.

## Validation

- `lake build TNLean.MPS.MPDO.CPSVVerticalDecomposition`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- proof-integrity search and `git diff --check origin/main...HEAD`
- kernel axiom audit: `propext`, `Classical.choice`, `Quot.sound`

Closes #5197.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin composition of already-proved existence lemmas plus blueprint text; no changes to auth, data, or core decomposition proofs.
> 
> **Overview**
> Adds **`exists_cpsvVerticalDecomposition_pair`**, which packages the existing one-site and two-site CPSV vertical decomposition existence results into a single **`Nonempty`** of a product type, so downstream Appendix C.4 work can cite both decompositions under the same literal CPSV + MPDO hypotheses in one step. The proof only **`obtain`**s witnesses from the separate theorems and pairs them; it does not add any compatibility between the two decompositions.
> 
> The blueprint gains **Corollary (Paired literal vertical decompositions)** (`cor:mpdo_literal_cpsv_vertical_decomposition_pair`) linked to that Lean name, stating simultaneous existence of the one-site and **`M^{[2]}`** decompositions described in the preceding theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac95e9da085addc7cb84275bf413a35459086f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->