### PR TITLE
feat(MPS/MPDO): complete literal CPSV Gibbs theorem

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -76,6 +76,7 @@ import TNLean.MPS.MPDO.CPSVOriginalSpaceLemmaL
 import TNLean.MPS.MPDO.CPSVPeriodicExclusion
 import TNLean.MPS.MPDO.CPSVRepresentativeGroupedLemmaL
 import TNLean.MPS.MPDO.CPSVSharpBlocking
+import TNLean.MPS.MPDO.CPSVTopologicalPhysicalGibbs
 import TNLean.MPS.MPDO.CPSVVerticalBNT
 import TNLean.MPS.MPDO.CPSVVerticalCanonicalForm
 import TNLean.MPS.MPDO.CPSVVerticalDecomposition

--- a/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
@@ -36,6 +36,20 @@ namespace HasBNTFusionTensorClause
 that satisfies the Definition 4.1 renormalization fixed-point condition has
 the active-support BNT fusion clause.
 
+**Scope restriction (active product BNT):** Only active product corners are
+retained. A one-site BNT label absent from a fixed product pair has zero fusion
+multiplicity. Documented in
+`docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`.
+
+**Local fix (Figure-11 fixed-pair support):** A fixed pair may have an empty
+active family; no unsupported corner is inserted. Documented in
+`docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`.
+
+**Local fix (Figure-11 fusion coisometry):** The fusion map has retained-row
+orientation and is a coisometry onto the active direct sum. Its adjoint gives
+the exact reconstruction. Documented in
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`.
+
 Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
 lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)

--- a/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
@@ -56,7 +56,7 @@ noncomputable def cpsvRFPBNTFusionTensorClause (M : MPOTensor d D)
     (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
     BNTFusionTensorClause M :=
-  Classical.choose
+  Classical.choice
     (HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm
       M hCanonical hM hRFP)
 

--- a/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.CPSVBNTFusionTensorClauseFromRFP
+import TNLean.MPS.MPDO.TopologicalPhysicalGibbs
+
+/-!
+# Literal CPSV RFP tensors have a physical commuting Gibbs decomposition
+
+This file selects the BNT fusion tensor clause furnished by the literal CPSV
+canonical-form theorem and applies the physical-coordinate Gibbs construction.
+
+## Main definitions
+
+* `MPOTensor.cpsvRFPBNTFusionTensorClause`
+
+## Main result
+
+* `MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS_of_cpsvCanonicalForm`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Theorems 4.14 and 4.15 and Appendix C.4
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+/-- A BNT fusion tensor clause selected from the literal CPSV canonical-form
+and renormalization fixed-point hypotheses.
+
+Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
+lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (active product BNT):** Only nonzero product corners occur;
+an absent output sector has zero multiplicity. See
+`docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`.
+
+**Local fix (Figure-11 fixed-pair support):** For a fixed input pair, the active
+output family may be empty. See
+`docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`.
+
+**Local fix (Figure-11 fusion coisometry):** The retained-row fusion map is a
+coisometry onto the active output sectors and satisfies exact adjoint
+reconstruction; no full-space isometry is asserted. See
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`. -/
+noncomputable def cpsvRFPBNTFusionTensorClause (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
+    BNTFusionTensorClause M :=
+  Classical.choose
+    (HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm
+      M hCanonical hM hRFP)
+
+/-- **Physical-coordinate commuting Gibbs decomposition for a literal CPSV
+RFP MPDO above one site.**
+
+For a tensor in literal CPSV canonical form which generates MPDOs and satisfies
+the renormalization fixed-point condition, select its BNT fusion tensor clause.
+If the associated coefficient family is independent of the chain length, then
+the selected clause gives the physical-coordinate commuting Gibbs
+decomposition on every chain of length `N + 2`.
+
+Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, Theorem 4.15,
+lines 1013--1016, and Appendix C.4, lines 1929--2046 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`.
+
+**Scope restriction (active product BNT):** Only nonzero product corners occur;
+an absent output sector has zero multiplicity. See
+`docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`.
+
+**Local fix (Figure-11 fixed-pair support):** For a fixed input pair, the active
+output family may be empty. See
+`docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`.
+
+**Local fix (Figure-11 fusion coisometry):** The retained-row fusion map is a
+coisometry onto the active output sectors and satisfies exact adjoint
+reconstruction; no full-space isometry is asserted. See
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`.
+
+**Local fix (physical complement):** The retained energy is extended by zero
+on the orthogonal physical complement, and the retained projectors are
+transported through the adjoint sitewise coisometry. See
+`docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`.
+
+**Scope restriction (positive chains of length at least two):** Definition 4.8
+does not specify a length-one two-site convention. This theorem covers exactly
+the source-defined lengths `N + 2`; see
+`docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`. -/
+theorem physicalTopologicalGibbsDecomposition_of_isRFPViaTS_of_cpsvCanonicalForm
+    (M : MPOTensor d D)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (hRFP : IsRFPViaTS M)
+    (hLI : (BNTLabelCoefficientFamily.ofChi
+      (cpsvRFPBNTFusionTensorClause M hCanonical hM hRFP).chi).LengthIndependent) :
+    let H := cpsvRFPBNTFusionTensorClause M hCanonical hM hRFP
+    H.HasPhysicalTopologicalGibbsDecomposition hM := by
+  dsimp only
+  exact
+    BNTFusionTensorClause.hasPhysicalTopologicalGibbsDecomposition
+      (cpsvRFPBNTFusionTensorClause M hCanonical hM hRFP) hM hLI
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/CPSVVerticalProductFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/CPSVVerticalProductFusionDecomposition.lean
@@ -34,6 +34,20 @@ namespace MPOTensor
 determines positive diagonal fusion data and coisometries onto the active
 product sectors.
 
+**Scope restriction (active product BNT):** Only active product corners are
+retained. A one-site BNT label absent from a fixed product pair has zero fusion
+multiplicity. Documented in
+`docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`.
+
+**Local fix (Figure-11 fixed-pair support):** A fixed pair may have an empty
+active family; no unsupported corner is inserted. Documented in
+`docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`.
+
+**Local fix (Figure-11 fusion coisometry):** The fusion map has retained-row
+orientation and is a coisometry onto the active direct sum. Its adjoint gives
+the exact reconstruction. Documented in
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`.
+
 Source: CPSV16, Proposition 4.13, lines 1863--1921, and Appendix C.4,
 lines 2001--2029. -/
 theorem exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm

--- a/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
+++ b/TNLean/MPS/MPDO/VerticalProductFusionDecomposition.lean
@@ -259,6 +259,20 @@ end OriginalCornerFamily
 /-- Positive normalized product corners determine a family of fusion
 coisometries for the original one-site BNT labels.
 
+**Scope restriction (active product BNT):** Only active product corners are
+retained. A one-site BNT label absent from a fixed product pair has zero fusion
+multiplicity. Documented in
+`docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`.
+
+**Local fix (Figure-11 fixed-pair support):** A fixed pair may have an empty
+active family; no unsupported corner is inserted. Documented in
+`docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`.
+
+**Local fix (Figure-11 fusion coisometry):** The fusion map has retained-row
+orientation and is a coisometry onto the active direct sum. Its adjoint gives
+the exact reconstruction. Documented in
+`docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`.
+
 Source: CPSV16, Appendix C.4, lines 2020--2029. -/
 theorem exists_bntFusionCoisometryFamily
     {g₂ : ℕ} {dim₂ : Fin g₂ → ℕ}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -909,6 +909,20 @@ exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm}
     Every diagonal entry of $\chi_{\alpha,\beta,\gamma}$ is positive.
     This is the positive fusion decomposition in
     \cite[Appendix~C.4, lines~2020--2029]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (active product BNT):} Only active product
+    corners occur. A label absent from a fixed product pair has zero fusion
+    multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
+    may have no active corner, and no unsupported sector is inserted. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row map is
+    a coisometry onto the active direct sum, and its adjoint gives the exact
+    reconstruction. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp_fusion_decomposition.tex
@@ -793,6 +793,20 @@ exists_bntFusionCoisometryFamily}
     reconstruction for every product tensor $M_\alpha M_\beta$. This is the
     active-corner construction in
     \cite[Appendix~C.4, lines~2020--2029]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (active product BNT):} Only active product
+    corners occur. A label absent from a fixed product pair has zero fusion
+    multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
+    may have no active corner, and no unsupported sector is inserted. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):} The retained-row map is
+    a coisometry onto the active direct sum, and its adjoint gives the exact
+    reconstruction. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -240,6 +240,20 @@ of_isRFPViaTS_of_cpsvCanonicalForm}
     \end{align}
     This is implication (i)$\Rightarrow$(iii) of
     \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (active product BNT):} For each fixed product
+    pair, only its active normal corners occur; an absent label has zero fusion
+    multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):} A fixed product pair
+    may have an empty active family, so no unsupported normal sector is added.
+    See \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):} Each fusion map is a
+    coisometry onto the active direct sum, and its adjoint reconstructs the
+    whole product tensor, including any discarded common zero corner. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -605,9 +605,9 @@
     \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
 \end{definition}
 
-\begin{theorem}[Retained-coordinate commuting Gibbs decomposition above one
-    site]%
-    \label{thm:mpdo_topological_gibbs_at_least_two}
+\begin{theorem}[Active-sector fusion gives a retained-coordinate commuting
+    Gibbs decomposition above one site]%
+    \label{thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
     \lean{MPOTensor.BNTFusionTensorClause.%
         topologicalGibbsLocalTerm_isHermitian}
     \lean{MPOTensor.BNTFusionTensorClause.%
@@ -623,16 +623,14 @@
     \lean{MPOTensor.BNTFusionTensorClause.%
         singleKrausMap_physicalIndexedGibbsDecomposition_eq_mpo}
     \lean{MPOTensor.BNTFusionTensorClause.hasTopologicalGibbsDecomposition}
-    \lean{MPOTensor.topologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
-    \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
+    \uses{def:mpdo, def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_topological_gibbs_data_at_least_two,
         thm:mpdo_terminal_spectral_projector_refinement}
-    Let $M$ be a matrix product density operator in normalized BNT-refined
-    horizontal form satisfying the renormalization fixed-point condition.
-    Select the fusion
-    clause supplied by that condition and suppose that its positive
-    trace-power coefficients are independent of the positive chain length.
+    Let $M$ generate matrix product density operators, and fix an
+    active-sector fusion clause for a vertical canonical decomposition of
+    $M$. Suppose that the trace-power coefficients of its positive diagonal
+    fusion matrices are independent of the positive chain length.
     There are non-negative numbers $\lambda_1,\ldots,\lambda_d$, independent
     of the chain length. For every $L\geq2$, the same two-site matrix $h$ is
     Hermitian, its periodic translates commute pairwise, and
@@ -658,11 +656,20 @@
     $\rho^{(L)}(M)$ from the right-hand side of
     (\ref{eq:rfp_retained_gibbs_sum}).
 
-    \textbf{Scope restriction (BNT-refined horizontal form):}
-    the normalized BNT-refined horizontal hypothesis is stronger than the
-    literal CPSV canonical-form hypothesis.
-    % The literal implication remains open; see
-    % docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
+    \textbf{Scope restriction (active product BNT):}
+    only nonzero product corners occur in the fusion clause. A normal label
+    absent from a fixed product pair has zero fusion multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):}
+    a fixed product pair may have an empty active family, and no unsupported
+    normal sector is inserted. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):}
+    the retained-row fusion map is a coisometry onto the active direct sum,
+    and its adjoint gives exact reconstruction of the product tensor. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
 
     \textbf{Scope restriction (retained vertical coordinates):}
     the formula is an equality for $R_L$ on the retained vertical space, not
@@ -697,6 +704,46 @@
     reconstruction of the retained density operator.
 \end{proof}
 
+\begin{theorem}[Retained-coordinate commuting Gibbs decomposition above one
+    site]%
+    \label{thm:mpdo_topological_gibbs_at_least_two}
+    \lean{MPOTensor.topologicalGibbsDecomposition_of_isRFPViaTS}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
+        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form satisfying the renormalization fixed-point condition.
+    Select the active-sector fusion clause supplied by that condition, and
+    suppose that the trace-power coefficients of this same clause are
+    independent of the positive chain length. Then the retained-coordinate
+    commuting Gibbs decomposition of
+    Theorem~\ref{thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
+    holds for every $L=N+2$.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+
+    \textbf{Scope restriction (retained vertical coordinates):}
+    the Hamiltonian and projectors act on the retained nonzero vertical
+    sectors. Applying the adjoint retained-row map reconstructs the physical
+    density operator, but does not provide a Hamiltonian or projectors on the
+    original physical space. See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+
+    \textbf{Scope restriction (positive chains of length at least two):}
+    the conclusion is proved for $L=N+2$; no length-one two-site convention
+    is asserted. See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    Select the active-sector fusion clause supplied by the renormalization
+    fixed-point condition and apply
+    Theorem~\ref{thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
+    with the assumed length independence of its trace-power coefficients.
+\end{proof}
+
 \begin{theorem}[Active-sector fusion gives a physical-coordinate commuting
     Gibbs decomposition above one site]%
     \label{thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
@@ -705,7 +752,7 @@
     \leanok
     \uses{def:mpdo, def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_topological_gibbs_data_at_least_two,
-        thm:mpdo_topological_gibbs_at_least_two}
+        thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
     Let $M$ generate matrix product density operators, and fix an
     active-sector fusion clause for a vertical canonical decomposition of
     $M$. Suppose that the trace-power coefficients of its positive diagonal
@@ -802,6 +849,12 @@
     \textbf{Scope restriction (BNT-refined horizontal form):}
     the normalized BNT-refined horizontal hypothesis is stronger than the
     literal CPSV canonical-form hypothesis.
+
+    \textbf{Local fix (physical complement):}
+    the retained one-site energy is compressed to physical coordinates and
+    extended by zero energy on the orthogonal complement. The retained
+    projectors are transported through the adjoint sitewise coisometry. See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
     the conclusion is proved for $L=N+2$; no length-one two-site convention

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -312,21 +312,71 @@
     the complementary tensor factors of each block.
 \end{definition}
 
-\begin{theorem}[All-label density decomposition of an RFP MPDO]%
-    \label{thm:mpdo_topological_density_decomposition}
+\begin{theorem}[All-label density decomposition from an active-sector fusion
+    clause]%
+    \label{thm:mpdo_fusion_clause_topological_density_decomposition}
     \lean{MPOTensor.BNTFusionTensorClause.%
         singleKrausMap_verticalCoisometry_mpo_eq_topologicalDensityOperatorSucc}
     \lean{MPOTensor.BNTFusionTensorClause.%
         singleKrausMap_conjTranspose_verticalCoisometry_topologicalDensityOperatorSucc_eq_mpo}
     \lean{MPOTensor.BNTFusionTensorClause.HasTopologicalDensityDecomposition}
     \lean{MPOTensor.BNTFusionTensorClause.hasTopologicalDensityDecomposition}
+    \leanok
+    \uses{def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_topological_density_operator,
+        def:mpdo_single_kraus_map,
+        def:mpdo_sitewise_physical_matrix}
+    Fix an active-sector fusion clause for a vertical canonical decomposition
+    of $M$. For every $N>0$, its retained-row vertical coisometry $V$ and
+    all-label recursive density operator $R_N$ satisfy
+    \begin{align}
+        V^{\otimes N}\rho^{(N)}(M)(V^{\otimes N})^\dagger
+        &=R_N,
+        \notag\\
+        ((V^\dagger)^{\otimes N})R_NV^{\otimes N}
+        &=\rho^{(N)}(M).
+        \notag
+    \end{align}
+
+    \textbf{Scope restriction (active product BNT):}
+    only nonzero product corners occur in the fusion clause. A normal label
+    absent from a fixed product pair has zero fusion multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):}
+    a fixed product pair may have an empty active family. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):}
+    the retained-row fusion map is a coisometry onto the active direct sum,
+    and its adjoint gives exact reconstruction. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+
+    \textbf{Local fix (rectangular vertical map):}
+    the reverse equality uses exact retained-sector reconstruction rather
+    than a square-unitary identity. See
+    \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{def:mpdo_topological_projector_recursion,
+        lem:mpdo_sitewise_physical_coordinate_congruence}
+    In retained coordinates, the one-site entries are block diagonal in the
+    label and multiplicity coordinates. Within each configuration, multiply
+    the scalar weights and apply the forward and adjoint recursive fusion
+    identities. Summing over all configurations gives the forward equality;
+    exact sitewise retained-sector reconstruction gives the reverse equality.
+\end{proof}
+
+\begin{theorem}[All-label density decomposition of an RFP MPDO]%
+    \label{thm:mpdo_topological_density_decomposition}
     \lean{MPOTensor.exists_topologicalDensityDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_topological_density_operator,
         def:mpdo_single_kraus_map,
-        def:mpdo_sitewise_physical_matrix}
+        def:mpdo_sitewise_physical_matrix,
+        thm:mpdo_fusion_clause_topological_density_decomposition}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form and suppose that it satisfies the renormalization
     fixed-point condition.
@@ -377,18 +427,46 @@
     every site, gives (\ref{eq:rfp_density_reverse}).
 \end{proof}
 
-\begin{corollary}[All-label density-factor commutator]%
-    \label{cor:mpdo_topological_density_factor_commutator}
+\begin{corollary}[All-label density-factor commutator from an active-sector
+    fusion clause]%
+    \label{cor:mpdo_fusion_clause_topological_density_factor_commutator}
     \lean{MPOTensor.BNTFusionTensorClause.%
         topologicalDensityOperatorSucc_eq_multiplicityWeight_mul_recursiveFactor}
     \lean{MPOTensor.BNTFusionTensorClause.%
         topologicalMultiplicityWeightFactorSucc_commutes_recursiveFactor}
-    \lean{MPOTensor.BNTFusionTensorClause.HasTopologicalDensityFactorCommutator}
-    \lean{MPOTensor.BNTFusionTensorClause.hasTopologicalDensityFactorCommutator}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        HasTopologicalDensityFactorCommutator}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        hasTopologicalDensityFactorCommutator}
+    \leanok
+    \uses{def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_topological_density_operator}
+    For any active-sector fusion clause and every $N>0$, its all-label
+    recursive density operator factors as
+    \begin{align}
+        R_N&=A_NT_N,
+        \notag\\
+        A_NT_N&=T_NA_N.
+        \notag
+    \end{align}
+    Thus the multiplicity-weight factor commutes with the reconstructed
+    recursive factor. No length-independence or spectral hypothesis is used.
+\end{corollary}
+\begin{proof}\leanok
+    In every copy configuration, $A_N$ is a scalar multiple of the identity
+    on the corresponding simple-bond space, so it commutes with the
+    coisometrically reconstructed recursive factor. Taking the direct sum
+    gives both identities.
+\end{proof}
+
+\begin{corollary}[All-label density-factor commutator]%
+    \label{cor:mpdo_topological_density_factor_commutator}
     \lean{MPOTensor.exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        def:mpdo_topological_density_operator}
+        def:mpdo_topological_density_operator,
+        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_fusion_clause_topological_density_factor_commutator}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form and suppose that it satisfies the renormalization
     fixed-point condition.
@@ -424,8 +502,9 @@
     decomposition.
 \end{proof}
 
-\begin{definition}[Terminal spectral refinement data]%
-    \label{def:mpdo_terminal_spectral_refinement}
+\begin{definition}[Terminal spectral refinement for an active-sector fusion
+    clause]%
+    \label{def:mpdo_fusion_clause_terminal_spectral_refinement}
     \lean{MPOTensor.BNTFusionTensorClause.terminalMatrix}
     \lean{MPOTensor.BNTFusionTensorClause.TerminalSpectralIndex}
     \lean{MPOTensor.BNTFusionTensorClause.terminalEigenvalue}
@@ -437,12 +516,43 @@
         topologicalSpectralProjectorSucc}
     \lean{MPOTensor.BNTFusionTensorClause.%
         HasTerminalSpectralProjectorRefinement}
+    \leanok
+    \uses{def:mpdo, def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_topological_density_operator,
+        def:mpdo_topological_projector_recursion,
+        thm:mpdo_terminal_transfer_positivity}
+    Let $M$ generate matrix product density operators, and fix an
+    active-sector fusion clause. For every terminal label $\gamma$, close the
+    horizontal operator leg of $M_\gamma$ to obtain a positive semidefinite
+    bond matrix $K_\gamma$. Its spectral indices are pairs
+    $s=(\gamma,k)$; write $\lambda_s$ for the corresponding eigenvalue and
+    $E_s$ for the rank-one spectral projection. Recursively transport this
+    family through every fusion history and the adjoint sequential
+    coisometry, and denote the resulting all-label operator at positive
+    length $N$ by $P_s^{(N)}$.
+
+    \textbf{Scope restriction (active product BNT):}
+    only nonzero product corners occur in the fusion clause. A normal label
+    absent from a fixed product pair has zero fusion multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):}
+    a fixed product pair may have an empty active family. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):}
+    the retained-row fusion map is a coisometry onto the active direct sum,
+    and its adjoint gives exact reconstruction. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+\end{definition}
+
+\begin{definition}[Terminal spectral refinement data]%
+    \label{def:mpdo_terminal_spectral_refinement}
     \lean{MPOTensor.rfpBNTFusionTensorClause}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause,
-        def:mpdo_topological_density_operator,
-        def:mpdo_topological_projector_recursion,
+        def:mpdo_fusion_clause_terminal_spectral_refinement,
         thm:mpdo_rfp_to_bnt_fusion_tensor}
     For an MPDO in normalized BNT-refined horizontal form satisfying the
     renormalization fixed-point condition, fix the fusion clause selected by
@@ -464,9 +574,9 @@
     % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{definition}
 
-\begin{theorem}[Terminal spectral projectors for a length-independent RFP
-    MPDO]%
-    \label{thm:mpdo_terminal_spectral_projector_refinement}
+\begin{theorem}[Terminal spectral projectors from an active-sector fusion
+    clause]%
+    \label{thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
     \lean{MPOTensor.BNTFusionTensorClause.terminalEigenvalue_nonneg}
     \lean{MPOTensor.BNTFusionTensorClause.%
         topologicalSpectralProjectorSucc_isOrthogonalProjection}
@@ -480,11 +590,60 @@
         topologicalDensityOperatorSucc_eq_sum_terminalSpectralProjector}
     \lean{MPOTensor.BNTFusionTensorClause.%
         hasTerminalSpectralProjectorRefinement}
+    \leanok
+    \uses{def:mpdo, def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_fusion_clause_terminal_spectral_refinement,
+        thm:mpdo_fusion_clause_topological_density_decomposition,
+        cor:mpdo_fusion_clause_topological_density_factor_commutator}
+    Let $M$ generate matrix product density operators, fix an active-sector
+    fusion clause, and suppose that its positive trace-power coefficients are
+    independent of the positive chain length. Then every terminal eigenvalue
+    $\lambda_s$ is non-negative. For every $N>0$, the operators
+    $P_s^{(N)}$ are pairwise orthogonal projections and
+    \begin{align}
+        T_N&=\sum_s\lambda_sP_s^{(N)},
+        \notag\\
+        A_NP_s^{(N)}&=P_s^{(N)}A_N,
+        \notag\\
+        R_N&=\sum_s\lambda_sA_NP_s^{(N)}.
+        \notag
+    \end{align}
+    This is the terminal spectral decomposition of
+    \cite[lines~1003--1012]{Cirac2016MPDO_arXiv}; it makes no Hamiltonian or
+    Gibbs-state assertion.
+
+    \textbf{Scope restriction (active product BNT):}
+    only nonzero product corners occur in the fusion clause. A normal label
+    absent from a fixed product pair has zero fusion multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):}
+    a fixed product pair may have an empty active family. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):}
+    the retained-row fusion map is a coisometry onto the active direct sum,
+    and its adjoint gives exact reconstruction. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    Positivity of the physical density operator makes each terminal bond
+    matrix positive semidefinite. Its spectral theorem supplies the
+    non-negative eigenvalues and orthogonal rank-one projections. Length
+    independence makes every retained fusion coefficient equal to one, so
+    recursive coisometric transport preserves orthogonality and the spectral
+    sum. The generic density-factor commutator gives the final two identities.
+\end{proof}
+
+\begin{theorem}[Terminal spectral projectors for a length-independent RFP
+    MPDO]%
+    \label{thm:mpdo_terminal_spectral_projector_refinement}
     \lean{MPOTensor.terminalSpectralProjectorRefinement_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_terminal_spectral_refinement,
-        cor:mpdo_topological_density_factor_commutator}
+        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition. Fix
     internally the
@@ -581,9 +740,10 @@
         topologicalGibbsHamiltonianSuccSucc}
     \lean{MPOTensor.BNTFusionTensorClause.HasTopologicalGibbsDecomposition}
     \leanok
-    \uses{def:mpdo_terminal_spectral_refinement}
-    Let $\mu$ be the strictly positive diagonal multiplicity matrix in the
-    retained one-site coordinates. Define
+    \uses{def:mpdo_fusion_clause_terminal_spectral_refinement}
+    Let $M$ generate matrix product density operators, fix an active-sector
+    fusion clause, and let $\mu$ be its strictly positive diagonal
+    multiplicity matrix in the retained one-site coordinates. Define
     $h=\diag(-\log\mu)\otimes I$ on two adjacent sites. For a chain of length
     $L=N+2$, let $H_L=\sum_{i=1}^{L}h_{i,i+1}$, with periodic indices.
 
@@ -626,7 +786,7 @@
     \leanok
     \uses{def:mpdo, def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_topological_gibbs_data_at_least_two,
-        thm:mpdo_terminal_spectral_projector_refinement}
+        thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
     Let $M$ generate matrix product density operators, and fix an
     active-sector fusion clause for a vertical canonical decomposition of
     $M$. Suppose that the trace-power coefficients of its positive diagonal
@@ -686,9 +846,9 @@
     \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:mpdo_topological_density_decomposition,
-        cor:mpdo_topological_density_factor_commutator,
-        thm:mpdo_terminal_spectral_projector_refinement}
+    \uses{thm:mpdo_fusion_clause_topological_density_decomposition,
+        cor:mpdo_fusion_clause_topological_density_factor_commutator,
+        thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
     Each diagonal entry of $\mu$ is strictly positive, so its negative
     logarithm is real. The translated terms are diagonal, and each site
     contributes once to their sum. Exponentiating gives

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -815,6 +815,35 @@
     with the assumed length independence of its trace-power coefficients.
 \end{proof}
 
+\begin{definition}[Selected literal CPSV RFP fusion clause]%
+    \label{def:mpdo_literal_cpsv_rfp_bnt_fusion_tensor_clause}
+    \lean{MPOTensor.cpsvRFPBNTFusionTensorClause}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form, def:is_rfp_via_ts,
+        def:mpdo_bnt_fusion_tensor_clause,
+        thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor}
+    Let $M$ generate matrix product density operators, suppose that its
+    doubled-index MPS tensor is in literal CPSV canonical form, and suppose
+    that $M$ satisfies the renormalization fixed-point condition. Choose one
+    active-sector BNT fusion tensor clause furnished by these hypotheses and
+    denote it by $\mathcal F_{\mathrm{CPSV}}(M)$.
+
+    \textbf{Scope restriction (active product BNT):}
+    only nonzero product corners occur in the selected fusion clause. A normal
+    label absent from a fixed product pair has zero fusion multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):}
+    a fixed product pair may have an empty active family, and no unsupported
+    normal sector is inserted. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):}
+    the retained-row fusion map is a coisometry onto the active direct sum,
+    and its adjoint gives exact reconstruction of the product tensor. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+\end{definition}
+
 \begin{theorem}[Literal CPSV physical-coordinate commuting Gibbs decomposition
     above one site]%
     \label{thm:mpdo_literal_cpsv_physical_coordinate_gibbs_at_least_two}
@@ -823,6 +852,7 @@ physicalTopologicalGibbsDecomposition_of_isRFPViaTS_of_cpsvCanonicalForm}
     \leanok
     \uses{def:mpdo, def:cpsv_canonical_form, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_literal_cpsv_rfp_bnt_fusion_tensor_clause,
         def:mpdo_topological_gibbs_data_at_least_two,
         thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -673,7 +673,7 @@
     \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
 
     \textbf{Scope restriction (positive chains of length at least two):}
-    the conclusion is proved for $L=N+2$. Definition~4.8 of
+    the conclusion is proved for $L=N+2$. Definition~4.8 of~
     \cite{Cirac2016MPDO_arXiv} defines $h$ on two spins but does not state a
     length-one convention; see
     \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
@@ -697,15 +697,19 @@
     reconstruction of the retained density operator.
 \end{proof}
 
-\begin{theorem}[Physical-coordinate commuting Gibbs decomposition above one
-    site]%
-    \label{thm:mpdo_physical_coordinate_gibbs_at_least_two}
-    \uses{thm:mpdo_topological_gibbs_at_least_two}
-    \lean{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
+\begin{theorem}[Active-sector fusion gives a physical-coordinate commuting
+    Gibbs decomposition above one site]%
+    \label{thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
+    \lean{MPOTensor.BNTFusionTensorClause.%
+        hasPhysicalTopologicalGibbsDecomposition}
     \leanok
-    Let $M$ be in normalized BNT-refined horizontal form and satisfy the
-    hypotheses of Theorem~\ref{thm:mpdo_topological_gibbs_at_least_two}. There
-    are
+    \uses{def:mpdo, def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_topological_gibbs_data_at_least_two,
+        thm:mpdo_topological_gibbs_at_least_two}
+    Let $M$ generate matrix product density operators, and fix an
+    active-sector fusion clause for a vertical canonical decomposition of
+    $M$. Suppose that the trace-power coefficients of its positive diagonal
+    fusion matrices are independent of the positive chain length. There are
     non-negative numbers $\lambda_1,\ldots,\lambda_d$ and one fixed Hermitian
     two-site matrix $\widehat h$, all independent of the chain length. For
     every $L\geq2$, let
@@ -725,17 +729,35 @@
           e^{-\widehat H_L}.
         \label{eq:rfp_physical_gibbs_sum}
     \end{align}
+    This is the fusion-clause implication in the proof of~
+    \cite[lines~999--1016]{Cirac2016MPDO_arXiv}.
 
-    \textbf{Scope restriction (BNT-refined horizontal form):}
-    the normalized BNT-refined horizontal hypothesis is stronger than the
-    literal CPSV canonical-form hypothesis.
-    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
+    \textbf{Scope restriction (active product BNT):}
+    only nonzero product corners occur in the fusion clause. A normal label
+    absent from a fixed product pair has zero fusion multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):}
+    a fixed product pair may have an empty active family, and no unsupported
+    normal sector is inserted. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):}
+    the retained-row fusion map is a coisometry onto the active direct sum,
+    and its adjoint gives exact reconstruction of the product tensor. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
 
     \textbf{Local fix (physical complement):}
     the retained one-site energy is compressed to physical coordinates and
     extended by zero energy on the orthogonal complement. The retained
     projectors are transported through the adjoint sitewise coisometry. See
     \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+
+    \textbf{Scope restriction (positive chains of length at least two):}
+    the conclusion is proved for $L=N+2$. Definition~4.8 of
+    \cite{Cirac2016MPDO_arXiv} defines the local interaction on two spins but
+    gives no length-one convention. See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
 \end{theorem}
 \begin{proof}\leanok
     Put $V$ for the retained-row coisometry and $k$ for the retained
@@ -758,6 +780,116 @@
     identities term by term to (\ref{eq:rfp_retained_gibbs_sum}), and then
     using exact adjoint reconstruction, gives
     (\ref{eq:rfp_physical_gibbs_sum}).
+\end{proof}
+
+\begin{theorem}[Physical-coordinate commuting Gibbs decomposition above one
+    site]%
+    \label{thm:mpdo_physical_coordinate_gibbs_at_least_two}
+    \lean{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
+    \leanok
+    \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
+        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form satisfying the renormalization fixed-point condition.
+    Select the active-sector fusion clause supplied by that condition, and
+    suppose that the trace-power coefficients of this same clause are
+    independent of the positive chain length. Then the physical-coordinate
+    commuting Gibbs decomposition of
+    Theorem~\ref{thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
+    holds for every $L=N+2$.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+
+    \textbf{Scope restriction (positive chains of length at least two):}
+    the conclusion is proved for $L=N+2$; no length-one two-site convention
+    is asserted. See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    Select the active-sector fusion clause supplied by the renormalization
+    fixed-point condition and apply
+    Theorem~\ref{thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
+    with the assumed length independence of its trace-power coefficients.
+\end{proof}
+
+\begin{theorem}[Literal CPSV physical-coordinate commuting Gibbs decomposition
+    above one site]%
+    \label{thm:mpdo_literal_cpsv_physical_coordinate_gibbs_at_least_two}
+    \lean{MPOTensor.%
+physicalTopologicalGibbsDecomposition_of_isRFPViaTS_of_cpsvCanonicalForm}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form, def:is_rfp_via_ts,
+        def:mpdo_bnt_fusion_tensor_clause,
+        def:mpdo_topological_gibbs_data_at_least_two,
+        thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
+    Let $M$ generate matrix product density operators, suppose that its
+    doubled-index MPS tensor is in literal CPSV canonical form, and suppose
+    that $M$ satisfies the renormalization fixed-point condition of
+    Definition~4.1. Select the active-sector fusion clause supplied by these
+    three hypotheses, and assume that the trace-power coefficients of this
+    same clause are independent of the positive chain length.
+
+    There are non-negative numbers
+    $\lambda_1,\ldots,\lambda_d$ and one fixed Hermitian two-site matrix
+    $\widehat h$, all independent of the chain length. For every $L=N+2$, let
+    $\widehat H_L=\sum_{j=1}^{L}\widehat h_{j,j+1}$. The translates of
+    $\widehat h$ commute pairwise, and there are pairwise orthogonal
+    projections
+    $\widehat P_1^{(L)},\ldots,\widehat P_d^{(L)}$ on the physical chain such
+    that
+    \begin{align}
+        [\widehat h_{j-1,j},\widehat h_{j,j+1}]
+        &=0,
+        \notag\\
+        [\widehat P_i^{(L)},e^{-\widehat H_L}]
+        &=0,
+        \notag\\
+        \rho^{(L)}(M)
+        &=\sum_{i=1}^{d}\lambda_i\widehat P_i^{(L)}
+          e^{-\widehat H_L}.
+        \notag
+    \end{align}
+    This is the physical-coordinate conclusion of~
+    \cite[lines~1013--1016]{Cirac2016MPDO_arXiv}, under the literal canonical
+    form and renormalization fixed-point hypotheses of~
+    \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (active product BNT):}
+    only nonzero product corners occur in the selected fusion clause. A normal
+    label absent from a fixed product pair has zero fusion multiplicity. See
+    \path{docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex}.
+
+    \textbf{Local fix (Figure-11 fixed-pair support):}
+    a fixed product pair may have an empty active family, and no unsupported
+    normal sector is inserted. See
+    \path{docs/paper-gaps/cpsv16_figure11_per_pair_support.tex}.
+
+    \textbf{Local fix (Figure-11 fusion coisometry):}
+    the retained-row fusion map is a coisometry onto the active direct sum,
+    and its adjoint gives exact reconstruction of the product tensor. See
+    \path{docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex}.
+
+    \textbf{Local fix (physical complement):}
+    the retained one-site energy is compressed to physical coordinates and
+    extended by zero energy on the orthogonal complement. The retained
+    projectors are transported through the adjoint sitewise coisometry. See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
+
+    \textbf{Scope restriction (positive chains of length at least two):}
+    the conclusion is proved exactly for $L=N+2$. Definition~4.8 of~
+    \cite{Cirac2016MPDO_arXiv} defines the local interaction on two spins but
+    gives no length-one convention. See
+    \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    Choose the active-sector fusion clause supplied by
+    Theorem~\ref{thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor}. Its
+    trace-power coefficients are length independent by hypothesis. Apply
+    Theorem~\ref{thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}.
 \end{proof}
 
 \begin{remark}[Printed length-one domain boundary]%

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -48,22 +48,32 @@ theorem. This is tracked by issue #873 under the proposition-level tracker #81.
 
 ## 2. Coverage crosswalk: CPSV16 (arXiv:1606.00608)
 
-At this revision, after the normal-tensor RFP characterization, the trace-normalized RFP-to-ZCL-and-SAL result, the unrestricted Proposition `prop3to4`, the fixed-bond/source-ZCL SAL theorem, and the literal sharp `propblockinj` theorem, the paper has 45 theorem-like occurrences and 40 distinct results. The occurrence-level count is 22 complete, 9 partial, and 14 not-ready; the distinct-result count is 21 complete, 7 partial, and 12 not-ready. Here **not-ready** means that the printed statement is false, ambiguous, or depends essentially on a formally refuted source lemma. It does not mean that every printed result has been formalized.
+At this revision, after the normal-tensor RFP characterization, the
+trace-normalized RFP-to-ZCL-and-SAL result, the unrestricted Proposition
+`prop3to4`, the fixed-bond/source-ZCL SAL theorem, the literal sharp
+`propblockinj` theorem, and the literal CPSV topological-projector commuting
+Gibbs theorem, the paper has 45 theorem-like occurrences and 40 distinct
+results. The occurrence-level count is 23 complete, 8 partial, and 14
+not-ready; the distinct-result count is 22 complete, 6 partial, and 12
+not-ready. Here **not-ready** means that the printed statement is false,
+ambiguous, or depends essentially on a formally refuted source lemma. It does
+not mean that every printed result has been formalized.
 
 The distinct count is the 40 source `thm`, `prop`, `cor`, and `lem`
 environments. The occurrence count adds five Appendix A/D restatements.
 The following ledger makes the count reproducible from source line numbers:
 
-- **Complete (21 distinct):** 249, 253, 342, 398, 606, 945, 1080, 1121, 1130,
-  1274, 1333, 1351, 1406, 1510, 1569, 1597, 1647, 1680, 1786, 1835, and 2221.
-- **Partial (7 distinct):** 278, 583, 801, 851, 972, 1013, and 1801.
+- **Complete (22 distinct):** 249, 253, 342, 398, 606, 945, 1013, 1080, 1121,
+  1130, 1274, 1333, 1351, 1406, 1510, 1569, 1597, 1647, 1680, 1786, 1835, and
+  2221.
+- **Partial (6 distinct):** 278, 583, 801, 851, 972, and 1801.
 - **Not-ready (12 distinct):** 349, 354, 500, 534, 543, 777, 1155, 1197,
   1484, 1503, 1740, and 1810.
 - **Additional occurrences:** the Appendix A restatements at 1137, 1167,
   and 1172 inherit partial, not-ready, and not-ready status, respectively; the
   Appendix D restatements at 1863 and 1929 inherit complete and partial status.
   Thus the five restatements add one complete, two partial, and two not-ready
-  occurrences, giving the displayed totals 22/9/14.
+  occurrences, giving the displayed totals 23/8/14.
 
 Definitions, equations, and explanatory proof-segment rows are not counted.
 In particular, Eq. `II_XAX` at 1072--1077 is excluded, while the purification
@@ -114,7 +124,7 @@ segments of Theorems 3.1 and 3.10, not additional theorem occurrences.
 | **Theorem 4.9** (l.851, `thm:main-simple`) | 851–893 | Simple-MPDO implication chain \((i)\Rightarrow(ii)\Leftrightarrow(iii)\Rightarrow(iv)\Rightarrow(v)\) | `TNLean/MPS/MPDO/RFPViaTSSAL.lean`; `TNLean/MPS/MPDO/CyclicActiveAreaLaw.lean`; `TNLean/MPS/MPDO/ActiveSectorSpanningAreaLaw.lean`; `TNLean/MPS/MPDO/PhysicalSectorFactorization.lean`; `TNLean/Channel/PetzProductReference.lean` | **partial** — implication \((i)\Rightarrow(ii)\) is complete at the explicit density-family boundary: positive semidefinite rings, nonzero trace at every positive length, and the Definition 4.1 local RFP equations imply source ZCL and SAL. The fixed-bond and source-ZCL implication to SAL is now complete for the original injective normal tensor. The overall theorem remains partial because the printed route to \((iv)\) depends on false Lemma C.5 and the recovery alternative remains incomplete under #4228/#4405; #4961/#4962 are dependent research follow-ups |
 | **Proposition 4.13** (source label `Prop:IV.12`, l.945) | 945–952; proof 1863–1922 | A literal CPSV canonical-form MPDO tensor is vertically in canonical form | `TNLean/MPS/MPDO/CPSVVerticalCanonicalForm.lean` (`MPOTensor.verticalCF_of_cpsvCanonicalForm`) and its prerequisite modules | **complete** — the theorem constructs positive grouped weights and a rectangular coisometry $U$ with $UU^\dagger=I$, $U\widetilde M U^\dagger=\bigoplus_\alpha\mu_\alpha\otimes M_\alpha$, and $\widetilde M=U^\dagger(\bigoplus_\alpha\mu_\alpha\otimes M_\alpha)U$; it does not assert $U^\dagger U=I$ |
 | **Theorem 4.14** (source label `thm:IV.13`, l.972) | 972–993; proof 1929–2088 | RFP iff the tensor-attached BNT algebra condition iff the fusion-isometry condition | `TNLean/MPS/MPDO/BNTAlgebraTensorClause.lean`; `BNTAlgebraTensorClauseSpectrum.lean`; `BNTFusionTensorClauseFromRFP.lean`; `AlgebraFusionCounterexample.lean` | **partial** — several directions and the tensor-attached data are complete; algebra⇒RFP still requires #4648, then #4645, then the CPTP construction and #3949. All three issues are assigned to `LionSR`; Proposition 4.13 does not supply the missing marked/common-target comparison |
-| Theorem (l.1013) | 1013–1016 | Length-independent coefficients imply a topological-projector commuting Gibbs form | `TNLean/MPS/MPDO/TopologicalPhysicalGibbs.lean` (`MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS`) | **partial** — the physical decomposition is proved for chains of length at least two under the stronger BNT-refined `IsHorizontalCF` hypothesis; the printed theorem assumes only an RFP MPDO and does not state that restriction |
+| Theorem (l.1013) | 1013–1016 | Length-independent coefficients imply a topological-projector commuting Gibbs form | `TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean` (`MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS_of_cpsvCanonicalForm`) | **complete, with documented local corrections and length boundary** — for a literal CPSV canonical-form MPDO tensor satisfying the RFP condition and clause-relative length independence, the theorem gives the physical-space decomposition for every source-defined chain length $L=N+2$. Active product sectors, empty fixed-pair support, retained-row coisometries, the finite physical complement, and the unspecified length-one two-site convention are recorded in the corresponding paper-gap notes |
 
 ### 2.4 Appendix A — Proofs of Section II
 
@@ -313,7 +323,7 @@ These are known oversized (documented in #1512/#1522) and do not block unrelated
 
 ## 7. Key remaining coverage gaps
 
-The 19 non-complete distinct CPSV16 results comprise 7 partial and 12
+The 18 non-complete distinct CPSV16 results comprise 6 partial and 12
 not-ready results. They are source-ambiguous, formally refuted, research-level,
 owner-held, or scope-restricted by the current formal interface. Lemma
 `Lsigma3`, the Hayashi strong-subadditivity equality characterization, and the
@@ -336,7 +346,6 @@ axiom-free.
 | Partial | CPSV16 | Proposition 4.5 | Monotonicity is proved; the thermodynamic limit is refuted; the finite $4\log D$ bound remains open | #4169/#4242/#4295, assigned to `LionSR` |
 | Partial | CPSV16 | Theorem 4.9 | Implication \((i)\Rightarrow(ii)\) is complete for positive semidefinite rings with nonzero trace at every positive length, and the fixed-bond plus source-ZCL implication to SAL is complete; Lemma C.5 is false, and the recovery alternative remains incomplete | #4228/#4405, assigned to `LionSR`; #4961/#4962 are dependent research follow-ups |
 | Partial | CPSV16 | Theorem 4.14 | Algebra⇒RFP still needs the tensor-attached Gram comparison, unitary normalization, and CPTP maps | #4648 → #4645 → #3949, assigned to `LionSR` |
-| Partial | CPSV16 | Topological-projector commuting Gibbs theorem, lines 1013–1016 | The physical decomposition is proved only above one site and under the stronger `IsHorizontalCF` hypothesis | Literal-RFP scope extension remains open |
 | Not-ready | CPSV16 | Lemma C.5 (`SALZCL`) | A formal injective four-sector counterexample has SAL and source ZCL but no rank-one active trace factorization | #4270 closed by counterexample |
 | Not-ready | CPSV16 | Structural corollary, lines 1503–1506 | Its printed proof depends on false Lemma C.5 | No source-faithful replacement known |
 | Complete | CPSV16 | Proposition `4to2`, lines 1597–1601 | The selected physical coordinates give all-cut Markov decompositions for the original tensor, hence SAL, which is transported back through the one-site isometry | `MPOTensor.EtaLocalStructureData.isSAL_of_isSourceZCL` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L459, 461 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L322 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L473, 475 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L336 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L734 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L736, 739, 742, 745 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |


### PR DESCRIPTION
## Summary

- select the BNT fusion tensor clause supplied by literal CPSV canonical form,
  MPDO positivity, and `IsRFPViaTS`
- derive the physical-coordinate commuting Gibbs decomposition from length
  independence of that selected clause, for the source-defined chains
  `L = N + 2 >= 2`
- propagate the active-product, empty fixed-pair, and retained-row coisometry
  qualifications required by the post-merge audit of #5199
- add exact Blueprint entries for the generic fusion-clause implication, the
  selected literal clause, and the literal CPSV capstone

## Source and faithfulness

This completes CPSV16 Theorem 4.15 using the corrected active-support forward implication (i) -> (iii) of Theorem 4.14; the reverse chain remains partial. The source references are
`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 972--993, 1013--1016, and
Appendix C.4.

The capstone hypotheses are exactly:

- `MPSTensor.IsCPSVCanonicalForm M.toMPSTensor`
- `MPOTensor.IsMPDO M`
- `MPOTensor.IsRFPViaTS M`
- length independence for the selected literal-RFP fusion clause

It does not pass through `IsHorizontalCF`, add a normalization premise, or
claim a length-one two-site convention.

The reader-visible qualifications cite:

- `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`
- `docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`
- `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`
- `docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex`
- `docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex`

## Validation

- `lake exe cache get` (0 downloads; 8,639 cached artifacts present)
- `lake build TNLean.MPS.MPDO.CPSVTopologicalPhysicalGibbs`
- `lake build TNLean.MPS.MPDO`
- `lake build`
- `lake exe checkdecls blueprint/lean_decls`
- Blueprint/Lean forward and reverse declaration sync
- import-aggregator check
- proof-integrity forbidden-token check
- reader-facing prose check
- tactic-pattern scan
- full Blueprint XeLaTeX print render for the delegated capstone statements

Closes #5159
Closes #5199
Closes #5203

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof and documentation changes in MPS/MPDO formalization; no runtime services, auth, or data mutation. Residual risk is mathematical scope (documented paper-gap qualifications), not production breakage.
> 
> **Overview**
> **Completes CPSV16’s physical commuting Gibbs theorem (lines 1013–1016)** for literal CPSV canonical form, MPDO, and `IsRFPViaTS`, without routing through `IsHorizontalCF`. A new Lean module selects `cpsvRFPBNTFusionTensorClause` and applies the existing `BNTFusionTensorClause.hasPhysicalTopologicalGibbsDecomposition` once clause-relative length independence holds, for chains `L = N + 2`.
> 
> **Documents audited scope on active-sector BNT fusion** (active product corners only, empty fixed-pair support, retained-row coisometry) in key fusion theorems and matching blueprint text, with pointers to `docs/paper-gaps/` notes.
> 
> **Refactors the recursive-density / Gibbs blueprint chapter** so density decomposition, factor commutator, terminal spectral refinement, retained-coordinate Gibbs, and physical-coordinate Gibbs are stated first for an arbitrary active-sector fusion clause; RFP and literal CPSV conclusions are thin corollaries. Adds blueprint entries for the selected literal CPSV clause and capstone.
> 
> The CPSV coverage audit **moves theorem (l.1013) from partial to complete** under the documented local fixes and length boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 596dbce197c56df638134f7b341883f83d5cd7b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
