### PR TITLE
doc(MPS/MPDO): correct two-site gauge gap contract

### DIFF
--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -89,6 +89,7 @@ conjugacies between its paired normal tensors.
 invertible conjugacy from Appendix C.4, but not the line-2057 conclusion that the
 gauge may be chosen unitary.  The missing common-target normalization contract is
 documented in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` and
+tracked in issue 4648.  The subsequent scalar-to-unitary normalization is
 tracked in issue 4645.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057 of
@@ -160,7 +161,8 @@ canonical form used in Appendix C.4 through Proposition 4.13; see
 equality and phase-one invertible conjugacy, but does not prove the line-2057
 unitary upgrade.  The missing common-target normalization contract is documented
 in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` and tracked in
-issue 4645.
+issue 4648.  The subsequent scalar-to-unitary normalization is tracked in issue
+4645.
 
 Source: arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -105,8 +105,9 @@ retained by
 \path{BNTAlgebraTensorClause.TwoSiteExactSectorGauge.tensor_eq}.  The two-site
 reference corner follows from the positive weights, coisometry, and
 reconstruction in \path{CPSVVerticalDecomposition}.  The theorem
-\path{IsHorizontalCF.gramDressing_eq_of_two_grouped_corners} compares two
-positive corners of a common representative, and
+\path{MPSTensor.IsCPSVCanonicalForm.gramDressing_eq_of_two_grouped_corners}
+compares two positive corners of a common representative under the literal
+CPSV canonical-form hypothesis, and
 \path{IsNormal.gram_eq_pos_smul_gram_of_gram_conj_eq} turns that comparison into
 \eqref{eq:gram-scalar}.  However, the characterization
 \path{isCPSVBasisOfNormalTensors_iff_canonicalForm_covered_and_minimal} supplies
@@ -307,8 +308,8 @@ This is a sharp obstruction to any proof using only the fields
 \path{TwoSiteExactSectorGauge.sector_sameMPV}.  It is not a counterexample to
 the complete tensor-attached hypotheses of Theorem~4.14(ii): the displayed
 two-by-two tensor has not been made into a tensor-attached algebra clause
-satisfying horizontal canonical form and positivity of every matrix product
-operator.
+satisfying the literal CPSV canonical-form hypothesis and positivity of every
+matrix product operator.
 
 \section{Non-circular product corners}
 
@@ -351,9 +352,10 @@ Figure~8 identity
   \operatorname{gramDressing}(\mathbf 1,A_\gamma),
   \label{eq:gram-dressing-target}
 \end{equation}
-derived from the tensor-attached algebra clause, horizontal canonical form,
-and positivity of the matrix product operators, without assuming
-$F_{\alpha\beta}$ or a raw corner of the form \eqref{eq:V-compression}.
+derived from the tensor-attached algebra clause, the literal CPSV
+canonical-form hypothesis, and positivity of the matrix product operators,
+without assuming $F_{\alpha\beta}$ or a raw corner of the form
+\eqref{eq:V-compression}.
 Equivalently, for every vertical letter $v$,
 \[
   (X_\gamma^\dagger X_\gamma)A_\gamma^v


### PR DESCRIPTION
### Motivation
- CPSV16 Proposition 4.13 compares actual sectors of one vertical canonical decomposition (`Papers/1606.00608/MPDO-22-12-17-2.tex`, lines 1898–1921).
- Appendix C.4 compares the one-site and blocked tensors and then states “By Proposition 4.13” the gauge is unitary (lines 2048–2057), without constructing the common physical sector needed by that proposition.
- The existing gap note still described the target using the stronger `IsHorizontalCF` hypothesis and routed the missing common-target step directly to #4645.

### Description
- State the #4648 target under the literal CPSV canonical-form hypothesis used by the cited source.
- Point the gap note to the current literal-CPSV Figure 8 theorem.
- Record the dependency order precisely: #4648 supplies the missing common physical comparison; #4645 performs the subsequent scalar-to-unitary normalization.
- Keep the open-gap verdict: this PR does not claim that closed-chain equality determines the missing physical inclusion.

### Testing
- Seeded from hot `main` at `337cb7258a63a463c9b9f323dd83849493425e51`; `lake exe cache get` reused 8,639 artifacts with zero downloads.
- `lake env lean TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpsv16_two_site_sector_unitary_gauge_gap.tex`
- Visually inspected the changed rendered pages (2 and 6); no clipping or overlap.

---
Addresses #4648

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and gap-note edits only; no proof or runtime behavior changes.
> 
> **Overview**
> **Corrects documentation** for the open two-site sector unitary-gauge gap so it matches the source-faithful formalization plan.
> 
> Lean docstrings on `TwoSiteExactSectorGauge` and `toTwoSiteExactSectorGauge` now assign the **missing common-target normalization** to **issue 4648**, with **issue 4645** reserved for the later **scalar-to-unitary** step. The gap note `cpsv16_two_site_sector_unitary_gauge_gap.tex` is updated in parallel: the cited comparison theorem is **`MPSTensor.IsCPSVCanonicalForm.gramDressing_eq_of_two_grouped_corners`** under the **literal CPSV canonical-form** hypothesis (replacing `IsHorizontalCF`), and the **#4648** target, counterexample wording, and dependency order (**4648** then **4645**) are aligned with that split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ac3efac16ad66e8d9e41c56c9848dec2e820ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->