### PR TITLE
doc(MPS/MPDO): qualify active-support fusion theorem

### DIFF
--- a/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
@@ -32,9 +32,9 @@ namespace MPOTensor
 
 namespace HasBNTFusionTensorClause
 
-/-- **Theorem 4.14(i) implies (iii).** An MPDO in literal CPSV canonical form
-that satisfies the Definition 4.1 renormalization fixed-point condition has
-the active-support BNT fusion clause.
+/-- **Corrected active-support formulation of Theorem 4.14(i) implies (iii).**
+An MPDO in literal CPSV canonical form that satisfies the Definition 4.1
+renormalization fixed-point condition has the active-support BNT fusion clause.
 
 **Scope restriction (active product BNT):** Only active product corners are
 retained. A one-site BNT label absent from a fixed product pair has zero fusion

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -238,8 +238,10 @@ of_isRFPViaTS_of_cpsvCanonicalForm}
         \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta.
       \notag
     \end{align}
-    This is implication (i)$\Rightarrow$(iii) of
-    \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}.
+    This is the corrected active-support formulation of implication
+    (i)$\Rightarrow$(iii) in
+    \cite[Theorem~4.14, lines~972--993]{Cirac2016MPDO_arXiv}, rather than the
+    unqualified printed statement.
 
     \textbf{Scope restriction (active product BNT):} For each fixed product
     pair, only its active normal corners occur; an absent label has zero fusion

--- a/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
+++ b/docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex
@@ -79,16 +79,12 @@ The source construction therefore determines the theorem on the domain
 \]
 Theorem~4.15 is printed without stating this lower bound, but its $N=1$
 instance is undefined unless an author or erratum specifies both $H_1$ and
-the coincident-edge convention.  The retained-coordinate theorem resolves
-only this length-domain boundary for the scoped analogue on $N\geq2$.  No
-length-one theorem is asserted, and the physical-coordinate complement
-remains unformalized; see
+the coincident-edge convention.  The formal retained- and physical-coordinate
+theorems therefore assert no length-one case.  The physical-coordinate
+complement is now complete on $N\geq2$; see
 \path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
-
-This printed-domain boundary is independent of the physical-coordinate
-complement described in
-\path{docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex}.
-Resolving either question would not resolve the other.
+That completion is independent of, and does not supply, the missing
+length-one convention.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex
+++ b/docs/paper-gaps/cpsv16_topological_gibbs_physical_complement.tex
@@ -16,14 +16,22 @@
 
 \section{Status}
 
-Resolved for the source-defined domain of chain lengths $L\geq2$ by the
-source-facing theorem
+Resolved for the source-defined domain of chain lengths $L\geq2$.  The generic
+fusion-clause theorem is
 \begin{center}
-  \small\path{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}.
+  \small\path{MPOTensor.BNTFusionTensorClause.hasPhysicalTopologicalGibbsDecomposition},
 \end{center}
-The theorem constructs the finite physical-complement extension, transports
-the retained projectors, and proves the literal physical density formula.
-The separate undefined length-one convention remains documented in
+and the literal CPSV fixed-point capstone is
+\begin{center}
+  \small\path{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS_of_cpsvCanonicalForm}.
+\end{center}
+The earlier normalized BNT-refined corollary
+\begin{center}
+  \small\path{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
+\end{center}
+remains available.  These theorems construct the finite physical-complement
+extension, transport the retained projectors, and prove the physical density
+formula.  The separate undefined length-one convention remains documented in
 \path{docs/paper-gaps/cpsv16_topological_gibbs_length_one.tex}.
 
 \section{Source statement}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L473, 475 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L336 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L475, 477 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L338 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L734 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L736, 739, 742, 745 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |


### PR DESCRIPTION
Closes #5199.

This post-merge faithfulness correction makes explicit that the literal CPSV fusion clause is the corrected active-support formulation of Theorem 4.14(i)⇒(iii), rather than the unqualified printed statement. The corresponding Blueprint sentence is corrected in parallel.

It also refreshes the two topological-Gibbs gap records: the physical complement is now marked complete for `L >= 2` at both the generic fusion-clause and literal CPSV boundaries, while the genuinely undefined `L = 1` convention remains open.

No theorem signature or proof changes. The existing scope and local-fix markers continue to cite:

- `docs/paper-gaps/cpsv16_bnt_uniqueness_zero_coefficient.tex`
- `docs/paper-gaps/cpsv16_figure11_per_pair_support.tex`
- `docs/paper-gaps/cpsv16_figure11_fusion_coisometry.tex`

Validation:

- `lake build TNLean.MPS.MPDO.CPSVBNTFusionTensorClauseFromRFP`
- reader-facing prose check
- forbidden-token diff check
- Blueprint/Lean synchronization and reverse coverage
- `leanblueprint checkdecls`
- `git diff --check`
- double LuaLaTeX on the full Blueprint print document (zero undefined cross-references; standalone citation warnings only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and docstring updates only; no Lean logic, API, or proof changes.
> 
> **Overview**
> This PR is a **faithfulness/documentation correction** only: it states explicitly that the literal CPSV RFP → active-sector BNT fusion result is the **corrected active-support** reading of Cirac–Pérez-García–Schuch–Verstraete Theorem 4.14 (i)⇒(iii), not the unqualified printed theorem.
> 
> The docstring on `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm` and the matching Blueprint theorem (`thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor`) are updated in parallel; **theorem signatures and proofs are unchanged**, and the existing scope/local-fix citations stay the same.
> 
> **Paper-gap notes** are also aligned: the physical Gibbs complement doc now points at the generic fusion-clause and literal CPSV capstone Lean names (with the older corollary still listed), and the length-one boundary note clarifies that formal theorems omit \(N=1\) while the \(N\ge2\) physical complement is complete—without conflating those issues. A one-line line-number tweak in `docs/tenkz/DISPOSITIONS.md` is incidental.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86404d12332cfc73af28d16e12d94a37ccd64ea9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->