### PR TITLE
feat(Analysis): add order-two sandwiched trace functional

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -39,6 +39,7 @@ import TNLean.Analysis.RelativeEntropySupportIntegral
 import TNLean.Analysis.RelativeEntropySupportLeftRightQuadratic
 import TNLean.Analysis.ResolventFunctionalCalculus
 import TNLean.Analysis.RpowConvexity
+import TNLean.Analysis.SandwichedRenyiTwo
 import TNLean.Analysis.SchattenNorm
 import TNLean.Analysis.SuperoperatorResolvent
 import TNLean.Analysis.TraceCFC

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
+import TNLean.Algebra.MatrixAux
+
+/-!
+# The order-two sandwiched trace functional
+
+This file introduces only the order-two trace functional
+\[
+  \operatorname{Tr}\!\left[
+    \left(\omega^{-1/4}\rho\,\omega^{-1/4}\right)^2
+  \right],
+\]
+which is the expression inside the logarithm in the order-two sandwiched
+Rényi divergence for trace-one states. Negative powers vanish on the zero
+eigenspace, in accordance with the support convention of the source.
+
+The logarithmic comparison with quantum relative entropy requires the
+monotonicity in the order of the sandwiched Rényi divergence. That analytic
+result is not asserted here.
+
+## Main definitions
+
+* `TNLean.sandwichedRenyiTwoTrace` — the order-two sandwiched trace functional.
+
+## Main results
+
+* `TNLean.sandwichedRenyiTwoTrace_nonneg` — positivity on
+  positive-semidefinite arguments.
+* `TNLean.posDef_quarter_inv_sq` — the faithful identity
+  \(\omega^{-1/4}\omega^{-1/4}=\omega^{-1/2}\).
+* `TNLean.sandwichedRenyiTwoTrace_eq_weighted` — the equivalent weighted
+  Hilbert--Schmidt trace expression for faithful \(\omega\).
+
+## References
+
+* Müller-Lennert, Dupuis, Szehr, Fehr, and Tomamichel,
+  *On quantum Rényi entropies: a new generalization and some properties*,
+  arXiv:1306.3142v4, Definition 2.
+* Beigi, *Sandwiched Rényi divergence satisfies data processing inequality*,
+  arXiv:1306.5920, Theorem 7.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace TNLean
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+open scoped Matrix.Norms.L2Operator
+
+private local instance instRenyiTwoNormedRing : NormedRing Mat :=
+  Matrix.instL2OpNormedRing
+private local instance instRenyiTwoNormedAlgebra : NormedAlgebra ℂ Mat :=
+  Matrix.instL2OpNormedAlgebra
+private local instance instRenyiTwoCStarRing : CStarRing Mat :=
+  Matrix.instCStarRing
+private local instance instRenyiTwoPartialOrder : PartialOrder Mat :=
+  Matrix.instPartialOrder
+private local instance instRenyiTwoStarOrderedRing : StarOrderedRing Mat :=
+  Matrix.instStarOrderedRing
+private local instance instRenyiTwoCStarAlgebra : CStarAlgebra Mat :=
+  CStarAlgebra.mk
+
+/-- The order-two sandwiched trace functional
+\(\operatorname{Re}\operatorname{Tr}[(\omega^{-1/4}\rho\omega^{-1/4})^2]\).
+
+For positive-semidefinite matrices the real part is redundant. The definition
+uses the source's convention that a negative power is zero on the zero
+eigenspace; see Müller-Lennert et al., arXiv:1306.3142v4, Definition 2 and
+lines 94--96. -/
+noncomputable def sandwichedRenyiTwoTrace (ρ ω : Mat) : ℝ :=
+  let q := ω ^ (-(1 / 4 : ℝ))
+  (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
+
+/-- The order-two sandwiched trace functional is nonnegative on
+positive-semidefinite arguments.
+
+This is the positivity of the expression in Müller-Lennert et al.,
+arXiv:1306.3142v4, Definition 2, specialized to order two. -/
+theorem sandwichedRenyiTwoTrace_nonneg
+    {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosSemidef) :
+    0 ≤ sandwichedRenyiTwoTrace ρ ω := by
+  let q := ω ^ (-(1 / 4 : ℝ))
+  have hq : q.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+  have hX : (q * ρ * q).PosSemidef := by
+    simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
+  exact (Complex.nonneg_iff.mp (hX.trace_mul_nonneg hX)).1
+
+/-- For a positive-definite matrix, two inverse quarter-powers multiply to the
+inverse square root.
+
+This is the exponent identity used in the order-two specialization of
+Müller-Lennert et al., arXiv:1306.3142v4, Definition 2. -/
+theorem posDef_quarter_inv_sq
+    {ω : Mat} (hω : ω.PosDef) :
+    ω ^ (-(1 / 4 : ℝ)) * ω ^ (-(1 / 4 : ℝ)) = ω ^ (-(1 / 2 : ℝ)) := by
+  rw [← CFC.rpow_add hω.isUnit]
+  congr 1
+  ring
+
+/-- For faithful \(\omega\), the order-two sandwiched trace is
+\(\operatorname{Re}\operatorname{Tr}
+  (\rho\omega^{-1/2}\rho\omega^{-1/2})\).
+
+This is the weighted Hilbert--Schmidt form of the order-two expression in
+Müller-Lennert et al., arXiv:1306.3142v4, Definition 2. -/
+theorem sandwichedRenyiTwoTrace_eq_weighted
+    {ρ ω : Mat} (hω : ω.PosDef) :
+    sandwichedRenyiTwoTrace ρ ω =
+      (Matrix.trace (ρ * ω ^ (-(1 / 2 : ℝ)) * ρ * ω ^ (-(1 / 2 : ℝ)))).re := by
+  rw [sandwichedRenyiTwoTrace]
+  let q := ω ^ (-(1 / 4 : ℝ))
+  have hq : q * q = ω ^ (-(1 / 2 : ℝ)) := posDef_quarter_inv_sq hω
+  have hcycle :
+      Matrix.trace ((q * ρ * q) * (q * ρ * q)) =
+        Matrix.trace (ρ * (q * q) * ρ * (q * q)) := by
+    calc
+      Matrix.trace ((q * ρ * q) * (q * ρ * q)) =
+          Matrix.trace (q * (ρ * q * q * ρ * q)) := by
+            congr 1
+            simp only [Matrix.mul_assoc]
+      _ = Matrix.trace ((ρ * q * q * ρ * q) * q) :=
+        Matrix.trace_mul_comm q _
+      _ = Matrix.trace (ρ * (q * q) * ρ * (q * q)) := by
+        congr 1
+        simp only [Matrix.mul_assoc]
+  rw [hcycle, hq]
+
+end
+
+end TNLean

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -16,8 +16,10 @@ This file introduces only the order-two trace functional
   \right],
 \]
 which is the expression inside the logarithm in the order-two sandwiched
-Rényi divergence for trace-one states. Negative powers vanish on the zero
-eigenspace, in accordance with the support convention of the source.
+Rényi divergence for trace-one states satisfying
+\(\operatorname{supp}\rho\subseteq\operatorname{supp}\omega\). Negative powers
+vanish on the zero eigenspace. Outside this support domain the totalized trace
+functional below remains finite, whereas the sandwiched divergence is infinite.
 
 The logarithmic comparison with quantum relative entropy requires the
 monotonicity in the order of the sandwiched Rényi divergence. That analytic
@@ -31,16 +33,17 @@ result is not asserted here.
 
 * `TNLean.sandwichedRenyiTwoTrace_nonneg` — positivity on
   positive-semidefinite arguments.
-* `TNLean.posDef_quarter_inv_sq` — the faithful identity
+* `TNLean.posDef_rpow_neg_quarter_mul_self` — the faithful identity
   \(\omega^{-1/4}\omega^{-1/4}=\omega^{-1/2}\).
-* `TNLean.sandwichedRenyiTwoTrace_eq_weighted` — the equivalent weighted
-  Hilbert--Schmidt trace expression for faithful \(\omega\).
+* `TNLean.sandwichedRenyiTwoTrace_eq_weighted` — a cyclically reordered trace
+  expression for faithful \(\omega\); when \(\rho\) is Hermitian, its common
+  value is the squared Hilbert--Schmidt norm of the sandwiched matrix.
 
 ## References
 
 * Müller-Lennert, Dupuis, Szehr, Fehr, and Tomamichel,
   *On quantum Rényi entropies: a new generalization and some properties*,
-  arXiv:1306.3142v4, Definition 2.
+  arXiv:1306.3142v4, Definition 2 and Theorem 5.
 * Beigi, *Sandwiched Rényi divergence satisfies data processing inequality*,
   arXiv:1306.5920, Theorem 7.
 -/
@@ -74,10 +77,13 @@ private local instance instRenyiTwoCStarAlgebra : CStarAlgebra Mat :=
 /-- The order-two sandwiched trace functional
 \(\operatorname{Re}\operatorname{Tr}[(\omega^{-1/4}\rho\omega^{-1/4})^2]\).
 
-For positive-semidefinite matrices the real part is redundant. The definition
-uses the source's convention that a negative power is zero on the zero
-eigenspace; see Müller-Lennert et al., arXiv:1306.3142v4, Definition 2 and
-lines 94--96. -/
+For positive-semidefinite matrices the real part is redundant. When the
+matrices have trace one and
+\(\operatorname{supp}\rho\subseteq\operatorname{supp}\omega\), its logarithm
+is the order-two sandwiched Rényi divergence. The negative power is zero on the
+zero eigenspace, so this totalized functional remains finite outside that
+support domain and must not there be identified with the divergence; see
+Müller-Lennert et al., arXiv:1306.3142v4, Definition 2 and lines 94--96. -/
 noncomputable def sandwichedRenyiTwoTrace (ρ ω : Mat) : ℝ :=
   let q := ω ^ (-(1 / 4 : ℝ))
   (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
@@ -102,18 +108,22 @@ inverse square root.
 
 This is the exponent identity used in the order-two specialization of
 Müller-Lennert et al., arXiv:1306.3142v4, Definition 2. -/
-theorem posDef_quarter_inv_sq
+theorem posDef_rpow_neg_quarter_mul_self
     {ω : Mat} (hω : ω.PosDef) :
     ω ^ (-(1 / 4 : ℝ)) * ω ^ (-(1 / 4 : ℝ)) = ω ^ (-(1 / 2 : ℝ)) := by
   rw [← CFC.rpow_add hω.isUnit]
   congr 1
   ring
 
-/-- For faithful \(\omega\), the order-two sandwiched trace is
+/-- For faithful \(\omega\), the order-two sandwiched trace satisfies the
+algebraic identity
 \(\operatorname{Re}\operatorname{Tr}
   (\rho\omega^{-1/2}\rho\omega^{-1/2})\).
 
-This is the weighted Hilbert--Schmidt form of the order-two expression in
+No Hermiticity assumption on \(\rho\) is needed for this cyclic trace identity.
+When \(\rho\) is Hermitian, in particular when it is positive semidefinite,
+\(\omega^{-1/4}\rho\omega^{-1/4}\) is Hermitian, and the common value is its
+squared Hilbert--Schmidt norm. This is the order-two expression in
 Müller-Lennert et al., arXiv:1306.3142v4, Definition 2. -/
 theorem sandwichedRenyiTwoTrace_eq_weighted
     {ρ ω : Mat} (hω : ω.PosDef) :
@@ -121,7 +131,8 @@ theorem sandwichedRenyiTwoTrace_eq_weighted
       (Matrix.trace (ρ * ω ^ (-(1 / 2 : ℝ)) * ρ * ω ^ (-(1 / 2 : ℝ)))).re := by
   rw [sandwichedRenyiTwoTrace]
   let q := ω ^ (-(1 / 4 : ℝ))
-  have hq : q * q = ω ^ (-(1 / 2 : ℝ)) := posDef_quarter_inv_sq hω
+  have hq : q * q = ω ^ (-(1 / 2 : ℝ)) :=
+    posDef_rpow_neg_quarter_mul_self hω
   have hcycle :
       Matrix.trace ((q * ρ * q) * (q * ρ * q)) =
         Matrix.trace (ρ * (q * q) * ρ * (q * q)) := by


### PR DESCRIPTION
## Summary

This pull request introduces the finite-dimensional order-two trace functional
\[
\operatorname{Tr}\!\left[
  \left(\omega^{-1/4}\rho\,\omega^{-1/4}\right)^2
\right]
\]
needed for the operator-Schmidt mutual-information argument in #4295.

It proves:

- nonnegativity on positive-semidefinite inputs;
- the faithful real-power identity
  \(\omega^{-1/4}\omega^{-1/4}=\omega^{-1/2}\);
- the cyclic weighted trace identity
  \[
  \operatorname{Tr}[(\omega^{-1/4}\rho\omega^{-1/4})^2]
  =\operatorname{Tr}(\rho\omega^{-1/2}\rho\omega^{-1/2}).
  \]

The documentation distinguishes the totalized trace functional from the sandwiched divergence: identification with \(\widetilde D_2\) requires positive trace-one inputs and \(\operatorname{supp}\rho\subseteq\operatorname{supp}\omega\). Outside that support domain the source divergence is infinite, whereas the totalized functional remains finite.

## Sources

- Müller-Lennert--Dupuis--Szehr--Fehr--Tomamichel, *On quantum Rényi entropies: a new generalization and some properties*, arXiv:1306.3142v4, Definition 2 and Theorem 5.
- Beigi, *Sandwiched Rényi Divergence Satisfies Data Processing Inequality*, arXiv:1306.5920, Theorem 7.

## Scope

This is a proved prerequisite for #5209, not its completion. The pull request does **not** assert
\[
D(\rho\|\omega)\le\widetilde D_2(\rho\|\omega).
\]
That comparison still requires the weighted Schatten interpolation/order-one-limit argument absent from the current library. Accordingly this PR does not close #5209, #4295, or any CPSV16 Blueprint entry.

Progresses #5209.

## Validation

- `lake exe cache get` completed before every Lean check;
- `lake env lean TNLean/Analysis/SandwichedRenyiTwo.lean`;
- generated import-aggregator check;
- reader-facing prose check;
- forbidden-token and proof-integrity checks;
- `git diff --check`.

An independent exact-head review confirmed the support convention, the real-power identities, the arbitrary-matrix cyclic identity, and the absence of any entropy-comparison overclaim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New self-contained analysis definitions and proofs with no changes to auth, data paths, or existing entropy APIs beyond a generated import line.
> 
> **Overview**
> Adds **`TNLean/Analysis/SandwichedRenyiTwo.lean`** and registers it in the generated **`TNLean.Analysis`** import aggregator.
> 
> Introduces **`sandwichedRenyiTwoTrace`**, the real part of \(\mathrm{Tr}[(\omega^{-1/4}\rho\omega^{-1/4})^2]\) on finite-dimensional matrices via CFC matrix powers. Docstrings stress that this **totalized** functional stays finite when support conditions fail, and must not be read as the sandwiched Rényi divergence (which is infinite there).
> 
> Proves three lemmas: **nonnegativity** when \(\rho\) is positive semidefinite; **`posDef_rpow_neg_quarter_mul_self`**, combining two \(-1/4\) powers to \(\omega^{-1/2}\) for positive-definite \(\omega\); and **`sandwichedRenyiTwoTrace_eq_weighted`**, rewriting the sandwiched square as \(\mathrm{Re}\,\mathrm{Tr}(\rho\omega^{-1/2}\rho\omega^{-1/2})\) by cyclic trace manipulation (no Hermiticity on \(\rho\)).
> 
> Does **not** prove \(D(\rho\|\omega) \le \widetilde D_2(\rho\|\omega)\) or sandwiched-Rényi monotonicity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73461bff8811c489ecbb6b205329a27ce0be54d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->