### PR TITLE
feat(Channel): make CPTP trace adjoints unital

### DIFF
--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -33,6 +33,7 @@ dimensions.
   map satisfies the Kadison--Schwarz inequality.
 * `IsKrausCP.traceAdjointMap`: the trace adjoint of a Kraus CP map is Kraus CP.
 * `IsKrausCPTP.trace_map`: a map satisfying `IsKrausCPTP` preserves trace.
+* `IsKrausCPTP.traceAdjointMap_one`: the trace adjoint of a Kraus CPTP map is unital.
 * `isKrausCPTP_of_isKrausCP_trace_preserving`: a Kraus CP map that preserves
   trace is Kraus CPTP.
 * `IsKrausCPTP.map_posSemidef`: a map satisfying `IsKrausCPTP` preserves
@@ -208,6 +209,18 @@ theorem IsKrausCPTP.trace_map
   obtain ⟨r, A, hA, hA_norm⟩ := hS
   rw [hA]
   exact kraus_tp_of_sum_conjTranspose_mul A hA_norm X
+
+/-- The trace-pairing adjoint of a trace-preserving completely positive map is unital.
+
+This is the Schrödinger--Heisenberg duality stated in Wolf, Section 1.2; local source
+`Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, line 315. -/
+theorem IsKrausCPTP.traceAdjointMap_one
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} (hS : IsKrausCPTP S) :
+    Matrix.traceAdjointMap S 1 = 1 := by
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro X
+  simpa only [Matrix.trace_traceAdjointMap_mul, Matrix.one_mul] using hS.trace_map X
 
 /-- A completely positive Kraus map that preserves the matrix trace is
 trace-preserving completely positive. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_renormalization.tex
@@ -115,6 +115,37 @@ section.
     \end{align}
 \end{proof}
 
+\begin{theorem}[The trace adjoint of a channel is unital]
+    \label{thm:is_kraus_cptp_trace_adjoint_one}
+    \lean{IsKrausCPTP.traceAdjointMap_one}
+    \leanok
+    \uses{def:is_kraus_cptp, def:trace_pairing_adjoint}
+    If $\mathcal S:\MN{D}\to\MN{D'}$ is trace-preserving and completely
+    positive, then its trace-pairing adjoint satisfies
+    \begin{align}
+        \mathcal S^*(\Id_{D'})
+        &=\Id_D.
+        \notag
+    \end{align}
+    This is the Schrödinger--Heisenberg duality of
+    \cite[Section~1.2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:trace_pairing_adjoint_identity,
+        thm:is_kraus_cptp_trace_map, thm:trace_nondeg}
+    For every $X\in\MN{D}$, trace duality and trace preservation give
+    \begin{align}
+        \tr\bigl(\mathcal S^*(\Id_{D'})X\bigr)
+        &=\tr\bigl(\mathcal S(X)\bigr)
+        =\tr(X)
+        =\tr(\Id_DX).
+        \notag
+    \end{align}
+    Nondegeneracy of the trace pairing proves the identity.
+\end{proof}
+
 \begin{lemma}[Positivity preservation for Kraus maps]
     \label{lem:is_kraus_cptp_map_pos}
     \lean{IsKrausCPTP.map_posSemidef}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -76,7 +76,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L475, 477 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L338 `tenkzfree` → `R-free+R-record` |
-| `ch21_mpdo_rfp_renormalization.tex` | — | — | L734 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L736, 739, 742, 745 `tnpic` → `C-picture+C-policy+C-record+R-record` |
+| `ch21_mpdo_rfp_renormalization.tex` | — | — | L765 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L767, 770, 773, 776 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |
 | `ch21_mpdo_rfp_simple_local_neighboring_bond_contractions.tex` | — | — | L792, 801, 808, 815, 888, 894 `tenkz` → `C-policy+C-record+R-record` |


### PR DESCRIPTION
## Summary

- prove that the trace-pairing adjoint of a rectangular Kraus CPTP map sends the identity to the identity
- record the Schrödinger--Heisenberg duality in the Blueprint with its exact trace-duality dependencies
- retain arbitrary finite input and output index types, including the empty cases

This is a prerequisite for the unital completely positive map used in the weighted Hilbert--Schmidt contraction of #5210. It does not close that issue.

## Mathematical source

Wolf, *Quantum Channels & Operations*, Section 1.2; local source `Notes/WolfNoteTexSource/ch01_deconstructing_quantum.tex`, line 315.

## Verification

- `lake env lean -DwarningAsError=true TNLean/Channel/KrausCPTP.lean`
- `lake build TNLean.Channel`
- empty-input and empty-output regression checks
- Blueprint declaration and dependency checks
- proof-integrity and prose scans
- independent exact-commit review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained formal lemma and blueprint prose with no auth, data, or runtime behavior changes.
> 
> **Overview**
> Adds **`IsKrausCPTP.traceAdjointMap_one`**: for rectangular Kraus CPTP maps, `traceAdjointMap S 1 = 1`, proved by matching `tr((traceAdjointMap S 1) X)` to `tr(S X)` via trace duality and **`IsKrausCPTP.trace_map`**.
> 
> The blueprint chapter **`ch21_mpdo_rfp_renormalization.tex`** gains theorem **`thm:is_kraus_cptp_trace_adjoint_one`** (linked to the Lean name) with a proof through trace-pairing adjoint identity, trace preservation, and nondegeneracy. Module doc lists the new result; **`docs/tenkz/DISPOSITIONS.md`** only updates line references for that file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67899363e418de4f80f1b2e4433684cf5389951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->