### PR TITLE
feat(Channel): prove weighted Hilbert–Schmidt contraction

### DIFF
--- a/TNLean/Algebra/FrobeniusHilbert.lean
+++ b/TNLean/Algebra/FrobeniusHilbert.lean
@@ -22,6 +22,8 @@ superoperators without introducing a second norm on matrices.
   isometric equivalence.
 * `Matrix.frobeniusEuclideanMap`: transport of a matrix superoperator through
   this equivalence.
+* `Matrix.frobeniusEuclideanLinearEquiv`: transport of a linear equivalence
+  between matrix spaces.
 * `Matrix.frobeniusEuclideanMap_comp`: Frobenius transport preserves
   composition.
 -/
@@ -113,6 +115,29 @@ theorem frobeniusEuclideanMap_apply
     frobeniusEquivEuclidean β β (E X)
   rw [(frobeniusEquivEuclidean α α).symm_apply_apply]
 
+/-- Transport a linear equivalence between finite matrix spaces through
+Frobenius vectorization. -/
+noncomputable def frobeniusEuclideanLinearEquiv
+    {α β : Type*} [Fintype α] [Fintype β]
+    (E : Matrix α α ℂ ≃ₗ[ℂ] Matrix β β ℂ) :
+    EuclideanSpace ℂ (α × α) ≃ₗ[ℂ] EuclideanSpace ℂ (β × β) :=
+  (frobeniusEquivEuclidean α α).toLinearEquiv.symm.trans
+    (E.trans (frobeniusEquivEuclidean β β).toLinearEquiv)
+
+/-- Frobenius transport of a linear equivalence agrees with its action on a
+vectorized matrix. -/
+@[simp]
+theorem frobeniusEuclideanLinearEquiv_apply
+    {α β : Type*} [Fintype α] [Fintype β]
+    (E : Matrix α α ℂ ≃ₗ[ℂ] Matrix β β ℂ) (X : Matrix α α ℂ) :
+    frobeniusEuclideanLinearEquiv E (frobeniusEquivEuclidean α α X) =
+      frobeniusEquivEuclidean β β (E X) := by
+  change frobeniusEquivEuclidean β β
+      (E ((frobeniusEquivEuclidean α α).symm
+        (frobeniusEquivEuclidean α α X))) =
+    frobeniusEquivEuclidean β β (E X)
+  rw [(frobeniusEquivEuclidean α α).symm_apply_apply]
+
 /-- Frobenius transport preserves composition of linear maps between matrix
 spaces. -/
 @[simp]
@@ -139,6 +164,16 @@ theorem frobeniusEuclideanMap_eq_conj
     (E : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
     frobeniusEuclideanMap E =
       (frobeniusEquivEuclidean α α).toLinearEquiv.conj E := by
+  rfl
+
+/-- Frobenius transport carries conjugation by a matrix-space equivalence to
+conjugation by the transported Euclidean-space equivalence. -/
+theorem frobeniusEuclideanMap_conj
+    {α β : Type*} [Fintype α] [Fintype β]
+    (S : Matrix α α ℂ ≃ₗ[ℂ] Matrix β β ℂ)
+    (E : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) :
+    frobeniusEuclideanMap (S.conj E) =
+      (frobeniusEuclideanLinearEquiv S).conj (frobeniusEuclideanMap E) := by
   rfl
 
 end Matrix

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -201,6 +201,23 @@ theorem traceAdjointMap_traceAdjointMap {n m : Type*} [Fintype n] [Fintype m]
             rw [Matrix.trace_mul_comm]
   simp [Matrix.sub_mul, Matrix.trace_sub, htrace]
 
+/-- The trace-pairing adjoint reverses composition of linear maps between
+finite matrix algebras. -/
+theorem traceAdjointMap_comp
+    {n m k : Type*} [Finite n] [Fintype m] [Fintype k]
+    (E : Matrix n n ℂ →ₗ[ℂ] Matrix m m ℂ)
+    (F : Matrix m m ℂ →ₗ[ℂ] Matrix k k ℂ) :
+    traceAdjointMap (F.comp E) =
+      (traceAdjointMap E).comp (traceAdjointMap F) := by
+  letI := Fintype.ofFinite n
+  apply LinearMap.ext
+  intro X
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro Y
+  simp only [LinearMap.comp_apply]
+  rw [trace_traceAdjointMap_mul, trace_traceAdjointMap_mul,
+    trace_traceAdjointMap_mul, LinearMap.comp_apply]
+
 end Matrix
 
 namespace MPSTensor

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -64,6 +64,7 @@ import TNLean.Channel.SchmidtRank
 import TNLean.Channel.Schwarz
 import TNLean.Channel.Semigroup
 import TNLean.Channel.Separable
+import TNLean.Channel.SingleKraus
 import TNLean.Channel.SingleKrausPositivity
 import TNLean.Channel.Spectral
 import TNLean.Channel.Stinespring

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -296,6 +296,39 @@ noncomputable alias sandwichMap := singleKrausMap
     singleKrausMap V X = V * X * Vᴴ :=
   rfl
 
+/-- Composition of two single-Kraus maps is the single-Kraus map associated
+with the product of their Kraus matrices. -/
+theorem singleKrausMap_comp
+    {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
+    (V : Matrix γ β ℂ) (W : Matrix β α ℂ) :
+    (singleKrausMap V).comp (singleKrausMap W) =
+      singleKrausMap (V * W) := by
+  apply LinearMap.ext
+  intro X
+  simp only [LinearMap.comp_apply, singleKrausMap_apply,
+    Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+/-- The trace-pairing adjoint of a single-Kraus map is the single-Kraus map
+associated with the conjugate-transposed Kraus matrix. -/
+theorem Matrix.traceAdjointMap_singleKrausMap
+    {α β : Type*} [Fintype α] [Fintype β]
+    (V : Matrix β α ℂ) :
+    Matrix.traceAdjointMap (singleKrausMap V) = singleKrausMap Vᴴ := by
+  apply LinearMap.ext
+  intro X
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro Y
+  rw [Matrix.trace_traceAdjointMap_mul]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
+  calc
+    Matrix.trace (X * (V * Y * Vᴴ)) =
+        Matrix.trace ((V * Y * Vᴴ) * X) := Matrix.trace_mul_comm _ _
+    _ = Matrix.trace (Vᴴ * X * (V * Y)) := by
+      symm
+      exact Matrix.trace_mul_cycle Vᴴ X (V * Y)
+    _ = Matrix.trace ((Vᴴ * X * V) * Y) := by
+      rw [← Matrix.mul_assoc]
+
 /-- Conjugation by one rectangular matrix is completely positive. -/
 theorem singleKrausMap_isKrausCP {α β : Type*}
     [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]

--- a/TNLean/Channel/KrausCPTP.lean
+++ b/TNLean/Channel/KrausCPTP.lean
@@ -296,39 +296,6 @@ noncomputable alias sandwichMap := singleKrausMap
     singleKrausMap V X = V * X * Vᴴ :=
   rfl
 
-/-- Composition of two single-Kraus maps is the single-Kraus map associated
-with the product of their Kraus matrices. -/
-theorem singleKrausMap_comp
-    {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
-    (V : Matrix γ β ℂ) (W : Matrix β α ℂ) :
-    (singleKrausMap V).comp (singleKrausMap W) =
-      singleKrausMap (V * W) := by
-  apply LinearMap.ext
-  intro X
-  simp only [LinearMap.comp_apply, singleKrausMap_apply,
-    Matrix.conjTranspose_mul, Matrix.mul_assoc]
-
-/-- The trace-pairing adjoint of a single-Kraus map is the single-Kraus map
-associated with the conjugate-transposed Kraus matrix. -/
-theorem Matrix.traceAdjointMap_singleKrausMap
-    {α β : Type*} [Fintype α] [Fintype β]
-    (V : Matrix β α ℂ) :
-    Matrix.traceAdjointMap (singleKrausMap V) = singleKrausMap Vᴴ := by
-  apply LinearMap.ext
-  intro X
-  apply Matrix.ext_iff_trace_mul_right.mpr
-  intro Y
-  rw [Matrix.trace_traceAdjointMap_mul]
-  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
-  calc
-    Matrix.trace (X * (V * Y * Vᴴ)) =
-        Matrix.trace ((V * Y * Vᴴ) * X) := Matrix.trace_mul_comm _ _
-    _ = Matrix.trace (Vᴴ * X * (V * Y)) := by
-      symm
-      exact Matrix.trace_mul_cycle Vᴴ X (V * Y)
-    _ = Matrix.trace ((Vᴴ * X * V) * Y) := by
-      rw [← Matrix.mul_assoc]
-
 /-- Conjugation by one rectangular matrix is completely positive. -/
 theorem singleKrausMap_isKrausCP {α β : Type*}
     [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]

--- a/TNLean/Channel/Peripheral/UnitalKraus.lean
+++ b/TNLean/Channel/Peripheral/UnitalKraus.lean
@@ -3,9 +3,11 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.FrobeniusHilbert
 import TNLean.Channel.KrausCPTP
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import Mathlib.Analysis.CStarAlgebra.ContinuousFunctionalCalculus.Order
+import Mathlib.Analysis.Normed.Operator.NormedSpace
 
 /-!
 # Operator-norm bounds for unital Kraus maps
@@ -17,14 +19,22 @@ matrix operator norm. Consequently, every eigenvalue lies in the closed unit dis
 
 * `IsKrausCP.norm_apply_le_of_map_one_eq_one`: operator-norm contractivity of a unital Kraus map.
 * `IsKrausCP.eigenvalue_norm_le_one_of_map_one_eq_one`: the spectral bound for a unital Kraus map.
+* `IsKrausCP.spectralRadius_frobeniusEuclideanMap_le_one_of_map_one_eq_one`:
+  the corresponding bound after Frobenius vectorization.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.1][Wolf2012QChannels]
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.L2Operator
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.L2Operator NNReal ENNReal
 open Matrix
+
+attribute [local instance 1001]
+  ContinuousLinearMap.toNormedAddCommGroup
+  ContinuousLinearMap.toNormedSpace
+  ContinuousLinearMap.toNormedRing
+  ContinuousLinearMap.toNormedAlgebra
 
 /-- A unital Kraus completely positive endomorphism is a contraction for the matrix operator norm.
 -/
@@ -75,3 +85,35 @@ theorem IsKrausCP.eigenvalue_norm_le_one_of_map_one_eq_one
   rw [hEig, norm_smul] at hContract
   have hXpos : 0 < ‖X‖ := norm_pos_iff.mpr hXne
   exact le_of_mul_le_mul_right (by simpa using hContract) hXpos
+
+open scoped Matrix.Norms.Frobenius in
+/-- The Frobenius-vectorized form of a unital Kraus completely positive
+endomorphism has spectral radius at most one. This statement also covers the
+zero-dimensional matrix algebra. -/
+theorem IsKrausCP.spectralRadius_frobeniusEuclideanMap_le_one_of_map_one_eq_one
+    {α : Type*} [Fintype α] [DecidableEq α]
+    {E : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ}
+    (hE : IsKrausCP E) (hOne : E 1 = 1) :
+    spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (EuclideanSpace ℂ (α × α)))
+        (Matrix.frobeniusEuclideanMap E)) ≤ 1 := by
+  let V := EuclideanSpace ℂ (α × α)
+  let Ê : V →ₗ[ℂ] V := Matrix.frobeniusEuclideanMap E
+  let Φ : (V →ₗ[ℂ] V) ≃ₐ[ℂ] (V →L[ℂ] V) :=
+    Module.End.toContinuousLinearMap V
+  have hSpecCLM : spectrum ℂ (Φ Ê) = spectrum ℂ Ê :=
+    AlgEquiv.spectrum_eq Φ Ê
+  have hSpecFrob : spectrum ℂ Ê = spectrum ℂ E := by
+    dsimp only [Ê]
+    rw [Matrix.frobeniusEuclideanMap_eq_conj]
+    exact AlgEquiv.spectrum_eq
+      ((Matrix.frobeniusEquivEuclidean α α).toLinearEquiv.conjAlgEquiv ℂ) E
+  change spectralRadius ℂ (Φ Ê) ≤ 1
+  rw [spectralRadius]
+  refine iSup₂_le fun μ hμ ↦ ?_
+  have hμE : μ ∈ spectrum ℂ E := hSpecFrob ▸ (hSpecCLM ▸ hμ)
+  have hEig : Module.End.HasEigenvalue E μ :=
+    Module.End.hasEigenvalue_iff_mem_spectrum.mpr hμE
+  have hBound : ‖μ‖ ≤ 1 :=
+    hE.eigenvalue_norm_le_one_of_map_one_eq_one hOne μ hEig
+  exact_mod_cast hBound

--- a/TNLean/Channel/SingleKraus.lean
+++ b/TNLean/Channel/SingleKraus.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KrausCPTP
+
+/-!
+# Single-Kraus map identities
+
+This file records composition and trace-adjoint identities for maps given by
+conjugation with one rectangular Kraus matrix.
+
+## Main declarations
+
+* `singleKrausMap_comp`: composition corresponds to multiplication of Kraus matrices.
+* `Matrix.traceAdjointMap_singleKrausMap`: the trace adjoint corresponds to conjugate
+  transposition of the Kraus matrix.
+-/
+
+open scoped Matrix
+
+/-- Composition of two single-Kraus maps is the single-Kraus map associated
+with the product of their Kraus matrices. -/
+theorem singleKrausMap_comp
+    {α β γ : Type*} [Fintype α] [Fintype β] [Fintype γ]
+    (V : Matrix γ β ℂ) (W : Matrix β α ℂ) :
+    (singleKrausMap V).comp (singleKrausMap W) =
+      singleKrausMap (V * W) := by
+  apply LinearMap.ext
+  intro X
+  simp only [LinearMap.comp_apply, singleKrausMap_apply,
+    Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+/-- The trace-pairing adjoint of a single-Kraus map is the single-Kraus map
+associated with the conjugate-transposed Kraus matrix. -/
+theorem Matrix.traceAdjointMap_singleKrausMap
+    {α β : Type*} [Fintype α] [Fintype β]
+    (V : Matrix β α ℂ) :
+    Matrix.traceAdjointMap (singleKrausMap V) = singleKrausMap Vᴴ := by
+  apply LinearMap.ext
+  intro X
+  apply Matrix.ext_iff_trace_mul_right.mpr
+  intro Y
+  rw [Matrix.trace_traceAdjointMap_mul]
+  simp only [singleKrausMap_apply, Matrix.conjTranspose_conjTranspose]
+  calc
+    Matrix.trace (X * (V * Y * Vᴴ)) =
+        Matrix.trace ((V * Y * Vᴴ) * X) := Matrix.trace_mul_comm _ _
+    _ = Matrix.trace (Vᴴ * X * (V * Y)) := by
+      symm
+      exact Matrix.trace_mul_cycle Vᴴ X (V * Y)
+    _ = Matrix.trace ((Vᴴ * X * V) * Y) := by
+      rw [← Matrix.mul_assoc]

--- a/TNLean/Channel/WeightedHilbertSchmidt.lean
+++ b/TNLean/Channel/WeightedHilbertSchmidt.lean
@@ -284,4 +284,22 @@ theorem weightedHilbertSchmidtMap_isHilbertSchmidtContraction
   have hNorm := weightedHilbertSchmidtMap_norm_le hΦ hσ hτ hmap X
   nlinarith [norm_nonneg (weightedHilbertSchmidtMap Φ σ τ X), norm_nonneg X]
 
+-- Compile-time regression check for the identity channel in a nonzero dimension.
+private theorem weightedHilbertSchmidtMap_identity_fin_two
+    (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    ‖weightedHilbertSchmidtMap
+      (LinearMap.id : Matrix (Fin 2) (Fin 2) ℂ →ₗ[ℂ] Matrix (Fin 2) (Fin 2) ℂ)
+      1 1 X‖ ≤ ‖X‖ := by
+  exact weightedHilbertSchmidtMap_norm_le isKrausCPTP_id
+    Matrix.PosDef.one Matrix.PosDef.one rfl X
+
+-- Compile-time regression check for the zero-dimensional matrix algebra.
+private theorem weightedHilbertSchmidtMap_identity_fin_zero
+    (X : Matrix (Fin 0) (Fin 0) ℂ) :
+    ‖weightedHilbertSchmidtMap
+      (LinearMap.id : Matrix (Fin 0) (Fin 0) ℂ →ₗ[ℂ] Matrix (Fin 0) (Fin 0) ℂ)
+      1 1 X‖ ≤ ‖X‖ := by
+  exact weightedHilbertSchmidtMap_norm_le isKrausCPTP_id
+    Matrix.PosDef.one Matrix.PosDef.one rfl X
+
 end Matrix

--- a/TNLean/Channel/WeightedHilbertSchmidt.lean
+++ b/TNLean/Channel/WeightedHilbertSchmidt.lean
@@ -6,8 +6,8 @@ Authors: TNLean contributors
 import TNLean.Algebra.FrobeniusHilbert
 import TNLean.Algebra.MatrixCongruence
 import TNLean.Algebra.RectangularChoi
-import TNLean.Channel.KrausCPTP
 import TNLean.Channel.Peripheral.UnitalKraus
+import TNLean.Channel.SingleKraus
 
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.Rayleigh

--- a/TNLean/Channel/WeightedHilbertSchmidt.lean
+++ b/TNLean/Channel/WeightedHilbertSchmidt.lean
@@ -4,23 +4,28 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FrobeniusHilbert
+import TNLean.Algebra.MatrixCongruence
+import TNLean.Algebra.RectangularChoi
 import TNLean.Channel.KrausCPTP
+import TNLean.Channel.Peripheral.UnitalKraus
 
 import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.Rayleigh
 
 /-!
 # Weighted Hilbert--Schmidt channel maps
 
-This file begins the finite-dimensional Hilbert-space infrastructure needed
-for the direct `p = 2` specialization of Beigi's weighted Schatten-norm
-contraction.  In particular, it identifies the trace-pairing adjoint of a
-rectangular Kraus map with its Hilbert-space adjoint after Frobenius
-vectorization.
+This file develops the finite-dimensional Hilbert-space infrastructure and
+proves the direct `p = 2` specialization of Beigi's weighted Schatten-norm
+contraction. It also identifies the trace-pairing adjoint of a rectangular
+Kraus map with its Hilbert-space adjoint after Frobenius vectorization.
 
 ## Main result
 
 * `Matrix.adjoint_frobeniusEuclideanMap_eq`: the Hilbert-space adjoint of a
   Kraus map is its trace-pairing adjoint.
+* `Matrix.weightedHilbertSchmidtMap`: the full-support weighted channel map.
+* `Matrix.weightedHilbertSchmidtMap_norm_le`: its Hilbert--Schmidt contraction bound.
 
 ## References
 
@@ -29,9 +34,15 @@ vectorization.
   Theorem 6 and equation (18).
 -/
 
-open scoped Matrix Matrix.Norms.Frobenius
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.Frobenius NNReal ENNReal
 
 namespace Matrix
+
+attribute [local instance 1001]
+  ContinuousLinearMap.toNormedAddCommGroup
+  ContinuousLinearMap.toNormedSpace
+  ContinuousLinearMap.toNormedRing
+  ContinuousLinearMap.toNormedAlgebra
 
 /-- After Frobenius vectorization, the Hilbert-space adjoint of a rectangular
 Kraus map is its trace-pairing adjoint.
@@ -56,5 +67,221 @@ theorem adjoint_frobeniusEuclideanMap_eq
     simp only [Matrix.conjTranspose_sum, Matrix.conjTranspose_mul,
       Matrix.conjTranspose_conjTranspose, Matrix.mul_assoc]
   rw [hstar, trace_traceAdjointMap_mul]
+
+/-- The weighted channel map
+`X ↦ τ^{-1/4} Φ(σ^{1/4} X σ^{1/4}) τ^{-1/4}` used in the full-support `p = 2`
+specialization of Beigi, arXiv:1306.5920, Theorem 6, equation (18).
+
+Invertibility of the two weights is imposed by the contraction theorem below. -/
+noncomputable def weightedHilbertSchmidtMap
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (σ : Matrix α α ℂ) (τ : Matrix β β ℂ) :
+    Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
+  (singleKrausMap (CFC.sqrt (CFC.sqrt τ))⁻¹).comp
+    (Φ.comp (singleKrausMap (CFC.sqrt (CFC.sqrt σ))))
+
+private theorem norm_apply_le_of_spectralRadius_adjoint_comp_le_one
+    {V W : Type*} [NormedAddCommGroup V] [InnerProductSpace ℂ V] [CompleteSpace V]
+    [NormedAddCommGroup W] [InnerProductSpace ℂ W] [CompleteSpace W]
+    (L : V →L[ℂ] W)
+    (hRad : spectralRadius ℂ (L.adjoint.comp L) ≤ 1) (x : V) :
+    ‖L x‖ ≤ ‖x‖ := by
+  let G := L.adjoint.comp L
+  have hGsa : IsSelfAdjoint G := by
+    rw [ContinuousLinearMap.isSelfAdjoint_iff']
+    simp [G]
+  have hGnorm : ‖G‖ ≤ 1 := by
+    have hGnnorm : ‖G‖₊ ≤ 1 := by
+      have hGenn : (↑‖G‖₊ : ENNReal) ≤ 1 := by
+        rw [← G.spectralRadius_eq_nnnorm hGsa]
+        exact hRad
+      exact_mod_cast hGenn
+    exact_mod_cast hGnnorm
+  have hLnorm : ‖L‖ ≤ 1 := by
+    rw [ContinuousLinearMap.norm_adjoint_comp_self] at hGnorm
+    nlinarith [norm_nonneg L]
+  exact (L.le_opNorm x).trans (mul_le_of_le_one_left (norm_nonneg x) hLnorm)
+
+/-- The full-support `p = 2` specialization of the weighted Schatten-norm
+contraction in Beigi, arXiv:1306.5920, Theorem 6, equation (18).
+
+**Scope restriction (full output support):** The output weight is assumed
+positive definite. The support-compressed form needed for arbitrary output
+support is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+theorem weightedHilbertSchmidtMap_norm_le
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {Φ : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    {σ : Matrix α α ℂ} {τ : Matrix β β ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) (hτ : τ.PosDef)
+    (hmap : Φ σ = τ) (X : Matrix α α ℂ) :
+    ‖weightedHilbertSchmidtMap Φ σ τ X‖ ≤ ‖X‖ := by
+  let sσ := CFC.sqrt σ
+  let qσ := CFC.sqrt sσ
+  let sτ := CFC.sqrt τ
+  let qτ := CFC.sqrt sτ
+  have hsσ_psd : sσ.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg σ)
+  have hqσ_psd : qσ.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg sσ)
+  have hsτ_psd : sτ.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg τ)
+  have hqτ_psd : qτ.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg sτ)
+  have hsσ_sq : sσ * sσ = σ := by
+    simpa only [sσ] using CFC.sqrt_mul_sqrt_self σ hσ.posSemidef.nonneg
+  have hqσ_sq : qσ * qσ = sσ := by
+    simpa only [qσ] using CFC.sqrt_mul_sqrt_self sσ hsσ_psd.nonneg
+  have hsτ_sq : sτ * sτ = τ := by
+    simpa only [sτ] using CFC.sqrt_mul_sqrt_self τ hτ.posSemidef.nonneg
+  have hqτ_sq : qτ * qτ = sτ := by
+    simpa only [qτ] using CFC.sqrt_mul_sqrt_self sτ hsτ_psd.nonneg
+  have hsσ_star : sσᴴ = sσ := by
+    exact hsσ_psd.isHermitian
+  have hqσ_star : qσᴴ = qσ := by
+    exact hqσ_psd.isHermitian
+  have hsτ_star : sτᴴ = sτ := by
+    exact hsτ_psd.isHermitian
+  have hqτ_star : qτᴴ = qτ := by
+    exact hqτ_psd.isHermitian
+  have hsσ_unit : IsUnit sσ :=
+    (CFC.isUnit_sqrt_iff σ hσ.posSemidef.nonneg).2 hσ.isUnit
+  have hqσ_unit : IsUnit qσ :=
+    (CFC.isUnit_sqrt_iff sσ hsσ_psd.nonneg).2 hsσ_unit
+  have hsτ_unit : IsUnit sτ :=
+    (CFC.isUnit_sqrt_iff τ hτ.posSemidef.nonneg).2 hτ.isUnit
+  have hqσ_det : qσ.det ≠ 0 :=
+    ((Matrix.isUnit_iff_isUnit_det qσ).1 hqσ_unit).ne_zero
+  have hsτ_det_unit : IsUnit sτ.det :=
+    (Matrix.isUnit_iff_isUnit_det sτ).1 hsτ_unit
+  have hsτ_inv_star : (sτ⁻¹)ᴴ = sτ⁻¹ := by
+    rw [Matrix.conjTranspose_nonsing_inv, hsτ_star]
+  have hsigma_one : singleKrausMap sσ 1 = σ := by
+    rw [singleKrausMap_apply, hsσ_star, Matrix.mul_one, hsσ_sq]
+  have htau_inv : singleKrausMap sτ⁻¹ τ = 1 := by
+    rw [singleKrausMap_apply, hsτ_inv_star, ← hsτ_sq]
+    calc
+      sτ⁻¹ * (sτ * sτ) * sτ⁻¹ = (sτ⁻¹ * sτ) * (sτ * sτ⁻¹) := by
+        noncomm_ring
+      _ = 1 * 1 := by
+        rw [Matrix.nonsing_inv_mul sτ hsτ_det_unit,
+          Matrix.mul_nonsing_inv sτ hsτ_det_unit]
+      _ = 1 := mul_one 1
+  let E := (traceAdjointMap Φ).comp
+    ((singleKrausMap sτ⁻¹).comp (Φ.comp (singleKrausMap sσ)))
+  have hEcp : IsKrausCP E := by
+    exact isKrausCP_comp
+      (isKrausCP_comp
+        (isKrausCP_comp (singleKrausMap_isKrausCP sσ) hΦ.isKrausCP)
+        (singleKrausMap_isKrausCP sτ⁻¹))
+      hΦ.isKrausCP.traceAdjointMap
+  have hEone : E 1 = 1 := by
+    simp only [E, LinearMap.comp_apply, hsigma_one, hmap, htau_inv]
+    exact hΦ.traceAdjointMap_one
+  let L := weightedHilbertSchmidtMap Φ σ τ
+  let S := congruenceLinearEquiv qσ hqσ_det
+  have hqτ_inv_sq : qτ⁻¹ * qτ⁻¹ = sτ⁻¹ := by
+    rw [← Matrix.mul_inv_rev, hqτ_sq]
+  have hqσ_inv_mul : qσ⁻¹ * qσ = 1 :=
+    Matrix.nonsing_inv_mul qσ (Ne.isUnit hqσ_det)
+  have hqσ_mul_inv : qσ * qσ⁻¹ = 1 :=
+    Matrix.mul_nonsing_inv qσ (Ne.isUnit hqσ_det)
+  have hAdjL : traceAdjointMap L =
+      (singleKrausMap qσ).comp
+        ((traceAdjointMap Φ).comp (singleKrausMap qτ⁻¹)) := by
+    dsimp only [L, weightedHilbertSchmidtMap]
+    rw [traceAdjointMap_comp, traceAdjointMap_comp,
+      traceAdjointMap_singleKrausMap, traceAdjointMap_singleKrausMap]
+    rw [Matrix.conjTranspose_nonsing_inv, hqτ_star, hqσ_star]
+    rfl
+  have hGramTrace : (traceAdjointMap L).comp L = S.conj E := by
+    apply LinearMap.ext
+    intro Y
+    rw [LinearEquiv.conj_apply]
+    change (traceAdjointMap L) (L Y) = S (E (S.symm Y))
+    rw [hAdjL]
+    rw [show S (E (S.symm Y)) = qσ * E (S.symm Y) * qσᴴ by
+      exact congruenceLinearEquiv_apply qσ hqσ_det (E (S.symm Y))]
+    rw [show S.symm Y = qσ⁻¹ * Y * (qσᴴ)⁻¹ by
+      exact congruenceLinearEquiv_symm_apply qσ hqσ_det Y]
+    simp only [L, weightedHilbertSchmidtMap, LinearMap.comp_apply,
+      singleKrausMap_apply, E]
+    rw [Matrix.conjTranspose_nonsing_inv, hqσ_star, hqτ_star, hsσ_star]
+    have hInput : sσ * (qσ⁻¹ * Y * qσ⁻¹) * sσ = qσ * Y * qσ := by
+      rw [← hqσ_sq]
+      calc
+        (qσ * qσ) * (qσ⁻¹ * Y * qσ⁻¹) * (qσ * qσ) =
+            qσ * (qσ * qσ⁻¹) * Y * (qσ⁻¹ * qσ) * qσ := by
+          noncomm_ring
+        _ = qσ * Y * qσ := by rw [hqσ_mul_inv, hqσ_inv_mul]; simp
+    have hOutput (Z : Matrix β β ℂ) :
+        qτ⁻¹ * (qτ⁻¹ * Z * qτ⁻¹) * qτ⁻¹ = sτ⁻¹ * Z * sτ⁻¹ := by
+      rw [← hqτ_inv_sq]
+      noncomm_ring
+    rw [hInput, hOutput]
+    rw [hsτ_inv_star]
+  have hLcp : IsKrausCP L := by
+    exact isKrausCP_comp
+      (isKrausCP_comp (singleKrausMap_isKrausCP qσ) hΦ.isKrausCP)
+      (singleKrausMap_isKrausCP qτ⁻¹)
+  let A := frobeniusEuclideanMap L
+  let T := frobeniusEuclideanLinearEquiv S
+  have hGramFrob : A.adjoint.comp A = T.conj (frobeniusEuclideanMap E) := by
+    dsimp only [A, T]
+    rw [adjoint_frobeniusEuclideanMap_eq L hLcp,
+      ← frobeniusEuclideanMap_comp, hGramTrace, frobeniusEuclideanMap_conj]
+  let V := EuclideanSpace ℂ (α × α)
+  let Acl : EuclideanSpace ℂ (α × α) →L[ℂ] EuclideanSpace ℂ (β × β) :=
+    LinearMap.toContinuousLinearMap A
+  let Ψ : (V →ₗ[ℂ] V) ≃ₐ[ℂ] (V →L[ℂ] V) :=
+    Module.End.toContinuousLinearMap V
+  have hGramCLM : Acl.adjoint.comp Acl = Ψ (T.conj (frobeniusEuclideanMap E)) := by
+    apply ContinuousLinearMap.ext
+    intro x
+    change A.adjoint (A x) = (T.conj (frobeniusEuclideanMap E)) x
+    exact DFunLike.congr_fun hGramFrob x
+  have hSpecLeft :
+      spectrum ℂ (Ψ (T.conj (frobeniusEuclideanMap E))) =
+        spectrum ℂ (T.conj (frobeniusEuclideanMap E)) :=
+    AlgEquiv.spectrum_eq Ψ (T.conj (frobeniusEuclideanMap E))
+  have hSpecConj :
+      spectrum ℂ (T.conj (frobeniusEuclideanMap E)) =
+        spectrum ℂ (frobeniusEuclideanMap E) :=
+    AlgEquiv.spectrum_eq (T.conjAlgEquiv ℂ) (frobeniusEuclideanMap E)
+  have hSpecRight :
+      spectrum ℂ (Ψ (frobeniusEuclideanMap E)) =
+        spectrum ℂ (frobeniusEuclideanMap E) :=
+    AlgEquiv.spectrum_eq Ψ (frobeniusEuclideanMap E)
+  have hRadConj :
+      spectralRadius ℂ (Ψ (T.conj (frobeniusEuclideanMap E))) =
+        spectralRadius ℂ (Ψ (frobeniusEuclideanMap E)) := by
+    rw [spectralRadius, spectralRadius, hSpecLeft, hSpecConj, hSpecRight]
+  have hRadE : spectralRadius ℂ (Ψ (frobeniusEuclideanMap E)) ≤ 1 :=
+    hEcp.spectralRadius_frobeniusEuclideanMap_le_one_of_map_one_eq_one hEone
+  have hRadGram : spectralRadius ℂ (Acl.adjoint.comp Acl) ≤ 1 := by
+    rw [hGramCLM, hRadConj]
+    exact hRadE
+  have hAx := norm_apply_le_of_spectralRadius_adjoint_comp_le_one Acl hRadGram
+    (frobeniusEquivEuclidean α α X)
+  simpa only [Acl, LinearMap.coe_toContinuousLinearMap', A,
+    frobeniusEuclideanMap_apply, LinearIsometryEquiv.norm_map] using hAx
+
+/-- The full-support weighted channel map is a Hilbert--Schmidt contraction.
+
+This is the quadratic-form formulation of
+`weightedHilbertSchmidtMap_norm_le`. -/
+theorem weightedHilbertSchmidtMap_isHilbertSchmidtContraction
+    {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    {Φ : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    {σ : Matrix α α ℂ} {τ : Matrix β β ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) (hτ : τ.PosDef)
+    (hmap : Φ σ = τ) :
+    IsHilbertSchmidtContraction (weightedHilbertSchmidtMap Φ σ τ) := by
+  intro X
+  rw [trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq,
+    trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
+  have hNorm := weightedHilbertSchmidtMap_norm_le hΦ hσ hτ hmap X
+  nlinarith [norm_nonneg (weightedHilbertSchmidtMap Φ σ τ X), norm_nonneg X]
 
 end Matrix

--- a/TNLean/Channel/WeightedHilbertSchmidt.lean
+++ b/TNLean/Channel/WeightedHilbertSchmidt.lean
@@ -284,7 +284,7 @@ theorem weightedHilbertSchmidtMap_isHilbertSchmidtContraction
   have hNorm := weightedHilbertSchmidtMap_norm_le hΦ hσ hτ hmap X
   nlinarith [norm_nonneg (weightedHilbertSchmidtMap Φ σ τ X), norm_nonneg X]
 
--- Compile-time regression check for the identity channel in a nonzero dimension.
+-- The contraction specializes to the identity channel on the two-dimensional matrix algebra.
 private theorem weightedHilbertSchmidtMap_identity_fin_two
     (X : Matrix (Fin 2) (Fin 2) ℂ) :
     ‖weightedHilbertSchmidtMap
@@ -293,7 +293,7 @@ private theorem weightedHilbertSchmidtMap_identity_fin_two
   exact weightedHilbertSchmidtMap_norm_le isKrausCPTP_id
     Matrix.PosDef.one Matrix.PosDef.one rfl X
 
--- Compile-time regression check for the zero-dimensional matrix algebra.
+-- The same specialization remains valid for the zero-dimensional matrix algebra.
 private theorem weightedHilbertSchmidtMap_identity_fin_zero
     (X : Matrix (Fin 0) (Fin 0) ℂ) :
     ‖weightedHilbertSchmidtMap

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -222,11 +222,7 @@ partial traces.
     \lean{Matrix.weightedHilbertSchmidtMap_norm_le,
         Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction}
     \leanok
-    \uses{thm:kraus_trace_adjoint_frobenius_adjoint,
-        lem:weighted_channel_transport_identities,
-        thm:unital_kraus_frobenius_spectral_radius,
-        thm:is_kraus_cptp_trace_adjoint_one,
-        def:weighted_hilbert_schmidt_map}
+    \uses{def:weighted_hilbert_schmidt_map}
     Let $I$ and $J$ be finite index sets, let
     $\Phi:\mathbb C^{I\times I}\to\mathbb C^{J\times J}$ be completely
     positive and trace preserving, and let $\sigma$ and $\tau$ be positive

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -222,7 +222,8 @@ partial traces.
     \lean{Matrix.weightedHilbertSchmidtMap_norm_le,
         Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction}
     \leanok
-    \uses{def:weighted_hilbert_schmidt_map}
+    \uses{def:is_kraus_cptp,
+        def:weighted_hilbert_schmidt_map}
     Let $I$ and $J$ be finite index sets, let
     $\Phi:\mathbb C^{I\times I}\to\mathbb C^{J\times J}$ be completely
     positive and trace preserving, and let $\sigma$ and $\tau$ be positive

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -157,6 +157,113 @@ partial traces.
     products and proves the assertion.
 \end{proof}
 
+\begin{lemma}[Transport identities for weighted channel maps]
+    \label{lem:weighted_channel_transport_identities}
+    \lean{Matrix.traceAdjointMap_comp,
+        singleKrausMap_comp,
+        Matrix.traceAdjointMap_singleKrausMap,
+        Matrix.frobeniusEuclideanLinearEquiv,
+        Matrix.frobeniusEuclideanLinearEquiv_apply,
+        Matrix.frobeniusEuclideanMap_conj}
+    \leanok
+    \uses{def:trace_pairing_adjoint,
+        def:frobenius_superoperator_transport}
+    Single-Kraus maps satisfy
+    $\mathcal K_V\circ\mathcal K_W=\mathcal K_{VW}$. Trace adjoints reverse
+    composition, and the trace adjoint of
+    $X\mapsto VXV^\dagger$ is $Y\mapsto V^\dagger YV$.  Frobenius
+    vectorization transports both linear equivalences and conjugation by such
+    equivalences.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Associativity proves the single-Kraus composition identity. The two
+    trace-adjoint assertions follow from cyclicity and non-degeneracy of the
+    trace pairing. The transport assertions follow by inserting the
+    vectorization and its inverse.
+\end{proof}
+
+\begin{theorem}[Spectral bound for a vectorized unital Kraus map]
+    \label{thm:unital_kraus_frobenius_spectral_radius}
+    \lean{IsKrausCP.spectralRadius_frobeniusEuclideanMap_le_one_of_map_one_eq_one}
+    \leanok
+    \uses{thm:unital_kraus_eigenvalue_bound,
+        def:frobenius_superoperator_transport}
+    Let $E:\mathbb C^{I\times I}\to\mathbb C^{I\times I}$ be a completely
+    positive map with $E(\Id)=\Id$.  Then the spectral radius of its
+    Frobenius transport is at most one.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:unital_kraus_eigenvalue_bound,
+        def:frobenius_superoperator_transport}
+    A unital completely positive map is contractive in the matrix operator
+    norm, so every eigenvalue has modulus at most one.  Similarity under
+    Frobenius vectorization preserves the spectrum.
+\end{proof}
+
+\begin{definition}[Full-support weighted channel map]
+    \label{def:weighted_hilbert_schmidt_map}
+    \lean{Matrix.weightedHilbertSchmidtMap}
+    \leanok
+    For matrices $\sigma\in\mathbb C^{I\times I}$ and
+    $\tau\in\mathbb C^{J\times J}$ and a complex-linear map
+    $\Phi:\mathbb C^{I\times I}\to\mathbb C^{J\times J}$, define
+    \begin{align}
+        L(X)&=\tau^{-1/4}\Phi(\sigma^{1/4}X\sigma^{1/4})\tau^{-1/4}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Full-support weighted Hilbert--Schmidt contraction]
+    \label{thm:weighted_hilbert_schmidt_contraction_full_support}
+    \lean{Matrix.weightedHilbertSchmidtMap_norm_le,
+        Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction}
+    \leanok
+    \uses{thm:kraus_trace_adjoint_frobenius_adjoint,
+        lem:weighted_channel_transport_identities,
+        thm:unital_kraus_frobenius_spectral_radius,
+        thm:is_kraus_cptp_trace_adjoint_one,
+        def:weighted_hilbert_schmidt_map}
+    Let $I$ and $J$ be finite index sets, let
+    $\Phi:\mathbb C^{I\times I}\to\mathbb C^{J\times J}$ be completely
+    positive and trace preserving, and let $\sigma$ and $\tau$ be positive
+    definite matrices satisfying $\Phi(\sigma)=\tau$.  Then, for every $X$,
+    \begin{align}
+        \left\|\tau^{-1/4}
+          \Phi(\sigma^{1/4}X\sigma^{1/4})\tau^{-1/4}\right\|_2
+        &\leq \|X\|_2.
+        \notag
+    \end{align}
+    Equivalently, $L$ is a Hilbert--Schmidt contraction.  This is the
+    full-support exponent-two specialization of
+    \cite[Theorem~6, Equation~(18)]{Beigi2013Sandwiched}; it does not assert
+    the support-compressed form for a singular output weight.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:kraus_trace_adjoint_frobenius_adjoint,
+        lem:weighted_channel_transport_identities,
+        thm:unital_kraus_frobenius_spectral_radius,
+        thm:is_kraus_cptp_trace_adjoint_one,
+        def:weighted_hilbert_schmidt_map}
+    Write $\Gamma_a(X)=aXa$.  The completely positive map
+    \begin{align}
+        E&=\Phi^*\circ\Gamma_{\tau^{1/2}}^{-1}
+             \circ\Phi\circ\Gamma_{\sigma^{1/2}}
+        \notag
+    \end{align}
+    is unital because $\Phi(\sigma)=\tau$ and trace preservation gives
+    $\Phi^*(\Id)=\Id$.  The adjoint-square of the Frobenius transport of $L$
+    is similar, by congruence with $\sigma^{1/4}$, to the Frobenius transport
+    of $E$.  Its spectral radius is therefore at most one.  Positivity and
+    self-adjointness of the adjoint-square identify its spectral radius with
+    its operator norm, which proves the contraction estimate.
+\end{proof}
+
 %% =========================================================
 \section{Further Choi-matrix identities}
 \label{sec:choi_matrix_further_identities}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -574,7 +574,8 @@ terms of operator-Schmidt rank.
     \end{align}
 \end{theorem}
 \begin{proof}
-    \uses{thm:rectangular_choi_rank_bound}
+    \uses{thm:rectangular_choi_rank_bound,
+        thm:weighted_hilbert_schmidt_contraction_full_support}
     Compress the two tensor factors to the supports of $\rho_A$ and $\rho_B$.
     This preserves both mutual information and operator-Schmidt rank, and makes
     the two marginals $\sigma=\rho_A$ and $\tau=\rho_B$ strictly positive.
@@ -591,8 +592,8 @@ terms of operator-Schmidt rank.
         L=\Gamma_\tau^{-1/2}\circ\Phi\circ\Gamma_\sigma^{1/2}.
         \notag
     \end{align}
-    Equation~(18) of \cite[Theorem~6]{Beigi2013Sandwiched} shows that $L$ is a
-    Hilbert--Schmidt contraction.  The order-two sandwiched whitening of
+    Theorem~\ref{thm:weighted_hilbert_schmidt_contraction_full_support} shows
+    that $L$ is a Hilbert--Schmidt contraction.  The order-two sandwiched whitening of
     $\rho_{AB}$ is the unnormalized Choi matrix
     \begin{align}
         W=\sum_{i,j}E_{ij}\otimes L(E_{ij}).

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -209,7 +209,15 @@ the support compression is formalized.\footnote{Formal declarations:
 \leanid{Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction} in
 \doclink{TNLean/Channel/WeightedHilbertSchmidt}.}
 This result assumes both weights are positive definite; it does not formalize
-an unrestricted support-compressed theorem for a singular output weight.
+an unrestricted support-compressed theorem for a singular output weight.  In
+particular, the Lean theorem assumes the output-faithfulness hypothesis
+$\tau>0$, which is absent from the cited source statement.  To eliminate this
+extra hypothesis, compress the output algebra to $\operatorname{supp}\tau$,
+interpret the negative quarter power as the inverse of the positive square
+root within that corner, prove the exponent-two contraction there, and
+transport the estimate back along the isometric inclusion of the support.
+This source-faithful singular-output extension is tracked in
+\href{https://github.com/LionSR/TNLean/issues/5225}{\#5225}.
 The remaining order-monotonicity and order-one-limit step is not yet
 formalized and is tracked in
 \href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  Assembly into the

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -203,10 +203,17 @@ The Choi-matrix estimate is also formalized.\footnote{Formal declarations:
 \leanid{Matrix.rectangularChoi_frobenius_parseval} and
 \leanid{Matrix.rectangularChoi_frobenius_sq_le_finrank_range} in
 \doclink{TNLean/Algebra/RectangularChoi}.}
-The two analytic inequalities are not yet formalized; they are tracked in
-\href{https://github.com/LionSR/TNLean/issues/5209}{\#5209} and
-\href{https://github.com/LionSR/TNLean/issues/5210}{\#5210}.  Their assembly
-into the sharp mutual-information theorem is tracked in
+The full-support exponent-two weighted Hilbert--Schmidt contraction used after
+the support compression is formalized.\footnote{Formal declarations:
+\leanid{Matrix.weightedHilbertSchmidtMap_norm_le} and
+\leanid{Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction} in
+\doclink{TNLean/Channel/WeightedHilbertSchmidt}.}
+This result assumes both weights are positive definite; it does not formalize
+an unrestricted support-compressed theorem for a singular output weight.
+The remaining order-monotonicity and order-one-limit step is not yet
+formalized and is tracked in
+\href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  Assembly into the
+sharp mutual-information theorem is tracked in
 \href{https://github.com/LionSR/TNLean/issues/5212}{\#5212}.
 
 \section{Diagonal matrix product operators}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -63,7 +63,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | — | L97 `tenkz` → `C-policy+C-record+R-record` |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
 | `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
-| `ch16_channel_representations_choi_and_kraus.tex` | — | L434 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | — | L541 `tenkz` → `C-policy+C-record` | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L20 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L232, 238 `tenkz` → `C-policy+C-record` | L153, 159, 336, 433 `tenkz` → `C-policy+C-record+R-record`<br>L177, 182 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -63,7 +63,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | — | L97 `tenkz` → `C-policy+C-record+R-record` |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
 | `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
-| `ch16_channel_representations_choi_and_kraus.tex` | — | L537 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | — | L538 `tenkz` → `C-policy+C-record` | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L20 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L232, 238 `tenkz` → `C-policy+C-record` | L153, 159, 336, 433 `tenkz` → `C-policy+C-record+R-record`<br>L177, 182 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -63,7 +63,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | — | L97 `tenkz` → `C-policy+C-record+R-record` |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
 | `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
-| `ch16_channel_representations_choi_and_kraus.tex` | — | L541 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | — | L537 `tenkz` → `C-policy+C-record` | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L20 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L232, 238 `tenkz` → `C-policy+C-record` | L153, 159, 336, 433 `tenkz` → `C-policy+C-record+R-record`<br>L177, 182 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |


### PR DESCRIPTION
## Summary

- prove the full-support, order-two weighted Hilbert–Schmidt contraction for rectangular Kraus CPTP maps;
- identify the Frobenius adjoint and Gram operator with the trace-adjoint construction, then transfer the spectral bound from a unital completely positive map;
- add the trace-adjoint, single-Kraus, and Frobenius transport identities used by the proof;
- record concrete identity-channel specializations for `Fin 2` and `Fin 0`;
- synchronize the blueprint and the MPDO mutual-information paper-gap record.

## Mathematical scope

This pull request formalizes
\[
L(X)=\tau^{-1/4}\Phi(\sigma^{1/4}X\sigma^{1/4})\tau^{-1/4},
\qquad \|L(X)\|_2\leq\|X\|_2,
\]
under `IsKrausCPTP Φ`, `σ.PosDef`, `τ.PosDef`, and `Φ σ = τ`.
It is precisely the full-support `p = 2` specialization used after the marginal-support compression in the MPDO argument. It does not claim that CPTP maps preserve faithfulness, nor does it claim Beigi's unrestricted singular-output statement. The latter requires a support-restricted inverse and is tracked separately in #5225.

Source: S. Beigi, *Sandwiched Rényi Divergence Satisfies Data Processing Inequality*, Theorem 6 and equation (18), arXiv:1306.5920.

Paper-gap record: `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`.

## Proof outline

For
\[
E=\Phi^*\circ\Gamma_{\tau^{1/2}}^{-1}\circ\Phi\circ\Gamma_{\sigma^{1/2}},
\]
complete positivity follows from the Kraus representation, while `Φ σ = τ` and trace preservation give `E(1)=1`. The Frobenius Gram operator of `L` is similar, by congruence with `σ^{1/4}`, to the Frobenius transport of `E`. The unital Kraus spectral bound therefore gives spectral radius at most one. Since the Gram operator is self-adjoint, its spectral radius is its operator norm, yielding the contraction.

## Validation

- full `lake build` (9,856 tasks);
- focused module build and direct Lean compilation;
- `leanblueprint web` and declaration checking;
- tenkz disposition reconciliation;
- proof-integrity, tactic-pattern, prose, style, and whitespace checks;
- two independent exact-head reviews at `6ec87fce3217665a49f99274eb195199c0283cdf`.

Closes #5210.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is substantial new analytic Lean (large `WeightedHilbertSchmidt` proof) on quantum channel theory, but it stays in finite-dimensional matrix algebra with explicit scope limits (full support only); remaining Rényi assembly is still open in other issues.
> 
> **Overview**
> Formalizes Beigi’s **full-support, order-two** weighted Hilbert–Schmidt contraction for Kraus CPTP maps: for positive definite weights with `Φ σ = τ`, the map `L(X) = τ^{-1/4} Φ(σ^{1/4} X σ^{1/4}) τ^{-1/4}` satisfies `‖L(X)‖₂ ≤ ‖X‖₂`.
> 
> The proof is built from new **transport and adjoint infrastructure**—Frobenius linear-equivalence transport and conjugation, trace-adjoint composition, single-Kraus composition/adjoint lemmas, and a **spectral-radius bound** for vectorized unital Kraus maps—then identifies the Gram operator of `L` with a unital CP map and bounds it via spectral radius.
> 
> **Blueprint** chapter 16 and the MPDO mutual-information paper-gap doc are updated to cite the Lean theorems; the ch21 proof now references the formal weighted contraction instead of an external citation alone. Singular-output / support-compressed variants remain tracked separately (#5225).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6bc417df815899b5456c51b9edf7581a3abfa78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->