### PR TITLE
feat(Channel): prove full-support whitened Choi estimate

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -72,6 +72,7 @@ import TNLean.Channel.SupportedMarginalChannel
 import TNLean.Channel.TensorMap
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WeightedHilbertSchmidt
+import TNLean.Channel.WhitenedChoi
 import TNLean.Channel.WolfChapter2Index
 import TNLean.Channel.WolfChapter6Index
 import TNLean.Channel.WolfChapter6Wrappers

--- a/TNLean/Channel/SupportedMarginalChannel.lean
+++ b/TNLean/Channel/SupportedMarginalChannel.lean
@@ -35,6 +35,8 @@ is not asserted here.
 
 ## Main statements
 
+* `Matrix.supportedMarginalMap_diagonal`: the supported-marginal map sends the
+  diagonal marginal density to the second marginal.
 * `Matrix.supportedMarginalInputScaling_surjective`: positivity of every
   marginal eigenvalue makes the scaling invertible.
 * `Matrix.range_supportedMarginalMap`: the resulting map has the same range as
@@ -192,6 +194,37 @@ theorem supportedMarginalMap_trace
     exact (pow_two (Real.sqrt (p i))).symm.trans (Real.sq_sqrt (le_of_lt (hp i)))
   rw [← hsq]
   field_simp
+
+omit [Fintype β] [DecidableEq β] in
+/-- The supported-marginal map sends the diagonal first marginal to the
+second marginal.
+
+This is the identity \(\Phi(\sigma)=\tau\) in the state--channel
+correspondence used in Beigi, arXiv:1306.5920, Theorem 6, equation (18). -/
+theorem supportedMarginalMap_diagonal
+    (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
+    (hp : ∀ i, 0 < p i) :
+    supportedMarginalMap ρ p (diagonal fun i ↦ (p i : ℂ)) =
+      partialTraceLeft ρ := by
+  ext a b
+  rw [supportedMarginalMap_apply, partialTraceLeft_apply]
+  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, operatorBlock]
+  rw [Fintype.sum_prod_type]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.sum_eq_single i]
+  · simp only [Matrix.diagonal_apply, if_pos, marginalInvSqrt]
+    have hi : (Real.sqrt (p i) : ℂ) ≠ 0 := by
+      exact_mod_cast ne_of_gt (Real.sqrt_pos.2 (hp i))
+    have hsq : (Real.sqrt (p i) : ℂ) * (Real.sqrt (p i) : ℂ) = (p i : ℂ) := by
+      norm_cast
+      exact (pow_two (Real.sqrt (p i))).symm.trans
+        (Real.sq_sqrt (le_of_lt (hp i)))
+    rw [← hsq]
+    field_simp
+  · intro j _ hji
+    simp [Ne.symm hji]
+  · simp
 
 /-- Positivity of the bipartite operator gives a rectangular Kraus
 representation of its supported-marginal map. -/

--- a/TNLean/Channel/SupportedMarginalChannel.lean
+++ b/TNLean/Channel/SupportedMarginalChannel.lean
@@ -199,8 +199,10 @@ omit [Fintype β] [DecidableEq β] in
 /-- The supported-marginal map sends the diagonal first marginal to the
 second marginal.
 
-This is the identity \(\Phi(\sigma)=\tau\) in the state--channel
-correspondence used in Beigi, arXiv:1306.5920, Theorem 6, equation (18). -/
+This normalization identity is needed to apply the weighted estimate from
+Beigi, arXiv:1306.5920, Theorem 6, equation (18), to the state--channel
+correspondence.  It follows directly from the partial-trace definitions and
+is not stated separately by Beigi. -/
 theorem supportedMarginalMap_diagonal
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hp : ∀ i, 0 < p i) :

--- a/TNLean/Channel/WhitenedChoi.lean
+++ b/TNLean/Channel/WhitenedChoi.lean
@@ -357,8 +357,8 @@ Theorem 6, equation (18), with the rectangular Choi rank estimate.
 **Scope restriction (faithful marginal supports):** Both marginals are
 positive definite in the displayed coordinates.  Two-sided compression of
 singular ambient marginals, including preservation of operator-Schmidt rank,
-is tracked in issue #5211; construction of the output support corner is
-tracked separately in issue #5225.  Both gaps are recorded in
+and construction of the output support corner are distinct remaining steps,
+as recorded in
 `docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
@@ -403,7 +403,7 @@ arXiv:1306.5920, Theorem 6, equation (18).
 **Scope restriction (faithful marginal supports):** The two-sided compression
 from singular ambient marginals to their supports, including preservation of
 operator-Schmidt rank, remains to be proved as recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` and issue #5211. -/
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)

--- a/TNLean/Channel/WhitenedChoi.lean
+++ b/TNLean/Channel/WhitenedChoi.lean
@@ -1,0 +1,377 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.SupportedMarginalChannel
+import TNLean.Channel.WeightedHilbertSchmidt
+
+/-!
+# Whitened bipartite operators as Choi matrices
+
+This file combines the supported-marginal channel, the full-support weighted
+Hilbert--Schmidt contraction, and the rectangular Choi rank estimate.  The
+first marginal is written in an eigenbasis, so its transpose is equal to
+itself.  The input transpose nevertheless appears explicitly in the general
+Choi covariance identity below.
+
+## Main declarations
+
+* `Matrix.rectangularChoi_singleKrausMap_comp_comp`: Choi covariance under
+  input and output congruences, including the input transpose.
+* `Matrix.supportedMarginalWhitenedState`: the order-two whitened bipartite
+  operator in a first-marginal eigenbasis.
+* `Matrix.supportedMarginalWhitenedState_eq_rectangularChoi`: the whitened
+  operator is exactly the Choi matrix of the weighted supported-marginal map.
+* `Matrix.supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank`:
+  the full-support whitened Choi estimate.
+
+## References
+
+* S. Beigi, *Sandwiched Rényi Divergence Satisfies Data Processing
+  Inequality*, J. Math. Phys. 54 (2013), 122202, arXiv:1306.5920,
+  Theorem 6 and equation (18).
+-/
+
+open scoped Matrix BigOperators ComplexOrder Kronecker MatrixOrder
+  Matrix.Norms.Frobenius
+
+namespace Matrix
+
+variable {α β : Type*} [Fintype α] [DecidableEq α]
+  [Fintype β] [DecidableEq β]
+
+omit [DecidableEq β] in
+/-- Choi matrices transform under input and output congruences with the
+transpose of the input congruence matrix.
+
+The transpose is forced by the convention
+`J(L)_{(i,a),(j,b)} = L(Eᵢⱼ)_{a,b}`. -/
+theorem rectangularChoi_singleKrausMap_comp_comp
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (A : Matrix α α ℂ) (B : Matrix β β ℂ) :
+    rectangularChoi ((singleKrausMap B).comp (Φ.comp (singleKrausMap A))) =
+      singleKrausMap (A.transpose ⊗ₖ B) (rectangularChoi Φ) := by
+  have hinput (i j : α) :
+      A * single i j 1 * Aᴴ =
+        ∑ r, ∑ s, (A r i * star (A s j)) • single r s 1 := by
+    rw [matrix_eq_sum_single (A * single i j 1 * Aᴴ)]
+    apply Finset.sum_congr rfl
+    intro r _
+    apply Finset.sum_congr rfl
+    intro s _
+    rw [Matrix.smul_single]
+    congr 1
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.single,
+      Matrix.of_apply, mul_ite, mul_one, mul_zero]
+    rw [Finset.sum_eq_single j]
+    · rw [Finset.sum_eq_single i]
+      · simp
+      · intro x _ hxi
+        simp [Ne.symm hxi]
+      · simp
+    · intro x _ hx
+      simp [Ne.symm hx]
+    · simp
+  ext ⟨i, a⟩ ⟨j, b⟩
+  rw [rectangularChoi_apply]
+  simp only [LinearMap.comp_apply, singleKrausMap_apply, hinput,
+    map_sum, map_smul, Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul,
+    Matrix.mul_apply, Matrix.kroneckerMap_apply,
+    Matrix.conjTranspose_kronecker, Matrix.conjTranspose_apply,
+    Matrix.transpose_apply]
+  simp_rw [Fintype.sum_prod_type, Finset.mul_sum, Finset.sum_mul]
+  simp_rw [rectangularChoi_apply, Finset.mul_sum]
+  let f : α → α → β → β → ℂ := fun r s d c ↦
+    A r i * star (A s j) *
+      (B a c * Φ (single r s 1) c d * star (B b d))
+  change (∑ r, ∑ s, ∑ d, ∑ c, f r s d c) = _
+  calc
+    (∑ r, ∑ s, ∑ d, ∑ c, f r s d c) =
+        ∑ s, ∑ d, ∑ r, ∑ c, f r s d c := by
+      rw [Finset.sum_comm]
+      apply Finset.sum_congr rfl
+      intro s _
+      rw [Finset.sum_comm]
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro s _
+      apply Finset.sum_congr rfl
+      intro d _
+      apply Finset.sum_congr rfl
+      intro r _
+      apply Finset.sum_congr rfl
+      intro c _
+      dsimp only [f]
+      ring
+
+/-- The positive fourth root of a diagonal marginal, written entrywise in its
+eigenbasis. -/
+noncomputable def diagonalMarginalQuarter (p : α → ℝ) : Matrix α α ℂ :=
+  diagonal fun i ↦ (Real.sqrt (Real.sqrt (p i)) : ℂ)
+
+/-- The iterated functional-calculus square root of a faithful diagonal
+marginal agrees with its entrywise positive fourth root. -/
+theorem sqrt_sqrt_diagonal_eq_diagonalMarginalQuarter
+    (p : α → ℝ) (hp : ∀ i, 0 < p i) :
+    CFC.sqrt (CFC.sqrt (diagonal fun i ↦ (p i : ℂ))) =
+      diagonalMarginalQuarter p := by
+  have hdiag : (diagonal fun i ↦ (p i : ℂ)).PosSemidef :=
+    PosSemidef.diagonal fun i ↦
+      (RCLike.ofReal_nonneg (K := ℂ)).2 (le_of_lt (hp i))
+  have hsqrt : CFC.sqrt (diagonal fun i ↦ (p i : ℂ)) =
+      diagonal fun i ↦ (Real.sqrt (p i) : ℂ) := by
+    rw [CFC.sqrt_eq_real_sqrt _ hdiag.nonneg, cfcₙ_eq_cfc,
+      cfc_diagonal p Real.sqrt]
+  have hsqrtDiag : (diagonal fun i ↦ (Real.sqrt (p i) : ℂ)).PosSemidef :=
+    PosSemidef.diagonal fun i ↦
+      (RCLike.ofReal_nonneg (K := ℂ)).2 (Real.sqrt_nonneg (p i))
+  rw [hsqrt, CFC.sqrt_eq_real_sqrt _ hsqrtDiag.nonneg, cfcₙ_eq_cfc,
+    cfc_diagonal (fun i ↦ Real.sqrt (p i)) Real.sqrt]
+  rfl
+
+/-- The diagonal matrix implementing the inverse-square-root input scaling of
+the supported-marginal channel. -/
+noncomputable def marginalInvSqrtDiagonal (p : α → ℝ) : Matrix α α ℂ :=
+  diagonal (marginalInvSqrt p)
+
+/-- The supported-marginal input scaling is congruence by the diagonal inverse
+square root. -/
+theorem supportedMarginalInputScaling_eq_singleKrausMap
+    (p : α → ℝ) :
+    supportedMarginalInputScaling p = singleKrausMap (marginalInvSqrtDiagonal p) := by
+  apply LinearMap.ext
+  intro X
+  ext i j
+  simp [supportedMarginalInputScaling, singleKrausMap_apply,
+    marginalInvSqrtDiagonal, Matrix.mul_apply, marginalInvSqrt,
+    Matrix.diagonal_apply]
+
+omit [DecidableEq β] in
+/-- The Choi matrix of the operator-Schmidt reshaping is the original
+bipartite matrix in the natural input--output ordering. -/
+theorem rectangularChoi_operatorSchmidtMap
+    (ρ : Matrix (α × β) (α × β) ℂ) :
+    rectangularChoi (operatorSchmidtMap ρ) = ρ := by
+  ext ⟨i, a⟩ ⟨j, b⟩
+  rw [rectangularChoi_apply, operatorSchmidtMap_apply]
+  simp only [Matrix.sum_apply, Matrix.smul_apply]
+  rw [Fintype.sum_prod_type]
+  rw [Finset.sum_eq_single i]
+  · rw [Finset.sum_eq_single j]
+    · simp [operatorBlock]
+    · intro k _ hkj
+      simp [Matrix.single, Ne.symm hkj]
+    · simp
+  · intro k _ hki
+    simp [Matrix.single, Ne.symm hki]
+  · simp
+
+/-- One inverse-square-root factor cancels one diagonal fourth-root factor. -/
+theorem marginalInvSqrtDiagonal_mul_diagonalMarginalQuarter
+    (p : α → ℝ) (hp : ∀ i, 0 < p i) :
+    marginalInvSqrtDiagonal p * diagonalMarginalQuarter p =
+      (diagonalMarginalQuarter p)⁻¹ := by
+  have hq (i : α) : (Real.sqrt (Real.sqrt (p i)) : ℂ) ≠ 0 := by
+    exact_mod_cast ne_of_gt (Real.sqrt_pos.2 (Real.sqrt_pos.2 (hp i)))
+  have hqdet : (diagonalMarginalQuarter p).det ≠ 0 := by
+    rw [diagonalMarginalQuarter, Matrix.det_diagonal]
+    exact Finset.prod_ne_zero_iff.mpr fun i _ ↦ hq i
+  have hprod : marginalInvSqrtDiagonal p * diagonalMarginalQuarter p *
+      diagonalMarginalQuarter p = 1 := by
+    rw [marginalInvSqrtDiagonal, diagonalMarginalQuarter,
+      Matrix.diagonal_mul_diagonal, Matrix.diagonal_mul_diagonal]
+    ext i j
+    by_cases hij : i = j
+    · subst j
+      simp only [Matrix.diagonal_apply, if_pos, marginalInvSqrt]
+      have hsqrt : (Real.sqrt (p i) : ℂ) ≠ 0 := by
+        exact_mod_cast ne_of_gt (Real.sqrt_pos.2 (hp i))
+      have hsq : (Real.sqrt (Real.sqrt (p i)) : ℂ) ^ 2 =
+          (Real.sqrt (p i) : ℂ) := by
+        norm_cast
+        exact Real.sq_sqrt (Real.sqrt_nonneg (p i))
+      rw [← hsq]
+      field_simp
+      simp [hq i]
+    · simp [hij]
+  calc
+    marginalInvSqrtDiagonal p * diagonalMarginalQuarter p =
+        (marginalInvSqrtDiagonal p * diagonalMarginalQuarter p) *
+          (diagonalMarginalQuarter p * (diagonalMarginalQuarter p)⁻¹) := by
+      rw [Matrix.mul_nonsing_inv _ (Ne.isUnit hqdet), Matrix.mul_one]
+    _ = (marginalInvSqrtDiagonal p * diagonalMarginalQuarter p *
+          diagonalMarginalQuarter p) * (diagonalMarginalQuarter p)⁻¹ := by
+      noncomm_ring
+    _ = (diagonalMarginalQuarter p)⁻¹ := by rw [hprod, Matrix.one_mul]
+
+/-- The order-two whitened bipartite operator in an eigenbasis of its faithful
+first marginal.
+
+If `σ = diagonal p`, then `σ.transpose = σ`; hence this is
+\((\sigma^T\otimes\tau)^{-1/4}\rho
+(\sigma^T\otimes\tau)^{-1/4}\) in the natural `α × β` ordering. -/
+noncomputable def supportedMarginalWhitenedState
+    (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ) (τ : Matrix β β ℂ) :
+    Matrix (α × β) (α × β) ℂ :=
+  singleKrausMap
+    ((diagonalMarginalQuarter p)⁻¹ ⊗ₖ
+      (CFC.sqrt (CFC.sqrt τ))⁻¹) ρ
+
+/-- In a faithful first-marginal eigenbasis, the order-two whitened state is
+exactly the unnormalized Choi matrix of the weighted supported-marginal map.
+
+The input transpose is explicit in
+`rectangularChoi_singleKrausMap_comp_comp` and disappears here only because
+the first marginal and its positive fourth root are diagonal.  This is the
+finite-dimensional Choi identification used after Beigi, arXiv:1306.5920,
+Theorem 6, equation (18). -/
+theorem supportedMarginalWhitenedState_eq_rectangularChoi
+    (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
+    (τ : Matrix β β ℂ) (hp : ∀ i, 0 < p i) :
+    supportedMarginalWhitenedState ρ p τ =
+      rectangularChoi
+        (weightedHilbertSchmidtMap (supportedMarginalMap ρ p)
+          (diagonal fun i ↦ (p i : ℂ)) τ) := by
+  let σ : Matrix α α ℂ := diagonal fun i ↦ (p i : ℂ)
+  let qσ := CFC.sqrt (CFC.sqrt σ)
+  let qτ := CFC.sqrt (CFC.sqrt τ)
+  let D := marginalInvSqrtDiagonal p
+  have hqσ : qσ = diagonalMarginalQuarter p := by
+    exact sqrt_sqrt_diagonal_eq_diagonalMarginalQuarter p hp
+  have hscaling : supportedMarginalInputScaling p = singleKrausMap D := by
+    exact supportedMarginalInputScaling_eq_singleKrausMap p
+  have hDq : D * qσ = (diagonalMarginalQuarter p)⁻¹ := by
+    rw [hqσ]
+    exact marginalInvSqrtDiagonal_mul_diagonalMarginalQuarter p hp
+  have hL : weightedHilbertSchmidtMap (supportedMarginalMap ρ p) σ τ =
+      (singleKrausMap qτ⁻¹).comp
+        ((operatorSchmidtMap ρ).comp (singleKrausMap (D * qσ))) := by
+    apply LinearMap.ext
+    intro X
+    simp only [weightedHilbertSchmidtMap, supportedMarginalMap, σ, qσ, qτ,
+      LinearMap.comp_apply, hscaling]
+    rw [← DFunLike.congr_fun (singleKrausMap_comp D qσ) X]
+    rfl
+  have htranspose :
+      ((diagonalMarginalQuarter p)⁻¹).transpose =
+        (diagonalMarginalQuarter p)⁻¹ := by
+    rw [Matrix.transpose_nonsing_inv]
+    congr 1
+    simp [diagonalMarginalQuarter]
+  rw [show (diagonal fun i ↦ (p i : ℂ)) = σ from rfl, hL]
+  rw [rectangularChoi_singleKrausMap_comp_comp,
+    rectangularChoi_operatorSchmidtMap, hDq, htranspose]
+  rfl
+
+/-- Pre- and post-composition by linear equivalences preserve the dimension of
+the range of a linear map. -/
+theorem finrank_range_equiv_comp_comp_equiv
+    {K U U' V V' : Type*} [Field K]
+    [AddCommGroup U] [Module K U] [AddCommGroup U'] [Module K U']
+    [AddCommGroup V] [Module K V] [AddCommGroup V'] [Module K V']
+    (A : V ≃ₗ[K] V') (L : U →ₗ[K] V) (B : U' ≃ₗ[K] U) :
+    Module.finrank K (LinearMap.range
+      (A.toLinearMap.comp (L.comp B.toLinearMap))) =
+      Module.finrank K (LinearMap.range L) := by
+  change Module.finrank K (LinearMap.range
+    ((A.toLinearMap.comp L).comp B.toLinearMap)) = _
+  rw [LinearMap.range_comp_of_range_eq_top _ B.range]
+  rw [LinearMap.range_comp]
+  exact LinearEquiv.finrank_map_eq A L.range
+
+/-- A single-Kraus congruence by an invertible matrix is the corresponding
+linear equivalence. -/
+theorem singleKrausMap_eq_congruenceLinearEquiv
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (C : Matrix ι ι ℂ) (hC : C.det ≠ 0) :
+    singleKrausMap C = (congruenceLinearEquiv C hC).toLinearMap := by
+  apply LinearMap.ext
+  intro X
+  exact congruenceLinearEquiv_apply C hC X |>.symm
+
+/-- Invertible modular congruences preserve the linear rank of the weighted
+Hilbert--Schmidt map. -/
+theorem finrank_range_weightedHilbertSchmidtMap
+    (Φ : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (σ : Matrix α α ℂ) (τ : Matrix β β ℂ)
+    (hσ : σ.PosDef) (hτ : τ.PosDef) :
+    Module.finrank ℂ (LinearMap.range
+      (weightedHilbertSchmidtMap Φ σ τ)) =
+      Module.finrank ℂ (LinearMap.range Φ) := by
+  let qσ := CFC.sqrt (CFC.sqrt σ)
+  let qτ := CFC.sqrt (CFC.sqrt τ)
+  have hsσ_psd : (CFC.sqrt σ).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg σ)
+  have hsτ_psd : (CFC.sqrt τ).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg τ)
+  have hqσ_unit : IsUnit qσ :=
+    (CFC.isUnit_sqrt_iff (CFC.sqrt σ) hsσ_psd.nonneg).2
+      ((CFC.isUnit_sqrt_iff σ hσ.posSemidef.nonneg).2 hσ.isUnit)
+  have hqτ_unit : IsUnit qτ :=
+    (CFC.isUnit_sqrt_iff (CFC.sqrt τ) hsτ_psd.nonneg).2
+      ((CFC.isUnit_sqrt_iff τ hτ.posSemidef.nonneg).2 hτ.isUnit)
+  have hqσ_det : qσ.det ≠ 0 :=
+    ((Matrix.isUnit_iff_isUnit_det qσ).1 hqσ_unit).ne_zero
+  have hqτ_det : qτ.det ≠ 0 :=
+    ((Matrix.isUnit_iff_isUnit_det qτ).1 hqτ_unit).ne_zero
+  have hqτ_inv_det : qτ⁻¹.det ≠ 0 :=
+    (Matrix.isUnit_nonsing_inv_det (A := qτ) (Ne.isUnit hqτ_det)).ne_zero
+  rw [show weightedHilbertSchmidtMap Φ σ τ =
+      (congruenceLinearEquiv qτ⁻¹ hqτ_inv_det).toLinearMap.comp
+        (Φ.comp (congruenceLinearEquiv qσ hqσ_det).toLinearMap) by
+    dsimp only [weightedHilbertSchmidtMap, qσ, qτ]
+    rw [singleKrausMap_eq_congruenceLinearEquiv,
+      singleKrausMap_eq_congruenceLinearEquiv]]
+  exact finrank_range_equiv_comp_comp_equiv
+    (congruenceLinearEquiv qτ⁻¹ hqτ_inv_det) Φ
+    (congruenceLinearEquiv qσ hqσ_det)
+
+/-- **Full-support, eigenbasis whitened Choi estimate.**  For a positive
+bipartite operator whose first marginal is faithful and diagonal, and whose
+second marginal is positive definite, the squared Frobenius norm of its
+order-two whitening is at most its operator-Schmidt rank.
+
+This combines the `p = 2` contraction from Beigi, arXiv:1306.5920,
+Theorem 6, equation (18), with the rectangular Choi rank estimate.
+
+**Scope restriction (faithful marginal supports):** Both marginals are
+positive definite in the displayed coordinates.  Compression of singular
+ambient marginals to their supports, and transport back to the ambient
+spaces, is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` and tracked in
+issue #5225. -/
+theorem supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
+    (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
+    (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)
+    (hA : partialTraceRight ρ = diagonal fun i ↦ (p i : ℂ))
+    (hB : (partialTraceLeft ρ).PosDef) :
+    ‖supportedMarginalWhitenedState ρ p (partialTraceLeft ρ)‖ ^ 2 ≤
+      operatorSchmidtRank ρ := by
+  have hdiag : (diagonal fun i ↦ (p i : ℂ)).PosDef := by
+    rw [posDef_diagonal_iff]
+    intro i
+    exact_mod_cast hp i
+  have hmap := supportedMarginalMap_diagonal ρ p hp
+  have hcontraction := weightedHilbertSchmidtMap_isHilbertSchmidtContraction
+    (supportedMarginalMap_isKrausCPTP ρ p hρ hp hA) hdiag hB hmap
+  rw [supportedMarginalWhitenedState_eq_rectangularChoi ρ p _ hp]
+  calc
+    ‖rectangularChoi
+      (weightedHilbertSchmidtMap
+        (supportedMarginalMap ρ p)
+        (diagonal fun i ↦ (p i : ℂ))
+        (partialTraceLeft ρ))‖ ^ 2
+        ≤ Module.finrank ℂ (LinearMap.range
+          (weightedHilbertSchmidtMap
+            (supportedMarginalMap ρ p)
+            (diagonal fun i ↦ (p i : ℂ))
+            (partialTraceLeft ρ))) :=
+      rectangularChoi_frobenius_sq_le_finrank_range _ hcontraction
+    _ = Module.finrank ℂ (LinearMap.range (supportedMarginalMap ρ p)) := by
+      exact_mod_cast finrank_range_weightedHilbertSchmidtMap
+        (supportedMarginalMap ρ p) _ _ hdiag hB
+    _ = operatorSchmidtRank ρ := by
+      exact_mod_cast finrank_range_supportedMarginalMap ρ p hp
+
+end Matrix

--- a/TNLean/Channel/WhitenedChoi.lean
+++ b/TNLean/Channel/WhitenedChoi.lean
@@ -355,11 +355,11 @@ This combines the `p = 2` contraction from Beigi, arXiv:1306.5920,
 Theorem 6, equation (18), with the rectangular Choi rank estimate.
 
 **Scope restriction (faithful marginal supports):** Both marginals are
-positive definite in the displayed coordinates.  Compression of singular
-ambient marginals to their supports, and transport back to the ambient
-spaces, is recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` and tracked in
-issue #5225. -/
+positive definite in the displayed coordinates.  Two-sided compression of
+singular ambient marginals, including preservation of operator-Schmidt rank,
+is tracked in issue #5211; construction of the output support corner is
+tracked separately in issue #5225.  Both gaps are recorded in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)

--- a/TNLean/Channel/WhitenedChoi.lean
+++ b/TNLean/Channel/WhitenedChoi.lean
@@ -19,12 +19,16 @@ Choi covariance identity below.
 
 * `Matrix.rectangularChoi_singleKrausMap_comp_comp`: Choi covariance under
   input and output congruences, including the input transpose.
-* `Matrix.supportedMarginalWhitenedState`: the order-two whitened bipartite
-  operator in a first-marginal eigenbasis.
-* `Matrix.supportedMarginalWhitenedState_eq_rectangularChoi`: the whitened
-  operator is exactly the Choi matrix of the weighted supported-marginal map.
+* `Matrix.supportedMarginalWhitenedState`: the raw congruence used for
+  order-two whitening in a first-marginal eigenbasis.
+* `Matrix.supportedMarginalWhitenedState_posSemidef`: the defining congruence
+  preserves positive semidefiniteness.
+* `Matrix.supportedMarginalWhitenedState_eq_rectangularChoi`: this congruence
+  is exactly the Choi matrix of the weighted supported-marginal map.
 * `Matrix.supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank`:
   the full-support whitened Choi estimate.
+* `Matrix.supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank`:
+  the full-support estimate in trace-square form.
 
 ## References
 
@@ -205,12 +209,15 @@ theorem marginalInvSqrtDiagonal_mul_diagonalMarginalQuarter
       noncomm_ring
     _ = (diagonalMarginalQuarter p)⁻¹ := by rw [hprod, Matrix.one_mul]
 
-/-- The order-two whitened bipartite operator in an eigenbasis of its faithful
-first marginal.
+/-- The raw same-factor congruence used for order-two whitening in an
+eigenbasis of the first marginal.
 
-If `σ = diagonal p`, then `σ.transpose = σ`; hence this is
+If `σ = diagonal p` and `τ` is positive definite, then
+`σ.transpose = σ`; hence this is
 \((\sigma^T\otimes\tau)^{-1/4}\rho
-(\sigma^T\otimes\tau)^{-1/4}\) in the natural `α × β` ordering. -/
+(\sigma^T\otimes\tau)^{-1/4}\) in the natural `α × β` ordering.  For an
+arbitrary `τ`, this definition denotes only the displayed raw congruence; no
+identification with the inverse fourth power of `τ` is asserted. -/
 noncomputable def supportedMarginalWhitenedState
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ) (τ : Matrix β β ℂ) :
     Matrix (α × β) (α × β) ℂ :=
@@ -218,14 +225,26 @@ noncomputable def supportedMarginalWhitenedState
     ((diagonalMarginalQuarter p)⁻¹ ⊗ₖ
       (CFC.sqrt (CFC.sqrt τ))⁻¹) ρ
 
-/-- In a faithful first-marginal eigenbasis, the order-two whitened state is
-exactly the unnormalized Choi matrix of the weighted supported-marginal map.
+/-- The raw congruence defining `supportedMarginalWhitenedState` preserves
+positive semidefiniteness.  When the two marginal weights are positive
+definite, this is positivity of the order-two whitened operator. -/
+theorem supportedMarginalWhitenedState_posSemidef
+    (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
+    (τ : Matrix β β ℂ) (hρ : ρ.PosSemidef) :
+    (supportedMarginalWhitenedState ρ p τ).PosSemidef := by
+  unfold supportedMarginalWhitenedState singleKrausMap
+  exact hρ.mul_mul_conjTranspose_same _
+
+/-- In a first-marginal eigenbasis, the raw congruence defining
+`supportedMarginalWhitenedState` is exactly the unnormalized Choi matrix of
+the weighted supported-marginal map.
 
 The input transpose is explicit in
 `rectangularChoi_singleKrausMap_comp_comp` and disappears here only because
-the first marginal and its positive fourth root are diagonal.  This is the
-finite-dimensional Choi identification used after Beigi, arXiv:1306.5920,
-Theorem 6, equation (18). -/
+the first marginal and its positive fourth root are diagonal.  When `τ` is
+positive definite, the raw congruence is the order-two whitening used after
+Beigi, arXiv:1306.5920, Theorem 6, equation (18); without this hypothesis, the
+theorem is only the algebraic Choi identity displayed in its statement. -/
 theorem supportedMarginalWhitenedState_eq_rectangularChoi
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (τ : Matrix β β ℂ) (hp : ∀ i, 0 < p i) :
@@ -373,5 +392,37 @@ theorem supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
         (supportedMarginalMap ρ p) _ _ hdiag hB
     _ = operatorSchmidtRank ρ := by
       exact_mod_cast finrank_range_supportedMarginalMap ρ p hp
+
+/-- **Full-support, eigenbasis trace-square estimate.**  Under faithful
+marginal weights, the whitened operator is positive semidefinite and the real
+trace of its square is at most its operator-Schmidt rank.
+
+This is the trace-square form of the order-two estimate used after Beigi,
+arXiv:1306.5920, Theorem 6, equation (18).
+
+**Scope restriction (faithful marginal supports):** The two-sided compression
+from singular ambient marginals to their supports, including preservation of
+operator-Schmidt rank, remains to be proved as recorded in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex` and issue #5211. -/
+theorem supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank
+    (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
+    (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)
+    (hA : partialTraceRight ρ = diagonal fun i ↦ (p i : ℂ))
+    (hB : (partialTraceLeft ρ).PosDef) :
+    (trace (supportedMarginalWhitenedState ρ p (partialTraceLeft ρ) *
+      supportedMarginalWhitenedState ρ p (partialTraceLeft ρ))).re ≤
+      operatorSchmidtRank ρ := by
+  have hW := supportedMarginalWhitenedState_posSemidef
+    ρ p (partialTraceLeft ρ) hρ
+  calc
+    (trace (supportedMarginalWhitenedState ρ p (partialTraceLeft ρ) *
+      supportedMarginalWhitenedState ρ p (partialTraceLeft ρ))).re =
+        (trace ((supportedMarginalWhitenedState ρ p (partialTraceLeft ρ))ᴴ *
+          supportedMarginalWhitenedState ρ p (partialTraceLeft ρ))).re := by
+      rw [hW.isHermitian.eq]
+    _ ≤ operatorSchmidtRank ρ := by
+      rw [trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
+      exact supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
+        ρ p hρ hp hA hB
 
 end Matrix

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -419,8 +419,15 @@
         &=\frac{\rho_{ij}}{\sqrt{p_ip_j}}.
         \notag
     \end{align}
-    Then $\Phi_\rho$ is completely positive and trace preserving,
-    $\dim\range\Phi_\rho=\operatorname{OSR}(\rho)$, and application of
+    Write $\sigma=\diag(p_1,\ldots,p_{d_A})$ and
+    $\tau=\tr_A\rho$. Then $\Phi_\rho$ is completely positive and trace
+    preserving,
+    \begin{align}
+        \Phi_\rho(\sigma)&=\tau,
+        &\dim\range\Phi_\rho&=\operatorname{OSR}(\rho),
+        \notag
+    \end{align}
+    and application of
     $\Phi_\rho$ to the first half of
     $\sum_{i,j}\sqrt{p_ip_j}\,E_{ij}\otimes E_{ij}$, followed by restoring the
     order of the two factors, reconstructs $\rho$.
@@ -428,8 +435,9 @@
 \begin{proof}\leanok
     Strict positivity of the $p_i$ makes the entrywise input scaling
     invertible, so it does not change the range. Positivity of $\rho$ gives a
-    Kraus representation of $\Phi_\rho$, while the displayed marginal equation
-    gives trace preservation. Substitution on matrix units proves the
+    Kraus representation of $\Phi_\rho$, while the first marginal equation
+    gives trace preservation. Summing the diagonal blocks gives
+    $\Phi_\rho(\sigma)=\tau$. Substitution on matrix units proves the
     reconstruction identity. This is the finite-dimensional Choi
     representation \cite{Choi1975CompletelyPositive} with the input marginal
     absorbed into the canonical purification.
@@ -614,16 +622,24 @@ terms of operator-Schmidt rank.
 
 \begin{theorem}[Full-support eigenbasis whitened Choi estimate]
     \label{thm:full_support_eigenbasis_whitened_choi_bound}
-    \lean{Matrix.supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank}
+    \lean{Matrix.supportedMarginalWhitenedState_posSemidef,
+      Matrix.supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank,
+      Matrix.supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank}
     \leanok
     \uses{thm:full_support_eigenbasis_whitening_choi,
       thm:rectangular_choi_rank_bound,
       thm:weighted_hilbert_schmidt_contraction_full_support}
     Under the hypotheses of
     Theorem~\ref{thm:full_support_eigenbasis_whitening_choi},
+    the matrix
     \begin{align}
-      \left\|(\sigma^T\otimes\tau)^{-1/4}\rho_{AB}
-        (\sigma^T\otimes\tau)^{-1/4}\right\|_F^2
+      W=(\sigma^T\otimes\tau)^{-1/4}\rho_{AB}
+        (\sigma^T\otimes\tau)^{-1/4}
+        \notag
+    \end{align}
+    is positive semidefinite, and
+    \begin{align}
+      \tr(W^2)=\|W\|_F^2
       &\leq \operatorname{OSR}(\rho_{AB}).
       \notag
     \end{align}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -653,6 +653,9 @@ terms of operator-Schmidt rank.
     \uses{thm:full_support_eigenbasis_whitening_choi,
       thm:rectangular_choi_rank_bound,
       thm:weighted_hilbert_schmidt_contraction_full_support}
+    The matrix $W$ is a congruence of $\rho_{AB}\geq0$, so it is positive
+    semidefinite and Hermitian; consequently
+    $\tr(W^2)=\|W\|_F^2$.
     The weighted map $L$ is a Hilbert--Schmidt contraction.  Its Choi matrix
     is the whitened state by the preceding theorem, while invertibility of
     the modular congruences and the supported-marginal correspondence give

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -405,6 +405,7 @@
     \label{thm:supported_marginal_channel}
     \lean{Matrix.finrank_range_supportedMarginalMap,
       Matrix.supportedMarginalMap_isKrausCPTP,
+      Matrix.supportedMarginalMap_diagonal,
       Matrix.supportedMarginalReconstruction_eq}
     \leanok
     \uses{def:bipartite_operator_schmidt_rank,
@@ -563,6 +564,91 @@ terms of operator-Schmidt rank.
     with $\|J(\mathcal L)\|_F^2$.
 \end{proof}
 
+\begin{theorem}[Full-support eigenbasis whitening as a Choi matrix]
+    \label{thm:full_support_eigenbasis_whitening_choi}
+    \lean{Matrix.rectangularChoi_singleKrausMap_comp_comp,
+      Matrix.supportedMarginalWhitenedState_eq_rectangularChoi,
+      Matrix.finrank_range_weightedHilbertSchmidtMap}
+    \leanok
+    \uses{thm:supported_marginal_channel,
+      def:rectangular_choi,
+      def:weighted_hilbert_schmidt_map}
+    Let $\rho_{AB}\geq0$, and choose an eigenbasis of its faithful first
+    marginal
+    $\sigma=\diag(p_1,\ldots,p_{d_A})>0$.  Suppose also that the second
+    marginal $\tau$ is positive definite.  For the supported-marginal channel
+    $\Phi_\rho$, set
+    \begin{align}
+      L(X)&=\tau^{-1/4}
+        \Phi_\rho(\sigma^{1/4}X\sigma^{1/4})\tau^{-1/4},\\
+      W&=(\sigma^T\otimes\tau)^{-1/4}\rho_{AB}
+        (\sigma^T\otimes\tau)^{-1/4}.
+        \notag
+    \end{align}
+    Then
+    \begin{align}
+      W&=J(L),
+      &\dim_{\C}\range L&=\dim_{\C}\range\Phi_\rho.
+      \notag
+    \end{align}
+    Here $\sigma^T=\sigma$ because the chosen basis diagonalizes $\sigma$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:supported_marginal_channel}
+    For arbitrary congruence matrices $A$ and $B$, the matrix-unit convention
+    for the Choi matrix gives
+    \begin{align}
+      J(\Gamma_B\circ\Phi\circ\Gamma_A)
+      &=\Gamma_{A^T\otimes B}(J(\Phi)).
+      \notag
+    \end{align}
+    Apply this identity to the inverse-square-root scaling in
+    $\Phi_\rho$ and to the two fourth-root factors defining $L$.
+    Entrywise diagonal functional calculus gives
+    $\sigma^{1/4}=\diag(p_i^{1/4})$ and
+    $\diag(p_i^{-1/2})\sigma^{1/4}=\sigma^{-1/4}$, proving the first
+    assertion.  The two modular congruences are invertible linear maps, so
+    pre- and post-composition by them preserve the range dimension.
+\end{proof}
+
+\begin{theorem}[Full-support eigenbasis whitened Choi estimate]
+    \label{thm:full_support_eigenbasis_whitened_choi_bound}
+    \lean{Matrix.supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank}
+    \leanok
+    \uses{thm:full_support_eigenbasis_whitening_choi,
+      thm:rectangular_choi_rank_bound,
+      thm:weighted_hilbert_schmidt_contraction_full_support}
+    Under the hypotheses of
+    Theorem~\ref{thm:full_support_eigenbasis_whitening_choi},
+    \begin{align}
+      \left\|(\sigma^T\otimes\tau)^{-1/4}\rho_{AB}
+        (\sigma^T\otimes\tau)^{-1/4}\right\|_F^2
+      &\leq \operatorname{OSR}(\rho_{AB}).
+      \notag
+    \end{align}
+    This is the faithful-marginal-support form of the order-two estimate
+    obtained from \cite[Theorem~6, Equation~(18)]{Beigi2013Sandwiched}.
+    % The passage from singular ambient marginals to their supports remains
+    % recorded in docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:full_support_eigenbasis_whitening_choi,
+      thm:rectangular_choi_rank_bound,
+      thm:weighted_hilbert_schmidt_contraction_full_support}
+    The weighted map $L$ is a Hilbert--Schmidt contraction.  Its Choi matrix
+    is the whitened state by the preceding theorem, while invertibility of
+    the modular congruences and the supported-marginal correspondence give
+    \begin{align}
+      \dim_{\C}\range L
+      &=\dim_{\C}\range\Phi_\rho
+       =\operatorname{OSR}(\rho_{AB}).
+      \notag
+    \end{align}
+    The rectangular Choi range-dimension estimate now proves the claim.
+\end{proof}
+
 \begin{theorem}[Mutual information from operator-Schmidt rank]
     \label{thm:mutual_information_le_log_operator_schmidt_rank}
     \uses{thm:supported_marginal_channel}
@@ -574,38 +660,20 @@ terms of operator-Schmidt rank.
     \end{align}
 \end{theorem}
 \begin{proof}
-    \uses{thm:rectangular_choi_rank_bound,
-        thm:weighted_hilbert_schmidt_contraction_full_support}
+    \uses{thm:full_support_eigenbasis_whitened_choi_bound}
     Compress the two tensor factors to the supports of $\rho_A$ and $\rho_B$.
     This preserves both mutual information and operator-Schmidt rank, and makes
     the two marginals $\sigma=\rho_A$ and $\tau=\rho_B$ strictly positive.
-    Theorem~\ref{thm:supported_marginal_channel} gives a completely positive
-    trace-preserving map $\Phi$ satisfying
+    Choose an eigenbasis of $\sigma$, and set
     \begin{align}
-        \tau=\Phi(\sigma),
-        \qquad
-        \dim_{\mathbb C}\range\Phi=\operatorname{OSR}(\rho_{AB}).
+        W=(\sigma^T\otimes\tau)^{-1/4}\rho_{AB}
+          (\sigma^T\otimes\tau)^{-1/4}.
         \notag
     \end{align}
-    For $\Gamma_\omega^z(X)=\omega^{z/2}X\omega^{z/2}$, set
+    The full-support eigenbasis estimate gives
     \begin{align}
-        L=\Gamma_\tau^{-1/2}\circ\Phi\circ\Gamma_\sigma^{1/2}.
-        \notag
-    \end{align}
-    Theorem~\ref{thm:weighted_hilbert_schmidt_contraction_full_support} shows
-    that $L$ is a Hilbert--Schmidt contraction.  The order-two sandwiched whitening of
-    $\rho_{AB}$ is the unnormalized Choi matrix
-    \begin{align}
-        W=\sum_{i,j}E_{ij}\otimes L(E_{ij}).
-        \notag
-    \end{align}
-    This is $J(L)$. Since $W$ is positive semidefinite,
-    Theorem~\ref{thm:rectangular_choi_rank_bound} gives
-    \begin{align}
-        \tr(W^2)
-        =\|W\|_F^2
-        \leq\dim_{\mathbb C}\range L
-        =\operatorname{OSR}(\rho_{AB}).
+        \tr(W^2)=\|W\|_F^2
+        \leq\operatorname{OSR}(\rho_{AB}).
         \notag
     \end{align}
     Monotonicity in the order and the order-one limit

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -208,6 +208,15 @@ the support compression is formalized.\footnote{Formal declarations:
 \leanid{Matrix.weightedHilbertSchmidtMap_norm_le} and
 \leanid{Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction} in
 \doclink{TNLean/Channel/WeightedHilbertSchmidt}.}
+The full-support eigenbasis assembly is also formalized: the whitening is
+identified exactly with the rectangular Choi matrix, including the input
+transpose convention, the modular congruences preserve the range dimension,
+and the resulting squared Frobenius norm is bounded by operator-Schmidt
+rank.\footnote{Formal declarations:
+\leanid{Matrix.supportedMarginalWhitenedState_eq_rectangularChoi},
+\leanid{Matrix.finrank_range_weightedHilbertSchmidtMap}, and
+\leanid{Matrix.supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank}
+in \doclink{TNLean/Channel/WhitenedChoi}.}
 This result assumes both weights are positive definite; it does not formalize
 an unrestricted support-compressed theorem for a singular output weight.  In
 particular, the Lean theorem assumes the output-faithfulness hypothesis

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -208,29 +208,30 @@ the support compression is formalized.\footnote{Formal declarations:
 \leanid{Matrix.weightedHilbertSchmidtMap_norm_le} and
 \leanid{Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction} in
 \doclink{TNLean/Channel/WeightedHilbertSchmidt}.}
-The full-support eigenbasis assembly is also formalized: the whitening is
+The full-support eigenbasis calculation is formalized: the whitening is
 identified exactly with the rectangular Choi matrix, including the input
 transpose convention, the modular congruences preserve the range dimension,
-and the resulting squared Frobenius norm is bounded by operator-Schmidt
-rank.\footnote{Formal declarations:
+and the resulting operator is positive semidefinite with its trace square and
+squared Frobenius norm bounded by operator-Schmidt rank.\footnote{Formal
+declarations:
 \leanid{Matrix.supportedMarginalWhitenedState_eq_rectangularChoi},
 \leanid{Matrix.finrank_range_weightedHilbertSchmidtMap}, and
-\leanid{Matrix.supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank}
+\leanid{Matrix.supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank}
 in \doclink{TNLean/Channel/WhitenedChoi}.}
-This result assumes both weights are positive definite; it does not formalize
-an unrestricted support-compressed theorem for a singular output weight.  In
-particular, the Lean theorem assumes the output-faithfulness hypothesis
-$\tau>0$, which is absent from the cited source statement.  To eliminate this
-extra hypothesis, compress the output algebra to $\operatorname{supp}\tau$,
-interpret the negative quarter power as the inverse of the positive square
-root within that corner, prove the exponent-two contraction there, and
-transport the estimate back along the isometric inclusion of the support.
-This source-faithful singular-output extension is tracked in
-\href{https://github.com/LionSR/TNLean/issues/5225}{\#5225}.
+These results do not complete
+\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  They assume both
+weights are positive definite and therefore do not provide the two-local
+compression from singular ambient marginals to their support algebras.  The
+proof that this two-sided compression preserves operator-Schmidt rank is also
+absent.  Both statements remain part of \#5211 and are required for the
+unrestricted theorem tracked in
+\href{https://github.com/LionSR/TNLean/issues/5212}{\#5212}.  The construction
+of the output support corner needed within this argument is separately tracked
+in \href{https://github.com/LionSR/TNLean/issues/5225}{\#5225}.
 The remaining order-monotonicity and order-one-limit step is not yet
 formalized and is tracked in
-\href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  Assembly into the
-sharp mutual-information theorem is tracked in
+\href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  The sharp
+mutual-information theorem remains tracked in
 \href{https://github.com/LionSR/TNLean/issues/5212}{\#5212}.
 
 \section{Diagonal matrix product operators}


### PR DESCRIPTION
## Summary

- prove Choi covariance under input/output single-Kraus congruences, with the required transpose on the input factor;
- identify the full-support sandwiched whitening of a bipartite operator with the rectangular Choi matrix of its weighted supported-marginal channel;
- prove that the invertible modular congruences preserve range dimension;
- derive both the Frobenius and literal trace-square bounds by operator-Schmidt rank;
- synchronize the supported-marginal Blueprint statement and record the remaining support-compression gap.

## Mathematical scope

In an eigenbasis of the faithful first marginal `σ = diagonal p`, with faithful second marginal `τ`, the pull request proves
\[
W=(\sigma^T\otimes\tau)^{-1/4}\rho(\sigma^T\otimes\tau)^{-1/4}=J(L),
\]
where
\[
L=\Gamma_\tau^{-1/2}\circ\Phi_\rho\circ\Gamma_\sigma^{1/2}.
\]
It then proves
\[
\operatorname{Re}\operatorname{Tr}(W^2)=\|W\|_F^2
\leq \operatorname{OSR}(\rho).
\]
The transpose is explicit in the general Choi covariance theorem and becomes invisible only because `σ` is diagonal in the chosen basis.

This is the faithful-marginal-support core toward #5211. The issue remains open because compression of both ambient marginal supports and preservation of operator-Schmidt rank under that compression remain to be formalized. The output-support corner needed by the weighted contraction is separately tracked in #5225. The unrestricted mutual-information Blueprint theorem remains unmarked.

Source for the contraction input: Beigi, arXiv:1306.5920, Theorem 6 and equation (18).

## Validation

- `lake build TNLean` (9,858 tasks);
- focused channel builds and zero-dimensional specializations;
- Blueprint web generation, synchronization, and declaration checking;
- generated-import, module-size, style, integrity, line-length, and whitespace checks;
- two independent exact-head approvals at `976ea7b090127d9f6099216cf6f68a57fa758ff0`.

Progress on #5211.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs and documentation in channel theory; no runtime or security-sensitive paths. Remaining gaps are explicitly scoped to full-support hypotheses only.
> 
> **Overview**
> Formalizes the **faithful-marginal-support** core of the order-two whitening bound: under diagonal faithful first marginal and positive-definite second marginal, the sandwiched operator `supportedMarginalWhitenedState` is identified with the rectangular Choi matrix of the weighted supported-marginal channel, and its squared Frobenius norm (equivalently **Re Tr(W²)**) is bounded by **operator-Schmidt rank**.
> 
> **Lean:** Adds `TNLean/Channel/WhitenedChoi.lean` (Choi covariance under input/output congruences with input transpose; whitening–Choi identity; finrank invariance under invertible modular congruences; Frobenius and trace-square estimates). Adds `supportedMarginalMap_diagonal` in `SupportedMarginalChannel.lean` so Beigi’s weighted contraction applies with **Φ(σ) = τ**. Wires the new module through `TNLean/Channel.lean`.
> 
> **Blueprint / docs:** Extends the supported-marginal channel theorem with **Φ(σ) = τ**, adds blueprint theorems for whitening-as-Choi and the whitened Choi bound, and refactors the mutual-information proof sketch to cite that bound. Updates `cpgsv17_mpdo_mutual_information_bound.tex` to record what is now formalized and that singular-marginal compression and OSR preservation remain open (#5211 / #5212 / #5225).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 976ea7b090127d9f6099216cf6f68a57fa758ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->