### PR TITLE
feat(Channel): prove singular-output weighted contraction

### DIFF
--- a/TNLean/Algebra/PosSemidefSupport.lean
+++ b/TNLean/Algebra/PosSemidefSupport.lean
@@ -285,6 +285,15 @@ variable {n : Type*} [Fintype n] [DecidableEq n] {A : Matrix n n ℂ}
 noncomputable def supportProj (hA : A.PosSemidef) : Matrix n n ℂ :=
   hA.isHermitian.supportProj
 
+/-- Equal positive-semidefinite matrices have equal support projections. -/
+theorem supportProj_congr {B : Matrix n n ℂ} (hA : A.PosSemidef)
+    (hB : B.PosSemidef) (hAB : A = B) :
+    hA.supportProj = hB.supportProj := by
+  subst B
+  have hProof : hA = hB := Subsingleton.elim _ _
+  subst hB
+  rfl
+
 /-- The support projection is Hermitian. -/
 theorem supportProj_isHermitian (hA : A.PosSemidef) : hA.supportProj.IsHermitian :=
   hA.isHermitian.supportProj_isHermitian

--- a/TNLean/Analysis/CoisometricCompression.lean
+++ b/TNLean/Analysis/CoisometricCompression.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import Mathlib.Analysis.Normed.Algebra.MatrixExponential
 import Mathlib.LinearAlgebra.Matrix.Bilinear
+import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.OrthogonalProjection
 import TNLean.Analysis.MarginalSupport
 
@@ -29,9 +30,11 @@ when $Z$ is supported on that initial space.
   on the initial space.
 * `Matrix.trace_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one` — expansion
   by the adjoint of a coisometry preserves the trace.
+* `Matrix.frobenius_norm_isometry_mul_mul_conjTranspose` — expansion by an
+  isometry preserves the Frobenius norm.
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix ComplexOrder Matrix.Norms.Frobenius
 
 namespace Matrix
 
@@ -107,6 +110,24 @@ theorem trace_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one
     Matrix.trace (Uᴴ * Z * U) = Matrix.trace (U * Uᴴ * Z) := by
       rw [Matrix.trace_mul_cycle]
     _ = Matrix.trace Z := by rw [hU, Matrix.one_mul]
+
+/-- Expansion along an isometry preserves the Frobenius norm. -/
+theorem frobenius_norm_isometry_mul_mul_conjTranspose
+    {p s : Type*} [Fintype p] [DecidableEq p] [Fintype s] [DecidableEq s]
+    (V : Matrix p s ℂ) (hV : Vᴴ * V = 1) (Z : Matrix s s ℂ) :
+    ‖V * Z * Vᴴ‖ = ‖Z‖ := by
+  have hsquare : ‖V * Z * Vᴴ‖ ^ 2 = ‖Z‖ ^ 2 := by
+    rw [← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq,
+      ← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
+    congr 1
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose]
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc Vᴴ V (Z * Vᴴ), hV, Matrix.one_mul]
+    rw [Matrix.trace_mul_comm V (Zᴴ * (Z * Vᴴ))]
+    rw [Matrix.mul_assoc Zᴴ (Z * Vᴴ) V, Matrix.mul_assoc Z Vᴴ V,
+      hV, Matrix.mul_one]
+  nlinarith [norm_nonneg (V * Z * Vᴴ), norm_nonneg Z]
 
 open scoped Norms.Operator in
 /-- Matrix exponential transports across a rectangular intertwiner. -/

--- a/TNLean/Analysis/MatrixFamilySupport.lean
+++ b/TNLean/Analysis/MatrixFamilySupport.lean
@@ -61,15 +61,6 @@ theorem familySupportProj_kronecker
     (A : ι → Matrix m n ℂ) (B : κ → Matrix p q ℂ) :
     familySupportProj (familyKronecker A B) =
       familySupportProj A ⊗ₖ familySupportProj B := by
-  have supportProj_congr :
-      ∀ {X Y : Matrix (m × p) (m × p) ℂ}
-        (hX : X.PosSemidef) (hY : Y.PosSemidef),
-        X = Y → hX.supportProj = hY.supportProj := by
-    intro X Y hX hY hXY
-    subst Y
-    have hProof : hX = hY := Subsingleton.elim _ _
-    subst hY
-    rfl
   let hA := familyColumnGram_posSemidef A
   let hB := familyColumnGram_posSemidef B
   let hProduct := familyColumnGram_posSemidef (familyKronecker A B)
@@ -77,7 +68,7 @@ theorem familySupportProj_kronecker
     familySupportProj (familyKronecker A B) =
         (hA.kronecker hB).supportProj := by
       rw [familySupportProj]
-      exact supportProj_congr hProduct (hA.kronecker hB)
+      exact hProduct.supportProj_congr (hA.kronecker hB)
         (familyColumnGram_kronecker A B)
     _ = hA.supportProj ⊗ₖ hB.supportProj :=
       hA.supportProj_kronecker hB

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -30,6 +30,7 @@ theory development.
 * `Matrix.PosSemidef.blockDiagonal'`: a finite dependent block diagonal of
   positive-semidefinite matrices is positive semidefinite.
 * `Matrix.PosSemidef.supportInvSqrt`: the inverse square root on the support.
+* `Matrix.PosSemidef.supportInvFourthRoot`: the negative quarter power on the support.
 * `Matrix.PosSemidef.supportInv`: the generalized inverse on the support.
 * `Matrix.PosDef.supportInvSqrt_eq_inv_sqrt`: agreement with the ordinary
   inverse square root for positive-definite matrices.
@@ -135,6 +136,32 @@ theorem PosSemidef.supportProj_mul_cfc_sqrt
     hρ.isHermitian.supportProj_isHermitian.eq] using
       congrArg Matrix.conjTranspose hρ.cfc_sqrt_mul_supportProj
 
+/-- Taking the positive square root does not change the support projection. -/
+theorem PosSemidef.supportProj_cfc_sqrt {D : ℕ}
+    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef) :
+    (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)).supportProj =
+      hρ.supportProj := by
+  let q := CFC.sqrt ρ
+  let hq : q.PosSemidef := Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)
+  have hq_sq : q * q = ρ := CFC.sqrt_mul_sqrt_self ρ hρ.nonneg
+  have hkerρq (v : Fin D → ℂ) (hv : ρ *ᵥ v = 0) : q *ᵥ v = 0 := by
+    apply (Matrix.conjTranspose_mul_self_mulVec_eq_zero q v).mp
+    rw [hq.isHermitian.eq, hq_sq]
+    exact hv
+  have hkerqρ (v : Fin D → ℂ) (hv : q *ᵥ v = 0) : ρ *ᵥ v = 0 := by
+    rw [← hq_sq, ← Matrix.mulVec_mulVec, hv, Matrix.mulVec_zero]
+  have hPqPρ : hq.supportProj * hρ.supportProj = hq.supportProj :=
+    hρ.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le fun v hv ↦
+      hq.supportProj_mulVec_eq_zero_of_mulVec_eq_zero v (hkerρq v hv)
+  have hPρPq : hρ.supportProj * hq.supportProj = hρ.supportProj :=
+    hq.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le fun v hv ↦
+      hρ.supportProj_mulVec_eq_zero_of_mulVec_eq_zero v (hkerqρ v hv)
+  have hPρPq' : hρ.supportProj * hq.supportProj = hq.supportProj := by
+    simpa only [Matrix.conjTranspose_mul, hρ.supportProj_isHermitian.eq,
+      hq.supportProj_isHermitian.eq] using congrArg Matrix.conjTranspose hPqPρ
+  change hq.supportProj = hρ.supportProj
+  exact hPρPq'.symm.trans hPρPq
+
 /-- The square of the Hermitian functional-calculus square root recovers the
 positive-semidefinite matrix. -/
 theorem PosSemidef.cfc_sqrt_mul_self {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
@@ -159,6 +186,43 @@ equation (8). -/
 noncomputable def PosSemidef.supportInvSqrt {ρ : Matrix n n ℂ}
     (hρ : ρ.PosSemidef) : Matrix n n ℂ :=
   hρ.isHermitian.cfc fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
+
+/-- The negative quarter power of a positive-semidefinite matrix on its support:
+the zero eigenspace is sent to zero and every positive eigenvalue `x` is sent
+to `x⁻¹⁄⁴`.
+
+This is the support convention in Beigi, arXiv:1306.5920, Theorem 6 and
+equation (18). -/
+noncomputable def PosSemidef.supportInvFourthRoot {ρ : Matrix n n ℂ}
+    (_hρ : ρ.PosSemidef) : Matrix n n ℂ :=
+  (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)).supportInvSqrt
+
+/-- The support inverse square root is absorbed on the right by the support
+projection. -/
+theorem PosSemidef.supportInvSqrt_mul_supportProj {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) :
+    hρ.supportInvSqrt * hρ.supportProj = hρ.supportInvSqrt := by
+  let f : ℝ → ℝ := fun x ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0
+  change hρ.isHermitian.cfc f * hρ.isHermitian.supportProj =
+    hρ.isHermitian.cfc f
+  rw [hρ.isHermitian.cfc_form f]
+  unfold Matrix.IsHermitian.supportProj
+  let U := (hρ.isHermitian.eigenvectorUnitary : Matrix n n ℂ)
+  let D := Matrix.diagonal
+    (fun i ↦ ((f (hρ.isHermitian.eigenvalues i) : ℝ) : ℂ))
+  let P := Matrix.diagonal
+    (fun i ↦ if hρ.isHermitian.eigenvalues i ≠ 0 then (1 : ℂ) else 0)
+  have hU : star U * U = 1 := by
+    exact Unitary.coe_star_mul_self hρ.isHermitian.eigenvectorUnitary
+  change (U * D * star U) * (U * P * star U) = U * D * star U
+  simp only [Matrix.mul_assoc]
+  rw [← Matrix.mul_assoc (star U) U (P * star U), hU, Matrix.one_mul,
+    ← Matrix.mul_assoc D P (star U)]
+  congr 2
+  simp only [D, P, Matrix.diagonal_mul_diagonal]
+  congr 1
+  funext i
+  by_cases hi : hρ.isHermitian.eigenvalues i = 0 <;> simp [f, hi]
 
 /-- The support inverse square root commutes with reindexing by an
 equivalence. -/
@@ -188,6 +252,15 @@ theorem PosSemidef.supportInvSqrt_isHermitian {ρ : Matrix n n ℂ}
   rw [PosSemidef.supportInvSqrt, ← hρ.isHermitian.cfc_eq]
   exact Matrix.isHermitian_iff_isSelfAdjoint.mpr
     (cfc_predicate (fun x : ℝ ↦ if x ≠ 0 then (Real.sqrt x)⁻¹ else 0) ρ)
+
+/-- The support inverse square root is absorbed on the left by the support
+projection. -/
+theorem PosSemidef.supportProj_mul_supportInvSqrt {ρ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) :
+    hρ.supportProj * hρ.supportInvSqrt = hρ.supportInvSqrt := by
+  simpa only [Matrix.conjTranspose_mul, hρ.supportProj_isHermitian.eq,
+    hρ.supportInvSqrt_isHermitian.eq] using
+      congrArg Matrix.conjTranspose hρ.supportInvSqrt_mul_supportProj
 
 /-- The support inverse square root is positive semidefinite.
 

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -137,18 +137,18 @@ theorem PosSemidef.supportProj_mul_cfc_sqrt
       congrArg Matrix.conjTranspose hρ.cfc_sqrt_mul_supportProj
 
 /-- Taking the positive square root does not change the support projection. -/
-theorem PosSemidef.supportProj_cfc_sqrt {D : ℕ}
-    {ρ : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef) :
+theorem PosSemidef.supportProj_cfc_sqrt
+    {ρ : Matrix n n ℂ} (hρ : ρ.PosSemidef) :
     (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)).supportProj =
       hρ.supportProj := by
   let q := CFC.sqrt ρ
   let hq : q.PosSemidef := Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)
   have hq_sq : q * q = ρ := CFC.sqrt_mul_sqrt_self ρ hρ.nonneg
-  have hkerρq (v : Fin D → ℂ) (hv : ρ *ᵥ v = 0) : q *ᵥ v = 0 := by
+  have hkerρq (v : n → ℂ) (hv : ρ *ᵥ v = 0) : q *ᵥ v = 0 := by
     apply (Matrix.conjTranspose_mul_self_mulVec_eq_zero q v).mp
     rw [hq.isHermitian.eq, hq_sq]
     exact hv
-  have hkerqρ (v : Fin D → ℂ) (hv : q *ᵥ v = 0) : ρ *ᵥ v = 0 := by
+  have hkerqρ (v : n → ℂ) (hv : q *ᵥ v = 0) : ρ *ᵥ v = 0 := by
     rw [← hq_sq, ← Matrix.mulVec_mulVec, hv, Matrix.mulVec_zero]
   have hPqPρ : hq.supportProj * hρ.supportProj = hq.supportProj :=
     hρ.isHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le fun v hv ↦

--- a/TNLean/Analysis/SupportCompression.lean
+++ b/TNLean/Analysis/SupportCompression.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.PosSemidefSupport
+import TNLean.Analysis.MatrixSqrt
 
 /-!
 # Faithful compression of a PSD matrix onto its support
@@ -20,13 +20,16 @@ positive definite when restricted to its support. This low-layer analysis module
 * `Matrix.PosSemidef.compression_on_support_posDef` — given a compression isometry
   `V : Matrix (Fin k) (Fin D) ℂ` with `V * Vᴴ = 1` and `Vᴴ * V = supportProj ρ`, the
   compression `V * ρ * Vᴴ` is positive definite.
+* `Matrix.PosSemidef.supportInvFourthRoot_compression_on_support` — the
+  support-restricted negative quarter power becomes the ordinary negative
+  quarter power after compression.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Corollary 6.6]
 -/
 
-open scoped Matrix ComplexOrder BigOperators
+open scoped Matrix ComplexOrder MatrixOrder BigOperators
 open Matrix
 
 namespace Matrix
@@ -93,6 +96,90 @@ theorem compression_on_support_posDef
   rw [h_quadform]
   -- Apply the pointwise strict positivity lemma.
   exact hρ.dotProduct_mulVec_pos_of_supportProj_fixed hu_ne hPu
+
+/-- The positive square root commutes with compression to the support. -/
+theorem sqrt_compression_on_support
+    {k : ℕ} {V : Matrix (Fin D) (Fin k) ℂ}
+    (hVrange : V * Vᴴ = hρ.supportProj) :
+    CFC.sqrt (Vᴴ * ρ * V) = Vᴴ * CFC.sqrt ρ * V := by
+  have hq : (CFC.sqrt ρ).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)
+  have hsqrt_eq : CFC.sqrt ρ = hρ.isHermitian.cfc Real.sqrt := by
+    rw [CFC.sqrt_eq_real_sqrt ρ hρ.nonneg, cfcₙ_eq_cfc, hρ.isHermitian.cfc_eq]
+  have hPq : hρ.supportProj * CFC.sqrt ρ = CFC.sqrt ρ := by
+    rw [hsqrt_eq]
+    exact hρ.supportProj_mul_cfc_sqrt
+  have hb : (0 : Matrix (Fin k) (Fin k) ℂ) ≤ Vᴴ * CFC.sqrt ρ * V :=
+    (hq.conjTranspose_mul_mul_same V).nonneg
+  refine CFC.sqrt_unique ?_ hb
+  calc
+    (Vᴴ * CFC.sqrt ρ * V) * (Vᴴ * CFC.sqrt ρ * V) =
+        Vᴴ * (CFC.sqrt ρ * (V * Vᴴ) * CFC.sqrt ρ) * V := by
+      simp [Matrix.mul_assoc]
+    _ = Vᴴ * (CFC.sqrt ρ * hρ.supportProj * CFC.sqrt ρ) * V := by
+      rw [hVrange]
+    _ = Vᴴ * (CFC.sqrt ρ * CFC.sqrt ρ) * V := by
+      have hinner : CFC.sqrt ρ * hρ.supportProj * CFC.sqrt ρ =
+          CFC.sqrt ρ * CFC.sqrt ρ := by
+        rw [Matrix.mul_assoc, hPq]
+      rw [hinner]
+    _ = Vᴴ * ρ * V := by rw [CFC.sqrt_mul_sqrt_self ρ hρ.nonneg]
+
+/-- The support inverse square root becomes the ordinary inverse square root
+after compression to the support. -/
+theorem supportInvSqrt_compression_on_support
+    {k : ℕ} (V : Matrix (Fin D) (Fin k) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = hρ.supportProj) :
+    Vᴴ * hρ.supportInvSqrt * V = (CFC.sqrt (Vᴴ * ρ * V))⁻¹ := by
+  have hsqrt := hρ.sqrt_compression_on_support hVrange
+  have hsqrt_eq : CFC.sqrt ρ = hρ.isHermitian.cfc Real.sqrt := by
+    rw [CFC.sqrt_eq_real_sqrt ρ hρ.nonneg, cfcₙ_eq_cfc, hρ.isHermitian.cfc_eq]
+  have hPq : hρ.supportProj * CFC.sqrt ρ = CFC.sqrt ρ := by
+    rw [hsqrt_eq]
+    exact hρ.supportProj_mul_cfc_sqrt
+  have hAq : hρ.supportInvSqrt * CFC.sqrt ρ = hρ.supportProj := by
+    rw [hsqrt_eq]
+    exact hρ.supportInvSqrt_mul_cfc_sqrt
+  apply Eq.symm
+  apply Matrix.inv_eq_left_inv
+  rw [hsqrt]
+  calc
+    (Vᴴ * hρ.supportInvSqrt * V) * (Vᴴ * CFC.sqrt ρ * V) =
+        Vᴴ * hρ.supportInvSqrt * (V * Vᴴ) * CFC.sqrt ρ * V := by
+      simp only [Matrix.mul_assoc]
+    _ = Vᴴ * hρ.supportInvSqrt * hρ.supportProj * CFC.sqrt ρ * V := by
+      rw [hVrange]
+    _ = Vᴴ * hρ.supportInvSqrt * CFC.sqrt ρ * V := by
+      have hinner : hρ.supportInvSqrt * hρ.supportProj * CFC.sqrt ρ =
+          hρ.supportInvSqrt * CFC.sqrt ρ := by
+        rw [Matrix.mul_assoc, hPq]
+      simpa only [Matrix.mul_assoc] using
+        congrArg (fun X ↦ Vᴴ * X * V) hinner
+    _ = Vᴴ * hρ.supportProj * V := by
+      simpa only [Matrix.mul_assoc] using
+        congrArg (fun X ↦ Vᴴ * X * V) hAq
+    _ = 1 := by
+      rw [← hVrange]
+      simp only [Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc Vᴴ V, hV, Matrix.one_mul]
+
+/-- The support-restricted negative quarter power becomes the ordinary
+negative quarter power after compression to the support. -/
+theorem supportInvFourthRoot_compression_on_support
+    {k : ℕ} (V : Matrix (Fin D) (Fin k) ℂ) (hV : Vᴴ * V = 1)
+    (hVrange : V * Vᴴ = hρ.supportProj) :
+    Vᴴ * hρ.supportInvFourthRoot * V =
+      (CFC.sqrt (CFC.sqrt (Vᴴ * ρ * V)))⁻¹ := by
+  let hq : (CFC.sqrt ρ).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg ρ)
+  have hqrange : V * Vᴴ = hq.supportProj := by
+    rw [hρ.supportProj_cfc_sqrt]
+    exact hVrange
+  have hinv := hq.supportInvSqrt_compression_on_support V hV hqrange
+  have hsqrt := hρ.sqrt_compression_on_support hVrange
+  change Vᴴ * hq.supportInvSqrt * V = _
+  have hquarter := congrArg (fun X ↦ (CFC.sqrt X)⁻¹) hsqrt
+  exact hinv.trans hquarter.symm
 
 end PosSemidef
 

--- a/TNLean/Channel/WeightedHilbertSchmidt.lean
+++ b/TNLean/Channel/WeightedHilbertSchmidt.lean
@@ -406,24 +406,6 @@ noncomputable def supportedWeightedHilbertSchmidtMap
   (singleKrausMap hτ.supportInvFourthRoot).comp
     (Φ.comp (singleKrausMap (CFC.sqrt (CFC.sqrt σ))))
 
-/-- Expansion along an isometry preserves the Frobenius norm. -/
-theorem frobenius_norm_isometry_mul_mul_conjTranspose
-    {p s : ℕ} (V : Matrix (Fin p) (Fin s) ℂ) (hV : Vᴴ * V = 1)
-    (Z : Matrix (Fin s) (Fin s) ℂ) :
-    ‖V * Z * Vᴴ‖ = ‖Z‖ := by
-  have hsquare : ‖V * Z * Vᴴ‖ ^ 2 = ‖Z‖ ^ 2 := by
-    rw [← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq,
-      ← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
-    congr 1
-    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
-      Matrix.conjTranspose_conjTranspose]
-    simp only [Matrix.mul_assoc]
-    rw [← Matrix.mul_assoc Vᴴ V (Z * Vᴴ), hV, Matrix.one_mul]
-    rw [Matrix.trace_mul_comm V (Zᴴ * (Z * Vᴴ))]
-    rw [Matrix.mul_assoc Zᴴ (Z * Vᴴ) V, Matrix.mul_assoc Z Vᴴ V,
-      hV, Matrix.mul_one]
-  nlinarith [norm_nonneg (V * Z * Vᴴ), norm_nonneg Z]
-
 /-- Compression proof of the support-weighted contraction with a named output
 weight and an explicit proof of its positivity. -/
 private theorem supportedWeightedHilbertSchmidtMap_norm_le_aux

--- a/TNLean/Channel/WeightedHilbertSchmidt.lean
+++ b/TNLean/Channel/WeightedHilbertSchmidt.lean
@@ -4,10 +4,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.FrobeniusHilbert
+import TNLean.Algebra.MatrixFamilySupport
 import TNLean.Algebra.MatrixCongruence
 import TNLean.Algebra.RectangularChoi
+import TNLean.Analysis.CoisometricCompression
+import TNLean.Analysis.MatrixSqrt
 import TNLean.Channel.Peripheral.UnitalKraus
 import TNLean.Channel.SingleKraus
+import TNLean.Channel.Spectral.Support
 
 import Mathlib.Analysis.InnerProductSpace.Adjoint
 import Mathlib.Analysis.InnerProductSpace.Rayleigh
@@ -26,6 +30,10 @@ Kraus map with its Hilbert-space adjoint after Frobenius vectorization.
   Kraus map is its trace-pairing adjoint.
 * `Matrix.weightedHilbertSchmidtMap`: the full-support weighted channel map.
 * `Matrix.weightedHilbertSchmidtMap_norm_le`: its Hilbert--Schmidt contraction bound.
+* `Matrix.supportedWeightedHilbertSchmidtMap`: the weighted channel map with
+  the negative output power restricted to its support.
+* `Matrix.supportedWeightedHilbertSchmidtMap_norm_le`: the contraction bound
+  without a full-support assumption on the output.
 
 ## References
 
@@ -284,6 +292,254 @@ theorem weightedHilbertSchmidtMap_isHilbertSchmidtContraction
   have hNorm := weightedHilbertSchmidtMap_norm_le hΦ hσ hτ hmap X
   nlinarith [norm_nonneg (weightedHilbertSchmidtMap Φ σ τ X), norm_nonneg X]
 
+/-! ### Singular output support -/
+
+/-- If a channel sends a positive-definite matrix to `τ`, then every output of the
+channel is supported on the support projection of `τ`.
+
+This is the support statement underlying the singular-output specialization of
+Beigi, arXiv:1306.5920, Theorem 6 and equation (18). -/
+theorem IsKrausCPTP.supportProj_mul_map
+    {r p : ℕ} {Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ}
+    {σ : Matrix (Fin r) (Fin r) ℂ} {τ : Matrix (Fin p) (Fin p) ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) (hmap : Φ σ = τ)
+    (X : Matrix (Fin r) (Fin r) ℂ) :
+    (hΦ.map_posSemidef hσ.posSemidef).supportProj * Φ X = Φ X := by
+  obtain ⟨d, A, hA⟩ := hΦ.isKrausCP
+  let sσ := CFC.sqrt σ
+  let B : Fin d → Matrix (Fin p) (Fin r) ℂ := fun i ↦ A i * sσ
+  have hsσ_psd : sσ.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg σ)
+  have hsσ_sq : sσ * sσ = σ := by
+    simpa only [sσ] using CFC.sqrt_mul_sqrt_self σ hσ.posSemidef.nonneg
+  have hsσ_star : sσᴴ = sσ := hsσ_psd.isHermitian.eq
+  have hsσ_unit : IsUnit sσ :=
+    (CFC.isUnit_sqrt_iff σ hσ.posSemidef.nonneg).2 hσ.isUnit
+  have hsσ_det : sσ.det ≠ 0 :=
+    ((Matrix.isUnit_iff_isUnit_det sσ).1 hsσ_unit).ne_zero
+  have hGram : familyColumnGram B = τ := by
+    rw [familyColumnGram_eq_sum]
+    calc
+      ∑ i, B i * (B i)ᴴ = ∑ i, A i * σ * (A i)ᴴ := by
+        apply Finset.sum_congr rfl
+        intro i hi
+        simp only [B, Matrix.conjTranspose_mul, hsσ_star]
+        simp only [Matrix.mul_assoc]
+        rw [← Matrix.mul_assoc sσ sσ, hsσ_sq]
+      _ = Φ σ := (hA σ).symm
+      _ = τ := hmap
+  have hSupport :
+      (hΦ.map_posSemidef hσ.posSemidef).supportProj = familySupportProj B := by
+    exact ((familyColumnGram_posSemidef B).supportProj_congr
+      (hΦ.map_posSemidef hσ.posSemidef) (hGram.trans hmap.symm)).symm
+  rw [hSupport, hA, Matrix.mul_sum]
+  apply Finset.sum_congr rfl
+  intro i hi
+  have hPA : familySupportProj B * A i = A i := by
+    calc
+      familySupportProj B * A i =
+          (familySupportProj B * A i) * (1 : Matrix (Fin r) (Fin r) ℂ) := by
+        rw [Matrix.mul_one]
+      _ = (familySupportProj B * A i) * (sσ * sσ⁻¹) := by
+        rw [Matrix.mul_nonsing_inv sσ (Ne.isUnit hsσ_det)]
+      _ = (familySupportProj B * (A i * sσ)) * sσ⁻¹ := by
+        simp only [Matrix.mul_assoc]
+      _ = (familySupportProj B * B i) * sσ⁻¹ := rfl
+      _ = B i * sσ⁻¹ := by rw [familySupportProj_mul]
+      _ = (A i * sσ) * sσ⁻¹ := rfl
+      _ = A i * (sσ * sσ⁻¹) := Matrix.mul_assoc _ _ _
+      _ = A i := by rw [Matrix.mul_nonsing_inv sσ (Ne.isUnit hsσ_det), Matrix.mul_one]
+  simp only [← Matrix.mul_assoc, hPA]
+
+/-- Under the hypotheses of `IsKrausCPTP.supportProj_mul_map`, every channel
+output is also supported on the right. -/
+theorem IsKrausCPTP.map_mul_supportProj
+    {r p : ℕ} {Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ}
+    {σ : Matrix (Fin r) (Fin r) ℂ} {τ : Matrix (Fin p) (Fin p) ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) (hmap : Φ σ = τ)
+    (X : Matrix (Fin r) (Fin r) ℂ) :
+    Φ X * (hΦ.map_posSemidef hσ.posSemidef).supportProj = Φ X := by
+  have hleft := Matrix.IsKrausCPTP.supportProj_mul_map hΦ hσ hmap Xᴴ
+  have hΦpos : IsPositiveMap Φ := fun Y hY ↦ hΦ.map_posSemidef hY
+  have hstar := congrArg Matrix.conjTranspose hleft
+  simpa only [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose,
+    (hΦ.map_posSemidef hσ.posSemidef).supportProj_isHermitian.eq,
+    hΦpos.map_conjTranspose] using hstar
+
+/-- Compress the output of a matrix map along an isometry `V`. -/
+noncomputable def outputSupportCompressedMap
+    {r p s : ℕ} (Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ)
+    (V : Matrix (Fin p) (Fin s) ℂ) :
+    Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin s) (Fin s) ℂ :=
+  (singleKrausMap Vᴴ).comp Φ
+
+/-- Compression of a channel to the support of the image of a faithful weight
+is again trace preserving and completely positive. -/
+theorem outputSupportCompressedMap_isKrausCPTP
+    {r p s : ℕ} {Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ}
+    {σ : Matrix (Fin r) (Fin r) ℂ} {τ : Matrix (Fin p) (Fin p) ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) (hmap : Φ σ = τ)
+    (V : Matrix (Fin p) (Fin s) ℂ)
+    (hVVt : V * Vᴴ = (hΦ.map_posSemidef hσ.posSemidef).supportProj) :
+    IsKrausCPTP (outputSupportCompressedMap Φ V) := by
+  apply isKrausCPTP_of_isKrausCP_trace_preserving
+  · exact isKrausCP_comp hΦ.isKrausCP (singleKrausMap_isKrausCP Vᴴ)
+  · intro X
+    rw [outputSupportCompressedMap, LinearMap.comp_apply, singleKrausMap_apply,
+      Matrix.conjTranspose_conjTranspose]
+    calc
+      Matrix.trace (Vᴴ * Φ X * V) = Matrix.trace (V * Vᴴ * Φ X) := by
+        rw [Matrix.trace_mul_cycle]
+      _ = Matrix.trace
+          ((hΦ.map_posSemidef hσ.posSemidef).supportProj * Φ X) := by rw [hVVt]
+      _ = Matrix.trace (Φ X) := by rw [Matrix.IsKrausCPTP.supportProj_mul_map hΦ hσ hmap]
+      _ = Matrix.trace X := hΦ.trace_map X
+
+/-- The support-weighted map
+`X ↦ τ⁻¹⁄⁴ Φ(σ¹⁄⁴ X σ¹⁄⁴) τ⁻¹⁄⁴`, with the negative power
+zero on the kernel of `τ`. -/
+noncomputable def supportedWeightedHilbertSchmidtMap
+    {r p : ℕ} (Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ)
+    (σ : Matrix (Fin r) (Fin r) ℂ) {τ : Matrix (Fin p) (Fin p) ℂ}
+    (hτ : τ.PosSemidef) :
+    Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ :=
+  (singleKrausMap hτ.supportInvFourthRoot).comp
+    (Φ.comp (singleKrausMap (CFC.sqrt (CFC.sqrt σ))))
+
+/-- Expansion along an isometry preserves the Frobenius norm. -/
+theorem frobenius_norm_isometry_mul_mul_conjTranspose
+    {p s : ℕ} (V : Matrix (Fin p) (Fin s) ℂ) (hV : Vᴴ * V = 1)
+    (Z : Matrix (Fin s) (Fin s) ℂ) :
+    ‖V * Z * Vᴴ‖ = ‖Z‖ := by
+  have hsquare : ‖V * Z * Vᴴ‖ ^ 2 = ‖Z‖ ^ 2 := by
+    rw [← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq,
+      ← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
+    congr 1
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+      Matrix.conjTranspose_conjTranspose]
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc Vᴴ V (Z * Vᴴ), hV, Matrix.one_mul]
+    rw [Matrix.trace_mul_comm V (Zᴴ * (Z * Vᴴ))]
+    rw [Matrix.mul_assoc Zᴴ (Z * Vᴴ) V, Matrix.mul_assoc Z Vᴴ V,
+      hV, Matrix.mul_one]
+  nlinarith [norm_nonneg (V * Z * Vᴴ), norm_nonneg Z]
+
+/-- Compression proof of the support-weighted contraction with a named output
+weight and an explicit proof of its positivity. -/
+private theorem supportedWeightedHilbertSchmidtMap_norm_le_aux
+    {r p : ℕ} {Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ}
+    {σ : Matrix (Fin r) (Fin r) ℂ} {τ : Matrix (Fin p) (Fin p) ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) (hτ : τ.PosSemidef)
+    (hmap : Φ σ = τ) (X : Matrix (Fin r) (Fin r) ℂ) :
+    ‖supportedWeightedHilbertSchmidtMap Φ σ hτ X‖ ≤ ‖X‖ := by
+  obtain ⟨s, V, hV, hVrange⟩ :=
+    hτ.isOrthogonalProjection_supportProj.exists_range_isometry
+  have hSupport :
+      (hΦ.map_posSemidef hσ.posSemidef).supportProj = hτ.supportProj := by
+    exact (hΦ.map_posSemidef hσ.posSemidef).supportProj_congr hτ hmap
+  let Ψ := outputSupportCompressedMap Φ V
+  let τc := Vᴴ * τ * V
+  have hΨ : IsKrausCPTP Ψ := by
+    apply outputSupportCompressedMap_isKrausCPTP hΦ hσ hmap V
+    exact hVrange.trans hSupport.symm
+  have hτc : τc.PosDef := by
+    have h := hτ.compression_on_support_posDef (V := Vᴴ)
+      (by simpa only [Matrix.conjTranspose_conjTranspose] using hV)
+      (by simpa only [Matrix.conjTranspose_conjTranspose] using hVrange)
+    simpa only [τc, Matrix.conjTranspose_conjTranspose] using h
+  have hmapc : Ψ σ = τc := by
+    simp only [Ψ, τc, outputSupportCompressedMap, LinearMap.comp_apply,
+      singleKrausMap_apply, Matrix.conjTranspose_conjTranspose, hmap]
+  let q := hτ.supportInvFourthRoot
+  let qc := (CFC.sqrt (CFC.sqrt τc))⁻¹
+  have hqcomp : Vᴴ * q * V = qc := by
+    simpa only [q, qc, τc] using
+      hτ.supportInvFourthRoot_compression_on_support V hV hVrange
+  have hPq : hτ.supportProj * q = q := by
+    let hsτ : (CFC.sqrt τ).PosSemidef :=
+      Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg τ)
+    change hτ.supportProj * hsτ.supportInvSqrt = hsτ.supportInvSqrt
+    rw [← hτ.supportProj_cfc_sqrt]
+    exact hsτ.supportProj_mul_supportInvSqrt
+  have hqP : q * hτ.supportProj = q := by
+    let hsτ : (CFC.sqrt τ).PosSemidef :=
+      Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg τ)
+    change hsτ.supportInvSqrt * hτ.supportProj = hsτ.supportInvSqrt
+    rw [← hτ.supportProj_cfc_sqrt]
+    exact hsτ.supportInvSqrt_mul_supportProj
+  have hqstar : qᴴ = q := by
+    exact (Matrix.nonneg_iff_posSemidef.mp
+      (CFC.sqrt_nonneg τ)).supportInvSqrt_isHermitian.eq
+  let qσ := CFC.sqrt (CFC.sqrt σ)
+  let Y := Φ (qσ * X * qσ)
+  have hPY : hτ.supportProj * Y = Y := by
+    rw [← hSupport]
+    exact Matrix.IsKrausCPTP.supportProj_mul_map hΦ hσ hmap (qσ * X * qσ)
+  have hYP : Y * hτ.supportProj = Y := by
+    rw [← hSupport]
+    exact Matrix.IsKrausCPTP.map_mul_supportProj hΦ hσ hmap (qσ * X * qσ)
+  let Z := weightedHilbertSchmidtMap Ψ σ τc X
+  have hZnorm : ‖Z‖ ≤ ‖X‖ :=
+    weightedHilbertSchmidtMap_norm_le hΨ hσ hτc hmapc X
+  have hqσstar : qσᴴ = qσ := by
+    exact (Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg (CFC.sqrt σ))).isHermitian.eq
+  have hqcstar : qcᴴ = qc := by
+    dsimp only [qc]
+    rw [Matrix.conjTranspose_nonsing_inv]
+    exact congrArg Inv.inv
+      (Matrix.nonneg_iff_posSemidef.mp
+        (CFC.sqrt_nonneg (CFC.sqrt τc))).isHermitian.eq
+  have hZ : Z = qc * (Vᴴ * Y * V) * qc := by
+    simp only [Z, weightedHilbertSchmidtMap, LinearMap.comp_apply,
+      singleKrausMap_apply, Ψ, outputSupportCompressedMap,
+      Matrix.conjTranspose_conjTranspose, hqσstar, qσ, Y, qc, hqcstar]
+  have hembed : V * Z * Vᴴ = q * Y * q := by
+    rw [hZ, ← hqcomp]
+    calc
+      V * ((Vᴴ * q * V) * (Vᴴ * Y * V) * (Vᴴ * q * V)) * Vᴴ =
+          (V * Vᴴ) * q * (V * Vᴴ) * Y * (V * Vᴴ) * q * (V * Vᴴ) := by
+        simp only [Matrix.mul_assoc]
+      _ = hτ.supportProj * q * hτ.supportProj * Y *
+          hτ.supportProj * q * hτ.supportProj := by rw [hVrange]
+      _ = q * Y * q := by
+        simp only [Matrix.mul_assoc, hPq, hqP, hYP]
+  have hsupported : supportedWeightedHilbertSchmidtMap Φ σ hτ X = q * Y * q := by
+    simp only [supportedWeightedHilbertSchmidtMap, LinearMap.comp_apply,
+      singleKrausMap_apply, hqstar, hqσstar, q, qσ, Y]
+  rw [hsupported, ← hembed, frobenius_norm_isometry_mul_mul_conjTranspose V hV]
+  exact hZnorm
+
+/-- The support-weighted `p = 2` specialization of the Schatten-norm
+contraction in Beigi, arXiv:1306.5920, Theorem 6 and equation (18).
+
+No full-support hypothesis is imposed on the output `Φ σ`; its negative
+quarter power vanishes on the kernel. -/
+theorem supportedWeightedHilbertSchmidtMap_norm_le
+    {r p : ℕ} {Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ}
+    {σ : Matrix (Fin r) (Fin r) ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) (X : Matrix (Fin r) (Fin r) ℂ) :
+    ‖supportedWeightedHilbertSchmidtMap Φ σ
+      (hΦ.map_posSemidef hσ.posSemidef) X‖ ≤ ‖X‖ := by
+  exact supportedWeightedHilbertSchmidtMap_norm_le_aux hΦ hσ
+    (hΦ.map_posSemidef hσ.posSemidef) rfl X
+
+/-- The support-weighted channel map is a Hilbert--Schmidt contraction without
+a full-support assumption on the output weight. -/
+theorem supportedWeightedHilbertSchmidtMap_isHilbertSchmidtContraction
+    {r p : ℕ} {Φ : Matrix (Fin r) (Fin r) ℂ →ₗ[ℂ] Matrix (Fin p) (Fin p) ℂ}
+    {σ : Matrix (Fin r) (Fin r) ℂ}
+    (hΦ : IsKrausCPTP Φ) (hσ : σ.PosDef) :
+    IsHilbertSchmidtContraction
+      (supportedWeightedHilbertSchmidtMap Φ σ
+        (hΦ.map_posSemidef hσ.posSemidef)) := by
+  intro X
+  rw [trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq,
+    trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
+  have hNorm := supportedWeightedHilbertSchmidtMap_norm_le hΦ hσ X
+  nlinarith [norm_nonneg
+    (supportedWeightedHilbertSchmidtMap Φ σ
+      (hΦ.map_posSemidef hσ.posSemidef) X), norm_nonneg X]
+
 -- The contraction specializes to the identity channel on the two-dimensional matrix algebra.
 private theorem weightedHilbertSchmidtMap_identity_fin_two
     (X : Matrix (Fin 2) (Fin 2) ℂ) :
@@ -301,5 +557,13 @@ private theorem weightedHilbertSchmidtMap_identity_fin_zero
       1 1 X‖ ≤ ‖X‖ := by
   exact weightedHilbertSchmidtMap_norm_le isKrausCPTP_id
     Matrix.PosDef.one Matrix.PosDef.one rfl X
+
+-- The support-weighted theorem includes the zero-dimensional output algebra.
+private theorem supportedWeightedHilbertSchmidtMap_identity_fin_zero
+    (X : Matrix (Fin 0) (Fin 0) ℂ) :
+    ‖supportedWeightedHilbertSchmidtMap
+      (LinearMap.id : Matrix (Fin 0) (Fin 0) ℂ →ₗ[ℂ] Matrix (Fin 0) (Fin 0) ℂ)
+      1 (isKrausCPTP_id.map_posSemidef Matrix.PosDef.one.posSemidef) X‖ ≤ ‖X‖ := by
+  exact supportedWeightedHilbertSchmidtMap_norm_le isKrausCPTP_id Matrix.PosDef.one X
 
 end Matrix

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -276,9 +276,7 @@ partial traces.
     positive-semidefinite matrices have equal support projections, and taking
     the positive square root leaves $P$ unchanged.  If
     $V:\mathbb C^K\to\mathbb C^J$ satisfies $VV^\dagger=P$, then
-    \[
-        \sqrt{V^\dagger\tau V}=V^\dagger\sqrt\tau V.
-    \]
+    $\sqrt{V^\dagger\tau V}=V^\dagger\sqrt\tau V$.
     Moreover, both $P\tau^{-1/2}_{\operatorname{supp}}
     =\tau^{-1/2}_{\operatorname{supp}}$ and
     $\tau^{-1/2}_{\operatorname{supp}}P

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -261,6 +261,137 @@ partial traces.
     its operator norm, which proves the contraction estimate.
 \end{proof}
 
+\begin{theorem}[Functional calculus under support compression]
+    \label{thm:functional_calculus_support_compression}
+    \lean{Matrix.PosSemidef.supportProj_congr,
+        Matrix.PosSemidef.supportProj_cfc_sqrt,
+        Matrix.PosSemidef.supportInvSqrt_mul_supportProj,
+        Matrix.PosSemidef.supportProj_mul_supportInvSqrt,
+        Matrix.PosSemidef.sqrt_compression_on_support,
+        Matrix.PosSemidef.supportInvSqrt_compression_on_support,
+        Matrix.PosSemidef.supportInvFourthRoot_compression_on_support,
+        Matrix.frobenius_norm_isometry_mul_mul_conjTranspose}
+    \leanok
+    Let $\tau\geq0$, let $P$ be its support projection, and let
+    $V:\operatorname{supp}\tau\to\mathbb C^J$ be an isometry with
+    $VV^\dagger=P$.  Taking the positive square root leaves $P$ unchanged,
+    and both $P\tau^{-1/2}_{\operatorname{supp}}
+    =\tau^{-1/2}_{\operatorname{supp}}$ and
+    $\tau^{-1/2}_{\operatorname{supp}}P
+    =\tau^{-1/2}_{\operatorname{supp}}$.  Moreover,
+    \begin{align}
+        \sqrt{V^\dagger\tau V}
+        &=V^\dagger\sqrt\tau V, \notag \\
+        V^\dagger\tau^{-1/2}_{\operatorname{supp}}V
+        &=(\sqrt{V^\dagger\tau V})^{-1}, \notag \\
+        V^\dagger\tau^{-1/4}_{\operatorname{supp}}V
+        &=(\sqrt{\sqrt{V^\dagger\tau V}})^{-1}.
+        \notag
+    \end{align}
+    For every matrix $Z$ on $\operatorname{supp}\tau$,
+    $\|VZV^\dagger\|_2=\|Z\|_2$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The square-root identity follows from uniqueness of the positive square
+    root.  The support inverse identities follow from the corresponding
+    cancellation relations on the positive spectral subspace.  The norm
+    identity follows by cyclicity of the trace and $V^\dagger V=\Id$.
+\end{proof}
+
+\begin{definition}[Output-support compression]
+    \label{def:output_support_compressed_map}
+    \lean{Matrix.outputSupportCompressedMap}
+    \leanok
+    For an isometry $V:\mathbb C^K\to\mathbb C^J$ and a complex-linear map
+    $\Phi:\mathbb C^{I\times I}\to\mathbb C^{J\times J}$, define
+    $\Psi(X)=V^\dagger\Phi(X)V$.
+\end{definition}
+
+\begin{theorem}[Channel outputs from a faithful input lie in its image support]
+    \label{thm:channel_output_support_from_faithful_input}
+    \lean{Matrix.IsKrausCPTP.supportProj_mul_map,
+        Matrix.IsKrausCPTP.map_mul_supportProj,
+        Matrix.outputSupportCompressedMap_isKrausCPTP}
+    \leanok
+    \uses{def:is_kraus_cptp, def:output_support_compressed_map}
+    Let $\Phi$ be completely positive and trace preserving, let $\sigma>0$,
+    set $\tau=\Phi(\sigma)$, and let $P$ be the support projection of $\tau$.
+    Then every matrix $X$ satisfies
+    $P\Phi(X)=\Phi(X)=\Phi(X)P$.  If $VV^\dagger=P$ and
+    $V^\dagger V=\Id$, then $\Psi(X)=V^\dagger\Phi(X)V$ is completely
+    positive and trace preserving.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Choose Kraus operators $A_i$ for $\Phi$.  The joint column Gram matrix of
+    $A_i\sqrt\sigma$ is $\tau$, so its column support is $P$.  Since
+    $\sqrt\sigma$ is invertible, $PA_i=A_i$ for every $i$, which gives the
+    two support identities.  Cyclicity of the trace then shows that compression
+    by $V$ preserves the trace of every output.
+\end{proof}
+
+\begin{definition}[Support-weighted channel map]
+    \label{def:supported_weighted_hilbert_schmidt_map}
+    \lean{Matrix.PosSemidef.supportInvFourthRoot,
+        Matrix.supportedWeightedHilbertSchmidtMap}
+    \leanok
+    Let $\tau\geq 0$.  Its support-restricted negative quarter power
+    $\tau^{-1/4}_{\operatorname{supp}}$ acts by $x^{-1/4}$ on every positive
+    eigenspace and vanishes on the kernel.  For a complex-linear map $\Phi$,
+    define
+    \begin{align}
+        L_{\operatorname{supp}}(X)
+        &=\tau^{-1/4}_{\operatorname{supp}}
+          \Phi(\sigma^{1/4}X\sigma^{1/4})
+          \tau^{-1/4}_{\operatorname{supp}}.
+        \notag
+    \end{align}
+\end{definition}
+
+\begin{theorem}[Support-weighted Hilbert--Schmidt contraction]
+    \label{thm:weighted_hilbert_schmidt_contraction_support}
+    \lean{Matrix.supportedWeightedHilbertSchmidtMap_norm_le,
+        Matrix.supportedWeightedHilbertSchmidtMap_isHilbertSchmidtContraction}
+    \leanok
+    \uses{def:is_kraus_cptp,
+        def:supported_weighted_hilbert_schmidt_map}
+    Let $\Phi:\mathbb C^{I\times I}\to\mathbb C^{J\times J}$ be completely
+    positive and trace preserving, let $\sigma>0$, and set
+    $\tau=\Phi(\sigma)$.  Then, for every $X$,
+    \begin{align}
+        \left\|\tau^{-1/4}_{\operatorname{supp}}
+          \Phi(\sigma^{1/4}X\sigma^{1/4})
+          \tau^{-1/4}_{\operatorname{supp}}\right\|_2
+        &\leq \|X\|_2.
+        \notag
+    \end{align}
+    Equivalently, $L_{\operatorname{supp}}$ is a Hilbert--Schmidt
+    contraction.  This is the exponent-two specialization of
+    \cite[Theorem~6, Equation~(18)]{Beigi2013Sandwiched}, including singular
+    output weights.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:weighted_hilbert_schmidt_contraction_full_support,
+        thm:functional_calculus_support_compression,
+        thm:channel_output_support_from_faithful_input}
+    Let $P$ be the support projection of $\tau$, and choose an isometry
+    $V:\operatorname{supp}\tau\to\mathbb C^J$ with $VV^\dagger=P$.  Since
+    $\sigma$ is positive definite, every Kraus operator of $\Phi$ has range
+    in $\operatorname{supp}\tau$.  Hence
+    $\Psi(A)=V^\dagger\Phi(A)V$ is completely positive and trace preserving,
+    while $\tau_c=V^\dagger\tau V$ is positive definite and
+    $\Psi(\sigma)=\tau_c$.  The full-support estimate applies to $\Psi$.
+    Functional calculus on the support gives
+    $V^\dagger\tau^{-1/4}_{\operatorname{supp}}V=\tau_c^{-1/4}$, and
+    expansion by $V$ preserves the Hilbert--Schmidt norm.  Transporting the
+    compressed estimate along $V$ proves the result.
+\end{proof}
+
 %% =========================================================
 \section{Further Choi-matrix identities}
 \label{sec:choi_matrix_further_identities}

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -272,24 +272,28 @@ partial traces.
         Matrix.PosSemidef.supportInvFourthRoot_compression_on_support,
         Matrix.frobenius_norm_isometry_mul_mul_conjTranspose}
     \leanok
-    Let $\tau\geq0$, let $P$ be its support projection, and let
-    $V:\operatorname{supp}\tau\to\mathbb C^J$ be an isometry with
-    $VV^\dagger=P$.  Taking the positive square root leaves $P$ unchanged,
-    and both $P\tau^{-1/2}_{\operatorname{supp}}
+    Let $\tau\geq0$, and let $P$ be its support projection.  Equal
+    positive-semidefinite matrices have equal support projections, and taking
+    the positive square root leaves $P$ unchanged.  If
+    $V:\mathbb C^K\to\mathbb C^J$ satisfies $VV^\dagger=P$, then
+    \[
+        \sqrt{V^\dagger\tau V}=V^\dagger\sqrt\tau V.
+    \]
+    Moreover, both $P\tau^{-1/2}_{\operatorname{supp}}
     =\tau^{-1/2}_{\operatorname{supp}}$ and
     $\tau^{-1/2}_{\operatorname{supp}}P
-    =\tau^{-1/2}_{\operatorname{supp}}$.  Moreover,
+    =\tau^{-1/2}_{\operatorname{supp}}$.  If, in addition,
+    $V^\dagger V=\Id$, then
     \begin{align}
-        \sqrt{V^\dagger\tau V}
-        &=V^\dagger\sqrt\tau V, \notag \\
         V^\dagger\tau^{-1/2}_{\operatorname{supp}}V
         &=(\sqrt{V^\dagger\tau V})^{-1}, \notag \\
         V^\dagger\tau^{-1/4}_{\operatorname{supp}}V
         &=(\sqrt{\sqrt{V^\dagger\tau V}})^{-1}.
         \notag
     \end{align}
-    For every matrix $Z$ on $\operatorname{supp}\tau$,
-    $\|VZV^\dagger\|_2=\|Z\|_2$.
+    Independently, if $W:\mathbb C^L\to\mathbb C^J$ satisfies
+    $W^\dagger W=\Id$, then $\|WZW^\dagger\|_2=\|Z\|_2$ for every
+    $Z\in\mathbb C^{L\times L}$.
 \end{theorem}
 
 \begin{proof}
@@ -297,14 +301,14 @@ partial traces.
     The square-root identity follows from uniqueness of the positive square
     root.  The support inverse identities follow from the corresponding
     cancellation relations on the positive spectral subspace.  The norm
-    identity follows by cyclicity of the trace and $V^\dagger V=\Id$.
+    identity follows by cyclicity of the trace and $W^\dagger W=\Id$.
 \end{proof}
 
 \begin{definition}[Output-support compression]
     \label{def:output_support_compressed_map}
     \lean{Matrix.outputSupportCompressedMap}
     \leanok
-    For an isometry $V:\mathbb C^K\to\mathbb C^J$ and a complex-linear map
+    For a matrix $V:\mathbb C^K\to\mathbb C^J$ and a complex-linear map
     $\Phi:\mathbb C^{I\times I}\to\mathbb C^{J\times J}$, define
     $\Psi(X)=V^\dagger\Phi(X)V$.
 \end{definition}
@@ -319,9 +323,8 @@ partial traces.
     Let $\Phi$ be completely positive and trace preserving, let $\sigma>0$,
     set $\tau=\Phi(\sigma)$, and let $P$ be the support projection of $\tau$.
     Then every matrix $X$ satisfies
-    $P\Phi(X)=\Phi(X)=\Phi(X)P$.  If $VV^\dagger=P$ and
-    $V^\dagger V=\Id$, then $\Psi(X)=V^\dagger\Phi(X)V$ is completely
-    positive and trace preserving.
+    $P\Phi(X)=\Phi(X)=\Phi(X)P$.  If $VV^\dagger=P$, then
+    $\Psi(X)=V^\dagger\Phi(X)V$ is completely positive and trace preserving.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -203,11 +203,15 @@ The Choi-matrix estimate is also formalized.\footnote{Formal declarations:
 \leanid{Matrix.rectangularChoi_frobenius_parseval} and
 \leanid{Matrix.rectangularChoi_frobenius_sq_le_finrank_range} in
 \doclink{TNLean/Algebra/RectangularChoi}.}
-The full-support exponent-two weighted Hilbert--Schmidt contraction used after
-the support compression is formalized.\footnote{Formal declarations:
-\leanid{Matrix.weightedHilbertSchmidtMap_norm_le} and
-\leanid{Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction} in
-\doclink{TNLean/Channel/WeightedHilbertSchmidt}.}
+The exponent-two weighted Hilbert--Schmidt contraction is formalized both for
+positive-definite output weights and for arbitrary positive-semidefinite output
+weights, with the negative quarter power taken on the output support.\footnote{
+Formal declarations:
+\leanid{Matrix.weightedHilbertSchmidtMap_norm_le},
+\leanid{Matrix.weightedHilbertSchmidtMap_isHilbertSchmidtContraction},
+\leanid{Matrix.supportedWeightedHilbertSchmidtMap_norm_le}, and
+\leanid{Matrix.supportedWeightedHilbertSchmidtMap_isHilbertSchmidtContraction}
+in \doclink{TNLean/Channel/WeightedHilbertSchmidt}.}
 The full-support eigenbasis calculation is formalized: the whitening is
 identified exactly with the rectangular Choi matrix, including the input
 transpose convention, the modular congruences preserve the range dimension,
@@ -262,15 +266,20 @@ The reconstruction and entropy identities are formalized separately.
 \leanid{TNLean.quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace_of_faithful}
 in \doclink{TNLean/Analysis/SupportCompressedEntropy}.}
 
+The one-sided output-support compression is also formalized: faithfulness of
+the input weight forces every channel output into the support of its image,
+the compressed channel is trace preserving, and the support-restricted
+negative quarter power agrees with the ordinary negative quarter power after
+compression.  The eigenbasis whitening statements still assume both marginal
+weights are positive definite and therefore do not supply the two-local
+compression from singular ambient marginals to both support algebras.
+
 This reduction does not complete
 \href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  That issue still
 requires simultaneous compression by the two marginal support isometries and a
 proof that this local two-factor compression preserves operator-Schmidt rank.
-The singular-output weighted contraction is handled separately in
-\href{https://github.com/LionSR/TNLean/issues/5225}{\#5225}; it is not a
-consequence of the single-reference entropy identities above.  The faithful
-comparison itself still requires the weighted interpolation and order-one-limit
-analysis tracked in
+The faithful comparison itself still requires the weighted interpolation and
+order-one-limit analysis tracked in
 \href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  Beigi proves
 order monotonicity \cite[Theorem~7]{Beigi2013Sandwiched}, while
 M\"uller-Lennert, Dupuis, Szehr, Fehr, and Tomamichel prove the order-one

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -24,6 +24,17 @@ abstracted — record why, so it is not re-proposed).
 
 ## Promoted
 
+### positive-semidefinite support congruence — promoted
+- **Pattern:** transport the support projection across an equality of positive
+  semidefinite matrices while identifying the two positivity proofs by proof
+  irrelevance.
+- **Seen:** three occurrences across `MatrixFamilySupport.lean` and
+  `WeightedHilbertSchmidt.lean` before promotion.
+- **Abstraction:** `Matrix.PosSemidef.supportProj_congr` in
+  `TNLean/Algebra/PosSemidefSupport.lean`.
+- **Notes:** the lemma isolates the dependent proof transport that ordinary
+  rewriting does not resolve directly.
+
 ### mpv_ext — promoted
 - **Pattern:** `intro N σ` / `intro N hN σ` prelude for `SameMPV₂` /
   `SameMPV₂Pos` goals.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -63,7 +63,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | — | L97 `tenkz` → `C-policy+C-record+R-record` |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
 | `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
-| `ch16_channel_representations_choi_and_kraus.tex` | — | L538 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | — | L670 `tenkz` → `C-policy+C-record` | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L20 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L232, 238 `tenkz` → `C-policy+C-record` | L153, 159, 336, 433 `tenkz` → `C-policy+C-record+R-record`<br>L177, 182 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |


### PR DESCRIPTION
## Summary

- define the negative fourth root of a positive-semidefinite matrix on its support;
- prove square-root and support-inverse covariance under compression to the support;
- show that every output of a channel lies in the support of the image of a faithful input;
- compress the output channel and derive the support-weighted Hilbert--Schmidt contraction from the full-support theorem;
- synchronize the Blueprint and the mutual-information paper-gap note.

## Mathematical statement

For a completely positive trace-preserving map Φ and a positive-definite input weight σ, set τ = Φ(σ), with no positive-definiteness assumption on τ. The pull request proves

‖τ⁻¹⁄⁴_supp Φ(σ¹⁄⁴ X σ¹⁄⁴) τ⁻¹⁄⁴_supp‖₂ ≤ ‖X‖₂,

where the negative quarter power acts on the positive spectral subspace of τ and vanishes on its kernel.

The proof compresses the output algebra to supp τ. The compressed output weight is positive definite, the compressed map remains trace preserving because every Kraus range lies in supp τ, and isometric inclusion preserves the Frobenius norm.

## Scope

This completes the one-sided singular-output contraction. It does not complete the two-factor marginal compression or the proof that such compression preserves operator-Schmidt rank; those remain under #5211. The mutual-information theorem remains open.

## Validation

- focused 3,057-job weighted-channel build;
- full 9,858-job TNLean build before the documentation-only exactness repairs;
- Blueprint web generation, synchronization, and declaration checking;
- style, proof-integrity, reader-facing prose, tactic-pattern, line-length, and whitespace checks;
- two independent exact-head approvals at `5b82ec69126f8a787ac27f9fa7be7b62bf8e4c83`.

Closes #5225.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Substantial new formal analysis in weighted channel maps and PSD support calculus; mistakes could affect downstream entropy or mutual-information proofs, but changes are localized to matrix/channel theory with no runtime or security surface.
> 
> **Overview**
> Adds **support-weighted** Hilbert–Schmidt channel maps and proves **‖τ⁻¹⁄⁴_supp Φ(σ¹⁄⁴ X σ¹⁄⁴) τ⁻¹⁄⁴_supp‖₂ ≤ ‖X‖₂** for CPTP Φ and faithful input σ, without requiring positive-definite output τ = Φ(σ). The negative quarter power is **`supportInvFourthRoot`** (kernel zero, x⁻¹⁄⁴ on the support).
> 
> The proof **compresses outputs** to supp τ with an isometry, shows **faithful σ forces all channel outputs into that support**, keeps the compressed map trace preserving, applies the existing full-support contraction on the compressed positive-definite weight, then **embeds back** using support functional-calculus identities (square roots, inverse square roots, quarter powers under compression) and **`frobenius_norm_isometry_mul_mul_conjTranspose`**.
> 
> Supporting library work: **`PosSemidef.supportProj_congr`**, absorption lemmas for support inverse powers, **`sqrt_compression_on_support`** and related compression theorems, and refactors (e.g. Kronecker family support) to use the shared congruence lemma. **Blueprint ch16** and the **mutual-information paper-gap** note are updated; closes **#5225**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e47508f95ceaf6fc079146e0764c9536ffac412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->