### PR TITLE
feat(Analysis): add sandwiched Rényi trace endpoints

### DIFF
--- a/TNLean/Analysis.lean
+++ b/TNLean/Analysis.lean
@@ -40,6 +40,7 @@ import TNLean.Analysis.RelativeEntropySupportIntegral
 import TNLean.Analysis.RelativeEntropySupportLeftRightQuadratic
 import TNLean.Analysis.ResolventFunctionalCalculus
 import TNLean.Analysis.RpowConvexity
+import TNLean.Analysis.SandwichedRenyi
 import TNLean.Analysis.SandwichedRenyiTwo
 import TNLean.Analysis.SchattenNorm
 import TNLean.Analysis.SuperoperatorResolvent

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -113,10 +113,8 @@ theorem sandwichedRenyiTrace_nonneg
     {α : ℝ} {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
     0 ≤ sandwichedRenyiTrace α ρ ω := by
   let q := ω ^ ((1 - α) / (2 * α))
-  have hq : q.PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
-  have hX : (q * ρ * q).PosSemidef := by
-    simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
+  have hX : (q * ρ * q).PosSemidef :=
+    Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω ((1 - α) / (2 * α))
   have hpow_nonneg : 0 ≤ (q * ρ * q) ^ α := by
     rw [CFC.rpow_eq_cfc_real hX.nonneg]
     exact cfc_nonneg fun x hx ↦
@@ -150,10 +148,8 @@ theorem sandwichedRenyiTrace_two
   rw [sandwichedRenyiTrace, sandwichedRenyiTwoTrace]
   rw [show (1 - (2 : ℝ)) / (2 * 2) = -(1 / 4 : ℝ) by norm_num]
   let q := ω ^ (-(1 / 4 : ℝ))
-  have hq : q.PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
-  have hX : (q * ρ * q).PosSemidef := by
-    simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
+  have hX : (q * ρ * q).PosSemidef :=
+    Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
   change (Matrix.trace ((q * ρ * q) ^ (2 : ℝ))).re =
     (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
   rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num,

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -16,14 +16,18 @@ For a real order \(\alpha\), this file defines the total trace functional
   \right].
 \]
 On positive-semidefinite \(\rho\) and positive-definite \(\omega\), this is the
-quantity inside the logarithm in the faithful sandwiched Rényi divergence. The
+unnormalized trace term entering the faithful sandwiched Rényi divergence. When
+\(\rho\) is a density matrix, it is the quantity inside the logarithm. The
 intended range here is \(1\leq\alpha\leq2\). No trace-one assumption is needed
 for the algebraic properties proved below.
 
 Continuous-functional-calculus real powers are total: in particular, negative
-powers vanish at a zero eigenvalue. Thus the definition remains finite outside
-the faithful domain, but that totalized value must not be identified with the
-sandwiched Rényi divergence when its support condition fails. We prove only
+powers vanish at a zero eigenvalue. For positive-semidefinite \(\rho\) and
+singular \(\omega\) satisfying \(\ker\omega\subseteq\ker\rho\), equivalently
+the required support inclusion, this zero-on-kernel convention is the
+generalized-inverse convention and gives the trace term of a finite divergence.
+If support inclusion fails, the divergence is infinite, whereas the totalized
+functional remains finite and must not be identified with it. We prove only
 nonnegativity on the faithful domain and the exact order-one and order-two
 endpoints; no assertion about continuity, interpolation, monotonicity, limits,
 derivatives, logarithmic divergence, or comparison with Umegaki relative
@@ -82,12 +86,15 @@ private local instance instRenyiCStarAlgebra : CStarAlgebra Mat :=
   \right].
 \]
 For positive-semidefinite \(\rho\), positive-definite \(\omega\), and
-\(1\leq\alpha\leq2\), this is the trace quantity used in the faithful
+\(1\leq\alpha\leq2\), this is the unnormalized trace term used in the faithful
 sandwiched Rényi divergence of Müller-Lennert et al., arXiv:1306.3142v4,
-Definition 2, and Beigi, arXiv:1306.5920, Definition 2. The definition is total
-for every real \(\alpha\), including \(\alpha=0\), and for nonfaithful
-\(\omega\); those extra values are algebraic totalizations, not values of the
-divergence. -/
+Definition 2, and Beigi, arXiv:1306.5920, Definition 2. For trace-one \(\rho\),
+it is the quantity inside the logarithm. The definition is total for every real
+\(\alpha\), including \(\alpha=0\), and for singular \(\omega\). On
+positive-semidefinite inputs with \(\ker\omega\subseteq\ker\rho\), its
+zero-on-kernel powers implement the generalized inverse and give the finite
+divergence trace term. If this support inclusion fails, the finite totalized
+value is not the divergence. -/
 noncomputable def sandwichedRenyiTrace (α : ℝ) (ρ ω : Mat) : ℝ :=
   let q := ω ^ ((1 - α) / (2 * α))
   (Matrix.trace ((q * ρ * q) ^ α)).re

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -110,11 +110,12 @@ Müller-Lennert et al., arXiv:1306.3142v4, Definition 2, and Beigi,
 arXiv:1306.5920, Equation (3). It holds for every real order because the
 continuous-functional-calculus real power is positive semidefinite. -/
 theorem sandwichedRenyiTrace_nonneg
-    {α : ℝ} {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
+    {α : ℝ} {ρ ω : Mat} (hρ : ρ.PosSemidef) (hω : ω.PosDef) :
     0 ≤ sandwichedRenyiTrace α ρ ω := by
   let q := ω ^ ((1 - α) / (2 * α))
   have hX : (q * ρ * q).PosSemidef :=
-    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω ((1 - α) / (2 * α))
+    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ hω.posSemidef
+      ((1 - α) / (2 * α))
   have hpow_nonneg : 0 ≤ (q * ρ * q) ^ α := by
     rw [CFC.rpow_eq_cfc_real hX.nonneg]
     exact cfc_nonneg fun x hx ↦
@@ -143,13 +144,13 @@ with `sandwichedRenyiTwoTrace`.
 This is the \(\alpha=2\) endpoint of Müller-Lennert et al.,
 arXiv:1306.3142v4, Definition 2, and Beigi, arXiv:1306.5920, Equation (3). -/
 theorem sandwichedRenyiTrace_two
-    {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
+    {ρ ω : Mat} (hρ : ρ.PosSemidef) (hω : ω.PosDef) :
     sandwichedRenyiTrace 2 ρ ω = sandwichedRenyiTwoTrace ρ ω := by
   rw [sandwichedRenyiTrace, sandwichedRenyiTwoTrace]
   rw [show (1 - (2 : ℝ)) / (2 * 2) = -(1 / 4 : ℝ) by norm_num]
   let q := ω ^ (-(1 / 4 : ℝ))
   have hX : (q * ρ * q).PosSemidef :=
-    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
+    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ hω.posSemidef (-(1 / 4 : ℝ))
   change (Matrix.trace ((q * ρ * q) ^ (2 : ℝ))).re =
     (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
   rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num,

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -50,7 +50,7 @@ entropy is made.
   *On quantum Rényi entropies: a new generalization and some properties*,
   arXiv:1306.3142v4, Definition 2 and Theorem 5.
 * Beigi, *Sandwiched Rényi divergence satisfies data processing inequality*,
-  arXiv:1306.5920, Equation (2) and Theorem 7.
+  arXiv:1306.5920, Equation (3) and Theorem 7.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -89,7 +89,7 @@ private local instance instRenyiCStarAlgebra : CStarAlgebra Mat :=
 For positive-semidefinite \(\rho\), positive-definite \(\omega\), and
 \(1\leq\alpha\leq2\), this is the unnormalized trace term used in the faithful
 sandwiched Rényi divergence of Müller-Lennert et al., arXiv:1306.3142v4,
-Definition 2, and Beigi, arXiv:1306.5920, Equation (2). For trace-one \(\rho\),
+Definition 2, and Beigi, arXiv:1306.5920, Equation (3). For trace-one \(\rho\),
 it is the quantity inside the logarithm. The definition is total for every real
 \(\alpha\), including \(\alpha=0\), and for singular \(\omega\). For
 \(\alpha>1\), within the present \(1\leq\alpha\leq2\) application, finite
@@ -107,7 +107,7 @@ positive semidefinite and \(\omega\) is positive definite.
 
 This is the faithful-domain positivity of the trace expression in
 Müller-Lennert et al., arXiv:1306.3142v4, Definition 2, and Beigi,
-arXiv:1306.5920, Equation (2). It holds for every real order because the
+arXiv:1306.5920, Equation (3). It holds for every real order because the
 continuous-functional-calculus real power is positive semidefinite. -/
 theorem sandwichedRenyiTrace_nonneg
     {α : ℝ} {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
@@ -141,7 +141,7 @@ theorem sandwichedRenyiTrace_one
 with `sandwichedRenyiTwoTrace`.
 
 This is the \(\alpha=2\) endpoint of Müller-Lennert et al.,
-arXiv:1306.3142v4, Definition 2, and Beigi, arXiv:1306.5920, Equation (2). -/
+arXiv:1306.3142v4, Definition 2, and Beigi, arXiv:1306.5920, Equation (3). -/
 theorem sandwichedRenyiTrace_two
     {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
     sandwichedRenyiTrace 2 ρ ω = sandwichedRenyiTwoTrace ρ ω := by

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -50,7 +50,7 @@ entropy is made.
   *On quantum Rényi entropies: a new generalization and some properties*,
   arXiv:1306.3142v4, Definition 2 and Theorem 5.
 * Beigi, *Sandwiched Rényi divergence satisfies data processing inequality*,
-  arXiv:1306.5920, Definition 2 and Theorem 7.
+  arXiv:1306.5920, Equation (2) and Theorem 7.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -89,7 +89,7 @@ private local instance instRenyiCStarAlgebra : CStarAlgebra Mat :=
 For positive-semidefinite \(\rho\), positive-definite \(\omega\), and
 \(1\leq\alpha\leq2\), this is the unnormalized trace term used in the faithful
 sandwiched Rényi divergence of Müller-Lennert et al., arXiv:1306.3142v4,
-Definition 2, and Beigi, arXiv:1306.5920, Definition 2. For trace-one \(\rho\),
+Definition 2, and Beigi, arXiv:1306.5920, Equation (2). For trace-one \(\rho\),
 it is the quantity inside the logarithm. The definition is total for every real
 \(\alpha\), including \(\alpha=0\), and for singular \(\omega\). For
 \(\alpha>1\), within the present \(1\leq\alpha\leq2\) application, finite
@@ -107,7 +107,7 @@ positive semidefinite and \(\omega\) is positive definite.
 
 This is the faithful-domain positivity of the trace expression in
 Müller-Lennert et al., arXiv:1306.3142v4, Definition 2, and Beigi,
-arXiv:1306.5920, Definition 2. It holds for every real order because the
+arXiv:1306.5920, Equation (2). It holds for every real order because the
 continuous-functional-calculus real power is positive semidefinite. -/
 theorem sandwichedRenyiTrace_nonneg
     {α : ℝ} {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
@@ -143,7 +143,7 @@ theorem sandwichedRenyiTrace_one
 with `sandwichedRenyiTwoTrace`.
 
 This is the \(\alpha=2\) endpoint of Müller-Lennert et al.,
-arXiv:1306.3142v4, Definition 2, and Beigi, arXiv:1306.5920, Definition 2. -/
+arXiv:1306.3142v4, Definition 2, and Beigi, arXiv:1306.5920, Equation (2). -/
 theorem sandwichedRenyiTrace_two
     {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
     sandwichedRenyiTrace 2 ρ ω = sandwichedRenyiTwoTrace ρ ω := by

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -22,12 +22,13 @@ intended range here is \(1\leq\alpha\leq2\). No trace-one assumption is needed
 for the algebraic properties proved below.
 
 Continuous-functional-calculus real powers are total: in particular, negative
-powers vanish at a zero eigenvalue. For positive-semidefinite \(\rho\) and
-singular \(\omega\) satisfying \(\ker\omega\subseteq\ker\rho\), equivalently
-the required support inclusion, this zero-on-kernel convention is the
-generalized-inverse convention and gives the trace term of a finite divergence.
-If support inclusion fails, the divergence is infinite, whereas the totalized
-functional remains finite and must not be identified with it. We prove only
+powers vanish at a zero eigenvalue. For \(\alpha>1\), within the present
+\(1\leq\alpha\leq2\) application, finite divergence requires
+\(\operatorname{supp}\rho\subseteq\operatorname{supp}\omega\), equivalently
+\(\ker\omega\subseteq\ker\rho\). On positive-semidefinite inputs satisfying
+this inclusion, the zero-on-kernel convention is the generalized inverse. If
+the inclusion fails, the divergence is infinite, whereas the totalized CFC
+value remains finite and is not the divergence trace term. We prove only
 nonnegativity on the faithful domain and the exact order-one and order-two
 endpoints; no assertion about continuity, interpolation, monotonicity, limits,
 derivatives, logarithmic divergence, or comparison with Umegaki relative
@@ -90,11 +91,13 @@ For positive-semidefinite \(\rho\), positive-definite \(\omega\), and
 sandwiched Rényi divergence of Müller-Lennert et al., arXiv:1306.3142v4,
 Definition 2, and Beigi, arXiv:1306.5920, Definition 2. For trace-one \(\rho\),
 it is the quantity inside the logarithm. The definition is total for every real
-\(\alpha\), including \(\alpha=0\), and for singular \(\omega\). On
-positive-semidefinite inputs with \(\ker\omega\subseteq\ker\rho\), its
-zero-on-kernel powers implement the generalized inverse and give the finite
-divergence trace term. If this support inclusion fails, the finite totalized
-value is not the divergence. -/
+\(\alpha\), including \(\alpha=0\), and for singular \(\omega\). For
+\(\alpha>1\), within the present \(1\leq\alpha\leq2\) application, finite
+divergence requires
+\(\operatorname{supp}\rho\subseteq\operatorname{supp}\omega\). On
+positive-semidefinite inputs satisfying this inclusion, the zero-on-kernel
+powers implement the generalized inverse. If the inclusion fails, the finite
+totalized CFC value is not the divergence trace term. -/
 noncomputable def sandwichedRenyiTrace (α : ℝ) (ρ ω : Mat) : ℝ :=
   let q := ω ^ ((1 - α) / (2 * α))
   (Matrix.trace ((q * ρ * q) ^ α)).re

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -107,8 +107,12 @@ theorem sandwichedRenyiTrace_nonneg
     Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
   have hX : (q * ρ * q).PosSemidef := by
     simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
+  have hpow_nonneg : 0 ≤ (q * ρ * q) ^ α := by
+    rw [CFC.rpow_eq_cfc_real hX.nonneg]
+    exact cfc_nonneg fun x hx ↦
+      Real.rpow_nonneg (spectrum_nonneg_of_nonneg hX.nonneg hx) α
   have hpow : ((q * ρ * q) ^ α).PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+    Matrix.nonneg_iff_posSemidef.mp hpow_nonneg
   exact (Complex.nonneg_iff.mp hpow.trace_nonneg).1
 
 /-- At order one, the sandwiched Rényi trace functional is

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -114,7 +114,7 @@ theorem sandwichedRenyiTrace_nonneg
     0 ≤ sandwichedRenyiTrace α ρ ω := by
   let q := ω ^ ((1 - α) / (2 * α))
   have hX : (q * ρ * q).PosSemidef :=
-    Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω ((1 - α) / (2 * α))
+    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω ((1 - α) / (2 * α))
   have hpow_nonneg : 0 ≤ (q * ρ * q) ^ α := by
     rw [CFC.rpow_eq_cfc_real hX.nonneg]
     exact cfc_nonneg fun x hx ↦
@@ -149,7 +149,7 @@ theorem sandwichedRenyiTrace_two
   rw [show (1 - (2 : ℝ)) / (2 * 2) = -(1 / 4 : ℝ) by norm_num]
   let q := ω ^ (-(1 / 4 : ℝ))
   have hX : (q * ρ * q).PosSemidef :=
-    Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
+    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
   change (Matrix.trace ((q * ρ * q) ^ (2 : ℝ))).re =
     (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
   rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num,

--- a/TNLean/Analysis/SandwichedRenyi.lean
+++ b/TNLean/Analysis/SandwichedRenyi.lean
@@ -1,0 +1,150 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.SandwichedRenyiTwo
+
+/-!
+# The sandwiched Rényi trace functional
+
+For a real order \(\alpha\), this file defines the total trace functional
+\[
+  \operatorname{Re}\operatorname{Tr}\!\left[
+    \left(\omega^{(1-\alpha)/(2\alpha)}
+      \rho\,\omega^{(1-\alpha)/(2\alpha)}\right)^\alpha
+  \right].
+\]
+On positive-semidefinite \(\rho\) and positive-definite \(\omega\), this is the
+quantity inside the logarithm in the faithful sandwiched Rényi divergence. The
+intended range here is \(1\leq\alpha\leq2\). No trace-one assumption is needed
+for the algebraic properties proved below.
+
+Continuous-functional-calculus real powers are total: in particular, negative
+powers vanish at a zero eigenvalue. Thus the definition remains finite outside
+the faithful domain, but that totalized value must not be identified with the
+sandwiched Rényi divergence when its support condition fails. We prove only
+nonnegativity on the faithful domain and the exact order-one and order-two
+endpoints; no assertion about continuity, interpolation, monotonicity, limits,
+derivatives, logarithmic divergence, or comparison with Umegaki relative
+entropy is made.
+
+## Main definitions
+
+* `TNLean.sandwichedRenyiTrace` — the total sandwiched Rényi trace functional.
+
+## Main results
+
+* `TNLean.sandwichedRenyiTrace_nonneg` — faithful-domain nonnegativity.
+* `TNLean.sandwichedRenyiTrace_one` — the exact order-one endpoint.
+* `TNLean.sandwichedRenyiTrace_two` — the exact order-two endpoint.
+
+## References
+
+* Müller-Lennert, Dupuis, Szehr, Fehr, and Tomamichel,
+  *On quantum Rényi entropies: a new generalization and some properties*,
+  arXiv:1306.3142v4, Definition 2 and Theorem 5.
+* Beigi, *Sandwiched Rényi divergence satisfies data processing inequality*,
+  arXiv:1306.5920, Definition 2 and Theorem 7.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace TNLean
+
+noncomputable section
+
+variable {D : ℕ}
+
+local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
+
+open scoped Matrix.Norms.L2Operator
+
+private local instance instRenyiNormedRing : NormedRing Mat :=
+  Matrix.instL2OpNormedRing
+private local instance instRenyiNormedAlgebra : NormedAlgebra ℂ Mat :=
+  Matrix.instL2OpNormedAlgebra
+private local instance instRenyiCStarRing : CStarRing Mat :=
+  Matrix.instCStarRing
+private local instance instRenyiPartialOrder : PartialOrder Mat :=
+  Matrix.instPartialOrder
+private local instance instRenyiStarOrderedRing : StarOrderedRing Mat :=
+  Matrix.instStarOrderedRing
+private local instance instRenyiCStarAlgebra : CStarAlgebra Mat :=
+  CStarAlgebra.mk
+
+/-- The total sandwiched Rényi trace functional
+\[
+  \operatorname{Re}\operatorname{Tr}\!\left[
+    \left(\omega^{(1-\alpha)/(2\alpha)}
+      \rho\,\omega^{(1-\alpha)/(2\alpha)}\right)^\alpha
+  \right].
+\]
+For positive-semidefinite \(\rho\), positive-definite \(\omega\), and
+\(1\leq\alpha\leq2\), this is the trace quantity used in the faithful
+sandwiched Rényi divergence of Müller-Lennert et al., arXiv:1306.3142v4,
+Definition 2, and Beigi, arXiv:1306.5920, Definition 2. The definition is total
+for every real \(\alpha\), including \(\alpha=0\), and for nonfaithful
+\(\omega\); those extra values are algebraic totalizations, not values of the
+divergence. -/
+noncomputable def sandwichedRenyiTrace (α : ℝ) (ρ ω : Mat) : ℝ :=
+  let q := ω ^ ((1 - α) / (2 * α))
+  (Matrix.trace ((q * ρ * q) ^ α)).re
+
+/-- The sandwiched Rényi trace functional is nonnegative when \(\rho\) is
+positive semidefinite and \(\omega\) is positive definite.
+
+This is the faithful-domain positivity of the trace expression in
+Müller-Lennert et al., arXiv:1306.3142v4, Definition 2, and Beigi,
+arXiv:1306.5920, Definition 2. It holds for every real order because the
+continuous-functional-calculus real power is positive semidefinite. -/
+theorem sandwichedRenyiTrace_nonneg
+    {α : ℝ} {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
+    0 ≤ sandwichedRenyiTrace α ρ ω := by
+  let q := ω ^ ((1 - α) / (2 * α))
+  have hq : q.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+  have hX : (q * ρ * q).PosSemidef := by
+    simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
+  have hpow : ((q * ρ * q) ^ α).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+  exact (Complex.nonneg_iff.mp hpow.trace_nonneg).1
+
+/-- At order one, the sandwiched Rényi trace functional is
+\(\operatorname{Re}\operatorname{Tr}(\rho)\).
+
+This is the \(\alpha=1\) endpoint of the expression in Müller-Lennert et al.,
+arXiv:1306.3142v4, Definition 2. -/
+theorem sandwichedRenyiTrace_one
+    {ρ ω : Mat} (hρ : ρ.PosSemidef) (hω : ω.PosDef) :
+    sandwichedRenyiTrace 1 ρ ω = (Matrix.trace ρ).re := by
+  rw [sandwichedRenyiTrace]
+  rw [show (1 - (1 : ℝ)) / (2 * 1) = 0 by norm_num]
+  rw [CFC.rpow_zero ω hω.posSemidef.nonneg]
+  simp only [Matrix.one_mul, Matrix.mul_one]
+  rw [CFC.rpow_one ρ hρ.nonneg]
+
+/-- At order two, the general sandwiched Rényi trace functional agrees exactly
+with `sandwichedRenyiTwoTrace`.
+
+This is the \(\alpha=2\) endpoint of Müller-Lennert et al.,
+arXiv:1306.3142v4, Definition 2, and Beigi, arXiv:1306.5920, Definition 2. -/
+theorem sandwichedRenyiTrace_two
+    {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosDef) :
+    sandwichedRenyiTrace 2 ρ ω = sandwichedRenyiTwoTrace ρ ω := by
+  rw [sandwichedRenyiTrace, sandwichedRenyiTwoTrace]
+  rw [show (1 - (2 : ℝ)) / (2 * 2) = -(1 / 4 : ℝ) by norm_num]
+  let q := ω ^ (-(1 / 4 : ℝ))
+  have hq : q.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+  have hX : (q * ρ * q).PosSemidef := by
+    simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
+  change (Matrix.trace ((q * ρ * q) ^ (2 : ℝ))).re =
+    (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
+  rw [show (2 : ℝ) = ((2 : ℕ) : ℝ) by norm_num,
+    CFC.rpow_natCast (q * ρ * q) 2 hX.nonneg, pow_two]
+
+end
+
+end TNLean

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -51,8 +51,6 @@ result is not asserted here.
 open scoped Matrix ComplexOrder MatrixOrder
 open Matrix
 
-namespace TNLean
-
 noncomputable section
 
 variable {D : ℕ}
@@ -74,6 +72,21 @@ private local instance instRenyiTwoStarOrderedRing : StarOrderedRing Mat :=
 private local instance instRenyiTwoCStarAlgebra : CStarAlgebra Mat :=
   CStarAlgebra.mk
 
+namespace Matrix.PosSemidef
+
+/-- Sandwiching a positive-semidefinite matrix between equal real powers of
+any matrix preserves positive semidefiniteness. -/
+theorem rpow_mul_mul_rpow
+    {ρ : Mat} (hρ : ρ.PosSemidef) (ω : Mat) (r : ℝ) :
+    (ω ^ r * ρ * ω ^ r).PosSemidef := by
+  have hωr : (ω ^ r).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+  simpa only [hωr.isHermitian.eq] using hρ.mul_mul_conjTranspose_same (ω ^ r)
+
+end Matrix.PosSemidef
+
+namespace TNLean
+
 /-- The order-two sandwiched trace functional
 \(\operatorname{Re}\operatorname{Tr}[(\omega^{-1/4}\rho\omega^{-1/4})^2]\).
 
@@ -88,15 +101,6 @@ noncomputable def sandwichedRenyiTwoTrace (ρ ω : Mat) : ℝ :=
   let q := ω ^ (-(1 / 4 : ℝ))
   (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
 
-/-- Sandwiching a positive-semidefinite matrix between equal real powers of
-any matrix preserves positive semidefiniteness. -/
-theorem Matrix.PosSemidef.rpow_mul_mul_rpow
-    {ρ : Mat} (hρ : ρ.PosSemidef) (ω : Mat) (r : ℝ) :
-    (ω ^ r * ρ * ω ^ r).PosSemidef := by
-  have hωr : (ω ^ r).PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
-  simpa only [hωr.isHermitian.eq] using hρ.mul_mul_conjTranspose_same (ω ^ r)
-
 /-- The order-two sandwiched trace functional is nonnegative on
 positive-semidefinite arguments.
 
@@ -107,7 +111,7 @@ theorem sandwichedRenyiTwoTrace_nonneg
     0 ≤ sandwichedRenyiTwoTrace ρ ω := by
   let q := ω ^ (-(1 / 4 : ℝ))
   have hX : (q * ρ * q).PosSemidef :=
-    Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
+    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
   exact (Complex.nonneg_iff.mp (hX.trace_mul_nonneg hX)).1
 
 /-- For a positive-definite matrix, two inverse quarter-powers multiply to the
@@ -155,6 +159,6 @@ theorem sandwichedRenyiTwoTrace_eq_weighted
         simp only [Matrix.mul_assoc]
   rw [hcycle, hq]
 
-end
-
 end TNLean
+
+end

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -74,13 +74,17 @@ private local instance instRenyiTwoCStarAlgebra : CStarAlgebra Mat :=
 
 namespace Matrix.PosSemidef
 
-/-- Sandwiching a positive-semidefinite matrix between equal real powers of
-any matrix preserves positive semidefiniteness. -/
+/-- Sandwiching a positive-semidefinite matrix between equal real powers of a
+positive-semidefinite matrix preserves positive semidefiniteness. -/
 theorem rpow_mul_mul_rpow
-    {ρ : Mat} (hρ : ρ.PosSemidef) (ω : Mat) (r : ℝ) :
+    {ρ ω : Mat} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef) (r : ℝ) :
     (ω ^ r * ρ * ω ^ r).PosSemidef := by
+  have hωr_nonneg : 0 ≤ ω ^ r := by
+    rw [CFC.rpow_eq_cfc_real hω.nonneg]
+    exact cfc_nonneg fun x hx ↦
+      Real.rpow_nonneg (spectrum_nonneg_of_nonneg hω.nonneg hx) r
   have hωr : (ω ^ r).PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+    Matrix.nonneg_iff_posSemidef.mp hωr_nonneg
   simpa only [hωr.isHermitian.eq] using hρ.mul_mul_conjTranspose_same (ω ^ r)
 
 end Matrix.PosSemidef
@@ -107,11 +111,11 @@ positive-semidefinite arguments.
 This is the positivity of the expression in Müller-Lennert et al.,
 arXiv:1306.3142v4, Definition 2, specialized to order two. -/
 theorem sandwichedRenyiTwoTrace_nonneg
-    {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosSemidef) :
+    {ρ ω : Mat} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef) :
     0 ≤ sandwichedRenyiTwoTrace ρ ω := by
   let q := ω ^ (-(1 / 4 : ℝ))
   have hX : (q * ρ * q).PosSemidef :=
-    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
+    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ hω (-(1 / 4 : ℝ))
   exact (Complex.nonneg_iff.mp (hX.trace_mul_nonneg hX)).1
 
 /-- For a positive-definite matrix, two inverse quarter-powers multiply to the

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -88,6 +88,15 @@ noncomputable def sandwichedRenyiTwoTrace (ρ ω : Mat) : ℝ :=
   let q := ω ^ (-(1 / 4 : ℝ))
   (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
 
+/-- Sandwiching a positive-semidefinite matrix between equal real powers of
+any matrix preserves positive semidefiniteness. -/
+theorem Matrix.PosSemidef.rpow_mul_mul_rpow
+    {ρ : Mat} (hρ : ρ.PosSemidef) (ω : Mat) (r : ℝ) :
+    (ω ^ r * ρ * ω ^ r).PosSemidef := by
+  have hωr : (ω ^ r).PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+  simpa only [hωr.isHermitian.eq] using hρ.mul_mul_conjTranspose_same (ω ^ r)
+
 /-- The order-two sandwiched trace functional is nonnegative on
 positive-semidefinite arguments.
 
@@ -97,10 +106,8 @@ theorem sandwichedRenyiTwoTrace_nonneg
     {ρ ω : Mat} (hρ : ρ.PosSemidef) (_hω : ω.PosSemidef) :
     0 ≤ sandwichedRenyiTwoTrace ρ ω := by
   let q := ω ^ (-(1 / 4 : ℝ))
-  have hq : q.PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
-  have hX : (q * ρ * q).PosSemidef := by
-    simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
+  have hX : (q * ρ * q).PosSemidef :=
+    Matrix.PosSemidef.rpow_mul_mul_rpow hρ ω (-(1 / 4 : ℝ))
   exact (Complex.nonneg_iff.mp (hX.trace_mul_nonneg hX)).1
 
 /-- For a positive-definite matrix, two inverse quarter-powers multiply to the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -915,14 +915,16 @@ terms of operator-Schmidt rank.
 \end{proof}
 
 The sandwiched R\'enyi comparison also uses the following unnormalized
-trace term.  For trace-one $\rho$, at orders for which the sandwiched R\'enyi
-divergence is defined, it is the quantity inside the logarithm
-\cite[Definition~2]{Beigi2013Sandwiched}
-\cite[Definition~2]{MullerLennert2013Renyi}.  This includes singular
-$\omega$ whenever $\rho,\omega\geq0$ and
-$\ker\omega\subseteq\ker\rho$, with negative powers interpreted as the
-generalized inverse on the support of $\omega$.  The statements below concern
-only this algebraic expression.  They are not assertions of
+trace term.  For trace-one $\rho$ and $\alpha>1$, it is the quantity inside the
+logarithm of the sandwiched R\'enyi divergence
+\cite[Equation~(2)]{Beigi2013Sandwiched}
+\cite[Definition~2]{MullerLennert2013Renyi} whenever
+$\rho,\omega\geq0$ and $\ker\omega\subseteq\ker\rho$.  This includes singular
+$\omega$, with negative powers interpreted as the generalized inverse on its
+support.  In this regime, finiteness of the divergence requires the support
+inclusion.  The present application uses $1<\alpha\leq2$; the order-one case is
+the Umegaki endpoint.  The statements below concern only this algebraic
+expression.  They are not assertions of
 \cite[Proposition~4.5]{Cirac2016MPDO_arXiv}, and they do not establish
 continuity or monotonicity in the order, interpolation between the endpoints,
 differentiability at order one, a limit to Umegaki relative entropy, a
@@ -945,10 +947,11 @@ logarithmic divergence, or a comparison with relative entropy.
     Real powers are defined by continuous functional calculus, with negative
     powers equal to zero on the zero eigenspace.  Thus
     $\widetilde Q_\alpha$ is total even when $\alpha=0$ or $\omega$ is singular.
-    On positive semidefinite inputs satisfying
+    For $\alpha>1$, on positive semidefinite inputs satisfying
     $\ker\omega\subseteq\ker\rho$, this convention gives the finite
-    sandwiched R\'enyi trace term.  If the support inclusion fails, the
-    totalized value remains finite but is not the divergence trace term.
+    sandwiched R\'enyi trace term.  In this regime, if the support inclusion
+    fails, the totalized value remains finite but is not the divergence trace
+    term.
 \end{definition}
 
 \begin{theorem}[Nonnegativity on the faithful domain]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -914,6 +914,98 @@ terms of operator-Schmidt rank.
     The rectangular Choi range-dimension estimate now proves the claim.
 \end{proof}
 
+The sandwiched R\'enyi comparison also uses the following total trace
+functional.  For faithful $\omega$ it is the quantity inside the logarithm of
+the sandwiched R\'enyi divergence
+\cite[Definition~2]{Beigi2013Sandwiched}
+\cite[Definition~2]{MullerLennert2013Renyi}.  The statements below concern only
+this algebraic expression.  They are not assertions of
+\cite[Proposition~4.5]{Cirac2016MPDO_arXiv}, and they do not establish
+continuity or monotonicity in the order, interpolation between the endpoints,
+differentiability at order one, a limit to Umegaki relative entropy, a
+logarithmic divergence, or a comparison with relative entropy.
+
+\begin{definition}[Total sandwiched R\'enyi trace]
+    \label{def:sandwiched_renyi_trace}
+    \lean{TNLean.sandwichedRenyiTrace}
+    \leanok
+    For square complex matrices $\rho$ and $\omega$ and every $\alpha\in\R$,
+    set
+    \begin{align}
+        \widetilde Q_\alpha(\rho\Vert\omega)
+        &=\re\tr\!\left[
+          \left(\omega^{(1-\alpha)/(2\alpha)}
+          \rho\,\omega^{(1-\alpha)/(2\alpha)}\right)^\alpha
+          \right].
+        \label{eq:sandwiched_renyi_trace}
+    \end{align}
+    Real powers are defined by continuous functional calculus, with negative
+    powers equal to zero on the zero eigenspace.  Thus
+    $\widetilde Q_\alpha$ is total even when $\alpha=0$ or $\omega$ is singular;
+    outside the faithful support domain it is not the sandwiched R\'enyi
+    divergence.
+\end{definition}
+
+\begin{theorem}[Nonnegativity on the faithful domain]
+    \label{thm:sandwiched_renyi_trace_nonneg}
+    \lean{TNLean.sandwichedRenyiTrace_nonneg}
+    \leanok
+    \uses{def:sandwiched_renyi_trace}
+    If $\rho\geq0$ and $\omega>0$, then, for every $\alpha\in\R$,
+    \begin{align}
+        0&\leq\widetilde Q_\alpha(\rho\Vert\omega).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:sandwiched_renyi_trace}
+    Put $q=\omega^{(1-\alpha)/(2\alpha)}$.  Continuous functional calculus
+    gives $q\geq0$, hence $q\rho q\geq0$ and $(q\rho q)^\alpha\geq0$.
+    The trace of the last matrix is real and nonnegative.
+\end{proof}
+
+\begin{theorem}[Order-one sandwiched trace]
+    \label{thm:sandwiched_renyi_trace_one}
+    \lean{TNLean.sandwichedRenyiTrace_one}
+    \leanok
+    \uses{def:sandwiched_renyi_trace}
+    If $\rho\geq0$ and $\omega>0$, then
+    \begin{align}
+        \widetilde Q_1(\rho\Vert\omega)&=\re\tr(\rho).
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:sandwiched_renyi_trace}
+    At $\alpha=1$ the two powers of $\omega$ have exponent zero, while the
+    remaining real power of $\rho$ has exponent one.  Substitution into
+    (\ref{eq:sandwiched_renyi_trace}) gives the identity.
+\end{proof}
+
+\begin{theorem}[Order-two sandwiched trace]
+    \label{thm:sandwiched_renyi_trace_two}
+    \lean{TNLean.sandwichedRenyiTrace_two}
+    \leanok
+    \uses{def:sandwiched_renyi_trace}
+    If $\rho\geq0$ and $\omega>0$, then
+    \begin{align}
+        \widetilde Q_2(\rho\Vert\omega)
+        &=\re\tr\!\left[
+          (\omega^{-1/4}\rho\,\omega^{-1/4})
+          (\omega^{-1/4}\rho\,\omega^{-1/4})\right].
+        \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:sandwiched_renyi_trace}
+    At $\alpha=2$ the sandwiching exponent is $-1/4$.
+    Since $\omega^{-1/4}\rho\,\omega^{-1/4}$ is positive semidefinite, its
+    continuous-functional-calculus square is its ordinary matrix square.
+\end{proof}
+
 \begin{theorem}[Mutual information from operator-Schmidt rank]
     \label{thm:mutual_information_le_log_operator_schmidt_rank}
     \uses{def:bipartite_operator_schmidt_rank}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -914,12 +914,15 @@ terms of operator-Schmidt rank.
     The rectangular Choi range-dimension estimate now proves the claim.
 \end{proof}
 
-The sandwiched R\'enyi comparison also uses the following total trace
-functional.  For faithful $\omega$ it is the quantity inside the logarithm of
-the sandwiched R\'enyi divergence
+The sandwiched R\'enyi comparison also uses the following unnormalized
+trace term.  For trace-one $\rho$, at orders for which the sandwiched R\'enyi
+divergence is defined, it is the quantity inside the logarithm
 \cite[Definition~2]{Beigi2013Sandwiched}
-\cite[Definition~2]{MullerLennert2013Renyi}.  The statements below concern only
-this algebraic expression.  They are not assertions of
+\cite[Definition~2]{MullerLennert2013Renyi}.  This includes singular
+$\omega$ whenever $\rho,\omega\geq0$ and
+$\ker\omega\subseteq\ker\rho$, with negative powers interpreted as the
+generalized inverse on the support of $\omega$.  The statements below concern
+only this algebraic expression.  They are not assertions of
 \cite[Proposition~4.5]{Cirac2016MPDO_arXiv}, and they do not establish
 continuity or monotonicity in the order, interpolation between the endpoints,
 differentiability at order one, a limit to Umegaki relative entropy, a
@@ -941,9 +944,11 @@ logarithmic divergence, or a comparison with relative entropy.
     \end{align}
     Real powers are defined by continuous functional calculus, with negative
     powers equal to zero on the zero eigenspace.  Thus
-    $\widetilde Q_\alpha$ is total even when $\alpha=0$ or $\omega$ is singular;
-    outside the faithful support domain it is not the sandwiched R\'enyi
-    divergence.
+    $\widetilde Q_\alpha$ is total even when $\alpha=0$ or $\omega$ is singular.
+    On positive semidefinite inputs satisfying
+    $\ker\omega\subseteq\ker\rho$, this convention gives the finite
+    sandwiched R\'enyi trace term.  If the support inclusion fails, the
+    totalized value remains finite but is not the divergence trace term.
 \end{definition}
 
 \begin{theorem}[Nonnegativity on the faithful domain]
@@ -988,19 +993,18 @@ logarithmic divergence, or a comparison with relative entropy.
     \label{thm:sandwiched_renyi_trace_two}
     \lean{TNLean.sandwichedRenyiTrace_two}
     \leanok
-    \uses{def:sandwiched_renyi_trace}
+    \uses{def:sandwiched_renyi_trace,
+      def:sandwiched_renyi_two_trace}
     If $\rho\geq0$ and $\omega>0$, then
     \begin{align}
-        \widetilde Q_2(\rho\Vert\omega)
-        &=\re\tr\!\left[
-          (\omega^{-1/4}\rho\,\omega^{-1/4})
-          (\omega^{-1/4}\rho\,\omega^{-1/4})\right].
+        \widetilde Q_2(\rho\Vert\omega)&=Q_2(\rho,\omega).
         \notag
     \end{align}
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:sandwiched_renyi_trace}
+    \uses{def:sandwiched_renyi_trace,
+      def:sandwiched_renyi_two_trace}
     At $\alpha=2$ the sandwiching exponent is $-1/4$.
     Since $\omega^{-1/4}\rho\,\omega^{-1/4}$ is positive semidefinite, its
     continuous-functional-calculus square is its ordinary matrix square.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -917,7 +917,7 @@ terms of operator-Schmidt rank.
 The sandwiched R\'enyi comparison also uses the following unnormalized
 trace term.  For trace-one $\rho$ and $\alpha>1$, it is the quantity inside the
 logarithm of the sandwiched R\'enyi divergence
-\cite[Equation~(2)]{Beigi2013Sandwiched}
+\cite[Equation~(3)]{Beigi2013Sandwiched}
 \cite[Definition~2]{MullerLennert2013Renyi} whenever
 $\rho,\omega\geq0$ and $\ker\omega\subseteq\ker\rho$.  This includes singular
 $\omega$, with negative powers interpreted as the generalized inverse on its

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -274,7 +274,7 @@ compression.  The eigenbasis whitening statements still assume both marginal
 weights are positive definite and therefore do not supply the two-local
 compression from singular ambient marginals to both support algebras.
 
-The total sandwiched R\'enyi trace expression
+The unnormalized sandwiched R\'enyi trace term
 \[
   \widetilde Q_\alpha(\rho\Vert\omega)
   =\operatorname{Re}\operatorname{Tr}\!\left[
@@ -282,7 +282,13 @@ The total sandwiched R\'enyi trace expression
       \rho\,\omega^{(1-\alpha)/(2\alpha)}\right)^\alpha
   \right]
 \]
-is now formalized, together with its nonnegativity for $\rho\geq0$ and
+is now formalized.  For trace-one $\rho$, at orders for which the sandwiched
+R\'enyi divergence is defined, this is the quantity inside the logarithm when
+$\rho,\omega\geq0$ and $\ker\omega\subseteq\ker\rho$.  This domain includes
+singular $\omega$: the zero-on-kernel powers implement the generalized inverse
+on its support.  If the support inclusion fails, the totalized
+continuous-functional-calculus value remains finite but is not the divergence
+trace term.  The formalized properties are nonnegativity for $\rho\geq0$ and
 $\omega>0$ and the exact identities at $\alpha=1$ and $\alpha=2$.
 \footnote{Formal declarations:
 \leanid{TNLean.sandwichedRenyiTrace},

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -282,14 +282,17 @@ The unnormalized sandwiched R\'enyi trace term
       \rho\,\omega^{(1-\alpha)/(2\alpha)}\right)^\alpha
   \right]
 \]
-is now formalized.  For trace-one $\rho$, at orders for which the sandwiched
-R\'enyi divergence is defined, this is the quantity inside the logarithm when
-$\rho,\omega\geq0$ and $\ker\omega\subseteq\ker\rho$.  This domain includes
-singular $\omega$: the zero-on-kernel powers implement the generalized inverse
-on its support.  If the support inclusion fails, the totalized
+is now formalized.  For trace-one $\rho$ and $\alpha>1$, this is the quantity
+inside the logarithm of the sandwiched R\'enyi divergence when
+$\rho,\omega\geq0$ and $\ker\omega\subseteq\ker\rho$.  This includes singular
+$\omega$: the zero-on-kernel powers implement the generalized inverse on its
+support.  In this regime, finiteness of the divergence requires the support
+inclusion.  If the inclusion fails, the totalized
 continuous-functional-calculus value remains finite but is not the divergence
-trace term.  The formalized properties are nonnegativity for $\rho\geq0$ and
-$\omega>0$ and the exact identities at $\alpha=1$ and $\alpha=2$.
+trace term.  The present application uses $1<\alpha\leq2$; the order-one case
+is the Umegaki endpoint.  The formalized properties are nonnegativity for
+$\rho\geq0$ and $\omega>0$ and the exact identities at $\alpha=1$ and
+$\alpha=2$.
 \footnote{Formal declarations:
 \leanid{TNLean.sandwichedRenyiTrace},
 \leanid{TNLean.sandwichedRenyiTrace_nonneg},

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -9,7 +9,7 @@
 
 \title{The Mutual-Information Bound for Matrix Product Density Operators}
 \author{}
-\date{2026-07-18}
+\date{2026-07-31}
 
 \begin{document}
 \maketitle
@@ -274,12 +274,34 @@ compression.  The eigenbasis whitening statements still assume both marginal
 weights are positive definite and therefore do not supply the two-local
 compression from singular ambient marginals to both support algebras.
 
-This reduction does not complete
+The total sandwiched R\'enyi trace expression
+\[
+  \widetilde Q_\alpha(\rho\Vert\omega)
+  =\operatorname{Re}\operatorname{Tr}\!\left[
+    \left(\omega^{(1-\alpha)/(2\alpha)}
+      \rho\,\omega^{(1-\alpha)/(2\alpha)}\right)^\alpha
+  \right]
+\]
+is now formalized, together with its nonnegativity for $\rho\geq0$ and
+$\omega>0$ and the exact identities at $\alpha=1$ and $\alpha=2$.
+\footnote{Formal declarations:
+\leanid{TNLean.sandwichedRenyiTrace},
+\leanid{TNLean.sandwichedRenyiTrace_nonneg},
+\leanid{TNLean.sandwichedRenyiTrace_one}, and
+\leanid{TNLean.sandwichedRenyiTrace_two} in
+\doclink{TNLean/Analysis/SandwichedRenyi}.}
+These are supporting analytic identities, not a theorem of
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete.  They prove neither continuity nor
+monotonicity in $\alpha$, interpolation between orders one and two,
+differentiability or a limit at $\alpha=1$, the logarithmic sandwiched R\'enyi
+divergence, nor a comparison with Umegaki relative entropy.
+
+Neither development completes
 \href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  That issue still
 requires simultaneous compression by the two marginal support isometries and a
 proof that this local two-factor compression preserves operator-Schmidt rank.
-The faithful comparison itself still requires the weighted interpolation and
-order-one-limit analysis tracked in
+The faithful comparison itself still requires continuity, weighted
+interpolation, order monotonicity, and the order-one limit tracked in
 \href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  Beigi proves
 order monotonicity \cite[Theorem~7]{Beigi2013Sandwiched}, while
 M\"uller-Lennert, Dupuis, Szehr, Fehr, and Tomamichel prove the order-one

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -192,6 +192,18 @@ abstracted — record why, so it is not re-proposed).
 
 ## Completed refactors
 
+### Positive-semidefinite sandwich by real powers
+- **Pattern:** three sandwiched Rényi proofs separately proved that a real power
+  of the reference matrix is positive semidefinite and used Hermiticity to
+  identify the resulting congruence with an equal-factor sandwich.
+- **Reuse:** `Matrix.PosSemidef.rpow_mul_mul_rpow` in
+  `TNLean/Analysis/SandwichedRenyiTwo.lean` proves
+  `(ω ^ r * ρ * ω ^ r).PosSemidef` from `ρ.PosSemidef`, for arbitrary real
+  `r` and with no hypothesis on `ω`.
+- **Result:** `sandwichedRenyiTwoTrace_nonneg`, `sandwichedRenyiTrace_nonneg`,
+  and `sandwichedRenyiTrace_two` retain their statements and each obtain the
+  sandwich positivity in one application.
+
 ### Distinguished grouped reference corner
 - **Pattern:** the horizontal BNT-refined and literal CPSV actual-grouped Figure~8 proofs
   both select the zero-index copy, use its identity gauge, and transport its physical corner

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -196,7 +196,7 @@ abstracted — record why, so it is not re-proposed).
 - **Pattern:** three sandwiched Rényi proofs separately proved that a real power
   of the reference matrix is positive semidefinite and used Hermiticity to
   identify the resulting congruence with an equal-factor sandwich.
-- **Reuse:** `Matrix.PosSemidef.rpow_mul_mul_rpow` in
+- **Reuse:** `_root_.Matrix.PosSemidef.rpow_mul_mul_rpow` in
   `TNLean/Analysis/SandwichedRenyiTwo.lean` proves
   `(ω ^ r * ρ * ω ^ r).PosSemidef` from `ρ.PosSemidef`, for arbitrary real
   `r` and with no hypothesis on `ω`.

--- a/docs/tactic_patterns.md
+++ b/docs/tactic_patterns.md
@@ -198,8 +198,8 @@ abstracted — record why, so it is not re-proposed).
   identify the resulting congruence with an equal-factor sandwich.
 - **Reuse:** `_root_.Matrix.PosSemidef.rpow_mul_mul_rpow` in
   `TNLean/Analysis/SandwichedRenyiTwo.lean` proves
-  `(ω ^ r * ρ * ω ^ r).PosSemidef` from `ρ.PosSemidef`, for arbitrary real
-  `r` and with no hypothesis on `ω`.
+  `(ω ^ r * ρ * ω ^ r).PosSemidef` from `ρ.PosSemidef` and
+  `ω.PosSemidef`, for arbitrary real `r`.
 - **Result:** `sandwichedRenyiTwoTrace_nonneg`, `sandwichedRenyiTrace_nonneg`,
   and `sandwichedRenyiTrace_two` retain their statements and each obtain the
   sandwich positivity in one application.


### PR DESCRIPTION
## What changed

- define the total sandwiched Rényi trace family on the faithful-reference interface
- prove nonnegativity and the exact order-one and order-two endpoint identities
- synchronize Chapter 21 and the mutual-information gap record while keeping order monotonicity and the Umegaki comparison open

## Scope

This is endpoint infrastructure for the Proposition 4.5 analytic chain. It does not prove continuity, interpolation, monotonicity in the Rényi order, the order-one derivative or limit, the logarithmic divergence, or the Umegaki-to-order-two comparison.

## Validation

- `lake build TNLean.Analysis.SandwichedRenyi TNLean.Analysis`
- generated import-aggregator checks
- fresh Blueprint declaration synchronization and `leanblueprint checkdecls`
- double LuaLaTeX with `TEXINPUTS="../../tex/tenkz//:"` and zero undefined cross-references
- proof-integrity and `git diff --check`

Closes #5234
Advances #5209, #5212, and #5213

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New analytic lemmas and documentation on a faithful PSD interface; no auth, security, or runtime behavior changes.
> 
> **Overview**
> Adds **general-order sandwiched Rényi trace infrastructure** for the Proposition 4.5 analytic chain: a total functional `TNLean.sandwichedRenyiTrace` and faithful-domain **nonnegativity**, plus exact **α = 1** and **α = 2** endpoint identities (the latter tied to existing `sandwichedRenyiTwoTrace`).
> 
> Extracts shared **`Matrix.PosSemidef.rpow_mul_mul_rpow`** in `SandwichedRenyiTwo.lean` and uses it to shorten the order-two nonnegativity proof and the new general proofs.
> 
> **Blueprint Chapter 21** and **`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`** are updated with `\lean{}` links and explicit scope: continuity, interpolation, monotonicity in α, and the Umegaki comparison remain **out of scope** (tracked in #5209 / #5211).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0395a6eb02959c1e9a11fad5359fb2b7fe923e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->