### PR TITLE
feat(Algebra): preserve operator-Schmidt rank under isometries

### DIFF
--- a/TNLean/Algebra/OperatorSchmidt.lean
+++ b/TNLean/Algebra/OperatorSchmidt.lean
@@ -38,6 +38,10 @@ of the operator blocks.
   decomposition exists with exactly the range dimension many terms.
 * `Matrix.operatorSchmidtRank_le_of_hasOperatorSchmidtDecomposition`: every
   product decomposition has at least the range dimension many terms.
+* `Matrix.operatorSchmidtRank_local_mul_le`: local left and right
+  multiplication cannot increase operator-Schmidt rank.
+* `Matrix.operatorSchmidtRank_local_isometry_conj`: local isometric
+  conjugation preserves operator-Schmidt rank.
 
 ## References
 
@@ -186,5 +190,61 @@ theorem operatorSchmidtRank_minimal (ρ : Matrix (m × n) (m × n) ℂ) :
     fun _ ↦ operatorSchmidtRank_le_of_hasOperatorSchmidtDecomposition⟩
 
 end Complex
+
+section LocalMultiplication
+
+variable {m' n' : Type*}
+
+/-- Multiplication on the left and right by product matrices cannot increase
+operator-Schmidt rank. This includes rectangular local matrices and empty finite
+index types. -/
+theorem operatorSchmidtRank_local_mul_le
+    [Fintype m] [Fintype m'] [Finite n] [Fintype n']
+    (L₁ : Matrix m m' ℂ) (L₂ : Matrix n n' ℂ)
+    (R₁ : Matrix m' m ℂ) (R₂ : Matrix n' n ℂ)
+    (X : Matrix (m' × n') (m' × n') ℂ) :
+    operatorSchmidtRank ((L₁ ⊗ₖ L₂) * X * (R₁ ⊗ₖ R₂)) ≤
+      operatorSchmidtRank X := by
+  letI := Fintype.ofFinite n
+  obtain ⟨A, B, hX⟩ := hasOperatorSchmidtDecomposition_operatorSchmidtRank X
+  apply operatorSchmidtRank_le_of_hasOperatorSchmidtDecomposition
+  refine ⟨fun t ↦ L₁ * A t * R₁, fun t ↦ L₂ * B t * R₂, ?_⟩
+  conv_lhs => rw [hX]
+  rw [Matrix.mul_sum, Matrix.sum_mul]
+  apply Finset.sum_congr rfl
+  intro t _
+  rw [← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+
+/-- Conjugation by a tensor product of two isometries preserves
+operator-Schmidt rank. No nonemptiness assumption is needed on any index type. -/
+theorem operatorSchmidtRank_local_isometry_conj
+    [Fintype m] [Fintype m'] [Fintype n] [Fintype n']
+    [DecidableEq m'] [DecidableEq n']
+    (V₁ : Matrix m m' ℂ) (V₂ : Matrix n n' ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (X : Matrix (m' × n') (m' × n') ℂ) :
+    operatorSchmidtRank ((V₁ ⊗ₖ V₂) * X * (V₁ ⊗ₖ V₂)ᴴ) =
+      operatorSchmidtRank X := by
+  apply Nat.le_antisymm
+  · rw [Matrix.conjTranspose_kronecker]
+    exact operatorSchmidtRank_local_mul_le V₁ V₂ V₁ᴴ V₂ᴴ X
+  · have hV : (V₁ ⊗ₖ V₂)ᴴ * (V₁ ⊗ₖ V₂) = 1 := by
+      rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul, hV₁, hV₂,
+        Matrix.one_kronecker_one]
+    have hrecover :
+        (V₁ ⊗ₖ V₂)ᴴ * ((V₁ ⊗ₖ V₂) * X * (V₁ ⊗ₖ V₂)ᴴ) *
+          (V₁ ⊗ₖ V₂) = X := by
+      calc
+        _ = ((V₁ ⊗ₖ V₂)ᴴ * (V₁ ⊗ₖ V₂)) * X *
+            ((V₁ ⊗ₖ V₂)ᴴ * (V₁ ⊗ₖ V₂)) := by
+          simp only [Matrix.mul_assoc]
+        _ = X := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+    have hle := operatorSchmidtRank_local_mul_le V₁ᴴ V₂ᴴ V₁ V₂
+      ((V₁ ⊗ₖ V₂) * X * (V₁ ⊗ₖ V₂)ᴴ)
+    rw [← Matrix.conjTranspose_kronecker] at hle
+    rw [hrecover] at hle
+    exact hle
+
+end LocalMultiplication
 
 end Matrix

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -401,6 +401,34 @@
     $s=\dim\range\mathcal R_\rho$.
 \end{proof}
 
+\begin{theorem}[Operator-Schmidt rank under local isometries]
+    \label{thm:operator_schmidt_rank_local_isometry}
+    \lean{Matrix.operatorSchmidtRank_local_mul_le,
+      Matrix.operatorSchmidtRank_local_isometry_conj}
+    \leanok
+    \uses{def:bipartite_operator_schmidt_rank}
+    Let $V_A:\mathcal H_A\to\mathcal K_A$ and
+    $V_B:\mathcal H_B\to\mathcal K_B$ be isometries between finite-dimensional
+    complex spaces. For every operator $X$ on
+    $\mathcal H_A\otimes\mathcal H_B$,
+    \begin{align}
+      \operatorname{OSR}\!\left(
+        (V_A\otimes V_B)X(V_A\otimes V_B)^\dagger\right)
+      &=\operatorname{OSR}(X).
+      \notag
+    \end{align}
+    This remains valid when one or more of the spaces have dimension zero.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:operator_schmidt_coefficient_space}
+    More generally, multiplying on the left and right by product matrices
+    cannot increase operator-Schmidt rank: apply the four local matrices to
+    the two factors in each term of a shortest product decomposition. Applying
+    this inequality first to $V_A,V_B$ and then to their adjoints gives the two
+    inequalities. The identities $V_A^\dagger V_A=1$ and
+    $V_B^\dagger V_B=1$ identify the twice-transformed operator with $X$.
+\end{proof}
+
 \begin{theorem}[Channel of a faithful bipartite marginal]
     \label{thm:supported_marginal_channel}
     \lean{Matrix.finrank_range_supportedMarginalMap,


### PR DESCRIPTION
## Summary

- prove that local left and right multiplication by product matrices cannot increase operator-Schmidt rank
- deduce invariance under conjugation by a tensor product of isometries, including zero-dimensional local spaces
- record the project-derived result in the MPDO area-law Blueprint without attributing it to CPSV16 or Beigi

## Validation

- `lake env lean TNLean/Algebra/OperatorSchmidt.lean`
- `lake build TNLean.Algebra.OperatorSchmidt`
- `lake build TNLean` (9,861 targets, repeated after rebase)
- explicit `Fin 0` specialization for all four local spaces
- `#print axioms` audit
- proof-integrity scan
- `lake exe checkdecls blueprint/lean_decls`
- Blueprint synchronization and reader-facing prose checks
- `leanblueprint web`
- `git diff --check`

Closes #5236
Refs #5211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New theorems in existing algebra infrastructure with no auth, data, or runtime impact; scope is localized to operator-Schmidt rank and Blueprint sync.
> 
> **Overview**
> Adds Lean proofs that **operator-Schmidt rank** is stable under local tensor-product maps used in MPDO area-law arguments.
> 
> **`operatorSchmidtRank_local_mul_le`** shows left/right multiplication by `(L₁ ⊗ₖ L₂)` and `(R₁ ⊗ₖ R₂)` cannot increase rank: a minimal product decomposition is pushed through the four local matrices term by term (Kronecker–mul identities). **`operatorSchmidtRank_local_isometry_conj`** then gives **equality** under conjugation by `(V₁ ⊗ₖ V₂)` when `Vᵢᴴ Vᵢ = 1`, via two applications of the submultiplicativity bound and recovery of `X` with `V†V = 1`; rectangular indices and **zero-dimensional** local types are in scope.
> 
> The MPDO Blueprint chapter gains **Theorem: Operator-Schmidt rank under local isometries**, linked to those lemmas, with a proof sketch (no new external citation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74679358fe24a5f01347a6617baef8f8f2d75056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->