### PR TITLE
feat(Channel): preserve OSR under support compression

### DIFF
--- a/TNLean/Channel/MarginalSupportAbsorption.lean
+++ b/TNLean/Channel/MarginalSupportAbsorption.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.OperatorSchmidt
 import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.MarginalSupport
 import TNLean.Channel.PartialTrace
@@ -28,6 +29,10 @@ form is a specialization of the other on the product index \(L\times R\).
   by the lifted support projector of the right partial trace.
 * `Matrix.PosSemidef.mul_leftKroneckerEmbed_supportProj_self`: the corresponding
   right absorption identity.
+* `Matrix.PosSemidef.eq_marginalSupport_expansion_compression`: simultaneous
+  compression to both marginal supports reconstructs the original operator.
+* `Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression`: this
+  simultaneous compression preserves operator-Schmidt rank.
 
 ## References
 
@@ -241,5 +246,81 @@ theorem PosSemidef.mul_rightKroneckerEmbed_supportProj_self
   rwa [Matrix.conjTranspose_mul, hρ.isHermitian.eq, hliftHerm.eq] at h
 
 end LeftMarginal
+
+/-! ### Simultaneous compression to both marginal supports -/
+
+section SimultaneousMarginalSupport
+
+variable {L R : Type*} [Fintype L] [DecidableEq L] [Fintype R] [DecidableEq R]
+variable {L' R' : Type*} [Fintype L'] [Fintype R']
+
+/-- Compression by coordinate maps for both marginal supports reconstructs
+the original positive semidefinite operator exactly.
+
+The statement permits zero-dimensional index types. It requires only that the
+two coordinate maps have the prescribed range projections; their isometry
+identities are not needed for reconstruction. -/
+theorem PosSemidef.eq_marginalSupport_expansion_compression
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix L L' ℂ) (V₂ : Matrix R R' ℂ)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    (V₁ ⊗ₖ V₂) * ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)) *
+      (V₁ ⊗ₖ V₂)ᴴ = ρ := by
+  let P₁ := hρ.partialTraceRight.isHermitian.supportProj
+  let P₂ := hρ.partialTraceLeft.isHermitian.supportProj
+  have hP₁ρ : (P₁ ⊗ₖ (1 : Matrix R R ℂ)) * ρ = ρ := by
+    simpa only [P₁, leftKroneckerEmbed_apply] using
+      hρ.leftKroneckerEmbed_supportProj_mul_self
+  have hP₂ρ : ((1 : Matrix L L ℂ) ⊗ₖ P₂) * ρ = ρ := by
+    simpa only [P₂, rightKroneckerEmbed_apply] using
+      hρ.rightKroneckerEmbed_supportProj_mul_self
+  have hρP₁ : ρ * (P₁ ⊗ₖ (1 : Matrix R R ℂ)) = ρ := by
+    simpa only [P₁, leftKroneckerEmbed_apply] using
+      hρ.mul_leftKroneckerEmbed_supportProj_self
+  have hρP₂ : ρ * ((1 : Matrix L L ℂ) ⊗ₖ P₂) = ρ := by
+    simpa only [P₂, rightKroneckerEmbed_apply] using
+      hρ.mul_rightKroneckerEmbed_supportProj_self
+  have hPρ : (P₁ ⊗ₖ P₂) * ρ = ρ := by
+    rw [show P₁ ⊗ₖ P₂ = (P₁ ⊗ₖ (1 : Matrix R R ℂ)) *
+        ((1 : Matrix L L ℂ) ⊗ₖ P₂) by
+      rw [← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]]
+    rw [Matrix.mul_assoc, hP₂ρ, hP₁ρ]
+  have hρP : ρ * (P₁ ⊗ₖ P₂) = ρ := by
+    rw [show P₁ ⊗ₖ P₂ = ((1 : Matrix L L ℂ) ⊗ₖ P₂) *
+        (P₁ ⊗ₖ (1 : Matrix R R ℂ)) by
+      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, Matrix.mul_one]]
+    rw [← Matrix.mul_assoc, hρP₂, hρP₁]
+  have hRange : (V₁ ⊗ₖ V₂) * (V₁ ⊗ₖ V₂)ᴴ = P₁ ⊗ₖ P₂ := by
+    rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul, hRange₁, hRange₂]
+  calc
+    (V₁ ⊗ₖ V₂) * ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)) * (V₁ ⊗ₖ V₂)ᴴ =
+        ((V₁ ⊗ₖ V₂) * (V₁ ⊗ₖ V₂)ᴴ) * ρ *
+          ((V₁ ⊗ₖ V₂) * (V₁ ⊗ₖ V₂)ᴴ) := by
+      simp only [Matrix.mul_assoc]
+    _ = (P₁ ⊗ₖ P₂) * ρ * (P₁ ⊗ₖ P₂) := by rw [hRange]
+    _ = ρ := by rw [hPρ, hρP]
+
+variable [DecidableEq L'] [DecidableEq R']
+
+/-- Simultaneous compression to coordinate spaces for the two marginal supports
+preserves operator-Schmidt rank.
+
+No marginal is assumed faithful, and the statement remains valid for
+zero-dimensional index types. -/
+theorem PosSemidef.operatorSchmidtRank_marginalSupport_compression
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix L L' ℂ) (V₂ : Matrix R R' ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    operatorSchmidtRank ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)) =
+      operatorSchmidtRank ρ := by
+  have hrank := operatorSchmidtRank_local_isometry_conj V₁ V₂ hV₁ hV₂
+    ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂))
+  rw [hρ.eq_marginalSupport_expansion_compression V₁ V₂ hRange₁ hRange₂] at hrank
+  exact hrank.symm
+
+end SimultaneousMarginalSupport
 
 end Matrix

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -429,6 +429,48 @@
     $V_B^\dagger V_B=1$ identify the twice-transformed operator with $X$.
 \end{proof}
 
+\begin{theorem}[Compression to both marginal supports]
+    \label{thm:operator_schmidt_rank_marginal_support_compression}
+    \lean{Matrix.PosSemidef.eq_marginalSupport_expansion_compression,
+      Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression}
+    \leanok
+    \uses{def:bipartite_operator_schmidt_rank}
+    Let $\rho\geq0$ be an operator on $H_A\otimes H_B$. Let
+    $V_A:\widehat H_A\to H_A$ and $V_B:\widehat H_B\to H_B$ be isometries
+    whose range projectors are the support projectors $P_A$ and $P_B$ of the
+    two marginals. Set $W=V_A\otimes V_B$ and
+    $\rho_c=W^\dagger\rho W$. Then
+    \begin{align}
+      W\rho_cW^\dagger&=\rho,
+      &\operatorname{OSR}(\rho_c)&=\operatorname{OSR}(\rho).
+      \notag
+    \end{align}
+    No marginal is required to be faithful, and zero-dimensional coordinate
+    spaces are permitted.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:marginal_support_left_absorption,
+      thm:marginal_support_right_absorption,
+      thm:right_marginal_support_left_absorption,
+      thm:right_marginal_support_right_absorption,
+      thm:operator_schmidt_rank_local_isometry}
+    The four marginal-support absorption identities give
+    \begin{align}
+      (P_A\otimes P_B)\rho&=\rho,
+      &\rho(P_A\otimes P_B)&=\rho.
+      \notag
+    \end{align}
+    Since $WW^\dagger=P_A\otimes P_B$, associativity yields
+    \begin{align}
+      W\rho_cW^\dagger
+      &=(WW^\dagger)\rho(WW^\dagger)=\rho.
+      \notag
+    \end{align}
+    The local-isometry theorem applied to $\rho_c$ gives
+    $\operatorname{OSR}(W\rho_cW^\dagger)=\operatorname{OSR}(\rho_c)$.
+    Substitution of the reconstruction identity proves the rank equality.
+\end{proof}
+
 \begin{theorem}[Channel of a faithful bipartite marginal]
     \label{thm:supported_marginal_channel}
     \lean{Matrix.finrank_range_supportedMarginalMap,
@@ -473,8 +515,9 @@
 
 \section{Support compression for entropy functionals}
 
-% Issue #5229: single-reference support compression.  The remaining
-% simultaneous two-marginal and operator-Schmidt-rank step is tracked in #5211.
+% Issues #5229 and #5241 establish one- and two-marginal support compression,
+% including preservation of operator-Schmidt rank.  Faithfulness of the two
+% compressed marginals is tracked in #5245 as a remaining step for #5211.
 
 \begin{definition}[Isometric conjugation into a larger matrix algebra]
     \label{def:isometric_nonunital_conjugation}
@@ -606,6 +649,7 @@
     \label{thm:support_log_vector_jensen}
     \lean{Matrix.PosSemidef.re_dotProduct_cfc_log_mulVec_le_log}
     \leanok
+    \uses{def:hermitian_support_projection}
     Let $A\in\MN{n}$ be positive semidefinite and let $v\in\C^n$ satisfy
     $\langle v,v\rangle=1$ and $P_{\supp(A)}v=v$. Then
     \begin{align}
@@ -619,6 +663,7 @@
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:hermitian_support_projection}
     Diagonalize $A=U\diag(\mu_i)U^\dagger$, set $w=U^\dagger v$, and put
     $p_i=|w_i|^2$. The support condition implies
     $\mu_i=0\Longrightarrow w_i=0$, so every spectral weight at zero vanishes.
@@ -1062,6 +1107,7 @@ logarithmic divergence, or a comparison with relative entropy.
 \end{theorem}
 \begin{proof}
     \uses{thm:relative_entropy_q2_faithful_reduction,
+      thm:operator_schmidt_rank_marginal_support_compression,
       thm:full_support_eigenbasis_whitened_choi_bound}
     Set $\omega=\rho_A\otimes\rho_B$. Positivity gives
     $\ker\omega\subseteq\ker\rho_{AB}$, so
@@ -1069,8 +1115,11 @@ logarithmic divergence, or a comparison with relative entropy.
     comparison $D(\rho_{AB}\Vert\omega)\leq\log Q_2(\rho_{AB},\omega)$ to
     faithful marginals. To relate the remaining order-two estimate to
     operator-Schmidt rank, compress the two tensor factors separately to the
-    supports of $\rho_A$ and $\rho_B$. This simultaneous local compression
-    must preserve operator-Schmidt rank.
+    supports of $\rho_A$ and $\rho_B$.
+    Theorem~\ref{thm:operator_schmidt_rank_marginal_support_compression}
+    shows that this simultaneous local compression reconstructs the original
+    operator and preserves operator-Schmidt rank. It remains to verify that
+    the two compressed marginals are faithful.
 
     In the resulting faithful spaces, write $\sigma=\rho_A$ and
     $\tau=\rho_B$. Choose an eigenbasis of $\sigma$, and set

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -330,9 +330,16 @@ differentiability or a limit at $\alpha=1$, the logarithmic sandwiched R\'enyi
 divergence, nor a comparison with Umegaki relative entropy.
 
 Neither development completes
-\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  That issue still
-requires simultaneous compression by the two marginal support isometries and a
-proof that this local two-factor compression preserves operator-Schmidt rank.
+\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  Simultaneous
+compression by the two marginal support isometries, exact reconstruction, and
+preservation of operator-Schmidt rank are now formalized.
+\footnote{Formal declarations:
+\leanid{Matrix.PosSemidef.eq_marginalSupport_expansion_compression} and
+\leanid{Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression} in
+\doclink{TNLean/Channel/MarginalSupportAbsorption}.}
+The remaining support step is to prove that the two compressed marginals are
+positive definite; this is tracked in
+\href{https://github.com/LionSR/TNLean/issues/5245}{\#5245}.
 The faithful comparison itself remains open in
 \href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  The support-aware
 Jensen inequality above does not by itself establish the relative-modular


### PR DESCRIPTION
## Summary

- prove that simultaneous compression to the supports of both bipartite marginals reconstructs the original positive semidefinite operator
- prove that this compression preserves operator-Schmidt rank by applying local-isometry invariance to the compressed operator
- retain zero-dimensional factors and avoid faithfulness or nonemptiness assumptions
- add a project-derived Blueprint theorem with direct statement and proof dependencies

## Validation

- `lake env lean TNLean/Channel/MarginalSupportAbsorption.lean`
- `lake build TNLean.Channel.MarginalSupportAbsorption` (3,041 targets)
- `lake build TNLean` (9,861 targets before rebase; 9,862 targets after rebase)
- explicit `Fin 0` specializations
- `#print axioms` audit
- proof-integrity and forbidden-token scans
- Blueprint synchronization and `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- reader-facing prose and tactic-pattern checks
- `git diff --check`

Closes #5241
Refs #5211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and documentation; no runtime or security-sensitive paths are modified.
> 
> **Overview**
> Adds Lean proofs that compressing a bipartite PSD operator onto **both** marginal supports via `V₁ ⊗ₖ V₂` **exactly reconstructs** `ρ` (`eq_marginalSupport_expansion_compression`) and **preserves operator-Schmidt rank** (`operatorSchmidtRank_marginalSupport_compression`), using existing single-sided absorption identities plus `operatorSchmidtRank_local_isometry_conj`. Statements allow zero-dimensional factors and do not require faithful marginals.
> 
> Introduces a matching **Blueprint** theorem (`operator_schmidt_rank_marginal_support_compression`) and updates the mutual-information proof sketch and issue notes: two-marginal compression/OSR preservation is done (#5241); **faithfulness of compressed marginals** remains (#5245).
> 
> Updates **`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`** to record the new formalizations and narrow what is still open for #5211.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1629d4d15ca2cbc6002af461d64b62c7523e8128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->