### PR TITLE
feat(Channel): prove faithful compressed marginals

### DIFF
--- a/TNLean/Channel/MarginalSupportAbsorption.lean
+++ b/TNLean/Channel/MarginalSupportAbsorption.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.OperatorSchmidt
 import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.MarginalSupport
+import TNLean.Analysis.SupportCompression
 import TNLean.Channel.PartialTrace
 
 /-!
@@ -33,6 +34,11 @@ form is a specialization of the other on the product index \(L\times R\).
   compression to both marginal supports reconstructs the original operator.
 * `Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression`: this
   simultaneous compression preserves operator-Schmidt rank.
+* `Matrix.PosSemidef.partialTraceRight_marginalSupport_compression` and
+  `Matrix.PosSemidef.partialTraceLeft_marginalSupport_compression`: the two
+  marginals after simultaneous support compression.
+* `Matrix.PosSemidef.marginalSupport_compression_partialTraces_posDef`: both
+  compressed marginals are positive definite.
 
 ## References
 
@@ -321,6 +327,86 @@ theorem PosSemidef.operatorSchmidtRank_marginalSupport_compression
   rw [hρ.eq_marginalSupport_expansion_compression V₁ V₂ hRange₁ hRange₂] at hrank
   exact hrank.symm
 
+/-- The right partial trace of the simultaneous support compression is the
+compression of the original retained left marginal. -/
+theorem PosSemidef.partialTraceRight_marginalSupport_compression
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix L L' ℂ) (V₂ : Matrix R R' ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    Matrix.partialTraceRight ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)) =
+      V₁ᴴ * Matrix.partialTraceRight ρ * V₁ := by
+  let ρc := (V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)
+  have hcov := partialTraceRight_kronecker_mul_mul_conjTranspose V₁ V₂ hV₂ ρc
+  rw [hρ.eq_marginalSupport_expansion_compression V₁ V₂ hRange₁ hRange₂] at hcov
+  change Matrix.partialTraceRight ρc = V₁ᴴ * Matrix.partialTraceRight ρ * V₁
+  calc
+    Matrix.partialTraceRight ρc =
+        (V₁ᴴ * V₁) * Matrix.partialTraceRight ρc * (V₁ᴴ * V₁) := by
+      rw [hV₁, Matrix.one_mul, Matrix.mul_one]
+    _ = V₁ᴴ * (V₁ * Matrix.partialTraceRight ρc * V₁ᴴ) * V₁ := by
+      simp only [Matrix.mul_assoc]
+    _ = V₁ᴴ * Matrix.partialTraceRight ρ * V₁ := by rw [hcov]
+
+/-- The left partial trace of the simultaneous support compression is the
+compression of the original retained right marginal. -/
+theorem PosSemidef.partialTraceLeft_marginalSupport_compression
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix L L' ℂ) (V₂ : Matrix R R' ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    Matrix.partialTraceLeft ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)) =
+      V₂ᴴ * Matrix.partialTraceLeft ρ * V₂ := by
+  let ρc := (V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)
+  have hcov := partialTraceLeft_kronecker_mul_mul_conjTranspose V₁ V₂ hV₁ ρc
+  rw [hρ.eq_marginalSupport_expansion_compression V₁ V₂ hRange₁ hRange₂] at hcov
+  change Matrix.partialTraceLeft ρc = V₂ᴴ * Matrix.partialTraceLeft ρ * V₂
+  calc
+    Matrix.partialTraceLeft ρc =
+        (V₂ᴴ * V₂) * Matrix.partialTraceLeft ρc * (V₂ᴴ * V₂) := by
+      rw [hV₂, Matrix.one_mul, Matrix.mul_one]
+    _ = V₂ᴴ * (V₂ * Matrix.partialTraceLeft ρc * V₂ᴴ) * V₂ := by
+      simp only [Matrix.mul_assoc]
+    _ = V₂ᴴ * Matrix.partialTraceLeft ρ * V₂ := by rw [hcov]
+
 end SimultaneousMarginalSupport
+
+section FinMarginalSupport
+
+variable {d₁ d₂ k₁ k₂ : ℕ}
+
+/-- Simultaneous compression to the two marginal supports makes both
+compressed marginals positive definite. This includes zero-dimensional
+coordinate spaces. -/
+theorem PosSemidef.marginalSupport_compression_partialTraces_posDef
+    {ρ : Matrix (Fin d₁ × Fin d₂) (Fin d₁ × Fin d₂) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix (Fin d₁) (Fin k₁) ℂ) (V₂ : Matrix (Fin d₂) (Fin k₂) ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    (Matrix.partialTraceRight ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂))).PosDef ∧
+      (Matrix.partialTraceLeft ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂))).PosDef := by
+  constructor
+  · rw [hρ.partialTraceRight_marginalSupport_compression
+      V₁ V₂ hV₁ hV₂ hRange₁ hRange₂]
+    simpa only [Matrix.conjTranspose_conjTranspose] using
+      hρ.partialTraceRight.compression_on_support_posDef
+        (V := V₁ᴴ)
+        (by simpa only [Matrix.conjTranspose_conjTranspose] using hV₁)
+        (by
+          rw [Matrix.conjTranspose_conjTranspose]
+          exact hRange₁)
+  · rw [hρ.partialTraceLeft_marginalSupport_compression V₁ V₂ hV₁ hV₂ hRange₁ hRange₂]
+    simpa only [Matrix.conjTranspose_conjTranspose] using
+      hρ.partialTraceLeft.compression_on_support_posDef
+        (V := V₂ᴴ)
+        (by simpa only [Matrix.conjTranspose_conjTranspose] using hV₂)
+        (by
+          rw [Matrix.conjTranspose_conjTranspose]
+          exact hRange₂)
+
+end FinMarginalSupport
 
 end Matrix

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -42,6 +42,10 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
   product
 * `Matrix.partialTraceLeft_kronecker`: the left partial trace of a Kronecker
   product
+* `Matrix.partialTraceRight_kronecker_mul_mul_conjTranspose`: covariance of the
+  right partial trace under a product isometry
+* `Matrix.partialTraceLeft_kronecker_mul_mul_conjTranspose`: covariance of the
+  left partial trace under a product isometry
 * `Matrix.PosDef.partialTraceRight`: the right partial trace of a positive
   definite matrix is positive definite when the traced factor is nonempty
 * `Matrix.PosDef.partialTraceLeft`: the analogous statement for the left
@@ -144,6 +148,57 @@ theorem partialTraceRight_kronecker (A : Matrix α α ℂ) (B : Matrix β β ℂ
   simp only [partialTraceRight_apply, kroneckerMap_apply, Matrix.smul_apply, Matrix.trace,
     Matrix.diag, smul_eq_mul, ← Finset.mul_sum]
   ring
+
+/-- The right partial trace is covariant under conjugation by a product matrix
+when the discarded factor is an isometry. -/
+theorem partialTraceRight_kronecker_mul_mul_conjTranspose
+    {γ δ : Type*} [Fintype α] [DecidableEq β] [Fintype δ]
+    (A : Matrix γ α ℂ) (B : Matrix δ β ℂ) (hB : Bᴴ * B = 1)
+    (X : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight ((A ⊗ₖ B) * X * (A ⊗ₖ B)ᴴ) =
+      A * partialTraceRight X * Aᴴ := by
+  classical
+  ext i j
+  have horth (x y : β) :
+      (∑ k : δ, B k x * star (B k y)) = if x = y then 1 else 0 := by
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply, mul_comm, eq_comm] using
+      congrFun (congrFun hB y) x
+  simp only [partialTraceRight_apply, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, kroneckerMap_apply, Fintype.sum_prod_type, star_mul]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [show ∀ (q : α) (b : β) (p : α) (a : β),
+      (∑ k : δ,
+        A i p * B k a * X (p, a) (q, b) *
+          (star (B k b) * star (A j q))) =
+        A i p * X (p, a) (q, b) *
+          (∑ k : δ, B k a * star (B k b)) * star (A j q) by
+    intro q b p a
+    calc
+      _ = ∑ k : δ,
+          (A i p * X (p, a) (q, b) * star (A j q)) *
+            (B k a * star (B k b)) := by
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      _ = (A i p * X (p, a) (q, b) * star (A j q)) *
+          ∑ k : δ, B k a * star (B k b) := by
+        rw [Finset.mul_sum]
+      _ = _ := by ring]
+  simp_rw [horth]
+  simp only [mul_ite, mul_one, mul_zero, RCLike.star_def, ite_mul,
+    zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
+  apply Finset.sum_congr rfl
+  intro q _
+  exact Finset.sum_comm
 
 /-- Reindex the right tensor factor as `β' × γ`, keeping the left factor fixed. -/
 def rightSplitEquiv {α β β' γ : Type*} (e : β ≃ β' × γ) :
@@ -262,6 +317,56 @@ theorem partialTraceLeft_kronecker (A : Matrix α α ℂ) (B : Matrix β β ℂ)
     Matrix.trace, Matrix.diag]
   rw [← Finset.sum_mul]
   rfl
+
+/-- The left partial trace is covariant under conjugation by a product matrix
+when the discarded factor is an isometry. -/
+theorem partialTraceLeft_kronecker_mul_mul_conjTranspose
+    {γ δ : Type*} [DecidableEq α] [Fintype β] [Fintype γ]
+    (A : Matrix γ α ℂ) (B : Matrix δ β ℂ) (hA : Aᴴ * A = 1)
+    (X : Matrix (α × β) (α × β) ℂ) :
+    partialTraceLeft ((A ⊗ₖ B) * X * (A ⊗ₖ B)ᴴ) =
+      B * partialTraceLeft X * Bᴴ := by
+  classical
+  ext i j
+  have horth (x y : α) :
+      (∑ k : γ, A k x * star (A k y)) = if x = y then 1 else 0 := by
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply, mul_comm, eq_comm] using
+      congrFun (congrFun hA y) x
+  simp only [partialTraceLeft_apply, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, kroneckerMap_apply, Fintype.sum_prod_type, star_mul]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [show ∀ (q : α) (b : β) (p : α) (a : β),
+      (∑ k : γ,
+        A k p * B i a * X (p, a) (q, b) *
+          (star (B j b) * star (A k q))) =
+        B i a * X (p, a) (q, b) *
+          (∑ k : γ, A k p * star (A k q)) * star (B j b) by
+    intro q b p a
+    calc
+      _ = ∑ k : γ,
+          (B i a * X (p, a) (q, b) * star (B j b)) *
+            (A k p * star (A k q)) := by
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      _ = (B i a * X (p, a) (q, b) * star (B j b)) *
+          ∑ k : γ, A k p * star (A k q) := by
+        rw [Finset.mul_sum]
+      _ = _ := by ring]
+  simp_rw [horth]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset α))
+    (t := (Finset.univ : Finset β))]
+  simp only [mul_ite, mul_one, mul_zero, RCLike.star_def, ite_mul,
+    zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
 
 /-- The left partial trace is adjoint to tensoring with the identity under the
 bilinear trace pairing:

--- a/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
@@ -43,49 +43,8 @@ theorem partialTraceRight_singleKraus_kronecker_isometry
     partialTraceRight
         (singleKrausMap (kroneckerMap (· * ·) A B) X) =
       singleKrausMap A (partialTraceRight X) := by
-  classical
-  ext i j
-  have horth (x y : β) :
-      (∑ k : δ, B k x * star (B k y)) = if x = y then 1 else 0 := by
-    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-      Matrix.one_apply, mul_comm, eq_comm] using
-      congrFun (congrFun hB y) x
-  simp only [partialTraceRight_apply, singleKrausMap_apply,
-    Matrix.mul_apply, Matrix.conjTranspose_apply, kroneckerMap_apply,
-    Fintype.sum_prod_type, star_mul]
-  simp_rw [Finset.mul_sum, Finset.sum_mul]
-  rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset α))]
-  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset β))]
-  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset α))]
-  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset β))]
-  simp_rw [show ∀ (q : α) (b : β) (p : α) (a : β),
-      (∑ k : δ,
-        A i p * B k a * X (p, a) (q, b) *
-          (star (B k b) * star (A j q))) =
-        A i p * X (p, a) (q, b) *
-          (∑ k : δ, B k a * star (B k b)) * star (A j q) by
-    intro q b p a
-    calc
-      _ = ∑ k : δ,
-          (A i p * X (p, a) (q, b) * star (A j q)) *
-            (B k a * star (B k b)) := by
-        apply Finset.sum_congr rfl
-        intro k _
-        ring
-      _ = (A i p * X (p, a) (q, b) * star (A j q)) *
-          ∑ k : δ, B k a * star (B k b) := by
-        rw [Finset.mul_sum]
-      _ = _ := by ring]
-  simp_rw [horth]
-  simp only [mul_ite, mul_one, mul_zero, RCLike.star_def, ite_mul,
-    zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
-  apply Finset.sum_congr rfl
-  intro q _
-  exact Finset.sum_comm
+  simpa only [singleKrausMap_apply] using
+    partialTraceRight_kronecker_mul_mul_conjTranspose A B hB X
 
 end Matrix
 

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -27,6 +27,32 @@ partial traces.
     \end{align}
 \end{definition}
 
+\begin{lemma}[Partial trace under product isometries]
+    \label{lem:partial_trace_product_isometry_covariance}
+    \lean{Matrix.partialTraceRight_kronecker_mul_mul_conjTranspose,
+      Matrix.partialTraceLeft_kronecker_mul_mul_conjTranspose}
+    \leanok
+    \uses{def:partial_trace}
+    Let $A$ and $B$ be rectangular complex matrices. If $B^\dagger B=1$, then
+    \begin{align}
+      \tr_B\!\left((A\otimes B)X(A\otimes B)^\dagger\right)
+      &=A(\tr_B X)A^\dagger.
+      \notag
+    \end{align}
+    Symmetrically, if $A^\dagger A=1$, then
+    \begin{align}
+      \tr_A\!\left((A\otimes B)X(A\otimes B)^\dagger\right)
+      &=B(\tr_A X)B^\dagger.
+      \notag
+    \end{align}
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:partial_trace}
+    Expand the matrix products and the defining diagonal sum for the partial
+    trace. The sum over the discarded factor contracts to the corresponding
+    matrix entry of $B^\dagger B$, or of $A^\dagger A$ in the symmetric case.
+\end{proof}
+
 \begin{definition}[Invertible matrix congruence]
     \label{def:invertible_matrix_congruence}
     \lean{Matrix.congruenceLinearEquiv,

--- a/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_choi_and_kraus.tex
@@ -27,8 +27,8 @@ partial traces.
     \end{align}
 \end{definition}
 
-\begin{lemma}[Partial trace under product isometries]
-    \label{lem:partial_trace_product_isometry_covariance}
+\begin{theorem}[Partial trace under product isometries]
+    \label{thm:partial_trace_product_isometry_covariance}
     \lean{Matrix.partialTraceRight_kronecker_mul_mul_conjTranspose,
       Matrix.partialTraceLeft_kronecker_mul_mul_conjTranspose}
     \leanok
@@ -45,7 +45,7 @@ partial traces.
       &=B(\tr_A X)B^\dagger.
       \notag
     \end{align}
-\end{lemma}
+\end{theorem}
 \begin{proof}\leanok
     \uses{def:partial_trace}
     Expand the matrix products and the defining diagonal sum for the partial

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -471,6 +471,36 @@
     Substitution of the reconstruction identity proves the rank equality.
 \end{proof}
 
+\begin{theorem}[Marginals after compression to both supports]
+    \label{thm:marginal_support_compression_faithful_marginals}
+    \lean{Matrix.PosSemidef.partialTraceRight_marginalSupport_compression,
+      Matrix.PosSemidef.partialTraceLeft_marginalSupport_compression,
+      Matrix.PosSemidef.marginalSupport_compression_partialTraces_posDef}
+    \leanok
+    \uses{def:partial_trace, def:hermitian_support_projection,
+      thm:operator_schmidt_rank_marginal_support_compression}
+    Under the hypotheses and notation of
+    Theorem~\ref{thm:operator_schmidt_rank_marginal_support_compression}, the
+    marginals of $\rho_c=W^\dagger\rho W$ satisfy
+    \begin{align}
+      \tr_B(\rho_c)&=V_A^\dagger(\tr_B\rho)V_A,
+      &\tr_A(\rho_c)&=V_B^\dagger(\tr_A\rho)V_B.
+      \notag
+    \end{align}
+    Both compressed marginals are positive definite. This remains valid for
+    zero-dimensional coordinate spaces.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:partial_trace_product_isometry_covariance,
+      thm:operator_schmidt_rank_marginal_support_compression,
+      thm:compression_on_support_posDef}
+    Reconstruct $\rho=W\rho_cW^\dagger$ and apply partial-trace covariance.
+    Sandwiching the resulting identities by $V_A^\dagger,V_A$ and by
+    $V_B^\dagger,V_B$ gives the displayed formulas. Each is the compression
+    of a positive semidefinite marginal to its full support, hence is positive
+    definite.
+\end{proof}
+
 \begin{theorem}[Channel of a faithful bipartite marginal]
     \label{thm:supported_marginal_channel}
     \lean{Matrix.finrank_range_supportedMarginalMap,
@@ -515,9 +545,9 @@
 
 \section{Support compression for entropy functionals}
 
-% Issues #5229 and #5241 establish one- and two-marginal support compression,
-% including preservation of operator-Schmidt rank.  Faithfulness of the two
-% compressed marginals is tracked in #5245 as a remaining step for #5211.
+% Issues #5229, #5241, and #5245 establish one- and two-marginal support
+% compression, including preservation of operator-Schmidt rank and
+% faithfulness of both compressed marginals.
 
 \begin{definition}[Isometric conjugation into a larger matrix algebra]
     \label{def:isometric_nonunital_conjugation}
@@ -1108,6 +1138,7 @@ logarithmic divergence, or a comparison with relative entropy.
 \begin{proof}
     \uses{thm:relative_entropy_q2_faithful_reduction,
       thm:operator_schmidt_rank_marginal_support_compression,
+      thm:marginal_support_compression_faithful_marginals,
       thm:full_support_eigenbasis_whitened_choi_bound}
     Set $\omega=\rho_A\otimes\rho_B$. Positivity gives
     $\ker\omega\subseteq\ker\rho_{AB}$, so
@@ -1118,8 +1149,9 @@ logarithmic divergence, or a comparison with relative entropy.
     supports of $\rho_A$ and $\rho_B$.
     Theorem~\ref{thm:operator_schmidt_rank_marginal_support_compression}
     shows that this simultaneous local compression reconstructs the original
-    operator and preserves operator-Schmidt rank. It remains to verify that
-    the two compressed marginals are faithful.
+    operator and preserves operator-Schmidt rank, while
+    Theorem~\ref{thm:marginal_support_compression_faithful_marginals} shows
+    that the two compressed marginals are faithful.
 
     In the resulting faithful spaces, write $\sigma=\rho_A$ and
     $\tau=\rho_B$. Choose an eigenbasis of $\sigma$, and set

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -491,7 +491,7 @@
     zero-dimensional coordinate spaces.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{lem:partial_trace_product_isometry_covariance,
+    \uses{thm:partial_trace_product_isometry_covariance,
       thm:operator_schmidt_rank_marginal_support_compression,
       thm:compression_on_support_posDef}
     Reconstruct $\rho=W\rho_cW^\dagger$ and apply partial-trace covariance.

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -331,15 +331,16 @@ divergence, nor a comparison with Umegaki relative entropy.
 
 Neither development completes
 \href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  Simultaneous
-compression by the two marginal support isometries, exact reconstruction, and
-preservation of operator-Schmidt rank are now formalized.
+compression by the two marginal support isometries, exact reconstruction,
+preservation of operator-Schmidt rank, and positive definiteness of both
+compressed marginals are now formalized.
 \footnote{Formal declarations:
 \leanid{Matrix.PosSemidef.eq_marginalSupport_expansion_compression} and
-\leanid{Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression} in
+\leanid{Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression},
+\leanid{Matrix.PosSemidef.partialTraceRight_marginalSupport_compression},
+\leanid{Matrix.PosSemidef.partialTraceLeft_marginalSupport_compression}, and
+\leanid{Matrix.PosSemidef.marginalSupport_compression_partialTraces_posDef} in
 \doclink{TNLean/Channel/MarginalSupportAbsorption}.}
-The remaining support step is to prove that the two compressed marginals are
-positive definite; this is tracked in
-\href{https://github.com/LionSR/TNLean/issues/5245}{\#5245}.
 The faithful comparison itself remains open in
 \href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  The support-aware
 Jensen inequality above does not by itself establish the relative-modular

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -63,7 +63,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch13_parent_hamiltonian_injective_ground_spaces_intersection_property.tex` | — | — | L97 `tenkz` → `C-policy+C-record+R-record` |
 | `ch13_parent_hamiltonian_injective_ground_spaces_local_parent_interaction.tex` | — | — | L35, 489, 528 `tenkz` → `C-policy+C-record+R-record` |
 | `ch14_correlations.tex` | — | — | L67 `tenkz` → `C-policy+C-record+R-record` |
-| `ch16_channel_representations_choi_and_kraus.tex` | — | L670 `tenkz` → `C-policy+C-record` | — |
+| `ch16_channel_representations_choi_and_kraus.tex` | — | L696 `tenkz` → `C-policy+C-record` | — |
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L20 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L232, 238 `tenkz` → `C-policy+C-record` | L153, 159, 336, 433 `tenkz` → `C-policy+C-record+R-record`<br>L177, 182 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |


### PR DESCRIPTION
## Summary

- add low-layer left and right partial-trace covariance under product isometries
- derive the two marginals of simultaneous compression to marginal supports
- prove both compressed marginals are positive definite, including zero-dimensional coordinate spaces
- replace the duplicated high-layer covariance proof with a wrapper around the Channel lemma
- synchronize the Blueprint and the MPDO mutual-information gap note

## Mathematical scope

These are project-derived finite-dimensional support-compression results needed by #5211. They are not attributed to CPSV16 or Beigi. The compressed-marginal proof uses the existing reconstruction theorem before applying covariance, then sandwiches by the support isometries and applies `compression_on_support_posDef`.

No faithfulness or nonemptiness hypothesis is added. The declarations use ordinary library names; no recovery-prefixed compatibility API is introduced.

## Validation

- `lake exe cache get` before Lean checks: all 8,639 Mathlib artifacts already present
- focused builds: `TNLean.Channel.PartialTrace`, `TNLean.Channel.MarginalSupportAbsorption`, `TNLean.MPS.MPDO.PhysicalSupportSALTransport`
- explicit ambient/support `Fin 0` elaboration
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- `python3 scripts/blueprint_lean_sync.py --ci`
- `python3 scripts/generate_import_aggregators.py --check`
- `git diff --check`
- proof-integrity scan and tactic-pattern scan
- independent exact-commit mathematical and Blueprint review

No broad local `lake build` was run; CI remains the full-build gate.

Closes #5245
Refs #5211

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style matrix/channel lemmas and doc sync; no runtime, auth, or API surface beyond new Lean theorems and blueprint links.
> 
> **Overview**
> Adds **partial-trace covariance** under conjugation by a Kronecker product isometry (`partialTraceRight_kronecker_mul_mul_conjTranspose` and the left analogue in `PartialTrace.lean`), then uses it in the bipartite **simultaneous marginal-support** story.
> 
> **MarginalSupportAbsorption** now shows that after compressing ρ with both marginal support isometries, each partial trace equals compressing the original marginal, and both compressed marginals are **positive definite** (including `Fin 0`). **PhysicalSupportSALTransport** drops a long duplicate proof in favor of the shared Channel lemma.
> 
> Blueprint **ch16** documents the isometry covariance theorem; **ch21** adds faithful marginals after two-sided compression and wires that into the mutual-information / operator-Schmidt proof sketch. The MPDO mutual-information gap note and issue comments mark **#5245** (faithful compressed marginals) as done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 402154e866902c0d1b91d6b839696f9839976ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->