### PR TITLE
fix(tenkz): index unordered string relations

### DIFF
--- a/tests/tenkz/kernel/regression/r_index_pair_scaling.tex
+++ b/tests/tenkz/kernel/regression/r_index_pair_scaling.tex
@@ -1,0 +1,46 @@
+% Regression: topology inference and crossing police traverse 100 index routes
+% by unordered pair, with one indexed touch fact per pair.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\int_new:N \g__tenkz_test_index_pair_int
+\cs_new_eq:NN
+  \__tenkz_test_index_join_pair:nn
+  \__tenkz_kernel_r_index_join_pair:nn
+\cs_set_protected:Npn \__tenkz_kernel_r_index_join_pair:nn #1#2
+  {
+    \int_gincr:N \g__tenkz_test_index_pair_int
+    \__tenkz_test_index_join_pair:nn {#1} {#2}
+  }
+\cs_new_eq:NN
+  \__tenkz_test_index_resolve:
+  \__tenkz_string_resolve:
+\cs_set_protected:Npn \__tenkz_string_resolve:
+  {
+    \int_compare:nNnF
+      { \prop_count:N \l__tenkz_string_touch_prop } = {4950}
+      {\errmessage{touch~facts~were~not~indexed~once~per~unordered~pair}}
+    \__tenkz_test_index_resolve:
+  }
+\cs_new_protected:Npn \__tenkz_test_many_index_wires:
+  {
+    \int_step_inline:nn {100}
+      { \tnwire[name=scale-##1]{w~outside}{e~outside} }
+  }
+\AtEndDocument
+  {
+    \int_compare:nNnF { \g__tenkz_test_index_pair_int } = {4950}
+      {\errmessage{index~routes~were~not~visited~once~per~unordered~pair}}
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=1, bonds=none]
+  \ExplSyntaxOn
+  \__tenkz_test_many_index_wires:
+  \ExplSyntaxOff
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_port_open_shared_host.tex
+++ b/tests/tenkz/kernel/regression/r_port_open_shared_host.tex
@@ -16,7 +16,7 @@
       {
         {1}
           {
-            \seq_if_empty:NT \l__tenkz_string_touch_seq
+            \prop_if_empty:NT \l__tenkz_string_touch_prop
               {\errmessage{shared-host~port~touch~was~lost}}
           }
         {2}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -3874,7 +3874,7 @@
 \prop_new:N \l__tenkz_kernel_r_species_prop   % species word -> hue
 \prop_new:N \l__tenkz_kernel_r_sid_record_prop
 \prop_new:N \l__tenkz_kernel_r_index_style_prop
-\prop_new:N \l__tenkz_kernel_r_index_join_prop
+\prop_new:N \l__tenkz_kernel_r_index_sid_prop
 \prop_new:N \l__tenkz_kernel_r_skin_over_wire_prop
 \prop_new:N \l__tenkz_kernel_r_port_box_prop
 \prop_new:N \l__tenkz_kernel_r_port_host_routes_prop
@@ -7393,6 +7393,8 @@
       \l__tenkz_kernel_r_sid_tl {#2}
     \prop_put:NVV \l__tenkz_kernel_r_sid_record_prop
       \l__tenkz_kernel_r_sid_tl \l__tenkz_kernel_r_wire_record_tl
+    \prop_put:NVV \l__tenkz_kernel_r_index_sid_prop
+      \l__tenkz_kernel_r_sid_tl \l__tenkz_kernel_r_wire_record_tl
     \prop_put:NVV \l__tenkz_kernel_r_index_style_prop
       \l__tenkz_kernel_r_wire_record_tl \l__tenkz_kernel_r_wire_style_tl
     \seq_put_right:NV \l__tenkz_kernel_r_index_routes_seq
@@ -9922,74 +9924,80 @@
 
 \cs_new_protected:Npn \__tenkz_kernel_r_index_joins:
   {
-    \prop_clear:N \l__tenkz_kernel_r_index_join_prop
-    \seq_map_inline:Nn \l__tenkz_kernel_r_index_routes_seq
+    \prop_if_empty:NF \l__tenkz_kernel_r_index_sid_prop
       {
-        \tl_set:Nn \l__tenkz_kernel_r_wire_record_tl {##1}
-        \__tenkz_kernel_r_sid:nN {##1} \l__tenkz_kernel_r_sid_tl
-        \seq_map_inline:Nn \l__tenkz_string_ids_seq
+        \__tenkz_string_map_unordered_pairs:N
+          \__tenkz_kernel_r_index_join_pair:nn
+      }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_r_index_join_pair:nn #1#2
+  {
+    \prop_get:NnN \l__tenkz_kernel_r_index_sid_prop {#1}
+      \l__tenkz_kernel_r_wire_record_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_r_wire_record_tl
+      {
+        \prop_get:NnN \l__tenkz_kernel_r_index_sid_prop {#2}
+          \l__tenkz_kernel_r_wire_record_tl
+        \quark_if_no_value:NF \l__tenkz_kernel_r_wire_record_tl
           {
-            \str_if_eq:VnF \l__tenkz_kernel_r_sid_tl {####1}
+            \__tenkz_kernel_r_index_join_oriented:nn {#2} {#1}
+          }
+      }
+      { \__tenkz_kernel_r_index_join_oriented:nn {#1} {#2} }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_r_index_join_oriented:nn #1#2
+  {
+    \tl_set:Nn \l__tenkz_kernel_r_sid_tl {#1}
+    \tl_set:Nn \l__tenkz_kernel_r_b_tl {#2}
+    \prop_get:NnN \l__tenkz_kernel_r_sid_record_prop {#2}
+      \l__tenkz_kernel_r_c_tl
+    \quark_if_no_value:NTF \l__tenkz_kernel_r_c_tl
+      {
+        \exp_args:NVV \__tenkz_string_touch:nn
+          \l__tenkz_kernel_r_sid_tl
+          \l__tenkz_kernel_r_b_tl
+      }
+      {
+        \__tenkz_model_get:nnN
+          { \l__tenkz_kernel_r_c_tl } {kind}
+          \l__tenkz_kernel_scratch_tl
+        \str_if_eq:VnTF
+          \l__tenkz_kernel_scratch_tl {pairing}
+          {
+            \exp_args:NVV
+              \__tenkz_kernel_r_wires_share_port:nnTF
+              \l__tenkz_kernel_r_wire_record_tl
+              \l__tenkz_kernel_r_c_tl
               {
-                \prop_if_in:NeF \l__tenkz_kernel_r_index_join_prop
-                  { \l__tenkz_kernel_r_sid_tl / ####1 }
+                \exp_args:NVV \__tenkz_string_touch:nn
+                  \l__tenkz_kernel_r_sid_tl
+                  \l__tenkz_kernel_r_b_tl
+              }
+              {
+                \exp_args:NVV
+                  \__tenkz_string_endpoint_meeting:nnTF
+                  \l__tenkz_kernel_r_sid_tl
+                  \l__tenkz_kernel_r_b_tl
                   {
-                    \prop_put:Nen \l__tenkz_kernel_r_index_join_prop
-                      { \l__tenkz_kernel_r_sid_tl / ####1 } {seen}
-                    \prop_put:Nen \l__tenkz_kernel_r_index_join_prop
-                      { ####1 / \l__tenkz_kernel_r_sid_tl } {seen}
-                    \tl_set:Nn \l__tenkz_kernel_r_b_tl {####1}
-                    \prop_get:NnN \l__tenkz_kernel_r_sid_record_prop {####1}
-                      \l__tenkz_kernel_r_c_tl
-                    \quark_if_no_value:NTF \l__tenkz_kernel_r_c_tl
-                      {
-                        \exp_args:NVV \__tenkz_string_touch:nn
-                          \l__tenkz_kernel_r_sid_tl
-                          \l__tenkz_kernel_r_b_tl
-                      }
-                      {
-                        \__tenkz_model_get:nnN
-                          { \l__tenkz_kernel_r_c_tl } {kind}
-                          \l__tenkz_kernel_scratch_tl
-                        \str_if_eq:VnTF
-                          \l__tenkz_kernel_scratch_tl {pairing}
-                          {
-                            \exp_args:NVV
-                              \__tenkz_kernel_r_wires_share_port:nnTF
-                              \l__tenkz_kernel_r_wire_record_tl
-                              \l__tenkz_kernel_r_c_tl
-                              {
-                                \exp_args:NVV \__tenkz_string_touch:nn
-                                  \l__tenkz_kernel_r_sid_tl
-                                  \l__tenkz_kernel_r_b_tl
-                              }
-                              {
-                                \exp_args:NVV
-                                  \__tenkz_string_endpoint_meeting:nnTF
-                                  \l__tenkz_kernel_r_sid_tl
-                                  \l__tenkz_kernel_r_b_tl
-                                  {
-                                    \exp_args:NVV \__tenkz_string_join:nn
-                                      \l__tenkz_kernel_r_sid_tl
-                                      \l__tenkz_kernel_r_b_tl
-                                  }
-                                  { }
-                              }
-                          }
-                          {
-                            \__tenkz_model_get:nnN
-                              { \l__tenkz_kernel_r_wire_record_tl } {origin}
-                              \l__tenkz_kernel_scratch_tl
-                            \str_if_eq:VnF
-                              \l__tenkz_kernel_scratch_tl {port-open}
-                              {
-                                \exp_args:NVV \__tenkz_string_touch:nn
-                                  \l__tenkz_kernel_r_sid_tl
-                                  \l__tenkz_kernel_r_b_tl
-                              }
-                          }
-                      }
+                    \exp_args:NVV \__tenkz_string_join:nn
+                      \l__tenkz_kernel_r_sid_tl
+                      \l__tenkz_kernel_r_b_tl
                   }
+                  { }
+              }
+          }
+          {
+            \__tenkz_model_get:nnN
+              { \l__tenkz_kernel_r_wire_record_tl } {origin}
+              \l__tenkz_kernel_scratch_tl
+            \str_if_eq:VnF
+              \l__tenkz_kernel_scratch_tl {port-open}
+              {
+                \exp_args:NVV \__tenkz_string_touch:nn
+                  \l__tenkz_kernel_r_sid_tl
+                  \l__tenkz_kernel_r_b_tl
               }
           }
       }
@@ -11448,7 +11456,7 @@
     \prop_clear:N \l__tenkz_kernel_r_species_prop
     \prop_clear:N \l__tenkz_kernel_r_sid_record_prop
     \prop_clear:N \l__tenkz_kernel_r_index_style_prop
-    \prop_clear:N \l__tenkz_kernel_r_index_join_prop
+    \prop_clear:N \l__tenkz_kernel_r_index_sid_prop
     \seq_clear:N \l__tenkz_kernel_r_index_routes_seq
     \seq_clear:N \l__tenkz_kernel_r_port_label_routes_seq
     \seq_clear:N \l__tenkz_kernel_r_strings_seq

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -73,8 +73,9 @@
 \prop_new:N \l__tenkz_string_kind_prop       % id -> open|closed|wind|around
 \prop_new:N \l__tenkz_string_source_prop     % id -> caller|generated
 \seq_new:N \l__tenkz_string_cross_seq        % {under}{over} pairs
-\seq_new:N \l__tenkz_string_join_seq         % unordered endpoint joins
-\seq_new:N \l__tenkz_string_touch_seq        % shared semantic wire ports
+\prop_new:N \l__tenkz_string_cross_prop      % unordered pair -> declarations
+\prop_new:N \l__tenkz_string_join_prop       % unordered pair -> endpoint joins
+\prop_new:N \l__tenkz_string_touch_prop      % shared semantic wire ports
 \prop_new:N \l__tenkz_string_disjoint_prop   % model-proven disjoint pairs
 \seq_new:N \l__tenkz_string_gap_ids_seq      % under paths awaiting one gap pass
 \seq_new:N \l__tenkz_string_self_gap_ids_seq % self paths awaiting branch gap
@@ -148,8 +149,9 @@
     \prop_clear:N \l__tenkz_string_kind_prop
     \prop_clear:N \l__tenkz_string_source_prop
     \seq_clear:N \l__tenkz_string_cross_seq
-    \seq_clear:N \l__tenkz_string_join_seq
-    \seq_clear:N \l__tenkz_string_touch_seq
+    \prop_clear:N \l__tenkz_string_cross_prop
+    \prop_clear:N \l__tenkz_string_join_prop
+    \prop_clear:N \l__tenkz_string_touch_prop
     \prop_clear:N \l__tenkz_string_disjoint_prop
     \seq_clear:N \l__tenkz_string_gap_ids_seq
     \seq_clear:N \l__tenkz_string_self_gap_ids_seq
@@ -157,6 +159,56 @@
     \prop_clear:N \l__tenkz_string_self_gap_prop
     \prop_clear:N \l__tenkz_string_external_gap_prop
     \prop_clear:N \l__tenkz_string_crossing_point_prop
+  }
+
+% Every unordered relation uses one canonical key.  The grouped form is
+% unambiguous even when one string id is a prefix of another.
+\cs_new:Npn \__tenkz_string_pair_key:nn #1#2
+  {
+    \str_compare:eNeTF {#1} > {#2}
+      { {#2} {#1} }
+      { {#1} {#2} }
+  }
+
+\cs_new_protected:Npn \__tenkz_string_pair_put:Nnn #1#2#3
+  { \prop_put:Nen #1 { \__tenkz_string_pair_key:nn {#2} {#3} } { } }
+
+\cs_new_protected:Npn \__tenkz_string_pair_count_incr:Nnn #1#2#3
+  {
+    \prop_get:NeNTF #1
+      { \__tenkz_string_pair_key:nn {#2} {#3} }
+      \l__tenkz_string_tmp_tl
+      {
+        \tl_set:Ne \l__tenkz_string_tmp_tl
+          { \int_eval:n { \l__tenkz_string_tmp_tl + 1 } }
+      }
+      { \tl_set:Nn \l__tenkz_string_tmp_tl {1} }
+    \prop_put:NeV #1
+      { \__tenkz_string_pair_key:nn {#2} {#3} }
+      \l__tenkz_string_tmp_tl
+  }
+
+\cs_new_protected:Npn \__tenkz_string_pair_count_get:NnnN #1#2#3#4
+  {
+    \prop_get:NeN #1
+      { \__tenkz_string_pair_key:nn {#2} {#3} }
+      \l__tenkz_string_tmp_tl
+    \quark_if_no_value:NTF \l__tenkz_string_tmp_tl
+      { \int_zero:N #4 }
+      { \int_set:Nn #4 { \l__tenkz_string_tmp_tl } }
+  }
+
+% Traverse each unordered pair once in declaration order.  Both kernel
+% topology inference and crossing validation use this same scaling boundary.
+\cs_new_protected:Npn \__tenkz_string_map_unordered_pairs:N #1
+  {
+    \seq_set_eq:NN \l__tenkz_string_scan_seq \l__tenkz_string_ids_seq
+    \seq_map_inline:Nn \l__tenkz_string_ids_seq
+      {
+        \seq_pop_left:NN \l__tenkz_string_scan_seq \l__tenkz_string_tmp_tl
+        \seq_map_inline:Nn \l__tenkz_string_scan_seq
+          { #1 {##1} {####1} }
+      }
   }
 
 \cs_new_protected:Npn \__tenkz_string_require_libs:
@@ -439,6 +491,8 @@
     \prop_if_in:NnF \l__tenkz_string_kind_prop {#2}
       { \msg_error:nnn {tenkz}{string-unknown} {#2} }
     \seq_put_right:Nn \l__tenkz_string_cross_seq { {#1} {#2} }
+    \__tenkz_string_pair_count_incr:Nnn
+      \l__tenkz_string_cross_prop {#1} {#2}
     \str_if_eq:nnT {#1} {#2}
       {
         \prop_get:NnNTF
@@ -460,23 +514,20 @@
       { \msg_error:nnn {tenkz}{string-unknown} {#1} }
     \prop_if_in:NnF \l__tenkz_string_kind_prop {#2}
       { \msg_error:nnn {tenkz}{string-unknown} {#2} }
-    \seq_put_right:Nn \l__tenkz_string_join_seq { {#1} {#2} }
+    \__tenkz_string_pair_count_incr:Nnn
+      \l__tenkz_string_join_prop {#1} {#2}
   }
 
 % Two model wires may share a semantic port while their measured ink paths
 % overlap near the glyph border.  That attachment is topology, not a crossing.
 \cs_new_protected:Npn \__tenkz_string_touch:nn #1#2
-  {
-    \seq_put_right:Nn \l__tenkz_string_touch_seq { {#1} {#2} }
-  }
+  { \__tenkz_string_pair_put:Nnn \l__tenkz_string_touch_prop {#1} {#2} }
 
 % Record a pair whose owning model proves cannot meet.  The crossing police
 % can answer zero without asking the drawing engine to rediscover topology
 % from potentially singular path arithmetic.
 \cs_new_protected:Npn \__tenkz_string_disjoint:nn #1#2
-  {
-    \prop_put:Nnn \l__tenkz_string_disjoint_prop { #1 / #2 } { }
-  }
+  { \__tenkz_string_pair_put:Nnn \l__tenkz_string_disjoint_prop {#1} {#2} }
 
 % intersection count of two saved paths through the pgf engine
 \cs_new_protected:Npn \__tenkz_string_count:nnN #1#2#3
@@ -1126,22 +1177,13 @@
   {
     \seq_map_inline:Nn \l__tenkz_string_ids_seq
       { \__tenkz_string_police_self:n {##1} }
-    \seq_set_eq:NN \l__tenkz_string_scan_seq \l__tenkz_string_ids_seq
-    \seq_map_inline:Nn \l__tenkz_string_ids_seq
-      {
-        \seq_pop_left:NN \l__tenkz_string_scan_seq \l__tenkz_string_tmp_tl
-        \seq_map_inline:Nn \l__tenkz_string_scan_seq
-          { \__tenkz_string_police_pair:nn {##1} {####1} }
-      }
+    \__tenkz_string_map_unordered_pairs:N \__tenkz_string_police_pair:nn
   }
 \cs_new_protected:Npn \__tenkz_string_police_self:n #1
   {
-    \int_zero:N \l__tenkz_string_declared_int
-    \seq_map_inline:Nn \l__tenkz_string_cross_seq
-      {
-        \tl_if_eq:nnT { {#1} {#1} } {##1}
-          { \int_incr:N \l__tenkz_string_declared_int }
-      }
+    \__tenkz_string_pair_count_get:NnnN
+      \l__tenkz_string_cross_prop {#1} {#1}
+      \l__tenkz_string_declared_int
     \prop_get:NnN
       \l__tenkz_string_kind_prop {#1} \l__tenkz_string_tmp_tl
     % A winding is a generated projection of its declared homotopy class.
@@ -1164,16 +1206,14 @@
 \cs_new_protected:Npn \__tenkz_string_police_pair:nn #1#2
   {
     \bool_set_false:N \l_tmpa_bool
-    \prop_if_in:NnT \l__tenkz_string_disjoint_prop { #1 / #2 }
-      { \bool_set_true:N \l_tmpa_bool }
-    \prop_if_in:NnT \l__tenkz_string_disjoint_prop { #2 / #1 }
+    \prop_if_in:NeT \l__tenkz_string_disjoint_prop
+      { \__tenkz_string_pair_key:nn {#1} {#2} }
       { \bool_set_true:N \l_tmpa_bool }
     \bool_if:NTF \l_tmpa_bool
       { \__tenkz_string_police_pair_disjoint:nn {#1} {#2} }
       {
-        \seq_if_in:NnT \l__tenkz_string_touch_seq { {#1} {#2} }
-          { \bool_set_true:N \l_tmpa_bool }
-        \seq_if_in:NnT \l__tenkz_string_touch_seq { {#2} {#1} }
+        \prop_if_in:NeT \l__tenkz_string_touch_prop
+          { \__tenkz_string_pair_key:nn {#1} {#2} }
           { \bool_set_true:N \l_tmpa_bool }
         \bool_if:NF \l_tmpa_bool
           { \__tenkz_string_police_pair_cross:nn {#1} {#2} }
@@ -1181,39 +1221,21 @@
   }
 \cs_new_protected:Npn \__tenkz_string_police_pair_disjoint:nn #1#2
   {
-    \seq_map_inline:Nn \l__tenkz_string_cross_seq
-      {
-        \tl_if_eq:nnT { {#1} {#2} } {##1}
-          { \msg_error:nnnn {tenkz}{cross-disjoint} {#1} {#2} }
-        \tl_if_eq:nnT { {#2} {#1} } {##1}
-          { \msg_error:nnnn {tenkz}{cross-disjoint} {#1} {#2} }
-      }
-    \seq_map_inline:Nn \l__tenkz_string_join_seq
-      {
-        \tl_if_eq:nnT { {#1} {#2} } {##1}
-          { \msg_error:nnnn {tenkz}{join-disjoint} {#1} {#2} }
-        \tl_if_eq:nnT { {#2} {#1} } {##1}
-          { \msg_error:nnnn {tenkz}{join-disjoint} {#1} {#2} }
-      }
+    \prop_if_in:NeT \l__tenkz_string_cross_prop
+      { \__tenkz_string_pair_key:nn {#1} {#2} }
+      { \msg_error:nnnn {tenkz}{cross-disjoint} {#1} {#2} }
+    \prop_if_in:NeT \l__tenkz_string_join_prop
+      { \__tenkz_string_pair_key:nn {#1} {#2} }
+      { \msg_error:nnnn {tenkz}{join-disjoint} {#1} {#2} }
   }
 \cs_new_protected:Npn \__tenkz_string_police_pair_cross:nn #1#2
   {
-    \int_zero:N \l__tenkz_string_n_int
-    \seq_map_inline:Nn \l__tenkz_string_cross_seq
-      {
-        \tl_if_eq:nnT { {#1} {#2} } {##1}
-          { \int_incr:N \l__tenkz_string_n_int }
-        \tl_if_eq:nnT { {#2} {#1} } {##1}
-          { \int_incr:N \l__tenkz_string_n_int }
-      }
-    \int_zero:N \l__tenkz_string_declared_int
-    \seq_map_inline:Nn \l__tenkz_string_join_seq
-      {
-        \tl_if_eq:nnT { {#1} {#2} } {##1}
-          { \int_incr:N \l__tenkz_string_declared_int }
-        \tl_if_eq:nnT { {#2} {#1} } {##1}
-          { \int_incr:N \l__tenkz_string_declared_int }
-      }
+    \__tenkz_string_pair_count_get:NnnN
+      \l__tenkz_string_cross_prop {#1} {#2}
+      \l__tenkz_string_n_int
+    \__tenkz_string_pair_count_get:NnnN
+      \l__tenkz_string_join_prop {#1} {#2}
+      \l__tenkz_string_declared_int
     \int_set_eq:NN \l_tmpa_int \l__tenkz_string_n_int
     \__tenkz_string_count:nnN {#1} {#2} \l__tenkz_string_n_int
     \int_compare:nNnT { \l__tenkz_string_n_int } > {1}


### PR DESCRIPTION
Advances the shared performance slice of LionSR/tenkz#113.

The string engine now indexes unordered cross, join, touch, and disjoint relations by one canonical pair key. It retains the directed crossing sequence only where rendering needs declaration order and multiplicity. Kernel index-route topology and crossing police share one declaration-order unordered-pair traversal, so neither revisits ordered pairs nor linearly scans accumulated relation lists.

A 100-route regression asserts exactly 4,950 topology callbacks and 4,950 canonical touch facts at the resolve boundary. The real pending GHZ state and workbench (81 atoms, 99 wires) both compile through this engine in about 62-64 seconds; they previously exceeded the 120-second gate.

Validation:
- 30 string-probe event and pixel artifacts byte-identical
- 82 kernel regressions; 8 sugar equivalences; 12 kernel streams; pixels byte-identical
- 264 corpus event streams byte-identical
- shrink census stable at 200 with all 132 flags covered
- changed-fixture lint: 0 findings
- no literal dimensions added