### PR TITLE
feat(Channel): prove faithful marginals after support compression

### DIFF
--- a/TNLean/Channel/MarginalSupportAbsorption.lean
+++ b/TNLean/Channel/MarginalSupportAbsorption.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import TNLean.Algebra.OperatorSchmidt
 import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.MarginalSupport
+import TNLean.Analysis.SupportCompression
 import TNLean.Channel.PartialTrace
 
 /-!
@@ -33,6 +34,13 @@ form is a specialization of the other on the product index \(L\times R\).
   compression to both marginal supports reconstructs the original operator.
 * `Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression`: this
   simultaneous compression preserves operator-Schmidt rank.
+* `Matrix.PosSemidef.partialTraceRight_marginalSupport_compression`: the
+  marginal obtained by tracing the right factor has the expected compressed
+  form.
+* `Matrix.PosSemidef.partialTraceLeft_marginalSupport_compression`: the
+  analogous formula for the marginal obtained by tracing the left factor.
+* `Matrix.PosSemidef.marginalSupport_compression_marginals_posDef`: both
+  compressed marginals are positive definite.
 
 ## References
 
@@ -321,6 +329,94 @@ theorem PosSemidef.operatorSchmidtRank_marginalSupport_compression
   rw [hρ.eq_marginalSupport_expansion_compression V₁ V₂ hRange₁ hRange₂] at hrank
   exact hrank.symm
 
+/-- After simultaneous compression to both marginal supports, the marginal
+obtained by tracing the right factor is the compression of the original right
+partial trace. -/
+theorem PosSemidef.partialTraceRight_marginalSupport_compression
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix L L' ℂ) (V₂ : Matrix R R' ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    Matrix.partialTraceRight ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)) =
+      V₁ᴴ * Matrix.partialTraceRight ρ * V₁ := by
+  let ρc := (V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)
+  have hreconstruct : (V₁ ⊗ₖ V₂) * ρc * (V₁ ⊗ₖ V₂)ᴴ = ρ := by
+    exact hρ.eq_marginalSupport_expansion_compression V₁ V₂ hRange₁ hRange₂
+  have hpartial := partialTraceRight_kronecker_conj_of_right_isometry
+    V₁ V₂ hV₂ ρc
+  rw [hreconstruct] at hpartial
+  change Matrix.partialTraceRight ρc = V₁ᴴ * Matrix.partialTraceRight ρ * V₁
+  symm
+  calc
+    V₁ᴴ * Matrix.partialTraceRight ρ * V₁ =
+        V₁ᴴ * (V₁ * Matrix.partialTraceRight ρc * V₁ᴴ) * V₁ := by
+      rw [hpartial]
+    _ = Matrix.partialTraceRight ρc := by
+      simp only [Matrix.mul_assoc, ← Matrix.mul_assoc V₁ᴴ V₁, hV₁,
+        Matrix.one_mul, Matrix.mul_one]
+
+/-- After simultaneous compression to both marginal supports, the marginal
+obtained by tracing the left factor is the compression of the original left
+partial trace. -/
+theorem PosSemidef.partialTraceLeft_marginalSupport_compression
+    {ρ : Matrix (L × R) (L × R) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix L L' ℂ) (V₂ : Matrix R R' ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    Matrix.partialTraceLeft ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)) =
+      V₂ᴴ * Matrix.partialTraceLeft ρ * V₂ := by
+  let ρc := (V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂)
+  have hreconstruct : (V₁ ⊗ₖ V₂) * ρc * (V₁ ⊗ₖ V₂)ᴴ = ρ := by
+    exact hρ.eq_marginalSupport_expansion_compression V₁ V₂ hRange₁ hRange₂
+  have hpartial := partialTraceLeft_kronecker_conj_of_left_isometry
+    V₁ V₂ hV₁ ρc
+  rw [hreconstruct] at hpartial
+  change Matrix.partialTraceLeft ρc = V₂ᴴ * Matrix.partialTraceLeft ρ * V₂
+  symm
+  calc
+    V₂ᴴ * Matrix.partialTraceLeft ρ * V₂ =
+        V₂ᴴ * (V₂ * Matrix.partialTraceLeft ρc * V₂ᴴ) * V₂ := by
+      rw [hpartial]
+    _ = Matrix.partialTraceLeft ρc := by
+      simp only [Matrix.mul_assoc, ← Matrix.mul_assoc V₂ᴴ V₂, hV₂,
+        Matrix.one_mul, Matrix.mul_one]
+
 end SimultaneousMarginalSupport
+
+section FiniteMarginalSupport
+
+variable {dL dR kL kR : ℕ}
+
+/-- Simultaneous compression to both marginal supports makes both compressed
+marginals positive definite, including when a support has dimension zero. -/
+theorem PosSemidef.marginalSupport_compression_marginals_posDef
+    {ρ : Matrix (Fin dL × Fin dR) (Fin dL × Fin dR) ℂ} (hρ : ρ.PosSemidef)
+    (V₁ : Matrix (Fin dL) (Fin kL) ℂ) (V₂ : Matrix (Fin dR) (Fin kR) ℂ)
+    (hV₁ : V₁ᴴ * V₁ = 1) (hV₂ : V₂ᴴ * V₂ = 1)
+    (hRange₁ : V₁ * V₁ᴴ = hρ.partialTraceRight.isHermitian.supportProj)
+    (hRange₂ : V₂ * V₂ᴴ = hρ.partialTraceLeft.isHermitian.supportProj) :
+    (Matrix.partialTraceRight ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂))).PosDef ∧
+      (Matrix.partialTraceLeft ((V₁ ⊗ₖ V₂)ᴴ * ρ * (V₁ ⊗ₖ V₂))).PosDef := by
+  let hρ₁ : (Matrix.partialTraceRight ρ).PosSemidef := hρ.partialTraceRight
+  let hρ₂ : (Matrix.partialTraceLeft ρ).PosSemidef := hρ.partialTraceLeft
+  change V₁ * V₁ᴴ = hρ₁.supportProj at hRange₁
+  change V₂ * V₂ᴴ = hρ₂.supportProj at hRange₂
+  constructor
+  · rw [hρ.partialTraceRight_marginalSupport_compression
+      V₁ V₂ hV₁ hV₂ hRange₁ hRange₂]
+    simpa only [Matrix.conjTranspose_conjTranspose] using
+      hρ₁.compression_on_support_posDef
+        (V := V₁ᴴ) (by simpa only [Matrix.conjTranspose_conjTranspose] using hV₁)
+          (by simpa only [Matrix.conjTranspose_conjTranspose] using hRange₁)
+  · rw [hρ.partialTraceLeft_marginalSupport_compression
+      V₁ V₂ hV₁ hV₂ hRange₁ hRange₂]
+    simpa only [Matrix.conjTranspose_conjTranspose] using
+      hρ₂.compression_on_support_posDef
+        (V := V₂ᴴ) (by simpa only [Matrix.conjTranspose_conjTranspose] using hV₂)
+          (by simpa only [Matrix.conjTranspose_conjTranspose] using hRange₂)
+
+end FiniteMarginalSupport
 
 end Matrix

--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -42,6 +42,11 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
   product
 * `Matrix.partialTraceLeft_kronecker`: the left partial trace of a Kronecker
   product
+* `Matrix.partialTraceRight_kronecker_conj_of_right_isometry`: covariance of
+  the right partial trace under conjugation by a product matrix whose right
+  factor is an isometry
+* `Matrix.partialTraceLeft_kronecker_conj_of_left_isometry`: the analogous
+  covariance identity for the left partial trace
 * `Matrix.PosDef.partialTraceRight`: the right partial trace of a positive
   definite matrix is positive definite when the traced factor is nonempty
 * `Matrix.PosDef.partialTraceLeft`: the analogous statement for the left
@@ -144,6 +149,58 @@ theorem partialTraceRight_kronecker (A : Matrix α α ℂ) (B : Matrix β β ℂ
   simp only [partialTraceRight_apply, kroneckerMap_apply, Matrix.smul_apply, Matrix.trace,
     Matrix.diag, smul_eq_mul, ← Finset.mul_sum]
   ring
+
+/-- Tracing the right factor after conjugation by a product matrix removes an
+isometry on the traced factor and retains conjugation on the other factor. -/
+theorem partialTraceRight_kronecker_conj_of_right_isometry
+    {α β γ δ : Type*} [Fintype α] [Fintype β] [DecidableEq β]
+    [Fintype δ]
+    (A : Matrix γ α ℂ) (B : Matrix δ β ℂ) (hB : Bᴴ * B = 1)
+    (X : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight ((A ⊗ₖ B) * X * (A ⊗ₖ B)ᴴ) =
+      A * partialTraceRight X * Aᴴ := by
+  classical
+  ext i j
+  have horth (x y : β) :
+      (∑ k : δ, B k x * star (B k y)) = if x = y then 1 else 0 := by
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply, mul_comm, eq_comm] using
+      congrFun (congrFun hB y) x
+  simp only [partialTraceRight_apply, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, kroneckerMap_apply, Fintype.sum_prod_type, star_mul]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [show ∀ (q : α) (b : β) (p : α) (a : β),
+      (∑ k : δ,
+        A i p * B k a * X (p, a) (q, b) *
+          (star (B k b) * star (A j q))) =
+        A i p * X (p, a) (q, b) *
+          (∑ k : δ, B k a * star (B k b)) * star (A j q) by
+    intro q b p a
+    calc
+      _ = ∑ k : δ,
+          (A i p * X (p, a) (q, b) * star (A j q)) *
+            (B k a * star (B k b)) := by
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      _ = (A i p * X (p, a) (q, b) * star (A j q)) *
+          ∑ k : δ, B k a * star (B k b) := by
+        rw [Finset.mul_sum]
+      _ = _ := by ring]
+  simp_rw [horth]
+  simp only [mul_ite, mul_one, mul_zero, RCLike.star_def, ite_mul,
+    zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
+  apply Finset.sum_congr rfl
+  intro q _
+  exact Finset.sum_comm
 
 /-- Reindex the right tensor factor as `β' × γ`, keeping the left factor fixed. -/
 def rightSplitEquiv {α β β' γ : Type*} (e : β ≃ β' × γ) :
@@ -262,6 +319,57 @@ theorem partialTraceLeft_kronecker (A : Matrix α α ℂ) (B : Matrix β β ℂ)
     Matrix.trace, Matrix.diag]
   rw [← Finset.sum_mul]
   rfl
+
+/-- Tracing the left factor after conjugation by a product matrix removes an
+isometry on the traced factor and retains conjugation on the other factor. -/
+theorem partialTraceLeft_kronecker_conj_of_left_isometry
+    {α β γ δ : Type*} [Fintype α] [DecidableEq α] [Fintype β]
+    [Fintype γ]
+    (A : Matrix γ α ℂ) (B : Matrix δ β ℂ) (hA : Aᴴ * A = 1)
+    (X : Matrix (α × β) (α × β) ℂ) :
+    partialTraceLeft ((A ⊗ₖ B) * X * (A ⊗ₖ B)ᴴ) =
+      B * partialTraceLeft X * Bᴴ := by
+  classical
+  ext i j
+  have horth (x y : α) :
+      (∑ k : γ, A k x * star (A k y)) = if x = y then 1 else 0 := by
+    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Matrix.one_apply, mul_comm, eq_comm] using
+      congrFun (congrFun hA y) x
+  simp only [partialTraceLeft_apply, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, kroneckerMap_apply, Fintype.sum_prod_type, star_mul]
+  simp_rw [Finset.mul_sum, Finset.sum_mul]
+  rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset α))]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset γ))
+    (t := (Finset.univ : Finset β))]
+  simp_rw [show ∀ (a : β) (p : α) (b : β) (q : α),
+      (∑ k : γ,
+        A k p * B i a * X (p, a) (q, b) *
+          (star (B j b) * star (A k q))) =
+        B i a * X (p, a) (q, b) *
+          (∑ k : γ, A k p * star (A k q)) * star (B j b) by
+    intro a p b q
+    calc
+      _ = ∑ k : γ,
+          (B i a * X (p, a) (q, b) * star (B j b)) *
+            (A k p * star (A k q)) := by
+        apply Finset.sum_congr rfl
+        intro k _
+        ring
+      _ = (B i a * X (p, a) (q, b) * star (B j b)) *
+          ∑ k : γ, A k p * star (A k q) := by
+        rw [Finset.mul_sum]
+      _ = _ := by ring]
+  simp_rw [horth]
+  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset α))
+    (t := (Finset.univ : Finset β))]
+  simp only [mul_ite, mul_one, mul_zero, RCLike.star_def, ite_mul,
+    zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
 
 /-- The left partial trace is adjoint to tensoring with the identity under the
 bilinear trace pairing:

--- a/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
+++ b/TNLean/MPS/MPDO/PhysicalSupportSALTransport.lean
@@ -43,49 +43,7 @@ theorem partialTraceRight_singleKraus_kronecker_isometry
     partialTraceRight
         (singleKrausMap (kroneckerMap (· * ·) A B) X) =
       singleKrausMap A (partialTraceRight X) := by
-  classical
-  ext i j
-  have horth (x y : β) :
-      (∑ k : δ, B k x * star (B k y)) = if x = y then 1 else 0 := by
-    simpa only [Matrix.mul_apply, Matrix.conjTranspose_apply,
-      Matrix.one_apply, mul_comm, eq_comm] using
-      congrFun (congrFun hB y) x
-  simp only [partialTraceRight_apply, singleKrausMap_apply,
-    Matrix.mul_apply, Matrix.conjTranspose_apply, kroneckerMap_apply,
-    Fintype.sum_prod_type, star_mul]
-  simp_rw [Finset.mul_sum, Finset.sum_mul]
-  rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset α))]
-  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset β))]
-  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset α))]
-  simp_rw [Finset.sum_comm (s := (Finset.univ : Finset δ))
-    (t := (Finset.univ : Finset β))]
-  simp_rw [show ∀ (q : α) (b : β) (p : α) (a : β),
-      (∑ k : δ,
-        A i p * B k a * X (p, a) (q, b) *
-          (star (B k b) * star (A j q))) =
-        A i p * X (p, a) (q, b) *
-          (∑ k : δ, B k a * star (B k b)) * star (A j q) by
-    intro q b p a
-    calc
-      _ = ∑ k : δ,
-          (A i p * X (p, a) (q, b) * star (A j q)) *
-            (B k a * star (B k b)) := by
-        apply Finset.sum_congr rfl
-        intro k _
-        ring
-      _ = (A i p * X (p, a) (q, b) * star (A j q)) *
-          ∑ k : δ, B k a * star (B k b) := by
-        rw [Finset.mul_sum]
-      _ = _ := by ring]
-  simp_rw [horth]
-  simp only [mul_ite, mul_one, mul_zero, RCLike.star_def, ite_mul,
-    zero_mul, Finset.sum_ite_eq', Finset.mem_univ, ↓reduceIte]
-  apply Finset.sum_congr rfl
-  intro q _
-  exact Finset.sum_comm
+  exact partialTraceRight_kronecker_conj_of_right_isometry A B hB X
 
 end Matrix
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -471,6 +471,69 @@
     Substitution of the reconstruction identity proves the rank equality.
 \end{proof}
 
+\begin{lemma}[Partial traces under product isometries]
+    \label{lem:partial_trace_product_isometry}
+    \lean{Matrix.partialTraceRight_kronecker_conj_of_right_isometry,
+      Matrix.partialTraceLeft_kronecker_conj_of_left_isometry}
+    \leanok
+    \uses{def:partial_trace, def:partial_trace_left}
+    Let $A:H_A\to K_A$ and $B:H_B\to K_B$ be linear maps between
+    finite-dimensional complex spaces, and let $X$ be an operator on
+    $H_A\otimes H_B$. If $B^\dagger B=1$, then
+    \begin{align}
+      \tr_{K_B}\!\left((A\otimes B)X(A\otimes B)^\dagger\right)
+      &=A(\tr_{H_B}X)A^\dagger.
+      \notag
+    \end{align}
+    If $A^\dagger A=1$, then, symmetrically,
+    \begin{align}
+      \tr_{K_A}\!\left((A\otimes B)X(A\otimes B)^\dagger\right)
+      &=B(\tr_{H_A}X)B^\dagger.
+      \notag
+    \end{align}
+    The identities include zero-dimensional spaces.
+\end{lemma}
+\begin{proof}\leanok
+    Expand the matrix entries in orthonormal bases. In the first identity, the
+    sum over the traced output basis gives the matrix entries of
+    $B^\dagger B=1$, and hence collapses the two input indices on $H_B$.
+    The second identity follows by the same argument with the factors
+    interchanged.
+\end{proof}
+
+\begin{theorem}[Faithful marginals after simultaneous support compression]
+    \label{thm:faithful_marginals_support_compression}
+    \lean{Matrix.PosSemidef.partialTraceRight_marginalSupport_compression,
+      Matrix.PosSemidef.partialTraceLeft_marginalSupport_compression,
+      Matrix.PosSemidef.marginalSupport_compression_marginals_posDef}
+    \leanok
+    \uses{thm:operator_schmidt_rank_marginal_support_compression}
+    In the setting of
+    Theorem~\ref{thm:operator_schmidt_rank_marginal_support_compression}, the
+    two marginals of $\rho_c$ satisfy
+    \begin{align}
+      \tr_{\widehat H_B}\rho_c
+      &=V_A^\dagger(\tr_{H_B}\rho)V_A,
+      &
+      \tr_{\widehat H_A}\rho_c
+      &=V_B^\dagger(\tr_{H_A}\rho)V_B.
+      \notag
+    \end{align}
+    Both compressed marginals are positive definite, including when one of
+    their spaces has dimension zero.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:partial_trace_product_isometry,
+      thm:compression_on_support_posDef,
+      thm:operator_schmidt_rank_marginal_support_compression}
+    Insert the reconstruction $\rho=W\rho_cW^\dagger$ into the two covariance
+    identities of Lemma~\ref{lem:partial_trace_product_isometry}, and multiply
+    by the corresponding adjoint isometries. Each displayed marginal is the
+    compression of a positive semidefinite matrix to its support, so its
+    positive definiteness follows from
+    Theorem~\ref{thm:compression_on_support_posDef}.
+\end{proof}
+
 \begin{theorem}[Channel of a faithful bipartite marginal]
     \label{thm:supported_marginal_channel}
     \lean{Matrix.finrank_range_supportedMarginalMap,
@@ -515,9 +578,10 @@
 
 \section{Support compression for entropy functionals}
 
-% Issues #5229 and #5241 establish one- and two-marginal support compression,
-% including preservation of operator-Schmidt rank.  Faithfulness of the two
-% compressed marginals is tracked in #5245 as a remaining step for #5211.
+% Issues #5229, #5241, and #5245 establish one- and two-marginal support
+% compression, including preservation of operator-Schmidt rank and
+% faithfulness of both compressed marginals.  The remaining analytic and
+% integration steps are tracked in #5211.
 
 \begin{definition}[Isometric conjugation into a larger matrix algebra]
     \label{def:isometric_nonunital_conjugation}
@@ -1108,6 +1172,7 @@ logarithmic divergence, or a comparison with relative entropy.
 \begin{proof}
     \uses{thm:relative_entropy_q2_faithful_reduction,
       thm:operator_schmidt_rank_marginal_support_compression,
+      thm:faithful_marginals_support_compression,
       thm:full_support_eigenbasis_whitened_choi_bound}
     Set $\omega=\rho_A\otimes\rho_B$. Positivity gives
     $\ker\omega\subseteq\ker\rho_{AB}$, so
@@ -1118,8 +1183,9 @@ logarithmic divergence, or a comparison with relative entropy.
     supports of $\rho_A$ and $\rho_B$.
     Theorem~\ref{thm:operator_schmidt_rank_marginal_support_compression}
     shows that this simultaneous local compression reconstructs the original
-    operator and preserves operator-Schmidt rank. It remains to verify that
-    the two compressed marginals are faithful.
+    operator and preserves operator-Schmidt rank. By
+    Theorem~\ref{thm:faithful_marginals_support_compression}, its two marginals
+    are faithful.
 
     In the resulting faithful spaces, write $\sigma=\rho_A$ and
     $\tau=\rho_B$. Choose an eigenbasis of $\sigma$, and set

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -294,9 +294,11 @@ The one-sided output-support compression is also formalized: faithfulness of
 the input weight forces every channel output into the support of its image,
 the compressed channel is trace preserving, and the support-restricted
 negative quarter power agrees with the ordinary negative quarter power after
-compression.  The eigenbasis whitening statements still assume both marginal
-weights are positive definite and therefore do not supply the two-local
-compression from singular ambient marginals to both support algebras.
+compression.  Simultaneous compression from singular ambient marginals to
+both support algebras is formalized below.  The eigenbasis whitening statements
+still assume both marginal weights are positive definite, so their application
+to the compressed operator remains part of the argument tracked in
+\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.
 
 The unnormalized sandwiched R\'enyi trace term
 \[
@@ -331,15 +333,16 @@ divergence, nor a comparison with Umegaki relative entropy.
 
 Neither development completes
 \href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  Simultaneous
-compression by the two marginal support isometries, exact reconstruction, and
-preservation of operator-Schmidt rank are now formalized.
+compression by the two marginal support isometries, exact reconstruction,
+preservation of operator-Schmidt rank, the exact formulas for the compressed
+marginals, and their positive definiteness are now formalized.
 \footnote{Formal declarations:
-\leanid{Matrix.PosSemidef.eq_marginalSupport_expansion_compression} and
-\leanid{Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression} in
+\leanid{Matrix.PosSemidef.eq_marginalSupport_expansion_compression},
+\leanid{Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression},
+\leanid{Matrix.PosSemidef.partialTraceRight_marginalSupport_compression},
+\leanid{Matrix.PosSemidef.partialTraceLeft_marginalSupport_compression}, and
+\leanid{Matrix.PosSemidef.marginalSupport_compression_marginals_posDef} in
 \doclink{TNLean/Channel/MarginalSupportAbsorption}.}
-The remaining support step is to prove that the two compressed marginals are
-positive definite; this is tracked in
-\href{https://github.com/LionSR/TNLean/issues/5245}{\#5245}.
 The faithful comparison itself remains open in
 \href{https://github.com/LionSR/TNLean/issues/5209}{\#5209}.  The support-aware
 Jensen inequality above does not by itself establish the relative-modular


### PR DESCRIPTION
Closes #5245.

## Mathematical content

- proves covariance of both partial traces under conjugation by product isometries;
- identifies both marginals after simultaneous compression to their supports;
- proves that both compressed marginals are positive definite, including zero-dimensional support spaces;
- reuses the general covariance result in the existing MPDO lemma; and
- synchronizes Chapter 21 and the CPSV17 paper-gap note while leaving the analytic and integration work in #5211 open.

## Verification

- `lake exe cache get` before compilation
- focused build of the three affected Lean modules (9,093 jobs)
- full `lake build TNLean` (9,864 jobs)
- zero-dimensional specialization
- five `#print axioms` audits (standard axioms only)
- `lake exe checkdecls`
- `leanblueprint checkdecls` and `leanblueprint web`
- proof-integrity, prose, tactic-pattern, formatting, and whitespace checks
- independent mathematical and faithfulness review of exact head `1c10afbe09384c4bd258123605830517d12690d2`

The remaining relative-entropy comparison and its application to the mutual-information bound continue to be tracked in #5211.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New matrix identities and PosDef marginal theorems sit on the critical path for the mutual-information / relative-entropy formalization (#5211); errors would affect downstream channel and MPDO arguments, but changes are localized proofs with existing consumers refactored to reuse them.
> 
> **Overview**
> Adds **general partial-trace covariance** under conjugation by `A ⊗ₖ B` when the isometry sits on the traced factor (`partialTraceRight_kronecker_conj_of_right_isometry` / `partialTraceLeft_kronecker_conj_of_left_isometry` in `PartialTrace.lean`), and reuses the right-factor case in `PhysicalSupportSALTransport.lean` instead of duplicating the Finset proof.
> 
> On top of simultaneous marginal-support compression, proves that **both partial traces** of the compressed state are the expected support compressions of the original marginals, and that those compressed marginals are **positive definite** (including zero-dimensional supports), via `SupportCompression` and a new `SupportCompression` import in `MarginalSupportAbsorption.lean`.
> 
> **Blueprint / docs:** Chapter 21 gains Lemma `partial_trace_product_isometry` and Theorem `faithful_marginals_support_compression`; the mutual-information proof sketch now cites faithful marginals instead of leaving that step open. The CPSV17 paper-gap note records closure of issue #5245 and still tracks the full #5211 pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 904d69d58bb9b2ce94b51114c8340ee5f0615335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->