### PR TITLE
fix(tenkz): keep port-open sentinel private

### DIFF
--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -298,6 +298,12 @@ grep -Fq 'kernel-boundary|signature=open:22.479434, phys:53.130102' \
   echo "FAIL: plane unmatched ports lost their transported boundary bearings" >&2
   exit 1
 }
+python3 "$REPO/scripts/tenkz_audit.py" \
+  "$WORK/r_unmatched_port_legs.tnlog" \
+  "$KERNEL/regression/r_unmatched_port_legs.tex" >/dev/null || {
+  echo "FAIL: unmatched typed ports leaked a private open-end sentinel" >&2
+  exit 1
+}
 [ "$(grep -c 'check|relation=1|result=equal' \
       "$WORK/r_physical_port_signature_equiv.tnlog" || true)" -eq 5 ] || {
   echo "FAIL: physical policy sugar diverged from explicit typed ports" >&2

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -3665,8 +3665,7 @@
                               \tl_use:N \l__tenkz_kernel_port_slot_tl ,
                             port-type =
                               \tl_use:N \l__tenkz_kernel_port_type_tl ,
-                            from = \tl_use:N \l__tenkz_kernel_port_node_tl ,
-                            to-open = port
+                            from = \tl_use:N \l__tenkz_kernel_port_node_tl
                             \tl_if_blank:VF \l__tenkz_kernel_port_label_tl
                               {
                                 , port-label =


### PR DESCRIPTION
Advances LionSR/tenkz#113 after LionSR/TNLean#5247.

Generated unmatched typed ports already carry their public topology through origin=port-open, host, port-face, port-slot, and port-type. This removes the redundant private to-open=port sentinel from their model records instead of widening the public open-end event vocabulary to accept it.

The existing 15-picture unmatched-port fixture now runs through the public event audit, covering cardinal and diagonal faces, flat and plane carriers, physical and virtual types, labels, consumed ports, and boundary signatures.

Validation:
- focused unmatched-port compile and audit: 0 hard errors, 0 advisories
- pending GHZ state: 81 atoms and 99 wires, compiles in 59 seconds, audit clean
- 82 kernel regressions; 8 sugar equivalences; 12 kernel streams; pixels byte-identical
- 264 corpus event streams byte-identical
- shrink census stable; source lint clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small kernel record-shape change with targeted regression and audit coverage; no auth, security, or data-path impact.
> 
> **Overview**
> **Generated unmatched typed ports** no longer carry the private **`to-open=port`** sentinel on their model wire records. Public topology stays on **`origin=port-open`** plus host, face, slot, and type fields, so the kernel does not widen the open-end event vocabulary to accept that redundant marker.
> 
> The kernel probe for **`r_unmatched_port_legs`** now runs **`tenkz_audit.py`** on that fixture’s `.tnlog`, so a regression that leaks the private sentinel fails CI with a clear message instead of relying only on grep counts and boundary signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10b0a68151370b5481d39b46b68f265414964674. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->