### PR TITLE
fix(tenkz): compress index touch topology

### DIFF
--- a/tests/tenkz/kernel/k_skin_pairings.tex
+++ b/tests/tenkz/kernel/k_skin_pairings.tex
@@ -7,6 +7,25 @@
 \makeatletter
 \ExplSyntaxOn
 \file_input:n { tenkz-kernel.code.tex }
+\cs_new_eq:NN
+  \__tenkz_test_skin_pairing_resolve:
+  \__tenkz_string_resolve:
+\cs_set_protected:Npn \__tenkz_string_resolve:
+  {
+    \seq_if_empty:NF \l__tenkz_kernel_r_skin_routes_seq
+      {
+        \seq_map_inline:Nn \l__tenkz_kernel_r_skin_routes_seq
+          {
+            \__tenkz_model_get:nnN {##1} {name}
+              \l__tenkz_kernel_scratch_tl
+            \prop_if_in:NVF
+              \l__tenkz_string_touch_all_exempt_prop
+              \l__tenkz_kernel_scratch_tl
+              {\errmessage{skin~pairing~lost~its~touch-all~exemption}}
+          }
+      }
+    \__tenkz_test_skin_pairing_resolve:
+  }
 \ExplSyntaxOff
 \makeatother
 \begin{document}

--- a/tests/tenkz/kernel/regression/r_index_pair_scaling.tex
+++ b/tests/tenkz/kernel/regression/r_index_pair_scaling.tex
@@ -1,18 +1,18 @@
-% Regression: topology inference and crossing police traverse 100 index routes
-% by unordered pair, with one indexed touch fact per pair.
+% Regression: topology inference stores one class fact per index route rather
+% than expanding the class default over every unordered route pair.
 \documentclass{standalone}
 \usepackage{tenkz}
 \makeatletter
 \ExplSyntaxOn
 \file_input:n { tenkz-kernel.code.tex }
-\int_new:N \g__tenkz_test_index_pair_int
+\int_new:N \g__tenkz_test_index_pairing_int
 \cs_new_eq:NN
-  \__tenkz_test_index_join_pair:nn
-  \__tenkz_kernel_r_index_join_pair:nn
-\cs_set_protected:Npn \__tenkz_kernel_r_index_join_pair:nn #1#2
+  \__tenkz_test_index_join_oriented:nn
+  \__tenkz_kernel_r_index_join_oriented:nn
+\cs_set_protected:Npn \__tenkz_kernel_r_index_join_oriented:nn #1#2
   {
-    \int_gincr:N \g__tenkz_test_index_pair_int
-    \__tenkz_test_index_join_pair:nn {#1} {#2}
+    \int_gincr:N \g__tenkz_test_index_pairing_int
+    \__tenkz_test_index_join_oriented:nn {#1} {#2}
   }
 \cs_new_eq:NN
   \__tenkz_test_index_resolve:
@@ -20,19 +20,21 @@
 \cs_set_protected:Npn \__tenkz_string_resolve:
   {
     \int_compare:nNnF
-      { \prop_count:N \l__tenkz_string_touch_prop } = {4950}
-      {\errmessage{touch~facts~were~not~indexed~once~per~unordered~pair}}
+      { \prop_count:N \l__tenkz_string_touch_all_prop } = {130}
+      {\errmessage{index~route~class~facts~were~not~stored~once~per~route}}
+    \prop_if_empty:NF \l__tenkz_string_touch_prop
+      {\errmessage{index~route~class~expanded~to~pair~touch~facts}}
     \__tenkz_test_index_resolve:
   }
 \cs_new_protected:Npn \__tenkz_test_many_index_wires:
   {
-    \int_step_inline:nn {100}
+    \int_step_inline:nn {130}
       { \tnwire[name=scale-##1]{w~outside}{e~outside} }
   }
 \AtEndDocument
   {
-    \int_compare:nNnF { \g__tenkz_test_index_pair_int } = {4950}
-      {\errmessage{index~routes~were~not~visited~once~per~unordered~pair}}
+    \int_compare:nNnF { \g__tenkz_test_index_pairing_int } = {0}
+      {\errmessage{ordinary~index~routes~entered~the~pairing~candidate~pass}}
   }
 \ExplSyntaxOff
 \makeatother

--- a/tests/tenkz/kernel/regression/r_port_open_shared_host.tex
+++ b/tests/tenkz/kernel/regression/r_port_open_shared_host.tex
@@ -16,13 +16,25 @@
       {
         {1}
           {
+            \prop_if_empty:NF \l__tenkz_string_touch_all_prop
+              {\errmessage{port-open~route~entered~the~touch-all~class}}
             \prop_if_empty:NT \l__tenkz_string_touch_prop
               {\errmessage{shared-host~port~touch~was~lost}}
           }
         {2}
           {
+            \prop_if_empty:NF \l__tenkz_string_touch_all_prop
+              {\errmessage{port-open~route~entered~the~touch-all~class}}
             \prop_if_empty:NT \l__tenkz_string_disjoint_prop
               {\errmessage{disjoint~port~boxes~were~lost}}
+          }
+        {3}
+          {
+            \int_compare:nNnF
+              { \prop_count:N \l__tenkz_string_touch_all_prop } = {1}
+              {\errmessage{ordinary~index~route~lost~its~topology~class}}
+            \prop_if_empty:NF \l__tenkz_string_touch_all_exempt_prop
+              {\errmessage{port-open~route~became~a~class~exemption}}
           }
       }
       {\errmessage{unexpected~port-topology~resolution}}
@@ -31,7 +43,7 @@
 \AtEndDocument
   {
     \int_compare:nNnF
-      { \g__tenkz_test_port_topology_resolve_int } = {2}
+      { \g__tenkz_test_port_topology_resolve_int } = {3}
       {\errmessage{port-topology~resolution~count~changed}}
   }
 \ExplSyntaxOff
@@ -44,5 +56,10 @@
 \begin{tenkz}[rows={wire}, cols=2, bonds=none]
   \tn[ports={180:virtual}]{} &
   \tn[ports={0:physical}]{}
+\end{tenkz}
+\begin{tenkz}[rows={wire}, cols=2, bonds=none]
+  \tn[at=(1,1), name=A, ports={0:virtual,45:physical}]{A}
+  \tn[at=(1,2), name=B, ports={180:virtual}]{B}
+  \tnwire{A.0}{B.180}
 \end{tenkz}
 \end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -9923,27 +9923,26 @@
 
 \cs_new_protected:Npn \__tenkz_kernel_r_index_joins:
   {
-    \prop_if_empty:NF \l__tenkz_kernel_r_index_sid_prop
+    \prop_map_inline:Nn \l__tenkz_kernel_r_index_sid_prop
       {
-        \__tenkz_string_map_unordered_pairs:N
-          \__tenkz_kernel_r_index_join_pair:nn
-      }
-  }
-
-\cs_new_protected:Npn \__tenkz_kernel_r_index_join_pair:nn #1#2
-  {
-    \prop_get:NnN \l__tenkz_kernel_r_index_sid_prop {#1}
-      \l__tenkz_kernel_r_wire_record_tl
-    \quark_if_no_value:NTF \l__tenkz_kernel_r_wire_record_tl
-      {
-        \prop_get:NnN \l__tenkz_kernel_r_index_sid_prop {#2}
-          \l__tenkz_kernel_r_wire_record_tl
-        \quark_if_no_value:NF \l__tenkz_kernel_r_wire_record_tl
+        \tl_set:Nn \l__tenkz_kernel_r_wire_record_tl {##2}
+        \__tenkz_model_get:nnN {##2} {origin}
+          \l__tenkz_kernel_scratch_tl
+        \str_if_eq:VnF \l__tenkz_kernel_scratch_tl {port-open}
+          { \__tenkz_string_touch_all:n {##1} }
+        % Deferred physical legs have saved paths but no model-wire owner.
+        % Preserve their explicit topology relation with every index route;
+        % unlike the common index class, they still cross-check user strings.
+        \prop_map_inline:Nn \l__tenkz_kernel_r_legdrawn_prop
+          { \__tenkz_string_touch:nn {##1} {####1} }
+        \seq_map_inline:Nn \l__tenkz_kernel_r_skin_routes_seq
           {
-            \__tenkz_kernel_r_index_join_oriented:nn {#2} {#1}
+            \__tenkz_model_get:nnN {####1} {name}
+              \l__tenkz_kernel_r_b_tl
+            \exp_args:NnV \__tenkz_kernel_r_index_join_oriented:nn
+              {##1} \l__tenkz_kernel_r_b_tl
           }
       }
-      { \__tenkz_kernel_r_index_join_oriented:nn {#1} {#2} }
   }
 
 \cs_new_protected:Npn \__tenkz_kernel_r_index_join_oriented:nn #1#2
@@ -10642,6 +10641,8 @@
     \exp_args:NVV \__tenkz_string_save_route:nn
       \l__tenkz_kernel_r_skin_wire_name_tl
       \l__tenkz_kernel_scratch_tl
+    \exp_args:NV \__tenkz_string_touch_all_exempt:n
+      \l__tenkz_kernel_r_skin_wire_name_tl
     \prop_put:NVn \l__tenkz_kernel_r_sid_record_prop
       \l__tenkz_kernel_r_skin_wire_name_tl {#1}
     \__tenkz_kernel_r_skin_wire_order:n {#1}

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -76,6 +76,8 @@
 \prop_new:N \l__tenkz_string_cross_prop      % unordered pair -> declarations
 \prop_new:N \l__tenkz_string_join_prop       % unordered pair -> endpoint joins
 \prop_new:N \l__tenkz_string_touch_prop      % shared semantic wire ports
+\prop_new:N \l__tenkz_string_touch_all_prop  % topology-owned overlap route
+\prop_new:N \l__tenkz_string_touch_all_exempt_prop % route still checked
 \prop_new:N \l__tenkz_string_disjoint_prop   % model-proven disjoint pairs
 \seq_new:N \l__tenkz_string_gap_ids_seq      % under paths awaiting one gap pass
 \seq_new:N \l__tenkz_string_self_gap_ids_seq % self paths awaiting branch gap
@@ -152,6 +154,8 @@
     \prop_clear:N \l__tenkz_string_cross_prop
     \prop_clear:N \l__tenkz_string_join_prop
     \prop_clear:N \l__tenkz_string_touch_prop
+    \prop_clear:N \l__tenkz_string_touch_all_prop
+    \prop_clear:N \l__tenkz_string_touch_all_exempt_prop
     \prop_clear:N \l__tenkz_string_disjoint_prop
     \seq_clear:N \l__tenkz_string_gap_ids_seq
     \seq_clear:N \l__tenkz_string_self_gap_ids_seq
@@ -522,6 +526,16 @@
 % overlap near the glyph border.  That attachment is topology, not a crossing.
 \cs_new_protected:Npn \__tenkz_string_touch:nn #1#2
   { \__tenkz_string_pair_put:Nnn \l__tenkz_string_touch_prop {#1} {#2} }
+
+% A renderer-owned route may treat otherwise-unqualified overlaps as topology.
+% Store that route-class fact once instead of expanding it to every route pair.
+\cs_new_protected:Npn \__tenkz_string_touch_all:n #1
+  { \prop_put:Nnn \l__tenkz_string_touch_all_prop {#1} { } }
+
+% Collision-sensitive routes, notably skin pairings, retain geometric checks
+% even beside a renderer-owned touch-all route.
+\cs_new_protected:Npn \__tenkz_string_touch_all_exempt:n #1
+  { \prop_put:Nnn \l__tenkz_string_touch_all_exempt_prop {#1} { } }
 
 % Record a pair whose owning model proves cannot meet.  The crossing police
 % can answer zero without asking the drawing engine to rediscover topology
@@ -1215,6 +1229,19 @@
         \prop_if_in:NeT \l__tenkz_string_touch_prop
           { \__tenkz_string_pair_key:nn {#1} {#2} }
           { \bool_set_true:N \l_tmpa_bool }
+        \bool_if:NF \l_tmpa_bool
+          {
+            \prop_if_in:NnF \l__tenkz_string_touch_all_exempt_prop {#1}
+              {
+                \prop_if_in:NnF \l__tenkz_string_touch_all_exempt_prop {#2}
+                  {
+                    \prop_if_in:NnT \l__tenkz_string_touch_all_prop {#1}
+                      { \bool_set_true:N \l_tmpa_bool }
+                    \prop_if_in:NnT \l__tenkz_string_touch_all_prop {#2}
+                      { \bool_set_true:N \l_tmpa_bool }
+                  }
+              }
+          }
         \bool_if:NF \l_tmpa_bool
           { \__tenkz_string_police_pair_cross:nn {#1} {#2} }
       }


### PR DESCRIPTION
## Summary

- store the ordinary-index overlap rule once per route instead of once per unordered pair
- retain explicit candidate checks for skin pairings and referenced physical-leg paths
- keep port-open routes outside the broad class while making ordinary-index/port-open topology order-independent
- replace the 4,950-pair scaling assertion with a 130-route linear-storage regression

## Motivation

The source-faithful 6-by-8 GHZ patch has 130 routes. Expanding the ordinary-index topology rule to every unordered pair made its compile exceed the 120-second RMP gate. Disabling only that expansion reached crossing validation in 21.1 seconds, while disabling self-intersection checks still timed out.

With this change, the complete 6-by-8 fixture compiles in 50.9 seconds. The fixture itself retains shared lattice metrics and contains no raw length literals.

## Validation

- `scripts/tenkz_kernel_probes.sh`
  - 82 review regressions
  - 8 sugar equivalences
  - 12 record streams
  - pinned kernel pixels
- `scripts/tenkz_string_probes.sh`
  - 30 event and pixel artifacts byte-identical
- `TENKZ_CORPUS_JOBS=4 scripts/tenkz_corpus.sh`
  - 264 standalone fixtures compiled and audited
- `TENKZ_CORPUS_JOBS=4 scripts/tenkz_golden.sh --check`
  - 264 event streams byte-identical
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`

Part of LionSR/tenkz#113.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the string engine decides topology vs crossings for many routes at once; behavior is guarded by new regressions and explicit exemptions for skin pairings and port-open routes.
> 
> **Overview**
> **Replaces quadratic index-route topology with per-route “touch-all” class facts**, cutting compile cost on large route counts (e.g. 130 routes) while keeping crossing validation semantics for routes that still need pairwise checks.
> 
> The kernel no longer walks every unordered index-route pair to register `touch` facts. Each non–`port-open` index route gets a single `__tenkz_string_touch_all:n` entry; deferred physical legs still get explicit `touch` pairs, and skin routes still go through `__tenkz_kernel_r_index_join_oriented`. Skin pairing wires are marked **`touch_all_exempt`** so they are not treated as blanket topology when an ordinary index route is touch-all.
> 
> The string engine adds `l__tenkz_string_touch_all_prop` and `l__tenkz_string_touch_all_exempt_prop`; crossing police skips geometric cross checks when either side is touch-all unless the other side is exempt. Regressions now assert **130 class facts and empty pair `touch`**, zero oriented pairing passes for bulk index wires, and correct port-open vs ordinary-index behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316a356daa1b50a975c3e62cad4b1f22009a3f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->