### PR TITLE
test(tenkz): pin nested skin join roles

### DIFF
--- a/tests/tenkz/kernel/k_skin_pairings.tex
+++ b/tests/tenkz/kernel/k_skin_pairings.tex
@@ -10,6 +10,18 @@
 \cs_new_eq:NN
   \__tenkz_test_skin_pairing_resolve:
   \__tenkz_string_resolve:
+% Pin the outer index SID and inner skin model-key roles in the nested maps.
+\cs_new_eq:NN
+  \__tenkz_test_skin_pairing_index_join_oriented:nn
+  \__tenkz_kernel_r_index_join_oriented:nn
+\cs_set_protected:Npn \__tenkz_kernel_r_index_join_oriented:nn #1#2
+  {
+    \prop_if_in:NeF \l__tenkz_kernel_r_index_sid_prop {#1}
+      {\errmessage{skin~pairing~join~lost~index~route~#1}}
+    \prop_if_in:NeF \l__tenkz_kernel_r_sid_record_prop {#2}
+      {\errmessage{skin~pairing~join~lost~pairing~route~#2}}
+    \__tenkz_test_skin_pairing_index_join_oriented:nn {#1} {#2}
+  }
 \cs_set_protected:Npn \__tenkz_string_resolve:
   {
     \seq_if_empty:NF \l__tenkz_kernel_r_skin_routes_seq

--- a/tex/tenkz/tenkz-string.code.tex
+++ b/tex/tenkz/tenkz-string.code.tex
@@ -202,8 +202,8 @@
       { \int_set:Nn #4 { \l__tenkz_string_tmp_tl } }
   }
 
-% Traverse each unordered pair once in declaration order.  Both kernel
-% topology inference and crossing validation use this same scaling boundary.
+% Traverse each unordered pair once in declaration order.  Crossing
+% validation uses this shared scaling boundary.
 \cs_new_protected:Npn \__tenkz_string_map_unordered_pairs:N #1
   {
     \seq_set_eq:NN \l__tenkz_string_scan_seq \l__tenkz_string_ids_seq


### PR DESCRIPTION
## Summary

- correct the unordered-pair helper comment after LionSR/TNLean#5252 moved ordinary-index
  topology to per-route class facts
- pin the expl3 nesting contract for index-to-skin joins

## Rationale

The outer `prop_map_inline` item in `__tenkz_kernel_r_index_joins:` is written
`##1`; the item of its nested `seq_map_inline` is written `####1`. A late
review of LionSR/TNLean#5252 proposed swapping those roles after the PR had already merged.
Applying that swap experimentally made the skin-pairing fixture fail with
`skin pairing join lost index route wire-8`.

The new wrapper assertion checks that argument 1 of
`__tenkz_kernel_r_index_join_oriented:nn` is an index SID and argument 2 is a
registered skin-pairing SID. Production behavior is unchanged.

## Validation

- `scripts/tenkz_kernel_probes.sh`
  - 82 review regressions
  - 8 sugar equivalences
  - 12 kernel record streams byte-identical
  - kernel pixels byte-identical

Follow-up to LionSR/TNLean#5252. Part of LionSR/tenkz#113.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only production change plus kernel test hooks; no runtime behavior change in shipped code.
> 
> **Overview**
> Adds **test-only assertions** in `k_skin_pairings.tex` around `__tenkz_kernel_r_index_join_oriented:nn`: the first argument must be an index route SID and the second a registered skin-pairing route SID, then the real join runs unchanged. This locks the expl3 nesting roles (`##1` = outer index key, `####1` = inner skin route) that a post-merge review had proposed swapping—doing that swap breaks the fixture with `skin pairing join lost index route …`.
> 
> In `tenkz-string.code.tex`, the comment on `__tenkz_string_map_unordered_pairs:N` no longer claims kernel topology inference shares that boundary; it now states only **crossing validation** uses it, matching LionSR/TNLean#5252 moving ordinary-index topology to per-route class facts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff33ef196053cc05819989de9d4b984151f47ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->