### PR TITLE
refactor(Analysis): expose support-correct Kronecker logarithm

### DIFF
--- a/TNLean/Analysis/CfcKronecker.lean
+++ b/TNLean/Analysis/CfcKronecker.lean
@@ -3,10 +3,12 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
+import TNLean.Algebra.PosSemidefSupport
 import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.TraceCFC
-import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic
+import Mathlib.LinearAlgebra.Matrix.Kronecker
 
 /-!
 # Continuous functional calculus through the unital tensor embeddings
@@ -33,9 +35,11 @@ either depending on the other.
   $f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$.
 * `Matrix.cfc_kronecker_of_mul_posSemidef` — multiplicative functional calculus
   on Kronecker products of positive-semidefinite matrices.
+* `Matrix.log_kronecker_posSemidef` — the support-correct logarithm of a
+  Kronecker product of positive-semidefinite matrices.
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open scoped Matrix ComplexOrder MatrixOrder Kronecker Matrix.Norms.L2Operator
 
 namespace Matrix
 
@@ -203,5 +207,120 @@ theorem cfc_kronecker_of_mul_posSemidef
     · simp [Matrix.diagonal_apply_ne _ hpq]
   rw [hcfAB, hcfA, hcfB, hU, hUstar, Matrix.mul_kronecker_mul,
     Matrix.mul_kronecker_mul, hdiag]
+
+/-- **Logarithm of a Kronecker product on its support.** If $A,B\geq0$, then
+\[
+  \log(A\otimes B)=(\log A)\otimes P_B+P_A\otimes(\log B),
+\]
+where $P_A$ and $P_B$ are the orthogonal projections onto the respective
+ranges. The logarithm vanishes on the kernel. Thus the support projections
+remove precisely the terms for which the scalar identity
+$\log(ab)=\log a+\log b$ does not apply.
+
+The statement permits zero-dimensional index types and does not require either
+factor to be positive definite. -/
+theorem log_kronecker_posSemidef {A : Matrix m m ℂ} {B : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    CFC.log (A ⊗ₖ B) =
+      (CFC.log A) ⊗ₖ hB.isHermitian.supportProj +
+        hA.isHermitian.supportProj ⊗ₖ (CFC.log B) := by
+  set evA := hA.isHermitian.eigenvalues with hevA
+  set evB := hB.isHermitian.eigenvalues with hevB
+  set UA : Matrix m m ℂ := (hA.isHermitian.eigenvectorUnitary : Matrix m m ℂ) with hUA
+  set UB : Matrix n n ℂ := (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ) with hUB
+  set U : Matrix (m × n) (m × n) ℂ := UA ⊗ₖ UB with hU
+  set g : m × n → ℝ := fun p ↦ evA p.1 * evB p.2 with hg
+  set D : Matrix (m × n) (m × n) ℂ := diagonal (fun p ↦ (g p : ℂ)) with hD
+  have hUstar : star U = star UA ⊗ₖ star UB := by
+    rw [hU, Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
+      Matrix.star_eq_conjTranspose, Matrix.star_eq_conjTranspose]
+  have hUmem : U ∈ Matrix.unitaryGroup (m × n) ℂ :=
+    Matrix.kronecker_mem_unitary
+      hA.isHermitian.eigenvectorUnitary.2 hB.isHermitian.eigenvectorUnitary.2
+  set Uu : unitary (Matrix (m × n) (m × n) ℂ) := ⟨U, hUmem⟩ with hUu
+  have hconj_eq : A ⊗ₖ B = U * D * star U := by
+    have hAeq := IsHermitian.spectral_form hA.isHermitian
+    have hBeq := IsHermitian.spectral_form hB.isHermitian
+    conv_lhs => rw [hAeq, hBeq]
+    rw [hU, hD, hg, hUstar, Matrix.mul_kronecker_mul, Matrix.mul_kronecker_mul,
+      Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp)]
+    congr 1
+    ext p
+    push_cast
+    ring
+  have hDherm : D.IsHermitian :=
+    isHermitian_diagonal_of_self_adjoint _ (by
+      rw [isSelfAdjoint_iff]
+      ext p
+      simp [Complex.conj_ofReal])
+  have hlogD : CFC.log D = diagonal (fun p ↦ ((Real.log (g p) : ℝ) : ℂ)) := by
+    rw [CFC.log, hD, Matrix.cfc_diagonal g Real.log
+      ((Set.finite_range g).continuousOn Real.log)]
+  have hlogAB : CFC.log (A ⊗ₖ B) =
+      U * diagonal (fun p ↦ ((Real.log (g p) : ℝ) : ℂ)) * star U := by
+    rw [hconj_eq, CFC.log, Matrix.cfc_conj_unitary hDherm Real.log Uu]
+    simp only [hUu]
+    rw [← CFC.log, hlogD]
+  have hlogA : CFC.log A =
+      UA * diagonal (fun i ↦ ((Real.log (evA i) : ℝ) : ℂ)) * star UA := by
+    rw [CFC.log, hA.isHermitian.cfc_eq, hA.isHermitian.cfc_form]
+  have hlogB : CFC.log B =
+      UB * diagonal (fun j ↦ ((Real.log (evB j) : ℝ) : ℂ)) * star UB := by
+    rw [CFC.log, hB.isHermitian.cfc_eq, hB.isHermitian.cfc_form]
+  have hPA : hA.isHermitian.supportProj =
+      UA * diagonal (fun i ↦ if evA i ≠ 0 then (1 : ℂ) else 0) * star UA := by
+    rfl
+  have hPB : hB.isHermitian.supportProj =
+      UB * diagonal (fun j ↦ if evB j ≠ 0 then (1 : ℂ) else 0) * star UB := by
+    rfl
+  have htermA : (CFC.log A) ⊗ₖ hB.isHermitian.supportProj =
+      U * (diagonal (fun i ↦ ((Real.log (evA i) : ℝ) : ℂ)) ⊗ₖ
+        diagonal (fun j ↦ if evB j ≠ 0 then (1 : ℂ) else 0)) * star U := by
+    rw [hlogA, hPB, hU, hUstar, Matrix.mul_kronecker_mul,
+      Matrix.mul_kronecker_mul]
+  have htermB : hA.isHermitian.supportProj ⊗ₖ (CFC.log B) =
+      U * (diagonal (fun i ↦ if evA i ≠ 0 then (1 : ℂ) else 0) ⊗ₖ
+        diagonal (fun j ↦ ((Real.log (evB j) : ℝ) : ℂ))) * star U := by
+    rw [hPA, hlogB, hU, hUstar, Matrix.mul_kronecker_mul,
+      Matrix.mul_kronecker_mul]
+  have hdiag : diagonal (fun p ↦ ((Real.log (g p) : ℝ) : ℂ)) =
+      diagonal (fun i ↦ ((Real.log (evA i) : ℝ) : ℂ)) ⊗ₖ
+          diagonal (fun j ↦ if evB j ≠ 0 then (1 : ℂ) else 0) +
+        diagonal (fun i ↦ if evA i ≠ 0 then (1 : ℂ) else 0) ⊗ₖ
+          diagonal (fun j ↦ ((Real.log (evB j) : ℝ) : ℂ)) := by
+    rw [Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp),
+      Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp)]
+    ext p q
+    by_cases hpq : p = q
+    · subst q
+      simp only [Matrix.diagonal_apply_eq, Matrix.add_apply]
+      by_cases ha0 : evA p.1 = 0
+      · simp [hg, ha0]
+      by_cases hb0 : evB p.2 = 0
+      · simp [hg, hb0]
+      rw [if_pos ha0, if_pos hb0, mul_one, one_mul, hg, Real.log_mul ha0 hb0]
+      push_cast
+      rfl
+    · simp [Matrix.diagonal_apply_ne _ hpq]
+  rw [hlogAB, htermA, htermB, hdiag]
+  noncomm_ring
+
+-- The formula includes a singular factor, without a positive-definiteness hypothesis.
+private theorem log_kronecker_zero_fin_two
+    {n : Type*} [Fintype n] [DecidableEq n] {B : Matrix n n ℂ} (hB : B.PosSemidef) :
+    CFC.log ((0 : Matrix (Fin 2) (Fin 2) ℂ) ⊗ₖ B) =
+      CFC.log (0 : Matrix (Fin 2) (Fin 2) ℂ) ⊗ₖ hB.isHermitian.supportProj +
+        Matrix.PosSemidef.zero.isHermitian.supportProj ⊗ₖ CFC.log B := by
+  exact log_kronecker_posSemidef Matrix.PosSemidef.zero hB
+
+-- The formula also includes a zero-dimensional matrix algebra.
+private theorem log_kronecker_fin_zero
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {A : Matrix (Fin 0) (Fin 0) ℂ} {B : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    CFC.log (A ⊗ₖ B) =
+      CFC.log A ⊗ₖ hB.isHermitian.supportProj +
+        hA.isHermitian.supportProj ⊗ₖ CFC.log B := by
+  exact log_kronecker_posSemidef hA hB
 
 end Matrix

--- a/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
+++ b/TNLean/Channel/Schwarz/SSAEqualityDPI.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
-import TNLean.Analysis.CfcConjugation
+import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.EntropyDecomposition
 import TNLean.Channel.MarginalSupportAbsorption
 import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
@@ -24,8 +24,6 @@ mixed reference on $A$.
 
 ## Main results
 
-* `Matrix.log_kronecker_posSemidef` gives the tensor logarithm on a singular
-  product support.
 * `quantumRelativeEntropy_product_marginals` evaluates relative entropy against
   the product of the two marginals.
 * `isSSAEquality_iff_product_marginal_data_processing_eq` gives the exact
@@ -42,117 +40,6 @@ arXiv:quant-ph/0304007v2, p. 3, equations (4)--(7).
 
 open scoped Matrix Kronecker ComplexOrder Matrix.Norms.L2Operator
 open Matrix
-
-namespace Matrix
-
-variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
-
-/-- **Tensor logarithm on a singular product support.** If $A,B\geq0$, then
-\[
-  \log(A\otimes B)=(\log A)\otimes P_B+P_A\otimes(\log B),
-\]
-where $P_A,P_B$ are the orthogonal projections onto the respective ranges.
-This is the singular replacement for the usual positive-definite tensor
-logarithm identity; the logarithm is extended by zero on the kernel. The
-formula follows by diagonalizing both factors and using
-$\log(ab)=\log a+\log b$ when $a,b>0$; the support projections remove all
-terms for which either eigenvalue vanishes.
-
-Analytic justification for the singular product-marginal evaluation underlying
-Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, p. 3, equation (4).
-The tensor-logarithm identity itself is not stated verbatim there. -/
-theorem log_kronecker_posSemidef {A : Matrix m m ℂ} {B : Matrix n n ℂ}
-    (hA : A.PosSemidef) (hB : B.PosSemidef) :
-    CFC.log (A ⊗ₖ B) =
-      (CFC.log A) ⊗ₖ hB.isHermitian.supportProj +
-        hA.isHermitian.supportProj ⊗ₖ (CFC.log B) := by
-  set evA := hA.isHermitian.eigenvalues with hevA
-  set evB := hB.isHermitian.eigenvalues with hevB
-  set UA : Matrix m m ℂ := (hA.isHermitian.eigenvectorUnitary : Matrix m m ℂ) with hUA
-  set UB : Matrix n n ℂ := (hB.isHermitian.eigenvectorUnitary : Matrix n n ℂ) with hUB
-  set U : Matrix (m × n) (m × n) ℂ := UA ⊗ₖ UB with hU
-  set g : m × n → ℝ := fun p ↦ evA p.1 * evB p.2 with hg
-  set D : Matrix (m × n) (m × n) ℂ := diagonal (fun p ↦ (g p : ℂ)) with hD
-  have hUstar : star U = (star UA) ⊗ₖ (star UB) := by
-    rw [hU, Matrix.star_eq_conjTranspose, Matrix.conjTranspose_kronecker,
-      Matrix.star_eq_conjTranspose, Matrix.star_eq_conjTranspose]
-  have hUmem : U ∈ Matrix.unitaryGroup (m × n) ℂ :=
-    Matrix.kronecker_mem_unitary
-      (hA.isHermitian.eigenvectorUnitary).2 (hB.isHermitian.eigenvectorUnitary).2
-  set Uu : unitary (Matrix (m × n) (m × n) ℂ) := ⟨U, hUmem⟩ with hUu
-  have hconj_eq : A ⊗ₖ B = U * D * star U := by
-    have hAeq := IsHermitian.eq_eigenvectorUnitary_mul_diagonal_mul hA.isHermitian
-    have hBeq := IsHermitian.eq_eigenvectorUnitary_mul_diagonal_mul hB.isHermitian
-    conv_lhs => rw [hAeq, hBeq]
-    rw [hU, hD, hg, hUstar,
-      Matrix.mul_kronecker_mul, Matrix.mul_kronecker_mul,
-      Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp)]
-    congr 1
-    ext p
-    push_cast
-    ring
-  have hDherm : D.IsHermitian :=
-    isHermitian_diagonal_of_self_adjoint _ (by
-      rw [isSelfAdjoint_iff]
-      ext p
-      simp [Complex.conj_ofReal])
-  have hlogD : CFC.log D = diagonal (fun p ↦ ((Real.log (g p) : ℝ) : ℂ)) := by
-    rw [CFC.log, hD, Matrix.cfc_diagonal g Real.log
-      ((Set.finite_range g).continuousOn Real.log)]
-  have hlogAB : CFC.log (A ⊗ₖ B) =
-      U * diagonal (fun p ↦ ((Real.log (g p) : ℝ) : ℂ)) * star U := by
-    rw [hconj_eq, CFC.log, Matrix.cfc_conj_unitary hDherm Real.log Uu]
-    simp only [hUu]
-    rw [← CFC.log, hlogD]
-  have hlogA : CFC.log A =
-      UA * diagonal (fun i ↦ ((Real.log (evA i) : ℝ) : ℂ)) * star UA := by
-    rw [CFC.log]
-    rw [Matrix.IsHermitian.cfc_eq hA.isHermitian Real.log,
-      hA.isHermitian.cfc_form Real.log]
-  have hlogB : CFC.log B =
-      UB * diagonal (fun j ↦ ((Real.log (evB j) : ℝ) : ℂ)) * star UB := by
-    rw [CFC.log]
-    rw [Matrix.IsHermitian.cfc_eq hB.isHermitian Real.log,
-      hB.isHermitian.cfc_form Real.log]
-  have hPA : hA.isHermitian.supportProj =
-      UA * diagonal (fun i ↦ if evA i ≠ 0 then (1 : ℂ) else 0) * star UA := by
-    rfl
-  have hPB : hB.isHermitian.supportProj =
-      UB * diagonal (fun j ↦ if evB j ≠ 0 then (1 : ℂ) else 0) * star UB := by
-    rfl
-  have htermA : (CFC.log A) ⊗ₖ hB.isHermitian.supportProj =
-      U * (diagonal (fun i ↦ ((Real.log (evA i) : ℝ) : ℂ)) ⊗ₖ
-        diagonal (fun j ↦ if evB j ≠ 0 then (1 : ℂ) else 0)) * star U := by
-    rw [hlogA, hPB, hU, hUstar]
-    rw [Matrix.mul_kronecker_mul, Matrix.mul_kronecker_mul]
-  have htermB : hA.isHermitian.supportProj ⊗ₖ (CFC.log B) =
-      U * (diagonal (fun i ↦ if evA i ≠ 0 then (1 : ℂ) else 0) ⊗ₖ
-        diagonal (fun j ↦ ((Real.log (evB j) : ℝ) : ℂ))) * star U := by
-    rw [hPA, hlogB, hU, hUstar]
-    rw [Matrix.mul_kronecker_mul, Matrix.mul_kronecker_mul]
-  have hdiag : diagonal (fun p ↦ ((Real.log (g p) : ℝ) : ℂ)) =
-      diagonal (fun i ↦ ((Real.log (evA i) : ℝ) : ℂ)) ⊗ₖ
-          diagonal (fun j ↦ if evB j ≠ 0 then (1 : ℂ) else 0) +
-        diagonal (fun i ↦ if evA i ≠ 0 then (1 : ℂ) else 0) ⊗ₖ
-          diagonal (fun j ↦ ((Real.log (evB j) : ℝ) : ℂ)) := by
-    rw [Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp),
-      Matrix.kroneckerMap_diagonal_diagonal _ (by intro x; simp) (by intro x; simp)]
-    ext p q
-    by_cases hpq : p = q
-    · subst q
-      simp only [Matrix.diagonal_apply_eq, Matrix.add_apply]
-      by_cases ha0 : evA p.1 = 0
-      · simp [hg, ha0]
-      by_cases hb0 : evB p.2 = 0
-      · simp [hg, hb0]
-      rw [if_pos ha0, if_pos hb0, mul_one, one_mul, hg, Real.log_mul ha0 hb0]
-      push_cast
-      rfl
-    · simp [Matrix.diagonal_apply_ne _ hpq]
-  rw [hlogAB, htermA, htermB, hdiag]
-  noncomm_ring
-
-end Matrix
 
 /-- **Relative entropy against the product of the marginals.** For every
 positive semidefinite bipartite operator $\omega_{XY}$,

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_i.tex
@@ -256,37 +256,6 @@
     \end{align}
 \end{definition}
 
-\begin{lemma}[Tensor logarithm on a singular product support]
-    \label{lem:log_kronecker_possemidef}
-    \lean{Matrix.log_kronecker_posSemidef}
-    \leanok
-    Let $A$ and $B$ be positive semidefinite, with $P_A$ and $P_B$ the
-    orthogonal projections onto their respective ranges. Then
-    \begin{align}
-        \log(A\otimes B)
-        &=(\log A)\otimes P_B+P_A\otimes(\log B).
-        \label{eq:entropy_log_product}
-    \end{align}
-    Here the logarithm is extended by zero on the kernel.
-    This identity is the analytic justification for the singular product
-    reference used below; it is not stated verbatim in
-    \cite{Hayden2004Structure}.
-\end{lemma}
-
-\begin{proof}\leanok
-    Diagonalize $A$ and $B$. On an eigenvector with eigenvalues $a,b\geq0$,
-    (\ref{eq:entropy_log_product}) becomes
-    \begin{align}
-        \log(ab)
-        &=\log(a)\mathbf 1_{b\ne0}
-            +\mathbf 1_{a\ne0}\log(b).
-        \notag
-    \end{align}
-    If $a,b>0$, this is the ordinary product identity for the logarithm. With
-    the kernel convention in the statement, both sides vanish if either
-    eigenvalue is zero.
-\end{proof}
-
 \begin{theorem}[Ancilla additivity on the support domain]
     \label{thm:relative_entropy_ancilla_additivity_support}
     \lean{quantumRelativeEntropy_kronecker_support}
@@ -304,7 +273,7 @@
 
 \begin{proof}\leanok
     \uses{def:hermitian_support_projection,
-        lem:log_kronecker_possemidef,
+        thm:mpdo_support_log_kronecker,
         thm:support_projection_absorption_kernel_inclusion}
     Write $P_\rho$, $P_\sigma$, and $P_\tau$ for the support projections. The
     kernel inclusion gives $P_\sigma\rho P_\sigma=\rho$ and

--- a/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
+++ b/blueprint/src/chapter/ch19_entropy_tripartite_and_ssa_ii.tex
@@ -973,14 +973,14 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:log_kronecker_possemidef,
+    \uses{thm:mpdo_support_log_kronecker,
         thm:marginal_support_left_absorption,
         thm:right_marginal_support_left_absorption,
         lem:trace_lift_left_factor_mul, lem:trace_lift_right_factor_mul}
     The lifted support projections $P_X\otimes\mathbf 1_Y$ and
     $\mathbf 1_X\otimes P_Y$ both fix $\omega_{XY}$. Substituting
-    Lemma~\ref{lem:log_kronecker_possemidef} into the cross term of the relative
-    entropy and using the two partial-trace adjoint identities gives
+    Theorem~\ref{thm:mpdo_support_log_kronecker} into the cross term of the
+    relative entropy and using the two partial-trace adjoint identities gives
     \begin{align}
         \re\tr
         (\omega_{XY}\log(\omega_X\otimes\omega_Y))

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -709,6 +709,39 @@
     (\ref{eq:mpdo_isometric_trace}).
 \end{proof}
 
+\begin{theorem}[Logarithm of a tensor product on its support]
+    \label{thm:mpdo_support_log_kronecker}
+    \lean{Matrix.log_kronecker_posSemidef}
+    \leanok
+    \uses{def:hermitian_support_projection}
+    Let $A$ and $B$ be positive semidefinite, with $P_A$ and $P_B$ the
+    orthogonal projections onto their respective ranges. Then
+    \begin{align}
+      \log(A\otimes B)
+      &=(\log A)\otimes P_B+P_A\otimes(\log B).
+      \label{eq:mpdo_support_log_tensor_product}
+    \end{align}
+    Here the logarithm is extended by zero on the kernel. Neither matrix is
+    required to be positive definite, and either index set may be empty.
+    This auxiliary identity is project-derived rather than a theorem of
+    CPSV16.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:hermitian_support_projection, lem:cfc_conj_unitary}
+    Diagonalize $A$ and $B$. On a product eigenvector with eigenvalues
+    $a,b\geq0$, equation~(\ref{eq:mpdo_support_log_tensor_product}) becomes
+    \begin{align}
+      \log(ab)
+      &=\log(a)\mathbf 1_{b\ne0}
+        +\mathbf 1_{a\ne0}\log(b).
+      \notag
+    \end{align}
+    If $a,b>0$, this is the ordinary product identity for the logarithm. If
+    either eigenvalue is zero, both sides vanish. Conjugating the resulting
+    diagonal identity by the product eigenbasis proves the formula.
+\end{proof}
+
 \begin{theorem}[Support-aware vector-state Jensen inequality for the logarithm]
     \label{thm:support_log_vector_jensen}
     \lean{Matrix.PosSemidef.re_dotProduct_cfc_log_mulVec_le_log}

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -266,6 +266,22 @@ The reconstruction and entropy identities are formalized separately.
 \leanid{TNLean.quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace_of_faithful}
 in \doclink{TNLean/Analysis/SupportCompressedEntropy}.}
 
+A support-correct tensor-product identity for the logarithm is also
+formalized.  For positive semidefinite $A$ and $B$,
+\[
+  \log(A\otimes B)
+  = (\log A)\otimes P_{\operatorname{supp}(B)}
+    +P_{\operatorname{supp}(A)}\otimes(\log B),
+\]
+where the logarithm vanishes on each kernel.  The statement neither assumes
+positive definiteness nor excludes zero-dimensional matrix algebras.
+\footnote{Formal declaration:
+\leanid{Matrix.log_kronecker_posSemidef} in
+\doclink{TNLean/Analysis/CfcKronecker}.}
+This is a project-derived auxiliary identity, not a theorem of CPSV16.  In
+particular, it does not supply the missing half-moment argument and does not
+complete Proposition~4.5.
+
 A support-aware vector-state Jensen inequality for the logarithm is also
 formalized.  If $A\geq0$, $\langle v,v\rangle=1$, and the support projection of
 $A$ fixes $v$, then


### PR DESCRIPTION
Closes #5251.

## Mathematical content

Relocates the existing theorem

`Matrix.log_kronecker_posSemidef`

from the channel-specific strong-subadditivity module to `TNLean.Analysis.CfcKronecker`, preserving its public name and weakest hypotheses:

[
log(Aotimes B)=(log A)otimes P_B+P_Aotimes(log B),qquad A,Bge 0.
]

The support projections make the formula correct for singular factors. The theorem continues to permit zero-dimensional index types and assumes neither positive definiteness nor nonemptiness. Existing Channel callers are unchanged.

The Blueprint result is moved from the Chapter 19 SSA discussion to a project-derived Chapter 21 entry, and the CPSV17 paper-gap note records this prerequisite while leaving #5242 and Proposition 4.5 open.

## Verification

- Mathlib cache fetched before compilation
- focused target and downstream consumer builds
- singular `Fin 2` and zero-dimensional `Fin 0` instantiation checks
- full `lake build` (9,864 jobs)
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- `leanblueprint checkdecls` and `leanblueprint web`
- Blueprint–Lean sync, prose, integrity, tactic-pattern, line-length, and whitespace checks
- independent exact-head review of `28aa1e9e06d181d97938fce46e92524ea66ebf90`

This supplies the hardest singular functional-calculus identity required by #5242; it does not prove the half-moment entropy comparison.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and documentation relocation with no API rename; channel callers keep the same theorem name via the new import path.
> 
> **Overview**
> **Moves** the support-correct Kronecker logarithm identity `Matrix.log_kronecker_posSemidef` from the SSA equality / DPI channel module into `TNLean/Analysis/CfcKronecker`, keeping the same public name and hypotheses (singular PSD factors, empty index types allowed). The proof is unchanged in substance; `CfcKronecker` gains the needed imports and two private instantiations (`Fin 2` with a zero factor, `Fin 0`).
> 
> **`SSAEqualityDPI`** now imports `CfcKronecker` instead of hosting the theorem locally; downstream proofs (e.g. product-marginal relative entropy, ancilla additivity) still call `Matrix.log_kronecker_posSemidef` unchanged.
> 
> **Blueprint / docs:** the standalone lemma is removed from Chapter 19 SSA material and reintroduced in Chapter 21 as project-derived `thm:mpdo_support_log_kronecker` (same Lean anchor). Chapter 19 proofs that used the old lemma now cite that theorem. The CPSV17 paper-gap note documents the formalization in `CfcKronecker` and states it does not close the remaining half-moment / Proposition 4.5 gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e1712d52803a38a221b3d3ab2100978e606b06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->