### PR TITLE
feat(Analysis): add transpose covariance consequences

### DIFF
--- a/TNLean/Analysis/CfcConjugation.lean
+++ b/TNLean/Analysis/CfcConjugation.lean
@@ -3,18 +3,21 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.PosSemidefSupport
 import Mathlib.Analysis.CStarAlgebra.Classes
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 import Mathlib.LinearAlgebra.Matrix.Reindex
 
 /-!
 # Covariance of the matrix continuous functional calculus
 
 This file records covariance of the continuous functional calculus for
-Hermitian matrices under reindexing and unitary conjugation. These are matrix
-instances of the general fact that continuous star-algebra homomorphisms
-commute with the continuous functional calculus.
+Hermitian matrices under reindexing, transpose, and unitary conjugation. These
+are matrix instances of the general fact that continuous star-algebra
+homomorphisms commute with the continuous functional calculus.
 
 The results have no quantum-information content. They are isolated in this
 low-level analysis module so that consumers can use them without importing the
@@ -26,14 +29,18 @@ quantum relative-entropy stack.
   homomorphism.
 * `Matrix.cfc_submatrix_equiv` — covariance of the continuous functional
   calculus under reindexing.
+* `Matrix.cfc_transpose` — covariance of the continuous functional calculus
+  under transpose.
+* `Matrix.IsHermitian.log_transpose` and `Matrix.IsHermitian.supportProj_transpose` —
+  transpose covariance of the logarithm and support projection.
+* `Matrix.PosSemidef.rpow_transpose` and `Matrix.PosSemidef.sqrt_transpose` —
+  transpose covariance of real powers and the positive square root.
 * `Matrix.cfc_conj_unitary` — covariance of the continuous functional calculus
   under conjugation by a unitary.
-* `Matrix.cfc_transpose` — covariance of the continuous functional calculus under
-  transpose on Hermitian matrices.
 * `Matrix.cfc_diagonal` — entrywise functional calculus for real diagonal matrices.
 -/
 
-open scoped Matrix.Norms.L2Operator
+open scoped Matrix ComplexOrder MatrixOrder Matrix.Norms.L2Operator
 
 namespace Matrix
 
@@ -126,6 +133,65 @@ theorem cfc_transpose {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ
     ← conjugateStarAlgHom_apply, ← conjugateStarAlgHom_apply]
   exact StarAlgHomClass.map_cfc conjugateStarAlgHom f A hcont hcontφ hsa
     (hsa.map conjugateStarAlgHom)
+
+/-- The matrix logarithm commutes with transpose on Hermitian matrices. -/
+theorem IsHermitian.log_transpose {A : Matrix n n ℂ} (hA : A.IsHermitian) :
+    CFC.log Aᵀ = (CFC.log A)ᵀ := by
+  exact (cfc_transpose hA Real.log).symm
+
+/-- Every real power of a positive-semidefinite matrix commutes with transpose. -/
+theorem PosSemidef.rpow_transpose {A : Matrix n n ℂ} (hA : A.PosSemidef) (r : ℝ) :
+    (Aᵀ) ^ r = (A ^ r)ᵀ := by
+  rw [CFC.rpow_eq_cfc_real hA.transpose.nonneg, CFC.rpow_eq_cfc_real hA.nonneg]
+  exact (cfc_transpose hA.isHermitian (fun x : ℝ ↦ x ^ r)).symm
+
+set_option linter.unusedDecidableInType false in
+/-- The positive square root of a positive-semidefinite matrix commutes with transpose. -/
+theorem PosSemidef.sqrt_transpose {A : Matrix n n ℂ} (hA : A.PosSemidef) :
+    CFC.sqrt Aᵀ = (CFC.sqrt A)ᵀ := by
+  classical
+  rw [CFC.sqrt_eq_real_sqrt Aᵀ hA.transpose.nonneg,
+    CFC.sqrt_eq_real_sqrt A hA.nonneg, cfcₙ_eq_cfc, cfcₙ_eq_cfc]
+  exact (cfc_transpose hA.isHermitian Real.sqrt).symm
+
+/-- The support projection of a Hermitian matrix commutes with transpose. -/
+theorem IsHermitian.supportProj_transpose {A : Matrix n n ℂ} (hA : A.IsHermitian) :
+    hA.transpose.supportProj = hA.supportProjᵀ := by
+  let f : ℝ → ℝ := fun x ↦ if x ≠ 0 then 1 else 0
+  have hsupport (B : Matrix n n ℂ) (hB : B.IsHermitian) :
+      hB.supportProj = cfc f B := by
+    rw [hB.cfc_eq]
+    unfold Matrix.IsHermitian.supportProj Matrix.IsHermitian.cfc
+    rw [Unitary.conjStarAlgAut_apply]
+    congr 2
+    ext i j
+    by_cases hij : i = j
+    · subst j
+      by_cases hi : hB.eigenvalues i = 0 <;> simp [f, hi]
+    · simp [Matrix.diagonal_apply_ne _ hij]
+  rw [hsupport Aᵀ hA.transpose, hsupport A hA]
+  exact (cfc_transpose hA f).symm
+
+-- All four consequences include the singular zero matrix.
+private theorem transpose_cfc_consequences_zero_fin_two (r : ℝ) :
+    let h0 : (0 : Matrix (Fin 2) (Fin 2) ℂ).PosSemidef := Matrix.PosSemidef.zero
+    CFC.log (0 : Matrix (Fin 2) (Fin 2) ℂ)ᵀ =
+        (CFC.log (0 : Matrix (Fin 2) (Fin 2) ℂ))ᵀ ∧
+      ((0 : Matrix (Fin 2) (Fin 2) ℂ)ᵀ) ^ r =
+        ((0 : Matrix (Fin 2) (Fin 2) ℂ) ^ r)ᵀ ∧
+      CFC.sqrt (0 : Matrix (Fin 2) (Fin 2) ℂ)ᵀ =
+        (CFC.sqrt (0 : Matrix (Fin 2) (Fin 2) ℂ))ᵀ ∧
+      h0.isHermitian.transpose.supportProj = h0.isHermitian.supportProjᵀ := by
+  dsimp only
+  let h0 : (0 : Matrix (Fin 2) (Fin 2) ℂ).PosSemidef := Matrix.PosSemidef.zero
+  exact ⟨h0.isHermitian.log_transpose, h0.rpow_transpose r,
+    h0.sqrt_transpose, h0.isHermitian.supportProj_transpose⟩
+
+-- Transpose covariance also permits the zero-dimensional matrix algebra.
+private theorem cfc_transpose_fin_zero (A : Matrix (Fin 0) (Fin 0) ℂ)
+    (hA : A.IsHermitian) (f : ℝ → ℝ) :
+    (cfc f A)ᵀ = cfc f Aᵀ :=
+  cfc_transpose hA f
 
 end Transpose
 

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -616,14 +616,6 @@ section Lieb
 
 open scoped Kronecker
 
-/-- The real power of a positive-definite matrix commutes with transpose:
-`(Bᵀ) ^ r = (B ^ r)ᵀ`. -/
-private lemma rpow_transpose (B : Mat) (hB : B.PosDef) (r : ℝ) : (Bᵀ) ^ r = (B ^ r)ᵀ := by
-  have h0B : (0 : Mat) ≤ B := hB.posSemidef.nonneg
-  have h0BT : (0 : Mat) ≤ Bᵀ := hB.transpose.posSemidef.nonneg
-  rw [CFC.rpow_eq_cfc_real h0BT, CFC.rpow_eq_cfc_real h0B]
-  exact (Matrix.cfc_transpose hB.isHermitian (fun x : ℝ => x ^ r)).symm
-
 /-- The reduction `(A ⊗ₖ 1)^s (1 ⊗ₖ Bᵀ)^{1-s} = A^s ⊗ₖ (Bᵀ)^{1-s}`, obtained by pushing the
 continuous functional calculus through each unital tensor embedding. -/
 private lemma lieb_kronecker_reduction (A B : Mat) (hA : A.PosDef) (hB : B.PosDef) (s : ℝ) :
@@ -648,7 +640,7 @@ private lemma lieb_quad_eq_trace (A B K : Mat) (hB : B.PosDef) (s : ℝ) :
       = (Kᴴ * A ^ s * K * B ^ (1 - s)).trace := by
   rw [Matrix.kronecker_mulVec_vec ((Bᵀ) ^ (1 - s)) Kᵀ (A ^ s),
     Matrix.star_vec_dotProduct_vec, ← Matrix.mul_assoc, ← Matrix.mul_assoc,
-    rpow_transpose B hB (1 - s), Matrix.transpose_conjTranspose K,
+    hB.posSemidef.rpow_transpose (1 - s), Matrix.transpose_conjTranspose K,
     ← Matrix.trace_transpose (Kᴴ * A ^ s * K * B ^ (1 - s))]
   simp only [Matrix.transpose_mul, Matrix.conjTranspose_transpose, Matrix.mul_assoc]
   rw [Matrix.trace_mul_comm (K.map star)]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -712,19 +712,42 @@
 \begin{theorem}[Functional calculus under transpose]
     \label{thm:cfc_transpose_hermitian}
     \lean{Matrix.cfc_transpose}
+    \lean{Matrix.IsHermitian.log_transpose}
+    \lean{Matrix.PosSemidef.rpow_transpose}
+    \lean{Matrix.PosSemidef.sqrt_transpose}
+    \lean{Matrix.IsHermitian.supportProj_transpose}
     \leanok
+    \uses{def:hermitian_support_projection}
     If $A\in\MN{n}$ is Hermitian and $f:\R\to\R$, then
     \begin{align}
       f(A)^T&=f(A^T).
       \label{eq:mpdo_cfc_transpose}
     \end{align}
+    In particular,
+    \begin{align}
+      \log(A^T)&=(\log A)^T, &
+      P_{A^T}&=P_A^T.
+      \label{eq:mpdo_log_support_transpose}
+    \end{align}
+    If $A$ is positive semidefinite, then for every $r\in\R$,
+    \begin{align}
+      (A^T)^r&=(A^r)^T, &
+      \sqrt{A^T}&=(\sqrt A)^T.
+      \label{eq:mpdo_power_sqrt_transpose}
+    \end{align}
+    These identities include singular matrices and matrices whose index set is
+    empty. They are project-derived rather than statements of CPSV16.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{def:hermitian_support_projection}
     For a Hermitian matrix, transpose is entrywise complex conjugation.
     Apply covariance of the continuous functional calculus under this real
     star-algebra automorphism. Continuity of $f$ is needed only on the finite
-    spectrum of $A$, where it is automatic.
+    spectrum of $A$, where it is automatic. The logarithm, real-power, and
+    square-root identities follow by specialization. For the support
+    projection, specialize to the function that is one away from zero and zero
+    at zero.
 \end{proof}
 
 \begin{theorem}[Logarithm of a tensor product on its support]

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -328,19 +328,27 @@ a Hermitian matrix and its functional calculus.
 This is an auxiliary analytic result, not a theorem of CPSV16.  It does not
 alter the source-coverage count or complete Proposition~4.5.
 
-The reusable logarithm identities and the entropy comparison are now
-formalized.  The tensor-product logarithm retains the two support projections,
-the logarithm commutes with transpose on Hermitian matrices, the logarithm of a
-positive-semidefinite square root is half the logarithm, and the logarithm of a
-real power of a positive-definite matrix is the exponent times the logarithm.
+The reusable functional-calculus identities and the entropy comparison are now
+formalized.  Functional calculus commutes with transpose on Hermitian matrices;
+in particular, so do the logarithm and support projection, and every real power
+and the positive square root commute with transpose on positive-semidefinite
+matrices.  These transpose identities include singular matrices and
+zero-dimensional matrix algebras.  The tensor-product logarithm retains the two
+support projections, the logarithm of a positive-semidefinite square root is
+half the logarithm, and the logarithm of a real power of a positive-definite
+matrix is the exponent times the logarithm.
 The faithful theorem assumes only $\rho\geq0$, $\omega>0$, and $\tr\rho=1$;
 the singular theorem assumes $\rho,\omega\geq0$, both traces equal to one, and
 $\ker\omega\subseteq\ker\rho$.
-These logarithm identities are project-derived auxiliary results, not theorems
-of CPSV16; in particular, the tensor-product statement permits singular
-factors and zero-dimensional matrix algebras.
+These functional-calculus identities are project-derived auxiliary results,
+not theorems of CPSV16; in particular, the tensor-product statement permits
+singular factors and zero-dimensional matrix algebras.
 \footnote{Formal declarations:
 \leanid{Matrix.cfc_transpose},
+\leanid{Matrix.IsHermitian.log_transpose},
+\leanid{Matrix.PosSemidef.rpow_transpose},
+\leanid{Matrix.PosSemidef.sqrt_transpose},
+\leanid{Matrix.IsHermitian.supportProj_transpose},
 \leanid{Matrix.log_kronecker_posSemidef},
 \leanid{Matrix.PosSemidef.cfc_log_sqrt},
 \leanid{Matrix.PosDef.cfc_log_rpow},
@@ -405,8 +413,9 @@ marginals, and their positive definiteness are now formalized.
 \leanid{Matrix.PosSemidef.partialTraceLeft_marginalSupport_compression}, and
 \leanid{Matrix.PosSemidef.marginalSupport_compression_marginals_posDef} in
 \doclink{TNLean/Channel/MarginalSupportAbsorption}.}
-The mathematical task tracked in
-\href{https://github.com/LionSR/TNLean/issues/5209}{\#5209} is complete: the
+The mathematical tasks tracked in
+\href{https://github.com/LionSR/TNLean/issues/5209}{\#5209} and
+\href{https://github.com/LionSR/TNLean/issues/5242}{\#5242} are complete: the
 faithful and singular relative-entropy comparisons are proved using the
 relative-modular half-moment, support-aware Jensen, and Hilbert--Schmidt
 Cauchy--Schwarz, without a general weighted interpolation theorem or an


### PR DESCRIPTION
Closes #5257.

PR #5250 merged while this branch was under review and now supplies the generic `Matrix.cfc_transpose` theorem and the relative-modular half-moment entropy comparison. This rebased PR preserves that implementation and adds only the reusable consequences still absent from `TNLean.Analysis.CfcConjugation`:

- `Matrix.IsHermitian.log_transpose`;
- `Matrix.PosSemidef.rpow_transpose`;
- `Matrix.PosSemidef.sqrt_transpose`; and
- `Matrix.IsHermitian.supportProj_transpose`.

The real-power and square-root statements require only positive semidefiniteness, hence include singular matrices. Boundary checks cover the zero matrix on `Fin 2` and generic covariance on `Fin 0`. `OperatorConvexity` drops its remaining private positive-definite real-power transpose lemma and uses the public positive-semidefinite result.

Chapter 21 and the paper-gap note retain #5250’s completed entropy theorem and record these additional project-derived consequences. GitHub confirms #5209 and #5242 are closed; #5211 remains open.

## Verification

- isolated worktree/package audit and pinned Mathlib cache
- focused combined build (3,124 jobs), including `SandwichedRenyiTwo`, `SupportCompressedEntropy`, and `OperatorConvexity`
- singular `Fin 2` and zero-dimensional `Fin 0` checks
- full 9,864-job build on the pre-rebase content; rebased focused build on current main
- axiom audits: only `propext`, `Classical.choice`, and `Quot.sound`
- Blueprint checkdecls/sync, prose, integrity, size, line-length, and diff checks
- independent exact-head review of `741d1bfe315ab905920e596aaaf4193ba8ed4047`

This PR does not alter the entropy comparison proved by #5250.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New analysis lemmas and a small refactor in Lieb proofs; no changes to auth, data handling, or core infrastructure.
> 
> **Overview**
> Adds **public corollaries** of `Matrix.cfc_transpose` in `TNLean/Analysis/CfcConjugation`: `IsHermitian.log_transpose`, `PosSemidef.rpow_transpose`, `PosSemidef.sqrt_transpose`, and `IsHermitian.supportProj_transpose`. Real-power and square-root statements use **positive semidefiniteness** (singular matrices included). Private checks on `Fin 2` (zero matrix) and `Fin 0` document empty-index edge cases.
> 
> **`OperatorConvexity`** drops its private positive-definite `rpow_transpose` lemma and calls `hB.posSemidef.rpow_transpose` in the Lieb vectorization step.
> 
> Blueprint Chapter 21 and the CPSV17 paper-gap note link the new Lean names and record that issues **#5209** and **#5242** are complete; entropy comparison from #5250 is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ed14ecbf6f03ae5e78671da2f027fb0e6bf105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->