### PR TITLE
refactor(tenkz): extend support folds to affine records

### DIFF
--- a/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
+++ b/tests/tenkz/kernel/regression/r_affine_hull_routes.tex
@@ -112,6 +112,82 @@
       \l__tenkz_test_support_seq {0}{1.6666666666667}{0.3} \l_tmpa_tl
     \fp_compare:nNnF { abs(\l_tmpa_tl - 0.5) } < {0.000001}
       { \errmessage{page~daylight~was~not~lifted~into~dual~units} }
+    \__tenkz_test_affine_support:
+  }
+\cs_new_protected:Npn \__tenkz_test_affine_support:
+  {
+    \__tenkz_test_support_equiv:nnnnn {circle}{0.5}{0}{0}{31}
+    \__tenkz_test_support_equiv:nnnnn {rect}{2}{1}{0}{31}
+    \__tenkz_test_support_equiv:nnnnn {roundrect}{2}{1}{0.25}{31}
+    \__tenkz_test_support_equiv:nnnnn {triangle}{2}{1}{0}{31}
+    \fp_set:Nn \l_tmpa_fp
+      {
+        \__tenkz_geom_support_basis:nnnnnnnnn
+          {circle}{0.5}{0}{0}{1}{0}{0.45}{0.60}{0}
+      }
+    \fp_compare:nNnF
+      { abs(\l_tmpa_fp - 0.5 * sqrt(1 + 0.45^2)) } < {0.000001}
+      { \errmessage{an~affine~circle~lost~its~transformed~support} }
+    \fp_set:Nn \l_tmpa_fp
+      {
+        \__tenkz_geom_support_basis:nnnnnnnnn
+          {rect}{2}{1}{0}{1}{0}{0.45}{0.60}{0}
+      }
+    \fp_compare:nNnF { abs(\l_tmpa_fp - 2.45) } < {0.000001}
+      { \errmessage{an~affine~rectangle~lost~one~basis~vector} }
+    \fp_set:Nn \l_tmpa_fp
+      {
+        \__tenkz_geom_support_basis:nnnnnnnnn
+          {roundrect}{2}{1}{0.25}{1}{0}{0.45}{0.60}{0}
+      }
+    \fp_compare:nNnF
+      {
+        abs(
+          \l_tmpa_fp
+          - 1.75 - 0.75 * 0.45 - 0.25 * sqrt(1 + 0.45^2) )
+      }
+      < {0.000001}
+      { \errmessage{an~affine~rounded~rectangle~lost~its~corner~support} }
+    \fp_set:Nn \l_tmpa_fp
+      {
+        \__tenkz_geom_support_basis:nnnnnnnnn
+          {triangle}{2}{1}{0}{1}{0}{0.45}{0.60}{0}
+      }
+    \fp_compare:nNnF { abs(\l_tmpa_fp - 2) } < {0.000001}
+      { \errmessage{an~affine~triangle~lost~its~apex~support} }
+    \seq_clear:N \l__tenkz_test_support_seq
+    \seq_put_right:Nn \l__tenkz_test_support_seq
+      { {rect}{1}{2}{0}{0}{-5}{0} }
+    \seq_put_right:Nn \l__tenkz_test_support_seq
+      { {affine}{rect}{2}{1}{0}{1}{0}{0.45}{0.60}{3}{4} }
+    \__tenkz_geom_support_max:nnN
+      {l__tenkz_test_support_seq}{0} \l_tmpa_tl
+    \fp_compare:nNnF { abs(\l_tmpa_tl - 5.45) } < {0.000001}
+      { \errmessage{a~mixed~support~fold~lost~its~affine~record} }
+    \__tenkz_geom_support_max_linear:nnnN
+      {l__tenkz_test_support_seq}{0}{1.6666666666667} \l_tmpa_tl
+    \fp_compare:nNnF
+      { abs(\l_tmpa_tl - 7.6666666666668) } < {0.000001}
+      {
+        \errmessage
+          {
+            a~dual-basis~support~fold~lost~its~affine~record:
+            ~\tl_use:N \l_tmpa_tl
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_test_support_equiv:nnnnn #1#2#3#4#5
+  {
+    \fp_set:Nn \l_tmpa_fp
+      { \__tenkz_geom_support:nnnnnn {#1}{#2}{#3}{#4}{#5}{17} }
+    \fp_set:Nn \l_tmpb_fp
+      {
+        \__tenkz_geom_support_basis:nnnnnnnnn
+          {#1}{#2}{#3}{#4}
+          {cosd(#5)}{sind(#5)}{-sind(#5)}{cosd(#5)}{17}
+      }
+    \fp_compare:nNnF { abs(\l_tmpa_fp - \l_tmpb_fp) } < {0.000001}
+      { \errmessage{an~orthogonal~basis~changed~established~support} }
   }
 \cs_new_protected:Npn \__tenkz_test_leg_lane:
   {

--- a/tex/tenkz/tenkz-geometry.code.tex
+++ b/tex/tenkz/tenkz-geometry.code.tex
@@ -797,13 +797,70 @@
 \cs_new:Npn \__tenkz_geom_rr:nnn #1#2#3
   { min( (#1) , (#2) , (#3) ) }
 
+% Support of one primitive transported through a complete east/north basis.
+% This is a distinct contract from the scalar-turn function above: an affine
+% support record is
+%   {affine}{family}{hx}{hy}{radius}{ex}{ey}{nx}{ny}{cx}{cy}.
+% The explicit tag keeps a basis out of the rotated record's angle slot and
+% lets one obstacle sequence contain established rotated and affine shapes.
+\cs_new:Npn \__tenkz_geom_support_basis:nnnnnnnnn
+    #1#2#3#4#5#6#7#8#9
+  {
+    \str_case:enF {#1}
+      {
+        {circle}
+          {
+            (#2) * sqrt(
+              ( (#5) * cosd(#9) + (#6) * sind(#9) ) ^ 2
+              + ( (#7) * cosd(#9) + (#8) * sind(#9) ) ^ 2 )
+          }
+        {rect}
+          {
+            abs( (#2) * ( (#5) * cosd(#9) + (#6) * sind(#9) ) )
+            + abs( (#3) * ( (#7) * cosd(#9) + (#8) * sind(#9) ) )
+          }
+        {roundrect}
+          {
+            abs(
+              ( (#2) - \__tenkz_geom_rr:nnn{#4}{#2}{#3} )
+              * ( (#5) * cosd(#9) + (#6) * sind(#9) ) )
+            + abs(
+                ( (#3) - \__tenkz_geom_rr:nnn{#4}{#2}{#3} )
+                * ( (#7) * cosd(#9) + (#8) * sind(#9) ) )
+            + \__tenkz_geom_rr:nnn{#4}{#2}{#3}
+              * sqrt(
+                  ( (#5) * cosd(#9) + (#6) * sind(#9) ) ^ 2
+                  + ( (#7) * cosd(#9) + (#8) * sind(#9) ) ^ 2 )
+          }
+        {triangle}
+          {
+            max(
+              (#2) * ( (#5) * cosd(#9) + (#6) * sind(#9) ) ,
+              - (#2) * ( (#5) * cosd(#9) + (#6) * sind(#9) )
+                + (#3) * ( (#7) * cosd(#9) + (#8) * sind(#9) ) ,
+              - (#2) * ( (#5) * cosd(#9) + (#6) * sind(#9) )
+                - (#3) * ( (#7) * cosd(#9) + (#8) * sind(#9) ) )
+          }
+      }
+      { \msg_expandable_error:nnn {tenkz}{geom-family} {#1} 0 }
+  }
+
 % fold max-support over {family}{hx}{hy}{radius}{theta}{cx}{cy} records:
 % each contributes its centre's reach plus its shape's support
 \cs_new_protected:Npn \__tenkz_geom_support_max:nnN #1#2#3
   {
     \tl_set:Nn #3 { -10000 }
     \seq_map_inline:cn {#1}
-      { \__tenkz_geom_support_max_one:nnnnnnnnN ##1 {#2} #3 }
+      { \__tenkz_geom_support_max_record:nnN {##1} {#2} #3 }
+  }
+\cs_new_protected:Npn \__tenkz_geom_support_max_record:nnN #1#2#3
+  { \__tenkz_geom_support_max_record_aux:w #1 \q_stop {#2} #3 }
+\cs_new_protected:Npn \__tenkz_geom_support_max_record_aux:w
+    #1#2\q_stop #3#4
+  {
+    \str_if_eq:nnTF {#1}{affine}
+      { \__tenkz_geom_support_max_affine_setup:w #2 \q_stop {#3} #4 }
+      { \__tenkz_geom_support_max_one:nnnnnnnnN {#1} #2 {#3} #4 }
   }
 \cs_new_protected:Npn \__tenkz_geom_support_max_one:nnnnnnnnN
     #1#2#3#4#5#6#7#8#9
@@ -814,6 +871,39 @@
                  (#6) * cosd(#8) + (#7) * sind(#8)
                  + \__tenkz_geom_support:nnnnnn
                      {#1}{#2}{#3}{#4}{#5}{#8} ) } }
+  }
+\tl_new:N \l__tenkz_geom_support_family_tl
+\tl_new:N \l__tenkz_geom_support_hx_tl
+\tl_new:N \l__tenkz_geom_support_hy_tl
+\tl_new:N \l__tenkz_geom_support_radius_tl
+\tl_new:N \l__tenkz_geom_support_shape_tl
+\cs_new_protected:Npn \__tenkz_geom_support_max_affine_setup:w
+    #1#2#3#4#5\q_stop #6#7
+  {
+    \tl_set:Nn \l__tenkz_geom_support_family_tl {#1}
+    \tl_set:Nn \l__tenkz_geom_support_hx_tl {#2}
+    \tl_set:Nn \l__tenkz_geom_support_hy_tl {#3}
+    \tl_set:Nn \l__tenkz_geom_support_radius_tl {#4}
+    \__tenkz_geom_support_max_affine_finish:w #5 \q_stop {#6} #7
+  }
+\cs_new_protected:Npn \__tenkz_geom_support_max_affine_finish:w
+    #1#2#3#4#5#6\q_stop #7#8
+  {
+    \tl_set:Ne #8
+      {
+        \fp_eval:n
+          {
+            max(
+              #8 ,
+              (#5) * cosd(#7) + (#6) * sind(#7)
+              + \__tenkz_geom_support_basis:nnnnnnnnn
+                  { \l__tenkz_geom_support_family_tl }
+                  { \l__tenkz_geom_support_hx_tl }
+                  { \l__tenkz_geom_support_hy_tl }
+                  { \l__tenkz_geom_support_radius_tl }
+                  {#1}{#2}{#3}{#4}{#7} )
+          }
+      }
   }
 
 % Fold support against an arbitrary page covector (gx,gy).  The result is in
@@ -828,8 +918,17 @@
     \tl_set:Nn #4 { -10000 }
     \seq_map_inline:cn {#1}
       {
-        \__tenkz_geom_support_max_linear_one:nnnnnnnN ##1 #4
+        \__tenkz_geom_support_max_linear_record:nN {##1} #4
       }
+  }
+\cs_new_protected:Npn \__tenkz_geom_support_max_linear_record:nN #1#2
+  { \__tenkz_geom_support_max_linear_record_aux:w #1 \q_stop #2 }
+\cs_new_protected:Npn \__tenkz_geom_support_max_linear_record_aux:w
+    #1#2\q_stop #3
+  {
+    \str_if_eq:nnTF {#1}{affine}
+      { \__tenkz_geom_support_max_linear_affine_setup:w #2 \q_stop #3 }
+      { \__tenkz_geom_support_max_linear_one:nnnnnnnN {#1} #2 #3 }
   }
 \cs_new_protected:Npn \__tenkz_geom_support_max_linear_one:nnnnnnnN
     #1#2#3#4#5#6#7#8
@@ -852,6 +951,51 @@
                         \l__tenkz_geom_support_gy_tl ,
                         \l__tenkz_geom_support_gx_tl )
                     }
+            )
+          }
+      }
+  }
+\cs_new_protected:Npn \__tenkz_geom_support_max_linear_affine_setup:w
+    #1#2#3#4#5\q_stop #6
+  {
+    \tl_set:Nn \l__tenkz_geom_support_family_tl {#1}
+    \tl_set:Nn \l__tenkz_geom_support_hx_tl {#2}
+    \tl_set:Nn \l__tenkz_geom_support_hy_tl {#3}
+    \tl_set:Nn \l__tenkz_geom_support_radius_tl {#4}
+    \__tenkz_geom_support_max_linear_affine_finish:w #5 \q_stop #6
+  }
+\cs_new_protected:Npn \__tenkz_geom_support_max_linear_affine_finish:w
+    #1#2#3#4#5#6\q_stop #7
+  {
+    \tl_set:Ne \l__tenkz_geom_support_shape_tl
+      {
+        \fp_eval:n
+          {
+            \__tenkz_geom_support_basis:nnnnnnnnn
+              { \l__tenkz_geom_support_family_tl }
+              { \l__tenkz_geom_support_hx_tl }
+              { \l__tenkz_geom_support_hy_tl }
+              { \l__tenkz_geom_support_radius_tl }
+              {#1}{#2}{#3}{#4}
+              {
+                atand(
+                  \l__tenkz_geom_support_gy_tl ,
+                  \l__tenkz_geom_support_gx_tl )
+              }
+          }
+      }
+    \tl_set:Ne #7
+      {
+        \fp_eval:n
+          {
+            max(
+              #7 ,
+              (#5) * \l__tenkz_geom_support_gx_tl
+                + (#6) * \l__tenkz_geom_support_gy_tl
+              + sqrt(
+                  ( \l__tenkz_geom_support_gx_tl ) ^ 2
+                  + ( \l__tenkz_geom_support_gy_tl ) ^ 2 )
+                * \l__tenkz_geom_support_shape_tl
             )
           }
       }


### PR DESCRIPTION
## Summary

- extend the shared angular and linear silhouette folds with tagged affine obstacle records
- preserve the established rotated-record path and orthogonal-basis equivalence
- cover circle, rectangle, rounded rectangle, and triangle support without page-specific lengths
- pin mixed-record and non-unit dual-covector behavior analytically

This is the first behavior-neutral prerequisite extracted from the preserved affine-skin prototype. It does not switch any rendered skin or change current pixels. The extraction also fixes an under-scaling bug in the prototype linear fold by evaluating shape support before applying the covector norm.

Tracks LionSR/tenkz#113.

## Validation

- focused affine hull/routes fixture
- scripts/tenkz_kernel_probes.sh
- scripts/tenkz_golden.sh --check
- scripts/tenkz_corpus.sh --render
- python3 scripts/tenkz_language.py check
- python3 scripts/test_tenkz_shrink.py
- tenkz lint on both changed files

Results: 82 kernel regressions, byte-identical kernel pixels and record streams, 264 golden event streams byte-identical, and 264 audited corpus PDFs / 266 pages rendered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core clearance/support folding in the geometry layer; scope is limited and golden tests report byte-identical output, but mistakes here would skew routing and hull math later.
> 
> **Overview**
> Adds **affine-tagged obstacle records** to the shared silhouette folds so mixed sequences can carry both classic rotated shapes and shapes defined by a full east/north basis, without changing rendered output today.
> 
> Introduces `__tenkz_geom_support_basis` for circle, rect, roundrect, and triangle support under an arbitrary basis, and routes `__tenkz_geom_support_max` / `__tenkz_geom_support_max_linear` through record dispatchers that branch on the `affine` tag. The **linear fold** for affine records evaluates shape support in basis space first, then scales by the covector norm—correcting under-scaling when dual-basis rows are non-unit.
> 
> The affine hull/routes regression fixture gains analytic checks for orthogonal-basis equivalence, per-family sheared support, and mixed rotated plus affine folds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc22ba9730fc40ab9a8a8211583d929526e1d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->