### PR TITLE
feat(Channel): bound marginal whitening by operator-Schmidt rank

### DIFF
--- a/TNLean/Analysis/CfcConjugation.lean
+++ b/TNLean/Analysis/CfcConjugation.lean
@@ -7,6 +7,7 @@ import TNLean.Algebra.PosSemidefSupport
 import Mathlib.Analysis.CStarAlgebra.Classes
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
+import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 import Mathlib.LinearAlgebra.Matrix.Reindex
@@ -37,6 +38,7 @@ quantum relative-entropy stack.
   transpose covariance of real powers and the positive square root.
 * `Matrix.cfc_conj_unitary` — covariance of the continuous functional calculus
   under conjugation by a unitary.
+* `Matrix.rpow_conj_unitary` — covariance of real powers under unitary conjugation.
 * `Matrix.cfc_diagonal` — entrywise functional calculus for real diagonal matrices.
 -/
 
@@ -220,6 +222,18 @@ theorem cfc_conj_unitary {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → 
   have hconj := StarAlgHomClass.map_cfc φ f A hcont hcontφ hsa hsa'
   rw [happ, happ] at hconj
   exact hconj.symm
+
+/-- Real powers commute with unitary conjugation of a positive-semidefinite
+matrix: $(U A U^\dagger)^s=U A^s U^\dagger$. -/
+theorem rpow_conj_unitary {A : Matrix n n ℂ} (hA : A.PosSemidef) (s : ℝ)
+    (U : unitary (Matrix n n ℂ)) :
+    ((U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ)) ^ s =
+      (U : Matrix n n ℂ) * A ^ s * star (U : Matrix n n ℂ) := by
+  have hconj : ((U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ)).PosSemidef := by
+    have := hA.conjTranspose_mul_mul_same (star (U : Matrix n n ℂ))
+    rwa [star_eq_conjTranspose, conjTranspose_conjTranspose] at this
+  rw [CFC.rpow_eq_cfc_real hconj.nonneg, CFC.rpow_eq_cfc_real hA.nonneg]
+  exact cfc_conj_unitary hA.isHermitian (fun x => x ^ s) U
 
 section Diagonal
 

--- a/TNLean/Analysis/CfcKronecker.lean
+++ b/TNLean/Analysis/CfcKronecker.lean
@@ -35,6 +35,8 @@ either depending on the other.
   $f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$.
 * `Matrix.cfc_kronecker_of_mul_posSemidef` — multiplicative functional calculus
   on Kronecker products of positive-semidefinite matrices.
+* `Matrix.PosSemidef.rpow_kronecker` — real powers factor across
+  positive-semidefinite Kronecker products.
 * `Matrix.log_kronecker_posSemidef` — the support-correct logarithm of a
   Kronecker product of positive-semidefinite matrices.
 -/
@@ -207,6 +209,16 @@ theorem cfc_kronecker_of_mul_posSemidef
     · simp [Matrix.diagonal_apply_ne _ hpq]
   rw [hcfAB, hcfA, hcfB, hU, hUstar, Matrix.mul_kronecker_mul,
     Matrix.mul_kronecker_mul, hdiag]
+
+/-- Real powers distribute over a positive-semidefinite Kronecker product. -/
+theorem PosSemidef.rpow_kronecker
+    {A : Matrix m m ℂ} {B : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) (s : ℝ) :
+    (A ⊗ₖ B) ^ s = (A ^ s) ⊗ₖ (B ^ s) := by
+  rw [CFC.rpow_eq_cfc_real (hA.kronecker hB).nonneg,
+    CFC.rpow_eq_cfc_real hA.nonneg, CFC.rpow_eq_cfc_real hB.nonneg]
+  exact cfc_kronecker_of_mul_posSemidef hA hB (fun x : ℝ ↦ x ^ s)
+    (fun x y hx hy ↦ Real.mul_rpow hx hy)
 
 /-- **Logarithm of a Kronecker product on its support.** If $A,B\geq0$, then
 \[

--- a/TNLean/Analysis/LiebOperatorIntegral.lean
+++ b/TNLean/Analysis/LiebOperatorIntegral.lean
@@ -38,7 +38,6 @@ combined with the resolvent-integrand concavity, yields the joint concavity of
 
 * `Matrix.rpow_diagonal`: the real power of a positive real diagonal matrix is the
   diagonal of the entrywise real powers.
-* `Matrix.rpow_conj_unitary`: covariance of the real power under unitary conjugation.
 * `Matrix.diagonal_lieb_integral`: the Lieb integral identity for a commuting pair of
   positive diagonal matrices.
 * `superop_lieb_integral_rep`: the operator integral representation on the Kronecker
@@ -82,21 +81,6 @@ lemma rpow_diagonal {g : n → ℝ} (hg : ∀ i, 0 < g i) (s : ℝ) :
   exact cfc_diagonal g (fun x => x ^ s)
     (ContinuousOn.rpow_const continuousOn_id fun x hx => Or.inl <| by
       rcases hx with ⟨i, rfl⟩; exact (hg i).ne')
-
-/-- **Covariance of the real power under unitary conjugation.** For a positive
-semidefinite matrix `M` and a unitary `U`, `(U M U^†)^s = U M^s U^†`. -/
-lemma rpow_conj_unitary {M : Matrix n n ℂ} (hM : M.PosSemidef) (s : ℝ)
-    (U : unitary (Matrix n n ℂ)) :
-    ((U : Matrix n n ℂ) * M * star (U : Matrix n n ℂ)) ^ s
-      = (U : Matrix n n ℂ) * M ^ s * star (U : Matrix n n ℂ) := by
-  have hUU : star (U : Matrix n n ℂ) * (U : Matrix n n ℂ) = 1 :=
-    Unitary.star_mul_self_of_mem U.prop
-  -- `U M U^†` is positive semidefinite, hence `0 ≤ U M U^†`.
-  have hconj : ((U : Matrix n n ℂ) * M * star (U : Matrix n n ℂ)).PosSemidef := by
-    have := hM.conjTranspose_mul_mul_same (star (U : Matrix n n ℂ))
-    rwa [star_eq_conjTranspose, conjTranspose_conjTranspose] at this
-  rw [CFC.rpow_eq_cfc_real hconj.nonneg, CFC.rpow_eq_cfc_real hM.nonneg]
-  exact cfc_conj_unitary hM.isHermitian (fun x => x ^ s) U
 
 set_option linter.unusedDecidableInType false in
 /-- The Bochner integral of a matrix-valued function is computed entrywise. The

--- a/TNLean/Analysis/MatrixSqrt.lean
+++ b/TNLean/Analysis/MatrixSqrt.lean
@@ -28,6 +28,8 @@ theory development.
   matrix, the logarithm of the square root is half the logarithm.
 * `Matrix.PosDef.cfc_log_rpow`: for a positive-definite matrix, the logarithm
   of a real power is the exponent times the logarithm.
+* `Matrix.PosDef.rpow_neg_quarter_eq_inv_sqrt_sqrt`: the inverse fourth power
+  is the inverse of the iterated positive square root.
 * `Matrix.PosSemidef.sqrt_smul`: the positive square root commutes with
   nonnegative real scaling.
 * `Matrix.PosSemidef.sqrt_kronecker`: positive square roots factor across
@@ -234,6 +236,18 @@ theorem PosDef.cfc_log_rpow {A : Matrix n n ℂ} (hA : A.PosDef) (s : ℝ) :
     exact hA.eigenvalues_pos i
   change Real.log (x ^ s) = s * Real.log x
   rw [Real.log_rpow hxpos]
+
+/-- The inverse fourth power of a positive-definite matrix is the inverse of
+its iterated positive square root. -/
+theorem PosDef.rpow_neg_quarter_eq_inv_sqrt_sqrt
+    {A : Matrix n n ℂ} (hA : A.PosDef) :
+    A ^ (-(1 / 4 : ℝ)) = (CFC.sqrt (CFC.sqrt A))⁻¹ := by
+  rw [CFC.sqrt_eq_rpow, CFC.sqrt_eq_rpow,
+    CFC.rpow_rpow _ _ _ (by norm_num)]
+  rw [Matrix.nonsing_inv_eq_ringInverse, CFC.inverse_eq_rpow_neg_one]
+  rw [CFC.rpow_rpow _ _ _ (by norm_num)]
+  congr 1
+  ring
 
 /-- The inverse square root of a positive-semidefinite matrix on its support:
 the zero eigenspace is sent to zero and every positive eigenvalue `x` is sent

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.FrobeniusHilbert
+import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.Entropy
 import TNLean.Analysis.SupportCompression
 import TNLean.Analysis.SupportLogJensen
@@ -42,6 +43,8 @@ reference support gives the singular-reference theorem in
 
 * `TNLean.sandwichedRenyiTwoTrace_nonneg` — positivity on
   positive-semidefinite arguments.
+* `TNLean.sandwichedRenyiTwoTrace_conj_unitary` — invariance under unitary
+  conjugation of both arguments.
 * `TNLean.posDef_rpow_neg_quarter_mul_self` — the faithful identity
   \(\omega^{-1/4}\omega^{-1/4}=\omega^{-1/2}\).
 * `TNLean.sandwichedRenyiTwoTrace_eq_weighted` — a cyclically reordered trace
@@ -122,6 +125,48 @@ noncomputable def sandwichedRenyiTwoTrace
     (ρ ω : Matrix n n ℂ) : ℝ :=
   let q := ω ^ (-(1 / 4 : ℝ))
   (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
+
+/-- The order-two sandwiched trace functional is invariant under simultaneous
+unitary conjugation of its state and reference arguments. -/
+theorem sandwichedRenyiTwoTrace_conj_unitary
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {ρ ω : Matrix n n ℂ} (hω : ω.PosSemidef)
+    (U : unitary (Matrix n n ℂ)) :
+    sandwichedRenyiTwoTrace
+        ((U : Matrix n n ℂ) * ρ * star (U : Matrix n n ℂ))
+        ((U : Matrix n n ℂ) * ω * star (U : Matrix n n ℂ)) =
+      sandwichedRenyiTwoTrace ρ ω := by
+  let q := ω ^ (-(1 / 4 : ℝ))
+  let Umat : Matrix n n ℂ := U
+  have hq :
+      (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) =
+        Umat * q * star Umat := by
+    exact Matrix.rpow_conj_unitary hω (-(1 / 4 : ℝ)) U
+  have hU : star Umat * Umat = 1 := Unitary.coe_star_mul_self U
+  rw [sandwichedRenyiTwoTrace, sandwichedRenyiTwoTrace]
+  change (Matrix.trace
+      (((Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) *
+          (Umat * ρ * star Umat) *
+          (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ))) *
+        ((Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) *
+          (Umat * ρ * star Umat) *
+          (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ))))).re = _
+  rw [hq]
+  have hsandwich :
+      (Umat * q * star Umat) * (Umat * ρ * star Umat) *
+          (Umat * q * star Umat) =
+        Umat * (q * ρ * q) * star Umat := by
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul,
+      ← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul]
+  rw [hsandwich]
+  have hsquare :
+      (Umat * (q * ρ * q) * star Umat) *
+          (Umat * (q * ρ * q) * star Umat) =
+        Umat * ((q * ρ * q) * (q * ρ * q)) * star Umat := by
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul]
+  rw [hsquare, Matrix.trace_mul_cycle, hU, Matrix.one_mul]
 
 /-- The order-two sandwiched trace functional is nonnegative on
 positive-semidefinite arguments.

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -117,7 +117,9 @@ is the order-two sandwiched Rényi divergence. The negative power is zero on the
 zero eigenspace, so this totalized functional remains finite outside that
 support domain and must not there be identified with the divergence; see
 Müller-Lennert et al., arXiv:1306.3142v4, Definition 2 and lines 94--96. -/
-noncomputable def sandwichedRenyiTwoTrace (ρ ω : Mat) : ℝ :=
+noncomputable def sandwichedRenyiTwoTrace
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (ρ ω : Matrix n n ℂ) : ℝ :=
   let q := ω ^ (-(1 / 4 : ℝ))
   (Matrix.trace ((q * ρ * q) * (q * ρ * q))).re
 

--- a/TNLean/Analysis/SupportCompressedEntropy.lean
+++ b/TNLean/Analysis/SupportCompressedEntropy.lean
@@ -49,9 +49,10 @@ variable {D k : ℕ}
 its adjoint is the support projection of $\omega$ reconstructs $\rho$ exactly
 from the corresponding compression and expansion. -/
 theorem PosSemidef.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj
-    {ρ ω : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
-    (hker : ∀ v : Fin D → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
-    (V : Matrix (Fin D) (Fin k) ℂ)
+    {n m : Type*} [Fintype n] [DecidableEq n] [Fintype m]
+    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
+    (hker : ∀ v : n → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (V : Matrix n m ℂ)
     (hRange : V * Vᴴ = hω.supportProj) :
     V * (Vᴴ * ρ * V) * Vᴴ = ρ := by
   have hright : ρ * hω.supportProj = ρ :=
@@ -91,8 +92,9 @@ private theorem support_compression_log
         Real.log Real.log_zero V hV
 
 private theorem support_compression_rpow
-    {A : Matrix (Fin D) (Fin D) ℂ} (hA : A.PosSemidef)
-    (s : ℝ) (hs : s ≠ 0) (V : Matrix (Fin D) (Fin k) ℂ)
+    {n m : Type*} [Fintype n] [DecidableEq n] [Fintype m] [DecidableEq m]
+    {A : Matrix n n ℂ} (hA : A.PosSemidef)
+    (s : ℝ) (hs : s ≠ 0) (V : Matrix n m ℂ)
     (hV : Vᴴ * V = 1) (hexpand : V * (Vᴴ * A * V) * Vᴴ = A) :
     A ^ s = V * (Vᴴ * A * V) ^ s * Vᴴ := by
   have hAc : (Vᴴ * A * V).PosSemidef := by
@@ -150,9 +152,10 @@ the support of its positive-semidefinite reference under the support inclusion
 $\ker\omega\subseteq\ker\rho$.  Negative quarter-powers use the zero-on-kernel
 convention on both sides. -/
 theorem sandwichedRenyiTwoTrace_support_compression
-    {ρ ω : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
-    (hker : ∀ v : Fin D → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
-    (V : Matrix (Fin D) (Fin k) ℂ) (hV : Vᴴ * V = 1)
+    {n m : Type*} [Fintype n] [DecidableEq n] [Fintype m] [DecidableEq m]
+    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
+    (hker : ∀ v : n → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (V : Matrix n m ℂ) (hV : Vᴴ * V = 1)
     (hRange : V * Vᴴ = hω.supportProj) :
     sandwichedRenyiTwoTrace ρ ω =
       sandwichedRenyiTwoTrace (Vᴴ * ρ * V) (Vᴴ * ω * V) := by

--- a/TNLean/Analysis/SupportCompressedEntropy.lean
+++ b/TNLean/Analysis/SupportCompressedEntropy.lean
@@ -125,7 +125,8 @@ theorem quantumRelativeEntropy_support_compression
   let ωc := Vᴴ * ω * V
   have hρexpand : V * ρc * Vᴴ = ρ := by
     simpa only [ρc] using
-      hρ.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj hω hker V hRange
+      hρ.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj
+        hω hker V hRange
   have hωexpand : V * ωc * Vᴴ = ω := by
     simpa only [ωc] using
       hω.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj hω
@@ -163,7 +164,8 @@ theorem sandwichedRenyiTwoTrace_support_compression
   let ωc := Vᴴ * ω * V
   have hρexpand : V * ρc * Vᴴ = ρ := by
     simpa only [ρc] using
-      hρ.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj hω hker V hRange
+      hρ.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj
+        hω hker V hRange
   have hωexpand : V * ωc * Vᴴ = ω := by
     simpa only [ωc] using
       hω.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj hω
@@ -222,7 +224,8 @@ theorem quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace_of_faithful
         simpa only [Matrix.conjTranspose_conjTranspose] using hRange)
   have hρexpand : V * ρc * Vᴴ = ρ := by
     simpa only [ρc] using
-      hρ.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj hω hker V hRange
+      hρ.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj
+        hω hker V hRange
   have hωexpand : V * ωc * Vᴴ = ω := by
     simpa only [ωc] using
       hω.eq_expansion_compression_of_kernel_le_of_mul_conjTranspose_eq_supportProj hω

--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -21,6 +21,7 @@ import TNLean.Channel.Determinant.HeisenbergDual
 import TNLean.Channel.Determinant.HilbertSchmidt
 import TNLean.Channel.Determinant.UnitaryCharacterization
 import TNLean.Channel.EntanglementWitness
+import TNLean.Channel.FaithfulMarginalWhitenedChoi
 import TNLean.Channel.FixedPoint
 import TNLean.Channel.InformationallyCompleteEffects
 import TNLean.Channel.Irreducible
@@ -33,6 +34,7 @@ import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.LocalizedKrausCPTP
 import TNLean.Channel.LorentzNormalForm
 import TNLean.Channel.MarginalSupportAbsorption
+import TNLean.Channel.MarginalSupportWhitenedChoi
 import TNLean.Channel.MaximalOverlap
 import TNLean.Channel.MaximallyEntangled
 import TNLean.Channel.NPositivityChainStrict

--- a/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
+++ b/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
@@ -60,8 +60,7 @@ theorem PosSemidef.rpow_kronecker
 conjugation. -/
 theorem sandwichedRenyiTwoTrace_conj_unitary
     {ι : Type*} [Fintype ι] [DecidableEq ι]
-    {ρ ω : Matrix ι ι ℂ}
-    (_hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
+    {ρ ω : Matrix ι ι ℂ} (hω : ω.PosSemidef)
     (U : unitary (Matrix ι ι ℂ)) :
     TNLean.sandwichedRenyiTwoTrace
         ((U : Matrix ι ι ℂ) * ρ * star (U : Matrix ι ι ℂ))
@@ -222,7 +221,7 @@ theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_o
           (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) := by
     rw [← hrefConj]
     simpa only [ρ', K, star_eq_conjTranspose] using
-      Matrix.sandwichedRenyiTwoTrace_conj_unitary hρ
+      Matrix.sandwichedRenyiTwoTrace_conj_unitary
         (hA.posSemidef.kronecker hB.posSemidef) K
   calc
     sandwichedRenyiTwoTrace ρ

--- a/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
+++ b/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Analysis.LiebOperatorIntegral
+import TNLean.Analysis.MatrixSqrt
 import TNLean.Analysis.SandwichedRenyiTwo
 import TNLean.Channel.WhitenedChoi
 
@@ -27,82 +27,10 @@ open Matrix
 
 noncomputable section
 
-namespace Matrix
-
-variable {n : Type*} [Fintype n] [DecidableEq n]
-
-/-- The inverse fourth power of a positive-definite matrix is the inverse of
-its iterated positive square root. -/
-theorem PosDef.rpow_neg_quarter_eq_inv_sqrt_sqrt
-    {A : Matrix n n ℂ} (hA : A.PosDef) :
-    A ^ (-(1 / 4 : ℝ)) = (CFC.sqrt (CFC.sqrt A))⁻¹ := by
-  rw [CFC.sqrt_eq_rpow, CFC.sqrt_eq_rpow,
-    CFC.rpow_rpow _ _ _ (by norm_num)]
-  rw [Matrix.nonsing_inv_eq_ringInverse, CFC.inverse_eq_rpow_neg_one]
-  rw [CFC.rpow_rpow _ _ _ (by norm_num)]
-  congr 1
-  ring
-
-variable {m : Type*} [Fintype m] [DecidableEq m]
-
-/-- Negative real powers distribute over a positive-semidefinite Kronecker
-product. -/
-theorem PosSemidef.rpow_kronecker
-    {A : Matrix n n ℂ} {B : Matrix m m ℂ}
-    (hA : A.PosSemidef) (hB : B.PosSemidef) (s : ℝ) :
-    (A ⊗ₖ B) ^ s = (A ^ s) ⊗ₖ (B ^ s) := by
-  rw [CFC.rpow_eq_cfc_real (hA.kronecker hB).nonneg,
-    CFC.rpow_eq_cfc_real hA.nonneg, CFC.rpow_eq_cfc_real hB.nonneg]
-  exact cfc_kronecker_of_mul_posSemidef hA hB (fun x : ℝ ↦ x ^ s)
-    (fun x y hx hy ↦ Real.mul_rpow hx hy)
-
-/-- The order-two sandwiched trace functional is invariant under unitary
-conjugation. -/
-theorem sandwichedRenyiTwoTrace_conj_unitary
-    {ι : Type*} [Fintype ι] [DecidableEq ι]
-    {ρ ω : Matrix ι ι ℂ} (hω : ω.PosSemidef)
-    (U : unitary (Matrix ι ι ℂ)) :
-    TNLean.sandwichedRenyiTwoTrace
-        ((U : Matrix ι ι ℂ) * ρ * star (U : Matrix ι ι ℂ))
-        ((U : Matrix ι ι ℂ) * ω * star (U : Matrix ι ι ℂ)) =
-      TNLean.sandwichedRenyiTwoTrace ρ ω := by
-  let q := ω ^ (-(1 / 4 : ℝ))
-  let Umat : Matrix ι ι ℂ := U
-  have hq :
-      (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) =
-        Umat * q * star Umat := by
-    exact rpow_conj_unitary hω (-(1 / 4 : ℝ)) U
-  have hU : star Umat * Umat = 1 := Unitary.coe_star_mul_self U
-  rw [TNLean.sandwichedRenyiTwoTrace, TNLean.sandwichedRenyiTwoTrace]
-  change (trace
-      (((Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) *
-          (Umat * ρ * star Umat) *
-          (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ))) *
-        ((Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) *
-          (Umat * ρ * star Umat) *
-          (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ))))).re = _
-  rw [hq]
-  have hsandwich :
-      (Umat * q * star Umat) * (Umat * ρ * star Umat) *
-          (Umat * q * star Umat) =
-        Umat * (q * ρ * q) * star Umat := by
-    simp only [Matrix.mul_assoc]
-    rw [← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul,
-      ← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul]
-  rw [hsandwich]
-  have hsquare :
-      (Umat * (q * ρ * q) * star Umat) *
-          (Umat * (q * ρ * q) * star Umat) =
-        Umat * ((q * ρ * q) * (q * ρ * q)) * star Umat := by
-    simp only [Matrix.mul_assoc]
-    rw [← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul]
-  rw [hsquare, Matrix.trace_mul_cycle, hU, Matrix.one_mul]
-
-end Matrix
-
 namespace TNLean
 
-variable {dA dB : ℕ}
+variable {α β : Type*} [Fintype α] [DecidableEq α]
+  [Fintype β] [DecidableEq β]
 
 /-- For a positive-semidefinite bipartite operator with faithful marginals,
 the order-two sandwiched trace against the product of the two marginals is at
@@ -112,47 +40,47 @@ The first marginal is conjugated by the adjoint of its eigenvector unitary.
 Under the Choi convention the input whitening carries a transpose; it becomes
 the ordinary diagonal whitening only in this eigenbasis. -/
 theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef
-    (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (ρ : Matrix (α × β) (α × β) ℂ)
     (hρ : ρ.PosSemidef) (hA : (partialTraceRight ρ).PosDef)
     (hB : (partialTraceLeft ρ).PosDef) :
     sandwichedRenyiTwoTrace ρ
         (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) ≤
       Matrix.operatorSchmidtRank ρ := by
-  let U : unitary (Matrix (Fin dA) (Fin dA) ℂ) :=
+  let U : unitary (Matrix α α ℂ) :=
     hA.isHermitian.eigenvectorUnitary
-  let Kmat : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ :=
-    star (U : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)
+  let Kmat : Matrix (α × β) (α × β) ℂ :=
+    star (U : Matrix α α ℂ) ⊗ₖ (1 : Matrix β β ℂ)
   have hKmat : Kmat ∈ unitary
-      (Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ) := by
+      (Matrix (α × β) (α × β) ℂ) := by
     exact Matrix.kronecker_mem_unitary (star U).prop (by simp)
-  let K : unitary (Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ) := ⟨Kmat, hKmat⟩
-  let ρ' : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ :=
+  let K : unitary (Matrix (α × β) (α × β) ℂ) := ⟨Kmat, hKmat⟩
+  let ρ' : Matrix (α × β) (α × β) ℂ :=
     Kmat * ρ * Kmatᴴ
-  let p : Fin dA → ℝ := hA.isHermitian.eigenvalues
+  let p : α → ℝ := hA.isHermitian.eigenvalues
   have hρ' : ρ'.PosSemidef := by
     exact hρ.mul_mul_conjTranspose_same Kmat
   have hp : ∀ i, 0 < p i := fun i ↦ hA.eigenvalues_pos i
-  have hKA : star (U : Matrix (Fin dA) (Fin dA) ℂ)ᴴ *
-      star (U : Matrix (Fin dA) (Fin dA) ℂ) = 1 := by
+  have hKA : star (U : Matrix α α ℂ)ᴴ *
+      star (U : Matrix α α ℂ) = 1 := by
     rw [star_eq_conjTranspose, Matrix.conjTranspose_conjTranspose]
     exact Unitary.mul_star_self_of_mem U.prop
-  have hstarU : (star (U : Matrix (Fin dA) (Fin dA) ℂ))ᴴ =
-      (U : Matrix (Fin dA) (Fin dA) ℂ) := by
+  have hstarU : (star (U : Matrix α α ℂ))ᴴ =
+      (U : Matrix α α ℂ) := by
     rw [star_eq_conjTranspose, Matrix.conjTranspose_conjTranspose]
-  have hKB : (1 : Matrix (Fin dB) (Fin dB) ℂ)ᴴ * 1 = 1 := by simp
+  have hKB : (1 : Matrix β β ℂ)ᴴ * 1 = 1 := by simp
   have hA' : partialTraceRight ρ' = diagonal fun i ↦ (p i : ℂ) := by
     dsimp only [ρ', Kmat]
     have h := partialTraceRight_kronecker_conj_of_right_isometry
-      (star (U : Matrix (Fin dA) (Fin dA) ℂ))
-      (1 : Matrix (Fin dB) (Fin dB) ℂ) hKB ρ
+      (star (U : Matrix α α ℂ))
+      (1 : Matrix β β ℂ) hKB ρ
     rw [h, hstarU]
     simpa [U, p, Function.comp_def, Unitary.conjStarAlgAut_star_apply] using
       hA.isHermitian.conjStarAlgAut_star_eigenvectorUnitary
   have hB' : partialTraceLeft ρ' = partialTraceLeft ρ := by
     dsimp only [ρ', Kmat]
     have h := partialTraceLeft_kronecker_conj_of_left_isometry
-      (star (U : Matrix (Fin dA) (Fin dA) ℂ))
-      (1 : Matrix (Fin dB) (Fin dB) ℂ) hKA ρ
+      (star (U : Matrix α α ℂ))
+      (1 : Matrix β β ℂ) hKA ρ
     simpa using h
   have hbound := supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank
     ρ' p hρ' hp hA' (hB' ▸ hB)
@@ -200,8 +128,8 @@ theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_o
     rw [hq, hW]
   have hOSR : Matrix.operatorSchmidtRank ρ' = Matrix.operatorSchmidtRank ρ := by
     simpa only [ρ', Kmat] using Matrix.operatorSchmidtRank_local_isometry_conj
-      (star (U : Matrix (Fin dA) (Fin dA) ℂ))
-      (1 : Matrix (Fin dB) (Fin dB) ℂ) hKA hKB ρ
+      (star (U : Matrix α α ℂ))
+      (1 : Matrix β β ℂ) hKA hKB ρ
   have hrefConj :
       Kmat * (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) * Kmatᴴ =
         partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ' := by
@@ -221,7 +149,7 @@ theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_o
           (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) := by
     rw [← hrefConj]
     simpa only [ρ', K, star_eq_conjTranspose] using
-      Matrix.sandwichedRenyiTwoTrace_conj_unitary
+      sandwichedRenyiTwoTrace_conj_unitary
         (hA.posSemidef.kronecker hB.posSemidef) K
   calc
     sandwichedRenyiTwoTrace ρ

--- a/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
+++ b/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
@@ -1,0 +1,237 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Analysis.LiebOperatorIntegral
+import TNLean.Analysis.SandwichedRenyiTwo
+import TNLean.Channel.WhitenedChoi
+
+/-!
+# Faithful marginal whitening in arbitrary coordinates
+
+This file removes the eigenbasis restriction from the faithful-marginal
+whitened Choi estimate.  The first marginal is diagonalized explicitly.  The
+input transpose forced by the Choi convention therefore disappears only after
+that basis change.
+
+## Main declaration
+
+* `TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef`
+  bounds the order-two sandwiched trace by ordinary operator-Schmidt rank when
+  both marginals are positive definite.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+noncomputable section
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The inverse fourth power of a positive-definite matrix is the inverse of
+its iterated positive square root. -/
+theorem PosDef.rpow_neg_quarter_eq_inv_sqrt_sqrt
+    {A : Matrix n n ℂ} (hA : A.PosDef) :
+    A ^ (-(1 / 4 : ℝ)) = (CFC.sqrt (CFC.sqrt A))⁻¹ := by
+  rw [CFC.sqrt_eq_rpow, CFC.sqrt_eq_rpow,
+    CFC.rpow_rpow _ _ _ (by norm_num)]
+  rw [Matrix.nonsing_inv_eq_ringInverse, CFC.inverse_eq_rpow_neg_one]
+  rw [CFC.rpow_rpow _ _ _ (by norm_num)]
+  congr 1
+  ring
+
+variable {m : Type*} [Fintype m] [DecidableEq m]
+
+/-- Negative real powers distribute over a positive-semidefinite Kronecker
+product. -/
+theorem PosSemidef.rpow_kronecker
+    {A : Matrix n n ℂ} {B : Matrix m m ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) (s : ℝ) :
+    (A ⊗ₖ B) ^ s = (A ^ s) ⊗ₖ (B ^ s) := by
+  rw [CFC.rpow_eq_cfc_real (hA.kronecker hB).nonneg,
+    CFC.rpow_eq_cfc_real hA.nonneg, CFC.rpow_eq_cfc_real hB.nonneg]
+  exact cfc_kronecker_of_mul_posSemidef hA hB (fun x : ℝ ↦ x ^ s)
+    (fun x y hx hy ↦ Real.mul_rpow hx hy)
+
+/-- The order-two sandwiched trace functional is invariant under unitary
+conjugation. -/
+theorem sandwichedRenyiTwoTrace_conj_unitary
+    {ι : Type*} [Fintype ι] [DecidableEq ι]
+    {ρ ω : Matrix ι ι ℂ}
+    (_hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
+    (U : unitary (Matrix ι ι ℂ)) :
+    TNLean.sandwichedRenyiTwoTrace
+        ((U : Matrix ι ι ℂ) * ρ * star (U : Matrix ι ι ℂ))
+        ((U : Matrix ι ι ℂ) * ω * star (U : Matrix ι ι ℂ)) =
+      TNLean.sandwichedRenyiTwoTrace ρ ω := by
+  let q := ω ^ (-(1 / 4 : ℝ))
+  let Umat : Matrix ι ι ℂ := U
+  have hq :
+      (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) =
+        Umat * q * star Umat := by
+    exact rpow_conj_unitary hω (-(1 / 4 : ℝ)) U
+  have hU : star Umat * Umat = 1 := Unitary.coe_star_mul_self U
+  rw [TNLean.sandwichedRenyiTwoTrace, TNLean.sandwichedRenyiTwoTrace]
+  change (trace
+      (((Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) *
+          (Umat * ρ * star Umat) *
+          (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ))) *
+        ((Umat * ω * star Umat) ^ (-(1 / 4 : ℝ)) *
+          (Umat * ρ * star Umat) *
+          (Umat * ω * star Umat) ^ (-(1 / 4 : ℝ))))).re = _
+  rw [hq]
+  have hsandwich :
+      (Umat * q * star Umat) * (Umat * ρ * star Umat) *
+          (Umat * q * star Umat) =
+        Umat * (q * ρ * q) * star Umat := by
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul,
+      ← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul]
+  rw [hsandwich]
+  have hsquare :
+      (Umat * (q * ρ * q) * star Umat) *
+          (Umat * (q * ρ * q) * star Umat) =
+        Umat * ((q * ρ * q) * (q * ρ * q)) * star Umat := by
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc (star Umat) Umat, hU, Matrix.one_mul]
+  rw [hsquare, Matrix.trace_mul_cycle, hU, Matrix.one_mul]
+
+end Matrix
+
+namespace TNLean
+
+variable {dA dB : ℕ}
+
+/-- For a positive-semidefinite bipartite operator with faithful marginals,
+the order-two sandwiched trace against the product of the two marginals is at
+most its operator-Schmidt rank.
+
+The first marginal is conjugated by the adjoint of its eigenvector unitary.
+Under the Choi convention the input whitening carries a transpose; it becomes
+the ordinary diagonal whitening only in this eigenbasis. -/
+theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef
+    (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ : ρ.PosSemidef) (hA : (partialTraceRight ρ).PosDef)
+    (hB : (partialTraceLeft ρ).PosDef) :
+    sandwichedRenyiTwoTrace ρ
+        (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) ≤
+      Matrix.operatorSchmidtRank ρ := by
+  let U : unitary (Matrix (Fin dA) (Fin dA) ℂ) :=
+    hA.isHermitian.eigenvectorUnitary
+  let Kmat : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ :=
+    star (U : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)
+  have hKmat : Kmat ∈ unitary
+      (Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ) := by
+    exact Matrix.kronecker_mem_unitary (star U).prop (by simp)
+  let K : unitary (Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ) := ⟨Kmat, hKmat⟩
+  let ρ' : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ :=
+    Kmat * ρ * Kmatᴴ
+  let p : Fin dA → ℝ := hA.isHermitian.eigenvalues
+  have hρ' : ρ'.PosSemidef := by
+    exact hρ.mul_mul_conjTranspose_same Kmat
+  have hp : ∀ i, 0 < p i := fun i ↦ hA.eigenvalues_pos i
+  have hKA : star (U : Matrix (Fin dA) (Fin dA) ℂ)ᴴ *
+      star (U : Matrix (Fin dA) (Fin dA) ℂ) = 1 := by
+    rw [star_eq_conjTranspose, Matrix.conjTranspose_conjTranspose]
+    exact Unitary.mul_star_self_of_mem U.prop
+  have hstarU : (star (U : Matrix (Fin dA) (Fin dA) ℂ))ᴴ =
+      (U : Matrix (Fin dA) (Fin dA) ℂ) := by
+    rw [star_eq_conjTranspose, Matrix.conjTranspose_conjTranspose]
+  have hKB : (1 : Matrix (Fin dB) (Fin dB) ℂ)ᴴ * 1 = 1 := by simp
+  have hA' : partialTraceRight ρ' = diagonal fun i ↦ (p i : ℂ) := by
+    dsimp only [ρ', Kmat]
+    have h := partialTraceRight_kronecker_conj_of_right_isometry
+      (star (U : Matrix (Fin dA) (Fin dA) ℂ))
+      (1 : Matrix (Fin dB) (Fin dB) ℂ) hKB ρ
+    rw [h, hstarU]
+    simpa [U, p, Function.comp_def, Unitary.conjStarAlgAut_star_apply] using
+      hA.isHermitian.conjStarAlgAut_star_eigenvectorUnitary
+  have hB' : partialTraceLeft ρ' = partialTraceLeft ρ := by
+    dsimp only [ρ', Kmat]
+    have h := partialTraceLeft_kronecker_conj_of_left_isometry
+      (star (U : Matrix (Fin dA) (Fin dA) ℂ))
+      (1 : Matrix (Fin dB) (Fin dB) ℂ) hKA ρ
+    simpa using h
+  have hbound := supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank
+    ρ' p hρ' hp hA' (hB' ▸ hB)
+  have hdiagPD : (diagonal fun i ↦ (p i : ℂ)).PosDef := by
+    rw [posDef_diagonal_iff]
+    intro i
+    exact_mod_cast hp i
+  have hqA :
+      (diagonal fun i ↦ (p i : ℂ)) ^ (-(1 / 4 : ℝ)) =
+        (diagonalMarginalQuarter p)⁻¹ := by
+    rw [hdiagPD.rpow_neg_quarter_eq_inv_sqrt_sqrt,
+      sqrt_sqrt_diagonal_eq_diagonalMarginalQuarter p hp]
+  have hqB :
+      (partialTraceLeft ρ') ^ (-(1 / 4 : ℝ)) =
+        (CFC.sqrt (CFC.sqrt (partialTraceLeft ρ')))⁻¹ :=
+    (hB' ▸ hB).rpow_neg_quarter_eq_inv_sqrt_sqrt
+  have href :
+      partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ' =
+        (diagonal fun i ↦ (p i : ℂ)) ⊗ₖ partialTraceLeft ρ' := by rw [hA']
+  have hq :
+      (partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') ^ (-(1 / 4 : ℝ)) =
+        (diagonalMarginalQuarter p)⁻¹ ⊗ₖ
+          (CFC.sqrt (CFC.sqrt (partialTraceLeft ρ')))⁻¹ := by
+    rw [href, hdiagPD.posSemidef.rpow_kronecker
+      (hB' ▸ hB).posSemidef, hqA, hqB]
+  let W := (diagonalMarginalQuarter p)⁻¹ ⊗ₖ
+    (CFC.sqrt (CFC.sqrt (partialTraceLeft ρ')))⁻¹
+  have hW : Wᴴ = W := by
+    dsimp only [W]
+    rw [← hq]
+    exact (Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg).isHermitian.eq
+  have hidentify :
+      sandwichedRenyiTwoTrace ρ'
+          (partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') =
+        (trace (supportedMarginalWhitenedState ρ' p (partialTraceLeft ρ') *
+          supportedMarginalWhitenedState ρ' p (partialTraceLeft ρ'))).re := by
+    rw [sandwichedRenyiTwoTrace]
+    unfold supportedMarginalWhitenedState singleKrausMap
+    change (trace
+      ((((partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') ^ (-(1 / 4 : ℝ))) * ρ' *
+          ((partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') ^ (-(1 / 4 : ℝ)))) *
+        (((partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') ^ (-(1 / 4 : ℝ))) * ρ' *
+          ((partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') ^ (-(1 / 4 : ℝ)))))).re =
+      (trace ((W * ρ' * Wᴴ) * (W * ρ' * Wᴴ))).re
+    rw [hq, hW]
+  have hOSR : Matrix.operatorSchmidtRank ρ' = Matrix.operatorSchmidtRank ρ := by
+    simpa only [ρ', Kmat] using Matrix.operatorSchmidtRank_local_isometry_conj
+      (star (U : Matrix (Fin dA) (Fin dA) ℂ))
+      (1 : Matrix (Fin dB) (Fin dB) ℂ) hKA hKB ρ
+  have hrefConj :
+      Kmat * (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) * Kmatᴴ =
+        partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ' := by
+    rw [hA', hB']
+    dsimp only [Kmat]
+    rw [Matrix.conjTranspose_kronecker,
+      ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul]
+    simp only [Matrix.conjTranspose_one, Matrix.mul_one, Matrix.one_mul]
+    rw [hstarU]
+    congr 1
+    simpa [U, p, Function.comp_def, Unitary.conjStarAlgAut_star_apply] using
+      hA.isHermitian.conjStarAlgAut_star_eigenvectorUnitary
+  have hQ2 :
+      sandwichedRenyiTwoTrace ρ'
+          (partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') =
+        sandwichedRenyiTwoTrace ρ
+          (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) := by
+    rw [← hrefConj]
+    simpa only [ρ', K, star_eq_conjTranspose] using
+      Matrix.sandwichedRenyiTwoTrace_conj_unitary hρ
+        (hA.posSemidef.kronecker hB.posSemidef) K
+  calc
+    sandwichedRenyiTwoTrace ρ
+        (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) =
+      sandwichedRenyiTwoTrace ρ'
+        (partialTraceRight ρ' ⊗ₖ partialTraceLeft ρ') := hQ2.symm
+    _ = (trace (supportedMarginalWhitenedState ρ' p (partialTraceLeft ρ') *
+          supportedMarginalWhitenedState ρ' p (partialTraceLeft ρ'))).re := hidentify
+    _ ≤ Matrix.operatorSchmidtRank ρ' := hbound
+    _ = Matrix.operatorSchmidtRank ρ := by exact_mod_cast hOSR
+
+end TNLean

--- a/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
+++ b/TNLean/Channel/FaithfulMarginalWhitenedChoi.lean
@@ -17,7 +17,7 @@ that basis change.
 
 ## Main declaration
 
-* `TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef`
+* `TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank_of_marginals_posDef`
   bounds the order-two sandwiched trace by ordinary operator-Schmidt rank when
   both marginals are positive definite.
 -/
@@ -39,7 +39,7 @@ most its operator-Schmidt rank.
 The first marginal is conjugated by the adjoint of its eigenvector unitary.
 Under the Choi convention the input whitening carries a transpose; it becomes
 the ordinary diagonal whitening only in this eigenbasis. -/
-theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef
+theorem sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank_of_marginals_posDef
     (ρ : Matrix (α × β) (α × β) ℂ)
     (hρ : ρ.PosSemidef) (hA : (partialTraceRight ρ).PosDef)
     (hB : (partialTraceLeft ρ).PosDef) :

--- a/TNLean/Channel/MarginalSupportWhitenedChoi.lean
+++ b/TNLean/Channel/MarginalSupportWhitenedChoi.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.CornerCompression
+import TNLean.Analysis.SupportCompressedEntropy
+import TNLean.Channel.FaithfulMarginalWhitenedChoi
+import TNLean.Channel.MarginalSupportAbsorption
+
+/-!
+# Marginal-support whitening
+
+A positive-semidefinite bipartite operator is compressed simultaneously to the
+supports of its two marginals.  The compressed marginals are faithful, while
+the order-two sandwiched trace and ordinary operator-Schmidt rank are unchanged.
+The support coordinate spaces may both be zero-dimensional.
+
+## Main declaration
+
+* `TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank`
+  is the arbitrary-support whitened Choi estimate.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+noncomputable section
+
+namespace TNLean
+
+variable {dA dB : ℕ}
+
+/-- For every positive-semidefinite bipartite operator, the order-two
+sandwiched trace against the product of its marginals is at most its ordinary
+operator-Schmidt rank.
+
+No normalization or positive-dimension assumption is needed.  Simultaneous
+compression to the two marginal supports includes the cases where either
+support coordinate space is `Fin 0`. -/
+theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank
+    (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ : ρ.PosSemidef) :
+    sandwichedRenyiTwoTrace ρ
+        (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) ≤
+      Matrix.operatorSchmidtRank ρ := by
+  let hA : (partialTraceRight ρ).PosSemidef := hρ.partialTraceRight
+  let hB : (partialTraceLeft ρ).PosSemidef := hρ.partialTraceLeft
+  let PA : Matrix (Fin dA) (Fin dA) ℂ :=
+    (Matrix.PosSemidef.partialTraceRight hρ).isHermitian.supportProj
+  let PB : Matrix (Fin dB) (Fin dB) ℂ :=
+    (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj
+  have hPA : IsOrthogonalProjection PA := by
+    exact ⟨(Matrix.PosSemidef.partialTraceRight hρ).isHermitian.supportProj_isHermitian,
+      (Matrix.PosSemidef.partialTraceRight hρ).isHermitian.supportProj_idem⟩
+  have hPB : IsOrthogonalProjection PB := by
+    exact ⟨(Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj_isHermitian,
+      (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj_idem⟩
+  have hPAA : PA = hA.supportProj := by
+    dsimp only [PA]
+    exact (Matrix.PosSemidef.partialTraceRight hρ).supportProj_congr hA rfl
+  have hPBB : PB = hB.supportProj := by
+    dsimp only [PB]
+    exact (Matrix.PosSemidef.partialTraceLeft hρ).supportProj_congr hB rfl
+  let SA := ProjectionSpectralSplit.ofOrthogonalProjection PA hPA
+  let SB := ProjectionSpectralSplit.ofOrthogonalProjection PB hPB
+  letI : Fintype SA.S := SA.instFintypeS
+  letI : Fintype SA.T := SA.instFintypeT
+  letI : DecidableEq SA.S := SA.instDecidableEqS
+  letI : DecidableEq SA.T := SA.instDecidableEqT
+  letI : Fintype SB.S := SB.instFintypeS
+  letI : Fintype SB.T := SB.instFintypeT
+  letI : DecidableEq SB.S := SB.instDecidableEqS
+  letI : DecidableEq SB.T := SB.instDecidableEqT
+  let VA : Matrix (Fin dA) (Fin SA.n) ℂ :=
+    cornerCompressionIsometry SA.Umat SA.eST SA.eS
+  let VB : Matrix (Fin dB) (Fin SB.n) ℂ :=
+    cornerCompressionIsometry SB.Umat SB.eST SB.eS
+  have hVA : VAᴴ * VA = 1 :=
+    cornerCompressionIsometry_conjTranspose_mul SA.Umat SA.eST SA.eS SA.hU'U
+  have hVB : VBᴴ * VB = 1 :=
+    cornerCompressionIsometry_conjTranspose_mul SB.Umat SB.eST SB.eS SB.hU'U
+  have hRangeA : VA * VAᴴ = PA := by
+    calc
+      VA * VAᴴ = VA * 1 * VAᴴ := by rw [Matrix.mul_one]
+      _ = cornerCompressionExpand SA.Umat SA.eST SA.eS 1 :=
+        (cornerCompressionExpand_eq_isometry SA.Umat SA.eST SA.eS 1).symm
+      _ = PA := cornerCompressionExpand_one PA (SA.Umatᴴ * PA * SA.Umat)
+        SA.Umat SA.eST SA.eS
+        (Matrix.fromBlocks (1 : Matrix SA.S SA.S ℂ) 0 0 (0 : Matrix SA.T SA.T ℂ))
+        rfl SA.hP_decomp SA.hPdiag_back
+  have hRangeB : VB * VBᴴ = PB := by
+    calc
+      VB * VBᴴ = VB * 1 * VBᴴ := by rw [Matrix.mul_one]
+      _ = cornerCompressionExpand SB.Umat SB.eST SB.eS 1 :=
+        (cornerCompressionExpand_eq_isometry SB.Umat SB.eST SB.eS 1).symm
+      _ = PB := cornerCompressionExpand_one PB (SB.Umatᴴ * PB * SB.Umat)
+        SB.Umat SB.eST SB.eS
+        (Matrix.fromBlocks (1 : Matrix SB.S SB.S ℂ) 0 0 (0 : Matrix SB.T SB.T ℂ))
+        rfl SB.hP_decomp SB.hPdiag_back
+  let V : Matrix (Fin dA × Fin dB) (Fin SA.n × Fin SB.n) ℂ := VA ⊗ₖ VB
+  let ρc : Matrix (Fin SA.n × Fin SB.n) (Fin SA.n × Fin SB.n) ℂ :=
+    Vᴴ * ρ * V
+  have hV : Vᴴ * V = 1 := by
+    dsimp only [V]
+    rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+      hVA, hVB, Matrix.one_kronecker_one]
+  have hRange : V * Vᴴ =
+      (hA.kronecker hB).supportProj := by
+    dsimp only [V]
+    rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
+      hRangeA, hRangeB, hPAA, hPBB, hA.supportProj_kronecker hB]
+  have hρc : ρc.PosSemidef := by
+    exact hρ.conjTranspose_mul_mul_same V
+  have hMarginals :
+      (partialTraceRight ρc).PosDef ∧ (partialTraceLeft ρc).PosDef := by
+    exact hρ.marginalSupport_compression_marginals_posDef
+      VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
+  have hMargA : partialTraceRight ρc = VAᴴ * partialTraceRight ρ * VA := by
+    exact hρ.partialTraceRight_marginalSupport_compression
+      VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
+  have hMargB : partialTraceLeft ρc = VBᴴ * partialTraceLeft ρ * VB := by
+    exact hρ.partialTraceLeft_marginalSupport_compression
+      VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
+  let ω := partialTraceRight ρ ⊗ₖ partialTraceLeft ρ
+  have hω : ω.PosSemidef := hA.kronecker hB
+  have hρPA : ρ * (PA ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) = ρ := by
+    simpa only [PA, Matrix.leftKroneckerEmbed_apply] using
+      hρ.mul_leftKroneckerEmbed_supportProj_self
+  have hρPB : ρ * ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ PB) = ρ := by
+    simpa only [PB, Matrix.rightKroneckerEmbed_apply] using
+      hρ.mul_rightKroneckerEmbed_supportProj_self
+  have hρP : ρ * (PA ⊗ₖ PB) = ρ := by
+    rw [show PA ⊗ₖ PB = ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ PB) *
+        (PA ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) by
+      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, Matrix.mul_one]]
+    rw [← Matrix.mul_assoc, hρPB, hρPA]
+  have hker : ∀ v : Fin dA × Fin dB → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0 := by
+    intro v hv
+    have hPv := hω.supportProj_mulVec_eq_zero_of_mulVec_eq_zero v hv
+    have hsupport : hω.supportProj = PA ⊗ₖ PB := by
+      calc
+        hω.supportProj = (hA.kronecker hB).supportProj :=
+          hω.supportProj_congr (hA.kronecker hB) rfl
+        _ = hA.supportProj ⊗ₖ hB.supportProj := hA.supportProj_kronecker hB
+        _ = PA ⊗ₖ PB := by rw [hPAA, hPBB]
+    rw [hsupport] at hPv
+    rw [← hρP, ← Matrix.mulVec_mulVec, hPv, Matrix.mulVec_zero]
+  have hωc : Vᴴ * ω * V = partialTraceRight ρc ⊗ₖ partialTraceLeft ρc := by
+    dsimp only [V, ω]
+    rw [Matrix.conjTranspose_kronecker,
+      ← Matrix.mul_kronecker_mul, ← Matrix.mul_kronecker_mul,
+      ← hMargA, ← hMargB]
+  have hQ2 := sandwichedRenyiTwoTrace_support_compression
+    hρ hω hker V hV hRange
+  have hOSR := hρ.operatorSchmidtRank_marginalSupport_compression
+    VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
+  calc
+    sandwichedRenyiTwoTrace ρ
+        (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) =
+      sandwichedRenyiTwoTrace ρc
+        (partialTraceRight ρc ⊗ₖ partialTraceLeft ρc) := by
+          rw [show partialTraceRight ρ ⊗ₖ partialTraceLeft ρ = ω from rfl,
+            hQ2, hωc]
+    _ ≤ Matrix.operatorSchmidtRank ρc :=
+      sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef
+        ρc hρc hMarginals.1 hMarginals.2
+    _ = Matrix.operatorSchmidtRank ρ := by
+      exact_mod_cast hOSR
+
+end TNLean

--- a/TNLean/Channel/MarginalSupportWhitenedChoi.lean
+++ b/TNLean/Channel/MarginalSupportWhitenedChoi.lean
@@ -17,7 +17,7 @@ The support coordinate spaces may both be zero-dimensional.
 
 ## Main declaration
 
-* `TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank`
+* `TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank`
   is the arbitrary-support whitened Choi estimate.
 -/
 
@@ -37,7 +37,7 @@ operator-Schmidt rank.
 No normalization or positive-dimension assumption is needed.  Simultaneous
 compression to the two marginal supports includes the cases where either
 support coordinate space is `Fin 0`. -/
-theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank
+theorem sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank
     (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
     (hρ : ρ.PosSemidef) :
     sandwichedRenyiTwoTrace ρ
@@ -103,7 +103,7 @@ theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank
           rw [show partialTraceRight ρ ⊗ₖ partialTraceLeft ρ = ω from rfl,
             hQ2, hωc]
     _ ≤ Matrix.operatorSchmidtRank ρc :=
-      sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef
+      sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank_of_marginals_posDef
         ρc hρc hMarginals.1 hMarginals.2
     _ = Matrix.operatorSchmidtRank ρ := by exact_mod_cast hOSR
 

--- a/TNLean/Channel/MarginalSupportWhitenedChoi.lean
+++ b/TNLean/Channel/MarginalSupportWhitenedChoi.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Algebra.CornerCompression
 import TNLean.Analysis.SupportCompressedEntropy
 import TNLean.Channel.FaithfulMarginalWhitenedChoi
 import TNLean.Channel.MarginalSupportAbsorption
@@ -46,104 +45,45 @@ theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank
       Matrix.operatorSchmidtRank ρ := by
   let hA : (partialTraceRight ρ).PosSemidef := hρ.partialTraceRight
   let hB : (partialTraceLeft ρ).PosSemidef := hρ.partialTraceLeft
-  let PA : Matrix (Fin dA) (Fin dA) ℂ :=
-    (Matrix.PosSemidef.partialTraceRight hρ).isHermitian.supportProj
-  let PB : Matrix (Fin dB) (Fin dB) ℂ :=
-    (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj
-  have hPA : IsOrthogonalProjection PA := by
-    exact ⟨(Matrix.PosSemidef.partialTraceRight hρ).isHermitian.supportProj_isHermitian,
-      (Matrix.PosSemidef.partialTraceRight hρ).isHermitian.supportProj_idem⟩
-  have hPB : IsOrthogonalProjection PB := by
-    exact ⟨(Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj_isHermitian,
-      (Matrix.PosSemidef.partialTraceLeft hρ).isHermitian.supportProj_idem⟩
-  have hPAA : PA = hA.supportProj := by
-    dsimp only [PA]
-    exact (Matrix.PosSemidef.partialTraceRight hρ).supportProj_congr hA rfl
-  have hPBB : PB = hB.supportProj := by
-    dsimp only [PB]
-    exact (Matrix.PosSemidef.partialTraceLeft hρ).supportProj_congr hB rfl
-  let SA := ProjectionSpectralSplit.ofOrthogonalProjection PA hPA
-  let SB := ProjectionSpectralSplit.ofOrthogonalProjection PB hPB
-  letI : Fintype SA.S := SA.instFintypeS
-  letI : Fintype SA.T := SA.instFintypeT
-  letI : DecidableEq SA.S := SA.instDecidableEqS
-  letI : DecidableEq SA.T := SA.instDecidableEqT
-  letI : Fintype SB.S := SB.instFintypeS
-  letI : Fintype SB.T := SB.instFintypeT
-  letI : DecidableEq SB.S := SB.instDecidableEqS
-  letI : DecidableEq SB.T := SB.instDecidableEqT
-  let VA : Matrix (Fin dA) (Fin SA.n) ℂ :=
-    cornerCompressionIsometry SA.Umat SA.eST SA.eS
-  let VB : Matrix (Fin dB) (Fin SB.n) ℂ :=
-    cornerCompressionIsometry SB.Umat SB.eST SB.eS
-  have hVA : VAᴴ * VA = 1 :=
-    cornerCompressionIsometry_conjTranspose_mul SA.Umat SA.eST SA.eS SA.hU'U
-  have hVB : VBᴴ * VB = 1 :=
-    cornerCompressionIsometry_conjTranspose_mul SB.Umat SB.eST SB.eS SB.hU'U
-  have hRangeA : VA * VAᴴ = PA := by
-    calc
-      VA * VAᴴ = VA * 1 * VAᴴ := by rw [Matrix.mul_one]
-      _ = cornerCompressionExpand SA.Umat SA.eST SA.eS 1 :=
-        (cornerCompressionExpand_eq_isometry SA.Umat SA.eST SA.eS 1).symm
-      _ = PA := cornerCompressionExpand_one PA (SA.Umatᴴ * PA * SA.Umat)
-        SA.Umat SA.eST SA.eS
-        (Matrix.fromBlocks (1 : Matrix SA.S SA.S ℂ) 0 0 (0 : Matrix SA.T SA.T ℂ))
-        rfl SA.hP_decomp SA.hPdiag_back
-  have hRangeB : VB * VBᴴ = PB := by
-    calc
-      VB * VBᴴ = VB * 1 * VBᴴ := by rw [Matrix.mul_one]
-      _ = cornerCompressionExpand SB.Umat SB.eST SB.eS 1 :=
-        (cornerCompressionExpand_eq_isometry SB.Umat SB.eST SB.eS 1).symm
-      _ = PB := cornerCompressionExpand_one PB (SB.Umatᴴ * PB * SB.Umat)
-        SB.Umat SB.eST SB.eS
-        (Matrix.fromBlocks (1 : Matrix SB.S SB.S ℂ) 0 0 (0 : Matrix SB.T SB.T ℂ))
-        rfl SB.hP_decomp SB.hPdiag_back
-  let V : Matrix (Fin dA × Fin dB) (Fin SA.n × Fin SB.n) ℂ := VA ⊗ₖ VB
-  let ρc : Matrix (Fin SA.n × Fin SB.n) (Fin SA.n × Fin SB.n) ℂ :=
-    Vᴴ * ρ * V
+  obtain ⟨kA, VA, hVA, hRangeA⟩ :=
+    hA.isOrthogonalProjection_supportProj.exists_range_isometry
+  obtain ⟨kB, VB, hVB, hRangeB⟩ :=
+    hB.isOrthogonalProjection_supportProj.exists_range_isometry
+  let V : Matrix (Fin dA × Fin dB) (Fin kA × Fin kB) ℂ := VA ⊗ₖ VB
+  let ρc : Matrix (Fin kA × Fin kB) (Fin kA × Fin kB) ℂ := Vᴴ * ρ * V
   have hV : Vᴴ * V = 1 := by
     dsimp only [V]
     rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
       hVA, hVB, Matrix.one_kronecker_one]
-  have hRange : V * Vᴴ =
-      (hA.kronecker hB).supportProj := by
+  have hRange : V * Vᴴ = (hA.kronecker hB).supportProj := by
     dsimp only [V]
     rw [Matrix.conjTranspose_kronecker, ← Matrix.mul_kronecker_mul,
-      hRangeA, hRangeB, hPAA, hPBB, hA.supportProj_kronecker hB]
-  have hρc : ρc.PosSemidef := by
-    exact hρ.conjTranspose_mul_mul_same V
+      hRangeA, hRangeB, hA.supportProj_kronecker hB]
+  have hρc : ρc.PosSemidef := hρ.conjTranspose_mul_mul_same V
+  have hreconstruct : V * ρc * Vᴴ = ρ := by
+    simpa only [V, ρc] using
+      hρ.eq_marginalSupport_expansion_compression VA VB hRangeA hRangeB
+  have hρP : ρ * (hA.kronecker hB).supportProj = ρ := by
+    rw [← hRange, ← hreconstruct]
+    simp only [Matrix.mul_assoc]
+    rw [← Matrix.mul_assoc Vᴴ V, hV, Matrix.one_mul]
   have hMarginals :
-      (partialTraceRight ρc).PosDef ∧ (partialTraceLeft ρc).PosDef := by
-    exact hρ.marginalSupport_compression_marginals_posDef
-      VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
-  have hMargA : partialTraceRight ρc = VAᴴ * partialTraceRight ρ * VA := by
-    exact hρ.partialTraceRight_marginalSupport_compression
-      VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
-  have hMargB : partialTraceLeft ρc = VBᴴ * partialTraceLeft ρ * VB := by
-    exact hρ.partialTraceLeft_marginalSupport_compression
-      VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
+      (partialTraceRight ρc).PosDef ∧ (partialTraceLeft ρc).PosDef :=
+    hρ.marginalSupport_compression_marginals_posDef
+      VA VB hVA hVB hRangeA hRangeB
+  have hMargA : partialTraceRight ρc = VAᴴ * partialTraceRight ρ * VA :=
+    hρ.partialTraceRight_marginalSupport_compression
+      VA VB hVA hVB hRangeA hRangeB
+  have hMargB : partialTraceLeft ρc = VBᴴ * partialTraceLeft ρ * VB :=
+    hρ.partialTraceLeft_marginalSupport_compression
+      VA VB hVA hVB hRangeA hRangeB
   let ω := partialTraceRight ρ ⊗ₖ partialTraceLeft ρ
   have hω : ω.PosSemidef := hA.kronecker hB
-  have hρPA : ρ * (PA ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) = ρ := by
-    simpa only [PA, Matrix.leftKroneckerEmbed_apply] using
-      hρ.mul_leftKroneckerEmbed_supportProj_self
-  have hρPB : ρ * ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ PB) = ρ := by
-    simpa only [PB, Matrix.rightKroneckerEmbed_apply] using
-      hρ.mul_rightKroneckerEmbed_supportProj_self
-  have hρP : ρ * (PA ⊗ₖ PB) = ρ := by
-    rw [show PA ⊗ₖ PB = ((1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ PB) *
-        (PA ⊗ₖ (1 : Matrix (Fin dB) (Fin dB) ℂ)) by
-      rw [← Matrix.mul_kronecker_mul, Matrix.one_mul, Matrix.mul_one]]
-    rw [← Matrix.mul_assoc, hρPB, hρPA]
   have hker : ∀ v : Fin dA × Fin dB → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0 := by
     intro v hv
     have hPv := hω.supportProj_mulVec_eq_zero_of_mulVec_eq_zero v hv
-    have hsupport : hω.supportProj = PA ⊗ₖ PB := by
-      calc
-        hω.supportProj = (hA.kronecker hB).supportProj :=
-          hω.supportProj_congr (hA.kronecker hB) rfl
-        _ = hA.supportProj ⊗ₖ hB.supportProj := hA.supportProj_kronecker hB
-        _ = PA ⊗ₖ PB := by rw [hPAA, hPBB]
+    have hsupport : hω.supportProj = (hA.kronecker hB).supportProj :=
+      hω.supportProj_congr (hA.kronecker hB) rfl
     rw [hsupport] at hPv
     rw [← hρP, ← Matrix.mulVec_mulVec, hPv, Matrix.mulVec_zero]
   have hωc : Vᴴ * ω * V = partialTraceRight ρc ⊗ₖ partialTraceLeft ρc := by
@@ -154,7 +94,7 @@ theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank
   have hQ2 := sandwichedRenyiTwoTrace_support_compression
     hρ hω hker V hV hRange
   have hOSR := hρ.operatorSchmidtRank_marginalSupport_compression
-    VA VB hVA hVB (by simpa only [PA] using hRangeA) (by simpa only [PB] using hRangeB)
+    VA VB hVA hVB hRangeA hRangeB
   calc
     sandwichedRenyiTwoTrace ρ
         (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) =
@@ -165,7 +105,6 @@ theorem sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank
     _ ≤ Matrix.operatorSchmidtRank ρc :=
       sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef
         ρc hρc hMarginals.1 hMarginals.2
-    _ = Matrix.operatorSchmidtRank ρ := by
-      exact_mod_cast hOSR
+    _ = Matrix.operatorSchmidtRank ρ := by exact_mod_cast hOSR
 
 end TNLean

--- a/TNLean/Channel/WhitenedChoi.lean
+++ b/TNLean/Channel/WhitenedChoi.lean
@@ -357,7 +357,9 @@ Theorem 6, equation (18), with the rectangular Choi rank estimate.
 **Scope restriction (faithful marginal supports):** Both marginals are
 positive definite in the displayed coordinates.  The arbitrary-basis result
 follows by unitary diagonalization, and simultaneous compression to both
-marginal supports gives the singular-marginal result. -/
+marginal supports gives the singular-marginal result.  This restriction and
+its removal are recorded in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)
@@ -401,7 +403,8 @@ arXiv:1306.5920, Theorem 6, equation (18).
 **Scope restriction (faithful marginal supports):** This eigenbasis statement
 is the faithful core.  Unitary diagonalization gives the arbitrary-basis
 version, and simultaneous support compression gives the singular-marginal
-version. -/
+version.  This restriction and its removal are recorded in
+`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
 theorem supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)

--- a/TNLean/Channel/WhitenedChoi.lean
+++ b/TNLean/Channel/WhitenedChoi.lean
@@ -355,11 +355,9 @@ This combines the `p = 2` contraction from Beigi, arXiv:1306.5920,
 Theorem 6, equation (18), with the rectangular Choi rank estimate.
 
 **Scope restriction (faithful marginal supports):** Both marginals are
-positive definite in the displayed coordinates.  Two-sided compression of
-singular ambient marginals, including preservation of operator-Schmidt rank,
-and construction of the output support corner are distinct remaining steps,
-as recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+positive definite in the displayed coordinates.  The arbitrary-basis result
+follows by unitary diagonalization, and simultaneous compression to both
+marginal supports gives the singular-marginal result. -/
 theorem supportedMarginalWhitenedState_frobenius_sq_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)
@@ -400,10 +398,10 @@ trace of its square is at most its operator-Schmidt rank.
 This is the trace-square form of the order-two estimate used after Beigi,
 arXiv:1306.5920, Theorem 6, equation (18).
 
-**Scope restriction (faithful marginal supports):** The two-sided compression
-from singular ambient marginals to their supports, including preservation of
-operator-Schmidt rank, remains to be proved as recorded in
-`docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex`. -/
+**Scope restriction (faithful marginal supports):** This eigenbasis statement
+is the faithful core.  Unitary diagonalization gives the arbitrary-basis
+version, and simultaneous support compression gives the singular-marginal
+version. -/
 theorem supportedMarginalWhitenedState_trace_sq_re_le_operatorSchmidtRank
     (ρ : Matrix (α × β) (α × β) ℂ) (p : α → ℝ)
     (hρ : ρ.PosSemidef) (hp : ∀ i, 0 < p i)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -746,8 +746,7 @@
     star-algebra automorphism. Continuity of $f$ is needed only on the finite
     spectrum of $A$, where it is automatic. The logarithm, real-power, and
     square-root identities follow by specialization. For the support
-    projection, specialize to the function that is one away from zero and zero
-    at zero.
+    projection, specialize to $f(x)=1$ for $x\neq0$ and $f(0)=0$.
 \end{proof}
 
 \begin{theorem}[Logarithm of a tensor product on its support]
@@ -1361,7 +1360,7 @@ terms of operator-Schmidt rank.
 
 \begin{theorem}[Faithful marginal whitening bound]
     \label{thm:sandwiched_renyi_two_osr_faithful}
-    \lean{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef}
+    \lean{TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank_of_marginals_posDef}
     \leanok
     \uses{def:sandwiched_renyi_two_trace,
       def:bipartite_operator_schmidt_rank}
@@ -1400,7 +1399,7 @@ terms of operator-Schmidt rank.
 
 \begin{theorem}[Marginal-support whitening bound]
     \label{thm:sandwiched_renyi_two_osr_support}
-    \lean{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank}
+    \lean{TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank}
     \leanok
     \uses{def:sandwiched_renyi_two_trace,
       def:bipartite_operator_schmidt_rank}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -1364,13 +1364,7 @@ terms of operator-Schmidt rank.
     \lean{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef}
     \leanok
     \uses{def:sandwiched_renyi_two_trace,
-      def:bipartite_operator_schmidt_rank,
-      lem:partial_trace_product_isometry,
-      thm:operator_schmidt_rank_local_isometry,
-      thm:full_support_eigenbasis_whitened_choi_bound,
-      thm:rpow_kronecker_possemidef,
-      thm:rpow_neg_quarter_inv_sqrt_sqrt,
-      thm:sandwiched_renyi_two_unitary_invariance}
+      def:bipartite_operator_schmidt_rank}
     Let $\rho_{AB}\succeq0$ have positive definite marginals $\rho_A$ and
     $\rho_B$. Then
     \begin{align}
@@ -1408,10 +1402,8 @@ terms of operator-Schmidt rank.
     \label{thm:sandwiched_renyi_two_osr_support}
     \lean{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank}
     \leanok
-    \uses{thm:sandwiched_renyi_two_osr_faithful,
-      thm:sandwiched_renyi_two_support_compression,
-      thm:operator_schmidt_rank_marginal_support_compression,
-      thm:faithful_marginals_support_compression}
+    \uses{def:sandwiched_renyi_two_trace,
+      def:bipartite_operator_schmidt_rank}
     Let $\rho_{AB}\succeq0$ be any finite-dimensional bipartite operator. Then
     \begin{align}
       Q_2(\rho_{AB},\rho_A\otimes\rho_B)
@@ -1424,7 +1416,9 @@ terms of operator-Schmidt rank.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:sandwiched_renyi_two_osr_faithful,
+    \uses{def:sandwiched_renyi_two_trace,
+      def:bipartite_operator_schmidt_rank,
+      thm:sandwiched_renyi_two_osr_faithful,
       thm:sandwiched_renyi_two_support_compression,
       thm:operator_schmidt_rank_marginal_support_compression,
       thm:faithful_marginals_support_compression}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -1284,6 +1284,162 @@ terms of operator-Schmidt rank.
     The rectangular Choi range-dimension estimate now proves the claim.
 \end{proof}
 
+\begin{theorem}[Real powers under unitary conjugation]
+    \label{thm:rpow_conj_unitary}
+    \lean{Matrix.rpow_conj_unitary}
+    \leanok
+    \uses{lem:cfc_conj_unitary}
+    Let $A\succeq0$, let $s\in\R$, and let $U$ be unitary. Then
+    \begin{align}
+      (UAU^\dagger)^s&=UA^sU^\dagger.
+      \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:cfc_conj_unitary}
+    Apply Lemma~\ref{lem:cfc_conj_unitary} to the function $x\mapsto x^s$.
+\end{proof}
+
+\begin{theorem}[Real powers of positive tensor products]
+    \label{thm:rpow_kronecker_possemidef}
+    \lean{Matrix.PosSemidef.rpow_kronecker}
+    \leanok
+    \uses{thm:multiplicative_functional_calculus_tensor_product}
+    Let $A\succeq0$ and $B\succeq0$. For every $s\in\R$,
+    \begin{align}
+      (A\otimes B)^s&=A^s\otimes B^s.
+      \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:multiplicative_functional_calculus_tensor_product}
+    Apply
+    Theorem~\ref{thm:multiplicative_functional_calculus_tensor_product} to
+    $x\mapsto x^s$, using $(xy)^s=x^sy^s$ for $x,y\geq0$.
+\end{proof}
+
+\begin{theorem}[Inverse quarter-power from iterated square roots]
+    \label{thm:rpow_neg_quarter_inv_sqrt_sqrt}
+    \lean{Matrix.PosDef.rpow_neg_quarter_eq_inv_sqrt_sqrt}
+    \leanok
+    If $A\succ0$, then
+    \begin{align}
+      A^{-1/4}&=\left(\sqrt{\sqrt A}\right)^{-1}.
+      \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    The continuous functional calculus gives
+    $\sqrt{\sqrt A}=A^{1/4}$. Positive definiteness makes this matrix
+    invertible, and inversion changes the exponent from $1/4$ to $-1/4$.
+\end{proof}
+
+\begin{theorem}[Unitary invariance of the order-two functional]
+    \label{thm:sandwiched_renyi_two_unitary_invariance}
+    \lean{TNLean.sandwichedRenyiTwoTrace_conj_unitary}
+    \leanok
+    \uses{def:sandwiched_renyi_two_trace, thm:rpow_conj_unitary}
+    Let $\omega\succeq0$, let $\rho$ be a square matrix of the same size, and
+    let $U$ be unitary. Then
+    \begin{align}
+      Q_2(U\rho U^\dagger,U\omega U^\dagger)
+      &=Q_2(\rho,\omega).
+      \notag
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:rpow_conj_unitary}
+    Theorem~\ref{thm:rpow_conj_unitary} gives
+    $(U\omega U^\dagger)^{-1/4}=U\omega^{-1/4}U^\dagger$.
+    Substitute this identity into both sandwiching factors and use
+    $U^\dagger U=1$ and cyclicity of the trace.
+\end{proof}
+
+\begin{theorem}[Faithful marginal whitening bound]
+    \label{thm:sandwiched_renyi_two_osr_faithful}
+    \lean{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef}
+    \leanok
+    \uses{def:sandwiched_renyi_two_trace,
+      def:bipartite_operator_schmidt_rank,
+      lem:partial_trace_product_isometry,
+      thm:operator_schmidt_rank_local_isometry,
+      thm:full_support_eigenbasis_whitened_choi_bound,
+      thm:rpow_kronecker_possemidef,
+      thm:rpow_neg_quarter_inv_sqrt_sqrt,
+      thm:sandwiched_renyi_two_unitary_invariance}
+    Let $\rho_{AB}\succeq0$ have positive definite marginals $\rho_A$ and
+    $\rho_B$. Then
+    \begin{align}
+      Q_2(\rho_{AB},\rho_A\otimes\rho_B)
+      &\leq\operatorname{OSR}(\rho_{AB}).
+      \label{eq:mpdo_faithful_q2_osr}
+    \end{align}
+    No trace normalization is required.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:partial_trace_product_isometry,
+      thm:operator_schmidt_rank_local_isometry,
+      thm:full_support_eigenbasis_whitened_choi_bound,
+      thm:rpow_kronecker_possemidef,
+      thm:rpow_neg_quarter_inv_sqrt_sqrt,
+      thm:sandwiched_renyi_two_unitary_invariance}
+    Choose a unitary $U$ that diagonalizes the first marginal and conjugate
+    $\rho_{AB}$ by $U^\dagger\otimes1$. The two marginals become
+    $\diag(p_i)$ and $\rho_B$, while positivity and operator-Schmidt rank are
+    unchanged. The transpose in the Choi whitening convention becomes
+    invisible only in this eigenbasis, since $\diag(p_i)^T=\diag(p_i)$.
+
+    Theorems~\ref{thm:rpow_kronecker_possemidef} and
+    \ref{thm:rpow_neg_quarter_inv_sqrt_sqrt} identify the negative
+    quarter-power of the product marginal with the two whitening factors in
+    Theorem~\ref{thm:full_support_eigenbasis_whitened_choi_bound}. That theorem
+    bounds the squared whitened trace by the ordinary operator-Schmidt rank.
+    Finally, Theorem~\ref{thm:sandwiched_renyi_two_unitary_invariance} and the
+    invariance of operator-Schmidt rank under local unitaries return
+    to the original basis.
+\end{proof}
+
+\begin{theorem}[Marginal-support whitening bound]
+    \label{thm:sandwiched_renyi_two_osr_support}
+    \lean{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank}
+    \leanok
+    \uses{thm:sandwiched_renyi_two_osr_faithful,
+      thm:sandwiched_renyi_two_support_compression,
+      thm:operator_schmidt_rank_marginal_support_compression,
+      thm:faithful_marginals_support_compression}
+    Let $\rho_{AB}\succeq0$ be any finite-dimensional bipartite operator. Then
+    \begin{align}
+      Q_2(\rho_{AB},\rho_A\otimes\rho_B)
+      &\leq\operatorname{OSR}(\rho_{AB}).
+      \label{eq:mpdo_support_q2_osr}
+    \end{align}
+    No trace normalization or positive-dimension hypothesis is required. The
+    statement includes the cases in which either marginal support has
+    dimension zero.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:sandwiched_renyi_two_osr_faithful,
+      thm:sandwiched_renyi_two_support_compression,
+      thm:operator_schmidt_rank_marginal_support_compression,
+      thm:faithful_marginals_support_compression}
+    Compress both factors simultaneously to the supports of $\rho_A$ and
+    $\rho_B$. The compressed marginals are positive definite by
+    Theorem~\ref{thm:faithful_marginals_support_compression}, even when a
+    support coordinate space has dimension zero. The order-two functional is
+    unchanged by
+    Theorem~\ref{thm:sandwiched_renyi_two_support_compression}, and the
+    ordinary operator-Schmidt rank is unchanged by
+    Theorem~\ref{thm:operator_schmidt_rank_marginal_support_compression}.
+    Apply Theorem~\ref{thm:sandwiched_renyi_two_osr_faithful} to the compressed
+    operator.
+\end{proof}
+
 The sandwiched R\'enyi comparison also uses the following unnormalized
 trace term.  For trace-one $\rho$ and $\alpha>1$, it is the quantity inside the
 logarithm of the sandwiched R\'enyi divergence
@@ -1392,50 +1548,25 @@ logarithmic divergence, or a comparison with relative entropy.
         \leq \log\operatorname{OSR}(\rho_{AB}).
         \notag
     \end{align}
-    The mathematical inequality is established, but its formal verification is
-    not yet complete.
-    % Formalization is tracked by issues #5211, #5212, and #5213.
+    % Formalization is tracked by issue #5212.
 \end{theorem}
 \begin{proof}
     \uses{thm:relative_entropy_q2_support,
-      thm:operator_schmidt_rank_marginal_support_compression,
-      thm:faithful_marginals_support_compression,
-      thm:full_support_eigenbasis_whitened_choi_bound}
+      thm:sandwiched_renyi_two_osr_support}
     Set $\omega=\rho_A\otimes\rho_B$. Positivity gives
-    $\ker\omega\subseteq\ker\rho_{AB}$, so
-    Theorem~\ref{thm:relative_entropy_q2_support} gives
-    $D(\rho_{AB}\Vert\omega)\leq\log Q_2(\rho_{AB},\omega)$ directly.
-    To relate the order-two functional to operator-Schmidt rank, compress the
-    two tensor factors separately to the supports of $\rho_A$ and $\rho_B$.
-    Theorem~\ref{thm:operator_schmidt_rank_marginal_support_compression}
-    shows that this simultaneous local compression reconstructs the original
-    operator and preserves operator-Schmidt rank. By
-    Theorem~\ref{thm:faithful_marginals_support_compression}, its two marginals
-    are faithful.
-
-    In the resulting faithful spaces, write $\sigma=\rho_A$ and
-    $\tau=\rho_B$. Choose an eigenbasis of $\sigma$, and set
+    $\ker\omega\subseteq\ker\rho_{AB}$, and the two matrices have trace one.
+    Therefore
     \begin{align}
-        W=(\sigma^T\otimes\tau)^{-1/4}\rho_{AB}
-          (\sigma^T\otimes\tau)^{-1/4}.
-        \notag
+      I(A:B)_\rho
+      &=D(\rho_{AB}\Vert\omega) \\
+      &\leq\log Q_2(\rho_{AB},\omega) \\
+      &\leq\log\operatorname{OSR}(\rho_{AB}).
+      \notag
     \end{align}
-    The full-support eigenbasis estimate gives
-    \begin{align}
-        \tr(W^2)=\|W\|_F^2
-        \leq\operatorname{OSR}(\rho_{AB}).
-        \notag
-    \end{align}
-    Theorem~\ref{thm:relative_entropy_q2_support} and the whitened
-    estimate now give
-    \begin{align}
-        I(A:B)_\rho
-        =D(\rho_{AB}\Vert\rho_A\otimes\rho_B)
-        \leq\log\tr(W^2)
-        \leq\log\operatorname{OSR}(\rho_{AB}),
-        \notag
-    \end{align}
-    which proves the result.
+    The first inequality is
+    Theorem~\ref{thm:relative_entropy_q2_support}; the second follows from
+    Theorem~\ref{thm:sandwiched_renyi_two_osr_support} and monotonicity of the
+    logarithm.
 \end{proof}
 
 \begin{remark}[Boundedness of the mutual information]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -580,8 +580,8 @@
 
 % Issues #5229, #5241, and #5245 establish one- and two-marginal support
 % compression, including preservation of operator-Schmidt rank and
-% faithfulness of both compressed marginals.  The remaining analytic and
-% integration steps are tracked in #5211.
+% faithfulness of both compressed marginals.  Issue #5211 combines these
+% results with the whitened-Choi estimate; #5212 tracks mutual information.
 
 \begin{definition}[Isometric conjugation into a larger matrix algebra]
     \label{def:isometric_nonunital_conjugation}

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -430,9 +430,9 @@ theorem there, and returns using exact preservation of $Q_2$ and ordinary
 operator-Schmidt rank.  It includes zero-dimensional support coordinates and
 requires no trace normalization.
 \footnote{Formal declarations:
-\leanid{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef}
+\leanid{TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank_of_marginals_posDef}
 in \doclink{TNLean/Channel/FaithfulMarginalWhitenedChoi}, and
-\leanid{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank}
+\leanid{TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank}
 in \doclink{TNLean/Channel/MarginalSupportWhitenedChoi}.}
 Thus the mathematical work tracked by
 \href{https://github.com/LionSR/TNLean/issues/5211}{\#5211} is complete.  The

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -364,11 +364,8 @@ The one-sided output-support compression is also formalized: faithfulness of
 the input weight forces every channel output into the support of its image,
 the compressed channel is trace preserving, and the support-restricted
 negative quarter power agrees with the ordinary negative quarter power after
-compression.  Simultaneous compression from singular ambient marginals to
-both support algebras is formalized below.  The eigenbasis whitening statements
-still assume both marginal weights are positive definite, so their application
-to the compressed operator remains part of the argument tracked in
-\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.
+compression.  Simultaneous compression to both marginal supports is used in
+the arbitrary-support estimate below.
 
 The unnormalized sandwiched R\'enyi trace term
 \[
@@ -401,11 +398,10 @@ monotonicity in $\alpha$, interpolation between orders one and two,
 differentiability or a limit at $\alpha=1$, the logarithmic sandwiched R\'enyi
 divergence, nor a comparison with Umegaki relative entropy.
 
-Neither development completes
-\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211}.  Simultaneous
-compression by the two marginal support isometries, exact reconstruction,
-preservation of operator-Schmidt rank, the exact formulas for the compressed
-marginals, and their positive definiteness are now formalized.
+Simultaneous compression by the two marginal support isometries, exact
+reconstruction, preservation of ordinary operator-Schmidt rank, the exact
+formulas for the compressed marginals, and their positive definiteness are
+formalized.
 \footnote{Formal declarations:
 \leanid{Matrix.PosSemidef.eq_marginalSupport_expansion_compression},
 \leanid{Matrix.PosSemidef.operatorSchmidtRank_marginalSupport_compression},
@@ -419,12 +415,31 @@ The mathematical tasks tracked in
 faithful and singular relative-entropy comparisons are proved using the
 relative-modular half-moment, support-aware Jensen, and Hilbert--Schmidt
 Cauchy--Schwarz, without a general weighted interpolation theorem or an
-order-one limit.  The remaining work in
-\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211} is to apply the
-existing full-support whitened-state/Choi identification and Hilbert--Schmidt
-rank estimate after simultaneous marginal-support compression.  The
-unrestricted sharp mutual-information theorem remains tracked in
-\href{https://github.com/LionSR/TNLean/issues/5212}{\#5212}.
+order-one limit.
+
+The faithful marginal-whitening theorem now diagonalizes the first marginal,
+where the input transpose from the Choi convention agrees with the diagonal
+marginal, and proves
+\[
+  Q_2(\rho_{AB},\rho_A\otimes\rho_B)
+  \leq\operatorname{OSR}(\rho_{AB})
+\]
+when both marginals are positive definite.  The arbitrary-support theorem
+compresses simultaneously to the two marginal supports, applies the faithful
+theorem there, and returns using exact preservation of $Q_2$ and ordinary
+operator-Schmidt rank.  It includes zero-dimensional support coordinates and
+requires no trace normalization.
+\footnote{Formal declarations:
+\leanid{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank_of_posDef}
+in \doclink{TNLean/Channel/FaithfulMarginalWhitenedChoi}, and
+\leanid{TNLean.sandwichedRenyiTwoTrace_partialTraces_kronecker_le_operatorSchmidtRank}
+in \doclink{TNLean/Channel/MarginalSupportWhitenedChoi}.}
+Thus the mathematical work tracked by
+\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211} is complete.  The
+unrestricted mutual-information inequality remains the downstream task in
+\href{https://github.com/LionSR/TNLean/issues/5212}{\#5212}; its application to
+the finite-chain MPO estimate remains tracked by
+\href{https://github.com/LionSR/TNLean/issues/5213}{\#5213}.
 
 \section{Diagonal matrix product operators}
 


### PR DESCRIPTION
## What changed

- prove the faithful arbitrary-basis bound
  \[
  \widetilde Q_2\!\left(\rho\middle\|\rho_A\otimes\rho_B\right)
  \le \operatorname{OSR}(\rho)
  \]
  by diagonalizing the first marginal, applying the existing whitened-Choi Hilbert--Schmidt estimate, and transporting the exact order-two functional and ordinary operator-Schmidt rank through the local unitary;
- prove the same bound for arbitrary positive-semidefinite bipartite operators by simultaneous compression to both marginal supports, including zero-dimensional support spaces;
- expose the reusable real-power, unitary-covariance, and support-compression identities at their natural Analysis layer and reuse the packaged marginal-support range isometries;
- synchronize Chapter 21 and the mutual-information gap record, marking the mathematical work of #5211 complete while leaving #5212 and #5213 open.

The Choi input transpose is removed only after the first marginal is put in its diagonal eigenbasis. The rank is ordinary operator-Schmidt rank, not state rank, Choi/Kraus rank, Schmidt number, or purification rank. No trace normalization or positive-dimension assumption is needed for these capstones.

## Validation

- full `lake build` — 9866 jobs;
- targeted Analysis/Channel and `TNLean.Channel` builds;
- explicit `Fin 0 × Fin 0`, `Fin 0 × Fin 3`, and `Fin 3 × Fin 0` elaboration tests;
- kernel-axiom checks: only `propext`, `Classical.choice`, and `Quot.sound`;
- generated import aggregators: 48 files covering 1159 production modules;
- Blueprint declaration regeneration, synchronization, and `leanblueprint checkdecls`;
- double LuaLaTeX with `TEXINPUTS='../../tex/tenkz//:'`: 823 pages, zero undefined cross-references or multiply-defined labels;
- proof-integrity, module-policy, prose, label, and `git diff --check` gates.

Closes #5211.
Advances #4295 and #4169.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are formal Lean proofs and blueprint/documentation sync in matrix analysis and channel theory; no runtime services, auth, or data paths are touched.
> 
> **Overview**
> This PR finishes the **marginal-product whitening → operator-Schmidt rank** chain for the order-two sandwiched trace \(Q_2(\rho,\rho_A\otimes\rho_B)\), closing the analytic gap tracked as #5211.
> 
> **Analysis layer:** Real powers now **commute with unitary conjugation** (`Matrix.rpow_conj_unitary`, moved from Lieb) and **factor across PSD Kronecker products** (`PosSemidef.rpow_kronecker`). **PosDef** matrices get \(A^{-1/4} = (\sqrt{\sqrt A})^{-1}\). **`sandwichedRenyiTwoTrace`** is generalized to arbitrary `Fintype` indices and gains **simultaneous unitary invariance**; support-compression lemmas are generalized beyond `Fin D`.
> 
> **Channel capstones:** **`FaithfulMarginalWhitenedChoi`** diagonalizes the first marginal, reuses the eigenbasis whitened-Choi trace bound, and transports \(Q_2\) and OSR by local unitary. **`MarginalSupportWhitenedChoi`** compresses to both marginal supports (including zero-dimensional supports), applies the faithful theorem on compressed faithful marginals, and restores the original operator.
> 
> **Docs:** Chapter 21 and the mutual-information gap note record the new theorems; the mutual-information proof is shortened to relative-entropy vs. \(Q_2\) plus the new OSR bound, with #5212/#5213 still open downstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e21f0f15a45a03d87f65eb9b4ed35ced44ec32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->