### PR TITLE
doc(tenkz): clarify transported physical faces

### DIFF
--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -205,8 +205,8 @@ kernel-\allowbreak{}atom & \texttt{wires} & positive-\allowbreak{}integer & 1 & 
 kernel-\allowbreak{}atom & \texttt{at} & address & next \allowbreak{}chain \allowbreak{}cell & Placement \allowbreak{}address. \\
 kernel-\allowbreak{}atom & \texttt{name} & identifier & generated & Addressable \allowbreak{}name. \\
 kernel-\allowbreak{}atom & \texttt{ports} & typed-\allowbreak{}port-\allowbreak{}list & from \allowbreak{}skin & Typed \allowbreak{}faces \allowbreak{}and \allowbreak{}slots. \\
-kernel-\allowbreak{}atom & \texttt{up} & math-\allowbreak{}list & empty & Outward \allowbreak{}physical \allowbreak{}labels,\allowbreak{} \allowbreak{}page-\allowbreak{}up. \\
-kernel-\allowbreak{}atom & \texttt{down} & math-\allowbreak{}list & empty & Outward \allowbreak{}physical \allowbreak{}labels,\allowbreak{} \allowbreak{}page-\allowbreak{}down. \\
+kernel-\allowbreak{}atom & \texttt{up} & math-\allowbreak{}list & empty & Physical \allowbreak{}labels \allowbreak{}on \allowbreak{}local \allowbreak{}north \allowbreak{}faces,\allowbreak{} \allowbreak{}transported \allowbreak{}by \allowbreak{}the \allowbreak{}carrier. \\
+kernel-\allowbreak{}atom & \texttt{down} & math-\allowbreak{}list & empty & Physical \allowbreak{}labels \allowbreak{}on \allowbreak{}local \allowbreak{}south \allowbreak{}faces,\allowbreak{} \allowbreak{}transported \allowbreak{}by \allowbreak{}the \allowbreak{}carrier. \\
 kernel-\allowbreak{}atom & \texttt{species} & declared-\allowbreak{}name & empty & Semantic \allowbreak{}species. \\
 kernel-\allowbreak{}atom & \texttt{pairing~cross} & indexed-\allowbreak{}crossing-\allowbreak{}list & empty & Per-\allowbreak{}instance \allowbreak{}crossings \allowbreak{}of \allowbreak{}generated \allowbreak{}skin \allowbreak{}pairings. \\
 kernel-\allowbreak{}atom & \texttt{size} & size-\allowbreak{}class & m & Per-\allowbreak{}atom \allowbreak{}metric \allowbreak{}size \allowbreak{}class. \\

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -305,7 +305,7 @@ python3 "$REPO/scripts/tenkz_audit.py" \
   exit 1
 }
 [ "$(grep -c 'check|relation=1|result=equal' \
-      "$WORK/r_physical_port_signature_equiv.tnlog" || true)" -eq 5 ] || {
+      "$WORK/r_physical_port_signature_equiv.tnlog" || true)" -eq 7 ] || {
   echo "FAIL: physical policy sugar diverged from explicit typed ports" >&2
   exit 1
 }

--- a/tests/tenkz/kernel/regression/r_physical_port_signature_equiv.tex
+++ b/tests/tenkz/kernel/regression/r_physical_port_signature_equiv.tex
@@ -19,6 +19,26 @@
   \end{tenkz}
 \end{tenkzeq}
 \begin{tenkzeq}[check={signature}]
+  \begin{tenkz}[
+      rows={wire}, cols=1, frame=plane, bonds=none, physical=up]
+    \tn[at=(1,1)]{}
+  \end{tenkz}
+  =
+  \begin{tenkz}[rows={wire}, cols=1, frame=plane, bonds=none]
+    \tn[at=(1,1), ports={90:physical}]{}
+  \end{tenkz}
+\end{tenkzeq}
+\begin{tenkzeq}[check={signature}]
+  \begin{tenkz}[
+      rows={wire}, cols=4, frame=circle, bonds=none, physical=up]
+    \tn[at=(1,2)]{}
+  \end{tenkz}
+  =
+  \begin{tenkz}[rows={wire}, cols=4, frame=circle, bonds=none]
+    \tn[at=(1,2), ports={90:physical}]{}
+  \end{tenkz}
+\end{tenkzeq}
+\begin{tenkzeq}[check={signature}]
   \begin{tenkz}[rows={wire}, cols=1, bonds=none]
     \tn[at=(1,1), ports={359.9999999:physical}]{}
   \end{tenkz}

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -290,8 +290,8 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{at}{address}{next chain cell}{kernel}{Placement address.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{name}{identifier}{generated}{kernel}{Addressable name.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{ports}{typed-port-list}{from skin}{kernel}{Typed faces and slots.}
-\__tenkz_language_registry_key:nnnnnn {kernel-atom}{up}{math-list}{empty}{kernel}{Outward physical labels, page-up.}
-\__tenkz_language_registry_key:nnnnnn {kernel-atom}{down}{math-list}{empty}{kernel}{Outward physical labels, page-down.}
+\__tenkz_language_registry_key:nnnnnn {kernel-atom}{up}{math-list}{empty}{kernel}{Physical labels on local north faces, transported by the carrier.}
+\__tenkz_language_registry_key:nnnnnn {kernel-atom}{down}{math-list}{empty}{kernel}{Physical labels on local south faces, transported by the carrier.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{species}{declared-name}{empty}{kernel}{Semantic species.}
 % Extension-gate: #5009 -- crossings with picture-external wires belong to
 % each placed atom, while pairings= remains reusable skin topology.


### PR DESCRIPTION
## Summary

- replace stale page-up/page-down registry prose with local north/south carrier-transported semantics
- regenerate the public language reference from the registry
- extend policy-versus-explicit physical-port equivalence to sheared plane and circle carriers

This resolves the semantic fork found while designing physical-leg lanes: kernel physical policy follows the same carrier-local face contract as explicit typed ports. The older page-vertical lattice behavior is a retiring dialect convention, not the kernel contract.

Tracks LionSR/tenkz#113.

## Validation

- focused physical-port signature fixture: 7 equalities
- scripts/tenkz_kernel_probes.sh
- python3 scripts/tenkz_language.py check
- python3 scripts/test_tenkz_shrink.py
- tenkz lint on changed TeX/reference files

Kernel record streams and pixels remain byte-identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and regression fixtures only; PR description states kernel record streams and pixels stay byte-identical.
> 
> **Overview**
> **Documents** the kernel contract for **`up`** and **`down`**: registry and generated language reference now describe **physical labels on local north/south faces, transported by the carrier**, replacing **page-up/page-down** wording so policy matches explicit typed physical ports.
> 
> **Extends** `r_physical_port_signature_equiv` with **sheared `frame=plane`** and **`frame=circle`** cases where **`physical=up`** must signature-match **`ports={90:physical}`**, and bumps **`tenkz_kernel_probes.sh`** to expect **7** equal checks (was 5). No kernel implementation changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a8883bb071cd13f1d75fa9761445ea71b07db2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->