### PR TITLE
refactor(tenkz): expose record carrier bases

### DIFF
--- a/tests/tenkz/kernel/regression/r_record_carrier_basis.tex
+++ b/tests/tenkz/kernel/regression/r_record_carrier_basis.tex
@@ -1,0 +1,162 @@
+% Regression: one record-level service exposes the complete carrier basis and
+% its dual for plane, flat, circle, cluster-child, and page-space atoms.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\int_new:N \l__tenkz_test_basis_count_int
+\tl_new:N \l__tenkz_test_basis_name_tl
+\cs_new_eq:NN
+  \__tenkz_test_basis_atom_glyph_ink:n
+  \__tenkz_kernel_r_atom_glyph_ink:n
+\cs_set_protected:Npn \__tenkz_kernel_r_atom_glyph_ink:n #1
+  {
+    \__tenkz_model_get:nnN {#1} {name} \l__tenkz_test_basis_name_tl
+    \quark_if_no_value:NF \l__tenkz_test_basis_name_tl
+      {
+        \str_case:Vn \l__tenkz_test_basis_name_tl
+          {
+            {G-1-1}{ \__tenkz_test_basis_plane:n {#1} }
+            {A}{ \__tenkz_test_basis_plane:n {#1} }
+            {K}{ \__tenkz_test_basis_plane:n {#1} }
+            {B}{ \__tenkz_test_basis_plane:n {#1} }
+            {M}{ \__tenkz_test_basis_page:n {#1} }
+            {F}{ \__tenkz_test_basis_page:n {#1} }
+            {C}{ \__tenkz_test_basis_circle:n {#1} }
+          }
+      }
+    \__tenkz_test_basis_atom_glyph_ink:n {#1}
+  }
+\cs_new_protected:Npn \__tenkz_test_basis_read:n #1
+  {
+    \int_gincr:N \l__tenkz_test_basis_count_int
+    \__tenkz_kernel_r_carrier_basis:n {#1}
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_basis_ux_tl
+            * \l__tenkz_kernel_r_basis_ex_tl
+          + \l__tenkz_kernel_r_basis_uy_tl
+            * \l__tenkz_kernel_r_basis_ey_tl - 1 )
+      }
+      < {0.000001}
+      { \errmessage{the~east~dual~does~not~read~the~east~basis} }
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_basis_ux_tl
+            * \l__tenkz_kernel_r_basis_nx_tl
+          + \l__tenkz_kernel_r_basis_uy_tl
+            * \l__tenkz_kernel_r_basis_ny_tl )
+      }
+      < {0.000001}
+      { \errmessage{the~east~dual~does~not~annihilate~the~north~basis} }
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_basis_vx_tl
+            * \l__tenkz_kernel_r_basis_ex_tl
+          + \l__tenkz_kernel_r_basis_vy_tl
+            * \l__tenkz_kernel_r_basis_ey_tl )
+      }
+      < {0.000001}
+      { \errmessage{the~north~dual~does~not~annihilate~the~east~basis} }
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_basis_vx_tl
+            * \l__tenkz_kernel_r_basis_nx_tl
+          + \l__tenkz_kernel_r_basis_vy_tl
+            * \l__tenkz_kernel_r_basis_ny_tl - 1 )
+      }
+      < {0.000001}
+      { \errmessage{the~north~dual~does~not~read~the~north~basis} }
+  }
+\cs_new_protected:Npn \__tenkz_test_basis_plane:n #1
+  {
+    \__tenkz_test_basis_read:n {#1}
+    \bool_if:NF \l__tenkz_kernel_r_basis_plane_bool
+      { \errmessage{a~plane~carrier~lost~its~declared~frame~kind} }
+    \fp_compare:nNnF
+      { abs(\l__tenkz_kernel_r_basis_ex_tl - 1) } < {0.000001}
+      { \errmessage{a~plane~carrier~lost~its~east~basis} }
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_basis_nx_tl
+          - \__tenkz_metric_ratio:n {planeslant} )
+      }
+      < {0.000001}
+      { \errmessage{a~plane~carrier~lost~its~north~shear} }
+    \fp_compare:nNnF
+      {
+        abs(
+          \l__tenkz_kernel_r_basis_ny_tl
+          - \__tenkz_metric_ratio:n {planerise} )
+      }
+      < {0.000001}
+      { \errmessage{a~plane~carrier~lost~its~north~rise} }
+  }
+\cs_new_protected:Npn \__tenkz_test_basis_page:n #1
+  {
+    \__tenkz_test_basis_read:n {#1}
+    \bool_if:NT \l__tenkz_kernel_r_basis_plane_bool
+      { \errmessage{a~page-space~or~flat~atom~claimed~a~plane~basis} }
+    \fp_compare:nNnF
+      {
+        abs(\l__tenkz_kernel_r_basis_ex_tl - 1)
+        + abs(\l__tenkz_kernel_r_basis_ey_tl)
+        + abs(\l__tenkz_kernel_r_basis_nx_tl)
+        + abs(\l__tenkz_kernel_r_basis_ny_tl - 1)
+      }
+      < {0.000001}
+      { \errmessage{a~page-space~or~flat~atom~lost~the~identity~basis} }
+  }
+\cs_new_protected:Npn \__tenkz_test_basis_circle:n #1
+  {
+    \__tenkz_test_basis_read:n {#1}
+    \bool_if:NT \l__tenkz_kernel_r_basis_plane_bool
+      { \errmessage{a~circle~station~claimed~a~plane~basis} }
+    \__tenkz_geom_local_basis:nnnNNNN {kpic}{1}{2}
+      \l_tmpa_tl \l_tmpb_tl \l_tmpc_tl \l_tmpd_tl
+    \fp_compare:nNnF
+      {
+        abs(\l__tenkz_kernel_r_basis_ex_tl - \l_tmpa_tl)
+        + abs(\l__tenkz_kernel_r_basis_ey_tl - \l_tmpb_tl)
+        + abs(\l__tenkz_kernel_r_basis_nx_tl - \l_tmpc_tl)
+        + abs(\l__tenkz_kernel_r_basis_ny_tl - \l_tmpd_tl)
+      }
+      < {0.000001}
+      { \errmessage{a~circle~station~lost~its~local~basis} }
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[
+    rows={wire}, cols=3, bonds=none,
+    frame={plane,basis={wire at (0,0),wire at (2,0)}}]
+  \tn[at=(1,1,1), name=G, cluster=1x1]{}
+  \tn[at=(1,2,1), name=A]{A}
+  \tn[at=(1,2,2), name=K]{K}
+  \tn[at=(1,3,1), name=B]{B}
+  \tn[at={midway A and B}, name=M]{M}
+\end{tenkz}
+\begin{tenkz}[rows={wire}, cols=1, frame=flat, bonds=none]
+  \tn[at=(1,1), name=F]{F}
+\end{tenkz}
+\begin{tenkz}[rows={wire}, cols=4, frame=circle, bonds=none]
+  \tn[at=(1,2), name=C]{C}
+\end{tenkz}
+\ExplSyntaxOn
+\int_compare:nNnF { \l__tenkz_test_basis_count_int } = {7}
+  {
+    \errmessage
+      {
+        the~carrier-basis~fixture~inspected~
+        \int_use:N \l__tenkz_test_basis_count_int ~atoms
+      }
+  }
+\ExplSyntaxOff
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -4197,6 +4197,63 @@
   }
 \prop_new:N \l__tenkz_kernel_r_turn_prop
 
+% The complete basis carried by one rendered atom.  Cell atoms and cluster
+% children resolve through the same carrier lookup used by projected labels;
+% page-space atoms retain their scalar-turn basis.  The dual is cached beside
+% the basis for inverse consumers such as local anchors and upright labels.
+% The plane result is a declared frame fact, not a floating-point guess about
+% whether the returned vectors happen to be orthogonal.
+\tl_new:N \l__tenkz_kernel_r_basis_ex_tl
+\tl_new:N \l__tenkz_kernel_r_basis_ey_tl
+\tl_new:N \l__tenkz_kernel_r_basis_nx_tl
+\tl_new:N \l__tenkz_kernel_r_basis_ny_tl
+\tl_new:N \l__tenkz_kernel_r_basis_ux_tl
+\tl_new:N \l__tenkz_kernel_r_basis_uy_tl
+\tl_new:N \l__tenkz_kernel_r_basis_vx_tl
+\tl_new:N \l__tenkz_kernel_r_basis_vy_tl
+\tl_new:N \l__tenkz_kernel_r_basis_turn_tl
+\bool_new:N \l__tenkz_kernel_r_basis_plane_bool
+\cs_new_protected:Npn \__tenkz_kernel_r_carrier_basis:n #1
+  {
+    \bool_set_false:N \l__tenkz_kernel_r_basis_plane_bool
+    \__tenkz_kernel_r_record_carrier:nNNN {#1}
+      \l__tenkz_kernel_turn_a_tl \l__tenkz_kernel_turn_b_tl
+      \l__tenkz_kernel_turn_bool
+    \bool_if:NTF \l__tenkz_kernel_turn_bool
+      {
+        \__tenkz_geom_local_basis:nnnNNNN {kpic}
+          { \l__tenkz_kernel_turn_a_tl }
+          { \l__tenkz_kernel_turn_b_tl }
+          \l__tenkz_kernel_r_basis_ex_tl
+          \l__tenkz_kernel_r_basis_ey_tl
+          \l__tenkz_kernel_r_basis_nx_tl
+          \l__tenkz_kernel_r_basis_ny_tl
+        \str_if_eq:eeT { \__tenkz_kernel_r_frame_word: } {plane}
+          { \bool_set_true:N \l__tenkz_kernel_r_basis_plane_bool }
+      }
+      {
+        \__tenkz_kernel_r_turn:nN {#1}
+          \l__tenkz_kernel_r_basis_turn_tl
+        \tl_set:Ne \l__tenkz_kernel_r_basis_ex_tl
+          { \fp_eval:n { cosd(\l__tenkz_kernel_r_basis_turn_tl) } }
+        \tl_set:Ne \l__tenkz_kernel_r_basis_ey_tl
+          { \fp_eval:n { sind(\l__tenkz_kernel_r_basis_turn_tl) } }
+        \tl_set:Ne \l__tenkz_kernel_r_basis_nx_tl
+          { \fp_eval:n { -sind(\l__tenkz_kernel_r_basis_turn_tl) } }
+        \tl_set:Ne \l__tenkz_kernel_r_basis_ny_tl
+          { \fp_eval:n { cosd(\l__tenkz_kernel_r_basis_turn_tl) } }
+      }
+    \__tenkz_geom_basis_dual:nnnnNNNN
+      { \l__tenkz_kernel_r_basis_ex_tl }
+      { \l__tenkz_kernel_r_basis_ey_tl }
+      { \l__tenkz_kernel_r_basis_nx_tl }
+      { \l__tenkz_kernel_r_basis_ny_tl }
+      \l__tenkz_kernel_r_basis_ux_tl
+      \l__tenkz_kernel_r_basis_uy_tl
+      \l__tenkz_kernel_r_basis_vx_tl
+      \l__tenkz_kernel_r_basis_vy_tl
+  }
+
 % Carry one of an atom's logical face directions to the page.  Kernel cell
 % coordinates are (row, column), whereas the face is measured from local east.
 % Geometry owns the complete east/north basis at that address and carries the


### PR DESCRIPTION
## Summary

- expose one record-level service returning a carrier east/north basis and its dual
- resolve cell atoms, declared basis members, and cluster children through the existing carrier lookup
- preserve orthonormal scalar-turn fallback for page-space records
- report projected-plane ownership from the declared frame word rather than floating-point tolerances

This is the second behavior-neutral prerequisite for exact affine skin contours and physical-leg lanes. No renderer consumes the new service yet.

Tracks LionSR/tenkz#113.

## Validation

- focused carrier-basis fixture covering plane cell, basis member, cluster child, page-space atom, flat frame, and nonzero circle station
- scripts/tenkz_kernel_probes.sh
- scripts/tenkz_golden.sh --check
- python3 scripts/tenkz_language.py check
- python3 scripts/test_tenkz_shrink.py
- tenkz lint on both changed files

Results: 83 kernel regressions, byte-identical kernel pixels and record streams, and 264 golden event streams byte-identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive kernel API and tests only; golden/kernel outputs unchanged and no production call sites yet.
> 
> **Overview**
> Adds a **record-level** `\__tenkz_kernel_r_carrier_basis:n` API that fills east/north basis components, their **dual**, and a **declared plane-frame flag** for one rendered atom. Cell atoms, basis members, and cluster children go through the same **carrier lookup** as projected labels (geometry local basis); page-space records keep the **orthonormal turn** from scalar carrier turn.
> 
> Plane vs page is determined from the **frame word**, not numeric orthogonality checks. Nothing in the renderer calls this yet; it is a behavior-neutral prerequisite for later affine skin work.
> 
> A new kernel regression (`r_record_carrier_basis.tex`) hooks glyph ink to assert dual orthogonality and frame-specific expectations across plane, flat, circle, cluster-child, and page-space fixtures (seven atoms).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0db49e8d9d5ed3f434afca2fd3b562e10f0464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->