### PR TITLE
refactor(tenkz): audit affine glyph path hulls

### DIFF
--- a/scripts/test_tenkz_label_overlap.py
+++ b/scripts/test_tenkz_label_overlap.py
@@ -38,6 +38,10 @@ SOURCE = r"""
   \fi}
 \def\tenkzassertsnapshotclean{%
   \edef\tenkztesttoken{\the\tenkz@glyphsnapuid}%
+  \tenkzassertrelax{tenkz@pathxmin@\tenkztesttoken}%
+  \tenkzassertrelax{tenkz@pathxmax@\tenkztesttoken}%
+  \tenkzassertrelax{tenkz@pathymin@\tenkztesttoken}%
+  \tenkzassertrelax{tenkz@pathymax@\tenkztesttoken}%
   \tenkzassertrelax{tenkz@outerx@\tenkztesttoken}%
   \tenkzassertrelax{tenkz@outery@\tenkztesttoken}%
   \tenkzassertrelax{tenkz@stroke@\tenkztesttoken}%
@@ -237,6 +241,52 @@ SOURCE = r"""
 \end{tenkzfree}
 \endgroup
 \tenkzassertsnapshotclean
+\end{document}
+"""
+
+AFFINE_GLYPHS = r"""
+\documentclass{article}
+\usepackage{tenkz}
+\pagestyle{empty}
+\begin{document}
+\tikzset{
+  tensor/.append style={tenkz glyph basis={1,0,.5,.75}},
+  box tensor/.append style={tenkz glyph basis={1,0,.5,.75}},
+  pill tensor/.append style={tenkz glyph basis={1,0,.5,.75}},
+  canonical tensor/.append style={tenkz glyph basis={1,0,.5,.75}}}
+\begin{tenkzfree}
+  \tnput[dot]{dot}{(0,0)}{}
+  \tnput[box]{box}{(2,0)}{}
+  \tnput[pill]{pill}{(4,0)}{}
+\end{tenkzfree}
+\begingroup
+\tikzset{tensor/.append style={outer sep=0pt}}
+\begin{tenkzfree}
+  \tnput[dot]{outer-zero}{(0,0)}{}
+\end{tenkzfree}
+\endgroup
+\begingroup
+\tikzset{tensor/.append style={outer sep=20pt}}
+\begin{tenkzfree}
+  \tnput[dot]{outer-large}{(0,0)}{}
+\end{tenkzfree}
+\endgroup
+\begin{tenkz}
+  \tn[tri=l]{}
+\end{tenkz}
+\makeatletter
+\def\tenkzassertaffineclean#1{%
+  \@for\tenkztestslot:=pathxmin,pathxmax,pathymin,pathymax\do{%
+    \expandafter\ifx\csname tenkz@\tenkztestslot @#1\endcsname\relax\else
+      \PackageError{tenkz test}{Affine path snapshot #1 was not released}{}%
+    \fi}}
+\tenkzassertaffineclean{1}
+\tenkzassertaffineclean{2}
+\tenkzassertaffineclean{3}
+\tenkzassertaffineclean{4}
+\tenkzassertaffineclean{5}
+\tenkzassertaffineclean{6}
+\makeatother
 \end{document}
 """
 
@@ -686,6 +736,56 @@ def main() -> int:
         if (len(rotate_control) != 1
                 or rotate_control[0].attrs.get("shape") != "roundrect"):
             raise AssertionError("ordinary node rotation was rejected as transformed")
+
+        affine = work / "affine-glyphs.tex"
+        affine.write_text(AFFINE_GLYPHS, encoding="utf-8")
+        affine_run = subprocess.run(
+            [engine, "-interaction=nonstopmode", "-halt-on-error", affine.name],
+            cwd=work,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=120,
+        )
+        if affine_run.returncode:
+            print(affine_run.stdout)
+            raise AssertionError("affine glyph fixture did not compile")
+        affine_status, affine_audit = audit_status(work / "affine-glyphs.tnlog")
+        if affine_status != 0:
+            raise AssertionError(
+                "audit rejected explicitly tagged affine glyphs: "
+                + "; ".join(finding.msg for finding in affine_audit.findings)
+            )
+        affine_geometry = [
+            event for event in affine_audit.events()
+            if event.kind == "glyph-geometry"
+        ]
+        if len(affine_geometry) != 6:
+            raise AssertionError(
+                f"affine fixture emitted {len(affine_geometry)} glyphs"
+            )
+        if any(
+                event.attrs.get("shape") != "rect"
+                or event.attrs.get("radius") != "0"
+                or any(event.attrs.get(field) != "0"
+                       for field in ("x1", "y1", "x2", "y2", "x3", "y3"))
+                for event in affine_geometry):
+            raise AssertionError(
+                "affine glyphs did not use conservative rectangular hulls: "
+                + repr([event.attrs for event in affine_geometry])
+            )
+        extents = [
+            (int(event.attrs["xmax"]) - int(event.attrs["xmin"]),
+             int(event.attrs["ymax"]) - int(event.attrs["ymin"]))
+            for event in affine_geometry
+        ]
+        if extents[-3] != extents[-2]:
+            raise AssertionError(
+                f"affine glyph hull retained outer separation: {extents[-3:-1]}"
+            )
+        if extents[0][0] == extents[0][1]:
+            raise AssertionError("affine dot fixture did not exercise anisotropy")
 
         invalid = work / "invalid-corners.tex"
         invalid.write_text(INVALID_CORNERS, encoding="utf-8")

--- a/tex/tenkz/tenkz-core.code.tex
+++ b/tex/tenkz/tenkz-core.code.tex
@@ -456,6 +456,7 @@
 \newif\iftenkz@bboxcapture
 \newif\iftenkz@identitylinear
 \newif\iftenkz@frameglyphrotated
+\newif\iftenkz@frameglyphaffine
 \newif\iftenkz@labelrectangle
 \newif\iftenkz@auditownermatch
 \tenkz@bboxcapturetrue
@@ -606,6 +607,10 @@
   \fi
   \endgroup}
 \def\tenkz@cleanupvisiblesnapshot#1{%
+  \global\expandafter\let\csname tenkz@pathxmin@#1\endcsname\relax
+  \global\expandafter\let\csname tenkz@pathxmax@#1\endcsname\relax
+  \global\expandafter\let\csname tenkz@pathymin@#1\endcsname\relax
+  \global\expandafter\let\csname tenkz@pathymax@#1\endcsname\relax
   \global\expandafter\let\csname tenkz@outerx@#1\endcsname\relax
   \global\expandafter\let\csname tenkz@outery@#1\endcsname\relax
   \global\expandafter\let\csname tenkz@stroke@#1\endcsname\relax
@@ -687,6 +692,15 @@
   \fi}
 \def\tenkz@captureactualpath#1#2{%
   \tenkz@incrementtokenslot{usecount}{#1}%
+  \def\tenkz@affine{affine}%
+  \ifx\tenkz@frameglyphangle\tenkz@affine
+    % PGF has already materialized the node's transformed visible path here.
+    % Preserve its page-space hull before the backend consumes and clears it.
+    \expandafter\xdef\csname tenkz@pathxmin@#1\endcsname{\the\pgf@pathminx}%
+    \expandafter\xdef\csname tenkz@pathxmax@#1\endcsname{\the\pgf@pathmaxx}%
+    \expandafter\xdef\csname tenkz@pathymin@#1\endcsname{\the\pgf@pathminy}%
+    \expandafter\xdef\csname tenkz@pathymax@#1\endcsname{\the\pgf@pathmaxy}%
+  \fi
   \pgfutil@in@{draw}{#2}%
   \ifpgfutil@in@
     \expandafter\gdef\csname tenkz@draw@#1\endcsname{1}%
@@ -1185,15 +1199,25 @@
           {Give every audited glyph a live fill, not only a drawn outline.}%
       \fi
       \tenkz@frameglyphrotatedfalse
+      \tenkz@frameglyphaffinefalse
       \expandafter\ifx\csname tenkz@frameglyph@#4\endcsname\relax
         \tenkz@requireidentitylinear{#1}{glyph}%
         \iftenkz@identitylinear\else\def\tenkz@glyphshape{unsupported}\fi
       \else
-        % The private frame key constructs rotation-only node transforms.
-        % Other affine transforms retain the identity-only audit contract.
+        % Only the private frame and basis keys sanction transformed glyphs.
+        % Arbitrary transform-shape customization remains identity-only.
         \edef\tenkz@nodematrix{\csname pgf@sh@nt@#1\endcsname}%
         \expandafter\tenkz@checklinear\tenkz@nodematrix
         \iftenkz@identitylinear\else\tenkz@frameglyphrotatedtrue\fi
+        \edef\tenkz@frameglyphkind{\csname tenkz@frameglyph@#4\endcsname}%
+        \def\tenkz@affine{affine}%
+        \ifx\tenkz@frameglyphkind\tenkz@affine
+          \tenkz@frameglyphaffinetrue
+          % The current audit schema has no ellipse or general curved-path
+          % primitive.  Publish the conservative captured path hull instead.
+          \def\tenkz@glyphshape{rect}%
+          \tenkz@glyphradius=0pt
+        \fi
       \fi
       \iftenkz@frameglyphrotated
         % A rotated rounded rectangle is not an axis-aligned rounded
@@ -1205,7 +1229,7 @@
         \fi
       \fi
       \tenkz@emitglyphinkuse
-      \tenkz@emitglyphgeometry{#1}%
+      \tenkz@emitglyphgeometry{#1}{#4}%
       \fi
     \fi
     \tenkz@cleanupglyphsnapshot{#4}%
@@ -1221,10 +1245,15 @@
   \ifdim\tenkz@bboxxa>\tenkz@bboxxmax \tenkz@bboxxmax=\tenkz@bboxxa\fi
   \ifdim\tenkz@bboxya<\tenkz@bboxymin \tenkz@bboxymin=\tenkz@bboxya\fi
   \ifdim\tenkz@bboxya>\tenkz@bboxymax \tenkz@bboxymax=\tenkz@bboxya\fi}
-\def\tenkz@emitglyphgeometry#1{%
+\def\tenkz@emitglyphgeometry#1#2{%
   \begingroup
   \def\tenkz@circle{circle}%
-  \ifx\tenkz@glyphshape\tenkz@circle
+  \iftenkz@frameglyphaffine
+    \tenkz@bboxxmin=\csname tenkz@pathxmin@#2\endcsname\relax
+    \tenkz@bboxxmax=\csname tenkz@pathxmax@#2\endcsname\relax
+    \tenkz@bboxymin=\csname tenkz@pathymin@#2\endcsname\relax
+    \tenkz@bboxymax=\csname tenkz@pathymax@#2\endcsname\relax
+  \else\ifx\tenkz@glyphshape\tenkz@circle
     % A circle's rotated corner anchors are not its axis extrema.  Recover
     % its invariant radius from the transformed centre-to-east vector.
     \pgfextractx{\tenkz@bboxxmin}{\pgfpointanchor{#1}{center}}%
@@ -1257,8 +1286,9 @@
       \pgfextracty{\tenkz@bboxymin}{\pgfpointanchor{#1}{south}}%
       \pgfextracty{\tenkz@bboxymax}{\pgfpointanchor{#1}{north}}%
     \fi
-  \fi
-  \ifx\tenkz@glyphshape\tenkz@circle
+  \fi\fi
+  \iftenkz@frameglyphaffine
+  \else\ifx\tenkz@glyphshape\tenkz@circle
     \ifdim\tenkz@glyphouterxsep<\tenkz@glyphouterysep
       \tenkz@glyphouterxsep=\tenkz@glyphouterysep
     \fi
@@ -1271,7 +1301,7 @@
     \advance\tenkz@bboxxmax by -\tenkz@glyphouterxsep
     \advance\tenkz@bboxymin by \tenkz@glyphouterysep
     \advance\tenkz@bboxymax by -\tenkz@glyphouterysep
-  \fi
+  \fi\fi
   \advance\tenkz@bboxxmin by -\tenkz@glyphhalfstroke
   \advance\tenkz@bboxxmax by \tenkz@glyphhalfstroke
   \advance\tenkz@bboxymin by -\tenkz@glyphhalfstroke
@@ -1335,6 +1365,10 @@
     transform shape,
     rotate=#1,
     /utils/exec={\def\tenkz@frameglyphangle{#1}}},
+  tenkz glyph basis/.style args={#1,#2,#3,#4}{
+    transform shape,
+    cm={#1,#2,#3,#4,(0pt,0pt)},
+    /utils/exec={\def\tenkz@frameglyphangle{affine}}},
   tenkz audited label/.style={
     /utils/exec=\tenkz@installlabelaudit},
   tenkz audited glyph/.style 2 args={


### PR DESCRIPTION
## Summary

- add an opt-in core `tenkz glyph basis` transform without switching any kernel renderer
- snapshot PGF's materialized affine path bounds and publish a conservative rectangular audit hull
- keep arbitrary `transform shape` customization rejected and release all per-node path snapshots
- cover sheared dot, box, pill, and triangle glyphs, outer-separation exclusion, and the existing raw-transform negatives

This is the behavior-neutral core prerequisite for the remaining affine skin-contour work in LionSR/tenkz#113. It deliberately does not copy the preserved prototype's ellipse-as-circle audit record or introduce per-shape affine formulas.

## Metric ownership

The production change introduces no print dimensions or page-specific constants. The basis is dimensionless; visible bounds come from PGF's materialized path and the already captured stroke width. The focused fixture uses only semantic coordinates, except for the deliberate existing-style `20pt` outer-separation stress value whose exclusion is the property under test.

## Validation

- `python3 scripts/test_tenkz_label_overlap.py`
- `scripts/tenkz_kernel_probes.sh`
- `scripts/tenkz_golden.sh --check` (264 event streams byte-identical)
- `scripts/tenkz_corpus.sh` (264 files compiled and audited)
- `python3 scripts/tenkz_lint.py 'blueprint/src/chapter/*.tex' 'docs/tenkz/manual2.tex' 'docs/tenkz/chapters2/*.tex' 'docs/slides/*.tex' 'tex/tenkz/examples/*.tex'`
- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_shrink.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches audited glyph geometry and overlap invariants in core TeX; behavior is gated to explicit basis styles and golden/corpus checks report no event-stream drift.
> 
> **Overview**
> **Adds opt-in affine glyph auditing** via a new `tenkz glyph basis` TikZ style (alongside the existing rotation-only `tenkz glyph frame`), without changing default kernel rendering.
> 
> When basis is active, the core **snapshots PGF’s page-space path bounds** at draw time (`pathxmin`/`pathxmax`/`pathymin`/`pathymax` per snapshot token), **releases those slots on cleanup**, and **emits `glyph-geometry` as conservative axis-aligned `rect` hulls** (zero triangle corners, no outer-sep inflation on the captured hull). Arbitrary `transform shape` on audited glyphs **stays rejected** unless routed through the sanctioned frame/basis keys.
> 
> **Regression coverage** extends `test_tenkz_label_overlap.py` with an affine fixture (sheared dot/box/pill, triangle, outer-sep cases) and stricter snapshot-clean asserts for path-bound registers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit babf2ee1963a9c0b2a919e220638825f118432ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->