### PR TITLE
feat(Channel): bound mutual information by operator-Schmidt rank

### DIFF
--- a/TNLean/Algebra/OperatorSchmidt.lean
+++ b/TNLean/Algebra/OperatorSchmidt.lean
@@ -38,6 +38,8 @@ of the operator blocks.
   decomposition exists with exactly the range dimension many terms.
 * `Matrix.operatorSchmidtRank_le_of_hasOperatorSchmidtDecomposition`: every
   product decomposition has at least the range dimension many terms.
+* `Matrix.operatorSchmidtRank_eq_zero_iff`: operator-Schmidt rank vanishes
+  exactly for the zero matrix.
 * `Matrix.operatorSchmidtRank_local_mul_le`: local left and right
   multiplication cannot increase operator-Schmidt rank.
 * `Matrix.operatorSchmidtRank_local_isometry_conj`: local isometric
@@ -188,6 +190,38 @@ theorem operatorSchmidtRank_minimal (ρ : Matrix (m × n) (m × n) ℂ) :
       ∀ r, HasOperatorSchmidtDecomposition ρ r → operatorSchmidtRank ρ ≤ r :=
   ⟨hasOperatorSchmidtDecomposition_operatorSchmidtRank ρ,
     fun _ ↦ operatorSchmidtRank_le_of_hasOperatorSchmidtDecomposition⟩
+
+/-- A bipartite complex matrix has operator-Schmidt rank zero exactly when it
+is the zero matrix. -/
+@[simp]
+theorem operatorSchmidtRank_eq_zero_iff
+    (ρ : Matrix (m × n) (m × n) ℂ) :
+    operatorSchmidtRank ρ = 0 ↔ ρ = 0 := by
+  rw [operatorSchmidtRank_eq_finrank_operatorBlockSpan,
+    Submodule.finrank_eq_zero]
+  constructor
+  · intro hspan
+    ext ⟨i, k⟩ ⟨j, l⟩
+    have hblock : operatorBlock ρ i j ∈ operatorBlockSpan ρ :=
+      Submodule.subset_span ⟨(i, j), rfl⟩
+    rw [hspan] at hblock
+    change operatorBlock ρ i j = 0 at hblock
+    simpa using congrFun (congrFun hblock k) l
+  · rintro rfl
+    rw [operatorBlockSpan]
+    apply le_antisymm
+    · apply Submodule.span_le.mpr
+      rintro _ ⟨⟨i, j⟩, rfl⟩
+      change (0 : Matrix n n ℂ) ∈ (⊥ : Submodule ℂ (Matrix n n ℂ))
+      exact Submodule.zero_mem _
+    · exact bot_le
+
+/-- A bipartite complex matrix has positive operator-Schmidt rank exactly when
+it is nonzero. -/
+theorem operatorSchmidtRank_pos_iff
+    (ρ : Matrix (m × n) (m × n) ℂ) :
+    0 < operatorSchmidtRank ρ ↔ ρ ≠ 0 := by
+  rw [Nat.pos_iff_ne_zero, ne_eq, operatorSchmidtRank_eq_zero_iff]
 
 end Complex
 

--- a/TNLean/Algebra/OrthogonalProjection.lean
+++ b/TNLean/Algebra/OrthogonalProjection.lean
@@ -19,6 +19,7 @@ channels and irreducibility.
 * `IsOrthogonalProjection`
 * `IsOrthogonalProjection.one_sub`
 * `IsOrthogonalProjection.exists_range_isometry`
+* `IsStarProjection.exists_range_isometry`
 * `IsStarProjection.conjTranspose_mul_mul_of_mul_conjTranspose_eq_one`
 * `isOrthogonalProjection_posSemidef`
 * `isOrthogonalProjection_sum_of_pairwise_mul_eq_zero`
@@ -169,6 +170,39 @@ theorem IsOrthogonalProjection.exists_range_isometry
           by_cases hp : p j
           · simp [hp, show f j = 1 from hp]
           · simp [hp, show f j = 0 from (hf01 j).resolve_right hp]
+
+/-- A star projection on an arbitrary finite index type is the range projection
+of an isometry from a finite coordinate space. -/
+theorem IsStarProjection.exists_range_isometry
+    {n : Type*} [Fintype n]
+    {P : Matrix n n ℂ} (hP : IsStarProjection P) :
+    ∃ (k : ℕ) (V : Matrix n (Fin k) ℂ),
+      Vᴴ * V = 1 ∧ V * Vᴴ = P := by
+  classical
+  let e : n ≃ Fin (Fintype.card n) := Fintype.equivFin n
+  let P' : Matrix (Fin (Fintype.card n)) (Fin (Fintype.card n)) ℂ :=
+    P.submatrix e.symm e.symm
+  have hHerm : P.IsHermitian := by
+    change Pᴴ = P
+    simpa [Matrix.star_eq_conjTranspose] using hP.isSelfAdjoint.star_eq
+  have hP' : IsOrthogonalProjection P' := by
+    constructor
+    · exact (Matrix.isHermitian_submatrix_equiv e.symm).2 hHerm
+    · dsimp only [P']
+      rw [Matrix.submatrix_mul_equiv, hP.isIdempotentElem.eq]
+  obtain ⟨k, V', hV', hRange'⟩ := hP'.exists_range_isometry
+  let V : Matrix n (Fin k) ℂ :=
+    V'.submatrix e (Equiv.refl (Fin k))
+  refine ⟨k, V, ?_, ?_⟩
+  · dsimp only [V]
+    rw [Matrix.conjTranspose_submatrix,
+      Matrix.submatrix_mul_equiv, hV', Matrix.submatrix_one_equiv]
+  · dsimp only [V]
+    rw [Matrix.conjTranspose_submatrix,
+      Matrix.submatrix_mul_equiv, hRange']
+    simp only [P', Matrix.submatrix_submatrix, Function.comp_def,
+      Equiv.symm_apply_apply]
+    rfl
 
 /-- A finite sum of pairwise orthogonal projections is an orthogonal
 projection. -/

--- a/TNLean/Algebra/PosSemidefSupport.lean
+++ b/TNLean/Algebra/PosSemidefSupport.lean
@@ -23,6 +23,8 @@ are specializations of that construction.
 * `Matrix.IsHermitian.mul_supportProj_eq_self_of_mulVec_kernel_le`: right
   absorption under kernel inclusion.
 * `Matrix.PosSemidef.supportProj`: the positive-semidefinite specialization.
+* `Matrix.PosSemidef.isStarProjection_supportProj`: the support projection is
+  a star projection on an arbitrary finite index type.
 * `Matrix.PosSemidef.isOrthogonalProjection_supportProj`: orthogonality of the
   positive-semidefinite support projection.
 * `Matrix.supportProj_mul_conjTranspose_mul_self`: the support projection of
@@ -354,12 +356,19 @@ definite is not the identity. -/
 theorem supportProj_ne_one_of_not_posDef (hA : A.PosSemidef) (hnotPD : ¬ A.PosDef) :
     hA.supportProj ≠ 1 := fun h => hnotPD (hA.posDef_of_supportProj_eq_one h)
 
+/-- The support projection is a star projection. -/
+theorem isStarProjection_supportProj (hρ : A.PosSemidef) :
+    IsStarProjection hρ.supportProj := by
+  rw [isStarProjection_iff']
+  refine ⟨hρ.supportProj_idem, ?_⟩
+  simpa [Matrix.star_eq_conjTranspose] using hρ.supportProj_isHermitian.eq
+
 variable {D : ℕ} {ρ : Matrix (Fin D) (Fin D) ℂ}
 
 /-- The support projection is an orthogonal projection. -/
 theorem isOrthogonalProjection_supportProj (hρ : ρ.PosSemidef) :
     IsOrthogonalProjection hρ.supportProj :=
-  ⟨hρ.supportProj_isHermitian, hρ.supportProj_idem⟩
+  hρ.isStarProjection_supportProj.isOrthogonalProjection
 
 end Matrix.PosSemidef
 

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -175,7 +175,7 @@ This is the positivity of the expression in Müller-Lennert et al.,
 arXiv:1306.3142v4, Definition 2, specialized to order two. -/
 theorem sandwichedRenyiTwoTrace_nonneg
     {n : Type*} [Fintype n] [DecidableEq n]
-    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef) :
+    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (_hω : ω.PosSemidef) :
     0 ≤ sandwichedRenyiTwoTrace ρ ω := by
   let q := ω ^ (-(1 / 4 : ℝ))
   have hq : q.PosSemidef :=

--- a/TNLean/Analysis/SandwichedRenyiTwo.lean
+++ b/TNLean/Analysis/SandwichedRenyiTwo.lean
@@ -174,11 +174,14 @@ positive-semidefinite arguments.
 This is the positivity of the expression in Müller-Lennert et al.,
 arXiv:1306.3142v4, Definition 2, specialized to order two. -/
 theorem sandwichedRenyiTwoTrace_nonneg
-    {ρ ω : Mat} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef) :
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef) :
     0 ≤ sandwichedRenyiTwoTrace ρ ω := by
   let q := ω ^ (-(1 / 4 : ℝ))
-  have hX : (q * ρ * q).PosSemidef :=
-    _root_.Matrix.PosSemidef.rpow_mul_mul_rpow hρ hω (-(1 / 4 : ℝ))
+  have hq : q.PosSemidef :=
+    Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg
+  have hX : (q * ρ * q).PosSemidef := by
+    simpa only [hq.isHermitian.eq] using hρ.mul_mul_conjTranspose_same q
   exact (Complex.nonneg_iff.mp (hX.trace_mul_nonneg hX)).1
 
 /-- For a positive-definite matrix, two inverse quarter-powers multiply to the

--- a/TNLean/Analysis/SupportCompressedEntropy.lean
+++ b/TNLean/Analysis/SupportCompressedEntropy.lean
@@ -76,8 +76,9 @@ noncomputable section
 variable {D k : ℕ}
 
 private theorem support_compression_log
-    {A : Matrix (Fin D) (Fin D) ℂ} (hA : A.PosSemidef)
-    (V : Matrix (Fin D) (Fin k) ℂ) (hV : Vᴴ * V = 1)
+    {n m : Type*} [Fintype n] [DecidableEq n] [Fintype m] [DecidableEq m]
+    {A : Matrix n n ℂ} (hA : A.PosSemidef)
+    (V : Matrix n m ℂ) (hV : Vᴴ * V = 1)
     (hexpand : V * (Vᴴ * A * V) * Vᴴ = A) :
     CFC.log A = V * CFC.log (Vᴴ * A * V) * Vᴴ := by
   let Ac := Vᴴ * A * V
@@ -115,9 +116,10 @@ positive-semidefinite reference.  The kernel inclusion is exactly the finite
 relative-entropy support condition; no faithfulness assumption is made on the
 ambient reference. -/
 theorem quantumRelativeEntropy_support_compression
-    {ρ ω : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
-    (hker : ∀ v : Fin D → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
-    (V : Matrix (Fin D) (Fin k) ℂ) (hV : Vᴴ * V = 1)
+    {n m : Type*} [Fintype n] [DecidableEq n] [Fintype m] [DecidableEq m]
+    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
+    (hker : ∀ v : n → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (V : Matrix n m ℂ) (hV : Vᴴ * V = 1)
     (hRange : V * Vᴴ = hω.supportProj) :
     quantumRelativeEntropy ρ ω =
       quantumRelativeEntropy (Vᴴ * ρ * V) (Vᴴ * ω * V) := by
@@ -204,9 +206,10 @@ isometric trace preservation supplies the corresponding normalizations for
 the compressed matrices.  The faithful inequality is an explicit hypothesis
 and is not proved here. -/
 theorem quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace_of_faithful
-    {ρ ω : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
     (hρtr : ρ.trace = 1) (hωtr : ω.trace = 1)
-    (hker : ∀ v : Fin D → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
+    (hker : ∀ v : n → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0)
     (hfaithful : ∀ {d : ℕ} (A B : Matrix (Fin d) (Fin d) ℂ),
       A.PosSemidef → B.PosDef → A.trace = 1 → B.trace = 1 →
         quantumRelativeEntropy A B ≤ Real.log (sandwichedRenyiTwoTrace A B)) :
@@ -258,9 +261,10 @@ logarithm of the order-two sandwiched trace. The proof compresses to the
 support of \(\omega\), where the reference is positive definite, and applies
 `quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace_posDef`. -/
 theorem quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace
-    {ρ ω : Matrix (Fin D) (Fin D) ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
+    {n : Type*} [Fintype n] [DecidableEq n]
+    {ρ ω : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hω : ω.PosSemidef)
     (hρtr : ρ.trace = 1) (hωtr : ω.trace = 1)
-    (hker : ∀ v : Fin D → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0) :
+    (hker : ∀ v : n → ℂ, ω *ᵥ v = 0 → ρ *ᵥ v = 0) :
     quantumRelativeEntropy ρ ω ≤ Real.log (sandwichedRenyiTwoTrace ρ ω) := by
   exact quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace_of_faithful
     hρ hω hρtr hωtr hker

--- a/TNLean/Analysis/SupportCompressedEntropy.lean
+++ b/TNLean/Analysis/SupportCompressedEntropy.lean
@@ -214,7 +214,7 @@ theorem quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace_of_faithful
       A.PosSemidef → B.PosDef → A.trace = 1 → B.trace = 1 →
         quantumRelativeEntropy A B ≤ Real.log (sandwichedRenyiTwoTrace A B)) :
     quantumRelativeEntropy ρ ω ≤ Real.log (sandwichedRenyiTwoTrace ρ ω) := by
-  obtain ⟨k, V, hV, hRange⟩ := hω.isOrthogonalProjection_supportProj.exists_range_isometry
+  obtain ⟨k, V, hV, hRange⟩ := hω.isStarProjection_supportProj.exists_range_isometry
   let ρc := Vᴴ * ρ * V
   let ωc := Vᴴ * ω * V
   have hρc : ρc.PosSemidef := by

--- a/TNLean/Channel/Schwarz.lean
+++ b/TNLean/Channel/Schwarz.lean
@@ -18,6 +18,7 @@ import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
+import TNLean.Channel.Schwarz.MutualInformationOperatorSchmidt
 import TNLean.Channel.Schwarz.OperatorConvexity
 import TNLean.Channel.Schwarz.OperatorJensenAux
 import TNLean.Channel.Schwarz.OperatorJensenIntegrands

--- a/TNLean/Channel/Schwarz/MutualInformationOperatorSchmidt.lean
+++ b/TNLean/Channel/Schwarz/MutualInformationOperatorSchmidt.lean
@@ -18,7 +18,7 @@ density operator by the logarithm of its ordinary operator-Schmidt rank.
 * `TNLean.quantumRelativeEntropy_product_marginals_eq_mutualInformation`
   identifies mutual information with relative entropy from the product of the
   marginals.
-* `TNLean.Entropy.mutualInformation_le_log_operatorSchmidtRank` proves the
+* `Entropy.mutualInformation_le_log_operatorSchmidtRank` proves the
   operator-Schmidt-rank bound.
 
 ## References
@@ -53,6 +53,10 @@ theorem quantumRelativeEntropy_product_marginals_eq_mutualInformation
   simpa only [Entropy.mutualInformation, Matrix.traceRight, Matrix.traceLeft]
     using quantumRelativeEntropy_product_marginals hρ
 
+end TNLean
+
+namespace Entropy
+
 /-- The mutual information of a finite-dimensional bipartite density operator
 is at most the logarithm of its ordinary operator-Schmidt rank.
 
@@ -60,10 +64,10 @@ This is a finite-dimensional consequence of the order-two sandwiched
 relative-entropy comparison of Müller-Lennert et al., arXiv:1306.3142v4,
 Definition 5 and Lemma 19, together with Beigi, arXiv:1306.5920, Theorem 6,
 equation (18). -/
-theorem Entropy.mutualInformation_le_log_operatorSchmidtRank
+theorem mutualInformation_le_log_operatorSchmidtRank
     (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
     (hρ : ρ.PosSemidef) (hρtr : ρ.trace = 1) :
-    Entropy.mutualInformation ρ hρ.isHermitian ≤
+    mutualInformation ρ hρ.isHermitian ≤
       Real.log (Matrix.operatorSchmidtRank ρ) := by
   let ω := partialTraceRight ρ ⊗ₖ partialTraceLeft ρ
   have hA : (partialTraceRight ρ).PosSemidef := hρ.partialTraceRight
@@ -82,21 +86,21 @@ theorem Entropy.mutualInformation_le_log_operatorSchmidtRank
   have hRankOne : (1 : ℝ) ≤ Matrix.operatorSchmidtRank ρ := by
     exact_mod_cast hRankPos
   have hQ2nonneg :
-      0 ≤ sandwichedRenyiTwoTrace ρ ω :=
-    sandwichedRenyiTwoTrace_nonneg hρ hω
+      0 ≤ TNLean.sandwichedRenyiTwoTrace ρ ω :=
+    TNLean.sandwichedRenyiTwoTrace_nonneg hρ hω
   have hQ2le :
-      sandwichedRenyiTwoTrace ρ ω ≤ Matrix.operatorSchmidtRank ρ :=
-    sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank ρ hρ
-  rw [← quantumRelativeEntropy_product_marginals_eq_mutualInformation hρ]
+      TNLean.sandwichedRenyiTwoTrace ρ ω ≤ Matrix.operatorSchmidtRank ρ :=
+    TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank ρ hρ
+  rw [← TNLean.quantumRelativeEntropy_product_marginals_eq_mutualInformation hρ]
   calc
-    quantumRelativeEntropy ρ ω ≤
-        Real.log (sandwichedRenyiTwoTrace ρ ω) :=
-      quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace
+    TNLean.quantumRelativeEntropy ρ ω ≤
+        Real.log (TNLean.sandwichedRenyiTwoTrace ρ ω) :=
+      TNLean.quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace
         hρ hω hρtr hωtr (Matrix.product_marginal_support hρ)
     _ ≤ Real.log (Matrix.operatorSchmidtRank ρ) := by
-      by_cases hQ2zero : sandwichedRenyiTwoTrace ρ ω = 0
+      by_cases hQ2zero : TNLean.sandwichedRenyiTwoTrace ρ ω = 0
       · rw [hQ2zero, Real.log_zero]
         exact Real.log_nonneg hRankOne
       · exact Real.log_le_log (lt_of_le_of_ne hQ2nonneg (Ne.symm hQ2zero)) hQ2le
 
-end TNLean
+end Entropy

--- a/TNLean/Channel/Schwarz/MutualInformationOperatorSchmidt.lean
+++ b/TNLean/Channel/Schwarz/MutualInformationOperatorSchmidt.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.MarginalSupportWhitenedChoi
+import TNLean.Channel.Schwarz.SSAEqualityDPI
+import TNLean.Channel.Schwarz.SSAEqualityPetzRecovery
+
+/-!
+# Mutual information from operator-Schmidt rank
+
+This file bounds the mutual information of a finite-dimensional bipartite
+density operator by the logarithm of its ordinary operator-Schmidt rank.
+
+## Main results
+
+* `TNLean.quantumRelativeEntropy_product_marginals_eq_mutualInformation`
+  identifies mutual information with relative entropy from the product of the
+  marginals.
+* `TNLean.Entropy.mutualInformation_le_log_operatorSchmidtRank` proves the
+  operator-Schmidt-rank bound.
+
+## References
+
+* Hayden, Jozsa, Petz, and Winter, arXiv:quant-ph/0304007v2, p. 3,
+  equation (4).
+* Müller-Lennert, Dupuis, Szehr, Fehr, and Tomamichel,
+  arXiv:1306.3142v4, Definition 5 and Lemma 19.
+* Beigi, arXiv:1306.5920, Theorem 6, equation (18).
+-/
+
+open scoped Kronecker MatrixOrder
+open Matrix
+
+noncomputable section
+
+namespace TNLean
+
+variable {dA dB : ℕ}
+
+/-- Mutual information is relative entropy from the product of the two
+marginals.
+
+Source: Hayden--Jozsa--Petz--Winter, arXiv:quant-ph/0304007v2, p. 3,
+equation (4). -/
+theorem quantumRelativeEntropy_product_marginals_eq_mutualInformation
+    {ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ}
+    (hρ : ρ.PosSemidef) :
+    quantumRelativeEntropy ρ
+        (partialTraceRight ρ ⊗ₖ partialTraceLeft ρ) =
+      Entropy.mutualInformation ρ hρ.isHermitian := by
+  simpa only [Entropy.mutualInformation, Matrix.traceRight, Matrix.traceLeft]
+    using quantumRelativeEntropy_product_marginals hρ
+
+/-- The mutual information of a finite-dimensional bipartite density operator
+is at most the logarithm of its ordinary operator-Schmidt rank.
+
+This is a finite-dimensional consequence of the order-two sandwiched
+relative-entropy comparison of Müller-Lennert et al., arXiv:1306.3142v4,
+Definition 5 and Lemma 19, together with Beigi, arXiv:1306.5920, Theorem 6,
+equation (18). -/
+theorem Entropy.mutualInformation_le_log_operatorSchmidtRank
+    (ρ : Matrix (Fin dA × Fin dB) (Fin dA × Fin dB) ℂ)
+    (hρ : ρ.PosSemidef) (hρtr : ρ.trace = 1) :
+    Entropy.mutualInformation ρ hρ.isHermitian ≤
+      Real.log (Matrix.operatorSchmidtRank ρ) := by
+  let ω := partialTraceRight ρ ⊗ₖ partialTraceLeft ρ
+  have hA : (partialTraceRight ρ).PosSemidef := hρ.partialTraceRight
+  have hB : (partialTraceLeft ρ).PosSemidef := hρ.partialTraceLeft
+  have hω : ω.PosSemidef := hA.kronecker hB
+  have hωtr : ω.trace = 1 := by
+    dsimp only [ω]
+    rw [Matrix.trace_kronecker, Matrix.trace_partialTraceRight,
+      Matrix.trace_partialTraceLeft, hρtr, one_mul]
+  have hρ_ne : ρ ≠ 0 := by
+    intro hρzero
+    rw [hρzero, Matrix.trace_zero] at hρtr
+    exact zero_ne_one hρtr
+  have hRankPos : 0 < Matrix.operatorSchmidtRank ρ :=
+    (Matrix.operatorSchmidtRank_pos_iff ρ).2 hρ_ne
+  have hRankOne : (1 : ℝ) ≤ Matrix.operatorSchmidtRank ρ := by
+    exact_mod_cast hRankPos
+  have hQ2nonneg :
+      0 ≤ sandwichedRenyiTwoTrace ρ ω :=
+    sandwichedRenyiTwoTrace_nonneg hρ hω
+  have hQ2le :
+      sandwichedRenyiTwoTrace ρ ω ≤ Matrix.operatorSchmidtRank ρ :=
+    sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank ρ hρ
+  rw [← quantumRelativeEntropy_product_marginals_eq_mutualInformation hρ]
+  calc
+    quantumRelativeEntropy ρ ω ≤
+        Real.log (sandwichedRenyiTwoTrace ρ ω) :=
+      quantumRelativeEntropy_le_log_sandwichedRenyiTwoTrace
+        hρ hω hρtr hωtr (Matrix.product_marginal_support hρ)
+    _ ≤ Real.log (Matrix.operatorSchmidtRank ρ) := by
+      by_cases hQ2zero : sandwichedRenyiTwoTrace ρ ω = 0
+      · rw [hQ2zero, Real.log_zero]
+        exact Real.log_nonneg hRankOne
+      · exact Real.log_le_log (lt_of_le_of_ne hQ2nonneg (Ne.symm hQ2zero)) hQ2le
+
+end TNLean

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -1534,7 +1534,7 @@ logarithmic divergence, or a comparison with relative entropy.
 
 \begin{theorem}[Mutual information from operator-Schmidt rank]
     \label{thm:mutual_information_le_log_operator_schmidt_rank}
-    \lean{TNLean.Entropy.mutualInformation_le_log_operatorSchmidtRank}
+    \lean{Entropy.mutualInformation_le_log_operatorSchmidtRank}
     \leanok
     \uses{def:mutual_information,
       def:bipartite_operator_schmidt_rank}
@@ -1560,9 +1560,8 @@ logarithmic divergence, or a comparison with relative entropy.
       &\leq\log\operatorname{OSR}(\rho_{AB}).
       \notag
     \end{align}
-    Since $\rho_{AB}$ has trace one, it is nonzero and its
-    operator-Schmidt rank is positive.  Thus the last logarithmic comparison
-    also covers the totalized case $Q_2=0$.
+    Since $\rho_{AB}$ has trace one, both $Q_2$ and its operator-Schmidt rank
+    are positive, so logarithmic monotonicity applies.
     The first inequality is
     Theorem~\ref{thm:relative_entropy_q2_support}; the second follows from
     Theorem~\ref{thm:sandwiched_renyi_two_osr_support} and monotonicity of the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law_diagonal_and_pure_state_bounds.tex
@@ -1534,17 +1534,21 @@ logarithmic divergence, or a comparison with relative entropy.
 
 \begin{theorem}[Mutual information from operator-Schmidt rank]
     \label{thm:mutual_information_le_log_operator_schmidt_rank}
-    \uses{def:bipartite_operator_schmidt_rank}
+    \lean{TNLean.Entropy.mutualInformation_le_log_operatorSchmidtRank}
+    \leanok
+    \uses{def:mutual_information,
+      def:bipartite_operator_schmidt_rank}
     For every finite-dimensional bipartite density operator $\rho_{AB}$,
     \begin{align}
         I(A:B)_\rho
         \leq \log\operatorname{OSR}(\rho_{AB}).
         \notag
     \end{align}
-    % Formalization is tracked by issue #5212.
 \end{theorem}
-\begin{proof}
-    \uses{thm:relative_entropy_q2_support,
+\begin{proof}\leanok
+    \uses{thm:relative_entropy_product_marginals,
+      lem:product_marginal_support,
+      thm:relative_entropy_q2_support,
       thm:sandwiched_renyi_two_osr_support}
     Set $\omega=\rho_A\otimes\rho_B$. Positivity gives
     $\ker\omega\subseteq\ker\rho_{AB}$, and the two matrices have trace one.
@@ -1556,6 +1560,9 @@ logarithmic divergence, or a comparison with relative entropy.
       &\leq\log\operatorname{OSR}(\rho_{AB}).
       \notag
     \end{align}
+    Since $\rho_{AB}$ has trace one, it is nonzero and its
+    operator-Schmidt rank is positive.  Thus the last logarithmic comparison
+    also covers the totalized case $Q_2=0$.
     The first inequality is
     Theorem~\ref{thm:relative_entropy_q2_support}; the second follows from
     Theorem~\ref{thm:sandwiched_renyi_two_osr_support} and monotonicity of the

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -441,7 +441,7 @@ the unrestricted finite-dimensional inequality
 \]
 for every bipartite density operator.
 \footnote{Formal declaration:
-\leanid{TNLean.Entropy.mutualInformation_le_log_operatorSchmidtRank}
+\leanid{Entropy.mutualInformation_le_log_operatorSchmidtRank}
 in \doclink{TNLean/Channel/Schwarz/MutualInformationOperatorSchmidt}.}
 This is a finite-dimensional consequence of the cited sandwiched R\'enyi
 results, not a statement of Proposition~4.5 in arXiv:1606.00608.  Thus the

--- a/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_mutual_information_bound.tex
@@ -434,11 +434,21 @@ requires no trace normalization.
 in \doclink{TNLean/Channel/FaithfulMarginalWhitenedChoi}, and
 \leanid{TNLean.sandwichedRenyiTwoTrace_product_marginals_le_operatorSchmidtRank}
 in \doclink{TNLean/Channel/MarginalSupportWhitenedChoi}.}
-Thus the mathematical work tracked by
-\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211} is complete.  The
-unrestricted mutual-information inequality remains the downstream task in
-\href{https://github.com/LionSR/TNLean/issues/5212}{\#5212}; its application to
-the finite-chain MPO estimate remains tracked by
+Combining this estimate with the support-restricted order-two comparison gives
+the unrestricted finite-dimensional inequality
+\[
+  I(A:B)_\rho\leq\log\operatorname{OSR}(\rho_{AB})
+\]
+for every bipartite density operator.
+\footnote{Formal declaration:
+\leanid{TNLean.Entropy.mutualInformation_le_log_operatorSchmidtRank}
+in \doclink{TNLean/Channel/Schwarz/MutualInformationOperatorSchmidt}.}
+This is a finite-dimensional consequence of the cited sandwiched R\'enyi
+results, not a statement of Proposition~4.5 in arXiv:1606.00608.  Thus the
+mathematical work tracked by
+\href{https://github.com/LionSR/TNLean/issues/5211}{\#5211} and
+\href{https://github.com/LionSR/TNLean/issues/5212}{\#5212} is complete.  Its
+application to the finite-chain MPO estimate remains tracked by
 \href{https://github.com/LionSR/TNLean/issues/5213}{\#5213}.
 
 \section{Diagonal matrix product operators}


### PR DESCRIPTION
Closes #5212.

## Summary

- prove `Entropy.mutualInformation_le_log_operatorSchmidtRank` for every finite-dimensional bipartite density operator
- add the natural zero/positivity characterization of ordinary operator-Schmidt rank
- expose finite-index support projections through the generic Mathlib-style `IsStarProjection` API and generalize the outer index type of the support-restricted order-two comparison
- synchronize the Blueprint and the existing MPDO mutual-information gap note

## Source scope

This is a finite-dimensional consequence assembled from the product-marginal relative-entropy identity, the support-restricted order-two comparison adapted from Müller-Lennert et al. (arXiv:1306.3142v4, Definition 5 and Lemma 19), and the Beigi contraction used by the operator-Schmidt capstone (arXiv:1306.5920, Theorem 6, equation (18)). It is not asserted as Proposition 4.5 of arXiv:1606.00608. The finite-chain MPO application remains tracked by #5213.

## Validation

- `lake exe cache get` with the pinned Mathlib v4.32.0 cache (8,264 prebuilt Mathlib artifacts)
- `lake build TNLean.Channel.Schwarz.MutualInformationOperatorSchmidt -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --update-lean-decls --warn-missing-blueprint ...`
- `python3 scripts/generate_import_aggregators.py --check`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity scan and `git diff --check`

The repository-wide `leanblueprint checkdecls` gate is left to CI because the generalized support-compression API invalidates downstream TNLean object files; rebuilding those locally would violate the repository's hot-main cache policy. The new module and every changed dependency compile in the focused build. Independent read-only audits checked the projection reindexing, empty-dimensional cases, totalized logarithm branch, namespace placement, source attribution, and Blueprint dependency split.
