### PR TITLE
refactor(MPS/MPDO): use literal CPSV form for BNT spectrum

### DIFF
--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -5,7 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.CanonicalForm.BNTUniqueness
 import TNLean.MPS.MPDO.BNTMultiplicityNormalization
-import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
+import TNLean.MPS.MPDO.CPSVVerticalDecomposition
 import TNLean.MPS.MPDO.VerticalBlockedOperatorRepresentations
 
 /-!
@@ -15,9 +15,8 @@ This file compares the chosen one-site vertical basis in a tensor-attached
 BNT algebra clause with a vertical canonical decomposition of the two-site
 blocking.  The same-length product law identifies the sectorwise power sums,
 and positivity turns them into the multiplicity-spectrum comparison used in
-the algebra-to-RFP implication.  The constructions below assume normalized
-BNT-refined horizontal form, which is stronger than literal CPSV canonical
-form.
+the algebra-to-RFP implication.  The constructions below use literal CPSV
+canonical form, as in the source.
 
 ## Main results
 
@@ -152,11 +151,6 @@ correspondence are assumed: full support of the two positive vertical
 decompositions derives the sector relabelling, and eventual BNT linear
 independence derives the power-sum equality.
 
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is the
-normalized BNT-refined horizontal form, stronger than the literal CPSV
-canonical form used in Appendix C.4 through Proposition 4.13; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
-
 **Scope restriction (invertible gauge):** The result retains bond-dimension
 equality and phase-one invertible conjugacy, but does not prove the line-2057
 unitary upgrade.  The missing common-target normalization contract is documented
@@ -168,7 +162,8 @@ Source: arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 noncomputable def toTwoSiteExactSectorGauge
     {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
-    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) :
     TwoSiteExactSectorGauge H := by
   classical
   let chi := H.algebraClause.positiveChi.chi
@@ -386,8 +381,7 @@ noncomputable def toTwoSiteExactSectorGauge
     rw [hPair] at hEntry
     exact hEntry.trans (P.mpv_toTensor_eq_sum_coeff σ).symm
   let D₂ : CPSVVerticalDecomposition (blockTwo M) := Classical.choice
-    (hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
-      (blockTwo M) hM.blockTwo)
+    (hCanonical.exists_cpsvVerticalDecomposition_blockTwo M hM)
   let Q : MPSTensor.SectorDecomposition (D * D) := {
     basisCount := D₂.labelCount
     basisDim := D₂.bondDim
@@ -714,35 +708,29 @@ noncomputable def toTwoSiteExactSectorGauge
       exact hExact }
 
 /-- The exact sector gauges determine the two-site multiplicity spectrum under
-normalized BNT-refined horizontal form.
-
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+literal CPSV canonical form.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 noncomputable def toTwoSiteMultiplicitySpectrum
     {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
-    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) :
     TwoSiteMultiplicitySpectrum H :=
-  (H.toTwoSiteExactSectorGauge hHorizontal hM).toTwoSiteMultiplicitySpectrum
+  (H.toTwoSiteExactSectorGauge hCanonical hM).toTwoSiteMultiplicitySpectrum
 
-/-- The two-site multiplicity spectrum under normalized BNT-refined horizontal
-form entails the corresponding multiplicity-spectrum comparison.
-
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+/-- The two-site multiplicity spectrum under literal CPSV canonical form entails
+the corresponding multiplicity-spectrum comparison.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2046--2058 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
 noncomputable def toMultiplicitySpectrumComparison
     {M : MPOTensor d D} (H : BNTAlgebraTensorClause M)
-    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M) :
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) :
     BNTMultiplicitySpectrumComparison H.algebraClause.positiveChi.chi
       H.traceScalars :=
-  (H.toTwoSiteMultiplicitySpectrum hHorizontal hM).toComparison
+  (H.toTwoSiteMultiplicitySpectrum hCanonical hM).toComparison
 
 end BNTAlgebraTensorClause
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -137,7 +137,8 @@
     \cite[Appendix~C.4, lines~2053--2057]{Cirac2016MPDO_arXiv}.
     It does not include the further conclusion on line~2057 that $Z_\gamma$
     may be chosen unitary.
-    % The full line-2057 unitary source step is tracked in issue 4645 and
+    % The line-2057 common-target Gram step is tracked in issue 4648; the
+    % subsequent scalar-to-unitary normalization is tracked in issue 4645 and
     % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{definition}
 
@@ -149,14 +150,14 @@
     \lean{MPOTensor.BNTAlgebraTensorClause.%
         toTwoSiteMultiplicitySpectrum}
     \leanok
-    \uses{def:horizontal_cf_mpdo, def:mpdo,
+    \uses{def:cpsv_canonical_form, def:mpdo,
         def:mpdo_bnt_algebra_tensor_clause,
         def:mpdo_bnt_two_site_multiplicity_spectrum,
         def:mpdo_bnt_two_site_exact_sector_gauge,
         def:mpdo_bnt_multiplicity_spectrum_comparison,
         def:mpdo_bnt_eventual_power_sums_multiplicity_comparison}
-    Let $M$ be an MPDO in normalized BNT-refined horizontal form, equipped
-    with a tensor-attached BNT algebra clause
+    Let $M$ be an MPDO whose doubled-index MPS tensor is in literal CPSV
+    canonical form, equipped with a tensor-attached BNT algebra clause
     $\widetilde M=\bigoplus_\alpha \mu_\alpha\otimes M_\alpha$.
     There is a vertical canonical decomposition of the two-site blocking,
     \begin{align}
@@ -188,16 +189,13 @@
     lines~2053--2057; no unitary choice of $Z_\gamma$ follows from this
     statement.
 
-    \textbf{Scope restriction (BNT-refined horizontal form):}
-    the normalized BNT-refined horizontal hypothesis is stronger than the
-    literal CPSV canonical-form hypothesis.
-    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
-    % The full line-2057 unitary source step is tracked in issue 4645 and
+    % The line-2057 common-target Gram step is tracked in issue 4648; the
+    % subsequent scalar-to-unitary normalization is tracked in issue 4645 and
     % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:vertical_cf_of_horizontal_cf}
+    \uses{thm:mpdo_literal_cpsv_vertical_decomposition_block_two}
     Multiplying the two one-site decompositions and using the BNT algebra law
     expresses the two-site closed chain in the basis $M_\gamma$, with
     coefficient


### PR DESCRIPTION
### Motivation

- Appendix C.4 of arXiv:1606.00608 starts the two-site BNT comparison from literal CPSV
  canonical form and MPDO positivity, but the existing constructor required the stronger
  project-specific normalized horizontal form.
- Source: `Papers/1606.00608/MPDO-22-12-17-2.tex`, Theorem `thm:IV.13`, lines 972–993;
  Proposition `Prop:IV.12`, lines 1863–1921; and Appendix C.4, lines 2046–2058. The source
  begins: “Given a tensor M in CF that generates MPDO”.

### Description

- Refactor `BNTAlgebraTensorClause.toTwoSiteExactSectorGauge` to assume literal
  `IsCPSVCanonicalForm M.toMPSTensor` and use the existing source-faithful two-site vertical
  decomposition.
- Propagate the same hypothesis correction to `toTwoSiteMultiplicitySpectrum` and
  `toMultiplicitySpectrumComparison`, preserving their established mathematical names.
- Synchronize the Chapter 21 Blueprint statement and proof dependencies.
- Keep the line-2057 common-target Gram step (#4648) and scalar-to-unitary normalization
  (#4645) explicitly separate; this PR still concludes only exact phase-one invertible gauges.

### Testing

- `lake build TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --update-lean-decls --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- Proof-integrity scan, recovered-name scan, and `git diff --check`
- `leanblueprint checkdecls` was not used as a local completion claim: the focused hot-main
  cache lacks the repository-wide TNLean object set. Exact-head CI remains the full declaration
  and build gate; no Mathlib source build was run.

Closes #5269

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hypotheses and proof dependencies for a central MPDO/BNT formalization theorem; logic is localized but callers must supply CPSV canonical form instead of horizontal CF.
> 
> **Overview**
> Aligns the **BNT algebra tensor clause → two-site multiplicity spectrum** constructors with arXiv:1606.00608 by replacing the stronger **normalized horizontal form** hypothesis (`IsHorizontalCF`) with **literal CPSV canonical form** on the doubled MPS tensor (`MPSTensor.IsCPSVCanonicalForm M.toMPSTensor`).
> 
> `toTwoSiteExactSectorGauge`, `toTwoSiteMultiplicitySpectrum`, and `toMultiplicitySpectrumComparison` now take `hCanonical` plus `IsMPDO`; the proof obtains the two-site vertical decomposition via `exists_cpsvVerticalDecomposition_blockTwo` from `CPSVVerticalDecomposition` instead of the horizontal-form / RFP fusion path. Module docs and docstrings drop the “BNT-refined horizontal is stronger than CPSV” scope notes.
> 
> Chapter 21 blueprint **Theorem** (two-site multiplicity spectrum from the BNT algebra clause) is updated to state literal CPSV canonical form, `\uses{def:cpsv_canonical_form, ...}`, and proof dependency `thm:mpdo_literal_cpsv_vertical_decomposition_block_two` instead of `thm:vertical_cf_of_horizontal_cf`. Comments still separate the line-2057 Gram step (#4648) from scalar-to-unitary normalization (#4645).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a66b278b4cc51045199a02b00763243a8c7f24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->