### PR TITLE
refactor(MPS/MPDO): consolidate CPSV RFP fusion theorem

### DIFF
--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -12,21 +12,20 @@ import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
 /-!
 # The BNT fusion clause from the MPDO renormalization fixed-point condition
 
-This file proves the implication from statement (i) to statement (iii) of
-CPSV16, Theorem 4.14, for an MPDO in normalized BNT-refined horizontal form.
-The transported one-site and two-site vertical forms give both representations
-of the blocked closed-chain operator.  Eventual linear independence of the BNT
-operators compares their coefficients, and the positive power-sum lemma gives
-the length-one trace-scalar identity.  The corresponding Theorem 4.14
-implication from the literal CPSV canonical form is not established here.
-Literal Proposition 4.13 is complete; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+This file gives the common construction of the BNT fusion tensor clause from
+one-site and two-site vertical decompositions, and its specialization to an
+MPDO in normalized BNT-refined horizontal form. The transported vertical forms
+give both representations of the blocked closed-chain operator. Eventual
+linear independence of the BNT operators compares their coefficients, and the
+positive power-sum lemma gives the length-one trace-scalar identity.
 
 ## Main result
 
-* `HasBNTFusionTensorClause.of_isRFPViaTS` constructs the active-support fusion
-  clause from the Definition 4.1 RFP maps under the normalized BNT-refined
-  horizontal-form hypothesis.
+* `HasBNTFusionTensorClause.of_verticalDecompositions_of_unitaryBlockEquiv`
+  completes positive fusion data related by a unitary sector equivalence to a
+  BNT fusion tensor clause.
+* `HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF` specializes the
+  construction to normalized BNT-refined horizontal form.
 
 ## References
 
@@ -304,42 +303,55 @@ theorem hasIdempotentCoefficientForm_of_blockedRepresentations
 
 namespace HasBNTFusionTensorClause
 
-/-- **BNT-refined Theorem 4.14(i) implies (iii).** An MPDO in normalized
-BNT-refined horizontal form that satisfies the Definition 4.1 renormalization
-fixed-point condition has the active-support BNT fusion clause.
+/-- Two vertical decompositions related by a unitary sector equivalence and a
+positive active-sector fusion decomposition determine the BNT fusion tensor
+clause.
 
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form used in Theorem 4.14 through
-Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
-
-The one-site vertical decomposition supplies the BNT tensors, multiplicities,
-and positive weights.
-The transported RFP maps compare it with the two-site decomposition, produce
-the positive chi matrices and fusion coisometries, and give both blocked
-operator representations.  The preceding coefficient comparison supplies the
-remaining length-one idempotent law.
+This is the common final construction in the forward implication of CPSV16,
+Theorem 4.14. The simultaneous one-site and two-site representations give the
+idempotent trace-scalar identity, which completes the supplied positive fusion
+data to the tensor clause.
 
 Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
-lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-theorem of_isRFPViaTS (M : MPOTensor d D)
-    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
-    (hRFP : IsRFPViaTS M) : HasBNTFusionTensorClause M := by
-  classical
-  obtain ⟨D₁⟩ := hHorizontal.exists_cpsvVerticalDecomposition M hM
-  obtain ⟨D₂⟩ := hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
-    (blockTwo M) hM.blockTwo
-  obtain ⟨Smap, T, hSCPTP, hTCPTP, hSphys, hTphys⟩ := hRFP
-  obtain ⟨sigma, hDim, V, _hContract, hLetter⟩ :=
-    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
-      D₁.bondDim D₁.multiplicity D₁.weight
-      D₂.bondDim D₂.multiplicity D₂.weight
-      D₁.multiplicity_pos D₁.weight_pos
-      D₂.multiplicity_pos D₂.weight_pos
-      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
-      D₁.verticalCoisometry D₂.verticalCoisometry
-      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
-      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
-      hTphys hSphys
+lines 2001--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem of_verticalDecompositions_of_unitaryBlockEquiv
+    {d D : ℕ} {M : MPOTensor d D}
+    (D₁ : CPSVVerticalDecomposition M)
+    (D₂ : CPSVVerticalDecomposition (blockTwo M))
+    (sigma : Fin D₁.labelCount ≃ Fin D₂.labelCount)
+    (hDim : ∀ i, D₁.bondDim i = D₂.bondDim (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (D₂.bondDim (sigma i))) ℂ)
+    (hLetter : ∀ (i : Fin D₁.labelCount) (ab : Fin (D * D)),
+      D₂.tensor (sigma i) ab =
+        (verticalMultiplicityTrace D₁.weight i /
+          verticalMultiplicityTrace D₂.weight (sigma i)) •
+        ((V i : Matrix (Fin (D₂.bondDim (sigma i)))
+            (Fin (D₂.bondDim (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (D₁.tensor i ab) *
+          (V i : Matrix (Fin (D₂.bondDim (sigma i)))
+            (Fin (D₂.bondDim (sigma i))) ℂ)ᴴ))
+    (chi : DiagonalChiFamily (Fin D₁.labelCount))
+    (U : ∀ α β : Fin D₁.labelCount,
+      Matrix ((γ : Fin D₁.labelCount) ×
+        (Fin (chi.dim α β γ) × Fin (D₁.bondDim γ)))
+        (Fin (D₁.bondDim α * D₁.bondDim β)) ℂ)
+    (hChiPos : chi.PosEntries)
+    (hCoisometry : ∀ α β, U α β * (U α β)ᴴ = 1)
+    (hFusion : ∀ (α β : Fin D₁.labelCount) (i j : Fin D),
+      U α β *
+          (mulTensor (verticalBNTMPO (D₁.tensor α))
+            (verticalBNTMPO (D₁.tensor β))) i j *
+          (U α β)ᴴ =
+        Matrix.blockDiagonal' fun γ ↦
+          chi.matrix α β γ ⊗ₖ (verticalBNTMPO (D₁.tensor γ)) i j)
+    (hReconstruction : ∀ (α β : Fin D₁.labelCount) (i j : Fin D),
+      (mulTensor (verticalBNTMPO (D₁.tensor α))
+        (verticalBNTMPO (D₁.tensor β))) i j =
+        (U α β)ᴴ *
+          (Matrix.blockDiagonal' fun γ ↦
+            chi.matrix α β γ ⊗ₖ (verticalBNTMPO (D₁.tensor γ)) i j) *
+          U α β) :
+    HasBNTFusionTensorClause M := by
   have hRepresentations : ∀ (L : ℕ), 0 < L →
       mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
           ∑ γ,
@@ -361,18 +373,8 @@ theorem of_isRFPViaTS (M : MPOTensor d D)
       D₁.coisometry D₂.coisometry
       D₁.reconstruction D₂.reconstruction
       sigma hDim V hLetter hL
-  obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
-    exists_positiveFusionDecomposition_of_unitaryBlockEquiv
-      D₁.bondDim D₁.multiplicity D₁.weight
-      D₂.bondDim D₂.multiplicity D₂.weight
-      D₁.multiplicity_pos D₁.weight_pos
-      D₂.multiplicity_pos D₂.weight_pos
-      M D₁.tensor D₂.tensor D₂.isCPSVBNT
-      D₁.verticalCoisometry D₂.verticalCoisometry
-      D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
-      sigma hDim V hLetter hHorizontal hM
   have hIdempotent := hasIdempotentCoefficientForm_of_blockedRepresentations
-    D₁ D₂ sigma chi U hChiPos hU hFusion hFusionReconstruction
+    D₁ D₂ sigma chi U hChiPos hCoisometry hFusion hReconstruction
     hRepresentations
   exact ⟨{
     labelCount := D₁.labelCount
@@ -390,11 +392,61 @@ theorem of_isRFPViaTS (M : MPOTensor d D)
     chi := chi
     chi_pos := hChiPos
     fusionCoisometry := U
-    fusionCoisometry_mul_conjTranspose := hU
+    fusionCoisometry_mul_conjTranspose := hCoisometry
     fusion := hFusion
-    fusionReconstruction := hFusionReconstruction
+    fusionReconstruction := hReconstruction
     idempotent := hIdempotent
   }⟩
+
+/-- An MPDO in normalized BNT-refined horizontal form that satisfies the
+Definition 4.1 renormalization fixed-point condition has the active-support
+BNT fusion clause.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Theorem 4.14 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
+The one-site vertical decomposition supplies the BNT tensors, multiplicities,
+and positive weights.
+The transported RFP maps compare it with the two-site decomposition, produce
+the positive chi matrices and fusion coisometries, and give both blocked
+operator representations.  The preceding coefficient comparison supplies the
+remaining length-one idempotent law.
+
+Source: CPSV16, Appendix C.4, lines 1929--2046 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem of_isRFPViaTS_of_horizontalCF (M : MPOTensor d D)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) : HasBNTFusionTensorClause M := by
+  classical
+  obtain ⟨D₁⟩ := hHorizontal.exists_cpsvVerticalDecomposition M hM
+  obtain ⟨D₂⟩ := hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
+    (blockTwo M) hM.blockTwo
+  obtain ⟨Smap, T, hSCPTP, hTCPTP, hSphys, hTphys⟩ := hRFP
+  obtain ⟨sigma, hDim, V, _hContract, hLetter⟩ :=
+    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
+      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
+      hTphys hSphys
+  obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
+    exists_positiveFusionDecomposition_of_unitaryBlockEquiv
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
+      sigma hDim V hLetter hHorizontal hM
+  exact of_verticalDecompositions_of_unitaryBlockEquiv
+    D₁ D₂ sigma hDim V hLetter chi U hChiPos hU hFusion
+      hFusionReconstruction
 
 end HasBNTFusionTensorClause
 

--- a/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
@@ -16,7 +16,7 @@ BNT fusion tensor clause.
 
 ## Main result
 
-* `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm`
+* `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS`
 
 ## References
 
@@ -52,7 +52,7 @@ the exact reconstruction. Documented in
 
 Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
 lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)
+theorem of_isRFPViaTS (M : MPOTensor d D)
     (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
     HasBNTFusionTensorClause M := by
@@ -71,27 +71,6 @@ theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)
       D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
       D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
       hTphys hSphys
-  have hRepresentations : ∀ (L : ℕ), 0 < L →
-      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
-          ∑ γ,
-            (((verticalMultiplicityTrace D₁.weight γ /
-                verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
-              (∑ r, D₂.weight (sigma γ) r ^ L)) •
-              mpo (verticalBNTMPO (D₁.tensor γ)) L ∧
-      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
-        ∑ α, ∑ β,
-          ((∑ q, D₁.weight α q ^ L) * (∑ r, D₁.weight β r ^ L)) •
-            (mpo (verticalBNTMPO (D₁.tensor α)) L *
-              mpo (verticalBNTMPO (D₁.tensor β)) L) := by
-    intro L hL
-    exact blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv
-      D₁.bondDim D₁.multiplicity D₁.weight
-      D₂.bondDim D₂.multiplicity D₂.weight
-      M D₁.tensor D₂.tensor
-      D₁.verticalCoisometry D₂.verticalCoisometry
-      D₁.coisometry D₂.coisometry
-      D₁.reconstruction D₂.reconstruction
-      sigma hDim V hLetter hL
   obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
     exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm
       D₁.bondDim D₁.multiplicity D₁.weight
@@ -102,30 +81,9 @@ theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)
       D₁.verticalCoisometry D₂.verticalCoisometry
       D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
       sigma hDim V hLetter hCanonical hM
-  have hIdempotent := hasIdempotentCoefficientForm_of_blockedRepresentations
-    D₁ D₂ sigma chi U hChiPos hU hFusion hFusionReconstruction
-    hRepresentations
-  exact ⟨{
-    labelCount := D₁.labelCount
-    bondDim := D₁.bondDim
-    multiplicity := D₁.multiplicity
-    weight := D₁.weight
-    tensor := D₁.tensor
-    verticalCoisometry := D₁.verticalCoisometry
-    multiplicity_pos := D₁.multiplicity_pos
-    weight_pos := D₁.weight_pos
-    coisometry := D₁.coisometry
-    isCPSVBNT := D₁.isCPSVBNT
-    forward := D₁.forward
-    reconstruction := D₁.reconstruction
-    chi := chi
-    chi_pos := hChiPos
-    fusionCoisometry := U
-    fusionCoisometry_mul_conjTranspose := hU
-    fusion := hFusion
-    fusionReconstruction := hFusionReconstruction
-    idempotent := hIdempotent
-  }⟩
+  exact of_verticalDecompositions_of_unitaryBlockEquiv
+    D₁ D₂ sigma hDim V hLetter chi U hChiPos hU hFusion
+      hFusionReconstruction
 
 end HasBNTFusionTensorClause
 

--- a/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
@@ -57,8 +57,7 @@ noncomputable def cpsvRFPBNTFusionTensorClause (M : MPOTensor d D)
     (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
     BNTFusionTensorClause M :=
   Classical.choice
-    (HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm
-      M hCanonical hM hRFP)
+    (HasBNTFusionTensorClause.of_isRFPViaTS M hCanonical hM hRFP)
 
 /-- **Physical-coordinate commuting Gibbs decomposition for a literal CPSV
 RFP MPDO above one site.**

--- a/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
+++ b/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
@@ -690,7 +690,8 @@ theorem exists_topologicalDensityDecomposition_of_isRFPViaTS
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
     (hRFP : IsRFPViaTS M) :
     ∃ H : BNTFusionTensorClause M, H.HasTopologicalDensityDecomposition := by
-  obtain ⟨H⟩ := HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
+  obtain ⟨H⟩ :=
+    HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF M hHorizontal hM hRFP
   exact ⟨H, H.hasTopologicalDensityDecomposition⟩
 
 /-- **All-label density-factor commutator for an RFP MPDO.**
@@ -714,7 +715,8 @@ theorem exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaT
     (hRFP : IsRFPViaTS M) :
     ∃ H : BNTFusionTensorClause M,
       H.HasTopologicalDensityDecomposition ∧ H.HasTopologicalDensityFactorCommutator := by
-  obtain ⟨H⟩ := HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
+  obtain ⟨H⟩ :=
+    HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF M hHorizontal hM hRFP
   exact ⟨H, H.hasTopologicalDensityDecomposition,
     H.hasTopologicalDensityFactorCommutator⟩
 

--- a/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
+++ b/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
@@ -613,7 +613,8 @@ noncomputable def rfpBNTFusionTensorClause (M : MPOTensor d D)
     (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
     (hRFP : IsRFPViaTS M) : BNTFusionTensorClause M :=
   Classical.choice
-    (HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP)
+    (HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF
+      M hHorizontal hM hRFP)
 
 /-- **Terminal spectral projector refinement for a length-independent RFP
 MPDO.**

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -188,9 +188,9 @@
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[BNT-refined renormalization fixed points have active-sector fusion]%
+\begin{theorem}[Horizontal-form renormalization fixed points have active-sector fusion]%
     \label{thm:mpdo_rfp_to_bnt_fusion_tensor}
-    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}
+    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF}
     \leanok
     \uses{def:is_rfp_via_ts,
         def:vertical_cf_mpdo,
@@ -221,8 +221,7 @@
 
 \begin{theorem}[Literal CPSV renormalization fixed points have active-sector fusion]%
     \label{thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor}
-    \lean{MPOTensor.HasBNTFusionTensorClause.%
-of_isRFPViaTS_of_cpsvCanonicalForm}
+    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}
     \leanok
     \uses{def:mpdo, def:cpsv_canonical_form, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause}

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L475, 477 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L338 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L474, 476 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L337 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |


### PR DESCRIPTION
## Summary

- make `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS` the unique source-facing theorem under literal CPSV canonical form
- retain the genuinely used stronger-boundary result as `of_isRFPViaTS_of_horizontalCF`
- factor both through the source-cited mathematical construction `of_verticalDecompositions_of_unitaryBlockEquiv`
- migrate all consumers and distinguish the literal theorem from its horizontal-form corollary in Chapter 21

## Source

This consolidates the forward implication in CPSV16, Theorem 4.14 and Appendix C.4, especially lines 1929–2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. The literal theorem keeps the existing active-support scope and documented local fixes.

## Validation

- cached targeted builds of the two defining modules
- cached targeted builds of `TopologicalDensityDecomposition`, `TopologicalTerminalSpectral`, and `CPSVTopologicalPhysicalGibbs`
- tactic-pattern scan
- Blueprint declaration sync and reverse-coverage checks
- reader-facing prose and proof-integrity scans
- `git diff --check`

No Mathlib source build or broad `lake build` was run. Local repository-wide `leanblueprint checkdecls` remains unavailable from the focused cache because aggregate current-main declarations are not hydrated; CI is authoritative for that gate.

Closes #5270

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor and API rename with no change to mathematical hypotheses; consumers and blueprint links are updated in the same PR.
> 
> **Overview**
> **Refactors** the Theorem 4.14(i)→(iii) proof so the duplicated “blocked representations + idempotent + assemble clause” logic lives in one place, and **renames** the public theorems to match the two hypotheses (literal CPSV vs BNT-refined horizontal form).
> 
> A new lemma **`HasBNTFusionTensorClause.of_verticalDecompositions_of_unitaryBlockEquiv`** takes one-site and two-site vertical decompositions, a unitary sector equivalence, and positive fusion data (`chi`, `U`, coisometry/fusion/reconstruction hypotheses) and finishes the BNT fusion tensor clause. The former monolithic proof in `BNTFusionTensorClauseFromRFP.lean` becomes this shared step plus a thin **`of_isRFPViaTS_of_horizontalCF`** that obtains `D₁`, `D₂`, `sigma`, `V`, and positive fusion from the RFP transport lemmas.
> 
> **Naming:** **`of_isRFPViaTS`** (with `IsCPSVCanonicalForm`) is now the **literal CPSV** theorem in `CPSVBNTFusionTensorClauseFromRFP.lean`; the horizontal-form result is **`of_isRFPViaTS_of_horizontalCF`**. Literal CPSV and horizontal paths both **`exact`** the shared constructor after their respective `exists_positiveFusionDecomposition_*` lemmas.
> 
> **Call sites** switch accordingly: `CPSVTopologicalPhysicalGibbs`, `TopologicalDensityDecomposition`, and `TopologicalTerminalSpectral` use the renamed theorems; Chapter 21 blueprint `\lean{...}` tags and theorem titles distinguish horizontal-form vs literal CPSV. A trivial line-number tweak in `docs/tenkz/DISPOSITIONS.md` for `ch21_mpdo_rfp_fusion_isometries_product_laws.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1ffd87fa18f0392a9f1a80cbe0727c91d3c598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->