### PR TITLE
refactor(MPS/MPDO): consolidate RFP fusion theorem

### DIFF
--- a/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/BNTFusionTensorClauseFromRFP.lean
@@ -12,21 +12,19 @@ import TNLean.MPS.MPDO.RFPPositiveFusionDecomposition
 /-!
 # The BNT fusion clause from the MPDO renormalization fixed-point condition
 
-This file proves the implication from statement (i) to statement (iii) of
-CPSV16, Theorem 4.14, for an MPDO in normalized BNT-refined horizontal form.
-The transported one-site and two-site vertical forms give both representations
-of the blocked closed-chain operator.  Eventual linear independence of the BNT
-operators compares their coefficients, and the positive power-sum lemma gives
-the length-one trace-scalar identity.  The corresponding Theorem 4.14
-implication from the literal CPSV canonical form is not established here.
-Literal Proposition 4.13 is complete; see
-`docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+This file proves the common construction from one-site and two-site vertical
+decompositions to the active-sector BNT fusion clause.  The transported forms
+give both representations of the blocked closed-chain operator.  Eventual
+linear independence of the BNT operators compares their coefficients, and the
+positive power-sum lemma gives the length-one trace-scalar identity.
 
 ## Main result
 
-* `HasBNTFusionTensorClause.of_isRFPViaTS` constructs the active-support fusion
-  clause from the Definition 4.1 RFP maps under the normalized BNT-refined
-  horizontal-form hypothesis.
+* `HasBNTFusionTensorClause.of_verticalDecompositions_of_unitaryBlockEquiv`
+  constructs the fusion clause from paired vertical decompositions, their
+  unitary sector correspondence, and positive fusion coisometries.
+* `HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF` gives the
+  normalized BNT-refined horizontal-form specialization.
 
 ## References
 
@@ -304,42 +302,52 @@ theorem hasIdempotentCoefficientForm_of_blockedRepresentations
 
 namespace HasBNTFusionTensorClause
 
-/-- **BNT-refined Theorem 4.14(i) implies (iii).** An MPDO in normalized
-BNT-refined horizontal form that satisfies the Definition 4.1 renormalization
-fixed-point condition has the active-support BNT fusion clause.
+/-- Paired vertical decompositions, their unitary sector correspondence, and
+positive fusion coisometries determine the tensor-attached fusion clause.
 
-**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
-stronger than the literal CPSV canonical form used in Theorem 4.14 through
-Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+The two descriptions of the blocked closed-chain operator give the
+length-one idempotent identity for the multiplicity traces.
 
-The one-site vertical decomposition supplies the BNT tensors, multiplicities,
-and positive weights.
-The transported RFP maps compare it with the two-site decomposition, produce
-the positive chi matrices and fusion coisometries, and give both blocked
-operator representations.  The preceding coefficient comparison supplies the
-remaining length-one idempotent law.
-
-Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
-lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-theorem of_isRFPViaTS (M : MPOTensor d D)
-    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
-    (hRFP : IsRFPViaTS M) : HasBNTFusionTensorClause M := by
-  classical
-  obtain ⟨D₁⟩ := hHorizontal.exists_cpsvVerticalDecomposition M hM
-  obtain ⟨D₂⟩ := hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
-    (blockTwo M) hM.blockTwo
-  obtain ⟨Smap, T, hSCPTP, hTCPTP, hSphys, hTphys⟩ := hRFP
-  obtain ⟨sigma, hDim, V, _hContract, hLetter⟩ :=
-    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
-      D₁.bondDim D₁.multiplicity D₁.weight
-      D₂.bondDim D₂.multiplicity D₂.weight
-      D₁.multiplicity_pos D₁.weight_pos
-      D₂.multiplicity_pos D₂.weight_pos
-      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
-      D₁.verticalCoisometry D₂.verticalCoisometry
-      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
-      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
-      hTphys hSphys
+Source: CPSV16, Appendix C.4, lines 2001--2046 of
+`Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem of_verticalDecompositions_of_unitaryBlockEquiv
+    {M : MPOTensor d D}
+    (D₁ : CPSVVerticalDecomposition M)
+    (D₂ : CPSVVerticalDecomposition (blockTwo M))
+    (sigma : Fin D₁.labelCount ≃ Fin D₂.labelCount)
+    (hDim : ∀ i, D₁.bondDim i = D₂.bondDim (sigma i))
+    (V : ∀ i, Matrix.unitaryGroup (Fin (D₂.bondDim (sigma i))) ℂ)
+    (hLetter : ∀ (i : Fin D₁.labelCount) (ab : Fin (D * D)),
+      D₂.tensor (sigma i) ab =
+        (verticalMultiplicityTrace D₁.weight i /
+          verticalMultiplicityTrace D₂.weight (sigma i)) •
+        ((V i : Matrix (Fin (D₂.bondDim (sigma i)))
+            (Fin (D₂.bondDim (sigma i))) ℂ) *
+          Matrix.reindexAlgEquiv ℂ ℂ (finCongr (hDim i)) (D₁.tensor i ab) *
+          (V i : Matrix (Fin (D₂.bondDim (sigma i)))
+            (Fin (D₂.bondDim (sigma i))) ℂ)ᴴ))
+    (chi : DiagonalChiFamily (Fin D₁.labelCount))
+    (U : ∀ α β : Fin D₁.labelCount,
+      Matrix ((γ : Fin D₁.labelCount) ×
+        (Fin (chi.dim α β γ) × Fin (D₁.bondDim γ)))
+        (Fin (D₁.bondDim α * D₁.bondDim β)) ℂ)
+    (hChiPos : chi.PosEntries)
+    (hU : ∀ α β, U α β * (U α β)ᴴ = 1)
+    (hFusion : ∀ (α β : Fin D₁.labelCount) (i j : Fin D),
+      U α β *
+          (mulTensor (verticalBNTMPO (D₁.tensor α))
+            (verticalBNTMPO (D₁.tensor β))) i j *
+          (U α β)ᴴ =
+        Matrix.blockDiagonal' fun γ ↦
+          chi.matrix α β γ ⊗ₖ (verticalBNTMPO (D₁.tensor γ)) i j)
+    (hFusionReconstruction : ∀ (α β : Fin D₁.labelCount) (i j : Fin D),
+      (mulTensor (verticalBNTMPO (D₁.tensor α))
+        (verticalBNTMPO (D₁.tensor β))) i j =
+          (U α β)ᴴ *
+            (Matrix.blockDiagonal' fun γ ↦
+              chi.matrix α β γ ⊗ₖ (verticalBNTMPO (D₁.tensor γ)) i j) *
+            U α β) :
+    HasBNTFusionTensorClause M := by
   have hRepresentations : ∀ (L : ℕ), 0 < L →
       mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
           ∑ γ,
@@ -361,16 +369,6 @@ theorem of_isRFPViaTS (M : MPOTensor d D)
       D₁.coisometry D₂.coisometry
       D₁.reconstruction D₂.reconstruction
       sigma hDim V hLetter hL
-  obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
-    exists_positiveFusionDecomposition_of_unitaryBlockEquiv
-      D₁.bondDim D₁.multiplicity D₁.weight
-      D₂.bondDim D₂.multiplicity D₂.weight
-      D₁.multiplicity_pos D₁.weight_pos
-      D₂.multiplicity_pos D₂.weight_pos
-      M D₁.tensor D₂.tensor D₂.isCPSVBNT
-      D₁.verticalCoisometry D₂.verticalCoisometry
-      D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
-      sigma hDim V hLetter hHorizontal hM
   have hIdempotent := hasIdempotentCoefficientForm_of_blockedRepresentations
     D₁ D₂ sigma chi U hChiPos hU hFusion hFusionReconstruction
     hRepresentations
@@ -395,6 +393,56 @@ theorem of_isRFPViaTS (M : MPOTensor d D)
     fusionReconstruction := hFusionReconstruction
     idempotent := hIdempotent
   }⟩
+
+/-- **BNT-refined Theorem 4.14(i) implies (iii).** An MPDO in normalized
+BNT-refined horizontal form that satisfies the Definition 4.1 renormalization
+fixed-point condition has the active-support BNT fusion clause.
+
+**Scope restriction (BNT-refined horizontal form):** `IsHorizontalCF` is
+stronger than the literal CPSV canonical form used in Theorem 4.14 through
+Proposition 4.13; see `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex`.
+
+The one-site vertical decomposition supplies the BNT tensors, multiplicities,
+and positive weights.
+The transported RFP maps compare it with the two-site decomposition, produce
+the positive chi matrices and fusion coisometries, and give both blocked
+operator representations.  The preceding coefficient comparison supplies the
+remaining length-one idempotent law.
+
+Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
+lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
+theorem of_isRFPViaTS_of_horizontalCF (M : MPOTensor d D)
+    (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
+    (hRFP : IsRFPViaTS M) : HasBNTFusionTensorClause M := by
+  classical
+  obtain ⟨D₁⟩ := hHorizontal.exists_cpsvVerticalDecomposition M hM
+  obtain ⟨D₂⟩ := hHorizontal.blockTwo.exists_cpsvVerticalDecomposition
+    (blockTwo M) hM.blockTwo
+  obtain ⟨Smap, T, hSCPTP, hTCPTP, hSphys, hTphys⟩ := hRFP
+  obtain ⟨sigma, hDim, V, _hContract, hLetter⟩ :=
+    transportedVerticalSector_exists_unitaryBlockEquiv_coefficient_eq
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₁.isCPSVBNT D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
+      D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
+      hTphys hSphys
+  obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
+    exists_positiveFusionDecomposition_of_unitaryBlockEquiv
+      D₁.bondDim D₁.multiplicity D₁.weight
+      D₂.bondDim D₂.multiplicity D₂.weight
+      D₁.multiplicity_pos D₁.weight_pos
+      D₂.multiplicity_pos D₂.weight_pos
+      M D₁.tensor D₂.tensor D₂.isCPSVBNT
+      D₁.verticalCoisometry D₂.verticalCoisometry
+      D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
+      sigma hDim V hLetter hHorizontal hM
+  exact of_verticalDecompositions_of_unitaryBlockEquiv
+    D₁ D₂ sigma hDim V hLetter chi U hChiPos hU hFusion
+    hFusionReconstruction
 
 end HasBNTFusionTensorClause
 

--- a/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
+++ b/TNLean/MPS/MPDO/CPSVBNTFusionTensorClauseFromRFP.lean
@@ -16,7 +16,7 @@ BNT fusion tensor clause.
 
 ## Main result
 
-* `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm`
+* `MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS`
 
 ## References
 
@@ -52,7 +52,7 @@ the exact reconstruction. Documented in
 
 Source: CPSV16, Theorem 4.14(i),(iii), lines 972--993, and Appendix C.4,
 lines 1929--2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
-theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)
+theorem of_isRFPViaTS (M : MPOTensor d D)
     (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
     HasBNTFusionTensorClause M := by
@@ -71,27 +71,6 @@ theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)
       D₁.coisometry D₂.coisometry T Smap hTCPTP hSCPTP
       D₁.forward D₁.reconstruction D₂.forward D₂.reconstruction
       hTphys hSphys
-  have hRepresentations : ∀ (L : ℕ), 0 < L →
-      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
-          ∑ γ,
-            (((verticalMultiplicityTrace D₁.weight γ /
-                verticalMultiplicityTrace D₂.weight (sigma γ)) ^ L) *
-              (∑ r, D₂.weight (sigma γ) r ^ L)) •
-              mpo (verticalBNTMPO (D₁.tensor γ)) L ∧
-      mpo (verticalBNTMPO (verticalTensor (blockTwo M))) L =
-        ∑ α, ∑ β,
-          ((∑ q, D₁.weight α q ^ L) * (∑ r, D₁.weight β r ^ L)) •
-            (mpo (verticalBNTMPO (D₁.tensor α)) L *
-              mpo (verticalBNTMPO (D₁.tensor β)) L) := by
-    intro L hL
-    exact blockedVerticalOperatorRepresentations_of_unitaryBlockEquiv
-      D₁.bondDim D₁.multiplicity D₁.weight
-      D₂.bondDim D₂.multiplicity D₂.weight
-      M D₁.tensor D₂.tensor
-      D₁.verticalCoisometry D₂.verticalCoisometry
-      D₁.coisometry D₂.coisometry
-      D₁.reconstruction D₂.reconstruction
-      sigma hDim V hLetter hL
   obtain ⟨chi, U, hChiPos, hU, hFusion, hFusionReconstruction⟩ :=
     exists_positiveFusionDecomposition_of_unitaryBlockEquiv_of_cpsvCanonicalForm
       D₁.bondDim D₁.multiplicity D₁.weight
@@ -102,30 +81,9 @@ theorem of_isRFPViaTS_of_cpsvCanonicalForm (M : MPOTensor d D)
       D₁.verticalCoisometry D₂.verticalCoisometry
       D₁.coisometry D₂.coisometry D₁.reconstruction D₂.reconstruction
       sigma hDim V hLetter hCanonical hM
-  have hIdempotent := hasIdempotentCoefficientForm_of_blockedRepresentations
-    D₁ D₂ sigma chi U hChiPos hU hFusion hFusionReconstruction
-    hRepresentations
-  exact ⟨{
-    labelCount := D₁.labelCount
-    bondDim := D₁.bondDim
-    multiplicity := D₁.multiplicity
-    weight := D₁.weight
-    tensor := D₁.tensor
-    verticalCoisometry := D₁.verticalCoisometry
-    multiplicity_pos := D₁.multiplicity_pos
-    weight_pos := D₁.weight_pos
-    coisometry := D₁.coisometry
-    isCPSVBNT := D₁.isCPSVBNT
-    forward := D₁.forward
-    reconstruction := D₁.reconstruction
-    chi := chi
-    chi_pos := hChiPos
-    fusionCoisometry := U
-    fusionCoisometry_mul_conjTranspose := hU
-    fusion := hFusion
-    fusionReconstruction := hFusionReconstruction
-    idempotent := hIdempotent
-  }⟩
+  exact of_verticalDecompositions_of_unitaryBlockEquiv
+    D₁ D₂ sigma hDim V hLetter chi U hChiPos hU hFusion
+    hFusionReconstruction
 
 end HasBNTFusionTensorClause
 

--- a/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
+++ b/TNLean/MPS/MPDO/CPSVTopologicalPhysicalGibbs.lean
@@ -57,8 +57,7 @@ noncomputable def cpsvRFPBNTFusionTensorClause (M : MPOTensor d D)
     (hM : IsMPDO M) (hRFP : IsRFPViaTS M) :
     BNTFusionTensorClause M :=
   Classical.choice
-    (HasBNTFusionTensorClause.of_isRFPViaTS_of_cpsvCanonicalForm
-      M hCanonical hM hRFP)
+    (HasBNTFusionTensorClause.of_isRFPViaTS M hCanonical hM hRFP)
 
 /-- **Physical-coordinate commuting Gibbs decomposition for a literal CPSV
 RFP MPDO above one site.**

--- a/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
+++ b/TNLean/MPS/MPDO/TopologicalDensityDecomposition.lean
@@ -690,7 +690,8 @@ theorem exists_topologicalDensityDecomposition_of_isRFPViaTS
     (M : MPOTensor d D) (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
     (hRFP : IsRFPViaTS M) :
     ∃ H : BNTFusionTensorClause M, H.HasTopologicalDensityDecomposition := by
-  obtain ⟨H⟩ := HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
+  obtain ⟨H⟩ :=
+    HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF M hHorizontal hM hRFP
   exact ⟨H, H.hasTopologicalDensityDecomposition⟩
 
 /-- **All-label density-factor commutator for an RFP MPDO.**
@@ -714,7 +715,8 @@ theorem exists_topologicalDensityDecomposition_and_factorCommutator_of_isRFPViaT
     (hRFP : IsRFPViaTS M) :
     ∃ H : BNTFusionTensorClause M,
       H.HasTopologicalDensityDecomposition ∧ H.HasTopologicalDensityFactorCommutator := by
-  obtain ⟨H⟩ := HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP
+  obtain ⟨H⟩ :=
+    HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF M hHorizontal hM hRFP
   exact ⟨H, H.hasTopologicalDensityDecomposition,
     H.hasTopologicalDensityFactorCommutator⟩
 

--- a/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
+++ b/TNLean/MPS/MPDO/TopologicalTerminalSpectral.lean
@@ -613,7 +613,8 @@ noncomputable def rfpBNTFusionTensorClause (M : MPOTensor d D)
     (hHorizontal : IsHorizontalCF M) (hM : IsMPDO M)
     (hRFP : IsRFPViaTS M) : BNTFusionTensorClause M :=
   Classical.choice
-    (HasBNTFusionTensorClause.of_isRFPViaTS M hHorizontal hM hRFP)
+    (HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF
+      M hHorizontal hM hRFP)
 
 /-- **Terminal spectral projector refinement for a length-independent RFP
 MPDO.**

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -188,41 +188,36 @@
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[BNT-refined renormalization fixed points have active-sector fusion]%
-    \label{thm:mpdo_rfp_to_bnt_fusion_tensor}
-    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}
+\begin{theorem}[Paired vertical decompositions determine active-sector fusion]%
+    \label{thm:mpdo_paired_vertical_decompositions_fusion}
+    \lean{MPOTensor.HasBNTFusionTensorClause.%
+of_verticalDecompositions_of_unitaryBlockEquiv}
     \leanok
-    \uses{def:is_rfp_via_ts,
-        def:vertical_cf_mpdo,
-        def:mpdo_bnt_fusion_tensor_clause}
-    Let $M$ be a matrix product density operator in normalized BNT-refined
-    horizontal form. If the one-site and two-site physical closures are
-    related in both directions by trace-preserving completely positive maps
-    as in Definition~4.1, then a vertical canonical decomposition of $M$ has the
-    active-sector fusion clause above. In particular, its positive diagonal
-    fusion matrices satisfy the length-one idempotent trace-scalar identity.
+    \uses{def:mpdo_bnt_fusion_tensor_clause,
+      thm:mpdo_blocked_vertical_operator_representations,
+      thm:mpdo_blocked_representations_idempotent_trace_scalars}
+    Let $\mathcal D_1$ and $\mathcal D_2$ be positive vertical canonical
+    decompositions of an MPO tensor and its two-site blocking. Suppose their
+    normal sectors are identified by a bijection $\sigma$ and unitary
+    conjugacies with the corresponding multiplicity-trace ratios. If the
+    products of the one-site normal tensors have positive active-sector fusion
+    coisometries, then $\mathcal D_1$ determines a tensor-attached fusion
+    clause.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:vertical_cf_of_horizontal_cf}
-    Choose vertical canonical decompositions of the one-site tensor and its
-    two-site blocking. Transporting the two physical maps through these
-    decompositions identifies their normal sectors and yields the positive
-    active-sector fusion of each product $M_\alpha M_\beta$. For every
-    positive length, the blocked operator is therefore both a sum over the
-    two-site multiplicity matrices and the product of the two one-site sums.
-    At all sufficiently large lengths, the normal-sector operators are
-    linearly independent, so their coefficients agree. Equality of the
-    resulting positive power sums identifies the two multisets of
-    multiplicity entries. Summing this multiset identity gives
+    The sector correspondence expresses the blocked closed-chain operator in
+    the one-site normal-tensor basis. Multiplication of the one-site vertical
+    decomposition gives a second expression in the same basis. At every
+    sufficiently large length, linear independence equates their
+    coefficients. Equality of the resulting positive power sums identifies
+    the multiplicity multisets, and summing their entries gives
     $m_\gamma=\sum_{\alpha,\beta}
-      \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$,
-    which completes the fusion clause.
+      \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$.
 \end{proof}
 
 \begin{theorem}[Literal CPSV renormalization fixed points have active-sector fusion]%
     \label{thm:mpdo_literal_cpsv_rfp_to_bnt_fusion_tensor}
-    \lean{MPOTensor.HasBNTFusionTensorClause.%
-of_isRFPViaTS_of_cpsvCanonicalForm}
+    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS}
     \leanok
     \uses{def:mpdo, def:cpsv_canonical_form, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause}
@@ -262,9 +257,8 @@ of_isRFPViaTS_of_cpsvCanonicalForm}
     \uses{thm:mpdo_literal_cpsv_vertical_decomposition,
       thm:mpdo_literal_cpsv_vertical_decomposition_block_two,
       thm:mpdo_transported_vertical_sector_coefficient_comparison,
-      thm:mpdo_blocked_vertical_operator_representations,
       thm:mpdo_literal_cpsv_vertical_product_positive_fusion_decomposition,
-      thm:mpdo_blocked_representations_idempotent_trace_scalars}
+      thm:mpdo_paired_vertical_decompositions_fusion}
     Choose the literal one-site and two-site vertical decompositions.
     Transporting the two physical maps through them identifies their normal
     sectors by trace-ratio unitary conjugacies. The literal positive-fusion
@@ -272,6 +266,36 @@ of_isRFPViaTS_of_cpsvCanonicalForm}
     reconstruction on every active product sector. The two simultaneous
     blocked-operator representations and eventual linear independence of the
     BNT operators then give the length-one idempotent trace-scalar identity.
+\end{proof}
+
+\begin{corollary}[BNT-refined renormalization fixed points have active-sector fusion]%
+    \label{cor:mpdo_rfp_to_bnt_fusion_tensor}
+    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF}
+    \leanok
+    \uses{def:is_rfp_via_ts,
+        def:vertical_cf_mpdo,
+        def:mpdo_bnt_fusion_tensor_clause}
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form. If the one-site and two-site physical closures are
+    related in both directions by trace-preserving completely positive maps
+    as in Definition~4.1, then a vertical canonical decomposition of $M$ has the
+    active-sector fusion clause above. In particular, its positive diagonal
+    fusion matrices satisfy the length-one idempotent trace-scalar identity.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:vertical_cf_of_horizontal_cf,
+      thm:mpdo_transported_vertical_sector_coefficient_comparison,
+      thm:mpdo_paired_vertical_decompositions_fusion}
+    Choose the one-site and two-site vertical canonical decompositions supplied
+    by the normalized BNT-refined horizontal form. The renormalization maps
+    identify their normal sectors and give positive fusion coisometries.
+    Apply the same blocked-operator comparison and positive power-sum argument
+    used in the literal CPSV theorem.
 \end{proof}
 
 \begin{theorem}[Active-sector fusion implies the tensor-attached algebra clause]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -409,7 +409,7 @@
     \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:mpdo_rfp_to_bnt_fusion_tensor,
+    \uses{cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_topological_projector_recursion,
         lem:mpdo_sitewise_physical_coordinate_congruence}
     Under the normalized BNT-refined horizontal hypothesis, the vertical
@@ -465,7 +465,7 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_topological_density_operator,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         cor:mpdo_fusion_clause_topological_density_factor_commutator}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form and suppose that it satisfies the renormalization
@@ -491,7 +491,7 @@
     % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{corollary}
 \begin{proof}\leanok
-    \uses{thm:mpdo_rfp_to_bnt_fusion_tensor}
+    \uses{cor:mpdo_rfp_to_bnt_fusion_tensor}
     In every sitewise copy configuration, the factor $A_N$ is the scalar
     $m(c)$ times the identity on the corresponding simple-bond space.
     It therefore commutes with
@@ -553,7 +553,7 @@
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_fusion_clause_terminal_spectral_refinement,
-        thm:mpdo_rfp_to_bnt_fusion_tensor}
+        cor:mpdo_rfp_to_bnt_fusion_tensor}
     For an MPDO in normalized BNT-refined horizontal form satisfying the
     renormalization fixed-point condition, fix the fusion clause selected by
     that construction. For every terminal label $\gamma$, close the horizontal
@@ -642,7 +642,7 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_terminal_spectral_refinement,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition. Fix
@@ -870,7 +870,7 @@
     \lean{MPOTensor.topologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition.
@@ -995,7 +995,7 @@
     \lean{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L475, 477 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L338 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L499, 501 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L362 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |


### PR DESCRIPTION
## Summary

- extract the common construction from paired one-site and two-site vertical decompositions to the tensor-attached active-sector fusion clause
- give the literal CPSV result the natural public name `HasBNTFusionTensorClause.of_isRFPViaTS`
- retain the stronger normalized horizontal-form result as the explicitly named corollary `of_isRFPViaTS_of_horizontalCF`
- migrate all consumers and replace the duplicate Blueprint theorem nodes by a shared theorem, the literal source theorem, and a scope-restricted corollary

The active-support, empty fixed-pair support, and fusion-coisometry corrections remain explicit and unchanged. No compatibility alias is introduced because the former name encoded the wrong hypothesis boundary.

Source: CPSV16, Theorem 4.14(i),(iii), lines 972–993, and Appendix C.4, lines 1929–2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

## Validation

- targeted compilation of the common theorem, literal theorem, and all migrated consumers
- `lake build`
- Blueprint synchronization and `leanblueprint checkdecls`
- style, prose, proof-integrity, tactic-pattern, and whitespace checks
- independent exact-commit source-faithfulness review

Closes #5270

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Renames break any external code still calling old Lean theorem names; proof logic is reorganized, not weakened, but the API boundary between CPSV and horizontal-form hypotheses is intentionally sharper.
> 
> **Overview**
> Refactors how **active-sector BNT fusion clauses** are obtained from renormalization fixed-point (RFP) data by factoring the duplicated proof into one shared lemma and aligning public theorem names with the actual hypotheses.
> 
> **Shared core:** `HasBNTFusionTensorClause.of_verticalDecompositions_of_unitaryBlockEquiv` now takes paired one-site and two-site vertical decompositions, unitary sector matching, and positive fusion coisometries, then builds blocked-operator representations and the length-one idempotent trace-scalar identity—the part that was duplicated between CPSV and horizontal-form routes.
> 
> **Entry points:** Literal CPSV canonical form + RFP uses the public name `of_isRFPViaTS` (formerly `of_isRFPViaTS_of_cpsvCanonicalForm`) and ends with a one-line call to the shared lemma. Normalized BNT-refined horizontal form + RFP is `of_isRFPViaTS_of_horizontalCF` (formerly the misnamed `of_isRFPViaTS` on the base file).
> 
> **Downstream:** `cpsvRFPBNTFusionTensorClause`, topological density, and terminal spectral code call the renamed lemmas. **Blueprint** adds theorem `thm:mpdo_paired_vertical_decompositions_fusion`, keeps the literal CPSV theorem on `of_isRFPViaTS`, and demotes the horizontal-form RFP implication to corollary `cor:mpdo_rfp_to_bnt_fusion_tensor`; recursive-density chapter proofs cite the corollary instead of the old theorem label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebcdf183d553251f7da1b4a48b41f7c25eae7968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->