### PR TITLE
doc(MPS/MPDO): expose paired fusion construction

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -291,9 +291,8 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     Transporting the two physical maps through them identifies their normal
     sectors by trace-ratio unitary conjugacies. The literal positive-fusion
     theorem gives the positive diagonal matrices, coisometries, and exact
-    reconstruction on every active product sector. The two simultaneous
-    blocked-operator representations and eventual linear independence of the
-    BNT operators then give the length-one idempotent trace-scalar identity.
+    reconstruction on every active product sector. The paired-decomposition
+    theorem then gives the tensor-attached fusion clause.
 \end{proof}
 
 \begin{theorem}[Active-sector fusion implies the tensor-attached algebra clause]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -188,12 +188,41 @@
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[Paired vertical decompositions determine active-sector fusion]%
+    \label{thm:mpdo_paired_vertical_decompositions_fusion}
+    \lean{MPOTensor.HasBNTFusionTensorClause.%
+of_verticalDecompositions_of_unitaryBlockEquiv}
+    \leanok
+    \uses{def:mpdo_bnt_fusion_tensor_clause}
+    Let $\mathcal D_1$ and $\mathcal D_2$ be positive vertical canonical
+    decompositions of an MPO tensor and its two-site blocking. Suppose their
+    normal sectors are identified by a bijection $\sigma$ and unitary
+    conjugacies with the corresponding multiplicity-trace ratios. If the
+    products of the one-site normal tensors have positive active-sector fusion
+    coisometries, then $\mathcal D_1$ determines a tensor-attached fusion
+    clause. This is the common final construction in the forward implication
+    of \cite[Theorem~4.14(i),(iii), lines~972--993, and Appendix~C.4,
+    lines~2001--2046]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpdo_blocked_vertical_operator_representations,
+      thm:mpdo_blocked_representations_idempotent_trace_scalars}
+    The sector correspondence expresses the blocked closed-chain operator in
+    the one-site normal-tensor basis. Multiplication of the one-site vertical
+    decomposition gives a second expression in the same basis. At every
+    sufficiently large length, linear independence equates their
+    coefficients. Equality of the resulting positive power sums identifies
+    the multiplicity multisets, and summing their entries gives
+    $m_\gamma=\sum_{\alpha,\beta}
+      \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$.
+\end{proof}
+
 \begin{theorem}[Horizontal-form renormalization fixed points have active-sector fusion]%
     \label{thm:mpdo_rfp_to_bnt_fusion_tensor}
     \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF}
     \leanok
     \uses{def:is_rfp_via_ts,
-        def:vertical_cf_mpdo,
+        def:horizontal_cf_mpdo,
         def:mpdo_bnt_fusion_tensor_clause}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form. If the one-site and two-site physical closures are
@@ -203,20 +232,15 @@
     fusion matrices satisfy the length-one idempotent trace-scalar identity.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:vertical_cf_of_horizontal_cf}
-    Choose vertical canonical decompositions of the one-site tensor and its
-    two-site blocking. Transporting the two physical maps through these
-    decompositions identifies their normal sectors and yields the positive
-    active-sector fusion of each product $M_\alpha M_\beta$. For every
-    positive length, the blocked operator is therefore both a sum over the
-    two-site multiplicity matrices and the product of the two one-site sums.
-    At all sufficiently large lengths, the normal-sector operators are
-    linearly independent, so their coefficients agree. Equality of the
-    resulting positive power sums identifies the two multisets of
-    multiplicity entries. Summing this multiset identity gives
-    $m_\gamma=\sum_{\alpha,\beta}
-      \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$,
-    which completes the fusion clause.
+    \uses{thm:vertical_cf_of_horizontal_cf,
+      thm:mpdo_transported_vertical_sector_coefficient_comparison,
+      thm:mpdo_transported_vertical_product_positive_fusion_decomposition,
+      thm:mpdo_paired_vertical_decompositions_fusion}
+    Choose the one-site and two-site vertical canonical decompositions supplied
+    by the normalized BNT-refined horizontal form. The renormalization maps
+    identify their normal sectors and give positive fusion coisometries.
+    Apply the paired-decomposition theorem to obtain the tensor-attached
+    fusion clause.
 \end{proof}
 
 \begin{theorem}[Literal CPSV renormalization fixed points have active-sector fusion]%
@@ -261,9 +285,8 @@
     \uses{thm:mpdo_literal_cpsv_vertical_decomposition,
       thm:mpdo_literal_cpsv_vertical_decomposition_block_two,
       thm:mpdo_transported_vertical_sector_coefficient_comparison,
-      thm:mpdo_blocked_vertical_operator_representations,
       thm:mpdo_literal_cpsv_vertical_product_positive_fusion_decomposition,
-      thm:mpdo_blocked_representations_idempotent_trace_scalars}
+      thm:mpdo_paired_vertical_decompositions_fusion}
     Choose the literal one-site and two-site vertical decompositions.
     Transporting the two physical maps through them identifies their normal
     sectors by trace-ratio unitary conjugacies. The literal positive-fusion

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L474, 476 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L337 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L497, 499 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L360 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L497, 499 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L360 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L496, 498 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L359 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |


### PR DESCRIPTION
## Summary

- add the Chapter 21 Blueprint node for the shared `of_verticalDecompositions_of_unitaryBlockEquiv` theorem introduced by #5273
- keep the horizontal-form specialization as a theorem and make its proof dependencies explicit
- factor the literal CPSV proof through the new shared Blueprint node
- refresh the tenkz disposition line inventory

This is the corrected Blueprint-only remainder from closed conflicting PR #5274. It is rebuilt from hot main and contains none of #5274's stale Lean changes.

## Source

The new node records the common final construction in CPSV16, Theorem 4.14(i),(iii), and Appendix C.4, lines 2001–2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

## Validation

- Blueprint Lean declaration sync and reverse-coverage checks
- reader-facing prose check
- tenkz disposition regression and exact inventory reconciliation
- `git diff --check`

No Lean source changed, and no Lake or Lean build was run. Repository-wide declaration checking is left to CI because local `leanblueprint checkdecls` attempted dependency hydration in the isolated worktree and was terminated before any compilation.

Follow-up to #5273. Supersedes the Blueprint-only portion of #5274.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Blueprint dependency wiring only; no Lean or runtime code changes.
> 
> **Overview**
> Adds a **Blueprint theorem** for the shared Lean result `MPOTensor.HasBNTFusionTensorClause.of_verticalDecompositions_of_unitaryBlockEquiv`, recording the common CPSV16 Theorem 4.14 / Appendix C.4 step where paired one- and two-site vertical decompositions (with sector bijection and positive product fusion coisometries) yield a tensor-attached active-sector fusion clause.
> 
> The **horizontal-form RFP** and **literal CPSV RFP** fusion theorems no longer inline that coefficient-matching argument; their proofs pick the appropriate decompositions and transport maps, then cite the new node. The horizontal-form theorem’s `\uses` list now references `def:horizontal_cf_mpdo` instead of `def:vertical_cf_mpdo`.
> 
> `docs/tenkz/DISPOSITIONS.md` is updated so the `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` line references match the shifted source (no Lean changes in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e6bc494cb56e06689a615085be4901af846ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->