### PR TITLE
feat(MPS/MPDO): construct the gauge-dressed sector corner

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
 import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.MPS.MPDO.BNTClosingSelection

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseCorner.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseCorner.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
+import TNLean.MPS.MPDO.FigureEightPairwise
+import TNLean.MPS.MPDO.VerticalProductPairBlocks
+
+/-!
+# The blocked physical corner of the exact two-site sector gauge
+
+The distinguished copy in the two-site vertical decomposition gives an
+isometric physical inclusion for the exact gauge-dressed algebra-side sector.
+The corresponding Gram-dressed marked chain therefore has the reflected form
+appearing on the right-hand side of Figures 7--8.
+
+This constructs only the gauge-dressed physical corner.  It does not construct
+an identity-dressed physical corner for the algebra-side representative and
+does not prove the common-target Gram identity required for the unitary gauge
+conclusion.
+
+## Main results
+
+* `TwoSiteExactSectorGauge.exists_blockTwo_gauge_sector_corner`
+* `TwoSiteExactSectorGauge.markedChainCoefficient_gauge_eq_reflectedAdjoint`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, Figures 7--8, lines 1909--1919, and Appendix C.4,
+  lines 2048--2057
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- Every matched two-site sector has an isometric physical corner whose
+compression is a positive scalar multiple of the exact gauge-dressed
+algebra-side representative.
+
+This is the gauge-dressed half of the marked sector comparison in CPSV16,
+Proposition 4.13, Figures 7--8, lines 1909--1919, applied to the two-site
+decomposition in Appendix C.4, lines 2048--2057.
+
+**Scope restriction (gauge-dressed corner):** This does not construct an
+identity-dressed corner and therefore does not prove the common-target Gram
+identity.  The remaining comparison is documented in
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1909--1919, and Appendix C.4,
+lines 2048--2057. -/
+theorem exists_blockTwo_gauge_sector_corner
+    (S : TwoSiteExactSectorGauge H) (γ : Fin H.labelCount) :
+    ∃ (V : Matrix (Fin (d * d))
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) (c : ℂ),
+      Vᴴ * V = 1 ∧ (0 : ℂ) < c ∧
+        ∀ v : Fin (D * D),
+          Vᴴ * verticalTensor (blockTwo M) v * V =
+            c • ((S.gauge γ : Matrix
+                (Fin (S.decomposition.bondDim (S.relabel γ)))
+                (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+              (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+                (H.tensor γ)) v *
+              (↑((S.gauge γ)⁻¹) : Matrix
+                (Fin (S.decomposition.bondDim (S.relabel γ)))
+                (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)) := by
+  classical
+  let V := blockedReferenceInclusion S.decomposition.bondDim
+    S.decomposition.multiplicity S.decomposition.multiplicity_pos
+    S.decomposition.verticalCoisometry (S.relabel γ)
+  let c := S.decomposition.weight (S.relabel γ)
+    ⟨0, S.decomposition.multiplicity_pos (S.relabel γ)⟩
+  refine ⟨V, c, ?_, ?_, ?_⟩
+  · exact blockedReferenceInclusion_isometry S.decomposition.bondDim
+      S.decomposition.multiplicity S.decomposition.multiplicity_pos
+      S.decomposition.verticalCoisometry S.decomposition.coisometry (S.relabel γ)
+  · exact S.decomposition.weight_pos (S.relabel γ)
+      ⟨0, S.decomposition.multiplicity_pos (S.relabel γ)⟩
+  · intro v
+    rw [← S.tensor_eq γ v]
+    exact (blockedReference_compression M S.decomposition.bondDim
+      S.decomposition.multiplicity S.decomposition.multiplicity_pos
+      S.decomposition.weight S.decomposition.tensor
+      S.decomposition.verticalCoisometry S.decomposition.coisometry
+      S.decomposition.reconstruction (S.relabel γ) v).symm
+
+/-- The marked chain of the exact gauge-dressed algebra-side sector equals
+the reflected-adjoint marked chain of the same representative in the adjoint
+two-site blocking.
+
+This is the gauge-dressed Figure 7 identity used on one side of Figure 8 in
+CPSV16, Proposition 4.13, lines 1909--1919, for the sector matching of
+Appendix C.4, lines 2048--2057.
+
+**Scope restriction (gauge-dressed corner):** The theorem does not compare
+this expression with the identity-dressed algebra-side representative and
+hence does not prove the common-target Gram identity.  The remaining
+comparison is documented in
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1909--1919, and Appendix C.4,
+lines 2048--2057. -/
+theorem markedChainCoefficient_gauge_eq_reflectedAdjoint
+    (S : TwoSiteExactSectorGauge H) (hM : IsMPDO M)
+    (γ : Fin H.labelCount) (N : ℕ)
+    (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
+    (σ τ : Fin N → Fin (d * d)) :
+    markedChainCoefficient
+        (gramDressing (S.gauge γ)
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)))
+        (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
+      markedChainCoefficient
+        (reflectedAdjoint
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)))
+        (adjointTensor (blockTwo M)) r s
+        (List.ofFn σ).reverse (List.ofFn τ).reverse := by
+  obtain ⟨V, c, _, hc, hcorner⟩ := S.exists_blockTwo_gauge_sector_corner γ
+  exact hM.blockTwo.markedChainCoefficient_gramDressing_eq_reflectedAdjoint
+    (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ))
+    V (S.gauge γ) c hc hcorner N r s σ τ
+
+end BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+end MPOTensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -414,16 +414,47 @@
     position, and positivity of $c$ permits cancellation without a phase.
 \end{proof}
 
+\begin{theorem}[Gram-dressed reflected marked-chain identity]
+    \label{thm:mpdo_gram_dressed_reflected_marked_chain}
+    \lean{MPOTensor.gramDressing}
+    \lean{MPOTensor.IsMPDO.%
+        markedChainCoefficient_gramDressing_eq_reflectedAdjoint}
+    \leanok
+    \uses{def:mpdo, thm:mpdo_reflected_marked_chain}
+    Let $M$ generate positive semidefinite operators on every nonempty chain,
+    and suppose that one vertical corner is a positive scalar multiple of a
+    similarity of a tensor $A$,
+    \begin{align}
+        V^\dagger\widetilde M^vV&=c\,X A^vX^{-1},
+        &c&>0.
+        \notag
+    \end{align}
+    Then the marked-chain coefficient of the Gram-dressed tensor
+    $(X^\dagger X)A^v(X^\dagger X)^{-1}$ equals the reflected-adjoint
+    marked-chain coefficient of $A$ in the adjoint tensor, with the two tail
+    words reversed. This is the single-corner, open-index conjugation step in
+    Figure~7 of
+    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_reflected_marked_chain}
+    Apply the reflected marked-chain identity to the similar tensor
+    $XA^vX^{-1}$. Conjugate its two open virtual indices by $X^\dagger$ and
+    $(X^{-1})^\dagger$. On the original side this gives the Gram dressing of
+    $A$; on the reflected side the gauge factors cancel, leaving the
+    reflected adjoint of $A$.
+\end{proof}
+
 \begin{theorem}[Pairwise Gram conjugation of grouped vertical corners]
     \label{thm:mpdo_pairwise_vertical_gram_conjugation}
-    \lean{MPOTensor.gramDressing}
     \lean{MPOTensor.cornerGramCoefficients}
-    \lean{MPOTensor.IsMPDO.markedChainCoefficient_gramDressing_eq_reflectedAdjoint}
     \lean{MPOTensor.IsMPDO.markedChainCoefficient_gramDressing_eq_of_two_corners}
     \lean{MPOTensor.IsHorizontalCF.gramDressing_eq_of_two_grouped_corners}
     \leanok
     \uses{def:mpdo, def:horizontal_cf_mpdo,
-        thm:mpdo_reflected_marked_chain,
+        thm:mpdo_gram_dressed_reflected_marked_chain,
         cor:horizontal_cf_linear_marked_separation}
     Let $M$ be in normalized BNT-refined horizontal form and generate positive
     semidefinite operators on every nonempty chain. Suppose two vertical
@@ -460,7 +491,7 @@
 
 \begin{proof}
     \leanok
-    \uses{thm:mpdo_reflected_marked_chain,
+    \uses{thm:mpdo_gram_dressed_reflected_marked_chain,
         cor:horizontal_cf_linear_marked_separation}
     Conjugate the open indices in the reflected marked-chain identity for
     the first corner by $X^\dagger$. Its left side becomes the marked chain

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -420,7 +420,7 @@
     \lean{MPOTensor.IsMPDO.%
         markedChainCoefficient_gramDressing_eq_reflectedAdjoint}
     \leanok
-    \uses{def:mpdo, thm:mpdo_reflected_marked_chain}
+    \uses{def:mpdo}
     Let $M$ generate positive semidefinite operators on every nonempty chain,
     and suppose that one vertical corner is a positive scalar multiple of a
     similarity of a tensor $A$,
@@ -453,8 +453,7 @@
     \lean{MPOTensor.IsMPDO.markedChainCoefficient_gramDressing_eq_of_two_corners}
     \lean{MPOTensor.IsHorizontalCF.gramDressing_eq_of_two_grouped_corners}
     \leanok
-    \uses{def:mpdo, def:horizontal_cf_mpdo,
-        thm:mpdo_gram_dressed_reflected_marked_chain}
+    \uses{def:mpdo, def:horizontal_cf_mpdo}
     Let $M$ be in normalized BNT-refined horizontal form and generate positive
     semidefinite operators on every nonempty chain. Suppose two vertical
     corners are positive scalar multiples of similarities of the same tensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -454,8 +454,7 @@
     \lean{MPOTensor.IsHorizontalCF.gramDressing_eq_of_two_grouped_corners}
     \leanok
     \uses{def:mpdo, def:horizontal_cf_mpdo,
-        thm:mpdo_gram_dressed_reflected_marked_chain,
-        cor:horizontal_cf_linear_marked_separation}
+        thm:mpdo_gram_dressed_reflected_marked_chain}
     Let $M$ be in normalized BNT-refined horizontal form and generate positive
     semidefinite operators on every nonempty chain. Suppose two vertical
     corners are positive scalar multiples of similarities of the same tensor

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -420,7 +420,7 @@
     \lean{MPOTensor.IsMPDO.%
         markedChainCoefficient_gramDressing_eq_reflectedAdjoint}
     \leanok
-    \uses{def:mpdo, thm:mpdo_reflected_marked_chain}
+    \uses{def:mpdo}
     Let $M$ generate positive semidefinite operators on every nonempty chain,
     and suppose that one vertical corner is a positive scalar multiple of a
     similarity of a tensor $A$,

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms_positivity_gram_normalization.tex
@@ -420,7 +420,7 @@
     \lean{MPOTensor.IsMPDO.%
         markedChainCoefficient_gramDressing_eq_reflectedAdjoint}
     \leanok
-    \uses{def:mpdo}
+    \uses{def:mpdo, thm:mpdo_reflected_marked_chain}
     Let $M$ generate positive semidefinite operators on every nonempty chain,
     and suppose that one vertical corner is a positive scalar multiple of a
     similarity of a tensor $A$,
@@ -432,8 +432,8 @@
     Then the marked-chain coefficient of the Gram-dressed tensor
     $(X^\dagger X)A^v(X^\dagger X)^{-1}$ equals the reflected-adjoint
     marked-chain coefficient of $A$ in the adjoint tensor, with the two tail
-    words reversed. This is the single-corner, open-index conjugation step in
-    Figure~7 of
+    words reversed. This is the single-corner, open-index conjugation step
+    from Figures~7--8 of
     \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -262,6 +262,8 @@
         &=M_\gamma^v.
         \notag
     \end{align}
+    This restriction is documented in
+    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
     % The missing identity-dressed corner and common-target Gram identity are
     % tracked in issue 4648.
 \end{theorem}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -219,6 +219,68 @@
     the multiset equality (\ref{eq:rfp_multiplicity_spectrum}).
 \end{proof}
 
+\begin{theorem}[Gauge-dressed physical corner of a matched two-site sector]
+    \label{thm:mpdo_bnt_exact_sector_gauge_blocked_corner}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        exists_blockTwo_gauge_sector_corner}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        markedChainCoefficient_gauge_eq_reflectedAdjoint}
+    \leanok
+    \uses{def:mpdo, def:mpdo_bnt_two_site_exact_sector_gauge,
+        thm:mpdo_blocked_reference_corners,
+        thm:mpdo_pairwise_vertical_gram_conjugation}
+    Let $M$ generate matrix product density operators, and suppose that the
+    one-site and two-site sectors are related by the exact invertible gauges
+    above. Let $\gamma$ be a one-site sector matched with a two-site sector by
+    the bijection $\sigma$, and identify their bond dimensions. There are an
+    isometry $V_\gamma$ into the bond space of the two-site blocking and a
+    scalar $c_\gamma>0$ such that, for every vertical letter $v$,
+    \begin{align}
+        V_\gamma^\dagger\widetilde{M^{(2)}}^vV_\gamma
+        &=c_\gamma Z_\gamma M_\gamma^vZ_\gamma^{-1}.
+        \label{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}
+    \end{align}
+    Consequently, for every pair of open bond indices and every pair of
+    two-site tail words, the marked-chain coefficient of
+    \begin{align}
+        (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
+        (Z_\gamma^\dagger Z_\gamma)^{-1}
+        \notag
+    \end{align}
+    equals the corresponding reflected-adjoint marked-chain coefficient in
+    the adjoint two-site blocking. This is one of the two marked comparisons
+    in Figures~7--8 of
+    \cite[Proposition~4.13, lines~1909--1919]{Cirac2016MPDO_arXiv}, applied
+    to the sector matching of Appendix~C.4, lines~2048--2057.
+
+    \textbf{Scope restriction (gauge-dressed corner):} This theorem constructs
+    only the physical corner in
+    (\ref{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}). It does not
+    construct an identity-dressed physical corner for $M_\gamma$ and does not
+    prove the common-target Gram identity
+    \begin{align}
+        (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
+        (Z_\gamma^\dagger Z_\gamma)^{-1}
+        &=M_\gamma^v.
+        \notag
+    \end{align}
+    % The missing identity-dressed corner and common-target Gram identity are
+    % tracked in issue 4648.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_blocked_reference_corners,
+        thm:mpdo_pairwise_vertical_gram_conjugation}
+    Choose the first positive-weight copy of the matched two-site sector.
+    Its distinguished inclusion is isometric and its compression selects the
+    corresponding weighted normal tensor. Substituting the exact sector
+    conjugacy gives
+    (\ref{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}), with the selected
+    weight as $c_\gamma$. The reflected marked-chain identity for this corner,
+    conjugated on its open indices by $Z_\gamma^\dagger$, gives the stated
+    equality of marked-chain coefficients.
+\end{proof}
+
 \begin{lemma}[Idempotence for the canonical chi coefficients]%
     \label{lem:mpdo_bnt_idempotent_coefficient_form_of_chi}
     \lean{MPOTensor.BNTAlgebraClause.idempotent_coefficient_form_ofChi}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -231,8 +231,8 @@
     one-site and two-site sectors are related by the exact invertible gauges
     above. Let $\gamma$ be a one-site sector matched with a two-site sector by
     the bijection $\sigma$, and identify their bond dimensions. There are an
-    isometry $V_\gamma$ into the bond space of the two-site blocking and a
-    scalar $c_\gamma>0$ such that, for every vertical letter $v$,
+    isometry $V_\gamma$ from the sector bond space into the blocked physical-index
+    space and a scalar $c_\gamma>0$ such that, for every vertical letter $v$,
     \begin{align}
         V_\gamma^\dagger\widetilde{M^{(2)}}^vV_\gamma
         &=c_\gamma Z_\gamma M_\gamma^vZ_\gamma^{-1}.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -226,11 +226,12 @@
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
         markedChainCoefficient_gauge_eq_reflectedAdjoint}
     \leanok
-    \uses{def:mpdo, def:mpdo_bnt_two_site_exact_sector_gauge}
-    Let $M$ generate matrix product density operators, and suppose that the
-    one-site and two-site sectors are related by the exact invertible gauges
-    above. Let $\gamma$ be a one-site sector matched with a two-site sector by
-    the bijection $\sigma$, and identify their bond dimensions. There are an
+    \uses{def:mpdo, def:mpdo_bnt_two_site_exact_sector_gauge,
+        thm:mpdo_gram_dressed_reflected_marked_chain}
+    Suppose that the one-site and two-site sectors are related by the exact
+    invertible gauges above. Let $\gamma$ be a one-site sector matched with a
+    two-site sector by the bijection $\sigma$, and identify their bond
+    dimensions. There are an
     isometry $V_\gamma$ from the sector bond space into the blocked physical-index
     space and a scalar $c_\gamma>0$ such that, for every vertical letter $v$,
     \begin{align}
@@ -238,8 +239,9 @@
         &=c_\gamma Z_\gamma M_\gamma^vZ_\gamma^{-1}.
         \label{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}
     \end{align}
-    Consequently, for every pair of open bond indices and every pair of
-    two-site tail words, the marked-chain coefficient of
+    If, in addition, $M$ generates matrix product density operators, then for
+    every pair of open bond indices and every pair of two-site tail words, the
+    marked-chain coefficient of
     \begin{align}
         (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
         (Z_\gamma^\dagger Z_\gamma)^{-1}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -226,9 +226,7 @@
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
         markedChainCoefficient_gauge_eq_reflectedAdjoint}
     \leanok
-    \uses{def:mpdo, def:mpdo_bnt_two_site_exact_sector_gauge,
-        thm:mpdo_blocked_reference_corners,
-        thm:mpdo_pairwise_vertical_gram_conjugation}
+    \uses{def:mpdo, def:mpdo_bnt_two_site_exact_sector_gauge}
     Let $M$ generate matrix product density operators, and suppose that the
     one-site and two-site sectors are related by the exact invertible gauges
     above. Let $\gamma$ be a one-site sector matched with a two-site sector by
@@ -270,15 +268,16 @@
 
 \begin{proof}\leanok
     \uses{thm:mpdo_blocked_reference_corners,
-        thm:mpdo_pairwise_vertical_gram_conjugation}
+        thm:mpdo_gram_dressed_reflected_marked_chain}
     Choose the first positive-weight copy of the matched two-site sector.
     Its distinguished inclusion is isometric and its compression selects the
     corresponding weighted normal tensor. Substituting the exact sector
     conjugacy gives
     (\ref{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}), with the selected
     weight as $c_\gamma$. The reflected marked-chain identity for this corner,
-    conjugated on its open indices by $Z_\gamma^\dagger$, gives the stated
-    equality of marked-chain coefficients.
+    conjugated on its open indices by $Z_\gamma^\dagger$ and
+    $(Z_\gamma^{-1})^\dagger$, gives the stated equality of marked-chain
+    coefficients; the gauge factors cancel on the reflected side.
 \end{proof}
 
 \begin{lemma}[Idempotence for the canonical chi coefficients]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -226,8 +226,7 @@
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
         markedChainCoefficient_gauge_eq_reflectedAdjoint}
     \leanok
-    \uses{def:mpdo, def:mpdo_bnt_two_site_exact_sector_gauge,
-        thm:mpdo_gram_dressed_reflected_marked_chain}
+    \uses{def:mpdo, def:mpdo_bnt_two_site_exact_sector_gauge}
     Suppose that the one-site and two-site sectors are related by the exact
     invertible gauges above. Let $\gamma$ be a one-site sector matched with a
     two-site sector by the bijection $\sigma$, and identify their bond

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -67,7 +67,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch16_channel_representations_dilations_and_ordered_cp.tex` | — | L20 `tenkz` → `C-policy+C-record` | — |
 | `ch20_mpdo_canonical_forms_first_site_contractions.tex` | — | L232, 238 `tenkz` → `C-policy+C-record` | L153, 159, 336, 433 `tenkz` → `C-policy+C-record+R-record`<br>L177, 182 `tenkz` → `R-record` |
 | `ch20_mpdo_canonical_forms_intro_finite_separation.tex` | — | L104 `tenkz` → `C-policy`<br>L108 `tenkz` → `C-policy+C-record` | L218 `tenkz` → `C-record+R-record`<br>L224, 359, 391, 465 `tenkzfree` → `R-free+R-record` |
-| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | — | — | L605, 610 `tenkz` → `C-policy+C-record+R-record` |
+| `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex` | — | — | L634, 639 `tenkz` → `C-policy+C-record+R-record` |
 | `ch20_mpdo_foundations.tex` | — | — | L16, 124, 370 `tenkz` → `C-policy+C-record+R-record`<br>L374 `tenkz` → `C-record+R-record` |
 | `ch21_mpdo_rfp_algebra_tower.tex` | — | — | L78, 93 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_blocked_rfp_positive_blocking_and_sector_algebra.tex` | — | — | L18, 21 `tnpic` → `C-picture+C-policy+C-record+R-record` |


### PR DESCRIPTION
## Summary

- construct the distinguished positive-weight physical corner of each matched two-site sector in `TwoSiteExactSectorGauge`
- derive the corresponding single-corner reflected marked-chain identity for the Gram-dressed algebra-side sector
- add an honest Chapter 20 node for the single-corner open-index conjugation step and a Chapter 21 theorem for the exact-gauge corner
- add the generated MPDO import-aggregator entry

This is only the gauge-dressed half of the Figure 7–8 comparison. It does not construct an identity-dressed physical corner, prove the common-target Gram identity of #4648, or upgrade the exact gauge to a unitary.

Source: CPSV16, Proposition 4.13, Figures 7–8 and lines 1909–1919, applied to Appendix C.4, lines 2048–2057 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

## Validation

- focused Lean compilation
- `lake build` (9,872 jobs)
- import-aggregator check
- Blueprint synchronization and `leanblueprint checkdecls`
- kernel axiom audit (`propext`, `Classical.choice`, `Quot.sound` only)
- proof-integrity, prose, tactic-pattern, label, line-length, and whitespace checks
- independent full-branch source-faithfulness review

Closes #5271

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proofs compose existing blocked-corner and marked-chain machinery; scope is documented and does not change auth, runtime, or global MPDO behavior beyond new formalized lemmas and blueprint nodes.
> 
> **Overview**
> Formalizes the **gauge-dressed half** of the CPSV16 Figure 7–8 sector comparison for `TwoSiteExactSectorGauge`: an isometric blocked physical corner compressing to a positive scalar times the gauge-wrapped algebra tensor, and equality of Gram-dressed marked chains with the reflected-adjoint chain on `blockTwo`.
> 
> New Lean module `BNTAlgebraTensorClauseCorner.lean` proves `exists_blockTwo_gauge_sector_corner` and `markedChainCoefficient_gauge_eq_reflectedAdjoint` by wiring blocked-reference inclusion/compression to the existing `IsMPDO.markedChainCoefficient_gramDressing_eq_reflectedAdjoint` lemma. The MPDO import aggregator picks up the module.
> 
> Blueprint **Chapter 20** pulls the single-corner Gram-dressed reflected marked-chain step into its own theorem (`thm:mpdo_gram_dressed_reflected_marked_chain`) and points the pairwise Gram theorem’s proof at it. **Chapter 21** adds the matched-sector corner theorem with `\leanok` links and documents that **no** identity-dressed corner or common-target Gram identity is proved (tracked gap / #4648).
> 
> `docs/tenkz/DISPOSITIONS.md` only updates line references for `ch20_mpdo_canonical_forms_positivity_gram_normalization.tex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53eb8ce62124038293e758c2331f62f584ba1644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->