### PR TITLE
doc(MPS/MPDO): distinguish the RFP fusion specialization

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -188,7 +188,7 @@
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Fusion-clause assembly from paired decompositions and positive fusion data]%
+\begin{theorem}[Fusion matrices and coisometries from paired vertical decompositions]%
     \label{thm:mpdo_paired_vertical_decompositions_fusion}
     \lean{MPOTensor.HasBNTFusionTensorClause.%
 of_verticalDecompositions_of_unitaryBlockEquiv}
@@ -216,7 +216,7 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     \end{align}
     Then the simultaneous blocked representations yield the missing
     length-one idempotent trace-scalar law and complete the tensor-attached
-    fusion clause. This is the final assembly construction extracted from
+    fusion clause. This is the resulting construction extracted from
     \cite[Appendix~C.4, lines~2001--2046]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
@@ -284,8 +284,8 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     theorem then gives the tensor-attached fusion clause.
 \end{proof}
 
-\begin{corollary}[Horizontal-form renormalization fixed points have active-sector fusion]%
-    \label{cor:mpdo_rfp_to_bnt_fusion_tensor}
+\begin{theorem}[Horizontal-form specialization of active-sector fusion]%
+    \label{thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor}
     \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF}
     \leanok
     \uses{def:is_rfp_via_ts,
@@ -301,8 +301,8 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     \textbf{Scope restriction (BNT-refined horizontal form):}
     the normalized BNT-refined horizontal hypothesis is stronger than the
     literal CPSV canonical-form hypothesis.
-    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
-\end{corollary}
+    See \path{docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex}.
+\end{theorem}
 \begin{proof}\leanok
     \uses{thm:vertical_cf_of_horizontal_cf,
       thm:mpdo_transported_vertical_sector_coefficient_comparison,

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -188,7 +188,7 @@
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Paired vertical decompositions determine active-sector fusion]%
+\begin{theorem}[Fusion-clause assembly from paired decompositions and positive fusion data]%
     \label{thm:mpdo_paired_vertical_decompositions_fusion}
     \lean{MPOTensor.HasBNTFusionTensorClause.%
 of_verticalDecompositions_of_unitaryBlockEquiv}
@@ -197,12 +197,27 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     Let $\mathcal D_1$ and $\mathcal D_2$ be positive vertical canonical
     decompositions of an MPO tensor and its two-site blocking. Suppose their
     normal sectors are identified by a bijection $\sigma$ and unitary
-    conjugacies with the corresponding multiplicity-trace ratios. If the
-    products of the one-site normal tensors have positive active-sector fusion
-    coisometries, then $\mathcal D_1$ determines a tensor-attached fusion
-    clause. This is the common final construction in the forward implication
-    of \cite[Theorem~4.14(i),(iii), lines~972--993, and Appendix~C.4,
-    lines~2001--2046]{Cirac2016MPDO_arXiv}.
+    conjugacies with the corresponding multiplicity-trace ratios. Suppose also
+    that positive diagonal matrices $\chi_{\alpha,\beta,\gamma}$ and
+    coisometries $U_{\alpha,\beta}$ are supplied, with
+    $U_{\alpha,\beta}U_{\alpha,\beta}^{\dagger}=1$, and satisfy both
+    \begin{align}
+      U_{\alpha,\beta}(M_\alpha M_\beta)^{ij}
+        U_{\alpha,\beta}^{\dagger}
+      &=\bigoplus_\gamma
+        \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij},
+      \notag\\
+      (M_\alpha M_\beta)^{ij}
+      &=U_{\alpha,\beta}^{\dagger}
+        \left(\bigoplus_\gamma
+          \chi_{\alpha,\beta,\gamma}\otimes M_\gamma^{ij}\right)
+        U_{\alpha,\beta}.
+      \notag
+    \end{align}
+    Then the simultaneous blocked representations yield the missing
+    length-one idempotent trace-scalar law and complete the tensor-attached
+    fusion clause. This is the final assembly construction extracted from
+    \cite[Appendix~C.4, lines~2001--2046]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:mpdo_blocked_vertical_operator_representations,
@@ -215,32 +230,6 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     the multiplicity multisets, and summing their entries gives
     $m_\gamma=\sum_{\alpha,\beta}
       \tr(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$.
-\end{proof}
-
-\begin{theorem}[Horizontal-form renormalization fixed points have active-sector fusion]%
-    \label{thm:mpdo_rfp_to_bnt_fusion_tensor}
-    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF}
-    \leanok
-    \uses{def:is_rfp_via_ts,
-        def:horizontal_cf_mpdo,
-        def:mpdo_bnt_fusion_tensor_clause}
-    Let $M$ be a matrix product density operator in normalized BNT-refined
-    horizontal form. If the one-site and two-site physical closures are
-    related in both directions by trace-preserving completely positive maps
-    as in Definition~4.1, then a vertical canonical decomposition of $M$ has the
-    active-sector fusion clause above. In particular, its positive diagonal
-    fusion matrices satisfy the length-one idempotent trace-scalar identity.
-\end{theorem}
-\begin{proof}\leanok
-    \uses{thm:vertical_cf_of_horizontal_cf,
-      thm:mpdo_transported_vertical_sector_coefficient_comparison,
-      thm:mpdo_transported_vertical_product_positive_fusion_decomposition,
-      thm:mpdo_paired_vertical_decompositions_fusion}
-    Choose the one-site and two-site vertical canonical decompositions supplied
-    by the normalized BNT-refined horizontal form. The renormalization maps
-    identify their normal sectors and give positive fusion coisometries.
-    Apply the paired-decomposition theorem to obtain the tensor-attached
-    fusion clause.
 \end{proof}
 
 \begin{theorem}[Literal CPSV renormalization fixed points have active-sector fusion]%
@@ -293,6 +282,37 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     theorem gives the positive diagonal matrices, coisometries, and exact
     reconstruction on every active product sector. The paired-decomposition
     theorem then gives the tensor-attached fusion clause.
+\end{proof}
+
+\begin{corollary}[Horizontal-form renormalization fixed points have active-sector fusion]%
+    \label{cor:mpdo_rfp_to_bnt_fusion_tensor}
+    \lean{MPOTensor.HasBNTFusionTensorClause.of_isRFPViaTS_of_horizontalCF}
+    \leanok
+    \uses{def:is_rfp_via_ts,
+        def:horizontal_cf_mpdo,
+        def:mpdo_bnt_fusion_tensor_clause}
+    Let $M$ be a matrix product density operator in normalized BNT-refined
+    horizontal form. If the one-site and two-site physical closures are
+    related in both directions by trace-preserving completely positive maps
+    as in Definition~4.1, then a vertical canonical decomposition of $M$ has the
+    active-sector fusion clause above. In particular, its positive diagonal
+    fusion matrices satisfy the length-one idempotent trace-scalar identity.
+
+    \textbf{Scope restriction (BNT-refined horizontal form):}
+    the normalized BNT-refined horizontal hypothesis is stronger than the
+    literal CPSV canonical-form hypothesis.
+    % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:vertical_cf_of_horizontal_cf,
+      thm:mpdo_transported_vertical_sector_coefficient_comparison,
+      thm:mpdo_transported_vertical_product_positive_fusion_decomposition,
+      thm:mpdo_paired_vertical_decompositions_fusion}
+    Choose the one-site and two-site vertical canonical decompositions supplied
+    by the normalized BNT-refined horizontal form. The renormalization maps
+    identify their normal sectors and give positive fusion coisometries.
+    Apply the paired-decomposition theorem to obtain the tensor-attached
+    fusion clause.
 \end{proof}
 
 \begin{theorem}[Active-sector fusion implies the tensor-attached algebra clause]%

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_product_laws.tex
@@ -188,7 +188,8 @@
     \cite[Proposition~4.13, lines~943--951]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Fusion matrices and coisometries from paired vertical decompositions]%
+\begin{theorem}[Fusion clause from paired decompositions with supplied fusion matrices
+    and coisometries]%
     \label{thm:mpdo_paired_vertical_decompositions_fusion}
     \lean{MPOTensor.HasBNTFusionTensorClause.%
 of_verticalDecompositions_of_unitaryBlockEquiv}
@@ -216,7 +217,7 @@ of_verticalDecompositions_of_unitaryBlockEquiv}
     \end{align}
     Then the simultaneous blocked representations yield the missing
     length-one idempotent trace-scalar law and complete the tensor-attached
-    fusion clause. This is the resulting construction extracted from
+    fusion clause. This completes the fusion-clause construction extracted from
     \cite[Appendix~C.4, lines~2001--2046]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -409,7 +409,7 @@
     \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{cor:mpdo_rfp_to_bnt_fusion_tensor,
+    \uses{thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor,
         thm:mpdo_topological_projector_recursion,
         lem:mpdo_sitewise_physical_coordinate_congruence}
     Under the normalized BNT-refined horizontal hypothesis, the vertical
@@ -465,7 +465,7 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_topological_density_operator,
-        cor:mpdo_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor,
         cor:mpdo_fusion_clause_topological_density_factor_commutator}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form and suppose that it satisfies the renormalization
@@ -491,7 +491,7 @@
     % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{corollary}
 \begin{proof}\leanok
-    \uses{cor:mpdo_rfp_to_bnt_fusion_tensor}
+    \uses{thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor}
     In every sitewise copy configuration, the factor $A_N$ is the scalar
     $m(c)$ times the identity on the corresponding simple-bond space.
     It therefore commutes with
@@ -553,7 +553,7 @@
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_fusion_clause_terminal_spectral_refinement,
-        cor:mpdo_rfp_to_bnt_fusion_tensor}
+        thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor}
     For an MPDO in normalized BNT-refined horizontal form satisfying the
     renormalization fixed-point condition, fix the fusion clause selected by
     that construction. For every terminal label $\gamma$, close the horizontal
@@ -642,7 +642,7 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_terminal_spectral_refinement,
-        cor:mpdo_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition. Fix
@@ -870,7 +870,7 @@
     \lean{MPOTensor.topologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        cor:mpdo_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition.
@@ -995,7 +995,7 @@
     \lean{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        cor:mpdo_rfp_to_bnt_fusion_tensor,
+        thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_fusion_isometries_recursive_density.tex
@@ -409,7 +409,7 @@
     \path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:mpdo_rfp_to_bnt_fusion_tensor,
+    \uses{cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_topological_projector_recursion,
         lem:mpdo_sitewise_physical_coordinate_congruence}
     Under the normalized BNT-refined horizontal hypothesis, the vertical
@@ -465,7 +465,7 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_topological_density_operator,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         cor:mpdo_fusion_clause_topological_density_factor_commutator}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form and suppose that it satisfies the renormalization
@@ -491,7 +491,7 @@
     % Scope tracking: docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex.
 \end{corollary}
 \begin{proof}\leanok
-    \uses{thm:mpdo_rfp_to_bnt_fusion_tensor}
+    \uses{cor:mpdo_rfp_to_bnt_fusion_tensor}
     In every sitewise copy configuration, the factor $A_N$ is the scalar
     $m(c)$ times the identity on the corresponding simple-bond space.
     It therefore commutes with
@@ -553,7 +553,7 @@
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_bnt_fusion_tensor_clause,
         def:mpdo_fusion_clause_terminal_spectral_refinement,
-        thm:mpdo_rfp_to_bnt_fusion_tensor}
+        cor:mpdo_rfp_to_bnt_fusion_tensor}
     For an MPDO in normalized BNT-refined horizontal form satisfying the
     renormalization fixed-point condition, fix the fusion clause selected by
     that construction. For every terminal label $\gamma$, close the horizontal
@@ -642,7 +642,7 @@
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
         def:mpdo_terminal_spectral_refinement,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_terminal_spectral_projector_refinement}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition. Fix
@@ -870,7 +870,7 @@
     \lean{MPOTensor.topologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_topological_gibbs_at_least_two}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition.
@@ -995,7 +995,7 @@
     \lean{MPOTensor.physicalTopologicalGibbsDecomposition_of_isRFPViaTS}
     \leanok
     \uses{def:horizontal_cf_mpdo, def:mpdo, def:is_rfp_via_ts,
-        thm:mpdo_rfp_to_bnt_fusion_tensor,
+        cor:mpdo_rfp_to_bnt_fusion_tensor,
         thm:mpdo_fusion_clause_physical_coordinate_gibbs_at_least_two}
     Let $M$ be a matrix product density operator in normalized BNT-refined
     horizontal form satisfying the renormalization fixed-point condition.

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L516, 518 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L379 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L517, 519 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L380 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L496, 498 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L359 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L515, 517 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L378 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |

--- a/docs/tenkz/DISPOSITIONS.md
+++ b/docs/tenkz/DISPOSITIONS.md
@@ -75,7 +75,7 @@ separate public-surface occurrence and therefore appears separately.
 | `ch21_mpdo_rfp_fusion_isometries_complete_zipper_coherence.tex` | — | L215, 219, 292, 293, 294, 295, 296 `tntree` → `C-tree` | L291 `tenkzcd` → `C-tree+R-cd+R-record`<br>L410 `tenkzcd` → `R-cd+R-record` |
 | `ch21_mpdo_rfp_fusion_isometries_fixed_final_comparison.tex` | — | L572, 577 `tntree` → `C-tree` | — |
 | `ch21_mpdo_rfp_fusion_isometries_foundations.tex` | — | — | L402, 643, 649, 656, 663, 671, 676 `tnpic` → `C-picture+C-record+R-record`<br>L409 `tnpic` → `C-picture+C-policy+C-record+R-record` |
-| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L515, 517 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L378 `tenkzfree` → `R-free+R-record` |
+| `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` | — | L516, 518 `tntree` → `C-tree` | L38, 50 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L379 `tenkzfree` → `R-free+R-record` |
 | `ch21_mpdo_rfp_renormalization.tex` | — | — | L629 `tenkzcd` → `C-picture+C-policy+C-record+R-cd+R-record`<br>L631, 634, 637, 640 `tnpic` → `C-picture+C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_closed_sector_contractions.tex` | — | — | L279, 284 `tenkz` → `C-policy+C-record+R-record` |
 | `ch21_mpdo_rfp_simple_local_inverse_map_factorization.tex` | — | — | L43, 48, 53 `tenkz` → `R-record`<br>L70, 709 `tenkz` → `C-record+R-record`<br>L80, 131, 265, 270, 275, 282, 287 `tenkz` → `C-policy+C-record+R-record`<br>L485 `tnpic` → `C-picture+C-policy+C-record+R-record`<br>L715, 719 `tenkz` → `C-policy+R-record` |


### PR DESCRIPTION
Closes #5275.

## Mathematical purpose

Chapter 21 now separates three logically distinct statements in the forward direction of CPSV16, Theorem 4.14 and Appendix C.4:

- the shared construction from paired vertical decompositions, positive fusion matrices, and coisometries;
- the literal RFP-to-fusion implication corresponding to the cited source;
- the normalized horizontal-form specialization, displayed separately with its stronger hypothesis.

The shared node states the sector bijection and unitary trace-ratio conjugacies, the positive diagonal fusion weights, the coisometry relations, the forward fusion identity, and exact adjoint reconstruction. The seven downstream horizontal-form dependencies now point to the specialization theorem, while the source-facing theorem and its existing local-fix and scope markers remain unchanged. The Blueprint theorem environment matches the primary Lean declaration.

No Lean declaration or proof is changed.

## Verification

- `leanblueprint checkdecls`
- Blueprint/Lean synchronization after regenerating the ignored declaration cache
- reader-facing prose check
- tenkz disposition reconciliation
- `git diff --check`

Source: CPSV16, Theorem 4.14 and Appendix C.4, especially lines 1929–2046 of `Papers/1606.00608/MPDO-22-12-17-2.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint and disposition ledger updates; theorem labels and cross-references are reorganized without code or proof changes.
> 
> **Overview**
> Chapter 21 **restructures the forward CPSV16 fusion-clause story** so the shared paired-vertical step, the literal CPSV RFP implication, and the normalized horizontal-form specialization are distinct statements instead of one overloaded RFP theorem.
> 
> The **paired-decomposition theorem** is retitled and now **states explicitly** that positive diagonal fusion weights and coisometries with the forward fusion identity and exact adjoint reconstruction must be supplied; it no longer reads as if those data are automatic from sector matching alone. The former general **RFP → active-sector fusion** theorem is removed as a standalone node; the **literal CPSV** route stays under its existing theorem, and the **BNT-refined horizontal** case is a separately labeled specialization with an explicit scope note that its hypothesis is stronger than literal CPSV form.
> 
> **Downstream blueprint** in the recursive-density chapter now cites `thm:mpdo_horizontal_rfp_to_bnt_fusion_tensor` wherever the horizontal specialization was intended. **`docs/tenkz/DISPOSITIONS.md`** line numbers for `ch21_mpdo_rfp_fusion_isometries_product_laws.tex` are nudged to match the edited file. No Lean changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04347e3171b992ead33352aa963e7df76999855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->