### PR TITLE
refactor(MPS/MPDO): share pair trace separation

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -539,6 +539,21 @@ private theorem pair_trace_zero_on_span {D₁ D₂ : ℕ}
               simp [Matrix.trace_smul, mul_add]
         _ = 0 := by simp [hM]
 
+private theorem eq_zero_and_eq_zero_of_pair_trace_eq_zero {D₁ D₂ : ℕ}
+    (W : Submodule ℂ
+      (Matrix (Fin D₁) (Fin D₁) ℂ × Matrix (Fin D₂) (Fin D₂) ℂ))
+    (hW : W = ⊤)
+    (ΔA : Matrix (Fin D₁) (Fin D₁) ℂ)
+    (ΔB : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hZero : ∀ M ∈ W,
+      Matrix.trace (ΔA * M.1) + Matrix.trace (ΔB * M.2) = 0) :
+    ΔA = 0 ∧ ΔB = 0 := by
+  constructor
+  · exact (Matrix.ext_iff_trace_mul_right (A := ΔA) (B := 0)).2 fun M ↦ by
+      simpa using hZero (M, 0) (by rw [hW]; exact Submodule.mem_top)
+  · exact (Matrix.ext_iff_trace_mul_right (A := ΔB) (B := 0)).2 fun N ↦ by
+      simpa using hZero (0, N) (by rw [hW]; exact Submodule.mem_top)
+
 /-- The pair trace-separation criterion is the dual form of pair product-span. -/
 theorem pairWordTupleSpanTop_of_pairTraceSeparatingAt {D₁ D₂ : ℕ}
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) {S : ℕ}
@@ -586,15 +601,8 @@ theorem pairTraceSeparatingAt_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
         rintro M ⟨w, rfl⟩
         exact hΔ w)
       M hM
-  constructor
-  · apply (Matrix.ext_iff_trace_mul_right (A := ΔA) (B := 0)).2
-    intro M
-    have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
-    simpa using hpair
-  · apply (Matrix.ext_iff_trace_mul_right (A := ΔB) (B := 0)).2
-    intro N
-    have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
-    simpa using hpair
+  exact eq_zero_and_eq_zero_of_pair_trace_eq_zero
+    (Submodule.span ℂ (Set.range (pairWordTuple A B S))) hSpan ΔA ΔB hZeroOnSpan
 
 /-- Homogeneous pair product-span is equivalent to homogeneous trace separation. -/
 theorem pairWordTupleSpanTop_iff_pairTraceSeparatingAt {D₁ D₂ : ℕ}
@@ -650,15 +658,8 @@ theorem pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop {D₁ D₂ : �
         rintro M ⟨w, hw, rfl⟩
         exact hΔ w hw)
       M (by simpa [pairCumulativeSpan] using hM)
-  constructor
-  · apply (Matrix.ext_iff_trace_mul_right (A := ΔA) (B := 0)).2
-    intro M
-    have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
-    simpa using hpair
-  · apply (Matrix.ext_iff_trace_mul_right (A := ΔB) (B := 0)).2
-    intro N
-    have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
-    simpa using hpair
+  exact eq_zero_and_eq_zero_of_pair_trace_eq_zero
+    (pairCumulativeSpan A B S) hSpan ΔA ΔB hZeroOnSpan
 
 /-- Cumulative trace separation is equivalent to cumulative pair product-span. -/
 theorem pairCumulativeWordTupleSpanTop_iff_pairTraceSeparatingUpTo {D₁ D₂ : ℕ}
@@ -742,15 +743,8 @@ theorem pairTraceSeparatingAll_of_pairAllWordsSpanTop {D₁ D₂ : ℕ}
         rintro M ⟨w, rfl⟩
         exact hΔ w)
       M (by simpa [pairAllWordsSpan] using hM)
-  constructor
-  · apply (Matrix.ext_iff_trace_mul_right (A := ΔA) (B := 0)).2
-    intro M
-    have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
-    simpa using hpair
-  · apply (Matrix.ext_iff_trace_mul_right (A := ΔB) (B := 0)).2
-    intro N
-    have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
-    simpa using hpair
+  exact eq_zero_and_eq_zero_of_pair_trace_eq_zero
+    (pairAllWordsSpan A B) hSpan ΔA ΔB hZeroOnSpan
 
 /-- All-length trace separation is equivalent to all-word pair product-span. -/
 theorem pairAllWordsSpanTop_iff_pairTraceSeparatingAll {D₁ D₂ : ℕ}


### PR DESCRIPTION
## Summary

- add a private lemma extracting both zero matrices from a trace-pairing functional that vanishes on a submodule equal to the top submodule
- replace the three identical homogeneous, cumulative, and all-word extraction arguments with that lemma
- preserve every public declaration and theorem statement

## Why

The three pair trace-separation converses repeated the same matrix trace-extensionality proof. Keeping the argument in one semantic lemma makes the duality proof uniform without introducing a public wrapper or changing the mathematical hypotheses.

## Validation

- `lake build TNLean.MPS.MPDO.BiCFDerivation.Core -q --log-level=info`
- `python3 scripts/tactic_pattern_scan.py --root TNLean/MPS/MPDO --min-count 3 --top 5 --show-locations 5`
- focused `sorry`/`admit`/`axiom`/`native_decide`/`unsafeCast` scan
- `git diff --check`

The targeted build used the seeded prebuilt cache; no Mathlib source compilation occurred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in BiCF derivation core; behavior and API are unchanged, with no runtime or security impact.
> 
> **Overview**
> **Refactors** the converse direction of pair trace separation (span ⇒ separation) by factoring out one private lemma.
> 
> Introduces **`eq_zero_and_eq_zero_of_pair_trace_eq_zero`**: when a pair trace functional vanishes on every element of a submodule that equals `⊤`, both test matrices `ΔA` and `ΔB` must be zero (via `Matrix.ext_iff_trace_mul_right` on pairs `(M, 0)` and `(0, N)`).
> 
> **Replaces** the same duplicated `constructor` + two trace-extensionality blocks in:
> - `pairTraceSeparatingAt_of_pairWordTupleSpanTop`
> - `pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop`
> - `pairTraceSeparatingAll_of_pairAllWordsSpanTop`
> 
> with a single call to that lemma, passing the appropriate span submodule and `hSpan`. **No** changes to public theorem statements or hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9d4904796344287dd2a1babc364579b2aceb35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->