### PR TITLE
refactor(tenkz): plan physical leg lanes

### DIFF
--- a/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
+++ b/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
@@ -1,0 +1,285 @@
+% Regression: a behavior-neutral physical-leg planner colors overlapping
+% face-relative intervals in discrete affine-carrier corridors.
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+% Make the named clearance nonstock so a literal copy of its default value
+% cannot satisfy the geometry assertions.
+\tl_set:Ne \l_tmpa_tl
+  {
+    \fp_eval:n
+      {
+        \__tenkz_metric_ratio:n {labelclear}
+        + \__tenkz_metric_ratio:n {cupmouth}
+      }
+  }
+\prop_gput:NnV \g__tenkz_metric_value_prop {daylight} \l_tmpa_tl
+\fp_new:N \l__tenkz_test_lp_ax_fp
+\fp_new:N \l__tenkz_test_lp_ay_fp
+\fp_new:N \l__tenkz_test_lp_bx_fp
+\fp_new:N \l__tenkz_test_lp_by_fp
+\fp_new:N \l__tenkz_test_lp_cx_fp
+\fp_new:N \l__tenkz_test_lp_cy_fp
+\fp_new:N \l__tenkz_test_lp_dx_fp
+\fp_new:N \l__tenkz_test_lp_dy_fp
+\fp_new:N \l__tenkz_test_lp_ex_fp
+\fp_new:N \l__tenkz_test_lp_ey_fp
+\fp_new:N \l__tenkz_test_lp_nx_fp
+\fp_new:N \l__tenkz_test_lp_ny_fp
+\fp_new:N \l__tenkz_test_lp_gap_ab_fp
+\fp_new:N \l__tenkz_test_lp_gap_ac_fp
+\fp_new:N \l__tenkz_test_lp_daylight_fp
+\fp_new:N \l__tenkz_test_lp_expected_b_reach_fp
+\fp_new:N \l__tenkz_test_lp_lane_fp
+\fp_new:N \l__tenkz_test_lp_reach_fp
+\fp_new:N \l__tenkz_test_lp_sx_fp
+\fp_new:N \l__tenkz_test_lp_sy_fp
+\fp_new:N \l__tenkz_test_lp_bendx_fp
+\fp_new:N \l__tenkz_test_lp_bendy_fp
+\fp_new:N \l__tenkz_test_lp_tipx_fp
+\fp_new:N \l__tenkz_test_lp_tipy_fp
+\tl_new:N \l__tenkz_test_lp_record_tl
+\tl_new:N \l__tenkz_test_lp_result_tl
+
+\cs_new_protected:Npn \__tenkz_test_lp_close:nnn #1#2#3
+  {
+    \fp_compare:nNnF {abs((#1)-(#2))} < {0.000001}
+      { \errmessage{#3} }
+  }
+\cs_new_protected:Npn \__tenkz_test_lp_unpack:nnnnnnnn #1#2#3#4#5#6#7#8
+  {
+    \fp_set:Nn \l__tenkz_test_lp_lane_fp {#1}
+    \fp_set:Nn \l__tenkz_test_lp_reach_fp {#2}
+    \fp_set:Nn \l__tenkz_test_lp_sx_fp {#3}
+    \fp_set:Nn \l__tenkz_test_lp_sy_fp {#4}
+    \fp_set:Nn \l__tenkz_test_lp_bendx_fp {#5}
+    \fp_set:Nn \l__tenkz_test_lp_bendy_fp {#6}
+    \fp_set:Nn \l__tenkz_test_lp_tipx_fp {#7}
+    \fp_set:Nn \l__tenkz_test_lp_tipy_fp {#8}
+  }
+\cs_new_protected:Npn \__tenkz_test_lp_get:n #1
+  {
+    \__tenkz_kernel_leg_plan_get:nN {#1} \l__tenkz_test_lp_result_tl
+    \quark_if_no_value:NT \l__tenkz_test_lp_result_tl
+      { \errmessage{the~lane~planner~lost~semantic~leg~#1} }
+    \exp_last_unbraced:NV \__tenkz_test_lp_unpack:nnnnnnnn
+      \l__tenkz_test_lp_result_tl
+  }
+\cs_new_protected:Npn \__tenkz_test_lp_plan:n #1
+  {
+    \__tenkz_kernel_r_carrier_basis:n {#1}
+    \fp_set:Nn \l__tenkz_test_lp_ex_fp
+      {\l__tenkz_kernel_r_basis_ex_tl}
+    \fp_set:Nn \l__tenkz_test_lp_ey_fp
+      {\l__tenkz_kernel_r_basis_ey_tl}
+    \fp_set:Nn \l__tenkz_test_lp_nx_fp
+      {\l__tenkz_kernel_r_basis_nx_tl}
+    \fp_set:Nn \l__tenkz_test_lp_ny_fp
+      {\l__tenkz_kernel_r_basis_ny_tl}
+    \fp_set:Nn \l_tmpa_fp
+      {sqrt(\l__tenkz_test_lp_nx_fp^2+\l__tenkz_test_lp_ny_fp^2)}
+    \fp_set:Nn \l__tenkz_test_lp_nx_fp
+      {\l__tenkz_test_lp_nx_fp/\l_tmpa_fp}
+    \fp_set:Nn \l__tenkz_test_lp_ny_fp
+      {\l__tenkz_test_lp_ny_fp/\l_tmpa_fp}
+    \fp_set:Nn \l__tenkz_test_lp_daylight_fp
+      {\__tenkz_metric_ratio:n {daylight}}
+    \fp_set:Nn \l__tenkz_test_lp_gap_ab_fp
+      {
+        (\l__tenkz_test_lp_ax_fp-\l__tenkz_test_lp_bx_fp)
+          *\l__tenkz_test_lp_nx_fp
+        +(\l__tenkz_test_lp_ay_fp-\l__tenkz_test_lp_by_fp)
+          *\l__tenkz_test_lp_ny_fp
+      }
+    \fp_set:Nn \l__tenkz_test_lp_gap_ac_fp
+      {
+        (\l__tenkz_test_lp_ax_fp-\l__tenkz_test_lp_cx_fp)
+          *\l__tenkz_test_lp_nx_fp
+        +(\l__tenkz_test_lp_ay_fp-\l__tenkz_test_lp_cy_fp)
+          *\l__tenkz_test_lp_ny_fp
+      }
+    \__tenkz_kernel_leg_plan_reset:
+    \__tenkz_kernel_leg_plan_corridor:nnnnn
+      {member-1/north/col-1}
+      {\l__tenkz_kernel_r_basis_nx_tl}
+      {\l__tenkz_kernel_r_basis_ny_tl}
+      {\l__tenkz_kernel_r_basis_ex_tl}
+      {\l__tenkz_kernel_r_basis_ey_tl}
+    % Repeating the same declared corridor is an idempotent topology fact.
+    \__tenkz_kernel_leg_plan_corridor:nnnnn
+      {member-1/north/col-1}
+      {\l__tenkz_kernel_r_basis_nx_tl}
+      {\l__tenkz_kernel_r_basis_ny_tl}
+      {\l__tenkz_kernel_r_basis_ex_tl}
+      {\l__tenkz_kernel_r_basis_ey_tl}
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {A}{member-1/north/col-1}
+      {\l__tenkz_test_lp_ax_fp}{\l__tenkz_test_lp_ay_fp}
+      {\l__tenkz_test_lp_daylight_fp}
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {B}{member-1/north/col-1}
+      {\l__tenkz_test_lp_bx_fp}{\l__tenkz_test_lp_by_fp}
+      {\l__tenkz_test_lp_gap_ab_fp}
+    \fp_set:Nn \l__tenkz_test_lp_expected_b_reach_fp
+      {
+        \l__tenkz_test_lp_gap_ab_fp
+        + 2 * \l__tenkz_test_lp_daylight_fp
+      }
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {B}{member-1/north/col-1}
+      {\l__tenkz_test_lp_bx_fp}{\l__tenkz_test_lp_by_fp}
+      {\l__tenkz_test_lp_expected_b_reach_fp}
+    % C ends exactly at A's start: closed intervals must still conflict.
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {C}{member-1/north/col-1}
+      {\l__tenkz_test_lp_cx_fp}{\l__tenkz_test_lp_cy_fp}
+      {\l__tenkz_test_lp_gap_ac_fp}
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {D}{member-1/north/col-1}
+      {\l__tenkz_test_lp_dx_fp}{\l__tenkz_test_lp_dy_fp}
+      {\l__tenkz_test_lp_daylight_fp}
+    % A second corridor isolates the final SID tie-break from numeric order.
+    \__tenkz_kernel_leg_plan_corridor:nnnnn
+      {member-1/north/tie}
+      {\l__tenkz_kernel_r_basis_nx_tl}
+      {\l__tenkz_kernel_r_basis_ny_tl}
+      {\l__tenkz_kernel_r_basis_ex_tl}
+      {\l__tenkz_kernel_r_basis_ey_tl}
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {tie-a}{member-1/north/tie}
+      {\l__tenkz_test_lp_ax_fp}{\l__tenkz_test_lp_ay_fp}
+      {\l__tenkz_test_lp_daylight_fp}
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {tie-z}{member-1/north/tie}
+      {\l__tenkz_test_lp_ax_fp}{\l__tenkz_test_lp_ay_fp}
+      {\l__tenkz_test_lp_daylight_fp}
+    \__tenkz_kernel_leg_plan_get:nN {A} \l__tenkz_test_lp_result_tl
+    \quark_if_no_value:NF \l__tenkz_test_lp_result_tl
+      { \errmessage{a~lane~result~existed~before~resolution} }
+    \__tenkz_kernel_leg_plan_resolve:
+    \__tenkz_test_lp_assertions:
+    % A longer duplicate request invalidates every interdependent result.
+    \fp_set:Nn \l__tenkz_test_lp_expected_b_reach_fp
+      {
+        \l__tenkz_test_lp_gap_ab_fp
+        + 3 * \l__tenkz_test_lp_daylight_fp
+      }
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {B}{member-1/north/col-1}
+      {\l__tenkz_test_lp_bx_fp}{\l__tenkz_test_lp_by_fp}
+      {\l__tenkz_test_lp_expected_b_reach_fp}
+    \__tenkz_kernel_leg_plan_get:nN {A} \l__tenkz_test_lp_result_tl
+    \quark_if_no_value:NF \l__tenkz_test_lp_result_tl
+      { \errmessage{a~request~mutation~left~stale~lane~results} }
+    \__tenkz_kernel_leg_plan_resolve:
+    \__tenkz_test_lp_assertions:
+    % Resolution owns its transient occupancy and is repeatable.
+    \__tenkz_kernel_leg_plan_resolve:
+    \__tenkz_test_lp_assertions:
+    \__tenkz_kernel_leg_plan_get:nN {missing} \l__tenkz_test_lp_result_tl
+    \quark_if_no_value:NF \l__tenkz_test_lp_result_tl
+      { \errmessage{an~unknown~semantic~leg~acquired~a~lane} }
+    \__tenkz_kernel_leg_plan_enrol:nnnnn {late}{member-1/north/tie}
+      {\l__tenkz_test_lp_dx_fp}{\l__tenkz_test_lp_dy_fp}
+      {\l__tenkz_test_lp_daylight_fp}
+    \__tenkz_kernel_leg_plan_get:nN {A} \l__tenkz_test_lp_result_tl
+    \quark_if_no_value:NF \l__tenkz_test_lp_result_tl
+      { \errmessage{a~new~request~left~stale~lane~results} }
+  }
+\cs_new_protected:Npn \__tenkz_test_lp_assertions:
+  {
+    \__tenkz_test_lp_get:n {A}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{0}
+      {the~outermost~leg~did~not~take~lane~zero}
+    \__tenkz_test_lp_close:nnn
+      {\l__tenkz_test_lp_bendx_fp}{\l__tenkz_test_lp_sx_fp}
+      {lane~zero~moved~its~bend~in~x}
+    \__tenkz_test_lp_close:nnn
+      {\l__tenkz_test_lp_bendy_fp}{\l__tenkz_test_lp_sy_fp}
+      {lane~zero~moved~its~bend~in~y}
+    \__tenkz_test_lp_get:n {B}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{1}
+      {the~middle~overlap~did~not~take~lane~one}
+    \__tenkz_test_lp_close:nnn
+      {\l__tenkz_test_lp_reach_fp}
+      {\l__tenkz_test_lp_expected_b_reach_fp}
+      {duplicate~semantic~legs~did~not~retain~maximum~reach}
+    \__tenkz_test_lp_close:nnn
+      {\l__tenkz_test_lp_sx_fp}{\l__tenkz_test_lp_bx_fp}
+      {the~lane~plan~lost~the~measured~face~x~coordinate}
+    \__tenkz_test_lp_close:nnn
+      {\l__tenkz_test_lp_sy_fp}{\l__tenkz_test_lp_by_fp}
+      {the~lane~plan~lost~the~measured~face~y~coordinate}
+    \fp_set:Nn \l_tmpa_fp
+      {\l__tenkz_test_lp_bendx_fp-\l__tenkz_test_lp_sx_fp}
+    \fp_set:Nn \l_tmpb_fp
+      {\l__tenkz_test_lp_bendy_fp-\l__tenkz_test_lp_sy_fp}
+    \__tenkz_test_lp_close:nnn
+      {sqrt(\l_tmpa_fp^2+\l_tmpb_fp^2)}
+      {\l__tenkz_test_lp_daylight_fp}
+      {one~lane~was~not~one~named~page-space~daylight}
+    \__tenkz_test_lp_close:nnn
+      {\l_tmpa_fp*\l__tenkz_test_lp_nx_fp
+        +\l_tmpb_fp*\l__tenkz_test_lp_ny_fp}
+      {0}
+      {a~lane~shift~was~not~perpendicular~to~its~outward~direction}
+    \fp_compare:nNnF
+      {\l_tmpa_fp*\l__tenkz_test_lp_ex_fp
+        +\l_tmpb_fp*\l__tenkz_test_lp_ey_fp} > {0}
+      { \errmessage{the~lane~normal~lost~the~carrier-east~handedness} }
+    \__tenkz_test_lp_close:nnn
+      {
+        (\l__tenkz_test_lp_tipx_fp-\l__tenkz_test_lp_bendx_fp)
+          *\l__tenkz_test_lp_nx_fp
+        +(\l__tenkz_test_lp_tipy_fp-\l__tenkz_test_lp_bendy_fp)
+          *\l__tenkz_test_lp_ny_fp
+      }
+      {\l__tenkz_test_lp_reach_fp}
+      {the~planned~tip~lost~its~face-relative~reach}
+    \__tenkz_test_lp_get:n {C}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{2}
+      {closed~endpoint~contact~did~not~consume~the~third~lane}
+    \__tenkz_test_lp_get:n {D}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{0}
+      {a~disjoint~deeper~interval~did~not~reuse~lane~zero}
+    \__tenkz_test_lp_get:n {tie-z}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{0}
+      {descending~semantic-id~order~did~not~take~the~first~lane}
+    \__tenkz_test_lp_get:n {tie-a}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{1}
+      {descending~semantic-id~order~did~not~take~the~second~lane}
+  }
+
+\cs_new_eq:NN \__tenkz_test_lp_atoms: \__tenkz_kernel_r_atoms:
+\cs_set_protected:Npn \__tenkz_kernel_r_atoms:
+  {
+    \prop_get:NnN \l__tenkz_kernel_named_prop {A}
+      \l__tenkz_test_lp_record_tl
+    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+      \l__tenkz_test_lp_record_tl {90}
+      \l__tenkz_test_lp_ax_fp \l__tenkz_test_lp_ay_fp
+    \prop_get:NnN \l__tenkz_kernel_named_prop {B}
+      \l__tenkz_test_lp_record_tl
+    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+      \l__tenkz_test_lp_record_tl {90}
+      \l__tenkz_test_lp_bx_fp \l__tenkz_test_lp_by_fp
+    \prop_get:NnN \l__tenkz_kernel_named_prop {C}
+      \l__tenkz_test_lp_record_tl
+    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+      \l__tenkz_test_lp_record_tl {90}
+      \l__tenkz_test_lp_cx_fp \l__tenkz_test_lp_cy_fp
+    \prop_get:NnN \l__tenkz_kernel_named_prop {D}
+      \l__tenkz_test_lp_record_tl
+    \exp_args:NV \__tenkz_kernel_r_glyph_anchor_xy:nnNN
+      \l__tenkz_test_lp_record_tl {90}
+      \l__tenkz_test_lp_dx_fp \l__tenkz_test_lp_dy_fp
+    \exp_args:NV \__tenkz_test_lp_plan:n \l__tenkz_test_lp_record_tl
+    \__tenkz_test_lp_atoms:
+  }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[
+    rows={wire,wire,wire,wire}, cols=1, bonds=none,
+    frame={plane,basis={wire at (0,0)}}]
+  \tn[at=(1,1,1), name=A]{}
+  \tn[at=(2,1,1), name=B]{}
+  \tn[at=(3,1,1), name=C]{}
+  \tn[at=(4,1,1), name=D]{}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
+++ b/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
@@ -42,6 +42,69 @@
 \fp_new:N \l__tenkz_test_lp_tipy_fp
 \tl_new:N \l__tenkz_test_lp_record_tl
 \tl_new:N \l__tenkz_test_lp_result_tl
+\tl_new:N \l__tenkz_test_lp_corridors_before_tl
+\tl_new:N \l__tenkz_test_lp_requests_before_tl
+\tl_new:N \l__tenkz_test_lp_results_before_tl
+\tl_new:N \l__tenkz_test_lp_corridors_after_tl
+\tl_new:N \l__tenkz_test_lp_requests_after_tl
+\tl_new:N \l__tenkz_test_lp_results_after_tl
+\int_new:N \l__tenkz_test_lp_diagnostic_count_int
+
+\cs_new_eq:NN \__tenkz_test_lp_msg_error:nne \msg_error:nne
+\cs_new_eq:NN \__tenkz_test_lp_msg_error:nnee \msg_error:nnee
+\cs_new_eq:NN \__tenkz_test_lp_msg_error:nneee \msg_error:nneee
+
+\cs_new_protected:Npn \__tenkz_test_lp_rejected:nn #1#2
+  {
+    \group_begin:
+      \tl_set:Ne \l__tenkz_test_lp_corridors_before_tl
+        {\prop_to_keyval:N \l__tenkz_kernel_lp_corridor_prop}
+      \tl_set:Ne \l__tenkz_test_lp_requests_before_tl
+        {\prop_to_keyval:N \l__tenkz_kernel_lp_request_prop}
+      \tl_set:Ne \l__tenkz_test_lp_results_before_tl
+        {\prop_to_keyval:N \l__tenkz_kernel_lp_result_prop}
+      \int_zero:N \l__tenkz_test_lp_diagnostic_count_int
+      \cs_set_protected:Npn \msg_error:nne ##1##2##3
+        {
+          \str_if_eq:eeTF {##1/##2}{tenkz/#1}
+            {\int_incr:N \l__tenkz_test_lp_diagnostic_count_int}
+            {\__tenkz_test_lp_msg_error:nne {##1}{##2}{##3}}
+        }
+      \cs_set_protected:Npn \msg_error:nnee ##1##2##3##4
+        {
+          \str_if_eq:eeTF {##1/##2}{tenkz/#1}
+            {\int_incr:N \l__tenkz_test_lp_diagnostic_count_int}
+            {\__tenkz_test_lp_msg_error:nnee {##1}{##2}{##3}{##4}}
+        }
+      \cs_set_protected:Npn \msg_error:nneee ##1##2##3##4##5
+        {
+          \str_if_eq:eeTF {##1/##2}{tenkz/#1}
+            {\int_incr:N \l__tenkz_test_lp_diagnostic_count_int}
+            {\__tenkz_test_lp_msg_error:nneee {##1}{##2}{##3}{##4}{##5}}
+        }
+      #2
+      \int_compare:nNnF \l__tenkz_test_lp_diagnostic_count_int = {1}
+        {\errmessage{a~rejected~leg-plan~operation~lost~its~coded~diagnostic}}
+      \tl_set:Ne \l__tenkz_test_lp_corridors_after_tl
+        {\prop_to_keyval:N \l__tenkz_kernel_lp_corridor_prop}
+      \tl_set:Ne \l__tenkz_test_lp_requests_after_tl
+        {\prop_to_keyval:N \l__tenkz_kernel_lp_request_prop}
+      \tl_set:Ne \l__tenkz_test_lp_results_after_tl
+        {\prop_to_keyval:N \l__tenkz_kernel_lp_result_prop}
+      \tl_if_eq:NNF
+        \l__tenkz_test_lp_corridors_before_tl
+        \l__tenkz_test_lp_corridors_after_tl
+        {\errmessage{a~rejected~leg-plan~operation~changed~corridor~state}}
+      \tl_if_eq:NNF
+        \l__tenkz_test_lp_requests_before_tl
+        \l__tenkz_test_lp_requests_after_tl
+        {\errmessage{a~rejected~leg-plan~operation~changed~request~state}}
+      \tl_if_eq:NNF
+        \l__tenkz_test_lp_results_before_tl
+        \l__tenkz_test_lp_results_after_tl
+        {\errmessage{a~rejected~leg-plan~operation~changed~result~state}}
+    \group_end:
+  }
 
 \cs_new_protected:Npn \__tenkz_test_lp_close:nnn #1#2#3
   {
@@ -182,6 +245,37 @@
       { \errmessage{a~request~mutation~left~stale~lane~results} }
     \__tenkz_kernel_leg_plan_resolve:
     \__tenkz_test_lp_assertions:
+    \__tenkz_test_lp_rejected:nn {kernel-leg-plan-vector}
+      {
+        \__tenkz_kernel_leg_plan_corridor:nnnnn
+          {invalid-zero-vector}{0}{0}{1}{0}
+      }
+    \__tenkz_test_lp_rejected:nn {kernel-leg-plan-basis}
+      {
+        \__tenkz_kernel_leg_plan_corridor:nnnnn
+          {member-1/north/col-1}
+          {-\l__tenkz_kernel_r_basis_nx_tl}
+          {-\l__tenkz_kernel_r_basis_ny_tl}
+          {\l__tenkz_kernel_r_basis_ex_tl}
+          {\l__tenkz_kernel_r_basis_ey_tl}
+      }
+    \__tenkz_test_lp_rejected:nn {kernel-leg-plan-corridor}
+      {
+        \__tenkz_kernel_leg_plan_enrol:nnnnn
+          {invalid-corridor}{undeclared}{0}{0}{1}
+      }
+    \__tenkz_test_lp_rejected:nn {kernel-leg-plan-face}
+      {
+        \__tenkz_kernel_leg_plan_enrol:nnnnn
+          {A}{member-1/north/col-1}
+          {\l__tenkz_test_lp_ax_fp + 1}{\l__tenkz_test_lp_ay_fp}
+          {\l__tenkz_test_lp_daylight_fp}
+      }
+    \__tenkz_test_lp_rejected:nn {kernel-leg-plan-reach}
+      {
+        \__tenkz_kernel_leg_plan_enrol:nnnnn
+          {invalid-reach}{member-1/north/col-1}{0}{0}{-1}
+      }
     % Resolution owns its transient occupancy and is repeatable.
     \__tenkz_kernel_leg_plan_resolve:
     \__tenkz_test_lp_assertions:

--- a/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
+++ b/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
@@ -148,6 +148,21 @@
     \__tenkz_kernel_leg_plan_enrol:nnnnn {tie-z}{member-1/north/tie}
       {\l__tenkz_test_lp_ax_fp}{\l__tenkz_test_lp_ay_fp}
       {\l__tenkz_test_lp_daylight_fp}
+    % A third corridor pins the descending-end key ahead of the SID key.
+    \__tenkz_kernel_leg_plan_corridor:nnnnn
+      {member-1/north/end-tie}
+      {\l__tenkz_kernel_r_basis_nx_tl}
+      {\l__tenkz_kernel_r_basis_ny_tl}
+      {\l__tenkz_kernel_r_basis_ex_tl}
+      {\l__tenkz_kernel_r_basis_ey_tl}
+    \__tenkz_kernel_leg_plan_enrol:nnnnn
+      {zz-short}{member-1/north/end-tie}
+      {\l__tenkz_test_lp_ax_fp}{\l__tenkz_test_lp_ay_fp}
+      {\l__tenkz_test_lp_daylight_fp}
+    \__tenkz_kernel_leg_plan_enrol:nnnnn
+      {aa-long}{member-1/north/end-tie}
+      {\l__tenkz_test_lp_ax_fp}{\l__tenkz_test_lp_ay_fp}
+      {2 * \l__tenkz_test_lp_daylight_fp}
     \__tenkz_kernel_leg_plan_get:nN {A} \l__tenkz_test_lp_result_tl
     \quark_if_no_value:NF \l__tenkz_test_lp_result_tl
       { \errmessage{a~lane~result~existed~before~resolution} }
@@ -242,6 +257,12 @@
     \__tenkz_test_lp_get:n {tie-a}
     \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{1}
       {descending~semantic-id~order~did~not~take~the~second~lane}
+    \__tenkz_test_lp_get:n {aa-long}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{0}
+      {descending~end~order~did~not~place~the~longer~interval~first}
+    \__tenkz_test_lp_get:n {zz-short}
+    \__tenkz_test_lp_close:nnn {\l__tenkz_test_lp_lane_fp}{1}
+      {descending~end~order~did~not~place~the~shorter~interval~second}
   }
 
 \cs_new_eq:NN \__tenkz_test_lp_atoms: \__tenkz_kernel_r_atoms:

--- a/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
+++ b/tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex
@@ -194,6 +194,17 @@
     \__tenkz_kernel_leg_plan_get:nN {A} \l__tenkz_test_lp_result_tl
     \quark_if_no_value:NF \l__tenkz_test_lp_result_tl
       { \errmessage{a~new~request~left~stale~lane~results} }
+    \__tenkz_kernel_leg_plan_reset:
+    \seq_if_empty:NF \l__tenkz_kernel_lp_sort_seq
+      { \errmessage{reset~left~the~transient~sort~sequence~populated} }
+    \prop_if_empty:NF \l__tenkz_kernel_lp_corridor_prop
+      { \errmessage{reset~left~corridor~state~populated} }
+    \prop_if_empty:NF \l__tenkz_kernel_lp_request_prop
+      { \errmessage{reset~left~request~state~populated} }
+    \prop_if_empty:NF \l__tenkz_kernel_lp_result_prop
+      { \errmessage{reset~left~result~state~populated} }
+    \prop_if_empty:NF \l__tenkz_kernel_lp_occupied_prop
+      { \errmessage{reset~left~transient~occupancy~state~populated} }
   }
 \cs_new_protected:Npn \__tenkz_test_lp_assertions:
   {

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -7529,9 +7529,11 @@
 
 \cs_new_protected:Npn \__tenkz_kernel_leg_plan_reset:
   {
+    \seq_clear:N \l__tenkz_kernel_lp_sort_seq
     \prop_clear:N \l__tenkz_kernel_lp_corridor_prop
     \prop_clear:N \l__tenkz_kernel_lp_request_prop
     \prop_clear:N \l__tenkz_kernel_lp_result_prop
+    \prop_clear:N \l__tenkz_kernel_lp_occupied_prop
   }
 
 % Declare one topology-owned corridor.  The outward vector becomes the unit

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -131,6 +131,21 @@
 \msg_new:nnn {tenkz}{kernel-glyph-face-none}
   { [TKZ-GLYPH-FACE-NONE]~record~#1~has~skin=none~and~no~declared~
     pairing~support,~so~it~has~no~glyph~face. }
+\msg_new:nnn {tenkz}{kernel-leg-plan-vector}
+  { [TKZ-LEG-PLAN-VECTOR]~physical-leg~corridor~'#1'~has~a~zero~
+    outward~direction. }
+\msg_new:nnn {tenkz}{kernel-leg-plan-basis}
+  { [TKZ-LEG-PLAN-BASIS]~physical-leg~corridor~'#1'~was~redeclared~
+    with~a~different~page-space~basis. }
+\msg_new:nnn {tenkz}{kernel-leg-plan-corridor}
+  { [TKZ-LEG-PLAN-CORRIDOR]~semantic~leg~'#1'~names~undeclared~
+    corridor~'#2'. }
+\msg_new:nnn {tenkz}{kernel-leg-plan-face}
+  { [TKZ-LEG-PLAN-FACE]~semantic~leg~'#1'~was~first~enrolled~at~#2,~
+    then~re-enrolled~at~#3. }
+\msg_new:nnn {tenkz}{kernel-leg-plan-reach}
+  { [TKZ-LEG-PLAN-REACH]~semantic~leg~'#1'~has~negative~face-relative~
+    reach~#2. }
 \msg_new:nnn {tenkz}{kernel-skin-pairings-parse}
   { [TKZ-SKIN-PAIRING-PARSE]~pairings~on~declared~skin~'#1'~must~be~
     one~braced~port-pair-list. }
@@ -7477,6 +7492,386 @@
         \fp_zero:N #4
       }
   }
+
+% ---------- physical-leg lane plan -------------------------------------------
+% This planner is deliberately data-only.  A later atomic contour switch may
+% consume it, but current leg ink, route lanes, labels, crossings, and events
+% do not.  Corridors are discrete topology identities supplied by the caller;
+% floating coordinates are never clustered to invent one.
+\seq_new:N  \l__tenkz_kernel_lp_sort_seq
+\prop_new:N \l__tenkz_kernel_lp_corridor_prop
+\prop_new:N \l__tenkz_kernel_lp_request_prop
+\prop_new:N \l__tenkz_kernel_lp_result_prop
+\prop_new:N \l__tenkz_kernel_lp_occupied_prop
+\tl_new:N   \l__tenkz_kernel_lp_cid_tl
+\tl_new:N   \l__tenkz_kernel_lp_request_cid_tl
+\tl_new:N   \l__tenkz_kernel_lp_sid_tl
+\tl_new:N   \l__tenkz_kernel_lp_tuple_tl
+\tl_new:N   \l__tenkz_kernel_lp_old_tl
+\tl_new:N   \l__tenkz_kernel_lp_face_tl
+\fp_new:N   \l__tenkz_kernel_lp_dx_fp
+\fp_new:N   \l__tenkz_kernel_lp_dy_fp
+\fp_new:N   \l__tenkz_kernel_lp_qx_fp
+\fp_new:N   \l__tenkz_kernel_lp_qy_fp
+\fp_new:N   \l__tenkz_kernel_lp_norm_fp
+\fp_new:N   \l__tenkz_kernel_lp_sx_fp
+\fp_new:N   \l__tenkz_kernel_lp_sy_fp
+\fp_new:N   \l__tenkz_kernel_lp_reach_fp
+\fp_new:N   \l__tenkz_kernel_lp_start_fp
+\fp_new:N   \l__tenkz_kernel_lp_end_fp
+\fp_new:N   \l__tenkz_kernel_lp_bx_fp
+\fp_new:N   \l__tenkz_kernel_lp_by_fp
+\fp_new:N   \l__tenkz_kernel_lp_tx_fp
+\fp_new:N   \l__tenkz_kernel_lp_ty_fp
+\int_new:N  \l__tenkz_kernel_lp_lane_int
+\bool_new:N \l__tenkz_kernel_lp_same_bool
+\bool_new:N \l__tenkz_kernel_lp_conflict_bool
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_reset:
+  {
+    \prop_clear:N \l__tenkz_kernel_lp_corridor_prop
+    \prop_clear:N \l__tenkz_kernel_lp_request_prop
+    \prop_clear:N \l__tenkz_kernel_lp_result_prop
+  }
+
+% Declare one topology-owned corridor.  The outward vector becomes the unit
+% direction d.  Its page-perpendicular q is oriented toward carrier east, so
+% one lane is exactly one page-space daylight in a stable handedness.  A valid
+% carrier basis makes east nonparallel to the outward direction.
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_corridor:nnnnn #1#2#3#4#5
+  {
+    \tl_set:Ne \l__tenkz_kernel_lp_cid_tl {#1}
+    \fp_set:Nn \l__tenkz_kernel_lp_dx_fp {#2}
+    \fp_set:Nn \l__tenkz_kernel_lp_dy_fp {#3}
+    \fp_set:Nn \l__tenkz_kernel_lp_norm_fp
+      {
+        sqrt(
+          \l__tenkz_kernel_lp_dx_fp ^ 2
+          + \l__tenkz_kernel_lp_dy_fp ^ 2 )
+      }
+    \fp_compare:nNnTF {\l__tenkz_kernel_lp_norm_fp} = {0}
+      {
+        \msg_error:nne {tenkz}{kernel-leg-plan-vector}
+          {\tl_use:N \l__tenkz_kernel_lp_cid_tl}
+      }
+      {
+        \fp_set:Nn \l__tenkz_kernel_lp_dx_fp
+          { \l__tenkz_kernel_lp_dx_fp / \l__tenkz_kernel_lp_norm_fp }
+        \fp_set:Nn \l__tenkz_kernel_lp_dy_fp
+          { \l__tenkz_kernel_lp_dy_fp / \l__tenkz_kernel_lp_norm_fp }
+        \fp_set:Nn \l__tenkz_kernel_lp_qx_fp
+          { -\l__tenkz_kernel_lp_dy_fp }
+        \fp_set_eq:NN \l__tenkz_kernel_lp_qy_fp
+          \l__tenkz_kernel_lp_dx_fp
+        \fp_compare:nNnT
+          {
+            \l__tenkz_kernel_lp_qx_fp * (#4)
+            + \l__tenkz_kernel_lp_qy_fp * (#5)
+          }
+          < {0}
+          {
+            \fp_set:Nn \l__tenkz_kernel_lp_qx_fp
+              { -\l__tenkz_kernel_lp_qx_fp }
+            \fp_set:Nn \l__tenkz_kernel_lp_qy_fp
+              { -\l__tenkz_kernel_lp_qy_fp }
+          }
+        \tl_set:Ne \l__tenkz_kernel_lp_tuple_tl
+          {
+            {\fp_use:N \l__tenkz_kernel_lp_dx_fp}
+            {\fp_use:N \l__tenkz_kernel_lp_dy_fp}
+            {\fp_use:N \l__tenkz_kernel_lp_qx_fp}
+            {\fp_use:N \l__tenkz_kernel_lp_qy_fp}
+          }
+        \prop_get:NVN \l__tenkz_kernel_lp_corridor_prop
+          \l__tenkz_kernel_lp_cid_tl \l__tenkz_kernel_lp_old_tl
+        \quark_if_no_value:NTF \l__tenkz_kernel_lp_old_tl
+          {
+            \prop_put:NVV \l__tenkz_kernel_lp_corridor_prop
+              \l__tenkz_kernel_lp_cid_tl \l__tenkz_kernel_lp_tuple_tl
+          }
+          {
+            \tl_if_eq:NNTF
+              \l__tenkz_kernel_lp_old_tl \l__tenkz_kernel_lp_tuple_tl
+              { }
+              {
+                \msg_error:nne {tenkz}{kernel-leg-plan-basis}
+                  {\tl_use:N \l__tenkz_kernel_lp_cid_tl}
+              }
+          }
+      }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_request_set:nnnn #1#2#3#4
+  {
+    \tl_set:Nn \l__tenkz_kernel_lp_request_cid_tl {#1}
+    \fp_set:Nn \l__tenkz_kernel_lp_sx_fp {#2}
+    \fp_set:Nn \l__tenkz_kernel_lp_sy_fp {#3}
+    \fp_set:Nn \l__tenkz_kernel_lp_reach_fp {#4}
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_enrol_new:
+  {
+    \prop_put:NVV \l__tenkz_kernel_lp_request_prop
+      \l__tenkz_kernel_lp_sid_tl \l__tenkz_kernel_lp_tuple_tl
+    \prop_clear:N \l__tenkz_kernel_lp_result_prop
+  }
+
+% Enrol one face-relative outward interval.  Repeated observations of the
+% same semantic leg share one exact face and retain only their greatest reach.
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_enrol:nnnnn #1#2#3#4#5
+  {
+    \tl_set:Ne \l__tenkz_kernel_lp_sid_tl {#1}
+    \tl_set:Ne \l__tenkz_kernel_lp_cid_tl {#2}
+    \fp_set:Nn \l__tenkz_kernel_lp_sx_fp {#3}
+    \fp_set:Nn \l__tenkz_kernel_lp_sy_fp {#4}
+    \fp_set:Nn \l__tenkz_kernel_lp_reach_fp {#5}
+    % Freeze caller expressions before unpacking an earlier request into the
+    % planner's scratch registers.
+    \tl_set:Ne \l__tenkz_kernel_lp_tuple_tl
+      {
+        {\tl_use:N \l__tenkz_kernel_lp_cid_tl}
+        {\fp_use:N \l__tenkz_kernel_lp_sx_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_sy_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_reach_fp}
+      }
+    \fp_compare:nNnTF {\l__tenkz_kernel_lp_reach_fp} < {0}
+      {
+        \msg_error:nnee {tenkz}{kernel-leg-plan-reach}
+          {\tl_use:N \l__tenkz_kernel_lp_sid_tl}
+          {\fp_use:N \l__tenkz_kernel_lp_reach_fp}
+      }
+      {
+        \prop_if_in:NVTF \l__tenkz_kernel_lp_corridor_prop
+          \l__tenkz_kernel_lp_cid_tl
+          {
+            \prop_get:NVN \l__tenkz_kernel_lp_request_prop
+              \l__tenkz_kernel_lp_sid_tl \l__tenkz_kernel_lp_old_tl
+            \quark_if_no_value:NTF \l__tenkz_kernel_lp_old_tl
+              { \__tenkz_kernel_leg_plan_enrol_new: }
+              {
+                \exp_last_unbraced:NV
+                  \__tenkz_kernel_leg_plan_request_set:nnnn
+                  \l__tenkz_kernel_lp_old_tl
+                \bool_set_true:N \l__tenkz_kernel_lp_same_bool
+                \str_if_eq:eeF
+                  {\tl_use:N \l__tenkz_kernel_lp_request_cid_tl}
+                  {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {1}}
+                  { \bool_set_false:N \l__tenkz_kernel_lp_same_bool }
+                \fp_compare:nNnF
+                  {\l__tenkz_kernel_lp_sx_fp}
+                  = {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {2}}
+                  { \bool_set_false:N \l__tenkz_kernel_lp_same_bool }
+                \fp_compare:nNnF
+                  {\l__tenkz_kernel_lp_sy_fp}
+                  = {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {3}}
+                  { \bool_set_false:N \l__tenkz_kernel_lp_same_bool }
+                \bool_if:NTF \l__tenkz_kernel_lp_same_bool
+                  {
+                    \fp_compare:nNnT
+                      {\l__tenkz_kernel_lp_reach_fp}
+                      < {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {4}}
+                      {
+                        \tl_set:Ne \l__tenkz_kernel_lp_old_tl
+                          {
+                            {\tl_use:N \l__tenkz_kernel_lp_request_cid_tl}
+                            {\fp_use:N \l__tenkz_kernel_lp_sx_fp}
+                            {\fp_use:N \l__tenkz_kernel_lp_sy_fp}
+                            {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {4}}
+                          }
+                        \prop_put:NVV \l__tenkz_kernel_lp_request_prop
+                          \l__tenkz_kernel_lp_sid_tl
+                          \l__tenkz_kernel_lp_old_tl
+                        \prop_clear:N \l__tenkz_kernel_lp_result_prop
+                      }
+                  }
+                  {
+                    \tl_set:Ne \l__tenkz_kernel_lp_old_tl
+                      {
+                        {\tl_use:N \l__tenkz_kernel_lp_request_cid_tl}
+                        {\fp_use:N \l__tenkz_kernel_lp_sx_fp}
+                        {\fp_use:N \l__tenkz_kernel_lp_sy_fp}
+                      }
+                    \tl_set:Ne \l__tenkz_kernel_lp_face_tl
+                      {
+                        {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {1}}
+                        {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {2}}
+                        {\tl_item:Nn \l__tenkz_kernel_lp_tuple_tl {3}}
+                      }
+                    \msg_error:nneee {tenkz}{kernel-leg-plan-face}
+                      {\tl_use:N \l__tenkz_kernel_lp_sid_tl}
+                      {\tl_use:N \l__tenkz_kernel_lp_old_tl}
+                      {\tl_use:N \l__tenkz_kernel_lp_face_tl}
+                  }
+              }
+          }
+          {
+            \msg_error:nnee {tenkz}{kernel-leg-plan-corridor}
+              {\tl_use:N \l__tenkz_kernel_lp_sid_tl}
+              {\tl_use:N \l__tenkz_kernel_lp_cid_tl}
+          }
+      }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_basis_set:nnnn #1#2#3#4
+  {
+    \fp_set:Nn \l__tenkz_kernel_lp_dx_fp {#1}
+    \fp_set:Nn \l__tenkz_kernel_lp_dy_fp {#2}
+    \fp_set:Nn \l__tenkz_kernel_lp_qx_fp {#3}
+    \fp_set:Nn \l__tenkz_kernel_lp_qy_fp {#4}
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_sort_item:nnn #1#2#3
+  {
+    \tl_set:Nn \l__tenkz_kernel_lp_sid_tl {#1}
+    \fp_set:Nn \l__tenkz_kernel_lp_start_fp {#2}
+    \fp_set:Nn \l__tenkz_kernel_lp_end_fp {#3}
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_conflict:
+  {
+    \bool_set_false:N \l__tenkz_kernel_lp_conflict_bool
+    \prop_get:NeN \l__tenkz_kernel_lp_occupied_prop
+      {\int_use:N \l__tenkz_kernel_lp_lane_int}
+      \l__tenkz_kernel_lp_old_tl
+    \quark_if_no_value:NF \l__tenkz_kernel_lp_old_tl
+      {
+        % Descending starts make the most recently placed start the only
+        % boundary to check.  Equality still conflicts: intervals are closed.
+        \fp_compare:nNnF
+          {\l__tenkz_kernel_lp_end_fp}
+          < {\l__tenkz_kernel_lp_old_tl}
+          { \bool_set_true:N \l__tenkz_kernel_lp_conflict_bool }
+      }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_resolve_one:n #1
+  {
+    \__tenkz_kernel_leg_plan_sort_item:nnn #1
+    \prop_get:NVN \l__tenkz_kernel_lp_request_prop
+      \l__tenkz_kernel_lp_sid_tl \l__tenkz_kernel_lp_old_tl
+    \exp_last_unbraced:NV
+      \__tenkz_kernel_leg_plan_request_set:nnnn
+      \l__tenkz_kernel_lp_old_tl
+    \int_zero:N \l__tenkz_kernel_lp_lane_int
+    \bool_set_true:N \l__tenkz_kernel_lp_conflict_bool
+    \bool_while_do:Nn \l__tenkz_kernel_lp_conflict_bool
+      {
+        \__tenkz_kernel_leg_plan_conflict:
+        \bool_if:NT \l__tenkz_kernel_lp_conflict_bool
+          { \int_incr:N \l__tenkz_kernel_lp_lane_int }
+      }
+    \prop_put:Nee \l__tenkz_kernel_lp_occupied_prop
+      {\int_use:N \l__tenkz_kernel_lp_lane_int}
+      {\fp_use:N \l__tenkz_kernel_lp_start_fp}
+    \fp_set:Nn \l__tenkz_kernel_lp_bx_fp
+      {
+        \l__tenkz_kernel_lp_sx_fp
+        + \l__tenkz_kernel_lp_lane_int
+          * \__tenkz_metric_ratio:n {daylight}
+          * \l__tenkz_kernel_lp_qx_fp
+      }
+    \fp_set:Nn \l__tenkz_kernel_lp_by_fp
+      {
+        \l__tenkz_kernel_lp_sy_fp
+        + \l__tenkz_kernel_lp_lane_int
+          * \__tenkz_metric_ratio:n {daylight}
+          * \l__tenkz_kernel_lp_qy_fp
+      }
+    \fp_set:Nn \l__tenkz_kernel_lp_tx_fp
+      { \l__tenkz_kernel_lp_bx_fp + \l__tenkz_kernel_lp_reach_fp
+          * \l__tenkz_kernel_lp_dx_fp }
+    \fp_set:Nn \l__tenkz_kernel_lp_ty_fp
+      { \l__tenkz_kernel_lp_by_fp + \l__tenkz_kernel_lp_reach_fp
+          * \l__tenkz_kernel_lp_dy_fp }
+    \tl_set:Ne \l__tenkz_kernel_lp_tuple_tl
+      {
+        {\int_use:N \l__tenkz_kernel_lp_lane_int}
+        {\fp_use:N \l__tenkz_kernel_lp_reach_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_sx_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_sy_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_bx_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_by_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_tx_fp}
+        {\fp_use:N \l__tenkz_kernel_lp_ty_fp}
+      }
+    \prop_put:NVV \l__tenkz_kernel_lp_result_prop
+      \l__tenkz_kernel_lp_sid_tl \l__tenkz_kernel_lp_tuple_tl
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_collect_request:nn #1#2
+  {
+    \__tenkz_kernel_leg_plan_request_set:nnnn #2
+    \str_if_eq:eeT
+      {\tl_use:N \l__tenkz_kernel_lp_request_cid_tl}
+      {\tl_use:N \l__tenkz_kernel_lp_cid_tl}
+      {
+        \fp_set:Nn \l__tenkz_kernel_lp_start_fp
+          {
+            \l__tenkz_kernel_lp_sx_fp * \l__tenkz_kernel_lp_dx_fp
+            + \l__tenkz_kernel_lp_sy_fp * \l__tenkz_kernel_lp_dy_fp
+          }
+        \fp_set:Nn \l__tenkz_kernel_lp_end_fp
+          { \l__tenkz_kernel_lp_start_fp + \l__tenkz_kernel_lp_reach_fp }
+        \seq_put_right:Ne \l__tenkz_kernel_lp_sort_seq
+          {
+            {#1}
+            {\fp_use:N \l__tenkz_kernel_lp_start_fp}
+            {\fp_use:N \l__tenkz_kernel_lp_end_fp}
+          }
+      }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_resolve_corridor:nn #1#2
+  {
+    \tl_set:Nn \l__tenkz_kernel_lp_cid_tl {#1}
+    \__tenkz_kernel_leg_plan_basis_set:nnnn #2
+    \seq_clear:N \l__tenkz_kernel_lp_sort_seq
+    \prop_clear:N \l__tenkz_kernel_lp_occupied_prop
+    \prop_map_function:NN \l__tenkz_kernel_lp_request_prop
+      \__tenkz_kernel_leg_plan_collect_request:nn
+    \seq_sort:Nn \l__tenkz_kernel_lp_sort_seq
+      {
+        \fp_compare:nNnTF
+          {\tl_item:nn {##1}{2}} < {\tl_item:nn {##2}{2}}
+          { \sort_return_swapped: }
+          {
+            \fp_compare:nNnTF
+              {\tl_item:nn {##1}{2}} > {\tl_item:nn {##2}{2}}
+              { \sort_return_same: }
+              {
+                \fp_compare:nNnTF
+                  {\tl_item:nn {##1}{3}} < {\tl_item:nn {##2}{3}}
+                  { \sort_return_swapped: }
+                  {
+                    \fp_compare:nNnTF
+                      {\tl_item:nn {##1}{3}} > {\tl_item:nn {##2}{3}}
+                      { \sort_return_same: }
+                      {
+                        \str_compare:eNeTF
+                          {\tl_item:nn {##1}{1}}
+                          < {\tl_item:nn {##2}{1}}
+                          { \sort_return_swapped: }
+                          { \sort_return_same: }
+                      }
+                  }
+              }
+          }
+      }
+    \seq_map_function:NN \l__tenkz_kernel_lp_sort_seq
+      \__tenkz_kernel_leg_plan_resolve_one:n
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_resolve:
+  {
+    \prop_clear:N \l__tenkz_kernel_lp_result_prop
+    \prop_map_function:NN \l__tenkz_kernel_lp_corridor_prop
+      \__tenkz_kernel_leg_plan_resolve_corridor:nn
+  }
+
+% Return {lane}{reach}{start-x}{start-y}{bend-x}{bend-y}{tip-x}{tip-y}.
+% An unknown or not-yet-resolved semantic id deliberately returns q_no_value.
+\cs_new_protected:Npn \__tenkz_kernel_leg_plan_get:nN #1#2
+  { \prop_get:NeN \l__tenkz_kernel_lp_result_prop {#1} #2 }
 
 % Resolve a live glyph anchor in the host's local axes and carry it to the
 % page.  The resolved port node supplies the span-slot centre, while the host


### PR DESCRIPTION
## Summary

- add a pure internal planner that assigns physical-leg projections to the least nonconflicting lane within an explicit geometric corridor
- derive page-space outward and lateral bases from caller geometry, with deterministic face ordering, closed-interval collision semantics, and max-reach duplicate enrolment
- invalidate stale results on every effective mutation and reject inconsistent corridor/face declarations
- pin the contract with a mutation-heavy regression, including overlapping independent corridors and a nonstock named-daylight override

This is behavior-neutral infrastructure for LionSR/tenkz#113: it does not activate a renderer, alter public syntax, change event streams, or add a new metric. It deliberately keeps the planning policy separate from the later rendering integration.

## Validation

- `tests/tenkz/kernel/regression/r_physical_leg_lane_plan.tex` (XeLaTeX)
- `scripts/tenkz_kernel_probes.sh` — 85 regressions; sugar and record streams byte-identical; pixels byte-identical
- `scripts/tenkz_golden.sh --check` — 264 event streams byte-identical
- `scripts/tenkz_corpus.sh` — 264 standalone files compiled and audited
- language registry check — 226 cases
- lint — 289 files, 0 issues
- shrink gate — census stable at 200 examples and 132 flags
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> ~400 lines of new kernel geometry/state logic, but it is internal-only, unused by existing render paths, and guarded by a focused regression plus reported byte-identical golden/corpus runs.
> 
> **Overview**
> Adds **behavior-neutral, data-only** physical-leg lane planning in the kernel: callers declare affine **corridors**, **enrol** face-relative outward intervals per semantic leg, then **resolve** to assign the least conflicting lane (one `daylight` per lane, carrier-east handedness) with closed-interval overlap, deterministic sort (start, end, semantic id), and max-reach merge for duplicate enrolments. Effective request changes clear cached results; invalid inputs raise five new `kernel-leg-plan-*` diagnostics without mutating planner state on rejection.
> 
> A mutation-heavy regression (`r_physical_leg_lane_plan.tex`) pins overlap geometry, tie-break corridors, stale-result invalidation, rejection paths, and reset semantics. **No renderer or public syntax** is hooked up yet—this is groundwork for a later contour switch (#5086).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d50c65e28d874eb8b559811a574c9956a0a3f7cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Negative-test boundary

The planner is internal data-only infrastructure and has no public parser or renderer entry point in this PR. Its five coded rejection paths are exercised together in the focused mutation harness, which checks both the exact diagnostic key and byte-identical corridor/request/result state after rejection. Dedicated `tests/tenkz/kernel/negative/n_*.tex` halt-on-error fixtures are intentionally deferred to the atomic contour switch in LionSR/tenkz#113, when these diagnostics become reachable through a public rendering workflow; adding five direct-internal fixtures here would duplicate the stronger harness without testing public reachability.