### PR TITLE
feat(MPS/MPDO): derive the conditional sector Gram identity

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -16,6 +16,7 @@ import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
 import TNLean.MPS.MPDO.BNTAssociativity

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
+import TNLean.MPS.MPDO.CPSVBlocking
+import TNLean.MPS.MPDO.CPSVFigureEight
+
+/-!
+# Conditional Gram identity for an exact two-site sector gauge
+
+An identity-dressed marked realization in the physical-letter span, with the
+same reflected target as the gauge-dressed corner, determines the Gram
+conjugation of an exact two-site sector gauge.  Normality then makes the gauge
+Gram matrix a positive scalar multiple of the identity.
+
+The identity-dressed realization is assumed here, not constructed.  Thus these
+results isolate the remaining implication in Appendix C.4 and do not complete
+the two-site unitary-gauge argument.
+
+## Main results
+
+* `TwoSiteExactSectorGauge.gramDressing_gauge_eq_one_of_identityMarkedRealization`
+* `TwoSiteExactSectorGauge.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, Figures 7--8, lines 1898--1921, and Appendix C.4,
+  lines 2048--2057
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- An identity-dressed physical-letter marked realization with the same
+reflected target as the exact gauge-dressed corner forces the two Gram
+dressings to agree.
+
+**Scope restriction (conditional identity-dressed marked realization):** The
+theorem assumes the physical-letter realization implicit at CPSV16 Appendix
+C.4, line 2048; it is not derived from the algebra clause and does not resolve
+the unconditional realization or conclusion of Appendix C.4.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+theorem gramDressing_gauge_eq_one_of_identityMarkedRealization
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (γ : Fin H.labelCount)
+    (fId : Fin (S.decomposition.bondDim (S.relabel γ) *
+        S.decomposition.bondDim (S.relabel γ)) →
+      Fin ((d * d) * (d * d)) → ℂ)
+    (hPhysical : ∀ u,
+      MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
+        horizontalSlice
+          (gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ))) u.divNat u.modNat)
+    (hTarget : ∀ (N : ℕ)
+      (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
+      (σ τ : Fin N → Fin (d * d)),
+      markedChainCoefficient
+          (gramDressing
+            (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)))
+          (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
+        markedChainCoefficient
+          (reflectedAdjoint
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)))
+          (adjointTensor (blockTwo M)) r s
+          (List.ofFn σ).reverse (List.ofFn τ).reverse) :
+    gramDressing (S.gauge γ)
+        (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ)) =
+      gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+        (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ)) := by
+  classical
+  obtain ⟨V, c, _, hc, hCorner⟩ := S.exists_blockTwo_gauge_sector_corner γ
+  let fGauge := cornerGramCoefficients V (S.gauge γ) c
+  have hTrace : ∀ (L : ℕ)
+      (u : Fin (S.decomposition.bondDim (S.relabel γ) *
+        S.decomposition.bondDim (S.relabel γ)))
+      (w : Fin L → Fin ((d * d) * (d * d))),
+      Matrix.trace
+          (MPSTensor.linearMarkedTensor fGauge (blockTwo M).toMPSTensor u *
+            MPSTensor.evalWord (blockTwo M).toMPSTensor (List.ofFn w)) =
+        Matrix.trace
+          (MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u *
+            MPSTensor.evalWord (blockTwo M).toMPSTensor (List.ofFn w)) := by
+    intro L u w
+    rw [show MPSTensor.linearMarkedTensor fGauge (blockTwo M).toMPSTensor u =
+        horizontalSlice
+          (gramDressing (S.gauge γ)
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ))) u.divNat u.modNat by
+      exact linearMarkedTensor_cornerGramCoefficients
+        (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ))
+        V (S.gauge γ) c hc hCorner u]
+    rw [hPhysical u]
+    rw [evalWord_toMPSTensor_ofFn]
+    exact
+      (S.markedChainCoefficient_gauge_eq_reflectedAdjoint hM γ L
+        u.divNat u.modNat (fun k ↦ (w k).divNat) (fun k ↦ (w k).modNat)).trans
+      (hTarget L u.divNat u.modNat
+        (fun k ↦ (w k).divNat) (fun k ↦ (w k).modNat)).symm
+  have hMarks :
+      MPSTensor.linearMarkedTensor fGauge (blockTwo M).toMPSTensor =
+        MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor :=
+    (IsCPSVCanonicalForm_toMPSTensor_blockTwo hCanonical).linearMarkedTensor_eq_of_trace_agree
+      (blockTwo M).toMPSTensor fGauge fId hTrace
+  funext v
+  obtain ⟨⟨a, b⟩, rfl⟩ := finProdFinEquiv.surjective v
+  ext r s
+  have hSlice := congrFun hMarks (finProdFinEquiv (r, s))
+  rw [show MPSTensor.linearMarkedTensor fGauge (blockTwo M).toMPSTensor
+        (finProdFinEquiv (r, s)) =
+      horizontalSlice
+        (gramDressing (S.gauge γ)
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)))
+        (finProdFinEquiv (r, s)).divNat (finProdFinEquiv (r, s)).modNat by
+    exact linearMarkedTensor_cornerGramCoefficients
+      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ))
+      V (S.gauge γ) c hc hCorner (finProdFinEquiv (r, s)),
+    hPhysical] at hSlice
+  simpa only [horizontalSlice, MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat] using congrFun (congrFun hSlice a) b
+
+/-- Under the same conditional identity-dressed marked realization, the Gram
+matrix of the exact two-site sector gauge is a positive real scalar multiple
+of the identity.
+
+**Scope restriction (conditional identity-dressed marked realization):** The
+theorem assumes the physical-letter realization implicit at CPSV16 Appendix
+C.4, line 2048; it is not derived from the algebra clause and does not establish
+the unconditional realization or conclusion of Appendix C.4.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+theorem gauge_gram_eq_pos_smul_one_of_identityMarkedRealization
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (γ : Fin H.labelCount)
+    (fId : Fin (S.decomposition.bondDim (S.relabel γ) *
+        S.decomposition.bondDim (S.relabel γ)) →
+      Fin ((d * d) * (d * d)) → ℂ)
+    (hPhysical : ∀ u,
+      MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
+        horizontalSlice
+          (gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ))) u.divNat u.modNat)
+    (hTarget : ∀ (N : ℕ)
+      (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
+      (σ τ : Fin N → Fin (d * d)),
+      markedChainCoefficient
+          (gramDressing
+            (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)))
+          (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
+        markedChainCoefficient
+          (reflectedAdjoint
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)))
+          (adjointTensor (blockTwo M)) r s
+          (List.ofFn σ).reverse (List.ofFn τ).reverse) :
+    ∃ ω : ℝ, 0 < ω ∧
+      (S.gauge γ : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ * S.gauge γ =
+        (ω : ℂ) • 1 := by
+  have hDress := S.gramDressing_gauge_eq_one_of_identityMarkedRealization
+    hCanonical hM γ fId hPhysical hTarget
+  have hNormalTensor : MPSTensor.IsNormalTensor
+      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ)) :=
+    (MPSTensor.isNormalTensor_cast_iff (S.bondDim_eq γ) (H.tensor γ)).2
+      (H.isCPSVBNT.blocks_normal γ)
+  apply hNormalTensor.isNormal.gram_eq_pos_smul_one_of_gram_conj_eq
+    (Matrix.isUnits_det_units (S.gauge γ))
+  intro v
+  simpa [gramDressing] using congrFun hDress v
+
+end BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -283,6 +283,63 @@
     coefficients; the gauge factors cancel on the reflected side.
 \end{proof}
 
+\begin{theorem}[Conditional Gram identity from an identity-dressed marked realization]
+    \label{thm:mpdo_bnt_conditional_identity_marked_gram}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        gramDressing_gauge_eq_one_of_identityMarkedRealization}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        gauge_gram_eq_pos_smul_one_of_identityMarkedRealization}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form,
+        def:mpdo_bnt_two_site_exact_sector_gauge}
+    In the setting of the preceding theorem, suppose in addition that the
+    doubled-index tensor of $M$ is in literal CPSV canonical form. Assume that
+    there is a family of linear combinations of the physical letters of
+    $M^{[2]}$ whose open-bond matrices are the horizontal slices of
+    $M_\gamma$, and that every resulting marked chain equals the
+    reflected-adjoint marked chain of $M_\gamma$ in the adjoint two-site
+    blocking. Then
+    \begin{align}
+        (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
+        (Z_\gamma^\dagger Z_\gamma)^{-1}
+        &=M_\gamma^v
+        \label{eq:mpdo_bnt_conditional_identity_marked_gram}
+    \end{align}
+    for every vertical letter $v$. Consequently, there is a real number
+    $\omega_\gamma>0$ such that
+    \begin{align}
+        Z_\gamma^\dagger Z_\gamma
+        &=\omega_\gamma\Id.
+        \label{eq:mpdo_bnt_conditional_scalar_gram}
+    \end{align}
+
+    \textbf{Scope restriction (conditional identity-dressed marked
+    realization):} The physical-letter realization used here is the missing
+    assertion implicit at Appendix~C.4, line~2048. It is assumed rather than
+    derived from the algebra clause. Thus this theorem does not establish the
+    unconditional realization or the conclusion of Appendix~C.4,
+    lines~2048--2057. The remaining gap is recorded in
+    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_bnt_exact_sector_gauge_blocked_corner,
+        thm:mpdo_literal_cpsv_positive_blocking,
+        thm:cpsv_original_coordinate_marked_lemma_l,
+        thm:eq3_of_dressed_adjoint}
+    The preceding theorem gives a physical-letter coefficient family for the
+    gauge-dressed mark and identifies its marked chains with the reflected
+    target. By hypothesis, the identity-dressed mark has another
+    physical-letter coefficient family with the same target. Their marked
+    traces therefore agree for every tail word. Literal CPSV canonical form
+    passes to the two-site blocking, and the original-coordinate marked
+    separation theorem identifies the two open-bond matrices. This gives
+    (\ref{eq:mpdo_bnt_conditional_identity_marked_gram}). Normality of
+    $M_\gamma$ then makes its commuting Gram matrix a positive real scalar
+    multiple of the identity, proving
+    (\ref{eq:mpdo_bnt_conditional_scalar_gram}).
+\end{proof}
+
 \begin{lemma}[Idempotence for the canonical chi coefficients]%
     \label{lem:mpdo_bnt_idempotent_coefficient_form_of_chi}
     \lean{MPOTensor.BNTAlgebraClause.idempotent_coefficient_form_ofChi}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -298,15 +298,14 @@
     $M^{[2]}$ whose open-bond matrices are the horizontal slices of
     $M_\gamma$, and that every resulting marked chain equals the
     reflected-adjoint marked chain of $M_\gamma$ in the adjoint two-site
-    blocking. Then
+    blocking. Then, for every vertical letter $v$,
     \begin{align}
         (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
         (Z_\gamma^\dagger Z_\gamma)^{-1}
         &=M_\gamma^v
         \label{eq:mpdo_bnt_conditional_identity_marked_gram}
     \end{align}
-    for every vertical letter $v$. Consequently, there is a real number
-    $\omega_\gamma>0$ such that
+    Consequently, there is a real number $\omega_\gamma>0$ such that
     \begin{align}
         Z_\gamma^\dagger Z_\gamma
         &=\omega_\gamma\Id.


### PR DESCRIPTION
Closes #5279. Addresses #4648.

## Mathematical result

For an exact two-site sector gauge, suppose the identity-dressed representative admits a marked realization in the physical-letter span and that its marked chains have the same reflected-adjoint target as the gauge-dressed corner constructed in PR #5277. The new theorem proves equality of the gauge-dressed and identity-dressed Gram conjugations. A separate corollary uses normality to obtain

```text
X_γ† X_γ = ω_γ I,    ω_γ > 0.
```

The proof constructs the gauge-dressed physical-letter coefficients from the existing blocked corner, compares both families through their common reflected target, applies literal CPSV Lemma L after two-site blocking, and then invokes the normal-commutant theorem.

## Scope

The identity-dressed physical-letter realization is an explicit assumption. It is not derived from the tensor-attached algebra clause. Consequently this pull request does not prove the unconditional Appendix C.4 step and does not close #4648. Both Lean docstrings and the Blueprint cite `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` and state this restriction visibly.

Source comparison: CPSV16, Proposition 4.13, Figures 7–8 and lines 1898–1921, applied at Appendix C.4, lines 2048–2057.

## Verification

- targeted Lean compilation
- full `lake build` (9,873 jobs)
- `#print axioms`: only `propext`, `Classical.choice`, and `Quot.sound`
- proof-integrity and forbidden-token checks
- Blueprint synchronization and both declaration checks
- reader-facing prose and tenkz disposition checks
- Blueprint web and PDF generation
- visual inspection of the rendered theorem page

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and Blueprint documentation in the MPDO/BNT track; no runtime, auth, or data-path behavior is affected.
> 
> **Overview**
> Adds formal Lean proofs and a matching Blueprint theorem for the **conditional** Appendix C.4 Gram step on exact two-site sector gauges.
> 
> Under explicit hypotheses—literal CPSV canonical form, an identity-dressed physical-letter marked realization whose open slices are `M_γ`, and the same reflected-adjoint marked-chain target as the gauge-dressed corner from the prior blocked-corner result—the new lemmas show gauge and identity Gram dressings agree, then that `Z_γ† Z_γ` is a positive real scalar multiple of the identity via sector normality. The proof matches gauge- and identity-dressed coefficient families through shared marked traces, applies CPSV Lemma L on `blockTwo`, and does **not** construct the identity-dressed realization from the BNT algebra clause.
> 
> Lean docstrings and Blueprint text both flag this as assuming the missing CPSV16 Appendix C.4 line 2048 assertion and point to `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`. The MPDO import aggregator picks up the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273d011eceb8397decd9fa44ebec2aebc5fd8853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->