### PR TITLE
feat(MPS/MPDO): normalize conditional sector gauges

### DIFF
--- a/TNLean/Algebra/MatrixGramUnitary.lean
+++ b/TNLean/Algebra/MatrixGramUnitary.lean
@@ -20,6 +20,15 @@ ranges to the ambient finite-dimensional Hilbert space.
 It also applies this extension to an isometric rectangular matrix, realizing
 its compression as a unitary conjugate of the corresponding square matrix
 with one complementary zero block.
+
+The inverse-square-root normalization of a matrix with positive scalar Gram
+matrix is unitary and has the same conjugation action as the original
+invertible matrix.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Proposition 4.13, lines 1903--1908.
 -/
 
 open scoped Matrix InnerProductSpace
@@ -197,5 +206,63 @@ theorem smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one
   rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_smul, hconjs]
   simp only [smul_mul_assoc, mul_smul_comm, smul_smul]
   rw [h, smul_smul, hscalar, one_smul]
+
+/-- Inverse-square-root normalization preserves the conjugation action of an
+invertible matrix whose Gram matrix is a positive scalar multiple of the
+identity.
+
+This is the equality between conjugation by
+$U = \omega^{-1/2}X$ and conjugation by $X$ used after equation
+`eq3:proof.IV.12` in CPSV16, Proposition 4.13, lines 1903--1908.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1903--1908. -/
+theorem normalized_conj_eq_conj_inv_of_gram_eq_smul_one
+    {n : Type*} [Fintype n] [DecidableEq n]
+    (A : Matrix n n ℂ) (X : GL n ℂ) {ω : ℝ} (hω : 0 < ω)
+    (hGram : (X : Matrix n n ℂ)ᴴ * X = (ω : ℂ) • 1) :
+    (((Real.sqrt ω : ℂ))⁻¹ • (X : Matrix n n ℂ)) * A *
+        (((Real.sqrt ω : ℂ))⁻¹ • (X : Matrix n n ℂ))ᴴ =
+      (X : Matrix n n ℂ) * A * (↑(X⁻¹) : Matrix n n ℂ) := by
+  have hs_sq : Real.sqrt ω * Real.sqrt ω = ω :=
+    Real.mul_self_sqrt hω.le
+  have hs_ne : ((Real.sqrt ω : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast (Real.sqrt_pos.mpr hω).ne'
+  have hconjs : star ((Real.sqrt ω : ℂ))⁻¹ =
+      ((Real.sqrt ω : ℂ))⁻¹ := by
+    rw [star_inv₀]
+    congr 1
+    exact Complex.conj_ofReal _
+  have hscalar : ((Real.sqrt ω : ℂ))⁻¹ *
+      ((Real.sqrt ω : ℂ))⁻¹ * (ω : ℂ) = 1 := by
+    rw [show ((ω : ℝ) : ℂ) =
+        (Real.sqrt ω : ℂ) * (Real.sqrt ω : ℂ) by
+      rw [← Complex.ofReal_mul, hs_sq]]
+    field_simp [hs_ne]
+  have hXstar : (X : Matrix n n ℂ)ᴴ =
+      (ω : ℂ) • (↑(X⁻¹) : Matrix n n ℂ) := by
+    have hXinv : (X : Matrix n n ℂ) *
+        (↑(X⁻¹) : Matrix n n ℂ) = 1 := X.val_inv
+    calc
+      (X : Matrix n n ℂ)ᴴ =
+          (X : Matrix n n ℂ)ᴴ *
+            ((X : Matrix n n ℂ) * (↑(X⁻¹) : Matrix n n ℂ)) := by
+              rw [hXinv, Matrix.mul_one]
+      _ = ((X : Matrix n n ℂ)ᴴ * X) *
+          (↑(X⁻¹) : Matrix n n ℂ) := by
+            rw [Matrix.mul_assoc]
+      _ = (ω : ℂ) • (↑(X⁻¹) : Matrix n n ℂ) := by
+            rw [hGram, Matrix.smul_mul, Matrix.one_mul]
+  rw [Matrix.conjTranspose_smul, hconjs, hXstar]
+  simp only [Matrix.smul_mul, Matrix.mul_smul, smul_smul,
+    Matrix.mul_assoc]
+  rw [show ((Real.sqrt ω : ℂ))⁻¹ * (ω : ℂ) *
+      ((Real.sqrt ω : ℂ))⁻¹ = 1 by
+    calc
+      ((Real.sqrt ω : ℂ))⁻¹ * (ω : ℂ) *
+          ((Real.sqrt ω : ℂ))⁻¹ =
+        ((Real.sqrt ω : ℂ))⁻¹ *
+          ((Real.sqrt ω : ℂ))⁻¹ * (ω : ℂ) := by ring
+      _ = 1 := hscalar]
+  simp
 
 end Matrix

--- a/TNLean/Algebra/MatrixGramUnitary.lean
+++ b/TNLean/Algebra/MatrixGramUnitary.lean
@@ -182,6 +182,23 @@ theorem exists_unitary_zero_extension_eq
       simp only [Matrix.mul_assoc]
     _ = _ := by rw [hJAJ]
 
+/-- The scalar identities used when normalizing by the inverse square root of
+a positive real number. -/
+private theorem inv_sqrt_star_eq_and_mul_self_of_pos
+    {ω : ℝ} (hω : 0 < ω) :
+    star ((Real.sqrt ω : ℂ))⁻¹ = ((Real.sqrt ω : ℂ))⁻¹ ∧
+      ((Real.sqrt ω : ℂ))⁻¹ * ((Real.sqrt ω : ℂ))⁻¹ * (ω : ℂ) = 1 := by
+  have hs_ne : ((Real.sqrt ω : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast (Real.sqrt_pos.mpr hω).ne'
+  constructor
+  · rw [star_inv₀]
+    congr 1
+    exact Complex.conj_ofReal _
+  · rw [show ((ω : ℝ) : ℂ) =
+        (Real.sqrt ω : ℂ) * (Real.sqrt ω : ℂ) by
+      rw [← Complex.ofReal_mul, Real.mul_self_sqrt hω.le]]
+    field_simp [hs_ne]
+
 /-- A matrix whose Gram matrix is a positive multiple of the identity becomes
 unitary after dividing by the square root of the multiple.  This is the
 isometric normalization $U_{\alpha,k} = \omega_{\alpha,k}^{-1/2}X_{\alpha,k}$
@@ -191,17 +208,7 @@ theorem smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one
     {X : Matrix n n ℂ} {ω : ℝ} (hω : 0 < ω)
     (h : Xᴴ * X = (ω : ℂ) • 1) :
     ((Real.sqrt ω : ℂ))⁻¹ • X ∈ Matrix.unitaryGroup n ℂ := by
-  have hs_pos : 0 < Real.sqrt ω := Real.sqrt_pos.mpr hω
-  have hs_ne : ((Real.sqrt ω : ℝ) : ℂ) ≠ 0 := by exact_mod_cast hs_pos.ne'
-  have hs_sq : Real.sqrt ω * Real.sqrt ω = ω := Real.mul_self_sqrt hω.le
-  have hconjs : star ((Real.sqrt ω : ℂ))⁻¹ = ((Real.sqrt ω : ℂ))⁻¹ := by
-    rw [star_inv₀]
-    congr 1
-    exact Complex.conj_ofReal _
-  have hscalar : ((Real.sqrt ω : ℂ))⁻¹ * ((Real.sqrt ω : ℂ))⁻¹ * (ω : ℂ) = 1 := by
-    rw [show ((ω : ℝ) : ℂ) = (Real.sqrt ω : ℂ) * (Real.sqrt ω : ℂ) by
-      rw [← Complex.ofReal_mul, hs_sq]]
-    field_simp
+  obtain ⟨hconjs, hscalar⟩ := inv_sqrt_star_eq_and_mul_self_of_pos hω
   refine Matrix.mem_unitaryGroup_iff'.mpr ?_
   rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_smul, hconjs]
   simp only [smul_mul_assoc, mul_smul_comm, smul_smul]
@@ -212,8 +219,8 @@ invertible matrix whose Gram matrix is a positive scalar multiple of the
 identity.
 
 This is the equality between conjugation by
-$U = \omega^{-1/2}X$ and conjugation by $X$ used after equation
-`eq3:proof.IV.12` in CPSV16, Proposition 4.13, lines 1903--1908.
+$U = \omega^{-1/2}X$ and conjugation by $X$ used after equation (IV.12)
+in the proof of CPSV16, Proposition 4.13, lines 1903--1908.
 
 Source: arXiv:1606.00608, Proposition 4.13, lines 1903--1908. -/
 theorem normalized_conj_eq_conj_inv_of_gram_eq_smul_one
@@ -223,21 +230,7 @@ theorem normalized_conj_eq_conj_inv_of_gram_eq_smul_one
     (((Real.sqrt ω : ℂ))⁻¹ • (X : Matrix n n ℂ)) * A *
         (((Real.sqrt ω : ℂ))⁻¹ • (X : Matrix n n ℂ))ᴴ =
       (X : Matrix n n ℂ) * A * (↑(X⁻¹) : Matrix n n ℂ) := by
-  have hs_sq : Real.sqrt ω * Real.sqrt ω = ω :=
-    Real.mul_self_sqrt hω.le
-  have hs_ne : ((Real.sqrt ω : ℝ) : ℂ) ≠ 0 := by
-    exact_mod_cast (Real.sqrt_pos.mpr hω).ne'
-  have hconjs : star ((Real.sqrt ω : ℂ))⁻¹ =
-      ((Real.sqrt ω : ℂ))⁻¹ := by
-    rw [star_inv₀]
-    congr 1
-    exact Complex.conj_ofReal _
-  have hscalar : ((Real.sqrt ω : ℂ))⁻¹ *
-      ((Real.sqrt ω : ℂ))⁻¹ * (ω : ℂ) = 1 := by
-    rw [show ((ω : ℝ) : ℂ) =
-        (Real.sqrt ω : ℂ) * (Real.sqrt ω : ℂ) by
-      rw [← Complex.ofReal_mul, hs_sq]]
-    field_simp [hs_ne]
+  obtain ⟨hconjs, hscalar⟩ := inv_sqrt_star_eq_and_mul_self_of_pos hω
   have hXstar : (X : Matrix n n ℂ)ᴴ =
       (ω : ℂ) • (↑(X⁻¹) : Matrix n n ℂ) := by
     have hXinv : (X : Matrix n n ℂ) *

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -17,6 +17,7 @@ import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalUnitary
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
 import TNLean.MPS.MPDO.BNTAssociativity

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
@@ -21,6 +21,7 @@ the two-site unitary-gauge argument.
 
 ## Main results
 
+* `TwoSiteExactSectorGauge.IdentityMarkedRealization`
 * `TwoSiteExactSectorGauge.gramDressing_gauge_eq_one_of_identityMarkedRealization`
 * `TwoSiteExactSectorGauge.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization`
 
@@ -41,6 +42,57 @@ namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
 
 variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
 
+/-- An identity-dressed marked realization in the physical-letter span, with
+the same reflected target as the gauge-dressed marked chains.
+
+**Scope restriction (conditional identity-dressed marked realization):** This
+structure packages the local realization implicit at CPSV16 Appendix C.4,
+line 2048; it is supplied as data rather than derived from the tensor-attached
+algebra clause.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+structure IdentityMarkedRealization (S : TwoSiteExactSectorGauge H)
+    (γ : Fin H.labelCount) where
+  /-- Coefficients realizing the identity-dressed horizontal slices as
+  physical letters of the two-site blocking.
+
+  Source: arXiv:1606.00608, Appendix C.4, line 2048. -/
+  fId : Fin (S.decomposition.bondDim (S.relabel γ) *
+      S.decomposition.bondDim (S.relabel γ)) →
+    Fin ((d * d) * (d * d)) → ℂ
+  /-- The coefficients realize each identity-dressed open-bond matrix.
+
+  Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and
+  lines 1898--1921, applied at Appendix C.4, line 2048. -/
+  physical : ∀ u,
+    MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
+      horizontalSlice
+        (gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ))) u.divNat u.modNat
+  /-- The identity-dressed marked chains have the reflected-adjoint target
+  used for the gauge-dressed marked chains.
+
+  Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and
+  lines 1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+  target : ∀ (N : ℕ)
+    (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
+    (σ τ : Fin N → Fin (d * d)),
+    markedChainCoefficient
+        (gramDressing
+          (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)))
+        (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
+      markedChainCoefficient
+        (reflectedAdjoint
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)))
+        (adjointTensor (blockTwo M)) r s
+        (List.ofFn σ).reverse (List.ofFn τ).reverse
+
 /-- An identity-dressed physical-letter marked realization with the same
 reflected target as the exact gauge-dressed corner forces the two Gram
 dressings to agree.
@@ -57,30 +109,7 @@ theorem gramDressing_gauge_eq_one_of_identityMarkedRealization
     (S : TwoSiteExactSectorGauge H)
     (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M) (γ : Fin H.labelCount)
-    (fId : Fin (S.decomposition.bondDim (S.relabel γ) *
-        S.decomposition.bondDim (S.relabel γ)) →
-      Fin ((d * d) * (d * d)) → ℂ)
-    (hPhysical : ∀ u,
-      MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
-        horizontalSlice
-          (gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ))) u.divNat u.modNat)
-    (hTarget : ∀ (N : ℕ)
-      (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
-      (σ τ : Fin N → Fin (d * d)),
-      markedChainCoefficient
-          (gramDressing
-            (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ)))
-          (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
-        markedChainCoefficient
-          (reflectedAdjoint
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ)))
-          (adjointTensor (blockTwo M)) r s
-          (List.ofFn σ).reverse (List.ofFn τ).reverse) :
+    (R : IdentityMarkedRealization S γ) :
     gramDressing (S.gauge γ)
         (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ)) =
       gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
@@ -96,7 +125,7 @@ theorem gramDressing_gauge_eq_one_of_identityMarkedRealization
           (MPSTensor.linearMarkedTensor fGauge (blockTwo M).toMPSTensor u *
             MPSTensor.evalWord (blockTwo M).toMPSTensor (List.ofFn w)) =
         Matrix.trace
-          (MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u *
+          (MPSTensor.linearMarkedTensor R.fId (blockTwo M).toMPSTensor u *
             MPSTensor.evalWord (blockTwo M).toMPSTensor (List.ofFn w)) := by
     intro L u w
     rw [show MPSTensor.linearMarkedTensor fGauge (blockTwo M).toMPSTensor u =
@@ -107,18 +136,18 @@ theorem gramDressing_gauge_eq_one_of_identityMarkedRealization
       exact linearMarkedTensor_cornerGramCoefficients
         (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ))
         V (S.gauge γ) c hc hCorner u]
-    rw [hPhysical u]
+    rw [R.physical u]
     rw [evalWord_toMPSTensor_ofFn]
     exact
       (S.markedChainCoefficient_gauge_eq_reflectedAdjoint hM γ L
         u.divNat u.modNat (fun k ↦ (w k).divNat) (fun k ↦ (w k).modNat)).trans
-      (hTarget L u.divNat u.modNat
+      (R.target L u.divNat u.modNat
         (fun k ↦ (w k).divNat) (fun k ↦ (w k).modNat)).symm
   have hMarks :
       MPSTensor.linearMarkedTensor fGauge (blockTwo M).toMPSTensor =
-        MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor :=
+        MPSTensor.linearMarkedTensor R.fId (blockTwo M).toMPSTensor :=
     (IsCPSVCanonicalForm_toMPSTensor_blockTwo hCanonical).linearMarkedTensor_eq_of_trace_agree
-      (blockTwo M).toMPSTensor fGauge fId hTrace
+      (blockTwo M).toMPSTensor fGauge R.fId hTrace
   funext v
   obtain ⟨⟨a, b⟩, rfl⟩ := finProdFinEquiv.surjective v
   ext r s
@@ -133,7 +162,7 @@ theorem gramDressing_gauge_eq_one_of_identityMarkedRealization
     exact linearMarkedTensor_cornerGramCoefficients
       (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ))
       V (S.gauge γ) c hc hCorner (finProdFinEquiv (r, s)),
-    hPhysical] at hSlice
+    R.physical] at hSlice
   simpa only [horizontalSlice, MPSTensor.finProdFinEquiv_divNat,
     MPSTensor.finProdFinEquiv_modNat] using congrFun (congrFun hSlice a) b
 
@@ -153,36 +182,13 @@ theorem gauge_gram_eq_pos_smul_one_of_identityMarkedRealization
     (S : TwoSiteExactSectorGauge H)
     (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M) (γ : Fin H.labelCount)
-    (fId : Fin (S.decomposition.bondDim (S.relabel γ) *
-        S.decomposition.bondDim (S.relabel γ)) →
-      Fin ((d * d) * (d * d)) → ℂ)
-    (hPhysical : ∀ u,
-      MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
-        horizontalSlice
-          (gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ))) u.divNat u.modNat)
-    (hTarget : ∀ (N : ℕ)
-      (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
-      (σ τ : Fin N → Fin (d * d)),
-      markedChainCoefficient
-          (gramDressing
-            (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ)))
-          (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
-        markedChainCoefficient
-          (reflectedAdjoint
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ)))
-          (adjointTensor (blockTwo M)) r s
-          (List.ofFn σ).reverse (List.ofFn τ).reverse) :
+    (R : IdentityMarkedRealization S γ) :
     ∃ ω : ℝ, 0 < ω ∧
       (S.gauge γ : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
           (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ * S.gauge γ =
         (ω : ℂ) • 1 := by
   have hDress := S.gramDressing_gauge_eq_one_of_identityMarkedRealization
-    hCanonical hM γ fId hPhysical hTarget
+    hCanonical hM γ R
   have hNormalTensor : MPSTensor.IsNormalTensor
       (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ)) :=
     (MPSTensor.isNormalTensor_cast_iff (S.bondDim_eq γ) (H.tensor γ)).2

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalUnitary.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalUnitary.lean
@@ -90,30 +90,7 @@ theorem exists_unitary_sector_conjugacy_of_identityMarkedRealization
     (S : TwoSiteExactSectorGauge H)
     (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
     (hM : IsMPDO M) (γ : Fin H.labelCount)
-    (fId : Fin (S.decomposition.bondDim (S.relabel γ) *
-        S.decomposition.bondDim (S.relabel γ)) →
-      Fin ((d * d) * (d * d)) → ℂ)
-    (hPhysical : ∀ u,
-      MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
-        horizontalSlice
-          (gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ))) u.divNat u.modNat)
-    (hTarget : ∀ (N : ℕ)
-      (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
-      (σ τ : Fin N → Fin (d * d)),
-      markedChainCoefficient
-          (gramDressing
-            (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ)))
-          (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
-        markedChainCoefficient
-          (reflectedAdjoint
-            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-              (H.tensor γ)))
-          (adjointTensor (blockTwo M)) r s
-          (List.ofFn σ).reverse (List.ofFn τ).reverse) :
+    (R : IdentityMarkedRealization S γ) :
     ∃ U : Matrix.unitaryGroup
         (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ,
       ∀ i : Fin (D * D),
@@ -126,7 +103,7 @@ theorem exists_unitary_sector_conjugacy_of_identityMarkedRealization
             (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ := by
   obtain ⟨ω, hω, hGram⟩ :=
     S.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization
-      hCanonical hM γ fId hPhysical hTarget
+      hCanonical hM γ R
   exact S.exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one
     γ ω hω hGram
 

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalUnitary.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalUnitary.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram
+
+/-!
+# Conditional unitary conjugacy for exact two-site sectors
+
+An exact invertible sector gauge whose Gram matrix is a positive scalar
+multiple of the identity can be normalized to a unitary matrix without
+changing its conjugation action.  Composing this normalization with the
+conditional Gram identity gives unitary conjugacy under an identity-dressed
+marked realization.
+
+The marked realization is assumed here, not constructed from the BNT algebra
+clause.  Thus the final theorem is conditional and does not establish the
+unconditional conclusion of Appendix C.4.
+
+## Main results
+
+* `TwoSiteExactSectorGauge.exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one`
+* `TwoSiteExactSectorGauge.exists_unitary_sector_conjugacy_of_identityMarkedRealization`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, lines 1903--1908, and Appendix C.4, lines 2053--2057
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- A positive scalar Gram identity normalizes an exact sector gauge to a
+unitary matrix with the same conjugation action.
+
+Source: arXiv:1606.00608, Proposition 4.13, lines 1903--1908, applied at
+Appendix C.4, lines 2053--2057. -/
+theorem exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one
+    (S : TwoSiteExactSectorGauge H) (γ : Fin H.labelCount)
+    (ω : ℝ) (hω : 0 < ω)
+    (hGram :
+      (S.gauge γ : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ * S.gauge γ =
+        (ω : ℂ) • 1) :
+    ∃ U : Matrix.unitaryGroup
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ,
+      ∀ i : Fin (D * D),
+        S.decomposition.tensor (S.relabel γ) i =
+          (U : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)) i *
+          (U : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ := by
+  let U : Matrix.unitaryGroup
+      (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ :=
+    ⟨((Real.sqrt ω : ℂ))⁻¹ •
+        (S.gauge γ : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ),
+      Matrix.smul_mem_unitaryGroup_of_conjTranspose_mul_self_eq_smul_one
+        hω hGram⟩
+  refine ⟨U, fun i ↦ ?_⟩
+  rw [S.tensor_eq γ i]
+  simpa [U] using
+    (Matrix.normalized_conj_eq_conj_inv_of_gram_eq_smul_one
+      ((cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+        (H.tensor γ)) i) (S.gauge γ) hω hGram).symm
+
+/-- Under the conditional identity-dressed marked realization, every exact
+two-site sector is unitarily conjugate to its matched one-site tensor.
+
+**Scope restriction (conditional identity-dressed marked realization):** The
+theorem assumes the physical-letter realization implicit at CPSV16 Appendix
+C.4, line 2048; it is not derived from the algebra clause and does not establish
+the unconditional line-2057 conclusion.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, lines 1903--1908,
+applied at Appendix C.4, lines 2048--2057. -/
+theorem exists_unitary_sector_conjugacy_of_identityMarkedRealization
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (γ : Fin H.labelCount)
+    (fId : Fin (S.decomposition.bondDim (S.relabel γ) *
+        S.decomposition.bondDim (S.relabel γ)) →
+      Fin ((d * d) * (d * d)) → ℂ)
+    (hPhysical : ∀ u,
+      MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
+        horizontalSlice
+          (gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ))) u.divNat u.modNat)
+    (hTarget : ∀ (N : ℕ)
+      (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
+      (σ τ : Fin N → Fin (d * d)),
+      markedChainCoefficient
+          (gramDressing
+            (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)))
+          (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
+        markedChainCoefficient
+          (reflectedAdjoint
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)))
+          (adjointTensor (blockTwo M)) r s
+          (List.ofFn σ).reverse (List.ofFn τ).reverse) :
+    ∃ U : Matrix.unitaryGroup
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ,
+      ∀ i : Fin (D * D),
+        S.decomposition.tensor (S.relabel γ) i =
+          (U : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)) i *
+          (U : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ := by
+  obtain ⟨ω, hω, hGram⟩ :=
+    S.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization
+      hCanonical hM γ fId hPhysical hTarget
+  exact S.exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one
+    γ ω hω hGram
+
+end BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean
@@ -88,8 +88,9 @@ conjugacies between its paired normal tensors.
 invertible conjugacy from Appendix C.4, but not the line-2057 conclusion that the
 gauge may be chosen unitary.  The missing common-target normalization contract is
 documented in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` and
-tracked in issue 4648.  The subsequent scalar-to-unitary normalization is
-tracked in issue 4645.
+tracked in issues 5284 and 4648.  The Gram identity and scalar-to-unitary
+normalization are available conditionally on a supplied identity-dressed
+marked realization, but issue 4645 remains open at the unconditional level.
 
 Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057 of
 `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/
@@ -155,8 +156,9 @@ independence derives the power-sum equality.
 equality and phase-one invertible conjugacy, but does not prove the line-2057
 unitary upgrade.  The missing common-target normalization contract is documented
 in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex` and tracked in
-issue 4648.  The subsequent scalar-to-unitary normalization is tracked in issue
-4645.
+issues 5284 and 4648.  The Gram identity and scalar-to-unitary normalization are
+available conditionally on a supplied identity-dressed marked realization, but
+issue 4645 remains open at the unconditional level.
 
 Source: arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2058
 of `Papers/1606.00608/MPDO-22-12-17-2.tex`. -/

--- a/TNLean/MPS/MPDO/NormalizedGroupedSectorMaps.lean
+++ b/TNLean/MPS/MPDO/NormalizedGroupedSectorMaps.lean
@@ -120,56 +120,6 @@ private theorem normalized_gauge_intertwining
   simp only [Matrix.mul_one, smul_smul]
   rw [mul_comm (((Real.sqrt omega : ℂ))⁻¹) c]
 
-private theorem normalized_gauge_corner
-    (A : Matrix (Fin n) (Fin n) ℂ) (X : GL (Fin n) ℂ)
-    (c : ℂ) (omega : ℝ) (homega : 0 < omega)
-    (hGram : (X : Matrix (Fin n) (Fin n) ℂ)ᴴ * X = (omega : ℂ) • 1) :
-    (((Real.sqrt omega : ℂ))⁻¹ •
-          (X : Matrix (Fin n) (Fin n) ℂ)) * (c • A) *
-        (((Real.sqrt omega : ℂ))⁻¹ •
-          (X : Matrix (Fin n) (Fin n) ℂ))ᴴ =
-      c • ((X : Matrix (Fin n) (Fin n) ℂ) * A *
-        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) := by
-  have hs_sq : Real.sqrt omega * Real.sqrt omega = omega :=
-    Real.mul_self_sqrt homega.le
-  have hconjs : star ((Real.sqrt omega : ℂ))⁻¹ =
-      ((Real.sqrt omega : ℂ))⁻¹ := by
-    rw [star_inv₀]
-    congr 1
-    exact Complex.conj_ofReal _
-  have hscalar : ((Real.sqrt omega : ℂ))⁻¹ *
-      ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ) = 1 := by
-    rw [show ((omega : ℝ) : ℂ) =
-        (Real.sqrt omega : ℂ) * (Real.sqrt omega : ℂ) by
-      rw [← Complex.ofReal_mul, hs_sq]]
-    field_simp
-  have hXstar : (X : Matrix (Fin n) (Fin n) ℂ)ᴴ =
-      (omega : ℂ) • (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) := by
-    have hXinv : (X : Matrix (Fin n) (Fin n) ℂ) *
-        (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) = 1 := by
-      exact X.val_inv
-    calc
-      (X : Matrix (Fin n) (Fin n) ℂ)ᴴ =
-          (X : Matrix (Fin n) (Fin n) ℂ)ᴴ *
-            ((X : Matrix (Fin n) (Fin n) ℂ) *
-              (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ)) := by
-                rw [hXinv, Matrix.mul_one]
-      _ = ((X : Matrix (Fin n) (Fin n) ℂ)ᴴ * X) *
-          (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) := by
-            rw [Matrix.mul_assoc]
-      _ = (omega : ℂ) • (↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ) := by
-            rw [hGram, Matrix.smul_mul, Matrix.one_mul]
-  rw [Matrix.conjTranspose_smul, hconjs, hXstar]
-  simp only [Matrix.smul_mul, Matrix.mul_smul, smul_smul, Matrix.mul_assoc]
-  rw [show ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ) *
-      (c * ((Real.sqrt omega : ℂ))⁻¹) = c by
-    calc
-      ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ) *
-          (c * ((Real.sqrt omega : ℂ))⁻¹) =
-        c * (((Real.sqrt omega : ℂ))⁻¹ *
-          ((Real.sqrt omega : ℂ))⁻¹ * (omega : ℂ)) := by ring
-      _ = c := by rw [hscalar, mul_one]]
-
 /-- The normalized sector map intertwines with the ungauged representative
 tensor.
 
@@ -214,7 +164,9 @@ theorem normalizedGroupedSectorMap_corner (h : m = n)
             simp only [Matrix.mul_assoc]
     _ = V * (c • ((X : Matrix (Fin m) (Fin m) ℂ) * A *
         (↑(X⁻¹) : Matrix (Fin m) (Fin m) ℂ))) * Vᴴ := by
-          rw [normalized_gauge_corner A X c omega homega hGram]
+          rw [Matrix.normalized_conj_eq_conj_inv_of_gram_eq_smul_one
+            (c • A) X homega hGram]
+          simp only [Matrix.mul_smul, Matrix.smul_mul]
 
 end LinearAlgebra
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -137,8 +137,10 @@
     \cite[Appendix~C.4, lines~2053--2057]{Cirac2016MPDO_arXiv}.
     It does not include the further conclusion on line~2057 that $Z_\gamma$
     may be chosen unitary.
-    % The line-2057 common-target Gram step is tracked in issue 4648; the
-    % subsequent scalar-to-unitary normalization is tracked in issue 4645 and
+    % Pull request 5282 proves the common-target Gram step conditionally, and issue
+    % 5283 proves the ensuing scalar-to-unitary normalization.  Issue 5284,
+    % under issue 4648, tracks the missing identity-dressed realization;
+    % issue 4645 therefore remains open.  See
     % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{definition}
 
@@ -189,8 +191,10 @@
     lines~2053--2057; no unitary choice of $Z_\gamma$ follows from this
     statement.
 
-    % The line-2057 common-target Gram step is tracked in issue 4648; the
-    % subsequent scalar-to-unitary normalization is tracked in issue 4645 and
+    % Pull request 5282 proves the common-target Gram step conditionally, and issue
+    % 5283 proves the ensuing scalar-to-unitary normalization.  Issue 5284,
+    % under issue 4648, tracks the missing identity-dressed realization;
+    % issue 4645 therefore remains open.  See
     % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
 \end{theorem}
 
@@ -265,8 +269,9 @@
     \end{align}
     This restriction is documented in
     \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
-    % The missing identity-dressed corner and common-target Gram identity are
-    % tracked in issue 4648.
+    % Pull request 5282 proves the common-target Gram identity from a supplied
+    % identity-dressed realization.  Constructing that realization from the
+    % tensor-attached algebra clause is tracked in issue 5284 under issue 4648.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -337,6 +342,58 @@
     $M_\gamma$ then makes its commuting Gram matrix a positive real scalar
     multiple of the identity, proving
     (\ref{eq:mpdo_bnt_conditional_scalar_gram}).
+\end{proof}
+
+\begin{theorem}[Conditional unitary conjugacy from an identity-dressed marked
+    realization]
+    \label{thm:mpdo_bnt_conditional_identity_marked_unitary_conjugacy}
+    \lean{Matrix.normalized_conj_eq_conj_inv_of_gram_eq_smul_one}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        exists_unitary_sector_conjugacy_of_identityMarkedRealization}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form,
+        def:mpdo_bnt_two_site_exact_sector_gauge}
+    Under the hypotheses of the preceding conditional theorem, define
+    \begin{align}
+        U_\gamma&=\omega_\gamma^{-1/2}Z_\gamma.
+        \notag
+    \end{align}
+    Then $U_\gamma$ is unitary and, for every physical index $i$,
+    \begin{align}
+        A_{\sigma(\gamma)}^i
+        &=U_\gamma M_\gamma^i U_\gamma^\dagger.
+        \label{eq:mpdo_bnt_conditional_unitary_conjugacy}
+    \end{align}
+    More generally, the same conclusion follows from any exact invertible
+    sector gauge whose Gram matrix is a positive scalar multiple of the
+    identity.  This is the inverse-square-root normalization used in
+    \cite[Proposition~4.13, lines~1903--1908]{Cirac2016MPDO_arXiv}, applied
+    at Appendix~C.4, lines~2053--2057.
+
+    \textbf{Scope restriction (conditional identity-dressed marked
+    realization):} The physical-letter realization at Appendix~C.4,
+    line~2048 remains an assumption.  Hence this theorem does not establish
+    the unconditional line-2057 conclusion.  Its derivation from the
+    tensor-attached algebra clause is the remaining premise recorded in
+    \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+    % Pull request 5282 is the conditional Gram endpoint, and issue 5283 composes it
+    % with scalar-to-unitary normalization.  Issue 5284, under issue 4648,
+    % tracks the missing premise; issue 4645 remains open.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_bnt_conditional_identity_marked_gram}
+    The preceding theorem gives
+    $Z_\gamma^\dagger Z_\gamma=\omega_\gamma\Id$ with
+    $\omega_\gamma>0$.  Therefore
+    $U_\gamma^\dagger U_\gamma=\Id$.  The two scalar factors introduced by
+    $U_\gamma$ and $U_\gamma^\dagger$ cancel, using the Gram identity to
+    identify the adjoint factor with $Z_\gamma^{-1}$.  Thus conjugation by
+    $U_\gamma$ equals conjugation by $Z_\gamma$, and the exact sector
+    conjugacy gives
+    (\ref{eq:mpdo_bnt_conditional_unitary_conjugacy}).
 \end{proof}
 
 \begin{lemma}[Idempotence for the canonical chi coefficients]%

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -34,13 +34,24 @@ at lines~2053--2056.  Line~2057 then invokes the result labelled
 
 \section{Formal boundary}
 
-The current two-site comparison retains equality of the matched bond
+The unconditional two-site comparison retains equality of the matched bond
 dimensions and the invertible matrix $Z_\gamma$ in
 \eqref{eq:gauge-phase}.  Positivity of the coefficients at two consecutive
 lengths proves $e^{i\theta_\gamma}=1$, so the resulting conjugacy is exact.
 This proves the invertible-gauge sub-result of lines~2053--2057.
 
-It does not yet prove the second part of \eqref{eq:unitary-upgrade}.
+Pull request~5282 proves the Gram identity
+\eqref{eq:gram-dressing-target}, and hence
+$Z_\gamma^\dagger Z_\gamma=\omega_\gamma\mathbf 1$ with
+$\omega_\gamma>0$, from a supplied identity-dressed marked realization.
+The inverse-square-root normalization
+$U_\gamma=\omega_\gamma^{-1/2}Z_\gamma$ is now formalized: it is unitary and
+has exactly the same conjugation action as $Z_\gamma$.  Thus the entire
+line~2057 conclusion is available conditionally on that supplied
+realization.
+
+This does not yet prove the second part of \eqref{eq:unitary-upgrade} from the
+tensor-attached algebra clause alone.
 The result labelled \path{Prop:IV.12} obtains unitary representatives by
 comparing every copy of a normal tensor with a common canonical target and
 proving proportionality of the corresponding Gram matrices.  The present
@@ -363,20 +374,38 @@ Equivalently, for every vertical letter $v$,
 \]
 Normality then implies \eqref{eq:gram-scalar}.
 
-The subsequent rescaling of $X_\gamma$ to a unitary gauge belongs to
-\href{https://github.com/LionSR/TNLean/issues/4645}{issue 4645}.  Until
-\eqref{eq:gram-dressing-target} has been proved without condition~(iii), the
-formal declaration and its blueprint entry remain restricted to phase-one
-invertible conjugacy.  Issues 4648 and 4645 remain open, and the full
-line~2057 unitary conclusion remains unformalized.
+Pull request~5282 establishes \eqref{eq:gram-dressing-target} conditionally on a
+supplied identity-dressed physical-letter coefficient family and its common
+reflected target.  From its positive scalar Gram conclusion, the present
+normalization result constructs
+\[
+  U_\gamma=\omega_\gamma^{-1/2}X_\gamma,
+  \qquad
+  A_{\sigma(\gamma)}^v
+  =U_\gamma A_\gamma^vU_\gamma^\dagger.
+\]
+This is the conditional endpoint of the scalar-to-unitary argument; it does
+not assert that the stored invertible gauge $X_\gamma$ itself is unitary.
+
+The remaining premise is to construct the coefficient family and the two
+target identities used by pull request~5282 directly from the tensor-attached
+algebra clause, literal CPSV canonical form, and the MPDO hypothesis.  This is
+tracked in \href{https://github.com/LionSR/TNLean/issues/5284}{issue 5284},
+under \href{https://github.com/LionSR/TNLean/issues/4648}{issue 4648}, without
+assuming a raw corner, a Gram identity, a unitary gauge, fusion data, or a
+renormalization fixed point.  Consequently issues 4648 and
+\href{https://github.com/LionSR/TNLean/issues/4645}{4645} remain open, and the
+unconditional line~2057 unitary conclusion remains unformalized.
 
 \section{Verdict}
 
-\textbf{Verdict: open gap.}  The Gram-dressing identity
-\eqref{eq:gram-dressing-target} has not been derived from condition~(ii)
-alone.  Appendix~C.4 therefore does not presently justify the line~2057
-unitary conclusion without the additional local map supplied by
-condition~(iii).
+\textbf{Verdict: open premise, conditional endpoint complete.}  The
+Gram-dressing identity \eqref{eq:gram-dressing-target} and the subsequent
+unitary normalization are formalized under the supplied identity-dressed
+marked realization.  That realization has not been derived from
+condition~(ii) alone.  Appendix~C.4 therefore does not presently justify the
+unconditional line~2057 unitary conclusion without a separately supplied
+local marked realization.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -399,7 +399,8 @@ unconditional line~2057 unitary conclusion remains unformalized.
 
 \section{Verdict}
 
-\textbf{Verdict: open premise, conditional endpoint complete.}  The
+\textbf{Scope restriction: the conditional endpoint is complete, while the
+unconditional premise remains open.}  The
 Gram-dressing identity \eqref{eq:gram-dressing-target} and the subsequent
 unitary normalization are formalized under the supplied identity-dressed
 marked realization.  That realization has not been derived from


### PR DESCRIPTION
## Summary

- add a reusable matrix lemma showing that inverse-square-root normalization preserves conjugation by an invertible matrix with positive scalar Gram matrix
- refactor the existing normalized grouped-sector corner proof to use that lemma and the established unitary-membership theorem
- construct a bundled exact unitary conjugacy from a supplied positive scalar sector Gram identity
- compose pull request #5282 to obtain the same conclusion under its explicit identity-dressed marked-realization hypotheses
- add the corresponding Blueprint theorem and update the scope discussion in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`

## Mathematical scope

The new endpoint is conditional. It normalizes the exact invertible sector gauge after the positive scalar Gram identity is supplied; it does not assert that the stored gauge itself is unitary. Constructing the identity-dressed marked realization from the tensor-attached algebra clause remains the missing premise tracked by #5284 under #4648. Hence #4645 and #4648 remain open.

Source: CPSV16, Proposition 4.13, lines 1903–1908, applied at Appendix C.4, lines 2053–2057.

## Validation

- `lake env lean TNLean/Algebra/MatrixGramUnitary.lean`
- `lake env lean TNLean/MPS/MPDO/NormalizedGroupedSectorMaps.lean`
- `lake env lean TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalUnitary.lean`
- `lake env lean TNLean/MPS/MPDO/BNTAlgebraTensorClauseSpectrum.lean`
- `python3 scripts/tactic_pattern_scan.py`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `lake build` (9,874 jobs)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci --diff-base origin/main`
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`
- visual inspection of PDF pages 723–724
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Closes #5283
Addresses #4645

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean proofs and documentation only; no runtime, auth, or data-path changes. Scope remains explicitly conditional on assumed marked realizations.
> 
> **Overview**
> Adds reusable matrix algebra for **inverse-square-root normalization** of invertible gauges with positive scalar Gram matrices: a shared helper for √ω identities, refactored unitary-membership proof, and **`normalized_conj_eq_conj_inv_of_gram_eq_smul_one`** showing ω⁻¹/²X conjugates like X.
> 
> **MPDO:** Introduces **`IdentityMarkedRealization`** and refactors conditional Gram theorems to take that bundle; new **`BNTAlgebraTensorClauseConditionalUnitary`** proves unitary sector conjugacy from a positive scalar Gram identity (composing with PR #5282’s conditional Gram step). **`NormalizedGroupedSectorMaps`** drops duplicated local proof in favor of the shared lemma.
> 
> Blueprint gains a conditional unitary-conjugacy theorem; spectrum docstrings and **`cpsv16_two_site_sector_unitary_gauge_gap.tex`** now state the line-2057 unitary conclusion is **conditional** on a supplied identity-dressed realization (issue 5284 / 4648 still open).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d834d4aabd08cd15a36b67f5af07c465bb87db1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->