### PR TITLE
feat(MPS/MPDO): reduce marked realization to a two-sided realization

### DIFF
--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
@@ -139,12 +139,12 @@ noncomputable def IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealiza
     fId := cornerGramCoefficients V X c
     physical := fun u ↦
       linearMarkedTensor_cornerGramCoefficients
-      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-        (H.tensor γ)) V X c hc hcornerOne u
+        (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+          (H.tensor γ)) V X c hc hcornerOne u
     target := fun N _hN r s σ τ ↦
       hBlock.markedChainCoefficient_gramDressing_eq_reflectedAdjoint
-      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-        (H.tensor γ)) V X c hc hcornerOne N r s σ τ }
+        (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+          (H.tensor γ)) V X c hc hcornerOne N r s σ τ }
 
 /-- An identity-dressed physical-letter marked realization with the same
 reflected target as the exact gauge-dressed corner at every positive tail

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
@@ -15,13 +15,16 @@ same reflected target as the gauge-dressed corner, determines the Gram
 conjugation of an exact two-site sector gauge.  Normality then makes the gauge
 Gram matrix a positive scalar multiple of the identity.
 
-The identity-dressed realization is assumed here, not constructed.  Thus these
-results isolate the remaining implication in Appendix C.4 and do not complete
-the two-site unitary-gauge argument.
+The identity-dressed realization remains conditional.  A constructor reduces
+it to a positive-coefficient two-sided physical realization, but does not
+derive that realization from the BNT algebra clause.  Thus these results
+isolate the remaining implication in Appendix C.4 and do not complete the
+two-site unitary-gauge argument.
 
 ## Main results
 
 * `TwoSiteExactSectorGauge.IdentityMarkedRealization`
+* `TwoSiteExactSectorGauge.IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealization`
 * `TwoSiteExactSectorGauge.gramDressing_gauge_eq_one_of_identityMarkedRealization`
 * `TwoSiteExactSectorGauge.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization`
 
@@ -92,6 +95,56 @@ structure IdentityMarkedRealization (S : TwoSiteExactSectorGauge H)
             (H.tensor γ)))
         (adjointTensor (blockTwo M)) r s
         (List.ofFn σ).reverse (List.ofFn τ).reverse
+
+/-- A positive-coefficient two-sided physical realization of the algebra-side
+representative gives an identity-dressed marked realization.
+
+No isometry condition on `V` is needed.  The physical-letter expansion uses
+the positive coefficient and the two-sided realization equation; the reflected
+marked-chain identity additionally uses MPDO positivity of the blocked tensor.
+
+**Scope restriction (conditional physical realization):** The two-sided
+realization is supplied as a hypothesis rather than derived from the
+tensor-attached algebra clause.  Its unconditional construction is one possible
+local identification for completing Appendix C.4; see
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+noncomputable def IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealization
+    (S : TwoSiteExactSectorGauge H) (hBlock : IsMPDO (blockTwo M))
+    (γ : Fin H.labelCount)
+    (V : Matrix (Fin (d * d))
+      (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+    (c : ℂ) (hc : (0 : ℂ) < c)
+    (hcorner : ∀ v : Fin (D * D),
+      Vᴴ * verticalTensor (blockTwo M) v * V =
+        c • (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+          (H.tensor γ)) v) :
+    IdentityMarkedRealization S γ := by
+  let X : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ := 1
+  have hcornerOne : ∀ v : Fin (D * D),
+      Vᴴ * verticalTensor (blockTwo M) v * V =
+        c • ((X : Matrix
+          (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)) v *
+          (↑(X⁻¹) : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)) := by
+    intro v
+    simpa [X] using hcorner v
+  refine {
+    fId := cornerGramCoefficients V X c
+    physical := fun u ↦
+      linearMarkedTensor_cornerGramCoefficients
+      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+        (H.tensor γ)) V X c hc hcornerOne u
+    target := fun N _hN r s σ τ ↦
+      hBlock.markedChainCoefficient_gramDressing_eq_reflectedAdjoint
+      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+        (H.tensor γ)) V X c hc hcornerOne N r s σ τ }
 
 /-- An identity-dressed physical-letter marked realization with the same
 reflected target as the exact gauge-dressed corner at every positive tail

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -51,6 +51,38 @@ line~2057 conclusion is available conditionally on that supplied
 realization.
 % The conditional Gram and unitary results are pull requests 5282 and 5286.
 
+One direct sufficient datum is weaker than the full marked realization.  Let
+$V$ be any matrix and let $c>0$ satisfy the positive-coefficient two-sided
+physical realization
+\begin{equation}
+  V^\dagger\widetilde M_{[2]}^vV=cM_\gamma^v
+  \label{eq:positive-coefficient-realization}
+\end{equation}
+for every vertical letter $v$.  The physical-letter expansion of the marked
+matrix uses \eqref{eq:positive-coefficient-realization}, while MPDO reflection identifies
+the resulting marked chain with the common target.  Neither step requires
+$V^\dagger V=\mathbf 1$.  This reduction is formalized by a conditional
+constructor.\footnote{Formal declaration:
+\leanid{IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealization}.}
+It gives a concrete sufficient local premise without adding orthogonality,
+reconstruction, or normalization assumptions.
+
+There is an independent sufficient route which need not pass through
+\eqref{eq:positive-coefficient-realization}.  The invertible similarity determines an
+algebra automorphism of the virtual matrix algebra.  If this automorphism is a
+positive map, then it preserves adjoints and hence is a star automorphism.
+Unitary Skolem--Noether then gives a unitary implementer.  Positivity of this
+virtual algebra map is therefore another possible target for completing the
+argument; it has not been derived from the tensor-attached algebra clause.
+
+Positivity of the virtual algebra map must not be confused with positivity of
+the closed sector operators.  A nonunitary similarity preserves every closed
+chain, and therefore transports an all-length positive closed family to the
+same positive family, while its virtual algebra automorphism need not be
+positive.  The bond-two singleton examples below exhibit precisely this
+distinction.  Thus closed sector MPDO positivity alone does not supply either
+of the sufficient local premises just described.
+
 The structure
 \path{BNTAlgebraTensorClause.TwoSiteExactSectorGauge.IdentityMarkedRealization}
 requires the common-target identity only at positive tail lengths.  More
@@ -65,13 +97,15 @@ representatives.
 
 This does not yet prove the second part of \eqref{eq:unitary-upgrade} from the
 tensor-attached algebra clause alone.
-The result labelled \path{Prop:IV.12} obtains unitary representatives by
-comparing every copy of a normal tensor with a common canonical target and
-proving proportionality of the corresponding Gram matrices.  The present
+The result labelled \path{Prop:IV.12} first compares two actual physical
+copies of a common normal representative and proves proportionality of their
+Gram matrices.  Only afterwards does the source choose the first copy to have
+identity gauge.  The present
 one-site and two-site decompositions are constructed independently.  The
 available normal-tensor matching theorem therefore supplies an invertible
-conjugacy, but no common target or Gram-normalization contract from which that
-particular conjugacy can be rescaled to a unitary one.
+conjugacy, but no second positive-coefficient physical realization of the form
+\eqref{eq:positive-coefficient-realization} with which the existing two-site corner can
+be compared.
 
 The missing step occurs immediately before the comparison.  At line~2048 the
 source writes the algebra-side positive direct sum and the independently
@@ -90,9 +124,10 @@ but it does not provide the geometric premise of the comparison.
 Appendix~C.4, lines~2048--2051, gives equality of positive-length closed
 chains for two independently chosen vertical canonical forms.
 Lines~2053--2057 then give an invertible similarity and invoke
-Proposition~4.13.  None of these lines constructs the common identity-gauge
-isometric corner whose open-bond compression would yield the identity-dressed
-marked family.
+Proposition~4.13.  None of these lines constructs a positive-coefficient
+two-sided physical realization whose open-bond matrices would yield the
+identity-dressed marked family.  An identity-gauge isometric corner would be a
+stronger sufficient datum, but is not needed by the marked-chain argument.
 
 \section{The circular corner construction}
 


### PR DESCRIPTION
## Summary

- construct `IdentityMarkedRealization` from a positive-coefficient two-sided physical realization of the prescribed algebra-side representative;
- assume only MPDO positivity of the blocked tensor, a positive scalar coefficient, and the two-sided realization equation;
- require no isometry, orthogonality, reconstruction, Gram, unitary, fusion, or renormalization hypothesis;
- correct the paper-gap account of Proposition 4.13: it compares two actual physical copies before choosing the first gauge to be the identity.

## Mathematical boundary

For a matched sector, the new constructor assumes

```text
c > 0,
Vᴴ · verticalTensor (blockTwo M) v · V = c · M_γ(v).
```

The existing corner-coefficient formula gives the physical marked matrix, and blocked MPDO reflection gives its common target. The condition `Vᴴ V = 1` is not used.

This is a conditional reduction, not the unconditional conclusion of Appendix C.4. Constructing this physical realization from the tensor-attached algebra clause remains #5284. The gap note also records the independent possible route through positivity of the induced virtual algebra automorphism and distinguishes that from positivity of closed sector operators.

## Verification

- `lake build TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram`
- full `lake build` (9878 jobs) before the review-driven signature minimization; the changed target recompiles afterward
- Blueprint–Lean synchronization check
- reader-facing prose check
- forbidden Lean token check
- `git diff --check`
- the affected paper-gap PDF builds successfully; pages 1–2 were visually inspected

Closes #5298.
Related: #5284, #4648, #4645, #3949.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are conditional constructors and documentation around an already-scoped MPS/MPDO proof boundary; no auth, data, or runtime behavior is affected.
> 
> **Overview**
> Adds **`IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealization`**, which builds an identity-dressed marked realization from **MPDO positivity of `blockTwo M`**, a **positive scalar** `c`, and the two-sided equation `Vᴴ · verticalTensor(blockTwo M) v · V = c · M_γ(v)`—**without** requiring `V` to be an isometry.
> 
> Module commentary now states that this is only a **conditional** reduction; deriving the two-sided realization from the BNT tensor clause is still open.
> 
> The **paper-gap note** documents the weaker sufficient premise (eq. positive-coefficient realization), an alternate completion route via **positivity of the virtual algebra automorphism** (vs. closed-sector MPDO positivity), and revises the **Prop. IV.12** story: the source compares two physical copies before fixing identity gauge, so the formalization still lacks a second realization to pair with the existing two-site corner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce548e105b83c350797cf43a854b5e9c9d25c6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->