### PR TITLE
doc(tenkz): mark the 1.0 contract as signed off

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -10,10 +10,12 @@ below in the change that lands the kernel; until then the 0.7 registry and
 kernel lands, a spelling absent from the registry does not exist, and every
 table below is checked against the registry by the census.
 
-<!-- Status: L1 draft for maintainer sign-off. Supersedes LANGUAGE.md (0.7).
-     Kernel follows the Session-0 compression review; where the earlier D1-D8
-     draft and the compression review differ, the compression review wins.
-     Open sign-off decisions are collected in §14. -->
+<!-- Status: signed off (#4687); this is the binding contract. Supersedes
+     LANGUAGE.md (0.7). Kernel follows the Session-0 compression review; where
+     the earlier D1-D8 draft and the compression review differ, the
+     compression review wins. The §14 decisions were confirmed at acceptance
+     (§14.3 was later reversed, as recorded there); execution state to the S4
+     surface swap is tracked on issue #4709. -->
 
 <!-- Amended 2026-07-25 by the nine signed amendments
      (AMENDMENT-corridor-and-crossing-order.md, AMENDMENT-remaining-demand.md,


### PR DESCRIPTION
The status comment still read 'L1 draft for maintainer sign-off' although
the contract was accepted in LionSR/TNLean#4687; the stale line has twice misled status
audits. Point execution tracking at LionSR/tenkz#13.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01R2tNmvagqAXLXDNjWf1fN2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only status comment update with no runtime, registry, or contract table changes.
> 
> **Overview**
> Updates the **status HTML comment** at the top of `docs/tenkz/LANGUAGE-1.0.md` so it matches reality after acceptance in **#4687**, instead of still calling the document an **L1 draft awaiting maintainer sign-off**.
> 
> The new text states the file is the **binding contract**, keeps the supersession of `LANGUAGE.md` (0.7) and the Session-0 compression-review precedence, notes that **§14** decisions were confirmed at acceptance (including the **§14.3** reversal called out in the doc), and points ongoing execution toward the **S4 surface swap** at issue **#4709**. No kernel tables, registry, or tooling change—metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23f9f0e5fe7dabc668e6981c66828bb92775c3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->