### PR TITLE
feat(Channel): implement positive algebra equivalences unitarily

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -56,6 +56,7 @@ import TNLean.Channel.PositiveConditionalExpectationDirectSum
 import TNLean.Channel.PositiveExamples
 import TNLean.Channel.PositiveFunctional
 import TNLean.Channel.PositiveMapDetection
+import TNLean.Channel.PositiveSkolemNoether
 import TNLean.Channel.Primitive
 import TNLean.Channel.RadonNikodym
 import TNLean.Channel.ReductionCriterion

--- a/TNLean/Channel/PositiveSkolemNoether.lean
+++ b/TNLean/Channel/PositiveSkolemNoether.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Algebra.SkolemNoetherUnitary
+import TNLean.Channel.Schwarz.PositiveMapProperties
+
+/-!
+# Positive automorphisms of complex matrix algebras
+
+A positive algebra automorphism of a nonzero full complex matrix algebra
+preserves adjoints and is therefore a star-algebra automorphism.  Unitary
+Skolem--Noether then realizes it as conjugation by a unitary matrix.
+
+## Main results
+
+* `exists_unitary_conj_of_positive_algEquiv_matrix`
+* `exists_unitary_conj_of_positive_bijective_multiplicative_matrix_linearMap`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.4, lines 1955--1997
+* [Wolf--Perez-Garcia 2010] arXiv:1005.4545, Theorem 8
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+/-- A positive algebra automorphism of a nonzero full complex matrix algebra
+is implemented by unitary conjugation.
+
+The positivity assumption is imposed on the underlying linear map.  It gives
+adjoint preservation, after which unitary Skolem--Noether applies.
+
+Source: CPSV16, arXiv:1606.00608, Appendix C.4, lines 1955--1997, together
+with Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8. -/
+theorem exists_unitary_conj_of_positive_algEquiv_matrix
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    (f : Matrix n n ℂ ≃ₐ[ℂ] Matrix n n ℂ)
+    (hf : IsPositiveMap f.toLinearMap) :
+    ∃ U : Matrix.unitaryGroup n ℂ, ∀ M : Matrix n n ℂ,
+      f M = (U : Matrix n n ℂ) * M * (U : Matrix n n ℂ)ᴴ := by
+  let fstar : Matrix n n ℂ ≃⋆ₐ[ℂ] Matrix n n ℂ :=
+    StarAlgEquiv.ofAlgEquiv f fun M ↦ by
+      rw [Matrix.star_eq_conjTranspose, Matrix.star_eq_conjTranspose]
+      exact hf.map_conjTranspose M
+  exact exists_unitary_conj_of_starAlgEquiv_matrix fstar
+
+/-- A positive, bijective, unital, multiplicative linear endomorphism of a
+nonzero full complex matrix algebra is implemented by unitary conjugation.
+
+This form permits applications in which the algebra equivalence has first
+been constructed as a linear extension.
+
+Source: CPSV16, arXiv:1606.00608, Appendix C.4, lines 1955--1997, together
+with Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8. -/
+theorem exists_unitary_conj_of_positive_bijective_multiplicative_matrix_linearMap
+    {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+    (T : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
+    (hOne : T 1 = 1)
+    (hMul : ∀ A B, T (A * B) = T A * T B)
+    (hBij : Function.Bijective T)
+    (hPos : IsPositiveMap T) :
+    ∃ U : Matrix.unitaryGroup n ℂ, ∀ M : Matrix n n ℂ,
+      T M = (U : Matrix n n ℂ) * M * (U : Matrix n n ℂ)ᴴ := by
+  let f : Matrix n n ℂ ≃ₐ[ℂ] Matrix n n ℂ :=
+    AlgEquiv.ofBijective
+      { toFun := T
+        map_one' := hOne
+        map_mul' := hMul
+        map_zero' := T.map_zero
+        map_add' := T.map_add
+        commutes' := fun c ↦ by
+          rw [Algebra.algebraMap_eq_smul_one, T.map_smul, hOne] }
+      hBij
+  have hfPos : IsPositiveMap f.toLinearMap := by
+    intro M hM
+    exact hPos M hM
+  obtain ⟨U, hU⟩ := exists_unitary_conj_of_positive_algEquiv_matrix f hfPos
+  exact ⟨U, hU⟩
+
+end MPSTensor

--- a/TNLean/Channel/PositiveSkolemNoether.lean
+++ b/TNLean/Channel/PositiveSkolemNoether.lean
@@ -49,7 +49,7 @@ theorem exists_unitary_conj_of_positive_algEquiv_matrix
       exact hf.map_conjTranspose M
   exact exists_unitary_conj_of_starAlgEquiv_matrix fstar
 
-/-- A positive, bijective, unital, multiplicative linear endomorphism of a
+/-- A positive, bijective, multiplicative linear endomorphism of a
 nonzero full complex matrix algebra is implemented by unitary conjugation.
 
 This form permits applications in which the algebra equivalence has first
@@ -60,12 +60,18 @@ with Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8. -/
 theorem exists_unitary_conj_of_positive_bijective_multiplicative_matrix_linearMap
     {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
     (T : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
-    (hOne : T 1 = 1)
     (hMul : ∀ A B, T (A * B) = T A * T B)
     (hBij : Function.Bijective T)
     (hPos : IsPositiveMap T) :
     ∃ U : Matrix.unitaryGroup n ℂ, ∀ M : Matrix n n ℂ,
       T M = (U : Matrix n n ℂ) * M * (U : Matrix n n ℂ)ᴴ := by
+  obtain ⟨X, hX⟩ := hBij.2 1
+  have hOne : T 1 = 1 := by
+    calc
+      T 1 = 1 * T 1 := (one_mul _).symm
+      _ = T X * T 1 := by rw [hX]
+      _ = T (X * 1) := (hMul X 1).symm
+      _ = 1 := by rw [mul_one, hX]
   let f : Matrix n n ℂ ≃ₐ[ℂ] Matrix n n ℂ :=
     AlgEquiv.ofBijective
       { toFun := T

--- a/TNLean/MPS/FundamentalTheorem.lean
+++ b/TNLean/MPS/FundamentalTheorem.lean
@@ -11,6 +11,7 @@ Authors: TNLean contributors
 import TNLean.MPS.FundamentalTheorem.Basic
 import TNLean.MPS.FundamentalTheorem.FiniteLength
 import TNLean.MPS.FundamentalTheorem.Multi
+import TNLean.MPS.FundamentalTheorem.PositiveLinearExtension
 import TNLean.MPS.FundamentalTheorem.ProductAlgebra
 import TNLean.MPS.FundamentalTheorem.Proportional
 import TNLean.MPS.FundamentalTheorem.SectorBNT

--- a/TNLean/MPS/FundamentalTheorem/PositiveLinearExtension.lean
+++ b/TNLean/MPS/FundamentalTheorem/PositiveLinearExtension.lean
@@ -53,7 +53,6 @@ theorem exists_unitary_conj_of_positive_perBlockLinearExtension
             (U : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)ᴴ :=
   exists_unitary_conj_of_positive_bijective_multiplicative_matrix_linearMap
     (perBlockLinearExtension A B hA hSame k)
-    (perBlockLinearExtension_one A B hA hSame k)
     (perBlockLinearExtension_mul A B hA hSame k)
     (perBlockLinearExtension_bijective A B hA hSame k)
     hPos

--- a/TNLean/MPS/FundamentalTheorem/PositiveLinearExtension.lean
+++ b/TNLean/MPS/FundamentalTheorem/PositiveLinearExtension.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.PositiveSkolemNoether
+import TNLean.MPS.FundamentalTheorem.ProductAlgebra
+
+/-!
+# Positive per-block linear extensions
+
+The linear extension between two matched injective matrix-product tensors is
+already unital, multiplicative, and bijective.  If it is also positive, then
+it is implemented by unitary conjugation.
+
+## Main results
+
+* `exists_unitary_conj_of_positive_perBlockLinearExtension`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.4, lines 1955--1997
+* [Wolf--Perez-Garcia 2010] arXiv:1005.4545, Theorem 8
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+
+/-- A positive per-block linear extension between matched injective tensors
+is implemented by unitary conjugation.
+
+**Scope restriction (positive linear extension):** Positivity of the virtual
+linear extension is assumed, not deduced from equality of closed chains or
+from a tensor-attached BNT algebra clause.  The missing deduction is recorded
+in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: CPSV16, arXiv:1606.00608, Appendix C.4, lines 1955--1997,
+together with Wolf--Perez-Garcia, arXiv:1005.4545, Theorem 8. -/
+theorem exists_unitary_conj_of_positive_perBlockLinearExtension
+    (A B : (k : Fin r) → MPSTensor d (dim k))
+    (hA : ∀ k, IsInjective (A k))
+    (hSame : ∀ k, SameMPV (A k) (B k))
+    (k : Fin r)
+    (hPos : IsPositiveMap (perBlockLinearExtension A B hA hSame k)) :
+    ∃ U : Matrix.unitaryGroup (Fin (dim k)) ℂ,
+      ∀ M : Matrix (Fin (dim k)) (Fin (dim k)) ℂ,
+        perBlockLinearExtension A B hA hSame k M =
+          (U : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) * M *
+            (U : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)ᴴ :=
+  exists_unitary_conj_of_positive_bijective_multiplicative_matrix_linearMap
+    (perBlockLinearExtension A B hA hSame k)
+    (perBlockLinearExtension_one A B hA hSame k)
+    (perBlockLinearExtension_mul A B hA hSame k)
+    (perBlockLinearExtension_bijective A B hA hSame k)
+    hPos
+
+end MPSTensor

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -71,9 +71,15 @@ There is an independent sufficient route which need not pass through
 \eqref{eq:positive-coefficient-realization}.  The invertible similarity determines an
 algebra automorphism of the virtual matrix algebra.  If this automorphism is a
 positive map, then it preserves adjoints and hence is a star automorphism.
-Unitary Skolem--Noether then gives a unitary implementer.  Positivity of this
-virtual algebra map is therefore another possible target for completing the
-argument; it has not been derived from the tensor-attached algebra clause.
+Unitary Skolem--Noether then gives a unitary implementer.  This implication,
+including its application to the per-block linear extension, is now
+formalized.\footnote{\scriptsize Formal declarations:
+\leanid{MPSTensor.exists_unitary_conj_of_positive_algEquiv_matrix}\\
+and
+\leanid{MPSTensor.exists_unitary_conj_of_positive_perBlockLinearExtension}.}
+Positivity of the virtual algebra map is therefore another possible target
+for completing the argument; it has not been derived from the tensor-attached
+algebra clause.
 
 Positivity of the virtual algebra map must not be confused with positivity of
 the closed sector operators.  A nonunitary similarity preserves every closed


### PR DESCRIPTION
Closes #5303.

## Mathematical content

A positive algebra automorphism of a nonzero full complex matrix algebra preserves adjoints. The resulting star-algebra automorphism is therefore implemented by a unitary matrix through the existing unitary Skolem--Noether theorem.

This pull request adds:

- `exists_unitary_conj_of_positive_algEquiv_matrix`;
- a form for positive, bijective, unital, multiplicative linear maps;
- `exists_unitary_conj_of_positive_perBlockLinearExtension`, applying the bridge to the per-block MPS linear extension.

The MPS theorem assumes positivity of the virtual linear extension. It does not infer that positivity from equality of closed chains, closed-sector MPDO positivity, or the tensor-attached BNT algebra clause. The paper-gap note records this exact remaining boundary and cites CPSV16 Appendix C.4 and Wolf--Perez-Garcia Theorem 8.

## Verification

- `lake exe cache get` completed before any build in the fresh worktree.
- `lake build` passed with 9,880 jobs.
- Targeted builds of both new modules passed.
- Blueprint--Lean synchronization and `checkdecls` passed.
- Generated import aggregators are current.
- Reader-facing prose and diff checks passed.
- The affected paper-gap PDF builds to 11 pages; pages 1--2 were visually inspected.
- No `sorry`, axioms, `native_decide`, or `unsafeCast` were introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization on top of existing Skolem–Noether infrastructure; no runtime, auth, or data-path changes, with explicit scope limits on assumed hypotheses.
> 
> **Overview**
> Formalizes the **positive automorphism → unitary conjugation** step for full complex matrix algebras: positivity of the linear map yields adjoint preservation, so the map is a star-algebra automorphism and existing unitary Skolem–Noether gives a unitary implementer.
> 
> Adds `exists_unitary_conj_of_positive_algEquiv_matrix`, a parallel theorem for positive bijective multiplicative linear maps (with a short proof that `T 1 = 1`), and **`exists_unitary_conj_of_positive_perBlockLinearExtension`** for MPS per-block linear extensions by reusing known multiplicativity and bijectivity. The MPS result **assumes** positivity of the virtual extension; it does not derive it from closed chains or BNT clauses, with that boundary documented in the module and in the CPSV16 paper-gap note.
> 
> The gap note now cites the new Lean declarations while stating that deriving virtual-map positivity from the tensor-attached algebra remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e1874220dc5ebb023fdc5be5b93d97c11152bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->