### PR TITLE
doc(blueprint): expose extension proof dependencies

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -185,6 +185,7 @@
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{thm:normal_tensor_gram_rigidity}
     The identity letter forces $c=1$. The matrix $S=V^\dagger X$ then
     commutes with all four letters of $A$, which span $\MN{2}$, and hence
     $S$ is scalar. Together with $V^\dagger V=\Id$, this would make
@@ -212,7 +213,8 @@
     $M,N\in\MN{D_k}$.
 \end{theorem}
 
-\begin{proof}\leanok\uses{def:mpdo_virtual_perBlockLinearExtension}
+\begin{proof}\leanok
+    \uses{def:mpdo_virtual_perBlockLinearExtension, thm:linear_ext_mul}
     The letters of $A_k$ span $\MN{D_k}$, and equality of the closed matrix
     product vectors gives the identity on products of spanning letters.
 \end{proof}
@@ -225,7 +227,9 @@
     The per-block extension $T_k$ is bijective.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:mpdo_virtual_perBlockLinearExtension_mul}
+\begin{proof}\leanok
+    \uses{thm:mpdo_virtual_perBlockLinearExtension_mul,
+        thm:simplicity, lem:trace_ne_zero}
     Multiplicativity makes the kernel an ideal of the simple matrix algebra.
     The map is nonzero: otherwise every letter of $B_k$ would vanish,
     contradicting the nonvanishing trace pairing for the injective family.


### PR DESCRIPTION
Follow-up to #5308.

## Summary

- record the Gram-rigidity theorem used by the nonunitary-similarity obstruction
- record the generic linear-extension multiplicativity theorem
- record the simplicity and nonzero-trace ingredients used for bijectivity

This changes only proof-level Blueprint dependency metadata; no Lean declaration or mathematical statement changes.

## Verification

- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint sync; no executable Lean or mathematical content changes.
> 
> **Overview**
> Blueprint proof metadata in `ch21_mpdo_rfp_bnt_theorem_data.tex` now records explicit Lean/blueprint dependencies for three virtual per-block extension arguments, without changing statements or proofs.
> 
> The **nonunitary-similarity obstruction** proof cites `thm:normal_tensor_gram_rigidity`. **Multiplicativity** of the per-block extension cites `thm:linear_ext_mul` in addition to the local definition. **Bijectivity** cites `thm:simplicity` and `lem:trace_ne_zero` alongside the multiplicativity theorem, with `\uses` moved onto its own line in each `\begin{proof}` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c5ff12cdd6fadd61eff52a659b2e13e8d54463. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->