### PR TITLE
doc(blueprint): declare extension proof dependencies

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -185,6 +185,7 @@
 \end{lemma}
 
 \begin{proof}\leanok
+    \uses{thm:normal_tensor_gram_rigidity}
     The identity letter forces $c=1$. The matrix $S=V^\dagger X$ then
     commutes with all four letters of $A$, which span $\MN{2}$, and hence
     $S$ is scalar. Together with $V^\dagger V=\Id$, this would make
@@ -212,7 +213,8 @@
     $M,N\in\MN{D_k}$.
 \end{theorem}
 
-\begin{proof}\leanok\uses{def:mpdo_virtual_perBlockLinearExtension}
+\begin{proof}\leanok
+    \uses{def:mpdo_virtual_perBlockLinearExtension, thm:linear_ext_mul}
     The letters of $A_k$ span $\MN{D_k}$, and equality of the closed matrix
     product vectors gives the identity on products of spanning letters.
 \end{proof}
@@ -225,7 +227,9 @@
     The per-block extension $T_k$ is bijective.
 \end{theorem}
 
-\begin{proof}\leanok\uses{thm:mpdo_virtual_perBlockLinearExtension_mul}
+\begin{proof}\leanok
+    \uses{thm:mpdo_virtual_perBlockLinearExtension_mul,
+        thm:simplicity, lem:trace_ne_zero}
     Multiplicativity makes the kernel an ideal of the simple matrix algebra.
     The map is nonzero: otherwise every letter of $B_k$ would vanish,
     contradicting the nonvanishing trace pairing for the injective family.


### PR DESCRIPTION
## Summary

- record the normal-tensor commutant-rigidity dependency in the nonpositive-isometric-realization proof
- record the generic linear-extension multiplicativity dependency in the per-block multiplicativity proof
- record simplicity and nonvanishing-trace dependencies in the per-block bijectivity proof

## Context

This is a narrow documentation follow-up to #5308. It addresses the proof-level dependency metadata requested in:

- https://github.com/LionSR/TNLean/pull/5308#discussion_r3696447066
- https://github.com/LionSR/TNLean/pull/5308#discussion_r3696447070
- https://github.com/LionSR/TNLean/pull/5308#discussion_r3696447074

The Lean proofs and theorem statements are unchanged; only the blueprint proof `\uses` edges are completed.

## Validation

- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

No Lake build was run because this PR changes only blueprint dependency metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint `\uses` metadata; no executable or proof logic changes.
> 
> **Overview**
> Completes **blueprint proof dependency metadata** in `ch21_mpdo_rfp_bnt_theorem_data.tex` for three MPDO virtual-extension proofs; **theorem statements and Lean proofs are unchanged**.
> 
> The nonpositive isometric-realization lemma proof now cites **`thm:normal_tensor_gram_rigidity`**. Per-block extension **multiplicativity** adds **`thm:linear_ext_mul`** alongside the definition. **Bijectivity** moves `\uses` into the proof body and cites **`thm:mpdo_virtual_perBlockLinearExtension_mul`**, **`thm:simplicity`**, and **`lem:trace_ne_zero`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bee688bda5c286cac6f15bcd8c5bbdf08e6b270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->