### PR TITLE
feat(MPS/MPDO): construct direct-sum unitary conjugations

### DIFF
--- a/TNLean/Channel/FixedPoint/DirectSumKraus.lean
+++ b/TNLean/Channel/FixedPoint/DirectSumKraus.lean
@@ -127,6 +127,36 @@ theorem IsKrausDirectSumMap.comp
   rw [IsKrausDirectSumMap, directSumMapExtension_comp]
   exact isKrausCP_comp hT hS
 
+section PiMap
+
+variable {q : ι → Type*}
+variable [∀ i, Fintype (q i)] [∀ i, DecidableEq (q i)]
+
+/-- A coordinatewise family of completely positive maps determines a completely positive map
+between the corresponding finite sums of matrix algebras. -/
+theorem isKrausDirectSumMap_piMap
+    (T : ∀ i, Matrix (n i) (n i) ℂ →ₗ[ℂ] Matrix (q i) (q i) ℂ)
+    (hT : ∀ i, IsKrausCP (T i)) :
+    IsKrausDirectSumMap (LinearMap.piMap T) := by
+  classical
+  choose r A hA using hT
+  change IsKrausCP (directSumMapExtension (LinearMap.piMap T))
+  rw [show directSumMapExtension (LinearMap.piMap T) = controlledKrausMap r A by
+    apply LinearMap.ext
+    intro X
+    ext ⟨i, b⟩ ⟨j, c⟩
+    by_cases hij : i = j
+    · subst j
+      rw [directSumMapExtension_apply, directSumDiagonalEmbedding_apply,
+        Matrix.blockDiagonal'_apply_eq, controlledKrausMap_sameBlock_apply]
+      exact congrFun (congrFun (hA i (X.submatrix (Sigma.mk i) (Sigma.mk i))) b) c
+    · rw [directSumMapExtension_apply, directSumDiagonalEmbedding_apply,
+        Matrix.blockDiagonal'_apply_ne _ _ _ hij,
+        controlledKrausMap_apply_of_ne _ _ _ hij]]
+  exact rectangularKrausMap_isKrausCP _
+
+end PiMap
+
 omit [Fintype ι] [(i : ι) → Fintype (n i)]
     [(i : ι) → DecidableEq (n i)] in
 /-- For an endomorphism of one finite direct sum, the extension between two

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -19,6 +19,7 @@ import TNLean.MPS.MPDO.BNTAlgebraTensorClause
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalUnitary
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary
 import TNLean.MPS.MPDO.BNTAlgebraTensorClausePositivity
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
 import TNLean.MPS.MPDO.BNTAssociativity

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseDirectSumUnitary.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseDirectSumUnitary.lean
@@ -1,0 +1,337 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.FixedPoint.TraceNonincreasingDirectSum
+import TNLean.Channel.PositiveConditionalExpectationDirectSum
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
+import TNLean.MPS.MPDO.VerticalSectorRetractions
+
+/-!
+# Direct-sum unitary conjugations in Appendix C.4
+
+After relabelling the paired one-site and two-site BNT sectors, a family of
+unitary sector conjugacies determines mutually inverse maps between the two
+finite sums of simple matrix algebras. The maps are completely positive and
+preserve the sum of the block traces.
+
+The unitary sector conjugacies are supplied as a hypothesis.  Their
+unconditional construction is the preceding open step in Appendix C.4.  The
+ambient retractions, normalized multiplicity embeddings, and physical maps
+are not constructed here.
+
+These are the middle conjugations in the converse implication of Appendix
+C.4, lines 2069 and 2080. They are distinct from the transported direct-sum
+maps in the forward implication at lines 1955--1997.
+
+## Main definitions
+
+* `TwoSiteExactSectorGauge.UnitarySectorConjugacy`
+* `UnitarySectorConjugacy.directSumUnitaryT`
+* `UnitarySectorConjugacy.directSumUnitaryS`
+
+## Main results
+
+* `UnitarySectorConjugacy.directSumUnitaryS_comp_directSumUnitaryT`
+* `UnitarySectorConjugacy.directSumUnitaryT_comp_directSumUnitaryS`
+* `UnitarySectorConjugacy.directSumUnitaryT_isKrausDirectSumMap`
+* `UnitarySectorConjugacy.directSumUnitaryS_isKrausDirectSumMap`
+* `UnitarySectorConjugacy.directSumUnitaryT_isTracePreservingBetweenDirectSums`
+* `UnitarySectorConjugacy.directSumUnitaryS_isTracePreservingBetweenDirectSums`
+* `UnitarySectorConjugacy.directSumUnitaryT_tensor`
+* `UnitarySectorConjugacy.directSumUnitaryS_tensor`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.4, lines 2053--2080
+-/
+
+open scoped Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- The two-site simple-sector algebra after relabelling its summands by the
+paired one-site labels.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2069. -/
+abbrev RelabeledTwoSiteSectorAlgebra (S : TwoSiteExactSectorGauge H) :=
+  VerticalSectorAlgebra
+    (fun γ ↦ S.decomposition.bondDim (S.relabel γ))
+
+/-- Unitary conjugacies between the paired one-site and two-site BNT sectors.
+
+**Scope restriction (supplied unitary sector conjugacies):** The structure
+records the unitary conclusion of Appendix C.4, line 2057, as a hypothesis.
+Its derivation from the tensor-attached algebra clause remains open; see
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
+structure UnitarySectorConjugacy (S : TwoSiteExactSectorGauge H) where
+  /-- The unitary matrix identifying a paired sector.
+
+  Source: arXiv:1606.00608, Appendix C.4, line 2057. -/
+  unitary : ∀ γ : Fin H.labelCount,
+    Matrix.unitaryGroup
+      (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ
+  /-- The two-site BNT tensor is the unitary conjugate of its paired one-site
+  BNT tensor.
+
+  Source: arXiv:1606.00608, Appendix C.4, lines 2053--2057. -/
+  tensor_eq : ∀ (γ : Fin H.labelCount) (i : Fin (D * D)),
+    S.decomposition.tensor (S.relabel γ) i =
+      (unitary γ : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+        (H.tensor γ)) i *
+      (unitary γ : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ
+
+private theorem reindexAlgEquiv_finCongr_apply_eq_cast
+    {p q e : ℕ} (h : p = q) (A : MPSTensor e p) (i : Fin e) :
+    Matrix.reindexAlgEquiv ℂ ℂ (finCongr h) (A i) =
+      (cast (congrArg (MPSTensor e) h) A) i := by
+  subst q
+  rfl
+
+/-- The linear equivalence of the paired direct sums induced by the sector
+unitaries.  Its forward direction is \(\widetilde T\), and its inverse is
+\(\widetilde S\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2069 and 2080. -/
+noncomputable def UnitarySectorConjugacy.sectorLinearEquiv
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    VerticalSectorAlgebra H.bondDim ≃ₗ[ℂ]
+      RelabeledTwoSiteSectorAlgebra S :=
+  LinearEquiv.piCongrRight fun γ ↦
+    (Matrix.unitaryReindexLinearEquiv
+      (finCongr (S.bondDim_eq γ)) (C.unitary γ) (C.unitary γ).property).symm
+
+/-- The direct-sum map \(\widetilde T\), given sectorwise by conjugation with
+\(U_\gamma\).
+
+Source: arXiv:1606.00608, Appendix C.4, line 2069. -/
+noncomputable def UnitarySectorConjugacy.directSumUnitaryT
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    VerticalSectorAlgebra H.bondDim →ₗ[ℂ]
+      RelabeledTwoSiteSectorAlgebra S :=
+  C.sectorLinearEquiv.toLinearMap
+
+/-- The direct-sum map \(\widetilde S\), given sectorwise by conjugation with
+\(U_\gamma^\dagger\).
+
+Source: arXiv:1606.00608, Appendix C.4, line 2080. -/
+noncomputable def UnitarySectorConjugacy.directSumUnitaryS
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    RelabeledTwoSiteSectorAlgebra S →ₗ[ℂ]
+      VerticalSectorAlgebra H.bondDim :=
+  C.sectorLinearEquiv.symm.toLinearMap
+
+/-- On each paired sector, \(\widetilde T\) reindexes the matrix coordinates
+and conjugates by \(U_\gamma\).
+
+Source: arXiv:1606.00608, Appendix C.4, line 2069. -/
+@[simp]
+theorem UnitarySectorConjugacy.directSumUnitaryT_apply
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
+    (X : VerticalSectorAlgebra H.bondDim) (γ : Fin H.labelCount) :
+    C.directSumUnitaryT X γ =
+      (C.unitary γ : Matrix
+        (Fin (S.decomposition.bondDim (S.relabel γ)))
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+      Matrix.reindexAlgEquiv ℂ ℂ (finCongr (S.bondDim_eq γ)) (X γ) *
+      (C.unitary γ : Matrix
+        (Fin (S.decomposition.bondDim (S.relabel γ)))
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ := by
+  simp [directSumUnitaryT, sectorLinearEquiv,
+    Matrix.star_eq_conjTranspose]
+
+/-- On each paired sector, \(\widetilde S\) conjugates by
+\(U_\gamma^\dagger\) and returns to the one-site matrix coordinates.
+
+Source: arXiv:1606.00608, Appendix C.4, line 2080. -/
+@[simp]
+theorem UnitarySectorConjugacy.directSumUnitaryS_apply
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
+    (Y : RelabeledTwoSiteSectorAlgebra S) (γ : Fin H.labelCount) :
+    C.directSumUnitaryS Y γ =
+      (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (S.bondDim_eq γ))).symm
+        ((C.unitary γ : Matrix
+          (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ * Y γ *
+        (C.unitary γ : Matrix
+          (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)) := by
+  simp [directSumUnitaryS, sectorLinearEquiv,
+    Matrix.star_eq_conjTranspose]
+
+private theorem UnitarySectorConjugacy.forwardComponent_isKrausCPTP
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
+    (γ : Fin H.labelCount) :
+    IsKrausCPTP
+      (Matrix.unitaryReindexLinearEquiv
+        (finCongr (S.bondDim_eq γ)) (C.unitary γ)
+          (C.unitary γ).property).symm.toLinearMap := by
+  rw [show (Matrix.unitaryReindexLinearEquiv
+      (finCongr (S.bondDim_eq γ)) (C.unitary γ)
+        (C.unitary γ).property).symm.toLinearMap =
+      singleKrausMap (C.unitary γ) ∘ₗ
+        Matrix.equivReindexMap (finCongr (S.bondDim_eq γ)) by
+    apply LinearMap.ext
+    intro X
+    simp [Matrix.unitaryReindexLinearEquiv_symm_apply,
+      Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
+      Matrix.star_eq_conjTranspose]]
+  apply isKrausCPTP_comp
+    (Matrix.equivReindexMap_isKrausCPTP (finCongr (S.bondDim_eq γ)))
+  apply singleKrausMap_isKrausCPTP
+  simpa only [Matrix.star_eq_conjTranspose] using
+    Matrix.mem_unitaryGroup_iff'.mp (C.unitary γ).property
+
+private theorem UnitarySectorConjugacy.backwardComponent_isKrausCPTP
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
+    (γ : Fin H.labelCount) :
+    IsKrausCPTP
+      (Matrix.unitaryReindexLinearEquiv
+        (finCongr (S.bondDim_eq γ)) (C.unitary γ)
+          (C.unitary γ).property).toLinearMap := by
+  rw [show (Matrix.unitaryReindexLinearEquiv
+      (finCongr (S.bondDim_eq γ)) (C.unitary γ)
+        (C.unitary γ).property).toLinearMap =
+      Matrix.equivReindexMap (finCongr (S.bondDim_eq γ)).symm ∘ₗ
+        singleKrausMap
+          ((C.unitary γ : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ) by
+    apply LinearMap.ext
+    intro Y
+    simp [Matrix.unitaryReindexLinearEquiv_apply,
+      Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv,
+      Matrix.star_eq_conjTranspose]]
+  apply isKrausCPTP_comp
+  · apply singleKrausMap_isKrausCPTP
+    simpa only [Matrix.star_eq_conjTranspose,
+      Matrix.conjTranspose_conjTranspose] using
+      Matrix.mem_unitaryGroup_iff.mp (C.unitary γ).property
+  · exact Matrix.equivReindexMap_isKrausCPTP
+      (finCongr (S.bondDim_eq γ)).symm
+
+/-- The map \(\widetilde T\) is completely positive between the two finite
+direct sums.
+
+Source: arXiv:1606.00608, Appendix C.4, line 2069. -/
+theorem UnitarySectorConjugacy.directSumUnitaryT_isKrausDirectSumMap
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    Matrix.IsKrausDirectSumMap C.directSumUnitaryT := by
+  rw [show C.directSumUnitaryT = LinearMap.piMap (fun γ ↦
+      (Matrix.unitaryReindexLinearEquiv
+        (finCongr (S.bondDim_eq γ)) (C.unitary γ)
+          (C.unitary γ).property).symm.toLinearMap) by
+    apply LinearMap.ext
+    intro X
+    rfl]
+  exact Matrix.isKrausDirectSumMap_piMap _
+    (fun γ ↦ (C.forwardComponent_isKrausCPTP γ).isKrausCP)
+
+/-- The map \(\widetilde S\) is completely positive between the two finite
+direct sums.
+
+Source: arXiv:1606.00608, Appendix C.4, line 2080. -/
+theorem UnitarySectorConjugacy.directSumUnitaryS_isKrausDirectSumMap
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    Matrix.IsKrausDirectSumMap C.directSumUnitaryS := by
+  rw [show C.directSumUnitaryS = LinearMap.piMap (fun γ ↦
+      (Matrix.unitaryReindexLinearEquiv
+        (finCongr (S.bondDim_eq γ)) (C.unitary γ)
+          (C.unitary γ).property).toLinearMap) by
+    apply LinearMap.ext
+    intro Y
+    rfl]
+  exact Matrix.isKrausDirectSumMap_piMap _
+    (fun γ ↦ (C.backwardComponent_isKrausCPTP γ).isKrausCP)
+
+/-- The map \(\widetilde T\) preserves the sum of the traces of its simple
+matrix summands.
+
+Source: arXiv:1606.00608, Appendix C.4, line 2069. -/
+theorem UnitarySectorConjugacy.directSumUnitaryT_isTracePreservingBetweenDirectSums
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    Matrix.IsTracePreservingBetweenDirectSums C.directSumUnitaryT := by
+  intro X
+  apply Finset.sum_congr rfl
+  intro γ _
+  exact (C.forwardComponent_isKrausCPTP γ).trace_map (X γ)
+
+/-- The map \(\widetilde S\) preserves the sum of the traces of its simple
+matrix summands.
+
+Source: arXiv:1606.00608, Appendix C.4, line 2080. -/
+theorem UnitarySectorConjugacy.directSumUnitaryS_isTracePreservingBetweenDirectSums
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    Matrix.IsTracePreservingBetweenDirectSums C.directSumUnitaryS := by
+  intro Y
+  apply Finset.sum_congr rfl
+  intro γ _
+  exact (C.backwardComponent_isKrausCPTP γ).trace_map (Y γ)
+
+/-- The direct-sum map \(\widetilde S\) is a left inverse of
+\(\widetilde T\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2069 and 2080. -/
+theorem UnitarySectorConjugacy.directSumUnitaryS_comp_directSumUnitaryT
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    C.directSumUnitaryS.comp C.directSumUnitaryT = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  exact C.sectorLinearEquiv.symm_apply_apply X
+
+/-- The direct-sum map \(\widetilde S\) is a right inverse of
+\(\widetilde T\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2069 and 2080. -/
+theorem UnitarySectorConjugacy.directSumUnitaryT_comp_directSumUnitaryS
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S) :
+    C.directSumUnitaryT.comp C.directSumUnitaryS = LinearMap.id := by
+  apply LinearMap.ext
+  intro Y
+  exact C.sectorLinearEquiv.apply_symm_apply Y
+
+/-- The map \(\widetilde T\) sends the family of one-site BNT tensor letters
+to the paired family of two-site BNT tensor letters.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2053--2069. -/
+theorem UnitarySectorConjugacy.directSumUnitaryT_tensor
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
+    (i : Fin (D * D)) :
+    C.directSumUnitaryT (fun γ ↦ H.tensor γ i) =
+      fun γ ↦ S.decomposition.tensor (S.relabel γ) i := by
+  funext γ
+  rw [directSumUnitaryT_apply, reindexAlgEquiv_finCongr_apply_eq_cast]
+  exact (C.tensor_eq γ i).symm
+
+/-- The map \(\widetilde S\) sends the paired family of two-site BNT tensor
+letters back to the one-site BNT tensor letters.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2053--2080. -/
+theorem UnitarySectorConjugacy.directSumUnitaryS_tensor
+    {S : TwoSiteExactSectorGauge H} (C : UnitarySectorConjugacy S)
+    (i : Fin (D * D)) :
+    C.directSumUnitaryS
+        (fun γ ↦ S.decomposition.tensor (S.relabel γ) i) =
+      fun γ ↦ H.tensor γ i := by
+  rw [← C.directSumUnitaryT_tensor i]
+  change (C.directSumUnitaryS.comp C.directSumUnitaryT)
+      (fun γ ↦ H.tensor γ i) = _
+  rw [C.directSumUnitaryS_comp_directSumUnitaryT]
+  rfl
+
+end BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
@@ -7,3 +7,4 @@
 \input{chapter/ch21_mpdo_rfp_bnt_coefficients}
 \input{chapter/ch21_mpdo_rfp_bnt_theorem_data}
 \input{chapter/ch21_mpdo_rfp_bnt_witnesses}
+\input{chapter/ch21_mpdo_rfp_bnt_direct_sum_unitary_conjugations}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_direct_sum_unitary_conjugations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_direct_sum_unitary_conjugations.tex
@@ -1,0 +1,128 @@
+\subsection{Direct-sum sector conjugations}
+
+\begin{definition}[Direct-sum unitary conjugations]
+    \label{def:mpdo_bnt_direct_sum_unitary_conjugations}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        RelabeledTwoSiteSectorAlgebra}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.sectorLinearEquiv}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryT}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryS}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryT_apply}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryS_apply}
+    \leanok
+    \uses{def:mpdo_bnt_two_site_exact_sector_gauge}
+    Work in the setting of
+    Definition~\ref{def:mpdo_bnt_two_site_exact_sector_gauge}.  Let
+    \begin{align}
+        \mathcal A_1
+        &=\bigoplus_\gamma \MN{d_\gamma},
+        &
+        \mathcal A_2^\sigma
+        &=\bigoplus_\gamma \MN{\widetilde d_{\sigma(\gamma)}}
+    \end{align}
+    be the one-site sector algebra and the two-site sector algebra relabelled
+    by the given sector matching.  Suppose that
+    $d_\gamma=\widetilde d_{\sigma(\gamma)}$ and that there is a unitary
+    $U_\gamma$ on each matched sector such that
+    \begin{align}
+        A_{\sigma(\gamma)}^i
+        &=U_\gamma M_\gamma^i U_\gamma^*
+        \label{eq:mpdo_bnt_sector_unitary_conjugacy}
+    \end{align}
+    for every physical index $i$.  Denote by $\iota_\gamma$ the coordinate
+    identification induced by the equality of the two bond dimensions.
+    Define mutually inverse linear maps
+    \begin{align}
+        \widetilde T\colon \mathcal A_1&\longrightarrow\mathcal A_2^\sigma,
+        &
+        [\widetilde T(X)]_\gamma
+        &=U_\gamma\iota_\gamma(X_\gamma)U_\gamma^*,
+        \label{eq:mpdo_bnt_direct_sum_unitary_T}
+        \\
+        \widetilde S\colon \mathcal A_2^\sigma&\longrightarrow\mathcal A_1,
+        &
+        [\widetilde S(Y)]_\gamma
+        &=\iota_\gamma^{-1}
+          (U_\gamma^*Y_\gamma U_\gamma).
+        \label{eq:mpdo_bnt_direct_sum_unitary_S}
+    \end{align}
+    These are the converse-direction middle conjugations introduced in
+    \cite[Appendix~C.4, lines~2053--2080]{Cirac2016MPDO_arXiv}.  The
+    existence of the unitaries in
+    (\ref{eq:mpdo_bnt_sector_unitary_conjugacy}) is an assumption here.
+    They are distinct from the transported direct-sum maps in
+    \cite[Appendix~C.4, lines~1955--1997]{Cirac2016MPDO_arXiv}.  No maps
+    between the ambient full matrix algebras are included here.
+\end{definition}
+
+\begin{theorem}[Properties of the direct-sum unitary conjugations]
+    \label{thm:mpdo_bnt_direct_sum_unitary_conjugations}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryT_isKrausDirectSumMap}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryS_isKrausDirectSumMap}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.%
+        directSumUnitaryT_isTracePreservingBetweenDirectSums}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.%
+        directSumUnitaryS_isTracePreservingBetweenDirectSums}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryS_comp_directSumUnitaryT}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryT_comp_directSumUnitaryS}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryT_tensor}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.directSumUnitaryS_tensor}
+    \leanok
+    \uses{def:kraus_map_between_direct_sums,
+        def:mpdo_bnt_direct_sum_unitary_conjugations}
+    The maps $\widetilde T$ and $\widetilde S$ are completely positive and
+    preserve the total trace on the direct sums.  They are mutually inverse:
+    \begin{align}
+        \widetilde S\widetilde T
+        &=\id_{\mathcal A_1},
+        &
+        \widetilde T\widetilde S
+        &=\id_{\mathcal A_2^\sigma}.
+        \label{eq:mpdo_bnt_direct_sum_unitary_inverses}
+    \end{align}
+    They also carry the matched tensor letters in both directions:
+    \begin{align}
+        \widetilde T\bigl((M_\gamma^i)_\gamma\bigr)
+        &=\bigl(A_{\sigma(\gamma)}^i\bigr)_\gamma,
+        \notag
+        \\
+        \widetilde S\bigl((A_{\sigma(\gamma)}^i)_\gamma\bigr)
+        &=\bigl(M_\gamma^i\bigr)_\gamma.
+        \label{eq:mpdo_bnt_direct_sum_unitary_tensor_letters}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:direct_sum_kraus_composition_schwarz}
+    On each summand, conjugation by $U_\gamma$ and the coordinate
+    identification $\iota_\gamma$ are completely positive and
+    trace-preserving.  Their direct sums therefore have the same properties.
+    Unitarity gives
+    \begin{align}
+        U_\gamma^*U_\gamma
+        &=I,
+        &
+        U_\gamma U_\gamma^*
+        &=I,
+    \end{align}
+    which proves (\ref{eq:mpdo_bnt_direct_sum_unitary_inverses}) sector by
+    sector.  The first identity in
+    (\ref{eq:mpdo_bnt_direct_sum_unitary_tensor_letters}) is precisely
+    (\ref{eq:mpdo_bnt_sector_unitary_conjugacy}); the second follows by
+    applying the inverse map.
+\end{proof}

--- a/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_schwarz_maps.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_direct_sum_schwarz_maps.tex
@@ -27,14 +27,17 @@
 % transported composites in CPSV16, Appendix C.4, lines 1974--1995.  It does
 % not establish Kraus representations for those transported maps; that is the
 % tensor-specific preparation and partial-trace step tracked in issue #4438.
-\begin{lemma}[Composition and trace-adjoint Schwarz for direct-sum Kraus maps]
+\begin{lemma}[Coordinatewise maps, composition, and trace-adjoint Schwarz for direct sums]
     \label{lem:direct_sum_kraus_composition_schwarz}
-    \lean{Matrix.directSumMapExtension_comp,
+    \lean{Matrix.isKrausDirectSumMap_piMap,
+        Matrix.directSumMapExtension_comp,
         Matrix.IsKrausDirectSumMap.comp, Matrix.isSchwarzDirectSumMap_of_directSumExtension_isSchwarzMap,
         Matrix.IsKrausDirectSumMap.directSumTraceAdjointMap_isSchwarz}
     \leanok
     \uses{def:kraus_map_between_direct_sums}
-    For direct-sum Kraus maps $T:\mathcal A\to\mathcal B$ and $S:\mathcal B\to\mathcal C$, one has
+    A coordinatewise family of completely positive maps between paired
+    summands determines a direct-sum Kraus map. For direct-sum Kraus maps
+    $T:\mathcal A\to\mathcal B$ and $S:\mathcal B\to\mathcal C$, one has
     $\widehat{S\circ T}=\widehat S\circ\widehat T$, and $S\circ T$ is again a direct-sum Kraus map. If an endomorphism
     $T:\mathcal A\to\mathcal A$ has an extension satisfying
     \begin{align}
@@ -54,6 +57,17 @@
 
 \begin{proof}\leanok
     \uses{thm:kadison_schwarz}
+    Choose a Kraus family $K_{i,r}$ for the map on the $i$-th paired
+    summand. The canonical extension of the coordinatewise map is the
+    controlled Kraus map
+    \begin{align}
+        \widehat T(X)
+        &=\sum_{i,r}K_{i,r}XK_{i,r}^*.
+        \notag
+    \end{align}
+    Each $K_{i,r}$ is supported on its paired input and output summands, so
+    the sum retains precisely the diagonal input blocks.
+
     Since $\pi_{\mathcal B}\iota_{\mathcal B}=\id_{\mathcal B}$,
     \begin{align}
         \widehat S\,\widehat T


### PR DESCRIPTION
## Summary

- package a supplied family of Appendix C.4 unitary sector conjugacies as mutually inverse direct-sum maps
- prove their component formulas, complete positivity, total-trace preservation, and action on matched tensor letters
- add the reusable coordinatewise direct-sum Kraus lemma and synchronize the Blueprint

## Source boundary

This formalizes the converse-direction middle conjugations at CPSV16 Appendix C.4, lines 2069 and 2080, conditional on the unitary sector correspondence stated at lines 2053–2057. The missing unconditional construction remains documented in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.

This change does not construct the ambient retractions, multiplicity embeddings, zero-complement extensions, or physical maps \(T,S\). Issues #4645 and #5285 remain open.

## Verification

- `lake build TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary`
- `lake env lean TNLean/MPS/MPDO.lean`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint pdf`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls`
- reader-facing prose, proof-integrity, line-length, and diff checks

Only targeted checks using the existing local cache were run; no fresh Mathlib or project build was performed.

Closes #5314

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization in Mathlib-style Lean and blueprint prose; no runtime, auth, or data paths. Scope is explicitly conditional on an open paper gap.
> 
> **Overview**
> Formalizes **Appendix C.4 converse-direction** direct-sum maps \(\widetilde T\) and \(\widetilde S\) between paired one-site and relabeled two-site BNT sector algebras, **conditional on** a hypothesized `UnitarySectorConjugacy` (sector unitaries matching tensor letters).
> 
> Adds **`Matrix.isKrausDirectSumMap_piMap`**: a coordinatewise family of CP summand maps yields a direct-sum Kraus map—used to prove complete positivity of the conjugation maps. Proves **mutual inverse**, **total trace preservation**, and **action on matched BNT tensor letters**.
> 
> Blueprint gains a **direct-sum unitary conjugations** subsection and extends the direct-sum Kraus lemma proof to cover the coordinatewise case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7bd8c4ca0945c11a29055105e3e4afa038d19c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->