### PR TITLE
feat(MPS/MPDO): construct ambient sector maps

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -16,12 +16,16 @@ import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.AlgebraStructure
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorCoordinates
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorMaps
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalUnitary
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseOneSiteAmbientSectorMaps
 import TNLean.MPS.MPDO.BNTAlgebraTensorClausePositivity
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseTwoSiteAmbientSectorMaps
 import TNLean.MPS.MPDO.BNTAssociativity
 import TNLean.MPS.MPDO.BNTClosingSelection
 import TNLean.MPS.MPDO.BNTCoefficients
@@ -280,6 +284,7 @@ import TNLean.MPS.MPDO.VerticalProductPairBlocks
 import TNLean.MPS.MPDO.VerticalProductReconstruction
 import TNLean.MPS.MPDO.VerticalProductSpectralFamily
 import TNLean.MPS.MPDO.VerticalReduction
+import TNLean.MPS.MPDO.VerticalSectorAmbientMaps
 import TNLean.MPS.MPDO.VerticalSectorCoefficientComparison
 import TNLean.MPS.MPDO.VerticalSectorCompletePositivity
 import TNLean.MPS.MPDO.VerticalSectorCoordinates

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseAmbientSectorCoordinates.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseAmbientSectorCoordinates.lean
@@ -1,0 +1,275 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum
+
+/-!
+# Relabelled ambient coordinates for the two-site BNT decomposition
+
+The sector matching between the one-site and two-site vertical canonical
+decompositions pulls the two-site bond dimensions, multiplicities, and positive
+weights back to the one-site label set.  The induced equivalence of retained
+coordinates turns the two-site vertical coisometry into a coisometry whose rows
+are indexed by these relabelled sectors.
+
+The relabelled coisometry carries native two-site block diagonals to the pulled-
+back block diagonals.  The one-site and matched two-site multiplicity traces
+coincide, giving the common normalization used by the outer maps of Appendix
+C.4.
+
+## Main definitions
+
+* `relabeledTwoSiteBondDim`
+* `relabeledTwoSiteMultiplicity`
+* `relabeledTwoSiteWeight`
+* `RelabeledTwoSiteSectorAlgebra`
+* `RelabeledTwoSiteWeightedSectorSpace`
+* `relabeledTwoSiteRetainedEquiv`
+* `relabeledTwoSiteCoisometry`
+
+## Main results
+
+* `relabeledTwoSiteCoisometry_coisometry`
+* `verticalSectorBlockDiagonal_relabel`
+* `relabeledTwoSiteCoisometry_forward`
+* `relabeledTwoSiteCoisometry_reconstruction`
+* `relabeledTwoSiteMultiplicityTrace_eq_oneSite`
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 2048--2064.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum
+
+variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- The two-site bond dimensions pulled back along the sector matching.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+abbrev relabeledTwoSiteBondDim (S : TwoSiteMultiplicitySpectrum H) :
+    Fin H.labelCount → ℕ :=
+  fun γ ↦ S.decomposition.bondDim (S.relabel γ)
+
+/-- The two-site multiplicities pulled back along the sector matching.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+abbrev relabeledTwoSiteMultiplicity (S : TwoSiteMultiplicitySpectrum H) :
+    Fin H.labelCount → ℕ :=
+  fun γ ↦ S.decomposition.multiplicity (S.relabel γ)
+
+/-- The two-site multiplicity weights pulled back along the sector matching.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2064. -/
+abbrev relabeledTwoSiteWeight (S : TwoSiteMultiplicitySpectrum H) :
+    (γ : Fin H.labelCount) → Fin (S.relabeledTwoSiteMultiplicity γ) → ℂ :=
+  fun γ ↦ S.decomposition.weight (S.relabel γ)
+
+/-- The two-site simple-sector algebra indexed by the matched one-site labels.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+abbrev RelabeledTwoSiteSectorAlgebra (S : TwoSiteMultiplicitySpectrum H) :=
+  VerticalSectorAlgebra S.relabeledTwoSiteBondDim
+
+/-- The two-site weighted-sector family indexed by the matched one-site labels.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+abbrev RelabeledTwoSiteWeightedSectorSpace
+    (S : TwoSiteMultiplicitySpectrum H) :=
+  VerticalWeightedSectorSpace S.relabeledTwoSiteBondDim
+    S.relabeledTwoSiteMultiplicity
+
+/-- Relabel the retained two-site coordinate from the matched one-site labels
+to the native labels of the two-site vertical decomposition.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+def relabeledTwoSiteRetainedEquiv (S : TwoSiteMultiplicitySpectrum H) :
+    Fin (∑ q : Fin (∑ γ : Fin H.labelCount,
+      S.relabeledTwoSiteMultiplicity γ),
+        verticalCopyDim S.relabeledTwoSiteBondDim
+          S.relabeledTwoSiteMultiplicity q) ≃
+      Fin (∑ q : Fin (∑ β : Fin S.decomposition.labelCount,
+        S.decomposition.multiplicity β),
+          verticalCopyDim S.decomposition.bondDim
+            S.decomposition.multiplicity q) :=
+  (verticalSectorFinEquiv S.relabeledTwoSiteBondDim
+      S.relabeledTwoSiteMultiplicity).symm |>.trans
+    ((Equiv.sigmaCongr S.relabel fun _ ↦ Equiv.refl _).trans
+      (verticalSectorFinEquiv S.decomposition.bondDim
+        S.decomposition.multiplicity))
+
+/-- On a relabelled sector coordinate, the retained-coordinate equivalence
+changes only the sector label.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+@[simp]
+theorem relabeledTwoSiteRetainedEquiv_apply
+    (S : TwoSiteMultiplicitySpectrum H) (γ : Fin H.labelCount)
+    (x : Fin (S.relabeledTwoSiteMultiplicity γ) ×
+      Fin (S.relabeledTwoSiteBondDim γ)) :
+    S.relabeledTwoSiteRetainedEquiv
+        (verticalSectorFinEquiv S.relabeledTwoSiteBondDim
+          S.relabeledTwoSiteMultiplicity ⟨γ, x⟩) =
+      verticalSectorFinEquiv S.decomposition.bondDim
+        S.decomposition.multiplicity ⟨S.relabel γ, x⟩ := by
+  simp only [relabeledTwoSiteRetainedEquiv, Equiv.trans_apply,
+    Equiv.symm_apply_apply]
+  unfold Equiv.sigmaCongr
+  rfl
+
+/-- The two-site vertical coisometry with its retained rows indexed by the
+matched one-site labels.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+def relabeledTwoSiteCoisometry (S : TwoSiteMultiplicitySpectrum H) :
+    Matrix
+      (Fin (∑ q : Fin (∑ γ : Fin H.labelCount,
+        S.relabeledTwoSiteMultiplicity γ),
+          verticalCopyDim S.relabeledTwoSiteBondDim
+            S.relabeledTwoSiteMultiplicity q))
+      (Fin (d * d)) ℂ :=
+  Matrix.reindex S.relabeledTwoSiteRetainedEquiv.symm (Equiv.refl _)
+    S.decomposition.verticalCoisometry
+
+/-- Relabelling the retained rows preserves the coisometry identity.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+theorem relabeledTwoSiteCoisometry_coisometry
+    (S : TwoSiteMultiplicitySpectrum H) :
+    S.relabeledTwoSiteCoisometry * S.relabeledTwoSiteCoisometryᴴ = 1 := by
+  rw [relabeledTwoSiteCoisometry, Matrix.conjTranspose_reindex]
+  change Matrix.reindexLinearEquiv ℂ ℂ
+      S.relabeledTwoSiteRetainedEquiv.symm (Equiv.refl _)
+        S.decomposition.verticalCoisometry *
+    Matrix.reindexLinearEquiv ℂ ℂ
+      (Equiv.refl _) S.relabeledTwoSiteRetainedEquiv.symm
+        S.decomposition.verticalCoisometryᴴ = 1
+  rw [Matrix.reindexLinearEquiv_mul, S.decomposition.coisometry,
+    Matrix.reindexLinearEquiv_one]
+
+/-- Relabelling the retained coordinate pulls a native two-site block diagonal
+back along the sector matching.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+theorem verticalSectorBlockDiagonal_relabel
+    (S : TwoSiteMultiplicitySpectrum H)
+    (Y : VerticalWeightedSectorSpace S.decomposition.bondDim
+      S.decomposition.multiplicity) :
+    Matrix.reindex S.relabeledTwoSiteRetainedEquiv.symm
+        S.relabeledTwoSiteRetainedEquiv.symm
+        (verticalSectorBlockDiagonal S.decomposition.bondDim
+          S.decomposition.multiplicity Y) =
+      verticalSectorBlockDiagonal S.relabeledTwoSiteBondDim
+        S.relabeledTwoSiteMultiplicity (fun γ ↦ Y (S.relabel γ)) := by
+  ext i j
+  obtain ⟨⟨γ, x⟩, rfl⟩ :=
+    (verticalSectorFinEquiv S.relabeledTwoSiteBondDim
+      S.relabeledTwoSiteMultiplicity).surjective i
+  obtain ⟨⟨δ, y⟩, rfl⟩ :=
+    (verticalSectorFinEquiv S.relabeledTwoSiteBondDim
+      S.relabeledTwoSiteMultiplicity).surjective j
+  simp only [Matrix.reindex_apply, Equiv.symm_symm]
+  change verticalSectorBlockDiagonal S.decomposition.bondDim
+      S.decomposition.multiplicity Y
+        (S.relabeledTwoSiteRetainedEquiv
+          (verticalSectorFinEquiv S.relabeledTwoSiteBondDim
+            S.relabeledTwoSiteMultiplicity ⟨γ, x⟩))
+        (S.relabeledTwoSiteRetainedEquiv
+          (verticalSectorFinEquiv S.relabeledTwoSiteBondDim
+            S.relabeledTwoSiteMultiplicity ⟨δ, y⟩)) = _
+  rw [S.relabeledTwoSiteRetainedEquiv_apply,
+    S.relabeledTwoSiteRetainedEquiv_apply]
+  by_cases hγδ : γ = δ
+  · subst δ
+    simp
+  · rw [verticalSectorBlockDiagonal_apply_ne _ _ _
+      (S.relabel.injective.ne hγδ)]
+    rw [verticalSectorBlockDiagonal_apply_ne _ _ _ hγδ]
+
+/-- A native two-site compression identity becomes the corresponding identity
+in the relabelled retained coordinates.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+theorem relabeledTwoSiteCoisometry_forward
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : Matrix (Fin (d * d)) (Fin (d * d)) ℂ)
+    (Y : VerticalWeightedSectorSpace S.decomposition.bondDim
+      S.decomposition.multiplicity)
+    (hForward : S.decomposition.verticalCoisometry * X *
+      S.decomposition.verticalCoisometryᴴ =
+        verticalSectorBlockDiagonal S.decomposition.bondDim
+          S.decomposition.multiplicity Y) :
+    S.relabeledTwoSiteCoisometry * X * S.relabeledTwoSiteCoisometryᴴ =
+      verticalSectorBlockDiagonal S.relabeledTwoSiteBondDim
+        S.relabeledTwoSiteMultiplicity (fun γ ↦ Y (S.relabel γ)) := by
+  rw [relabeledTwoSiteCoisometry, Matrix.conjTranspose_reindex]
+  change Matrix.reindexLinearEquiv ℂ ℂ
+        S.relabeledTwoSiteRetainedEquiv.symm (Equiv.refl _)
+        S.decomposition.verticalCoisometry *
+      Matrix.reindexLinearEquiv ℂ ℂ (Equiv.refl _) (Equiv.refl _) X *
+      Matrix.reindexLinearEquiv ℂ ℂ
+        (Equiv.refl _) S.relabeledTwoSiteRetainedEquiv.symm
+        S.decomposition.verticalCoisometryᴴ = _
+  rw [Matrix.reindexLinearEquiv_mul, Matrix.reindexLinearEquiv_mul,
+    hForward]
+  exact S.verticalSectorBlockDiagonal_relabel Y
+
+/-- A native two-site reconstruction identity becomes the corresponding
+identity in the relabelled retained coordinates.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2058. -/
+theorem relabeledTwoSiteCoisometry_reconstruction
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : Matrix (Fin (d * d)) (Fin (d * d)) ℂ)
+    (Y : VerticalWeightedSectorSpace S.decomposition.bondDim
+      S.decomposition.multiplicity)
+    (hReconstruct : X = S.decomposition.verticalCoisometryᴴ *
+      verticalSectorBlockDiagonal S.decomposition.bondDim
+        S.decomposition.multiplicity Y *
+      S.decomposition.verticalCoisometry) :
+    X = S.relabeledTwoSiteCoisometryᴴ *
+      verticalSectorBlockDiagonal S.relabeledTwoSiteBondDim
+        S.relabeledTwoSiteMultiplicity (fun γ ↦ Y (S.relabel γ)) *
+      S.relabeledTwoSiteCoisometry := by
+  rw [relabeledTwoSiteCoisometry, Matrix.conjTranspose_reindex,
+    ← S.verticalSectorBlockDiagonal_relabel Y]
+  change X = Matrix.reindexLinearEquiv ℂ ℂ
+        (Equiv.refl _) S.relabeledTwoSiteRetainedEquiv.symm
+        S.decomposition.verticalCoisometryᴴ *
+      Matrix.reindexLinearEquiv ℂ ℂ
+        S.relabeledTwoSiteRetainedEquiv.symm
+        S.relabeledTwoSiteRetainedEquiv.symm
+        (verticalSectorBlockDiagonal S.decomposition.bondDim
+          S.decomposition.multiplicity Y) *
+      Matrix.reindexLinearEquiv ℂ ℂ
+        S.relabeledTwoSiteRetainedEquiv.symm (Equiv.refl _)
+        S.decomposition.verticalCoisometry
+  rw [Matrix.reindexLinearEquiv_mul, Matrix.reindexLinearEquiv_mul]
+  exact hReconstruct
+
+/-- The matched one-site and two-site multiplicity matrices have the same
+trace \(m_\gamma\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2064. -/
+theorem relabeledTwoSiteMultiplicityTrace_eq_oneSite
+    (S : TwoSiteMultiplicitySpectrum H) (γ : Fin H.labelCount) :
+    verticalMultiplicityTrace S.relabeledTwoSiteWeight γ =
+      verticalMultiplicityTrace H.weight γ := by
+  have h := H.algebraClause.twoMultiplicityTrace_eq_traceScalar
+    S.toComparison γ
+  change (∑ r, S.decomposition.weight (S.relabel γ) r) =
+    ∑ q, H.weight γ q
+  exact h
+
+end BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseAmbientSectorMaps.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseAmbientSectorMaps.lean
@@ -1,0 +1,21 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorCoordinates
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseOneSiteAmbientSectorMaps
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseTwoSiteAmbientSectorMaps
+
+/-!
+# Ambient sector maps for the BNT algebra clause
+
+This module provides the relabelled two-site retained coordinates together
+with the one-site and two-site ambient sector retractions and normalized
+restorations used in Appendix C.4.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 2048--2083.
+-/

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseOneSiteAmbientSectorMaps.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseOneSiteAmbientSectorMaps.lean
@@ -1,0 +1,250 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClause
+import TNLean.MPS.MPDO.VerticalSectorAmbientMaps
+import TNLean.MPS.MPDO.VerticalSectorGeneration
+
+/-!
+# One-site ambient sector maps for the BNT algebra clause
+
+The chosen one-site vertical canonical decomposition determines a raw
+retraction from the ambient physical matrix algebra to its simple-sector
+algebra and a normalized restoration in the opposite direction.  The raw map
+compresses to the retained sectors and takes the multiplicity partial trace.
+The normalized map prepares the positive multiplicity matrix with unit trace
+and expands through the adjoint coisometry.
+
+The canonical full-matrix representatives are completely positive.  The
+normalized restoration preserves trace and is a right inverse of the raw
+retraction.  On the weighted vertical tensor letters, the two maps respectively
+extract and restore the factor given by the multiplicity trace.
+
+## Main definitions
+
+* `oneSiteAmbientSectorRetraction`
+* `oneSiteAmbientSectorRetractionExtension`
+* `oneSiteNormalizedAmbientSectorRestoration`
+* `oneSiteNormalizedAmbientSectorRestorationExtension`
+
+## Main results
+
+* `verticalSectorTrace_oneSiteAmbientSectorRetraction_le`
+* `oneSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP`
+* `oneSiteAmbientSectorRetraction_comp_normalizedRestoration`
+* `oneSiteAmbientSectorRetraction_verticalTensor`
+* `oneSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor`
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 2048--2051, 2065--2068, and 2081--2083.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-- The assembled one-site vertical tensor letter is the block diagonal whose
+sector blocks are \(\mu_\alpha \otimes M_\alpha\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2051. -/
+theorem verticalAssembledTensor_eq_verticalSectorBlockDiagonal
+    (H : BNTAlgebraTensorClause M) (v : Fin (D * D)) :
+    verticalAssembledTensor H.bondDim H.multiplicity H.weight H.tensor v =
+      verticalSectorBlockDiagonal H.bondDim H.multiplicity (fun α ↦
+        Matrix.kroneckerMap (· * ·) (Matrix.diagonal (H.weight α))
+          (H.tensor α v)) := by
+  simpa only [MPSTensor.contractBondMatrix_single_mod_div] using
+    contractBondMatrix_verticalAssembledTensor_eq_sectorBlockDiagonal
+      H.bondDim H.multiplicity H.weight H.tensor
+        (Matrix.single v.modNat v.divNat 1)
+
+/-- The one-site raw sector retraction \(R_1\) compresses to the retained
+vertical sectors and traces out their multiplicity coordinates.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068. -/
+def oneSiteAmbientSectorRetraction (H : BNTAlgebraTensorClause M) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] VerticalSectorAlgebra H.bondDim :=
+  verticalSectorAmbientRetraction H.bondDim H.multiplicity H.verticalCoisometry
+
+/-- The one-site raw retraction is the generic ambient retraction for the
+chosen one-site vertical decomposition.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068. -/
+@[simp]
+theorem oneSiteAmbientSectorRetraction_apply
+    (H : BNTAlgebraTensorClause M) (X : Matrix (Fin d) (Fin d) ℂ) :
+    H.oneSiteAmbientSectorRetraction X =
+      verticalSectorAmbientRetraction H.bondDim H.multiplicity
+        H.verticalCoisometry X := by
+  rfl
+
+/-- The canonical full-matrix representative of the one-site raw retraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068. -/
+def oneSiteAmbientSectorRetractionExtension (H : BNTAlgebraTensorClause M) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Σ α, Fin (H.bondDim α)) (Σ α, Fin (H.bondDim α)) ℂ :=
+  verticalSectorAmbientRetractionExtension H.bondDim H.multiplicity
+    H.verticalCoisometry
+
+/-- The canonical full-matrix representative of the one-site raw retraction
+is completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068. -/
+theorem oneSiteAmbientSectorRetractionExtension_isKrausCP
+    (H : BNTAlgebraTensorClause M) :
+    IsKrausCP H.oneSiteAmbientSectorRetractionExtension := by
+  exact verticalSectorAmbientRetractionExtension_isKrausCP
+    H.bondDim H.multiplicity H.verticalCoisometry
+
+/-- The normalized one-site restoration \(\widetilde R_1\) prepares the normalized
+multiplicity matrix in each sector and returns to the ambient space.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2081--2083. -/
+def oneSiteNormalizedAmbientSectorRestoration
+    (H : BNTAlgebraTensorClause M) :
+    VerticalSectorAlgebra H.bondDim →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ :=
+  normalizedVerticalSectorAmbientRestoration H.bondDim H.multiplicity H.weight
+    H.verticalCoisometry
+
+/-- The normalized one-site restoration is the generic ambient restoration
+for the chosen one-site vertical decomposition.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2081--2083. -/
+@[simp]
+theorem oneSiteNormalizedAmbientSectorRestoration_apply
+    (H : BNTAlgebraTensorClause M) (X : VerticalSectorAlgebra H.bondDim) :
+    H.oneSiteNormalizedAmbientSectorRestoration X =
+      normalizedVerticalSectorAmbientRestoration H.bondDim H.multiplicity
+        H.weight H.verticalCoisometry X := by
+  rfl
+
+/-- The canonical full-matrix representative of normalized one-site
+restoration.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2081--2083. -/
+def oneSiteNormalizedAmbientSectorRestorationExtension
+    (H : BNTAlgebraTensorClause M) :
+    Matrix (Σ α, Fin (H.bondDim α)) (Σ α, Fin (H.bondDim α)) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ :=
+  normalizedVerticalSectorAmbientRestorationExtension H.bondDim H.multiplicity
+    H.weight H.verticalCoisometry
+
+/-- The canonical full-matrix representative of normalized one-site
+restoration is completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2081--2083. -/
+theorem oneSiteNormalizedAmbientSectorRestorationExtension_isKrausCP
+    (H : BNTAlgebraTensorClause M) :
+    IsKrausCP H.oneSiteNormalizedAmbientSectorRestorationExtension := by
+  exact normalizedVerticalSectorAmbientRestorationExtension_isKrausCP
+    H.bondDim H.multiplicity H.weight H.multiplicity_pos H.weight_pos
+      H.verticalCoisometry
+
+/-- The total sector trace after the one-site raw retraction equals the trace
+of the coisometric compression to the retained vertical sectors.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068. -/
+theorem verticalSectorTrace_oneSiteAmbientSectorRetraction
+    (H : BNTAlgebraTensorClause M) (X : Matrix (Fin d) (Fin d) ℂ) :
+    verticalSectorTrace (H.oneSiteAmbientSectorRetraction X) =
+      Matrix.trace
+        (H.verticalCoisometry * X * H.verticalCoisometryᴴ) := by
+  rw [oneSiteAmbientSectorRetraction_apply,
+    verticalSectorAmbientRetraction_apply,
+    verticalSectorTrace_retainedVerticalSectorPartialTrace]
+
+/-- The one-site raw retraction does not increase the total trace of a
+positive ambient matrix.
+
+**Local fix (zero-sector complement):** The raw retraction may discard the
+orthogonal complement of the retained vertical sectors; hence it is only
+trace-nonincreasing on positive matrices.  This is documented in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068. -/
+theorem verticalSectorTrace_oneSiteAmbientSectorRetraction_le
+    (H : BNTAlgebraTensorClause M) (X : Matrix (Fin d) (Fin d) ℂ)
+    (hX : X.PosSemidef) :
+    verticalSectorTrace (H.oneSiteAmbientSectorRetraction X) ≤
+      Matrix.trace X := by
+  exact verticalSectorTrace_verticalSectorAmbientRetraction_le
+    H.bondDim H.multiplicity H.verticalCoisometry H.coisometry X hX
+
+/-- Normalized one-site restoration preserves the total sector trace.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2081--2083. -/
+theorem trace_oneSiteNormalizedAmbientSectorRestoration
+    (H : BNTAlgebraTensorClause M) (X : VerticalSectorAlgebra H.bondDim) :
+    Matrix.trace (H.oneSiteNormalizedAmbientSectorRestoration X) =
+      verticalSectorTrace X := by
+  exact trace_normalizedVerticalSectorAmbientRestoration
+    H.bondDim H.multiplicity H.weight H.multiplicity_pos H.weight_pos
+      H.verticalCoisometry H.coisometry X
+
+/-- The canonical full-matrix representative of normalized one-site
+restoration is completely positive and trace-preserving.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2081--2083. -/
+theorem oneSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP
+    (H : BNTAlgebraTensorClause M) :
+    IsKrausCPTP H.oneSiteNormalizedAmbientSectorRestorationExtension := by
+  exact normalizedVerticalSectorAmbientRestorationExtension_isKrausCPTP
+    H.bondDim H.multiplicity H.weight H.multiplicity_pos H.weight_pos
+      H.verticalCoisometry H.coisometry
+
+/-- One-site raw retraction after normalized restoration is the identity on
+the one-site sector algebra.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2081--2083. -/
+theorem oneSiteAmbientSectorRetraction_comp_normalizedRestoration
+    (H : BNTAlgebraTensorClause M) :
+    H.oneSiteAmbientSectorRetraction.comp
+        H.oneSiteNormalizedAmbientSectorRestoration = LinearMap.id := by
+  exact verticalSectorAmbientRetraction_comp_normalizedRestoration
+    H.bondDim H.multiplicity H.weight H.multiplicity_pos H.weight_pos
+      H.verticalCoisometry H.coisometry
+
+/-- On a vertical tensor letter, the one-site raw retraction returns each BNT
+sector multiplied by its multiplicity trace \(m_\alpha\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2051 and 2067--2068. -/
+theorem oneSiteAmbientSectorRetraction_verticalTensor
+    (H : BNTAlgebraTensorClause M) (v : Fin (D * D)) :
+    H.oneSiteAmbientSectorRetraction (verticalTensor M v) =
+      fun α ↦ verticalMultiplicityTrace H.weight α • H.tensor α v := by
+  rw [oneSiteAmbientSectorRetraction_apply,
+    verticalSectorAmbientRetraction_apply, H.forward v,
+    H.verticalAssembledTensor_eq_verticalSectorBlockDiagonal v]
+  exact retainedVerticalSectorPartialTrace_weightedBlockDiagonal
+    H.bondDim H.multiplicity H.weight (fun α ↦ H.tensor α v)
+
+/-- Normalized one-site restoration sends the multiplicity-trace-scaled BNT
+sectors back to the corresponding vertical tensor letter.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2051 and 2081--2083. -/
+theorem oneSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor
+    (H : BNTAlgebraTensorClause M) (v : Fin (D * D)) :
+    H.oneSiteNormalizedAmbientSectorRestoration
+        (fun α ↦ verticalMultiplicityTrace H.weight α • H.tensor α v) =
+      verticalTensor M v := by
+  rw [oneSiteNormalizedAmbientSectorRestoration_apply,
+    normalizedVerticalSectorAmbientRestoration_trace_smul
+      H.bondDim H.multiplicity H.weight H.multiplicity_pos H.weight_pos
+        H.verticalCoisometry]
+  rw [← H.verticalAssembledTensor_eq_verticalSectorBlockDiagonal v]
+  exact (H.reconstruction v).symm
+
+end BNTAlgebraTensorClause
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseTwoSiteAmbientSectorMaps.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseTwoSiteAmbientSectorMaps.lean
@@ -1,0 +1,450 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorCoordinates
+import TNLean.MPS.MPDO.VerticalSectorAmbientMaps
+
+/-!
+# Two-site ambient sector maps for the BNT algebra clause
+
+The relabelled two-site vertical canonical decomposition determines a raw
+retraction from the product-index physical matrix algebra to its matched
+simple-sector algebra and a normalized restoration in the opposite direction.
+The canonical equivalence between a pair of physical indices and one blocked
+index transports both maps between these two descriptions.
+
+The canonical full-matrix representatives are completely positive.  The raw
+retraction is trace-nonincreasing because the retained coisometry may omit a
+zero-sector complement, whereas the normalized restoration preserves trace and
+is a right inverse.  On weighted two-site vertical tensor letters, both maps
+use the multiplicity trace inherited from the matched one-site sector.
+
+## Main definitions
+
+* `twoSiteAmbientSectorRetraction`
+* `twoSiteAmbientSectorRetractionExtension`
+* `twoSiteNormalizedAmbientSectorRestoration`
+* `twoSiteNormalizedAmbientSectorRestorationExtension`
+
+## Main results
+
+* `verticalSectorTrace_twoSiteAmbientSectorRetraction_le`
+* `twoSiteNormalizedAmbientSectorRestoration_apply_explicit`
+* `twoSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP`
+* `twoSiteAmbientSectorRetraction_comp_normalizedRestoration`
+* `twoSiteAmbientSectorRetraction_verticalTensor`
+* `twoSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor`
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 2048--2079.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum
+
+variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-! ### Relabelled two-site ambient sector maps -/
+
+/-- The two-site raw sector retraction \(R_2\) first decodes the two physical
+indices, compresses to the retained relabelled sectors, and traces out their
+multiplicity coordinates.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2079. -/
+def twoSiteAmbientSectorRetraction (S : TwoSiteMultiplicitySpectrum H) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      S.RelabeledTwoSiteSectorAlgebra :=
+  (verticalSectorAmbientRetraction S.relabeledTwoSiteBondDim
+      S.relabeledTwoSiteMultiplicity S.relabeledTwoSiteCoisometry).comp
+    (Matrix.equivReindexMap (blockedIndexEquiv d).symm)
+
+/-- The two-site raw retraction is the generic ambient retraction after the
+canonical identification of a pair of physical indices with one blocked
+index.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2079. -/
+@[simp]
+theorem twoSiteAmbientSectorRetraction_apply
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
+    S.twoSiteAmbientSectorRetraction X =
+      verticalSectorAmbientRetraction S.relabeledTwoSiteBondDim
+        S.relabeledTwoSiteMultiplicity S.relabeledTwoSiteCoisometry
+          (Matrix.equivReindexMap (blockedIndexEquiv d).symm X) := by
+  rfl
+
+/-- The canonical full-matrix representative of the two-site raw sector
+retraction.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2079. -/
+def twoSiteAmbientSectorRetractionExtension
+    (S : TwoSiteMultiplicitySpectrum H) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Σ γ, Fin (S.relabeledTwoSiteBondDim γ))
+        (Σ γ, Fin (S.relabeledTwoSiteBondDim γ)) ℂ :=
+  (verticalSectorAmbientRetractionExtension S.relabeledTwoSiteBondDim
+      S.relabeledTwoSiteMultiplicity S.relabeledTwoSiteCoisometry).comp
+    (Matrix.equivReindexMap (blockedIndexEquiv d).symm)
+
+/-- The canonical full-matrix representative of the two-site raw retraction
+is completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2079. -/
+theorem twoSiteAmbientSectorRetractionExtension_isKrausCP
+    (S : TwoSiteMultiplicitySpectrum H) :
+    IsKrausCP S.twoSiteAmbientSectorRetractionExtension := by
+  apply isKrausCP_comp
+  · exact (Matrix.equivReindexMap_isKrausCPTP
+      (blockedIndexEquiv d).symm).isKrausCP
+  · exact verticalSectorAmbientRetractionExtension_isKrausCP
+      S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+        S.relabeledTwoSiteCoisometry
+
+/-- The total sector trace after the two-site raw retraction equals the trace
+of the corresponding coisometric compression in the blocked physical
+coordinate.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2079. -/
+theorem verticalSectorTrace_twoSiteAmbientSectorRetraction
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
+    verticalSectorTrace (S.twoSiteAmbientSectorRetraction X) =
+      Matrix.trace (S.relabeledTwoSiteCoisometry *
+        Matrix.equivReindexMap (blockedIndexEquiv d).symm X *
+        S.relabeledTwoSiteCoisometryᴴ) := by
+  rw [twoSiteAmbientSectorRetraction_apply,
+    verticalSectorAmbientRetraction_apply,
+    verticalSectorTrace_retainedVerticalSectorPartialTrace]
+
+/-- The two-site raw retraction does not increase the total trace of a
+positive ambient matrix.
+
+**Local fix (zero complement):** The raw retraction may discard the
+orthogonal complement of the retained two-site sectors; hence it is only
+trace-nonincreasing on positive matrices.  This is documented in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2079. -/
+theorem verticalSectorTrace_twoSiteAmbientSectorRetraction_le
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ)
+    (hX : X.PosSemidef) :
+    verticalSectorTrace (S.twoSiteAmbientSectorRetraction X) ≤
+      Matrix.trace X := by
+  calc
+    verticalSectorTrace (S.twoSiteAmbientSectorRetraction X) ≤
+        Matrix.trace (Matrix.equivReindexMap (blockedIndexEquiv d).symm X) :=
+      verticalSectorTrace_verticalSectorAmbientRetraction_le
+        S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+          S.relabeledTwoSiteCoisometry
+          S.relabeledTwoSiteCoisometry_coisometry _
+          ((Matrix.equivReindexMap_isKrausCPTP
+            (blockedIndexEquiv d).symm).map_posSemidef hX)
+    _ = Matrix.trace X :=
+      (Matrix.equivReindexMap_isKrausCPTP
+        (blockedIndexEquiv d).symm).trace_map X
+
+/-- The normalized two-site restoration \(\widetilde R_2\) prepares each
+matched two-site multiplicity matrix with unit trace, returns to the blocked
+ambient coordinate, and decodes its physical index.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+def twoSiteNormalizedAmbientSectorRestoration
+    (S : TwoSiteMultiplicitySpectrum H) :
+    S.RelabeledTwoSiteSectorAlgebra →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  (Matrix.equivReindexMap (blockedIndexEquiv d)).comp
+    (normalizedVerticalSectorAmbientRestoration S.relabeledTwoSiteBondDim
+      S.relabeledTwoSiteMultiplicity S.relabeledTwoSiteWeight
+        S.relabeledTwoSiteCoisometry)
+
+/-- The normalized two-site restoration is the generic restoration followed
+by the canonical decoding of the blocked physical index.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+@[simp]
+theorem twoSiteNormalizedAmbientSectorRestoration_apply
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : S.RelabeledTwoSiteSectorAlgebra) :
+    S.twoSiteNormalizedAmbientSectorRestoration X =
+      Matrix.equivReindexMap (blockedIndexEquiv d)
+        (normalizedVerticalSectorAmbientRestoration
+          S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+            S.relabeledTwoSiteWeight S.relabeledTwoSiteCoisometry X) := by
+  rfl
+
+/-- In each matched two-site sector, the normalized multiplicity matrix is
+divided by the common one-site multiplicity trace \(m_\gamma\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+theorem normalizedRelabeledTwoSiteEmbedding_apply_oneSiteTrace
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : S.RelabeledTwoSiteSectorAlgebra) (γ : Fin H.labelCount) :
+    normalizedVerticalSectorEmbedding S.relabeledTwoSiteBondDim
+        S.relabeledTwoSiteMultiplicity S.relabeledTwoSiteWeight X γ =
+      Matrix.kroneckerMap (· * ·)
+        (Matrix.diagonal (fun q ↦
+          S.relabeledTwoSiteWeight γ q /
+            verticalMultiplicityTrace H.weight γ)) (X γ) := by
+  rw [normalizedVerticalSectorEmbedding_apply,
+    S.relabeledTwoSiteMultiplicityTrace_eq_oneSite]
+  ext ⟨q, i⟩ ⟨r, j⟩
+  simp only [Matrix.smul_apply, Matrix.kroneckerMap_apply]
+  by_cases hqr : q = r
+  · subst r
+    simp [div_eq_mul_inv]
+    ring
+  · simp [hqr]
+
+/-- The normalized two-site restoration has the source formula with
+\(\nu_{\sigma(\gamma)}/m_\gamma\) on the matched sector block.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+theorem twoSiteNormalizedAmbientSectorRestoration_apply_explicit
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : S.RelabeledTwoSiteSectorAlgebra) :
+    S.twoSiteNormalizedAmbientSectorRestoration X =
+      Matrix.equivReindexMap (blockedIndexEquiv d)
+        (S.relabeledTwoSiteCoisometryᴴ *
+          verticalSectorBlockDiagonal S.relabeledTwoSiteBondDim
+            S.relabeledTwoSiteMultiplicity (fun γ ↦
+              Matrix.kroneckerMap (· * ·)
+                (Matrix.diagonal (fun q ↦
+                  S.relabeledTwoSiteWeight γ q /
+                    verticalMultiplicityTrace H.weight γ)) (X γ)) *
+          S.relabeledTwoSiteCoisometry) := by
+  have hNormalized :
+      normalizedRetainedVerticalSectorEmbedding S.relabeledTwoSiteBondDim
+          S.relabeledTwoSiteMultiplicity S.relabeledTwoSiteWeight X =
+        verticalSectorBlockDiagonal S.relabeledTwoSiteBondDim
+          S.relabeledTwoSiteMultiplicity (fun γ ↦
+            Matrix.kroneckerMap (· * ·)
+              (Matrix.diagonal (fun q ↦
+                S.relabeledTwoSiteWeight γ q /
+                  verticalMultiplicityTrace H.weight γ)) (X γ)) := by
+    simp only [normalizedRetainedVerticalSectorEmbedding,
+      LinearMap.comp_apply]
+    apply congrArg (verticalSectorBlockDiagonal
+      S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity)
+    funext γ
+    exact S.normalizedRelabeledTwoSiteEmbedding_apply_oneSiteTrace X γ
+  rw [twoSiteNormalizedAmbientSectorRestoration_apply,
+    normalizedVerticalSectorAmbientRestoration_apply, hNormalized]
+
+/-- The canonical full-matrix representative of the normalized two-site
+restoration.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+def twoSiteNormalizedAmbientSectorRestorationExtension
+    (S : TwoSiteMultiplicitySpectrum H) :
+    Matrix (Σ γ, Fin (S.relabeledTwoSiteBondDim γ))
+        (Σ γ, Fin (S.relabeledTwoSiteBondDim γ)) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  (Matrix.equivReindexMap (blockedIndexEquiv d)).comp
+    (normalizedVerticalSectorAmbientRestorationExtension
+      S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+        S.relabeledTwoSiteWeight S.relabeledTwoSiteCoisometry)
+
+/-- The canonical full-matrix representative of normalized two-site
+restoration is completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+theorem twoSiteNormalizedAmbientSectorRestorationExtension_isKrausCP
+    (S : TwoSiteMultiplicitySpectrum H) :
+    IsKrausCP S.twoSiteNormalizedAmbientSectorRestorationExtension := by
+  apply isKrausCP_comp
+  · exact normalizedVerticalSectorAmbientRestorationExtension_isKrausCP
+      S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+        S.relabeledTwoSiteWeight
+        (fun γ ↦ S.decomposition.multiplicity_pos (S.relabel γ))
+        (fun γ q ↦ S.decomposition.weight_pos (S.relabel γ) q)
+        S.relabeledTwoSiteCoisometry
+  · exact (Matrix.equivReindexMap_isKrausCPTP
+      (blockedIndexEquiv d)).isKrausCP
+
+/-- Normalized two-site restoration preserves the total sector trace.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+theorem trace_twoSiteNormalizedAmbientSectorRestoration
+    (S : TwoSiteMultiplicitySpectrum H)
+    (X : S.RelabeledTwoSiteSectorAlgebra) :
+    Matrix.trace (S.twoSiteNormalizedAmbientSectorRestoration X) =
+      verticalSectorTrace X := by
+  rw [twoSiteNormalizedAmbientSectorRestoration_apply,
+    (Matrix.equivReindexMap_isKrausCPTP
+      (blockedIndexEquiv d)).trace_map]
+  exact trace_normalizedVerticalSectorAmbientRestoration
+    S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+      S.relabeledTwoSiteWeight
+      (fun γ ↦ S.decomposition.multiplicity_pos (S.relabel γ))
+      (fun γ q ↦ S.decomposition.weight_pos (S.relabel γ) q)
+      S.relabeledTwoSiteCoisometry
+      S.relabeledTwoSiteCoisometry_coisometry X
+
+/-- The canonical full-matrix representative of normalized two-site
+restoration is completely positive and trace-preserving.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071. -/
+theorem twoSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP
+    (S : TwoSiteMultiplicitySpectrum H) :
+    IsKrausCPTP S.twoSiteNormalizedAmbientSectorRestorationExtension := by
+  exact isKrausCPTP_comp
+    (normalizedVerticalSectorAmbientRestorationExtension_isKrausCPTP
+      S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+        S.relabeledTwoSiteWeight
+        (fun γ ↦ S.decomposition.multiplicity_pos (S.relabel γ))
+        (fun γ q ↦ S.decomposition.weight_pos (S.relabel γ) q)
+        S.relabeledTwoSiteCoisometry
+        S.relabeledTwoSiteCoisometry_coisometry)
+    (Matrix.equivReindexMap_isKrausCPTP (blockedIndexEquiv d))
+
+/-- Two-site raw retraction after normalized restoration is the identity on
+the relabelled two-site sector algebra.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2058--2071 and 2078--2079. -/
+theorem twoSiteAmbientSectorRetraction_comp_normalizedRestoration
+    (S : TwoSiteMultiplicitySpectrum H) :
+    S.twoSiteAmbientSectorRetraction.comp
+        S.twoSiteNormalizedAmbientSectorRestoration = LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  simpa [twoSiteAmbientSectorRetraction,
+    twoSiteNormalizedAmbientSectorRestoration,
+    Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv] using
+      LinearMap.congr_fun
+        (verticalSectorAmbientRetraction_comp_normalizedRestoration
+          S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+            S.relabeledTwoSiteWeight
+            (fun γ ↦ S.decomposition.multiplicity_pos (S.relabel γ))
+            (fun γ q ↦ S.decomposition.weight_pos (S.relabel γ) q)
+            S.relabeledTwoSiteCoisometry
+            S.relabeledTwoSiteCoisometry_coisometry) X
+
+/-- Each assembled two-site vertical tensor letter is the block diagonal of
+its native weighted sectors.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2064. -/
+theorem twoSiteVerticalAssembledTensor_eq_verticalSectorBlockDiagonal
+    (S : TwoSiteMultiplicitySpectrum H) (v : Fin (D * D)) :
+    verticalAssembledTensor S.decomposition.bondDim
+        S.decomposition.multiplicity S.decomposition.weight
+        S.decomposition.tensor v =
+      verticalSectorBlockDiagonal S.decomposition.bondDim
+        S.decomposition.multiplicity (fun β ↦
+          Matrix.kroneckerMap (· * ·)
+            (Matrix.diagonal (S.decomposition.weight β))
+            (S.decomposition.tensor β v)) := by
+  simpa only [MPSTensor.contractBondMatrix_single_mod_div] using
+    contractBondMatrix_verticalAssembledTensor_eq_sectorBlockDiagonal
+      S.decomposition.bondDim S.decomposition.multiplicity
+        S.decomposition.weight S.decomposition.tensor
+        (Matrix.single v.modNat v.divNat 1)
+
+/-- Compressing a two-site vertical tensor letter by the relabelled
+coisometry gives the matched weighted sector blocks.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2064 and 2078--2079. -/
+theorem relabeledTwoSiteCoisometry_forward_verticalTensor
+    (S : TwoSiteMultiplicitySpectrum H) (v : Fin (D * D)) :
+    S.relabeledTwoSiteCoisometry * verticalTensor (blockTwo M) v *
+        S.relabeledTwoSiteCoisometryᴴ =
+      verticalSectorBlockDiagonal S.relabeledTwoSiteBondDim
+        S.relabeledTwoSiteMultiplicity (fun γ ↦
+          Matrix.kroneckerMap (· * ·)
+            (Matrix.diagonal (S.relabeledTwoSiteWeight γ))
+            (S.decomposition.tensor (S.relabel γ) v)) := by
+  apply S.relabeledTwoSiteCoisometry_forward
+    (X := verticalTensor (blockTwo M) v)
+    (Y := fun β ↦ Matrix.kroneckerMap (· * ·)
+      (Matrix.diagonal (S.decomposition.weight β))
+      (S.decomposition.tensor β v))
+  rw [S.decomposition.forward v,
+    S.twoSiteVerticalAssembledTensor_eq_verticalSectorBlockDiagonal v]
+
+/-- Expanding the matched weighted sector blocks reconstructs the two-site
+vertical tensor letter.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2064 and 2070--2071. -/
+theorem relabeledTwoSiteCoisometry_reconstruction_verticalTensor
+    (S : TwoSiteMultiplicitySpectrum H) (v : Fin (D * D)) :
+    verticalTensor (blockTwo M) v = S.relabeledTwoSiteCoisometryᴴ *
+      verticalSectorBlockDiagonal S.relabeledTwoSiteBondDim
+        S.relabeledTwoSiteMultiplicity (fun γ ↦
+          Matrix.kroneckerMap (· * ·)
+            (Matrix.diagonal (S.relabeledTwoSiteWeight γ))
+            (S.decomposition.tensor (S.relabel γ) v)) *
+      S.relabeledTwoSiteCoisometry := by
+  apply S.relabeledTwoSiteCoisometry_reconstruction
+    (X := verticalTensor (blockTwo M) v)
+    (Y := fun β ↦ Matrix.kroneckerMap (· * ·)
+      (Matrix.diagonal (S.decomposition.weight β))
+      (S.decomposition.tensor β v))
+  rw [S.decomposition.reconstruction v,
+    S.twoSiteVerticalAssembledTensor_eq_verticalSectorBlockDiagonal v]
+
+/-- On a two-site vertical tensor letter, the raw retraction returns each
+matched BNT sector multiplied by the one-site multiplicity trace
+\(m_\gamma\).
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2064 and 2078--2079. -/
+theorem twoSiteAmbientSectorRetraction_verticalTensor
+    (S : TwoSiteMultiplicitySpectrum H) (v : Fin (D * D)) :
+    S.twoSiteAmbientSectorRetraction
+        (Matrix.equivReindexMap (blockedIndexEquiv d)
+          (verticalTensor (blockTwo M) v)) =
+      fun γ ↦ verticalMultiplicityTrace H.weight γ •
+        S.decomposition.tensor (S.relabel γ) v := by
+  rw [twoSiteAmbientSectorRetraction_apply]
+  have hReindex :
+      Matrix.equivReindexMap (blockedIndexEquiv d).symm
+          (Matrix.equivReindexMap (blockedIndexEquiv d)
+            (verticalTensor (blockTwo M) v)) =
+        verticalTensor (blockTwo M) v := by
+    simp [Matrix.equivReindexMap, Matrix.coe_reindexLinearEquiv]
+  rw [hReindex, verticalSectorAmbientRetraction_apply,
+    S.relabeledTwoSiteCoisometry_forward_verticalTensor v,
+    retainedVerticalSectorPartialTrace_weightedBlockDiagonal]
+  funext γ
+  rw [S.relabeledTwoSiteMultiplicityTrace_eq_oneSite]
+
+/-- Normalized two-site restoration sends the one-site-trace-scaled matched
+BNT sectors back to the decoded two-site vertical tensor letter.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2048--2064 and 2070--2071. -/
+theorem twoSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor
+    (S : TwoSiteMultiplicitySpectrum H) (v : Fin (D * D)) :
+    S.twoSiteNormalizedAmbientSectorRestoration
+        (fun γ ↦ verticalMultiplicityTrace H.weight γ •
+          S.decomposition.tensor (S.relabel γ) v) =
+      Matrix.equivReindexMap (blockedIndexEquiv d)
+        (verticalTensor (blockTwo M) v) := by
+  rw [twoSiteNormalizedAmbientSectorRestoration_apply]
+  apply congrArg (Matrix.equivReindexMap (blockedIndexEquiv d))
+  have hScaled :
+      (fun γ ↦ verticalMultiplicityTrace H.weight γ •
+          S.decomposition.tensor (S.relabel γ) v) =
+        (fun γ ↦ verticalMultiplicityTrace S.relabeledTwoSiteWeight γ •
+          S.decomposition.tensor (S.relabel γ) v) := by
+    funext γ
+    rw [S.relabeledTwoSiteMultiplicityTrace_eq_oneSite]
+  rw [hScaled,
+    normalizedVerticalSectorAmbientRestoration_trace_smul
+      S.relabeledTwoSiteBondDim S.relabeledTwoSiteMultiplicity
+        S.relabeledTwoSiteWeight
+        (fun γ ↦ S.decomposition.multiplicity_pos (S.relabel γ))
+        (fun γ q ↦ S.decomposition.weight_pos (S.relabel γ) q)
+        S.relabeledTwoSiteCoisometry]
+  exact (S.relabeledTwoSiteCoisometry_reconstruction_verticalTensor v).symm
+
+end BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/VerticalSectorAmbientMaps.lean
+++ b/TNLean/MPS/MPDO/VerticalSectorAmbientMaps.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.VerticalSectorTraceLoss
+
+/-!
+# Ambient vertical-sector retractions and restorations
+
+Let \(U\) be the coisometry from an ambient physical space onto the retained
+vertical sectors.  The raw retraction compresses by \(U\), extracts the sector
+diagonal blocks, and takes the partial trace over each multiplicity space.  The
+normalized restoration prepares the normalized positive multiplicity matrix in
+each sector and expands the resulting block-diagonal matrix by \(U^\dagger\).
+
+The canonical full-matrix representatives are completely positive.  The raw
+retraction is trace-nonincreasing on positive matrices because the orthogonal
+complement of the retained sectors may be nonzero.  The normalized restoration
+preserves the total sector trace and is a right inverse of the raw retraction.
+
+## Main definitions
+
+* `verticalSectorAmbientRetraction`
+* `normalizedVerticalSectorAmbientRestoration`
+* `verticalSectorAmbientRetractionExtension`
+* `normalizedVerticalSectorAmbientRestorationExtension`
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Appendix C.4, lines 2065--2083.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {g d : ℕ}
+
+/-- Compress an ambient matrix to the retained vertical sectors and trace out
+each multiplicity coordinate.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+def verticalSectorAmbientRetraction
+    (dim mult : Fin g → ℕ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] VerticalSectorAlgebra dim :=
+  (retainedVerticalSectorPartialTrace dim mult).comp (singleKrausMap U)
+
+/-- The ambient retraction is retained-sector partial trace after coisometric
+compression.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+@[simp]
+theorem verticalSectorAmbientRetraction_apply
+    (dim mult : Fin g → ℕ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) (X : Matrix (Fin d) (Fin d) ℂ) :
+    verticalSectorAmbientRetraction dim mult U X =
+      retainedVerticalSectorPartialTrace dim mult (U * X * Uᴴ) := by
+  rfl
+
+/-- In a fixed sector, the ambient retraction is the multiplicity partial
+trace of the corresponding diagonal block of the compressed matrix.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+theorem verticalSectorAmbientRetraction_apply_sector
+    (dim mult : Fin g → ℕ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) (X : Matrix (Fin d) (Fin d) ℂ) (α : Fin g) :
+    verticalSectorAmbientRetraction dim mult U X α =
+      Matrix.traceLeft ((U * X * Uᴴ).submatrix
+        (fun i ↦ verticalSectorFinEquiv dim mult ⟨α, i⟩)
+        (fun i ↦ verticalSectorFinEquiv dim mult ⟨α, i⟩)) := by
+  rfl
+
+/-- The canonical full-matrix representative of the ambient retraction, with
+the output sector family placed on the block diagonal.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+def verticalSectorAmbientRetractionExtension
+    (dim mult : Fin g → ℕ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Σ α, Fin (dim α)) (Σ α, Fin (dim α)) ℂ :=
+  Matrix.directSumDiagonalEmbedding.comp
+    (verticalSectorAmbientRetraction dim mult U)
+
+/-- The full-matrix representative of the ambient retraction factors as
+coisometric compression, retained-coordinate reindexing, and the canonical
+extension of multiplicity partial trace.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+theorem verticalSectorAmbientRetractionExtension_factorization
+    (dim mult : Fin g → ℕ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    verticalSectorAmbientRetractionExtension dim mult U =
+      (Matrix.directSumMapExtension (verticalSectorPartialTrace dim mult)).comp
+        ((Matrix.equivReindexMap (verticalSectorFinEquiv dim mult).symm).comp
+          (singleKrausMap U)) := by
+  apply LinearMap.ext
+  intro X
+  rfl
+
+/-- The canonical full-matrix representative of the ambient retraction is
+completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+theorem verticalSectorAmbientRetractionExtension_isKrausCP
+    (dim mult : Fin g → ℕ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    IsKrausCP (verticalSectorAmbientRetractionExtension dim mult U) := by
+  rw [verticalSectorAmbientRetractionExtension_factorization]
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · exact singleKrausMap_isKrausCP U
+    · exact (Matrix.equivReindexMap_isKrausCPTP
+        (verticalSectorFinEquiv dim mult).symm).isKrausCP
+  · exact verticalSectorPartialTrace_isKrausDirectSumMap dim mult
+
+/-- Restore a sector family to the ambient space by preparing the normalized
+positive multiplicity matrices and expanding along the adjoint coisometry.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+def normalizedVerticalSectorAmbientRestoration
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    VerticalSectorAlgebra dim →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ :=
+  (singleKrausMap Uᴴ).comp
+    (normalizedRetainedVerticalSectorEmbedding dim mult weight)
+
+/-- The normalized restoration is the expansion of the retained normalized
+sector embedding along the adjoint coisometry.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+@[simp]
+theorem normalizedVerticalSectorAmbientRestoration_apply
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) (X : VerticalSectorAlgebra dim) :
+    normalizedVerticalSectorAmbientRestoration dim mult weight U X =
+      Uᴴ * normalizedRetainedVerticalSectorEmbedding dim mult weight X * U := by
+  simp [normalizedVerticalSectorAmbientRestoration]
+
+/-- The canonical full-matrix representative of the normalized restoration,
+with the input restricted to its diagonal sector blocks.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+def normalizedVerticalSectorAmbientRestorationExtension
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    Matrix (Σ α, Fin (dim α)) (Σ α, Fin (dim α)) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ :=
+  (normalizedVerticalSectorAmbientRestoration dim mult weight U).comp
+    Matrix.directSumDiagonalCompression
+
+/-- The full-matrix representative of normalized restoration factors as the
+canonical normalized preparation, retained-coordinate reindexing, and expansion
+along the adjoint coisometry.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+theorem normalizedVerticalSectorAmbientRestorationExtension_factorization
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    normalizedVerticalSectorAmbientRestorationExtension dim mult weight U =
+      (singleKrausMap Uᴴ).comp
+        ((Matrix.equivReindexMap (verticalSectorFinEquiv dim mult)).comp
+          (Matrix.directSumMapExtension
+            (normalizedVerticalSectorEmbedding dim mult weight))) := by
+  apply LinearMap.ext
+  intro X
+  rfl
+
+/-- The canonical full-matrix representative of normalized restoration is
+completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+theorem normalizedVerticalSectorAmbientRestorationExtension_isKrausCP
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) :
+    IsKrausCP
+      (normalizedVerticalSectorAmbientRestorationExtension dim mult weight U) := by
+  rw [normalizedVerticalSectorAmbientRestorationExtension_factorization]
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · exact normalizedVerticalSectorEmbedding_isKrausDirectSumMap
+        dim mult weight hMult hWeight
+    · exact (Matrix.equivReindexMap_isKrausCPTP
+        (verticalSectorFinEquiv dim mult)).isKrausCP
+  · exact singleKrausMap_isKrausCP Uᴴ
+
+/-- The raw ambient retraction does not increase the total trace of a positive
+matrix.
+
+**Local fix (zero-sector complement):** The source formula may discard the
+orthogonal complement of the retained sectors, so the conclusion is an
+inequality rather than ambient trace preservation.  This is documented in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+theorem verticalSectorTrace_verticalSectorAmbientRetraction_le
+    (dim mult : Fin g → ℕ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1) (X : Matrix (Fin d) (Fin d) ℂ) (hX : X.PosSemidef) :
+    verticalSectorTrace (verticalSectorAmbientRetraction dim mult U X) ≤
+      Matrix.trace X := by
+  rw [verticalSectorAmbientRetraction_apply,
+    verticalSectorTrace_retainedVerticalSectorPartialTrace]
+  exact hX.trace_mul_mul_conjTranspose_le_of_mul_conjTranspose_eq_one U hU
+
+/-- Normalized restoration preserves the total trace of a sector family.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+theorem trace_normalizedVerticalSectorAmbientRestoration
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1) (X : VerticalSectorAlgebra dim) :
+    Matrix.trace
+        (normalizedVerticalSectorAmbientRestoration dim mult weight U X) =
+      verticalSectorTrace X := by
+  rw [normalizedVerticalSectorAmbientRestoration_apply,
+    Matrix.trace_conjTranspose_mul_mul_of_mul_conjTranspose_eq_one U hU,
+    trace_normalizedRetainedVerticalSectorEmbedding dim mult weight
+      hMult hWeight X]
+
+/-- The canonical full-matrix representative of normalized restoration is
+trace-preserving and completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+theorem normalizedVerticalSectorAmbientRestorationExtension_isKrausCPTP
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1) :
+    IsKrausCPTP
+      (normalizedVerticalSectorAmbientRestorationExtension dim mult weight U) := by
+  apply isKrausCPTP_of_isKrausCP_trace_preserving
+    (normalizedVerticalSectorAmbientRestorationExtension_isKrausCP
+      dim mult weight hMult hWeight U)
+  intro X
+  simp only [normalizedVerticalSectorAmbientRestorationExtension,
+    LinearMap.comp_apply]
+  rw [trace_normalizedVerticalSectorAmbientRestoration
+    dim mult weight hMult hWeight U hU]
+  exact Matrix.sum_trace_directSumDiagonalCompression X
+
+/-- Ambient retraction after normalized restoration is the identity on the
+vertical-sector algebra.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068, 2070--2071,
+2078--2079, and 2081--2083. -/
+theorem verticalSectorAmbientRetraction_comp_normalizedRestoration
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1) :
+    (verticalSectorAmbientRetraction dim mult U).comp
+        (normalizedVerticalSectorAmbientRestoration dim mult weight U) =
+      LinearMap.id := by
+  apply LinearMap.ext
+  intro X
+  simp only [LinearMap.comp_apply, verticalSectorAmbientRetraction_apply,
+    normalizedVerticalSectorAmbientRestoration_apply, LinearMap.id_apply]
+  simp only [← Matrix.mul_assoc, hU, Matrix.one_mul]
+  rw [Matrix.mul_assoc, hU, Matrix.mul_one]
+  simpa only [LinearMap.comp_apply, LinearMap.id_apply] using
+    LinearMap.congr_fun
+      (retainedVerticalSectorPartialTrace_comp_normalizedEmbedding
+        dim mult weight hMult hWeight) X
+
+/-- Restoring a family scaled by its multiplicity traces gives the unnormalized
+weighted sector matrix expanded into the ambient space.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2071 and 2081--2083. -/
+theorem normalizedVerticalSectorAmbientRestoration_trace_smul
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (hMult : ∀ α, 0 < mult α)
+    (hWeight : ∀ α q, (0 : ℂ) < weight α q)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ) (X : VerticalSectorAlgebra dim) :
+    normalizedVerticalSectorAmbientRestoration dim mult weight U
+        (fun α ↦ verticalMultiplicityTrace weight α • X α) =
+      Uᴴ * verticalSectorBlockDiagonal dim mult (fun α ↦
+        Matrix.kroneckerMap (· * ·) (Matrix.diagonal (weight α)) (X α)) * U := by
+  rw [normalizedVerticalSectorAmbientRestoration_apply,
+    normalizedRetainedVerticalSectorEmbedding_trace_smul
+      dim mult weight hMult hWeight X]
+
+/-- Retracting an ambient expansion of an unnormalized weighted sector matrix
+returns the sector family scaled by its multiplicity traces.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2067--2068 and 2078--2079. -/
+theorem verticalSectorAmbientRetraction_weightedBlockDiagonal
+    (dim mult : Fin g → ℕ)
+    (weight : (α : Fin g) → Fin (mult α) → ℂ)
+    (U : Matrix
+      (Fin (∑ q : Fin (∑ α : Fin g, mult α), verticalCopyDim dim mult q))
+      (Fin d) ℂ)
+    (hU : U * Uᴴ = 1) (X : VerticalSectorAlgebra dim) :
+    verticalSectorAmbientRetraction dim mult U
+        (Uᴴ * verticalSectorBlockDiagonal dim mult (fun α ↦
+          Matrix.kroneckerMap (· * ·) (Matrix.diagonal (weight α)) (X α)) * U) =
+      fun α ↦ verticalMultiplicityTrace weight α • X α := by
+  rw [verticalSectorAmbientRetraction_apply]
+  simp only [← Matrix.mul_assoc, hU, Matrix.one_mul]
+  rw [Matrix.mul_assoc, hU, Matrix.mul_one]
+  exact retainedVerticalSectorPartialTrace_weightedBlockDiagonal
+    dim mult weight X
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
@@ -8,3 +8,4 @@
 \input{chapter/ch21_mpdo_rfp_bnt_theorem_data}
 \input{chapter/ch21_mpdo_rfp_bnt_witnesses}
 \input{chapter/ch21_mpdo_rfp_bnt_direct_sum_unitary_conjugations}
+\input{chapter/ch21_mpdo_rfp_bnt_ambient_sector_maps}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_ambient_sector_maps.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_ambient_sector_maps.tex
@@ -1,0 +1,373 @@
+\subsection{Ambient sector retractions and normalized embeddings}
+
+\begin{definition}[Ambient sector retractions and normalized embeddings]
+    \label{def:mpdo_bnt_ambient_sector_maps}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteAmbientSectorRetraction}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteAmbientSectorRetraction_apply}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteNormalizedAmbientSectorRestoration}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteNormalizedAmbientSectorRestoration_apply}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteAmbientSectorRetraction}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteAmbientSectorRetraction_apply}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteNormalizedAmbientSectorRestoration}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteNormalizedAmbientSectorRestoration_apply}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteNormalizedAmbientSectorRestoration_apply_explicit}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        relabeledTwoSiteMultiplicityTrace_eq_oneSite}
+    \lean{MPOTensor.verticalSectorAmbientRetraction}
+    \lean{MPOTensor.verticalSectorAmbientRetraction_apply}
+    \lean{MPOTensor.verticalSectorAmbientRetraction_apply_sector}
+    \lean{MPOTensor.normalizedVerticalSectorAmbientRestoration}
+    \lean{MPOTensor.normalizedVerticalSectorAmbientRestoration_apply}
+    \leanok
+    \uses{def:mpdo_bnt_two_site_multiplicity_spectrum,
+        def:mpdo_normalized_vertical_sector_maps,
+        def:mpdo_retained_vertical_sector_coordinates,
+        def:mpdo_two_site_blocking,
+        thm:mpdo_bnt_multiplicity_trace_normalization}
+    Let
+    \begin{align}
+        \mathcal A_1
+        &=\bigoplus_\gamma \MN{d_\gamma},
+        &
+        \mathcal A_2^\sigma
+        &=\bigoplus_\gamma \MN{\widetilde d_{\sigma(\gamma)}}
+        \notag
+    \end{align}
+    be the one-site sector algebra and the relabelled two-site sector algebra.
+    Their retained physical spaces are
+    \begin{align}
+        \mathcal K_1
+        &=\bigoplus_\gamma
+          \left(\C^{r_\gamma}\otimes\C^{d_\gamma}\right),
+        &
+        \mathcal K_2^\sigma
+        &=\bigoplus_\gamma
+          \left(\C^{\widetilde r_{\sigma(\gamma)}}
+            \otimes\C^{\widetilde d_{\sigma(\gamma)}}\right).
+        \notag
+    \end{align}
+    Let $W_1\colon\C^d\to\mathcal K_1$ and
+    $W_2\colon\C^{d^2}\to\mathcal K_2^\sigma$ be the corresponding
+    coisometries, so that $W_i W_i^\dagger=I$.  Write $\Pi_{1,\gamma}$ for
+    the projection onto the $\gamma$-summand of $\mathcal K_1$ and
+    $\Pi_{2,\gamma}^\sigma$ for the projection onto the
+    $\sigma(\gamma)$-summand of $\mathcal K_2^\sigma$.  Let
+    \begin{align}
+        \kappa_\ast\colon\MN{d^2}
+        &\longrightarrow \MN{d}\otimes\MN{d}
+        \notag
+    \end{align}
+    be the canonical relabelling of a pair of physical indices.  For the
+    positive diagonal multiplicity matrices $\mu_\gamma$ and
+    $\nu_{\sigma(\gamma)}$, set
+    \begin{align}
+        m_\gamma
+        &=\tr(\mu_\gamma)
+         =\tr(\nu_{\sigma(\gamma)}).
+        \label{eq:mpdo_bnt_ambient_sector_trace_weights}
+    \end{align}
+    Define
+    \begin{align}
+        R_1\colon\MN{d}&\longrightarrow\mathcal A_1,
+        &
+        [R_1(X)]_\gamma
+        &=\tr_{\mathrm{mult}}
+          \left(\Pi_{1,\gamma}W_1XW_1^\dagger\Pi_{1,\gamma}\right),
+        \label{eq:mpdo_bnt_ambient_sector_R1}
+        \\
+        R_2\colon\MN{d}\otimes\MN{d}&\longrightarrow\mathcal A_2^\sigma,
+        &
+        [R_2(Y)]_\gamma
+        &=\tr_{\mathrm{mult}}
+          \left(\Pi_{2,\gamma}^\sigma W_2\kappa_\ast^{-1}(Y)W_2^\dagger
+            \Pi_{2,\gamma}^\sigma\right),
+        \label{eq:mpdo_bnt_ambient_sector_R2}
+        \\
+        \widetilde R_1\colon\mathcal A_1&\longrightarrow\MN{d},
+        &
+        \widetilde R_1((X_\gamma)_\gamma)
+        &=W_1^\dagger
+          \left(\bigoplus_\gamma
+            \frac{\mu_\gamma}{m_\gamma}\otimes X_\gamma\right)W_1,
+        \label{eq:mpdo_bnt_ambient_sector_R1_tilde}
+        \\
+        \widetilde R_2\colon\mathcal A_2^\sigma
+          &\longrightarrow\MN{d}\otimes\MN{d},
+        &
+        \widetilde R_2((Y_\gamma)_\gamma)
+        &=\kappa_\ast\!\left[
+          W_2^\dagger\left(\bigoplus_\gamma
+            \frac{\nu_{\sigma(\gamma)}}{m_\gamma}\otimes Y_\gamma\right)W_2
+          \right].
+        \label{eq:mpdo_bnt_ambient_sector_R2_tilde}
+    \end{align}
+    In Appendix~C.4 of \cite{Cirac2016MPDO_arXiv}, lines~2067--2068 define
+    $R_1$ by~(\ref{eq:mpdo_bnt_ambient_sector_R1}), and lines~2078--2079
+    define $R_2$ by~(\ref{eq:mpdo_bnt_ambient_sector_R2}).
+    Lines~2081--2083 give the normalized map $\widetilde R_1$ in
+    (\ref{eq:mpdo_bnt_ambient_sector_R1_tilde}).  Lines~2058--2071 give
+    $\widetilde R_2$, including its common denominator, in
+    (\ref{eq:mpdo_bnt_ambient_sector_R2_tilde}).
+    These four definitions use only the two vertical decompositions, their
+    sector relabelling, and
+    (\ref{eq:mpdo_bnt_ambient_sector_trace_weights}).
+\end{definition}
+
+\begin{theorem}[Complete positivity of the ambient sector maps]
+    \label{thm:mpdo_bnt_ambient_sector_complete_positivity}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteAmbientSectorRetractionExtension_isKrausCP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteAmbientSectorRetractionExtension}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        oneSiteNormalizedAmbientSectorRestorationExtension_isKrausCP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteNormalizedAmbientSectorRestorationExtension}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteAmbientSectorRetractionExtension_isKrausCP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteAmbientSectorRetractionExtension}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteNormalizedAmbientSectorRestorationExtension_isKrausCP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteNormalizedAmbientSectorRestorationExtension}
+    \lean{MPOTensor.verticalSectorAmbientRetractionExtension}
+    \lean{MPOTensor.verticalSectorAmbientRetractionExtension_factorization}
+    \lean{MPOTensor.verticalSectorAmbientRetractionExtension_isKrausCP}
+    \lean{MPOTensor.normalizedVerticalSectorAmbientRestorationExtension}
+    \lean{MPOTensor.normalizedVerticalSectorAmbientRestorationExtension_factorization}
+    \lean{MPOTensor.normalizedVerticalSectorAmbientRestorationExtension_isKrausCP}
+    \leanok
+    \uses{def:kraus_map_between_direct_sums,
+        def:mpdo_bnt_ambient_sector_maps}
+    Represent a sector family by its block-diagonal matrix.  For a map whose
+    domain is a sector algebra, first extract the diagonal sector blocks from
+    an arbitrary matrix.  With these canonical full-matrix representatives,
+    each of $R_1$, $R_2$, $\widetilde R_1$, and $\widetilde R_2$ is completely
+    positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_vertical_sector_partial_trace_kraus,
+        lem:mpdo_single_kraus_map_cp,
+        thm:mpdo_equiv_reindex_cptp,
+        lem:is_kraus_cp_comp}
+    Each raw retraction is the composition of compression by $W_i$, a unitary
+    relabelling of coordinates, sectorwise partial trace, and block-diagonal
+    inclusion.  Each normalized embedding is the composition of diagonal-block
+    extraction, preparation of the positive matrix
+    $\mu_\gamma/m_\gamma$ or
+    $\nu_{\sigma(\gamma)}/m_\gamma$, coordinate relabelling, and expansion by
+    $W_i^\dagger$.  Every constituent has a Kraus representation, and
+    compositions of such maps are completely positive.
+\end{proof}
+
+% Local fix (zero-sector complement): the coisometries need not have full
+% ambient support, so the raw maps are trace-nonincreasing rather than
+% trace-preserving. Documented in
+% docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex.
+\begin{theorem}[Trace of the ambient sector maps]
+    \label{thm:mpdo_bnt_ambient_sector_trace}
+    \lean{MPOTensor.BNTAlgebraTensorClause.verticalSectorTrace_oneSiteAmbientSectorRetraction}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        verticalSectorTrace_twoSiteAmbientSectorRetraction}
+    \lean{MPOTensor.BNTAlgebraTensorClause.verticalSectorTrace_oneSiteAmbientSectorRetraction_le}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        verticalSectorTrace_twoSiteAmbientSectorRetraction_le}
+    \lean{MPOTensor.BNTAlgebraTensorClause.trace_oneSiteNormalizedAmbientSectorRestoration}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        trace_twoSiteNormalizedAmbientSectorRestoration}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        oneSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP}
+    \lean{MPOTensor.verticalSectorTrace_verticalSectorAmbientRetraction_le}
+    \lean{MPOTensor.trace_normalizedVerticalSectorAmbientRestoration}
+    \lean{MPOTensor.normalizedVerticalSectorAmbientRestorationExtension_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_bnt_ambient_sector_maps,
+        def:mpdo_positive_vertical_sector_family,
+        thm:mpdo_bnt_ambient_sector_complete_positivity}
+    For arbitrary ambient matrices $X\in\MN{d}$ and
+    $Y\in\MN{d}\otimes\MN{d}$,
+    \begin{align}
+        \Trsec(R_1(X))
+        &=\tr(W_1XW_1^\dagger),
+        \label{eq:mpdo_bnt_ambient_sector_R1_trace}
+        \\
+        \Trsec(R_2(Y))
+        &=\tr\!\left(W_2\kappa_\ast^{-1}(Y)W_2^\dagger\right).
+        \label{eq:mpdo_bnt_ambient_sector_R2_trace}
+    \end{align}
+    If $X$ and $Y$ are positive semidefinite, then
+    \begin{align}
+        \Trsec(R_1(X))
+        &\leq\tr(X),
+        &
+        \Trsec(R_2(Y))
+        &\leq\tr(Y).
+        \label{eq:mpdo_bnt_ambient_sector_trace_loss}
+    \end{align}
+    In the other direction, for $Z\in\mathcal A_1$ and
+    $Z'\in\mathcal A_2^\sigma$,
+    \begin{align}
+        \tr(\widetilde R_1(Z))
+        &=\Trsec(Z),
+        &
+        \tr(\widetilde R_2(Z'))
+        &=\Trsec(Z').
+        \label{eq:mpdo_bnt_ambient_sector_embedding_trace}
+    \end{align}
+    Hence the canonical full-matrix representatives of $\widetilde R_1$ and
+    $\widetilde R_2$ are trace-preserving completely positive maps.
+
+    The inequalities in
+    (\ref{eq:mpdo_bnt_ambient_sector_trace_loss}) may be strict.  Indeed,
+    $W_i^\dagger W_i$ is the projection onto the retained nonzero sectors and
+    need not be the identity on the ambient space.  A positive matrix supported
+    on the discarded orthogonal complement is annihilated by the corresponding
+    compression.  Thus $R_1$ and $R_2$ are not asserted to preserve the trace
+    on all ambient positive matrices, and no term acting on the discarded
+    complement is included.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_normalized_vertical_sector_positive_trace,
+        lem:mpdo_coisometric_compression_trace,
+        thm:mpdo_equiv_reindex_cptp}
+    Sectorwise partial trace and block-diagonal inclusion preserve the total
+    trace, which gives
+    (\ref{eq:mpdo_bnt_ambient_sector_R1_trace}) and
+    (\ref{eq:mpdo_bnt_ambient_sector_R2_trace}).  For
+    $P_i=W_i^\dagger W_i$, cyclicity of trace gives
+    \begin{align}
+        \tr(W_i ZW_i^\dagger)
+        &=\tr(P_i Z)\leq\tr(Z)
+        \notag
+    \end{align}
+    when $Z\succeq0$.  The relabelling $\kappa_\ast$ preserves positivity and
+    trace, proving (\ref{eq:mpdo_bnt_ambient_sector_trace_loss}).  Finally, each
+    normalized multiplicity matrix has trace one, and
+    $W_i W_i^\dagger=I$ gives
+    $\tr(W_i^\dagger BW_i)=\tr(B)$.  This proves
+    (\ref{eq:mpdo_bnt_ambient_sector_embedding_trace}); complete positivity is
+    supplied by the preceding theorem.
+\end{proof}
+
+\begin{theorem}[Retraction identities for the ambient sector maps]
+    \label{thm:mpdo_bnt_ambient_sector_retractions}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        oneSiteAmbientSectorRetraction_comp_normalizedRestoration}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteAmbientSectorRetraction_comp_normalizedRestoration}
+    \lean{MPOTensor.verticalSectorAmbientRetraction_comp_normalizedRestoration}
+    \leanok
+    \uses{def:mpdo_bnt_ambient_sector_maps}
+    The raw retractions are left inverses of their normalized embeddings:
+    \begin{align}
+        R_1\widetilde R_1
+        &=\id_{\mathcal A_1},
+        &
+        R_2\widetilde R_2
+        &=\id_{\mathcal A_2^\sigma}.
+        \label{eq:mpdo_bnt_ambient_sector_retractions}
+    \end{align}
+    No identity is asserted for either reverse composite on the full ambient
+    matrix algebra.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_retained_vertical_sector_retraction,
+        thm:mpdo_equiv_reindex_cptp}
+    Compressing an expansion by $W_i^\dagger$ gives the original retained
+    block-diagonal matrix because $W_i W_i^\dagger=I$.  On every sector,
+    \begin{align}
+        \tr_{\mathrm{mult}}
+        \left(\frac{\mu_\gamma}{m_\gamma}\otimes X_\gamma\right)
+        &=X_\gamma,
+        &
+        \tr_{\mathrm{mult}}
+        \left(\frac{\nu_{\sigma(\gamma)}}{m_\gamma}\otimes Y_\gamma\right)
+        &=Y_\gamma,
+        \notag
+    \end{align}
+    where the second equality uses
+    $\tr(\nu_{\sigma(\gamma)})=m_\gamma$.  The two coordinate relabellings in
+    the two-site composite cancel.  These identities prove
+    (\ref{eq:mpdo_bnt_ambient_sector_retractions}).
+\end{proof}
+
+\begin{theorem}[Action on the weighted tensor letters]
+    \label{thm:mpdo_bnt_ambient_sector_tensor_letters}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteAmbientSectorRetraction_verticalTensor}
+    \lean{MPOTensor.BNTAlgebraTensorClause.%
+        oneSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteAmbientSectorRetraction_verticalTensor}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor}
+    \lean{MPOTensor.verticalSectorAmbientRetraction_weightedBlockDiagonal}
+    \lean{MPOTensor.normalizedVerticalSectorAmbientRestoration_trace_smul}
+    \leanok
+    \uses{def:mpdo_bnt_ambient_sector_maps,
+        lem:mpdo_normalized_retained_vertical_sector_embedding,
+        lem:mpdo_retained_vertical_sector_partial_trace,
+        thm:mpdo_bnt_multiplicity_trace_normalization}
+    For every vertical letter $v$, the one-site maps satisfy
+    \begin{align}
+        R_1(\widetilde M_v)
+        &=\bigl(m_\gamma M_\gamma^v\bigr)_\gamma,
+        &
+        \widetilde R_1\bigl((m_\gamma M_\gamma^v)_\gamma\bigr)
+        &=\widetilde M_v.
+        \label{eq:mpdo_bnt_ambient_sector_one_site_letters}
+    \end{align}
+    The relabelled two-site maps satisfy
+    \begin{align}
+        R_2\!\left(\kappa_\ast(\widetilde{M^{[2]}}_v)\right)
+        &=\bigl(m_\gamma A_{\sigma(\gamma)}^v\bigr)_\gamma,
+        \notag\\
+        \widetilde R_2\bigl((m_\gamma A_{\sigma(\gamma)}^v)_\gamma\bigr)
+        &=\kappa_\ast(\widetilde{M^{[2]}}_v).
+        \label{eq:mpdo_bnt_ambient_sector_two_site_letters}
+    \end{align}
+    The first and second one-site identities combine the one-site weighted
+    sector form of
+    \cite[Appendix~C.4, lines~2048--2051]{Cirac2016MPDO_arXiv} with,
+    respectively,
+    \cite[Appendix~C.4, lines~2067--2068]{Cirac2016MPDO_arXiv} and
+    \cite[Appendix~C.4, lines~2081--2083]{Cirac2016MPDO_arXiv}.
+    The first two-site identity combines the matched weighted sector form of
+    \cite[Appendix~C.4, lines~2048--2064]{Cirac2016MPDO_arXiv} with the map
+    $R_2$ of \cite[Appendix~C.4, lines~2078--2079]{Cirac2016MPDO_arXiv}.
+    The second combines the same sector form with the normalized map
+    $\widetilde R_2$ of
+    \cite[Appendix~C.4, lines~2070--2071]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_normalized_retained_vertical_sector_embedding,
+        lem:mpdo_retained_vertical_sector_partial_trace,
+        thm:mpdo_bnt_multiplicity_trace_normalization}
+    The vertical reconstruction identities give
+    \begin{align}
+        \widetilde M_v
+        &=W_1^\dagger\left(\bigoplus_\gamma
+          \mu_\gamma\otimes M_\gamma^v\right)W_1,
+        \notag\\
+        \widetilde{M^{[2]}}_v
+        &=W_2^\dagger\left(\bigoplus_\gamma
+          \nu_{\sigma(\gamma)}\otimes A_{\sigma(\gamma)}^v\right)W_2.
+        \notag
+    \end{align}
+    Compression removes the two outer coisometries, and partial trace over the
+    multiplicity coordinate multiplies the simple-sector letter by
+    $\tr(\mu_\gamma)=m_\gamma$ or
+    $\tr(\nu_{\sigma(\gamma)})=m_\gamma$.  This proves the first identity in
+    each of (\ref{eq:mpdo_bnt_ambient_sector_one_site_letters}) and
+    (\ref{eq:mpdo_bnt_ambient_sector_two_site_letters}).  Preparing the
+    normalized multiplicity matrix cancels the factor $m_\gamma$ and the
+    reconstruction identities give the two reverse formulas.
+\end{proof}


### PR DESCRIPTION
## Summary

This PR constructs the one-site and two-site ambient sector retractions
\(R_1,R_2\) and normalized restorations \(\widetilde R_1,\widetilde R_2\)
from CPSV16 Appendix C.4.

It proves:

- Kraus complete positivity for all four ambient extensions;
- trace nonincrease for the raw retractions and trace preservation for the
  normalized restorations;
- \(R_1\widetilde R_1=\mathrm{id}\) and
  \(R_2\widetilde R_2=\mathrm{id}\) on the sector algebras;
- the weighted one-site and relabelled two-site tensor-letter formulas.

The two-site construction uses `TwoSiteMultiplicitySpectrum`, its retained-sector
coordinates, and the established equality between the one-site and relabelled
two-site multiplicity traces. The coordinate, one-site, and two-site arguments
are separated into focused modules so that each cached local check remains within
the repository compilation-time policy. Chapter 21 and the generated MPDO import
aggregator are synchronized. The new Blueprint subsection links the 49 declarations
used in its mathematical presentation.

## Source faithfulness

The definitions and theorems cite CPSV16 Appendix C.4, lines 2058–2083. The raw
retractions vanish on the orthogonal complement of the retained vertical sector;
therefore their faithful ambient statement is trace nonincrease on positive
matrices, not trace preservation. This local correction is recorded in
`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. The normalized
restorations are trace-preserving and hence CPTP.

The scope deliberately stops before the middle-sector maps, complement maps,
final \(T,S\) maps, and `IsRFPViaTS`; it introduces no unitary supplied by issue
#4645. Issues #4645, #5285, and #3949 remain open.

## Validation

All Lean checks used the existing cache-seeded hot worktree. `lake exe cache get`
was run first and reported that no files needed downloading; no cache was cleared
and no fresh Mathlib build was started.

- `lake env lean` on each of the five new Lean modules
- `lake build TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorMaps`
- hot cached import-chain refresh through `TNLean.MPS.MPDO`, `TNLean.MPS`, and
  `TNLean`, solely to refresh the declaration-checker environment
- `leanblueprint checkdecls`
- `leanblueprint web`
- `leanblueprint pdf`, followed by visual inspection of the affected pages
- Blueprint–Lean synchronization: 49/49 declarations
- generated-import check and its nine unit tests
- `chktex`, `lacheck`, tactic-pattern scan, and proof-integrity scans

Closes #5317.

