### PR TITLE
feat(MPS/MPDO): complete conditional physical channels

### DIFF
--- a/TNLean/Channel.lean
+++ b/TNLean/Channel.lean
@@ -71,6 +71,7 @@ import TNLean.Channel.SingleKraus
 import TNLean.Channel.SingleKrausPositivity
 import TNLean.Channel.Spectral
 import TNLean.Channel.Stinespring
+import TNLean.Channel.SupportCompletion
 import TNLean.Channel.SupportedMarginalChannel
 import TNLean.Channel.TensorMap
 import TNLean.Channel.TransferMatrix

--- a/TNLean/Channel/SupportCompletion.lean
+++ b/TNLean/Channel/SupportCompletion.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.KrausCPTP
+
+/-!
+# Trace-preserving completion outside a matrix support
+
+A completely positive map may preserve only the trace seen by a projection
+onto an active subspace.  This file completes such a map by measuring the
+orthogonal complement and preparing a fixed density matrix.  The completed
+map agrees with the original map on matrices supported by the projection.
+
+## Main definitions
+
+* `Matrix.tracePrepareMap`: discard a matrix and prepare a fixed matrix with
+  the same trace when the fixed matrix has trace one.
+* `Matrix.supportComplementMap`: measure the weight outside a projection and
+  prepare a fixed matrix.
+* `Matrix.supportCompletion`: add the complementary term to a map supported
+  by the projection.
+
+## Main results
+
+* `Matrix.supportCompletion_isKrausCPTP`: the completed map is trace-preserving
+  and completely positive.
+* `Matrix.supportCompletion_apply_of_supported`: the completed map agrees with
+  the original map on matrices supported by the projection.
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608, Definition 4.1,
+  lines 638--660, and Appendix C.4, lines 2065--2085.  The completion supplies
+  the otherwise unspecified action on discarded physical complements; see
+  `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+-/
+
+open scoped ComplexOrder Matrix
+
+noncomputable section
+
+namespace Matrix
+
+variable {α β : Type*} [Fintype α] [DecidableEq α]
+  [Fintype β] [DecidableEq β]
+
+/-- The trace-and-prepare map sends `X` to `trace X • ρ`.
+
+It is expressed as state preparation, interchange of the two tensor factors,
+and partial trace.  This factorization supplies its rectangular Kraus form
+without any nonemptiness assumption on either index type. -/
+def tracePrepareMap (ρ : Matrix β β ℂ) :
+    Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
+  (partialTraceRightLM (α := β) (β := α)).comp
+    ((equivReindexMap (Equiv.prodComm α β)).comp (preparationMap ρ))
+
+/-- The trace-and-prepare map has the formula `X ↦ trace X • ρ`. -/
+@[simp]
+theorem tracePrepareMap_apply (ρ : Matrix β β ℂ) (X : Matrix α α ℂ) :
+    tracePrepareMap ρ X = Matrix.trace X • ρ := by
+  classical
+  ext b c
+  change (∑ a, X a a * ρ b c) = (∑ a, X a a) * ρ b c
+  rw [Finset.sum_mul]
+
+/-- The output trace of the trace-and-prepare map is the product of the input
+trace and the trace of the prepared matrix. -/
+theorem tracePrepareMap_trace (ρ : Matrix β β ℂ) (X : Matrix α α ℂ) :
+    Matrix.trace (tracePrepareMap ρ X) = Matrix.trace X * Matrix.trace ρ := by
+  rw [tracePrepareMap_apply, Matrix.trace_smul, smul_eq_mul]
+
+/-- Trace-and-prepare is completely positive when the prepared matrix is
+positive semidefinite. -/
+theorem tracePrepareMap_isKrausCP (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef) :
+    IsKrausCP (tracePrepareMap (α := α) ρ) := by
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · exact preparationMap_isKrausCP ρ hρ
+    · exact (equivReindexMap_isKrausCPTP (Equiv.prodComm α β)).isKrausCP
+  · exact (partialTraceRightLM_isKrausCPTP (α := β) (β := α)).isKrausCP
+
+/-- Trace-and-prepare is trace-preserving and completely positive when the
+prepared matrix is positive semidefinite with trace one. -/
+theorem tracePrepareMap_isKrausCPTP
+    (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef) (hρtrace : Matrix.trace ρ = 1) :
+    IsKrausCPTP (tracePrepareMap (α := α) ρ) := by
+  apply isKrausCPTP_comp
+  · apply isKrausCPTP_comp
+    · exact preparationMap_isKrausCPTP ρ hρ hρtrace
+    · exact equivReindexMap_isKrausCPTP (Equiv.prodComm α β)
+  · exact partialTraceRightLM_isKrausCPTP (α := β) (β := α)
+
+/-- The complementary map first applies the single Kraus operator `1 - P`,
+then discards the resulting matrix and prepares `ρ`. -/
+def supportComplementMap (P : Matrix α α ℂ) (ρ : Matrix β β ℂ) :
+    Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
+  (tracePrepareMap ρ).comp (singleKrausMap (1 - P))
+
+/-- The complementary map measures the weight of a matrix outside `P` and
+prepares `ρ` with that weight. -/
+@[simp]
+theorem supportComplementMap_apply
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ) (X : Matrix α α ℂ) :
+    supportComplementMap P ρ X =
+      Matrix.trace ((1 - P) * X * (1 - P)ᴴ) • ρ := by
+  rw [supportComplementMap, LinearMap.comp_apply, tracePrepareMap_apply,
+    singleKrausMap_apply]
+
+/-- The complementary map is completely positive when the prepared matrix
+is positive semidefinite. -/
+theorem supportComplementMap_isKrausCP
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ) (hρ : ρ.PosSemidef) :
+    IsKrausCP (supportComplementMap P ρ) := by
+  apply isKrausCP_comp
+  · exact singleKrausMap_isKrausCP (1 - P)
+  · exact tracePrepareMap_isKrausCP ρ hρ
+
+/-- If `P` is a Hermitian projection and `ρ` has trace one, the
+complementary term contributes precisely the trace outside `P`. -/
+theorem supportComplementMap_trace
+    (P : Matrix α α ℂ) (hPherm : P.IsHermitian) (hPidem : P * P = P)
+    (ρ : Matrix β β ℂ) (hρtrace : Matrix.trace ρ = 1) (X : Matrix α α ℂ) :
+    Matrix.trace (supportComplementMap P ρ X) =
+      Matrix.trace ((1 - P) * X) := by
+  let Q : Matrix α α ℂ := 1 - P
+  have hQherm : Q.IsHermitian := by
+    exact Matrix.isHermitian_one.sub hPherm
+  have hQidem : Q * Q = Q := by
+    rw [show Q = 1 - P from rfl]
+    calc
+      (1 - P) * (1 - P) = 1 - P - P + P * P := by noncomm_ring
+      _ = 1 - P := by rw [hPidem]; abel
+  rw [supportComplementMap_apply, Matrix.trace_smul, hρtrace, smul_eq_mul,
+    mul_one]
+  change Matrix.trace (Q * X * Qᴴ) = Matrix.trace (Q * X)
+  rw [hQherm.eq]
+  calc
+    Matrix.trace (Q * X * Q) = Matrix.trace ((Q * Q) * X) := by
+      simpa only [Matrix.mul_assoc] using Matrix.trace_mul_cycle Q X Q
+    _ = Matrix.trace (Q * X) := by rw [hQidem]
+
+/-- The support completion of `E` adds a map carrying the complementary
+trace weight to the fixed matrix `ρ`. -/
+def supportCompletion
+    (E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ) :
+    Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ :=
+  E + supportComplementMap P ρ
+
+/-- The support completion is the sum of the original map and its
+complementary term. -/
+@[simp]
+theorem supportCompletion_apply
+    (E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ)
+    (X : Matrix α α ℂ) :
+    supportCompletion E P ρ X = E X + supportComplementMap P ρ X := by
+  rfl
+
+/-- The support completion is completely positive when the original map is
+completely positive and the prepared matrix is positive semidefinite. -/
+theorem supportCompletion_isKrausCP
+    (E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ)
+    (hE : IsKrausCP E) (hρ : ρ.PosSemidef) :
+    IsKrausCP (supportCompletion E P ρ) := by
+  exact hE.add (supportComplementMap_isKrausCP P ρ hρ)
+
+/-- If `E` preserves the trace on the `P`-part, its support completion
+preserves the full trace. -/
+theorem supportCompletion_trace
+    (E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ)
+    (hPherm : P.IsHermitian) (hPidem : P * P = P)
+    (hEtrace : ∀ X, Matrix.trace (E X) = Matrix.trace (P * X))
+    (hρtrace : Matrix.trace ρ = 1) (X : Matrix α α ℂ) :
+    Matrix.trace (supportCompletion E P ρ X) = Matrix.trace X := by
+  rw [supportCompletion_apply, Matrix.trace_add, hEtrace,
+    supportComplementMap_trace P hPherm hPidem ρ hρtrace]
+  calc
+    Matrix.trace (P * X) + Matrix.trace ((1 - P) * X) =
+        Matrix.trace (P * X + (1 - P) * X) := by rw [Matrix.trace_add]
+    _ = Matrix.trace ((P + (1 - P)) * X) := by rw [Matrix.add_mul]
+    _ = Matrix.trace X := by simp
+
+/-- A completely positive map that preserves the trace on the part selected by
+a Hermitian projection extends to a channel by the complementary construction. -/
+theorem supportCompletion_isKrausCPTP
+    (E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ)
+    (hE : IsKrausCP E) (hPherm : P.IsHermitian) (hPidem : P * P = P)
+    (hEtrace : ∀ X, Matrix.trace (E X) = Matrix.trace (P * X))
+    (hρ : ρ.PosSemidef) (hρtrace : Matrix.trace ρ = 1) :
+    IsKrausCPTP (supportCompletion E P ρ) := by
+  apply isKrausCPTP_of_isKrausCP_trace_preserving
+  · exact supportCompletion_isKrausCP E P ρ hE hρ
+  · exact supportCompletion_trace E P ρ hPherm hPidem hEtrace hρtrace
+
+/-- The support completion agrees with the original map on matrices supported
+on both sides by `P`. -/
+theorem supportCompletion_apply_of_supported
+    (E : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ)
+    (P : Matrix α α ℂ) (ρ : Matrix β β ℂ)
+    (X : Matrix α α ℂ) (hPherm : P.IsHermitian) (hPidem : P * P = P)
+    (hX : P * X * P = X) :
+    supportCompletion E P ρ X = E X := by
+  let Q : Matrix α α ℂ := 1 - P
+  have hQherm : Q.IsHermitian := by
+    exact Matrix.isHermitian_one.sub hPherm
+  have hPX : P * X = X := by
+    calc
+      P * X = P * (P * X * P) := by rw [hX]
+      _ = (P * P) * X * P := by simp only [Matrix.mul_assoc]
+      _ = P * X * P := by rw [hPidem]
+      _ = X := hX
+  have hXP : X * P = X := by
+    calc
+      X * P = (P * X * P) * P := by rw [hX]
+      _ = P * X * (P * P) := by simp only [Matrix.mul_assoc]
+      _ = P * X * P := by rw [hPidem]
+      _ = X := hX
+  have hQXQ : Q * X * Q = 0 := by
+    rw [show Q = 1 - P from rfl]
+    calc
+      (1 - P) * X * (1 - P) = X - P * X - X * P + P * X * P := by
+        noncomm_ring
+      _ = 0 := by rw [hPX, hXP]; abel
+  rw [supportCompletion_apply, supportComplementMap_apply]
+  change E X + Matrix.trace (Q * X * Qᴴ) • ρ = E X
+  rw [hQherm.eq, hQXQ, Matrix.trace_zero, zero_smul, add_zero]
+
+end Matrix

--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -19,6 +19,7 @@ import TNLean.MPS.MPDO.BNTAlgebraTensorClause
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorCoordinates
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorMaps
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalPhysicalMaps
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalUnitary
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalPhysicalMaps.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalPhysicalMaps.lean
@@ -1,0 +1,718 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.SupportCompletion
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorMaps
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary
+import TNLean.MPS.MPDO.RFPViaTS
+
+/-!
+# Conditional physical channels from the BNT algebra clause
+
+Assume the unitary conjugacies between the matched one-site and two-site BNT
+sectors in Appendix C.4.  The direct-sum unitary maps can then be placed
+between the ambient sector retractions and normalized restorations.  The
+resulting raw physical maps are completely positive and have the required
+action on every physical closure, but they can lose trace on the zero-sector
+complements of the retained vertical canonical forms.
+
+The raw maps are completed on those complements by fixed measure-and-prepare
+terms.  The complement terms vanish on the physical closures because the
+vertical reconstruction identities place those closures in the retained
+supports.  This gives the two trace-preserving completely positive maps of
+Definition 4.1, conditionally on the supplied unitary sector conjugacies.
+
+## Main definitions
+
+* `UnitarySectorConjugacy.rawPhysicalT`
+* `UnitarySectorConjugacy.rawPhysicalS`
+* `UnitarySectorConjugacy.physicalT`
+* `UnitarySectorConjugacy.physicalS`
+
+## Main result
+
+* `UnitarySectorConjugacy.isRFPViaTS`
+
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:1606.00608,
+  Definition 4.1, lines 638--660, and Appendix C.4, lines 2053--2085.
+-/
+
+open scoped BigOperators ComplexOrder Matrix
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause
+
+variable {d D : ℕ} {M : MPOTensor d D}
+
+/-! ### Retained physical projections -/
+
+/-- The one-site initial projection of the vertical coisometry.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2068 and 2081--2083. -/
+def oneSiteRetainedProjection (H : BNTAlgebraTensorClause M) :
+    Matrix (Fin d) (Fin d) ℂ :=
+  H.verticalCoisometryᴴ * H.verticalCoisometry
+
+/-- The one-site retained projection is Hermitian.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2068. -/
+theorem oneSiteRetainedProjection_isHermitian
+    (H : BNTAlgebraTensorClause M) :
+    H.oneSiteRetainedProjection.IsHermitian := by
+  exact (Matrix.isOrthogonalProjection_conjTranspose_mul_of_mul_conjTranspose_eq_one
+    H.verticalCoisometry H.coisometry).1
+
+/-- The one-site retained projection is idempotent.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2068. -/
+theorem oneSiteRetainedProjection_mul_self
+    (H : BNTAlgebraTensorClause M) :
+    H.oneSiteRetainedProjection * H.oneSiteRetainedProjection =
+      H.oneSiteRetainedProjection := by
+  exact (Matrix.isOrthogonalProjection_conjTranspose_mul_of_mul_conjTranspose_eq_one
+    H.verticalCoisometry H.coisometry).2
+
+namespace TwoSiteMultiplicitySpectrum
+
+/-- The two-site initial projection of the relabelled vertical coisometry,
+transported from a blocked physical index to a pair of physical indices.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2079. -/
+def twoSiteRetainedProjection {H : BNTAlgebraTensorClause M}
+    (S : TwoSiteMultiplicitySpectrum H) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  Matrix.equivReindexMap (blockedIndexEquiv d)
+    (S.relabeledTwoSiteCoisometryᴴ * S.relabeledTwoSiteCoisometry)
+
+/-- The relabelled two-site retained projection is Hermitian.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2079. -/
+theorem twoSiteRetainedProjection_isHermitian
+    {H : BNTAlgebraTensorClause M} (S : TwoSiteMultiplicitySpectrum H) :
+    S.twoSiteRetainedProjection.IsHermitian := by
+  rw [twoSiteRetainedProjection, Matrix.equivReindexMap]
+  exact (Matrix.isOrthogonalProjection_conjTranspose_mul_of_mul_conjTranspose_eq_one
+    S.relabeledTwoSiteCoisometry
+    S.relabeledTwoSiteCoisometry_coisometry).1.reindex _
+
+/-- The relabelled two-site retained projection is idempotent.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2070--2079. -/
+theorem twoSiteRetainedProjection_mul_self
+    {H : BNTAlgebraTensorClause M} (S : TwoSiteMultiplicitySpectrum H) :
+    S.twoSiteRetainedProjection * S.twoSiteRetainedProjection =
+      S.twoSiteRetainedProjection := by
+  rw [twoSiteRetainedProjection, Matrix.equivReindexMap]
+  change
+    Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d) (blockedIndexEquiv d)
+        (S.relabeledTwoSiteCoisometryᴴ * S.relabeledTwoSiteCoisometry) *
+      Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d) (blockedIndexEquiv d)
+        (S.relabeledTwoSiteCoisometryᴴ * S.relabeledTwoSiteCoisometry) =
+    Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d) (blockedIndexEquiv d)
+      (S.relabeledTwoSiteCoisometryᴴ * S.relabeledTwoSiteCoisometry)
+  rw [Matrix.reindexLinearEquiv_mul]
+  rw [(Matrix.isOrthogonalProjection_conjTranspose_mul_of_mul_conjTranspose_eq_one
+    S.relabeledTwoSiteCoisometry
+    S.relabeledTwoSiteCoisometry_coisometry).2]
+
+end TwoSiteMultiplicitySpectrum
+
+namespace TwoSiteExactSectorGauge
+
+variable {H : BNTAlgebraTensorClause M} {S : TwoSiteExactSectorGauge H}
+
+/-! ### Raw physical maps -/
+
+/-- The raw refinement map
+\(T_0=\widetilde R_2\widetilde T R_1\), expressed through canonical
+full-matrix extensions of the sector maps.
+
+**Scope restriction (supplied unitary sector conjugacies):** The middle map
+uses the unitary conclusion of Appendix C.4, line 2057, as a hypothesis.  Its
+unconditional derivation is documented in
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2071. -/
+def UnitarySectorConjugacy.rawPhysicalT (C : UnitarySectorConjugacy S) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  S.toTwoSiteMultiplicitySpectrum.twoSiteNormalizedAmbientSectorRestorationExtension.comp
+    ((Matrix.directSumMapExtension C.directSumUnitaryT).comp
+      H.oneSiteAmbientSectorRetractionExtension)
+
+/-- The raw coarse-graining map
+\(S_0=\widetilde R_1\widetilde S R_2\), expressed through canonical
+full-matrix extensions of the sector maps.
+
+**Scope restriction (supplied unitary sector conjugacies):** The middle map
+uses the unitary conclusion of Appendix C.4, line 2057, as a hypothesis.  Its
+unconditional derivation is documented in
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2083. -/
+def UnitarySectorConjugacy.rawPhysicalS (C : UnitarySectorConjugacy S) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ :=
+  H.oneSiteNormalizedAmbientSectorRestorationExtension.comp
+    ((Matrix.directSumMapExtension C.directSumUnitaryS).comp
+      S.toTwoSiteMultiplicitySpectrum.twoSiteAmbientSectorRetractionExtension)
+
+/-- The raw refinement map is completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2071. -/
+theorem UnitarySectorConjugacy.rawPhysicalT_isKrausCP
+    (C : UnitarySectorConjugacy S) :
+    IsKrausCP C.rawPhysicalT := by
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · exact H.oneSiteAmbientSectorRetractionExtension_isKrausCP
+    · exact C.directSumUnitaryT_isKrausDirectSumMap
+  · exact S.toTwoSiteMultiplicitySpectrum
+      |>.twoSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP
+      |>.isKrausCP
+
+/-- The raw coarse-graining map is completely positive.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2083. -/
+theorem UnitarySectorConjugacy.rawPhysicalS_isKrausCP
+    (C : UnitarySectorConjugacy S) :
+    IsKrausCP C.rawPhysicalS := by
+  apply isKrausCP_comp
+  · apply isKrausCP_comp
+    · exact S.toTwoSiteMultiplicitySpectrum
+        |>.twoSiteAmbientSectorRetractionExtension_isKrausCP
+    · exact C.directSumUnitaryS_isKrausDirectSumMap
+  · exact H.oneSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP.isKrausCP
+
+/-- The canonical full-matrix extension of a trace-preserving map between two
+finite direct sums preserves the ordinary matrix trace.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2069 and 2080. -/
+private theorem trace_directSumMapExtension_of_tracePreserving
+    {g₁ g₂ : ℕ} {dim₁ : Fin g₁ → ℕ} {dim₂ : Fin g₂ → ℕ}
+    (F : VerticalSectorAlgebra dim₁ →ₗ[ℂ] VerticalSectorAlgebra dim₂)
+    (hF : Matrix.IsTracePreservingBetweenDirectSums F)
+    (X : Matrix (Σ α, Fin (dim₁ α)) (Σ α, Fin (dim₁ α)) ℂ) :
+    Matrix.trace (Matrix.directSumMapExtension F X) = Matrix.trace X := by
+  rw [Matrix.directSumMapExtension_apply,
+    Matrix.trace_directSumDiagonalEmbedding, hF,
+    Matrix.sum_trace_directSumDiagonalCompression]
+
+/-- The trace of the raw refinement map is the trace retained by the one-site
+vertical support projection.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2071. -/
+theorem UnitarySectorConjugacy.trace_rawPhysicalT
+    (C : UnitarySectorConjugacy S) (X : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix.trace (C.rawPhysicalT X) =
+      Matrix.trace (H.oneSiteRetainedProjection * X) := by
+  rw [rawPhysicalT, LinearMap.comp_apply, LinearMap.comp_apply]
+  rw [S.toTwoSiteMultiplicitySpectrum
+    |>.twoSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP.trace_map]
+  rw [trace_directSumMapExtension_of_tracePreserving C.directSumUnitaryT
+    C.directSumUnitaryT_isTracePreservingBetweenDirectSums]
+  change Matrix.trace
+      (Matrix.directSumDiagonalEmbedding (H.oneSiteAmbientSectorRetraction X)) = _
+  rw [Matrix.trace_directSumDiagonalEmbedding]
+  change verticalSectorTrace (H.oneSiteAmbientSectorRetraction X) = _
+  rw [H.verticalSectorTrace_oneSiteAmbientSectorRetraction,
+    Matrix.trace_mul_cycle]
+  rfl
+
+/-- The trace of the raw coarse-graining map is the trace retained by the
+two-site vertical support projection.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2083. -/
+theorem UnitarySectorConjugacy.trace_rawPhysicalS
+    (C : UnitarySectorConjugacy S)
+    (X : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) :
+    Matrix.trace (C.rawPhysicalS X) =
+      Matrix.trace
+        (S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection * X) := by
+  rw [rawPhysicalS, LinearMap.comp_apply, LinearMap.comp_apply]
+  rw [H.oneSiteNormalizedAmbientSectorRestorationExtension_isKrausCPTP.trace_map]
+  rw [trace_directSumMapExtension_of_tracePreserving C.directSumUnitaryS
+    C.directSumUnitaryS_isTracePreservingBetweenDirectSums]
+  change Matrix.trace (Matrix.directSumDiagonalEmbedding
+      (S.toTwoSiteMultiplicitySpectrum.twoSiteAmbientSectorRetraction X)) = _
+  rw [Matrix.trace_directSumDiagonalEmbedding]
+  change verticalSectorTrace
+      (S.toTwoSiteMultiplicitySpectrum.twoSiteAmbientSectorRetraction X) = _
+  rw [S.toTwoSiteMultiplicitySpectrum
+      |>.verticalSectorTrace_twoSiteAmbientSectorRetraction,
+    Matrix.trace_mul_cycle]
+  rw [TwoSiteMultiplicitySpectrum.twoSiteRetainedProjection]
+  simp only [Matrix.equivReindexMap]
+  let P := S.relabeledTwoSiteCoisometryᴴ * S.relabeledTwoSiteCoisometry
+  let Y := Matrix.reindex (blockedIndexEquiv d).symm
+    (blockedIndexEquiv d).symm X
+  change (P * Y).trace =
+    (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) P * X).trace
+  have hY : Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) Y = X := by
+    simpa only [Y, Matrix.coe_reindexLinearEquiv,
+      Matrix.symm_reindexLinearEquiv] using
+      (Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d)
+        (blockedIndexEquiv d)).apply_symm_apply X
+  have hmul :
+      Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) P *
+          Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) Y =
+        Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) (P * Y) := by
+    exact Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (blockedIndexEquiv d) (blockedIndexEquiv d) (blockedIndexEquiv d) P Y
+  calc
+    (P * Y).trace =
+        (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d)
+          (P * Y)).trace := (Matrix.trace_reindex (blockedIndexEquiv d) _).symm
+    _ = (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) P *
+          Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) Y).trace := by
+      rw [hmul]
+    _ = (Matrix.reindex (blockedIndexEquiv d) (blockedIndexEquiv d) P * X).trace := by
+      rw [hY]
+
+/-! ### Action on tensor letters and physical closures -/
+
+/-- The direct-sum refinement commutes with sector-dependent scalar
+multiplication on the matched tensor family.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2053--2069. -/
+private theorem UnitarySectorConjugacy.directSumUnitaryT_smul_tensor
+    (C : UnitarySectorConjugacy S) (a : Fin H.labelCount → ℂ)
+    (v : Fin (D * D)) :
+    C.directSumUnitaryT (fun γ ↦ a γ • H.tensor γ v) =
+      fun γ ↦ a γ • S.decomposition.tensor (S.relabel γ) v := by
+  funext γ
+  calc
+    C.directSumUnitaryT (fun δ ↦ a δ • H.tensor δ v) γ =
+        a γ • C.directSumUnitaryT (fun δ ↦ H.tensor δ v) γ := by
+      simp only [directSumUnitaryT_apply, map_smul, Matrix.mul_smul,
+        Matrix.smul_mul]
+    _ = a γ • S.decomposition.tensor (S.relabel γ) v := by
+      rw [congrFun (C.directSumUnitaryT_tensor v) γ]
+
+/-- The direct-sum coarse-graining commutes with sector-dependent scalar
+multiplication on the matched tensor family.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2053--2080. -/
+private theorem UnitarySectorConjugacy.directSumUnitaryS_smul_tensor
+    (C : UnitarySectorConjugacy S) (a : Fin H.labelCount → ℂ)
+    (v : Fin (D * D)) :
+    C.directSumUnitaryS
+        (fun γ ↦ a γ • S.decomposition.tensor (S.relabel γ) v) =
+      fun γ ↦ a γ • H.tensor γ v := by
+  funext γ
+  calc
+    C.directSumUnitaryS
+        (fun δ ↦ a δ • S.decomposition.tensor (S.relabel δ) v) γ =
+        a γ • C.directSumUnitaryS
+          (fun δ ↦ S.decomposition.tensor (S.relabel δ) v) γ := by
+      simp only [directSumUnitaryS_apply, map_smul, Matrix.mul_smul,
+        Matrix.smul_mul]
+    _ = a γ • H.tensor γ v := by
+      rw [congrFun (C.directSumUnitaryS_tensor v) γ]
+
+/-- On a one-site vertical tensor letter, the raw refinement map gives the
+corresponding decoded two-site vertical tensor letter.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2071. -/
+theorem UnitarySectorConjugacy.rawPhysicalT_verticalTensor
+    (C : UnitarySectorConjugacy S) (v : Fin (D * D)) :
+    C.rawPhysicalT (verticalTensor M v) =
+      Matrix.equivReindexMap (blockedIndexEquiv d)
+        (verticalTensor (blockTwo M) v) := by
+  simp only [rawPhysicalT, LinearMap.comp_apply,
+    oneSiteAmbientSectorRetractionExtension,
+    verticalSectorAmbientRetractionExtension,
+    Matrix.directSumMapExtension_apply,
+    Matrix.directSumDiagonalCompression_embedding,
+    TwoSiteMultiplicitySpectrum.twoSiteNormalizedAmbientSectorRestorationExtension,
+    normalizedVerticalSectorAmbientRestorationExtension]
+  change S.toTwoSiteMultiplicitySpectrum.twoSiteNormalizedAmbientSectorRestoration
+      (C.directSumUnitaryT
+        (H.oneSiteAmbientSectorRetraction (verticalTensor M v))) =
+    Matrix.equivReindexMap (blockedIndexEquiv d)
+      (verticalTensor (blockTwo M) v)
+  rw [H.oneSiteAmbientSectorRetraction_verticalTensor,
+    C.directSumUnitaryT_smul_tensor
+      (fun γ ↦ verticalMultiplicityTrace H.weight γ) v]
+  exact S.toTwoSiteMultiplicitySpectrum
+    |>.twoSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor v
+
+/-- On a decoded two-site vertical tensor letter, the raw coarse-graining map
+gives the corresponding one-site vertical tensor letter.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2078--2083. -/
+theorem UnitarySectorConjugacy.rawPhysicalS_verticalTensor
+    (C : UnitarySectorConjugacy S) (v : Fin (D * D)) :
+    C.rawPhysicalS
+        (Matrix.equivReindexMap (blockedIndexEquiv d)
+          (verticalTensor (blockTwo M) v)) =
+      verticalTensor M v := by
+  simp only [rawPhysicalS, LinearMap.comp_apply,
+    TwoSiteMultiplicitySpectrum.twoSiteAmbientSectorRetractionExtension,
+    verticalSectorAmbientRetractionExtension,
+    Matrix.directSumMapExtension_apply,
+    Matrix.directSumDiagonalCompression_embedding,
+    oneSiteNormalizedAmbientSectorRestorationExtension,
+    normalizedVerticalSectorAmbientRestorationExtension]
+  change H.oneSiteNormalizedAmbientSectorRestoration
+      (C.directSumUnitaryS
+        (S.toTwoSiteMultiplicitySpectrum.twoSiteAmbientSectorRetraction
+          (Matrix.equivReindexMap (blockedIndexEquiv d)
+            (verticalTensor (blockTwo M) v)))) =
+    verticalTensor M v
+  rw [S.toTwoSiteMultiplicitySpectrum
+      |>.twoSiteAmbientSectorRetraction_verticalTensor,
+    C.directSumUnitaryS_smul_tensor
+      (fun γ ↦ verticalMultiplicityTrace H.weight γ) v]
+  exact H.oneSiteNormalizedAmbientSectorRestoration_trace_smul_verticalTensor v
+
+/-- The raw refinement map has the Definition 4.1 action on every one-site
+physical closure.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2065--2071. -/
+theorem UnitarySectorConjugacy.rawPhysicalT_physClose1
+    (C : UnitarySectorConjugacy S) (X : Matrix (Fin D) (Fin D) ℂ) :
+    C.rawPhysicalT (physClose1 M X) = physClose2 M X := by
+  rw [← contractBondMatrix_verticalTensor_eq_physClose1]
+  calc
+    C.rawPhysicalT (MPSTensor.contractBondMatrix (verticalTensor M) X) =
+        ∑ v : Fin (D * D), X v.modNat v.divNat •
+          Matrix.equivReindexMap (blockedIndexEquiv d)
+            (verticalTensor (blockTwo M) v) := by
+      simp only [MPSTensor.contractBondMatrix_apply, map_sum, map_smul,
+        C.rawPhysicalT_verticalTensor]
+    _ = Matrix.equivReindexMap (blockedIndexEquiv d)
+        (MPSTensor.contractBondMatrix (verticalTensor (blockTwo M)) X) := by
+      simp only [MPSTensor.contractBondMatrix_apply, map_sum, map_smul]
+    _ = Matrix.equivReindexMap (blockedIndexEquiv d)
+        (physClose1 (blockTwo M) X) := by
+      rw [contractBondMatrix_verticalTensor_eq_physClose1]
+    _ = physClose2 M X := physClose1_blockTwo_eq_physClose2_apply M X
+
+/-- The raw coarse-graining map has the Definition 4.1 action on every
+two-site physical closure.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2078--2083. -/
+theorem UnitarySectorConjugacy.rawPhysicalS_physClose2
+    (C : UnitarySectorConjugacy S) (X : Matrix (Fin D) (Fin D) ℂ) :
+    C.rawPhysicalS (physClose2 M X) = physClose1 M X := by
+  rw [← physClose1_blockTwo_eq_physClose2_apply M X,
+    ← contractBondMatrix_verticalTensor_eq_physClose1]
+  calc
+    C.rawPhysicalS
+        (Matrix.equivReindexMap (blockedIndexEquiv d)
+          (MPSTensor.contractBondMatrix (verticalTensor (blockTwo M)) X)) =
+        ∑ v : Fin (D * D), X v.modNat v.divNat • verticalTensor M v := by
+      simp only [MPSTensor.contractBondMatrix_apply, map_sum, map_smul,
+        C.rawPhysicalS_verticalTensor]
+    _ = MPSTensor.contractBondMatrix (verticalTensor M) X := by
+      rw [MPSTensor.contractBondMatrix_apply]
+    _ = physClose1 M X := by
+      rw [contractBondMatrix_verticalTensor_eq_physClose1]
+
+/-! ### Support of the source-generated physical closures -/
+
+/-- A matrix reconstructed by expansion along a coisometry is supported on
+the coisometry's initial projection.
+
+Source: arXiv:1606.00608, Appendix C.4, lines 2065--2083. -/
+private theorem supported_of_eq_conjTranspose_mul_mul
+    {r n : ℕ} (U : Matrix (Fin r) (Fin n) ℂ) (hU : U * Uᴴ = 1)
+    (Z : Matrix (Fin r) (Fin r) ℂ) :
+    (Uᴴ * U) * (Uᴴ * Z * U) * (Uᴴ * U) = Uᴴ * Z * U := by
+  calc
+    (Uᴴ * U) * (Uᴴ * Z * U) * (Uᴴ * U) =
+        Uᴴ * (U * Uᴴ) * Z * (U * Uᴴ) * U := by
+      simp only [Matrix.mul_assoc]
+    _ = Uᴴ * Z * U := by rw [hU]; simp
+
+/-- Every one-site physical closure is supported on the retained one-site
+vertical subspace.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2065--2068. -/
+theorem oneSiteRetainedProjection_physClose1
+    (H : BNTAlgebraTensorClause M) (X : Matrix (Fin D) (Fin D) ℂ) :
+    H.oneSiteRetainedProjection * physClose1 M X *
+        H.oneSiteRetainedProjection =
+      physClose1 M X := by
+  rw [oneSiteRetainedProjection,
+    physClose1_eq_of_vertical_reconstruction M
+      (verticalAssembledTensor H.bondDim H.multiplicity H.weight H.tensor)
+      H.verticalCoisometry H.reconstruction X]
+  exact supported_of_eq_conjTranspose_mul_mul H.verticalCoisometry H.coisometry _
+
+/-- Every two-site physical closure is supported on the retained relabelled
+two-site vertical subspace.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2070--2079. -/
+theorem twoSiteRetainedProjection_physClose2
+    (S₀ : TwoSiteMultiplicitySpectrum H) (X : Matrix (Fin D) (Fin D) ℂ) :
+    S₀.twoSiteRetainedProjection * physClose2 M X *
+        S₀.twoSiteRetainedProjection =
+      physClose2 M X := by
+  let U := S₀.relabeledTwoSiteCoisometry
+  have hBlocked :
+      (Uᴴ * U) * physClose1 (blockTwo M) X * (Uᴴ * U) =
+        physClose1 (blockTwo M) X := by
+    rw [physClose1_eq_of_vertical_reconstruction (blockTwo M)
+      (fun v ↦ verticalSectorBlockDiagonal S₀.relabeledTwoSiteBondDim
+        S₀.relabeledTwoSiteMultiplicity (fun γ ↦
+          Matrix.kroneckerMap (· * ·)
+            (Matrix.diagonal (S₀.relabeledTwoSiteWeight γ))
+            (S₀.decomposition.tensor (S₀.relabel γ) v)))
+      U S₀.relabeledTwoSiteCoisometry_reconstruction_verticalTensor X]
+    exact supported_of_eq_conjTranspose_mul_mul U
+      S₀.relabeledTwoSiteCoisometry_coisometry _
+  rw [← physClose1_blockTwo_eq_physClose2_apply M X,
+    TwoSiteMultiplicitySpectrum.twoSiteRetainedProjection,
+    Matrix.equivReindexMap]
+  change
+    Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d) (blockedIndexEquiv d)
+          (S₀.relabeledTwoSiteCoisometryᴴ * S₀.relabeledTwoSiteCoisometry) *
+        Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d) (blockedIndexEquiv d)
+          (physClose1 (blockTwo M) X) *
+      Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d) (blockedIndexEquiv d)
+        (S₀.relabeledTwoSiteCoisometryᴴ * S₀.relabeledTwoSiteCoisometry) =
+    Matrix.reindexLinearEquiv ℂ ℂ (blockedIndexEquiv d) (blockedIndexEquiv d)
+      (physClose1 (blockTwo M) X)
+  rw [Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (blockedIndexEquiv d) (blockedIndexEquiv d) (blockedIndexEquiv d),
+    Matrix.reindexLinearEquiv_mul ℂ ℂ
+      (blockedIndexEquiv d) (blockedIndexEquiv d) (blockedIndexEquiv d)]
+  exact congrArg (Matrix.reindexLinearEquiv ℂ ℂ
+    (blockedIndexEquiv d) (blockedIndexEquiv d)) hBlocked
+
+/-! ### Trace-preserving physical completions -/
+
+/-- On an empty input matrix algebra, the zero map is trace-preserving and
+completely positive, with the empty Kraus family resolving the empty
+identity.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660. -/
+private theorem zero_isKrausCPTP_of_isEmpty
+    {m n : Type*} [Fintype m] [DecidableEq m] [IsEmpty m]
+    [Fintype n] [DecidableEq n] :
+    IsKrausCPTP (0 : Matrix m m ℂ →ₗ[ℂ] Matrix n n ℂ) := by
+  refine ⟨0, fun i ↦ Fin.elim0 i, ?_, ?_⟩
+  · intro X
+    simp
+  · ext i j
+    exact isEmptyElim i
+
+/-- The completed physical refinement map.  Outside the retained one-site
+support it measures the discarded weight and prepares a fixed faithful
+two-site density matrix.
+
+**Local fix (zero-sector complement):** The raw retraction can discard a zero
+sector.  The measure-and-prepare completion restores trace without changing
+the tensor-generated physical closures; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+**Scope restriction (supplied unitary sector conjugacies):** The middle map
+uses the unitary conclusion of Appendix C.4, line 2057, as a hypothesis; see
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2065--2071. -/
+def UnitarySectorConjugacy.physicalT (C : UnitarySectorConjugacy S) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  if hd : d = 0 then 0
+  else
+    letI : NeZero d := ⟨hd⟩
+    Matrix.supportCompletion C.rawPhysicalT H.oneSiteRetainedProjection
+      (Matrix.faithfulDensity (Fin d × Fin d))
+
+/-- The completed physical coarse-graining map.  Outside the retained
+two-site support it measures the discarded weight and prepares a fixed
+faithful one-site density matrix.
+
+**Local fix (zero-sector complement):** The raw retraction can discard a zero
+sector.  The measure-and-prepare completion restores trace without changing
+the tensor-generated physical closures; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+**Scope restriction (supplied unitary sector conjugacies):** The middle map
+uses the unitary conclusion of Appendix C.4, line 2057, as a hypothesis; see
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2078--2083. -/
+def UnitarySectorConjugacy.physicalS (C : UnitarySectorConjugacy S) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ →ₗ[ℂ]
+      Matrix (Fin d) (Fin d) ℂ :=
+  if hd : d = 0 then 0
+  else
+    letI : NeZero d := ⟨hd⟩
+    Matrix.supportCompletion C.rawPhysicalS
+      S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection
+      (Matrix.faithfulDensity (Fin d))
+
+/-- The completed physical refinement map is trace-preserving and completely
+positive.
+
+**Local fix (zero-sector complement):** The complementary branch restores
+the trace discarded by the raw one-site retraction; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+**Scope restriction (supplied unitary sector conjugacies):** The middle map
+uses the supplied line-2057 unitary conjugacies; see
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2065--2071. -/
+theorem UnitarySectorConjugacy.physicalT_isKrausCPTP
+    (C : UnitarySectorConjugacy S) :
+    IsKrausCPTP C.physicalT := by
+  rw [physicalT]
+  split
+  · rename_i hd
+    subst d
+    exact zero_isKrausCPTP_of_isEmpty
+  · rename_i hd
+    letI : NeZero d := ⟨hd⟩
+    exact Matrix.supportCompletion_isKrausCPTP
+      C.rawPhysicalT H.oneSiteRetainedProjection
+      (Matrix.faithfulDensity (Fin d × Fin d))
+      C.rawPhysicalT_isKrausCP
+      H.oneSiteRetainedProjection_isHermitian
+      H.oneSiteRetainedProjection_mul_self
+      C.trace_rawPhysicalT
+      (Matrix.faithfulDensity_posDef (Fin d × Fin d)).posSemidef
+      (Matrix.faithfulDensity_trace (Fin d × Fin d))
+
+/-- The completed physical coarse-graining map is trace-preserving and
+completely positive.
+
+**Local fix (zero-sector complement):** The complementary branch restores
+the trace discarded by the raw two-site retraction; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+**Scope restriction (supplied unitary sector conjugacies):** The middle map
+uses the supplied line-2057 unitary conjugacies; see
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2078--2083. -/
+theorem UnitarySectorConjugacy.physicalS_isKrausCPTP
+    (C : UnitarySectorConjugacy S) :
+    IsKrausCPTP C.physicalS := by
+  rw [physicalS]
+  split
+  · rename_i hd
+    subst d
+    exact zero_isKrausCPTP_of_isEmpty
+  · rename_i hd
+    letI : NeZero d := ⟨hd⟩
+    exact Matrix.supportCompletion_isKrausCPTP
+      C.rawPhysicalS S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection
+      (Matrix.faithfulDensity (Fin d))
+      C.rawPhysicalS_isKrausCP
+      S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection_isHermitian
+      S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection_mul_self
+      C.trace_rawPhysicalS
+      (Matrix.faithfulDensity_posDef (Fin d)).posSemidef
+      (Matrix.faithfulDensity_trace (Fin d))
+
+/-- The completed refinement map has the Definition 4.1 action on every
+one-site physical closure.
+
+**Local fix (zero-sector complement):** The added complement vanishes on the
+retained support of every physical closure; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2065--2071. -/
+theorem UnitarySectorConjugacy.physicalT_physClose1
+    (C : UnitarySectorConjugacy S) (X : Matrix (Fin D) (Fin D) ℂ) :
+    C.physicalT (physClose1 M X) = physClose2 M X := by
+  rw [physicalT]
+  split
+  · rename_i hd
+    subst d
+    exact Subsingleton.elim _ _
+  · rename_i hd
+    letI : NeZero d := ⟨hd⟩
+    calc
+      Matrix.supportCompletion C.rawPhysicalT H.oneSiteRetainedProjection
+          (Matrix.faithfulDensity (Fin d × Fin d)) (physClose1 M X) =
+          C.rawPhysicalT (physClose1 M X) :=
+        Matrix.supportCompletion_apply_of_supported
+          C.rawPhysicalT H.oneSiteRetainedProjection
+          (Matrix.faithfulDensity (Fin d × Fin d)) (physClose1 M X)
+          H.oneSiteRetainedProjection_isHermitian
+          H.oneSiteRetainedProjection_mul_self
+          (oneSiteRetainedProjection_physClose1 H X)
+      _ = physClose2 M X := C.rawPhysicalT_physClose1 X
+
+/-- The completed coarse-graining map has the Definition 4.1 action on every
+two-site physical closure.
+
+**Local fix (zero-sector complement):** The added complement vanishes on the
+retained support of every physical closure; see
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2078--2083. -/
+theorem UnitarySectorConjugacy.physicalS_physClose2
+    (C : UnitarySectorConjugacy S) (X : Matrix (Fin D) (Fin D) ℂ) :
+    C.physicalS (physClose2 M X) = physClose1 M X := by
+  rw [physicalS]
+  split
+  · rename_i hd
+    subst d
+    exact Subsingleton.elim _ _
+  · rename_i hd
+    letI : NeZero d := ⟨hd⟩
+    calc
+      Matrix.supportCompletion C.rawPhysicalS
+          S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection
+          (Matrix.faithfulDensity (Fin d)) (physClose2 M X) =
+          C.rawPhysicalS (physClose2 M X) :=
+        Matrix.supportCompletion_apply_of_supported
+          C.rawPhysicalS
+          S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection
+          (Matrix.faithfulDensity (Fin d)) (physClose2 M X)
+          S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection_isHermitian
+          S.toTwoSiteMultiplicitySpectrum.twoSiteRetainedProjection_mul_self
+          (twoSiteRetainedProjection_physClose2
+            S.toTwoSiteMultiplicitySpectrum X)
+      _ = physClose1 M X := C.rawPhysicalS_physClose2 X
+
+/-- The BNT algebra clause gives the trace-preserving completely positive
+maps of Definition 4.1, conditionally on the unitary conjugacies between its
+matched one-site and two-site sectors.
+
+**Scope restriction (supplied unitary sector conjugacies):** This theorem
+assumes the unitary conclusion of Appendix C.4, line 2057.  Its derivation
+from the tensor-attached algebra clause remains open and is documented in
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+**Local fix (zero-sector complement):** The raw maps are completed on the
+orthogonal complements of the retained vertical sectors as documented in
+`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.
+
+Source: arXiv:1606.00608, Definition 4.1, lines 638--660, and Appendix C.4,
+lines 2053--2085. -/
+theorem UnitarySectorConjugacy.isRFPViaTS
+    (C : UnitarySectorConjugacy S) : IsRFPViaTS M := by
+  exact ⟨C.physicalS, C.physicalT,
+    C.physicalS_isKrausCPTP, C.physicalT_isKrausCPTP,
+    C.physicalS_physClose2, C.physicalT_physClose1⟩
+
+end TwoSiteExactSectorGauge
+
+end BNTAlgebraTensorClause
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_structure.tex
@@ -9,3 +9,4 @@
 \input{chapter/ch21_mpdo_rfp_bnt_witnesses}
 \input{chapter/ch21_mpdo_rfp_bnt_direct_sum_unitary_conjugations}
 \input{chapter/ch21_mpdo_rfp_bnt_ambient_sector_maps}
+\input{chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
@@ -1,0 +1,247 @@
+\subsection{Trace-preserving completions and physical channels}
+
+\begin{theorem}[Trace-preserving completion outside a projection]
+    \label{thm:matrix_support_completion_cptp}
+    \lean{Matrix.supportCompletion_isKrausCPTP}
+    \lean{Matrix.tracePrepareMap}
+    \lean{Matrix.tracePrepareMap_apply}
+    \lean{Matrix.tracePrepareMap_trace}
+    \lean{Matrix.tracePrepareMap_isKrausCP}
+    \lean{Matrix.tracePrepareMap_isKrausCPTP}
+    \lean{Matrix.supportComplementMap}
+    \lean{Matrix.supportComplementMap_apply}
+    \lean{Matrix.supportComplementMap_isKrausCP}
+    \lean{Matrix.supportComplementMap_trace}
+    \lean{Matrix.supportCompletion}
+    \lean{Matrix.supportCompletion_apply}
+    \lean{Matrix.supportCompletion_isKrausCP}
+    \lean{Matrix.supportCompletion_trace}
+    \lean{Matrix.supportCompletion_apply_of_supported}
+    \leanok
+    \uses{def:is_kraus_cp, def:is_kraus_cptp,
+        def:mpdo_state_preparation_map,
+        def:mpdo_equiv_reindex_map,
+        def:mpdo_right_partial_trace_map,
+        def:mpdo_single_kraus_map}
+    Let $P\in\MN{m}$ be an orthogonal projection, let
+    $\rho\in\MN{n}$ be positive semidefinite with $\tr(\rho)=1$, and let
+    $\mathcal E\colon\MN{m}\to\MN{n}$ be completely positive.  Define the
+    trace-and-prepare map and its complementary restriction by
+    \begin{align}
+        \mathcal D_\rho(X)
+        &=\tr(X)\rho,
+        &
+        \mathcal C_{P,\rho}(X)
+        &=\mathcal D_\rho\bigl((I-P)X(I-P)^\dagger\bigr).
+        \label{eq:matrix_support_complement_map}
+    \end{align}
+    Both maps are completely positive, and $\mathcal D_\rho$ is
+    trace-preserving.  If
+    \begin{align}
+        \tr(\mathcal E(X))=\tr(PX)
+        \label{eq:matrix_support_map_trace}
+    \end{align}
+    for every $X\in\MN{m}$, then the completion
+    \begin{align}
+        \widehat{\mathcal E}(X)
+        &=\mathcal E(X)+\mathcal C_{P,\rho}(X)
+        \label{eq:matrix_support_completion}
+    \end{align}
+    is trace-preserving and completely positive.  It agrees with
+    $\mathcal E$ on every matrix supported by $P$:
+    \begin{align}
+        PXP=X
+        \quad\Longrightarrow\quad
+        \widehat{\mathcal E}(X)=\mathcal E(X).
+        \label{eq:matrix_support_completion_agreement}
+    \end{align}
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:mpdo_state_preparation_cp,
+        lem:mpdo_state_preparation_cptp,
+        thm:mpdo_equiv_reindex_cptp,
+        lem:mpdo_right_partial_trace_cptp,
+        lem:mpdo_single_kraus_map_apply,
+        lem:mpdo_single_kraus_map_cp,
+        lem:is_kraus_cp_comp,
+        lem:is_kraus_cptp_comp,
+        lem:is_kraus_cp_add,
+        thm:is_kraus_cptp_of_is_kraus_cp_trace_preserving}
+    The map $\mathcal D_\rho$ factors as state preparation, interchange of
+    the two tensor factors, and partial trace.  The map
+    $X\mapsto(I-P)X(I-P)^\dagger$ has a single Kraus operator.  Thus the two
+    maps in~(\ref{eq:matrix_support_complement_map}) are completely positive.
+    Since $P=P^\dagger=P^2$,
+    \begin{align}
+        \tr\bigl(\mathcal C_{P,\rho}(X)\bigr)
+        &=\tr((I-P)X).
+        \notag
+    \end{align}
+    Adding this identity to~(\ref{eq:matrix_support_map_trace}) gives
+    $\tr(\widehat{\mathcal E}(X))=\tr(X)$.  Finally, $PXP=X$ implies
+    $(I-P)X(I-P)=0$, which proves
+    (\ref{eq:matrix_support_completion_agreement}).
+\end{proof}
+
+\begin{theorem}[Physical channels from unitary sector conjugacies]
+    \label{thm:mpdo_bnt_conditional_physical_channels}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.isRFPViaTS}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteRetainedProjection}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteRetainedProjection_isHermitian}
+    \lean{MPOTensor.BNTAlgebraTensorClause.oneSiteRetainedProjection_mul_self}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteRetainedProjection}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteRetainedProjection_isHermitian}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteMultiplicitySpectrum.%
+        twoSiteRetainedProjection_mul_self}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.rawPhysicalT}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.rawPhysicalS}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.rawPhysicalT_isKrausCP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.rawPhysicalS_isKrausCP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.trace_rawPhysicalT}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.trace_rawPhysicalS}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.rawPhysicalT_physClose1}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.rawPhysicalS_physClose2}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        oneSiteRetainedProjection_physClose1}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        twoSiteRetainedProjection_physClose2}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.physicalT}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.physicalS}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.physicalT_isKrausCPTP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.physicalS_isKrausCPTP}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.physicalT_physClose1}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.physicalS_physClose2}
+    \leanok
+    \uses{def:mpdo_bnt_ambient_sector_maps,
+        def:mpdo_bnt_direct_sum_unitary_conjugations,
+        def:mpdo_faithful_uniform_density,
+        def:is_rfp_via_ts}
+    Suppose that the one-site and two-site sector decompositions are paired by
+    a relabelling $\sigma$ and unitaries $U_\gamma$ satisfying
+    \begin{align}
+        A_{\sigma(\gamma)}^i
+        &=U_\gamma M_\gamma^i U_\gamma^\dagger
+        \label{eq:mpdo_bnt_physical_channel_unitary_conjugacy}
+    \end{align}
+    for every sector $\gamma$ and every vertical letter $i$.  With the maps of
+    the preceding two subsections, set
+    \begin{align}
+        \mathcal T_0
+        &=\widetilde R_2\circ\widetilde T\circ R_1,
+        &
+        \mathcal S_0
+        &=\widetilde R_1\circ\widetilde S\circ R_2.
+        \label{eq:mpdo_bnt_active_physical_maps}
+    \end{align}
+    Let
+    \begin{align}
+        P_1&=W_1^\dagger W_1,
+        &
+        P_2&=\kappa_\ast(W_2^\dagger W_2),
+        &
+        Q_i&=I-P_i.
+        \label{eq:mpdo_bnt_physical_active_projections}
+    \end{align}
+    The matrices $P_1$ and $P_2$ are orthogonal projections.  If $d>0$, put
+    $\tau_1=d^{-1}I_d$ and $\tau_2=d^{-2}I_{d^2}$, and define
+    \begin{align}
+        \mathcal T(X)
+        &=\mathcal T_0(X)+\tr(Q_1XQ_1)\tau_2,
+        \notag\\
+        \mathcal S(Y)
+        &=\mathcal S_0(Y)+\tr(Q_2YQ_2)\tau_1.
+        \label{eq:mpdo_bnt_completed_physical_maps}
+    \end{align}
+    If $d=0$, take both maps to be zero; their domain and codomain matrix
+    algebras then consist only of zero.
+    Then $\mathcal T$ and $\mathcal S$ are trace-preserving completely positive
+    maps on the full physical matrix algebras.  For every virtual matrix $Z$,
+    they satisfy
+    \begin{align}
+        \mathcal T[M_1(Z)]&=M_2(Z),
+        &
+        \mathcal S[M_2(Z)]&=M_1(Z).
+        \label{eq:mpdo_bnt_completed_physical_map_actions}
+    \end{align}
+    Hence $M$ is a renormalization fixed point in the sense of
+    Definition~\ref{def:is_rfp_via_ts}.
+
+    The compositions in
+    (\ref{eq:mpdo_bnt_active_physical_maps}) are the formulas of
+    \cite[Appendix~C.4, lines~2065--2085]{Cirac2016MPDO_arXiv}.  Those formulas
+    determine the action after compression to the retained physical sectors.
+    With rectangular coisometries, the literal composites annihilate the
+    discarded zero-sector complements and fail to preserve trace there.
+    Definition~4.1 nevertheless requires maps on the full physical algebras
+    \cite[Definition~4.1, lines~638--660]{Cirac2016MPDO_arXiv}.
+    The source does not specify a trace-restoring modification on the discarded
+    complements.  Formula~(\ref{eq:mpdo_bnt_completed_physical_maps}) makes one
+    such choice when the physical space is nonzero.  Replacing
+    $\tau_1,\tau_2$ by any density matrices gives the same action on the
+    physical operators generated by $M$.  The conclusion is conditional on
+    the unitaries in
+    (\ref{eq:mpdo_bnt_physical_channel_unitary_conjugacy}); their existence is
+    not asserted here.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_bnt_ambient_sector_complete_positivity,
+        thm:mpdo_bnt_ambient_sector_trace,
+        thm:mpdo_bnt_ambient_sector_tensor_letters,
+        thm:mpdo_bnt_direct_sum_unitary_conjugations,
+        thm:matrix_support_completion_cptp,
+        thm:mpdo_faithful_uniform_density,
+        lem:mpdo_coisometric_compression_trace,
+        lem:mpdo_vertical_bond_contraction_phys_close,
+        lem:mpdo_vertical_bond_contraction_reconstruction,
+        thm:mpdo_one_site_closure_two_site_blocking}
+    Complete positivity of the four outer maps and of the two direct-sum
+    conjugations gives complete positivity of $\mathcal T_0$ and
+    $\mathcal S_0$.  Their traces are
+    \begin{align}
+        \tr(\mathcal T_0(X))&=\tr(P_1X),
+        &
+        \tr(\mathcal S_0(Y))&=\tr(P_2Y).
+        \label{eq:mpdo_bnt_active_physical_map_traces}
+    \end{align}
+    Suppose first that $d>0$.  Since $Q_i$ is a projection and $\tau_i$ has
+    trace one, the corresponding complementary term is completely positive
+    and has trace $\tr(Q_iXQ_i)=\tr(Q_iX)$.  Adding
+    (\ref{eq:mpdo_bnt_active_physical_map_traces}) and using $P_i+Q_i=I$
+    proves trace preservation of the completed maps.  If $d=0$, every ambient
+    matrix is zero, so the zero maps are completely positive and trace
+    preserving.
+
+    The reconstruction identities for the two vertical decompositions imply
+    \begin{align}
+        P_1M_1(Z)P_1&=M_1(Z),
+        &
+        P_2M_2(Z)P_2&=M_2(Z).
+        \label{eq:mpdo_bnt_physical_closure_support}
+    \end{align}
+    Thus both complementary terms vanish on the corresponding physical
+    operators.  The retraction formulas extract the families
+    $(m_\gamma M_\gamma^i)_\gamma$ and
+    $(m_\gamma A_{\sigma(\gamma)}^i)_\gamma$; unitary conjugation carries
+    these families into one another, and the normalized restorations recover
+    the one-site and two-site letters.  Linearity in the virtual matrix gives
+    (\ref{eq:mpdo_bnt_completed_physical_map_actions}).
+\end{proof}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -197,25 +197,29 @@ Only after this trace equality is obtained do the normalizing maps in
     \widetilde R_1\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
       = \bigoplus_\gamma \frac{\mu_\gamma}{m_\gamma}\otimes X_\gamma .
 \]
-These are the maps used in
-$T=\widetilde R_2\widetilde T R_1$ and
-$S=\widetilde R_1\widetilde S R_2$.  The first denominator is normalized by
+These are the maps used in the retained-sector composites
+$T_0=\widetilde R_2\widetilde T R_1$ and
+$S_0=\widetilde R_1\widetilde S R_2$.  The first denominator is normalized by
 $\tr(\nu_\gamma)=m_\gamma$, proved above; the second by the defining equality
-$m_\gamma=\tr(\mu_\gamma)$ for the original block coefficient.
+$m_\gamma=\tr(\mu_\gamma)$ for the original block coefficient.  When a
+vertical canonical form has a discarded zero sector, these composites are
+trace preserving only on the retained physical supports.  Their completion
+to maps on the full physical matrix algebras is described in
+\path{cpgsv17_vertical_isometry_zero_sector.tex}.
 
 The present algebra predicate
 \leanid{MPOTensor.IsRFP_MPDO_via_algebra} does not include these BNT-label
 coefficients, the positive $\chi_{\alpha,\beta,\gamma}$, or the length-one
 idempotent trace identity.  It proves the fixed-point-space equation above, not
 the displayed BNT coefficient comparison.  Thus a source-faithful construction
-must first obtain the BNT-label theorem witness from the MPDO tensor and then use
-the trace identity to construct the physical trace-preserving completely
-positive maps of Appendix~C.4.  The one-site transfer-retract criterion
+must first obtain the BNT-label theorem witness from the MPDO tensor, use the
+trace identity to construct the retained-sector composites, and complete them
+on the discarded physical complements.  The one-site transfer-retract criterion
 \leanid{MPOTensor.transferRetractData_one_iff_isRFP} concerns the separate
 transfer-map idempotence predicate and cannot supply these physical maps.
 
 The scalar normalization step is now isolated independently of the still
-missing channel construction.  The structure
+missing unconditional channel construction.  The structure
 \leanid{MPOTensor.BNTMultiplicitySpectrumComparison} records the one-site
 traces and the sectorwise multiset equality obtained from the vertical BNT
 comparison at lines~2048--2058.  Given this comparison, the BNT algebra
@@ -823,9 +827,12 @@ To eliminate the source-theorem gap, the formalization should instead:
         decompositions used in Appendix~C.4, lines~2048--2058, and prove the
         unitary relabelling and the positive multiset identity for the
         $\nu_{\gamma,k}$;
-    \item deduce $\tr(\nu_\gamma)=m_\gamma$ and construct the maps
-        $T=\widetilde R_2\widetilde T R_1$ and
-        $S=\widetilde R_1\widetilde S R_2$ exactly as in lines~2065--2085;
+    \item deduce $\tr(\nu_\gamma)=m_\gamma$ and construct the retained-sector
+        composites $T_0=\widetilde R_2\widetilde T R_1$ and
+        $S_0=\widetilde R_1\widetilde S R_2$ from lines~2065--2085, then add a
+        trace-preserving completely positive completion on the orthogonal
+        complements as recorded in
+        \path{cpgsv17_vertical_isometry_zero_sector.tex};
     \item conclude the paper's renormalization fixed-point predicate, namely
         the existence of the two trace-preserving completely positive maps in
         Definition~4.1.  Any comparison with the transfer-retract predicate

--- a/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex
@@ -165,6 +165,73 @@ trace equality on these families.  No global trace-preserving extension,
 complete-positivity assertion for the finite products, or inverse relation is
 asserted.
 
+\section{Ambient completion in the converse construction}
+
+Definition~4.1 requires trace-preserving completely positive maps on the full
+one-site and two-site physical matrix algebras (source lines~638--660).  In the
+converse implication of Theorem~4.14, Appendix~C.4 instead first defines the
+retained-sector compositions
+\begin{equation}
+  T_0=\widetilde R_2\widetilde T R_1,
+  \qquad
+  S_0=\widetilde R_1\widetilde S R_2
+  \label{eq:converse-active-composites}
+\end{equation}
+at source lines~2065--2085.  Here $R_1$ and $R_2$ begin with compression by
+the one-site and two-site coisometries.  Consequently
+\begin{equation}
+  \operatorname{tr}(T_0(X))=\operatorname{tr}(P_1X),
+  \qquad
+  \operatorname{tr}(S_0(Y))=\operatorname{tr}(P_2Y),
+  \label{eq:converse-active-traces}
+\end{equation}
+where, after the canonical relabelling of the two-site indices,
+$P_i=U_i^\dagger U_i$.  These maps preserve trace on matrices supported in
+the retained sectors, but not on arbitrary ambient matrices when
+$P_i\neq I$.
+
+Put $Q_i=I-P_i$.  When $d>0$, choose density matrices $\tau_1$ and $\tau_2$
+on the one-site and two-site physical spaces.  The measure-and-prepare
+completion
+\begin{equation}
+  T(X)=T_0(X)+\operatorname{tr}(Q_1XQ_1)\tau_2,
+  \qquad
+  S(Y)=S_0(Y)+\operatorname{tr}(Q_2YQ_2)\tau_1
+  \label{eq:converse-completed-channels}
+\end{equation}
+is completely positive.  Since $Q_i$ is a projection and
+$\operatorname{tr}(\tau_i)=1$, equations
+\eqref{eq:converse-active-traces} give
+\begin{equation}
+  \operatorname{tr}(T(X))=\operatorname{tr}(X),
+  \qquad
+  \operatorname{tr}(S(Y))=\operatorname{tr}(Y).
+  \label{eq:converse-completed-traces}
+\end{equation}
+When $d=0$, both ambient physical matrix algebras contain only zero; the
+uncompleted maps are already completely positive and trace preserving, and no
+density matrix is required.
+The source does not specify the states $\tau_i$ or any other trace-restoring
+modification of the literal composites on the discarded complements.  This
+choice is immaterial for its conclusion: the reconstruction identities give
+\begin{equation}
+  P_1M_1(Z)P_1=M_1(Z),
+  \qquad
+  P_2M_2(Z)P_2=M_2(Z)
+  \label{eq:converse-source-support}
+\end{equation}
+for every virtual matrix $Z$.  Hence the added terms vanish on the family to
+which the equations at source lines~2074 and~2085 are applied.
+
+This completion is distinct from the transported maps discussed in the
+preceding section.  In the forward implication at source lines~1955--1980,
+the full physical channels are hypotheses and are compressed to retained
+sector coordinates; their possible trace loss is governed by
+\eqref{eq:transported-image-preservation}.  In the converse implication at
+source lines~2065--2085, the sector maps are used to construct full physical
+channels, and equation~\eqref{eq:converse-completed-channels} supplies the
+otherwise unspecified action on the orthogonal complements.
+
 \section{Formal correction}
 
 The vertical canonical-form predicate requires $UU^\dagger=I_s$ in the
@@ -197,6 +264,21 @@ trace consequences are
 \leanid{MPOTensor.transportedVerticalSectorT_trace_of_source_generated} and
 \leanid{MPOTensor.transportedVerticalSectorS_trace_of_source_generated}.}
 
+The general measure-and-prepare completion is recorded in
+\path{TNLean/Channel/SupportCompletion.lean}.\footnote{Formal declaration:
+\leanid{Matrix.supportCompletion\_isKrausCPTP}.}
+Under supplied unitary conjugacies between the paired sectors, the active
+compositions and the completed physical channels are recorded in
+\path{TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalPhysicalMaps.lean}.%
+\footnote{Formal declaration:
+\leanid{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+UnitarySectorConjugacy.isRFPViaTS}.}
+The existence of these unitary conjugacies is treated separately in
+\path{cpsv16_two_site_sector_unitary_gauge_gap.tex}.
+The complementary terms are choices on the discarded subspaces, not
+additional assertions of Appendix~C.4.  Their action on the source-generated
+family is fixed by \eqref{eq:converse-source-support}.
+
 \paragraph{Verdict.}
 The earlier two-sided-unitary condition was absent from the source and was
 false when the vertically viewed tensor had a zero sector.  Replacing it by
@@ -204,11 +286,16 @@ the coisometry identity $UU^\dagger=I$, while retaining exact reconstruction
 from the nonzero sectors, corrects the conclusion without adding a
 full-support hypothesis.  Literal Proposition~4.13 and the separate stronger
 horizontal theorem now prove this corrected conclusion.  This completion does
-not supply a trace-preserving map on every element of the finite products in
-Appendix~C.4; the support conditions
+not make the forward transported maps trace preserving on every element of the
+finite products in Appendix~C.4; the support conditions
 \eqref{eq:transported-image-preservation} remain necessary there.  It also
-does not prove the renormalization fixed-point characterization of
-Theorem~4.14.
+does not determine a preferred action on the discarded physical complements.
+For the converse implication, the measure-and-prepare terms in
+\eqref{eq:converse-completed-channels} give global physical channels with the
+same action on the source-generated family.  This conclusion remains
+conditional on the unitary sector conjugacies used in
+\eqref{eq:converse-active-composites}; it does not prove their unconditional
+existence in Theorem~4.14.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Mathematical result

This change completes the retained-sector composites of CPSV16 Appendix C.4 to
trace-preserving completely positive maps on the full one-site and two-site
physical matrix algebras.

- It proves a general support-completion theorem. If a completely positive map
  has trace `tr(PX)` for an orthogonal projection `P`, a
  measure-and-prepare term on `I - P` restores the full trace and vanishes on
  matrices supported by `P`.
- From a supplied
  `TwoSiteExactSectorGauge.UnitarySectorConjugacy`, it constructs the raw
  Appendix C.4 composites, proves their complete positivity and exact
  retained-support trace formulas, and proves their action on the physical
  closures.
- It completes both raw composites on the discarded zero-sector complements
  and proves that the resulting maps are Kraus CPTP. The zero-dimensional
  physical space is treated by the unique zero maps, without an additional
  public hypothesis.
- The final theorem
  `UnitarySectorConjugacy.isRFPViaTS` packages the two physical maps and their
  closure identities.

## Source faithfulness and remaining scope

The load-bearing declarations cite CPSV16 Definition 4.1, lines 638–660, and
Appendix C.4, lines 2053–2085. The trace-restoring complement is not printed in
the source; it supplies the otherwise unspecified action on the discarded
physical complements. This local correction is recorded in
`docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.

The result is conditional on the unitary sector conjugacies at Appendix C.4,
line 2057. Their unconditional derivation remains in #4648 → #4645, as recorded
in `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`. Thus this
change closes the present conditional task but does not complete or close
parent issue #5285.

## Blueprint and mathematical notes

Chapter 21 now contains the general support-completion theorem and the
conditional physical-channel theorem, with declaration links and checked
dependencies. The zero-sector note distinguishes the converse construction
from the forward transported maps, and the blocked-χ note now distinguishes
the retained composites `T₀,S₀` from their ambient CPTP completions.

## Verification

The worktree was seeded from the hot `main` cache, followed by
`lake exe cache get`; no fresh Mathlib build was performed.

- `lake env lean -DwarningAsError=true` on both new Lean files
- cache-backed named target builds and an incremental `lake build`
- `lake exe lint_style --github`
- proof-integrity, prose, line-length, module-size, generated-import, and
  numbered-module checks
- `python3 scripts/tactic_pattern_scan.py`
- `leanblueprint web`, `leanblueprint checkdecls`, and
  `leanblueprint pdf`
- visual inspection of the new PDF pages 738–739

The incremental build only replayed pre-existing warnings from unrelated
imported files. Independent audits found no mathematical, source-faithfulness,
proof-integrity, or documentation defect after the final corrections.

Closes #5320

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proofs in channel/MPDO theory with a documented off-source completion on discarded complements; conclusion remains hypothesis-dependent on unitary sector conjugacies rather than unconditional Theorem 4.14.
> 
> **Overview**
> Adds a **general support-completion** layer for completely positive maps that only preserve trace on a Hermitian projection: a measure-and-prepare term on the orthogonal complement restores full trace and agrees with the original map on supported inputs (`Matrix.supportCompletion` and `supportCompletion_isKrausCPTP`).
> 
> On top of that, the PR wires **Appendix C.4 retained-sector composites** into full physical channels: given `UnitarySectorConjugacy`, it defines raw maps `rawPhysicalT` / `rawPhysicalS`, proves CP and retained-support trace formulas, then completes them with faithful densities on the vertical **zero-sector complements** (`physicalT` / `physicalS`). Physical closures stay unchanged because closures lie in the retained supports. **`UnitarySectorConjugacy.isRFPViaTS`** packages the two Kraus CPTP maps and the Definition 4.1 closure identities, still **conditional** on the line-2057 unitary sector conjugacies.
> 
> Blueprint chapter 21 and the `cpgsv17_*` gap notes are updated to record the completion choice and to separate composites `T₀,S₀` from ambient CPTP completions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 484a90f2a9ac09ee6d95c620165a58437f877a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->