### PR TITLE
fix(tests/tenkz): honor checked equation outcomes

### DIFF
--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -1514,6 +1514,68 @@ class Audit:
     def check_equation_boundaries(self) -> None:
         if not self.tex_linked:
             return
+        relation_checks: dict[int, Event] = {}
+        check_events = [
+            event for event in self.log_events if event.kind == "check"
+        ]
+        check_offset = 0
+        equation_tokens = list(re.finditer(
+            r"\\(begin|end)\{tenkzeq\}", self._tex_src
+        ))
+        equation_stack: list[re.Match[str]] = []
+        equation_scopes: list[tuple[int, list[int], bool]] = []
+        for token in equation_tokens:
+            if token.group(1) == "begin":
+                equation_stack.append(token)
+                continue
+            if not equation_stack:
+                continue
+            begin = equation_stack.pop()
+            first_construct = next(
+                (construct for construct in self.constructs
+                 if begin.end() <= construct.start < token.start()),
+                None,
+            )
+            if first_construct is None:
+                continue
+            header = self._tex_src[begin.end():first_construct.start]
+            checked = re.search(r"\bcheck\s*=", header) is not None
+            members = [
+                index for index, construct in enumerate(self.constructs)
+                if begin.end() <= construct.start and construct.end <= token.start()
+            ]
+            relation_pairs = [
+                left for left, right in zip(members, members[1:])
+                if same_equation(
+                    self._tex_src[
+                        self.constructs[left].end:self.constructs[right].start
+                    ]
+                )
+            ]
+            equation_scopes.append((begin.start(), relation_pairs, checked))
+
+        # Every tenkzeq emits one record per relation, even without `check=`.
+        # Some `off` records precede its pictures while ordinary results follow
+        # them, so partition all records by source scope before using the
+        # relation number.  Only explicitly checked scopes may delegate.
+        for _, relation_pairs, checked in sorted(equation_scopes):
+            relation_count = len(relation_pairs)
+            if relation_count == 0:
+                continue
+            scope_events = check_events[
+                check_offset:check_offset + relation_count
+            ]
+            check_offset += relation_count
+            if not checked or len(scope_events) != relation_count:
+                continue
+            for event in scope_events:
+                relation = event.attrs.get("relation", "")
+                if not relation.isdigit():
+                    continue
+                relation_index = int(relation)
+                if 1 <= relation_index <= relation_count:
+                    relation_checks[relation_pairs[relation_index - 1]] = event
+
         for i in range(len(self.pictures) - 1):
             a, b = self.pictures[i], self.pictures[i + 1]
             if a.lang != b.lang or a.lang not in {"grid", "kernel"}:
@@ -1524,17 +1586,12 @@ class Audit:
             sep = self._tex_src[ca.end:cb.start]
             if not same_equation(sep):
                 continue
-            if a.lang == "kernel":
-                # `tenkzeq` already emits the authoritative result after
-                # applying `off=` and `modulo=bundles`.  The log-only kernel
-                # check consumes that result; do not re-check its raw panel
-                # signatures here with less policy information.
-                begin_a = self._tex_src.rfind(r"\begin{tenkzeq}", 0, ca.start)
-                end_a = self._tex_src.rfind(r"\end{tenkzeq}", 0, ca.start)
-                begin_b = self._tex_src.rfind(r"\begin{tenkzeq}", 0, cb.start)
-                end_b = self._tex_src.rfind(r"\end{tenkzeq}", 0, cb.start)
-                if begin_a > end_a and begin_a == begin_b and begin_b > end_b:
-                    continue
+            relation_check = relation_checks.get(i)
+            if (
+                relation_check is not None
+                and relation_check.attrs.get("result") in {"equal", "off"}
+            ):
+                continue
             if a.lang == "kernel":
                 sig_a, sig_b = a.kernel_boundary(), b.kernel_boundary()
             else:
@@ -1547,7 +1604,7 @@ class Audit:
                 def without_direction(item: str) -> tuple[str, ...]:
                     parts = item.split(":")
                     kind = parts[0].strip()
-                    if kind in {"open", "edge"}:
+                    if kind in {"edge", "open"}:
                         kind = "virtual"
                     weight = (
                         ":".join(parts[2:]).strip()
@@ -1692,7 +1749,7 @@ _INLINE_EQUALITY_GLUE = re.compile(
 
 def same_equation(sep: str) -> bool:
     """Heuristic: the comment-stripped source between two constructs is a
-    single displayed equation's glue iff it contains `=`, crosses no
+    single displayed equation's glue iff it contains a brace-top-level `=`, crosses no
     math-mode boundary and no other environment, and is short.  This keeps
     the check to `A = B` pairs like the gauge/blocking benchmarks.
 
@@ -1703,11 +1760,24 @@ def same_equation(sep: str) -> bool:
     """
     if _INLINE_EQUALITY_GLUE.fullmatch(sep.strip()):
         return True
-    if "=" not in sep:
-        return False
     if any(tok in sep for tok in ("$", "\\[", "\\]", "&", "\\begin", "\\end")):
         return False
-    return len(sep.strip()) <= 200
+    if len(sep.strip()) > 200:
+        return False
+    depth = 0
+    escaped = False
+    for char in sep:
+        if char == "\\":
+            escaped = not escaped
+            continue
+        if char == "{" and not escaped:
+            depth += 1
+        elif char == "}" and not escaped:
+            depth = max(0, depth - 1)
+        elif char == "=" and depth == 0:
+            return True
+        escaped = False
+    return False
 
 
 # ---------------- CLI ----------------

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1448,6 +1448,13 @@ grep -Fq 'result=equal|modulo=bundles' "$WORK/r_bundle_modulo.tnlog" || {
   echo "FAIL: bundle regrouping did not pass modulo bundles" >&2
   exit 1
 }
+python3 "$REPO/scripts/tenkz_audit.py" \
+  "$WORK/r_bundle_modulo.tnlog" "$KERNEL/regression/r_bundle_modulo.tex" \
+  >"$WORK/r_bundle_modulo.audit" || {
+  echo "FAIL: bundle modulo regression failed the event audit" >&2
+  cat "$WORK/r_bundle_modulo.audit" >&2
+  exit 1
+}
 
 bundle_modulo_negative="$KERNEL/negative/n_bundle_modulo_mismatch.tex"
 if ( cd "$WORK" &&
@@ -1502,6 +1509,13 @@ grep -Fq 'check|relation=1|result=off|reason=first' \
 grep -Fq 'check|relation=3|result=off|reason=third' \
   "$WORK/r_multiple_off.tnlog" || {
   echo "FAIL: the later equation opt-out was silently dropped" >&2
+  exit 1
+}
+python3 "$REPO/scripts/tenkz_audit.py" \
+  "$WORK/r_multiple_off.tnlog" "$KERNEL/regression/r_multiple_off.tex" \
+  >"$WORK/r_multiple_off.audit" || {
+  echo "FAIL: multiple equation opt-outs failed the event audit" >&2
+  cat "$WORK/r_multiple_off.audit" >&2
   exit 1
 }
 regression_count=$(find "$WORK" -maxdepth 1 -name 'r_*.tex' | wc -l | tr -d ' ')

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from tenkz_audit import Audit
+from tenkz_audit import Audit, same_equation
 
 
 GOOD_LOG = """\
@@ -48,6 +48,10 @@ def audit_log(log: str, source: str | None = None) -> Audit:
 
 
 def main() -> int:
+    assert not same_equation(r"\def\foo{a=b}")
+    assert not same_equation(r"\text{a=b}")
+    assert same_equation(r"\;=\;\delta_{i,j}\;")
+
     good = audit_log(GOOD_LOG)
     assert not good.findings, good.findings
     assert [event.kind for event in good.pictures[0].content()] == [
@@ -175,39 +179,12 @@ kernel-boundary|signature=phys:up
         finding.rule for finding in rotated_open_equation.findings
     ]
 
-    equivalent_virtual_equation = audit_log(
+    mixed_virtual_equation = audit_log(
         equation_log.replace("phys:up", "edge:e"),
         equation_source,
     )
     assert "eq-boundary-mismatch" not in [
-        finding.rule for finding in equivalent_virtual_equation.findings
-    ]
-
-    checked_equation_source = (
-        "\\begin{tenkzeq}[check={signature, off={1: reason}}]\n"
-        + equation_source
-        + "\\end{tenkzeq}\n"
-    )
-    checked_equation = audit_log(
-        "check|relation=1|result=off|reason=reason\n" + equation_log,
-        checked_equation_source,
-    )
-    assert "eq-boundary-mismatch" not in [
-        finding.rule for finding in checked_equation.findings
-    ]
-    bundled_equation = audit_log(
-        "check|relation=1|result=equal|modulo=bundles\n" + equation_log,
-        checked_equation_source.replace("off={1: reason}", "modulo=bundles"),
-    )
-    assert "eq-boundary-mismatch" not in [
-        finding.rule for finding in bundled_equation.findings
-    ]
-    mismatched_checked_equation = audit_log(
-        "check|relation=1|result=mismatch|reason=boundary\n" + equation_log,
-        checked_equation_source,
-    )
-    assert "kernel-check" in [
-        finding.rule for finding in mismatched_checked_equation.findings
+        finding.rule for finding in mixed_virtual_equation.findings
     ]
 
     weighted_open_equation = audit_log(
@@ -242,6 +219,58 @@ kernel-boundary|signature=phys:up
     assert "eq-boundary-mismatch" in [
         finding.rule for finding in different_bundle_equation.findings
     ]
+
+    checked_equation_source = (
+        "\\begin{tenkzeq}[check={signature, modulo=bundles}]\n"
+        "\\begin{tenkz}\\tn{A}\\end{tenkz}\n"
+        "=\n"
+        "\\begin{tenkz}\\tn{B}\\end{tenkz}\n"
+        "\\end{tenkzeq}\n"
+    )
+    checked_equation_log = (
+        equation_log.replace("open:w", "edge:w:bundle=3").replace(
+            "phys:up", "open:e"
+        )
+        + "check|relation=1|result=equal|modulo=bundles|signature=edge:e\n"
+    )
+    checked_equation = audit_log(checked_equation_log, checked_equation_source)
+    assert "eq-boundary-mismatch" not in [
+        finding.rule for finding in checked_equation.findings
+    ]
+
+    opted_out_equation = audit_log(
+        "check|relation=1|result=off|reason=documented\n" + equation_log,
+        checked_equation_source.replace(
+            "check={signature, modulo=bundles}",
+            "check={signature, off={1: documented}}",
+        ),
+    )
+    assert "eq-boundary-mismatch" not in [
+        finding.rule for finding in opted_out_equation.findings
+    ]
+
+    checkless_equation_source = (
+        "\\begin{tenkzeq}[size=m]\n"
+        + equation_source
+        + "\\end{tenkzeq}\n"
+    )
+    checked_mismatch_source = checked_equation_source.replace(
+        "check={signature, modulo=bundles}", "check={signature}"
+    )
+    matching_equation_log = equation_log.replace("phys:up", "open:e")
+    second_equation_log = equation_log.replace("k1", "k3").replace("k2", "k4")
+    mixed_equations = audit_log(
+        matching_equation_log
+        + "check|relation=1|result=equal|signature=open:e, open:w\n"
+        + second_equation_log
+        + "check|relation=1|result=mismatch|reason=boundary\n",
+        checkless_equation_source + checked_mismatch_source,
+    )
+    mixed_boundary_mismatches = [
+        finding for finding in mixed_equations.findings
+        if finding.rule == "eq-boundary-mismatch"
+    ]
+    assert len(mixed_boundary_mismatches) == 1, mixed_equations.findings
 
     overlap_log = """\
 picture|id=k1|lang=kernel

--- a/tests/tenkz/kernel/regression/r_multiple_off.tex
+++ b/tests/tenkz/kernel/regression/r_multiple_off.tex
@@ -12,9 +12,13 @@
     \tnwire{w outside}{e outside}
   \end{tenkz}
   =
-  \begin{tenkz}[rows={wire}, cols=1, bonds=none]\end{tenkz}
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+    \tn[ports={}]{A}
+  \end{tenkz}
   =
-  \begin{tenkz}[rows={wire}, cols=1, bonds=none]\end{tenkz}
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+    \tn[ports={}]{B}
+  \end{tenkz}
   =
   \begin{tenkz}[rows={wire}, cols=1, bonds=none]
     \tnwire{w outside}{e outside}


### PR DESCRIPTION
## Summary

Follow up on #5315 by making the source-linked equation audit delegate only to an emitted, accepted `tenkzeq` relation outcome. The audit associates every emitted relation record with its source equation scope and relation number, while only source scopes declaring `check=` may delegate boundary validation.

This addresses all three merged-PR boundary-audit findings:

- https://github.com/LionSR/TNLean/pull/5315#discussion_r3697048170
- https://github.com/LionSR/TNLean/pull/5315#discussion_r3697048172
- https://github.com/LionSR/TNLean/pull/5315#discussion_r3697074933

It also addresses the exact-head review findings on this draft:

- https://github.com/LionSR/TNLean/pull/5322#discussion_r3697115017
- https://github.com/LionSR/TNLean/pull/5322#discussion_r3697115019

## Root cause

The merged audit used structural nesting inside `tenkzeq` as sufficient evidence that a policy-aware result existed. A check-less equation or interrupted/missing check record could suppress a real raw boundary mismatch. In addition, `same_equation` accepted equality signs nested inside arbitrary TeX braces, so definitions and text labels could turn unrelated neighboring pictures into a hard equation-boundary failure.

A concrete compile of the existing check-less `r_basis_equation.tex` fixture confirmed that every `tenkzeq` emits one relation record even without a source `check=` key. Ignoring those records desynchronized later checked scopes.

## Changes

- Partition every emitted `tenkzeq` relation record by ordered source scope and relation index.
- Delegate only for source-declared checks whose matching outcome is accepted as `equal` or `off`; missing and mismatched outcomes retain hard findings.
- Require relation glue to contain an equality at TeX brace depth zero, while retaining inline `$=$` glue and scalar-factor separators such as `\;=\;\delta_{i,j}\;`.
- Normalize `open` and `edge` as virtual boundary kinds while keeping physical legs and normalized weights distinct.
- Drive `r_multiple_off` and `r_bundle_modulo` through named audit CLI probes that preserve failure output.

The corpus separator survey tightened 274 heuristic matches to 255 real relation pairs across 169 files. The 19 removed matches were definitions, labels, or summation indices; both existing idempotent scalar-factor separators remain matched.

## Validation

- `python3 scripts/test_tenkz_kernel_audit.py`
- `scripts/tenkz_kernel_probes.sh --check`
  - 87 review regressions
  - 8 sugar equivalences
  - 12 pinned kernel record streams
  - byte-identical kernel pixels
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
  - census stable at 200; all 132 flags carry verdicts

No Lake command was run.