### PR TITLE
fix(tests/tenkz/rmp): complete R-left operator incidence

### DIFF
--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1261,3 +1261,14 @@ The post-pull SPT panel retains the explicit physical contraction through
 the two-port `U_g` station. No parser row or case-specific metric is added.
 
 Census-correction: #5086
+
+### 2026-08-02 — projected R contractions enter the event graph
+
+M4 rises from 18.51 to 18.60. The left R panel now splits each black lattice
+carrier and each red operator string at typed ports on its seven string
+tensors. Its two horizontal rails, both diagonal ends, and all three lower
+operator continuations are semantic open ends. Thus every source contraction
+and declared boundary leg is model incidence rather than geometric
+coincidence, without changing the public language.
+
+Census-correction: #5086

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -21,7 +21,7 @@
   },
   "m4_lines_per_case": {
     "definition": "mean non-comment non-blank lines over the frozen 130 benchmark cases; the fidelity meter against fake shrink",
-    "value": 18.51
+    "value": 18.6
   },
   "m5_aliases": {
     "definition": "key and value alias rows plus sunset compliance; near zero at the 1.0 freeze",

--- a/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-r-tensor-left.tex
+++ b/tests/tenkz/rmp/section-iii-b/cases/rmp-iii-b-r-tensor-left.tex
@@ -19,40 +19,51 @@
     \tn[at=(3,1), name=v, ports={90:physical}]{}
     \tnwire[name=iphys]{i.90}{open n}
     \tnwire[name=vphys]{v.90}{open n}
-    % String tensors own named virtual faces on the black rails: three on the
-    % lower rail and four ringing the anyon.  Their placement uses only the
-    % plane basis and named-address constructions.
-    \tn[at=(3,2), name=bL, role=extra, label pos=s,
-      ports={0:virtual,180:virtual}]{b}
-    \tn[at=(3,3), name=bR, role=extra, label pos=se,
-      ports={0:virtual,180:virtual}]{b}
-    \tn[at=midway bL and bR, name=aa, role=marked, label pos=sw,
-      ports={0:virtual,180:virtual}]{a}
+    % The seven string tensors own separate lattice and operator ports.  Their
+    % named placements use only the plane frame's relative-address grammar.
+    \tn[at=1 e of v, name=bL, role=extra, label pos=s,
+      ports={0:virtual,60:virtual,180:virtual,270:virtual}]{b}
+    \tn[at=1.5 e of v, name=aa, role=marked, label pos=s,
+      ports={0:virtual,90:virtual,180:virtual,270:virtual}]{a}
+    \tn[at=2 e of v, name=bR, role=extra, label pos=s,
+      ports={0:virtual,90:virtual,180:virtual,270:virtual}]{b}
     \tn[at=midway i and v, name=rS, role=extra,
-      ports={45:virtual,225:virtual}]{}
-    \tn[at=midway (1,1) and i, name=rW, role=extra,
-      ports={0:virtual,180:virtual}]{}
-    \tn[at=midway i and 1 n of 1 e of i, name=rN, role=extra,
-      ports={45:virtual,225:virtual}]{}
-    \tn[at=midway i and (1,3), name=rE, role=extra, label pos=ne,
-      ports={0:virtual,180:virtual}]{b}
-    % Two horizontal rails and the diagonal transversal terminate on those
-    % faces, so every black contraction belongs to the semantic graph.
+      ports={30:virtual,90:virtual,210:virtual,240:virtual}]{}
+    \tn[at=0.5 w of i, name=rW, role=extra,
+      ports={0:virtual,45:virtual,180:virtual,270:virtual}]{}
+    \tn[at=0.7 ne of i, name=rN, role=extra,
+      ports={45:virtual,180:virtual,225:virtual,270:virtual}]{}
+    \tn[at=1 e of i, name=rE, role=extra, label pos=ne,
+      ports={0:virtual,90:virtual,180:virtual,270:virtual}]{b}
+    % Each black carrier terminates on the two lattice-facing ports.
     \tnwire{open w}{rW.180} \tnwire{rW.0}{i.w}
     \tnwire{i.e}{rE.180} \tnwire{rE.0}{open e}
     \tnwire{open w}{v.w} \tnwire{v.e}{bL.180}
     \tnwire{bL.0}{aa.180} \tnwire{aa.0}{bR.180}
     \tnwire{bR.0}{open e}
     \tnwire{i.45}{rN.225} \tnwire{rN.45}{open ne}
-    \tnwire{i.225}{rS.45} \tnwire{rS.225}{v.45}
+    \tnwire{i.225}{rS.30} \tnwire{rS.210}{v.45}
     \tnwire{v.225}{open sw}
-    % the b string winds once around the anyon, passing under its physical leg
-    \tnwire[kind=string, species=operator, name=s,
-            via={bL, rS, rW, midway i and rN, rN, rE, bR},
-            cross={under at crossing of s and iphys}]
-           {1 s of bL}{1 s of bR}
-    % The i string lands on the a station before continuing below the rail.
-    \tnwire[kind=string, species=operator, name=t,
-            via={aa}]{i.315}{open s}
+    % The b string is a chain of port-owned segments.  Only the segment from
+    % rW to rN crosses the physical leg, with the source's under-order.
+    \tnwire[kind=string, species=operator, name=s-in]
+      {open s}{bL.270}
+    \tnwire[kind=string, species=operator, name=s-bL-rS]
+      {bL.60}{rS.240}
+    \tnwire[kind=string, species=operator, name=s-rS-rW]
+      {rS.90}{rW.270}
+    \tnwire[kind=string, species=operator, name=s-rW-rN,
+      via={midway i and rN},
+      cross={under at crossing of s-rW-rN and iphys}]
+      {rW.45}{rN.180}
+    \tnwire[kind=string, species=operator, name=s-rN-rE]
+      {rN.270}{rE.90}
+    \tnwire[kind=string, species=operator, name=s-rE-bR]
+      {rE.270}{bR.90}
+    \tnwire[kind=string, species=operator, name=s-out]
+      {bR.270}{open s}
+    % The i string terminates on both operator-facing ports of a.
+    \tnwire[kind=string, species=operator, name=t-in]{i.315}{aa.90}
+    \tnwire[kind=string, species=operator, name=t-out]{aa.270}{open s}
   \end{tenkz}
 \]

--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -3,7 +3,7 @@
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
 pairing_sha256 = "b3375317e8dddb4402eda08b0d74e1aaa4789467cf5a84fe4d4bd722ef470e89"
-campaign_sha256 = "d7d2b456aec151048b28665f01d71493048c901ebb6ba43d41ba18667783f1e2"
+campaign_sha256 = "3b107105285885a085972b0598e8b37a3add3af253c3484c17f082a03af347d8"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"
@@ -747,11 +747,11 @@ status = "faithful"
 pairing = "verified"
 pairing_by = "codex-source-and-annotation-review-2026-08-01"
 defects = []
-case_sha256 = "5e93377ce5007cc6bd60e346a2f5ebe0146bca5314efc4a1c6d5054199e74fa6"
-second_viewer = "rmp-r-resolver-named-contract-review-2026-08-01"
-reviewed = "2026-08-01"
-renderer = "codex-named-ring-contract-source-review-2026-08-01-300dpi"
-note = "one plane basis carries both rails and the diagonal transversal; the b winding contracts with all four ring tensors and both b stations, passes under i's leg, and the i-string runs from i through a"
+case_sha256 = "50c2435dfff2fd51eeaddf2d8d79aaf49cebd9e64bd6626a96bc790c7ee11038"
+second_viewer = "codex-semantic-boundary-source-review-2026-08-02"
+reviewed = "2026-08-02"
+renderer = "codex-semantic-boundary-source-review-2026-08-02-300dpi"
+note = "one plane basis carries both rails and the diagonal transversal; seven four-port tensors split their black carriers and red operator strings, all nine virtual boundary legs are semantic open events, the rW-to-rN segment passes under i's leg, and the i-string terminates on a"
 
 [[verdict]]
 id = "rmp-iii-b-r-tensor-right"


### PR DESCRIPTION
## Summary

Follow-up to LionSR/TNLean#5315. The merged R-left panel split the black rails, but its seven string stations still had only the rail-facing ports and the red `s` and `t` operators passed through them as geometric waypoints.

This draft completes the incidence model:

- gives all seven string tensors distinct lattice-facing and operator-facing ports;
- splits the red winding into seven face-to-face segments and the `i` string into two segments terminating on `a`;
- preserves the source under-crossing and ordering while making every declared boundary leg a kernel event;
- updates the verdict and M4 census, with an append-only shrink session.

No parser, kernel, grammar, or public-language change is included.

## Root cause

LionSR/TNLean#5315 made the black carriers semantic but left the operator contractions encoded only by `via` waypoints. Visual coincidence therefore still stood in for the source's tensor incidence at the seven stations.

## Validation

- `python3 scripts/tenkz_rmp.py check --id rmp-iii-b-r-tensor-left`
- `python3 scripts/tenkz_rmp.py check --section section-iii-b` (11/11)
- `python3 scripts/tenkz_language.py check` (226 records)
- focused kernel and equation audit tests
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref 010dfabe5cf2ab485d6f0f3410c47990f29c5552` (200 census, 132 flags)
- `TENKZ_CORPUS_JOBS=4 scripts/tenkz_corpus.sh` (264/264)

The refreshed 300-dpi source comparison preserves the panel order and topology. Its exact boundary signature is:

`open:e, open:e, open:ne, open:s, open:s, open:s, open:sw, open:w, open:w, phys:n, phys:n`

The reviewed case hash is `50c2435dfff2fd51eeaddf2d8d79aaf49cebd9e64bd6626a96bc790c7ee11038`.

After integrating LionSR/TNLean#5318, the combined M4 is `18.6` and the campaign digest is `3b107105285885a085972b0598e8b37a3add3af253c3484c17f082a03af347d8`.
