### PR TITLE
chore(tests/tenkz/rmp): refresh campaign digest

### DIFF
--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -3,7 +3,7 @@
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
 pairing_sha256 = "b3375317e8dddb4402eda08b0d74e1aaa4789467cf5a84fe4d4bd722ef470e89"
-campaign_sha256 = "d7d2b456aec151048b28665f01d71493048c901ebb6ba43d41ba18667783f1e2"
+campaign_sha256 = "9329171ae1126dcab8467201a57a125905a1b6a31a3a86eba5921e4386f3134b"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"


### PR DESCRIPTION
### Motivation

PR LionSR/TNLean#5318 refreshed the RMP campaign digest on its branch, but LionSR/TNLean#5322 changed
`scripts/tenkz_audit.py` before LionSR/TNLean#5318 landed. That audit file is deliberately
part of `campaign_digest`, so merged `main` warned that the campaign record was
stale even though every per-case hash remained valid.

Addresses LionSR/tenkz#113.

### Description

- refresh `campaign_sha256` against the combined landed state of LionSR/TNLean#5318 and
  LionSR/TNLean#5322;
- make no case, renderer, metric, parser, or verdict-status change.

### Testing

Validated at exact head `bfdcadd798a87f623df63493a2dc8c29c27740bc`:

- recomputed campaign digest equals the recorded
  `9329171ae1126dcab8467201a57a125905a1b6a31a3a86eba5921e4386f3134b`;
- `TENKZ_RMP_JOBS=1 python3 scripts/tenkz_rmp.py check --id rmp-iii-a-spt-mpo`
  passes without the stale-campaign warning;
- `python3 scripts/test_tenkz_corpus_provenance.py`;
- `python3 scripts/test_tenkz_shrink.py`;
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`;
- `git diff --check origin/main...HEAD`.

Before this one-line ledger update, the full merged-main benchmark build passed
all 130 targets, including both GHZ cases and the three LionSR/TNLean#5318 cases. No Lake
command was run because this PR changes only the RMP verdict ledger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata hash in a test ledger; no runtime or verdict logic changes.
> 
> **Overview**
> Updates **`campaign_sha256`** in `tests/tenkz/rmp/verdicts.toml` so the RMP verdict ledger matches the current **`campaign_digest`** after merged changes (including updates to `scripts/tenkz_audit.py`, which is hashed as part of that digest).
> 
> No per-target verdict fields change—statuses, `case_sha256`, renderers, and pairing metadata stay the same. This clears the stale-campaign warning from `tenkz_rmp.py check` without re-reviewing cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfdcadd798a87f623df63493a2dc8c29c27740bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->