### PR TITLE
chore(tests/tenkz/rmp): refresh campaign digest

### DIFF
--- a/tests/tenkz/rmp/verdicts.toml
+++ b/tests/tenkz/rmp/verdicts.toml
@@ -3,7 +3,7 @@
 # recorded, including failure; the check rejects lies, never gaps.
 schema_version = 1
 pairing_sha256 = "b3375317e8dddb4402eda08b0d74e1aaa4789467cf5a84fe4d4bd722ef470e89"
-campaign_sha256 = "3b107105285885a085972b0598e8b37a3add3af253c3484c17f082a03af347d8"
+campaign_sha256 = "9e0fa1f42fda08bcd97aa528178e931cb370e0f3b9e361f00f4c927948bb3be7"
 
 [[verdict]]
 id = "rmp-ii-peps-projection"


### PR DESCRIPTION
## Summary

- follow up on #5325 by recomputing the RMP campaign digest from exact main `c4a7b8a91286117d9d3447b3554d06672c90f520`
- update only `campaign_sha256`; verdict statuses, pairing provenance, and per-case hashes are unchanged
- supersede the closed #5324 digest, which correctly represented the intermediate #5318/#5322 state before #5325 changed hashed audit, parser, and kernel inputs

Computed digest: `9e0fa1f42fda08bcd97aa528178e931cb370e0f3b9e361f00f4c927948bb3be7`

## Validation

- computed digest equals the recorded digest
- `TENKZ_RMP_JOBS=1 python3 scripts/tenkz_rmp.py check --id rmp-iii-a-spt-mpo` (no stale-campaign warning)
- `python3 scripts/test_tenkz_corpus_provenance.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `git diff --check`

No Lake commands were run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in a test benchmark ledger; no runtime or product logic changes.
> 
> **Overview**
> Updates **`campaign_sha256`** in `tests/tenkz/rmp/verdicts.toml` so the ledger matches the campaign inputs on current main (after #5325), replacing the digest that reflected the pre-#5325 audit/parser/kernel state.
> 
> No verdict rows, statuses, pairing provenance, or per-case hashes change—only the top-level campaign fingerprint is bumped to `9e0fa1f42fda08bcd97aa528178e931cb370e0f3b9e361f00f4c927948bb3be7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ab0d1d1fcbe56aa97348476423333d32fd5083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->