### PR TITLE
fix(tenkz): require equation check scopes

### DIFF
--- a/scripts/tenkzlib/tnlog.py
+++ b/scripts/tenkzlib/tnlog.py
@@ -354,6 +354,13 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
     },
 }
 
+# Fields whose absence makes an otherwise typed event unusable.  Most event
+# kinds are picture records and use the shared picture= requirement below;
+# equation checks are top-level records whose scope is their ownership key.
+REQUIRED_FIELDS: dict[str, frozenset[str]] = {
+    "check": frozenset({"scope"}),
+}
+
 
 @dataclass
 class Event:
@@ -497,6 +504,14 @@ def parse_log(
                         f"{kind} field {key}={value!r} fails validation: {line}",
                     )
                     valid = False
+            missing = sorted(REQUIRED_FIELDS.get(kind, frozenset()) - attrs.keys())
+            if missing:
+                hard(
+                    "malformed-event",
+                    where,
+                    f"{kind} event lacks required field(s): {', '.join(missing)}: {line}",
+                )
+                valid = False
             if kind != "picture" and "picture" not in attrs:
                 if current_kernel is not None and kind in {
                     "atom",

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -21,7 +21,7 @@ string|id=b|kind=open|pts=2
 string|id=c|kind=wind|pts=2
 string|id=d|kind=around|pts=2
 stringcross|under=b|over=a|hits=1
-check|relation=1|result=equal|signature=open:e, open:w
+check|scope=1|relation=1|result=equal|signature=open:e, open:w
 """
 
 

--- a/scripts/test_tnlog.py
+++ b/scripts/test_tnlog.py
@@ -57,6 +57,7 @@ def main() -> int:
                 "atom|picture=oops|cell=1-1|name=A|kind=tensor",
                 "frame|picture=1|scope=atom|map=rotate(30)|"
                 "a=bad|b=0|c=0|d=1",
+                "check|relation=1|result=equal|signature=open:e",
                 "mystery|picture=2|bare",
             )
         ),
@@ -71,6 +72,11 @@ def main() -> int:
         "dangling-picture-ref",
     }
     assert {finding[0] for finding in notes} == {"unknown-event", "unknown-lang"}
+    assert any(
+        finding[0] == "malformed-event"
+        and "check event lacks required field(s): scope" in finding[2]
+        for finding in malformed
+    )
 
     assert AuditEvent is Event
     assert AuditPicture is Picture


### PR DESCRIPTION
## Summary

- require `scope` on typed `check` events
- report an unscoped check as a hard `malformed-event`
- cover the parser contract and update the kernel-audit fixture to the scoped format

Follow-up to the late review thread on #5325.

## Validation

- `python3 scripts/test_tnlog.py`
- `python3 scripts/test_tenkz_kernel_audit.py`
- `python3 -m py_compile scripts/tenkzlib/tnlog.py scripts/test_tnlog.py scripts/test_tenkz_kernel_audit.py`
- `git diff --check`

No Lake command was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser validation-only change in tenkz log tooling; no runtime auth, data, or production paths affected.
> 
> **Overview**
> The tnlog parser now treats **`scope`** as mandatory on **`check`** events (top-level equation checks keyed by scope, not `picture=`). Missing `scope` is reported as a hard **`malformed-event`** via a new **`REQUIRED_FIELDS`** map, alongside existing per-field validators.
> 
> Tests add an unscoped `check` line to the malformed fixture and assert the new message; the kernel-audit golden log’s `check` line is updated to **`scope=1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8554ffae03eebe74fbb06f217f100e96e7f143fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->