### PR TITLE
fix(tenkz): fail closed on equation scopes

### DIFF
--- a/scripts/check_tenkz_dispositions.py
+++ b/scripts/check_tenkz_dispositions.py
@@ -12,7 +12,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
-from tenkzlib.texcase import Construct, match_group, scan_constructs, strip_comments
+from tenkzlib.texcase import (
+    Construct,
+    following_group,
+    following_group_span,
+    match_group,
+    scan_constructs,
+    strip_comments,
+    top_level_options,
+)
 from tenkz_language import load_registry
 
 
@@ -177,59 +185,6 @@ def normalized_environment_spacing(source: str) -> str:
         return rf"\{match.group(1)}{{{match.group(4)}}}" + whitespace
 
     return pattern.sub(replace, source)
-
-
-def top_level_options(options: str) -> list[tuple[str, str | None]]:
-    """Parse one comma-separated option group without splitting nested values."""
-    start = 0
-    depths = {"{": 0, "[": 0, "(": 0}
-    closing = {"}": "{", "]": "[", ")": "("}
-    parts: list[str] = []
-    index = 0
-    while index < len(options):
-        character = options[index]
-        if character == "\\":
-            index += 2
-            continue
-        if character in depths:
-            depths[character] += 1
-        elif character in closing:
-            opener = closing[character]
-            depths[opener] = max(0, depths[opener] - 1)
-        elif character == "," and not any(depths.values()):
-            parts.append(options[start:index])
-            start = index + 1
-        index += 1
-    parts.append(options[start:])
-    result: list[tuple[str, str | None]] = []
-    for part in parts:
-        key, separator, value = part.partition("=")
-        key = re.sub(r"\s+", " ", key.strip())
-        if key:
-            result.append((key, value.strip() if separator else None))
-    return result
-
-
-def following_group_span(
-    source: str, position: int, opener: str, closer: str
-) -> tuple[str, int] | None:
-    """Return a following group's contents and ending offset."""
-    while position < len(source) and source[position].isspace():
-        position += 1
-    if source[position : position + 1] != opener:
-        return None
-    end = match_group(source, position, opener, closer)
-    if end == -1:
-        return None
-    return source[position + 1 : end - 1], end
-
-
-def following_group(
-    source: str, position: int, opener: str, closer: str
-) -> str | None:
-    """Return the contents of a group following optional whitespace."""
-    group = following_group_span(source, position, opener, closer)
-    return group[0] if group is not None else None
 
 
 def encountered_option_groups(source: str) -> list[tuple[str, str]]:

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -773,7 +773,7 @@ class Audit:
                     "boundary records; expected exactly one",
                 )
         for event in self.log_events:
-            if event.kind != "check":
+            if event.kind != "check" or not event.valid:
                 continue
             # The canonical parser already reports these record-level fields;
             # keep invalid events out of the semantic checks without emitting
@@ -1535,7 +1535,7 @@ class Audit:
         picture_scopes: dict[int, int] = {}
         scope_pictures: dict[int, list[int]] = {}
         for event in self.log_events:
-            if event.kind != "picture":
+            if event.kind != "picture" or not event.valid:
                 continue
             scope = event.attrs.get("scope", "")
             picture = picture_indices.get(event.attrs.get("id", ""))
@@ -1548,7 +1548,7 @@ class Audit:
         scope_events: dict[int, list[Event]] = {}
         malformed_scopes: set[int] = set()
         for event in self.log_events:
-            if event.kind != "check":
+            if event.kind != "check" or not event.valid:
                 continue
             scope = event.attrs.get("scope", "")
             if not scope.isdigit():

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -775,9 +775,20 @@ class Audit:
         for event in self.log_events:
             if event.kind != "check":
                 continue
-            if not self.require_fields(event, {"result"}, "check"):
+            # The canonical parser already reports these record-level fields;
+            # keep invalid events out of the semantic checks without emitting
+            # the same malformed-event finding twice.
+            if not {"scope", "result"}.issubset(event.attrs):
                 continue
             result = event.attrs["result"]
+            if result != "malformed" and not self.require_fields(
+                event, {"relation"}, "check"
+            ):
+                continue
+            if result == "off" and not self.require_fields(
+                event, {"reason"}, "check opt-out"
+            ):
+                continue
             if result in {"mismatch", "malformed"}:
                 relation = event.attrs.get("relation", "?")
                 self.hard(
@@ -1534,18 +1545,19 @@ class Audit:
             picture_scopes[picture] = scope_index
             scope_pictures.setdefault(scope_index, []).append(picture)
 
-        relation_events: dict[tuple[int, int], list[Event]] = {}
+        scope_events: dict[int, list[Event]] = {}
         malformed_scopes: set[int] = set()
         for event in self.log_events:
             if event.kind != "check":
                 continue
             scope = event.attrs.get("scope", "")
-            if scope.isdigit() and event.attrs.get("result") == "malformed":
-                malformed_scopes.add(int(scope))
-            relation = event.attrs.get("relation", "")
-            if not scope.isdigit() or not relation.isdigit():
+            if not scope.isdigit():
                 continue
-            relation_events.setdefault((int(scope), int(relation)), []).append(event)
+            scope_index = int(scope)
+            if event.attrs.get("result") == "malformed":
+                malformed_scopes.add(scope_index)
+                continue
+            scope_events.setdefault(scope_index, []).append(event)
 
         equation_tokens = list(re.finditer(
             r"\\(begin|end)\{tenkzeq\}", self._tex_src
@@ -1569,6 +1581,12 @@ class Audit:
             checked = re.search(r"\bcheck\s*=", header) is not None
             if not checked:
                 continue
+            declared_offs = {
+                int(match.group(1))
+                for match in re.finditer(
+                    r"\boff\s*=\s*\{\s*(\d+)\s*:", header
+                )
+            }
             members = [
                 index for index, construct in enumerate(self.constructs)
                 if begin.end() <= construct.start and construct.end <= token.start()
@@ -1581,11 +1599,35 @@ class Audit:
             )
             if scope in malformed_scopes or scope_pictures.get(scope) != members:
                 continue
+            expected_relations = set(range(1, len(members)))
+            events = scope_events.get(scope, [])
+            relation_numbers = [
+                int(event.attrs["relation"])
+                for event in events
+                if event.attrs.get("relation", "").isdigit()
+            ]
+            # Every non-malformed event in the scope must own exactly one
+            # expected relation.  Missing, duplicate, unowned, and surplus
+            # records disable the whole scope instead of authorizing a waiver.
+            if (
+                len(events) != len(expected_relations)
+                or len(relation_numbers) != len(events)
+                or set(relation_numbers) != expected_relations
+            ):
+                continue
+            by_relation = {
+                int(event.attrs["relation"]): event for event in events
+            }
+            logged_offs = {
+                relation for relation, event in by_relation.items()
+                if event.attrs.get("result") == "off"
+            }
+            # An event-stream opt-out is authority only when the same relation
+            # is explicitly waived in this source scope.
+            if logged_offs != declared_offs:
+                continue
             for relation, left in enumerate(members[:-1], 1):
-                events = relation_events.get((scope, relation), [])
-                if len(events) != 1:
-                    continue
-                relation_checks[left] = events[0]
+                relation_checks[left] = by_relation[relation]
 
         for i in range(len(self.pictures) - 1):
             a, b = self.pictures[i], self.pictures[i + 1]

--- a/scripts/tenkz_audit.py
+++ b/scripts/tenkz_audit.py
@@ -94,7 +94,14 @@ from fractions import Fraction
 from pathlib import Path
 from typing import Optional
 
-from tenkzlib.texcase import Construct, scan_constructs, strip_comments
+from tenkzlib.texcase import (
+    Construct,
+    following_group,
+    following_group_span,
+    scan_constructs,
+    strip_comments,
+    top_level_options,
+)
 from tenkzlib.tnlog import (
     FIELD_VALIDATORS,
     Event,
@@ -477,7 +484,7 @@ class Audit:
                 self.check_tree_event(event) if event.kind == "tree" else None
             ),
         )
-        self.log_events = parsed.events
+        self.log_events = parsed.valid_events
         self.pictures = parsed.pictures
         self.by_id = parsed.by_id
 
@@ -773,22 +780,9 @@ class Audit:
                     "boundary records; expected exactly one",
                 )
         for event in self.log_events:
-            if event.kind != "check" or not event.valid:
-                continue
-            # The canonical parser already reports these record-level fields;
-            # keep invalid events out of the semantic checks without emitting
-            # the same malformed-event finding twice.
-            if not {"scope", "result"}.issubset(event.attrs):
+            if event.kind != "check":
                 continue
             result = event.attrs["result"]
-            if result != "malformed" and not self.require_fields(
-                event, {"relation"}, "check"
-            ):
-                continue
-            if result == "off" and not self.require_fields(
-                event, {"reason"}, "check opt-out"
-            ):
-                continue
             if result in {"mismatch", "malformed"}:
                 relation = event.attrs.get("relation", "?")
                 self.hard(
@@ -1535,7 +1529,7 @@ class Audit:
         picture_scopes: dict[int, int] = {}
         scope_pictures: dict[int, list[int]] = {}
         for event in self.log_events:
-            if event.kind != "picture" or not event.valid:
+            if event.kind != "picture":
                 continue
             scope = event.attrs.get("scope", "")
             picture = picture_indices.get(event.attrs.get("id", ""))
@@ -1548,7 +1542,7 @@ class Audit:
         scope_events: dict[int, list[Event]] = {}
         malformed_scopes: set[int] = set()
         for event in self.log_events:
-            if event.kind != "check" or not event.valid:
+            if event.kind != "check":
                 continue
             scope = event.attrs.get("scope", "")
             if not scope.isdigit():
@@ -1577,16 +1571,9 @@ class Audit:
             )
             if first_construct is None:
                 continue
-            header = self._tex_src[begin.end():first_construct.start]
-            checked = re.search(r"\bcheck\s*=", header) is not None
-            if not checked:
+            declared_offs = _tenkzeq_declared_offs(self._tex_src, begin.end())
+            if declared_offs is None:
                 continue
-            declared_offs = {
-                int(match.group(1))
-                for match in re.finditer(
-                    r"\boff\s*=\s*\{\s*(\d+)\s*:", header
-                )
-            }
             members = [
                 index for index, construct in enumerate(self.constructs)
                 if begin.end() <= construct.start and construct.end <= token.start()
@@ -1798,6 +1785,34 @@ _INLINE_EQUALITY_SPACE = r"(?:\s|\\[,;:!]|\\(?:quad|qquad)\b)*"
 _INLINE_EQUALITY_GLUE = re.compile(
     rf"\${_INLINE_EQUALITY_SPACE}={_INLINE_EQUALITY_SPACE}\$"
 )
+
+
+def _tenkzeq_declared_offs(source: str, position: int) -> set[int] | None:
+    """Return source-authorized opt-outs from one equation's actual options.
+
+    ``None`` means that the environment has no single top-level ``check`` key,
+    so its event records cannot authorize source-linked boundary delegation.
+    """
+    options = following_group(source, position, "[", "]")
+    if options is None:
+        return None
+    check_values = [
+        value for key, value in top_level_options(options) if key == "check"
+    ]
+    if len(check_values) != 1 or check_values[0] is None:
+        return None
+    check_value = check_values[0]
+    grouped = following_group_span(check_value, 0, "{", "}")
+    if grouped is not None and not check_value[grouped[1] :].strip():
+        check_value = grouped[0]
+    declared: set[int] = set()
+    for key, value in top_level_options(check_value):
+        if key != "off" or value is None:
+            continue
+        match = re.fullmatch(r"\{\s*(\d+)\s*:\s*[^}]*\}", value)
+        if match is not None:
+            declared.add(int(match.group(1)))
+    return declared
 
 
 def same_equation(sep: str) -> bool:

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1489,6 +1489,10 @@ grep -Fq '[TKZ-EQ-NESTED]' "$WORK/n_nested_equation.transcript" || {
   echo "FAIL: nested equation lacked TKZ-EQ-NESTED" >&2
   exit 1
 }
+[ -f "$WORK/n_nested_equation.tnlog" ] || {
+  echo "FAIL: nested equation did not write its audit log" >&2
+  exit 1
+}
 if grep -Fq '|scope=2' "$WORK/n_nested_equation.tnlog"; then
   echo "FAIL: a rejected nested equation mutated scope ownership" >&2
   exit 1

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1476,6 +1476,24 @@ grep -Fq 'result=mismatch|modulo=bundles' \
   exit 1
 }
 
+nested_equation="$KERNEL/negative/n_nested_equation.tex"
+if ( cd "$WORK" &&
+     TEXINPUTS="$REPO/tex/tenkz//:" \
+       timeout 120 xelatex -interaction=nonstopmode -halt-on-error \
+       "$nested_equation" \
+       >"$WORK/n_nested_equation.transcript" 2>&1 ); then
+  echo "FAIL: a nested equation audit scope was accepted" >&2
+  exit 1
+fi
+grep -Fq '[TKZ-EQ-NESTED]' "$WORK/n_nested_equation.transcript" || {
+  echo "FAIL: nested equation lacked TKZ-EQ-NESTED" >&2
+  exit 1
+}
+if grep -Fq '|scope=2' "$WORK/n_nested_equation.tnlog"; then
+  echo "FAIL: a rejected nested equation mutated scope ownership" >&2
+  exit 1
+fi
+
 for arity_negative in n_missing_relation n_dangling_relation; do
   source="$KERNEL/negative/$arity_negative.tex"
   if ( cd "$WORK" &&

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1489,11 +1489,11 @@ grep -Fq '[TKZ-EQ-NESTED]' "$WORK/n_nested_equation.transcript" || {
   echo "FAIL: nested equation lacked TKZ-EQ-NESTED" >&2
   exit 1
 }
-[ -f "$WORK/n_nested_equation.tnlog" ] || {
-  echo "FAIL: nested equation did not write its audit log" >&2
+grep -Eq '(^|[|])scope=1([|]|$)' "$WORK/n_nested_equation.tnlog" || {
+  echo "FAIL: nested equation did not preserve its outer audit scope" >&2
   exit 1
 }
-if grep -Fq '|scope=2' "$WORK/n_nested_equation.tnlog"; then
+if grep -Eq '(^|[|])scope=2([|]|$)' "$WORK/n_nested_equation.tnlog"; then
   echo "FAIL: a rejected nested equation mutated scope ownership" >&2
   exit 1
 fi

--- a/scripts/tenkz_rmp.py
+++ b/scripts/tenkz_rmp.py
@@ -160,7 +160,7 @@ def rendered_ink_environment_families(parsed: ParsedLog) -> set[str]:
     """Return picture owners from the compiled model event stream."""
     languages = {
         event.attrs["lang"]
-        for event in parsed.events
+        for event in parsed.valid_events
         if event.kind == "picture"
     }
     unknown_languages = languages.difference((*INK_EVENT_FAMILIES, "lattice"))
@@ -176,19 +176,19 @@ def rendered_ink_environment_families(parsed: ParsedLog) -> set[str]:
     }
     if any(
         event.kind == "tree" and event.attrs["picture"] == "0"
-        for event in parsed.events
+        for event in parsed.valid_events
     ):
         # A command-scope \tntree is a complete public tenkz composition but
         # deliberately logs against picture 0 rather than opening a container.
         families.add("tenkz")
     lattice_pictures = {
         event.attrs["id"]
-        for event in parsed.events
+        for event in parsed.valid_events
         if event.kind == "picture" and event.attrs["lang"] == "lattice"
     }
     planes_pictures = {
         event.attrs["picture"]
-        for event in parsed.events
+        for event in parsed.valid_events
         if event.kind == "surface" and event.attrs["name"] == "tenkzplanes"
     }
     if planes_pictures.difference(lattice_pictures):
@@ -807,7 +807,7 @@ def event_signatures(parsed: ParsedLog) -> tuple[str, ...]:
     """Return concise signatures from a parsed render event stream."""
     boundaries = tuple(
         event.raw
-        for event in parsed.events
+        for event in parsed.valid_events
         if event.kind in {"boundary", "kernel-boundary"}
     )
     if boundaries:
@@ -816,7 +816,7 @@ def event_signatures(parsed: ParsedLog) -> tuple[str, ...]:
     languages: dict[str, str] = {}
     counts: dict[str, Counter[str]] = {}
     boundary_atoms: Counter[str] = Counter()
-    for event in parsed.events:
+    for event in parsed.valid_events:
         if event.kind == "picture":
             picture = event.attrs.get("id", "?")
             languages[picture] = event.attrs.get("lang", "unknown")

--- a/scripts/tenkzlib/texcase.py
+++ b/scripts/tenkzlib/texcase.py
@@ -72,6 +72,59 @@ def match_group(
     return -1
 
 
+def following_group_span(
+    source: str, position: int, opener: str, closer: str
+) -> tuple[str, int] | None:
+    """Return a following group's contents and ending offset."""
+    while position < len(source) and source[position].isspace():
+        position += 1
+    if source[position : position + 1] != opener:
+        return None
+    end = match_group(source, position, opener, closer)
+    if end == -1:
+        return None
+    return source[position + 1 : end - 1], end
+
+
+def following_group(
+    source: str, position: int, opener: str, closer: str
+) -> str | None:
+    """Return the contents of a group following optional whitespace."""
+    group = following_group_span(source, position, opener, closer)
+    return group[0] if group is not None else None
+
+
+def top_level_options(options: str) -> list[tuple[str, str | None]]:
+    """Parse one comma-separated option group without splitting nested values."""
+    start = 0
+    depths = {"{": 0, "[": 0, "(": 0}
+    closing = {"}": "{", "]": "[", ")": "("}
+    parts: list[str] = []
+    index = 0
+    while index < len(options):
+        character = options[index]
+        if character == "\\":
+            index += 2
+            continue
+        if character in depths:
+            depths[character] += 1
+        elif character in closing:
+            opener = closing[character]
+            depths[opener] = max(0, depths[opener] - 1)
+        elif character == "," and not any(depths.values()):
+            parts.append(options[start:index])
+            start = index + 1
+        index += 1
+    parts.append(options[start:])
+    result: list[tuple[str, str | None]] = []
+    for part in parts:
+        key, separator, value = part.partition("=")
+        key = re.sub(r"\s+", " ", key.strip())
+        if key:
+            result.append((key, value.strip() if separator else None))
+    return result
+
+
 def _find_env_end(
     source: str, name: str, position: int
 ) -> re.Match[str] | None:

--- a/scripts/tenkzlib/tnlog.py
+++ b/scripts/tenkzlib/tnlog.py
@@ -369,6 +369,7 @@ class Event:
     attrs: dict[str, str]
     line: int
     raw: str
+    valid: bool = True  # False when canonical parsing rejects the record.
 
 
 @dataclass
@@ -499,7 +500,7 @@ def parse_log(
                 valid = False
                 continue
             attrs[key] = value.strip()
-        event = Event(kind, attrs, line_number, line)
+        event = Event(kind, attrs, line_number, line, valid)
         events.append(event)
         validators = FIELD_VALIDATORS.get(kind)
         if validators is None:
@@ -522,6 +523,7 @@ def parse_log(
                     f"{kind} event lacks required field(s): {', '.join(missing)}: {line}",
                 )
                 valid = False
+            event.valid = valid
             if kind != "picture" and "picture" not in attrs:
                 if current_kernel is not None and kind in {
                     "atom",
@@ -535,10 +537,11 @@ def parse_log(
                 }:
                     # A kernel record: it belongs to the open kernel picture
                     # by nesting, not by a picture= field.
-                    current_kernel.events.append(event)
+                    if event.valid:
+                        current_kernel.events.append(event)
                     continue
                 if kind == "check":
-                    if check_event is not None:
+                    if check_event is not None and event.valid:
                         check_event(event)
                     continue
                 hard(
@@ -547,8 +550,10 @@ def parse_log(
                     f"{kind} event lacks required picture=: {line}",
                 )
                 valid = False
+                event.valid = False
         if kind == "picture":
             if not valid or "id" not in attrs or not _is_picture_id(attrs["id"]):
+                event.valid = False
                 continue
             # Dialect ids stay integers (every existing consumer indexes with
             # them); kernel ids keep their k-prefixed spelling as strings.
@@ -568,19 +573,20 @@ def parse_log(
                     f"picture id {picture_id} already declared at line "
                     f"{by_id[picture_id].line}",
                 )
+                event.valid = False
                 continue
             picture = Picture(picture_id, lang, line_number)
             by_id[picture_id] = picture
             pictures.append(picture)
             current_kernel = picture if lang == "kernel" else None
             continue
-        if check_event is not None:
-            check_event(event)
         reference = attrs.get("picture", "")
         if not _is_picture_id(reference):
             continue
         picture_id = reference if reference.startswith("k") else int(reference)
         if picture_id == 0 and kind == "tree":
+            if check_event is not None and event.valid:
+                check_event(event)
             continue
         if picture_id not in by_id:
             hard(
@@ -588,6 +594,11 @@ def parse_log(
                 where,
                 f"{kind} references undeclared picture {picture_id}",
             )
+            event.valid = False
             continue
+        if not event.valid:
+            continue
+        if check_event is not None:
+            check_event(event)
         by_id[picture_id].events.append(event)
     return ParsedLog(events, pictures, by_id)

--- a/scripts/tenkzlib/tnlog.py
+++ b/scripts/tenkzlib/tnlog.py
@@ -356,9 +356,10 @@ FIELD_VALIDATORS: dict[str, dict[str, Callable[[str], bool]]] = {
 
 # Fields whose absence makes an otherwise typed event unusable.  Most event
 # kinds are picture records and use the shared picture= requirement below;
-# equation checks are top-level records whose scope is their ownership key.
+# equation checks are top-level records whose scope is their ownership key and
+# whose result determines whether the record can authorize a boundary check.
 REQUIRED_FIELDS: dict[str, frozenset[str]] = {
-    "check": frozenset({"scope"}),
+    "check": frozenset({"scope", "result"}),
 }
 
 
@@ -488,7 +489,16 @@ def parse_log(
                 valid = False
                 continue
             key, value = part.split("=", 1)
-            attrs[key.strip()] = value.strip()
+            key = key.strip()
+            if key in attrs:
+                hard(
+                    "malformed-event",
+                    where,
+                    f"duplicate field {key!r}: {line}",
+                )
+                valid = False
+                continue
+            attrs[key] = value.strip()
         event = Event(kind, attrs, line_number, line)
         events.append(event)
         validators = FIELD_VALIDATORS.get(kind)

--- a/scripts/tenkzlib/tnlog.py
+++ b/scripts/tenkzlib/tnlog.py
@@ -362,6 +362,19 @@ REQUIRED_FIELDS: dict[str, frozenset[str]] = {
     "check": frozenset({"scope", "result"}),
 }
 
+REQUIRED_CHECK_FIELDS_BY_RESULT: dict[str, frozenset[str]] = {
+    "equal": frozenset({"relation", "signature"}),
+    "mismatch": frozenset({"relation"}),
+    "off": frozenset({"relation", "reason"}),
+    "malformed": frozenset({"reason", "panels", "relations"}),
+}
+
+# Equation checks are scope-owned top-level records.  A picture= field would
+# give them a second, conflicting owner and must never enter semantic checks.
+FORBIDDEN_FIELDS: dict[str, frozenset[str]] = {
+    "check": frozenset({"picture"}),
+}
+
 
 @dataclass
 class Event:
@@ -446,6 +459,11 @@ class ParsedLog:
     pictures: list[Picture]
     by_id: dict[int | str, Picture]
 
+    @property
+    def valid_events(self) -> list[Event]:
+        """Return only records accepted by the canonical parser."""
+        return [event for event in self.events if event.valid]
+
 
 FindingCallback = Callable[[str, str, str], None]
 EventCallback = Callable[[Event], None]
@@ -515,7 +533,14 @@ def parse_log(
                         f"{kind} field {key}={value!r} fails validation: {line}",
                     )
                     valid = False
-            missing = sorted(REQUIRED_FIELDS.get(kind, frozenset()) - attrs.keys())
+            required = set(REQUIRED_FIELDS.get(kind, frozenset()))
+            if kind == "check":
+                required.update(
+                    REQUIRED_CHECK_FIELDS_BY_RESULT.get(
+                        attrs.get("result", ""), frozenset()
+                    )
+                )
+            missing = sorted(required - attrs.keys())
             if missing:
                 hard(
                     "malformed-event",
@@ -523,7 +548,20 @@ def parse_log(
                     f"{kind} event lacks required field(s): {', '.join(missing)}: {line}",
                 )
                 valid = False
+            forbidden = sorted(FORBIDDEN_FIELDS.get(kind, frozenset()) & attrs.keys())
+            if forbidden:
+                hard(
+                    "malformed-event",
+                    where,
+                    f"{kind} event forbids field(s): {', '.join(forbidden)}: {line}",
+                )
+                valid = False
             event.valid = valid
+            if kind == "check":
+                # A scope-owned equation check is emitted outside every panel
+                # and therefore closes the preceding kernel picture even when
+                # the check itself is malformed.
+                current_kernel = None
             if kind != "picture" and "picture" not in attrs:
                 if current_kernel is not None and kind in {
                     "atom",
@@ -552,6 +590,9 @@ def parse_log(
                 valid = False
                 event.valid = False
         if kind == "picture":
+            # Every picture header ends the preceding picture's implicit
+            # ownership, even when the new header is malformed or duplicate.
+            current_kernel = None
             if not valid or "id" not in attrs or not _is_picture_id(attrs["id"]):
                 event.valid = False
                 continue

--- a/scripts/test_tenkz_corpus_provenance.py
+++ b/scripts/test_tenkz_corpus_provenance.py
@@ -17,6 +17,7 @@ from tenkz_rmp import (
     DEFAULT_MANIFEST,
     DEFAULT_VERDICT,
     RMPError,
+    event_signatures,
     ink_environment_problems,
     load_author_source_hashes,
     load_manifest,
@@ -102,6 +103,19 @@ def test_ink_environment_owner() -> None:
     }
     if used != expected:
         raise AssertionError(f"compiled Ink owners disagree: {used!r}")
+    malformed: list[tuple[str, str, str]] = []
+    rejected = parse_log(
+        "picture|id=1|id=2|lang=grid\n"
+        "kernel-boundary|picture=1|signature=a|signature=b\n",
+        source_name="invalid-owner-test.tnlog",
+        hard=lambda *finding: malformed.append(finding),
+    )
+    if not malformed or rejected.valid_events:
+        raise AssertionError("invalid records escaped canonical quarantine")
+    if rendered_ink_environment_families(rejected):
+        raise AssertionError("invalid picture changed compiled Ink ownership")
+    if event_signatures(rejected) != ("model-events|none",):
+        raise AssertionError("invalid boundary changed compiled event signatures")
     with tempfile.TemporaryDirectory(prefix="tenkz-ink-owner-") as tmp:
         log_path = Path(tmp) / "ink-owner-test.tnlog"
         log_path.write_text(log, encoding="utf-8")

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -287,6 +287,60 @@ kernel-boundary|signature=phys:up
         finding.rule for finding in duplicate_opt_out.findings
     ]
 
+    duplicate_scope = audit_log(
+        "check|scope=1|scope=9|relation=1|result=equal|signature=\n"
+        + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1"),
+        checked_equation_source.replace(
+            "check={signature, modulo=bundles}", "check={signature}"
+        ),
+    )
+    duplicate_scope_rules = [finding.rule for finding in duplicate_scope.findings]
+    assert "malformed-event" in duplicate_scope_rules
+    assert "eq-boundary-mismatch" in duplicate_scope_rules
+
+    missing_result = audit_log(
+        "check|scope=1|relation=1\n"
+        + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1"),
+        checked_equation_source.replace(
+            "check={signature, modulo=bundles}", "check={signature}"
+        ),
+    )
+    missing_result_rules = [finding.rule for finding in missing_result.findings]
+    assert "malformed-event" in missing_result_rules
+    assert "eq-boundary-mismatch" in missing_result_rules
+    assert not next(
+        event for event in missing_result.log_events if event.kind == "check"
+    ).valid
+
+    duplicate_result = audit_log(
+        "check|scope=1|relation=1|result=mismatch|result=equal\n"
+    )
+    duplicate_result_rules = [
+        finding.rule for finding in duplicate_result.findings
+    ]
+    assert "malformed-event" in duplicate_result_rules
+    assert "kernel-check" not in duplicate_result_rules
+
+    invalid_picture_scope = audit_log(
+        equation_log.replace(
+            "picture|id=k1|lang=kernel",
+            "picture|id=k1|lang=kernel|scope=9",
+        ).replace(
+            "picture|id=k2|lang=kernel",
+            "picture|id=k1|lang=kernel|scope=1|scope=9\n"
+            "picture|id=k2|lang=kernel|scope=1",
+        )
+        + "check|scope=1|relation=1|result=equal|signature=\n",
+        checked_equation_source.replace(
+            "check={signature, modulo=bundles}", "check={signature}"
+        ),
+    )
+    invalid_picture_rules = [
+        finding.rule for finding in invalid_picture_scope.findings
+    ]
+    assert "malformed-event" in invalid_picture_rules
+    assert "eq-boundary-mismatch" in invalid_picture_rules
+
     checkless_equation_source = (
         "\\begin{tenkzeq}[size=m]\n"
         + equation_source

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -308,9 +308,23 @@ kernel-boundary|signature=phys:up
     missing_result_rules = [finding.rule for finding in missing_result.findings]
     assert "malformed-event" in missing_result_rules
     assert "eq-boundary-mismatch" in missing_result_rules
-    assert not next(
-        event for event in missing_result.log_events if event.kind == "check"
-    ).valid
+
+    for incomplete_check in (
+        "check|scope=1|relation=1|result=off\n",
+        "check|scope=1|relation=1|result=equal\n",
+        "check|scope=1|result=mismatch|reason=boundary\n",
+    ):
+        incomplete = audit_log(
+            incomplete_check
+            + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1"),
+            checked_equation_source.replace(
+                "check={signature, modulo=bundles}",
+                "check={signature, off={1: documented}}",
+            ),
+        )
+        incomplete_rules = [finding.rule for finding in incomplete.findings]
+        assert "malformed-event" in incomplete_rules
+        assert "eq-boundary-mismatch" in incomplete_rules
 
     duplicate_result = audit_log(
         "check|scope=1|relation=1|result=mismatch|result=equal\n"
@@ -340,6 +354,61 @@ kernel-boundary|signature=phys:up
     ]
     assert "malformed-event" in invalid_picture_rules
     assert "eq-boundary-mismatch" in invalid_picture_rules
+
+    for picture_reference in ("oops", "k1"):
+        picture_owned_check = audit_log(
+            f"check|picture={picture_reference}|scope=1|relation=1|"
+            "result=equal|signature=\n"
+            + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1"),
+            checked_equation_source.replace(
+                "check={signature, modulo=bundles}", "check={signature}"
+            ),
+        )
+        picture_owned_rules = [
+            finding.rule for finding in picture_owned_check.findings
+        ]
+        assert "malformed-event" in picture_owned_rules
+        assert "eq-boundary-mismatch" in picture_owned_rules
+
+    scoped_off_log = (
+        "check|scope=1|relation=1|result=off|reason=documented\n"
+        + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1")
+    )
+    optionless_body_spoof = checked_equation_source.replace(
+        "[check={signature, modulo=bundles}]",
+        "\n$check={signature, off={1:\\mathrm{note}}}$",
+    )
+    body_off_spoof = checked_equation_source.replace(
+        "check={signature, modulo=bundles}]",
+        "check={signature}]\n$off={1:\\mathrm{note}}$",
+    )
+    nested_option_spoof = checked_equation_source.replace(
+        "check={signature, modulo=bundles}",
+        "frame={note={check={signature}, off={1: documented}}}",
+    )
+    for spoofed_source in (
+        optionless_body_spoof,
+        body_off_spoof,
+        nested_option_spoof,
+    ):
+        spoofed = audit_log(scoped_off_log, spoofed_source)
+        assert "eq-boundary-mismatch" in [
+            finding.rule for finding in spoofed.findings
+        ]
+
+    trailing_boundary = audit_log(
+        "picture|id=k1|lang=kernel|scope=1\n"
+        "atom|id=atom-1|kind=tn\n"
+        "kernel-boundary|signature=phys:up\n"
+        "picture|id=k2|lang=kernel|scope=1\n"
+        "atom|id=atom-1|kind=tn\n"
+        "check|scope=1|relation=1|result=equal|signature=phys:up\n"
+        "kernel-boundary|signature=phys:up\n",
+        checked_equation_source,
+    )
+    trailing_boundary_rules = [finding.rule for finding in trailing_boundary.findings]
+    assert "malformed-event" in trailing_boundary_rules
+    assert "kernel-check" in trailing_boundary_rules
 
     checkless_equation_source = (
         "\\begin{tenkzeq}[size=m]\n"

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -10,7 +10,7 @@ from tenkz_audit import Audit, same_equation
 
 
 GOOD_LOG = """\
-picture|id=k1|lang=kernel
+picture|id=k1|lang=kernel|scope=1
 wire|id=wire-1|from=addr-1|kind=string|name=a|to=addr-2
 wire|id=wire-2|cross=under at crossing of a and b|from=addr-3|kind=string|name=b|to=addr-4
 wire|id=wire-3|from=addr-5|host=atom-1|kind=pairing|name=skin-atom-1-1|origin=skin|route=arc|species=shift|to=addr-6
@@ -248,6 +248,30 @@ kernel-boundary|signature=phys:up
     )
     assert "eq-boundary-mismatch" not in [
         finding.rule for finding in opted_out_equation.findings
+    ]
+
+    undeclared_opt_out = audit_log(
+        "check|scope=1|relation=1|result=off|reason=stale\n"
+        + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1"),
+        checked_equation_source.replace(
+            "check={signature, modulo=bundles}", "check={signature}"
+        ),
+    )
+    assert "eq-boundary-mismatch" in [
+        finding.rule for finding in undeclared_opt_out.findings
+    ]
+
+    surplus_opt_out = audit_log(
+        "check|scope=1|relation=1|result=off|reason=documented\n"
+        "check|scope=1|relation=2|result=equal|signature=\n"
+        + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1"),
+        checked_equation_source.replace(
+            "check={signature, modulo=bundles}",
+            "check={signature, off={1: documented}}",
+        ),
+    )
+    assert "eq-boundary-mismatch" in [
+        finding.rule for finding in surplus_opt_out.findings
     ]
 
     checkless_equation_source = (

--- a/scripts/test_tenkz_kernel_audit.py
+++ b/scripts/test_tenkz_kernel_audit.py
@@ -274,6 +274,19 @@ kernel-boundary|signature=phys:up
         finding.rule for finding in surplus_opt_out.findings
     ]
 
+    duplicate_opt_out = audit_log(
+        "check|scope=1|relation=1|result=off|reason=documented\n"
+        "check|scope=1|relation=1|result=equal|signature=\n"
+        + equation_log.replace("|lang=kernel", "|lang=kernel|scope=1"),
+        checked_equation_source.replace(
+            "check={signature, modulo=bundles}",
+            "check={signature, off={1: documented}}",
+        ),
+    )
+    assert "eq-boundary-mismatch" in [
+        finding.rule for finding in duplicate_opt_out.findings
+    ]
+
     checkless_equation_source = (
         "\\begin{tenkzeq}[size=m]\n"
         + equation_source

--- a/scripts/test_texcase.py
+++ b/scripts/test_texcase.py
@@ -4,7 +4,13 @@
 from tenkz_audit import scan_constructs as audit_scan_constructs
 from tenkz_audit import strip_comments as audit_strip_comments
 from tenkz_lint import scan_bodies
-from tenkzlib.texcase import scan_constructs, strip_comments
+from tenkzlib.texcase import (
+    following_group,
+    following_group_span,
+    scan_constructs,
+    strip_comments,
+    top_level_options,
+)
 
 
 def main() -> int:
@@ -24,6 +30,18 @@ def main() -> int:
     assert "\\% visible percent" in stripped
     assert "hidden after" not in stripped
     assert "hidden atom" not in stripped
+
+    option_source = "  [check={signature, off={1: note}}, frame={x=[a,b]}] tail"
+    option_group = following_group(option_source, 0, "[", "]")
+    assert option_group == "check={signature, off={1: note}}, frame={x=[a,b]}"
+    assert following_group_span(option_source, 0, "[", "]") == (
+        option_group,
+        option_source.index("] tail") + 1,
+    )
+    assert top_level_options(option_group) == [
+        ("check", "{signature, off={1: note}}"),
+        ("frame", "{x=[a,b]}"),
+    ]
 
     constructs = scan_constructs(stripped)
     assert [construct.name for construct in constructs] == [

--- a/scripts/test_tnlog.py
+++ b/scripts/test_tnlog.py
@@ -57,7 +57,8 @@ def main() -> int:
                 "atom|picture=oops|cell=1-1|name=A|kind=tensor",
                 "frame|picture=1|scope=atom|map=rotate(30)|"
                 "a=bad|b=0|c=0|d=1",
-                "check|relation=1|result=equal|signature=open:e",
+                "check|relation=1|result=equal",
+                "check|scope=9|scope=1|relation=1|result=equal",
                 "mystery|picture=2|bare",
             )
         ),
@@ -77,6 +78,7 @@ def main() -> int:
         and "check event lacks required field(s): scope" in finding[2]
         for finding in malformed
     )
+    assert any("duplicate field 'scope'" in finding[2] for finding in malformed)
 
     assert AuditEvent is Event
     assert AuditPicture is Picture

--- a/scripts/test_tnlog.py
+++ b/scripts/test_tnlog.py
@@ -60,6 +60,11 @@ def main() -> int:
                 "a=bad|b=0|c=0|d=1",
                 "check|relation=1|result=equal",
                 "check|scope=9|scope=1|relation=1|result=equal",
+                "check|picture=1|scope=1|relation=1|result=equal",
+                "check|scope=1|relation=1|result=off",
+                "check|scope=1|relation=1|result=equal",
+                "check|scope=1|result=mismatch",
+                "check|scope=1|result=malformed|reason=relation-count",
                 "mystery|picture=2|bare",
             )
         ),
@@ -80,12 +85,54 @@ def main() -> int:
         for finding in malformed
     )
     assert any("duplicate field 'scope'" in finding[2] for finding in malformed)
+    assert any(
+        "check event forbids field(s): picture" in finding[2]
+        for finding in malformed
+    )
     assert all(
         not event.valid
         for event in malformed_parsed.events
         if event.kind == "check"
     )
     assert not malformed_parsed.by_id[1].events
+
+    stale_findings: list[tuple[str, str, str]] = []
+    stale_owner = parse_log(
+        "picture|id=k1|lang=kernel\n"
+        "atom|id=atom-1|kind=tn\n"
+        "picture|id=k2|lang=kernel|scope=1|scope=2\n"
+        "kernel-boundary|signature=bad\n",
+        source_name="stale-owner.tnlog",
+        known_langs={"kernel"},
+        hard=lambda *finding: stale_findings.append(finding),
+    )
+    assert {finding[0] for finding in stale_findings} == {"malformed-event"}
+    assert [event.kind for event in stale_owner.by_id["k1"].events] == ["atom"]
+    assert not next(
+        event for event in stale_owner.events
+        if event.kind == "kernel-boundary"
+    ).valid
+
+    check_delimiter_findings: list[tuple[str, str, str]] = []
+    check_delimiter = parse_log(
+        "picture|id=k1|lang=kernel\n"
+        "atom|id=atom-1|kind=tn\n"
+        "check|scope=1|relation=1|result=equal|signature=open:e\n"
+        "kernel-boundary|signature=open:e\n",
+        source_name="check-delimiter.tnlog",
+        known_langs={"kernel"},
+        hard=lambda *finding: check_delimiter_findings.append(finding),
+    )
+    assert {finding[0] for finding in check_delimiter_findings} == {
+        "malformed-event"
+    }
+    assert [event.kind for event in check_delimiter.by_id["k1"].events] == [
+        "atom"
+    ]
+    assert not next(
+        event for event in check_delimiter.events
+        if event.kind == "kernel-boundary"
+    ).valid
 
     assert AuditEvent is Event
     assert AuditPicture is Picture

--- a/scripts/test_tnlog.py
+++ b/scripts/test_tnlog.py
@@ -40,6 +40,7 @@ def main() -> int:
         "boundary",
         "tree",
     ]
+    assert all(event.valid for event in parsed.events)
     assert len(parsed.pictures) == 1
     picture = parsed.pictures[0]
     assert picture is parsed.by_id[1]
@@ -49,7 +50,7 @@ def main() -> int:
 
     malformed: list[tuple[str, str, str]] = []
     notes: list[tuple[str, str, str]] = []
-    parse_log(
+    malformed_parsed = parse_log(
         "\n".join(
             (
                 "picture|id=1|lang=future",
@@ -79,6 +80,12 @@ def main() -> int:
         for finding in malformed
     )
     assert any("duplicate field 'scope'" in finding[2] for finding in malformed)
+    assert all(
+        not event.valid
+        for event in malformed_parsed.events
+        if event.kind == "check"
+    )
+    assert not malformed_parsed.by_id[1].events
 
     assert AuditEvent is Event
     assert AuditPicture is Picture

--- a/tests/tenkz/kernel/negative/n_nested_equation.tex
+++ b/tests/tenkz/kernel/negative/n_nested_equation.tex
@@ -1,0 +1,21 @@
+% Negative regression: one equation audit scope cannot contain another.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkzeq}[check={signature}]
+  \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+    \tn[ports={}]{A}
+  \end{tenkz}
+  =
+  \begin{tenkzeq}[check={signature}]
+    \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+      \tn[ports={}]{B}
+    \end{tenkz}
+    =
+    \begin{tenkz}[rows={wire}, cols=1, bonds=none]
+      \tn[ports={}]{C}
+    \end{tenkz}
+  \end{tenkzeq}
+\end{tenkzeq}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -72,6 +72,9 @@
 \msg_new:nnn {tenkz}{kernel-equation-arity}
   { [TKZ-EQ-ARITY]~an~equation~with~#1~panel(s)~has~#2~relation~glyph(s);~
     expected~one~fewer~relation~than~panels~and~at~least~two~panels. }
+\msg_new:nnn {tenkz}{kernel-equation-nested}
+  { [TKZ-EQ-NESTED]~tenkzeq~cannot~be~nested;~each~equation~is~one~
+    audit~scope,~and~the~tngroup~command~nests~picture~content. }
 \msg_new:nnn {tenkz}{kernel-cellset}
   { [TKZ-LANG-CELLSET]~#1=#2~is~not~a~cell-set~of~
     (interface,column)~terms~(record~#3). }
@@ -13269,6 +13272,8 @@
 % per glyph, and the audit compares adjacent panels per relation.
 \cs_new_protected:Npn \__tenkz_kernel_eq_begin:n #1
   {
+    \bool_if:NT \l__tenkz_kernel_ineq_bool
+      { \msg_fatal:nn {tenkz}{kernel-equation-nested} }
     \group_begin:
     \int_gincr:N \g__tenkz_kernel_eq_scope_int
     \bool_set_true:N \l__tenkz_kernel_ineq_bool


### PR DESCRIPTION
## Summary

Follow up on LionSR/TNLean#5325 by making equation-scope ownership fail closed at every shared boundary.

- Require `scope` and `result` on every `check` record and reject duplicate event fields.
- Delegate a checked scope only when it contains exactly one record for every expected relation.
- Honor `result=off` only when the same relation is explicitly waived in that source `tenkzeq`.
- Reject nested `tenkzeq` fatally before it can increment the global scope or clear the outer panel state.
- Pin missing, duplicate, surplus, undeclared-opt-out, and true nested-environment regressions.

## Root cause

The scoped association landed in LionSR/TNLean#5325 removed document-wide positional drift, but three trust gaps remained: fields were validated only when present, logged opt-outs were not checked against source authority, and unsupported nested equation environments could overwrite the outer global sequences. These paths could still accept an unowned waiver or corrupt scope state.

## Validation

Exact rebased head:

- `python3 scripts/test_tnlog.py`
- `python3 scripts/test_tenkz_kernel_audit.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- changed files verified byte-identical across the rebase onto current `main`

Pre-publication changed-tree validation:

- all Python consumers of `scripts/tenkzlib/tnlog.py`
- `scripts/tenkz_kernel_probes.sh --check`: 88 regressions, 8 sugar equivalences, 12 pinned streams, byte-identical pixels
- `scripts/tenkz_golden.sh --check`: 264 byte-identical event streams
- `scripts/tenkz_corpus.sh`: 264 standalone files compiled and audited

No Lake command was run.

Refs LionSR/tenkz#27.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trust boundaries for kernel equation auditing and log parsing; mistakes could false-positive audits or let bad tnlog influence provenance, but scope is validation tooling rather than runtime auth or data stores.
> 
> **Overview**
> Makes **kernel equation scopes fail closed** end-to-end: malformed or incomplete `check` records no longer participate in audits, and boundary delegation only runs when a scope’s log matches the TeX.
> 
> **Event log parsing (`tnlog`)** now marks rejected records with `valid=False`, exposes `ParsedLog.valid_events`, requires `scope` and `result` on every `check`, enforces **result-specific required fields**, rejects duplicate keys and `picture=` on checks, and stops attaching invalid events to pictures.
> 
> **Equation boundary audit** only trusts a scoped equation when it has exactly one check per expected relation, `result=off` relations match **`check={..., off={n: ...}}`** parsed from the real environment options (via shared **`top_level_options`** in `texcase`), and the scope isn’t malformed—otherwise it falls back to boundary comparison and can report `eq-boundary-mismatch`.
> 
> **LaTeX** fatals on nested `\begin{tenkzeq}` with `[TKZ-EQ-NESTED]` before inner scopes can corrupt global panel state. **RMP/corpus tooling** reads `valid_events` so bad streams can’t skew ink ownership or signatures. Tests and **`tenkz_kernel_probes.sh`** add nested-equation and opt-out spoofing regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355f56d08463b850b73b2795be0ad465a105f3ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->