### PR TITLE
feat(tenkz): add contract-defined planes sugar

### DIFF
--- a/docs/tenkz/SHRINK.md
+++ b/docs/tenkz/SHRINK.md
@@ -1272,3 +1272,20 @@ and declared boundary leg is model incidence rather than geometric
 coincidence, without changing the public language.
 
 Census-correction: #5086
+
+### 2026-08-02 — the contract-defined `planes` preset reaches the kernel
+
+The kernel gains the contract-defined `planes` sugar from `LANGUAGE-1.0` section
+9: one plane frame with ket and bra basis members at their declared
+quarter-pitch offsets. The preset owns placement only; callers continue to
+state `bonds=none` when a multi-member basis has explicit connectivity. M1
+sugar rows rise from 12 to 13 and M2 parser leaves rise from 227 to 228.
+Kernel, alias, escape, and overload counts are unchanged.
+
+Extension-gate: #5086
+
+Census-correction: #5086
+
+| flag | verdict |
+|---|---|
+| flag:consumers:key:kernel-picture:planes | keep-because: `LANGUAGE-1.0` section 9 fixes the bilayer expansion; the kernel equivalence pair lands now and the named bilayer and condensation consumers migrate through #5086; expiry 1.0 |

--- a/docs/tenkz/chapters2/generated-language-reference.tex
+++ b/docs/tenkz/chapters2/generated-language-reference.tex
@@ -198,6 +198,7 @@ kernel-\allowbreak{}picture & \texttt{boundary} & enum(\allowbreak{}open\textbar
 kernel-\allowbreak{}picture & \texttt{lattice} & pair & empty & RxC \allowbreak{}wire-\allowbreak{}row \allowbreak{}lattice \allowbreak{}preset. \\
 kernel-\allowbreak{}picture & \texttt{ring} & integer & empty & Circle-\allowbreak{}frame \allowbreak{}ring \allowbreak{}preset. \\
 kernel-\allowbreak{}picture & \texttt{surface} & identifier & empty & Torus \allowbreak{}closure \allowbreak{}preset. \\
+kernel-\allowbreak{}picture & \texttt{planes} & flag & false & Plane \allowbreak{}frame \allowbreak{}with \allowbreak{}ket \allowbreak{}and \allowbreak{}bra \allowbreak{}basis \allowbreak{}members. \\
 kernel-\allowbreak{}picture & \texttt{physical} & physical-\allowbreak{}policy & none & Expander: \allowbreak{}outward \allowbreak{}physical \allowbreak{}port \allowbreak{}per \allowbreak{}populated \allowbreak{}atom. \\
 kernel-\allowbreak{}atom & \texttt{skin} & silhouette-\allowbreak{}name & theme \allowbreak{}default & Declared \allowbreak{}silhouette. \\
 kernel-\allowbreak{}atom & \texttt{wide} & positive-\allowbreak{}integer & 1 & Cells \allowbreak{}spanned. \\

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -1600,14 +1600,14 @@ regression_count=$(find "$WORK" -maxdepth 1 -name 'r_*.tex' | wc -l | tr -d ' ')
 echo "PASS: $regression_count review regressions hold"
 
 fail=0
-for pair in s1 s2 s3 s4 s5 s6 s7 s8; do
+for pair in s1 s2 s3 s4 s5 s6 s7 s8 s9; do
   if ! cmp -s "$WORK/${pair}_sugar.tnlog" "$WORK/${pair}_kernel.tnlog"; then
     echo "FAIL: sugar pair $pair diverges from its kernel expansion" >&2
     diff "$WORK/${pair}_sugar.tnlog" "$WORK/${pair}_kernel.tnlog" >&2 || true
     fail=1
   fi
 done
-[ "$fail" -eq 0 ] && echo "PASS: 8 sugar spellings byte-identical to their expansions"
+[ "$fail" -eq 0 ] && echo "PASS: 9 sugar spellings byte-identical to their expansions"
 
 CURRENT="$WORK/current.sha256"
 ( cd "$WORK"

--- a/tests/tenkz/census-baseline.json
+++ b/tests/tenkz/census-baseline.json
@@ -7,13 +7,13 @@
       "environments": 6,
       "escape": 11,
       "kernel": 140,
-      "sugar": 12
+      "sugar": 13
     }
   },
   "m2_parser_paths": {
     "definition": "public leaf keys installed by the TeX parsers; identity changes require an Extension-gate citation",
-    "identity_sha256": "5853468972c6d88f5dfaf50419d2805b4350eaa46e80eaebf5c4c6b335944d43",
-    "value": 227
+    "identity_sha256": "4a08c61b901632a53081549e14f504335f1728d442c9cb3709735d6cb8b70a40",
+    "value": 228
   },
   "m3_escape_usage": {
     "definition": "occurrences of escape-ledger spellings in the demand corpus; every occurrence names a core-grammar gap",

--- a/tests/tenkz/kernel/sugar/s9_kernel.tex
+++ b/tests/tenkz/kernel/sugar/s9_kernel.tex
@@ -1,0 +1,13 @@
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, bonds=none,
+  frame={plane,basis={ket at (0,0),bra at (2,2)}}]\end{tenkz}
+\mbox{p}
+\end{document}

--- a/tests/tenkz/kernel/sugar/s9_sugar.tex
+++ b/tests/tenkz/kernel/sugar/s9_sugar.tex
@@ -1,0 +1,12 @@
+\documentclass{standalone}
+\usepackage{tenkz}
+\makeatletter
+\ExplSyntaxOn
+\file_input:n { tenkz-kernel.code.tex }
+\ExplSyntaxOff
+\makeatother
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, bonds=none, planes]\end{tenkz}
+\mbox{p}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -1042,6 +1042,13 @@
     lattice .code:n  = { \__tenkz_kernel_desugar_lattice:n {#1} },
     ring .code:n     = { \__tenkz_kernel_desugar_ring:n {#1} },
     surface .code:n  = { \__tenkz_kernel_desugar_surface:n {#1} },
+    planes .code:n =
+      {
+        \__tenkz_kernel_sugar:n {planes}
+        \keys_set:nn {tenkz-kernel-picture}
+          {frame={plane,basis={ket~at~(0,0),bra~at~(2,2)}}}
+      },
+    planes .default:n = ,
     physical .code:n = { \__tenkz_kernel_desugar_physical:n {#1} }
   }
 

--- a/tex/tenkz/tenkz-language-registry.tex
+++ b/tex/tenkz/tenkz-language-registry.tex
@@ -283,6 +283,7 @@
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{lattice}{pair}{empty}{sugar(rows=, cols=)}{RxC wire-row lattice preset.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{ring}{integer}{empty}{sugar(rows=, cols=, frame=circle, west=trace, east=trace)}{Circle-frame ring preset.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{surface}{identifier}{empty}{sugar(west=trace, east=trace, north=trace, south=trace)}{Torus closure preset.}
+\__tenkz_language_registry_key:nnnnnn {kernel-picture}{planes}{flag}{false}{sugar(frame={plane, basis={ket at (0,0), bra at (2,2)}})}{Plane frame with ket and bra basis members.}
 \__tenkz_language_registry_key:nnnnnn {kernel-picture}{physical}{physical-policy}{none}{sugar(rows)}{Expander: outward physical port per populated atom.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{skin}{silhouette-name}{theme default}{kernel}{Declared silhouette.}
 \__tenkz_language_registry_key:nnnnnn {kernel-atom}{wide}{positive-integer}{1}{kernel}{Cells spanned.}


### PR DESCRIPTION
## Summary
- implement the exact LANGUAGE-1.0 section 9 `planes` sugar
- keep connectivity explicit instead of folding `bonds=none` into a geometry preset
- register the key, regenerate the language reference, and update the shrink census
- add a byte-identical sugar/kernel event-stream pair

## Contract boundary

`planes` expands only to `frame={plane, basis={ket at (0,0), bra at (2,2)}}`. Multi-member connectivity remains caller-specified.

Refs LionSR/tenkz#113

## Validation
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_language.py`
- `python3 scripts/test_tenkz_shrink.py`
- `python3 scripts/tenkz_shrink.py gate --base-ref origin/main`
- `bash scripts/tenkz_kernel_probes.sh --check` (88 regressions, 9 sugar pairs, 12 streams, pixel parity)
- `TENKZ_CORPUS_JOBS=4 bash scripts/tenkz_corpus.sh` (264 fixtures)
- `TENKZ_CORPUS_JOBS=4 bash scripts/tenkz_golden.sh --check` (264 event streams)
- `bash scripts/tenkz_string_probes.sh` (30 event/pixel artifacts)
- `python3 scripts/tenkz_manual_doctest.py` (9 displayed and 25 reference examples)
- `python3 scripts/check_tenkz_dispositions.py`
