### PR TITLE
feat(MPS/MPDO): realize identity-dressed physical span

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -23,6 +23,7 @@ import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalPhysicalMaps
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalUnitary
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseIdentityPhysicalSpan
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseOneSiteAmbientSectorMaps
 import TNLean.MPS.MPDO.BNTAlgebraTensorClausePositivity
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseSpectrum

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseIdentityPhysicalSpan
 import TNLean.MPS.MPDO.CPSVBlocking
 import TNLean.MPS.MPDO.CPSVFigureEight
 
@@ -15,11 +15,12 @@ same reflected target as the gauge-dressed corner, determines the Gram
 conjugation of an exact two-site sector gauge.  Normality then makes the gauge
 Gram matrix a positive scalar multiple of the identity.
 
-The identity-dressed realization remains conditional.  A constructor reduces
-it to a positive-coefficient two-sided physical realization, but does not
-derive that realization from the BNT algebra clause.  Thus these results
-isolate the remaining implication in Appendix C.4 and do not complete the
-two-site unitary-gauge argument.
+The identity-dressed physical-letter coefficients are supplied unconditionally
+by the oblique two-sided compression.  Its reversed orientation gives the
+Gram-dressed representative, however, so the positive-tail equality with the
+raw reflected target remains conditional.  Thus these results isolate the
+remaining implication in Appendix C.4 and do not complete the two-site
+unitary-gauge argument.
 
 ## Main results
 
@@ -48,10 +49,11 @@ variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
 /-- An identity-dressed marked realization in the physical-letter span, with
 the same reflected target as the gauge-dressed marked chains.
 
-**Scope restriction (conditional identity-dressed marked realization):** This
-structure packages the local realization implicit at CPSV16 Appendix C.4,
-line 2048; it is supplied as data rather than derived from the tensor-attached
-algebra clause.  See
+**Scope restriction (conditional reflected target):** The coefficients and
+their physical-letter identity follow from the exact sector gauge.  The
+positive-tail equality with the raw reflected target is assumed rather than
+derived; the unconditional oblique compression instead has the Gram-dressed
+representative in its reversed orientation.  See
 `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
 
 Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
@@ -96,17 +98,18 @@ structure IdentityMarkedRealization (S : TwoSiteExactSectorGauge H)
         (adjointTensor (blockTwo M)) r s
         (List.ofFn σ).reverse (List.ofFn τ).reverse
 
-/-- A positive-coefficient two-sided physical realization of the algebra-side
+/-- A positive-coefficient same-sided physical realization of the algebra-side
 representative gives an identity-dressed marked realization.
 
 No isometry condition on `V` is needed.  The physical-letter expansion uses
-the positive coefficient and the two-sided realization equation; the reflected
+the positive coefficient and the same-sided realization equation; the reflected
 marked-chain identity additionally uses MPDO positivity of the blocked tensor.
 
-**Scope restriction (conditional physical realization):** The two-sided
-realization is supplied as a hypothesis rather than derived from the
-tensor-attached algebra clause.  Its unconditional construction is one possible
-local identification for completing Appendix C.4; see
+**Scope restriction (same-sided physical realization):** The same-sided
+realization is supplied as a hypothesis.  The unconditional oblique
+compression has distinct left and right maps and supplies the physical-letter
+identity, but its reversed orientation gives the Gram-dressed representative
+rather than the raw reflected target.  See
 `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
 
 Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
@@ -150,10 +153,11 @@ noncomputable def IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealiza
 reflected target as the exact gauge-dressed corner at every positive tail
 length forces the two Gram dressings to agree.
 
-**Scope restriction (conditional identity-dressed marked realization):** The
-theorem assumes the physical-letter realization implicit at CPSV16 Appendix
-C.4, line 2048; it is not derived from the algebra clause and does not resolve
-the unconditional realization or conclusion of Appendix C.4.  See
+**Scope restriction (conditional reflected target):** The physical-letter
+component is available unconditionally from the oblique compression.  The
+theorem additionally assumes its positive-tail equality with the raw reflected
+target, which is not derived from the algebra clause and remains the missing
+step in Appendix C.4.  See
 `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
 
 Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
@@ -223,10 +227,11 @@ theorem gramDressing_gauge_eq_one_of_identityMarkedRealization
 matrix of the exact two-site sector gauge is a positive real scalar multiple
 of the identity.
 
-**Scope restriction (conditional identity-dressed marked realization):** The
-theorem assumes the physical-letter realization implicit at CPSV16 Appendix
-C.4, line 2048; it is not derived from the algebra clause and does not establish
-the unconditional realization or conclusion of Appendix C.4.  See
+**Scope restriction (conditional reflected target):** The physical-letter
+component is available unconditionally from the oblique compression.  The
+theorem additionally assumes its positive-tail equality with the raw reflected
+target, which is not derived from the algebra clause and remains the missing
+step in Appendix C.4.  See
 `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
 
 Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.BNTAlgebraTensorClauseIdentityPhysicalSpan
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.CPSVBlocking
 import TNLean.MPS.MPDO.CPSVFigureEight
 

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalGram.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseIdentityPhysicalSpan
 import TNLean.MPS.MPDO.CPSVBlocking
 import TNLean.MPS.MPDO.CPSVFigureEight
 
@@ -24,10 +24,12 @@ unitary-gauge argument.
 
 ## Main results
 
+* `TwoSiteExactSectorGauge.HasIdentityPositiveTailReflectedTarget`
 * `TwoSiteExactSectorGauge.IdentityMarkedRealization`
+* `TwoSiteExactSectorGauge.IdentityMarkedRealization.ofPositiveTailReflectedTarget`
 * `TwoSiteExactSectorGauge.IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealization`
-* `TwoSiteExactSectorGauge.gramDressing_gauge_eq_one_of_identityMarkedRealization`
-* `TwoSiteExactSectorGauge.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization`
+* `TwoSiteExactSectorGauge.gramDressing_gauge_eq_one_of_positive_tail_reflected_target`
+* `TwoSiteExactSectorGauge.gauge_gram_eq_pos_smul_one_of_positive_tail_reflected_target`
 
 ## References
 
@@ -45,6 +47,35 @@ namespace MPOTensor
 namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
 
 variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- The identity-dressed marked chains have the reflected-adjoint target used
+for the gauge-dressed marked chains at every positive tail length.
+
+**Scope restriction (conditional reflected target):** This is precisely the
+remaining target identity; it is assumed here rather than derived from the
+tensor-attached algebra clause.  The oblique physical-letter construction
+supplies the marked insertion, but its reversed orientation is Gram-dressed.
+See `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+def HasIdentityPositiveTailReflectedTarget (S : TwoSiteExactSectorGauge H)
+    (γ : Fin H.labelCount) : Prop :=
+  ∀ (N : ℕ), 0 < N → ∀
+    (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
+    (σ τ : Fin N → Fin (d * d)),
+    markedChainCoefficient
+        (gramDressing
+          (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)))
+        (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
+      markedChainCoefficient
+        (reflectedAdjoint
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)))
+        (adjointTensor (blockTwo M)) r s
+        (List.ofFn σ).reverse (List.ofFn τ).reverse
 
 /-- An identity-dressed marked realization in the physical-letter span, with
 the same reflected target as the gauge-dressed marked chains.
@@ -82,21 +113,29 @@ structure IdentityMarkedRealization (S : TwoSiteExactSectorGauge H)
 
   Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and
   lines 1898--1921, applied at Appendix C.4, lines 2048--2057. -/
-  target : ∀ (N : ℕ), 0 < N → ∀
-    (r s : Fin (S.decomposition.bondDim (S.relabel γ)))
-    (σ τ : Fin N → Fin (d * d)),
-    markedChainCoefficient
-        (gramDressing
-          (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
-          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-            (H.tensor γ)))
-        (blockTwo M) r s (List.ofFn σ) (List.ofFn τ) =
-      markedChainCoefficient
-        (reflectedAdjoint
-          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
-            (H.tensor γ)))
-        (adjointTensor (blockTwo M)) r s
-        (List.ofFn σ).reverse (List.ofFn τ).reverse
+  target : HasIdentityPositiveTailReflectedTarget S γ
+
+/-- The positive-tail reflected target completes the unconditional
+physical-letter coefficients to an identity-dressed marked realization.
+
+**Scope restriction (conditional reflected target):** The target is assumed.
+The coefficient family and its physical-letter identity are instead obtained
+from the oblique compression.  Thus this constructor introduces no further
+hypothesis beyond the remaining star-compatible target.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+noncomputable def IdentityMarkedRealization.ofPositiveTailReflectedTarget
+    (S : TwoSiteExactSectorGauge H) (γ : Fin H.labelCount)
+    (hTarget : HasIdentityPositiveTailReflectedTarget S γ) :
+    IdentityMarkedRealization S γ := by
+  let hPhysical := S.exists_identity_physical_letter_coefficients γ
+  exact {
+    fId := Classical.choose hPhysical
+    physical := Classical.choose_spec hPhysical
+    target := hTarget
+  }
 
 /-- A positive-coefficient same-sided physical realization of the algebra-side
 representative gives an identity-dressed marked realization.
@@ -223,6 +262,30 @@ theorem gramDressing_gauge_eq_one_of_identityMarkedRealization
   simpa only [horizontalSlice, MPSTensor.finProdFinEquiv_divNat,
     MPSTensor.finProdFinEquiv_modNat] using congrFun (congrFun hSlice a) b
 
+/-- The positive-tail reflected target alone forces the gauge and identity
+Gram dressings to agree.  The physical-letter coefficients are constructed
+from the exact sector gauge by the oblique compression.
+
+**Scope restriction (conditional reflected target):** The target hypothesis is
+not derived from the tensor-attached algebra clause and remains the missing
+step in Appendix C.4.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+theorem gramDressing_gauge_eq_one_of_positive_tail_reflected_target
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (γ : Fin H.labelCount)
+    (hTarget : HasIdentityPositiveTailReflectedTarget S γ) :
+    gramDressing (S.gauge γ)
+        (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ)) =
+      gramDressing (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+        (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+          (H.tensor γ)) :=
+  S.gramDressing_gauge_eq_one_of_identityMarkedRealization hCanonical hM γ
+    (IdentityMarkedRealization.ofPositiveTailReflectedTarget S γ hTarget)
+
 /-- Under the same conditional identity-dressed marked realization, the Gram
 matrix of the exact two-site sector gauge is a positive real scalar multiple
 of the identity.
@@ -255,6 +318,29 @@ theorem gauge_gram_eq_pos_smul_one_of_identityMarkedRealization
     (Matrix.isUnits_det_units (S.gauge γ))
   intro v
   simpa [gramDressing] using congrFun hDress v
+
+/-- The positive-tail reflected target alone makes the gauge Gram matrix a
+positive real scalar multiple of the identity.  The identity-dressed
+physical-letter realization is supplied by the oblique compression.
+
+**Scope restriction (conditional reflected target):** The target hypothesis is
+not derived from the tensor-attached algebra clause and remains the missing
+step in Appendix C.4.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and lines
+1898--1921, applied at Appendix C.4, lines 2048--2057. -/
+theorem gauge_gram_eq_pos_smul_one_of_positive_tail_reflected_target
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (γ : Fin H.labelCount)
+    (hTarget : HasIdentityPositiveTailReflectedTarget S γ) :
+    ∃ ω : ℝ, 0 < ω ∧
+      (S.gauge γ : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ * S.gauge γ =
+        (ω : ℂ) • 1 :=
+  S.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization hCanonical hM γ
+    (IdentityMarkedRealization.ofPositiveTailReflectedTarget S γ hTarget)
 
 end BNTAlgebraTensorClause.TwoSiteExactSectorGauge
 

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalUnitary.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalUnitary.lean
@@ -14,14 +14,16 @@ changing its conjugation action.  Composing this normalization with the
 conditional Gram identity gives unitary conjugacy under an identity-dressed
 marked realization.
 
-The marked realization is assumed here, not constructed from the BNT algebra
-clause.  Thus the final theorem is conditional and does not establish the
-unconditional conclusion of Appendix C.4.
+The physical-letter part of the marked realization is constructed from the
+exact sector gauge.  Its positive-tail reflected target remains assumed.
+Thus the final theorem is conditional and does not establish the unconditional
+conclusion of Appendix C.4.
 
 ## Main results
 
 * `TwoSiteExactSectorGauge.exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one`
 * `TwoSiteExactSectorGauge.exists_unitary_sector_conjugacy_of_identityMarkedRealization`
+* `TwoSiteExactSectorGauge.exists_unitary_sector_conjugacy_of_positive_tail_reflected_target`
 
 ## References
 
@@ -75,13 +77,15 @@ theorem exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one
       ((cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
         (H.tensor γ)) i) (S.gauge γ) hω hGram).symm
 
-/-- Under the conditional identity-dressed marked realization, every exact
-two-site sector is unitarily conjugate to its matched one-site tensor.
+/-- A complete identity-dressed marked realization makes every exact two-site
+sector unitarily conjugate to its matched one-site tensor.
 
-**Scope restriction (conditional identity-dressed marked realization):** The
-theorem assumes the physical-letter realization implicit at CPSV16 Appendix
-C.4, line 2048; it is not derived from the algebra clause and does not establish
-the unconditional line-2057 conclusion.  See
+**Scope restriction (packaged conditional form):** This form accepts all three
+parts of the marked realization.  The physical-letter part is now obtained
+unconditionally from the oblique compression, and the target-only theorem
+below gives the sharper hypothesis.  In either form, the reflected target is
+not derived from the algebra clause, so the unconditional line-2057 conclusion
+does not follow.  See
 `docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
 
 Source comparison: arXiv:1606.00608, Proposition 4.13, lines 1903--1908,
@@ -104,6 +108,38 @@ theorem exists_unitary_sector_conjugacy_of_identityMarkedRealization
   obtain ⟨ω, hω, hGram⟩ :=
     S.gauge_gram_eq_pos_smul_one_of_identityMarkedRealization
       hCanonical hM γ R
+  exact S.exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one
+    γ ω hω hGram
+
+/-- Under the conditional positive-tail reflected target, every exact two-site
+sector is unitarily conjugate to its matched one-site tensor.  The
+physical-letter coefficients are constructed from the exact sector gauge.
+
+**Scope restriction (conditional reflected target):** The target hypothesis is
+not derived from the tensor-attached algebra clause and remains the missing
+step in Appendix C.4.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, lines 1903--1908,
+applied at Appendix C.4, lines 2048--2057. -/
+theorem exists_unitary_sector_conjugacy_of_positive_tail_reflected_target
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M) (γ : Fin H.labelCount)
+    (hTarget : HasIdentityPositiveTailReflectedTarget S γ) :
+    ∃ U : Matrix.unitaryGroup
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ,
+      ∀ i : Fin (D * D),
+        S.decomposition.tensor (S.relabel γ) i =
+          (U : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)) i *
+          (U : Matrix (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ := by
+  obtain ⟨ω, hω, hGram⟩ :=
+    S.gauge_gram_eq_pos_smul_one_of_positive_tail_reflected_target
+      hCanonical hM γ hTarget
   exact S.exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one
     γ ω hω hGram
 

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseIdentityPhysicalSpan.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseIdentityPhysicalSpan.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
+
+/-!
+# Identity-dressed physical-letter span for exact two-site sectors
+
+The gauge-dressed physical corner of an exact matched two-site sector gives
+two oblique physical maps.  In one orientation their compression is the raw
+algebra-side representative; in the opposite orientation it is the
+Gram-dressed representative.  The first orientation expresses every
+identity-dressed horizontal slice as a linear combination of physical letters
+of the two-site blocking.
+
+The two physical maps need not coincide.  Consequently this construction is
+not a positive physical corner and does not identify the raw and Gram-dressed
+reflected marked chains.
+
+## Main results
+
+* `TwoSiteExactSectorGauge.exists_blockTwo_identity_oblique_compression`
+  constructs both orientations of the oblique two-site compression.
+* `TwoSiteExactSectorGauge.exists_identity_physical_letter_coefficients`
+  constructs the identity-dressed physical-letter coefficients.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13, Figures 7--8, lines 1909--1919, and Appendix C.4,
+  lines 2048--2057
+-/
+
+open scoped Matrix ComplexOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+variable {d D : ℕ}
+
+namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+variable {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- The gauge-dressed physical corner of a matched two-site sector determines
+two oblique maps.  If `V` is the isometric corner, `X` is the exact sector
+gauge, and
+
+`L = V * (X⁻¹)ᴴ`, `R = V * X`,
+
+then the `L,R` compression is the raw representative, while the reversed
+`R,L` compression is its Gram dressing.
+
+The maps `L` and `R` need not coincide.  Thus the conclusion is not a positive
+physical corner and supplies no common reflected target for the two marked
+chains.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and
+lines 1909--1919, applied in Appendix C.4, lines 2048--2057. -/
+theorem exists_blockTwo_identity_oblique_compression
+    (S : TwoSiteExactSectorGauge H) (γ : Fin H.labelCount) :
+    ∃ (V : Matrix (Fin (d * d))
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) (c : ℂ)
+      (L R : Matrix (Fin (d * d))
+        (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ),
+      Vᴴ * V = 1 ∧ (0 : ℂ) < c ∧
+        L = V *
+          ((↑((S.gauge γ)⁻¹) : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ))ᴴ ∧
+        R = V * (S.gauge γ : Matrix
+          (Fin (S.decomposition.bondDim (S.relabel γ)))
+          (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) ∧
+        (∀ v : Fin (D * D),
+          Lᴴ * verticalTensor (blockTwo M) v * R =
+            c • (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)) v) ∧
+        (∀ v : Fin (D * D),
+          Rᴴ * verticalTensor (blockTwo M) v * L =
+            c • gramDressing (S.gauge γ)
+              (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+                (H.tensor γ)) v) := by
+  obtain ⟨V, c, hV, hc, hcorner⟩ := S.exists_blockTwo_gauge_sector_corner γ
+  let L := V *
+    ((↑((S.gauge γ)⁻¹) : Matrix
+      (Fin (S.decomposition.bondDim (S.relabel γ)))
+      (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ))ᴴ
+  let R := V * (S.gauge γ : Matrix
+    (Fin (S.decomposition.bondDim (S.relabel γ)))
+    (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+  refine ⟨V, c, L, R, hV, hc, rfl, rfl, ?_, ?_⟩
+  · intro v
+    dsimp only [L, R]
+    rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
+    simp only [Matrix.mul_assoc]
+    calc
+      (↑((S.gauge γ)⁻¹) : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+          (Vᴴ * (verticalTensor (blockTwo M) v *
+            (V * (S.gauge γ : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)))) =
+        (↑((S.gauge γ)⁻¹) : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+          (Vᴴ * verticalTensor (blockTwo M) v * V) *
+            (S.gauge γ : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) := by
+        simp only [Matrix.mul_assoc]
+      _ = (↑((S.gauge γ)⁻¹) : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+          (c • ((S.gauge γ : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)) v *
+            (↑((S.gauge γ)⁻¹) : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ))) *
+          (S.gauge γ : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) := by
+        rw [hcorner v]
+      _ = c • (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+          (H.tensor γ)) v := by
+        simp only [Matrix.mul_smul, Matrix.smul_mul, ← Matrix.mul_assoc]
+        rw [← Units.val_mul]
+        simp
+  · intro v
+    dsimp only [L, R]
+    rw [Matrix.conjTranspose_mul]
+    simp only [Matrix.mul_assoc]
+    calc
+      (S.gauge γ : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ *
+          (Vᴴ * (verticalTensor (blockTwo M) v *
+            (V * (↑((S.gauge γ)⁻¹) : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ))) =
+        (S.gauge γ : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ *
+          (Vᴴ * verticalTensor (blockTwo M) v * V) *
+            (↑((S.gauge γ)⁻¹) : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ := by
+        simp only [Matrix.mul_assoc]
+      _ = (S.gauge γ : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ *
+          (c • ((S.gauge γ : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ) *
+            (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+              (H.tensor γ)) v *
+            (↑((S.gauge γ)⁻¹) : Matrix
+              (Fin (S.decomposition.bondDim (S.relabel γ)))
+              (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ))) *
+          (↑((S.gauge γ)⁻¹) : Matrix
+            (Fin (S.decomposition.bondDim (S.relabel γ)))
+            (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)ᴴ := by
+        rw [hcorner v]
+      _ = c • gramDressing (S.gauge γ)
+          (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+            (H.tensor γ)) v := by
+        symm
+        dsimp only [gramDressing]
+        rw [Matrix.coe_units_inv, Matrix.mul_inv_rev,
+          Matrix.conjTranspose_nonsing_inv]
+        simp only [Matrix.mul_assoc, Matrix.mul_smul, Matrix.smul_mul]
+
+/-- Every exact matched two-site sector has coefficients whose physical-letter
+linear combinations are the horizontal slices of the identity-dressed raw
+representative.
+
+This is only the physical-letter-span part of the comparison.  It gives no
+positive corner and no equality with the common reflected target required to
+identify the raw and Gram-dressed representatives.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and
+lines 1909--1919, applied in Appendix C.4, lines 2048--2057. -/
+theorem exists_identity_physical_letter_coefficients
+    (S : TwoSiteExactSectorGauge H) (γ : Fin H.labelCount) :
+    ∃ fId : Fin (S.decomposition.bondDim (S.relabel γ) *
+          S.decomposition.bondDim (S.relabel γ)) →
+        Fin ((d * d) * (d * d)) → ℂ,
+      ∀ u,
+        MPSTensor.linearMarkedTensor fId (blockTwo M).toMPSTensor u =
+          horizontalSlice
+            (gramDressing
+              (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+              (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+                (H.tensor γ))) u.divNat u.modNat := by
+  obtain ⟨V, c, L, R, _hV, hc, _hL, _hR, hcompression, _hreverse⟩ :=
+    S.exists_blockTwo_identity_oblique_compression γ
+  refine ⟨twoSidedCompressionCoefficients L R c, ?_⟩
+  intro u
+  have hPhysical := linearMarkedTensor_twoSidedCompressionCoefficients
+    (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ)) (H.tensor γ))
+    L R c (ne_of_gt hc) hcompression u
+  have hOne : gramDressing
+      (1 : GL (Fin (S.decomposition.bondDim (S.relabel γ))) ℂ)
+      (cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+        (H.tensor γ)) =
+      cast (congrArg (MPSTensor (D * D)) (S.bondDim_eq γ))
+        (H.tensor γ) := by
+    funext v
+    simp only [gramDressing, Units.val_one, Matrix.conjTranspose_one,
+      Matrix.one_mul, inv_one, Matrix.mul_one]
+  rw [hOne]
+  exact hPhysical
+
+end BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+end MPOTensor

--- a/TNLean/MPS/MPDO/FigureEightPairwise.lean
+++ b/TNLean/MPS/MPDO/FigureEightPairwise.lean
@@ -215,6 +215,50 @@ theorem horizontalSlice_twoSidedCompression
   intro j _
   ring
 
+/-- Coefficients of the physical-letter expansion of a two-sided compression
+`Lᴴ * verticalTensor M v * R`, normalized by a nonzero scalar `c`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and
+lines 1909--1919. -/
+noncomputable def twoSidedCompressionCoefficients
+    (L R : Matrix (Fin d) (Fin n) ℂ) (c : ℂ) :
+    Fin (n * n) → Fin (d * d) → ℂ :=
+  fun u z ↦ c⁻¹ * star (L z.divNat u.divNat) * R z.modNat u.modNat
+
+/-- A two-sided compression by `L` and `R`, scaled by a nonzero scalar, has
+horizontal slices in the span of the physical letters with coefficients
+`twoSidedCompressionCoefficients L R c`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, Figures 7--8 and
+lines 1909--1919. -/
+theorem linearMarkedTensor_twoSidedCompressionCoefficients
+    {M : MPOTensor d D} (A : MPSTensor (D * D) n)
+    (L R : Matrix (Fin d) (Fin n) ℂ) (c : ℂ) (hc : c ≠ 0)
+    (hcompression : ∀ v, Lᴴ * verticalTensor M v * R = c • A v)
+    (u : Fin (n * n)) :
+    MPSTensor.linearMarkedTensor (twoSidedCompressionCoefficients L R c)
+        M.toMPSTensor u =
+      horizontalSlice A u.divNat u.modNat := by
+  have hRecover : A = fun v ↦ c⁻¹ • (Lᴴ * verticalTensor M v * R) := by
+    funext v
+    rw [hcompression v]
+    simp [hc]
+  rw [hRecover, horizontalSlice_smul, horizontalSlice_twoSidedCompression]
+  rw [MPSTensor.linearMarkedTensor]
+  rw [← finProdFinEquiv.sum_comp, Fintype.sum_prod_type]
+  dsimp only [twoSidedCompressionCoefficients, MPOTensor.toMPSTensor]
+  simp only [MPSTensor.finProdFinEquiv_divNat,
+    MPSTensor.finProdFinEquiv_modNat]
+  rw [Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [smul_smul]
+  congr 1
+  ring
+
 /-- Coefficients expressing a Gram-dressed corner in the physical-letter
 span of the horizontal tensor. -/
 noncomputable def cornerGramCoefficients
@@ -261,29 +305,16 @@ theorem linearMarkedTensor_cornerGramCoefficients
         rw [Matrix.conjTranspose_mul]
         simp only [Matrix.mul_assoc]
   have hc0 : c ≠ 0 := ne_of_gt hc
-  have hRecover : gramDressing X A = fun v ↦
-      c⁻¹ • ((V * (X : Matrix (Fin n) (Fin n) ℂ))ᴴ *
-        verticalTensor M v * (V * Xiᴴ)) := by
-    funext v
-    rw [← hScaled v]
-    simp [hc0]
-  rw [hRecover, horizontalSlice_smul,
-    horizontalSlice_twoSidedCompression]
-  rw [MPSTensor.linearMarkedTensor]
-  rw [← finProdFinEquiv.sum_comp, Fintype.sum_prod_type]
-  dsimp only [cornerGramCoefficients, MPOTensor.toMPSTensor, Xi]
-  simp only [MPSTensor.finProdFinEquiv_divNat,
-    MPSTensor.finProdFinEquiv_modNat]
-  rw [Finset.smul_sum]
-  apply Finset.sum_congr rfl
-  intro i _
-  rw [Finset.smul_sum]
-  apply Finset.sum_congr rfl
-  intro j _
-  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply]
-  rw [smul_smul]
-  congr 1
-  ring
+  have hPhysical := linearMarkedTensor_twoSidedCompressionCoefficients
+    (gramDressing X A) (V * (X : Matrix (Fin n) (Fin n) ℂ))
+    (V * Xiᴴ) c hc0 (fun v ↦ (hScaled v).symm) u
+  have hCoefficients : cornerGramCoefficients V X c =
+      twoSidedCompressionCoefficients
+        (V * (X : Matrix (Fin n) (Fin n) ℂ)) (V * Xiᴴ) c := by
+    funext r z
+    rfl
+  rw [hCoefficients]
+  exact hPhysical
 
 /-- Evaluating the doubled-index MPS view on paired physical letters is the
 same as evaluating the ket and bra words separately. -/

--- a/TNLean/MPS/MPDO/FigureEightPairwise.lean
+++ b/TNLean/MPS/MPDO/FigureEightPairwise.lean
@@ -264,10 +264,9 @@ span of the horizontal tensor. -/
 noncomputable def cornerGramCoefficients
     (V : Matrix (Fin d) (Fin n) ℂ) (X : GL (Fin n) ℂ) (c : ℂ) :
     Fin (n * n) → Fin (d * d) → ℂ :=
-  fun u z ↦ c⁻¹ *
-    star ((V * (X : Matrix (Fin n) (Fin n) ℂ)) z.divNat u.divNat) *
-      (V * ((((X)⁻¹ : GL (Fin n) ℂ) :
-        Matrix (Fin n) (Fin n) ℂ))ᴴ) z.modNat u.modNat
+  twoSidedCompressionCoefficients
+    (V * (X : Matrix (Fin n) (Fin n) ℂ))
+    (V * ((↑(X⁻¹) : Matrix (Fin n) (Fin n) ℂ))ᴴ) c
 
 /-- The coefficients of a grouped corner recover the horizontal slices of
 its Gram-dressed representative. -/
@@ -308,13 +307,7 @@ theorem linearMarkedTensor_cornerGramCoefficients
   have hPhysical := linearMarkedTensor_twoSidedCompressionCoefficients
     (gramDressing X A) (V * (X : Matrix (Fin n) (Fin n) ℂ))
     (V * Xiᴴ) c hc0 (fun v ↦ (hScaled v).symm) u
-  have hCoefficients : cornerGramCoefficients V X c =
-      twoSidedCompressionCoefficients
-        (V * (X : Matrix (Fin n) (Fin n) ℂ)) (V * Xiᴴ) c := by
-    funext r z
-    rfl
-  rw [hCoefficients]
-  exact hPhysical
+  simpa [cornerGramCoefficients, Xi] using hPhysical
 
 /-- Evaluating the doubled-index MPS view on paired physical letters is the
 same as evaluating the ket and bra words separately. -/

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -1142,22 +1142,28 @@
     (\ref{eq:mpdo_bnt_identity_physical_span}).
 \end{proof}
 
-\begin{theorem}[Conditional Gram identity from an identity-dressed marked realization]
+\begin{theorem}[Conditional Gram identity from the positive-tail reflected target]
     \label{thm:mpdo_bnt_conditional_identity_marked_gram}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        HasIdentityPositiveTailReflectedTarget}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        IdentityMarkedRealization.ofPositiveTailReflectedTarget}
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
         gramDressing_gauge_eq_one_of_identityMarkedRealization}
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
         gauge_gram_eq_pos_smul_one_of_identityMarkedRealization}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        gramDressing_gauge_eq_one_of_positive_tail_reflected_target}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        gauge_gram_eq_pos_smul_one_of_positive_tail_reflected_target}
     \leanok
     \uses{def:mpdo, def:cpsv_canonical_form,
         def:mpdo_bnt_two_site_exact_sector_gauge}
     In the setting of the preceding theorem, suppose in addition that the
-    doubled-index tensor of $M$ is in literal CPSV canonical form. Assume that
-    there is a family of linear combinations of the physical letters of
-    $M^{[2]}$ whose open-bond matrices are the horizontal slices of
-    $M_\gamma$, and that, for every positive tail length, every resulting
-    marked chain equals the reflected-adjoint marked chain of $M_\gamma$ in
-    the adjoint two-site blocking. No equality for the empty tail is assumed.
+    doubled-index tensor of $M$ is in literal CPSV canonical form. Assume that,
+    for every positive tail length, the identity-dressed marked chain equals
+    the reflected-adjoint marked chain of $M_\gamma$ in the adjoint two-site
+    blocking. No equality for the empty tail is assumed.
     Then, for every vertical letter $v$,
     \begin{align}
         (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
@@ -1208,14 +1214,14 @@
     (\ref{eq:mpdo_bnt_conditional_scalar_gram}).
 \end{proof}
 
-\begin{theorem}[Conditional unitary conjugacy from an identity-dressed marked
-    realization]
+\begin{theorem}[Conditional unitary conjugacy from the positive-tail reflected
+    target]
     \label{thm:mpdo_bnt_conditional_identity_marked_unitary_conjugacy}
     \lean{Matrix.normalized_conj_eq_conj_inv_of_gram_eq_smul_one}
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
         exists_unitary_sector_conjugacy_of_gauge_gram_eq_pos_smul_one}
     \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
-        exists_unitary_sector_conjugacy_of_identityMarkedRealization}
+        exists_unitary_sector_conjugacy_of_positive_tail_reflected_target}
     \leanok
     \uses{def:mpdo, def:cpsv_canonical_form,
         def:mpdo_bnt_two_site_exact_sector_gauge}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_theorem_data.tex
@@ -1015,8 +1015,8 @@
     \textbf{Scope restriction (gauge-dressed corner):} This theorem constructs
     only the physical corner in
     (\ref{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}). It does not
-    construct an identity-dressed physical corner for $M_\gamma$ and does not
-    prove the common-target Gram identity
+    construct a same-sided identity-dressed physical corner for $M_\gamma$
+    and does not prove the common-target Gram identity
     \begin{align}
         (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
         (Z_\gamma^\dagger Z_\gamma)^{-1}
@@ -1025,9 +1025,10 @@
     \end{align}
     This restriction is documented in
     \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
-    % Pull request 5282 proves the common-target Gram identity from a supplied
-    % identity-dressed realization.  Constructing that realization from the
-    % tensor-attached algebra clause is tracked in issue 5284 under issue 4648.
+    The following theorem nevertheless realizes the identity-dressed
+    horizontal slices by an oblique compression. Its left and right maps need
+    not agree, so it does not supply the missing positive corner or common
+    reflected target.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1042,6 +1043,103 @@
     conjugated on its open indices by $Z_\gamma^\dagger$ and
     $(Z_\gamma^{-1})^\dagger$, gives the stated equality of marked-chain
     coefficients; the gauge factors cancel on the reflected side.
+\end{proof}
+
+\begin{theorem}[Oblique physical-letter realization of a matched two-site sector]
+    \label{thm:mpdo_bnt_exact_sector_identity_oblique_physical_span}
+    \lean{MPOTensor.twoSidedCompressionCoefficients}
+    \lean{MPOTensor.linearMarkedTensor_twoSidedCompressionCoefficients}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        exists_blockTwo_identity_oblique_compression}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        exists_identity_physical_letter_coefficients}
+    \leanok
+    \uses{thm:mpdo_bnt_exact_sector_gauge_blocked_corner}
+    In the setting of the preceding theorem, choose $V_\gamma$ and
+    $c_\gamma>0$ as in
+    (\ref{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}), and set
+    \begin{align}
+        L_\gamma
+        &=V_\gamma(Z_\gamma^{-1})^\dagger,
+        &
+        R_\gamma
+        &=V_\gamma Z_\gamma.
+        \label{eq:mpdo_bnt_identity_oblique_maps}
+    \end{align}
+    Then, for every vertical letter $v$,
+    \begin{align}
+        L_\gamma^\dagger\widetilde{M^{(2)}}^vR_\gamma
+        &=c_\gamma M_\gamma^v,
+        \label{eq:mpdo_bnt_identity_oblique_compression}\\
+        R_\gamma^\dagger\widetilde{M^{(2)}}^vL_\gamma
+        &=c_\gamma
+          (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
+          (Z_\gamma^\dagger Z_\gamma)^{-1}.
+        \label{eq:mpdo_bnt_identity_oblique_opposite}
+    \end{align}
+    Write $\mc{R}(M_\gamma)^{rs}$ for the horizontal slice
+    $v\mapsto(M_\gamma^v)_{rs}$. For open bond indices $r,s$ and blocked
+    physical indices $i,j$, define
+    \begin{align}
+        f^\gamma_{(r,s),(i,j)}
+        &=c_\gamma^{-1}
+          \overline{(L_\gamma)_{ir}}(R_\gamma)_{js}.
+        \label{eq:mpdo_bnt_identity_physical_coefficients}
+    \end{align}
+    These coefficients realize every identity-dressed horizontal slice in
+    the physical-letter span of the two-site blocking:
+    \begin{align}
+        \sum_{i,j}f^\gamma_{(r,s),(i,j)}(M^{[2]})^{ij}
+        &=\mc{R}(M_\gamma)^{rs}.
+        \label{eq:mpdo_bnt_identity_physical_span}
+    \end{align}
+    This supplies the physical-letter span needed for the attempted comparison
+    of the two vertical forms at
+    \cite[Appendix~C.4, lines~2048--2057]{Cirac2016MPDO_arXiv}.
+
+    \textbf{Scope restriction (oblique realization):} In general
+    $L_\gamma\ne R_\gamma$. Thus
+    (\ref{eq:mpdo_bnt_identity_oblique_compression}) is not a positive
+    same-sided corner. At the marked-chain level, adjoint reflection exchanges
+    the two maps together with the bond-pair and tail reversal. The reflected
+    orientation is therefore governed by the Gram-dressed compression in
+    (\ref{eq:mpdo_bnt_identity_oblique_opposite}), rather than by a second copy
+    of the raw tensor. The theorem supplies the physical-letter realization
+    needed for the identity-dressed mark, but it proves neither a common
+    reflected target nor the Gram identity
+    \begin{align}
+        (Z_\gamma^\dagger Z_\gamma)M_\gamma^v
+        (Z_\gamma^\dagger Z_\gamma)^{-1}
+        &=M_\gamma^v.
+        \notag
+    \end{align}
+    The latter remains the unproved step in the direct application of
+    \cite[Proposition~4.13, Figures~7--8]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Taking adjoints in the left factor of
+    (\ref{eq:mpdo_bnt_identity_oblique_maps}) and substituting
+    (\ref{eq:mpdo_bnt_exact_sector_gauge_blocked_corner}) gives
+    \begin{align}
+        L_\gamma^\dagger\widetilde{M^{(2)}}^vR_\gamma
+        &=Z_\gamma^{-1}
+          \bigl(V_\gamma^\dagger\widetilde{M^{(2)}}^vV_\gamma\bigr)
+          Z_\gamma
+         =c_\gamma M_\gamma^v.
+        \notag
+    \end{align}
+    Reversing the two maps instead gives
+    (\ref{eq:mpdo_bnt_identity_oblique_opposite}). Finally, taking the
+    $(r,s)$ matrix entry of a general two-sided compression yields
+    \begin{align}
+        \bigl[L^\dagger\widetilde{M^{(2)}}^vR\bigr]_{rs}
+        &=\sum_{i,j}\overline{L_{ir}}R_{js}(M^{[2]})^{ij}_v.
+        \notag
+    \end{align}
+    Divide by $c_\gamma$ and use
+    (\ref{eq:mpdo_bnt_identity_oblique_compression}) to obtain
+    (\ref{eq:mpdo_bnt_identity_physical_span}).
 \end{proof}
 
 \begin{theorem}[Conditional Gram identity from an identity-dressed marked realization]
@@ -1074,31 +1172,36 @@
         \label{eq:mpdo_bnt_conditional_scalar_gram}
     \end{align}
 
-    \textbf{Scope restriction (conditional identity-dressed marked
-    realization):} The physical-letter realization and common reflected
-    target used here are assumed rather than derived from the algebra clause.
-    Appendix~C.4, lines~2048--2057, gives two independently chosen vertical
-    canonical forms and their closed-chain comparison; it does not construct
-    a common identity-gauge physical corner for $M_\gamma$. Thus this theorem
-    does not establish the unconditional realization or the conclusion of
-    those lines. The remaining gap is recorded in
+    \textbf{Scope restriction (conditional reflected target):} The preceding
+    theorem derives an identity-dressed physical-letter coefficient family
+    from the exact sector gauge. What remains assumed here is that such a
+    family has the same reflected-adjoint target as the gauge-dressed marked
+    chains at every positive tail length. The oblique construction cannot
+    provide this identity: adjoint reflection, with the required bond-pair and
+    tail reversal, exchanges $L_\gamma$ and $R_\gamma$ and is governed by the
+    Gram-dressed compression
+    (\ref{eq:mpdo_bnt_identity_oblique_opposite}). Thus this theorem does not
+    establish the unconditional conclusion of Appendix~C.4,
+    lines~2048--2057. The remaining gap is recorded in
     \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:mpdo_bnt_exact_sector_gauge_blocked_corner,
+        thm:mpdo_bnt_exact_sector_identity_oblique_physical_span,
         thm:mpdo_literal_cpsv_positive_blocking,
         thm:cpsv_original_coordinate_marked_lemma_l,
         thm:eq3_of_dressed_adjoint}
-    The preceding theorem gives a physical-letter coefficient family for the
+    The gauge-dressed corner gives a physical-letter coefficient family for the
     gauge-dressed mark and identifies its marked chains with the reflected
-    target. By hypothesis, the identity-dressed mark has another
-    physical-letter coefficient family with the same target. Their marked
-    traces therefore agree for every positive-length tail word. Literal CPSV
-    canonical form passes to the two-site blocking, and the positive-tail
-    form of the original-coordinate marked separation theorem, corresponding
-    to \cite[Appendix~C.3, lines~1835--1858]{Cirac2016MPDO_arXiv}, identifies
-    the two open-bond matrices. This gives
+    target. The oblique theorem supplies a physical-letter coefficient family
+    for the identity-dressed mark; the remaining hypothesis identifies its
+    marked chains with the same target. Their marked traces therefore agree
+    for every positive-length tail word. Literal CPSV canonical form passes to
+    the two-site blocking, and the positive-tail form of the
+    original-coordinate marked separation theorem, corresponding to
+    \cite[Appendix~C.3, lines~1835--1858]{Cirac2016MPDO_arXiv}, identifies the
+    two open-bond matrices. This gives
     (\ref{eq:mpdo_bnt_conditional_identity_marked_gram}). Normality of
     $M_\gamma$ then makes its commuting Gram matrix a positive real scalar
     multiple of the identity, proving
@@ -1133,13 +1236,13 @@
     \cite[Proposition~4.13, lines~1903--1908]{Cirac2016MPDO_arXiv}, applied
     at Appendix~C.4, lines~2053--2057.
 
-    \textbf{Scope restriction (conditional identity-dressed marked
-    realization):} The positive-tail marked realization remains an
-    assumption. Appendix~C.4, lines~2048--2057, does not construct the common
-    identity-gauge physical corner that would supply it. Hence this theorem
-    does not establish the unconditional line-2057 conclusion. Its derivation
-    from the tensor-attached algebra clause is the remaining premise recorded
-    in
+    \textbf{Scope restriction (conditional reflected target):} The
+    physical-letter coefficients are supplied by
+    Theorem~\ref{thm:mpdo_bnt_exact_sector_identity_oblique_physical_span},
+    but their common positive-tail reflected target remains an assumption.
+    Appendix~C.4, lines~2048--2057, does not establish this star-compatible
+    target for the raw representative. Hence this theorem does not establish
+    the unconditional line-2057 conclusion. The missing target is recorded in
     \path{docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex}.
     % Pull request 5282 is the conditional Gram theorem, and pull request 5286
     % composes it with scalar-to-unitary normalization.  Issue 5284, under issue 4648,

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -40,15 +40,18 @@ dimensions and the invertible matrix $Z_\gamma$ in
 lengths proves $e^{i\theta_\gamma}=1$, so the resulting conjugacy is exact.
 This proves the invertible-gauge sub-result of lines~2053--2057.
 
-The conditional Gram theorem proves
+The target-only conditional Gram theorem proves
 \eqref{eq:gram-dressing-target}, and hence
 $Z_\gamma^\dagger Z_\gamma=\omega_\gamma\mathbf 1$ with
-$\omega_\gamma>0$, from a supplied identity-dressed marked realization.
-Its unitary-normalization corollary sets
+$\omega_\gamma>0$, from the positive-tail identity
+\path{HasIdentityPositiveTailReflectedTarget}.  The constructor
+\path{IdentityMarkedRealization.ofPositiveTailReflectedTarget} supplies the
+physical-letter coefficient family and its physical-slice identity from the
+oblique compression.  The unitary-normalization corollary sets
 $U_\gamma=\omega_\gamma^{-1/2}Z_\gamma$ and proves that $U_\gamma$ is
 unitary with the same conjugation action as $Z_\gamma$.  Thus the entire
-line~2057 conclusion is available conditionally on that supplied
-realization.
+line~2057 conclusion is available conditionally on the positive-tail
+reflected target alone.
 % The conditional Gram and unitary results are pull requests 5282 and 5286.
 
 The physical-letter part of this realization is now unconditional.  The
@@ -177,7 +180,13 @@ The structure
 has a physical-letter coefficient field, its physical-slice identity, and a
 common-target identity.  Equations~\eqref{eq:oblique-raw-compression} and
 \eqref{eq:oblique-physical-coefficients} discharge the first two parts.  The
-last part is required only at positive tail lengths.  More precisely, after
+last part is isolated as
+\path{HasIdentityPositiveTailReflectedTarget}.  The constructor
+\path{IdentityMarkedRealization.ofPositiveTailReflectedTarget} obtains the
+first two fields from the oblique compression and assumes exactly this final
+target.  Thus the conditional Gram and unitary conclusions now have
+target-only forms; no independent physical-letter hypothesis remains.
+More precisely, after
 one open-bond matrix has been inserted at the marked site, equality with the
 common reflected-adjoint target is assumed for every tail length $N>0$; no
 empty-tail equality is required.  This is sufficient because representative
@@ -661,7 +670,8 @@ Consequently Theorem~4.14 remains partial.  Issue
 \href{https://github.com/LionSR/TNLean/issues/4648}{\#4648}, and
 \href{https://github.com/LionSR/TNLean/issues/4645}{\#4645} remains open.
 The terminal-positivity theorem and the conditional Gram and unitary theorems
-remain unchanged.
+remain valid; the latter now assume precisely the positive-tail reflected
+target isolated above.
 
 \section{Non-circular product corners}
 
@@ -715,13 +725,14 @@ Equivalently, for every vertical letter $v$,
 \]
 Normality then implies \eqref{eq:gram-scalar}.
 
-The conditional Gram theorem establishes \eqref{eq:gram-dressing-target}
-from a supplied identity-dressed physical-letter coefficient family and its
-common reflected target at every positive tail length.  The empty tail is not
-part of this hypothesis.  The coefficient family and its physical-slice
-identity are now supplied unconditionally by
-\eqref{eq:oblique-physical-coefficients}; only the common reflected target
-remains conditional.  The unitary-normalization corollary then constructs
+The target-only conditional Gram theorem establishes
+\eqref{eq:gram-dressing-target} from the common reflected target at every
+positive tail length.  The empty tail is not part of this hypothesis.  The
+coefficient family and its physical-slice identity are supplied
+unconditionally by \eqref{eq:oblique-physical-coefficients} and packaged by
+\path{IdentityMarkedRealization.ofPositiveTailReflectedTarget}; only the
+common reflected target remains conditional.  The unitary-normalization
+corollary then constructs
 \[
   U_\gamma=\omega_\gamma^{-1/2}X_\gamma,
   \qquad

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -9,7 +9,7 @@
 
 \title{The Two-Site Sector Comparison Stops at an Invertible Gauge}
 \author{}
-\date{2026-08-01}
+\date{2026-08-02}
 
 \begin{document}
 \maketitle
@@ -51,21 +51,76 @@ line~2057 conclusion is available conditionally on that supplied
 realization.
 % The conditional Gram and unitary results are pull requests 5282 and 5286.
 
-One direct sufficient datum is weaker than the full marked realization.  Let
-$V$ be any matrix and let $c>0$ satisfy the positive-coefficient two-sided
-physical realization
+The physical-letter part of this realization is now unconditional.  The
+gauge-dressed two-site corner provides $V_\gamma$ and $c_\gamma>0$ such that
+\begin{equation}
+  V_\gamma^\dagger\widetilde M_{[2]}^vV_\gamma
+  =c_\gamma Z_\gamma M_\gamma^vZ_\gamma^{-1}.
+  \label{eq:gauge-dressed-corner}
+\end{equation}
+Set
+\begin{equation}
+  L_\gamma=V_\gamma(Z_\gamma^{-1})^\dagger,
+  \qquad
+  R_\gamma=V_\gamma Z_\gamma.
+  \label{eq:oblique-maps}
+\end{equation}
+Then direct cancellation of the invertible gauge gives
+\begin{equation}
+  L_\gamma^\dagger\widetilde M_{[2]}^vR_\gamma
+  =c_\gamma M_\gamma^v.
+  \label{eq:oblique-raw-compression}
+\end{equation}
+Consequently
+\begin{equation}
+  f^\gamma_{(r,s),(i,j)}
+  =c_\gamma^{-1}\overline{(L_\gamma)_{ir}}(R_\gamma)_{js}
+  \label{eq:oblique-physical-coefficients}
+\end{equation}
+expresses every horizontal slice of $M_\gamma$ as a linear combination of
+the physical letters of the two-site blocking.  Thus the \path{fId} and
+\path{physical} fields of the marked realization are discharged.
+\footnote{Formal declarations:
+\leanid{MPOTensor.twoSidedCompressionCoefficients},
+\leanid{MPOTensor.linearMarkedTensor_twoSidedCompressionCoefficients},
+\leanid{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+exists_blockTwo_identity_oblique_compression}, and
+\leanid{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+exists_identity_physical_letter_coefficients}.}
+
+This construction is oblique: in general $L_\gamma\ne R_\gamma$.  Reversing
+the two maps gives
+\begin{equation}
+  R_\gamma^\dagger\widetilde M_{[2]}^vL_\gamma
+  =c_\gamma(Z_\gamma^\dagger Z_\gamma)M_\gamma^v
+    (Z_\gamma^\dagger Z_\gamma)^{-1}.
+  \label{eq:oblique-gram-compression}
+\end{equation}
+At the marked-chain level, adjoint reflection exchanges the two oblique maps
+together with the bond-pair and tail reversal.  The reflected orientation is
+therefore governed by the Gram-dressed compression
+\eqref{eq:oblique-gram-compression}; it does not identify the raw mark with the
+common reflected target.  The irreducible remaining gap is the star-compatible
+positive-tail target identity, which is equivalent to
+\eqref{eq:gram-dressing-target}; it is not the physical-letter span assertion.
+
+A same-sided realization is a stronger local datum, but it is still weaker
+than the full marked realization.  Let $V$ be any matrix and let $c>0$ satisfy
+the positive-coefficient same-sided physical realization
 \begin{equation}
   V^\dagger\widetilde M_{[2]}^vV=cM_\gamma^v
   \label{eq:positive-coefficient-realization}
 \end{equation}
 for every vertical letter $v$.  The physical-letter expansion of the marked
-matrix uses \eqref{eq:positive-coefficient-realization}, while MPDO reflection identifies
-the resulting marked chain with the common target.  Neither step requires
-$V^\dagger V=\mathbf 1$.  This reduction is formalized by a conditional
-constructor.\footnote{Formal declaration:
+matrix uses \eqref{eq:positive-coefficient-realization}, while MPDO reflection
+identifies the resulting marked chain with the common target.  Neither step
+requires $V^\dagger V=\mathbf 1$.  This reduction is formalized by a
+conditional constructor.\footnote{Formal declaration:
 \leanid{IdentityMarkedRealization.ofPositiveCoefficientPhysicalRealization}.}
-It gives a concrete sufficient local premise without adding orthogonality,
-reconstruction, or normalization assumptions.
+It gives a concrete sufficient local premise for the missing target without
+adding orthogonality, reconstruction, or normalization assumptions.  The
+oblique maps in \eqref{eq:oblique-maps} do not meet this premise because their
+left and right factors are different.
 
 There is an independent sufficient route which need not pass through
 \eqref{eq:positive-coefficient-realization}.  The invertible similarity determines an
@@ -119,14 +174,17 @@ of the sufficient local premises just described.
 
 The structure
 \path{BNTAlgebraTensorClause.TwoSiteExactSectorGauge.IdentityMarkedRealization}
-requires the common-target identity only at positive tail lengths.  More
-precisely, after one open-bond matrix has been inserted at the marked site,
-equality with the common reflected-adjoint target is assumed for every tail
-length $N>0$; no empty-tail equality is required.  This is sufficient because
-representative separation chooses a sufficiently large tail length.  It is
-the form of Lemma~L justified by Appendix~C.3, lines~1835--1858: the source
-states first-site equality for positive system sizes, and its proof uses a
-length at which block injectivity and a nonzero power sum separate the normal
+has a physical-letter coefficient field, its physical-slice identity, and a
+common-target identity.  Equations~\eqref{eq:oblique-raw-compression} and
+\eqref{eq:oblique-physical-coefficients} discharge the first two parts.  The
+last part is required only at positive tail lengths.  More precisely, after
+one open-bond matrix has been inserted at the marked site, equality with the
+common reflected-adjoint target is assumed for every tail length $N>0$; no
+empty-tail equality is required.  This is sufficient because representative
+separation chooses a sufficiently large tail length.  It is the form of
+Lemma~L justified by Appendix~C.3, lines~1835--1858: the source states
+first-site equality for positive system sizes, and its proof uses a length at
+which block injectivity and a nonzero power sum separate the normal
 representatives.
 
 This does not yet prove the second part of \eqref{eq:unitary-upgrade} from the
@@ -136,10 +194,12 @@ copies of a common normal representative and proves proportionality of their
 Gram matrices.  Only afterwards does the source choose the first copy to have
 identity gauge.  The present
 one-site and two-site decompositions are constructed independently.  The
-available normal-tensor matching theorem therefore supplies an invertible
-conjugacy, but no second positive-coefficient physical realization of the form
-\eqref{eq:positive-coefficient-realization} with which the existing two-site corner can
-be compared.
+available normal-tensor matching theorem and the existing two-site corner
+therefore supply the oblique realization
+\eqref{eq:oblique-raw-compression}, but no second same-sided
+positive-coefficient realization of the form
+\eqref{eq:positive-coefficient-realization} with which the gauge-dressed
+corner can be compared.
 
 The missing step occurs immediately before the comparison.  At line~2048 the
 source writes the algebra-side positive direct sum and the independently
@@ -147,11 +207,12 @@ chosen two-site decomposition as physical vertical canonical forms, up to
 unitary changes of basis.  The displayed operator identity at lines~2049--2051
 then gives equality of all positive-length closed chains.  In the present
 formalization this implication yields equality of those closed chains and
-gauge-phase coverage of their normal representatives, but it does not produce
-an isometric physical inclusion of the algebra-side representative into the
-bond space of the two-site blocking.  Proposition~4.13, lines~1898--1921,
-compares actual physical sectors; it cannot be applied until this inclusion is
-available.
+gauge-phase coverage of their normal representatives.  The invertible gauge
+then produces an oblique inclusion of the algebra-side representative into
+the bond space of the two-site blocking, but not a same-sided isometric or
+positive corner.  Proposition~4.13, lines~1898--1921, compares actual
+physical sectors through the latter kind of corner; the oblique inclusion
+does not supply its star-compatible comparison.
 
 Thus the positive-tail restriction removes an unnecessary empty-word premise,
 but it does not provide the geometric premise of the comparison.
@@ -159,9 +220,12 @@ Appendix~C.4, lines~2048--2051, gives equality of positive-length closed
 chains for two independently chosen vertical canonical forms.
 Lines~2053--2057 then give an invertible similarity and invoke
 Proposition~4.13.  None of these lines constructs a positive-coefficient
-two-sided physical realization whose open-bond matrices would yield the
-identity-dressed marked family.  An identity-gauge isometric corner would be a
-stronger sufficient datum, but is not needed by the marked-chain argument.
+same-sided physical realization.  The formal oblique construction does yield
+the identity-dressed physical-letter family, but its reflected orientation is
+the Gram-dressed family in \eqref{eq:oblique-gram-compression}.  An
+identity-gauge isometric corner would be a stronger sufficient datum for the
+missing target, but the exact remaining assertion is only the positive-tail
+star-compatible marked identity.
 
 \section{The circular corner construction}
 
@@ -465,8 +529,8 @@ This no-go result does not settle the missing tensor-attached marked
 comparison.  \href{https://github.com/LionSR/TNLean/issues/5284}{Issue 5284}
 remains open.  Every counterexample to that proposed comparison must use
 retained sectors whose terminal transfers are positive semidefinite.
-Terminal positivity alone does not produce the identity-dressed marked
-realization or a unitary gauge.
+Terminal positivity alone does not produce the star-compatible positive-tail
+target identity or a unitary gauge.
 
 \section{A bond-two singleton physical-similarity obstruction}
 
@@ -654,7 +718,10 @@ Normality then implies \eqref{eq:gram-scalar}.
 The conditional Gram theorem establishes \eqref{eq:gram-dressing-target}
 from a supplied identity-dressed physical-letter coefficient family and its
 common reflected target at every positive tail length.  The empty tail is not
-part of this hypothesis.  Its unitary-normalization corollary then constructs
+part of this hypothesis.  The coefficient family and its physical-slice
+identity are now supplied unconditionally by
+\eqref{eq:oblique-physical-coefficients}; only the common reflected target
+remains conditional.  The unitary-normalization corollary then constructs
 \[
   U_\gamma=\omega_\gamma^{-1/2}X_\gamma,
   \qquad
@@ -667,38 +734,40 @@ Terminal sector positivity excludes the generic nonunitary-similarity witness
 from the full tensor-attached setting.  The bond-two deformation has a genuine
 tensor-attached BNT algebra clause and literal horizontal CPSV canonical form,
 but a nonscalar Gram matrix makes its length-two operator nonpositive.  These
-facts do not supply the missing marked comparison.
+facts do not supply the missing star-compatible marked comparison.
 
-The remaining premise is to construct the coefficient family, prove its
-physical-slice identity, and prove its common reflected-target identity at
-positive tail lengths directly from the tensor-attached algebra clause,
-literal CPSV canonical form, and the MPDO hypothesis.  A common identity-gauge
-isometric corner would suffice to produce these marked identities, but that
-corner remains unconstructed.  This is
+The remaining premise is to prove the common reflected-target identity at
+positive tail lengths for the coefficient family in
+\eqref{eq:oblique-physical-coefficients}, directly from the tensor-attached
+algebra clause, literal CPSV canonical form, and the MPDO hypothesis.  A
+common identity-gauge isometric corner would suffice to produce this identity,
+but such a positive corner is stronger than the required conclusion and
+remains unconstructed.  The target identity is
 tracked in \href{https://github.com/LionSR/TNLean/issues/5284}{issue 5284},
 under \href{https://github.com/LionSR/TNLean/issues/4648}{issue 4648}, without
-assuming a raw corner, a Gram identity, a unitary gauge, fusion data, or a
-renormalization fixed point.  Consequently issues 4648 and
+assuming a positive raw corner, a Gram identity, a unitary gauge, fusion data,
+or a renormalization fixed point.  Consequently issues 4648 and
 \href{https://github.com/LionSR/TNLean/issues/4645}{4645} remain open, and the
 unconditional line~2057 unitary conclusion remains unformalized.
 
 \section{Verdict}
 
-\textbf{Scope restriction: the conditional conclusion is complete, while the
-unconditional marked realization remains an open gap.}  The
-Gram-dressing identity \eqref{eq:gram-dressing-target} and the subsequent
-unitary normalization are formalized under a supplied identity-dressed marked
-realization whose common-target identity is required only at positive tail
-lengths.  That realization, and in particular its common identity-gauge
-physical corner, has not been derived from condition~(ii) alone.  Terminal
-sector positivity rules out the generic nonunitary witness.  The concrete
-bond-two deformation does carry a tensor-attached BNT algebra clause and has
-literal horizontal CPSV canonical form, but it fails the MPDO hypothesis at
-length two.  It is therefore not a full-contract counterexample and constructs
-no identity-dressed marked realization.  Appendix~C.4 therefore does not
-presently justify the
-unconditional line~2057 unitary conclusion without a separately supplied local
-marked realization.
+\textbf{Scope restriction: the identity-dressed physical-letter span is
+complete, while the common positive-tail target remains open.}  The oblique
+maps \eqref{eq:oblique-maps} give the coefficients
+\eqref{eq:oblique-physical-coefficients} without a scalar Gram hypothesis or a
+unitary gauge.  Since $L_\gamma$ and $R_\gamma$ need not agree, this result is
+not a positive corner.  Its adjoint-reflected orientation is governed by the
+Gram-dressed compression \eqref{eq:oblique-gram-compression}, with the
+bond-pair and tail reversal included.  The direct equality of this target
+with the reflected raw target remains unproved; equivalently,
+\eqref{eq:gram-dressing-target} remains conditional.  Terminal sector
+positivity rules out the generic nonunitary witness.  The concrete bond-two
+deformation does carry a tensor-attached BNT algebra clause and has literal
+horizontal CPSV canonical form, but it fails the MPDO hypothesis at length
+two.  It is therefore not a full-contract counterexample and does not supply
+the missing target.  Appendix~C.4 therefore does not presently justify the
+unconditional line~2057 unitary conclusion.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Motivation

The exact two-site sector gauge already gives a positive gauge-dressed corner,
but the Appendix C.4 gap note treated the entire identity-dressed marked
realization as missing. The invertible gauge in fact yields the required
physical-letter span by an oblique compression. Isolating this consequence
narrows the remaining problem to the star-compatible positive-tail reflected
target.

## Description

- add reusable coefficients for a general two-sided compression and make the
  existing Gram-corner coefficients a direct specialization;
- construct
  \(L_\gamma=V_\gamma(Z_\gamma^{-1})^\dagger\) and
  \(R_\gamma=V_\gamma Z_\gamma\), proving
  \[
  L_\gamma^\dagger\widetilde M_{[2]}^vR_\gamma=c_\gamma M_\gamma^v
  \]
  and the reversed Gram-dressed compression;
- derive explicit coefficients realizing every identity-dressed horizontal
  slice in the physical-letter span of the two-site blocking;
- isolate the remaining condition as
  `HasIdentityPositiveTailReflectedTarget`, construct the bundled marked
  realization from that condition alone, and add target-only Gram, scalar-Gram,
  and unitary-conjugacy corollaries;
- synchronize Chapter 21 and the Appendix C.4 paper-gap note with the complete
  proof composition.

The two oblique maps need not coincide, so this pull request proves neither a
positive same-sided corner nor the common reflected target. Issues #5284,
#4648, and #4645 therefore remain open.

## Testing

- seeded the worktree from the hot `main` Lake build and ran
  `lake exe cache get` before Lean checks; no Mathlib source rebuild was used;
- `lake env lean -DwarningAsError=true` on the changed proof-bearing modules,
  including the conditional Gram and unitary endpoints;
- targeted Lake builds of the new module and its conditional dependents;
- final incremental `lake build` (9,890 jobs, successful; only pre-existing
  warnings in unrelated modules);
- generated-import check, tactic-pattern scan, diff-scoped reader-facing prose
  check, proof-integrity token scan, line-length scan, and `git diff --check`;
- `leanblueprint checkdecls`, `leanblueprint web`, and
  `leanblueprint pdf`;
- visual inspection of the oblique, target-only Gram, and target-only unitary
  statements in the rendered 849-page Blueprint PDF.

Closes #5333.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and documentation only; no runtime, auth, or data paths. Remaining conditional assumptions are explicitly documented and unchanged in strength for the open gap.
> 
> **Overview**
> **Unconditionally derives** the identity-dressed physical-letter coefficients for exact two-site sector gauges from the existing gauge-dressed corner, narrowing the Appendix C.4 gap to a single **positive-tail reflected-target** hypothesis.
> 
> Adds reusable **`twoSidedCompressionCoefficients`** / **`linearMarkedTensor_twoSidedCompressionCoefficients`** in `FigureEightPairwise.lean` and refactors **`cornerGramCoefficients`** through them. New module **`BNTAlgebraTensorClauseIdentityPhysicalSpan.lean`** builds oblique maps \(L_\gamma = V_\gamma(Z_\gamma^{-1})^\dagger\), \(R_\gamma = V_\gamma Z_\gamma\): one orientation compresses to the raw sector tensor, the reversed orientation to the **Gram-dressed** representative—so \(L_\gamma \ne R_\gamma\) in general and this is **not** a same-sided positive corner.
> 
> Conditional Gram/unitary layer is reshaped: **`HasIdentityPositiveTailReflectedTarget`**, **`IdentityMarkedRealization.ofPositiveTailReflectedTarget`**, and target-only theorems (**`gramDressing_gauge_eq_one_of_positive_tail_reflected_target`**, **`exists_unitary_sector_conjugacy_of_positive_tail_reflected_target`**). Blueprint Ch.21 and **`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`** are updated to match; issues #5284 / #4645 remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a574fa317179b7a8b3b9d501531a1558638093c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->