### PR TITLE
doc(MPS/Periodic): synchronize completed overlap dichotomy

### DIFF
--- a/TNLean/MPS/Periodic/CornerContraction.lean
+++ b/TNLean/MPS/Periodic/CornerContraction.lean
@@ -46,12 +46,11 @@ multiple of `m`).
   corner data, contracting the concatenation
   `∏_k (A_k^{σ_k} · F_{k+1}^{ρ_k})` to the chain `∏_k (A_k^{σ_k} · X_k)`.
 
-The remaining steps of Appendix A (lines 1063--1080) — recombining the two
-mechanisms with the per-sector scalar bookkeeping into the uniform
-product-tensor identity `eq:resultprop`, and feeding it to
+The downstream theorem `sectorTensor_proportional_of_blockedMatch` recombines
+these mechanisms with the per-sector scalar bookkeeping into the uniform
+product-tensor identity `eq:resultprop`, then applies
 `PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`
-— are not addressed here; see
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
+to continue Appendix A, lines 1063--1080.
 
 ## References
 

--- a/TNLean/MPS/Periodic/CornerTransition.lean
+++ b/TNLean/MPS/Periodic/CornerTransition.lean
@@ -29,9 +29,10 @@ requires no injectivity or normality input:
   cycle to reach an injective length (eq:Fu).  The junction projector
   `P (u + w₁.length • 1)` is absorbed by idempotency.
 
-These are the `A_u^i`/`F_u` building blocks for the sector-match case. The
-downstream theorem `sectorTensor_proportional_of_blockedMatch` uses their
-right-inverse contraction to obtain the uniform product-tensor identity, applies
+These are the `A_u^i`/`F_u` building blocks for the sector-match case. In
+`TNLean.MPS.Periodic.Overlap.SectorMatch.Contraction`, the theorem
+`sectorTensor_proportional_of_blockedMatch` uses their right-inverse contraction
+to obtain the uniform product-tensor identity, applies
 `PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`,
 and assembles the global gauge.
 

--- a/TNLean/MPS/Periodic/CornerTransition.lean
+++ b/TNLean/MPS/Periodic/CornerTransition.lean
@@ -29,12 +29,11 @@ requires no injectivity or normality input:
   cycle to reach an injective length (eq:Fu).  The junction projector
   `P (u + w₁.length • 1)` is absorbed by idempotency.
 
-These are the `A_u^i`/`F_u` building blocks named in the issue's split plan for
-Case 3.  The remaining steps of Appendix A — the right-inverse contraction of
-`F_u` to the uniform product-tensor identity (feeding
-`PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`)
-and the global gauge assembly — are not addressed here; see
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
+These are the `A_u^i`/`F_u` building blocks for the sector-match case. The
+downstream theorem `sectorTensor_proportional_of_blockedMatch` uses their
+right-inverse contraction to obtain the uniform product-tensor identity, applies
+`PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`,
+and assembles the global gauge.
 
 ## References
 

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -41,12 +41,10 @@ The proportional theorem `thm:bd` is stated in two forms:
   plus the existence of non-decaying cross-family overlaps (`exists_nondecaying_A/B`),
   which encode the paper's proportional-MPV assumption.
 
-  **Caveat**: `periodicOverlapDichotomy` is stated and callable, but its proof still
-  depends on the remaining Case-3 contraction with \(F_u\), \(\Omega_u\), and the
-  phases \(\kappa_v\) from arXiv:1708.00029, Appendix A, lines 1023--1117,
-  formalized as `sectorTensor_proportional_of_blockedMatch` in
-  `TNLean.MPS.Periodic.Overlap.SectorMatch`. Subsequent results using the `_of_isPeriodic`
-  variant therefore inherit that obligation and should not be treated as unconditional.
+  The overlap dichotomy, including the full-cycle contraction with \(F_u\),
+  \(\Omega_u\), and the phases \(\kappa_v\), is proved in
+  `TNLean.MPS.Periodic.Overlap.SectorMatch` and assembled in
+  `TNLean.MPS.Periodic.Overlap.Dichotomy`.
 
 The Z-gauge construction (the scalar-entry part of `thm:bdequal`) is fully proved.
 
@@ -114,11 +112,9 @@ abbrev PeriodicBlockMatchingWitness
 /-- Hypothesis giving the periodic overlap dichotomy
 (arXiv:1708.00029, proposition `equal-or-orthogonal-generalized`).
 
-The `hetRepeatedBlocks_of_nondecaying` field can be filled via `periodicOverlapDichotomy`
-(see `PeriodicOverlapHypothesis.ofIsPeriodic`), though that dichotomy still relies on
-the remaining Case-3 contraction with \(F_u\), \(\Omega_u\), and the phases
-\(\kappa_v\) from arXiv:1708.00029, Appendix A, lines 1023--1117, formalized as
-`sectorTensor_proportional_of_blockedMatch`. The fields capture the essential results:
+The `hetRepeatedBlocks_of_nondecaying` field can be filled via the proved
+`periodicOverlapDichotomy` (see `PeriodicOverlapHypothesis.ofIsPeriodic`). The fields
+capture the essential results:
 1. For each block in one family, a non-decaying overlap partner exists in the other.
 2. Non-decaying overlap forces `HetRepeatedBlocks`.
 
@@ -150,15 +146,10 @@ non-decay) or `HetRepeatedBlocks (A j) (B k)`.
 The `exists_nondecaying_A/B` fields remain as explicit hypotheses — they encode the
 paper's content that proportional total MPVs force non-vanishing per-block overlaps.
 
-**Remaining proof obligations.** `periodicOverlapDichotomy` is stated and callable, but
-its proof transitively depends on admitted lemmas in the split overlap development:
-`TNLean.MPS.Periodic.Overlap.SelfOverlap` for self-overlap and cyclic-sector setup,
-`TNLean.MPS.Periodic.Overlap.NoSectorMatch` for the no-sector-match decay route,
-`TNLean.MPS.Periodic.Overlap.SectorMatch` for the sector-match repeated-block route, and
-`TNLean.MPS.Periodic.Overlap.Dichotomy` for the final dichotomy and eventual
-linear-independence statement. Subsequent users of this constructor therefore inherit
-those obligations and
-should not treat the resulting `PeriodicOverlapHypothesis` as unconditionally proven. -/
+All branches of `periodicOverlapDichotomy` are proved in the split overlap development:
+`SelfOverlap` supplies the cyclic-sector setup, `NoSectorMatch` supplies the decay route,
+`SectorMatch` supplies the repeated-block route, and `Dichotomy` performs the final case
+split. -/
 theorem PeriodicOverlapHypothesis.ofIsPeriodic
     {rA rB : ℕ}
     {dimA : Fin rA → ℕ} {dimB : Fin rB → ℕ}
@@ -206,9 +197,7 @@ its periodic self-overlap limit `m_a` along the subsequence `m_a * ℕ`.
 Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623, with the periodic overlap
 dichotomy from Appendix A, lines 1023--1117. The positive-length formulation is recorded in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
-
-As with `periodicOverlapDichotomy`, this theorem currently inherits the admitted sub-lemmas in
-`Periodic/Overlap`. -/
+-/
 theorem peripheralProportionalCase_periodicFT_of_sameMPV₂Pos
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (A : MPSTensor d D₁) (B : MPSTensor d D₂) {m_a m_b : ℕ}
@@ -264,9 +253,9 @@ MPVs to `HetRepeatedBlocks`. Thus the remaining single-block proportional gap in
 the source theorem `thm:bd` is exactly the phase-rescaling step provided by that
 hypothesis.
 
-Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623. The missing phase-rescaling
-argument is recorded in `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. This proof
-inherits the admitted Case-3 sector contraction through the positive-length equality theorem. -/
+Source: arXiv:1708.00029, theorem `thm:bd`, lines 613--623. The remaining
+phase-rescaling argument is recorded in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (hRescale : PeripheralProportionalCaseRootFromRescaling d D₁ D₂)
@@ -314,14 +303,9 @@ existence step that turns proportionality of the assembled tensors into the
 non-decaying cross-overlap hypotheses `exists_nondecaying_A/B`.
 
 The `PeriodicOverlapHypothesis` parameter can be supplied via
-`PeriodicOverlapHypothesis.ofIsPeriodic`, which uses `periodicOverlapDichotomy`
-to fill the `hetRepeatedBlocks_of_nondecaying` field; see
-`fundamentalTheorem_periodic_proportional_of_isPeriodic`. Note that
-`periodicOverlapDichotomy` still relies on the remaining Case-3 contraction with
-\(F_u\), \(\Omega_u\), and the phases \(\kappa_v\) from arXiv:1708.00029,
-Appendix A, lines 1023--1117, formalized as
-`sectorTensor_proportional_of_blockedMatch`; callers going through that route inherit
-that obligation. -/
+`PeriodicOverlapHypothesis.ofIsPeriodic`, which uses the proved
+`periodicOverlapDichotomy` to fill the `hetRepeatedBlocks_of_nondecaying` field; see
+`fundamentalTheorem_periodic_proportional_of_isPeriodic`. -/
 theorem fundamentalTheorem_periodic_proportional
     (A : (j : Fin rA) → MPSTensor d (dimA j))
     (B : (k : Fin rB) → MPSTensor d (dimB k))
@@ -394,13 +378,10 @@ This is the form intended by the paper: two families of periodic blocks whose cr
 overlaps do not all vanish must match up to bijection and per-block `HetRepeatedBlocks`
 equivalence.
 
-**Remaining proof obligation.** `periodicOverlapDichotomy` is stated and callable, but
-its proof still uses the remaining Case-3 contraction with \(F_u\), \(\Omega_u\), and
-the phases \(\kappa_v\) from arXiv:1708.00029, Appendix A, lines 1023--1117,
-formalized as `sectorTensor_proportional_of_blockedMatch` in
-`TNLean.MPS.Periodic.Overlap.SectorMatch`. Subsequent users of this theorem inherit that
-obligation: this variant is a convenience reformulation, not an unconditional
-strengthening. -/
+The overlap-dichotomy input is unconditional: its sector-match branch uses the proved
+full-cycle contraction `sectorTensor_proportional_of_blockedMatch`. The explicit
+non-decaying cross-family overlap hypotheses remain the mathematical input encoding the
+paper's proportional-MPV step. -/
 theorem fundamentalTheorem_periodic_proportional_of_isPeriodic
     (A : (j : Fin rA) → MPSTensor d (dimA j))
     (B : (k : Fin rB) → MPSTensor d (dimB k))

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -493,11 +493,11 @@ The equal-case Fundamental Theorem of MPS in irreducible form combines:
 2. **Z-gauge construction** (`equalCase_zgauge_of_power_sums`):
    Newton–Girard plus a scalar multiplicity-entry Z-gauge diagonal.
 
-**Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and per-block
-multiplicity-entry power equality hypotheses remain to be discharged from the
-periodic overlap dichotomy (`equal-or-orthogonal-generalized`) and the coefficient
-extraction theory.
-The Z-gauge construction itself is fully proved.
+**Remaining source hypotheses:** The existence of non-decaying cross-family
+partners in `PeriodicOverlapHypothesis` must still be derived from equality of the
+assembled MPVs; the proved overlap dichotomy then supplies its repeated-block field.
+The per-block multiplicity-entry power equalities remain to be derived by coefficient
+extraction. The Z-gauge construction itself is fully proved.
 -/
 
 section EqualCase
@@ -513,8 +513,9 @@ per-block `HetRepeatedBlocks` equivalence.
 Convenience reformulation of `fundamentalTheorem_periodic_proportional` that extracts block
 families from `IsIrreducibleForm`.
 
-**Remaining source hypothesis:** The `PeriodicOverlapHypothesis` parameter remains to be
-discharged from the periodic overlap dichotomy (`equal-or-orthogonal-generalized`). -/
+**Remaining source hypothesis:** The two non-decaying-partner fields of
+`PeriodicOverlapHypothesis` must be derived from equality of the assembled MPVs; the
+proved overlap dichotomy supplies its repeated-block field. -/
 theorem fundamentalTheorem_periodic_equalCase_matching
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hA : IsIrreducibleForm A) (hB : IsIrreducibleForm B)
@@ -541,10 +542,12 @@ overlap dichotomy and per-block multiplicity-entry power equality, then:
 
 This composes the proportional theorem `thm:bd` with the Z-gauge construction.
 
-**Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and `hPowEq` hypotheses
-remain to be discharged from the periodic overlap dichotomy and coefficient extraction
-theory. The Z-gauge construction itself (`equalCase_zgauge_of_power_sums`) is fully
-proved. The source theorem allows arbitrary diagonal multiplicity matrices
+**Remaining source hypotheses:** Equality of the assembled MPVs must still provide the
+non-decaying-partner fields of `PeriodicOverlapHypothesis`; its repeated-block field
+comes from the proved overlap dichotomy. The `hPowEq` hypothesis remains to be derived
+by coefficient extraction. The Z-gauge construction itself
+(`equalCase_zgauge_of_power_sums`) is fully proved. The source theorem allows arbitrary
+diagonal multiplicity matrices
 `R_j, S_j`; the present theorem records the scalar multiplicity-entry component,
 not the full multiplicity-space statement. -/
 theorem fundamentalTheorem_periodic_equalCase

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -138,10 +138,9 @@ structure PeriodicOverlapHypothesis
 
 /-- **Build `PeriodicOverlapHypothesis` from `IsPeriodic` data via the overlap dichotomy.**
 
-Given block families with `IsPeriodic` data on each block, the
-`hetRepeatedBlocks_of_nondecaying` field is filled by `periodicOverlapDichotomy`
-for any pair `A j, B k`: the dichotomy returns either overlap decay (contradicting
-non-decay) or `HetRepeatedBlocks (A j) (B k)`.
+For periodic blocks, `periodicOverlapDichotomy` shows that every non-decaying
+cross-family overlap yields `HetRepeatedBlocks`: its decay alternative contradicts
+non-decay, leaving the repeated-block alternative.
 
 The `exists_nondecaying_A/B` fields remain as explicit hypotheses — they encode the
 paper's content that proportional total MPVs force non-vanishing per-block overlaps.

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -61,9 +61,10 @@ theorem periodicOverlapDichotomy
   --                            → `periodicOverlap_tendsto_zero_of_no_sector_match`
   --   * same period/dim, a sector match
   --                            → `periodicOverlap_gaugeEquiv_of_sector_match`
-  -- Each branch theorem is proved; the sector-match branch is proved modulo
-  -- the remaining Case-3 contraction and phase-assembly theorem
-  -- `sectorTensor_proportional_of_blockedMatch`.
+  -- Each branch theorem is proved.  In the sector-match branch,
+  -- `sectorTensor_proportional_of_blockedMatch` supplies the full-cycle contraction
+  -- and phase assembly before `periodicOverlap_gaugeEquiv_of_sector_match` returns
+  -- the repeated-block relation.
   classical
   by_cases hm : m_a = m_b
   · subst hm

--- a/TNLean/MPS/Periodic/Overlap/NoSectorMatch.lean
+++ b/TNLean/MPS/Periodic/Overlap/NoSectorMatch.lean
@@ -53,10 +53,8 @@ the original blocked tensor, and `hCyclic` ensures the block indexing
 follows the cyclic orbit structure of the transfer map's peripheral
 spectrum (see `IsCyclicSectorDecomp`).
 
-The orbit-lift / corner-irreducibility input is now supplied unconditionally by
-`SelfOverlap.primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`. The
-remaining gaps in this file lie further along, in the sector-match and
-mixed-overlap arguments. -/
+The orbit-lift / corner-irreducibility input is supplied unconditionally by
+`SelfOverlap.primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`. -/
 lemma sectorBlocked_isNormal_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A)

--- a/TNLean/MPS/Periodic/Overlap/NoSectorMatch.lean
+++ b/TNLean/MPS/Periodic/Overlap/NoSectorMatch.lean
@@ -268,14 +268,11 @@ private lemma exists_nondecaying_sectorOverlap_of_blockedGaugePhaseEquiv_cyclicD
     (gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
       A B hA hB hGPE_block) hGlobalZero
 
-/-- Compressed-sector uniqueness statement after blocking.
+/-- Existence of a matching pair of compressed sectors after blocking.
 
-Once global gauge-phase equivalence has been transported to the blocked
-tensors, the cyclic sector decompositions of the two blocked tensors should be
-unique up to relabeling of nonzero Wedderburn/cyclic sectors. This statement is
-the precise remaining statement needed for `exists_sector_match_of_gaugePhaseEquiv`:
-it extracts one nonzero compressed sector of `A` and a gauge-phase-equivalent
-compressed sector of `B`. -/
+After transporting global gauge-phase equivalence to the blocked tensors, the
+block-sum overlap gives a non-decaying pair of sectors. Irreducibility then
+forces equal dimensions and gauge-phase equivalence for that pair. -/
 private lemma exists_sector_match_of_blockedGaugePhaseEquiv_cyclicDecomp
     [NeZero D] (A B : MPSTensor d D)
     {m : ℕ} [NeZero m]

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -165,8 +165,8 @@ decomposition are orthogonal corners, so for `u ≠ v` these corner states canno
 be related by an invertible gauge and nonzero scalar.
 
 The cyclic-sector decomposition supplies the trace formula and projection data. The
-missing mathematical input is orthogonal-corner rigidity: distinct cyclic corners
-cannot be related by an invertible gauge and a nonzero scalar. -/
+key mathematical input is orthogonal-corner rigidity: distinct cyclic corners cannot
+be related by an invertible gauge and a nonzero scalar. -/
 private lemma sectorBlocks_not_gaugePhaseEquiv_of_ne
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A)

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -207,7 +207,7 @@
               differ by a unit-modulus phase and an invertible gauge.
     \end{enumerate}
 \end{theorem}
-\begin{proof}\notready
+\begin{proof}\leanok
     \uses{thm:periodic_overlap_zero_ne_period,
         thm:periodic_overlap_zero_no_sector_match,
         thm:periodic_overlap_zero_ne_dim,
@@ -269,14 +269,12 @@
     this restriction and its elimination plan.
 \end{theorem}
 
-\begin{proof}
-    \notready
+\begin{proof}\leanok
     \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
-    The missing point is not the Gram-matrix argument itself. It is the
-    sector-match alternative in
-    Theorem~\ref{thm:periodic_overlap_dichotomy}. In the notation of
-    Appendix~A of \cite{DeLasCuevas2017Irreducible}, after choosing inverses
-    $\Omega_u$ for the injective words $F_u$, the required contraction is
+    The sector-match alternative in
+    Theorem~\ref{thm:periodic_overlap_dichotomy} follows the construction in
+    Appendix~A of \cite{DeLasCuevas2017Irreducible}. After choosing inverses
+    $\Omega_u$ for the injective words $F_u$, one proves
     \begin{align}
         A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots
         \otimes A_{u+m-1}^{i_m}
@@ -314,10 +312,6 @@
         \notag
     \end{align}
     one obtains the global relation $A^i=e^{i\xi}UB^iU^\dagger$.
-    % Remaining step: see
-    % docs/paper-gaps/1708_periodic_overlap_route_alignment.tex,
-    % Section ``Remaining Case-3 input''.
-
     Let
     $G_N(j,k)=\braket{V^{(pN)}(A_j)}{V^{(pN)}(A_k)}$
     be the Gram matrix of the periodic vectors. The diagonal entries have
@@ -402,7 +396,7 @@
 \begin{theorem}[Peripheral proportional case from positive-length MPV equality]
     \label{thm:peripheral_periodic_ft_proportional_same}
     \lean{MPSTensor.peripheralProportionalCase_periodicFT_of_sameMPV₂Pos}
-    \notready
+    \leanok
     \uses{def:periodic_tensor, def:same_mpv2_pos, thm:periodic_overlap_dichotomy,
         thm:periodic_self_overlap_tendsto}
     Let $A$ and $B$ be periodic tensors with the same matrix product vectors
@@ -410,7 +404,7 @@
     Then their bond dimensions agree, and after identifying the bond spaces,
     $A$ and $B$ are repeated blocks.
 \end{theorem}
-\begin{proof}\notready
+\begin{proof}\leanok
     By Theorem~\ref{thm:periodic_overlap_dichotomy}, either the overlap
     $\braket{V^{(N)}(A)}{V^{(N)}(B)}$ tends to $0$ or the bond dimensions agree
     and $A$ and $B$ are repeated blocks. In the decay case,
@@ -440,14 +434,14 @@
 \begin{theorem}[Peripheral proportional case from phase rescaling]
     \label{thm:peripheral_periodic_ft_proportional_rescaling}
     \lean{MPSTensor.peripheralProportionalCase_periodicFT_of_rootFromRescaling}
-    \notready
+    \leanok
     \uses{def:periodic_tensor, thm:peripheral_periodic_ft_proportional_same}
     Assume that whenever two periodic tensors have proportional MPV families,
     one can rescale one tensor by a unit-modulus phase so that the MPV families
     agree at every positive length. Then proportional periodic MPV families already force the
     tensors to be repeated blocks.
 \end{theorem}
-\begin{proof}\notready
+\begin{proof}\leanok
     Apply the phase-rescaling hypothesis to replace $A$ by a periodic tensor
     $A'$ with the same positive-length MPV family as $B$.
     Theorem~\ref{thm:peripheral_periodic_ft_proportional_same}

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -312,10 +312,10 @@
     \begin{align}
         U&=\sum_{u=1}^{m}e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q},
         \notag\\
-        \theta&=\eta/m,
+        \xi&=\eta/m,
         \notag
     \end{align}
-    one obtains the global relation $A^i=e^{i\theta}UB^iU^\dagger$.
+    one obtains the global relation $A^i=e^{i\xi}UB^iU^\dagger$.
     Let
     $G_N(j,k)=\braket{V^{(pN)}(A_j)}{V^{(pN)}(A_k)}$
     be the Gram matrix of the periodic vectors. The diagonal entries have

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -259,11 +259,13 @@
 
     \emph{Scope restriction.}  The source consequence following the
     periodic-overlap dichotomy
-    \cite[lines~589--609]{DeLasCuevas2017Irreducible} also states that
-    the non-zero vectors $\ket{V_N(A_j)}$ span the vector $\ket{V_N(A)}$;
+    \cite[lines~589--609]{DeLasCuevas2017Irreducible} states eventual
+    independence at every sufficiently large length and also states that the
+    non-zero vectors $\ket{V_N(A_j)}$ span the vector $\ket{V_N(A)}$;
     this spanning assertion is what the paper cites as justification for
     the phrase ``basis of periodic vectors''. The theorem recorded here
-    contains only the independence assertion. The corresponding paper-gap
+    proves independence only along the common-multiple subsequence $pN$ and
+    omits the spanning assertion. The corresponding paper-gap
     note, \path{docs/paper-gaps/1708_periodic_overlap_route_alignment.tex},
     Section ``Scope restriction: independence without spanning'', records
     this restriction and its elimination plan.
@@ -280,8 +282,8 @@
         \otimes A_{u+m-1}^{i_m}
         &=
         e^{i\eta_v}
-        B_v^{i_1}\otimes B_{v+1}^{i_2}\otimes\cdots
-        \otimes B_{v+m-1}^{i_m}.
+        \widetilde B_v^{i_1}\otimes \widetilde B_{v+1}^{i_2}\otimes\cdots
+        \otimes \widetilde B_{v+m-1}^{i_m}.
         \notag
     \end{align}
     Applying the same identity after a cyclic translation gives
@@ -289,7 +291,7 @@
     $\ell=0,\ldots,m-1$, so we write the common phase as $e^{i\eta}$.
     The product-tensor identity then gives scalars $\kappa_v$ with
     \begin{align}
-        A_u^i&=\kappa_v e^{i\eta/m}B_v^i,
+        A_u^i&=\kappa_v e^{i\eta/m}\widetilde B_v^i,
         \notag\\
         \prod_{v=1}^{m}\kappa_v&=1.
         \notag
@@ -308,10 +310,10 @@
     \begin{align}
         U&=\sum_{u=1}^{m}e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q},
         \notag\\
-        \xi&=\eta/m,
+        \theta&=\eta/m,
         \notag
     \end{align}
-    one obtains the global relation $A^i=e^{i\xi}UB^iU^\dagger$.
+    one obtains the global relation $A^i=e^{i\theta}UB^iU^\dagger$.
     Let
     $G_N(j,k)=\braket{V^{(pN)}(A_j)}{V^{(pN)}(A_k)}$
     be the Gram matrix of the periodic vectors. The diagonal entries have
@@ -436,10 +438,12 @@
     \lean{MPSTensor.peripheralProportionalCase_periodicFT_of_rootFromRescaling}
     \leanok
     \uses{def:periodic_tensor, thm:peripheral_periodic_ft_proportional_same}
-    Assume that whenever two periodic tensors have proportional MPV families,
-    one can rescale one tensor by a unit-modulus phase so that the MPV families
-    agree at every positive length. Then proportional periodic MPV families already force the
-    tensors to be repeated blocks.
+    Assume a uniform rescaling principle for the prescribed bond dimensions:
+    whenever the first tensor is periodic and has an MPV family proportional to
+    that of an arbitrary second tensor, one can rescale the first tensor by a
+    unit-modulus phase so that the MPV families agree at every positive length.
+    Then proportional MPV families of two periodic tensors force the tensors to
+    be repeated blocks.
 \end{theorem}
 \begin{proof}\leanok
     Apply the phase-rescaling hypothesis to replace $A$ by a periodic tensor

--- a/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft_overlap_sector_match_and_consequences.tex
@@ -260,8 +260,10 @@
     \emph{Scope restriction.}  The source consequence following the
     periodic-overlap dichotomy
     \cite[lines~589--609]{DeLasCuevas2017Irreducible} states eventual
-    independence at every sufficiently large length and also states that the
-    non-zero vectors $\ket{V_N(A_j)}$ span the vector $\ket{V_N(A)}$;
+    independence at every sufficiently large length and also states that, for
+    an ambient tensor $A$ in irreducible form having $\{A_j\}_{j\in J}$ as
+    its basis of periodic tensors, the non-zero vectors $\ket{V_N(A_j)}$
+    span the vector $\ket{V_N(A)}$;
     this spanning assertion is what the paper cites as justification for
     the phrase ``basis of periodic vectors''. The theorem recorded here
     proves independence only along the common-multiple subsequence $pN$ and


### PR DESCRIPTION
This PR synchronizes the periodic Fundamental Theorem documentation and Chapter 22 blueprint with the completed overlap dichotomy. It removes obsolete caveats about the sector-match contraction, marks the established consequences as checked, and states the remaining proportional-MPV and coefficient-extraction hypotheses precisely.

The scope restriction on eventual independence remains explicit: the current result treats the common-multiple subsequence and does not assert the source paper’s spanning statement.

Updates #81.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint status updates only; no executable Lean or runtime behavior changes.
> 
> **Overview**
> Documentation-only PR: it **reframes** periodic FT and overlap-route commentary now that `periodicOverlapDichotomy` and the sector-match **Ω/F contraction** (`sectorTensor_proportional_of_blockedMatch`) are treated as proved, without changing Lean proofs.
> 
> **Lean module docs** (`CornerContraction`, `CornerTransition`, `FundamentalTheorem`, `Dichotomy`, `NoSectorMatch`, `SelfOverlap`) drop “remaining Case-3 / admitted obligation” language and instead point to `SectorMatch` / `Dichotomy` and downstream assembly. **`FundamentalTheorem.lean`** now states that dichotomy-filled routes are unconditional for the repeated-block field, while **non-decaying cross-family partners**, **phase rescaling** (`PeripheralProportionalCaseRootFromRescaling`), and **coefficient-extraction / `hPowEq`** remain explicit gaps.
> 
> **Blueprint Ch.22** flips several items from `\notready` to `\leanok` (dichotomy, eventual LI, peripheral proportional theorems and proofs), tightens the sector-match proof narrative (gauge-absorbed `\widetilde B`, removes “remaining step” gap callouts), clarifies the **independence-only / $pN$ subsequence** scope vs. the paper’s spanning claim, and sharpens the phase-rescaling theorem hypothesis wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf9a6b40be4b2b10d662f4216fae422d886ea0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->