### PR TITLE
feat(MPS/MPDO): derive conditional RFP from reflected targets

### DIFF
--- a/TNLean/MPS/MPDO.lean
+++ b/TNLean/MPS/MPDO.lean
@@ -20,6 +20,7 @@ import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorCoordinates
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseAmbientSectorMaps
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalGram
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalPhysicalMaps
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalRFP
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalUnitary
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseCorner
 import TNLean.MPS.MPDO.BNTAlgebraTensorClauseDirectSumUnitary

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalRFP.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalRFP.lean
@@ -56,13 +56,14 @@ noncomputable def UnitarySectorConjugacy.ofPositiveTailReflectedTarget
     (hM : IsMPDO M)
     (hTarget : ∀ γ : Fin H.labelCount,
       HasIdentityPositiveTailReflectedTarget S γ) :
-    UnitarySectorConjugacy S where
-  unitary γ := Classical.choose
-    (S.exists_unitary_sector_conjugacy_of_positive_tail_reflected_target
-      hCanonical hM γ (hTarget γ))
-  tensor_eq γ i := Classical.choose_spec
-    (S.exists_unitary_sector_conjugacy_of_positive_tail_reflected_target
-      hCanonical hM γ (hTarget γ)) i
+    UnitarySectorConjugacy S := by
+  let hUnitary (γ : Fin H.labelCount) :=
+    S.exists_unitary_sector_conjugacy_of_positive_tail_reflected_target
+      hCanonical hM γ (hTarget γ)
+  exact {
+    unitary := fun γ ↦ Classical.choose (hUnitary γ)
+    tensor_eq := fun γ i ↦ Classical.choose_spec (hUnitary γ) i
+  }
 
 /-- Positive-tail reflected-target identities for every sector give the
 trace-preserving completely positive maps and the two renormalization

--- a/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalRFP.lean
+++ b/TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalRFP.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalPhysicalMaps
+import TNLean.MPS.MPDO.BNTAlgebraTensorClauseConditionalUnitary
+
+/-!
+# Conditional RFP maps from positive-tail reflected targets
+
+For every paired one-site and two-site BNT sector, a common positive-tail
+reflected target gives a unitary conjugacy.  Selecting these unitaries
+simultaneously and applying the physical trace-preserving completely positive
+maps gives the renormalization identities of Definition 4.1.
+
+The positive-tail reflected targets remain assumptions.  Their derivation from
+the tensor-attached algebra product law, literal CPSV canonical form, and MPDO
+positivity is the remaining step in the implication (ii) to (i) of Theorem
+4.14.
+
+## Main results
+
+* `UnitarySectorConjugacy.ofPositiveTailReflectedTarget`
+* `isRFPViaTS_of_positive_tail_reflected_target`
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Appendix C.4, lines 2048--2085
+-/
+
+noncomputable section
+
+namespace MPOTensor
+
+namespace BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+variable {d D : ℕ} {M : MPOTensor d D} {H : BNTAlgebraTensorClause M}
+
+/-- Positive-tail reflected-target identities for all sectors determine
+simultaneous unitary conjugacies between the paired one-site and two-site BNT
+tensors.
+
+**Scope restriction (conditional reflected targets):** The reflected-target
+identities are assumed rather than derived from the tensor-attached algebra
+product law.  This is the comparison omitted from the Appendix C.4 invocation
+of Proposition 4.13; see
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+Source comparison: arXiv:1606.00608, Proposition 4.13, lines 1903--1908,
+applied at Appendix C.4, lines 2048--2057. -/
+noncomputable def UnitarySectorConjugacy.ofPositiveTailReflectedTarget
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M)
+    (hTarget : ∀ γ : Fin H.labelCount,
+      HasIdentityPositiveTailReflectedTarget S γ) :
+    UnitarySectorConjugacy S where
+  unitary γ := Classical.choose
+    (S.exists_unitary_sector_conjugacy_of_positive_tail_reflected_target
+      hCanonical hM γ (hTarget γ))
+  tensor_eq γ i := Classical.choose_spec
+    (S.exists_unitary_sector_conjugacy_of_positive_tail_reflected_target
+      hCanonical hM γ (hTarget γ)) i
+
+/-- Positive-tail reflected-target identities for every sector give the
+trace-preserving completely positive maps and the two renormalization
+identities of Definition 4.1.
+
+**Scope restriction (conditional reflected targets):** The reflected-target
+identities are assumed rather than derived from the tensor-attached algebra
+product law.  Thus this theorem does not prove the unconditional implication
+(ii) to (i) of Theorem 4.14.  See
+`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`.
+
+**Local fix (zero-sector complement):** The physical channels used here have
+the trace-restoring completion on discarded zero-sector complements documented
+in `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`.  The additional
+terms vanish on the one-site and blocked two-site tensor images.
+
+Source comparison: arXiv:1606.00608, Definition 4.1, lines 638--660, and
+Appendix C.4, lines 2048--2085. -/
+theorem isRFPViaTS_of_positive_tail_reflected_target
+    (S : TwoSiteExactSectorGauge H)
+    (hCanonical : MPSTensor.IsCPSVCanonicalForm M.toMPSTensor)
+    (hM : IsMPDO M)
+    (hTarget : ∀ γ : Fin H.labelCount,
+      HasIdentityPositiveTailReflectedTarget S γ) :
+    IsRFPViaTS M :=
+  (UnitarySectorConjugacy.ofPositiveTailReflectedTarget
+    S hCanonical hM hTarget).isRFPViaTS
+
+end BNTAlgebraTensorClause.TwoSiteExactSectorGauge
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
@@ -245,3 +245,57 @@
     the one-site and two-site letters.  Linearity in the virtual matrix gives
     (\ref{eq:mpdo_bnt_completed_physical_map_actions}).
 \end{proof}
+
+\begin{theorem}[Renormalization fixed point from positive-tail reflected
+    sector targets]
+    \label{thm:mpdo_bnt_conditional_rfp_from_reflected_targets}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        isRFPViaTS_of_positive_tail_reflected_target}
+    \lean{MPOTensor.BNTAlgebraTensorClause.TwoSiteExactSectorGauge.%
+        UnitarySectorConjugacy.ofPositiveTailReflectedTarget}
+    \leanok
+    \uses{def:mpdo, def:cpsv_canonical_form,
+        def:mpdo_bnt_two_site_exact_sector_gauge,
+        def:is_rfp_via_ts}
+    Let the one-site and blocked two-site BNT decompositions have the
+    source-derived exact sector pairing, including the matched multiplicity
+    spectrum, and suppose that $M$ generates matrix product density operators
+    and that its doubled-index tensor is in literal CPSV canonical form.
+    Assume, for every sector $\gamma$, every positive tail length, every pair
+    of open bond indices, and every pair of two-site tail words, that the
+    identity-dressed marked-chain coefficient equals the corresponding
+    reflected-adjoint marked-chain coefficient of $M_\gamma$ in the adjoint
+    two-site blocking, with both tail words reversed on the reflected-adjoint
+    side. This is the additional comparison needed to reproduce the Figure~8
+    argument in
+    \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv} at its
+    invocation in Appendix~C.4, line~2057. Then there are trace-preserving
+    completely positive maps
+    $\mathcal T$ and $\mathcal S$ satisfying
+    \begin{align}
+        \mathcal T[M_1(X)]&=M_2(X),
+        &
+        \mathcal S[M_2(X)]&=M_1(X)
+        \label{eq:mpdo_bnt_reflected_target_rfp}
+    \end{align}
+    for every virtual matrix $X$. Hence $M$ is a renormalization fixed point
+    in the sense of Definition~\ref{def:is_rfp_via_ts}.
+    % Scope restriction (conditional reflected targets): the common target is
+    % assumed in every sector, so this does not prove the unconditional
+    % implication (ii) \Rightarrow (i) of Theorem 4.14. See
+    % docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_bnt_conditional_identity_marked_unitary_conjugacy,
+        thm:mpdo_bnt_conditional_physical_channels}
+    For each sector,
+    Theorem~\ref{thm:mpdo_bnt_conditional_identity_marked_unitary_conjugacy}
+    supplies a unitary $U_\gamma$ satisfying
+    (\ref{eq:mpdo_bnt_conditional_unitary_conjugacy}), which is precisely
+    (\ref{eq:mpdo_bnt_physical_channel_unitary_conjugacy}). Choose these
+    unitaries simultaneously over the finite set of sectors.
+    Theorem~\ref{thm:mpdo_bnt_conditional_physical_channels} then gives
+    $\mathcal T$ and $\mathcal S$ together with
+    (\ref{eq:mpdo_bnt_reflected_target_rfp}).
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_conditional_physical_channels.tex
@@ -270,16 +270,11 @@
     argument in
     \cite[Proposition~4.13, lines~1903--1921]{Cirac2016MPDO_arXiv} at its
     invocation in Appendix~C.4, line~2057. Then there are trace-preserving
-    completely positive maps
-    $\mathcal T$ and $\mathcal S$ satisfying
-    \begin{align}
-        \mathcal T[M_1(X)]&=M_2(X),
-        &
-        \mathcal S[M_2(X)]&=M_1(X)
-        \label{eq:mpdo_bnt_reflected_target_rfp}
-    \end{align}
-    for every virtual matrix $X$. Hence $M$ is a renormalization fixed point
-    in the sense of Definition~\ref{def:is_rfp_via_ts}.
+    completely positive maps $\mathcal T$ and $\mathcal S$ satisfying the
+    identities in
+    (\ref{eq:mpdo_bnt_completed_physical_map_actions}) for every virtual
+    matrix $X$. Hence $M$ is a renormalization fixed point in the sense of
+    Definition~\ref{def:is_rfp_via_ts}.
     % Scope restriction (conditional reflected targets): the common target is
     % assumed in every sector, so this does not prove the unconditional
     % implication (ii) \Rightarrow (i) of Theorem 4.14. See
@@ -297,5 +292,5 @@
     unitaries simultaneously over the finite set of sectors.
     Theorem~\ref{thm:mpdo_bnt_conditional_physical_channels} then gives
     $\mathcal T$ and $\mathcal S$ together with
-    (\ref{eq:mpdo_bnt_reflected_target_rfp}).
+    (\ref{eq:mpdo_bnt_completed_physical_map_actions}).
 \end{proof}

--- a/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
+++ b/docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex
@@ -54,6 +54,23 @@ line~2057 conclusion is available conditionally on the positive-tail
 reflected target alone.
 % The conditional Gram and unitary results are pull requests 5282 and 5286.
 
+If this target holds for every sector, the corresponding unitaries may be
+chosen simultaneously.  The direct-sum conjugations, vertical retractions,
+and normalized restorations give the two composites written in
+Appendix~C.4, lines~2065--2085, on the retained physical sectors.  The source
+does not prescribe their values on the discarded complements.  The
+formalization uses the trace-restoring completion documented in
+\path{docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex} to obtain the
+two channels of Definition~4.1 on the full physical matrix algebras.  The
+additional terms vanish on $M_1(X)$ and $M_2(X)$, so they do not alter the
+retained-sector identities.
+Consequently, beyond the tensor-attached algebra clause, literal CPSV
+canonical form, MPDO positivity, and the source-derived sector pairing with
+matched multiplicity spectra, the all-sector positive-tail target is the sole
+additional unproved comparison needed for the renormalization-fixed-point
+conclusion.  No unitary conjugacy, fusion isometry, or renormalization fixed
+point is assumed.
+
 The physical-letter part of this realization is now unconditional.  The
 gauge-dressed two-site corner provides $V_\gamma$ and $c_\gamma>0$ such that
 \begin{equation}
@@ -763,9 +780,20 @@ unconditional line~2057 unitary conclusion remains unformalized.
 
 \section{Verdict}
 
-\textbf{Scope restriction: the identity-dressed physical-letter span is
-complete, while the common positive-tail target remains open.}  The oblique
-maps \eqref{eq:oblique-maps} give the coefficients
+\textbf{Scope restriction: the renormalization-fixed-point conclusion is
+complete conditional on the common positive-tail targets, while those targets
+remain open.}  Once the targets are supplied in every sector, the conditional
+Gram theorem, unitary normalization, and physical channel construction give
+completely positive, trace-preserving maps satisfying
+\(
+  \mathcal T[M_1(X)]=M_2(X)
+\)
+and
+\(
+  \mathcal S[M_2(X)]=M_1(X)
+\)
+for every virtual matrix $X$.  The oblique maps
+\eqref{eq:oblique-maps} give the coefficients
 \eqref{eq:oblique-physical-coefficients} without a scalar Gram hypothesis or a
 unitary gauge.  Since $L_\gamma$ and $R_\gamma$ need not agree, this result is
 not a positive corner.  Its adjoint-reflected orientation is governed by the


### PR DESCRIPTION
## Summary

- choose the sectorwise unitary conjugacies simultaneously from the positive-tail reflected-target hypotheses;
- apply the previously constructed trace-preserving completely positive maps to obtain `IsRFPViaTS M`;
- add the matching Blueprint theorem and update the CPSV16 paper-gap verdict.

## Mathematical scope

The new theorem is conditional on
`∀ γ, HasIdentityPositiveTailReflectedTarget S γ`.
This comparison is the missing input needed to reproduce the invocation of CPSV16 Proposition 4.13 in Appendix C.4, line 2057. Consequently, the pull request does not claim the unconditional implication (ii) ⇒ (i) of Theorem 4.14.

The maps use the trace-restoring completion on discarded zero-sector complements documented in `docs/paper-gaps/cpgsv17_vertical_isometry_zero_sector.tex`. Those terms vanish on the one-site and blocked two-site tensor images, so the exact renormalization identities are unchanged.

Source comparison: arXiv:1606.00608, Proposition 4.13 and Appendix C.4, lines 2048–2085.

## Verification

- `lake env lean -DwarningAsError=true TNLean/MPS/MPDO/BNTAlgebraTensorClauseConditionalRFP.lean`
- cached `lake build`
- generated-import check
- reader-facing prose check
- Lean declaration–Blueprint synchronization
- `leanblueprint checkdecls`
- kernel-axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- Blueprint and paper-gap PDF rendering with visual inspection

Closes #5336.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formalization and documentation with explicit conditional scope; no runtime, auth, or data-path impact.
> 
> **Overview**
> Adds **`BNTAlgebraTensorClauseConditionalRFP.lean`**, which assumes **all-sector** `HasIdentityPositiveTailReflectedTarget` hypotheses and builds a simultaneous `UnitarySectorConjugacy` via `Classical.choose`, then derives **`IsRFPViaTS M`** by composing with the existing `UnitarySectorConjugacy.isRFPViaTS` physical-channel construction. The MPDO aggregator import list is updated accordingly.
> 
> The Blueprint chapter gains **Theorem** `thm:mpdo_bnt_conditional_rfp_from_reflected_targets`, wired to those Lean declarations and proved by chaining the conditional unitary conjugacy and physical-channel theorems. **`docs/paper-gaps/cpsv16_two_site_sector_unitary_gauge_gap.tex`** is revised to state that the renormalization-fixed-point conclusion is **complete conditional on** the positive-tail targets (with trace-restoring zero-sector completion), while the targets themselves and the unconditional (ii)⇒(i) implication of Theorem 4.14 remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31bc7d3f32682245319dc44118676ef789e5951. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->