### PR TITLE
fix(tenkz): reject diagonal circle opens

### DIFF
--- a/docs/tenkz/LANGUAGE-1.0.md
+++ b/docs/tenkz/LANGUAGE-1.0.md
@@ -286,7 +286,10 @@ the coded error `[TKZ-ADDR-CYCLE]`, printed with the cycle.
 Open legs are policy, not objects. An unbonded typed port renders as a stub
 in the direction of its face; a wire endpoint may be `open`, with a direction
 when the end is to sit on the picture margin and without one when it takes
-its place from the route (§5). There are no placeholder atoms.
+its place from the route (§5). Circle frames accept only the station-based
+cardinal directions `n`, `e`, `s`, and `w`; diagonal circle opens are rejected
+with `[TKZ-CIRCLE-OPEN-DIRECTION]` until a station-local or geodesic diagonal
+construction is part of the language. There are no placeholder atoms.
 <!-- Consumers of the open-end policy: every former tenkzfree body; e.g.
      rmp-ii-triangle-network, rmp-ii-mpo-sheet, rmp-iii-b-braid-one. -->
 

--- a/scripts/tenkz_kernel_probes.sh
+++ b/scripts/tenkz_kernel_probes.sh
@@ -928,6 +928,35 @@ grep -Fq '[TKZ-FRAME-WORD]' "$WORK/n_frame_word.transcript" || {
   exit 1
 }
 
+for circle_open_case in ne:from se:to sw:from nw:to; do
+  direction=${circle_open_case%%:*}
+  endpoint=${circle_open_case#*:}
+  circle_open_negative="$KERNEL/negative/n_circle_open_$direction.tex"
+  if ( cd "$WORK" &&
+       TEXINPUTS="$REPO/tex/tenkz//:" \
+         timeout 120 xelatex -interaction=nonstopmode -halt-on-error \
+         "$circle_open_negative" \
+         >"$WORK/n_circle_open_$direction.transcript" 2>&1 ); then
+    echo "FAIL: circle frame accepted diagonal open $direction" >&2
+    exit 1
+  fi
+  grep -Fq '[TKZ-CIRCLE-OPEN-DIRECTION]' \
+    "$WORK/n_circle_open_$direction.transcript" || {
+    echo "FAIL: diagonal circle open $direction lacked its coded diagnostic" >&2
+    exit 1
+  }
+  grep -Fq "direction '$direction'" \
+    "$WORK/n_circle_open_$direction.transcript" || {
+    echo "FAIL: diagonal circle diagnostic lost bearing $direction" >&2
+    exit 1
+  }
+  grep -Fq "at the $endpoint end" \
+    "$WORK/n_circle_open_$direction.transcript" || {
+    echo "FAIL: diagonal circle diagnostic lost endpoint $endpoint" >&2
+    exit 1
+  }
+done
+
 for basis_case in \
   n_frame_basis_parse n_frame_basis_semicolon n_frame_basis_kind \
   n_frame_basis_member \

--- a/tests/tenkz/kernel/negative/n_circle_open_ne.tex
+++ b/tests/tenkz/kernel/negative/n_circle_open_ne.tex
@@ -1,0 +1,9 @@
+%% Negative regression: circle frames do not define diagonal open ends.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, frame=circle, bonds=none]
+  \tnwire{open ne}{(1,1)}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_circle_open_nw.tex
+++ b/tests/tenkz/kernel/negative/n_circle_open_nw.tex
@@ -1,0 +1,9 @@
+%% Negative regression: circle frames do not define diagonal open ends.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, frame=circle, bonds=none]
+  \tnwire{(1,1)}{open nw}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_circle_open_se.tex
+++ b/tests/tenkz/kernel/negative/n_circle_open_se.tex
@@ -1,0 +1,9 @@
+%% Negative regression: circle frames do not define diagonal open ends.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, frame=circle, bonds=none]
+  \tnwire{(1,1)}{open se}
+\end{tenkz}
+\end{document}

--- a/tests/tenkz/kernel/negative/n_circle_open_sw.tex
+++ b/tests/tenkz/kernel/negative/n_circle_open_sw.tex
@@ -1,0 +1,9 @@
+%% Negative regression: circle frames do not define diagonal open ends.
+\documentclass{standalone}
+\usepackage{tenkz}
+\begin{document}
+\tenkzkernel
+\begin{tenkz}[rows={wire}, cols=2, frame=circle, bonds=none]
+  \tnwire{open sw}{(1,1)}
+\end{tenkz}
+\end{document}

--- a/tex/tenkz/tenkz-kernel.code.tex
+++ b/tex/tenkz/tenkz-kernel.code.tex
@@ -91,6 +91,9 @@
     not~a~picture~(record~picture). }
 \msg_new:nnn {tenkz}{kernel-frame-word}
   { [TKZ-FRAME-WORD]~frame~word~'#1'~is~not~flat|plane|circle. }
+\msg_new:nnn {tenkz}{kernel-circle-open-direction}
+  { [TKZ-CIRCLE-OPEN-DIRECTION]~circle~frame~does~not~define~diagonal~open~
+    direction~'#3'~at~the~#2~end~of~wire~'#1';~use~n|e|s|w. }
 \msg_new:nnn {tenkz}{kernel-frame-basis-parse}
   { [TKZ-FRAME-BASIS-PARSE]~basis~member~'#1'~must~be~
     '<row~kind>~at~(<integer>,<integer>)'. }
@@ -2054,6 +2057,33 @@
                       \l__tenkz_kernel_list_item_tl
                     \exp_args:NnnnV \__tenkz_model_normalize_field:nnnn
                       {##1} {target} {node} \l__tenkz_kernel_list_item_tl
+                  }
+              }
+          }
+      }
+  }
+
+\cs_new_protected:Npn \__tenkz_kernel_validate_circle_open_ends:
+  {
+    \str_if_eq:eeT { \__tenkz_kernel_r_frame_word: } {circle}
+      {
+        \__tenkz_model_map_ids:nn {wire}
+          {
+            \clist_map_inline:nn {from, to}
+              {
+                \__tenkz_model_get:nnN {##1} {####1-open}
+                  \l__tenkz_kernel_scratch_tl
+                \quark_if_no_value:NF \l__tenkz_kernel_scratch_tl
+                  {
+                    \exp_args:NnV \regex_match:nnT
+                      { \A (nw|ne|sw|se) \Z }
+                      \l__tenkz_kernel_scratch_tl
+                      {
+                        \msg_error:nneee
+                          {tenkz}{kernel-circle-open-direction}
+                          {##1} {####1}
+                          { \tl_use:N \l__tenkz_kernel_scratch_tl }
+                      }
                   }
               }
           }
@@ -13723,6 +13753,7 @@
     \__tenkz_kernel_bonds:
     \__tenkz_kernel_closures:
     \__tenkz_kernel_port_opens:
+    \__tenkz_kernel_validate_circle_open_ends:
     \__tenkz_kernel_validate_addresses:
     \__tenkz_kernel_plane_model:
     % Boundary topology and signatures use the same resolved carrier geometry


### PR DESCRIPTION
Closes LionSR/tenkz#117.

## What changes

- Reject diagonal `open ne`, `open se`, `open sw`, and `open nw` endpoints when the effective picture frame is `circle`.
- Emit `[TKZ-CIRCLE-OPEN-DIRECTION]` before plane modeling, rendering, or equation-audit acceptance.
- Add four negative fixtures covering every diagonal bearing across both `from` and `to` endpoints.
- Document that circle open ends currently use only the established station-based cardinal directions; no diagonal curved geometry is invented.

## Root cause

The endpoint grammar accepted all eight compass bearings, while the circle-frame endpoint resolver defined only `n`, `e`, `s`, and `w`. A diagonal circle endpoint could therefore reach rendering without a resolved tip.

## Validation

- `scripts/tenkz_kernel_probes.sh`: 93 review regressions, 9 sugar expansions, 12 kernel record streams, and kernel pixel hashes pass unchanged.
- Focused XeLaTeX negatives mechanically assert the coded diagnostic, bearing, and endpoint for all four diagonals.
- `python3 scripts/tenkz_language.py check`
- `python3 scripts/test_tenkz_language.py`
- `bash -n scripts/tenkz_kernel_probes.sh`
- `git diff --check`

No Lake command was run; this change is confined to the tenkz language, probes, fixtures, and documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation-only change with early hard errors and negative regressions; no change to resolved geometry for valid cardinal circle opens.
> 
> **Overview**
> Fixes a gap where the open-end grammar allowed eight compass bearings but circle frames only resolve station cardinals **`n`**, **`e`**, **`s`**, and **`w`**, so diagonal opens could reach rendering without a defined tip.
> 
> The kernel adds **`__tenkz_kernel_validate_circle_open_ends:`**, wired into picture finalization **before** address validation, plane modeling, and rendering. On **`frame=circle`**, any wire **`from-open`** / **`to-open`** matching **`nw|ne|sw|se`** triggers **`[TKZ-CIRCLE-OPEN-DIRECTION]`** (wire id, endpoint, bearing; message points authors to cardinals).
> 
> **`LANGUAGE-1.0.md`** documents that policy. **`scripts/tenkz_kernel_probes.sh`** loops four negative fixtures (`ne`/`se`/`sw`/`nw`, both wire ends) and asserts compile failure plus diagnostic text for code, direction, and **`from`** vs **`to`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 853d66315352226e5eaa125b812bf63167793b26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->