### PR TITLE
feat(Channel/FixedPoint): formalize arbitrary fixed-point decomposition

### DIFF
--- a/TNLean/Channel/FixedPoint/Cesaro.lean
+++ b/TNLean/Channel/FixedPoint/Cesaro.lean
@@ -3,14 +3,16 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Basic
+import TNLean.Channel.Schwarz.PositiveMapProperties
 
 /-!
 # Fixed point existence via Cesàro means
 
 This file proves that every quantum channel (CPTP map) on `M_D(ℂ)` has a nonzero
-PSD fixed point, using the Cesàro mean / Markov-Kakutani argument. It also states
-the decomposition of Hermitian fixed points (Wolf Proposition 6.8).
+PSD fixed point, using the Cesàro mean / Markov-Kakutani argument. It also proves
+the positive fixed-point decomposition of Wolf Proposition 6.8.
 
 The decomposition theorem uses only positivity and trace preservation. The fixed-point
 existence theorem is stated for channels.
@@ -20,9 +22,12 @@ existence theorem is stated for channels.
 * `cesaroMean`: the Cesàro mean of iterates of a linear map
 * `cesaroMean_telescope`: telescoping identity for Cesàro means
 * `IsChannel.exists_posSemidef_fixedPoint`: existence of PSD fixed point
-* `IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint`: Wolf Proposition 6.8
-  for positive trace-preserving maps, stated for the canonical positive and negative
-  parts.
+* `IsPositiveMap.posPart_negPart_fixed_of_fixedPoint`: Wolf Proposition 6.8 for
+  positive trace-preserving maps, using the four canonical positive parts.
+* `IsPositiveMap.exists_posSemidef_fixedPoints_decomposition`: existential form of
+  the preceding theorem.
+* `IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint`: the Hermitian
+  intermediate result.
 * `IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint`: existential compatibility
   form of the preceding theorem.
 * `IsChannel.posSemidef_parts_of_hermitian_fixedPoint`: the channel specialization.
@@ -197,6 +202,69 @@ theorem IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint
   have hEQ₁ : E Q₁ = Q₁ := by rw [hEQ₁_eq, hY_zero, add_zero]
   have hEQ₂ : E Q₂ = Q₂ := by rw [hEQ₂_eq, hY_zero, add_zero]
   simpa [hQ₁_def, hQ₂_def] using And.intro hEQ₁ hEQ₂
+
+/-- **Wolf Proposition 6.8.** If `E` is positive and trace-preserving, then the
+four canonical positive parts obtained from the Hermitian and skew-Hermitian
+components of any fixed point are also fixed points.
+
+Source: Wolf, *Quantum Channels & Operations*, Proposition 6.8; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1161--1191. -/
+theorem IsPositiveMap.posPart_negPart_fixed_of_fixedPoint
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX_fix : E X = X) :
+    E (X + Xᴴ)⁺ = (X + Xᴴ)⁺ ∧
+      E (X + Xᴴ)⁻ = (X + Xᴴ)⁻ ∧
+      E (Complex.I • (X - Xᴴ))⁺ = (Complex.I • (X - Xᴴ))⁺ ∧
+      E (Complex.I • (X - Xᴴ))⁻ = (Complex.I • (X - Xᴴ))⁻ := by
+  obtain ⟨H₁, H₂, hH₁def, hH₂def, hH₁herm, hH₂herm, _hXdecomp⟩ :=
+    Matrix.exists_isHermitian_decomposition X
+  have hXstar : E Xᴴ = Xᴴ := by
+    rw [hE.map_conjTranspose, hX_fix]
+  have hH₁fix : E H₁ = H₁ := by
+    rw [hH₁def, E.map_add, hX_fix, hXstar]
+  have hH₂fix : E H₂ = H₂ := by
+    rw [hH₂def, E.map_smul, E.map_sub, hX_fix, hXstar]
+  obtain ⟨hH₁pos, hH₁neg⟩ :=
+    IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint
+      E hE hTP hH₁herm hH₁fix
+  obtain ⟨hH₂pos, hH₂neg⟩ :=
+    IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint
+      E hE hTP hH₂herm hH₂fix
+  simpa only [hH₁def, hH₂def] using
+    And.intro hH₁pos (And.intro hH₁neg (And.intro hH₂pos hH₂neg))
+
+/-- Existential form of Wolf Proposition 6.8: every fixed point of a positive,
+trace-preserving map is a fixed complex linear combination of four positive
+semidefinite fixed points.
+
+Source: Wolf, *Quantum Channels & Operations*, Proposition 6.8; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1161--1191. -/
+theorem IsPositiveMap.exists_posSemidef_fixedPoints_decomposition
+    (hE : IsPositiveMap E) (hTP : IsTracePreservingMap E)
+    {X : Matrix (Fin D) (Fin D) ℂ} (hX_fix : E X = X) :
+    ∃ P₁ P₂ P₃ P₄ : Matrix (Fin D) (Fin D) ℂ,
+      P₁.PosSemidef ∧ P₂.PosSemidef ∧ P₃.PosSemidef ∧ P₄.PosSemidef ∧
+      E P₁ = P₁ ∧ E P₂ = P₂ ∧ E P₃ = P₃ ∧ E P₄ = P₄ ∧
+      X = (2⁻¹ : ℂ) • (P₁ - P₂) - ((2⁻¹ : ℂ) * Complex.I) • (P₃ - P₄) := by
+  obtain ⟨H₁, H₂, hH₁def, hH₂def, hH₁herm, hH₂herm, hXdecomp⟩ :=
+    Matrix.exists_isHermitian_decomposition X
+  have hH₁decomp : H₁ = H₁⁺ - H₁⁻ :=
+    (CFC.posPart_sub_negPart H₁ (isSelfAdjoint_iff.mpr hH₁herm)).symm
+  have hH₂decomp : H₂ = H₂⁺ - H₂⁻ :=
+    (CFC.posPart_sub_negPart H₂ (isSelfAdjoint_iff.mpr hH₂herm)).symm
+  obtain ⟨hP₁fix, hP₂fix, hP₃fix, hP₄fix⟩ :=
+    IsPositiveMap.posPart_negPart_fixed_of_fixedPoint E hE hTP hX_fix
+  have hH₁posfix : E H₁⁺ = H₁⁺ := by simpa only [hH₁def] using hP₁fix
+  have hH₁negfix : E H₁⁻ = H₁⁻ := by simpa only [hH₁def] using hP₂fix
+  have hH₂posfix : E H₂⁺ = H₂⁺ := by simpa only [hH₂def] using hP₃fix
+  have hH₂negfix : E H₂⁻ = H₂⁻ := by simpa only [hH₂def] using hP₄fix
+  rw [hH₁decomp, hH₂decomp] at hXdecomp
+  exact ⟨H₁⁺, H₁⁻, H₂⁺, H₂⁻,
+    Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H₁),
+    Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H₁),
+    Matrix.nonneg_iff_posSemidef.mp (CFC.posPart_nonneg H₂),
+    Matrix.nonneg_iff_posSemidef.mp (CFC.negPart_nonneg H₂),
+    hH₁posfix, hH₁negfix, hH₂posfix, hH₂negfix, hXdecomp⟩
 
 /-- Existential compatibility form of Wolf Proposition 6.8. The witnesses are the
 canonical positive and negative parts of the Hermitian fixed point. -/

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -267,13 +267,16 @@ In `TNLean.Channel.FixedPoint.Algebra`:
 
 ### Wolf Proposition 6.8 (Positive fixed-points)
 
-* `IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint` — the source-faithful
-  positive trace-preserving statement for the canonical positive and negative parts in
+* `IsPositiveMap.posPart_negPart_fixed_of_fixedPoint` — the source-faithful positive
+  trace-preserving statement for the four canonical positive parts in
   `TNLean.Channel.FixedPoint.Cesaro`.
-* `IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint` — the existential
-  compatibility form.
+* `IsPositiveMap.exists_posSemidef_fixedPoints_decomposition` — the existential form.
+* `IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint` and
+  `IsPositiveMap.posSemidef_parts_of_hermitian_fixedPoint` — Hermitian intermediate
+  forms.
 * `IsChannel.posSemidef_parts_of_hermitian_fixedPoint` — the channel specialization.
-* Numbered theorem: `IsChannel.wolf_prop_6_8` — `TNLean.Channel.WolfChapter6Wrappers`
+* Numbered theorem: `IsPositiveMap.wolf_prop_6_8` —
+  `TNLean.Channel.WolfChapter6Wrappers`.
 
 ### Wolf Corollary 6.6 (projected support corner) — FORMALIZED (Kraus case)
 

--- a/TNLean/Channel/WolfChapter6Wrappers.lean
+++ b/TNLean/Channel/WolfChapter6Wrappers.lean
@@ -13,7 +13,7 @@ This module provides stable theorem names that mirror Wolf's numbering for
 results already formalized elsewhere:
 
 * Proposition 6.6 (`isIrreducibleMap_full_similarity`)
-* Proposition 6.8 (`IsChannel.posSemidef_parts_of_hermitian_fixedPoint`)
+* Proposition 6.8 (`IsPositiveMap.wolf_prop_6_8`)
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
@@ -36,21 +36,23 @@ theorem wolf_prop_6_6
 
 end Kraus
 
-namespace IsChannel
+namespace IsPositiveMap
 
 variable {d : ℕ}
 
-/-- Wolf Proposition 6.8: Hermitian fixed points decompose into
-positive-semidefinite fixed points. -/
+/-- Wolf Proposition 6.8: every fixed point is a fixed complex linear combination
+of four positive-semidefinite fixed points. -/
 theorem wolf_prop_6_8
-    [NeZero d]
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
-    (hT : IsChannel T)
+    (hT : IsPositiveMap T)
+    (hTP : IsTracePreservingMap T)
     {X : Matrix (Fin d) (Fin d) ℂ}
-    (hXh : X.IsHermitian)
     (hXfix : T X = X) :
-    ∃ A B : Matrix (Fin d) (Fin d) ℂ,
-      A.PosSemidef ∧ B.PosSemidef ∧ X = A - B ∧ T A = A ∧ T B = B :=
-  IsChannel.posSemidef_parts_of_hermitian_fixedPoint T hT hXh hXfix
+    ∃ P₁ P₂ P₃ P₄ : Matrix (Fin d) (Fin d) ℂ,
+      P₁.PosSemidef ∧ P₂.PosSemidef ∧ P₃.PosSemidef ∧ P₄.PosSemidef ∧
+      T P₁ = P₁ ∧ T P₂ = P₂ ∧ T P₃ = P₃ ∧ T P₄ = P₄ ∧
+      X = (2⁻¹ : ℂ) • (P₁ - P₂) - ((2⁻¹ : ℂ) * Complex.I) • (P₃ - P₄) :=
+  IsPositiveMap.exists_posSemidef_fixedPoints_decomposition
+    T hT hTP hXfix
 
-end IsChannel
+end IsPositiveMap

--- a/blueprint/src/chapter/ch27_channel_asymptotics_mean_ergodic.tex
+++ b/blueprint/src/chapter/ch27_channel_asymptotics_mean_ergodic.tex
@@ -208,28 +208,30 @@
     Theorem~\ref{thm:adjoint_mean_ergodic_projection}.
 \end{proof}
 
-\begin{theorem}[Hermitian fixed-point decomposition]\label{thm:hermitian_fixedpoint_parts}
-    \lean{IsPositiveMap.posPart_negPart_fixed_of_hermitian_fixedPoint}
+\begin{theorem}[Positive fixed-point decomposition]\label{thm:positive_fixedpoint_parts}
+    \lean{IsPositiveMap.posPart_negPart_fixed_of_fixedPoint}
     \leanok
     \uses{def:positive_map, def:trace_preserving}
     Let $E$ be a positive trace-preserving linear map and let $X=E(X)$ be a
-    Hermitian fixed point. Let $P_+=X^+$ and $P_-=X^-$ be its canonical
-    positive and negative parts. Thus $X=P_+-P_-$, $P_\pm\geq0$, and
-    $P_+P_-=P_-P_+=0$. Then $E(P_+)=P_+$ and $E(P_-)=P_-$.
-    This is \cite[Proposition~6.8]{Wolf2012Quantum}.
+    fixed point. Set $H_1=X+X^*$ and $H_2=i(X-X^*)$, and write
+    $H_j=P_{j,+}-P_{j,-}$ for the canonical positive and negative parts.
+    Then all four positive semidefinite matrices $P_{j,\pm}$ are fixed by
+    $E$. This is \cite[Proposition~6.8]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The fixed-point equation gives the common difference
-    $Y=E(P_+)-P_+=E(P_-)-P_-$. Hence $P_++Y$ and $P_-+Y$ are positive
-    semidefinite, while trace preservation gives $\tr(Y)=0$. Diagonalize
-    $P_+$. Since $P_+P_-=P_-P_+=0$, each eigenvector belongs to the kernel
-    of $P_+$ or to the kernel of $P_-$. Positivity of the corresponding
-    matrix $P_++Y$ or $P_-+Y$ shows that every diagonal coefficient of $Y$
-    in this basis is non-negative. Their sum is $\tr(Y)=0$, so every such
-    coefficient vanishes. A positive semidefinite matrix with a zero diagonal
-    coefficient annihilates the corresponding basis vector. Applying this to
-    $P_++Y$ or $P_-+Y$ shows that $Y$ annihilates the entire eigenbasis.
-    Thus $Y=0$, and consequently $E(P_\pm)=P_\pm$.
+    Positivity implies that $E$ preserves adjoints. Hence $H_1$ and $H_2$
+    are Hermitian fixed points. For either $H_j$, the fixed-point equation
+    gives the common difference
+    $Y=E(P_{j,+})-P_{j,+}=E(P_{j,-})-P_{j,-}$. Hence $P_{j,+}+Y$ and
+    $P_{j,-}+Y$ are positive semidefinite, while trace preservation gives
+    $\tr(Y)=0$. Diagonalize $P_{j,+}$. Orthogonality of the positive and
+    negative parts shows that each eigenvector belongs to the kernel of one
+    of them. Positivity of the corresponding matrix shows that every diagonal
+    coefficient of $Y$ in this basis is non-negative. Their sum is zero, so
+    every such coefficient vanishes. The positive semidefinite matrices then
+    annihilate the corresponding basis vectors, and therefore $Y=0$.
+    Applying this argument to $H_1$ and $H_2$ proves that all four parts are
+    fixed.
 \end{proof}


### PR DESCRIPTION
## Summary

- prove Wolf Proposition 6.8 for an arbitrary fixed point of a positive trace-preserving linear map
- expose canonical and existential four-positive-fixed-point forms with natural library names
- align the numbered channel wrapper, Chapter 6 index, and Blueprint statement with the source

This addresses the positive fixed-point decomposition slice of LionSR/QICLean#207. The broader Brouwer, nonlinear stationary-state, and stationary-basis work remains open.

Source: Wolf, *Quantum Channels & Operations*, Proposition 6.8; `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 1161--1191.

## Validation

- `lake env lean TNLean/Channel/FixedPoint/Cesaro.lean`
- `lake build TNLean.Channel.WolfChapter6Wrappers TNLean.Channel.WolfChapter6Index`
- `python3 scripts/blueprint_lean_sync.py --ci --changed-files TNLean/Channel/FixedPoint/Cesaro.lean TNLean/Channel/WolfChapter6Wrappers.lean TNLean/Channel/WolfChapter6Index.lean`
- `python3 scripts/tactic_pattern_scan.py`
- proof-integrity scan of changed Lean files
- `git diff --check`

The worktree was seeded from hot main and used cached Mathlib artifacts; no clean Mathlib rebuild was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization on top of existing Hermitian lemmas; no runtime, auth, or data-path changes. Main risk is Mathlib proof maintenance if upstream APIs shift.
> 
> **Overview**
> **Wolf Proposition 6.8** is now proved for **any** fixed point of a positive trace-preserving map, not only Hermitian ones. The proof splits `X` into Hermitian and skew-Hermitian parts via `Matrix.exists_isHermitian_decomposition`, shows those components are fixed using adjoint preservation, then applies the existing Hermitian pos/neg-part lemma twice to get **four** canonical PSD fixed points.
> 
> New Lean results: `IsPositiveMap.posPart_negPart_fixed_of_fixedPoint` and `IsPositiveMap.exists_posSemidef_fixedPoints_decomposition` (existential form: `X` as a fixed complex combination of four PSD fixed matrices). `Cesaro.lean` gains imports for Hermitian helpers and positive-map properties.
> 
> **`IsPositiveMap.wolf_prop_6_8`** in `WolfChapter6Wrappers` replaces the old channel-only Hermitian wrapper: hypotheses are `IsPositiveMap` + trace preservation (no `IsChannel` or Hermitianity on `X`). The Chapter 6 index and blueprint theorem `thm:positive_fixedpoint_parts` are updated to match the four-part statement and proof sketch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d3bcad8e35ec946b3854c15d1280dc2f6b3d0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->