### PR TITLE
feat(Channel/Determinant): expose positive map eigenvalue bound

### DIFF
--- a/TNLean/Channel/Determinant/Bound.lean
+++ b/TNLean/Channel/Determinant/Bound.lean
@@ -21,6 +21,8 @@ this bounded-orbit argument to eigenvectors of the channel.
 
 ## Main statements
 
+* `IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving` — every eigenvalue of a
+  positive trace-preserving map lies in the closed unit disk.
 * `channelDet_norm_le_one_of_positive_tracePreserving` — Wolf's determinant
   bound for positive trace-preserving maps.
 * `channelDet_norm_le_one_of_channel` — the CPTP specialization.
@@ -141,7 +143,12 @@ private theorem positiveTracePreserving_bounded_orbit_of_trace_zero_hermitian [N
     _ ≤ ‖c‖ * (M + M) :=
       mul_le_mul_of_nonneg_left (add_le_add hρ_orbit hσ_orbit) (norm_nonneg _)
 
-private theorem positiveTracePreserving_eigenvalue_norm_le_one [NeZero d]
+/-- Every eigenvalue of a positive trace-preserving map lies in the closed unit disk.
+
+This is the unit-disk conclusion of Wolf, *Quantum Channels & Operations*,
+Proposition 6.1; local source
+`Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 73--91. -/
+theorem IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving [NeZero d]
     {T : MatrixEnd d} (hPos : IsPositiveMap T) (hTP : IsTracePreservingMap T)
     (μ : ℂ) (hμ : Module.End.HasEigenvalue T μ) :
     ‖μ‖ ≤ 1 := by
@@ -282,7 +289,7 @@ theorem channelDet_norm_le_one_of_positive_tracePreserving
   · haveI : NeZero d := ⟨hd⟩
     apply channelDet_norm_le_one_of_eigenvalues_bounded
     intro μ hμ
-    exact positiveTracePreserving_eigenvalue_norm_le_one (d := d) hPos hTP μ
+    exact hPos.eigenvalue_norm_le_one_of_tracePreserving (d := d) hTP μ
       (Module.End.hasEigenvalue_iff_mem_spectrum.2
         ((AlgEquiv.spectrum_eq (LinearMap.toMatrixAlgEquiv
             (ChannelDeterminant.Internal.matrixSpaceBasis d)) T) ▸

--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Determinant.HilbertSchmidt
+import TNLean.Channel.Schwarz.MultiplicativeDomain
 
 /-!
 # Heisenberg-dual multiplicativity from determinant saturation

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -5,7 +5,6 @@ Authors: TNLean contributors
 -/
 import TNLean.Channel.Determinant.Bound
 import TNLean.Algebra.MatrixAux
-import TNLean.Channel.Peripheral.IrreducibleChannel
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.InnerProductSpace.Trace
@@ -84,7 +83,7 @@ theorem channel_all_eigenvalues_norm_one [NeZero d]
     AlgEquiv.spectrum_eq (LinearMap.toMatrixAlgEquiv (matrixSpaceBasis d)) T
   have hroot_le : ∀ μ ∈ A.charpoly.roots, ‖μ‖ ≤ 1 := by
     intro μ hμ
-    exact IsChannel.eigenvalue_norm_le_one hT μ
+    exact hT.cp.isPositiveMap.eigenvalue_norm_le_one_of_tracePreserving hT.tp μ
       (Module.End.hasEigenvalue_iff_mem_spectrum.2
         (hspectrum ▸ Matrix.mem_spectrum_of_isRoot_charpoly
           ((Polynomial.mem_roots A.charpoly_monic.ne_zero).1 hμ)))

--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Channel.Determinant.HeisenbergDual
+import TNLean.Channel.KrausRepresentation
 import TNLean.Algebra.SkolemNoether
 import Mathlib.Algebra.Central.Matrix
 import Mathlib.LinearAlgebra.Matrix.Vec

--- a/TNLean/Channel/Peripheral/IrreducibleChannel.lean
+++ b/TNLean/Channel/Peripheral/IrreducibleChannel.lean
@@ -8,6 +8,7 @@ import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.Irreducible.PerronFrobenius
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import TNLean.Channel.KrausRepresentation
+import TNLean.Channel.Determinant.Bound
 import TNLean.MPS.CanonicalForm.BlockingViaAdjoint
 import TNLean.Spectral.TransferOperatorGap
 
@@ -41,22 +42,13 @@ variable {D : ℕ}
 
 /-- Every eigenvalue of a quantum channel has modulus at most `1`.
 
-We choose a Kraus representation `E = transferMap K` and reduce to the existing
-mixed-transfer bound for normalized tensors. -/
+This is the completely positive specialization of the unit-disk theorem for
+positive trace-preserving maps. -/
 theorem IsChannel.eigenvalue_norm_le_one [NeZero D]
     {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hE : IsChannel E) (μ : ℂ) (hμ : Module.End.HasEigenvalue E μ) :
     ‖μ‖ ≤ 1 := by
-  obtain ⟨r, K, hK⟩ := hE.cp
-  have hE_eq : E = MPSTensor.transferMap (d := r) (D := D) K := by
-    apply LinearMap.ext
-    intro X
-    simpa [MPSTensor.transferMap_apply] using hK X
-  have hK_tp : ∑ i : Fin r, (K i)ᴴ * K i = 1 :=
-    kraus_sum_conjTranspose_mul_of_tp K E hK hE.tp
-  have hμ_mixed : Module.End.HasEigenvalue (MPSTensor.mixedTransferMap K K) μ := by
-    simpa [MPSTensor.mixedTransferMap_self, hE_eq] using hμ
-  exact MPSTensor.eigenvalue_norm_le_one (A := K) (B := K) hK_tp hK_tp μ hμ_mixed
+  exact hE.cp.isPositiveMap.eigenvalue_norm_le_one_of_tracePreserving hE.tp μ hμ
 
 /-- Hermitian fixed points of trace `0` vanish for irreducible channels. -/
 private theorem hermitian_fixedPoint_eq_zero_of_trace_eq_zero_of_irreducible_channel

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Analysis.MeanErgodic
+import TNLean.Channel.Determinant.Bound
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.Cesaro
 import TNLean.Channel.FixedPoint.MeanErgodicProjection
@@ -47,6 +48,18 @@ formalized / not yet formalized), and the Lean declaration(s) that correspond.
 No new proofs are introduced here; this is a documentation-only index module.
 
 ---
+
+## Section 6.1 Spectral radius and determinant
+
+### Wolf Proposition 6.1 (Spectral radius of positive maps) — PARTIAL
+
+* `IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving` — every eigenvalue of a
+  positive trace-preserving map lies in the closed unit disk, in
+  `TNLean.Channel.Determinant.Bound`.
+* `IsChannel.eigenvalue_norm_le_one` — the completely positive specialization.
+
+The general bound `ρ(T) ≤ ‖T(1)‖∞`, existence of the eigenvalue `1`, and the resulting
+spectral-radius equality remain unformalized.
 
 ## Section 6.2 Irreducible maps and Perron–Frobenius theory
 

--- a/TNLean/Channel/WolfChapter6Index.lean
+++ b/TNLean/Channel/WolfChapter6Index.lean
@@ -56,7 +56,6 @@ No new proofs are introduced here; this is a documentation-only index module.
 * `IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving` — every eigenvalue of a
   positive trace-preserving map lies in the closed unit disk, in
   `TNLean.Channel.Determinant.Bound`.
-* `IsChannel.eigenvalue_norm_le_one` — the completely positive specialization.
 
 The general bound `ρ(T) ≤ ‖T(1)‖∞`, existence of the eigenvalue `1`, and the resulting
 spectral-radius equality remain unformalized.

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -499,11 +499,31 @@ This section states the existence theorems from
     $\overline{\det U}^{\,D}(\det U)^D=1$.
 \end{proof}
 
+\begin{theorem}[Eigenvalue disk bound for positive trace-preserving maps]
+    \label{thm:positive_tp_eigenvalue_disk}
+    \lean{IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving}\leanok
+    \uses{def:positive_map, def:trace_preserving}
+    Let $D>0$, and let $T:\MN{D}\to\MN{D}$ be positive and trace-preserving.
+    If $T(X)=\mu X$ for some nonzero $X$, then $|\mu|\leq1$.
+    This is the unit-disk conclusion of
+    \cite[Proposition~6.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $\tr(X)\neq0$, trace preservation gives $\mu=1$. Otherwise decompose
+    $X$ into trace-zero Hermitian and skew-Hermitian parts. Each Hermitian
+    part is a scalar multiple of the difference of two density matrices.
+    Positivity and trace preservation keep all iterates of those density
+    matrices in the compact set of density matrices, so the orbit of $X$ is
+    bounded. Since $T^n(X)=\mu^nX$, this is impossible when $|\mu|>1$.
+\end{proof}
+
 \begin{theorem}[Determinant bound for positive trace-preserving maps]
     \label{thm:channelDet_norm_le_one}
     \lean{channelDet_norm_le_one_of_positive_tracePreserving,
         channelDet_norm_le_one_of_channel}\leanok
-    \uses{def:channel_det, def:positive_map, def:trace_preserving}
+    \uses{def:channel_det, def:positive_map, def:trace_preserving,
+        thm:positive_tp_eigenvalue_disk}
     For any positive trace-preserving map $T : \MN{D} \to \MN{D}$,
     $|\det T|\leq1$.
     This is \cite[Theorem~6.1(1)]{Wolf2012Quantum}.

--- a/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
+++ b/blueprint/src/chapter/ch16_channel_representations_normal_forms_and_determinant.tex
@@ -522,14 +522,14 @@ This section states the existence theorems from
     \label{thm:channelDet_norm_le_one}
     \lean{channelDet_norm_le_one_of_positive_tracePreserving,
         channelDet_norm_le_one_of_channel}\leanok
-    \uses{def:channel_det, def:positive_map, def:trace_preserving,
-        thm:positive_tp_eigenvalue_disk}
+    \uses{def:channel_det, def:positive_map, def:trace_preserving}
     For any positive trace-preserving map $T : \MN{D} \to \MN{D}$,
     $|\det T|\leq1$.
     This is \cite[Theorem~6.1(1)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
+    \uses{thm:positive_tp_eigenvalue_disk}
     Every eigenvalue $\mu$ of $T$ satisfies $|\mu|\leq1$
     (positivity and trace preservation force spectral radius~$\leq1$).
     Since $\det T$ is the product of the eigenvalues


### PR DESCRIPTION
## Summary

- publish the existing positive trace-preserving eigenvalue disk theorem as `IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving`
- reuse that lower-level theorem in determinant saturation and remove its unnecessary peripheral/MPS import
- add narrowly partial Wolf Proposition 6.1 index and Blueprint coverage

This advances only the eigenvalue-disk slice of LionSR/QICLean#36. The general spectral-radius bound, eigenvalue-one/radius-equality results, peripheral Jordan result, Cesaro projection, and Dirichlet approximation remain open.

Source: Wolf, *Quantum Channels & Operations*, Proposition 6.1; `Notes/WolfNoteTexSource/ch06_spectral_properties.tex`, lines 73--91.

## Validation

- `lake env lean TNLean/Channel/Determinant/Bound.lean`
- `lake env lean TNLean/Channel/Determinant/HilbertSchmidt.lean`
- `lake build TNLean.Channel.Determinant.Bound TNLean.Channel.WolfChapter6Index`
- `python3 scripts/blueprint_lean_sync.py --ci --changed-files TNLean/Channel/Determinant/Bound.lean TNLean/Channel/Determinant/HilbertSchmidt.lean TNLean/Channel/WolfChapter6Index.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base HEAD^`
- proof-integrity scan of changed Lean files
- `git diff --check`

The worktree was seeded from hot main and used cached Mathlib artifacts; no clean Mathlib rebuild was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor and API exposure of an existing proof with no change to mathematical content; import graph is simplified in one place. Risk is limited to module dependency ordering and doc/blueprint sync.
> 
> **Overview**
> Promotes the existing positive trace-preserving **eigenvalue unit-disk** proof to the public theorem `IsPositiveMap.eigenvalue_norm_le_one_of_tracePreserving` in `Bound.lean`, with module docs and Wolf Proposition 6.1 references.
> 
> **Call sites** now route through that API: determinant bounds in `Bound.lean`, saturation eigenvalue arguments in `HilbertSchmidt.lean`, and `IsChannel.eigenvalue_norm_le_one` in `IrreducibleChannel.lean` (replacing the Kraus/MPS transfer-map proof with a one-line CP+TP delegation). `HilbertSchmidt.lean` drops the `Peripheral/IrreducibleChannel` import.
> 
> **Docs/sync:** `WolfChapter6Index` records a **partial** Wolf Prop. 6.1 entry; Blueprint ch16 adds `thm:positive_tp_eigenvalue_disk` and wires the determinant-bound proof to it. Minor import additions (`Bound` on index/peripheral path; `MultiplicativeDomain` / `KrausRepresentation` on determinant modules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc58b0d29e9a9f82c5ceefb9de304e760acf1af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->