### PR TITLE
doc(MPS/MPDO): use repository-local gap-note preamble

### DIFF
--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -5,7 +5,7 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
-\input{command}
+\input{./command}
 
 \title{The Perron--Frobenius Rank-One Step in Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2}
 \author{}


### PR DESCRIPTION
## Summary

- make the CPGSV17 Perron--Frobenius rank-one gap note import its repository-local command.tex explicitly
- prevent TeX search paths from selecting an unrelated user-level preamble
- leave the mathematical text and layout unchanged

## Reproducibility

From docs/paper-gaps, the unqualified name command.tex resolves in this environment to /Users/siruilu/Local/TEX/command.tex, whereas ./command.tex resolves to the file committed beside the note. Their SHA-256 hashes differ, and the external preamble does not define all repository paper-gap macros.

## Validation

- kpsewhich ./command.tex resolves ./command.tex
- latexmk completes for cpgsv17_pf_rank_one.tex and produces a 12-page PDF
- the final log contains no fatal error or undefined control sequence
- rendered pages 1 and 12 were visually inspected; both are intact
- git diff --check passes

No Lean source changed, so no Lean build was started.

Closes #5371

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line TeX `\input` path change in documentation; no Lean or runtime code affected.
> 
> **Overview**
> **Build reproducibility for the CPGSV17 Perron–Frobenius gap note:** `cpgsv17_pf_rank_one.tex` now loads the preamble with `\input{./command}` instead of `\input{command}`.
> 
> That pins the document to **`docs/paper-gaps/command.tex`** next to the note, so TeX/kpathsea cannot pick an unrelated user-level `command.tex` that lacks the repo’s paper-gap macros. **No mathematical or layout changes**—only which preamble file is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c611cda6ec24dbf8e90b534ca85f2b7f700a05f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->